### PR TITLE
fix(charts): marker legend key for markers-only scatter series (#803)

### DIFF
--- a/packages/core/src/chart/renderer-scatter-legend-key.test.ts
+++ b/packages/core/src/chart/renderer-scatter-legend-key.test.ts
@@ -1,0 +1,205 @@
+// Regression test for issue #803 (follow-up to PR #802):
+//
+//   A scatter series whose connecting line is suppressed — either the whole
+//   chart group is markers-only (`<c:scatterStyle val="marker">`, the default)
+//   or a specific series overrides the group line with `<a:noFill/>`
+//   (§21.2.2.198, surfaced as `ChartSeries.lineHidden`) — must draw a MARKER
+//   glyph as its legend key, matching Excel. Before this fix the legend key was
+//   always a horizontal line swatch for any scatter chart (`legendSwatchStyle`
+//   returned 'line' unconditionally for scatter), which read as a
+//   line-with-no-markers series that the plot never draws.
+//
+//   A scatter series that DOES draw a connecting line (group scatterStyle =
+//   line / lineMarker / smooth… and the series line is not hidden) keeps the
+//   line swatch — the legend key must mirror what the plot actually renders.
+
+import { describe, it, expect } from 'vitest';
+import type { ChartModel, ChartSeries, ChartRect } from '../types/chart';
+import { renderChart } from './renderer.js';
+
+const RECT: ChartRect = { x: 0, y: 0, w: 640, h: 360 };
+
+function baseModel(over: Partial<ChartModel>): ChartModel {
+  return {
+    chartType: 'scatter',
+    title: null,
+    categories: [],
+    series: [],
+    showDataLabels: false,
+    valMin: null,
+    valMax: null,
+    catAxisTitle: null,
+    valAxisTitle: null,
+    catAxisHidden: false,
+    valAxisHidden: false,
+    catAxisLineHidden: false,
+    valAxisLineHidden: false,
+    plotAreaBg: null,
+    chartBg: null,
+    showLegend: true,
+    legendPos: 'b',
+    catAxisCrossBetween: 'between',
+    valAxisMajorTickMark: 'out',
+    catAxisMajorTickMark: 'out',
+    titleFontSizeHpt: null,
+    titleFontColor: null,
+    titleFontFace: null,
+    catAxisFontSizeHpt: null,
+    valAxisFontSizeHpt: null,
+    dataLabelFontSizeHpt: null,
+    subtotalIndices: [],
+    ...over,
+  };
+}
+
+function series(over: Partial<ChartSeries>): ChartSeries {
+  return { name: '', color: null, values: [], ...over };
+}
+
+/** Recording context that classifies the legend KEY drawn next to each label.
+ *
+ *  A legend key is drawn immediately before the label text at the same y. The
+ *  bottom legend sits below the plot, so we scope classification to the legend
+ *  band (`y >= LEGEND_Y_MIN`). Within that band the key is either:
+ *    • a MARKER glyph — a `fill()`/`fillRect()` following a `beginPath` (arc /
+ *      diamond / triangle / star / square), or an `x`/`plus`/`dash` stroke; OR
+ *    • a LINE swatch — a 2-vertex horizontal `stroke()` (`drawLegendSwatch`'s
+ *      'line' style).
+ *  We record, per `fillText` in the band, whichever key kind was seen most
+ *  recently. Plot-area strokes (y above the band) are ignored. */
+const LEGEND_Y_MIN = 320; // RECT.h = 360; the bottom legend band starts well below the plot.
+
+function recordingCtx(): {
+  ctx: CanvasRenderingContext2D;
+  keys: Array<'marker' | 'line'>;
+} {
+  const keys: Array<'marker' | 'line'> = [];
+  let pathVerts = 0;
+  let lastPathY = 0;   // y of the last moveTo/lineTo/arc vertex (band gating).
+  let pendingKey: 'marker' | 'line' | null = null;
+  const inBand = (): boolean => lastPathY >= LEGEND_Y_MIN;
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif',
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    globalAlpha: 1,
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText':
+          return (t: string) => ({ width: String(t).length * 6 });
+        case 'save':
+        case 'restore':
+          return () => undefined;
+        case 'beginPath':
+          return () => { pathVerts = 0; };
+        case 'moveTo':
+        case 'lineTo':
+        case 'bezierCurveTo':
+        case 'quadraticCurveTo':
+          return (_x: number, y: number) => { pathVerts += 1; lastPathY = y; };
+        case 'arc':
+          return (_cx: number, cy: number) => { pathVerts += 1; lastPathY = cy; };
+        case 'fill':
+          // A marker glyph (arc/diamond/triangle/star) fills a closed path.
+          return () => { if (inBand()) pendingKey = 'marker'; };
+        case 'fillRect':
+          return (_x: number, y: number) => { if (y >= LEGEND_Y_MIN) pendingKey = 'marker'; };
+        case 'stroke':
+          return () => {
+            if (!inBand()) return;
+            // A legend line swatch is a 2-vertex horizontal stroke. x/plus/dash
+            // markers also stroke but from a fresh beginPath with 2 vertices —
+            // those are handled by 'marker' fills; the only 2-vertex stroke a
+            // markers-only legend emits comes from the line swatch itself, so a
+            // 2-vertex band stroke unambiguously means a line key here.
+            if (pathVerts === 2) pendingKey = 'line';
+          };
+        case 'fillText':
+          return (_text: string, _x: number, y: number) => {
+            if (y >= LEGEND_Y_MIN && pendingKey) { keys.push(pendingKey); pendingKey = null; }
+          };
+        case 'createLinearGradient':
+        case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        default:
+          return () => undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, keys };
+}
+
+const scatterModel = (over: Partial<ChartModel>, serOver: Partial<ChartSeries> = {}): ChartModel =>
+  baseModel({
+    categories: ['1', '2', '3'],
+    series: [series({
+      name: 'S',
+      color: '4f81bd',
+      values: [10, 20, 15],
+      categories: ['1', '2', '3'],
+      showMarker: true,
+      ...serOver,
+    })],
+    ...over,
+  });
+
+describe('scatter legend key reflects the plotted mark (#803, §21.2.2.42/.198)', () => {
+  it('draws a MARKER key for a markers-only scatter (scatterStyle default)', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, scatterModel({ scatterStyle: 'marker' }), RECT, 1);
+    expect(rec.keys).toContain('marker');
+    expect(rec.keys).not.toContain('line');
+  });
+
+  it('draws a MARKER key when a series line is noFill (lineHidden) despite lineMarker style', () => {
+    const rec = recordingCtx();
+    renderChart(
+      rec.ctx,
+      scatterModel({ scatterStyle: 'lineMarker' }, { lineHidden: true }),
+      RECT, 1,
+    );
+    expect(rec.keys).toContain('marker');
+    expect(rec.keys).not.toContain('line');
+  });
+
+  it('honors the series marker SYMBOL for the legend key (square)', () => {
+    // A square marker draws a fillRect — still classified as 'marker'. The point
+    // is that a non-line scatter never emits a line swatch.
+    const rec = recordingCtx();
+    renderChart(
+      rec.ctx,
+      scatterModel({ scatterStyle: 'marker' }, { markerSymbol: 'square' }),
+      RECT, 1,
+    );
+    expect(rec.keys).toEqual(['marker']);
+  });
+
+  it('keeps the LINE key for a line-drawing scatter (lineMarker, series line visible)', () => {
+    const rec = recordingCtx();
+    renderChart(
+      rec.ctx,
+      scatterModel({ scatterStyle: 'lineMarker' }, { lineHidden: null }),
+      RECT, 1,
+    );
+    expect(rec.keys).toContain('line');
+    expect(rec.keys).not.toContain('marker');
+  });
+
+  it('keeps the LINE key for a lineNoMarker scatter', () => {
+    const rec = recordingCtx();
+    renderChart(
+      rec.ctx,
+      scatterModel({ scatterStyle: 'lineNoMarker' }),
+      RECT, 1,
+    );
+    expect(rec.keys).toContain('line');
+    expect(rec.keys).not.toContain('marker');
+  });
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -232,12 +232,69 @@ function legendSwatchStyle(chartType: string | undefined): LegendSwatchStyle {
   return 'fill';
 }
 
