### PR TITLE
fix(xlsx): infer implicit cell/row positions when r is omitted

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -937,10 +937,13 @@ fn parse_worksheet(
     let mut tab_color: Option<String> = None;
     let mut auto_filter: Option<CellRange> = None;
     let mut hyperlink_rids: HyperlinkRids = Vec::new();
-    // ECMA-376 §18.3.1.73: `@r` on `<row>` is optional. When omitted, the row
-    // number is the previous row's + 1 (the first row is 1); an explicit `@r`
-    // re-anchors this counter. `prev_row_idx == 0` means "no row yet", so the
-    // first implicit row lands at index 1.
+    // ECMA-376 §18.3.1.73 (CT_Row, sml.xsd) makes `@r` on `<row>` optional with
+    // no default; the spec does not spell out how an omitted value is resolved.
+    // We follow the de-facto consumer convention (Excel, LibreOffice, SheetJS
+    // agree; no competing interpretation exists): an r-less row is the previous
+    // row's number + 1 (the first row is 1), and an explicit `@r` re-anchors
+    // this counter. `prev_row_idx == 0` means "no row yet", so the first
+    // implicit row lands at index 1.
     let mut prev_row_idx: u32 = 0;
 
     // Pre-scan worksheet-level extLst for x14:dataBar extension attributes.
@@ -1236,8 +1239,10 @@ fn parse_worksheet(
                 }
             }
             "row" if is_x_ns(node.tag_name().namespace()) => {
-                // §18.3.1.73: honor an explicit `@r`; otherwise take the running
-                // previous row + 1 (implicit sequential numbering). An explicit
+                // §18.3.1.73 makes `@r` optional; honor an explicit value when
+                // present. When omitted, take the running previous row + 1
+                // (implicit sequential numbering — the de-facto consumer
+                // convention; the spec only grants the optionality). An explicit
                 // value also re-anchors the counter for following implicit rows.
                 let row_idx: u32 = match node.attribute("r").and_then(|s| s.parse::<u32>().ok()) {
                     Some(r) => r,
@@ -2303,7 +2308,8 @@ fn load_sheet_sparklines(
 fn parse_row_cells(
     row_node: &roxmltree::Node,
     // The resolved 1-based row number of the containing `<row>`. Used as the row
-    // coordinate for any `<c>` that omits its own `@r` (ECMA-376 §18.3.1.4).
+    // coordinate for any `<c>` that omits its own `@r` (optional per ECMA-376
+    // §18.3.1.4 / CT_Cell in sml.xsd).
     row_index: u32,
     // Shared-string cells now ship an `si` reference (resolved consumer-side),
     // so this table is no longer read here. Kept in the signature for symmetry
@@ -2312,11 +2318,14 @@ fn parse_row_cells(
     theme_colors: &[String],
 ) -> Vec<Cell> {
     let mut cells = Vec::new();
-    // ECMA-376 §18.3.1.4: `@r` on `<c>` is optional. When omitted, the cell's
-    // column is the one after the previous cell in this row (the first cell
-    // starts at column A / 1); an explicit `@r` re-anchors this running column
-    // so subsequent omitted cells continue from it. `prev_col == 0` means "no
-    // cell yet", so the first implicit cell lands at column 1.
+    // ECMA-376 §18.3.1.4 (CT_Cell, sml.xsd) makes `@r` on `<c>` optional with no
+    // default; the spec does not spell out how an omitted value is resolved. We
+    // follow the de-facto consumer convention (Excel, LibreOffice, SheetJS
+    // agree; no competing interpretation exists): an r-less cell takes the
+    // column after the previous cell in this row (the first cell starts at
+    // column A / 1), and an explicit `@r` re-anchors this running column so
+    // subsequent omitted cells continue from it. `prev_col == 0` means "no cell
+    // yet", so the first implicit cell lands at column 1.
     let mut prev_col: u32 = 0;
     for c_node in row_node.children() {
         if c_node.tag_name().name() != "c" || !is_x_ns(c_node.tag_name().namespace()) {
@@ -4253,8 +4262,10 @@ mod rb7_partial_degradation_tests {
 
 /// Implicit (omitted) cell/row references — ECMA-376 §18.3.1.4 (`c`) and
 /// §18.3.1.73 (`row`). Both `@r` attributes are `use="optional"` in the schema
-/// (CT_Cell / CT_Row, sml.xsd) with no default. When omitted, position is
-/// determined by ordinal document order:
+/// (CT_Cell / CT_Row, sml.xsd) with no default; that optionality is all the
+/// spec mandates — it does not spell out how an omitted reference is resolved.
+/// The resolution below is the de-facto consumer convention, on which Excel,
+/// LibreOffice, and SheetJS agree (no competing interpretation exists):
 ///
 ///   * `<c>` without `@r` → the next column after the previous cell in the same
 ///     row (the first cell in a row starts at column A / 1); an explicit `@r`
@@ -4340,9 +4351,10 @@ mod implicit_reference_tests {
         );
     }
 
-    /// Mixed: some cells carry an explicit `@r`, some don't. Per §18.3.1.4 an
-    /// explicit reference re-anchors the running column, so omitted cells after
-    /// it continue from that column, not from the ordinal count.
+    /// Mixed: some cells carry an explicit `@r`, some don't. Under the de-facto
+    /// convention (the spec grants only the optionality), an explicit reference
+    /// re-anchors the running column, so omitted cells after it continue from
+    /// that column, not from the ordinal count.
     #[test]
     fn explicit_r_reanchors_running_column() {
         // A1 (implicit) → col 1; then jump to D1 (explicit) → col 4; the next

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -937,6 +937,11 @@ fn parse_worksheet(
     let mut tab_color: Option<String> = None;
     let mut auto_filter: Option<CellRange> = None;
     let mut hyperlink_rids: HyperlinkRids = Vec::new();
+    // ECMA-376 §18.3.1.73: `@r` on `<row>` is optional. When omitted, the row
+    // number is the previous row's + 1 (the first row is 1); an explicit `@r`
+    // re-anchors this counter. `prev_row_idx == 0` means "no row yet", so the
+    // first implicit row lands at index 1.
+    let mut prev_row_idx: u32 = 0;
 
     // Pre-scan worksheet-level extLst for x14:dataBar extension attributes.
     // Excel 2010+ stores the `gradient` flag on `<x14:dataBar>` inside
@@ -1231,10 +1236,14 @@ fn parse_worksheet(
                 }
             }
             "row" if is_x_ns(node.tag_name().namespace()) => {
-                let row_idx: u32 = node
-                    .attribute("r")
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(0);
+                // §18.3.1.73: honor an explicit `@r`; otherwise take the running
+                // previous row + 1 (implicit sequential numbering). An explicit
+                // value also re-anchors the counter for following implicit rows.
+                let row_idx: u32 = match node.attribute("r").and_then(|s| s.parse::<u32>().ok()) {
+                    Some(r) => r,
+                    None => prev_row_idx + 1,
+                };
+                prev_row_idx = row_idx;
                 let hidden = attr_bool(&node, "hidden").unwrap_or(false);
                 // ECMA-376 §18.3.1.73 `<row>@ht` is the row height in points.
                 // Gating the value on `@customHeight="1"` (0.37.0) was too
@@ -1262,7 +1271,7 @@ fn parse_worksheet(
                     .unwrap_or(0)
                     .min(7);
                 let collapsed = attr_bool(&node, "collapsed").unwrap_or(false);
-                let cells = parse_row_cells(&node, shared_strings, theme_colors);
+                let cells = parse_row_cells(&node, row_idx, shared_strings, theme_colors);
                 rows.push(Row {
                     index: row_idx,
                     height,
@@ -2293,6 +2302,9 @@ fn load_sheet_sparklines(
 
 fn parse_row_cells(
     row_node: &roxmltree::Node,
+    // The resolved 1-based row number of the containing `<row>`. Used as the row
+    // coordinate for any `<c>` that omits its own `@r` (ECMA-376 §18.3.1.4).
+    row_index: u32,
     // Shared-string cells now ship an `si` reference (resolved consumer-side),
     // so this table is no longer read here. Kept in the signature for symmetry
     // with `parse_worksheet`'s threading; prefixed `_` to silence the warning.
@@ -2300,12 +2312,21 @@ fn parse_row_cells(
     theme_colors: &[String],
 ) -> Vec<Cell> {
     let mut cells = Vec::new();
+    // ECMA-376 §18.3.1.4: `@r` on `<c>` is optional. When omitted, the cell's
+    // column is the one after the previous cell in this row (the first cell
+    // starts at column A / 1); an explicit `@r` re-anchors this running column
+    // so subsequent omitted cells continue from it. `prev_col == 0` means "no
+    // cell yet", so the first implicit cell lands at column 1.
+    let mut prev_col: u32 = 0;
     for c_node in row_node.children() {
         if c_node.tag_name().name() != "c" || !is_x_ns(c_node.tag_name().namespace()) {
             continue;
         }
-        let cell_ref = c_node.attribute("r").unwrap_or("A1").to_string();
-        let (col, row) = parse_cell_ref(&cell_ref);
+        let (col, row) = match c_node.attribute("r") {
+            Some(cell_ref) => parse_cell_ref(cell_ref),
+            None => (prev_col + 1, row_index),
+        };
+        prev_col = col;
         let cell_type = c_node.attribute("t").unwrap_or("");
         let style_index: u32 = c_node
             .attribute("s")
@@ -3965,6 +3986,99 @@ mod rb7_partial_degradation_tests {
         );
     }
 
+    // ── #832 / #833-1: implicit references through the whole-archive path ─────
+
+    /// Build a 1-sheet workbook that OMITS `@r` on both `<row>` and every `<c>`
+    /// (the minimal enterprise-exporter shape from #832 / #833-1), backed by a
+    /// real `sharedStrings.xml`. Exercised end-to-end through `parse_sheet_native`
+    /// — the same code the WASM `parse_sheet` entry runs — so this proves the fix
+    /// survives ZIP extraction + shared-string resolution, not just the isolated
+    /// `parse_worksheet` unit path.
+    fn build_implicit_ref_workbook() -> Vec<u8> {
+        let ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        // Two rows, no @r anywhere; row 1 = three shared strings, row 2 = a
+        // shared string then two numbers. Positions must fill A1:C2.
+        let sheet = format!(
+            r#"<worksheet xmlns="{ns}"><sheetData>
+              <row><c t="s"><v>0</v></c><c t="s"><v>1</v></c><c t="s"><v>2</v></c></row>
+              <row><c t="s"><v>3</v></c><c t="n"><v>42.5</v></c><c t="n"><v>100</v></c></row>
+            </sheetData></worksheet>"#
+        );
+        let shared = format!(
+            r#"<sst xmlns="{ns}" count="4" uniqueCount="4"><si><t>Alpha</t></si><si><t>Beta</t></si><si><t>Gamma</t></si><si><t>Delta</t></si></sst>"#
+        );
+        let workbook = r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>"#;
+        let wb_rels = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>"#;
+        let styles = r#"<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts><fills count="1"><fill><patternFill patternType="none"/></fill></fills><borders count="1"><border/></borders><cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellXfs></styleSheet>"#;
+        let entries: Vec<(String, String)> = vec![
+            ("xl/workbook.xml".into(), workbook.into()),
+            ("xl/_rels/workbook.xml.rels".into(), wb_rels.into()),
+            ("xl/worksheets/sheet1.xml".into(), sheet),
+            ("xl/sharedStrings.xml".into(), shared),
+            ("xl/styles.xml".into(), styles.into()),
+        ];
+        let mut buf = Vec::new();
+        {
+            let mut w = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let o = zip::write::SimpleFileOptions::default();
+            for (name, body) in &entries {
+                w.start_file(name.as_str(), o).unwrap();
+                w.write_all(body.as_bytes()).unwrap();
+            }
+            w.finish().unwrap();
+        }
+        buf
+    }
+
+    /// End-to-end: an implicit-reference workbook parses to a full 2×3 grid —
+    /// not a single A1 cell. Cell coordinates (col/row) and the shared-string
+    /// `si` indices survive ZIP extraction + the shared-string load. (The `si`
+    /// index → text mapping is resolved consumer-side and covered elsewhere;
+    /// here `<v>0..3</v>` map to si 0..3 by insertion order.) This is the #832
+    /// reproduction driven through the real archive path (== the WASM entry).
+    #[test]
+    fn implicit_refs_resolve_full_grid_through_archive() {
+        let data = build_implicit_ref_workbook();
+        let ws = parse_sheet_json(&data, 0, "Sheet1");
+        assert!(
+            ws["parseError"].is_null(),
+            "healthy implicit-ref sheet must carry no parseError; got {ws}"
+        );
+        let rows = ws["rows"].as_array().expect("rows array");
+        assert_eq!(rows.len(), 2, "two rows must materialize");
+        assert_eq!(rows[0]["index"].as_u64(), Some(1), "first <row> → 1");
+        assert_eq!(rows[1]["index"].as_u64(), Some(2), "second <row> → 2");
+
+        let cell_at = |r: usize, c: usize| -> &serde_json::Value { &ws["rows"][r]["cells"][c] };
+
+        // CellValue is internally tagged (`tag = "type"`): a shared reference
+        // serializes as { "type": "shared", "si": N }, a number as
+        // { "type": "number", "number": X }.
+        // Row 1: three shared strings at columns A, B, C (si 0, 1, 2).
+        for (i, col) in [1u64, 2, 3].iter().enumerate() {
+            let cell = cell_at(0, i);
+            assert_eq!(cell["col"].as_u64(), Some(*col), "row1 cell {i} col");
+            assert_eq!(cell["row"].as_u64(), Some(1), "row1 cell {i} row");
+            assert_eq!(cell["value"]["type"].as_str(), Some("shared"));
+            assert_eq!(
+                cell["value"]["si"].as_u64(),
+                Some(i as u64),
+                "row1 cell {i} shared si"
+            );
+        }
+
+        // Row 2: A2 = shared si 3, B2 = 42.5, C2 = 100.
+        let a2 = cell_at(1, 0);
+        assert_eq!((a2["col"].as_u64(), a2["row"].as_u64()), (Some(1), Some(2)));
+        assert_eq!(a2["value"]["si"].as_u64(), Some(3));
+        let b2 = cell_at(1, 1);
+        assert_eq!((b2["col"].as_u64(), b2["row"].as_u64()), (Some(2), Some(2)));
+        assert_eq!(b2["value"]["number"].as_f64(), Some(42.5));
+        let c2 = cell_at(1, 2);
+        assert_eq!((c2["col"].as_u64(), c2["row"].as_u64()), (Some(3), Some(2)));
+        assert_eq!(c2["value"]["number"].as_f64(), Some(100.0));
+    }
+
     // ── #773: corrupt sharedStrings surfaces (not silent) ────────────────────
 
     /// Build a 1-sheet workbook whose one string cell (`A1`, `t="s"`) references
@@ -4134,5 +4248,162 @@ mod rb7_partial_degradation_tests {
             wb["parseError"].is_null(),
             "an absent sharedStrings is normal, not a degradation; got {wb}"
         );
+    }
+}
+
+/// Implicit (omitted) cell/row references — ECMA-376 §18.3.1.4 (`c`) and
+/// §18.3.1.73 (`row`). Both `@r` attributes are `use="optional"` in the schema
+/// (CT_Cell / CT_Row, sml.xsd) with no default. When omitted, position is
+/// determined by ordinal document order:
+///
+///   * `<c>` without `@r` → the next column after the previous cell in the same
+///     row (the first cell in a row starts at column A / 1); an explicit `@r`
+///     resets the running column so subsequent omitted cells continue from it.
+///   * `<row>` without `@r` → the previous row's number + 1 (the first row is 1).
+///
+/// Enterprise exporters (Dynamics, SAP, Oracle, SSRS) emit this minimal form to
+/// shrink files; Excel/Sheets/LibreOffice/SheetJS all accept it (#832, #833-1).
+#[cfg(test)]
+mod implicit_reference_tests {
+    use super::*;
+
+    const NS: &str = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    /// #832: every `<c>` omits `@r`. Columns must run A, B, C per ordinal
+    /// position within each row (reset at each `<row>`), not all collapse to A1.
+    #[test]
+    fn cells_without_r_get_sequential_columns() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetData>
+              <row r="1"><c t="s"><v>0</v></c><c t="s"><v>1</v></c><c t="s"><v>2</v></c></row>
+              <row r="2"><c t="s"><v>3</v></c><c t="n"><v>42.5</v></c><c t="n"><v>100</v></c></row>
+            </sheetData></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("parse");
+        assert_eq!(ws.rows.len(), 2);
+
+        let r1 = &ws.rows[0].cells;
+        assert_eq!((r1[0].col, r1[0].row), (1, 1), "first cell of row 1 → A1");
+        assert_eq!((r1[1].col, r1[1].row), (2, 1), "second cell → B1");
+        assert_eq!((r1[2].col, r1[2].row), (3, 1), "third cell → C1");
+
+        let r2 = &ws.rows[1].cells;
+        assert_eq!((r2[0].col, r2[0].row), (1, 2), "first cell of row 2 → A2");
+        assert_eq!((r2[1].col, r2[1].row), (2, 2), "second cell → B2");
+        assert_eq!((r2[2].col, r2[2].row), (3, 2), "third cell → C2");
+        match &r2[1].value {
+            CellValue::Number { number } => assert_eq!(*number, 42.5),
+            other => panic!("expected number 42.5 at B2, got {other:?}"),
+        }
+    }
+
+    /// #833-1: every `<row>` omits `@r`. Rows must number 1, 2, 3 by document
+    /// order, not all collapse to index 0.
+    #[test]
+    fn rows_without_r_get_sequential_indices() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetData>
+              <row><c r="A1" t="s"><v>0</v></c></row>
+              <row><c r="A2" t="s"><v>1</v></c></row>
+              <row><c r="A3" t="s"><v>2</v></c></row>
+            </sheetData></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("parse");
+        assert_eq!(ws.rows.len(), 3);
+        assert_eq!(ws.rows[0].index, 1, "first <row> → 1");
+        assert_eq!(ws.rows[1].index, 2, "second <row> → 2");
+        assert_eq!(ws.rows[2].index, 3, "third <row> → 3");
+    }
+
+    /// Both `<row>` and `<c>` omit `@r` simultaneously (the common enterprise
+    /// export shape). Positions must fill A1:C2 exactly.
+    #[test]
+    fn both_row_and_cell_omit_r() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetData>
+              <row><c t="s"><v>0</v></c><c t="s"><v>1</v></c><c t="s"><v>2</v></c></row>
+              <row><c t="s"><v>3</v></c><c t="n"><v>42.5</v></c><c t="n"><v>100</v></c></row>
+            </sheetData></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("parse");
+        assert_eq!(ws.rows[0].index, 1);
+        assert_eq!(ws.rows[1].index, 2);
+        let coords: Vec<(u32, u32)> = ws
+            .rows
+            .iter()
+            .flat_map(|r| r.cells.iter().map(|c| (c.col, c.row)))
+            .collect();
+        assert_eq!(
+            coords,
+            vec![(1, 1), (2, 1), (3, 1), (1, 2), (2, 2), (3, 2)],
+            "row+cell implicit refs must fill A1:C2"
+        );
+    }
+
+    /// Mixed: some cells carry an explicit `@r`, some don't. Per §18.3.1.4 an
+    /// explicit reference re-anchors the running column, so omitted cells after
+    /// it continue from that column, not from the ordinal count.
+    #[test]
+    fn explicit_r_reanchors_running_column() {
+        // A1 (implicit) → col 1; then jump to D1 (explicit) → col 4; the next
+        // implicit cell must be E1 (col 5), and the last implicit → F1 (col 6).
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetData>
+              <row r="1"><c t="s"><v>0</v></c><c r="D1" t="s"><v>1</v></c><c t="s"><v>2</v></c><c t="s"><v>3</v></c></row>
+            </sheetData></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("parse");
+        let cols: Vec<u32> = ws.rows[0].cells.iter().map(|c| c.col).collect();
+        assert_eq!(
+            cols,
+            vec![1, 4, 5, 6],
+            "implicit → A(1); explicit D(4) re-anchors; then E(5), F(6)"
+        );
+    }
+
+    /// A `<row>` with an explicit `@r` re-anchors the running row index, so a
+    /// following `<row>` without `@r` is that number + 1 (not a blind counter).
+    #[test]
+    fn explicit_row_r_reanchors_running_index() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetData>
+              <row><c r="A1"><v>1</v></c></row>
+              <row r="5"><c r="A5"><v>2</v></c></row>
+              <row><c r="A6"><v>3</v></c></row>
+            </sheetData></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("parse");
+        assert_eq!(ws.rows[0].index, 1, "first implicit row → 1");
+        assert_eq!(ws.rows[1].index, 5, "explicit r=5 honored");
+        assert_eq!(ws.rows[2].index, 6, "implicit after r=5 → 6");
+    }
+
+    /// Implicit references must not disturb the other minimal-exporter
+    /// constructs from #833: an inline string (`t="inlineStr"`) with rich
+    /// runs and a shared-string reference resolve correctly even when `@r` is
+    /// omitted on both the row and the cells.
+    #[test]
+    fn implicit_refs_coexist_with_inline_and_shared_strings() {
+        let shared = vec![SharedString {
+            text: "Shared".to_string(),
+            ..Default::default()
+        }];
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><sheetData>
+              <row><c t="s"><v>0</v></c><c t="inlineStr"><is><r><rPr><b/></rPr><t>Bold</t></r><r><t> tail</t></r></is></c></row>
+            </sheetData></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &shared, &[], "Sheet1").expect("parse");
+        let cells = &ws.rows[0].cells;
+        assert_eq!((cells[0].col, cells[0].row), (1, 1));
+        assert_eq!((cells[1].col, cells[1].row), (2, 1));
+        match &cells[0].value {
+            CellValue::Shared { si } => assert_eq!(*si, 0),
+            other => panic!("expected shared ref, got {other:?}"),
+        }
+        match &cells[1].value {
+            CellValue::Text { text, .. } => assert_eq!(text, "Bold tail"),
+            other => panic!("expected concatenated inline rich text, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

`XlsxViewer` rendered a nearly empty grid for XLSX files whose `<c>` / `<row>` elements omit the optional `r` attribute (#832). ECMA-376 marks `@r` `use="optional"` on both `CT_Cell` (§18.3.1.4) and `CT_Row` (§18.3.1.73); enterprise exporters (Dynamics, SAP, Oracle, SSRS) emit this minimal form, and Excel / Google Sheets / LibreOffice / SheetJS all accept it. Our parser fell back to `"A1"` for r-less cells and `0` for r-less rows, collapsing every implicit cell onto A1.

The parser now resolves omitted references by ordinal document order:

- `<c>` without `@r` → the column after the previous cell in the same row (first cell = column A). An explicit `@r` re-anchors the running column, so implicit cells after it continue from there.
- `<row>` without `@r` → the previous row's number + 1 (first row = 1). An explicit `@r` likewise re-anchors the counter.
- `parse_row_cells` now receives the containing row's resolved index so an r-less cell inherits its row coordinate.

## Assessment of all constructs raised in #832 / #833

| # | Construct | Spec | Status |
|---|---|---|---|
| 1 | `<c>` without `@r` (#832) | §18.3.1.4 | **Fixed in this PR** — previously every r-less cell collapsed to A1 |
| 2 | `<row>` without `@r` (#833-1) | §18.3.1.73 | **Fixed in this PR** — previously every r-less row got index 0 |
| 3 | Inline strings `t="inlineStr"` (#833-2) | §18.3.1.4 | **Already supported** since the first release — `<is>` parses through the same rich-text path as `<si>` (plain `<t>`, `<r>` runs, phonetic `<rPh>`); pinned by existing tests |
| 4 | Rich text runs in shared strings (#833-3) | §18.4.4 / §18.4.8 | **Already supported** — `parse_si_node` concatenates `<r><t>` segments and preserves per-run formatting; pinned by existing tests |
| 5 | Strict Open XML namespaces (#833-4) | ISO/IEC 29500 Strict | **Already fixed on main** (not yet released) — all element matching routes through `is_x_ns`, which accepts both Transitional and Strict (`purl.oclc.org`) URIs; pinned by `strict_namespace_cell_tests`. v0.70.2 predates this; it ships in the next release |

## Verification

- **TDD**: 6 new unit tests (all-implicit cells, all-implicit rows, both at once, mixed explicit/implicit re-anchoring for cells and rows, coexistence with inline/shared strings) — all failed before the fix, all pass after.
- **Whole-archive e2e**: a new test drives a real ZIP through `parse_sheet_native` (the WASM entry's code path) and confirms an all-implicit 2×3 workbook materializes A1:C2 with correct shared-string indices and numbers.
- **Byte-identical non-regression**: parser JSON hashed old-vs-new across all 31 local sample workbooks (104 outputs: 31 workbook + 73 sheet JSONs, all with explicit `@r`) — 104/104 identical.
- **Render equality**: an implicit-ref workbook renders pixel-identically (pixelmatch threshold 0, diff 0) to its explicit-`@r` twin through `XlsxWorkbook.load` → `renderViewport` in Chrome, and is non-blank.
- **Gates**: cargo test 135/135, `cargo fmt --check` clean, `clippy --all-targets -D warnings` clean, root vitest 2908/2908, ast-grep scan clean (no new findings), demo VRT passed.

Closes #832
Refs #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)