### PR TITLE
fix(charts): draw area-chart gridlines under the series (z-order)

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -7,6 +7,37 @@ set fillStyle=#333
 set textAlign=center
 set textBaseline=top
 fillText "Area" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
+set strokeStyle=#aaa
+beginPath
+moveTo 88.8,313.45
+lineTo 479.2,313.45
+stroke ss=#aaa lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+beginPath
+moveTo 88.8,277.7
+lineTo 479.2,277.7
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,241.95
+lineTo 479.2,241.95
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,206.2
+lineTo 479.2,206.2
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,170.45
+lineTo 479.2,170.45
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,134.7
+lineTo 479.2,134.7
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,98.95
+lineTo 479.2,98.95
+stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
 moveTo 105.0667,313.45
 lineTo 105.0667,259.825
@@ -34,95 +65,67 @@ set textBaseline=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 88.8,313.45
-lineTo 479.2,313.45
-stroke ss=#aaa lw=1 dash=
-beginPath
 moveTo 84.8,313.45
 lineTo 88.8,313.45
 stroke ss=#aaa lw=1 dash=
+set strokeStyle=#4472C4
+set lineWidth=1.5
 set fillStyle=#555
 set textAlign=right
 fillText "0" 82.8,313.45 fs=#555 font=10.725px sans-serif al=right bl=middle
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-beginPath
-moveTo 88.8,277.7
-lineTo 479.2,277.7
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,277.7
 lineTo 88.8,277.7
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "2" 82.8,277.7 fs=#555 font=10.725px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,241.95
-lineTo 479.2,241.95
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,241.95
 lineTo 88.8,241.95
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "4" 82.8,241.95 fs=#555 font=10.725px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,206.2
-lineTo 479.2,206.2
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,206.2
 lineTo 88.8,206.2
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "6" 82.8,206.2 fs=#555 font=10.725px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,170.45
-lineTo 479.2,170.45
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,170.45
 lineTo 88.8,170.45
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "8" 82.8,170.45 fs=#555 font=10.725px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,134.7
-lineTo 479.2,134.7
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,134.7
 lineTo 88.8,134.7
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "10" 82.8,134.7 fs=#555 font=10.725px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,98.95
-lineTo 479.2,98.95
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,98.95
 lineTo 88.8,98.95
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "12" 82.8,98.95 fs=#555 font=10.725px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
@@ -1880,6 +1883,49 @@ restore"
 
 exports[`renderChart draw-call signature (characterization) > is stable for: stackedArea 1`] = `
 "save
+set strokeStyle=#aaa
+beginPath
+moveTo 88.8,335.45
+lineTo 620,335.45
+stroke ss=#aaa lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+beginPath
+moveTo 88.8,304.7222
+lineTo 620,304.7222
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,273.9944
+lineTo 620,273.9944
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,243.2667
+lineTo 620,243.2667
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,212.5389
+lineTo 620,212.5389
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,181.8111
+lineTo 620,181.8111
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,151.0833
+lineTo 620,151.0833
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,120.3556
+lineTo 620,120.3556
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,89.6278
+lineTo 620,89.6278
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,58.9
+lineTo 620,58.9
+stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
 moveTo 177.3333,286.2856
 lineTo 354.4,243.2667
@@ -1912,134 +1958,94 @@ set textBaseline=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 88.8,335.45
-lineTo 620,335.45
-stroke ss=#aaa lw=1 dash=
-beginPath
 moveTo 84.8,335.45
 lineTo 88.8,335.45
 stroke ss=#aaa lw=1 dash=
+set strokeStyle=#4472C4
+set lineWidth=1.5
 set fillStyle=#555
 set textAlign=right
 fillText "0" 82.8,335.45 fs=#555 font=11px sans-serif al=right bl=middle
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-beginPath
-moveTo 88.8,304.7222
-lineTo 620,304.7222
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,304.7222
 lineTo 88.8,304.7222
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "5" 82.8,304.7222 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,273.9944
-lineTo 620,273.9944
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,273.9944
 lineTo 88.8,273.9944
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "10" 82.8,273.9944 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,243.2667
-lineTo 620,243.2667
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,243.2667
 lineTo 88.8,243.2667
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "15" 82.8,243.2667 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,212.5389
-lineTo 620,212.5389
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,212.5389
 lineTo 88.8,212.5389
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "20" 82.8,212.5389 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,181.8111
-lineTo 620,181.8111
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,181.8111
 lineTo 88.8,181.8111
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "25" 82.8,181.8111 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,151.0833
-lineTo 620,151.0833
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,151.0833
 lineTo 88.8,151.0833
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "30" 82.8,151.0833 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,120.3556
-lineTo 620,120.3556
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,120.3556
 lineTo 88.8,120.3556
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "35" 82.8,120.3556 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,89.6278
-lineTo 620,89.6278
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,89.6278
 lineTo 88.8,89.6278
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "40" 82.8,89.6278 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 88.8,58.9
-lineTo 620,58.9
-stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 84.8,58.9
 lineTo 88.8,58.9
 stroke ss=#aaa lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
+set strokeStyle=#4472C4
+set lineWidth=1.5
 fillText "45" 82.8,58.9 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1

--- a/packages/core/src/chart/renderer-gridline-zorder.test.ts
+++ b/packages/core/src/chart/renderer-gridline-zorder.test.ts
@@ -1,0 +1,165 @@
+// CH — value-axis MAJOR gridlines must be painted UNDER the data series, not
+// over them. PowerPoint draws `<c:valAx><c:majorGridlines>` beneath the plotted
+// geometry so an opaque area fill occludes the gridlines inside its region
+// (verified against private/sample-14.pdf slide-6: every gridline that falls
+// inside the teal ARR area reads solid teal, only the gridlines above the fill
+// top are visible). The bar/line/stock/scatter/waterfall/box renderers already
+// stroke gridlines before their series; this pins that ordering for the AREA
+// family (which historically drew fills first, then gridlines on top) and guards
+// the others against regressing.
+import { describe, it, expect } from 'vitest';
+import type { ChartModel, ChartSeries, ChartRect } from '../types/chart';
+import { renderChart } from './renderer.js';
+
+// Ordered event recorder: logs each fill()/stroke() with the style in effect at
+// the call, so we can assert the RELATIVE order of gridline strokes vs series
+// fills. A translucent `rgba(...)` fillStyle marks a series area/line fill; a
+// thin hairline strokeStyle (the resolved gridline color, default `#e0e0e0`)
+// marks a gridline. We tag events by role and check the first gridline precedes
+// the first series fill.
+type Ev = { op: 'fill' | 'stroke'; fillStyle: string; strokeStyle: string; lineWidth: number };
+
+function orderedRecordingCtx(): { ctx: CanvasRenderingContext2D; events: Ev[] } {
+  const events: Ev[] = [];
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif',
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    globalAlpha: 1,
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_t, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText':
+          return (t: string) => ({ width: String(t).length * 6 });
+        case 'fill':
+          return () => events.push({ op: 'fill', fillStyle: String(state.fillStyle), strokeStyle: String(state.strokeStyle), lineWidth: Number(state.lineWidth) });
+        case 'stroke':
+          return () => events.push({ op: 'stroke', fillStyle: String(state.fillStyle), strokeStyle: String(state.strokeStyle), lineWidth: Number(state.lineWidth) });
+        case 'createLinearGradient':
+        case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        case 'save': case 'restore': case 'beginPath': case 'closePath':
+        case 'moveTo': case 'lineTo': case 'arc': case 'fillRect':
+        case 'bezierCurveTo': case 'quadraticCurveTo': case 'rect':
+        case 'strokeRect': case 'clearRect': case 'fillText': case 'strokeText':
+        case 'setLineDash': case 'translate': case 'rotate': case 'scale':
+        case 'clip': case 'setTransform': case 'resetTransform': case 'getTransform':
+          return () => undefined;
+        default:
+          return undefined;
+      }
+    },
+    set(_t, prop: string, value) { state[prop] = value; return true; },
+  };
+  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, events };
+}
+
+function series(over: Partial<ChartSeries>): ChartSeries {
+  return { name: '', color: null, values: [], ...over };
+}
+
+function baseModel(over: Partial<ChartModel>): ChartModel {
+  return {
+    chartType: 'area',
+    title: null,
+    categories: [],
+    series: [],
+    showDataLabels: false,
+    valMin: null,
+    valMax: null,
+    catAxisTitle: null,
+    valAxisTitle: null,
+    catAxisHidden: false,
+    valAxisHidden: false,
+    catAxisLineHidden: false,
+    valAxisLineHidden: false,
+    plotAreaBg: null,
+    chartBg: null,
+    showLegend: false,
+    legendPos: null,
+    catAxisCrossBetween: 'between',
+    valAxisMajorTickMark: 'out',
+    catAxisMajorTickMark: 'out',
+    titleFontSizeHpt: null,
+    titleFontColor: null,
+    titleFontFace: null,
+    catAxisFontSizeHpt: null,
+    valAxisFontSizeHpt: null,
+    dataLabelFontSizeHpt: null,
+    subtotalIndices: [],
+    ...over,
+  };
+}
+
+const RECT: ChartRect = { x: 0, y: 0, w: 640, h: 360 };
+
+// The default value-axis gridline is a thin hairline (`#e0e0e0`, 0.5 px). A
+// series fill for the area family is a translucent `rgba(...)`. These heuristics
+// classify the recorded events by role.
+const isGridlineStroke = (e: Ev): boolean =>
+  e.op === 'stroke' && e.lineWidth <= 1 && e.strokeStyle.toLowerCase() === '#e0e0e0';
+const isSeriesFill = (e: Ev): boolean => e.op === 'fill' && /^rgba\(/i.test(e.fillStyle);
+
+describe('CH — value-axis gridlines paint under the data series', () => {
+  it('an area chart strokes its major gridlines BEFORE filling the series area', () => {
+    const rec = orderedRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'area',
+      categories: ['Jan', 'Feb', 'Mar', 'Apr'],
+      series: [series({ name: 'ARR', values: [37, 40, 44, 48] })],
+    }), RECT, 1);
+
+    const firstGridline = rec.events.findIndex(isGridlineStroke);
+    const firstSeriesFill = rec.events.findIndex(isSeriesFill);
+
+    expect(firstSeriesFill).toBeGreaterThanOrEqual(0); // the area fill happened
+    expect(firstGridline).toBeGreaterThanOrEqual(0);    // a gridline was stroked
+    // The gridline must be laid down first so the opaque/translucent area sits
+    // on top of it (PowerPoint occludes gridlines inside the fill region).
+    expect(firstGridline).toBeLessThan(firstSeriesFill);
+  });
+
+  it('a stacked area chart also strokes gridlines before any fill', () => {
+    const rec = orderedRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedArea',
+      categories: ['Jan', 'Feb', 'Mar'],
+      series: [
+        series({ name: 'A', values: [10, 12, 14] }),
+        series({ name: 'B', values: [5, 6, 7] }),
+      ],
+    }), RECT, 1);
+
+    const firstGridline = rec.events.findIndex(isGridlineStroke);
+    const firstSeriesFill = rec.events.findIndex(isSeriesFill);
+    expect(firstSeriesFill).toBeGreaterThanOrEqual(0);
+    expect(firstGridline).toBeGreaterThanOrEqual(0);
+    expect(firstGridline).toBeLessThan(firstSeriesFill);
+  });
+
+  it('a plain line/area combo keeps gridlines below the area fill', () => {
+    // Guard the line renderer (which draws area-like fills? no — line strokes).
+    // Line chart already gridlines-first; assert it does not regress by pinning a
+    // filled marker/area does not precede the gridline. Uses the line renderer.
+    const rec = orderedRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'area',
+      categories: ['A', 'B', 'C', 'D', 'E'],
+      series: [series({ name: 'S', values: [1, 2, 3, 2, 4] })],
+      // Explicit gridline color exercises the `grid.explicit` uniform-stroke path.
+      valAxisGridlineColor: '888888',
+    }), RECT, 1);
+    const firstGridline = rec.events.findIndex(e => e.op === 'stroke' && e.strokeStyle.toLowerCase() === '#888888');
+    const firstSeriesFill = rec.events.findIndex(isSeriesFill);
+    expect(firstGridline).toBeGreaterThanOrEqual(0);
+    expect(firstSeriesFill).toBeGreaterThanOrEqual(0);
+    expect(firstGridline).toBeLessThan(firstSeriesFill);
+  });
+});

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -2473,9 +2473,37 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   const { color: catLineColor, width: catLineW } = resolveAxisLine(chart.catAxisLineColor, chart.catAxisLineWidthEmu, ptToPx);
   const { color: valLineColor, width: valLineW } = resolveAxisLine(chart.valAxisLineColor, chart.valAxisLineWidthEmu, ptToPx);
 
