### PR TITLE
feat(viewers): unify the zoom API across all five viewers (IX9)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -364,6 +364,21 @@ export { computeVisibleRange, type VisibleRange, type VisibleRangePad } from './
 // Shared exponential wheel/pinch zoom step (Ctrl/⌘+wheel). Pure — the caller
 // clamps to its own [zoomMin, zoomMax]. Used by XlsxViewer + the scroll viewers.
 export { zoomStepScale } from './interaction/zoom';
+// IX9 — the shared zoom API contract for all five viewers: the ZoomableViewer
+// interface (getScale/setScale/zoomIn/zoomOut/fitWidth/fitPage) plus its pure
+// support logic (the discrete zoom-step ladder, fit-to-content scale math, clamp).
+// One definition of "what a zoom factor means / what +/- steps are" across
+// docx / pptx / xlsx so a host drives any viewer through the same calls.
+export {
+  type ZoomableViewer,
+  type FitInput,
+  type FitMode,
+  ZOOM_STEP_LADDER,
+  nextZoomStep,
+  prevZoomStep,
+  clampScale,
+  fitScale,
+} from './interaction/zoomable';
 // Shared hyperlink model + URL scheme-allowlist sanitiser (IX1). One
 // HyperlinkTarget shape + one sanitizeHyperlinkUrl predicate for docx / pptx /
 // xlsx so the external-URL safety policy is defined once, not per format.

--- a/packages/core/src/interaction/zoomable.test.ts
+++ b/packages/core/src/interaction/zoomable.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ZOOM_STEP_LADDER,
+  nextZoomStep,
+  prevZoomStep,
+  clampScale,
+  fitScale,
+} from './zoomable.js';
+
+/**
+ * IX9 — the shared zoom contract's PURE helpers. The interface itself
+ * ({@link import('./zoomable.js').ZoomableViewer}) is a type and is verified by the
+ * per-viewer tests; here we lock the ladder stepping, the fit math, and the clamp
+ * that every viewer's `zoomIn`/`zoomOut`/`fitWidth`/`fitPage` build on.
+ */
+describe('ZOOM_STEP_LADDER', () => {
+  it('is strictly ascending', () => {
+    for (let i = 1; i < ZOOM_STEP_LADDER.length; i++) {
+      expect(ZOOM_STEP_LADDER[i]).toBeGreaterThan(ZOOM_STEP_LADDER[i - 1]);
+    }
+  });
+
+  it('includes 100% and spans 25%–400% (the Excel/Acrobat family)', () => {
+    expect(ZOOM_STEP_LADDER).toContain(1);
+    expect(ZOOM_STEP_LADDER[0]).toBe(0.25);
+    expect(ZOOM_STEP_LADDER[ZOOM_STEP_LADDER.length - 1]).toBe(4);
+  });
+
+  it('is frozen (a caller cannot mutate the shared ladder)', () => {
+    expect(Object.isFrozen(ZOOM_STEP_LADDER)).toBe(true);
+  });
+});
+
+describe('nextZoomStep (+ step)', () => {
+  it('jumps to the next rung above an on-rung value', () => {
+    expect(nextZoomStep(1)).toBe(1.1);
+    expect(nextZoomStep(0.25)).toBe(0.33);
+    expect(nextZoomStep(2)).toBe(2.5);
+  });
+
+  it('snaps an off-ladder value UP to the next rung', () => {
+    // 1.03 (a wheel-zoomed value) → the first rung strictly greater, 1.1.
+    expect(nextZoomStep(1.03)).toBe(1.1);
+    expect(nextZoomStep(0.8)).toBe(0.9);
+  });
+
+  it('caps at the top rung', () => {
+    expect(nextZoomStep(4)).toBe(4);
+    expect(nextZoomStep(10)).toBe(4);
+  });
+
+  it('does not re-select a rung it is essentially already on (float slop)', () => {
+    expect(nextZoomStep(1 + 1e-9)).toBe(1.1);
+  });
+});
+
+describe('prevZoomStep (− step)', () => {
+  it('jumps to the next rung below an on-rung value', () => {
+    expect(prevZoomStep(1)).toBe(0.9);
+    expect(prevZoomStep(4)).toBe(3);
+    expect(prevZoomStep(0.33)).toBe(0.25);
+  });
+
+  it('snaps an off-ladder value DOWN to the next rung', () => {
+    expect(prevZoomStep(1.03)).toBe(1);
+    expect(prevZoomStep(0.7)).toBe(0.67);
+  });
+
+  it('floors at the bottom rung', () => {
+    expect(prevZoomStep(0.25)).toBe(0.25);
+    expect(prevZoomStep(0.05)).toBe(0.25);
+  });
+
+  it('round-trips +/- symmetrically on-ladder', () => {
+    expect(prevZoomStep(nextZoomStep(1))).toBe(1);
+    expect(nextZoomStep(prevZoomStep(2))).toBe(2);
+  });
+});
+
+describe('clampScale', () => {
+  it('passes a value inside the range through', () => {
+    expect(clampScale(1.5, 0.1, 4)).toBe(1.5);
+  });
+  it('clamps to the floor and ceiling', () => {
+    expect(clampScale(0.01, 0.1, 4)).toBe(0.1);
+    expect(clampScale(9, 0.1, 4)).toBe(4);
+  });
+  it('degenerate bounds resolve to the floor', () => {
+    expect(clampScale(1, 4, 0.1)).toBe(4);
+  });
+});
+
+describe('fitScale', () => {
+  const input = { contentWidth: 800, contentHeight: 600, containerWidth: 400, containerHeight: 600 };
+
+  it("'width' fits the width only", () => {
+    expect(fitScale(input, 'width')).toBeCloseTo(0.5, 10); // 400/800
+  });
+
+  it("'page' fits the tighter of width/height", () => {
+    // width fit = 400/800 = 0.5; height fit = 600/600 = 1 → min = 0.5.
+    expect(fitScale(input, 'page')).toBeCloseTo(0.5, 10);
+    // A short-but-wide container: height now binds.
+    expect(
+      fitScale({ contentWidth: 800, contentHeight: 600, containerWidth: 1600, containerHeight: 300 }, 'page'),
+    ).toBeCloseTo(0.5, 10); // min(2, 0.5)
+  });
+
+  it('returns 0 (defer) for an unlaid-out container', () => {
+    expect(fitScale({ ...input, containerWidth: 0 }, 'width')).toBe(0);
+    expect(fitScale({ ...input, containerHeight: 0 }, 'page')).toBe(0);
+    // 'width' mode ignores containerHeight, so a 0 height still fits by width.
+    expect(fitScale({ ...input, containerHeight: 0 }, 'width')).toBeCloseTo(0.5, 10);
+  });
+
+  it('returns 0 for empty content', () => {
+    expect(fitScale({ ...input, contentWidth: 0 }, 'width')).toBe(0);
+    expect(fitScale({ ...input, contentHeight: 0 }, 'page')).toBe(0);
+  });
+});

--- a/packages/core/src/interaction/zoomable.ts
+++ b/packages/core/src/interaction/zoomable.ts
@@ -1,0 +1,143 @@
+/**
+ * IX9 — the shared zoom API contract for every viewer (DocxViewer, PptxViewer,
+ * DocxScrollViewer, PptxScrollViewer, XlsxViewer).
+ *
+ * This module owns ONLY the pure, DOM-free pieces of the contract: the type
+ * ({@link ZoomableViewer}), the discrete zoom-step ladder ({@link nextZoomStep} /
+ * {@link prevZoomStep}), the fit-to-content scale math ({@link fitScale}), and the
+ * range clamp ({@link clampScale}). Each viewer implements the interface with its
+ * own scale field and re-render path; this keeps ONE definition of "what a zoom
+ * factor means" and "what the +/- steps are" across all five, so a host can drive
+ * any viewer through the same six calls without special-casing the format.
+ *
+ * SCALE SEMANTICS (the contract): a scale of `1` means 100% — the natural /
+ * fit-to-width baseline. `getScale()` and `setScale(n)` speak this user-facing
+ * factor for EVERY viewer, even though the viewers store scale differently
+ * internally (XlsxViewer's `cellScale` already is this factor; the single-canvas
+ * viewers multiply the page's natural pt→px size; the scroll viewers multiply
+ * their established fit-to-width base). Implementations translate to/from their
+ * internal representation at the boundary so the contract stays uniform.
+ *
+ * API SHAPE (idiomatic default — the integrator MAY veto; see the IX9 PR): a
+ * six-method surface plus one change notification (`onScaleChange`). Deliberately
+ * NO new UI here — the contract is API only (design decision IX9 §4). Touch-pinch
+ * (IX8) is out of scope.
+ */
+
+/**
+ * The zoom contract every viewer satisfies. All scales are the user-facing factor
+ * where `1` = 100% (see the module note). `fitWidth`/`fitPage` are async because a
+ * fit re-renders at the new scale; the getters/steppers resolve synchronously.
+ */
+export interface ZoomableViewer {
+  /** The current zoom factor (`1` = 100%). Never throws — returns the default
+   *  (`1`) before anything is loaded. */
+  getScale(): number;
+  /** Set the absolute zoom factor (`1` = 100%), clamped to the viewer's
+   *  `[zoomMin, zoomMax]`. Re-renders at the new scale and fires `onScaleChange`
+   *  when the clamped value actually changes. */
+  setScale(scale: number): void | Promise<void>;
+  /** Step up to the next larger rung of the shared zoom ladder (25 %→400 %),
+   *  clamped to `zoomMax`. Equivalent to `setScale(nextZoomStep(getScale()))`. */
+  zoomIn(): void | Promise<void>;
+  /** Step down to the next smaller ladder rung, clamped to `zoomMin`. */
+  zoomOut(): void | Promise<void>;
+  /** Fit the content's WIDTH to the container (the common "fit width" / "fit
+   *  page width" verb). Sets the scale so one page/slide/sheet-column-run spans
+   *  the available width, then re-renders. Resolves once the fit render settles. */
+  fitWidth(): void | Promise<void>;
+  /** Fit the WHOLE content (width AND height) inside the container, so an entire
+   *  page/slide is visible without scrolling. Sets the scale to the smaller of the
+   *  width- and height-fit factors, then re-renders. */
+  fitPage(): void | Promise<void>;
+}
+
+/**
+ * The discrete zoom rungs the +/- steppers snap through, as user-facing factors.
+ * The Excel / Acrobat family (25, 33, 50, 67, 75, 90, 100, 110, 125, 150, 175,
+ * 200, 250, 300, 400 %) — one consistent ascending series (a superset of Excel's
+ * status-bar presets and Acrobat's toolbar presets), so `zoomIn`/`zoomOut` feel
+ * familiar in either lineage. Frozen (readonly) so a caller cannot mutate the
+ * shared ladder. Values are factors, not percents (0.25 … 4).
+ */
+export const ZOOM_STEP_LADDER: readonly number[] = Object.freeze([
+  0.25, 0.33, 0.5, 0.67, 0.75, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4,
+]);
+
+/** Small epsilon so a `scale` sitting exactly on (or a floating-point hair away
+ *  from) a ladder rung steps to the NEXT rung, not back to the one it is already
+ *  on. 0.5 % of a factor is far below the gap between any two adjacent rungs. */
+const LADDER_EPS = 0.005;
+
+/**
+ * The next ladder rung strictly greater than `scale` (the "+" step). A `scale`
+ * already at or above the top rung returns the top rung (the caller then clamps
+ * to `zoomMax`, which may be higher or lower than the ladder top). A `scale`
+ * between rungs jumps UP to the next rung — so an arbitrary wheel-zoomed value
+ * snaps back onto the ladder on the first "+" press. Pure.
+ */
+export function nextZoomStep(scale: number): number {
+  for (const rung of ZOOM_STEP_LADDER) {
+    if (rung > scale + LADDER_EPS) return rung;
+  }
+  return ZOOM_STEP_LADDER[ZOOM_STEP_LADDER.length - 1];
+}
+
+/**
+ * The next ladder rung strictly less than `scale` (the "−" step). Mirror of
+ * {@link nextZoomStep}: a `scale` at or below the bottom rung returns the bottom
+ * rung; a between-rungs value jumps DOWN to the next rung. Pure.
+ */
+export function prevZoomStep(scale: number): number {
+  for (let i = ZOOM_STEP_LADDER.length - 1; i >= 0; i--) {
+    const rung = ZOOM_STEP_LADDER[i];
+    if (rung < scale - LADDER_EPS) return rung;
+  }
+  return ZOOM_STEP_LADDER[0];
+}
+
+/** Clamp `scale` to `[min, max]`. Pure; `max < min` yields `min` (degenerate
+ *  bounds resolve to the floor, matching the viewers' inline clamps). */
+export function clampScale(scale: number, min: number, max: number): number {
+  return scale < min ? min : scale > max ? max : scale;
+}
+
+/** Content + container extents (px, same axis) for a fit computation. */
+export interface FitInput {
+  /** Natural content width at 100% (CSS px). */
+  contentWidth: number;
+  /** Natural content height at 100% (CSS px). */
+  contentHeight: number;
+  /** Available container width (CSS px). */
+  containerWidth: number;
+  /** Available container height (CSS px). Only used by {@link fitScale} in
+   *  `'page'` mode; a `'width'` fit ignores it. */
+  containerHeight: number;
+}
+
+/** Which dimension a fit targets: `'width'` fits the width only (height scrolls);
+ *  `'page'` fits both so the whole page is visible. */
+export type FitMode = 'width' | 'page';
+
+/**
+ * The user-facing zoom factor that fits the content to the container.
+ *
+ * - `'width'`: `containerWidth / contentWidth` — the page spans the width, height
+ *   overflows into the scroll region.
+ * - `'page'`: `min(containerWidth / contentWidth, containerHeight / contentHeight)`
+ *   — the whole page fits inside the box (letterboxed on the looser axis).
+ *
+ * Returns `0` when any input needed for the chosen mode is non-positive (an
+ * unlaid-out container or empty content) so the caller can DEFER — the same
+ * zero-as-defer convention the scroll viewers already use for their base fit.
+ * Pure; no DOM, no clamping (the caller clamps to `[zoomMin, zoomMax]`).
+ */
+export function fitScale(input: FitInput, mode: FitMode): number {
+  const { contentWidth, contentHeight, containerWidth, containerHeight } = input;
+  if (contentWidth <= 0 || containerWidth <= 0) return 0;
+  const widthFit = containerWidth / contentWidth;
+  if (mode === 'width') return widthFit;
+  if (contentHeight <= 0 || containerHeight <= 0) return 0;
+  const heightFit = containerHeight / contentHeight;
+  return Math.min(widthFit, heightFit);
+}

