### PR TITLE
fix(docx): keep vertical 、。 upper-right and centre ！／？ (tbRl)

### DIFF
--- a/packages/core/src/text/vertical-orientation.test.ts
+++ b/packages/core/src/text/vertical-orientation.test.ts
@@ -72,12 +72,19 @@ describe('verticalOrientation (UAX #50 Vertical_Orientation)', () => {
 });
 
 describe('verticalFormSubstitute (UAX #50 §5 vertical-form glyph substitution)', () => {
-  it('maps the Tu punctuation with a dedicated U+FE1x vertical form', () => {
+  it('maps the CORNER-HANGING Tu punctuation (comma/full stop) to its U+FE1x form', () => {
     expect(verticalFormSubstitute(0x3001)).toBe(0xfe11); // 、 → ︑
     expect(verticalFormSubstitute(0x3002)).toBe(0xfe12); // 。 → ︒
     expect(verticalFormSubstitute(0xff0c)).toBe(0xfe10); // ， → ︐
-    expect(verticalFormSubstitute(0xff01)).toBe(0xfe15); // ！ → ︕
-    expect(verticalFormSubstitute(0xff1f)).toBe(0xfe16); // ？ → ︖
+  });
+
+  it('does NOT substitute ！／？ (they stand upright & centred, not corner-hanging)', () => {
+    // ！ FF01 → FE15 and ？ FF1F → FE16 are deliberately absent. The FE15/FE16
+    // vertical forms are corner-designed in many fonts and shift ！／？ off the
+    // column centre; the original fullwidth mark drawn upright is already the
+    // correct, centred vertical appearance (PDF-verified on sample-26, #771).
+    expect(verticalFormSubstitute(0xff01)).toBeNull(); // ！
+    expect(verticalFormSubstitute(0xff1f)).toBeNull(); // ？
   });
 
   it('returns null for non-Tu punctuation (Tr rotates, R stays sideways — no substitute)', () => {

--- a/packages/core/src/text/vertical-orientation.ts
+++ b/packages/core/src/text/vertical-orientation.ts
@@ -66,20 +66,31 @@ export function verticalOrientation(cp: number): VerticalOrientation {
  *
  * UAX #50 §5 ("Glyph Changes for Vertical Orientation") describes the Tu/Tr
  * transform as substituting a vertical glyph variant. A Canvas cannot invoke the
- * font's `vert`/`vrt2` OpenType feature, so for the Tu punctuation that has a
- * dedicated Unicode presentation form we substitute the code point itself and
- * let the font supply the pre-positioned glyph (upper-right cell corner).
+ * font's `vert`/`vrt2` OpenType feature, so for the CORNER-HANGING Tu punctuation
+ * that has a dedicated Unicode presentation form we substitute the code point
+ * itself and let the font supply the pre-positioned glyph (upper-right cell
+ * corner). The caller then draws it em-box-centred (NO ink re-centring), so the
+ * font's designed corner offset is preserved — that is what places 、。 in the
+ * cell's upper-right the way Word does (PDF-verified on sample-26: 、 ink at
+ * −0.32em along-column, +0.33em cross-axis).
  *
  * NOTE: this map is a rendering mapping (fullwidth/CJK source → vertical form),
  * NOT the strict inverse of UnicodeData's `<vertical>` compatibility
- * decompositions. Per UnicodeData.txt, FE10/FE13–FE16 decompose to the ASCII
- * comma / colon / semicolon / exclamation / question mark
- * (U+002C/003A/003B/0021/003F) — but vertical Japanese text carries the
- * FULLWIDTH forms, so the map keys on those. Only FE11 (← 3001 、) and
- * FE12 (← 3002 。) are exact inverses.
+ * decompositions. Per UnicodeData.txt, FE10 decomposes to the ASCII comma
+ * (U+002C) — but vertical Japanese text carries the FULLWIDTH comma, so the map
+ * keys on that. Only FE11 (← 3001 、) and FE12 (← 3002 。) are exact inverses.
  *
  * Every key is vo=Tu, i.e. actually reaches the renderers' upright/substitute
  * draw branch. Deliberately NOT in the map:
+ *   • ！ FF01 (→ FE15) and ？ FF1F (→ FE16) — although vo=Tu, the exclamation /
+ *     question marks stand UPRIGHT and HORIZONTALLY CENTRED in a vertical line,
+ *     unlike the corner-hanging comma / full stop. The original fullwidth ！／？
+ *     drawn upright is already the correct vertical shape (the marks are
+ *     vertically symmetric) and lands centred on the column in every font. The
+ *     U+FE15/FE16 "vertical form" glyphs are corner-designed in many fonts
+ *     (Hiragino ink at +0.31em cross-axis), so substituting them pushed ！／？ to
+ *     the right of the column — the sample-26 "！ shifted right" defect (#771).
+ *     PDF ground truth: Word centres ！ (+0.03em), matching the upright original.
  *   • ：FF1A / ；FF1B and 〖3016 / 〗3017 are vo=Tr — the Tr draw branch rotates
  *     them and never consults this map. Making Tr substitute-first (FE13/FE14/
  *     FE17/FE18 here, plus the U+FE35+ forms for fullwidth parens/brackets —
@@ -106,12 +117,21 @@ export function verticalFormSubstitute(cp: number): number | null {
 // verticalFormSubstitute doc above for why the map keys on the fullwidth forms
 // and why Tr/R punctuation (：；〖〗…) is excluded. Names per the Unicode
 // "Vertical Forms" chart (U+FE10–U+FE1F).
+//
+// ONLY the CORNER-HANGING punctuation (comma / full stop) is substituted. In
+// vertical Japanese typography these hang in the UPPER-RIGHT of the cell (JIS X
+// 4051 §4.3 kutōten placement), which is exactly how a font designs its FE10–FE12
+// glyph — ink pushed to the corner of the em box. Substituting the code point and
+// drawing it em-box-centred reproduces that corner placement directly.
+//
+// Deliberately NOT substituted: ！ FF01 (→ FE15) and ？ FF1F (→ FE16) — see the
+// verticalFormSubstitute doc above. They stand upright and centred, so the FE15/
+// FE16 corner-designed forms would shift them off-column; the original ！／？ is
+// drawn upright instead.
 const VERTICAL_FORM_MAP: ReadonlyMap<number, number> = new Map<number, number>([
   [0xff0c, 0xfe10], // ， fullwidth comma       → PRESENTATION FORM FOR VERTICAL COMMA
   [0x3001, 0xfe11], // 、 ideographic comma     → … FOR VERTICAL IDEOGRAPHIC COMMA
   [0x3002, 0xfe12], // 。 ideographic full stop → … FOR VERTICAL IDEOGRAPHIC FULL STOP
-  [0xff01, 0xfe15], // ！ fullwidth exclamation → … FOR VERTICAL EXCLAMATION MARK
-  [0xff1f, 0xfe16], // ？ fullwidth question    → … FOR VERTICAL QUESTION MARK
 ]);
 
 /**

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -276,6 +276,43 @@ describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin side
     // reports none, so the along-column correction is 0 (y = 0) too.
     expect(fills.every((f) => f.x === 0 && f.y === 0)).toBe(true);
   });
+
+  it('does NOT ink-centre a substituted Tu comma even when ink metrics are present', () => {
+    // The comma/full stop vertical forms (︑ ︒) are DESIGNED with their ink in the
+    // cell's upper-right corner (JIS X 4051). Unlike a Tr bracket, they must NOT be
+    // pulled to the geometric cell centre by the along-column ink metric — doing so
+    // drops them LOW (the "、。 sit too low" defect, #771). So even with ink metrics
+    // reported, the punctuation draws at the em-box centre (y = 0), letting the
+    // font's designed corner offset stand.
+    const { ctx, ops } = mockCtx({
+      // Model ︑ ink hugging the top of the cell (as a real vertical comma does).
+      inkMiddle: { '︑': { asc: 21, desc: -9 } },
+    });
+    drawVerticalRun(ctx, '、', 0, 0, 12, 0);
+    const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fill?.text).toBe('︑');
+    // y stays 0 (em-box centred) — the ink metric is deliberately ignored here.
+    expect(fill?.y).toBe(0);
+    // Contrast: a Tr bracket WITH the same ink metric IS shifted (see the ︵/︶ test
+    // above), proving the skip is punctuation-specific, not a blanket disable.
+  });
+
+  it('draws ！ / ？ UPRIGHT without substitution (they stand centred, not corner-hung)', () => {
+    // ！ FF01 and ？ FF1F are vo=Tu but NOT substituted to FE15/FE16: those vertical
+    // forms are corner-designed in many fonts and would push the mark off the column
+    // centre (the sample-26 "！ shifted right" defect, #771). The original fullwidth
+    // mark drawn upright is already the correct, centred vertical appearance.
+    const { ctx, ops } = mockCtx();
+    drawVerticalRun(ctx, '！？', 0, 0, 12, 0);
+    const fills = ops.filter((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    // Drawn as the ORIGINAL code points (no FE15/FE16 substitution), counter-rotated
+    // upright and centred on the cell (center/middle at x=0, y=0).
+    expect(fills.map((f) => f.text)).toEqual(['！', '？']);
+    const rotates = ops.filter((o): o is Extract<Op, { op: 'rotate' }> => o.op === 'rotate');
+    expect(rotates).toHaveLength(2);
+    expect(fills.every((f) => f.align === 'center' && f.baseline === 'middle')).toBe(true);
+    expect(fills.every((f) => f.x === 0 && f.y === 0)).toBe(true);
+  });
 });
 
 describe('drawUprightBox (§17.6.20 — keep images upright inside the rotated page)', () => {

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -13,11 +13,15 @@
 //     a local −90° counter-rotation about the glyph's own centre, cancelling the
 //     page rotation so it stands UPRIGHT while still advancing down the line.
 //   • vo=Tu (transform, fallback upright): 、。，．！？ and small kana. UAX#50
-//     substitutes a vertical presentation glyph; where Unicode supplies one
-//     (、。，！？ → U+FE10–FE12/FE15/FE16, core `verticalFormSubstitute`) we draw
-//     THAT code point upright, so the comma/full stop sit in the cell's
-//     upper-right as Word does; where none exists (．, small kana) we draw the
-//     original upright unchanged (． keeps a corner-nudge fallback).
+//     substitutes a vertical presentation glyph. For the CORNER-HANGING comma/full
+//     stop (、。， → U+FE10–FE12, core `verticalFormSubstitute`) we draw THAT code
+//     point upright and em-box-centred so the font's designed upper-right ink
+//     placement lands the punctuation in the cell corner as Word does. ！？ are
+//     NOT substituted — they stand upright and CENTRED, so the original fullwidth
+//     mark drawn upright is the correct vertical form (the FE15/FE16 forms are
+//     corner-designed in many fonts and would shift ！？ off-column). Where no
+//     form exists (．, small kana) we draw the original upright unchanged (．
+//     keeps a corner-nudge fallback).
 //   • vo=Tr (transform, fallback rotate): （「」〈〉“”：；〖〗 and the ー prolonged
 //     sound mark. UAX#50's fallback (no vertical glyph available to a Canvas —
 //     the font's `vert`/`vrt2` OpenType feature is not reachable via `fillText`)
@@ -94,9 +98,9 @@ export function isUprightVerticalGlyph(cp: number): boolean {
 /** The Tu punctuation whose upper-right cell position is approximated by a
  *  draw-time nudge WHEN the font has no U+FExx vertical form to substitute (see
  *  {@link verticalGlyphOffset}). The comma/full stop that DO have a vertical form
- *  ({@link verticalFormSubstitute}: 、。，！？) are substituted instead and the
- *  font positions them, so they are NOT nudged. The fullwidth full stop ． (FF0E)
- *  has no vertical form in Unicode, so it stays on the nudge fallback. */
+ *  ({@link verticalFormSubstitute}: 、。，) are substituted instead and the font
+ *  positions them, so they are NOT nudged. The fullwidth full stop ． (FF0E) has
+ *  no vertical form in Unicode, so it stays on the nudge fallback. */
 const VERTICAL_PUNCT_UPPER_RIGHT = new Set<number>([
   0xff0e, // ． fullwidth full stop (no U+FExx vertical form → nudge fallback)
 ]);
@@ -279,12 +283,17 @@ export function drawVerticalRun(
     if (mode === 'upright' || bracketCp !== null) {
       // vo=U / Tu, or a substituted Tr bracket. Counter-rotate −90° about the
       // cell centre so the glyph (which the page rotation would otherwise lay on
-      // its side) stands upright. For Tu punctuation with a Unicode vertical form
-      // (、。，！？ → U+FE10–FE12/FE15/FE16) and Tr brackets (（）「」… → U+FE35–FE44)
+      // its side) stands upright. For corner-hanging Tu punctuation with a Unicode
+      // vertical form (、。， → U+FE10–FE12) and Tr brackets (（）「」… → U+FE35–FE44)
       // draw THAT glyph so the font supplies the vertical shape; the original
       // advance is kept. Substitution is a GLYPH-only change: the width above and
       // everything the renderer reports (selection, find) use the original `ch`.
-      const drawCp = bracketCp !== null ? bracketCp : verticalFormSubstitute(cp);
+      // ！？ are NOT substituted (see verticalFormSubstitute) — they draw upright
+      // as the original fullwidth mark, which is already centred on the column.
+      // A substituted Tu punctuation form (、。， → FE10–FE12) vs. everything else.
+      // The Tr bracket substitute is tracked separately by `bracketCp`.
+      const puncCp = bracketCp !== null ? null : verticalFormSubstitute(cp);
+      const drawCp = bracketCp !== null ? bracketCp : puncCp;
       const drawStr = drawCp !== null ? String.fromCodePoint(drawCp) : ch;
       const cx = x + ax + adv / 2;
       // Corner nudge fallback only for a Tu punct with NO vertical form (． FF0E);
@@ -297,7 +306,21 @@ export function drawVerticalRun(
       // bracket (ink hugging one cell end) it is the needed correction. Replaces
       // the old `+0.12em` font-tuned heuristic. Skipped when the ． corner nudge is
       // active (`off.dy`), which is a self-contained upper-right cell placement.
-      const alongEm = off.dy === 0 ? inkCenterAboveMiddlePx(ctx, drawStr) / fontPx : 0;
+      //
+      // NOT applied to a substituted Tu punctuation form (comma/full stop 、。，
+      // → FE10–FE12): those glyphs are DESIGNED with their ink in the cell's
+      // upper-right corner (JIS X 4051 §4.3 kutōten placement — Word keeps them
+      // there, PDF-verified on sample-26: 、 ink at −0.32em along-column). Ink-
+      // centring would force that intentional offset back to the geometric cell
+      // centre, dropping the comma/full stop LOW — the reported "、。 sit too low"
+      // defect (#771). Drawing them em-box-centred preserves the font's corner
+      // design. The Tr brackets DO get the correction: their two halves must sit a
+      // full cell apart and the font centres the em box, not the ink (#792).
+      const isPunctSubstitute = puncCp !== null;
+      const alongEm =
+        off.dy === 0 && !isPunctSubstitute
+          ? inkCenterAboveMiddlePx(ctx, drawStr) / fontPx
+          : 0;
       ctx.save();
       ctx.translate(cx, baseline);
       ctx.rotate(-Math.PI / 2);

--- a/packages/node/src/docx-vertical-mixed-metrics.probe.test.ts
+++ b/packages/node/src/docx-vertical-mixed-metrics.probe.test.ts
@@ -1,22 +1,35 @@
 /**
  * Cross-axis centering probe for docx vertical (tbRl) text (ECMA-376 §17.6.20).
  *
- * Two symptoms reported on sample-26 (the vertical newspaper):
+ * Four symptoms reported on sample-26 (the vertical newspaper):
  *   1. In a mixed column, the SIDEWAYS (Latin/digit) glyphs of "03-1234-5678"
  *      do not share the column centerline with the UPRIGHT "電話" glyphs — the
  *      digits sit off to one physical side.
  *   2. The Tr rotated fullwidth parens （）of "…日（土）" crowd the neighbouring
  *      glyph instead of sitting a full cell apart.
+ *   3. The Tu comma / full stop 、。 sit TOO LOW in their cell (along-column). Word
+ *      hangs them in the cell's UPPER-RIGHT corner (JIS X 4051 §4.3, PDF-verified:
+ *      、 ink centroid at ≈ −0.32em along-column). The #792 along-column ink-centring
+ *      force-pulled the designed corner ink back to the geometric cell centre,
+ *      dropping them low; the fix skips ink-centring for the FE10–FE12 punctuation
+ *      substitutes so the font's corner design stands.
+ *   4. The ！ (and ？) sit shifted to the RIGHT of the column (cross-axis). Word
+ *      centres them (PDF-verified: ！ ink at ≈ +0.03em cross-axis). The FE15/FE16
+ *      "vertical form" substitution was corner-designed in the render font and
+ *      pushed the mark right; the fix stops substituting ！／？ and draws the
+ *      original fullwidth mark upright, which is centred in every font.
  *
  * This probe measures glyph INK CENTROIDS directly on the rendered canvas — the
- * cross-axis (physical x) centroid for symptom 1, and the along-column (physical
- * y) centroids / spacing for symptom 2 — so the fix is validated in pixels, not
- * by eye. It renders through the REAL `drawVerticalRun` inside the REAL page +90°
- * transform (translate(W,0)·rotate(+90°), same as renderDocumentToCanvas).
+ * cross-axis (physical x) centroid for symptoms 1 & 4, and the along-column
+ * (physical y) centroids / spacing for symptoms 2 & 3 — so the fix is validated in
+ * pixels, not by eye. It renders through the REAL `drawVerticalRun` inside the REAL
+ * page +90° transform (translate(W,0)·rotate(+90°), same as renderDocumentToCanvas).
  *
  * Font: Hiragino Mincho ProN registered under the serif JP fallback names the
  * renderer emits for ＭＳ 明朝 (the sample's body face). A substitute font shifts
- * absolute positions but before/after use the same font, so the comparison holds.
+ * absolute positions but the corner-vs-centre distinction the fix asserts is a
+ * DIRECTION (comma high-right, ！ centred), which holds across fonts, so the guard
+ * uses generous em-fraction tolerances rather than exact PDF pixel matches.
  *
  * CI-safe: gated on skia (a devDependency). Pure `drawVerticalRun` needs no WASM.
  */
@@ -205,5 +218,68 @@ describe.skipIf(!skia || !vtMod || !haveFont)('docx vertical mixed-metrics cente
     // that no gap collapses below ~0.8 cell (the reported crowding symptom).
     for (const g of gaps) expect(Math.abs(g - cellW)).toBeLessThanOrEqual(6);
     expect(Math.min(...gaps)).toBeGreaterThan(cellW * 0.8);
+  });
+
+  it('SYMPTOM 3: 、。 hang in the cell UPPER part, not pulled low to the centre', () => {
+    // Word / JIS X 4051 place the vertical comma/full stop in the cell's upper-right
+    // corner. Along the column that means the ink centroid sits ABOVE the cell
+    // centre (smaller physical y). PDF ground truth (sample-26): 、 ≈ −0.32em.
+    // The #792 ink-centring dropped them to ≈ 0 (the "too low" defect); the fix
+    // restores the font's corner design (Hiragino: ≈ −0.33em).
+    const W = 400;
+    const H = 400;
+    const baseline = 150;
+    const cellW = fontPx;
+    const logX = 40;
+    // 富 、 士 。 会 — CJK anchors around each punctuation mark.
+    const { data } = renderRuns([{ text: '富、士。会', x: logX, letterSpacing: 0 }], baseline, W, H);
+    const prof = inkProfileY(data, W, H);
+    const offsets: number[] = [];
+    const labels = ['富', '、', '士', '。', '会'];
+    for (let i = 0; i < 5; i++) {
+      const cellCentre = logX + (i + 0.5) * cellW;
+      const c = centroidInWindow(prof, cellCentre, cellW / 2);
+      offsets.push((c - cellCentre) / cellW); // em-fraction, negative = above centre
+    }
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n[SYMPTOM3] along-column offsets (em, −=up): ` +
+        labels.map((l, i) => `${l}=${offsets[i].toFixed(3)}`).join(', ') +
+        `  (PDF: 、≈-0.32, 。 font-dependent)`,
+    );
+    // The comma (index 1) must sit clearly ABOVE the cell centre — the corner design.
+    // Pre-fix it was ≈ −0.02em (at centre). Guard: at least 0.15em up (well past the
+    // pre-fix state), confirming ink-centring no longer flattens the corner offset.
+    expect(offsets[1]).toBeLessThan(-0.15);
+    // CJK ideographs stay ≈ centred (their ink IS centred), unaffected by the fix.
+    for (const i of [0, 2, 4]) expect(Math.abs(offsets[i])).toBeLessThanOrEqual(0.06);
+  });
+
+  it('SYMPTOM 4: ！ stays on the column centreline (cross-axis), not shifted right', () => {
+    // ！ FF01 is drawn upright WITHOUT FE15 substitution, so its ink centres on the
+    // column like the neighbouring CJK cells. PDF ground truth: ！ ≈ +0.03em cross-
+    // axis. The old FE15 substitute pushed it to ≈ +0.30em right.
+    const W = 400;
+    const H = 400;
+    const baseline = 150;
+    const cellW = fontPx;
+    const logX = 40;
+    const centerline = W - baseline;
+    // 話 ！ 話 — CJK anchors on both sides of the exclamation.
+    const { data } = renderRuns([{ text: '話！話', x: logX, letterSpacing: 0 }], baseline, W, H);
+    const cCJK1 = crossAxisCentroid(data, W, logX, logX + cellW);
+    const cExcl = crossAxisCentroid(data, W, logX + cellW, logX + 2 * cellW);
+    const cCJK2 = crossAxisCentroid(data, W, logX + 2 * cellW, logX + 3 * cellW);
+    const cjkMean = (cCJK1 + cCJK2) / 2;
+    const offEm = (cExcl - cjkMean) / cellW;
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n[SYMPTOM4] centerline X=${centerline}\n` +
+        `  話 centroidX=${cCJK1.toFixed(1)}  ！ centroidX=${cExcl.toFixed(1)}  話 centroidX=${cCJK2.toFixed(1)}\n` +
+        `  ！ cross-axis off from CJK centreline = ${(cExcl - cjkMean).toFixed(1)}px (${offEm.toFixed(3)}em)  (PDF: +0.03em)`,
+    );
+    // ！ ink must share the column centreline with the CJK cells (within 0.1em). The
+    // pre-fix FE15 substitute sat ≈ +0.30em right — this guard would fail on it.
+    expect(Math.abs(offEm)).toBeLessThanOrEqual(0.1);
   });
 });


### PR DESCRIPTION
## Summary

Two placement defects in docx vertical (tbRl) text, reported on **sample-26** (the vertical newspaper) after PR #792, both fixed here. The root causes are distinct, so this is split into a core commit and a docx commit.

### Symptom 1 — 、。 sit too low (along-column)
PR #792 introduced an along-column ink-centring step (`inkCenterAboveMiddlePx`) that shifts a substituted upright glyph so its ink lands on the geometric cell centre. That is correct for the Tr bracket forms (︵ ︶ ﹁ ﹂, whose two halves must sit a full cell apart), but **wrong for the Tu comma / full stop** (、。， → FE10–FE12): those glyphs are DESIGNED with their ink in the cell's **upper-right corner** (JIS X 4051 §4.3 kutōten placement, which Word keeps). Force-centring the ink dropped them low.

**Fix (docx):** skip the ink-centring for a substituted Tu punctuation form; draw it em-box-centred so the font's corner design stands. The Tr bracket path is unchanged, so the #792 "日（土）" spacing does not regress.

### Symptom 2 — ！ shifted right (cross-axis)
The vo=Tu vertical-form map substituted ！ FF01 → FE15 and ？ FF1F → FE16. Unlike the corner-hanging 、。, the exclamation / question marks stand **upright and horizontally centred**. The FE15/FE16 forms are corner-designed in many fonts (Hiragino ink at +0.31em cross-axis), so substituting them pushed ！／？ to the right of the column.

**Fix (core):** remove FF01/FF1F from `verticalFormSubstitute`; the original fullwidth ！／？ drawn upright is already the correct, centred vertical shape in every font.

## Verification (all pixel-measured, not eyeballed)

PDF ground truth extracted from `sample-26.pdf` (pdftoppm 300dpi, cell grid anchored on adjacent CJK glyphs):

| glyph | axis | pre-fix | after fix | PDF (Word) |
|-------|------|---------|-----------|------------|
| 、 | along-column | −0.017em (at centre) | **−0.330em** (upper) | −0.323em |
| 。 | along-column | −0.017em | −0.329em | font-dependent |
| ！ | cross-axis | +0.303em (right) | **−0.020em** (centred) | +0.028em |

Non-regression (unchanged from #792):
- `日（土）` bracket gaps: 45.7 / 53.3 / 46.4px (min > 0.8 cell) ✓
- `電話 03-1234-5678` mixed-column centreline: within 0.6px ✓

End-to-end (real renderer + WASM + docGrid, sample-26 rendered at dpr=4): comma along-column −0.355em (upper-right); ！ cross-axis +0.26px (centred). Matches the isolated `drawVerticalRun` probe.

## Tests
- New probe symptoms **SYMPTOM 3** (、。 upper-right) and **SYMPTOM 4** (！ centred) in `docx-vertical-mixed-metrics.probe.test.ts` — both fail on the pre-fix source (stash-verified), pass after.
- New unit tests: Tu comma not ink-centred even with ink metrics; ！／？ drawn upright without substitution; core `verticalFormSubstitute(！/？)` returns null.
- Horizontal path byte-identical: docx demo VRT green (pages 4–6 pixel-identical, 1–3 within standing tolerance, worker-equivalence 0.000%).
- core + docx vitest, tsc, ast-grep green. The existing `docx-vertical-mixed-metrics.probe` still passes.

Refs #771