### PR TITLE
fix(docx): RTL tab leader drawn in the wrong visual segment (follow-up to #830)

### DIFF
--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -45,11 +45,6 @@ import {
   resolveLineFloatWindow,
   wordMinLineStartPx,
 } from './float-layout.js';
-// Pure UAX#9 per-line reorder helper. `bidi-line.ts` imports only from
-// `@silurus/ooxml-core` (never from this module), so this is a one-directional
-// value import — no runtime cycle (same rule as the renderer.ts → line-layout.ts
-// split documented above).
-import { computeLineVisualOrder } from './bidi-line.js';
 
 export interface LayoutTextSeg {
   text: string;
@@ -1348,15 +1343,12 @@ export interface BidiTabResult {
   width: number;
   /** Leader to paint across this tab's span (`'none'`/undefined ⇒ blank). */
   leader?: TabStop['leader'];
-  /** Visual x (px, from the line's LEFT text edge) of this segment's left edge —
-   *  where the draw walk should paint it. */
-  visualX: number;
 }
 
 /**
  * ECMA-376 §17.3.1.37 / §17.15.1.25 / §17.18.84 — lay out ONE line of a BIDI
- * (RTL-base) paragraph's tab-aligned cells, returning each segment's tab width
- * and its final VISUAL x.
+ * (RTL-base) paragraph's tab-aligned cells, returning each tab's width and
+ * leader BY LOGICAL INDEX.
  *
  * The LTR layout pass ({@link layoutLines}) resolves tab widths against the pen
  * in LOGICAL order but in a LEFT-to-right frame, which is wrong for a bidi
@@ -1366,29 +1358,46 @@ export interface BidiTabResult {
  * wrong visual side — often overflowing and wrapping to a new line (the "leaders
  * appear/disappear" and "page number on its own row" symptoms of issue #820).
  *
- * This lays the line out in the RTL reading frame: the pen starts at the LEADING
- * (right) text edge and moves LEFT. A tab stop's `pos` is its distance from that
- * leading edge; the Nth tab in reading order advances to the next stop further
- * left (larger `pos`), exactly like the LTR pen advances rightward through
- * stops. Alignment is logical (Part 4 §14.11.2): physical `left` = `start`
- * (leading ⇒ following content's leading/RIGHT edge on the stop), physical
- * `right` = `end` (trailing ⇒ its trailing/LEFT edge on the stop); `center` is
- * unchanged; `bar`/`clear` advance like `start`. Automatic stops fall on the
- * §17.15.1.25 grid from the leading edge, after all custom stops. A stop past
- * the left margin pins its content to the margin (Word never pushes it off the
- * page). The reading-frame positions are converted to the draw loop's visual
- * L→R x at the end.
+ * This lays the line out in the RTL READING frame: the pen starts at the right
+ * TEXT MARGIN (pen 0) and moves LEFT (increasing pen). A tab stop's `pos` is its
+ * distance from that MARGIN — not from the paragraph's indented edge (verified
+ * against Word: sample-28's TOC2 title tab at 1017 twips lands 50.85pt from the
+ * page margin even though the paragraph carries a 36pt logical-left indent).
+ * Content begins at `startPenPx` (the paragraph's leading-indent + first-line
+ * indent); the Nth tab in reading order advances to the next stop further left
+ * (larger `pos`), exactly like the LTR pen advances rightward through stops.
+ * Alignment is logical (Part 4 §14.11.2): physical `left` = `start` (leading ⇒
+ * following content's leading/RIGHT edge on the stop), physical `right` = `end`
+ * (trailing ⇒ its trailing/LEFT edge on the stop); `center` is unchanged;
+ * `bar`/`clear` advance like `start`. Automatic stops fall on the §17.15.1.25
+ * grid from the margin, after all custom stops. A stop past the LEFT text
+ * margin (`leftLimitPx`) pins its content to that margin (Word never pushes it
+ * off the page — sample-28's page numbers pin at x=72).
+ *
+ * The widths returned here reproduce Word's layout through the draw loop's
+ * VISUAL walk because {@link computeLineVisualOrder} classifies tabs as UAX#9 S:
+ * rule L2 then reverses cells AND tabs together, so the logical tab between
+ * cells k−1 and k sits visually between the mirrored cells k and k−1 — its
+ * reading-frame gap IS its visual gap. (This is why results map back by logical
+ * index; resolving stops against the visual sequence would reverse the tab→stop
+ * assignment and paint the leader in the wrong cell gap — the #830 follow-up
+ * bug where the TOC leader appeared between the title and the chapter number
+ * instead of between the page number and the title.)
  *
  * @param items line segments in LOGICAL order (as `line.segments`).
- * @param customStopsPx custom tab stops in leading-edge px (`pos * scale`).
- * @param availWidthPx the line's available content width in px.
+ * @param customStopsPx custom tab stops in margin px (`pos * scale`).
+ * @param startPenPx reading-frame pen at the line's content start = the leading
+ *   (logical-left ⇒ physical-right) indent, plus any first-line indent.
+ * @param leftLimitPx reading-frame position of the LEFT text margin (= the
+ *   margin-to-margin text width).
  * @param intervalPx automatic-stop interval = `defaultTabPt * scale`.
  * @returns one {@link BidiTabResult} per LOGICAL index (1:1 with `items`).
  */
 export function layoutBidiTabStops(
   items: BidiTabItem[],
   customStopsPx: { pos: number; alignment: TabStop['alignment']; leader?: TabStop['leader'] }[],
-  availWidthPx: number,
+  startPenPx: number,
+  leftLimitPx: number,
   intervalPx: number,
 ): BidiTabResult[] {
   const n = items.length;
@@ -1406,30 +1415,23 @@ export function layoutBidiTabStops(
     return w;
   };
 
-  // Reading-frame layout. `pen` = distance from the LEADING (right) edge; content
-  // and tabs push it further LEFT (increasing). `leftEdge[i]` / `rightEdge[i]` are
-  // each segment's edges in this frame (leftEdge = larger margin = further left).
-  const leftMargin = availWidthPx; // pen value at the physical LEFT text edge
-  let pen = 0;
-  const rightEdge = new Array(n).fill(0);
-  const leftEdge = new Array(n).fill(0);
+  // Reading-frame walk. `pen` = distance from the right TEXT MARGIN; content and
+  // tabs push it further LEFT (increasing).
+  let pen = startPenPx;
   for (let i = 0; i < n; i++) {
     const it = items[i];
     if (!it.isTab) {
-      rightEdge[i] = pen;
       pen += width[i];
-      leftEdge[i] = pen;
       continue;
     }
     const stop = nextTabStopRtl(pen, customStopsPx, intervalPx);
     if (!stop) {
       // No stop further left: the tab collapses (following content continues).
-      rightEdge[i] = pen;
-      leftEdge[i] = pen;
+      width[i] = 0;
       continue;
     }
-    // Where the tab's OWN leading (right) edge sits: at the pen. Its trailing
-    // (left) edge is the stop-aligned target, giving the gap it fills.
+    // The tab's leading (right) edge sits at the pen; its trailing (left) edge
+    // is the stop-aligned target, giving the gap it fills.
     const fw = followW(i + 1);
     let target: number; // pen value after the tab (its trailing/left edge)
     if (stop.alignment === 'right') {
@@ -1443,27 +1445,18 @@ export function layoutBidiTabStops(
       // edge on the stop.
       target = stop.pos;
     }
-    // Pin content that would fall past the left margin onto the margin: the
+    // Pin content that would fall past the left text margin onto the margin: the
     // following cell spans [target, target + fw] in reading-frame margins, so its
-    // far (left) edge must stay ≤ leftMargin (Word never pushes it off the page).
-    if (target + fw > leftMargin) target = leftMargin - fw;
+    // far (left) edge must stay ≤ leftLimitPx.
+    if (target + fw > leftLimitPx) target = leftLimitPx - fw;
     // Never let a tab move the pen backwards (right).
     if (target < pen) target = pen;
-    rightEdge[i] = pen;
     width[i] = target - pen;
-    leftEdge[i] = target;
     leader[i] = stop.leader;
     pen = target;
   }
 
-  // Convert reading-frame margins to visual (L→R from the left text edge) x:
-  // visualX = availWidthPx − leftEdge (the segment's LEFT visual edge is the
-  // FURTHEST-left reading-frame edge = its largest margin value).
-  return items.map((_, i) => ({
-    width: width[i],
-    leader: leader[i],
-    visualX: availWidthPx - leftEdge[i],
-  }));
+  return items.map((_, i) => ({ width: width[i], leader: leader[i] }));
 }
 
 /** Value equivalence of two resolved kinsoku rule sets, with a reference fast
@@ -1987,21 +1980,37 @@ export function layoutLines(
   const applyBidiTabs = (): void => {
     if (!baseRtl) return;
     if (!currentLine.some((s) => 'isTab' in s)) return;
-    const order = computeLineVisualOrder(currentLine, true).order;
-    const items: BidiTabItem[] = order.map((li) => {
-      const s = currentLine[li];
-      return { isTab: 'isTab' in s, width: s.measuredWidth };
-    });
-    const availW = lineMaxWidth - (isFirst ? firstIndent : 0);
-    const res = layoutBidiTabStops(items, bidiCustomStopsPx, availW, bidiIntervalPx);
-    // Map visual results back to the logical segments (order[vi] = logical idx).
+    // LOGICAL order — the reading-frame walk resolves the Nth tab against the
+    // Nth-reachable stop, exactly like Word's pen. Do NOT feed the VISUAL
+    // sequence here: UAX#9 L2 reverses cells AND tabs together, so a
+    // visual-order walk assigns the stops in reverse and paints the leader in
+    // the wrong cell gap (the #830 follow-up bug — the TOC underscore leader
+    // appeared between the title and the chapter number instead of between the
+    // page number and the title). Because the reversal is symmetric, each
+    // logical tab's reading-frame gap IS its visual gap, so widths mapped back
+    // by logical index tile correctly under the draw loop's visual walk.
+    const items: BidiTabItem[] = currentLine.map((s) => ({
+      isTab: 'isTab' in s,
+      width: s.measuredWidth,
+    }));
+    // Margin-anchored frame (§17.3.1.37 — stops measure from the TEXT MARGIN):
+    // pen 0 = right text margin. Content starts after the leading indent — the
+    // line window's RIGHT edge is paraX-relative `lineXOffset + lineMaxWidth`
+    // (= maxWidth when no float narrows it), so its margin distance is
+    // marginRightPx minus that — plus the first line's first-line indent
+    // (which narrows the leading edge under an RTL base, mirroring the draw
+    // loop's `effAvailW`). The left text margin sits tabOriginPx past the
+    // paragraph box (its trailing indent).
+    const startPen = marginRightPx - (lineXOffset + lineMaxWidth) + (isFirst ? firstIndent : 0);
+    const leftLimit = marginRightPx + tabOriginPx;
+    const res = layoutBidiTabStops(items, bidiCustomStopsPx, startPen, leftLimit, bidiIntervalPx);
     let delta = 0;
-    for (let vi = 0; vi < order.length; vi++) {
-      const s = currentLine[order[vi]];
+    for (let i = 0; i < currentLine.length; i++) {
+      const s = currentLine[i];
       if (!('isTab' in s)) continue;
-      delta += res[vi].width - s.measuredWidth;
-      s.measuredWidth = res[vi].width;
-      (s as LayoutTabSeg).leader = res[vi].leader;
+      delta += res[i].width - s.measuredWidth;
+      s.measuredWidth = res[i].width;
+      (s as LayoutTabSeg).leader = res[i].leader;
     }
     currentWidth += delta;
   };

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3237,16 +3237,17 @@ function estimateParagraphHeight(
   suppressSpaceBefore = false,
   paraXPt = 0,
 ): number {
-  const indLeft = para.indentLeft;
-  const indRight = para.indentRight;
+  // ECMA-376 §17.3.1.12 / Part 4 §14.11.2 — the transitional left/right indent
+  // attributes are logical start/end, so they swap physical sides in a bidi
+  // paragraph. Resolve the PHYSICAL indents once and use them for the float
+  // window (paraX), the tab origin and the text-margin right edge below, so
+  // this measure pass agrees with renderParagraph's paint pass (a bidi
+  // paragraph's tab stops anchor at the text margin — layoutBidiTabStops —
+  // and a mismatched tabOrigin/marginRight here would wrap differently).
+  const indLeft = para.bidi === true ? para.indentRight : para.indentLeft;
+  const indRight = para.bidi === true ? para.indentLeft : para.indentRight;
   const paraW = Math.max(1, contentWPt - indLeft - indRight);
-  // Float-wrap windows are evaluated at the paragraph's content left edge =
-  // contentX + physical left indent, matching renderParagraph. The left/right
-  // indents swap to physical sides in a bidi paragraph (§17.3.1.12 / Part 4
-  // §14.11.2), so use the bidi-resolved left indent; otherwise an indented / RTL
-  // paragraph wrapping a square float would measure the gap at the wrong X and
-  // diverge from the paint pass.
-  const paraX = paraXPt + (para.bidi === true ? indRight : indLeft);
+  const paraX = paraXPt + indLeft;
   const segs = buildSegments(para.runs, state);
   // Word renders ruby paragraphs with consistent line spacing — every line
   // in a paragraph that carries ANY furigana snaps to the same pitch
@@ -3478,16 +3479,17 @@ function splitParagraphAcrossPages(
     if (tagSectionPageNumType) el.sectionPageNumType = tagSectionPageNumType();
     return el;
   };
-  const indLeft = para.indentLeft;
-  const indRight = para.indentRight;
+  // Mirror renderParagraph's PHYSICAL indents (ECMA-376 §17.3.1.12; the
+  // left/right indents swap to physical sides in a bidi paragraph, Part 4
+  // §14.11.2). They feed the float-window X (paraX), the tab origin and the
+  // text-margin right edge passed to layoutLines below — a logical/physical
+  // mismatch there would anchor a bidi paragraph's tab stops differently from
+  // the paint pass (layoutBidiTabStops measures stops from the text margin)
+  // and re-introduce a paginate/render disagreement.
+  const indLeft = para.bidi === true ? para.indentRight : para.indentLeft;
+  const indRight = para.bidi === true ? para.indentLeft : para.indentRight;
   const paraW = Math.max(1, contentWPt - indLeft - indRight);
-  // Mirror renderParagraph's paragraph-content left edge: contentX + the
-  // physical left indent (ECMA-376 §17.3.1.12; the left/right indents swap to
-  // physical sides in a bidi paragraph, Part 4 §14.11.2). Using the bare margin
-  // here would evaluate square-float wrap windows at the wrong X for indented /
-  // RTL paragraphs, re-introducing a paginate/render disagreement.
-  const physLeftInd = para.bidi === true ? indRight : indLeft;
-  const paraX = marginLeftPt + physLeftInd;
+  const paraX = marginLeftPt + indLeft;
   // A paragraph with no layoutable inline lines (literally empty, or only
   // wrap-float anchors) is a single paragraph-mark line (§17.3.1.29) that cannot
   // be split. If it doesn't fit in the space left on this page, relocate it
@@ -8512,8 +8514,12 @@ function measureParaHeight(
   // slightly differently from the paint pass. No such cell exists in the covered
   // samples; revisit together with estimateParagraphHeight if list-in-cell
   // fidelity is needed.
-  const indLeftPx = para.indentLeft * scale;
-  const indRightPx = para.indentRight * scale;
+  // PHYSICAL indents (§17.3.1.12 / Part 4 §14.11.2 — logical start/end swap
+  // sides under a bidi paragraph), matching renderParagraph's paint pass so a
+  // bidi cell paragraph's tab origin / text-margin edge agree between the row
+  // measurer and the paint (LTR values are untouched).
+  const indLeftPx = (para.bidi === true ? para.indentRight : para.indentLeft) * scale;
+  const indRightPx = (para.bidi === true ? para.indentLeft : para.indentRight) * scale;
   const paraW = Math.max(1, maxWidth - indLeftPx - indRightPx);
   // RESERVATION: no `marginRightPx` argument is passed here, so a
   // `<w:ptab w:relativeTo="margin">` inside a table cell resolves its target
@@ -8532,7 +8538,11 @@ function measureParaHeight(
   // to the margin rather than the indent), so it's deferred rather than
   // threaded through opportunistically. Revisit together with any other
   // measure/paint mismatch cleanup in this area.
-  const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst * scale, scale, para.tabStops, undefined, state.fontFamilyClasses, indLeftPx, state.kinsoku, gridCharDeltaPx(grid, scale), state.defaultTabPt, paraW, para.bidi === true);
+  // marginRightPx: LTR keeps the deliberate `paraW` reservation above (ptab in a
+  // cell). A BIDI cell paragraph needs the true text-margin edge — its tab stops
+  // anchor there (layoutBidiTabStops) — so pass `paraW + indRightPx` only then;
+  // LTR cell layout is byte-identical.
+  const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst * scale, scale, para.tabStops, undefined, state.fontFamilyClasses, indLeftPx, state.kinsoku, gridCharDeltaPx(grid, scale), state.defaultTabPt, para.bidi === true ? paraW + indRightPx : paraW, para.bidi === true);
   // Phase 4-1 B2 T2 — compute-once for TABLE-CELL paragraphs. This is the ONLY
   // point a cell paragraph's lines are laid out at scale 1: the paginator sizes
   // every table row through computeTablePtLayout → resolveTableRowHeights →
@@ -8570,7 +8580,7 @@ function measureParaHeight(
     stampParagraphLines(para, lines, {
       paraW,
       firstIndent: para.indentFirst,
-      tabOriginPx: indLeftPx, // == para.indentLeft at scale 1
+      tabOriginPx: indLeftPx, // == the PHYSICAL left indent at scale 1 (bidi swaps sides)
       gridDeltaPx: gridCharDeltaPx(grid, 1),
       hasFloats: false,
       kinsoku: state.kinsoku,

--- a/packages/docx/src/rtl-tab-stops.test.ts
+++ b/packages/docx/src/rtl-tab-stops.test.ts
@@ -58,57 +58,74 @@ describe('computeLineVisualOrder treats a tab as a segment separator (UAX#9 S)',
   });
 });
 
-describe('layoutBidiTabStops (§17.3.1.37 mirror — reading-frame layout)', () => {
-  const avail = 400; // content width px (0 = left edge, 400 = leading/right edge)
+describe('layoutBidiTabStops (§17.3.1.37 mirror — margin-anchored reading frame)', () => {
+  const avail = 400; // margin-to-margin width px (no-indent case: startPen 0, leftLimit 400)
+
+  /** Reading-frame LEFT edge (px from the right text margin) of each segment
+   *  after the walk: startPen + cumulative widths through index i. */
+  const readingEdges = (
+    items: BidiTabItem[],
+    res: { width: number }[],
+    startPen: number,
+  ): number[] => {
+    let pen = startPen;
+    return items.map((_, i) => (pen += res[i].width));
+  };
 
   it('places an end (right) tab so its page number trails at the mirrored stop', () => {
     // TOC row logical order: chapNum(20) space(4) title(80) TAB pageNum(8).
-    // The tab is the style right/underscore leader stop at pos 300 from the right
-    // edge. The page number is trailing-aligned: its LEFT edge sits on the stop
-    // (visual x = avail-300 = 100).
+    // The tab is the style right/underscore leader stop at pos 300 from the
+    // right text margin. The page number is trailing-aligned: its trailing
+    // (reading-left) edge sits ON the stop.
     const items: BidiTabItem[] = [
       { isTab: false, width: 20 }, { isTab: false, width: 4 }, { isTab: false, width: 80 },
       { isTab: true, width: 0 },
       { isTab: false, width: 8 },
     ];
     const stops = [{ pos: 300, alignment: 'right' as const, leader: 'underscore' as const }];
-    const res = layoutBidiTabStops(items, stops, avail, 36);
-    expect(res[4].visualX).toBeCloseTo(100, 1);
-    // Chapter number (first logical, leading) sits at the RIGHT edge: its right
-    // edge = avail.
-    expect(res[0].visualX + 20).toBeCloseTo(avail, 1);
+    const res = layoutBidiTabStops(items, stops, 0, avail, 36);
+    const edge = readingEdges(items, res, 0);
+    // The page number's trailing (reading-left) edge is on the stop: the tab
+    // advances the pen to stop − fw (edge[3] = 292), and the page number's own
+    // width carries it onto the stop (edge[4] = 300).
+    expect(edge[3]).toBeCloseTo(292, 6);
+    expect(edge[4]).toBeCloseTo(300, 6);
+    // Chapter number (first logical, leading) starts at the RIGHT text margin.
+    expect(edge[0]).toBeCloseTo(20, 6);
     // The tab carries the underscore leader and fills the visible gap.
     expect(res[3].leader).toBe('underscore');
     expect(res[3].width).toBeGreaterThan(0);
   });
 
-  it('pins a page number to the left margin when the stop is past it', () => {
-    // A right/leader stop at pos 420 (past avail=400) would place the page
-    // number's left edge left of the margin; it pins so its far (left) edge is on
-    // the margin (visual x 0), the page number spanning [0, 8].
+  it('pins a page number to the left text margin when the stop is past it', () => {
+    // A right/leader stop at pos 420 (past the 400px left margin) would place
+    // the page number past the margin; it pins so its far (left) edge is ON the
+    // margin: reading left edge = 400.
     const items: BidiTabItem[] = [
       { isTab: false, width: 20 }, { isTab: false, width: 80 },
       { isTab: true, width: 0 },
       { isTab: false, width: 8 },
     ];
     const stops = [{ pos: 420, alignment: 'right' as const, leader: 'underscore' as const }];
-    const res = layoutBidiTabStops(items, stops, avail, 36);
-    expect(res[3].visualX).toBeCloseTo(0, 1);
+    const res = layoutBidiTabStops(items, stops, 0, avail, 36);
+    const edge = readingEdges(items, res, 0);
+    expect(edge[3]).toBeCloseTo(avail, 6); // page number's far (left) edge on the margin
   });
 
   it('flips physical left (leading) so its content ends at the mirrored stop', () => {
-    // Single leading (left) tab at pos 150 from the right edge → visual x
-    // avail-150 = 250. Following content (width 30) has its LEADING (right) edge
-    // there, so it spans [220, 250].
+    // Single leading (left) tab at pos 150 from the right margin. Following
+    // content (width 30) has its LEADING (right) edge there: reading span
+    // [150, 180] (= visual [220, 250]).
     const items: BidiTabItem[] = [
       { isTab: false, width: 40 }, // leading content
       { isTab: true, width: 0 },
       { isTab: false, width: 30 }, // follows the tab
     ];
     const stops = [{ pos: 150, alignment: 'left' as const, leader: 'none' as const }];
-    const res = layoutBidiTabStops(items, stops, avail, 1000 /* no auto grid */);
-    // Following content's RIGHT edge at the stop (visual x 250).
-    expect(res[2].visualX + 30).toBeCloseTo(250, 1);
+    const res = layoutBidiTabStops(items, stops, 0, avail, 1000 /* no auto grid */);
+    const edge = readingEdges(items, res, 0);
+    expect(edge[1]).toBeCloseTo(150, 6); // pen after the tab = the stop
+    expect(edge[2]).toBeCloseTo(180, 6); // content extends 30 further left
     expect(res[1].leader ?? 'none').toBe('none');
   });
 
@@ -119,15 +136,60 @@ describe('layoutBidiTabStops (§17.3.1.37 mirror — reading-frame layout)', () 
       { isTab: false, width: 20 },
     ];
     const stops = [{ pos: 200, alignment: 'center' as const, leader: 'none' as const }];
-    const res = layoutBidiTabStops(items, stops, avail, 1000);
-    // Center stop mirrors to visual x avail-200 = 200; the width-20 content is
-    // centered on it → spans [190, 210], midpoint 200.
-    expect(res[2].visualX + 10).toBeCloseTo(200, 1);
+    const res = layoutBidiTabStops(items, stops, 0, avail, 1000);
+    const edge = readingEdges(items, res, 0);
+    // Content spans reading [190, 210]: centered on the stop (200).
+    expect(edge[1]).toBeCloseTo(190, 6);
+    expect(edge[2]).toBeCloseTo(210, 6);
+  });
+
+  it('assigns the Nth tab the Nth-reachable stop IN READING ORDER (leader cell)', () => {
+    // sample-28 TOC2 shape: [chapNum][TAB][title][TAB][pageNum] with an early
+    // left stop and the right/underscore leader stop. The FIRST logical tab must
+    // take the early left stop and the SECOND (the one before the page number)
+    // the leader stop — resolving against the VISUAL sequence reverses the
+    // assignment and paints the leader between the title and the chapter number
+    // (the #830 follow-up bug).
+    const items: BidiTabItem[] = [
+      { isTab: false, width: 20 },  // chapter number
+      { isTab: true, width: 0 },    // → left@50
+      { isTab: false, width: 100 }, // title
+      { isTab: true, width: 0 },    // → right/underscore@380
+      { isTab: false, width: 8 },   // page number
+    ];
+    const stops = [
+      { pos: 50, alignment: 'left' as const, leader: 'none' as const },
+      { pos: 380, alignment: 'right' as const, leader: 'underscore' as const },
+    ];
+    const res = layoutBidiTabStops(items, stops, 0, avail, 1000);
+    expect(res[1].leader ?? 'none').toBe('none'); // first tab: plain left stop
+    expect(res[3].leader).toBe('underscore');     // second tab: the leader
+    const edge = readingEdges(items, res, 0);
+    expect(edge[1]).toBeCloseTo(50, 6);  // title's leading (right) edge on 50
+    expect(edge[3]).toBeCloseTo(372, 6); // page number trails at 380 − 8
+  });
+
+  it('anchors stops at the TEXT MARGIN, not the indented paragraph edge', () => {
+    // A 36px leading indent (startPen 36, sample-28 TOC2's w:ind left=720): the
+    // chapter number begins at the indent, but the tab's stop at pos 100 still
+    // measures from the MARGIN — the following title's leading edge lands at
+    // reading 100, NOT 136 (verified against the Word PDF: TOC2 titles align at
+    // margin − 50.85pt despite the 36pt indent).
+    const items: BidiTabItem[] = [
+      { isTab: false, width: 20 },
+      { isTab: true, width: 0 },
+      { isTab: false, width: 50 },
+    ];
+    const stops = [{ pos: 100, alignment: 'left' as const, leader: 'none' as const }];
+    const res = layoutBidiTabStops(items, stops, 36, avail, 1000);
+    const edge = readingEdges(items, res, 36);
+    expect(edge[0]).toBeCloseTo(56, 6);  // chapter: indent 36 + width 20
+    expect(edge[1]).toBeCloseTo(100, 6); // stop is margin-anchored
   });
 
   it('is a no-op shape for a line with no tabs (widths unchanged)', () => {
     const items: BidiTabItem[] = [{ isTab: false, width: 10 }, { isTab: false, width: 20 }];
-    const res = layoutBidiTabStops(items, [], avail, 36);
+    const res = layoutBidiTabStops(items, [], 0, avail, 36);
     expect(res.map((r) => r.width)).toEqual([10, 20]);
   });
 });
@@ -249,5 +311,58 @@ describe('bidi TOC / footer rows render on one line, mirrored (issue #820)', () 
     // the mirrored stop (400-380 = 20) on the visual LEFT.
     expect(n!.x).toBeCloseTo(20, 0);
     expect(p!.x).toBeGreaterThan(n!.x);
+  });
+
+  it('paints the leader in the tab CELL GAP between page number and title (#830 follow-up)', async () => {
+    const { canvas, fills, leaderXs } = makeRecordingCanvas();
+    // sample-28 TOC2 shape: [chapNum][TAB→left@50][title][TAB→underscore@380][pageNum].
+    // Correct visual layout (Word PDF): [pageNum][LEADER][title][blank][chapNum].
+    // The regression drew [pageNum][blank][title][LEADER][chapNum] — the leader
+    // migrated to the wrong cell gap because the tab→stop assignment was made
+    // against the visual sequence instead of reading order.
+    const row = bidiPara(
+      [txt('AB', true), txt('\t', true), txt('TITLE', true), txt('\t', true), txt('9', true)],
+      [
+        { pos: 50, alignment: 'left', leader: 'none' },
+        { pos: 380, alignment: 'right', leader: 'underscore' },
+      ],
+    );
+    await renderDocumentToCanvas(docOf([row]), canvas, 0, { dpr: 1, width: 400 });
+    const pageNum = fills.find((f) => f.text === '9');
+    const title = fills.find((f) => f.text === 'TITLE');
+    const chapter = fills.find((f) => f.text === 'AB');
+    expect(pageNum).toBeDefined();
+    expect(title).toBeDefined();
+    expect(chapter).toBeDefined();
+    // Page number trails at the mirrored leader stop: 400 − 380 = 20.
+    expect(pageNum!.x).toBeCloseTo(20, 0);
+    // Title's leading (right) edge on the mirrored left stop: 400 − 50 = 350
+    // (5 glyphs × 10px ⇒ left edge 300).
+    expect(title!.x).toBeCloseTo(300, 0);
+    // The underscore leader lies ENTIRELY between the page number and the title
+    // (the visual span of the leader tab's cell gap) — not right of the title.
+    expect(leaderXs.length).toBeGreaterThan(3);
+    expect(Math.min(...leaderXs)).toBeGreaterThan(pageNum!.x);
+    expect(Math.max(...leaderXs)).toBeLessThan(title!.x);
+  });
+
+  it('anchors a bidi tab stop at the text margin under a leading indent', async () => {
+    const { canvas, fills } = makeRecordingCanvas();
+    // Paragraph with logical-left indent 36 (physical RIGHT under bidi): the
+    // chapter starts at the indented edge (400−36−20 ⇒ x=344), but the tab's
+    // stop at pos 100 measures from the MARGIN, so the title's right edge lands
+    // at 400−100 = 300 (left edge 250) — not 300−36.
+    const row = bidiPara(
+      [txt('AB', true), txt('\t', true), txt('TITLE', true)],
+      [{ pos: 100, alignment: 'left', leader: 'none' }],
+      { indentLeft: 36 },
+    );
+    await renderDocumentToCanvas(docOf([row]), canvas, 0, { dpr: 1, width: 400 });
+    const chapter = fills.find((f) => f.text === 'AB');
+    const title = fills.find((f) => f.text === 'TITLE');
+    expect(chapter).toBeDefined();
+    expect(title).toBeDefined();
+    expect(chapter!.x).toBeCloseTo(344, 0);
+    expect(title!.x).toBeCloseTo(250, 0);
   });
 });


