### PR TITLE
fix(charts): honor series-line noFill and per-point dLbl overrides

### DIFF
--- a/packages/core/src/chart/renderer-scatter-line-and-pie-labels.test.ts
+++ b/packages/core/src/chart/renderer-scatter-line-and-pie-labels.test.ts
@@ -1,0 +1,243 @@
+// Regression tests for two chart data-fidelity fixes:
+//
+//   1. Scatter connecting line: a series-level `<c:spPr><a:ln><a:noFill/>`
+//      (ECMA-376 §21.2.2.198) OVERRIDES the chart-group `<c:scatterStyle>`
+//      (§21.2.2.42). Excel draws a MARKERS-ONLY scatter when the series line is
+//      `<a:noFill/>` even though the group default is `lineMarker`. The parser
+//      records this as `ChartSeries.lineHidden`; the renderer must draw no
+//      connecting line for such a series (sample-30 sheet 1's two scatters).
+//
+//   2. Pie per-point data labels: a per-point `<c:dLbl idx>` (§21.2.2.47)
+//      carries its own show-flag group (§21.2.2.177/.180/.187/.189) and text
+//      style, which OVERRIDE the series-level `<c:dLbls>` defaults (§21.2.2.49)
+//      for that one slice. sample-14 slide-7's pie sets `showCatName=0
+//      showPercent=1` + white text PER SLICE while the series default is
+//      `showCatName=1` black — so each label must render as WHITE PERCENT-ONLY,
+//      not black "category + percent".
+//
+// Both broke when the pptx/xlsx parsers were unified onto the shared
+// ooxml-common `parse_chart_part` (which now surfaces scatterStyle /
+// series-level dLbls the renderer honors) without carrying the override /
+// noFill semantics that suppress or reshape those defaults.
+
+import { describe, it, expect } from 'vitest';
+import type { ChartModel, ChartSeries, ChartRect } from '../types/chart';
+import { renderChart } from './renderer.js';
+
+const RECT: ChartRect = { x: 0, y: 0, w: 640, h: 360 };
+
+function baseModel(over: Partial<ChartModel>): ChartModel {
+  return {
+    chartType: 'clusteredBar',
+    title: null,
+    categories: [],
+    series: [],
+    showDataLabels: false,
+    valMin: null,
+    valMax: null,
+    catAxisTitle: null,
+    valAxisTitle: null,
+    catAxisHidden: false,
+    valAxisHidden: false,
+    catAxisLineHidden: false,
+    valAxisLineHidden: false,
+    plotAreaBg: null,
+    chartBg: null,
+    showLegend: false,
+    legendPos: null,
+    catAxisCrossBetween: 'between',
+    valAxisMajorTickMark: 'out',
+    catAxisMajorTickMark: 'out',
+    titleFontSizeHpt: null,
+    titleFontColor: null,
+    titleFontFace: null,
+    catAxisFontSizeHpt: null,
+    valAxisFontSizeHpt: null,
+    dataLabelFontSizeHpt: null,
+    subtotalIndices: [],
+    ...over,
+  };
+}
+
+function series(over: Partial<ChartSeries>): ChartSeries {
+  return { name: '', color: null, values: [], ...over };
+}
+
+interface TextCall { text: string; fillStyle: string }
+
+/** Recording context that captures: (a) `stroke()` calls that follow a
+ *  `moveTo`/`lineTo` path with ≥2 vertices AND whose strokeStyle is `matchColor`
+ *  (the series line color) — this isolates the scatter connecting line from
+ *  gridlines/axis rules, which stroke in grey; (b) `fillText` calls with the
+ *  fillStyle in effect. Enough to assert the scatter line pass and pie labels. */
+function recordingCtx(matchColor = '#4f81bd'): {
+  ctx: CanvasRenderingContext2D;
+  counts: { polylineStrokes: number };
+  texts: TextCall[];
+} {
+  const texts: TextCall[] = [];
+  const counts = { polylineStrokes: 0 };
+  let pathVerts = 0;
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif',
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    globalAlpha: 1,
+  };
+  const fontPx = (font: string): number => {
+    const m = /(\d+(?:\.\d+)?)px/.exec(font);
+    return m ? parseFloat(m[1]) : 10;
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText':
+          return (t: string) => {
+            const px = fontPx(String(state.font));
+            let w = 0;
+            for (const ch of String(t)) w += ch.charCodeAt(0) > 0x2e7f ? px : px * 0.6;
+            return { width: w };
+          };
+        case 'beginPath':
+          return () => { pathVerts = 0; };
+        case 'moveTo':
+        case 'lineTo':
+        case 'bezierCurveTo':
+        case 'quadraticCurveTo':
+          return () => { pathVerts += 1; };
+        // A marker is a single `arc` + `fill`; it does not build a multi-vertex
+        // moveTo/lineTo path. Only a stroke in the SERIES color with ≥2 vertices
+        // is a connecting line (gridlines/axes stroke grey → excluded).
+        case 'stroke':
+          return () => {
+            if (pathVerts >= 2 && String(state.strokeStyle).toLowerCase() === matchColor.toLowerCase()) {
+              counts.polylineStrokes += 1;
+            }
+          };
+        case 'fillText':
+          return (text: string) =>
+            texts.push({ text, fillStyle: String(state.fillStyle) });
+        case 'createLinearGradient':
+        case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        default:
+          return () => undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return {
+    ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D,
+    counts,
+    texts,
+  };
+}
+
+describe('scatter series-line noFill overrides scatterStyle (§21.2.2.198)', () => {
+  // sample-30 sheet 1: `<c:scatterStyle val="lineMarker">` at the group level,
+  // but each series carries `<c:spPr><a:ln><a:noFill/></c:spPr>` → markers only.
+  const scatterModel = (lineHidden: boolean | null): ChartModel =>
+    baseModel({
+      chartType: 'scatter',
+      scatterStyle: 'lineMarker',
+      categories: ['1', '2', '3', '4'],
+      series: [series({
+        name: 'S',
+        color: '4f81bd',
+        values: [10, 20, 15, 25],
+        categories: ['1', '2', '3', '4'],
+        showMarker: true,
+        lineHidden,
+      })],
+    });
+
+  it('draws NO connecting polyline when the series line is noFill', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, scatterModel(true), RECT, 1);
+    expect(rec.counts.polylineStrokes).toBe(0);
+  });
+
+  it('still draws the connecting polyline for a normal lineMarker scatter', () => {
+    // Guard: the fix must not suppress lines universally — a series WITHOUT the
+    // noFill flag keeps the group scatterStyle line (regression the other way).
+    const rec = recordingCtx();
+    renderChart(rec.ctx, scatterModel(null), RECT, 1);
+    expect(rec.counts.polylineStrokes).toBeGreaterThan(0);
+  });
+});
+
+describe('pie per-point dLbl flags override series defaults (§21.2.2.47)', () => {
+  // sample-14 slide-7 pie: series default `<c:dLbls>` says showCatName=1,
+  // black; every slice's `<c:dLbl>` says showCatName=0 showPercent=1, WHITE.
+  // Result must be white percent-only labels.
+  const pieModel = (): ChartModel =>
+    baseModel({
+      chartType: 'pie',
+      showDataLabels: true,
+      categories: ['Alpha', 'Beta', 'Gamma'],
+      series: [series({
+        name: 'Share',
+        values: [50, 30, 20],
+        categories: ['Alpha', 'Beta', 'Gamma'],
+        dataPointColors: ['ff0000', '00ff00', '0000ff'],
+        seriesDataLabels: {
+          showVal: false,
+          showCatName: true,   // series default WOULD show category names…
+          showSerName: false,
+          showPercent: true,
+          fontColor: '000000', // …in black.
+          fontBold: true,
+          fontSizeHpt: 1800,
+          formatCode: '0%',
+          position: 'ctr',
+        },
+        dataLabelOverrides: [0, 1, 2].map(idx => ({
+          idx,
+          text: '',            // no custom text → compose from flags
+          fontColor: 'FFFFFF', // per-slice WHITE
+          fontBold: true,
+          fontSizeHpt: 1200,
+          showVal: false,
+          showCatName: false,  // per-slice: percent only
+          showSerName: false,
+          showPercent: true,
+        })),
+      })],
+    });
+
+  it('renders white, percent-only labels (no category names, not black)', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, pieModel(), RECT, 1);
+    const labels = rec.texts.filter(t => /%$/.test(t.text) || /Alpha|Beta|Gamma/.test(t.text));
+    expect(labels.length).toBeGreaterThan(0);
+    // Every drawn slice label is a bare percentage…
+    for (const l of labels) {
+      expect(l.text).toMatch(/^\d+%$/);
+      // …in white (the per-point override color), never the series-default black.
+      expect(l.fillStyle.toLowerCase()).toBe('#ffffff');
+    }
+    // And no category name leaked through.
+    expect(rec.texts.some(t => /Alpha|Beta|Gamma/.test(t.text))).toBe(false);
+  });
+
+  it('a genuine <c:delete> per-point override still skips that slice', () => {
+    const model = pieModel();
+    model.series[0].dataLabelOverrides = [
+      { idx: 0, text: '', deleted: true },
+      ...([1, 2].map(idx => ({
+        idx, text: '', fontColor: 'FFFFFF', showCatName: false, showPercent: true,
+      }))),
+    ];
+    const rec = recordingCtx();
+    renderChart(rec.ctx, model, RECT, 1);
+    const pctLabels = rec.texts.filter(t => /^\d+%$/.test(t.text));
+    // Two slices labeled (idx 1,2); the deleted idx 0 is skipped.
+    expect(pctLabels.length).toBe(2);
+  });
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -2783,31 +2783,59 @@ function drawPieRichLabels(
     return;
   }
 
