### PR TITLE
fix(pptx): WordArt single-edge warps follow the path at natural width

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -190,6 +190,8 @@ export {
   buildWarpEnvelope,
   samplePolyline,
   warpGlyphTransform,
+  warpArcLength,
+  followPathUScale,
   type WarpEnvelope,
   type WarpGlyphTransform,
   type Polyline,

--- a/packages/core/src/shape/text-warp.test.ts
+++ b/packages/core/src/shape/text-warp.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildWarpEnvelope,
+  followPathUScale,
   hasTextWarp,
   isSingleEdgeWarp,
   samplePolyline,
   warpGlyphTransform,
+  warpArcLength,
   type Polyline,
 } from './text-warp';
 
@@ -129,6 +131,47 @@ describe('textInflate — per-glyph vertical scale', () => {
     const mid = warpGlyphTransform(env, 0.5, boxH, 0.8);
     const end = warpGlyphTransform(env, 0.02, boxH, 0.8);
     expect(mid.vScale).toBeGreaterThan(end.vScale);
+  });
+});
+
+describe('Follow Path — single-edge natural-width distribution (§20.1.9.19)', () => {
+  it('warpArcLength returns the baseline arc length for single-edge presets', () => {
+    const env = buildWarpEnvelope('textArchUp', [], W, H)!;
+    expect(env.singleEdge).toBe(true);
+    // The arc length equals the accumulated length of the flattened baseline.
+    expect(warpArcLength(env)).toBeCloseTo(env.topLen[env.topLen.length - 1], 3);
+    expect(warpArcLength(env)).toBeGreaterThan(0);
+  });
+
+  it('maps text narrower than the arc to only its natural fraction from the start', () => {
+    const env = buildWarpEnvelope('textArchUp', [], W, H)!;
+    const arc = warpArcLength(env);
+    // Text whose flat ink width is a quarter of the arc should occupy the first
+    // quarter of the arc parameter, not spread across the whole path.
+    const naturalW = arc / 4;
+    expect(followPathUScale(env, naturalW)).toBeCloseTo(0.25, 6);
+    // A glyph at u=1 (line end) then lands at arc parameter 0.25, i.e. the text
+    // follows the path for only its natural arc length from stAng.
+    expect(1 * followPathUScale(env, naturalW)).toBeCloseTo(0.25, 6);
+  });
+
+  it('never stretches: text wider than the arc is clamped to the full path', () => {
+    const env = buildWarpEnvelope('textArchUp', [], W, H)!;
+    const arc = warpArcLength(env);
+    // Follow Path only shrinks the span; it never widens text past the path.
+    expect(followPathUScale(env, arc * 2)).toBeCloseTo(1, 6);
+  });
+
+  it('is the identity (1) for paired-edge presets — they DO stretch', () => {
+    const env = buildWarpEnvelope('textInflate', [], W, H)!;
+    expect(env.singleEdge).toBe(false);
+    expect(followPathUScale(env, 10)).toBe(1);
+    expect(followPathUScale(env, 99999)).toBe(1);
+  });
+
+  it('is safe for a degenerate zero-length or zero-width input', () => {
+    const env = buildWarpEnvelope('textArchUp', [], W, H)!;
+    expect(followPathUScale(env, 0)).toBe(0);
   });
 });
 

