### PR TITLE
feat(docx): section decorations — page borders, line numbering, vertical alignment

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1387,6 +1387,88 @@ fn parse_pgnum_type(sect_pr: roxmltree::Node) -> Option<PageNumType> {
     Some(PageNumType { start, fmt })
 }
 
+/// ECMA-376 §17.6.10 `<w:pgBorders>` — parse the page borders of one sectPr.
+/// Returns `None` when the element is absent OR carries no drawable edge (all four
+/// edges missing / `nil`), so a document with no page border stays byte-identical.
+/// Each edge is a `CT_Border` (§17.18.4). For a page border, `@w:space` is a POINT
+/// measure (ST_PointMeasure §17.18.68), NOT twips — read it directly; `@w:sz` is
+/// eighths of a point like every other CT_Border width.
+fn parse_page_borders(sect_pr: roxmltree::Node) -> Option<PageBorders> {
+    let pgb = child_w(sect_pr, "pgBorders")?;
+    // §17.18.63 offsetFrom default = "text"; §17.18.62 display default = "allPages";
+    // §17.18.64 zOrder default = "front".
+    let offset_from = attr_w(pgb, "offsetFrom").unwrap_or_else(|| "text".to_string());
+    let display = attr_w(pgb, "display").unwrap_or_else(|| "allPages".to_string());
+    let z_order = attr_w(pgb, "zOrder").unwrap_or_else(|| "front".to_string());
+
+    let top = child_w(pgb, "top").and_then(parse_page_border_edge);
+    let bottom = child_w(pgb, "bottom").and_then(parse_page_border_edge);
+    let left = child_w(pgb, "left").and_then(parse_page_border_edge);
+    let right = child_w(pgb, "right").and_then(parse_page_border_edge);
+    if top.is_none() && bottom.is_none() && left.is_none() && right.is_none() {
+        return None;
+    }
+    Some(PageBorders {
+        offset_from,
+        display,
+        z_order,
+        top,
+        bottom,
+        left,
+        right,
+    })
+}
+
+/// Parse one edge of `<w:pgBorders>` (a `CT_Border`, §17.18.4). Returns `None` for
+/// an edge whose `@w:val` is absent or resolves to "none"/"nil" (no ink). `@w:sz`
+/// is eighths of a point (÷ 8 ⇒ pt), matching `parse_border_spec`; `@w:space` is a
+/// direct POINT measure for page borders (§17.18.68).
+fn parse_page_border_edge(node: roxmltree::Node) -> Option<PageBorderEdge> {
+    let style = attr_w(node, "val")?;
+    if style == "none" || style == "nil" {
+        return None;
+    }
+    // §17.18.4: sz is eighths of a point; default matches parse_border_spec (0.5pt
+    // when absent). space is a plain point count (0–31) for page borders.
+    let width = attr_w(node, "sz")
+        .and_then(|v| v.trim().parse::<f64>().ok())
+        .map(|v| v / 8.0)
+        .unwrap_or(0.5);
+    let space = attr_w(node, "space")
+        .and_then(|v| v.trim().parse::<f64>().ok())
+        .unwrap_or(0.0);
+    let color = attr_w(node, "color")
+        .filter(|c| c != "auto")
+        .map(|c| c.to_lowercase());
+    Some(PageBorderEdge {
+        style,
+        color,
+        width,
+        space,
+    })
+}
+
+/// ECMA-376 §17.6.8 `<w:lnNumType>` — parse a section's line numbering. Returns
+/// `None` when the element is absent OR `@w:countBy` is missing (the spec: "If
+/// this attribute is missing, no line numbering shall be applied to the section").
+/// `@w:start` defaults to 1; `@w:distance` is twips ⇒ pt; `@w:restart` defaults to
+/// "newPage" (§17.18.47).
+fn parse_line_numbering(sect_pr: roxmltree::Node) -> Option<LineNumbering> {
+    let ln = child_w(sect_pr, "lnNumType")?;
+    let count_by = attr_w(ln, "countBy").and_then(|v| v.trim().parse::<i64>().ok())?;
+    let start = attr_w(ln, "start")
+        .and_then(|v| v.trim().parse::<i64>().ok())
+        .unwrap_or(1);
+    let distance = attr_w(ln, "distance").map(|v| twips_to_pt(&v));
+    let restart = attr_w(ln, "restart").unwrap_or_else(|| "newPage".to_string());
+    Some(LineNumbering {
+        count_by,
+        start,
+        distance,
+        restart,
+    })
+}
+
 /// ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` spec defaults for a
 /// section's page geometry: US Letter portrait (612×792 pt), 1" margins (72 pt),
 /// 0.5" header/footer distance (36 pt). This is the ONE place these defaults
