### PR TITLE
fix(docx): centre vertical-text mixed glyphs and Tr brackets by font metrics

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -320,6 +320,7 @@ export { isCjkBreakChar, isLatinWordCodePoint } from './text/cjk-ranges';
 export {
   verticalOrientation,
   verticalFormSubstitute,
+  verticalBracketFormSubstitute,
   VO_UNICODE_VERSION,
 } from './text/vertical-orientation';
 export type { VerticalOrientation } from './text/vertical-orientation';

--- a/packages/core/src/text/vertical-orientation.test.ts
+++ b/packages/core/src/text/vertical-orientation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   verticalOrientation,
   verticalFormSubstitute,
+  verticalBracketFormSubstitute,
 } from './vertical-orientation.js';
 
 const cp = (ch: string): number => ch.codePointAt(0) ?? 0;
@@ -93,11 +94,46 @@ describe('verticalFormSubstitute (UAX #50 §5 vertical-form glyph substitution)'
   it('returns null for code points without a vertical presentation form', () => {
     // Small kana are Tu but have no U+FExx form (font handles them via `vert`).
     expect(verticalFormSubstitute(0x3041)).toBeNull(); // ぁ
-    // Corner brackets are Tr with no U+FExx form (rotated by the renderer).
+    // Corner brackets are Tr; verticalFormSubstitute is the Tu-only map (the Tr
+    // bracket forms live in verticalBracketFormSubstitute), so this stays null.
     expect(verticalFormSubstitute(0x300c)).toBeNull(); // 「
     // Ordinary upright ideographs.
     expect(verticalFormSubstitute(cp('漢'))).toBeNull();
     // Latin.
     expect(verticalFormSubstitute(cp('A'))).toBeNull();
+  });
+});
+
+describe('verticalBracketFormSubstitute (UAX #50 Tr brackets → U+FE30 vertical forms)', () => {
+  it('maps each fullwidth bracket/paren/brace to its U+FE3x vertical form', () => {
+    expect(verticalBracketFormSubstitute(0xff08)).toBe(0xfe35); // （ → ︵
+    expect(verticalBracketFormSubstitute(0xff09)).toBe(0xfe36); // ） → ︶
+    expect(verticalBracketFormSubstitute(0xff5b)).toBe(0xfe37); // ｛ → ︷
+    expect(verticalBracketFormSubstitute(0xff5d)).toBe(0xfe38); // ｝ → ︸
+    expect(verticalBracketFormSubstitute(0x3014)).toBe(0xfe39); // 〔 → ︹
+    expect(verticalBracketFormSubstitute(0x3015)).toBe(0xfe3a); // 〕 → ︺
+    expect(verticalBracketFormSubstitute(0x3010)).toBe(0xfe3b); // 【 → ︻
+    expect(verticalBracketFormSubstitute(0x3011)).toBe(0xfe3c); // 】 → ︼
+    expect(verticalBracketFormSubstitute(0x300a)).toBe(0xfe3d); // 《 → ︽
+    expect(verticalBracketFormSubstitute(0x300b)).toBe(0xfe3e); // 》 → ︾
+    expect(verticalBracketFormSubstitute(0x3008)).toBe(0xfe3f); // 〈 → ︿
+    expect(verticalBracketFormSubstitute(0x3009)).toBe(0xfe40); // 〉 → ﹀
+    expect(verticalBracketFormSubstitute(0x300c)).toBe(0xfe41); // 「 → ﹁
+    expect(verticalBracketFormSubstitute(0x300d)).toBe(0xfe42); // 」 → ﹂
+    expect(verticalBracketFormSubstitute(0x300e)).toBe(0xfe43); // 『 → ﹃
+    expect(verticalBracketFormSubstitute(0x300f)).toBe(0xfe44); // 』 → ﹄
+  });
+
+  it('returns null for Tr code points with no U+FE30 vertical form (ー, quotes)', () => {
+    expect(verticalBracketFormSubstitute(0x30fc)).toBeNull(); // ー prolonged sound mark
+    expect(verticalBracketFormSubstitute(0x201c)).toBeNull(); // “ left double quote
+    expect(verticalBracketFormSubstitute(0x201d)).toBeNull(); // ” right double quote
+  });
+
+  it('returns null for non-bracket code points (Tu punctuation, ideographs, Latin)', () => {
+    expect(verticalBracketFormSubstitute(0x3001)).toBeNull(); // 、 (Tu)
+    expect(verticalBracketFormSubstitute(cp('漢'))).toBeNull(); // ideograph (U)
+    expect(verticalBracketFormSubstitute(cp('A'))).toBeNull(); // Latin (R)
+    expect(verticalBracketFormSubstitute(cp('('))).toBeNull(); // ASCII paren (R)
   });
 });

--- a/packages/core/src/text/vertical-orientation.ts
+++ b/packages/core/src/text/vertical-orientation.ts
@@ -113,3 +113,71 @@ const VERTICAL_FORM_MAP: ReadonlyMap<number, number> = new Map<number, number>([
   [0xff01, 0xfe15], // ！ fullwidth exclamation → … FOR VERTICAL EXCLAMATION MARK
   [0xff1f, 0xfe16], // ？ fullwidth question    → … FOR VERTICAL QUESTION MARK
 ]);
