### PR TITLE
feat(xlsx): furigana / phonetic hints (rPh + phoneticPr, §18.4.6/§18.4.3)

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -3815,6 +3815,85 @@ mod rb7_partial_degradation_tests {
         buf
     }
 
+    /// Build a synthetic workbook whose one shared string ("課長") carries a
+    /// `<phoneticPr>` + two `<rPh>` runs, and whose sheet has an A1 cell with
+    /// `ph="1"` (opts into the furigana) and a B1 cell with the same string but
+    /// no `ph` (furigana off). Mirrors the ph=true/ph=false split of the
+    /// private fixtures. Styles include a small phonetic font at index 2.
+    fn build_phonetic_workbook() -> Vec<u8> {
+        let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        let sheet = format!(
+            r#"<worksheet xmlns="{ns}"><sheetData><row r="1"><c r="A1" t="s" ph="1"><v>0</v></c><c r="B1" t="s"><v>0</v></c></row></sheetData></worksheet>"#
+        );
+        let ss = format!(
+            r#"<sst xmlns="{ns}" count="2" uniqueCount="1"><si><t>課長</t><rPh sb="0" eb="1"><t>カ</t></rPh><rPh sb="1" eb="2"><t>チョウ</t></rPh><phoneticPr fontId="2" alignment="center"/></si></sst>"#
+        );
+        let workbook = format!(
+            r#"<workbook xmlns="{ns}" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Alpha" sheetId="1" r:id="rId1"/></sheets></workbook>"#
+        );
+        let wb_rels = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>"#;
+        let styles = format!(
+            r#"<styleSheet xmlns="{ns}"><fonts count="3"><font><sz val="11"/><name val="Calibri"/></font><font><sz val="11"/><name val="Calibri"/></font><font><sz val="6"/><name val="Calibri"/></font></fonts><fills count="1"><fill><patternFill patternType="none"/></fill></fills><borders count="1"><border/></borders><cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellXfs></styleSheet>"#
+        );
+        let entries: Vec<(String, String)> = vec![
+            ("xl/workbook.xml".into(), workbook),
+            ("xl/_rels/workbook.xml.rels".into(), wb_rels.into()),
+            ("xl/worksheets/sheet1.xml".into(), sheet),
+            ("xl/styles.xml".into(), styles),
+            ("xl/sharedStrings.xml".into(), ss),
+        ];
+        let mut buf = Vec::new();
+        {
+            let mut w = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let o = zip::write::SimpleFileOptions::default();
+            for (name, body) in &entries {
+                w.start_file(name.as_str(), o).unwrap();
+                w.write_all(body.as_bytes()).unwrap();
+            }
+            w.finish().unwrap();
+        }
+        buf
+    }
+
+    /// End-to-end (real zip → JSON): a `<si>` with `<rPh>`/`<phoneticPr>` surfaces
+    /// on the shared-string table, and the cell `ph` attribute flows onto the
+    /// per-cell `showPhonetic` flag. B1 (no `ph`) stays false even though it
+    /// references the SAME phonetic string — the reading is display-off there,
+    /// exactly like the private fixtures (rPh present, no cell opts in).
+    #[test]
+    fn phonetic_workbook_round_trips_rph_and_cell_ph() {
+        let data = build_phonetic_workbook();
+        // The full `ParsedWorkbook` (what `parse_xlsx` ships to TS) carries the
+        // phonetic shared string in its `sharedStrings` table.
+        let parsed = parse_xlsx_inner(&data).expect("workbook opens");
+        let wb_json = serde_json::to_string(&parsed).unwrap();
+        let wb: serde_json::Value = serde_json::from_str(&wb_json).unwrap();
+        let si0 = &wb["sharedStrings"][0];
+        assert_eq!(si0["text"].as_str(), Some("課長"), "base text only");
+        let rph = si0["phoneticRuns"]
+            .as_array()
+            .expect("phoneticRuns present");
+        assert_eq!(rph.len(), 2);
+        assert_eq!(rph[0]["sb"].as_u64(), Some(0));
+        assert_eq!(rph[0]["eb"].as_u64(), Some(1));
+        assert_eq!(rph[0]["text"].as_str(), Some("カ"));
+        assert_eq!(si0["phoneticPr"]["fontId"].as_u64(), Some(2));
+        assert_eq!(si0["phoneticPr"]["alignment"].as_str(), Some("center"));
+        // type absent → the consumer applies the fullwidthKatakana default.
+        assert!(si0["phoneticPr"].get("type").is_none());
+
+        // The sheet's A1 opts in (ph=1); B1 does not (schema default false).
+        let ws = parse_sheet_json(&data, 0, "Alpha");
+        let cells = ws["rows"][0]["cells"].as_array().unwrap();
+        let a1 = cells.iter().find(|c| c["col"].as_u64() == Some(1)).unwrap();
+        let b1 = cells.iter().find(|c| c["col"].as_u64() == Some(2)).unwrap();
+        assert_eq!(a1["showPhonetic"].as_bool(), Some(true), "A1 ph=1 → show");
+        assert!(
+            b1.get("showPhonetic").is_none() || b1["showPhonetic"].as_bool() == Some(false),
+            "B1 has no ph → showPhonetic omitted/false; got {b1}"
+        );
+    }
+
     /// #773: a PRESENT-but-corrupt `xl/sharedStrings.xml` (§18.4.9) silently
     /// blanked every string cell before this fix. Now the workbook still opens (no
     /// sheet is taken down) but the loss is SURFACED as a workbook-level,

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -762,6 +762,11 @@ fn parse_si_node(node: &roxmltree::Node, theme_colors: &[String]) -> SharedStrin
     let mut text = String::new();
     let mut runs: Vec<Run> = Vec::new();
     let mut has_runs = false;
