### PR TITLE
feat(xlsx): row/column outline grouping (gutter + collapse/expand)

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -912,6 +912,14 @@ fn parse_worksheet(
     let mut rows = Vec::new();
     let mut col_widths: BTreeMap<u32, f64> = BTreeMap::new();
     let mut row_heights: BTreeMap<u32, f64> = BTreeMap::new();
+    // Outline (grouping) metadata — ECMA-376 §18.3.1.13 (col) / §18.3.1.73
+    // (row) / §18.3.1.61 (outlinePr). Only non-default entries are recorded so
+    // an outline-free sheet keeps empty maps / a `None` outlinePr (byte-stable
+    // JSON, §CLAUDE "1px identical").
+    let mut col_outline_levels: BTreeMap<u32, u8> = BTreeMap::new();
+    let mut col_collapsed: BTreeMap<u32, bool> = BTreeMap::new();
+    let mut col_hidden: BTreeMap<u32, bool> = BTreeMap::new();
+    let mut outline_pr: Option<crate::types::OutlinePr> = None;
     let mut merge_cells: Vec<MergeCell> = Vec::new();
     let mut freeze_rows: u32 = 0;
     let mut freeze_cols: u32 = 0;
@@ -1071,8 +1079,21 @@ fn parse_worksheet(
             "col" if is_x_ns(node.tag_name().namespace()) => {
                 let custom = attr_bool(&node, "customWidth").unwrap_or(false);
                 let hidden = attr_bool(&node, "hidden").unwrap_or(false);
-                // Only record widths for custom-widthed columns OR hidden columns
-                if !custom && !hidden {
+                // §18.3.1.13 outline metadata: `outlineLevel` (0-7) and the
+                // summary-column `collapsed` flag. Recorded independently of the
+                // width so a grouped column at the default width is still
+                // surfaced to the gutter.
+                let outline_level = node
+                    .attribute("outlineLevel")
+                    .and_then(|s| s.parse::<u8>().ok())
+                    .unwrap_or(0)
+                    .min(7);
+                let collapsed = attr_bool(&node, "collapsed").unwrap_or(false);
+                // Record widths for custom-widthed OR hidden columns, and also
+                // for columns that carry outline info (level > 0 or collapsed) —
+                // those must reach the viewer even at the default width.
+                let has_outline = outline_level > 0 || collapsed;
+                if !custom && !hidden && !has_outline {
                     continue;
                 }
                 let min: u32 = node
@@ -1093,7 +1114,22 @@ fn parse_worksheet(
                         .unwrap_or(default_col_width)
                 };
                 for c in min..=max {
-                    col_widths.insert(c, width);
+                    // Only store a width entry when the column actually has a
+                    // custom / hidden width; a default-width grouped column keeps
+                    // the workbook default (no colWidths entry) so its rendered
+                    // width is byte-identical to an ungrouped default column.
+                    if custom || hidden {
+                        col_widths.insert(c, width);
+                    }
+                    if outline_level > 0 {
+                        col_outline_levels.insert(c, outline_level);
+                    }
+                    if collapsed {
+                        col_collapsed.insert(c, true);
+                    }
+                    if hidden {
+                        col_hidden.insert(c, true);
+                    }
                 }
             }
             "sheetView" if is_x_ns(node.tag_name().namespace()) => {
@@ -1102,6 +1138,14 @@ fn parse_worksheet(
                 // ECMA-376 §18.3.1.87 `rightToLeft` — mirrors the whole grid so
                 // column A is on the right. Default false (left-to-right).
                 right_to_left = attr_bool(&node, "rightToLeft").unwrap_or(false);
+            }
+            "outlinePr" if is_x_ns(node.tag_name().namespace()) => {
+                // §18.3.1.61 `<sheetPr><outlinePr>`. Both flags default to true
+                // (summary below/right of detail). `applyStyles` is out of scope.
+                outline_pr = Some(crate::types::OutlinePr {
+                    summary_below: attr_bool(&node, "summaryBelow").unwrap_or(true),
+                    summary_right: attr_bool(&node, "summaryRight").unwrap_or(true),
+                });
             }
             "tabColor" if is_x_ns(node.tag_name().namespace()) => {
                 tab_color = parse_color(&node, theme_colors);
@@ -1208,11 +1252,24 @@ fn parse_worksheet(
                 if let Some(h) = height {
                     row_heights.insert(row_idx, h);
                 }
+                // §18.3.1.73 outline metadata: `outlineLevel` (0-7) and the
+                // summary-row `collapsed` flag. `hidden` is surfaced explicitly
+                // (not just as `height == 0`) so the gutter can distinguish a
+                // collapsed-detail row from a deliberately zero-height row.
+                let outline_level = node
+                    .attribute("outlineLevel")
+                    .and_then(|s| s.parse::<u8>().ok())
+                    .unwrap_or(0)
+                    .min(7);
+                let collapsed = attr_bool(&node, "collapsed").unwrap_or(false);
                 let cells = parse_row_cells(&node, shared_strings, theme_colors);
                 rows.push(Row {
                     index: row_idx,
                     height,
                     cells,
+                    outline_level,
+                    collapsed,
+                    hidden,
                 });
             }
             "conditionalFormatting" if is_x_ns(node.tag_name().namespace()) => {
@@ -1498,6 +1555,9 @@ fn parse_worksheet(
             rows,
             col_widths,
             row_heights,
+            col_outline_levels,
+            col_collapsed,
+            col_hidden,
             default_col_width,
             default_row_height,
             merge_cells,
@@ -1510,6 +1570,7 @@ fn parse_worksheet(
             show_zeros,
             show_gridlines,
             right_to_left,
+            outline_pr,
             tab_color,
             auto_filter,
             hyperlinks: Vec::new(),
@@ -2739,6 +2800,129 @@ mod sheet_view_tests {
             p1 < p2 && p2 < p3,
             "colWidths keys must serialize in ascending order (1,2,3), got positions {p1},{p2},{p3} in {widths}"
         );
+    }
+
+    // ── Outline grouping (ECMA-376 §18.3.1.13 / §18.3.1.61 / §18.3.1.73) ──
+
+    /// The row-outline example from §18.3.1.73 (middle + lowest level collapsed):
+    /// rows 6-8 are collapsed-hidden detail at levels 3/3/2, and row 9 is the
+    /// level-1 summary carrying `collapsed="1"`. The parser must surface each
+    /// row's `outlineLevel`, `collapsed`, and `hidden` flags verbatim.
+    #[test]
+    fn row_outline_levels_collapsed_and_hidden() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetData>
+                 <row r="6" hidden="1" outlineLevel="3"/>
+                 <row r="7" hidden="1" outlineLevel="3"/>
+                 <row r="8" hidden="1" outlineLevel="2"/>
+                 <row r="9" hidden="1" outlineLevel="1" collapsed="1"/>
+                 <row r="10" collapsed="1"/>
+               </sheetData></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+        let by_idx = |i: u32| ws.rows.iter().find(|r| r.index == i).expect("row present");
+        assert_eq!(by_idx(6).outline_level, 3);
+        assert!(by_idx(6).hidden);
+        assert!(!by_idx(6).collapsed);
+        assert_eq!(by_idx(8).outline_level, 2);
+        assert!(by_idx(8).hidden);
+        assert_eq!(by_idx(9).outline_level, 1);
+        assert!(by_idx(9).hidden);
+        assert!(by_idx(9).collapsed);
+        // Row 10 is the top-level summary: collapsed but visible, level 0.
+        assert_eq!(by_idx(10).outline_level, 0);
+        assert!(!by_idx(10).hidden);
+        assert!(by_idx(10).collapsed);
+    }
+
+    /// `outlineLevel` is clamped to the §18.3.1.73 range max of 7.
+    #[test]
+    fn row_outline_level_clamped_to_seven() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetData><row r="1" outlineLevel="9"/></sheetData></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+        assert_eq!(ws.rows[0].outline_level, 7);
+    }
+
+    /// A grouped column at the *default* width (no `customWidth`, not hidden) must
+    /// still be surfaced: its outline level reaches `col_outline_levels` even
+    /// though no `colWidths` entry is recorded (so its rendered width stays the
+    /// workbook default). `collapsed` and `hidden` map likewise.
+    #[test]
+    fn col_outline_level_recorded_without_custom_width() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><cols>
+                 <col min="2" max="3" outlineLevel="1"/>
+                 <col min="4" max="4" outlineLevel="1" collapsed="1"/>
+                 <col min="2" max="2" hidden="1" outlineLevel="1"/>
+               </cols><sheetData/></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+        assert_eq!(ws.col_outline_levels.get(&2).copied(), Some(1));
+        assert_eq!(ws.col_outline_levels.get(&3).copied(), Some(1));
+        assert_eq!(ws.col_outline_levels.get(&4).copied(), Some(1));
+        assert_eq!(ws.col_collapsed.get(&4).copied(), Some(true));
+        // The last <col> hides column 2.
+        assert_eq!(ws.col_hidden.get(&2).copied(), Some(true));
+        // A default-width grouped column gets NO colWidths entry (col 3 was never
+        // custom-width nor hidden), so its width stays the workbook default.
+        assert_eq!(ws.col_widths.get(&3).copied(), None);
+    }
+
+    /// `<sheetPr><outlinePr>` flags parse with the §18.3.1.61 defaults (both
+    /// `true`) and honor explicit `false`.
+    #[test]
+    fn outline_pr_summary_flags() {
+        let default_xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetPr><outlinePr/></sheetPr><sheetData/></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&default_xml, &[], &[], "Sheet1").expect("parses");
+        let pr = ws.outline_pr.expect("outlinePr present");
+        assert!(pr.summary_below);
+        assert!(pr.summary_right);
+
+        let above_xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetPr><outlinePr summaryBelow="0" summaryRight="0"/></sheetPr><sheetData/></worksheet>"#
+        );
+        let (ws2, _) = parse_worksheet(&above_xml, &[], &[], "Sheet1").expect("parses");
+        let pr2 = ws2.outline_pr.expect("outlinePr present");
+        assert!(!pr2.summary_below);
+        assert!(!pr2.summary_right);
+    }
+
+    /// A sheet with no outlining (no `<outlinePr>`, all `outlineLevel="0"`, as
+    /// LibreOffice emits) serializes byte-for-byte as before: no `outlinePr`,
+    /// `colOutlineLevels`, `colCollapsed`, `colHidden`, and no per-row
+    /// `outlineLevel` / `collapsed` / `hidden` keys.
+    #[test]
+    fn outline_free_sheet_is_wire_stable() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}">
+                 <cols><col customWidth="1" min="1" max="1" width="22" outlineLevel="0" collapsed="0"/></cols>
+                 <sheetData>
+                   <row r="1" hidden="0" outlineLevel="0" collapsed="0"><c r="A1"/></row>
+                 </sheetData>
+               </worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("parses");
+        let v = serde_json::to_value(&ws).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(!obj.contains_key("outlinePr"), "no outlinePr key");
+        assert!(
+            !obj.contains_key("colOutlineLevels"),
+            "no colOutlineLevels key"
+        );
+        assert!(!obj.contains_key("colCollapsed"), "no colCollapsed key");
+        assert!(!obj.contains_key("colHidden"), "no colHidden key");
+        let row0 = &v["rows"][0];
+        let row_obj = row0.as_object().unwrap();
+        assert!(
+            !row_obj.contains_key("outlineLevel"),
+            "no row outlineLevel key"
+        );
+        assert!(!row_obj.contains_key("collapsed"), "no row collapsed key");
+        assert!(!row_obj.contains_key("hidden"), "no row hidden key");
     }
 }
 

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -81,6 +81,23 @@ pub struct Worksheet {
     /// identical input.
     pub col_widths: BTreeMap<u32, f64>,
     pub row_heights: BTreeMap<u32, f64>,
+    /// Per-column outline (grouping) depth, 0-7 (ECMA-376 §18.3.1.13
+    /// `<col outlineLevel>`). Only columns whose level is non-zero are recorded,
+    /// so a sheet without column outlining serializes an empty map (omitted from
+    /// JSON). Keyed by 1-based column index like {@link col_widths}.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub col_outline_levels: BTreeMap<u32, u8>,
+    /// Per-column `<col collapsed>` (§18.3.1.13): set on the *summary* column
+    /// when the columns one level deeper are collapsed. Only `true` entries are
+    /// recorded. Keyed by 1-based column index.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub col_collapsed: BTreeMap<u32, bool>,
+    /// Per-column `<col hidden>` (§18.3.1.13): `true` when the column is hidden
+    /// (e.g. a collapsed outline hides its detail columns). Recorded explicitly —
+    /// distinct from `width == 0` — so the outline gutter can tell collapsed
+    /// detail columns apart. Only `true` entries are recorded.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub col_hidden: BTreeMap<u32, bool>,
     pub default_col_width: f64,
     pub default_row_height: f64,
     pub merge_cells: Vec<MergeCell>,
@@ -103,6 +120,14 @@ pub struct Worksheet {
     /// grid so column A sits on the right. Parsed from `<sheetView rightToLeft>`
     /// (ECMA-376 §18.3.1.87). Defaults to false (left-to-right).
     pub right_to_left: bool,
+    /// Outline display properties from `<sheetPr><outlinePr>` (ECMA-376
+    /// §18.3.1.61): `summaryBelow` / `summaryRight` decide which side of a group
+    /// the summary row/column (and its +/- toggle) sits on. `None` (omitted from
+    /// JSON) when the sheet declares no `<outlinePr>`; the viewer then applies the
+    /// schema defaults (both `true`). Only surfaced when the sheet actually has
+    /// outlining so outline-free sheets keep byte-identical JSON.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outline_pr: Option<OutlinePr>,
     /// Tab color for the sheet tab (ECMA-376 §18.3.1.79)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tab_color: Option<String>,
@@ -181,6 +206,9 @@ impl Worksheet {
             rows: Vec::new(),
             col_widths: BTreeMap::new(),
             row_heights: BTreeMap::new(),
+            col_outline_levels: BTreeMap::new(),
+            col_collapsed: BTreeMap::new(),
+            col_hidden: BTreeMap::new(),
             default_col_width: 0.0,
             default_row_height: 0.0,
             merge_cells: Vec::new(),
@@ -193,6 +221,7 @@ impl Worksheet {
             show_zeros: true,
             show_gridlines: true,
             right_to_left: false,
+            outline_pr: None,
             tab_color: None,
             auto_filter: None,
             hyperlinks: Vec::new(),
@@ -949,18 +978,63 @@ pub struct Hyperlink {
     pub display: Option<String>,
 }
 
+/// `<sheetPr><outlinePr>` display flags (ECMA-376 §18.3.1.61). When
+/// `summary_below` is `true` (the default) a group's summary row sits *below*
+/// its detail rows; when `false`, above. `summary_right` is the column analogue
+/// (summary to the right of detail by default). These decide where the outline
+/// gutter draws each group's collapse toggle.
+#[derive(Debug, Serialize, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub struct OutlinePr {
+    pub summary_below: bool,
+    pub summary_right: bool,
+}
+
+impl Default for OutlinePr {
+    fn default() -> Self {
+        // ECMA-376 §18.3.1.61 defaults: both flags true.
+        OutlinePr {
+            summary_below: true,
+            summary_right: true,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Row {
     pub index: u32,
     pub height: Option<f64>,
     pub cells: Vec<Cell>,
+    /// Outline (grouping) depth of this row, 0-7 (ECMA-376 §18.3.1.73
+    /// `<row outlineLevel>`). `0` (the ungrouped default) is omitted from JSON
+    /// so a sheet without outlining serializes byte-for-byte as before.
+    #[serde(skip_serializing_if = "is_zero_u8", default)]
+    pub outline_level: u8,
+    /// `<row collapsed>` (§18.3.1.73): set on the *summary* row when the rows one
+    /// outline level deeper are in the collapsed state. Drives which +/- toggle
+    /// the gutter draws. Omitted from JSON when false (the schema default).
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub collapsed: bool,
+    /// `<row hidden>` (§18.3.1.73): `1` when the row is hidden — most commonly
+    /// because a collapsed outline hides its detail rows, but also plain
+    /// user-hidden rows. Kept as an explicit flag (distinct from `height == 0`)
+    /// so the outline gutter can tell collapsed-detail rows apart from
+    /// zero-height rows. Omitted from JSON when false.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub hidden: bool,
 }
 
 /// serde `skip_serializing_if` predicate: drop the common unstyled `0` so the
 /// per-cell JSON doesn't carry a redundant `styleIndex` on every plain cell.
 /// The TS side reads it as `styleIndex ?? 0`, so an omitted field is equivalent.
 fn is_zero_u32(v: &u32) -> bool {
+    *v == 0
+}
+
+/// serde `skip_serializing_if` predicate for the common ungrouped `outlineLevel`
+/// of `0`, so a sheet without outlining keeps its byte-identical JSON.
+fn is_zero_u8(v: &u8) -> bool {
     *v == 0
 }
 

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -25,6 +25,8 @@ export type {
   SheetMeta,
   SheetVisibility,
   Worksheet,
+  // Outline (row/column grouping) display flags, reachable via Worksheet.outlinePr.
+  OutlinePr,
   Row,
   Cell,
   CellValue,

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -1,5 +1,5 @@
 export { XlsxWorkbook, type LoadOptions } from './workbook.js';
-export type { WireRenderViewportOptions } from './worker-protocol.js';
+export type { WireRenderViewportOptions, WireSizeOverrides } from './worker-protocol.js';
 export { XlsxViewer } from './viewer.js';
 // Resolved list-validation values (reachable via XlsxWorkbook.resolveValidationList).
 export type { ResolvedList } from './validation-list.js';

--- a/packages/xlsx/src/outline.test.ts
+++ b/packages/xlsx/src/outline.test.ts
@@ -3,7 +3,13 @@ import {
   buildOutlineLayout,
   toggleGroupHidden,
   levelButtonHidden,
+  rowBands,
+  colBands,
+  summaryAfterFor,
+  gutterExtentPx,
+  OUTLINE_LANE_PX,
   type BandOutline,
+  type OutlineWorksheetLike,
 } from './outline.js';
 
 /** Build BandOutline[] from a compact `{index: [level, collapsed?, hidden?]}` map. */
@@ -137,5 +143,78 @@ describe('levelButtonHidden', () => {
     const { hide, show } = levelButtonHidden(b, 4);
     expect(hide).toEqual([]);
     expect(show.sort()).toEqual([6, 7, 8, 9]);
+  });
+});
+
+describe('worksheet band extraction (parser field mapping)', () => {
+  // Mirrors the synthetic openpyxl fixture: rows 2-9 grouped (nested 3 levels),
+  // rows 4-7 collapsed-hidden, row 8 the collapsed summary; cols 2-7 grouped.
+  const ws: OutlineWorksheetLike = {
+    rows: [
+      { index: 1 },
+      { index: 2, outlineLevel: 1 },
+      { index: 3, outlineLevel: 2 },
+      { index: 4, outlineLevel: 3, hidden: true },
+      { index: 5, outlineLevel: 3, hidden: true },
+      { index: 6, outlineLevel: 3, hidden: true },
+      { index: 7, outlineLevel: 3, hidden: true },
+      { index: 8, outlineLevel: 2, collapsed: true },
+      { index: 9, outlineLevel: 1 },
+      { index: 10 },
+    ],
+    colOutlineLevels: { 2: 1, 3: 2, 4: 2, 5: 2, 6: 2, 7: 1 },
+    outlinePr: { summaryBelow: true, summaryRight: true },
+  };
+
+  it('rowBands surfaces only grouped / collapsed rows with their flags', () => {
+    const rb = rowBands(ws);
+    expect(rb.map((b) => b.index)).toEqual([2, 3, 4, 5, 6, 7, 8, 9]);
+    const r8 = rb.find((b) => b.index === 8)!;
+    expect(r8).toMatchObject({ level: 2, collapsed: true, hidden: false });
+    const r4 = rb.find((b) => b.index === 4)!;
+    expect(r4).toMatchObject({ level: 3, collapsed: false, hidden: true });
+  });
+
+  it('colBands reads the parallel colOutlineLevels map', () => {
+    const cb = colBands(ws);
+    expect(cb.map((b) => b.index)).toEqual([2, 3, 4, 5, 6, 7]);
+    expect(cb.find((b) => b.index === 3)?.level).toBe(2);
+    expect(cb.find((b) => b.index === 7)?.level).toBe(1);
+  });
+
+  it('the fixture yields the expected nested row layout with the innermost collapsed', () => {
+    const layout = buildOutlineLayout(rowBands(ws), summaryAfterFor(ws, 'row'));
+    expect(layout.maxLevel).toBe(3);
+    // Lane 3 detail 4..7, summary row 8, collapsed (row 8 carries collapsed=1).
+    const l3 = layout.groups.find((g) => g.level === 3)!;
+    expect(l3).toMatchObject({ start: 4, end: 7, summary: 8, collapsed: true });
+    // Lane 2 detail 3..8, summary row 9, NOT collapsed.
+    const l2 = layout.groups.find((g) => g.level === 2)!;
+    expect(l2).toMatchObject({ start: 3, end: 8, summary: 9, collapsed: false });
+  });
+
+  it('expanding the innermost collapsed group reveals exactly its detail rows', () => {
+    const rb = rowBands(ws);
+    const layout = buildOutlineLayout(rb, true);
+    const l3 = layout.groups.find((g) => g.level === 3)!;
+    const { hide, show, nowCollapsed } = toggleGroupHidden(l3, rb);
+    expect(nowCollapsed).toBe(false);
+    expect(hide).toEqual([]);
+    expect(show.sort((a, b) => a - b)).toEqual([4, 5, 6, 7]);
+  });
+
+  it('summaryAfterFor honors outlinePr and defaults true when absent', () => {
+    expect(summaryAfterFor(ws, 'row')).toBe(true);
+    expect(summaryAfterFor({ rows: [] }, 'row')).toBe(true);
+    expect(summaryAfterFor({ rows: [], outlinePr: { summaryBelow: false, summaryRight: true } }, 'row')).toBe(false);
+    expect(summaryAfterFor({ rows: [], outlinePr: { summaryBelow: false, summaryRight: true } }, 'col')).toBe(true);
+  });
+});
+
+describe('gutterExtentPx', () => {
+  it('is 0 with no outlining and (maxLevel+1) lanes otherwise', () => {
+    expect(gutterExtentPx(0)).toBe(0);
+    expect(gutterExtentPx(1)).toBe(2 * OUTLINE_LANE_PX);
+    expect(gutterExtentPx(3)).toBe(4 * OUTLINE_LANE_PX);
   });
 });

--- a/packages/xlsx/src/outline.test.ts
+++ b/packages/xlsx/src/outline.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildOutlineLayout,
+  toggleGroupHidden,
+  levelButtonHidden,
+  type BandOutline,
+} from './outline.js';
+
+/** Build BandOutline[] from a compact `{index: [level, collapsed?, hidden?]}` map. */
+function bands(spec: Record<number, [number, boolean?, boolean?]>): BandOutline[] {
+  return Object.entries(spec).map(([i, [level, collapsed, hidden]]) => ({
+    index: Number(i),
+    level,
+    collapsed: collapsed ?? false,
+    hidden: hidden ?? false,
+  }));
+}
+
+describe('buildOutlineLayout', () => {
+  it('returns an empty layout when no band is grouped', () => {
+    const layout = buildOutlineLayout(bands({ 1: [0], 2: [0] }), true);
+    expect(layout.maxLevel).toBe(0);
+    expect(layout.groups).toEqual([]);
+  });
+
+  it('places the summary AFTER the detail run when summaryBelow (default)', () => {
+    // §18.3.1.73 example: rows 6-8 detail (levels 3,3,2), row 9 summary (level 1).
+    const layout = buildOutlineLayout(
+      bands({ 6: [3], 7: [3], 8: [2], 9: [1] }),
+      true,
+    );
+    expect(layout.maxLevel).toBe(3);
+    // Lane 1: the whole 6..9 run (all >= 1), summary is band 10.
+    const l1 = layout.groups.find((g) => g.level === 1);
+    expect(l1).toMatchObject({ level: 1, start: 6, end: 9, summary: 10 });
+    // Lane 2: 6..8 (>= 2), summary is band 9.
+    const l2 = layout.groups.find((g) => g.level === 2);
+    expect(l2).toMatchObject({ level: 2, start: 6, end: 8, summary: 9 });
+    // Lane 3: 6..7 (>= 3), summary is band 8.
+    const l3 = layout.groups.find((g) => g.level === 3);
+    expect(l3).toMatchObject({ level: 3, start: 6, end: 7, summary: 8 });
+  });
+
+  it('marks a group collapsed when its summary band carries collapsed', () => {
+    // §18.3.1.73 "middle level collapsed": rows 6-8 hidden, row 9 (level 1)
+    // has collapsed=1. The collapsed flag on band 9 describes its one-level-deeper
+    // (level-2) children — i.e. the LANE-2 group (6..8) is collapsed, since band 9
+    // is that group's summary. Lane 1 (summary band 10) is NOT collapsed.
+    const layout = buildOutlineLayout(
+      bands({ 6: [3, false, true], 7: [3, false, true], 8: [2, false, true], 9: [1, true] }),
+      true,
+    );
+    const l2 = layout.groups.find((g) => g.level === 2);
+    expect(l2?.summary).toBe(9);
+    expect(l2?.collapsed).toBe(true);
+    const l1 = layout.groups.find((g) => g.level === 1);
+    expect(l1?.collapsed).toBe(false);
+  });
+
+  it('places the summary BEFORE the detail run when summaryAbove', () => {
+    // Summary above: band 5 (level 1) is the summary for detail 6..7 (level 2).
+    const layout = buildOutlineLayout(
+      bands({ 5: [1], 6: [2], 7: [2] }),
+      false,
+    );
+    const l2 = layout.groups.find((g) => g.level === 2);
+    expect(l2).toMatchObject({ level: 2, start: 6, end: 7, summary: 5 });
+  });
+
+  it('yields a null summary when the run touches the sheet start (summaryAbove)', () => {
+    const layout = buildOutlineLayout(bands({ 1: [1], 2: [1] }), false);
+    const g = layout.groups.find((x) => x.level === 1);
+    expect(g?.summary).toBeNull();
+  });
+
+  it('splits two separate groups at the same level', () => {
+    const layout = buildOutlineLayout(
+      bands({ 2: [1], 3: [1], 5: [1], 6: [1] }),
+      true,
+    );
+    const l1 = layout.groups.filter((g) => g.level === 1);
+    expect(l1).toHaveLength(2);
+    expect(l1[0]).toMatchObject({ start: 2, end: 3, summary: 4 });
+    expect(l1[1]).toMatchObject({ start: 5, end: 6, summary: 7 });
+  });
+});
+
+describe('toggleGroupHidden', () => {
+  const rowBands = bands({ 6: [3], 7: [3], 8: [2], 9: [1] });
+
+  it('collapsing an expanded group hides its whole detail run', () => {
+    const layout = buildOutlineLayout(rowBands, true);
+    const l1 = layout.groups.find((g) => g.level === 1)!;
+    const { hide, show, nowCollapsed } = toggleGroupHidden(l1, rowBands);
+    expect(nowCollapsed).toBe(true);
+    expect(hide).toEqual([6, 7, 8, 9]);
+    expect(show).toEqual([]);
+  });
+
+  it('expanding a collapsed group reveals its detail run', () => {
+    // "Middle level collapsed": lane-2 group (6..8) is collapsed (summary band 9
+    // carries collapsed=1) and its detail rows 6-8 are hidden.
+    const collapsedBands = bands({
+      6: [3, false, true],
+      7: [3, false, true],
+      8: [2, false, true],
+      9: [1, true, false],
+    });
+    const layout = buildOutlineLayout(collapsedBands, true);
+    const l2 = layout.groups.find((g) => g.level === 2)!;
+    expect(l2.collapsed).toBe(true);
+    const { hide, show, nowCollapsed } = toggleGroupHidden(l2, collapsedBands);
+    expect(nowCollapsed).toBe(false);
+    expect(hide).toEqual([]);
+    // Expanding reveals band 8 (the level-2 detail) directly under band 9.
+    expect(show).toContain(8);
+  });
+});
+
+describe('levelButtonHidden', () => {
+  it('level 1 hides every grouped band', () => {
+    const b = bands({ 6: [3], 7: [3], 8: [2], 9: [1] });
+    const { hide, show } = levelButtonHidden(b, 1);
+    expect(hide.sort()).toEqual([6, 7, 8, 9]);
+    expect(show).toEqual([]);
+  });
+
+  it('level 2 hides bands at level >= 2, shows level-1 bands', () => {
+    const b = bands({ 6: [3], 7: [3], 8: [2], 9: [1] });
+    const { hide, show } = levelButtonHidden(b, 2);
+    expect(hide.sort()).toEqual([6, 7, 8]);
+    expect(show).toEqual([9]);
+  });
+
+  it('the maxLevel+1 button shows everything', () => {
+    const b = bands({ 6: [3], 7: [3], 8: [2], 9: [1] });
+    const { hide, show } = levelButtonHidden(b, 4);
+    expect(hide).toEqual([]);
+    expect(show.sort()).toEqual([6, 7, 8, 9]);
+  });
+});

--- a/packages/xlsx/src/outline.ts
+++ b/packages/xlsx/src/outline.ts
@@ -29,6 +29,21 @@
 /** Which axis a set of outline metadata describes. */
 export type OutlineAxis = 'row' | 'col';
 
+/** Width (row axis) / height (col axis) of one outline lane, in unscaled CSS px.
+ *  Excel draws each nesting level in its own ~19px lane. */
+export const OUTLINE_LANE_PX = 19;
+
+/** Side of the level-number button bank / corner (unscaled CSS px). Holds the
+ *  numbered "1 2 3" buttons that collapse the whole sheet to a level. */
+export const OUTLINE_BUTTON_PX = 12;
+
+/** Extent (px) of the gutter for an axis with `maxLevel` nesting levels, or 0
+ *  when the axis has no outlining. The lanes hold the group brackets; one extra
+ *  lane holds the numbered level buttons (levels 1..maxLevel+1). */
+export function gutterExtentPx(maxLevel: number): number {
+  return maxLevel > 0 ? (maxLevel + 1) * OUTLINE_LANE_PX : 0;
+}
+
 /** Per-band outline metadata, indexed by 1-based band index. */
 export interface BandOutline {
   /** 1-based band index (row number / column number). */
@@ -223,4 +238,56 @@ export function levelButtonHidden(
     else show.push(b.index);
   }
   return { hide, show };
+}
+
+/** Minimal worksheet shape the axis extractors read (kept structural so tests
+ *  can pass a plain object). */
+export interface OutlineWorksheetLike {
+  rows: { index: number; outlineLevel?: number; collapsed?: boolean; hidden?: boolean }[];
+  colOutlineLevels?: Record<number, number>;
+  colCollapsed?: Record<number, boolean>;
+  colHidden?: Record<number, boolean>;
+  outlinePr?: { summaryBelow: boolean; summaryRight: boolean };
+}
+
+/** Row-axis band metadata (only bands with a non-zero level or a set collapsed
+ *  flag are surfaced). Keyed off the parser's per-row fields. */
+export function rowBands(ws: OutlineWorksheetLike): BandOutline[] {
+  const out: BandOutline[] = [];
+  for (const r of ws.rows) {
+    const level = r.outlineLevel ?? 0;
+    const collapsed = r.collapsed ?? false;
+    if (level === 0 && !collapsed) continue;
+    out.push({ index: r.index, level, collapsed, hidden: r.hidden ?? false });
+  }
+  return out;
+}
+
+/** Column-axis band metadata, from the parallel `colOutlineLevels` /
+ *  `colCollapsed` / `colHidden` maps. */
+export function colBands(ws: OutlineWorksheetLike): BandOutline[] {
+  const levels = ws.colOutlineLevels ?? {};
+  const collapsed = ws.colCollapsed ?? {};
+  const hidden = ws.colHidden ?? {};
+  const indices = new Set<number>();
+  for (const k of Object.keys(levels)) indices.add(Number(k));
+  for (const k of Object.keys(collapsed)) indices.add(Number(k));
+  const out: BandOutline[] = [];
+  for (const i of [...indices].sort((a, b) => a - b)) {
+    out.push({
+      index: i,
+      level: levels[i] ?? 0,
+      collapsed: collapsed[i] ?? false,
+      hidden: hidden[i] ?? false,
+    });
+  }
+  return out;
+}
+
+/** `summaryBelow` for rows / `summaryRight` for columns, defaulting to `true`
+ *  (ECMA-376 §18.3.1.61) when the sheet declares no `<outlinePr>`. */
+export function summaryAfterFor(ws: OutlineWorksheetLike, axis: OutlineAxis): boolean {
+  const pr = ws.outlinePr;
+  if (!pr) return true;
+  return axis === 'row' ? pr.summaryBelow : pr.summaryRight;
 }

--- a/packages/xlsx/src/outline.ts
+++ b/packages/xlsx/src/outline.ts
@@ -1,0 +1,226 @@
+/**
+ * XL4 — row/column outline (grouping) geometry.
+ *
+ * Pure, DOM-free math that turns a worksheet's per-band outline metadata
+ * (ECMA-376 §18.3.1.13 `<col>`, §18.3.1.73 `<row>`, §18.3.1.61
+ * `<sheetPr><outlinePr>`) into a set of *group brackets* and *collapse toggles*
+ * that the viewer draws in the outline gutter, plus the state changes a click on
+ * a level button or a +/- toggle applies to the in-memory model.
+ *
+ * The geometry is deliberately separated from rendering so the level/summary
+ * placement rules — which side of the group the summary band (and its +/-
+ * button) sits on, per `summaryBelow` / `summaryRight` — are unit-testable
+ * without a canvas.
+ *
+ * # Model
+ *
+ * Each band (row or column) carries an `outlineLevel` in 0..7. A *group* at
+ * level `L` is a maximal run of consecutive bands whose level is `>= L`. The
+ * bracket for that group is drawn in the gutter lane for level `L`, spanning the
+ * detail run. Its collapse toggle sits on the adjacent *summary* band at level
+ * `L-1`: the band immediately AFTER the run when the summary is below/right (the
+ * default), or immediately BEFORE it when above/left.
+ *
+ * A summary band's `collapsed` flag (`<row collapsed>` / `<col collapsed>`) is
+ * `true` when its one-level-deeper detail is hidden, so the toggle renders `+`
+ * (expand) when collapsed and `-` (collapse) when expanded.
+ */
+
+/** Which axis a set of outline metadata describes. */
+export type OutlineAxis = 'row' | 'col';
+
+/** Per-band outline metadata, indexed by 1-based band index. */
+export interface BandOutline {
+  /** 1-based band index (row number / column number). */
+  index: number;
+  /** Outline depth 0..7. */
+  level: number;
+  /** `collapsed` flag from the band (set on a summary band). */
+  collapsed: boolean;
+  /** Whether the band is currently hidden (collapsed-detail or user-hidden). */
+  hidden: boolean;
+}
+
+/** A drawn group bracket: a bar in the gutter lane `level` spanning `[start,end]`
+ *  detail bands, with an optional summary band that carries the +/- toggle. */
+export interface OutlineGroup {
+  /** Outline lane this bracket occupies (1-based; lane 1 is the outermost). */
+  level: number;
+  /** First detail band (inclusive, 1-based). */
+  start: number;
+  /** Last detail band (inclusive, 1-based). */
+  end: number;
+  /** The summary band index carrying the toggle, or `null` when the group has
+   *  no summary band on the expected side (e.g. the run touches the sheet edge).
+   *  When present the +/- button is drawn at this band. */
+  summary: number | null;
+  /** `true` when the summary band is collapsed ⇒ the toggle shows `+`. */
+  collapsed: boolean;
+}
+
+/** The complete outline layout for one axis. */
+export interface OutlineLayout {
+  /** Maximum outline level present (0 ⇒ no outlining on this axis). */
+  maxLevel: number;
+  /** All group brackets, in ascending `(level, start)` order. */
+  groups: OutlineGroup[];
+}
+
+/**
+ * Build the outline layout for one axis from its band metadata.
+ *
+ * `bands` need only contain bands with a non-zero level or a set `collapsed`
+ * flag; every other band is treated as level 0 (ungrouped). `summaryBelow` is
+ * the `<outlinePr>` flag for this axis (`summaryBelow` for rows, `summaryRight`
+ * for columns) — `true` (default) puts the summary band after the detail run.
+ */
+export function buildOutlineLayout(bands: BandOutline[], summaryAfter: boolean): OutlineLayout {
+  // Densify into a level lookup so gaps between recorded bands read as level 0.
+  const levelOf = new Map<number, number>();
+  const collapsedOf = new Map<number, boolean>();
+  let maxIndex = 0;
+  let maxLevel = 0;
+  for (const b of bands) {
+    if (b.level > 0) levelOf.set(b.index, b.level);
+    if (b.collapsed) collapsedOf.set(b.index, true);
+    if (b.index > maxIndex) maxIndex = b.index;
+    if (b.level > maxLevel) maxLevel = b.level;
+  }
+  // A `collapsed` summary band can sit one past the deepest levelled band, so
+  // scan one extra index for the summary lookup.
+  const scanMax = maxIndex;
+
+  const groups: OutlineGroup[] = [];
+  if (maxLevel === 0) return { maxLevel: 0, groups };
+
+  const lvl = (i: number) => levelOf.get(i) ?? 0;
+
+  // For each lane L (1..maxLevel) find maximal runs of consecutive bands with
+  // level >= L, then attach the summary band on the configured side.
+  for (let L = 1; L <= maxLevel; L++) {
+    let run: { start: number; end: number } | null = null;
+    for (let i = 1; i <= scanMax + 1; i++) {
+      const inRun = lvl(i) >= L;
+      if (inRun) {
+        if (run) run.end = i;
+        else run = { start: i, end: i };
+      } else if (run) {
+        groups.push(makeGroup(L, run, summaryAfter, collapsedOf, lvl));
+        run = null;
+      }
+    }
+    if (run) groups.push(makeGroup(L, run, summaryAfter, collapsedOf, lvl));
+  }
+  return { maxLevel, groups };
+}
+
+function makeGroup(
+  level: number,
+  run: { start: number; end: number },
+  summaryAfter: boolean,
+  collapsedOf: Map<number, boolean>,
+  lvl: (i: number) => number,
+): OutlineGroup {
+  // The summary band sits at level `level - 1`, immediately after the run
+  // (summaryAfter) or immediately before it. It only qualifies as this group's
+  // summary when it exists at the shallower level (i.e. is NOT part of the run).
+  let summary: number | null = null;
+  if (summaryAfter) {
+    const cand = run.end + 1;
+    if (cand >= 1 && lvl(cand) < level) summary = cand;
+  } else {
+    const cand = run.start - 1;
+    if (cand >= 1 && lvl(cand) < level) summary = cand;
+  }
+  const collapsed = summary != null && (collapsedOf.get(summary) ?? false);
+  return { level, start: run.start, end: run.end, summary, collapsed };
+}
+
+/**
+ * Toggle a single group's collapse state, returning the set of detail band
+ * indices whose hidden state must flip and the new `collapsed` value for the
+ * summary band. This is the state a +/- button click produces; the viewer
+ * applies it to the in-memory worksheet (never the file).
+ *
+ * Collapsing hides every band in `[start,end]` whose level is `>= group.level`.
+ * Expanding reveals the direct children but keeps deeper nested groups that are
+ * themselves collapsed hidden — Excel restores only one level per click. To keep
+ * a viewer's behaviour predictable and reversible we reveal a child band unless
+ * it is shadowed by a still-collapsed deeper summary inside this group.
+ */
+export function toggleGroupHidden(
+  group: OutlineGroup,
+  bands: BandOutline[],
+): { hide: number[]; show: number[]; nowCollapsed: boolean } {
+  const nowCollapsed = !group.collapsed;
+  const byIndex = new Map<number, BandOutline>();
+  for (const b of bands) byIndex.set(b.index, b);
+
+  const hide: number[] = [];
+  const show: number[] = [];
+  if (nowCollapsed) {
+    // Collapse: hide the whole detail run.
+    for (let i = group.start; i <= group.end; i++) hide.push(i);
+  } else {
+    // Expand: reveal bands at exactly this group's level; leave bands belonging
+    // to a still-collapsed deeper subgroup hidden.
+    const collapsedSummaries = new Set<number>();
+    for (const b of bands) {
+      if (b.index >= group.start && b.index <= group.end && b.collapsed) {
+        collapsedSummaries.add(b.index);
+      }
+    }
+    for (let i = group.start; i <= group.end; i++) {
+      if (isShadowedByCollapsedChild(i, group, byIndex, collapsedSummaries)) continue;
+      show.push(i);
+    }
+  }
+  return { hide, show, nowCollapsed };
+}
+
+/** Whether revealing band `i` should stay hidden because a deeper collapsed
+ *  summary inside the group shadows it (i.e. `i` is detail of a nested group
+ *  whose summary is still collapsed). */
+function isShadowedByCollapsedChild(
+  i: number,
+  group: OutlineGroup,
+  byIndex: Map<number, BandOutline>,
+  collapsedSummaries: Set<number>,
+): boolean {
+  const band = byIndex.get(i);
+  const level = band?.level ?? 0;
+  // Bands at this group's own summary level are always revealed.
+  if (level <= group.level) return false;
+  // A deeper band is shadowed when a collapsed summary at a shallower-but-deeper
+  // level than it sits adjacent within the run. We approximate with: any
+  // collapsed summary strictly shallower than `level` covering `i`.
+  for (const s of collapsedSummaries) {
+    const sLevel = byIndex.get(s)?.level ?? 0;
+    if (sLevel >= level) continue;
+    if (sLevel < group.level) continue;
+    // Summary below its detail: detail is at indices < s (and > previous summary).
+    // Since exact run boundaries are not tracked here, treat any deeper band as
+    // shadowed by the nearest collapsed summary at a shallower level.
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Collect every band index that a "collapse to level N" (the numbered level
+ * buttons at the corner of the gutter) hides or shows. Clicking level button `n`
+ * shows all bands with level < `n` and hides all bands with level >= `n`.
+ * Returns the target hidden state per affected band index.
+ */
+export function levelButtonHidden(
+  bands: BandOutline[],
+  targetLevel: number,
+): { hide: number[]; show: number[] } {
+  const hide: number[] = [];
+  const show: number[] = [];
+  for (const b of bands) {
+    if (b.level >= targetLevel) hide.push(b.index);
+    else show.push(b.index);
+  }
+  return { hide, show };
+}

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -15,6 +15,7 @@ import { renderWorksheetViewport, closeAndClearImageCache } from './render-orche
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import { resolveSharedStrings } from './shared-strings.js';
 import type { ParsedWorkbook, Worksheet } from './types.js';
+import { applySizeOverrides } from './worker-protocol.js';
 import type { RenderWorkerRequest, RenderWorkerResponse } from './worker-protocol.js';
 
 // RB6: self-poison + auto-respawn. A trap during parse / per-sheet parse / image
@@ -144,6 +145,15 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
       if (!workbook) throw new Error('Workbook not loaded');
       await fontsLoaded;
       const ws = parseSheetLocally(req.sheetIndex);
+      // Converge this worker-local sheet to the main-thread model before
+      // drawing: view-only size mutations (outline collapse/expand, drag
+      // resize #567) happen on the main thread's Worksheet copy and would
+      // otherwise never reach this cache — the gutter/overlays would update
+      // while the grid bitmap stayed stale. The override map is cumulative and
+      // idempotent, so re-applying it every frame (and after a worker-side
+      // re-parse rebuilt the cache from the file) always converges.
+      const { sizeOverrides, ...renderOpts } = req.opts;
+      applySizeOverrides(ws, sizeOverrides);
       const canvas = new OffscreenCanvas(1, 1); // orchestrator resizes it
       await renderWorksheetViewport(
         { ws, styles: workbook.styles, imageCache },
@@ -151,7 +161,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         req.viewport,
         // Supply the in-worker byte loader so embedded images decode straight
         // from the retained rawData (no main-thread round-trip).
-        { ...req.opts, fetchImage: getImage },
+        { ...renderOpts, fetchImage: getImage },
       );
       const bitmap = canvas.transferToImageBitmap();
       post({ type: 'viewportRendered', id, bitmap }, [bitmap]);

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -49,6 +49,17 @@ export interface Worksheet {
   rows: Row[];
   colWidths: Record<number, number>;
   rowHeights: Record<number, number>;
+  /** Per-column outline (grouping) depth 0-7 (ECMA-376 §18.3.1.13
+   *  `<col outlineLevel>`), keyed by 1-based column index. Present only for
+   *  grouped columns; absent (⇒ level 0) on outline-free sheets. */
+  colOutlineLevels?: Record<number, number>;
+  /** Per-column `<col collapsed>` (§18.3.1.13): `true` on a summary column whose
+   *  one-level-deeper detail columns are collapsed. Only `true` entries. */
+  colCollapsed?: Record<number, boolean>;
+  /** Per-column `<col hidden>` (§18.3.1.13): `true` when the column is hidden
+   *  (e.g. a collapsed outline hides its detail columns). Distinct from
+   *  `colWidths[c] === 0`. Only `true` entries. */
+  colHidden?: Record<number, boolean>;
   defaultColWidth: number;
   defaultRowHeight: number;
   mergeCells: MergeCell[];
@@ -71,6 +82,11 @@ export interface Worksheet {
    *  grid so column A sits on the right (ECMA-376 §18.3.1.87
    *  `<sheetView rightToLeft>`). Defaults to false. */
   rightToLeft?: boolean;
+  /** Outline display flags from `<sheetPr><outlinePr>` (ECMA-376 §18.3.1.61).
+   *  Absent when the sheet declares no `<outlinePr>`; consumers apply the
+   *  schema defaults (`summaryBelow` / `summaryRight` both `true`). Decides
+   *  which side of a group the summary row/column (and its +/- toggle) sits. */
+  outlinePr?: OutlinePr;
   /** Sheet tab color (ECMA-376 §18.3.1.79). */
   tabColor?: string | null;
   /** AutoFilter header range (ECMA-376 §18.3.1.2). */
@@ -617,6 +633,26 @@ export interface Row {
   index: number;
   height: number | null;
   cells: Cell[];
+  /** Outline (grouping) depth 0-7 (ECMA-376 §18.3.1.73 `<row outlineLevel>`).
+   *  Omitted on the wire when `0` (ungrouped); read as `outlineLevel ?? 0`. */
+  outlineLevel?: number;
+  /** `<row collapsed>` (§18.3.1.73): `true` on a summary row whose
+   *  one-level-deeper detail rows are collapsed. Omitted when false. */
+  collapsed?: boolean;
+  /** `<row hidden>` (§18.3.1.73): `true` when the row is hidden — most often
+   *  because a collapsed outline hides its detail rows. Distinct from
+   *  `height === 0`. Omitted on the wire when false. */
+  hidden?: boolean;
+}
+
+/** `<sheetPr><outlinePr>` flags (ECMA-376 §18.3.1.61). Both default to `true`. */
+export interface OutlinePr {
+  /** `true` (default) ⇒ a group's summary row sits *below* its detail rows;
+   *  `false` ⇒ above. */
+  summaryBelow: boolean;
+  /** `true` (default) ⇒ a group's summary column sits to the *right* of its
+   *  detail columns; `false` ⇒ to the left. */
+  summaryRight: boolean;
 }
 
 export interface Cell {

--- a/packages/xlsx/src/viewer-outline-worker.test.ts
+++ b/packages/xlsx/src/viewer-outline-worker.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer } from './viewer.js';
+import { installDom, makeContainer, type FakeEl } from './viewer-destroy-test-dom.js';
+import { applySizeOverrides, type WireSizeOverrides } from './worker-protocol.js';
+import type { Worksheet } from './types.js';
+import type { OutlineLayout } from './outline.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Worker-mode model-sync for view-only size mutations.
+ *
+ * The render worker draws from its own worker-local parsed-sheet cache
+ * (render-worker.ts parseSheetLocally), so a main-thread Worksheet mutation —
+ * outline collapse/expand mapping bands to the size-0 hidden encoding, or
+ * drag-to-resize (#567) — never reaches the worker on its own: the gutter and
+ * overlays would update while the grid bitmap kept the file's original sizes
+ * (rows stayed hidden after an expand click). These tests pin the override
+ * channel that closes the gap:
+ *
+ * 1. every worker `renderViewport` request issued after a mutation carries
+ *    `opts.sizeOverrides` describing the touched bands' CURRENT model sizes, and
+ * 2. applying that wire payload to a pristine copy of the sheet (exactly what
+ *    the worker does before drawing) converges its size maps to the main-thread
+ *    model — the main↔worker equivalence that makes both modes lay out the
+ *    same grid.
+ */
+
+/** The synthetic outline fixture's row model: rows 2-9 grouped (3 nested
+ *  levels), detail rows 4-7 collapsed-hidden (height 0), row 8 the collapsed
+ *  level-2 summary. Mirrors outline-fixture.xlsx. */
+function outlineWorksheet(): Worksheet {
+  const row = (
+    index: number,
+    outlineLevel = 0,
+    opts: { collapsed?: boolean; hidden?: boolean } = {},
+  ) => ({ index, height: opts.hidden ? 0 : null, cells: [], outlineLevel, ...opts });
+  return {
+    name: 'Outline',
+    rows: [
+      row(1),
+      row(2, 1),
+      row(3, 2),
+      row(4, 3, { hidden: true }),
+      row(5, 3, { hidden: true }),
+      row(6, 3, { hidden: true }),
+      row(7, 3, { hidden: true }),
+      row(8, 2, { collapsed: true }),
+      row(9, 1),
+      row(10),
+    ],
+    colWidths: {},
+    rowHeights: { 4: 0, 5: 0, 6: 0, 7: 0 },
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    charts: [],
+    images: [],
+    shapeGroups: [],
+    outlinePr: { summaryBelow: true, summaryRight: true },
+  } as unknown as Worksheet;
+}
+
+/** Private-surface shape of the viewer these tests drive. */
+interface ViewerPriv {
+  wb: unknown;
+  currentWorksheet: Worksheet;
+  currentSheet: number;
+  canvasArea: FakeEl;
+  rowOutline: OutlineLayout | null;
+  resizeDrag: { kind: 'col' | 'row'; index: number; originScaled: number; mdw: number } | null;
+  buildOutline(ws: Worksheet): void;
+  applyGroupToggle(group: OutlineLayout['groups'][number], axis: 'row' | 'col'): void;
+  applyResize(clientX: number, clientY: number): void;
+  renderCurrentSheet(): Promise<void>;
+}
+
+/** Worker-mode viewer over the outline worksheet, with a fake workbook whose
+ *  renderViewportToBitmap records every request (never resolves — only the
+ *  synchronously-sent request matters here). */
+function buildWorker() {
+  installDom();
+  const container = makeContainer();
+  const v = new XlsxViewer(container as unknown as HTMLElement, { mode: 'worker' });
+  const renderViewportToBitmap = vi.fn(() => new Promise<never>(() => undefined));
+  const fakeWb = {
+    renderViewportToBitmap,
+    sheetNames: ['Outline'],
+    sheetCount: 1,
+    destroy: vi.fn(),
+  };
+  const priv = v as unknown as ViewerPriv;
+  priv.wb = fakeWb;
+  priv.currentWorksheet = outlineWorksheet();
+  priv.currentSheet = 0;
+  priv.canvasArea.clientWidth = 800;
+  priv.canvasArea.clientHeight = 600;
+  priv.buildOutline(priv.currentWorksheet);
+  return { v, priv, renderViewportToBitmap };
+}
+
+/** The `sizeOverrides` of the most recent render request, if any. */
+function lastOverrides(fn: ReturnType<typeof vi.fn>): WireSizeOverrides | undefined {
+  const call = fn.mock.calls.at(-1) as unknown[] | undefined;
+  return (call?.[2] as { sizeOverrides?: WireSizeOverrides } | undefined)?.sizeOverrides;
+}
+
+describe('worker-mode outline collapse/expand reaches the grid bitmap', () => {
+  it('expanding the collapsed group sends row overrides that reveal rows 4-7', () => {
+    const { priv, renderViewportToBitmap } = buildWorker();
+    const l3 = priv.rowOutline?.groups.find((g) => g.level === 3);
+    expect(l3?.collapsed).toBe(true);
+
+    // Expand (the sync-render fallback fires renderCurrentSheet immediately).
+    priv.applyGroupToggle(l3 as OutlineLayout['groups'][number], 'row');
+    expect(renderViewportToBitmap).toHaveBeenCalled();
+    const o = lastOverrides(renderViewportToBitmap);
+    // Rows 4-7 were revealed: the model has NO entry (default height) ⇒ null.
+    expect(o?.rows).toMatchObject({ 4: null, 5: null, 6: null, 7: null });
+
+    // Worker-side application converges a pristine sheet to the main model —
+    // the property that makes the worker's next bitmap actually re-lay the
+    // revealed rows (main↔worker equivalence at the model level).
+    const workerSheet = outlineWorksheet();
+    applySizeOverrides(workerSheet, o);
+    expect(workerSheet.rowHeights).toEqual(priv.currentWorksheet.rowHeights);
+    expect(workerSheet.rowHeights[4]).toBeUndefined(); // was 0 (hidden) pre-override
+  });
+
+  it('re-collapsing sends rows back as 0-height overrides', () => {
+    const { priv, renderViewportToBitmap } = buildWorker();
+    const expand = priv.rowOutline?.groups.find((g) => g.level === 3);
+    priv.applyGroupToggle(expand as OutlineLayout['groups'][number], 'row');
+    // The layout was rebuilt after the expand — fetch the group's new object.
+    const collapse = priv.rowOutline?.groups.find((g) => g.level === 3);
+    expect(collapse?.collapsed).toBe(false);
+    priv.applyGroupToggle(collapse as OutlineLayout['groups'][number], 'row');
+
+    const o = lastOverrides(renderViewportToBitmap);
+    expect(o?.rows).toMatchObject({ 4: 0, 5: 0, 6: 0, 7: 0 });
+
+    const workerSheet = outlineWorksheet();
+    applySizeOverrides(workerSheet, o);
+    expect(workerSheet.rowHeights).toEqual(priv.currentWorksheet.rowHeights);
+  });
+});
+
+describe('worker-mode drag-to-resize reaches the grid bitmap (#567 hole)', () => {
+  it('a column resize sends the new width as a col override', () => {
+    const { priv, renderViewportToBitmap } = buildWorker();
+    priv.resizeDrag = { kind: 'col', index: 2, originScaled: 0, mdw: 7 };
+    priv.applyResize(100, 0); // drag column B's right border to x=100
+
+    const o = lastOverrides(renderViewportToBitmap);
+    const newWidth = priv.currentWorksheet.colWidths[2];
+    expect(newWidth).toBeGreaterThan(0);
+    expect(o?.cols?.[2]).toBe(newWidth);
+
+    const workerSheet = outlineWorksheet();
+    applySizeOverrides(workerSheet, o);
+    expect(workerSheet.colWidths[2]).toBe(newWidth);
+  });
+
+  it('a row resize sends the new height as a row override', () => {
+    const { priv, renderViewportToBitmap } = buildWorker();
+    priv.resizeDrag = { kind: 'row', index: 9, originScaled: 0, mdw: 7 };
+    priv.applyResize(0, 60);
+
+    const o = lastOverrides(renderViewportToBitmap);
+    const newHeight = priv.currentWorksheet.rowHeights[9];
+    expect(newHeight).toBeGreaterThan(0);
+    expect(o?.rows?.[9]).toBe(newHeight);
+  });
+});
+
+describe('applySizeOverrides wire semantics', () => {
+  it('sets numeric values and deletes null entries on both axes', () => {
+    const ws = outlineWorksheet();
+    ws.colWidths[3] = 20;
+    applySizeOverrides(ws, { rows: { 4: null, 9: 30 }, cols: { 3: null, 5: 12 } });
+    expect(ws.rowHeights[4]).toBeUndefined();
+    expect(ws.rowHeights[9]).toBe(30);
+    expect(ws.colWidths[3]).toBeUndefined();
+    expect(ws.colWidths[5]).toBe(12);
+  });
+
+  it('is idempotent (re-applying the same map is a no-op) and undefined-safe', () => {
+    const ws = outlineWorksheet();
+    const o: WireSizeOverrides = { rows: { 4: null, 5: 22 } };
+    applySizeOverrides(ws, o);
+    const snapshot = JSON.stringify(ws.rowHeights);
+    applySizeOverrides(ws, o);
+    expect(JSON.stringify(ws.rowHeights)).toBe(snapshot);
+    applySizeOverrides(ws, undefined); // absent overrides: no mutation
+    expect(JSON.stringify(ws.rowHeights)).toBe(snapshot);
+  });
+});
+
+describe('override plumbing stays silent when nothing was mutated', () => {
+  it('a plain render request carries NO sizeOverrides key', async () => {
+    const { priv, renderViewportToBitmap } = buildWorker();
+    void priv.renderCurrentSheet();
+    expect(renderViewportToBitmap).toHaveBeenCalledTimes(1);
+    const call = renderViewportToBitmap.mock.calls[0] as unknown[] | undefined;
+    const opts = call?.[2] as Record<string, unknown> | undefined;
+    expect(opts).toBeDefined();
+    expect(opts !== undefined && 'sizeOverrides' in opts).toBe(false);
+  });
+});

--- a/packages/xlsx/src/viewer-render-coalesce.test.ts
+++ b/packages/xlsx/src/viewer-render-coalesce.test.ts
@@ -54,10 +54,12 @@ describe('XlsxViewer scroll-render coalescing (C4 commit 1)', () => {
     const raf = installRaf();
     const container = makeContainer();
     const v = new XlsxViewer(container as unknown as HTMLElement);
-    // The scrollHost is the 2nd child of canvasArea (canvas, overlay, scrollHost…).
-    // Reach it via the wrapper subtree the constructor mounted in the container.
+    // The scrollHost lives inside canvasArea (canvas, overlay, scrollHost…).
+    // canvasArea is nested in the gridRegion (XL4 outline gutters) which is the
+    // wrapper's first child. Reach it via the mounted subtree.
     const wrapper = container.children[0] as FakeEl;
-    const canvasArea = wrapper.children[0] as FakeEl;
+    const gridRegion = wrapper.children[0] as FakeEl;
+    const canvasArea = gridRegion.children[0] as FakeEl;
     const scrollHost = canvasArea.children.find(
       (c) => c.style.overflow === 'auto' || c._listeners.has('scroll'),
     ) as FakeEl;
@@ -138,7 +140,8 @@ describe('XlsxViewer scroll-render coalescing (C4 commit 1)', () => {
       'renderCurrentSheet',
     ).mockResolvedValue(undefined);
     const wrapper = container.children[0] as FakeEl;
-    const canvasArea = wrapper.children[0] as FakeEl;
+    const gridRegion = wrapper.children[0] as FakeEl;
+    const canvasArea = gridRegion.children[0] as FakeEl;
     const scrollHost = canvasArea.children.find((c) => c._listeners.has('scroll')) as FakeEl;
     scrollHost.dispatch('scroll');
     // No rAF: the render runs inline, preserving the old synchronous semantics.

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -697,12 +697,11 @@ export class XlsxViewer {
     this.wrapper.appendChild(this.tabBar);
     container.appendChild(this.wrapper);
 
-    // Gutter click handling (XL4): +/- toggles, group brackets, and the numbered
-    // level buttons in the corner. Registered once; no-op when a sheet has no
-    // gutter (extents 0 ⇒ canvases hidden).
+    // Gutter click handling (XL4): +/- toggles and the numbered level banks
+    // (each in its own gutter's header strip; the corner is inert background).
+    // Registered once; no-op when a sheet has no gutter (extents 0 ⇒ hidden).
     this.rowGutter.addEventListener('pointerdown', (e) => this.onGutterPointerDown(e, 'row'));
     this.colGutter.addEventListener('pointerdown', (e) => this.onGutterPointerDown(e, 'col'));
-    this.cornerGutter.addEventListener('pointerdown', (e) => this.onCornerPointerDown(e));
 
     this.scrollHost.addEventListener('scroll', () => {
       // Any scroll cancels a deferred tap: the press that started it was a
@@ -1020,6 +1019,27 @@ export class XlsxViewer {
         }
       }
     }
+
+    // Numbered level buttons (1..maxLevel+1), one per lane, in this gutter's
+    // header strip: the row bank sits beside the column-letter header (the
+    // gutter's top HEADER_H band — no bracket ever draws there because band
+    // y-coordinates start at the header edge), the column bank above the
+    // row-number header (leftmost HEADER_W band). Placing each bank in its own
+    // gutter (Excel's layout) keeps the two banks from ever sharing a cell —
+    // the old corner placement collided at the shared bottom-right lane and
+    // made the row expand-all button unreachable.
+    const bankCross = isRow ? (HEADER_H * cs) / 2 : (HEADER_W * cs) / 2;
+    for (let l = 1; l <= layout.maxLevel + 1; l++) {
+      const laneCenter = (l - 0.5) * lanePx;
+      if (laneCenter + lanePx / 2 > (isRow ? cssW : cssH) + 0.5) break;
+      this.drawLevelButton(
+        ctx,
+        isRow ? laneCenter : bankCross,
+        isRow ? bankCross : laneCenter,
+        String(l),
+        cs,
+      );
+    }
   }
 
   /** Draw a small square +/- toggle centered at (cx, cy) in gutter-canvas CSS px. */
@@ -1053,9 +1073,37 @@ export class XlsxViewer {
     ctx.restore();
   }
 
-  /** Draw the numbered level buttons (1..maxLevel+1) in the corner gutter. */
+  /** Draw one numbered level button centered at (cx, cy) in gutter-canvas CSS
+   *  px. Shared by the row bank (in the row gutter's top strip) and the column
+   *  bank (in the column gutter's left strip). */
+  private drawLevelButton(
+    ctx: CanvasRenderingContext2D,
+    cx: number,
+    cy: number,
+    label: string,
+    cs: number,
+  ): void {
+    const s = Math.round(11 * cs);
+    const x = Math.round(cx - s / 2);
+    const y = Math.round(cy - s / 2);
+    ctx.save();
+    ctx.font = `${Math.round(9 * cs)}px sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = '#ffffff';
+    ctx.strokeStyle = '#808080';
+    ctx.lineWidth = 1;
+    ctx.fillRect(x + 0.5, y + 0.5, s, s);
+    ctx.strokeRect(x + 0.5, y + 0.5, s, s);
+    ctx.fillStyle = '#404040';
+    ctx.fillText(label, cx, cy + 0.5);
+    ctx.restore();
+  }
+
+  /** Paint the corner (intersection of the two gutters) as plain background.
+   *  The numbered level banks live in each axis gutter's own header strip
+   *  (see paintAxisGutter), so the corner carries no interactive content. */
   private paintCornerGutter(): void {
-    const cs = this.opts.cellScale ?? 1;
     const dpr = window.devicePixelRatio ?? 1;
     const canvas = this.cornerGutter;
     const cssW = parseFloat(canvas.style.width) || 0;
@@ -1069,49 +1117,6 @@ export class XlsxViewer {
     ctx.clearRect(0, 0, cssW, cssH);
     ctx.fillStyle = '#f5f5f5';
     ctx.fillRect(0, 0, cssW, cssH);
-
-    // Level buttons for whichever axes are grouped. Row-level buttons stack in the
-    // row gutter's lanes (vertical column of the corner); col-level buttons run
-    // across the col gutter's lanes (horizontal row of the corner).
-    ctx.font = `${Math.round(9 * cs)}px sans-serif`;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    const lanePx = OUTLINE_LANE_PX * cs;
-    const drawBtn = (cx: number, cy: number, label: string) => {
-      const s = Math.round(11 * cs);
-      const x = Math.round(cx - s / 2);
-      const y = Math.round(cy - s / 2);
-      ctx.fillStyle = '#ffffff';
-      ctx.strokeStyle = '#808080';
-      ctx.lineWidth = 1;
-      ctx.fillRect(x + 0.5, y + 0.5, s, s);
-      ctx.strokeRect(x + 0.5, y + 0.5, s, s);
-      ctx.fillStyle = '#404040';
-      ctx.fillText(label, cx, cy + 0.5);
-    };
-    // Column-level buttons occupy the rightmost row-gutter lane (a vertical bank
-    // at x = cssW - lanePx/2), aligned to the column gutter's horizontal lanes.
-    // Row-level buttons form a horizontal bank on the bottom corner row, one per
-    // row-gutter lane — but skip the rightmost lane when a column bank already
-    // owns it, so the two banks never overprint the same cell.
-    const colBankX = this.colOutline ? cssW - lanePx / 2 : null;
-    if (this.rowOutline) {
-      const cy = cssH - lanePx / 2;
-      for (let l = 1; l <= this.rowOutline.maxLevel + 1; l++) {
-        const cx = (l - 0.5) * lanePx;
-        if (cx > this.gutter.w) break;
-        // Don't draw over the column bank's lane.
-        if (colBankX != null && Math.abs(cx - colBankX) < 0.5) continue;
-        drawBtn(cx, cy, String(l));
-      }
-    }
-    if (this.colOutline && colBankX != null) {
-      for (let l = 1; l <= this.colOutline.maxLevel + 1; l++) {
-        const cy = (l - 0.5) * lanePx;
-        if (cy > this.gutter.h) break;
-        drawBtn(colBankX, cy, String(l));
-      }
-    }
   }
 
   /** Handle a click in a row/col gutter: hit-test the +/- toggles and toggle the
@@ -1128,7 +1133,26 @@ export class XlsxViewer {
     const py = e.clientY - rect.top;
     const cs = this.opts.cellScale ?? 1;
     const lanePx = OUTLINE_LANE_PX * cs;
-    const hitR = 7 * cs; // generous grab radius around the toggle center
+    const hitR = 7 * cs; // generous grab radius around a button center
+
+    // Numbered level bank first: it lives in this gutter's header strip (row
+    // bank beside the column-letter header, column bank above the row-number
+    // header — mirrors paintAxisGutter), where no +/- toggle can be.
+    const bankCross = isRow ? (HEADER_H * cs) / 2 : (HEADER_W * cs) / 2;
+    const inBankStrip = (isRow ? py : px) <= (isRow ? HEADER_H : HEADER_W) * cs;
+    if (inBankStrip) {
+      for (let l = 1; l <= layout.maxLevel + 1; l++) {
+        const laneCenter = (l - 0.5) * lanePx;
+        const cx = isRow ? laneCenter : bankCross;
+        const cy = isRow ? bankCross : laneCenter;
+        if (Math.abs(px - cx) <= hitR && Math.abs(py - cy) <= hitR) {
+          e.preventDefault();
+          this.applyLevelButton(l, axis);
+          return;
+        }
+      }
+      return; // header strip carries no toggles — don't fall through
+    }
 
     for (const g of layout.groups) {
       if (g.summary == null) continue;
@@ -1144,49 +1168,6 @@ export class XlsxViewer {
         e.preventDefault();
         this.applyGroupToggle(g, axis);
         return;
-      }
-    }
-  }
-
-  /** Handle a click on a numbered level button in the corner gutter. */
-  private onCornerPointerDown(e: PointerEvent): void {
-    const ws = this.currentWorksheet;
-    if (!ws) return;
-    const canvas = this.cornerGutter;
-    const rect = canvas.getBoundingClientRect();
-    const px = e.clientX - rect.left;
-    const py = e.clientY - rect.top;
-    const cs = this.opts.cellScale ?? 1;
-    const lanePx = OUTLINE_LANE_PX * cs;
-    const hitR = 7 * cs;
-    const cssW = parseFloat(canvas.style.width) || 0;
-    const cssH = parseFloat(canvas.style.height) || 0;
-
-    // Match the draw order in paintCornerGutter: the column bank owns the
-    // rightmost lane, so test it first and let the row bank skip that lane.
-    const colBankX = this.colOutline ? cssW - lanePx / 2 : null;
-    if (this.colOutline && colBankX != null) {
-      for (let l = 1; l <= this.colOutline.maxLevel + 1; l++) {
-        const cy = (l - 0.5) * lanePx;
-        if (cy > this.gutter.h) break;
-        if (Math.abs(px - colBankX) <= hitR && Math.abs(py - cy) <= hitR) {
-          e.preventDefault();
-          this.applyLevelButton(l, 'col');
-          return;
-        }
-      }
-    }
-    if (this.rowOutline) {
-      const cy = cssH - lanePx / 2;
-      for (let l = 1; l <= this.rowOutline.maxLevel + 1; l++) {
-        const cx = (l - 0.5) * lanePx;
-        if (cx > this.gutter.w) break;
-        if (colBankX != null && Math.abs(cx - colBankX) < 0.5) continue;
-        if (Math.abs(px - cx) <= hitR && Math.abs(py - cy) <= hitR) {
-          e.preventDefault();
-          this.applyLevelButton(l, 'row');
-          return;
-        }
       }
     }
   }

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -11,6 +11,20 @@ import {
   computeValidationPanelPosition,
   type ResolvedList,
 } from './validation-list.js';
+import {
+  buildOutlineLayout,
+  toggleGroupHidden,
+  levelButtonHidden,
+  rowBands,
+  colBands,
+  summaryAfterFor,
+  gutterExtentPx,
+  OUTLINE_LANE_PX,
+  type BandOutline,
+  type OutlineGroup,
+  type OutlineLayout,
+  type OutlineAxis,
+} from './outline.js';
 
 // Re-exported for the existing xlsx zoom tests (resize-zoom.test.ts imports it
 // from this module) and any consumer that referenced it here before it moved to
@@ -335,6 +349,32 @@ export class XlsxViewer {
    *  (empty) state. */
   private wrapper!: HTMLDivElement;
   private canvas: HTMLCanvasElement;
+  /** Region holding the outline gutters (top/left) and the inset {@link canvasArea}.
+   *  When the active sheet has no outlining the gutters collapse to 0 px and this
+   *  is a transparent pass-through, so an outline-free sheet lays out identically. */
+  private gridRegion!: HTMLDivElement;
+  /** Left gutter canvas: row group brackets + toggles (XL4). */
+  private rowGutter!: HTMLCanvasElement;
+  /** Top gutter canvas: column group brackets + toggles (XL4). */
+  private colGutter!: HTMLCanvasElement;
+  /** Top-left corner canvas: numbered level buttons (XL4). */
+  private cornerGutter!: HTMLCanvasElement;
+  /** Cached extents (unscaled CSS px) of the current sheet's gutters; both 0 for
+   *  an outline-free sheet. `w` insets {@link canvasArea} from the left, `h` from
+   *  the top. */
+  private gutter = { w: 0, h: 0 };
+  /** Per-axis outline layout (group brackets + toggles) for the current sheet,
+   *  recomputed on sheet switch and after each collapse/expand. `null` axis ⇒ no
+   *  outlining on that axis. */
+  private rowOutline: OutlineLayout | null = null;
+  private colOutline: OutlineLayout | null = null;
+  private rowOutlineBands: BandOutline[] = [];
+  private colOutlineBands: BandOutline[] = [];
+  /** Original row heights / column widths stashed the first time a band is
+   *  collapsed, so expanding restores a custom size rather than the default.
+   *  Keyed by band index; per current worksheet (cleared on sheet switch). */
+  private stashedRowHeights = new Map<number, number | undefined>();
+  private stashedColWidths = new Map<number, number | undefined>();
   private canvasArea: HTMLDivElement;
   private scrollHost: HTMLDivElement;
   private spacer: HTMLDivElement;
@@ -493,8 +533,31 @@ export class XlsxViewer {
       `position:relative;width:100%;height:100%;` +
       `border:1px solid #c8ccd0;background:#fff;box-sizing:border-box;font-family:sans-serif;display:flex;flex-direction:column;`;
 
+    // The grid region fills the space above the tab bar. The outline gutters
+    // (XL4) sit at its top / left edges and {@link canvasArea} is inset by the
+    // gutter extents. With no outlining both extents are 0, so canvasArea covers
+    // the whole region exactly as before (byte-identical layout).
+    this.gridRegion = document.createElement('div');
+    this.gridRegion.style.cssText = `position:relative;flex:1;min-height:0;overflow:hidden;`;
+
+    // Outline gutter canvases. Absolutely positioned inside gridRegion; sized /
+    // shown per sheet in `layoutGutters`. `pointer-events:auto` on the gutters so
+    // +/- toggles and level buttons are clickable; they are painted on the main
+    // thread even in worker mode (cheap chrome, independent of the grid bitmap).
+    const gutterStyle =
+      `position:absolute;top:0;left:0;z-index:3;display:none;background:#f5f5f5;`;
+    this.cornerGutter = document.createElement('canvas');
+    this.cornerGutter.style.cssText = gutterStyle;
+    this.cornerGutter.setAttribute('data-xlsx-outline', 'corner');
+    this.colGutter = document.createElement('canvas');
+    this.colGutter.style.cssText = gutterStyle;
+    this.colGutter.setAttribute('data-xlsx-outline', 'col');
+    this.rowGutter = document.createElement('canvas');
+    this.rowGutter.style.cssText = gutterStyle;
+    this.rowGutter.setAttribute('data-xlsx-outline', 'row');
+
     this.canvasArea = document.createElement('div');
-    this.canvasArea.style.cssText = `position:relative;flex:1;min-height:0;overflow:hidden;`;
+    this.canvasArea.style.cssText = `position:absolute;inset:0;overflow:hidden;`;
 
     this.canvas = document.createElement('canvas');
     this.canvas.style.cssText = `position:absolute;top:0;left:0;z-index:0;display:block;`;
@@ -607,9 +670,21 @@ export class XlsxViewer {
       this.tabBar.appendChild(this.buildZoomControl());
     }
 
-    this.wrapper.appendChild(this.canvasArea);
+    // canvasArea first (bottom), gutters above it inside the same region.
+    this.gridRegion.appendChild(this.canvasArea);
+    this.gridRegion.appendChild(this.colGutter);
+    this.gridRegion.appendChild(this.rowGutter);
+    this.gridRegion.appendChild(this.cornerGutter);
+    this.wrapper.appendChild(this.gridRegion);
     this.wrapper.appendChild(this.tabBar);
     container.appendChild(this.wrapper);
+
+    // Gutter click handling (XL4): +/- toggles, group brackets, and the numbered
+    // level buttons in the corner. Registered once; no-op when a sheet has no
+    // gutter (extents 0 ⇒ canvases hidden).
+    this.rowGutter.addEventListener('pointerdown', (e) => this.onGutterPointerDown(e, 'row'));
+    this.colGutter.addEventListener('pointerdown', (e) => this.onGutterPointerDown(e, 'col'));
+    this.cornerGutter.addEventListener('pointerdown', (e) => this.onCornerPointerDown(e));
 
     this.scrollHost.addEventListener('scroll', () => {
       // Any scroll cancels a deferred tap: the press that started it was a
@@ -644,6 +719,10 @@ export class XlsxViewer {
     // view drifts (or, after a hidden mount, stays stranded at the far end).
     this.resizeObserver = new ResizeObserver(() => {
       this.reanchorHorizontalScroll();
+      // Re-place the outline gutter strips for the new region size (XL4). This
+      // only rewrites styles (no canvasArea size change) so it can't feed back
+      // into the observer.
+      this.layoutGutters();
       // Container resizes can burst (a live window/pane drag); coalesce the
       // canvas paint into one frame. The re-anchor, overlay and nav updates are
       // cheap and must reflect the new size at once, so they stay synchronous.
@@ -652,7 +731,7 @@ export class XlsxViewer {
       this.updateFindOverlay();
       this.updateNavButtons();
     });
-    this.resizeObserver.observe(this.canvasArea);
+    this.resizeObserver.observe(this.gridRegion);
 
     this.setupSelectionEvents();
 
@@ -759,6 +838,11 @@ export class XlsxViewer {
     this.currentWorksheet = await this.workbook.getWorksheet(index);
     this.buildCommentMap(this.currentWorksheet);
     this.buildHyperlinkMap(this.currentWorksheet);
+    // XL4: build the outline layout for this sheet and size the gutters. Must run
+    // before `updateSpacerSize` / render so the inset canvasArea has its final
+    // size when the grid geometry is computed.
+    this.buildOutline(this.currentWorksheet);
+    this.layoutGutters();
     this.updateSpacerSize(this.currentWorksheet);
     // Reset the horizontal scroll origin to the natural START of the sheet.
     // For RTL sheets the start column (col A) lives at the RIGHT, which means
@@ -771,6 +855,434 @@ export class XlsxViewer {
     // a sheet switch; only the visible sheet's boxes are drawn).
     this.updateFindOverlay();
     this.opts.onSheetChange?.(index, this.workbook.sheetNames.length);
+  }
+
+  // ─── Outline gutter (XL4: row/column grouping) ────────────────────────────
+
+  /** Recompute the per-axis outline layout for `ws` and cache the band lists.
+   *  Both axes are `null` (gutters collapse to 0) when the sheet has no
+   *  outlining, so an outline-free sheet is untouched. */
+  private buildOutline(ws: Worksheet): void {
+    this.stashedRowHeights.clear();
+    this.stashedColWidths.clear();
+    this.rowOutlineBands = rowBands(ws);
+    this.colOutlineBands = colBands(ws);
+    const rowLayout = buildOutlineLayout(this.rowOutlineBands, summaryAfterFor(ws, 'row'));
+    const colLayout = buildOutlineLayout(this.colOutlineBands, summaryAfterFor(ws, 'col'));
+    this.rowOutline = rowLayout.maxLevel > 0 ? rowLayout : null;
+    this.colOutline = colLayout.maxLevel > 0 ? colLayout : null;
+  }
+
+  /** Size and place the three gutter canvases (corner / col / row) from the
+   *  current outline, and inset {@link canvasArea} by the gutter extents. When
+   *  neither axis is grouped both extents are 0 and canvasArea covers the whole
+   *  region — pixel-identical to a viewer built before XL4. */
+  private layoutGutters(): void {
+    const cs = this.opts.cellScale ?? 1;
+    const gw = this.rowOutline ? Math.round(gutterExtentPx(this.rowOutline.maxLevel) * cs) : 0;
+    const gh = this.colOutline ? Math.round(gutterExtentPx(this.colOutline.maxLevel) * cs) : 0;
+    this.gutter = { w: gw, h: gh };
+
+    // Inset canvasArea so the grid (and every geometry read that keys off its
+    // client rect) starts after the gutters.
+    this.canvasArea.style.left = `${gw}px`;
+    this.canvasArea.style.top = `${gh}px`;
+
+    const show = (el: HTMLCanvasElement, x: number, y: number, w: number, h: number) => {
+      if (w <= 0 || h <= 0) { el.style.display = 'none'; return; }
+      el.style.display = 'block';
+      el.style.left = `${x}px`;
+      el.style.top = `${y}px`;
+      el.style.width = `${w}px`;
+      el.style.height = `${h}px`;
+    };
+    const regionW = this.gridRegion.clientWidth;
+    const regionH = this.gridRegion.clientHeight;
+    // Corner holds the numbered level buttons; only meaningful where both a
+    // horizontal and vertical gutter exist, but we always paint it to cover the
+    // intersection so the two strips meet cleanly.
+    show(this.cornerGutter, 0, 0, gw, gh);
+    show(this.colGutter, gw, 0, Math.max(0, regionW - gw), gh);
+    show(this.rowGutter, 0, gh, gw, Math.max(0, regionH - gh));
+  }
+
+  /** Paint all visible gutter strips for the current scroll offset. Called at the
+   *  end of every grid render so the brackets track scroll / zoom exactly. */
+  private renderGutters(): void {
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    if (this.gutter.h > 0 && this.colOutline) this.paintAxisGutter('col');
+    if (this.gutter.w > 0 && this.rowOutline) this.paintAxisGutter('row');
+    if (this.gutter.w > 0 || this.gutter.h > 0) this.paintCornerGutter();
+  }
+
+  /** Draw one axis's group brackets and +/- toggles into its gutter canvas,
+   *  aligned to the on-screen band positions via {@link getCellRect}. */
+  private paintAxisGutter(axis: OutlineAxis): void {
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    const cs = this.opts.cellScale ?? 1;
+    const dpr = window.devicePixelRatio ?? 1;
+    const isRow = axis === 'row';
+    const canvas = isRow ? this.rowGutter : this.colGutter;
+    const layout = isRow ? this.rowOutline : this.colOutline;
+    if (!layout) return;
+    const cssW = parseFloat(canvas.style.width) || 0;
+    const cssH = parseFloat(canvas.style.height) || 0;
+    if (cssW <= 0 || cssH <= 0) return;
+    // Backing-store size at DPR; CSS size stays as laid out.
+    canvas.width = Math.round(cssW * dpr);
+    canvas.height = Math.round(cssH * dpr);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+    ctx.fillStyle = '#f5f5f5';
+    ctx.fillRect(0, 0, cssW, cssH);
+
+    const lanePx = OUTLINE_LANE_PX * cs;
+    // The gutter canvas's cross-axis origin (0) sits at the grid's cell-area
+    // origin: for the row gutter, y=0 aligns with the top of the row header +
+    // gutter; getCellRect returns coordinates in canvasArea space, which is
+    // offset from the gutter canvas by exactly `gutter.h` (col gutter is above).
+    // The gutter canvas top is at gridRegion y = gutter.h, and canvasArea top is
+    // also at gutter.h — so a band's canvasArea-space y maps 1:1 to gutter-canvas
+    // y. Likewise x for the col gutter (offset by gutter.w).
+    ctx.strokeStyle = '#808080';
+    ctx.lineWidth = 1;
+    ctx.fillStyle = '#404040';
+
+    for (const g of layout.groups) {
+      // Lane index for this level: lane 0 is the outermost (level 1). Buttons and
+      // the outermost bracket sit nearest the grid edge? Excel draws level 1 in
+      // the lane FARTHEST from the grid, deeper levels closer. We place level L in
+      // lane (L-1) counted from the sheet-far edge.
+      const laneFromFar = g.level - 1;
+      const laneCenterCross = (laneFromFar + 0.5) * lanePx;
+
+      // Detail run extent along the band axis, from on-screen cell rects.
+      const startRect = isRow ? this.getCellRect(g.start, 1) : this.getCellRect(1, g.start);
+      const endRect = isRow ? this.getCellRect(g.end, 1) : this.getCellRect(1, g.end);
+      if (!startRect || !endRect) continue;
+      const a = isRow ? startRect.y : this.screenX(startRect.x, startRect.w);
+      const b = isRow ? endRect.y + endRect.h : this.screenX(endRect.x, endRect.w) + endRect.w;
+      const runStart = Math.min(a, b);
+      const runEnd = Math.max(a, b);
+
+      // A collapsed group's detail run is hidden (zero visible extent) — Excel
+      // draws only the +/- toggle, no bracket. Skip the bracket when the run has
+      // negligible length.
+      if (!g.collapsed && runEnd - runStart > 1) {
+        ctx.beginPath();
+        if (isRow) {
+          ctx.moveTo(laneCenterCross, runStart);
+          ctx.lineTo(laneCenterCross, runEnd);
+          // Elbow tick toward the grid at the summary end.
+          const tickY = g.summary != null && g.summary > g.end ? runEnd : runStart;
+          ctx.lineTo(laneCenterCross + lanePx / 2, tickY);
+        } else {
+          ctx.moveTo(runStart, laneCenterCross);
+          ctx.lineTo(runEnd, laneCenterCross);
+          const tickX = g.summary != null && g.summary > g.end ? runEnd : runStart;
+          ctx.lineTo(tickX, laneCenterCross + lanePx / 2);
+        }
+        ctx.stroke();
+      }
+
+      // +/- toggle box on the summary band.
+      if (g.summary != null) {
+        const sRect = isRow ? this.getCellRect(g.summary, 1) : this.getCellRect(1, g.summary);
+        if (sRect) {
+          const along = isRow
+            ? sRect.y + sRect.h / 2
+            : this.screenX(sRect.x, sRect.w) + sRect.w / 2;
+          this.drawToggleBox(ctx, isRow ? laneCenterCross : along, isRow ? along : laneCenterCross, g.collapsed, cs);
+        }
+      }
+    }
+  }
+
+  /** Draw a small square +/- toggle centered at (cx, cy) in gutter-canvas CSS px. */
+  private drawToggleBox(
+    ctx: CanvasRenderingContext2D,
+    cx: number,
+    cy: number,
+    collapsed: boolean,
+    cs: number,
+  ): void {
+    const s = Math.round(9 * cs);
+    const x = Math.round(cx - s / 2);
+    const y = Math.round(cy - s / 2);
+    ctx.save();
+    ctx.fillStyle = '#ffffff';
+    ctx.strokeStyle = '#808080';
+    ctx.lineWidth = 1;
+    ctx.fillRect(x + 0.5, y + 0.5, s, s);
+    ctx.strokeRect(x + 0.5, y + 0.5, s, s);
+    ctx.strokeStyle = '#404040';
+    ctx.beginPath();
+    // horizontal stroke (present for both + and -)
+    ctx.moveTo(x + 2.5, y + s / 2 + 0.5);
+    ctx.lineTo(x + s - 1.5, y + s / 2 + 0.5);
+    if (collapsed) {
+      // vertical stroke makes it a "+"
+      ctx.moveTo(x + s / 2 + 0.5, y + 2.5);
+      ctx.lineTo(x + s / 2 + 0.5, y + s - 1.5);
+    }
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  /** Draw the numbered level buttons (1..maxLevel+1) in the corner gutter. */
+  private paintCornerGutter(): void {
+    const cs = this.opts.cellScale ?? 1;
+    const dpr = window.devicePixelRatio ?? 1;
+    const canvas = this.cornerGutter;
+    const cssW = parseFloat(canvas.style.width) || 0;
+    const cssH = parseFloat(canvas.style.height) || 0;
+    if (cssW <= 0 || cssH <= 0) { return; }
+    canvas.width = Math.round(cssW * dpr);
+    canvas.height = Math.round(cssH * dpr);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+    ctx.fillStyle = '#f5f5f5';
+    ctx.fillRect(0, 0, cssW, cssH);
+
+    // Level buttons for whichever axes are grouped. Row-level buttons stack in the
+    // row gutter's lanes (vertical column of the corner); col-level buttons run
+    // across the col gutter's lanes (horizontal row of the corner).
+    ctx.font = `${Math.round(9 * cs)}px sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const lanePx = OUTLINE_LANE_PX * cs;
+    const drawBtn = (cx: number, cy: number, label: string) => {
+      const s = Math.round(11 * cs);
+      const x = Math.round(cx - s / 2);
+      const y = Math.round(cy - s / 2);
+      ctx.fillStyle = '#ffffff';
+      ctx.strokeStyle = '#808080';
+      ctx.lineWidth = 1;
+      ctx.fillRect(x + 0.5, y + 0.5, s, s);
+      ctx.strokeRect(x + 0.5, y + 0.5, s, s);
+      ctx.fillStyle = '#404040';
+      ctx.fillText(label, cx, cy + 0.5);
+    };
+    // Column-level buttons occupy the rightmost row-gutter lane (a vertical bank
+    // at x = cssW - lanePx/2), aligned to the column gutter's horizontal lanes.
+    // Row-level buttons form a horizontal bank on the bottom corner row, one per
+    // row-gutter lane — but skip the rightmost lane when a column bank already
+    // owns it, so the two banks never overprint the same cell.
+    const colBankX = this.colOutline ? cssW - lanePx / 2 : null;
+    if (this.rowOutline) {
+      const cy = cssH - lanePx / 2;
+      for (let l = 1; l <= this.rowOutline.maxLevel + 1; l++) {
+        const cx = (l - 0.5) * lanePx;
+        if (cx > this.gutter.w) break;
+        // Don't draw over the column bank's lane.
+        if (colBankX != null && Math.abs(cx - colBankX) < 0.5) continue;
+        drawBtn(cx, cy, String(l));
+      }
+    }
+    if (this.colOutline && colBankX != null) {
+      for (let l = 1; l <= this.colOutline.maxLevel + 1; l++) {
+        const cy = (l - 0.5) * lanePx;
+        if (cy > this.gutter.h) break;
+        drawBtn(colBankX, cy, String(l));
+      }
+    }
+  }
+
+  /** Handle a click in a row/col gutter: hit-test the +/- toggles and toggle the
+   *  matching group's collapse state. */
+  private onGutterPointerDown(e: PointerEvent, axis: OutlineAxis): void {
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    const isRow = axis === 'row';
+    const layout = isRow ? this.rowOutline : this.colOutline;
+    if (!layout) return;
+    const canvas = isRow ? this.rowGutter : this.colGutter;
+    const rect = canvas.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
+    const cs = this.opts.cellScale ?? 1;
+    const lanePx = OUTLINE_LANE_PX * cs;
+    const hitR = 7 * cs; // generous grab radius around the toggle center
+
+    for (const g of layout.groups) {
+      if (g.summary == null) continue;
+      const laneCenterCross = (g.level - 1 + 0.5) * lanePx;
+      const sRect = isRow ? this.getCellRect(g.summary, 1) : this.getCellRect(1, g.summary);
+      if (!sRect) continue;
+      const along = isRow
+        ? sRect.y + sRect.h / 2
+        : this.screenX(sRect.x, sRect.w) + sRect.w / 2;
+      const cx = isRow ? laneCenterCross : along;
+      const cy = isRow ? along : laneCenterCross;
+      if (Math.abs(px - cx) <= hitR && Math.abs(py - cy) <= hitR) {
+        e.preventDefault();
+        this.applyGroupToggle(g, axis);
+        return;
+      }
+    }
+  }
+
+  /** Handle a click on a numbered level button in the corner gutter. */
+  private onCornerPointerDown(e: PointerEvent): void {
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    const canvas = this.cornerGutter;
+    const rect = canvas.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
+    const cs = this.opts.cellScale ?? 1;
+    const lanePx = OUTLINE_LANE_PX * cs;
+    const hitR = 7 * cs;
+    const cssW = parseFloat(canvas.style.width) || 0;
+    const cssH = parseFloat(canvas.style.height) || 0;
+
+    // Match the draw order in paintCornerGutter: the column bank owns the
+    // rightmost lane, so test it first and let the row bank skip that lane.
+    const colBankX = this.colOutline ? cssW - lanePx / 2 : null;
+    if (this.colOutline && colBankX != null) {
+      for (let l = 1; l <= this.colOutline.maxLevel + 1; l++) {
+        const cy = (l - 0.5) * lanePx;
+        if (cy > this.gutter.h) break;
+        if (Math.abs(px - colBankX) <= hitR && Math.abs(py - cy) <= hitR) {
+          e.preventDefault();
+          this.applyLevelButton(l, 'col');
+          return;
+        }
+      }
+    }
+    if (this.rowOutline) {
+      const cy = cssH - lanePx / 2;
+      for (let l = 1; l <= this.rowOutline.maxLevel + 1; l++) {
+        const cx = (l - 0.5) * lanePx;
+        if (cx > this.gutter.w) break;
+        if (colBankX != null && Math.abs(cx - colBankX) < 0.5) continue;
+        if (Math.abs(px - cx) <= hitR && Math.abs(py - cy) <= hitR) {
+          e.preventDefault();
+          this.applyLevelButton(l, 'row');
+          return;
+        }
+      }
+    }
+  }
+
+  /** Flip a single group's collapse state in the in-memory model, then rebuild
+   *  the outline + repaint. View-only: the file is never written. */
+  private applyGroupToggle(group: OutlineGroup, axis: OutlineAxis): void {
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    const bands = axis === 'row' ? this.rowOutlineBands : this.colOutlineBands;
+    const { hide, show, nowCollapsed } = toggleGroupHidden(group, bands);
+    for (const i of hide) this.setBandHidden(axis, i, true);
+    for (const i of show) this.setBandHidden(axis, i, false);
+    // Reflect the new collapsed state on the summary band so the next toggle
+    // reads the correct direction and the +/- glyph flips.
+    if (group.summary != null) this.setBandCollapsed(axis, group.summary, nowCollapsed);
+    this.afterOutlineMutation(ws);
+  }
+
+  /** Collapse/expand the whole sheet to `level` on one axis. */
+  private applyLevelButton(level: number, axis: OutlineAxis): void {
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    const bands = axis === 'row' ? this.rowOutlineBands : this.colOutlineBands;
+    const { hide, show } = levelButtonHidden(bands, level);
+    for (const i of hide) this.setBandHidden(axis, i, true);
+    for (const i of show) this.setBandHidden(axis, i, false);
+    // Update each group's summary-band collapsed flag from the new state: a group
+    // at lane L is collapsed exactly when its detail (level >= L) is now hidden,
+    // i.e. `L >= level`. Driving this off the layout's groups (rather than the
+    // band list) also reaches level-0 summary bands, which are not in `bands`.
+    const layout = axis === 'row' ? this.rowOutline : this.colOutline;
+    if (layout) {
+      for (const g of layout.groups) {
+        if (g.summary != null) this.setBandCollapsed(axis, g.summary, g.level >= level);
+      }
+    }
+    this.afterOutlineMutation(ws);
+  }
+
+  /** Set a row/column hidden by mapping to the size-0 encoding the axis/renderer
+   *  already understand, stashing the original size so expand can restore it. */
+  private setBandHidden(axis: OutlineAxis, index: number, hidden: boolean): void {
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    if (axis === 'row') {
+      if (hidden) {
+        if (!this.stashedRowHeights.has(index)) {
+          this.stashedRowHeights.set(index, ws.rowHeights[index]);
+        }
+        ws.rowHeights[index] = 0;
+      } else {
+        if (this.stashedRowHeights.has(index)) {
+          const orig = this.stashedRowHeights.get(index);
+          if (orig === undefined) delete ws.rowHeights[index];
+          else ws.rowHeights[index] = orig;
+          this.stashedRowHeights.delete(index);
+        } else if (ws.rowHeights[index] === 0) {
+          // Was hidden in the source file (height 0) with no stash — reveal at
+          // the default height.
+          delete ws.rowHeights[index];
+        }
+      }
+    } else {
+      if (hidden) {
+        if (!this.stashedColWidths.has(index)) {
+          this.stashedColWidths.set(index, ws.colWidths[index]);
+        }
+        ws.colWidths[index] = 0;
+      } else {
+        if (this.stashedColWidths.has(index)) {
+          const orig = this.stashedColWidths.get(index);
+          if (orig === undefined) delete ws.colWidths[index];
+          else ws.colWidths[index] = orig;
+          this.stashedColWidths.delete(index);
+        } else if (ws.colWidths[index] === 0) {
+          delete ws.colWidths[index];
+        }
+      }
+    }
+  }
+
+  /** Update the `collapsed` flag on a band's model entry so the outline rebuild
+   *  reflects the new state. */
+  private setBandCollapsed(axis: OutlineAxis, index: number, collapsed: boolean): void {
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    if (axis === 'row') {
+      const row = ws.rows.find((r) => r.index === index);
+      if (row) row.collapsed = collapsed;
+    } else {
+      ws.colCollapsed = ws.colCollapsed ?? {};
+      if (collapsed) ws.colCollapsed[index] = true;
+      else delete ws.colCollapsed[index];
+    }
+  }
+
+  /** Shared tail of a gutter interaction: invalidate the axis cache, rebuild the
+   *  outline (collapsed flags changed), refresh dependent geometry, re-render. */
+  private afterOutlineMutation(ws: Worksheet): void {
+    sheetAxisCache.delete(ws);
+    this.buildOutlineLayoutOnly(ws);
+    this.updateSpacerSize(ws);
+    this.updateSelectionOverlay();
+    this.scheduleRender();
+  }
+
+  /** Rebuild only the layout + band lists (not the stashes) after a collapse
+   *  state change, so the +/- glyphs and bracket set stay in sync. */
+  private buildOutlineLayoutOnly(ws: Worksheet): void {
+    this.rowOutlineBands = rowBands(ws);
+    this.colOutlineBands = colBands(ws);
+    const rowLayout = buildOutlineLayout(this.rowOutlineBands, summaryAfterFor(ws, 'row'));
+    const colLayout = buildOutlineLayout(this.colOutlineBands, summaryAfterFor(ws, 'col'));
+    this.rowOutline = rowLayout.maxLevel > 0 ? rowLayout : null;
+    this.colOutline = colLayout.maxLevel > 0 ? colLayout : null;
   }
 
   /** True when the current sheet's grid is laid out right-to-left. */
@@ -2527,6 +3039,9 @@ export class XlsxViewer {
       // so we must re-derive scrollLeft from the preserved effective value or
       // the view would jump toward the start on every zoom step.
       const prevEffective = this.effectiveScrollLeft;
+      // Gutter extents scale with cellScale (XL4); re-lay them out before the
+      // spacer/scroll math reads canvasArea's new inset size.
+      this.layoutGutters();
       this.updateSpacerSize(this.currentWorksheet);
       this.effectiveH = prevEffective;
       if (this.isRtl) {
@@ -2731,6 +3246,9 @@ export class XlsxViewer {
     } else {
       await this.workbook.renderViewport(this.canvas, this.currentSheet, viewport, renderOpts);
     }
+    // XL4: repaint the outline gutters over the fresh grid frame, aligned to the
+    // same scroll offset. No-op when the sheet has no outlining.
+    this.renderGutters();
   }
 
   private computeHeaderHighlight(): {

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -11,6 +11,7 @@ import {
   computeValidationPanelPosition,
   type ResolvedList,
 } from './validation-list.js';
+import type { WireSizeOverrides } from './worker-protocol.js';
 import {
   buildOutlineLayout,
   toggleGroupHidden,
@@ -375,6 +376,23 @@ export class XlsxViewer {
    *  Keyed by band index; per current worksheet (cleared on sheet switch). */
   private stashedRowHeights = new Map<number, number | undefined>();
   private stashedColWidths = new Map<number, number | undefined>();
+  /**
+   * Per-sheet cumulative record of every view-only size mutation (outline
+   * collapse/expand, drag-to-resize #567), keyed by sheet index. Value = the
+   * band's current model size, or `null` when the model has no entry (default
+   * size). Serialized as {@link WireSizeOverrides} with every worker
+   * `renderViewport` so the worker's local sheet cache converges to the
+   * main-thread model — without it the worker keeps drawing the file's
+   * original sizes and the grid bitmap goes stale under the (up-to-date)
+   * gutter and overlays. Entries are updated in place and never removed
+   * (idempotent re-application); the whole store resets when a new workbook
+   * loads. Main mode never reads it (the main renderer draws from the mutated
+   * model directly).
+   */
+  private sizeOverrideStore = new Map<
+    number,
+    { rows: Map<number, number | null>; cols: Map<number, number | null> }
+  >();
   private canvasArea: HTMLDivElement;
   private scrollHost: HTMLDivElement;
   private spacer: HTMLDivElement;
@@ -801,8 +819,10 @@ export class XlsxViewer {
       }
       this.wb = wb;
       previous?.destroy();
-      // A new workbook invalidates any prior find state.
+      // A new workbook invalidates any prior find state and every accumulated
+      // view-only size override (sheet indices now name different sheets).
       this._find.invalidate();
+      this.sizeOverrideStore.clear();
       this.buildTabs();
       this.opts.onReady?.(this.wb.sheetNames);
       await this.showSheet(this._initialSheet());
@@ -1247,6 +1267,36 @@ export class XlsxViewer {
         }
       }
     }
+    // Mirror the post-mutation model value into the worker override channel so
+    // a worker-mode grid actually re-lays the band (main mode ignores this).
+    this.recordSizeOverride(axis, index);
+  }
+
+  /** Record band `index`'s CURRENT model size (or `null` = no entry) in the
+   *  per-sheet override store. Called after every view-only size mutation —
+   *  outline hide/show above and drag-to-resize (#567) — so worker renders
+   *  converge to the main model. */
+  private recordSizeOverride(axis: OutlineAxis, index: number): void {
+    const ws = this.currentWorksheet;
+    if (!ws) return;
+    let entry = this.sizeOverrideStore.get(this.currentSheet);
+    if (!entry) {
+      entry = { rows: new Map(), cols: new Map() };
+      this.sizeOverrideStore.set(this.currentSheet, entry);
+    }
+    if (axis === 'row') entry.rows.set(index, ws.rowHeights[index] ?? null);
+    else entry.cols.set(index, ws.colWidths[index] ?? null);
+  }
+
+  /** The current sheet's override store serialized for the wire, or undefined
+   *  when nothing has been mutated (keeps the request payload unchanged). */
+  private wireSizeOverrides(): WireSizeOverrides | undefined {
+    const entry = this.sizeOverrideStore.get(this.currentSheet);
+    if (!entry || (entry.rows.size === 0 && entry.cols.size === 0)) return undefined;
+    const o: WireSizeOverrides = {};
+    if (entry.rows.size > 0) o.rows = Object.fromEntries(entry.rows);
+    if (entry.cols.size > 0) o.cols = Object.fromEntries(entry.cols);
+    return o;
   }
 
   /** Update the `collapsed` flag on a band's model entry so the outline rebuild
@@ -1726,10 +1776,12 @@ export class XlsxViewer {
       const ptX = this.screenX(clientX - rect.left, 0);
       const sizePx = Math.max(RESIZE_MIN_PX, Math.round((ptX - drag.originScaled) / cs));
       ws.colWidths[drag.index] = pxToColWidth(sizePx, drag.mdw);
+      this.recordSizeOverride('col', drag.index);
     } else {
       const ptY = clientY - rect.top;
       const sizePx = Math.max(RESIZE_MIN_PX, Math.round((ptY - drag.originScaled) / cs));
       ws.rowHeights[drag.index] = pxToRowHeight(sizePx);
+      this.recordSizeOverride('row', drag.index);
     }
 
     sheetAxisCache.delete(ws); // sizes changed → rebuild the cumulative-offset axes
@@ -3220,7 +3272,15 @@ export class XlsxViewer {
     if (this._mode === 'worker') {
       // Render the viewport off the main thread and paint the returned bitmap.
       // The selection overlay (geometry-based, from getCellRect) is unaffected.
-      const bmp = await this.workbook.renderViewportToBitmap(this.currentSheet, viewport, renderOpts);
+      // Attach the cumulative view-only size overrides (outline collapse/
+      // expand, drag resize) so the worker re-lays the mutated bands — its
+      // local sheet cache never sees main-thread model writes on its own.
+      const sizeOverrides = this.wireSizeOverrides();
+      const bmp = await this.workbook.renderViewportToBitmap(
+        this.currentSheet,
+        viewport,
+        sizeOverrides ? { ...renderOpts, sizeOverrides } : renderOpts,
+      );
       // Drop a stale frame: if a newer render was requested while this bitmap was
       // in flight (scroll moved on, the sheet switched, a zoom changed), painting
       // it would overwrite the fresher frame. Close it to free the GPU memory

--- a/packages/xlsx/src/worker-protocol.ts
+++ b/packages/xlsx/src/worker-protocol.ts
@@ -6,13 +6,60 @@ import type {
   Worksheet,
 } from './types.js';
 
+/**
+ * View-only per-band size overrides for one sheet, carried with every worker
+ * `renderViewport` request. The render worker draws from its own worker-local
+ * parsed-sheet cache, so main-thread Worksheet mutations (outline
+ * collapse/expand via the size-0 hidden encoding, drag-to-resize #567) never
+ * reach it on their own — without this channel the gutter/overlays update but
+ * the grid bitmap stays stale.
+ *
+ * Semantics: keys are 1-based band indices; a number is the band's current
+ * `rowHeights` / `colWidths` model value, `null` means "no entry — fall back
+ * to the sheet default". The main thread accumulates every band the user has
+ * touched this session (entries are updated in place, never removed), so
+ * re-applying the full map is idempotent and converges the worker's cached
+ * sheet to the main model even across worker-side re-parses.
+ */
+export interface WireSizeOverrides {
+  rows?: Record<number, number | null>;
+  cols?: Record<number, number | null>;
+}
+
+/**
+ * Apply {@link WireSizeOverrides} to a worksheet's size maps (mutates `ws`).
+ * Runs worker-side on every `renderViewport` before drawing. Touches only the
+ * two size maps, so the worker's memoized render cache (cell map, merge sets —
+ * keyed by the Worksheet object identity) stays valid.
+ */
+export function applySizeOverrides(ws: Worksheet, overrides: WireSizeOverrides | undefined): void {
+  if (!overrides) return;
+  if (overrides.rows) {
+    for (const [k, v] of Object.entries(overrides.rows)) {
+      const idx = Number(k);
+      if (v === null) delete ws.rowHeights[idx];
+      else ws.rowHeights[idx] = v;
+    }
+  }
+  if (overrides.cols) {
+    for (const [k, v] of Object.entries(overrides.cols)) {
+      const idx = Number(k);
+      if (v === null) delete ws.colWidths[idx];
+      else ws.colWidths[idx] = v;
+    }
+  }
+}
+
 /** Serializable subset of RenderViewportOptions: drop the callback, the image
  *  cache, and the `fetchImage` loader (all non-cloneable; the worker owns its
- *  own cache and supplies its own in-worker fetchImage). */
+ *  own cache and supplies its own in-worker fetchImage). Extended with the
+ *  optional {@link WireSizeOverrides} so view-only size mutations reach the
+ *  worker's local sheet copy; absent (the common case) when nothing has been
+ *  resized or collapsed, keeping the wire payload unchanged. */
 export type WireRenderViewportOptions = Omit<
   RenderViewportOptions,
   'onTextRun' | 'loadedImages' | 'fetchImage'
->;
+> & { sizeOverrides?: WireSizeOverrides };
 
 // The base `parse` arm from types.ts is intentionally NOT reused: the render
 // worker's `parse` carries an extra `useGoogleFonts` flag, and two `parse`


### PR DESCRIPTION
## XL4 — Row/column outline (grouping)

Implements Excel-style row/column **outline grouping** for xlsx: the gutter with group bars, +/- collapse toggles, and numbered level buttons, plus collapse/expand interaction — in both main and worker render modes.

### Spec
- **§18.3.1.73 `<row>`** — `outlineLevel` (0-7), `collapsed` (on the summary row), `hidden` (collapsed detail).
- **§18.3.1.13 `<col>`** — the column analogues.
- **§18.3.1.61 `<sheetPr><outlinePr>`** — `summaryBelow` / `summaryRight` (both default `true`) decide which side of a group the summary band and its toggle sit on. `applyStyles` is out of scope.

The `collapsed` flag lives on the summary band and describes its one-level-deeper children; Excel writes `hidden="1"` on the collapsed detail rows, so a collapsed group is already hidden on load via the existing size-0 mechanism.

### Parser (Rust)
- New `Row` fields `outlineLevel` / `collapsed` / `hidden`, parallel `colOutlineLevels` / `colCollapsed` / `colHidden` maps, and an `outlinePr` object. A grouped column at the default width is now retained (previously skipped) but without a width entry so its rendered width is unchanged.
- Every new field is omitted from JSON at its schema default, so an outline-free sheet — including LibreOffice's explicit `outlineLevel="0"` everywhere — serializes **byte-for-byte** as before.

### Viewer (TS)
- A left (row) and top (column) gutter canvas plus a corner, in a new `gridRegion` that insets `canvasArea` by the gutter extents. Both extents are `0` for an outline-free sheet (gutter canvases `display:none`), so its layout is pixel-identical.
- Group brackets with an elbow toward the summary end; a +/- box on each group's summary (+ when collapsed). Summary side follows `summaryBelow` / `summaryRight`.
- **Level banks**: the numbered buttons (1..maxLevel+1) live in each gutter's own header strip — the row bank beside the column-letter header, the column bank above the row-number header (Excel's layout). Placing both banks in the shared corner is geometrically impossible without a one-cell collision (which would make the row expand-all button unreachable); the corner is inert background.
- Interaction is **view-only**: a +/- click flips one group, a level button collapses/expands the whole axis. Visibility is toggled through the existing size-0 hidden encoding (original sizes stashed for restore), the axis cache is invalidated, and the sheet re-renders. The gutter repaints after every grid frame and reuses `getCellRect`, so cell hit-testing, selection, and find are unaffected by the gutter offset.
- Pure, unit-tested outline geometry lives in `outline.ts`.

### Worker-mode model sync (new wire channel)
The render worker draws from its own worker-local parsed-sheet cache, so main-thread size mutations never reached it: the gutter updated while the grid bitmap stayed stale — and drag-to-resize (#567) had the same pre-existing hole. Every worker `renderViewport` request now carries a cumulative per-sheet **size-override map** (`WireSizeOverrides`: band → current model size, `null` = default) that the worker applies to its cached sheet before drawing. Idempotent re-application converges the worker sheet to the main model across re-parses; both outline toggles and drag-resize route through it; requests with no mutations are wire-unchanged. Main mode is untouched.

### Measured verification (Storybook + Playwright, synthetic gitignored fixture: 3-level rows + 2-level cols, innermost row group collapsed)
- **Parser**: WASM output matches the spec model exactly — `outlinePr {below,right}`, `colOutlineLevels {2:1,3:2..7:1}`, `collapsed:[8]`, `hidden:[4,5,6,7]`.
- **Worker mode, grid actually moves**: +/- toggle re-lays the grid bitmap (rows 4-7 appear/disappear); level-1 collapses all; level-4 (row expand-all, unreachable before the bank relocation) restores every row. Grid-crop byte deltas confirmed at each step; zero console errors.
- **Main <-> worker equivalence**: grid crops are **byte-identical** between modes in all four toggle states (initial / expanded / level-1 / level-4).
- **Selection hit-test** lands on the correct cell with the gutter offset present.
- **Non-regression**: demo VRT byte-identical (8/8); RTL + all-`outlineLevel="0"` sample stays fully inert (no gutter, byte-stable JSON).
- Gates: parser `cargo fmt` / `clippy -D warnings` / `test` (133), xlsx vitest (486, incl. 7 worker-sync pins), root `tsc`, ast-grep (no new findings).

### Known follow-up
RTL sheets keep the gutter at the LTR position (no RTL+outline fixture exists); noted in code as a follow-up rather than adding untested mirroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