--- a/packages/core/src/interaction/zoomable.ts
+++ b/packages/core/src/interaction/zoomable.ts
@@ -10,13 +10,27 @@
  * factor means" and "what the +/- steps are" across all five, so a host can drive
  * any viewer through the same six calls without special-casing the format.
  *
- * SCALE SEMANTICS (the contract): a scale of `1` means 100% — the natural /
- * fit-to-width baseline. `getScale()` and `setScale(n)` speak this user-facing
- * factor for EVERY viewer, even though the viewers store scale differently
- * internally (XlsxViewer's `cellScale` already is this factor; the single-canvas
- * viewers multiply the page's natural pt→px size; the scroll viewers multiply
- * their established fit-to-width base). Implementations translate to/from their
- * internal representation at the boundary so the contract stays uniform.
+ * SCALE SEMANTICS (the contract): a scale of `1` means 100% — the content at its
+ * natural size (a docx page at `widthPt × PT_TO_PX`, a pptx slide at
+ * `slideWidth / EMU_PER_PX`, an xlsx grid at `cellScale` 1). `getScale()` and
+ * `setScale(n)` speak this user-facing factor for EVERY viewer.
+ *
+ * KNOWN FAMILY DIFFERENCE — the INITIAL scale right after load (deliberate,
+ * documented rather than papered over): the single-canvas viewers (DocxViewer /
+ * PptxViewer) and XlsxViewer start at `1` (or the effective factor implied by an
+ * explicit `width` option); the continuous-scroll viewers (DocxScrollViewer /
+ * PptxScrollViewer) AUTO-FIT to the container on first layout, so their
+ * `getScale()` right after load reports the fit-to-width BASE factor (≠ 1 unless
+ * the container happens to match the natural width). The unit is identical — only
+ * the starting point differs, because fit-to-width is the natural resting state
+ * of a continuous document viewer.
+ *
+ * PRE-LOAD `setScale` (family-unified, IX9 F1): a `setScale` called before the
+ * content is loaded / before the layout is established is LATCHED — never
+ * silently dropped — and applied once the viewer establishes its scale (the
+ * single-canvas viewers honour it on the first render; the scroll viewers apply
+ * it right after the base fit establishes, firing `onScaleChange` at application
+ * time). `getScale()` reports the latched factor while it is pending.
  *
  * API SHAPE (idiomatic default — the integrator MAY veto; see the IX9 PR): a
  * six-method surface plus one change notification (`onScaleChange`). Deliberately
@@ -31,11 +45,15 @@
  */
 export interface ZoomableViewer {
   /** The current zoom factor (`1` = 100%). Never throws — returns the default
-   *  (`1`) before anything is loaded. */
+   *  (`1`) before anything is loaded, or the latched pending factor when a
+   *  pre-load `setScale` is waiting to be applied (see the module note). */
   getScale(): number;
   /** Set the absolute zoom factor (`1` = 100%), clamped to the viewer's
    *  `[zoomMin, zoomMax]`. Re-renders at the new scale and fires `onScaleChange`
-   *  when the clamped value actually changes. */
+   *  when the clamped value actually changes. Called BEFORE the content is
+   *  loaded / the layout is established, the (clamped) factor is LATCHED and
+   *  applied once the viewer establishes its scale — family-unified semantics
+   *  (IX9 F1): never silently dropped by any viewer. */
   setScale(scale: number): void | Promise<void>;
   /** Step up to the next larger rung of the shared zoom ladder (25 %→400 %),
    *  clamped to `zoomMax`. Equivalent to `setScale(nextZoomStep(getScale()))`. */
@@ -44,11 +62,26 @@ export interface ZoomableViewer {
   zoomOut(): void | Promise<void>;
   /** Fit the content's WIDTH to the container (the common "fit width" / "fit
    *  page width" verb). Sets the scale so one page/slide/sheet-column-run spans
-   *  the available width, then re-renders. Resolves once the fit render settles. */
+   *  the available width, then re-renders. Resolves once the fit render settles.
+   *
+   *  PERSISTENCE is viewer-implementation-dependent (deliberate, by family): the
+   *  single-canvas viewers (DocxViewer / PptxViewer) and XlsxViewer apply the fit
+   *  ONE-SHOT — they observe no container resizes, so a later resize does NOT
+   *  re-fit (call `fitWidth()` again after a layout change). The continuous-
+   *  scroll viewers (DocxScrollViewer / PptxScrollViewer) re-fit their width-fit
+   *  base on every container resize, so a `fitWidth()` there effectively
+   *  PERSISTS across resizes (the resize re-fit preserves the width-fit state). */
   fitWidth(): void | Promise<void>;
   /** Fit the WHOLE content (width AND height) inside the container, so an entire
    *  page/slide is visible without scrolling. Sets the scale to the smaller of the
-   *  width- and height-fit factors, then re-renders. */
+   *  width- and height-fit factors, then re-renders.
+   *
+   *  PERSISTENCE is viewer-implementation-dependent, and — unlike `fitWidth` —
+   *  a page fit does NOT persist across container resizes on ANY viewer: the
+   *  single-canvas viewers and XlsxViewer observe no resizes at all (one-shot),
+   *  and the continuous-scroll viewers' resize handler re-applies the WIDTH fit
+   *  (preserving the zoom multiplier), not the page fit. Re-invoke `fitPage()`
+   *  after a layout change to re-fit. */
   fitPage(): void | Promise<void>;
 }
 

--- a/packages/docx/src/scroll-viewer-zoom-contract.test.ts
+++ b/packages/docx/src/scroll-viewer-zoom-contract.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { DocxScrollViewer } from './scroll-viewer.js';
+import { installDom, makeContainer, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * IX9 — DocxScrollViewer's slice of the shared
+ * {@link import('@silurus/ooxml-core').ZoomableViewer} contract. The viewer
+ * already had an ABSOLUTE `setScale(scale)` (1 = 100%, the base fit ≠ 1),
+ * Ctrl-wheel zoom, and a container-resize re-fit; IX9 keeps that verbatim and
+ * layers on `getScale` / `zoomIn` / `zoomOut` / `fitWidth` / `fitPage` and the
+ * `onScaleChange` notification. The absolute `_scale` IS the contract's
+ * user-facing factor (a page draws at `widthPt × PT_TO_PX × _scale`), so the new
+ * methods operate directly on it.
+ */
+
+/** A page 100pt × 200pt (natural CSS 133.33 × 266.67 px at 100%). */
+const PAGE = { widthPt: 100, heightPt: 200 };
+
+function setup(opts: Record<string, unknown> = {}, host = { w: 200, h: 400 }) {
+  installDom();
+  const container = makeContainer(host.w, host.h);
+  const engine = new FakeDocxEngine(5, [PAGE]);
+  const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+    document: engine.asDoc(),
+    gap: 10,
+    paddingTop: 0,
+    paddingBottom: 0,
+    paddingLeft: 0,
+    paddingRight: 0,
+    zoomMin: 0.1,
+    zoomMax: 4,
+    ...opts,
+  });
+  const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+  scrollHost.clientHeight = host.h;
+  scrollHost.clientWidth = host.w;
+  v.relayout();
+  return { v, scrollHost, engine, container };
+}
+
+describe('DocxScrollViewer IX9 zoom contract', () => {
+  it('getScale() returns the absolute factor (the base fit after load)', () => {
+    const { v } = setup();
+    // base = 200 / (100 × 4/3) = 1.5
+    expect(v.getScale()).toBeCloseTo(1.5, 5);
+    expect(v.getScale()).toBeCloseTo(v.scaleForTest(), 10);
+    v.destroy();
+  });
+
+  it('getScale() is 1 before a scale is established (no width yet)', () => {
+    installDom();
+    const engine = new FakeDocxEngine(3, [PAGE]);
+    const v = new DocxScrollViewer(makeContainer(0, 0) as unknown as HTMLElement, {
+      document: engine.asDoc(),
+    });
+    expect(v.getScale()).toBe(1);
+    v.destroy();
+  });
+
+  it('setScale fires onScaleChange with the new factor on a change only', () => {
+    const onScaleChange = vi.fn();
+    const { v } = setup({ onScaleChange });
+    v.setScale(2);
+    expect(v.getScale()).toBeCloseTo(2, 5);
+    expect(onScaleChange).toHaveBeenCalledTimes(1);
+    expect(onScaleChange).toHaveBeenCalledWith(2);
+    onScaleChange.mockClear();
+    v.setScale(2); // unchanged
+    expect(onScaleChange).not.toHaveBeenCalled();
+    v.destroy();
+  });
+
+  it('zoomIn / zoomOut walk the shared ladder (off-base start snaps on)', () => {
+    const { v } = setup();
+    // Start at base 1.5 (an off-ladder value). First zoomIn snaps to 1.75.
+    v.zoomIn();
+    expect(v.getScale()).toBeCloseTo(1.75, 5);
+    v.zoomIn();
+    expect(v.getScale()).toBeCloseTo(2, 5);
+    v.zoomOut();
+    expect(v.getScale()).toBeCloseTo(1.75, 5);
+    v.zoomOut();
+    expect(v.getScale()).toBeCloseTo(1.5, 5); // ladder rung between 1.5 base
+    v.destroy();
+  });
+
+  it('fitWidth restores the width-fit base after a zoom', () => {
+    const { v } = setup();
+    v.setScale(4); // zoom right in
+    expect(v.getScale()).toBeCloseTo(4, 5);
+    v.fitWidth();
+    // Back to the width-fit base = 200 / (100 × 4/3) = 1.5.
+    expect(v.getScale()).toBeCloseTo(1.5, 5);
+    v.destroy();
+  });
+
+  it('fitPage takes the tighter of width/height fit', () => {
+    // Container 200 wide × 200 tall. Natural page 133.33 × 266.67.
+    // widthfit = 200/133.33 = 1.5; heightfit = 200/266.67 = 0.75 ⇒ page-fit 0.75.
+    const { v } = setup({}, { w: 200, h: 200 });
+    v.fitPage();
+    expect(v.getScale()).toBeCloseTo(0.75, 4);
+    v.destroy();
+  });
+
+  it('the wheel-zoom path also notifies through onScaleChange', () => {
+    const onScaleChange = vi.fn();
+    const { v, scrollHost } = setup({ onScaleChange });
+    // Ctrl+wheel up (deltaY < 0 ⇒ zoom in). The handler routes through setScale.
+    scrollHost.dispatch('wheel', { ctrlKey: true, deltaY: -50, preventDefault() {} });
+    expect(onScaleChange).toHaveBeenCalledTimes(1);
+    expect(onScaleChange.mock.calls[0][0]).toBeGreaterThan(1.5);
+    v.destroy();
+  });
+});

--- a/packages/docx/src/scroll-viewer-zoom-contract.test.ts
+++ b/packages/docx/src/scroll-viewer-zoom-contract.test.ts
@@ -117,4 +117,54 @@ describe('DocxScrollViewer IX9 zoom contract', () => {
     expect(onScaleChange.mock.calls[0][0]).toBeGreaterThan(1.5);
     v.destroy();
   });
+
+  // IX9 F1 — family-unified pre-load setScale semantics: a setScale before the
+  // layout establishes must be LATCHED and applied once it does (the
+  // single-canvas viewers honour a pre-load setScale on their first render; the
+  // scroll viewers used to silently drop it).
+  it('setScale before load/layout is latched and applied once established (IX9 F1)', () => {
+    installDom();
+    const container = makeContainer(0, 0); // zero-width ⇒ fit deferred, nothing established
+    const engine = new FakeDocxEngine(5, [PAGE]);
+    const onScaleChange = vi.fn();
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 10,
+      paddingTop: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+      onScaleChange,
+    });
+    v.setScale(2); // pre-establishment: latched, not dropped
+    expect(v.getScale()).toBe(2); // getScale reports the pending factor
+    expect(onScaleChange).not.toHaveBeenCalled(); // fires at APPLICATION time
+    // Container gains width ⇒ the next relayout establishes and applies the latch.
+    container.clientWidth = 200;
+    container.clientHeight = 400;
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientWidth = 200;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    expect(v.scaleForTest()).toBeCloseTo(2, 6); // applied over the 1.5 base fit
+    expect(v.getScale()).toBeCloseTo(2, 6);
+    expect(onScaleChange).toHaveBeenCalledTimes(1);
+    expect(onScaleChange).toHaveBeenCalledWith(2);
+    // The base fit itself is still the true base (resize re-fit multiplier intact).
+    expect(v.baseScaleForTest()).toBeCloseTo(1.5, 5);
+    v.destroy();
+  });
+
+  it('a pre-establishment setScale latch is clamped to [zoomMin, zoomMax] (IX9 F1)', () => {
+    installDom();
+    const engine = new FakeDocxEngine(5, [PAGE]);
+    const v = new DocxScrollViewer(makeContainer(0, 0) as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      zoomMin: 0.5,
+      zoomMax: 3,
+    });
+    v.setScale(100);
+    expect(v.getScale()).toBe(3); // latched pre-clamped
+    v.destroy();
+  });
 });

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1,5 +1,5 @@
-import { computeVisibleRange, openExternalHyperlink, PT_TO_PX, zoomStepScale, type VisibleRange } from '@silurus/ooxml-core';
-import type { HyperlinkTarget } from '@silurus/ooxml-core';
+import { computeVisibleRange, openExternalHyperlink, PT_TO_PX, zoomStepScale, nextZoomStep, prevZoomStep, fitScale, type VisibleRange } from '@silurus/ooxml-core';
+import type { HyperlinkTarget, ZoomableViewer } from '@silurus/ooxml-core';
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
 import type { DocxTextRunInfo } from './renderer';
