### PR TITLE
fix(charts): place solid-pie ctr data labels near the rim (§21.2.2.48)

### DIFF
--- a/packages/core/src/chart/renderer-scatter-line-and-pie-labels.test.ts
+++ b/packages/core/src/chart/renderer-scatter-line-and-pie-labels.test.ts
@@ -63,19 +63,23 @@ function series(over: Partial<ChartSeries>): ChartSeries {
   return { name: '', color: null, values: [], ...over };
 }
 
-interface TextCall { text: string; fillStyle: string }
+interface TextCall { text: string; fillStyle: string; x: number; y: number }
 
 /** Recording context that captures: (a) `stroke()` calls that follow a
  *  `moveTo`/`lineTo` path with ≥2 vertices AND whose strokeStyle is `matchColor`
  *  (the series line color) — this isolates the scatter connecting line from
  *  gridlines/axis rules, which stroke in grey; (b) `fillText` calls with the
  *  fillStyle in effect. Enough to assert the scatter line pass and pie labels. */
+interface ArcCall { cx: number; cy: number; r: number }
+
 function recordingCtx(matchColor = '#4f81bd'): {
   ctx: CanvasRenderingContext2D;
   counts: { polylineStrokes: number };
   texts: TextCall[];
+  arcs: ArcCall[];
 } {
   const texts: TextCall[] = [];
+  const arcs: ArcCall[] = [];
   const counts = { polylineStrokes: 0 };
   let pathVerts = 0;
   const state: Record<string, unknown> = {
@@ -106,6 +110,12 @@ function recordingCtx(matchColor = '#4f81bd'): {
           };
         case 'beginPath':
           return () => { pathVerts = 0; };
+        // Pie/doughnut slices are drawn with `arc(cx, cy, r, …)`; recording the
+        // centre + radius lets a test recover the exact pie geometry the renderer
+        // used (the outermost rim is the max-radius arc) without duplicating the
+        // frame math.
+        case 'arc':
+          return (cx: number, cy: number, r: number) => { arcs.push({ cx, cy, r }); };
         case 'moveTo':
         case 'lineTo':
         case 'bezierCurveTo':
@@ -121,8 +131,8 @@ function recordingCtx(matchColor = '#4f81bd'): {
             }
           };
         case 'fillText':
-          return (text: string) =>
-            texts.push({ text, fillStyle: String(state.fillStyle) });
+          return (text: string, x: number, y: number) =>
+            texts.push({ text, fillStyle: String(state.fillStyle), x, y });
         case 'createLinearGradient':
         case 'createRadialGradient':
           return () => ({ addColorStop() {} });
@@ -136,7 +146,16 @@ function recordingCtx(matchColor = '#4f81bd'): {
     ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D,
     counts,
     texts,
+    arcs,
   };
+}
+
+/** Recover the pie/doughnut centre + outer radius from recorded `arc()` calls.
+ *  The outermost rim is the arc with the largest radius; every slice on that ring
+ *  shares the same centre. */
+function pieGeometry(arcs: ArcCall[]): { cx: number; cy: number; outerR: number } {
+  const outer = arcs.reduce((a, b) => (b.r > a.r ? b : a));
+  return { cx: outer.cx, cy: outer.cy, outerR: outer.r };
 }
 
 describe('scatter series-line noFill overrides scatterStyle (§21.2.2.198)', () => {
@@ -239,5 +258,76 @@ describe('pie per-point dLbl flags override series defaults (§21.2.2.47)', () =
     const pctLabels = rec.texts.filter(t => /^\d+%$/.test(t.text));
     // Two slices labeled (idx 1,2); the deleted idx 0 is skipped.
     expect(pctLabels.length).toBe(2);
+  });
+});
+
+describe('pie / doughnut ctr data-label radius (§21.2.2.48, PowerPoint layout)', () => {
+  // Radial placement of `ctr` (and default) data labels, verified against the
+  // sample-14.pdf ground truth (PowerPoint's own render):
+  //   • SOLID pie   → labels sit near the rim at ≈0.88·outerR (measured 0.878 /
+  //     0.888 / 0.887 / 0.912 across the 54/27/14/5% slices; center + outer
+  //     radius from a least-squares rim fit, residual std 0.43pt). PowerPoint
+  //     does NOT place a pie `ctr` label at the disc's geometric mid-radius.
+  //   • DOUGHNUT    → labels sit at the RING midpoint (innerR+outerR)/2. For the
+  //     55% hole this is 0.775·outerR, matching the PDF (measured 0.772–0.778
+  //     across all five slices). This branch must not move.
+  const pieModel = (chartType: 'pie' | 'doughnut', position?: string): ChartModel =>
+    baseModel({
+      chartType,
+      showDataLabels: true,
+      holeSize: chartType === 'doughnut' ? 55 : undefined,
+      categories: ['A', 'B', 'C', 'D'],
+      series: [series({
+        name: 'Share',
+        values: [54, 27, 14, 5],
+        categories: ['A', 'B', 'C', 'D'],
+        dataPointColors: ['ff0000', '00ff00', '0000ff', 'ffff00'],
+        seriesDataLabels: {
+          showVal: false, showCatName: false, showSerName: false, showPercent: true,
+          fontColor: 'FFFFFF', fontBold: true, formatCode: '0%',
+          ...(position ? { position } : {}),
+        },
+      })],
+    });
+
+  it('places SOLID-pie ctr labels near the rim (≈0.88R), not at mid-radius', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, pieModel('pie', 'ctr'), RECT, 1);
+    const { cx, cy, outerR } = pieGeometry(rec.arcs);
+    const labels = rec.texts.filter(t => /^\d+%$/.test(t.text));
+    expect(labels.length).toBe(4);
+    for (const l of labels) {
+      const ratio = Math.hypot(l.x - cx, l.y - cy) / outerR;
+      // Near the rim: comfortably beyond mid-radius, inside the outer edge.
+      expect(ratio).toBeGreaterThan(0.8);
+      expect(ratio).toBeLessThan(1.0);
+      // And specifically close to the PowerPoint-measured ≈0.88 constant.
+      expect(Math.abs(ratio - 0.88)).toBeLessThan(0.06);
+    }
+  });
+
+  it('keeps DOUGHNUT ctr labels at the ring midpoint (0.775R for a 55% hole)', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, pieModel('doughnut'), RECT, 1);
+    const { cx, cy, outerR } = pieGeometry(rec.arcs);
+    const labels = rec.texts.filter(t => /^\d+%$/.test(t.text));
+    expect(labels.length).toBeGreaterThan(0);
+    for (const l of labels) {
+      const ratio = Math.hypot(l.x - cx, l.y - cy) / outerR;
+      // (innerR + outerR)/2 with innerR = 0.55·outerR ⇒ 0.775.
+      expect(Math.abs(ratio - 0.775)).toBeLessThan(0.02);
+    }
+  });
+
+  it('still pushes outEnd pie labels OUTSIDE the rim', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, pieModel('pie', 'outEnd'), RECT, 1);
+    const { cx, cy, outerR } = pieGeometry(rec.arcs);
+    const labels = rec.texts.filter(t => /^\d+%$/.test(t.text));
+    expect(labels.length).toBe(4);
+    for (const l of labels) {
+      const ratio = Math.hypot(l.x - cx, l.y - cy) / outerR;
+      expect(ratio).toBeGreaterThan(1.0);
+    }
   });
 });

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -2606,6 +2606,16 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
 // Pie / Doughnut — supports dataPointColors (per slice).
 // ═══════════════════════════════════════════════════════════════════════════
 
