### PR TITLE
fix(docx): scope the 1-inch float line-start rule to content lines (regression from #676)

### DIFF
--- a/packages/docx/src/float-layout.ts
+++ b/packages/docx/src/float-layout.ts
@@ -72,18 +72,34 @@ export const FLOAT_OVERLAP_EPS = 0.01;
 export const FLOAT_PAGE_RIGHT_SLACK = 0.5;
 
 /** Minimum horizontal space (pt) a free side-gap must have before Word will
- *  START a line beside a float, rather than flowing it below the float band.
- *  Measured — NOT from ECMA-376, which mandates no side-gap minimum (§20.4.2.17
- *  only says text wraps around the rectangle; §17.18.3 `<w:br w:clear>` is the
- *  sole spec-mandated flow onto a float-free region). Word's rule is exactly
- *  1 inch (1440 twips): established from the fixture set private/sample-19/20/22,
- *  Word-exported PDF, pdftotext bbox — a gap of 70pt flows the line below, a gap
- *  of 72pt starts the line beside. The threshold is INDEPENDENT of the line's
- *  content (an empty paragraph mark and a text line switch at the same width),
- *  of font size (8/12/24pt all switch at 72pt), and of line spacing
- *  (single/1.5/double all switch at 72pt) — i.e. it is an absolute width, not
- *  an em- or line-height-proportional quantity. See issue #676. Callers convert
- *  to px with `WORD_MIN_LINE_START_PT * scale` (renderer scale is px/pt). */
+ *  START a CONTENT (text / inline-object) line beside a float, rather than
+ *  flowing it below the float band. Measured — NOT from ECMA-376, which mandates
+ *  no side-gap minimum (§20.4.2.17 only says text wraps around the rectangle;
+ *  §17.18.3 `<w:br w:clear>` is the sole spec-mandated flow onto a float-free
+ *  region). Word's rule is exactly 1 inch (1440 twips): established from the
+ *  fixture set private/sample-19/20/22, Word-exported PDF, pdftotext bbox — a gap
+ *  of 70pt flows the line below, a gap of 72pt starts the line beside. For a
+ *  content line the threshold is INDEPENDENT of the line's text, of font size
+ *  (8/12/24pt all switch at 72pt), and of line spacing (single/1.5/double all
+ *  switch at 72pt) — i.e. it is an absolute width, not an em- or
+ *  line-height-proportional quantity. See issue #676. Callers convert to px with
+ *  `WORD_MIN_LINE_START_PT * scale` (renderer scale is px/pt).
+ *
+ *  SCOPE — content lines only. An EMPTY paragraph-mark line (a literally-empty or
+ *  anchor-only paragraph's pilcrow, no width-bearing content) does NOT obey this
+ *  1-inch rule: Word keeps such a mark beside a float whenever the gap can hold
+ *  the pilcrow itself, dropping it below only when the gap is narrower than that
+ *  (effectively a full-width float band). Grounded from sample-9 p.4 (full-width
+ *  band → mark drops below, carrying its wrapNone anchor image) AND sample-12 p.2
+ *  (a ~62pt side-gap, below 1 inch, where the nine authoring blank-line marks
+ *  after the figure stay BESIDE the float — flowing them below at 1 inch (the
+ *  regression #676 introduced) pushed the caption + CONCLUSION onto the next
+ *  page). The empty-mark
+ *  threshold is `paragraphMarkEmPx` (renderer.ts); it governs the literally-empty
+ *  / anchor-only paragraph paths — the paint pass `resolveEmptyMarkTop` and the
+ *  paginator's mirror `flowMarkLine` — while every CONTENT line (including a
+ *  content paragraph's trailing-break empty final line inside `layoutLines`)
+ *  passes `wordMinLineStartPx` below. */
 export const WORD_MIN_LINE_START_PT = 72;
 
 /** Tolerance (pt) subtracted from the 1-inch requirement when testing a side
@@ -105,11 +121,14 @@ export const WORD_MIN_LINE_START_PT = 72;
  *  granularity it absorbs. */
 export const LINE_START_GAP_EPS_PT = 0.05; // one twip (1/20 pt)
 
-/** The `requiredWidth` (px) every docx caller passes to `resolveLineFloatWindow`
- *  for a line-start probe: Word's 1-inch minimum side-gap, minus the half-twip
- *  rounding tolerance, at the render scale (px/pt). Single source of truth so the
- *  paint pass and both paginator mirrors agree bit-for-bit on the flow/beside
- *  decision. See WORD_MIN_LINE_START_PT and LINE_START_GAP_EPS_PT (issue #676). */
+/** The `requiredWidth` (px) every CONTENT-line caller passes to
+ *  `resolveLineFloatWindow` for a line-start probe: Word's 1-inch minimum
+ *  side-gap, minus the one-twip rounding tolerance, at the render scale (px/pt).
+ *  Single source of truth so the paint pass and both paginator mirrors agree
+ *  bit-for-bit on the flow/beside decision. Empty paragraph-mark lines use the
+ *  narrower `paragraphMarkEmPx` threshold instead (see WORD_MIN_LINE_START_PT's
+ *  SCOPE note). See WORD_MIN_LINE_START_PT and LINE_START_GAP_EPS_PT (issue
+ *  #676). */
 export function wordMinLineStartPx(scale: number): number {
   return (WORD_MIN_LINE_START_PT - LINE_START_GAP_EPS_PT) * scale;
 }

--- a/packages/docx/src/float-line-start-one-inch.test.ts
+++ b/packages/docx/src/float-line-start-one-inch.test.ts
@@ -17,9 +17,10 @@ import {
 // Word's measured minimum line-start rule beside a float (issue #676).
 //
 // GROUND TRUTH (fixtures private/sample-19/20/22, Word-exported PDF, pdftotext
-// bbox): Word starts a line beside a float ONLY when the free horizontal gap is
-// ≥ 72pt (= 1 inch = 1440 twips), and always when it is. The threshold is:
-//   - content-independent (an empty paragraph mark and a text line switch at the
+// bbox): Word starts a CONTENT line beside a float ONLY when the free horizontal
+// gap is ≥ 72pt (= 1 inch = 1440 twips), and always when it is. For a content
+// line the threshold is:
+//   - text-independent (a short-token line and a long-word line switch at the
 //     same width),
 //   - font-size-independent (8/12/24pt switch at 72pt),
 //   - line-spacing-independent (single/1.5/double switch at 72pt),
@@ -27,6 +28,15 @@ import {
 // gap of 70pt the line flows below the band; at 72pt it sits beside. A first
 // word that overruns the ≥1-inch gap is force-broken there (Word's "AFTE"/"R-10"
 // wrap), not refused.
+//
+// SCOPE — this 1-inch rule is the CONTENT-line threshold. A literally-empty /
+// anchor-only paragraph's pilcrow uses the NARROWER pilcrow-em threshold
+// (paragraphMarkEmPx via resolveEmptyMarkTop / flowMarkLine): Word keeps such a
+// mark beside a float down to a sub-inch gap and drops it below only for a
+// full-width band (sample-9 p.4 + sample-12 p.2; the #676 change wrongly
+// applied 1 inch to empty marks). The (c) case below exercises the layoutLines
+// EMPTY-CONTENT-line path (a paragraph carrying an empty text segment), which is
+// a content line and keeps the 1-inch rule.
 //
 // The boundary is INCLUSIVE at 1 inch, but a frame authored so the gap is
 // exactly 1 inch computes as content-width − frame-width slightly under 72
@@ -37,10 +47,11 @@ import {
 // beside. See issue #676.
 //
 // This file pins the pure geometry gate (resolveLineFloatWindow) and the
-// layoutLines integration that consumes it. It replaces the prior 1-em-of-the-
-// mark-font heuristic (resolveEmptyMarkTop) and the first-atomic-token-width
-// probe (the former requiredLineWidth), both retired in favour of this single
-// grounded rule.
+// layoutLines integration that consumes it. It replaced the first-atomic-token-
+// width probe (the former requiredLineWidth) for content lines with this single
+// grounded 1-inch rule. The literally-empty-paragraph mark path
+// (resolveEmptyMarkTop / flowMarkLine) keeps its own pilcrow-em threshold — see
+// the SCOPE note above.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** A LEFT-anchored square float band occupying [0, floatRightPx] horizontally on
@@ -188,8 +199,11 @@ describe('layoutLines — 1-inch line-start rule end to end (issue #676)', () =>
   // A gap just under 1 inch (70px) and just over (72px) at scale 1.
   const bandFor = (gapPx: number) => [leftBand(colW - gapPx, floatBottom)];
 
-  it('(c) an empty-content line flows below a sub-inch gap and beside a ≥1-inch gap', () => {
-    // No width-bearing content — the empty/paragraph-mark line path.
+  it('(c) an empty-content CONTENT line flows below a sub-inch gap and beside a ≥1-inch gap', () => {
+    // A content paragraph whose sole segment is empty text — the layoutLines
+    // content-line path, which keeps the 1-inch rule. (A literally-empty
+    // paragraph with NO runs is placed by resolveEmptyMarkTop against the
+    // narrower pilcrow-em threshold instead — see SCOPE note.)
     const emptyBelow = layoutLines(makeLinearCtx(), [textSeg('', 10)], colW, 0, scale, [], wrapCtx(bandFor(70)), {}, 0);
     const emptyBeside = layoutLines(makeLinearCtx(), [textSeg('', 10)], colW, 0, scale, [], wrapCtx(bandFor(72)), {}, 0);
     expect(firstLinePlacement(emptyBelow)).toBe('below');

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1609,21 +1609,28 @@ export function layoutLines(
   let lineXOffset = 0;
   let currentLineTopY = wrapCtx?.startPageY ?? 0;
 
-  // Minimum clear side-space (px) a line needs before it may START beside a
-  // float rather than flow below the band. Word's measured rule is 1 inch
-  // (wordMinLineStartPx(scale) — the 1-inch requirement less a half-twip rounding
-  // tolerance), INDEPENDENT of the line's content — the same threshold for an
-  // empty paragraph mark, a short-token line, and a long-word line (a first word
-  // that overruns the ≥1-inch gap is force-broken there by the over-long-word
-  // char-break below, matching Word's "AFTE"/"R-10" wrapping). This replaces two
-  // former implementation-defined branches — a per-line first-atomic-token width
-  // probe for text lines, and a 1-em-of-the-mark-font reservation
-  // (`wrapCtx.markEmPx`) for empty/trailing-break lines — both of which
-  // mis-placed lines relative to Word (they wedged short-token lines into
-  // sub-inch gaps and refused ≥1-inch gaps to long-word lines). See issue #676
-  // (fixtures private/sample-19/20/22, pdftotext bbox). Shared by the paint pass
-  // and the paginator's two mirror layouts (they call layoutLines with scale 1),
-  // so the flow/beside decision agrees across passes.
+  // Minimum clear side-space (px) a CONTENT line needs before it may START beside
+  // a float rather than flow below the band. Word's measured rule is 1 inch
+  // (wordMinLineStartPx(scale) — the 1-inch requirement less a one-twip rounding
+  // tolerance), INDEPENDENT of a content line's text — the same threshold for a
+  // short-token line and a long-word line (a first word that overruns the ≥1-inch
+  // gap is force-broken there by the over-long-word char-break below, matching
+  // Word's "AFTE"/"R-10" wrapping). This replaced a per-line first-atomic-token
+  // width probe that wedged short-token lines into sub-inch gaps and refused
+  // ≥1-inch gaps to long-word lines. See issue #676 (fixtures
+  // private/sample-19/20/22, pdftotext bbox). Shared by the paint pass and the
+  // paginator's two mirror layouts (they call layoutLines with scale 1), so the
+  // flow/beside decision agrees across passes.
+  //
+  // NOTE — this 1-inch rule is the CONTENT-line threshold. A literally-empty /
+  // anchor-only paragraph's pilcrow is placed by resolveEmptyMarkTop /
+  // flowMarkLine (renderer.ts) against the NARROWER pilcrow-em threshold
+  // (paragraphMarkEmPx): Word keeps such a mark beside a float down to a
+  // sub-inch gap and drops it below only for a full-width band. #676
+  // over-generalized 1 inch onto empty marks and pushed sample-12's caption
+  // to the next page. Lines routed through layoutLines carry inline content
+  // (or a content paragraph's trailing-break final line) and keep the 1-inch
+  // rule.
   const minLineStartWidth = (): number => wordMinLineStartPx(scale);
 
   // Compute wrap constraints for a new line about to start. Mutates

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -67,7 +67,6 @@ import {
   isWrapFloat,
   resolveLineFloatWindow,
   skipPastTopAndBottom,
-  wordMinLineStartPx,
 } from './float-layout.js';
 import {
   distributeLineSlack,
@@ -3034,12 +3033,14 @@ function estimateParagraphHeight(
   if (hasFloats) cursor = skipPastTopAndBottom(cursor, state.floats);
   const flowMarkLine = (): void => {
     // Empty / anchor-only paragraph: one paragraph-mark line box, flowed below a
-    // full-width float band exactly like renderEmptyMarkParagraph. Uses Word's
-    // measured 1-inch minimum side-gap (wordMinLineStartPx; scale 1 here in the
-    // paginator's pt-space mirror), the SAME content-independent threshold as the
-    // paint pass — issue #676.
+    // full-width float band exactly like renderEmptyMarkParagraph. An empty mark
+    // uses the pilcrow-em threshold (paragraphMarkEmPx; scale 1 here in the
+    // paginator's pt-space mirror), NOT the 1-inch content-line rule — Word keeps
+    // the mark beside the float whenever the gap holds the pilcrow and drops it
+    // below only for a full-width band (sample-9 p.4 / sample-12 p.2, the #676 regression).
+    // Mirrors the paint pass's resolveEmptyMarkTop so the two agree.
     if (hasFloats) {
-      const win = resolveLineFloatWindow(cursor, wordMinLineStartPx(1), 10, paraX, paraW, state.floats);
+      const win = resolveLineFloatWindow(cursor, paragraphMarkEmPx(para, 1), 10, paraX, paraW, state.floats);
       if (win.topY > cursor) cursor = win.topY;
     }
     cursor += paragraphMarkLineHeight(para, 1, grid, paraHasRuby, state.docEastAsian, state.ctx, state.fontFamilyClasses);
@@ -4873,33 +4874,33 @@ function renderParagraph(
   // produces ONE paragraph-mark line box (ECMA-376 §17.3.1.29 regulates only the
   // existence of that line; the horizontal wrap geometry around a square float is
   // §20.4.2.17). The displacement below — flow the mark line below the float band
-  // when the side gap cannot hold a line start — has no dedicated §x.x.x: the
-  // only SPEC-mandated flow of a line onto a float-free region is the explicit
-  // `<w:br w:clear>` of §17.18.3, which is not what fires here. But the TRIGGER
-  // (how much clear side-space Word requires before it starts a line beside a
-  // float) is not implementation-free-choice — it is Word's measured behaviour:
-  // exactly 1 inch of horizontal gap (WORD_MIN_LINE_START_PT), independent of the
-  // line's content, font size, and line spacing. Grounded from Word-exported PDFs
-  // (fixtures private/sample-19/20/22, pdftotext bbox: 70pt gap → below, 72pt →
-  // beside), NOT fitted to a single sample — see issue #676, which this replaces
-  // (the prior code used a 1-em-of-the-mark-font width here as an admitted
-  // HEURISTIC; the 1-inch rule discriminated against it because at gap = 1.5em
-  // for a 24pt mark, i.e. 36pt < 1 inch, Word still refuses to start the line
-  // beside the band). Without this an empty paragraph mark wedges into a sub-inch
-  // sliver beside a full-width float band and the following paragraphs (and any
-  // wrapNone image they anchor) stay pinned inside the band. We resolve the mark
-  // line's flowed top here and use it for the mark advance, the shading/border
-  // rect, and the paragraph-relative base of any wrapNone anchor image drawn
-  // below.
+  // when the side gap cannot hold the pilcrow — has no dedicated §x.x.x: the only
+  // SPEC-mandated flow of a line onto a float-free region is the explicit
+  // `<w:br w:clear>` of §17.18.3, which is not what fires here. The TRIGGER for an
+  // EMPTY paragraph mark is Word's measured behaviour: the mark stays BESIDE the
+  // float as long as the free side-gap can hold the pilcrow itself (its em width),
+  // and drops below only when the gap is narrower than that — i.e. effectively a
+  // full-width float band. This is NARROWER than the 1-inch rule Word applies to
+  // CONTENT lines (issue #676, wordMinLineStartPx): an empty mark in a ~62pt gap
+  // (under 1 inch) still sits beside the float — flowing it below at 1 inch pushed
+  // sample-12's caption + CONCLUSION onto the next page (#676 over-generalized the
+  // content-line threshold onto empty marks; this restores the pilcrow threshold).
+  // Grounded from sample-9 p.4 (full-width band → drops below, carrying
+  // its wrapNone anchor image) and sample-12 p.2 (~62pt gap → beside). Without the
+  // drop-below an empty mark wedges into a sub-pilcrow sliver beside a full-width
+  // float band and the following paragraphs (and any wrapNone image they anchor)
+  // stay pinned inside the band. We resolve the mark line's flowed top here and
+  // use it for the mark advance, the shading/border rect, and the
+  // paragraph-relative base of any wrapNone anchor image drawn below.
   const resolveEmptyMarkTop = (): number => {
     if (state.floats.length === 0) return textAreaTopY;
-    // Required side-gap for the mark line: Word's measured 1 inch
-    // (wordMinLineStartPx), the SAME threshold used for text lines — the rule is
-    // content-independent (issue #676). A gap narrower than 1 inch cannot hold
-    // the line start, so the mark line flows below the band.
+    // Required side-gap for the mark line: the pilcrow's em width
+    // (paragraphMarkEmPx) — the empty-mark threshold, NOT the 1-inch content-line
+    // rule (issue #676). A gap narrower than the pilcrow cannot hold the
+    // mark, so it flows below the band.
     const probeH = 10 * scale;
     const win = resolveLineFloatWindow(
-      textAreaTopY, wordMinLineStartPx(scale), probeH, paraX, paraW, state.floats,
+      textAreaTopY, paragraphMarkEmPx(para, scale), probeH, paraX, paraW, state.floats,
     );
     return win.topY;
   };
@@ -8538,6 +8539,26 @@ function picBulletSizePt(num: NumberingInfo, para: DocParagraph): { w: number; h
     w: num.picBulletWidthPt ?? fallback,
     h: num.picBulletHeightPt ?? fallback,
   };
+}
+
+/** Minimum clear side-gap (px) an EMPTY paragraph-mark line needs before it may
+ *  START beside a float rather than flow below the float band — the pilcrow's own
+ *  em width (the paragraph-mark font size × scale). Distinct from the 1-inch
+ *  CONTENT-line rule (`wordMinLineStartPx`, issue #676): Word keeps an empty mark
+ *  beside a float whenever the gap can hold the pilcrow, and drops it below only
+ *  when the gap is narrower than that — i.e. effectively a full-width band. See
+ *  WORD_MIN_LINE_START_PT's SCOPE note. Grounded from sample-9 p.4 (a full-width
+ *  float band → the mark drops below, carrying its wrapNone anchor image, PR
+ *  b897bbf) AND sample-12 p.2 (a ~62pt side-gap under 1 inch where the figure's
+ *  nine trailing blank-line marks stay beside the float; flowing them below at
+ *  1 inch pushed the caption + CONCLUSION onto page 3 — the regression #676
+ *  introduced, which this restores). Single source of truth for the literally-empty /
+ *  anchor-only paragraph sites — the paint pass `resolveEmptyMarkTop` and the
+ *  paginator mirror `flowMarkLine` — so the two agree bit-for-bit. (A content
+ *  paragraph's trailing-break empty final line stays on the 1-inch content-line
+ *  rule inside `layoutLines`; see WORD_MIN_LINE_START_PT's SCOPE note.) */
+function paragraphMarkEmPx(para: DocParagraph, scale: number): number {
+  return getDefaultFontSize(para) * scale;
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/node/src/docx-continuous-columns.test.ts
+++ b/packages/node/src/docx-continuous-columns.test.ts
@@ -73,6 +73,39 @@ describe.skipIf(!skia || !docxMod || !rendererMod || !haveSamples)(
       expect(paginate(12).length).toBe(3);
     });
 
+    // Text of a paginated body element (paragraph runs / field fallbacks). Enough
+    // to locate a caption / heading paragraph by content; tables not needed here.
+    const elementText = (el: unknown): string => {
+      const out: string[] = [];
+      const runs = (el as { runs?: Array<Record<string, unknown>> }).runs;
+      for (const r of runs ?? []) {
+        if (r == null) continue;
+        if (typeof r.text === 'string') out.push(r.text);
+        else if (typeof r.fallbackText === 'string') out.push(r.fallbackText);
+      }
+      return out.join('');
+    };
+    const findParaPage = (pages: unknown[][], startsWith: string): number =>
+      pages.findIndex((p) =>
+        p.some((el) => elementText(el).replace(/\s+/g, ' ').trim().startsWith(startsWith)),
+      );
+
+    // ECMA-376 §17.3.1.29 + §20.4.2.17 (regression from #676): the
+    // figure on sample-12 p.2 is a wrapSquare anchor offset ~70pt into the column,
+    // so both side gaps are ~61–64pt — BELOW 1 inch. #676 replaced the empty
+    // paragraph-mark line-start threshold with the 1-inch CONTENT-line rule, which
+    // flowed the figure's nine trailing blank-line marks BELOW the float band and
+    // pushed the caption "Figure 1 …" + the 4. CONCLUSION heading onto page 3. An
+    // empty paragraph mark stays beside a float whenever the gap holds the pilcrow
+    // (paragraphMarkEmPx), dropping below only for a full-width band — so the
+    // caption and CONCLUSION belong on page 2 (0-indexed page 1), matching the
+    // Word-exported PDF (sample-12.pdf p.2).
+    it('sample-12 keeps the figure caption + CONCLUSION on page 2 (#676 regression)', () => {
+      const pages = paginate(12);
+      expect(findParaPage(pages, 'Figure 1 This is a Sample Figure')).toBe(1);
+      expect(findParaPage(pages, 'The other first headings can be Research')).toBe(1);
+    });
+
     // 5 pages, matching Word. The intro 2-col section opens with a "continuous"
     // section break, so it stays on the title page (§17.6.22: the break is
     // governed by the upcoming section's start type, not the title section's


### PR DESCRIPTION
## Symptom

sample-12 (Journal template, 2-column) page 2: the figure caption **"Figure 1 This is a Sample Figure"** and the **"4. CONCLUSION"** heading + body were pushed onto page 3. In the Word-exported PDF (`sample-12.pdf` page 2) both belong on page 2, directly below the figure.

## Root cause (bisected)

Bisected with a Node paginate probe (caption paragraph page index vs. the Word PDF) to **1109740** — PR **#696**, *"fix(docx): replace the 1-em float-side line-start heuristic with Word's measured 1-inch rule (closes #676)"*.

That change routed **all** float line-start decisions — text lines **and** empty paragraph marks — through the 1-inch `wordMinLineStartPx` threshold. sample-12's figure is a `wrapSquare` anchor offset ~70pt into the column (`positionH` posOffset `885825` EMU = 69.75pt), so both side gaps are ~61–64pt — **below 1 inch**. The nine authoring blank-line paragraph marks after the figure therefore flowed **below** the float band (each advancing a full line height), overflowing the page and pushing the caption + CONCLUSION onto page 3.

Empirically (paginator mirror), the first empty mark jumped from `cursor y=359.7` straight to the float bottom `y=577.1`, then the marks stacked past the page bottom. Before #696 (1-em threshold ≈ 11px) every mark satisfied `win.topY == cursor` and stayed beside the float, landing the caption at `y≈619` on page 2 — matching Word (caption bbox `y≈604`).

## Correct behaviour — ECMA-376 §17.3.1.29 / §20.4.2.17

The 1-inch rule (#676, grounded on `private/sample-19/20/22`) is Word's rule for where a **content** (text / inline-object) line starts beside a float. An **empty paragraph mark** obeys a **narrower** rule: it stays beside the float whenever the gap can hold the pilcrow itself (~1 em), dropping below only when the gap is narrower than that — an effectively full-width band. Grounded from:

- **sample-9 p.4** (full-width band → the mark drops below, carrying its `wrapNone` anchor image; PR b897bbf), and
- **sample-12 p.2** (~62pt gap → the marks stay beside the float).

#696 over-generalized the content-line threshold onto empty marks. This is the spec-faithful correction, not a per-sample constant.

## Fix

Restore the pilcrow-em threshold (`paragraphMarkEmPx`) at the two literally-empty / anchor-only paragraph sites — the paint pass `resolveEmptyMarkTop` and the paginator mirror `flowMarkLine` — while keeping `wordMinLineStartPx` (1 inch) for every **content** line inside `layoutLines` (a content paragraph's trailing-break empty final line included). Only two call sites and one restored helper change; `resolveLineFloatWindow` and the `layoutLines` content-line path are untouched, so the #676 text-line rule is intact.

## Verification

**Page assignment (Node paginate, skia) — before → after:**

| Item | before (#676) | after | Word PDF |
|---|---|---|---|
| sample-12 figure caption | page 3 (0-idx 2) | **page 2 (0-idx 1)** | page 2 |
| sample-12 CONCLUSION heading + body | page 3 | **page 2** | page 2 |
| sample-12 total pages | 3 | 3 | 3 |

**Non-regression on the #676 fixtures** (paginate page counts, before == after, both = the counts PR #696 reported): sample-9 = 11, sample-19 = 15, sample-20 = 15, sample-22 = 10.

**Pixel:** rendered sample-12 page 2 matches the Word PDF page 2 layout (Table 1 + table, figure region, "Figure 1 …" caption + Source, "4. CONCLUSION" heading + body).

**Gates:**
- docx unit suite: 686 passed (incl. `float-line-start-one-inch` 14/14 — the content-line 1-inch rule is unchanged).
- New Node regression test: *sample-12 keeps the caption + CONCLUSION on page 2*.
- Root vitest: 2505 passed.
- `tsc --build`: clean.
- docx demo VRT: `demo/sample-1` pages 1–6 pass (the only committed references; `private/*` fixtures are absent in this worktree and 404, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)