### PR TITLE
fix(docx): clamp find/selection overlay over a 縦中横 run to its one-em cell (§17.3.2.10)

### DIFF
--- a/packages/docx/src/find-highlight-layer.test.ts
+++ b/packages/docx/src/find-highlight-layer.test.ts
@@ -128,6 +128,61 @@ describe('buildDocxHighlightLayer', () => {
     expect(layer.children[0].style.transform).toBe('rotate(90deg)');
   });
 
+  // ECMA-376 §17.3.2.10 縦中横 (#836): a tate-chu-yoko run is drawn compressed into
+  // ONE em cell (`run.w`), but the slice extent measures the run's NATURAL width
+  // (~2× for "２９"), so the highlight box overshoots into the following cell along
+  // the column. The overlay must clamp the extent to the drawn cell.
+  it('clamps an eastAsianVert (縦中横) run highlight to the one-em cell, not natural width', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    // "２９": natural width 2·W=14px (monospace stub), drawn cell run.w=7px (one em
+    // at fontSize 7). A whole-run match should span the 7px CELL, not 14px.
+    const runs = [
+      run({ text: '２９', x: 30, y: 40, w: 7, h: 16, fontSize: 7, eastAsianVert: true, transform: 'rotate(90deg)' }),
+    ];
+    const matches: DocxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 0, end: 2 }], active: false },
+    ];
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    expect(layer.children).toHaveLength(1);
+    const box = layer.children[0];
+    // Clamped: box starts at the run origin and spans exactly the one-em cell.
+    expect(box.style.left).toBe('30px');
+    expect(box.style.width).toBe('7px'); // the cell, NOT 14px natural
+    // The rotate transform (vertical page) is preserved.
+    expect(box.style.transform).toBe('rotate(90deg)');
+  });
+
+  it('scales a PARTIAL slice of a 縦中横 run proportionally within the cell', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    // "２９" natural 14px, cell 7px ⇒ scale 0.5. A slice of just "９" (the 2nd
+    // glyph) is natural [7,14) ⇒ clamped to [3.5, 7): left offset 3.5, width 3.5.
+    const runs = [
+      run({ text: '２９', x: 0, y: 0, w: 7, h: 16, fontSize: 7, eastAsianVert: true }),
+    ];
+    const matches: DocxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 1, end: 2 }], active: false },
+    ];
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    const box = layer.children[0];
+    expect(box.style.left).toBe('3.5px');
+    expect(box.style.width).toBe('3.5px');
+  });
+
+  it('leaves a non-eastAsianVert run measured at natural width (unchanged)', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    // Same text/w but NOT flagged 縦中横 ⇒ natural 14px extent (byte-identical to
+    // the pre-#836 behaviour). w is irrelevant to the highlight here.
+    const runs = [run({ text: '２９', x: 0, w: 7, fontSize: 7 })];
+    const matches: DocxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 0, end: 2 }], active: false },
+    ];
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    expect(layer.children[0].style.width).toBe('14px');
+  });
+
   it('clears the layer and skips zero-width slices', () => {
     vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
     const layer = makeEl('div');

--- a/packages/docx/src/find-highlight-layer.ts
+++ b/packages/docx/src/find-highlight-layer.ts
@@ -22,6 +22,7 @@
  */
 import { sliceHorizontalExtent, type MatchRunSlice } from '@silurus/ooxml-core';
 import type { DocxTextRunInfo } from './renderer';
+import { tateChuYokoOverlayScale } from './tate-chu-yoko-overlay';
 
 /** One page's highlight input: the run-slices a match covers, and whether that
  *  match is the active one (emphasis colour). */
@@ -78,7 +79,16 @@ export function buildDocxHighlightLayer(
       const run = runs[slice.runIndex];
       if (!run) continue;
       const measure = measureForFont(run.font);
-      const { x, width } = sliceHorizontalExtent(run.text, slice.start, slice.end, measure);
+      const extent = sliceHorizontalExtent(run.text, slice.start, slice.end, measure);
+      // ECMA-376 §17.3.2.10 縦中横 (#836): a tate-chu-yoko run is drawn compressed
+      // into one em cell (`run.w`), so its natural per-glyph extents overshoot the
+      // drawn box. Scale the slice offset + width by `run.w / naturalWidth` so the
+      // highlight lands on the compressed cell (a no-op factor of 1 for every
+      // ordinary run — see tate-chu-yoko-overlay.ts). Applying one factor keeps a
+      // partial match proportional within the cell.
+      const k = tateChuYokoOverlayScale(run, measure);
+      const x = extent.x * k;
+      const width = extent.width * k;
       if (width <= 0) continue;
       const box = document.createElement('div');
       // A vertical (tbRl) page reports the run at its physical top-left and

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -431,6 +431,14 @@ export interface DocxTextRunInfo {
    *  non-link run. The text-layer overlay turns a run carrying this into a
    *  clickable region; the drawn glyphs are unaffected. */
   hyperlink?: HyperlinkTarget;
+  /** ECMA-376 §17.3.2.10 eastAsianLayout `w:vert` (縦中横 / horizontal-in-vertical):
+   *  `true` when this run was drawn as tate-chu-yoko — its glyphs laid out
+   *  horizontally, side by side, COMPRESSED into ONE em cell of the vertical
+   *  column (see {@link drawTateChuYokoRun}). `w` is the drawn cell extent (one
+   *  em), NOT the natural text width, so the find / selection overlays must clamp
+   *  their horizontal extent to `w` rather than re-measuring the run's natural
+   *  glyphs (issue #836). Absent for every ordinary run. */
+  eastAsianVert?: boolean;
 }
 
 export interface RenderDocumentOptions {
@@ -6420,6 +6428,12 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             // run becomes clickable. Undefined for non-link runs (no payload
             // change). Does not touch any drawing above.
             hyperlink: s.hyperlink,
+            // §17.3.2.10 縦中横 — flag a tate-chu-yoko run so the overlays clamp
+            // their extent to the drawn one-em cell (`w`) instead of the run's
+            // natural glyph width (#836). Only set on a vertical page, where the
+            // 縦中横 draw path (above) actually fires; `undefined` otherwise so a
+            // non-縦中横 run's payload is byte-identical.
+            eastAsianVert: state.verticalCJK && s.tateChuYoko ? true : undefined,
           });
         }
 

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -206,6 +206,10 @@ export class DocxScrollViewer implements ZoomableViewer {
    *  reporting an error so a rejection that lands after teardown is swallowed
    *  rather than surfaced to a `onError` on a dead viewer. */
   private _destroyed = false;
+  /** Throwaway 2D context reused to measure text for the §17.3.2.10 縦中横 overlay
+   *  clamp (#836). Lazily created; `null` when canvas metrics are unavailable
+   *  (headless), in which case the overlay degrades to the un-clamped span. */
+  private _measureCtx: CanvasRenderingContext2D | null | undefined;
   /**
    * Concurrent-load latch (generation token). Every self-loading `load()`
    * increments this and captures the value; after its engine finishes loading it
@@ -783,6 +787,7 @@ export class DocxScrollViewer implements ZoomableViewer {
             slot.canvas.style.width || `${slot.canvas.width}px`,
             slot.canvas.style.height || `${slot.canvas.height}px`,
             this._hyperlinkHandler(),
+            (font) => this._measureForFont(font),
           );
         }
       })
@@ -815,6 +820,22 @@ export class DocxScrollViewer implements ZoomableViewer {
       const page = this._doc?.getBookmarkPage(target.ref);
       if (page !== undefined) this.scrollToPage(page);
     };
+  }
+
+  /** A width-measurer primed with a run's `font` — used ONLY to clamp a §17.3.2.10
+   *  縦中横 selection span to its drawn one-em cell (#836). Mirrors DocxViewer's
+   *  `_measureForFont`. Returns a length-based fallback when canvas metrics are
+   *  unavailable so the caller still gets a callable (the overlay then sees scale
+   *  1 and leaves the span un-clamped). */
+  private _measureForFont(font: string): (s: string) => number {
+    if (this._measureCtx === undefined) {
+      const c = document.createElement('canvas');
+      this._measureCtx = c.getContext('2d');
+    }
+    const ctx = this._measureCtx;
+    if (!ctx) return (s) => s.length;
+    ctx.font = font;
+    return (s) => ctx.measureText(s).width;
   }
 
   /** Route an async render failure to `onError`, or `console.error` when none is
@@ -928,6 +949,7 @@ export class DocxScrollViewer implements ZoomableViewer {
             slot.canvas.style.width || `${slot.canvas.width}px`,
             slot.canvas.style.height || `${slot.canvas.height}px`,
             this._hyperlinkHandler(),
+            (font) => this._measureForFont(font),
           );
         }
       }
@@ -1292,6 +1314,7 @@ export class DocxScrollViewer implements ZoomableViewer {
               spare.style.width || `${spare.width}px`,
               spare.style.height || `${spare.height}px`,
               this._hyperlinkHandler(),
+              (font) => this._measureForFont(font),
             );
           }
         }

--- a/packages/docx/src/tate-chu-yoko-overlay.test.ts
+++ b/packages/docx/src/tate-chu-yoko-overlay.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { tateChuYokoOverlayScale } from './tate-chu-yoko-overlay.js';
+import type { DocxTextRunInfo } from './renderer';
+
+// ECMA-376 §17.3.2.10 縦中横 overlay clamp (#836) — the shared factor used by both
+// the find-highlight and the text-selection overlays.
+
+function run(partial: Partial<DocxTextRunInfo>): DocxTextRunInfo {
+  return { text: 'X', x: 0, y: 0, w: 10, h: 12, fontSize: 12, font: '12px serif', ...partial };
+}
+
+describe('tateChuYokoOverlayScale', () => {
+  it('returns 1 for a run that is not eastAsianVert (no clamp)', () => {
+    const r = run({ text: '２９', w: 7 });
+    expect(tateChuYokoOverlayScale(r, (s) => [...s].length * 7)).toBe(1);
+  });
+
+  it('returns run.w / naturalWidth for a 縦中横 run (compresses to the cell)', () => {
+    // "２９" natural 14px, cell 7px ⇒ 0.5.
+    const r = run({ text: '２９', w: 7, eastAsianVert: true });
+    expect(tateChuYokoOverlayScale(r, (s) => [...s].length * 7)).toBeCloseTo(0.5, 10);
+  });
+
+  it('folds in w:w: a further-narrowed cell yields a smaller factor', () => {
+    // With w:w compression the reported cell can be < one em; the factor tracks
+    // whatever the drawn cell is (natural 14px, cell 5px ⇒ 5/14).
+    const r = run({ text: '２９', w: 5, eastAsianVert: true });
+    expect(tateChuYokoOverlayScale(r, (s) => [...s].length * 7)).toBeCloseTo(5 / 14, 10);
+  });
+
+  it('never expands: a cell wider than the natural glyphs keeps scale 1', () => {
+    const r = run({ text: '２', w: 20, eastAsianVert: true }); // natural 7, cell 20
+    expect(tateChuYokoOverlayScale(r, (s) => [...s].length * 7)).toBe(1);
+  });
+
+  it('degrades to 1 when the measurer reports a degenerate (zero) width', () => {
+    const r = run({ text: '２９', w: 7, eastAsianVert: true });
+    expect(tateChuYokoOverlayScale(r, () => 0)).toBe(1);
+  });
+});

--- a/packages/docx/src/tate-chu-yoko-overlay.ts
+++ b/packages/docx/src/tate-chu-yoko-overlay.ts
@@ -1,0 +1,42 @@
+import type { DocxTextRunInfo } from './renderer';
+
+/**
+ * ECMA-376 §17.3.2.10 eastAsianLayout `w:vert` (縦中横 / horizontal-in-vertical)
+ * overlay geometry — shared by the find-highlight overlay and the text-selection
+ * overlay so both clamp a tate-chu-yoko run identically (packages/docx/CLAUDE.md
+ * — no duplicated geometry).
+ *
+ * The 縦中横 draw path lays a run's glyphs out horizontally, side by side,
+ * COMPRESSED into ONE em cell of the vertical column (see `drawTateChuYokoRun`):
+ * the digits "２９" whose natural advance is ~2 em are drawn inside a single
+ * ~1 em cell. `onTextRun` reports that drawn cell as `run.w` (pinned to one em by
+ * `segAdvanceWidth`'s 縦中横 branch), but the overlays otherwise size themselves
+ * from the run's NATURAL glyph width — so a find / selection box over "２９"
+ * overshoots ~2× into the following cell (#836).
+ *
+ * The correct clamp is a single horizontal SCALE: the drawn run is exactly its
+ * natural glyphs compressed by `run.w / naturalWidth` (this folds in `w:w`, which
+ * further narrows the digits — the compression is whatever it takes to land the
+ * natural glyphs inside the reported cell). Applying that one factor keeps every
+ * intra-run offset proportional, so a partial match / partial selection inside the
+ * cell still maps to the right sub-extent.
+ *
+ * @param run      the run to test.
+ * @param measure  advance width (px) of a substring in the run's font — a
+ *                 `ctx.measureText(s).width` closure already primed with
+ *                 `run.font`. Only called for a 縦中横 run.
+ * @returns the horizontal scale factor to apply to the run's natural overlay
+ *          extent, or `1` when the run is not 縦中横 (or its natural width is
+ *          degenerate / already ≤ the cell, so no compression is needed).
+ */
+export function tateChuYokoOverlayScale(
+  run: DocxTextRunInfo,
+  measure: (s: string) => number,
+): number {
+  if (!run.eastAsianVert) return 1;
+  const natural = measure(run.text);
+  // Guard a zero / NaN measure (headless without canvas metrics) and never
+  // EXPAND — the cell is the ceiling; a run already within it keeps scale 1.
+  if (!(natural > 0) || run.w >= natural) return 1;
+  return run.w / natural;
+}

--- a/packages/docx/src/tate-chu-yoko-render.test.ts
+++ b/packages/docx/src/tate-chu-yoko-render.test.ts
@@ -294,6 +294,41 @@ describe('§17.3.2.10 縦中横 (horizontal-in-vertical) — sample-26 "9月29�
     expect(nichi.y - getsu.y).toBeCloseTo(2 * FONT_PX, 6);
   });
 
+  it('flags the 縦中横 run info with eastAsianVert so the overlays clamp it (#836)', async () => {
+    const { runs } = await render(
+      [
+        para([
+          textRun(NINE),
+          textRun(TCY, { charScale: 0.67, eastAsianVert: true, eastAsianVertCompress: true }),
+          textRun(NICHI),
+        ]),
+      ],
+      verticalSection(),
+    );
+    const tcy = runs.find((r) => r.text === TCY)!;
+    const nine = runs.find((r) => r.text === NINE)!;
+    // Only the 縦中横 run carries the flag; ordinary vertical cells do not.
+    expect(tcy.eastAsianVert).toBe(true);
+    expect(nine.eastAsianVert).toBeUndefined();
+    // The reported width IS the drawn one-em cell (what the overlay clamps to),
+    // not the natural 2·FONT_PX. On a vertical page onTextRun's `w` is the
+    // cross-column cell width = one em.
+    expect(tcy.w).toBeCloseTo(FONT_PX, 6);
+  });
+
+  it('does NOT flag eastAsianVert on a horizontal page (the run is not 縦中横 there)', async () => {
+    const { runs } = await render(
+      [
+        para([
+          textRun(TCY, { charScale: 0.67, eastAsianVert: true, eastAsianVertCompress: true }),
+        ]),
+      ],
+      horizontalSection(),
+    );
+    const tcy = runs.find((r) => r.text === TCY)!;
+    expect(tcy.eastAsianVert).toBeUndefined();
+  });
+
   it('leaves a horizontal page byte-identical (縦中横 flag inert without tbRl)', async () => {
     // The SAME runs on a HORIZONTAL page: eastAsianVert is meaningful only in
     // vertical text (§17.3.2.10), so buildSegments never sets the flag and the

--- a/packages/docx/src/text-layer.test.ts
+++ b/packages/docx/src/text-layer.test.ts
@@ -107,4 +107,48 @@ describe('buildDocxTextLayer (extracted from DocxViewer._buildTextLayer)', () =>
     expect(b.textContent).toBe('World');
     expect(b.style.left).toBe('50px');
   });
+
+  // ECMA-376 §17.3.2.10 縦中横 (#836): a tate-chu-yoko run is drawn compressed into
+  // ONE em cell (`run.w`), but the selection span lays out at the run's NATURAL
+  // font width (~2× for "２９"), so the selection box overshoots into the next cell.
+  // With a measurer, the span composes a horizontal scaleX(run.w/naturalWidth) so
+  // its extent matches the drawn cell.
+  it('compresses an eastAsianVert (縦中横) span to the one-em cell via scaleX', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    // "２９" natural 14px (monospace 7px/char), drawn cell run.w=7px ⇒ scaleX 0.5.
+    const runs = [
+      run({ text: '２９', x: 30, y: 40, w: 7, h: 16, fontSize: 7, font: '7px serif', eastAsianVert: true, transform: 'rotate(90deg)' }),
+    ];
+    const measureForFont = () => (s: string) => [...s].length * 7;
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, '1px', '1px', undefined, measureForFont);
+    const span = layer.children[0];
+    // The rotate is preceded by scaleX(0.5) so the natural 14px width compresses to
+    // the 7px cell BEFORE rotating into the column (transform-origin top-left).
+    expect(span.style.transform).toBe('rotate(90deg) scaleX(0.5)');
+    expect(span.style.cssText).toContain('transform-origin:top left');
+  });
+
+  it('leaves a 縦中横 span un-scaled when no measurer is supplied (graceful degrade)', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [
+      run({ text: '２９', w: 7, fontSize: 7, eastAsianVert: true, transform: 'rotate(90deg)' }),
+    ];
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, '1px', '1px');
+    // No measurer ⇒ the scale cannot be computed; the span keeps the bare rotate
+    // (byte-identical to the pre-#836 overlay — no regression when the caller
+    // does not thread a measurer).
+    expect(layer.children[0].style.transform).toBe('rotate(90deg)');
+  });
+
+  it('does not scale a non-eastAsianVert run even with a measurer', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({ text: 'Hello', x: 12, font: '14px Arial' })];
+    const measureForFont = () => (s: string) => s.length * 8;
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, '1px', '1px', undefined, measureForFont);
+    // Ordinary run: no transform at all (horizontal page), so no scaleX sneaks in.
+    expect(layer.children[0].style.transform ?? '').toBe('');
+  });
 });

