### PR TITLE
feat(core): international ST_NumberFormat numbering (§17.18.59)

### DIFF
--- a/packages/core/src/text/field-format-switch.test.ts
+++ b/packages/core/src/text/field-format-switch.test.ts
@@ -29,11 +29,44 @@ describe('parseFieldFormatSwitch — ECMA-376 §17.16.4.3.1 general-formatting s
     expect(parseFieldFormatSwitch('PAGE \\* roman \\# 0')).toBe('lowerRoman');
   });
 
+  it('maps the locale-independent international switch arguments', () => {
+    // §17.16.4.3.1 — each of these rows maps to exactly ONE ST_NumberFormat
+    // regardless of the field language, so they are safe to route.
+    expect(parseFieldFormatSwitch('PAGE \\* ARABICABJAD')).toBe('arabicAbjad');
+    expect(parseFieldFormatSwitch('PAGE \\* ARABICALPHA')).toBe('arabicAlpha');
+    expect(parseFieldFormatSwitch('PAGE \\* HEBREW1')).toBe('hebrew1');
+    expect(parseFieldFormatSwitch('PAGE \\* HEBREW2')).toBe('hebrew2');
+    expect(parseFieldFormatSwitch('PAGE \\* HINDIARABIC')).toBe('hindiNumbers');
+    expect(parseFieldFormatSwitch('PAGE \\* HINDILETTER1')).toBe('hindiVowels');
+    expect(parseFieldFormatSwitch('PAGE \\* HINDILETTER2')).toBe('hindiConsonants');
+    expect(parseFieldFormatSwitch('PAGE \\* THAIARABIC')).toBe('thaiNumbers');
+    expect(parseFieldFormatSwitch('PAGE \\* THAILETTER')).toBe('thaiLetters');
+    expect(parseFieldFormatSwitch('PAGE \\* CHOSUNG')).toBe('chosung');
+    expect(parseFieldFormatSwitch('PAGE \\* GANADA')).toBe('ganada');
+    expect(parseFieldFormatSwitch('PAGE \\* DBCHAR')).toBe('decimalFullWidth');
+    expect(parseFieldFormatSwitch('PAGE \\* SBCHAR')).toBe('decimalHalfWidth');
+  });
+
   it('returns null for a format argument this converter does not support', () => {
     // CardText etc. are recognised switches but not numeric-native — the caller
     // then keeps the section fmt / decimal. We surface null (not decimal) so the
     // caller can distinguish "no override" from "override to decimal".
     expect(parseFieldFormatSwitch('PAGE \\* CardText')).toBeNull();
     expect(parseFieldFormatSwitch('PAGE \\* Ordinal')).toBeNull();
+    expect(parseFieldFormatSwitch('PAGE \\* BAHTTEXT')).toBeNull(); // Thai spell-out
+  });
+
+  it('returns null for the LOCALE-DEPENDENT switch arguments (needs w:lang)', () => {
+    // §17.16.4.3.1 — these map to different ST_NumberFormat values per language
+    // (e.g. DBNUM1 → ideographDigital in ja-JP vs koreanDigital in ko-KR). We do
+    // not thread the field language, so we decline rather than guess a script.
+    expect(parseFieldFormatSwitch('PAGE \\* CHINESENUM1')).toBeNull();
+    expect(parseFieldFormatSwitch('PAGE \\* CHINESENUM2')).toBeNull();
+    expect(parseFieldFormatSwitch('PAGE \\* CHINESENUM3')).toBeNull();
+    expect(parseFieldFormatSwitch('PAGE \\* DBNUM1')).toBeNull();
+    expect(parseFieldFormatSwitch('PAGE \\* DBNUM2')).toBeNull();
+    expect(parseFieldFormatSwitch('PAGE \\* KANJINUM1')).toBeNull();
+    expect(parseFieldFormatSwitch('PAGE \\* IROHA')).toBeNull();
+    expect(parseFieldFormatSwitch('PAGE \\* AIUEO')).toBeNull();
   });
 });

