### PR TITLE
fix(pptx): draw each shared table gridline once (border conflict resolution)

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -89,6 +89,7 @@ import {
 import { fitCjkLine, type MeasuredChar } from './cjk-wrap.js';
 import { justifyLine, type Justified } from './text-justify';
 import { justifiedPiecePositions } from '@silurus/ooxml-core';
+import { resolveTableBorderConflict } from './table-border-conflict.js';
 
 /** Theme font context threaded through the render call chain. */
 export interface RenderContext {
@@ -3850,7 +3851,7 @@ function applyStroke(ctx: CanvasRenderingContext2D, stroke: Stroke | null, scale
 
 // ─── Table rendering ─────────────────────────────────────────────────────────
 
-function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: number, slideNumber?: number, rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 }) {
+export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: number, slideNumber?: number, rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 }) {
   const x0 = emuToPx(el.x, scale);
   const y0 = emuToPx(el.y, scale);
 
@@ -3955,7 +3956,19 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
   // non-continuation cell's paint box once; rowSpan/gridSpan and the RTL
   // coordinate flip are already baked into colX/rowY/cellW/cellH, so both passes
   // replay identical geometry.
-  const jobs: Array<{ cell: TableCell; colX: number; rowY: number; cellW: number; cellH: number }> = [];
+  // Each job also records its GRID footprint (top-left slot ci/ri, its column
+  // span and last row) so the border pass can find, for every interior gridline,
+  // the neighbouring cell that shares it — DrawingML tables populate every grid
+  // slot (a spanning `<a:tc>` is followed by `hMerge`/`vMerge` continuation
+  // `<a:tc>`s), so `ci` is the true grid column index.
+  const jobs: Array<{
+    cell: TableCell; colX: number; rowY: number; cellW: number; cellH: number;
+    ci: number; ri: number; span: number; lastRi: number;
+  }> = [];
+  // Grid-slot → job index occupancy, so an interior edge can look up the adjacent
+  // cell. A spanning anchor fills every slot it covers; the neighbour query on any
+  // covered slot resolves back to that anchor job.
+  const occupancy: number[][] = el.rows.map(() => new Array<number>(numCols).fill(-1));
   for (let ri = 0; ri < el.rows.length; ri++) {
     const row = el.rows[ri];
     const rowY = rowTop[ri];
@@ -3963,11 +3976,22 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
       const cell = row.cells[ci];
       // Merged-cell continuations are drawn by their anchor cell.
       if (cell.hMerge || cell.vMerge) continue;
-      const cellW = spannedWidth(ci, cell.gridSpan || 1);
+      const span = cell.gridSpan || 1;
+      const rspan = cell.rowSpan || 1;
+      const cellW = spannedWidth(ci, span);
       let cellH = 0;
-      for (let span = 0; span < (cell.rowSpan || 1); span++) cellH += rowHeights[ri + span] ?? 0;
-      const colX = spannedLeft(ci, cell.gridSpan || 1);
-      jobs.push({ cell, colX, rowY, cellW, cellH });
+      for (let s = 0; s < rspan; s++) cellH += rowHeights[ri + s] ?? 0;
+      const colX = spannedLeft(ci, span);
+      const lastRi = Math.min(ri + rspan - 1, el.rows.length - 1);
+      const jobIndex = jobs.length;
+      jobs.push({ cell, colX, rowY, cellW, cellH, ci, ri, span, lastRi });
+      // Record this cell's grid footprint so interior-edge neighbour lookups
+      // resolve to it (a spanning cell owns every slot it covers).
+      for (let rj = ri; rj <= lastRi; rj++) {
+        for (let cj = ci; cj < ci + span && cj < numCols; cj++) {
+          occupancy[rj][cj] = jobIndex;
+        }
+      }
     }
   }
 
@@ -3987,6 +4011,23 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
   }
 
   // Pass 2: borders, painted on top of every fill.
+  //
+  // SPEC IS SILENT on adjacent-cell border conflict for DrawingML/PresentationML
+  // tables (unlike WordprocessingML §17.4.66). When cell spacing is zero, two
+  // neighbouring cells each contribute a line for the SHARED interior gridline;
+  // the OLD code drew both, so the later-painted cell won by paint order (and a
+  // translucent line doubled its ink). We now draw each gridline EXACTLY ONCE via
+  // a single-ownership convention (the pptx leg / structural mirror of docx
+  // PR #811, §17.4.66):
+  //   • outer table edges → the single bordering cell draws its own line;
+  //   • interior VERTICAL line → the physically-LEFT cell owns it (drawn as its
+  //     physical-right edge), resolved against the physically-right neighbour;
+  //   • interior HORIZONTAL line → the physically-ABOVE cell owns it (drawn as its
+  //     bottom edge), resolved against the below neighbour.
+  // The winner between two conflicting facing lines is chosen by our DEFINED,
+  // deterministic rule (spec silent): null loses → wider wins → darker wins →
+  // owner (reading-order-first) wins. See `resolveTableBorderConflict`.
+  //
   // Crispness nudge (see crispOffset): an axis-aligned thin grid line whose
   // device-pixel width is odd straddles two device rows/cols on a DPR=1 display
   // (each ~50% ink → blurry). Snapping the cell edge perpendicular to the line