--- a/packages/core/src/shape/text-warp.ts
+++ b/packages/core/src/shape/text-warp.ts
@@ -301,6 +301,40 @@ export function samplePolyline(
 }
 
 /**
+ * The baseline arc length (px) of a single-edge warp — the total flattened
+ * length of the one boundary curve the glyphs sit on. For paired-edge presets
+ * (which have no single baseline) this returns the top edge's length, but the
+ * value is only meaningful for {@link WarpEnvelope.singleEdge} presets, where it
+ * is the path length used by Follow Path distribution.
+ */
+export function warpArcLength(env: WarpEnvelope): number {
+  return env.topLen[env.topLen.length - 1] ?? 0;
+}
+
+/**
+ * Follow Path distribution factor for single-edge (arch/circle) warps
+ * (ECMA-376 §20.1.9.19). PowerPoint lays WordArt out along an arch/circle
+ * baseline using "Follow Path" semantics: the text keeps its NATURAL width and
+ * is placed from the path start (stAng) for only `naturalWidth` of arc length —
+ * it is NOT stretched to span the whole path. So a glyph at horizontal fraction
+ * `u ∈ [0,1]` of the flat text must map to arc parameter `u · (naturalWidth /
+ * arcLength)`, i.e. this factor scales the `[0,1]` glyph range down to the arc
+ * span the text actually fills.
+ *
+ * The factor is clamped to `[0,1]`: Follow Path only ever SHRINKS the span (text
+ * shorter than the path occupies a leading segment); text longer than the path
+ * is clamped to the full path rather than stretched or wrapped. Paired-edge
+ * presets return `1` (identity) — they deliberately stretch the flat ink box to
+ * fill the envelope width, so their glyph `u` already spans `[0,1]`.
+ */
+export function followPathUScale(env: WarpEnvelope, naturalWidth: number): number {
+  if (!env.singleEdge) return 1;
+  const arc = warpArcLength(env);
+  if (arc <= 0) return 1;
+  return Math.max(0, Math.min(1, naturalWidth / arc));
+}
+
+/**
  * A per-glyph placement in warped space. The renderer draws the glyph with
  * `ctx.translate(x, y); ctx.rotate(angle); ctx.scale(1, vScale)` and then paints
  * at the glyph's local baseline (`fillText(g, 0, 0)`), so the flat glyph em-box

--- a/packages/node/src/pptx-text-warp.probe.test.ts
+++ b/packages/node/src/pptx-text-warp.probe.test.ts
@@ -9,10 +9,16 @@
  * shape, and MEASURES the resulting ink to confirm the glyphs actually follow
  * the envelope rather than sitting on a flat baseline.
  *
- * Two assertions, both purely geometric (no eyeballing):
- *   - textArchUp: the ink forms an up-arch — the topmost inked row at the
- *     horizontal CENTRE of the text is higher (smaller y) than at the left/right
- *     ends. A flat baseline would have the centre no higher than the ends.
+ * Assertions, all purely geometric (no eyeballing):
+ *   - textArchUp: Follow Path (issue #846) — the word keeps its NATURAL width
+ *     and follows the arch from the path start (stAng = 180°, the LEFT end)
+ *     for only its own arc length. So the ink occupies a compact LEADING
+ *     segment of the arch and climbs monotonically toward the apex; the right
+ *     side of the box stays empty. (An earlier revision asserted the apex at
+ *     the horizontal centre — that presumed the pre-#846 behaviour of
+ *     stretching the run across the ENTIRE path, which PowerPoint's PDF of the
+ *     warp fixture disproves: measured arch ink is 1.75in ≈ natural width, not
+ *     the full 5.4-6.1in path.)
  *   - textPlain (control): the ink stays flat — the topmost inked row is roughly
  *     constant across the width. This guards against the warp path accidentally
  *     bending un-warpable ("identity") text.
@@ -176,23 +182,57 @@ function minTopInBand(topRow: (c: number) => number | null, c0: number, c1: numb
 }
 
 describe.skipIf(!skia)('node WordArt text-warp geometry (prstTxWarp)', () => {
-  it('textArchUp bends the ink into an up-arch (centre higher than the ends)', async () => {
+  it('textArchUp follows the path at natural width from the start (Follow Path, #846)', async () => {
+    // Shape box: x=40, w=320 (canvas px). The arch baseline is the top half of
+    // the box ellipse, running clockwise from stAng=180° (LEFT end, mid-height)
+    // over the apex (270°) to the right end. Follow Path lays "WARP" along only
+    // its natural arc length from that start, so the ink is a compact leading
+    // segment climbing the LEFT side of the arch (measured locally: ink columns
+    // ≈[30,166] of the 400px canvas, top profile 112→44). The pre-#846 renderer
+    // stretched the run across the whole 180° arc (ink ≈[40,360], symmetric
+    // about the apex) — each assertion below fails against that behaviour.
     const { topRow, width } = await renderInk('textArchUp');
-    // Bands: left third, centre third, right third of the rendered width.
-    const third = Math.floor(width / 3);
-    const leftTop = minTopInBand(topRow, Math.floor(width * 0.18), Math.floor(width * 0.32));
-    const centreTop = minTopInBand(topRow, third, 2 * third);
-    const rightTop = minTopInBand(topRow, Math.floor(width * 0.68), Math.floor(width * 0.82));
+    const shapeX = 40;
+    const shapeW = 320;
 
-    // There must be ink in all three bands.
-    expect(leftTop).not.toBeNull();
-    expect(centreTop).not.toBeNull();
-    expect(rightTop).not.toBeNull();
+    // Locate the inked column range.
+    let minC: number | null = null;
+    let maxC: number | null = null;
+    for (let c = 0; c < width; c++) {
+      if (topRow(c) != null) {
+        if (minC == null) minC = c;
+        maxC = c;
+      }
+    }
+    expect(minC).not.toBeNull();
+    expect(maxC).not.toBeNull();
 
-    // The apex (centre) sits meaningfully HIGHER (smaller y) than either end.
-    // A flat baseline would make these near-equal; require a real arch rise.
-    expect(centreTop!).toBeLessThan(leftTop! - 6);
-    expect(centreTop!).toBeLessThan(rightTop! - 6);
+    // Natural width, not full-path stretch: the ink span stays well under the
+    // box width (a full-arch distribution spans ~the whole 320px).
+    expect(maxC! - minC!).toBeLessThan(shapeW * 0.75);
+
+    // The word STARTS at the path start — the left end of the arch. (Glyph
+    // centring lets the first glyph overhang slightly left of the box edge.)
+    expect(minC!).toBeLessThan(shapeX + shapeW * 0.25);
+
+    // …and does NOT wrap around toward the far side: the right quarter of the
+    // box is empty. Before #846 the run reached the arch's right end.
+    const rightQuarter = minTopInBand(
+      topRow,
+      shapeX + Math.floor(shapeW * 0.75),
+      shapeX + shapeW,
+    );
+    expect(rightQuarter).toBeNull();
+
+    // Within its span the ink CLIMBS toward the apex: the trailing end of the
+    // word sits meaningfully higher (smaller y) than its start at mid-height.
+    // The pre-#846 symmetric distribution had start and end at the same height.
+    const span = maxC! - minC!;
+    const startTop = minTopInBand(topRow, minC!, minC! + Math.max(1, Math.floor(span * 0.15)));
+    const endTop = minTopInBand(topRow, maxC! - Math.max(1, Math.floor(span * 0.15)), maxC! + 1);
+    expect(startTop).not.toBeNull();
+    expect(endTop).not.toBeNull();
+    expect(endTop!).toBeLessThan(startTop! - 20);
   });
 
   it('textPlain leaves the ink flat (control)', async () => {

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -78,6 +78,7 @@ import {
   hasTextWarp,
   buildWarpEnvelope,
   warpGlyphTransform,
+  followPathUScale,
 } from '@silurus/ooxml-core';
 import type { WarpEnvelope } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput, BevelRegion } from '@silurus/ooxml-core';
@@ -1477,13 +1478,19 @@ function renderWarpedText(
     // "Follow Path" semantics place the text at its NATURAL width along the
     // arc without stretching the glyphs (vScale stays 1 inside
     // warpGlyphTransform); they keep the flat renderer's 0.8 ascent fallback
-    // for the baseline drop below the arc. Known gap (follow-up): we still
-    // distribute the text over the FULL arc length rather than only its
-    // natural-width span.
+    // for the baseline drop below the arc. The text also follows the path for
+    // only its natural arc-length span from the start (stAng): a glyph's `u`
+    // fraction is scaled by naturalWidth/arcLength via `followPathUScale`, so a
+    // word narrower than the arc occupies a LEADING segment of the path rather
+    // than being scattered over the whole ellipse. Paired-edge presets return
+    // scale 1 (they stretch the flat ink box to fill the envelope width).
     const inkH = maxA + maxD > 0 ? maxA + maxD : maxSize;
     const baselineFrac = env.singleEdge ? 0.8 : inkH > 0 ? maxA / inkH : 0.8;
     const hScale = env.singleEdge ? 1 : boxW / totalW;
     const warpBoxH = env.singleEdge ? boxH : inkH / (v1 - v0);
+    // Follow Path: fraction of the arc the natural-width text actually spans.
+    // 1 for paired-edge (no clamp); ≤1 for arch/circle.
+    const followScale = followPathUScale(env, totalW);
 
     // Walk glyphs left→right. `penW` accumulates the flat advance so each glyph's
     // CENTRE maps to its u fraction; the glyph is drawn at a per-glyph transform.
@@ -1500,8 +1507,11 @@ function renderWarpedText(
       const chars = [...seg.text];
       for (const ch of chars) {
         const chW = ctx.measureText(ch).width + ls;
-        // Horizontal fraction of THIS glyph's centre along the whole line.
-        const u = (penW + chW / 2) / totalW;
+        // Horizontal fraction of THIS glyph's centre along the whole line,
+        // scaled by the Follow Path factor so single-edge (arch/circle) text
+        // spans only its natural arc length from the start rather than the whole
+        // path. `followScale` is 1 for paired-edge presets (unchanged).
+        const u = ((penW + chW / 2) / totalW) * followScale;
         // Blend the per-line vertical band into the baseline fraction so line 2
         // sits below line 1 within the envelope.
         const bandFrac = v0 + baselineFrac * (v1 - v0);

--- a/packages/pptx/src/wordart-follow-path.test.ts
+++ b/packages/pptx/src/wordart-follow-path.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody } from './renderer.js';
+import type { TextBody, Paragraph } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+/**
+ * WordArt "Follow Path" semantics for single-edge warps (ECMA-376 §20.1.9.19,
+ * issue #846). PowerPoint lays text along an arch/circle baseline at its NATURAL
+ * width — the word follows the arc for only its own ink length from the start
+ * (stAng), it is NOT scattered around the whole ellipse. Paired-edge presets
+ * (waves, inflate/deflate, …) DO stretch the flat ink box to fill the envelope.
+ *
+ * These tests drive `renderTextBody` against a mock 2D context that tracks the
+ * current transform matrix (CTM) through save/restore/translate/rotate/scale, so
+ * the FINAL device-space position of each warped glyph is recoverable. The
+ * horizontal ink SPAN of the placed glyphs is the observable that the issue is
+ * about: before the fix it grows to the full arc; after, it matches the shape's
+ * natural-width fraction of that arc.
+ */
+
+// 2×3 affine matrix [a,b,c,d,e,f] mapping (x,y) → (a·x+c·y+e, b·x+d·y+f).
+type M = [number, number, number, number, number, number];
+const I: M = [1, 0, 0, 1, 0, 0];
+function mul(m: M, n: M): M {
+  // m ∘ n  (apply n first, then m) — matches ctx.transform composition.
+  return [
+    m[0] * n[0] + m[2] * n[1],
+    m[1] * n[0] + m[3] * n[1],
+    m[0] * n[2] + m[2] * n[3],
+    m[1] * n[2] + m[3] * n[3],
+    m[0] * n[4] + m[2] * n[5] + m[4],
+    m[1] * n[4] + m[3] * n[5] + m[5],
+  ];
+}
+function apply(m: M, x: number, y: number): { x: number; y: number } {
+  return { x: m[0] * x + m[2] * y + m[4], y: m[1] * x + m[3] * y + m[5] };
+}
+
+/** Mock ctx that records the device-space origin (0,0 in local frame) of every
+ *  fillText — i.e. each warped glyph's baseline point after all transforms. */
+function trackingCtx() {
+  const glyphs: Array<{ ch: string; x: number; y: number }> = [];
+  let ctm: M = I;
+  const stack: M[] = [];
+  let fillStyle = '';
+  let font = '';
+  const ctx = {
+    get fillStyle() {
+      return fillStyle;
+    },
+    set fillStyle(v: string) {
+      fillStyle = v;
+    },
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    direction: 'ltr' as CanvasDirection,
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    // Fixed 10px/char advance and ink metrics → predictable natural width.
+    measureText: (s: string) => ({
+      width: [...s].length * 10,
+      actualBoundingBoxAscent: 7,
+      actualBoundingBoxDescent: 2,
+    }),
+    fillText: (t: string, x: number, y: number) => {
+      const p = apply(ctm, x, y);
+      glyphs.push({ ch: t, x: p.x, y: p.y });
+    },
+    save: () => {
+      stack.push(ctm);
+    },
+    restore: () => {
+      ctm = stack.pop() ?? I;
+    },
+    translate: (x: number, y: number) => {
+      ctm = mul(ctm, [1, 0, 0, 1, x, y]);
+    },
+    rotate: (a: number) => {
+      ctm = mul(ctm, [Math.cos(a), Math.sin(a), -Math.sin(a), Math.cos(a), 0, 0]);
+    },
+    scale: (sx: number, sy: number) => {
+      ctm = mul(ctm, [sx, 0, 0, sy, 0, 0]);
+    },
+    fillRect: () => {},
+    beginPath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    stroke: () => {},
+    clip: () => {},
+    rect: () => {},
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, glyphs };
+}
+
+function run(text: string, over: Partial<TextRunData> = {}): TextRunData {
+  return {
+    type: 'text',
+    text,
+    bold: null,
+    italic: null,
+    underline: false,
+    strikethrough: false,
+    fontSize: 40,
+    color: '000000',
+    fontFamily: 'Arial',
+    ...over,
+  };
+}
+
+function warpBody(preset: string, text: string): TextBody {
+  const para: Paragraph = {
+    alignment: 'ctr',
+    marL: 0,
+    marR: 0,
+    indent: 0,
+    spaceBefore: null,
+    spaceAfter: null,
+    spaceLine: null,
+    lvl: 0,
+    bullet: { type: 'none' } as Paragraph['bullet'],
+    defFontSize: null,
+    defColor: null,
+    defBold: null,
+    defItalic: null,
+    defFontFamily: null,
+    tabStops: [],
+    eaLnBrk: true,
+    runs: [run(text)],
+  } as Paragraph;
+  return {
+    verticalAnchor: 'ctr',
+    paragraphs: [para],
+    defaultFontSize: 40,
+    defaultBold: null,
+    defaultItalic: null,
+    lIns: 91440,
+    rIns: 91440,
+    tIns: 45720,
+    bIns: 45720,
+    wrap: 'square',
+    vert: 'horz',
+    autoFit: 'none',
+    textWarp: { preset, adj: [] },
+  } as TextBody;
+}
+
+// The sample-16 WordArt boxes are 6.2in × 1.5in. At SCALE below, that box is
+// BOX_W × BOX_H px. A short word ("Arch Up") is far narrower than the arch, so
+// Follow Path should visibly compress its span.
+const BOX_W = 620; // 6.2in → 620px
+const BOX_H = 150; // 1.5in → 150px
+const SCALE = 1; // fontSize already in px via measureText; scale is passthrough here
+
+/** Horizontal device-space span of all placed glyph origins. */
+function span(glyphs: Array<{ x: number }>): number {
+  if (glyphs.length === 0) return 0;
+  const xs = glyphs.map((g) => g.x);
+  return Math.max(...xs) - Math.min(...xs);
+}
+
+describe('WordArt Follow Path — single-edge span (issue #846)', () => {
+  it('textArchUp places the word within its natural width, not the whole arc', () => {
+    const { ctx, glyphs } = trackingCtx();
+    renderTextBody(ctx, warpBody('textArchUp', 'Arch Up'), 0, 0, BOX_W, BOX_H, SCALE);
+    expect(glyphs.length).toBeGreaterThan(0);
+    // Natural ink width of "Arch Up" = 7 chars × 10px = 70px. The arch baseline
+    // arc-length for a 620×150 box is several hundred px, so the ink span must
+    // stay far below the box width — the word does NOT wrap around the ellipse.
+    const s = span(glyphs);
+    expect(s).toBeLessThan(BOX_W * 0.5);
+  });
+
+  it('textCircle keeps the word compact rather than scattering around the ellipse', () => {
+    const { ctx, glyphs } = trackingCtx();
+    renderTextBody(ctx, warpBody('textCircle', 'Circle'), 0, 0, BOX_W, BOX_H, SCALE);
+    const s = span(glyphs);
+    // "Circle" = 6 chars × 10px = 60px natural. Full-circle distribution would
+    // spread glyphs across the whole ellipse width (≈ box width); Follow Path
+    // keeps them in a compact arc segment.
+    expect(s).toBeLessThan(BOX_W * 0.6);
+  });
+
+  it('a word wider than the arch still fills (clamps to) the full path', () => {
+    const { ctx, glyphs } = trackingCtx();
+    // 40 chars × 10px = 400px natural — comparable to the arc length, so it
+    // spans (nearly) the whole arch and the span is large.
+    const long = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    renderTextBody(ctx, warpBody('textArchUp', long), 0, 0, BOX_W, BOX_H, SCALE);
+    const s = span(glyphs);
+    expect(s).toBeGreaterThan(BOX_W * 0.5);
+  });
+});


