### PR TITLE
fix(pptx): apply local envelope slope shear to warped WordArt glyphs

### DIFF
--- a/packages/core/src/shape/text-warp.test.ts
+++ b/packages/core/src/shape/text-warp.test.ts
@@ -111,8 +111,12 @@ describe('textArchUp — single arc baseline', () => {
     const gl = warpGlyphTransform(env, 0.5, boxH, 0.8);
     const gr = warpGlyphTransform(env, 0.85, boxH, 0.8);
     const glft = warpGlyphTransform(env, 0.15, boxH, 0.8);
-    // Single-edge presets never compress the glyph height.
+    // Single-edge presets never compress the glyph height…
     expect(gl.vScale).toBe(1);
+    // …and never shear: Follow Path glyphs rigidly rotate along the arc.
+    expect(gl.shear).toBe(0);
+    expect(gr.shear).toBe(0);
+    expect(glft.shear).toBe(0);
     // At the apex the axis is horizontal; toward the right end it tilts down
     // (positive angle), toward the left end it tilts up (negative angle), and
     // the tilt grows monotonically away from the apex.
@@ -131,6 +135,77 @@ describe('textInflate — per-glyph vertical scale', () => {
     const mid = warpGlyphTransform(env, 0.5, boxH, 0.8);
     const end = warpGlyphTransform(env, 0.02, boxH, 0.8);
     expect(mid.vScale).toBeGreaterThan(end.vScale);
+  });
+});
+
+describe('local envelope shear (§20.1.9.19) — paired-edge slope skews the glyph', () => {
+  // Reconstruct the per-glyph linear map the renderer applies:
+  //   rotate(angle) · [[1, shear],[0, 1]] · scale(1, vScale)
+  // Its VERTICAL column must equal the true envelope gap vector (B(u)−T(u))
+  // per unit box height — that is what makes vertical strokes track the gap
+  // while the baseline follows the slope (the glyph leans, not rigidly rotates).
+  function verticalColumn(g: {
+    angle: number;
+    shear: number;
+    vScale: number;
+  }): { x: number; y: number } {
+    const c = Math.cos(g.angle);
+    const s = Math.sin(g.angle);
+    // column_y of rotate·shear·scale = rotate · (shear·vScale, vScale)
+    const lx = g.shear * g.vScale;
+    const ly = g.vScale;
+    return { x: c * lx - s * ly, y: s * lx + c * ly };
+  }
+
+  it('flat edges (textPlain) produce zero shear', () => {
+    const env = buildWarpEnvelope('textPlain', [], W, H)!;
+    for (const u of [0, 0.25, 0.5, 0.75, 1]) {
+      const g = warpGlyphTransform(env, u, H, 0.75);
+      expect(g.shear).toBeCloseTo(0, 6);
+    }
+  });
+
+  it('textWave1 shears where the wave slopes and is flat at the crest/troughs', () => {
+    // 320×160 matches the warp fixture's Wave One shape; default adj.
+    const env = buildWarpEnvelope('textWave1', [], 320, 160)!;
+    const box = 100;
+    // The wave's zero-slope points sit at the quarter marks (u≈0.25, 0.75)
+    // where the cubic turns; the steepest slope is at the mid-band (u≈0.5) and
+    // the ends (u≈0,1). At the flat quarter marks shear ≈ 0.
+    const flatish = warpGlyphTransform(env, 0.25, box, 0.8);
+    expect(Math.abs(flatish.shear)).toBeLessThan(0.12);
+    // At the mid-band the edge slopes ~17°, so the glyph must shear noticeably.
+    const sloped = warpGlyphTransform(env, 0.5, box, 0.8);
+    expect(Math.abs(sloped.shear)).toBeGreaterThan(0.2);
+    // The end of the wave slopes the OTHER way → opposite-sign shear.
+    const end = warpGlyphTransform(env, 0.98, box, 0.8);
+    expect(Math.sign(end.shear)).toBe(-Math.sign(sloped.shear));
+  });
+
+  it('reconstructed vertical column equals the true gap vector B(u)−T(u)/box', () => {
+    const env = buildWarpEnvelope('textWave1', [], 320, 160)!;
+    const box = 100;
+    for (const u of [0.1, 0.35, 0.5, 0.65, 0.9]) {
+      const g = warpGlyphTransform(env, u, box, 0.8);
+      const t = samplePolyline(env.top, env.topLen, u);
+      const b = samplePolyline(env.bottom, env.bottomLen, u);
+      const col = verticalColumn(g);
+      expect(col.x).toBeCloseTo((b.x - t.x) / box, 4);
+      expect(col.y).toBeCloseTo((b.y - t.y) / box, 4);
+    }
+  });
+
+  it('keeps vertical strokes near-vertical on a wave (unlike a rigid rotation)', () => {
+    // On textWave1 the two edges are parallel, so the gap vector is vertical
+    // everywhere → the transform's vertical column stays vertical and only the
+    // horizontal (advance) axis tilts. A rigid rotate would tilt BOTH.
+    const env = buildWarpEnvelope('textWave1', [], 320, 160)!;
+    const g = warpGlyphTransform(env, 0.5, 100, 0.8);
+    const col = verticalColumn(g);
+    const devFromVertical = Math.abs(Math.atan2(col.x, col.y));
+    expect(devFromVertical).toBeLessThan(0.02); // ≈0 rad: stays vertical
+    // …while the advance axis is clearly tilted (the source of the lean).
+    expect(Math.abs(g.angle)).toBeGreaterThan(0.15);
   });
 });
 

