### PR TITLE
fix(docx): render 縦中横 (eastAsianLayout vert) as a one-cell horizontal group (§17.3.2.10)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2943,6 +2943,15 @@ fn parse_run_inner(
     let char_scale = fmt.char_scale;
     let position = fmt.position;
     let kerning = fmt.kerning;
+    // East Asian typography (ECMA-376 §17.3.2.10 eastAsianLayout), resolved
+    // through the style chain into `fmt`. `east_asian_vert` (縦中横) drives the
+    // vertical (tbRl) renderer's horizontal-in-vertical cell; `vert_compress`
+    // fits it to the line height. `combine`/`combine_brackets` are carried for a
+    // future two-lines-in-one implementation (parsed, not yet drawn).
+    let east_asian_vert = fmt.east_asian_vert;
+    let east_asian_vert_compress = fmt.east_asian_vert_compress;
+    let east_asian_combine = fmt.east_asian_combine;
+    let east_asian_combine_brackets = fmt.east_asian_combine_brackets.clone();
 
     // Set by the "noBreakHyphen" arm below when it just pushed/extended a text
     // run for a `<w:noBreakHyphen/>` — tells the VERY NEXT loop iteration's
@@ -3000,6 +3009,10 @@ fn parse_run_inner(
                         char_scale,
                         position,
                         kerning,
+                        east_asian_vert,
+                        east_asian_vert_compress,
+                        east_asian_combine,
+                        east_asian_combine_brackets: east_asian_combine_brackets.clone(),
                         note_ref: None,
                     };
                     match runs.last_mut() {
@@ -3073,6 +3086,10 @@ fn parse_run_inner(
                         char_scale,
                         position,
                         kerning,
+                        east_asian_vert,
+                        east_asian_vert_compress,
+                        east_asian_combine,
+                        east_asian_combine_brackets: east_asian_combine_brackets.clone(),
                         note_ref: None,
                     })));
                 }
@@ -3116,6 +3133,10 @@ fn parse_run_inner(
                     char_scale,
                     position,
                     kerning,
+                    east_asian_vert,
+                    east_asian_vert_compress,
+                    east_asian_combine,
+                    east_asian_combine_brackets: east_asian_combine_brackets.clone(),
                     note_ref: None,
                 })));
             }
