### PR TITLE
feat(pptx): piecewise-affine strip subdivision for envelope-warped WordArt glyphs

### DIFF
--- a/packages/node/src/pptx-text-warp.probe.test.ts
+++ b/packages/node/src/pptx-text-warp.probe.test.ts
@@ -421,4 +421,63 @@ describe.skipIf(!skia)('node WordArt text-warp geometry (prstTxWarp)', () => {
     // Measured: single-affine ≈1.00 (fails), strips ≈1.30 (passes).
     expect(rightH / leftH).toBeGreaterThan(1.12);
   });
+
+  it('high-curvature envelopes (rings/pours) stay contiguous — no radial slivers', async () => {
+    // Regression guard for the ADAPTIVE strip count. On ring/pour envelopes the
+    // edge tangent sweeps up to ~345° across the width, so with a fixed
+    // width-only strip count adjacent strips rotate apart faster than the ±1px
+    // overlap can bridge: each glyph shatters into a fan of disconnected radial
+    // slivers (measured: "WARP" in textRingOutside split into dozens of
+    // 8-connected ink components; a contiguous render has one component per
+    // detached glyph part). The deviation-driven subdivision keeps every strip
+    // within 1 device px of the exact envelope map, so the ink stays connected.
+    // "WARP" is four single-piece letters — allow a small margin for warped
+    // letters splitting at hairline joins, but a sliver fan (>>8) must fail.
+    for (const preset of ['textCirclePour', 'textRingOutside', 'textCanUp']) {
+      const width = 400;
+      const height = 240;
+      const canvas = new Canvas(width, height);
+      await renderSlideNode(
+        canvas as unknown as Parameters<typeof renderSlideNode>[0],
+        buildSlide(preset),
+        0,
+        { width, dpr: 1, factory: warpFactory },
+      );
+      const ctx = canvas.getContext('2d');
+      const data = ctx.getImageData(0, 0, width, height).data as unknown as Uint8ClampedArray;
+      const grid = new Uint8Array(width * height);
+      let inkPx = 0;
+      for (let p = 0; p < width * height; p++) {
+        const i = p * 4;
+        const lum = 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+        if (data[i + 3] > 40 && lum < 128) { grid[p] = 1; inkPx++; }
+      }
+      expect(inkPx).toBeGreaterThan(100);
+      // 8-connected component count over the ink mask.
+      const seen = new Uint8Array(width * height);
+      const stack: number[] = [];
+      let comps = 0;
+      for (let start = 0; start < width * height; start++) {
+        if (!grid[start] || seen[start]) continue;
+        comps++;
+        stack.length = 0;
+        stack.push(start);
+        seen[start] = 1;
+        while (stack.length) {
+          const p = stack.pop() as number;
+          const x = p % width, y = (p / width) | 0;
+          for (let dy = -1; dy <= 1; dy++) for (let dx = -1; dx <= 1; dx++) {
+            if (!dx && !dy) continue;
+            const nx = x + dx, ny = y + dy;
+            if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+            const np = ny * width + nx;
+            if (grid[np] && !seen[np]) { seen[np] = 1; stack.push(np); }
+          }
+        }
+      }
+      // eslint-disable-next-line no-console
+      console.log(`${preset}: inkPx=${inkPx} components=${comps}`);
+      expect(comps).toBeLessThanOrEqual(8);
+    }
+  });
 });

--- a/packages/node/src/pptx-text-warp.probe.test.ts
+++ b/packages/node/src/pptx-text-warp.probe.test.ts
@@ -32,10 +32,23 @@ import { importForTests, loadSkiaForTests } from './test-imports';
 
 const skia = await loadSkiaForTests();
 type Skia = typeof import('skia-canvas');
-const { Canvas } = (skia ?? {}) as Skia;
+const { Canvas, loadImage } = (skia ?? {}) as Skia;
 
 const renderMod = await importForTests(() => import('./render.ts'), './render.ts');
 const { renderSlideNode } = (renderMod ?? {}) as typeof import('./render.ts');
+type NodeCanvasFactory = import('./render.ts').NodeCanvasFactory;
+// A canvas factory so renderSlideNode installs the OffscreenCanvas shim: the
+// paired-edge warp path renders each glyph to an auxiliary canvas and blits it in
+// strips (piecewise-affine envelope), which needs `createAuxCanvas` to succeed.
+// Without the factory that allocation returns null and the renderer falls back to
+// the single-affine per-glyph draw — so passing it here is what exercises the
+// real strip code in CI.
+const warpFactory: NodeCanvasFactory | undefined = skia
+  ? {
+      createCanvas: (w, h) => new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+      loadImage: (b) => loadImage(b as Buffer) as unknown as ReturnType<NodeCanvasFactory['loadImage']>,
+    }
+  : undefined;
 
 const EMU_PER_PX = 9525; // 96 dpi
 const px = (n: number) => Math.round(n * EMU_PER_PX);
