### PR TITLE
fix(charts): explicit majorUnit on all axes, category gridlines, out-of-range label rotation

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -2078,6 +2078,31 @@ describe('CH6 — category-axis label rotation + tickLblPos (commit 2)', () => {
     renderChart(rec.ctx, colModel({ catAxisLabelRotation: 0 }), RECT, 1);
     expect(rec.rotates.length).toBe(0);
   });
+
+  // #748: a rot outside the ST_FixedAngle (§20.1.10.23) (-90°,90°) text-rotation
+  // range is not a valid axis-label rotation — Office draws such labels
+  // horizontal. sample-24's cat/date/value axes all carry rot="-60000000"
+  // (-1000°) yet Word renders every label horizontal (verified against
+  // sample-24.pdf: "Category" label bbox is wide/short, ratio ≈ 3.0). Naively
+  // dividing -60000000/60000 = -1000° (or wrapping mod 360 → +80°) rotates them
+  // near-vertical, which is wrong.
+  it('an out-of-range rot ("-60000000" = -1000°) draws labels HORIZONTAL, not rotated', () => {
+    const rec = rotateRecordingCtx();
+    renderChart(rec.ctx, colModel({ catAxisLabelRotation: -60_000_000 }), RECT, 1);
+    // Office ignores the out-of-range rotation: no rotate() calls (horizontal
+    // fast path), labels still drawn.
+    expect(rec.rotates.length).toBe(0);
+    expect(rec.texts.some(t => t.startsWith('Alpha'))).toBe(true);
+  });
+
+  it('a rot at the ±90° ST_FixedAngle boundary (-5400000 = -90°) is still honored', () => {
+    // -90° is the inclusive edge of Office's axis-text rotation range; keep it
+    // working (genuine vertical axis labels).
+    const rec = rotateRecordingCtx();
+    renderChart(rec.ctx, colModel({ catAxisLabelRotation: -5_400_000 }), RECT, 1);
+    expect(rec.rotates.length).toBeGreaterThan(0);
+    expect(rec.rotates[0]).toBeCloseTo((-90 * Math.PI) / 180, 6);
+  });
 });
 
 /** Recording context that captures line-dash state alongside stroked segments,

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -2067,6 +2067,101 @@ describe('#744 — category-axis (vertical) major gridlines', () => {
   });
 });
 
+// #738: an explicit `<c:valAx><c:majorUnit>` (§21.2.2.103) must be honored on
+// EVERY chart type's value axis, not just the primary bar/line axis. The area,
+// radar and scatter renderers ignored `chart.valAxisMajorUnit`; the secondary
+// (combo) axis had no majorUnit surface at all.
+describe('#738 — explicit majorUnit honored on every value axis (§21.2.2.103)', () => {
+  /** Numeric value-axis tick labels drawn by a chart, as numbers. */
+  function valTickNumbers(over: Partial<ChartModel>): number[] {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel(over), RECT, 1);
+    return rec.texts
+      .map(t => t.text)
+      .filter(t => /^\d+(\.\d+)?$/.test(t))
+      .map(Number);
+  }
+
+  it('area: majorUnit widens the value-axis step (labels land on multiples of it)', () => {
+    // Data 0..100. Auto step is fine-grained; majorUnit 50 → coarse ticks
+    // 0,50,100 and NOTHING at 25/75.
+    const auto = valTickNumbers({
+      chartType: 'area', categories: ['A', 'B', 'C'],
+      series: [series({ name: 'S', values: [20, 60, 100] })],
+    });
+    const coarse = valTickNumbers({
+      chartType: 'area', categories: ['A', 'B', 'C'],
+      series: [series({ name: 'S', values: [20, 60, 100] })],
+      valAxisMajorUnit: 50,
+    });
+    expect(coarse).toContain(50);
+    expect(coarse).not.toContain(25);
+    // Coarser than auto: strictly fewer distinct tick labels.
+    expect(new Set(coarse).size).toBeLessThan(new Set(auto).size);
+  });
+
+  it('scatter: majorUnit widens the Y (value) axis step', () => {
+    const auto = valTickNumbers({
+      chartType: 'scatter',
+      series: [series({ name: 'S', values: [10, 40, 70, 100] })],
+    });
+    const coarse = valTickNumbers({
+      chartType: 'scatter',
+      series: [series({ name: 'S', values: [10, 40, 70, 100] })],
+      valAxisMajorUnit: 50,
+    });
+    expect(coarse).toContain(50);
+    expect(new Set(coarse).size).toBeLessThan(new Set(auto).size);
+  });
+
+  it('radar: majorUnit widens the ring step (fewer radial ticks)', () => {
+    const auto = valTickNumbers({
+      chartType: 'radar', categories: ['A', 'B', 'C', 'D'],
+      series: [series({ name: 'S', values: [20, 60, 80, 100] })],
+    });
+    const coarse = valTickNumbers({
+      chartType: 'radar', categories: ['A', 'B', 'C', 'D'],
+      series: [series({ name: 'S', values: [20, 60, 80, 100] })],
+      valAxisMajorUnit: 50,
+    });
+    // Radar skips the center 0-label, so labels are the ring values.
+    expect(new Set(coarse).size).toBeLessThan(new Set(auto).size);
+    expect(coarse).toContain(50);
+  });
+
+  it('secondary (combo) axis: majorUnit widens its independent step', () => {
+    // A line chart whose secondary series rides an independent right-edge axis
+    // (the shared computeSecondaryAxis path, used by line/area and the bar-combo
+    // line series). Secondary data 0..100; an explicit majorUnit 50 → right-side
+    // ticks land on multiples of 50 (0,50,100) and NOTHING at 25.
+    const secModel = (majorUnit: number | null): ChartModel => baseModel({
+      chartType: 'line',
+      categories: ['A', 'B', 'C'],
+      series: [
+        series({ name: 'Big', values: [10, 20, 30] }),
+        series({ name: 'Small', values: [20, 60, 100], useSecondaryAxis: true }),
+      ],
+      secondaryValAxis: {
+        min: null, max: null, title: 'Rate', hidden: false,
+        majorTickMark: 'out', lineHidden: false, majorUnit,
+      },
+    });
+    const rightTicks = (m: ChartModel): number[] => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, m, RECT, 1);
+      return rec.texts
+        .filter(t => t.x > RECT.x + RECT.w * 0.75 && /^\d+(\.\d+)?$/.test(t.text))
+        .map(t => Number(t.text));
+    };
+    const auto = rightTicks(secModel(null));
+    const coarse = rightTicks(secModel(50));
+    expect(auto.length).toBeGreaterThan(0); // guard: right-edge ticks exist
+    expect(coarse).toContain(50);
+    expect(coarse).not.toContain(25);
+    expect(new Set(coarse).size).toBeLessThan(new Set(auto).size);
+  });
+});
+
 /** Recording context that counts rotate() calls and captures fillText, for the
  *  category-label rotation / tickLblPos tests. */
 function rotateRecordingCtx(): { ctx: CanvasRenderingContext2D; rotates: number[]; texts: string[] } {

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1856,6 +1856,13 @@ function horizGridlines(segs: Seg[]): Seg[] {
   });
 }
 