@@ -112,6 +112,12 @@ export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onText
    *  `computeVisibleRange` (the first page intersecting the viewport top,
    *  EXCLUDING overscan). */
   onVisiblePageChange?: (topIndex: number, total: number) => void;
+  /** IX9 — fires whenever the zoom factor actually changes (`1` = 100% = a page
+   *  at its natural pt→px size): from {@link DocxScrollViewer.setScale},
+   *  `zoomIn`/`zoomOut`, `fitWidth`/`fitPage`, a Ctrl/⌘+wheel gesture, or a
+   *  container-resize re-fit. Named `onScaleChange` to match the single-canvas
+   *  viewers so all five share one notification shape. */
+  onScaleChange?: (scale: number) => void;
   /** IX1 (design decision — NOT user-confirmed, integrator may veto). Called when
    *  a hyperlink run is clicked. When omitted, the default is: external → open in a
    *  new tab via core `openExternalHyperlink` (sanitised, noopener,noreferrer);
@@ -151,7 +157,7 @@ interface PageSlot {
   bitmapCtx: ImageBitmapRenderingContext | null;
 }
 
-export class DocxScrollViewer {
+export class DocxScrollViewer implements ZoomableViewer {
   private _doc: DocxDocument | null = null;
   private readonly _injected: boolean;
   private readonly _opts: DocxScrollViewerOptions;
@@ -1006,6 +1012,74 @@ export class DocxScrollViewer {
     //     after the LAST setScale so a wheel/pinch burst coalesces into one render.
     this._previewVisible();
     this._scheduleSettle();
+    // IX9 change notification. Only reached when `next` differs from the prior
+    // scale (early-returned above), so every source — the public setScale, the
+    // ladder steppers, fitWidth/fitPage, Ctrl-wheel, and the _onResize re-fit
+    // (which routes through here) — notifies through this one hook.
+    this._opts.onScaleChange?.(next);
+  }
+
+  // ─── IX9 zoom contract (ZoomableViewer) ───────────────────────────────────
+
+  /** IX9 {@link ZoomableViewer} — the current zoom factor, where `1` = 100% (a
+   *  page at its natural pt→px width). This is the viewer's absolute `_scale`
+   *  (`widthPt × PT_TO_PX × _scale` is the drawn width), so it reads `1` at true
+   *  100% and, after the initial fit-to-width, the base fit factor. `1` before a
+   *  scale is established. */
+  getScale(): number {
+    return this._scaleEstablished ? this._scale : 1;
+  }
+
+  /** IX9 {@link ZoomableViewer} — step up to the next rung of the shared zoom
+   *  ladder above the current factor (clamped to `zoomMax` by {@link setScale}). */
+  zoomIn(): void {
+    this.setScale(nextZoomStep(this.getScale()));
+  }
+
+  /** IX9 {@link ZoomableViewer} — step down to the next lower ladder rung. */
+  zoomOut(): void {
+    this.setScale(prevZoomStep(this.getScale()));
+  }
+
+  /**
+   * IX9 {@link ZoomableViewer} — fit a page's WIDTH to the container (the classic
+   * continuous-scroll "fit width"). Sets the scale to the width-fit base for the
+   * current container, then re-anchors + re-renders via {@link setScale}. Defers
+   * (no-op) while the container is unlaid-out. Note the `zoomMin`/`zoomMax` clamp
+   * still applies, so a fit below `zoomMin` pins to `zoomMin`.
+   */
+  fitWidth(): void {
+    this._fit('width');
+  }
+
+  /**
+   * IX9 {@link ZoomableViewer} — fit a WHOLE page (width and height) inside the
+   * container so one page is visible without scrolling; takes the tighter of the
+   * width/height fit. Uses the FIRST page's size (the continuous viewer's fit
+   * reference, matching the base-fit convention). Defers while unlaid-out.
+   */
+  fitPage(): void {
+    this._fit('page');
+  }
+
+  /** Shared fit for {@link fitWidth}/{@link fitPage}: the width-fit factor is the
+   *  established base (`_baseScale`); the page-fit additionally bounds by the
+   *  container height against the first page's height. Applies via {@link setScale}
+   *  so the flicker-free re-anchor / settle path and `onScaleChange` all run. */
+  private _fit(mode: 'width' | 'page'): void {
+    if (!this._doc || this._doc.pageCount === 0) return;
+    const size = this._doc.pageSize(0);
+    const scale = fitScale(
+      {
+        contentWidth: size.widthPt * PT_TO_PX,
+        contentHeight: size.heightPt * PT_TO_PX,
+        containerWidth: this._fitWidthPx(),
+        containerHeight: this._scrollHost.clientHeight,
+      },
+      mode,
+    );
+    if (scale <= 0) return; // unlaid-out — defer
+    this.setScale(scale);
   }
 
   /**

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -179,6 +179,18 @@ export class DocxScrollViewer implements ZoomableViewer {
    *  than a `_scale === 1` sentinel because a fit scale of exactly 1 is a valid
    *  established state (a 1× fit would otherwise be re-fit forever). */
   private _scaleEstablished = false;
+  /**
+   * IX9 F1 — a `setScale` factor requested BEFORE the base fit is established
+   * (pre-load, or a zero-width container), already clamped to
+   * `[zoomMin, zoomMax]`, or `null` when none is pending. The single-canvas
+   * viewers latch a pre-load `setScale` and honour it on the first render; the
+   * scroll viewers used to silently DROP it — the family-unified semantics are
+   * "latch and apply once the layout establishes". `relayout()` applies (and
+   * clears) this right after establishing the base, firing `onScaleChange` at
+   * application time; `getScale()` reports it while pending so the caller sees
+   * the same value a single-canvas viewer would show.
+   */
+  private _pendingScale: number | null = null;
   /** Live slots keyed by page index. */
   private readonly _slots = new Map<number, PageSlot>();
   /** Recyclable detached slots (canvas + textLayer reused across pages). */
@@ -480,6 +492,22 @@ export class DocxScrollViewer implements ZoomableViewer {
         this._prevBase = base;
         this._lastFitWidth = this._fitWidthPx();
         this._scaleEstablished = true;
+        // IX9 F1: apply a setScale latched BEFORE establishment (pre-load / a
+        // zero-width container), now that the base exists. Applied here — before
+        // heights/spacer/mount below — so the first window renders directly at
+        // the requested factor (no intermediate base-scale frame). `_prevBase`
+        // stays the true base so a later resize re-fit preserves the implied
+        // zoom multiplier. onScaleChange fires at application time (the latch
+        // itself was silent), and only when the pending factor actually moved
+        // the scale off the base fit.
+        if (this._pendingScale !== null) {
+          const pending = this._pendingScale;
+          this._pendingScale = null;
+          if (pending !== this._scale) {
+            this._scale = pending;
+            this._opts.onScaleChange?.(pending);
+          }
+        }
       } else {
         return; // container has no width yet — retry on the next resize
       }
