### PR TITLE
fix(xlsx): treat shape lnRef idx=0 as no outline (equation text box border)

### DIFF
--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -1064,20 +1064,28 @@ pub(crate) fn collect_shapes(
                     s.children()
                         .find(|n| n.is_element() && n.tag_name().name() == "lnRef")
                 }) {
-                    if let Some(c) = parse_solid_fill(&ln_ref, theme_colors) {
-                        stroke_color = Some(c);
-                        let idx: usize = ln_ref
-                            .attribute("idx")
-                            .and_then(|v| v.parse().ok())
-                            .unwrap_or(0);
-                        // Missing/out-of-range entries fall back to the
-                        // CT_LineProperties default width (§20.1.2.2.24,
-                        // 9525 EMU = 0.75 pt).
-                        stroke_width = if idx >= 1 {
-                            theme_ln_widths.get(idx - 1).copied().unwrap_or(9525)
-                        } else {
-                            9525
-                        };
+                    let idx: usize = ln_ref
+                        .attribute("idx")
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0);
+                    // ST_StyleMatrixColumnIndex (§20.1.10.57): the style-matrix
+                    // lists (`lnStyleLst` etc.) are 1-based, so `idx="0"`
+                    // references NO entry — the well-known DrawingML encoding for
+                    // "no line". Excel / PowerPoint write it when the shape
+                    // outline is set to "No Line" (e.g. sample-28's inserted
+                    // equation text boxes carry `<a:lnRef idx="0">`). The child
+                    // colour is only the phClr substitution that would apply IF a
+                    // line style were selected; with idx=0 none is, so we must not
+                    // draw an outline. Matches pptx `shape.rs` (idx==0 → None).
+                    // Only idx>=1 resolves a themed stroke.
+                    if idx >= 1 {
+                        if let Some(c) = parse_solid_fill(&ln_ref, theme_colors) {
+                            stroke_color = Some(c);
+                            // Missing/out-of-range entries fall back to the
+                            // CT_LineProperties default width (§20.1.2.2.24,
+                            // 9525 EMU = 0.75 pt).
+                            stroke_width = theme_ln_widths.get(idx - 1).copied().unwrap_or(9525);
+                        }
                     }
                 }
             }
@@ -2492,6 +2500,26 @@ mod style_lnref_tests {
         );
         assert_eq!(color.as_deref(), Some("#4472C4"));
         assert_eq!(width, 9_525);
+    }
+
+    /// §20.1.4.2.19 + ST_StyleMatrixColumnIndex (§20.1.10.57): the style-matrix
+    /// lists (`lnStyleLst` etc.) are 1-based, so `<a:lnRef idx="0">` references
+    /// NO entry — it is the well-known DrawingML encoding for "no line". Excel /
+    /// PowerPoint write exactly this when the user sets the shape outline to
+    /// "No Line" (e.g. an inserted equation text box in sample-28, which carries
+    /// `<a:lnRef idx="0"><a:scrgbClr r="0" g="0" b="0"/></a:lnRef>`). The child
+    /// colour is only the phClr substitution that WOULD apply if a line style
+    /// were selected; with idx=0 no style is selected, so no outline is drawn.
+    /// Must yield no stroke — matching pptx's `shape.rs` (idx==0 → None). Before
+    /// the fix xlsx read the colour and drew a spurious 0.75 pt black border.
+    #[test]
+    fn lnref_idx_zero_is_no_line() {
+        let (color, width) = shape_of(
+            "",
+            r#"<xdr:style><a:lnRef idx="0"><a:scrgbClr r="0" g="0" b="0"/></a:lnRef></xdr:style>"#,
+        );
+        assert!(color.is_none(), "lnRef idx=0 → no outline");
+        assert_eq!(width, 0);
     }
 
     /// A standalone `<xdr:pic>` directly under a `twoCellAnchor` is a plain image


### PR DESCRIPTION
## Summary

User-reported (private `sample-28.xlsx`, sheet 1, "Insert > Equation" text box) — visual comparison against Excel:

1. **Spurious outline** — our render drew a thin black border around the equation; Excel shows none. **← fixed here.**
2. **Vertical position "slightly low"** — investigated; our placement is spec-faithful, the residual is a math-engine metric difference, not a placement bug with a clean fix. **← no code change (see below).**

## Diagnosis

### Shape XML (drawing1.xml, the equation text box)

The equation is a stand-alone `<xdr:oneCellAnchor><xdr:sp>` wrapped in a shape-level `<mc:AlternateContent>`:

- **`<mc:Choice Requires="a14">`** — the live shape: `txBody` -> `a:p` -> `a14:m` -> `<m:oMathPara>` (OMML). **This is the branch we take** (`parse_shape_anchors` unwraps `AlternateContent` -> `Choice`, ECMA-376 Part 3 §9.3; the math extracts as a display equation).
- `<mc:Fallback>` — a plain-text linear-notation copy, correctly ignored.