@@ -144,6 +157,7 @@ async function renderInk(preset: string): Promise<{
   await renderSlideNode(canvas as unknown as Parameters<typeof renderSlideNode>[0], buildSlide(preset), 0, {
     width,
     dpr,
+    factory: warpFactory,
   });
   const ctx = canvas.getContext('2d');
   const img = ctx.getImageData(0, 0, width * dpr, height * dpr);
@@ -290,7 +304,7 @@ describe.skipIf(!skia)('node WordArt text-warp geometry (prstTxWarp)', () => {
       canvas as unknown as Parameters<typeof renderSlideNode>[0],
       buildSlide('textWave1'),
       0,
-      { width, dpr: 1 },
+      { width, dpr: 1, factory: warpFactory },
     );
     const ctx = canvas.getContext('2d');
     const data = ctx.getImageData(0, 0, width, height).data as unknown as Uint8ClampedArray;
@@ -341,5 +355,70 @@ describe.skipIf(!skia)('node WordArt text-warp geometry (prstTxWarp)', () => {
     // tilt could not do that.
     expect(Math.max(...shifts)).toBeGreaterThan(2);
     expect(Math.min(...shifts)).toBeLessThan(-2);
+  });
+
+  it('textInflate stretches a single glyph MORE on its centre-facing edge (piecewise-affine strips)', async () => {
+    // The definitive strip-subdivision invariant. On Inflate the envelope gap
+    // (top→bottom) is TALLEST at the box centre and shrinks toward the ends, and
+    // the gap stays VERTICAL everywhere (top/bottom mirror-symmetric) — so shear
+    // and angle are ~0 and the only warp is a vertical stretch that VARIES with x.
+    // A single per-glyph affine (#866) samples that stretch at ONE u (the glyph
+    // centre) and applies it uniformly, leaving a wide glyph the SAME height on
+    // its left and right edges. Mapping the glyph outline continuously (as
+    // PowerPoint does) makes the edge nearer the box centre taller. We render a
+    // single wide glyph sitting in the LEFT half of the box and require its RIGHT
+    // (centre-facing) edge to be meaningfully taller than its LEFT edge. Strips
+    // reproduce this; the single affine cannot (ratio ≈ 1).
+    const width = 400;
+    const height = 240;
+    const canvas = new Canvas(width, height);
+    // A wide glyph then filler so the measured glyph lands left-of-centre.
+    const slide = buildSlide('textInflate');
+    // Swap the run text to "W....." (wide W, dotted filler pushes it left).
+    (slide.slides[0].elements[0] as ShapeElement).textBody!.paragraphs[0].runs[0] = {
+      type: 'text', text: 'W.....', bold: true, italic: null, underline: false,
+      strikethrough: false, fontSize: 40, color: '000000', fontFamily: 'Arial',
+    } as Paragraph['runs'][number];
+    await renderSlideNode(
+      canvas as unknown as Parameters<typeof renderSlideNode>[0],
+      slide,
+      0,
+      { width, dpr: 1, factory: warpFactory },
+    );
+    const ctx = canvas.getContext('2d');
+    const data = ctx.getImageData(0, 0, width, height).data as unknown as Uint8ClampedArray;
+    const inked = (x: number, y: number): boolean => {
+      const i = (y * width + x) * 4;
+      const a = data[i + 3];
+      const lum = 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+      return a > 40 && lum < 128;
+    };
+    const span = (x: number): number | null => {
+      let t = -1, b = -1;
+      for (let y = 0; y < height; y++) if (inked(x, y)) { if (t < 0) t = y; b = y; }
+      return t < 0 ? null : b - t + 1;
+    };
+    // Leftmost inked column, then the first glyph block (until an >8px empty gap).
+    let minX = width;
+    for (let x = 0; x < width; x++) if (span(x) != null) { minX = x; break; }
+    let gx1 = minX, gap = 0;
+    for (let x = minX; x < width; x++) {
+      if (span(x) != null) { gx1 = x; gap = 0; }
+      else { gap++; if (gap > 8 && gx1 > minX + 4) break; }
+    }
+    const gw = gx1 - minX;
+    expect(gw).toBeGreaterThan(10);
+    const edgeH = (f: number): number => {
+      const c = Math.round(minX + gw * f);
+      let s = 0, n = 0;
+      for (let x = c - 1; x <= c + 1; x++) { const v = span(x); if (v != null) { s += v; n++; } }
+      return n ? s / n : 0;
+    };
+    const leftH = edgeH(0.15);
+    const rightH = edgeH(0.85);
+    expect(leftH).toBeGreaterThan(0);
+    // Centre-facing (right) edge is at least 12% taller than the outer (left) edge.
+    // Measured: single-affine ≈1.00 (fails), strips ≈1.30 (passes).
+    expect(rightH / leftH).toBeGreaterThan(1.12);
   });
 });

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1341,6 +1341,152 @@ function clearShadow(ctx: CanvasRenderingContext2D) {
   ctx.shadowOffsetY = 0;
 }
 
