### PR TITLE
fix(docx): use per-section page geometry for newspaper-column band

### DIFF
--- a/packages/docx/src/per-section-page-geometry.test.ts
+++ b/packages/docx/src/per-section-page-geometry.test.ts
@@ -3,6 +3,7 @@ import { computePages, paginateDocument, renderDocumentToCanvas } from './render
 import type {
   BodyElement, DocParagraph, DocxTextRun, SectionProps, DocxDocumentModel,
   SectionGeom, PaginatedBodyElement, HeaderFooter,
+  DocTable, DocTableRow, DocTableCell,
 } from './types';
 
 // ECMA-376 §17.6.13 `<w:pgSz>` + §17.6.11 `<w:pgMar>` — page geometry is
@@ -430,5 +431,84 @@ describe('page-size fact (§17.6.13/§17.6.11) — paginateDocument sectionGeom'
     expect(workerish.mode).toBe('worker');
     const mainish = make({ _mode: 'main' });
     expect(mainish.mode).toBe('main');
+  });
+});
+
+// ECMA-376 §17.6.11 (pgMar) + §17.6.13 (pgSz) — a newspaper-column band's WIDTH
+// and x-origin derive from the OWNING section's page geometry, not the body-level
+// section. `computeColumns` is fed by `sectionColumnsFrom`; the paginator sizes a
+// table to the active column band (`colW()`), so the stamped `tableColWidthsPt`
+// is the observable proxy for the band width the fix corrects.
+function cellPara(text: string): DocParagraph {
+  return {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text,
+      bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'NotInMetrics', isLink: false,
+      background: null, vertAlign: null, hyperlink: null,
+    }],
+    defaultFontSize: 10, defaultFontFamily: 'NotInMetrics', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+// A single-row, single-column FIXED-layout table whose `<w:tblGrid>` width is
+// `gridWidthPt`. Fixed layout uses the grid verbatim and only scales DOWN when the
+// grid overflows the available band (resolveColumnWidths §17.4.52), so the stamped
+// `tableColWidthsPt` equals `gridWidthPt` iff the band is ≥ that width.
+function fixedTable(gridWidthPt: number): DocTable {
+  const cell: DocTableCell = {
+    content: [{ type: 'paragraph', ...cellPara('x') }],
+    colSpan: 1, vMerge: null,
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    background: null, vAlign: 'top', widthPt: gridWidthPt,
+  } as unknown as DocTableCell;
+  const row: DocTableRow = {
+    cells: [cell], rowHeight: null, rowHeightRule: 'auto', isHeader: false,
+  } as unknown as DocTableRow;
+  return {
+    colWidths: [gridWidthPt], rows: [row],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left', layout: 'fixed', widthPt: gridWidthPt,
+  } as unknown as DocTable;
+}
+
+describe('per-section newspaper-column band (§17.6.11/§17.6.13) — paginator', () => {
+  it('sizes a table to the OWNING section band width, not the body-level band', () => {
+    // First section (ended by the nextPage break): page 600 wide, margins L=10 R=40
+    // ⇒ content band 600−10−40 = 550. Its single fixed table has a tblGrid of 550,
+    // so it fits EXACTLY and its columns stay 550.
+    const sec1: SectionGeom = {
+      pageWidth: 600, pageHeight: 500,
+      marginTop: 20, marginRight: 40, marginBottom: 20, marginLeft: 10,
+      headerDistance: 0, footerDistance: 0,
+    };
+    // Body (final) section: page 600 wide, margins L=75 R=75 ⇒ content band 450.
+    // BEFORE the fix, `sectionColumnsFrom` builds the first section's band from THIS
+    // body-level width (450), so the 550-wide grid is clamped to 450.
+    const bodySection: SectionProps = {
+      pageWidth: 600, pageHeight: 500,
+      marginTop: 20, marginRight: 75, marginBottom: 20, marginLeft: 75,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps;
+    const body: BodyElement[] = [
+      { type: 'table', ...fixedTable(550) } as BodyElement,
+      { type: 'sectionBreak', kind: 'nextPage', geom: sec1 } as BodyElement,
+      para('BODY_SECTION'),
+    ];
+    const doc = {
+      section: bodySection, body,
+      headers: { default: null, first: null, even: null },
+      footers: { default: null, first: null, even: null },
+      fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    const tbl = pages[0].find((e) => e.type === 'table') as PaginatedBodyElement;
+    const stampedTotal = (tbl.tableColWidthsPt ?? []).reduce((s, w) => s + w, 0);
+    // The table belongs to the first section (band 550), so its columns sum to 550 —
+    // NOT the body-level band 450 the bug clamps them to.
+    expect(stampedTotal).toBeCloseTo(550, 5);
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1831,15 +1831,18 @@ export function computePages(
     for (let j = startIdx; j < body.length; j++) {
       const e = body[j];
       if (e.type === 'sectionBreak') {
-        // Resolve this section's cols by swapping in its ColumnsSpec. Page
-        // GEOMETRY is now per-section (`sectionGeomFrom`), but `computeColumns`
-        // here still receives the BODY-LEVEL width (`section.pageWidth`/margins) —
-        // a documented residual: a mid-body section with a different page WIDTH and
-        // multiple columns tiles against the body width, not its own. Single-column
-        // sections and uniform-width documents are unaffected. Aligning column
-        // widths to the per-section width is the width-residual follow-up in the
-        // design doc; do NOT change it here.
-        return computeColumns({ ...section, columns: e.columns ?? null });
+        // Resolve this section's cols by swapping in its ColumnsSpec AND its page
+        // GEOMETRY. `computeColumns` derives the text band from
+        // pageWidth/marginLeft/marginRight (ECMA-376 §17.6.13 pgSz + §17.6.11
+        // pgMar), which are PER-SECTION — the ending section's geometry lives on
+        // this same SectionBreak marker (`e.geom`, from `sectionGeomFrom`). Spread
+        // it over the body-level `section` so the band width and x-origin come from
+        // the owning section, not the body-level one. `SectionGeom`'s field names
+        // and semantics match `SectionProps` (see the SectionGeom warning comment),
+        // so this only overrides the page-box fields. A `geom`-less marker (an
+        // inheriting section) falls back to the body-level geometry, matching
+        // `sectionGeomFrom`'s `?? bodySectionGeom`.
+        return computeColumns({ ...section, ...(e.geom ?? {}), columns: e.columns ?? null });
       }
     }
     return computeColumns(section);


### PR DESCRIPTION
## Problem

`computePages` → `sectionColumnsFrom` (packages/docx/src/renderer.ts) built each section's newspaper-column text band with:

```ts
return computeColumns({ ...section, columns: e.columns ?? null });
```

`computeColumns` derives the text band from `pageWidth − marginLeft − marginRight` and its x-origin from `marginLeft`. Those are **per-section** page-geometry values (ECMA-376 **§17.6.13** `<w:pgSz>` + **§17.6.11** `<w:pgMar>`), but the call fed the **body-level** `section`. A mid-body section whose margins differ from the body-level section therefore got the wrong band **width** and wrong left **x-origin**.

The old in-code comment claimed *"single-column sections and uniform-width documents are unaffected"* — this is wrong. Any single-column section whose margins differ from the body section is affected (e.g. a first section with `marL=426/marR=1440` twips still tiled against the body's `1440/1440` band).

## Fix

The ending section's own geometry already rides on the same `SectionBreak` marker as `e.geom` (populated by `sectionGeomFrom`; `SectionGeom`'s field names and semantics match `SectionProps` — see the `SectionGeom` warning comment in types.ts). Spread it over the body-level section:

```ts
return computeColumns({ ...section, ...(e.geom ?? {}), columns: e.columns ?? null });
```

A `geom`-less marker (an inheriting section) falls back to the body-level geometry, mirroring `sectionGeomFrom`'s `?? bodySectionGeom`. The misleading comment is corrected in the same commit.

## Red → Green (TDD)

New test in `packages/docx/src/per-section-page-geometry.test.ts`:
- First section: page 600pt wide, margins **L=10 / R=40** ⇒ band **550**, closed by a `nextPage` break carrying that `geom`.
- The first section holds a **fixed-layout** table whose `<w:tblGrid>` sums to **550**.
- Body (final) section: margins **L=75 / R=75** ⇒ band **450**.

The paginator sizes a table to the active column band (`colW()`), and `resolveColumnWidths` (fixed layout, §17.4.52) only scales the grid DOWN when it overflows the band — so the stamped `tableColWidthsPt` total is the observable proxy for the band width.

- **Before the fix**: stamped total = **450** (grid clamped to the body-level band) → test fails (`expected 450 to be close to 550`).
- **After the fix**: stamped total = **550** → test passes.

## Gates

- **docx vitest**: 875 passed / 123 files.
- **root typecheck**: `tsc --build` clean (exit 0) + markdown/node/vscode-extension typechecks all pass.
- **ast-grep scan**: 0 errors; no new findings in touched files (pre-existing production double-cast warnings unchanged).
- **docx demo VRT** (committed reference `demo/sample-1`): all 6 pages match the committed scores (99.8 / 99.1 / 99.2 / 100 / 100 / 100) — **no regression**.

## Private-fixture VRT (local, gitignored)

- **sample-5** (7-page multi-section): **byte-identical** (0.000% diff every page) — its sections share uniform margins, so the fix is behavior-neutral.
- **sample-12 / sample-13** (multi-section, incl. 2-column sections): **byte-identical with vs without the fix** (0.0000% diff every page) — all their sections carry uniform `pgMar`, so the spread overrides with identical values.
- **sample-28** (Arabic RTL, A4): the **only** sample whose first section has margins that differ from the body section (first `pgMar left=426/right=1440` twips vs body `1440/1440`). Pages **3–21 stay 100%** identical; pages **1–2 change** because the fix is taking effect. This is a **correction toward Word ground truth**, verified against the sample-28 Word PDF:
  - Word PDF page 1 leftmost text = **34.8pt**.
  - Old (buggy) renderer leftmost body-text ink = **88px** (clamped to the body-level left margin — wrong by ~53px).
  - Fixed renderer leftmost body-text ink = **35px** — matches Word's 34.8pt.

  The `references/private/sample-28/*` PNGs (and `scores.json` = 100.00%) are self-snapshots of the old buggy output, so the fidelity ratchet flags the change. Per the repo policy, private references are **not** auto-updated here (`UPDATE_REFS` was not run) — regenerating them is a user-gated step.

## Background

This is an **independent re-implementation** of a change first validated red→green on `fix/docx-table-width-rtl`. That branch reverted it because sample-28's headline symptom turned out to be a separate floating-table width-cap mechanism; the per-section geometry fix itself was adjudicated **sound** and is landed here on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)