--- a/packages/core/src/shape/text-warp.ts
+++ b/packages/core/src/shape/text-warp.ts
@@ -336,18 +336,37 @@ export function followPathUScale(env: WarpEnvelope, naturalWidth: number): numbe
 
 /**
  * A per-glyph placement in warped space. The renderer draws the glyph with
- * `ctx.translate(x, y); ctx.rotate(angle); ctx.scale(1, vScale)` and then paints
- * at the glyph's local baseline (`fillText(g, 0, 0)`), so the flat glyph em-box
- * is bent onto the envelope.
+ * `ctx.translate(x, y); ctx.rotate(angle); ctx.transform(1, 0, shear, 1, 0, 0);
+ * ctx.scale(hScale, vScale)` and then paints at the glyph's local baseline
+ * (`fillText(g, 0, 0)`), so the flat glyph em-box is bent onto the envelope.
+ *
+ * The four linear terms together reproduce the LOCAL JACOBIAN of the envelope
+ * map `P(u, v) = (1−v)·T(u) + v·B(u)` at the glyph centre — see
+ * {@link warpGlyphTransform}. `angle` + `hScale` orient/scale the horizontal
+ * (advance) axis to the mean edge tangent; `shear` + `vScale` bend the vertical
+ * (em-height) axis onto the true gap vector `B(u)−T(u)`. On a sloped envelope
+ * edge (a wave crest, a taper) these two axes are NOT orthogonal, so `shear`
+ * is what tilts the glyph into a parallelogram — vertical strokes stay aligned
+ * with the gap while the baseline follows the slope, matching PowerPoint's
+ * WordArt (the glyph "leans" along the wave rather than rigidly rotating).
  */
 export interface WarpGlyphTransform {
   /** Canvas-space baseline origin (shape-local; caller adds the shape offset). */
   x: number;
   y: number;
-  /** Rotation of the local text axis, radians (envelope slope). */
+  /** Rotation of the local text (advance) axis, radians (mean edge slope). */
   angle: number;
-  /** Vertical scale of the glyph em-box (1 = unchanged). */
+  /** Vertical scale of the glyph em-box along the (post-shear) up-axis. */
   vScale: number;
+  /**
+   * Horizontal skew of the em-box in the rotated frame (0 = no shear). Applied
+   * as `ctx.transform(1, 0, shear, 1, 0, 0)` AFTER `rotate(angle)` and BEFORE
+   * `scale(hScale, vScale)`: it slides the top of the glyph forward/back along
+   * the advance axis so the vertical column of the transform lands on the true
+   * envelope gap vector `B(u)−T(u)`. Zero for single-edge (arch/circle) presets
+   * and for flat (unsloped) envelope points; nonzero on sloped paired edges.
+   */
+  shear: number;
 }
 
 /**
@@ -360,14 +379,22 @@ export interface WarpGlyphTransform {
  *
  * Two regimes:
  * - **Paired-edge** (waves, inflate/deflate, cascade, …): the glyph em-box is
- *   fitted between `T(u)` and `B(u)`. The baseline lands at `baselineFrac` of the
- *   top→bottom span, the axis rotates to the mean edge tangent, and `vScale`
- *   compresses/stretches the glyph so its box exactly spans the gap.
+ *   fitted between `T(u)` and `B(u)` by the LOCAL JACOBIAN of the envelope map
+ *   `P(u, v) = (1−v)·T(u) + v·B(u)`. Its two columns are `∂P/∂u ≈ mean edge
+ *   tangent` (the advance axis → `angle`) and `∂P/∂v = B(u)−T(u)` (the em-height
+ *   axis → the gap vector). Because these columns are generally NOT orthogonal on
+ *   a sloped edge, the transform is a rotate + shear + non-uniform scale, not a
+ *   plain rotate+scale: `angle` orients the advance axis, `shear`+`vScale` bend
+ *   the vertical column onto the true gap vector so vertical strokes track the
+ *   gap while the baseline follows the slope (the glyph LEANS, matching
+ *   PowerPoint WordArt — cf. ECMA-376 §20.1.9.19). The baseline lands at
+ *   `baselineFrac` of the top→bottom span.
  * - **Single-edge** (arch/circle): the one curve IS the baseline. The glyph sits
  *   ON the curve, its up-axis is the curve NORMAL (so letters stand perpendicular
- *   to the arc), `vScale` stays 1 (glyphs keep their height), and the baseline is
- *   nudged along the normal by the box's descent so the arc passes through the
- *   glyph baseline rather than its top.
+ *   to the arc), `vScale` stays 1 (glyphs keep their height), `shear` is 0, and
+ *   the baseline is nudged along the normal by the box's descent so the arc
+ *   passes through the glyph baseline rather than its top. Follow Path presets
+ *   deliberately keep a rigid per-glyph rotation (no shear).
  */
 export function warpGlyphTransform(
   env: WarpEnvelope,
@@ -390,6 +417,7 @@ export function warpGlyphTransform(
       y: c.y - ny * descent,
       angle,
       vScale: 1,
+      shear: 0,
     };
   }
 
