### PR TITLE
feat(docx): VML watermarks, bare-pict imagedata, and CT_Object drawing delegation (WD3)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3293,13 +3293,28 @@ fn parse_run_inner(
                 }
             }
             "object" => {
-                // Embedded OLE object (§17.3.3.19 CT_Object). We can't run the
-                // embedded application, but Word bakes a preview image into a
-                // legacy VML `<v:shape><v:imagedata r:id>` for exactly this case.
-                // Surface that preview through the ordinary inline-image pipeline
-                // (the preview is usually EMF/WMF, which core already rasterizes)
-                // instead of silently dropping the object.
-                if let Some(img) = parse_object_ole_image(child, media_map) {
+                // Embedded OLE object (§17.3.3.19 CT_Object). The schema is
+                // `sequence(drawing?, choice(control|objectLink|objectEmbed|
+                // movie)?)`: the OPTIONAL first child is a modern `<w:drawing>`
+                // carrying the object's DrawingML static representation, and the
+                // choice names the actual embedding. Precedence:
+                //   1. If a `<w:drawing>` child is present, it IS the on-page
+                //      picture — delegate to the DrawingML picture path
+                //      (§17.3.3.9). Word emits this in its back-compat output
+                //      alongside a legacy VML fallback, so taking the drawing
+                //      first also prevents a double-draw.
+                //   2. Otherwise fall back to the legacy VML preview Word bakes
+                //      into a `<v:shape><v:imagedata r:id>` (usually EMF/WMF,
+                //      which core rasterizes), surfaced through the inline-image
+                //      pipeline instead of being silently dropped.
+                let drawing = child
+                    .children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "drawing");
+                if let Some(drawing) = drawing {
+                    for r in parse_inline_drawing(style_map, drawing, media_map, chart_map, theme) {
+                        runs.push(r);
+                    }
+                } else if let Some(img) = parse_object_ole_image(child, media_map) {
                     runs.push(DocRun::Image(img));
                 }
             }
@@ -5258,10 +5273,10 @@ fn parse_vml_pict(
 /// silent-skip rather than emitting a zero-sized or path-less image.
 ///
 /// Note: CT_Object (§17.3.3.19) may hold a modern `<w:drawing>` as its first
-/// child instead of (or beside) the VML fallback; Word's real output is
-/// back-compat and VML-dominant, so only the VML preview path is handled here.
-/// Delegating a `<w:drawing>`-first CT_Object to the DrawingML picture path is a
-/// follow-up.
+/// child instead of (or beside) the VML fallback. The `object` run dispatcher
+/// takes that drawing first (delegating to `parse_inline_drawing`); this
+/// function is only reached when there is NO `<w:drawing>` child, so it handles
+/// the pure legacy-VML preview form.
 fn parse_object_ole_image(
     object: roxmltree::Node,
     media_map: &HashMap<String, String>,
@@ -13596,6 +13611,103 @@ mod ole_object_tests {
             "a dangling v:imagedata rId ⇒ no image run, got {}",
             imgs.len()
         );
+    }
+
+    /// §17.3.3.19 CT_Object — the FIRST child may be a modern `<w:drawing>` (the
+    /// DrawingML static representation), per the schema
+    /// `sequence(drawing?, choice(control|objectLink|objectEmbed|movie)?)`. When
+    /// present, the object's on-page appearance is that inline picture, so it
+    /// must be delegated to the DrawingML picture path (`parse_inline_drawing`) —
+    /// not the VML `<v:imagedata>` fallback. This exercises a `<w:object>` whose
+    /// first child is a `<w:drawing><wp:inline>` blip picture.
+    #[test]
+    fn object_with_drawing_first_child_emits_inline_picture() {
+        let body = format!(
+            r##"<w:document{ns}
+                xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+              <w:body>
+              <w:p><w:r><w:object w:dxaOrig="3000" w:dyaOrig="1500">
+                <w:drawing>
+                  <wp:inline>
+                    <wp:extent cx="1905000" cy="952500"/>
+                    <a:graphic><a:graphicData
+                        uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                      <pic:pic><pic:blipFill>
+                        <a:blip r:embed="rIdDraw"/>
+                      </pic:blipFill></pic:pic>
+                    </a:graphicData></a:graphic>
+                  </wp:inline>
+                </w:drawing>
+                <o:OLEObject Type="Embed" ProgID="Excel.Sheet.12" r:id="rIdData"/>
+              </w:object></w:r></w:p>
+            </w:body></w:document>"##,
+            ns = OLE_NS,
+        );
+        let mut media = HashMap::new();
+        media.insert("rIdDraw".to_string(), "word/media/image1.png".to_string());
+
+        let imgs = image_runs(&body, &media);
+        assert_eq!(imgs.len(), 1, "the modern <w:drawing> child is the picture");
+        assert_eq!(imgs[0].image_path, "word/media/image1.png");
+        // 1905000 EMU / 12700 = 150pt, 952500 / 12700 = 75pt (from <wp:extent>,
+        // NOT the object's dxaOrig — the drawing carries its own natural size).
+        assert!(
+            (imgs[0].width_pt - 150.0).abs() < 1e-6,
+            "width from wp:extent, got {}",
+            imgs[0].width_pt
+        );
+        assert!(
+            (imgs[0].height_pt - 75.0).abs() < 1e-6,
+            "height from wp:extent, got {}",
+            imgs[0].height_pt
+        );
+    }
+
+    /// A `<w:object>` that carries BOTH a modern `<w:drawing>` first child AND a
+    /// legacy VML `<v:imagedata>` fallback (Word's back-compat output) must NOT
+    /// double-emit — the `<w:drawing>` wins and the VML fallback is skipped, so
+    /// exactly one image run surfaces.
+    #[test]
+    fn object_with_drawing_and_vml_fallback_does_not_double_emit() {
+        let body = format!(
+            r##"<w:document{ns}
+                xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+              <w:body>
+              <w:p><w:r><w:object w:dxaOrig="3000" w:dyaOrig="1500">
+                <w:drawing>
+                  <wp:inline>
+                    <wp:extent cx="1905000" cy="952500"/>
+                    <a:graphic><a:graphicData
+                        uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                      <pic:pic><pic:blipFill>
+                        <a:blip r:embed="rIdDraw"/>
+                      </pic:blipFill></pic:pic>
+                    </a:graphicData></a:graphic>
+                  </wp:inline>
+                </w:drawing>
+                <v:shape id="s5" type="#_x0000_t75" style="width:150pt;height:75pt">
+                  <v:imagedata r:id="rIdPrev" o:title=""/>
+                </v:shape>
+                <o:OLEObject Type="Embed" ProgID="Excel.Sheet.12" ShapeID="s5" r:id="rIdData"/>
+              </w:object></w:r></w:p>
+            </w:body></w:document>"##,
+            ns = OLE_NS,
+        );
+        let mut media = HashMap::new();
+        media.insert("rIdDraw".to_string(), "word/media/image1.png".to_string());
+        media.insert("rIdPrev".to_string(), "word/media/image2.emf".to_string());
+
+        let imgs = image_runs(&body, &media);
+        assert_eq!(
+            imgs.len(),
+            1,
+            "the <w:drawing> child wins; the VML fallback must not also emit"
+        );
+        assert_eq!(imgs[0].image_path, "word/media/image1.png");
     }
 }
 

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -5193,23 +5193,23 @@ fn parse_vml_pict(
         return None;
     }
 
-    // VML colors: `fillcolor` / `strokecolor` are "#rrggbb" (or named); we keep
-    // the 6-hex form the renderer expects (no leading '#').
-    let hex6 = |c: &str| -> Option<String> {
-        let s = c.trim().trim_start_matches('#');
-        if s.len() == 6 && s.chars().all(|ch| ch.is_ascii_hexdigit()) {
-            Some(s.to_ascii_lowercase())
-        } else {
-            None
-        }
-    };
+    // VML colors: `fillcolor` / `strokecolor` are "#rrggbb" or a named color; we
+    // keep the 6-hex form the renderer expects (no leading '#').
     let fill = shape
         .attribute("fillcolor")
-        .and_then(hex6)
+        .and_then(vml_color_hex6)
         .map(|color| ShapeFill::Solid { color });