### PR DESCRIPTION
## Problem

After #830, sample-28's Arabic TOC still rendered its underscore **leaders in the
wrong visual segment**:

- **Word (correct)**: `[page number] [LEADER] [title] [chapter №]` (visual L→R)
- **Rendered (wrong)**: `[page number] [blank] [title] [LEADER] [chapter №]`

The leader migrated to the gap between the title and the chapter number, leaving
the gap between the page number and the title empty.

## Root causes

Two coordinate errors in the #830 bidi tab post-pass:

1. **Tab→stop assignment ran on the VISUAL sequence.** `applyBidiTabs` fed
   `layoutBidiTabStops` the line's segments in visual order, but UAX#9 L2
   reverses the tab-delimited cells **and the tabs together** (tabs are class S),
   so the walk met the tabs in reverse and handed the leader stop to the wrong
   tab — the one visually between the title and the chapter number. The walk now
   runs in **LOGICAL (reading) order**: the Nth tab takes the Nth-reachable stop,
   exactly like Word's pen. Because the L2 reversal is symmetric, each logical
   tab's reading-frame gap IS its visual gap, so the widths mapped back by
   logical index tile correctly under the draw loop's visual walk.

2. **Stops were anchored at the paragraph's indented edge, not the text margin.**
   §17.3.1.37 stops measure from the TEXT MARGIN: sample-28's TOC2 title tab
   (1017 twips) lands 50.85 pt from the page margin even though the paragraph
   carries a 36 pt logical-left indent (Word PDF: title right edge x = 472.6 =
   523.35 − 50.85). `layoutBidiTabStops` now works in a margin-anchored frame
   (`startPenPx` = leading indent + first-line indent, `leftLimitPx` = the left
   text margin) and pins overflowing content at the left text margin.

