### PR TITLE
feat(docx): evaluate TIME/DATE field \@ date-time picture (§17.16.5.72/.16)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -341,6 +341,9 @@ export { justifiedPiecePositions, type JustifiedPiece } from './text/justify-pos
 // parsing — the shared numbering kernel (page numbers, list markers, …).
 export { formatOrdinalNumber, type NumberFormat } from './text/number-format';
 export { parseFieldFormatSwitch } from './text/field-format-switch';
+// ECMA-376 §17.16.4.1 date-and-time formatting ("picture") switch — evaluates a
+// DATE/TIME field's `\@ "…"` picture against a given instant (shared by docx/pptx).
+export { formatDateTimePicture, parseDateTimePictureSwitch } from './text/date-time-picture';
 // Format-agnostic index navigation for hidden-item "skip" mode (pptx hidden
 // slides, xlsx hidden sheets): pure math over an isHidden(i) callback.
 export { nextVisibleIndex, resolveVisibleIndex, countVisible } from './nav/visible-index';

--- a/packages/core/src/text/date-time-picture.test.ts
+++ b/packages/core/src/text/date-time-picture.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { formatDateTimePicture, parseDateTimePictureSwitch } from './date-time-picture';
+
+// ECMA-376 §17.16.4.1 reference instant used by the spec's example table:
+// Tuesday, January 3, 2006, 5:28:34 PM (local time).
+const REF = new Date(2006, 0, 3, 17, 28, 34);
+
+describe('parseDateTimePictureSwitch — §17.16.4.1 \\@ switch', () => {
+  it('extracts a quoted picture', () => {
+    expect(parseDateTimePictureSwitch(' DATE \\@ "M/d/yyyy" \\* MERGEFORMAT ')).toBe('M/d/yyyy');
+    expect(parseDateTimePictureSwitch(' TIME  \\@ "YYYY"  \\* MERGEFORMAT ')).toBe('YYYY');
+    expect(parseDateTimePictureSwitch(`DATE \\@ "'Today is 'HH:mm:ss"`)).toBe("'Today is 'HH:mm:ss");
+  });
+
+  it('extracts a bare single-token picture', () => {
+    expect(parseDateTimePictureSwitch('DATE \\@ yyyy')).toBe('yyyy');
+  });
+
+  it('returns null when no \\@ switch is present', () => {
+    expect(parseDateTimePictureSwitch('PAGE \\* MERGEFORMAT')).toBeNull();
+    expect(parseDateTimePictureSwitch('TIME \\* MERGEFORMAT')).toBeNull();
+    expect(parseDateTimePictureSwitch('')).toBeNull();
+  });
+});
+
+describe('formatDateTimePicture — §17.16.4.1 picture items (spec example table)', () => {
+  const cases: Array<[string, string]> = [
+    ['M/d/yyyy', '1/3/2006'],
+    ['dddd, MMMM dd, yyyy', 'Tuesday, January 03, 2006'],
+    ['MMMM d, yyyy', 'January 3, 2006'],
+    ['M/d/yy', '1/3/06'],
+    ['yyyy-MM-dd', '2006-01-03'],
+    ['d-MMM-yy', '3-Jan-06'],
+    ['M.d.yyyy', '1.3.2006'],
+    ['d MMMM yyyy', '3 January 2006'],
+    ['MMMM yy', 'January 06'],
+    ['M/d/yyyy h:mm am/pm', '1/3/2006 5:28 PM'],
+    ['M/d/yyyy h:mm:ss am/pm', '1/3/2006 5:28:34 PM'],
+    ['h:mm am/pm', '5:28 PM'],
+    ['h:mm:ss am/pm', '5:28:34 PM'],
+    ["'Today is 'HH:mm:ss", 'Today is 17:28:34'],
+  ];
+  for (const [pic, want] of cases) {
+    it(`${pic} → ${want}`, () => {
+      expect(formatDateTimePicture(pic, REF)).toBe(want);
+    });
+  }
+
+  it('YYYY (uppercase) formats the 4-digit year (sample-28 footer)', () => {
+    expect(formatDateTimePicture('YYYY', REF)).toBe('2006');
+    expect(formatDateTimePicture('YY', REF)).toBe('06');
+  });
+
+  it('HH is 24-hour with leading zero; H drops it', () => {
+    const morning = new Date(2006, 0, 3, 9, 5, 7);
+    expect(formatDateTimePicture('HH:mm:ss', morning)).toBe('09:05:07');
+    expect(formatDateTimePicture('H:m:s', morning)).toBe('9:5:7');
+  });
+
+  it('12-hour h maps midnight/noon to 12; meridiem is always uppercase (§17.16.4.1 example)', () => {
+    const midnight = new Date(2006, 0, 3, 0, 0, 0);
+    const noon = new Date(2006, 0, 3, 12, 0, 0);
+    // The picture's "am/pm" is lowercase but Word emits uppercase AM/PM.
+    expect(formatDateTimePicture('h:mm am/pm', midnight)).toBe('12:00 AM');
+    expect(formatDateTimePicture('h:mm am/pm', noon)).toBe('12:00 PM');
+    expect(formatDateTimePicture('h:mm AM/PM', noon)).toBe('12:00 PM');
+  });
+
+  it('A/P is the single-letter meridiem (always uppercase)', () => {
+    expect(formatDateTimePicture('h A/P', REF)).toBe('5 P');
+    const am = new Date(2006, 0, 3, 9, 0, 0);
+    expect(formatDateTimePicture('h a/p', am)).toBe('9 A');
+  });
+
+  it("copies literal 'text' and passes other characters through", () => {
+    expect(formatDateTimePicture("'Year: 'yyyy", REF)).toBe('Year: 2006');
+    // doubled '' is an escaped single quote inside a literal
+    expect(formatDateTimePicture("'it''s 'yyyy", REF)).toBe("it's 2006");
+  });
+
+  it('returns null for an unsupported letter token so the caller keeps the cache', () => {
+    // `bbbb` (Thai Buddhist era) and `e` (Japanese emperor era) are unimplemented.
+    expect(formatDateTimePicture('bbbb', REF)).toBeNull();
+    expect(formatDateTimePicture('ee', REF)).toBeNull();
+    // A picture that mixes a supported and an unsupported token still bails.
+    expect(formatDateTimePicture('yyyy bbbb', REF)).toBeNull();
+  });
+});