+/** Category-axis MAJOR gridlines: near-vertical segments spanning the plot
+ *  height (x roughly constant, big y span). Filters by the gridline color so
+ *  bar edges / data lines aren't counted. */
+function vertGridlines(segs: Seg[], color = '#e0e0e0'): Seg[] {
+  return segs.filter(s => Math.abs(s.x0 - s.x1) < 0.5 && Math.abs(s.y1 - s.y0) > 50 && s.ss === color);
+}
+
 describe('CH6 — axis scale model', () => {
   const lineModel = (over: Partial<ChartModel>): ChartModel => baseModel({
     chartType: 'line',
@@ -1992,6 +1999,71 @@ describe('CH6 — axis scale model', () => {
     const rec = segRecordingCtx();
     renderChart(rec.ctx, lineModel({}), RECT, 1);
     expect(horizGridlines(rec.segs).length).toBeGreaterThan(2);
+  });
+});
+
+// #744: `<c:catAx><c:majorGridlines>` (ECMA-376 §21.2.2.100) draws VERTICAL
+// gridlines at each category tick across the plot height. The parse+type
+// surface (catAxisMajorGridlines / catAxisGridlineColor / catAxisGridlineWidthEmu)
+// already existed but had no renderer consumer, so a chart declaring cat-axis
+// gridlines rendered without them.
+describe('#744 — category-axis (vertical) major gridlines', () => {
+  const colModel = (over: Partial<ChartModel>): ChartModel => baseModel({
+    chartType: 'clusteredBar',
+    categories: ['A', 'B', 'C', 'D'],
+    series: [series({ name: 'S', values: [10, 20, 30, 40] })],
+    ...over,
+  });
+
+  it('OFF by default: no vertical gridlines (byte-stable)', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, colModel({}), RECT, 1);
+    expect(vertGridlines(rec.segs).length).toBe(0);
+  });
+
+  it('catAxisMajorGridlines=true draws vertical gridlines spanning the plot height', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, colModel({ catAxisMajorGridlines: true }), RECT, 1);
+    const grids = vertGridlines(rec.segs);
+    // At least one gridline per category boundary/center. crossBetween="between"
+    // (bar default) → n+1 dividers; either way several full-height verticals.
+    expect(grids.length).toBeGreaterThanOrEqual(3);
+    // Each spans (nearly) the whole plot height — much taller than a bar.
+    const tallest = Math.max(...grids.map(s => Math.abs(s.y1 - s.y0)));
+    expect(tallest).toBeGreaterThan(RECT.h * 0.5);
+  });
+
+  it('honors an explicit catAxisGridlineColor / width (§21.2.2.100)', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, colModel({
+      catAxisMajorGridlines: true,
+      catAxisGridlineColor: '8fa878',
+      catAxisGridlineWidthEmu: 12700, // 1 pt
+    }), RECT, 1);
+    const colored = vertGridlines(rec.segs, '#8fa878');
+    expect(colored.length).toBeGreaterThanOrEqual(3);
+    // 1 pt × ptToPx=1 → 1 px width.
+    expect(colored.every(s => s.lw === 1)).toBe(true);
+    // No faint default lines remain when a color is pinned.
+    expect(vertGridlines(rec.segs, '#e0e0e0').length).toBe(0);
+  });
+
+  it('line chart also draws category gridlines when declared', () => {
+    // The cat-gridline pass is wired into the bar, line and area renderers.
+    const off = segRecordingCtx();
+    renderChart(off.ctx, baseModel({
+      chartType: 'line', categories: ['A', 'B', 'C'],
+      series: [series({ name: 'S', values: [10, 20, 30] })],
+    }), RECT, 1);
+    expect(vertGridlines(off.segs).length).toBe(0);
+
+    const on = segRecordingCtx();
+    renderChart(on.ctx, baseModel({
+      chartType: 'line', categories: ['A', 'B', 'C'],
+      series: [series({ name: 'S', values: [10, 20, 30] })],
+      catAxisMajorGridlines: true,
+    }), RECT, 1);
+    expect(vertGridlines(on.segs).length).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -670,12 +670,31 @@ function catLabelsVisible(chart: ChartModel): boolean {
   return chart.catAxisTickLabelPos !== 'none';
 }
 
+/** 90° in 60000ths of a degree — the boundary of the `ST_FixedAngle`
+ *  (ECMA-376 §20.1.10.23) text-rotation range `(-90°, 90°)`. */
+const FIXED_ANGLE_LIMIT_60K = 5_400_000;
+
 /** Category-axis label rotation in RADIANS (canvas convention), from
- *  `<c:catAx><c:txPr><a:bodyPr rot>` (DrawingML `ST_Angle`, 60000ths of a
- *  degree). Returns 0 when unset — the un-rotated fast path callers keep. */
+ *  `<c:catAx|dateAx><c:txPr><a:bodyPr rot>` (DrawingML `ST_Angle`
+ *  §20.1.10.3, 60000ths of a degree). Returns 0 when unset — the un-rotated
+ *  fast path callers keep.
+ *
+ *  `bodyPr@rot` is typed `ST_Angle` (a restriction of XML Schema `int`, so any
+ *  integer is schema-valid), but a *text* rotation is only meaningful within
+ *  the `ST_FixedAngle` (§20.1.10.23) range `(-90°, 90°)` — the band Office's
+ *  Format-Axis "Custom angle" control uses. Office writes `rot="-60000000"`
+ *  (-1000°, ≈2.8 full turns) as a sentinel for "auto / horizontal" axis text
+ *  and renders those labels horizontal; the identical value even appears on the
+ *  numeric value axis in sample-1/sample-24, whose labels are indisputably
+ *  horizontal in the Word/Excel PDF ground truth. So a rot whose magnitude
+ *  exceeds ±90° is outside the valid text-rotation domain and is treated as no
+ *  rotation (0°) rather than reduced mod 360 (which would map -1000° → +80°,
+ *  near-vertical — wrong per sample-24.pdf). Genuine in-range rotations
+ *  (-45° = -2700000, -90° = -5400000) are honored unchanged. */
 function catLabelRotationRad(chart: ChartModel): number {
   const rot = chart.catAxisLabelRotation;
   if (rot == null || rot === 0) return 0;
+  if (Math.abs(rot) > FIXED_ANGLE_LIMIT_60K) return 0;
   return (rot / 60000) * (Math.PI / 180);
 }
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -517,6 +517,39 @@ function valGridStroke(
   return { color, width, explicit: chart.valAxisGridlineColor != null };
 }
 
+/** Whether to draw CATEGORY-axis MAJOR gridlines (`<c:catAx><c:majorGridlines>`,
+ *  ECMA-376 §21.2.2.100). Office omits them by default, so only `true` turns
+ *  them on (null/undefined/false ⇒ off, byte-stable). */
+function drawCatMajorGridlines(chart: ChartModel): boolean {
+  return chart.catAxisMajorGridlines === true;
+}
+
+/** Resolve the CATEGORY-axis major gridline stroke, mirroring
+ *  {@link valGridStroke}. `<c:catAx><c:majorGridlines><c:spPr><a:ln>` gives the
+ *  color/width (`chart.catAxisGridlineColor`/`catAxisGridlineWidthEmu`); absent
+ *  ⇒ the same faint `#e0e0e0`/0.5 px default as the value axis. Category
+ *  gridlines have no zero-line emphasis (there is no "zero category"), so a
+ *  single resolved stroke suffices. */
+function catGridStroke(chart: ChartModel, ptToPx: number): { color: string; width: number } {
+  return resolveGridline(chart.catAxisGridlineColor, chart.catAxisGridlineWidthEmu, ptToPx);
+}
+
+/** The plot-fraction positions (0..1 across the category extent) of the CATEGORY
+ *  major gridlines / ticks for `n` categories. With crossBetween="between" (the
+ *  bar/column default) they sit on the `n+1` band BOUNDARIES; under "midCat"
+ *  they sit at the `n` category CENTERS. Shared by the category tick loop and
+ *  the category-gridline pass so both stay aligned (§21.2.2.100/§21.2.2.32). */
+function catGridlineFractions(chart: ChartModel, n: number): number[] {
+  if (n <= 0) return [];
+  const onBoundary = isCrossBetween(chart);
+  const fracs: number[] = [];
+  const last = onBoundary ? n : n - 1;
+  for (let ci = 0; ci <= last; ci++) {
+    fracs.push(onBoundary ? ci / n : (n === 1 ? 0.5 : ci / (n - 1)));
+  }
+  return fracs;
+}
+
 /** True when the value axis is reversed (`<c:valAx><c:scaling><c:orientation
  *  val="maxMin">`, ECMA-376 §21.2.2.130). Absent/"minMax" ⇒ false (byte-stable). */
 function valAxisReversed(chart: ChartModel): boolean {
@@ -1222,6 +1255,30 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     }
   }
 
+  // Category-axis MAJOR gridlines (`<c:catAx><c:majorGridlines>`, §21.2.2.100).
+  // Perpendicular to the value gridlines: vertical for a column chart (cat axis
+  // runs along x), horizontal for a horizontal-bar chart (cat axis runs along
+  // y). Positioned at the same fractions as the category ticks — band
+  // boundaries under crossBetween="between" (bar default), category centers
+  // under "midCat". Drawn under the bars (like value gridlines). Office omits
+  // these by default so the common path is byte-stable.
+  if (!chart.catAxisHidden && drawCatMajorGridlines(chart)) {
+    const cg = catGridStroke(chart, ptToPx);
+    ctx.strokeStyle = cg.color;
+    ctx.lineWidth = cg.width;
+    for (const frac of catGridlineFractions(chart, n)) {
+      ctx.beginPath();
+      if (!isH) {
+        const gx = px0 + frac * pw;
+        ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph);
+      } else {
+        const gy = py0 + frac * ph;
+        ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy);
+      }
+      ctx.stroke();
+    }
+  }
+
   // Axis rules. The CATEGORY axis runs along the bars' baseline — bottom
   // (horizontal) for a column chart, left (vertical) for a horizontal bar
   // chart — and the VALUE axis is perpendicular to it. The previous code