+    // ECMA-376 §18.4.6 `<rPh>` phonetic runs (furigana) and §18.4.3
+    // `<phoneticPr>` display properties. Accumulated alongside the base text so
+    // a String Item's reading rides with the string without polluting `text`.
+    let mut phonetic_runs: Vec<PhoneticRun> = Vec::new();
+    let mut phonetic_pr: Option<PhoneticProperties> = None;
     for child in node.children() {
         if !child.is_element() {
             continue;
@@ -771,6 +776,45 @@ fn parse_si_node(node: &roxmltree::Node, theme_colors: &[String]) -> SharedStrin
                 if let Some(s) = child.text() {
                     text.push_str(s);
                 }
+            }
+            "rPh" if is_x_ns(child.tag_name().namespace()) => {
+                // §18.4.6: sb/eb are zero-based base-text character offsets
+                // (sb < eb). The hint text sits in the child <t>.
+                let sb: u32 = child
+                    .attribute("sb")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                let eb: u32 = child
+                    .attribute("eb")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                let mut rph_text = String::new();
+                for rc in child.children() {
+                    if rc.tag_name().name() == "t" {
+                        if let Some(s) = rc.text() {
+                            rph_text.push_str(s);
+                        }
+                    }
+                }
+                phonetic_runs.push(PhoneticRun {
+                    sb,
+                    eb,
+                    text: rph_text,
+                });
+            }
+            "phoneticPr" if is_x_ns(child.tag_name().namespace()) => {
+                // §18.4.3: fontId required (0-based into styles fonts); type
+                // defaults to fullwidthKatakana, alignment to left. We carry
+                // the raw enum strings; the renderer applies the defaults.
+                let font_id: u32 = child
+                    .attribute("fontId")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                phonetic_pr = Some(PhoneticProperties {
+                    font_id,
+                    r#type: child.attribute("type").map(|s| s.to_string()),
+                    alignment: child.attribute("alignment").map(|s| s.to_string()),
+                });
             }
             "r" if is_x_ns(child.tag_name().namespace()) => {
                 has_runs = true;
@@ -839,6 +883,8 @@ fn parse_si_node(node: &roxmltree::Node, theme_colors: &[String]) -> SharedStrin
     SharedString {
         text,
         runs: if has_runs { Some(runs) } else { None },
+        phonetic_runs,
+        phonetic_pr,
     }
 }
 /// Pending cell-hyperlink descriptors, awaiting rels resolution of the external
@@ -2231,6 +2277,8 @@ fn parse_row_cells(
                     CellValue::Text {
                         text: ss.text,
                         runs: ss.runs,
+                        phonetic_runs: ss.phonetic_runs,
+                        phonetic_pr: ss.phonetic_pr,
                     }
                 }
                 None => CellValue::Empty,
@@ -2251,6 +2299,8 @@ fn parse_row_cells(
                 "str" => CellValue::Text {
                     text: v_text,
                     runs: None,
+                    phonetic_runs: Vec::new(),
+                    phonetic_pr: None,
                 },
                 "b" => CellValue::Bool {
                     bool: v_text == "1" || v_text == "true",
@@ -2263,11 +2313,18 @@ fn parse_row_cells(
                         CellValue::Text {
                             text: v_text,
                             runs: None,
+                            phonetic_runs: Vec::new(),
+                            phonetic_pr: None,
                         }
                     }
                 }
             }
         };
+
+        // ECMA-376 §18.3.1.4 `<c ph="1">` — per-cell furigana display toggle.
+        // Defaults to false (schema default), so a cell only shows its String
+        // Item's phonetic hint when it explicitly opts in.
+        let show_phonetic = attr_bool(&c_node, "ph").unwrap_or(false);
 
         cells.push(Cell {
             col,
@@ -2275,6 +2332,7 @@ fn parse_row_cells(
             value,
             style_index,
             formula,
+            show_phonetic,
         });
     }
     cells
