### PR TITLE
feat(docx): honor pgNumType restart/format in PAGE fields (§17.6.12)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -337,6 +337,10 @@ export {
   type SegStretch,
 } from './text/line-distribute';
 export { justifiedPiecePositions, type JustifiedPiece } from './text/justify-positions';
+// ECMA-376 §17.18.59 ST_NumberFormat rendering + §17.16.4.3.1 field-format switch
+// parsing — the shared numbering kernel (page numbers, list markers, …).
+export { formatOrdinalNumber, type NumberFormat } from './text/number-format';
+export { parseFieldFormatSwitch } from './text/field-format-switch';
 // Format-agnostic index navigation for hidden-item "skip" mode (pptx hidden
 // slides, xlsx hidden sheets): pure math over an isHidden(i) callback.
 export { nextVisibleIndex, resolveVisibleIndex, countVisible } from './nav/visible-index';

--- a/packages/core/src/text/field-format-switch.test.ts
+++ b/packages/core/src/text/field-format-switch.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { parseFieldFormatSwitch } from './field-format-switch';
+
+describe('parseFieldFormatSwitch — ECMA-376 §17.16.4.3.1 general-formatting switch', () => {
+  it('returns null when the instruction carries no \\* switch', () => {
+    expect(parseFieldFormatSwitch('PAGE')).toBeNull();
+    expect(parseFieldFormatSwitch('PAGE \\* MERGEFORMAT')).toBeNull(); // MERGEFORMAT is not a number format
+    expect(parseFieldFormatSwitch('')).toBeNull();
+  });
+
+  it('maps the numeric switch arguments to ST_NumberFormat values (case-sensitive)', () => {
+    // Arabic -> decimal
+    expect(parseFieldFormatSwitch('PAGE \\* Arabic')).toBe('decimal');
+    // Roman (uppercase) vs roman (lowercase) are DISTINCT arguments
+    expect(parseFieldFormatSwitch('PAGE \\* Roman')).toBe('upperRoman');
+    expect(parseFieldFormatSwitch('PAGE \\* roman')).toBe('lowerRoman');
+    // ALPHABETIC vs alphabetic
+    expect(parseFieldFormatSwitch('PAGE \\* ALPHABETIC')).toBe('upperLetter');
+    expect(parseFieldFormatSwitch('PAGE \\* alphabetic')).toBe('lowerLetter');
+  });
+
+  it('ignores a trailing MERGEFORMAT after a real format switch', () => {
+    expect(parseFieldFormatSwitch('PAGE \\* roman \\* MERGEFORMAT')).toBe('lowerRoman');
+    expect(parseFieldFormatSwitch('PAGE \\* MERGEFORMAT \\* Roman')).toBe('upperRoman');
+  });
+
+  it('tolerates extra whitespace and surrounding switches', () => {
+    expect(parseFieldFormatSwitch('  PAGE    \\*    Roman   ')).toBe('upperRoman');
+    expect(parseFieldFormatSwitch('PAGE \\* roman \\# 0')).toBe('lowerRoman');
+  });
+
+  it('returns null for a format argument this converter does not support', () => {
+    // CardText etc. are recognised switches but not numeric-native — the caller
+    // then keeps the section fmt / decimal. We surface null (not decimal) so the
+    // caller can distinguish "no override" from "override to decimal".
+    expect(parseFieldFormatSwitch('PAGE \\* CardText')).toBeNull();
+    expect(parseFieldFormatSwitch('PAGE \\* Ordinal')).toBeNull();
+  });
+});

--- a/packages/core/src/text/field-format-switch.ts
+++ b/packages/core/src/text/field-format-switch.ts
@@ -1,0 +1,50 @@
+// ECMA-376 §17.16.4.3 / §17.16.4.3.1 — the field "general formatting switch"
+// (`\*`). A field instruction may carry `\* <argument>` to format its numeric
+// result: `\* Roman` → uppercase roman, `\* alphabetic` → lowercase letters, etc.
+// This is a PER-FIELD override that takes precedence over a section-level format
+// (e.g. `<w:pgNumType w:fmt>`), because the switch is authored ON the field
+// itself. §17.16.4.3.1 lists every argument and its ST_NumberFormat equivalent;
+// we recognise the NUMERIC, locale-independent subset that `formatOrdinalNumber`
+// (number-format.ts) can render — the same subset the page-number wiring uses.
+//
+// The mapping table below is verbatim from §17.16.4.3.1 ("Corresponds to an
+// ST_NumberFormat enumeration value of …"):
+//   Arabic      → decimal        Roman  → upperRoman   roman     → lowerRoman
+//   ALPHABETIC  → upperLetter    alphabetic → lowerLetter
+// The switch arguments are CASE-SENSITIVE (Roman ≠ roman, ALPHABETIC ≠
+// alphabetic) — §17.16.4.3.1 lists them as distinct rows with different results.
+
+import type { NumberFormat } from './number-format';
+
+// Case-sensitive switch-argument → ST_NumberFormat, restricted to the values
+// `formatOrdinalNumber` renders natively. Arguments outside this set (CardText,
+// Ordinal, DBNUM1, Hex, …) intentionally have no entry: `parseFieldFormatSwitch`
+// returns null for them so the caller keeps the section format rather than
+// silently downgrading to decimal.
+const SWITCH_TO_FORMAT: Readonly<Record<string, NumberFormat>> = {
+  Arabic: 'decimal',
+  Roman: 'upperRoman',
+  roman: 'lowerRoman',
+  ALPHABETIC: 'upperLetter',
+  alphabetic: 'lowerLetter',
+};
+
+/**
+ * Parse a field instruction's general-formatting switch (§17.16.4.3.1) into an
+ * ST_NumberFormat, or `null` when the instruction carries no numeric-format
+ * switch this converter supports (no `\*`, or only `\* MERGEFORMAT`, or an
+ * argument outside the native subset). The first supported `\*` argument wins;
+ * unsupported ones (e.g. `MERGEFORMAT`) are skipped so `\* MERGEFORMAT \* Roman`
+ * still resolves to `upperRoman`.
+ */
+export function parseFieldFormatSwitch(instruction: string): NumberFormat | null {
+  // Match every `\* <arg>` occurrence; `<arg>` is a run of non-space chars
+  // (switch arguments are single tokens — MERGEFORMAT, Roman, Arabic, …).
+  const re = /\\\*\s+(\S+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(instruction)) !== null) {
+    const fmt = SWITCH_TO_FORMAT[m[1]];
+    if (fmt) return fmt;
+  }
+  return null;
+}

--- a/packages/core/src/text/number-format.test.ts
+++ b/packages/core/src/text/number-format.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { formatOrdinalNumber, type NumberFormat } from './number-format';
+
+describe('formatOrdinalNumber — ECMA-376 §17.18.59 ST_NumberFormat', () => {
+  describe('decimal (Arabic cardinal)', () => {
+    it('renders positive integers verbatim', () => {
+      expect(formatOrdinalNumber(1, 'decimal')).toBe('1');
+      expect(formatOrdinalNumber(123, 'decimal')).toBe('123');
+      expect(formatOrdinalNumber(0, 'decimal')).toBe('0');
+    });
+    it('keeps the sign for negatives', () => {
+      expect(formatOrdinalNumber(-5, 'decimal')).toBe('-5');
+    });
+  });
+
+  describe('lowerRoman / upperRoman — §17.16.4.3.1 roman / Roman', () => {
+    it('converts standard values (spec example: 123 -> cxxiii / CXXIII)', () => {
+      expect(formatOrdinalNumber(123, 'lowerRoman')).toBe('cxxiii');
+      expect(formatOrdinalNumber(123, 'upperRoman')).toBe('CXXIII');
+    });
+    it('handles the four subtractive pairs', () => {
+      expect(formatOrdinalNumber(4, 'upperRoman')).toBe('IV');
+      expect(formatOrdinalNumber(9, 'upperRoman')).toBe('IX');
+      expect(formatOrdinalNumber(40, 'upperRoman')).toBe('XL');
+      expect(formatOrdinalNumber(90, 'upperRoman')).toBe('XC');
+      expect(formatOrdinalNumber(400, 'upperRoman')).toBe('CD');
+      expect(formatOrdinalNumber(900, 'upperRoman')).toBe('CM');
+    });
+    it('renders 1 and 3999 (max within the classic additive system)', () => {
+      expect(formatOrdinalNumber(1, 'lowerRoman')).toBe('i');
+      expect(formatOrdinalNumber(3999, 'upperRoman')).toBe('MMMCMXCIX');
+    });
+    it('renders values above 3999 with repeated M (no bars/overlines)', () => {
+      // 4000 = MMMM (Word writes four Ms; it does NOT use the vinculum bar form).
+      expect(formatOrdinalNumber(4000, 'upperRoman')).toBe('MMMM');
+      expect(formatOrdinalNumber(4999, 'upperRoman')).toBe('MMMMCMXCIX');
+    });
+    it('falls back to decimal for zero and negatives (roman has no glyph for 0)', () => {
+      expect(formatOrdinalNumber(0, 'lowerRoman')).toBe('0');
+      expect(formatOrdinalNumber(-1, 'upperRoman')).toBe('-1');
+    });
+  });
+
+  describe('lowerLetter / upperLetter — §17.16.4.3.1 alphabetic / ALPHABETIC', () => {
+    it('maps 1..26 to a..z / A..Z', () => {
+      expect(formatOrdinalNumber(1, 'lowerLetter')).toBe('a');
+      expect(formatOrdinalNumber(26, 'lowerLetter')).toBe('z');
+      expect(formatOrdinalNumber(1, 'upperLetter')).toBe('A');
+      expect(formatOrdinalNumber(26, 'upperLetter')).toBe('Z');
+    });
+    it('repeats the same letter beyond 26 (spec: 27 -> aa, 52 -> zz, 54 -> BBB)', () => {
+      expect(formatOrdinalNumber(27, 'lowerLetter')).toBe('aa');
+      expect(formatOrdinalNumber(28, 'lowerLetter')).toBe('bb');
+      expect(formatOrdinalNumber(52, 'lowerLetter')).toBe('zz');
+      expect(formatOrdinalNumber(53, 'lowerLetter')).toBe('aaa');
+      expect(formatOrdinalNumber(54, 'upperLetter')).toBe('BBB');
+    });
+    it('falls back to decimal for zero and negatives (no letter for 0)', () => {
+      expect(formatOrdinalNumber(0, 'upperLetter')).toBe('0');
+      expect(formatOrdinalNumber(-3, 'lowerLetter')).toBe('-3');
+    });
+  });
+
+  describe('unsupported / text formats fall back to decimal', () => {
+    it('renders cardinalText, ordinal, none, etc. as decimal (documented residual)', () => {
+      // Text-based formats (cardinalText, ordinalText, ...) are NOT implemented;
+      // they degrade to Arabic decimal so a page number is never blank.
+      expect(formatOrdinalNumber(5, 'cardinalText' as NumberFormat)).toBe('5');
+      expect(formatOrdinalNumber(5, 'none' as NumberFormat)).toBe('5');
+      expect(formatOrdinalNumber(5, undefined)).toBe('5');
+    });
+  });
+});

