### PR TITLE
fix(docx): reserve the bottom paragraph-border extent in the vertical flow (§17.3.1.7)

### DIFF
--- a/packages/docx/src/para-bottom-border-flow.test.ts
+++ b/packages/docx/src/para-bottom-border-flow.test.ts
@@ -3,6 +3,9 @@ import { renderDocumentToCanvas } from './renderer.js';
 import type {
   BodyElement,
   DocParagraph,
+  DocTable,
+  DocTableCell,
+  DocTableRow,
   DocxDocumentModel,
   ParagraphBorders,
   SectionProps,
@@ -31,21 +34,26 @@ const WIDTH_PT = 1.5; // sz12 = 12 eighths of a point → 1.5 pt
 const EXPECTED_EXTENT = SPACE_PT + WIDTH_PT / 2; // 1.75 pt
 
 interface HStroke { y: number; strokeStyle: string; }
+interface FillRectCall { x: number; y: number; w: number; h: number; fillStyle: string; }
 
 function makeRecordingCanvas(): {
   canvas: HTMLCanvasElement;
   hStrokes: HStroke[];
   textBaselines: number[];
+  fillRects: FillRectCall[];
 } {
   let font = '10px serif';
   let strokeStyle = '#000';
+  let fillStyle = '#000';
   const hStrokes: HStroke[] = [];
   const textBaselines: number[] = [];
+  const fillRects: FillRectCall[] = [];
   let path: { x: number; y: number }[] = [];
   const ctx = {
     get font() { return font; },
     set font(v: string) { font = v; },
-    fillStyle: '#000',
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string) { fillStyle = v; },
     get strokeStyle() { return strokeStyle; },
     set strokeStyle(v: string) { strokeStyle = v; },
     letterSpacing: '0px',
@@ -68,7 +76,9 @@ function makeRecordingCanvas(): {
       }
     },
     fill() {},
-    fillRect() {},
+    fillRect(x: number, y: number, w: number, h: number) {
+      fillRects.push({ x, y, w, h, fillStyle });
+    },
     strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
     setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
     bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
@@ -80,7 +90,10 @@ function makeRecordingCanvas(): {
     globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
   };
   const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
-  return { canvas: canvas as unknown as HTMLCanvasElement, hStrokes, textBaselines };
+  // Real CanvasRenderingContext2D has a `.canvas` back-reference; the renderer
+  // reads it on some table paths (e.g. the §17.4.80 Y-axis clip).
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, hStrokes, textBaselines, fillRects };
 }
 
 function bottomBorderOnly(): ParagraphBorders {
@@ -160,5 +173,81 @@ describe('a bottom paragraph border reserves flow so following content clears it
     // below the border edge = borderY + width/2.
     const boxTop = withBorder.baseline - 8;
     expect(boxTop).toBeGreaterThanOrEqual((withBorder.borderY as number) + WIDTH_PT / 2 - 1e-6);
+  });
+
+  it('a bordered paragraph inside a table cell measures as tall as it paints (B2 single measurer)', async () => {
+    // measureCellElementHeight must mirror the paint pass's trailing advance
+    // max(spaceAfter, bottom-border extent) — renderCellContent → renderParagraph
+    // advances by the border extent, so a cell measured without it sizes its row
+    // SHORT and the painted content pokes past the cell band (clipped under an
+    // `exact` row rule, bleeding otherwise). A LARGE extent (space=6, sz48 → 6 pt
+    // stroke → extent 9 pt) makes the pre-fix shortfall far exceed the line box's
+    // internal leading, so the assertion discriminates cleanly.
+    const CELL_SPACE_PT = 6;
+    const CELL_WIDTH_PT = 6; // sz48 = 48 eighths of a point → 6 pt stroke
+    const CELL_BG = 'ffeecc';
+    const ruled: DocParagraph = {
+      ...para('Ruled', null),
+      borders: {
+        top: null,
+        bottom: { style: 'single', color: BORDER_COLOR, width: CELL_WIDTH_PT, space: CELL_SPACE_PT } as NonNullable<ParagraphBorders['bottom']>,
+        left: null, right: null, between: null,
+      },
+    } as DocParagraph;
+    const cell: DocTableCell = {
+      content: [
+        { type: 'paragraph', ...ruled },
+        { type: 'paragraph', ...para('Below', null) },
+      ],
+      colSpan: 1, vMerge: null,
+      borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+      background: CELL_BG,
+      vAlign: 'top',
+      widthPt: 300,
+    } as unknown as DocTableCell;
+    const row: DocTableRow = {
+      cells: [cell], rowHeight: null, rowHeightRule: 'auto', isHeader: false,
+    } as unknown as DocTableRow;
+    const table: DocTable = {
+      colWidths: [300], rows: [row],
+      borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+      cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+      jc: 'left',
+    } as unknown as DocTable;
+    const doc = {
+      section: {
+        pageWidth: PAGE_WIDTH, pageHeight: 4000,
+        marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+        headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+      } as SectionProps,
+      body: [{ type: 'table', ...table } as unknown as BodyElement],
+      headers: { default: null, first: null, even: null },
+      footers: { default: null, first: null, even: null },
+      fontFamilyClasses: { 'Times New Roman': 'roman' },
+    } as unknown as DocxDocumentModel;
+
+    const { canvas, hStrokes, textBaselines, fillRects } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, canvas, 0, {
+      dpr: 1, width: PAGE_WIDTH, // scale = 1 px per pt
+      fetchImage: async (_p: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }),
+    });
+
+    // The cell background fillRect's height IS the measured row band (auto row =
+    // measureCellContentHeightPx). The painted content must fit inside it.
+    const bg = fillRects.filter((r) => r.fillStyle === `#${CELL_BG}`);
+    expect(bg.length).toBe(1);
+    const bandBottom = bg[0].y + bg[0].h;
+
+    // Both paragraphs drew; "Below" is the lowest baseline. Its line box bottom
+    // (baseline + 0.2 em descent with the mock metrics) must not poke past the
+    // measured band — pre-fix the band was `space + width/2` (9 pt) short.
+    expect(textBaselines.length).toBeGreaterThanOrEqual(2);
+    const lastBaseline = Math.max(...textBaselines);
+    expect(lastBaseline + 2).toBeLessThanOrEqual(bandBottom + 1e-6);
+
+    // Sanity: the rule itself was drawn, inside the band.
+    const rule = hStrokes.filter((s) => s.strokeStyle === `#${BORDER_COLOR}`);
+    expect(rule.length).toBeGreaterThanOrEqual(1);
+    expect(Math.max(...rule.map((s) => s.y))).toBeLessThanOrEqual(bandBottom + CELL_WIDTH_PT / 2 + 1e-6);
   });
 });