-  // Draw the translucent series fills FIRST, then lay gridlines, axis rules,
-  // tick marks and labels on top so they stay visible across the filled
-  // region (PowerPoint keeps the gridlines legible under the 55%-alpha area).
+  // Value-axis MAJOR gridlines are drawn UNDER the series (before the fills), so
+  // an opaque/translucent area occludes the gridlines inside its region —
+  // matching PowerPoint (verified against private/sample-14.pdf slide-6, where
+  // every gridline inside the teal ARR fill reads solid teal and only the
+  // gridlines above the fill top stay visible). This mirrors the bar/line/stock/
+  // scatter/waterfall/box renderers, which already stroke gridlines first. The
+  // axis rules, tick marks and value/category labels stay AFTER the series (drawn
+  // further below) so they sit atop the plot. `<c:valAx><c:majorGridlines>` is on
+  // by default (`drawValMajorGridlines`); `<c:minorGridlines>` only when declared.
+  if (!chart.valAxisHidden && drawValMajorGridlines(chart)) {
+    const grid = valGridStroke(chart, ptToPx);
+    const steps = Math.round(axMax / step);
+    for (let si = 0; si <= steps; si++) {
+      const v = si * step;
+      strokeValueGridlineH(ctx, px0, pw, toY(v), si === 0, grid);
+    }
+  }
+  // Category-axis MAJOR gridlines (`<c:catAx><c:majorGridlines>`, §21.2.2.100):
+  // vertical lines at the category ticks, also under the fills. Off by default
+  // (byte-stable when the file omits them).
+  if (!chart.catAxisHidden && drawCatMajorGridlines(chart)) {
+    const cg = catGridStroke(chart, ptToPx);
+    ctx.strokeStyle = cg.color;
+    ctx.lineWidth = cg.width;
+    for (const frac of catGridlineFractions(chart, n)) {
+      const gx = px0 + frac * pw;
+      ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
+    }
+  }
+
+  // Draw the series area fills ON TOP of the gridlines laid down above.
   const stackBase = stacked ? new Array(n).fill(0) as number[] : null;
   for (let si = chart.series.length - 1; si >= 0; si--) {
     const s = chart.series[si];
@@ -2598,29 +2626,19 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     }
   }
 