--- a/packages/core/src/text/date-time-picture.ts
+++ b/packages/core/src/text/date-time-picture.ts
@@ -1,0 +1,173 @@
+/**
+ * ECMA-376 §17.16.4.1 — date-and-time formatting ("picture") switch evaluator,
+ * shared across the docx / pptx field renderers (DATE §17.16.5.16, TIME
+ * §17.16.5.72, and any field whose result is a date/time, e.g. CREATEDATE /
+ * SAVEDATE / PRINTDATE). The DATE/TIME field displays the CURRENT date/time
+ * "filtered through the specified date picture" (§17.16.4.1); this pure function
+ * performs that filtering so each renderer can format the injected current time
+ * deterministically.
+ *
+ * The instruction carries the picture in a `\@ "…"` switch (§17.16.4.1
+ * `date-and-time-formatting-switch = \@ switch-argument`). A switch-argument is a
+ * series of picture items; we implement the necessary-and-sufficient Gregorian
+ * (US-locale) set Word writes in practice:
+ *
+ *   year   : yyyy/YYYY (4-digit) · yy/YY/y/Y (2-digit)
+ *   month  : MMMM (full name) · MMM (abbrev) · MM (2-digit) · M (no-zero)
+ *   day    : dddd/DDDD (full weekday) · ddd/DDD (abbrev weekday) · dd/DD
+ *            (2-digit day-of-month) · d/D (no-zero day-of-month)
+ *   hour   : HH (24-h, 2-digit) · H (24-h) · hh (12-h, 2-digit) · h (12-h)
+ *   minute : mm (2-digit) · m (no-zero)
+ *   second : ss (2-digit) · s (no-zero)
+ *   period : AM/PM · am/pm (and A/P · a/p) → the locale meridiem
+ *   literal: 'text' passes through verbatim; any other character is copied as-is
+ *
+ * Locale-specific and calendar-shifting items (aaa/A Japanese numerals, bb/bbbb
+ * Thai Buddhist era, e/ee/E emperor era, Thai ปปปป/ดดดด/วววว, the `\s`/`\h`
+ * switches, numbered-item back-references) are NOT implemented: encountering an
+ * unsupported LETTER run makes the evaluator return `null`, so the caller falls
+ * back to the field's cached result rather than emitting a wrong date. Month and
+ * weekday NAMES are English (the practical default; the `lang`-driven localization
+ * of §17.3.2.20 is a follow-up — a name request with a non-English requirement is
+ * still English here, which is the same limitation Word documents assume in an
+ * en-US context).
+ */
+
+const MONTHS_FULL = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+const MONTHS_ABBR = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+const WEEKDAYS_FULL = [
+  'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',
+];
+const WEEKDAYS_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const pad2 = (n: number): string => (n < 10 ? `0${n}` : `${n}`);
+
+/**
+ * Extract the `\@ "picture"` (or `\@ picture` — a bare single-token argument)
+ * from a field instruction (§17.16.4.1). Returns the picture string, or `null`
+ * when the instruction carries no date-time switch.
+ */
+export function parseDateTimePictureSwitch(instruction: string): string | null {
+  // Quoted argument: \@ "…". The picture may contain spaces, so capture up to the
+  // closing quote. `[^"]*` is safe — the switch argument itself never contains a
+  // literal double-quote (nested literals use single quotes per §17.16.4.1).
+  const quoted = /\\@\s*"([^"]*)"/.exec(instruction);
+  if (quoted) return quoted[1];
+  // Bare single-token argument: \@ token (rare, e.g. `\@ yyyy`).
+  const bare = /\\@\s*(\S+)/.exec(instruction);
+  return bare ? bare[1] : null;
+}
+
+/**
+ * Format a Date through a §17.16.4.1 picture string. Returns the formatted text,
+ * or `null` when the picture contains an unsupported letter token (so the caller
+ * can fall back to the field's cached result).
+ */
+export function formatDateTimePicture(picture: string, date: Date): string | null {
+  const year = date.getFullYear();
+  const month = date.getMonth(); // 0-based
+  const dom = date.getDate();
+  const dow = date.getDay(); // 0=Sun
+  const hour24 = date.getHours();
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  const minute = date.getMinutes();
+  const second = date.getSeconds();
+  const isPM = hour24 >= 12;
+
+  let out = '';
+  let i = 0;
+  const n = picture.length;
+  while (i < n) {
+    const ch = picture[i];
+
+    // 'text' literal — copy verbatim, honoring a doubled '' as an escaped quote.
+    if (ch === "'") {
+      i++;
+      let lit = '';
+      while (i < n) {
+        if (picture[i] === "'") {
+          if (picture[i + 1] === "'") { lit += "'"; i += 2; continue; }
+          i++; // closing quote
+          break;
+        }
+        lit += picture[i++];
+      }
+      out += lit;
+      continue;
+    }
+
+    // A run of the same letter is one picture item; its length selects the form.
+    if (/[A-Za-z]/.test(ch)) {
+      let j = i;
+      while (j < n && picture[j] === ch) j++;
+      const run = picture.slice(i, j);
+      const len = run.length;
+      const lower = ch.toLowerCase();
+      let piece: string | null = null;
+
+      if (ch === 'y' || ch === 'Y') {
+        piece = len >= 4 ? String(year).padStart(4, '0') : pad2(year % 100);
+      } else if (ch === 'M') {
+        // Month (uppercase M). MMMM full · MMM abbrev · MM 2-digit · M no-zero.
+        piece = len >= 4 ? MONTHS_FULL[month]
+          : len === 3 ? MONTHS_ABBR[month]
+          : len === 2 ? pad2(month + 1)
+          : String(month + 1);
+      } else if (lower === 'd') {
+        // Day. dddd/DDDD full weekday · ddd/DDD abbrev weekday · dd/DD 2-digit
+        // day-of-month · d/D no-zero day-of-month.
+        piece = len >= 4 ? WEEKDAYS_FULL[dow]
+          : len === 3 ? WEEKDAYS_ABBR[dow]
+          : len === 2 ? pad2(dom)
+          : String(dom);
+      } else if (ch === 'H') {
+        piece = len >= 2 ? pad2(hour24) : String(hour24);
+      } else if (ch === 'h') {
+        piece = len >= 2 ? pad2(hour12) : String(hour12);
+      } else if (ch === 'm') {
+        // minute (lowercase m). mm 2-digit · m no-zero.
+        piece = len >= 2 ? pad2(minute) : String(minute);
+      } else if (ch === 's') {
+        piece = len >= 2 ? pad2(second) : String(second);
+      } else if (lower === 'a' || lower === 'p') {
+        // AM/PM · am/pm · A/P · a/p meridiem. Word treats the whole "AM/PM"
+        // (or "A/P") — including the slash — as a single meridiem item; consume
+        // the letter, an optional "M"/"m", the slash, and the trailing token.
+        piece = null; // handled below via the meridiem matcher
+      }
+
+      if (piece !== null) {
+        out += piece;
+        i = j;
+        continue;
+      }
+      // Unsupported letter token (and not a meridiem handled below) → bail so the
+      // caller keeps the cached result.
+      if (!(lower === 'a' || lower === 'p')) return null;
+    }
+
+    // Meridiem: AM/PM, am/pm, A/P, a/p. Per the §17.16.4.1 example table the
+    // emitted meridiem is ALWAYS uppercase regardless of the picture's case
+    // (`… h:mm am/pm` → "5:28 PM"). Matched here (not as a single-letter run)
+    // because it spans a "/" between two tokens.
+    const merid = /^([AaPp])([Mm])?\/([AaPp])([Mm])?/.exec(picture.slice(i));
+    if (merid) {
+      const twoLetter = merid[2] !== undefined; // "AM/PM" form vs "A/P" form
+      out += twoLetter ? (isPM ? 'PM' : 'AM') : (isPM ? 'P' : 'A');
+      i += merid[0].length;
+      continue;
+    }
+
+    // Any other character (":", "-", "/", " ", ".", …) passes through verbatim.
+    out += ch;
+    i++;
+  }
+
+  return out;
+}

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2738,6 +2738,14 @@ fn classify_field(instr: &str) -> String {
     match token.as_str() {
         "PAGE" => "page".to_string(),
         "NUMPAGES" => "numPages".to_string(),
+        // ECMA-376 §17.16.5.16 DATE / §17.16.5.72 TIME — display the CURRENT
+        // date/time filtered through the field's `\@` date-time picture
+        // (§17.16.4.1). Classified as recomputable so the fldChar `separate`
+        // handler sets `substitute=true`: the authored cached result is swallowed
+        // (and preserved as the run's `fallback_text`) and the renderer formats
+        // the injected current time from the instruction's picture instead.
+        "DATE" => "date".to_string(),
+        "TIME" => "time".to_string(),
         _ => "other".to_string(),
     }
 }
