### PR TITLE
fix(docx): parse and apply w:tblInd table indent (§17.4.50)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -6534,6 +6534,23 @@ fn parse_table(
         .and_then(|j| attr_w(j, "val"))
         .unwrap_or_else(|| "left".to_string());
 
+    // ECMA-376 §17.4.50 `<w:tblInd>` — indentation added BEFORE the table's
+    // LEADING edge (left in an LTR table, right in an RTL/`bidiVisual` table),
+    // shifting the table into the text margin. The value is a common table
+    // measurement (§17.4.87 CT_TblWidth); only `type="dxa"` is a length — `pct`
+    // and `auto` are ignored per §17.4.50. `w:w` is signed twips: a NEGATIVE value
+    // pulls the table OUTWARD past the leading margin toward the page edge (Word
+    // writes this for a header banner that must reach the physical page edge).
+    // The renderer applies it only when the resolved `jc` is left/leading
+    // (§17.4.50: "if the resulting justification … is not left … this property
+    // shall be ignored"). Omitted ⇒ None (style-hierarchy inheritance is a
+    // follow-up; direct inline is the common case and what sample-28 uses).
+    let tbl_ind = tbl_pr
+        .and_then(|p| child_w(p, "tblInd"))
+        .filter(|n| attr_w(*n, "type").map(|t| t == "dxa").unwrap_or(true))
+        .and_then(|n| attr_w(n, "w"))
+        .map(|v| twips_to_pt(&v));
+
     // ECMA-376 §17.4.52 w:tblLayout/@w:type — "fixed" | "autofit". Absent ⇒ None
     // (renderer applies the spec default "autofit").
     let layout = tbl_pr
@@ -6613,6 +6630,7 @@ fn parse_table(
         cell_margin_left: cm_left,
         cell_margin_right: cm_right,
         jc,
+        tbl_ind,
         layout,
         width_pt: tbl_w_pt,
         width_pct: tbl_w_pct,
@@ -7270,6 +7288,51 @@ mod tests {
         );
         assert_eq!(t.width_pt, None);
         assert_eq!(t.width_pct, None);
+    }
+
+    // ECMA-376 §17.4.50 — `<w:tblInd w:type="dxa">` surfaces as signed pt.
+    #[test]
+    fn tbl_ind_dxa_surfaces_as_pt() {
+        let t = parse_tbl(
+            r#"<w:tblPr><w:tblInd w:w="1440" w:type="dxa"/></w:tblPr>
+               <w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr><w:tc><w:p/></w:tc></w:tr>"#,
+        );
+        assert_eq!(t.tbl_ind, Some(72.0)); // 1440 twips = 72 pt
+    }
+
+    // ECMA-376 §17.4.50 — a NEGATIVE tblInd (table pulled outward toward the page
+    // edge, as sample-28's header banner uses) round-trips its sign.
+    #[test]
+    fn tbl_ind_negative_dxa_round_trips_sign() {
+        let t = parse_tbl(
+            r#"<w:tblPr><w:tblInd w:w="-1301" w:type="dxa"/></w:tblPr>
+               <w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr><w:tc><w:p/></w:tc></w:tr>"#,
+        );
+        assert_eq!(t.tbl_ind, Some(-65.05)); // -1301 twips = -65.05 pt
+    }
+
+    // ECMA-376 §17.4.50 — `type="pct"`/`auto` are NOT lengths and must be ignored.
+    #[test]
+    fn tbl_ind_pct_is_ignored() {
+        let t = parse_tbl(
+            r#"<w:tblPr><w:tblInd w:w="500" w:type="pct"/></w:tblPr>
+               <w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr><w:tc><w:p/></w:tc></w:tr>"#,
+        );
+        assert_eq!(t.tbl_ind, None);
+    }
+
+    // Omitting `<w:tblInd>` leaves the direct indent unset (None).
+    #[test]
+    fn tbl_ind_absent_is_none() {
+        let t = parse_tbl(
+            r#"<w:tblPr/>
+               <w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>
+               <w:tr><w:tc><w:p/></w:tc></w:tr>"#,
+        );
+        assert_eq!(t.tbl_ind, None);
     }
 
     // Regression guard for the direct-rPr merge path. `apply_direct_run` now

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1705,6 +1705,14 @@ pub struct DocTable {
     pub cell_margin_right: f64,
     /// table horizontal alignment on the page: "left" | "center" | "right" (w:tblPr/w:jc).
     pub jc: String,
+    /// ECMA-376 §17.4.50 `<w:tblInd>` — indentation added before the table's
+    /// LEADING edge (left in LTR, right in RTL/`bidi_visual`), in pt (signed —
+    /// a negative value pulls the table outward past the leading margin toward
+    /// the page edge). `type="dxa"` only; `pct`/`auto` are ignored per §17.4.50.
+    /// `None` ⇒ no direct indent (the renderer adds nothing). Applied by the
+    /// renderer only when the resolved `jc` is left/leading.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tbl_ind: Option<f64>,
     /// ECMA-376 §17.4.52 `<w:tblLayout w:type>`. "fixed" or "autofit".
     /// Absent in the source ⇒ None, which the renderer treats as the spec
     /// default "autofit" (size columns by preferred widths). When "fixed" the

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -8363,16 +8363,47 @@ function renderTable(table: DocTable, state: RenderState): void {
     return;
   }
 
-  const { contentX, contentW } = state;
-  const { colWidths, tableW, rowHeights } = computeTableLayout(table, contentW, state);
+  const { contentX, contentW, scale } = state;
+
+  // ECMA-376 §17.4.50 `<w:tblInd>` — indentation added before the table's LEADING
+  // edge, shifting it into the text margin. It applies ONLY when the resolved `jc`
+  // is left/leading (§17.4.50: "if the resulting justification … is not left …
+  // this property shall be ignored"). A NEGATIVE indent pulls the table OUTWARD
+  // past the leading margin toward the page edge (sample-28's header banner). Such
+  // a table legitimately extends into the page margins and keeps its full
+  // preferred width, so widen the layout budget to the whole page (otherwise
+  // `resolveColumnWidths`' content-width fit would scale the banner down to the
+  // narrower text column and it would never reach the page edge).
+  const applyInd = table.tblInd != null && table.jc === 'left';
+  const layoutBudget =
+    applyInd && (table.tblInd as number) < 0 ? state.pageWidth * scale : contentW;
+  const { colWidths, tableW, rowHeights } = computeTableLayout(table, layoutBudget, state);
 
   // Horizontal table alignment on the page (w:tblPr/w:jc).
-  const tableX =
+  let tableX =
     table.jc === 'center'
       ? contentX + Math.max(0, (contentW - tableW) / 2)
       : table.jc === 'right'
         ? contentX + Math.max(0, contentW - tableW)
         : contentX;
+
+  if (applyInd) {
+    // §17.4.50 places the table's LEADING edge `tblInd` inward from the leading
+    // text margin (so a NEGATIVE indent pushes it OUTWARD into the margin).
+    // `drawTableRows` always takes the physical LEFT origin (`tableX`) and mirrors
+    // the columns internally for RTL, so resolve the leading edge to a left origin:
+    //   • LTR — leading edge = LEFT text margin (contentX). Left origin =
+    //     contentX + tblInd.
+    //   • RTL (`bidiVisual`) — leading edge = RIGHT text margin
+    //     (contentX + contentW). Its RIGHT edge sits `tblInd` inward from there,
+    //     i.e. rightEdge = contentX + contentW − tblInd, so the left origin is
+    //     rightEdge − tableW.
+    const indPx = (table.tblInd as number) * scale;
+    tableX =
+      table.bidiVisual === true
+        ? contentX + contentW - indPx - tableW
+        : contentX + indPx;
+  }
 
   const y = drawTableRows(table, colWidths, tableW, rowHeights, tableX, state.y, state);
 

--- a/packages/docx/src/table-tblind.test.ts
+++ b/packages/docx/src/table-tblind.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  DocxDocumentModel,
+  DocTable,
+  DocTableRow,
+  DocTableCell,
+  DocParagraph,
+  SectionProps,
+} from './types';
+
+/**
+ * ECMA-376 §17.4.50 `<w:tblInd>` — indentation added before the table's LEADING
+ * edge (left in LTR, right in RTL/`bidiVisual`), shifting the table into the text
+ * margin. A NEGATIVE value pulls the table OUTWARD past the leading margin toward
+ * the page edge. Applies only when the resolved `jc` is left/leading.
+ *
+ * These tests pin the physical x-origin the renderer resolves for each direction
+ * by capturing every `moveTo`/`lineTo` x-coordinate (cell borders are stroked via
+ * `strokeCrispSegment` → `moveTo`/`lineTo`) and reading the table's left/right
+ * extent from them. A vertical border is nudged ≤0.5 px by the crispness snap
+ * (`crispOffset`), so the extent assertions allow a 0.75 px tolerance.
+ */
+
+/** Assert `actual` is within 0.75 px of `expected` (absorbs the ≤0.5 px crisp
+ *  snap on a thin vertical border). */
+function expectNear(actual: number, expected: number, msg: string): void {
+  expect(Math.abs(actual - expected), `${msg} (got ${actual}, want ~${expected})`).toBeLessThanOrEqual(0.75);
+}
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; xs: number[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const xs: number[] = [];
+  const record = (x: number) => xs.push(x);
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo(x: number) { record(x); }, lineTo(x: number) { record(x); },
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {},
+    rect() {}, clip() {}, scale() {}, translate() {},
+    setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, xs };
+}
+
+function solidBorder() { return { width: 0.5, color: '000000', style: 'single' }; }
+function allSolid() {
+  const b = solidBorder();
+  return { top: b, bottom: b, left: b, right: b, insideH: b, insideV: b };
+}
+function bodyParagraph(text: string): DocParagraph {
+  return {
+    alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: text === '' ? [] : [{
+      type: 'text', text,
+      bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+      isLink: false, background: null, vertAlign: null, hyperlink: null,
+    }],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman',
+    widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+/** A 1×1 solid-border table (single column `colW` pt wide) with the given
+ *  `tblInd` (pt) and bidiVisual flag, on a 200×200 pt page with 20 pt margins
+ *  (content [20, 180], width 160). */
+function tableDoc(colW: number, tblInd: number | undefined, bidiVisual: boolean): DocxDocumentModel {
+  const cell: DocTableCell = {
+    content: [{ type: 'paragraph', ...bodyParagraph('x') }],
+    colSpan: 1, vMerge: null, borders: allSolid(), background: null, vAlign: 'top',
+    widthPt: colW,
+  } as unknown as DocTableCell;
+  const row: DocTableRow = {
+    cells: [cell], rowHeight: null, rowHeightRule: 'auto', isHeader: false,
+  } as unknown as DocTableRow;
+  const table: DocTable = {
+    colWidths: [colW], rows: [row], borders: allSolid(),
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left', tblInd, bidiVisual, widthPt: colW,
+  } as unknown as DocTable;
+  return {
+    section: {
+      pageWidth: 200, pageHeight: 200,
+      marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [{ type: 'table', ...table }],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+describe('§17.4.50 tblInd — table indent from the leading margin', () => {
+  it('LTR: negative tblInd pulls the LEFT origin outward past the left margin', async () => {
+    // scale=1 (width 200 = pageWidth). content=[20,180]. colW=160 fits content.
+    // No indent: left origin = contentX = 20. With tblInd=-10 → left origin = 10.
+    const noInd = makeRecordingCanvas();
+    await renderDocumentToCanvas(tableDoc(160, undefined, false), noInd.canvas, 0, { dpr: 1, width: 200 });
+    expectNear(Math.min(...noInd.xs), 20, 'LTR base left origin = contentX');
+
+    const withInd = makeRecordingCanvas();
+    await renderDocumentToCanvas(tableDoc(160, -10, false), withInd.canvas, 0, { dpr: 1, width: 200 });
+    expectNear(Math.min(...withInd.xs), 10, 'LTR left origin = contentX + tblInd = 20 + (-10)');
+  });
+
+  it('RTL (bidiVisual): negative tblInd pushes the RIGHT leading edge into the right margin', async () => {
+    // No indent, bidiVisual, colW=160=content: table fills [20,180]; right edge 180.
+    const noInd = makeRecordingCanvas();
+    await renderDocumentToCanvas(tableDoc(160, undefined, true), noInd.canvas, 0, { dpr: 1, width: 200 });
+    expectNear(Math.max(...noInd.xs), 180, 'RTL base right edge = contentRight');
+
+    // tblInd=-10, bidiVisual, colW=160. The table keeps its full 160 width and its
+    // leading (RIGHT) edge sits 10 pt PAST the right margin: rightEdge =
+    // contentX + contentW - tblInd = 20 + 160 - (-10) = 190. Left origin = 190-160 = 30.
+    const withInd = makeRecordingCanvas();
+    await renderDocumentToCanvas(tableDoc(160, -10, true), withInd.canvas, 0, { dpr: 1, width: 200 });
+    expectNear(Math.max(...withInd.xs), 190, 'RTL right edge = contentRight - tblInd = 190');
+    expectNear(Math.min(...withInd.xs), 30, 'RTL left origin = rightEdge - tableW = 30');
+  });
+
+  it('a positive tblInd only applies when jc resolves to left/leading (§17.4.50)', async () => {
+    // jc='right' → not leading → tblInd ignored. Table right-aligns to content.
+    const doc = tableDoc(100, 20, false);
+    (doc.body[0] as unknown as DocTable).jc = 'right';
+    const rec = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, rec.canvas, 0, { dpr: 1, width: 200 });
+    // jc=right: right edge at contentRight (180), unaffected by the ignored indent.
+    expectNear(Math.max(...rec.xs), 180, 'jc=right ignores tblInd; right edge = contentRight');
+  });
+});

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1288,6 +1288,14 @@ export interface DocTable {
   cellMarginRight: number;
   /** table horizontal alignment on the page: 'left' | 'center' | 'right'. */
   jc: string;
+  /** ECMA-376 §17.4.50 `<w:tblInd>` — indentation added before the table's
+   *  LEADING edge (left in an LTR table, right in an RTL/`bidiVisual` table), in
+   *  pt. SIGNED: a negative value pulls the table outward past the leading margin
+   *  toward the page edge (Word writes this for a header banner that must reach
+   *  the physical page edge). `type="dxa"` only; `pct`/`auto` are dropped by the
+   *  parser per §17.4.50. Absent ⇒ no direct indent. The renderer applies it only
+   *  when the resolved `jc` is left/leading (§17.4.50). */
+  tblInd?: number;
   /** ECMA-376 §17.4.52 `<w:tblLayout w:type>` — 'fixed' | 'autofit'. Absent
    *  (undefined) ⇒ spec default 'autofit'. Both paths size columns from the
    *  tblGrid (§17.4.48) scaled to fit: 'fixed' uses the grid verbatim; 'autofit'


### PR DESCRIPTION
## Summary

The docx parser dropped `<w:tblInd>` (§17.4.50) entirely — **0 parse hits** — so a table's leading-edge indent from the text margin was never applied. A header/banner table authored with a **negative** `tblInd` (Word's idiom for a table that must reach the physical page edge) instead sat at the text margin and was scaled down to the narrow text column, so its bottom rule stopped short of the page edge.

## Spec

- **§17.4.50** `<w:tblInd>` — indentation before the table's LEADING edge (left in LTR, right in RTL/`bidiVisual`); a negative value pulls the table outward into the margin; applies **only** when the resolved `jc` is left/leading.
- **§17.4.87** `CT_TblWidth` — the measurement type; `type="dxa"` only (`pct`/`auto` ignored per §17.4.50).

## Changes

**Parser** (`parser.rs` / `types.rs`): parse `<w:tblInd>` as signed pt (dxa only), surface as `DocTable.tblInd` (skipped when absent).

**Renderer** (`renderer.ts`): apply the indent to the table's physical x-origin, gated on `jc === 'left'`:
- LTR — `tableX = contentX + tblInd`.
- RTL (`bidiVisual`) — `rightEdge = contentX + contentW − tblInd; tableX = rightEdge − tableW` (`drawTableRows` mirrors columns inside `[tableX, tableX+tableW]`, so `tableX` is always the physical left origin).
- A negative indent lets the table keep its full preferred width and extend into both margins, so the layout budget is widened to the full page for that case (otherwise `resolveColumnWidths`' content-width fit scales the banner down and it never reaches the page edge).

## Measured before/after (sample-28 p.1 header table — `bidiVisual`, `tblInd=-1301`, `tblW=574.8pt`)

Header bottom rule horizontal extent (px ≈ pt at 1px/pt), page width 595:

| | rule x-span |
|---|---|
| **Before** | `[21 .. 522]` (stops at the content right margin) |
| **After** | `[14 .. 588]` (reaches the page right edge) |
| **Word PDF** | `[14 .. 587]` |

## Non-regression

- `tblInd` is inert unless present **and** `jc=left`; only a negative value widens the layout budget. Every table without a (negative) `tblInd` is byte-identical.
- Of the committed VRT set, **none** carry `tblInd`; docx `demo/sample-1` VRT unchanged.
- New parser tests (dxa / negative-sign / pct-ignored / absent) + renderer tests (LTR origin, RTL leading edge, jc=right gating). cargo fmt/clippy/test (267) green; root vitest (2759) + tsc green.

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)