+  // Value-axis tick marks + labels. The gridlines themselves were already laid
+  // down UNDER the series (above the fill loop); here we only add the tick marks
+  // and the value labels, which belong ON TOP of the plot.
   if (!chart.valAxisHidden) {
     ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     ctx.textBaseline = 'middle';
-    const grid = valGridStroke(chart, ptToPx);
     const steps = Math.round(axMax / step);
     for (let si = 0; si <= steps; si++) {
       const v = si * step; const gy = toY(v);
-      strokeValueGridlineH(ctx, px0, pw, gy, si === 0, grid);
       drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, valLineColor, valLineW);
       ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
       ctx.textAlign = 'right';
       ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
-    }
-  }
-  // Category-axis MAJOR gridlines (`<c:catAx><c:majorGridlines>`, §21.2.2.100):
-  // vertical lines at the category ticks. Off by default (byte-stable).
-  if (!chart.catAxisHidden && drawCatMajorGridlines(chart)) {
-    const cg = catGridStroke(chart, ptToPx);
-    ctx.strokeStyle = cg.color;
-    ctx.lineWidth = cg.width;
-    for (const frac of catGridlineFractions(chart, n)) {
-      const gx = px0 + frac * pw;
-      ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
     }
   }
   // Category-axis baseline + value-axis rule. `<c:*Ax><c:spPr><a:ln><a:noFill>`


