### PR TITLE
fix(charts): honor <c:minorGridlines> in the area renderer

### DIFF
--- a/packages/core/src/chart/renderer-gridline-zorder.test.ts
+++ b/packages/core/src/chart/renderer-gridline-zorder.test.ts
@@ -144,6 +144,41 @@ describe('CH — value-axis gridlines paint under the data series', () => {
     expect(firstGridline).toBeLessThan(firstSeriesFill);
   });
 
+  it('an area chart honors <c:minorGridlines> with the same count as line, all before the fill', () => {
+    // Regression for #883: renderAreaChart silently ignored `<c:minorGridlines>`
+    // (§21.2.2.129) while bar/line/stock honored it. With an identical value-axis
+    // config the area renderer must stroke the same number of gridlines as the
+    // line renderer (major + minor), and every gridline must precede the series
+    // fill (same z-order as the major pass moved by #881).
+    const cfg: Partial<ChartModel> = {
+      categories: ['Jan', 'Feb', 'Mar', 'Apr'],
+      series: [series({ name: 'ARR', values: [37, 40, 44, 48] })],
+      valMax: 50,
+      valAxisMajorUnit: 5,
+      valAxisMinorGridlines: true,
+      valAxisMinorUnit: 2.5,
+    };
+
+    const areaRec = orderedRecordingCtx();
+    renderChart(areaRec.ctx, baseModel({ chartType: 'area', ...cfg }), RECT, 1);
+    const lineRec = orderedRecordingCtx();
+    renderChart(lineRec.ctx, baseModel({ chartType: 'line', ...cfg }), RECT, 1);
+
+    const areaGrid = areaRec.events.filter(isGridlineStroke).length;
+    const lineGrid = lineRec.events.filter(isGridlineStroke).length;
+    // Line = 10 major + minor; area must match now that #883 is fixed.
+    expect(lineGrid).toBeGreaterThan(0);
+    expect(areaGrid).toBe(lineGrid);
+
+    // Every gridline (major AND minor) sits before the first series fill.
+    const firstFill = areaRec.events.findIndex(isSeriesFill);
+    const lastGridline =
+      areaRec.events.length - 1 -
+      [...areaRec.events].reverse().findIndex(isGridlineStroke);
+    expect(firstFill).toBeGreaterThanOrEqual(0);
+    expect(lastGridline).toBeLessThan(firstFill);
+  });
+
   it('a plain line/area combo keeps gridlines below the area fill', () => {
     // Guard the line renderer (which draws area-like fills? no — line strokes).
     // Line chart already gridlines-first; assert it does not regress by pinning a

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -2482,12 +2482,28 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   // axis rules, tick marks and value/category labels stay AFTER the series (drawn
   // further below) so they sit atop the plot. `<c:valAx><c:majorGridlines>` is on
   // by default (`drawValMajorGridlines`); `<c:minorGridlines>` only when declared.
-  if (!chart.valAxisHidden && drawValMajorGridlines(chart)) {
+  if (!chart.valAxisHidden) {
     const grid = valGridStroke(chart, ptToPx);
-    const steps = Math.round(axMax / step);
-    for (let si = 0; si <= steps; si++) {
-      const v = si * step;
-      strokeValueGridlineH(ctx, px0, pw, toY(v), si === 0, grid);
+    // Minor gridlines (`<c:valAx><c:minorGridlines>`, §21.2.2.129) drawn first,
+    // UNDER the majors and the series, only when the file declares them AND a
+    // positive `<c:minorUnit>` smaller than the major step. Interior multiples of
+    // the minor unit that don't coincide with a major line — same computation as
+    // planValueAxis (renderer.ts ~686-696) used by bar/line/stock, with the area
+    // axis anchored at min = 0. Fixes #883 (area previously ignored minor lines).
+    const mu = chart.valAxisMinorUnit;
+    if (chart.valAxisMinorGridlines && mu != null && isFinite(mu) && mu > 0 && mu < step) {
+      for (let v = mu; v < axMax - 1e-9; v += mu) {
+        if (Math.abs(v / step - Math.round(v / step)) > 1e-6) {
+          strokeValueGridlineH(ctx, px0, pw, toY(v), false, grid);
+        }
+      }
+    }
+    if (drawValMajorGridlines(chart)) {
+      const steps = Math.round(axMax / step);
+      for (let si = 0; si <= steps; si++) {
+        const v = si * step;
+        strokeValueGridlineH(ctx, px0, pw, toY(v), si === 0, grid);
+      }
     }
   }
   // Category-axis MAJOR gridlines (`<c:catAx><c:majorGridlines>`, §21.2.2.100):


### PR DESCRIPTION
## Summary

`renderAreaChart` (`packages/core/src/chart/renderer.ts`) never referenced the minor-gridline config, so an area chart with a declared `<c:minorGridlines>` (ECMA-376 §21.2.2.129) rendered **only its major lines** — while the bar, line and stock renderers all honor it. Pre-existing gap surfaced during the adversarial review of #881.

**Measured (recording mock, identical value-axis config `valAxisMinorGridlines:true`, `valAxisMinorUnit:2.5`, `valAxisMajorUnit:5`, `valMax:50`):**
- line renderer → **20** gridline strokes (10 major + 10 minor)
- area renderer → **10** (major only) ❌ before → **20** ✅ after

## Fix

Add the minor-gridline pass to `renderAreaChart`, **before the series fills** — the same z-order the major pass was moved to by #881, so the opaque/translucent area occludes both minor and major lines inside its region (matching PowerPoint). The interior-multiple computation is copied verbatim from `planValueAxis` (`renderer.ts` ~686–696, the shared plan used by bar/line/stock), with the area axis anchored at `min = 0`. Minor lines draw independently of the major-gridlines flag, exactly like the line renderer (`renderer.ts` ~1888–1890).

## Tests

- **TDD** (red→green) in `renderer-gridline-zorder.test.ts`: an area chart with a minor config now strokes the **same gridline count as the line renderer**, and every gridline (major + minor) precedes the first series fill.
- Full core chart suite: **271 passed** (incl. renderer-signature snapshot — unchanged, no minor-config snapshot case for area).
- `tsc -p packages/core` clean; `ast-grep scan` no new findings.
- **demo VRT byte-identical**: pptx demo (9 slides) + xlsx demo (7 checks) pass with no chart-region change. Confirmed by scan: no demo fixture contains an `areaChart`, and no fixture (demo or private) declares an area chart **with** `minorGridlines`, so no existing render changes — the two area-chart fixtures (pptx sample-14 chart5, xlsx sample-13 chart1) have no minor unit and take the byte-identical path.

Closes #883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)