### PR TITLE
test(docx): sample-28 VRT page count 22 after float-table deferral

### DIFF
--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -23,7 +23,7 @@ const DOCX_FILES: { name: string; pageCount: number; width: number }[] = [
   // sample-27 = continuous section-break page-number restart fixture (US Letter, 612pt).
   { name: 'private/sample-27', pageCount: 2, width: 612 },
   // sample-28 = Arabic RTL long-form (A4).
-  { name: 'private/sample-28', pageCount: 21, width: 595 },
+  { name: 'private/sample-28', pageCount: 22, width: 595 },
   // sample-29 = Thai script (A4).
   { name: 'private/sample-29', pageCount: 14, width: 595 },
   // sample-30 = Korean script (A4).


### PR DESCRIPTION
One-line follow-up to #867: the hardcoded VRT matrix entry for private/sample-28 still declared pageCount 21, so UPDATE_REFS/regression runs silently ignore the new 22nd page produced by the float-table deferral. Bumps it to 22 (current renderer output, matching the Word PDF composition on p16–p19; the remaining 22 vs 23 gap is tracked in #868).

References for sample-28 are private/gitignored and regenerated locally per the approved reference-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)