### PR TITLE
fix(docx): honor wps:style fontRef as textbox default text color (#821)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -4876,6 +4876,27 @@ fn parse_wsp_shape(
     let head_end = parse_line_end("headEnd");
     let tail_end = parse_line_end("tailEnd");
 
+    // ECMA-376 §20.1.4.1.17 `<wps:style><a:fontRef>` → the shape's DEFAULT text
+    // color. A `<wps:txbx>` run that sets no explicit `<w:color>` inherits this
+    // (Word draws sample-28's white cover banner text from a `<a:fontRef
+    // idx="minor"><a:schemeClr val="lt1"/></a:fontRef>` — the runs carry no color
+    // of their own). Mirrors pptx's `default_text_color` from the placeholder
+    // fontRef (shape.rs). `<a:fontRef>` is a plain color container (its child is a
+    // `<a:schemeClr>`/`<a:srgbClr>`), so it resolves through the SAME shared
+    // DrawingML color grammar the fill/stroke use (`resolve_color_element` →
+    // `ooxml_common::color::parse_color_node` with Word's slot lookup + literal
+    // tint), including any lumMod/lumOff/shade transforms on the inner color.
+    // The `@idx` (major/minor/none) font-face selection is intentionally ignored
+    // here — this axis carries only the color (fonts resolve via rFonts/docDefaults).
+    let default_text_color = wsp
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "style")
+        .and_then(|st| {
+            st.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "fontRef")
+        })
+        .and_then(|fr| resolve_color_element(fr, theme));
+
     // Shape body text: <wps:txbx><w:txbxContent>...</w:txbxContent></wps:txbx>
     // and the bodyPr (insets / vertical anchor).
     let (
@@ -4911,6 +4932,7 @@ fn parse_wsp_shape(
         flip_v,
         wrap_mode: anchor_meta.wrap_mode.clone(),
         text_blocks,
+        default_text_color,
         text_anchor,
         text_autofit,
         text_inset_l,
@@ -13000,6 +13022,122 @@ mod txbx_inline_image_tests {
                   <w:r><w:t>x</w:t></w:r></w:p>"#,
         );
         assert_eq!(absent.bidi, None, "absent ⇒ unspecified (inherit)");
+    }
+}
+
+// ECMA-376 §20.1.4.1.17 `<wps:style><a:fontRef>` — the shape's DEFAULT text
+// color. A `<wps:txbx>` run that sets no `<w:color>` of its own inherits this
+// (sample-28's white Arabic cover banner: the runs carry no color, so Word draws
+// them in the fontRef's `lt1` = white). Mirrors pptx's placeholder fontRef color
+// (shape.rs). These tests pin the parser's `ShapeRun.default_text_color`.
+#[cfg(test)]
+mod shape_fontref_color_tests {
+    use super::*;
+
+    /// A theme whose `lt1`/`dk1`/`accent1` slots are known, matching sample-28's
+    /// scheme (`lt1 = window/FFFFFF`, `dk1 = windowText/000000`).
+    fn theme() -> ThemeColors {
+        ThemeColors::parse(
+            r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                 <a:themeElements><a:clrScheme name="t">
+                   <a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>
+                   <a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>
+                   <a:dk2><a:srgbClr val="44546A"/></a:dk2>
+                   <a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>
+                   <a:accent1><a:srgbClr val="4472C4"/></a:accent1>
+                 </a:clrScheme></a:themeElements>
+               </a:theme>"#,
+        )
+    }
+
+    /// Build a minimal `<wps:wsp>` with the given `<wps:style>` fragment and a
+    /// one-run text box, then parse it into a `ShapeRun` via `parse_wsp_shape`.
+    fn shape_with_style(style: &str) -> ShapeRun {
+        let xml = format!(
+            r#"<wps:wsp
+                 xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+                 xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                 <wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="2540000" cy="1270000"/></a:xfrm>
+                   <a:prstGeom prst="rect"/></wps:spPr>
+                 {style}
+                 <wps:txbx><w:txbxContent><w:p><w:r><w:t>الملاحق</w:t></w:r></w:p></w:txbxContent></wps:txbx>
+               </wps:wsp>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        parse_wsp_shape(
+            &StyleMap::default(),
+            doc.root_element(),
+            &theme(),
+            &HashMap::new(),
+            0.0,
+            true,
+            0.0,
+            true,
+            &AnchorMeta::default(),
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0,
+        )
+        .expect("shape parses")
+    }
+
+    /// sample-28's cover banner: `<a:fontRef idx="minor"><a:schemeClr val="lt1"/>`
+    /// resolves `lt1` → window → FFFFFF (white). The `@idx` is ignored (color axis
+    /// only). This is the value that gives a color-less run its white text.
+    #[test]
+    fn fontref_scheme_color_resolves_shape_default_text_color() {
+        let shape = shape_with_style(
+            r#"<wps:style><a:fontRef idx="minor"><a:schemeClr val="lt1"/></a:fontRef></wps:style>"#,
+        );
+        assert_eq!(
+            shape.default_text_color.as_deref(),
+            Some("FFFFFF"),
+            "fontRef schemeClr lt1 → white"
+        );
+    }
+
+    /// A `<a:fontRef>` with an explicit srgbClr resolves that hex directly, and a
+    /// `<a:lumMod>`/`<a:lumOff>` transform on the inner scheme color is honored —
+    /// the same DrawingML grammar the fill/stroke path uses.
+    #[test]
+    fn fontref_srgb_and_scheme_transform() {
+        let srgb = shape_with_style(
+            r#"<wps:style><a:fontRef idx="major"><a:srgbClr val="C0504D"/></a:fontRef></wps:style>"#,
+        );
+        assert_eq!(srgb.default_text_color.as_deref(), Some("C0504D"));
+
+        // accent1 (4472C4) with lumMod 50% darkens it; assert it resolves to SOME
+        // color that is not the untransformed base (the transform is applied, not
+        // dropped). The exact hex is owned by the shared color grammar.
+        let transformed = shape_with_style(
+            r#"<wps:style><a:fontRef idx="minor"><a:schemeClr val="accent1"><a:lumMod val="50000"/></a:schemeClr></a:fontRef></wps:style>"#,
+        );
+        let c = transformed
+            .default_text_color
+            .as_deref()
+            .expect("transformed accent1 resolves");
+        assert_ne!(c, "4472C4", "lumMod transform must alter the base accent1");
+    }
+
+    /// No `<wps:style>` (or a style with no `<a:fontRef>`) ⇒ `default_text_color`
+    /// stays None, so a color-less run keeps falling back to the document/theme
+    /// default (black). This is the no-regression case for the many existing text
+    /// boxes that carry run colors or rely on the black default.
+    #[test]
+    fn absent_fontref_leaves_default_text_color_none() {
+        let no_style = shape_with_style("");
+        assert_eq!(no_style.default_text_color, None, "no <wps:style> ⇒ None");
+
+        let style_without_fontref = shape_with_style(
+            r#"<wps:style><a:fillRef idx="1"><a:schemeClr val="accent1"/></a:fillRef></wps:style>"#,
+        );
+        assert_eq!(
+            style_without_fontref.default_text_color, None,
+            "style with no <a:fontRef> ⇒ None"
+        );
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -994,6 +994,15 @@ pub struct ShapeRun {
     /// paragraph) isn't supported in shape bodies yet.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub text_blocks: Vec<ShapeText>,
+    /// ECMA-376 §20.1.4.1.17 `<wps:style><a:fontRef>` — the shape's DEFAULT text
+    /// color (hex, no `#`). A text-box run that sets no explicit `<w:color>`
+    /// takes this before falling back to the document/theme default (black). The
+    /// same DrawingML `<a:fontRef>` PowerPoint resolves for placeholder text
+    /// (pptx `shape.rs`); Word applies it to `<wps:txbx>` runs. This resolves the
+    /// COLOR axis only — the `fontRef @idx` (major/minor/none) font-face effect is
+    /// out of scope here (fonts already resolve through `rFonts`/docDefaults).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_text_color: Option<String>,
     /// Vertical anchor for the shape text box: "t" (top), "ctr" (center),
     /// "b" (bottom). Read from <wps:bodyPr @anchor>. Default = "t".
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7011,10 +7011,19 @@ export function renderShapeText(
 ): void {
   const effState: RenderState =
     state ?? shapeRenderState(ctx, scale, fontFamilyClasses, images);
-  // Default glyph colour for tab leaders (§17.3.1.37) drawn on this path. Text
-  // runs carry their own colour; a leader has none, so it takes the document
-  // default (black when the caller threads no state — the unit-test path).
-  const defaultColor = effState.defaultColor ?? '#000000';
+  // Default glyph colour for a run/leader that carries no explicit colour.
+  // Precedence (ECMA-376 §17.3.2.6 run color > §20.1.4.1.17 shape fontRef default
+  // > document/theme default): a `<wps:style><a:fontRef>` gives the WHOLE text box
+  // a default color (sample-28's cover banner draws its color-less Arabic runs in
+  // the fontRef's `lt1` = white; without this they fell back to black on the dark
+  // panel). The shape default folds OVER the document default (black when the
+  // caller threads no state — the unit-test path). A run's own `<w:color>` still
+  // wins (resolved per segment below). Mirrors pptx renderTextBody's
+  // `shapeDefaultTextColor ?? themeDefaultColor`.
+  const documentDefaultColor = effState.defaultColor ?? '#000000';
+  const defaultColor = shape.defaultTextColor
+    ? `#${shape.defaultTextColor}`
+    : documentDefaultColor;
   const blocks = shape.textBlocks ?? [];
   const lIns = (shape.textInsetL ?? 0) * scale;
   const tIns = (shape.textInsetT ?? 0) * scale;
@@ -7470,7 +7479,11 @@ export function renderShapeText(
               ? s.fontSize * scale * 0.15
               : 0;
           ctx.font = buildFont(s.bold, s.italic, effSizePx, s.fontFamily, fontFamilyClasses);
-          ctx.fillStyle = s.color ? `#${s.color}` : '#000000';
+          // §17.3.2.6: a run's own color wins; otherwise fall to `defaultColor`,
+          // which folds the shape's §20.1.4.1.17 fontRef default over the
+          // document/theme default (black). A color-less run in a fontRef text
+          // box (sample-28's white cover banner) thus draws in the fontRef color.
+          ctx.fillStyle = s.color ? `#${s.color}` : defaultColor;
           // Draw the glyphs (§17.18.44). Anchor each justified piece to the
           // WHOLE-string cumulative advance plus accumulated pitch, the SAME core
           // helper the body uses, so contextual CJK packing (約物半角) is honoured

--- a/packages/docx/src/textbox-fontref-color.test.ts
+++ b/packages/docx/src/textbox-fontref-color.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { renderShapeText } from './renderer.js';
+import type { ShapeRun, ShapeText, ShapeTextRun } from './types';
+
+// ECMA-376 §20.1.4.1.17 `<wps:style><a:fontRef>` gives a text box a DEFAULT text
+// color. A `<wps:txbx>` run that sets no explicit `<w:color>` inherits it before
+// falling back to the document/theme default (black). sample-28's Arabic cover
+// banner draws its color-less runs in the fontRef's `lt1` = white; without this
+// fallback they render black on the dark panel (issue #821). These characterization
+// tests capture the `fillStyle` active at each glyph draw to pin the precedence:
+//   run color > shape fontRef default (defaultTextColor) > document default.
+
+interface FillTextEvent { text: string; x: number; y: number; fillStyle: string }
+
+/** Recording 2D context that captures the `fillStyle` at each fillText call.
+ *  measureText width is code-point count × the current font's px so widths are
+ *  deterministic (no real font needed). */
+function makeRecordingCanvas(): { ctx: CanvasRenderingContext2D; fillTexts: FillTextEvent[] } {
+  let font = '10px serif';
+  let letterSpacing = '0px';
+  let fillStyle = '#000000';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ls = () => parseFloat(/(-?\d+(?:\.\d+)?)px/.exec(letterSpacing)?.[1] ?? '0');
+  const fillTexts: FillTextEvent[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(v: string) { letterSpacing = v; },
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string) { fillStyle = v; },
+    measureText: (s: string) => {
+      const p = px();
+      const n = [...s].length;
+      return {
+        width: n * p + n * ls(),
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, x: number, y: number) { fillTexts.push({ text: s, x, y, fillStyle }); },
+    strokeText(s: string, x: number, y: number) { fillTexts.push({ text: s, x, y, fillStyle }); },
+    strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fillTexts };
+}
+
+const SHAPE_X = 100, SHAPE_Y = 50, W = 400, H = 200, SCALE = 1;
+
+function block(text: string, runColor?: string): ShapeText {
+  return {
+    text,
+    fontSizePt: 10,
+    fontFamily: 'serif',
+    alignment: 'left',
+    runs: [{ text, fontSizePt: 10, fontFamily: 'serif', color: runColor } as ShapeTextRun],
+  } as unknown as ShapeText;
+}
+
+function shape(blocks: ShapeText[], defaultTextColor?: string): ShapeRun {
+  return {
+    type: 'shape',
+    presetGeometry: 'rect', wrapMode: 'none', textAnchor: 't',
+    textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+    textBlocks: blocks,
+    defaultTextColor,
+  } as unknown as ShapeRun;
+}
+
+function render(s: ShapeRun): FillTextEvent[] {
+  const { ctx, fillTexts } = makeRecordingCanvas();
+  renderShapeText(s, SHAPE_X, SHAPE_Y, W, H, ctx, SCALE);
+  return fillTexts;
+}
+
+describe('text-box fontRef default text color (§20.1.4.1.17, issue #821)', () => {
+  it('draws a color-less run in the shape defaultTextColor (sample-28 white banner)', () => {
+    // Arabic text, no run color, shape defaultTextColor = FFFFFF (fontRef lt1).
+    const evs = render(shape([block('الملاحق')], 'FFFFFF'));
+    expect(evs.length).toBeGreaterThan(0);
+    for (const e of evs) {
+      expect(e.fillStyle.toLowerCase()).toBe('#ffffff');
+    }
+  });
+
+  it('a run with its own color overrides the shape defaultTextColor', () => {
+    // Run carries an explicit red; the shape default (white) must NOT win.
+    const evs = render(shape([block('X', 'FF0000')], 'FFFFFF'));
+    expect(evs.length).toBeGreaterThan(0);
+    for (const e of evs) {
+      expect(e.fillStyle.toLowerCase()).toBe('#ff0000');
+    }
+  });
+
+  it('falls back to black when neither the run nor the shape set a color', () => {
+    // No defaultTextColor, no run color, no threaded document default ⇒ black.
+    const evs = render(shape([block('X')]));
+    expect(evs.length).toBeGreaterThan(0);
+    for (const e of evs) {
+      expect(e.fillStyle.toLowerCase()).toBe('#000000');
+    }
+  });
+});

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -829,6 +829,15 @@ export interface ShapeRun {
   wrapSide?: string | null;
   /** Text rendered INSIDE the shape's bounding box (`<wps:txbx><w:txbxContent>`). */
   textBlocks?: ShapeText[];
+  /** ECMA-376 §20.1.4.1.17 `<wps:style><a:fontRef>` — the shape's DEFAULT text
+   *  color (hex, no `#`). A text-box run ({@link ShapeTextRun}) with no explicit
+   *  {@link ShapeTextRun.color} inherits this before falling back to the
+   *  document/theme default (black); an explicit run color still wins. This is
+   *  the color axis of the fontRef only — the `@idx` (major/minor/none) font-face
+   *  selection is out of scope (fonts resolve via rFonts/docDefaults). Mirrors
+   *  pptx's per-shape default text color from the placeholder fontRef. Absent ⇒
+   *  no shape default (the run color or black applies). */
+  defaultTextColor?: string | null;
   /** "t" | "ctr" | "b" — vertical anchor for the shape's text body (`<wps:bodyPr @anchor>`). */
   textAnchor?: string | null;
   /** ECMA-376 §21.1.2.1.1 auto-fit mode from `<wps:bodyPr>`, normalized to the


### PR DESCRIPTION
## Problem

A DrawingML text box (`<wps:txbx>`) whose runs carry no explicit `<w:color>` derives its default text color from the shape's `<wps:style><a:fontRef>` (ECMA-376 §20.1.4.1.17). The docx parser ignored the fontRef and the renderer fell back to black. In sample-28 (Arabic), the "الملاحق" (Appendices) cover-divider banner is a transparent `<wps:txbx>` shape whose runs have no `<w:color>` and whose text color comes from `<a:fontRef idx="minor"><a:schemeClr val="lt1"/></a:fontRef>` (= white). It rendered **black** instead of white. User-confirmed symptom.

## Fix

- **parser** (`parse_wsp_shape`): resolve `<wps:style><a:fontRef>` into a new `ShapeRun.default_text_color`, reusing the existing `resolve_color_element` (the shared `ooxml_common::color` DrawingML grammar with Word's slot lookup + literal tint, including `lumMod`/`lumOff`/`shade` transforms). `<a:fontRef>` is a plain color container, so no new abstraction is warranted.
- **types** (Rust + TS): add the `defaultTextColor` field on `ShapeRun`.
- **renderer** (`renderShapeText`): fold the shape's fontRef default over the document/theme default. Precedence is now **run `<w:color>` > shape fontRef default > document default (black)** — mirroring pptx `renderTextBody`'s `shapeDefaultTextColor ?? themeDefaultColor`. Applies to both glyph fill and tab leaders.

Only the **color axis** of the fontRef is resolved; the `@idx` (major/minor/none) font-face selection is intentionally out of scope (fonts already resolve via `rFonts`/docDefaults).

## Cross-package parity

pptx (`shape.rs`) and xlsx (`drawing.rs`) already resolve the fontRef default text color for shape text; **docx was the only format missing it**. This closes the gap. The DrawingML color grammar is already shared in `ooxml_common::color`, so this is a docx-local wiring change — no shared-layer edit needed.

## Verification (numeric)

Rendered sample-28 page 2 (the "Appendices" divider) before vs after and diffed the banner region:

| | before | after |
|---|---|---|
| banner glyph center pixel | `(92, 92, 92)` (black) | `(255, 255, 255)` (white) |
| black→white pixels in banner region | — | **654** |
| changed-pixel bbox | tight box over "الملاحق" only | same |

Matches the Word PDF ground truth (white text on the green divider panel). The separate green-panel-background rendering gap (the shape itself is `<a:noFill/>`; the panel is a distinct element) is unrelated to this color fix.

## Tests

- **Rust** (4): fontRef `schemeClr lt1` → `FFFFFF`; explicit `srgbClr`; `accent1` + `lumMod` transform applied (not dropped); run-color precedence / absent-fontRef no-op.
- **Renderer** (3, `textbox-fontref-color.test.ts`): color-less run draws in `defaultTextColor`; an explicit run color overrides it; black fallback when neither is set.

## Gates

Rust fmt + clippy (`-D warnings`) + 266 tests green; docx vitest 770 green (incl. the 3 new); root `tsc --build` clean; ast-grep no new findings; docx **demo** VRT (committed references) green (private-sample VRT skipped — those fixtures/references are gitignored and 404 in this worktree, unrelated to this change).

Closes #821