### PR TITLE
fix(docx): render footnotes referenced from inside tables (§17.11.10)

### DIFF
--- a/packages/docx/src/footnote-in-table.test.ts
+++ b/packages/docx/src/footnote-in-table.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement, CellElement, DocNote, DocParagraph, DocTable, DocTableCell,
+  DocTableRow, DocxDocumentModel, SectionProps,
+} from './types';
+
+// ECMA-376 §17.11.10 — a footnote is drawn at the bottom of the page that holds
+// its reference, regardless of WHERE in the document story that reference sits.
+// A `<w:footnoteReference>` can appear inside a table cell (the cell paragraph
+// carries the noteRef run), so the footnote block must be drawn — and the body
+// area reserved — even when the only reference on a page lives in a table.
+//
+// Regression: `drawPageFootnotes` and the pagination reserve pass only scanned
+// TOP-LEVEL paragraphs, so a footnote referenced solely from a table cell had
+// its marker painted (the cell run draws normally) but its content silently
+// dropped (issue #840). Endnotes were unaffected because `drawEndnotes` draws
+// every note unconditionally without scanning the body for references.
+
+const TEST_FONT = 'Times New Roman';
+
+interface Call { text: string; y: number; }
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
+  let font = '10px serif';
+  const calls: Call[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
+    strokeText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, calls };
+}
+
+function textRun(text: string, extra: Record<string, unknown> = {}) {
+  return {
+    type: 'text', text, bold: false, italic: false, underline: false,
+    strikethrough: false, fontSize: 10, color: null, fontFamily: TEST_FONT,
+    fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    ...extra,
+  };
+}
+
+function para(runs: Array<Record<string, unknown>>): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: runs as DocParagraph['runs'],
+    defaultFontSize: 10, defaultFontFamily: TEST_FONT, widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function cell(content: CellElement[]): DocTableCell {
+  return {
+    content,
+    colSpan: 1, vMerge: null,
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    background: null, vAlign: 'top', widthPt: 380,
+  } as DocTableCell;
+}
+
+function tableOf(rows: DocTableRow[]): DocTable {
+  return {
+    colWidths: [380], rows,
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left',
+  } as DocTable;
+}
+
+function row(cells: DocTableCell[]): DocTableRow {
+  return { cells, rowHeight: null, rowHeightRule: 'auto', isHeader: false } as DocTableRow;
+}
+
+function docWith(body: BodyElement[], footnotes: DocNote[]): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 400, pageHeight: 400,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage',
+  } as SectionProps;
+  return {
+    section, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { [TEST_FONT]: 'roman' },
+    footnotes,
+  } as unknown as DocxDocumentModel;
+}
+
+async function renderPage0(doc: DocxDocumentModel): Promise<Call[]> {
+  const { canvas, calls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc, canvas, 0, { dpr: 1, width: 400 });
+  return calls;
+}
+
+describe('footnote referenced from a table cell (ECMA-376 §17.11.10)', () => {
+  const footnotes: DocNote[] = [
+    { id: 'fn1', content: [para([textRun('NOTE')]) as unknown as BodyElement] },
+  ];
+
+  it('draws the footnote block for a reference that lives inside a table cell', async () => {
+    // The ONLY footnote reference on the page sits in a table cell.
+    const cellPara = para([
+      textRun('CELL'),
+      textRun('', { noteRef: { kind: 'footnote', id: 'fn1' }, vertAlign: 'super' }),
+    ]);
+    const table = tableOf([row([cell([cellPara as unknown as CellElement])])]);
+    const body: BodyElement[] = [
+      para([textRun('BODY')]) as unknown as BodyElement,
+      { type: 'table', ...table } as unknown as BodyElement,
+    ];
+    const calls = await renderPage0(docWith(body, footnotes));
+
+    // The footnote content must be painted somewhere on the page.
+    const noteY = calls.filter((c) => c.text === 'NOTE').map((c) => c.y);
+    expect(noteY.length).toBeGreaterThan(0);
+    // And it must sit at the BOTTOM of the page (below the body/table content).
+    const cellY = Math.max(...calls.filter((c) => c.text === 'CELL').map((c) => c.y));
+    expect(Math.max(...noteY)).toBeGreaterThan(cellY);
+  });
+
+  it('reserves body space so the footnote does not overlap table content', async () => {
+    // A tall footnote referenced from a cell must shrink the body area so the
+    // note (drawn at the bottom margin) never overlaps the table content above.
+    const tallNote: DocNote[] = [
+      {
+        id: 'fn1',
+        content: Array.from({ length: 6 }, () => para([textRun('NOTELINE')]) as unknown as BodyElement),
+      },
+    ];
+    const cellPara = para([
+      textRun('CELL'),
+      textRun('', { noteRef: { kind: 'footnote', id: 'fn1' }, vertAlign: 'super' }),
+    ]);
+    const table = tableOf([row([cell([cellPara as unknown as CellElement])])]);
+    const body: BodyElement[] = [
+      { type: 'table', ...table } as unknown as BodyElement,
+    ];
+    const calls = await renderPage0(docWith(body, tallNote));
+
+    const noteY = calls.filter((c) => c.text === 'NOTELINE').map((c) => c.y);
+    const cellY = calls.filter((c) => c.text === 'CELL').map((c) => c.y);
+    expect(noteY.length).toBeGreaterThan(0);
+    expect(cellY.length).toBeGreaterThan(0);
+    // Every footnote line sits below the cell text — no overlap.
+    expect(Math.min(...noteY)).toBeGreaterThan(Math.max(...cellY));
+  });
+
+  it('descends into a NESTED table (§17.4.7) to find the reference', async () => {
+    // The reference lives in a cell of a table nested inside another table's
+    // cell — the collector must recurse through both levels.
+    const innerPara = para([
+      textRun('INNER'),
+      textRun('', { noteRef: { kind: 'footnote', id: 'fn1' }, vertAlign: 'super' }),
+    ]);
+    const innerTable = tableOf([row([cell([innerPara as unknown as CellElement])])]);
+    const outerCell = cell([{ type: 'table', ...innerTable } as unknown as CellElement]);
+    const outerTable = tableOf([row([outerCell])]);
+    const body: BodyElement[] = [
+      { type: 'table', ...outerTable } as unknown as BodyElement,
+    ];
+    const calls = await renderPage0(docWith(body, footnotes));
+
+    const noteY = calls.filter((c) => c.text === 'NOTE').map((c) => c.y);
+    expect(noteY.length).toBeGreaterThan(0);
+  });
+
+  it('does not draw footnotes for a document with no references (byte-identical guard)', async () => {
+    // A table document that references NO footnote leaves the note undrawn — the
+    // fix is gated behind an actual reference, so footnote-free docs are unchanged.
+    const table = tableOf([row([cell([para([textRun('CELL')]) as unknown as CellElement])])]);
+    const body: BodyElement[] = [{ type: 'table', ...table } as unknown as BodyElement];
+    const calls = await renderPage0(docWith(body, footnotes));
+    expect(calls.filter((c) => c.text === 'NOTE').length).toBe(0);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1404,20 +1404,18 @@ function drawPageFootnotes(
   const noteById = indexNotes(doc.footnotes);
 
   // Collect referenced footnote ids in document (reading) order, de-duplicated.
+  // Descends into table cells / nested tables (§17.4.7) so a footnote referenced
+  // only from inside a table is still drawn at the page bottom (issue #840).
   const ids: string[] = [];
   const seen = new Set<string>();
-  const scan = (els: PaginatedBodyElement[]) => {
-    for (const el of els) {
-      if (el.type !== 'paragraph') continue;
-      for (const id of footnoteRefsInRuns((el as unknown as DocParagraph).runs)) {
-        if (!seen.has(id) && noteById.has(id)) {
-          seen.add(id);
-          ids.push(id);
-        }
+  for (const el of elements) {
+    for (const id of footnoteRefsInElement(el)) {
+      if (!seen.has(id) && noteById.has(id)) {
+        seen.add(id);
+        ids.push(id);
       }
     }
-  };
-  scan(elements);
+  }
   if (ids.length === 0) return;
 
   // Total block height (pt). The last note's trailing spaceAfter overflows the
@@ -1571,6 +1569,30 @@ function footnoteRefsInRuns(runs: DocRun[]): string[] {
     if (nr && nr.kind === 'footnote' && nr.id) ids.push(nr.id);
   }
   return ids;
+}
+
+/** Collect, in document (reading) order, every footnote id referenced anywhere
+ *  in a body element — including inside table cells and nested tables (ECMA-376
+ *  §17.4.7). §17.11.10 anchors a footnote to the bottom of the page holding its
+ *  reference no matter WHERE in the story the reference sits, so both the
+ *  reserve pass and the draw scan must descend into tables (a reference that
+ *  lives only in a cell would otherwise reserve no space and never be drawn —
+ *  issue #840). Paragraphs contribute their own runs' refs; a table contributes
+ *  every cell's content recursively. */
+function footnoteRefsInElement(el: BodyElement | CellElement): string[] {
+  if (el.type === 'paragraph') {
+    return footnoteRefsInRuns(el.runs);
+  }
+  if (el.type === 'table') {
+    const ids: string[] = [];
+    for (const r of el.rows) {
+      for (const c of r.cells) {
+        for (const ce of c.content) ids.push(...footnoteRefsInElement(ce));
+      }
+    }
+    return ids;
+  }
+  return [];
 }
 
 /** Measure one footnote's content block (pt). `total` is every paragraph's full
@@ -2060,6 +2082,20 @@ export function computePages(
   const effContentH = () => {
     const r = reserveAt(pages.length - 1);
     return fullContentH() - (footnoteReservePt[pages.length - 1] ?? 0) - r.bottom - r.top;
+  };
+  // ECMA-376 §17.11 — sum the reserve height (pt) for a set of newly-referenced
+  // notes, charging the separator region only to the first note on a page (when
+  // that page has no reserve yet). Shared by the paragraph and table placement
+  // paths so a footnote referenced from either reserves body space consistently.
+  const sumReserve = (ids: string[]): number => {
+    let sum = 0;
+    for (let k = 0; k < ids.length; k++) {
+      const note = noteById.get(ids[k]);
+      if (!note) continue;
+      const firstOnPage = (footnoteReservePt[pages.length - 1] ?? 0) === 0 && k === 0;
+      sum += footnoteReserveHeightPt(note, measureState, colW(), firstOnPage);
+    }
+    return sum;
   };
   const startPageBookkeeping = () => {
     footnoteReservePt[pages.length - 1] = 0;
@@ -2551,19 +2587,6 @@ export function computePages(
       // don't fit, both move to the next page together.
       let newRefIds: string[] = [];
       let addReservePt = 0;
-      // Sum the reserve for a set of newly-referenced notes, charging the
-      // separator region only to the first note on a page (when that page has
-      // no reserve yet).
-      const sumReserve = (ids: string[]): number => {
-        let sum = 0;
-        for (let k = 0; k < ids.length; k++) {
-          const note = noteById.get(ids[k]);
-          if (!note) continue;
-          const firstOnPage = (footnoteReservePt[pages.length - 1] ?? 0) === 0 && k === 0;
-          sum += footnoteReserveHeightPt(note, measureState, colW(), firstOnPage);
-        }
-        return sum;
-      };
       if (haveFootnotes) {
         const seen = new Set<string>();
         for (const id of footnoteRefsInRuns(para.runs)) {
@@ -2893,11 +2916,39 @@ export function computePages(
       const { colWidthsPt: tblColWidthsPt, rowHeightsPt: rowHs } =
         computeTablePtLayout(measureState, tbl, tblContentWPt);
       const h = rowHs.reduce((s, x) => s + x, 0);
-      // Footnote references inside table cells are not folded into the reserve
-      // (the per-page reserve is driven by body paragraphs); they still draw at
-      // page bottom via the renderer's page scan. effContentH() respects any
-      // reserve already accumulated on this page.
-      const tableContentH = effContentH();
+      // ECMA-376 §17.11.10 — a footnote referenced from inside a table cell is
+      // drawn at the bottom of the page holding the table, so the body area must
+      // shrink by the note height just as it does for a body-paragraph reference
+      // (issue #840). Collect the table's not-yet-reserved footnote ids and fold
+      // their height into BOTH the fit decision and the committed page reserve.
+      // (A row-split table reserves on the page where it ends — the same
+      // approximation a split footnote-bearing paragraph uses above; §17.11.10's
+      // per-row placement across a split is a documented residual.)
+      let tblNewRefIds: string[] = [];
+      let tblReservePt = 0;
+      if (haveFootnotes) {
+        const seen = new Set<string>();
+        for (const id of footnoteRefsInElement(el)) {
+          if (pageNoteIds.has(id) || seen.has(id) || !noteById.has(id)) continue;
+          seen.add(id);
+          tblNewRefIds.push(id);
+        }
+        tblReservePt = sumReserve(tblNewRefIds);
+      }
+      // effContentH() respects any reserve already accumulated on this page; the
+      // table's own footnote reserve is subtracted on top so the note clears the
+      // table content.
+      const tableContentH = effContentH() - tblReservePt;
+      const commitTableReserve = () => {
+        if (!haveFootnotes || tblNewRefIds.length === 0) return;
+        // Re-filter against the landing page (a split may have advanced pages, so
+        // the separator region is charged only if that page had no note yet).
+        tblNewRefIds = tblNewRefIds.filter((id) => !pageNoteIds.has(id));
+        const addPt = sumReserve(tblNewRefIds);
+        const idx = pages.length - 1;
+        footnoteReservePt[idx] = (footnoteReservePt[idx] ?? 0) + addPt;
+        for (const id of tblNewRefIds) pageNoteIds.add(id);
+      };
       if (h > tableContentH) {
         // Taller than a full column: split row-by-row so the overflow continues
         // into the next column / page instead of being clipped (ECMA-376 table
@@ -2923,6 +2974,7 @@ export function computePages(
         );
         y = endY;
         measureState.y = bodyTopPt() + endY;
+        commitTableReserve();
       } else {
         // §17.6.4 column balancing (wantsBalanceBreak) OR a table that doesn't fit
         // the rest of this column ⇒ advance to the next column / page.
@@ -2932,6 +2984,7 @@ export function computePages(
         pushTagged(el as PaginatedBodyElement);
         y += h;
         measureState.y += h;
+        commitTableReserve();
       }
       prevPara = null;
     }


### PR DESCRIPTION
## Summary

Fixes footnote content silently vanishing when the `<w:footnoteReference>` lives inside a table cell (reported in #840). The inline reference marker rendered, but the footnote body at the bottom of the page did not — while endnotes rendered correctly.

## Root cause

The parser extracts `word/footnotes.xml` and `word/endnotes.xml` symmetrically and correctly — both note bodies and the body reference markers are present in the model (verified against `sample-11` and a synthetic fixture). The bug is entirely in the **renderer**:

- `drawPageFootnotes` collected referenced footnote ids by scanning only **top-level paragraphs** (`el.type === 'paragraph'`), never descending into tables.
- The pagination **reserve pass** likewise folded footnote height into the body only for top-level paragraph references; the table branch explicitly skipped it.

So a footnote referenced only from a table cell reserved no body space and was never drawn. Endnotes were immune because `drawEndnotes` draws every note unconditionally without scanning the body for references — which is exactly the asymmetry the reporter observed.

A footnote referenced from an ordinary top-level paragraph (the simplified repro in the issue) always worked; the real-world trigger is a reference nested in a table.

## Fix (ECMA-376 §17.11.10 / §17.4.7)

§17.11.10 anchors a footnote to the bottom of the page holding its reference regardless of where in the story the reference sits.

- Add `footnoteRefsInElement`, a recursive collector that descends into table cells and nested tables (§17.4.7). `drawPageFootnotes` now uses it.
- Hoist `sumReserve` to `computePages` scope and fold a table's newly referenced footnotes into both the fit decision and the committed per-page reserve, so the body area shrinks and the note clears the table content (no overlap).

The fix is gated behind an actual footnote reference, so footnote-free documents paginate and paint byte-identically. Both the main-thread `renderPage` path and the worker `renderPageToBitmap` path go through the same `computePages` / `drawPageFootnotes`, so `DocxViewer`, `DocxScrollViewer`, and worker mode are all fixed.

## Scope / residual

A row-split table reserves its footnotes on the page where it *ends* — the same approximation a split footnote-bearing paragraph already uses. §17.11.10's exact per-row placement across a table split remains a documented residual (noted in the code).

## Tests

New `footnote-in-table.test.ts` (recording-canvas harness, y-position assertions):
- footnote referenced from a table cell draws at the page bottom, below the table content;
- a tall footnote reserves body space so it never overlaps the cell content;
- the collector descends into a nested table (§17.4.7);
- a footnote-free table document draws no note (byte-identical guard).

Verified: full docx vitest suite (811 passing), docx demo VRT (`demo/sample-1`, which itself carries a footnote reference, matches its committed reference), docx `tsc --noEmit` clean, ast-grep clean (no new double-casts), parser footnote unit tests green (no parser changes were needed).

Thanks to @ShargilKeys for the precise report and minimal reproduction — the "markers render but content doesn't, endnotes are fine" framing pointed straight at the scan asymmetry.

Closes #840