Plus a consistency fix: the paginator's two measure paths and the table-row
measurer now resolve **physical** (bidi-swapped) indents for `tabOriginPx` /
`marginRightPx`, matching the paint pass, so bidi tab lines cannot wrap
differently between measure and paint. LTR values are untouched.

## Measured results (sample-28 TOC page, real-font render vs Word PDF)

Leader ink intervals (x ranges, pt), IoU = interval overlap with the PDF:

| entry | PDF leader | before | after | IoU before | IoU after |
|---|---|---|---|---|---|
| 1 | [78,356] | [239,421] | [81,354] | 34% | **98%** |
| 1.1 | [78,291] | [302,469] | [81,291] | 0% | **98%** |
| 1.2 | [78,352] | [244,468] | [81,347] | 28% | **97%** |
| 2.6 | [78,347] | [248,465] | [81,347] | 26% | **99%** |
| 3.1 | [88,398] | [200,466] | [87,395] | 52% | **99%** |
| 4.6 | [88,389] | [205,464] | [87,388] | 49% | **99%** |

**Mean IoU across all 20 leader-bearing entries: 34% → 93%** (96–99% each; the
remaining entries "2"/"2.1" are known sub-pt font-metric borderline cases where
the title width sits within ~0.3 pt of a stop). Page numbers stay at x=72 and
chapter numbers at x=473/517 — the #830 positions are preserved. The footer
("Page N of M" / "© MOJ") is unchanged and matches the PDF ([524,575]).

## Verification

- **Byte-identical** (canvas SHA-256, before vs after): LTR samples 1–5 (8
  pages), demo/sample-1, and RTL-without-tabs samples 7/8 — all identical.
- 796 docx vitest green (15 in `rtl-tab-stops.test.ts`, incl. 3 new: reading-order
  stop assignment, margin anchoring, and an end-to-end leader-cell-gap pin).
- `tsc` 0 errors, `ast-grep` 0 errors (114 pre-existing warnings unchanged).

Refs #820 (follow-up to #830)