### PR TITLE
fix(docx): defer page-anchored floating table when its band intersects another float table

### DIFF
--- a/packages/docx/src/float-table-page-fit.test.ts
+++ b/packages/docx/src/float-table-page-fit.test.ts
@@ -456,4 +456,61 @@ describe('computePages — floating-table page-fit / row-split (§17.4.57, Word 
       if (el) expect((el as unknown as DocTable).tblpPr).toBeDefined();
     }
   });
+
+  it('(g) DEFERS a page-anchored floating table to the next page when its raw band intersects another table float already on the page (sample-28 projects-form shape)', () => {
+    // ── Two page-anchored floating tables whose raw bands collide (§17.4.56 / Word
+    //    ground truth, sample-28 pp.16→17) ──────────────────────────────────────
+    // Content band is 100pt (pageH 140 − margins 20+20), bodyTop 20.
+    //
+    // Table A: vertAnchor="page", tblpY=10, 4 rows × 30pt = 120pt > 100pt ⇒ it
+    //   ROW-SPLITS (pageAnchoredOverflows). Slice 1 (A1–A3) fills page 1 from its
+    //   absolute page-y 10; the continuation A4 flows onto page 2 at the body top
+    //   (content-relative y 0 → 30).
+    // Table B: vertAnchor="page", tblpY=25, 3 rows × 30pt = 90pt ≤ 100pt ⇒ B alone
+    //   FITS the text region (single element, no split). Its raw absolute box is at
+    //   page-y 25 (content-relative y 5), height 90 ⇒ it would occupy content-y
+    //   5 → 95 on whatever page it lands on.
+    //
+    // If B is placed on page 2 (where A4's continuation band sits at content-y
+    // 0 → 30), B's raw band (content-y 5 → 95) INTERSECTS A4's band — two floating
+    // tables overlapping. Word's PDF (sample-28: the previous-projects experience
+    // table lands on a FRESH page after the competitor-form residue, never stacked
+    // over it) defers the whole of B to the next page, where its absolute tblpY=25
+    // no longer collides with any other table float.
+    const body = [
+      para({ text: 'a' }),
+      floatTableRows(tblp({ vertAnchor: 'page', tblpY: 10 }), 4, 30), // Table A → r1..r4
+      para({ text: 'mid' }),
+      floatTableRows(tblp({ vertAnchor: 'page', tblpY: 25 }), 3, 30), // Table B → r1..r3
+      para({ text: 'end' }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+
+    // Page 2 (index 1) carries A's continuation (A4) but MUST NOT also carry any of
+    // Table B — B is deferred so it never overlaps A4's band.
+    const bandCollisionPage = pages[1];
+    const tableFloatsOnPage2 = bandCollisionPage.filter(isFloatTable);
+    // Exactly one table float on page 2 (A's continuation slice), not two stacked.
+    expect(tableFloatsOnPage2.length).toBe(1);
+    // And it is A's continuation (a single row on that band), not B.
+    expect(floatRowsOn(bandCollisionPage)).toEqual(['r4']);
+
+    // Table B is deferred to a LATER page and lands there as ONE un-split element
+    // (its 90pt fits the 100pt region once it is on a clean page).
+    const bPageIdx = pages.findIndex(
+      (p, i) => i > 1 && p.some(isFloatTable),
+    );
+    expect(bPageIdx).toBeGreaterThan(1);
+    const bPage = pages[bPageIdx];
+    const bFloats = bPage.filter(isFloatTable);
+    expect(bFloats.length).toBe(1);
+    expect(floatRowsOn(bPage)).toEqual(['r1', 'r2', 'r3']);
+
+    // No page ever holds two DISTINCT table-float bands that vertically overlap:
+    // assert every page has at most one floating-table element (each table's slice
+    // owns its page's band alone here, since neither co-resident split occurs).
+    for (const p of pages) {
+      expect(p.filter(isFloatTable).length).toBeLessThanOrEqual(1);
+    }
+  });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -9004,6 +9004,20 @@ function renderCell(
     // background (e.g. a nested table). renderParagraph narrows this to the
     // paragraph shading when the paragraph declares its own.
     containerShading: cell.background ?? state.containerShading,
+    // ECMA-376 §17.4.57 / §20.4.2.x — a table cell is its own text container: the
+    // page's floating objects (anchor images, text frames, and floating TABLES)
+    // exclude MAIN-STORY text, NOT text inside a table cell. Word never flows cell
+    // content around a page float that happens to overlap the cell's box. Spreading
+    // `state.floats` into the cell made a cell paragraph's line layout skip past an
+    // OUTER float's wrap band (skipPastTopAndBottom / resolveLineFloatWindow read
+    // `state.floats`), pushing the cell's first line down — measured on sample-28
+    // p.17, where a vAlign="center" header cell's text was displaced ~17 px below
+    // its centred slot by the projects float's band overlapping the cell. Give the
+    // cell an isolated (empty) float set so its content lays out only against the
+    // cell box; an in-cell anchor float then also stays scoped to the cell instead
+    // of leaking onto the page. floatParaSeq restarts at 0 for the same isolation.
+    floats: [],
+    floatParaSeq: 0,
   };
 
   if (cell.vAlign === 'center' || cell.vAlign === 'bottom') {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -66,6 +66,7 @@ import {
 } from './bidi-line.js';
 import {
   type FloatRect,
+  FLOAT_OVERLAP_EPS,
   isWrapFloat,
   resolveLineFloatWindow,
   skipPastTopAndBottom,
@@ -2855,7 +2856,65 @@ export function computePages(
             const rawBox = computeFloatTableBox(tp, measureState, measureState.y, layout.tableW, tableH, true);
             return { box, rawBox, layout, contentWPt: cW / measureState.scale };
           });
-        const first = measureFloat();
+        let first = measureFloat();
+        const isTextAnchored = tp.vertAnchor !== 'page' && tp.vertAnchor !== 'margin';
+
+        // ── Page/margin-anchored deferral on table-float band collision ──────────
+        // (§17.4.56 tblOverlap / Word ground truth, sample-28 pp.16→17) ───────────
+        // §17.4.56's NOMINAL default (tblOverlap="overlap") lets a floating table
+        // overlap other floats, but Word's ACTUAL layout of a page/margin-anchored
+        // table whose ABSOLUTE tblpY band would land ON TOP of another floating
+        // table already placed on this page is to DEFER the whole table to the next
+        // page, where its same absolute tblpY no longer collides. Measured from
+        // sample-28: the previous-projects experience form (vertAnchor="page",
+        // tblpY≈2174 twips) begins on a FRESH page after the competitor-info form's
+        // continuation band — it is never stacked over that band even though its raw
+        // tblpY falls inside it. (Its absolute in-page position is then identical on
+        // the deferred page, so nothing about the table's own geometry changes; only
+        // which page hosts it.) This is the page/margin-anchored analogue of the
+        // "not even the first row fits ⇒ advancePage first" mirror inside
+        // splitFloatTableAcrossPages: a fresh page clears page-scoped floats
+        // (measureState.floats reset in newPage), so the collision can only push the
+        // table forward ONE page and never loops. Gated to page/margin anchors: a
+        // vertAnchor="text" table rides the flow cursor and is placed by the row-
+        // split path, which already sequences it after the preceding float.
+        if (!isTextAnchored) {
+          // Absolute-px band the table's RAW box (un-clamped tblpY) would occupy on
+          // whatever page hosts it (scale is 1 in the paginator; rawBox.y is the
+          // absolute page-y, independent of the flow cursor). Compared against the
+          // exclusion rects of the table floats ALREADY on this page — using the
+          // padded exclusion range Word wraps text around — with the shared
+          // FLOAT_OVERLAP_EPS slack so a coincident/touching edge is not a clash.
+          const collidesWithTableFloat = (): boolean => {
+            const top = first.rawBox.y;
+            const bottom = first.rawBox.y + first.rawBox.h;
+            const left = first.rawBox.x;
+            const right = first.rawBox.x + first.rawBox.w;
+            return measureState.floats.some(
+              (f) =>
+                f.kind === 'table' &&
+                bottom - f.yTop > FLOAT_OVERLAP_EPS &&
+                f.yBottom - top > FLOAT_OVERLAP_EPS &&
+                right - f.xLeft > FLOAT_OVERLAP_EPS &&
+                f.xRight - left > FLOAT_OVERLAP_EPS,
+            );
+          };
+          // Only defer when a fuller/cleaner band exists on a fresh page — i.e. the
+          // current page is non-empty (newPage is a no-op on an empty page, so a
+          // deferral there would loop). prescanFloatsFrom on the fresh page could in
+          // principle re-introduce a page-level float, but a page-anchored TABLE
+          // float is only ever registered by THIS branch, so the fresh page starts
+          // with none of kind==='table' and the loop terminates in one step.
+          if (
+            collidesWithTableFloat() &&
+            pages[pages.length - 1].length > 0
+          ) {
+            nextColumnOrPage(i);
+            y = colTopY;
+            first = measureFloat();
+          }
+        }
+
         // Distance from the table's in-flow top (measureState.y == paraTop) down
         // to its body-box bottom — the table analogue of the frame's
         // frameBottomOff. The bottom is vSpace-exclusive (box.h is the bare table
@@ -2864,7 +2923,6 @@ export function computePages(
         // offset + its height; for page/margin it mixes an absolute box.y with the
         // flow cursor and is not a keep signal, so it is gated out below.
         const tableBottomOff = first.box.y + first.box.h - measureState.y;
-        const isTextAnchored = tp.vertAnchor !== 'page' && tp.vertAnchor !== 'margin';
         const tableOverflowsHere =
           isTextAnchored && tableBottomOff > 0 && y + tableBottomOff > effContentH();
 


### PR DESCRIPTION
## Problem

On sample-28 (an Arabic RTL competitor-qualification form), two page-anchored
`<w:tblpPr>` floating tables were drawn **stacked in the same y-range**. The
competitor-info form (§4.1) splits across pages, leaving a continuation band at
the top of the next page; the previous-projects experience form (§4.2,
`vertAnchor="page"`, `tblpY≈2174 twips = 108.7 pt`) was then painted at its raw
absolute `tblpY` **on top of** that band — an unreadable overlap of two floating
tables. As a knock-on, `renderCell` shared the page float list into each cell, so
a `vAlign="center"` header cell's text was displaced ~17 px by the overlapping
float band.

## Ground truth (Word-exported PDF, `sample-28.pdf`, 23 pages)

`pdftoppm -r 72` + visual/text (`pdftotext -layout`) inspection of pp.15–21:

| Page | Word PDF (ground truth) |
|---|---|
| p15 | competitor form (§4.1) slice 1 |
| p16 | competitor form residue **only** (company-rep info §1.4) |
| p17 | §4.2 heading + intro + previous-projects table slice 1 |
| p18 | previous-projects table residue |
| p19 | §4.3 heading + current-projects table slice 1 |
| p20 | current-projects table residue only |
| p21 | §4.4 admin-staff form (heading + block table) |

The key fact: on p16 the competitor residue sits **alone**; the projects table
begins on a **fresh** page (p17), never stacked over the residue band.

## §17.4.56 note

`<w:tblOverlap>`'s nominal default is `"overlap"` (a floating table *may* overlap
other floats). But Word's **actual** layout of a page/margin-anchored table whose
absolute `tblpY` band would land on top of another floating table already placed
on the page is to **defer the whole table to the next page**, where its identical
absolute `tblpY` no longer collides. This PR follows the measured Word behaviour,
not the spec-literal "overlap permitted" default. No heuristic constants are
introduced — the decision is a pure band-intersection test against the page's
existing table floats.

## Fix (commit 1 — primary)

`renderer.ts` `computePages`, floating-table branch (the page/margin-anchored
`first = measureFloat()` site, ~L2865): before placing slice 1, test the table's
raw (un-clamped) box against the exclusion rects of the table floats already on
the current page (`kind==='table'`, shared `FLOAT_OVERLAP_EPS` slack). On a hit —
and only when the current page is non-empty — `advancePage()` first and
re-measure. This mirrors the existing "not even the first row fits ⇒ advancePage
first" guard inside `splitFloatTableAcrossPages`. A fresh page clears page-scoped
floats, so a collision pushes the table forward exactly one page and never loops.

TDD: `float-table-page-fit.test.ts` case **(g)** — two page-anchored floating
tables whose raw bands collide ⇒ the second defers to a later page as one
un-split element; no page holds two overlapping table-float bands. Red before /
green after.

## Fix (commit 2 — secondary)

`renderCell` spread `state.floats` into `cellState` by reference, so cell
paragraphs skipped past an outer float's wrap band. Per §17.4.57 / §20.4.2.x a
table cell is its own text container (page floats exclude main-story text, not
cell text). `cellState` now gets an isolated `floats: []` / `floatParaSeq: 0`.
Verified via `onTextRun`: the sample-28 p.17 `vAlign="center"` header cell text
moves from y=282 back to its centred slot **y=264.8** (−17.2 px).

## Before / after page map (sample-28)

| | recorded ref (buggy) | this PR | Word PDF |
|---|---|---|---|
| total pages | 21 | 22 | 23 |
| p16 | competitor residue **+ projects table stacked (overlap)** | competitor residue **only** | competitor residue only |
| p17 | (projects rows overprinted) | intro + projects table slice 1 | §4.2 heading + intro + projects slice 1 |

The overlap is resolved (competitor residue and projects table no longer stacked).
The remaining 22↦23 gap is a **separate** keep-with-anchor concern: Word keeps a
section heading (e.g. the §4.2 `TOC2` heading — which has **no** `keepNext`, so
this is floating-table-anchor retention, not `keepNext`) on the same page as its
deferred table, and a second, **pre-existing** case keeps the §4.4 *block* table
with its heading. Both are orthogonal to this band-collision fix and are called
out as follow-ups.

## Verification

- **docx vitest**: 875/875 pass (incl. new case (g)).
- **root typecheck** (`tsc --build` + markdown/node/vscode): clean, exit 0.
- **ast-grep** (`ast-grep scan`): no new violations.
- **docx VRT**: sample-28 pages 1–15 are **100.0 % byte-identical**; pages 16–21
  diff **by design** (deferral re-flows the tail). The recorded reference
  (`pageCount: 21`) is **intentionally NOT updated**. All other samples
  (private 1–5, 24–27, 29–31; demo/sample-1) pass byte-identical / within
  threshold. sample-24 (floating tables) = 0-px diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