@@ -1749,6 +1831,9 @@ fn parse_section(
         doc_grid_char_space: None,
         columns: None,
         page_num_type: None,
+        page_borders: None,
+        line_numbering: None,
+        v_align: None,
     };
 
     let Some(sp) = sect_pr else {
@@ -1831,6 +1916,22 @@ fn parse_section(
     // (@w:fmt). `None` when absent (numbering continues; decimal). The renderer
     // resolves the displayed page number per physical page from this.
     props.page_num_type = parse_pgnum_type(sp);
+
+    // ECMA-376 §17.6.10 w:pgBorders — page borders (top/left/bottom/right edges +
+    // placement globals). `None` when absent (no page border).
+    props.page_borders = parse_page_borders(sp);
+
+    // ECMA-376 §17.6.8 w:lnNumType — line numbering. `None` when absent OR when
+    // `@w:countBy` is missing (no line numbering per the spec).
+    props.line_numbering = parse_line_numbering(sp);
+
+    // ECMA-376 §17.6.23 w:vAlign — body vertical alignment. Default "top" is
+    // dropped to `None` so top-aligned (the common case) stays byte-identical.
+    if let Some(va) = child_w(sp, "vAlign").and_then(|n| attr_w(n, "val")) {
+        if va != "top" {
+            props.v_align = Some(va);
+        }
+    }
 
     // Collect header/footer references from THIS sectPr.
     let mut refs = SectionRefs::default();
@@ -11460,6 +11561,136 @@ mod column_tests {
         assert!(parse(r#"<w:pgNumType w:chapStyle="1" w:chapSep="colon"/>"#)
             .page_num_type
             .is_none());
+    }
+
+    /// ECMA-376 §17.6.10 `<w:pgBorders>` — the four edges + placement globals
+    /// (offsetFrom / display / zOrder, with their spec defaults) surface on
+    /// SectionProps.page_borders. Absent element ⇒ None; an all-`nil`/`none`
+    /// pgBorders ⇒ None (no drawable edge).
+    #[test]
+    fn section_props_carries_page_borders() {
+        let parse = |sect: &str| {
+            let xml = format!(r#"<w:sectPr xmlns:w="{ns}">{sect}</w:sectPr>"#, ns = W_NS);
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            let rel_map: HashMap<String, String> = HashMap::new();
+            parse_section(Some(doc.root_element()), &rel_map).0
+        };
+        // Spec example (§17.6.10): dashed box, offsetFrom="page", sz=4 (0.5pt),
+        // space=24 (points), color auto ⇒ None.
+        let pb = parse(
+            r#"<w:pgBorders w:offsetFrom="page">
+                 <w:top w:val="dashed" w:sz="4" w:space="24" w:color="auto"/>
+                 <w:left w:val="dashed" w:sz="4" w:space="24" w:color="auto"/>
+                 <w:bottom w:val="dashed" w:sz="4" w:space="24" w:color="auto"/>
+                 <w:right w:val="dashed" w:sz="4" w:space="24" w:color="auto"/>
+               </w:pgBorders>"#,
+        )
+        .page_borders
+        .expect("page_borders surfaced");
+        assert_eq!(pb.offset_from, "page");
+        assert_eq!(pb.display, "allPages"); // §17.18.62 default
+        assert_eq!(pb.z_order, "front"); // §17.18.64 default
+        let top = pb.top.expect("top edge");
+        assert_eq!(top.style, "dashed");
+        assert!((top.width - 0.5).abs() < 1e-9); // sz 4 / 8 = 0.5pt
+        assert!((top.space - 24.0).abs() < 1e-9); // page-border space is POINTS, not twips
+        assert_eq!(top.color, None); // auto ⇒ None
+        assert!(pb.left.is_some() && pb.bottom.is_some() && pb.right.is_some());
+
+        // offsetFrom defaults to "text" (§17.18.63) when omitted; explicit color +
+        // display + zOrder carried.
+        let pb2 = parse(
+            r#"<w:pgBorders w:display="firstPage" w:zOrder="back">
+                 <w:top w:val="single" w:sz="24" w:space="1" w:color="FF0000"/>
+               </w:pgBorders>"#,
+        )
+        .page_borders
+        .expect("page_borders surfaced");
+        assert_eq!(pb2.offset_from, "text");
+        assert_eq!(pb2.display, "firstPage");
+        assert_eq!(pb2.z_order, "back");
+        let t2 = pb2.top.expect("top edge");
+        assert!((t2.width - 3.0).abs() < 1e-9); // sz 24 / 8 = 3pt
+        assert_eq!(t2.color, Some("ff0000".to_string())); // lowercased
+        assert!(pb2.bottom.is_none());
+
+        // Absent element ⇒ None.
+        assert!(parse(r#"<w:cols w:num="2"/>"#).page_borders.is_none());
+        // All edges nil/none ⇒ None (nothing to draw).
+        assert!(parse(
+            r#"<w:pgBorders><w:top w:val="nil"/><w:bottom w:val="none"/></w:pgBorders>"#
+        )
+        .page_borders
+        .is_none());
+    }
+
+    /// ECMA-376 §17.6.8 `<w:lnNumType>` — line numbering surfaces on
+    /// SectionProps.line_numbering. `@w:countBy` is REQUIRED (absent ⇒ no line
+    /// numbering ⇒ None); start defaults to 1, restart to "newPage", distance is
+    /// twips ⇒ pt.
+    #[test]
+    fn section_props_carries_line_numbering() {
+        let parse = |sect: &str| {
+            let xml = format!(r#"<w:sectPr xmlns:w="{ns}">{sect}</w:sectPr>"#, ns = W_NS);
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            let rel_map: HashMap<String, String> = HashMap::new();
+            parse_section(Some(doc.root_element()), &rel_map).0
+        };
+        // Minimal: countBy only ⇒ start=1, restart=newPage, distance=None.
+        let ln = parse(r#"<w:lnNumType w:countBy="1"/>"#)
+            .line_numbering
+            .expect("line_numbering surfaced");
+        assert_eq!(ln.count_by, 1);
+        assert_eq!(ln.start, 1); // §17.6.8 default
+        assert_eq!(ln.restart, "newPage"); // §17.18.47 default
+        assert_eq!(ln.distance, None);
+
+        // Full: countBy=5, start=3, distance=720 twips (36pt), restart=continuous.
+        let ln2 = parse(
+            r#"<w:lnNumType w:countBy="5" w:start="3" w:distance="720" w:restart="continuous"/>"#,
+        )
+        .line_numbering
+        .expect("line_numbering surfaced");
+        assert_eq!(ln2.count_by, 5);
+        assert_eq!(ln2.start, 3);
+        assert_eq!(ln2.restart, "continuous");
+        assert!((ln2.distance.unwrap() - 36.0).abs() < 1e-9);
+
+        // Absent element ⇒ None.
+        assert!(parse(r#"<w:cols w:num="2"/>"#).line_numbering.is_none());
+        // countBy missing (spec: no line numbering) ⇒ None.
+        assert!(parse(r#"<w:lnNumType w:start="1"/>"#)
+            .line_numbering
+            .is_none());
+    }
+
+    /// ECMA-376 §17.6.23 `<w:vAlign w:val>` — body vertical alignment surfaces on
+    /// SectionProps.v_align. The default "top" is dropped to None (byte-identical
+    /// top-aligned rendering); center/both/bottom are carried verbatim.
+    #[test]
+    fn section_props_carries_v_align() {
+        let parse = |sect: &str| {
+            let xml = format!(r#"<w:sectPr xmlns:w="{ns}">{sect}</w:sectPr>"#, ns = W_NS);
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            let rel_map: HashMap<String, String> = HashMap::new();
+            parse_section(Some(doc.root_element()), &rel_map).0
+        };
+        assert_eq!(
+            parse(r#"<w:vAlign w:val="center"/>"#).v_align,
+            Some("center".to_string())
+        );
+        assert_eq!(
+            parse(r#"<w:vAlign w:val="bottom"/>"#).v_align,
+            Some("bottom".to_string())
+        );
+        assert_eq!(
+            parse(r#"<w:vAlign w:val="both"/>"#).v_align,
+            Some("both".to_string())
+        );
+        // Default "top" ⇒ None (unchanged rendering).
+        assert_eq!(parse(r#"<w:vAlign w:val="top"/>"#).v_align, None);
+        // Absent ⇒ None.
+        assert_eq!(parse(r#"<w:cols w:num="2"/>"#).v_align, None);
     }
 
     /// ECMA-376 §17.6.22 — the body (final) section's `<w:type>` start type is

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -208,6 +208,81 @@ pub struct PageNumType {
     pub fmt: Option<String>,
 }
 
+/// ECMA-376 §17.6.10 `<w:pgBorders>` — the page borders drawn around each page of
+/// a section. Each edge is a `CT_Border` (§17.18.4: val / sz / space / color);
+/// the container carries the placement globals `offsetFrom`, `display`, `zOrder`.
+/// `None` on `SectionProps` when the sectPr declares no `<w:pgBorders>` (the
+/// common case — no page border), so existing snapshots are byte-identical.
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PageBorders {
+    /// `@w:offsetFrom` (ST_PageBorderOffset §17.18.63): "page" ⇒ each edge's
+    /// `space` is measured from the PAGE edge; "text" (the spec DEFAULT) ⇒ from
+    /// the text margin. Carried verbatim; the renderer positions the rectangle
+    /// accordingly.
+    pub offset_from: String,
+    /// `@w:display` (ST_PageBorderDisplay §17.18.62): "allPages" (default) |
+    /// "firstPage" | "notFirstPage". Governs which physical pages of the section
+    /// show the border.
+    pub display: String,
+    /// `@w:zOrder` (ST_PageBorderZOrder §17.18.64): "front" (default) ⇒ the border
+    /// is painted OVER intersecting text/objects; "back" ⇒ UNDER them.
+    pub z_order: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top: Option<PageBorderEdge>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bottom: Option<PageBorderEdge>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub left: Option<PageBorderEdge>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub right: Option<PageBorderEdge>,
+}
+
+/// ECMA-376 §17.18.4 `CT_Border` as used by one edge of `<w:pgBorders>`. Same
+/// shape as `ParaBorderEdge`: a line style + color + width (pt) + spacing (pt).
+/// Art borders (`@w:val` naming a decorative image, §17.18.2 ST_Border art
+/// values) are NOT modeled — an art `val` is carried verbatim and the renderer
+/// falls back to no ink (documented as unsupported).
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PageBorderEdge {
+    /// `@w:val` — ST_Border line style ("single" | "double" | "dashed" | "dotted"
+    /// | "thick" | …). Reused by the renderer's shared border-line drawing.
+    pub style: String,
+    /// `@w:color` — hex 6, or `None` for "auto" (renderer defaults to black).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    /// `@w:sz` in pt (eighths of a point ÷ 8), like every other CT_Border width.
+    pub width: f64,
+    /// `@w:space` in pt. For page borders `space` is a POINT measure (ST_PointMeasure
+    /// §17.18.68, 0–31), NOT twips — the offset the border is inset by from the
+    /// `offset_from` reference (page edge or text margin).
+    pub space: f64,
+}
+
+/// ECMA-376 §17.6.8 `<w:lnNumType>` — line numbering for a section: a number is
+/// drawn in the left margin of each body line that is a multiple of `count_by`.
+/// `None` on `SectionProps` when the sectPr declares no `<w:lnNumType>` (line
+/// numbering is off — the common case; snapshots stay byte-identical).
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LineNumbering {
+    /// `@w:countBy` (§17.6.8): only lines whose number is an even multiple of this
+    /// value display a number. Required for the struct to exist — an absent
+    /// `countBy` means NO line numbering, so the whole struct is `None` then.
+    pub count_by: i64,
+    /// `@w:start` — the starting line number after each restart. Default 1.
+    pub start: i64,
+    /// `@w:distance` in pt (twips ÷ 20) — the gap between the text margin and the
+    /// line-number glyphs. `None` ⇒ implementation-defined positioning (§17.6.8);
+    /// the renderer uses a default gap then.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distance: Option<f64>,
+    /// `@w:restart` (ST_LineNumberRestart §17.18.47): "newPage" (default) |
+    /// "newSection" | "continuous". When the counter is reset to `start`.
+    pub restart: String,
+}
+
 /// ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — a section's page
 /// geometry: page size + margins + header/footer distances (all pt, converted
 /// from twips). Carried on a `BodyElement::SectionBreak` (`geom`) so mid-body
@@ -310,6 +385,19 @@ pub struct SectionProps {
     /// physical page from this + the per-section `geom.pageNumType`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page_num_type: Option<PageNumType>,
+    /// ECMA-376 §17.6.10 `<w:pgBorders>` — page borders for this section. `None`
+    /// when the sectPr declares none (no page border — the common case).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_borders: Option<PageBorders>,
+    /// ECMA-376 §17.6.8 `<w:lnNumType>` — line numbering for this section. `None`
+    /// when line numbering is off (no `<w:lnNumType countBy>`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_numbering: Option<LineNumbering>,
+    /// ECMA-376 §17.6.23 `<w:vAlign w:val>` — vertical alignment of the body text
+    /// between the top/bottom margins ("top" | "center" | "both" | "bottom").
+    /// `None` ⇒ "top" (the default; body flows from the top margin unchanged).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub v_align: Option<String>,
 }
 
 /// ECMA-376 §17.6.4 `<w:cols>` — the section's multi-column configuration.

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -35,6 +35,11 @@ export type {
   // Per-section page-numbering settings (reachable via SectionProps.pageNumType
   // and the BodyElement sectionBreak arm's `pageNumType`, ECMA-376 §17.6.12).
   PageNumType,
+  // Per-section page decorations (reachable via SectionProps): page borders
+  // (§17.6.10) and line numbering (§17.6.8).
+  PageBorders,
+  PageBorderEdge,
+  LineNumbering,
   // Multi-column section sub-types (reachable via SectionProps.columns).
   ColumnsSpec,
   ColSpec,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,7 +1,7 @@
 import type {
   DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
   DocRun, DocxTextRun, ImageRun, ChartRun, ShapeRun, ShapeFill, TextPath, ShapeText, ShapeTextRun, FieldRun, HeaderFooter, HeadersFooters, LineSpacing, BorderSpec, TableBorders, CellBorders,
-  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, SectionGeom, PageNumType, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr, DocSettings,
+  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, SectionGeom, PageNumType, PageBorders, PageBorderEdge, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr, DocSettings,
 } from './types';
 import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
 import {
@@ -336,6 +336,27 @@ export interface RenderState {
    *  and replays them after the whole page's flow, so front floats land on top.
    *  `null`/absent ⇒ draw in place (headers/footers and measurement passes). */
   deferFront?: Array<() => void> | null;
+  /** ECMA-376 §17.6.8 `<w:lnNumType>` — active line-numbering config for the
+   *  BODY flow of the current section, or `undefined` when line numbering is off.
+   *  When set, {@link drawParagraphLine} draws the line's number in the left
+   *  margin (for lines whose 1-based count is a multiple of `countBy`) and the
+   *  body flow advances {@link lineNumberCounter}. Only the top-level body render
+   *  sets this — nested renders (headers/footers, table cells, notes) clear it so
+   *  their lines are not numbered (§17.6.8 numbers the main document story). */
+  lineNumbering?: {
+    countBy: number;
+    start: number;
+    /** Left-margin gap from the text margin to the number glyphs (pt). */
+    distancePt: number;
+    /** The number font size (pt) — the document's default, so numbers match the
+     *  body baseline grid. */
+    fontSizePt: number;
+  };
+  /** ECMA-376 §17.6.8 — the running body line count for the current page. Seeded
+   *  to `lineNumbering.start` at the top of each page (restart="newPage", the
+   *  default) or to the continued value for continuous/newSection. Incremented
+   *  once per body line drawn (or measured in a dry-run counting pass). */
+  lineNumberCounter?: number;
   /** ECMA-376 §17.6.20 vertical writing (tbRl). When true the page is laid out
    *  in a SWAPPED logical coordinate space (logical width = physical page height)
    *  and the whole page paint is rotated +90° into physical space by
@@ -1213,7 +1234,79 @@ export async function renderDocumentToCanvas(
   // and the header's extent, so a tall header (headerReservePx > 0) pushes the first
   // body line down to the header's bottom. The same overflow shrank the paginated
   // content area from the top (computeHeaderReserves), so the body fits within margins.
-  const bodyState: RenderState = { ...baseState, y: bodyTopPt * scale + headerReservePx };
+  const bodyTopY = bodyTopPt * scale + headerReservePx;
+  const bodyState: RenderState = { ...baseState, y: bodyTopY };
+
+  // ECMA-376 §17.6.8 — line numbering. Seed the body render's per-line counter so
+  // drawParagraphLine numbers each body line. `newPage` (the default) restarts at
+  // `start` on every page; `continuous`/`newSection` need the running total of body
+  // lines on the pages before this one, obtained by a dry-run body render of each
+  // prior page (the counter is advanced there too — the increment is outside the
+  // `!dryRun` ink guard). Header/footer/cell/note renders never carry `lineNumbering`
+  // (bodyState alone sets it; nested states clear it), so only the main document
+  // story (§17.6.8) is numbered. Line numbering runs only for a single-column body:
+  // per-column numbering geometry is not modeled (documented follow-up).
+  const lnCfg = sec.lineNumbering;
+  if (lnCfg && columns.length <= 1) {
+    const lineNumbering = {
+      countBy: lnCfg.countBy,
+      start: lnCfg.start,
+      distancePt: lnCfg.distance ?? LINE_NUMBER_DEFAULT_DISTANCE_PT,
+      fontSizePt: docDefaultFontSizePt(doc),
+    };
+    bodyState.lineNumbering = lineNumbering;
+    let startCount = lnCfg.start;
+    if ((lnCfg.restart === 'continuous' || lnCfg.restart === 'newSection') && pageIndex > 0) {
+      // Count body lines on all prior pages via a dry-run body render, so this
+      // page's numbering continues from the running total. (newSection restarts at
+      // a section boundary; single-section docs — the only fixtures here — have no
+      // interior boundary, so it behaves like continuous. A per-section reset is a
+      // documented follow-up.)
+      let count = lnCfg.start;
+      for (let p = 0; p < pageIndex; p++) {
+        const priorState: RenderState = {
+          ...bodyState,
+          y: 0,
+          dryRun: true,
+          floats: [],
+          lineNumberCounter: count,
+        };
+        renderBodyElements(pages[p] ?? [], priorState, computeColumns(sec), 0);
+        count = priorState.lineNumberCounter ?? count;
+      }
+      startCount = count;
+    }
+    bodyState.lineNumberCounter = startCount;
+  }
+
+  // ECMA-376 §17.6.23 — body vertical alignment (`<w:vAlign>`). "top" (default)
+  // leaves the body at the top margin. "center"/"bottom" measure the total body
+  // content height for THIS page and shift the whole flow down. "both" (vertical
+  // justification by distributing inter-paragraph space) is parsed but not yet
+  // distributed — it falls back to "top" (documented follow-up). vAlign is skipped
+  // when a header pushed the body down (headerReservePx > 0): the reserved area is
+  // not available for centering.
+  const vAlign = sec.vAlign;
+  if ((vAlign === 'center' || vAlign === 'bottom') && headerReservePx === 0) {
+    // Available vertical band between the top and bottom text margins (§17.6.23).
+    const bandTopY = bodyTopPt * scale;
+    const bandBottomY = cssHeight - bodyBottomPt * scale - footerReservePx;
+    const bandH = bandBottomY - bandTopY;
+    // Measure the body content height for this page (dry run; no ink, no counter).
+    const measureState: RenderState = { ...bodyState, y: 0, dryRun: true, floats: [], lineNumbering: undefined, lineNumberCounter: undefined };
+    renderBodyElements(elements, measureState, columns, 0);
+    const contentH = measureState.y;
+    if (contentH < bandH) {
+      const shift = vAlign === 'center' ? (bandH - contentH) / 2 : bandH - contentH;
+      bodyState.y = bandTopY + shift;
+    }
+  }
+
+  // ECMA-376 §17.6.10 — page borders with zOrder="back" are painted UNDER the body
+  // flow (behind intersecting text/objects). Drawn here, before the body.
+  if (sec.pageBorders && sec.pageBorders.zOrder === 'back' && pageBorderShownOnPage(sec.pageBorders, pageIndex)) {
+    drawPageBorders(ctx, sec.pageBorders, sec, scale);
+  }
   // Optional column separator rules (`<w:cols w:sep="1">`), drawn before the text
   // so glyphs sit on top. A thin rule is centred in each inter-column gap and
   // spans the content height. With per-section columns a page can carry more than
@@ -1248,6 +1341,12 @@ export async function renderDocumentToCanvas(
   // page, after the body flow. Minimal impl: a heading-less list at doc end.
   if (pageIndex === totalPages - 1) {
     drawEndnotes(doc, bodyState, scale, cssHeight, sec);
+  }
+
+  // ECMA-376 §17.6.10 — page borders with zOrder="front" (the default) are painted
+  // OVER intersecting text/objects, so draw them LAST (after the whole page flow).
+  if (sec.pageBorders && sec.pageBorders.zOrder !== 'back' && pageBorderShownOnPage(sec.pageBorders, pageIndex)) {
+    drawPageBorders(ctx, sec.pageBorders, sec, scale);
   }
 }
 
@@ -1390,7 +1489,8 @@ function drawEndnotes(
   ctx.stroke();
   ctx.restore();
 
-  const noteState: RenderState = { ...bodyState, y: y + FOOTNOTE_SEPARATOR_GAP_PT * scale };
+  // §17.6.8 numbers the main document story only — endnote lines are not numbered.
+  const noteState: RenderState = { ...bodyState, y: y + FOOTNOTE_SEPARATOR_GAP_PT * scale, lineNumbering: undefined, lineNumberCounter: undefined };
   for (const note of notes) {
     noteState.currentNoteNumber = doc.endnotes.findIndex((n) => n.id === note.id) + 1;
     const paras = note.content.filter((e) => e.type === 'paragraph') as unknown as DocParagraph[];
@@ -1542,6 +1642,78 @@ export function computeColumns(section: SectionProps): ColumnGeom[] {
     out.push({ xPt: section.marginLeft + i * (colW + space), wPt: colW });
   }
   return out;
+}
+
+/** ECMA-376 §17.6.8 — default gap (pt) between the text margin and the line-number
+ *  glyphs when `<w:lnNumType w:distance>` is absent (the spec says the positioning
+ *  is then implementation-defined). Word's default is ~1/4" (≈18pt). */
+const LINE_NUMBER_DEFAULT_DISTANCE_PT = 18;
+
+/** The document's default body font size in pt, used to size line-number glyphs so
+ *  they share the body baseline grid. Resolved from the first body paragraph's
+ *  `defaultFontSize` (which the parser folds from docDefaults + the style chain),
+ *  falling back to 10pt (the ECMA-376 docDefaults sz absent value). */
+function docDefaultFontSizePt(doc: DocxDocumentModel): number {
+  for (const el of doc.body) {
+    if (el.type === 'paragraph') {
+      const p = el as unknown as DocParagraph;
+      if (typeof p.defaultFontSize === 'number') return p.defaultFontSize;
+      for (const run of p.runs) {
+        if (run.type === 'text') return (run as unknown as DocxTextRun).fontSize;
+      }
+    }
+  }
+  return 10;
+}
+
+/** ECMA-376 §17.6.10 `@w:display` (§17.18.62) — whether the section's page borders
+ *  are shown on the physical page at `pageIndex` (0-based within the document; for
+ *  a single-section document this equals the section-relative page index — the
+ *  fixture case). "allPages" (default) ⇒ always; "firstPage" ⇒ only page 0;
+ *  "notFirstPage" ⇒ every page except page 0. */
+function pageBorderShownOnPage(pb: PageBorders, pageIndex: number): boolean {
+  switch (pb.display) {
+    case 'firstPage':
+      return pageIndex === 0;
+    case 'notFirstPage':
+      return pageIndex !== 0;
+    default: // "allPages" and any unknown value
+      return true;
+  }
+}
+
+/** ECMA-376 §17.6.10 — draw a section's page borders as a rectangle inset from the
+ *  page edge (`offsetFrom="page"`) or the text margin (`offsetFrom="text"`, the
+ *  default). Each edge's `space` (pt) is the inset from the reference; `sz`→width
+ *  and `val`→style reuse the shared border-line drawing (single/double/dashed/…).
+ *  Art borders (§17.18.2 decorative-image styles) are unsupported — such a `val`
+ *  yields no drawable dash/line and is skipped. */
+function drawPageBorders(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  pb: PageBorders,
+  sec: SectionProps,
+  scale: number,
+): void {
+  // Reference edges (pt): the page box, or the text-margin box.
+  const fromText = pb.offsetFrom === 'text';
+  const refLeftPt = fromText ? sec.marginLeft : 0;
+  const refRightPt = fromText ? sec.pageWidth - sec.marginRight : sec.pageWidth;
+  const refTopPt = fromText ? bodyMarginInsetPt(sec.marginTop) : 0;
+  const refBottomPt = fromText ? sec.pageHeight - bodyMarginInsetPt(sec.marginBottom) : sec.pageHeight;
+
+  // Each edge is inset from its reference by that edge's `space` (pt), TOWARD the
+  // page interior: the top border moves DOWN, bottom UP, left RIGHT, right LEFT.
+  const asSpec = (e: PageBorderEdge): BorderSpec => ({ width: e.width, color: e.color ?? null, style: e.style });
+  const topY = (refTopPt + (pb.top?.space ?? 0)) * scale;
+  const bottomY = (refBottomPt - (pb.bottom?.space ?? 0)) * scale;
+  const leftX = (refLeftPt + (pb.left?.space ?? 0)) * scale;
+  const rightX = (refRightPt - (pb.right?.space ?? 0)) * scale;
+
+  // The four sides span between the two perpendicular inset lines so corners meet.
+  if (pb.top) drawBorderLine(ctx, leftX, topY, rightX, topY, asSpec(pb.top), scale, 1);
+  if (pb.bottom) drawBorderLine(ctx, leftX, bottomY, rightX, bottomY, asSpec(pb.bottom), scale, 1);
+  if (pb.left) drawBorderLine(ctx, leftX, topY, leftX, bottomY, asSpec(pb.left), scale, 1);
+  if (pb.right) drawBorderLine(ctx, rightX, topY, rightX, bottomY, asSpec(pb.right), scale, 1);
 }
 
 /** ECMA-376 §17.6.11 — the per-page content-area insets (pt) reserved for a header
@@ -6040,7 +6212,43 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     flushBorderGroup();
     if (paraNeedsBidi) ctx.direction = 'ltr'; // reset for subsequent draws
 
+    // ECMA-376 §17.6.8 — line numbering. Each body line advances the section's
+    // line counter; a number is drawn in the left margin when its 1-based count
+    // is an even multiple of countBy. Only the top-level body render sets
+    // `state.lineNumbering` (nested renders clear it), so header/footer/cell/note
+    // lines are never numbered (§17.6.8 numbers the main document story).
+    if (state.lineNumbering && state.lineNumberCounter !== undefined) {
+      const n = state.lineNumberCounter;
+      if (n % state.lineNumbering.countBy === 0 && !dryRun) {
+        drawLineNumber(ctx, n, baseline, contentX, state.lineNumbering, scale, state.defaultColor);
+      }
+      state.lineNumberCounter = n + 1;
+    }
+
     state.y += lineH;
+}
+
+/** ECMA-376 §17.6.8 — draw one line number `n` in the left margin, its RIGHT edge
+ *  `distancePt` to the left of the text margin (`contentX`), aligned to the line's
+ *  `baseline`. The distance attribute is "the distance between the text margin and
+ *  the edge of any line numbers" (§17.6.8). */
+function drawLineNumber(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  n: number,
+  baseline: number,
+  contentX: number,
+  cfg: { distancePt: number; fontSizePt: number },
+  scale: number,
+  color: string,
+): void {
+  ctx.save();
+  ctx.fillStyle = color;
+  ctx.font = buildFont(false, false, cfg.fontSizePt * scale, null, {});
+  const prevAlign = ctx.textAlign;
+  ctx.textAlign = 'right';
+  ctx.fillText(String(n), contentX - cfg.distancePt * scale, baseline);
+  ctx.textAlign = prevAlign;
+  ctx.restore();
 }
 
 // ===== Text layout =====
@@ -8322,6 +8530,10 @@ function renderCell(
     contentX: x + ml,
     contentW: w - ml - mr,
     y: y + mt,
+    // ECMA-376 §17.6.8 numbers the MAIN document story only — table-cell lines are
+    // never numbered. Clear any inherited line-numbering config/counter.
+    lineNumbering: undefined,
+    lineNumberCounter: undefined,
   };
 
   if (cell.vAlign === 'center' || cell.vAlign === 'bottom') {

--- a/packages/docx/src/section-decorations.test.ts
+++ b/packages/docx/src/section-decorations.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxDocumentModel,
+  DocxTextRun,
+  LineNumbering,
+  PageBorders,
+  SectionProps,
+} from './types';
+
+// ECMA-376 §17.6.10 (pgBorders), §17.6.8 (lnNumType), §17.6.23 (vAlign) — the
+// three sectPr page decorations. These tests render a synthetic single-section
+// document through `renderDocumentToCanvas` and read the recording canvas to
+// pin the DRAWN geometry (border rectangle, line-number glyphs, body offset).
+
+const TEST_FONT = 'Synthetic Untabled Serif';
+
+interface FillTextCall { text: string; x: number; y: number; font: string; align: string; }
+interface Seg { x1: number; y1: number; x2: number; y2: number; }
+
+// A crisp-snapped border stroke may be nudged by up to ~0.5 px perpendicular to
+// its direction (see strokeCrispSegment / crispOffset). Match a horizontal rule
+// whose y is within 1 px of the target, and likewise a vertical rule's x.
+function hasHoriz(segs: Seg[], y: number): boolean {
+  return segs.some((s) => Math.abs(s.y1 - s.y2) < 0.5 && Math.abs(s.y1 - y) <= 1);
+}
+function hasVert(segs: Seg[], x: number): boolean {
+  return segs.some((s) => Math.abs(s.x1 - s.x2) < 0.5 && Math.abs(s.x1 - x) <= 1);
+}
+
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fillTextCalls: FillTextCall[];
+  segments: Seg[];
+} {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const fillTextCalls: FillTextCall[] = [];
+  const segments: Seg[] = [];
+  let cur = { x: 0, y: 0 };
+  let align: CanvasTextAlign = 'left';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get textAlign() { return align; },
+    set textAlign(v: CanvasTextAlign) { align = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo(x: number, y: number) { cur = { x, y }; },
+    lineTo(x: number, y: number) { segments.push({ x1: cur.x, y1: cur.y, x2: x, y2: y }); cur = { x, y }; },
+    stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText(text: string, x: number, y: number) {
+      fillTextCalls.push({ text, x, y, font, align });
+    },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fillTextCalls, segments };
+}
+
+function textRun(text: string): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 10, color: null, fontFamily: TEST_FONT, fontFamilyEastAsia: '',
+    isLink: false, background: null, vertAlign: null, hyperlink: null,
+  } as unknown as DocxTextRun;
+}
+
+function para(text: string, opts: Partial<DocParagraph> = {}): BodyElement {
+  return {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{ type: 'text', ...textRun(text) }],
+    defaultFontSize: 10, defaultFontFamily: TEST_FONT,
+    widowControl: false,
+    ...opts,
+  } as unknown as BodyElement;
+}
+
+function section(over: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 200, pageHeight: 200,
+    marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 40,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    ...over,
+  } as SectionProps;
+}
+
+function docOf(body: BodyElement[], sec: SectionProps): DocxDocumentModel {
+  return {
+    section: sec,
+    body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { [TEST_FONT]: 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(doc: DocxDocumentModel, pageIndex = 0) {
+  const rec = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc, rec.canvas, pageIndex, {
+    dpr: 1,
+    width: 200, // scale = 1 (px per pt) ⇒ asserts are in pt units
+  });
+  return rec;
+}
+
+// ============================================================================
+// §17.6.10 — page borders
+// ============================================================================
+
+describe('§17.6.10 pgBorders — page border rectangle', () => {
+  const edge = (over = {}) => ({ style: 'single', color: 'ff0000', width: 1, space: 24, ...over });
+
+  it('offsetFrom="page": each edge is inset from the PAGE edge by its space (pt)', async () => {
+    const pb: PageBorders = {
+      offsetFrom: 'page', display: 'allPages', zOrder: 'front',
+      top: edge(), bottom: edge(), left: edge(), right: edge(),
+    };
+    const { segments } = await render(docOf([para('body')], section({ pageBorders: pb })));
+    // Four axis-aligned segments forming a rectangle inset 24 pt from every page
+    // edge. Page is 200×200 at scale 1 ⇒ rectangle [24,24]–[176,176].
+    expect(hasHoriz(segments, 24)).toBe(true);   // top
+    expect(hasHoriz(segments, 176)).toBe(true);  // bottom (200 - 24)
+    expect(hasVert(segments, 24)).toBe(true);    // left
+    expect(hasVert(segments, 176)).toBe(true);   // right
+  });
+
+  it('offsetFrom="text": each edge is inset from the TEXT MARGIN by its space', async () => {
+    const pb: PageBorders = {
+      offsetFrom: 'text', display: 'allPages', zOrder: 'front',
+      top: edge({ space: 4 }), left: edge({ space: 4 }),
+      bottom: edge({ space: 4 }), right: edge({ space: 4 }),
+    };
+    // margins: top/bottom 20, left 40, right 20 ⇒ text box [40,20]–[180,180].
+    // +4 pt inset ⇒ rectangle [44,24]–[176,176].
+    const { segments } = await render(docOf([para('body')], section({ pageBorders: pb })));
+    expect(hasHoriz(segments, 24)).toBe(true);   // top margin 20 + 4
+    expect(hasHoriz(segments, 176)).toBe(true);  // bottom margin (200-20) - 4
+    expect(hasVert(segments, 44)).toBe(true);    // left margin 40 + 4
+    expect(hasVert(segments, 176)).toBe(true);   // right margin (200-20) - 4
+  });
+
+  it('display="firstPage" shows the border only on page 0', async () => {
+    const pb: PageBorders = { offsetFrom: 'page', display: 'firstPage', zOrder: 'front', top: edge() };
+    const twoPages = [para('a'), { type: 'pageBreak' } as BodyElement, para('b')];
+    const p0 = await render(docOf(twoPages, section({ pageBorders: pb })), 0);
+    const p1 = await render(docOf(twoPages, section({ pageBorders: pb })), 1);
+    expect(hasHoriz(p0.segments, 24)).toBe(true);
+    expect(hasHoriz(p1.segments, 24)).toBe(false);
+  });
+
+  it('display="notFirstPage" hides the border on page 0, shows it later', async () => {
+    const pb: PageBorders = { offsetFrom: 'page', display: 'notFirstPage', zOrder: 'front', top: edge() };
+    const twoPages = [para('a'), { type: 'pageBreak' } as BodyElement, para('b')];
+    const p0 = await render(docOf(twoPages, section({ pageBorders: pb })), 0);
+    const p1 = await render(docOf(twoPages, section({ pageBorders: pb })), 1);
+    expect(hasHoriz(p0.segments, 24)).toBe(false);
+    expect(hasHoriz(p1.segments, 24)).toBe(true);
+  });
+
+  it('no pgBorders ⇒ no border rectangle drawn (non-regression)', async () => {
+    const { segments } = await render(docOf([para('body')], section()));
+    // A plain paragraph draws no long axis-aligned rules at a border inset.
+    expect(hasHoriz(segments, 24)).toBe(false);
+  });
+});
+
+// ============================================================================
+// §17.6.8 — line numbering
+// ============================================================================
+
+describe('§17.6.8 lnNumType — line numbering', () => {
+  const ln = (over: Partial<LineNumbering> = {}): LineNumbering =>
+    ({ countBy: 1, start: 1, distance: 10, restart: 'newPage', ...over });
+
+  it('countBy=1 numbers every body line in the left margin, right-aligned', async () => {
+    const doc = docOf([para('one'), para('two'), para('three')], section({ lineNumbering: ln() }));
+    const { fillTextCalls } = await render(doc);
+    const numbers = fillTextCalls.filter((c) => /^\d+$/.test(c.text));
+    expect(numbers.map((n) => n.text)).toEqual(['1', '2', '3']);
+    // Right edge sits distance(10) pt left of the text margin (marginLeft 40) ⇒ x=30.
+    for (const n of numbers) {
+      expect(n.x).toBeCloseTo(30, 2);
+      expect(n.align).toBe('right');
+    }
+  });
+
+  it('countBy=2 numbers only every 2nd line', async () => {
+    const doc = docOf(
+      [para('a'), para('b'), para('c'), para('d')],
+      section({ lineNumbering: ln({ countBy: 2 }) }),
+    );
+    const { fillTextCalls } = await render(doc);
+    const numbers = fillTextCalls.filter((c) => /^\d+$/.test(c.text)).map((n) => n.text);
+    expect(numbers).toEqual(['2', '4']);
+  });
+
+  it('start=5 begins the counter at 5', async () => {
+    const doc = docOf([para('a'), para('b')], section({ lineNumbering: ln({ start: 5 }) }));
+    const { fillTextCalls } = await render(doc);
+    const numbers = fillTextCalls.filter((c) => /^\d+$/.test(c.text)).map((n) => n.text);
+    expect(numbers).toEqual(['5', '6']);
+  });
+
+  it('restart="newPage" restarts the counter at `start` on every page', async () => {
+    const body = [para('a'), para('b'), { type: 'pageBreak' } as BodyElement, para('c'), para('d')];
+    const doc = docOf(body, section({ lineNumbering: ln({ restart: 'newPage' }) }));
+    const p1 = await render(doc, 1);
+    const numbers = p1.fillTextCalls.filter((c) => /^\d+$/.test(c.text)).map((n) => n.text);
+    // Page 1 restarts at 1 (newPage), so its two lines are 1,2 (NOT 3,4).
+    expect(numbers).toEqual(['1', '2']);
+  });
+
+  it('restart="continuous" continues the counter across pages', async () => {
+    const body = [para('a'), para('b'), { type: 'pageBreak' } as BodyElement, para('c'), para('d')];
+    const doc = docOf(body, section({ lineNumbering: ln({ restart: 'continuous' }) }));
+    const p1 = await render(doc, 1);
+    const numbers = p1.fillTextCalls.filter((c) => /^\d+$/.test(c.text)).map((n) => n.text);
+    // Page 0 drew lines 1,2 ⇒ page 1 continues at 3,4.
+    expect(numbers).toEqual(['3', '4']);
+  });
+
+  it('no lnNumType ⇒ no line numbers drawn (non-regression)', async () => {
+    const { fillTextCalls } = await render(docOf([para('a'), para('b')], section()));
+    expect(fillTextCalls.filter((c) => /^\d+$/.test(c.text))).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// §17.6.23 — vertical alignment
+// ============================================================================
+
+describe('§17.6.23 vAlign — body vertical alignment', () => {
+  // One 10 pt line: ascent 8, descent 2. Body band = [20, 180] (margins 20/20)
+  // ⇒ band height 160, content height ~10.
+  it('vAlign="center" shifts the body to the vertical centre of the text band', async () => {
+    const top = await render(docOf([para('x')], section()));
+    const centered = await render(docOf([para('x')], section({ vAlign: 'center' })));
+    const topX = top.fillTextCalls.find((c) => c.text === 'x')!;
+    const midX = centered.fillTextCalls.find((c) => c.text === 'x')!;
+    // Top-aligned baseline sits near the top margin (20 + ascent 8 = 28).
+    expect(topX.y).toBeCloseTo(28, 1);
+    // Centred baseline sits ~ (band centre 100) − halfLine + ascent ≈ 20 + 75 + 8.
+    // Band 160, content 10 ⇒ shift (160-10)/2 = 75. New top 20+75=95, baseline 95+8=103.
+    expect(midX.y).toBeCloseTo(103, 1);
+  });
+
+  it('vAlign="bottom" pushes the body to the bottom margin', async () => {
+    const bottom = await render(docOf([para('x')], section({ vAlign: 'bottom' })));
+    const bx = bottom.fillTextCalls.find((c) => c.text === 'x')!;
+    // Shift = band(160) − content(10) = 150. New top 20+150=170, baseline 170+8=178.
+    // Inked bottom = baseline + descent(2) = 180 = bottom margin.
+    expect(bx.y + 10 * 0.2).toBeCloseTo(180, 1);
+  });
+
+  it('vAlign="top" (default) leaves the body at the top margin (non-regression)', async () => {
+    const noAlign = await render(docOf([para('x')], section()));
+    const topAlign = await render(docOf([para('x')], section({ vAlign: 'top' })));
+    const a = noAlign.fillTextCalls.find((c) => c.text === 'x')!;
+    const b = topAlign.fillTextCalls.find((c) => c.text === 'x')!;
+    expect(a.y).toBeCloseTo(b.y, 2);
+  });
+});

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -154,6 +154,59 @@ export interface PageNumType {
   fmt?: string;
 }
 
+/** ECMA-376 §17.6.10 `<w:pgBorders>` — page borders drawn around each page of a
+ *  section. Mirrors the Rust `PageBorders`. Each edge is a CT_Border (§17.18.4);
+ *  the container carries the placement globals. Absent on {@link SectionProps}
+ *  (`pageBorders` undefined) ⇒ no page border (the common case). Art borders
+ *  (§17.18.2 decorative-image styles) are unsupported — the renderer draws only
+ *  the standard line styles (single/double/dashed/dotted/thick/…). */
+export interface PageBorders {
+  /** `@w:offsetFrom` (§17.18.63): "page" ⇒ each edge's `space` is from the PAGE
+   *  edge; "text" (the default) ⇒ from the text margin. */
+  offsetFrom: string;
+  /** `@w:display` (§17.18.62): "allPages" (default) | "firstPage" |
+   *  "notFirstPage" — which physical pages of the section show the border. */
+  display: string;
+  /** `@w:zOrder` (§17.18.64): "front" (default; over text) | "back" (under). */
+  zOrder: string;
+  top?: PageBorderEdge;
+  bottom?: PageBorderEdge;
+  left?: PageBorderEdge;
+  right?: PageBorderEdge;
+}
+
+/** ECMA-376 §17.18.4 CT_Border for one edge of `<w:pgBorders>`. Mirrors the Rust
+ *  `PageBorderEdge`. Same shape as a paragraph border edge. */
+export interface PageBorderEdge {
+  /** `@w:val` — ST_Border line style ("single" | "double" | "dashed" | …). */
+  style: string;
+  /** `@w:color` hex 6, or absent for "auto" (renderer defaults to black). */
+  color?: string;
+  /** `@w:sz` in pt (eighths of a point ÷ 8). */
+  width: number;
+  /** `@w:space` in pt — a POINT measure (§17.18.68, 0–31) for page borders, NOT
+   *  twips — the inset from the `offsetFrom` reference. */
+  space: number;
+}
+
+/** ECMA-376 §17.6.8 `<w:lnNumType>` — line numbering for a section. Mirrors the
+ *  Rust `LineNumbering`. A number is drawn in the left margin of each body line
+ *  whose count is a multiple of `countBy`. Absent on {@link SectionProps}
+ *  (`lineNumbering` undefined) ⇒ line numbering off. */
+export interface LineNumbering {
+  /** `@w:countBy` — only lines whose number is a multiple of this display a
+   *  number. Required (absent ⇒ the whole struct is absent per §17.6.8). */
+  countBy: number;
+  /** `@w:start` — the starting number after each restart. Default 1. */
+  start: number;
+  /** `@w:distance` in pt (twips ÷ 20) — gap between the text margin and the
+   *  number glyphs. Absent ⇒ implementation-defined (renderer uses a default). */
+  distance?: number;
+  /** `@w:restart` (§17.18.47): "newPage" (default) | "newSection" |
+   *  "continuous" — when the counter resets to `start`. */
+  restart: string;
+}
+
 /** ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — a section's page
  *  geometry: page size + margins + header/footer distances (pt). Mirrors the Rust
  *  `SectionGeom`. Carried on a {@link BodyElement} `sectionBreak` arm (`geom`) so a
@@ -237,6 +290,18 @@ export interface SectionProps {
    *  renderer resolves the displayed page number per physical page from this plus
    *  the per-section `SectionBreak.pageNumType` markers. */
   pageNumType?: PageNumType | null;
+  /** ECMA-376 §17.6.10 `<w:pgBorders>` — page borders for this section.
+   *  `null`/absent ⇒ no page border (the common case). */
+  pageBorders?: PageBorders | null;
+  /** ECMA-376 §17.6.8 `<w:lnNumType>` — line numbering for this section.
+   *  `null`/absent ⇒ line numbering off. */
+  lineNumbering?: LineNumbering | null;
+  /** ECMA-376 §17.6.23 `<w:vAlign w:val>` — body vertical alignment between the
+   *  top/bottom margins ("top" | "center" | "both" | "bottom"). `null`/absent ⇒
+   *  "top" (body flows from the top margin unchanged). "both" (vertical
+   *  justification) is parsed but rendered as "top" until distribution is
+   *  implemented (see renderer note). */
+  vAlign?: string | null;
 }
 
 /** ECMA-376 §17.6.4 `<w:cols>` — the section's multi-column configuration. */

--- a/packages/node/src/docx-section-decorations.probe.test.ts
+++ b/packages/node/src/docx-section-decorations.probe.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { deflateRawSync, crc32 } from 'node:zlib';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+/**
+ * WD6 end-to-end WASM boundary probe: build a minimal synthetic `.docx` in
+ * memory carrying `<w:sectPr>` with `<w:pgBorders>` (§17.6.10), `<w:lnNumType>`
+ * (§17.6.8), and `<w:vAlign>` (§17.6.23), parse it through the REAL WASM docx
+ * parser, and assert the resolved `DocxDocumentModel.section` carries the three
+ * decorations with the exact camelCase field names the TS renderer reads. This
+ * proves the Rust → JSON → TS serialization contract (the Rust unit tests cover
+ * the parse logic; the docx renderer unit tests cover the drawing; this closes
+ * the loop across the WASM boundary with no hand-built model).
+ *
+ * skia is only needed to import the docx WASM glue in node (the module statically
+ * imports git-ignored WASM); absent → skip cleanly, OOXML_REQUIRE_SKIA=1 → hard
+ * fail (CI).
+ */
+const skia = await loadSkiaForTests();
+const docxMod = skia ? await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)') : null;
+
+// ---- minimal ZIP (store + deflate) writer -------------------------------------
+// The Rust `zip` crate reads both stored (method 0) and deflated (method 8)
+// entries. We deflate each part (raw DEFLATE) and assemble a compliant local-
+// file-header + central-directory ZIP by hand — no third-party zip dependency.
+interface Entry { name: string; data: Buffer; }
+
+function u16(n: number): Buffer { const b = Buffer.alloc(2); b.writeUInt16LE(n >>> 0, 0); return b; }
+function u32(n: number): Buffer { const b = Buffer.alloc(4); b.writeUInt32LE(n >>> 0, 0); return b; }
+
+function buildZip(entries: Entry[]): Buffer {
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
+  for (const e of entries) {
+    const nameBuf = Buffer.from(e.name, 'utf8');
+    const comp = deflateRawSync(e.data);
+    const crc = crc32(e.data) >>> 0;
+    const local = Buffer.concat([
+      u32(0x04034b50), u16(20), u16(0), u16(8), // sig, ver, flags, method=deflate
+      u16(0), u16(0), // time, date
+      u32(crc), u32(comp.length), u32(e.data.length),
+      u16(nameBuf.length), u16(0), // name len, extra len
+      nameBuf, comp,
+    ]);
+    locals.push(local);
+    const central = Buffer.concat([
+      u32(0x02014b50), u16(20), u16(20), u16(0), u16(8),
+      u16(0), u16(0), u32(crc), u32(comp.length), u32(e.data.length),
+      u16(nameBuf.length), u16(0), u16(0), u16(0), u16(0), u32(0),
+      u32(offset), nameBuf,
+    ]);
+    centrals.push(central);
+    offset += local.length;
+  }
+  const centralDir = Buffer.concat(centrals);
+  const localData = Buffer.concat(locals);
+  const eocd = Buffer.concat([
+    u32(0x06054b50), u16(0), u16(0),
+    u16(entries.length), u16(entries.length),
+    u32(centralDir.length), u32(localData.length), u16(0),
+  ]);
+  return Buffer.concat([localData, centralDir, eocd]);
+}
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`;
+
+const ROOT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function documentXml(sectPrInner: string): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${W}">
+  <w:body>
+    <w:p><w:r><w:t>line one</w:t></w:r></w:p>
+    <w:p><w:r><w:t>line two</w:t></w:r></w:p>
+    <w:sectPr>
+      <w:pgSz w:w="12240" w:h="15840"/>
+      <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/>
+      ${sectPrInner}
+    </w:sectPr>
+  </w:body>
+</w:document>`;
+}
+
+function makeDocx(sectPrInner: string): Uint8Array {
+  return buildZip([
+    { name: '[Content_Types].xml', data: Buffer.from(CONTENT_TYPES, 'utf8') },
+    { name: '_rels/.rels', data: Buffer.from(ROOT_RELS, 'utf8') },
+    { name: 'word/document.xml', data: Buffer.from(documentXml(sectPrInner), 'utf8') },
+  ]);
+}
+
+describe.skipIf(!skia)('WD6 sectPr decorations — WASM parse boundary', () => {
+  const parse = (sectPrInner: string) => {
+    const { parseDocx } = docxMod as unknown as { parseDocx: (b: Uint8Array) => { section: Record<string, unknown> } };
+    return parseDocx(makeDocx(sectPrInner));
+  };
+
+  it('§17.6.10 pgBorders round-trips to section.pageBorders with camelCase edges', () => {
+    const doc = parse(
+      `<w:pgBorders w:offsetFrom="page" w:zOrder="back" w:display="firstPage">
+         <w:top w:val="dashed" w:sz="24" w:space="24" w:color="FF0000"/>
+         <w:left w:val="single" w:sz="8" w:space="12" w:color="auto"/>
+       </w:pgBorders>`,
+    );
+    const pb = doc.section.pageBorders as Record<string, unknown>;
+    expect(pb).toBeTruthy();
+    expect(pb.offsetFrom).toBe('page');
+    expect(pb.zOrder).toBe('back');
+    expect(pb.display).toBe('firstPage');
+    const top = pb.top as Record<string, unknown>;
+    expect(top.style).toBe('dashed');
+    expect(top.width).toBeCloseTo(3, 6);   // sz 24 / 8
+    expect(top.space).toBeCloseTo(24, 6);  // POINTS, not twips
+    expect(top.color).toBe('ff0000');
+    const left = pb.left as Record<string, unknown>;
+    expect(left.color).toBeUndefined();    // auto ⇒ omitted
+    expect(pb.bottom).toBeUndefined();
+    expect(pb.right).toBeUndefined();
+  });
+
+  it('§17.6.8 lnNumType round-trips to section.lineNumbering', () => {
+    const doc = parse(`<w:lnNumType w:countBy="5" w:start="3" w:distance="720" w:restart="continuous"/>`);
+    const ln = doc.section.lineNumbering as Record<string, unknown>;
+    expect(ln).toBeTruthy();
+    expect(ln.countBy).toBe(5);
+    expect(ln.start).toBe(3);
+    expect(ln.distance).toBeCloseTo(36, 6); // 720 twips ⇒ pt
+    expect(ln.restart).toBe('continuous');
+  });
+
+  it('§17.6.23 vAlign round-trips to section.vAlign (default "top" ⇒ omitted)', () => {
+    expect(parse(`<w:vAlign w:val="center"/>`).section.vAlign).toBe('center');
+    expect(parse(`<w:vAlign w:val="both"/>`).section.vAlign).toBe('both');
+    expect(parse(`<w:vAlign w:val="top"/>`).section.vAlign).toBeUndefined();
+  });
+
+  it('a bare sectPr carries none of the three (non-regression: fields omitted)', () => {
+    const doc = parse('');
+    expect(doc.section.pageBorders).toBeUndefined();
+    expect(doc.section.lineNumbering).toBeUndefined();
+    expect(doc.section.vAlign).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements **WD6**: parse and render three `<w:sectPr>` decorations that were previously ignored.

| Feature | Spec | Status |
| --- | --- | --- |
| Page borders (`<w:pgBorders>`) | §17.6.10 | ✅ standard line styles; art borders unsupported (documented) |
| Line numbering (`<w:lnNumType>`) | §17.6.8 | ✅ countBy/start/distance; restart newPage + continuous |
| Vertical alignment (`<w:vAlign>`) | §17.6.23 | ✅ top/center/bottom; `both` falls back to top (follow-up) |

## Parser (§17.6.10 / §17.6.8 / §17.6.23)

- `PageBorders { offsetFrom, display, zOrder, top/left/bottom/right: PageBorderEdge }`. Defaults per spec: `offsetFrom="text"` (§17.18.63), `display="allPages"` (§17.18.62), `zOrder="front"` (§17.18.64). Each edge is a CT_Border (§17.18.4): `sz` in eighths of a point, `space` a **point** measure (§17.18.68, not twips). An all-nil/none or absent element ⇒ `None`.
- `LineNumbering { countBy, start, distance, restart }`. `countBy` is required (absent ⇒ no line numbering per §17.6.8); `start` defaults to 1, `restart` to `"newPage"` (§17.18.47), `distance` twips→pt.
- `vAlign` (§17.18.101: top/center/both/bottom); the default `"top"` is dropped to `None` so top-aligned documents serialize unchanged.

## Renderer

- **pgBorders** — `drawPageBorders` strokes a rectangle inset from the page edge or text margin per `offsetFrom`, each edge inset toward the interior by its `space`. `display` gates the physical pages; `zOrder="back"` draws under the body flow, `"front"` (default) over it. Reuses the existing border-line drawing (single/double/dashed/dotted/thick/…).
- **lnNumType** — `drawParagraphLine` advances a per-body-line counter and draws the number right-aligned `distance` pt left of the text margin, for lines whose count is a multiple of `countBy`. `newPage` reseeds each page; `continuous`/`newSection` continue from the running total of prior pages (dry-run count). Only the **main document story** is numbered — header/footer/table-cell/note renders clear the config (§17.6.8).
- **vAlign** — `center`/`bottom` measure the page's body content height (dry run) and shift the whole flow within the top/bottom text band; `top` unchanged.

## Scope notes (documented follow-ups)

- Art page borders (§17.18.2 decorative-image styles) are not drawn.
- `vAlign="both"` (vertical justification by inter-paragraph distribution) is parsed but renders as `top`.
- Line numbering runs for a single-column body; per-column numbering geometry and per-section decoration threading are follow-ups (the body-level sectPr — the common case — is covered).

## Tests & verification

- **Rust** (`cargo test`): +3 parse tests (249 total pass); fmt + clippy clean.
- **TS** (`vitest`): `section-decorations.test.ts` (14 cases: border rect geometry for page/text offset, display gating, line-number counter/restart, vAlign offsets, non-regression). Full docx suite 730/730 pass.
- **WASM boundary** (`docx-section-decorations.probe.test.ts`): a hand-assembled synthetic `.docx` is parsed through the real WASM parser and the three decorations round-trip with the exact camelCase contract.
- **VRT**: `demo/sample-1` unchanged (no sectPr decorations ⇒ byte-identical body/border output). `private/sample-*` are 404 (git-ignored fixtures absent in CI/worktree), not regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)