### PR TITLE
fix(docx): multilevel heading numbering — lvl/pStyle backlinks (§17.9.23) + full lvlOverride substitution (§17.9.7)

### DIFF
--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -74,6 +74,14 @@ pub struct LevelDef {
     /// parse time to the bullet image's zip path (+ MIME + pt size from the
     /// `<v:shape style>`). `None` ⇒ ordinary text/glyph marker.
     pub pic_bullet: Option<PicBullet>,
+    /// ECMA-376 §17.9.23 `<w:lvl><w:pStyle w:val>` — the styleId of the
+    /// paragraph style ASSOCIATED with this level. Paragraphs of that style
+    /// "shall automatically utilize this numbering level", and the ilvl carried
+    /// by the STYLE's own `numPr` "shall be ignored" in its favor. Resolved via
+    /// [`NumberingMap::level_for_style`] into each style's numbering level after
+    /// both parts are parsed (see `StyleMap::resolve_numbering_level_backlinks`).
+    /// `None` ⇒ no style association on this level.
+    pub p_style: Option<String>,
 }
 
 /// ECMA-376 §17.9.20 `<w:numPicBullet>` — an image used as a list marker. The
@@ -112,6 +120,7 @@ impl Default for LevelDef {
             start: 1,
             rpr: RunFmt::default(),
             pic_bullet: None,
+            p_style: None,
         }
     }
 }