### PR DESCRIPTION
## Problem

User report (private/sample-14.pptx slide-6, the "Annual recurring revenue" **area chart**): PowerPoint draws the gray horizontal major gridlines **behind** the green area fill, so they are occluded inside the fill. Our renderer drew them **on top**, so gridlines were visible across the filled region.

The area renderer was the **only** cartesian chart type with this inversion. It filled the series first and then stroked the value-axis (and category-axis) major gridlines afterward. bar / line / stock / scatter / waterfall / box all already stroke gridlines *before* their series.

## Ground truth (PDF, pixel-measured)

`packages/pptx/public/private/sample-14.pdf` slide-6, rendered at 150 dpi. The teal area fill body is **RGB(125,216,206)**. Sampling each major-gridline y-position inside the fill:

| value | gridline y | pixel inside fill | verdict |
|-------|-----------|-------------------|---------|
| 10 | 844 | RGB(125,216,206) | GREEN — occluded |
| 20 | 741 | RGB(125,216,206) | GREEN — occluded |
| 30 | 638 | RGB(125,216,206) | GREEN — occluded |
| 40 | 535 | RGB(125,216,206) | GREEN — occluded |
| 50 | 432 | RGB(226,232,240) | GRAY — visible (above fill top) |
| 60 | 329 | RGB(255,255,255) | white (above fill) |