-    let stroke = shape.attribute("strokecolor").and_then(hex6);
-    // VML default stroke weight is 0.75pt when a stroke color is present and no
-    // explicit weight is given (Part 4 §14.1.2.21 strokeweight default).
+    // `stroked="f"` (or "false") disables the stroke regardless of strokecolor
+    // (§19.1.2 shape stroked attribute). Otherwise a strokecolor implies a
+    // stroke; VML's default weight is 0.75pt (Part 4 §19.1.2.21 strokeweight).
+    let stroked_off = shape
+        .attribute("stroked")
+        .is_some_and(|v| matches!(v.trim(), "f" | "false" | "0"));
+    let stroke = if stroked_off {
+        None
+    } else {
+        shape.attribute("strokecolor").and_then(vml_color_hex6)
+    };
     let stroke_width = if stroke.is_some() {
         shape
             .descendants()
@@ -5226,17 +5226,72 @@ fn parse_vml_pict(
         0.0
     };
 
-    // Body text from <v:textbox><w:txbxContent>.
-    let text_blocks: Vec<ShapeText> = shape
-        .descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "txbxContent")
-        .map(|content| {
-            children_w_flat(content, "p")
-                .into_iter()
-                .filter_map(|p| extract_simple_paragraph_text(style_map, p, theme, media_map))
-                .collect()
-        })
-        .unwrap_or_default();
+    // ECMA-376 Part 4 §19.1.2.5 `<v:fill opacity>` — fill alpha (default opaque).
+    let fill_opacity = shape
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "fill")
+        .and_then(|f| f.attribute("opacity"))
+        .and_then(parse_vml_opacity);
+
+    // §19.1.2.23 `<v:textpath>` — WordArt text (a watermark). When present this
+    // shape draws stretched rotated text instead of a fill/stroke panel + body.
+    let text_path = shape
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "textpath")
+        .and_then(parse_vml_textpath);
+
+    // §19.1.2.19 style `rotation` — degrees clockwise (default 0).
+    let rotation = vml_css_length_pt(style, "rotation").unwrap_or(0.0);
+
+    // §19.1.2.19 style positioning. `mso-position-horizontal/vertical` give the
+    // alignment (absolute|left|center|right|inside|outside); their `-relative`
+    // companions give the container (margin|page|text|char|line). Map them onto
+    // the shared anchor model the renderer already understands (align + relativeFrom).
+    let map_align = |v: &str| match v {
+        "center" => Some("center".to_string()),
+        "left" | "inside" => Some("left".to_string()),
+        "right" | "outside" => Some("right".to_string()),
+        _ => None, // "absolute" ⇒ use the numeric margin-left/top offset instead
+    };
+    let map_valign = |v: &str| match v {
+        "center" => Some("center".to_string()),
+        "top" | "inside" => Some("top".to_string()),
+        "bottom" | "outside" => Some("bottom".to_string()),
+        _ => None,
+    };
+    let anchor_x_align = vml_css_str(style, "mso-position-horizontal").and_then(map_align);
+    let anchor_y_align = vml_css_str(style, "mso-position-vertical").and_then(map_valign);
+    // `text` and `char`/`line` relative-froms map to paragraph-relative flow; we
+    // only forward the page/margin containers the watermark cares about.
+    let map_rel = |v: &str| match v {
+        "margin" => Some("margin".to_string()),
+        "page" => Some("page".to_string()),
+        _ => None,
+    };
+    let anchor_x_relative_from =
+        vml_css_str(style, "mso-position-horizontal-relative").and_then(map_rel);
+    let anchor_y_relative_from =
+        vml_css_str(style, "mso-position-vertical-relative").and_then(map_rel);
+
+    // §19.1.2.19 style `z-index` — a negative value places the shape BEHIND the
+    // document text (a watermark), matching wp:anchor behindDoc semantics.
+    let behind_doc = vml_css_length_pt(style, "z-index").is_some_and(|z| z < 0.0);
+
+    // Body text from <v:textbox><w:txbxContent> (none for a textpath watermark).
+    let text_blocks: Vec<ShapeText> = if text_path.is_some() {
+        Vec::new()
+    } else {
+        shape
+            .descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "txbxContent")
+            .map(|content| {
+                children_w_flat(content, "p")
+                    .into_iter()
+                    .filter_map(|p| extract_simple_paragraph_text(style_map, p, theme, media_map))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
 
     Some(ShapeRun {
         width_pt,
@@ -5244,16 +5299,22 @@ fn parse_vml_pict(
         anchor_x_pt: 0.0,
         anchor_y_pt: 0.0,
         anchor_x_from_margin: true,
-        anchor_y_from_para: true,
-        behind_doc: false,
+        anchor_y_from_para: !behind_doc,
+        anchor_x_align,
+        anchor_y_align,
+        anchor_x_relative_from,
+        anchor_y_relative_from,
+        behind_doc,
         z_order: 0,
         subpaths: Vec::new(),
         preset_geometry: Some("rect".to_string()),
         adj_values: Vec::new(),
         fill,
+        fill_opacity,
         stroke,
         stroke_width,
-        rotation: 0.0,
+        rotation,
+        text_path,
         // VML t202 text-box default insets are the OOXML defaults (§21.1.2.1.1).
         text_blocks,
         text_anchor: None,
@@ -5284,6 +5345,98 @@ fn vml_css_length_pt(style: &str, prop: &str) -> Option<f64> {
         }
     }
     None
+}
+
+/// Read a raw string property from a VML CSS `style` string (§19.1.2.19),
+/// case-insensitive on the property name, value trimmed. `None` when absent.
+fn vml_css_str<'a>(style: &'a str, prop: &str) -> Option<&'a str> {
+    for decl in style.split(';') {
+        let mut kv = decl.splitn(2, ':');
+        let k = kv.next()?.trim();
+        let v = match kv.next() {
+            Some(v) => v.trim(),
+            None => continue,
+        };
+        if k.eq_ignore_ascii_case(prop) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// Resolve a VML color value (ECMA-376 Part 4 §19.1.2 — `fillcolor` /
+/// `strokecolor`, or a CSS color word) to the renderer's 6-hex form WITHOUT a
+/// leading `#`. Accepts `#rrggbb` / `rrggbb` hex and the CSS/VML named colors
+/// (`silver`, `black`, `red`, …) resolved through the shared
+/// `ooxml_common::theme::preset_color` table. `None` for an unrecognized value
+/// (e.g. `windowText`, a palette-relative token we don't model here).
+fn vml_color_hex6(c: &str) -> Option<String> {
+    let s = c.trim().trim_start_matches('#');
+    if s.len() == 6 && s.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return Some(s.to_ascii_lowercase());
+    }
+    ooxml_common::theme::preset_color(s.trim()).map(|hex| hex.to_ascii_lowercase())
+}
+
+/// Parse a VML `<v:fill opacity>` value (§19.1.2.5). The opacity is a number in
+/// [0.0, 1.0] (default 1.0). Per the spec it may ALSO be written in 1/65536-ths
+/// with a trailing `f` (e.g. `52429f` = 52429/65536 ≈ 0.8). Returns the decoded
+/// fraction, or `None` when unparseable.
+fn parse_vml_opacity(raw: &str) -> Option<f64> {
+    let raw = raw.trim();
+    if let Some(num) = raw.strip_suffix('f') {
+        return num.trim().parse::<f64>().ok().map(|n| n / 65536.0);
+    }
+    raw.parse::<f64>().ok()
+}
+
+/// Parse a `<v:textpath>` (§19.1.2.23) into a `TextPath`: its `string` (the
+/// WordArt text) plus the font family / weight / style extracted from the
+/// element's CSS `style` (`font-family`, `font-weight`, `font-style`, and the
+/// `bold`/`italic` keywords of the `font` shorthand). Quotes around the family
+/// are stripped. Returns `None` when the element carries no `string`.
+fn parse_vml_textpath(textpath: roxmltree::Node) -> Option<TextPath> {
+    let string = textpath.attribute("string")?.to_string();
+    let style = textpath.attribute("style").unwrap_or("");
+
+    // font-family: prefer the explicit property, else the last token of the
+    // `font` shorthand (`style variant weight size/line family`). Strip quotes.
+    let strip_quotes = |s: &str| s.trim().trim_matches(|c| c == '"' || c == '\'').to_string();
+    let font_family = vml_css_str(style, "font-family")
+        .map(strip_quotes)
+        .or_else(|| {
+            vml_css_str(style, "font").and_then(|shorthand| {
+                // The family is everything after the size token; a simple,
+                // robust take is the substring after the last size-like token.
+                // Fall back to the last whitespace-delimited token.
+                shorthand
+                    .rsplit(|c: char| c.is_whitespace())
+                    .find(|t| !t.is_empty())
+                    .map(strip_quotes)
+            })
+        })
+        .filter(|f| !f.is_empty());
+
+    let font_lc = vml_css_str(style, "font")
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let bold = vml_css_str(style, "font-weight")
+        .map(|w| w.eq_ignore_ascii_case("bold") || w.trim().parse::<u32>().is_ok_and(|n| n >= 600))
+        .unwrap_or(false)
+        || font_lc.split_whitespace().any(|t| t == "bold");
+    let italic = vml_css_str(style, "font-style")
+        .map(|s| s.eq_ignore_ascii_case("italic") || s.eq_ignore_ascii_case("oblique"))
+        .unwrap_or(false)
+        || font_lc
+            .split_whitespace()
+            .any(|t| t == "italic" || t == "oblique");
+
+    Some(TextPath {
+        string,
+        font_family,
+        bold,
+        italic,
+    })
 }
 
 /// Parse a bare legacy VML `<w:pict>` picture — a `<v:shape>` (or
@@ -13964,6 +14117,108 @@ mod vml_pict_tests {
             imgs.iter().all(|i| i.width_pt < 5000.0),
             "a grouped imagedata must not be sized from group units as pt: {:?}",
             imgs.iter().map(|i| i.width_pt).collect::<Vec<_>>()
+        );
+    }
+
+    /// §19.1.2.23 textpath — Word's canonical text watermark: a
+    /// `PowerPlusWaterMarkObject` `<v:shape type="#_x0000_t136">` positioned
+    /// absolute + centred in the margin box, rotated, `stroked="f"`, with a
+    /// `<v:fill opacity>` and a `<v:textpath string="…" style="font-family:…">`.
+    /// It must surface as a ShapeRun carrying the text_path (string + font),
+    /// rotation (§19.1.2.19), fill colour, and fill_opacity (§19.1.2.5) — the
+    /// renderer draws the stretched rotated semi-transparent text.
+    #[test]
+    fn watermark_textpath_shape_carries_text_rotation_and_opacity() {
+        let body = format!(
+            r##"<w:document{ns}><w:body>
+              <w:p><w:r><w:pict>
+                <v:shape id="PowerPlusWaterMarkObject1" type="#_x0000_t136"
+                  style="position:absolute;margin-left:0;margin-top:0;width:415pt;height:207.5pt;rotation:315;z-index:-251657216;mso-position-horizontal:center;mso-position-horizontal-relative:margin;mso-position-vertical:center;mso-position-vertical-relative:margin"
+                  fillcolor="silver" stroked="f">
+                  <v:fill opacity=".5"/>
+                  <v:textpath style="font-family:&quot;Calibri&quot;;font-size:1pt"
+                    string="DRAFT"/>
+                </v:shape>
+              </w:pict></w:r></w:p>
+            </w:body></w:document>"##,
+            ns = VML_NS,
+        );
+        let shapes = shape_runs(&body, &HashMap::new());
+        assert_eq!(shapes.len(), 1, "one watermark shape");
+        let s = &shapes[0];
+        let tp = s.text_path.as_ref().expect("text_path must be present");
+        assert_eq!(tp.string, "DRAFT");
+        assert_eq!(
+            tp.font_family.as_deref(),
+            Some("Calibri"),
+            "quotes stripped"
+        );
+        assert!((s.width_pt - 415.0).abs() < 1e-6, "w {}", s.width_pt);
+        assert!((s.height_pt - 207.5).abs() < 1e-6, "h {}", s.height_pt);
+        // rotation:315 deg (clockwise) from the shape style.
+        assert!((s.rotation - 315.0).abs() < 1e-6, "rotation {}", s.rotation);
+        // fillcolor silver → hex, opacity .5.
+        match &s.fill {
+            Some(ShapeFill::Solid { color }) => assert_eq!(color, "c0c0c0", "silver → c0c0c0"),
+            other => panic!("expected silver solid fill, got {other:?}"),
+        }
+        assert!(
+            (s.fill_opacity.unwrap() - 0.5).abs() < 1e-6,
+            "opacity {:?}",
+            s.fill_opacity
+        );
+        // It is a WordArt text path, not a text-box panel.
+        assert!(s.text_blocks.is_empty(), "no txbx body text");
+        // stroked="f" ⇒ no stroke.
+        assert_eq!(s.stroke_width, 0.0, "stroked=f ⇒ no stroke");
+        // Centred in the margin box (§19.1.2.19 mso-position-*).
+        assert_eq!(s.anchor_x_align.as_deref(), Some("center"));
+        assert_eq!(s.anchor_y_align.as_deref(), Some("center"));
+        assert_eq!(s.anchor_x_relative_from.as_deref(), Some("margin"));
+        assert_eq!(s.anchor_y_relative_from.as_deref(), Some("margin"));
+        // Negative z-index ⇒ behind the body text.
+        assert!(s.behind_doc, "negative z-index ⇒ behindDoc");
+    }
+
+    /// §19.1.2.5 opacity — the "52429f" form (1/65536-ths, trailing `f`) decodes
+    /// to 0.8; an absent `<v:fill opacity>` ⇒ fully opaque (`fill_opacity` =
+    /// None). Also checks an unquoted `font-family`.
+    #[test]
+    fn watermark_opacity_fraction_form_decodes() {
+        let mk = |fill: &str| {
+            format!(
+                r##"<w:document{ns}><w:body>
+                  <w:p><w:r><w:pict>
+                    <v:shape id="PowerPlusWaterMarkObject1" type="#_x0000_t136"
+                      style="position:absolute;width:400pt;height:200pt" fillcolor="red" stroked="f">
+                      {fill}
+                      <v:textpath style="font-family:Arial" string="CONFIDENTIAL"/>
+                    </v:shape>
+                  </w:pict></w:r></w:p>
+                </w:body></w:document>"##,
+                ns = VML_NS,
+                fill = fill,
+            )
+        };
+        let f_form = shape_runs(&mk(r#"<v:fill opacity="52429f"/>"#), &HashMap::new());
+        assert!(
+            (f_form[0].fill_opacity.unwrap() - 0.8).abs() < 1e-3,
+            "52429f → 0.8, got {:?}",
+            f_form[0].fill_opacity
+        );
+        let no_fill = shape_runs(&mk(""), &HashMap::new());
+        assert!(
+            no_fill[0].fill_opacity.is_none(),
+            "no <v:fill opacity> ⇒ opaque (None)"
+        );
+        assert_eq!(
+            no_fill[0]
+                .text_path
+                .as_ref()
+                .unwrap()
+                .font_family
+                .as_deref(),
+            Some("Arial")
         );
     }
 }

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3283,12 +3283,20 @@ fn parse_run_inner(
                 }
             }
             "pict" => {
-                // Legacy VML drawing (ECMA-376 Part 4 §14.1): <w:pict> wraps a
-                // <v:shape>/<v:rect>/<v:roundrect> with optional <v:textbox>.
-                // Word still emits these for simple text boxes. We surface the
-                // shape's fill/stroke/size and its txbxContent as a ShapeRun so
-                // the existing shape renderer draws the panel + RTL body text.
-                if let Some(shp) = parse_vml_pict(style_map, child, theme, media_map) {
+                // Legacy VML drawing (ECMA-376 Part 4 §19.1.2): a `<w:pict>`
+                // wraps a `<v:shape>`/`<v:rect>`/`<v:roundrect>` carrying one of
+                // several payloads. Dispatch by payload:
+                //   1. `<v:imagedata r:id>` (§19.1.2.11) — a non-OLE inline VML
+                //      picture. Surface it as an inline `ImageRun` through the
+                //      ordinary image pipeline.
+                //   2. `<v:textbox><w:txbxContent>` or a filled/stroked panel —
+                //      surface the shape's fill/stroke/size and its body text as
+                //      a `ShapeRun` (the existing text-box path).
+                // The imagedata form is tried first so a picture pict is not
+                // mistaken for an (empty) text-box panel.
+                if let Some(img) = parse_vml_pict_image(child, media_map) {
+                    runs.push(DocRun::Image(img));
+                } else if let Some(shp) = parse_vml_pict(style_map, child, theme, media_map) {
                     runs.push(DocRun::Shape(Box::new(shp)));
                 }
             }
@@ -5154,37 +5162,33 @@ fn extract_simple_paragraph_text(
 /// below the preceding content.
 ///
 /// Note: a bare `<w:pict>` carrying a `<v:imagedata>` (a non-OLE inline VML
-/// image, not a text box) is not resolved here — that remains an existing gap.
-/// The OLE-object case (`<w:object>` with a VML preview) is handled separately;
-/// see `parse_object_ole_image`.
+/// picture) is resolved by `parse_vml_pict_image` BEFORE this function runs, so
+/// an imagedata shape never reaches here — this path only builds fill/stroke/
+/// text-box panels. The OLE-object case (`<w:object>` with a VML preview) is
+/// handled separately; see `parse_object_ole_image`.
 fn parse_vml_pict(
     style_map: &StyleMap,
     pict: roxmltree::Node,
     theme: &ThemeColors,
     media_map: &HashMap<String, String>,
 ) -> Option<ShapeRun> {
-    // v:shape / v:rect / v:roundrect — any VML shape element with geometry.
+    // v:shape / v:rect / v:roundrect — any VML shape element with geometry. A
+    // shape whose payload is a `<v:imagedata>` is a PICTURE, not a text/fill
+    // panel (it is drawn by parse_vml_pict_image, or intentionally skipped when
+    // its image can't be resolved); such a shape must not be turned into an
+    // empty rectangle here, so it is excluded from the candidate set.
     let shape = pict.descendants().find(|n| {
-        n.is_element() && matches!(n.tag_name().name(), "shape" | "rect" | "roundrect" | "oval")
+        n.is_element()
+            && matches!(n.tag_name().name(), "shape" | "rect" | "roundrect" | "oval")
+            && !n
+                .children()
+                .any(|c| c.is_element() && c.tag_name().name() == "imagedata")
     })?;
 
     // CSS-like `style`: "position:relative;width:300pt;height:60pt;…"
     let style = shape.attribute("style").unwrap_or("");
-    let css_pt = |prop: &str| -> Option<f64> {
-        for decl in style.split(';') {
-            let mut kv = decl.splitn(2, ':');
-            let k = kv.next()?.trim();
-            let v = kv.next()?.trim();
-            if k.eq_ignore_ascii_case(prop) {
-                // strip a trailing "pt" unit; VML lengths default to pt here.
-                let num = v.trim_end_matches("pt").trim();
-                return num.parse::<f64>().ok();
-            }
-        }
-        None
-    };
-    let width_pt = css_pt("width").unwrap_or(0.0);
-    let height_pt = css_pt("height").unwrap_or(0.0);
+    let width_pt = vml_css_length_pt(style, "width").unwrap_or(0.0);
+    let height_pt = vml_css_length_pt(style, "height").unwrap_or(0.0);
     if width_pt <= 0.0 || height_pt <= 0.0 {
         return None;
     }
@@ -5261,6 +5265,109 @@ fn parse_vml_pict(
     })
 }
 
+/// Read a length from a VML CSS `style` string (ECMA-376 Part 4 §19.1.2.19
+/// "style" — a semicolon-delimited `name:value` list). Returns the numeric value
+/// with a trailing `pt` unit stripped; VML lengths in a `<w:pict>` default to
+/// points, so a bare number is taken as pt. Non-`pt` units (px/cm/…) and
+/// percentages are not converted here (callers that need them handle it).
+/// Property match is case-insensitive per the CSS2 grammar.
+fn vml_css_length_pt(style: &str, prop: &str) -> Option<f64> {
+    for decl in style.split(';') {
+        let mut kv = decl.splitn(2, ':');
+        let k = kv.next()?.trim();
+        let v = match kv.next() {
+            Some(v) => v.trim(),
+            None => continue,
+        };
+        if k.eq_ignore_ascii_case(prop) {
+            return v.trim_end_matches("pt").trim().parse::<f64>().ok();
+        }
+    }
+    None
+}
+
+/// Parse a bare legacy VML `<w:pict>` picture — a `<v:shape>` (or
+/// `<v:rect>`/`<v:roundrect>`/`<v:oval>`) carrying a `<v:imagedata r:id>`
+/// (ECMA-376 Part 4 §19.1.2.11 imagedata) with NO surrounding `<w:object>`. This
+/// is the non-OLE inline VML image form (e.g. a header picture Word emits as VML
+/// rather than DrawingML). The rId maps to an embedded part via the media map,
+/// and the draw size comes from the shape's CSS `style` width/height in pt
+/// (§19.1.2.19). The result is an inline `ImageRun`, feeding the same image
+/// pipeline as a DrawingML `<a:blip>` picture.
+///
+/// Returns `None` (leaving the pict to the text-box path) when:
+///   - no shape carries a `<v:imagedata r:id>` (it is a filled/text panel), or
+///   - the relevant shape is inside a `<v:group>` — a grouped shape's
+///     width/height are expressed in the GROUP's coordinate system
+///     (`coordsize`), not points, so treating them as pt would badly mis-size
+///     the image. Resolving the group transform (child offset × group scale) is
+///     a separate VML-group feature; until then a grouped imagedata is skipped
+///     rather than mis-rendered, matching the prior behaviour, or
+///   - the rId does not resolve, or the shape has no positive pt dimensions.
+fn parse_vml_pict_image(
+    pict: roxmltree::Node,
+    media_map: &HashMap<String, String>,
+) -> Option<ImageRun> {
+    let is_shape = |n: &roxmltree::Node| {
+        n.is_element() && matches!(n.tag_name().name(), "shape" | "rect" | "roundrect" | "oval")
+    };
+    // The first shape carrying an <v:imagedata r:id>, that is NOT nested in a
+    // <v:group> (grouped geometry is in group units, handled elsewhere).
+    let shape = pict.descendants().find(|n| {
+        is_shape(n)
+            && n.children()
+                .any(|c| c.is_element() && c.tag_name().name() == "imagedata")
+            && !n
+                .ancestors()
+                .any(|a| a.is_element() && a.tag_name().name() == "group")
+    })?;
+
+    let imagedata = shape
+        .children()
+        .find(|c| c.is_element() && c.tag_name().name() == "imagedata")?;
+    let rid = attr_ns(
+        &imagedata,
+        relationships::TRANSITIONAL,
+        relationships::STRICT,
+        "id",
+    )?;
+    let image_path = media_map.get(rid)?.clone();
+    let mime_type = mime_from_ext(&image_path).to_string();
+
+    let style = shape.attribute("style").unwrap_or("");
+    let width_pt = vml_css_length_pt(style, "width").unwrap_or(0.0);
+    let height_pt = vml_css_length_pt(style, "height").unwrap_or(0.0);
+    if width_pt <= 0.0 || height_pt <= 0.0 {
+        return None;
+    }
+
+    Some(ImageRun {
+        image_path,
+        mime_type,
+        svg_image_path: None,
+        src_rect: None,
+        width_pt,
+        height_pt,
+        anchor: false,
+        anchor_x_pt: 0.0,
+        anchor_y_pt: 0.0,
+        anchor_x_from_margin: false,
+        anchor_y_from_para: false,
+        color_replace_from: None,
+        wrap_mode: None,
+        dist_top: 0.0,
+        dist_bottom: 0.0,
+        dist_left: 0.0,
+        dist_right: 0.0,
+        wrap_side: None,
+        allow_overlap: true,
+        anchor_x_align: None,
+        anchor_y_align: None,
+        anchor_x_relative_from: None,
+        anchor_y_relative_from: None,
+    })
+}
+
 /// Extract the preview image from an embedded OLE object (`<w:object>`,
 /// §17.3.3.19 CT_Object). Word represents the object's on-page appearance as a
 /// legacy VML `<v:shape>` (or `<v:rect>`/`<v:roundrect>`/`<v:oval>`) carrying a
@@ -5300,17 +5407,6 @@ fn parse_object_ole_image(
         n.is_element() && matches!(n.tag_name().name(), "shape" | "rect" | "roundrect" | "oval")
     });
     let style = shape.and_then(|s| s.attribute("style")).unwrap_or("");
-    let css_pt = |prop: &str| -> Option<f64> {
-        for decl in style.split(';') {
-            let mut kv = decl.splitn(2, ':');
-            let k = kv.next()?.trim();
-            let v = kv.next()?.trim();
-            if k.eq_ignore_ascii_case(prop) {
-                return v.trim_end_matches("pt").trim().parse::<f64>().ok();
-            }
-        }
-        None
-    };
     let dxa_pt = |name: &str| -> Option<f64> {
         attr_ns(
             &object,
@@ -5321,8 +5417,10 @@ fn parse_object_ole_image(
         .and_then(|v| v.trim().parse::<f64>().ok())
         .map(|twentieths| twentieths / 20.0)
     };
-    let width_pt = css_pt("width").or_else(|| dxa_pt("dxaOrig")).unwrap_or(0.0);
-    let height_pt = css_pt("height")
+    let width_pt = vml_css_length_pt(style, "width")
+        .or_else(|| dxa_pt("dxaOrig"))
+        .unwrap_or(0.0);
+    let height_pt = vml_css_length_pt(style, "height")
         .or_else(|| dxa_pt("dyaOrig"))
         .unwrap_or(0.0);
     if width_pt <= 0.0 || height_pt <= 0.0 {
@@ -13708,6 +13806,165 @@ mod ole_object_tests {
             "the <w:drawing> child wins; the VML fallback must not also emit"
         );
         assert_eq!(imgs[0].image_path, "word/media/image1.png");
+    }
+}
+
+/// Legacy VML `<w:pict>` picture and text-watermark fixtures (ECMA-376 Part 4,
+/// §19.1.2 VML Reference). Covers a bare `<w:pict>` carrying a
+/// `<v:shape><v:imagedata>` (a non-OLE inline VML image) and a
+/// `<v:textpath>` text watermark, which Word emits in a header.
+#[cfg(test)]
+mod vml_pict_tests {
+    use super::*;
+
+    const VML_NS: &str = concat!(
+        r#" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main""#,
+        r#" xmlns:v="urn:schemas-microsoft-com:vml""#,
+        r#" xmlns:o="urn:schemas-microsoft-com:office:office""#,
+        r#" xmlns:w10="urn:schemas-microsoft-com:office:word""#,
+        r#" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships""#
+    );
+
+    /// Parse a `<w:document>` fixture and return every DocRun across its
+    /// paragraphs, in document order.
+    fn all_runs(body_xml: &str, media: &HashMap<String, String>) -> Vec<DocRun> {
+        let doc = roxmltree::Document::parse(body_xml).unwrap();
+        let body = doc
+            .root_element()
+            .descendants()
+            .find(|n| n.tag_name().name() == "body")
+            .unwrap();
+        let mut num_map = NumberingMap::default();
+        parse_body_elements(
+            body,
+            &StyleMap::default(),
+            &mut num_map,
+            media,
+            &HashMap::new(),
+            &HashMap::new(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .into_iter()
+        .filter_map(|e| match e {
+            BodyElement::Paragraph(p) => Some(p),
+            _ => None,
+        })
+        .flat_map(|p| p.runs.into_iter())
+        .collect()
+    }
+
+    fn image_runs(body_xml: &str, media: &HashMap<String, String>) -> Vec<ImageRun> {
+        all_runs(body_xml, media)
+            .into_iter()
+            .filter_map(|r| match r {
+                DocRun::Image(img) => Some(img),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn shape_runs(body_xml: &str, media: &HashMap<String, String>) -> Vec<ShapeRun> {
+        all_runs(body_xml, media)
+            .into_iter()
+            .filter_map(|r| match r {
+                DocRun::Shape(s) => Some(*s),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// §19.1.2.11 imagedata — a bare `<w:pict>` (no `<w:object>` wrapper) whose
+    /// `<v:shape>` carries a `<v:imagedata r:id>` is a non-OLE inline VML image.
+    /// It must surface as an inline `ImageRun` sized from the shape's CSS `style`
+    /// (width/height in pt, §19.1.2.19 style), resolved through the media map.
+    #[test]
+    fn bare_pict_imagedata_emits_inline_image() {
+        let body = format!(
+            r##"<w:document{ns}><w:body>
+              <w:p><w:r><w:pict>
+                <v:shape id="s1" type="#_x0000_t75" style="width:120pt;height:90pt">
+                  <v:imagedata r:id="rIdImg" o:title="logo"/>
+                </v:shape>
+              </w:pict></w:r></w:p>
+            </w:body></w:document>"##,
+            ns = VML_NS,
+        );
+        let mut media = HashMap::new();
+        media.insert("rIdImg".to_string(), "word/media/image1.png".to_string());
+
+        let imgs = image_runs(&body, &media);
+        assert_eq!(imgs.len(), 1, "one inline image from the bare pict");
+        assert_eq!(imgs[0].image_path, "word/media/image1.png");
+        assert!(!imgs[0].anchor, "an inline (position-static) VML image");
+        assert!(
+            (imgs[0].width_pt - 120.0).abs() < 1e-6,
+            "w {}",
+            imgs[0].width_pt
+        );
+        assert!(
+            (imgs[0].height_pt - 90.0).abs() < 1e-6,
+            "h {}",
+            imgs[0].height_pt
+        );
+        // It must NOT also produce a text-box ShapeRun (the previous behaviour
+        // treated any pict shape as a panel).
+        assert!(
+            shape_runs(&body, &media).is_empty(),
+            "an imagedata pict is an image, not a shape panel"
+        );
+    }
+
+    /// A bare `<w:pict>` imagedata with a dangling `r:id` (not in the media map)
+    /// emits nothing — the part cannot be located, so it is skipped rather than
+    /// producing a path-less image.
+    #[test]
+    fn bare_pict_imagedata_dangling_rid_emits_nothing() {
+        let body = format!(
+            r##"<w:document{ns}><w:body>
+              <w:p><w:r><w:pict>
+                <v:shape id="s1" type="#_x0000_t75" style="width:120pt;height:90pt">
+                  <v:imagedata r:id="rIdMissing"/>
+                </v:shape>
+              </w:pict></w:r></w:p>
+            </w:body></w:document>"##,
+            ns = VML_NS,
+        );
+        let media = HashMap::new();
+        assert!(image_runs(&body, &media).is_empty());
+        assert!(shape_runs(&body, &media).is_empty());
+    }
+
+    /// A `<v:imagedata>` living inside a `<v:group>` uses the GROUP's coordinate
+    /// system (`coordsize`), not points, for the shape's width/height. Resolving
+    /// that requires the full VML group transform, which is a separate feature —
+    /// so a grouped imagedata is left unresolved here (no mis-sized image) rather
+    /// than treating the group-unit dimensions as points. (sample-1's header
+    /// background is exactly this grouped form.)
+    #[test]
+    fn grouped_pict_imagedata_is_not_mis_sized() {
+        let body = format!(
+            r##"<w:document{ns}><w:body>
+              <w:p><w:r><w:pict>
+                <v:group id="g1" style="position:absolute;width:612pt;height:792pt"
+                         coordsize="77724,100584">
+                  <v:shape id="s1" type="#_x0000_t75" style="width:77724;height:100584">
+                    <v:imagedata r:id="rIdBg" o:title="background"/>
+                  </v:shape>
+                </v:group>
+              </w:pict></w:r></w:p>
+            </w:body></w:document>"##,
+            ns = VML_NS,
+        );
+        let mut media = HashMap::new();
+        media.insert("rIdBg".to_string(), "word/media/image50.png".to_string());
+        // No image run with a 77724pt width (the group-unit value taken as pt).
+        let imgs = image_runs(&body, &media);
+        assert!(
+            imgs.iter().all(|i| i.width_pt < 5000.0),
+            "a grouped imagedata must not be sized from group units as pt: {:?}",
+            imgs.iter().map(|i| i.width_pt).collect::<Vec<_>>()
+        );
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -948,6 +948,40 @@ pub struct ShapeRun {
     /// | "largest". Defaults to "bothSides" when absent. Mirrors ImageRun.wrap_side.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wrap_side: Option<String>,
+    /// ECMA-376 Part 4 §19.1.2.23 `<v:textpath>` — WordArt text laid along the
+    /// shape's path (a text watermark). When set the renderer draws this string,
+    /// scaled to fill the shape box (`fitshape`), rotated by `rotation`, and
+    /// filled with `fill`/`fill_opacity`, INSTEAD of a fill/stroke panel + body
+    /// text. `None` for an ordinary VML shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_path: Option<TextPath>,
+    /// ECMA-376 Part 4 §19.1.2.5 `<v:fill opacity>` — the fill's alpha in
+    /// [0.0, 1.0] (default 1.0 ⇒ opaque). Used with `text_path` to draw the
+    /// watermark semi-transparently. `None` ⇒ fully opaque.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fill_opacity: Option<f64>,
+}
+
+/// ECMA-376 Part 4 §19.1.2.23 `<v:textpath>` — a WordArt vector text path. Word
+/// emits this for text watermarks (the `PowerPlusWaterMarkObject` shape). The
+/// text is stretched to fit the shape's bounding box (`fitshape`, the WordArt
+/// `#_x0000_t136` shapetype default), so the on-screen size derives from the
+/// shape geometry rather than the nominal `font-size` in the textpath style.
+#[derive(Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TextPath {
+    /// The `string` attribute — the watermark text (e.g. "DRAFT").
+    pub string: String,
+    /// `font-family` from the textpath `style` CSS `font`/`font-family` (quotes
+    /// stripped). `None` ⇒ the renderer's default family.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub font_family: Option<String>,
+    /// `font-weight:bold` (or the `bold` keyword in the `font` shorthand).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub bold: bool,
+    /// `font-style:italic` (or the `italic` keyword in the `font` shorthand).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub italic: bool,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -54,6 +54,8 @@ export type {
   // ECMA-376 §21.2).
   ChartRun,
   ShapeRun,
+  // VML `<v:textpath>` watermark text (reachable via ShapeRun.textPath).
+  TextPath,
   ShapeText,
   // Per-run shape-text formatting (reachable via ShapeText.runs).
   ShapeTextRun,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,6 +1,6 @@
 import type {
   DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
-  DocRun, DocxTextRun, ImageRun, ChartRun, ShapeRun, ShapeText, ShapeTextRun, FieldRun, HeaderFooter, HeadersFooters, LineSpacing, BorderSpec, TableBorders, CellBorders,
+  DocRun, DocxTextRun, ImageRun, ChartRun, ShapeRun, ShapeFill, TextPath, ShapeText, ShapeTextRun, FieldRun, HeaderFooter, HeadersFooters, LineSpacing, BorderSpec, TableBorders, CellBorders,
   TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, SectionGeom, PageNumType, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr, DocSettings,
 } from './types';
 import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
@@ -6409,6 +6409,74 @@ function resolveShapeBox(
   return { x, y, w, h };
 }
 
+/** The solid fill colour of a shape as a CSS `#rrggbb` string, or `null` when
+ *  the shape has no solid fill (gradient / none). Used for watermark text. */
+function shapeFillColor(fill: ShapeFill | null | undefined): string | null {
+  if (fill && fill.fillType === 'solid') return `#${fill.color}`;
+  return null;
+}
+
+/**
+ * Draw a VML `<v:textpath>` text watermark (ECMA-376 Part 4 §19.1.2.23) into the
+ * box `(x, y, w, h)` (device px). Word emits watermarks with the WordArt
+ * `#_x0000_t136` shapetype, whose `fitshape` default STRETCHES the text to the
+ * edges of the shape box — so the drawn size is derived from the box geometry,
+ * not the nominal `font-size` in the textpath style (which Word writes as a
+ * placeholder `1pt`). The text is:
+ *   - measured once at a reference size to get its natural advance/height,
+ *   - non-uniformly scaled so it exactly fills `w × h` (fitshape),
+ *   - rotated by `rotationDeg` (clockwise, §19.1.2.19) about the box centre,
+ *   - filled with `color` at `opacity` alpha (§19.1.2.5 `<v:fill opacity>`).
+ *
+ * The transform is applied about the box centre and the text is drawn centred
+ * (`textAlign`/`textBaseline` = middle), so the watermark sits centred in its
+ * box regardless of rotation. Exported for unit testing the geometry.
+ */
+export function drawWatermarkTextPath(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  textPath: TextPath,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  rotationDeg: number,
+  color: string | null,
+  opacity: number,
+  fontFamilyClasses: Record<string, string> = {},
+): void {
+  const text = textPath.string;
+  if (!text || w <= 0 || h <= 0) return;
+
+  // Reference measurement at a fixed pixel size; the fitshape scale maps the
+  // natural text box onto the shape box. REF is arbitrary (cancels out in the
+  // scale ratio) but large enough to keep measureText precise.
+  const REF = 100;
+  ctx.save();
+  ctx.font = buildFont(textPath.bold ?? false, textPath.italic ?? false, REF, textPath.fontFamily ?? null, fontFamilyClasses);
+  const m = ctx.measureText(text);
+  const natW = m.width || REF;
+  // Prefer the font bounding box (cap-to-descender) for the natural height; fall
+  // back to the em size when the platform doesn't report it.
+  const asc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? REF * 0.8;
+  const desc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? REF * 0.2;
+  const natH = asc + desc || REF;
+
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+  ctx.translate(cx, cy);
+  if (rotationDeg !== 0) ctx.rotate((rotationDeg * Math.PI) / 180);
+  // fitshape: stretch the text to the box edges (non-uniform). The reference
+  // font renders at REF px; scaling the axes by (w/natW, h/natH) lands the ink
+  // exactly on the box.
+  ctx.scale(w / natW, h / natH);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.globalAlpha = Math.max(0, Math.min(1, opacity));
+  ctx.fillStyle = color ?? '#c0c0c0';
+  ctx.fillText(text, 0, 0);
+  ctx.restore();
+}
+
 function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: number): void {
   const { ctx, scale } = state;
   const { x, y, w, h } = resolveShapeBox(shape, state, paragraphTopPx);
@@ -6432,6 +6500,22 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
     preset.startsWith('bentconnector');
   if (w < 0 || h < 0) return;
   if (isLineGeom ? w === 0 && h === 0 : w === 0 || h === 0) return;
+
+  // ECMA-376 Part 4 §19.1.2.23 `<v:textpath>` — a WordArt text watermark. It
+  // draws stretched, rotated, semi-transparent text filling the shape box
+  // INSTEAD of a fill/stroke panel + body text, then returns.
+  if (shape.textPath && shape.textPath.string.length > 0) {
+    drawWatermarkTextPath(
+      ctx as CanvasRenderingContext2D,
+      shape.textPath,
+      x, y, w, h,
+      shape.rotation ?? 0,
+      shapeFillColor(shape.fill),
+      shape.fillOpacity ?? 1,
+      state.fontFamilyClasses,
+    );
+    return;
+  }
 
   const rot = shape.rotation ?? 0;
   const flipH = shape.flipH ?? false;

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -776,6 +776,30 @@ export interface ShapeRun {
   textInsetT?: number;  // pt
   textInsetR?: number;  // pt
   textInsetB?: number;  // pt
+  /** ECMA-376 Part 4 §19.1.2.23 `<v:textpath>` — WordArt text laid on the
+   *  shape path (a text watermark). When set the renderer draws this string,
+   *  scaled to fill the box (`fitshape`), rotated by {@link ShapeRun.rotation},
+   *  filled with {@link ShapeRun.fill} at {@link ShapeRun.fillOpacity} alpha —
+   *  INSTEAD of a fill/stroke panel + body text. */
+  textPath?: TextPath | null;
+  /** ECMA-376 Part 4 §19.1.2.5 `<v:fill opacity>` — fill alpha in `[0, 1]`
+   *  (default 1 = opaque). Used with {@link ShapeRun.textPath} to draw the
+   *  watermark semi-transparently. Absent ⇒ opaque. */
+  fillOpacity?: number | null;
+}
+
+/** ECMA-376 Part 4 §19.1.2.23 `<v:textpath>` — a WordArt vector text path,
+ *  emitted by Word for text watermarks (the `PowerPlusWaterMarkObject` shape).
+ *  The text is stretched to fit the shape box (`fitshape`, the WordArt
+ *  `#_x0000_t136` shapetype default), so its drawn size derives from the shape
+ *  geometry rather than the nominal `font-size` in the textpath style. */
+export interface TextPath {
+  /** The `string` attribute — the watermark text (e.g. "DRAFT"). */
+  string: string;
+  /** `font-family` from the textpath style (quotes stripped). */
+  fontFamily?: string | null;
+  bold?: boolean;
+  italic?: boolean;
 }
 
 /** DrawingML line-end (arrow head). ECMA-376 §20.1.8.3 CT_LineEndProperties.

--- a/packages/docx/src/watermark-textpath.test.ts
+++ b/packages/docx/src/watermark-textpath.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { drawWatermarkTextPath } from './renderer';
+import type { TextPath } from './types';
+
+/**
+ * ECMA-376 Part 4 §19.1.2.23 `<v:textpath>` text watermark rendering.
+ *
+ * `drawWatermarkTextPath` draws the watermark string filling the shape box
+ * (`fitshape`, §19.1.2.23), rotated by the shape's `rotation` (§19.1.2.19,
+ * clockwise) about the box centre, filled with the shape's `fillcolor` at the
+ * `<v:fill opacity>` alpha (§19.1.2.5). These tests drive it with a recording
+ * canvas context and assert the geometry numerically — the transform sequence
+ * (translate to box centre → rotate → non-uniform scale to the box), the alpha,
+ * the fill colour, and the drawn text — rather than eyeballing pixels.
+ */
+
+interface Op {
+  op: string;
+  args: number[];
+}
+
+function makeRecordingCtx(): {
+  ctx: CanvasRenderingContext2D;
+  ops: Op[];
+  fillTextCalls: { text: string; x: number; y: number; alpha: number; fillStyle: string }[];
+} {
+  let font = '10px serif';
+  let fillStyle = '#000';
+  let globalAlpha = 1;
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ops: Op[] = [];
+  const fillTextCalls: { text: string; x: number; y: number; alpha: number; fillStyle: string }[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string) { fillStyle = v; },
+    get globalAlpha() { return globalAlpha; },
+    set globalAlpha(v: number) { globalAlpha = v; },
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    direction: 'ltr' as CanvasDirection,
+    measureText: (s: string) => {
+      const p = px();
+      // Deterministic: advance = charCount × 0.6 × em; box = 0.8/0.2 em.
+      return {
+        width: [...s].length * p * 0.6,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() { ops.push({ op: 'save', args: [] }); },
+    restore() { ops.push({ op: 'restore', args: [] }); },
+    translate(x: number, y: number) { ops.push({ op: 'translate', args: [x, y] }); },
+    rotate(a: number) { ops.push({ op: 'rotate', args: [a] }); },
+    scale(sx: number, sy: number) { ops.push({ op: 'scale', args: [sx, sy] }); },
+    beginPath() {}, moveTo() {}, lineTo() {}, stroke() {}, fillRect() {},
+    fillText(text: string, x: number, y: number) {
+      fillTextCalls.push({ text, x, y, alpha: globalAlpha, fillStyle });
+      ops.push({ op: 'fillText', args: [x, y] });
+    },
+    strokeText() {},
+    strokeStyle: '#000', lineWidth: 1,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, ops, fillTextCalls };
+}
+
+const draft = (): TextPath => ({ string: 'DRAFT', fontFamily: 'Calibri' });
+
+describe('drawWatermarkTextPath (§19.1.2.23)', () => {
+  it('translates to the box centre, rotates, then non-uniformly scales to fill the box', () => {
+    const { ctx, ops } = makeRecordingCtx();
+    // Box (x=100, y=200, w=400, h=200). Rotation 315° (Word watermark default).
+    drawWatermarkTextPath(ctx, draft(), 100, 200, 400, 200, 315, '#c0c0c0', 0.5);
+
+    const names = ops.map((o) => o.op);
+    // Order: save → translate(centre) → rotate → scale → fillText → restore.
+    expect(names).toEqual(['save', 'translate', 'rotate', 'scale', 'fillText', 'restore']);
+
+    const translate = ops.find((o) => o.op === 'translate')!;
+    // Centre = (100 + 400/2, 200 + 200/2) = (300, 300).
+    expect(translate.args[0]).toBeCloseTo(300, 6);
+    expect(translate.args[1]).toBeCloseTo(300, 6);
+
+    const rotate = ops.find((o) => o.op === 'rotate')!;
+    // 315° clockwise = 315 × π/180 rad.
+    expect(rotate.args[0]).toBeCloseTo((315 * Math.PI) / 180, 6);
+
+    // Scale must map the natural text box onto the shape box (fitshape). With
+    // REF=100px, natW = 5 chars × 100 × 0.6 = 300; natH = 100×(0.8+0.2)=100.
+    const scale = ops.find((o) => o.op === 'scale')!;
+    expect(scale.args[0]).toBeCloseTo(400 / 300, 4); // w / natW
+    expect(scale.args[1]).toBeCloseTo(200 / 100, 4); // h / natH
+  });
+
+  it('draws the text centred at the transformed origin with the fill colour and opacity', () => {
+    const { ctx, fillTextCalls } = makeRecordingCtx();
+    drawWatermarkTextPath(ctx, draft(), 0, 0, 300, 150, 0, '#808080', 0.35);
+    expect(fillTextCalls).toHaveLength(1);
+    const call = fillTextCalls[0];
+    expect(call.text).toBe('DRAFT');
+    // Centred: the transform put the origin at the box centre, so text draws at (0,0).
+    expect(call.x).toBeCloseTo(0, 6);
+    expect(call.y).toBeCloseTo(0, 6);
+    expect(call.alpha).toBeCloseTo(0.35, 6);
+    expect(call.fillStyle).toBe('#808080');
+  });
+
+  it('sets textAlign/textBaseline to centre so the string is centred in its box', () => {
+    const { ctx } = makeRecordingCtx();
+    drawWatermarkTextPath(ctx, draft(), 0, 0, 200, 100, 0, '#c0c0c0', 1);
+    expect(ctx.textAlign).toBe('center');
+    expect(ctx.textBaseline).toBe('middle');
+  });
+
+  it('clamps opacity into [0,1] and falls back to a default fill colour when null', () => {
+    const { ctx, fillTextCalls } = makeRecordingCtx();
+    drawWatermarkTextPath(ctx, draft(), 0, 0, 200, 100, 0, null, 5);
+    expect(fillTextCalls[0].alpha).toBe(1); // clamped from 5
+    expect(fillTextCalls[0].fillStyle).toBe('#c0c0c0'); // default when color=null
+  });
+
+  it('draws nothing for an empty string or a degenerate box', () => {
+    const { ctx: c1, fillTextCalls: f1 } = makeRecordingCtx();
+    drawWatermarkTextPath(c1, { string: '' }, 0, 0, 200, 100, 0, '#000', 1);
+    expect(f1).toHaveLength(0);
+
+    const { ctx: c2, fillTextCalls: f2 } = makeRecordingCtx();
+    drawWatermarkTextPath(c2, draft(), 0, 0, 0, 100, 0, '#000', 1);
+    expect(f2).toHaveLength(0);
+  });
+});

--- a/packages/node/src/docx-vml-watermark.probe.test.ts
+++ b/packages/node/src/docx-vml-watermark.probe.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Pixel-level render + z-order probe for the VML `<v:textpath>` text watermark
+ * (ECMA-376 Part 4 §19.1.2.23), driven end-to-end through the real WASM parser
+ * and the docx renderer on a skia canvas.
+ *
+ * The synthetic `.docx` (built in-memory as a STORED zip, no file committed)
+ * puts Word's canonical `PowerPlusWaterMarkObject` watermark in the header —
+ * "DRAFT", silver fill @0.5 opacity, rotated 315°, centred in the margin box,
+ * negative z-index — and one large centred BLACK body paragraph ("BODYTEXT").
+ *
+ * It MEASURES device pixels (not eyeballs), asserting three things the feature
+ * must guarantee:
+ *   (a) the watermark ink is drawn — grey pixels appear in the page interior;
+ *   (c) it is SEMI-TRANSPARENT — the grey is the silver(192) blended over
+ *       white(255) at α≈0.5 (≈224), NOT opaque silver(192) and NOT white; and
+ *   (b) Z-ORDER — the body's black text sits ON TOP of the watermark: near-black
+ *       glyph pixels exist in the centre band where the two overlap, so the
+ *       watermark (a header shape painted before the body) does not cover the
+ *       text.
+ *
+ * CI-safe: gated on both skia-canvas (devDependency) and the docx WASM (built by
+ * `pnpm build:wasm`); skips locally when either is absent, hard-fails under
+ * OOXML_REQUIRE_SKIA=1.
+ */
+import { describe, it, expect } from 'vitest';
+import { crc32 } from 'node:zlib';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
+const rendererMod = await importForTests(
+  () => import('./../../docx/src/renderer.ts'),
+  'packages/docx/src/renderer.ts',
+);
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed for the watermark probe');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+  'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ' +
+  'xmlns:v="urn:schemas-microsoft-com:vml" ' +
+  'xmlns:o="urn:schemas-microsoft-com:office:office" ' +
+  'xmlns:w10="urn:schemas-microsoft-com:office:word"';
+
+function storedZip(files: Record<string, string>): Uint8Array {
+  const enc = new TextEncoder();
+  const chunks: number[] = [];
+  const central: number[] = [];
+  const u16 = (n: number) => [n & 0xff, (n >> 8) & 0xff];
+  const u32 = (n: number) => [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff];
+  let offset = 0;
+  for (const [name, content] of Object.entries(files)) {
+    const nameBytes = [...enc.encode(name)];
+    const data = [...enc.encode(content)];
+    const crc = crc32(Uint8Array.from(data)) >>> 0;
+    const local = [
+      ...u32(0x04034b50), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...nameBytes, ...data,
+    ];
+    central.push(
+      ...u32(0x02014b50), ...u16(20), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...u16(0), ...u16(0), ...u16(0), ...u32(0), ...u32(offset),
+      ...nameBytes,
+    );
+    chunks.push(...local);
+    offset += local.length;
+  }
+  const centralOffset = offset;
+  const end = [
+    ...u32(0x06054b50), ...u16(0), ...u16(0),
+    ...u16(Object.keys(files).length), ...u16(Object.keys(files).length),
+    ...u32(central.length), ...u32(centralOffset), ...u16(0),
+  ];
+  return Uint8Array.from([...chunks, ...central, ...end]);
+}
+
+function watermarkDocx(): Uint8Array {
+  const contentTypes =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+    '</Types>';
+  const rootRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+    '</Relationships>';
+  const docRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rIdHdr" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>' +
+    '</Relationships>';
+  const document =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document ${NS}><w:body>` +
+    // Several centred lines of big black text spanning the vertical centre so the
+    // body ink overlaps the diagonal watermark band.
+    '<w:p><w:pPr><w:jc w:val="center"/></w:pPr>' +
+    '<w:r><w:rPr><w:color w:val="000000"/><w:sz w:val="80"/></w:rPr><w:t>BBBBBBBBBB</w:t></w:r></w:p>' +
+    '<w:p><w:pPr><w:jc w:val="center"/></w:pPr>' +
+    '<w:r><w:rPr><w:color w:val="000000"/><w:sz w:val="80"/></w:rPr><w:t>BBBBBBBBBB</w:t></w:r></w:p>' +
+    '<w:p><w:pPr><w:jc w:val="center"/></w:pPr>' +
+    '<w:r><w:rPr><w:color w:val="000000"/><w:sz w:val="80"/></w:rPr><w:t>BBBBBBBBBB</w:t></w:r></w:p>' +
+    '<w:sectPr><w:headerReference w:type="default" r:id="rIdHdr"/>' +
+    '<w:pgSz w:w="12240" w:h="15840"/>' +
+    '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/>' +
+    '</w:sectPr></w:body></w:document>';
+  const header =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:hdr ${NS}><w:p><w:r><w:pict>` +
+    '<v:shape id="PowerPlusWaterMarkObject357476642" type="#_x0000_t136" ' +
+    'style="position:absolute;margin-left:0;margin-top:0;width:415pt;height:207.5pt;rotation:315;' +
+    'z-index:-251657216;mso-position-horizontal:center;mso-position-horizontal-relative:margin;' +
+    'mso-position-vertical:center;mso-position-vertical-relative:margin" fillcolor="silver" stroked="f">' +
+    '<v:fill opacity=".5"/>' +
+    '<v:textpath style="font-family:&quot;Calibri&quot;;font-size:1pt" string="DRAFT"/>' +
+    '</v:shape></w:pict></w:r></w:p></w:hdr>';
+  return storedZip({
+    '[Content_Types].xml': contentTypes,
+    '_rels/.rels': rootRels,
+    'word/_rels/document.xml.rels': docRels,
+    'word/document.xml': document,
+    'word/header1.xml': header,
+  });
+}
+
+interface Rendered {
+  data: Uint8ClampedArray;
+  w: number;
+  h: number;
+}
+
+async function render(): Promise<Rendered> {
+  const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => { section: { pageWidth: number; pageHeight: number } } };
+  const doc = parseDocx(watermarkDocx());
+  const { renderDocumentToCanvas } = rendererMod as {
+    renderDocumentToCanvas: (
+      doc: unknown,
+      canvas: unknown,
+      pageIndex: number,
+      opts: { dpr: number; width: number },
+    ) => Promise<void>;
+  };
+  const widthPx = doc.section.pageWidth; // scale 1 px/pt
+  const heightPx = doc.section.pageHeight;
+  const canvas = new Canvas(Math.round(widthPx), Math.round(heightPx));
+  const restoreImg = installImageBitmapShim(factory);
+  const restoreOff = installOffscreenCanvasShim(factory);
+  try {
+    await renderDocumentToCanvas(doc, canvas, 0, { dpr: 1, width: widthPx });
+  } finally {
+    restoreOff();
+    restoreImg();
+  }
+  const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+  const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  return { data: img.data, w: canvas.width, h: canvas.height };
+}
+
+function lum(r: number, g: number, b: number): number {
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+describe.skipIf(!skia || !docxMod || !rendererMod)('VML text watermark render (§19.1.2.23)', () => {
+  it('draws a semi-transparent watermark with the body text on top (z-order)', async () => {
+    const { data, w, h } = await render();
+
+    // Classify each pixel in the page interior (inside margins ~ 1in @ scale 1 =
+    // 96px, so scan 120..w-120 × 120..h-120) as white / grey (watermark) / dark
+    // (text). Neutral (near-grey) classification avoids counting anti-aliased
+    // edges.
+    let greyWatermark = 0;
+    let darkText = 0;
+    const greyLums: number[] = [];
+    const x0 = 120, x1 = w - 120, y0 = 120, y1 = h - 120;
+    for (let y = y0; y < y1; y++) {
+      for (let x = x0; x < x1; x++) {
+        const i = (y * w + x) * 4;
+        const r = data[i], g = data[i + 1], b = data[i + 2];
+        const L = lum(r, g, b);
+        const spread = Math.max(r, g, b) - Math.min(r, g, b);
+        if (spread > 24) continue; // coloured / edge pixel — skip
+        if (L < 90) {
+          darkText++;
+        } else if (L >= 200 && L < 248) {
+          greyWatermark++;
+          greyLums.push(L);
+        }
+      }
+    }
+
+    // (a) the watermark is drawn — a meaningful count of grey pixels.
+    expect(greyWatermark, 'watermark grey ink present in the page interior').toBeGreaterThan(500);
+
+    // (c) it is SEMI-TRANSPARENT: silver(192) over white(255) at α≈0.5 → ≈224.
+    //     Median grey must sit in the blended band, well above opaque silver(192)
+    //     and below white(248). (Opaque silver would land ≈192.)
+    greyLums.sort((p, q) => p - q);
+    const median = greyLums[Math.floor(greyLums.length / 2)];
+    expect(median, `median watermark luminance ${median} in the α≈0.5 band`).toBeGreaterThan(205);
+    expect(median).toBeLessThan(245);
+
+    // (b) Z-ORDER: the body's black glyphs are visible in the vertical centre
+    //     band where they overlap the watermark. If the watermark (header shape)
+    //     covered the text there would be no near-black ink in the interior.
+    expect(darkText, 'black body text visible on top of the watermark').toBeGreaterThan(500);
+  });
+});

--- a/packages/node/src/docx-vml-watermark.test.ts
+++ b/packages/node/src/docx-vml-watermark.test.ts
@@ -1,0 +1,165 @@
+/**
+ * End-to-end parse of a VML text watermark (ECMA-376 Part 4 §19.1.2.23
+ * `<v:textpath>`) and a bare VML picture (§19.1.2.11 `<v:imagedata>`) through
+ * the real WASM parser.
+ *
+ * Word emits a text watermark as a legacy VML `PowerPlusWaterMarkObject`: a
+ * `<v:shape type="#_x0000_t136">` in a header, positioned absolute + centred in
+ * the margin box, rotated, `stroked="f"`, with a `<v:fill opacity>` and a
+ * `<v:textpath string="…" style="font-family:…">`. There is no such fixture in
+ * the private corpus (verified by unzipping every sample-*.docx), so the test
+ * SYNTHESISES the exact XML Word writes into a minimal, self-contained `.docx`
+ * (built in-memory as a STORED zip — no file committed, no zip dependency) and
+ * asserts the parsed model. The expected values are derived from the VML spec,
+ * not from any renderer output.
+ *
+ * The pixel-level render + z-order verification lives in the skia probe
+ * (`docx-vml-watermark.probe.test.ts`); this test covers the parser contract and
+ * runs everywhere the docx WASM is built.
+ */
+import { describe, it, expect } from 'vitest';
+import { crc32 } from 'node:zlib';
+import { importForTests } from './test-imports';
+
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
+
+/** Build a minimal STORED (method 0, uncompressed) ZIP from `{name: bytes}`.
+ *  The Rust `zip` crate reads stored entries, so no compression is needed. */
+function storedZip(files: Record<string, string>): Uint8Array {
+  const enc = new TextEncoder();
+  const chunks: number[] = [];
+  const central: number[] = [];
+  const u16 = (n: number) => [n & 0xff, (n >> 8) & 0xff];
+  const u32 = (n: number) => [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff];
+  let offset = 0;
+  for (const [name, content] of Object.entries(files)) {
+    const nameBytes = [...enc.encode(name)];
+    const data = [...enc.encode(content)];
+    const crc = crc32(Uint8Array.from(data)) >>> 0;
+    const local = [
+      ...u32(0x04034b50), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...nameBytes, ...data,
+    ];
+    central.push(
+      ...u32(0x02014b50), ...u16(20), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...u16(0), ...u16(0), ...u16(0), ...u32(0), ...u32(offset),
+      ...nameBytes,
+    );
+    chunks.push(...local);
+    offset += local.length;
+  }
+  const centralOffset = offset;
+  const end = [
+    ...u32(0x06054b50), ...u16(0), ...u16(0),
+    ...u16(Object.keys(files).length), ...u16(Object.keys(files).length),
+    ...u32(central.length), ...u32(centralOffset), ...u16(0),
+  ];
+  return Uint8Array.from([...chunks, ...central, ...end]);
+}
+
+const NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+  'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ' +
+  'xmlns:v="urn:schemas-microsoft-com:vml" ' +
+  'xmlns:o="urn:schemas-microsoft-com:office:office" ' +
+  'xmlns:w10="urn:schemas-microsoft-com:office:word"';
+
+function watermarkDocx(): Uint8Array {
+  const contentTypes =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+    '</Types>';
+  const rootRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+    '</Relationships>';
+  const docRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rIdHdr" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>' +
+    '</Relationships>';
+  const document =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document ${NS}><w:body>` +
+    '<w:p><w:pPr><w:jc w:val="center"/></w:pPr>' +
+    '<w:r><w:rPr><w:color w:val="000000"/><w:sz w:val="72"/></w:rPr><w:t>BODYTEXT</w:t></w:r></w:p>' +
+    '<w:sectPr><w:headerReference w:type="default" r:id="rIdHdr"/>' +
+    '<w:pgSz w:w="12240" w:h="15840"/>' +
+    '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/>' +
+    '</w:sectPr></w:body></w:document>';
+  const header =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:hdr ${NS}><w:p><w:r><w:pict>` +
+    '<v:shape id="PowerPlusWaterMarkObject357476642" type="#_x0000_t136" ' +
+    'style="position:absolute;margin-left:0;margin-top:0;width:415pt;height:207.5pt;rotation:315;' +
+    'z-index:-251657216;mso-position-horizontal:center;mso-position-horizontal-relative:margin;' +
+    'mso-position-vertical:center;mso-position-vertical-relative:margin" fillcolor="silver" stroked="f">' +
+    '<v:fill opacity=".5"/>' +
+    '<v:textpath style="font-family:&quot;Calibri&quot;;font-size:1pt" string="DRAFT"/>' +
+    '</v:shape></w:pict></w:r></w:p></w:hdr>';
+  return storedZip({
+    '[Content_Types].xml': contentTypes,
+    '_rels/.rels': rootRels,
+    'word/_rels/document.xml.rels': docRels,
+    'word/document.xml': document,
+    'word/header1.xml': header,
+  });
+}
+
+interface AnyRun {
+  type?: string;
+  text?: string;
+  textPath?: { string?: string; fontFamily?: string | null };
+  rotation?: number;
+  fill?: { fillType?: string; color?: string } | null;
+  fillOpacity?: number | null;
+  behindDoc?: boolean;
+  anchorXAlign?: string | null;
+  anchorYAlign?: string | null;
+  anchorXRelativeFrom?: string | null;
+  anchorYRelativeFrom?: string | null;
+  widthPt?: number;
+  heightPt?: number;
+}
+
+describe.skipIf(!docxMod)('VML text watermark (§19.1.2.23) end-to-end parse', () => {
+  it('surfaces the header watermark shape with text, rotation, fill and opacity', () => {
+    const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => unknown };
+    const doc = parseDocx(watermarkDocx()) as {
+      headers: { default: { body: { runs?: AnyRun[] }[] } | null };
+      body: { runs?: AnyRun[] }[];
+    };
+    const hdr = doc.headers.default;
+    expect(hdr, 'default header present').toBeTruthy();
+    const hdrRuns = hdr!.body.flatMap((el) => el.runs ?? []);
+    const shape = hdrRuns.find((r) => r.type === 'shape');
+    expect(shape, 'header carries a shape run').toBeTruthy();
+
+    // §19.1.2.23 textpath string + font (quotes stripped).
+    expect(shape!.textPath?.string).toBe('DRAFT');
+    expect(shape!.textPath?.fontFamily).toBe('Calibri');
+    // §19.1.2.19 rotation (clockwise).
+    expect(shape!.rotation).toBeCloseTo(315, 3);
+    // fillcolor silver → c0c0c0, §19.1.2.5 opacity .5.
+    expect(shape!.fill).toEqual({ fillType: 'solid', color: 'c0c0c0' });
+    expect(shape!.fillOpacity).toBeCloseTo(0.5, 6);
+    // Centred in the margin box, behind the body (negative z-index).
+    expect(shape!.behindDoc).toBe(true);
+    expect(shape!.anchorXAlign).toBe('center');
+    expect(shape!.anchorYAlign).toBe('center');
+    expect(shape!.anchorXRelativeFrom).toBe('margin');
+    expect(shape!.anchorYRelativeFrom).toBe('margin');
+    // Box size from the shape CSS style (pt).
+    expect(shape!.widthPt).toBeCloseTo(415, 6);
+    expect(shape!.heightPt).toBeCloseTo(207.5, 6);
+
+    // The body carries the black text that must sit ON TOP of the watermark.
+    const bodyRuns = doc.body.flatMap((el) => el.runs ?? []);
+    expect(bodyRuns.find((r) => r.type === 'text')?.text).toBe('BODYTEXT');
+  });
+});


### PR DESCRIPTION
Completes the remaining **WD3** work for docx legacy VML (`<w:pict>` / `<w:object>`). The OLE-preview `v:imagedata` path landed earlier; this adds the three remaining pieces, each spec-driven (ECMA-376 **Part 4** VML Reference §19.1.2, Part 1 §17.3.3.19).

## 1. Bare `<w:pict>` `<v:imagedata>` → inline image (§19.1.2.11)
A `<w:pict>` whose `<v:shape>` carries a `<v:imagedata r:id>` with **no** `<w:object>` wrapper is a non-OLE inline VML picture (e.g. a header picture Word emits as VML instead of DrawingML). Previously it fell into the text-box path and became an empty rectangle. It now resolves the rId through the media map and emits an inline `ImageRun` sized from the shape's CSS `style` width/height in pt (§19.1.2.19), feeding the same pipeline as a DrawingML `<a:blip>` picture.

Guards (spec-faithful, not heuristic):
- A shape carrying `<v:imagedata>` is excluded from the text-box path, so a picture is never turned into a fill/stroke panel, and a dangling rId is dropped (matching the OLE preview behaviour) rather than drawn as a box.
- A **grouped** imagedata (`<v:group>`) is left unresolved: a grouped shape's width/height are in the group coordinate system (`coordsize`), not points, so treating them as pt would badly mis-size the image. Resolving the VML group transform is a separate feature (sample-1's header background is exactly this grouped form).

## 2. `<v:textpath>` text watermark (§19.1.2.23)
Word emits a text watermark as a legacy VML `PowerPlusWaterMarkObject`: a `<v:shape type="#_x0000_t136">` in a header, positioned absolute + centred in the margin box, rotated, `stroked="f"`, with a `<v:fill opacity>` and a `<v:textpath string="…" style="font-family:…">`.

**Parser**: new `TextPath` model (string + font family/weight/style) on `ShapeRun`, plus `fill_opacity` (§19.1.2.5 `<v:fill opacity>`, incl. the `52429f` 1/65536-ths form). `parse_vml_pict` now reads `<v:textpath>`, the shape's `rotation` (§19.1.2.19, clockwise), `<v:fill opacity>`, `fillcolor` (named colours resolved via `ooxml_common::theme::preset_color`), `stroked="f"`, and maps `mso-position-horizontal/vertical` + `-relative` (§19.1.2.19) onto the shared anchor align/relativeFrom model. A negative `z-index` sets `behindDoc`.

**Renderer**: `drawWatermarkTextPath` draws the string filling the shape box (`fitshape`: non-uniform scale to the box edges), rotated about the box centre, filled with the shape colour at the fill opacity. `renderAnchorShape` short-circuits to it when `textPath` is set. Header shapes already paint before the body, so a header-borne watermark lands behind the text.

## 3. CT_Object `<w:drawing>` first-child delegation (§17.3.3.19)
Per the schema `CT_Object = sequence(drawing?, choice(control|objectLink|objectEmbed|movie)?)`, the optional first child `<w:drawing>` is the object's modern DrawingML static representation. When present it IS the object's on-page picture, so the object dispatcher now delegates to `parse_inline_drawing` and only falls back to the legacy VML `<v:imagedata>` preview when there is no `<w:drawing>` child — handling the modern form and preventing a double-draw of Word's back-compat output.

## Fixtures & verification
No watermark/imagedata fixture exists in the private corpus (verified by unzipping every `sample-*.docx`), so the watermark is verified against **synthesised** Word-canonical XML built in-memory as a stored zip (no docx committed):
- **Rust unit tests** (parser): bare-pict imagedata (inline / dangling / grouped), CT_Object drawing delegation (+ no double-emit), and the watermark (textpath string/font, rotation, fill, opacity fraction form, mso-position mapping, behindDoc). — `253 passed`.
- **`drawWatermarkTextPath` unit test** (renderer): the transform sequence (translate→rotate→non-uniform scale), alpha, fill colour, centring — asserted numerically.
- **End-to-end Node test**: parses the synthetic watermark docx through the real WASM parser and asserts the header shape model.
- **Skia render probe** (CI-gated): renders the page and MEASURES device pixels — the watermark is drawn, is semi-transparent (silver-over-white α≈0.5 → median luminance ≈224, not opaque 192), and the black body text sits **on top** (z-order). Measured locally: greyWatermark=19853, darkText=5228, medianGrey=224.

Non-regression: full docx + node vitest (`770 passed`), root `tsc --build`, ast-grep, and `cargo fmt`/`clippy`/`test` all green. The pict-bearing private samples (5/6/8/9/10/15) still produce their text-box shapes and images unchanged (0 accidental textpath shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)