@@ -3204,6 +3225,10 @@ fn parse_run_inner(
                     char_scale,
                     position,
                     kerning,
+                    east_asian_vert,
+                    east_asian_vert_compress,
+                    east_asian_combine,
+                    east_asian_combine_brackets: east_asian_combine_brackets.clone(),
                     note_ref: None,
                 };
                 match runs.last_mut() {
@@ -3391,6 +3416,10 @@ fn parse_run_inner(
                     char_scale,
                     position,
                     kerning,
+                    east_asian_vert,
+                    east_asian_vert_compress,
+                    east_asian_combine,
+                    east_asian_combine_brackets: east_asian_combine_brackets.clone(),
                     note_ref: Some(crate::types::NoteRef {
                         kind: kind.to_string(),
                         id: id_str,
@@ -8748,6 +8777,42 @@ mod cs_toggle_tests {
         // §17.3.2.7 <w:cs/> — the complex-script run toggle.
         let run = run_of(r#"<w:p><w:r><w:rPr><w:cs/></w:rPr><w:t>x</w:t></w:r></w:p>"#);
         assert_eq!(run.cs, Some(true));
+    }
+
+    #[test]
+    fn east_asian_layout_vert_flows_to_text_run_model() {
+        // §17.3.2.10 <w:eastAsianLayout w:vert="1" w:vertCompress="1"> — the 縦中横
+        // (horizontal-in-vertical) toggles survive from direct rPr onto the
+        // serialized TextRun model. Mirrors sample-26's date-digit run.
+        let run = run_of(
+            r#"<w:p><w:r><w:rPr>
+                 <w:w w:val="67"/>
+                 <w:eastAsianLayout w:id="121422848" w:vert="1" w:vertCompress="1"/>
+               </w:rPr><w:t>２９</w:t></w:r></w:p>"#,
+        );
+        assert_eq!(run.east_asian_vert, Some(true));
+        assert_eq!(run.east_asian_vert_compress, Some(true));
+        assert!((run.char_scale.unwrap() - 0.67).abs() < 1e-9); // w:w still parsed
+                                                                // combine/combineBrackets absent ⇒ None (parsed but not present here).
+        assert_eq!(run.east_asian_combine, None);
+        assert_eq!(run.east_asian_combine_brackets, None);
+    }
+
+    #[test]
+    fn east_asian_layout_combine_and_off_values_parse() {
+        // §17.3.2.10 combine + combineBrackets parse (two-lines-in-one; carried
+        // for a future implementation). And the ST_OnOff "off"/"0"/"false"
+        // vocabulary (§22.9.2.7) reads as Some(false), distinct from an absent
+        // attribute (None → inherit).
+        let run = run_of(
+            r#"<w:p><w:r><w:rPr>
+                 <w:eastAsianLayout w:combine="on" w:combineBrackets="curly" w:vert="off"/>
+               </w:rPr><w:t>x</w:t></w:r></w:p>"#,
+        );
+        assert_eq!(run.east_asian_combine, Some(true));
+        assert_eq!(run.east_asian_combine_brackets.as_deref(), Some("curly"));
+        assert_eq!(run.east_asian_vert, Some(false)); // explicit off ≠ inherit
+        assert_eq!(run.east_asian_vert_compress, None); // absent → inherit
     }
 
     #[test]

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -127,6 +127,32 @@ pub struct RunFmt {
     /// (Word's default is OFF, unlike Canvas's default `fontKerning='auto'`).
     /// `Some(0.0)` = kern at every size.
     pub kerning: Option<f64>,
+    /// ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:vert>` — "Horizontal in Vertical
+    /// (Rotate Text)" (縦中横 / tate-chū-yoko). When `Some(true)`, in a VERTICAL
+    /// (tbRl) document the run's characters are laid out HORIZONTALLY within a
+    /// single cell of the vertical line ("keeping the text on the same line"),
+    /// i.e. rotated 90° relative to the surrounding vertical flow. `None` =
+    /// inherit; the property is inert in a horizontal document (§17.3.2.10 is only
+    /// meaningful in vertical text).
+    pub east_asian_vert: Option<bool>,
+    /// ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:vertCompress>` — "Compress
+    /// Rotated Text to Line Height". Ignored unless `east_asian_vert` is set. When
+    /// `Some(true)`, the horizontally-laid-out (rotated) run is compressed so it
+    /// fits into the existing line height without growing the line. `None` =
+    /// inherit (default: not compressed).
+    pub east_asian_vert_compress: Option<bool>,
+    /// ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:combine>` — "Two Lines in One":
+    /// the run's characters are written on two sub-lines within one logical line.
+    /// PARSED for completeness (§17.3.2.10) but not yet rendered (no fixture);
+    /// carried so a future two-lines-in-one implementation has the flag. `None` =
+    /// inherit / off.
+    pub east_asian_combine: Option<bool>,
+    /// ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:combineBrackets>` — the bracket
+    /// style (§17.18.8 ST_CombineBrackets: `none` | `round` | `square` | `angle` |
+    /// `curly`) enclosing two-lines-in-one text. Ignored unless `combine` is set.
+    /// PARSED for completeness; the two-lines-in-one draw is a follow-up. `None` =
+    /// no brackets.
+    pub east_asian_combine_brackets: Option<String>,
 }
 
 /// Resolved paragraph formatting.
@@ -897,6 +923,21 @@ pub(crate) fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
     if src.kerning.is_some() {
         dst.kerning = src.kerning;
     }
+    // East Asian typography (§17.3.2.10 eastAsianLayout) — each attribute is a
+    // set-wins toggle/value like the run properties above: a level that names it
+    // overrides, absence inherits.
+    if src.east_asian_vert.is_some() {
+        dst.east_asian_vert = src.east_asian_vert;
+    }
+    if src.east_asian_vert_compress.is_some() {
+        dst.east_asian_vert_compress = src.east_asian_vert_compress;
+    }
+    if src.east_asian_combine.is_some() {
+        dst.east_asian_combine = src.east_asian_combine;
+    }
+    if src.east_asian_combine_brackets.is_some() {
+        dst.east_asian_combine_brackets = src.east_asian_combine_brackets.clone();
+    }
 
     // Complex-script font size resolution (ECMA-376 §17.3.2.18). Word treats a
     // directly-applied `w:sz` as also setting the complex-script size UNLESS the
@@ -1419,6 +1460,21 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
         if let Some(v) = attr_w(kern, "val") {
             fmt.kerning = Some(half_pt_to_pt(&v));
         }
+    }
+
+    // East Asian typography settings (ECMA-376 §17.3.2.10 `<w:eastAsianLayout>`).
+    // `w:vert` (horizontal-in-vertical / 縦中横) and `w:vertCompress` are ST_OnOff
+    // toggles; `w:combine` (two-lines-in-one) + `w:combineBrackets` (§17.18.8) are
+    // parsed for completeness — the two-lines-in-one draw is a follow-up (no
+    // fixture). All four are Option so an unset attribute inherits through the
+    // style chain like the other run properties. `w:id` (§17.18.10) only links
+    // multiple runs into one eastAsianLayout region and does not affect a single
+    // run's layout, so it is not modeled.
+    if let Some(eal) = child_w(rpr, "eastAsianLayout") {
+        fmt.east_asian_vert = on_off_attr(eal, "vert");
+        fmt.east_asian_vert_compress = on_off_attr(eal, "vertCompress");
+        fmt.east_asian_combine = on_off_attr(eal, "combine");
+        fmt.east_asian_combine_brackets = attr_w(eal, "combineBrackets").filter(|v| v != "none");
     }
 
     fmt

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1329,6 +1329,27 @@ pub struct TextRun {
     /// = kerning off (the hierarchy default). `Some(0.0)` = kern at all sizes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kerning: Option<f64>,
+    /// ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:vert>` — horizontal-in-vertical
+    /// (縦中横 / tate-chū-yoko). `Some(true)` means that in a VERTICAL (tbRl) page
+    /// this run's characters are laid out horizontally within one cell of the
+    /// vertical line. `None`/absent = normal vertical stacking. Inert in a
+    /// horizontal page (the property is only meaningful in vertical text).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub east_asian_vert: Option<bool>,
+    /// ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:vertCompress>` — compress the
+    /// horizontally-laid-out (縦中横) run to fit the existing line height. Ignored
+    /// unless `east_asian_vert` is set. `None`/absent = not compressed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub east_asian_vert_compress: Option<bool>,
+    /// ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:combine>` — two-lines-in-one.
+    /// PARSED for completeness; not yet rendered (no fixture). `None`/absent = off.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub east_asian_combine: Option<bool>,
+    /// ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:combineBrackets>` (§17.18.8) —
+    /// bracket style around two-lines-in-one text. PARSED for completeness; the
+    /// two-lines-in-one draw is a follow-up. `None` = no brackets / `none`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub east_asian_combine_brackets: Option<String>,
     /// ECMA-376 §17.11.6 / §17.11.7 / §17.11.16 / §17.11.17 — set when this run
     /// is a footnote/endnote reference mark (`<w:footnoteReference>` in the body,
     /// `<w:footnoteRef>` inside the note content, and the endnote equivalents).

--- a/packages/docx/parser/src/xml_util.rs
+++ b/packages/docx/parser/src/xml_util.rs
@@ -84,3 +84,14 @@ pub fn bool_prop(node: Node, tag: &str) -> Option<bool> {
         Some("0") | Some("false") | Some("off")
     ))
 }
+
+/// Parse a ST_OnOff-valued ATTRIBUTE (e.g. `<w:eastAsianLayout w:vert="1">`,
+/// §17.3.2.10) directly on `node`, using the same "true"/"false"/"1"/"0"/"on"/
+/// "off" vocabulary as {@link bool_prop} (§22.9.2.7 ST_OnOff). Unlike `bool_prop`
+/// (which reads a CHILD element's `w:val`), the value here is the attribute
+/// itself. Returns `None` when the attribute is absent so the caller can
+/// distinguish "explicitly off" from "inherited".
+pub fn on_off_attr(node: Node, name: &str) -> Option<bool> {
+    let val = attr_w(node, name)?;
+    Some(!matches!(val.as_str(), "0" | "false" | "off"))
+}

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -139,6 +139,20 @@ export interface LayoutTextSeg {
    *  font size ≥ the threshold. Absent ⇒ kerning off (`ctx.fontKerning='none'`
    *  is NOT forced globally; only a threshold-satisfied run enables it). */
   kerning?: number;
+  /** ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:vert>` — horizontal-in-vertical
+   *  (縦中横). Set by {@link buildSegments} ONLY when the run declares `w:vert`
+   *  AND the page is vertical (tbRl); the property is inert in a horizontal page,
+   *  so the gate is folded in here at build time and the measure/paint passes just
+   *  read this flag. When set, the whole segment occupies ONE cell along the
+   *  vertical column (advance = 1em, NOT the per-glyph sideways width), with its
+   *  characters drawn horizontally side by side across the column (§17.3.2.10,
+   *  PDF-verified on sample-26). Absent ⇒ normal per-glyph vertical advance. */
+  tateChuYoko?: boolean;
+  /** ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:vertCompress>` — set alongside
+   *  {@link tateChuYoko} when the run also declares `w:vertCompress`. Compresses
+   *  the horizontally-laid-out run so it fits the line height. Only meaningful
+   *  when {@link tateChuYoko} is set. */
+  tateChuYokoCompress?: boolean;
 }
 
 /**
@@ -689,6 +703,16 @@ export function segAdvanceWidth(
   gridDeltaPx: number,
   scale: number,
 ): number {
+  // ECMA-376 §17.3.2.10 縦中横 (horizontal-in-vertical): the whole run is written
+  // horizontally inside ONE cell of the vertical line ("keeping the text on the
+  // same line"), so its advance ALONG the column is exactly one em (one cell),
+  // independent of the character count and of `w:w` (which stretches the
+  // side-by-side glyphs ACROSS the column, not the along-column cell height).
+  // PDF-verified on sample-26: the "２９" run occupies exactly one 12 pt cell.
+  // (Because the vertical page lays out in a swapped logical frame, this
+  // logical-horizontal advance IS the vertical column advance after the page
+  // rotation — see vertical-text.ts and renderer's page transform.)
+  if (seg.tateChuYoko) return seg.fontSize * scale;
   const scaled = naturalWidthPx * charScaleFactor(seg) + gridSegDeltaPx(seg.text, gridDeltaPx);
   const cpCount = [...seg.text].length;
   return scaled + cpCount * charSpacingDeltaPx(seg, scale);
@@ -1640,6 +1664,16 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         charScale: r.charScale,
         position: r.position,
         kerning: r.kerning,
+        // ECMA-376 §17.3.2.10 eastAsianLayout — 縦中横 is meaningful ONLY in a
+        // vertical (tbRl) page, so fold the vertical gate in HERE at build time
+        // (buildSegments has RenderState). Measure/paint then read a single
+        // pre-gated flag. `vertCompress` rides only when `vert` is set (spec: it
+        // is ignored otherwise).
+        tateChuYoko: state.verticalCJK && r.eastAsianVert === true ? true : undefined,
+        tateChuYokoCompress:
+          state.verticalCJK && r.eastAsianVert === true && r.eastAsianVertCompress === true
+            ? true
+            : undefined,
       });
       firstSeg = false;
       gluePending = false; // glue applies only to a piece's FIRST segment

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -143,6 +143,7 @@ import {
 } from './emphasis-mark.js';
 import {
   drawVerticalRun,
+  drawTateChuYokoRun,
   drawUprightBox,
   physicalToLogicalAnchorBox,
   verticalTextLayerPlacement,
@@ -5948,7 +5949,24 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
         //      `justifiedPiecePositions` slice-at-gaps path.
         //   3. Neither: a single fillText (the common path).
         const segGridDelta = gridSegDeltaPx(s.text, drawGridDeltaPx);
-        if (state.verticalCJK) {
+        if (state.verticalCJK && s.tateChuYoko) {
+          // ECMA-376 §17.3.2.10 縦中横 (horizontal-in-vertical): draw the whole run
+          // horizontally, side by side, inside ONE cell of the vertical column.
+          // The cell's along-column advance is `spanW` (= s.measuredWidth, which
+          // segAdvanceWidth pinned to one em for a 縦中横 seg — measure==paint).
+          // `w:w` (segCharScale) compresses the digits' cross-column width;
+          // vertCompress fits their height to the cell. See vertical-text.ts.
+          drawTateChuYokoRun(
+            ctx,
+            s.text,
+            x,
+            baseline + yOffset,
+            effSizePx,
+            spanW,
+            segCharScale,
+            !!s.tateChuYokoCompress,
+          );
+        } else if (state.verticalCJK) {
           // ECMA-376 §17.6.20 (tbRl) — the run flows DOWN the column (logical
           // +x). Draw each glyph advancing by its measured horizontal width plus
           // the per-cell grid delta, counter-rotating upright (CJK) glyphs so

--- a/packages/docx/src/run-char-metrics.test.ts
+++ b/packages/docx/src/run-char-metrics.test.ts
@@ -74,4 +74,25 @@ describe('WD4 run character-metric width helpers', () => {
     // natural 20 + 1 cp × (1 pt × scale 1) = 21.
     expect(segAdvanceWidth(s, 20, 0, 1)).toBe(21);
   });
+
+  it('segAdvanceWidth pins a 縦中横 run to ONE em along the column (§17.3.2.10)', () => {
+    // A tateChuYoko seg occupies exactly one cell (fontSize × scale) regardless
+    // of char count, w:w, or w:spacing — the horizontal side-by-side layout is a
+    // paint concern (drawTateChuYokoRun), not the along-column advance. This is
+    // the measure side of the sample-26 regression fix: the "２９" cell advances
+    // one em, not natural × 0.67, so the following "日" no longer overlaps.
+    const s = seg({ text: '２９', fontSize: 12, tateChuYoko: true, charScale: 0.67, charSpacing: 5 });
+    // Natural width, w:w, and w:spacing are all IGNORED for the advance.
+    expect(segAdvanceWidth(s, 999, 3, 1)).toBe(12); // 12 pt × scale 1 = one em
+    // Scale 2 → one em is 24 px.
+    expect(segAdvanceWidth(s, 999, 3, 2)).toBe(24);
+  });
+
+  it('segAdvanceWidth ignores tateChuYoko when the flag is unset (normal advance)', () => {
+    // Same run WITHOUT the (vertical-gated) flag falls back to the w:w advance —
+    // so a horizontal page (where buildSegments never sets tateChuYoko) is
+    // byte-identical.
+    const s = seg({ text: '２９', fontSize: 12, charScale: 0.67 });
+    expect(segAdvanceWidth(s, 100, 0, 1)).toBeCloseTo(67, 10);
+  });
 });

--- a/packages/docx/src/tate-chu-yoko-render.test.ts
+++ b/packages/docx/src/tate-chu-yoko-render.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas, type DocxTextRunInfo } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// ECMA-376 §17.3.2.10 eastAsianLayout w:vert (horizontal-in-vertical / 縦中横).
+//
+// Regression: sample-26 ("９月２９日") renders the date-digit run "２９" with
+// `<w:w w:val="67"/>` + `<w:eastAsianLayout w:vert="1" w:vertCompress="1"/>`.
+// PR #813 (w:w) folded the 67% scale into the MEASURED advance, so the "２９"
+// cell shrank to 67% along the vertical column — but the two full-width digits
+// were painted full-width upright, overrunning the compressed cell and
+// OVERLAPPING the following "日" (the reported "9 と 日 が重なる").
+//
+// Word draws "２９" as 縦中横: one cell of the vertical line with the two digits
+// laid out horizontally side by side (sample-26.pdf: exactly one 12 pt cell).
+// The fix makes a 縦中横 seg advance ONE em along the column and draws its whole
+// text as a single upright fillText, so the following "日" abuts the next cell
+// with no overlap.
+//
+// Because a vertical page is laid out in a SWAPPED LOGICAL frame (horizontal
+// layout, then a +90° page rotation), `onTextRun` reports each cell with `y`
+// as the ALONG-column position (cells stack DOWN the column via increasing y)
+// and `h` as the along-column advance; `x`/`w` are the cross-column offset and
+// width. The regression is about the along-column advance, so we assert on y/h.
+
+const FONT_PX = 20; // px advance per full-width CJK char in the stub (scale 1)
+
+/** Recording 2D context. `measureText` gives every code point FONT_PX width (so
+ *  "２９" measures 2·FONT_PX naturally); `fillText` records text + x + y. The
+ *  canvas is deliberately metric-free of contextual shaping — the 縦中横 draw is a
+ *  single fillText whose position we assert, and the along-column advance is
+ *  pinned to one em by the layout regardless of natural width. */
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fillTextCalls: { text: string; x: number; y: number }[];
+} {
+  let font = `${FONT_PX}px serif`;
+  let textAlign = 'start';
+  let textBaseline = 'alphabetic';
+  let letterSpacing = '0px';
+  const fillTextCalls: { text: string; x: number; y: number }[] = [];
+  const ctx = {
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    get textAlign() {
+      return textAlign;
+    },
+    set textAlign(v: string) {
+      textAlign = v;
+    },
+    get textBaseline() {
+      return textBaseline;
+    },
+    set textBaseline(v: string) {
+      textBaseline = v;
+    },
+    get letterSpacing() {
+      return letterSpacing;
+    },
+    set letterSpacing(v: string) {
+      letterSpacing = v;
+    },
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    globalAlpha: 1,
+    save() {},
+    restore() {},
+    translate() {},
+    rotate() {},
+    scale() {},
+    beginPath() {},
+    closePath() {},
+    moveTo() {},
+    lineTo() {},
+    rect() {},
+    fill() {},
+    stroke() {},
+    clip() {},
+    fillRect() {},
+    strokeRect() {},
+    clearRect() {},
+    setTransform() {},
+    resetTransform() {},
+    measureText(s: string) {
+      // Parse the current font px so effSize-scaled runs still measure per-cp.
+      const m = /(\d+(?:\.\d+)?)px/.exec(font);
+      const px = m ? parseFloat(m[1]) : FONT_PX;
+      const per = px; // 1 em per code point (full-width CJK)
+      return {
+        width: [...s].length * per,
+        actualBoundingBoxAscent: px * 0.8,
+        actualBoundingBoxDescent: px * 0.2,
+        fontBoundingBoxAscent: px * 0.8,
+        fontBoundingBoxDescent: px * 0.2,
+      } as TextMetrics;
+    },
+    fillText(text: string, x: number, y: number) {
+      fillTextCalls.push({ text, x, y });
+    },
+    strokeText() {},
+  };
+  const canvas = {
+    width: 0,
+    height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fillTextCalls };
+}
+
+function textRun(text: string, extra: Partial<DocxTextRun> = {}): DocxTextRun {
+  return {
+    text,
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    fontSize: FONT_PX,
+    color: null,
+    // A face that is NOT in the metrics table so line height is the fallback —
+    // keeps the stub deterministic (mirrors the sibling render tests).
+    fontFamily: 'NotInMetrics',
+    isLink: false,
+    background: null,
+    vertAlign: null,
+    hyperlink: null,
+    ...extra,
+  };
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+function para(runs: DocxTextRun[]): BodyElement {
+  const p: DocParagraph = {
+    alignment: 'left',
+    indentLeft: 0,
+    indentRight: 0,
+    indentFirst: 0,
+    spaceBefore: 0,
+    spaceAfter: 0,
+    lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    runs: runs.map((r) => ({ type: 'text', ...r }) as DocRun),
+    defaultFontSize: FONT_PX,
+    defaultFontFamily: 'NotInMetrics',
+    widowControl: false,
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+/** A vertical (tbRl) section. `pageHeight`/`pageWidth` are swapped internally by
+ *  the renderer; the along-column advance is the logical x reported by
+ *  onTextRun. */
+function verticalSection(overrides: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 400,
+    pageHeight: 600,
+    marginTop: 0,
+    marginRight: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    headerDistance: 0,
+    footerDistance: 0,
+    titlePage: false,
+    evenAndOddHeaders: false,
+    textDirection: 'tbRl',
+    ...overrides,
+  } as SectionProps;
+}
+
+function horizontalSection(overrides: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 600,
+    pageHeight: 400,
+    marginTop: 0,
+    marginRight: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    headerDistance: 0,
+    footerDistance: 0,
+    titlePage: false,
+    evenAndOddHeaders: false,
+    ...overrides,
+  } as SectionProps;
+}
+
+function doc(body: BodyElement[], sec: SectionProps): DocxDocumentModel {
+  return {
+    section: sec,
+    body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(
+  body: BodyElement[],
+  sec: SectionProps,
+): Promise<{
+  runs: DocxTextRunInfo[];
+  fillTextCalls: { text: string; x: number; y: number }[];
+}> {
+  const { canvas, fillTextCalls } = makeRecordingCanvas();
+  const runs: DocxTextRunInfo[] = [];
+  await renderDocumentToCanvas(doc(body, sec), canvas, 0, {
+    dpr: 1,
+    width: sec.pageWidth,
+    onTextRun: (r) => runs.push(r),
+  });
+  return { runs, fillTextCalls };
+}
+
+// The sample-26 date runs: ９ / 月 / ２９(vert+w:w=67) / 日. Full-width digits so
+// buildSegments keeps "２９" as ONE east-Asian segment.
+const NINE = '９';
+const GETSU = '月';
+const TCY = '２９';
+const NICHI = '日';
+
+describe('§17.3.2.10 縦中横 (horizontal-in-vertical) — sample-26 "9月29日" regression', () => {
+  it('advances the 縦中横 "２９" run exactly ONE cell along the vertical column', async () => {
+    const { runs } = await render(
+      [
+        para([
+          textRun(NINE),
+          textRun(GETSU),
+          textRun(TCY, {
+            charScale: 0.67,
+            eastAsianVert: true,
+            eastAsianVertCompress: true,
+          }),
+          textRun(NICHI),
+        ]),
+      ],
+      verticalSection(),
+    );
+
+    const nine = runs.find((r) => r.text === NINE);
+    const tcy = runs.find((r) => r.text === TCY);
+    expect(nine, '"９" reported').toBeDefined();
+    expect(tcy, '"２９" reported').toBeDefined();
+
+    // The 縦中横 cell's ALONG-column advance (`h` in vertical reporting) is ONE
+    // em — NOT 2·FONT_PX (full width) and NOT 2·FONT_PX·0.67 (the #813
+    // regression). One cell = FONT_PX at scale 1.
+    expect(tcy!.h).toBeCloseTo(FONT_PX, 6);
+    // A normal single CJK cell ("９") is also one em — so "２９" occupies the same
+    // along-column extent as a single character, exactly as sample-26.pdf shows.
+    expect(tcy!.h).toBeCloseTo(nine!.h, 6);
+  });
+
+  it('draws "２９" as ONE upright fillText and the following "日" does not overlap', async () => {
+    const { runs, fillTextCalls } = await render(
+      [
+        para([
+          textRun(NINE),
+          textRun(GETSU),
+          textRun(TCY, { charScale: 0.67, eastAsianVert: true, eastAsianVertCompress: true }),
+          textRun(NICHI),
+        ]),
+      ],
+      verticalSection(),
+    );
+
+    // The whole run is painted by exactly ONE fillText carrying "２９" (縦中横),
+    // not two isolated upright digit draws.
+    const tcyCalls = fillTextCalls.filter((c) => c.text === TCY);
+    expect(tcyCalls.length, 'one fillText for the 縦中横 run').toBe(1);
+
+    const getsu = runs.find((r) => r.text === GETSU)!;
+    const tcy = runs.find((r) => r.text === TCY)!;
+    const nichi = runs.find((r) => r.text === NICHI)!;
+
+    // Cells abut DOWN the column (along-column axis = `y`): each starts where the
+    // previous ended (start + advance `h`). No overlap between "月" → "２９" →
+    // "日" (the regression symptom: "２９" overran its cell and "日" was pulled
+    // back over it).
+    expect(tcy.y).toBeCloseTo(getsu.y + getsu.h, 6);
+    expect(nichi.y).toBeCloseTo(tcy.y + tcy.h, 6);
+    // "日" starts exactly ONE cell after "２９", which is one cell after "月":
+    // "月" → "日" spans two 1-em cells ("２９" occupies exactly one of them).
+    expect(nichi.y - getsu.y).toBeCloseTo(2 * FONT_PX, 6);
+  });
+
+  it('leaves a horizontal page byte-identical (縦中横 flag inert without tbRl)', async () => {
+    // The SAME runs on a HORIZONTAL page: eastAsianVert is meaningful only in
+    // vertical text (§17.3.2.10), so buildSegments never sets the flag and the
+    // "２９" run keeps its w:w=67 advance (2·FONT_PX·0.67), not one em.
+    const { runs } = await render(
+      [
+        para([
+          textRun(NINE),
+          textRun(GETSU),
+          textRun(TCY, { charScale: 0.67, eastAsianVert: true, eastAsianVertCompress: true }),
+          textRun(NICHI),
+        ]),
+      ],
+      horizontalSection(),
+    );
+    const tcy = runs.find((r) => r.text === TCY)!;
+    // Horizontal: advance = natural (2·FONT_PX) × 0.67 = 26.8 — the w:w path,
+    // unchanged by the 縦中横 code (which is gated on the vertical flag).
+    expect(tcy.w).toBeCloseTo(2 * FONT_PX * 0.67, 6);
+  });
+});

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1114,6 +1114,23 @@ export interface DocxTextRun {
    *  to the threshold; absent ⇒ kerning off (the hierarchy default). `0` = kern
    *  at all sizes. */
   kerning?: number;
+  /** ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:vert>` — horizontal-in-vertical
+   *  (縦中横 / tate-chū-yoko). `true` means that in a VERTICAL (tbRl) page this
+   *  run's characters are laid out horizontally side by side within ONE cell of
+   *  the vertical line (rotated 90° relative to the vertical flow). Absent ⇒
+   *  normal vertical stacking. Inert in a horizontal page. */
+  eastAsianVert?: boolean;
+  /** ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:vertCompress>` — compress the
+   *  縦中横 run to fit the existing line height without growing the line. Ignored
+   *  unless {@link eastAsianVert} is set. Absent ⇒ not compressed. */
+  eastAsianVertCompress?: boolean;
+  /** ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:combine>` — two-lines-in-one.
+   *  PARSED for completeness; not yet rendered (no fixture). */
+  eastAsianCombine?: boolean;
+  /** ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:combineBrackets>` (§17.18.8) —
+   *  bracket style around two-lines-in-one text. PARSED for completeness; the
+   *  two-lines-in-one draw is a follow-up. */
+  eastAsianCombineBrackets?: string;
   /** ECMA-376 §17.11.6/.7/.16/.17 — set when this run is a footnote/endnote
    *  reference marker (`<w:footnoteReference>` in the body, `<w:footnoteRef>` at
    *  the start of the note's content, and the endnote equivalents). `text` holds

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -5,6 +5,7 @@ import {
   verticalGlyphOffset,
   splitVerticalOrientationRuns,
   drawVerticalRun,
+  drawTateChuYokoRun,
   drawUprightBox,
   physicalToLogicalAnchorBox,
   verticalTextLayerPlacement,
@@ -113,6 +114,7 @@ type Op =
   | { op: 'restore' }
   | { op: 'translate'; x: number; y: number }
   | { op: 'rotate'; a: number }
+  | { op: 'scale'; sx: number; sy: number }
   | { op: 'fillText'; text: string; x: number; y: number; align: string; baseline: string }
   | { op: 'draw'; dx: number; dy: number; dw: number; dh: number };
 
@@ -146,6 +148,9 @@ function mockCtx(metrics: MockMetrics = {}): { ctx: any; ops: Op[] } {
     },
     rotate(a: number) {
       ops.push({ op: 'rotate', a });
+    },
+    scale(sx: number, sy: number) {
+      ops.push({ op: 'scale', sx, sy });
     },
     measureText(s: string) {
       // Every code point is 10px wide.
@@ -312,6 +317,72 @@ describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin side
     expect(rotates).toHaveLength(2);
     expect(fills.every((f) => f.align === 'center' && f.baseline === 'middle')).toBe(true);
     expect(fills.every((f) => f.x === 0 && f.y === 0)).toBe(true);
+  });
+});
+
+describe('drawTateChuYokoRun (§17.3.2.10 — horizontal-in-vertical / 縦中横)', () => {
+  it('draws the whole run as ONE upright, centred fillText in the cell centre', () => {
+    // Two full-width digits "２９" in a 12px cell (cellAdvance=12), no scale.
+    const { ctx, ops } = mockCtx();
+    drawTateChuYokoRun(ctx, '２９', 100, 200, 12, 12, 1, false);
+    // Exactly one fillText — the whole run, not per glyph.
+    const fills = ops.filter((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fills).toHaveLength(1);
+    expect(fills[0].text).toBe('２９');
+    // Centred (center/middle) at local origin.
+    expect(fills[0]).toMatchObject({ align: 'center', baseline: 'middle', x: 0, y: 0 });
+    // Counter-rotated −90° (upright, cancels the +90° page rotation).
+    const rotates = ops.filter((o): o is Extract<Op, { op: 'rotate' }> => o.op === 'rotate');
+    expect(rotates).toHaveLength(1);
+    expect(rotates[0].a).toBeCloseTo(-Math.PI / 2, 12);
+    // Pivot = cell centre along the column: x = 100 + cellAdvance/2 = 106, y=200.
+    const translate = ops.find((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
+    expect(translate).toEqual({ op: 'translate', x: 106, y: 200 });
+  });
+
+  it('applies w:w only to the cross-column (glyph width) axis — scale(charScale, 1)', () => {
+    // §17.3.2.43 w:w=67 compresses the digits side-by-side ACROSS the column
+    // (local x), NOT the along-column cell height (local y stays 1).
+    const { ctx, ops } = mockCtx();
+    drawTateChuYokoRun(ctx, '２９', 0, 0, 12, 12, 0.67, false);
+    const scale = ops.find((o): o is Extract<Op, { op: 'scale' }> => o.op === 'scale');
+    expect(scale).toEqual({ op: 'scale', sx: 0.67, sy: 1 });
+  });
+
+  it('leaves the along-column axis at 1 when vertCompress content already fits one em', () => {
+    // vertCompress on a single-line run whose natural height (asc+desc) equals the
+    // em: no compression needed, so scale y stays 1 (the common 2-digit case).
+    const { ctx, ops } = mockCtx({ fontBoundingBoxAscent: 9, fontBoundingBoxDescent: 3 }); // 12 = 1em
+    drawTateChuYokoRun(ctx, '２９', 0, 0, 12, 12, 1, true);
+    const scale = ops.find((o): o is Extract<Op, { op: 'scale' }> => o.op === 'scale');
+    expect(scale).toEqual({ op: 'scale', sx: 1, sy: 1 });
+  });
+
+  it('compresses the along-column axis when vertCompress content is taller than one em', () => {
+    // A run whose natural upright height exceeds one em is squeezed to fit one
+    // cell (§17.3.2.10): scale y = fontPx / height. Here height = 18 > 12 → 12/18.
+    const { ctx, ops } = mockCtx({ fontBoundingBoxAscent: 14, fontBoundingBoxDescent: 4 }); // 18px
+    drawTateChuYokoRun(ctx, '２９', 0, 0, 12, 12, 1, true);
+    const scale = ops.find((o): o is Extract<Op, { op: 'scale' }> => o.op === 'scale');
+    expect(scale?.sx).toBe(1);
+    expect(scale?.sy).toBeCloseTo(12 / 18, 12);
+  });
+
+  it('does not compress the height when vertCompress is off, even if content is tall', () => {
+    const { ctx, ops } = mockCtx({ fontBoundingBoxAscent: 14, fontBoundingBoxDescent: 4 });
+    drawTateChuYokoRun(ctx, '２９', 0, 0, 12, 12, 1, false);
+    const scale = ops.find((o): o is Extract<Op, { op: 'scale' }> => o.op === 'scale');
+    expect(scale).toEqual({ op: 'scale', sx: 1, sy: 1 });
+  });
+
+  it('combines w:w (width) and vertCompress (height) independently', () => {
+    // 3-digit-style case: w:w=0.5 across the column AND a tall run compressed to
+    // one em along the column — the two axes are set independently.
+    const { ctx, ops } = mockCtx({ fontBoundingBoxAscent: 18, fontBoundingBoxDescent: 6 }); // 24px
+    drawTateChuYokoRun(ctx, '２９９', 0, 0, 12, 12, 0.5, true);
+    const scale = ops.find((o): o is Extract<Op, { op: 'scale' }> => o.op === 'scale');
+    expect(scale?.sx).toBe(0.5);
+    expect(scale?.sy).toBeCloseTo(12 / 24, 12);
   });
 });
 

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -366,6 +366,96 @@ export function drawVerticalRun(
 }
 
 /**
+ * Draw one 縦中横 (tate-chū-yoko / horizontal-in-vertical) run — ECMA-376
+ * §17.3.2.10 `<w:eastAsianLayout w:vert="1">`. In a vertical (tbRl) page the run
+ * "keeps the text on the same line as all other text" while its characters are
+ * rendered HORIZONTALLY: the whole run string is drawn UPRIGHT (counter-rotated
+ * −90° to cancel the +90° page rotation, exactly like the upright CJK cells) so
+ * the glyphs read left-to-right ACROSS the column, packed into ONE cell of the
+ * vertical line.
+ *
+ * Geometry (all in the rotated logical page frame; `x` advances DOWN the column
+ * = logical +x, `baseline` is the column centre-line = logical +y):
+ *   - The cell spans `[x, x + cellAdvance]` along the column; the run centres on
+ *     the cell centre `x + cellAdvance/2`. `cellAdvance` is one em (one cell) —
+ *     the same value the layout measured (`segAdvanceWidth`), so measure==paint.
+ *   - After the −90° counter-rotation the run is upright; local +x is the
+ *     cross-column (the glyphs' own left→right width) and local +y is the
+ *     along-column (the text's height). Drawn `center`/`middle`, so the run's
+ *     em box centres on the cell centre AND on the column centre-line.
+ *   - `charScale` (§17.3.2.43 `w:w`) compresses the glyphs' WIDTH via
+ *     `ctx.scale(charScale, 1)` in the upright local frame — i.e. across the
+ *     column — matching Word (PDF-verified on sample-26: "２９" at w:w=67 spans
+ *     ≈15.6 pt wide inside a 12 pt cell). It does NOT change the along-column
+ *     cell height.
+ *   - `vertCompress` (§17.3.2.10) compresses the run's HEIGHT to one cell so the
+ *     rotated text never grows the line: if the run's natural upright height
+ *     (`fontBoundingBox*`) exceeds one em, scale the along-column axis down to
+ *     fit. For a single-line run (height ≈ 1 em) this is a no-op, so the common
+ *     2-digit date case is unaffected; it only bites a run whose glyphs are
+ *     taller than the em box.
+ *
+ * The whole run is one contextually-shaped `fillText`, so kerning/shaping across
+ * the digits is preserved and the text model / selection keep the original
+ * characters.
+ *
+ * @param ctx          2D context, already in the rotated logical page frame.
+ *                     `ctx.font`/`ctx.fillStyle` are set by the caller.
+ * @param text         The run's text (e.g. "２９").
+ * @param x            Logical left edge of the cell along the column (px).
+ * @param baseline     Logical column centre-line y (px).
+ * @param fontPx       Effective font size in px (one em = one cell).
+ * @param cellAdvance  The cell's along-column advance in px (one em; the value
+ *                     the layout measured for this segment).
+ * @param charScale    §17.3.2.43 `w:w` fraction (1 = 100%); compresses the
+ *                     glyphs' cross-column width.
+ * @param compress     §17.3.2.10 `w:vertCompress`; fit the run's height to one em.
+ */
+export function drawTateChuYokoRun(
+  ctx: Ctx2D,
+  text: string,
+  x: number,
+  baseline: number,
+  fontPx: number,
+  cellAdvance: number,
+  charScale: number,
+  compress: boolean,
+): void {
+  const prevAlign = ctx.textAlign;
+  const prevBaseline = ctx.textBaseline;
+  // Along-column compression factor (§17.3.2.10 vertCompress). The run is drawn
+  // upright, so its along-column extent is the font's design HEIGHT
+  // (fontBoundingBoxAscent + descent). When that exceeds one em and vertCompress
+  // is set, scale the along-column (local y) axis so the height fits one cell.
+  // Measured with a `middle` baseline (the box used below). For ordinary
+  // single-line text the height is ≈1 em, so `compY` stays 1 (no-op).
+  let compY = 1;
+  if (compress) {
+    const m = ctx.measureText(text);
+    const asc = m.fontBoundingBoxAscent;
+    const desc = m.fontBoundingBoxDescent;
+    if (typeof asc === 'number' && typeof desc === 'number') {
+      const heightPx = asc + desc;
+      if (heightPx > fontPx && heightPx > 0) compY = fontPx / heightPx;
+    }
+  }
+  const cx = x + cellAdvance / 2;
+  ctx.save();
+  ctx.translate(cx, baseline);
+  ctx.rotate(-Math.PI / 2);
+  // Upright local frame: local +x = cross-column (glyph width), local +y =
+  // along-column (glyph height). `w:w` compresses width (local x); vertCompress
+  // fits height (local y). center/middle centres the run's em box on the cell.
+  ctx.scale(charScale, compY);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, 0, 0);
+  ctx.restore();
+  ctx.textAlign = prevAlign;
+  ctx.textBaseline = prevBaseline;
+}
+
+/**
  * Run `draw` with the context counter-rotated so a graphic that would otherwise
  * be painted lying on its side (rotated with the +90° page transform) appears
  * UPRIGHT. Used for inline / anchored images and shapes in a vertical (tbRl)


### PR DESCRIPTION
## Summary

Implements **ECMA-376 §17.3.2.10 `<w:eastAsianLayout w:vert>`** (縦中横 / *tate-chū-yoko*, horizontal-in-vertical) for DOCX vertical (tbRl) pages, and **fixes a regression from #813** where `sample-26`'s date "９月２９日" rendered with the "９" digit and "日" overlapping.

### Root cause of the regression

The "２９" run carries `<w:w w:val="67"/>` **and** `<w:eastAsianLayout w:id="…" w:vert="1" w:vertCompress="1"/>`. PR #813 folded `w:w=67` into the *measured* advance, shrinking the "２９" cell to 67% along the vertical column — but the two full-width digits were still painted full-width, upright, stacked vertically, so they overran the compressed cell and collided with the following "日". The real fix is that `w:eastAsianLayout w:vert` (縦中横) was never parsed: Word lays "２９" out as **one cell of the vertical line with the digits side by side horizontally** (verified against `sample-26.pdf`: exactly one 12 pt cell).

### What changed

**Parser (§17.3.2.10)** — parse `vert` / `vertCompress` (drive the renderer) and `combine` / `combineBrackets` (carried for a future two-lines-in-one implementation; no fixture yet) into the run model, resolved through the style chain like the other run properties. Adds an `on_off_attr` helper for ST_OnOff-valued *attributes* (§22.9.2.7), distinct from `bool_prop` (child-element `w:val`).

**Renderer / layout (measure == paint)**
- A 縦中横 seg advances **exactly one em (one cell)** along the column (`segAdvanceWidth` short-circuits), independent of char count and `w:w`.
- `buildSegments` folds in the vertical gate — §17.3.2.10 is meaningful **only** in vertical text — so the flag is inert on horizontal pages (they stay byte-identical).
- `drawTateChuYokoRun` draws the whole run as one upright, centred `fillText` across the column; `w:w` (§17.3.2.43) compresses the digits' **cross-column width** via `scale(charScale, 1)`; `w:vertCompress` fits their **height** to one em (no-op for single-line content).

### §17.3.2.10 composition rule (vert / vertCompress / w:w)

| axis | attribute | effect |
|---|---|---|
| along-column (cell height) | `vert` | run occupies **one cell** (one em), regardless of char count |
| cross-column (glyph width) | `w:w` | digits laid side by side, scaled — allowed to overflow the column width |
| along-column (height fit) | `vertCompress` | squeeze the rotated run's height to one line (no-op when it already fits) |

### "9月29日" spacing (along-column advance, pt)

| cell | `sample-26.pdf` (ground truth) | before (main) | after (this PR) |
|---|---|---|---|
| ９ | 12.0 | 12.3 | 12.1 |
| 月 | 12.0 | 12.3 | 12.1 |
| **２９** | **12.0 (one cell)** | **16.7 (overflows → overlaps 日)** | **12.2 (one cell)** |

The "２９" cell now advances one em, the two digits sit side by side inside it, and "日" abuts the next cell — matching Word.

### Verification

- **Real-browser render of `sample-26.docx`** (Chrome, actual CJK shaping): "２９" now a single 縦中横 cell, "９"/"日" no longer overlap — visually matches `sample-26.pdf`. Before/after screenshots captured locally.
- New unit tests: `drawTateChuYokoRun` (vert-only / vert+w:w / vert+vertCompress / tall-content compression / 3-digit combined), `segAdvanceWidth` one-em pin.
- New end-to-end render test pins the "9月29日" no-overlap invariant and the horizontal-page byte-identical inertness of the flag.
- Gates: `cargo test/fmt/clippy -D warnings` (277 pass), docx `vitest` (803 pass) + `tsc`, `ast-grep` (0 new findings), docx demo VRT byte-identical.

### Scope / follow-ups
- `combine` / `combineBrackets` (two-lines-in-one) are parsed but not yet drawn (no fixture) — flagged inline.
- Full-width digits keep the run as one segment; a 縦中横 run mixing EA and Latin content would split per-slot — not present in any fixture.
- The `sample-26` vertical VRT reference is private/gitignored and **not** updated here (would have captured the buggy render).

Refs #771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