--- a/packages/core/src/text/field-format-switch.test.ts
+++ b/packages/core/src/text/field-format-switch.test.ts
@@ -9,8 +9,10 @@ describe('parseFieldFormatSwitch — ECMA-376 §17.16.4.3.1 general-formatting s
   });
 
   it('maps the numeric switch arguments to ST_NumberFormat values (case-sensitive)', () => {
-    // Arabic -> decimal
+    // Arabic -> decimal; ArabicDash -> "- N -"; Hex -> uppercase hexadecimal
     expect(parseFieldFormatSwitch('PAGE \\* Arabic')).toBe('decimal');
+    expect(parseFieldFormatSwitch('PAGE \\* ArabicDash')).toBe('numberInDash');
+    expect(parseFieldFormatSwitch('PAGE \\* Hex')).toBe('hex');
     // Roman (uppercase) vs roman (lowercase) are DISTINCT arguments
     expect(parseFieldFormatSwitch('PAGE \\* Roman')).toBe('upperRoman');
     expect(parseFieldFormatSwitch('PAGE \\* roman')).toBe('lowerRoman');

--- a/packages/core/src/text/field-format-switch.ts
+++ b/packages/core/src/text/field-format-switch.ts
@@ -13,20 +13,44 @@
 //   ALPHABETIC  → upperLetter    alphabetic → lowerLetter
 // The switch arguments are CASE-SENSITIVE (Roman ≠ roman, ALPHABETIC ≠
 // alphabetic) — §17.16.4.3.1 lists them as distinct rows with different results.
+//
+// The international switch arguments below are the LOCALE-INDEPENDENT ones: each
+// §17.16.4.3.1 row that maps to exactly ONE ST_NumberFormat regardless of the
+// document language. The LOCALE-DEPENDENT arguments — CHINESENUM1/2/3, DBNUM1–4,
+// KANJINUM1–3, IROHA, AIUEO — are intentionally OMITTED: a single argument like
+// `\* DBNUM1` maps to ideographDigital (ja-JP) OR koreanDigital (ko-KR)
+// depending on the field's `w:lang`, which this parser does not thread. Guessing
+// a locale would be a heuristic (root CLAUDE.md forbids), so they return null and
+// the caller keeps the section format instead of choosing the wrong script.
 
 import type { NumberFormat } from './number-format';
 
 // Case-sensitive switch-argument → ST_NumberFormat, restricted to the values
-// `formatOrdinalNumber` renders natively. Arguments outside this set (CardText,
-// Ordinal, DBNUM1, Hex, …) intentionally have no entry: `parseFieldFormatSwitch`
-// returns null for them so the caller keeps the section format rather than
-// silently downgrading to decimal.
+// `formatOrdinalNumber` renders natively AND unambiguous across locales. Text
+// spell-out arguments (CardText, Ordinal, OrdText, BAHTTEXT, …) intentionally
+// have no entry: `parseFieldFormatSwitch` returns null for them so the caller
+// keeps the section format rather than silently downgrading to decimal.
 const SWITCH_TO_FORMAT: Readonly<Record<string, NumberFormat>> = {
+  // §17.16.4.3.1 Latin / roman core.
   Arabic: 'decimal',
   Roman: 'upperRoman',
   roman: 'lowerRoman',
   ALPHABETIC: 'upperLetter',
   alphabetic: 'lowerLetter',
+  // §17.16.4.3.1 international, locale-independent (one ST_NumberFormat each).
+  ARABICABJAD: 'arabicAbjad', // ascending Abjad numerals
+  ARABICALPHA: 'arabicAlpha', // Arabic alphabet
+  HEBREW1: 'hebrew1', // Hebrew numerals (gematria)
+  HEBREW2: 'hebrew2', // Hebrew alphabet
+  HINDIARABIC: 'hindiNumbers', // Hindi numbers
+  HINDILETTER1: 'hindiVowels', // Hindi vowels
+  HINDILETTER2: 'hindiConsonants', // Hindi consonants
+  THAIARABIC: 'thaiNumbers', // Thai numbers
+  THAILETTER: 'thaiLetters', // Thai letters
+  CHOSUNG: 'chosung', // Korean Chosung
+  GANADA: 'ganada', // Korean Ganada
+  DBCHAR: 'decimalFullWidth', // double-byte (full-width) Arabic
+  SBCHAR: 'decimalHalfWidth', // single-byte (half-width) Arabic
 };
 
 /**

--- a/packages/core/src/text/field-format-switch.ts
+++ b/packages/core/src/text/field-format-switch.ts
@@ -31,8 +31,10 @@ import type { NumberFormat } from './number-format';
 // have no entry: `parseFieldFormatSwitch` returns null for them so the caller
 // keeps the section format rather than silently downgrading to decimal.
 const SWITCH_TO_FORMAT: Readonly<Record<string, NumberFormat>> = {
-  // §17.16.4.3.1 Latin / roman core.
+  // §17.16.4.3.1 Latin / roman / hex / dash core.
   Arabic: 'decimal',
+  ArabicDash: 'numberInDash', // "- 123 -"
+  Hex: 'hex', // uppercase hexadecimal
   Roman: 'upperRoman',
   roman: 'lowerRoman',
   ALPHABETIC: 'upperLetter',

--- a/packages/core/src/text/number-format.test.ts
+++ b/packages/core/src/text/number-format.test.ts
@@ -181,10 +181,14 @@ describe('formatOrdinalNumber — ECMA-376 §17.18.59 ST_NumberFormat', () => {
       ['arabicAbjad', [
         [1, 'أ'], [12, 'ل'], [28, 'ظ'], [29, 'أأ'],
       ]],
-      // hebrew2 (22-letter alphabet, repeat). 23 = א twice, 24 = ב twice,
-      // 44 = ת twice (2×22, last letter of the second cycle).
+      // hebrew2 (22-letter alphabet + ת suffix — NOT the repeat scheme).
+      // §17.18.59 steps: write the RESULT glyph once, then append ת once per
+      // 22 subtracted: 23 -> את, 24 -> בת. §17.16.4.3.1 field example:
+      // 123 \* HEBREW2 -> מ + 5×ת (123 − 5×22 = 13 -> מ). 44 − 22 = 22 stops
+      // ("equal to or less than the size of the set") -> glyph ת + 1×ת = תת.
       ['hebrew2', [
-        [1, 'א'], [10, 'י'], [22, 'ת'], [23, 'אא'], [24, 'בב'], [44, 'תת'],
+        [1, 'א'], [10, 'י'], [22, 'ת'], [23, 'את'], [24, 'בת'], [44, 'תת'],
+        [45, 'אתת'], [123, 'מתתתתת'],
       ]],
       // russianLower / russianUpper (29-letter alphabet, repeat).
       ['russianLower', [

--- a/packages/core/src/text/number-format.test.ts
+++ b/packages/core/src/text/number-format.test.ts
@@ -223,6 +223,25 @@ describe('formatOrdinalNumber — ECMA-376 §17.18.59 ST_NumberFormat', () => {
         [20, 'כ'], [21, 'כא'], [100, 'ק'], [123, 'קכג'], [200, 'ר'],
         [400, 'ת'], [500, 'ך'],
       ]],
+
+      // ── Other algorithmic systems ───────────────────────────────────────
+      // hex: base-16 over 0–9, A–F, UPPERCASE (§17.18.59 example: …, E, F, 10,
+      // 11, …, 1E, 1F, 20). NOTE the §17.16.4.3.1 field example "355 → FF" is
+      // the spec's own arithmetic error (0xFF = 255); the algorithm is normative.
+      ['hex', [
+        [1, '1'], [9, '9'], [10, 'A'], [15, 'F'], [16, '10'], [30, '1E'],
+        [31, '1F'], [32, '20'], [255, 'FF'], [4096, '1000'],
+      ]],
+      // numberInDash: decimal between two dashes (§17.18.59 example: - 1 -,
+      // - 2 -, …, - 10 -; §17.16.4.3.1 ArabicDash: 123 -> - 123 -).
+      ['numberInDash', [
+        [1, '- 1 -'], [9, '- 9 -'], [10, '- 10 -'], [123, '- 123 -'],
+      ]],
+      // decimalZero: 1–9 zero-padded, everything else plain decimal (§17.18.59
+      // example: 01, 02, …, 09, 10, 11, …, 99, 100, 101).
+      ['decimalZero', [
+        [1, '01'], [9, '09'], [10, '10'], [99, '99'], [100, '100'],
+      ]],
     ];
 
     for (const [fmt, rows] of cases) {

--- a/packages/core/src/text/number-format.test.ts
+++ b/packages/core/src/text/number-format.test.ts
@@ -165,6 +165,12 @@ describe('formatOrdinalNumber — ECMA-376 §17.18.59 ST_NumberFormat', () => {
         [1, '일'], [10, '십'], [11, '십일'], [20, '이십'], [100, '백'],
         [2024, '이천이십사'],
       ]],
+      // koreanLegal: native-Korean words, tens-word + ones-word (§17.18.59
+      // example: 하나, 열, 열하나, 스물, 스물하나). ≥100 undefined → decimal.
+      ['koreanLegal', [
+        [1, '하나'], [9, '아홉'], [10, '열'], [11, '열하나'], [20, '스물'],
+        [21, '스물하나'], [90, '아흔'], [99, '아흔아홉'], [100, '100'],
+      ]],
 
       // ── Repeat-letter alphabets ─────────────────────────────────────────
       // arabicAlpha (28): §17.16.4.3.1 ARABICALPHA example 12 -> س.

--- a/packages/core/src/text/number-format.test.ts
+++ b/packages/core/src/text/number-format.test.ts
@@ -61,12 +61,186 @@ describe('formatOrdinalNumber — ECMA-376 §17.18.59 ST_NumberFormat', () => {
     });
   });
 
+  // Table-driven per-format checks for the international systems. Each row is a
+  // format and a list of [input, expected] pairs derived from the §17.18.59
+  // enumeration definitions (character sets + construction steps) and, where the
+  // spec gives them, the §17.16.4.3.1 field-switch examples (noted inline).
+  describe('international ST_NumberFormat systems', () => {
+    const cases: Array<[NumberFormat, Array<[number, string]>]> = [
+      // ── Positional digit substitution (base-10, own zero glyph) ──────────
+      // decimalFullWidth ０–９ (U+FF10–U+FF19).
+      ['decimalFullWidth', [
+        [1, '１'], [9, '９'], [10, '１０'], [123, '１２３'], [2024, '２０２４'],
+      ]],
+      // decimalHalfWidth == ASCII decimal.
+      ['decimalHalfWidth', [
+        [1, '1'], [10, '10'], [123, '123'],
+      ]],
+      // thaiNumbers ๐–๙ (spec field example 123 -> ๑๒๓).
+      ['thaiNumbers', [
+        [1, '๑'], [9, '๙'], [10, '๑๐'], [20, '๒๐'], [123, '๑๒๓'],
+      ]],
+      // hindiNumbers १–९, zero ० (spec field example 123 -> १२३).
+      ['hindiNumbers', [
+        [1, '१'], [9, '९'], [10, '१०'], [123, '१२३'],
+      ]],
+      // ideographDigital 〇一二…九, positional (spec: 10 -> 一〇, 20 -> 二〇).
+      ['ideographDigital', [
+        [1, '一'], [9, '九'], [10, '一〇'], [11, '一一'], [20, '二〇'],
+        [100, '一〇〇'], [2024, '二〇二四'],
+      ]],
+      // japaneseDigitalTenThousand is identical to ideographDigital.
+      ['japaneseDigitalTenThousand', [
+        [10, '一〇'], [100, '一〇〇'],
+      ]],
+      // koreanDigital 영일이…구, positional (zero = 영).
+      ['koreanDigital', [
+        [1, '일'], [9, '구'], [10, '일영'], [11, '일일'], [20, '이영'],
+        [100, '일영영'],
+      ]],
+      // koreanDigital2 CJK numerals, zero = 零.
+      ['koreanDigital2', [
+        [1, '一'], [10, '一零'], [11, '一一'],
+      ]],
+      // taiwaneseDigital CJK numerals, zero = ○.
+      ['taiwaneseDigital', [
+        [1, '一'], [10, '一○'], [20, '二○'],
+      ]],
+
+      // ── chineseCounting / taiwaneseCounting (十-prefix positional) ────────
+      // §17.18.59 example: 10 -> 十, 11 -> 十一, 20 -> 二十, 99 -> 九十九,
+      // 100 -> 一〇〇, 101 -> 一〇一.
+      ['chineseCounting', [
+        [1, '一'], [9, '九'], [10, '十'], [11, '十一'], [15, '十五'],
+        [19, '十九'], [20, '二十'], [21, '二十一'], [99, '九十九'],
+        [100, '一〇〇'], [101, '一〇一'], [111, '一一一'], [200, '二〇〇'],
+        [2024, '二〇二四'],
+      ]],
+      ['taiwaneseCounting', [
+        [10, '十'], [20, '二十'], [99, '九十九'], [100, '一○○'],
+      ]],
+
+      // ── Grouped counting / legal CJK ────────────────────────────────────
+      // japaneseCounting: leading-one elision (10 -> 十, 100 -> 百), NO 零 fill.
+      // §17.18.59 example: 十, 十一, …, 二十, 二十一.
+      ['japaneseCounting', [
+        [1, '一'], [10, '十'], [11, '十一'], [19, '十九'], [20, '二十'],
+        [21, '二十一'], [100, '百'], [111, '百十一'], [200, '二百'],
+        [1000, '千'], [2024, '二千二十四'], [10000, '一万'], [10005, '一万五'],
+        [12345, '一万二千三百四十五'],
+      ]],
+      // chineseCountingThousand: NO leading-one elision (10 -> 一十), WITH 零 fill.
+      ['chineseCountingThousand', [
+        [1, '一'], [10, '一十'], [11, '一十一'], [20, '二十'], [100, '一百'],
+        [111, '一百一十一'], [1000, '一千'], [1001, '一千零一'],
+        [2024, '二千零二十四'], [10000, '一万'], [10005, '一万零五'],
+        [12345, '一万二千三百四十五'],
+      ]],
+      // taiwaneseCountingThousand mirrors chineseCountingThousand's rules.
+      ['taiwaneseCountingThousand', [
+        [10, '一十'], [1001, '一千零一'],
+      ]],
+      // chineseLegalSimplified: legal digits 壹贰叁…, 拾佰仟万, WITH 零 fill.
+      // §17.16.4.3.1 CHINESENUM2 example 123 -> 壹佰貳拾參 (traditional); the
+      // simplified glyphs give 壹佰贰拾叁.
+      ['chineseLegalSimplified', [
+        [1, '壹'], [10, '壹拾'], [20, '贰拾'], [100, '壹佰'],
+        [123, '壹佰贰拾叁'], [1001, '壹仟零壹'],
+      ]],
+      // ideographLegalTraditional: traditional legal digits 壹貳參…, NO 零 fill.
+      // §17.18.59 example: 壹, …, 壹拾, 壹拾壹, …, 貳拾, 貳拾壹.
+      ['ideographLegalTraditional', [
+        [1, '壹'], [10, '壹拾'], [11, '壹拾壹'], [20, '貳拾'], [21, '貳拾壹'],
+        [123, '壹佰貳拾參'],
+      ]],
+      // japaneseLegal: 壱弐参…, thousand = 阡, myriad = 萬, NO 零 fill.
+      // §17.18.59 example: 壱, 弐, 参, …, 壱拾, 壱拾壱, …, 弐拾, 弐拾壱.
+      ['japaneseLegal', [
+        [1, '壱'], [10, '壱拾'], [11, '壱拾壱'], [20, '弐拾'], [21, '弐拾壱'],
+        [100, '壱百'], [2024, '弐阡弐拾四'], [10000, '壱萬'],
+      ]],
+      // koreanCounting: 일이삼…, 십백천만, leading-one elision, NO 零 fill.
+      // §17.18.59 example: 일, 이, 삼, …, 팔, 구, 십, 십일.
+      ['koreanCounting', [
+        [1, '일'], [10, '십'], [11, '십일'], [20, '이십'], [100, '백'],
+        [2024, '이천이십사'],
+      ]],
+
+      // ── Repeat-letter alphabets ─────────────────────────────────────────
+      // arabicAlpha (28): §17.16.4.3.1 ARABICALPHA example 12 -> س.
+      ['arabicAlpha', [
+        [1, 'أ'], [12, 'س'], [28, 'ي'], [29, 'أأ'], [56, 'يي'], [57, 'أأأ'],
+      ]],
+      // arabicAbjad (28): §17.16.4.3.1 ARABICABJAD example 12 -> ل.
+      ['arabicAbjad', [
+        [1, 'أ'], [12, 'ل'], [28, 'ظ'], [29, 'أأ'],
+      ]],
+      // hebrew2 (22-letter alphabet, repeat). 23 = א twice, 24 = ב twice,
+      // 44 = ת twice (2×22, last letter of the second cycle).
+      ['hebrew2', [
+        [1, 'א'], [10, 'י'], [22, 'ת'], [23, 'אא'], [24, 'בב'], [44, 'תת'],
+      ]],
+      // russianLower / russianUpper (29-letter alphabet, repeat).
+      ['russianLower', [
+        [1, 'а'], [29, 'я'], [30, 'аа'], [58, 'яя'], [59, 'ааа'],
+      ]],
+      ['russianUpper', [
+        [1, 'А'], [29, 'Я'], [30, 'АА'],
+      ]],
+      // thaiLetters (41-letter set, repeat).
+      ['thaiLetters', [
+        [1, 'ก'], [41, 'ฮ'], [42, 'กก'],
+      ]],
+      // chosung / ganada (14-jamo/syllable sets, repeat).
+      ['chosung', [
+        [1, 'ㄱ'], [14, 'ㅎ'], [15, 'ㄱㄱ'],
+      ]],
+      ['ganada', [
+        [1, '가'], [14, '하'], [15, '가가'],
+      ]],
+      // hindiVowels (37) / hindiConsonants (18) sets, repeat.
+      ['hindiVowels', [
+        [1, 'क'], [37, 'ह'], [38, 'कक'],
+      ]],
+      ['hindiConsonants', [
+        [1, 'अ'], [16, 'औ'], [17, 'अं'], [18, 'अः'], [19, 'अअ'],
+      ]],
+
+      // ── Hebrew gematria (positional letters) ────────────────────────────
+      // §17.16.4.3.1 HEBREW1 example 123 -> קכג. 15/16 special cases (טו/טז).
+      ['hebrew1', [
+        [1, 'א'], [9, 'ט'], [10, 'י'], [15, 'טו'], [16, 'טז'], [17, 'יז'],
+        [20, 'כ'], [21, 'כא'], [100, 'ק'], [123, 'קכג'], [200, 'ר'],
+        [400, 'ת'], [500, 'ך'],
+      ]],
+    ];
+
+    for (const [fmt, rows] of cases) {
+      describe(fmt, () => {
+        for (const [input, expected] of rows) {
+          it(`${input} -> ${expected}`, () => {
+            expect(formatOrdinalNumber(input, fmt)).toBe(expected);
+          });
+        }
+        it('falls back to decimal for zero and negatives', () => {
+          expect(formatOrdinalNumber(0, fmt)).toBe('0');
+          expect(formatOrdinalNumber(-2, fmt)).toBe('-2');
+        });
+      });
+    }
+  });
+
   describe('unsupported / text formats fall back to decimal', () => {
-    it('renders cardinalText, ordinal, none, etc. as decimal (documented residual)', () => {
-      // Text-based formats (cardinalText, ordinalText, ...) are NOT implemented;
-      // they degrade to Arabic decimal so a page number is never blank.
+    it('renders the language spell-out formats as decimal (documented residual)', () => {
+      // cardinalText/ordinalText/ordinal/thaiCounting/vietnameseCounting/… are
+      // language-dependent spell-outs with no algorithmic definition in
+      // §17.18.59; they degrade to Arabic decimal so a page number is never blank.
       expect(formatOrdinalNumber(5, 'cardinalText' as NumberFormat)).toBe('5');
+      expect(formatOrdinalNumber(5, 'ordinalText' as NumberFormat)).toBe('5');
+      expect(formatOrdinalNumber(5, 'thaiCounting' as NumberFormat)).toBe('5');
+      expect(formatOrdinalNumber(5, 'vietnameseCounting' as NumberFormat)).toBe('5');
       expect(formatOrdinalNumber(5, 'none' as NumberFormat)).toBe('5');
+      expect(formatOrdinalNumber(5, 'custom' as NumberFormat)).toBe('5');
       expect(formatOrdinalNumber(5, undefined)).toBe('5');
     });
   });

--- a/packages/core/src/text/number-format.ts
+++ b/packages/core/src/text/number-format.ts
@@ -40,6 +40,7 @@ export type NumberFormat =
   // Positional digit substitution (base-10, own zero glyph).
   | 'decimalFullWidth'
   | 'decimalHalfWidth'
+  | 'decimalZero'
   | 'thaiNumbers'
   | 'hindiNumbers'
   | 'ideographDigital'
@@ -72,6 +73,9 @@ export type NumberFormat =
   // Hebrew (positional gematria / alphabet-with-ת-suffix — NOT the repeat scheme).
   | 'hebrew1'
   | 'hebrew2'
+  // Other algorithmic systems.
+  | 'hex'
+  | 'numberInDash'
   // Accepted but rendered as decimal (documented residual) — kept in the type so
   // callers can pass a raw parsed value without a cast for the common ones.
   | 'none'
@@ -332,6 +336,20 @@ export function formatOrdinalNumber(n: number, fmt: NumberFormat | undefined): s
       return n >= 1 ? toHebrewGematria(n) : String(n);
     case 'hebrew2':
       return n >= 1 ? toHebrew2(n) : String(n);
+    // Other algorithmic systems.
+    case 'hex':
+      // §17.18.59 hex: base-16 positional over 0–9, A–F (U+0030–U+0039,
+      // U+0041–U+0046 — uppercase). Example: …, E, F, 10, 11, …, 1E, 1F, 20.
+      return n >= 1 ? n.toString(16).toUpperCase() : String(n);
+    case 'numberInDash':
+      // §17.18.59 numberInDash: the Arabic decimal "placed between two dashes";
+      // the example pattern spaces them: - 1 -, - 2 -, …, - 10 -. §17.16.4.3.1
+      // ArabicDash concurs: 'prefix of "- " and a suffix of " -"' (123 → - 123 -).
+      return n >= 1 ? `- ${n} -` : String(n);
+    case 'decimalZero':
+      // §17.18.59 decimalZero: Arabic decimal "with a zero added to numbers one
+      // through nine" — 01, 02, …, 09, 10, 11, …, 99, 100 (only 1–9 are padded).
+      return n >= 1 && n <= 9 ? `0${n}` : String(n);
     // Positional digit substitution (n=0 renders the zero glyph — but list/page
     // numbering is 1-based, so we still gate ≥1 and fall back for ≤0).
     case 'decimalFullWidth':

--- a/packages/core/src/text/number-format.ts
+++ b/packages/core/src/text/number-format.ts
@@ -62,7 +62,6 @@ export type NumberFormat =
   // Repeat-letter alphabets (subtract set size, repeat the glyph).
   | 'arabicAlpha'
   | 'arabicAbjad'
-  | 'hebrew2'
   | 'russianLower'
   | 'russianUpper'
   | 'thaiLetters'
@@ -70,8 +69,9 @@ export type NumberFormat =
   | 'ganada'
   | 'hindiVowels'
   | 'hindiConsonants'
-  // Positional Hebrew gematria.
+  // Hebrew (positional gematria / alphabet-with-ת-suffix — NOT the repeat scheme).
   | 'hebrew1'
+  | 'hebrew2'
   // Accepted but rendered as decimal (documented residual) — kept in the type so
   // callers can pass a raw parsed value without a cast for the common ones.
   | 'none'
@@ -116,13 +116,14 @@ function toUpperRoman(n: number): string {
 }
 
 // ── Repeat-letter alphabets ─────────────────────────────────────────────────
-// §17.18.59 upperLetter/lowerLetter/arabicAlpha/arabicAbjad/hebrew2/russian*/
+// §17.18.59 upperLetter/lowerLetter/arabicAlpha/arabicAbjad/russian*/
 // thaiLetters/chosung/ganada/hindiVowels/hindiConsonants all share ONE scheme:
 // a fixed ordered character set of size N; the value maps into 1..N, and for
 // values > N the SAME character is REPEATED once per full N subtracted (§17.18.59
 // "written once and then repeated for each time the size of the set was
 // subtracted"). This is Word's letter-column-UNLIKE scheme — NOT base-N. For
 // English (N=26): 27 → "aa", 53 → "aaa", 54 → "BBB". Caller guarantees n ≥ 1.
+// (hebrew2 is NOT in this family — it appends a ת run instead; see toHebrew2.)
 function repeatAlphabet(n: number, glyphs: readonly string[]): string {
   const size = glyphs.length;
   const repeats = Math.floor((n - 1) / size) + 1;
@@ -312,8 +313,6 @@ export function formatOrdinalNumber(n: number, fmt: NumberFormat | undefined): s
       return n >= 1 ? repeatAlphabet(n, ARABIC_ALPHA) : String(n);
     case 'arabicAbjad':
       return n >= 1 ? repeatAlphabet(n, ARABIC_ABJAD) : String(n);
-    case 'hebrew2':
-      return n >= 1 ? repeatAlphabet(n, HEBREW_ALPHABET) : String(n);
     case 'russianLower':
       return n >= 1 ? repeatAlphabet(n, RUSSIAN_LOWER) : String(n);
     case 'russianUpper':
@@ -328,9 +327,11 @@ export function formatOrdinalNumber(n: number, fmt: NumberFormat | undefined): s
       return n >= 1 ? repeatAlphabet(n, HINDI_VOWELS) : String(n);
     case 'hindiConsonants':
       return n >= 1 ? repeatAlphabet(n, HINDI_CONSONANTS) : String(n);
-    // Positional Hebrew gematria.
+    // Hebrew.
     case 'hebrew1':
       return n >= 1 ? toHebrewGematria(n) : String(n);
+    case 'hebrew2':
+      return n >= 1 ? toHebrew2(n) : String(n);
     // Positional digit substitution (n=0 renders the zero glyph — but list/page
     // numbering is 1-based, so we still gate ≥1 and fall back for ≤0).
     case 'decimalFullWidth':
@@ -420,6 +421,24 @@ function toHebrewGematria(n: number): string {
   out += HEBREW_TENS[tens];
   out += HEBREW_ONES[ones];
   return out;
+}
+
+// ── Hebrew alphabet with ת suffix (hebrew2) ─────────────────────────────────
+// §17.18.59 hebrew2: NOT the repeat-letter scheme. For n > 22: "1. Repeatedly
+// subtract the size of the set (22) from the value until the result is equal to
+// or less than the size of the set. 2. Write the symbol represented by the
+// result value. 3. Then the ת symbol is repeated … for each time the size of the
+// set was subtracted." So the RESULT glyph appears ONCE, followed by one ת per
+// subtraction — 23 → את, 24 → בת; and per the §17.16.4.3.1 field example,
+// 123 \* HEBREW2 → מ + 5×ת (5 subtractions leave 13 → מ).
+// Caller guarantees n ≥ 1.
+function toHebrew2(n: number): string {
+  const size = HEBREW_ALPHABET.length; // 22
+  // Subtractions until the remainder is in 1..22 (a remainder of exactly 22
+  // stops — "equal to or less than the size of the set", so 44 → ת + 1×ת).
+  const subtractions = Math.floor((n - 1) / size);
+  const remainder = n - size * subtractions; // 1..22
+  return HEBREW_ALPHABET[remainder - 1] + 'ת'.repeat(subtractions);
 }
 
 // ── Grouped CJK counting / legal (myriad grouping) ──────────────────────────

--- a/packages/core/src/text/number-format.ts
+++ b/packages/core/src/text/number-format.ts
@@ -56,6 +56,7 @@ export type NumberFormat =
   | 'japaneseCounting'
   | 'japaneseLegal'
   | 'koreanCounting'
+  | 'koreanLegal'
   | 'taiwaneseCountingThousand'
   | 'ideographLegalTraditional'
   // Repeat-letter alphabets (subtract set size, repeat the glyph).
@@ -369,6 +370,8 @@ export function formatOrdinalNumber(n: number, fmt: NumberFormat | undefined): s
       return n >= 1 ? toMyriadGrouped(n, MYRIAD_JAPANESE_LEGAL) : String(n);
     case 'koreanCounting':
       return n >= 1 ? toMyriadGrouped(n, MYRIAD_KOREAN) : String(n);
+    case 'koreanLegal':
+      return n >= 1 ? toKoreanLegal(n) : String(n);
     case 'decimal':
     default:
       return String(n);
@@ -587,4 +590,27 @@ function toMyriadGrouped(n: number, t: MyriadTable): string {
     out += renderMyriadGroup(lowerGroup, t, t.elideOne);
   }
   return out;
+}
+
+// ── koreanLegal (native-Korean numerals) ────────────────────────────────────
+// §17.18.59 koreanLegal: NOT the myriad system — native Korean number words
+// concatenated tens-word + ones-word. The spec tables ones 1–9 and tens 10..90
+// explicitly (하나/둘/…, 열/스물/…), and its example shows the concatenation
+// (11 → 열하나, 21 → 스물하나). The spec does NOT define values ≥ 100, so we
+// render the fully-specified 1–99 range and fall back to decimal above it
+// (rendering only what §17.18.59 tables — no invented composition).
+const KOREAN_LEGAL_ONES: readonly string[] = [
+  '', '하나', '둘', '셋', '넷', '다섯', '여섯', '일곱', '여덟', '아홉',
+];
+const KOREAN_LEGAL_TENS: readonly string[] = [
+  '', '열', '스물', '서른', '마흔', '쉰', '예순', '일흔', '여든', '아흔',
+];
+
+/** koreanLegal for 1–99 (§17.18.59); ≥ 100 is undefined by the spec, so the
+ *  caller's decimal fallback applies. Caller guarantees n ≥ 1. */
+function toKoreanLegal(n: number): string {
+  if (n >= 100) return String(n); // spec tables only 1–99.
+  const tens = Math.floor(n / 10);
+  const ones = n % 10;
+  return KOREAN_LEGAL_TENS[tens] + KOREAN_LEGAL_ONES[ones];
 }

--- a/packages/core/src/text/number-format.ts
+++ b/packages/core/src/text/number-format.ts
@@ -4,27 +4,73 @@
 // carries an ST_NumberFormat: page numbering (§17.6.12 `<w:pgNumType w:fmt>` and
 // the §17.16.4.3.1 field general-formatting switches `\* roman` / `\* ALPHABETIC`
 // / …), list markers (§17.9.17 `<w:numFmt>`), footnote/endnote numbering, etc.
-// Keeping it in `core` means a future list-numbering feature reuses ONE roman /
-// letter converter instead of forking a second copy.
+// Keeping it in `core` means every consumer reuses ONE converter instead of
+// forking a copy. (NOTE: the docx list-marker path also duplicates this table in
+// Rust — `packages/docx/parser/src/numbering.rs::format_counter` — because the
+// `%1.%2` multi-level composition happens at parse time; the two MUST stay in
+// sync. See that file's header.)
 //
-// SCOPE (this pass): the numeric, locale-independent formats Word's page-number
-// and list surfaces use in practice — `decimal`, `upperRoman`/`lowerRoman`,
-// `upperLetter`/`lowerLetter`. Every OTHER ST_NumberFormat value (the text
-// spell-outs `cardinalText`/`ordinalText`, the CJK / Hebrew / Thai / Hindi
-// counting systems, the enclosed-glyph families, `hex`, `none`, …) is a
-// DOCUMENTED RESIDUAL: it degrades to `decimal` so a page number is never blank.
-// Those are follow-ups; extend the switch below (and the docx page-number wiring)
-// when a fixture needs them.
+// SCOPE: the numeric, algorithmically-defined formats §17.18.59 specifies with a
+// concrete character set + construction steps. The families below cover the
+// Latin/roman core, the CJK counting/legal systems, the RTL Hebrew/Arabic
+// alphabets, and the positional digit substitutions (Thai/Hindi/full-width/…).
+//
+// A DOCUMENTED RESIDUAL degrades to `decimal` (so a page number is never blank):
+//   * The language SPELL-OUT formats — `cardinalText`, `ordinalText`, `ordinal`,
+//     `thaiCounting`, `vietnameseCounting`, `hindiCounting`, `bahtText`,
+//     `dollarText`, `custom` — §17.18.59 defines these only as "the textual
+//     representation, in the language of the lang element, of …". There is NO
+//     algorithm or character table to implement; they require a per-language
+//     dictionary keyed off the run's `w:lang`, which this pure converter has no
+//     access to. Implementing them would mean inventing spell-outs (a heuristic).
+//   * The Chinese sexagenary-cycle ideographs (`ideographTraditional`,
+//     `ideographZodiac`, `ideographZodiacTraditional`) and other rarely-authored
+//     enclosed families we have not yet added.
 
-/** ECMA-376 §17.18.59 ST_NumberFormat — the subset this converter renders
- *  natively (see module header). Any other string is accepted at the call site
- *  and falls back to `decimal`. */
+/** ECMA-376 §17.18.59 ST_NumberFormat — the values this converter renders
+ *  natively. Any other string is accepted at the call site and falls back to
+ *  `decimal` (see module header). */
 export type NumberFormat =
+  // Latin / roman core (§17.16.4.3.1 field switches map onto these).
   | 'decimal'
   | 'upperRoman'
   | 'lowerRoman'
   | 'upperLetter'
   | 'lowerLetter'
+  // Positional digit substitution (base-10, own zero glyph).
+  | 'decimalFullWidth'
+  | 'decimalHalfWidth'
+  | 'thaiNumbers'
+  | 'hindiNumbers'
+  | 'ideographDigital'
+  | 'japaneseDigitalTenThousand'
+  | 'koreanDigital'
+  | 'koreanDigital2'
+  | 'taiwaneseDigital'
+  // Positional CJK with the 十 tens-prefix rule.
+  | 'chineseCounting'
+  | 'taiwaneseCounting'
+  // Grouped "counting / legal" CJK (万/千/百/十 place words, 零 zero-fill).
+  | 'chineseCountingThousand'
+  | 'chineseLegalSimplified'
+  | 'japaneseCounting'
+  | 'japaneseLegal'
+  | 'koreanCounting'
+  | 'taiwaneseCountingThousand'
+  | 'ideographLegalTraditional'
+  // Repeat-letter alphabets (subtract set size, repeat the glyph).
+  | 'arabicAlpha'
+  | 'arabicAbjad'
+  | 'hebrew2'
+  | 'russianLower'
+  | 'russianUpper'
+  | 'thaiLetters'
+  | 'chosung'
+  | 'ganada'
+  | 'hindiVowels'
+  | 'hindiConsonants'
+  // Positional Hebrew gematria.
+  | 'hebrew1'
   // Accepted but rendered as decimal (documented residual) — kept in the type so
   // callers can pass a raw parsed value without a cast for the common ones.
   | 'none'
@@ -33,10 +79,12 @@ export type NumberFormat =
   | 'ordinal'
   | (string & {});
 
-// Classic additive roman numerals, greedily consumed high→low. The four
-// subtractive pairs (CM/CD/XC/XL/IX/IV) are inlined so 4/9/40/… render correctly.
-// Values ≥ 4000 have no classical single glyph; Word writes repeated M (no
-// vinculum bar), which the greedy 1000→M step reproduces (4000 → "MMMM").
+// ── Roman numerals ──────────────────────────────────────────────────────────
+// §17.18.59 upperRoman/lowerRoman. Classic additive numerals, greedily consumed
+// high→low. The four subtractive pairs (CM/CD/XC/XL/IX/IV) are inlined so
+// 4/9/40/… render correctly. Values ≥ 4000 have no classical single glyph; Word
+// writes repeated M (no vinculum bar), which the greedy 1000→M step reproduces
+// (4000 → "MMMM").
 const ROMAN_TABLE: ReadonlyArray<readonly [number, string]> = [
   [1000, 'M'],
   [900, 'CM'],
@@ -66,35 +114,477 @@ function toUpperRoman(n: number): string {
   return out;
 }
 
-/** ECMA-376 §17.16.4.3.1 ALPHABETIC/alphabetic (⇔ ST_NumberFormat
- *  upperLetter/lowerLetter): the value maps into A..Z, and for values > 26 the
- *  SAME letter is REPEATED once per full 26 subtracted (27 → "aa", 53 → "aaa",
- *  54 → "BBB"). This is Word's spreadsheet-column-UNLIKE scheme — NOT base-26
- *  (which would give 27 → "aa" too but 53 → "ba"). Caller guarantees n ≥ 1. */
-function toUpperLetter(n: number): string {
-  const repeats = Math.floor((n - 1) / 26) + 1;
-  const letter = String.fromCharCode(0x41 + ((n - 1) % 26)); // 'A' + index
-  return letter.repeat(repeats);
+// ── Repeat-letter alphabets ─────────────────────────────────────────────────
+// §17.18.59 upperLetter/lowerLetter/arabicAlpha/arabicAbjad/hebrew2/russian*/
+// thaiLetters/chosung/ganada/hindiVowels/hindiConsonants all share ONE scheme:
+// a fixed ordered character set of size N; the value maps into 1..N, and for
+// values > N the SAME character is REPEATED once per full N subtracted (§17.18.59
+// "written once and then repeated for each time the size of the set was
+// subtracted"). This is Word's letter-column-UNLIKE scheme — NOT base-N. For
+// English (N=26): 27 → "aa", 53 → "aaa", 54 → "BBB". Caller guarantees n ≥ 1.
+function repeatAlphabet(n: number, glyphs: readonly string[]): string {
+  const size = glyphs.length;
+  const repeats = Math.floor((n - 1) / size) + 1;
+  const glyph = glyphs[(n - 1) % size];
+  return glyph.repeat(repeats);
 }
 
-/**
- * Render `n` in the ST_NumberFormat `fmt`. Non-native formats — and zero /
- * negative values under a format that has no glyph for them (roman, letters) —
- * fall back to Arabic decimal, so the result is never empty. `undefined`/absent
- * `fmt` is the spec default `decimal`.
- */
+/** A-Z, built once for the letter converters. */
+const LATIN_UPPER: readonly string[] = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode(0x41 + i),
+);
+
+// §17.18.59 arabicAlpha "Arabic Alphabet" — positions 1–28 (spec character list).
+const ARABIC_ALPHA: readonly string[] = [
+  'أ', 'ب', 'ت', 'ث', 'ج', 'ح', 'خ', 'د',
+  'ذ', 'ر', 'ز', 'س', 'ش', 'ص', 'ض', 'ط',
+  'ظ', 'ع', 'غ', 'ف', 'ق', 'ك', 'ل', 'م',
+  'ن', 'ه', 'و', 'ي',
+];
+
+// §17.18.59 arabicAbjad "Arabic Abjad Numerals" — positions 1–28 (spec list).
+const ARABIC_ABJAD: readonly string[] = [
+  'أ', 'ب', 'ج', 'د', 'ه', 'و', 'ز', 'ح',
+  'ط', 'ي', 'ك', 'ل', 'م', 'ن', 'س', 'ع',
+  'ف', 'ص', 'ق', 'ر', 'ش', 'ت', 'ث', 'خ',
+  'ذ', 'ض', 'غ', 'ظ',
+];
+
+// §17.18.59 hebrew2 "Hebrew Alphabet" — positions 1–22 (spec list, note the
+// non-contiguous ranges: aleph..yod, then kaf/lamed/mem, nun..ayin, pe, tsadi..tav).
+const HEBREW_ALPHABET: readonly string[] = [
+  'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח',
+  'ט', 'י', // 1–10 aleph..yod
+  'כ', 'ל', 'מ', // kaf, lamed, mem
+  'נ', 'ס', 'ע', // nun, samekh, ayin
+  'פ', // pe
+  'צ', 'ק', 'ר', 'ש', 'ת', // tsadi, qof, resh, shin, tav
+];
+
+// §17.18.59 russianLower/russianUpper — positions 1–29 (the Russian alphabet
+// MINUS ё, й, ъ, ь per the spec's explicit range list). Lower: а–и, к–п, р–щ, ы,
+// э, ю, я.
+const RUSSIAN_LOWER: readonly string[] = [
+  ...rangeChars(0x0430, 0x0438), // а–и
+  ...rangeChars(0x043A, 0x043F), // к–п
+  ...rangeChars(0x0440, 0x0449), // р–щ
+  'ы', // ы
+  'э', // э
+  'ю', // ю
+  'я', // я
+];
+const RUSSIAN_UPPER: readonly string[] = [
+  ...rangeChars(0x0410, 0x0418), // А–И
+  ...rangeChars(0x041A, 0x041F), // К–П
+  ...rangeChars(0x0420, 0x0429), // Р–Щ
+  'Ы', // Ы
+  'Э', // Э
+  'Ю', // Ю
+  'Я', // Я
+];
+
+// §17.18.59 thaiLetters — positions 1–41 (spec: U+0E01, U+0E02, U+0E04,
+// U+0E07–U+0E23, U+0E25, U+0E27–U+0E2E — the Thai consonants minus a few).
+const THAI_LETTERS: readonly string[] = [
+  'ก', 'ข', 'ค',
+  ...rangeChars(0x0E07, 0x0E23),
+  'ล',
+  ...rangeChars(0x0E27, 0x0E2E),
+];
+
+// §17.18.59 chosung "Korean Chosung" — positions 1–14 (spec list of jamo).
+const KOREAN_CHOSUNG: readonly string[] = [
+  'ㄱ', 'ㄴ', 'ㄷ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅅ', 'ㅇ',
+  'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ',
+];
+
+// §17.18.59 ganada "Korean Ganada" — positions 1–14 (spec list of syllables).
+const KOREAN_GANADA: readonly string[] = [
+  '가', '나', '다', '라', '마', '바', '사', '아',
+  '자', '차', '카', '타', '파', '하',
+];
+
+// §17.18.59 hindiVowels — positions 1–37 = U+0915–U+0939 (the Devanagari
+// consonants; the spec label "vowels" is a misnomer for this range).
+const HINDI_VOWELS: readonly string[] = rangeChars(0x0915, 0x0939);
+
+// §17.18.59 hindiConsonants — positions 1–18 = U+0905–U+0914, then U+0905+U+0902
+// and U+0905+U+0903 (the Devanagari independent vowels + two anusvara/visarga
+// combinations; the spec label "consonants" is likewise a misnomer).
+const HINDI_CONSONANTS: readonly string[] = [
+  ...rangeChars(0x0905, 0x0914),
+  'अं',
+  'अः',
+];
+
+/** Inclusive code-point range → array of single-character strings. */
+function rangeChars(fromCp: number, toCp: number): string[] {
+  const out: string[] = [];
+  for (let cp = fromCp; cp <= toCp; cp++) out.push(String.fromCodePoint(cp));
+  return out;
+}
+
+// ── Positional digit substitution ───────────────────────────────────────────
+// §17.18.59 decimalFullWidth/thaiNumbers/hindiNumbers/ideographDigital/… : a
+// base-10 positional system with a fixed 10-glyph digit set (index 0 is the zero
+// glyph). The displayed text is the decimal string with each ASCII digit swapped
+// for its glyph. Caller guarantees n ≥ 1 (n=0 also renders fine — "zeroGlyph").
+function toPositionalDigits(n: number, digits: readonly string[]): string {
+  return String(n)
+    .split('')
+    .map((d) => digits[d.charCodeAt(0) - 0x30])
+    .join('');
+}
+
+// Digit sets for the positional formats, index 0 = zero glyph … index 9.
+// Full-width Arabic ０–９ (§17.18.59 decimalFullWidth, U+FF10–U+FF19).
+const DIGITS_FULLWIDTH: readonly string[] = rangeChars(0xff10, 0xff19);
+// Thai numerals ๐–๙ (§17.18.59 thaiNumbers, U+0E50–U+0E59).
+const DIGITS_THAI: readonly string[] = rangeChars(0x0e50, 0x0e59);
+// Hindi (Devanagari) numerals ०–९ (§17.18.59 hindiNumbers, U+0966–U+096F).
+const DIGITS_HINDI: readonly string[] = rangeChars(0x0966, 0x096f);
+// Ideographic digits 〇一二…九 (§17.18.59 ideographDigital, zero = U+3007).
+const DIGITS_IDEOGRAPH: readonly string[] = [
+  '〇', '一', '二', '三', '四', '五', '六', '七',
+  '八', '九',
+];
+// Korean hangul digits 영일이삼… (§17.18.59 koreanDigital, zero = 영 U+C601).
+const DIGITS_KOREAN: readonly string[] = [
+  '영', '일', '이', '삼', '사', '오', '육', '칠',
+  '팔', '구',
+];
+// koreanDigital2: same hangul-value positions but zero = 零 (U+96F6) and the
+// value glyphs are the CJK numerals 一二三… (§17.18.59 koreanDigital2).
+const DIGITS_KOREAN2: readonly string[] = [
+  '零', '一', '二', '三', '四', '五', '六', '七',
+  '八', '九',
+];
+// taiwaneseDigital: CJK numerals with zero = ○ (U+25CB) (§17.18.59).
+const DIGITS_TAIWANESE: readonly string[] = [
+  '○', '一', '二', '三', '四', '五', '六', '七',
+  '八', '九',
+];
+
+// ── chineseCounting / taiwaneseCounting (十-prefix positional) ───────────────
+// §17.18.59 chineseCounting: NOT the myriad grouping system. It is base-10
+// positional with ONE special rule for the tens place: "Divide the value by 10
+// and write the symbol for the remainder. If the quotient is less than 10, write
+// 十 to the left of the symbol." So the 十 tens-word appears ONLY while the
+// running quotient is a single digit — i.e. for 2-digit values (10–99). For
+// values ≥ 100 the top quotient is ≥ 10, so the rule never fires and the number
+// renders as pure positional digit substitution (with 〇 for zero).
+// Verified against §17.18.59 examples: 10 → 十, 11 → 十一, 20 → 二十, 99 → 九十九,
+// 100 → 一〇〇, 101 → 一〇一.
+function toChineseCounting(n: number, digits: readonly string[]): string {
+  // digits[0] is the zero glyph (〇 for chineseCounting, ○ for taiwaneseCounting).
+  if (n < 10) return digits[n];
+  const TEN = '十'; // 十
+  if (n < 100) {
+    const tens = Math.floor(n / 10);
+    const ones = n % 10;
+    // Leading-one elision: 10–19 → 十… (no 一 before 十). 20+ → <digit>十.
+    const head = tens === 1 ? TEN : digits[tens] + TEN;
+    return ones === 0 ? head : head + digits[ones];
+  }
+  // ≥ 100: pure positional digit substitution (the 十 rule no longer applies).
+  return toPositionalDigits(n, digits);
+}
+
+/** ECMA-376 §17.18.59 ST_NumberFormat converter dispatch. Non-native formats —
+ *  and zero / negative values under a format that has no glyph for them (roman,
+ *  letters) — fall back to Arabic decimal, so the result is never empty.
+ *  `undefined`/absent `fmt` is the spec default `decimal`. */
 export function formatOrdinalNumber(n: number, fmt: NumberFormat | undefined): string {
   switch (fmt) {
+    // Roman.
     case 'upperRoman':
       return n >= 1 ? toUpperRoman(n) : String(n);
     case 'lowerRoman':
       return n >= 1 ? toUpperRoman(n).toLowerCase() : String(n);
+    // Latin letters.
     case 'upperLetter':
-      return n >= 1 ? toUpperLetter(n) : String(n);
+      return n >= 1 ? repeatAlphabet(n, LATIN_UPPER) : String(n);
     case 'lowerLetter':
-      return n >= 1 ? toUpperLetter(n).toLowerCase() : String(n);
+      return n >= 1 ? repeatAlphabet(n, LATIN_UPPER).toLowerCase() : String(n);
+    // Repeat-letter non-Latin alphabets.
+    case 'arabicAlpha':
+      return n >= 1 ? repeatAlphabet(n, ARABIC_ALPHA) : String(n);
+    case 'arabicAbjad':
+      return n >= 1 ? repeatAlphabet(n, ARABIC_ABJAD) : String(n);
+    case 'hebrew2':
+      return n >= 1 ? repeatAlphabet(n, HEBREW_ALPHABET) : String(n);
+    case 'russianLower':
+      return n >= 1 ? repeatAlphabet(n, RUSSIAN_LOWER) : String(n);
+    case 'russianUpper':
+      return n >= 1 ? repeatAlphabet(n, RUSSIAN_UPPER) : String(n);
+    case 'thaiLetters':
+      return n >= 1 ? repeatAlphabet(n, THAI_LETTERS) : String(n);
+    case 'chosung':
+      return n >= 1 ? repeatAlphabet(n, KOREAN_CHOSUNG) : String(n);
+    case 'ganada':
+      return n >= 1 ? repeatAlphabet(n, KOREAN_GANADA) : String(n);
+    case 'hindiVowels':
+      return n >= 1 ? repeatAlphabet(n, HINDI_VOWELS) : String(n);
+    case 'hindiConsonants':
+      return n >= 1 ? repeatAlphabet(n, HINDI_CONSONANTS) : String(n);
+    // Positional Hebrew gematria.
+    case 'hebrew1':
+      return n >= 1 ? toHebrewGematria(n) : String(n);
+    // Positional digit substitution (n=0 renders the zero glyph — but list/page
+    // numbering is 1-based, so we still gate ≥1 and fall back for ≤0).
+    case 'decimalFullWidth':
+      return n >= 1 ? toPositionalDigits(n, DIGITS_FULLWIDTH) : String(n);
+    case 'decimalHalfWidth':
+      return String(n); // half-width Arabic == ASCII decimal.
+    case 'thaiNumbers':
+      return n >= 1 ? toPositionalDigits(n, DIGITS_THAI) : String(n);
+    case 'hindiNumbers':
+      return n >= 1 ? toPositionalDigits(n, DIGITS_HINDI) : String(n);
+    case 'ideographDigital':
+    case 'japaneseDigitalTenThousand': // identical digit-substitution system.
+      return n >= 1 ? toPositionalDigits(n, DIGITS_IDEOGRAPH) : String(n);
+    case 'koreanDigital':
+      return n >= 1 ? toPositionalDigits(n, DIGITS_KOREAN) : String(n);
+    case 'koreanDigital2':
+      return n >= 1 ? toPositionalDigits(n, DIGITS_KOREAN2) : String(n);
+    case 'taiwaneseDigital':
+      return n >= 1 ? toPositionalDigits(n, DIGITS_TAIWANESE) : String(n);
+    // Positional CJK with the 十 tens-prefix.
+    case 'chineseCounting':
+      return n >= 1 ? toChineseCounting(n, DIGITS_IDEOGRAPH) : String(n);
+    case 'taiwaneseCounting':
+      return n >= 1 ? toChineseCounting(n, DIGITS_TAIWANESE) : String(n);
+    // Grouped counting / legal CJK.
+    case 'chineseCountingThousand':
+      return n >= 1 ? toMyriadGrouped(n, MYRIAD_CHINESE) : String(n);
+    case 'taiwaneseCountingThousand':
+      return n >= 1 ? toMyriadGrouped(n, MYRIAD_TAIWANESE) : String(n);
+    case 'chineseLegalSimplified':
+      return n >= 1 ? toMyriadGrouped(n, MYRIAD_CHINESE_LEGAL) : String(n);
+    case 'ideographLegalTraditional':
+      return n >= 1 ? toMyriadGrouped(n, MYRIAD_TRAD_LEGAL) : String(n);
+    case 'japaneseCounting':
+      return n >= 1 ? toMyriadGrouped(n, MYRIAD_JAPANESE) : String(n);
+    case 'japaneseLegal':
+      return n >= 1 ? toMyriadGrouped(n, MYRIAD_JAPANESE_LEGAL) : String(n);
+    case 'koreanCounting':
+      return n >= 1 ? toMyriadGrouped(n, MYRIAD_KOREAN) : String(n);
     case 'decimal':
     default:
       return String(n);
   }
+}
+
+// ── Hebrew gematria (hebrew1) ───────────────────────────────────────────────
+// §17.18.59 hebrew1 "Hebrew Letters": positional letter arithmetic. Replace each
+// decimal place (ones, tens, hundreds, thousands) with its Hebrew symbol, reading
+// right-to-left in logical order (units first, so the string is
+// hundreds+tens+ones when read left-to-right). Two special cases: 15 → טו and
+// 16 → טז (to avoid spelling a divine name). Thousands reuse the ones glyphs.
+const HEBREW_ONES: readonly string[] = [
+  '', 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז',
+  'ח', 'ט', // 0..9: -, א..ט
+];
+const HEBREW_TENS: readonly string[] = [
+  '', 'י', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע',
+  'פ', 'צ', // 0..90 step 10: -, י,כ,ל,מ,נ,ס,ע,פ,צ
+];
+const HEBREW_HUNDREDS: readonly string[] = [
+  '', 'ק', 'ר', 'ש', 'ת', 'ך', 'ם', 'ן',
+  'ף', 'ץ', // 0..900 step 100: -, ק,ר,ש,ת,ך,ם,ן,ף,ץ
+];
+
+/** hebrew1 gematria for a positive integer (§17.18.59). Values are built
+ *  hundreds→tens→ones (visual left-to-right). Above 999 the thousands digit is
+ *  written with the ones glyphs, prepended. Caller guarantees n ≥ 1. */
+function toHebrewGematria(n: number): string {
+  let out = '';
+  let rem = n;
+  const thousands = Math.floor(rem / 1000);
+  rem %= 1000;
+  const hundreds = Math.floor(rem / 100);
+  rem %= 100;
+  // §17.18.59 step 1: thousands digit uses the ones symbols.
+  if (thousands > 0) out += HEBREW_ONES[thousands % 10];
+  // §17.18.59 step 2: hundreds. Values >400 combine (e.g. 500 = ת + ק), but the
+  // spec's explicit hundreds table covers 100–900 directly, so use it.
+  out += HEBREW_HUNDREDS[hundreds];
+  // §17.18.59 step 3: 15/16 special case (avoid spelling יה / יו).
+  if (rem === 15) return out + 'טו'; // טו
+  if (rem === 16) return out + 'טז'; // טז
+  const tens = Math.floor(rem / 10);
+  const ones = rem % 10;
+  out += HEBREW_TENS[tens];
+  out += HEBREW_ONES[ones];
+  return out;
+}
+
+// ── Grouped CJK counting / legal (myriad grouping) ──────────────────────────
+// §17.18.59 chineseCountingThousand / japaneseCounting / *Legal / koreanCounting:
+// the East-Asian myriad (万-grouped) system. A value < 10^8 is split into two
+// 4-digit myriad groups (ones-myriad and 万-myriad); each group is rendered
+// digit-by-place using the 千/百/十 unit words, with the 万 unit appended to the
+// upper group. A run of interior zeros collapses to a single 零 (§17.18.59 "write
+// the symbol 零 instead"). The formats differ ONLY in their glyph tables and in
+// whether a leading "1" is written before 十/百/千.
+interface MyriadTable {
+  /** Value glyphs for digits 0–9 (index 0 is the zero-fill glyph, e.g. 零/〇). */
+  readonly digits: readonly string[];
+  /** Unit glyphs for 10, 100, 1000. */
+  readonly ten: string;
+  readonly hundred: string;
+  readonly thousand: string;
+  /** Unit glyph for the 10^4 myriad group. */
+  readonly myriad: string;
+  /** Whether "1" is elided before a leading 十/百/千 (Japanese: 十, not 一十;
+   *  Chinese thousand-counting: writes 一十). */
+  readonly elideOne: boolean;
+  /** Whether a single 零 fills an interior zero gap (§17.18.59: the Chinese
+   *  counting/legal formats specify this; the Japanese/Korean/traditional-legal
+   *  step lists do NOT mention 零, so they omit it — e.g. japaneseCounting
+   *  10005 → 一万五, chineseCountingThousand 10005 → 一万零五). */
+  readonly insertZero: boolean;
+}
+
+// Normal simplified/generic CJK digits and units.
+const CJK_DIGITS: readonly string[] = DIGITS_KOREAN2; // 零 一 二 … 九
+const MYRIAD_JAPANESE: MyriadTable = {
+  digits: CJK_DIGITS,
+  ten: '十', // 十
+  hundred: '百', // 百
+  thousand: '千', // 千
+  myriad: '万', // 万
+  elideOne: true, // §17.18.59 example: 10 → 十, 20 → 二十.
+  insertZero: false, // japaneseCounting step list has no 零 rule.
+};
+const MYRIAD_CHINESE: MyriadTable = {
+  ...MYRIAD_JAPANESE,
+  elideOne: false, // §17.18.59 example: 10 → 一十.
+  insertZero: true, // chineseCountingThousand specifies the 零 gap rule.
+};
+const MYRIAD_TAIWANESE: MyriadTable = {
+  // taiwaneseCountingThousand shares the simplified units but its example shows
+  // 10 → 一十 (no elision) like chineseCountingThousand, and specifies 零.
+  ...MYRIAD_CHINESE,
+};
+const MYRIAD_KOREAN: MyriadTable = {
+  digits: ['영', '일', '이', '삼', '사', '오', '육', '칠', '팔', '구'],
+  ten: '십', // 십
+  hundred: '백', // 백
+  thousand: '천', // 천
+  myriad: '만', // 만
+  elideOne: true, // §17.18.59 example: 10 → 십, 십일.
+  insertZero: false, // koreanCounting step list has no 零 rule.
+};
+const MYRIAD_CHINESE_LEGAL: MyriadTable = {
+  // §17.18.59 chineseLegalSimplified digits 0–9: 零 壹 贰 叁 肆 伍 陆 柒 捌 玖.
+  digits: ['零', '壹', '贰', '叁', '肆', '伍', '陆', '柒', '捌', '玖'],
+  ten: '拾', // 拾
+  hundred: '佰', // 佰
+  thousand: '仟', // 仟
+  myriad: '万', // 万
+  elideOne: false,
+  insertZero: true, // chineseLegalSimplified specifies the 零 gap rule.
+};
+const MYRIAD_JAPANESE_LEGAL: MyriadTable = {
+  // §17.18.59 japaneseLegal digits: 壱 弐 参 四 伍 六 七 八 九 (zero-fill reuses 零).
+  digits: ['零', '壱', '弐', '参', '四', '伍', '六', '七', '八', '九'],
+  ten: '拾', // 拾
+  hundred: '百', // 百
+  thousand: '阡', // 阡
+  myriad: '萬', // 萬
+  elideOne: false, // §17.18.59 example: 壱拾 (10).
+  insertZero: false, // japaneseLegal step list has no 零 rule.
+};
+const MYRIAD_TRAD_LEGAL: MyriadTable = {
+  // §17.18.59 ideographLegalTraditional digits: 壹 貳 參 肆 伍 陸 柒 捌 玖.
+  digits: ['零', '壹', '貳', '參', '肆', '伍', '陸', '柒', '捌', '玖'],
+  ten: '拾', // 拾
+  hundred: '佰', // 佰
+  thousand: '仟', // 仟
+  myriad: '萬', // 萬
+  elideOne: false, // §17.18.59 example: 壹拾 (10).
+  insertZero: false, // ideographLegalTraditional step list has no 零 rule.
+};
+
+/** Render one 4-digit myriad group (0–9999) with 千/百/十 units. Returns '' for
+ *  a zero group. A single interior 零 marks a gap between nonzero places
+ *  (§17.18.59). `elideOne` drops a leading "1" before 十/百/千 when set. */
+function renderMyriadGroup(group: number, t: MyriadTable, elideOne: boolean): string {
+  const thousands = Math.floor(group / 1000) % 10;
+  const hundreds = Math.floor(group / 100) % 10;
+  const tens = Math.floor(group / 10) % 10;
+  const ones = group % 10;
+  const places: Array<{ digit: number; unit: string }> = [
+    { digit: thousands, unit: t.thousand },
+    { digit: hundreds, unit: t.hundred },
+    { digit: tens, unit: t.ten },
+    { digit: ones, unit: '' },
+  ];
+  let out = '';
+  let sawNonZero = false;
+  let pendingZero = false;
+  for (const { digit, unit } of places) {
+    if (digit === 0) {
+      // Mark a zero gap only once we have already emitted a higher nonzero place
+      // (leading zeros contribute nothing).
+      if (sawNonZero) pendingZero = true;
+      continue;
+    }
+    if (pendingZero) {
+      // Single 零 for the collapsed interior zero run — only for formats that
+      // specify it (§17.18.59: Chinese counting/legal; Japanese/Korean omit).
+      if (t.insertZero) out += t.digits[0];
+      pendingZero = false;
+    }
+    // Elide the multiplier "1" before 十/百/千 when the table asks for it
+    // (Japanese/Korean: 十 not 一十, 百 not 一百, and mid-number too — 111 → 百十一,
+    // 1100 → 千百). The ones place has no unit, so its "1" is always written; the
+    // 万/億 myriad units sit OUTSIDE this group render, so 10000 keeps its 一 (一万).
+    // Chinese-thousand / legal formats set elide=false and write 一十/一百/一千.
+    if (elideOne && digit === 1 && unit) {
+      out += unit;
+    } else {
+      out += t.digits[digit] + unit;
+    }
+    sawNonZero = true;
+  }
+  return out;
+}
+
+/** East-Asian myriad-grouped counting/legal formatter (§17.18.59). Handles values
+ *  up to 10^8 − 1 precisely (two myriad groups). For ≥ 10^8 we render the 億
+ *  group recursively with the same rules — the spec sketches this as "an
+ *  additional symbol at one hundred million" but does not fully table it, so the
+ *  高位 rendering is a faithful extension of the documented < 10^8 algorithm.
+ *  Caller guarantees n ≥ 1. */
+function toMyriadGrouped(n: number, t: MyriadTable): string {
+  if (n >= 100000000) {
+    // 億 = 10^8. Recurse: <upper>億<remainder>, remainder rendered with no leading
+    // elision quirk changes. (U+5104 億 for JP/CN, U+5104 shared.)
+    const upper = Math.floor(n / 100000000);
+    const lower = n % 100000000;
+    const OKU = '億'; // 億
+    const head = toMyriadGrouped(upper, t) + OKU;
+    if (lower === 0) return head;
+    // A gap between the 億 group and a small remainder gets a 零 (e.g. 100000001)
+    // for the formats that specify the 零 rule.
+    const gap = t.insertZero && lower < 10000000 ? t.digits[0] : '';
+    return head + gap + toMyriadGrouped(lower, t);
+  }
+  const upperGroup = Math.floor(n / 10000); // 万 group (0–9999).
+  const lowerGroup = n % 10000; // ones group (0–9999).
+  let out = '';
+  if (upperGroup > 0) {
+    out += renderMyriadGroup(upperGroup, t, t.elideOne) + t.myriad;
+  }
+  if (lowerGroup > 0) {
+    // Insert a single 零 when the ones-group's highest place is below thousands
+    // but the 万 group is present (e.g. 10005 → 一万零五): a gap exists between 万
+    // and the ones group (§17.18.59 "if no groups are formed … write 零"). Only
+    // for formats that specify the 零 rule.
+    if (t.insertZero && upperGroup > 0 && lowerGroup < 1000) out += t.digits[0];
+    out += renderMyriadGroup(lowerGroup, t, t.elideOne);
+  }
+  return out;
 }

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -458,20 +458,65 @@ impl NumberingMap {
     }
 }
 
+// ── ST_NumberFormat rendering (ECMA-376 §17.18.59) ──────────────────────────
+// This is the RUST twin of `packages/core/src/text/number-format.ts`
+// (`formatOrdinalNumber`). List markers resolve to a final string at PARSE time
+// (`resolve_text` composes `%1.%2` here in Rust), so the same numbering systems
+// must be implemented on both sides and produce BYTE-IDENTICAL output. When you
+// touch a format here, mirror it there (and vice versa); the TS unit tests are
+// the reference values. `bullet` is a list-only concern (no §17.18.59 numeric
+// meaning) and stays Rust-only.
 fn format_counter(n: u32, format: &str) -> String {
+    if format == "bullet" {
+        return "•".to_string();
+    }
+    // The numeric systems are 1-based; a level with start=0 (rare) or an
+    // underflow falls back to the decimal string, matching the TS `n >= 1` gate.
+    if n == 0 {
+        return n.to_string();
+    }
     match format {
-        "decimal" => n.to_string(),
-        "bullet" => "•".to_string(),
-        "lowerLetter" => {
-            let c = (b'a' + ((n - 1) % 26) as u8) as char;
-            c.to_string()
-        }
-        "upperLetter" => {
-            let c = (b'A' + ((n - 1) % 26) as u8) as char;
-            c.to_string()
-        }
+        "decimal" | "decimalHalfWidth" => n.to_string(),
+        // Roman.
         "lowerRoman" => to_roman(n).to_lowercase(),
         "upperRoman" => to_roman(n),
+        // Latin + non-Latin repeat-letter alphabets (§17.18.59).
+        "lowerLetter" => repeat_alphabet(n, &latin_upper()).to_lowercase(),
+        "upperLetter" => repeat_alphabet(n, &latin_upper()),
+        "arabicAlpha" => repeat_alphabet(n, ARABIC_ALPHA),
+        "arabicAbjad" => repeat_alphabet(n, ARABIC_ABJAD),
+        "hebrew2" => repeat_alphabet(n, HEBREW_ALPHABET),
+        "russianLower" => repeat_alphabet(n, RUSSIAN_LOWER),
+        "russianUpper" => repeat_alphabet(n, RUSSIAN_UPPER),
+        "thaiLetters" => repeat_alphabet(n, THAI_LETTERS),
+        "chosung" => repeat_alphabet(n, KOREAN_CHOSUNG),
+        "ganada" => repeat_alphabet(n, KOREAN_GANADA),
+        "hindiVowels" => repeat_alphabet(n, HINDI_VOWELS),
+        "hindiConsonants" => repeat_alphabet(n, HINDI_CONSONANTS),
+        // Positional Hebrew gematria.
+        "hebrew1" => to_hebrew_gematria(n),
+        // Positional digit substitution.
+        "decimalFullWidth" => to_positional_digits(n, DIGITS_FULLWIDTH),
+        "thaiNumbers" => to_positional_digits(n, DIGITS_THAI),
+        "hindiNumbers" => to_positional_digits(n, DIGITS_HINDI),
+        "ideographDigital" | "japaneseDigitalTenThousand" => {
+            to_positional_digits(n, DIGITS_IDEOGRAPH)
+        }
+        "koreanDigital" => to_positional_digits(n, DIGITS_KOREAN),
+        "koreanDigital2" => to_positional_digits(n, DIGITS_KOREAN2),
+        "taiwaneseDigital" => to_positional_digits(n, DIGITS_TAIWANESE),
+        // 十-prefix positional.
+        "chineseCounting" => to_chinese_counting(n, DIGITS_IDEOGRAPH),
+        "taiwaneseCounting" => to_chinese_counting(n, DIGITS_TAIWANESE),
+        // Grouped counting / legal CJK.
+        "japaneseCounting" => to_myriad_grouped(n, &MYRIAD_JAPANESE),
+        "chineseCountingThousand" => to_myriad_grouped(n, &MYRIAD_CHINESE),
+        "taiwaneseCountingThousand" => to_myriad_grouped(n, &MYRIAD_CHINESE),
+        "chineseLegalSimplified" => to_myriad_grouped(n, &MYRIAD_CHINESE_LEGAL),
+        "ideographLegalTraditional" => to_myriad_grouped(n, &MYRIAD_TRAD_LEGAL),
+        "japaneseLegal" => to_myriad_grouped(n, &MYRIAD_JAPANESE_LEGAL),
+        "koreanCounting" => to_myriad_grouped(n, &MYRIAD_KOREAN),
+        // Documented residual (language spell-outs / unimplemented) → decimal.
         _ => n.to_string(),
     }
 }
@@ -501,6 +546,282 @@ fn to_roman(n: u32) -> String {
         }
     }
     s
+}
+
+// A–Z, built for the Latin letter converters (repeat scheme, not base-26).
+fn latin_upper() -> Vec<&'static str> {
+    const A: [&str; 26] = [
+        "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R",
+        "S", "T", "U", "V", "W", "X", "Y", "Z",
+    ];
+    A.to_vec()
+}
+
+// §17.18.59 arabicAlpha "Arabic Alphabet" — positions 1–28.
+const ARABIC_ALPHA: &[&str] = &[
+    "أ", "ب", "ت", "ث", "ج", "ح", "خ", "د", "ذ", "ر", "ز", "س", "ش", "ص", "ض", "ط", "ظ", "ع", "غ",
+    "ف", "ق", "ك", "ل", "م", "ن", "ه", "و", "ي",
+];
+// §17.18.59 arabicAbjad "Arabic Abjad Numerals" — positions 1–28.
+const ARABIC_ABJAD: &[&str] = &[
+    "أ", "ب", "ج", "د", "ه", "و", "ز", "ح", "ط", "ي", "ك", "ل", "م", "ن", "س", "ع", "ف", "ص", "ق",
+    "ر", "ش", "ت", "ث", "خ", "ذ", "ض", "غ", "ظ",
+];
+// §17.18.59 hebrew2 "Hebrew Alphabet" — positions 1–22.
+const HEBREW_ALPHABET: &[&str] = &[
+    "א", "ב", "ג", "ד", "ה", "ו", "ז", "ח", "ט", "י", "כ", "ל", "מ", "נ", "ס", "ע", "פ", "צ", "ק",
+    "ר", "ש", "ת",
+];
+// §17.18.59 russianLower/Upper — positions 1–29 (alphabet minus ё, й, ъ, ь).
+const RUSSIAN_LOWER: &[&str] = &[
+    "а", "б", "в", "г", "д", "е", "ж", "з", "и", "к", "л", "м", "н", "о", "п", "р", "с", "т", "у",
+    "ф", "х", "ц", "ч", "ш", "щ", "ы", "э", "ю", "я",
+];
+const RUSSIAN_UPPER: &[&str] = &[
+    "А", "Б", "В", "Г", "Д", "Е", "Ж", "З", "И", "К", "Л", "М", "Н", "О", "П", "Р", "С", "Т", "У",
+    "Ф", "Х", "Ц", "Ч", "Ш", "Щ", "Ы", "Э", "Ю", "Я",
+];
+// §17.18.59 thaiLetters — positions 1–41 (U+0E01, U+0E02, U+0E04, U+0E07–U+0E23,
+// U+0E25, U+0E27–U+0E2E).
+const THAI_LETTERS: &[&str] = &[
+    "ก", "ข", "ค", "ง", "จ", "ฉ", "ช", "ซ", "ฌ", "ญ", "ฎ", "ฏ", "ฐ", "ฑ", "ฒ", "ณ", "ด", "ต", "ถ",
+    "ท", "ธ", "น", "บ", "ป", "ผ", "ฝ", "พ", "ฟ", "ภ", "ม", "ย", "ร", "ล", "ว", "ศ", "ษ", "ส", "ห",
+    "ฬ", "อ", "ฮ",
+];
+// §17.18.59 chosung "Korean Chosung" — positions 1–14.
+const KOREAN_CHOSUNG: &[&str] = &[
+    "ㄱ", "ㄴ", "ㄷ", "ㄹ", "ㅁ", "ㅂ", "ㅅ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ",
+];
+// §17.18.59 ganada "Korean Ganada" — positions 1–14.
+const KOREAN_GANADA: &[&str] = &[
+    "가", "나", "다", "라", "마", "바", "사", "아", "자", "차", "카", "타", "파", "하",
+];
+// §17.18.59 hindiVowels — positions 1–37 = U+0915–U+0939 (contiguous).
+const HINDI_VOWELS: &[&str] = &[
+    "क", "ख", "ग", "घ", "ङ", "च", "छ", "ज", "झ", "ञ", "ट", "ठ", "ड", "ढ", "ण", "त", "थ", "द", "ध",
+    "न", "ऩ", "प", "फ", "ब", "भ", "म", "य", "र", "ऱ", "ल", "ळ", "ऴ", "व", "श", "ष", "स", "ह",
+];
+// §17.18.59 hindiConsonants — positions 1–18 = U+0905–U+0914 then अं / अः.
+const HINDI_CONSONANTS: &[&str] = &[
+    "अ", "आ", "इ", "ई", "उ", "ऊ", "ऋ", "ऌ", "ऍ", "ऎ", "ए", "ऐ", "ऑ", "ऒ", "ओ", "औ", "अं", "अः",
+];
+
+/// §17.18.59 repeat-letter alphabets: map 1..N into the set; for n>N repeat the
+/// SAME glyph once per full N subtracted (not base-N). Mirrors the TS
+/// `repeatAlphabet`.
+fn repeat_alphabet(n: u32, glyphs: &[&str]) -> String {
+    let size = glyphs.len() as u32;
+    let repeats = (n - 1) / size + 1;
+    let glyph = glyphs[((n - 1) % size) as usize];
+    glyph.repeat(repeats as usize)
+}
+
+// Positional digit sets, index 0 = zero glyph … index 9 (§17.18.59).
+const DIGITS_FULLWIDTH: &[&str] = &["０", "１", "２", "３", "４", "５", "６", "７", "８", "９"];
+const DIGITS_THAI: &[&str] = &["๐", "๑", "๒", "๓", "๔", "๕", "๖", "๗", "๘", "๙"];
+const DIGITS_HINDI: &[&str] = &["०", "१", "२", "३", "४", "५", "६", "७", "८", "९"];
+const DIGITS_IDEOGRAPH: &[&str] = &["〇", "一", "二", "三", "四", "五", "六", "七", "八", "九"];
+const DIGITS_KOREAN: &[&str] = &["영", "일", "이", "삼", "사", "오", "육", "칠", "팔", "구"];
+const DIGITS_KOREAN2: &[&str] = &["零", "一", "二", "三", "四", "五", "六", "七", "八", "九"];
+const DIGITS_TAIWANESE: &[&str] = &["○", "一", "二", "三", "四", "五", "六", "七", "八", "九"];
+
+/// §17.18.59 base-10 positional digit substitution. Mirrors TS `toPositionalDigits`.
+fn to_positional_digits(n: u32, digits: &[&str]) -> String {
+    n.to_string()
+        .bytes()
+        .map(|b| digits[(b - b'0') as usize])
+        .collect()
+}
+
+/// §17.18.59 chineseCounting / taiwaneseCounting: base-10 positional with the 十
+/// tens-word for 2-digit values only (10 → 十, 20 → 二十, 99 → 九十九), pure
+/// positional at ≥ 100 (100 → 一〇〇). Mirrors TS `toChineseCounting`.
+fn to_chinese_counting(n: u32, digits: &[&str]) -> String {
+    if n < 10 {
+        return digits[n as usize].to_string();
+    }
+    if n < 100 {
+        let tens = n / 10;
+        let ones = n % 10;
+        let head = if tens == 1 {
+            "十".to_string()
+        } else {
+            format!("{}十", digits[tens as usize])
+        };
+        return if ones == 0 {
+            head
+        } else {
+            format!("{}{}", head, digits[ones as usize])
+        };
+    }
+    to_positional_digits(n, digits)
+}
+
+// ── Grouped CJK counting / legal (myriad grouping) ──────────────────────────
+// Mirrors the TS `MyriadTable` + `toMyriadGrouped`.
+struct MyriadTable {
+    digits: &'static [&'static str], // index 0 = 零/〇 zero-fill glyph … 9
+    ten: &'static str,
+    hundred: &'static str,
+    thousand: &'static str,
+    myriad: &'static str,
+    elide_one: bool,   // Japanese/Korean elide the "1" before 十/百/千.
+    insert_zero: bool, // Chinese counting/legal fill an interior gap with 零.
+}
+
+const CJK_DIGITS: &[&str] = DIGITS_KOREAN2; // 零 一 二 … 九
+const MYRIAD_JAPANESE: MyriadTable = MyriadTable {
+    digits: CJK_DIGITS,
+    ten: "十",
+    hundred: "百",
+    thousand: "千",
+    myriad: "万",
+    elide_one: true,
+    insert_zero: false,
+};
+const MYRIAD_CHINESE: MyriadTable = MyriadTable {
+    elide_one: false,
+    insert_zero: true,
+    ..MYRIAD_JAPANESE
+};
+const MYRIAD_KOREAN: MyriadTable = MyriadTable {
+    digits: &["영", "일", "이", "삼", "사", "오", "육", "칠", "팔", "구"],
+    ten: "십",
+    hundred: "백",
+    thousand: "천",
+    myriad: "만",
+    elide_one: true,
+    insert_zero: false,
+};
+const MYRIAD_CHINESE_LEGAL: MyriadTable = MyriadTable {
+    digits: &["零", "壹", "贰", "叁", "肆", "伍", "陆", "柒", "捌", "玖"],
+    ten: "拾",
+    hundred: "佰",
+    thousand: "仟",
+    myriad: "万",
+    elide_one: false,
+    insert_zero: true,
+};
+const MYRIAD_JAPANESE_LEGAL: MyriadTable = MyriadTable {
+    digits: &["零", "壱", "弐", "参", "四", "伍", "六", "七", "八", "九"],
+    ten: "拾",
+    hundred: "百",
+    thousand: "阡",
+    myriad: "萬",
+    elide_one: false,
+    insert_zero: false,
+};
+const MYRIAD_TRAD_LEGAL: MyriadTable = MyriadTable {
+    digits: &["零", "壹", "貳", "參", "肆", "伍", "陸", "柒", "捌", "玖"],
+    ten: "拾",
+    hundred: "佰",
+    thousand: "仟",
+    myriad: "萬",
+    elide_one: false,
+    insert_zero: false,
+};
+
+/// Render one 4-digit myriad group (0–9999). Mirrors TS `renderMyriadGroup`.
+fn render_myriad_group(group: u32, t: &MyriadTable) -> String {
+    let thousands = group / 1000 % 10;
+    let hundreds = group / 100 % 10;
+    let tens = group / 10 % 10;
+    let ones = group % 10;
+    let places = [
+        (thousands, t.thousand),
+        (hundreds, t.hundred),
+        (tens, t.ten),
+        (ones, ""),
+    ];
+    let mut out = String::new();
+    let mut saw_non_zero = false;
+    let mut pending_zero = false;
+    for (digit, unit) in places {
+        if digit == 0 {
+            if saw_non_zero {
+                pending_zero = true;
+            }
+            continue;
+        }
+        if pending_zero {
+            if t.insert_zero {
+                out.push_str(t.digits[0]);
+            }
+            pending_zero = false;
+        }
+        if t.elide_one && digit == 1 && !unit.is_empty() {
+            out.push_str(unit);
+        } else {
+            out.push_str(t.digits[digit as usize]);
+            out.push_str(unit);
+        }
+        saw_non_zero = true;
+    }
+    out
+}
+
+/// East-Asian myriad-grouped counting/legal formatter. Mirrors TS
+/// `toMyriadGrouped` (values ≥ 10^8 recurse through 億).
+fn to_myriad_grouped(n: u32, t: &MyriadTable) -> String {
+    if n >= 100_000_000 {
+        let upper = n / 100_000_000;
+        let lower = n % 100_000_000;
+        let head = format!("{}億", to_myriad_grouped(upper, t));
+        if lower == 0 {
+            return head;
+        }
+        let gap = if t.insert_zero && lower < 10_000_000 {
+            t.digits[0]
+        } else {
+            ""
+        };
+        return format!("{}{}{}", head, gap, to_myriad_grouped(lower, t));
+    }
+    let upper_group = n / 10000;
+    let lower_group = n % 10000;
+    let mut out = String::new();
+    if upper_group > 0 {
+        out.push_str(&render_myriad_group(upper_group, t));
+        out.push_str(t.myriad);
+    }
+    if lower_group > 0 {
+        if t.insert_zero && upper_group > 0 && lower_group < 1000 {
+            out.push_str(t.digits[0]);
+        }
+        out.push_str(&render_myriad_group(lower_group, t));
+    }
+    out
+}
+
+// §17.18.59 hebrew1 gematria. Mirrors TS `toHebrewGematria`.
+const HEBREW_ONES: &[&str] = &["", "א", "ב", "ג", "ד", "ה", "ו", "ז", "ח", "ט"];
+const HEBREW_TENS: &[&str] = &["", "י", "כ", "ל", "מ", "נ", "ס", "ע", "פ", "צ"];
+const HEBREW_HUNDREDS: &[&str] = &["", "ק", "ר", "ש", "ת", "ך", "ם", "ן", "ף", "ץ"];
+
+fn to_hebrew_gematria(n: u32) -> String {
+    let mut out = String::new();
+    let mut rem = n;
+    let thousands = rem / 1000;
+    rem %= 1000;
+    let hundreds = rem / 100;
+    rem %= 100;
+    if thousands > 0 {
+        out.push_str(HEBREW_ONES[(thousands % 10) as usize]);
+    }
+    out.push_str(HEBREW_HUNDREDS[hundreds as usize]);
+    if rem == 15 {
+        out.push_str("טו");
+        return out;
+    }
+    if rem == 16 {
+        out.push_str("טז");
+        return out;
+    }
+    let tens = rem / 10;
+    let ones = rem % 10;
+    out.push_str(HEBREW_TENS[tens as usize]);
+    out.push_str(HEBREW_ONES[ones as usize]);
+    out
 }
 
 #[cfg(test)]