--- a/packages/core/src/text/number-format.ts
+++ b/packages/core/src/text/number-format.ts
@@ -1,0 +1,100 @@
+// ECMA-376 §17.18.59 ST_NumberFormat — render an ordinal integer (a list item's
+// index, a page number, …) as the text a consumer displays for that value. This
+// is the SHARED numbering-format kernel for every WordprocessingML surface that
+// carries an ST_NumberFormat: page numbering (§17.6.12 `<w:pgNumType w:fmt>` and
+// the §17.16.4.3.1 field general-formatting switches `\* roman` / `\* ALPHABETIC`
+// / …), list markers (§17.9.17 `<w:numFmt>`), footnote/endnote numbering, etc.
+// Keeping it in `core` means a future list-numbering feature reuses ONE roman /
+// letter converter instead of forking a second copy.
+//
+// SCOPE (this pass): the numeric, locale-independent formats Word's page-number
+// and list surfaces use in practice — `decimal`, `upperRoman`/`lowerRoman`,
+// `upperLetter`/`lowerLetter`. Every OTHER ST_NumberFormat value (the text
+// spell-outs `cardinalText`/`ordinalText`, the CJK / Hebrew / Thai / Hindi
+// counting systems, the enclosed-glyph families, `hex`, `none`, …) is a
+// DOCUMENTED RESIDUAL: it degrades to `decimal` so a page number is never blank.
+// Those are follow-ups; extend the switch below (and the docx page-number wiring)
+// when a fixture needs them.
+
+/** ECMA-376 §17.18.59 ST_NumberFormat — the subset this converter renders
+ *  natively (see module header). Any other string is accepted at the call site
+ *  and falls back to `decimal`. */
+export type NumberFormat =
+  | 'decimal'
+  | 'upperRoman'
+  | 'lowerRoman'
+  | 'upperLetter'
+  | 'lowerLetter'
+  // Accepted but rendered as decimal (documented residual) — kept in the type so
+  // callers can pass a raw parsed value without a cast for the common ones.
+  | 'none'
+  | 'cardinalText'
+  | 'ordinalText'
+  | 'ordinal'
+  | (string & {});
+
+// Classic additive roman numerals, greedily consumed high→low. The four
+// subtractive pairs (CM/CD/XC/XL/IX/IV) are inlined so 4/9/40/… render correctly.
+// Values ≥ 4000 have no classical single glyph; Word writes repeated M (no
+// vinculum bar), which the greedy 1000→M step reproduces (4000 → "MMMM").
+const ROMAN_TABLE: ReadonlyArray<readonly [number, string]> = [
+  [1000, 'M'],
+  [900, 'CM'],
+  [500, 'D'],
+  [400, 'CD'],
+  [100, 'C'],
+  [90, 'XC'],
+  [50, 'L'],
+  [40, 'XL'],
+  [10, 'X'],
+  [9, 'IX'],
+  [5, 'V'],
+  [4, 'IV'],
+  [1, 'I'],
+];
+
+/** Uppercase roman numerals for a positive integer. Caller guarantees n ≥ 1. */
+function toUpperRoman(n: number): string {
+  let out = '';
+  let rem = n;
+  for (const [value, glyph] of ROMAN_TABLE) {
+    while (rem >= value) {
+      out += glyph;
+      rem -= value;
+    }
+  }
+  return out;
+}
+
+/** ECMA-376 §17.16.4.3.1 ALPHABETIC/alphabetic (⇔ ST_NumberFormat
+ *  upperLetter/lowerLetter): the value maps into A..Z, and for values > 26 the
+ *  SAME letter is REPEATED once per full 26 subtracted (27 → "aa", 53 → "aaa",
+ *  54 → "BBB"). This is Word's spreadsheet-column-UNLIKE scheme — NOT base-26
+ *  (which would give 27 → "aa" too but 53 → "ba"). Caller guarantees n ≥ 1. */
+function toUpperLetter(n: number): string {
+  const repeats = Math.floor((n - 1) / 26) + 1;
+  const letter = String.fromCharCode(0x41 + ((n - 1) % 26)); // 'A' + index
+  return letter.repeat(repeats);
+}
+
+/**
+ * Render `n` in the ST_NumberFormat `fmt`. Non-native formats — and zero /
+ * negative values under a format that has no glyph for them (roman, letters) —
+ * fall back to Arabic decimal, so the result is never empty. `undefined`/absent
+ * `fmt` is the spec default `decimal`.
+ */
+export function formatOrdinalNumber(n: number, fmt: NumberFormat | undefined): string {
+  switch (fmt) {
+    case 'upperRoman':
+      return n >= 1 ? toUpperRoman(n) : String(n);
+    case 'lowerRoman':
+      return n >= 1 ? toUpperRoman(n).toLowerCase() : String(n);
+    case 'upperLetter':
+      return n >= 1 ? toUpperLetter(n) : String(n);
+    case 'lowerLetter':
+      return n >= 1 ? toUpperLetter(n).toLowerCase() : String(n);
+    case 'decimal':
+    default:
+      return String(n);
+  }
+}

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1369,6 +1369,24 @@ fn read_section_break_type(sect_pr: roxmltree::Node) -> Option<String> {
         .find_map(|n| attr_w(n, "val"))
 }
 
+/// ECMA-376 §17.6.12 `<w:pgNumType>` — parse a section's page-numbering settings.
+/// Returns `None` when the sectPr has no `<w:pgNumType>` OR the element carries
+/// neither `@w:start` nor `@w:fmt` (only chapter attributes, which are out of
+/// scope) — a `None` result means "numbering continues; decimal", identical to an
+/// absent element, so the renderer's per-page counter is unaffected. `@w:start`
+/// is ST_DecimalNumber (signed; Word writes `start="0"`); a non-integer value is
+/// dropped. `@w:fmt` is ST_NumberFormat (§17.18.59), carried verbatim for the TS
+/// `formatOrdinalNumber` kernel to map.
+fn parse_pgnum_type(sect_pr: roxmltree::Node) -> Option<PageNumType> {
+    let pg = child_w(sect_pr, "pgNumType")?;
+    let start = attr_w(pg, "start").and_then(|s| s.trim().parse::<i64>().ok());
+    let fmt = attr_w(pg, "fmt").map(|s| s.trim().to_string());
+    if start.is_none() && fmt.is_none() {
+        return None;
+    }
+    Some(PageNumType { start, fmt })
+}
+
 /// ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` spec defaults for a
 /// section's page geometry: US Letter portrait (612×792 pt), 1" margins (72 pt),
 /// 0.5" header/footer distance (36 pt). This is the ONE place these defaults
@@ -1468,6 +1486,8 @@ fn section_break_element(
         title_page: resolved.title_page,
         // ECMA-376 §17.6.13 / §17.6.11 — this ending section's page geometry.
         geom: section_geom(sect_pr),
+        // ECMA-376 §17.6.12 — this ending section's page-numbering restart/format.
+        page_num_type: parse_pgnum_type(sect_pr),
     }
 }
 