@@ -3997,41 +4038,91 @@ function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: num
   // (T/B) shift Y from their y; vertical edges (L/R) shift X from their x.
   // Diagonals can't be pixel-aligned, so untouched.
   const dpr = rc.dpr;
-  for (const { cell, colX, rowY, cellW, cellH } of jobs) {
+
+  // Resolve the job whose grid footprint covers slot (ri, ci), or null when the
+  // slot is empty / out of range (an occupancy value of -1 or an index off-grid).
+  const jobAt = (ri: number, ci: number): typeof jobs[number] | null => {
+    if (ri < 0 || ri >= occupancy.length) return null;
+    if (ci < 0 || ci >= numCols) return null;
+    const idx = occupancy[ri][ci];
+    return idx < 0 ? null : jobs[idx];
+  };
+
+  const strokeSeg = (
+    stroke: Stroke,
+    x1: number, y1: number, x2: number, y2: number,
+  ) => {
+    applyStroke(ctx, stroke, scale);
+    // Vertical edge (x1===x2) nudges X; horizontal edge (y1===y2) nudges Y.
+    const dx = x1 === x2 ? crispOffset(x1, ctx.lineWidth, dpr) : 0;
+    const dy = y1 === y2 ? crispOffset(y1, ctx.lineWidth, dpr) : 0;
+    ctx.beginPath();
+    ctx.moveTo(x1 + dx, y1 + dy);
+    ctx.lineTo(x2 + dx, y2 + dy);
+    ctx.stroke();
+  };
+
+  for (const j of jobs) {
+    const { cell, colX, rowY, cellW, cellH } = j;
     ctx.save();
-    if (cell.borderT) {
-      applyStroke(ctx, cell.borderT, scale);
-      const dy = crispOffset(rowY, ctx.lineWidth, dpr);
-      ctx.beginPath();
-      ctx.moveTo(colX, rowY + dy);
-      ctx.lineTo(colX + cellW, rowY + dy);
-      ctx.stroke();
+
+    // Map this cell's LOGICAL border specs onto PHYSICAL sides. Under a
+    // right-to-left table (§21.1.3.13) logical column 0 is at the physical RIGHT,
+    // so a cell's logical-left border (`borderL`) paints on its physical-right
+    // edge and its logical-right border (`borderR`) on its physical-left edge;
+    // the physically-right NEIGHBOUR sits at a LOWER logical column. LTR keeps the
+    // natural mapping.
+    const physLeftSpec = el.rtl ? cell.borderR : cell.borderL;
+    const physRightSpec = el.rtl ? cell.borderL : cell.borderR;
+    const physLeftOuter = el.rtl ? j.ci + j.span === numCols : j.ci === 0;
+    const physRightOuter = el.rtl ? j.ci === 0 : j.ci + j.span === numCols;
+    // Grid slot of the physically-right neighbour (whose facing edge conflicts
+    // with THIS cell's physical-right line). LTR: the column just past this span.
+    // RTL: the column just before this cell's leading logical column.
+    const physRightNbrCi = el.rtl ? j.ci - 1 : j.ci + j.span;
+    // The neighbour's facing edge is the one on ITS physical-left side, i.e. its
+    // logical-right spec under RTL, logical-left spec otherwise.
+    const nbrPhysLeftSpec = (nb: TableCell): Stroke | null => (el.rtl ? nb.borderR : nb.borderL);
+
+    // TOP: only the outer top row draws its own top; interior tops are owned by
+    // the cell above (its bottom). Vertical direction is unaffected by RTL.
+    if (j.ri === 0 && cell.borderT) {
+      strokeSeg(cell.borderT, colX, rowY, colX + cellW, rowY);
     }
-    if (cell.borderB) {
-      applyStroke(ctx, cell.borderB, scale);
-      const dy = crispOffset(rowY + cellH, ctx.lineWidth, dpr);
-      ctx.beginPath();
-      ctx.moveTo(colX, rowY + cellH + dy);
-      ctx.lineTo(colX + cellW, rowY + cellH + dy);
-      ctx.stroke();
+    // PHYSICAL LEFT: only the outer-left column draws its own left; interior
+    // lefts are owned by the physically-left neighbour (its right edge).
+    if (physLeftOuter && physLeftSpec) {
+      strokeSeg(physLeftSpec, colX, rowY, colX, rowY + cellH);
     }
-    if (cell.borderL) {
-      applyStroke(ctx, cell.borderL, scale);
-      const dx = crispOffset(colX, ctx.lineWidth, dpr);
-      ctx.beginPath();
-      ctx.moveTo(colX + dx, rowY);
-      ctx.lineTo(colX + dx, rowY + cellH);
-      ctx.stroke();
+    // BOTTOM: outer bottom → own spec; interior → resolve THIS cell's bottom
+    // against the below neighbour's top and draw the single winner.
+    {
+      let spec: Stroke | null;
+      if (j.lastRi === el.rows.length - 1) {
+        spec = cell.borderB;
+      } else {
+        const below = jobAt(j.lastRi + 1, j.ci);
+        spec = resolveTableBorderConflict(cell.borderB, below ? below.cell.borderT : null);
+      }
+      if (spec) strokeSeg(spec, colX, rowY + cellH, colX + cellW, rowY + cellH);
     }
-    if (cell.borderR) {
-      applyStroke(ctx, cell.borderR, scale);
-      const dx = crispOffset(colX + cellW, ctx.lineWidth, dpr);
-      ctx.beginPath();
-      ctx.moveTo(colX + cellW + dx, rowY);
-      ctx.lineTo(colX + cellW + dx, rowY + cellH);
-      ctx.stroke();
+    // PHYSICAL RIGHT: outer-right → own spec; interior → resolve THIS cell's
+    // physical-right line against the physically-right neighbour's facing edge
+    // (so each shared vertical line is drawn once).
+    {
+      let spec: Stroke | null;
+      if (physRightOuter) {
+        spec = physRightSpec;
+      } else {
+        const right = jobAt(j.ri, physRightNbrCi);
+        spec = resolveTableBorderConflict(physRightSpec, right ? nbrPhysLeftSpec(right.cell) : null);
+      }
+      if (spec) strokeSeg(spec, colX + cellW, rowY, colX + cellW, rowY + cellH);
     }
-    // Diagonal borders: top-left→bottom-right and bottom-left→top-right
+
+    // Diagonal borders: top-left→bottom-right and bottom-left→top-right. These
+    // are never shared between cells, so they are always drawn per-cell (and are
+    // not pixel-aligned).
     if (cell.diagonalTL) {
       applyStroke(ctx, cell.diagonalTL, scale);
       ctx.beginPath();

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -4101,6 +4101,13 @@ export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, sca
       if (j.lastRi === el.rows.length - 1) {
         spec = cell.borderB;
       } else {
+        // KNOWN LATENT LIMITATION: span vs subdivided neighbour with differing
+        // borders resolves only the origin slot — a gridSpan cell whose bottom
+        // faces MULTIPLE below-cells with different borderT specs (e.g.
+        // [thin, thick]) picks the winner from slot (lastRi+1, ci) alone and
+        // strokes the whole span with it, dropping the non-origin slots' specs.
+        // Zero occurrences in the private corpus; segment-wise resolution
+        // tracked in issue #824.
         const below = jobAt(j.lastRi + 1, j.ci);
         spec = resolveTableBorderConflict(cell.borderB, below ? below.cell.borderT : null);
       }
@@ -4114,6 +4121,13 @@ export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, sca
       if (physRightOuter) {
         spec = physRightSpec;
       } else {
+        // KNOWN LATENT LIMITATION: span vs subdivided neighbour with differing
+        // borders resolves only the origin slot — a rowSpan cell whose physical-
+        // right edge faces MULTIPLE right-neighbours with different facing specs
+        // picks the winner from slot (ri, physRightNbrCi) alone and strokes the
+        // whole span with it, dropping the non-origin slots' specs. Zero
+        // occurrences in the private corpus; segment-wise resolution tracked in
+        // issue #824.
         const right = jobAt(j.ri, physRightNbrCi);
         spec = resolveTableBorderConflict(physRightSpec, right ? nbrPhysLeftSpec(right.cell) : null);
       }

--- a/packages/pptx/src/table-border-conflict.test.ts
+++ b/packages/pptx/src/table-border-conflict.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import type { Stroke } from '@silurus/ooxml-core';
+import { resolveTableBorderConflict } from './table-border-conflict.js';
+
+// DrawingML `<a:tbl>` adjacent-cell border conflict — pure kernel. The spec is
+// SILENT (no §17.4.66 analog for PresentationML), so these assert OUR defined
+// deterministic rule: null loses → wider wins → darker wins → owner (a) wins.
+
+const ln = (over: Partial<Stroke> = {}): Stroke => ({
+  color: '000000',
+  width: 12700, // 1pt in EMU
+  ...over,
+});
+
+describe('resolveTableBorderConflict (DrawingML shared-edge, spec-silent)', () => {
+  it('both null ⇒ null (no line)', () => {
+    expect(resolveTableBorderConflict(null, null)).toBeNull();
+  });
+
+  it('rule #0 — a null side loses; the other real line is displayed', () => {
+    const real = ln({ color: '112233' });
+    expect(resolveTableBorderConflict(null, real)).toBe(real);
+    expect(resolveTableBorderConflict(real, null)).toBe(real);
+  });
+
+  it('rule #1 — the wider line wins (EMU width), regardless of side', () => {
+    const thin = ln({ width: 12700, color: 'ff0000' });
+    const thick = ln({ width: 38100, color: '0000ff' });
+    expect(resolveTableBorderConflict(thin, thick)).toBe(thick);
+    expect(resolveTableBorderConflict(thick, thin)).toBe(thick);
+  });
+
+  it('rule #2 — equal width ⇒ the darker colour wins', () => {
+    const dark = ln({ width: 12700, color: '000000' });
+    const light = ln({ width: 12700, color: 'ffffff' });
+    expect(resolveTableBorderConflict(light, dark)).toBe(dark);
+    expect(resolveTableBorderConflict(dark, light)).toBe(dark);
+  });
+
+  it('rule #3 — fully tied ⇒ the owning side (a) wins', () => {
+    const a = ln({ width: 12700, color: '336699' });
+    const b = ln({ width: 12700, color: '336699' });
+    expect(resolveTableBorderConflict(a, b)).toBe(a);
+  });
+
+  it('an 8-hex colour ignores its alpha pair for the luminance compare', () => {
+    // 00000080 (translucent black) vs ffffffff (opaque white) — black is darker.
+    const dark = ln({ width: 12700, color: '00000080' });
+    const light = ln({ width: 12700, color: 'ffffffff' });
+    expect(resolveTableBorderConflict(light, dark)).toBe(dark);
+  });
+});

--- a/packages/pptx/src/table-border-conflict.ts
+++ b/packages/pptx/src/table-border-conflict.ts
@@ -1,0 +1,86 @@
+import type { Stroke } from '@silurus/ooxml-core';
+
+/**
+ * DrawingML table (`<a:tbl>`) — adjacent-cell border conflict resolution.
+ *
+ * SPEC IS SILENT. ECMA-376 / ISO-29500 define the WordprocessingML analog
+ * (§17.4.66 `tcBorders` conflict rules) but give NO conflict-resolution rule for
+ * a DrawingML/PresentationML table: `<a:tcPr>` carries `<a:lnL>` / `<a:lnR>` /
+ * `<a:lnT>` / `<a:lnB>` per cell, and when cell spacing is zero two neighbouring
+ * cells each contribute a line for the shared interior gridline — but the spec
+ * never says which one PowerPoint displays. The renderer previously drew BOTH,
+ * so the later-painted cell won by paint order (and with a translucent line the
+ * overlap doubled the ink density). This module is the pure kernel that picks a
+ * single winner so each shared gridline is drawn exactly once.
+ *
+ * Because the spec is silent, the rules below are OUR OWN DETERMINISTIC choice
+ * (they are NOT quoted from ECMA-376). They mirror the SHAPE of the docx
+ * §17.4.66 resolver (see `docx/src/cell-border-conflict.ts`) but adapted to the
+ * DrawingML data model, where a suppressed line (`<a:ln><a:noFill/></a:ln>`) is
+ * parsed to `null` — there is no `nil`/`none` style marker to carry, so a
+ * missing/suppressed edge is simply the `null` candidate.
+ *
+ * Rules, applied in order:
+ *   0. A `null` candidate (absent OR `<a:noFill>` line) contributes nothing — the
+ *      OTHER side is displayed. Both `null` ⇒ nothing (`null`).
+ *   1. Both real ⇒ the WIDER line wins (larger `<a:ln w>` in EMU). PowerPoint has
+ *      no style "weight" table like Word's; line width is the natural strength
+ *      ordering for DrawingML strokes.
+ *   2. Equal width ⇒ the DARKER colour wins (smaller perceived luminance), so the
+ *      choice is deterministic and independent of paint order.
+ *   3. Fully tied (equal width AND equal luminance) ⇒ the OWNING side (`a`, the
+ *      cell first in reading order) is displayed. The caller passes the
+ *      reading-order-first cell as `a` (interior vertical → the LEFT cell;
+ *      interior horizontal → the ABOVE cell), matching the ownership convention
+ *      that draws each line exactly once.
+ */
+
+/** Parse a 6- or 8-hex colour to (r,g,b). `null`/malformed ⇒ black (0,0,0). The
+ *  DrawingML stroke colour is stored without a leading `#`; an 8-hex value's
+ *  trailing alpha pair is ignored for the luminance comparison. */
+function rgb(color: string | null | undefined): { r: number; g: number; b: number } {
+  if (!color) return { r: 0, g: 0, b: 0 };
+  const hex = color.replace(/^#/, '');
+  if (hex.length < 6 || /[^0-9a-fA-F]/.test(hex.slice(0, 6))) return { r: 0, g: 0, b: 0 };
+  return {
+    r: parseInt(hex.slice(0, 2), 16),
+    g: parseInt(hex.slice(2, 4), 16),
+    b: parseInt(hex.slice(4, 6), 16),
+  };
+}
+
+/** Perceived luminance (Rec. 601 weights). Smaller = darker. Only the ORDERING
+ *  matters here, so the exact weights are not load-bearing — any monotonic
+ *  darkness metric would make the tie-break deterministic. */
+function luminance(color: string | null | undefined): number {
+  const c = rgb(color);
+  return 0.299 * c.r + 0.587 * c.g + 0.114 * c.b;
+}
+
+/**
+ * Pick the winning stroke for a shared interior cell edge from the two
+ * neighbouring cells' facing lines. `a` is the OWNING (reading-order-first) side;
+ * it wins a total tie (rule #3). Either side may be `null` (that cell contributes
+ * no line to this edge). Returns the winning stroke, or `null` when neither side
+ * paints.
+ *
+ * NOTE: the spec is silent — see the module doc. This is a DEFINED deterministic
+ * rule, not an ECMA-376 requirement.
+ */
+export function resolveTableBorderConflict(a: Stroke | null, b: Stroke | null): Stroke | null {
+  // Rule #0 — a null candidate contributes nothing.
+  if (!a && !b) return null;
+  if (!a) return b;
+  if (!b) return a;
+
+  // Rule #1 — the wider line wins (EMU width).
+  if (a.width !== b.width) return a.width > b.width ? a : b;
+
+  // Rule #2 — equal width ⇒ the darker colour wins.
+  const la = luminance(a.color);
+  const lb = luminance(b.color);
+  if (la !== lb) return la < lb ? a : b;
+
+  // Rule #3 — fully tied ⇒ the owning (reading-order-first) side.
+  return a;
+}

--- a/packages/pptx/src/table-border-single-draw.test.ts
+++ b/packages/pptx/src/table-border-single-draw.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import type { Stroke } from '@silurus/ooxml-core';
+import { renderTable } from './renderer.js';
+import type { TableCell, TableElement, TableRow } from './types';
+
+// DrawingML `<a:tbl>` — end-to-end render: an interior gridline SHARED by two
+// adjacent cells is drawn exactly ONCE (not once per cell), and when the two
+// cells DISAGREE the drawn line is the conflict WINNER, not the later-painted
+// cell. The spec is SILENT for PresentationML (no §17.4.66 analog), so this is
+// the pptx leg / structural mirror of docx PR #811.
+//
+// We record each stroked segment (endpoints + width + colour) from a fake 2D
+// context (the pptx renderer strokes borders via beginPath/moveTo/lineTo/stroke
+// after applyStroke sets strokeStyle + lineWidth), then read the shared line.
+
+interface StrokeSeg { x1: number; y1: number; x2: number; y2: number; width: number; color: string; }
+
+function makeRecordingCtx(): { ctx: CanvasRenderingContext2D; strokes: StrokeSeg[] } {
+  const strokes: StrokeSeg[] = [];
+  let cur = { x: 0, y: 0 };
+  let pending: { x1: number; y1: number; x2: number; y2: number } | null = null;
+  let lineWidth = 1;
+  let strokeStyle = '#000000';
+  const ctx = {
+    canvas: { width: 1000, height: 1000 },
+    get lineWidth() { return lineWidth; },
+    set lineWidth(v: number) { lineWidth = v; },
+    get strokeStyle() { return strokeStyle as string; },
+    set strokeStyle(v: string) { strokeStyle = v; },
+    fillStyle: '#000000',
+    lineCap: 'butt' as CanvasLineCap,
+    lineJoin: 'miter' as CanvasLineJoin,
+    globalAlpha: 1,
+    save() {}, restore() {},
+    beginPath() { pending = null; }, closePath() {},
+    moveTo(x: number, y: number) { cur = { x, y }; },
+    lineTo(x: number, y: number) { pending = { x1: cur.x, y1: cur.y, x2: x, y2: y }; cur = { x, y }; },
+    stroke() {
+      if (pending) strokes.push({ ...pending, width: lineWidth, color: String(strokeStyle) });
+    },
+    fill() {}, fillRect() {}, strokeRect() {}, clearRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setTransform() {}, transform() {}, resetTransform() {},
+    setLineDash() {}, getLineDash() { return []; },
+    drawImage() {}, arc() {}, arcTo() {}, ellipse() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    createPattern() { return null; },
+    measureText: () => ({ width: 0, fontBoundingBoxAscent: 8, fontBoundingBoxDescent: 2, actualBoundingBoxAscent: 8, actualBoundingBoxDescent: 2 } as TextMetrics),
+    fillText() {}, strokeText() {},
+    font: '10px sans-serif',
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    direction: 'ltr' as CanvasDirection,
+    letterSpacing: '0px',
+    globalCompositeOperation: 'source-over' as GlobalCompositeOperation,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, strokes };
+}
+
+const EMU = 12700; // 1 pt
+
+// A stroke helper. width defaults to 1pt; colour is 6-hex without '#'.
+const ln = (over: Partial<Stroke> = {}): Stroke => ({ color: '000000', width: EMU, ...over });
+
+function cell(over: Partial<TableCell> = {}): TableCell {
+  return {
+    textBody: null, fill: null,
+    borderL: null, borderR: null, borderT: null, borderB: null,
+    diagonalTL: null, diagonalTR: null,
+    gridSpan: 1, rowSpan: 1, hMerge: false, vMerge: false,
+    ...over,
+  } as TableCell;
+}
+
+function tableOf(rows: TableCell[][], cols: number[]): TableElement {
+  const rowH = 20 * EMU;
+  const tableRows: TableRow[] = rows.map((cells) => ({ height: rowH, cells }));
+  return {
+    type: 'table', x: 0, y: 0,
+    width: cols.reduce((a, b) => a + b, 0), height: rowH * rows.length,
+    cols, rows: tableRows,
+  };
+}
+
+// scale=1 ⇒ emuToPx is identity; a 60pt (60*EMU) column ⇒ 60px wide. Two 60pt
+// columns put the shared vertical gridline at x=60. Rows are 20pt ⇒ shared
+// horizontal line at y=20.
+const SCALE = 1 / EMU; // makes 1 EMU → (1/EMU)px; so 60*EMU → 60px, widths in EMU → px
+const COL = 60 * EMU;
+
+function render(t: TableElement): StrokeSeg[] {
+  const { ctx, strokes } = makeRecordingCtx();
+  renderTable(ctx, t, SCALE, undefined, { themeMajorFont: null, themeMinorFont: null, dpr: 1 });
+  return strokes;
+}
+
+function verticalAt(strokes: StrokeSeg[], x: number): StrokeSeg[] {
+  return strokes.filter((s) => Math.abs(s.x1 - s.x2) < 0.5 && Math.abs(s.x1 - x) <= 1);
+}
+function horizontalAt(strokes: StrokeSeg[], y: number): StrokeSeg[] {
+  return strokes.filter((s) => Math.abs(s.y1 - s.y2) < 0.5 && Math.abs(s.y1 - y) <= 1);
+}
+
+// applyStroke sets ctx.strokeStyle via hexToRgba, so a recorded segment colour is
+// `rgba(r,g,b,a)`. Convert a 6-hex authoring colour to that form for comparison.
+function rgba(hex: string): string {
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  return `rgba(${r},${g},${b},1)`;
+}
+
+describe('DrawingML <a:tbl> — shared interior gridline drawn once (spec-silent)', () => {
+  it('shared VERTICAL gridline is drawn exactly ONCE (not once per cell)', () => {
+    // Left cell right = 1pt; right cell left = 1pt (same). Previously TWO strokes
+    // at x=60 (one per cell); now exactly one.
+    const strokes = render(tableOf([
+      [cell({ borderR: ln() }), cell({ borderL: ln() })],
+    ], [COL, COL]));
+    expect(verticalAt(strokes, 60)).toHaveLength(1);
+  });
+
+  it('wider line wins the shared gridline (rule #1), ignoring paint order', () => {
+    // Left cell right = 1pt red; right cell left = 3pt blue ⇒ blue (wider) wins.
+    const strokes = render(tableOf([
+      [cell({ borderR: ln({ width: EMU, color: 'ff0000' }) }),
+       cell({ borderL: ln({ width: 3 * EMU, color: '0000ff' }) })],
+    ], [COL, COL]));
+    const shared = verticalAt(strokes, 60);
+    expect(shared).toHaveLength(1);
+    expect(shared[0].color).toBe(rgba('0000ff')); // wider blue wins
+    expect(Math.abs(shared[0].width - 3)).toBeLessThan(0.6); // winner's 3pt width
+  });
+
+  it('null on one side leaves the OTHER side visible (rule #0)', () => {
+    // Left cell right = null (no line); right cell left = 1pt. The real line shows.
+    const strokes = render(tableOf([
+      [cell({ borderR: null }), cell({ borderL: ln({ color: '112233' }) })],
+    ], [COL, COL]));
+    const shared = verticalAt(strokes, 60);
+    expect(shared).toHaveLength(1);
+    expect(shared[0].color).toBe(rgba('112233'));
+  });
+
+  it('null on BOTH sides suppresses the shared gridline entirely', () => {
+    const strokes = render(tableOf([
+      [cell({ borderR: null }), cell({ borderL: null })],
+    ], [COL, COL]));
+    expect(verticalAt(strokes, 60)).toHaveLength(0);
+  });
+
+  it('shared HORIZONTAL gridline resolves between stacked rows (wider wins)', () => {
+    // Row0 cell bottom = 1pt red; row1 cell top = 3pt green ⇒ green wins. Shared
+    // line at y=20 (rows 20pt tall).
+    const strokes = render(tableOf([
+      [cell({ borderB: ln({ width: EMU, color: 'ff0000' }) })],
+      [cell({ borderT: ln({ width: 3 * EMU, color: '00ff00' }) })],
+    ], [COL]));
+    const shared = horizontalAt(strokes, 20);
+    expect(shared).toHaveLength(1);
+    expect(shared[0].color).toBe(rgba('00ff00')); // wider green wins
+  });
+
+  it('outer table edges are unaffected (non-regression: each drawn once)', () => {
+    // Single-cell table with all four outer borders → 4 edges, each once.
+    const strokes = render(tableOf([
+      [cell({ borderT: ln(), borderB: ln(), borderL: ln(), borderR: ln() })],
+    ], [COL]));
+    expect(verticalAt(strokes, 0)).toHaveLength(1);   // outer left
+    expect(verticalAt(strokes, 60)).toHaveLength(1);  // outer right
+    expect(horizontalAt(strokes, 0)).toHaveLength(1); // outer top
+    expect(horizontalAt(strokes, 20)).toHaveLength(1);// outer bottom
+  });
+
+  it('gridSpan: a horizontally-merged cell spans the shared vertical line region', () => {
+    // Row0: one cell spanning both columns (gridSpan=2) + hMerge continuation.
+    // Row1: two separate cells sharing a vertical line at x=60.
+    // The spanning cell has NO interior vertical line inside it (x=60 within the
+    // merged cell must not be drawn from row0), and row1's shared line at x=60 is
+    // drawn once. Also the horizontal line between the rows at y=20 under x∈[0,60]
+    // and x∈[60,120] must not double up where row0's single wide cell meets the
+    // two row1 cells.
+    const strokes = render(tableOf([
+      [cell({ gridSpan: 2, borderT: ln(), borderB: ln() }), cell({ hMerge: true })],
+      [cell({ borderR: ln(), borderB: ln() }), cell({ borderL: ln(), borderB: ln() })],
+    ], [COL, COL]));
+    // Row1 interior vertical shared line at x=60 drawn exactly once.
+    expect(verticalAt(strokes, 60)).toHaveLength(1);
+  });
+
+  it('rtl (§21.1.3.13): shared vertical gridline still drawn once with the winner', () => {
+    // A right-to-left table places logical column 0 at the physical RIGHT. Two
+    // cells, logical [a, b]: a is physically RIGHT (x=60..120), b physically LEFT
+    // (x=0..60), so the shared interior line is at x=60. At that line a's PHYSICAL-
+    // left edge is its logical-RIGHT border (a.borderR), and b's PHYSICAL-right
+    // edge is its logical-LEFT border (b.borderL) — these face each other.
+    // a.borderR=1pt vs b.borderL=3pt ⇒ the wider (b's) wins, drawn once.
+    const t = tableOf([
+      [cell({ borderR: ln({ width: EMU, color: 'ff0000' }) }),
+       cell({ borderL: ln({ width: 3 * EMU, color: '0000ff' }) })],
+    ], [COL, COL]);
+    t.rtl = true;
+    const strokes = render(t);
+    const shared = verticalAt(strokes, 60);
+    expect(shared).toHaveLength(1);
+    expect(shared[0].color).toBe(rgba('0000ff')); // wider (b's borderR) wins
+    // Outer physical edges (x=0 = b's physical left / logical right side of grid,
+    // x=120 = a's physical right) carry no authored border here, so none drawn.
+    expect(verticalAt(strokes, 0)).toHaveLength(0);
+    expect(verticalAt(strokes, 120)).toHaveLength(0);
+  });
+
+  it('rowSpan: a vertically-merged cell spans the shared horizontal line region', () => {
+    // Col0 row0 rowSpan=2 (+ vMerge continuation in row1); col1 has two cells that
+    // share a horizontal line at y=20. The merged cell must not draw an interior
+    // horizontal line at y=20 within its own footprint.
+    const strokes = render(tableOf([
+      [cell({ rowSpan: 2, borderR: ln() }), cell({ borderB: ln() })],
+      [cell({ vMerge: true }), cell({ borderT: ln() })],
+    ], [COL, COL]));
+    // Col1's shared horizontal line at y=20 (x in [60,120]) drawn exactly once.
+    const shared = horizontalAt(strokes, 20).filter((s) => Math.min(s.x1, s.x2) >= 59);
+    expect(shared).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

DrawingML tables (`<a:tbl>`) drew a border for **every** cell edge, so an interior gridline shared by two adjacent cells was stroked **twice** — the later-painted cell won by paint-order accident, and a translucent line doubled its ink density. This replaces the per-edge border pass with an occupancy-based single-ownership pass so each line segment is drawn **exactly once** with a **defined, deterministic winner**. It is the pptx structural mirror of docx PR #811 (§17.4.66).

Closes #812.

## Conflict rule (and why it's ours, not the spec's)

ECMA-376 / ISO-29500 define the WordprocessingML §17.4.66 `tcBorders` conflict rules, but are **SILENT** for PresentationML — `<a:tcPr>` carries `<a:lnL/R/T/B>` per cell with no stated resolution when two neighbours disagree on the shared edge. So the rule below is **our own deterministic choice** (documented as such in `table-border-conflict.ts`), shaped like the docx resolver but adapted to the DrawingML data model where a suppressed line (`<a:ln><a:noFill/></a:ln>`) is parsed to `null` (there is no `nil`/`none` style marker to carry):

0. a `null` candidate (absent or `noFill`) contributes nothing — the other side shows;
1. both real ⇒ the **wider** line wins (`<a:ln w>` in EMU);
2. equal width ⇒ the **darker** colour wins (deterministic, paint-order-independent);
3. fully tied ⇒ the **owner** (reading-order-first cell) wins.

## Ownership model

- outer table edges → the single bordering cell draws its own line;
- interior **vertical** line → the physically-**left** cell owns it (its physical-right edge), resolved vs the right neighbour's facing edge;
- interior **horizontal** line → the physically-**above** cell owns it (its bottom edge), resolved vs the below neighbour;
- a grid-slot → job occupancy map handles `gridSpan`/`rowSpan` (DrawingML populates every slot: a spanning `<a:tc>` is followed by `hMerge`/`vMerge` continuation cells);
- RTL (§21.1.3.13) folds the logical→physical side swap into the spec/neighbour lookup; diagonals are never shared, so they stay per-cell.

## Verification

- **Real PowerPoint tables** (private samples, headless-parsed): sample-2 slide6 (8×7) **224 → 127** border strokes (97 redundant interior double-draws removed); slide9 (9×5) 180 → 104; slide15 (8×5) 160 → 93; sample-6/9/10 also reduced. A render probe on the real `renderTable` output confirms **zero overlapping duplicate segments** while every grid line is still fully outlined. An outer-only table (sample-4) is unchanged (0 eliminated).
- **Visual**: the three table slides render cleanly (uniform single interior separators, crisp single-drawn outer boxes) with no errors.
- **Tests**: new `table-border-conflict.test.ts` (kernel) + `table-border-single-draw.test.ts` (end-to-end render: shared line once, wider/darker wins, null side, outer non-regression, gridSpan/rowSpan, RTL). Full pptx vitest 324 passed; root vitest 2753 passed; `tsc` clean; `ast-grep` no new warnings; pptx demo VRT (no tables) 9/9 pass — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)