### PR TITLE
fix(core): classify Antiqua serif faces as serif

### DIFF
--- a/packages/core/src/fonts/scripts.test.ts
+++ b/packages/core/src/fonts/scripts.test.ts
@@ -91,6 +91,18 @@ describe('classifyFontGeneric — font name → CSS generic class', () => {
     expect(classifyFontGeneric('Noto Serif')).toBe('serif');
   });
 
+  it('classifies Antiqua serif faces (Book Antiqua / Palatino clones) as serif', () => {
+    // ECMA-376 documents authored in Central/Eastern Europe and Cyrillic locales
+    // frequently use "*Antiqua" serif families (Book Antiqua — a Palatino clone —
+    // plus locale variants like URW Antiqua, Antiqua). "Antiqua" is the German/
+    // typographic term for a Roman/serif face, so any "*antiqua" name is serif and
+    // must resolve to the serif Noto/Times fallback chain, not sans.
+    expect(classifyFontGeneric('Book Antiqua')).toBe('serif');
+    expect(classifyFontGeneric('Antiqua')).toBe('serif');
+    expect(classifyFontGeneric('URW Antiqua')).toBe('serif');
+    expect(classifyFontGeneric('BookAntiqua')).toBe('serif');
+  });
+
   it('classifies CJK serif (song/ming/kai/fangsong) faces as serif', () => {
     expect(classifyFontGeneric('SimSun')).toBe('serif');
     expect(classifyFontGeneric('PMingLiU')).toBe('serif');

--- a/packages/core/src/fonts/scripts.ts
+++ b/packages/core/src/fonts/scripts.ts
@@ -125,7 +125,9 @@ export type FontGenericClass = 'serif' | 'sans' | 'mono';
  *
  * - mono : mono / courier / consolas / 等幅 …
  * - serif: Latin serifs (Times, Cambria/Caladea, Georgia, Garamond, Century,
- *          Palatino, Didot, Bodoni, Playfair, "… Serif", roman) AND CJK
+ *          Palatino, Antiqua (Book Antiqua & other Palatino clones — "Antiqua"
+ *          is the typographic term for a Roman/serif face), Didot, Bodoni,
+ *          Playfair, "… Serif", roman) AND CJK
  *          song/ming/kai/fangsong faces (SimSun 宋 / Batang / PMingLiU 細明 /
  *          KaiTi 楷 / FangSong 仿宋 / *Mincho 明朝) — so the per-language Noto CJK
  *          fallback picks its serif variant.
@@ -141,7 +143,7 @@ export function classifyFontGeneric(family: string | null | undefined): FontGene
   // authoritative split is the §17.8.3.10 <w:family> class the caller checks
   // first; this only refines the name-pattern fallback.)
   if (
-    /roman|times|cambria|caladea|georgia|garamond|century(?!\s*gothic)|palatino|didot|bodoni|playfair|source serif|noto serif|min\s*cho|明朝体|明朝|song|sung|simsun|nsimsun|batang|gungsuh|ming\s*liu|mingliu|pmingliu|fang\s*song|fangsong|kai\s*ti|kaiti|simkai|simfang|stsong|stkaiti|stfangsong|stzhongsong|新細明|細明|宋体|楷体|楷體|仿宋|標楷|游明朝|ＭＳ 明朝|ms mincho|yu mincho|hiragino mincho|ヒラギノ明朝/.test(
+    /roman|times|cambria|caladea|georgia|garamond|century(?!\s*gothic)|palatino|antiqua|didot|bodoni|playfair|source serif|noto serif|min\s*cho|明朝体|明朝|song|sung|simsun|nsimsun|batang|gungsuh|ming\s*liu|mingliu|pmingliu|fang\s*song|fangsong|kai\s*ti|kaiti|simkai|simfang|stsong|stkaiti|stfangsong|stzhongsong|新細明|細明|宋体|楷体|楷體|仿宋|標楷|游明朝|ＭＳ 明朝|ms mincho|yu mincho|hiragino mincho|ヒラギノ明朝/.test(
       l,
     ) ||
     /新細明體|細明體|宋体|明朝|楷体|楷體|仿宋|標楷體|游明朝|ＭＳ 明朝/.test(family)


### PR DESCRIPTION
## Summary

`classifyFontGeneric` — the ECMA-376 §17.8.3.10 name-pattern fallback shared by the docx / pptx / xlsx renderers — omitted the **Antiqua** token, so **Book Antiqua** (a Palatino clone, a Roman/serif face) was classified `sans`. Documents whose theme minor font is Book Antiqua (common in Central/Eastern-European and Cyrillic-locale files) resolved their body text to the SANS Noto/Arial fallback chain instead of the correct serif Times/Cambria/Noto Serif chain.

"Antiqua" is the typographic term for a Roman/serif face, so any `*antiqua` family name is serif. This adds the token to the serif regex in `packages/core/src/fonts/scripts.ts`.

## Spec

- ECMA-376 §17.8.3.10 (`<w:family>` font classification) — the name-pattern fallback consulted when a face is absent from `word/fontTable.xml` or marked `auto`.

## Measured before/after (sample-31 — Russian, `docDefault asciiTheme=minorHAnsi` → theme minor latin = Book Antiqua)

| | body-run font stack | right text edge (p.1) |
|---|---|---|
| **Before** | `"Book Antiqua", "Noto Sans", …, Arial, Helvetica, …, sans-serif` | 566.95 pt |
| **After** | `"Book Antiqua", "Noto Serif", …, "Times New Roman", Cambria, …, serif` | 566.95 pt |
| **Word PDF** | serif (Book Antiqua) | 566.9 pt |

With Book Antiqua absent locally (the common case for non-Windows users / CI), Cyrillic text now falls to **Noto Serif** instead of a sans face — matching Word. Word ground truth is 12 pages (A4).

## Non-regression

- `antiqua` appears in no other font name anywhere in the codebase (grep) — zero name-collision risk from the new token.
- New unit tests in `scripts.test.ts` (Book Antiqua / Antiqua / URW Antiqua / BookAntiqua → serif).
- Full core vitest (1153) + root vitest (2755) green.
- docx / pptx / xlsx `demo/sample-1` VRT unchanged (none use an Antiqua face).

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)