### PR TITLE
test(docx): add sample-27..31 to the VRT sample matrix

### DIFF
--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -18,6 +18,18 @@ const DOCX_FILES: { name: string; pageCount: number; width: number }[] = [
   // newspaper. width = physical page width (842pt, A4 landscape). Reference is
   // private (gitignored) and generated locally with UPDATE_REFS=1.
   { name: 'private/sample-26', pageCount: 1, width: 842 },
+  // Multilingual / section coverage (references private + gitignored, generated
+  // locally with UPDATE_REFS=1):
+  // sample-27 = continuous section-break page-number restart fixture (US Letter, 612pt).
+  { name: 'private/sample-27', pageCount: 2, width: 612 },
+  // sample-28 = Arabic RTL long-form (A4).
+  { name: 'private/sample-28', pageCount: 21, width: 595 },
+  // sample-29 = Thai script (A4).
+  { name: 'private/sample-29', pageCount: 14, width: 595 },
+  // sample-30 = Korean script (A4).
+  { name: 'private/sample-30', pageCount: 4, width: 595 },
+  // sample-31 = Russian / Cyrillic (A4).
+  { name: 'private/sample-31', pageCount: 12, width: 595 },
   { name: 'demo/sample-1', pageCount: 6, width: 595 },
 ];
 


### PR DESCRIPTION
## Summary

Extends the docx visual-regression sample matrix (`packages/docx/tests/visual/visual.spec.ts`) with five new fixtures that broaden **section-break** and **multilingual-script** coverage.

| Sample | Pages | Width (pt) | Content |
|--------|-------|-----------|---------|
| sample-27 | 2 | 612 (US Letter) | continuous section-break page-number restart fixture |
| sample-28 | 21 | 595 (A4) | Arabic RTL long-form |
| sample-29 | 14 | 595 (A4) | Thai script |
| sample-30 | 4 | 595 (A4) | Korean script |
| sample-31 | 12 | 595 (A4) | Russian / Cyrillic |

Page counts and page widths were measured against the current `main` renderer via `DocxDocument.pageCount` / `pageSize()` (headless). The `width` column follows the existing convention (physical page width in points: 595 = A4 portrait, 612 = US Letter).

## Notes

- The fixtures (`packages/docx/public/private/sample-*.docx`) and their reference PNGs (`packages/docx/tests/visual/references/private/`) are **redistribution-restricted** and remain **gitignored** — only the sample-matrix entry is tracked. References + `scores.json` are generated locally with `UPDATE_REFS=1` / `UPDATE_SCORES=1`, matching the existing private-sample workflow.
- VRT is local-only (does not run in CI), consistent with the other private-sample entries already in the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)