@@ -397,17 +425,31 @@ export function warpGlyphTransform(
   const b = samplePolyline(env.bottom, env.bottomLen, u);
   const gapx = b.x - t.x;
   const gapy = b.y - t.y;
-  const gap = Math.hypot(gapx, gapy);
   const bx = t.x + gapx * baselineFrac;
   const by = t.y + gapy * baselineFrac;
-  // Average the two edges' unit tangents for the local axis rotation.
+  // Advance axis: mean of the two edges' unit tangents (∂P/∂u direction).
   const sumTx = t.tx + b.tx;
   const sumTy = t.ty + b.ty;
   const angle = Math.atan2(sumTy, sumTx);
+
+  // Em-height axis: the TRUE gap vector ∂P/∂v = B(u)−T(u), per unit box height.
+  // Decompose it in the rotated (advance-axis) frame. Its component ALONG the
+  // advance axis is the shear (skews the glyph top forward/back on a slope); its
+  // component PERPENDICULAR is the vertical scale. When the edge is flat this
+  // gap vector is already perpendicular to the tangent → shear≈0, vScale=gap/box,
+  // recovering the old rotate+scale behaviour exactly.
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  const gapAlong = (c * gapx + s * gapy) / (boxHeight > 0 ? boxHeight : 1);
+  const gapPerp = (-s * gapx + c * gapy) / (boxHeight > 0 ? boxHeight : 1);
+  const vScale = gapPerp !== 0 ? gapPerp : boxHeight > 0 ? Math.hypot(gapx, gapy) / boxHeight : 1;
+  const shear = gapPerp !== 0 ? gapAlong / gapPerp : 0;
+
   return {
     x: bx,
     y: by,
     angle,
-    vScale: boxHeight > 0 ? gap / boxHeight : 1,
+    vScale,
+    shear,
   };
 }