@@ -289,6 +298,8 @@ impl NumberingMap {
                     .and_then(|n| attr_w(n, "val"))
                     .and_then(|v| v.parse::<u32>().ok())
                     .and_then(|id| pic_bullets.get(&id).cloned());
+                // §17.9.23 — the paragraph style this level is associated with.
+                let p_style = child_w(lvl_node, "pStyle").and_then(|n| attr_w(n, "val"));
                 levels.push(LevelDef {
                     format,
                     text,
@@ -301,6 +312,7 @@ impl NumberingMap {
                     start,
                     rpr,
                     pic_bullet,
+                    p_style,
                 });
             }
             map.abstract_nums.insert(abs_id, levels);
@@ -341,6 +353,21 @@ impl NumberingMap {
         let abs_id = self.num_to_abstract.get(&num_id)?;
         let levels = self.abstract_nums.get(abs_id)?;
         levels.get(level as usize)
+    }
+
+    /// ECMA-376 §17.9.23 — the numbering level ASSOCIATED with a paragraph
+    /// style inside the numbering definition that `num_id` references: the
+    /// first `<w:lvl>` whose `<w:pStyle w:val>` equals `style_id`. Paragraphs
+    /// of that style "shall automatically utilize this numbering level"; the
+    /// ilvl in the STYLE's own `numPr` "shall be ignored" in its favor. `None`
+    /// ⇒ the list has no association for this style (or the numId dangles).
+    pub fn level_for_style(&self, num_id: u32, style_id: &str) -> Option<u32> {
+        let abs_id = self.num_to_abstract.get(&num_id)?;
+        let levels = self.abstract_nums.get(abs_id)?;
+        levels
+            .iter()
+            .position(|l| l.p_style.as_deref() == Some(style_id))
+            .map(|i| i as u32)
     }
 
     pub fn get_start(&self, num_id: u32, level: u32) -> u32 {

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -145,6 +145,14 @@ pub struct NumberingMap {
     num_to_abstract: HashMap<u32, u32>,
     /// numId → level override starts
     num_overrides: HashMap<u32, HashMap<u32, u32>>,
+    /// ECMA-376 §17.9.7 — numId → per-level FULL `<w:lvl>` replacements from
+    /// `<w:num><w:lvlOverride><w:lvl>`: "the numbering level formatting which
+    /// shall be substituted for the given numbering level of the abstract
+    /// definition". Formatting only — the abstract's shared running counter is
+    /// untouched (a restart needs `<w:startOverride>`, §17.9.27, tracked in
+    /// `num_overrides`). Consulted before the abstract's levels in `get_level`,
+    /// so lvlText/numFmt/indents/rPr/pStyle all substitute per-numId.
+    num_level_overrides: HashMap<u32, HashMap<u32, LevelDef>>,
     /// per-**abstractNumId** per-level counter. ECMA-376 §17.9: the running
     /// count belongs to the abstract numbering definition, so every `<w:num>`
     /// (numId) that references the same `<w:abstractNum>` shares one counter —
@@ -160,6 +168,98 @@ pub struct NumberingMap {
     /// only on its FIRST appearance at that level (§17.9.6 / §17.9.7); afterward
     /// it increments the shared counter like any other num on the abstract.
     started: HashSet<(u32, u32)>,
+}
+
+/// Parse one `<w:lvl>` element (ECMA-376 §17.9.6) into a [`LevelDef`].
+///
+/// Shared by the two places a level definition may appear: inside
+/// `<w:abstractNum>` (§17.9.1) and as the FULL replacement inside a
+/// `<w:num><w:lvlOverride>` (§17.9.7 — "the numbering level formatting which
+/// shall be substituted for the given numbering level"). `depth` is the level's
+/// 0-based position, used only for the spec-less fallback indent when the level
+/// carries no `w:ind` at all.
+fn parse_level_def(
+    lvl_node: roxmltree::Node,
+    depth: usize,
+    pic_bullets: &HashMap<u32, PicBullet>,
+) -> LevelDef {
+    let start = child_w(lvl_node, "start")
+        .and_then(|n| attr_w(n, "val"))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+    let format = child_w(lvl_node, "numFmt")
+        .and_then(|n| attr_w(n, "val"))
+        .unwrap_or_else(|| "decimal".to_string());
+    let text = child_w(lvl_node, "lvlText")
+        .and_then(|n| attr_w(n, "val"))
+        .unwrap_or_else(|| "%1.".to_string());
+    let ind_node = child_w(lvl_node, "pPr").and_then(|p| child_w(p, "ind"));
+    // When the level defines a w:ind, a missing @left means "no
+    // start indent from this source" (an RTL level carries its
+    // indent in @right ≡ end instead); the per-level depth default
+    // applies only when no w:ind exists at all.
+    let indent_left = ind_node
+        .and_then(|i| attr_w(i, "left"))
+        .map(|v| twips_to_pt(&v))
+        .unwrap_or(if ind_node.is_some() {
+            0.0
+        } else {
+            720.0 / 20.0 * (depth as f64 + 1.0)
+        });
+    let indent_right = ind_node
+        .and_then(|i| attr_w(i, "right"))
+        .map(|v| twips_to_pt(&v));
+    // §17.3.1.12: a first-line indent is EITHER `w:hanging` (negative —
+    // the marker hangs left of the body) OR `w:firstLine` (positive — an
+    // additional first-line indent); `hanging` wins when both appear, the
+    // same precedence `styles.rs` applies to a direct `w:ind`. Keep the
+    // SIGN in `indent_first`; `tab` keeps the positive magnitude for the
+    // marker's tab-advance.
+    let indent_first = ind_node
+        .and_then(|i| {
+            attr_w(i, "hanging")
+                .map(|v| -twips_to_pt(&v))
+                .or_else(|| attr_w(i, "firstLine").map(|v| twips_to_pt(&v)))
+        })
+        .unwrap_or(-36.0);
+    let tab = indent_first.abs();
+    // §17.9.28: absent <w:suff> means "tab".
+    let suff = child_w(lvl_node, "suff")
+        .and_then(|n| attr_w(n, "val"))
+        .unwrap_or_else(|| "tab".to_string());
+    // §17.9.8 `<w:lvlJc>` — marker justification; absent ⇒ "left".
+    let lvl_jc = child_w(lvl_node, "lvlJc")
+        .and_then(|n| attr_w(n, "val"))
+        .unwrap_or_else(|| "left".to_string());
+    // §17.9.6 — the level's run properties for the marker glyph.
+    // Parsed with the SAME `parse_run_fmt` body runs use; theme refs
+    // stay as "@theme:<ref>" markers and are resolved at use-site once
+    // merged over the paragraph's run formatting.
+    let rpr = child_w(lvl_node, "rPr")
+        .map(parse_run_fmt)
+        .unwrap_or_default();
+    // §17.9.9 — resolve the level's picture bullet (if any) against
+    // the `<w:numPicBullet>` definitions collected by the caller.
+    let pic_bullet = child_w(lvl_node, "lvlPicBulletId")
+        .and_then(|n| attr_w(n, "val"))
+        .and_then(|v| v.parse::<u32>().ok())
+        .and_then(|id| pic_bullets.get(&id).cloned());
+    // §17.9.23 — the paragraph style this level is associated with.
+    let p_style = child_w(lvl_node, "pStyle").and_then(|n| attr_w(n, "val"));
+    LevelDef {
+        format,
+        text,
+        indent_left,
+        indent_right,
+        indent_first,
+        tab,
+        suff,
+        lvl_jc,
+        start,
+        rpr,
+        pic_bullet,
+        p_style,
+    }
 }
 
 impl NumberingMap {
@@ -237,83 +337,8 @@ impl NumberingMap {
             let abs_id: u32 = abs_id_s.parse().unwrap_or(0);
             let mut levels = vec![];
             for lvl_node in children_w(abs_node, "lvl") {
-                let start = child_w(lvl_node, "start")
-                    .and_then(|n| attr_w(n, "val"))
-                    .and_then(|v| v.parse().ok())
-                    .unwrap_or(1);
-                let format = child_w(lvl_node, "numFmt")
-                    .and_then(|n| attr_w(n, "val"))
-                    .unwrap_or_else(|| "decimal".to_string());
-                let text = child_w(lvl_node, "lvlText")
-                    .and_then(|n| attr_w(n, "val"))
-                    .unwrap_or_else(|| "%1.".to_string());
-                let ind_node = child_w(lvl_node, "pPr").and_then(|p| child_w(p, "ind"));
-                // When the level defines a w:ind, a missing @left means "no
-                // start indent from this source" (an RTL level carries its
-                // indent in @right ≡ end instead); the per-level depth default
-                // applies only when no w:ind exists at all.
-                let indent_left = ind_node
-                    .and_then(|i| attr_w(i, "left"))
-                    .map(|v| twips_to_pt(&v))
-                    .unwrap_or(if ind_node.is_some() {
-                        0.0
-                    } else {
-                        720.0 / 20.0 * (levels.len() as f64 + 1.0)
-                    });
-                let indent_right = ind_node
-                    .and_then(|i| attr_w(i, "right"))
-                    .map(|v| twips_to_pt(&v));
-                // §17.3.1.12: a first-line indent is EITHER `w:hanging` (negative —
-                // the marker hangs left of the body) OR `w:firstLine` (positive — an
-                // additional first-line indent); `hanging` wins when both appear, the
-                // same precedence `styles.rs` applies to a direct `w:ind`. Keep the
-                // SIGN in `indent_first`; `tab` keeps the positive magnitude for the
-                // marker's tab-advance.
-                let indent_first = ind_node
-                    .and_then(|i| {
-                        attr_w(i, "hanging")
-                            .map(|v| -twips_to_pt(&v))
-                            .or_else(|| attr_w(i, "firstLine").map(|v| twips_to_pt(&v)))
-                    })
-                    .unwrap_or(-36.0);
-                let tab = indent_first.abs();
-                // §17.9.28: absent <w:suff> means "tab".
-                let suff = child_w(lvl_node, "suff")
-                    .and_then(|n| attr_w(n, "val"))
-                    .unwrap_or_else(|| "tab".to_string());
-                // §17.9.8 `<w:lvlJc>` — marker justification; absent ⇒ "left".
-                let lvl_jc = child_w(lvl_node, "lvlJc")
-                    .and_then(|n| attr_w(n, "val"))
-                    .unwrap_or_else(|| "left".to_string());
-                // §17.9.6 — the level's run properties for the marker glyph.
-                // Parsed with the SAME `parse_run_fmt` body runs use; theme refs
-                // stay as "@theme:<ref>" markers and are resolved at use-site once
-                // merged over the paragraph's run formatting.
-                let rpr = child_w(lvl_node, "rPr")
-                    .map(parse_run_fmt)
-                    .unwrap_or_default();
-                // §17.9.9 — resolve the level's picture bullet (if any) against
-                // the `<w:numPicBullet>` definitions collected above.
-                let pic_bullet = child_w(lvl_node, "lvlPicBulletId")
-                    .and_then(|n| attr_w(n, "val"))
-                    .and_then(|v| v.parse::<u32>().ok())
-                    .and_then(|id| pic_bullets.get(&id).cloned());
-                // §17.9.23 — the paragraph style this level is associated with.
-                let p_style = child_w(lvl_node, "pStyle").and_then(|n| attr_w(n, "val"));
-                levels.push(LevelDef {
-                    format,
-                    text,
-                    indent_left,
-                    indent_right,
-                    indent_first,
-                    tab,
-                    suff,
-                    lvl_jc,
-                    start,
-                    rpr,
-                    pic_bullet,
-                    p_style,
-                });
+                let depth = levels.len();
+                levels.push(parse_level_def(lvl_node, depth, &pic_bullets));
             }
             map.abstract_nums.insert(abs_id, levels);
         }
@@ -331,6 +356,7 @@ impl NumberingMap {
             }
             // Level overrides
             let mut overrides = HashMap::new();
+            let mut level_overrides = HashMap::new();
             for lvl_ov in children_w(num_node, "lvlOverride") {
                 let ilvl: u32 = attr_w(lvl_ov, "ilvl")
                     .and_then(|v| v.parse().ok())
@@ -340,16 +366,35 @@ impl NumberingMap {
                 {
                     overrides.insert(ilvl, start_ov.parse().unwrap_or(1));
                 }
+                // §17.9.7 — a FULL <w:lvl> child substitutes the level's
+                // definition for this numId (formatting only; no restart).
+                if let Some(lvl_node) = child_w(lvl_ov, "lvl") {
+                    level_overrides
+                        .insert(ilvl, parse_level_def(lvl_node, ilvl as usize, &pic_bullets));
+                }
             }
             if !overrides.is_empty() {
                 map.num_overrides.insert(num_id, overrides);
+            }
+            if !level_overrides.is_empty() {
+                map.num_level_overrides.insert(num_id, level_overrides);
             }
         }
 
         map
     }
 
+    /// The EFFECTIVE level definition for (numId, level): the numId's own
+    /// `<w:lvlOverride><w:lvl>` substitution when present (§17.9.7), else the
+    /// abstract definition's level (§17.9.6).
     pub fn get_level(&self, num_id: u32, level: u32) -> Option<&LevelDef> {
+        if let Some(ov) = self
+            .num_level_overrides
+            .get(&num_id)
+            .and_then(|m| m.get(&level))
+        {
+            return Some(ov);
+        }
         let abs_id = self.num_to_abstract.get(&num_id)?;
         let levels = self.abstract_nums.get(abs_id)?;
         levels.get(level as usize)
@@ -357,17 +402,18 @@ impl NumberingMap {
 
     /// ECMA-376 §17.9.23 — the numbering level ASSOCIATED with a paragraph
     /// style inside the numbering definition that `num_id` references: the
-    /// first `<w:lvl>` whose `<w:pStyle w:val>` equals `style_id`. Paragraphs
-    /// of that style "shall automatically utilize this numbering level"; the
-    /// ilvl in the STYLE's own `numPr` "shall be ignored" in its favor. `None`
-    /// ⇒ the list has no association for this style (or the numId dangles).
+    /// first level whose `<w:pStyle w:val>` equals `style_id`. Paragraphs of
+    /// that style "shall automatically utilize this numbering level"; the ilvl
+    /// in the STYLE's own `numPr` "shall be ignored" in its favor. Goes through
+    /// [`Self::get_level`] so a backlink carried by a per-numId `<w:lvlOverride>`
+    /// substitution (§17.9.7) participates too. `None` ⇒ the list has no
+    /// association for this style (or the numId dangles). WordprocessingML caps
+    /// lists at 9 levels (ST_Ilvl, §17.18.38).
     pub fn level_for_style(&self, num_id: u32, style_id: &str) -> Option<u32> {
-        let abs_id = self.num_to_abstract.get(&num_id)?;
-        let levels = self.abstract_nums.get(abs_id)?;
-        levels
-            .iter()
-            .position(|l| l.p_style.as_deref() == Some(style_id))
-            .map(|i| i as u32)
+        (0..9).find(|&l| {
+            self.get_level(num_id, l)
+                .is_some_and(|def| def.p_style.as_deref() == Some(style_id))
+        })
     }
 
     pub fn get_start(&self, num_id: u32, level: u32) -> u32 {

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -132,7 +132,7 @@ pub fn parse(zip: &mut Zip) -> Result<Document, String> {
             }
         })
         .unwrap_or_else(|| "word/styles.xml".to_string());
-    let style_map = read_zip_string(zip, &styles_path)
+    let mut style_map = read_zip_string(zip, &styles_path)
         .map(|s| StyleMap::parse(&s))
         .unwrap_or_else(|_| StyleMap::parse(""));
 
@@ -168,6 +168,9 @@ pub fn parse(zip: &mut Zip) -> Result<Document, String> {
     let mut num_map = read_zip_string(zip, &numbering_path)
         .map(|s| NumberingMap::parse(&s, &numbering_media_map))
         .unwrap_or_default();
+    // §17.9.23 — fold each `<w:lvl><w:pStyle>` backlink into its style's
+    // numbering level, now that both parts exist (see the method doc).
+    style_map.resolve_numbering_level_backlinks(&num_map);
 
     // Theme is referenced by a relationship with Type ending in "/theme" — resolve
     // to word/<target> and parse the clrScheme.
@@ -9714,12 +9717,14 @@ mod footnote_tests {
             .descendants()
             .find(|n| n.tag_name().name() == "body")
             .unwrap();
-        let style_map = StyleMap::parse(styles_xml);
+        let mut style_map = StyleMap::parse(styles_xml);
         let mut num_map = if numbering_xml.is_empty() {
             NumberingMap::default()
         } else {
             NumberingMap::parse(numbering_xml, &HashMap::new())
         };
+        // Mirror production `parse`: §17.9.23 backlinks resolve after both parts.
+        style_map.resolve_numbering_level_backlinks(&num_map);
         let elems = parse_body_elements(
             body_node,
             &style_map,
@@ -9758,12 +9763,14 @@ mod footnote_tests {
             .descendants()
             .find(|n| n.tag_name().name() == "body")
             .unwrap();
-        let style_map = StyleMap::parse(styles_xml);
+        let mut style_map = StyleMap::parse(styles_xml);
         let mut num_map = if numbering_xml.is_empty() {
             NumberingMap::default()
         } else {
             NumberingMap::parse(numbering_xml, &HashMap::new())
         };
+        // Mirror production `parse`: §17.9.23 backlinks resolve after both parts.
+        style_map.resolve_numbering_level_backlinks(&num_map);
         parse_body_elements(
             body_node,
             &style_map,
@@ -15399,6 +15406,169 @@ mod embedded_font_tests {
             garbage_err.matches("zip container").count(),
             1,
             "the container tag must not be doubled; got {garbage_err:?}"
+        );
+    }
+}
+
+// ===== ECMA-376 §17.9.23: <w:lvl><w:pStyle> paragraph-style ↔ level association =====
+//
+// End-to-end (zip → parse_from_bytes) tests for the lvl/pStyle BACKLINK: an
+// abstractNum level names a paragraph style, and paragraphs of that style must
+// use THAT level — even when the style's own numPr carries no <w:ilvl> (the
+// authoring Word's "Define Multilevel List → Link level to style" UI emits,
+// e.g. sample-28's KPMGHeading1/2/3 → abstractNum 67 levels 0/1/2).
+#[cfg(test)]
+mod lvl_pstyle_backlink_tests {
+    use super::*;
+    use crate::types::BodyElement;
+    use crate::xml_util::W_NS;
+
+    /// Build a docx zip carrying document + styles + numbering parts. The rels
+    /// part is empty: the production parser falls back to `word/styles.xml` /
+    /// `word/numbering.xml` when the relationships omit them, so this exercises
+    /// the REAL `parse` wiring (StyleMap + NumberingMap construction order and
+    /// any cross-map resolution), not a test-local reimplementation.
+    fn build_docx_with_parts(body_inner: &str, styles_xml: &str, numbering_xml: &str) -> Vec<u8> {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        let document = format!(
+            r#"<w:document xmlns:w="{ns}"><w:body>{body_inner}</w:body></w:document>"#,
+            ns = W_NS,
+        );
+        let rels_xml = r#"<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>"#;
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            let opts = SimpleFileOptions::default();
+            zw.start_file("word/document.xml", opts).unwrap();
+            zw.write_all(document.as_bytes()).unwrap();
+            zw.start_file("word/_rels/document.xml.rels", opts).unwrap();
+            zw.write_all(rels_xml.as_bytes()).unwrap();
+            zw.start_file("word/styles.xml", opts).unwrap();
+            zw.write_all(styles_xml.as_bytes()).unwrap();
+            zw.start_file("word/numbering.xml", opts).unwrap();
+            zw.write_all(numbering_xml.as_bytes()).unwrap();
+            zw.finish().unwrap();
+        }
+        buf
+    }
+
+    /// Parse and collect every body paragraph's resolved (level, marker text).
+    fn heading_markers(data: &[u8]) -> Vec<(u32, String)> {
+        let doc = parse_from_bytes(data).expect("synthetic docx parses");
+        doc.body
+            .iter()
+            .filter_map(|e| match e {
+                BodyElement::Paragraph(p) => {
+                    let n = p.numbering.as_ref().expect("heading is numbered");
+                    Some((n.level, n.text.clone()))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// sample-28's authoring shape: the heading styles carry ONLY
+    /// `<w:numPr><w:numId/></w:numPr>` (no <w:ilvl>), and the level ↔ style
+    /// association lives in the abstractNum's `<w:lvl><w:pStyle>` (§17.9.23).
+    fn styles_numid_only() -> String {
+        format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+              <w:style w:type="paragraph" w:styleId="H1"><w:name w:val="heading 1"/><w:basedOn w:val="Normal"/><w:pPr><w:numPr><w:numId w:val="19"/></w:numPr></w:pPr></w:style>
+              <w:style w:type="paragraph" w:styleId="H2"><w:name w:val="heading 2"/><w:basedOn w:val="Normal"/><w:pPr><w:numPr><w:numId w:val="19"/></w:numPr></w:pPr></w:style>
+              <w:style w:type="paragraph" w:styleId="H3"><w:name w:val="heading 3"/><w:basedOn w:val="H2"/></w:style>
+            </w:styles>"#,
+            ns = W_NS
+        )
+    }
+
+    /// abstractNum 67 shape (sample-28): every level backlinks its style via
+    /// `<w:pStyle>` and composes ancestors with `%1.%2` (§17.9.11). H3 has NO
+    /// numPr of its own anywhere — its numId arrives via basedOn=H2 and its
+    /// LEVEL arrives purely from the backlink.
+    fn numbering_with_backlinks() -> String {
+        format!(
+            r#"<w:numbering xmlns:w="{ns}">
+              <w:abstractNum w:abstractNumId="67">
+                <w:multiLevelType w:val="multilevel"/>
+                <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:pStyle w:val="H1"/><w:lvlText w:val="%1"/></w:lvl>
+                <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:pStyle w:val="H2"/><w:lvlText w:val="%1.%2"/></w:lvl>
+                <w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:pStyle w:val="H3"/><w:lvlText w:val="%1.%2.%3"/></w:lvl>
+              </w:abstractNum>
+              <w:num w:numId="19"><w:abstractNumId w:val="67"/></w:num>
+            </w:numbering>"#,
+            ns = W_NS
+        )
+    }
+
+    /// §17.9.23 — the reported sample-28 failure: heading styles whose numPr has
+    /// numId but NO ilvl must still land on their pStyle-linked levels. A
+    /// regression flattens the outline to "1 / 2 / 3 / 4 / 5 / 6" (every heading
+    /// advancing level 0) — exactly the user-visible "2, 3, 4" bug.
+    #[test]
+    fn lvl_pstyle_backlink_resolves_style_linked_levels() {
+        let body = r#"
+            <w:p><w:pPr><w:pStyle w:val="H1"/></w:pPr><w:r><w:t>A</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H2"/></w:pPr><w:r><w:t>B</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H2"/></w:pPr><w:r><w:t>C</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H3"/></w:pPr><w:r><w:t>D</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H1"/></w:pPr><w:r><w:t>E</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H2"/></w:pPr><w:r><w:t>F</w:t></w:r></w:p>"#;
+        let data = build_docx_with_parts(body, &styles_numid_only(), &numbering_with_backlinks());
+        assert_eq!(
+            heading_markers(&data),
+            vec![
+                (0, "1".to_string()),
+                (1, "1.1".to_string()),
+                (1, "1.2".to_string()),
+                (2, "1.2.1".to_string()),
+                (0, "2".to_string()),
+                (1, "2.1".to_string()),
+            ],
+            "styles with numId-only numPr must use their §17.9.23 pStyle-linked levels"
+        );
+    }
+
+    /// §17.7.2 — a DIRECT `<w:ilvl>` on the paragraph itself (what Word writes
+    /// when the user Tab-demotes a heading) is the most specific layer and wins
+    /// over the style's §17.9.23 association.
+    #[test]
+    fn direct_ilvl_overrides_lvl_pstyle_backlink() {
+        // An H1 paragraph (backlinked to level 0) demoted to level 1 directly.
+        let body = r#"
+            <w:p><w:pPr><w:pStyle w:val="H1"/></w:pPr><w:r><w:t>A</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H1"/><w:numPr><w:ilvl w:val="1"/></w:numPr></w:pPr><w:r><w:t>B</w:t></w:r></w:p>"#;
+        let data = build_docx_with_parts(body, &styles_numid_only(), &numbering_with_backlinks());
+        assert_eq!(
+            heading_markers(&data),
+            vec![(0, "1".to_string()), (1, "1.1".to_string())],
+            "a direct <w:ilvl> outranks the style's pStyle-linked level"
+        );
+    }
+
+    /// §17.9.23 sentence 2: "any numbering level defined by the numPr element
+    /// shall be ignored" — a style whose numPr carries a WRONG explicit ilvl
+    /// still lands on its pStyle-linked level.
+    #[test]
+    fn style_explicit_ilvl_is_ignored_when_backlink_exists() {
+        let styles = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+              <w:style w:type="paragraph" w:styleId="H1"><w:name w:val="heading 1"/><w:pPr><w:numPr><w:numId w:val="19"/></w:numPr></w:pPr></w:style>
+              <w:style w:type="paragraph" w:styleId="H2"><w:name w:val="heading 2"/><w:pPr><w:numPr><w:ilvl w:val="5"/><w:numId w:val="19"/></w:numPr></w:pPr></w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        let body = r#"
+            <w:p><w:pPr><w:pStyle w:val="H1"/></w:pPr><w:r><w:t>A</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H2"/></w:pPr><w:r><w:t>B</w:t></w:r></w:p>"#;
+        let data = build_docx_with_parts(body, &styles, &numbering_with_backlinks());
+        assert_eq!(
+            heading_markers(&data),
+            vec![(0, "1".to_string()), (1, "1.1".to_string())],
+            "the style's own explicit ilvl is ignored in favor of the §17.9.23 association"
         );
     }
 }

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -15572,3 +15572,141 @@ mod lvl_pstyle_backlink_tests {
         );
     }
 }
+
+// ===== ECMA-376 §17.9.7: <w:lvlOverride> with a FULL <w:lvl> replacement =====
+//
+// Shares the zip-level harness style with `lvl_pstyle_backlink_tests` above —
+// both exercise numbering-definition wiring through the production
+// `parse_from_bytes` path.
+#[cfg(test)]
+mod lvl_override_full_lvl_tests {
+    use super::*;
+    use crate::types::BodyElement;
+    use crate::xml_util::W_NS;
+
+    fn build_docx_with_parts(body_inner: &str, numbering_xml: &str) -> Vec<u8> {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        let document = format!(
+            r#"<w:document xmlns:w="{ns}"><w:body>{body_inner}</w:body></w:document>"#,
+            ns = W_NS,
+        );
+        let styles = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+            </w:styles>"#,
+            ns = W_NS,
+        );
+        let rels_xml = r#"<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>"#;
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            let opts = SimpleFileOptions::default();
+            zw.start_file("word/document.xml", opts).unwrap();
+            zw.write_all(document.as_bytes()).unwrap();
+            zw.start_file("word/_rels/document.xml.rels", opts).unwrap();
+            zw.write_all(rels_xml.as_bytes()).unwrap();
+            zw.start_file("word/styles.xml", opts).unwrap();
+            zw.write_all(styles.as_bytes()).unwrap();
+            zw.start_file("word/numbering.xml", opts).unwrap();
+            zw.write_all(numbering_xml.as_bytes()).unwrap();
+            zw.finish().unwrap();
+        }
+        buf
+    }
+
+    fn markers(data: &[u8]) -> Vec<String> {
+        let doc = parse_from_bytes(data).expect("synthetic docx parses");
+        doc.body
+            .iter()
+            .filter_map(|e| match e {
+                BodyElement::Paragraph(p) => {
+                    Some(p.numbering.as_ref().expect("numbered").text.clone())
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn p(ilvl: u32, num_id: u32) -> String {
+        format!(
+            r#"<w:p><w:pPr><w:numPr><w:ilvl w:val="{ilvl}"/><w:numId w:val="{num_id}"/></w:numPr></w:pPr><w:r><w:t>x</w:t></w:r></w:p>"#
+        )
+    }
+
+    /// §17.9.7 — "the numbering level formatting which shall be substituted":
+    /// a full `<w:lvl>` inside `<w:lvlOverride>` REPLACES that level's
+    /// definition (lvlText / numFmt / indents) for THAT numId only. sample-28's
+    /// numId 76 overrides every level of an abstract whose lvlText are
+    /// single-token ("%1." / "%2." / "%3.") with cross-level compositions
+    /// ("%1." / "%1.%2." / "%1.%2.%3."); after four lvl-0 and two lvl-1 hidden
+    /// primer paragraphs, Word renders the deliverables heading as "4.2.1."
+    /// (sample-28 PDF p.12). Ignoring the override yields a flat "1.".
+    #[test]
+    fn full_lvl_override_replaces_level_definition() {
+        let numbering = format!(
+            r#"<w:numbering xmlns:w="{ns}">
+              <w:abstractNum w:abstractNumId="64">
+                <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>
+                <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%2."/></w:lvl>
+                <w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%3."/></w:lvl>
+              </w:abstractNum>
+              <w:num w:numId="76">
+                <w:abstractNumId w:val="64"/>
+                <w:lvlOverride w:ilvl="1"><w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2."/></w:lvl></w:lvlOverride>
+                <w:lvlOverride w:ilvl="2"><w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2.%3."/></w:lvl></w:lvlOverride>
+              </w:num>
+            </w:numbering>"#,
+            ns = W_NS
+        );
+        let body: String = [
+            p(0, 76),
+            p(0, 76),
+            p(0, 76),
+            p(0, 76),
+            p(1, 76),
+            p(1, 76),
+            p(2, 76),
+        ]
+        .concat();
+        let data = build_docx_with_parts(&body, &numbering);
+        assert_eq!(
+            markers(&data),
+            vec!["1.", "2.", "3.", "4.", "4.1.", "4.2.", "4.2.1."],
+            "a full <w:lvl> inside <w:lvlOverride> substitutes the level definition (§17.9.7)"
+        );
+    }
+
+    /// §17.9.7 vs §17.9.27 — a full-lvl override WITHOUT `<w:startOverride>`
+    /// substitutes FORMATTING only; it must NOT restart the abstract's shared
+    /// running counter the way a startOverride does on first use.
+    #[test]
+    fn full_lvl_override_does_not_restart_shared_counter() {
+        let numbering = format!(
+            r#"<w:numbering xmlns:w="{ns}">
+              <w:abstractNum w:abstractNumId="1">
+                <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>
+              </w:abstractNum>
+              <w:num w:numId="5"><w:abstractNumId w:val="1"/></w:num>
+              <w:num w:numId="6">
+                <w:abstractNumId w:val="1"/>
+                <w:lvlOverride w:ilvl="0"><w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="[%1]"/></w:lvl></w:lvlOverride>
+              </w:num>
+              <w:num w:numId="7">
+                <w:abstractNumId w:val="1"/>
+                <w:lvlOverride w:ilvl="0"><w:startOverride w:val="1"/></w:lvlOverride>
+              </w:num>
+            </w:numbering>"#,
+            ns = W_NS
+        );
+        let body: String = [p(0, 5), p(0, 5), p(0, 6), p(0, 7)].concat();
+        let data = build_docx_with_parts(&body, &numbering);
+        assert_eq!(
+            markers(&data),
+            vec!["1.", "2.", "[3]", "1."],
+            "formatting-only override continues the shared count (its lvlText applies); \
+             only startOverride restarts (§17.9.27)"
+        );
+    }
+}

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -9738,6 +9738,116 @@ mod footnote_tests {
         panic!("no paragraph parsed");
     }
 
+    /// Like `first_para_with`, but returns EVERY body paragraph (in order) so a
+    /// numbering SEQUENCE across several paragraphs can be exercised end-to-end
+    /// (the running counter lives in `NumberingMap`, so a single-paragraph helper
+    /// cannot observe how level advances/resets compose).
+    fn paras_with(
+        body_inner: &str,
+        styles_xml: &str,
+        numbering_xml: &str,
+    ) -> Vec<crate::types::DocParagraph> {
+        let xml = format!(
+            r#"<w:document xmlns:w="{ns}"><w:body>{inner}</w:body></w:document>"#,
+            ns = W_NS,
+            inner = body_inner,
+        );
+        let doc = XmlDoc::parse(&xml).unwrap();
+        let body_node = doc
+            .root_element()
+            .descendants()
+            .find(|n| n.tag_name().name() == "body")
+            .unwrap();
+        let style_map = StyleMap::parse(styles_xml);
+        let mut num_map = if numbering_xml.is_empty() {
+            NumberingMap::default()
+        } else {
+            NumberingMap::parse(numbering_xml, &HashMap::new())
+        };
+        parse_body_elements(
+            body_node,
+            &style_map,
+            &mut num_map,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .into_iter()
+        .filter_map(|e| match e {
+            BodyElement::Paragraph(p) => Some(p),
+            _ => None,
+        })
+        .collect()
+    }
+
+    /// ECMA-376 §17.9.2/§17.9.22/§17.9.11 — MULTILEVEL heading numbering resolved
+    /// PURELY through the paragraph-style chain, the way real templates (e.g. the
+    /// MSR journal template, sample-13) author it: the heading paragraphs carry
+    /// ONLY `<w:pStyle>` (no direct `<w:numPr>`), each heading style's `pPr/numPr`
+    /// supplies `<w:ilvl>` + `<w:numId>` (Heading3 inherits the numId from its
+    /// `basedOn` Heading2), and the shared abstractNum composes cross-level markers
+    /// with `%1.%2`. The running counter must therefore: (a) pick up the ilvl from
+    /// the STYLE (not default to 0 for a paragraph that lacks a direct numPr),
+    /// (b) NOT advance the level-0 counter when a level-1 heading appears, and
+    /// (c) reset the deeper counter when the parent advances. A regression here
+    /// renders the classic "1 / 1.1 / 1.2 / 2 / 2.1" outline as a flat "1 / 2 / 3
+    /// / 4 / 5".
+    #[test]
+    fn multilevel_headings_via_pstyle_chain_resolve_hierarchically() {
+        let styles = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+              <w:style w:type="paragraph" w:styleId="H1"><w:name w:val="heading 1"/><w:basedOn w:val="Normal"/><w:pPr><w:numPr><w:numId w:val="6"/></w:numPr></w:pPr></w:style>
+              <w:style w:type="paragraph" w:styleId="H2"><w:name w:val="heading 2"/><w:basedOn w:val="Normal"/><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="6"/></w:numPr></w:pPr></w:style>
+              <w:style w:type="paragraph" w:styleId="H3"><w:name w:val="heading 3"/><w:basedOn w:val="H2"/><w:pPr><w:numPr><w:ilvl w:val="2"/></w:numPr></w:pPr></w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        let numbering = format!(
+            r#"<w:numbering xmlns:w="{ns}">
+              <w:abstractNum w:abstractNumId="20">
+                <w:multiLevelType w:val="multilevel"/>
+                <w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:pStyle w:val="H1"/><w:lvlText w:val="%1."/></w:lvl>
+                <w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:pStyle w:val="H2"/><w:lvlText w:val="%1.%2"/></w:lvl>
+                <w:lvl w:ilvl="2"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:pStyle w:val="H3"/><w:lvlText w:val="%1.%2.%3"/></w:lvl>
+              </w:abstractNum>
+              <w:num w:numId="6"><w:abstractNumId w:val="20"/></w:num>
+            </w:numbering>"#,
+            ns = W_NS
+        );
+        // Sequence: H1, H2, H2, H3, H1, H2 — the canonical outline the user reported.
+        let body = r#"
+            <w:p><w:pPr><w:pStyle w:val="H1"/></w:pPr><w:r><w:t>A</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H2"/></w:pPr><w:r><w:t>B</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H2"/></w:pPr><w:r><w:t>C</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H3"/></w:pPr><w:r><w:t>D</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H1"/></w:pPr><w:r><w:t>E</w:t></w:r></w:p>
+            <w:p><w:pPr><w:pStyle w:val="H2"/></w:pPr><w:r><w:t>F</w:t></w:r></w:p>"#;
+        let paras = paras_with(body, &styles, &numbering);
+        let markers: Vec<(u32, &str)> = paras
+            .iter()
+            .map(|p| {
+                let n = p.numbering.as_ref().expect("heading is numbered");
+                (n.level, n.text.as_str())
+            })
+            .collect();
+        assert_eq!(
+            markers,
+            vec![
+                (0, "1."),
+                (1, "1.1"),
+                (1, "1.2"),
+                (2, "1.2.1"),
+                (0, "2."),
+                (1, "2.1"),
+            ],
+            "multilevel headings authored via the pStyle chain must resolve \
+             hierarchically, not flatten to 1/2/3/4/5/6"
+        );
+    }
+
     /// ECMA-376 §17.3.1.19 — `numId=0` explicitly removes numbering, so the paragraph
     /// is not a list item and drops the indent it would otherwise inherit from a
     /// numbered-heading style's basedOn chain (List Paragraph, ind left=720). Word

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -643,6 +643,63 @@ impl StyleMap {
         }
     }
 
+    /// ECMA-376 §17.9.23 (`<w:lvl><w:pStyle>`) — resolve each style's
+    /// paragraph-style ↔ numbering-level ASSOCIATION into that style's own
+    /// `num_level`.
+    ///
+    /// Word's "Define Multilevel List → Link level to style" authoring stores
+    /// the level on the NUMBERING side: the style's `numPr` carries only a
+    /// `<w:numId>` (no `<w:ilvl>`), and the abstractNum's `<w:lvl>` names the
+    /// style back via `<w:pStyle>` (sample-28's KPMGHeading1/2/3 →
+    /// abstractNum 67 levels 0/1/2). §17.9.23: paragraphs of that style "shall
+    /// automatically utilize this numbering level", and "any numbering level
+    /// defined by the numPr element [of the style] shall be ignored" — so the
+    /// association also overrides an explicit (redundant or stale) ilvl written
+    /// in the style's own numPr.
+    ///
+    /// Rewriting the level AT THE STYLE LAYER (rather than per paragraph) keeps
+    /// every downstream rule intact for free: `basedOn` children inherit the
+    /// corrected level through the normal cascade (`apply_para`), and a
+    /// paragraph's DIRECT `<w:ilvl>` (Word's Tab-demotion) still outranks it as
+    /// direct-over-style formatting (§17.7.2).
+    ///
+    /// The lookup uses the style's EFFECTIVE numId (its own `numPr` numId or
+    /// the nearest `basedOn` ancestor's, §17.7.4.17) so a derived style that
+    /// only inherits its list still finds its own association. A style whose
+    /// chain carries no numbering never fires — which also discharges
+    /// §17.9.23's "not a paragraph style → can be ignored" clause, since only
+    /// styles with (inherited) paragraph numbering are affected.
+    ///
+    /// Call once after BOTH `styles.xml` and `numbering.xml` are parsed.
+    pub fn resolve_numbering_level_backlinks(&mut self, num_map: &crate::numbering::NumberingMap) {
+        let ids: Vec<String> = self.styles.keys().cloned().collect();
+        for id in ids {
+            let Some(num_id) = self.effective_num_id(&id) else {
+                continue;
+            };
+            if let Some(level) = num_map.level_for_style(num_id, &id) {
+                if let Some(def) = self.styles.get_mut(&id) {
+                    def.para.num_level = Some(level);
+                }
+            }
+        }
+    }
+
+    /// The style's EFFECTIVE numId: its own `pPr/numPr/numId` or the nearest
+    /// `basedOn` ancestor's (§17.7.4.17 style inheritance). Hop-capped so a
+    /// malformed `basedOn` cycle terminates.
+    fn effective_num_id(&self, id: &str) -> Option<u32> {
+        let mut cur = id;
+        for _ in 0..=self.styles.len() {
+            let def = self.styles.get(cur)?;
+            if def.para.num_id.is_some() {
+                return def.para.num_id;
+            }
+            cur = def.based_on.as_deref()?;
+        }
+        None
+    }
+
     /// Resolve a character style (rStyle, §17.3.2.29) chain WITHOUT prepending
     /// docDefaults or the default paragraph style. ECMA-376 §17.7.2 (Style
     /// Hierarchy) layers character styles ON TOP of the paragraph's


### PR DESCRIPTION
## Summary

User report: multilevel section headings render **flat** — Word shows `2 / 2.1 / 2.2` but we render `2 / 3 / 4`.

Investigation ran in two phases:

1. **sample-13 (first suspect): not reproducible.** Its headings resolve correctly (`1. / 2. / A. / (none) / 3. / 4.`, matching its PDF) because its template *redundantly* writes explicit `<w:ilvl>` in each heading style. A characterization test pins that path (commit 1).
2. **sample-28 (Arabic RTL, the real target): reproduced and fixed.** Two unimplemented §17.9 mechanisms; before the fix the whole outline flattened to a single sequence `1..43`.

## Root cause 1 — §17.9.23 `<w:lvl><w:pStyle>` backlink dropped (commit 2)

sample-28 authors its outline the way Word's *Define Multilevel List → Link level to style* does:

```xml
<!-- styles.xml: numId only, NO ilvl -->
<w:style w:styleId="KPMGHeading2" ...>
  <w:pPr><w:numPr><w:numId w:val="19"/></w:numPr> ...</w:pPr>
</w:style>

<!-- numbering.xml: abstractNum 67 — the level names the style BACK -->
<w:lvl w:ilvl="1"> ... <w:pStyle w:val="KPMGHeading2"/><w:lvlText w:val="%1.%2"/> ... </w:lvl>
```

**§17.9.23**: paragraphs of that style "shall automatically utilize this numbering level", and "any numbering level defined by the numPr element [of the style] shall be ignored". The parser dropped the backlink and defaulted the style's missing ilvl to 0 (`styles.rs` `parse_para_fmt`), so every KPMG heading advanced the level-0 counter — the reported `2, 3, 4`.

**Fix (style layer):** after both parts parse, `StyleMap::resolve_numbering_level_backlinks` folds each level's `<w:pStyle>` backlink into that style's `num_level` (`NumberingMap::level_for_style`, keyed by the style's chain-effective numId per §17.7.4.17). Rewriting at the style layer keeps every downstream rule for free: `basedOn` children inherit the corrected level through the normal cascade, and a paragraph's DIRECT `<w:ilvl>` (Tab demotion) still outranks it (§17.7.2). No per-sample logic.

## Root cause 2 — §17.9.7 full `<w:lvl>` lvlOverride dropped (commit 3)

sample-28's numId 76 overrides **every** level of its abstract (single-token `%1.` / `%2.` / `%3.`) with cross-level compositions (`%1.` / `%1.%2.` / `%1.%2.%3.`) via `<w:lvlOverride><w:lvl>`. The parser only read `<w:startOverride>` and ignored full-lvl substitutions, so the deliverables heading rendered `1.` instead of **`4.2.1.`** (PDF p.12; the four level-0 / two level-1 primers are `w:vanish`-hidden paragraphs that Word still counts — as do we).

**Fix:** extract `parse_level_def` (verbatim) and reuse it for lvlOverride children; store substitutions per (numId, ilvl); `get_level` consults them first so lvlText/numFmt/indents/rPr/pStyle substitute everywhere. Formatting-only overrides do **not** restart the shared abstract counter — that still requires `<w:startOverride>` (§17.9.27); pinned by test.

## sample-28 heading numbers — before / after / ground truth

Ground truth = sample-28.pdf (Word output). The docx's own cached TOC agrees except one **stale** entry (see note).

| PDF page | Heading (Arabic) | Before | **After** | PDF |
|---|---|---|---|---|
| 4 | الملحق الأول: لمحة عامة | 1 | **1** | 1 |
| 4 | نبذه عن رؤية المملكة… 2030 | 1.1 | **1.1** | 1.1 |
| 5 | نبذة عن برنامج التحول الوطني | 1.2 | **1.2** | 1.2 |
| 6 | نبذة عن وزارة العدل | 1.3 | **1.3** | 1.3 |
| 7 | الملحق الثاني: نبذه عن الخدمة المطلوبة | 2 | **2** | 2 |
| 7 | إسم المشروع | ~~3~~ | **2.1** | 2.1 |
| 7 | التاريخ المستهدف لبداية المشروع | ~~4~~ | **2.2** | 2.2 |
| 7 | مدة المشروع | ~~5~~ | **2.3** | 2.3 |
| 7 | موقع العمل | ~~6~~ | **2.4** | 2.4 |
| 7 | وصف عام للخدمة المطلوبة | ~~7~~ | **2.5** | 2.5 |
| 8 | وصف تفصيلي للخدمة المطلوبة | (none) | **(none)** | (none) ¹ |
| 10 | مقدمة | 1.4 | **1.4** | 1.4 |
| 11 | متطلبات تجهيز بيئات العمل | 1.5 | **1.5** | 1.5 |
| 12 | المخرجات Deliverables | ~~1.~~ | **4.2.1.** | 4.2.1. |
| 12 | المعايير المطلوبة | ~~8~~ | **2.6** | 2.6 |
| 13 | الملحق الثالث: المتطلبات | ~~9~~ | **3** | 3 |
| 13 | المستندات المطلوبة | ~~10~~ | **3.1** | 3.1 |
| 13 | المستندات الرسمية أو القانونية | ~~11~~ | **3.1.1** | 3.1.1 |
| 13 | (7 certificate items) | ~~12–18~~ | **3.1.1.1–3.1.1.7** | 3.1.1.1–7 |
| 13 | المستندات الفنية والخبرات السابقة | ~~19~~ | **3.1.2** | 3.1.2 |
| 13 | (2 items) | ~~20–21~~ | **3.1.2.1–2** | 3.1.2.1–2 |
| 13 | (6 items) | ~~22–27~~ | **3.1.3–3.1.8** | 3.1.3–8 |
| 14 | تعليمات التسليم | ~~28~~ | **3.2** | 3.2 |
| 14 | (8 items) | ~~29–36~~ | **3.2.1–3.2.8** | 3.2.1–8 |
| 15 | الملحق الرابع: النماذج المرفقة | ~~37~~ | **4** | 4 |
| 15 | نموذج معلومات عن المتنافس | ~~38~~ | **4.1** | 4.1 |
| 17–23 | (5 more نموذج headings) | ~~39–43~~ | **4.2–4.6** | 4.2–4.6 |

¹ De-listed via direct `<w:numPr><w:numId w:val="0"/></w:numPr>` (§17.3.1.19) — unnumbered in the body and in the PDF. The docx's cached TOC still says "2.6 وصف تفصيلي": a **stale field cache** (author de-listed after the last TOC update). The PDF (p.12: `2.6 المعايير المطلوبة`) is authoritative and matches our output. We render the cached TOC text verbatim, as Word does without a field update.

## Regression evidence

- **Full parsed-model SHA-256, before vs after, all 31 private samples + demo/sample-1: byte-identical except sample-28.** In particular the list-regression set sample-6/8/9/11/12 and sample-13 are untouched (renderer input identical ⇒ render identical).
- **docx VRT: 84/84 pass.** sample-28 pages 7/12/13/14/15/16/19/20 show small in-threshold diffs exactly where numbering corrected (e.g. p13: 975 px = 0.2%); references **not** updated (user-approval item). demo/sample-1 pages 1–3 diffs are pre-existing baseline noise (model byte-identical).
- **cargo**: fmt clean, clippy `-D warnings` clean, `cargo test --lib` **285 passed** (280 base + 5 new).
- **WASM** rebuilt via `pnpm --filter @silurus/ooxml-docx wasm` (reinit injection intact). Root `tsc --build` + package typechecks pass. `ast-grep scan` clean.
- TS parity: none needed — `number-format.ts` (core) is the ST_NumberFormat formatter only; level resolution and `%N` composition live in the Rust parser, and the renderer draws `numbering.text` verbatim.

## Commits

1. `test(docx)`: end-to-end characterization of the pStyle-chain multilevel path (sample-13 shape — already-correct, pinned).
2. `fix(docx)`: §17.9.23 lvl/pStyle backlink resolution (+ 3 zip-level tests incl. direct-ilvl-wins and stale-style-ilvl-ignored).
3. `feat(docx)`: §17.9.7 full `<w:lvl>` lvlOverride substitution (+ 2 tests incl. no-restart-without-startOverride).

Cross-package note: §17.9 numbering (`numbering.xml`, style backlinks, lvlOverride) is WordprocessingML-only — DrawingML lists (pptx `a:lvlNpPr`) and xlsx have no equivalent constructs, so no cross-package hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
