### PR TITLE
test(docx): sample-28 VRT page count 24 after leading page-break fix

### DIFF
--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -23,7 +23,7 @@ const DOCX_FILES: { name: string; pageCount: number; width: number }[] = [
   // sample-27 = continuous section-break page-number restart fixture (US Letter, 612pt).
   { name: 'private/sample-27', pageCount: 2, width: 612 },
   // sample-28 = Arabic RTL long-form (A4).
-  { name: 'private/sample-28', pageCount: 22, width: 595 },
+  { name: 'private/sample-28', pageCount: 24, width: 595 },
   // sample-29 = Thai script (A4).
   { name: 'private/sample-29', pageCount: 14, width: 595 },
   // sample-30 = Korean script (A4).


### PR DESCRIPTION
One-line follow-up to #871 (same pattern as #869): the VRT matrix still declares pageCount 22 for private/sample-28, so runs ignore the pages added by the leading-page-break fix. Bumps to 24 (current renderer output; Word PDF is 23 — the +1 residual is the known #868 keep-with-anchor item).

Private references regenerated locally per the approved reference-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)