@@ -1747,6 +1804,20 @@ function renderLineChart(
         ctx.textAlign = 'right';
         ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
       }
+    }
+  }
+
+  // Category-axis MAJOR gridlines (`<c:catAx><c:majorGridlines>`, §21.2.2.100):
+  // vertical lines at the category ticks across the plot height. Off by default
+  // (byte-stable). Shared placement with the bar renderer via
+  // `catGridlineFractions`.
+  if (!chart.catAxisHidden && drawCatMajorGridlines(chart)) {
+    const cg = catGridStroke(chart, ptToPx);
+    ctx.strokeStyle = cg.color;
+    ctx.lineWidth = cg.width;
+    for (const frac of catGridlineFractions(chart, n)) {
+      const gx = px0 + frac * pw;
+      ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
     }
   }
 
@@ -2443,6 +2514,17 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
       ctx.textAlign = 'right';
       ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
+    }
+  }
+  // Category-axis MAJOR gridlines (`<c:catAx><c:majorGridlines>`, §21.2.2.100):
+  // vertical lines at the category ticks. Off by default (byte-stable).
+  if (!chart.catAxisHidden && drawCatMajorGridlines(chart)) {
+    const cg = catGridStroke(chart, ptToPx);
+    ctx.strokeStyle = cg.color;
+    ctx.lineWidth = cg.width;
+    for (const frac of catGridlineFractions(chart, n)) {
+      const gx = px0 + frac * pw;
+      ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
     }
   }
   // Category-axis baseline + value-axis rule. `<c:*Ax><c:spPr><a:ln><a:noFill>`

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -793,7 +793,9 @@ function computeSecondaryAxis(
   }
   const dMin = secVals.length ? Math.min(...secVals) : 0;
   const dMax = secVals.length ? Math.max(...secVals) : 1;