@@ -7398,6 +7406,86 @@ mod tests {
             f.emphasis_mark.as_deref(),
             Some("dot"),
             "PAGE field run must carry w:em like a plain text run"
+        );
+    }
+
+    // ECMA-376 §17.16.5.16 DATE / §17.16.5.72 TIME — a `fldSimple` DATE/TIME
+    // field classifies as `date`/`time` (recomputable) and preserves its `\@`
+    // date-time picture in `instruction`; the authored text is its `fallback_text`.
+    #[test]
+    fn date_time_fields_classify_and_keep_picture() {
+        let base = RunFmt::default();
+        let styles = StyleMap::parse("");
+        let date = parse_para(
+            r#"<w:fldSimple w:instr=" DATE \@ &quot;yyyy-MM-dd&quot; ">
+                <w:r><w:t>2019-01-02</w:t></w:r>
+            </w:fldSimple>"#,
+            &base,
+            &styles,
+        );
+        let f = date
+            .iter()
+            .find_map(|r| match r {
+                DocRun::Field(f) => Some(f),
+                _ => None,
+            })
+            .expect("date field run");
+        assert_eq!(f.field_type, "date");
+        assert!(f.instruction.contains("yyyy-MM-dd"), "picture preserved");
+        assert_eq!(
+            f.fallback_text, "2019-01-02",
+            "cached result kept as fallback"
+        );
+
+        let time = parse_para(
+            r#"<w:fldSimple w:instr=" TIME \@ &quot;HH:mm&quot; ">
+                <w:r><w:t>09:41</w:t></w:r>
+            </w:fldSimple>"#,
+            &base,
+            &styles,
+        );
+        let f = time
+            .iter()
+            .find_map(|r| match r {
+                DocRun::Field(f) => Some(f),
+                _ => None,
+            })
+            .expect("time field run");
+        assert_eq!(f.field_type, "time");
+    }
+
+    // A complex (fldChar) TIME field swallows its cached result but preserves it
+    // as `fallback_text` (the sample-28 footer shape: TIME \@ "YYYY" → cached
+    // "2019"). The renderer recomputes from the picture, falling back to this.
+    #[test]
+    fn complex_time_field_swallows_cache_into_fallback() {
+        let base = RunFmt::default();
+        let styles = StyleMap::parse("");
+        let runs = parse_para(
+            r#"<w:r><w:fldChar w:fldCharType="begin"/></w:r>
+               <w:r><w:instrText xml:space="preserve"> TIME  \@ "YYYY"  \* MERGEFORMAT </w:instrText></w:r>
+               <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+               <w:r><w:t>2019</w:t></w:r>
+               <w:r><w:fldChar w:fldCharType="end"/></w:r>"#,
+            &base,
+            &styles,
+        );
+        let f = runs
+            .iter()
+            .find_map(|r| match r {
+                DocRun::Field(f) => Some(f),
+                _ => None,
+            })
+            .expect("time field run");
+        assert_eq!(f.field_type, "time");
+        assert!(f.instruction.contains("YYYY"), "picture preserved");
+        assert_eq!(f.fallback_text, "2019", "cached year kept as fallback");
+        // The cached "2019" must NOT also leak as a standalone text run.
+        assert!(
+            !runs
+                .iter()
+                .any(|r| matches!(r, DocRun::Text(t) if t.text == "2019")),
+            "cached result swallowed, not rendered as text"
         );
     }
 

