### PR TITLE
fix(docx): adjacent cell border conflict resolution (§17.4.66)

### DIFF
--- a/packages/docx/src/cell-border-conflict-render.test.ts
+++ b/packages/docx/src/cell-border-conflict-render.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  BorderSpec,
+  CellElement,
+  DocTable,
+  DocTableCell,
+  DocTableRow,
+  DocxDocumentModel,
+  DocxTextRun,
+  SectionProps,
+} from './types';
+
+// ECMA-376 §17.4.66 — end-to-end: render a table whose adjacent cells DISAGREE on
+// their shared interior gridline and assert the drawn line uses the §17.4.66
+// WINNER (not the later-painted cell). We record each border stroke as a segment
+// with its width + colour, then read the shared vertical/horizontal line.
+
+const TEST_FONT = 'Synthetic Untabled Serif';
+
+interface StrokeSeg { x1: number; y1: number; x2: number; y2: number; width: number; color: string; }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; strokes: StrokeSeg[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const strokes: StrokeSeg[] = [];
+  let cur = { x: 0, y: 0 };
+  let pending: { x1: number; y1: number; x2: number; y2: number } | null = null;
+  let lineWidth = 1;
+  let strokeStyle = '#000000';
+  let fillStyle = '#000000';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get lineWidth() { return lineWidth; },
+    set lineWidth(v: number) { lineWidth = v; },
+    get strokeStyle() { return strokeStyle; },
+    set strokeStyle(v: string) { strokeStyle = v; },
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string) { fillStyle = v; },
+    textAlign: 'left' as CanvasTextAlign,
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() { pending = null; }, closePath() {},
+    moveTo(x: number, y: number) { cur = { x, y }; },
+    lineTo(x: number, y: number) { pending = { x1: cur.x, y1: cur.y, x2: x, y2: y }; cur = { x, y }; },
+    stroke() {
+      if (pending) strokes.push({ ...pending, width: lineWidth, color: strokeStyle });
+    },
+    fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText() {}, strokeText() {},
+    direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, strokes };
+}
+
+function textRun(text: string): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 10, color: null, fontFamily: TEST_FONT, fontFamilyEastAsia: '',
+    isLink: false, background: null, vertAlign: null, hyperlink: null,
+  } as unknown as DocxTextRun;
+}
+
+function paraOf(text: string): CellElement {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{ type: 'text', ...textRun(text) }],
+    defaultFontSize: 10, defaultFontFamily: TEST_FONT, widowControl: false,
+  } as unknown as CellElement;
+}
+
+type Edges = { top: BorderSpec | null; bottom: BorderSpec | null; left: BorderSpec | null; right: BorderSpec | null; insideH: BorderSpec | null; insideV: BorderSpec | null };
+const NO_BORDERS: Edges = { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null };
+
+function cell(text: string, borders: Partial<Edges> = {}): DocTableCell {
+  return {
+    content: [paraOf(text)], colSpan: 1, vMerge: null,
+    borders: { ...NO_BORDERS, ...borders },
+    background: null, vAlign: 'top', widthPt: 60,
+  } as unknown as DocTableCell;
+}
+
+function tableOf(rows: DocTableRow[], tableBorders: Partial<Edges> = {}): DocTable {
+  // Fixed 60 pt columns (one per logical column of the widest row). The page is
+  // sized to the grid sum below so autofit never stretches the columns — the
+  // shared interior vertical gridline then sits at a known x (60 for two cols).
+  const cols = Math.max(...rows.map((r) => r.cells.length));
+  return {
+    colWidths: new Array(cols).fill(60), rows,
+    borders: { ...NO_BORDERS, ...tableBorders },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left',
+  } as unknown as DocTable;
+}
+
+function rowOf(cells: DocTableCell[]): DocTableRow {
+  return { cells, rowHeight: 20, rowHeightRule: 'atLeast', isHeader: false } as unknown as DocTableRow;
+}
+
+function docOf(t: DocTable): DocxDocumentModel {
+  // Page width == grid sum so the content band exactly holds the fixed columns
+  // (no autofit stretch). marginLeft 0 ⇒ grid origin at x=0.
+  const gridSum = t.colWidths.reduce((s, w) => s + w, 0);
+  return {
+    section: {
+      pageWidth: gridSum, pageHeight: 200,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [{ type: 'table', ...t } as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { [TEST_FONT]: 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(t: DocTable) {
+  const { canvas, strokes } = makeRecordingCanvas();
+  const gridSum = t.colWidths.reduce((s, w) => s + w, 0);
+  await renderDocumentToCanvas(docOf(t), canvas, 0, { dpr: 1, width: gridSum });
+  return strokes;
+}
+
+const bs = (over: Partial<BorderSpec>): BorderSpec => ({ style: 'single', width: 0.5, color: null, ...over });
+
+// The two cells are 60 pt wide each at scale 1 ⇒ the shared vertical gridline is
+// at x=60. Only vertical strokes near x=60 are the shared interior line.
+function verticalAt(strokes: StrokeSeg[], x: number): StrokeSeg[] {
+  return strokes.filter((s) => Math.abs(s.x1 - s.x2) < 0.5 && Math.abs(s.x1 - x) <= 1);
+}
+function horizontalAt(strokes: StrokeSeg[], y: number): StrokeSeg[] {
+  return strokes.filter((s) => Math.abs(s.y1 - s.y2) < 0.5 && Math.abs(s.y1 - y) <= 1);
+}
+
+describe('§17.4.66 — adjacent cell border conflict, end-to-end render', () => {
+  it('shared vertical gridline is drawn exactly ONCE (not once per cell)', async () => {
+    // Both cells set their facing edge to the SAME single 1pt border. Previously
+    // each cell drew it (two strokes at x=60); now it is drawn once.
+    const strokes = await render(tableOf([
+      rowOf([
+        cell('a', { right: bs({ width: 1 }) }),
+        cell('b', { left: bs({ width: 1 }) }),
+      ]),
+    ]));
+    expect(verticalAt(strokes, 60)).toHaveLength(1);
+  });
+
+  it('heavier border wins the shared gridline (dashed beats single, ignoring width)', async () => {
+    // Left cell right = single 3pt; right cell left = dashed 1pt. §17.4.66 weight:
+    // single 1×1=1 vs dashed 1×5=5 ⇒ dashed wins DESPITE its smaller width (the
+    // spec weights style, not sz). Both are stroke-based so the mock reads the
+    // winner's colour directly.
+    const strokes = await render(tableOf([
+      rowOf([
+        cell('a', { right: bs({ style: 'single', width: 3, color: 'ff0000' }) }),
+        cell('b', { left: bs({ style: 'dashed', width: 1, color: '0000ff' }) }),
+      ]),
+    ]));
+    const shared = verticalAt(strokes, 60);
+    expect(shared.length).toBeGreaterThanOrEqual(1);
+    // The winner (dashed, blue) must appear at x=60; the loser (single, red) must not.
+    const colors = shared.map((s) => s.color.toLowerCase());
+    expect(colors.some((c) => c.includes('0000ff'))).toBe(true);
+    expect(colors.some((c) => c.includes('ff0000'))).toBe(false);
+    // And the width drawn is the WINNER's (dashed 1pt), not the loser's 3pt.
+    expect(shared.every((s) => Math.abs(s.width - 1) < 0.5)).toBe(true);
+  });
+
+  it('a cell border beats a table-level inside border (rule #1)', async () => {
+    // Table insideV = thick 4pt; the left cell explicitly sets its right edge to a
+    // single 1pt. A CELL border always beats a TABLE border (rule #1), so the
+    // single wins — the right cell contributes no own edge (falls to table insideV
+    // = thick), and cell-vs-table ⇒ cell.
+    const strokes = await render(tableOf(
+      [rowOf([
+        cell('a', { right: bs({ style: 'single', width: 1, color: '00ff00' }) }),
+        cell('b'),
+      ])],
+      { insideV: bs({ style: 'thick', width: 4, color: 'ff0000' }) },
+    ));
+    const shared = verticalAt(strokes, 60);
+    const colors = shared.map((s) => s.color.toLowerCase());
+    expect(colors.some((c) => c.includes('00ff00'))).toBe(true); // cell single wins
+    expect(colors.some((c) => c.includes('ff0000'))).toBe(false); // table thick loses
+  });
+
+  it('nil on one side leaves the OTHER side visible (rule #0)', async () => {
+    // Left cell right = nil (suppress); right cell left = single 1pt. The opposing
+    // real border is displayed.
+    const strokes = await render(tableOf([
+      rowOf([
+        cell('a', { right: bs({ style: 'nil' }) }),
+        cell('b', { left: bs({ style: 'single', width: 1, color: '112233' }) }),
+      ]),
+    ]));
+    const shared = verticalAt(strokes, 60);
+    expect(shared).toHaveLength(1);
+    expect(shared[0].color.toLowerCase()).toContain('112233');
+  });
+
+  it('nil on BOTH sides suppresses the shared gridline entirely', async () => {
+    const strokes = await render(tableOf([
+      rowOf([
+        cell('a', { right: bs({ style: 'nil' }) }),
+        cell('b', { left: bs({ style: 'nil' }) }),
+      ]),
+    ]));
+    expect(verticalAt(strokes, 60)).toHaveLength(0);
+  });
+
+  it('shared HORIZONTAL gridline resolves between stacked rows (dashed beats thick)', async () => {
+    // Row0 cell bottom = thick 4pt; row1 cell top = dashed 1pt. Weight: thick
+    // 1×2=2 vs dashed 1×5=5 ⇒ dashed wins. Rows are 20pt tall ⇒ shared line at y=20.
+    const strokes = await render(tableOf([
+      rowOf([cell('a', { bottom: bs({ style: 'thick', width: 4, color: 'ff0000' }) })]),
+      rowOf([cell('b', { top: bs({ style: 'dashed', width: 1, color: '00ff00' }) })]),
+    ]));
+    const shared = horizontalAt(strokes, 20);
+    expect(shared.length).toBeGreaterThanOrEqual(1);
+    const colors = shared.map((s) => s.color.toLowerCase());
+    expect(colors.some((c) => c.includes('00ff00'))).toBe(true);  // dashed wins
+    expect(colors.some((c) => c.includes('ff0000'))).toBe(false); // thick loses
+  });
+
+  it('bidiVisual: shared vertical gridline still drawn once with the winner', async () => {
+    // Under <w:bidiVisual> logical column 0 is at the PHYSICAL right. Two cells,
+    // logical [a, b]: a is physically RIGHT (x=60..120), b physically LEFT
+    // (x=0..60), so the shared line is at x=60. a.right = single 1pt (green),
+    // b.left = single 1pt (green) — same spec ⇒ drawn once.
+    const t = tableOf([
+      rowOf([
+        cell('a', { right: bs({ width: 1, color: '00aa00' }) }),
+        cell('b', { left: bs({ width: 1, color: '00aa00' }) }),
+      ]),
+    ]);
+    (t as unknown as { bidiVisual: boolean }).bidiVisual = true;
+    const strokes = await render(t);
+    // Exactly one shared interior vertical line at x=60 (not two, not zero).
+    expect(verticalAt(strokes, 60)).toHaveLength(1);
+    // Outer verticals at x=0 (b's physical left) and x=120 (a's physical right)
+    // are each drawn once too.
+    expect(verticalAt(strokes, 0).length + verticalAt(strokes, 120).length).toBe(0);
+  });
+
+  it('outer table edges are unaffected (non-regression: still drawn once)', async () => {
+    // A single-cell table with an outer border on all sides. Each outer edge is
+    // drawn once by the sole cell.
+    const strokes = await render(tableOf([
+      rowOf([cell('x', { top: bs({ width: 1 }), bottom: bs({ width: 1 }), left: bs({ width: 1 }), right: bs({ width: 1 }) })]),
+    ]));
+    // 4 edges (cell 60 wide, 20 tall): left x=0, right x=60, top y=0, bottom y=20.
+    expect(verticalAt(strokes, 0)).toHaveLength(1);
+    expect(verticalAt(strokes, 60)).toHaveLength(1);
+    expect(horizontalAt(strokes, 0)).toHaveLength(1);
+    expect(horizontalAt(strokes, 20)).toHaveLength(1);
+  });
+});

--- a/packages/docx/src/cell-border-conflict.test.ts
+++ b/packages/docx/src/cell-border-conflict.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { resolveBorderConflict } from './cell-border-conflict.js';
+import type { BorderSpec } from './types';
+
+// ECMA-376 §17.4.66 — adjacent table cell border conflict resolution. When cell
+// spacing is zero, two cells that share an interior gridline both contribute a
+// border for that edge; the DISPLAYED border is chosen by these rules (in order):
+//   0. nil/none loses to any real border (if BOTH nil ⇒ nothing).
+//   1. a CELL border beats a TABLE border.
+//   2. weight = (# of lines in the style) × (style rank number); larger wins.
+//   3. equal weight ⇒ higher on the style precedence list wins.
+//   4. identical style ⇒ darker colour wins, by three successive brightness
+//      formulas R+B+2G, then B+2G, then G (smaller wins each).
+//   5. still identical ⇒ the first in reading order (caller-provided `a`) wins.
+
+const spec = (over: Partial<BorderSpec> = {}): BorderSpec =>
+  ({ style: 'single', width: 0.5, color: null, ...over });
+
+/** A conflicting pair: `a` is the reading-order-first candidate. Each carries a
+ *  `source` flag ("cell" | "table") for rule #1. */
+const cell = (over: Partial<BorderSpec> = {}) => ({ spec: spec(over), source: 'cell' as const });
+const tbl = (over: Partial<BorderSpec> = {}) => ({ spec: spec(over), source: 'table' as const });
+
+describe('§17.4.66 resolveBorderConflict', () => {
+  it('rule 0: nil/none loses to a real border', () => {
+    expect(resolveBorderConflict(cell({ style: 'nil' }), cell({ style: 'single' }))!.spec.style).toBe('single');
+    expect(resolveBorderConflict(cell({ style: 'single' }), cell({ style: 'none' }))!.spec.style).toBe('single');
+  });
+
+  it('rule 0: both nil/none ⇒ no border (null)', () => {
+    expect(resolveBorderConflict(cell({ style: 'nil' }), cell({ style: 'none' }))).toBeNull();
+  });
+
+  it('one side null (absent) ⇒ the other wins', () => {
+    expect(resolveBorderConflict(null, cell({ style: 'single' }))!.spec.style).toBe('single');
+    expect(resolveBorderConflict(cell({ style: 'dashed' }), null)!.spec.style).toBe('dashed');
+    expect(resolveBorderConflict(null, null)).toBeNull();
+  });
+
+  it('rule 1: a cell border beats a table border regardless of weight', () => {
+    // table `double` (weight 2×3=6) vs cell `single` (1×1=1): the cell still wins.
+    const r = resolveBorderConflict(tbl({ style: 'double' }), cell({ style: 'single' }));
+    expect(r!.spec.style).toBe('single');
+    expect(r!.source).toBe('cell');
+  });
+
+  it('rule 2: heavier weight wins (double 2×3=6 beats single 1×1=1)', () => {
+    const r = resolveBorderConflict(cell({ style: 'single' }), cell({ style: 'double' }));
+    expect(r!.spec.style).toBe('double');
+  });
+
+  it('rule 2: dashed (1×5=5) beats thick (1×2=2)', () => {
+    const r = resolveBorderConflict(cell({ style: 'thick' }), cell({ style: 'dashed' }));
+    expect(r!.spec.style).toBe('dashed');
+  });
+
+  it('rule 2: triple (3×8=24) beats double (2×3=6)', () => {
+    const r = resolveBorderConflict(cell({ style: 'double' }), cell({ style: 'triple' }));
+    expect(r!.spec.style).toBe('triple');
+  });
+
+  it('rule 3: equal weight ⇒ higher on the precedence list wins (single before thick)', () => {
+    // Contrive equal weight: single (1×1=1) vs … there is no other weight-1 style,
+    // so use two styles that tie. thinThickSmallGap (2×9=18) vs … pick a real tie:
+    // dotDash (1×6=6) vs double (2×3=6) — equal weight 6. Precedence: double is
+    // higher on the list than dotDash, so double wins.
+    const r = resolveBorderConflict(cell({ style: 'dotDash' }), cell({ style: 'double' }));
+    expect(r!.spec.style).toBe('double');
+  });
+
+  it('rule 4: identical style ⇒ darker colour wins (R+B+2G smaller)', () => {
+    // Same style + weight; compare brightness. Black (000000) vs red (ff0000):
+    // brightness(black)=0, brightness(red)=255 ⇒ black (darker) wins.
+    const r = resolveBorderConflict(cell({ style: 'single', color: '000000' }), cell({ style: 'single', color: 'ff0000' }));
+    expect(r!.spec.color).toBe('000000');
+  });
+
+  it('rule 4: null (auto) colour is treated as black (0,0,0) — the darkest', () => {
+    // auto ⇒ black; red loses. `a` has auto (null), `b` has red.
+    const r = resolveBorderConflict(cell({ style: 'single', color: null }), cell({ style: 'single', color: 'ffffff' }));
+    expect(r!.spec.color).toBeNull();
+  });
+
+  it('rule 4: brightness tie on R+B+2G broken by B+2G then G', () => {
+    // Two colours with equal R+B+2G but different B+2G. Choose (R,G,B):
+    //   c1 = (10, 0, 0)  ⇒ R+B+2G = 10,  B+2G = 0
+    //   c2 = (0, 0, 10)  ⇒ R+B+2G = 10,  B+2G = 10
+    // Equal first formula; second formula smaller for c1 ⇒ c1 wins.
+    const r = resolveBorderConflict(
+      cell({ style: 'single', color: '0a0000' }),
+      cell({ style: 'single', color: '00000a' }),
+    );
+    expect(r!.spec.color).toBe('0a0000');
+  });
+
+  it('rule 5: fully identical ⇒ the reading-order-first candidate (a) wins', () => {
+    const a = cell({ style: 'single', color: '808080' });
+    const b = cell({ style: 'single', color: '808080' });
+    const r = resolveBorderConflict(a, b);
+    expect(r).toBe(a); // same reference — `a` is displayed
+  });
+});

--- a/packages/docx/src/cell-border-conflict.ts
+++ b/packages/docx/src/cell-border-conflict.ts
@@ -1,0 +1,183 @@
+import type { BorderSpec } from './types';
+
+/**
+ * ECMA-376 §17.4.66 (tcBorders) — adjacent table cell border conflict resolution.
+ *
+ * When cell spacing is zero, two cells that share an interior gridline each
+ * contribute a border for that edge. Word displays exactly ONE of them, chosen
+ * by the following rules (applied in order); this module is the pure kernel that
+ * decides the winner. The renderer ({@link drawTableRows}) supplies the two
+ * candidates for each shared edge and draws only the returned winner, so a
+ * gridline is drawn once with the correct spec (no more "last cell painted wins").
+ *
+ * Rules (§17.4.66):
+ *   0. If either border is `nil`/`none` (no border), the OTHER is displayed. If
+ *      both are nil/none ⇒ nothing (`null`).
+ *   1. A CELL border always beats a TABLE(-level or table-style) border.
+ *   2. Weight = (# of lines in the border) × (the style's "border number"); the
+ *      larger weight wins.
+ *   3. Equal weight ⇒ the style higher on the precedence list wins.
+ *   4. Identical style ⇒ the darker colour wins, by three successive brightness
+ *      formulas: R+B+2G, then B+2G, then G (smaller value wins each).
+ *   5. Still identical ⇒ the border FIRST in reading order (`a`) is displayed.
+ */
+
+/** A conflict candidate: the resolved {@link BorderSpec} for one cell's edge plus
+ *  whether it came from the cell's own formatting or from a table/table-style
+ *  border (rule #1). `null` ⇒ this side contributes no candidate at all. */
+export interface BorderCandidate {
+  spec: BorderSpec;
+  source: 'cell' | 'table';
+}
+
+/** ECMA-376 §17.4.66 — the "border number" rank of each ST_Border style. The
+ *  larger the rank, the heavier the style (before the line-count multiplier).
+ *  Unknown / art styles are treated as rank 0 (they never out-weigh a real line
+ *  style; art borders are unsupported anyway). */
+const BORDER_NUMBER: Record<string, number> = {
+  single: 1,
+  thick: 2,
+  double: 3,
+  dotted: 4,
+  dashed: 5,
+  dotDash: 6,
+  dotDotDash: 7,
+  triple: 8,
+  thinThickSmallGap: 9,
+  thickThinSmallGap: 10,
+  thinThickThinSmallGap: 11,
+  thinThickMediumGap: 12,
+  thickThinMediumGap: 13,
+  thinThickThinMediumGap: 14,
+  thinThickLargeGap: 15,
+  thickThinLargeGap: 16,
+  thinThickThinLargeGap: 17,
+  wave: 18,
+  doubleWave: 19,
+  dashSmallGap: 20,
+  dashDotStroked: 21,
+  threeDEmboss: 22,
+  threeDEngrave: 23,
+  outset: 24,
+  inset: 25,
+};
+
+/** ECMA-376 §17.18.2 — the number of parallel lines each ST_Border style draws,
+ *  the first factor of the §17.4.66 weight. A single rule is 1; a `double` is 2;
+ *  a `triple` and the "thinThickThin" families are 3; the two-band "thinThick" /
+ *  "thickThin" families and `doubleWave` are 2. All dash / dot / wave / 3D /
+ *  outset / inset single-stroke styles are 1. Unknown styles default to 1. */
+const BORDER_LINES: Record<string, number> = {
+  double: 2,
+  triple: 3,
+  thinThickSmallGap: 2,
+  thickThinSmallGap: 2,
+  thinThickThinSmallGap: 3,
+  thinThickMediumGap: 2,
+  thickThinMediumGap: 2,
+  thinThickThinMediumGap: 3,
+  thinThickLargeGap: 2,
+  thickThinLargeGap: 2,
+  thinThickThinLargeGap: 3,
+  doubleWave: 2,
+};
+
+/** §17.4.66 rule #3 precedence list — index 0 is the highest priority. Identical
+ *  to the BORDER_NUMBER ordering (single first … inset last); a smaller index
+ *  wins a weight tie. */
+const PRECEDENCE: string[] = [
+  'single', 'thick', 'double', 'dotted', 'dashed', 'dotDash', 'dotDotDash', 'triple',
+  'thinThickSmallGap', 'thickThinSmallGap', 'thinThickThinSmallGap', 'thinThickMediumGap',
+  'thickThinMediumGap', 'thinThickThinMediumGap', 'thinThickLargeGap', 'thickThinLargeGap',
+  'thinThickThinLargeGap', 'wave', 'doubleWave', 'dashSmallGap', 'dashDotStroked',
+  'threeDEmboss', 'threeDEngrave', 'outset', 'inset',
+];
+
+function borderNumber(style: string): number {
+  return BORDER_NUMBER[style] ?? 0;
+}
+function borderLines(style: string): number {
+  return BORDER_LINES[style] ?? 1;
+}
+function borderWeight(style: string): number {
+  return borderLines(style) * borderNumber(style);
+}
+function precedenceIndex(style: string): number {
+  const i = PRECEDENCE.indexOf(style);
+  return i === -1 ? PRECEDENCE.length : i; // unknown ⇒ lowest priority
+}
+
+/** True for a border that draws no ink (`nil`/`none`), which §17.4.66 rule #0
+ *  treats as "no border". */
+function isNil(spec: BorderSpec): boolean {
+  return spec.style === 'nil' || spec.style === 'none';
+}
+
+/** Parse a 6-hex colour to (r,g,b). `null`/auto ⇒ black (0,0,0): §17.4.66's
+ *  darkness comparison uses the RENDERED colour, and auto resolves to black. A
+ *  malformed value also falls back to black. */
+function rgb(color: string | null): { r: number; g: number; b: number } {
+  if (!color) return { r: 0, g: 0, b: 0 };
+  const hex = color.replace(/^#/, '');
+  if (hex.length !== 6 || /[^0-9a-fA-F]/.test(hex)) return { r: 0, g: 0, b: 0 };
+  return {
+    r: parseInt(hex.slice(0, 2), 16),
+    g: parseInt(hex.slice(2, 4), 16),
+    b: parseInt(hex.slice(4, 6), 16),
+  };
+}
+
+/** §17.4.66 rules #4a–#4c — compare two colours by brightness, DARKER wins.
+ *  Returns <0 when `a` is darker (wins), >0 when `b` is darker, 0 when identical
+ *  under all three formulas. */
+function compareBrightness(a: string | null, b: string | null): number {
+  const ca = rgb(a);
+  const cb = rgb(b);
+  const f1 = (c: { r: number; g: number; b: number }) => c.r + c.b + 2 * c.g;
+  const f2 = (c: { r: number; g: number; b: number }) => c.b + 2 * c.g;
+  const f3 = (c: { r: number; g: number; b: number }) => c.g;
+  for (const f of [f1, f2, f3]) {
+    const d = f(ca) - f(cb);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
+
+/**
+ * Resolve the winning border for a shared cell edge per ECMA-376 §17.4.66. `a` is
+ * the border FIRST in reading order (it wins a total tie, rule #5). Either side
+ * may be `null` (that cell contributes no border to this edge). Returns the
+ * winning candidate, or `null` when neither side paints (both absent or nil/none).
+ */
+export function resolveBorderConflict(
+  a: BorderCandidate | null,
+  b: BorderCandidate | null,
+): BorderCandidate | null {
+  // Rule #0 — nil/none (or absent) contributes nothing.
+  const av = a && !isNil(a.spec) ? a : null;
+  const bv = b && !isNil(b.spec) ? b : null;
+  if (!av && !bv) return null;
+  if (!av) return bv;
+  if (!bv) return av;
+
+  // Rule #1 — a cell border beats a table border.
+  if (av.source === 'cell' && bv.source === 'table') return av;
+  if (bv.source === 'cell' && av.source === 'table') return bv;
+
+  // Rule #2 — heavier weight wins.
+  const wa = borderWeight(av.spec.style);
+  const wb = borderWeight(bv.spec.style);
+  if (wa !== wb) return wa > wb ? av : bv;
+
+  // Rule #3 — equal weight ⇒ higher on the precedence list (smaller index).
+  const pa = precedenceIndex(av.spec.style);
+  const pb = precedenceIndex(bv.spec.style);
+  if (pa !== pb) return pa < pb ? av : bv;
+
+  // Rule #4 — identical style ⇒ darker colour wins.
+  const cmp = compareBrightness(av.spec.color, bv.spec.color);
+  if (cmp !== 0) return cmp < 0 ? av : bv;
+
+  // Rule #5 — fully identical ⇒ the first in reading order.
+  return av;
+}

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -54,6 +54,7 @@ import type { MathNode, MathRenderer, KinsokuRules, HyperlinkTarget, NumberForma
 import { computePageNumbering } from './page-numbering.js';
 import { docxUnderlineToDrawingML } from './underline-map.js';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
+import { resolveBorderConflict } from './cell-border-conflict.js';
 import {
   segmentsHaveRtl,
   computeLineVisualOrder,
@@ -7701,7 +7702,20 @@ function drawTableRows(
     h: number;
     edges: CellEdgeFlags;
     clipExact: boolean;
+    /** ECMA-376 §17.4.66 — this cell's grid footprint, so the border pass can find
+     *  the cells that share each interior gridline (its right/bottom neighbours).
+     *  `ci`/`ri` are the logical top-left grid slot; `span` the column span; `lastRi`
+     *  the last row the cell occupies (vMerge-span aware). */
+    ci: number;
+    ri: number;
+    span: number;
+    lastRi: number;
   }> = [];
+  // ECMA-376 §17.4.66 — grid-slot → job index occupancy, so an interior edge can
+  // look up the adjacent cell. A vMerge/colSpan cell fills every slot it covers
+  // (its restart job index), so a neighbour query on any slot resolves to the
+  // owning job. Continue (vMerge=false) cells are covered by their restart job.
+  const occupancy: number[][] = table.rows.map(() => new Array<number>(colWidths.length).fill(-1));
 
   let y = startY;
   for (let ri = 0; ri < table.rows.length; ri++) {
@@ -7734,7 +7748,7 @@ function drawTableRows(
         }
         // ECMA-376 §17.4.38/§17.4.39: classify which physical edges of this cell
         // are the table's OUTER edges (vs. interior gridlines) from its grid
-        // position so drawCellBorders can pick table.top/bottom/left/right vs.
+        // position so resolveCellEdges can pick table.top/bottom/left/right vs.
         // table.insideH/insideV. `leftCol`/`rightCol` are the LOGICAL columns
         // (gridSpan-aware); the renderer flips them for bidiVisual via `mirror`.
         const edges: CellEdgeFlags = {
@@ -7750,7 +7764,18 @@ function drawTableRows(
         // exact height — only single-row cells clip.
         const clipExact = row.rowHeightRule === 'exact' && cell.vMerge !== true;
         if (dryRun) measureCellContent(cell, table, cellW, scale, state);
-        else jobs.push({ cell, x: leadX, y, w: cellW, h: drawH, edges, clipExact });
+        else {
+          const jobIndex = jobs.length;
+          jobs.push({ cell, x: leadX, y, w: cellW, h: drawH, edges, clipExact, ci, ri, span, lastRi: lastRowOfCell });
+          // ECMA-376 §17.4.66 — record this cell's grid footprint so interior-edge
+          // neighbour lookups resolve to it. A vMerge=restart cell owns every row it
+          // spans; a colSpan cell owns every column in its span.
+          for (let rj = ri; rj <= lastRowOfCell && rj < occupancy.length; rj++) {
+            for (let cj = ci; cj < ci + span && cj < colWidths.length; cj++) {
+              occupancy[rj][cj] = jobIndex;
+            }
+          }
+        }
       }
 
       x += cellW;
@@ -7767,13 +7792,146 @@ function drawTableRows(
   for (const j of jobs) {
     renderCell(j.cell, table, j.x, j.y, j.w, j.h, state, j.clipExact);
   }
+
+  // ECMA-376 §17.4.66 — adjacent-cell border conflict resolution. Each SHARED
+  // interior gridline is drawn ONCE with the §17.4.66 winner (weight → precedence
+  // → luminance → reading order), instead of both neighbours painting it and the
+  // later one winning. Ownership convention so every line is drawn exactly once:
+  //   • outer table edges → the single bordering cell draws its own resolved spec;
+  //   • interior VERTICAL line → the LEFT cell owns it (drawn as its right edge),
+  //     resolved against the RIGHT neighbour's left edge;
+  //   • interior HORIZONTAL line → the ABOVE cell owns it (drawn as its bottom
+  //     edge), resolved against the BELOW neighbour's top edge.
+  // A cell's own top/left INTERIOR edges are therefore not drawn by the cell — the
+  // neighbour that owns that gridline consults this cell's spec as the opponent.
+  const ctx = state.ctx;
+  const dpr = state.dpr;
   for (const j of jobs) {
-    drawCellBorders(
-      state.ctx, j.x, j.y, j.w, j.h, j.cell.borders, table.borders,
-      scale, j.edges, mirror, state.dpr,
-    );
+    const { x, y, w, h } = j;
+    const own = resolveCellEdges(j.cell.borders, table.borders, j.edges, mirror);
+    // `own.left`/`own.right` are already PHYSICAL (resolveCellEdges folded the
+    // bidiVisual swap into the spec). The OUTER-vs-interior GATE must be physical
+    // too: under mirror a cell's physical-left edge is the logical RIGHT edge, so
+    // the physical outer-left flag is `edges.rightCol` (and vice versa). The
+    // physical-right NEIGHBOUR sits at the grid slot on that physical side —
+    // logical `ci + span` in LTR, logical `ci - 1` under mirror.
+    const physLeftOuter = mirror ? j.edges.rightCol : j.edges.leftCol;
+    const physRightOuter = mirror ? j.edges.leftCol : j.edges.rightCol;
+    const physRightCi = mirror ? j.ci - 1 : j.ci + j.span;
+
+    // TOP: only the outer top row draws its own top; interior tops are owned by
+    // the cell above (its bottom). (Vertical direction is unaffected by mirror.)
+    if (j.edges.topRow) {
+      const spec = paintable(own.top?.spec ?? null);
+      if (spec) drawBorderLine(ctx, x, y, x + w, y, spec, scale, dpr);
+    }
+    // PHYSICAL LEFT: only the outer-left column draws its own left; interior lefts
+    // are owned by the physically-left neighbour (its right edge).
+    if (physLeftOuter) {
+      const spec = paintable(own.left?.spec ?? null);
+      if (spec) drawBorderLine(ctx, x, y, x, y + h, spec, scale, dpr);
+    }
+    // BOTTOM: outer bottom → own spec; interior → resolve vs the below neighbour's
+    // top and draw the winner (this ABOVE cell owns the shared horizontal line).
+    {
+      let spec: BorderSpec | null;
+      if (j.edges.bottomRow) {
+        spec = paintable(own.bottom?.spec ?? null);
+      } else {
+        const below = neighbourEdges(jobs, occupancy, j.lastRi + 1, j.ci, mirror, table.borders);
+        spec = resolveSharedEdge(own.bottom, below?.top ?? null);
+      }
+      if (spec) drawBorderLine(ctx, x, y + h, x + w, y + h, spec, scale, dpr);
+    }
+    // PHYSICAL RIGHT: outer-right → own spec; interior → resolve vs the physically-
+    // right neighbour's left and draw the winner (this cell owns the shared
+    // vertical line as its physical right edge — so each line is drawn once).
+    {
+      let spec: BorderSpec | null;
+      if (physRightOuter) {
+        spec = paintable(own.right?.spec ?? null);
+      } else {
+        const right = neighbourEdges(jobs, occupancy, j.ri, physRightCi, mirror, table.borders);
+        spec = resolveSharedEdge(own.right, right?.left ?? null);
+      }
+      if (spec) drawBorderLine(ctx, x + w, y, x + w, y + h, spec, scale, dpr);
+    }
   }
   return y;
+}
+
+/** ECMA-376 §17.4.66 — the resolved physical edge specs of one cell (top / bottom
+ *  / left / right), each folding the cell's own edge → cell inside → table
+ *  inside/outer precedence (§17.4.38/§17.4.39), with `mirror` swapping the logical
+ *  left/right onto physical sides for a bidiVisual table. `null` = the edge paints
+ *  nothing at the cell level (before the neighbour conflict is considered).
+ *  A `source` tag ('cell' | 'table') travels with each spec for §17.4.66 rule #1. */
+interface ResolvedCellEdges {
+  top: { spec: BorderSpec; source: 'cell' | 'table' } | null;
+  bottom: { spec: BorderSpec; source: 'cell' | 'table' } | null;
+  left: { spec: BorderSpec; source: 'cell' | 'table' } | null;
+  right: { spec: BorderSpec; source: 'cell' | 'table' } | null;
+}
+
+function resolveCellEdges(
+  cell: CellBorders,
+  table: TableBorders,
+  edges: CellEdgeFlags,
+  mirror: boolean,
+): ResolvedCellEdges {
+  // Per-edge cascade: the cell's own explicit edge (source 'cell') wins; else an
+  // interior edge falls to the cell's insideH/insideV then the table inside spec;
+  // an outer edge falls to the table outer spec (all source 'table').
+  const horiz = (own: BorderSpec | null, outer: boolean, tableOuter: BorderSpec | null) => {
+    if (own) return { spec: own, source: 'cell' as const };
+    const t = outer ? tableOuter : (cell.insideH ?? table.insideH);
+    return t ? { spec: t, source: 'table' as const } : null;
+  };
+  const vert = (own: BorderSpec | null, outer: boolean, tableOuter: BorderSpec | null) => {
+    if (own) return { spec: own, source: 'cell' as const };
+    const t = outer ? tableOuter : (cell.insideV ?? table.insideV);
+    return t ? { spec: t, source: 'table' as const } : null;
+  };
+  const top = horiz(cell.top, edges.topRow, table.top);
+  const bottom = horiz(cell.bottom, edges.bottomRow, table.bottom);
+  // bidiVisual mirrors which logical edge maps to each physical side (§17.4.1).
+  const left = mirror
+    ? vert(cell.right, edges.rightCol, table.right)
+    : vert(cell.left, edges.leftCol, table.left);
+  const right = mirror
+    ? vert(cell.left, edges.leftCol, table.left)
+    : vert(cell.right, edges.rightCol, table.right);
+  return { top, bottom, left, right };
+}
+
+/** Resolve the neighbour cell at grid slot (ri, ci) and return its resolved
+ *  edges, or `null` when the slot is empty/out of range. */
+function neighbourEdges(
+  jobs: ReadonlyArray<{ cell: DocTableCell; edges: CellEdgeFlags }>,
+  occupancy: number[][],
+  ri: number,
+  ci: number,
+  mirror: boolean,
+  table: TableBorders,
+): ResolvedCellEdges | null {
+  if (ri < 0 || ri >= occupancy.length) return null;
+  if (ci < 0 || ci >= occupancy[ri].length) return null;
+  const idx = occupancy[ri][ci];
+  if (idx < 0) return null;
+  const nb = jobs[idx];
+  return resolveCellEdges(nb.cell.borders, table, nb.edges, mirror);
+}
+
+/** ECMA-376 §17.4.66 — pick the winning border for a shared interior edge from
+ *  the two neighbouring cells' resolved edges, then reduce it to a paintable
+ *  {@link BorderSpec} (nil/none ⇒ null). `a` is the owning (reading-order-first)
+ *  side. */
+function resolveSharedEdge(
+  a: { spec: BorderSpec; source: 'cell' | 'table' } | null,
+  b: { spec: BorderSpec; source: 'cell' | 'table' } | null,
+): BorderSpec | null {
+  const winner = resolveBorderConflict(a, b);
+  return winner ? paintable(winner.spec) : null;
 }
 
 /**
@@ -8203,7 +8361,7 @@ function renderCellContent(content: CellElement[], state: RenderState): void {
   }
 }
 
-/** Which grid edges of the table this cell touches, so {@link drawCellBorders}
+/** Which grid edges of the table this cell touches, so {@link resolveCellEdges}
  *  can pick the OUTER (table.top/bottom/left/right) vs the INNER
  *  (table.insideH/insideV) spec per physical edge (ECMA-376 §17.4.38/§17.4.39). */
 interface CellEdgeFlags {
@@ -8219,73 +8377,6 @@ function paintable(b: BorderSpec | null): BorderSpec | null {
   if (!b) return null;
   if (b.style === 'none' || b.style === 'nil') return null;
   return b;
-}
-
-function drawCellBorders(
-  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
-  x: number, y: number, w: number, h: number,
-  cell: CellBorders,
-  table: TableBorders,
-  scale: number,
-  edges: CellEdgeFlags,
-  mirror = false,
-  dpr = 1,
-): void {
-  // ECMA-376 §17.4.38/§17.4.39: a cell's TOP/BOTTOM use the table OUTER border
-  // (top/bottom) only on the table's outermost rows; an interior horizontal
-  // gridline uses table.insideH. Likewise LEFT/RIGHT use the outer left/right
-  // only on the outermost columns, interior verticals use table.insideV.
-  // Per-edge precedence (§17.4.38/§17.4.39, the tblBorders presence cascade):
-  // the cell's own explicit edge (which already folds the conditional
-  // firstRow/lastRow/band tcBorders at parse time) wins; for an interior edge
-  // the cell's insideH/insideV is consulted before the table inside spec; the
-  // table outer spec is the last resort on outer edges.
-  //
-  // TODO(border-conflict §17.4.66): true adjacent-cell border conflict
-  // resolution is NOT implemented. Per §17.4.66 (tcBorders), when cell spacing
-  // is zero and the two cells sharing an interior gridline disagree, Word picks
-  // the winner by border WEIGHT, not by sz/width:
-  //   weight = (number of lines in the border) × (border style's number)
-  // where "border style's number" is the spec's CT_Border style rank table
-  // (single=1, thick=2, double=3, dotted=4, dashed=5, …, inset=25). The larger
-  // weight wins. Ties are broken, in order:
-  //   1. a style precedence list (single > thick > double > dotted > … > inset);
-  //   2. luminance, darker wins, via three formulas applied in sequence —
-  //      R+B+2G, then B+2G, then G (smaller value wins);
-  //   3. reading order: the first border in reading order is displayed.
-  // (There is no "top-then-left ownership" rule — that was a CSS-ism, not spec.)
-  // Today each cell paints its own four edges, so an interior gridline is drawn
-  // once by each of the two adjacent cells; for matching specs this is visually
-  // identical, and `nil` on either side still suppresses that side's stroke.
-  // When the two sides disagree the later-painted cell currently wins rather
-  // than the §17.4.66 weight rule above.
-  const horiz = (own: BorderSpec | null, outer: boolean): BorderSpec | null =>
-    paintable(own ?? (outer ? table.top : (cell.insideH ?? table.insideH)));
-  const horizB = (own: BorderSpec | null, outer: boolean): BorderSpec | null =>
-    paintable(own ?? (outer ? table.bottom : (cell.insideH ?? table.insideH)));
-  const vert = (own: BorderSpec | null, outer: boolean): BorderSpec | null =>
-    paintable(own ?? (outer ? table.left : (cell.insideV ?? table.insideV)));
-  const vertR = (own: BorderSpec | null, outer: boolean): BorderSpec | null =>
-    paintable(own ?? (outer ? table.right : (cell.insideV ?? table.insideV)));
-
-  const top = horiz(cell.top, edges.topRow);
-  const bottom = horizB(cell.bottom, edges.bottomRow);
-  // ECMA-376 §17.4.1: under bidiVisual the columns are visually reversed, so a
-  // cell's logical left (start) border is drawn on its physical right edge and
-  // vice versa. Borders are owned by the cell, so swap which spec each side uses,
-  // AND swap which outer edge / inside-fallback applies (the start column's outer
-  // edge is the physical right under bidiVisual).
-  const left = mirror
-    ? vertR(cell.right, edges.rightCol)
-    : vert(cell.left, edges.leftCol);
-  const right = mirror
-    ? vert(cell.left, edges.leftCol)
-    : vertR(cell.right, edges.rightCol);
-
-  if (top) drawBorderLine(ctx, x, y, x + w, y, top, scale, dpr);
-  if (bottom) drawBorderLine(ctx, x, y + h, x + w, y + h, bottom, scale, dpr);
-  if (left) drawBorderLine(ctx, x, y, x, y + h, left, scale, dpr);
-  if (right) drawBorderLine(ctx, x + w, y, x + w, y + h, right, scale, dpr);
 }
 
 /** Stroke one crisp axis-aligned segment. `perp` shifts the whole line


### PR DESCRIPTION
## Summary

Implements **WD7**: correct ECMA-376 **§17.4.66** (tcBorders) conflict resolution for adjacent table cells that disagree on a shared interior gridline.

### The bug

Each cell painted its own four edges independently, so an interior gridline shared by two cells was drawn **twice** and the later-painted cell won when the two specs disagreed — wrong per §17.4.66 (the spec resolves by border **weight**, not paint order), and it let a neighbour's background fill re-cover half of an already-drawn rule. The `drawCellBorders` function even carried a standing `TODO(border-conflict §17.4.66)` documenting this exact gap.

### The fix

**Pure kernel** (`cell-border-conflict.ts`) — `resolveBorderConflict` implements the §17.4.66 decision, unit-tested in isolation:

0. `nil`/`none` loses to any real border (both nil ⇒ none).
1. a **cell** border beats a **table**(-style) border.
2. `weight = (# of lines in the style) × (style border-number rank)`; larger wins — **style-weighted, not sz**. Ranks single=1 … inset=25 (§17.4.66 list); line counts single=1, double=2, triple/thinThickThin\*=3, thinThick\*/thickThin\*/doubleWave=2 (§17.18.2).
3. equal weight ⇒ higher on the precedence list.
4. identical style ⇒ darker colour wins, by three successive brightness formulas R+B+2G → B+2G → G (smaller wins); auto ⇒ black.
5. fully identical ⇒ first in reading order.

**Renderer integration** (`drawTableRows`) — records each cell's grid footprint into a slot→job occupancy map and draws every gridline **exactly once** with the winner:

- outer table edges → the single bordering cell draws its own resolved spec;
- interior **vertical** line → owned by the physically-left cell (its right edge), resolved against the right neighbour's left;
- interior **horizontal** line → owned by the above cell (its bottom edge), resolved against the below neighbour's top.

`resolveCellEdges` factors the per-edge cell→inside→table cascade (§17.4.38/.39) out of the old `drawCellBorders`, tagging each edge `'cell'`/`'table'` for rule #1. **bidiVisual** mirroring is handled: the outer-vs-interior gate and neighbour lookup use PHYSICAL sides (logical left/right swap under mirror), verified by a dedicated test. The old per-cell `drawCellBorders` and its stale TODO are removed.

## Tests & verification

- `cell-border-conflict.test.ts` — 12 cases covering every rule (nil, cell-beats-table, weight, precedence tie, three brightness formulas, reading order).
- `cell-border-conflict-render.test.ts` — 8 end-to-end render cases: single-draw, weight winner ignoring sz, cell-beats-table-inside, nil (one side + both), horizontal + vertical gridlines, **bidiVisual**, outer-edge non-regression.
- Full docx suite: **732/732 pass**. tsc + ast-grep clean.
- **VRT**: `demo/sample-1` all pages pass. Its table page shifts ~0.4% where a shared gridline is now single-drawn (the intended §17.4.66 direction), well within threshold. `private/sample-*` are 404 (git-ignored fixtures absent), not regressions.

## Cross-package inspection (report only — no edits)

The same "adjacent cell shared-border" concept exists in the other two formats:

- **PPTX** (`<a:tbl>`, `renderTable` in `packages/pptx/src/renderer.ts`, border pass ~L4000): **the same gap exists.** Each cell draws its four `<a:lnL/R/T/B>` edges independently; a shared gridline is drawn twice and the later cell wins by paint-order accident. DrawingML/PresentationML has **no** documented conflict-resolution algorithm, so there is no spec kernel to port — but the double-draw / later-wins behaviour is a latent bug. Flagged as a follow-up.
- **XLSX** (`packages/xlsx/src/renderer.ts`, `pickStrongerEdge` / `borderPrecedence` ~L4117): **already resolved**, via an Excel-empirical 13-level style-precedence ladder (hair … double). ECMA-376 Part 1 §18 is silent on cell-border conflicts, so Excel's observable behaviour is the correct ground truth there — this is intentionally NOT the §17.4.66 algorithm and should stay as-is.

Only DOCX (`<w:tcBorders>`) has an explicit ECMA-376 §17.4.66 specification, so the shared kernel stays docx-local (a false abstraction to hoist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)