### PR TITLE
feat(docx): render anchored (floating) charts (#752)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3583,6 +3583,64 @@ fn parse_inline_drawing(
         shp.wrap_side = anchor_meta.wrap_side.clone();
     };
 
+    // ECMA-376 §20.4.2.3 (`<wp:anchor>`) + §21.2 (chart) — a floating chart.
+    // Wired identically to the inline chart path above (`<a:graphicData
+    // uri=".../chart">` wrapping a `<c:chart r:id>` child; the modern chartex
+    // uri `.../2014/chartex` is accepted the same way), only the enclosing
+    // container is `<wp:anchor>`. Detect it BEFORE the wgp/wsp/blip fallbacks —
+    // a chart graphicData has no `<a:blip>`, so without this it would fall all
+    // the way through to `resolve_inline_blip` and silently drop (issue #752).
+    // The parsed `pos_x`/`pos_y` + `x_from_margin`/`y_from_para` are carried on
+    // the ChartRun exactly like the anchor ImageRun path, so the renderer draws
+    // the chart at the same absolute page coordinates a floating picture uses.
+    if let Some(graphic_data) = container
+        .descendants()
+        .find(|n| n.tag_name().name() == "graphicData")
+    {
+        let is_chart = graphic_data.attribute("uri").is_some_and(|uri| {
+            uri.contains("drawingml/2006/chart")
+                || uri.contains("chartex")
+                || uri.contains("chartEx")
+        });
+        if is_chart {
+            if let Some(chart_node) = container
+                .descendants()
+                .find(|n| n.tag_name().name() == "chart")
+            {
+                let rid = attr_ns(
+                    &chart_node,
+                    relationships::TRANSITIONAL,
+                    relationships::STRICT,
+                    "id",
+                );
+                if let Some(chart) = rid.and_then(|rid| chart_map.get(rid)) {
+                    // Same `<wp:extent>` (cx/cy EMU → pt) contract as the inline
+                    // chart path: a chart without a parseable extent falls
+                    // through to the blip path (which also drops it).
+                    if let Some(extent) = container
+                        .descendants()
+                        .find(|n| n.tag_name().name() == "extent")
+                    {
+                        let cx: Option<f64> = extent.attribute("cx").and_then(|v| v.parse().ok());
+                        let cy: Option<f64> = extent.attribute("cy").and_then(|v| v.parse().ok());
+                        if let (Some(cx), Some(cy)) = (cx, cy) {
+                            return vec![DocRun::Chart(Box::new(ChartRun {
+                                chart: chart.clone(),
+                                width_pt: cx / 12700.0,
+                                height_pt: cy / 12700.0,
+                                anchor: true,
+                                anchor_x_pt: pos_x,
+                                anchor_y_pt: pos_y,
+                                anchor_x_from_margin: x_from_margin,
+                                anchor_y_from_para: y_from_para,
+                            }))];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // Check for wgp (Word Graphics Group) — expands to multiple per-element entries
     if let Some(wgp) = container
         .descendants()
@@ -10294,6 +10352,100 @@ mod anchor_image_relative_from_tests {
             }
             other => panic!("expected DocRun::Chart, got {other:?}"),
         }
+    }
+
+    /// ECMA-376 §20.4.2.3 (`<wp:anchor>`) + §21.2 (chart) — a floating chart is
+    /// wired exactly like an inline chart (`<a:graphicData uri=".../chart">`
+    /// wrapping `<c:chart r:id>`), only the enclosing `<wp:inline>` is a
+    /// `<wp:anchor>` carrying `<wp:positionH>`/`<wp:positionV>`. Before this fix
+    /// the anchor branch of `parse_inline_drawing` had no chart detection (only
+    /// wgp/wsp/blip), so a floating chart fell through to `resolve_inline_blip`
+    /// (no blip present) and emitted nothing. It must now emit a `ChartRun` with
+    /// `anchor == true` and the parsed anchor offsets — mirroring the anchor
+    /// ImageRun path — so the renderer can draw it at absolute page coordinates.
+    /// The legacy `<a:graphicData uri=".../2006/chart">` and the modern chartex
+    /// uri are both accepted (same gate as the inline path).
+    #[test]
+    fn anchor_chart_drawing_emits_anchor_chart_run() {
+        // pos H/V posOffset in EMU: 914400 EMU = 72pt, 457200 EMU = 36pt.
+        let xml = r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:r><w:drawing>
+            <wp:anchor xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+                       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                       xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                       behindDoc="0" distT="0" distB="0" distL="0" distR="0"
+                       allowOverlap="1" relativeHeight="1">
+              <wp:positionH relativeFrom="column"><wp:posOffset>914400</wp:posOffset></wp:positionH>
+              <wp:positionV relativeFrom="paragraph"><wp:posOffset>457200</wp:posOffset></wp:positionV>
+              <wp:extent cx="5029200" cy="2743200"/>
+              <wp:wrapNone/>
+              <wp:docPr id="1" name="Chart 1"/>
+              <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+                <c:chart r:id="rIdChart"/>
+              </a:graphicData></a:graphic>
+            </wp:anchor>
+          </w:drawing></w:r>
+        </w:p>"#;
+        let doc = XmlDoc::parse(xml).unwrap();
+        let drawing = doc
+            .descendants()
+            .find(|n| n.tag_name().name() == "drawing")
+            .unwrap();
+        let style_map = StyleMap::parse("");
+        let media: HashMap<String, String> = HashMap::new();
+        let theme = ThemeColors::default();
+
+        let model = parse_docx_chart(
+            r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <c:chart><c:plotArea><c:barChart>
+                <c:barDir val="col"/><c:grouping val="clustered"/>
+                <c:ser><c:idx val="0"/><c:order val="0"/>
+                  <c:val><c:numRef><c:numCache><c:ptCount val="1"/>
+                    <c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val>
+                </c:ser><c:axId val="1"/><c:axId val="2"/>
+              </c:barChart></c:plotArea></c:chart></c:chartSpace>"#,
+            None,
+            &theme,
+        )
+        .expect("model");
+        let mut chart_map: HashMap<String, ooxml_common::chart::ChartModel> = HashMap::new();
+        chart_map.insert("rIdChart".to_string(), model);
+
+        let runs = parse_inline_drawing(&style_map, drawing, &media, &chart_map, &theme);
+        assert_eq!(runs.len(), 1, "one anchored chart run expected");
+        match &runs[0] {
+            DocRun::Chart(c) => {
+                assert!(c.anchor, "anchored chart must carry anchor == true");
+                assert_eq!(c.chart.chart_type, "clusteredBar");
+                assert!((c.width_pt - 396.0).abs() < 1e-6, "width_pt={}", c.width_pt);
+                assert!(
+                    (c.height_pt - 216.0).abs() < 1e-6,
+                    "height_pt={}",
+                    c.height_pt
+                );
+                assert!(
+                    (c.anchor_x_pt - 72.0).abs() < 1e-6,
+                    "anchor_x_pt={}",
+                    c.anchor_x_pt
+                );
+                assert!(
+                    (c.anchor_y_pt - 36.0).abs() < 1e-6,
+                    "anchor_y_pt={}",
+                    c.anchor_y_pt
+                );
+            }
+            other => panic!("expected DocRun::Chart, got {other:?}"),
+        }
+
+        // Unresolvable rId (empty map) → no run (chart fell through, no blip).
+        let empty: HashMap<String, ooxml_common::chart::ChartModel> = HashMap::new();
+        let none = parse_inline_drawing(&style_map, drawing, &media, &empty, &theme);
+        assert!(
+            none.is_empty(),
+            "unresolvable anchored chart rId must emit nothing"
+        );
     }
 
     /// CH14 end-to-end — `private/sample-24.docx` has 6 `<w:drawing>` chart

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1408,16 +1408,17 @@ fn is_zero_f64(v: &f64) -> bool {
 }
 
 /// A DrawingML chart embedded in the run flow (ECMA-376 §21.2). Positioned like
-/// an inline picture: the `<wp:inline><wp:extent cx/cy>` natural size in points
-/// governs the box the chart is drawn into. The `chart` payload is the shared
+/// a picture: the `<wp:extent cx/cy>` natural size in points governs the box
+/// the chart is drawn into. The `chart` payload is the shared
 /// [`ooxml_common::chart::ChartModel`] — identical to what pptx/xlsx pass to the
 /// core chart renderer — so the docx renderer draws charts at pptx/xlsx quality
 /// through the same `renderChart` entry point.
 ///
-/// Anchor (floating) charts are modeled with the same anchor fields the
-/// `ImageRun` carries; the current renderer path only draws `anchor == false`
-/// (inline) charts. The fields are present so a follow-up can position a
-/// floating `<wp:anchor>` chart without a wire-format change.
+/// Both placements are drawn: an inline chart (`anchor == false`) flows with the
+/// text like an inline picture, and an anchored (floating) chart
+/// (`anchor == true`, §20.4.2.3 `<wp:anchor>`) carries the same anchor fields an
+/// `ImageRun` does and is painted at its absolute page box by the renderer's
+/// anchor path (issue #752).
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ChartRun {
@@ -1428,8 +1429,8 @@ pub struct ChartRun {
     pub width_pt: f64,
     /// Natural height from `<wp:extent cy>` (EMU → pt).
     pub height_pt: f64,
-    /// true = `<wp:anchor>` (absolute page position), false = `<wp:inline>`
-    /// (flows with text). Only inline charts are drawn today.
+    /// true = `<wp:anchor>` (absolute page position, drawn by the renderer's
+    /// anchor path), false = `<wp:inline>` (flows with text).
     pub anchor: bool,
     /// Anchor X offset (pt). Anchor-only; interpretation mirrors `ImageRun`.
     #[serde(skip_serializing_if = "is_zero_f64")]

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -160,12 +160,14 @@ export interface LayoutImageSeg {
    *  box. `undefined` ⇒ draw the full bitmap. */
   srcRect?: { l: number; t: number; r: number; b: number };
   /** ECMA-376 §21.2 — when set, this "image" box is actually a DrawingML chart.
-   *  The box flows and is sized exactly like an inline picture (via
-   *  {@link LayoutImageSeg.widthPt}/{@link LayoutImageSeg.heightPt}), but the
-   *  draw site paints it with the shared `renderChart` instead of blitting a
-   *  bitmap. `imagePath`/`mimeType` are empty sentinels for a chart seg — no
-   *  blip is fetched (the bitmap-prefetch walk keys off `run.type === 'image'`
-   *  and never sees a chart run). */
+   *  The box is sized like a picture (via {@link LayoutImageSeg.widthPt}/
+   *  {@link LayoutImageSeg.heightPt}) and painted with the shared `renderChart`
+   *  instead of blitting a bitmap: an inline chart seg flows with the text and
+   *  is drawn at its flow position; an anchored chart seg (`anchor: true`,
+   *  §20.4.2.3) is zero-width in the flow and the chart is drawn at its
+   *  absolute page box by `renderAnchorImages`. `imagePath`/`mimeType` are
+   *  empty sentinels for a chart seg — no blip is fetched (the bitmap-prefetch
+   *  walk keys off `run.type === 'image'` and never sees a chart run). */
   chart?: ChartModel;
   measuredWidth: number;
 }

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1450,24 +1450,27 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         measuredWidth: 0,
       });
     } else if (run.type === 'chart') {
-      // ECMA-376 §21.2 inline chart. Flow it as an inline picture box of the
-      // `<wp:extent>` natural size: the same LayoutImageSeg shape (empty
-      // `imagePath`/`mimeType` sentinels so `'imagePath' in seg` routes it
-      // through the image measurement/split path) but carrying the ChartModel,
-      // which the draw site paints with the shared `renderChart`. Anchor
-      // (floating) charts are not drawn yet — skip them so they occupy no box.
+      // ECMA-376 §21.2 chart. Flow it as a picture box of the `<wp:extent>`
+      // natural size: the same LayoutImageSeg shape (empty `imagePath`/
+      // `mimeType` sentinels so `'imagePath' in seg` routes it through the image
+      // measurement/split path) but carrying the ChartModel, which the draw site
+      // paints with the shared `renderChart`.
+      //
+      // A `<wp:anchor>` (floating) chart (§20.4.2.3) carries `anchor: true` and
+      // its parsed page-offset fields, exactly like an anchor ImageRun: the
+      // measure pass zeroes an anchor seg's width (it is not part of the inline
+      // flow) and `renderAnchorImages` draws it at the resolved absolute box.
       const chartRun = run as unknown as import('./types').ChartRun & { type: 'chart' };
-      if (chartRun.anchor) continue;
       segs.push({
         imagePath: '',
         mimeType: '',
         widthPt: chartRun.widthPt,
         heightPt: chartRun.heightPt,
-        anchor: false,
-        anchorXPt: 0,
-        anchorYPt: 0,
-        anchorXFromMargin: false,
-        anchorYFromPara: false,
+        anchor: chartRun.anchor ?? false,
+        anchorXPt: chartRun.anchorXPt ?? 0,
+        anchorYPt: chartRun.anchorYPt ?? 0,
+        anchorXFromMargin: chartRun.anchorXFromMargin ?? false,
+        anchorYFromPara: chartRun.anchorYFromPara ?? false,
         chart: chartRun.chart,
         measuredWidth: 0,
       });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,6 +1,6 @@
 import type {
   DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
-  DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeText, ShapeTextRun, FieldRun, HeaderFooter, HeadersFooters, LineSpacing, BorderSpec, TableBorders, CellBorders,
+  DocRun, DocxTextRun, ImageRun, ChartRun, ShapeRun, ShapeText, ShapeTextRun, FieldRun, HeaderFooter, HeadersFooters, LineSpacing, BorderSpec, TableBorders, CellBorders,
   TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, SectionGeom, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr, DocSettings,
 } from './types';
 import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
@@ -6203,6 +6203,40 @@ function renderAnchorImages(
       const s = run as unknown as ShapeRun;
       if (s.behindDoc) continue;
       renderAnchorShape(s, state, paragraphTopPx);
+      continue;
+    }
+    if (run.type === 'chart') {
+      // ECMA-376 §20.4.2.3 (`<wp:anchor>`) + §21.2 (chart) — a floating chart is
+      // placed at the same absolute page box a floating picture uses, then
+      // painted with the shared core `renderChart` (identical to the inline
+      // chart draw at renderInlineImage). Only `anchor === true` charts reach
+      // here; inline charts flow as segments and are drawn during line layout.
+      const chartRun = run as unknown as ChartRun & { type: 'chart' };
+      if (!chartRun.anchor) continue;
+      // resolveAnchorBox reads only the box + anchor-placement fields, all of
+      // which the ChartRun carries (widthPt/heightPt/anchorXPt/anchorYPt/
+      // anchorXFromMargin/anchorYFromPara). The image-specific fields
+      // (align/relativeFrom/dist*/srcRect) are absent → the `?? 0`/`?? null`
+      // defaults inside resolveAnchorBox fall back to the plain offset path,
+      // matching how the parser emits an anchored chart (posOffset only).
+      const boxSrc = {
+        widthPt: chartRun.widthPt,
+        heightPt: chartRun.heightPt,
+        anchorXPt: chartRun.anchorXPt,
+        anchorYPt: chartRun.anchorYPt,
+        anchorXFromMargin: chartRun.anchorXFromMargin,
+        anchorYFromPara: chartRun.anchorYFromPara,
+      } as unknown as ImageRun;
+      const { x: pageX, y: pageY, w, h } = resolveAnchorBox(boxSrc, state, paragraphTopPx);
+      const chart = chartRun.chart;
+      if (state.verticalCJK) {
+        // §17.6.20 (tbRl) — a chart is a graphic, not text: keep it upright.
+        drawUprightBox(state.ctx, pageX, pageY, w, h, (dx, dy, dw, dh) =>
+          renderChart(state.ctx as CanvasRenderingContext2D, chart, { x: dx, y: dy, w: dw, h: dh }, state.scale),
+        );
+      } else {
+        renderChart(state.ctx as CanvasRenderingContext2D, chart, { x: pageX, y: pageY, w, h }, state.scale);
+      }
       continue;
     }
     if (run.type !== 'image') continue;

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -608,18 +608,19 @@ export type DocRun =
   | { type: 'ptab' } & PTabRun;
 
 /** ECMA-376 §21.2 — a DrawingML chart embedded in the run flow via
- *  `<w:drawing><wp:inline>…<a:graphicData uri=".../chart"><c:chart r:id>`.
+ *  `<w:drawing><wp:inline|wp:anchor>…<a:graphicData uri=".../chart"><c:chart r:id>`.
  *  Mirrors the Rust `ChartRun`. `chart` is the shared {@link ChartModel} the
  *  core `renderChart` consumes (identical to what pptx/xlsx pass), so a docx
  *  chart draws at the same quality through the same code path. `widthPt`/
- *  `heightPt` are the `<wp:extent>` natural size; the renderer flows the chart
- *  as an inline box of that size and draws it with `renderChart`. */
+ *  `heightPt` are the `<wp:extent>` natural size. An inline chart flows as an
+ *  inline box of that size; an anchored chart (§20.4.2.3) is painted at its
+ *  absolute page box by `renderAnchorImages` — both via `renderChart`. */
 export interface ChartRun {
   chart: ChartModel;
   widthPt: number;
   heightPt: number;
-  /** true = `<wp:anchor>` (absolute); false = `<wp:inline>` (flows). Only
-   *  inline charts are drawn today. */
+  /** true = `<wp:anchor>` (absolute page position, drawn by the anchor path);
+   *  false = `<wp:inline>` (flows with text). */
   anchor: boolean;
   anchorXPt?: number;
   anchorYPt?: number;

--- a/packages/node/src/docx-anchored-chart.probe.test.ts
+++ b/packages/node/src/docx-anchored-chart.probe.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  installImageBitmapShim,
+  installOffscreenCanvasShim,
+  type NodeCanvasFactory,
+} from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+// skia-canvas is a devDependency; the private chart sample is git-ignored.
+// absent → skip cleanly (local), OOXML_REQUIRE_SKIA=1 (CI) → hard failure.
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, loadImage } = (skia ?? {}) as Skia;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (async (buf: ArrayBuffer | Uint8Array | Buffer) =>
+    loadImage(Buffer.from(buf as Uint8Array))) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const RENDERER_PATH = resolve(ROOT, 'packages/docx/src/renderer.ts');
+
+const docxMod = skia ? await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)') : null;
+const rendererMod = skia
+  ? await importForTests(() => import(RENDERER_PATH), 'packages/docx/src/renderer.ts')
+  : null;
+
+const SAMPLE_24 = resolve(ROOT, 'packages/docx/public/private/sample-24.docx');
+const haveSample = existsSync(SAMPLE_24);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+// Recursively collect every DocRun of the given `type` from a document body,
+// descending into table cells (charts in sample-24 sit in ordinary body paras).
+function collectRuns(body: Any[], type: string): Any[] {
+  const out: Any[] = [];
+  const walkPara = (p: Any) => {
+    for (const r of p.runs ?? []) if (r.type === type) out.push(r);
+  };
+  const walkTable = (t: Any) => {
+    for (const row of t.rows ?? [])
+      for (const cell of row.cells ?? [])
+        for (const el of cell.content ?? []) {
+          if (el.type === 'table' || el.rows) walkTable(el);
+          else walkPara(el);
+        }
+  };
+  for (const el of body) {
+    if (el.type === 'paragraph' || (el.runs && !el.rows)) walkPara(el);
+    else if (el.type === 'table' || el.rows) walkTable(el);
+  }
+  return out;
+}
+
+async function renderPage(
+  doc: Any,
+  pageIndex: number,
+  dpr = 1,
+): Promise<{ data: Uint8ClampedArray; w: number; h: number }> {
+  const { renderDocumentToCanvas } = rendererMod as {
+    renderDocumentToCanvas: (
+      doc: Any,
+      canvas: unknown,
+      pageIndex: number,
+      opts: { dpr: number; width: number },
+    ) => Promise<void>;
+  };
+  const widthPx = doc.section.pageWidth;
+  const heightPx = doc.section.pageHeight;
+  const canvas = new Canvas(Math.round(widthPx * dpr), Math.round(heightPx * dpr));
+  const restoreImg = installImageBitmapShim(factory);
+  const restoreOff = installOffscreenCanvasShim(factory);
+  try {
+    await renderDocumentToCanvas(doc, canvas, pageIndex, { dpr, width: widthPx });
+  } finally {
+    restoreOff();
+    restoreImg();
+  }
+  const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+  const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  return { data: img.data, w: canvas.width, h: canvas.height };
+}
+
+// Count non-white (drawn) pixels inside a page-space rect (in px).
+function nonWhiteInRect(
+  data: Uint8ClampedArray,
+  w: number,
+  h: number,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+): number {
+  let n = 0;
+  const xa = Math.max(0, Math.floor(x0));
+  const xb = Math.min(w, Math.ceil(x1));
+  const ya = Math.max(0, Math.floor(y0));
+  const yb = Math.min(h, Math.ceil(y1));
+  for (let y = ya; y < yb; y++) {
+    for (let x = xa; x < xb; x++) {
+      const i = (y * w + x) * 4;
+      if (data[i] < 250 || data[i + 1] < 250 || data[i + 2] < 250) n++;
+    }
+  }
+  return n;
+}
+
+describe.skipIf(!skia || !docxMod || !rendererMod || !haveSample)(
+  'docx anchored + chartex charts render (sample-24, #747/#752)',
+  () => {
+    // #747 — sample-24's two inline PNG pictures are the mc:Fallback rendered
+    // images of the two chartex charts (chart4/chart6). Because the parser
+    // understands `Requires="cx"`, MCE (ECMA-376 Part 3) selects the Choice
+    // (live chartEx chart) and drops the Fallback picture — so the correct
+    // parse is 6 charts + 0 image runs (no double-emit). Word renders the same
+    // two charts, NOT the static snapshots.
+    it('sample-24 parses 6 chart runs and 0 image runs (MCE Choice, not Fallback)', () => {
+      const { parseDocx } = docxMod!;
+      const doc = parseDocx(readFileSync(SAMPLE_24)) as Any;
+      const charts = collectRuns(doc.body, 'chart');
+      const images = collectRuns(doc.body, 'image');
+      expect(charts.length).toBe(6);
+      // The 2 chartex fallback PNGs must NOT surface as image runs.
+      expect(images.length).toBe(0);
+      // All inline (no anchored charts in this fixture).
+      expect(charts.every((c) => c.anchor === false)).toBe(true);
+    });
+
+    // The chartex charts (chart4 boxWhisker, chart6 sunburst) must actually
+    // draw — proving the whole zip → parse → renderChart pipeline paints ink
+    // where Word's PDF ground truth shows the two charts.
+    it('sample-24 pages paint ink for every chart box (charts draw, not blank)', async () => {
+      const { parseDocx } = docxMod!;
+      const doc = parseDocx(readFileSync(SAMPLE_24)) as Any;
+      const restoreImg = installImageBitmapShim(factory);
+      const restoreOff = installOffscreenCanvasShim(factory);
+      let pageCount: number;
+      try {
+        pageCount = (
+          rendererMod as { paginateDocument: (d: Any) => Any[][] }
+        ).paginateDocument(doc).length;
+      } finally {
+        restoreOff();
+        restoreImg();
+      }
+      let totalInk = 0;
+      for (let p = 0; p < pageCount; p++) {
+        const { data, w, h } = await renderPage(doc, p);
+        totalInk += nonWhiteInRect(data, w, h, 0, 0, w, h);
+      }
+      // A blank multi-chart document would be near-zero; charts + text draw
+      // hundreds of thousands of non-white px.
+      expect(totalInk).toBeGreaterThan(50000);
+    });
+
+    // #752 render path — synthesize a floating chart by flipping one of
+    // sample-24's inline charts to `<wp:anchor>` (posOffset 72pt/72pt from the
+    // page), render it as the SOLE body content, and assert ink lands in the
+    // anchored box. Before the fix, an anchored chart was dropped in layout
+    // (`if (chartRun.anchor) continue;`) and renderAnchorImages had no chart
+    // branch, so the box stayed blank.
+    it('an anchored chart draws at its absolute page box (#752)', async () => {
+      const { parseDocx } = docxMod!;
+      const base = parseDocx(readFileSync(SAMPLE_24)) as Any;
+
+      // Find a REAL parsed paragraph that carries an inline chart (keeps every
+      // paragraph prop the layout/pagination path reads), and flip that chart
+      // run to a floating `<wp:anchor>` at 72pt/72pt from the page top-left.
+      let hostPara: Any = null;
+      let chartRun: Any = null;
+      for (const el of base.body) {
+        if (el.type === 'paragraph' && el.runs) {
+          const c = el.runs.find((r: Any) => r.type === 'chart');
+          if (c) {
+            hostPara = el;
+            chartRun = c;
+            break;
+          }
+        }
+      }
+      expect(hostPara).toBeTruthy();
+      expect(chartRun).toBeTruthy();
+
+      const chartWidthPt = chartRun.widthPt;
+      const chartHeightPt = chartRun.heightPt;
+      const offPt = 72; // 1 inch from the page top-left
+      chartRun.anchor = true;
+      chartRun.anchorXPt = offPt;
+      chartRun.anchorYPt = offPt;
+      chartRun.anchorXFromMargin = false; // relativeFrom page/column → offset path
+      chartRun.anchorYFromPara = false;
+
+      // Render ONLY the host paragraph so the anchored box is isolated in white
+      // (strip headers/footers/notes for the same reason). Keep the real
+      // section (page geometry).
+      const doc: Any = {
+        ...base,
+        body: [hostPara],
+        headers: { default: null, first: null, even: null },
+        footers: { default: null, first: null, even: null },
+        footnotes: [],
+        endnotes: [],
+      };
+
+      const { data, w, h } = await renderPage(doc, 0, 1); // dpr 1, scale 1 px/pt
+      const bx0 = offPt;
+      const by0 = offPt;
+      const bx1 = bx0 + chartWidthPt;
+      const by1 = by0 + chartHeightPt;
+      const inkInBox = nonWhiteInRect(data, w, h, bx0, by0, bx1, by1);
+      // The chart fills a large fraction of its box → tens of thousands of px.
+      expect(inkInBox).toBeGreaterThan(5000);
+
+      // Nothing should draw in the band ABOVE the anchored box: the chart is
+      // the only graphic and it starts at y=offPt, so y∈[0, offPt/2) must be
+      // blank — confirming the chart landed at the anchor, not the flow top.
+      const inkAbove = nonWhiteInRect(data, w, h, 0, 0, w, offPt / 2);
+      expect(inkAbove).toBe(0);
+    });
+  },
+);


### PR DESCRIPTION
## Summary

docx rendered **inline** charts only. The `<wp:anchor>` (floating) drawing path had no chart branch, so a chart placed with text wrapping was silently dropped in both the parser and the renderer (both legacy `<c:chart>` and the Microsoft 2014 chartEx extension). This wires the same chart pipeline the inline path already uses through the anchor path.

Closes #752.

## Parser — ECMA-376 §20.4.2.3 (`<wp:anchor>`) + §21.2 (chart)

`parse_inline_drawing`'s anchor branch now detects a chart `graphicData` (`<a:graphicData uri=".../2006/chart">` or the `.../2014/chartex` uri, wrapping `<c:chart r:id>`) **before** the wgp/wsp/blip fallbacks. A chart graphicData carries no `<a:blip>`, so without this it fell all the way through to `resolve_inline_blip` and emitted nothing. It now emits a `ChartRun` with `anchor = true` and the parsed `<wp:positionH>`/`<wp:positionV>` offsets, exactly mirroring the anchor `ImageRun` path. The `ChartRun` wire format already carried the anchor fields (added in the CH12 follow-up in anticipation of this).

## Renderer

- `line-layout.ts` no longer drops an anchor chart run; it emits a zero-width (skipped-from-flow) anchor `LayoutImageSeg` carrying the `ChartModel` and anchor offsets — the same treatment an anchor `ImageRun` gets.
- `renderAnchorImages` gains a chart branch that resolves the absolute page box via the shared `resolveAnchorBox` and paints with the core `renderChart` (identical entry point to the inline chart draw and to pptx/xlsx), including the §17.6.20 (tbRl) upright counter-rotation.

## Tests

- New Rust unit test `anchor_chart_drawing_emits_anchor_chart_run`: a `<wp:anchor>` chart parses to a `ChartRun { anchor: true, anchor_x_pt, anchor_y_pt }` (and an unresolvable rId still emits nothing).
- New headless render probe (`docx-anchored-chart.probe.test.ts`, skia): a chart flipped to `<wp:anchor>` at a 72pt/72pt page offset draws its ink inside the anchored box, with the band above it blank (the chart lands at the anchor, not the flow top). The same probe confirms sample-24's six charts (including the two chartEx box-whisker/sunburst parts) still render.

## Verification

`cargo fmt` / `clippy -D warnings` / `cargo test --workspace` clean (240 docx-parser tests). Root `tsc --build` clean. `vitest` core+docx: 1712 passed. docx demo VRT: zero regression (sample-1 has no charts). Manual PDF ground-truth comparison of sample-24 (all 3 pages) confirms the bar/line/radar/box-whisker/sunburst charts render in the same positions Word draws them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)