+  const overrides = s.dataLabelOverrides ?? [];
   let angle = startAngle;
   for (let i = 0; i < vals.length; i++) {
     const slice = (vals[i] / total) * Math.PI * 2;
     const midAngle = angle + slice / 2;
     angle += slice;
-    // §21.2.2.35 label composition. dLblPos: "outEnd" places the label just
-    // beyond the rim; "inEnd"/"ctr" (and default) sit inside the slice at the
-    // radial midpoint. Percent is derived from the slice's share of the total.
-    const parts: string[] = [];
-    if (def.showCatName) parts.push((cats[i] ?? '').toString());
-    if (def.showSerName) parts.push(s.name);
-    if (def.showVal) parts.push(formatChartValWithCode(vals[i], def.formatCode ?? null, chart.date1904 ?? false));
-    if (def.showPercent) parts.push(`${Math.round((vals[i] / total) * 100)}%`);
-    const text = parts.filter(Boolean).join(' ');
+    // A per-point `<c:dLbl idx>` (§21.2.2.47) overrides the series-level
+    // `<c:dLbls>` (§21.2.2.49) for this one slice. Its show-flags, font color /
+    // size / bold, and position each fall back to the series default when the
+    // point declares none. sample-14 slide-7's pie sets `showCatName=0
+    // showPercent=1` + white text per slice while the series default is
+    // `showCatName=1` black — so honoring the per-point flags is what makes the
+    // labels render as white percent-only (matching PowerPoint / the PDF).
+    const ov = overrides.find(o => o.idx === i);
+    // A genuinely deleted label (`<c:delete val="1">`, §21.2.2.43) is skipped.
+    // A style/flag-only `<c:dLbl>` (no `<c:tx>`) is NOT a delete — sample-14's
+    // pie slices carry `text: ""` with white/percent-only flag overrides, so we
+    // key off the explicit `deleted` flag, never the empty text.
+    if (ov?.deleted) continue;
+    const showCatName = ov?.showCatName ?? def.showCatName;
+    const showSerName = ov?.showSerName ?? def.showSerName;
+    const showVal     = ov?.showVal ?? def.showVal;
+    const showPercent = ov?.showPercent ?? def.showPercent;
+    // §21.2.2.35 label composition. A per-point custom `<c:tx>` (non-empty
+    // override text) wins outright; otherwise compose from the resolved flags.
+    // dLblPos: "outEnd" places the label just beyond the rim; "inEnd"/"ctr"
+    // (and default) sit inside the slice at the radial midpoint. Percent is the
+    // slice's share of the total.
+    let text: string;
+    if (ov && ov.text) {
+      text = ov.text;
+    } else {
+      const parts: string[] = [];
+      if (showCatName) parts.push((cats[i] ?? '').toString());
+      if (showSerName) parts.push(s.name);
+      if (showVal) parts.push(formatChartValWithCode(vals[i], def.formatCode ?? null, chart.date1904 ?? false));
+      if (showPercent) parts.push(`${Math.round((vals[i] / total) * 100)}%`);
+      text = parts.filter(Boolean).join(' ');
+    }
     if (!text) continue;
-    const pos = def.position ?? 'bestFit';
+    const pos = ov?.position ?? def.position ?? 'bestFit';
     const outside = pos === 'outEnd';
     const labelR = outside
       ? outerR + Math.max(10, outerR * 0.12)
       : (innerR + outerR) / 2;
     const lx2 = cx2 + Math.cos(midAngle) * labelR;
     const ly2 = cy2 + Math.sin(midAngle) * labelR;
-    const sizePx = def.fontSizeHpt ? def.fontSizeHpt / 100 : Math.max(8, outerR * 0.1);
-    ctx.font = `${def.fontBold ? 'bold ' : ''}${sizePx}px ${font}`;
-    ctx.fillStyle = def.fontColor ? `#${def.fontColor}` : (outside ? '#333' : '#fff');
+    const sizeHpt = ov?.fontSizeHpt ?? def.fontSizeHpt;
+    const sizePx = sizeHpt ? sizeHpt / 100 : Math.max(8, outerR * 0.1);
+    const bold = ov?.fontBold ?? def.fontBold;
+    const fontColor = ov?.fontColor ?? def.fontColor;
+    ctx.font = `${bold ? 'bold ' : ''}${sizePx}px ${font}`;
+    ctx.fillStyle = fontColor ? `#${fontColor}` : (outside ? '#333' : '#fff');
     ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
     ctx.fillText(text, lx2, ly2);
   }