--- a/packages/docx/src/date-time-field.test.ts
+++ b/packages/docx/src/date-time-field.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { resolveFieldText } from './line-layout.js';
+import type { RenderState } from './renderer.js';
+import type { FieldRun } from './types';
+
+// ECMA-376 §17.16.5.16 DATE / §17.16.5.72 TIME — resolveFieldText formats the
+// injected `currentDateMs` through the field's `\@` picture (§17.16.4.1), falling
+// back to the authored cached result when there is no picture or an unsupported
+// token. Reference instant: Tue Jan 3 2006 17:28:34 (matches the spec example).
+const REF_MS = new Date(2006, 0, 3, 17, 28, 34).getTime();
+
+function state(currentDateMs?: number): RenderState {
+  return { currentDateMs, totalPages: 1, pageIndex: 0 } as unknown as RenderState;
+}
+
+function field(fieldType: string, instruction: string, fallbackText = ''): FieldRun {
+  return { fieldType, instruction, fallbackText } as unknown as FieldRun;
+}
+
+describe('resolveFieldText — DATE/TIME (§17.16.5.16 / §17.16.5.72)', () => {
+  it('formats a TIME field YYYY picture to the injected year (sample-28 footer)', () => {
+    // sample-28: ` TIME  \@ "YYYY"  \* MERGEFORMAT ` cached "2019".
+    const f = field('time', ' TIME  \\@ "YYYY"  \\* MERGEFORMAT ', '2019');
+    expect(resolveFieldText(f, state(REF_MS))).toBe('2006');
+    // The cached "2019" is NOT emitted — the field recomputes.
+    expect(resolveFieldText(f, state(REF_MS))).not.toBe('2019');
+  });
+
+  it('formats a DATE field with a full picture', () => {
+    const f = field('date', ' DATE \\@ "dddd, MMMM dd, yyyy" ', 'cached');
+    expect(resolveFieldText(f, state(REF_MS))).toBe('Tuesday, January 03, 2006');
+  });
+
+  it('falls back to the cached result when the field has no \\@ picture', () => {
+    const f = field('date', ' DATE \\* MERGEFORMAT ', 'Jan 2, 2019');
+    expect(resolveFieldText(f, state(REF_MS))).toBe('Jan 2, 2019');
+  });
+
+  it('falls back to the cached result for an unsupported picture token', () => {
+    // `bbbb` (Thai Buddhist era) is unimplemented — keep the cache.
+    const f = field('time', ' TIME \\@ "bbbb" ', '2562');
+    expect(resolveFieldText(f, state(REF_MS))).toBe('2562');
+  });
+
+  it('defaults to the real current time when currentDateMs is absent', () => {
+    const f = field('date', ' DATE \\@ "yyyy" ', 'cached');
+    const nowYear = String(new Date().getFullYear());
+    expect(resolveFieldText(f, state(undefined))).toBe(nowYear);
+  });
+
+  it('leaves non-date/time fields (fallback text) untouched', () => {
+    const f = field('other', ' AUTHOR ', 'Jane Doe');
+    expect(resolveFieldText(f, state(REF_MS))).toBe('Jane Doe');
+  });
+});

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -36,6 +36,8 @@ import {
   symbolTextToUnicodeSegments,
   formatOrdinalNumber,
   parseFieldFormatSwitch,
+  formatDateTimePicture,
+  parseDateTimePictureSwitch,
 } from '@silurus/ooxml-core';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
 import {
@@ -950,6 +952,23 @@ export function resolveFieldText(f: FieldRun, state: RenderState): string {
     const fmt = parseFieldFormatSwitch(f.instruction) ?? 'decimal';
     return formatOrdinalNumber(state.totalPages, fmt);
   }
+  // ECMA-376 §17.16.5.16 DATE / §17.16.5.72 TIME — display the CURRENT date/time
+  // filtered through the field's `\@` date-time picture (§17.16.4.1). The
+  // "current" instant is injected via `state.currentDateMs` (default = real time,
+  // set at the render entry point) so the output is deterministic under test.
+  // A field with NO `\@` picture, or one whose picture uses an unimplemented
+  // token, falls back to the authored cached result (§17.16.4.1: with no picture
+  // the result is formatted "in an implementation-defined manner" — we keep
+  // Word's cached rendering rather than invent one).
+  if (f.fieldType === 'date' || f.fieldType === 'time') {
+    const picture = parseDateTimePictureSwitch(f.instruction);
+    if (picture) {
+      const now = new Date(state.currentDateMs ?? Date.now());
+      const formatted = formatDateTimePicture(picture, now);
+      if (formatted !== null) return formatted;
+    }
+    return f.fallbackText;
+  }
   return f.fallbackText;
 }
 