--- a/packages/node/src/pptx-text-warp.probe.test.ts
+++ b/packages/node/src/pptx-text-warp.probe.test.ts
@@ -267,4 +267,79 @@ describe.skipIf(!skia)('node WordArt text-warp geometry (prstTxWarp)', () => {
     }
     expect(maxSpan).toBeGreaterThan(boxHpx * 0.5);
   });
+
+  it('textWave1 shears glyphs along the wave slope, not a rigid rotation', async () => {
+    // ECMA-376 §20.1.9.19: the envelope map's local Jacobian is a rotate+shear,
+    // not a plain rotate+scale — on the wave's rising/falling flanks the glyph
+    // em-box skews into a parallelogram (vertical strokes track the vertical
+    // edge-gap while the baseline follows the slope). PowerPoint's own PDF of the
+    // warp fixture shows the "Wave One" glyphs leaning italic-forward.
+    //
+    // Pixel signature of a SHEAR (as opposed to a rigid rotation): within a
+    // narrow vertical slab, the ink's horizontal CENTROID shifts between the
+    // upper and lower parts of the glyph band — the top slides forward on an
+    // upslope and back on a downslope. A rigid rotation keeps the slab's ink
+    // vertically aligned (top and bottom centroids agree). We sample several
+    // slabs across the word and require a MEANINGFUL top↔bottom shift that also
+    // CHANGES SIGN across the wave (proof the skew tracks the local slope rather
+    // than being a single global tilt).
+    const width = 400;
+    const height = 240;
+    const canvas = new Canvas(width, height);
+    await renderSlideNode(
+      canvas as unknown as Parameters<typeof renderSlideNode>[0],
+      buildSlide('textWave1'),
+      0,
+      { width, dpr: 1 },
+    );
+    const ctx = canvas.getContext('2d');
+    const data = ctx.getImageData(0, 0, width, height).data as unknown as Uint8ClampedArray;
+    const inked = (x: number, y: number): boolean => {
+      const i = (y * width + x) * 4;
+      const a = data[i + 3];
+      const lum = 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+      return a > 40 && lum < 128;
+    };
+    // Ink bbox of the whole warped word.
+    let minX = width, maxX = -1, minY = height, maxY = -1;
+    for (let y = 0; y < height; y++)
+      for (let x = 0; x < width; x++)
+        if (inked(x, y)) {
+          if (x < minX) minX = x;
+          if (x > maxX) maxX = x;
+          if (y < minY) minY = y;
+          if (y > maxY) maxY = y;
+        }
+    expect(maxX).toBeGreaterThan(minX);
+    expect(maxY).toBeGreaterThan(minY);
+
+    // For a vertical slab [xc-6, xc+6], the mean-x of ink in the TOP third vs the
+    // BOTTOM third of the glyph band. Positive shift = top sits right of bottom.
+    const slabShift = (xc: number): number | null => {
+      const bandTop = minY + (maxY - minY) * 0.15;
+      const bandBot = minY + (maxY - minY) * 0.85;
+      const third = (bandBot - bandTop) / 3;
+      let txSum = 0, tN = 0, bxSum = 0, bN = 0;
+      for (let x = Math.max(0, xc - 6); x <= Math.min(width - 1, xc + 6); x++) {
+        for (let y = Math.floor(bandTop); y < bandTop + third; y++) if (inked(x, y)) { txSum += x; tN++; }
+        for (let y = Math.floor(bandBot - third); y < bandBot; y++) if (inked(x, y)) { bxSum += x; bN++; }
+      }
+      if (tN < 4 || bN < 4) return null;
+      return txSum / tN - bxSum / bN;
+    };
+    const shifts: number[] = [];
+    for (let f = 0.15; f <= 0.85; f += 0.05) {
+      const s = slabShift(Math.round(minX + (maxX - minX) * f));
+      if (s != null) shifts.push(s);
+    }
+    expect(shifts.length).toBeGreaterThan(4);
+    // The lean is substantial somewhere (a rigid rotate keeps |shift| small since
+    // the whole glyph turns together; the shear slides the top several px).
+    const maxAbs = Math.max(...shifts.map((s) => Math.abs(s)));
+    expect(maxAbs).toBeGreaterThan(4);
+    // …and it reverses across the wave (upslope vs downslope) — a single global
+    // tilt could not do that.
+    expect(Math.max(...shifts)).toBeGreaterThan(2);
+    expect(Math.min(...shifts)).toBeLessThan(-2);
+  });
 });

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1519,6 +1519,13 @@ function renderWarpedText(
         ctx.save();
         ctx.translate(boxX + g.x, boxY + g.y);
         ctx.rotate(g.angle);
+        // Local envelope shear (§20.1.9.19): on a sloped paired edge the em-height
+        // axis (gap vector B−T) is not perpendicular to the advance axis, so the
+        // glyph must skew — vertical strokes track the gap while the baseline
+        // follows the slope. `g.shear` is the horizontal skew in the rotated
+        // frame; 0 for flat points and single-edge (arch/circle) presets, so this
+        // is a no-op there and leaves Follow Path glyphs rigidly rotated.
+        if (g.shear !== 0) ctx.transform(1, 0, g.shear, 1, 0, 0);
         if (hScale !== 1 || g.vScale !== 1) ctx.scale(hScale, g.vScale);
         // Draw the glyph centred on the mapped point: shift left by half its
         // advance so its own centre lands on `u`.


### PR DESCRIPTION
## Problem

`private/sample-16.pptx` slide 1 "Wave One" (`prstTxWarp prst="textWave1"`) did not match Word/PowerPoint. Glyph **positions** were right, but glyphs stood **upright** — Word shears them so the letters lean italic-forward and lie along the wave (`packages/pptx/public/private/sample-16.pdf`, the user's Office-exported ground truth).

## Root cause (ECMA-376 §20.1.9.19, `prstTxWarp`)

`renderWarpedText` (`packages/pptx/src/renderer.ts`) placed each glyph via `warpGlyphTransform` (`packages/core/src/shape/text-warp.ts`) as

```
translate(x,y) · rotate(angle) · scale(hScale, vScale)   // angle = mean edge tangent
```

a **rigid rotation** of the whole em-box — correct only where the envelope edges are flat. It had **no shear term** (renderer.ts:1521 rotate → 1522 scale; the paired-edge branch returned only `{x,y,angle,vScale}`).

The envelope map between the two boundary curves `T(u)` (top) and `B(u)` (bottom) is

```
P(u, v) = (1-v)·T(u) + v·B(u),   u in [0,1] across width,  v in [0,1] top->bottom
```

Its local Jacobian at a glyph has two columns:

```
dP/du = (1-v)·T'(u) + v·B'(u)      <- advance axis, tracks the wave slope
dP/dv = B(u) - T(u)                <- em-height axis, the edge GAP vector
```

On a sloped edge these columns are **not orthogonal**. `rotate(angle)·scale` forces the vertical column perpendicular to the tangent, so it **tilts vertical strokes that should stay aligned with the gap**. For `textWave1` (parallel edges -> gap purely vertical) the mean tangent reaches **17.4 deg at the mid-band and +/-32 deg at the ends**, so the whole glyph rotated up to 17-32 deg instead of shearing.

## Fix

Return the true Jacobian. Decompose the gap vector `dP/dv = B(u)-T(u)` in the rotated (advance-axis) frame:

```
gapAlong = ( cos0·gapx + sin0·gapy) / boxHeight
gapPerp  = (-sin0·gapx + cos0·gapy) / boxHeight
vScale = gapPerp                 // em-height along the (post-shear) up-axis
shear  = gapAlong / gapPerp      // horizontal skew in the rotated frame
```

The renderer applies one extra horizontal skew between rotate and scale:

```
translate · rotate(angle) · [[1, shear],[0, 1]] · scale(hScale, vScale)
```

This reproduces the Jacobian columns exactly (reconstructed vertical column equals `(B-T)/boxHeight` to 1e-4). Vertical strokes now track the gap, the baseline follows the slope, and the glyph leans into a parallelogram.

**General, not wave-specific.** No preset name or empirical constant is branched on. On flat envelope points `gapAlong -> 0`, so `shear -> 0` and `vScale -> gap/boxHeight`, recovering the old behaviour byte-identically. Single-edge (arch/circle) Follow Path presets return `shear:0` explicitly and are untouched (they keep the rigid per-glyph rotation from #856).

## Pixel verification (headless skia render of sample-16, 96 dpi, vs the PDF)

**Wave One glyph lean** - median lean cancels on a symmetric wave, so the distinguishing metric is the *spread* of near-vertical stroke lean (structure-tensor edge orientation of anti-aliased ink):

| crop | lean IQR | p90 (forward lean) | frac lean>8deg |
|---|---|---|---|
| BEFORE (rigid rotate) | 23.4 | +23.7 | 57% |
| **AFTER (shear)** | **42.4** | **+41.4** | **85%** |
| PowerPoint PDF (truth) | 54.6 | +43.0 | 81% |

AFTER moves the stroke-lean distribution decisively from BEFORE toward the PDF. IoU(Wave1, PDF) rose 0.016 -> 0.038 (+2.4x); the low absolute IoU reflects a pre-existing vertical positioning offset, not shear quality.

**Per-preset before->after diff (slide 1, all 8 presets):**

| preset | family | before->after diff | note |
|---|---|---|---|
| textArchUp | single-edge (Follow Path) | 0.00% | unchanged |
| textArchDown | single-edge (Follow Path) | glyphs 0.000%* | unchanged |
| textCircle | single-edge (Follow Path) | 0.00% | unchanged |
| **textWave1** | **paired-edge** | **40.9%** | the fix |
| textInflate | paired-edge | 0.00% | flat at glyph points |
| textDeflate | paired-edge | 0.00% | flat at glyph points |
| textCascadeUp | paired-edge | 7.1% | subtle shear, no visual regression |
| textChevron | paired-edge | 11.7% | subtle shear, no visual regression |

*ArchDown's cell shows 3.08% total, but that is entirely Wave One's now-taller sheared ink bleeding up from the cell below - the ArchDown **glyph region (top of the cell) is 0.000% diff**. Follow Path presets are genuinely unchanged.

## Gates

- `packages/core/src/shape/text-warp.test.ts` - 19 pass (15 pre-existing byte-identical + 4 new: flat->shear 0; wave shears at slopes & reverses sign at the far end; reconstructed vertical column == gap vector; vertical strokes stay vertical on a parallel-edge wave). The single-edge arch test now also locks `shear === 0`.
- `packages/node/src/pptx-text-warp.probe.test.ts` - 4 pass. The #856 invariants (textArchUp Follow Path, textPlain flat, textInflate stretch) are unchanged; the new textWave1 shear probe **fails on the pre-shear renderer** and passes now.
- `tsc --build` (all packages) - clean.
- pptx vitest 349/349, core/shape vitest 182/182, node probes 61 pass / 11 skip (skips are demo-fixture-gated, not warp).
- pptx **demo VRT byte-identical** (all `demo/sample-1` pass; `private/sample-*` 404 because those fixtures are gitignored/absent - no warp fixture is in the VRT spec, so demo-only is sufficient per repo policy).
- No reference images touched.

## Cross-package check

docx and xlsx have **no WordArt warp draw path** (`renderWarpedText`/`buildWarpEnvelope`/`textWarp` grep = pptx + core only). The shear lives in the shared `core` geometry, so any future format that adds a warp path inherits it. No docx/xlsx changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