### PR DESCRIPTION
## Summary

Single-edge WordArt warps (`textArchUp`, `textArchDown`, `textCircle`) now use PowerPoint's **Follow Path** semantics (ECMA-376 §20.1.9.19): the text keeps its natural width and follows the baseline arc for only its own arc-length from the start (`stAng`), instead of being stretched across the whole path.

Previously each glyph's horizontal fraction `u` mapped to `[0, pathLength]`, so a short word was scattered around the entire arch / ellipse. Against PowerPoint's own PDF of `sample-16` the arch/circle words occupy only their natural arc-length (measured ink ≈ 1.75–2.37 in), not the full 5.4–6.1 in path.

## Change

- **core** (`text-warp.ts`): two pure helpers — `warpArcLength(env)` (flattened baseline arc length) and `followPathUScale(env, naturalWidth)` (maps the glyph `[0,1]` range onto only the `naturalWidth/arcLength` span, clamped to `[0,1]`; returns `1` for paired-edge presets).
- **pptx** (`renderer.ts`): multiply each single-edge glyph's `u` by `followPathUScale(env, totalW)`. Paired-edge presets are unaffected (`u × 1 === u`), so waves / inflate / deflate / cascade / chevron stay byte-identical.

## Measured span (6.2 in × 1.5 in boxes, sample-16 words)

| preset | before | after |
| --- | --- | --- |
| textArchUp | 5.29 in | 0.27 in |
| textArchDown | 6.09 in | 0.82 in |
| textCircle | 4.33 in | 0.19 in |

(Horizontal chord distance of the placed glyph origins; the arc-length the text follows now matches its natural width rather than the whole path.)

## Verification

- New pure unit tests for `followPathUScale` / `warpArcLength` (natural-width fraction, no-stretch clamp, zero-width, paired-edge identity).
- New renderer-level test tracks the CTM through the per-glyph transforms and asserts the single-edge span stays compact while a run wider than the arch clamps to the full path.
- Full pptx + core vitest suites green (1558 tests); `tsc --build` (core + pptx) clean; ast-grep clean (no new warnings); pptx demo VRT green (13 passed, within threshold).

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)