@@ -3186,6 +3244,7 @@ mod strict_namespace_cell_tests {
         let shared = vec![SharedString {
             text: "Shared Hello".to_string(),
             runs: None,
+            ..Default::default()
         }];
         let xml = format!(
             r#"<worksheet xmlns="{ns}">
@@ -3225,6 +3284,124 @@ mod strict_namespace_cell_tests {
         match &cells[2].value {
             CellValue::Number { number } => assert_eq!(*number, 42.5),
             other => panic!("expected a number, got {other:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod phonetic_tests {
+    use super::*;
+
+    const NS: &str = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    /// ECMA-376 §18.4.6 / §18.4.3: a `<si>` with `<rPh>` runs and a
+    /// `<phoneticPr>` must parse the furigana runs (sb/eb + hint text) and the
+    /// display properties, while `text` stays the base string only.
+    #[test]
+    fn parse_si_node_reads_rph_and_phonetic_pr() {
+        let xml = format!(
+            r#"<si xmlns="{ns}"><t>課長</t><rPh sb="0" eb="1"><t>カ</t></rPh><rPh sb="1" eb="2"><t>チョウ</t></rPh><phoneticPr fontId="2" type="Hiragana" alignment="center"/></si>"#,
+            ns = NS,
+        );
+        let doc = roxmltree::Document::parse(&xml).expect("parse");
+        let ss = parse_si_node(&doc.root_element(), &[]);
+        assert_eq!(ss.text, "課長", "base text excludes the furigana");
+        assert_eq!(ss.phonetic_runs.len(), 2, "two rPh runs");
+        assert_eq!(ss.phonetic_runs[0].sb, 0);
+        assert_eq!(ss.phonetic_runs[0].eb, 1);
+        assert_eq!(ss.phonetic_runs[0].text, "カ");
+        assert_eq!(ss.phonetic_runs[1].sb, 1);
+        assert_eq!(ss.phonetic_runs[1].eb, 2);
+        assert_eq!(ss.phonetic_runs[1].text, "チョウ");
+        let pr = ss.phonetic_pr.expect("phoneticPr present");
+        assert_eq!(pr.font_id, 2);
+        assert_eq!(pr.r#type.as_deref(), Some("Hiragana"));
+        assert_eq!(pr.alignment.as_deref(), Some("center"));
+    }
+
+    /// A `<phoneticPr>` with only the required `fontId` leaves `type` /
+    /// `alignment` absent so the consumer applies the schema defaults
+    /// (fullwidthKatakana / left) rather than a wrong hard-coded value.
+    #[test]
+    fn phonetic_pr_omits_optional_attrs_when_absent() {
+        let xml = format!(
+            r#"<si xmlns="{ns}"><t>山</t><rPh sb="0" eb="1"><t>ヤマ</t></rPh><phoneticPr fontId="1"/></si>"#,
+            ns = NS,
+        );
+        let doc = roxmltree::Document::parse(&xml).expect("parse");
+        let ss = parse_si_node(&doc.root_element(), &[]);
+        let pr = ss.phonetic_pr.expect("phoneticPr present");
+        assert_eq!(pr.font_id, 1);
+        assert!(pr.r#type.is_none(), "type absent → consumer defaults");
+        assert!(
+            pr.alignment.is_none(),
+            "alignment absent → consumer defaults"
+        );
+    }
+
+    /// A `<si>` with NO phonetic markup yields empty phonetic_runs and no
+    /// phonetic_pr, so non-Japanese workbooks stay byte-identical on the wire.
+    #[test]
+    fn plain_si_has_no_phonetic_data() {
+        let xml = format!(r#"<si xmlns="{ns}"><t>Hello</t></si>"#, ns = NS);
+        let doc = roxmltree::Document::parse(&xml).expect("parse");
+        let ss = parse_si_node(&doc.root_element(), &[]);
+        assert!(ss.phonetic_runs.is_empty());
+        assert!(ss.phonetic_pr.is_none());
+    }
+
+    /// ECMA-376 §18.3.1.4 `<c ph="1">` sets the cell's show_phonetic flag;
+    /// a cell without `ph` (or with `ph="0"`) stays false (schema default).
+    #[test]
+    fn cell_ph_attribute_drives_show_phonetic() {
+        let xml = format!(
+            r#"<worksheet xmlns="{ns}"><sheetData><row r="1">
+              <c r="A1" t="s" ph="1"><v>0</v></c>
+              <c r="B1" t="s" ph="0"><v>0</v></c>
+              <c r="C1" t="s"><v>0</v></c>
+            </row></sheetData></worksheet>"#,
+            ns = NS,
+        );
+        let shared = vec![SharedString {
+            text: "課長".to_string(),
+            ..Default::default()
+        }];
+        let (ws, _) = parse_worksheet(&xml, &shared, &[], "Sheet1").expect("parse");
+        let cells = &ws.rows[0].cells;
+        assert!(cells[0].show_phonetic, "ph=1 → show");
+        assert!(!cells[1].show_phonetic, "ph=0 → hide");
+        assert!(
+            !cells[2].show_phonetic,
+            "no ph → hide (schema default false)"
+        );
+    }
+
+    /// An inline string (`t="inlineStr"`) carries its own `<rPh>` runs straight
+    /// onto the resolved `CellValue::Text` (no shared-string indirection).
+    #[test]
+    fn inline_string_carries_phonetic_runs() {
+        let xml = format!(
+            r#"<worksheet xmlns="{ns}"><sheetData><row r="1">
+              <c r="A1" t="inlineStr" ph="1"><is><t>森</t><rPh sb="0" eb="1"><t>モリ</t></rPh><phoneticPr fontId="1"/></is></c>
+            </row></sheetData></worksheet>"#,
+            ns = NS,
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("parse");
+        let cell = &ws.rows[0].cells[0];
+        assert!(cell.show_phonetic);
+        match &cell.value {
+            CellValue::Text {
+                text,
+                phonetic_runs,
+                phonetic_pr,
+                ..
+            } => {
+                assert_eq!(text, "森");
+                assert_eq!(phonetic_runs.len(), 1);
+                assert_eq!(phonetic_runs[0].text, "モリ");
+                assert_eq!(phonetic_pr.as_ref().expect("pr").font_id, 1);
+            }
+            other => panic!("expected text cell, got {other:?}"),
         }
     }
 }

--- a/packages/xlsx/parser/src/markdown.rs
+++ b/packages/xlsx/parser/src/markdown.rs
@@ -218,10 +218,12 @@ mod tests {
             SharedString {
                 text: "Alpha".to_string(),
                 runs: None,
+                ..Default::default()
             },
             SharedString {
                 text: "Beta".to_string(),
                 runs: None,
+                ..Default::default()
             },
         ];
         let sheet = json!({

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -978,6 +978,13 @@ pub struct Cell {
     /// last saved) doesn't show a stale date.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub formula: Option<String>,
+    /// ECMA-376 §18.3.1.4 `<c ph="1">` — whether this cell should display its
+    /// phonetic hint (furigana). Defaults to `false` (the schema default), so a
+    /// cell whose String Item carries `<rPh>` runs still shows NO furigana
+    /// unless the cell opts in with `ph="1"`. This mirrors Excel: the shared
+    /// string keeps the reading, but display is a per-cell toggle.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub show_phonetic: bool,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -989,6 +996,15 @@ pub enum CellValue {
         text: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         runs: Option<Vec<Run>>,
+        /// ECMA-376 §18.4.6 phonetic runs (furigana) for this text, carried
+        /// over from the resolved String Item. Only populated for inline
+        /// strings here; shared-string cells ship a `Shared { si }` reference
+        /// and the consumer pulls the phonetic data off the `SharedString`.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        phonetic_runs: Vec<PhoneticRun>,
+        /// ECMA-376 §18.4.3 phonetic display properties for the furigana above.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        phonetic_pr: Option<PhoneticProperties>,
     },
     Number {
         number: f64,
@@ -1044,6 +1060,56 @@ pub struct SharedString {
     pub text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runs: Option<Vec<Run>>,
+    /// ECMA-376 §18.4.6 `<rPh>` phonetic runs (furigana) for this string item.
+    /// Each run's `sb`/`eb` are zero-based character offsets into `text`; the
+    /// hint applies over `text[sb..eb)`. Empty when the `<si>` carries no
+    /// furigana. Kept separate from `text`/`runs` so the base string a
+    /// consumer searches / measures never includes the phonetic hint (matching
+    /// Excel, whose Find searches base text, not furigana).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub phonetic_runs: Vec<PhoneticRun>,
+    /// ECMA-376 §18.4.3 `<phoneticPr>` — how the furigana is displayed (font
+    /// record index, character set, alignment). Absent when the `<si>` has no
+    /// `<phoneticPr>`; the renderer then applies the schema defaults
+    /// (fullwidthKatakana / left) and falls back to font 0 for the size.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phonetic_pr: Option<PhoneticProperties>,
+}
+
+/// ECMA-376 §18.4.6 `<rPh sb=".." eb=".."><t>..</t></rPh>` — one furigana run.
+/// `sb`/`eb` are zero-based **character** (Unicode scalar) offsets into the
+/// String Item's base text; the phonetic hint `text` is shown over the base
+/// characters `[sb, eb)`. The spec requires `sb < eb` and both within the base
+/// length; the renderer positions the hint over that base span.
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PhoneticRun {
+    /// Zero-based start character offset into the base text (inclusive).
+    pub sb: u32,
+    /// Zero-based end character offset into the base text (exclusive).
+    pub eb: u32,
+    /// The phonetic hint text (e.g. the katakana reading).
+    pub text: String,
+}
+
+/// ECMA-376 §18.4.3 `<phoneticPr>` — phonetic display properties for a String
+/// Item. `fontId` is a required zero-based index into `styles.xml`'s font
+/// records; out of bounds falls back to font 0 (§18.4.3). `type` and
+/// `alignment` default to `fullwidthKatakana` and `left` respectively when the
+/// attribute is absent (CT_PhoneticPr schema defaults).
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PhoneticProperties {
+    /// Zero-based index into the style sheet's font records (§18.18.32 ST_FontId).
+    pub font_id: u32,
+    /// ECMA-376 §18.18.57 ST_PhoneticType — "fullwidthKatakana" (default) |
+    /// "halfwidthKatakana" | "Hiragana" | "noConversion".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<String>,
+    /// ECMA-376 §18.18.56 ST_PhoneticAlignment — "left" (default) | "center" |
+    /// "distributed" | "noControl".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alignment: Option<String>,
 }
 
 #[derive(Debug, Serialize, Default)]

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -44,6 +44,12 @@ export type {
   Run,
   RunFont,
   SharedString,
+  // Phonetic hints / furigana (ECMA-376 §18.4.6 / §18.4.3), reachable via
+  // Cell text values and SharedString.
+  PhoneticRun,
+  PhoneticProperties,
+  PhoneticType,
+  PhoneticAlignment,
   // Differential / gradient style sub-types (reachable via Styles).
   Dxf,
   GradientFillSpec,

--- a/packages/xlsx/src/phonetic-render.test.ts
+++ b/packages/xlsx/src/phonetic-render.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { drawPhoneticBand } from './renderer.js';
+import type { CellFont, PhoneticProperties, PhoneticRun, Styles } from './types.js';
+
+// Renderer-level checks for the furigana band draw (ECMA-376 §18.4.6 / §18.4.3).
+// `drawPhoneticBand` is the single entry point; the in-viewport draw path calls
+// it after the base text. Here we drive it directly with a recording context so
+// we can assert the reading strings, their x (band placement over the base
+// glyphs), the reading font size (from `phoneticPr.fontId`), and the alignment
+// spread — all without a real Canvas.
+
+interface FillTextCall {
+  text: string;
+  x: number;
+  y: number;
+  font: string;
+  letterSpacing: string;
+}
+
+/** A recording context. Every code point is `px()` wide in whatever font is
+ *  active (font px parsed from the CSS font string), so base-font vs reading-
+ *  font advances differ by their size, exactly like a real measurer. */
+function makeRecordingCtx() {
+  let font = '11px sans-serif';
+  let letterSpacing = '0px';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
+  const calls: FillTextCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(v: string) { letterSpacing = v; },
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    textAlign: 'left' as CanvasTextAlign,
+    fillStyle: '#000' as string,
+    measureText: (s: string) => ({ width: [...s].length * px() }) as TextMetrics,
+    fillText(text: string, x: number, y: number) {
+      calls.push({ text, x, y, font, letterSpacing });
+    },
+    save() {},
+    restore() {},
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+const BASE_FONT: CellFont = { bold: false, italic: false, underline: false, strike: false, size: 11, color: null, name: null };
+const READING_FONT: CellFont = { bold: false, italic: false, underline: false, strike: false, size: 6, color: null, name: null };
+
+/** styles.fonts[0] = base 11pt, styles.fonts[2] = reading 6pt (mirrors the real
+ *  sample where phoneticPr fontId=2 is a small font). */
+const STYLES: Styles = {
+  fonts: [BASE_FONT, BASE_FONT, READING_FONT],
+  fills: [],
+  borders: [],
+  cellXfs: [],
+  numFmts: [],
+  dxfs: [],
+};
+
+const RUNS: PhoneticRun[] = [
+  { sb: 0, eb: 1, text: 'カ' },
+  { sb: 1, eb: 2, text: 'チョウ' },
+];
+
+function draw(pr: PhoneticProperties | undefined, runs = RUNS, baseText = '課長', baseLeftX = 100) {
+  const { ctx, calls } = makeRecordingCtx();
+  // baseFontStr must be the 11px base font so base-span advances are 11/cp.
+  drawPhoneticBand(ctx, runs, pr, baseText, '11px sans-serif', STYLES, baseLeftX, 0, 1, '#000000');
+  return calls;
+}
+
+// Reading font (fontId=2) is 6pt → round(6 × 4/3) = 8px. Base font here is the
+// literal '11px sans-serif' string we pass as baseFontStr, so base-span advances
+// are 11px/code-point. Font 0 (fallback) is 11pt → round(11 × 4/3) = 15px.
+const READING_PX = '8px';
+const FALLBACK_PX = '15px';
+
+describe('drawPhoneticBand (§18.4.6 / §18.4.3)', () => {
+  it('draws each reading string in the phoneticPr.fontId font (6pt → 8px), not the base', () => {
+    const calls = draw({ fontId: 2, alignment: 'left' });
+    expect(calls.map((c) => c.text)).toEqual(['カ', 'チョウ']);
+    expect(calls.every((c) => c.font.includes(READING_PX))).toBe(true);
+  });
+
+  it('positions each reading over its base span (left alignment): base char is 11px wide', () => {
+    const calls = draw({ fontId: 2, alignment: 'left' });
+    // base char0 span starts at baseLeftX=100; char1 at 100+11=111.
+    expect(calls[0].x).toBe(100);
+    expect(calls[1].x).toBe(111);
+  });
+
+  it('center alignment centres the natural reading width over the base span', () => {
+    const calls = draw({ fontId: 2, alignment: 'center' });
+    // char0 base span [100,111) width 11; reading "カ" is 1 cp × 8px = 8.
+    // centred x = 100 + (11 - 8)/2 = 101.5
+    expect(calls[0].x).toBeCloseTo(101.5, 5);
+  });
+
+  it('distributed alignment sets letterSpacing to spread the reading across the span', () => {
+    // Use a reading whose natural width < span so spreading applies.
+    const runs: PhoneticRun[] = [{ sb: 0, eb: 2, text: 'ヤマ' }]; // 2 cps, base span = 2×11 = 22
+    const calls = draw({ fontId: 2, alignment: 'distributed' }, runs, '山川');
+    // natural reading width = 2 × 8 = 16; span 22; gap count 1 → extra = (22-16)/1 = 6.
+    expect(calls[0].letterSpacing).toBe('6px');
+    expect(calls[0].text).toBe('ヤマ');
+  });
+
+  it('defaults alignment to left when phoneticPr is absent (schema default)', () => {
+    const calls = draw(undefined);
+    // Falls back to fontId 0 (11pt → 15px) and left alignment.
+    expect(calls[0].x).toBe(100);
+    expect(calls[1].x).toBe(111);
+    expect(calls.every((c) => c.font.includes(FALLBACK_PX))).toBe(true);
+  });
+
+  it('falls back to font 0 when fontId is out of bounds (§18.4.3)', () => {
+    const calls = draw({ fontId: 99, alignment: 'left' });
+    // fonts[99] undefined → fonts[0] (11pt → 15px).
+    expect(calls.every((c) => c.font.includes(FALLBACK_PX))).toBe(true);
+  });
+
+  it('draws nothing for an empty run list', () => {
+    const calls = draw({ fontId: 2 }, []);
+    expect(calls).toEqual([]);
+  });
+
+  it('noControl lays readings out sequentially from the text start (not per word)', () => {
+    const calls = draw({ fontId: 2, alignment: 'noControl' });
+    // Reading widths (8px/cp): カ = 8, チョウ = 24. Sequential from baseLeftX=100.
+    expect(calls[0].x).toBe(100);
+    expect(calls[1].x).toBe(108);
+  });
+});

--- a/packages/xlsx/src/phonetic.test.ts
+++ b/packages/xlsx/src/phonetic.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { placePhoneticRuns, toCodePoints } from './phonetic.js';
+import type { PhoneticRun } from './types.js';
+
+/** A fixed-advance measurer: every code point is `w` wide. Lets us assert exact
+ *  band geometry without a Canvas. */
+function fixedMeasure(w: number) {
+  return (s: string) => toCodePoints(s).length * w;
+}
+
+describe('placePhoneticRuns (§18.4.6 / §18.18.56)', () => {
+  const base = '課長'; // 2 code points
+  const runs: PhoneticRun[] = [
+    { sb: 0, eb: 1, text: 'カ' },
+    { sb: 1, eb: 2, text: 'チョウ' },
+  ];
+
+  it('left alignment: each hint band starts at its base span left edge', () => {
+    // base char width 10, baseLeftX 100 → char0 span [100,110), char1 [110,120)
+    const placed = placePhoneticRuns(runs, base, 100, 'left', fixedMeasure(10));
+    expect(placed).toEqual([
+      { text: 'カ', x: 100, width: 10, spread: 'start' },
+      { text: 'チョウ', x: 110, width: 10, spread: 'start' },
+    ]);
+  });
+
+  it('center alignment: band spans the base char, spread=center', () => {
+    const placed = placePhoneticRuns(runs, base, 0, 'center', fixedMeasure(10));
+    expect(placed).toEqual([
+      { text: 'カ', x: 0, width: 10, spread: 'center' },
+      { text: 'チョウ', x: 10, width: 10, spread: 'center' },
+    ]);
+  });
+
+  it('distributed alignment: spread=distribute over the base span width', () => {
+    const placed = placePhoneticRuns(runs, base, 0, 'distributed', fixedMeasure(10));
+    expect(placed.map((p) => p.spread)).toEqual(['distribute', 'distribute']);
+  });
+
+  it('multi-char base span sums advances for the start offset', () => {
+    // base "受注実績" (4 cps), a run over chars [2,4)
+    const b = '受注実績';
+    const r: PhoneticRun[] = [{ sb: 2, eb: 4, text: 'ジッセキ' }];
+    const placed = placePhoneticRuns(r, b, 0, 'left', fixedMeasure(10));
+    // span start = 2 chars × 10 = 20; width = 2 chars × 10 = 20
+    expect(placed).toEqual([{ text: 'ジッセキ', x: 20, width: 20, spread: 'start' }]);
+  });
+
+  it('skips runs with sb >= eb or out of range (defensive, spec requires sb<eb)', () => {
+    const bad: PhoneticRun[] = [
+      { sb: 1, eb: 1, text: 'x' }, // empty span
+      { sb: 5, eb: 6, text: 'y' }, // out of range (base only 2 cps)
+      { sb: 0, eb: 1, text: 'ok' },
+    ];
+    const placed = placePhoneticRuns(bad, base, 0, 'left', fixedMeasure(10));
+    expect(placed).toEqual([{ text: 'ok', x: 0, width: 10, spread: 'start' }]);
+  });
+
+  it('clamps eb to the base length', () => {
+    const r: PhoneticRun[] = [{ sb: 0, eb: 99, text: 'z' }];
+    const placed = placePhoneticRuns(r, base, 0, 'left', fixedMeasure(10));
+    // eb clamps to 2 → width = 2 × 10 = 20
+    expect(placed).toEqual([{ text: 'z', x: 0, width: 20, spread: 'start' }]);
+  });
+
+  it('counts a surrogate pair as one base character', () => {
+    // "𠀋" (U+2000B) is a single code point but two UTF-16 units.
+    const b = '𠀋田'; // 2 code points
+    const r: PhoneticRun[] = [{ sb: 1, eb: 2, text: 'タ' }];
+    const placed = placePhoneticRuns(r, b, 0, 'left', fixedMeasure(10));
+    // char1 (田) span start = 1 cp × 10 = 10, not 2 (would be wrong with .length)
+    expect(placed).toEqual([{ text: 'タ', x: 10, width: 10, spread: 'start' }]);
+  });
+});

--- a/packages/xlsx/src/phonetic.ts
+++ b/packages/xlsx/src/phonetic.ts
@@ -1,0 +1,81 @@
+/**
+ * XL5 furigana (phonetic-hint) geometry.
+ *
+ * Pure layout math for the ruby-like phonetic band Excel draws across the top
+ * of a cell (ECMA-376 §18.4.6 `<rPh>` / §18.4.3 `<phoneticPr>`). Kept free of
+ * any Canvas dependency (a `measure` callback is injected) so the placement is
+ * unit-testable without a DOM.
+ *
+ * Not shared with the docx ruby renderer: docx ruby is laid out per line inside
+ * the paragraph engine (grid pitch, ascent reserve, per-glyph baseline), while
+ * xlsx furigana is placed relative to the CELL rectangle and the base string's
+ * horizontal glyph advances. The only common idea ("small text above base") is
+ * two lines of Canvas code, so a shared core primitive would be a
+ * false-abstraction. The pure predicate here (offset → x-span) is xlsx-specific.
+ */
+import type { PhoneticAlignment, PhoneticRun } from './types.js';
+
+/** A positioned phonetic hint ready to draw: the hint string plus the sheet-x
+ *  span it occupies and how its characters should be spread inside that span. */
+export interface PlacedPhonetic {
+  /** The phonetic hint text (a single `<rPh>` run's reading). */
+  text: string;
+  /** Left edge (sheet-x, same space as the base text draw) of the hint band. */
+  x: number;
+  /** Width of the band the hint is laid out within. */
+  width: number;
+  /** How to distribute the hint's glyphs inside `[x, x+width]`:
+   *  - `'start'`: draw from `x` (left-justified).
+   *  - `'center'`: centre the natural hint width inside the band.
+   *  - `'distribute'`: spread the glyphs so the first hugs `x` and the last
+   *    hugs `x+width` (letter-spacing based). */
+  spread: 'start' | 'center' | 'distribute';
+}
+
+/** Split a string into an array of user-perceived code points (so surrogate
+ *  pairs — e.g. rare kanji — count as one base character, matching the spec's
+ *  "character" offset semantics for `sb`/`eb`). */
+export function toCodePoints(s: string): string[] {
+  return Array.from(s);
+}
+
+/**
+ * Place the per-word phonetic runs of a cell into sheet-x bands over the base
+ * text. Handles the three PER-WORD alignments (§18.18.56 left / center /
+ * distributed); `noControl` (NOT per word) is laid out by the caller with the
+ * reading font, so it is not handled here.
+ *
+ * `measure(str)` returns the advance width of `str` in the BASE font at the
+ * current scale — the same measurer the base-text draw uses — so the phonetic
+ * band lines up with the glyphs it annotates. `baseLeftX` is the sheet-x where
+ * the base text's first glyph starts.
+ *
+ * Runs whose `sb >= eb` or that fall outside the base length are skipped
+ * (defensive — the spec requires `sb < eb` within bounds).
+ */
+export function placePhoneticRuns(
+  runs: readonly PhoneticRun[],
+  baseText: string,
+  baseLeftX: number,
+  alignment: Exclude<PhoneticAlignment, 'noControl'>,
+  measure: (s: string) => number,
+): PlacedPhonetic[] {
+  const cps = toCodePoints(baseText);
+  const n = cps.length;
+  const out: PlacedPhonetic[] = [];
+
+  for (const run of runs) {
+    const sb = run.sb;
+    const eb = run.eb;
+    if (!(sb < eb) || sb >= n) continue;
+    const clampedEb = Math.min(eb, n);
+    const spanStart = baseLeftX + measure(cps.slice(0, sb).join(''));
+    const spanWidth = measure(cps.slice(sb, clampedEb).join(''));
+    const spread: PlacedPhonetic['spread'] =
+      alignment === 'center' ? 'center'
+      : alignment === 'distributed' ? 'distribute'
+      : 'start';
+    out.push({ text: run.text, x: spanStart, width: spanWidth, spread });
+  }
+  return out;
+}

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3,7 +3,9 @@ import type {
   ViewportRange, RenderViewportOptions, XlsxTextRunInfo,
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, GradientFillSpec, ShapeInfo, SlicerItem,
+  PhoneticRun, PhoneticProperties, PhoneticAlignment,
 } from './types.js';
+import { placePhoneticRuns } from './phonetic.js';
 import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValueWithColor } from './number-format.js';
@@ -635,6 +637,101 @@ function buildFont(font: CellFont, cs = 1): string {
   const weight = font.bold ? 'bold ' : '';
   const sizePx = Math.max(1, Math.round(font.size * PT_TO_PX * cs));
   return `${style}${weight}${sizePx}px ${fontStackFor(font.name)}`;
+}
+
+/**
+ * Draw the furigana (phonetic-hint) band across the top of a cell
+ * (ECMA-376 §18.4.6 `<rPh>` / §18.4.3 `<phoneticPr>`).
+ *
+ * The caller must have already set the clip to the cell rect and drawn the base
+ * text; this stamps the small reading glyphs ABOVE the base text, sitting in the
+ * top strip Excel reserves when a phonetic row is auto-fitted (that expanded
+ * height is already stored in the row's `ht`, so we never grow the row here —
+ * we draw within the existing rectangle, which clips an over-tall reading the
+ * same way Excel clips when a manual height is too small).
+ *
+ * `phoneticPr.fontId` (§18.18.32) selects the reading font from the style sheet;
+ * out of bounds falls back to font 0 (§18.4.3). `alignment` (§18.18.56) and
+ * `type` (§18.18.57) default to `left` / `fullwidthKatakana` when absent.
+ * `baseLeftX` is the sheet-x of the base text's first glyph — the phonetic
+ * band is positioned relative to the base glyphs it annotates.
+ */
+export function drawPhoneticBand(
+  ctx: CanvasRenderingContext2D,
+  runs: readonly PhoneticRun[],
+  pr: PhoneticProperties | undefined,
+  baseText: string,
+  baseFontStr: string,
+  styles: Styles,
+  baseLeftX: number,
+  cellTopY: number,
+  cs: number,
+  color: string,
+): void {
+  if (runs.length === 0) return;
+  // §18.4.3: fontId selects the reading font; out of bounds → font 0.
+  const fontId = pr?.fontId ?? 0;
+  const phFont: CellFont | undefined = styles.fonts[fontId] ?? styles.fonts[0];
+  if (!phFont) return;
+  const alignment: PhoneticAlignment = pr?.alignment ?? 'left';
+
+  ctx.save();
+  ctx.font = buildFont(phFont, cs);
+  ctx.textBaseline = 'top';
+  ctx.textAlign = 'left';
+  ctx.fillStyle = color;
+
+  // Sit the reading just below the cell's top padding.
+  const y = cellTopY + Math.round(2 * cs);
+
+  if (alignment === 'noControl') {
+    // §18.18.56 noControl: NOT per word — lay the readings out left-to-right
+    // from the base text's left edge, each at its own natural (reading-font)
+    // width, in run order. Measured with the reading font already active.
+    let cursor = baseLeftX;
+    for (const run of runs) {
+      ctx.fillText(run.text, cursor, y);
+      cursor += ctx.measureText(run.text).width;
+    }
+    ctx.restore();
+    return;
+  }
+
+  // Per-word (left / center / distributed): position each hint over its base
+  // span using BASE-font advances (so the band lines up with the glyphs it
+  // annotates). `baseFontStr` is the font string the base text was drawn with.
+  const placed = placePhoneticRuns(runs, baseText, baseLeftX, alignment, (s) =>
+    measureInFont(ctx, s, baseFontStr),
+  );
+
+  for (const p of placed) {
+    const naturalW = ctx.measureText(p.text).width;
+    const cps = [...p.text];
+    if (p.spread === 'distribute' && cps.length > 1 && naturalW < p.width) {
+      // §18.18.56 distributed: spread the reading glyphs so the first hugs the
+      // left edge and the last the right edge of the base span.
+      const extra = (p.width - naturalW) / (cps.length - 1);
+      try { (ctx as CanvasRenderingContext2D & { letterSpacing: string }).letterSpacing = `${extra}px`; } catch { /* ignore */ }
+      ctx.fillText(p.text, p.x, y);
+      try { (ctx as CanvasRenderingContext2D & { letterSpacing: string }).letterSpacing = '0px'; } catch { /* ignore */ }
+    } else if (p.spread === 'center') {
+      // §18.18.56 center: centre the natural reading width over the base span.
+      ctx.fillText(p.text, p.x + (p.width - naturalW) / 2, y);
+    } else {
+      // §18.18.56 left: left-justified at the base span's left edge.
+      ctx.fillText(p.text, p.x, y);
+    }
+  }
+  ctx.restore();
+}
+
+/** Measure `s` under `fontStr`, restoring the caller's current font afterward. */
+function measureInFont(ctx: CanvasRenderingContext2D, s: string, fontStr: string): number {
+  const prev = ctx.font;
+  ctx.font = fontStr;
+  const w = ctx.measureText(s).width;
+  ctx.font = prev;
+  return w;
 }
 
 /**
@@ -2599,6 +2696,38 @@ function renderQuadrant(
           else { ctx.textBaseline = 'bottom'; textY = cy + cellH - paddingY; }
           ctx.fillText(drawText, textX, textY + vaYShift);
         }
+      }
+
+      // ECMA-376 §18.4.6 / §18.4.3 furigana: when the cell opts in (`ph="1"`)
+      // and its String Item carries phonetic runs, stamp the reading across the
+      // top of the cell over the base glyphs. Drawn inside the cell clip (so an
+      // over-tall reading clips like Excel) and skipped for stacked/rotated
+      // text (which return early above) and hard-break multi-line values
+      // (furigana over wrapped lines is not a shape Excel produces for
+      // phonetic cells). `baseLeftX` follows where the base text is drawn:
+      // left/general anchors at the text start; center/right shift by the
+      // measured base width.
+      const phRuns = cell.value.type === 'text' ? cell.value.phoneticRuns : undefined;
+      if (cell.showPhonetic && phRuns && phRuns.length > 0 && !text.includes('\n')) {
+        const baseFontStr = buildFont(fontForDraw, cs);
+        const baseTextW = measureInFont(ctx, text, baseFontStr);
+        let baseLeftX: number;
+        if (alignH === 'right') baseLeftX = cx + cellW - paddingX - baseTextW;
+        else if (alignH === 'center') baseLeftX = cx + cellW / 2 - baseTextW / 2;
+        else baseLeftX = cx + leftPad;
+        const phColor = textColor ? hexToRgba(textColor) : '#000000';
+        drawPhoneticBand(
+          ctx,
+          phRuns,
+          cell.value.type === 'text' ? cell.value.phoneticPr : undefined,
+          text,
+          baseFontStr,
+          styles,
+          baseLeftX,
+          cy,
+          cs,
+          phColor,
+        );
       }
 
       ctx.restore();

--- a/packages/xlsx/src/shared-strings.test.ts
+++ b/packages/xlsx/src/shared-strings.test.ts
@@ -93,6 +93,37 @@ describe('resolveSharedStrings', () => {
     expect(sheet.rows[0].cells[3].value).toEqual({ type: 'empty' });
   });
 
+  it('carries §18.4.6/§18.4.3 phonetic data onto the resolved text cell', () => {
+    const table: SharedString[] = [
+      {
+        text: '課長',
+        phoneticRuns: [
+          { sb: 0, eb: 1, text: 'カ' },
+          { sb: 1, eb: 2, text: 'チョウ' },
+        ],
+        phoneticPr: { fontId: 2, type: 'Hiragana', alignment: 'center' },
+      },
+    ];
+    const sheet = resolveSharedStrings(ws([sharedCell(1, 0)]), table);
+    expect(sheet.rows[0].cells[0].value).toEqual({
+      type: 'text',
+      text: '課長',
+      phoneticRuns: [
+        { sb: 0, eb: 1, text: 'カ' },
+        { sb: 1, eb: 2, text: 'チョウ' },
+      ],
+      phoneticPr: { fontId: 2, type: 'Hiragana', alignment: 'center' },
+    });
+  });
+
+  it('does not add phonetic keys when the shared string carries none', () => {
+    const table: SharedString[] = [{ text: 'plain' }];
+    const sheet = resolveSharedStrings(ws([sharedCell(1, 0)]), table);
+    const v = sheet.rows[0].cells[0].value as { phoneticRuns?: unknown; phoneticPr?: unknown };
+    expect('phoneticRuns' in v).toBe(false);
+    expect('phoneticPr' in v).toBe(false);
+  });
+
   it('is idempotent: a worksheet with no shared cells is returned unchanged', () => {
     const num: Cell = { col: 1, row: 1, value: { type: 'number', number: 7 } };
     const sheet = ws([num]);

--- a/packages/xlsx/src/shared-strings.ts
+++ b/packages/xlsx/src/shared-strings.ts
@@ -1,4 +1,4 @@
-import type { SharedString, Worksheet } from './types.js';
+import type { CellValue, SharedString, Worksheet } from './types.js';
 
 /**
  * Resolve every `{ type: 'shared', si }` cell in `ws` to a concrete
@@ -18,11 +18,20 @@ export function resolveSharedStrings(ws: Worksheet, sharedStrings: SharedString[
       const v = cell.value;
       if (v.type === 'shared') {
         const ss = sharedStrings[v.si];
-        cell.value = ss
-          ? ss.runs !== undefined
-            ? { type: 'text', text: ss.text, runs: ss.runs }
-            : { type: 'text', text: ss.text }
-          : { type: 'text', text: '' };
+        if (ss) {
+          // Carry the String Item's furigana (§18.4.6 rPh / §18.4.3
+          // phoneticPr) onto the resolved text cell so the renderer can draw
+          // the phonetic band. Only meaningful when the CELL opted in with
+          // `ph="1"` (checked at draw time), but the reading always rides with
+          // the resolved value.
+          const resolved: CellValue = { type: 'text', text: ss.text };
+          if (ss.runs !== undefined) resolved.runs = ss.runs;
+          if (ss.phoneticRuns !== undefined) resolved.phoneticRuns = ss.phoneticRuns;
+          if (ss.phoneticPr !== undefined) resolved.phoneticPr = ss.phoneticPr;
+          cell.value = resolved;
+        } else {
+          cell.value = { type: 'text', text: '' };
+        }
       }
     }
   }

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -631,11 +631,29 @@ export interface Cell {
    *  so the cached `<v>` — frozen when the file was last saved — doesn't
    *  show a stale date. */
   formula?: string;
+  /** ECMA-376 §18.3.1.4 `<c ph="1">` — whether this cell displays its phonetic
+   *  hint (furigana). Omitted on the wire when false (the schema default), so
+   *  read as `showPhonetic ?? false`. A cell whose String Item carries `<rPh>`
+   *  runs still shows NO furigana unless it opts in with `ph="1"`. */
+  showPhonetic?: boolean;
 }
 
 export type CellValue =
   | { type: 'empty' }
-  | { type: 'text'; text: string; runs?: Run[] }
+  | {
+      type: 'text';
+      text: string;
+      runs?: Run[];
+      /** ECMA-376 §18.4.6 phonetic runs (furigana) carried over from the
+       *  resolved String Item. Present for inline strings, and populated by
+       *  {@link resolveSharedStrings} for shared-string cells. Absent when the
+       *  string has no furigana. */
+      phoneticRuns?: PhoneticRun[];
+      /** ECMA-376 §18.4.3 phonetic display properties (font index / char set /
+       *  alignment) for the furigana above. Absent when the `<si>` had no
+       *  `<phoneticPr>`. */
+      phoneticPr?: PhoneticProperties;
+    }
   | { type: 'number'; number: number }
   | { type: 'bool'; bool: boolean }
   | { type: 'error'; error: string }
@@ -644,6 +662,42 @@ export type CellValue =
    *  renderer (or any other consumer) sees it, so downstream code never
    *  encounters this variant. */
   | { type: 'shared'; si: number };
+
+/** ECMA-376 §18.4.6 `<rPh sb=".." eb="..">` — one furigana run. `sb`/`eb` are
+ *  zero-based character offsets into the base text; the hint `text` is shown
+ *  over base characters `[sb, eb)`. */
+export interface PhoneticRun {
+  /** Zero-based start character offset into the base text (inclusive). */
+  sb: number;
+  /** Zero-based end character offset into the base text (exclusive). */
+  eb: number;
+  /** The phonetic hint text (e.g. the katakana reading). */
+  text: string;
+}
+
+/** ECMA-376 §18.18.57 ST_PhoneticType — the East-Asian character set the
+ *  furigana is displayed in. Absent on {@link PhoneticProperties} defaults to
+ *  `'fullwidthKatakana'` per the CT_PhoneticPr schema. */
+export type PhoneticType =
+  | 'fullwidthKatakana'
+  | 'halfwidthKatakana'
+  | 'Hiragana'
+  | 'noConversion';
+
+/** ECMA-376 §18.18.56 ST_PhoneticAlignment — how the furigana is aligned over
+ *  the base text. Absent on {@link PhoneticProperties} defaults to `'left'`. */
+export type PhoneticAlignment = 'left' | 'center' | 'distributed' | 'noControl';
+
+/** ECMA-376 §18.4.3 `<phoneticPr>` — phonetic display properties. */
+export interface PhoneticProperties {
+  /** Zero-based index into `Styles.fonts` (§18.18.32 ST_FontId). Out of bounds
+   *  falls back to font 0 (§18.4.3). Drives the furigana font size / family. */
+  fontId: number;
+  /** §18.18.57 — absent means `'fullwidthKatakana'` (schema default). */
+  type?: PhoneticType;
+  /** §18.18.56 — absent means `'left'` (schema default). */
+  alignment?: PhoneticAlignment;
+}
 
 export interface Run {
   text: string;
@@ -674,6 +728,12 @@ export interface RunFont {
 export interface SharedString {
   text: string;
   runs?: Run[];
+  /** ECMA-376 §18.4.6 phonetic runs (furigana). Absent when the `<si>` has no
+   *  `<rPh>`. */
+  phoneticRuns?: PhoneticRun[];
+  /** ECMA-376 §18.4.3 phonetic display properties. Absent when the `<si>` has
+   *  no `<phoneticPr>`. */
+  phoneticPr?: PhoneticProperties;
 }
 
 export interface NumFmt {


### PR DESCRIPTION
## Summary

Implements **XL5**: East-Asian furigana (phonetic hints) for xlsx. Japanese Excel workbooks store a reading over the top of a cell via `<rPh>` runs (§18.4.6) and `<phoneticPr>` display properties (§18.4.3); this renders that band when the cell opts in with `ph="1"` (§18.3.1.4).

## Spec faithfulness (the `ph` display condition)

The key subtlety, confirmed against ECMA-376:

- **Cell `ph` defaults to `false`** (CT_Cell schema: `<xsd:attribute name="ph" ... default="false"/>`). A cell whose String Item carries `<rPh>` runs shows **no** furigana unless it explicitly sets `ph="1"`. This matches Excel — the reading rides with the shared string, but display is a per-cell toggle.
- `phoneticPr` schema defaults: `type` → `fullwidthKatakana`, `alignment` → `left`, `fontId` **required** (0-based into the style-sheet fonts; out of bounds → font 0).
- The reading **font size comes from the `fontId` font's `sz`** (e.g. a 6 pt font registered in `styles.xml`), not a hard-coded 50 % ratio.

The private fixture `sample-11.xlsx` is the negative case: it has `<rPh>` in `sharedStrings.xml` but **no cell with `ph="1"`**, so Excel (and now this renderer) shows no furigana there — verified byte-identical below.

## Parser (Rust)

- `parse_si_node` reads `<rPh sb/eb>` runs and `<phoneticPr>` into `SharedString.phonetic_runs` / `phonetic_pr` (and onto `CellValue::Text` for inline strings). Kept **out of** `text` so the base string a consumer searches / measures never includes the reading.
- `parse_row_cells` reads `<c ph>` into `Cell.show_phonetic` (default false).
- All new fields skip-serialize when empty → non-phonetic workbooks are byte-identical on the wire.

## Renderer (TS)

- `phonetic.ts` — pure per-word placement (`placePhoneticRuns`): maps each `sb/eb` span to a base-font x-band, splitting on code points so a surrogate-pair kanji counts as one character.
- `renderer.ts` `drawPhoneticBand` — resolves the reading font from `fontId`, draws each hint in the cell's top strip over its base glyphs. §18.18.56 alignment: `left` / `center` / `distributed` (letterSpacing spread) / `noControl` (sequential, not per word).
- Row height: **not** grown here — Excel writes the phonetic auto-fit expansion into the row `ht`, which the parser already honors, so an over-tall reading clips within the existing rectangle exactly as Excel clips a too-small manual height.
- `resolveSharedStrings` carries the reading onto the resolved text cell without touching `text`, so `findText` still searches base text only (Excel Find parity).

## docx ruby relationship

Not shared. docx ruby (§17.3.3) is laid out inside the paragraph line engine (grid pitch / ascent reserve / per-glyph baseline); xlsx furigana is placed relative to the **cell rectangle** and base-glyph advances. The only overlap ("small text above base") is two lines of Canvas code — a shared core primitive would be a false-abstraction.

## Verification

- **Parser**: 6 new unit tests + 1 e2e (real zip → `ParsedWorkbook`) round-trip. `cargo test` 128 pass, `fmt`/`clippy` clean.
- **Renderer**: 15 furigana tests (pure geometry + `drawPhoneticBand` positions/size/alignment) + shared-string resolution tests. Full xlsx vitest 462 pass; core vitest 1149 pass; `tsc` + ast-grep clean.
- **Non-regression (byte-identical)**: `demo/sample-1` all sheets 100 %. `private/sample-11` (rPh, no `ph`) renders **identically** to the base commit `origin/main` (both 97.2 % / 25,446 px vs its stale border-drift reference) — my change is a no-op there.
- **Positive visual**: a synthetic `ph="1"` workbook renders `カ チョウ` over 課長 (left), `ヤマダ タロウ` centered over 山田太郎, distributed over 受注実績; the same strings with `ph="0"` show no furigana. (Fixture not committed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)