Neither branch carries an explicit `<a:ln>`. Both use:

```xml
<a:noFill/>
<xdr:style>
  <a:lnRef idx="0"><a:scrgbClr r="0" g="0" b="0"/></a:lnRef>
  ...
</xdr:style>
```

### Root cause of the border — `packages/xlsx/parser/src/drawing.rs`

`collect_shapes` (shared by both the grouped and stand-alone shape paths) resolved a stroke from `<a:lnRef>` whenever the ref carried a colour, **without checking `idx`**. With `idx="0"` it read the black `<a:scrgbClr>` and — because `idx==0` fell into the `else` branch — assigned the `9525`-EMU (0.75 pt) default width, painting a border.

Per **ST_StyleMatrixColumnIndex (§20.1.10.57)** the style-matrix lists (`lnStyleLst`, ...) are **1-based**, so `idx="0"` references **no entry** — the well-known DrawingML encoding for **"No Line"**. Excel/PowerPoint write exactly this when the user sets a shape outline to *No Line*. The `<a:lnRef>` child colour is only the `phClr` substitution that would apply *if* a line style were selected; with `idx=0` none is, so no outline may be drawn.

### Fix

Gate the `lnRef` stroke fallback on `idx >= 1`, matching **pptx's `shape.rs`** which already does `if idx == 0 { None }`. `idx>=1` still resolves the themed width/colour exactly as before.

**TDD:** added `style_lnref_tests::lnref_idx_zero_is_no_line` (RED -> GREEN) asserting `idx="0"` + child colour yields no stroke. The existing `idx=2` / `idx=9` / explicit-`ln` tests still pass unchanged.

## Before / after (measured)

Parsed model of the equation shape:

| | before | after |
|---|---|---|
| `strokeColor` | `#000000` | `none` |
| `strokeWidth` (EMU) | `9525` (0.75 pt) | `0` |

Render (Storybook, sheet 1): border **gone**, equation otherwise unchanged.

## Position finding (no code change — spec-first)

Measured analytically (100 % zoom) via the same MathJax path the renderer uses:

- Excel autofit box inner height: **47.99 px** (`cy=457073` EMU, `tIns=bIns=0`).
- Our MathJax (STIX Two Math) raster of the same OMML at 11 pt: ascent 22.35 + descent 16.70 = **39.04 px**.
- Box slack: **8.94 px**.

Placement is spec-faithful:
- Box top = anchor `<xdr:from>` row/rowOff (§20.5.2 oneCellAnchor). Correct.
- Within the box the equation is top-anchored per `<a:bodyPr anchor="t">` (§20.1.7.2). Correct — no spurious offset (`math top = lineTop = y0 = padTop = 0`).

The residual "slightly low/small" comes from **MathJax/STIX rendering this equation ~19 % shorter than Excel's Cambria Math autofit box** (39 px vs 48 px), i.e. a math-engine metric difference, not a layout offset we compute wrong. Adding a vertical compensation offset would be an empirical, single-sample heuristic (forbidden by the repo's spec-first rule), so **no position change is made**. Faithfully matching Word/Excel's OMML metrics is a separate, larger effort (different typesetting engine) and would need explicit approval.

## Cross-package check (horizontal integration)

- **pptx** — already correct (`packages/pptx/parser/src/shape.rs`: `lnRef idx=0 -> None`). Used as the reference for this fix.
- **docx** — does **not** have this over-drawing bug: `packages/docx/parser/src/parser.rs` (~L4879) only reads an explicit `<a:ln>` and never falls back to `<a:lnRef>` for the stroke, so an `idx="0"` shape already draws border-less. (It also means a docx shape relying on `lnRef idx>=1` for a border under-draws — a *missing feature*, not this over-drawing bug — intentionally out of scope here.)
- The `idx=0 -> no line` semantics is a per-package predicate tied to each parser's stroke resolution, so no new shared-layer abstraction is warranted (only pptx + xlsx exercise the lnRef fallback; both now agree).

## Gates

- Rust: `cargo fmt --check` PASS, `cargo clippy -D warnings` PASS, `cargo test` **149 passed** (incl. new test).
- TS: `vitest` xlsx **503 passed** (regression guard; no TS changed). `ast-grep scan` clean.
- WASM rebuilt via `pnpm --filter @silurus/ooxml-xlsx wasm` (reinit injected).
- VRT: `demo/sample-1` **byte-identical** (100.0 %, 0 px diff across all sheets); **worker-equivalence passes** (worker parity intact). Private samples have no committed reference (gitignored) — none updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