@@ -1728,6 +1748,7 @@ fn parse_section(
         doc_grid_line_pitch: None,
         doc_grid_char_space: None,
         columns: None,
+        page_num_type: None,
     };
 
     let Some(sp) = sect_pr else {
@@ -1805,6 +1826,11 @@ fn parse_section(
     // column leaves `columns` None so the renderer keeps its full-width column
     // (unchanged behavior).
     props.columns = parse_columns(sp);
+
+    // ECMA-376 §17.6.12 w:pgNumType — page-numbering restart (@w:start) + format
+    // (@w:fmt). `None` when absent (numbering continues; decimal). The renderer
+    // resolves the displayed page number per physical page from this.
+    props.page_num_type = parse_pgnum_type(sp);
 
     // Collect header/footer references from THIS sectPr.
     let mut refs = SectionRefs::default();
@@ -11126,6 +11152,48 @@ mod column_tests {
         let (props, _) = parse_section(Some(doc.root_element()), &rel_map);
         let cols = props.columns.expect("columns surfaced on SectionProps");
         assert_eq!(cols.count, 2);
+    }
+
+    /// ECMA-376 §17.6.12 `<w:pgNumType>` — `@w:start` (restart) and `@w:fmt`
+    /// (format) surface on SectionProps.page_num_type so the renderer can compute
+    /// the displayed page number per section. Absent element / chapter-only
+    /// element ⇒ None (numbering continues; decimal).
+    #[test]
+    fn section_props_carries_pgnum_type() {
+        let parse = |sect: &str| {
+            let xml = format!(r#"<w:sectPr xmlns:w="{ns}">{sect}</w:sectPr>"#, ns = W_NS);
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            let rel_map: HashMap<String, String> = HashMap::new();
+            parse_section(Some(doc.root_element()), &rel_map).0
+        };
+        // start only (the common restart case; Word writes start="0" too).
+        let p = parse(r#"<w:pgNumType w:start="25"/>"#)
+            .page_num_type
+            .unwrap();
+        assert_eq!(p.start, Some(25));
+        assert_eq!(p.fmt, None);
+        let p0 = parse(r#"<w:pgNumType w:start="0"/>"#)
+            .page_num_type
+            .unwrap();
+        assert_eq!(p0.start, Some(0));
+        // fmt only (numbering continues, but re-formatted).
+        let pf = parse(r#"<w:pgNumType w:fmt="lowerRoman"/>"#)
+            .page_num_type
+            .unwrap();
+        assert_eq!(pf.start, None);
+        assert_eq!(pf.fmt, Some("lowerRoman".to_string()));
+        // both.
+        let pb = parse(r#"<w:pgNumType w:start="1" w:fmt="upperRoman"/>"#)
+            .page_num_type
+            .unwrap();
+        assert_eq!(pb.start, Some(1));
+        assert_eq!(pb.fmt, Some("upperRoman".to_string()));
+        // absent element ⇒ None.
+        assert!(parse(r#"<w:cols w:num="2"/>"#).page_num_type.is_none());
+        // chapter-only element (start/fmt absent) ⇒ None (out-of-scope attrs).
+        assert!(parse(r#"<w:pgNumType w:chapStyle="1" w:chapSep="colon"/>"#)
+            .page_num_type
+            .is_none());
     }
 
     /// ECMA-376 §17.6.22 — the body (final) section's `<w:type>` start type is

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -179,6 +179,35 @@ pub struct HeaderFooter {
     pub body: Vec<BodyElement>,
 }
 
+/// ECMA-376 §17.6.12 `<w:pgNumType>` — a section's page-numbering settings. Only
+/// the two attributes that affect the DISPLAYED page number are carried:
+///
+/// * `start` (`@w:start`, ST_DecimalNumber) — the page number shown on the FIRST
+///   page of the section. When absent (`None`) numbering continues from the
+///   previous section's highest page number (§17.6.12). Kept as a signed integer
+///   because Word writes `start="0"` (and, in principle, negatives).
+/// * `fmt` (`@w:fmt`, ST_NumberFormat §17.18.59) — the number format for every
+///   page number in the section (decimal / upperRoman / lowerLetter / …). `None`
+///   ⇒ the spec default `decimal`. Carried verbatim; the TS renderer maps it via
+///   the shared `formatOrdinalNumber` kernel.
+///
+/// `chapStyle`/`chapSep` (chapter-prefixed numbering) are intentionally NOT
+/// modeled — out of scope for this pass (they require resolving heading numbering
+/// state); a `<w:pgNumType>` that carries only those is treated as "no start / no
+/// fmt" and numbering continues normally.
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PageNumType {
+    /// `@w:start` — the first page number of the section. `None` ⇒ continue from
+    /// the previous section (§17.6.12).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<i64>,
+    /// `@w:fmt` — ST_NumberFormat (§17.18.59) for this section's page numbers.
+    /// `None` ⇒ decimal (the spec default).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fmt: Option<String>,
+}
+
 /// ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — a section's page
 /// geometry: page size + margins + header/footer distances (all pt, converted
 /// from twips). Carried on a `BodyElement::SectionBreak` (`geom`) so mid-body
@@ -275,6 +304,12 @@ pub struct SectionProps {
     /// content column (unchanged behavior).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub columns: Option<ColumnsSpec>,
+    /// ECMA-376 §17.6.12 `<w:pgNumType>` — the body (final) section's
+    /// page-numbering settings (start / fmt). `None` when the body-level sectPr
+    /// omits `<w:pgNumType>`. The renderer resolves the DISPLAYED page number per
+    /// physical page from this + the per-section `geom.pageNumType`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_num_type: Option<PageNumType>,
 }
 
 /// ECMA-376 §17.6.4 `<w:cols>` — the section's multi-column configuration.
@@ -378,6 +413,16 @@ pub enum BodyElement {
         /// The final (body-level) section's geometry stays on `Document.section`.
         #[serde(skip_serializing_if = "Option::is_none")]
         geom: Option<SectionGeom>,
+        /// ECMA-376 §17.6.12 `<w:pgNumType>` — this ENDING section's page-numbering
+        /// settings (start / fmt). `None` when the sectPr omits `<w:pgNumType>` (or
+        /// carries only chapter attributes) — numbering continues; decimal. Carried
+        /// SEPARATELY from `geom` (not bundled) because a section may inherit its
+        /// page geometry yet still restart / re-format its page numbers; the
+        /// renderer resolves the displayed number per physical page from this + the
+        /// body-level `Document.section.page_num_type`. Mirrors how `columns` /
+        /// `headers` are carried per-terminating-section.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        page_num_type: Option<PageNumType>,
     },
 }
 

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -32,6 +32,9 @@ export type {
   // Per-section page geometry (reachable via the BodyElement sectionBreak arm's
   // `geom` and PaginatedBodyElement's `sectionGeom`, ECMA-376 §17.6.13/§17.6.11).
   SectionGeom,
+  // Per-section page-numbering settings (reachable via SectionProps.pageNumType
+  // and the BodyElement sectionBreak arm's `pageNumType`, ECMA-376 §17.6.12).
+  PageNumType,
   // Multi-column section sub-types (reachable via SectionProps.columns).
   ColumnsSpec,
   ColSpec,

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -34,6 +34,8 @@ import {
   isComplexScriptCodePoint,
   isSymbolFontFamily,
   symbolTextToUnicodeSegments,
+  formatOrdinalNumber,
+  parseFieldFormatSwitch,
 } from '@silurus/ooxml-core';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
 import {
@@ -858,8 +860,25 @@ export function findNearbyFontSize(runs: DocRun[], idx: number): number {
 }
 
 export function resolveFieldText(f: FieldRun, state: RenderState): string {
-  if (f.fieldType === 'page') return String(state.pageIndex + 1);
-  if (f.fieldType === 'numPages') return String(state.totalPages);
+  if (f.fieldType === 'page') {
+    // ECMA-376 §17.16.5.44 PAGE — "the number of the current page". Use the
+    // per-section DISPLAY number (§17.6.12 `w:start` restart), falling back to the
+    // raw physical index for a single-section document without `<w:pgNumType>`.
+    const n = state.displayPageNumber ?? state.pageIndex + 1;
+    // §17.16.4.3.1 — the field's own general-formatting switch (`\* roman`, …)
+    // OVERRIDES the section format (§17.6.12 `w:fmt`); it is authored ON the field.
+    // No switch ⇒ the section format (or decimal for a single-section document).
+    const fmt = parseFieldFormatSwitch(f.instruction) ?? state.pageNumberFormat ?? 'decimal';
+    return formatOrdinalNumber(n, fmt);
+  }
+  // ECMA-376 §17.16.5.42 NUMPAGES — "the number of pages in the current document".
+  // This is the DOCUMENT's physical page count and is NOT affected by §17.6.12
+  // page-number restart (which only shifts the DISPLAYED number). It IS still
+  // subject to the field's own `\*` format switch.
+  if (f.fieldType === 'numPages') {
+    const fmt = parseFieldFormatSwitch(f.instruction) ?? 'decimal';
+    return formatOrdinalNumber(state.totalPages, fmt);
+  }
   return f.fallbackText;
 }
 

--- a/packages/docx/src/page-number-field-render.test.ts
+++ b/packages/docx/src/page-number-field-render.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import { computePages, renderDocumentToCanvas } from './renderer.js';
+import { computePageNumbering } from './page-numbering.js';
+import type {
+  BodyElement, DocParagraph, DocxTextRun, FieldRun, SectionProps, DocxDocumentModel,
+  SectionGeom, PageNumType, PaginatedBodyElement, HeaderFooter,
+} from './types';
+
+// ECMA-376 §17.6.12 `<w:pgNumType>` — end-to-end coverage of per-section page-number
+// RESTART (`w:start`) + FORMAT (`w:fmt`) and the §17.16.4.3.1 field `\*` switch,
+// from the parsed model through pagination (which stamps `sectionPageNumType`) to
+// the PAGE field text a footer paints. Mirrors per-section-page-geometry.test.ts's
+// deterministic stub-canvas approach (glyph advance = charCount × fontPx, line
+// height = fontPx) so pagination is exact and headless.
+
+function makeCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, fillText() {}, strokeText() {}, beginPath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fillRect() {}, drawImage() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    letterSpacing: '0px',
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+// OffscreenCanvas polyfill (paginateWithHeaderFooterReserve builds its measure ctx
+// from `new OffscreenCanvas`, absent in node). Same deterministic stub.
+(globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+  getContext() { return makeCtx(); }
+};
+
+type DocRun = DocParagraph['runs'][number];
+function textRun(text: string, fontSize: number): DocRun {
+  const run: DocxTextRun = {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize, color: null, fontFamily: 'NotInMetrics', isLink: false, background: null,
+    vertAlign: null, hyperlink: null,
+  } as unknown as DocxTextRun;
+  return { type: 'text', ...run } as DocRun;
+}
+function pageFieldRun(instruction = 'PAGE', fontSize = 20): DocRun {
+  const f: FieldRun = {
+    fieldType: 'page', instruction, fallbackText: '?',
+    bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize, color: null, fontFamily: 'NotInMetrics', background: null, vertAlign: null,
+  } as unknown as FieldRun;
+  return { type: 'field', ...f } as DocRun;
+}
+function para(text: string, fontSize = 20): BodyElement {
+  const p: DocParagraph = {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: [textRun(text, fontSize)],
+    defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics', widowControl: false,
+  } as unknown as DocParagraph;
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+function footerWithPageField(instruction = 'PAGE'): HeaderFooter {
+  const p: DocParagraph = {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: [pageFieldRun(instruction, 20)],
+    defaultFontSize: 20, defaultFontFamily: 'NotInMetrics', widowControl: false,
+  } as unknown as DocParagraph;
+  return { body: [{ type: 'paragraph', ...p } as BodyElement] };
+}
+
+const GEOM = (): SectionGeom => ({
+  pageWidth: 200, pageHeight: 140,
+  marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+  headerDistance: 0, footerDistance: 0,
+});
+// content height 100 ⇒ five 20pt lines per page.
+
+/** A 2-section doc: front matter (fmt/start on the mid-body break) + body (final
+ *  section, its pgNumType on doc.section). `bodyLines` per section controls how
+ *  many physical pages each spans. */
+function twoSectionDoc(
+  frontPgNum: PageNumType | null,
+  bodyPgNum: PageNumType | null,
+  frontLines = 6,
+  bodyLines = 6,
+  footerInstr = 'PAGE',
+): DocxDocumentModel {
+  const front: BodyElement[] = [];
+  for (let i = 0; i < frontLines; i++) front.push(para(`F${i}`));
+  const body: BodyElement[] = [];
+  for (let i = 0; i < bodyLines; i++) body.push(para(`B${i}`));
+  const footer = footerWithPageField(footerInstr);
+  const bodySection: SectionProps = {
+    ...GEOM(), titlePage: false, evenAndOddHeaders: false,
+    pageNumType: bodyPgNum,
+  } as unknown as SectionProps;
+  return {
+    section: bodySection,
+    body: [
+      ...front,
+      {
+        type: 'sectionBreak', kind: 'nextPage', geom: GEOM(),
+        headers: { default: null, first: null, even: null },
+        footers: { default: footer, first: null, even: null },
+        titlePage: false,
+        pageNumType: frontPgNum,
+      } as BodyElement,
+      ...body,
+    ],
+    headers: { default: null, first: null, even: null },
+    footers: { default: footer, first: null, even: null },
+    fontFamilyClasses: {},
+  } as unknown as DocxDocumentModel;
+}
+
+describe('page-number restart + format — pagination stamp → computePageNumbering', () => {
+  it('front matter lowerRoman(start=1) + body decimal(restart start=1)', () => {
+    // 6 front lines / 6 body lines, 5 lines per page ⇒ 2 pages each ⇒ 4 physical.
+    const doc = twoSectionDoc(
+      { fmt: 'lowerRoman', start: 1 },
+      { fmt: 'decimal', start: 1 },
+    );
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    expect(pages.length).toBe(4);
+    const nums = computePageNumbering(pages);
+    // §17.6.12: front matter i, ii; body RESTARTS to 1, 2.
+    expect(nums).toEqual([
+      { displayNumber: 1, format: 'lowerRoman' },
+      { displayNumber: 2, format: 'lowerRoman' },
+      { displayNumber: 1, format: 'decimal' },
+      { displayNumber: 2, format: 'decimal' },
+    ]);
+  });
+
+  it('front matter with no pgNumType numbers 1..N in decimal (byte-identical baseline)', () => {
+    const doc = twoSectionDoc(null, null);
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    const nums = computePageNumbering(pages).map((n) => `${n.displayNumber}/${n.format}`);
+    expect(nums).toEqual(['1/decimal', '2/decimal', '3/decimal', '4/decimal']);
+  });
+});
+
+// Recording canvas — captures fillText so we can read the exact PAGE-field string
+// painted in each page's footer.
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; texts: string[] } {
+  let font = '10px serif';
+  const texts: string[] = [];
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string) { texts.push(s); }, strokeText(s: string) { texts.push(s); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, texts };
+}
+
+describe('PAGE field renders the per-section displayed number (footer)', () => {
+  async function footerTexts(doc: DocxDocumentModel, pageIndex: number): Promise<string[]> {
+    const { canvas, texts } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, canvas, pageIndex, { dpr: 1 });
+    return texts;
+  }
+
+  it('paints i, ii, then restarts to 1, 2 across the two sections', async () => {
+    const doc = twoSectionDoc(
+      { fmt: 'lowerRoman', start: 1 },
+      { fmt: 'decimal', start: 1 },
+    );
+    // The footer's PAGE field is the only glyph on each page besides body text; the
+    // roman/decimal string is unique enough to assert via `.includes`.
+    expect(await footerTexts(doc, 0)).toContain('i');
+    expect(await footerTexts(doc, 1)).toContain('ii');
+    expect(await footerTexts(doc, 2)).toContain('1');
+    expect(await footerTexts(doc, 3)).toContain('2');
+  });
+
+  it('start=0 offsets the first page number to 0 (Word writes start="0")', async () => {
+    const doc = twoSectionDoc({ start: 0 }, null, 6, 1);
+    // page 0 shows "0", page 1 shows "1" (decimal — no fmt on the front section).
+    expect(await footerTexts(doc, 0)).toContain('0');
+    expect(await footerTexts(doc, 1)).toContain('1');
+  });
+
+  it('field \\* switch overrides the section fmt (PAGE \\* Roman on a decimal section)', async () => {
+    // Body section decimal; the footer field carries `\* Roman` ⇒ uppercase roman.
+    const doc = twoSectionDoc(null, { fmt: 'decimal', start: 3 }, 1, 1, 'PAGE \\* Roman');
+    // front page 0 = 1 (decimal, no fmt) but its footer also carries \* Roman ⇒ "I".
+    expect(await footerTexts(doc, 0)).toContain('I');
+    // body page 1 restarts to 3; \* Roman ⇒ "III".
+    expect(await footerTexts(doc, 1)).toContain('III');
+  });
+
+  it('single-section document without pgNumType is unchanged (decimal 1..N)', async () => {
+    const footer = footerWithPageField('PAGE');
+    const section: SectionProps = {
+      ...GEOM(), titlePage: false, evenAndOddHeaders: false,
+    } as unknown as SectionProps;
+    const doc = {
+      section,
+      body: [para('A0'), para('A1'), para('A2'), para('A3'), para('A4'), para('A5')],
+      headers: { default: null, first: null, even: null },
+      footers: { default: footer, first: null, even: null },
+      fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    // 6 lines, 5 per page ⇒ 2 pages: footers "1" and "2".
+    expect(await footerTexts(doc, 0)).toContain('1');
+    expect(await footerTexts(doc, 1)).toContain('2');
+  });
+});

--- a/packages/docx/src/page-numbering.test.ts
+++ b/packages/docx/src/page-numbering.test.ts
@@ -94,9 +94,11 @@ describe('computePageNumbering — ECMA-376 §17.6.12', () => {
   });
 
   it('does NOT restart mid-page: a continuous section sharing a page keeps its number', () => {
-    // The paginator puts the continuous section's content on the SAME page as the
-    // preceding section, so the page's FIRST element still belongs to the preceding
-    // section — its stamped start is not observed at a page boundary.
+    // A continuous section starts mid-page, so the SHARED page's FIRST element
+    // still belongs to the preceding section and no restart fires THERE. (If the
+    // continuous section's content then SPILLS to the next page, that page's top
+    // IS owned by it and its start fires at the spillover boundary — see the
+    // module header in page-numbering.ts; this stub models only the shared page.)
     const s1 = {};
     const pages = [
       page(s1, null), // page 1: first element belongs to s1 (even if s2 continues below)
@@ -112,16 +114,22 @@ describe('computePageNumbering — ECMA-376 §17.6.12', () => {
     expect(computePageNumbering(pages).map((n) => n.displayNumber)).toEqual([3, 4, 5]);
   });
 
-  // Non-regression: sample-13's real shape. break[0] is nextPage with start=1
-  // (the FIRST section ⇒ physical page 1, identity), and a later continuous
-  // section carries start=2 but shares a page with the preceding section, so its
-  // restart is never observed at a page boundary. Word's PDF shows sequential
-  // 1,2,3,4,5; the numbering layer must reproduce that (not restart to 2 mid-doc).
-  // Here every physical page's TOP belongs to the first (nextPage) section — the
-  // continuous section's content lands BELOW it on the SAME pages — so all pages
-  // carry the start=1 section's identity and settings.
+  // Non-regression: a SIMPLIFIED sample-13-like shape — one section with start=1
+  // owning every page top. Word's PDF for sample-13 shows sequential 1,2,3,4,5 and
+  // this stub asserts the identity case (start=1 on physical page 1 ⇒ 1..N).
+  //
+  // NOTE — this stub is NOT how real sample-13 paginates. Measured on the real
+  // file, the start=2 continuous section's content SPILLS and owns the top of
+  // physical page 2, where computePageNumbering resets the counter to 2; the
+  // output is sequential only because start=2 coincides with the natural
+  // continuation (1+1). The real-file behaviour is covered end-to-end by
+  // tests/visual/page-number.spec.ts (renders sample-13 and asserts 1..5); this
+  // stub only pins the start=1-identity arithmetic. Whether Word fires a
+  // continuous section's restart at a spillover boundary when start does NOT
+  // coincide is unverified (no distinguishing fixture) — tracked as a follow-up
+  // issue; see the module header in page-numbering.ts.
   it('reproduces sample-13: nextPage start=1 + continuous start=2 stays sequential', () => {
-    const firstSection = {}; // owns every physical page top (start=1)
+    const firstSection = {};
     const num: PageNumType = { start: 1 };
     const pages = [
       page(firstSection, num),
@@ -130,8 +138,7 @@ describe('computePageNumbering — ECMA-376 §17.6.12', () => {
       page(firstSection, num),
       page(firstSection, num),
     ];
-    // start=1 on the first section (physical page 1) is the identity ⇒ 1..5, and
-    // the continuous start=2 never surfaces (not a page-top section).
+    // start=1 fires on physical page 1 (the identity) ⇒ 1..5.
     expect(computePageNumbering(pages).map((n) => n.displayNumber)).toEqual([1, 2, 3, 4, 5]);
   });
 });

--- a/packages/docx/src/page-numbering.test.ts
+++ b/packages/docx/src/page-numbering.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { computePageNumbering } from './page-numbering';
+import type { PaginatedBodyElement, PageNumType } from './types';
+
+// Build one physical page carrying a section identity + its pgNumType. The
+// paginator stamps `sectionHF` (a SINGLE object reference SHARED across all pages
+// of one section — object identity is how a section boundary is detected) and
+// `sectionPageNumType` on each element; the numbering layer reads only those, so a
+// single stub element per page is sufficient. `sectionId` must therefore be the
+// SAME object for every page of the same section (mirroring `currentSectionHF`).
+function page(sectionId: object, pgNum: PageNumType | null): PaginatedBodyElement[] {
+  const el = {
+    type: 'paragraph',
+    // Use `sectionId` itself as the identity object the numbering layer compares.
+    sectionHF: sectionId as unknown,
+    sectionPageNumType: pgNum,
+  } as unknown as PaginatedBodyElement;
+  return [el];
+}
+
+describe('computePageNumbering — ECMA-376 §17.6.12', () => {
+  it('single section without pgNumType numbers 1..N in decimal (unchanged behaviour)', () => {
+    const s = {};
+    const pages = [page(s, null), page(s, null), page(s, null)];
+    expect(computePageNumbering(pages)).toEqual([
+      { displayNumber: 1, format: 'decimal' },
+      { displayNumber: 2, format: 'decimal' },
+      { displayNumber: 3, format: 'decimal' },
+    ]);
+  });
+
+  it('start=1 on the first section is the identity (matches physical numbers)', () => {
+    const s = {};
+    const pages = [page(s, { start: 1 }), page(s, null), page(s, null)];
+    expect(computePageNumbering(pages).map((n) => n.displayNumber)).toEqual([1, 2, 3]);
+  });
+
+  it('start=0 offsets the whole document (physical page 1 shows 0)', () => {
+    const s = {};
+    const pages = [page(s, { start: 0 }), page(s, null), page(s, null)];
+    expect(computePageNumbering(pages).map((n) => n.displayNumber)).toEqual([0, 1, 2]);
+  });
+
+  it('start=25 offsets numbering to begin at 25', () => {
+    const s = {};
+    const pages = [page(s, { start: 25 }), page(s, null)];
+    expect(computePageNumbering(pages).map((n) => n.displayNumber)).toEqual([25, 26]);
+  });
+
+  it('restarts the counter when a NEW section (page break) declares w:start', () => {
+    // Front matter (2 pages, lowerRoman, start=1) then body (restart decimal from 1).
+    // Every page of a section carries that section's pgNumType (the paginator stamps
+    // `currentSectionPageNumType` on EVERY element, not only the section's first).
+    const front = {};
+    const body = {};
+    const frontNum: PageNumType = { start: 1, fmt: 'lowerRoman' };
+    const bodyNum: PageNumType = { start: 1, fmt: 'decimal' };
+    const pages = [
+      page(front, frontNum),
+      page(front, frontNum),
+      page(body, bodyNum),
+      page(body, bodyNum),
+    ];
+    expect(computePageNumbering(pages)).toEqual([
+      { displayNumber: 1, format: 'lowerRoman' },
+      { displayNumber: 2, format: 'lowerRoman' },
+      { displayNumber: 1, format: 'decimal' },
+      { displayNumber: 2, format: 'decimal' },
+    ]);
+  });
+
+  it('a new section WITHOUT w:start continues numbering from the previous section', () => {
+    const s1 = {};
+    const s2 = {};
+    const pages = [page(s1, { start: 5 }), page(s1, null), page(s2, null), page(s2, null)];
+    // 5, 6 in s1; s2 has no start so it continues 7, 8.
+    expect(computePageNumbering(pages).map((n) => n.displayNumber)).toEqual([5, 6, 7, 8]);
+  });
+
+  it('applies each section format independently; absent fmt is decimal (not inherited)', () => {
+    const s1 = {};
+    const s2 = {};
+    const s3 = {};
+    const pages = [
+      page(s1, { fmt: 'lowerRoman' }),
+      page(s2, { start: 1 }), // no fmt ⇒ decimal, not roman
+      page(s3, { fmt: 'upperLetter', start: 1 }),
+    ];
+    expect(computePageNumbering(pages)).toEqual([
+      { displayNumber: 1, format: 'lowerRoman' },
+      { displayNumber: 1, format: 'decimal' },
+      { displayNumber: 1, format: 'upperLetter' },
+    ]);
+  });
+
+  it('does NOT restart mid-page: a continuous section sharing a page keeps its number', () => {
+    // The paginator puts the continuous section's content on the SAME page as the
+    // preceding section, so the page's FIRST element still belongs to the preceding
+    // section — its stamped start is not observed at a page boundary.
+    const s1 = {};
+    const pages = [
+      page(s1, null), // page 1: first element belongs to s1 (even if s2 continues below)
+      page(s1, null),
+    ];
+    expect(computePageNumbering(pages).map((n) => n.displayNumber)).toEqual([1, 2]);
+  });
+
+  it('handles an empty page (no stamped element) as a decimal continuation', () => {
+    const s = {};
+    const pages = [page(s, { start: 3 }), [] as PaginatedBodyElement[], page(s, null)];
+    // page 2 empty ⇒ continues 4; page 3 continues 5.
+    expect(computePageNumbering(pages).map((n) => n.displayNumber)).toEqual([3, 4, 5]);
+  });
+
+  // Non-regression: sample-13's real shape. break[0] is nextPage with start=1
+  // (the FIRST section ⇒ physical page 1, identity), and a later continuous
+  // section carries start=2 but shares a page with the preceding section, so its
+  // restart is never observed at a page boundary. Word's PDF shows sequential
+  // 1,2,3,4,5; the numbering layer must reproduce that (not restart to 2 mid-doc).
+  // Here every physical page's TOP belongs to the first (nextPage) section — the
+  // continuous section's content lands BELOW it on the SAME pages — so all pages
+  // carry the start=1 section's identity and settings.
+  it('reproduces sample-13: nextPage start=1 + continuous start=2 stays sequential', () => {
+    const firstSection = {}; // owns every physical page top (start=1)
+    const num: PageNumType = { start: 1 };
+    const pages = [
+      page(firstSection, num),
+      page(firstSection, num),
+      page(firstSection, num),
+      page(firstSection, num),
+      page(firstSection, num),
+    ];
+    // start=1 on the first section (physical page 1) is the identity ⇒ 1..5, and
+    // the continuous start=2 never surfaces (not a page-top section).
+    expect(computePageNumbering(pages).map((n) => n.displayNumber)).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/packages/docx/src/page-numbering.ts
+++ b/packages/docx/src/page-numbering.ts
@@ -20,12 +20,20 @@
 //     continuation clause, so each section's format is independent (absent ⇒
 //     decimal, NOT inherited from the previous section).
 //
-// A CONTINUOUS section break does not open a new physical page, so a continuous
-// section that declares `w:start` does not restart the number of the page it
-// SHARES with the preceding section — its content is not the FIRST element of a
-// new page, so we never observe its restart at a page boundary. This matches Word
-// (and preserves sample-13, whose `start="2"` continuous section shows no visible
-// restart because it never starts a fresh page).
+// A CONTINUOUS section break does not open a new physical page, so on the page it
+// SHARES with the preceding section the restart is not observed (that page's top
+// is still owned by the preceding section). The section-identity switch happens
+// MID-PAGE, however, and persists: when the continuous section's content SPILLS
+// onto the next physical page, THAT page's top is owned by the continuous section
+// and its `w:start` fires there — a mid-document restart at the spillover
+// boundary (probe: continuous start=50 spilling ⇒ display numbers [1, 50, 51]).
+// This is exactly what happens in real sample-13: its `start="2"` continuous
+// section owns the top of physical page 2, where the counter resets to 2 — the
+// output LOOKS sequential only because 2 coincides with the natural continuation
+// (1+1). Whether Word also fires a continuous section's restart at a spillover
+// boundary is UNVERIFIED — no distinguishing fixture exists (every real sample's
+// continuous `w:start` equals the natural continuation value); tracked as a
+// follow-up issue.
 
 import type { PaginatedBodyElement, PageNumType } from './types';
 import type { NumberFormat } from '@silurus/ooxml-core';

--- a/packages/docx/src/page-numbering.ts
+++ b/packages/docx/src/page-numbering.ts
@@ -1,0 +1,87 @@
+// ECMA-376 §17.6.12 `<w:pgNumType>` — resolve the DISPLAYED page number (and its
+// number format) for every PHYSICAL page, honoring per-section restart (`w:start`)
+// and re-formatting (`w:fmt`). This is the layer that separates the "physical page
+// index" (0..N-1, produced by the paginator) from the number a PAGE field shows.
+//
+// The paginator stamps each element with `sectionPageNumType` — the page-numbering
+// settings of the section that element belongs to (from the upcoming
+// `SectionBreak.pageNumType`, or the body-level `section.pageNumType`). We read the
+// FIRST element of each physical page to learn which section OWNS the top of that
+// page and whether that section carries a restart.
+//
+// ── §17.6.12 semantics ──────────────────────────────────────────────────────
+//   • `start` — "the page number that appears on the first page of the section."
+//     So when a NEW section begins at the top of a physical page and that section
+//     declares `w:start`, the running counter RESETS to `start` on that page.
+//     "If this value is omitted, numbering continues from the highest page number
+//     in the previous section" — i.e. keep incrementing.
+//   • `fmt` — "the number format that shall be used for all page numbering in this
+//     section." Absent ⇒ decimal (the default). Unlike `start`, `fmt` has no
+//     continuation clause, so each section's format is independent (absent ⇒
+//     decimal, NOT inherited from the previous section).
+//
+// A CONTINUOUS section break does not open a new physical page, so a continuous
+// section that declares `w:start` does not restart the number of the page it
+// SHARES with the preceding section — its content is not the FIRST element of a
+// new page, so we never observe its restart at a page boundary. This matches Word
+// (and preserves sample-13, whose `start="2"` continuous section shows no visible
+// restart because it never starts a fresh page).
+
+import type { PaginatedBodyElement, PageNumType } from './types';
+import type { NumberFormat } from '@silurus/ooxml-core';
+
+/** The displayed page number + its format for one physical page. */
+export interface PageNumber {
+  /** The number a PAGE field shows on this page (after §17.6.12 restart). */
+  displayNumber: number;
+  /** The ST_NumberFormat the section governing this page's TOP declares (§17.18.59);
+   *  `decimal` when the section omits `w:fmt`. A PAGE field may still override this
+   *  with its own `\*` switch (that is applied at field-resolution time, not here). */
+  format: NumberFormat;
+}
+
+/** The page-numbering settings governing the TOP of physical page `pageIndex`,
+ *  read from the first stamped element (the section that owns the page start).
+ *  `null` when the page is empty or the section carries no `<w:pgNumType>`. */
+function pageTopSettings(page: PaginatedBodyElement[] | undefined): PageNumType | null {
+  return page?.[0]?.sectionPageNumType ?? null;
+}
+
+/** Identity of the section owning a page's top, used to detect a NEW section at a
+ *  page boundary. We reuse the same `sectionHF` object identity the paginator
+ *  stamps (a fresh object per section in the pagination pass), mirroring
+ *  `resolvePageSection`'s `isFirstPageOfSection` test. */
+function pageTopSectionId(page: PaginatedBodyElement[] | undefined): unknown {
+  return page?.[0]?.sectionHF;
+}
+
+/**
+ * Compute the displayed page number + format for every physical page.
+ *
+ * @param pages the paginated body (one array of stamped elements per physical page)
+ * @returns a per-physical-page array of {@link PageNumber}
+ */
+export function computePageNumbering(pages: PaginatedBodyElement[][]): PageNumber[] {
+  const out: PageNumber[] = [];
+  let counter = 0; // the previous page's display number (0 before the first page)
+  for (let p = 0; p < pages.length; p++) {
+    const settings = pageTopSettings(pages[p]);
+    const fmt = (settings?.fmt ?? 'decimal') as NumberFormat;
+
+    // A page starts a NEW section when its owning section differs from the
+    // previous page's (or it is the very first page). Only a NEW section may
+    // restart the counter — a section continuing across a page break keeps
+    // incrementing.
+    const startsNewSection = p === 0 || pageTopSectionId(pages[p]) !== pageTopSectionId(pages[p - 1]);
+
+    if (startsNewSection && settings?.start != null) {
+      // §17.6.12 `w:start` — the number shown on the first page of the section.
+      counter = settings.start;
+    } else {
+      // §17.6.12 — otherwise numbering continues from the previous page.
+      counter = counter + 1;
+    }
+    out.push({ displayNumber: counter, format: fmt });
+  }
+  return out;
+}

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,7 +1,7 @@
 import type {
   DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
   DocRun, DocxTextRun, ImageRun, ChartRun, ShapeRun, ShapeText, ShapeTextRun, FieldRun, HeaderFooter, HeadersFooters, LineSpacing, BorderSpec, TableBorders, CellBorders,
-  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, SectionGeom, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr, DocSettings,
+  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, SectionGeom, PageNumType, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr, DocSettings,
 } from './types';
 import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
 import {
@@ -50,7 +50,8 @@ import {
   drawUnderline,
   renderChart,
 } from '@silurus/ooxml-core';
-import type { MathNode, MathRenderer, KinsokuRules, HyperlinkTarget } from '@silurus/ooxml-core';
+import type { MathNode, MathRenderer, KinsokuRules, HyperlinkTarget, NumberFormat } from '@silurus/ooxml-core';
+import { computePageNumbering } from './page-numbering.js';
 import { docxUnderlineToDrawingML } from './underline-map.js';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
 import {
@@ -232,6 +233,15 @@ export interface RenderState {
   pageIndex: number;
   /** total page count in the document */
   totalPages: number;
+  /** ECMA-376 §17.6.12 — the DISPLAYED page number for the current page (after
+   *  per-section `w:start` restart). A PAGE field renders this instead of the raw
+   *  `pageIndex + 1`. Absent ⇒ `pageIndex + 1` (single-section fallback). */
+  displayPageNumber?: number;
+  /** ECMA-376 §17.6.12 / §17.18.59 — the ST_NumberFormat governing the current
+   *  page's number (from the page's section `w:fmt`). A PAGE field formats its
+   *  result with this unless it carries its own `\*` switch (§17.16.4.3.1). Absent
+   *  ⇒ decimal. */
+  pageNumberFormat?: NumberFormat;
   /** preloaded drawable images keyed by `imageKey(imagePath, colorReplaceFrom)`
    *  (raster ImageBitmap or, for an `asvg:svgBlip` vector original, an
    *  HTMLImageElement) */
@@ -976,6 +986,14 @@ export async function renderDocumentToCanvas(
   const totalPages = Math.max(opts.totalPages ?? pages.length, pages.length);
   const elements = pages[pageIndex] ?? pages[0] ?? [];
 
+  // ECMA-376 §17.6.12 — the DISPLAYED page number + format for every physical page,
+  // honoring per-section `w:start` restart / `w:fmt`. Computed over ALL pages (the
+  // restart counter walks page order) and indexed by this `pageIndex`. For a
+  // single-section document with no `<w:pgNumType>` every page resolves to
+  // { displayNumber: pageIndex+1, format: 'decimal' } — the pre-feature behaviour.
+  const pageNumbering = computePageNumbering(pages);
+  const thisPageNumber = pageNumbering[pageIndex] ?? { displayNumber: pageIndex + 1, format: 'decimal' as NumberFormat };
+
   // ECMA-376 §17.6.13 / §17.6.11 — page geometry is PER-SECTION. Size THIS page from
   // the section active at its top (resolvePageSection.geom, stamped by the paginator),
   // NOT from the single body-level `doc.section`. `sec` merges the resolved geometry
@@ -1094,6 +1112,10 @@ export async function renderDocumentToCanvas(
     defaultColor: opts.defaultTextColor ?? '#000000',
     pageIndex,
     totalPages,
+    // ECMA-376 §17.6.12 — the current page's displayed number + format (per-section
+    // restart / fmt), consumed by a PAGE field in the body, header, or footer.
+    displayPageNumber: thisPageNumber.displayNumber,
+    pageNumberFormat: thisPageNumber.format,
     images,
     dryRun: false,
     marginLeft: sec.marginLeft,
@@ -1693,6 +1715,22 @@ export function computePages(
     return bodySectionGeom;
   };
 
+  // ECMA-376 §17.6.12 `<w:pgNumType>` — the page-numbering settings (start / fmt)
+  // of the section that OWNS the content starting at body index `startIdx`.
+  // Mirrors `sectionGeomFrom`: carried on the NEXT `SectionBreak` marker at/after
+  // `startIdx` (the marker ENDS that section); if there is none, the content
+  // belongs to the FINAL (body-level) section whose settings live on
+  // `section.pageNumType`. `null` ⇒ no restart / decimal (numbering continues).
+  // Stamped on each element so `computePageNumbering` can resolve each physical
+  // page's owning section's numbering without re-deriving the body→page mapping.
+  const sectionPageNumTypeFrom = (startIdx: number): PageNumType | null => {
+    for (let j = startIdx; j < body.length; j++) {
+      const e = body[j];
+      if (e.type === 'sectionBreak') return e.pageNumType ?? null;
+    }
+    return section.pageNumType ?? null;
+  };
+
   // The active section's column geometry. Reassigned (a) here for the first
   // section and (b) at every `SectionBreak` as the flow enters the next section.
   // `colIndex` tracks which column we are filling; `colX()`/`colW()` give its
@@ -1715,6 +1753,11 @@ export function computePages(
   // Stamped on each element so the renderer sizes each page from its own section.
   // For a single-section document this stays the body-level geometry throughout.
   let currentSectionGeom = sectionGeomFrom(0);
+  // ECMA-376 §17.6.12 — the active section's page-numbering settings, tracked in
+  // lockstep with `currentSectionGeom` (reassigned at every SectionBreak). Stamped
+  // on each element so `computePageNumbering` resolves each physical page's owning
+  // section's restart/format. `null` for a section with no `<w:pgNumType>`.
+  let currentSectionPageNumType = sectionPageNumTypeFrom(0);
   // ECMA-376 §17.6.4 / §17.18.79 — the CURRENT multi-column region's vertical
   // extent on the current page, in content-relative pt (0 = page content top,
   // i.e. the same frame as `y`). A region tiled into N newspaper columns is a
@@ -2029,6 +2072,7 @@ export function computePages(
     el.colTopPt = colTopAbsPt();
     el.sectionHF = currentSectionHF;
     el.sectionGeom = currentSectionGeom;
+    el.sectionPageNumType = currentSectionPageNumType;
     pages[pages.length - 1].push(el);
   };
 
@@ -2089,6 +2133,8 @@ export function computePages(
       currentSectionHF = sectionHFFrom(i + 1);
       // ECMA-376 §17.6.13 / §17.6.11 — and its page geometry (size + margins).
       currentSectionGeom = sectionGeomFrom(i + 1);
+      // ECMA-376 §17.6.12 — and its page-numbering settings (start / fmt).
+      currentSectionPageNumType = sectionPageNumTypeFrom(i + 1);
       // The break is governed by the UPCOMING section's start type (§17.6.22),
       // not this marker's own kind (the section it closes). See sectionKindFrom.
       // The sample-5 cover overprint that prompted the 0.66.1 hotfix is now fixed
@@ -2472,6 +2518,7 @@ export function computePages(
           columnBottomLimit,
           () => currentSectionHF,
           () => currentSectionGeom,
+          () => currentSectionPageNumType,
         );
         // After splitting, `y` is the bottom of the last slice in the
         // current column (continues for the LAST slice; intermediate slices
@@ -2674,6 +2721,7 @@ export function computePages(
           bodyTopPt(),
           () => currentSectionHF,
           () => currentSectionGeom,
+          () => currentSectionPageNumType,
           // B2 table stage 1b — stamp the scale-1 layout onto each slice so the
           // paint pass reuses it. Each slice records ITS rows' heights; the column
           // widths + contentWPt are constant across the split.
@@ -3205,6 +3253,11 @@ function splitParagraphAcrossPages(
    *  all slices; stamped so the renderer sizes each page from the right section.
    *  Omitted ⇒ the renderer's body-level fallback. */
   tagSectionGeom?: () => SectionGeom,
+  /** ECMA-376 §17.6.12 — the active SECTION's page-numbering settings (start /
+   *  fmt). Constant across a paragraph's slices; stamped so `computePageNumbering`
+   *  sees the section's restart/format on EVERY physical page a spilled paragraph
+   *  lands on (not only the section's first page). Omitted ⇒ `null` (continue). */
+  tagSectionPageNumType?: () => PageNumType | null,
 ): { endY: number } {
   const colTop = columnTop ?? (() => 0);
   const colBot = columnBottom ?? (() => contentH);
@@ -3229,6 +3282,7 @@ function splitParagraphAcrossPages(
     }
     if (tagSectionHF) el.sectionHF = tagSectionHF();
     if (tagSectionGeom) el.sectionGeom = tagSectionGeom();
+    if (tagSectionPageNumType) el.sectionPageNumType = tagSectionPageNumType();
     return el;
   };
   const indLeft = para.indentLeft;
@@ -3795,6 +3849,10 @@ export function splitTableAcrossPages(
    *  margins; constant across the split). Stamped so the renderer sizes each page
    *  from the right section. Omitted ⇒ the renderer's body-level fallback. */
   tagSectionGeom?: () => SectionGeom,
+  /** ECMA-376 §17.6.12 — the active SECTION's page-numbering settings (constant
+   *  across the split). Stamped so `computePageNumbering` sees the section's
+   *  restart/format on every page a spilled table lands on. Omitted ⇒ `null`. */
+  tagSectionPageNumType?: () => PageNumType | null,
   /** B2 table stage 1b — the scale-1 layout to stamp onto each slice for paint
    *  reuse. `colWidthsPt` is the full grid (constant across the split); each slice
    *  gets ITS rows' heights (sliced from `rowHs`, with the repeated header rows
@@ -3838,6 +3896,7 @@ export function splitTableAcrossPages(
     if (columnTop && marginTopPt != null) sliceEl.colTopPt = marginTopPt + colTop();
     if (tagSectionHF) sliceEl.sectionHF = tagSectionHF();
     if (tagSectionGeom) sliceEl.sectionGeom = tagSectionGeom();
+    if (tagSectionPageNumType) sliceEl.sectionPageNumType = tagSectionPageNumType();
     // B2 table stage 1b — stamp this slice's own row heights (repeated header rows
     // prepended on continuations, matching `sliceRows`) so the paint pass reuses
     // them 1:1 instead of re-measuring the slice.

--- a/packages/docx/src/table-layout-reuse.test.ts
+++ b/packages/docx/src/table-layout-reuse.test.ts
@@ -154,7 +154,7 @@ describe('splitTableAcrossPages — table stamp (B2 table stage 1b)', () => {
     // then 50, then 60 — one row per later page (each > 65-startY residual).
     splitTableAcrossPages(
       t, rowHs, 0, 65, pages, newPage,
-      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined, undefined,
       { colWidthsPt, contentWPt: 500 },
     );
 
@@ -187,7 +187,7 @@ describe('splitTableAcrossPages — table stamp (B2 table stage 1b)', () => {
     // header(15) + as many body as fit in 60-15=45 ⇒ 2 body (40).
     splitTableAcrossPages(
       t, rowHs, 0, 60, pages, newPage,
-      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined, undefined,
       { colWidthsPt: [200, 300], contentWPt: 500 },
     );
     const slices = pages.map((p) => p[0]).filter(Boolean);

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -138,6 +138,22 @@ export interface HeaderFooter {
   body: BodyElement[];
 }
 
+/** ECMA-376 §17.6.12 `<w:pgNumType>` — a section's page-numbering settings.
+ *  Mirrors the Rust `PageNumType`. Only the two attributes that change the
+ *  DISPLAYED page number are carried:
+ *  - `start` — the number shown on the FIRST page of the section (§17.6.12);
+ *    absent ⇒ numbering continues from the previous section's highest number.
+ *    Kept as a possibly-zero / possibly-negative integer (Word writes `start="0"`).
+ *  - `fmt` — the ST_NumberFormat (§17.18.59) for the section's page numbers
+ *    (decimal / upperRoman / lowerLetter / …); absent ⇒ decimal.
+ *  `chapStyle`/`chapSep` (chapter-prefixed numbering) are out of scope for this
+ *  pass and never surfaced. Field names match the Rust `PageNumType` serialization
+ *  (`start`, `fmt`). */
+export interface PageNumType {
+  start?: number;
+  fmt?: string;
+}
+
 /** ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — a section's page
  *  geometry: page size + margins + header/footer distances (pt). Mirrors the Rust
  *  `SectionGeom`. Carried on a {@link BodyElement} `sectionBreak` arm (`geom`) so a
@@ -216,6 +232,11 @@ export interface SectionProps {
    *  body text flows top-to-bottom through `count` columns (newspaper fill);
    *  see {@link computeColumns}. */
   columns?: ColumnsSpec | null;
+  /** ECMA-376 §17.6.12 `<w:pgNumType>` — the body (final) section's page-numbering
+   *  settings (start / fmt). `null`/absent ⇒ numbering continues; decimal. The
+   *  renderer resolves the displayed page number per physical page from this plus
+   *  the per-section `SectionBreak.pageNumType` markers. */
+  pageNumType?: PageNumType | null;
 }
 
 /** ECMA-376 §17.6.4 `<w:cols>` — the section's multi-column configuration. */
@@ -284,6 +305,11 @@ export type BodyElement =
        *  (size + margins). Absent when the sectPr inherits both pgSz and pgMar
        *  (the renderer then falls back to the body-level section geometry). */
       geom?: SectionGeom;
+      /** ECMA-376 §17.6.12 `<w:pgNumType>` — this ENDING section's page-numbering
+       *  settings (start / fmt). Absent ⇒ numbering continues; decimal. Carried
+       *  separately from `geom` because a section may inherit its geometry yet
+       *  still restart / re-format its page numbers. */
+      pageNumType?: PageNumType | null;
     };
 
 /** A BodyElement annotated with a line range to render. Set when the
@@ -355,6 +381,13 @@ export type PaginatedBodyElement = BodyElement & {
    *  the renderer uses the body-level `doc.section` geometry (single-section docs are
    *  unaffected). Runtime-only — never emitted by the parser. */
   sectionGeom?: SectionGeom;
+  /** ECMA-376 §17.6.12 `<w:pgNumType>` — the page-numbering settings (start / fmt)
+   *  of the SECTION this element belongs to. Stamped by the paginator (from the
+   *  upcoming `SectionBreak`'s `pageNumType`, or the body-level section) so
+   *  `computePageNumbering` resolves each physical page's DISPLAYED number and
+   *  format. `null` ⇒ the section has no `<w:pgNumType>` (numbering continues;
+   *  decimal). Runtime-only — never emitted by the parser. */
+  sectionPageNumType?: PageNumType | null;
   /** B2 table stage 1b — compute-once table layout. When this element is a table
    *  (`type === 'table'`), the paginator stamps the per-grid-column widths (pt) it
    *  resolved via {@link resolveColumnWidths}. The paint pass ({@link computeTableLayout})

--- a/packages/docx/tests/visual/page-number.spec.ts
+++ b/packages/docx/tests/visual/page-number.spec.ts
@@ -5,10 +5,15 @@ import { existsSync } from 'node:fs';
 // carry `<w:pgNumType>` (sample-12: continuous start=1; sample-13: nextPage start=1
 // + a continuous start=2; sample-14: nextPage start=1) plus a footer PAGE field.
 // Word's PDF ground truth (measured with pdftotext) shows SEQUENTIAL footer numbers
-// — none of these restarts is visible because start=1 on the first section is the
-// identity and the continuous restarts share a page (never a page-top section). So
-// the DISPLAYED footer number must equal the physical page number, unchanged from
-// before this feature. Skips gracefully when the (gitignored) sample is absent.
+// — none of these restarts is VISIBLE because every start value coincides with the
+// natural continuation at the page where it fires: start=1 on the first section is
+// the identity, and sample-13's continuous start=2 section spills onto physical
+// page 2, where its restart fires but 2 equals the natural continuation (1+1)
+// anyway. (A continuous restart is thus observed at a spillover page top, not
+// suppressed — see page-numbering.ts; whether Word matches at a NON-coinciding
+// spillover start is unverified, tracked as a follow-up issue.) So the DISPLAYED
+// footer number must equal the physical page number, unchanged from before this
+// feature. Skips gracefully when the (gitignored) sample is absent.
 // sample-12 (continuous start=1, footer PAGE) and sample-13 (nextPage start=1 +
 // continuous start=2, footer PAGE) both isolate the footer number cleanly at the
 // page bottom, so their sequential numbering is a direct non-regression check.

--- a/packages/docx/tests/visual/page-number.spec.ts
+++ b/packages/docx/tests/visual/page-number.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+
+// ECMA-376 §17.6.12 non-regression on REAL private samples. sample-12/13/14 all
+// carry `<w:pgNumType>` (sample-12: continuous start=1; sample-13: nextPage start=1
+// + a continuous start=2; sample-14: nextPage start=1) plus a footer PAGE field.
+// Word's PDF ground truth (measured with pdftotext) shows SEQUENTIAL footer numbers
+// — none of these restarts is visible because start=1 on the first section is the
+// identity and the continuous restarts share a page (never a page-top section). So
+// the DISPLAYED footer number must equal the physical page number, unchanged from
+// before this feature. Skips gracefully when the (gitignored) sample is absent.
+// sample-12 (continuous start=1, footer PAGE) and sample-13 (nextPage start=1 +
+// continuous start=2, footer PAGE) both isolate the footer number cleanly at the
+// page bottom, so their sequential numbering is a direct non-regression check.
+// (sample-14 also carries pgNumType but its footer shares the bottom band with
+// other numeric content, so the position heuristic can't isolate it; its structure
+// — nextPage start=1 on the first section — is identical to sample-13's break[0]
+// and is covered deterministically by page-numbering.test.ts.)
+const CASES: { file: string; pageCount: number; width: number; expected: string[] }[] = [
+  { file: 'private/sample-12', pageCount: 4, width: 595, expected: ['1', '2', '3', '4'] },
+  { file: 'private/sample-13', pageCount: 6, width: 595, expected: ['1', '2', '3', '4', '5'] },
+];
+
+test.describe('page-number restart non-regression (§17.6.12)', () => {
+  for (const { file, pageCount, width, expected } of CASES) {
+    test(`${file}: footer PAGE numbers stay sequential`, async ({ page }) => {
+      if (!existsSync(`${process.cwd()}/public/${file}.docx`)) {
+        test.skip(true, `gitignored sample ${file}.docx not present`);
+      }
+      // Load a page in the Vite module graph first so a dynamic `import('/src/...')`
+      // inside page.evaluate resolves against the dev server (the fixture imports it).
+      await page.goto(`/tests/visual/fixture.html?file=demo/sample-1.docx&page=0&width=595`);
+      await page.waitForFunction(
+        () => document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
+        { timeout: 30_000 },
+      );
+      // Render each page and collect the bottom-most SHORT text run (the footer
+      // page number). A footer number is a 1–3 char numeric/roman/letter token near
+      // the page bottom, so we take the lowest run whose text is <= 4 chars.
+      const numbers = await page.evaluate(
+        async ({ file, pageCount, width }) => {
+          const { DocxDocument } = await import('/src/index.ts');
+          const doc = await DocxDocument.load('/' + file + '.docx');
+          const out: (string | null)[] = [];
+          for (let i = 0; i < pageCount; i++) {
+            const canvas = document.createElement('canvas');
+            const runs: { text: string; y: number }[] = [];
+            await doc.renderPage(canvas, i, {
+              width, dpr: 1,
+              onTextRun: (r: { text: string; y: number }) => runs.push({ text: r.text, y: r.y }),
+            });
+            // Footer page number = the lowest-on-page run whose trimmed text is a
+            // pure page-number token (Arabic digits, or roman/letter glyphs). This
+            // excludes footnote/dagger marks (†) and body text. Prefer the bottom-most.
+            const isPageToken = (t: string) => /^[0-9]{1,4}$/.test(t) || /^[ivxlcdmIVXLCDM]{1,4}$/.test(t) || /^[a-zA-Z]{1,3}$/.test(t);
+            const tokens = runs
+              .map((r) => ({ text: r.text.trim(), y: r.y }))
+              .filter((r) => isPageToken(r.text))
+              .sort((a, b) => b.y - a.y);
+            out.push(tokens.length ? tokens[0].text : null);
+          }
+          return out;
+        },
+        { file, pageCount, width },
+      );
+      // The first `expected.length` pages carry a footer; assert those.
+      for (let i = 0; i < expected.length; i++) {
+        expect(numbers[i], `${file} page ${i + 1} footer number`).toBe(expected[i]);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Implements **WD2**: the docx PAGE field previously ignored `<w:pgNumType>` (§17.6.12 restart/format) and the field number-format switches, so page numbers were wrong in documents with front matter or explicit start offsets. This wires per-section page-number **restart** (`w:start`) and **format** (`w:fmt`) into PAGE fields (body, header, and footer), plus the `\*` general-formatting switch (§17.16.4.3.1).

## Spec basis

- **§17.6.12 `<w:pgNumType>`** — `w:start` = the number shown on the section's first page (absent ⇒ numbering continues from the previous section); `w:fmt` = the section's ST_NumberFormat (absent ⇒ decimal).
- **§17.18.59 ST_NumberFormat** — decimal / upperRoman / lowerRoman / upperLetter / lowerLetter rendered natively; text/CJK/enclosed formats degrade to decimal (documented residual).
- **§17.16.4.3.1** — the field `\*` switch (`Arabic`/`Roman`/`roman`/`ALPHABETIC`/`alphabetic`) overrides the section fmt; letters use the repeated-letter scheme (54 → `BBB`), NOT base-26.
- **§17.16.5.44 PAGE** — displays the current (restart-aware) page number. **§17.16.5.42 NUMPAGES** — stays the document's physical page count (unaffected by §17.6.12), still honoring its own `\*` switch.

## Design

- **Parser (Rust):** `<w:pgNumType>` → `PageNumType { start, fmt }`, surfaced on `SectionProps.page_num_type` (final section) and the `SectionBreak` marker (mid-body), carried separately from `geom` (a section may inherit geometry yet restart numbering). `chapStyle`/`chapSep` out of scope.
- **Shared kernel (core):** pure `formatOrdinalNumber` + `parseFieldFormatSwitch` in `core/text`, so a future list-numbering feature reuses one roman/letter converter.
- **Page numbering (docx):** `computePageNumbering(pages)` — a pure pass over physical pages applying §17.6.12 restart: a section's `w:start` fires on the first physical page whose TOP that section owns. The paginator stamps each element's `sectionPageNumType` (lockstep with `sectionGeom`/`sectionHF`, including paragraph/table split continuation paths). `resolveFieldText` renders PAGE with the per-page display number + format, switch overriding fmt.
- **Continuous-break mechanism:** a continuous break switches the section identity MID-PAGE, so no restart fires on the SHARED page — but when the continuous section's content spills onto the next physical page, that page's top is owned by it and its `w:start` fires there (probe: continuous start=50 spilling ⇒ display numbers [1, 50, 51]). This is what actually happens in real sample-13: its continuous start=2 section owns physical page 2's top and the counter resets to 2, which coincides with the natural continuation (1+1), so the output looks sequential. Whether Word also fires a continuous section's restart at a spillover boundary when start does NOT coincide with the natural continuation is unverified — no distinguishing fixture exists (every real sample's continuous `w:start` equals the natural continuation) — tracked as a follow-up issue.

## Verification

- Rust: `parse_pgnum_type` unit test (start/fmt/both/absent/chapter-only); all 246 parser tests pass; fmt+clippy clean.
- TS: `number-format` / `field-format-switch` (16 tests, boundary values 0/neg/27/54/3999/4000), `computePageNumbering` (10 tests incl. sample-13-shape), end-to-end `page-number-field-render` (footer i/ii → restart 1/2, start=0, `\* Roman` override). Full docx+core suite: **1854 passed**. `tsc --build` clean.
- **Non-regression (real samples):** new `page-number.spec.ts` renders sample-12 (continuous start=1) and sample-13 (nextPage start=1 + continuous start=2) and asserts sequential footer numbers matching Word's PDF ground truth (for sample-13 the start=2 restart fires at its spillover page but coincides with the natural continuation — see the continuous-break mechanism note above). docx demo VRT unchanged. Single-section docs without `<w:pgNumType>` are byte-identical (`{ pageIndex+1, decimal }` fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
