### PR TITLE
feat(docx/pptx): text selection & findText parity in worker mode (IX6)

### DIFF
--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -14,7 +14,7 @@ import {
   type MathRenderer,
 } from '@silurus/ooxml-core';
 import type { PaginatedBodyElement, DocxDocumentModel, RenderPageOptions, WorkerRequest, WorkerResponse, DocComment, DocNote } from './types';
-import { renderDocumentToCanvas, documentHasMath, prepareMathRuns, paginateDocument, dropColorReplacedCache, physicalPageSizePt } from './renderer';
+import { renderDocumentToCanvas, documentHasMath, prepareMathRuns, paginateDocument, dropColorReplacedCache, physicalPageSizePt, type DocxTextRunInfo } from './renderer';
 import { buildBookmarkPageMap } from './bookmark-nav';
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
 import { loadEmbeddedFonts } from './embedded-fonts';
@@ -44,6 +44,15 @@ export interface LoadOptions extends CoreLoadOptions {
    */
   mode?: 'main' | 'worker';
 }
+
+/** IX6 — options for {@link DocxDocument.renderPageToBitmap}: the serializable
+ *  render knobs plus an OPTIONAL `onTextRun`. The callback stays main-thread (it
+ *  never crosses the wire); in worker mode the proxy invokes it with the runs
+ *  the worker shipped back beside the bitmap, so a caller gets the selection /
+ *  find geometry on the same path in both modes. */
+export type RenderPageToBitmapOptions = WireRenderPageOptions & {
+  onTextRun?: (run: DocxTextRunInfo) => void;
+};
 
 export class DocxDocument {
   private _document: DocxDocumentModel | null = null;
@@ -433,9 +442,19 @@ export class DocxDocument {
    * The returned ImageBitmap is owned by the caller: pass it to
    * `transferFromImageBitmap` (which consumes it) or call `bitmap.close()`
    * when done, or its backing memory is held until GC.
+   *
+   * IX6 — an optional `onTextRun` in `opts` receives the page's text-run
+   * geometry (the same stream `renderPage` emits in main mode), so a caller can
+   * build the selection / find overlay from a worker-rendered page on the SAME
+   * code path as main mode. In worker mode the runs ride back beside the bitmap
+   * (one round-trip, no second render).
    */
-  async renderPageToBitmap(pageIndex: number, opts: WireRenderPageOptions = {}): Promise<ImageBitmap> {
-    const wireOpts = { ...opts, dpr: opts.dpr ?? defaultDpr() };
+  async renderPageToBitmap(
+    pageIndex: number,
+    opts: RenderPageToBitmapOptions = {},
+  ): Promise<ImageBitmap> {
+    const { onTextRun, ...wire } = opts;
+    const wireOpts: WireRenderPageOptions = { ...wire, dpr: wire.dpr ?? defaultDpr() };
     if (this._mode === 'worker') {
       if (!Number.isInteger(pageIndex) || pageIndex < 0 || pageIndex >= this.pageCount) {
         throw new Error(`Page index ${pageIndex} out of range (count: ${this.pageCount})`);
@@ -443,10 +462,43 @@ export class DocxDocument {
       const res = await this._bridge.request(
         (id) => ({ type: 'renderPage', id, pageIndex, opts: wireOpts }) satisfies RenderWorkerRequest,
       );
-      return (res as Extract<RenderWorkerResponse, { type: 'pageRendered' }>).bitmap;
+      const rendered = res as Extract<RenderWorkerResponse, { type: 'pageRendered' }>;
+      if (onTextRun) for (const r of rendered.runs) onTextRun(r);
+      return rendered.bitmap;
     }
     const off = new OffscreenCanvas(1, 1);
-    await this.renderPage(off, pageIndex, wireOpts);
+    await this.renderPage(off, pageIndex, { ...wireOpts, onTextRun });
     return off.transferToImageBitmap();
+  }
+
+  /**
+   * IX6 — collect a page's text-run geometry (`DocxTextRunInfo[]`) without
+   * painting a visible canvas. Works in BOTH modes: worker mode renders the page
+   * off-thread and ships only the runs (no bitmap transfer); main mode renders
+   * to a throwaway offscreen canvas. Used by the find controller to scan every
+   * page for matches. The geometry is identical to a `renderPage` of the same
+   * page at the same width/dpr.
+   */
+  async collectPageRuns(
+    pageIndex: number,
+    opts: WireRenderPageOptions = {},
+  ): Promise<DocxTextRunInfo[]> {
+    const wireOpts: WireRenderPageOptions = { ...opts, dpr: opts.dpr ?? defaultDpr() };
+    if (this._mode === 'worker') {
+      if (!Number.isInteger(pageIndex) || pageIndex < 0 || pageIndex >= this.pageCount) {
+        throw new Error(`Page index ${pageIndex} out of range (count: ${this.pageCount})`);
+      }
+      const res = await this._bridge.request(
+        (id) => ({ type: 'collectRuns', id, pageIndex, opts: wireOpts }) satisfies RenderWorkerRequest,
+      );
+      return (res as Extract<RenderWorkerResponse, { type: 'runsCollected' }>).runs;
+    }
+    const runs: DocxTextRunInfo[] = [];
+    const off =
+      typeof OffscreenCanvas !== 'undefined'
+        ? new OffscreenCanvas(1, 1)
+        : (globalThis.document?.createElement('canvas') as HTMLCanvasElement);
+    await this.renderPage(off, pageIndex, { ...wireOpts, onTextRun: (r) => runs.push(r) });
+    return runs;
   }
 }

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -1,4 +1,4 @@
-export { DocxDocument, type LoadOptions } from './document';
+export { DocxDocument, type LoadOptions, type RenderPageToBitmapOptions } from './document';
 export type { WireRenderPageOptions } from './worker-protocol';
 export { DocxViewer, type DocxViewerOptions } from './viewer';
 export { DocxScrollViewer, type DocxScrollViewerOptions } from './scroll-viewer';

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -10,7 +10,7 @@
 import init, { DocxArchive, reinit } from './wasm/docx_parser.js';
 import { decodeDataUrl, preloadGoogleFonts, WasmParserHost } from '@silurus/ooxml-core';
 import type { DocxDocumentModel, PaginatedBodyElement } from './types';
-import { paginateDocument, renderDocumentToCanvas, physicalPageSizePt } from './renderer';
+import { paginateDocument, renderDocumentToCanvas, physicalPageSizePt, type DocxTextRunInfo } from './renderer';
 import { buildBookmarkPageMap } from './bookmark-nav';
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
 import { loadEmbeddedFonts } from './embedded-fonts';
@@ -126,14 +126,37 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
     if (req.type === 'renderPage') {
       if (!doc || !pages) throw new Error('Document not loaded');
       const canvas = new OffscreenCanvas(1, 1); // renderer resizes it
+      // IX6 — collect the run geometry the same render emits so the main thread
+      // can build its selection / find overlay without a second render. The
+      // callback runs worker-side; only the resulting plain array crosses back.
+      const runs: DocxTextRunInfo[] = [];
       await renderDocumentToCanvas(doc, canvas, req.pageIndex, {
         ...req.opts,
         totalPages: pages.length,
         prebuiltPages: pages,
         fetchImage: getImage,
+        onTextRun: (r) => runs.push(r),
       });
       const bitmap = canvas.transferToImageBitmap();
-      post({ type: 'pageRendered', id, bitmap }, [bitmap]);
+      post({ type: 'pageRendered', id, bitmap, runs }, [bitmap]);
+      return;
+    }
+    if (req.type === 'collectRuns') {
+      // IX6 — render a page purely to harvest its text-run geometry (find scans
+      // every page). The bitmap is discarded worker-side; only `runs` crosses
+      // the wire. Same renderer / prebuilt pagination as `renderPage`, so the
+      // geometry is identical to what a `renderPage` of the same page would draw.
+      if (!doc || !pages) throw new Error('Document not loaded');
+      const canvas = new OffscreenCanvas(1, 1);
+      const runs: DocxTextRunInfo[] = [];
+      await renderDocumentToCanvas(doc, canvas, req.pageIndex, {
+        ...req.opts,
+        totalPages: pages.length,
+        prebuiltPages: pages,
+        fetchImage: getImage,
+        onTextRun: (r) => runs.push(r),
+      });
+      post({ type: 'runsCollected', id, runs });
       return;
     }
     if (req.type === 'extractImage') {

--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -279,9 +279,12 @@ export class FakeDocxEngine {
   renderCalls: RenderCall[] = [];
   bitmapCalls: RenderCall[] = [];
   createdBitmaps: Array<{ width: number; height: number; close: ReturnType<typeof vi.fn> }> = [];
-  /** Runs fed to `renderPage`'s `onTextRun` (main mode only) so a test can drive
-   *  the viewer's per-slot text overlay (buildDocxTextLayer) without a real
-   *  render. Empty/undefined ⇒ no runs emitted. */
+  /** Runs fed to the `onTextRun` callback of `renderPage` (main) /
+   *  `renderPageToBitmap` (worker) and returned by `collectPageRuns`, so a test
+   *  can drive the viewer's per-slot text overlay (buildDocxTextLayer) and find
+   *  scan without a real render. Empty/undefined ⇒ no runs emitted. IX6 — the
+   *  worker path now ships runs back beside the bitmap, so the stub mirrors that
+   *  by replaying `feedTextRuns` to `renderPageToBitmap`'s `onTextRun` too. */
   feedTextRuns?: DocxTextRunInfo[];
   constructor(
     private _pageCount: number,
@@ -341,10 +344,17 @@ export class FakeDocxEngine {
       if (!this.deferred) resolve();
     });
   }
-  renderPageToBitmap(page: number, opts?: WireRenderPageOptions): Promise<ImageBitmap> {
+  renderPageToBitmap(
+    page: number,
+    opts?: WireRenderPageOptions & { onTextRun?: (r: DocxTextRunInfo) => void },
+  ): Promise<ImageBitmap> {
     const size = this.pageSize(page);
     const bmp = { width: Math.round(size.widthPt), height: Math.round(size.heightPt), close: vi.fn() };
     this.createdBitmaps.push(bmp);
+    // IX6 — replay fed runs to the caller's collector, mirroring the real proxy
+    // which invokes `onTextRun` with the runs the worker shipped beside the
+    // bitmap. Lets a worker-mode test drive the selection overlay from the stub.
+    for (const r of this.feedTextRuns ?? []) opts?.onTextRun?.(r);
     return new Promise<ImageBitmap>((resolve, reject) => {
       const call: RenderCall = {
         page,
@@ -355,6 +365,11 @@ export class FakeDocxEngine {
       this.bitmapCalls.push(call);
       if (!this.deferred) resolve(bmp as unknown as ImageBitmap);
     });
+  }
+  /** IX6 — mode-agnostic run collection for the find scan (mirrors the real
+   *  `DocxDocument.collectPageRuns`). Returns the fed runs regardless of mode. */
+  collectPageRuns(_page: number, _opts?: WireRenderPageOptions): Promise<DocxTextRunInfo[]> {
+    return Promise.resolve([...(this.feedTextRuns ?? [])]);
   }
   /** The per-call `width` (px) recorded for every renderPage call, in call order.
    *  T3 asserts each mounted page received its OWN px width. */

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1010,11 +1010,12 @@ describe('DocxScrollViewer — text selection (T5)', () => {
     v.destroy();
   });
 
-  it('worker mode: warns once and builds no overlay spans', async () => {
+  it('worker mode: builds an overlay span per run (IX6, no warning)', async () => {
     installDom();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const container = makeContainer(200, 400);
     const engine = new FakeDocxEngine(3, [{ widthPt: 100, heightPt: 200 }], 'worker');
+    engine.feedTextRuns = [RUN];
     const v = new DocxScrollViewer(container as unknown as HTMLElement, {
       document: engine.asDoc(),
       enableTextSelection: true,
@@ -1023,17 +1024,24 @@ describe('DocxScrollViewer — text selection (T5)', () => {
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
     v.relayout();
+    // The overlay is built in the renderPageToBitmap resolution microtask; give
+    // the bitmap promise chain a couple of turns to settle.
     await Promise.resolve();
     await Promise.resolve();
-    // Warned exactly once with the same wording as DocxViewer, across every
-    // mounted slot's render.
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0][0]).toMatch(/text selection is unavailable in mode: 'worker'/);
-    // No renderPage (worker path only) and no overlay spans anywhere.
+    await Promise.resolve();
+    // IX6 — worker mode no longer warns; the runs ride back beside the bitmap so
+    // the overlay is populated identically to main mode.
+    expect(warn).not.toHaveBeenCalled();
+    // The worker path (renderPageToBitmap), NOT renderPage, was used.
     expect(engine.renderCalls.length).toBe(0);
+    expect(engine.bitmapCalls.length).toBeGreaterThan(0);
+    // Every mounted slot got its overlay built from the worker-shipped runs.
+    const mounted = v.mountedPageIndicesForTest();
+    expect(mounted.length).toBeGreaterThan(0);
     for (const wrapper of scrollHost.children.filter((c) => c.children.some((k) => k.tag === 'canvas'))) {
       const textLayer = wrapper.children.find((c) => c.tag === 'div') as FakeEl;
-      expect(textLayer.children.length).toBe(0);
+      expect(textLayer.children.length).toBe(1);
+      expect(textLayer.children[0].textContent).toBe('Hi');
     }
     warn.mockRestore();
     v.destroy();

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -67,9 +67,10 @@ export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onText
   paddingRight?: number;
   /** Pages kept mounted beyond the viewport on each side. Default 1. */
   overscan?: number;
-  /** Per-page transparent text-selection overlay. MAIN render mode only:
-   *  in worker mode `onTextRun` cannot cross the worker boundary, so the overlay
-   *  stays empty and the viewer logs one warning (design §11). */
+  /** Per-page transparent text-selection overlay. IX6 — works in BOTH render
+   *  modes: in worker mode the per-run geometry is collected off-thread and
+   *  shipped back beside the page bitmap, so the overlay is populated identically
+   *  to main mode (no more empty overlay / one-time warning). */
   enableTextSelection?: boolean;
   /** Minimum zoom scale (px-per-pt multiplier floor). Default 0.1. */
   zoomMin?: number;
@@ -133,7 +134,8 @@ export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onText
 }
 
 /** One mounted page. `canvas` is the drawn page; `textLayer` the optional
- *  per-page selection overlay (main mode only). `renderedPage` guards against
+ *  per-page selection overlay (both render modes — IX6 ships the worker's run
+ *  geometry back beside the bitmap). `renderedPage` guards against
  *  re-rendering a recycled slot for a page whose render is still in flight. */
 interface PageSlot {
   wrapper: HTMLDivElement;
@@ -251,11 +253,6 @@ export class DocxScrollViewer implements ZoomableViewer {
    *  is host-agnostic. */
   private _settleTimer: ReturnType<typeof setTimeout> | null = null;
   private _wheelListener: ((e: WheelEvent) => void) | null = null;
-  /** One-shot latch for the worker-mode text-selection warning. The overlay is a
-   *  main-mode-only feature: in worker mode the per-run `onTextRun` geometry
-   *  cannot cross the worker boundary, so an `enableTextSelection` overlay stays
-   *  empty. We warn once (parity with `DocxViewer`) rather than per slot. */
-  private _warnedNoTextSelection = false;
   /** Observes the container so a width change re-fits the base scale. Disconnected
    *  in `destroy()`. */
   private _resizeObserver: ResizeObserver | null = null;
@@ -794,18 +791,6 @@ export class DocxScrollViewer implements ZoomableViewer {
       });
   }
 
-  /** Warn once when an `enableTextSelection` overlay was requested but the render
-   *  mode is `worker` (so the overlay stays empty). Same wording as
-   *  `DocxViewer._render` — one warning per viewer, not per slot. */
-  private _maybeWarnNoTextSelection(): void {
-    if (this._opts.enableTextSelection && !this._warnedNoTextSelection) {
-      this._warnedNoTextSelection = true;
-      console.warn(
-        "[ooxml] text selection is unavailable in mode: 'worker'; the overlay will be empty. Use mode: 'main' for selectable text.",
-      );
-    }
-  }
-
   /**
    * IX1/IX-nav — the click handler passed to the text-layer overlay. When the
    * caller supplied `onHyperlinkClick`, it fully owns the behaviour (the default
@@ -868,11 +853,6 @@ export class DocxScrollViewer implements ZoomableViewer {
     dpr: number,
     scale: number,
   ): Promise<void> {
-    // Worker-mode + enableTextSelection: the overlay can't be populated (onTextRun
-    // doesn't cross the worker boundary), so warn once (parity with DocxViewer)
-    // and leave the overlay empty. Fires before the coalescing guards so it is
-    // reported even when this particular dispatch is coalesced/dropped.
-    this._maybeWarnNoTextSelection();
     if (this._bitmapInFlight.has(i)) return; // coalesce: already dispatched
     // Drop-stale before dispatch: if this page already scrolled out of the
     // mounted window, don't dispatch at all.
@@ -891,12 +871,19 @@ export class DocxScrollViewer implements ZoomableViewer {
     if (!slot.bitmapCtx) {
       slot.bitmapCtx = slot.canvas.getContext('bitmaprenderer') as ImageBitmapRenderingContext | null;
     }
+    // IX6 — harvest the page's run geometry alongside the bitmap so the
+    // worker-mode selection overlay is built from the SAME data main mode uses.
+    // The runs ride back beside the bitmap (one round-trip), collected only when
+    // an overlay is actually wanted.
+    const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
+    const runs: DocxTextRunInfo[] = [];
     try {
       const bmp = await this._doc!.renderPageToBitmap(i, {
         width: widthPx,
         dpr,
         defaultTextColor: this._opts.defaultTextColor,
         showTrackChanges: this._opts.showTrackChanges,
+        onTextRun: wantOverlay ? (r) => runs.push(r) : undefined,
       });
       // Stale if EITHER (a) the epoch moved (a setScale rescaled mid-flight, so
       // this bitmap is at a superseded resolution — this catches the case where
@@ -924,6 +911,26 @@ export class DocxScrollViewer implements ZoomableViewer {
       // This bitmap now defines the scale the on-screen canvas lives at, so a
       // later zoom preview stretches from HERE (design §7 renderedScale).
       slot.renderedScale = scale;
+      // IX6 — build the selection overlay from the runs the worker just shipped.
+      // Reached only past the staleness gate, so the geometry matches THIS paint
+      // (same epoch guard the main-mode path relies on for stale-scale safety).
+      // Clear any preview transform first: a settle re-render lands at the
+      // current scale, so the overlay's `scale()` from `_previewSlot` is stale
+      // and the rebuilt spans already sit at the crisp geometry (mirrors the
+      // main-mode `_settleSlot` clear).
+      if (slot.textLayer) {
+        slot.textLayer.style.transform = '';
+        slot.textLayer.style.transformOrigin = '';
+        if (wantOverlay) {
+          buildDocxTextLayer(
+            slot.textLayer,
+            runs,
+            slot.canvas.style.width || `${slot.canvas.width}px`,
+            slot.canvas.style.height || `${slot.canvas.height}px`,
+            this._hyperlinkHandler(),
+          );
+        }
+      }
       painted = true;
     } catch (err) {
       this._reportRenderError(err);
@@ -1195,12 +1202,11 @@ export class DocxScrollViewer implements ZoomableViewer {
 
   /** Full-resolution settle re-render of the visible window (design §7 mechanisms
    *  2+3). Re-renders each mounted slot at the current scale via the double-buffer
-   *  swap (main) / same-canvas transfer (worker). Main mode also rebuilds the text
-   *  overlay and clears its preview transform; in worker mode the overlay is
-   *  permanently empty (text selection is main-mode-only), so the transform is
-   *  inert there and is reset on recycle. Dispatched at the CURRENT epoch; the
-   *  existing epoch gate discards it if a later `setScale` supersedes it
-   *  mid-render. */
+   *  swap (main) / same-canvas transfer (worker). Both modes rebuild the text
+   *  overlay from the fresh render's run geometry (IX6 — worker mode collects the
+   *  runs off-thread via `_renderSlotBitmap`) and clear the preview transform.
+   *  Dispatched at the CURRENT epoch; the existing epoch gate discards it if a
+   *  later `setScale` supersedes it mid-render. */
   private _settleRender(): void {
     if (this._destroyed || !this._doc || this._doc.pageCount === 0) return;
     for (const [i, slot] of [...this._slots]) {

--- a/packages/docx/src/text-layer.ts
+++ b/packages/docx/src/text-layer.ts
@@ -8,8 +8,9 @@ import type { HyperlinkTarget } from '@silurus/ooxml-core';
  * lands on the drawn glyphs. Extracted verbatim from `DocxViewer._buildTextLayer`
  * so both the pager (DocxViewer) and the continuous-scroll viewer (DocxScrollViewer)
  * share one implementation; also public API for integrators building their own
- * overlay (design §10). MAIN render mode only — `onTextRun` cannot cross the
- * worker boundary.
+ * overlay (design §10). IX6 — usable in BOTH render modes: worker mode collects
+ * the same `DocxTextRunInfo[]` off-thread and ships it back beside the bitmap, so
+ * the overlay is built from identical geometry regardless of thread.
  *
  * @param layer            the overlay div (position:relative parent expected).
  * @param runs             per-run geometry from `renderPage({ onTextRun })`.

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -78,9 +78,6 @@ export class DocxViewer implements ZoomableViewer {
    *  holds one context type for its lifetime; the main-mode 2d render path is
    *  never used on the same canvas). */
   private _bitmapCtx: ImageBitmapRenderingContext | null = null;
-  private _warnedNoTextSelection = false;
-  /** One-shot guard so the worker-mode findText warning prints once. */
-  private _warnedNoFind = false;
   /** Set by {@link destroy} (first line). Guards {@link _reportRenderError} so a
    *  render rejection that lands AFTER teardown is swallowed rather than surfaced
    *  to an `onError` / `console.error` on a dead viewer — parity with the scroll
@@ -145,8 +142,8 @@ export class DocxViewer implements ZoomableViewer {
 
     // IX2 — the find-highlight overlay layer. Appended last so it stacks above
     // the text/selection layer; `pointer-events:none` keeps selection + link
-    // clicks working through it. In worker mode `onTextRun` can't fire, so it
-    // stays empty (find is main-mode only, warned at find() time).
+    // clicks working through it. IX6 — populated in BOTH render modes (worker
+    // mode ships the run geometry back beside the bitmap).
     this._highlightLayer = document.createElement('div');
     this._highlightLayer.style.cssText =
       'position:absolute;top:0;left:0;width:100%;height:100%;' +
@@ -352,26 +349,17 @@ export class DocxViewer implements ZoomableViewer {
    * `{ page }` (0-based). Case-insensitive by default (browser find-in-page);
    * pass `{ caseSensitive: true }` to match case exactly.
    *
-   * Scans all pages, so a large document renders each page once offscreen to
-   * read its text (the visible page reuses its on-screen render). Not available
-   * in `mode: 'worker'` (the `onTextRun` stream can't cross the worker boundary)
-   * — returns `[]` there after a one-time warning. An empty query clears the
-   * find and returns `[]`.
+   * Scans all pages, so a large document renders each page once (offscreen) to
+   * read its text (the visible page reuses its on-screen render). IX6 — works in
+   * BOTH `mode: 'main'` and `mode: 'worker'`: in worker mode each page's run
+   * geometry is collected off-thread and shipped back, so find returns the same
+   * matches on the same code path. An empty query clears the find and returns `[]`.
    */
   async findText(
     query: string,
     opts: FindMatchesOptions = {},
   ): Promise<FindMatch<DocxMatchLocation>[]> {
     if (!this._doc) return [];
-    if (this._mode === 'worker') {
-      if (!this._warnedNoFind) {
-        this._warnedNoFind = true;
-        console.warn(
-          "[ooxml] findText is unavailable in mode: 'worker' (text runs can't cross the worker boundary). Use mode: 'main'.",
-        );
-      }
-      return [];
-    }
     const matches = await this._find.find(query, opts);
     // Redraw the current page's highlights (matches on it become visible without
     // navigating). Cheap DOM geometry — no page re-render.
@@ -493,29 +481,33 @@ export class DocxViewer implements ZoomableViewer {
   private async _renderPage(): Promise<void> {
     if (!this._doc) return;
     const isWorker = this._mode === 'worker';
-    // In worker mode rendering happens off the main thread, so the onTextRun
-    // callback can't fire — the text-selection overlay is unavailable.
-    if (isWorker && this._textLayer && !this._warnedNoTextSelection) {
-      this._warnedNoTextSelection = true;
-      console.warn(
-        "[ooxml] text selection is unavailable in mode: 'worker'; the overlay will be empty. Use mode: 'main' for selectable text.",
-      );
-    }
     // IX9: the width to render at. When no zoom method was ever called
     // (`_scale === null`) this is exactly `opts.width` (pre-IX9 path, byte-
     // identical default); once a zoom latched a factor it is `naturalWidth ×
     // scale`.
     const renderWidth = this._renderWidth();
+    // Collect runs unconditionally (not just when a text layer exists): the
+    // find-highlight overlay needs the current page's run geometry too, and
+    // caching them here means find() reuses the visible render for this page
+    // instead of re-rendering it offscreen. IX6 — in worker mode the runs ride
+    // back beside the bitmap, so both modes populate the same `runs` array,
+    // at the zoom-aware `renderWidth` (the geometry follows setScale).
+    const runs: DocxTextRunInfo[] = [];
+    const onTextRun = (r: DocxTextRunInfo) => runs.push(r);
     if (isWorker) {
       const dpr = this._opts.dpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
       // Only serializable render options may cross to the worker — spreading the
       // full viewer opts would postMessage non-cloneable values (the math
-      // engine, callbacks, container element) and throw a DataCloneError.
+      // engine, callbacks, container element) and throw a DataCloneError. The
+      // `onTextRun` callback stays main-thread; the proxy invokes it with the
+      // worker's returned runs (IX6).
       const bmp = await this._doc.renderPageToBitmap(this._currentPage, {
         width: renderWidth,
         dpr: this._opts.dpr,
         defaultTextColor: this._opts.defaultTextColor,
         showTrackChanges: this._opts.showTrackChanges,
+        currentDate: this._opts.currentDate,
+        onTextRun,
       });
       this._canvas.width = bmp.width;
       this._canvas.height = bmp.height;
@@ -525,21 +517,17 @@ export class DocxViewer implements ZoomableViewer {
       this._canvas.style.height = `${Math.round(bmp.height / dpr)}px`;
       this._bitmapCtx?.transferFromImageBitmap(bmp);
     } else {
-      // Collect runs unconditionally (not just when a text layer exists): the
-      // find-highlight overlay needs the current page's run geometry too, and
-      // caching them here means find() reuses the visible render for this page
-      // instead of re-rendering it offscreen.
-      const runs: DocxTextRunInfo[] = [];
-      const onTextRun = (r: DocxTextRunInfo) => runs.push(r);
       await this._doc.renderPage(this._canvas, this._currentPage, { ...this._opts, width: renderWidth, onTextRun });
-      if (this._textLayer) {
-        this._buildTextLayer(this._textLayer, runs);
-      }
-      // Feed the just-rendered page's runs to the find controller so highlight
-      // geometry matches exactly what was drawn, then (re)draw the highlights.
-      this._find.setPageRuns(this._currentPage, runs);
-      this._buildHighlightLayer(runs);
     }
+    // IX6 — identical overlay build for both modes: the run geometry the worker
+    // shipped is the same shape `onTextRun` emits in main mode.
+    if (this._textLayer) {
+      this._buildTextLayer(this._textLayer, runs);
+    }
+    // Feed the just-rendered page's runs to the find controller so highlight
+    // geometry matches exactly what was drawn, then (re)draw the highlights.
+    this._find.setPageRuns(this._currentPage, runs);
+    this._buildHighlightLayer(runs);
     this._opts.onPageChange?.(this._currentPage, this.pageCount);
   }
 
@@ -578,19 +566,22 @@ export class DocxViewer implements ZoomableViewer {
    *  (text + geometry) for search, without touching the visible canvas. Used by
    *  the find controller for pages other than the one on screen. */
   private async _collectPageRuns(page: number): Promise<DocxTextRunInfo[]> {
-    if (!this._doc || this._mode === 'worker') return [];
-    // The currently displayed page's runs are already cached by _renderPage; the
-    // controller only calls this for other pages.
-    const runs: DocxTextRunInfo[] = [];
-    const off =
-      typeof OffscreenCanvas !== 'undefined'
-        ? new OffscreenCanvas(1, 1)
-        : (document.createElement('canvas') as HTMLCanvasElement);
-    await this._doc.renderPage(off, page, {
-      ...this._opts,
-      onTextRun: (r: DocxTextRunInfo) => runs.push(r),
+    if (!this._doc) return [];
+    // IX6 — `collectPageRuns` renders the page (off-thread in worker mode, to a
+    // throwaway offscreen canvas in main mode) and returns just its run
+    // geometry. The find controller only calls this for pages OTHER than the one
+    // on screen (the visible page's runs are cached by _renderPage). Pass the
+    // same serializable options as the visible render — including the IX9
+    // zoom-aware `_renderWidth()`, so the harvested geometry matches what a
+    // navigation to that page would draw at the current scale (worker mode
+    // postMessages these — no callbacks/engine).
+    return this._doc.collectPageRuns(page, {
+      width: this._renderWidth(),
+      dpr: this._opts.dpr,
+      defaultTextColor: this._opts.defaultTextColor,
+      showTrackChanges: this._opts.showTrackChanges,
+      currentDate: this._opts.currentDate,
     });
-    return runs;
   }
 
   private _buildTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): void {

--- a/packages/docx/src/worker-protocol.ts
+++ b/packages/docx/src/worker-protocol.ts
@@ -1,4 +1,5 @@
 import type { DocComment, DocNote, RenderPageOptions, WorkerResponse } from './types';
+import type { DocxTextRunInfo } from './renderer';
 
 /** Lightweight summary returned by the render worker's `parse` — everything
  *  the main-thread proxy needs for its synchronous getters. The full model
@@ -32,10 +33,19 @@ export type RenderWorkerRequest =
   | { type: 'init'; wasmUrl: string }
   | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number; useGoogleFonts?: boolean }
   | { type: 'renderPage'; id: number; pageIndex: number; opts: WireRenderPageOptions }
+  // IX6 — collect a page's text-run geometry WITHOUT transferring a bitmap. The
+  // find controller scans every page for its runs; a bitmap per page would be
+  // wasted work + transfer for pages the user never looks at.
+  | { type: 'collectRuns'; id: number; pageIndex: number; opts: WireRenderPageOptions }
   | { type: 'extractImage'; id: number; path: string }
   | { type: 'toMarkdown'; id: number };
 
 export type RenderWorkerResponse =
   | Exclude<WorkerResponse, { type: 'parsed' }>
   | { type: 'parsedMeta'; id: number; meta: DocumentMeta }
-  | { type: 'pageRendered'; id: number; bitmap: ImageBitmap };
+  // IX6 — the render worker collects each rendered page's `onTextRun` geometry
+  // (a plain, structured-clone-safe `DocxTextRunInfo[]`) and ships it beside the
+  // bitmap, so the main thread can build the text-selection / find-highlight
+  // overlay on the SAME code path as main mode (no second render).
+  | { type: 'pageRendered'; id: number; bitmap: ImageBitmap; runs: DocxTextRunInfo[] }
+  | { type: 'runsCollected'; id: number; runs: DocxTextRunInfo[] };

--- a/packages/docx/tests/visual/worker-selection-equivalence.spec.ts
+++ b/packages/docx/tests/visual/worker-selection-equivalence.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * IX6 functional worker-equivalence: the text-selection overlay and findText
+ * must produce the SAME result in `mode: 'worker'` as in `mode: 'main'`. The
+ * run geometry is collected off-thread in worker mode and shipped back beside
+ * the bitmap, so the selection spans (text + rounded box) and the findText match
+ * set must be byte-for-byte identical to main mode. This is the functional twin
+ * of the pixel worker-equivalence spec: it fails if a run is dropped on the wire
+ * or findText silently returns `[]` in worker mode (the pre-IX6 behaviour).
+ */
+test('worker mode selection overlay + findText match main mode › demo/sample-1', async ({ page }) => {
+  await page.goto('/tests/visual/worker-selection-fixture.html?docx=demo/sample-1&q=the');
+  await page.waitForFunction(
+    () => document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
+    { timeout: 60_000 },
+  );
+  const status = await page.evaluate(() => document.body.dataset.status);
+  if (status === 'error') {
+    throw new Error(await page.evaluate(() => document.body.dataset.errorMessage ?? ''));
+  }
+
+  const data = await page.evaluate(() => ({
+    mainOverlay: document.body.dataset.mainOverlay ?? '[]',
+    workerOverlay: document.body.dataset.workerOverlay ?? '[]',
+    mainMatches: document.body.dataset.mainMatches ?? '[]',
+    workerMatches: document.body.dataset.workerMatches ?? '[]',
+  }));
+
+  const mainOverlay = JSON.parse(data.mainOverlay) as unknown[];
+  const workerOverlay = JSON.parse(data.workerOverlay) as unknown[];
+  const mainMatches = JSON.parse(data.mainMatches) as unknown[];
+  const workerMatches = JSON.parse(data.workerMatches) as unknown[];
+
+  // The overlay must be non-empty (a real document with selectable text), or the
+  // equivalence below would be a vacuous [] === [].
+  expect(mainOverlay.length).toBeGreaterThan(0);
+  // The selection overlay is identical run-for-run between modes.
+  expect(workerOverlay).toEqual(mainOverlay);
+
+  // findText found real matches in main mode…
+  expect(mainMatches.length).toBeGreaterThan(0);
+  // …and worker mode returns the exact same match set (this is the guard the
+  // pre-IX6 code broke: worker findText returned [] + a console.warn).
+  expect(workerMatches).toEqual(mainMatches);
+});

--- a/packages/docx/tests/visual/worker-selection-equivalence.spec.ts
+++ b/packages/docx/tests/visual/worker-selection-equivalence.spec.ts
@@ -1,46 +1,93 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * IX6 functional worker-equivalence: the text-selection overlay and findText
- * must produce the SAME result in `mode: 'worker'` as in `mode: 'main'`. The
- * run geometry is collected off-thread in worker mode and shipped back beside
- * the bitmap, so the selection spans (text + rounded box) and the findText match
- * set must be byte-for-byte identical to main mode. This is the functional twin
- * of the pixel worker-equivalence spec: it fails if a run is dropped on the wire
- * or findText silently returns `[]` in worker mode (the pre-IX6 behaviour).
+ * IX6 functional worker-equivalence (+ IX9 zoom integration): the
+ * text-selection overlay, the findText match set, and the find-highlight boxes
+ * must be identical in `mode: 'worker'` and `mode: 'main'`, both at the initial
+ * scale AND after a `setScale(1.5)` zoom. The run geometry is collected
+ * off-thread in worker mode and shipped back beside the bitmap, so:
+ *  - the selection spans (text + rounded box) match main mode exactly;
+ *  - findText returns the same match set (the pre-IX6 guard returned `[]`);
+ *  - after setScale(1.5) the render width is exactly natural × 1.5 and the
+ *    overlay/highlight coordinates follow the zoom (worker re-render round-trips
+ *    fresh runs at the new width).
+ * This is the functional twin of the pixel worker-equivalence spec.
  */
-test('worker mode selection overlay + findText match main mode › demo/sample-1', async ({ page }) => {
+
+interface Snap {
+  overlay: { text: string; left: number; top: number }[];
+  highlights: { left: number; top: number; width: number }[];
+  canvasW: number;
+  scale: number;
+  page: number;
+}
+interface ModeData {
+  matches: { text: string; page: number }[];
+  before: Snap;
+  after: Snap;
+}
+
+test('worker selection + findText + zoom match main mode › demo/sample-1', async ({ page }) => {
+  test.setTimeout(120_000);
   await page.goto('/tests/visual/worker-selection-fixture.html?docx=demo/sample-1&q=the');
   await page.waitForFunction(
     () => document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
-    { timeout: 60_000 },
+    { timeout: 90_000 },
   );
   const status = await page.evaluate(() => document.body.dataset.status);
   if (status === 'error') {
     throw new Error(await page.evaluate(() => document.body.dataset.errorMessage ?? ''));
   }
 
-  const data = await page.evaluate(() => ({
-    mainOverlay: document.body.dataset.mainOverlay ?? '[]',
-    workerOverlay: document.body.dataset.workerOverlay ?? '[]',
-    mainMatches: document.body.dataset.mainMatches ?? '[]',
-    workerMatches: document.body.dataset.workerMatches ?? '[]',
+  const raw = await page.evaluate(() => ({
+    main: document.body.dataset.main ?? '{}',
+    worker: document.body.dataset.worker ?? '{}',
   }));
+  const main = JSON.parse(raw.main) as ModeData;
+  const worker = JSON.parse(raw.worker) as ModeData;
 
-  const mainOverlay = JSON.parse(data.mainOverlay) as unknown[];
-  const workerOverlay = JSON.parse(data.workerOverlay) as unknown[];
-  const mainMatches = JSON.parse(data.mainMatches) as unknown[];
-  const workerMatches = JSON.parse(data.workerMatches) as unknown[];
+  // --- findText: real matches, identical across modes (the pre-IX6 worker
+  // guard returned [] + console.warn — this is the regression tripwire).
+  expect(main.matches.length).toBeGreaterThan(0);
+  expect(worker.matches).toEqual(main.matches);
 
-  // The overlay must be non-empty (a real document with selectable text), or the
-  // equivalence below would be a vacuous [] === [].
-  expect(mainOverlay.length).toBeGreaterThan(0);
-  // The selection overlay is identical run-for-run between modes.
-  expect(workerOverlay).toEqual(mainOverlay);
+  // --- initial scale: overlay + highlight parity (non-empty — findNext
+  // navigated to the first match's page, so highlight boxes must exist).
+  expect(main.before.overlay.length).toBeGreaterThan(0);
+  expect(worker.before.overlay).toEqual(main.before.overlay);
+  expect(main.before.highlights.length).toBeGreaterThan(0);
+  expect(worker.before.highlights).toEqual(main.before.highlights);
+  expect(worker.before.page).toBe(main.before.page);
 
-  // findText found real matches in main mode…
-  expect(mainMatches.length).toBeGreaterThan(0);
-  // …and worker mode returns the exact same match set (this is the guard the
-  // pre-IX6 code broke: worker findText returned [] + a console.warn).
-  expect(workerMatches).toEqual(mainMatches);
+  // --- IX9 zoom in worker mode: scale latched, render width = natural × 1.5.
+  expect(worker.after.scale).toBe(1.5);
+  expect(main.after.scale).toBe(1.5);
+  // naturalWidth = beforeW / beforeScale (getScale() before any zoom is the
+  // effective opts.width / natural factor), so the post-zoom canvas must be
+  // round(natural × 1.5) — allow ±1 for the two roundings involved.
+  const naturalPx = worker.before.canvasW / worker.before.scale;
+  expect(Math.abs(worker.after.canvasW - naturalPx * 1.5)).toBeLessThanOrEqual(1);
+  expect(worker.after.canvasW).toBe(main.after.canvasW);
+
+  // --- post-zoom parity: overlay + highlights identical across modes.
+  expect(main.after.overlay.length).toBeGreaterThan(0);
+  expect(worker.after.overlay).toEqual(main.after.overlay);
+  expect(main.after.highlights.length).toBeGreaterThan(0);
+  expect(worker.after.highlights).toEqual(main.after.highlights);
+
+  // --- the worker overlay/highlight coordinates FOLLOW the zoom: every box
+  // scaled by (1.5 / beforeScale) within a small rounding tolerance.
+  const ratio = 1.5 / worker.before.scale;
+  const follow = (before: number, after: number) =>
+    Math.abs(after - before * ratio) <= 3;
+  expect(worker.after.overlay.length).toBe(worker.before.overlay.length);
+  for (let i = 0; i < worker.before.overlay.length; i++) {
+    expect(follow(worker.before.overlay[i].left, worker.after.overlay[i].left)).toBe(true);
+    expect(follow(worker.before.overlay[i].top, worker.after.overlay[i].top)).toBe(true);
+  }
+  expect(worker.after.highlights.length).toBe(worker.before.highlights.length);
+  for (let i = 0; i < worker.before.highlights.length; i++) {
+    expect(follow(worker.before.highlights[i].left, worker.after.highlights[i].left)).toBe(true);
+    expect(follow(worker.before.highlights[i].top, worker.after.highlights[i].top)).toBe(true);
+  }
 });

--- a/packages/docx/tests/visual/worker-selection-fixture.html
+++ b/packages/docx/tests/visual/worker-selection-fixture.html
@@ -6,10 +6,12 @@
 </head>
 <body>
   <!-- IX6 functional worker-equivalence: build a real DocxViewer in BOTH main
-       and worker mode, capture the text-selection overlay DOM (one span per run)
-       and the findText match set, then expose both so the spec can assert
-       main === worker. Proves the run geometry crosses the worker boundary
-       identically (selection) and that findText works in worker mode. -->
+       and worker mode, capture the text-selection overlay DOM (one span per run),
+       the findText match set, and the find-highlight boxes, then zoom (IX9
+       setScale) and capture again — so the spec can assert main === worker at
+       BOTH scales and that the overlay/highlight geometry follows the zoom.
+       Proves the run geometry crosses the worker boundary identically and that
+       findText + zoom work in worker mode. -->
   <div id="main-host"></div>
   <div id="worker-host"></div>
   <script type="module">
@@ -19,14 +21,20 @@
     const name = params.get('docx') ?? 'demo/sample-1';
     const query = params.get('q') ?? 'the';
     const width = 900;
+    const ZOOM = 1.5;
 
     // Serialize the text-selection overlay: one entry per span, rounded so
     // sub-pixel rasterization jitter between the main <canvas> and the worker
     // OffscreenCanvas cannot spuriously fail an exact-equality assertion. The
     // run GEOMETRY is computed identically in both modes (same renderer), so the
     // rounded boxes must match exactly.
+    const layersOf = (host) => {
+      const wrapper = host.querySelector('div'); // the viewer's positioned wrapper
+      return wrapper ? [...wrapper.children].filter((c) => c.tagName === 'DIV') : [];
+    };
+    // Wrapper stacking order: [canvas, textLayer, highlightLayer].
     const serializeOverlay = (host) => {
-      const layer = host.querySelector('div'); // the viewer's text layer
+      const layer = layersOf(host)[0];
       const spans = layer ? [...layer.querySelectorAll('span')] : [];
       return spans.map((s) => ({
         text: s.textContent,
@@ -34,6 +42,25 @@
         top: Math.round(parseFloat(s.style.top) || 0),
       }));
     };
+    // IX2 highlight boxes (absolutely positioned divs in the LAST layer).
+    const serializeHighlights = (host) => {
+      const layers = layersOf(host);
+      const layer = layers[layers.length - 1];
+      const boxes = layer ? [...layer.children] : [];
+      return boxes.map((b) => ({
+        left: Math.round(parseFloat(b.style.left) || 0),
+        top: Math.round(parseFloat(b.style.top) || 0),
+        width: Math.round(parseFloat(b.style.width) || 0),
+      }));
+    };
+
+    const capture = (host, viewer, canvas) => ({
+      overlay: serializeOverlay(host),
+      highlights: serializeHighlights(host),
+      canvasW: Math.round(parseFloat(canvas.style.width) || canvas.width),
+      scale: viewer.getScale(),
+      page: viewer.currentPage,
+    });
 
     const buildViewer = async (hostId, mode) => {
       const host = document.getElementById(hostId);
@@ -49,13 +76,19 @@
         useGoogleFonts: true,
       });
       await viewer.load(buf);
-      // findText scans every page; capture the match set (count + per-match page).
+      // findText scans every page; findNext navigates to the first match's page
+      // so the current page is guaranteed to carry highlight boxes.
       const matches = await viewer.findText(query);
-      const overlay = serializeOverlay(host);
+      await viewer.findNext();
+      const before = capture(host, viewer, canvas);
+      // IX9 × IX6 — zoom while in the same mode: the re-render (worker: bitmap +
+      // runs round-trip) must rebuild the overlay + highlights at the new scale.
+      await viewer.setScale(ZOOM);
+      const after = capture(host, viewer, canvas);
       return {
-        overlay,
         matches: matches.map((m) => ({ text: m.text, page: m.location.page })),
-        pageCount: viewer.pageCount,
+        before,
+        after,
         viewer,
       };
     };
@@ -64,11 +97,9 @@
       const main = await buildViewer('main-host', 'main');
       const worker = await buildViewer('worker-host', 'worker');
 
-      document.body.dataset.mainOverlay = JSON.stringify(main.overlay);
-      document.body.dataset.workerOverlay = JSON.stringify(worker.overlay);
-      document.body.dataset.mainMatches = JSON.stringify(main.matches);
-      document.body.dataset.workerMatches = JSON.stringify(worker.matches);
-      document.body.dataset.pageCount = String(main.pageCount);
+      const pack = ({ matches, before, after }) => ({ matches, before, after });
+      document.body.dataset.main = JSON.stringify(pack(main));
+      document.body.dataset.worker = JSON.stringify(pack(worker));
 
       main.viewer.destroy();
       worker.viewer.destroy();

--- a/packages/docx/tests/visual/worker-selection-fixture.html
+++ b/packages/docx/tests/visual/worker-selection-fixture.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <style>* { margin: 0; padding: 0; } canvas { display: block; }</style>
+</head>
+<body>
+  <!-- IX6 functional worker-equivalence: build a real DocxViewer in BOTH main
+       and worker mode, capture the text-selection overlay DOM (one span per run)
+       and the findText match set, then expose both so the spec can assert
+       main === worker. Proves the run geometry crosses the worker boundary
+       identically (selection) and that findText works in worker mode. -->
+  <div id="main-host"></div>
+  <div id="worker-host"></div>
+  <script type="module">
+    import { DocxViewer } from '/src/index.ts';
+
+    const params = new URLSearchParams(location.search);
+    const name = params.get('docx') ?? 'demo/sample-1';
+    const query = params.get('q') ?? 'the';
+    const width = 900;
+
+    // Serialize the text-selection overlay: one entry per span, rounded so
+    // sub-pixel rasterization jitter between the main <canvas> and the worker
+    // OffscreenCanvas cannot spuriously fail an exact-equality assertion. The
+    // run GEOMETRY is computed identically in both modes (same renderer), so the
+    // rounded boxes must match exactly.
+    const serializeOverlay = (host) => {
+      const layer = host.querySelector('div'); // the viewer's text layer
+      const spans = layer ? [...layer.querySelectorAll('span')] : [];
+      return spans.map((s) => ({
+        text: s.textContent,
+        left: Math.round(parseFloat(s.style.left) || 0),
+        top: Math.round(parseFloat(s.style.top) || 0),
+      }));
+    };
+
+    const buildViewer = async (hostId, mode) => {
+      const host = document.getElementById(hostId);
+      const canvas = document.createElement('canvas');
+      host.appendChild(canvas);
+      const resp = await fetch(`/${name}.docx`);
+      if (!resp.ok) throw new Error(`fetch ${name}.docx -> ${resp.status}`);
+      const buf = await resp.arrayBuffer();
+      const viewer = new DocxViewer(canvas, {
+        mode,
+        width,
+        enableTextSelection: true,
+        useGoogleFonts: true,
+      });
+      await viewer.load(buf);
+      // findText scans every page; capture the match set (count + per-match page).
+      const matches = await viewer.findText(query);
+      const overlay = serializeOverlay(host);
+      return {
+        overlay,
+        matches: matches.map((m) => ({ text: m.text, page: m.location.page })),
+        pageCount: viewer.pageCount,
+        viewer,
+      };
+    };
+
+    try {
+      const main = await buildViewer('main-host', 'main');
+      const worker = await buildViewer('worker-host', 'worker');
+
+      document.body.dataset.mainOverlay = JSON.stringify(main.overlay);
+      document.body.dataset.workerOverlay = JSON.stringify(worker.overlay);
+      document.body.dataset.mainMatches = JSON.stringify(main.matches);
+      document.body.dataset.workerMatches = JSON.stringify(worker.matches);
+      document.body.dataset.pageCount = String(main.pageCount);
+
+      main.viewer.destroy();
+      worker.viewer.destroy();
+      document.body.dataset.status = 'ready';
+    } catch (err) {
+      document.body.dataset.status = 'error';
+      document.body.dataset.errorMessage = err.message;
+      console.error('[worker-selection-fixture] error:', err);
+    }
+  </script>
+</body>
+</html>

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -1,5 +1,5 @@
 import type { DimOptions, MediaElement, Presentation, WorkerRequest, WorkerResponse } from './types';
-import { renderSlide, dropImageBitmapCache, type TextRunCallback } from './renderer';
+import { renderSlide, dropImageBitmapCache, type TextRunCallback, type PptxTextRunInfo } from './renderer';
 import { createPresentationHandle, type PresentationHandle } from './presentation-handle';
 import { selectNotes } from './notes';
 import { selectHidden } from './hidden';
@@ -55,6 +55,14 @@ export interface RenderSlideToBitmapOptions {
   skipMediaControls?: boolean;
   /** Translucent overlay drawn over the finished slide (hidden-slide dimming). */
   dim?: DimOptions;
+  /**
+   * IX6 — receives the slide's text-run geometry (the same stream `renderSlide`
+   * emits in main mode). Stays main-thread (never crosses the wire); in worker
+   * mode the proxy invokes it with the runs the worker shipped back beside the
+   * bitmap, so a caller builds the selection / find overlay on the SAME code
+   * path in both modes.
+   */
+  onTextRun?: TextRunCallback;
 }
 
 /** Options for rendering a single slide onto a canvas. */
@@ -384,11 +392,46 @@ export class PptxPresentation {
       const res = await this._bridge.request(
         (id) => ({ kind: 'renderSlide', id, slideIndex, width, dpr, skipMediaControls: opts.skipMediaControls, dim: opts.dim }) satisfies RenderWorkerRequest,
       );
-      return (res as Extract<RenderWorkerResponse, { kind: 'slideRendered' }>).bitmap;
+      const rendered = res as Extract<RenderWorkerResponse, { kind: 'slideRendered' }>;
+      // IX6 — replay the worker's run geometry to the caller's collector so the
+      // selection / find overlay is built on the same path as main mode.
+      if (opts.onTextRun) for (const r of rendered.runs) opts.onTextRun(r);
+      return rendered.bitmap;
     }
     const off = new OffscreenCanvas(1, 1);
-    await this.renderSlide(off, slideIndex, { width, dpr, skipMediaControls: opts.skipMediaControls, dim: opts.dim });
+    await this.renderSlide(off, slideIndex, {
+      width,
+      dpr,
+      skipMediaControls: opts.skipMediaControls,
+      dim: opts.dim,
+      onTextRun: opts.onTextRun,
+    });
     return off.transferToImageBitmap();
+  }
+
+  /**
+   * IX6 — collect a slide's text-run geometry (`PptxTextRunInfo[]`) without
+   * painting a visible canvas. Works in BOTH modes: worker mode renders the
+   * slide off-thread and ships only the runs (no bitmap transfer); main mode
+   * renders to a throwaway offscreen canvas. Used by the find controller to scan
+   * every slide for matches. Run geometry is in CSS px (independent of dpr) and
+   * dimming does not move glyphs, so only `width` is threaded — matching the
+   * historical main-mode `_collectSlideRuns`.
+   */
+  async collectSlideRuns(slideIndex: number, width = 960): Promise<PptxTextRunInfo[]> {
+    if (this._mode === 'worker') {
+      if (!Number.isInteger(slideIndex) || slideIndex < 0 || slideIndex >= this.slideCount) {
+        throw new Error(`Slide index ${slideIndex} out of range (count: ${this.slideCount})`);
+      }
+      const res = await this._bridge.request(
+        (id) => ({ kind: 'collectRuns', id, slideIndex, width }) satisfies RenderWorkerRequest,
+      );
+      return (res as Extract<RenderWorkerResponse, { kind: 'runsCollected' }>).runs;
+    }
+    const runs: PptxTextRunInfo[] = [];
+    const off = new OffscreenCanvas(1, 1);
+    await this.renderSlide(off, slideIndex, { width, onTextRun: (r) => runs.push(r) });
+    return runs;
   }
 
   /**
@@ -482,19 +525,14 @@ export class PptxPresentation {
     const dpr = opts.dpr ?? defaultDpr();
     const width = opts.width ?? (canvas.offsetWidth || 960);
 
-    if (this._mode === 'worker' && opts.onTextRun) {
-      // The callback can't cross the worker boundary.
-      console.warn(
-        "[ooxml] onTextRun is unavailable in mode: 'worker'; the text selection overlay will be empty for this slide.",
-      );
-    }
-
     const drawBase =
       this._mode === 'worker'
         ? async () => {
             // Whole slide rendered off-thread; the handle snapshots this paint
             // into its own base copy, so the bitmap can be closed right after.
-            const bmp = await this.renderSlideToBitmap(slideIndex, { width, dpr, skipMediaControls: true, dim: opts.dim });
+            // IX6 — the run geometry rides back beside the bitmap, so a media
+            // slide is as selectable/searchable in worker mode as in main mode.
+            const bmp = await this.renderSlideToBitmap(slideIndex, { width, dpr, skipMediaControls: true, dim: opts.dim, onTextRun: opts.onTextRun });
             canvas.width = bmp.width;
             canvas.height = bmp.height;
             // Set only the CSS width and let height follow the intrinsic aspect

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -11,7 +11,7 @@
  */
 import type { MediaElement, Presentation } from './types';
 import init, { PptxArchive, reinit } from './wasm/pptx_parser.js';
-import { renderSlide } from './renderer';
+import { renderSlide, type PptxTextRunInfo } from './renderer';
 import { selectNotes } from './notes';
 import { findMimeTypeForPath } from './media-mime';
 import { PPTX_GOOGLE_FONTS, pptxFontPreloadNames } from './google-fonts';
@@ -138,6 +138,10 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
       if (!slide) throw new Error(`Slide index ${req.slideIndex} out of range (count: ${pres.slides.length})`);
       await fontsLoaded;
       const canvas = new OffscreenCanvas(1, 1); // renderSlide resizes it
+      // IX6 — collect the run geometry the same render emits so the main thread
+      // can build its selection / find overlay without a second render. The
+      // callback runs worker-side; only the resulting plain array crosses back.
+      const runs: PptxTextRunInfo[] = [];
       await renderSlide(canvas, slide, pres.slideWidth, pres.slideHeight, {
         width: req.width,
         dpr: req.dpr,
@@ -151,9 +155,34 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         dim: req.dim,
         // math intentionally omitted: MathJax needs a DOM <script>; worker
         // mode skips equations (documented in the design spec).
-      });
+      }, (r) => runs.push(r));
       const bitmap = canvas.transferToImageBitmap();
-      post({ kind: 'slideRendered', id: req.id, bitmap }, [bitmap]);
+      post({ kind: 'slideRendered', id: req.id, bitmap, runs }, [bitmap]);
+      return;
+    }
+    if (req.kind === 'collectRuns') {
+      // IX6 — render a slide purely to harvest its text-run geometry (find scans
+      // every slide). The bitmap is discarded worker-side; only `runs` crosses
+      // the wire. Same renderer / width as the main-mode `_collectSlideRuns`, so
+      // the geometry is identical to what a `renderSlide` of the same slide draws
+      // (no dpr / dim needed: run geometry is in CSS px, independent of dpr, and
+      // dimming does not move glyphs — matching main-mode `_collectSlideRuns`).
+      if (!pres) throw new Error('No pptx loaded');
+      const slide = pres.slides[req.slideIndex];
+      if (!slide) throw new Error(`Slide index ${req.slideIndex} out of range (count: ${pres.slides.length})`);
+      await fontsLoaded;
+      const canvas = new OffscreenCanvas(1, 1);
+      const runs: PptxTextRunInfo[] = [];
+      await renderSlide(canvas, slide, pres.slideWidth, pres.slideHeight, {
+        width: req.width,
+        defaultTextColor: pres.defaultTextColor,
+        majorFont: pres.majorFont,
+        minorFont: pres.minorFont,
+        hlinkColor: pres.hlinkColor ?? null,
+        fetchMedia: getMedia,
+        fetchImage: getImage,
+      }, (r) => runs.push(r));
+      post({ kind: 'runsCollected', id: req.id, runs });
       return;
     }
 

--- a/packages/pptx/src/scroll-viewer-test-dom.ts
+++ b/packages/pptx/src/scroll-viewer-test-dom.ts
@@ -281,9 +281,12 @@ export class FakePptxEngine {
   renderCalls: RenderCall[] = [];
   bitmapCalls: RenderCall[] = [];
   createdBitmaps: Array<{ width: number; height: number; close: ReturnType<typeof vi.fn> }> = [];
-  /** Runs fed to `renderSlide`'s `onTextRun` (main mode only) so a test can drive
-   *  the viewer's per-slot text overlay (buildPptxTextLayer) without a real
-   *  render. Empty/undefined ⇒ no runs emitted. */
+  /** Runs fed to the `onTextRun` callback of `renderSlide` (main) /
+   *  `renderSlideToBitmap` (worker) and returned by `collectSlideRuns`, so a test
+   *  can drive the viewer's per-slot text overlay (buildPptxTextLayer) and find
+   *  scan without a real render. Empty/undefined ⇒ no runs emitted. IX6 — the
+   *  worker path now ships runs back beside the bitmap, so the stub mirrors that
+   *  by replaying `feedTextRuns` to `renderSlideToBitmap`'s `onTextRun` too. */
   feedTextRuns?: PptxTextRunInfo[];
   constructor(
     private _slideCount: number,
@@ -343,6 +346,10 @@ export class FakePptxEngine {
     const h = this.slideWidth > 0 ? Math.round((w * this.slideHeight) / this.slideWidth) : 0;
     const bmp = { width: w, height: h, close: vi.fn() };
     this.createdBitmaps.push(bmp);
+    // IX6 — replay fed runs to the caller's collector, mirroring the real proxy
+    // which invokes `onTextRun` with the runs the worker shipped beside the
+    // bitmap. Lets a worker-mode test drive the selection overlay from the stub.
+    for (const r of this.feedTextRuns ?? []) opts?.onTextRun?.(r);
     return new Promise<ImageBitmap>((resolve, reject) => {
       const call: RenderCall = {
         slide,
@@ -353,6 +360,11 @@ export class FakePptxEngine {
       this.bitmapCalls.push(call);
       if (!this.deferred) resolve(bmp as unknown as ImageBitmap);
     });
+  }
+  /** IX6 — mode-agnostic run collection for the find scan (mirrors the real
+   *  `PptxPresentation.collectSlideRuns`). Returns the fed runs regardless of mode. */
+  collectSlideRuns(_slide: number, _width?: number): Promise<PptxTextRunInfo[]> {
+    return Promise.resolve([...(this.feedTextRuns ?? [])]);
   }
   /** The per-call `width` (px) recorded for every renderSlide call, in call order.
    *  T3 asserts each mounted slide received its OWN px width. */

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1155,11 +1155,12 @@ describe('PptxScrollViewer — text selection (T5)', () => {
     v.destroy();
   });
 
-  it('worker mode: warns once and builds no overlay spans', async () => {
+  it('worker mode: builds a shape div with a nested run span (IX6, no warning)', async () => {
     installDom();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const container = makeContainer(200, 400);
     const engine = new FakePptxEngine(3, SLIDE_W_EMU, SLIDE_H_EMU, 'worker');
+    engine.feedTextRuns = [RUN];
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
       enableTextSelection: true,
@@ -1168,17 +1169,28 @@ describe('PptxScrollViewer — text selection (T5)', () => {
     const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
     scrollHost.clientHeight = 400;
     v.relayout();
+    // The overlay is built in the renderSlideToBitmap resolution microtask; give
+    // the bitmap promise chain a couple of turns to settle.
     await Promise.resolve();
     await Promise.resolve();
-    // Warned exactly once with the same wording as PptxViewer, across every
-    // mounted slot's render.
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0][0]).toMatch(/text selection is unavailable in mode: 'worker'/);
-    // No renderSlide (worker path only) and no overlay children anywhere.
+    await Promise.resolve();
+    // IX6 — worker mode no longer warns; the runs ride back beside the bitmap so
+    // the overlay is populated identically to main mode.
+    expect(warn).not.toHaveBeenCalled();
+    // The worker path (renderSlideToBitmap), NOT renderSlide, was used.
     expect(engine.renderCalls.length).toBe(0);
+    expect(engine.bitmapCalls.length).toBeGreaterThan(0);
+    const mounted = v.mountedSlideIndicesForTest();
+    expect(mounted.length).toBeGreaterThan(0);
     for (const wrapper of scrollHost.children.filter((c) => c.children.some((k) => k.tag === 'canvas'))) {
       const textLayer = wrapper.children.find((c) => c.tag === 'div') as FakeEl;
-      expect(textLayer.children.length).toBe(0);
+      // Same nesting as main mode: textLayer → shape <div> → run <span>.
+      expect(textLayer.children.length).toBe(1);
+      const shapeDiv = textLayer.children[0] as FakeEl;
+      expect(shapeDiv.tag).toBe('div');
+      expect(shapeDiv.children.length).toBe(1);
+      expect(shapeDiv.children[0].tag).toBe('span');
+      expect(shapeDiv.children[0].textContent).toBe('Hi');
     }
     warn.mockRestore();
     v.destroy();

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -70,9 +70,10 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
   paddingRight?: number;
   /** Slides kept mounted beyond the viewport on each side. Default 1. */
   overscan?: number;
-  /** Per-slide transparent text-selection overlay. MAIN render mode only:
-   *  in worker mode `onTextRun` cannot cross the worker boundary, so the overlay
-   *  stays empty and the viewer logs one warning (design §11). */
+  /** Per-slide transparent text-selection overlay. IX6 — works in BOTH render
+   *  modes: in worker mode the per-run geometry is collected off-thread and
+   *  shipped back beside the slide bitmap, so the overlay is populated identically
+   *  to main mode (no more empty overlay / one-time warning). */
   enableTextSelection?: boolean;
   /** Minimum zoom scale — a DIMENSIONLESS multiplier over the 96-dpi natural
    *  slide size (10% = 0.1), matching `DocxScrollViewer`. Default 0.1. */
@@ -143,7 +144,8 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
 }
 
 /** One mounted slide. `canvas` is the drawn slide; `textLayer` the optional
- *  per-slide selection overlay (main mode only). `renderedSlide` guards against
+ *  per-slide selection overlay (both render modes — IX6 ships the worker's run
+ *  geometry back beside the bitmap). `renderedSlide` guards against
  *  re-rendering a recycled slot for a slide whose render is still in flight. */
 interface SlideSlot {
   wrapper: HTMLDivElement;
@@ -265,11 +267,6 @@ export class PptxScrollViewer implements ZoomableViewer {
    *  is host-agnostic. */
   private _settleTimer: ReturnType<typeof setTimeout> | null = null;
   private _wheelListener: ((e: WheelEvent) => void) | null = null;
-  /** One-shot latch for the worker-mode text-selection warning. The overlay is a
-   *  main-mode-only feature: in worker mode the per-run `onTextRun` geometry
-   *  cannot cross the worker boundary, so an `enableTextSelection` overlay stays
-   *  empty. We warn once (parity with `PptxViewer`) rather than per slot. */
-  private _warnedNoTextSelection = false;
   /** Observes the container so a width change re-fits the base scale. Disconnected
    *  in `destroy()`. */
   private _resizeObserver: ResizeObserver | null = null;
@@ -805,18 +802,6 @@ export class PptxScrollViewer implements ZoomableViewer {
       });
   }
 
-  /** Warn once when an `enableTextSelection` overlay was requested but the render
-   *  mode is `worker` (so the overlay stays empty). Same wording as
-   *  `PptxViewer` — one warning per viewer, not per slot. */
-  private _maybeWarnNoTextSelection(): void {
-    if (this._opts.enableTextSelection && !this._warnedNoTextSelection) {
-      this._warnedNoTextSelection = true;
-      console.warn(
-        "[ooxml] text selection is unavailable in mode: 'worker'; the overlay will be empty. Use mode: 'main' for selectable text.",
-      );
-    }
-  }
-
   /** Route an async render failure to `onError`, or `console.error` when none is
    *  set (so failures are never fully silent), and never after teardown. */
   private _reportRenderError(err: unknown): void {
@@ -858,11 +843,6 @@ export class PptxScrollViewer implements ZoomableViewer {
     dpr: number,
     scale: number,
   ): Promise<void> {
-    // Worker-mode + enableTextSelection: the overlay can't be populated (onTextRun
-    // doesn't cross the worker boundary), so warn once (parity with PptxViewer)
-    // and leave the overlay empty. Fires before the coalescing guards so it is
-    // reported even when this particular dispatch is coalesced/dropped.
-    this._maybeWarnNoTextSelection();
     if (this._slideInFlight.has(i)) return; // coalesce: already dispatched
     // Drop-stale before dispatch: if this slide already scrolled out of the
     // mounted window, don't dispatch at all.
@@ -881,10 +861,17 @@ export class PptxScrollViewer implements ZoomableViewer {
     if (!slot.bitmapCtx) {
       slot.bitmapCtx = slot.canvas.getContext('bitmaprenderer') as ImageBitmapRenderingContext | null;
     }
+    // IX6 — harvest the slide's run geometry alongside the bitmap so the
+    // worker-mode selection overlay is built from the SAME data main mode uses.
+    // The runs ride back beside the bitmap (one round-trip), collected only when
+    // an overlay is actually wanted.
+    const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
+    const runs: PptxTextRunInfo[] = [];
     try {
       const bmp = await this._pres!.renderSlideToBitmap(i, {
         width: widthPx,
         dpr,
+        onTextRun: wantOverlay ? (r) => runs.push(r) : undefined,
       });
       // Stale if EITHER (a) the epoch moved (a setScale rescaled mid-flight, so
       // this bitmap is at a superseded resolution — this catches the case where
@@ -912,6 +899,25 @@ export class PptxScrollViewer implements ZoomableViewer {
       // This bitmap now defines the scale the on-screen canvas lives at, so a
       // later zoom preview stretches from HERE (design §7 renderedScale).
       slot.renderedScale = scale;
+      // IX6 — build the selection overlay from the runs the worker just shipped.
+      // Reached only past the staleness gate, so the geometry matches THIS paint.
+      // Clear any preview transform first (a settle lands at the current scale, so
+      // the `scale()` from `_previewSlot` is stale) — mirrors the main path. The
+      // overlay is sized to the slot's CSS box (Math.round of the uniform slide
+      // width/height at the current scale), NOT the dpr-scaled backing store.
+      if (slot.textLayer) {
+        slot.textLayer.style.transform = '';
+        slot.textLayer.style.transformOrigin = '';
+        if (wantOverlay) {
+          buildPptxTextLayer(
+            slot.textLayer,
+            runs,
+            Math.round(widthPx),
+            Math.round(this._slideHeightPx()),
+            (t) => this._onHyperlinkClick(t),
+          );
+        }
+      }
       painted = true;
     } catch (err) {
       this._reportRenderError(err);
@@ -1184,12 +1190,11 @@ export class PptxScrollViewer implements ZoomableViewer {
 
   /** Full-resolution settle re-render of the visible window (design §7 mechanisms
    *  2+3). Re-renders each mounted slot at the current scale via the double-buffer
-   *  swap (main) / same-canvas transfer (worker). Main mode also rebuilds the text
-   *  overlay and clears its preview transform; in worker mode the overlay is
-   *  permanently empty (text selection is main-mode-only), so the transform is
-   *  inert there and is reset on recycle. Dispatched at the CURRENT epoch; the
-   *  existing epoch gate discards it if a later `setScale` supersedes it
-   *  mid-render. */
+   *  swap (main) / same-canvas transfer (worker). Both modes rebuild the text
+   *  overlay from the fresh render's run geometry (IX6 — worker mode collects the
+   *  runs off-thread via `_renderSlotBitmap`) and clear the preview transform.
+   *  Dispatched at the CURRENT epoch; the existing epoch gate discards it if a
+   *  later `setScale` supersedes it mid-render. */
   private _settleRender(): void {
     if (this._destroyed || !this._pres || this._pres.slideCount === 0) return;
     for (const [i, slot] of [...this._slots]) {

--- a/packages/pptx/src/text-layer.ts
+++ b/packages/pptx/src/text-layer.ts
@@ -10,8 +10,9 @@ import type { PptxTextRunInfo } from './renderer';
  * shape div (`inShapeX`/`inShapeY`). Extracted verbatim from
  * `PptxViewer._buildTextLayer` so the pager (PptxViewer) and the continuous-scroll
  * viewer (PptxScrollViewer, WS4) share one implementation; public API for
- * integrators (design §10). MAIN render mode only — `onTextRun` cannot cross the
- * worker boundary.
+ * integrators (design §10). IX6 — usable in BOTH render modes: worker mode
+ * collects the same `PptxTextRunInfo[]` off-thread and ships it back beside the
+ * bitmap, so the overlay is built from identical geometry regardless of thread.
  *
  * IX1 — when a run carries a resolved `hyperlink` (from `<a:hlinkClick>`) and an
  * `onHyperlinkClick` callback is supplied, its span becomes a click target

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -124,8 +124,6 @@ export class PptxViewer implements ZoomableViewer {
   private _find: PptxFindController;
   /** Private 2d context for measuring highlight text (own 1×1 canvas). */
   private _measureCtx: CanvasRenderingContext2D | null = null;
-  /** One-shot guard for the worker-mode findText warning. */
-  private _warnedNoFind = false;
   private engine: PptxPresentation | null = null;
   private readonly opts: PptxViewerOptions;
   private currentSlide = 0;
@@ -136,7 +134,6 @@ export class PptxViewer implements ZoomableViewer {
    *  render path. The media-playback path keeps a 2d context (via presentSlide),
    *  so this is obtained only when worker mode renders without media playback. */
   private _bitmapCtx: ImageBitmapRenderingContext | null = null;
-  private _warnedNoTextSelection = false;
   /** Set by {@link destroy} (first line). Guards {@link _reportRenderError} so a
    *  render rejection that lands AFTER teardown is swallowed rather than surfaced
    *  to an `onError` / `console.error` on a dead viewer — parity with the scroll
@@ -201,7 +198,8 @@ export class PptxViewer implements ZoomableViewer {
 
     // IX2 — find-highlight overlay layer, appended last (stacks above the text
     // layer). `pointer-events:none` keeps selection + link clicks working
-    // through it. Empty in worker mode (onTextRun can't fire there).
+    // through it. IX6 — populated in BOTH render modes (worker mode ships the
+    // run geometry back beside the bitmap).
     this.highlightLayer = document.createElement('div');
     this.highlightLayer.style.cssText =
       'position:absolute;top:0;left:0;width:100%;height:100%;overflow:hidden;pointer-events:none;';
@@ -467,19 +465,13 @@ export class PptxViewer implements ZoomableViewer {
     this.handle = null;
 
     const isWorker = this._mode === 'worker';
-    // In worker mode rendering happens off the main thread, so the onTextRun
-    // callback can't fire — the text-selection overlay is unavailable.
-    if (isWorker && this.textLayer && !this._warnedNoTextSelection) {
-      this._warnedNoTextSelection = true;
-      console.warn(
-        "[ooxml] text selection is unavailable in mode: 'worker'; the overlay will be empty. Use mode: 'main' for selectable text.",
-      );
-    }
-    // Collect runs unconditionally in main mode (not just when a text layer
-    // exists): the find-highlight overlay needs the current slide's run geometry
-    // too, and caching them lets find() reuse the visible render for this slide.
+    // Collect runs unconditionally (not just when a text layer exists): the
+    // find-highlight overlay needs the current slide's run geometry too, and
+    // caching them lets find() reuse the visible render for this slide. IX6 —
+    // in worker mode the runs ride back beside the bitmap (via the proxy's
+    // `onTextRun`), so both modes populate the same `runs` array.
     const runs: PptxTextRunInfo[] = [];
-    const onTextRun = !isWorker ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
+    const onTextRun = (r: PptxTextRunInfo) => runs.push(r);
 
     try {
       if (this.opts.enableMediaPlayback) {
@@ -489,9 +481,10 @@ export class PptxViewer implements ZoomableViewer {
           width: targetWidth,
           dpr,
           dim,
+          onTextRun,
         });
       } else if (isWorker) {
-        const bmp = await this.engine.renderSlideToBitmap(this.currentSlide, { width: targetWidth, dpr, dim });
+        const bmp = await this.engine.renderSlideToBitmap(this.currentSlide, { width: targetWidth, dpr, dim, onTextRun });
         this.canvas.width = bmp.width;
         this.canvas.height = bmp.height;
         this._bitmapCtx?.transferFromImageBitmap(bmp);
@@ -503,15 +496,15 @@ export class PptxViewer implements ZoomableViewer {
       this._reportRenderError(err);
     }
 
-    if (this.textLayer && !isWorker) {
+    // IX6 — identical overlay build for both modes: the run geometry the worker
+    // shipped is the same shape `onTextRun` emits in main mode.
+    if (this.textLayer) {
       this._buildTextLayer(this.textLayer, runs, targetWidth, cssHeight);
     }
-    if (!isWorker) {
-      // Feed the just-rendered slide's runs to the find controller (geometry
-      // matches what was drawn) and (re)draw its highlights.
-      this._find.setSlideRuns(this.currentSlide, runs);
-      this._buildHighlightLayer(runs, targetWidth, cssHeight);
-    }
+    // Feed the just-rendered slide's runs to the find controller (geometry
+    // matches what was drawn) and (re)draw its highlights.
+    this._find.setSlideRuns(this.currentSlide, runs);
+    this._buildHighlightLayer(runs, targetWidth, cssHeight);
   }
 
   /** Draw the find-highlight boxes for the current slide from its runs. */
@@ -536,22 +529,15 @@ export class PptxViewer implements ZoomableViewer {
     return (s) => ctx.measureText(s).width;
   }
 
-  /** Render a slide to a throwaway offscreen canvas to collect its runs for
-   *  search, without touching the visible canvas. Used for slides other than the
-   *  one on screen. */
+  /** IX6 — collect a slide's runs for search without touching the visible
+   *  canvas. Delegates to `collectSlideRuns`, which works in BOTH modes (worker:
+   *  off-thread, ships only the runs; main: throwaway offscreen canvas). Used for
+   *  slides other than the one on screen. */
   private async _collectSlideRuns(slide: number): Promise<PptxTextRunInfo[]> {
-    if (!this.engine || this._mode === 'worker') return [];
-    const runs: PptxTextRunInfo[] = [];
-    const off =
-      typeof OffscreenCanvas !== 'undefined'
-        ? new OffscreenCanvas(1, 1)
-        : (document.createElement('canvas') as HTMLCanvasElement);
-    const targetWidth = this._targetWidth();
-    await this.engine.renderSlide(off, slide, {
-      width: targetWidth,
-      onTextRun: (r: PptxTextRunInfo) => runs.push(r),
-    });
-    return runs;
+    if (!this.engine) return [];
+    // IX9 — collect at the zoom-aware width so the harvested geometry matches
+    // what a navigation to that slide would draw at the current scale.
+    return this.engine.collectSlideRuns(slide, this._targetWidth());
   }
 
   /**
@@ -561,23 +547,16 @@ export class PptxViewer implements ZoomableViewer {
    * by default; pass `{ caseSensitive: true }` for an exact match.
    *
    * Scans all slides (each rendered once offscreen to read its text; the visible
-   * slide reuses its on-screen render). Not available in `mode: 'worker'` —
-   * returns `[]` there after a one-time warning. An empty query clears the find.
+   * slide reuses its on-screen render). IX6 — works in BOTH `mode: 'main'` and
+   * `mode: 'worker'`: in worker mode each slide's run geometry is collected
+   * off-thread and shipped back, so find returns the same matches on the same
+   * code path. An empty query clears the find.
    */
   async findText(
     query: string,
     opts: FindMatchesOptions = {},
   ): Promise<FindMatch<PptxMatchLocation>[]> {
     if (!this.engine) return [];
-    if (this._mode === 'worker') {
-      if (!this._warnedNoFind) {
-        this._warnedNoFind = true;
-        console.warn(
-          "[ooxml] findText is unavailable in mode: 'worker' (text runs can't cross the worker boundary). Use mode: 'main'.",
-        );
-      }
-      return [];
-    }
     const matches = await this._find.find(query, opts);
     this._redrawHighlights();
     return matches;

--- a/packages/pptx/src/worker-protocol.ts
+++ b/packages/pptx/src/worker-protocol.ts
@@ -1,4 +1,5 @@
 import type { DimOptions, MediaElement, WorkerResponse } from './types';
+import type { PptxTextRunInfo } from './renderer';
 
 /** Lightweight summary returned by the render worker's `parse` — everything
  *  the main-thread proxy needs for its synchronous getters. The full model
@@ -33,9 +34,18 @@ export type RenderWorkerRequest =
   | { kind: 'extractImage'; id: number; path: string }
   | { kind: 'toMarkdown'; id: number }
   | { kind: 'parse'; id: number; buffer: ArrayBuffer; maxZipEntryBytes?: number; useGoogleFonts?: boolean }
-  | { kind: 'renderSlide'; id: number; slideIndex: number; width: number; dpr: number; skipMediaControls?: boolean; dim?: DimOptions };
+  | { kind: 'renderSlide'; id: number; slideIndex: number; width: number; dpr: number; skipMediaControls?: boolean; dim?: DimOptions }
+  // IX6 — collect a slide's text-run geometry WITHOUT transferring a bitmap. The
+  // find controller scans every slide for its runs; a bitmap per slide would be
+  // wasted work + transfer for slides the user never looks at.
+  | { kind: 'collectRuns'; id: number; slideIndex: number; width: number };
 
 export type RenderWorkerResponse =
   | Exclude<WorkerResponse, { kind: 'parsed' }>
   | { kind: 'parsedMeta'; id: number; meta: PresentationMeta }
-  | { kind: 'slideRendered'; id: number; bitmap: ImageBitmap };
+  // IX6 — the render worker collects each rendered slide's `onTextRun` geometry
+  // (a plain, structured-clone-safe `PptxTextRunInfo[]`) and ships it beside the
+  // bitmap, so the main thread can build the text-selection / find-highlight
+  // overlay on the SAME code path as main mode (no second render).
+  | { kind: 'slideRendered'; id: number; bitmap: ImageBitmap; runs: PptxTextRunInfo[] }
+  | { kind: 'runsCollected'; id: number; runs: PptxTextRunInfo[] };

--- a/packages/pptx/tests/visual/worker-selection-equivalence.spec.ts
+++ b/packages/pptx/tests/visual/worker-selection-equivalence.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * IX6 functional worker-equivalence: the text-selection overlay and findText
+ * must produce the SAME result in `mode: 'worker'` as in `mode: 'main'`. The
+ * run geometry is collected off-thread in worker mode and shipped back beside
+ * the bitmap, so the selection spans (text + rounded shape/in-shape box) and the
+ * findText match set must be byte-for-byte identical to main mode. This is the
+ * functional twin of the pixel worker-equivalence spec: it fails if a run is
+ * dropped on the wire or findText silently returns `[]` in worker mode (the
+ * pre-IX6 behaviour).
+ */
+test('worker mode selection overlay + findText match main mode › demo/sample-1', async ({ page }) => {
+  await page.goto('/tests/visual/worker-selection-fixture.html?pptx=demo/sample-1&q=a');
+  await page.waitForFunction(
+    () => document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
+    { timeout: 60_000 },
+  );
+  const status = await page.evaluate(() => document.body.dataset.status);
+  if (status === 'error') {
+    throw new Error(await page.evaluate(() => document.body.dataset.errorMessage ?? ''));
+  }
+
+  const data = await page.evaluate(() => ({
+    mainOverlay: document.body.dataset.mainOverlay ?? '[]',
+    workerOverlay: document.body.dataset.workerOverlay ?? '[]',
+    mainMatches: document.body.dataset.mainMatches ?? '[]',
+    workerMatches: document.body.dataset.workerMatches ?? '[]',
+  }));
+
+  const mainOverlay = JSON.parse(data.mainOverlay) as unknown[];
+  const workerOverlay = JSON.parse(data.workerOverlay) as unknown[];
+  const mainMatches = JSON.parse(data.mainMatches) as unknown[];
+  const workerMatches = JSON.parse(data.workerMatches) as unknown[];
+
+  // The overlay must be non-empty (a real slide with selectable text), or the
+  // equivalence below would be a vacuous [] === [].
+  expect(mainOverlay.length).toBeGreaterThan(0);
+  // The selection overlay is identical run-for-run between modes.
+  expect(workerOverlay).toEqual(mainOverlay);
+
+  // findText found real matches in main mode…
+  expect(mainMatches.length).toBeGreaterThan(0);
+  // …and worker mode returns the exact same match set (this is the guard the
+  // pre-IX6 code broke: worker findText returned [] + a console.warn).
+  expect(workerMatches).toEqual(mainMatches);
+});

--- a/packages/pptx/tests/visual/worker-selection-equivalence.spec.ts
+++ b/packages/pptx/tests/visual/worker-selection-equivalence.spec.ts
@@ -1,47 +1,95 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * IX6 functional worker-equivalence: the text-selection overlay and findText
- * must produce the SAME result in `mode: 'worker'` as in `mode: 'main'`. The
- * run geometry is collected off-thread in worker mode and shipped back beside
- * the bitmap, so the selection spans (text + rounded shape/in-shape box) and the
- * findText match set must be byte-for-byte identical to main mode. This is the
- * functional twin of the pixel worker-equivalence spec: it fails if a run is
- * dropped on the wire or findText silently returns `[]` in worker mode (the
- * pre-IX6 behaviour).
+ * IX6 functional worker-equivalence (+ IX9 zoom integration): the
+ * text-selection overlay (per-shape div + nested run span), the findText match
+ * set, and the find-highlight boxes must be identical in `mode: 'worker'` and
+ * `mode: 'main'`, both at the initial scale AND after a `setScale(1.5)` zoom.
+ * The run geometry is collected off-thread in worker mode and shipped back
+ * beside the bitmap, so:
+ *  - the selection overlay matches main mode exactly;
+ *  - findText returns the same match set (the pre-IX6 guard returned `[]`);
+ *  - after setScale(1.5) the render width is exactly natural × 1.5 and the
+ *    overlay/highlight coordinates follow the zoom (worker re-render round-trips
+ *    fresh runs at the new width).
+ * This is the functional twin of the pixel worker-equivalence spec.
  */
-test('worker mode selection overlay + findText match main mode › demo/sample-1', async ({ page }) => {
+
+interface Snap {
+  overlay: { text: string; shapeLeft: number; shapeTop: number; inLeft: number; inTop: number }[];
+  highlights: { left: number; top: number; width: number }[];
+  canvasW: number;
+  scale: number;
+  slide: number;
+}
+interface ModeData {
+  matches: { text: string; slide: number }[];
+  before: Snap;
+  after: Snap;
+}
+
+test('worker selection + findText + zoom match main mode › demo/sample-1', async ({ page }) => {
+  test.setTimeout(120_000);
   await page.goto('/tests/visual/worker-selection-fixture.html?pptx=demo/sample-1&q=a');
   await page.waitForFunction(
     () => document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
-    { timeout: 60_000 },
+    { timeout: 90_000 },
   );
   const status = await page.evaluate(() => document.body.dataset.status);
   if (status === 'error') {
     throw new Error(await page.evaluate(() => document.body.dataset.errorMessage ?? ''));
   }
 
-  const data = await page.evaluate(() => ({
-    mainOverlay: document.body.dataset.mainOverlay ?? '[]',
-    workerOverlay: document.body.dataset.workerOverlay ?? '[]',
-    mainMatches: document.body.dataset.mainMatches ?? '[]',
-    workerMatches: document.body.dataset.workerMatches ?? '[]',
+  const raw = await page.evaluate(() => ({
+    main: document.body.dataset.main ?? '{}',
+    worker: document.body.dataset.worker ?? '{}',
   }));
+  const main = JSON.parse(raw.main) as ModeData;
+  const worker = JSON.parse(raw.worker) as ModeData;
 
-  const mainOverlay = JSON.parse(data.mainOverlay) as unknown[];
-  const workerOverlay = JSON.parse(data.workerOverlay) as unknown[];
-  const mainMatches = JSON.parse(data.mainMatches) as unknown[];
-  const workerMatches = JSON.parse(data.workerMatches) as unknown[];
+  // --- findText: real matches, identical across modes (the pre-IX6 worker
+  // guard returned [] + console.warn — this is the regression tripwire).
+  expect(main.matches.length).toBeGreaterThan(0);
+  expect(worker.matches).toEqual(main.matches);
 
-  // The overlay must be non-empty (a real slide with selectable text), or the
-  // equivalence below would be a vacuous [] === [].
-  expect(mainOverlay.length).toBeGreaterThan(0);
-  // The selection overlay is identical run-for-run between modes.
-  expect(workerOverlay).toEqual(mainOverlay);
+  // --- initial scale: overlay + highlight parity (non-empty — findNext
+  // navigated to the first match's slide, so highlight boxes must exist).
+  expect(main.before.overlay.length).toBeGreaterThan(0);
+  expect(worker.before.overlay).toEqual(main.before.overlay);
+  expect(main.before.highlights.length).toBeGreaterThan(0);
+  expect(worker.before.highlights).toEqual(main.before.highlights);
+  expect(worker.before.slide).toBe(main.before.slide);
 
-  // findText found real matches in main mode…
-  expect(mainMatches.length).toBeGreaterThan(0);
-  // …and worker mode returns the exact same match set (this is the guard the
-  // pre-IX6 code broke: worker findText returned [] + a console.warn).
-  expect(workerMatches).toEqual(mainMatches);
+  // --- IX9 zoom in worker mode: scale latched, render width = natural × 1.5.
+  expect(worker.after.scale).toBe(1.5);
+  expect(main.after.scale).toBe(1.5);
+  // naturalWidth = beforeW / beforeScale (getScale() before any zoom is the
+  // effective opts.width / natural factor), so the post-zoom canvas must be
+  // round(natural × 1.5) — allow ±1 for the two roundings involved.
+  const naturalPx = worker.before.canvasW / worker.before.scale;
+  expect(Math.abs(worker.after.canvasW - naturalPx * 1.5)).toBeLessThanOrEqual(1);
+  expect(worker.after.canvasW).toBe(main.after.canvasW);
+
+  // --- post-zoom parity: overlay + highlights identical across modes.
+  expect(main.after.overlay.length).toBeGreaterThan(0);
+  expect(worker.after.overlay).toEqual(main.after.overlay);
+  expect(main.after.highlights.length).toBeGreaterThan(0);
+  expect(worker.after.highlights).toEqual(main.after.highlights);
+
+  // --- the worker overlay/highlight coordinates FOLLOW the zoom: shape frames
+  // and in-shape offsets scaled by (1.5 / beforeScale) within a small rounding
+  // tolerance (slide geometry px = EMU × scale, linear in the zoom factor).
+  const ratio = 1.5 / worker.before.scale;
+  const follow = (before: number, after: number) =>
+    Math.abs(after - before * ratio) <= 3;
+  expect(worker.after.overlay.length).toBe(worker.before.overlay.length);
+  for (let i = 0; i < worker.before.overlay.length; i++) {
+    expect(follow(worker.before.overlay[i].shapeLeft, worker.after.overlay[i].shapeLeft)).toBe(true);
+    expect(follow(worker.before.overlay[i].shapeTop, worker.after.overlay[i].shapeTop)).toBe(true);
+  }
+  expect(worker.after.highlights.length).toBe(worker.before.highlights.length);
+  for (let i = 0; i < worker.before.highlights.length; i++) {
+    expect(follow(worker.before.highlights[i].left, worker.after.highlights[i].left)).toBe(true);
+    expect(follow(worker.before.highlights[i].top, worker.after.highlights[i].top)).toBe(true);
+  }
 });

--- a/packages/pptx/tests/visual/worker-selection-fixture.html
+++ b/packages/pptx/tests/visual/worker-selection-fixture.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <style>* { margin: 0; padding: 0; } canvas { display: block; }</style>
+</head>
+<body>
+  <!-- IX6 functional worker-equivalence: build a real PptxViewer in BOTH main
+       and worker mode, capture the text-selection overlay DOM (per-shape <div>
+       with nested run <span>s) and the findText match set, then expose both so
+       the spec can assert main === worker. Proves the run geometry crosses the
+       worker boundary identically (selection) and that findText works in worker
+       mode. -->
+  <div id="main-host"></div>
+  <div id="worker-host"></div>
+  <script type="module">
+    import { PptxViewer } from '/src/index.ts';
+
+    const params = new URLSearchParams(location.search);
+    const name = params.get('pptx') ?? 'demo/sample-1';
+    const query = params.get('q') ?? 'a';
+    const width = 900;
+
+    // Serialize the text-selection overlay: pptx nests run <span>s inside a
+    // per-shape <div>, so walk shape → span and record the span text plus its
+    // shape-frame origin and in-shape offset (rounded — sub-pixel raster jitter
+    // between the main <canvas> and the worker OffscreenCanvas must not fail an
+    // exact-equality assertion). The run GEOMETRY is computed identically in both
+    // modes (same renderer), so the rounded boxes must match exactly.
+    const serializeOverlay = (host) => {
+      const layer = host.querySelector('div.__pptx-textlayer') ?? host.querySelector('div > div')?.parentElement;
+      // The viewer's wrapper holds [canvas, textLayer, highlightLayer]. The text
+      // layer is the div whose children are shape divs (each holding spans).
+      const wrapper = host.querySelector('div');
+      const layers = wrapper ? [...wrapper.children].filter((c) => c.tagName === 'DIV') : [];
+      // textLayer = the layer that actually contains shape divs with spans.
+      const textLayer = layers.find((l) => l.querySelector('span')) ?? layers[0];
+      const out = [];
+      if (textLayer) {
+        for (const shape of textLayer.children) {
+          const sx = Math.round(parseFloat(shape.style.left) || 0);
+          const sy = Math.round(parseFloat(shape.style.top) || 0);
+          for (const span of shape.querySelectorAll('span')) {
+            out.push({
+              text: span.textContent,
+              shapeLeft: sx,
+              shapeTop: sy,
+              inLeft: Math.round(parseFloat(span.style.left) || 0),
+              inTop: Math.round(parseFloat(span.style.top) || 0),
+            });
+          }
+        }
+      }
+      return out;
+    };
+
+    const buildViewer = async (hostId, mode) => {
+      const host = document.getElementById(hostId);
+      const canvas = document.createElement('canvas');
+      host.appendChild(canvas);
+      const resp = await fetch(`/${name}.pptx`);
+      if (!resp.ok) throw new Error(`fetch ${name}.pptx -> ${resp.status}`);
+      const buf = await resp.arrayBuffer();
+      const viewer = new PptxViewer(canvas, {
+        mode,
+        width,
+        enableTextSelection: true,
+        useGoogleFonts: true,
+      });
+      await viewer.load(buf);
+      const matches = await viewer.findText(query);
+      const overlay = serializeOverlay(host);
+      return {
+        overlay,
+        matches: matches.map((m) => ({ text: m.text, slide: m.location.slide })),
+        slideCount: viewer.slideCount,
+        viewer,
+      };
+    };
+
+    try {
+      const main = await buildViewer('main-host', 'main');
+      const worker = await buildViewer('worker-host', 'worker');
+
+      document.body.dataset.mainOverlay = JSON.stringify(main.overlay);
+      document.body.dataset.workerOverlay = JSON.stringify(worker.overlay);
+      document.body.dataset.mainMatches = JSON.stringify(main.matches);
+      document.body.dataset.workerMatches = JSON.stringify(worker.matches);
+      document.body.dataset.slideCount = String(main.slideCount);
+
+      main.viewer.destroy();
+      worker.viewer.destroy();
+      document.body.dataset.status = 'ready';
+    } catch (err) {
+      document.body.dataset.status = 'error';
+      document.body.dataset.errorMessage = err.message;
+      console.error('[worker-selection-fixture] error:', err);
+    }
+  </script>
+</body>
+</html>

--- a/packages/pptx/tests/visual/worker-selection-fixture.html
+++ b/packages/pptx/tests/visual/worker-selection-fixture.html
@@ -7,10 +7,11 @@
 <body>
   <!-- IX6 functional worker-equivalence: build a real PptxViewer in BOTH main
        and worker mode, capture the text-selection overlay DOM (per-shape <div>
-       with nested run <span>s) and the findText match set, then expose both so
-       the spec can assert main === worker. Proves the run geometry crosses the
-       worker boundary identically (selection) and that findText works in worker
-       mode. -->
+       with nested run <span>s), the findText match set, and the find-highlight
+       boxes, then zoom (IX9 setScale) and capture again — so the spec can assert
+       main === worker at BOTH scales and that the overlay/highlight geometry
+       follows the zoom. Proves the run geometry crosses the worker boundary
+       identically and that findText + zoom work in worker mode. -->
   <div id="main-host"></div>
   <div id="worker-host"></div>
   <script type="module">
@@ -20,21 +21,21 @@
     const name = params.get('pptx') ?? 'demo/sample-1';
     const query = params.get('q') ?? 'a';
     const width = 900;
+    const ZOOM = 1.5;
 
+    const layersOf = (host) => {
+      const wrapper = host.querySelector('div'); // the viewer's positioned wrapper
+      return wrapper ? [...wrapper.children].filter((c) => c.tagName === 'DIV') : [];
+    };
     // Serialize the text-selection overlay: pptx nests run <span>s inside a
     // per-shape <div>, so walk shape → span and record the span text plus its
     // shape-frame origin and in-shape offset (rounded — sub-pixel raster jitter
     // between the main <canvas> and the worker OffscreenCanvas must not fail an
     // exact-equality assertion). The run GEOMETRY is computed identically in both
     // modes (same renderer), so the rounded boxes must match exactly.
+    // Wrapper stacking order: [canvas, textLayer, highlightLayer].
     const serializeOverlay = (host) => {
-      const layer = host.querySelector('div.__pptx-textlayer') ?? host.querySelector('div > div')?.parentElement;
-      // The viewer's wrapper holds [canvas, textLayer, highlightLayer]. The text
-      // layer is the div whose children are shape divs (each holding spans).
-      const wrapper = host.querySelector('div');
-      const layers = wrapper ? [...wrapper.children].filter((c) => c.tagName === 'DIV') : [];
-      // textLayer = the layer that actually contains shape divs with spans.
-      const textLayer = layers.find((l) => l.querySelector('span')) ?? layers[0];
+      const textLayer = layersOf(host)[0];
       const out = [];
       if (textLayer) {
         for (const shape of textLayer.children) {
@@ -53,6 +54,29 @@
       }
       return out;
     };
+    // IX2 highlight boxes (absolutely positioned divs in the LAST layer; pptx
+    // groups them per shape like the text layer, so walk to the leaf divs that
+    // carry a background).
+    const serializeHighlights = (host) => {
+      const layers = layersOf(host);
+      const layer = layers[layers.length - 1];
+      if (!layer) return [];
+      return [...layer.querySelectorAll('div')]
+        .filter((b) => b.style.background)
+        .map((b) => ({
+          left: Math.round(parseFloat(b.style.left) || 0),
+          top: Math.round(parseFloat(b.style.top) || 0),
+          width: Math.round(parseFloat(b.style.width) || 0),
+        }));
+    };
+
+    const capture = (host, viewer, canvas) => ({
+      overlay: serializeOverlay(host),
+      highlights: serializeHighlights(host),
+      canvasW: Math.round(parseFloat(canvas.style.width) || canvas.width),
+      scale: viewer.getScale(),
+      slide: viewer.currentSlide,
+    });
 
     const buildViewer = async (hostId, mode) => {
       const host = document.getElementById(hostId);
@@ -68,12 +92,19 @@
         useGoogleFonts: true,
       });
       await viewer.load(buf);
+      // findText scans every slide; findNext navigates to the first match's
+      // slide so the current slide is guaranteed to carry highlight boxes.
       const matches = await viewer.findText(query);
-      const overlay = serializeOverlay(host);
+      await viewer.findNext();
+      const before = capture(host, viewer, canvas);
+      // IX9 × IX6 — zoom while in the same mode: the re-render (worker: bitmap +
+      // runs round-trip) must rebuild the overlay + highlights at the new scale.
+      await viewer.setScale(ZOOM);
+      const after = capture(host, viewer, canvas);
       return {
-        overlay,
         matches: matches.map((m) => ({ text: m.text, slide: m.location.slide })),
-        slideCount: viewer.slideCount,
+        before,
+        after,
         viewer,
       };
     };
@@ -82,11 +113,9 @@
       const main = await buildViewer('main-host', 'main');
       const worker = await buildViewer('worker-host', 'worker');
 
-      document.body.dataset.mainOverlay = JSON.stringify(main.overlay);
-      document.body.dataset.workerOverlay = JSON.stringify(worker.overlay);
-      document.body.dataset.mainMatches = JSON.stringify(main.matches);
-      document.body.dataset.workerMatches = JSON.stringify(worker.matches);
-      document.body.dataset.slideCount = String(main.slideCount);
+      const pack = ({ matches, before, after }) => ({ matches, before, after });
+      document.body.dataset.main = JSON.stringify(pack(main));
+      document.body.dataset.worker = JSON.stringify(pack(worker));
 
       main.viewer.destroy();
       worker.viewer.destroy();


### PR DESCRIPTION
## Summary

Worker mode silently dropped two features that main mode has: **text selection** (the overlay stayed empty with a one-time warning) and **findText** (returned `[]` + a `console.warn` — the PR #783 guard). Both broke for the same reason: the per-run `onTextRun` geometry was computed inside the render worker and could not cross the worker boundary back to the main thread, so the main-side selection/find overlays had no data to build from.

The run geometry (`DocxTextRunInfo` / `PptxTextRunInfo`) is a **flat, structured-clone-safe** shape (its only nested field, `HyperlinkTarget`, is a plain discriminated union). So the fix is simply: the render worker collects the runs during the render it already runs, and ships them back **beside the bitmap**. The main thread then builds the selection / find overlays on the **same code path** as main mode — no second render, no duplicate implementation.

This follows the IX-nav (#778) precedent of serializing derived data (bookmarkPages / partNames) through the render worker's response.

## Protocol change

- `pageRendered` / `slideRendered` now carry `runs: TextRunInfo[]` beside the bitmap.
- New `collectRuns` request / `runsCollected` response harvest a page/slide's runs **without** a bitmap transfer — the find controller scans every page/slide, and a bitmap per page would be wasted work + transfer for pages the user never looks at.
- Proxy: `renderPageToBitmap` / `renderSlideToBitmap` accept an optional `onTextRun` (main-thread only; in worker mode the proxy replays the returned runs to it). New mode-agnostic `collectPageRuns` / `collectSlideRuns`.

## Viewers

- `DocxViewer` / `PptxViewer` and the scroll viewers now build the selection overlay and feed the find controller on **one** branch for both modes. The worker-mode guards (`findText` → `[]` + warn, empty selection overlay + warn) are removed. `findText` / `findNext` / `findPrev` / `clearFind` return identical results in both modes.
- pptx `presentSlide` threads `onTextRun` through its worker draw path too, so media slides are selectable/searchable in worker mode.

## Verification

- **New functional worker-equivalence specs** (docx + pptx): load the same demo sample in main **and** worker mode, then assert the selection-overlay DOM (per-run boxes; per-shape div + nested span for pptx) and the `findText` match set are **byte-identical** between modes. Fails if a run is dropped on the wire or findText regresses to `[]`.
- **Pixel worker-equivalence** (existing): unchanged at **0.000%** diff, docx + pptx.
- **Transfer cost**: measured `renderPageToBitmap` response time with vs without run collection across 8–20 page text-heavy documents (up to ~3700 runs total). The median delta is **≤ 0** — the structured-clone of a few hundred small run objects is below measurement noise next to the render + bitmap transfer. No opt-out needed.
- Full docx + pptx unit suite (1116 tests) green; node find-highlight tests green; `tsc --build` clean; ast-grep clean on changed files (no new warnings).

xlsx is intentionally untouched (findText already works in both modes there; selection is cell-based).

🤖 Generated with [Claude Code](https://claude.com/claude-code)