@@ -2884,23 +2912,28 @@ function drawPieCalloutLabels(
     if (slice <= 0) continue;
 
     const ov = findOverride(i);
-    // A `<c:delete val="1"/>` label carries an empty override text and NO
-    // styling — skip it entirely. A per-point *styling* override (sample-25's
-    // idx 0) also has text==="" but carries position/fontColor/box, in which
-    // case the label is still drawn using the composed cat/percent text.
-    const isDeleted = ov != null && ov.text === '' && ov.position === undefined
-      && ov.fontColor === undefined && ov.fontSizeHpt === undefined
-      && ov.fontBold === undefined && ov.labelBox === undefined;
-    if (isDeleted) continue;
+    // A genuine `<c:delete val="1"/>` (§21.2.2.43) skips the label; a per-point
+    // *styling / flag* override (sample-25's idx 0) is NOT a delete even though
+    // it also has `text === ""` — key off the explicit `deleted` flag.
+    if (ov?.deleted) continue;
 
-    // §21.2.2.35 composition. Word stacks category name and percent on
-    // SEPARATE lines (see sample-25.pdf), so each `show*` part is its own line
-    // rather than space-joined.
+    // §21.2.2.35 composition, with per-point `<c:dLbl>` show-flags (§21.2.2.47)
+    // overriding the series defaults for this slice. Word stacks category name
+    // and percent on SEPARATE lines (see sample-25.pdf), so each `show*` part is
+    // its own line rather than space-joined.
+    const showCatName = ov?.showCatName ?? def.showCatName;
+    const showSerName = ov?.showSerName ?? def.showSerName;
+    const showVal     = ov?.showVal ?? def.showVal;
+    const showPercent = ov?.showPercent ?? def.showPercent;
     const lines: string[] = [];
-    if (def.showCatName) { const c = (cats[i] ?? '').toString(); if (c) lines.push(c); }
-    if (def.showSerName && s.name) lines.push(s.name);
-    if (def.showVal) lines.push(formatChartValWithCode(vals[i], def.formatCode ?? null, chart.date1904 ?? false));
-    if (def.showPercent) lines.push(`${Math.round((vals[i] / total) * 100)}%`);
+    if (ov && ov.text) {
+      lines.push(ov.text);
+    } else {
+      if (showCatName) { const c = (cats[i] ?? '').toString(); if (c) lines.push(c); }
+      if (showSerName && s.name) lines.push(s.name);
+      if (showVal) lines.push(formatChartValWithCode(vals[i], def.formatCode ?? null, chart.date1904 ?? false));
+      if (showPercent) lines.push(`${Math.round((vals[i] / total) * 100)}%`);
+    }
     if (lines.length === 0) continue;
 
     // Per-point overrides (font colour/size/bold + box), else series defaults.
@@ -3491,7 +3524,11 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     }
 
     // Connecting lines (scatterStyle = line / smooth / lineMarker / smoothMarker).
