### PR TITLE
fix(docx): mirror tab stops in RTL (bidi) paragraphs (#820)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -12,8 +12,8 @@ use zip::ZipArchive;
 
 use crate::numbering::NumberingMap;
 use crate::styles::{
-    apply_para, apply_run, merge_cond_layers, parse_para_fmt, parse_run_fmt, CondFmt, EdgeBorder,
-    RawTblBorders, RunFmt, StyleMap,
+    apply_para, apply_run, merge_cond_layers, merge_tab_stops, parse_para_fmt, parse_run_fmt,
+    CondFmt, EdgeBorder, RawTblBorders, RunFmt, StyleMap,
 };
 use crate::types::*;
 use crate::xml_util::*;
@@ -5212,18 +5212,21 @@ fn extract_simple_paragraph_text(
     // drift-prone re-implementation of an existing parse). Carried onto `ShapeText`
     // so the text box is laid out by the main line engine (kinsoku/bidi/justify/
     // tabs), which the old simplified wrapper never applied.
-    let tab_stops: Vec<TabStop> = direct_ind
-        .tab_stops
-        .clone()
-        .or_else(|| style_para.tab_stops.clone())
-        .unwrap_or_default()
-        .into_iter()
-        .map(|(pos, alignment, leader)| TabStop {
-            pos,
-            alignment,
-            leader,
-        })
-        .collect();
+    // §17.3.1.37 — MERGE direct over style-resolved stops by position (not
+    // replace), the same rule the body-paragraph path uses via `apply_para`
+    // (styles.rs `merge_tab_stops`): a text box's direct tab keeps the style's
+    // leader tab rather than dropping it.
+    let tab_stops: Vec<TabStop> = merge_tab_stops(
+        style_para.tab_stops.as_deref().unwrap_or(&[]),
+        direct_ind.tab_stops.as_deref().unwrap_or(&[]),
+    )
+    .into_iter()
+    .map(|(pos, alignment, leader)| TabStop {
+        pos,
+        alignment,
+        leader,
+    })
+    .collect();
     let bidi = direct_ind.bidi.or(style_para.bidi);
 
     // Single block-level format fields come from the FIRST text run (kept for

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -635,6 +635,36 @@ impl StyleMap {
     }
 }
 
+/// ECMA-376 §17.3.1.37 tab-stop inheritance — MERGE a more-specific set (`src`,
+/// e.g. a paragraph's direct `<w:tabs>`) over an inherited one (`base`, e.g. the
+/// resolved style-chain stops) by POSITION, not wholesale replace. Word treats
+/// each `<w:tab>` as keyed on its `pos`: a more-specific stop at the same
+/// position OVERRIDES the inherited one (its alignment/leader win), a
+/// `val="clear"` stop REMOVES the inherited stop at that position, and stops at
+/// positions the inherited set lacks are ADDED. This is what lets a TOC entry's
+/// direct left tab coexist with the TOC style's right dot-/underscore-leader tab
+/// (the leader + page-number column). Positions compare within a 1/20-pt epsilon
+/// (twips round-trip). The result is sorted; `clear` markers are stripped (they
+/// only delete). A wholesale replace here silently dropped the style's leader
+/// tab whenever a paragraph added ANY direct tab (issue #820 TOC leaders).
+pub(crate) fn merge_tab_stops(
+    base: &[(f64, String, String)],
+    src: &[(f64, String, String)],
+) -> Vec<(f64, String, String)> {
+    const EPS: f64 = 0.05; // 1/20 pt — the twips grid
+    let mut out: Vec<(f64, String, String)> = base.to_vec();
+    for s in src {
+        // Remove any inherited stop at the same position (override or clear).
+        out.retain(|b| (b.0 - s.0).abs() > EPS);
+        if s.1 != "clear" {
+            out.push(s.clone());
+        }
+    }
+    out.retain(|t| t.1 != "clear");
+    out.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    out
+}
+
 /// Layer the paragraph format `src` OVER `dst`: every property `src` explicitly
 /// sets replaces `dst`'s. Used both for the style cascade (basedOn parent →
 /// child) and — via parser.rs — for a paragraph's DIRECT pPr over its resolved
@@ -676,8 +706,12 @@ pub(crate) fn apply_para(dst: &mut ParaFmt, src: &ParaFmt) {
     if src.num_level.is_some() {
         dst.num_level = src.num_level;
     }
-    if src.tab_stops.is_some() {
-        dst.tab_stops = src.tab_stops.clone();
+    if let Some(src_tabs) = &src.tab_stops {
+        // §17.3.1.37 — MERGE by position (see `merge_tab_stops`), not replace, so
+        // a direct/child tab set keeps the inherited style's other stops (e.g. a
+        // TOC leader tab). `dst` empty ⇒ merge is just the sorted src.
+        let base = dst.tab_stops.take().unwrap_or_default();
+        dst.tab_stops = Some(merge_tab_stops(&base, src_tabs));
     }
     if src.shading.is_some() {
         dst.shading = src.shading.clone();
@@ -970,15 +1004,18 @@ pub fn parse_para_fmt(ppr: roxmltree::Node) -> ParaFmt {
         let mut tabs: Vec<(f64, String, String)> = Vec::new();
         for t in children_w(tabs_node, "tab") {
             let val = attr_w(t, "val").unwrap_or_else(|| "left".to_string());
-            // val="clear" removes an inherited tab — MVP: skip (no tab to emit)
-            if val == "clear" {
-                continue;
-            }
             let pos = match attr_w(t, "pos").map(|s| twips_to_pt(&s)) {
                 Some(p) => p,
                 None => continue,
             };
             let leader = attr_w(t, "leader").unwrap_or_else(|| "none".to_string());
+            // `val="clear"` (§17.3.1.37 / §17.18.84) is preserved through the
+            // style-chain merge (`apply_para` → `merge_tab_stops`), where it
+            // REMOVES an inherited stop at this position; `merge_tab_stops` drops any
+            // remaining `clear` (and the final `TabStop` conversion never emits
+            // one). Keeping it here — rather than dropping at parse — is what
+            // lets a direct `<w:tab val="clear" pos="X">` cancel a style stop
+            // at X while other direct stops merge with the inherited set.
             tabs.push((pos, val, leader));
         }
         if !tabs.is_empty() {
@@ -1546,6 +1583,50 @@ fn parse_tbl_style_def(style_node: roxmltree::Node, based_on: Option<String>) ->
 mod tests {
     use super::*;
     use roxmltree::Document as XmlDoc;
+
+    fn stop(pos: f64, al: &str, ldr: &str) -> (f64, String, String) {
+        (pos, al.to_string(), ldr.to_string())
+    }
+
+    #[test]
+    fn merge_tab_stops_unions_by_position_keeping_inherited_leader() {
+        // §17.3.1.37 — a direct left tab must NOT drop the style's right leader
+        // tab (issue #820 TOC): the two coexist because they sit at different
+        // positions. Result is sorted by pos.
+        let style = vec![
+            stop(50.85, "left", "none"),
+            stop(467.5, "right", "underscore"),
+        ];
+        let direct = vec![stop(195.05, "left", "none")];
+        let merged = merge_tab_stops(&style, &direct);
+        assert_eq!(
+            merged,
+            vec![
+                stop(50.85, "left", "none"),
+                stop(195.05, "left", "none"),
+                stop(467.5, "right", "underscore"),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_tab_stops_direct_overrides_at_same_position() {
+        // A direct stop at (within epsilon of) an inherited position wins.
+        let style = vec![stop(100.0, "left", "dot")];
+        let direct = vec![stop(100.02, "right", "none")];
+        let merged = merge_tab_stops(&style, &direct);
+        assert_eq!(merged, vec![stop(100.02, "right", "none")]);
+    }
+
+    #[test]
+    fn merge_tab_stops_clear_removes_inherited_and_never_emits() {
+        // `val="clear"` at a position removes the inherited stop there and is
+        // itself dropped from the result (§17.18.84).
+        let style = vec![stop(100.0, "left", "none"), stop(200.0, "right", "dot")];
+        let direct = vec![stop(100.0, "clear", "none")];
+        let merged = merge_tab_stops(&style, &direct);
+        assert_eq!(merged, vec![stop(200.0, "right", "dot")]);
+    }
 
     fn run_fmt_from(rpr_xml: &str) -> RunFmt {
         let xml = format!(

--- a/packages/docx/src/bidi-line.ts
+++ b/packages/docx/src/bidi-line.ts
@@ -35,6 +35,11 @@ const segRtl = (s: unknown): boolean => (s as { rtl?: unknown }).rtl === true;
 const segDigitsAsAN = (s: unknown): boolean =>
   (s as { digitsAsAN?: unknown }).digitsAsAN === true;
 
+/** Is this a laid-out TAB segment (ECMA-376 §17.3.1.37)? A tab character is
+ *  Unicode Bidi_Class S (Segment Separator), NOT a neutral object — see
+ *  {@link computeLineVisualOrder}. */
+const segIsTab = (s: unknown): boolean => 'isTab' in (s as object);
+
 /**
  * Cheap gate: does this run of segments need the bidi pass? True when any
  * segment contains a strong-RTL character OR carries a run-level `<w:rtl>`
@@ -99,6 +104,13 @@ export function computeLineVisualOrder(
   //    reorders to Word's "2026-02-28" under an RTL base (§17.3.2.20).
   //  - rtl-marked segments (§17.3.2.30): punctuation/symbols → R, so the run's
   //    ambiguous characters resolve RTL at the base level (see doc above).
+  //  - TAB segments (§17.3.1.37): the placeholder is forced to S (Segment
+  //    Separator) — a tab character's real Bidi_Class. Rules L1/L2 then reset it
+  //    to the paragraph level and reorder each tab-delimited CELL independently,
+  //    so an RTL paragraph's tab-aligned cells appear in mirrored (leading-cell-
+  //    at-the-right) order, matching Word. Modelled as a class override rather
+  //    than by emitting a literal "\t" so the segment↔code-unit mapping stays
+  //    1:1 (every non-text inline object is one code unit).
   // `undefined` until any segment opts in, so the pure algorithm runs for
   // ordinary lines.
   let classOverride: (BidiClass | null)[] | undefined;
@@ -113,7 +125,10 @@ export function computeLineVisualOrder(
     full += t.length > 0 ? t : OBJECT_PLACEHOLDER;
     segEnd[i] = full.length;
 
-    if (t.length > 0 && (segDigitsAsAN(segments[i]) || segRtl(segments[i]))) {
+    if (segIsTab(segments[i])) {
+      // Single placeholder code unit at segStart[i]; classify it S.
+      ensureOverride()[segStart[i]] = 'S';
+    } else if (t.length > 0 && (segDigitsAsAN(segments[i]) || segRtl(segments[i]))) {
       const ov = ensureOverride();
       const digitsAN = segDigitsAsAN(segments[i]);
       const rtlMarked = segRtl(segments[i]);

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -43,6 +43,11 @@ import {
   resolveLineFloatWindow,
   wordMinLineStartPx,
 } from './float-layout.js';
+// Pure UAX#9 per-line reorder helper. `bidi-line.ts` imports only from
+// `@silurus/ooxml-core` (never from this module), so this is a one-directional
+// value import — no runtime cycle (same rule as the renderer.ts → line-layout.ts
+// split documented above).
+import { computeLineVisualOrder } from './bidi-line.js';
 
 export interface LayoutTextSeg {
   text: string;
@@ -1269,6 +1274,179 @@ export function nextTabStop(
   return custom ?? auto;
 }
 
+/** ECMA-376 §17.3.1.37 / §17.15.1.25 in a BIDI paragraph — the RTL twin of
+ *  {@link nextTabStop}. In a right-to-left paragraph the tab-stop coordinate
+ *  system is anchored at the LEADING (right) text edge: a stop's `pos` is the
+ *  distance from that right edge, and the pen advances LEFTWARD (decreasing
+ *  margin position). This finds the nearest stop strictly BELOW the pen — i.e.
+ *  the next stop to the left — using the same automatic-grid rule (§17.15.1.25:
+ *  automatic stops sit past all custom stops, here on the far LEFT of the line).
+ *
+ *  @param curMarginPx pen position measured from the right (leading) text edge.
+ *  @param customStopsPx custom stops in right-edge px (`pos * scale`).
+ *  @param intervalPx automatic-stop interval = `defaultTabPt * scale`.
+ *  @returns the chosen stop (custom keeps its alignment/leader; automatic is
+ *    `'left'`), or `null` when the pen is already at/left of every stop. */
+export function nextTabStopRtl(
+  curMarginPx: number,
+  customStopsPx: { pos: number; alignment: TabStop['alignment']; leader?: TabStop['leader'] }[],
+  intervalPx: number,
+): { pos: number; alignment: TabStop['alignment']; leader?: TabStop['leader'] } | null {
+  // Candidate 1 — the nearest custom stop strictly PAST the pen (greater pos =
+  // further from the right edge = further left). Symmetric to nextTabStop.
+  let custom: { pos: number; alignment: TabStop['alignment']; leader?: TabStop['leader'] } | null = null;
+  let maxCustomPx = 0;
+  for (const t of customStopsPx) {
+    if (t.pos > maxCustomPx) maxCustomPx = t.pos;
+    if (t.pos > curMarginPx && (custom === null || t.pos < custom.pos)) custom = t;
+  }
+  // Candidate 2 — nearest automatic multiple past BOTH the pen and the last
+  // custom stop (§17.15.1.25). Identical grid to nextTabStop; the mirror is
+  // entirely in how `pos` is interpreted (distance from the right edge).
+  let auto: { pos: number; alignment: TabStop['alignment'] } | null = null;
+  if (intervalPx > 0) {
+    const EPS = 1e-6;
+    const from = Math.max(curMarginPx, maxCustomPx);
+    let pos = Math.ceil((from + EPS) / intervalPx) * intervalPx;
+    if (pos <= curMarginPx) pos += intervalPx;
+    auto = { pos, alignment: 'left' };
+  }
+  if (custom && auto) return custom.pos <= auto.pos ? custom : auto;
+  return custom ?? auto;
+}
+
+/** One entry in a bidi line's LOGICAL-order sequence, for {@link layoutBidiTabStops}. */
+export interface BidiTabItem {
+  /** True for a tab segment (its width is (re)computed); false for content. */
+  isTab: boolean;
+  /** Content width in px (ignored for tabs). Set by the LTR layout pass. */
+  width: number;
+}
+
+/** Per-segment result of {@link layoutBidiTabStops}. */
+export interface BidiTabResult {
+  /** New measuredWidth for the tab at this LOGICAL index (non-tabs: unchanged). */
+  width: number;
+  /** Leader to paint across this tab's span (`'none'`/undefined ⇒ blank). */
+  leader?: TabStop['leader'];
+  /** Visual x (px, from the line's LEFT text edge) of this segment's left edge —
+   *  where the draw walk should paint it. */
+  visualX: number;
+}
+
+/**
+ * ECMA-376 §17.3.1.37 / §17.15.1.25 / §17.18.84 — lay out ONE line of a BIDI
+ * (RTL-base) paragraph's tab-aligned cells, returning each segment's tab width
+ * and its final VISUAL x.
+ *
+ * The LTR layout pass ({@link layoutLines}) resolves tab widths against the pen
+ * in LOGICAL order but in a LEFT-to-right frame, which is wrong for a bidi
+ * paragraph: a tab advances the pen in READING order, which under an RTL base
+ * runs RIGHT-to-LEFT, and the tab-delimited cells then reorder visually. The LTR
+ * result lands the trailing content (a TOC page number, a footer field) on the
+ * wrong visual side — often overflowing and wrapping to a new line (the "leaders
+ * appear/disappear" and "page number on its own row" symptoms of issue #820).
+ *
+ * This lays the line out in the RTL reading frame: the pen starts at the LEADING
+ * (right) text edge and moves LEFT. A tab stop's `pos` is its distance from that
+ * leading edge; the Nth tab in reading order advances to the next stop further
+ * left (larger `pos`), exactly like the LTR pen advances rightward through
+ * stops. Alignment is logical (Part 4 §14.11.2): physical `left` = `start`
+ * (leading ⇒ following content's leading/RIGHT edge on the stop), physical
+ * `right` = `end` (trailing ⇒ its trailing/LEFT edge on the stop); `center` is
+ * unchanged; `bar`/`clear` advance like `start`. Automatic stops fall on the
+ * §17.15.1.25 grid from the leading edge, after all custom stops. A stop past
+ * the left margin pins its content to the margin (Word never pushes it off the
+ * page). The reading-frame positions are converted to the draw loop's visual
+ * L→R x at the end.
+ *
+ * @param items line segments in LOGICAL order (as `line.segments`).
+ * @param customStopsPx custom tab stops in leading-edge px (`pos * scale`).
+ * @param availWidthPx the line's available content width in px.
+ * @param intervalPx automatic-stop interval = `defaultTabPt * scale`.
+ * @returns one {@link BidiTabResult} per LOGICAL index (1:1 with `items`).
+ */
+export function layoutBidiTabStops(
+  items: BidiTabItem[],
+  customStopsPx: { pos: number; alignment: TabStop['alignment']; leader?: TabStop['leader'] }[],
+  availWidthPx: number,
+  intervalPx: number,
+): BidiTabResult[] {
+  const n = items.length;
+  const width = items.map((it) => it.width);
+  const leader: (TabStop['leader'] | undefined)[] = new Array(n).fill(undefined);
+
+  // Width of the content run immediately FOLLOWING index `i` in reading order
+  // (up to the next tab / line end) — the trailing/centered stop needs it.
+  const followW = (from: number): number => {
+    let w = 0;
+    for (let j = from; j < n; j++) {
+      if (items[j].isTab) break;
+      w += width[j];
+    }
+    return w;
+  };
+
+  // Reading-frame layout. `pen` = distance from the LEADING (right) edge; content
+  // and tabs push it further LEFT (increasing). `leftEdge[i]` / `rightEdge[i]` are
+  // each segment's edges in this frame (leftEdge = larger margin = further left).
+  const leftMargin = availWidthPx; // pen value at the physical LEFT text edge
+  let pen = 0;
+  const rightEdge = new Array(n).fill(0);
+  const leftEdge = new Array(n).fill(0);
+  for (let i = 0; i < n; i++) {
+    const it = items[i];
+    if (!it.isTab) {
+      rightEdge[i] = pen;
+      pen += width[i];
+      leftEdge[i] = pen;
+      continue;
+    }
+    const stop = nextTabStopRtl(pen, customStopsPx, intervalPx);
+    if (!stop) {
+      // No stop further left: the tab collapses (following content continues).
+      rightEdge[i] = pen;
+      leftEdge[i] = pen;
+      continue;
+    }
+    // Where the tab's OWN leading (right) edge sits: at the pen. Its trailing
+    // (left) edge is the stop-aligned target, giving the gap it fills.
+    const fw = followW(i + 1);
+    let target: number; // pen value after the tab (its trailing/left edge)
+    if (stop.alignment === 'right') {
+      // end/trailing: following content's TRAILING (left) edge on the stop, i.e.
+      // its right edge sits fw to the RIGHT (smaller margin) of the stop.
+      target = stop.pos - fw;
+    } else if (stop.alignment === 'center') {
+      target = stop.pos - fw / 2;
+    } else {
+      // start/leading (or bar/clear/left): following content's LEADING (right)
+      // edge on the stop.
+      target = stop.pos;
+    }
+    // Pin content that would fall past the left margin onto the margin: the
+    // following cell spans [target, target + fw] in reading-frame margins, so its
+    // far (left) edge must stay ≤ leftMargin (Word never pushes it off the page).
+    if (target + fw > leftMargin) target = leftMargin - fw;
+    // Never let a tab move the pen backwards (right).
+    if (target < pen) target = pen;
+    rightEdge[i] = pen;
+    width[i] = target - pen;
+    leftEdge[i] = target;
+    leader[i] = stop.leader;
+    pen = target;
+  }
+
+  // Convert reading-frame margins to visual (L→R from the left text edge) x:
+  // visualX = availWidthPx − leftEdge (the segment's LEFT visual edge is the
+  // FURTHEST-left reading-frame edge = its largest margin value).
+  return items.map((_, i) => ({
+    width: width[i],
+    leader: leader[i],
+    visualX: availWidthPx - leftEdge[i],
+  }));
+}
+
 /** Value equivalence of two resolved kinsoku rule sets, with a reference fast
  *  path. The reuse gate cannot rely on `===` alone: `resolveKinsokuRules` builds
  *  a FRESH object (fresh Sets) on every call, and the prebuiltPages production
@@ -1689,6 +1867,13 @@ export function layoutLines(
   // edge is `-tabOriginPx`. `relativeTo="indent"` uses the content box
   // (`[0, maxWidth]`) and needs neither.
   marginRightPx: number = maxWidth,
+  // ECMA-376 §17.3.1.6 `<w:bidi>` — the paragraph's base direction is RTL. Tab
+  // stops mirror to the leading (right) edge in this case (§17.18.84 start/end
+  // are logical edges): the tab widths are computed in the VISUAL frame by a
+  // per-line post-pass (`layoutBidiTabStops`) instead of the LTR pen math, and
+  // tabs do not trigger the LTR right/center/overflow wrap paths. Default false
+  // ⇒ the LTR tab paths run unchanged (byte-identical output).
+  baseRtl = false,
 ): LayoutLine[] {
   const lines: LayoutLine[] = [];
   let currentLine: (LayoutTextSeg | LayoutImageSeg | LayoutMathSeg | LayoutTabSeg)[] = [];
@@ -1765,8 +1950,42 @@ export function layoutLines(
 
   const availW = () => lineMaxWidth - (isFirst ? firstIndent : 0);
 
+  // ECMA-376 §17.3.1.37 tab stops in leading-edge px, for the bidi post-pass.
+  const bidiCustomStopsPx = baseRtl
+    ? tabStops.map((t) => ({ pos: t.pos * scale, alignment: t.alignment, leader: t.leader }))
+    : [];
+  const bidiIntervalPx = defaultTabPt * scale;
+
+  // Rewrite a finalized bidi line's tab widths (+ leaders) in the VISUAL frame
+  // (§17.3.1.6 base RTL). The line's tabs were laid out with provisional width 0
+  // by the tab block below (the LTR pen math does not apply under an RTL base);
+  // here we place each tab-delimited cell at its mirrored stop. No-op for a line
+  // without tabs (LTR paragraphs skip this entirely — `baseRtl` is false).
+  const applyBidiTabs = (): void => {
+    if (!baseRtl) return;
+    if (!currentLine.some((s) => 'isTab' in s)) return;
+    const order = computeLineVisualOrder(currentLine, true).order;
+    const items: BidiTabItem[] = order.map((li) => {
+      const s = currentLine[li];
+      return { isTab: 'isTab' in s, width: s.measuredWidth };
+    });
+    const availW = lineMaxWidth - (isFirst ? firstIndent : 0);
+    const res = layoutBidiTabStops(items, bidiCustomStopsPx, availW, bidiIntervalPx);
+    // Map visual results back to the logical segments (order[vi] = logical idx).
+    let delta = 0;
+    for (let vi = 0; vi < order.length; vi++) {
+      const s = currentLine[order[vi]];
+      if (!('isTab' in s)) continue;
+      delta += res[vi].width - s.measuredWidth;
+      s.measuredWidth = res[vi].width;
+      (s as LayoutTabSeg).leader = res[vi].leader;
+    }
+    currentWidth += delta;
+  };
+
   let lineHasRuby = false;
   const flush = (forceHeight?: number, brTerminated = false) => {
+    applyBidiTabs();
     const h = forceHeight !== undefined ? forceHeight : (lineHeight || 10);
     // If the line has no measured content (empty/line-break line), synthesize
     // stable ascent/descent from the effective font size so wrap/baseline math
@@ -1936,6 +2155,20 @@ export function layoutLines(
 
     // ── Tab segment ──────────────────────────────────────
     if ('isTab' in seg) {
+      // ── ECMA-376 §17.3.1.6 base-RTL ordinary tab ─────────────────────────
+      // The LTR pen math below resolves stops in LOGICAL order, which mis-places
+      // a bidi paragraph's tab-delimited cells (they reorder visually — see
+      // `layoutBidiTabStops`). Add the tab with a PROVISIONAL width of 0 and do
+      // NOT wrap on it; the per-line post-pass (`applyBidiTabs`, run in `flush`)
+      // recomputes every tab width in the visual frame once the line's content
+      // is known. A `<w:ptab>` (absolute-position tab) keeps the LTR path for
+      // now (no bidi ptab fixture; its own NOTE flags the gap).
+      if (baseRtl && !seg.ptab) {
+        seg.measuredWidth = 0;
+        addToLine(seg, 0, seg.fontSize, seg.fontSize * scale * 0.8, seg.fontSize * scale * 0.2);
+        continue;
+      }
+
       // Absolute position on the line measured from paraX (line origin for continuation lines)
       const absFromParaX = currentWidth + (isFirst ? firstIndent : 0);
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3279,7 +3279,7 @@ function estimateParagraphHeight(
       lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, grid, paraHasRuby, is ?? 0, paragraphIsEastAsian(para)),
       pageH: state.pageH,
     } : undefined;
-    const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, gridCharDeltaPx(grid, 1), state.defaultTabPt, paraW + indRight);
+    const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, gridCharDeltaPx(grid, 1), state.defaultTabPt, paraW + indRight, para.bidi === true);
     if (lines.length === 0) {
       // Anchor-only paragraph: no inline content, but the paragraph mark still
       // occupies one (possibly flowed) line (§17.3.1.29).
@@ -3496,7 +3496,7 @@ function splitParagraphAcrossPages(
     lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, measureState.docGrid, paragraphHasRuby(para), is ?? 0, paragraphIsEastAsian(para)),
     pageH: measureState.pageH,
   } : undefined;
-  const lines = layoutLines(measureState.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, measureState.fontFamilyClasses, indLeft, measureState.kinsoku, gridCharDeltaPx(paraGrid(para, measureState), 1), measureState.defaultTabPt, paraW + indRight);
+  const lines = layoutLines(measureState.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, measureState.fontFamilyClasses, indLeft, measureState.kinsoku, gridCharDeltaPx(paraGrid(para, measureState), 1), measureState.defaultTabPt, paraW + indRight, para.bidi === true);
   if (lines.length === 0) {
     // Anchor-only paragraph: no inline lines, but the paragraph mark still
     // occupies one (possibly relocated) line (§17.3.1.29).
@@ -5256,9 +5256,9 @@ function renderParagraph(
   const lines = reuse
     ? rescaleLayoutLines(stamped.layoutLines as LayoutLine[], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx)
     : wrapCtx
-      ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx)
+      ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx, baseRtl)
       : rescaleLayoutLines(
-          layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt, marginRightPx1),
+          layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt, marginRightPx1, baseRtl),
           scale, ctx, state.fontFamilyClasses, paintGridDeltaPx,
         );
 
@@ -7214,6 +7214,12 @@ export function renderShapeText(
           } as ShapeTextRun];
     const docRuns = runs.map(shapeRunToDocRun);
     const segs = buildSegments(docRuns, effState);
+    // Base direction (§17.3.1.6): honor an explicit `<w:bidi>` on the block, else
+    // first-strong of the concatenated block text (the pre-change per-line probe
+    // used the same auto rule; a set flag now overrides it as Word does).
+    // Resolved BEFORE layout so a base-RTL block's tab stops mirror in layout
+    // (§17.3.1.37 / §17.18.84 — see layoutBidiTabStops).
+    const baseRtl = resolveBaseDirection(b.bidi, b.text) === 'rtl';
     const lines = layoutLines(
       ctx,
       segs,
@@ -7227,12 +7233,10 @@ export function renderShapeText(
       effState.kinsoku,
       0,
       effState.defaultTabPt,
+      ind.paraW, // marginRightPx: block text has no separate right-indent origin
+      baseRtl,
     );
     const metrics = lines.map((line) => lineMetricsFor(b, line));
-    // Base direction (§17.3.1.6): honor an explicit `<w:bidi>` on the block, else
-    // first-strong of the concatenated block text (the pre-change per-line probe
-    // used the same auto rule; a set flag now overrides it as Word does).
-    const baseRtl = resolveBaseDirection(b.bidi, b.text) === 'rtl';
     return {
       kind: 'text',
       lines,
@@ -8464,7 +8468,7 @@ function measureParaHeight(
   // to the margin rather than the indent), so it's deferred rather than
   // threaded through opportunistically. Revisit together with any other
   // measure/paint mismatch cleanup in this area.
-  const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst * scale, scale, para.tabStops, undefined, state.fontFamilyClasses, indLeftPx, state.kinsoku, gridCharDeltaPx(grid, scale), state.defaultTabPt);
+  const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst * scale, scale, para.tabStops, undefined, state.fontFamilyClasses, indLeftPx, state.kinsoku, gridCharDeltaPx(grid, scale), state.defaultTabPt, paraW, para.bidi === true);
   // Phase 4-1 B2 T2 — compute-once for TABLE-CELL paragraphs. This is the ONLY
   // point a cell paragraph's lines are laid out at scale 1: the paginator sizes
   // every table row through computeTablePtLayout → resolveTableRowHeights →

--- a/packages/docx/src/rtl-tab-stops.test.ts
+++ b/packages/docx/src/rtl-tab-stops.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest';
+import {
+  layoutBidiTabStops,
+  nextTabStopRtl,
+  type BidiTabItem,
+} from './line-layout.js';
+import { computeLineVisualOrder } from './bidi-line.js';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { DocParagraph, DocxDocumentModel, SectionProps } from './types.js';
+
+// ECMA-376 §17.3.1.6 (base RTL) + §17.3.1.37 (tabs) + §17.15.1.25 (default tab)
+// + §17.18.84 (ST_TabJc start/end logical edges) — a bidi paragraph's tab stops
+// are anchored at the LEADING (right) text edge and its cells reorder visually.
+// Issue #820: the Arabic TOC's page numbers and dot/underscore leaders (and the
+// footer's tab-aligned fields) landed on the wrong visual side (or wrapped to a
+// new line) because tabs were resolved in LTR pen coordinates. These tests pin
+// the mirrored resolution independently of any font metrics.
+
+describe('nextTabStopRtl (§17.3.1.37 / §17.15.1.25, leading = right edge)', () => {
+  const stops = [
+    { pos: 100, alignment: 'left' as const, leader: 'none' as const },
+    { pos: 300, alignment: 'right' as const, leader: 'underscore' as const },
+  ];
+  it('advances leftward to the nearest custom stop past the pen', () => {
+    // Pen 50 from the right edge → next stop further left is pos 100.
+    expect(nextTabStopRtl(50, stops, 36)?.pos).toBe(100);
+    // Pen 100 (on the first stop) → advances to 300.
+    expect(nextTabStopRtl(100, stops, 36)?.pos).toBe(300);
+  });
+  it('falls onto the §17.15.1.25 automatic grid AFTER all custom stops', () => {
+    // Past the last custom stop (300); the grid is anchored at the leading edge
+    // with interval 36, so the next multiple past 300 is 324.
+    const s = nextTabStopRtl(300, stops, 36);
+    expect(s?.pos).toBe(324);
+    expect(s?.alignment).toBe('left');
+    expect(s?.leader).toBeUndefined();
+  });
+  it('returns null when no interval and the pen is past every custom stop', () => {
+    expect(nextTabStopRtl(400, stops, 0)).toBeNull();
+  });
+});
+
+describe('computeLineVisualOrder treats a tab as a segment separator (UAX#9 S)', () => {
+  it('reorders tab-delimited cells in mirrored order under an RTL base', () => {
+    // Logical order: [chapNum][space][title] TAB [pageNum] (all rtl-marked).
+    const segs = [
+      { text: '1.1', rtl: true }, { text: ' ', rtl: true }, { text: 'TITLE', rtl: true },
+      { isTab: true },
+      { text: '4', rtl: true },
+    ];
+    const { order } = computeLineVisualOrder(segs as unknown[], true);
+    // Visual L→R must be: pageNum, TAB, title, space, chapNum — the page number
+    // ends up on the visual LEFT and the chapter number on the visual RIGHT, with
+    // the tab (leader region) between the cells. Without the S classification the
+    // whole line reversed as one run and the page number landed mid-line.
+    expect(order.map((i) => (('isTab' in segs[i]) ? 'TAB' : (segs[i] as { text: string }).text)))
+      .toEqual(['4', 'TAB', 'TITLE', ' ', '1.1']);
+  });
+});
+
+describe('layoutBidiTabStops (§17.3.1.37 mirror — reading-frame layout)', () => {
+  const avail = 400; // content width px (0 = left edge, 400 = leading/right edge)
+
+  it('places an end (right) tab so its page number trails at the mirrored stop', () => {
+    // TOC row logical order: chapNum(20) space(4) title(80) TAB pageNum(8).
+    // The tab is the style right/underscore leader stop at pos 300 from the right
+    // edge. The page number is trailing-aligned: its LEFT edge sits on the stop
+    // (visual x = avail-300 = 100).
+    const items: BidiTabItem[] = [
+      { isTab: false, width: 20 }, { isTab: false, width: 4 }, { isTab: false, width: 80 },
+      { isTab: true, width: 0 },
+      { isTab: false, width: 8 },
+    ];
+    const stops = [{ pos: 300, alignment: 'right' as const, leader: 'underscore' as const }];
+    const res = layoutBidiTabStops(items, stops, avail, 36);
+    expect(res[4].visualX).toBeCloseTo(100, 1);
+    // Chapter number (first logical, leading) sits at the RIGHT edge: its right
+    // edge = avail.
+    expect(res[0].visualX + 20).toBeCloseTo(avail, 1);
+    // The tab carries the underscore leader and fills the visible gap.
+    expect(res[3].leader).toBe('underscore');
+    expect(res[3].width).toBeGreaterThan(0);
+  });
+
+  it('pins a page number to the left margin when the stop is past it', () => {
+    // A right/leader stop at pos 420 (past avail=400) would place the page
+    // number's left edge left of the margin; it pins so its far (left) edge is on
+    // the margin (visual x 0), the page number spanning [0, 8].
+    const items: BidiTabItem[] = [
+      { isTab: false, width: 20 }, { isTab: false, width: 80 },
+      { isTab: true, width: 0 },
+      { isTab: false, width: 8 },
+    ];
+    const stops = [{ pos: 420, alignment: 'right' as const, leader: 'underscore' as const }];
+    const res = layoutBidiTabStops(items, stops, avail, 36);
+    expect(res[3].visualX).toBeCloseTo(0, 1);
+  });
+
+  it('flips physical left (leading) so its content ends at the mirrored stop', () => {
+    // Single leading (left) tab at pos 150 from the right edge → visual x
+    // avail-150 = 250. Following content (width 30) has its LEADING (right) edge
+    // there, so it spans [220, 250].
+    const items: BidiTabItem[] = [
+      { isTab: false, width: 40 }, // leading content
+      { isTab: true, width: 0 },
+      { isTab: false, width: 30 }, // follows the tab
+    ];
+    const stops = [{ pos: 150, alignment: 'left' as const, leader: 'none' as const }];
+    const res = layoutBidiTabStops(items, stops, avail, 1000 /* no auto grid */);
+    // Following content's RIGHT edge at the stop (visual x 250).
+    expect(res[2].visualX + 30).toBeCloseTo(250, 1);
+    expect(res[1].leader ?? 'none').toBe('none');
+  });
+
+  it('centers content around a mirrored center stop', () => {
+    const items: BidiTabItem[] = [
+      { isTab: false, width: 40 },
+      { isTab: true, width: 0 },
+      { isTab: false, width: 20 },
+    ];
+    const stops = [{ pos: 200, alignment: 'center' as const, leader: 'none' as const }];
+    const res = layoutBidiTabStops(items, stops, avail, 1000);
+    // Center stop mirrors to visual x avail-200 = 200; the width-20 content is
+    // centered on it → spans [190, 210], midpoint 200.
+    expect(res[2].visualX + 10).toBeCloseTo(200, 1);
+  });
+
+  it('is a no-op shape for a line with no tabs (widths unchanged)', () => {
+    const items: BidiTabItem[] = [{ isTab: false, width: 10 }, { isTab: false, width: 20 }];
+    const res = layoutBidiTabStops(items, [], avail, 36);
+    expect(res.map((r) => r.width)).toEqual([10, 20]);
+  });
+});
+
+// ── End-to-end: render a synthetic bidi TOC row + footer row through
+// renderDocumentToCanvas with a recording canvas (fixed-width glyphs), so the
+// full layout→reorder→draw path is exercised (not just the pure helper). The
+// mock glyph is `fontSize` px wide; positions are therefore exact and font-free.
+interface FillCall { text: string; x: number; }
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[]; leaderXs: number[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const fills: FillCall[] = [];
+  const leaderXs: number[] = [];
+  let dir: CanvasDirection = 'ltr';
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    get direction() { return dir; }, set direction(v: CanvasDirection) { dir = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, rect() {}, clip() {}, scale() {},
+    translate() {}, setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; }, drawImage() {},
+    fillText(text: string, x: number) {
+      if (text === '_' || text === '.' || text === '·' || text === '-') leaderXs.push(x);
+      else fills.push({ text, x });
+    },
+    strokeText() {}, fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, globalAlpha: 1,
+    lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills, leaderXs };
+}
+
+function bidiPara(runs: unknown[], tabStops: unknown[], opts: Partial<DocParagraph> = {}): DocParagraph {
+  return {
+    alignment: 'left', bidi: true,
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null,
+    tabStops, runs,
+    defaultFontSize: 10, defaultFontFamily: 'Arial', widowControl: false,
+    ...opts,
+  } as unknown as DocParagraph;
+}
+function txt(text: string, rtl = false) {
+  return {
+    type: 'text', text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 10, color: null, fontFamily: 'Arial', fontFamilyEastAsia: 'Arial',
+    isLink: false, background: null, vertAlign: null, hyperlink: null, rtl: rtl || undefined,
+  };
+}
+function docOf(paras: DocParagraph[], width = 400): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: width, pageHeight: 400, marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    settings: { defaultTabStop: 36 },
+    body: paras.map((p) => ({ type: 'paragraph', ...p })),
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { Arial: 'swiss' },
+  } as unknown as DocxDocumentModel;
+}
+
+describe('bidi TOC / footer rows render on one line, mirrored (issue #820)', () => {
+  it('draws the TOC page number at the left, chapter at the right, with a leader', async () => {
+    const { canvas, fills, leaderXs } = makeRecordingCanvas();
+    // pageWidth 400, no margins ⇒ scale 1, content [0,400]. Right/underscore
+    // stop at 380pt (near the leading/right edge distance), so the page number
+    // trails at 400-380 = 20.
+    const row = bidiPara(
+      [txt('AB', true), txt(' ', true), txt('TITLE', true), txt('\t', true), txt('9', true)],
+      [{ pos: 380, alignment: 'right', leader: 'underscore' }],
+    );
+    await renderDocumentToCanvas(docOf([row]), canvas, 0, { dpr: 1, width: 400 });
+
+    const pageNum = fills.find((f) => f.text === '9');
+    const chapter = fills.find((f) => f.text === 'AB');
+    expect(pageNum, 'page number drawn').toBeDefined();
+    expect(chapter, 'chapter number drawn').toBeDefined();
+    // Page number on the visual LEFT (near x=20), chapter number on the visual
+    // RIGHT (its 2 glyphs = 20px end at the right edge 400 ⇒ starts near 380).
+    expect(pageNum!.x).toBeCloseTo(20, 0);
+    expect(chapter!.x).toBeGreaterThan(pageNum!.x + 100);
+    // A continuous underscore leader fills the gap between them.
+    expect(leaderXs.length).toBeGreaterThan(3);
+    expect(Math.min(...leaderXs)).toBeGreaterThan(pageNum!.x);
+    expect(Math.max(...leaderXs)).toBeLessThan(chapter!.x);
+    // Everything on ONE line (no wrap): the page number and chapter share a row.
+    // A single-line paragraph draws each token exactly once.
+    expect(fills.filter((f) => f.text === '9')).toHaveLength(1);
+  });
+
+  it('right-aligns a footer field row (Page N tab of M) to the leading edge', async () => {
+    const { canvas, fills } = makeRecordingCanvas();
+    // Footer with a trailing right tab at 380: the "of" cell right-aligns near
+    // the right edge. Verify the last token ends at/near the right margin.
+    const row = bidiPara(
+      [txt('P', true), txt('\t', true), txt('N', true)],
+      [{ pos: 380, alignment: 'right', leader: 'none' }],
+    );
+    await renderDocumentToCanvas(docOf([row]), canvas, 0, { dpr: 1, width: 400 });
+    const p = fills.find((f) => f.text === 'P');
+    const n = fills.find((f) => f.text === 'N');
+    expect(p).toBeDefined();
+    expect(n).toBeDefined();
+    // "P" is the leading (logical-first) token → visual RIGHT edge; "N" trails at
+    // the mirrored stop (400-380 = 20) on the visual LEFT.
+    expect(n!.x).toBeCloseTo(20, 0);
+    expect(p!.x).toBeGreaterThan(n!.x);
+  });
+});


### PR DESCRIPTION
## Problem

In an Arabic (`<w:bidi>`) document (issue #820, sample-28), tab-aligned
content rendered on the wrong visual side:

- **TOC**: page numbers were scattered / wrapped onto their own row, and the
  dot/underscore leaders appeared and disappeared between entries.
- **Footer** (`Page N of M © MOJ …`): the tab-aligned fields were mis-placed.

Two independent bugs combined to produce this.

## Root causes & fixes

### 1. Tab stops were replaced, not merged, across the style hierarchy (parser)

`ECMA-376 §17.3.1.37` — a paragraph's direct `<w:tabs>` and its inherited
**style** tab stops MERGE by position. The parser did a wholesale replace, so a
TOC entry with a per-entry direct left tab silently lost the TOC style's
right/underscore **leader** tab (the leader + page-number column).

`merge_tab_stops` now unions the sets keyed on position: a more-specific stop
overrides an inherited one at the same position (1/20-pt epsilon), `val="clear"`
removes the inherited stop there, and new positions are added. Used by both the
body-paragraph path (`apply_para`) and the shape-text path.

### 2. Tab stops were resolved in LTR pen coordinates for bidi paragraphs (renderer)

`ECMA-376 §17.3.1.6 / §17.3.1.37 / §17.18.84` — in an RTL paragraph a tab
advances the pen in **reading order** (right-to-left) and stops are anchored at
the **leading (right)** text edge (`start`/`end` are logical edges). Tab widths
were computed in LTR pen order, with the UAX#9 reorder applied only afterwards,
so cells landed on the wrong side; a right/leader tab whose LTR advance went
negative hit a clamp and wrapped the page number to a new line.

All fixes are gated on the paragraph base direction (LTR path untouched):

- **`bidi-line.ts`**: a tab segment's placeholder is classified as UAX#9 **S**
  (Segment Separator) in `computeLineVisualOrder`, so rules L1/L2 reorder each
  tab-delimited cell independently and mirror the cell order under an RTL base.
- **`line-layout.ts`**: `layoutBidiTabStops` lays out a bidi line's cells in the
  RTL reading frame (pen at the leading/right edge moving left; stops mirror to
  `avail − pos`; physical left/right flip to logical start/end; content past the
  left margin pins to it). `nextTabStopRtl` walks the §17.15.1.25 automatic grid
  leftward. `layoutLines` gains a `baseRtl` flag: bidi tabs get provisional width
  0 (no LTR pen math, no tab-triggered wrap) and each finalized line is re-solved
  by a visual-frame post-pass in `flush`.
- **`renderer.ts`**: threads `baseRtl` (= `para.bidi`) through the paragraph,
  pagination, table-cell, and shape-text `layoutLines` call sites.

## Verification

- **sample-28** (real-font browser render vs the Word PDF): TOC page numbers now
  align at the left margin (x≈72, PDF x=72), chapter numbers at the right
  (x≈473–517, PDF 473–523), leaders continuous on every entry; the footer fields
  right-align to the leading edge. Each entry is one line (no more wrapping).
- **LTR byte-identical**: SHA-256 of the rendered canvas for sample-1..5 (8 pages
  incl. tab-heavy pages) is identical before/after. Parser tab-stop output for
  sample-1..5/24..26 is unchanged; only sample-28's TOC2 entries change.
- **RTL without tabs** (sample-7/8): renders unchanged (byte-identical).
- Tests: 266 Rust + 778 docx vitest (incl. 11 new RTL-tab tests: pure
  `layoutBidiTabStops`/`nextTabStopRtl`, the tab-as-S reorder, and end-to-end
  recording-canvas TOC + footer rows) + `cargo fmt`/`clippy -D warnings` + `tsc`
  + `ast-grep` all green.

## Cross-package note (report only)

- **pptx** has the same latent gap: `renderer.ts` resolves `a:tabLst` stops from
  the **left** edge and draws right/center tab-stop segments at LTR absolute
  positions, bypassing the bidi reorder — an RTL pptx paragraph with tab stops
  would mis-place them. No known fixture; left as a follow-up.
- **xlsx** has no paragraph tab-stop resolution (immune).

Closes #820