@@ -940,7 +968,10 @@ export class DocxScrollViewer implements ZoomableViewer {
    * `[zoomMin ?? 0.1, zoomMax ?? 4]` (absolute bounds, XlsxViewer convention — NOT
    * multiples of the base fit; design §3 keeps the clamp in the viewer, not core),
    * then re-anchor VERTICALLY so the page currently under the viewport top stays
-   * fixed. A no-op when nothing is loaded or when the clamped scale is unchanged.
+   * fixed. A no-op when the clamped scale is unchanged. Called BEFORE the doc is
+   * loaded / the base fit is established, the clamped factor is LATCHED (IX9 F1,
+   * family-unified with the single-canvas viewers) and applied by `relayout()`
+   * once the layout establishes — `onScaleChange` fires then.
    *
    * FLICKER-FREE (design §7): this does NOT re-render the visible pages inline.
    * It shows an immediate CSS preview (stretch the existing bitmaps, scale the
@@ -961,10 +992,18 @@ export class DocxScrollViewer implements ZoomableViewer {
    * can no longer return below the floor to the original base fit through this API.
    */
   setScale(scale: number): void {
-    if (!this._doc || this._doc.pageCount === 0 || !this._scaleEstablished) return;
     const zoomMin = this._opts.zoomMin ?? 0.1;
     const zoomMax = this._opts.zoomMax ?? 4;
     const next = Math.min(zoomMax, Math.max(zoomMin, scale));
+    if (!this._doc || this._doc.pageCount === 0 || !this._scaleEstablished) {
+      // IX9 F1 (family-unified pre-load semantics): a setScale before the doc is
+      // loaded / before the base fit is established is LATCHED, not dropped —
+      // matching the single-canvas viewers, which honour a pre-load setScale on
+      // their first render. relayout() applies it right after establishing the
+      // base and fires onScaleChange there (at application time).
+      this._pendingScale = next;
+      return;
+    }
     if (next === this._scale) return;
 
     // Capture the anchor from the CURRENT layout, before rescale.
@@ -1024,10 +1063,12 @@ export class DocxScrollViewer implements ZoomableViewer {
   /** IX9 {@link ZoomableViewer} — the current zoom factor, where `1` = 100% (a
    *  page at its natural pt→px width). This is the viewer's absolute `_scale`
    *  (`widthPt × PT_TO_PX × _scale` is the drawn width), so it reads `1` at true
-   *  100% and, after the initial fit-to-width, the base fit factor. `1` before a
-   *  scale is established. */
+   *  100% and, after the initial fit-to-width, the base fit factor. Before the
+   *  fit is established it reports a latched pre-load `setScale` (IX9 F1) if one
+   *  is pending — matching what a single-canvas viewer would show — else `1`. */
   getScale(): number {
-    return this._scaleEstablished ? this._scale : 1;
+    if (this._scaleEstablished) return this._scale;
+    return this._pendingScale ?? 1;
   }
 
   /** IX9 {@link ZoomableViewer} — step up to the next rung of the shared zoom

--- a/packages/docx/src/viewer-zoom-contract.test.ts
+++ b/packages/docx/src/viewer-zoom-contract.test.ts
@@ -134,3 +134,33 @@ describe('DocxViewer IX9 zoom contract — fitWidth / fitPage', () => {
     expect(onScaleChange).not.toHaveBeenCalled();
   });
 });
+
+// IX9 F1 — family-unified pre-load setScale semantics (pinned across all five
+// viewers): a setScale before load is LATCHED and applied to the first render.
+describe('DocxViewer IX9 zoom contract — pre-load setScale latch (F1)', () => {
+  it('setScale before load/layout is latched and applied once established (IX9 F1)', async () => {
+    installDom();
+    const canvas = makeEl('canvas');
+    const engine = new FakeDocxEngine(3, PAGE);
+    vi.spyOn(DocxDocument, 'load').mockResolvedValue(engine.asDoc());
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement, {});
+    await v.setScale(1.5); // nothing loaded yet — latched, render no-ops
+    expect(v.getScale()).toBe(1.5); // getScale reports the latched factor
+    await v.load('x.docx');
+    // The first real render already honours the latched factor.
+    expect(lastRenderWidth(engine)).toBe(Math.round(NATURAL_W * 1.5));
+    expect(v.getScale()).toBe(1.5);
+    v.destroy();
+  });
+
+  it('a pre-load setScale latch is clamped to [zoomMin, zoomMax] (IX9 F1)', async () => {
+    installDom();
+    const canvas = makeEl('canvas');
+    const engine = new FakeDocxEngine(3, PAGE);
+    vi.spyOn(DocxDocument, 'load').mockResolvedValue(engine.asDoc());
+    const v = new DocxViewer(canvas as unknown as HTMLCanvasElement, { zoomMin: 0.5, zoomMax: 3 });
+    await v.setScale(100);
+    expect(v.getScale()).toBe(3); // latched pre-clamped
+    v.destroy();
+  });
+});

--- a/packages/docx/src/viewer-zoom-contract.test.ts
+++ b/packages/docx/src/viewer-zoom-contract.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { DocxViewer } from './viewer.js';
+import { DocxDocument } from './document.js';
+import { PT_TO_PX } from '@silurus/ooxml-core';
+import { installDom, makeEl, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const PAGE = [{ widthPt: 600, heightPt: 800 }];
+const NATURAL_W = 600 * PT_TO_PX; // 800 CSS px at 100%
+const NATURAL_H = 800 * PT_TO_PX;
+
+/** Mount a DocxViewer over a FakeDocxEngine (the render-error suite's seam), with
+ *  a parent container of the given size so fit has something to measure. */
+async function mount(opts: Record<string, unknown> = {}, containerSize?: { w: number; h: number }) {
+  installDom();
+  const canvas = makeEl('canvas');
+  if (containerSize) {
+    // Give the canvas a laid-out parent; the viewer reparents into it, so
+    // `_wrapper.parentElement` becomes this element and `_fitContainer` sees it.
+    const parent = makeEl('div');
+    parent.clientWidth = containerSize.w;
+    parent.clientHeight = containerSize.h;
+    parent.appendChild(canvas);
+  }
+  const engine = new FakeDocxEngine(3, PAGE);
+  vi.spyOn(DocxDocument, 'load').mockResolvedValue(engine.asDoc());
+  const v = new DocxViewer(canvas as unknown as HTMLCanvasElement, opts);
+  await v.load('x.docx');
+  return { v, engine, canvas: canvas as FakeEl };
+}
+
+/** The `width` passed to the most recent renderPage call. */
+function lastRenderWidth(engine: FakeDocxEngine): number | undefined {
+  const w = engine.renderCalls;
+  return w[w.length - 1]?.width;
+}
+
+describe('DocxViewer IX9 zoom contract — byte-identical default', () => {
+  it('renders at opts.width verbatim when no zoom method is called', async () => {
+    const { engine } = await mount({ width: 1000 });
+    // The initial load render used opts.width unchanged (no zoom latched).
+    expect(lastRenderWidth(engine)).toBe(1000);
+  });
+
+  it('renders at the natural width (undefined) when opts.width is unset', async () => {
+    const { engine } = await mount();
+    expect(lastRenderWidth(engine)).toBeUndefined();
+  });
+
+  it('getScale() reflects opts.width / natural before any zoom call', async () => {
+    const { v } = await mount({ width: NATURAL_W * 2 });
+    expect(v.getScale()).toBeCloseTo(2, 6);
+  });
+
+  it('getScale() is 1 when opts.width is unset (natural render)', async () => {
+    const { v } = await mount();
+    expect(v.getScale()).toBe(1);
+  });
+});
+
+describe('DocxViewer IX9 zoom contract — setScale / steppers', () => {
+  it('setScale renders at naturalWidth × scale and fires onScaleChange', async () => {
+    const onScaleChange = vi.fn();
+    const { v, engine } = await mount({ onScaleChange });
+    await v.setScale(1.5);
+    expect(v.getScale()).toBe(1.5);
+    expect(lastRenderWidth(engine)).toBe(Math.round(NATURAL_W * 1.5));
+    expect(onScaleChange).toHaveBeenCalledTimes(1);
+    expect(onScaleChange).toHaveBeenCalledWith(1.5);
+  });
+
+  it('setScale clamps to [zoomMin, zoomMax]', async () => {
+    const { v } = await mount({ zoomMin: 0.5, zoomMax: 2 });
+    await v.setScale(10);
+    expect(v.getScale()).toBe(2);
+    await v.setScale(0.01);
+    expect(v.getScale()).toBe(0.5);
+  });
+
+  it('setScale does not fire onScaleChange when the factor is unchanged', async () => {
+    const onScaleChange = vi.fn();
+    const { v } = await mount({ onScaleChange });
+    await v.setScale(1.5);
+    onScaleChange.mockClear();
+    await v.setScale(1.5);
+    expect(onScaleChange).not.toHaveBeenCalled();
+  });
+
+  it('zoomIn / zoomOut walk the shared ladder from 100%', async () => {
+    const { v } = await mount();
+    expect(v.getScale()).toBe(1);
+    await v.zoomIn();
+    expect(v.getScale()).toBe(1.1);
+    await v.zoomIn();
+    expect(v.getScale()).toBe(1.25);
+    await v.zoomOut();
+    expect(v.getScale()).toBe(1.1);
+  });
+});
+
+describe('DocxViewer IX9 zoom contract — fitWidth / fitPage', () => {
+  it('fitWidth sets the scale that spans the page width in the container', async () => {
+    const { v } = await mount({}, { w: NATURAL_W / 2, h: 10000 });
+    await v.fitWidth();
+    // container width = naturalW/2 ⇒ fit factor 0.5.
+    expect(v.getScale()).toBeCloseTo(0.5, 6);
+  });
+
+  it('fitPage takes the tighter of width/height', async () => {
+    // Container: width fits at 1.0 (== natural), height fits at 0.5.
+    const { v } = await mount({}, { w: NATURAL_W, h: NATURAL_H / 2 });
+    await v.fitPage();
+    expect(v.getScale()).toBeCloseTo(0.5, 6);
+  });
+
+  it('fitWidth respects an explicit opts.container over the DOM parent', async () => {
+    const container = makeEl('div');
+    container.clientWidth = NATURAL_W / 4; // ⇒ fit 0.25
+    container.clientHeight = 10000;
+    const { v } = await mount({ container: container as unknown as HTMLElement });
+    await v.fitWidth();
+    expect(v.getScale()).toBeCloseTo(0.25, 6);
+  });
+
+  it('fitWidth defers (no-op) with no container to measure', async () => {
+    const onScaleChange = vi.fn();
+    const { v } = await mount({ onScaleChange }); // detached canvas, no parent
+    await v.fitWidth();
+    expect(v.getScale()).toBe(1);
+    expect(onScaleChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -5,8 +5,8 @@ import type { DocxTextRunInfo } from './renderer';
 import { buildDocxTextLayer } from './text-layer';
 import { buildDocxHighlightLayer, type DocxHighlightMatch } from './find-highlight-layer';
 import { DocxFindController, type DocxMatchLocation } from './find';
-import { openExternalHyperlink } from '@silurus/ooxml-core';
-import type { HyperlinkTarget, FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
+import { openExternalHyperlink, PT_TO_PX, nextZoomStep, prevZoomStep, clampScale, fitScale } from '@silurus/ooxml-core';
+import type { HyperlinkTarget, FindMatch, FindMatchesOptions, ZoomableViewer } from '@silurus/ooxml-core';
 
 export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
   container?: HTMLElement;
@@ -17,6 +17,17 @@ export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
   enableTextSelection?: boolean;
   /** Called when a page finishes rendering. */
   onPageChange?: (index: number, total: number) => void;
+  /** IX9 zoom contract ({@link ZoomableViewer}) — the clamp range for
+   *  {@link DocxViewer.setScale} / `zoomIn` / `zoomOut` / `fitWidth` / `fitPage`,
+   *  as user-facing zoom factors (`1` = 100% = the page at its natural pt→px
+   *  size). Defaults 0.1–4 (10%–400%), matching the other viewers. */
+  zoomMin?: number;
+  zoomMax?: number;
+  /** IX9 — fires whenever the zoom factor actually changes (`1` = 100%): from
+   *  {@link DocxViewer.setScale}, `zoomIn`/`zoomOut`, or `fitWidth`/`fitPage`.
+   *  Named `onScaleChange` to match the pptx/xlsx viewers so all five share one
+   *  notification shape. */
+  onScaleChange?: (scale: number) => void;
   /** IX1 (design decision — NOT user-confirmed, integrator may veto). Called when
    *  a hyperlink run is clicked. When omitted, the default is: external → open in a
    *  new tab via core `openExternalHyperlink` (sanitised, noopener,noreferrer);
@@ -26,9 +37,18 @@ export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
   onError?: (err: Error) => void;
 }
 
-export class DocxViewer {
+export class DocxViewer implements ZoomableViewer {
   private _doc: DocxDocument | null = null;
   private _currentPage = 0;
+  /**
+   * IX9 explicit zoom factor (`1` = 100% = the page at its natural pt→px width),
+   * or `null` when the caller has never invoked a zoom method. `null` preserves
+   * the pre-IX9 render path EXACTLY: the page renders at `opts.width` (or its
+   * natural width when that is unset), so default rendering is byte-identical. The
+   * first `setScale`/`zoomIn`/`zoomOut`/`fitWidth`/`fitPage` call latches a number
+   * here, after which `_renderPage` derives the canvas width from it instead.
+   */
+  private _scale: number | null = null;
   private _canvas: HTMLCanvasElement;
   private _wrapper: HTMLDivElement;
   /** The canvas's DOM position BEFORE the constructor reparented it into
@@ -221,6 +241,110 @@ export class DocxViewer {
   async nextPage(): Promise<void> { await this.goToPage(this._currentPage + 1); }
   async prevPage(): Promise<void> { await this.goToPage(this._currentPage - 1); }
 
+  // ─── IX9 zoom contract (ZoomableViewer) ───────────────────────────────────
+
+  /** Natural (100%) CSS-px width of the current page — `widthPt × PT_TO_PX`.
+   *  This is the scale-1 reference every zoom factor multiplies. 0 when nothing
+   *  is loaded. */
+  private _naturalWidthPx(): number {
+    if (!this._doc || this._doc.pageCount === 0) return 0;
+    return this._doc.pageSize(this._currentPage).widthPt * PT_TO_PX;
+  }
+
+  /**
+   * The width (CSS px) `_renderPage` renders the current page at, honouring the
+   * zoom state. `_scale === null` (no zoom method ever called) ⇒ the pre-IX9
+   * value `opts.width` verbatim (byte-identical default: `undefined` lets the
+   * renderer use the page's natural width). Once a factor latched ⇒
+   * `naturalWidth × scale` (rounded), so the on-screen page is exactly `scale ×`
+   * its natural size regardless of the original `opts.width`.
+   */
+  private _renderWidth(): number | undefined {
+    if (this._scale === null) return this._opts.width;
+    const natural = this._naturalWidthPx();
+    if (natural <= 0) return this._opts.width; // unloaded — fall back, defer
+    return Math.round(natural * this._scale);
+  }
+
+  /** IX9 {@link ZoomableViewer} — the current zoom factor (`1` = 100%). Before
+   *  any zoom method is called this is the EFFECTIVE scale implied by the current
+   *  render width: `opts.width / naturalWidth`, or `1` when `opts.width` is unset
+   *  (the page renders at its natural size) or nothing is loaded. */
+  getScale(): number {
+    if (this._scale !== null) return this._scale;
+    const natural = this._naturalWidthPx();
+    if (natural <= 0) return 1;
+    return this._opts.width && this._opts.width > 0 ? this._opts.width / natural : 1;
+  }
+
+  private _zoomMin(): number { return this._opts.zoomMin ?? 0.1; }
+  private _zoomMax(): number { return this._opts.zoomMax ?? 4; }
+
+  /**
+   * IX9 {@link ZoomableViewer} — set the absolute zoom factor (`1` = 100% = the
+   * page at its natural pt→px width), clamped to `[zoomMin, zoomMax]`, and
+   * re-render the current page at the new size. Fires `onScaleChange` when the
+   * clamped factor actually changes. Resolves once the re-render settles. A no-op
+   * (but still latches the scale) when nothing is loaded.
+   */
+  async setScale(scale: number): Promise<void> {
+    const next = clampScale(scale, this._zoomMin(), this._zoomMax());
+    const changed = next !== this.getScale();
+    this._scale = next;
+    await this._render();
+    if (changed) this._opts.onScaleChange?.(next);
+  }
+
+  /** IX9 {@link ZoomableViewer} — step up to the next rung of the shared zoom
+   *  ladder (clamped to `zoomMax`). */
+  async zoomIn(): Promise<void> { await this.setScale(nextZoomStep(this.getScale())); }
+
+  /** IX9 {@link ZoomableViewer} — step down to the next lower ladder rung. */
+  async zoomOut(): Promise<void> { await this.setScale(prevZoomStep(this.getScale())); }
+
+  /**
+   * IX9 {@link ZoomableViewer} — fit the current page's WIDTH to the host
+   * container (the element the canvas lives in, or `opts.container` if supplied),
+   * then re-render. Defers (no-op) when nothing is loaded or the container is
+   * unlaid-out. Routes through {@link setScale}, so the factor is clamped and
+   * `onScaleChange` fires.
+   */
+  async fitWidth(): Promise<void> { await this._fit('width'); }
+
+  /**
+   * IX9 {@link ZoomableViewer} — fit the WHOLE current page (width and height)
+   * inside the container so it is visible without scrolling; takes the tighter of
+   * the width/height fit. Defers when unloaded / unlaid-out.
+   */
+  async fitPage(): Promise<void> { await this._fit('page'); }
+
+  /** Shared fit for {@link fitWidth}/{@link fitPage}: measure the natural page
+   *  size + the container box, ask core's pure `fitScale`, apply via setScale. */
+  private async _fit(mode: 'width' | 'page'): Promise<void> {
+    if (!this._doc || this._doc.pageCount === 0) return;
+    const size = this._doc.pageSize(this._currentPage);
+    const container = this._fitContainer();
+    if (!container) return;
+    const scale = fitScale(
+      {
+        contentWidth: size.widthPt * PT_TO_PX,
+        contentHeight: size.heightPt * PT_TO_PX,
+        containerWidth: container.clientWidth,
+        containerHeight: container.clientHeight,
+      },
+      mode,
+    );
+    if (scale <= 0) return; // unlaid-out / empty — defer
+    await this.setScale(scale);
+  }
+
+  /** The element a fit measures against: the explicit `opts.container`, else the
+   *  host the wrapper was inserted into (`_wrapper.parentElement`). `null` when
+   *  the canvas was mounted detached (no host to fit to). */
+  private _fitContainer(): { clientWidth: number; clientHeight: number } | null {
+    return this._opts.container ?? this._wrapper.parentElement ?? null;
+  }
+
   /**
    * IX2 — find every occurrence of `query` in the document and highlight them
    * all (a soft box per match, drawn on the highlight overlay over the drawn
@@ -377,13 +501,18 @@ export class DocxViewer {
         "[ooxml] text selection is unavailable in mode: 'worker'; the overlay will be empty. Use mode: 'main' for selectable text.",
       );
     }
+    // IX9: the width to render at. When no zoom method was ever called
+    // (`_scale === null`) this is exactly `opts.width` (pre-IX9 path, byte-
+    // identical default); once a zoom latched a factor it is `naturalWidth ×
+    // scale`.
+    const renderWidth = this._renderWidth();
     if (isWorker) {
       const dpr = this._opts.dpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
       // Only serializable render options may cross to the worker — spreading the
       // full viewer opts would postMessage non-cloneable values (the math
       // engine, callbacks, container element) and throw a DataCloneError.
       const bmp = await this._doc.renderPageToBitmap(this._currentPage, {
-        width: this._opts.width,
+        width: renderWidth,
         dpr: this._opts.dpr,
         defaultTextColor: this._opts.defaultTextColor,
         showTrackChanges: this._opts.showTrackChanges,
@@ -402,7 +531,7 @@ export class DocxViewer {
       // instead of re-rendering it offscreen.
       const runs: DocxTextRunInfo[] = [];
       const onTextRun = (r: DocxTextRunInfo) => runs.push(r);
-      await this._doc.renderPage(this._canvas, this._currentPage, { ...this._opts, onTextRun });
+      await this._doc.renderPage(this._canvas, this._currentPage, { ...this._opts, width: renderWidth, onTextRun });
       if (this._textLayer) {
         this._buildTextLayer(this._textLayer, runs);
       }

--- a/packages/pptx/src/scroll-viewer-zoom-contract.test.ts
+++ b/packages/pptx/src/scroll-viewer-zoom-contract.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { PptxScrollViewer } from './scroll-viewer.js';
+import { installDom, makeContainer, FakePptxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * IX9 — PptxScrollViewer's slice of the shared
+ * {@link import('@silurus/ooxml-core').ZoomableViewer} contract. Mirrors the docx
+ * scroll-viewer contract test: the pre-existing ABSOLUTE `setScale`, Ctrl-wheel
+ * zoom and resize re-fit stay verbatim; IX9 adds getScale / zoomIn / zoomOut /
+ * fitWidth / fitPage + onScaleChange over the same absolute `_scale` (a slide
+ * draws at `slideWidth/EMU_PER_PX × _scale`).
+ */
+const SLIDE_W_EMU = 9525 * 200; // natural 200 px
+const SLIDE_H_EMU = 9525 * 120; // natural 120 px
+
+function setup(opts: Record<string, unknown> = {}, host = { w: 200, h: 400 }) {
+  installDom();
+  const container = makeContainer(host.w, host.h);
+  const engine = new FakePptxEngine(20, SLIDE_W_EMU, SLIDE_H_EMU);
+  const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+    presentation: engine.asPres(),
+    gap: 10,
+    paddingTop: 0,
+    paddingBottom: 0,
+    paddingLeft: 0,
+    paddingRight: 0,
+    zoomMin: 0.1,
+    zoomMax: 4,
+    ...opts,
+  });
+  const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+  scrollHost.clientHeight = host.h;
+  scrollHost.clientWidth = host.w;
+  v.relayout();
+  return { v, scrollHost, engine, container };
+}
+
+describe('PptxScrollViewer IX9 zoom contract', () => {
+  it('getScale() returns the absolute factor (the base fit after load)', () => {
+    const { v } = setup();
+    // base = 200 / 200 = 1.0
+    expect(v.getScale()).toBeCloseTo(1.0, 6);
+    expect(v.getScale()).toBeCloseTo(v.scaleForTest(), 10);
+    v.destroy();
+  });
+
+  it('getScale() is 1 before a scale is established (no width yet)', () => {
+    installDom();
+    const engine = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const v = new PptxScrollViewer(makeContainer(0, 0) as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+    });
+    expect(v.getScale()).toBe(1);
+    v.destroy();
+  });
+
+  it('setScale fires onScaleChange with the new factor on a change only', () => {
+    const onScaleChange = vi.fn();
+    const { v } = setup({ onScaleChange });
+    v.setScale(2);
+    expect(v.getScale()).toBeCloseTo(2, 6);
+    expect(onScaleChange).toHaveBeenCalledTimes(1);
+    expect(onScaleChange).toHaveBeenCalledWith(2);
+    onScaleChange.mockClear();
+    v.setScale(2); // unchanged
+    expect(onScaleChange).not.toHaveBeenCalled();
+    v.destroy();
+  });
+
+  it('zoomIn / zoomOut walk the shared ladder from the base 1.0', () => {
+    const { v } = setup();
+    expect(v.getScale()).toBeCloseTo(1.0, 6);
+    v.zoomIn();
+    expect(v.getScale()).toBeCloseTo(1.1, 6);
+    v.zoomIn();
+    expect(v.getScale()).toBeCloseTo(1.25, 6);
+    v.zoomOut();
+    expect(v.getScale()).toBeCloseTo(1.1, 6);
+    v.destroy();
+  });
+
+  it('fitWidth restores the width-fit base after a zoom', () => {
+    const { v } = setup();
+    v.setScale(4);
+    expect(v.getScale()).toBeCloseTo(4, 6);
+    v.fitWidth();
+    expect(v.getScale()).toBeCloseTo(1.0, 6);
+    v.destroy();
+  });
+
+  it('fitPage takes the tighter of width/height fit', () => {
+    // Container 200 wide × 60 tall. Natural slide 200 × 120.
+    // widthfit = 200/200 = 1.0; heightfit = 60/120 = 0.5 ⇒ page-fit 0.5.
+    const { v } = setup({}, { w: 200, h: 60 });
+    v.fitPage();
+    expect(v.getScale()).toBeCloseTo(0.5, 5);
+    v.destroy();
+  });
+
+  it('the wheel-zoom path also notifies through onScaleChange', () => {
+    const onScaleChange = vi.fn();
+    const { v, scrollHost } = setup({ onScaleChange });
+    scrollHost.dispatch('wheel', { ctrlKey: true, deltaY: -50, preventDefault() {} });
+    expect(onScaleChange).toHaveBeenCalledTimes(1);
+    expect(onScaleChange.mock.calls[0][0]).toBeGreaterThan(1.0);
+    v.destroy();
+  });
+});

--- a/packages/pptx/src/scroll-viewer-zoom-contract.test.ts
+++ b/packages/pptx/src/scroll-viewer-zoom-contract.test.ts
@@ -110,4 +110,54 @@ describe('PptxScrollViewer IX9 zoom contract', () => {
     expect(onScaleChange.mock.calls[0][0]).toBeGreaterThan(1.0);
     v.destroy();
   });
+
+  // IX9 F1 — family-unified pre-load setScale semantics: a setScale before the
+  // layout establishes must be LATCHED and applied once it does (the
+  // single-canvas viewers honour a pre-load setScale on their first render; the
+  // scroll viewers used to silently drop it).
+  it('setScale before load/layout is latched and applied once established (IX9 F1)', () => {
+    installDom();
+    const container = makeContainer(0, 0); // zero-width ⇒ fit deferred, nothing established
+    const engine = new FakePptxEngine(20, SLIDE_W_EMU, SLIDE_H_EMU);
+    const onScaleChange = vi.fn();
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 10,
+      paddingTop: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+      onScaleChange,
+    });
+    v.setScale(2); // pre-establishment: latched, not dropped
+    expect(v.getScale()).toBe(2); // getScale reports the pending factor
+    expect(onScaleChange).not.toHaveBeenCalled(); // fires at APPLICATION time
+    // Container gains width ⇒ the next relayout establishes and applies the latch.
+    container.clientWidth = 200;
+    container.clientHeight = 400;
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientWidth = 200;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+    expect(v.scaleForTest()).toBeCloseTo(2, 6); // applied over the 1.0 base fit
+    expect(v.getScale()).toBeCloseTo(2, 6);
+    expect(onScaleChange).toHaveBeenCalledTimes(1);
+    expect(onScaleChange).toHaveBeenCalledWith(2);
+    // The base fit itself is still the true base (resize re-fit multiplier intact).
+    expect(v.baseScaleForTest()).toBeCloseTo(1.0, 6);
+    v.destroy();
+  });
+
+  it('a pre-establishment setScale latch is clamped to [zoomMin, zoomMax] (IX9 F1)', () => {
+    installDom();
+    const engine = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU);
+    const v = new PptxScrollViewer(makeContainer(0, 0) as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      zoomMin: 0.5,
+      zoomMax: 3,
+    });
+    v.setScale(100);
+    expect(v.getScale()).toBe(3); // latched pre-clamped
+    v.destroy();
+  });
 });

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1,4 +1,4 @@
-import { computeVisibleRange, EMU_PER_PX, zoomStepScale, type VisibleRange, type HyperlinkTarget, openExternalHyperlink } from '@silurus/ooxml-core';
+import { computeVisibleRange, EMU_PER_PX, zoomStepScale, nextZoomStep, prevZoomStep, fitScale, type VisibleRange, type HyperlinkTarget, type ZoomableViewer, openExternalHyperlink } from '@silurus/ooxml-core';
 import { PptxPresentation, type LoadOptions, type RenderSlideOptions } from './presentation';
 import type { PptxTextRunInfo } from './renderer';
 import { buildPptxTextLayer } from './text-layer';
@@ -116,6 +116,12 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
    *  `computeVisibleRange` (the first slide intersecting the viewport top,
    *  EXCLUDING overscan). */
   onVisibleSlideChange?: (topIndex: number, total: number) => void;
+  /** IX9 — fires whenever the zoom factor actually changes (`1` = 100% = a slide
+   *  at its natural EMU→px size): from {@link PptxScrollViewer.setScale},
+   *  `zoomIn`/`zoomOut`, `fitWidth`/`fitPage`, a Ctrl/⌘+wheel gesture, or a
+   *  container-resize re-fit. Named `onScaleChange` to match the single-canvas
+   *  viewers so all five share one notification shape. */
+  onScaleChange?: (scale: number) => void;
   /** Error callback. When set, `load()` invokes it and resolves (otherwise the
    *  error is rethrown — shared viewer error contract). It ALSO fires for async
    *  per-slot render failures (both main `renderSlide` and worker
@@ -161,7 +167,7 @@ interface SlideSlot {
   bitmapCtx: ImageBitmapRenderingContext | null;
 }
 
-export class PptxScrollViewer {
+export class PptxScrollViewer implements ZoomableViewer {
   private _pres: PptxPresentation | null = null;
   private readonly _injected: boolean;
   private readonly _opts: PptxScrollViewerOptions;
@@ -995,6 +1001,74 @@ export class PptxScrollViewer {
     //     after the LAST setScale so a wheel/pinch burst coalesces into one render.
     this._previewVisible();
     this._scheduleSettle();
+    // IX9 change notification. Only reached when `next` differs from the prior
+    // scale (early-returned above), so every source — the public setScale, the
+    // ladder steppers, fitWidth/fitPage, Ctrl-wheel, and the _onResize re-fit
+    // (which routes through here) — notifies through this one hook.
+    this._opts.onScaleChange?.(next);
+  }
+
+  // ─── IX9 zoom contract (ZoomableViewer) ───────────────────────────────────
+
+  /** IX9 {@link ZoomableViewer} — the current zoom factor, where `1` = 100% (a
+   *  slide at its natural EMU→px size). This is the viewer's absolute `_scale`
+   *  (`slideWidth/EMU_PER_PX × _scale` is the drawn width), so it reads `1` at
+   *  true 100% and, after the initial fit-to-width, the base fit factor. `1`
+   *  before a scale is established. */
+  getScale(): number {
+    return this._scaleEstablished ? this._scale : 1;
+  }
+
+  /** IX9 {@link ZoomableViewer} — step up to the next rung of the shared zoom
+   *  ladder above the current factor (clamped to `zoomMax` by {@link setScale}). */
+  zoomIn(): void {
+    this.setScale(nextZoomStep(this.getScale()));
+  }
+
+  /** IX9 {@link ZoomableViewer} — step down to the next lower ladder rung. */
+  zoomOut(): void {
+    this.setScale(prevZoomStep(this.getScale()));
+  }
+
+  /**
+   * IX9 {@link ZoomableViewer} — fit a slide's WIDTH to the container (the classic
+   * continuous-scroll "fit width"). Sets the scale to the width-fit base for the
+   * current container, then re-anchors + re-renders via {@link setScale}. Defers
+   * (no-op) while the container is unlaid-out. The `zoomMin`/`zoomMax` clamp still
+   * applies, so a fit below `zoomMin` pins to `zoomMin`.
+   */
+  fitWidth(): void {
+    this._fit('width');
+  }
+
+  /**
+   * IX9 {@link ZoomableViewer} — fit a WHOLE slide (width and height) inside the
+   * container so one slide is visible without scrolling; takes the tighter of the
+   * width/height fit. Uses the deck-wide (uniform) slide size. Defers while
+   * unlaid-out.
+   */
+  fitPage(): void {
+    this._fit('page');
+  }
+
+  /** Shared fit for {@link fitWidth}/{@link fitPage}: the width-fit factor is the
+   *  established base (`_baseScale`); the page-fit additionally bounds by the
+   *  container height against the (uniform) slide height. Applies via
+   *  {@link setScale} so the flicker-free re-anchor / settle path and
+   *  `onScaleChange` all run. */
+  private _fit(mode: 'width' | 'page'): void {
+    if (!this._pres || this._pres.slideCount === 0) return;
+    const scale = fitScale(
+      {
+        contentWidth: this._pres.slideWidth / EMU_PER_PX,
+        contentHeight: this._pres.slideHeight / EMU_PER_PX,
+        containerWidth: this._fitWidthPx(),
+        containerHeight: this._scrollHost.clientHeight,
+      },
+      mode,
+    );
+    if (scale <= 0) return; // unlaid-out — defer
+    this.setScale(scale);
   }
 
   /**

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -192,6 +192,18 @@ export class PptxScrollViewer implements ZoomableViewer {
    *  than a `_scale === 1` sentinel because a fit scale of exactly 1 is a valid
    *  established state (a 1× fit would otherwise be re-fit forever). */
   private _scaleEstablished = false;
+  /**
+   * IX9 F1 — a `setScale` factor requested BEFORE the base fit is established
+   * (pre-load, or a zero-width container), already clamped to
+   * `[zoomMin, zoomMax]`, or `null` when none is pending. The single-canvas
+   * viewers latch a pre-load `setScale` and honour it on the first render; the
+   * scroll viewers used to silently DROP it — the family-unified semantics are
+   * "latch and apply once the layout establishes". `relayout()` applies (and
+   * clears) this right after establishing the base, firing `onScaleChange` at
+   * application time; `getScale()` reports it while pending so the caller sees
+   * the same value a single-canvas viewer would show.
+   */
+  private _pendingScale: number | null = null;
   /** Live slots keyed by slide index. */
   private readonly _slots = new Map<number, SlideSlot>();
   /** Recyclable detached slots (canvas + textLayer reused across slides). */
@@ -497,6 +509,22 @@ export class PptxScrollViewer implements ZoomableViewer {
         this._prevBase = base;
         this._lastFitWidth = this._fitWidthPx();
         this._scaleEstablished = true;
+        // IX9 F1: apply a setScale latched BEFORE establishment (pre-load / a
+        // zero-width container), now that the base exists. Applied here — before
+        // heights/spacer/mount below — so the first window renders directly at
+        // the requested factor (no intermediate base-scale frame). `_prevBase`
+        // stays the true base so a later resize re-fit preserves the implied
+        // zoom multiplier. onScaleChange fires at application time (the latch
+        // itself was silent), and only when the pending factor actually moved
+        // the scale off the base fit.
+        if (this._pendingScale !== null) {
+          const pending = this._pendingScale;
+          this._pendingScale = null;
+          if (pending !== this._scale) {
+            this._scale = pending;
+            this._opts.onScaleChange?.(pending);
+          }
+        }
       } else {
         return; // container has no width yet — retry on the next resize
       }
@@ -929,7 +957,10 @@ export class PptxScrollViewer implements ZoomableViewer {
    * `[zoomMin ?? 0.1, zoomMax ?? 4]` (absolute bounds, XlsxViewer convention — NOT
    * multiples of the base fit; design §3 keeps the clamp in the viewer, not core),
    * then re-anchor VERTICALLY so the slide currently under the viewport top stays
-   * fixed. A no-op when nothing is loaded or when the clamped scale is unchanged.
+   * fixed. A no-op when the clamped scale is unchanged. Called BEFORE the deck is
+   * loaded / the base fit is established, the clamped factor is LATCHED (IX9 F1,
+   * family-unified with the single-canvas viewers) and applied by `relayout()`
+   * once the layout establishes — `onScaleChange` fires then.
    *
    * FLICKER-FREE (design §7): this does NOT re-render the visible slides inline.
    * It shows an immediate CSS preview (stretch the existing bitmaps, scale the
@@ -950,10 +981,18 @@ export class PptxScrollViewer implements ZoomableViewer {
    * can no longer return below the floor to the original base fit through this API.
    */
   setScale(scale: number): void {
-    if (!this._pres || this._pres.slideCount === 0 || !this._scaleEstablished) return;
     const zoomMin = this._opts.zoomMin ?? 0.1;
     const zoomMax = this._opts.zoomMax ?? 4;
     const next = Math.min(zoomMax, Math.max(zoomMin, scale));
+    if (!this._pres || this._pres.slideCount === 0 || !this._scaleEstablished) {
+      // IX9 F1 (family-unified pre-load semantics): a setScale before the deck is
+      // loaded / before the base fit is established is LATCHED, not dropped —
+      // matching the single-canvas viewers, which honour a pre-load setScale on
+      // their first render. relayout() applies it right after establishing the
+      // base and fires onScaleChange there (at application time).
+      this._pendingScale = next;
+      return;
+    }
     if (next === this._scale) return;
 
     // Capture the anchor from the CURRENT layout, before rescale.
@@ -1013,10 +1052,12 @@ export class PptxScrollViewer implements ZoomableViewer {
   /** IX9 {@link ZoomableViewer} — the current zoom factor, where `1` = 100% (a
    *  slide at its natural EMU→px size). This is the viewer's absolute `_scale`
    *  (`slideWidth/EMU_PER_PX × _scale` is the drawn width), so it reads `1` at
-   *  true 100% and, after the initial fit-to-width, the base fit factor. `1`
-   *  before a scale is established. */
+   *  true 100% and, after the initial fit-to-width, the base fit factor. Before
+   *  the fit is established it reports a latched pre-load `setScale` (IX9 F1) if
+   *  one is pending — matching what a single-canvas viewer would show — else `1`. */
   getScale(): number {
-    return this._scaleEstablished ? this._scale : 1;
+    if (this._scaleEstablished) return this._scale;
+    return this._pendingScale ?? 1;
   }
 
   /** IX9 {@link ZoomableViewer} — step up to the next rung of the shared zoom

--- a/packages/pptx/src/viewer-zoom-contract.test.ts
+++ b/packages/pptx/src/viewer-zoom-contract.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { PptxViewer } from './viewer.js';
+import { PptxPresentation } from './presentation.js';
+import { EMU_PER_PX } from '@silurus/ooxml-core';
+import { installDom, makeEl, FakePptxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SLIDE_W_EMU = 9144000; // 960 CSS px at 100%
+const SLIDE_H_EMU = 6858000; // 720 CSS px at 100%
+const NATURAL_W = SLIDE_W_EMU / EMU_PER_PX; // 960
+const NATURAL_H = SLIDE_H_EMU / EMU_PER_PX; // 720
+
+/** Mount a PptxViewer over a FakePptxEngine, optionally with a laid-out DOM
+ *  parent so fit has a container to measure. */
+async function mount(opts: Record<string, unknown> = {}, containerSize?: { w: number; h: number }) {
+  installDom();
+  const canvas = makeEl('canvas');
+  if (containerSize) {
+    const parent = makeEl('div');
+    parent.clientWidth = containerSize.w;
+    parent.clientHeight = containerSize.h;
+    parent.appendChild(canvas);
+  }
+  const engine = new FakePptxEngine(4, SLIDE_W_EMU, SLIDE_H_EMU);
+  vi.spyOn(PptxPresentation, 'load').mockResolvedValue(engine.asPres());
+  const v = new PptxViewer(canvas as unknown as HTMLCanvasElement, opts);
+  await v.load('x.pptx');
+  return { v, engine, canvas: canvas as FakeEl };
+}
+
+function lastRenderWidth(engine: FakePptxEngine): number | undefined {
+  const w = engine.renderCalls;
+  return w[w.length - 1]?.width;
+}
+
+describe('PptxViewer IX9 zoom contract — byte-identical default', () => {
+  it('renders at opts.width verbatim when no zoom method is called', async () => {
+    const { engine } = await mount({ width: 1200 });
+    expect(lastRenderWidth(engine)).toBe(1200);
+  });
+
+  it('renders at the offsetWidth||960 fallback when opts.width is unset', async () => {
+    const { engine } = await mount(); // fake canvas.offsetWidth = 0 ⇒ 960
+    expect(lastRenderWidth(engine)).toBe(960);
+  });
+
+  it('getScale() reflects the effective render width before any zoom call', async () => {
+    const { v } = await mount({ width: NATURAL_W * 2 }); // 1920
+    expect(v.getScale()).toBeCloseTo(2, 6);
+  });
+
+  it('getScale() is 1 at the natural default width', async () => {
+    const { v } = await mount(); // 960 == natural
+    expect(v.getScale()).toBeCloseTo(1, 6);
+  });
+});
+
+describe('PptxViewer IX9 zoom contract — setScale / steppers', () => {
+  it('setScale renders at naturalWidth × scale and fires onScaleChange', async () => {
+    const onScaleChange = vi.fn();
+    const { v, engine } = await mount({ onScaleChange });
+    await v.setScale(1.5);
+    expect(v.getScale()).toBe(1.5);
+    expect(lastRenderWidth(engine)).toBe(Math.round(NATURAL_W * 1.5));
+    expect(onScaleChange).toHaveBeenCalledTimes(1);
+    expect(onScaleChange).toHaveBeenCalledWith(1.5);
+  });
+
+  it('setScale clamps to [zoomMin, zoomMax]', async () => {
+    const { v } = await mount({ zoomMin: 0.5, zoomMax: 2 });
+    await v.setScale(10);
+    expect(v.getScale()).toBe(2);
+    await v.setScale(0.01);
+    expect(v.getScale()).toBe(0.5);
+  });
+
+  it('setScale does not fire onScaleChange when the factor is unchanged', async () => {
+    const onScaleChange = vi.fn();
+    const { v } = await mount({ onScaleChange });
+    await v.setScale(1.5);
+    onScaleChange.mockClear();
+    await v.setScale(1.5);
+    expect(onScaleChange).not.toHaveBeenCalled();
+  });
+
+  it('zoomIn / zoomOut walk the shared ladder from 100%', async () => {
+    const { v } = await mount();
+    expect(v.getScale()).toBeCloseTo(1, 6);
+    await v.zoomIn();
+    expect(v.getScale()).toBe(1.1);
+    await v.zoomIn();
+    expect(v.getScale()).toBe(1.25);
+    await v.zoomOut();
+    expect(v.getScale()).toBe(1.1);
+  });
+});
+
+describe('PptxViewer IX9 zoom contract — fitWidth / fitPage', () => {
+  it('fitWidth sets the scale that spans the slide width in the container', async () => {
+    const { v } = await mount({}, { w: NATURAL_W / 2, h: 10000 });
+    await v.fitWidth();
+    expect(v.getScale()).toBeCloseTo(0.5, 6);
+  });
+
+  it('fitPage takes the tighter of width/height', async () => {
+    // width fits at 1.0, height fits at 0.5 ⇒ min = 0.5.
+    const { v } = await mount({}, { w: NATURAL_W, h: NATURAL_H / 2 });
+    await v.fitPage();
+    expect(v.getScale()).toBeCloseTo(0.5, 6);
+  });
+
+  it('fitWidth defers (no-op) with no container to measure', async () => {
+    const onScaleChange = vi.fn();
+    const { v } = await mount({ onScaleChange }); // detached canvas
+    await v.fitWidth();
+    expect(v.getScale()).toBeCloseTo(1, 6);
+    expect(onScaleChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pptx/src/viewer-zoom-contract.test.ts
+++ b/packages/pptx/src/viewer-zoom-contract.test.ts
@@ -121,3 +121,33 @@ describe('PptxViewer IX9 zoom contract — fitWidth / fitPage', () => {
     expect(onScaleChange).not.toHaveBeenCalled();
   });
 });
+
+// IX9 F1 — family-unified pre-load setScale semantics (pinned across all five
+// viewers): a setScale before load is LATCHED and applied to the first render.
+describe('PptxViewer IX9 zoom contract — pre-load setScale latch (F1)', () => {
+  it('setScale before load/layout is latched and applied once established (IX9 F1)', async () => {
+    installDom();
+    const canvas = makeEl('canvas');
+    const engine = new FakePptxEngine(4, SLIDE_W_EMU, SLIDE_H_EMU);
+    vi.spyOn(PptxPresentation, 'load').mockResolvedValue(engine.asPres());
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement, {});
+    await v.setScale(1.5); // nothing loaded yet — latched, render no-ops
+    expect(v.getScale()).toBe(1.5); // getScale reports the latched factor
+    await v.load('x.pptx');
+    // The first real render already honours the latched factor.
+    expect(lastRenderWidth(engine)).toBe(Math.round(NATURAL_W * 1.5));
+    expect(v.getScale()).toBe(1.5);
+    v.destroy();
+  });
+
+  it('a pre-load setScale latch is clamped to [zoomMin, zoomMax] (IX9 F1)', async () => {
+    installDom();
+    const canvas = makeEl('canvas');
+    const engine = new FakePptxEngine(4, SLIDE_W_EMU, SLIDE_H_EMU);
+    vi.spyOn(PptxPresentation, 'load').mockResolvedValue(engine.asPres());
+    const v = new PptxViewer(canvas as unknown as HTMLCanvasElement, { zoomMin: 0.5, zoomMax: 3 });
+    await v.setScale(100);
+    expect(v.getScale()).toBe(3); // latched pre-clamped
+    v.destroy();
+  });
+});

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -10,7 +10,13 @@ import {
   type HyperlinkTarget,
   type FindMatch,
   type FindMatchesOptions,
+  type ZoomableViewer,
+  EMU_PER_PX,
   openExternalHyperlink,
+  nextZoomStep,
+  prevZoomStep,
+  clampScale,
+  fitScale,
 } from '@silurus/ooxml-core';
 
 /** How {@link PptxViewer} presents hidden slides (`<p:sld show="0">`). */
@@ -24,6 +30,17 @@ export interface PptxViewerOptions extends RenderOptions, LoadOptions {
   onSlideChange?: (index: number, total: number) => void;
   /** Called on parse or render errors */
   onError?: (err: Error) => void;
+  /** IX9 zoom contract ({@link ZoomableViewer}) — the clamp range for
+   *  {@link PptxViewer.setScale} / `zoomIn` / `zoomOut` / `fitWidth` / `fitPage`,
+   *  as user-facing zoom factors (`1` = 100% = the slide at its natural
+   *  EMU→px size). Defaults 0.1–4 (10%–400%), matching the other viewers. */
+  zoomMin?: number;
+  zoomMax?: number;
+  /** IX9 — fires whenever the zoom factor actually changes (`1` = 100%): from
+   *  {@link PptxViewer.setScale}, `zoomIn`/`zoomOut`, or `fitWidth`/`fitPage`.
+   *  Named `onScaleChange` to match the docx/xlsx viewers so all five share one
+   *  notification shape. */
+  onScaleChange?: (scale: number) => void;
   /**
    * Enable interactive audio/video playback. When true, slides are rendered
    * via {@link PptxPresentation.presentSlide} so media elements become
@@ -78,9 +95,18 @@ export interface PptxViewerOptions extends RenderOptions, LoadOptions {
  *
  * For custom layouts (multi-canvas, thumbnails, scroll view) use PptxPresentation directly.
  */
-export class PptxViewer {
+export class PptxViewer implements ZoomableViewer {
   private readonly canvas: HTMLCanvasElement;
   private readonly wrapper: HTMLDivElement;
+  /**
+   * IX9 explicit zoom factor (`1` = 100% = the slide at its natural EMU→px
+   * width), or `null` when the caller has never invoked a zoom method. `null`
+   * preserves the pre-IX9 render path EXACTLY: the slide renders at `opts.width`
+   * (or `canvas.offsetWidth || 960` when unset), so default rendering is
+   * byte-identical. The first zoom call latches a number here, after which
+   * {@link _targetWidth} derives the render width from it.
+   */
+  private _scale: number | null = null;
   /** The canvas's DOM position BEFORE the constructor reparented it into
    *  {@link wrapper}, captured so {@link destroy} can return the caller-owned
    *  canvas to exactly where it was. `null` parent = canvas was passed
@@ -331,13 +357,105 @@ export class PptxViewer {
   /** The underlying <canvas> element. */
   get canvasElement(): HTMLCanvasElement { return this.canvas; }
 
+  // ─── IX9 zoom contract (ZoomableViewer) ───────────────────────────────────
+
+  /** Natural (100%) CSS-px width of a slide — `slideWidth(EMU) / EMU_PER_PX`.
+   *  0 when nothing is loaded. The scale-1 reference every zoom factor
+   *  multiplies. */
+  private _naturalWidthPx(): number {
+    const emu = this.engine?.slideWidth ?? 0;
+    return emu > 0 ? emu / EMU_PER_PX : 0;
+  }
+
+  /**
+   * The width (CSS px) the render paths draw the slide at, honouring the zoom
+   * state. `_scale === null` (no zoom method ever called) ⇒ the pre-IX9 value
+   * `opts.width ?? (canvas.offsetWidth || 960)` verbatim (byte-identical
+   * default). Once a factor latched ⇒ `naturalWidth × scale` (rounded), so the
+   * slide is exactly `scale ×` its natural size regardless of `opts.width`.
+   */
+  private _targetWidth(): number {
+    if (this._scale === null) return this.opts.width ?? (this.canvas.offsetWidth || 960);
+    const natural = this._naturalWidthPx();
+    if (natural <= 0) return this.opts.width ?? (this.canvas.offsetWidth || 960);
+    return Math.round(natural * this._scale);
+  }
+
+  /** IX9 {@link ZoomableViewer} — the current zoom factor (`1` = 100%). Before
+   *  any zoom method is called this is the EFFECTIVE scale implied by the render
+   *  width: `targetWidth / naturalWidth`, or `1` when nothing is loaded. */
+  getScale(): number {
+    if (this._scale !== null) return this._scale;
+    const natural = this._naturalWidthPx();
+    if (natural <= 0) return 1;
+    return this._targetWidth() / natural;
+  }
+
+  private _zoomMin(): number { return this.opts.zoomMin ?? 0.1; }
+  private _zoomMax(): number { return this.opts.zoomMax ?? 4; }
+
+  /**
+   * IX9 {@link ZoomableViewer} — set the absolute zoom factor (`1` = 100% = the
+   * slide at its natural EMU→px width), clamped to `[zoomMin, zoomMax]`, and
+   * re-render the current slide at the new size. Fires `onScaleChange` when the
+   * clamped factor actually changes. Resolves once the re-render settles.
+   */
+  async setScale(scale: number): Promise<void> {
+    const next = clampScale(scale, this._zoomMin(), this._zoomMax());
+    const changed = next !== this.getScale();
+    this._scale = next;
+    await this.renderCurrentSlide();
+    if (changed) this.opts.onScaleChange?.(next);
+  }
+
+  /** IX9 {@link ZoomableViewer} — step up to the next rung of the shared zoom
+   *  ladder (clamped to `zoomMax`). */
+  async zoomIn(): Promise<void> { await this.setScale(nextZoomStep(this.getScale())); }
+
+  /** IX9 {@link ZoomableViewer} — step down to the next lower ladder rung. */
+  async zoomOut(): Promise<void> { await this.setScale(prevZoomStep(this.getScale())); }
+
+  /**
+   * IX9 {@link ZoomableViewer} — fit the current slide's WIDTH to the host
+   * container (the element the canvas lives in), then re-render. Defers (no-op)
+   * when nothing is loaded or the container is unlaid-out. Routes through
+   * {@link setScale}.
+   */
+  async fitWidth(): Promise<void> { await this._fit('width'); }
+
+  /**
+   * IX9 {@link ZoomableViewer} — fit the WHOLE current slide (width and height)
+   * inside the container so it is fully visible; takes the tighter of the
+   * width/height fit. Defers when unloaded / unlaid-out.
+   */
+  async fitPage(): Promise<void> { await this._fit('page'); }
+
+  /** Shared fit for {@link fitWidth}/{@link fitPage}: measure the natural slide
+   *  size + the container box, ask core's pure `fitScale`, apply via setScale. */
+  private async _fit(mode: 'width' | 'page'): Promise<void> {
+    if (!this.engine) return;
+    const container = this.wrapper.parentElement;
+    if (!container) return;
+    const scale = fitScale(
+      {
+        contentWidth: this.engine.slideWidth / EMU_PER_PX,
+        contentHeight: this.engine.slideHeight / EMU_PER_PX,
+        containerWidth: container.clientWidth,
+        containerHeight: container.clientHeight,
+      },
+      mode,
+    );
+    if (scale <= 0) return; // unlaid-out / empty — defer
+    await this.setScale(scale);
+  }
+
   private async renderCurrentSlide(): Promise<void> {
     if (!this.engine) return;
     const dim =
       this._hiddenMode === 'dim' && this.engine.isHidden(this.currentSlide)
         ? this._dim()
         : undefined;
-    const targetWidth = this.opts.width ?? (this.canvas.offsetWidth || 960);
+    const targetWidth = this._targetWidth();
     const dpr = this.opts.dpr ?? (window.devicePixelRatio || 1);
 
     const scale = targetWidth / this.engine.slideWidth;
@@ -428,7 +546,7 @@ export class PptxViewer {
       typeof OffscreenCanvas !== 'undefined'
         ? new OffscreenCanvas(1, 1)
         : (document.createElement('canvas') as HTMLCanvasElement);
-    const targetWidth = this.opts.width ?? (this.canvas.offsetWidth || 960);
+    const targetWidth = this._targetWidth();
     await this.engine.renderSlide(off, slide, {
       width: targetWidth,
       onTextRun: (r: PptxTextRunInfo) => runs.push(r),
@@ -504,7 +622,7 @@ export class PptxViewer {
   /** Rebuild the highlight overlay for the current slide from cached runs. */
   private _redrawHighlights(): void {
     const runs = this._find.slideRuns(this.currentSlide) ?? [];
-    const targetWidth = this.opts.width ?? (this.canvas.offsetWidth || 960);
+    const targetWidth = this._targetWidth();
     const cssHeight = this.engine
       ? Math.round(this.engine.slideHeight * (targetWidth / this.engine.slideWidth))
       : 0;

--- a/packages/xlsx/src/viewer-zoom-contract.test.ts
+++ b/packages/xlsx/src/viewer-zoom-contract.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer } from './viewer.js';
+import { installDom, makeContainer } from './viewer-destroy-test-dom.js';
+import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, getMdwForWorksheet } from './renderer.js';
+import type { Worksheet } from './types.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * IX9 — the XlsxViewer's slice of the shared {@link import('@silurus/ooxml-core').ZoomableViewer}
+ * contract. XlsxViewer already had `setScale` + a slider + Ctrl-wheel zoom; IX9
+ * adds `getScale` / `zoomIn` / `zoomOut` / `fitWidth` / `fitPage` and the
+ * `onScaleChange` notification, WITHOUT changing the existing slider / setScale
+ * clamp-and-snap behaviour (non-regression is pinned below).
+ *
+ * The viewer is driven through its real API on the hand-rolled fake DOM (the repo
+ * has no jsdom). A worksheet is injected into the private `currentWorksheet` field
+ * — the same technique the hit-test suite uses — so scale + fit run against real
+ * geometry. `renderCurrentSheet` early-returns on the fake DOM's 0-sized canvas,
+ * so these tests observe scale STATE and the callback, not pixels.
+ */
+
+/** A small used range: 3 custom columns + defaults, 2 custom rows. */
+function makeSheet(): Worksheet {
+  return {
+    name: 'Sheet1',
+    rows: [{ index: 5, cells: [{ row: 5, col: 8, value: 'x' }] }],
+    colWidths: { 1: 12, 2: 20, 3: 30 },
+    rowHeights: { 1: 25, 2: 40 },
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    images: [],
+    charts: [],
+  } as unknown as Worksheet;
+}
+
+interface Priv {
+  currentWorksheet: Worksheet | null;
+  canvasArea: { clientWidth: number; clientHeight: number };
+}
+
+/** Construct a viewer, inject `ws`, and size the canvas area so fit math has a
+ *  laid-out container (the fake DOM defaults geometry to 0). */
+function mount(
+  ws: Worksheet | null,
+  opts: ConstructorParameters<typeof XlsxViewer>[1] = {},
+  container = { cw: 400, ch: 300 },
+): { v: XlsxViewer; priv: Priv } {
+  const v = new XlsxViewer(makeContainer() as unknown as HTMLElement, opts);
+  const priv = v as unknown as Priv;
+  priv.currentWorksheet = ws;
+  priv.canvasArea.clientWidth = container.cw;
+  priv.canvasArea.clientHeight = container.ch;
+  return { v, priv };
+}
+
+/** Natural (cs=1) used-range extent oracle, mirroring the viewer's private
+ *  `_naturalContentExtent` (header + used cols/rows, no scroll headroom). */
+function naturalExtent(ws: Worksheet): { width: number; height: number } {
+  const mdw = getMdwForWorksheet(ws);
+  let maxRow = Math.max(50, ws.freezeRows ?? 0);
+  let maxCol = Math.max(26, ws.freezeCols ?? 0);
+  for (const row of ws.rows) {
+    if (row.index > maxRow) maxRow = row.index;
+    for (const cell of row.cells) if (cell.col > maxCol) maxCol = cell.col;
+  }
+  let width = HEADER_W;
+  for (let c = 1; c <= maxCol; c++) width += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw);
+  let height = HEADER_H;
+  for (let r = 1; r <= maxRow; r++) height += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+  return { width, height };
+}
+
+describe('XlsxViewer IX9 zoom contract', () => {
+  it('getScale() is 1 (100%) by default and reflects the cellScale option', () => {
+    installDom();
+    expect(mount(makeSheet()).v.getScale()).toBe(1);
+    expect(mount(makeSheet(), { cellScale: 1.5 }).v.getScale()).toBe(1.5);
+  });
+
+  it('setScale fires onScaleChange with the snapped factor exactly once', () => {
+    installDom();
+    const onScaleChange = vi.fn();
+    const { v } = mount(makeSheet(), { onScaleChange });
+    v.setScale(1.5);
+    expect(v.getScale()).toBe(1.5);
+    expect(onScaleChange).toHaveBeenCalledTimes(1);
+    expect(onScaleChange).toHaveBeenCalledWith(1.5);
+  });
+
+  it('setScale does NOT fire onScaleChange when the scale is unchanged', () => {
+    installDom();
+    const onScaleChange = vi.fn();
+    const { v } = mount(makeSheet(), { onScaleChange, cellScale: 2 });
+    v.setScale(2); // already 200%
+    expect(onScaleChange).not.toHaveBeenCalled();
+  });
+
+  it('setScale clamps to [zoomMin, zoomMax]', () => {
+    installDom();
+    const { v } = mount(makeSheet(), { zoomMin: 0.5, zoomMax: 2 });
+    v.setScale(10);
+    expect(v.getScale()).toBe(2);
+    v.setScale(0.01);
+    expect(v.getScale()).toBe(0.5);
+  });
+
+  it('zoomIn / zoomOut walk the shared ladder', () => {
+    installDom();
+    const { v } = mount(makeSheet());
+    expect(v.getScale()).toBe(1);
+    v.zoomIn();
+    expect(v.getScale()).toBe(1.1); // 100% → next ladder rung
+    v.zoomIn();
+    expect(v.getScale()).toBe(1.25);
+    v.zoomOut();
+    expect(v.getScale()).toBe(1.1);
+    v.zoomOut();
+    expect(v.getScale()).toBe(1);
+  });
+
+  it('zoomIn from an off-ladder (wheel-zoomed) scale snaps onto the ladder', () => {
+    installDom();
+    const { v } = mount(makeSheet(), { cellScale: 1.03 });
+    v.zoomIn();
+    expect(v.getScale()).toBe(1.1);
+  });
+
+  it('fitWidth sets the scale that spans the used-range width in the container', () => {
+    installDom();
+    const ws = makeSheet();
+    const { width } = naturalExtent(ws);
+    const cw = 400;
+    const { v } = mount(ws, {}, { cw, ch: 300 });
+    v.fitWidth();
+    // fitScale = cw / width, then snapped to whole percent by setScale.
+    const expected = Math.round((cw / width) * 100) / 100;
+    expect(v.getScale()).toBe(expected);
+  });
+
+  it('fitPage takes the tighter of the width/height fit', () => {
+    installDom();
+    const ws = makeSheet();
+    const { width, height } = naturalExtent(ws);
+    const cw = 400;
+    const ch = 300;
+    const { v } = mount(ws, {}, { cw, ch });
+    v.fitPage();
+    const raw = Math.min(cw / width, ch / height);
+    const expected = Math.round(raw * 100) / 100;
+    expect(v.getScale()).toBe(expected);
+    // fitPage must never exceed fitWidth (height can only tighten).
+    const wRaw = cw / width;
+    expect(raw).toBeLessThanOrEqual(wRaw);
+  });
+
+  it('fitWidth is a no-op (defers) with no sheet or an unlaid-out container', () => {
+    installDom();
+    const onScaleChange = vi.fn();
+    // No worksheet.
+    const a = mount(null, { onScaleChange });
+    a.v.fitWidth();
+    expect(a.v.getScale()).toBe(1);
+    // Zero-width container ⇒ fitScale returns 0 ⇒ defer.
+    const b = mount(makeSheet(), { onScaleChange }, { cw: 0, ch: 0 });
+    b.v.fitWidth();
+    expect(b.v.getScale()).toBe(1);
+    expect(onScaleChange).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Non-regression: the pre-IX9 slider position ↔ scale mapping (PR #315's
+ * "100% dead-center piecewise-linear" behaviour) is unchanged. These call the
+ * private helpers directly so a future contract change can't silently alter the
+ * slider feel.
+ */
+describe('XlsxViewer zoom slider mapping (pre-IX9 non-regression)', () => {
+  it('slider position 50 maps to 100% for any bounds', () => {
+    installDom();
+    const { v } = mount(makeSheet());
+    const priv = v as unknown as {
+      zoomPosToScale(p: number, min: number, max: number): number;
+      zoomScaleToPos(s: number, min: number, max: number): number;
+    };
+    expect(priv.zoomPosToScale(50, 0.1, 4)).toBeCloseTo(1, 10);
+    expect(priv.zoomScaleToPos(1, 0.1, 4)).toBeCloseTo(50, 10);
+    // Each half is its own linear segment.
+    expect(priv.zoomPosToScale(0, 0.1, 4)).toBeCloseTo(0.1, 10);
+    expect(priv.zoomPosToScale(100, 0.1, 4)).toBeCloseTo(4, 10);
+  });
+});

--- a/packages/xlsx/src/viewer-zoom-contract.test.ts
+++ b/packages/xlsx/src/viewer-zoom-contract.test.ts
@@ -174,6 +174,24 @@ describe('XlsxViewer IX9 zoom contract', () => {
     expect(b.v.getScale()).toBe(1);
     expect(onScaleChange).not.toHaveBeenCalled();
   });
+
+  // IX9 F1 — family-unified pre-load setScale semantics (pinned across all five
+  // viewers): a setScale before load is LATCHED and applied to the first render
+  // (cellScale is read by every subsequent sheet render).
+  it('setScale before load/layout is latched and applied once established (IX9 F1)', () => {
+    installDom();
+    // No worksheet loaded yet — setScale must latch (renderCurrentSheet no-ops).
+    const v = new XlsxViewer(makeContainer() as unknown as HTMLElement, {});
+    v.setScale(1.5);
+    expect(v.getScale()).toBe(1.5); // latched; the first showSheet renders at it
+  });
+
+  it('a pre-load setScale latch is clamped to [zoomMin, zoomMax] (IX9 F1)', () => {
+    installDom();
+    const v = new XlsxViewer(makeContainer() as unknown as HTMLElement, { zoomMin: 0.5, zoomMax: 3 });
+    v.setScale(100);
+    expect(v.getScale()).toBe(3); // latched pre-clamped
+  });
 });
 
 /**

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,7 +1,7 @@
 import { XlsxWorkbook } from './workbook.js';
 import type { Hyperlink, ViewportRange, Worksheet, XlsxComment } from './types.js';
-import type { HyperlinkTarget, LoadOptions, FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
-import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale, openExternalHyperlink } from '@silurus/ooxml-core';
+import type { HyperlinkTarget, LoadOptions, FindMatch, FindMatchesOptions, ZoomableViewer } from '@silurus/ooxml-core';
+import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale, openExternalHyperlink, nextZoomStep, prevZoomStep, fitScale } from '@silurus/ooxml-core';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, pxToColWidth, pxToRowHeight, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 import { findListValidationAt } from './data-validation.js';
 import { parseA1 } from './a1.js';
@@ -99,9 +99,20 @@ export interface XlsxViewerOptions extends LoadOptions {
    *  own zoom control). */
   showZoomSlider?: boolean;
   /** Lower/upper bounds for the zoom slider as scale factors. Default 0.1–4
-   *  (10%–400%, matching Excel's zoom range). */
+   *  (10%–400%, matching Excel's zoom range). Also the clamp range for the IX9
+   *  {@link ZoomableViewer} zoom contract ({@link XlsxViewer.setScale} etc.). */
   zoomMin?: number;
   zoomMax?: number;
+  /**
+   * IX9 — fires whenever the zoom factor actually changes (`1` = 100%), whatever
+   * the source: {@link XlsxViewer.setScale}, {@link XlsxViewer.zoomIn} /
+   * {@link XlsxViewer.zoomOut}, {@link XlsxViewer.fitWidth} /
+   * {@link XlsxViewer.fitPage}, the built-in zoom slider, the +/- buttons, or a
+   * Ctrl/⌘+wheel gesture. Named `onScaleChange` to match the docx/pptx viewers so
+   * all five share one notification shape. Not fired when a call resolves to the
+   * same (clamped/snapped) scale.
+   */
+  onScaleChange?: (scale: number) => void;
   onReady?: (sheetNames: string[]) => void;
   /**
    * Called when the active sheet changes, with the new sheet's zero-based
@@ -328,7 +339,7 @@ function getSheetAxes(ws: Worksheet, mdw: number): SheetAxes {
   return axes;
 }
 
-export class XlsxViewer {
+export class XlsxViewer implements ZoomableViewer {
   private wb: XlsxWorkbook | null = null;
   /** The single subtree root the constructor appended to the caller's
    *  container. destroy() removes it to return the container to its original
@@ -2500,9 +2511,13 @@ export class XlsxViewer {
       : 50 + ((clamped - 1) / (max - 1)) * 50;
   }
 
-  /** Set the cell/header scale and re-lay-out the current sheet. Clamped to the
-   *  zoom bounds; keeps the slider thumb, percentage label and the row-header-
-   *  aligned tab-nav width in sync. */
+  /**
+   * IX9 {@link ZoomableViewer} — set the cell/header scale (`1` = 100%; the
+   * viewer's `cellScale`) and re-lay-out the current sheet. Clamped to the zoom
+   * bounds and snapped to whole percent; keeps the slider thumb, percentage label
+   * and the row-header-aligned tab-nav width in sync, and fires `onScaleChange`
+   * when the resolved scale actually changes.
+   */
   setScale(scale: number): void {
     const zoomMin = this.opts.zoomMin ?? 0.1;
     const zoomMax = this.opts.zoomMax ?? 4;
@@ -2537,6 +2552,92 @@ export class XlsxViewer {
     this.updateSelectionOverlay();
     this.updateFindOverlay();
     this.updateNavButtons();
+    // IX9 change notification (fired last, after the view is consistent). Only
+    // reached when `next` differs from the prior scale (early-returned above).
+    this.opts.onScaleChange?.(next);
+  }
+
+  /** IX9 {@link ZoomableViewer} — the current zoom factor (`1` = 100%). This is
+   *  the viewer's `cellScale`; `1` before anything is set. */
+  getScale(): number {
+    return this.opts.cellScale ?? 1;
+  }
+
+  /** IX9 {@link ZoomableViewer} — step up to the next rung of the shared zoom
+   *  ladder (clamped to `zoomMax` by {@link setScale}). */
+  zoomIn(): void {
+    this.setScale(nextZoomStep(this.getScale()));
+  }
+
+  /** IX9 {@link ZoomableViewer} — step down to the next lower ladder rung. */
+  zoomOut(): void {
+    this.setScale(prevZoomStep(this.getScale()));
+  }
+
+  /**
+   * IX9 {@link ZoomableViewer} — fit the used data range's WIDTH to the canvas
+   * area. The "content" is the natural (100%) width of the row header plus the
+   * used columns; the container is `canvasArea.clientWidth`. A no-op (defers) when
+   * nothing is loaded or the container is unlaid-out. Routes through
+   * {@link setScale}, so the result is clamped/snapped and fires `onScaleChange`.
+   */
+  fitWidth(): void {
+    this._fit('width');
+  }
+
+  /**
+   * IX9 {@link ZoomableViewer} — fit the used data range's WIDTH AND HEIGHT inside
+   * the canvas area (header + used columns/rows), so the whole used range is
+   * visible without scrolling. Takes the tighter of the width- and height-fit
+   * factors. Defers when unloaded / unlaid-out; routes through {@link setScale}.
+   */
+  fitPage(): void {
+    this._fit('page');
+  }
+
+  /** Shared fit implementation for {@link fitWidth} / {@link fitPage}: derive the
+   *  natural (cs=1) content extent of the used data range, ask core's pure
+   *  {@link fitScale} for the factor, and apply it via {@link setScale}. */
+  private _fit(mode: 'width' | 'page'): void {
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    const { width, height } = this._naturalContentExtent(ws);
+    const scale = fitScale(
+      {
+        contentWidth: width,
+        contentHeight: height,
+        containerWidth: this.canvasArea.clientWidth,
+        containerHeight: this.canvasArea.clientHeight,
+      },
+      mode,
+    );
+    if (scale <= 0) return; // unlaid-out / empty — defer (fitScale's 0 sentinel)
+    this.setScale(scale);
+  }
+
+  /** Natural (unscaled, cs=1) CSS-px extent of a worksheet's used data range:
+   *  the row/column header plus every used column width / row height. Mirrors
+   *  {@link updateSpacerSize} at cs=1 (same used-range detection) so the fit
+   *  targets exactly the region the spacer/scroll extent covers. */
+  private _naturalContentExtent(ws: Worksheet): { width: number; height: number } {
+    const mdw = getMdwForWorksheet(ws);
+    let maxRow = Math.max(50, ws.freezeRows ?? 0);
+    let maxCol = Math.max(26, ws.freezeCols ?? 0);
+    for (const row of ws.rows) {
+      if (row.index > maxRow) maxRow = row.index;
+      for (const cell of row.cells) {
+        if (cell.col > maxCol) maxCol = cell.col;
+      }
+    }
+    let width = HEADER_W;
+    for (let c = 1; c <= maxCol; c++) {
+      width += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw);
+    }
+    let height = HEADER_H;
+    for (let r = 1; r <= maxRow; r++) {
+      height += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+    }
+    return { width, height };
   }
 
   private updateSpacerSize(ws: Worksheet): void {


### PR DESCRIPTION
## IX9 — unified zoom API contract

Before this PR, zoom was inconsistent across the five viewers: the single-canvas `DocxViewer`/`PptxViewer` had **no** zoom API at all (only a per-call `width` option), the `DocxScrollViewer`/`PptxScrollViewer` had an absolute `setScale` but no `getScale`/steppers/fit and no UI, and only `XlsxViewer` shipped a zoom slider. This PR gives **all five** viewers one shared contract so a host can drive any of them through the same calls.

### The contract (`packages/core`)

New `ZoomableViewer` interface + its pure support logic in `packages/core/src/interaction/zoomable.ts`:

```ts
interface ZoomableViewer {
  getScale(): number;                 // 1 = 100%
  setScale(scale: number): void | Promise<void>;
  zoomIn(): void | Promise<void>;
  zoomOut(): void | Promise<void>;
  fitWidth(): void | Promise<void>;
  fitPage(): void | Promise<void>;
}
```

- `ZOOM_STEP_LADDER` — the Excel/Acrobat preset family (25 %–400 %) as one ascending series; `nextZoomStep`/`prevZoomStep` snap an off-ladder (wheel-zoomed) value back onto the ladder on the first press.
- `fitScale(input, 'width' | 'page')` — pure fit-to-content scale, returning `0` to **defer** on an unlaid-out container (the scroll viewers' base-fit convention).
- `clampScale` — the shared `[zoomMin, zoomMax]` clamp.

**Scale semantics:** `1` = 100% (the content at its natural pt→px / EMU→px size) for **every** viewer, so `zoomIn`/`zoomOut` and the ladder behave identically regardless of format.

**Change notification:** every viewer gains an `onScaleChange?(scale)` option, fired on an actual change from any source (setScale, steppers, fit, Ctrl-wheel, resize re-fit). Named to match across all five.

> **API shape is the idiomatic default — the integrator may veto.** The six-method surface + `onScaleChange` name are chosen defaults; open to changing names/shape.

### Per-viewer implementation

| Viewer | How the contract maps |
|---|---|
| **XlsxViewer** | Already had `setScale` + slider + Ctrl-wheel. Added `getScale`/`zoomIn`/`zoomOut`/`fitWidth`/`fitPage`/`onScaleChange`; `cellScale` is the factor. Slider clamp/snap + PR #315 piecewise-linear mapping **unchanged** (pinned by a non-regression test). |
| **DocxViewer / PptxViewer** (single-canvas) | New; a `_scale` field starts `null` so the default render path passes `opts.width` verbatim — **byte-identical default**. First zoom call latches a factor; render width becomes `naturalWidth × scale`. |
| **DocxScrollViewer / PptxScrollViewer** | The pre-existing **absolute** `setScale` is exactly the contract's factor (a page draws at `natural × _scale`), so it is kept verbatim (heavily relied on by the existing suite). Added the rest of the contract over the same `_scale`; `onScaleChange` fires from `setScale`, which the Ctrl-wheel handler and the resize re-fit already route through. |

No new UI (design IX9 §4 — API only). Touch-pinch (IX8) is out of scope. `devicePixelRatio` stays orthogonal to zoom (composed as before, documented in comments).

### Verification

- **Root `vitest run`**: 2883 passed / 10 skipped / **0 failed** (incl. 6 new IX9 test files: core ladder/fit/clamp + one per viewer).
- **`tsc --build`**: clean (all five `implements ZoomableViewer`).
- **`ast-grep scan`**: no new warnings in production code.
- **Demo VRT (byte-identical default)**: docx **8 passed, 0 px diff**; xlsx **7 passed, 0 px diff**; pptx **12 passed** incl. worker-equivalence (per-slide diffs are the pre-existing pptx text-noise, under threshold). The only VRT "failures" are `private/sample-*` 404s — those fixtures are re-distribution-restricted and gitignored, so they are absent in a fresh worktree by design.

Commits are split 1-concern-each: core contract → xlsx → docx (single) → pptx (single) → docx (scroll) → pptx (scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)