-    if (drawLines || drawSmooth) {
+    // A series-level `<c:spPr><a:ln><a:noFill/>` (§21.2.2.198) OVERRIDES the
+    // group `<c:scatterStyle>` and suppresses the connecting line — Excel draws
+    // a markers-only scatter even when the group style is `lineMarker`. Guard the
+    // whole line pass on it so `lineHidden` series show markers only.
+    if ((drawLines || drawSmooth) && s.lineHidden !== true) {
       const pts: Array<{ x: number; y: number }> = [];
       for (let ci = 0; ci < s.values.length; ci++) {
         const yv = s.values[ci]; if (yv == null) continue;
@@ -3789,17 +3826,23 @@ function drawSeriesDataLabels(
     const xv = useIndexX ? i : parseFloat(cats[i] ?? '0');
     if (isNaN(xv)) continue;
     const ovr = overrides.find(o => o.idx === i);
+    // A genuine `<c:delete val="1"/>` (§21.2.2.43) skips the point; a per-point
+    // `<c:dLbl>` that only carries style / flag overrides (empty `<c:tx>`) is NOT
+    // a delete — key off the explicit `deleted` flag, then honor per-point
+    // show-flags (§21.2.2.47) over the series defaults.
+    if (ovr?.deleted) continue;
+    const showCatName = ovr?.showCatName ?? seriesDef?.showCatName;
+    const showSerName = ovr?.showSerName ?? seriesDef?.showSerName;
+    const showVal     = ovr?.showVal ?? seriesDef?.showVal;
     let text: string;
-    if (ovr) {
-      // `<c:delete val="1"/>` produced an empty text — skip drawing.
-      if (ovr.text === '') continue;
+    if (ovr?.text) {
       text = ovr.text;
-    } else if (seriesDef && (seriesDef.showVal || seriesDef.showSerName || seriesDef.showCatName)) {
+    } else if (showVal || showSerName || showCatName) {
       const parts: string[] = [];
-      if (seriesDef.showCatName && !useIndexX) parts.push(cats[i] ?? '');
-      if (seriesDef.showSerName) parts.push(s.name);
-      if (seriesDef.showVal) {
-        parts.push(formatChartValWithCode(yv, seriesDef.formatCode ?? null, date1904));
+      if (showCatName && !useIndexX) parts.push(cats[i] ?? '');
+      if (showSerName) parts.push(s.name);
+      if (showVal) {
+        parts.push(formatChartValWithCode(yv, seriesDef?.formatCode ?? null, date1904));
       }
       text = parts.filter(Boolean).join(' ');
       if (!text) continue;
@@ -4025,15 +4068,21 @@ function drawCategoryDataLabels(
     if (s.values[ci] == null && !plotNullAsZero) continue;
     const pv = plotted(ci);
     const ovr = overrides.find(o => o.idx === ci);
+    // Genuine `<c:delete val="1"/>` (§21.2.2.43) skips; a style/flag-only
+    // override is not a delete. Per-point show-flags (§21.2.2.47) win over the
+    // series defaults.
+    if (ovr?.deleted) continue;
+    const showCatName = ovr?.showCatName ?? seriesDef?.showCatName;
+    const showSerName = ovr?.showSerName ?? seriesDef?.showSerName;
+    const showVal     = ovr?.showVal ?? seriesDef?.showVal;
     let text: string;
-    if (ovr) {
-      if (ovr.text === '') continue; // `<c:delete val="1"/>` — deleted label
+    if (ovr?.text) {
       text = ovr.text;
-    } else if (seriesDef && (seriesDef.showVal || seriesDef.showSerName || seriesDef.showCatName)) {
+    } else if (showVal || showSerName || showCatName) {
       const parts: string[] = [];
-      if (seriesDef.showCatName) parts.push(cats[ci] ?? '');
-      if (seriesDef.showSerName) parts.push(s.name);
-      if (seriesDef.showVal) parts.push(formatChartValWithCode(pv, seriesDef.formatCode ?? null, date1904));
+      if (showCatName) parts.push(cats[ci] ?? '');
+      if (showSerName) parts.push(s.name);
+      if (showVal) parts.push(formatChartValWithCode(pv, seriesDef?.formatCode ?? null, date1904));
       text = parts.filter(Boolean).join(' ');
       if (!text) continue;
     } else {

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -128,6 +128,16 @@ export interface ChartSeries {
    * series that never declare one).
    */
   trendLines?: ChartTrendline[] | null;
+  /**
+   * `<c:ser><c:spPr><a:ln><a:noFill/>` (ECMA-376 §21.2.2.198 CT_ShapeProperties
+   * → DrawingML §20.1.2.2.24 CT_LineProperties). true when the series connecting
+   * line is explicitly turned OFF. For a scatter/line series this OVERRIDES the
+   * chart-group `<c:scatterStyle>` (§21.2.2.42) / line default — Excel and
+   * PowerPoint draw markers only (no connecting line) even when the group style
+   * is `lineMarker`. null/undefined = no explicit line-off, so the group default
+   * governs (byte-stable for series that carry a paintable line).
+   */
+  lineHidden?: boolean | null;
 }
 
 /**
@@ -198,6 +208,27 @@ export interface ChartDataLabelOverride {
   /** Per-point callout box (`<c:dLbl><c:spPr>`, ECMA-376 §21.2.2.47/§21.2.2.197):
    *  overrides the series-default box for this one slice. */
   labelBox?: ChartLabelBox;
+  /**
+   * Per-point label-content flags (`<c:dLbl>` §21.2.2.47 carries the same
+   * show-flag group as the series `<c:dLbls>` §21.2.2.49: §21.2.2.189
+   * `<c:showVal>`, §21.2.2.177 `<c:showCatName>`, §21.2.2.180 `<c:showSerName>`,
+   * §21.2.2.187 `<c:showPercent>`). When present they OVERRIDE the series-level
+   * defaults for that one point (e.g. sample-14 slide-7's pie sets
+   * `showCatName=0 showPercent=1` per slice while the series default is
+   * `showCatName=1`, so each label is percent only). undefined = inherit the
+   * series default for that flag.
+   */
+  showVal?: boolean;
+  showCatName?: boolean;
+  showSerName?: boolean;
+  showPercent?: boolean;
+  /**
+   * `<c:dLbl><c:delete val="1"/>` (ECMA-376 §21.2.2.43) — the point's label is
+   * removed. Distinguishes a genuine delete from a `<c:dLbl>` that only carries
+   * style / flag overrides with no `<c:tx>` (both otherwise present as
+   * `text === ''`). true = skip the label; undefined/absent = not deleted.
+   */
+  deleted?: boolean;
 }
 
 /** Callout-box style for a pie/doughnut data label — the white (or themed)

--- a/packages/node/src/verify-chart-regressions.probe.test.ts
+++ b/packages/node/src/verify-chart-regressions.probe.test.ts
@@ -1,0 +1,139 @@
+// End-to-end verification of the two chart regressions against the REAL
+// private fixtures, rendered through the actual WASM parser + core renderer on
+// skia. Gated on skia + the git-ignored fixtures, so it skips cleanly where
+// either is absent (CI has no private samples). This is a local acceptance
+// probe, not a committed regression guard — the parse/render logic is pinned by
+// the ooxml-common `parse_chart_part_*` tests and the core
+// `renderer-scatter-line-and-pie-labels` unit tests.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadSkiaForTests, importForTests } from './test-imports';
+import type { ChartModel } from '../../core/src/types/chart.ts';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const SAMPLE_14 = resolve(ROOT, 'packages/pptx/public/private/sample-14.pptx');
+const SAMPLE_30 = resolve(ROOT, 'packages/xlsx/public/private/sample-30.xlsx');
+
+const pptxMod = skia && existsSync(SAMPLE_14)
+  ? await importForTests(() => import('./pptx.ts'), './pptx.ts (pptx WASM)')
+  : null;
+const xlsxMod = skia && existsSync(SAMPLE_30)
+  ? await importForTests(() => import('./xlsx.ts'), './xlsx.ts (xlsx WASM)')
+  : null;
+const CORE_RENDERER = resolve(ROOT, 'packages/core/src/chart/renderer.ts');
+const coreMod = skia
+  ? await importForTests(() => import(CORE_RENDERER), 'packages/core/src/chart/renderer.ts')
+  : null;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+/** Depth-first collect every `type:'chart'` element's ChartModel from a slide. */
+function collectCharts(node: Any, out: ChartModel[]): void {
+  if (!node || typeof node !== 'object') return;
+  if (node.type === 'chart' && node.chart) out.push(node.chart as ChartModel);
+  for (const k of Object.keys(node)) {
+    const v = (node as Any)[k];
+    if (Array.isArray(v)) v.forEach(c => collectCharts(c, out));
+    else if (v && typeof v === 'object') collectCharts(v, out);
+  }
+}
+
+/** Render a chart, capturing fillText calls with the fillStyle in effect and a
+ *  count of series-colored (matchColor) connecting-line strokes. */
+function renderCapture(
+  chart: ChartModel,
+  renderChart: (ctx: unknown, c: ChartModel, r: unknown, p?: number) => void,
+  matchColor: string,
+): { texts: Array<{ text: string; fill: string }>; seriesStrokes: number } {
+  const canvas = new Canvas(640, 400);
+  const raw = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+  const texts: Array<{ text: string; fill: string }> = [];
+  let verts = 0;
+  let seriesStrokes = 0;
+  const proxy = new Proxy(raw, {
+    get(t, p: string) {
+      if (p === 'fillText') {
+        return (text: string, x: number, y: number) => {
+          texts.push({ text, fill: String((raw as Any).fillStyle) });
+          return (raw.fillText as Any)(text, x, y);
+        };
+      }
+      if (p === 'beginPath') return () => { verts = 0; (raw.beginPath as Any)(); };
+      if (p === 'moveTo' || p === 'lineTo' || p === 'bezierCurveTo') {
+        return (...a: number[]) => { verts += 1; return (raw as Any)[p](...a); };
+      }
+      if (p === 'stroke') {
+        return () => {
+          // A genuine data connecting line spans ≥3 vertices (≥3 data points);
+          // a 2-vertex series-colored segment is the legend line-key swatch,
+          // not a plot connecting line, so require ≥3 to isolate the plot line.
+          if (verts >= 3 && String((raw as Any).strokeStyle).toLowerCase() === matchColor.toLowerCase()) {
+            seriesStrokes += 1;
+          }
+          return (raw.stroke as Any)();
+        };
+      }
+      const v = (t as Any)[p];
+      return typeof v === 'function' ? v.bind(t) : v;
+    },
+    set(t, p: string, v) { (t as Any)[p] = v; return true; },
+  }) as unknown as CanvasRenderingContext2D;
+  renderChart(proxy, chart, { x: 0, y: 0, w: 640, h: 400 }, 1.05);
+  return { texts, seriesStrokes };
+}
+
+describe.skipIf(!pptxMod || !coreMod)('sample-14 slide-7 pie: white percent-only labels', () => {
+  it('renders bare percentages in white (no black category names)', () => {
+    const { parsePptx } = pptxMod as Any;
+    const { renderChart } = coreMod as Any;
+    const pres = parsePptx(readFileSync(SAMPLE_14));
+    const slide7 = pres.slides[6];
+    const charts: ChartModel[] = [];
+    collectCharts(slide7, charts);
+    const pie = charts.find(c => c.chartType === 'pie');
+    expect(pie, 'slide 7 has a pie chart').toBeTruthy();
+
+    const { texts } = renderCapture(pie as ChartModel, renderChart, '#000000');
+    // The slice DATA LABELS are the ones drawn in the per-point white; the
+    // category names appear only in the LEGEND (drawn in the neutral legend
+    // grey, not white). Isolate the white labels — those are the slice labels.
+    const whiteLabels = texts.filter(t => t.fill.toLowerCase() === '#ffffff');
+    expect(whiteLabels.length, 'pie draws white slice labels').toBeGreaterThan(0);
+    for (const l of whiteLabels) {
+      // Every white slice label is a bare percentage — no category name, no
+      // black text (the pre-fix regression drew black "category + percent").
+      expect(l.text).toMatch(/^\d+%$/);
+    }
+    // No slice label is drawn in black (the overridden series-default color).
+    const catNames = (pie as ChartModel).categories ?? [];
+    const blackSliceLabels = texts.filter(t =>
+      t.fill.toLowerCase() === '#000000' && catNames.some(cn => cn && t.text.includes(cn)));
+    expect(blackSliceLabels.length, 'no black category-name slice labels').toBe(0);
+  });
+});
+
+describe.skipIf(!xlsxMod || !coreMod)('sample-30 sheet-1 scatter: markers only (no lines)', () => {
+  it('draws no series connecting line for the noFill scatter series', () => {
+    const { parseSheet } = xlsxMod as Any;
+    const { renderChart } = coreMod as Any;
+    // Sheet 1 (index 0). parseSheet returns a Worksheet with `charts`.
+    const ws = parseSheet(readFileSync(SAMPLE_30), 0, 'Sheet1');
+    const anchors = (ws.charts ?? []) as Any[];
+    const scatters = anchors.map(a => a.chart as ChartModel).filter(c => c.chartType === 'scatter');
+    expect(scatters.length, 'sheet 1 has scatter charts').toBeGreaterThan(0);
+    for (const sc of scatters) {
+      const color = sc.series[0]?.color ? `#${sc.series[0].color}` : '#4f81bd';
+      const { seriesStrokes } = renderCapture(sc, renderChart, color);
+      expect(seriesStrokes, 'noFill scatter draws zero connecting lines').toBe(0);
+    }
+  });
+});

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -375,6 +375,15 @@ pub struct ChartSeries {
     /// when the series declares none (byte-stable).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trend_lines: Option<Vec<ChartTrendline>>,
+    /// `<c:ser><c:spPr><a:ln><a:noFill/>` (§21.2.2.198 CT_ShapeProperties →
+    /// DrawingML §20.1.2.2.24 CT_LineProperties). `Some(true)` when the series'
+    /// connecting line is explicitly turned OFF. For a scatter/line series this
+    /// overrides the chart-group `<c:scatterStyle>` (§21.2.2.42) / line default:
+    /// Excel/PowerPoint draw NO connecting line when the series line is
+    /// `<a:noFill/>`, even if the group style is `lineMarker`. `None` (omitted)
+    /// = the series carries no explicit line-off, so the group default governs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_hidden: Option<bool>,
 }
 
 /// Mirror of TS `ChartTrendline` — `<c:ser><c:trendline>` (§21.2.2.211).
@@ -449,6 +458,31 @@ pub struct ChartDataLabelOverride {
     /// (e.g. a differently tinted callout for one slice). See [`ChartLabelBox`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label_box: Option<ChartLabelBox>,
+    /// Per-point label-content flags (`<c:dLbl>` §21.2.2.47 carries the full
+    /// `CT_DLbl` show-flag group: §21.2.2.189 `<c:showVal>`, §21.2.2.177
+    /// `<c:showCatName>`, §21.2.2.180 `<c:showSerName>`, §21.2.2.187
+    /// `<c:showPercent>`). When a `<c:dLbl>` sets these they OVERRIDE the
+    /// series-level `<c:dLbls>` defaults (§21.2.2.49) for that one point — e.g.
+    /// sample-14 slide-7's pie sets `showCatName=0 showPercent=1` per slice even
+    /// though the series default is `showCatName=1`, so each label is percent
+    /// only. `None` = the point declared no such flag, so the series default
+    /// governs (byte-stable for points that carry none).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub show_val: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub show_cat_name: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub show_ser_name: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub show_percent: Option<bool>,
+    /// `<c:dLbl><c:delete val="1"/>` (§21.2.2.43) — this point's label is
+    /// removed. Distinguishes a genuinely deleted label from a `<c:dLbl>` that
+    /// merely carries style/flag overrides with no `<c:tx>` (both formerly
+    /// collapsed to `text == ""`). `Some(true)` = skip the label entirely;
+    /// `None`/absent = not deleted (compose from flags / text). Byte-stable for
+    /// points that carry no `<c:delete>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deleted: Option<bool>,
 }
 
 /// Callout-box style for a pie/doughnut data label — the white (or themed)
@@ -2081,6 +2115,8 @@ pub fn parse_chartex_part(
         smooth: None,
         // chartEx series carry no classic `<c:trendline>`.
         trend_lines: None,
+        // chartEx has no scatter connecting line to suppress.
+        line_hidden: None,
     }];
 
     // ChartEx axis visibility — shared helper that pairs each `<cx:axis hidden>`
@@ -2813,6 +2849,14 @@ pub fn parse_series_data_labels(
                 .find(|n| n.is_element() && n.tag_name().name() == "spPr"),
             resolver,
         );
+        // Per-point show-flags (§21.2.2.47 CT_DLbl carries the same show-flag
+        // group as CT_DLbls). Read as `Option` so an absent flag falls through
+        // to the series default; a present flag overrides it for this point.
+        let opt_bool_flag = |name: &str| -> Option<bool> {
+            child(dl, name)
+                .and_then(|c| c.attribute("val"))
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        };
         overrides.push(ChartDataLabelOverride {
             idx,
             text,
@@ -2821,6 +2865,14 @@ pub fn parse_series_data_labels(
             font_size_hpt,
             font_bold,
             label_box,
+            show_val: opt_bool_flag("showVal"),
+            show_cat_name: opt_bool_flag("showCatName"),
+            show_ser_name: opt_bool_flag("showSerName"),
+            show_percent: opt_bool_flag("showPercent"),
+            // §21.2.2.43 `<c:delete>` — record genuine deletes distinctly from a
+            // style-only `<c:dLbl>` so the renderer never mistakes an empty tx
+            // (compose-from-flags) for a removed label.
+            deleted: if deleted { Some(true) } else { None },
         });
     }
 
@@ -3625,6 +3677,15 @@ pub fn parse_chart_part(
                 .and_then(|fill| color_resolver.resolve_solid_fill(fill))
                 .or_else(|| color_resolver.resolve_series_accent(series_idx));
 
+            // §21.2.2.198 series-level `<c:spPr><a:ln>`: an explicit `<a:noFill/>`
+            // turns the connecting line OFF, overriding the chart-group
+            // `<c:scatterStyle>` (§21.2.2.42) / line-group default. Excel draws a
+            // markers-only scatter when the series line is `<a:noFill/>` even
+            // though `<c:scatterStyle val="lineMarker">` sets the group default to
+            // connect points. Only the noFill flag matters here (color/width ride
+            // on `color` above), so discard the other two tuple fields.
+            let (_, _, line_no_fill) = extract_sp_pr_ln_style(*ser, color_resolver);
+
             // Per-data-point colors from <c:dPt> (§21.2.2.52; important for
             // pie charts). The point index is the CHILD element `<c:idx val>`
             // (ECMA-376 §21.2.2.84, CT_UnsignedInt), not an attribute on
@@ -3818,6 +3879,10 @@ pub fn parse_chart_part(
                 // `<c:ser><c:trendline>` (§21.2.2.211) — regression lines. Shared
                 // extractor; the line color resolves through the pptx theme.
                 trend_lines: extract_series_trendlines(*ser, color_resolver),
+                // §21.2.2.198 `<c:spPr><a:ln><a:noFill/>` — series connecting line
+                // explicitly off. Only serialized when set, so byte-stable for
+                // series that carry no line-off (the common case).
+                line_hidden: if line_no_fill { Some(true) } else { None },
             }
         })
         .collect();
@@ -4443,6 +4508,7 @@ mod tests {
                 bubble_sizes: None,
                 smooth: None,
                 trend_lines: None,
+                line_hidden: None,
             }],
             show_data_labels: false,
             val_min: None,
@@ -5788,6 +5854,119 @@ mod tests {
             &FixtureResolver
         )
         .is_none());
+    }
+
+    /// §21.2.2.198: a scatter series whose `<c:spPr><a:ln>` is `<a:noFill/>`
+    /// has its connecting line turned OFF, overriding the group-level
+    /// `<c:scatterStyle val="lineMarker">` (§21.2.2.42). The parser must set
+    /// `line_hidden = Some(true)` so the renderer draws markers only — the
+    /// sample-30 sheet-1 scatter shape. A series with a paintable line leaves
+    /// `line_hidden = None`.
+    #[test]
+    fn parse_chart_part_scatter_series_line_nofill_sets_line_hidden() {
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+              <c:chart><c:plotArea>
+                <c:scatterChart>
+                  <c:scatterStyle val="lineMarker"/>
+                  <c:ser>
+                    <c:idx val="0"/>
+                    <c:spPr><a:ln w="25400"><a:noFill/></a:ln></c:spPr>
+                    <c:xVal><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt></c:numCache></c:xVal>
+                    <c:yVal><c:numCache><c:pt idx="0"><c:v>10</c:v></c:pt><c:pt idx="1"><c:v>20</c:v></c:pt></c:numCache></c:yVal>
+                  </c:ser>
+                  <c:ser>
+                    <c:idx val="1"/>
+                    <c:spPr><a:ln w="19050"><a:solidFill><a:srgbClr val="ED7D31"/></a:solidFill></a:ln></c:spPr>
+                    <c:xVal><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt></c:numCache></c:xVal>
+                    <c:yVal><c:numCache><c:pt idx="0"><c:v>5</c:v></c:pt><c:pt idx="1"><c:v>8</c:v></c:pt></c:numCache></c:yVal>
+                  </c:ser>
+                  <c:axId val="1"/><c:axId val="2"/>
+                </c:scatterChart>
+                <c:valAx><c:axId val="1"/><c:crossAx val="2"/></c:valAx>
+                <c:valAx><c:axId val="2"/><c:crossAx val="1"/></c:valAx>
+              </c:plotArea></c:chart>
+            </c:chartSpace>"#
+        );
+        let m = parse_chart_part(chart_space_of(&xml).root_element(), &FixtureResolver)
+            .expect("scatter chart parses");
+        assert_eq!(m.chart_type, "scatter");
+        assert_eq!(m.scatter_style.as_deref(), Some("lineMarker"));
+        // Series 0: explicit `<a:noFill/>` line → line_hidden set.
+        assert_eq!(
+            m.series[0].line_hidden,
+            Some(true),
+            "a `<a:ln><a:noFill/>` series line must record line_hidden"
+        );
+        // Series 1: a paintable line → line_hidden stays None (group style governs).
+        assert_eq!(
+            m.series[1].line_hidden, None,
+            "a series with a solid line must NOT set line_hidden"
+        );
+    }
+
+    /// §21.2.2.47: a per-point `<c:dLbl>` carries its own show-flag group and
+    /// text style, overriding the series-level `<c:dLbls>` (§21.2.2.49) for that
+    /// point. sample-14 slide-7's pie sets `showCatName=0 showPercent=1` + white
+    /// per slice while the series default is `showCatName=1` black. The parser
+    /// must surface both the series default AND the per-point flag / color
+    /// overrides, and mark a genuine `<c:delete>` distinctly from a style-only
+    /// `<c:dLbl>` (which has an empty `text`).
+    #[test]
+    fn parse_chart_part_pie_per_point_dlbl_overrides_series_defaults() {
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+              <c:chart><c:plotArea>
+                <c:pieChart>
+                  <c:ser>
+                    <c:idx val="0"/>
+                    <c:dLbls>
+                      <c:dLbl>
+                        <c:idx val="0"/>
+                        <c:txPr><a:p><a:pPr><a:defRPr b="1"><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill></a:defRPr></a:pPr></a:p></c:txPr>
+                        <c:showVal val="0"/><c:showCatName val="0"/><c:showSerName val="0"/><c:showPercent val="1"/>
+                      </c:dLbl>
+                      <c:dLbl>
+                        <c:idx val="1"/>
+                        <c:delete val="1"/>
+                      </c:dLbl>
+                      <c:txPr><a:p><a:pPr><a:defRPr b="1"><a:solidFill><a:srgbClr val="000000"/></a:solidFill></a:defRPr></a:pPr></a:p></c:txPr>
+                      <c:showVal val="0"/><c:showCatName val="1"/><c:showSerName val="0"/><c:showPercent val="1"/>
+                    </c:dLbls>
+                    <c:cat><c:strCache><c:pt idx="0"><c:v>A</c:v></c:pt><c:pt idx="1"><c:v>B</c:v></c:pt></c:strCache></c:cat>
+                    <c:val><c:numCache><c:pt idx="0"><c:v>60</c:v></c:pt><c:pt idx="1"><c:v>40</c:v></c:pt></c:numCache></c:val>
+                  </c:ser>
+                </c:pieChart>
+              </c:plotArea></c:chart>
+            </c:chartSpace>"#
+        );
+        let m = parse_chart_part(chart_space_of(&xml).root_element(), &FixtureResolver)
+            .expect("pie chart parses");
+        assert_eq!(m.chart_type, "pie");
+        let def = m.series[0]
+            .series_data_labels
+            .as_ref()
+            .expect("series-level dLbls present");
+        // Series default: category name ON, black text.
+        assert!(def.show_cat_name, "series default shows category name");
+        assert!(def.show_percent);
+        assert_eq!(def.font_color.as_deref(), Some("000000"));
+
+        let ovs = m.series[0]
+            .data_label_overrides
+            .as_ref()
+            .expect("per-point overrides present");
+        let ov0 = ovs.iter().find(|o| o.idx == 0).expect("idx 0 override");
+        // Per-point idx 0: category name OFF, percent ON, white — overrides the
+        // series default so this slice renders as white percent-only.
+        assert_eq!(ov0.show_cat_name, Some(false));
+        assert_eq!(ov0.show_percent, Some(true));
+        assert_eq!(ov0.font_color.as_deref(), Some("FFFFFF"));
+        assert_ne!(ov0.deleted, Some(true), "a style-only dLbl is not a delete");
+
+        let ov1 = ovs.iter().find(|o| o.idx == 1).expect("idx 1 override");
+        // Per-point idx 1: a genuine `<c:delete>` → flagged so the renderer skips it.
+        assert_eq!(ov1.deleted, Some(true));
     }
 
     // ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes two chart data-fidelity regressions reported against the private fixtures. Both were introduced when the pptx/xlsx parsers were unified onto the shared `ooxml_common::chart::parse_chart_part` — that path now surfaces the group `<c:scatterStyle>` and the series-level `<c:dLbls>` the renderer honors, but it dropped the two *override* mechanisms that reshape or suppress those defaults, so the renderer over-drew.

| Symptom | Cause commit | Concept |
|---|---|---|
| xlsx scatter draws connecting lines that should be markers-only | `3beec07` (`refactor(xlsx): parse charts directly through shared parse_chart_part`) | series `<a:ln><a:noFill/>` overrides `<c:scatterStyle>` |
| pptx pie labels show black "category + percent" instead of white percent-only | `5f51a8e` (`refactor(charts): centralize legacy chart parse … (pptx switched)`) | per-point `<c:dLbl>` overrides series `<c:dLbls>` defaults |

Different commits, same regression class (shared-parse unification surfaced richer defaults without the override semantics). Both fixes land in the shared layer (`ooxml-common` parse + `core` types/renderer), so pptx and xlsx get them through the one parse path — a single coordinated PR per the repo's cross-package integration principle.

## 1. Scatter connecting line (§21.2.2.198)

sample-30 sheet 1's two XY scatters declare `<c:scatterStyle val="lineMarker">` at the group level, but each series carries `<c:spPr><a:ln><a:noFill/></c:spPr>`. Per ECMA-376 §21.2.2.198 (CT_ShapeProperties) → DrawingML §20.1.2.2.24 (CT_LineProperties), the **series-level line overrides the group scatter style** — Excel draws markers only.

The old xlsx parser hard-set `scatter_style: None` (renderer defaulted to markers — correct by accident); the shared path parses `lineMarker` and the renderer connected the points. **Fix:** parse the series `<a:ln><a:noFill/>` into `ChartSeries.line_hidden` and gate the scatter connecting-line pass on it. A series with a paintable line is unaffected (guarded by a test).

**Before/after (real fixture, skia render):** all 3 scatter series parse `lineHidden=true`; the renderer now emits **0** series-colored connecting-line strokes through the data points (was drawing the full `lineMarker` polyline).

## 2. Pie per-point data labels (§21.2.2.47)

sample-14 slide-7's pie/doughnut set the series-default `<c:dLbls>` to `showCatName=1` + black `000000`, but every slice's per-point `<c:dLbl>` (§21.2.2.47) overrides that with `showCatName=0 showPercent=1` + white `FFFFFF`. Ground truth `sample-14.pdf` p.7 = **white percent-only** labels.

Before `5f51a8e` the pie renderer ignored rich `<c:dLbls>` and always drew `round(pct)%` in white (#561 / `f3f299f`); the shared path introduced `series_data_labels`, and the renderer began honoring the series *default* flags but not the per-point overrides — drawing black "category + percent". **Fix:** parse the per-point `<c:dLbl>` show-flag group (§21.2.2.177/.180/.187/.189) and an explicit `deleted` flag (§21.2.2.43) into `ChartDataLabelOverride`, and have every data-label composer (pie rich + callout, scatter/line, area/bar) resolve the per-point flag / color / text over the series default. The explicit `deleted` flag also fixes a latent conflation where a style-only `<c:dLbl>` (empty `<c:tx>`) was mistaken for a `<c:delete>` and skipped.

**Before/after (real fixture, skia render, matches PDF p.7):**
- pie slice labels: `54%` `27%` `14%` `5%` — all `#ffffff` (was black `category + percent`)
- doughnut slice labels: `33%` `24%` `18%` `15%` `10%` — all `#ffffff`
- category names appear only in the legend (correct), never as black slice labels

## Non-regression of the cause PRs

- `3beec07` target (xlsx charts through shared parse): xlsx cargo suite (122) + TS suite green; `line_hidden` is additive.
- `5f51a8e` target (pptx nested chart emit): `chart-nested-emit.test.ts` green.
- `#561` / `f3f299f` (pie showPercent labels): preserved — pie still shows `%`, now correctly white percent-only.

## Verification

- `ooxml-common` cargo: **205** pass (incl. new `parse_chart_part_scatter_series_line_nofill_sets_line_hidden`, `parse_chart_part_pie_per_point_dlbl_overrides_series_defaults`); pptx **144**, xlsx **122**.
- core TS: **1132** pass (new `renderer-scatter-line-and-pie-labels.test.ts`); pptx + xlsx TS: **669** pass.
- skia end-to-end probe against the real fixtures: pie white percent-only, scatter zero connecting lines (gated on the git-ignored samples).
- root `tsc --build` clean; `cargo fmt --check` + `clippy -D warnings` (ooxml-common/pptx/xlsx) clean; `ast-grep scan` clean.
- pptx demo VRT (`demo/sample-1`, 9 slides + worker-equivalence) and xlsx demo VRT (`demo/sample-1`, 5 sheets + worker-equivalence): **zero regression**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)