### PR TITLE
feat: pointer-anchored (zoom-toward-cursor) trackpad/Ctrl+wheel zoom

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -382,7 +382,10 @@ export {
 export { computeVisibleRange, type VisibleRange, type VisibleRangePad } from './layout/virtual-scroll';
 // Shared exponential wheel/pinch zoom step (Ctrl/⌘+wheel). Pure — the caller
 // clamps to its own [zoomMin, zoomMax]. Used by XlsxViewer + the scroll viewers.
-export { zoomStepScale } from './interaction/zoom';
+// `anchoredZoomOffset` is the companion pointer-anchored ("zoom toward the
+// cursor") scroll correction: given the pointer position it returns the new
+// scroll offset that keeps the content point under the cursor fixed across a zoom.
+export { zoomStepScale, anchoredZoomOffset, type ScrollClamp } from './interaction/zoom';
 // IX9 — the shared zoom API contract for all five viewers: the ZoomableViewer
 // interface (getScale/setScale/zoomIn/zoomOut/fitWidth/fitPage) plus its pure
 // support logic (the discrete zoom-step ladder, fit-to-content scale math, clamp).

--- a/packages/core/src/interaction/zoom.test.ts
+++ b/packages/core/src/interaction/zoom.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { zoomStepScale } from './zoom.js';
+import { zoomStepScale, anchoredZoomOffset } from './zoom.js';
 
 /**
  * Ctrl/⌘ + wheel (and trackpad pinch, which the browser reports as a ctrl-wheel)
@@ -40,5 +40,81 @@ describe('zoomStepScale (ctrl/pinch zoom)', () => {
     const from1 = zoomStepScale(1, -10) - 1;
     const from2 = zoomStepScale(2, -10) - 2;
     expect(from2).toBeCloseTo(from1 * 2, 10);
+  });
+});
+
+/**
+ * anchoredZoomOffset — the pointer-anchored ("zoom toward the cursor") scroll
+ * correction. The invariant it exists to guarantee: the content pixel under the
+ * gesture anchor before the zoom is under the SAME anchor after the zoom. Screen
+ * position of that content pixel is `anchor + (c − scrollNew)` where `c` is its
+ * scaled-content coordinate; the assertions below verify it lands back on `anchor`.
+ */
+describe('anchoredZoomOffset (pointer-anchored zoom)', () => {
+  const NO_CLAMP = { maxScroll: Number.POSITIVE_INFINITY };
+
+  /** Screen offset of the content pixel that was under `anchor` at the OLD scale,
+   *  measured after applying `scrollNew` at the NEW scale. Should equal `anchor`. */
+  const screenAfter = (
+    scrollOld: number,
+    anchor: number,
+    scaleOld: number,
+    scaleNew: number,
+    scrollNew: number,
+  ) => {
+    const c = (scrollOld + anchor) * (scaleNew / scaleOld); // pinned content px @ new scale
+    return c - scrollNew;
+  };
+
+  it('keeps the point under the anchor fixed when zooming IN', () => {
+    const scrollOld = 300;
+    const anchor = 200;
+    const scrollNew = anchoredZoomOffset(scrollOld, anchor, 1, 2, NO_CLAMP);
+    expect(screenAfter(scrollOld, anchor, 1, 2, scrollNew)).toBeCloseTo(anchor, 9);
+  });
+
+  it('keeps the point under the anchor fixed when zooming OUT', () => {
+    const scrollOld = 800;
+    const anchor = 150;
+    const scrollNew = anchoredZoomOffset(scrollOld, anchor, 2, 1, NO_CLAMP);
+    expect(screenAfter(scrollOld, anchor, 2, 1, scrollNew)).toBeCloseTo(anchor, 9);
+  });
+
+  it('is the identity when the scale does not change (no drift on a no-op zoom)', () => {
+    expect(anchoredZoomOffset(432, 210, 1.3, 1.3, NO_CLAMP)).toBeCloseTo(432, 9);
+  });
+
+  it('round-trips: zoom in by r then out by 1/r returns the original offset', () => {
+    const scrollOld = 500;
+    const anchor = 120;
+    const zoomedIn = anchoredZoomOffset(scrollOld, anchor, 1, 1.6, NO_CLAMP);
+    const back = anchoredZoomOffset(zoomedIn, anchor, 1.6, 1, NO_CLAMP);
+    expect(back).toBeCloseTo(scrollOld, 9);
+  });
+
+  it('anchor at the region start (0) reduces to an origin-anchored rescale', () => {
+    // scrollNew = scrollOld · ratio when anchor = 0.
+    expect(anchoredZoomOffset(400, 0, 1, 2, NO_CLAMP)).toBeCloseTo(800, 9);
+    expect(anchoredZoomOffset(400, 0, 2, 1, NO_CLAMP)).toBeCloseTo(200, 9);
+  });
+
+  it('clamps to 0 (never scrolls above the content top)', () => {
+    // Zooming out near the top would want a negative offset; pin to 0.
+    const scrollNew = anchoredZoomOffset(10, 200, 2, 1, NO_CLAMP);
+    expect(scrollNew).toBe(0);
+  });
+
+  it('clamps to maxScroll (never scrolls past the content bottom)', () => {
+    // A large zoom-in near the bottom would overshoot the scrollable extent.
+    const scrollNew = anchoredZoomOffset(900, 400, 1, 4, { maxScroll: 1000 });
+    expect(scrollNew).toBe(1000);
+  });
+
+  it('treats a degenerate negative maxScroll (content < viewport) as 0', () => {
+    expect(anchoredZoomOffset(0, 100, 1, 2, { maxScroll: -50 })).toBe(0);
+  });
+
+  it('does not divide by zero when the old scale is 0 (returns a clamped no-op)', () => {
+    expect(anchoredZoomOffset(120, 60, 0, 2, NO_CLAMP)).toBe(120);
   });
 });

--- a/packages/core/src/interaction/zoom.ts
+++ b/packages/core/src/interaction/zoom.ts
@@ -26,3 +26,65 @@ const ZOOM_WHEEL_SENSITIVITY = 0.01;
 export function zoomStepScale(currentScale: number, deltaY: number): number {
   return currentScale * Math.exp(-deltaY * ZOOM_WHEEL_SENSITIVITY);
 }
+
+/** Clamp range for {@link anchoredZoomOffset}: the scroll offset must stay within
+ *  `[0, maxScroll]` (the browser clamps native scrollLeft/scrollTop the same way).
+ *  `maxScroll` is the largest legal scroll on that axis at the NEW scale (usually
+ *  `totalContentPx − viewportPx`, floored at 0). */
+export interface ScrollClamp {
+  /** Largest legal scroll offset on this axis at the new scale (≥ 0). A degenerate
+   *  `maxScroll < 0` (content shorter than the viewport) is treated as 0. */
+  maxScroll: number;
+}
+
+/**
+ * The new scroll offset (one axis) that keeps the content point currently under a
+ * gesture anchor pinned under that same anchor across a zoom — i.e. pointer-
+ * anchored ("zoom toward the cursor") zoom, instead of the viewport-top / origin
+ * anchoring a naive rescale gives.
+ *
+ * DERIVATION. Work in the SCALING content's own pixels, both measured from the
+ * start of that region (the caller subtracts any scale-invariant lead-in — desk
+ * padding, a frozen header/pane — from the pointer BEFORE calling, so `anchor` is
+ * the pointer's distance into the region that actually zooms):
+ *
+ *   - `scrollOld` — current scroll offset into the region (scaled px, ≥ 0).
+ *   - `anchor`    — the pointer's offset from the region's on-screen start
+ *                   (scaled px). The content pixel under the pointer is therefore
+ *                   `c = scrollOld + anchor`.
+ *   - A zoom multiplies every content pixel by `ratio = scaleNew / scaleOld`, so
+ *     that SAME logical content sits at `c' = c · ratio` at the new scale.
+ *   - To keep it under the (unchanged, screen-fixed) pointer, we need
+ *     `scrollNew + anchor = c'`, hence:
+ *
+ *         scrollNew = (scrollOld + anchor) · (scaleNew / scaleOld) − anchor
+ *
+ * IDENTITY: `scaleNew === scaleOld` ⇒ `ratio = 1` ⇒ `scrollNew = scrollOld` (no
+ * drift on a no-op zoom). ROUND-TRIP: zooming out by the inverse ratio returns the
+ * original offset exactly (the map is affine and invertible). ANCHOR = 0 (pointer
+ * at the region start) reduces to the plain `scrollOld · ratio` origin-anchored
+ * rescale.
+ *
+ * CLAMP: the result is clamped to `[0, clamp.maxScroll]` — the same range the
+ * browser pins native scroll to. AT A CONTENT EDGE the anchor cannot always be
+ * honoured (there is no scroll offset that would place the pinned point under the
+ * pointer without exposing off-content area); the clamp then wins and the point
+ * drifts, which is the natural, expected behaviour (design §5.3).
+ *
+ * Pure; no DOM. Shared by the two continuous-scroll viewers (both axes) and
+ * XlsxViewer (both axes, past its fixed header + frozen panes).
+ */
+export function anchoredZoomOffset(
+  scrollOld: number,
+  anchor: number,
+  scaleOld: number,
+  scaleNew: number,
+  clamp: ScrollClamp,
+): number {
+  // Guard a degenerate old scale (never happens for a live viewer, but keeps the
+  // function total): fall back to no movement rather than dividing by zero.
+  const ratio = scaleOld > 0 ? scaleNew / scaleOld : 1;
+  const want = (scrollOld + anchor) * ratio - anchor;
+  const max = clamp.maxScroll > 0 ? clamp.maxScroll : 0;
+  return want < 0 ? 0 : want > max ? max : want;
+}

--- a/packages/core/src/interaction/zoom.ts
+++ b/packages/core/src/interaction/zoom.ts
@@ -43,21 +43,31 @@ export interface ScrollClamp {
  * anchored ("zoom toward the cursor") zoom, instead of the viewport-top / origin
  * anchoring a naive rescale gives.
  *
- * DERIVATION. Work in the SCALING content's own pixels, both measured from the
- * start of that region (the caller subtracts any scale-invariant lead-in — desk
- * padding, a frozen header/pane — from the pointer BEFORE calling, so `anchor` is
- * the pointer's distance into the region that actually zooms):
+ * DERIVATION. Work in the SCALING content's own pixels:
  *
- *   - `scrollOld` — current scroll offset into the region (scaled px, ≥ 0).
- *   - `anchor`    — the pointer's offset from the region's on-screen start
- *                   (scaled px). The content pixel under the pointer is therefore
- *                   `c = scrollOld + anchor`.
+ *   - `scrollOld` — the current NATIVE scroll offset (scaled px, ≥ 0).
+ *   - `anchor`    — the pointer's offset INTO the scaling region (scaled px).
+ *                   The content pixel under the pointer is `c = scrollOld + anchor`.
  *   - A zoom multiplies every content pixel by `ratio = scaleNew / scaleOld`, so
  *     that SAME logical content sits at `c' = c · ratio` at the new scale.
  *   - To keep it under the (unchanged, screen-fixed) pointer, we need
  *     `scrollNew + anchor = c'`, hence:
  *
  *         scrollNew = (scrollOld + anchor) · (scaleNew / scaleOld) − anchor
+ *
+ * LEAD-INS — how the caller derives `anchor` from a raw pointer position `x`
+ * (measured from the scroll viewport's origin). The two kinds behave differently:
+ *
+ *   - FIXED lead-in (scale-INVARIANT space before the scaling content, e.g. the
+ *     scroll viewers' left desk gutter `padL`, where screen-x of content pixel c
+ *     is `padL + c − scroll`): subtract it from the ANCHOR ONLY — `anchor = x −
+ *     padL` — and keep `scrollOld` and the clamp in NATIVE scroll space. Do NOT
+ *     also shift the scroll by ±padL around the call: that runs the fixed gutter
+ *     through the zoom ratio and over-compensates by `padL·(ratio−1)` per step.
+ *   - SCALING lead-in (a lead-in drawn at ×scale, e.g. XlsxViewer's fixed-screen
+ *     header + frozen band of UNSCALED extent K, where the logical content under
+ *     the pointer is `(x + scroll)/scale − K`): the `K·scale` terms cancel out of
+ *     the invariance equation entirely, so pass the RAW pointer — `anchor = x`.
  *
  * IDENTITY: `scaleNew === scaleOld` ⇒ `ratio = 1` ⇒ `scrollNew = scrollOld` (no
  * drift on a no-op zoom). ROUND-TRIP: zooming out by the inverse ratio returns the
@@ -71,8 +81,9 @@ export interface ScrollClamp {
  * pointer without exposing off-content area); the clamp then wins and the point
  * drifts, which is the natural, expected behaviour (design §5.3).
  *
- * Pure; no DOM. Shared by the two continuous-scroll viewers (both axes) and
- * XlsxViewer (both axes, past its fixed header + frozen panes).
+ * Pure; no DOM. Shared by the two continuous-scroll viewers (both axes; fixed
+ * gutter subtracted from the horizontal anchor) and XlsxViewer (both axes; its
+ * header + frozen band is a SCALING lead-in, so the raw pointer is the anchor).
  */
 export function anchoredZoomOffset(
   scrollOld: number,

--- a/packages/docx/src/scroll-viewer-test-dom.ts
+++ b/packages/docx/src/scroll-viewer-test-dom.ts
@@ -28,8 +28,13 @@ export interface FakeEl {
   height: number;
   // scrollHost-only (settable by the test to drive the virtualization loop)
   scrollTop: number;
+  scrollLeft: number;
   clientHeight: number;
   clientWidth: number;
+  /** Spacer-only: laid-out width. The real DOM derives it from style.width; the
+   *  fake keeps it a settable number (default 0) so a horizontal-zoom test can
+   *  give the scroll extent a concrete size. */
+  offsetWidth: number;
   _listeners: Map<string, Array<(e: unknown) => void>>;
   _bitmapCtx?: { transferFromImageBitmap: (b: unknown) => void; lastBitmap: unknown };
   /** Records every DEVICE-BUFFER resize (a `canvas.width`/`canvas.height`
@@ -64,8 +69,10 @@ export function makeEl(tag: string): FakeEl {
     width: 0,
     height: 0,
     scrollTop: 0,
+    scrollLeft: 0,
     clientHeight: 0,
     clientWidth: 0,
+    offsetWidth: 0,
     children: [],
     parentElement: null,
     // Placeholders for the interface; replaced by computed getters below

--- a/packages/docx/src/scroll-viewer-zoom-contract.test.ts
+++ b/packages/docx/src/scroll-viewer-zoom-contract.test.ts
@@ -217,4 +217,36 @@ describe('DocxScrollViewer IX9 zoom contract', () => {
     expect(v.viewportYOfForTest(topContent.page, topContent.frac)).toBeCloseTo(0, 4);
     v.destroy();
   });
+
+  // HORIZONTAL pointer anchor with a non-zero left gutter. The gutter `padL` is
+  // FIXED (does not scale), so the invariant is on the LOGICAL content-x under
+  // the pointer: screen-x of content pixel c is `padL + c − scrollLeft`, hence
+  // logicalX = (scrollLeft + x − padL) / scale must not move across the zoom.
+  // Regression pin: subtracting/adding padL around the SCROLL as well (instead of
+  // subtracting it from the anchor only) over-compensates by padL·(ratio−1).
+  it('a Ctrl+wheel zoom keeps the content under the pointer fixed horizontally (padL > 0)', () => {
+    const padL = 24;
+    const { v, scrollHost } = setup({ paddingLeft: padL, paddingRight: padL });
+    v.setScale(3); // page 133.33 × 3 = 400px wide > the 200px viewport ⇒ h-scrollable
+    // The fake DOM derives no layout from style; give the spacer a generous
+    // laid-out width so the [0, maxLeft] clamp does not bind.
+    const spacer = scrollHost.children[0] as FakeEl;
+    spacer.offsetWidth = 100_000;
+    scrollHost.scrollLeft = 120;
+    const ax = 130; // pointer x in viewport px (over the page, right of the gutter)
+    const scaleBefore = v.getScale();
+    const logicalXBefore = (scrollHost.scrollLeft + ax - padL) / scaleBefore;
+    scrollHost.dispatch('wheel', {
+      ctrlKey: true,
+      deltaY: -20, // ratio e^0.2 ≈ 1.221 ⇒ 3 → ≈3.66, inside zoomMax 4 (unclamped)
+      clientX: ax,
+      clientY: 200,
+      preventDefault() {},
+    });
+    const scaleAfter = v.getScale();
+    expect(scaleAfter).toBeGreaterThan(scaleBefore);
+    const logicalXAfter = (scrollHost.scrollLeft + ax - padL) / scaleAfter;
+    expect(logicalXAfter).toBeCloseTo(logicalXBefore, 6);
+    v.destroy();
+  });
 });

--- a/packages/docx/src/scroll-viewer-zoom-contract.test.ts
+++ b/packages/docx/src/scroll-viewer-zoom-contract.test.ts
@@ -249,4 +249,26 @@ describe('DocxScrollViewer IX9 zoom contract', () => {
     expect(logicalXAfter).toBeCloseTo(logicalXBefore, 6);
     v.destroy();
   });
+
+  // A wheel gesture whose setScale is a NO-OP (already clamped at zoomMax) must
+  // NOT leak its pointer anchor into the next non-gesture setScale: the stepper
+  // right after it still anchors on the viewport TOP.
+  it('a no-op gesture (clamped at zoomMax) does not leak its anchor into the next setScale', () => {
+    const { v, scrollHost } = setup();
+    v.setScale(4); // pinned at zoomMax
+    scrollHost.scrollTop = 500;
+    // Ctrl+wheel zoom-IN at zoomMax ⇒ clamped to 4 ⇒ no-op; its anchor must be dropped.
+    scrollHost.dispatch('wheel', {
+      ctrlKey: true,
+      deltaY: -60,
+      clientX: 100,
+      clientY: 250,
+      preventDefault() {},
+    });
+    expect(v.getScale()).toBe(4); // confirmed no-op
+    const topContent = v.contentAtViewportYForTest(0);
+    v.zoomOut(); // non-gesture stepper — must keep the viewport-TOP anchor
+    expect(v.viewportYOfForTest(topContent.page, topContent.frac)).toBeCloseTo(0, 4);
+    v.destroy();
+  });
 });

--- a/packages/docx/src/scroll-viewer-zoom-contract.test.ts
+++ b/packages/docx/src/scroll-viewer-zoom-contract.test.ts
@@ -167,4 +167,54 @@ describe('DocxScrollViewer IX9 zoom contract', () => {
     expect(v.getScale()).toBe(3); // latched pre-clamped
     v.destroy();
   });
+
+  // Pointer-anchored ("zoom toward the cursor") Ctrl/⌘+wheel zoom: the content
+  // point under the pointer before the zoom must be under the SAME viewport-y
+  // after. The fake DOM reports getBoundingClientRect().top = 0, so the wheel
+  // event's clientY is exactly the scrollHost-viewport y.
+  it('a Ctrl+wheel zoom keeps the content under the pointer fixed (zoom in)', () => {
+    const { v, scrollHost } = setup();
+    scrollHost.scrollTop = 500; // scrolled into the document
+    const pointerY = 250; // mid-viewport
+    const before = v.contentAtViewportYForTest(pointerY);
+    scrollHost.dispatch('wheel', {
+      ctrlKey: true,
+      deltaY: -60, // zoom in
+      clientX: 100,
+      clientY: pointerY,
+      preventDefault() {},
+    });
+    expect(v.getScale()).toBeGreaterThan(1.5); // zoomed in past the base
+    // The same content point (page + intra-page fraction) is back under pointerY.
+    expect(v.viewportYOfForTest(before.page, before.frac)).toBeCloseTo(pointerY, 4);
+    v.destroy();
+  });
+
+  it('a Ctrl+wheel zoom keeps the content under the pointer fixed (zoom out)', () => {
+    const { v, scrollHost } = setup();
+    v.setScale(3); // start zoomed in so there is room to zoom out
+    scrollHost.scrollTop = 400;
+    const pointerY = 120;
+    const before = v.contentAtViewportYForTest(pointerY);
+    scrollHost.dispatch('wheel', {
+      ctrlKey: true,
+      deltaY: 60, // zoom out
+      clientX: 80,
+      clientY: pointerY,
+      preventDefault() {},
+    });
+    expect(v.getScale()).toBeLessThan(3);
+    expect(v.viewportYOfForTest(before.page, before.frac)).toBeCloseTo(pointerY, 4);
+    v.destroy();
+  });
+
+  it('a non-gesture setScale still anchors on the viewport top (unchanged)', () => {
+    const { v, scrollHost } = setup();
+    scrollHost.scrollTop = 500;
+    const topContent = v.contentAtViewportYForTest(0); // what sits at the viewport top
+    v.setScale(3); // public API, no pointer anchor
+    // The viewport-top content is preserved (historical top-anchor behaviour).
+    expect(v.viewportYOfForTest(topContent.page, topContent.frac)).toBeCloseTo(0, 4);
+    v.destroy();
+  });
 });

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1104,8 +1104,9 @@ export class DocxScrollViewer implements ZoomableViewer {
     // HORIZONTAL anchor (gesture only — a non-gesture setScale leaves scrollLeft
     // untouched, matching the historical behaviour). The page's left edge sits at
     // the scale-INVARIANT left gutter `padL` when it overflows the viewport (see
-    // `_positionSlot`), so the scaling region starts at `padL`; feed the pointer's
-    // offset PAST that lead-in to the pure anchored-offset helper.
+    // `_positionSlot`): screen-x of content pixel c is `padL + c − scrollLeft`,
+    // so the pointer's offset INTO the scaling region is `x − padL` and the
+    // scroll offset itself already lives in the region's own px.
     const padL = this._padH().left;
     const scrollLeft0 = this._scrollHost.scrollLeft || 0;
 
@@ -1135,16 +1136,23 @@ export class DocxScrollViewer implements ZoomableViewer {
     const newContentY = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
     this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, newContentY - anchorY));
 
-    // Re-anchor horizontally for a gesture zoom (past the fixed `padL` lead-in),
-    // clamped to the new horizontal extent. Skipped entirely for a non-gesture
-    // setScale so slider/stepper/API/resize behaviour is byte-for-byte unchanged.
+    // Re-anchor horizontally for a gesture zoom. `padL` is a FIXED (non-scaling)
+    // gutter, so it is subtracted from the ANCHOR only — the scroll offset stays
+    // in NATIVE space with the browser's own [0, maxLeft] clamp. (Shifting the
+    // scroll by ±padL as well would run the fixed gutter through the zoom ratio
+    // and over-compensate by padL·(ratio−1) per step: with `screen = padL + c −
+    // scrollLeft`, pinning c·ratio under the pointer x gives exactly
+    // `scrollLeft' = ratio·(scrollLeft + (x−padL)) − (x−padL)`.) Skipped entirely
+    // for a non-gesture setScale so slider/stepper/API/resize is unchanged.
     if (gestureAnchor) {
       const maxLeft = Math.max(0, (this._spacer.offsetWidth || 0) - this._scrollHost.clientWidth);
-      this._scrollHost.scrollLeft =
-        padL +
-        anchoredZoomOffset(scrollLeft0 - padL, gestureAnchor.x - padL, prevScale, next, {
-          maxScroll: maxLeft - padL,
-        });
+      this._scrollHost.scrollLeft = anchoredZoomOffset(
+        scrollLeft0,
+        gestureAnchor.x - padL,
+        prevScale,
+        next,
+        { maxScroll: maxLeft },
+      );
     }
 
     // FLICKER-FREE ZOOM (design §7). Do NOT recycle + re-render in-window slots

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1,4 +1,4 @@
-import { computeVisibleRange, openExternalHyperlink, PT_TO_PX, zoomStepScale, nextZoomStep, prevZoomStep, fitScale, type VisibleRange } from '@silurus/ooxml-core';
+import { computeVisibleRange, openExternalHyperlink, PT_TO_PX, zoomStepScale, anchoredZoomOffset, nextZoomStep, prevZoomStep, fitScale, type VisibleRange } from '@silurus/ooxml-core';
 import type { HyperlinkTarget, ZoomableViewer } from '@silurus/ooxml-core';
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
@@ -257,6 +257,14 @@ export class DocxScrollViewer implements ZoomableViewer {
    *  is host-agnostic. */
   private _settleTimer: ReturnType<typeof setTimeout> | null = null;
   private _wheelListener: ((e: WheelEvent) => void) | null = null;
+  /** Gesture-only pointer anchor for the NEXT `setScale`, in scrollHost-viewport
+   *  px (`{ x, y }` from the wheel event, relative to the scroll host's top-left).
+   *  Set by the Ctrl/⌘+wheel handler right before it calls `setScale` so the zoom
+   *  pivots on the cursor ("zoom toward the pointer") in BOTH axes; consumed and
+   *  cleared by `setScale`. `null` for every non-gesture source (the public
+   *  `setScale`, the +/- steppers, `fitWidth`/`fitPage`, the resize re-fit), which
+   *  keep the historical viewport-TOP re-anchor so their behaviour is unchanged. */
+  private _pendingZoomAnchor: { x: number; y: number } | null = null;
   /** Observes the container so a width change re-fits the base scale. Disconnected
    *  in `destroy()`. */
   private _resizeObserver: ResizeObserver | null = null;
@@ -338,6 +346,16 @@ export class DocxScrollViewer implements ZoomableViewer {
         if (!(e.ctrlKey || e.metaKey)) return; // bare wheel scrolls natively
         e.preventDefault();
         if (e.deltaY === 0) return;
+        // Pointer-anchored zoom: pivot on the cursor, not the viewport top. Record
+        // the pointer in scrollHost-viewport px (subtract the host's on-screen
+        // origin) so `setScale` can keep the content point under the cursor fixed.
+        // A malformed event (no clientX/Y) yields a non-finite anchor; drop it so
+        // `setScale` falls back to the historical viewport-top re-anchor.
+        const rect = this._scrollHost.getBoundingClientRect();
+        const ax = e.clientX - rect.left;
+        const ay = e.clientY - rect.top;
+        this._pendingZoomAnchor =
+          Number.isFinite(ax) && Number.isFinite(ay) ? { x: ax, y: ay } : null;
         this.setScale(zoomStepScale(this._scale, e.deltaY));
       };
       this._scrollHost.addEventListener('wheel', this._wheelListener as EventListener, {
@@ -550,6 +568,28 @@ export class DocxScrollViewer implements ZoomableViewer {
   private _padH(): { left: number; right: number } {
     const gap = this._gap();
     return { left: this._opts.paddingLeft ?? gap, right: this._opts.paddingRight ?? gap };
+  }
+
+  /** Index of the page whose slot spans content-offset `y` (largest `i` with
+   *  `offsets[i] <= y`), for the pointer-anchored zoom re-anchor. Mirrors the
+   *  `topIndex` search `computeVisibleRange` runs for the scrollTop, but for an
+   *  ARBITRARY content-y (the pointer, not the viewport top). Clamped into
+   *  `[0, n-1]`; a `y` below the first page (inside the leading pad) yields 0. */
+  private _pageIndexAtOffset(r: VisibleRange, y: number): number {
+    const { offsets } = r;
+    let lo = 0;
+    let hi = offsets.length - 1;
+    let idx = 0;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (offsets[mid] <= y) {
+        idx = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return idx;
   }
 
   private _range(): VisibleRange {
@@ -1034,17 +1074,40 @@ export class DocxScrollViewer implements ZoomableViewer {
       return;
     }
     if (next === this._scale) return;
+    const prevScale = this._scale;
 
-    // Capture the anchor from the CURRENT layout, before rescale.
+    // Consume the gesture-only pointer anchor (Ctrl/⌘+wheel set it just above).
+    // `null` for every non-gesture source, which anchors on the viewport TOP as
+    // before (anchorY 0). Clear immediately so a subsequent non-gesture setScale
+    // never inherits a stale anchor.
+    const gestureAnchor = this._pendingZoomAnchor;
+    this._pendingZoomAnchor = null;
+    const anchorY = gestureAnchor ? gestureAnchor.y : 0;
+
+    // Capture the VERTICAL anchor from the CURRENT layout, before rescale, as a
+    // (page index, intra-page fraction) pair. Anchoring on a page — not on the raw
+    // scrollTop — is what keeps the re-anchor exact despite the scale-INVARIANT
+    // desk padding and inter-page gaps (only the page heights scale, so a whole-
+    // scroll linear rescale would drift by the padding). The point we pin is the
+    // content under the pointer: content-y = scrollTop + anchorY (anchorY 0 ⇒ the
+    // viewport top, the historical behaviour).
     const r0 = this._range();
-    const top = r0.topIndex;
+    const anchorContentY = this._scrollHost.scrollTop + anchorY;
+    // Which page does that content-y fall in? `computeVisibleRange` attributes a
+    // point in the trailing gap to the page ABOVE it, so clamp the fraction to
+    // [0,1] to pin the page rather than drift into the gap.
+    const top = this._pageIndexAtOffset(r0, anchorContentY);
     const h0 = this._heights[top] || 0;
-    // intraFrac: the fraction of page `top` that has scrolled above the viewport
-    // top. Clamp to [0,1] — a scrollTop inside the trailing gap after page `top`
-    // is attributed to `top` by computeVisibleRange and would push intraFrac past
-    // 1, which would drift the re-anchor into the gap; pin the page instead.
-    let intraFrac = h0 > 0 ? (this._scrollHost.scrollTop - r0.offsets[top]) / h0 : 0;
+    let intraFrac = h0 > 0 ? (anchorContentY - r0.offsets[top]) / h0 : 0;
     intraFrac = Math.min(1, Math.max(0, intraFrac));
+
+    // HORIZONTAL anchor (gesture only — a non-gesture setScale leaves scrollLeft
+    // untouched, matching the historical behaviour). The page's left edge sits at
+    // the scale-INVARIANT left gutter `padL` when it overflows the viewport (see
+    // `_positionSlot`), so the scaling region starts at `padL`; feed the pointer's
+    // offset PAST that lead-in to the pure anchored-offset helper.
+    const padL = this._padH().left;
+    const scrollLeft0 = this._scrollHost.scrollLeft || 0;
 
     // Bump the render epoch BEFORE recycling/re-dispatching so any in-flight
     // render dispatched at the old scale is recognised as stale on resolution.
@@ -1065,10 +1128,24 @@ export class DocxScrollViewer implements ZoomableViewer {
     // The page px width changed with the scale, so the horizontal extent moves too.
     this._syncSpacerWidth();
 
-    // Pin the same fractional position of the same page under the viewport top.
+    // Pin the same fractional position of the same page under the pointer (or the
+    // viewport top for a non-gesture zoom): the on-screen y of that content point
+    // must stay at `anchorY`, so newScrollTop = newContentY − anchorY.
     const maxTop = Math.max(0, r1.totalHeight - this._scrollHost.clientHeight);
-    const wantTop = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
-    this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, wantTop));
+    const newContentY = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
+    this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, newContentY - anchorY));
+
+    // Re-anchor horizontally for a gesture zoom (past the fixed `padL` lead-in),
+    // clamped to the new horizontal extent. Skipped entirely for a non-gesture
+    // setScale so slider/stepper/API/resize behaviour is byte-for-byte unchanged.
+    if (gestureAnchor) {
+      const maxLeft = Math.max(0, (this._spacer.offsetWidth || 0) - this._scrollHost.clientWidth);
+      this._scrollHost.scrollLeft =
+        padL +
+        anchoredZoomOffset(scrollLeft0 - padL, gestureAnchor.x - padL, prevScale, next, {
+          maxScroll: maxLeft - padL,
+        });
+    }
 
     // FLICKER-FREE ZOOM (design §7). Do NOT recycle + re-render in-window slots
     // (that blanks each visible page to white every tick). Instead:
@@ -1470,6 +1547,28 @@ export class DocxScrollViewer implements ZoomableViewer {
    *  via the constructor's ResizeObserver). */
   resizeForTest(): void {
     this._onResize();
+  }
+
+  /** @internal test hook: the content point (page index + intra-page fraction)
+   *  currently under viewport-y `y` (px from the scroll host top). Lets a test
+   *  capture "what is under the cursor" before a zoom and re-query its on-screen
+   *  y afterwards to assert the pointer-anchored invariant. */
+  contentAtViewportYForTest(y: number): { page: number; frac: number } {
+    const r = this._range();
+    const contentY = this._scrollHost.scrollTop + y;
+    const page = this._pageIndexAtOffset(r, contentY);
+    const h = this._heights[page] || 0;
+    const frac = h > 0 ? Math.min(1, Math.max(0, (contentY - r.offsets[page]) / h)) : 0;
+    return { page, frac };
+  }
+
+  /** @internal test hook: inverse of {@link contentAtViewportYForTest} — the
+   *  current viewport-y (px from the scroll host top) of the content point at
+   *  (`page`, intra-page `frac`). */
+  viewportYOfForTest(page: number, frac: number): number {
+    const r = this._range();
+    const contentY = (r.offsets[page] ?? 0) + frac * (this._heights[page] || 0);
+    return contentY - this._scrollHost.scrollTop;
   }
 
   /**

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1064,6 +1064,14 @@ export class DocxScrollViewer implements ZoomableViewer {
     const zoomMin = this._opts.zoomMin ?? 0.1;
     const zoomMax = this._opts.zoomMax ?? 4;
     const next = Math.min(zoomMax, Math.max(zoomMin, scale));
+    // Consume the gesture-only pointer anchor (Ctrl/⌘+wheel set it just above)
+    // FIRST — before every early return — so a gesture whose setScale ends up a
+    // NO-OP (already pinned at zoomMin/zoomMax) or latches pre-establishment can
+    // never leak a stale anchor into a later non-gesture setScale (slider,
+    // steppers, fitWidth/fitPage, resize re-fit, public API), which must keep
+    // the historical viewport-TOP anchoring. `null` for every non-gesture source.
+    const gestureAnchor = this._pendingZoomAnchor;
+    this._pendingZoomAnchor = null;
     if (!this._doc || this._doc.pageCount === 0 || !this._scaleEstablished) {
       // IX9 F1 (family-unified pre-load semantics): a setScale before the doc is
       // loaded / before the base fit is established is LATCHED, not dropped —
@@ -1075,13 +1083,6 @@ export class DocxScrollViewer implements ZoomableViewer {
     }
     if (next === this._scale) return;
     const prevScale = this._scale;
-
-    // Consume the gesture-only pointer anchor (Ctrl/⌘+wheel set it just above).
-    // `null` for every non-gesture source, which anchors on the viewport TOP as
-    // before (anchorY 0). Clear immediately so a subsequent non-gesture setScale
-    // never inherits a stale anchor.
-    const gestureAnchor = this._pendingZoomAnchor;
-    this._pendingZoomAnchor = null;
     const anchorY = gestureAnchor ? gestureAnchor.y : 0;
 
     // Capture the VERTICAL anchor from the CURRENT layout, before rescale, as a

--- a/packages/pptx/src/scroll-viewer-test-dom.ts
+++ b/packages/pptx/src/scroll-viewer-test-dom.ts
@@ -26,8 +26,13 @@ export interface FakeEl {
   height: number;
   // scrollHost-only (settable by the test to drive the virtualization loop)
   scrollTop: number;
+  scrollLeft: number;
   clientHeight: number;
   clientWidth: number;
+  /** Spacer-only: laid-out width. The real DOM derives it from style.width; the
+   *  fake keeps it a settable number (default 0) so a horizontal-zoom test can
+   *  give the scroll extent a concrete size. */
+  offsetWidth: number;
   _listeners: Map<string, Array<(e: unknown) => void>>;
   _bitmapCtx?: { transferFromImageBitmap: (b: unknown) => void; lastBitmap: unknown };
   /** Records every DEVICE-BUFFER resize (a `canvas.width`/`canvas.height`
@@ -62,8 +67,10 @@ export function makeEl(tag: string): FakeEl {
     width: 0,
     height: 0,
     scrollTop: 0,
+    scrollLeft: 0,
     clientHeight: 0,
     clientWidth: 0,
+    offsetWidth: 0,
     children: [],
     parentElement: null,
     // Placeholders for the interface; replaced by computed getters below

--- a/packages/pptx/src/scroll-viewer-zoom-contract.test.ts
+++ b/packages/pptx/src/scroll-viewer-zoom-contract.test.ts
@@ -208,4 +208,36 @@ describe('PptxScrollViewer IX9 zoom contract', () => {
     expect(v.viewportYOfForTest(topContent.slide, topContent.frac)).toBeCloseTo(0, 4);
     v.destroy();
   });
+
+  // HORIZONTAL pointer anchor with a non-zero left gutter. The gutter `padL` is
+  // FIXED (does not scale), so the invariant is on the LOGICAL content-x under
+  // the pointer: screen-x of content pixel c is `padL + c − scrollLeft`, hence
+  // logicalX = (scrollLeft + x − padL) / scale must not move across the zoom.
+  // Regression pin: subtracting/adding padL around the SCROLL as well (instead of
+  // subtracting it from the anchor only) over-compensates by padL·(ratio−1).
+  it('a Ctrl+wheel zoom keeps the content under the pointer fixed horizontally (padL > 0)', () => {
+    const padL = 24;
+    const { v, scrollHost } = setup({ paddingLeft: padL, paddingRight: padL });
+    v.setScale(3); // slide 200 × 3 = 600px wide > the 200px viewport ⇒ h-scrollable
+    // The fake DOM derives no layout from style; give the spacer a generous
+    // laid-out width so the [0, maxLeft] clamp does not bind.
+    const spacer = scrollHost.children[0] as FakeEl;
+    spacer.offsetWidth = 100_000;
+    scrollHost.scrollLeft = 120;
+    const ax = 130; // pointer x in viewport px (over the slide, right of the gutter)
+    const scaleBefore = v.getScale();
+    const logicalXBefore = (scrollHost.scrollLeft + ax - padL) / scaleBefore;
+    scrollHost.dispatch('wheel', {
+      ctrlKey: true,
+      deltaY: -20, // ratio e^0.2 ≈ 1.221 ⇒ 3 → ≈3.66, inside zoomMax 4 (unclamped)
+      clientX: ax,
+      clientY: 200,
+      preventDefault() {},
+    });
+    const scaleAfter = v.getScale();
+    expect(scaleAfter).toBeGreaterThan(scaleBefore);
+    const logicalXAfter = (scrollHost.scrollLeft + ax - padL) / scaleAfter;
+    expect(logicalXAfter).toBeCloseTo(logicalXBefore, 6);
+    v.destroy();
+  });
 });

--- a/packages/pptx/src/scroll-viewer-zoom-contract.test.ts
+++ b/packages/pptx/src/scroll-viewer-zoom-contract.test.ts
@@ -240,4 +240,26 @@ describe('PptxScrollViewer IX9 zoom contract', () => {
     expect(logicalXAfter).toBeCloseTo(logicalXBefore, 6);
     v.destroy();
   });
+
+  // A wheel gesture whose setScale is a NO-OP (already clamped at zoomMax) must
+  // NOT leak its pointer anchor into the next non-gesture setScale: the stepper
+  // right after it still anchors on the viewport TOP.
+  it('a no-op gesture (clamped at zoomMax) does not leak its anchor into the next setScale', () => {
+    const { v, scrollHost } = setup();
+    v.setScale(4); // pinned at zoomMax
+    scrollHost.scrollTop = 600;
+    // Ctrl+wheel zoom-IN at zoomMax ⇒ clamped to 4 ⇒ no-op; its anchor must be dropped.
+    scrollHost.dispatch('wheel', {
+      ctrlKey: true,
+      deltaY: -60,
+      clientX: 100,
+      clientY: 250,
+      preventDefault() {},
+    });
+    expect(v.getScale()).toBe(4); // confirmed no-op
+    const topContent = v.contentAtViewportYForTest(0);
+    v.zoomOut(); // non-gesture stepper — must keep the viewport-TOP anchor
+    expect(v.viewportYOfForTest(topContent.slide, topContent.frac)).toBeCloseTo(0, 4);
+    v.destroy();
+  });
 });

--- a/packages/pptx/src/scroll-viewer-zoom-contract.test.ts
+++ b/packages/pptx/src/scroll-viewer-zoom-contract.test.ts
@@ -160,4 +160,52 @@ describe('PptxScrollViewer IX9 zoom contract', () => {
     expect(v.getScale()).toBe(3); // latched pre-clamped
     v.destroy();
   });
+
+  // Pointer-anchored ("zoom toward the cursor") Ctrl/⌘+wheel zoom: the content
+  // point under the pointer before the zoom must be under the SAME viewport-y
+  // after. getBoundingClientRect().top = 0 in the fake DOM, so clientY == the
+  // scrollHost-viewport y.
+  it('a Ctrl+wheel zoom keeps the content under the pointer fixed (zoom in)', () => {
+    const { v, scrollHost } = setup();
+    scrollHost.scrollTop = 600;
+    const pointerY = 250;
+    const before = v.contentAtViewportYForTest(pointerY);
+    scrollHost.dispatch('wheel', {
+      ctrlKey: true,
+      deltaY: -60,
+      clientX: 100,
+      clientY: pointerY,
+      preventDefault() {},
+    });
+    expect(v.getScale()).toBeGreaterThan(1);
+    expect(v.viewportYOfForTest(before.slide, before.frac)).toBeCloseTo(pointerY, 4);
+    v.destroy();
+  });
+
+  it('a Ctrl+wheel zoom keeps the content under the pointer fixed (zoom out)', () => {
+    const { v, scrollHost } = setup();
+    v.setScale(3);
+    scrollHost.scrollTop = 500;
+    const pointerY = 140;
+    const before = v.contentAtViewportYForTest(pointerY);
+    scrollHost.dispatch('wheel', {
+      ctrlKey: true,
+      deltaY: 60,
+      clientX: 80,
+      clientY: pointerY,
+      preventDefault() {},
+    });
+    expect(v.getScale()).toBeLessThan(3);
+    expect(v.viewportYOfForTest(before.slide, before.frac)).toBeCloseTo(pointerY, 4);
+    v.destroy();
+  });
+
+  it('a non-gesture setScale still anchors on the viewport top (unchanged)', () => {
+    const { v, scrollHost } = setup();
+    scrollHost.scrollTop = 600;
+    const topContent = v.contentAtViewportYForTest(0);
+    v.setScale(3);
+    expect(v.viewportYOfForTest(topContent.slide, topContent.frac)).toBeCloseTo(0, 4);
+    v.destroy();
+  });
 });

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1030,6 +1030,14 @@ export class PptxScrollViewer implements ZoomableViewer {
     const zoomMin = this._opts.zoomMin ?? 0.1;
     const zoomMax = this._opts.zoomMax ?? 4;
     const next = Math.min(zoomMax, Math.max(zoomMin, scale));
+    // Consume the gesture-only pointer anchor (Ctrl/⌘+wheel set it just above)
+    // FIRST — before every early return — so a gesture whose setScale ends up a
+    // NO-OP (already pinned at zoomMin/zoomMax) or latches pre-establishment can
+    // never leak a stale anchor into a later non-gesture setScale (slider,
+    // steppers, fitWidth/fitPage, resize re-fit, public API), which must keep
+    // the historical viewport-TOP anchoring. `null` for every non-gesture source.
+    const gestureAnchor = this._pendingZoomAnchor;
+    this._pendingZoomAnchor = null;
     if (!this._pres || this._pres.slideCount === 0 || !this._scaleEstablished) {
       // IX9 F1 (family-unified pre-load semantics): a setScale before the deck is
       // loaded / before the base fit is established is LATCHED, not dropped —
@@ -1041,13 +1049,6 @@ export class PptxScrollViewer implements ZoomableViewer {
     }
     if (next === this._scale) return;
     const prevScale = this._scale;
-
-    // Consume the gesture-only pointer anchor (Ctrl/⌘+wheel set it just above).
-    // `null` for every non-gesture source, which anchors on the viewport TOP as
-    // before (anchorY 0). Clear immediately so a subsequent non-gesture setScale
-    // never inherits a stale anchor.
-    const gestureAnchor = this._pendingZoomAnchor;
-    this._pendingZoomAnchor = null;
     const anchorY = gestureAnchor ? gestureAnchor.y : 0;
 
     // Capture the VERTICAL anchor from the CURRENT layout, before rescale, as a

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1,4 +1,4 @@
-import { computeVisibleRange, EMU_PER_PX, zoomStepScale, nextZoomStep, prevZoomStep, fitScale, type VisibleRange, type HyperlinkTarget, type ZoomableViewer, openExternalHyperlink } from '@silurus/ooxml-core';
+import { computeVisibleRange, EMU_PER_PX, zoomStepScale, anchoredZoomOffset, nextZoomStep, prevZoomStep, fitScale, type VisibleRange, type HyperlinkTarget, type ZoomableViewer, openExternalHyperlink } from '@silurus/ooxml-core';
 import { PptxPresentation, type LoadOptions, type RenderSlideOptions } from './presentation';
 import type { PptxTextRunInfo } from './renderer';
 import { buildPptxTextLayer } from './text-layer';
@@ -267,6 +267,14 @@ export class PptxScrollViewer implements ZoomableViewer {
    *  is host-agnostic. */
   private _settleTimer: ReturnType<typeof setTimeout> | null = null;
   private _wheelListener: ((e: WheelEvent) => void) | null = null;
+  /** Gesture-only pointer anchor for the NEXT `setScale`, in scrollHost-viewport
+   *  px (`{ x, y }` from the wheel event, relative to the scroll host's top-left).
+   *  Set by the Ctrl/⌘+wheel handler right before it calls `setScale` so the zoom
+   *  pivots on the cursor ("zoom toward the pointer") in BOTH axes; consumed and
+   *  cleared by `setScale`. `null` for every non-gesture source (the public
+   *  `setScale`, the +/- steppers, `fitWidth`/`fitPage`, the resize re-fit), which
+   *  keep the historical viewport-TOP re-anchor so their behaviour is unchanged. */
+  private _pendingZoomAnchor: { x: number; y: number } | null = null;
   /** Observes the container so a width change re-fits the base scale. Disconnected
    *  in `destroy()`. */
   private _resizeObserver: ResizeObserver | null = null;
@@ -348,6 +356,16 @@ export class PptxScrollViewer implements ZoomableViewer {
         if (!(e.ctrlKey || e.metaKey)) return; // bare wheel scrolls natively
         e.preventDefault();
         if (e.deltaY === 0) return;
+        // Pointer-anchored zoom: pivot on the cursor, not the viewport top. Record
+        // the pointer in scrollHost-viewport px (subtract the host's on-screen
+        // origin) so `setScale` can keep the content point under the cursor fixed.
+        // A malformed event (no clientX/Y) yields a non-finite anchor; drop it so
+        // `setScale` falls back to the historical viewport-top re-anchor.
+        const rect = this._scrollHost.getBoundingClientRect();
+        const ax = e.clientX - rect.left;
+        const ay = e.clientY - rect.top;
+        this._pendingZoomAnchor =
+          Number.isFinite(ax) && Number.isFinite(ay) ? { x: ax, y: ay } : null;
         this.setScale(zoomStepScale(this._scale, e.deltaY));
       };
       this._scrollHost.addEventListener('wheel', this._wheelListener as EventListener, {
@@ -565,6 +583,28 @@ export class PptxScrollViewer implements ZoomableViewer {
   private _padH(): { left: number; right: number } {
     const gap = this._gap();
     return { left: this._opts.paddingLeft ?? gap, right: this._opts.paddingRight ?? gap };
+  }
+
+  /** Index of the slide whose slot spans content-offset `y` (largest `i` with
+   *  `offsets[i] <= y`), for the pointer-anchored zoom re-anchor. Mirrors the
+   *  `topIndex` search `computeVisibleRange` runs for the scrollTop, but for an
+   *  ARBITRARY content-y (the pointer, not the viewport top). Clamped into
+   *  `[0, n-1]`; a `y` below the first slide (inside the leading pad) yields 0. */
+  private _slideIndexAtOffset(r: VisibleRange, y: number): number {
+    const { offsets } = r;
+    let lo = 0;
+    let hi = offsets.length - 1;
+    let idx = 0;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (offsets[mid] <= y) {
+        idx = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return idx;
   }
 
   private _range(): VisibleRange {
@@ -1000,17 +1040,40 @@ export class PptxScrollViewer implements ZoomableViewer {
       return;
     }
     if (next === this._scale) return;
+    const prevScale = this._scale;
 
-    // Capture the anchor from the CURRENT layout, before rescale.
+    // Consume the gesture-only pointer anchor (Ctrl/⌘+wheel set it just above).
+    // `null` for every non-gesture source, which anchors on the viewport TOP as
+    // before (anchorY 0). Clear immediately so a subsequent non-gesture setScale
+    // never inherits a stale anchor.
+    const gestureAnchor = this._pendingZoomAnchor;
+    this._pendingZoomAnchor = null;
+    const anchorY = gestureAnchor ? gestureAnchor.y : 0;
+
+    // Capture the VERTICAL anchor from the CURRENT layout, before rescale, as a
+    // (slide index, intra-slide fraction) pair. Anchoring on a slide — not on the
+    // raw scrollTop — is what keeps the re-anchor exact despite the scale-INVARIANT
+    // desk padding and inter-slide gaps (only the slide heights scale, so a whole-
+    // scroll linear rescale would drift by the padding). The point we pin is the
+    // content under the pointer: content-y = scrollTop + anchorY (anchorY 0 ⇒ the
+    // viewport top, the historical behaviour).
     const r0 = this._range();
-    const top = r0.topIndex;
+    const anchorContentY = this._scrollHost.scrollTop + anchorY;
+    // Which slide does that content-y fall in? `computeVisibleRange` attributes a
+    // point in the trailing gap to the slide ABOVE it, so clamp the fraction to
+    // [0,1] to pin the slide rather than drift into the gap.
+    const top = this._slideIndexAtOffset(r0, anchorContentY);
     const h0 = this._heights[top] || 0;
-    // intraFrac: the fraction of slide `top` that has scrolled above the viewport
-    // top. Clamp to [0,1] — a scrollTop inside the trailing gap after slide `top`
-    // is attributed to `top` by computeVisibleRange and would push intraFrac past
-    // 1, which would drift the re-anchor into the gap; pin the slide instead.
-    let intraFrac = h0 > 0 ? (this._scrollHost.scrollTop - r0.offsets[top]) / h0 : 0;
+    let intraFrac = h0 > 0 ? (anchorContentY - r0.offsets[top]) / h0 : 0;
     intraFrac = Math.min(1, Math.max(0, intraFrac));
+
+    // HORIZONTAL anchor (gesture only — a non-gesture setScale leaves scrollLeft
+    // untouched, matching the historical behaviour). The slide's left edge sits at
+    // the scale-INVARIANT left gutter `padL` when it overflows the viewport (see
+    // `_positionSlot`), so the scaling region starts at `padL`; feed the pointer's
+    // offset PAST that lead-in to the pure anchored-offset helper.
+    const padL = this._padH().left;
+    const scrollLeft0 = this._scrollHost.scrollLeft || 0;
 
     // Bump the render epoch BEFORE recycling/re-dispatching so any in-flight
     // render dispatched at the old scale is recognised as stale on resolution.
@@ -1031,10 +1094,24 @@ export class PptxScrollViewer implements ZoomableViewer {
     // The slide px width changed with the scale, so the horizontal extent moves too.
     this._syncSpacerWidth();
 
-    // Pin the same fractional position of the same slide under the viewport top.
+    // Pin the same fractional position of the same slide under the pointer (or the
+    // viewport top for a non-gesture zoom): the on-screen y of that content point
+    // must stay at `anchorY`, so newScrollTop = newContentY − anchorY.
     const maxTop = Math.max(0, r1.totalHeight - this._scrollHost.clientHeight);
-    const wantTop = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
-    this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, wantTop));
+    const newContentY = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
+    this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, newContentY - anchorY));
+
+    // Re-anchor horizontally for a gesture zoom (past the fixed `padL` lead-in),
+    // clamped to the new horizontal extent. Skipped entirely for a non-gesture
+    // setScale so slider/stepper/API/resize behaviour is byte-for-byte unchanged.
+    if (gestureAnchor) {
+      const maxLeft = Math.max(0, (this._spacer.offsetWidth || 0) - this._scrollHost.clientWidth);
+      this._scrollHost.scrollLeft =
+        padL +
+        anchoredZoomOffset(scrollLeft0 - padL, gestureAnchor.x - padL, prevScale, next, {
+          maxScroll: maxLeft - padL,
+        });
+    }
 
     // FLICKER-FREE ZOOM (design §7). Do NOT recycle + re-render in-window slots
     // (that blanks each visible slide to white every tick). Instead:
@@ -1461,6 +1538,28 @@ export class PptxScrollViewer implements ZoomableViewer {
    *  via the constructor's ResizeObserver). */
   resizeForTest(): void {
     this._onResize();
+  }
+
+  /** @internal test hook: the content point (slide index + intra-slide fraction)
+   *  currently under viewport-y `y` (px from the scroll host top). Lets a test
+   *  capture "what is under the cursor" before a zoom and re-query its on-screen
+   *  y afterwards to assert the pointer-anchored invariant. */
+  contentAtViewportYForTest(y: number): { slide: number; frac: number } {
+    const r = this._range();
+    const contentY = this._scrollHost.scrollTop + y;
+    const slide = this._slideIndexAtOffset(r, contentY);
+    const h = this._heights[slide] || 0;
+    const frac = h > 0 ? Math.min(1, Math.max(0, (contentY - r.offsets[slide]) / h)) : 0;
+    return { slide, frac };
+  }
+
+  /** @internal test hook: inverse of {@link contentAtViewportYForTest} — the
+   *  current viewport-y (px from the scroll host top) of the content point at
+   *  (`slide`, intra-slide `frac`). */
+  viewportYOfForTest(slide: number, frac: number): number {
+    const r = this._range();
+    const contentY = (r.offsets[slide] ?? 0) + frac * (this._heights[slide] || 0);
+    return contentY - this._scrollHost.scrollTop;
   }
 
   /**

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1070,8 +1070,9 @@ export class PptxScrollViewer implements ZoomableViewer {
     // HORIZONTAL anchor (gesture only — a non-gesture setScale leaves scrollLeft
     // untouched, matching the historical behaviour). The slide's left edge sits at
     // the scale-INVARIANT left gutter `padL` when it overflows the viewport (see
-    // `_positionSlot`), so the scaling region starts at `padL`; feed the pointer's
-    // offset PAST that lead-in to the pure anchored-offset helper.
+    // `_positionSlot`): screen-x of content pixel c is `padL + c − scrollLeft`,
+    // so the pointer's offset INTO the scaling region is `x − padL` and the
+    // scroll offset itself already lives in the region's own px.
     const padL = this._padH().left;
     const scrollLeft0 = this._scrollHost.scrollLeft || 0;
 
@@ -1101,16 +1102,23 @@ export class PptxScrollViewer implements ZoomableViewer {
     const newContentY = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
     this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, newContentY - anchorY));
 
-    // Re-anchor horizontally for a gesture zoom (past the fixed `padL` lead-in),
-    // clamped to the new horizontal extent. Skipped entirely for a non-gesture
-    // setScale so slider/stepper/API/resize behaviour is byte-for-byte unchanged.
+    // Re-anchor horizontally for a gesture zoom. `padL` is a FIXED (non-scaling)
+    // gutter, so it is subtracted from the ANCHOR only — the scroll offset stays
+    // in NATIVE space with the browser's own [0, maxLeft] clamp. (Shifting the
+    // scroll by ±padL as well would run the fixed gutter through the zoom ratio
+    // and over-compensate by padL·(ratio−1) per step: with `screen = padL + c −
+    // scrollLeft`, pinning c·ratio under the pointer x gives exactly
+    // `scrollLeft' = ratio·(scrollLeft + (x−padL)) − (x−padL)`.) Skipped entirely
+    // for a non-gesture setScale so slider/stepper/API/resize is unchanged.
     if (gestureAnchor) {
       const maxLeft = Math.max(0, (this._spacer.offsetWidth || 0) - this._scrollHost.clientWidth);
-      this._scrollHost.scrollLeft =
-        padL +
-        anchoredZoomOffset(scrollLeft0 - padL, gestureAnchor.x - padL, prevScale, next, {
-          maxScroll: maxLeft - padL,
-        });
+      this._scrollHost.scrollLeft = anchoredZoomOffset(
+        scrollLeft0,
+        gestureAnchor.x - padL,
+        prevScale,
+        next,
+        { maxScroll: maxLeft },
+      );
     }
 
     // FLICKER-FREE ZOOM (design §7). Do NOT recycle + re-render in-window slots

--- a/packages/xlsx/src/viewer-zoom-contract.test.ts
+++ b/packages/xlsx/src/viewer-zoom-contract.test.ts
@@ -41,9 +41,20 @@ function makeSheet(): Worksheet {
   } as unknown as Worksheet;
 }
 
+interface FakeScrollHost {
+  scrollTop: number;
+  scrollLeft: number;
+  clientWidth: number;
+  clientHeight: number;
+  scrollWidth: number;
+  scrollHeight: number;
+}
 interface Priv {
   currentWorksheet: Worksheet | null;
-  canvasArea: { clientWidth: number; clientHeight: number };
+  canvasArea: { clientWidth: number; clientHeight: number; getBoundingClientRect(): DOMRect };
+  scrollHost: FakeScrollHost;
+  _pendingZoomAnchor: { x: number; y: number } | null;
+  frozenExtent(ws: Worksheet): { frozenW: number; frozenH: number };
 }
 
 /** Construct a viewer, inject `ws`, and size the canvas area so fit math has a
@@ -191,6 +202,61 @@ describe('XlsxViewer IX9 zoom contract', () => {
     const v = new XlsxViewer(makeContainer() as unknown as HTMLElement, { zoomMin: 0.5, zoomMax: 3 });
     v.setScale(100);
     expect(v.getScale()).toBe(3); // latched pre-clamped
+  });
+
+  // Pointer-anchored ("zoom toward the cursor") zoom, both axes, past the fixed
+  // header + frozen band. The logical cell under the pointer is invariant across
+  // the zoom. From getCellAt: logical content-Y under screen-y `py` is
+  // `(py + scrollTop)/cs − (HEADER_H + frozenH)`; the x mirror-image holds via the
+  // effective (start-anchored) scrollLeft. We drive setScale with an injected
+  // gesture anchor and a generously-sized scroll host so the clamps do not bind.
+  it('a gesture-anchored zoom keeps the logical cell under the pointer fixed', () => {
+    installDom();
+    const ws = makeSheet(); // no frozen panes ⇒ frozen extent 0
+    const { v, priv } = mount(ws, { cellScale: 1 });
+    // A roomy scroll host so neither axis clamps at an edge.
+    priv.scrollHost.clientWidth = 400;
+    priv.scrollHost.clientHeight = 300;
+    priv.scrollHost.scrollWidth = 100000;
+    priv.scrollHost.scrollHeight = 100000;
+    priv.scrollHost.scrollTop = 800;
+    priv.scrollHost.scrollLeft = 600;
+
+    const { frozenW, frozenH } = priv.frozenExtent(ws);
+    const py = 180; // pointer screen-y within the grid
+    const px = 260; // pointer screen-x
+    const csOld = 1;
+    // Logical content coordinate under the pointer BEFORE the zoom.
+    const logicalYBefore = (py + priv.scrollHost.scrollTop) / csOld - (HEADER_H + frozenH);
+    const logicalXBefore = (px + priv.scrollHost.scrollLeft) / csOld - (HEADER_W + frozenW);
+
+    // Inject the gesture anchor exactly as the Ctrl/⌘+wheel handler would, then
+    // zoom in via setScale (the same path the handler calls).
+    priv._pendingZoomAnchor = { x: px, y: py };
+    v.setScale(1.5);
+    const csNew = v.getScale();
+    expect(csNew).toBe(1.5);
+
+    const logicalYAfter = (py + priv.scrollHost.scrollTop) / csNew - (HEADER_H + frozenH);
+    const logicalXAfter = (px + priv.scrollHost.scrollLeft) / csNew - (HEADER_W + frozenW);
+    expect(logicalYAfter).toBeCloseTo(logicalYBefore, 2);
+    expect(logicalXAfter).toBeCloseTo(logicalXBefore, 2);
+  });
+
+  it('a non-gesture setScale preserves the START-anchored top-left (unchanged)', () => {
+    installDom();
+    const ws = makeSheet();
+    const { v, priv } = mount(ws, { cellScale: 1 });
+    priv.scrollHost.clientWidth = 400;
+    priv.scrollHost.clientHeight = 300;
+    priv.scrollHost.scrollWidth = 100000;
+    priv.scrollHost.scrollHeight = 100000;
+    priv.scrollHost.scrollLeft = 600;
+    // No _pendingZoomAnchor ⇒ the historical start-anchored branch runs; the
+    // effective (LTR) scroll position is preserved verbatim (scrollLeft unchanged
+    // for an LTR sheet).
+    v.setScale(1.5);
+    expect(priv.scrollHost.scrollLeft).toBe(600);
   });
 });
 

--- a/packages/xlsx/src/viewer-zoom-contract.test.ts
+++ b/packages/xlsx/src/viewer-zoom-contract.test.ts
@@ -258,6 +258,29 @@ describe('XlsxViewer IX9 zoom contract', () => {
     v.setScale(1.5);
     expect(priv.scrollHost.scrollLeft).toBe(600);
   });
+
+  // A gesture whose setScale is a NO-OP (the whole-percent snap swallows a small
+  // deltaY, or the scale is pinned at zoomMin/zoomMax) must NOT leak its pointer
+  // anchor into the next non-gesture setScale: the stepper right after it still
+  // preserves the START-anchored (top-left) position.
+  it('a no-op gesture (percent-snap) does not leak its anchor into the next setScale', () => {
+    installDom();
+    const ws = makeSheet();
+    const { v, priv } = mount(ws, { cellScale: 1 });
+    priv.scrollHost.clientWidth = 400;
+    priv.scrollHost.clientHeight = 300;
+    priv.scrollHost.scrollWidth = 100000;
+    priv.scrollHost.scrollHeight = 100000;
+    priv.scrollHost.scrollLeft = 600;
+    // Inject the anchor exactly as the wheel handler would, then a setScale that
+    // snaps to the SAME whole percent (1.004 → 100%) ⇒ no-op; anchor must drop.
+    priv._pendingZoomAnchor = { x: 260, y: 180 };
+    v.setScale(1.004);
+    expect(v.getScale()).toBe(1); // confirmed no-op
+    v.zoomIn(); // non-gesture stepper (1 → 1.1) — must run the START-anchored branch
+    expect(v.getScale()).toBe(1.1);
+    expect(priv.scrollHost.scrollLeft).toBe(600); // unchanged for an LTR sheet
+  });
 });
 
 /**

--- a/packages/xlsx/src/viewer-zoom-contract.test.ts
+++ b/packages/xlsx/src/viewer-zoom-contract.test.ts
@@ -54,7 +54,21 @@ interface Priv {
   canvasArea: { clientWidth: number; clientHeight: number; getBoundingClientRect(): DOMRect };
   scrollHost: FakeScrollHost;
   _pendingZoomAnchor: { x: number; y: number } | null;
-  frozenExtent(ws: Worksheet): { frozenW: number; frozenH: number };
+}
+
+/** Unscaled (cs=1) frozen band extent of `ws` — mirrors getCellAt's inline
+ *  loops. Used only to spell out the full logical-coordinate oracle below. */
+function frozenExtent(ws: Worksheet): { frozenW: number; frozenH: number } {
+  const mdw = getMdwForWorksheet(ws);
+  let frozenH = 0;
+  for (let r = 1; r <= (ws.freezeRows ?? 0); r++) {
+    frozenH += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+  }
+  let frozenW = 0;
+  for (let c = 1; c <= (ws.freezeCols ?? 0); c++) {
+    frozenW += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw);
+  }
+  return { frozenW, frozenH };
 }
 
 /** Construct a viewer, inject `ws`, and size the canvas area so fit math has a
@@ -222,7 +236,7 @@ describe('XlsxViewer IX9 zoom contract', () => {
     priv.scrollHost.scrollTop = 800;
     priv.scrollHost.scrollLeft = 600;
 
-    const { frozenW, frozenH } = priv.frozenExtent(ws);
+    const { frozenW, frozenH } = frozenExtent(ws);
     const py = 180; // pointer screen-y within the grid
     const px = 260; // pointer screen-x
     const csOld = 1;
@@ -241,6 +255,66 @@ describe('XlsxViewer IX9 zoom contract', () => {
     const logicalXAfter = (px + priv.scrollHost.scrollLeft) / csNew - (HEADER_W + frozenW);
     expect(logicalYAfter).toBeCloseTo(logicalYBefore, 2);
     expect(logicalXAfter).toBeCloseTo(logicalXBefore, 2);
+  });
+
+  // FROZEN PANES: the header + frozen band is a SCALING lead-in (drawn at ×cs),
+  // so it cancels out of the anchor equation — the raw pointer is the anchor and
+  // the SAME logical-cell invariance holds with freezeRows/freezeCols > 0.
+  it('a gesture-anchored zoom keeps the logical cell fixed with frozen panes', () => {
+    installDom();
+    const ws = makeSheet();
+    (ws as { freezeRows?: number }).freezeRows = 2;
+    (ws as { freezeCols?: number }).freezeCols = 1;
+    const { v, priv } = mount(ws, { cellScale: 1 });
+    priv.scrollHost.clientWidth = 400;
+    priv.scrollHost.clientHeight = 300;
+    priv.scrollHost.scrollWidth = 100000;
+    priv.scrollHost.scrollHeight = 100000;
+    priv.scrollHost.scrollTop = 800;
+    priv.scrollHost.scrollLeft = 600;
+
+    const { frozenW, frozenH } = frozenExtent(ws);
+    expect(frozenH).toBeGreaterThan(0); // the frozen band is real in this fixture
+    expect(frozenW).toBeGreaterThan(0);
+    const py = 220; // pointer inside the scrollable region (below header + frozen)
+    const px = 300;
+    const csOld = 1;
+    const logicalYBefore = (py + priv.scrollHost.scrollTop) / csOld - (HEADER_H + frozenH);
+    const logicalXBefore = (px + priv.scrollHost.scrollLeft) / csOld - (HEADER_W + frozenW);
+
+    priv._pendingZoomAnchor = { x: px, y: py };
+    v.setScale(1.5);
+    const csNew = v.getScale();
+    expect(csNew).toBe(1.5);
+
+    const logicalYAfter = (py + priv.scrollHost.scrollTop) / csNew - (HEADER_H + frozenH);
+    const logicalXAfter = (px + priv.scrollHost.scrollLeft) / csNew - (HEADER_W + frozenW);
+    expect(logicalYAfter).toBeCloseTo(logicalYBefore, 2);
+    expect(logicalXAfter).toBeCloseTo(logicalXBefore, 2);
+  });
+
+  // Near the sheet START the pointer-pinning offset may legitimately fall BELOW
+  // the scaled lead-in (header + frozen) — the clamp must be the native
+  // [0, maxScroll], not a K·cs floor (regression pin for the virtual-scroll
+  // detour, which clamped scrollTop up to K·cs_new near the top).
+  it('a gesture zoom near the sheet start is not floored at the scaled lead-in', () => {
+    installDom();
+    const ws = makeSheet();
+    const { v, priv } = mount(ws, { cellScale: 1 });
+    priv.scrollHost.clientWidth = 400;
+    priv.scrollHost.clientHeight = 300;
+    priv.scrollHost.scrollWidth = 100000;
+    priv.scrollHost.scrollHeight = 100000;
+    priv.scrollHost.scrollTop = 0; // at the very top
+    priv.scrollHost.scrollLeft = 0;
+
+    const py = 100;
+    priv._pendingZoomAnchor = { x: 50, y: py };
+    v.setScale(1.2);
+    // Exact pointer-pinned offset: ratio·(scrollTop + py) − py = 1.2·100 − 100.
+    expect(priv.scrollHost.scrollTop).toBeCloseTo(20, 6);
+    // The K·cs_new floor would have been HEADER_H·1.2 = 24 (> 20).
+    expect(priv.scrollHost.scrollTop).toBeLessThan(HEADER_H * 1.2);
   });
 
   it('a non-gesture setScale preserves the START-anchored top-left (unchanged)', () => {

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -3135,15 +3135,17 @@ export class XlsxViewer implements ZoomableViewer {
     );
     const next = pct / 100;
     const prevScale = this.opts.cellScale ?? 1;
-    if (next === prevScale) return;
-    this.opts.cellScale = next;
-
-    // Consume the gesture-only pointer anchor (Ctrl/⌘+wheel set it just above).
-    // `null` for every non-gesture source, which keeps the START-anchored
-    // (top-left) preservation below. Cleared immediately so a subsequent
-    // non-gesture setScale never inherits a stale anchor.
+    // Consume the gesture-only pointer anchor (Ctrl/⌘+wheel set it just above)
+    // FIRST — before the no-op early return — so a gesture whose setScale ends
+    // up a NO-OP (pinned at zoomMin/zoomMax, or a small deltaY swallowed by the
+    // whole-percent snap) can never leak a stale anchor into a later non-gesture
+    // setScale (slider, steppers, fitWidth/fitPage, public API), which must keep
+    // the historical START-anchored (top-left) preservation. `null` for every
+    // non-gesture source.
     const gestureAnchor = this._pendingZoomAnchor;
     this._pendingZoomAnchor = null;
+    if (next === prevScale) return;
+    this.opts.cellScale = next;
 
     if (this.zoomSlider) this.zoomSlider.value = String(this.zoomScaleToPos(next, zoomMin, zoomMax));
     if (this.zoomLabel) this.zoomLabel.textContent = `${pct}%`;

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,7 +1,7 @@
 import { XlsxWorkbook } from './workbook.js';
 import type { Hyperlink, ViewportRange, Worksheet, XlsxComment } from './types.js';
 import type { HyperlinkTarget, LoadOptions, FindMatch, FindMatchesOptions, ZoomableViewer } from '@silurus/ooxml-core';
-import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale, openExternalHyperlink, nextZoomStep, prevZoomStep, fitScale } from '@silurus/ooxml-core';
+import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale, anchoredZoomOffset, openExternalHyperlink, nextZoomStep, prevZoomStep, fitScale } from '@silurus/ooxml-core';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, pxToColWidth, pxToRowHeight, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 import { findListValidationAt } from './data-validation.js';
 import { parseA1 } from './a1.js';
@@ -485,6 +485,16 @@ export class XlsxViewer implements ZoomableViewer {
    * strand the view at the sheet's far end once the host gains its real size.
    */
   private effectiveH = 0;
+
+  /** Gesture-only pointer anchor for the NEXT `setScale`, in canvasArea-viewport
+   *  px (`{ x, y }` from the wheel event, relative to the grid's top-left). Set by
+   *  the Ctrl/⌘+wheel handler right before it calls `setScale` so the zoom pivots
+   *  on the cursor ("zoom toward the pointer") in BOTH axes, past the fixed
+   *  header + frozen-pane lead-in; consumed and cleared by `setScale`. `null` for
+   *  every non-gesture source (the public `setScale`, the +/- steppers, the zoom
+   *  slider, `fitWidth`/`fitPage`), which keep the historical START-anchored
+   *  (top-left) preservation so their behaviour is unchanged. */
+  private _pendingZoomAnchor: { x: number; y: number } | null = null;
 
   // Selection state
   private anchorCell: CellAddress | null = null;
@@ -1391,6 +1401,25 @@ export class XlsxViewer implements ZoomableViewer {
    */
   private screenX(logicalX: number, w: number): number {
     return this.isRtl ? rtlMirrorX(logicalX, w, this.canvasArea.clientWidth) : logicalX;
+  }
+
+  /** Total UNSCALED (cs=1) px of the frozen row band / column band of a sheet:
+   *  the sum of the frozen rows' heights and frozen columns' widths. The header
+   *  (HEADER_W/HEADER_H) is NOT included — callers add it separately. Mirrors the
+   *  inline frozen-dimension loops in {@link getCellAt}; factored out so the
+   *  pointer-anchored zoom re-anchor measures the same fixed (non-scrolling)
+   *  lead-in past which the grid actually scrolls. */
+  private frozenExtent(ws: Worksheet): { frozenW: number; frozenH: number } {
+    const mdw = getMdwForWorksheet(ws);
+    let frozenH = 0;
+    for (let r = 1; r <= (ws.freezeRows ?? 0); r++) {
+      frozenH += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
+    }
+    let frozenW = 0;
+    for (let c = 1; c <= (ws.freezeCols ?? 0); c++) {
+      frozenW += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw);
+    }
+    return { frozenW, frozenH };
   }
 
   /** Park the scrollbar at the sheet's natural start: scrollLeft=0 for LTR,
@@ -2838,6 +2867,17 @@ export class XlsxViewer implements ZoomableViewer {
         if (!(e.ctrlKey || e.metaKey)) return;
         e.preventDefault();
         if (e.deltaY === 0) return;
+        // Pointer-anchored zoom: pivot on the cursor, not the top-left corner.
+        // Record the pointer relative to the grid's top-left (canvasArea rect,
+        // which the scrollHost overlays with inset:0) so `setScale` keeps the
+        // cell under the cursor fixed. `scrollHost` and `canvasArea` share a rect.
+        // A malformed event (no clientX/Y) yields a non-finite anchor; drop it so
+        // `setScale` falls back to the historical START-anchored preservation.
+        const rect = this.canvasArea.getBoundingClientRect();
+        const ax = e.clientX - rect.left;
+        const ay = e.clientY - rect.top;
+        this._pendingZoomAnchor =
+          Number.isFinite(ax) && Number.isFinite(ay) ? { x: ax, y: ay } : null;
         this.setScale(zoomStepScale(this.opts.cellScale ?? 1, e.deltaY));
       },
       { passive: false },
@@ -3094,8 +3134,16 @@ export class XlsxViewer implements ZoomableViewer {
       Math.max(Math.round(zoomMin * 100), Math.round(scale * 100)),
     );
     const next = pct / 100;
-    if (next === (this.opts.cellScale ?? 1)) return;
+    const prevScale = this.opts.cellScale ?? 1;
+    if (next === prevScale) return;
     this.opts.cellScale = next;
+
+    // Consume the gesture-only pointer anchor (Ctrl/⌘+wheel set it just above).
+    // `null` for every non-gesture source, which keeps the START-anchored
+    // (top-left) preservation below. Cleared immediately so a subsequent
+    // non-gesture setScale never inherits a stale anchor.
+    const gestureAnchor = this._pendingZoomAnchor;
+    this._pendingZoomAnchor = null;
 
     if (this.zoomSlider) this.zoomSlider.value = String(this.zoomScaleToPos(next, zoomMin, zoomMax));
     if (this.zoomLabel) this.zoomLabel.textContent = `${pct}%`;
@@ -3109,13 +3157,49 @@ export class XlsxViewer implements ZoomableViewer {
       // so we must re-derive scrollLeft from the preserved effective value or
       // the view would jump toward the start on every zoom step.
       const prevEffective = this.effectiveScrollLeft;
+      const prevScrollTop = this.scrollHost.scrollTop;
       // Gutter extents scale with cellScale (XL4); re-lay them out before the
       // spacer/scroll math reads canvasArea's new inset size.
       this.layoutGutters();
       this.updateSpacerSize(this.currentWorksheet);
-      this.effectiveH = prevEffective;
-      if (this.isRtl) {
-        this.scrollHost.scrollLeft = Math.max(0, this.maxScrollLeft - prevEffective);
+
+      if (gestureAnchor) {
+        // POINTER-ANCHORED zoom (both axes). The header + frozen band are drawn at
+        // a FIXED screen position and do NOT scroll (see getCellAt); the grid
+        // scrolls BELOW/RIGHT of them. Their on-screen size is the UNSCALED lead-in
+        // × cs, so it scales with the zoom. Work in a "virtual scroll" whose origin
+        // is the grid's top-left (canvasArea): T = scroll − leadIn·cs. In that space
+        // the scaling content is purely linear, so core's anchoredZoomOffset (anchor
+        // = the raw pointer offset from the grid top-left) keeps the cell under the
+        // cursor fixed; add the NEW-scale lead-in back to recover the native scroll.
+        const { frozenW, frozenH } = this.frozenExtent(this.currentWorksheet);
+        const leadX = HEADER_W + frozenW; // unscaled px from grid start to scroll origin (x)
+        const leadY = HEADER_H + frozenH; // …and (y)
+
+        // Vertical: native scrollTop is start-anchored in both LTR/RTL.
+        const maxTop = Math.max(0, this.scrollHost.scrollHeight - this.scrollHost.clientHeight);
+        const tTop = anchoredZoomOffset(prevScrollTop - leadY * prevScale, gestureAnchor.y, prevScale, next, {
+          maxScroll: maxTop - leadY * next,
+        });
+        this.scrollHost.scrollTop = Math.min(maxTop, Math.max(0, tTop + leadY * next));
+
+        // Horizontal: anchor in the logical-LTR space the grid math uses, so RTL
+        // is handled by translating the pointer through screenX (an involution)
+        // and re-deriving the native scrollLeft from the effective (start-anchored)
+        // position, exactly as the START-anchored branch does.
+        const anchorLogicalX = this.screenX(gestureAnchor.x, 0);
+        const maxLeftV = this.maxScrollLeft;
+        const tLeft = anchoredZoomOffset(prevEffective - leadX * prevScale, anchorLogicalX, prevScale, next, {
+          maxScroll: maxLeftV - leadX * next,
+        });
+        const newEffective = Math.min(maxLeftV, Math.max(0, tLeft + leadX * next));
+        this.effectiveH = newEffective;
+        this.scrollHost.scrollLeft = this.isRtl ? Math.max(0, maxLeftV - newEffective) : newEffective;
+      } else {
+        this.effectiveH = prevEffective;
+        if (this.isRtl) {
+          this.scrollHost.scrollLeft = Math.max(0, this.maxScrollLeft - prevEffective);
+        }
       }
     }
     void this.renderCurrentSheet();

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1403,25 +1403,6 @@ export class XlsxViewer implements ZoomableViewer {
     return this.isRtl ? rtlMirrorX(logicalX, w, this.canvasArea.clientWidth) : logicalX;
   }
 
-  /** Total UNSCALED (cs=1) px of the frozen row band / column band of a sheet:
-   *  the sum of the frozen rows' heights and frozen columns' widths. The header
-   *  (HEADER_W/HEADER_H) is NOT included — callers add it separately. Mirrors the
-   *  inline frozen-dimension loops in {@link getCellAt}; factored out so the
-   *  pointer-anchored zoom re-anchor measures the same fixed (non-scrolling)
-   *  lead-in past which the grid actually scrolls. */
-  private frozenExtent(ws: Worksheet): { frozenW: number; frozenH: number } {
-    const mdw = getMdwForWorksheet(ws);
-    let frozenH = 0;
-    for (let r = 1; r <= (ws.freezeRows ?? 0); r++) {
-      frozenH += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
-    }
-    let frozenW = 0;
-    for (let c = 1; c <= (ws.freezeCols ?? 0); c++) {
-      frozenW += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw);
-    }
-    return { frozenW, frozenH };
-  }
-
   /** Park the scrollbar at the sheet's natural start: scrollLeft=0 for LTR,
    *  the right end for RTL (so col A shows first). */
   private resetHorizontalScroll(): void {
@@ -3166,35 +3147,35 @@ export class XlsxViewer implements ZoomableViewer {
       this.updateSpacerSize(this.currentWorksheet);
 
       if (gestureAnchor) {
-        // POINTER-ANCHORED zoom (both axes). The header + frozen band are drawn at
-        // a FIXED screen position and do NOT scroll (see getCellAt); the grid
-        // scrolls BELOW/RIGHT of them. Their on-screen size is the UNSCALED lead-in
-        // × cs, so it scales with the zoom. Work in a "virtual scroll" whose origin
-        // is the grid's top-left (canvasArea): T = scroll − leadIn·cs. In that space
-        // the scaling content is purely linear, so core's anchoredZoomOffset (anchor
-        // = the raw pointer offset from the grid top-left) keeps the cell under the
-        // cursor fixed; add the NEW-scale lead-in back to recover the native scroll.
-        const { frozenW, frozenH } = this.frozenExtent(this.currentWorksheet);
-        const leadX = HEADER_W + frozenW; // unscaled px from grid start to scroll origin (x)
-        const leadY = HEADER_H + frozenH; // …and (y)
+        // POINTER-ANCHORED zoom (both axes). The header + frozen band are drawn
+        // at a FIXED screen position and do NOT scroll (see getCellAt), but their
+        // on-screen size is the UNSCALED extent K × cs — a SCALING lead-in. From
+        // getCellAt, the logical row under screen-y `py` is
+        //   (py + scrollTop)/cs − K            (K = HEADER_H + frozenH)
+        // and requiring that to be invariant across cs makes the K·cs terms
+        // cancel exactly:
+        //   scrollTop' = ratio·(scrollTop + py) − py
+        // — i.e. the RAW pointer is the anchor and the clamp is the native
+        // [0, maxScroll] (see anchoredZoomOffset's LEAD-INS note; routing through
+        // a lead-in-shifted virtual scroll would distort the low clamp and floor
+        // scrollTop at K·cs near the sheet start).
 
         // Vertical: native scrollTop is start-anchored in both LTR/RTL.
         const maxTop = Math.max(0, this.scrollHost.scrollHeight - this.scrollHost.clientHeight);
-        const tTop = anchoredZoomOffset(prevScrollTop - leadY * prevScale, gestureAnchor.y, prevScale, next, {
-          maxScroll: maxTop - leadY * next,
+        this.scrollHost.scrollTop = anchoredZoomOffset(prevScrollTop, gestureAnchor.y, prevScale, next, {
+          maxScroll: maxTop,
         });
-        this.scrollHost.scrollTop = Math.min(maxTop, Math.max(0, tTop + leadY * next));
 
-        // Horizontal: anchor in the logical-LTR space the grid math uses, so RTL
-        // is handled by translating the pointer through screenX (an involution)
-        // and re-deriving the native scrollLeft from the effective (start-anchored)
+        // Horizontal: anchor in the logical-LTR space the grid math uses (the
+        // same cancellation holds for K = HEADER_W + frozenW), so RTL is handled
+        // by translating the pointer through screenX (an involution) and
+        // re-deriving the native scrollLeft from the effective (start-anchored)
         // position, exactly as the START-anchored branch does.
         const anchorLogicalX = this.screenX(gestureAnchor.x, 0);
         const maxLeftV = this.maxScrollLeft;
-        const tLeft = anchoredZoomOffset(prevEffective - leadX * prevScale, anchorLogicalX, prevScale, next, {
-          maxScroll: maxLeftV - leadX * next,
+        const newEffective = anchoredZoomOffset(prevEffective, anchorLogicalX, prevScale, next, {
+          maxScroll: maxLeftV,
         });
-        const newEffective = Math.min(maxLeftV, Math.max(0, tLeft + leadX * next));
         this.effectiveH = newEffective;
         this.scrollHost.scrollLeft = this.isRtl ? Math.max(0, maxLeftV - newEffective) : newEffective;
       } else {


### PR DESCRIPTION
## What

Make trackpad pinch / `Ctrl`(`⌘`)+wheel zoom **pivot on the pointer** (zoom toward the cursor) instead of the viewport top-left. Previously the gesture re-anchored on the viewport TOP (vertical only) for the scroll viewers and on the start-anchored top-left corner for xlsx, so the point under the cursor drifted away as you zoomed.

## Current-state survey (viewer × gesture)

| Viewer | Handles Ctrl/⌘+wheel? | Old anchor | New anchor |
|---|---|---|---|
| `DocxScrollViewer` | ✅ (scrollHost `wheel`) | viewport **top** (vertical only; horizontal drifted) | **pointer**, both axes |
| `PptxScrollViewer` | ✅ (scrollHost `wheel`) | viewport **top** (vertical only; horizontal drifted) | **pointer**, both axes |
| `XlsxViewer` | ✅ (scrollHost `wheel`) | start-anchored **top-left** (vertical drifted) | **pointer**, both axes, past the fixed header + frozen band |
| `DocxViewer` (single canvas) | ❌ no internal scroll — host controls layout | — | — (out of scope) |
| `PptxViewer` (single canvas) | ❌ no internal scroll — host controls layout | — | — (out of scope) |

The VS Code webview and `PptxPresentation`/`DocxDocument` headless APIs use the scroll viewers, so they inherit the fix.

## The math (core, pure)

New `anchoredZoomOffset(scrollOld, anchor, scaleOld, scaleNew, {maxScroll})` in `packages/core/src/interaction/zoom.ts`. Working in the scaling content's own px, measured from the start of the region that zooms (the caller subtracts any scale-invariant lead-in — desk padding / a frozen header/pane — first):

```
scrollNew = (scrollOld + anchor) · (scaleNew / scaleOld) − anchor
```

clamped to `[0, maxScroll]`. Identity on a no-op zoom (`scaleOld == scaleNew`), invertible (exact round-trip), reduces to an origin-anchored rescale at `anchor = 0`. At a content edge the clamp wins and the point drifts (natural).

## Implementation points

- **core**: `packages/core/src/interaction/zoom.ts` (`anchoredZoomOffset`, `ScrollClamp`); exported from `packages/core/src/index.ts`.
- **docx**: `packages/docx/src/scroll-viewer.ts` — wheel handler records `_pendingZoomAnchor` (scrollHost-viewport px); `setScale` consumes it: vertical via page-fraction re-anchor at the pointer (new `_pageIndexAtOffset`), horizontal via `anchoredZoomOffset` past the fixed left gutter.
- **pptx**: `packages/pptx/src/scroll-viewer.ts` — same, with `_slideIndexAtOffset`.
- **xlsx**: `packages/xlsx/src/viewer.ts` — both axes past the FIXED header + frozen-pane lead-in (which scales with cs) via a virtual-scroll transform `T = scroll − leadIn·cs`; horizontal re-derives native `scrollLeft` from the effective (start-anchored) position so RTL still works. New `frozenExtent` factors the frozen band.

Non-gesture sources (public `setScale`, `zoomIn`/`zoomOut`, the xlsx zoom slider, `fitWidth`/`fitPage`, the resize re-fit) keep their **exact historical anchoring** — the pointer anchor is gesture-only and dropped when a wheel event lacks finite `clientX/Y`.

## Public API

**Unchanged.** The IX9 contract (`getScale`/`setScale`/`zoomIn`/`zoomOut`/`fitWidth`/`fitPage`) is untouched; the pointer anchor is an internal implementation detail. No `site/src/lib/api-reference.ts` sync needed.

## Commits (1 concern each)

1. `feat(core): add anchoredZoomOffset for pointer-anchored zoom` — pure function + 9 unit tests.
2. `feat(viewers): pointer-anchored Ctrl/⌘+wheel zoom` — the three viewers + anchor-invariance tests.

## Verification

- **core unit** (red→green): 9 new tests — anchor invariance, identity, round-trip, edge clamps (0 / maxScroll / degenerate), divide-by-zero guard. 15/15 pass.
- **viewer unit**: anchor-invariance suites added to docx/pptx/xlsx zoom-contract tests (zoom-in and zoom-out keep the content under the pointer fixed; a non-gesture `setScale` still top/start-anchors). All green.
- **Playwright (Chrome, real geometry)** on `DocxScrollViewer` + `demo/sample-1.docx`, real `WheelEvent{ctrlKey}` at mid-viewport — the content point stays under the cursor:
  - zoom in  1.55→3.45: drift **0.50 px**
  - zoom out 3.45→1.55: drift **0.29 px**
  - small zoom 1.55→2.10: drift **0.45 px**
  - all **≤0.5 px** (sub-pixel residual is DPR bitmap-height rounding, not anchor error). Harness was temporary — not committed.
- **Gates**: `tsc --build` clean; full vitest **3223 passed** (core+docx+pptx+xlsx), plus 38 zoom/scroll-viewer specs green; ast-grep **0 errors** (114 pre-existing warnings, none new); **demo VRT byte-identical** across all three packages (visual + worker + selection/zoom equivalence all pass; `private/sample-*` fail only with 404 — those fixtures are gitignored, unrelated).
- **Reference images: not updated.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)