-  const { min, max, step } = valueAxisScale(Math.min(0, dMin), dMax, sec.min, sec.max, plotHeightPt);
+  // An explicit `<c:valAx><c:majorUnit>` on the secondary axis (§21.2.2.103)
+  // overrides the auto step, mirroring the primary axis. null ⇒ auto.
+  const { min, max, step } = valueAxisScale(Math.min(0, dMin), dMax, sec.min, sec.max, plotHeightPt, sec.majorUnit);
   const range = (max - min) || 1;
   return {
     min,
@@ -2352,8 +2354,9 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   if (chart.valMax != null) dataMax = chart.valMax;
   if (dataMax === 0) dataMax = 1;
   // Area anchors the value axis at 0; ignore the returned min. Value axis is
-  // vertical → length = plot height (axis-length-aware auto major unit).
-  const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax, ph / ptToPx);
+  // vertical → length = plot height (axis-length-aware auto major unit). An
+  // explicit `<c:valAx><c:majorUnit>` (§21.2.2.103) overrides the auto step.
+  const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax, ph / ptToPx, chart.valAxisMajorUnit);
 
   // crossBetween="between" (Office's default; ECMA-376 §21.2.2.32 leaves the
   // default application-defined) gives each category a band of width pw/n and
@@ -3102,16 +3105,27 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
   for (const s of chart.series) for (const v of s.values) dataMax = Math.max(dataMax, v ?? 0);
   if (chart.valMax != null) dataMax = chart.valMax;
   if (dataMax === 0) dataMax = 1;