+
+/**
+ * DRAW-TIME vertical-form substitution for vo=Tr BRACKETS: the U+FE35–U+FE44
+ * "Presentation Forms For Vertical" glyph for a fullwidth paren / corner
+ * bracket / angle bracket / brace / lenticular bracket, or `null` when the code
+ * point is not one of them (or is a Tr code point with no vertical form).
+ *
+ * WHY this is separate from {@link verticalFormSubstitute} (the Tu map): the two
+ * fallbacks differ. A Tu code point with no vertical form draws UPRIGHT; a Tr
+ * one ROTATES. Keeping the maps distinct lets each draw branch pick the right
+ * fallback (see the docx renderer's `drawVerticalRun`) without conflating the
+ * two UAX #50 transform classes.
+ *
+ * WHY substitute a Tr bracket at all: UAX #50 §5 defines the Tr transform as
+ * "substitute a vertical glyph variant; ROTATE only as the fallback when none is
+ * available." A Canvas cannot reach the font's `vert`/`vrt2` OpenType feature via
+ * `fillText`, but the Unicode "Presentation Forms For Vertical" block supplies a
+ * dedicated, already-vertical code point for every fullwidth bracket, and those
+ * code points ARE reachable. Drawing the vertical form UPRIGHT (rather than
+ * rotating the horizontal bracket) is both closer to Word (which uses the same
+ * `vert` glyphs) and — critically — measurable: an upright glyph's along-column
+ * position is governed by its VERTICAL ink extent (`actualBoundingBoxAscent/
+ * Descent`, which a Canvas exposes), whereas a ROTATED bracket's along-column
+ * position is governed by its HORIZONTAL ink offset inside the advance box, which
+ * `measureText` does NOT expose (it reports the advance box, not the tight ink
+ * box). So substitution is what makes metric-driven cell-centring possible.
+ *
+ * Deliberately NOT here (they are vo=Tr but have no U+FE3x vertical form, so the
+ * renderer keeps the rotate fallback):
+ *   • ー U+30FC prolonged sound mark
+ *   • “ ” U+201C/201D double quotation marks
+ *
+ * Mapping source: the UnicodeData.txt `<vertical>` compatibility decompositions
+ * of the U+FE30 block (each vertical form decomposes to its horizontal bracket).
+ *
+ * Renderers apply this ONLY at glyph-draw time (glyph selection): the advance/
+ * width, text model, selection, and find/highlight all keep the ORIGINAL code
+ * point, so searching for （ still matches a substituted （.
+ *
+ * @param cp A Unicode scalar value.
+ * @returns The U+FE3x vertical presentation-form code point, or null.
+ */
+export function verticalBracketFormSubstitute(cp: number): number | null {
+  return VERTICAL_BRACKET_FORM_MAP.get(cp) ?? null;
+}
+
+// vo=Tr fullwidth brackets → U+FE35–U+FE44 "Presentation Forms For Vertical".
+// Keyed on the horizontal bracket; values from the UnicodeData `<vertical>`
+// decompositions. ー (30FC) and the double quotes (201C/201D) are vo=Tr with no
+// vertical form and are absent, so the renderer rotates them.
+const VERTICAL_BRACKET_FORM_MAP: ReadonlyMap<number, number> = new Map<number, number>([
+  [0xff08, 0xfe35], // （ fullwidth left parenthesis  → ︵
+  [0xff09, 0xfe36], // ） fullwidth right parenthesis → ︶
+  [0xff5b, 0xfe37], // ｛ fullwidth left curly brace  → ︷
+  [0xff5d, 0xfe38], // ｝ fullwidth right curly brace → ︸
+  [0x3014, 0xfe39], // 〔 left tortoise-shell bracket → ︹
+  [0x3015, 0xfe3a], // 〕 right tortoise-shell bracket→ ︺
+  [0x3010, 0xfe3b], // 【 left black lenticular       → ︻
+  [0x3011, 0xfe3c], // 】 right black lenticular      → ︼
+  [0x300a, 0xfe3d], // 《 left double angle bracket    → ︽
+  [0x300b, 0xfe3e], // 》 right double angle bracket   → ︾
+  [0x3008, 0xfe3f], // 〈 left angle bracket           → ︿
+  [0x3009, 0xfe40], // 〉 right angle bracket          → ﹀
+  [0x300c, 0xfe41], // 「 left corner bracket          → ﹁
+  [0x300d, 0xfe42], // 」 right corner bracket         → ﹂
+  [0x300e, 0xfe43], // 『 left white corner bracket    → ﹃
+  [0x300f, 0xfe44], // 』 right white corner bracket   → ﹄
+]);

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -116,7 +116,20 @@ type Op =
   | { op: 'fillText'; text: string; x: number; y: number; align: string; baseline: string }
   | { op: 'draw'; dx: number; dy: number; dw: number; dh: number };
 