--- a/packages/docx/src/text-layer.ts
+++ b/packages/docx/src/text-layer.ts
@@ -1,5 +1,6 @@
 import type { DocxTextRunInfo } from './renderer';
 import type { HyperlinkTarget } from '@silurus/ooxml-core';
+import { tateChuYokoOverlayScale } from './tate-chu-yoko-overlay';
 
 /**
  * Build the transparent text-selection overlay for a rendered docx page: one
@@ -27,6 +28,14 @@ import type { HyperlinkTarget } from '@silurus/ooxml-core';
  *                         the browser's own navigation can never bypass the
  *                         caller's URL sanitisation. When omitted, link runs are
  *                         rendered exactly like plain runs (no click affordance).
+ * @param measureForFont   optional width-measurer factory (primed with a run's
+ *                         `font`), used ONLY to clamp a §17.3.2.10 縦中横
+ *                         (eastAsianVert) span to its drawn one-em cell (#836):
+ *                         the span composes a `scaleX(run.w / naturalWidth)` so
+ *                         its selection extent matches the compressed glyphs
+ *                         instead of the run's natural ~2× width. When omitted,
+ *                         a 縦中横 span keeps the bare rotate (no regression for
+ *                         callers that do not thread a measurer).
  */
 export function buildDocxTextLayer(
   layer: HTMLDivElement,
@@ -34,6 +43,7 @@ export function buildDocxTextLayer(
   canvasCssWidth: string,
   canvasCssHeight: string,
   onHyperlinkClick?: (target: HyperlinkTarget) => void,
+  measureForFont?: (font: string) => (s: string) => number,
 ): void {
   layer.innerHTML = '';
   layer.style.width = canvasCssWidth;
@@ -53,8 +63,20 @@ export function buildDocxTextLayer(
     // its top-left so the horizontal DOM text lies along the drawn (rotated) glyph
     // run. Horizontal pages carry no transform and place the span at `x`/`y`
     // untransformed (byte-identical to the pre-vertical overlay).
-    const transform = run.transform
-      ? `transform:${run.transform};transform-origin:top left;`
+    // ECMA-376 §17.3.2.10 縦中横 (#836): a tate-chu-yoko run is drawn compressed
+    // into one em cell (`run.w`), so append a `scaleX(run.w / naturalWidth)` (when
+    // a measurer is available) so the span's selectable extent matches the drawn
+    // cell instead of the natural ~2× glyph width. Ordered AFTER the rotate so it
+    // compresses the span's horizontal (pre-rotation) axis — the along-column
+    // direction of the cell. A no-op factor of 1 for every ordinary run (see
+    // tate-chu-yoko-overlay.ts), so a non-縦中横 span's transform is unchanged.
+    let transformValue = run.transform ?? '';
+    if (measureForFont && run.eastAsianVert) {
+      const k = tateChuYokoOverlayScale(run, measureForFont(run.font));
+      if (k !== 1) transformValue = `${transformValue ? `${transformValue} ` : ''}scaleX(${k})`;
+    }
+    const transform = transformValue
+      ? `transform:${transformValue};transform-origin:top left;`
       : '';
     // IX1 — a run with a resolved hyperlink target becomes a clickable region.
     // Only the cursor changes to a pointer and a title tooltip is added; the

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -591,6 +591,9 @@ export class DocxViewer implements ZoomableViewer {
       this._canvas.style.width || this._canvas.width + 'px',
       this._canvas.style.height || this._canvas.height + 'px',
       this._hyperlinkHandler(),
+      // §17.3.2.10 縦中横 (#836) — the same measurer the highlight overlay uses,
+      // so a tate-chu-yoko selection span is clamped to its drawn one-em cell.
+      (font) => this._measureForFont(font),
     );
   }
 


### PR DESCRIPTION
## Summary

A tate-chu-yoko (`eastAsianLayout w:vert`, 縦中横) run is drawn compressed into **one em cell** of the vertical column — the date digits "２９" (natural advance ~2 em) are painted side by side inside a single cell (`drawTateChuYokoRun`). But the two overlays sized their horizontal extent from the run's **natural** ~2× width:

- `find-highlight-layer.ts` — `sliceHorizontalExtent` measured natural text.
- `text-layer.ts` — the selection span laid out at `font:${run.font}` (natural).

So a find / selection box over "２９" overshot ~2× into the following cell along the column (#836). Copy/search content was already correct; only the transparent overlay geometry was wrong.

## Fix

The renderer already reports the drawn cell as `run.w` (pinned to one em by `segAdvanceWidth`'s 縦中横 branch). This PR:

- Adds `DocxTextRunInfo.eastAsianVert`, set only for a 縦中横 run on a vertical page (payload-only — no draw-path change).
- Clamps both overlays via one shared factor `run.w / naturalWidth` (`tate-chu-yoko-overlay.ts` — no duplicated geometry): the highlight scales the slice offset + width; the selection span composes a `scaleX(k)` **after** its `rotate` so its selectable extent matches the compressed glyphs.
- Threads the existing `DocxViewer._measureForFont` into `buildDocxTextLayer` and adds the twin helper to `DocxScrollViewer`'s three overlay call sites.

Both clamps are gated on the flag + a measurer, so every ordinary run is byte-identical (flag `undefined`, factor `1`).

## Verification

- Real-browser check on **sample-26** (the actual 縦中横 fixture): `findText("29")` builds exactly **one** 縦中横 span with `rotate(90deg) scaleX(0.50)` and a **one-em (12.1px)** highlight box, while every other vertical span keeps the bare `rotate(90deg)`.
- All canvas VRT is byte-identical (this is an overlay-only change; the demo VRT passes at 0% diff).
- Full docx vitest (869 tests) passes; `tsc` clean; no new ast-grep warnings. New coverage: `tate-chu-yoko-overlay.test.ts` + overlay-clamp cases in the text-layer / find-highlight / tate-chu-yoko-render suites.

Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)