+/** A resolved marker legend key: the glyph a scatter series draws for its
+ *  points, used as the legend swatch when the series has no connecting line
+ *  (§21.2.2.32). `fill`/`line` are hex without `#` (chartColor / markerFill). */
+interface LegendMarker { symbol: string; fill: string; line: string | null }
+
+/** Whether a scatter/bubble series draws a connecting line in the plot, so its
+ *  legend key should be a line swatch rather than a marker glyph. Mirrors the
+ *  plot gate in {@link renderScatterChart}: the group `<c:scatterStyle>` decides
+ *  whether points are connected, and a series-level `<a:noFill/>` line override
+ *  (§21.2.2.198, `lineHidden`) suppresses the connecting line even when the group
+ *  style is `line`/`lineMarker`. Bubble charts are always markers-only. */
+function scatterSeriesDrawsLine(
+  chartType: string | undefined,
+  scatterStyle: string | null | undefined,
+  series: ChartSeries,
+): boolean {
+  if (chartType !== 'scatter') return false;
+  const style = scatterStyle ?? 'marker';
+  const styleDrawsLine =
+    style === 'line' || style === 'lineMarker' || style === 'lineNoMarker' ||
+    style === 'smooth' || style === 'smoothMarker' || style === 'smoothNoMarker';
+  return styleDrawsLine && series.lineHidden !== true;
+}
+
+/** The marker legend key for a scatter series that draws no connecting line
+ *  (markers-only, whether by group style or a series `<a:noFill/>` override).
+ *  Excel renders such a series' legend key as its point marker, not a line
+ *  swatch. Returns null when a marker key does not apply (non-scatter, or a
+ *  scatter series that does draw a line). Colors/symbol resolve exactly like the
+ *  plotted markers in {@link renderScatterChart}. */
+function legendMarkerFor(
+  chartType: string | undefined,
+  scatterStyle: string | null | undefined,
+  series: ChartSeries[],
+  entryIndex: number,
+): LegendMarker | null {
+  if (chartType !== 'scatter') return null;
+  const s = series[entryIndex];
+  if (!s) return null;
+  if (scatterSeriesDrawsLine(chartType, scatterStyle, s)) return null;
+  const symbol = s.markerSymbol ?? 'circle';
+  // `markerSymbol: "none"` means the series plots no marker at all; there is no
+  // glyph to show, so fall back to the (line) swatch rather than invent one.
+  if (symbol === 'none') return null;
+  const base = chartColor(entryIndex, s); // '#RRGGBB'
+  const fill = s.markerFill ?? base.replace(/^#/, '');
+  return { symbol, fill, line: s.markerLine ?? null };
+}
+
 function drawLegendSwatch(
   ctx: CanvasRenderingContext2D,
   style: LegendSwatchStyle,
   color: string,
   x: number, y: number, w: number, h: number,
+  marker: LegendMarker | null = null,
 ): void {
+  // Markers-only scatter series show their point glyph as the key (#803).
+  if (marker) {
+    // drawMarker sizes by `sizePt * ptToPx`; the swatch slot is `w × h` px, so
+    // pass a point size that yields ~h px at ptToPx=1 and center it in the slot.
+    drawMarker(ctx, x + w / 2, y + h / 2, marker.symbol, h, marker.fill, marker.line, 1);
+    return;
+  }
   ctx.fillStyle = color;
   if (style === 'line') {
     // Horizontal stroke centered vertically inside the swatch slot. 2 px
@@ -258,13 +315,18 @@ function drawLegendSwatch(
 
 /** A single legend row: a label and the color of its swatch. Built so that the
  *  swatch color is resolved exactly like the mark it represents (slice / bar /
- *  line). See {@link legendEntryColor}. */
-interface LegendEntry { label: string; color: string }
+ *  line). See {@link legendEntryColor}. `marker` is set only for markers-only
+ *  scatter series, whose key is a point glyph instead of the line swatch (#803). */
+interface LegendEntry { label: string; color: string; marker: LegendMarker | null }
 
 /** Build the legend entries for a chart. Pie/doughnut legends are
  *  category-driven (one row per data point of the first series, labeled by
  *  category); every other chart type is series-driven (one row per series). */
-function buildLegendEntries(series: ChartSeries[], chartType: string | undefined): LegendEntry[] {
+function buildLegendEntries(
+  series: ChartSeries[],
+  chartType: string | undefined,
+  scatterStyle?: string | null,
+): LegendEntry[] {
   if (legendIsCategoryDriven(chartType)) {
     const first = series[0];
     const n = first ? first.values.length : 0;
@@ -272,11 +334,13 @@ function buildLegendEntries(series: ChartSeries[], chartType: string | undefined
     return Array.from({ length: n }, (_, i) => ({
       label: (cats[i] ?? `Item ${i + 1}`).toString(),
       color: legendEntryColor(chartType, series, i),
+      marker: null, // pie/doughnut keys are always filled swatches.
     }));
   }
   return series.map((s, i) => ({
     label: s.name || `Series ${i + 1}`,
     color: legendEntryColor(chartType, series, i),
+    marker: legendMarkerFor(chartType, scatterStyle, series, i),
   }));
 }
 
@@ -305,10 +369,11 @@ function drawLegend(
   orient: 'vertical' | 'horizontal' = 'vertical',
   chartType?: string,
   style: LegendTextStyle = DEFAULT_LEGEND_STYLE,
+  scatterStyle?: string | null,
 ): void {
   const sw = 10; const gap = 4;
   const swatchStyle = legendSwatchStyle(chartType);
-  const entries = buildLegendEntries(series, chartType);
+  const entries = buildLegendEntries(series, chartType, scatterStyle);
   const boldPrefix = style.bold ? 'bold ' : '';
   if (orient === 'horizontal') {
     // Excel lays a bottom/top legend as a single horizontal row, centered.
@@ -331,7 +396,7 @@ function drawLegend(
     let rx = lx + (lw - total) / 2;
     const ry = ly + lh / 2;
     for (let i = 0; i < entries.length; i++) {
-      drawLegendSwatch(ctx, swatchStyle, entries[i].color, rx, ry - fontSize / 2, sw, fontSize);
+      drawLegendSwatch(ctx, swatchStyle, entries[i].color, rx, ry - fontSize / 2, sw, fontSize, entries[i].marker);
       ctx.fillStyle = style.color; ctx.textAlign = 'left';
       ctx.fillText(labels[i], rx + sw + gap, ry);
       rx += itemWidths[i] + itemGap;
@@ -347,7 +412,7 @@ function drawLegend(
   const maxTextPx = lw - sw - gap;
   let ry = ly + (lh - rowH * entries.length) / 2;
   for (let i = 0; i < entries.length; i++) {
-    drawLegendSwatch(ctx, swatchStyle, entries[i].color, lx, ry, sw, fontSize);
+    drawLegendSwatch(ctx, swatchStyle, entries[i].color, lx, ry, sw, fontSize, entries[i].marker);
     ctx.fillStyle = style.color; ctx.textAlign = 'left';
     ctx.fillText(elideToWidth(ctx, entries[i].label, maxTextPx), lx + sw + gap, ry + fontSize / 2);
     ry += rowH;
@@ -398,21 +463,21 @@ function drawLegendForLayout(
     // when on left/right. A manual box wider than tall implies horizontal —
     // matches Excel's one-row legend rendering for top/bottom manual layouts.
     const orient = lw >= lh ? 'horizontal' : 'vertical';
-    drawLegend(ctx, chart.series, lx, ly, lw, lh, orient, chart.chartType, legStyle);
+    drawLegend(ctx, chart.series, lx, ly, lw, lh, orient, chart.chartType, legStyle, chart.scatterStyle);
     return;
   }
   switch (leg.side) {
     case 'r':
-      drawLegend(ctx, chart.series, x + w - leg.reserveW + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle);
+      drawLegend(ctx, chart.series, x + w - leg.reserveW + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle, chart.scatterStyle);
       break;
     case 'l':
-      drawLegend(ctx, chart.series, x + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle);
+      drawLegend(ctx, chart.series, x + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle, chart.scatterStyle);
       break;
     case 't':
-      drawLegend(ctx, chart.series, px0, y + topBand, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle);
+      drawLegend(ctx, chart.series, px0, y + topBand, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle, chart.scatterStyle);
       break;
     case 'b':
-      drawLegend(ctx, chart.series, px0, y + h - leg.reserveH, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle);
+      drawLegend(ctx, chart.series, px0, y + h - leg.reserveH, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle, chart.scatterStyle);
       break;
   }
 }

--- a/packages/node/src/verify-chart-regressions.probe.test.ts
+++ b/packages/node/src/verify-chart-regressions.probe.test.ts
@@ -47,29 +47,60 @@ function collectCharts(node: Any, out: ChartModel[]): void {
   }
 }
 
-/** Render a chart, capturing fillText calls with the fillStyle in effect and a
- *  count of series-colored (matchColor) connecting-line strokes. */
+/** Render a chart, capturing fillText calls with the fillStyle in effect, a
+ *  count of series-colored (matchColor) connecting-line strokes, and the legend
+ *  KEY kind (marker glyph vs. line swatch) drawn in the bottom legend band. The
+ *  legend band is the strip below `LEGEND_Y_MIN`; a marker key fills a path
+ *  (`fill`/`fillRect`), a line key is a 2-vertex horizontal `stroke`. Used by
+ *  the scatter legend-key check (#803). */
+const RECT_H = 400;
+const LEGEND_Y_MIN = RECT_H - 40; // bottom legend strip (plot is above).
 function renderCapture(
   chart: ChartModel,
   renderChart: (ctx: unknown, c: ChartModel, r: unknown, p?: number) => void,
   matchColor: string,
-): { texts: Array<{ text: string; fill: string }>; seriesStrokes: number } {
-  const canvas = new Canvas(640, 400);
+): {
+  texts: Array<{ text: string; fill: string }>;
+  seriesStrokes: number;
+  legendKeys: Array<'marker' | 'line'>;
+} {
+  const canvas = new Canvas(640, RECT_H);
   const raw = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
   const texts: Array<{ text: string; fill: string }> = [];
+  const legendKeys: Array<'marker' | 'line'> = [];
   let verts = 0;
+  let lastY = 0;
   let seriesStrokes = 0;
+  let pendingKey: 'marker' | 'line' | null = null;
+  const inBand = (): boolean => lastY >= LEGEND_Y_MIN;
   const proxy = new Proxy(raw, {
     get(t, p: string) {
       if (p === 'fillText') {
         return (text: string, x: number, y: number) => {
           texts.push({ text, fill: String((raw as Any).fillStyle) });
+          if (y >= LEGEND_Y_MIN && pendingKey) { legendKeys.push(pendingKey); pendingKey = null; }
           return (raw.fillText as Any)(text, x, y);
         };
       }
       if (p === 'beginPath') return () => { verts = 0; (raw.beginPath as Any)(); };
       if (p === 'moveTo' || p === 'lineTo' || p === 'bezierCurveTo') {
-        return (...a: number[]) => { verts += 1; return (raw as Any)[p](...a); };
+        return (x: number, y: number, ...rest: number[]) => {
+          verts += 1; lastY = y;
+          return (raw as Any)[p](x, y, ...rest);
+        };
+      }
+      if (p === 'arc') {
+        return (cx: number, cy: number, ...rest: number[]) => {
+          verts += 1; lastY = cy;
+          return (raw.arc as Any)(cx, cy, ...rest);
+        };
+      }
+      if (p === 'fill') return () => { if (inBand()) pendingKey = 'marker'; return (raw.fill as Any)(); };
+      if (p === 'fillRect') {
+        return (x: number, y: number, w: number, h: number) => {
+          if (y >= LEGEND_Y_MIN) pendingKey = 'marker';
+          return (raw.fillRect as Any)(x, y, w, h);
+        };
       }
       if (p === 'stroke') {
         return () => {
@@ -79,6 +110,8 @@ function renderCapture(
           if (verts >= 3 && String((raw as Any).strokeStyle).toLowerCase() === matchColor.toLowerCase()) {
             seriesStrokes += 1;
           }
+          // A 2-vertex stroke in the legend band is the line-key swatch.
+          if (inBand() && verts === 2) pendingKey = 'line';
           return (raw.stroke as Any)();
         };
       }
@@ -87,8 +120,8 @@ function renderCapture(
     },
     set(t, p: string, v) { (t as Any)[p] = v; return true; },
   }) as unknown as CanvasRenderingContext2D;
-  renderChart(proxy, chart, { x: 0, y: 0, w: 640, h: 400 }, 1.05);
-  return { texts, seriesStrokes };
+  renderChart(proxy, chart, { x: 0, y: 0, w: 640, h: RECT_H }, 1.05);
+  return { texts, seriesStrokes, legendKeys };
 }
 
 describe.skipIf(!pptxMod || !coreMod)('sample-14 slide-7 pie: white percent-only labels', () => {
@@ -135,5 +168,33 @@ describe.skipIf(!xlsxMod || !coreMod)('sample-30 sheet-1 scatter: markers only (
       const { seriesStrokes } = renderCapture(sc, renderChart, color);
       expect(seriesStrokes, 'noFill scatter draws zero connecting lines').toBe(0);
     }
+  });
+
+  it('draws a MARKER legend key (not a line swatch) for the markers-only scatter (#803)', () => {
+    const { parseSheet } = xlsxMod as Any;
+    const { renderChart } = coreMod as Any;
+    const ws = parseSheet(readFileSync(SAMPLE_30), 0, 'Sheet1');
+    const anchors = (ws.charts ?? []) as Any[];
+    const scatters = anchors.map(a => a.chart as ChartModel).filter(c => c.chartType === 'scatter');
+    expect(scatters.length, 'sheet 1 has scatter charts').toBeGreaterThan(0);
+    // The parser must surface the `<a:noFill/>` line override as lineHidden —
+    // this is the exact input the legend-key fix keys on.
+    expect(
+      scatters.some(sc => sc.series.some(s => s.lineHidden === true)),
+      'a scatter series is lineHidden (noFill line)',
+    ).toBe(true);
+    let sawMarker = false;
+    for (const sc of scatters) {
+      // Force the legend to the bottom so its key lands in the recorded band,
+      // independent of the file's own legend visibility (a separate concern).
+      const model: ChartModel = { ...sc, showLegend: true, legendPos: 'b' };
+      const color = sc.series[0]?.color ? `#${sc.series[0].color}` : '#4f81bd';
+      const { legendKeys } = renderCapture(model, renderChart, color);
+      // A markers-only scatter must never draw a line-swatch key…
+      expect(legendKeys, 'no line-swatch key for a markers-only scatter').not.toContain('line');
+      if (legendKeys.includes('marker')) sawMarker = true;
+    }
+    // …and at least one scatter shows a marker key.
+    expect(sawMarker, 'a scatter draws a marker legend key').toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

A scatter series whose connecting line is suppressed drew a horizontal **line swatch** as its legend key — reading as a line-with-no-markers series the plot never renders. Excel draws the **point marker** as the key for such a series. This is the cosmetic follow-up flagged in PR #802.

Two cases produce a markers-only scatter (no connecting line):
- the whole group is markers-only: `<c:scatterStyle val="marker">` (the default), or
- a series-level `<c:spPr><a:ln><a:noFill/>` override (§21.2.2.198), surfaced by the parser as `ChartSeries.lineHidden`, which suppresses the line even when the group style is `lineMarker` (sample-30's three scatters).

## Change

In the legend composer (`packages/core/src/chart/renderer.ts`):
- `scatterSeriesDrawsLine(chartType, scatterStyle, series)` — pure predicate mirroring the plot gate in `renderScatterChart` (group style decides connection; `lineHidden` overrides it).
- `legendMarkerFor(...)` — resolves the series' marker (symbol/fill/line, exactly like the plotted points) for a scatter series that draws no line; returns `null` otherwise (including `markerSymbol: "none"`).
- `buildLegendEntries` attaches the marker per entry; `drawLegendSwatch` draws that glyph via `drawMarker` instead of the line swatch.

The whole path is gated on `chartType === 'scatter'`, so bar / line / area / pie / radar legends are untouched.

## Verification

- **New core unit test** `renderer-scatter-legend-key.test.ts`: marker key for `scatterStyle: 'marker'` and for `lineMarker + lineHidden`; honors the marker symbol; **line key retained** for a line-drawing scatter (`lineMarker`, visible line) and `lineNoMarker`.
- **End-to-end** (extended `verify-chart-regressions.probe.test.ts`): real xlsx WASM parser + core renderer on **sample-30** — the parser surfaces `lineHidden`, and the rendered legend key is a marker, never a line swatch.
- **No regression**: pptx + xlsx **demo VRT 0.0% diff** (lineChart / barChart / lineChart / radarChart legends byte-identical).
- Full root vitest **2984 passed / 0 failed**; core + node `tsc` clean; ast-grep clean (no new findings).

Closes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)