### PR TITLE
feat(core): shared round-half-up decimal formatter for Office display rounding (#801)

### DIFF
--- a/packages/core/src/chart/chart-number-format.ts
+++ b/packages/core/src/chart/chart-number-format.ts
@@ -6,6 +6,7 @@
 // dates.
 
 import { excelSerialToUtcDate } from '../excel-date';
+import { roundDecimalHalfUp } from '../text/round-decimal';
 
 /** Excel's default `formatCode="General"` for charts: raw numbers with no
  *  "k"/"M" abbreviation, trailing decimal zeros trimmed. */
@@ -13,8 +14,11 @@ export function formatChartVal(v: number): string {
   // Matches Excel's default `<c:valAx><c:numFmt formatCode="General">` which
   // shows raw numbers — no "k"/"M" abbreviation.
   if (Number.isInteger(v)) return String(v);
-  // Trim trailing zeros on decimals (so 0.50 → "0.5") but cap at 6 digits.
-  return v.toFixed(6).replace(/\.?0+$/, '');
+  // Cap at 6 decimals and trim trailing zeros (0.50 → "0.5"). Round half-UP on
+  // the decimal value like Excel (matters only at a `.xxxxxx5` boundary; equal
+  // to `toFixed(6)` otherwise), so this path never disagrees with the explicit
+  // number-format sections below.
+  return roundDecimalHalfUp(v, 6).replace(/\.?0+$/, '');
 }
 
 /**
@@ -300,7 +304,9 @@ function formatNumericPattern(value: number, pattern: string): string {
   const fracDigits = (fracPart.match(/[#0?]/g) ?? []).length;
   // Minimum integer digits = count of `0` in integer part.
   const minIntDigits = (intPart.replace(/,/g, '').match(/0/g) ?? []).length;
-  const rounded = value.toFixed(fracDigits);
+  // Office rounds a chart label's decimals half-UP on the decimal value
+  // (2.675 → "2.68"); `toFixed` would round the binary double down.
+  const rounded = roundDecimalHalfUp(value, fracDigits);
   const [ints, fracs = ''] = rounded.split('.');
   const paddedInts = ints.padStart(minIntDigits, '0');
   const withSeparators = thousands ? paddedInts.replace(/\B(?=(\d{3})+(?!\d))/g, ',') : paddedInts;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -353,6 +353,10 @@ export { justifiedPiecePositions, type JustifiedPiece } from './text/justify-pos
 // ECMA-376 §17.18.59 ST_NumberFormat rendering + §17.16.4.3.1 field-format switch
 // parsing — the shared numbering kernel (page numbers, list markers, …).
 export { formatOrdinalNumber, type NumberFormat } from './text/number-format';
+// Office-style decimal (round-half-up) formatting for fixed-precision display —
+// Excel/Word/PowerPoint round `.xx5` up where `toFixed` rounds the binary double
+// down (2.675 → "2.68"). Shared by xlsx number-format + chart label formatting.
+export { roundDecimalHalfUp } from './text/round-decimal';
 export { parseFieldFormatSwitch } from './text/field-format-switch';
 // ECMA-376 §17.16.4.1 date-and-time formatting ("picture") switch — evaluates a
 // DATE/TIME field's `\@ "…"` picture against a given instant (shared by docx/pptx).

--- a/packages/core/src/text/round-decimal.test.ts
+++ b/packages/core/src/text/round-decimal.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { roundDecimalHalfUp } from './round-decimal';
+
+describe('roundDecimalHalfUp — Office-style decimal (round-half-up) formatting', () => {
+  // Office (Excel/Word/PowerPoint) rounds on the DECIMAL representation, so a
+  // `.xx5` boundary rounds UP. JavaScript `toFixed` rounds the binary double,
+  // which for these values sits just below the .5 boundary → rounds down.
+  describe('.xx5 boundaries that toFixed gets wrong', () => {
+    const cases: Array<[number, number, string, string]> = [
+      // [value, digits, expected (Excel), toFixed (wrong)]. Only values whose
+      // nearest double sits just BELOW the .xx5 boundary (so toFixed rounds
+      // down) — not e.g. 0.125, which is exactly representable and toFixed
+      // already rounds up.
+      [2.675, 2, '2.68', '2.67'],
+      [1.005, 2, '1.01', '1.00'],
+      [9.995, 2, '10.00', '9.99'],
+      [1.255, 2, '1.26', '1.25'],
+      [8.575, 2, '8.58', '8.57'],
+    ];
+    for (const [value, digits, expected, toFixedResult] of cases) {
+      it(`${value} @ ${digits} → "${expected}" (toFixed gives "${toFixedResult}")`, () => {
+        expect(roundDecimalHalfUp(value, digits)).toBe(expected);
+        // Guard: confirm this really is a case toFixed mishandles, so the test
+        // is a genuine regression pin, not a tautology.
+        expect(value.toFixed(digits)).toBe(toFixedResult);
+      });
+    }
+  });
+
+  describe('carry propagation', () => {
+    it('9.995 @ 2 → "10.00" (carry ripples through all places)', () => {
+      expect(roundDecimalHalfUp(9.995, 2)).toBe('10.00');
+    });
+    it('0.995 @ 2 → "1.00"', () => {
+      expect(roundDecimalHalfUp(0.995, 2)).toBe('1.00');
+    });
+    it('99.95 @ 1 → "100.0"', () => {
+      expect(roundDecimalHalfUp(99.95, 1)).toBe('100.0');
+    });
+    it('9.5 @ 0 → "10"', () => {
+      expect(roundDecimalHalfUp(9.5, 0)).toBe('10');
+    });
+  });
+
+  describe('negatives round half AWAY from zero (Excel display magnitude)', () => {
+    it('-2.675 @ 2 → "-2.68"', () => {
+      expect(roundDecimalHalfUp(-2.675, 2)).toBe('-2.68');
+    });
+    it('-1.005 @ 2 → "-1.01"', () => {
+      expect(roundDecimalHalfUp(-1.005, 2)).toBe('-1.01');
+    });
+    it('-9.995 @ 2 → "-10.00"', () => {
+      expect(roundDecimalHalfUp(-9.995, 2)).toBe('-10.00');
+    });
+    it('-0.5 @ 0 → "-1"', () => {
+      expect(roundDecimalHalfUp(-0.5, 0)).toBe('-1');
+    });
+  });
+
+  describe('digits / padding', () => {
+    it('pads to the requested precision (0.5 @ 2 → "0.50")', () => {
+      expect(roundDecimalHalfUp(0.5, 2)).toBe('0.50');
+    });
+    it('digits=0 emits an integer with no dot (3.14 → "3")', () => {
+      expect(roundDecimalHalfUp(3.14, 0)).toBe('3');
+    });
+    it('exact integers pad correctly (5 @ 2 → "5.00")', () => {
+      expect(roundDecimalHalfUp(5, 2)).toBe('5.00');
+    });
+    it('value already shorter than digits pads (1.2 @ 3 → "1.200")', () => {
+      expect(roundDecimalHalfUp(1.2, 3)).toBe('1.200');
+    });
+  });
+
+  describe('non-boundary values match toFixed (no drift on normal data)', () => {
+    const cases: Array<[number, number, string]> = [
+      [3.14159, 2, '3.14'],
+      [3.14659, 2, '3.15'],
+      [1234.5678, 2, '1234.57'],
+      [0.1, 2, '0.10'],
+      [0, 2, '0.00'],
+      [-3.14159, 2, '-3.14'],
+      [1000, 0, '1000'],
+      [2.4, 0, '2'],
+      [2.6, 0, '3'],
+    ];
+    for (const [value, digits, expected] of cases) {
+      it(`${value} @ ${digits} → "${expected}"`, () => {
+        expect(roundDecimalHalfUp(value, digits)).toBe(expected);
+        // These are NOT .xx5 boundaries, so Office and toFixed agree.
+        expect(value.toFixed(digits)).toBe(expected);
+      });
+    }
+  });
+
+  describe('edge inputs', () => {
+    it('negative zero normalizes to "0.00" (no "-0.00")', () => {
+      expect(roundDecimalHalfUp(-0, 2)).toBe('0.00');
+      // A tiny negative that rounds to zero must not carry a minus sign.
+      expect(roundDecimalHalfUp(-0.0001, 2)).toBe('0.00');
+    });
+    it('non-finite falls back to the raw string', () => {
+      expect(roundDecimalHalfUp(NaN, 2)).toBe('NaN');
+      expect(roundDecimalHalfUp(Infinity, 2)).toBe('Infinity');
+      expect(roundDecimalHalfUp(-Infinity, 2)).toBe('-Infinity');
+    });
+    it('large magnitudes keep integer precision (12345678.905 @ 2 → "12345678.91")', () => {
+      expect(roundDecimalHalfUp(12345678.905, 2)).toBe('12345678.91');
+    });
+  });
+});

--- a/packages/core/src/text/round-decimal.ts
+++ b/packages/core/src/text/round-decimal.ts
@@ -1,0 +1,91 @@
+// Office-style decimal rounding for DISPLAY formatting.
+//
+// Excel, Word and PowerPoint round numbers on their DECIMAL representation with
+// half-up (round half away from zero) semantics: `#,##0.00` on 2.675 shows
+// "2.68". JavaScript's `Number.prototype.toFixed` rounds the underlying BINARY
+// double instead, and the nearest double to 2.675 is 2.67499999999999982…, so
+// `(2.675).toFixed(2) === "2.67"`. Likewise 1.005 → "1.00", 8.575 → "8.57".
+//
+// `roundDecimalHalfUp` reproduces the spreadsheet behaviour by operating on the
+// shortest round-tripping decimal string `String(value)` (the decimal the user
+// authored), then rounding that string half-up with integer carry — no scaled
+// multiply, so it never reintroduces a binary artefact. On values that are NOT
+// on a `.xx5` boundary it agrees with `toFixed`, so adopting it is a no-op for
+// real corpus data and only fixes the boundary cases.
+
+/** Round `value` to `digits` fractional places using Office's decimal
+ *  round-half-up (half away from zero) and return the fixed-precision string
+ *  (always exactly `digits` fractional digits; no thousands separators).
+ *
+ *  - `2.675, 2` → `"2.68"`, `1.005, 2` → `"1.01"`, `9.995, 2` → `"10.00"`.
+ *  - Negatives round away from zero by magnitude: `-2.675, 2` → `"-2.68"`.
+ *  - A value that rounds to zero never carries a `-` sign (`-0.0001, 2` → `"0.00"`).
+ *  - Non-finite inputs fall back to `String(value)` (`NaN`/`Infinity`).
+ *
+ *  `digits` must be a non-negative integer. */
+export function roundDecimalHalfUp(value: number, digits: number): string {
+  if (!Number.isFinite(value)) return String(value);
+  const d = Math.max(0, Math.trunc(digits));
+
+  const negative = value < 0;
+  // Shortest decimal that round-trips to `value` — the decimal the author meant
+  // (`String(2.675) === "2.675"`), free of the binary artefact `toFixed` sees.
+  const decimal = expandExponential(Math.abs(value).toString());
+  const [intPart, fracPartRaw = ''] = decimal.split('.');
+
+  // Digit array for the integer part plus the fraction padded to at least d+1
+  // places, so index `d` is the first dropped digit (the rounding decider).
+  const fracPart = fracPartRaw.padEnd(d + 1, '0');
+  const keptFrac = fracPart.slice(0, d);
+  const decider = fracPart.charCodeAt(d) - 48; // digit at position d (0..9)
+
+  let digitsArr = (intPart + keptFrac).split('').map((c) => c.charCodeAt(0) - 48);
+  if (decider >= 5) {
+    // Propagate the carry from the least-significant kept digit leftwards.
+    let i = digitsArr.length - 1;
+    for (; i >= 0; i--) {
+      if (digitsArr[i] === 9) {
+        digitsArr[i] = 0;
+      } else {
+        digitsArr[i] += 1;
+        break;
+      }
+    }
+    if (i < 0) digitsArr.unshift(1); // carried past the most-significant digit
+  }
+
+  // Split back into integer + fraction. The fraction is always the last d
+  // digits (the integer part grows, but never shrinks, under carry).
+  const combined = digitsArr.map((n) => String(n)).join('');
+  const fracLen = d;
+  const intStr = (fracLen > 0 ? combined.slice(0, combined.length - fracLen) : combined) || '0';
+  const fracStr = fracLen > 0 ? combined.slice(combined.length - fracLen) : '';
+
+  const intClean = intStr.replace(/^0+(?=\d)/, ''); // drop leading zeros, keep one
+  const body = fracStr.length > 0 ? `${intClean}.${fracStr}` : intClean;
+
+  // A value that rounds to all-zero must not keep the sign (avoid "-0.00").
+  const isZero = /^[0.]*$/.test(body) && !/[1-9]/.test(body);
+  return negative && !isZero ? `-${body}` : body;
+}
+
+/** Expand a JS numeric string in exponential form (`"1.2e-7"`, `"5e+21"`) into
+ *  plain decimal digits so the string rounder can index its fraction. Non-
+ *  exponential input is returned unchanged. Operates on the magnitude only
+ *  (callers strip the sign first). */
+function expandExponential(s: string): string {
+  const m = /^(\d+)(?:\.(\d+))?[eE]([+-]?\d+)$/.exec(s);
+  if (!m) return s;
+  const [, intDigits, fracDigits = '', expStr] = m;
+  const exp = parseInt(expStr, 10);
+  const mantissa = intDigits + fracDigits;
+  // Position of the decimal point measured from the start of `mantissa`.
+  const pointPos = intDigits.length + exp;
+  if (pointPos <= 0) {
+    return '0.' + '0'.repeat(-pointPos) + mantissa;
+  }
+  if (pointPos >= mantissa.length) {
+    return mantissa + '0'.repeat(pointPos - mantissa.length);
+  }
+  return mantissa.slice(0, pointPos) + '.' + mantissa.slice(pointPos);
+}

--- a/packages/xlsx/src/number-format.ts
+++ b/packages/xlsx/src/number-format.ts
@@ -1,4 +1,4 @@
-import { excelSerialToUtcDate } from '@silurus/ooxml-core';
+import { excelSerialToUtcDate, roundDecimalHalfUp } from '@silurus/ooxml-core';
 import type { Cell, CellValue, Styles } from './types.js';
 import { todaySerial, nowSerial } from './formula.js';
 
@@ -993,12 +993,14 @@ function renderNumericSection(num: number, body: string, useMagnitude: boolean):
       // placeholder count so `#0.0E+0` on 1.22e7 → `12.2E+6`.
       e = Math.floor(e / intPlaceCount) * intPlaceCount;
       mantissa = abs / Math.pow(10, e);
-      if (parseFloat(mantissa.toFixed(decCount)) >= Math.pow(10, intPlaceCount)) {
+      if (parseFloat(roundDecimalHalfUp(mantissa, decCount)) >= Math.pow(10, intPlaceCount)) {
         e += intPlaceCount;
         mantissa = abs / Math.pow(10, e);
       }
     }
-    const mantStr = mantissa.toFixed(decCount);
+    // Round the mantissa's decimals half-UP like the plain section (Excel is
+    // consistent across sections); `toFixed` would round the binary double down.
+    const mantStr = roundDecimalHalfUp(mantissa, decCount);
     const [mInt, mFrac = ''] = mantStr.split('.');
     const intText = fillIntegerTemplate(mInt, lex.intSpec, false);
     const fracText = fillFractionText(mFrac, lex.fracSpec);
@@ -1009,7 +1011,9 @@ function renderNumericSection(num: number, body: string, useMagnitude: boolean):
 
   // ── Plain fixed-point section ─────────────────────────────────────────────
   const decCount = lex.fracSpec.length;
-  const rounded = abs.toFixed(decCount);
+  // Excel rounds the displayed decimals half-UP on the decimal value
+  // (2.675 under `0.00` → "2.68"); `toFixed` rounds the binary double down.
+  const rounded = roundDecimalHalfUp(abs, decCount);
   const [intDigitsRaw, fracDigits = ''] = rounded.split('.');
   let intDigits = intDigitsRaw.replace(/^0+/, '');
   // Keep a leading zero when a `0`/`?` placeholder forces the units digit, or


### PR DESCRIPTION
## Summary

Excel, Word and PowerPoint round fixed-precision display on the **decimal** value with half-up: `2.675` under `#,##0.00` shows `2.68`. JavaScript `toFixed` rounds the underlying **binary double** — the nearest double to 2.675 is 2.67499999…, so `(2.675).toFixed(2) === "2.67"`. The xlsx number-format engine and the chart data-label / axis-label formatter both used `toFixed`, diverging from Office at `.xx5` boundaries (flagged in the PR #799 review).

## Change

New pure helper `roundDecimalHalfUp(value, digits): string` in `packages/core/src/text/round-decimal.ts`. It rounds on the **shortest round-tripping decimal string** `String(value)` (the decimal the author meant — `String(2.675) === "2.675"`) with integer carry — no scaled multiply, so it never reintroduces a binary artefact. Handles carry (`9.995 → "10.00"`), negatives (half away from zero by magnitude), negative-zero normalization (`-0.0001 → "0.00"`), and non-finite fallback.

Adopted by (per the cross-package principle, one coordinated PR touching `core` + `xlsx`):
- **xlsx `number-format.ts`** — plain fixed-point section + scientific mantissa (round + overflow check).
- **core `chart-number-format.ts`** — numeric-pattern sections + the General 6-decimal path, so every chart decimal display shares one rounding.

`toFixed` sites left untouched: only Storybook byte-size stats (not Excel formatting).

## Verification

- **Table-driven tests** (`round-decimal.test.ts`, 29 cases): `.xx5` boundaries (2.675→2.68, 1.005→1.01, 8.575→8.58), carry (9.995→10.00, 99.95→100.0, 9.5→10), negatives (-2.675→-2.68), padding/precision, negative-zero, non-finite. Guards assert each boundary case is one `toFixed` actually mishandles (not a tautology).
- **1.2M-combination divergence sweep** (values × 0–4 digits): `roundDecimalHalfUp` differs from `toFixed` in **12,618 cases, every one a `.xx5` boundary** → **zero real-data drift**, boundary-only correction (the #799 review method: "変化は .xx5 境界値のみ = 実データ変化ゼロ").
- xlsx **number-format corpus** (spec-cited, §18.8.30) unchanged; root vitest **3007 passed / 0 failed**; core + xlsx `tsc` clean; ast-grep clean; xlsx demo **VRT 0.0% diff**.

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)