@@ -786,5 +1107,146 @@ mod tests {
         // abstractNumId 4's counter (which would yield 2).
         let b = m.advance(4, 0);
         assert_eq!(m.resolve_text(4, 0, b), "1.");
+    }
+
+    /// ECMA-376 §17.18.59 — the Rust `format_counter` MUST match the core TS
+    /// `formatOrdinalNumber` byte-for-byte (list markers resolve here at parse
+    /// time). These expected values are the SAME rows as
+    /// packages/core/src/text/number-format.test.ts — keep the two in sync.
+    #[test]
+    fn format_counter_international_matches_core_ts() {
+        let cases: &[(&str, &[(u32, &str)])] = &[
+            // Latin repeat-letter (beyond 26 now repeats — previously Rust only
+            // handled 1–26, a bug this parity pass fixes).
+            (
+                "upperLetter",
+                &[(1, "A"), (26, "Z"), (27, "AA"), (54, "BBB")],
+            ),
+            (
+                "lowerLetter",
+                &[(1, "a"), (26, "z"), (27, "aa"), (53, "aaa")],
+            ),
+            (
+                "upperRoman",
+                &[(4, "IV"), (123, "CXXIII"), (3999, "MMMCMXCIX")],
+            ),
+            ("lowerRoman", &[(1, "i"), (123, "cxxiii")]),
+            // Positional digit substitution.
+            ("decimalFullWidth", &[(1, "１"), (123, "１２３")]),
+            ("thaiNumbers", &[(1, "๑"), (123, "๑๒๓")]),
+            ("hindiNumbers", &[(1, "१"), (123, "१२३")]),
+            (
+                "ideographDigital",
+                &[(10, "一〇"), (100, "一〇〇"), (2024, "二〇二四")],
+            ),
+            ("koreanDigital", &[(10, "일영"), (100, "일영영")]),
+            // 十-prefix positional.
+            (
+                "chineseCounting",
+                &[
+                    (10, "十"),
+                    (20, "二十"),
+                    (99, "九十九"),
+                    (100, "一〇〇"),
+                    (101, "一〇一"),
+                ],
+            ),
+            // Grouped counting / legal.
+            (
+                "japaneseCounting",
+                &[
+                    (10, "十"),
+                    (11, "十一"),
+                    (100, "百"),
+                    (111, "百十一"),
+                    (2024, "二千二十四"),
+                    (10005, "一万五"),
+                    (12345, "一万二千三百四十五"),
+                ],
+            ),
+            (
+                "chineseCountingThousand",
+                &[
+                    (10, "一十"),
+                    (100, "一百"),
+                    (1001, "一千零一"),
+                    (2024, "二千零二十四"),
+                    (10005, "一万零五"),
+                ],
+            ),
+            (
+                "chineseLegalSimplified",
+                &[
+                    (1, "壹"),
+                    (10, "壹拾"),
+                    (123, "壹佰贰拾叁"),
+                    (1001, "壹仟零壹"),
+                ],
+            ),
+            (
+                "ideographLegalTraditional",
+                &[(10, "壹拾"), (123, "壹佰貳拾參")],
+            ),
+            (
+                "japaneseLegal",
+                &[(10, "壱拾"), (2024, "弐阡弐拾四"), (10000, "壱萬")],
+            ),
+            (
+                "koreanCounting",
+                &[(10, "십"), (11, "십일"), (2024, "이천이십사")],
+            ),
+            // Repeat-letter non-Latin alphabets.
+            ("arabicAlpha", &[(1, "أ"), (12, "س"), (28, "ي"), (29, "أأ")]),
+            ("arabicAbjad", &[(1, "أ"), (12, "ل"), (28, "ظ"), (29, "أأ")]),
+            ("hebrew2", &[(1, "א"), (22, "ת"), (23, "אא"), (24, "בב")]),
+            ("russianLower", &[(1, "а"), (29, "я"), (30, "аа")]),
+            ("thaiLetters", &[(1, "ก"), (41, "ฮ"), (42, "กก")]),
+            ("chosung", &[(1, "ㄱ"), (14, "ㅎ"), (15, "ㄱㄱ")]),
+            ("ganada", &[(1, "가"), (14, "하"), (15, "가가")]),
+            ("hindiVowels", &[(1, "क"), (37, "ह"), (38, "कक")]),
+            (
+                "hindiConsonants",
+                &[(1, "अ"), (16, "औ"), (17, "अं"), (18, "अः")],
+            ),
+            // Positional Hebrew gematria.
+            (
+                "hebrew1",
+                &[
+                    (1, "א"),
+                    (15, "טו"),
+                    (16, "טז"),
+                    (17, "יז"),
+                    (123, "קכג"),
+                    (500, "ך"),
+                ],
+            ),
+            // Documented residual / spell-outs fall back to decimal.
+            ("cardinalText", &[(5, "5")]),
+            ("thaiCounting", &[(5, "5")]),
+            ("none", &[(5, "5")]),
+        ];
+        for (fmt, rows) in cases {
+            for (input, expected) in *rows {
+                assert_eq!(
+                    format_counter(*input, fmt),
+                    *expected,
+                    "format_counter({input}, {fmt:?})"
+                );
+            }
+        }
+    }
+
+    /// A numbered list whose level uses an international `<w:numFmt>` resolves the
+    /// marker through `format_counter` — the end-to-end list path (§17.9.17).
+    #[test]
+    fn list_marker_uses_international_numfmt() {
+        let mut m = map(r#"<w:abstractNum w:abstractNumId="9">
+                 <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="ideographDigital"/><w:lvlText w:val="%1."/></w:lvl>
+               </w:abstractNum>
+               <w:num w:numId="9"><w:abstractNumId w:val="9"/></w:num>"#);
+        let a = m.advance(9, 0);
+        assert_eq!(m.resolve_text(9, 0, a), "一."); // 1 → 一
+        let b = m.advance(9, 0);
+        assert_eq!(m.resolve_text(9, 0, b), "二."); // 2 → 二
     }
 }

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -485,7 +485,6 @@ fn format_counter(n: u32, format: &str) -> String {
         "upperLetter" => repeat_alphabet(n, &latin_upper()),
         "arabicAlpha" => repeat_alphabet(n, ARABIC_ALPHA),
         "arabicAbjad" => repeat_alphabet(n, ARABIC_ABJAD),
-        "hebrew2" => repeat_alphabet(n, HEBREW_ALPHABET),
         "russianLower" => repeat_alphabet(n, RUSSIAN_LOWER),
         "russianUpper" => repeat_alphabet(n, RUSSIAN_UPPER),
         "thaiLetters" => repeat_alphabet(n, THAI_LETTERS),
@@ -493,8 +492,9 @@ fn format_counter(n: u32, format: &str) -> String {
         "ganada" => repeat_alphabet(n, KOREAN_GANADA),
         "hindiVowels" => repeat_alphabet(n, HINDI_VOWELS),
         "hindiConsonants" => repeat_alphabet(n, HINDI_CONSONANTS),
-        // Positional Hebrew gematria.
+        // Hebrew: positional gematria / alphabet-with-ת-suffix (NOT repeat).
         "hebrew1" => to_hebrew_gematria(n),
+        "hebrew2" => to_hebrew2(n),
         // Positional digit substitution.
         "decimalFullWidth" => to_positional_digits(n, DIGITS_FULLWIDTH),
         "thaiNumbers" => to_positional_digits(n, DIGITS_THAI),
@@ -844,6 +844,21 @@ fn to_hebrew_gematria(n: u32) -> String {
     out.push_str(HEBREW_TENS[tens as usize]);
     out.push_str(HEBREW_ONES[ones as usize]);
     out
+}
+
+/// §17.18.59 hebrew2 — NOT the repeat-letter scheme: subtract 22 until the
+/// result is ≤ 22, write THAT glyph once, then append ת once per subtraction
+/// (23 → את, 24 → בת; §17.16.4.3.1 field example 123 → מ + 5×ת). Mirrors TS
+/// `toHebrew2`.
+fn to_hebrew2(n: u32) -> String {
+    let size = HEBREW_ALPHABET.len() as u32; // 22
+    let subtractions = (n - 1) / size;
+    let remainder = n - size * subtractions; // 1..=22
+    format!(
+        "{}{}",
+        HEBREW_ALPHABET[(remainder - 1) as usize],
+        "ת".repeat(subtractions as usize)
+    )
 }
 
 #[cfg(test)]
@@ -1231,7 +1246,6 @@ mod tests {
             // Repeat-letter non-Latin alphabets.
             ("arabicAlpha", &[(1, "أ"), (12, "س"), (28, "ي"), (29, "أأ")]),
             ("arabicAbjad", &[(1, "أ"), (12, "ل"), (28, "ظ"), (29, "أأ")]),
-            ("hebrew2", &[(1, "א"), (22, "ת"), (23, "אא"), (24, "בב")]),
             ("russianLower", &[(1, "а"), (29, "я"), (30, "аа")]),
             ("thaiLetters", &[(1, "ก"), (41, "ฮ"), (42, "กก")]),
             ("chosung", &[(1, "ㄱ"), (14, "ㅎ"), (15, "ㄱㄱ")]),
@@ -1241,7 +1255,7 @@ mod tests {
                 "hindiConsonants",
                 &[(1, "अ"), (16, "औ"), (17, "अं"), (18, "अः")],
             ),
-            // Positional Hebrew gematria.
+            // Hebrew: positional gematria / alphabet-with-ת-suffix.
             (
                 "hebrew1",
                 &[
@@ -1251,6 +1265,20 @@ mod tests {
                     (17, "יז"),
                     (123, "קכג"),
                     (500, "ך"),
+                ],
+            ),
+            // hebrew2: result glyph once + ת per 22 subtracted (§17.18.59 steps;
+            // §17.16.4.3.1 example 123 → מ + 5×ת). NOT the repeat scheme.
+            (
+                "hebrew2",
+                &[
+                    (1, "א"),
+                    (22, "ת"),
+                    (23, "את"),
+                    (24, "בת"),
+                    (44, "תת"),
+                    (45, "אתת"),
+                    (123, "מתתתתת"),
                 ],
             ),
             // Documented residual / spell-outs fall back to decimal.

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -495,6 +495,16 @@ fn format_counter(n: u32, format: &str) -> String {
         // Hebrew: positional gematria / alphabet-with-ת-suffix (NOT repeat).
         "hebrew1" => to_hebrew_gematria(n),
         "hebrew2" => to_hebrew2(n),
+        // Other algorithmic systems (§17.18.59 hex / numberInDash / decimalZero).
+        "hex" => format!("{:X}", n),
+        "numberInDash" => format!("- {} -", n),
+        "decimalZero" => {
+            if n <= 9 {
+                format!("0{}", n)
+            } else {
+                n.to_string()
+            }
+        }
         // Positional digit substitution.
         "decimalFullWidth" => to_positional_digits(n, DIGITS_FULLWIDTH),
         "thaiNumbers" => to_positional_digits(n, DIGITS_THAI),
@@ -1280,6 +1290,19 @@ mod tests {
                     (45, "אתת"),
                     (123, "מתתתתת"),
                 ],
+            ),
+            // Other algorithmic systems.
+            (
+                "hex",
+                &[(1, "1"), (10, "A"), (16, "10"), (31, "1F"), (255, "FF")],
+            ),
+            (
+                "numberInDash",
+                &[(1, "- 1 -"), (10, "- 10 -"), (123, "- 123 -")],
+            ),
+            (
+                "decimalZero",
+                &[(1, "01"), (9, "09"), (10, "10"), (100, "100")],
             ),
             // Documented residual / spell-outs fall back to decimal.
             ("cardinalText", &[(5, "5")]),

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -516,9 +516,31 @@ fn format_counter(n: u32, format: &str) -> String {
         "ideographLegalTraditional" => to_myriad_grouped(n, &MYRIAD_TRAD_LEGAL),
         "japaneseLegal" => to_myriad_grouped(n, &MYRIAD_JAPANESE_LEGAL),
         "koreanCounting" => to_myriad_grouped(n, &MYRIAD_KOREAN),
+        "koreanLegal" => to_korean_legal(n),
         // Documented residual (language spell-outs / unimplemented) → decimal.
         _ => n.to_string(),
     }
+}
+
+// §17.18.59 koreanLegal — native-Korean tens-word + ones-word, tabled for 1–99
+// (≥100 undefined by the spec → decimal fallback). Mirrors TS `toKoreanLegal`.
+const KOREAN_LEGAL_ONES: &[&str] = &[
+    "", "하나", "둘", "셋", "넷", "다섯", "여섯", "일곱", "여덟", "아홉",
+];
+const KOREAN_LEGAL_TENS: &[&str] = &[
+    "", "열", "스물", "서른", "마흔", "쉰", "예순", "일흔", "여든", "아흔",
+];
+
+fn to_korean_legal(n: u32) -> String {
+    if n >= 100 {
+        return n.to_string();
+    }
+    let tens = n / 10;
+    let ones = n % 10;
+    format!(
+        "{}{}",
+        KOREAN_LEGAL_TENS[tens as usize], KOREAN_LEGAL_ONES[ones as usize]
+    )
 }
 
 fn to_roman(n: u32) -> String {
@@ -1194,6 +1216,17 @@ mod tests {
             (
                 "koreanCounting",
                 &[(10, "십"), (11, "십일"), (2024, "이천이십사")],
+            ),
+            (
+                "koreanLegal",
+                &[
+                    (1, "하나"),
+                    (10, "열"),
+                    (11, "열하나"),
+                    (21, "스물하나"),
+                    (99, "아흔아홉"),
+                    (100, "100"),
+                ],
             ),
             // Repeat-letter non-Latin alphabets.
             ("arabicAlpha", &[(1, "أ"), (12, "س"), (28, "ي"), (29, "أأ")]),

--- a/packages/docx/src/page-number-field-render.test.ts
+++ b/packages/docx/src/page-number-field-render.test.ts
@@ -301,6 +301,24 @@ describe('PAGE field renders the per-section displayed number (footer)', () => {
     expect(await footerTexts(doc, 1)).toContain('III');
   });
 
+  it('routes an international section fmt end-to-end (chineseCounting §17.6.12/§17.18.59)', async () => {
+    // §17.18.59 chineseCounting: 1 → 一, 2 → 二. The core converter extension flows
+    // straight through the PAGE-field path (resolveFieldText → formatOrdinalNumber)
+    // with no renderer change — this pins that wiring for the CJK systems.
+    const doc = twoSectionDoc(null, { fmt: 'chineseCounting', start: 1 }, 1, 6);
+    // front page 0 = 1 (decimal, no fmt); body pages restart to 一, 二 (chineseCounting).
+    expect(await footerTexts(doc, 0)).toContain('1');
+    expect(await footerTexts(doc, 1)).toContain('一');
+    expect(await footerTexts(doc, 2)).toContain('二');
+  });
+
+  it('routes an international field \\* switch end-to-end (PAGE \\* HEBREW1 §17.16.4.3.1)', async () => {
+    // §17.16.4.3.1 HEBREW1 → hebrew1 gematria; §17.18.59: 1 → א. The field switch
+    // overrides the (absent) section fmt on the single body page.
+    const doc = twoSectionDoc(null, { start: 1 }, 1, 1, 'PAGE \\* HEBREW1');
+    expect(await footerTexts(doc, 0)).toContain('א'); // page 1 → א
+  });
+
   it('single-section document without pgNumType is unchanged (decimal 1..N)', async () => {
     const footer = footerWithPageField('PAGE');
     const section: SectionProps = {


### PR DESCRIPTION
Implements the international ST_NumberFormat numbering systems (ECMA-376 §17.18.59) as pure integer→string converters in `core`, and wires them into all three consumers.

## What

The WD2 work scoped `formatOrdinalNumber` to `decimal` / `upperRoman` / `lowerRoman` / `upperLetter` / `lowerLetter`. This PR extends it to the algorithmically-defined international systems and routes them everywhere an ST_NumberFormat surfaces.

### Formats implemented (all with §17.18.59 spec character sets + construction steps)

**Tier 1 — CJK**
`chineseCounting`, `taiwaneseCounting` (十-prefix positional) · `chineseCountingThousand`, `taiwaneseCountingThousand`, `chineseLegalSimplified`, `japaneseCounting`, `japaneseLegal`, `ideographLegalTraditional`, `koreanCounting`, `koreanLegal` (myriad-grouped counting/legal, with the per-format 零-fill and leading-一 elision rules) · `ideographDigital`, `japaneseDigitalTenThousand`, `koreanDigital`, `koreanDigital2`, `taiwaneseDigital`, `decimalFullWidth`, `decimalHalfWidth` (positional digit substitution)

**Tier 2 — RTL**
`hebrew1` (positional gematria, incl. the 15→טו / 16→טז cases) · `hebrew2` (result glyph + ת once per 22 subtracted: 23 → את, 123 → מ+5×ת — fixed per review, NOT the repeat scheme) · `arabicAlpha`, `arabicAbjad` (repeat-letter alphabets)

**Tier 3 — Other**
`thaiNumbers`, `hindiNumbers` (positional) · `thaiLetters`, `russianLower`, `russianUpper`, `chosung`, `ganada`, `hindiVowels`, `hindiConsonants` (repeat-letter alphabets) · `hex` (uppercase base-16), `numberInDash` (`- 123 -`), `decimalZero` (01…09, 10, …) — added per review

### Consumers wired
1. **Page numbers** (`<w:pgNumType w:fmt>`, §17.6.12) — flows through `resolveFieldText` → core `formatOrdinalNumber` with no renderer change; pinned end-to-end (chineseCounting section fmt → 一/二).
2. **Field switches** (`\*`, §17.16.4.3.1) — `parseFieldFormatSwitch` now routes the LOCALE-INDEPENDENT international switch arguments (`ARABICABJAD`, `HEBREW1`, `THAIARABIC`, `CHOSUNG`, `DBCHAR`, …) plus `Hex` and `ArabicDash`; pinned end-to-end (`PAGE \* HEBREW1` → א).
3. **List numbering** (`<w:numFmt>`, §17.9.17) — resolved at parse time in the Rust parser (`%1.%2` composition), so the same systems are mirrored in `numbering.rs::format_counter`, byte-identical to the TS converter (a parity test asserts the same expected values on both sides). This also fixes a pre-existing Rust bug where list `lowerLetter`/`upperLetter` only handled 1–26.

## Deliberately NOT implemented (documented residual → decimal)

- **Language spell-outs**: `cardinalText`, `ordinalText`, `ordinal`, `thaiCounting`, `vietnameseCounting`, `hindiCounting`, `bahtText`, `dollarText`, `custom`. §17.18.59 defines these only as "the textual representation, in the language of the `lang` element" — there is no algorithm or character table, so they'd require a per-language dictionary (a heuristic this pure converter can't and shouldn't invent). They degrade to decimal so a page number is never blank.
- **Locale-dependent field switches** (`CHINESENUM1/2/3`, `DBNUM1–4`, `KANJINUM1–3`, `IROHA`, `AIUEO`): a single switch maps to different ST_NumberFormat values per `w:lang` (e.g. `DBNUM1` → ideographDigital in ja-JP vs koreanDigital in ko-KR). We don't thread the field language, so `parseFieldFormatSwitch` declines rather than guess a script; the caller keeps the section format.
- **Sexagenary-cycle ideographs** (`ideographTraditional`, `ideographZodiac`, `ideographZodiacTraditional`) and rarely-authored enclosed-glyph families — follow-up; degrade to decimal.

Note: the grouped CJK examples in the ECMA-376 PDF are visibly OCR-corrupted (e.g. "九九"/"一, 二, 二, 三"); the myriad implementation follows the numbered construction **steps** (consistent across the family) rather than the garbled example strings, and the tests assert values derived from the algorithm + the clean §17.16.4.3.1 field examples (123→קכג, 12→ل, 12→س).

## Tests
- Core: table-driven per-format units (≈150 rows) sourced from the spec definitions + field-switch examples; field-switch routing (locale-independent yes / locale-dependent + spell-outs null).
- docx: two end-to-end page-number cases (section fmt + field switch).
- Rust: a parity test asserting the SAME expected values as the TS table (so the two implementations cannot silently diverge) + a list-marker end-to-end case.
- Non-regression: full core + docx vitest (2291 across 200 files), full Rust suite (279), `cargo fmt`/`clippy -D warnings`, core & docx `tsc`, and the committed docx `demo/sample-1` VRT (byte-identical — no document in the suite uses the new formats).

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)