+// ── WordArt paired-edge warp: piecewise-affine strip subdivision ─────────────
+//
+// A single glyph is drawn once to this reusable offscreen canvas (at device
+// resolution, so it stays crisp on HiDPI), then blitted onto the envelope one
+// vertical STRIP at a time. Reused across glyphs so a warped title does not
+// churn one canvas allocation per character. `null` in headless test envs with
+// no OffscreenCanvas/document (createAuxCanvas returns null); the caller then
+// falls back to the single-affine per-glyph draw.
+let warpGlyphAux: ReturnType<typeof createAuxCanvas> = null;
+function warpGlyphOffscreen(w: number, h: number): ReturnType<typeof createAuxCanvas> {
+  const cw = Math.max(1, Math.ceil(w));
+  const ch = Math.max(1, Math.ceil(h));
+  const cur = warpGlyphAux;
+  if (!cur || cur.width < cw || cur.height < ch) {
+    // Grow-only: allocate the max seen so far so we rarely reallocate. A fresh
+    // canvas starts transparent; we clear the used sub-rect before each glyph.
+    warpGlyphAux = createAuxCanvas(Math.max(cw, cur?.width ?? 0), Math.max(ch, cur?.height ?? 0));
+  }
+  return warpGlyphAux;
+}
+
+// Target strip width in DEVICE px. The per-strip affine (the #866 Jacobian
+// evaluated at the strip's centre-u) approximates the true envelope map with an
+// edge error that grows as the SQUARE of the strip's u-span, so bounding the
+// device-px width bounds the error independent of shape/glyph size. Measured on
+// the warp fixture's presets (320×160 shape), an 8-device-px strip keeps the
+// worst-case edge misplacement under 0.3 px for every paired-edge preset
+// (Inflate/Deflate ≈0.1 px, the higher-curvature Wave1 ≈0.28 px) — sub-pixel, so
+// the piecewise approximation is invisible. Cascade/Chevron envelopes are
+// piecewise-LINEAR (`m l l`), so their per-strip affine is exact at any width;
+// they ride the same path for a single, preset-agnostic code path (no preset
+// branch, no empirical constant — §20.1.9.19's envelope map is the sole basis).
+const WARP_STRIP_DEVICE_PX = 8;
+// Overlap each strip by ~1 device px on each side so the sub-pixel seam gap
+// between adjacent strips (≈0.8 shape px, measured) is covered with no visible
+// hairline. The overlap is symmetric, so it does not bias the mapping.
+const WARP_STRIP_OVERLAP_DEVICE_PX = 1;
+
+/**
+ * Draw one glyph across a PAIRED-EDGE warp envelope as a stack of vertical
+ * strips (piecewise-affine approximation of the envelope map, ECMA-376
+ * §20.1.9.19).
+ *
+ * The #866 per-glyph transform samples the envelope's local Jacobian at a SINGLE
+ * u (the glyph centre) and applies one affine (rotate + shear + non-uniform
+ * scale) to the whole glyph. That is exact only where the map is locally affine;
+ * on Inflate/Deflate the vertical stretch `vScale` varies WITHIN a glyph (the
+ * top/bottom edges are mirror-symmetric so the gap stays vertical — shear 0,
+ * angle 0 — but the gap MAGNITUDE peaks at the centre and shrinks toward the
+ * ends), which a single affine cannot represent: it leaves the glyph uniformly
+ * scaled instead of stretched more where the envelope is taller. PowerPoint maps
+ * the glyph OUTLINE continuously through `P(u,v) = (1−v)·T(u) + v·B(u)`, so a
+ * wide glyph leans/stretches asymmetrically across its own width.
+ *
+ * Subdividing the glyph into narrow strips and mapping each strip by the Jacobian
+ * at ITS centre-u converges to that continuous map as the strip count grows (the
+ * general solution — no preset special-casing). Each strip is a vertical slice of
+ * the pre-rendered glyph bitmap, drawn with the strip's own affine; the shared
+ * strip edges land within a sub-pixel of each other, and a ~1px overlap hides the
+ * seam.
+ *
+ * The reusable offscreen `gAux` already carries THIS glyph, rendered at
+ * `devScale` with the glyph pen-origin at device-x `padDev` and the baseline at
+ * device-y `blY`; the offscreen is `auxDevH` device px tall (ascent above the
+ * baseline + descent below). `chW` is the glyph's flat advance (css px, incl.
+ * letter-spacing). `flatX0` is the glyph's flat left edge along the whole line
+ * (css px). The remaining args mirror the per-glyph draw: `hScale` stretches flat
+ * ink to the box width, `warpBoxH`/`bandFrac` drive `warpGlyphTransform`,
+ * `boxX`/`boxY` are the shape origin, `totalW`/`followScale` map flat-x to the
+ * envelope fraction u.
+ */
+function drawWarpedGlyphStrips(
+  ctx: CanvasRenderingContext2D,
+  gAux: NonNullable<ReturnType<typeof createAuxCanvas>>,
+  devScale: number,
+  padDev: number,
+  blY: number,
+  auxDevH: number,
+  env: WarpEnvelope,
+  chW: number,
+  flatX0: number,
+  totalW: number,
+  followScale: number,
+  hScale: number,
+  warpBoxH: number,
+  bandFrac: number,
+  boxX: number,
+  boxY: number,
+): void {
+  if (chW <= 0) return;
+  // Strip count: one strip per WARP_STRIP_DEVICE_PX of the glyph's WARPED advance
+  // (chW·hScale is the on-envelope width). ≥1; the error bound is per-strip so a
+  // wide "W" gets more strips than a thin "l".
+  const warpedAdvDev = chW * hScale * devScale;
+  const k = Math.max(1, Math.round(warpedAdvDev / WARP_STRIP_DEVICE_PX));
+  // The offscreen ink top row is `blY` device px above the baseline; the whole
+  // offscreen (auxDevH tall) maps to a css slab of height auxDevH/devScale whose
+  // baseline (row blY) sits at local y = 0.
+  const dstH = auxDevH / devScale;
+  const dstY = -blY / devScale;
+  for (let j = 0; j < k; j++) {
+    // Strip's flat sub-range within the glyph advance, [s0, s1] in css px from
+    // the glyph's flat left edge (pen origin).
+    const s0 = (j / k) * chW;
+    const s1 = ((j + 1) / k) * chW;
+    const stripCenterFlat = flatX0 + (s0 + s1) / 2;
+    const u = (stripCenterFlat / totalW) * followScale;
+    const g = warpGlyphTransform(env, u, warpBoxH, bandFrac);
+
+    // Source rect on the offscreen (device px): the glyph pen origin is at
+    // device-x `padDev`, so flat-x `s` maps to device-x `padDev + s·devScale`.
+    // Grow by the overlap on each side (clamped to the offscreen) so neighbours
+    // share a hair of pixels and no seam shows.
+    const srcX0 = Math.max(0, padDev + s0 * devScale - WARP_STRIP_OVERLAP_DEVICE_PX);
+    const srcX1 = Math.min(gAux.width, padDev + s1 * devScale + WARP_STRIP_OVERLAP_DEVICE_PX);
+    const srcW = srcX1 - srcX0;
+    if (srcW <= 0) continue;
+
+    ctx.save();
+    // Same transform chain as the single-affine per-glyph draw, but anchored at
+    // the STRIP centre so vScale/shear/angle track this slice's u.
+    ctx.translate(boxX + g.x, boxY + g.y);
+    ctx.rotate(g.angle);
+    if (g.shear !== 0) ctx.transform(1, 0, g.shear, 1, 0, 0);
+    if (hScale !== 1 || g.vScale !== 1) ctx.scale(hScale, g.vScale);
+    // Map the offscreen slice into this strip's local frame: a source pixel at
+    // device-x `sx` sits at flat-x `(sx − padDev)/devScale` from the pen origin,
+    // so its local x (relative to the strip centre `(s0+s1)/2`) is
+    // `(sx − padDev)/devScale − (s0+s1)/2`.
+    const dstX = (srcX0 - padDev) / devScale - (s0 + s1) / 2;
+    const dstW = srcW / devScale;
+    ctx.drawImage(
+      gAux as CanvasImageSource,
+      srcX0,
+      0,
+      srcW,
+      auxDevH,
+      dstX,
+      dstY,
+      dstW,
+      dstH,
+    );
+    ctx.restore();
+  }
+}
+
 /**
  * Render a WordArt text body through its `<a:prstTxWarp>` envelope (ECMA-376
  * §20.1.9.19). Canvas 2D cannot deform glyph outlines, so this is the standard
@@ -1422,6 +1568,22 @@ function renderWarpedText(
   ctx.save();
   ctx.textAlign = 'left';
   ctx.textBaseline = 'alphabetic';
+
+  // Device scale folded into the live transform (dpr · slide scale), so glyph
+  // bitmaps for the paired-edge strip path are rasterised at the same pixel
+  // density as the canvas — no HiDPI blur. sqrt(|det|) of the transform's linear
+  // part is dpr regardless of rotation/flip (same idiom as the scene3d/effect
+  // offscreens). Computed LAZILY on the first paired-edge glyph only: single-edge
+  // (Follow Path) warps never allocate an offscreen, and some unit tests drive a
+  // mock ctx without getTransform, so the single-edge path must never touch it.
+  let devScaleCache = -1;
+  const getDevScale = (): number => {
+    if (devScaleCache >= 0) return devScaleCache;
+    const tf = typeof ctx.getTransform === 'function' ? ctx.getTransform() : null;
+    const det = tf ? Math.abs(tf.a * tf.d - tf.b * tf.c) : 1;
+    devScaleCache = det > 0 ? Math.sqrt(det) : 1;
+    return devScaleCache;
+  };
 
   const lineCount = lines.length;
   for (let li = 0; li < lineCount; li++) {
@@ -1507,14 +1669,51 @@ function renderWarpedText(
       const chars = [...seg.text];
       for (const ch of chars) {
         const chW = ctx.measureText(ch).width + ls;
+        // Blend the per-line vertical band into the baseline fraction so line 2
+        // sits below line 1 within the envelope.
+        const bandFrac = v0 + baselineFrac * (v1 - v0);
+
+        // Paired-edge (envelope) presets: the envelope map is NON-affine within a
+        // glyph (on Inflate/Deflate the vertical stretch varies across the glyph's
+        // own width; on waves the slope does), so a single per-glyph affine loses
+        // that intra-glyph deformation. Draw the glyph via piecewise-affine STRIPS
+        // (each strip's affine sampled at its own centre-u) so the mapping
+        // converges to PowerPoint's continuous outline warp (§20.1.9.19). The
+        // single-edge (Follow Path) branch below is UNCHANGED (byte-identical):
+        // its glyphs are rigidly rotated onto a baseline, already exact per glyph.
+        if (!env.singleEdge && chW > 0) {
+          const drawn = drawWarpedGlyphViaStrips(
+            ctx,
+            ch,
+            seg.font,
+            seg.color,
+            ls,
+            chW,
+            getDevScale(),
+            env,
+            penW,
+            totalW,
+            followScale,
+            hScale,
+            warpBoxH,
+            bandFrac,
+            boxX,
+            boxY,
+          );
+          if (drawn) {
+            penW += chW;
+            continue;
+          }
+          // Offscreen unavailable (headless env) → fall through to single-affine.
+          ctx.font = seg.font;
+          ctx.fillStyle = seg.color;
+        }
+
         // Horizontal fraction of THIS glyph's centre along the whole line,
         // scaled by the Follow Path factor so single-edge (arch/circle) text
         // spans only its natural arc length from the start rather than the whole
         // path. `followScale` is 1 for paired-edge presets (unchanged).
         const u = ((penW + chW / 2) / totalW) * followScale;
-        // Blend the per-line vertical band into the baseline fraction so line 2
-        // sits below line 1 within the envelope.
-        const bandFrac = v0 + baselineFrac * (v1 - v0);
         const g = warpGlyphTransform(env, u, warpBoxH, bandFrac);
         ctx.save();
         ctx.translate(boxX + g.x, boxY + g.y);
@@ -1536,6 +1735,92 @@ function renderWarpedText(
     }
   }
   ctx.restore();
+}
+
+/**
+ * Render one glyph to the reusable offscreen and blit it across a paired-edge
+ * warp via {@link drawWarpedGlyphStrips}. Returns `false` when no offscreen
+ * canvas is available (headless test env with neither OffscreenCanvas nor
+ * document), so the caller can fall back to the single-affine per-glyph draw.
+ *
+ * The offscreen is sized to the glyph's measured ink (ascent above baseline +
+ * descent below, plus the left side-bearing) at `devScale`, with a small pad so
+ * strokes that overhang the pen advance (italic tails, wide accents) are not
+ * clipped. `penW` is the flat advance consumed BEFORE this glyph on the line.
+ */
+function drawWarpedGlyphViaStrips(
+  ctx: CanvasRenderingContext2D,
+  ch: string,
+  font: string,
+  color: string,
+  ls: number,
+  chW: number,
+  devScale: number,
+  env: WarpEnvelope,
+  penW: number,
+  totalW: number,
+  followScale: number,
+  hScale: number,
+  warpBoxH: number,
+  bandFrac: number,
+  boxX: number,
+  boxY: number,
+): boolean {
+  ctx.font = font;
+  const m = ctx.measureText(ch);
+  // Ink extents around the baseline (fallbacks keep degenerate metrics safe).
+  const asc = m.actualBoundingBoxAscent > 0 ? m.actualBoundingBoxAscent : chW;
+  const desc = m.actualBoundingBoxDescent > 0 ? m.actualBoundingBoxDescent : chW * 0.25;
+  // Left side-bearing: ink may start left of the pen origin (e.g. italic 'f').
+  const lsb = m.actualBoundingBoxLeft > 0 ? m.actualBoundingBoxLeft : 0;
+  const rsb = m.actualBoundingBoxRight > chW ? m.actualBoundingBoxRight - chW : 0;
+  // css pad on each side so overhang and the strip overlap have room.
+  const padCss = Math.max(lsb, rsb, 2);
+  const padDev = Math.ceil(padCss * devScale);
+  const ascDev = Math.ceil(asc * devScale);
+  const descDev = Math.ceil(desc * devScale);
+  const auxDevW = padDev + Math.ceil((chW + padCss) * devScale);
+  const auxDevH = ascDev + descDev;
+  const gAux = warpGlyphOffscreen(auxDevW, auxDevH);
+  if (!gAux) return false;
+  const gctx = gAux.getContext('2d') as CanvasRenderingContext2D | null;
+  if (!gctx) return false;
+
+  // Paint the glyph: baseline at device row `ascDev`, pen origin at device-x
+  // `padDev`. Clear only the used sub-rect (grow-only offscreen may be larger).
+  gctx.save();
+  gctx.setTransform(1, 0, 0, 1, 0, 0);
+  gctx.clearRect(0, 0, auxDevW, auxDevH);
+  gctx.scale(devScale, devScale);
+  gctx.textAlign = 'left';
+  gctx.textBaseline = 'alphabetic';
+  gctx.font = font;
+  gctx.fillStyle = color;
+  // Shift right by half the letter-spacing so the ink is centred in its advance,
+  // matching the single-affine draw's `-chW/2 + ls/2` origin convention.
+  gctx.fillText(ch, padCss + ls / 2, asc);
+  gctx.restore();
+
+  const flatX0 = penW;
+  drawWarpedGlyphStrips(
+    ctx,
+    gAux,
+    devScale,
+    padDev,
+    ascDev,
+    auxDevH,
+    env,
+    chW,
+    flatX0,
+    totalW,
+    followScale,
+    hScale,
+    warpBoxH,
+    bandFrac,
+    boxX,
+    boxY,
+  );
+  return true;
 }
 
 /**

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -80,7 +80,7 @@ import {
   warpGlyphTransform,
   followPathUScale,
 } from '@silurus/ooxml-core';
-import type { WarpEnvelope } from '@silurus/ooxml-core';
+import type { WarpEnvelope, WarpGlyphTransform } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput, BevelRegion } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
 import type { HyperlinkTarget } from '@silurus/ooxml-core';
@@ -1362,22 +1362,49 @@ function warpGlyphOffscreen(w: number, h: number): ReturnType<typeof createAuxCa
   return warpGlyphAux;
 }
 
-// Target strip width in DEVICE px. The per-strip affine (the #866 Jacobian
-// evaluated at the strip's centre-u) approximates the true envelope map with an
-// edge error that grows as the SQUARE of the strip's u-span, so bounding the
-// device-px width bounds the error independent of shape/glyph size. Measured on
-// the warp fixture's presets (320×160 shape), an 8-device-px strip keeps the
-// worst-case edge misplacement under 0.3 px for every paired-edge preset
-// (Inflate/Deflate ≈0.1 px, the higher-curvature Wave1 ≈0.28 px) — sub-pixel, so
-// the piecewise approximation is invisible. Cascade/Chevron envelopes are
-// piecewise-LINEAR (`m l l`), so their per-strip affine is exact at any width;
-// they ride the same path for a single, preset-agnostic code path (no preset
-// branch, no empirical constant — §20.1.9.19's envelope map is the sole basis).
+// BASE strip width in DEVICE px — the coarse first guess only; the adaptive
+// deviation loop below is what actually guarantees accuracy. Width alone bounds
+// just the chord-vs-curve error of the BASELINE curve (∝ width², sub-pixel at
+// 8 px for every preset), but NOT the error away from the baseline: a slab
+// corner at distance d from the baseline anchor is additionally misplaced by
+// the angle/vScale mismatch across the strip (≈ d·Δangle + |y|·ΔvScale), which
+// at 8 px width is measured at ~0.7 px (Inflate) to ~0.2 px (Wave1/Chevron) at
+// the baseline but grows to several px at the em-box extremes (Wave1 ≈2.4,
+// Button ≈5.9) and tens of px on high-curvature ring/pour families
+// (CirclePour ≈11, CanUp ≈44 at em-box edges) — the strips fan apart into
+// radial slivers. Hence the width criterion is only the starting k; the
+// deviation-driven refinement below subdivides until every painted corner is
+// within WARP_STRIP_DEVIATION_BUDGET_DEVICE_PX of the exact envelope map.
 const WARP_STRIP_DEVICE_PX = 8;
-// Overlap each strip by ~1 device px on each side so the sub-pixel seam gap
-// between adjacent strips (≈0.8 shape px, measured) is covered with no visible
-// hairline. The overlap is symmetric, so it does not bias the mapping.
+// Overlap each strip by 1 device px on each side, so adjacent strips share
+// 2 device px of source. Combined with the deviation budget below (each strip's
+// painted corners within 1 px of the exact map ⇒ adjacent strips diverge by at
+// most 2 px at a shared boundary), the overlap fully covers the worst seam and
+// no hairline can show. The overlap is symmetric, so it does not bias the map.
 const WARP_STRIP_OVERLAP_DEVICE_PX = 1;
+// Max deviation (device px) of any painted slab corner from the EXACT envelope
+// map, enforced by the adaptive loop. Derivation: the true map places the
+// glyph's vertical ruling at flat-x b onto Q(b, y) = A(u_b)·(0, y), where A(u)
+// is the envelope's local frame at u (anchor T(u)+bandFrac·gap, advance-axis
+// angle, gap shear/scale — exactly what warpGlyphTransform returns). A strip
+// centred at c paints that same ruling at S(b, y) = A(u_c)·(b−c, y). The
+// deviation |S−Q| at the slab's four corners (both strip edges × slab
+// top/bottom) is the exact per-strip error of the piecewise-affine map — it
+// contains ALL mismatch components at once: rotational fan-out d·Δangle
+// (dominant on rings/pours, whose tangent sweeps up to ~345°), vertical-scale
+// slide |y|·ΔvScale (dominant on textButton, whose mean-tangent angle is
+// constant 0 so a pure angle criterion would miss it), and the baseline chord
+// error. Two adjacent strips each deviate ≤ budget from the SAME true ruling at
+// their shared boundary, so their mutual crack is ≤ 2·budget = the 2 device px
+// of shared overlap — i.e. budget 1 is the largest value the overlap provably
+// covers. Every quantity is geometric; no preset branch.
+const WARP_STRIP_DEVIATION_BUDGET_DEVICE_PX = 1;
+// Hard cap on strips per glyph, bounding draw cost for extreme geometry (one
+// glyph sweeping a large arc of a ring at high em-height). At the cap the
+// residual deviation is reported by the loop's last measurement and the seam
+// stays proportional (a full-ring glyph at ~250 device px em-height measures a
+// few px — degraded but bounded, and localized to that pathological glyph).
+const WARP_STRIP_MAX_PER_GLYPH = 256;
 
 /**
  * Draw one glyph across a PAIRED-EDGE warp envelope as a stack of vertical
@@ -1397,10 +1424,14 @@ const WARP_STRIP_OVERLAP_DEVICE_PX = 1;
  *
  * Subdividing the glyph into narrow strips and mapping each strip by the Jacobian
  * at ITS centre-u converges to that continuous map as the strip count grows (the
- * general solution — no preset special-casing). Each strip is a vertical slice of
- * the pre-rendered glyph bitmap, drawn with the strip's own affine; the shared
- * strip edges land within a sub-pixel of each other, and a ~1px overlap hides the
- * seam.
+ * general solution — no preset special-casing). The count is chosen ADAPTIVELY:
+ * from a base width criterion, strips double until every painted corner deviates
+ * from the exact envelope map by at most 1 device px (see
+ * WARP_STRIP_DEVIATION_BUDGET_DEVICE_PX), so high-curvature envelopes (rings,
+ * pours — tangent sweep up to ~345°) subdivide as finely as they need while flat
+ * ones stay coarse. Each strip is a vertical slice of the pre-rendered glyph
+ * bitmap, drawn with the strip's own affine; adjacent strips then diverge ≤ 2
+ * device px at their shared boundary, which the ±1 px overlap covers.
  *
  * The reusable offscreen `gAux` already carries THIS glyph, rendered at
  * `devScale` with the glyph pen-origin at device-x `padDev` and the baseline at
@@ -1431,25 +1462,56 @@ function drawWarpedGlyphStrips(
   boxY: number,
 ): void {
   if (chW <= 0) return;
-  // Strip count: one strip per WARP_STRIP_DEVICE_PX of the glyph's WARPED advance
-  // (chW·hScale is the on-envelope width). ≥1; the error bound is per-strip so a
-  // wide "W" gets more strips than a thin "l".
-  const warpedAdvDev = chW * hScale * devScale;
-  const k = Math.max(1, Math.round(warpedAdvDev / WARP_STRIP_DEVICE_PX));
   // The offscreen ink top row is `blY` device px above the baseline; the whole
   // offscreen (auxDevH tall) maps to a css slab of height auxDevH/devScale whose
   // baseline (row blY) sits at local y = 0.
   const dstH = auxDevH / devScale;
   const dstY = -blY / devScale;
-  for (let j = 0; j < k; j++) {
-    // Strip's flat sub-range within the glyph advance, [s0, s1] in css px from
-    // the glyph's flat left edge (pen origin).
-    const s0 = (j / k) * chW;
-    const s1 = ((j + 1) / k) * chW;
-    const stripCenterFlat = flatX0 + (s0 + s1) / 2;
-    const u = (stripCenterFlat / totalW) * followScale;
-    const g = warpGlyphTransform(env, u, warpBoxH, bandFrac);
 
+  // ── Adaptive strip count ──────────────────────────────────────────────────
+  // Start from the width criterion (one strip per WARP_STRIP_DEVICE_PX of the
+  // glyph's WARPED advance, chW·hScale·devScale), then DOUBLE the count until
+  // every painted slab corner is within the deviation budget of the exact
+  // envelope map (see WARP_STRIP_DEVIATION_BUDGET_DEVICE_PX for the formula and
+  // why the budget ties to the overlap). Deviation from the smooth part of the
+  // envelope halves with each doubling (it is ∝ the strip's u-span to first
+  // order), so the loop converges in a few steps for arcs of any curvature —
+  // this is what keeps high-curvature ring/pour envelopes (tangent sweep up to
+  // ~345°) contiguous instead of fanning into radial slivers. If a doubling
+  // fails to reduce the deviation by ≥ 25 %, the residual sits at a C0 corner of
+  // the envelope itself (e.g. the chevron apex): the true map genuinely creases
+  // there, refinement can only narrow the affected band — keep the finer
+  // partition and stop rather than spinning to the cap.
+  const warpedAdvDev = chW * hScale * devScale;
+  let k = Math.min(
+    WARP_STRIP_MAX_PER_GLYPH,
+    Math.max(1, Math.round(warpedAdvDev / WARP_STRIP_DEVICE_PX)),
+  );
+  const build = (count: number): WarpStrip[] =>
+    buildWarpStrips(count, env, chW, flatX0, totalW, followScale, warpBoxH, bandFrac);
+  let strips = build(k);
+  let dev = maxWarpStripDeviationDev(
+    strips, env, flatX0, totalW, followScale, warpBoxH, bandFrac, hScale, devScale, dstY, dstY + dstH,
+  );
+  while (dev > WARP_STRIP_DEVIATION_BUDGET_DEVICE_PX && k < WARP_STRIP_MAX_PER_GLYPH) {
+    const k2 = Math.min(WARP_STRIP_MAX_PER_GLYPH, k * 2);
+    const strips2 = build(k2);
+    const dev2 = maxWarpStripDeviationDev(
+      strips2, env, flatX0, totalW, followScale, warpBoxH, bandFrac, hScale, devScale, dstY, dstY + dstH,
+    );
+    if (dev2 >= dev * 0.75) {
+      // Not converging: C0 crease in the envelope (see above). The finer
+      // partition still localizes the crease to a narrower strip — keep it.
+      strips = strips2;
+      break;
+    }
+    k = k2;
+    strips = strips2;
+    dev = dev2;
+  }
+
+  for (const strip of strips) {
+    const { s0, s1, g } = strip;
     // Source rect on the offscreen (device px): the glyph pen origin is at
     // device-x `padDev`, so flat-x `s` maps to device-x `padDev + s·devScale`.
     // Grow by the overlap on each side (clamped to the offscreen) so neighbours
@@ -1485,6 +1547,94 @@ function drawWarpedGlyphStrips(
     );
     ctx.restore();
   }
+}
+
+/** One strip of a glyph: flat sub-range `[s0, s1]` (css px from the glyph's flat
+ *  left edge / pen origin) and the envelope frame sampled at its centre-u. */
+interface WarpStrip {
+  s0: number;
+  s1: number;
+  g: WarpGlyphTransform;
+}
+
+/** Uniform-in-u partition of a glyph's advance into `k` strips, each carrying
+ *  the envelope frame at its own centre-u. */
+function buildWarpStrips(
+  k: number,
+  env: WarpEnvelope,
+  chW: number,
+  flatX0: number,
+  totalW: number,
+  followScale: number,
+  warpBoxH: number,
+  bandFrac: number,
+): WarpStrip[] {
+  const strips: WarpStrip[] = new Array(k);
+  for (let j = 0; j < k; j++) {
+    const s0 = (j / k) * chW;
+    const s1 = ((j + 1) / k) * chW;
+    const u = ((flatX0 + (s0 + s1) / 2) / totalW) * followScale;
+    strips[j] = { s0, s1, g: warpGlyphTransform(env, u, warpBoxH, bandFrac) };
+  }
+  return strips;
+}
+
+/** Apply a strip's affine (scale → shear → rotate → translate, the same chain
+ *  the draw path pushes onto the canvas) to a strip-local css point. */
+function mapWarpLocalPoint(
+  g: WarpGlyphTransform,
+  hScale: number,
+  x: number,
+  y: number,
+): { x: number; y: number } {
+  const sx = x * hScale;
+  const sy = y * g.vScale;
+  const hx = sx + g.shear * sy;
+  const c = Math.cos(g.angle);
+  const s = Math.sin(g.angle);
+  return { x: g.x + c * hx - s * sy, y: g.y + s * hx + c * sy };
+}
+
+/**
+ * Worst-case deviation (device px) of the strips' painted slab corners from the
+ * EXACT envelope map — the quantity the adaptive loop drives under the budget.
+ *
+ * For each strip edge b (a boundary of the flat sub-range), the exact map
+ * places the glyph ruling at `Q(b, y) = A(u_b)·(0, y)` — the envelope frame
+ * sampled AT the boundary — while the strip paints it at
+ * `S(b, y) = A(u_centre)·(b − centre, y)`. `|S − Q|` is evaluated at the slab's
+ * top and bottom (`yTop`/`yBot`, css, baseline-relative) for both edges of
+ * every strip; the max over all of them bounds every painted pixel's error
+ * (corners are the extreme points of an affine image of a rectangle).
+ */
+function maxWarpStripDeviationDev(
+  strips: WarpStrip[],
+  env: WarpEnvelope,
+  flatX0: number,
+  totalW: number,
+  followScale: number,
+  warpBoxH: number,
+  bandFrac: number,
+  hScale: number,
+  devScale: number,
+  yTop: number,
+  yBot: number,
+): number {
+  let max = 0;
+  for (const strip of strips) {
+    const centre = (strip.s0 + strip.s1) / 2;
+    for (const b of [strip.s0, strip.s1]) {
+      const uB = ((flatX0 + b) / totalW) * followScale;
+      const gB = warpGlyphTransform(env, uB, warpBoxH, bandFrac);
+      for (const y of [yTop, yBot]) {
+        const q = mapWarpLocalPoint(gB, hScale, 0, y);
+        const p = mapWarpLocalPoint(strip.g, hScale, b - centre, y);
+        const d = Math.hypot(p.x - q.x, p.y - q.y) * devScale;
+        if (d > max) max = d;
+      }
+    }
+  }
+  return max;
 }
 
 /**


### PR DESCRIPTION
## Problem

PR #866 draws WordArt paired-edge (envelope) warps per glyph with a **single affine** — the local Jacobian of the envelope map `P(u,v) = (1−v)·T(u) + v·B(u)` sampled at the glyph centre (rotate + shear + non-uniform vertical scale). That is exact only where the map is locally affine.

**Inflate/Deflate** are the reported failure case: their top and bottom edges are mirror-symmetric, so the gap vector `B(u)−T(u)` is always vertical (shear 0, angle 0) — but its **magnitude** varies across a glyph's own width (tallest toward the box centre). A single per-glyph affine applies one uniform vertical scale, so a wide glyph came out the same height on its left and right edges, and adjacent glyphs stair-stepped instead of tracing one continuous curve. PowerPoint maps the glyph **outline** continuously through the envelope (ECMA-376 §20.1.9.19) — a fundamental limitation of one affine per glyph, not a tuning issue.

## Approach — piecewise-affine strips with deviation-driven adaptive count

**Commit 1** subdivides each glyph into vertical **strips**, each mapped by `warpGlyphTransform` sampled at **its own** centre-u; each glyph is rendered once to a reusable device-resolution offscreen and blitted per strip. As the strip count grows this converges to the true map — no preset branch, no empirical constant.

**Commit 2** (review fix) makes the strip count **adaptive**, driven by the exact error of the piecewise map. For each strip edge `b`, the true map places the glyph ruling at `Q(b,y) = A(u_b)·(0,y)` (the frame `warpGlyphTransform` returns at the boundary), while the strip paints it at `S(b,y) = A(u_centre)·(b−centre,y)`. `|S−Q|` at the slab corners is the **complete** per-strip error — it simultaneously contains:

- rotational fan-out `d·Δangle` (dominant on ring/pour envelopes, whose edge tangent sweeps up to ~345°),
- vertical-scale slide `|y|·ΔvScale` (dominant on textButton, whose mean-tangent angle is constant 0 — a pure angle-change criterion would miss it entirely),
- the baseline chord error.

Strips double until this deviation ≤ **1 device px**: two adjacent strips each within 1 px of the *same* true ruling diverge ≤ 2 px, which the 2 device px of shared overlap provably covers — that is the derivation tying the budget to the overlap. If a doubling fails to reduce the deviation by ≥ 25 %, the residual sits at a C0 corner of the envelope itself (chevron apex — a genuine crease that refinement can only localize), so the loop keeps the finer partition and stops instead of spinning to the `WARP_STRIP_MAX_PER_GLYPH = 256` cap. **No preset fallback branch anywhere.**

**Single-edge (Follow Path — Arch/Circle, #856) is untouched and byte-identical.** Device scale is read lazily on the first paired-edge glyph only.

## Error analysis (corrected per independent review)

The original claim "8-px strips keep error < 0.3 px for every preset" was **wrong** — it held only near the baseline of the low-curvature fixture presets. Corrected measurements for the fixed 8-device-px width (before the adaptive loop): baseline-vicinity Inflate 0.72 / Wave1 0.19 / Chevron 0.12 px, but at em-box extremes Wave1 ≈2.4 / Button ≈5.9 / CirclePour ≈11 / CanUp ≈44 px — the ring/pour families shattered into radial slivers (a 5-letter word: **156 ink components** on textRingOutside, 21 on textCirclePour).

With the adaptive loop (representative 28-css-px glyph, dpr 2):

| Preset | k (width → adaptive) | deviation (device px) |
|---|---|---|
| textButton | 30 → 240 | 6.07 → **0.76** |
| textCirclePour | 30 → 240 | 5.61 → **0.70** |
| textRingOutside | 30 → 240 | 4.73 → **0.59** |
| textArchUpPour | 30 → 60 | 1.59 → **0.79** |
| textInflate / Deflate / Wave1 / Cascade / Chevron | 30 → 30 | 0.03–0.71 (already ≤ budget) |

Ink components ("Round"): CirclePour 21 → **5**, RingOutside 156 → **4**, CanUp/Button/ArchUpPour stable at 5. The fixed renders are contiguous, readable text bending around the ring — better than both the sliver regression *and* the single-affine baseline (rigid flat letters at discrete rotations).

## Verification

### Intra-glyph asymmetry (the originally reported defect) — unchanged by the review fix

Wide glyph in the box's left half; right (centre-facing) edge ink-height ÷ left edge:

| Preset | single affine | strips | expected (PowerPoint PDF) |
|---|---|---|---|
| Inflate | 0.98 | **1.30** | centre bulge ✓ |
| Deflate | 0.98 | **0.72** | centre pinch ✓ |

Regression test asserts `right/left > 1.12` for Inflate; fails on the single-affine baseline (0.977).

### Reviewed presets preserved after the adaptive change

Pixel diff of the adaptive build vs the previously reviewed strip build: Inflate / Cascade / Chevron / ArchUp / ArchDown / Circle **0.000 %**; Deflate 1.13 % and Wave1 0.77 % refine further toward the exact map (those glyphs exceeded the 1 px budget and subdivided). vs the single-affine baseline the paired-edge presets still differ 5–7.6 %, single-edge 0.000 %.

### Seams

Hairline-gap scan: 0 candidates on all fixture presets; 1–2 isolated 2-px candidates on CirclePour/ArchUpPour whole-word renders (vs thousands of gap pixels in the sliver regression).

### Performance

`renderSlide`, dpr 2, median: fixture slide (8 warps) 2.5 ms (single affine) → 10.6 ms (fixed width) → **11.9 ms** (adaptive). Worst high-curvature case: textCirclePour, 5 glyphs × k=240 ≈ 1200 blits → **6.8 ms**/slide; textRingOutside 5.8 ms.

### Gates

- pptx vitest **349 passed**, core shape **182 passed**, core text-warp **19 passed**
- node warp probe **6 passed** (+ sliver guard: components ≤ 8 on CirclePour/RingOutside/CanUp — fails on the width-only revision with 34 components, passes here)
- pptx renderer + node probe typecheck **0 errors**; ast-grep unchanged (3 pre-existing warnings, no new `as unknown as`)
- pptx demo VRT: all demo tests pass — visual regression 9 slides byte-identical, worker equivalence (3 slides + selection/findText/zoom + IX-nav) ✓

## Files
- `packages/pptx/src/renderer.ts` — strip subdivision draw path + deviation-driven adaptive strip count (paired-edge only)
- `packages/node/src/pptx-text-warp.probe.test.ts` — factory to exercise strips in CI, intra-glyph asymmetry regression test, high-curvature sliver guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
