### PR TITLE
fix(docx): honor a hard page break that opens a paragraph (sample-28 p.15 table/body overlap)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1331,18 +1331,28 @@ fn split_para_on_page_breaks(para: DocParagraph) -> Vec<ParaPiece> {
     };
 
     let mut out: Vec<ParaPiece> = Vec::new();
-    let mut emitted_para = false;
     for (i, runs) in chunks.into_iter().enumerate() {
         // Drop the leading chunk when it carries no visible content — this
         // happens when the paragraph starts with <w:lastRenderedPageBreak/>
         // (Word's hint duplicating a paragraph-level break that the
-        // surrounding section break already covers).
+        // surrounding section break already covers), OR with a HARD
+        // `<w:br w:type="page"/>` (ECMA-376 §17.3.1.20): "this paragraph begins
+        // on a new page". The empty chunk carries no runs, but its trailing
+        // separator (seps[0], emitted below for chunk 1) is the hard break that
+        // MUST still advance the page — dropping it silently would let the
+        // paragraph's text overprint whatever ends this page (private/sample-28
+        // p.15: an "Annex 4" heading that opens with a page break, followed by a
+        // page-anchored floating table, was drawn on the preceding list's page).
+        // RenderedPage hints never reach `seps` (they are filtered above), so this
+        // never re-honors the ignored hint.
         if i == 0 && !has_visible(&runs) {
             continue;
         }
-        if emitted_para {
-            // seps[i-1] separates chunk[i-1] from chunk[i]; emit its kind
-            // (page vs column) so the boundary type is preserved.
+        // seps[i-1] separates chunk[i-1] from chunk[i]; emit its kind (page vs
+        // column) so the boundary type is preserved. Every chunk after the first
+        // is preceded by a real hard break — including chunk 1 when chunk 0 was an
+        // empty leading chunk (a paragraph that opens with a hard break).
+        if i > 0 {
             out.push(match seps.get(i - 1) {
                 Some(ParaPiece::ColumnBreak) => ParaPiece::ColumnBreak,
                 _ => ParaPiece::PageBreak,
@@ -1351,7 +1361,6 @@ fn split_para_on_page_breaks(para: DocParagraph) -> Vec<ParaPiece> {
         let mut chunk = para.clone();
         chunk.runs = runs;
         out.push(ParaPiece::Para(chunk));
-        emitted_para = true;
     }
     if out.is_empty() {
         out.push(ParaPiece::Para(para));
@@ -12155,6 +12164,65 @@ mod column_tests {
         assert!(matches!(body[2], BodyElement::Paragraph(_)));
         assert!(matches!(body[3], BodyElement::ColumnBreak));
         assert!(matches!(body[4], BodyElement::Paragraph(_)));
+    }
+
+    /// ECMA-376 §17.3.1.20 — a `<w:br w:type="page"/>` that is the FIRST run of a
+    /// paragraph (before any visible content) means "this paragraph begins on a new
+    /// page". The leading empty chunk (nothing precedes the break) must NOT swallow
+    /// the break: the body must be PageBreak, Para("annex"), so the paragraph is
+    /// pushed to the next page. Regression from private/sample-28 p.15, where an
+    /// "Annex 4" heading that starts with a page break — followed by a page-anchored
+    /// floating table — was drawn on the SAME page as the preceding list, letting the
+    /// list text overprint the table.
+    #[test]
+    fn leading_page_break_in_paragraph_still_advances_page() {
+        let body = body_from(
+            r#"<w:p><w:r><w:t>before</w:t></w:r></w:p>
+               <w:p>
+                 <w:r><w:br w:type="page"/></w:r>
+                 <w:r><w:t>annex</w:t></w:r>
+               </w:p>"#,
+        );
+        // Para(before), PageBreak, Para(annex).
+        assert_eq!(body.len(), 3);
+        assert!(matches!(body[0], BodyElement::Paragraph(_)));
+        assert!(matches!(body[1], BodyElement::PageBreak { .. }));
+        assert!(matches!(body[2], BodyElement::Paragraph(_)));
+    }
+
+    /// The leading-break rule preserves the break KIND: a paragraph that opens with a
+    /// `<w:br w:type="column"/>` yields ColumnBreak, Para(...) — not PageBreak.
+    #[test]
+    fn leading_column_break_in_paragraph_emits_column_break() {
+        let body = body_from(
+            r#"<w:p>
+                 <w:r><w:br w:type="column"/></w:r>
+                 <w:r><w:t>next-col</w:t></w:r>
+               </w:p>"#,
+        );
+        // ColumnBreak, Para(next-col).
+        assert_eq!(body.len(), 2);
+        assert!(matches!(body[0], BodyElement::ColumnBreak));
+        assert!(matches!(body[1], BodyElement::Paragraph(_)));
+    }
+
+    /// A leading `<w:lastRenderedPageBreak/>` (Word's ignored layout hint, not a hard
+    /// break) must still be stripped WITHOUT injecting a body-level break — only a
+    /// hard `<w:br w:type="page"/>` advances the page. Guards the leading-break fix
+    /// against re-honoring the hint (package CLAUDE.md: never mix honoring/ignoring
+    /// `<w:lastRenderedPageBreak/>`).
+    #[test]
+    fn leading_rendered_page_break_hint_does_not_advance_page() {
+        let body = body_from(
+            r#"<w:p><w:r><w:t>before</w:t></w:r></w:p>
+               <w:p>
+                 <w:r><w:lastRenderedPageBreak/><w:t>heading</w:t></w:r>
+               </w:p>"#,
+        );
+        // Para(before), Para(heading) — the rendered-page hint is dropped, no break.
+        assert_eq!(body.len(), 2);
+        assert!(matches!(body[0], BodyElement::Paragraph(_)));
+        assert!(matches!(body[1], BodyElement::Paragraph(_)));
     }
 
     /// ECMA-376 §17.5.2 — a "Cover Pages" building block (sdt with


### PR DESCRIPTION
## Summary

Fixes the reported table/body overlap on **sample-28 p.15** (the user's report said "sample-13 p.15", but sample-13 is only 5 pages and renders cleanly — the real file is `private/sample-28.docx`, the Arabic RTL Ministry-of-Justice form; its footer reads "Page 15 of 22/23/24").

**Symptom:** a page-anchored floating table (the competitor-info form, `vertAnchor="page"`, `tblpY=123pt`) was drawn on the same page as the preceding delivery-instructions list, so the list body text overprinted the table cells. Exactly the reported "本文が表の後ろに重なる／本文が続くなら表は次ページへ送られるべき".

## Diagnosis (confirmed, spec-first)

- **Table type:** all sample-28 floating tables are `vertAnchor="page"` (`tblpPr`), NOT block tables. So this is a **table×body** overlap, outside #867's `kind==='table'` (table×table) deferral scope — consistent with the task's leading hypothesis.
- **Root cause is in the parser, not the paginator.** The "الملحق الرابع" (Annex 4) heading paragraph begins with `<w:br w:type="page"/>` as its **first run**, immediately followed by the page-anchored float table. `split_para_on_page_breaks` (`packages/docx/parser/src/parser.rs`) split the paragraph into chunks around the break, dropped the empty *leading* chunk (correct — no visible content), but the old `emitted_para` gate meant the separating break was only emitted *after* a para had already been emitted. For a paragraph that OPENS with a hard break, chunk 0 is empty and skipped, so the break in `seps[0]` was **never emitted** — the page break was silently swallowed.
- **Why it manifests as overlap:** with the break lost, the heading + `vertAnchor="page"` float stayed on the list's page (our page 15). The paginator places a page-anchored table at its absolute `tblpY=123pt` regardless of the in-flow cursor, so it painted over the list text already occupying that band. `preRegisterPageFloats` registers only image/shape floats (never tables), so the body lines never wrapped around it either — but the true fix is upstream: restore the dropped page break.

### Regression / bisect
Not a regression from #845/#867 (those touch only `tblpPr` float-table row-split / table×table deferral; this bug is in paragraph-break parsing and predates them). Confirmed by the swallowed-break mechanism being independent of the float-table paginator path.

## Fix (`§17.3.1.20`)

`split_para_on_page_breaks`: emit the separating break before every chunk after the first (`i > 0`) — including chunk 1 when chunk 0 was an empty leading chunk — instead of gating on `emitted_para`. A `<w:br w:type="page"/>` (or `column`) as a paragraph's first run now advances the page/column, matching Word. Ignored `<w:lastRenderedPageBreak/>` hints never reach `seps`, so the hint is still never honored (package CLAUDE.md rule preserved; covered by a new guard test).

## Before / after (measured, width=595, A4)

| | our page 15 | our page 16 | Word PDF |
|---|---|---|---|
| **before** | 3.2 list **+** Annex-4 heading **+** float table (list overprints table) | (next content) | PDF p.14 = 3.2 list; PDF p.15 = Annex-4 heading + table, clean |
| **after** | 3.2 delivery-instructions list only (clean) | Annex-4 heading + float table (clean, no overlap) | matches PDF p.14 / p.15 |

Page count: sample-28 **22 → 24** (Word PDF is 23; the ±1 residual is the known #868 pagination difference, unrelated to this overlap).

## Validation

- **Parser tests:** `cargo test --lib` → **282 passed** (3 new: leading page-break advances page, leading column-break preserved, leading `lastRenderedPageBreak` hint still dropped).
- **docx TS units:** `vitest run packages/docx/src` → **876 passed**.
- **Typecheck:** `pnpm --filter @silurus/ooxml-docx typecheck` clean.
- **Rust gates:** `cargo fmt --all` + `cargo clippy --all-targets -D warnings` clean.
- **ast-grep:** `pnpm lint` (0 errors) + `pnpm lint:test` (3/3 rules pass).
- **VRT** (`pnpm --filter @silurus/ooxml-docx vrt`): **84/84 passed.**
  - demo/sample-1: byte-identical to committed refs (small pre-existing AA noise only); 6 pages unchanged.
  - Float-table samples 9/10/18/21/24: byte-identical — none has a paragraph opening with a hard break (24 in VRT = 100% match).
  - **sample-28: pages 1–14 = 100% match; pages 15–22 diff 3–9%** vs the committed 22-page refs — this is the intended fix (content shifted by one page). **References were NOT updated** (user-approval item): the sample-28 refs still encode the 22-page overlapping output and should be regenerated with `UPDATE_REFS=1` once the 24-page output is approved.

## Touched files
- `packages/docx/parser/src/parser.rs` — `split_para_on_page_breaks` leading-break fix + 3 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)