### PR TITLE
fix(charts): span the primary value axis over combo bar+line series

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -3014,3 +3014,111 @@ describe('canvas state leak (#766) — renderChart restores ctx state', () => {
     expect(after.baseline).toBe('alphabetic');
   });
 });
+
+describe('CH — combo bar+line primary value axis spans BOTH the bars and the primary-axis line (§21.2.2.16 / §21.2.2.76)', () => {
+  // A stacked-column + line combo (bar + line series sharing ONE `<c:valAx>`,
+  // e.g. xlsx sample-9 "MONTHLY OVERVIEW"). The bars stack to a per-category
+  // maximum well BELOW the line's tallest point. Excel scales the shared
+  // primary value axis to encompass every series plotted on it, regardless of
+  // chart type — so the axis top must cover the line, not just the bar stack.
+  //
+  // Recreates sample-9's data: 3 stacked bar series (max category sum 150) plus
+  // one primary-axis line "Amount Spent" whose tallest point is 180. Excel draws
+  // the axis $0..$200; before the fix the renderer sized the axis to the bar sum
+  // alone (150 → 160) and the 180 line point overshot the top gridline into the
+  // chart title.
+  const numericValLabels = (rec: Recorded): number[] =>
+    rec.texts
+      .map(t => Number(String(t.text).replace(/[^0-9.\-]/g, '')))
+      .filter(v => Number.isFinite(v));
+
+  it('the primary-axis line pushes the axis maximum above the stacked-bar sum', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBar',
+      categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul'],
+      series: [
+        series({ name: 'Birthday',  seriesType: 'bar',  values: [20, 0, 0, 0, 0, 50, 0] }),
+        series({ name: 'Holiday',   seriesType: 'bar',  values: [0, 0, 0, 0, 0, 0, 50] }),
+        series({ name: 'Other',     seriesType: 'bar',  values: [0, 0, 0, 20, 0, 100, 0] }),
+        // Primary-axis line: NOT on a secondary axis. Tallest point 180 > the
+        // stacked bar's per-category max sum of 150.
+        series({ name: 'Amount Spent', seriesType: 'line', values: [30, 0, 0, 20, 0, 180, 70] }),
+      ],
+    }), RECT, 1);
+    const nums = numericValLabels(rec);
+    const axisMax = Math.max(...nums);
+    // Excel draws $0..$200 for this data. The axis top must at minimum cover the
+    // line's 180 (the bug capped it at 160, hiding the tallest line point).
+    expect(axisMax).toBeGreaterThanOrEqual(180);
+    // And it must be the next nice unit above 180 — 200 — not an over-scaled
+    // value. (niceAxisMax(180, step=50) with headroom = 200.)
+    expect(axisMax).toBe(200);
+  });
+
+  it('WITHOUT the line, the same bars alone scale the axis to just cover 150 (isolates the line contribution)', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBar',
+      categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul'],
+      series: [
+        series({ name: 'Birthday', seriesType: 'bar', values: [20, 0, 0, 0, 0, 50, 0] }),
+        series({ name: 'Holiday',  seriesType: 'bar', values: [0, 0, 0, 0, 0, 0, 50] }),
+        series({ name: 'Other',    seriesType: 'bar', values: [0, 0, 0, 20, 0, 100, 0] }),
+      ],
+    }), RECT, 1);
+    const axisMax = Math.max(...numericValLabels(rec));
+    // Bars alone: max category sum 150 → axis top 160 (unchanged by the fix).
+    expect(axisMax).toBe(160);
+    // The line contribution is what lifts the previous case from 160 to 200.
+  });
+
+  it('a negative primary-axis line pulls the axis minimum below the bars', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBar',
+      categories: ['A', 'B'],
+      series: [
+        series({ name: 'Bar',  seriesType: 'bar',  values: [40, 40] }),
+        // Positive-only bars would anchor the axis at 0; the line dips to -30.
+        series({ name: 'Line', seriesType: 'line', values: [10, -30] }),
+      ],
+    }), RECT, 1);
+    const nums = numericValLabels(rec);
+    // Some negative tick label appears (axis min < 0), covering the -30 line point.
+    expect(nums.some(v => v <= -30)).toBe(true);
+  });
+
+  it('a SECONDARY-axis line does NOT inflate the primary axis (guards over-scaling)', () => {
+    // When a line rides its own right-hand `<c:valAx>` (secondaryValAxis +
+    // useSecondaryAxis), its large values live on the secondary scale and must
+    // NOT stretch the primary (bar) axis — the two axes are independent. We prove
+    // this by the invariant: the primary bar geometry is byte-identical whether
+    // the secondary line is present or absent. If the 950 line leaked onto the
+    // primary axis, the primary scale would jump ~24× and the bars would shrink.
+    const bars = (secondaryLine: boolean): RectCall[] => {
+      const rec = recordingCtx();
+      const s: ChartSeries[] = [series({ name: 'Bar', seriesType: 'bar', values: [40, 40] })];
+      if (secondaryLine) {
+        s.push(series({ name: 'Line', seriesType: 'line', values: [900, 950], useSecondaryAxis: true }));
+      }
+      renderChart(rec.ctx, baseModel({
+        chartType: 'stackedBar',
+        categories: ['A', 'B'],
+        series: s,
+        secondaryValAxis: secondaryLine ? {
+          min: null, max: null, title: null, hidden: false,
+          lineHidden: false, majorTickMark: 'out', majorUnit: null,
+        } : null,
+      }), RECT, 1);
+      return rec.rects;
+    };
+    const withLine = bars(true);
+    const withoutLine = bars(false);
+    // Same two bars, same heights — the secondary line did not touch the primary.
+    expect(withLine.length).toBe(2);
+    expect(withoutLine.length).toBe(2);
+    expect(withLine[0].h).toBeCloseTo(withoutLine[0].h, 4);
+    expect(withLine[1].h).toBeCloseTo(withoutLine[1].h, 4);
+  });
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1145,6 +1145,28 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       dataMin = Math.min(dataMin, negSum);
     }
   }