Every gridline that falls inside the fill is fully occluded (solid teal); only the gridlines **above** the fill top stay visible. PowerPoint draws major gridlines **under** the opaque area fill.

## Fix

In `renderAreaChart` (`packages/core/src/chart/renderer.ts`): move the value-axis MAJOR gridline pass and the category-axis MAJOR gridline pass **ahead of the series fill loop**. Keep the axis rules, tick marks and value/category labels **after** the series so they still sit atop the plot (the PDF shows axis ticks/labels are outside/above the fill). This is not an area-only hack — it aligns area with the ordering every other renderer already uses.

### Before / after draw order (area chart, recorded fill/stroke stream)

- **Before:** `FILL rgba(...,0.6)` (series) at index 0 → gridline `#e0e0e0`/`#aaa` strokes at index 4+ → gridline **over** fill.
- **After:** gridline strokes at indices 0–11 → series `FILL` at index 12 → gridline **under** fill.

### Before / after pixels (same skia render of the slide-6 ARR model, fill body RGB(169,221,216))

- **Before (origin/main):** 10 gridline pixels bleed through the fill at y = 241, 242, 276, 310, 344, 378, 379, 413, 447, 481 (colors ~RGB(183,222,218)).
- **After (this branch):** **0** gridline pixels inside the fill — every gridline occluded, matching the PDF.

Coordinates, colors and widths are unchanged; only the draw **order** moves. The `renderer-signature` snapshots for `area+legend` / `stackedArea` reorder the identical gridline strokes verbatim (same y-positions 88.8→479.2 spans). All other snapshots and non-chart drawing are byte-identical.

## Full chart-family impact

| renderer | gridlines vs series (origin/main) | changed here |
|----------|-----------------------------------|--------------|
| bar / column (incl. **combo bar+line+markers**) | gridlines first (under) ✓ | no |
| line | gridlines first (under) ✓ | no |
| stock | gridlines first (under) ✓ | no |
| scatter / bubble | gridlines first (under) ✓ | no |
| waterfall | gridlines first (under) ✓ | no |
| box & whisker | gridlines first (under) ✓ | no |
| radar | polar (no horizontal value gridlines) | no |
| pie / doughnut | no gridlines | no |
| **area / stackedArea / stackedAreaPct** | **fills first, gridlines on top ✗** | **yes** |

### Second report: sample-9.xlsx combo chart — already correct (no change needed)

The "Gift budget and tracker" combo (stacked columns + teal line + markers) routes through the bar renderer, which already strokes gridlines first. Verified by reading the live canvas (origin/main, 3132×1870):

- At each of the 8 gridlines crossing a column, **0** gridline pixels show over the column (88 column pixels per gridline row, all opaque) — columns occlude the gridlines.
- At every gridline the teal line crosses, the on-gridline pixel reads teal RGB(0,95,96) with `onIsTeal=true` — the **line** sits on top of the gridline.
- Markers (solid teal discs) at gridline crossings read teal — **markers** on top too.

So the combo chart's gridlines are already behind the columns, line and markers; this PR does not touch that path.

## Tests / gates

- New `packages/core/src/chart/renderer-gridline-zorder.test.ts` (TDD red→green): asserts the gridline stroke precedes the series fill for area / stackedArea / explicit-gridline-color. 3/3 pass.
- `renderer-signature` snapshots updated for the two area cases (verbatim reorder).
- Full core suite: **1483 passed** (82 files). Core `tsc --noEmit`: clean. `ast-grep scan`: clean.
- References were **not** touched. (The pre-existing root `tsc --build` WASM-glue errors are unrelated — the worktree has no built WASM.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)