+/** Inside-radius fraction (of the outer radius) for a SOLID pie's `ctr` / `inEnd`
+ *  / `bestFit` data labels (§21.2.2.48). PowerPoint places these near the rim,
+ *  not at the disc mid-radius: measured from sample-14.pdf, the 54/27/14/5%
+ *  slice labels sit at 0.878 / 0.888 / 0.887 / 0.912·outerR — a flat near-rim
+ *  constant independent of slice angle (see the `labelR` comment in
+ *  {@link drawPieRichLabels}). 0.88 is the empirical fit; it is an approximation
+ *  of an undocumented PowerPoint layout, not a spec-defined geometry. Doughnut
+ *  labels use the exact ring midpoint instead and never consult this. */
+const PIE_CTR_LABEL_RADIUS_FRAC = 0.88;
+
 function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: ChartRect, isDoughnut: boolean, ptToPx: number): void {
   const { x, y, w, h } = r;
   const s = chart.series[0]; if (!s) return;
@@ -2808,8 +2818,7 @@ function drawPieRichLabels(
     const showPercent = ov?.showPercent ?? def.showPercent;
     // §21.2.2.35 label composition. A per-point custom `<c:tx>` (non-empty
     // override text) wins outright; otherwise compose from the resolved flags.
-    // dLblPos: "outEnd" places the label just beyond the rim; "inEnd"/"ctr"
-    // (and default) sit inside the slice at the radial midpoint. Percent is the
+    // Positioning is handled below (§21.2.2.48 `dLblPos`). Percent is the
     // slice's share of the total.
     let text: string;
     if (ov && ov.text) {
@@ -2825,9 +2834,28 @@ function drawPieRichLabels(
     if (!text) continue;
     const pos = ov?.position ?? def.position ?? 'bestFit';
     const outside = pos === 'outEnd';
+    // §21.2.2.48 ST_DLblPos radial placement. The spec enumerates the positions
+    // (bestFit / ctr / inEnd / outEnd …) but gives no geometry, so the inside
+    // radii below reproduce PowerPoint's own layout, measured from sample-14.pdf
+    // (PowerPoint's render of slide-7's pie + doughnut):
+    //
+    //   • outEnd → just beyond the rim (leader-line territory).
+    //   • DOUGHNUT (innerR > 0), ctr / inEnd / bestFit → the RING midpoint
+    //     (innerR + outerR)/2. Verified on the 55%-hole doughnut: labels sit at
+    //     0.772–0.778·outerR ≈ (0.55+1)/2 = 0.775. Byte-stable — unchanged.
+    //   • SOLID pie (innerR ≈ 0), ctr / inEnd / bestFit → ≈0.88·outerR, NOT the
+    //     disc mid-radius. Measured label-centroid ratios across the 54/27/14/5%
+    //     slices were 0.878 / 0.888 / 0.887 / 0.912 (center + outer radius from a
+    //     least-squares rim fit, residual std 0.43pt), i.e. a flat near-rim
+    //     constant independent of slice angle — so it is a fixed fraction, not a
+    //     sector centroid. The 5% sliver rides marginally further out in
+    //     PowerPoint; we do not model that per-slice nudge. This is an empirical
+    //     approximation of an undocumented PowerPoint layout, not a spec formula.
     const labelR = outside
       ? outerR + Math.max(10, outerR * 0.12)
-      : (innerR + outerR) / 2;
+      : innerR > 0.01
+        ? (innerR + outerR) / 2
+        : outerR * PIE_CTR_LABEL_RADIUS_FRAC;
     const lx2 = cx2 + Math.cos(midAngle) * labelR;
     const ly2 = cy2 + Math.sin(midAngle) * labelR;
     const sizeHpt = ov?.fontSizeHpt ?? def.fontSizeHpt;


### PR DESCRIPTION
## Problem

On sample-14 slide-7, PowerPoint places the solid pie's percent labels
(`54% / 27% / 14% / 5%`, chart6, `<c:dLblPos val=\"ctr\"/>`) **near the outer
rim**, but the renderer put them at **half the radius** (mid-disc). The
neighbouring doughnut (chart7) was already correct.

## Root cause

`drawPieRichLabels` positioned every non-`outEnd` label at the ring midpoint
`(innerR + outerR) / 2`. That is right for a doughnut but, for a **solid pie**
(`innerR = 0`), collapses to `0.5·outerR`.

## Ground truth (measured from sample-14.pdf)

Center + outer radius come from a least-squares fit to the pie's outer rim
(residual std 0.43pt). Label centroids:

| slice | measured r / R |
|-------|----------------|
| 54%   | 0.878 |
| 27%   | 0.888 |
| 14%   | 0.887 |
| 5%    | 0.912 |

A flat near-rim constant, independent of slice angle — so it is a fixed
fraction, **not** a sector centroid. The doughnut (55% hole) measures
0.772–0.778·outerR ≈ `(0.55 + 1)/2 = 0.775`, i.e. the exact ring midpoint.

§21.2.2.48 enumerates `ST_DLblPos` (bestFit / ctr / inEnd / outEnd …) but
defines **no geometry** for these — the radial placement is PowerPoint
application behaviour. Reverse-engineering was explicitly requested for this
fidelity match; the measurement method and cross-slice consistency are
documented at the new constant and at the `labelR` computation.

## Fix

- Solid pie (`innerR ≈ 0`) → `ctr` / `inEnd` / `bestFit` labels at
  `0.88·outerR` (`PIE_CTR_LABEL_RADIUS_FRAC`).
- Doughnut (`innerR > 0`) → unchanged ring midpoint `(innerR + outerR)/2`.
- `outEnd` (outside the rim) → unchanged.
- Legacy inline percent path (plain pie without rich `<c:dLbls>`) → untouched,
  so the renderer-signature snapshot stays byte-stable. sample-25 pie3D uses
  the callout path and is unaffected.

## Verification

- **TDD**: added `renderer-scatter-line-and-pie-labels.test.ts` cases asserting
  the pie `ctr` label radius (~0.88R, Red→Green), the doughnut ring-midpoint
  (0.775R), and `outEnd` outside the rim.
- **End-to-end (real pptx pipeline)**: sample-14 slide-7 pie label radius ratio
  moved **0.50 → 0.88** (matching the PDF); the doughnut right-half render hash
  is **byte-identical** before/after (`9be1c143…`).
- `renderer-signature` snapshot unchanged; core chart vitest (261) green; core
  package vitest (1152) green; `tsc` (core) clean; `ast-grep scan` no new
  violations; pptx/xlsx demo VRT green (private-fixture 404s are expected in
  this worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)