@@ -1308,7 +1327,11 @@ export function paragraphSegsStateSensitive(para: DocParagraph): boolean {
   for (const run of para.runs) {
     if (run.type === 'field') {
       const ft = (run as unknown as FieldRun).fieldType;
-      if (ft === 'page' || ft === 'numPages') return true;
+      // page / numPages depend on the per-page render context. date / time depend
+      // on the injected `state.currentDateMs`, which the measure state does not
+      // carry (buildMeasureState) — so these too must recompute rather than stamp
+      // a measure-time value (§17.16.4.1 DATE/TIME resolve at paint).
+      if (ft === 'page' || ft === 'numPages' || ft === 'date' || ft === 'time') return true;
     } else if (run.type === 'text' && (run as unknown as DocxTextRun).noteRef) {
       return true;
     }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -303,6 +303,11 @@ export interface RenderState {
   /** When false, runs tagged with a `revision` render without the
    *  track-changes overlay (no author colour, no underline/strikethrough). */
   showTrackChanges: boolean;
+  /** ECMA-376 §17.16.5.16 DATE / §17.16.5.72 TIME — the "current" instant (epoch
+   *  ms) a DATE/TIME field formats through its `\@` picture (§17.16.4.1). Injected
+   *  from the render option `currentDate` so field output is deterministic under
+   *  test; absent ⇒ `Date.now()` (real time). */
+  currentDateMs?: number;
   /** ECMA-376 §17.11 — footnote/endnote reference markers (`noteRef` runs)
    *  display the note's 1-based sequential number, not the raw `@w:id`. Keyed by
    *  `"footnote:<id>"` / `"endnote:<id>"`. The in-note `<w:footnoteRef>`
@@ -440,6 +445,12 @@ export interface RenderDocumentOptions {
    *  no underline / strikethrough overlay — useful for a "final / no markup"
    *  view of a tracked document. */
   showTrackChanges?: boolean;
+  /** ECMA-376 §17.16.5.16 DATE / §17.16.5.72 TIME — the "current" instant that a
+   *  DATE/TIME field formats through its `\@` date picture (§17.16.4.1). Accepts a
+   *  `Date` or epoch-ms number. Default = the real current time (`Date.now()` at
+   *  render). Provide a fixed value to make DATE/TIME field output deterministic
+   *  (e.g. in tests / reproducible exports). */
+  currentDate?: Date | number;
 }
 
 // ===== Image preloading =====
@@ -481,6 +492,13 @@ interface ImagePair {
    *  crop, so the decode must prefer the raster (the crop math needs the
    *  bitmap's native pixel grid; an SVG vector original has none). */
   hasCrop?: boolean;
+}
+
+/** Normalize the `currentDate` render option (Date | epoch-ms | undefined) to
+ *  epoch milliseconds. Undefined ⇒ the real current time (§17.16.4.1 DATE/TIME). */
+function resolveCurrentDateMs(currentDate: Date | number | undefined): number {
+  if (currentDate == null) return Date.now();
+  return typeof currentDate === 'number' ? currentDate : currentDate.getTime();
 }
 
 /** Returns a stable map key for an (imagePath, colorReplaceFrom) pair. */
@@ -1163,6 +1181,8 @@ export async function renderDocumentToCanvas(
     mathDefJc: doc.settings?.mathDefJc,
     onTextRun: opts.onTextRun,
     showTrackChanges: opts.showTrackChanges ?? true,
+    // §17.16.4.1 — the instant DATE/TIME fields format against (default real time).
+    currentDateMs: resolveCurrentDateMs(opts.currentDate),
     noteNumbers,
     // ECMA-376 §17.6.20 — when set, the glyph-draw path counter-rotates upright
     // (CJK) glyphs so they stand up inside the +90°-rotated page (see the page

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1426,4 +1426,9 @@ export interface RenderPageOptions {
    *  in their normal style (no author colour, no underline / strikethrough)
    *  — equivalent to Word's "Final / No Markup" view. */
   showTrackChanges?: boolean;
+  /** ECMA-376 §17.16.5.16 DATE / §17.16.5.72 TIME — the "current" instant a
+   *  DATE/TIME field formats through its `\@` date picture (§17.16.4.1). A `Date`
+   *  or epoch-ms number. Default = the real current time at render. Set a fixed
+   *  value for deterministic / reproducible DATE/TIME field output. */
+  currentDate?: Date | number;
 }


### PR DESCRIPTION
## Summary

A **DATE** (§17.16.5.16) / **TIME** (§17.16.5.72) field displays the *current* date/time filtered through its `\@` date-time picture (§17.16.4.1). The docx renderer ignored these fields and drew the authored cached result verbatim, so a footer authored years ago showed its stale cached year (sample-28: `TIME \@ "YYYY"` cached **"2019"**) instead of the current year.

## Spec

- **§17.16.5.16 DATE / §17.16.5.72 TIME** — display the current date/time filtered through the `\@` picture.
- **§17.16.4.1** — the date-and-time formatting ("picture") switch grammar.

## Changes

**Core** (`date-time-picture.ts` — shared with pptx's DATE/TIME fields, lives beside `parseFieldFormatSwitch`):
- `parseDateTimePictureSwitch` extracts the `\@ "…"` picture; `formatDateTimePicture` evaluates it against a given instant.
- Implements the necessary-and-sufficient Gregorian/US token set: `yyyy/YYYY·yy/YY·y/Y`, `MMMM/MMM/MM/M`, `dddd/DDDD·ddd/DDD·dd/DD·d/D`, `HH/H·hh/h`, `mm/m`, `ss/s`, `AM/PM·am/pm·A/P` (always uppercase per the §17.16.4.1 example table), `'literal'`, pass-through chars.
- An **unsupported letter token** (Thai era `bb/bbbb`, emperor era `e/ee/E`, `\s`/`\h`, …) returns `null` so the caller keeps the cache. Verified against the **full §17.16.4.1 example table**.

**Parser**: `classify_field` maps DATE/TIME → `date`/`time` (recomputable): the fldChar `separate` handler sets `substitute=true`, so the cached result is swallowed **and** preserved as the run's `fallback_text`.

**Renderer**: `resolveFieldText` formats the `\@` picture against the injected current time; with no picture or an unsupported token it returns the cached `fallback_text`. The instant is injected via the new **`currentDate` render option** (`Date | epoch-ms`; default = real `Date.now()`), threaded as `RenderState.currentDateMs` — making output deterministic under test. date/time join page/numPages in `paragraphSegsStateSensitive` so they recompute at paint.

## Measured before/after (sample-28 footer — `TIME \@ "YYYY"`, cached "2019")

| render option | footer year (all pages) |
|---|---|
| **Before** (field ignored) | 2019 (stale cache) |
| **After**, no option | the real current year (not 2019) |
| **After**, `currentDate` = 2031 | 2031 |

## Non-regression

- Only `date`/`time` fields change behavior; PAGE / NUMPAGES / TOC / other fields are untouched. docx `demo/sample-1` VRT unchanged.
- New tests: core (23, full spec table), parser (fldSimple classification + complex-field cache preservation), renderer resolver (picture / no-picture / unsupported-token / default-now). cargo fmt/clippy/test (265) + core vitest (1175) + root vitest (2800) + tsc green.

Closes #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)