### PR TITLE
feat(xlsx): parse row-level phonetic toggle <row ph> (§18.3.1.73)

### DIFF
--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1276,7 +1276,12 @@ fn parse_worksheet(
                     .unwrap_or(0)
                     .min(7);
                 let collapsed = attr_bool(&node, "collapsed").unwrap_or(false);
-                let cells = parse_row_cells(&node, row_idx, shared_strings, theme_colors);
+                // ECMA-376 §18.3.1.73 `<row ph="1">` — the row-level furigana
+                // display toggle. Every cell in the row shows its phonetic hint
+                // unless the cell overrides with its own `@ph`. Threaded into
+                // `parse_row_cells` so each cell resolves the effective value.
+                let row_ph = attr_bool(&node, "ph").unwrap_or(false);
+                let cells = parse_row_cells(&node, row_idx, row_ph, shared_strings, theme_colors);
                 rows.push(Row {
                     index: row_idx,
                     height,
@@ -2311,6 +2316,10 @@ fn parse_row_cells(
     // coordinate for any `<c>` that omits its own `@r` (optional per ECMA-376
     // §18.3.1.4 / CT_Cell in sml.xsd).
     row_index: u32,
+    // ECMA-376 §18.3.1.73 `<row ph>` — the row-level furigana display toggle.
+    // A cell inherits this when it does not carry its own `<c ph>` (see the
+    // `show_phonetic` resolution below).
+    row_ph: bool,
     // Shared-string cells now ship an `si` reference (resolved consumer-side),
     // so this table is no longer read here. Kept in the signature for symmetry
     // with `parse_worksheet`'s threading; prefixed `_` to silence the warning.
@@ -2412,10 +2421,13 @@ fn parse_row_cells(
             }
         };
 
-        // ECMA-376 §18.3.1.4 `<c ph="1">` — per-cell furigana display toggle.
-        // Defaults to false (schema default), so a cell only shows its String
-        // Item's phonetic hint when it explicitly opts in.
-        let show_phonetic = attr_bool(&c_node, "ph").unwrap_or(false);
+        // Furigana display resolves as `cell/@ph ?? row/@ph ?? false`:
+        // - ECMA-376 §18.3.1.4 `<c ph>` — per-cell toggle, wins when present
+        //   (including an explicit `ph="0"` that overrides an enabled row).
+        // - ECMA-376 §18.3.1.73 `<row ph>` — inherited when the cell omits `@ph`.
+        // - otherwise the schema default (false): a cell whose String Item
+        //   carries `<rPh>` runs still shows NO furigana unless opted in.
+        let show_phonetic = attr_bool(&c_node, "ph").unwrap_or(row_ph);
 
         cells.push(Cell {
             col,
@@ -3587,6 +3599,87 @@ mod phonetic_tests {
         assert!(
             !cells[2].show_phonetic,
             "no ph → hide (schema default false)"
+        );
+    }
+
+    /// ECMA-376 §18.3.1.73 `<row ph="1">` turns on furigana display for every
+    /// cell in the row, resolved as `cell/@ph ?? row/@ph ?? false`: a cell
+    /// without its own `ph` inherits the row flag, while a cell that sets
+    /// `ph="0"` explicitly overrides the row back to hidden.
+    #[test]
+    fn row_ph_attribute_drives_show_phonetic_with_cell_override() {
+        let xml = format!(
+            r#"<worksheet xmlns="{ns}"><sheetData><row r="1" ph="1">
+              <c r="A1" t="s"><v>0</v></c>
+              <c r="B1" t="s" ph="0"><v>0</v></c>
+              <c r="C1" t="s" ph="1"><v>0</v></c>
+            </row></sheetData></worksheet>"#,
+            ns = NS,
+        );
+        let shared = vec![SharedString {
+            text: "課長".to_string(),
+            ..Default::default()
+        }];
+        let (ws, _) = parse_worksheet(&xml, &shared, &[], "Sheet1").expect("parse");
+        let cells = &ws.rows[0].cells;
+        assert!(cells[0].show_phonetic, "no cell ph → inherits row ph=1");
+        assert!(
+            !cells[1].show_phonetic,
+            "cell ph=0 overrides row ph=1 → hide"
+        );
+        assert!(cells[2].show_phonetic, "cell ph=1 agrees with row ph=1");
+    }
+
+    /// A row WITHOUT `ph` keeps the schema default (false) for its cells, so a
+    /// non-Japanese sheet stays byte-identical. A cell may still opt in per-cell.
+    #[test]
+    fn row_without_ph_leaves_cells_at_schema_default() {
+        let xml = format!(
+            r#"<worksheet xmlns="{ns}"><sheetData><row r="1">
+              <c r="A1" t="s"><v>0</v></c>
+              <c r="B1" t="s" ph="1"><v>0</v></c>
+            </row></sheetData></worksheet>"#,
+            ns = NS,
+        );
+        let shared = vec![SharedString {
+            text: "課長".to_string(),
+            ..Default::default()
+        }];
+        let (ws, _) = parse_worksheet(&xml, &shared, &[], "Sheet1").expect("parse");
+        let cells = &ws.rows[0].cells;
+        assert!(!cells[0].show_phonetic, "no row/cell ph → hide (default)");
+        assert!(cells[1].show_phonetic, "cell ph=1 still opts in");
+    }
+
+    /// Worker-boundary contract: the RESOLVED `show_phonetic` crosses the wire
+    /// as `showPhonetic` (camelCase). A row-inherited `true` serializes the field
+    /// so the TS renderer gate (`cell.showPhonetic`) sees it, while a cell that
+    /// resolved to `false` (the `ph="0"` override) is omitted (serde skips false)
+    /// and reads back as `showPhonetic ?? false`. No new row-level field is added
+    /// to the JSON — resolving at parse time keeps the boundary schema stable.
+    #[test]
+    fn resolved_show_phonetic_serializes_to_json_boundary() {
+        let xml = format!(
+            r#"<worksheet xmlns="{ns}"><sheetData><row r="1" ph="1">
+              <c r="A1" t="s"><v>0</v></c>
+              <c r="B1" t="s" ph="0"><v>0</v></c>
+            </row></sheetData></worksheet>"#,
+            ns = NS,
+        );
+        let shared = vec![SharedString {
+            text: "課長".to_string(),
+            ..Default::default()
+        }];
+        let (ws, _) = parse_worksheet(&xml, &shared, &[], "Sheet1").expect("parse");
+        let json = serde_json::to_value(&ws.rows[0].cells).expect("serialize cells");
+        assert_eq!(
+            json[0].get("showPhonetic"),
+            Some(&serde_json::Value::Bool(true)),
+            "row-inherited cell serializes showPhonetic:true"
+        );
+        assert!(
+            json[1].get("showPhonetic").is_none(),
+            "override cell (resolved false) omits showPhonetic — reads back as ?? false"
         );
     }
 

--- a/packages/xlsx/src/phonetic-row-gate.test.ts
+++ b/packages/xlsx/src/phonetic-row-gate.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { renderViewport } from './renderer.js';
+import type { Cell, PhoneticRun, Styles, Worksheet } from './types.js';
+
+/**
+ * Row-level furigana gate (ECMA-376 §18.3.1.73 `<row ph>`, issue #814).
+ *
+ * The parser resolves each cell's `showPhonetic` as `cell/@ph ?? row/@ph ??
+ * false`, so a cell that inherits an enabled row arrives here with
+ * `showPhonetic: true`, and a cell that overrode the row with `ph="0"` arrives
+ * with `showPhonetic: false` (omitted on the wire). This render test drives the
+ * real viewport draw and asserts the furigana band is stamped only for the
+ * cell whose RESOLVED value is true — i.e. the row-level toggle reaches the
+ * renderer gate exactly like the per-cell one, through the same `showPhonetic`
+ * field. (The resolution itself is unit-tested in the parser's Rust tests.)
+ */
+
+const READING: PhoneticRun[] = [{ sb: 0, eb: 1, text: 'カ' }];
+
+/** A text cell carrying a furigana run, with `showPhonetic` set as the parser
+ *  would have resolved it (true = row-inherited or cell opt-in, false = hidden). */
+function phoneticCell(col: number, showPhonetic: boolean): Cell {
+  return {
+    col,
+    row: 1,
+    value: { type: 'text', text: '課', phoneticRuns: READING },
+    styleIndex: 0,
+    showPhonetic,
+  } as Cell;
+}
+
+const BASE_FONT = {
+  bold: false,
+  italic: false,
+  underline: false,
+  strike: false,
+  size: 11,
+  color: null,
+  name: null,
+};
+
+const STYLES: Styles = {
+  fonts: [BASE_FONT],
+  fills: [],
+  borders: [],
+  cellXfs: [{ fontId: 0, fillId: 0, borderId: 0, numFmtId: 0 } as Styles['cellXfs'][number]],
+  numFmts: [],
+  dxfs: [],
+};
+
+/** Worksheet with a single row: A1 resolved show=true, B1 resolved show=false. */
+function sheet(aShow: boolean, bShow: boolean): Worksheet {
+  return {
+    name: 'Sheet1',
+    rows: [
+      {
+        index: 1,
+        height: null,
+        cells: [phoneticCell(1, aShow), phoneticCell(2, bShow)],
+      },
+    ],
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    images: [],
+    charts: [],
+    defaultFontFamily: 'Calibri',
+    defaultFontSize: 11,
+  } as Worksheet;
+}
+
+/** Recording ctx that captures every fillText string and exposes a canvas. */
+function recordingCtx(width = 400, height = 200) {
+  const texts: string[] = [];
+  let font = '11px sans-serif';
+  const ctx: Record<string, unknown> = {
+    canvas: { width, height },
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    textBaseline: 'alphabetic',
+    textAlign: 'left',
+    letterSpacing: '0px',
+    direction: 'ltr',
+    globalAlpha: 1,
+    measureText: (s: string) => ({ width: [...s].length * 8 }),
+    fillText: (t: string) => {
+      texts.push(t);
+    },
+    strokeText: () => {},
+    fillRect: () => {},
+    strokeRect: () => {},
+    clearRect: () => {},
+    beginPath: () => {},
+    closePath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    rect: () => {},
+    arc: () => {},
+    fill: () => {},
+    stroke: () => {},
+    clip: () => {},
+    save: () => {},
+    restore: () => {},
+    translate: () => {},
+    rotate: () => {},
+    scale: () => {},
+    setLineDash: () => {},
+    setTransform: () => {},
+    createLinearGradient: () => ({ addColorStop: () => {} }),
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, texts };
+}
+
+const VIEWPORT = { row: 1, col: 1, rows: 1, cols: 2 };
+
+describe('row-level furigana gate (§18.3.1.73)', () => {
+  it('draws the reading for a cell whose resolved showPhonetic is true', () => {
+    const { ctx, texts } = recordingCtx();
+    renderViewport(ctx, sheet(true, false), STYLES, VIEWPORT);
+    // The furigana reading "カ" is stamped exactly once — for A1 (row-inherited
+    // true), NOT for B1 (cell ph="0" override → false).
+    expect(texts.filter((t) => t === 'カ').length).toBe(1);
+    // Both base texts still draw.
+    expect(texts.filter((t) => t === '課').length).toBe(2);
+  });
+
+  it('skips the reading when every cell resolved to false', () => {
+    const { ctx, texts } = recordingCtx();
+    renderViewport(ctx, sheet(false, false), STYLES, VIEWPORT);
+    expect(texts.some((t) => t === 'カ')).toBe(false);
+    expect(texts.filter((t) => t === '課').length).toBe(2);
+  });
+
+  it('draws the reading for every cell when the whole row resolved to true', () => {
+    const { ctx, texts } = recordingCtx();
+    renderViewport(ctx, sheet(true, true), STYLES, VIEWPORT);
+    expect(texts.filter((t) => t === 'カ').length).toBe(2);
+  });
+});

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -667,10 +667,13 @@ export interface Cell {
    *  so the cached `<v>` — frozen when the file was last saved — doesn't
    *  show a stale date. */
   formula?: string;
-  /** ECMA-376 §18.3.1.4 `<c ph="1">` — whether this cell displays its phonetic
-   *  hint (furigana). Omitted on the wire when false (the schema default), so
+  /** Whether this cell displays its phonetic hint (furigana). The parser
+   *  resolves it as `cell/@ph ?? row/@ph ?? false` — the per-cell `<c ph>`
+   *  (ECMA-376 §18.3.1.4) wins when present (an explicit `ph="0"` overrides an
+   *  enabled row), otherwise the row-level `<row ph>` (§18.3.1.73) is inherited,
+   *  otherwise the schema default (false). Omitted on the wire when false, so
    *  read as `showPhonetic ?? false`. A cell whose String Item carries `<rPh>`
-   *  runs still shows NO furigana unless it opts in with `ph="1"`. */
+   *  runs still shows NO furigana unless the resolved value is true. */
   showPhonetic?: boolean;
 }
 


### PR DESCRIPTION
## Summary

ECMA-376 §18.3.1.73 defines a row-level furigana display toggle `<row ph="1">` that shows the phonetic hint (furigana) for **every** cell in the row. PR #810 wired only the per-cell `<c ph>` (§18.3.1.4), so a workbook toggling furigana at row level under-rendered.

This parses `row/@ph` and resolves each cell's `showPhonetic` as **`cell/@ph ?? row/@ph ?? false`**:

- the per-cell `<c ph>` wins when present — an explicit `ph="0"` overrides an enabled row back to hidden;
- otherwise the row-level `<row ph>` is inherited;
- otherwise the schema default (`false`).

## Worker boundary

The resolution happens **at parse time** on each `Cell`, so the worker-boundary JSON schema is unchanged: the existing per-cell `showPhonetic` already carries the final value. No new row-level field is serialized, and the TS renderer gate (`cell.showPhonetic`) needs no change. A workbook carrying `<rPh>` data but no display flags (e.g. `sample-11` / `sample-30`) stays byte-identical, and the demo VRT worker-vs-main diff is 0.000%.

## Verification

- **parser (Rust)**: 3 new tests — row inheritance + cell `ph="0"` override, row-less schema default, and a JSON-serialization check confirming the resolved value crosses the boundary (`showPhonetic:true` for the inherited cell, omitted for the override). Existing `phonetic_workbook_round_trips_rph_and_cell_ph` integration test still passes (backward-compatible). 143 cargo tests green; `cargo fmt --check` + `clippy -D warnings` clean.
- **renderer (TS)**: new `renderViewport` render-gate test proves the furigana band is stamped only for cells whose resolved `showPhonetic` is true (synthetic row-inherited + override fixture). 503 xlsx vitest tests green; `tsc --build` + ast-grep clean.
- **VRT**: xlsx demo VRT green (7 passed, 100% match; worker equivalence 0.000%).

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)