-  // Radar anchors the value axis at 0; ignore the returned min.
-  const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax);
+  // Radar anchors the value axis at 0; ignore the returned min. An explicit
+  // `<c:valAx><c:majorUnit>` (§21.2.2.103) overrides the auto ring step. The
+  // axis-length-aware auto density (GRIDLINE_SPACING_PT) is calibrated against
+  // Cartesian bar/line/area axes, not the radial spoke, so radar keeps the
+  // legacy fixed auto target (axisLenPt undefined) — only the explicit majorUnit
+  // path is new (byte-stable auto rings).
+  const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax, undefined, chart.valAxisMajorUnit);
 
   const angle0 = -Math.PI / 2;
   const spoke  = (i: number) => angle0 + (i / n) * Math.PI * 2;
 
+  // Rings sit on the value-axis MAJOR ticks — i.e. at value `ri * step`, whose
+  // radius is proportional to the value (`v / axMax`). Deriving the radius from
+  // the value (not `ri / rings`) keeps the rings on the major-unit multiples
+  // even when `axMax` is not an exact multiple of `step` (e.g. an explicit
+  // `<c:majorUnit>` §21.2.2.103 that doesn't divide the auto-rounded max).
   const rings = Math.round(axMax / step);
+  const ringValue = (ri: number): number => Math.min(ri * step, axMax);
   ctx.strokeStyle = '#ddd'; ctx.lineWidth = 0.5;
   for (let ri = 1; ri <= rings; ri++) {
-    const rr = (ri / rings) * rd;
+    const rr = (ringValue(ri) / axMax) * rd;
     ctx.beginPath();
     for (let i = 0; i < n; i++) {
       const a = spoke(i);
@@ -3139,8 +3153,8 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
     ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
     for (let ri = 1; ri <= rings; ri++) {
-      const v = (ri / rings) * axMax;
-      const rr = (ri / rings) * rd;
+      const v = ringValue(ri);
+      const rr = (v / axMax) * rd;
       ctx.fillText(formatChartVal(v), cx2 - 3, cy2 - rr);
     }
   }
@@ -3334,9 +3348,14 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   // chart.valMin/valMax as the explicit args reproduces the prior `?? niceAxis…`
   // behavior exactly. Explicit <c:valAx><c:scaling> wins. NB: the auto major
   // unit is not specified by ECMA-376 (Excel-proprietary); niceStep approximates
-  // it and may differ from Excel by one step on some ranges.
+  // it and may differ from Excel by one step on some ranges. An explicit
+  // `<c:valAx><c:majorUnit>` (§21.2.2.103) overrides the auto step. The
+  // axis-length-aware auto density (GRIDLINE_SPACING_PT) is calibrated against
+  // the bar/line/area value axes; scatter/bubble keep the legacy fixed auto
+  // target (axisLenPt undefined) so their auto gridlines stay byte-stable —
+  // only the explicit majorUnit path is new here.
   const { min: niceYMin, max: niceYMax, step: yAxisStep } =
-    valueAxisScale(yMin, yMax, chart.valMin, chart.valMax);
+    valueAxisScale(yMin, yMax, chart.valMin, chart.valMax, undefined, chart.valAxisMajorUnit);
   yMin = niceYMin; yMax = niceYMax;
   if (chart.catAxisMin != null) xMin = chart.catAxisMin;
   if (chart.catAxisMax != null) xMax = chart.catAxisMax;

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -703,8 +703,12 @@ function catLabelsVisible(chart: ChartModel): boolean {
   return chart.catAxisTickLabelPos !== 'none';
 }
 
-/** 90° in 60000ths of a degree — the boundary of the `ST_FixedAngle`
- *  (ECMA-376 §20.1.10.23) text-rotation range `(-90°, 90°)`. */
+/** 90° in 60000ths of a degree. `ST_FixedAngle` (ECMA-376 §20.1.10.23) bounds
+ *  a fixed-range angle to the OPEN interval "greater than -5400000 / less than
+ *  5400000", so ±5400000 itself lies outside the schema type — but Office's
+ *  Format-Axis "Custom angle" control accepts -90°…+90° INCLUSIVE, so the code
+ *  below deliberately uses a closed boundary (`> LIMIT` rejects, `== LIMIT`
+ *  honors) to keep genuine ±90° (vertical) axis labels working. */
 const FIXED_ANGLE_LIMIT_60K = 5_400_000;
 
 /** Category-axis label rotation in RADIANS (canvas convention), from
@@ -714,16 +718,18 @@ const FIXED_ANGLE_LIMIT_60K = 5_400_000;
  *
  *  `bodyPr@rot` is typed `ST_Angle` (a restriction of XML Schema `int`, so any
  *  integer is schema-valid), but a *text* rotation is only meaningful within
- *  the `ST_FixedAngle` (§20.1.10.23) range `(-90°, 90°)` — the band Office's
- *  Format-Axis "Custom angle" control uses. Office writes `rot="-60000000"`
- *  (-1000°, ≈2.8 full turns) as a sentinel for "auto / horizontal" axis text
- *  and renders those labels horizontal; the identical value even appears on the
- *  numeric value axis in sample-1/sample-24, whose labels are indisputably
- *  horizontal in the Word/Excel PDF ground truth. So a rot whose magnitude
- *  exceeds ±90° is outside the valid text-rotation domain and is treated as no
- *  rotation (0°) rather than reduced mod 360 (which would map -1000° → +80°,
- *  near-vertical — wrong per sample-24.pdf). Genuine in-range rotations
- *  (-45° = -2700000, -90° = -5400000) are honored unchanged. */
+ *  the `ST_FixedAngle` (§20.1.10.23) fixed-angle domain — an open interval
+ *  (-90°, 90°) at the schema level, which Office's Format-Axis "Custom angle"
+ *  control widens to -90°…+90° inclusive (we follow the UI's closed range; see
+ *  {@link FIXED_ANGLE_LIMIT_60K}). Office writes `rot="-60000000"` (-1000°,
+ *  ≈2.8 full turns) as a sentinel for "auto / horizontal" axis text and renders
+ *  those labels horizontal; the identical value even appears on the numeric
+ *  value axis in sample-1/sample-24, whose labels are indisputably horizontal
+ *  in the Word/Excel PDF ground truth. So a rot whose magnitude exceeds ±90°
+ *  is outside the valid text-rotation domain and is treated as no rotation
+ *  (0°) rather than reduced mod 360 (which would map -1000° → +80°,
+ *  near-vertical — wrong per sample-24.pdf). Genuine rotations within the
+ *  closed range (-45° = -2700000, -90° = -5400000) are honored unchanged. */
 function catLabelRotationRad(chart: ChartModel): number {
   const rot = chart.catAxisLabelRotation;
   if (rot == null || rot === 0) return 0;

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -746,6 +746,13 @@ export interface SecondaryValueAxis {
   lineHidden: boolean;
   /** `<c:majorTickMark>` — "cross" (default) | "out" | "in" | "none". */
   majorTickMark: string;
+  /**
+   * `<c:valAx><c:majorUnit val>` (§21.2.2.103) — explicit distance between
+   * major ticks/gridlines on THIS secondary axis, overriding the Excel-style
+   * auto "nice" step. null/undefined ⇒ auto step (byte-stable). Symmetric with
+   * {@link ChartModel.valAxisMajorUnit} on the primary axis.
+   */
+  majorUnit?: number | null;
   /** `<c:title>` run-prop font size (hpt). */
   titleFontSizeHpt?: number | null;
   /** `<c:title>` run-prop bold flag. */

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -553,6 +553,10 @@ pub struct SecondaryValueAxis {
     pub line_width_emu: Option<u32>,
     pub line_hidden: bool,
     pub major_tick_mark: String,
+    /// `<c:valAx><c:majorUnit val>` (§21.2.2.103) — explicit major-unit step on
+    /// this secondary axis, overriding the auto "nice" step. `None` ⇒ auto.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub major_unit: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_font_size_hpt: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3973,6 +3977,7 @@ pub fn parse_chart_part(
             line_width_emu,
             line_hidden,
             major_tick_mark: extract_axis_tick_mark_or_default(ax, "majorTickMark"),
+            major_unit: extract_axis_major_unit(ax),
             title_font_size_hpt: title_size,
             title_font_bold: title_bold,
             title_font_color: title_color,
@@ -5587,6 +5592,7 @@ mod tests {
                   <c:axPos val="r"/>
                   <c:crosses val="max"/>
                   <c:scaling><c:min val="0"/><c:max val="1"/></c:scaling>
+                  <c:majorUnit val="0.25"/>
                   <c:title><c:tx><c:rich><a:p><a:r><a:t>Margin</a:t></a:r></a:p></c:rich></c:tx></c:title>
                 </c:valAx>
               </c:plotArea></c:chart>
@@ -5616,6 +5622,11 @@ mod tests {
         assert_eq!(sec.max, Some(1.0));
         assert_eq!(sec.title.as_deref(), Some("Margin"));
         assert!(!sec.hidden);
+        // #738: an explicit `<c:majorUnit>` on the secondary axis (§21.2.2.103)
+        // is threaded into the model (was silently dropped before).
+        assert_eq!(sec.major_unit, Some(0.25));
+        // The primary value axis declared no majorUnit → stays None.
+        assert_eq!(m.val_axis_major_unit, None);
     }
 
     /// (c) Doughnut chart with per-point `<c:dPt>` colors, `showPercent`, and


### PR DESCRIPTION
Three chart-axis follow-ups surfaced by the #737/#743/#746/#753 reviews, each grounded in an ECMA-376 section and verified end-to-end against the Word/Excel PDF ground truth (`private/sample-24`, `private/sample-14`).

## #748 — out-of-range axis-label rotation drawn horizontal (§20.1.10.23)
`catLabelRotationRad` divided `<c:catAx|dateAx><c:txPr><a:bodyPr rot>` by 60000 unconditionally. `bodyPr@rot` is typed `ST_Angle` (§20.1.10.3, a restriction of XML Schema `int`), but a *text* rotation is only meaningful within the `ST_FixedAngle` (§20.1.10.23) fixed-angle domain — an open interval `(-90°, 90°)` at the schema level, which Office's Format-Axis "Custom angle" control widens to −90°…+90° inclusive (the fix follows the UI's closed range so genuine ±90° vertical labels keep working). sample-24's stock/bar/line/date axes carry `rot="-60000000"` (-1000°, Office's "auto / horizontal" sentinel) — the identical value even sits on the numeric value axis, whose labels are indisputably horizontal in the PDF (the "Category" tick-label bbox is wide/short, `w/h ≈ 3.0`). The old code rotated them ≈-1000° (near-vertical); reducing mod 360 (→ +80°) is likewise near-vertical and wrong.

**Fix:** honor the rotation only when `|rot| ≤ 5400000` (±90°); anything outside is not a valid label rotation → drawn horizontal (0°). Genuine in-range rotations (-45°, -90°) are unchanged. Verified: parsing the real sample-24.docx and rendering charts 1/2/5 now yields **0 rotate() calls** (horizontal).

## #744 — category-axis (vertical) major gridlines (§21.2.2.100)
`<c:catAx><c:majorGridlines>` was parsed (`catAxisMajorGridlines` / `catAxisGridlineColor` / `catAxisGridlineWidthEmu`, landed in #743) but had **no renderer consumer**. Added a category-gridline pass to the bar, line and area renderers — lines perpendicular to the value gridlines, at the category ticks (band boundaries under `crossBetween="between"`, centers under `midCat`) via a shared `catGridlineFractions`, colour/width from `catGridStroke` (same faint `#e0e0e0`/0.5 px default as the value axis). Gated on `catAxisMajorGridlines === true`, so charts without it are byte-stable.

## #738 — explicit majorUnit honored on every value axis (§21.2.2.103)
The primary bar/line axis honored `<c:valAx><c:majorUnit>` via `planValueAxis`; four other axes ignored it:
- **area** primary, **radar** radial, **scatter/bubble** Y — now pass `chart.valAxisMajorUnit`. Radar's ring/label loop is derived from the value (`ri * step`, radius `v / axMax`) so rings stay on the major-unit multiples even when the auto-rounded `axMax` isn't a step multiple.
- **secondary (combo) axis** — `SecondaryValueAxis` gained a `major_unit` field (Rust `ooxml-common` + TS type), parsed from the right-hand `<c:valAx>` via the existing `extract_axis_major_unit` and threaded through the shared `computeSecondaryAxis`.

Radar and scatter/bubble deliberately keep their legacy fixed auto target (`axisLenPt` left `undefined`): the axis-length-aware density constant is calibrated for the Cartesian bar/line/area axes, not the radial spoke / scatter geometry, so wiring it there would churn their auto gridlines with no ground-truth backing. Only the explicit-majorUnit path is new for those two; their auto rendering is byte-stable. Verified end-to-end: injecting `majorUnit=50` into the real sample-14 combo collapses its right-edge ticks from `[0,10,…,100]` to `[0,50,100]`.

## Testing
- `packages/core/src/chart`: **251 pass** (+10 new). Full root vitest: **2415 pass**. `renderer-signature.test.ts` characterization snapshot **unchanged** (byte-stable).
- Rust: `cargo test -p ooxml-common chart` (101 pass, incl. an updated combo test asserting `sec.major_unit == Some(0.25)`); `cargo fmt --all --check` + `cargo clippy -D warnings` clean.
- `tsc --build` clean; ast-grep lint: no new warnings.
- No committed demo VRT reference is affected. pptx demo sample-1's chart declares none of these features (no bodyPr rot, no catAx gridlines, no majorUnit) and the docx demo has no charts, so those are byte-stable. The **xlsx** demo sample-1 charts DO carry `rot="-60000000"` on their category axes, so #748 changes their label rendering (rotated → horizontal) — the demo VRT still passes because those labels sit **outside the 1280×720 VRT capture region**, leaving the committed reference pixels unchanged.

Closes #738
Closes #744
Closes #748