-function mockCtx(): { ctx: any; ops: Op[] } {
+// Optional metrics the mock returns from `measureText`, keyed by the metric it
+// is asked to model. `fontBoundingBox*` are font-level (glyph-independent, used
+// for the sideways em-box-centre shift); `actualBoundingBox*` are per-glyph tight
+// ink bounds (used for the upright along-column ink centring). Values are read at
+// the CURRENT textBaseline the helper sets before measuring, so the mock reports
+// the same numbers regardless — the helper does the (asc−desc)/2 arithmetic.
+interface MockMetrics {
+  fontBoundingBoxAscent?: number;
+  fontBoundingBoxDescent?: number;
+  // Per-glyph tight ink extent under a `middle` textBaseline, by draw glyph.
+  inkMiddle?: Record<string, { asc: number; desc: number }>;
+}
+
+function mockCtx(metrics: MockMetrics = {}): { ctx: any; ops: Op[] } {
   const ops: Op[] = [];
   const ctx: any = {
     textAlign: 'start',
@@ -136,7 +149,17 @@ function mockCtx(): { ctx: any; ops: Op[] } {
     },
     measureText(s: string) {
       // Every code point is 10px wide.
-      return { width: [...s].length * 10 };
+      const m: Record<string, number> = { width: [...s].length * 10 };
+      if (metrics.fontBoundingBoxAscent !== undefined) {
+        m.fontBoundingBoxAscent = metrics.fontBoundingBoxAscent;
+        m.fontBoundingBoxDescent = metrics.fontBoundingBoxDescent ?? 0;
+      }
+      const ink = metrics.inkMiddle?.[s];
+      if (ink && this.textBaseline === 'middle') {
+        m.actualBoundingBoxAscent = ink.asc;
+        m.actualBoundingBoxDescent = ink.desc;
+      }
+      return m;
     },
     fillText(text: string, x: number, y: number) {
       ops.push({ op: 'fillText', text, x, y, align: this.textAlign, baseline: this.textBaseline });
@@ -166,8 +189,26 @@ describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin side
     drawVerticalRun(ctx, 'A', 100, 200, 12, 0);
     expect(ops.some((o) => o.op === 'rotate')).toBe(false);
     const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
-    // Sideways: left at run x (advance 0), baseline y kept.
-    expect(fill).toMatchObject({ text: 'A', x: 100, y: 200 });
+    // Sideways: left at run x (advance 0), alphabetic baseline. The cross-axis y
+    // is shifted down by the em-box centre so the glyph's ink centres on the same
+    // column line the upright cells use. With no fontBoundingBox metrics the mock
+    // falls back to 0.38·fontPx = 4.56, so y = 200 + 4.56.
+    expect(fill?.text).toBe('A');
+    expect(fill?.x).toBe(100);
+    expect(fill?.baseline).toBe('alphabetic');
+    expect(fill?.y).toBeCloseTo(200 + 0.38 * 12, 6);
+  });
+
+  it('centres a sideways glyph on the em-box centre from fontBoundingBox metrics (§17.6.20)', () => {
+    // Symptom 1: mixed columns like "電話 03-…" must share one centreline. The
+    // sideways glyph is drawn on its alphabetic baseline shifted down by the
+    // font's em-box centre = (fontBoundingBoxAscent − fontBoundingBoxDescent)/2.
+    const { ctx, ops } = mockCtx({ fontBoundingBoxAscent: 40, fontBoundingBoxDescent: 10 });
+    drawVerticalRun(ctx, '0', 100, 200, 48, 0);
+    const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    // emBoxCenter = (40 − 10)/2 = 15 → y = 200 + 15 = 215.
+    expect(fill).toMatchObject({ text: '0', x: 100, baseline: 'alphabetic' });
+    expect(fill?.y).toBeCloseTo(215, 6);
   });
 
   it('advances each glyph by measure + letterSpacing (measure == draw)', () => {
@@ -177,14 +218,49 @@ describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin side
     expect(fills.map((f) => f.x)).toEqual([0, 14]);
   });
 
-  it('rotates a Tr glyph (ー, （, ）) with the page — centred on the column, NOT counter-rotated', () => {
+  it('rotates a Tr glyph WITHOUT a vertical form (ー) with the page — centred, NOT counter-rotated', () => {
     const { ctx, ops } = mockCtx();
     drawVerticalRun(ctx, 'ー', 100, 200, 12, 0);
-    // Tr uses the page rotation (no −90° counter-rotation) and centres on the
-    // column: fill at the cell centre (105, 200) with center/middle alignment.
+    // ー (U+30FC) has no U+FE3x vertical form, so it keeps the rotate fallback:
+    // the page rotation only (no −90° counter-rotation), centred on the column at
+    // the cell centre (105, 200) with center/middle alignment.
     expect(ops.some((o) => o.op === 'rotate')).toBe(false);
     const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
     expect(fill).toMatchObject({ text: 'ー', x: 105, y: 200, align: 'center', baseline: 'middle' });
+  });
+
+  it('substitutes a Tr bracket with its vertical form (（→︵, ）→︶) and draws it UPRIGHT', () => {
+    // Symptom 2: a rotated fullwidth bracket lands its ink off-cell (unmeasurable
+    // on a Canvas). Substituting the U+FE35/FE36 vertical form and drawing it
+    // upright (counter-rotated) lets a per-glyph vertical-ink metric centre it.
+    const { ctx, ops } = mockCtx({
+      // Model ︵/︶ ink hugging opposite cell ends under a `middle` baseline.
+      inkMiddle: { '︵': { asc: -9, desc: 21 }, '︶': { asc: 21, desc: -9 } },
+    });
+    drawVerticalRun(ctx, '（）', 0, 0, 12, 0);
+    // Both are substituted to their vertical forms and COUNTER-ROTATED (upright).
+    const fills = ops.filter((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fills.map((f) => f.text)).toEqual(['︵', '︶']);
+    const rotates = ops.filter((o): o is Extract<Op, { op: 'rotate' }> => o.op === 'rotate');
+    expect(rotates).toHaveLength(2);
+    expect(rotates.every((r) => Math.abs(r.a - -Math.PI / 2) < 1e-9)).toBe(true);
+    // Along-column ink centring: fillText y = (asc − desc)/2. For ︵: (−9−21)/2 =
+    // −15; for ︶: (21−(−9))/2 = 15. Drawn centred (x = 0, the cell centre).
+    expect(fills.map((f) => f.align)).toEqual(['center', 'center']);
+    expect(fills.map((f) => f.baseline)).toEqual(['middle', 'middle']);
+    expect(fills.map((f) => f.x)).toEqual([0, 0]);
+    expect(fills[0].y).toBeCloseTo(-15, 6);
+    expect(fills[1].y).toBeCloseTo(15, 6);
+  });
+
+  it('keeps a Tr bracket at the cell centre when the Canvas reports no ink metrics', () => {
+    // No actualBoundingBox* → along-column correction is 0, so the substituted
+    // vertical form draws at the cell centre exactly (graceful degradation).
+    const { ctx, ops } = mockCtx();
+    drawVerticalRun(ctx, '「」', 0, 0, 12, 0);
+    const fills = ops.filter((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fills.map((f) => f.text)).toEqual(['﹁', '﹂']); // FE41 / FE42
+    expect(fills.every((f) => f.x === 0 && f.y === 0)).toBe(true);
   });
 
   it('substitutes a Tu comma/period with its vertical presentation form (、→︑, 。→︒)', () => {
@@ -196,8 +272,9 @@ describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin side
     const rotates = ops.filter((o): o is Extract<Op, { op: 'rotate' }> => o.op === 'rotate');
     expect(rotates).toHaveLength(2);
     // Substituted forms are pre-positioned by the font → drawn at the cell centre
-    // with no upper-right nudge (local x offset 0).
-    expect(fills.every((f) => f.x === 0)).toBe(true);
+    // with no upper-right nudge (local x offset 0). With no ink metrics the mock
+    // reports none, so the along-column correction is 0 (y = 0) too.
+    expect(fills.every((f) => f.x === 0 && f.y === 0)).toBe(true);
   });
 });
 

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -45,7 +45,11 @@
 // header/footer + tables in tbRl, and paragraph-relative vertical anchors are
 // follow-ups.
 
-import { verticalOrientation, verticalFormSubstitute } from '@silurus/ooxml-core';
+import {
+  verticalOrientation,
+  verticalFormSubstitute,
+  verticalBracketFormSubstitute,
+} from '@silurus/ooxml-core';
 
 /** How a code point is painted inside the +90°-rotated vertical page:
  *   - `upright`  — counter-rotated −90° to stand up (vo=U, and vo=Tu).
@@ -161,6 +165,69 @@ export function splitVerticalOrientationRuns(
 type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
 
 /**
+ * Cross-axis (column-thickness) offset, in px, from the alphabetic baseline to
+ * the font's EM-BOX CENTRE — i.e. `(fontBoundingBoxAscent − fontBoundingBoxDescent)/2`.
+ *
+ * This is a FONT metric (glyph-independent): `fontBoundingBox*` describe the
+ * font's design box, not one glyph's ink. In vertical text the column's cross
+ * axis is where every cell centres, and the UPRIGHT cells (drawn with a `middle`
+ * textBaseline) already sit their em box on the caller's `baseline`. A SIDEWAYS
+ * (Latin/digit) glyph, however, is drawn on its ALPHABETIC baseline, so its ink
+ * (which sits ~this many px above the baseline) would land off the column centre
+ * by exactly this amount. Shifting the sideways draw down the cross axis by this
+ * offset re-centres its em box on the same line the upright cells use — so mixed
+ * columns like "電話 03-1234-5678" share one centreline (ECMA-376 §17.6.20).
+ *
+ * Falls back to `0.38 × fontPx` (the near-universal CJK/Latin em-box centre ratio)
+ * only if the Canvas does not report `fontBoundingBox*` (older engines); on those
+ * engines the previous baseline-anchored placement is no worse than today.
+ */
+function emBoxCenterAboveBaselinePx(ctx: Ctx2D, sample: string, fontPx: number): number {
+  const prevBaseline = ctx.textBaseline;
+  ctx.textBaseline = 'alphabetic';
+  const m = ctx.measureText(sample);
+  ctx.textBaseline = prevBaseline;
+  const asc = m.fontBoundingBoxAscent;
+  const desc = m.fontBoundingBoxDescent;
+  if (typeof asc === 'number' && typeof desc === 'number' && (asc !== 0 || desc !== 0)) {
+    return (asc - desc) / 2;
+  }
+  return 0.38 * fontPx;
+}
+
+/**
+ * Along-column offset, in px, from a glyph's own cell centre to its INK centre
+ * when the glyph is drawn UPRIGHT — i.e. `(actualBoundingBoxAscent −
+ * actualBoundingBoxDescent)/2` measured with a `middle` textBaseline.
+ *
+ * For an upright-drawn glyph the page transform maps the glyph's VERTICAL extent
+ * onto the along-column axis, so a glyph whose ink is not vertically centred in
+ * its em box (most visibly a substituted vertical bracket form ︵ ︶ ﹁ ﹂,
+ * whose ink hugs one end of the cell) lands off the cell centre by this amount.
+ * The renderer shifts the draw by `+this` so the ink re-centres — a per-GLYPH
+ * measured metric (`actualBoundingBox*` is the tight ink box), NOT a constant.
+ * For an ordinary ideograph/kana this is ≈0, so upright CJK cells are unaffected.
+ *
+ * Returns 0 when the Canvas does not report `actualBoundingBox*` (older engines):
+ * the glyph then draws at the cell centre exactly as before this metric existed.
+ */
+function inkCenterAboveMiddlePx(ctx: Ctx2D, drawStr: string): number {
+  const prevAlign = ctx.textAlign;
+  const prevBaseline = ctx.textBaseline;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  const m = ctx.measureText(drawStr);
+  ctx.textAlign = prevAlign;
+  ctx.textBaseline = prevBaseline;
+  const asc = m.actualBoundingBoxAscent;
+  const desc = m.actualBoundingBoxDescent;
+  if (typeof asc === 'number' && typeof desc === 'number') {
+    return (asc - desc) / 2;
+  }
+  return 0;
+}
+
+/**
  * Draw one run's glyphs in vertical mode. The context is assumed to already be
  * in the page's SWAPPED logical frame (the +90° page rotation is installed by
  * `renderDocumentToCanvas`), so an ordinary `fillText` advances DOWN the line.
@@ -192,6 +259,11 @@ export function drawVerticalRun(
 ): void {
   const prevAlign = ctx.textAlign;
   const prevBaseline = ctx.textBaseline;
+  // Cross-axis (column-thickness) distance from the alphabetic baseline to the
+  // font's em-box centre — the line the UPRIGHT cells centre on. Measured once
+  // per run (font-level, glyph-independent). Used to re-centre SIDEWAYS glyphs,
+  // which are otherwise drawn on their baseline and so land off the centreline.
+  const emBoxCenterPx = emBoxCenterAboveBaselinePx(ctx, text, fontPx);
   let ax = 0; // cumulative advance from run left (logical +x)
   for (const ch of text) {
     const cp = ch.codePointAt(0) ?? 0;
@@ -199,58 +271,70 @@ export function drawVerticalRun(
     // Advance/width uses the ORIGINAL code point (measure == draw, and the text
     // model / selection / find keep the original character — see the module doc).
     const adv = ctx.measureText(ch).width + letterSpacingPx;
-    if (mode === 'upright') {
-      // vo=U or Tu. Counter-rotate −90° about the cell centre so the glyph
-      // (which the page rotation would otherwise lay on its side) stands upright.
-      // For Tu punctuation with a Unicode vertical presentation form
-      // (、。，！？ → U+FE10–FE12/FE15/FE16), draw THAT glyph so the font places
-      // it in the cell's upper-right (Word behaviour); the original advance is
-      // kept. (：；〖〗 are vo=Tr — they take the rotate branch below, never this
-      // substitution; substitute-first Tr is the #790/#771 follow-up.)
-      // Substitution is a GLYPH-only change: the width above and everything the
-      // renderer reports (selection, find) use the original `ch`.
-      const drawCp = verticalFormSubstitute(cp);
+    // A vo=Tr bracket with a Unicode vertical presentation form (（）「」〈〉…) is
+    // SUBSTITUTED and drawn upright, exactly like the upright cells — UAX#50 §5
+    // Tr means "substitute a vertical glyph; rotate only as fallback". Only Tr
+    // code points with NO vertical form (ー, quotes “”) keep the rotate fallback.
+    const bracketCp = mode === 'rotate' ? verticalBracketFormSubstitute(cp) : null;
+    if (mode === 'upright' || bracketCp !== null) {
+      // vo=U / Tu, or a substituted Tr bracket. Counter-rotate −90° about the
+      // cell centre so the glyph (which the page rotation would otherwise lay on
+      // its side) stands upright. For Tu punctuation with a Unicode vertical form
+      // (、。，！？ → U+FE10–FE12/FE15/FE16) and Tr brackets (（）「」… → U+FE35–FE44)
+      // draw THAT glyph so the font supplies the vertical shape; the original
+      // advance is kept. Substitution is a GLYPH-only change: the width above and
+      // everything the renderer reports (selection, find) use the original `ch`.
+      const drawCp = bracketCp !== null ? bracketCp : verticalFormSubstitute(cp);
       const drawStr = drawCp !== null ? String.fromCodePoint(drawCp) : ch;
       const cx = x + ax + adv / 2;
-      // No positional nudge when we substituted a vertical form (the glyph is
-      // pre-positioned); otherwise fall back to the corner nudge for ． (FF0E).
+      // Corner nudge fallback only for a Tu punct with NO vertical form (． FF0E);
+      // every substituted glyph is positioned by its own vertical metric below.
       const off = drawCp !== null ? { dx: 0, dy: 0 } : verticalGlyphOffset(cp);
+      // ALONG-COLUMN centring: an upright glyph's VERTICAL ink extent maps to the
+      // column axis, so shift by its measured ink centre so the ink lands on the
+      // cell centre. Per-GLYPH metric (the drawn glyph's tight ink box): for an
+      // ideograph/kana it is ≈0 (cells unchanged); for a substituted vertical
+      // bracket (ink hugging one cell end) it is the needed correction. Replaces
+      // the old `+0.12em` font-tuned heuristic. Skipped when the ． corner nudge is
+      // active (`off.dy`), which is a self-contained upper-right cell placement.
+      const alongEm = off.dy === 0 ? inkCenterAboveMiddlePx(ctx, drawStr) / fontPx : 0;
       ctx.save();
       ctx.translate(cx, baseline);
       ctx.rotate(-Math.PI / 2);
-      // In the upright local frame: draw centred horizontally (the cell centre)
-      // with a `middle` baseline that centres the glyph box on the cell.
-      // HEURISTIC (approximation, font-dependent): the extra +0.12em vertical
-      // shift nudges typical CJK metrics so the visual centre lands on the cell
-      // centre — NOT a spec constant (JIS X 4051 positions the glyph from the
-      // font's ideographic em-box / vertical baseline, which the browser does not
-      // expose here). Replace with the font's vertical metrics (`ideographic`
-      // textBaseline once broadly supported). Tracked in issue #771.
+      // In the upright local frame: `center`/`middle` puts the em box on the cell
+      // centre; local +x = cross axis, local +y = along-column. `off.dx` nudges
+      // ． toward the cell's upper-right corner (cross axis); `alongEm + off.dy`
+      // centres the ink along the column.
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillText(drawStr, off.dx * fontPx, (0.12 + off.dy) * fontPx);
+      ctx.fillText(drawStr, off.dx * fontPx, (alongEm + off.dy) * fontPx);
       ctx.restore();
     } else if (mode === 'rotate') {
-      // vo=Tr: full-width brackets （「」〈〉“” and the ー prolonged sound mark.
-      // UAX#50's Tr fallback (no vertical glyph reachable on a Canvas) is to
-      // ROTATE the glyph 90° CW. A plain `fillText` in the +90° page frame IS
-      // that rotation; centre the (full-width) glyph on the column axis by using
-      // `center`/`middle` at the cell centre and the caller's `baseline` (the
-      // same column-centre reference the upright cells use). This is what makes
-      // the ー and （ ） appear rotated and mid-column rather than upright.
+      // vo=Tr with NO vertical form: ー (U+30FC) and the double quotes “”. UAX#50's
+      // Tr fallback (no vertical glyph reachable on a Canvas) is to ROTATE the
+      // glyph 90° CW. A plain `fillText` in the +90° page frame IS that rotation;
+      // centre it on the column with `center`/`middle` at the cell centre. (The
+      // bracket forms never reach here — they were substituted and drawn upright
+      // above; a rotated bracket's ink offset is not measurable from a Canvas.)
       const cx = x + ax + adv / 2;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
       ctx.fillText(ch, cx, baseline);
     } else {
-      // vo=R (Latin/digit): draw as-is (rotated with the page). Keep the caller's
-      // alphabetic baseline; position the glyph's left at the current advance. A
-      // group of consecutive sideways glyphs would ideally be one fillText for
-      // shaping, but per-glyph keeps the advance model uniform and Latin advances
-      // are context-free enough at these sizes.
+      // vo=R (Latin/digit): drawn SIDEWAYS (rotated with the page). Keep the
+      // caller's alphabetic baseline and position the glyph's left at the current
+      // advance, but shift the cross axis by the em-box centre so the glyph's ink
+      // centres on the SAME column centreline the upright cells use — otherwise a
+      // baseline-anchored sideways glyph sits ~0.38em off (its ink is above the
+      // baseline), the "電話 / 03-…" left-right drift. A group of consecutive
+      // sideways glyphs would ideally be one fillText for shaping, but per-glyph
+      // keeps the advance model uniform and Latin advances are context-free enough
+      // at these sizes.
+      // `alphabetic` baseline pins the em-box-centre shift (emBoxCenterPx is
+      // measured relative to the alphabetic baseline).
       ctx.textAlign = prevAlign;
-      ctx.textBaseline = prevBaseline;
-      ctx.fillText(ch, x + ax, baseline);
+      ctx.textBaseline = 'alphabetic';
+      ctx.fillText(ch, x + ax, baseline + emBoxCenterPx);
     }
     ax += adv;
   }

--- a/packages/node/src/docx-vertical-mixed-metrics.probe.test.ts
+++ b/packages/node/src/docx-vertical-mixed-metrics.probe.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Cross-axis centering probe for docx vertical (tbRl) text (ECMA-376 §17.6.20).
+ *
+ * Two symptoms reported on sample-26 (the vertical newspaper):
+ *   1. In a mixed column, the SIDEWAYS (Latin/digit) glyphs of "03-1234-5678"
+ *      do not share the column centerline with the UPRIGHT "電話" glyphs — the
+ *      digits sit off to one physical side.
+ *   2. The Tr rotated fullwidth parens （）of "…日（土）" crowd the neighbouring
+ *      glyph instead of sitting a full cell apart.
+ *
+ * This probe measures glyph INK CENTROIDS directly on the rendered canvas — the
+ * cross-axis (physical x) centroid for symptom 1, and the along-column (physical
+ * y) centroids / spacing for symptom 2 — so the fix is validated in pixels, not
+ * by eye. It renders through the REAL `drawVerticalRun` inside the REAL page +90°
+ * transform (translate(W,0)·rotate(+90°), same as renderDocumentToCanvas).
+ *
+ * Font: Hiragino Mincho ProN registered under the serif JP fallback names the
+ * renderer emits for ＭＳ 明朝 (the sample's body face). A substitute font shifts
+ * absolute positions but before/after use the same font, so the comparison holds.
+ *
+ * CI-safe: gated on skia (a devDependency). Pure `drawVerticalRun` needs no WASM.
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { loadSkiaForTests, importForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, FontLibrary } = (skia ?? {}) as Skia;
+
+// Hiragino Mincho ProN — present on macOS dev hosts; skip elsewhere.
+const MINCHO = '/System/Library/Fonts/ヒラギノ明朝 ProN.ttc';
+const haveFont = existsSync(MINCHO);
+
+const vtMod = await importForTests(
+  () => import('../../docx/src/vertical-text.ts'),
+  'packages/docx/src/vertical-text.ts',
+);
+
+function useFont(): void {
+  // Register under every serif-JP fallback name normalizeFontFamily emits.
+  for (const fam of ['MS Mincho', 'Hiragino Mincho ProN', 'Noto Serif JP', 'Yu Mincho']) {
+    FontLibrary.use(fam, [MINCHO]);
+  }
+}
+
+/** Ink weight (0..255) of a pixel: 255 = full black ink on white. */
+function ink(data: Uint8ClampedArray, i: number): number {
+  return 255 - (0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2]);
+}
+
+describe.skipIf(!skia || !vtMod || !haveFont)('docx vertical mixed-metrics centering (§17.6.20)', () => {
+  const fontPx = 48;
+
+  /** Render a run list with the page +90° transform and return the pixel buffer.
+   *  Each entry draws one `drawVerticalRun` at logical (x, baseline). */
+  function renderRuns(
+    runs: Array<{ text: string; x: number; letterSpacing: number }>,
+    baseline: number,
+    W: number,
+    H: number,
+  ): { data: Uint8ClampedArray; W: number; H: number } {
+    const { drawVerticalRun } = vtMod as {
+      drawVerticalRun: (
+        ctx: unknown,
+        text: string,
+        x: number,
+        baseline: number,
+        fontPx: number,
+        letterSpacingPx: number,
+      ) => void;
+    };
+    useFont();
+    const canvas = new Canvas(W, H);
+    const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(0, 0, W, H);
+    ctx.fillStyle = '#000';
+    ctx.font = `${fontPx}px "MS Mincho", serif`;
+    ctx.save();
+    ctx.translate(W, 0);
+    ctx.rotate(Math.PI / 2);
+    for (const r of runs) drawVerticalRun(ctx, r.text, r.x, baseline, fontPx, r.letterSpacing);
+    ctx.restore();
+    const img = ctx.getImageData(0, 0, W, H);
+    return { data: img.data, W, H };
+  }
+
+  /** Ink-weighted mean physical X over a band of physical rows [py0,py1). The
+   *  column centerline is at physical X = W − baseline. */
+  function crossAxisCentroid(
+    data: Uint8ClampedArray,
+    W: number,
+    py0: number,
+    py1: number,
+  ): number {
+    let sx = 0;
+    let sw = 0;
+    for (let py = py0; py < py1; py++) {
+      for (let px = 0; px < W; px++) {
+        const w = ink(data, (py * W + px) * 4);
+        if (w > 20) {
+          sx += px * w;
+          sw += w;
+        }
+      }
+    }
+    return sw > 0 ? sx / sw : NaN;
+  }
+
+  /** Project all ink onto the physical-y (column) axis → one weight per row. */
+  function inkProfileY(data: Uint8ClampedArray, W: number, H: number): number[] {
+    const prof = new Array<number>(H).fill(0);
+    for (let py = 0; py < H; py++) {
+      let s = 0;
+      for (let px = 0; px < W; px++) {
+        const w = ink(data, (py * W + px) * 4);
+        if (w > 20) s += w;
+      }
+      prof[py] = s;
+    }
+    return prof;
+  }
+
+  /** Ink-weighted centroid of a physical-y profile within a window [c−r, c+r]. */
+  function centroidInWindow(prof: number[], c: number, r: number): number {
+    let sy = 0;
+    let sw = 0;
+    const y0 = Math.max(0, Math.round(c - r));
+    const y1 = Math.min(prof.length, Math.round(c + r));
+    for (let y = y0; y < y1; y++) {
+      sy += y * prof[y];
+      sw += prof[y];
+    }
+    return sw > 0 ? sy / sw : NaN;
+  }
+
+  it('SYMPTOM 1: upright CJK and sideways digits share the column centerline (≤1px)', () => {
+    const W = 400;
+    const H = 400;
+    const baseline = 150;
+    const centerline = W - baseline;
+    const cellW = fontPx; // fullwidth cell
+    const logX = 40;
+    // "電話" upright (2 fullwidth cells), then "0" sideways in the 3rd cell.
+    const { data } = renderRuns(
+      [
+        { text: '電話', x: logX, letterSpacing: 0 },
+        { text: '0', x: logX + 2 * cellW, letterSpacing: 0 },
+      ],
+      baseline,
+      W,
+      H,
+    );
+    // Physical y band of glyph i = [logX + i*cellW, logX + (i+1)*cellW).
+    const cCJK1 = crossAxisCentroid(data, W, logX, logX + cellW);
+    const cCJK2 = crossAxisCentroid(data, W, logX + cellW, logX + 2 * cellW);
+    const cDigit = crossAxisCentroid(data, W, logX + 2 * cellW, logX + 3 * cellW);
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n[SYMPTOM1] centerline X=${centerline}\n` +
+        `  電 centroidX=${cCJK1.toFixed(1)} off=${(cCJK1 - centerline).toFixed(1)}\n` +
+        `  話 centroidX=${cCJK2.toFixed(1)} off=${(cCJK2 - centerline).toFixed(1)}\n` +
+        `  0  centroidX=${cDigit.toFixed(1)} off=${(cDigit - centerline).toFixed(1)}\n` +
+        `  CJK↔digit gap=${Math.abs(cDigit - (cCJK1 + cCJK2) / 2).toFixed(1)}px`,
+    );
+    const cjkMean = (cCJK1 + cCJK2) / 2;
+    // The digit's cross-axis centroid must sit on the same centerline the CJK
+    // glyphs do (within 1px). The em-box center is the shared reference.
+    expect(Math.abs(cDigit - cjkMean)).toBeLessThanOrEqual(1);
+    // And the CJK glyphs themselves must sit on the centerline.
+    expect(Math.abs(cjkMean - centerline)).toBeLessThanOrEqual(1.5);
+  });
+
+  it('SYMPTOM 2: 日（土）— the Tr parens sit a full cell from their neighbours', () => {
+    const W = 500;
+    const H = 500;
+    const baseline = 150;
+    const cellW = fontPx;
+    const logX = 40;
+    // 日 ( 土 ) — all fullwidth cells (parens are Tr rotate, 日/土 upright).
+    const text = '日（土）';
+    const { data } = renderRuns([{ text, x: logX, letterSpacing: 0 }], baseline, W, H);
+    // Project ink to the column axis, then take each glyph's centroid within a
+    // window centered on its expected cell centre (± half a cell) so a tall
+    // narrow paren's ink is not miscounted into a neighbour's band.
+    const prof = inkProfileY(data, W, H);
+    const centers: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      const expected = logX + (i + 0.5) * cellW;
+      centers.push(centroidInWindow(prof, expected, cellW / 2));
+    }
+    const gaps = [centers[1] - centers[0], centers[2] - centers[1], centers[3] - centers[2]];
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n[SYMPTOM2] cellW=${cellW} centers=${centers.map((c) => c.toFixed(1)).join(', ')}\n` +
+        `  gaps 日→( , (→土 , 土→) = ${gaps.map((g) => g.toFixed(1)).join(', ')}`,
+    );
+    // Each glyph's ink centroid sits ~one cell (fontPx) from its neighbour. The
+    // tolerance is 6px (0.125em): we correct the bracket by its geometric ink-box
+    // centre (actualBoundingBox*), which differs from the ink-WEIGHTED centroid
+    // this probe measures by a few px — an inherent, typographically-correct
+    // residual (Word centres by designed metrics too). The pre-fix state crowded
+    // 土→) to 27px (0.44 cell); the fix removes that crowding. The KEY guard is
+    // that no gap collapses below ~0.8 cell (the reported crowding symptom).
+    for (const g of gaps) expect(Math.abs(g - cellW)).toBeLessThanOrEqual(6);
+    expect(Math.min(...gaps)).toBeGreaterThan(cellW * 0.8);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two positioning defects in docx vertical (tbRl, ECMA-376 §17.6.20) text
that the user reported on sample-26 after PR #789, both replacing centring
heuristics with **measured font metrics**:

1. **Mixed-column drift** — in "電話 03-1234-5678", the sideways Latin/digit run
   sat to one side of the upright "電話" column. Root cause: sideways glyphs were
   drawn on their **alphabetic baseline** while upright cells centre on the **em
   box**, so the digit ink landed ~0.38em off the column centreline. Fix: shift
   the sideways draw across the column by the font's em-box centre,
   `(fontBoundingBoxAscent − fontBoundingBoxDescent)/2`. Headless measurement:
   CJK↔digit cross-axis gap **14.0px → 0.6px** (48px font).

2. **`（土）` crowding** — 土 was squeezed against the parens. Root cause: a
   rotated fullwidth paren lands its ink off-cell along the column, and that
   horizontal ink offset is **not measurable** on a Canvas (`measureText` reports
   the advance box). Fix (UAX#50 §5 Tr = "substitute a vertical glyph; rotate
   only as fallback"): substitute the U+FE35+ **vertical presentation form** and
   draw it **upright**, so the along-column position is governed by the glyph's
   *vertical* ink extent (which the Canvas *does* expose), then centre by
   `(actualBoundingBoxAscent − actualBoundingBoxDescent)/2`. Crowding removed
   (土→) gap **27px → 47px**); matches Word's PDF, which uses the same vert
   glyphs. ー and the quotes "" (no vertical form) keep the rotate fallback.

Also removes the `+0.12em` upright-centring heuristic from #789 (stage-1),
replaced by the same per-glyph vertical-ink metric (≈0 for ideographs → upright
CJK cells unchanged).

## Cross-cutting

`verticalBracketFormSubstitute` (the Tr bracket → U+FE35–FE44 map) lives in
`core` as pure UAX#50 data, ready for pptx/xlsx vertical text.

## Verification (measured, headless skia)

- New device-pixel probe (`packages/node/src/docx-vertical-mixed-metrics.probe.test.ts`)
  measures both symptoms' ink centroids; **fails on the pre-fix renderer**, passes after.
- Confirmed against `sample-26.pdf` ground truth: digits centre on the column and
  the parens render as vertical presentation forms, matching Word.
- `packages/docx` + `packages/core` vitest: **1822 passed** (incl. findText /
  selection / text-layer — the advance model and overlay geometry are unchanged).
- docx + core + root `tsc --noEmit`: clean. `ast-grep`: clean.
- Horizontal path is byte-identical: every changed draw is behind the
  `state.verticalCJK` gate.

Refs #771