--- a/packages/docx/src/para-bottom-border-flow.test.ts
+++ b/packages/docx/src/para-bottom-border-flow.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxDocumentModel,
+  ParagraphBorders,
+  SectionProps,
+} from './types';
+
+// ECMA-376 §17.3.1.7 — a paragraph BOTTOM border is drawn `w:space` points below
+// the text ("the space after the bottom of the text … before this border is
+// drawn"), and §17.3.4 gives the border its own width (`w:sz`, eighths of a point).
+// drawParaBorders strokes the line CENTERED on `textBottom + space`, so its outer
+// (bottom) edge is at `textBottom + space + width/2`. Word reserves that whole
+// extent in the vertical flow — a bottom-bordered paragraph pushes the FOLLOWING
+// paragraph BELOW the border rather than letting its first line box overlap the
+// rule. The spec is silent on the flow reservation; this is Word's observed layout
+// (sample-14: the reference-list rule sat ~1.75 pt too high — half a border-width
+// plus its space — so "Further examples…" nearly touched the rule).
+//
+// The renderer used to draw the bottom border PAST `state.y` without advancing the
+// flow by that extent, so the next paragraph overlapped it. This test measures the
+// flow delta a bottom border introduces: the follower's baseline must drop by
+// exactly `space + width/2` versus an identical layout whose leading paragraph has
+// NO border.
+
+const BORDER_COLOR = 'aa00bb';
+const SPACE_PT = 1;
+const WIDTH_PT = 1.5; // sz12 = 12 eighths of a point → 1.5 pt
+const EXPECTED_EXTENT = SPACE_PT + WIDTH_PT / 2; // 1.75 pt
+
+interface HStroke { y: number; strokeStyle: string; }
+
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  hStrokes: HStroke[];
+  textBaselines: number[];
+} {
+  let font = '10px serif';
+  let strokeStyle = '#000';
+  const hStrokes: HStroke[] = [];
+  const textBaselines: number[] = [];
+  let path: { x: number; y: number }[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    fillStyle: '#000',
+    get strokeStyle() { return strokeStyle; },
+    set strokeStyle(v: string) { strokeStyle = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {},
+    beginPath() { path = []; },
+    closePath() {},
+    moveTo(x: number, y: number) { path.push({ x, y }); },
+    lineTo(x: number, y: number) { path.push({ x, y }); },
+    stroke() {
+      for (let i = 1; i < path.length; i++) {
+        if (path[i].y === path[i - 1].y) hStrokes.push({ y: path[i].y, strokeStyle });
+      }
+    },
+    fill() {},
+    fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(_t: string, _x: number, y: number) { textBaselines.push(y); },
+    strokeText() {},
+    lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, hStrokes, textBaselines };
+}
+
+function bottomBorderOnly(): ParagraphBorders {
+  return {
+    top: null,
+    bottom: { style: 'single', color: BORDER_COLOR, width: WIDTH_PT, space: SPACE_PT } as NonNullable<ParagraphBorders['bottom']>,
+    left: null, right: null, between: null,
+  };
+}
+
+function para(text: string, borders: ParagraphBorders | null): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    borders,
+    runs: text
+      ? [{
+          type: 'text', text, bold: false, italic: false, underline: false,
+          strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+          fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null,
+          hyperlink: null,
+        } as DocParagraph['runs'][number]]
+      : [],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+const PAGE_WIDTH = 400;
+function docOf(...paras: DocParagraph[]): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: PAGE_WIDTH, pageHeight: 4000,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: paras.map((p) => p as unknown as BodyElement),
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function followerBaseline(leadHasBorder: boolean): Promise<{ baseline: number; borderY: number | null }> {
+  const { canvas, hStrokes, textBaselines } = makeRecordingCanvas();
+  await renderDocumentToCanvas(
+    docOf(para('', leadHasBorder ? bottomBorderOnly() : null), para('Follower', null)),
+    canvas, 0, {
+      dpr: 1, width: PAGE_WIDTH, // scale = 1 px per pt
+      fetchImage: async (_p: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }),
+    });
+  const borderStrokes = hStrokes.filter((s) => s.strokeStyle === `#${BORDER_COLOR}`);
+  return {
+    baseline: Math.min(...textBaselines),
+    borderY: borderStrokes.length ? Math.max(...borderStrokes.map((s) => s.y)) : null,
+  };
+}
+
+describe('a bottom paragraph border reserves flow so following content clears it (§17.3.1.7)', () => {
+  it('a bottom border drops the following paragraph by exactly space + width/2', async () => {
+    // Baseline layouts differ ONLY in whether the leading empty paragraph carries a
+    // bottom border. The border must push the follower down by its outer extent
+    // (space + half the stroke width) so the follower's line box clears the rule.
+    const withBorder = await followerBaseline(true);
+    const noBorder = await followerBaseline(false);
+
+    expect(withBorder.borderY).not.toBeNull();
+    const delta = withBorder.baseline - noBorder.baseline;
+    // Exact reservation (a sub-pixel crispness nudge on the stroke does not move the
+    // baseline, which is placed by the flow cursor, so no tolerance is needed here —
+    // allow a hair for float arithmetic).
+    expect(delta).toBeCloseTo(EXPECTED_EXTENT, 3);
+
+    // And the follower's line box now clears the border's OUTER edge: with a
+    // 10 pt font (ascent 0.8 em = 8 pt here) the box top = baseline − 8 sits at or
+    // below the border edge = borderY + width/2.
+    const boxTop = withBorder.baseline - 8;
+    expect(boxTop).toBeGreaterThanOrEqual((withBorder.borderY as number) + WIDTH_PT / 2 - 1e-6);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2584,7 +2584,7 @@ export function computePages(
       // sectionBreak / table / any non-paragraph breaks the run → not shared).
       const nextEl = body[i + 1];
       const nextShares = nextEl?.type === 'paragraph'
-        && parasShareBorderBox(para, nextEl as unknown as DocParagraph);
+        && parasShareBorderBox(para, nextEl);
       const h = estimateParagraphHeight(measureState, para, colW(), suppressBefore, colX(), nextShares);
 
       // ECMA-376 §17.11: a footnote shares the page with its reference, so the
@@ -8164,10 +8164,11 @@ function measureCellContentHeightPx(
   // The mark itself is still painted by renderCellContent; being empty it adds no
   // visible content, so excluding it from sizing cannot hide anything.
   const measured = trimTrailingStructuralMarker(cell.content);
-  // measureCellElementHeight always includes paragraph spaceBefore+spaceAfter;
-  // sumCellContentHeight folds in contextualSuppressed (§17.3.1.33) and the
-  // prevSpaceAfter/spaceBefore overlap collapse to match the paint pass's
-  // renderCellContent. Spacing is converted from pt to px with `scale`.
+  // measureCellElementHeight always includes paragraph spaceBefore plus
+  // max(spaceAfter, bottom-border extent) — the same trailing advance the paint
+  // pass emits (§17.3.1.7); sumCellContentHeight folds in contextualSuppressed
+  // (§17.3.1.33) and the prevSpaceAfter/spaceBefore overlap collapse to match the
+  // paint pass's renderCellContent. Spacing is converted from pt to px with `scale`.
   return (cm.top + cm.bottom) * scale + sumCellContentHeight(
     measured,
     (ce) => measureCellElementHeight(state, ce, contentW, scale),
@@ -8743,8 +8744,13 @@ function measureCellElementHeight(
 ): number {
   if (ce.type === 'paragraph') {
     const para = ce as unknown as DocParagraph;
+    // §17.3.1.7: the paint pass (renderCellContent → renderParagraph) advances
+    // `max(spaceAfter, bottomBorderExtentPt)` below the text box so following
+    // content clears a drawn bottom border. Mirror it here, or a bordered cell
+    // paragraph paints taller than the cell measures (B2: single measurer).
+    // renderCellContent never passes a borderMerge, so no suppression term.
     return measureParaHeight(state, para, innerWPx, scale)
-      + (para.spaceBefore + para.spaceAfter) * scale;
+      + (para.spaceBefore + Math.max(para.spaceAfter, bottomBorderExtentPt(para.borders))) * scale;
   }
   // Nested table — estimateTableHeight works in pt; convert to px.
   const tbl = ce as unknown as DocTable;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2578,7 +2578,14 @@ export function computePages(
       const paragraphAnchorY = measureState.y;
       registerAnchorFloats(para, measureState, paragraphAnchorY);
 
-      const h = estimateParagraphHeight(measureState, para, colW(), suppressBefore, colX());
+      // §17.3.1.7 border-box merge: the bottom-border extent is only reserved when
+      // this paragraph's bottom edge is actually drawn. It is suppressed when the
+      // NEXT in-flow element is a paragraph that shares this border box (a
+      // sectionBreak / table / any non-paragraph breaks the run → not shared).
+      const nextEl = body[i + 1];
+      const nextShares = nextEl?.type === 'paragraph'
+        && parasShareBorderBox(para, nextEl as unknown as DocParagraph);
+      const h = estimateParagraphHeight(measureState, para, colW(), suppressBefore, colX(), nextShares);
 
       // ECMA-376 §17.11: a footnote shares the page with its reference, so the
       // body must stop short of the footnote area. Measure the footnotes this
@@ -3290,6 +3297,9 @@ function estimateParagraphHeight(
   contentWPt: number,
   suppressSpaceBefore = false,
   paraXPt = 0,
+  /** §17.3.1.7: the next in-flow paragraph shares this paragraph's border box, so
+   *  its bottom edge is suppressed (the box continues) and reserves no extent. */
+  nextSharesBottomBorder = false,
 ): number {
   // ECMA-376 §17.3.1.12 / Part 4 §14.11.2 — the transitional left/right indent
   // attributes are logical start/end, so they swap physical sides in a bidi
@@ -3378,7 +3388,14 @@ function estimateParagraphHeight(
       }
     }
   }
-  cursor += para.spaceAfter;
+  // §17.3.1.7: a BOTTOM border extends `space + width/2` below the text box; the
+  // next paragraph must clear it (bottomBorderExtentPt). spaceAfter (trailing
+  // whitespace) already pushes content down, so reserve only the amount by which
+  // the border pokes PAST spaceAfter — MAX, not SUM — matching Word (which does not
+  // stack the border extent on top of a larger spaceAfter). Suppressed when a
+  // same-border paragraph follows (the box continues; no bottom edge is drawn).
+  const bottomExtent = nextSharesBottomBorder ? 0 : bottomBorderExtentPt(para.borders);
+  cursor += Math.max(para.spaceAfter, bottomExtent);
   return cursor - startY;
 }
 
@@ -4820,9 +4837,14 @@ function renderEmptyMarkParagraph(
     drawParaBorders(ctx, contentX + indLeft, markRectTop, paraW, emptyH, para.borders, scale, state.dpr, borderMerge);
   }
   // Only the slice covering the FINAL line emits spaceAfter. With no inline
-  // lines there is a single slice, so this is the whole paragraph.
+  // lines there is a single slice, so this is the whole paragraph. §17.3.1.7: a
+  // drawn bottom border extends `space + width/2` below the mark box; reserve the
+  // amount it pokes past spaceAfter (MAX) so the next paragraph clears it — mirrors
+  // estimateParagraphHeight, keeping paint and pagination in lockstep.
   const isFinalSlice = !lineSlice || lineSlice.end >= totalLines;
-  if (isFinalSlice) state.y += para.spaceAfter * scale;
+  if (isFinalSlice) {
+    state.y += Math.max(para.spaceAfter, bottomBorderExtentPt(para.borders, borderMerge)) * scale;
+  }
   // wrapNone anchor images anchor relative to the paragraph (ayFromPara); when
   // the mark line flowed below a float band the paragraph (and its wrapNone
   // image) drops by the same amount, so shift the anchor base by flowShift while
@@ -5480,9 +5502,14 @@ function renderParagraph(
   }
 
   // spaceAfter is paragraph-level; only emit it on the slice that covers
-  // the FINAL line of the paragraph (or when no slice is set at all).
+  // the FINAL line of the paragraph (or when no slice is set at all). §17.3.1.7: a
+  // drawn bottom border extends `space + width/2` below the text box; reserve the
+  // amount it pokes past spaceAfter (MAX) so the next paragraph clears the rule —
+  // mirrors estimateParagraphHeight / renderEmptyMarkParagraph.
   const isFinalSlice = !lineSlice || lineSlice.end >= lines.length;
-  if (isFinalSlice) state.y += para.spaceAfter * scale;
+  if (isFinalSlice) {
+    state.y += Math.max(para.spaceAfter, bottomBorderExtentPt(para.borders, borderMerge)) * scale;
+  }
 
   // Anchor images are absolutely positioned — draw after inline flow.
   // Skip this for continuation slices: anchor positioning is paragraph-relative
@@ -9093,6 +9120,32 @@ function drawParaBorders(
   }
   drawEdge(borders.left,   x - sp(borders.left), y,        x - sp(borders.left), y + h);
   drawEdge(borders.right,  x + w + sp(borders.right), y,   x + w + sp(borders.right), y + h);
+}
+
+/** ECMA-376 §17.3.1.7 — the vertical extent (in scale-1 points) a paragraph's
+ *  BOTTOM border adds BELOW the text box, so following content clears it.
+ *
+ *  §17.3.1.7 places the bottom border `w:space` points below the text ("the space
+ *  after the bottom of the text … before this border is drawn"), and §17.3.4 gives
+ *  the border its own width (`w:sz`, eighths of a point). {@link drawParaBorders}
+ *  strokes the line CENTERED on `textBottom + space`, so its outer (bottom) edge is
+ *  at `textBottom + space + width/2`. Word reserves that whole extent in the flow —
+ *  a bottom-bordered paragraph pushes the next paragraph BELOW the border rather
+ *  than letting the following line box overlap it (the spec is silent on the flow
+ *  reservation; this is Word's observed layout, verified against sample-14's
+ *  reference-list rule, whose `space=1 sz=12` rule sat ~1.75 pt too high without it).
+ *
+ *  Returns 0 when there is no visible bottom edge, or when a same-border paragraph
+ *  follows (the bottom edge is suppressed by the §17.3.1.7 merge — the box
+ *  continues into the next paragraph, so nothing is drawn here to clear). */
+function bottomBorderExtentPt(
+  borders: ParagraphBorders | null | undefined,
+  merge?: ParaBorderMerge,
+): number {
+  if (!borders || merge?.suppressBottom) return 0;
+  const b = borders.bottom;
+  if (!b || b.style === 'none') return 0;
+  return (b.space ?? 0) + (b.width ?? 0) / 2;
 }
 
 // ===== Utilities =====


### PR DESCRIPTION
## Problem

In `packages/docx/public/private/sample-14.docx` (last page, reference-list section), the full-width horizontal rule above "Further examples of formats for other reference types" sat too close to the text below it versus the Word ground truth (`sample-14.pdf`).

The rule is the **bottom border of an empty paragraph** carrying only `<w:pBdr><w:bottom w:space="1" w:sz="12" w:val="single"/></w:pBdr>` — a RevTeX idiom for a full-width rule (the same paragraph fixed in #613 for a *different* reason: its direct `pPr` borders were being dropped by `apply_direct_para`). This PR is about the rule's **position / spacing**, not its existence.

## Root cause

Per **§17.3.1.7**, the bottom border is drawn `w:space` points *below the text* ("the space after the bottom of the text … before this border is drawn"), and **§17.3.4** gives it its own stroke width (`w:sz`, eighths of a point). `drawParaBorders` strokes the line centered on `textBottom + space`, so its outer edge is at `textBottom + space + width/2`.

Word reserves that whole extent in the vertical flow — a bottom-bordered paragraph pushes the **following** paragraph below the rule. The renderer drew the border past `state.y` **without advancing the flow** by that extent, so the next paragraph's first line box overlapped the rule. In sample-14 the effect was amplified by the collapsed continuous-section spacer between the rule and "Further examples…" (the spacer adds no height, so the follower landed at the rule's mark-box bottom).

## Measurements (rule-to-text gap, sample-14 p.3, pdftotext -bbox / pixel-measured PDF)

| | rule → "Further examples" |
|---|---|
| **Word (PDF, ground truth)** | 2.64 pt |
| **Before** | 0.75 pt (rule nearly touches the text) |
| **After** | 2.50 pt (within 0.14 pt of Word) |

The rule itself does not move; only the following reference list shifts down `space + width/2 = 1.75 pt` to clear it.

## Fix

Add `bottomBorderExtentPt = space + width/2` and reserve `max(spaceAfter, extent)` (**MAX, not SUM** — Word does not stack the border extent on top of a larger `spaceAfter`) in both paint paths (`renderParagraph`, `renderEmptyMarkParagraph`) and in `estimateParagraphHeight`, keeping paint and pagination in lockstep. The extent is suppressed when a same-border paragraph follows (the §17.3.1.7 merge draws no bottom edge there — the box continues into the next paragraph).

**Review follow-up (2nd commit):** `measureCellElementHeight` — the B2 single cell-content measurer — still summed `spaceBefore + spaceAfter`, while the cell paint path (`renderCellContent` → `renderParagraph`) now advances `max(spaceAfter, extent)`. A bordered cell paragraph (extent > spaceAfter) followed by content painted taller than the cell measured (clip under an `exact` row rule, bleed otherwise). The same `max(...)` is now mirrored there (`renderCellContent` never passes a `borderMerge`, so no suppression term on that path), pinned by a red→green cell test. The paginator's next-shares check also drops its `as unknown as` double-cast — the `type === 'paragraph'` discriminant already narrows the `BodyElement` union member.

## Known limitations (non-blocking, review findings F2/F3)

- **Page/column-split boundary asymmetry**: for a bordered paragraph split across pages, the paint pass suppresses edges per-page while the paginator's next-shares check walks the body sequence, so the reserved extent can differ at the split boundary by up to the extent itself (pt-scale). Bounded and self-healing — the following page re-syncs; no covered sample hits it.
- **Other `estimateParagraphHeight` callers** (cell/lookahead/total-height estimates) default `nextSharesBottomBorder=false` and may over-reserve the extent for a merged same-border run — a conservative direction (never clips content); merged bordered runs do not occur in the covered samples.

## Non-regression

- **Surgical blast radius**: a before/after render (branch vs current `main`, post-rebase) of sample-2/5/11/13/14 changes **only sample-14 page 3** (bbox exactly the reference-list region below the rule); all other pages are byte-identical. sample-11's only real `pBdr` carries a **right** edge only (no bottom border — the other `w:bottom val="single"` hits in its XML are *table cell* borders), so it is a structural no-op there; no covered sample has a bordered paragraph inside a table cell (that path is guarded by the new cell test instead).
- Content only shifts 1.75 pt; nothing is clipped and the page count stays 3.
- `demo/sample-1` VRT unchanged (99.1–100 % vs committed reference), including worker-equivalence.
- Full docx unit suite green (836 tests) on the branch **rebased onto current main** (includes #835 / #849, whose renderer changes touch text-height terms, orthogonal to this trailing-spacing term). New TDD tests: flow-delta test (follower drops by exactly `space + width/2`) and the bordered-cell measure/paint lockstep test — both red without the fix, green with it.
- `tsc --build` clean. `ast-grep scan`: no new findings — the double-cast the initial revision added at the paginator call site has been removed in favor of discriminant narrowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
