### PR TITLE
fix(pptx): draw warp strips as clipped vector fillText (browser artifacts)

### DIFF
--- a/packages/node/src/pptx-text-warp.probe.test.ts
+++ b/packages/node/src/pptx-text-warp.probe.test.ts
@@ -37,12 +37,11 @@ const { Canvas, loadImage } = (skia ?? {}) as Skia;
 const renderMod = await importForTests(() => import('./render.ts'), './render.ts');
 const { renderSlideNode } = (renderMod ?? {}) as typeof import('./render.ts');
 type NodeCanvasFactory = import('./render.ts').NodeCanvasFactory;
-// A canvas factory so renderSlideNode installs the OffscreenCanvas shim: the
-// paired-edge warp path renders each glyph to an auxiliary canvas and blits it in
-// strips (piecewise-affine envelope), which needs `createAuxCanvas` to succeed.
-// Without the factory that allocation returns null and the renderer falls back to
-// the single-affine per-glyph draw — so passing it here is what exercises the
-// real strip code in CI.
+// A canvas factory so renderSlideNode installs the OffscreenCanvas shim. The
+// paired-edge strip draw itself no longer needs it (each strip is a clipped
+// vector fillText — no auxiliary canvas anywhere), but the factory keeps the
+// rest of the renderer's aux-canvas paths (effects, patterns) live, matching
+// how the browser runs.
 const warpFactory: NodeCanvasFactory | undefined = skia
   ? {
       createCanvas: (w, h) => new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1343,24 +1343,16 @@ function clearShadow(ctx: CanvasRenderingContext2D) {
 
 // ── WordArt paired-edge warp: piecewise-affine strip subdivision ─────────────
 //
-// A single glyph is drawn once to this reusable offscreen canvas (at device
-// resolution, so it stays crisp on HiDPI), then blitted onto the envelope one
-// vertical STRIP at a time. Reused across glyphs so a warped title does not
-// churn one canvas allocation per character. `null` in headless test envs with
-// no OffscreenCanvas/document (createAuxCanvas returns null); the caller then
-// falls back to the single-affine per-glyph draw.
-let warpGlyphAux: ReturnType<typeof createAuxCanvas> = null;
-function warpGlyphOffscreen(w: number, h: number): ReturnType<typeof createAuxCanvas> {
-  const cw = Math.max(1, Math.ceil(w));
-  const ch = Math.max(1, Math.ceil(h));
-  const cur = warpGlyphAux;
-  if (!cur || cur.width < cw || cur.height < ch) {
-    // Grow-only: allocate the max seen so far so we rarely reallocate. A fresh
-    // canvas starts transparent; we clear the used sub-rect before each glyph.
-    warpGlyphAux = createAuxCanvas(Math.max(cw, cur?.width ?? 0), Math.max(ch, cur?.height ?? 0));
-  }
-  return warpGlyphAux;
-}
+// Each glyph is drawn as a stack of vertical STRIPS, every strip re-issuing
+// `fillText` under its own affine with a clip rect bounding the strip's share
+// of the glyph advance. Drawing VECTOR text per strip (instead of slicing a
+// pre-rasterised glyph bitmap, as an earlier revision did) rasterises the
+// glyph at the strip's final device transform, which kills three
+// bitmap-transfer artifact classes a real browser exposed: blur from
+// re-magnifying a raster (vScale stretches up to ~4×), glyph parts cut by the
+// offscreen slab rectangle, and detached hairlines from stretched source-edge
+// antialiasing. It also needs no auxiliary canvas at all, so the draw works
+// identically on the main thread, in a worker, and under headless node.
 
 // BASE strip width in DEVICE px — the coarse first guess only; the adaptive
 // deviation loop below is what actually guarantees accuracy. Width alone bounds
@@ -1376,11 +1368,18 @@ function warpGlyphOffscreen(w: number, h: number): ReturnType<typeof createAuxCa
 // deviation-driven refinement below subdivides until every painted corner is
 // within WARP_STRIP_DEVIATION_BUDGET_DEVICE_PX of the exact envelope map.
 const WARP_STRIP_DEVICE_PX = 8;
-// Overlap each strip by 1 device px on each side, so adjacent strips share
-// 2 device px of source. Combined with the deviation budget below (each strip's
-// painted corners within 1 px of the exact map ⇒ adjacent strips diverge by at
-// most 2 px at a shared boundary), the overlap fully covers the worst seam and
-// no hairline can show. The overlap is symmetric, so it does not bias the map.
+// Extend each strip's CLIP rect by 1 device px into its neighbour on each
+// side. Two abutting clip edges antialiased in separate fill passes leave the
+// classic shared-edge coverage dip (each pass covers the boundary pixel
+// partially; src-over of two ~50 % coverages of colour C over white composes
+// to ~0.75·C, a faint light seam through every glyph) — and the two edges can
+// additionally diverge by up to 2·budget at the ink extremes. Overlapping the
+// clips makes strip i paint the boundary band at FULL coverage before strip
+// i+1's partial-coverage edge lands on top; painting the same opaque colour
+// over itself is idempotent, so the seam vanishes. (For a translucent fill the
+// 2-px band composes twice and darkens slightly — the same trade-off the
+// earlier bitmap overlap had.) The overlap is symmetric, so it does not bias
+// the mapping.
 const WARP_STRIP_OVERLAP_DEVICE_PX = 1;
 // Max deviation (device px) of any painted slab corner from the EXACT envelope
 // map, enforced by the adaptive loop. Derivation: the true map places the
@@ -1395,9 +1394,10 @@ const WARP_STRIP_OVERLAP_DEVICE_PX = 1;
 // slide |y|·ΔvScale (dominant on textButton, whose mean-tangent angle is
 // constant 0 so a pure angle criterion would miss it), and the baseline chord
 // error. Two adjacent strips each deviate ≤ budget from the SAME true ruling at
-// their shared boundary, so their mutual crack is ≤ 2·budget = the 2 device px
-// of shared overlap — i.e. budget 1 is the largest value the overlap provably
-// covers. Every quantity is geometric; no preset branch.
+// their shared boundary, so their mutual divergence is ≤ 2·budget = the
+// 2 device px their overlapping clips share — i.e. budget 1 is the largest
+// value the clip overlap provably covers. Every quantity is geometric; no
+// preset branch.
 const WARP_STRIP_DEVIATION_BUDGET_DEVICE_PX = 1;
 // Hard cap on strips per glyph, bounding draw cost for extreme geometry (one
 // glyph sweeping a large arc of a ring at high em-height). At the cap the
@@ -1429,29 +1429,33 @@ const WARP_STRIP_MAX_PER_GLYPH = 256;
  * from the exact envelope map by at most 1 device px (see
  * WARP_STRIP_DEVIATION_BUDGET_DEVICE_PX), so high-curvature envelopes (rings,
  * pours — tangent sweep up to ~345°) subdivide as finely as they need while flat
- * ones stay coarse. Each strip is a vertical slice of the pre-rendered glyph
- * bitmap, drawn with the strip's own affine; adjacent strips then diverge ≤ 2
- * device px at their shared boundary, which the ±1 px overlap covers.
+ * ones stay coarse.
  *
- * The reusable offscreen `gAux` already carries THIS glyph, rendered at
- * `devScale` with the glyph pen-origin at device-x `padDev` and the baseline at
- * device-y `blY`; the offscreen is `auxDevH` device px tall (ascent above the
- * baseline + descent below). `chW` is the glyph's flat advance (css px, incl.
- * letter-spacing). `flatX0` is the glyph's flat left edge along the whole line
- * (css px). The remaining args mirror the per-glyph draw: `hScale` stretches flat
- * ink to the box width, `warpBoxH`/`bandFrac` drive `warpGlyphTransform`,
- * `boxX`/`boxY` are the shape origin, `totalW`/`followScale` map flat-x to the
- * envelope fraction u.
+ * Each strip re-issues `fillText` under its own affine, clipped to the strip's
+ * share of the glyph advance. The clip rect is expressed in GLYPH-LOCAL
+ * (flat-advance) coordinates, so adjacent strips cut the glyph at the same
+ * flat-x boundary; the text itself is rasterised by the canvas at the strip's
+ * final device-space transform — full device resolution, no intermediate
+ * bitmap. The clip is effectively unbounded vertically (the subdivision is
+ * horizontal only) and the OUTER edges of a glyph's first/last strips are
+ * unbounded outward, so side-bearing overhang ink (italic tails, swashes)
+ * rides the end strips instead of being cut at the advance box.
+ *
+ * `chW` is the glyph's flat advance (css px, incl. letter-spacing `ls`);
+ * `flatX0` is the glyph's flat left edge along the whole line (css px). The
+ * remaining args mirror the per-glyph draw: `hScale` stretches flat ink to the
+ * box width, `warpBoxH`/`bandFrac` drive `warpGlyphTransform`, `boxX`/`boxY`
+ * are the shape origin, `totalW`/`followScale` map flat-x to the envelope
+ * fraction u. `ctx.font` / `ctx.fillStyle` must already be set for this glyph
+ * (save/restore around each strip preserves them).
  */
 function drawWarpedGlyphStrips(
   ctx: CanvasRenderingContext2D,
-  gAux: NonNullable<ReturnType<typeof createAuxCanvas>>,
-  devScale: number,
-  padDev: number,
-  blY: number,
-  auxDevH: number,
-  env: WarpEnvelope,
+  ch: string,
+  ls: number,
   chW: number,
+  devScale: number,
+  env: WarpEnvelope,
   flatX0: number,
   totalW: number,
   followScale: number,
@@ -1462,19 +1466,20 @@ function drawWarpedGlyphStrips(
   boxY: number,
 ): void {
   if (chW <= 0) return;
-  // The offscreen ink top row is `blY` device px above the baseline; the whole
-  // offscreen (auxDevH tall) maps to a css slab of height auxDevH/devScale whose
-  // baseline (row blY) sits at local y = 0.
-  const dstH = auxDevH / devScale;
-  const dstY = -blY / devScale;
+  // Ink extremes about the baseline (css px), from real metrics — this is where
+  // the deviation budget must hold, since that is where ink actually lands.
+  // Fallbacks keep degenerate metrics safe (mirrors the flat renderer).
+  const m = ctx.measureText(ch);
+  const asc = m.actualBoundingBoxAscent > 0 ? m.actualBoundingBoxAscent : chW;
+  const desc = m.actualBoundingBoxDescent > 0 ? m.actualBoundingBoxDescent : chW * 0.25;
 
   // ── Adaptive strip count ──────────────────────────────────────────────────
   // Start from the width criterion (one strip per WARP_STRIP_DEVICE_PX of the
   // glyph's WARPED advance, chW·hScale·devScale), then DOUBLE the count until
-  // every painted slab corner is within the deviation budget of the exact
+  // every painted ink corner is within the deviation budget of the exact
   // envelope map (see WARP_STRIP_DEVIATION_BUDGET_DEVICE_PX for the formula and
-  // why the budget ties to the overlap). Deviation from the smooth part of the
-  // envelope halves with each doubling (it is ∝ the strip's u-span to first
+  // why the budget ties to the clip overlap). Deviation from the smooth part of
+  // the envelope halves with each doubling (it is ∝ the strip's u-span to first
   // order), so the loop converges in a few steps for arcs of any curvature —
   // this is what keeps high-curvature ring/pour envelopes (tangent sweep up to
   // ~345°) contiguous instead of fanning into radial slivers. If a doubling
@@ -1491,13 +1496,13 @@ function drawWarpedGlyphStrips(
     buildWarpStrips(count, env, chW, flatX0, totalW, followScale, warpBoxH, bandFrac);
   let strips = build(k);
   let dev = maxWarpStripDeviationDev(
-    strips, env, flatX0, totalW, followScale, warpBoxH, bandFrac, hScale, devScale, dstY, dstY + dstH,
+    strips, env, flatX0, totalW, followScale, warpBoxH, bandFrac, hScale, devScale, -asc, desc,
   );
   while (dev > WARP_STRIP_DEVIATION_BUDGET_DEVICE_PX && k < WARP_STRIP_MAX_PER_GLYPH) {
     const k2 = Math.min(WARP_STRIP_MAX_PER_GLYPH, k * 2);
     const strips2 = build(k2);
     const dev2 = maxWarpStripDeviationDev(
-      strips2, env, flatX0, totalW, followScale, warpBoxH, bandFrac, hScale, devScale, dstY, dstY + dstH,
+      strips2, env, flatX0, totalW, followScale, warpBoxH, bandFrac, hScale, devScale, -asc, desc,
     );
     if (dev2 >= dev * 0.75) {
       // Not converging: C0 crease in the envelope (see above). The finer
@@ -1510,17 +1515,20 @@ function drawWarpedGlyphStrips(
     dev = dev2;
   }
 
-  for (const strip of strips) {
-    const { s0, s1, g } = strip;
-    // Source rect on the offscreen (device px): the glyph pen origin is at
-    // device-x `padDev`, so flat-x `s` maps to device-x `padDev + s·devScale`.
-    // Grow by the overlap on each side (clamped to the offscreen) so neighbours
-    // share a hair of pixels and no seam shows.
-    const srcX0 = Math.max(0, padDev + s0 * devScale - WARP_STRIP_OVERLAP_DEVICE_PX);
-    const srcX1 = Math.min(gAux.width, padDev + s1 * devScale + WARP_STRIP_OVERLAP_DEVICE_PX);
-    const srcW = srcX1 - srcX0;
-    if (srcW <= 0) continue;
+  // Vertical clip extent: the subdivision is horizontal only, so the clip's
+  // sole job is to bound x. ±10⁴ css px is four orders of magnitude beyond any
+  // glyph's extent (so no ink is ever cut in y), kept finite only so the
+  // rasterizer's float precision on the boundary line stays sub-thousandth-px.
+  const CLIP_Y = 1e4;
+  // Clip overlap in glyph-local flat units: the local x axis is scaled by
+  // hScale (then the canvas dpr) on the way to device px, so this makes the
+  // painted overlap WARP_STRIP_OVERLAP_DEVICE_PX device px wide.
+  const ov = WARP_STRIP_OVERLAP_DEVICE_PX / (hScale * devScale);
 
+  const last = strips.length - 1;
+  for (let i = 0; i <= last; i++) {
+    const { s0, s1, g } = strips[i];
+    const centre = (s0 + s1) / 2;
     ctx.save();
     // Same transform chain as the single-affine per-glyph draw, but anchored at
     // the STRIP centre so vScale/shear/angle track this slice's u.
@@ -1528,23 +1536,18 @@ function drawWarpedGlyphStrips(
     ctx.rotate(g.angle);
     if (g.shear !== 0) ctx.transform(1, 0, g.shear, 1, 0, 0);
     if (hScale !== 1 || g.vScale !== 1) ctx.scale(hScale, g.vScale);
-    // Map the offscreen slice into this strip's local frame: a source pixel at
-    // device-x `sx` sits at flat-x `(sx − padDev)/devScale` from the pen origin,
-    // so its local x (relative to the strip centre `(s0+s1)/2`) is
-    // `(sx − padDev)/devScale − (s0+s1)/2`.
-    const dstX = (srcX0 - padDev) / devScale - (s0 + s1) / 2;
-    const dstW = srcW / devScale;
-    ctx.drawImage(
-      gAux as CanvasImageSource,
-      srcX0,
-      0,
-      srcW,
-      auxDevH,
-      dstX,
-      dstY,
-      dstW,
-      dstH,
-    );
+    // Strip clip in glyph-local coordinates (origin at the strip centre): the
+    // interior boundaries sit at the shared flat-x values s0/s1 (± the
+    // overlap); the glyph's outer edges are unbounded outward so side-bearing
+    // overhang ink is not cut.
+    const x0 = i === 0 ? -CLIP_Y : s0 - centre - ov;
+    const x1 = i === last ? CLIP_Y : s1 - centre + ov;
+    ctx.beginPath();
+    ctx.rect(x0, -CLIP_Y, x1 - x0, 2 * CLIP_Y);
+    ctx.clip();
+    // Pen origin sits at local −centre; the ls/2 shift centres the ink inside
+    // its letter-spaced advance, matching the flat draw's origin convention.
+    ctx.fillText(ch, -centre + ls / 2, 0);
     ctx.restore();
   }
 }
@@ -1827,16 +1830,16 @@ function renderWarpedText(
         // glyph (on Inflate/Deflate the vertical stretch varies across the glyph's
         // own width; on waves the slope does), so a single per-glyph affine loses
         // that intra-glyph deformation. Draw the glyph via piecewise-affine STRIPS
-        // (each strip's affine sampled at its own centre-u) so the mapping
-        // converges to PowerPoint's continuous outline warp (§20.1.9.19). The
+        // (each strip a clipped vector fillText under its own affine, sampled at
+        // its own centre-u) so the mapping converges to PowerPoint's continuous
+        // outline warp (§20.1.9.19). Needs no auxiliary canvas, so it runs
+        // unconditionally (main thread, worker, headless node alike). The
         // single-edge (Follow Path) branch below is UNCHANGED (byte-identical):
         // its glyphs are rigidly rotated onto a baseline, already exact per glyph.
         if (!env.singleEdge && chW > 0) {
-          const drawn = drawWarpedGlyphViaStrips(
+          drawWarpedGlyphStrips(
             ctx,
             ch,
-            seg.font,
-            seg.color,
             ls,
             chW,
             getDevScale(),
@@ -1850,13 +1853,8 @@ function renderWarpedText(
             boxX,
             boxY,
           );
-          if (drawn) {
-            penW += chW;
-            continue;
-          }
-          // Offscreen unavailable (headless env) → fall through to single-affine.
-          ctx.font = seg.font;
-          ctx.fillStyle = seg.color;
+          penW += chW;
+          continue;
         }
 
         // Horizontal fraction of THIS glyph's centre along the whole line,
@@ -1885,92 +1883,6 @@ function renderWarpedText(
     }
   }
   ctx.restore();
-}
-
-/**
- * Render one glyph to the reusable offscreen and blit it across a paired-edge
- * warp via {@link drawWarpedGlyphStrips}. Returns `false` when no offscreen
- * canvas is available (headless test env with neither OffscreenCanvas nor
- * document), so the caller can fall back to the single-affine per-glyph draw.
- *
- * The offscreen is sized to the glyph's measured ink (ascent above baseline +
- * descent below, plus the left side-bearing) at `devScale`, with a small pad so
- * strokes that overhang the pen advance (italic tails, wide accents) are not
- * clipped. `penW` is the flat advance consumed BEFORE this glyph on the line.
- */
-function drawWarpedGlyphViaStrips(
-  ctx: CanvasRenderingContext2D,
-  ch: string,
-  font: string,
-  color: string,
-  ls: number,
-  chW: number,
-  devScale: number,
-  env: WarpEnvelope,
-  penW: number,
-  totalW: number,
-  followScale: number,
-  hScale: number,
-  warpBoxH: number,
-  bandFrac: number,
-  boxX: number,
-  boxY: number,
-): boolean {
-  ctx.font = font;
-  const m = ctx.measureText(ch);
-  // Ink extents around the baseline (fallbacks keep degenerate metrics safe).
-  const asc = m.actualBoundingBoxAscent > 0 ? m.actualBoundingBoxAscent : chW;
-  const desc = m.actualBoundingBoxDescent > 0 ? m.actualBoundingBoxDescent : chW * 0.25;
-  // Left side-bearing: ink may start left of the pen origin (e.g. italic 'f').
-  const lsb = m.actualBoundingBoxLeft > 0 ? m.actualBoundingBoxLeft : 0;
-  const rsb = m.actualBoundingBoxRight > chW ? m.actualBoundingBoxRight - chW : 0;
-  // css pad on each side so overhang and the strip overlap have room.
-  const padCss = Math.max(lsb, rsb, 2);
-  const padDev = Math.ceil(padCss * devScale);
-  const ascDev = Math.ceil(asc * devScale);
-  const descDev = Math.ceil(desc * devScale);
-  const auxDevW = padDev + Math.ceil((chW + padCss) * devScale);
-  const auxDevH = ascDev + descDev;
-  const gAux = warpGlyphOffscreen(auxDevW, auxDevH);
-  if (!gAux) return false;
-  const gctx = gAux.getContext('2d') as CanvasRenderingContext2D | null;
-  if (!gctx) return false;
-
-  // Paint the glyph: baseline at device row `ascDev`, pen origin at device-x
-  // `padDev`. Clear only the used sub-rect (grow-only offscreen may be larger).
-  gctx.save();
-  gctx.setTransform(1, 0, 0, 1, 0, 0);
-  gctx.clearRect(0, 0, auxDevW, auxDevH);
-  gctx.scale(devScale, devScale);
-  gctx.textAlign = 'left';
-  gctx.textBaseline = 'alphabetic';
-  gctx.font = font;
-  gctx.fillStyle = color;
-  // Shift right by half the letter-spacing so the ink is centred in its advance,
-  // matching the single-affine draw's `-chW/2 + ls/2` origin convention.
-  gctx.fillText(ch, padCss + ls / 2, asc);
-  gctx.restore();
-
-  const flatX0 = penW;
-  drawWarpedGlyphStrips(
-    ctx,
-    gAux,
-    devScale,
-    padDev,
-    ascDev,
-    auxDevH,
-    env,
-    chW,
-    flatX0,
-    totalW,
-    followScale,
-    hScale,
-    warpBoxH,
-    bandFrac,
-    boxX,
-    boxY,
-  );
-  return true;
 }
 
 /**

--- a/packages/pptx/tests/visual/warp-quality-fixture.html
+++ b/packages/pptx/tests/visual/warp-quality-fixture.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { background: #ffffff; }
+    canvas { display: block; margin: 4px; }
+  </style>
+</head>
+<body>
+  <!--
+    WordArt warp quality fixture: renders SYNTHETIC warped slides (no .pptx
+    fetch, no private fixtures) straight through renderSlide, one canvas per
+    preset, plus a flat (unwarped) control canvas for sharpness comparison.
+    Used by warp-strip-quality.spec.ts to measure stray-ink / sharpness /
+    contour-step metrics of the strip-subdivision draw path in a real browser.
+  -->
+  <script type="module">
+    import { renderSlide } from '/src/renderer.ts';
+
+    const EMU = 9525;
+    const px = (n) => Math.round(n * EMU);
+    const BOX_W = 6.2 * 96;
+    const BOX_H = 1.5 * 96;
+
+    function slideFor(preset, text, boxH) {
+      const para = {
+        alignment: 'ctr', marL: 0, marR: 0, indent: 0, spaceBefore: null, spaceAfter: null,
+        spaceLine: null, lvl: 0, bullet: { type: 'none' }, defFontSize: null, defColor: null,
+        defBold: null, defItalic: null, defFontFamily: null, tabStops: [], eaLnBrk: true,
+        runs: [{ type: 'text', text, bold: true, italic: null, underline: false,
+          strikethrough: false, fontSize: 40, color: '1F4E79', fontFamily: 'Arial' }],
+      };
+      const textBody = {
+        verticalAnchor: 'ctr', paragraphs: [para], defaultFontSize: 40,
+        defaultBold: null, defaultItalic: null, lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+        wrap: 'none', vert: 'horz', autoFit: 'none',
+        textWarp: preset ? { preset } : undefined,
+      };
+      return {
+        slide: {
+          index: 0, slideNumber: 1, background: null,
+          elements: [{
+            type: 'shape', x: px(20), y: px(20), width: px(BOX_W), height: px(boxH),
+            rotation: 0, flipH: false, flipV: false, geometry: 'rect',
+            fill: null, stroke: null, textBody, defaultTextColor: null, custGeom: null,
+            adj: null, adj2: null, adj3: null, adj4: null, adj5: null, adj6: null,
+            adj7: null, adj8: null, shadow: null,
+          }],
+        },
+        w: px(BOX_W + 40),
+        h: px(boxH + 40),
+      };
+    }
+
+    const CASES = [
+      // [id, preset (null = flat control), text, box height css px]
+      ['flat', null, 'Inflate', BOX_H],
+      ['inflate', 'textInflate', 'Inflate', BOX_H],
+      ['deflate', 'textDeflate', 'Deflate', BOX_H],
+      ['cascade', 'textCascadeUp', 'Cascade', BOX_H],
+      ['wave1', 'textWave1', 'Wave One', BOX_H],
+      ['circlepour', 'textCirclePour', 'Round', 3 * 96],
+    ];
+
+    try {
+      await document.fonts.ready;
+      const timings = {};
+      for (const [id, preset, text, boxH] of CASES) {
+        const { slide, w, h } = slideFor(preset, text, boxH);
+        const canvas = document.createElement('canvas');
+        canvas.id = id;
+        document.body.appendChild(canvas);
+        const t0 = performance.now();
+        await renderSlide(canvas, slide, w, h, {
+          width: BOX_W + 40,
+          defaultTextColor: null,
+          majorFont: null,
+          minorFont: null,
+          hlinkColor: null,
+          fetchMedia: async () => new Blob([]),
+          fetchImage: async () => new Blob([]),
+          skipMediaControls: true,
+        });
+        timings[id] = +(performance.now() - t0).toFixed(1);
+      }
+      document.body.dataset.timings = JSON.stringify(timings);
+      document.body.dataset.status = 'ready';
+    } catch (err) {
+      document.body.dataset.status = 'error';
+      document.body.dataset.errorMessage = String(err);
+      console.error('[warp-fixture] fatal:', err);
+    }
+  </script>
+</body>
+</html>

--- a/packages/pptx/tests/visual/warp-strip-quality.spec.ts
+++ b/packages/pptx/tests/visual/warp-strip-quality.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Browser-rendering quality gate for the WordArt paired-edge warp strips
+ * (ECMA-376 §20.1.9.19; piecewise-affine subdivision from #872).
+ *
+ * The strip draw is exercised in a REAL browser because the artifacts this
+ * guards against are browser-specific: Chrome's drawImage/AA pipeline exposed
+ * three defects of the original bitmap-blit strips that skia-canvas (the node
+ * probe harness) does not reproduce — detached hairlines from stretched
+ * source-edge antialiasing, glyphs cut by the offscreen slab rectangle, and
+ * blur from re-magnifying a rasterised glyph (vScale up to ~4). The vector
+ * clip+fillText strip draw removes the bitmap from the path entirely; these
+ * metrics pin that quality in the browser:
+ *
+ *  - strayInk: faint ink pixels with no solid ink within 3 px — detached
+ *    hairlines / stretched AA fringes. Must be 0.
+ *  - edgeRatio: (faint edge pixels) / (solid pixels) — a proxy for edge
+ *    softness. Warped text must stay in the same regime as flat fillText
+ *    (bitmap re-magnification measured ≈2× the flat ratio; vector ≈1×).
+ *  - contour steps: P95 of adjacent-column top-contour jumps — staircase
+ *    seams at strip boundaries on the sheared Cascade envelope.
+ *  - CirclePour ink components: readability guard for high-curvature rings
+ *    (radial-sliver regression would shatter glyphs into dozens of parts).
+ *
+ * Synthetic slides only (no .pptx fetch, no private fixtures) — see
+ * warp-quality-fixture.html.
+ */
+import { test, expect } from '@playwright/test';
+
+// The artifacts under test are HiDPI re-sampling artifacts: render at dpr 2.
+test.use({ deviceScaleFactor: 2, viewport: { width: 1400, height: 1600 } });
+
+interface CanvasMetrics {
+  solid: number;
+  faint: number;
+  stray: number;
+  components: number;
+  contourP95: number;
+  contourMax: number;
+}
+
+/** Compute ink metrics for one fixture canvas, in-page. */
+async function metricsFor(page: import('@playwright/test').Page, id: string): Promise<CanvasMetrics> {
+  return page.evaluate((canvasId) => {
+    const canvas = document.getElementById(canvasId) as HTMLCanvasElement;
+    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+    const W = canvas.width;
+    const H = canvas.height;
+    const data = ctx.getImageData(0, 0, W, H).data;
+    // Luminance against the white page background (canvas is opaque white).
+    const lum = (i: number) => 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+    const solidMask = new Uint8Array(W * H);
+    const inkMask = new Uint8Array(W * H); // any visible ink, however faint
+    let solid = 0;
+    let faint = 0;
+    for (let p = 0; p < W * H; p++) {
+      const l = lum(p * 4);
+      if (l <= 100) { solidMask[p] = 1; inkMask[p] = 1; solid++; }
+      else if (l < 235) { inkMask[p] = 1; if (l > 100 && l < 220) faint++; }
+    }
+    // Stray faint ink: visible ink with no solid ink within Chebyshev radius 3.
+    let stray = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const p = y * W + x;
+        if (!inkMask[p] || solidMask[p]) continue;
+        let nearSolid = false;
+        for (let dy = -3; dy <= 3 && !nearSolid; dy++) {
+          const yy = y + dy;
+          if (yy < 0 || yy >= H) continue;
+          for (let dx = -3; dx <= 3; dx++) {
+            const xx = x + dx;
+            if (xx < 0 || xx >= W) continue;
+            if (solidMask[yy * W + xx]) { nearSolid = true; break; }
+          }
+        }
+        if (!nearSolid) stray++;
+      }
+    }
+    // 8-connected components of VISIBLE ink (readability / sliver guard; the
+    // faint tier is included so a hairline-thin but continuous stroke — e.g.
+    // the compressed inner radius of a ring — counts as one piece, matching
+    // the node/skia probe's ink threshold).
+    const seen = new Uint8Array(W * H);
+    const stack: number[] = [];
+    let components = 0;
+    for (let start = 0; start < W * H; start++) {
+      if (!inkMask[start] || seen[start]) continue;
+      components++;
+      stack.length = 0;
+      stack.push(start);
+      seen[start] = 1;
+      while (stack.length) {
+        const p = stack.pop() as number;
+        const x = p % W, y = (p / W) | 0;
+        for (let dy = -1; dy <= 1; dy++) for (let dx = -1; dx <= 1; dx++) {
+          if (!dx && !dy) continue;
+          const nx = x + dx, ny = y + dy;
+          if (nx < 0 || ny < 0 || nx >= W || ny >= H) continue;
+          const np = ny * W + nx;
+          if (inkMask[np] && !seen[np]) { seen[np] = 1; stack.push(np); }
+        }
+      }
+    }
+    // Top-contour steps: per column, topmost row with lum<160; jumps between
+    // adjacent inked columns. P95 filters the rare legitimate intra-glyph
+    // feature jump; strip-boundary staircases inflate the bulk of the
+    // distribution instead.
+    const tops: Array<number | null> = new Array(W).fill(null);
+    for (let x = 0; x < W; x++) {
+      for (let y = 0; y < H; y++) {
+        if (lum((y * W + x) * 4) < 160) { tops[x] = y; break; }
+      }
+    }
+    const jumps: number[] = [];
+    for (let x = 1; x < W; x++) {
+      const a = tops[x - 1];
+      const b = tops[x];
+      if (a != null && b != null) jumps.push(Math.abs(b - a));
+    }
+    jumps.sort((m, n) => m - n);
+    const contourP95 = jumps.length ? jumps[Math.floor(jumps.length * 0.95)] : 0;
+    const contourMax = jumps.length ? jumps[jumps.length - 1] : 0;
+    return { solid, faint, stray, components, contourP95, contourMax };
+  }, id);
+}
+
+test('warp strips render clean in a real browser (stray ink / sharpness / seams)', async ({ page }) => {
+  await page.goto('/tests/visual/warp-quality-fixture.html');
+  await page.waitForFunction(() => document.body.dataset.status === 'ready', undefined, {
+    timeout: 30_000,
+  });
+
+  const flat = await metricsFor(page, 'flat');
+  const results: Record<string, CanvasMetrics> = { flat };
+  for (const id of ['inflate', 'deflate', 'cascade', 'wave1', 'circlepour']) {
+    results[id] = await metricsFor(page, id);
+  }
+  // eslint-disable-next-line no-console
+  console.log('[warp-quality]', JSON.stringify(results, null, 1));
+
+  const flatRatio = flat.faint / Math.max(1, flat.solid);
+  for (const id of ['inflate', 'deflate', 'cascade', 'wave1', 'circlepour']) {
+    const m = results[id];
+    expect(m.solid, `${id}: has ink`).toBeGreaterThan(500);
+    // 1) No detached hairlines / stretched AA fringes anywhere.
+    expect(m.stray, `${id}: stray faint ink pixels`).toBe(0);
+    // 2) Edge softness stays in the flat-fillText regime. The warp stretches
+    //    glyphs (vScale up to ~4 → up to ~4× the outline length per solid px),
+    //    so allow that geometric factor but not the compounding blur of a
+    //    re-magnified bitmap (measured ≈2× worse again on the bitmap path).
+    expect(m.faint / Math.max(1, m.solid), `${id}: edge-softness ratio`).toBeLessThan(
+      flatRatio * 4,
+    );
+  }
+  // 3) Sheared piecewise-linear envelope must not staircase at strip seams:
+  //    the bulk of adjacent-column contour jumps stays at the AA scale.
+  expect(results.cascade.contourP95, 'cascade: top-contour P95 step').toBeLessThanOrEqual(3);
+  // 4) High-curvature ring stays readable — one blob per glyph part, not a
+  //    fan of radial slivers ("Round" = 5 single-piece letters; warped letters
+  //    may merge or split at hairline joins, slivers are dozens).
+  expect(results.circlepour.components, 'circlepour: ink components').toBeLessThanOrEqual(10);
+});


### PR DESCRIPTION
## Problem — browser-only artifacts of the #872 bitmap strips

User verification of #872 in Storybook/Chrome (dpr 2) surfaced three artifact classes, none reproducible under the skia-canvas node harness the change had been verified with:

1. **Detached hairlines** below/around glyphs (Inflate bottom, Cascade top/bottom) — the offscreen glyph bitmap's edge rows carry antialiased ink; stretching a source-rect edge through the strip transform smears that fringe into faint free-standing line segments. Reproduced numerically in chromium (dpr 2, synthetic fixture): **471–2589 stray faint ink pixels per word**; 0 in skia.
2. **Glyphs cut by a rectangle** — ink outside the measured offscreen slab (side-bearing overhang, swashes) never reached the bitmap.
3. **Blur** — the glyph raster is re-magnified by the strip transform (vScale up to ~4), compounding two resampling passes.

All three are inherent to bitmap transfer, so per the approved course change this PR replaces the mechanism instead of patching it.

## Fix — per-strip vector `clip` + `fillText`

Each strip now re-issues `fillText` under its own affine (the identical `warpGlyphTransform` chain from #872), clipped to the strip's share of the glyph advance:

- **Full device resolution** — the browser rasterises the outline at the strip's final device transform. No intermediate bitmap → no re-magnification blur.
- **No bitmap boundary** — the clip is effectively unbounded vertically and at each glyph's outer edges, so overhang ink rides the end strips instead of being cut.
- **No detached hairlines** — nothing paints outside the glyph outline; clip edges only cut painted ink.
- **Seam handling** — clip rects live in glyph-local flat coordinates, so adjacent strips cut at the same flat-x boundary; interior boundaries keep the 1-device-px overlap because two abutting clip edges antialiased in separate fill passes leave the classic shared-edge coverage dip (~25 % background bleed). Painting the same opaque colour over itself is idempotent, so the overlapped band composes seamlessly. (Translucent fills compose twice in that 2 px band — the same trade-off the bitmap overlap already had.)
- **No auxiliary canvas at all** — the offscreen machinery and its headless fallback branch are deleted (net −89 lines); the draw is identical on the main thread, in a worker (OffscreenCanvas), and under headless node.

The **adaptive strip count is reused unchanged** (deviation ≤ 1 device px against the exact envelope map, cap 256, C0-crease stall guard) — only the painting of each strip changed.

## Measured (chromium, dpr 2)

| Metric | bitmap (#872) | vector (this PR) |
|---|---|---|
| Stray faint ink, Inflate / Deflate / Cascade / Wave1 / CirclePour | 2564 / 1115 / 594 / 471 / 2589 | **0 / 0 / 0 / 0 / 0** |
| Faint-edge pixels (blur proxy), Wave1 / CirclePour | 12126 / 14525 | **4607 / 5727** (flat-fillText regime) |
| CirclePour ink components (readability) | 43 | **5** |
| sample-16 slide 1 @3840×2160 stray ink | — | **0** |
| Worker vs main, sample-16 warp slide | — | **0 px (0.000 %)** |
| Render, Inflate / CirclePour | 4.6 / 6.3 ms | **3.8 / 4.5 ms** (faster — Chrome's glyph cache) |

Node/skia probes all stay green (intra-glyph asymmetry ratios, high-curvature sliver guard components 3–5, Follow Path invariants). skia render time increases (sample-16 slide 11.9 → 36.6 ms; skia-canvas re-shapes text per fillText) — a harness-only cost on a decorative element, accepted in favour of correct browser output; the production browser path got faster.

## New gate — browser rendering quality spec

`tests/visual/warp-strip-quality.spec.ts` + `warp-quality-fixture.html`: renders synthetic warped slides (no private fixtures) through `renderSlide` in chromium at dpr 2 and asserts stray-ink = 0, edge-softness within the flat regime, Cascade contour P95 ≤ 3, CirclePour components ≤ 10. **Fails against the bitmap implementation (stray 2564), passes here** — the artifact class the skia probes structurally cannot see is now pinned in CI-shape (runs with the local VRT suite).

## Gates

- pptx vitest **349 passed**, core shape **182 passed**, node warp probes **6 passed**
- pptx VRT: **15 passed** (demo visual ×9 byte-identical, worker equivalence ×5, new quality gate; private-fixture 404s unchanged)
- typecheck 0 errors (pptx + node); ast-grep 3 pre-existing warnings, none added (the `as CanvasImageSource` cast is gone with the bitmap)
- Inflate/Deflate intra-glyph asymmetry and CirclePour readability preserved (probe-asserted)

## Files
- `packages/pptx/src/renderer.ts` — vector strip draw (paired-edge only; single-edge Follow Path untouched)
- `packages/pptx/tests/visual/warp-quality-fixture.html`, `warp-strip-quality.spec.ts` — browser quality gate
- `packages/node/src/pptx-text-warp.probe.test.ts` — comment accuracy (factory no longer gates the strip path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)