### PR TITLE
hotfix(xlsx): layouts smoke — detach outline gutter canvases on outline-free sheets

### DIFF
--- a/packages/xlsx/src/viewer-outline-dom-parity.test.ts
+++ b/packages/xlsx/src/viewer-outline-dom-parity.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { XlsxViewer } from './viewer.js';
+import { installDom, makeContainer, type FakeEl } from './viewer-destroy-test-dom.js';
+import type { Worksheet } from './types.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Outline gutter DOM parity (hotfix for the layouts-smoke regression).
+ *
+ * The three gutter canvases must exist in the DOM only while the shown sheet
+ * actually has an outline. `display:none` is NOT enough: consumers that count
+ * or index `<canvas>` elements see hidden nodes — the layouts smoke's
+ * `page.locator('canvas').count()` broke on outline-free demo/sample-1
+ * (expected N+1 canvases, got N+4) when the gutters were attached
+ * unconditionally. An outline-free sheet must present the exact pre-outline
+ * element set: one grid canvas, nothing else.
+ */
+
+function countCanvases(el: FakeEl): number {
+  let n = el.tag === 'canvas' ? 1 : 0;
+  for (const c of el.children) n += countCanvases(c);
+  return n;
+}
+
+function worksheet(withOutline: boolean): Worksheet {
+  return {
+    name: 'S',
+    rows: withOutline
+      ? [
+          { index: 1, height: null, cells: [] },
+          { index: 2, height: null, cells: [], outlineLevel: 1 },
+          { index: 3, height: null, cells: [], outlineLevel: 1 },
+        ]
+      : [{ index: 1, height: null, cells: [] }],
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    charts: [],
+    images: [],
+    shapeGroups: [],
+  } as unknown as Worksheet;
+}
+
+interface ViewerPriv {
+  currentWorksheet: Worksheet;
+  buildOutline(ws: Worksheet): void;
+  layoutGutters(): void;
+}
+
+describe('outline gutter canvases are attached only while an outline exists', () => {
+  it('a freshly constructed viewer has exactly ONE canvas (the grid)', () => {
+    installDom();
+    const container = makeContainer();
+    const v = new XlsxViewer(container as unknown as HTMLElement);
+    expect(countCanvases(container as unknown as FakeEl)).toBe(1);
+    v.destroy();
+  });
+
+  it('gutter canvases appear with an outline sheet and disappear again on an outline-free sheet', () => {
+    installDom();
+    const container = makeContainer();
+    const v = new XlsxViewer(container as unknown as HTMLElement);
+    const priv = v as unknown as ViewerPriv;
+
+    // Outline sheet: grid + row/col/corner gutters = 4 canvases.
+    priv.currentWorksheet = worksheet(true);
+    priv.buildOutline(priv.currentWorksheet);
+    priv.layoutGutters();
+    expect(countCanvases(container as unknown as FakeEl)).toBe(4);
+
+    // Back to an outline-free sheet: exact pre-outline parity (1 canvas).
+    priv.currentWorksheet = worksheet(false);
+    priv.buildOutline(priv.currentWorksheet);
+    priv.layoutGutters();
+    expect(countCanvases(container as unknown as FakeEl)).toBe(1);
+
+    // And an outline sheet again: the cached elements re-attach (4).
+    priv.currentWorksheet = worksheet(true);
+    priv.buildOutline(priv.currentWorksheet);
+    priv.layoutGutters();
+    expect(countCanvases(container as unknown as FakeEl)).toBe(4);
+    v.destroy();
+  });
+});

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -699,11 +699,14 @@ export class XlsxViewer implements ZoomableViewer {
       this.tabBar.appendChild(this.buildZoomControl());
     }
 
-    // canvasArea first (bottom), gutters above it inside the same region.
+    // canvasArea only — the gutter canvases are attached lazily by
+    // layoutGutters when (and only when) the shown sheet actually has an
+    // outline, and detached again otherwise. Keeping them OUT of the DOM for
+    // outline-free sheets preserves exact element parity with the pre-outline
+    // viewer: consumers that count or index `<canvas>` elements (the layouts
+    // smoke does `page.locator('canvas').count()`, which includes
+    // `display:none` nodes) must see no difference.
     this.gridRegion.appendChild(this.canvasArea);
-    this.gridRegion.appendChild(this.colGutter);
-    this.gridRegion.appendChild(this.rowGutter);
-    this.gridRegion.appendChild(this.cornerGutter);
     this.wrapper.appendChild(this.gridRegion);
     this.wrapper.appendChild(this.tabBar);
     container.appendChild(this.wrapper);
@@ -912,6 +915,25 @@ export class XlsxViewer implements ZoomableViewer {
     const gw = this.rowOutline ? Math.round(gutterExtentPx(this.rowOutline.maxLevel) * cs) : 0;
     const gh = this.colOutline ? Math.round(gutterExtentPx(this.colOutline.maxLevel) * cs) : 0;
     this.gutter = { w: gw, h: gh };
+
+    // Attach the gutter canvases only while an outline exists; detach them
+    // entirely for outline-free sheets. A hidden-but-attached canvas is NOT
+    // neutral — DOM consumers that count/index `<canvas>` elements (e.g. the
+    // layouts smoke's `page.locator('canvas').count()`) see it — so element
+    // parity with the pre-outline viewer requires absence, not `display:none`.
+    // The elements (and their pointer listeners) are constructed once and
+    // survive detach/reattach across sheet switches.
+    if (gw > 0 || gh > 0) {
+      if (!this.colGutter.parentElement) {
+        this.gridRegion.appendChild(this.colGutter);
+        this.gridRegion.appendChild(this.rowGutter);
+        this.gridRegion.appendChild(this.cornerGutter);
+      }
+    } else {
+      this.colGutter.remove();
+      this.rowGutter.remove();
+      this.cornerGutter.remove();
+    }
 
     // Inset canvasArea so the grid (and every geometry read that keys off its
     // client rect) starts after the gutters.


### PR DESCRIPTION
## Hotfix: layouts smoke red on main after #843

`tests/smoke/layouts.spec.ts:170` — "MasterDetail renders sheet tabs + preview and switches on click" — failed on **all three browsers** after #843 merged: `Expected: 6, Received: 9`.

### Root cause
#843 created **and appended** the three outline gutter canvases (row / col / corner) unconditionally at viewer construction, relying on `display:none` to be neutral for outline-free sheets. That is visual parity but not **element** parity: `page.locator('canvas').count()` counts hidden nodes too. MasterDetail embeds an `XlsxViewer` over the outline-free `demo/sample-1` and asserts exactly sheets+1 canvases — the 3 hidden gutters inflated it to +3.

### Fix
Attach the gutter canvases lazily in `layoutGutters` when (and only when) the shown sheet has a non-zero gutter extent; detach them (`remove()`) otherwise. Elements + pointer listeners are constructed once and survive detach/reattach across sheet switches. Outline-free sheets now present the **exact pre-#843 element set** (one grid canvas); outline sheets are unchanged.

### Measured
- **Repro before fix** (local Storybook + smoke): `Expected: 6, Received: 9` on chrome/webkit/firefox — identical to CI.
- **After fix**: full `pnpm smoke` **27/27 green** on chrome/webkit/firefox (pptx + docx + xlsx).
- Outline story sanity (browser): 3 gutter canvases attach + paint, the +/- toggle still expands rows; outline-free demo has **0** outline canvases, 1 total.
- Gates: xlsx vitest **500/500** (incl. 2 new DOM-parity pins), root `tsc --build` clean, ast-grep 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