+  // Combo line series plotted on the PRIMARY value axis (a bar+line chart whose
+  // line rides the same `<c:valAx>` as the bars — no secondary axis, or one the
+  // line doesn't opt into) must expand the primary axis extent just like the
+  // bars do. Excel scales a shared value axis to encompass EVERY series on it,
+  // regardless of chart type; a tall line point can exceed the bar stack (xlsx
+  // sample-9 "MONTHLY OVERVIEW": bars sum to 150 but the line reaches 180, so
+  // Excel draws $0..$200 — sizing to the bars alone would clip the line into the
+  // title). The line is an unstacked overlay, so each raw datum widens the range
+  // directly. Secondary-axis line series are excluded (they own an independent
+  // scale, mirrored by the `yOf` split below). Skipped for percentStacked, whose
+  // axis is definitionally ±100% (§21.2.2.76). `sec` matches the draw-time gate.
+  if (!pct) {
+    for (const s of lineSeries) {
+      if (sec && s.useSecondaryAxis === true) continue;
+      for (let ci = 0; ci < n; ci++) {
+        const v = s.values[ci];
+        if (v == null) continue;
+        dataMax = Math.max(dataMax, v);
+        dataMin = Math.min(dataMin, v);
+      }
+    }
+  }
   if (pct) {
     // percentStacked normalizes each category to Σ|v|; the axis spans the
     // side(s) the data actually reaches (100% up if any positives, -100% down


### PR DESCRIPTION
## Problem

xlsx `private/sample-9.xlsx` (Gift budget and tracker), sheet "Gift budget and tracker", chart "MONTHLY OVERVIEW": **Excel draws the value axis \$0–\$200 but we drew \$0–\$160**. The tallest data point (~\$180) overshot our top gridline and collided with the chart title.

## Diagnosis (spec-first)

`xl/charts/chart1.xml` is a **combo chart**: one `<c:valAx>` (id 428000472) shared by a **stacked** bar group and a **standard** line group.

```xml
<c:barChart><c:grouping val="stacked"/> … </c:barChart>   <!-- 3 bar series -->
<c:lineChart><c:grouping val="standard"/> … </c:lineChart> <!-- 1 line series -->
<c:valAx>…<c:scaling><c:orientation val="minMax"/></c:scaling>…</c:valAx> <!-- auto, no min/max -->
```

Series values (verified by unzip + parse):

| series | type | per-point max | notes |
|---|---|---|---|
| Birthday Budget | bar | 50 | |
| Holiday Budget | bar | 50 | |
| Other Gift Budget | bar | 100 | |
| **Amount Spent** | **line** | **180** | primary axis (`useSecondaryAxis=null`) |

Per-category stacked bar sums peak at **150** (Jun: 50+100). The primary-axis line reaches **180**.

**Root cause** — `renderBarChart` (`packages/core/src/chart/renderer.ts`) filters `barSeries`/`lineSeries` and computes the primary axis extent (`dataMax`/`dataMin`) **from `barSeries` only** (loop at ~L1134). Primary-axis line series are drawn with `toYPrimaryLine` (the `yOf` split at ~L1590) but were **never folded into the axis extent**. So the axis was sized to the bar stack (150 → nice ceiling 160) and the 180 line point ran off the top.

Excel scales a shared value axis to encompass **every** series plotted on it, regardless of chart type — ECMA-376 **§21.2.2.16** (barChart) / **§21.2.2.76** (ST_Grouping). Excel here draws **\$0–\$200** (step 20, headroom above 180).

## Fix

In core `renderBarChart`, after the bar loop, fold each **primary-axis** line series' raw per-point values into `dataMax`/`dataMin`:

- The combo line is an **unstacked overlay**, so each raw datum widens the range directly.
- **Secondary-axis** line series are excluded (`if (sec && s.useSecondaryAxis === true) continue;`) — they own an independent scale, matching the draw-time `yOf` gate.
- Skipped for **percentStacked**, whose axis is definitionally ±100% (§21.2.2.76).

The fix lives in **core** (`packages/core/src/chart/renderer.ts`), so it applies to **xlsx, pptx and docx** combo charts. `renderBarChart` is the only renderer that splits `barSeries`/`lineSeries`; combos always route here (bar takes precedence over line in the parser's `chart_type` resolution), so it's the unique locus of this hole. No empirical constant added — the change is the mathematical necessity that the axis contains the plotted data.

## sample-9 measurement (real parsed model, before/after)

| | value-axis labels | axis max | Excel |
|---|---|---|---|
| **before** | 20…160 | **160** | 200 |
| **after** | 20, 40, …, 180, **200** | **200** | **200** ✅ |

## Non-regression (all 37 charts in the xlsx/pptx/docx corpus)

Each chart parsed via its real WASM parser, rendered through core `renderChart`, and its axis labels + fillRect geometry fingerprinted before vs. after:

| format | charts | changed | combo charts unchanged (line ≤ bars) |
|---|---|---|---|
| xlsx | 17 | **1** (sample-9: 160→200) | 3 (sample-16/18/19) |
| pptx | 13 | **0** | 2 (sample-14 #c2/#c3) |
| docx | 7 | **0** | 1 (sample-24 #c1) |
| **total** | **37** | **1** | 6 |

Only sample-9 changes, in the Excel direction. The six other combo charts whose primary line does not exceed the bar stack are inert (proves no spurious over-scaling), and every non-combo chart is byte-identical (proves the change is scoped to the combo-primary-line path).

## Tests / gates

- **TDD**: 4 new tests in `renderer-correctness.test.ts` (Red→Green) — primary line pushes axis max above the bar stack (sample-9 data → 200); a negative primary line pulls the axis min below 0; the "bars alone → 160" isolator; a secondary-axis line does NOT touch the primary geometry.
- core chart vitest: **267 passed** (incl. `renderer-signature` byte-identical characterization).
- full vitest (core + xlsx + pptx + docx): **3208 passed**.
- root `tsc --build`: clean. `ast-grep scan`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)