### PR TITLE
feat(xlsx): blip duotone (§20.1.8.23) + alphaModFix (§20.1.8.6) picture effects

### DIFF
--- a/packages/core/src/image/duotone.test.ts
+++ b/packages/core/src/image/duotone.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hex6ToRgb,
+  luminance601,
+  duotoneImageData,
+  type RgbaBuffer,
+} from './duotone.js';
+
+// ── Duotone effect (ECMA-376 §20.1.8.23) unit tests ──────────────────────────
+// The pixel remap is a pure function over an ImageData-shaped buffer, so it is
+// exercised here with hand-built RGBA arrays — no canvas needed. clr1 is the
+// dark endpoint (luminance 0), clr2 the light endpoint (luminance 1).
+
+describe('hex6ToRgb', () => {
+  it('parses a 6-char hex to a byte triple', () => {
+    expect(hex6ToRgb('DAB6BA')).toEqual([0xda, 0xb6, 0xba]);
+    expect(hex6ToRgb('000000')).toEqual([0, 0, 0]);
+    expect(hex6ToRgb('ffffff')).toEqual([255, 255, 255]);
+  });
+  it('rejects malformed input', () => {
+    expect(hex6ToRgb('#DAB6BA')).toBeNull();
+    expect(hex6ToRgb('DAB6B')).toBeNull();
+    expect(hex6ToRgb('DAB6BAA')).toBeNull();
+    expect(hex6ToRgb('GGGGGG')).toBeNull();
+  });
+});
+
+describe('luminance601', () => {
+  it('returns 0 for black and 1 for white', () => {
+    expect(luminance601(0, 0, 0)).toBe(0);
+    expect(luminance601(255, 255, 255)).toBeCloseTo(1, 6);
+  });
+  it('uses Rec. 601 weights', () => {
+    // Pure green is the heaviest channel (0.587).
+    expect(luminance601(0, 255, 0)).toBeCloseTo(0.587, 6);
+    expect(luminance601(255, 0, 0)).toBeCloseTo(0.299, 6);
+    expect(luminance601(0, 0, 255)).toBeCloseTo(0.114, 6);
+  });
+});
+
+/** Build a 1×N RGBA buffer from `[r,g,b,a]` tuples. */
+function buf(pixels: Array<[number, number, number, number]>): RgbaBuffer {
+  const data = new Uint8ClampedArray(pixels.length * 4);
+  pixels.forEach((p, i) => {
+    data[i * 4] = p[0];
+    data[i * 4 + 1] = p[1];
+    data[i * 4 + 2] = p[2];
+    data[i * 4 + 3] = p[3];
+  });
+  return { data, width: pixels.length, height: 1 };
+}
+
+describe('duotoneImageData', () => {
+  const DARK = '000000'; // clr1
+  const LIGHT = 'DAB6BA'; // clr2 (light pink), matching sample-9.xlsx
+
+  it('maps a black pixel (t=0) to clr1', () => {
+    const b = buf([[0, 0, 0, 255]]);
+    duotoneImageData(b, DARK, LIGHT);
+    expect([b.data[0], b.data[1], b.data[2]]).toEqual([0, 0, 0]);
+    expect(b.data[3]).toBe(255); // alpha preserved
+  });
+
+  it('maps a white pixel (t=1) to clr2', () => {
+    const b = buf([[255, 255, 255, 255]]);
+    duotoneImageData(b, DARK, LIGHT);
+    expect([b.data[0], b.data[1], b.data[2]]).toEqual([0xda, 0xb6, 0xba]);
+    expect(b.data[3]).toBe(255);
+  });
+
+  it('maps a mid-grey (t=0.5) to the midpoint of the ramp', () => {
+    // luminance601(128,128,128) = 128/255 ≈ 0.502.
+    const b = buf([[128, 128, 128, 255]]);
+    duotoneImageData(b, DARK, LIGHT);
+    const t = 128 / 255;
+    expect(b.data[0]).toBe(Math.round(0 + (0xda - 0) * t));
+    expect(b.data[1]).toBe(Math.round(0 + (0xb6 - 0) * t));
+    expect(b.data[2]).toBe(Math.round(0 + (0xba - 0) * t));
+  });
+
+  it('preserves per-pixel alpha and skips fully transparent pixels', () => {
+    const b = buf([
+      [255, 255, 255, 128], // semi-transparent white → clr2, alpha kept
+      [10, 20, 30, 0], // fully transparent → RGB untouched
+    ]);
+    duotoneImageData(b, DARK, LIGHT);
+    expect([b.data[0], b.data[1], b.data[2], b.data[3]]).toEqual([0xda, 0xb6, 0xba, 128]);
+    expect([b.data[4], b.data[5], b.data[6], b.data[7]]).toEqual([10, 20, 30, 0]);
+  });
+
+  it('respects colour role order (swapping endpoints inverts the ramp)', () => {
+    const white = buf([[255, 255, 255, 255]]);
+    duotoneImageData(white, LIGHT, DARK); // clr1=pink, clr2=black
+    // t=1 now maps to clr2=black.
+    expect([white.data[0], white.data[1], white.data[2]]).toEqual([0, 0, 0]);
+  });
+
+  it('is a no-op when a colour is malformed', () => {
+    const b = buf([[123, 45, 67, 255]]);
+    duotoneImageData(b, 'nothex', LIGHT);
+    expect([b.data[0], b.data[1], b.data[2]]).toEqual([123, 45, 67]);
+  });
+
+  it('near-white sample-9 corner (RGB 243–249) lands in the pink range', () => {
+    const b = buf([[246, 246, 246, 255]]);
+    duotoneImageData(b, DARK, LIGHT);
+    // ~96% up the ramp toward DAB6BA → clearly pink, R>G, R>B, all high.
+    expect(b.data[0]).toBeGreaterThan(200); // R near 0xDA
+    expect(b.data[0]).toBeGreaterThan(b.data[1]); // pink: R>G
+    expect(b.data[0]).toBeGreaterThan(b.data[2]); // pink: R>B
+  });
+});

--- a/packages/core/src/image/duotone.ts
+++ b/packages/core/src/image/duotone.ts
@@ -1,0 +1,160 @@
+// Shared DrawingML duotone image effect (ECMA-376 §20.1.8.23 CT_DuotoneEffect)
+// for the docx, pptx and xlsx renderers. Spec text (§20.1.8.23):
+//
+//   "For each pixel, combines clr1 and clr2 through a linear interpolation to
+//    determine the new color for that pixel."
+//
+// `clr1` is the first `EG_ColorChoice` child, `clr2` the second. The
+// interpolation factor is the pixel's luminance (0 = darkest → `clr1`, 1 =
+// lightest → `clr2`), so a near-white photo under a `black`↔`light-pink` duotone
+// is remapped along that ramp to pink (the sample-9.xlsx "Gift budget" picture).
+// This matches PowerPoint / Word / Excel, which recolor by luminance.
+//
+// The pixel transform lives here as a pure function over an ImageData-shaped
+// buffer so it is unit-testable without a canvas; the thin canvas wrapper
+// (getImageData → transform → putImageData → ImageBitmap) is provided for the
+// renderers and works on both OffscreenCanvas (browser/worker) and node-canvas
+// (skia) via the shared 2D context surface.
+
+/** A duotone effect resolved to its two endpoint colours. Both are 6-char
+ *  uppercase hex WITHOUT a leading `#` (the form the Rust parsers emit). `clr1`
+ *  is the dark endpoint (luminance 0), `clr2` the light endpoint (luminance 1),
+ *  matching the child order of `<a:duotone>` in §20.1.8.23. Any per-colour
+ *  transforms (lumMod/lumOff/tint/satMod/…) are already baked into these hexes
+ *  by the parser's colour-resolution machinery. */
+export interface Duotone {
+  /** First `EG_ColorChoice` child — the dark endpoint. 6-char hex, no `#`. */
+  clr1: string;
+  /** Second `EG_ColorChoice` child — the light endpoint. 6-char hex, no `#`. */
+  clr2: string;
+}
+
+/** An ImageData-shaped RGBA buffer: `data` is `RGBA…` bytes row-major, length
+ *  `width*height*4`. A real {@link ImageData} satisfies this; tests pass a plain
+ *  object so the transform is exercised without a canvas. */
+export interface RgbaBuffer {
+  data: Uint8ClampedArray | Uint8Array;
+  width: number;
+  height: number;
+}
+
+/** Parse a 6-char hex (no `#`) to `[r, g, b]` (0–255). Returns `null` when the
+ *  string is not exactly 6 hex digits, so a malformed colour disables the
+ *  effect rather than corrupting pixels. */
+export function hex6ToRgb(hex: string): [number, number, number] | null {
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return null;
+  return [
+    parseInt(hex.slice(0, 2), 16),
+    parseInt(hex.slice(2, 4), 16),
+    parseInt(hex.slice(4, 6), 16),
+  ];
+}
+
+/** Rec. 601 relative luminance (0–1) of an sRGB byte triple. Rec. 601 is the
+ *  classic grayscale weighting used by DrawingML raster effects (the same
+ *  coefficients Office uses for its "washout"/recolor luminance ramp); it is a
+ *  gamma-space approximation, matching how the effect is applied to stored
+ *  (non-linear) pixel values rather than linear light. */
+export function luminance601(r: number, g: number, b: number): number {
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+/** In-place duotone remap of an RGBA buffer along the `clr1`→`clr2` ramp by
+ *  per-pixel Rec. 601 luminance. The alpha channel is left untouched (a duotone
+ *  recolours; it does not change opacity — {@link alphaModFix} is a separate
+ *  §20.1.8.6 effect). Fully transparent pixels are skipped (their RGB is
+ *  irrelevant and left as-is). Returns the same buffer for chaining. */
+export function duotoneImageData(buf: RgbaBuffer, dark: string, light: string): RgbaBuffer {
+  const c1 = hex6ToRgb(dark);
+  const c2 = hex6ToRgb(light);
+  if (!c1 || !c2) return buf;
+  const [dr, dg, db] = c1;
+  const [lr, lg, lb] = c2;
+  const d = buf.data;
+  for (let i = 0; i < d.length; i += 4) {
+    if (d[i + 3] === 0) continue; // fully transparent: nothing to recolour
+    const t = luminance601(d[i], d[i + 1], d[i + 2]);
+    d[i] = Math.round(dr + (lr - dr) * t);
+    d[i + 1] = Math.round(dg + (lg - dg) * t);
+    d[i + 2] = Math.round(db + (lb - db) * t);
+    // d[i+3] (alpha) unchanged
+  }
+  return buf;
+}
+
+/** Minimal 2D context surface the canvas wrapper needs. Both
+ *  `OffscreenCanvasRenderingContext2D` and node-canvas's context satisfy it. */
+interface Ctx2DLike {
+  drawImage(img: CanvasImageSource, dx: number, dy: number): void;
+  getImageData(sx: number, sy: number, sw: number, sh: number): ImageData;
+  putImageData(data: ImageData, dx: number, dy: number): void;
+}
+
+/** An offscreen drawing surface {@link applyDuotone} draws onto and reads back.
+ *  It must both expose a 2D context (for the pixel round-trip) AND be a valid
+ *  `ImageBitmapSource` (so the recoloured surface can be baked into a new
+ *  `ImageBitmap`). A real `OffscreenCanvas` satisfies both; the intersection lets
+ *  the factory return one without any cast, and a node-canvas / test mock is
+ *  cast (once) at the factory boundary where the shape is known. */
+export type OffscreenSurface = ImageBitmapSource & {
+  readonly width: number;
+  readonly height: number;
+  getContext(id: '2d'): Ctx2DLike | null;
+};
+
+/** Factory for an offscreen drawing surface. Injected so the renderers pass an
+ *  `OffscreenCanvas` (browser/worker) or a node-canvas (skia) constructor; the
+ *  transform code stays environment-agnostic. Returns `null` when no surface can
+ *  be made, in which case {@link applyDuotone} returns the source untransformed. */
+export type OffscreenFactory = (w: number, h: number) => OffscreenSurface | null;
+
+/** Default factory: a real `OffscreenCanvas` when the runtime provides one
+ *  (browsers, workers, recent node). Renderers without it (older node) pass
+ *  their own skia-backed factory. `OffscreenCanvas` already satisfies
+ *  {@link OffscreenSurface} (it is an `ImageBitmapSource` with a 2D context), so
+ *  no cast is needed. */
+export const defaultOffscreenFactory: OffscreenFactory = (w, h) => {
+  if (typeof OffscreenCanvas === 'undefined') return null;
+  return new OffscreenCanvas(w, h);
+};
+
+/** Apply a duotone effect to a decoded image, returning a NEW `ImageBitmap`
+ *  (via `createImageBitmap`) recoloured along the `clr1`→`clr2` luminance ramp.
+ *  The source is drawn onto an offscreen surface at its native pixel size, its
+ *  pixels are remapped by {@link duotoneImageData}, and the result is baked back
+ *  into an `ImageBitmap` so the render path is unchanged (still a
+ *  `CanvasImageSource` drawn by `drawImageCropped`). Alpha is preserved.
+ *
+ *  Returns the ORIGINAL source unchanged when the surface/ImageData pipeline is
+ *  unavailable (e.g. `createImageBitmap`/`OffscreenCanvas` missing), so a picture
+ *  never vanishes — it just renders without the recolor. Callers cache the
+ *  result keyed by (image path + both colours) so the transform runs once. */
+export async function applyDuotone(
+  img: CanvasImageSource,
+  duotone: Duotone,
+  opts: {
+    width: number;
+    height: number;
+    offscreenFactory?: OffscreenFactory;
+  },
+): Promise<CanvasImageSource> {
+  const { width, height } = opts;
+  if (width <= 0 || height <= 0) return img;
+  if (typeof createImageBitmap === 'undefined') return img;
+  const factory = opts.offscreenFactory ?? defaultOffscreenFactory;
+  const surface = factory(width, height);
+  if (!surface) return img;
+  const ctx = surface.getContext('2d');
+  if (!ctx) return img;
+  ctx.drawImage(img, 0, 0);
+  let data: ImageData;
+  try {
+    data = ctx.getImageData(0, 0, width, height);
+  } catch {
+    // Tainted canvas / unsupported readback — leave the picture unrecoloured.
+    return img;
+  }
+  duotoneImageData(data, duotone.clr1, duotone.clr2);
+  ctx.putImageData(data, 0, 0);
+  return createImageBitmap(surface);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,6 +165,22 @@ export {
   metafileRasterSize,
   type SrcRect,
 } from './image/crop';
+// Shared DrawingML duotone image effect (§20.1.8.23): recolour a decoded image
+// along a `clr1`→`clr2` luminance ramp. The pure pixel transform + a canvas
+// wrapper that returns a new ImageBitmap, cached by the renderers per (path +
+// colours). Consumed by all three formats (xlsx first; pptx/docx pictures can
+// carry duotone too).
+export {
+  applyDuotone,
+  duotoneImageData,
+  hex6ToRgb,
+  luminance601,
+  defaultOffscreenFactory,
+  type Duotone,
+  type RgbaBuffer,
+  type OffscreenFactory,
+  type OffscreenSurface,
+} from './image/duotone';
 // Shared vector-vs-raster blip gate: prefer the Microsoft asvg:svgBlip vector
 // original except when an <a:srcRect> crop is present (then the raster's native
 // pixel grid is required for the fractional crop math). Used by all three

--- a/packages/node/src/render.ts
+++ b/packages/node/src/render.ts
@@ -105,7 +105,18 @@ export function installOffscreenCanvasShim(factory: NodeCanvasFactory): () => vo
 export function installImageBitmapShim(factory: NodeCanvasFactory): () => void {
   const g = globalThis as unknown as { createImageBitmap?: unknown };
   const prev = g.createImageBitmap;
-  g.createImageBitmap = async (source: Blob | ArrayBuffer | Uint8Array) => {
+  // The source may be raw bytes (the raster-decode path) OR a canvas-like
+  // surface with a 2D context (core's `applyDuotone`, §20.1.8.23, which bakes a
+  // recoloured offscreen surface back into an "ImageBitmap"). Widen the param so
+  // the canvas branch is a real member and needs no double-cast.
+  type CanvasLike = { getContext(id: '2d'): unknown };
+  g.createImageBitmap = async (source: Blob | ArrayBuffer | Uint8Array | CanvasLike) => {
+    // A canvas-like source is already a drawable image source in node-canvas —
+    // return it directly. The surface IS the skia Canvas the factory made, so no
+    // byte round-trip is needed (and skia has no `createImageBitmap(canvas)`).
+    if (source && typeof (source as CanvasLike).getContext === 'function') {
+      return source as CanvasLike;
+    }
     let buf: ArrayBuffer | Uint8Array | Buffer;
     if (source instanceof Uint8Array || source instanceof ArrayBuffer) {
       buf = source;

--- a/packages/node/src/xlsx-blip-duotone-alpha.probe.test.ts
+++ b/packages/node/src/xlsx-blip-duotone-alpha.probe.test.ts
@@ -1,0 +1,213 @@
+/**
+ * End-to-end device-pixel probe for xlsx blip effects (issue #880):
+ *  - `<a:duotone>` recolour (ECMA-376 §20.1.8.23), and
+ *  - `<a:alphaModFix>` opacity (§20.1.8.6).
+ *
+ * Real file (sample-9.xlsx, "Gift budget and tracker"): a near-white opaque
+ * photo is shown by Excel as PINK and SEMI-TRANSPARENT — the pink comes from a
+ * duotone (`black` ↔ light-pink `FFF3F4`, resolved from `DAB6BA` + lumMod/lumOff/
+ * tint/satMod), and the translucency from `alphaModFix amt="70000"` (0.70), which
+ * blends the picture with the coloured cells beneath. We previously drew the raw
+ * opaque white PNG.
+ *
+ * This probe is FIXTURE-FREE (CI-safe — sample-9 is private/redistribution-
+ * restricted): it builds a synthetic worksheet whose single picture is a solid
+ * near-white 4×4 PNG carrying `alpha: 0.7` + `duotone {clr1:000000,clr2:FFF3F4}`,
+ * over a fully-coloured (pure blue) sheet region. It renders twice through the
+ * SAME orchestrator path the browser/worker use, once WITH the effects and once
+ * with a raw (effect-stripped) copy, and asserts, at real device pixels:
+ *   1. duotone recolours the neutral white photo to a pink cast (R > G ≈ B); and
+ *   2. alphaModFix < 1 makes the picture composite over the blue cell beneath
+ *      (the drawn pixel is pulled toward blue vs. the opaque control).
+ * Gated on skia like the sibling render probes.
+ */
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import type { Worksheet, Styles, ViewportRange, ImageAnchor } from '@silurus/ooxml-xlsx';
+import { loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, loadImage } = (skia ?? {}) as Skia;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: ((buf: ArrayBuffer | Uint8Array | Buffer) =>
+    loadImage(Buffer.from(buf as Uint8Array))) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const ORCH_PATH = resolve(ROOT, 'packages/xlsx/src/render-orchestrator.ts');
+
+/** A minimal 4×4 solid opaque PNG of colour (r,g,b), base-64 → bytes. Built with
+ *  skia so we don't hand-encode PNG. Returned as a Blob for `fetchImage`. */
+function solidPngBytes(r: number, g: number, b: number): Uint8Array {
+  const c = new Canvas(4, 4);
+  const ctx = c.getContext('2d') as unknown as CanvasRenderingContext2D;
+  ctx.fillStyle = `rgb(${r},${g},${b})`;
+  ctx.fillRect(0, 0, 4, 4);
+  // skia-canvas: `toBufferSync('png')` (sync) or the async `png` getter.
+  const buf = (c as unknown as { toBufferSync(fmt: string): Buffer }).toBufferSync('png');
+  return new Uint8Array(buf);
+}
+
+/** A sheet with one twoCellAnchor picture over a fully blue-filled region. */
+function buildSynthetic(): { ws: Worksheet; styles: Styles } {
+  const blueFill = { patternType: 'solid', fgColor: '#0000FF', bgColor: null } as const;
+  const styles = {
+    fonts: [{ bold: false, italic: false, underline: false, strike: false, size: 11, color: null, name: 'Calibri' }],
+    fills: [{ patternType: 'none', fgColor: null, bgColor: null }, blueFill],
+    borders: [{ left: null, right: null, top: null, bottom: null }],
+    cellXfs: [
+      { fontId: 0, fillId: 0, borderId: 0, numFmtId: 0, alignH: null, alignV: null, wrapText: false },
+      { fontId: 0, fillId: 1, borderId: 0, numFmtId: 0, alignH: null, alignV: null, wrapText: false },
+    ],
+    numFmts: [],
+    dxfs: [],
+  } as unknown as Styles;
+
+  // Fill a block of cells (cols 1..6, rows 1..12) with the blue fill so the
+  // picture sits over solid colour (so an alpha blend is visible).
+  const rows = [];
+  for (let r = 1; r <= 12; r++) {
+    const cells = [];
+    for (let col = 1; col <= 6; col++) {
+      cells.push({ col, row: r, value: { type: 'empty' as const }, styleIndex: 1 });
+    }
+    rows.push({ index: r, height: null, cells });
+  }
+
+  const image: ImageAnchor = {
+    fromCol: 1, fromColOff: 0, fromRow: 2, fromRowOff: 0,
+    toCol: 5, toColOff: 0, toRow: 10, toRowOff: 0,
+    nativeExtCx: 0, nativeExtCy: 0,
+    imagePath: 'xl/media/image1.png',
+    mimeType: 'image/png',
+    alpha: 0.7,
+    duotone: { clr1: '000000', clr2: 'FFF3F4' },
+  };
+
+  const ws = {
+    name: 'S',
+    rows,
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 12,
+    defaultRowHeight: 20,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    images: [image],
+    charts: [],
+    showGridlines: false,
+    defaultFontFamily: 'Calibri',
+    defaultFontSize: 11,
+  } as unknown as Worksheet;
+
+  return { ws, styles };
+}
+
+const W = 500;
+const H = 400;
+
+async function render(effects: 'full' | 'duotone-opaque' | 'raw'): Promise<{ data: Uint8ClampedArray; w: number; h: number }> {
+  const { ws, styles } = buildSynthetic();
+  // A mid-grey opaque source PNG. sample-9's photo corners are near-white, but a
+  // mid grey lands the duotone at a mid-pink (leaving clear channel headroom so
+  // the alpha blend over the blue cell is measurable — with a near-white source
+  // the pink endpoint FFF3F4 is itself so close to white that the blend delta is
+  // tiny). The recolour/blend LOGIC is identical for any luminance.
+  const pngBytes = solidPngBytes(150, 150, 150);
+  const fetchImage = async (): Promise<Blob> =>
+    new Blob([pngBytes as unknown as BlobPart], { type: 'image/png' });
+
+  // Clone + optionally strip effects for the controls.
+  const ws2 = JSON.parse(JSON.stringify(ws)) as Worksheet;
+  const im = (ws2.images as ImageAnchor[])[0];
+  if (effects === 'duotone-opaque') delete im.alpha;
+  if (effects === 'raw') { delete im.alpha; delete im.duotone; }
+
+  const { renderWorksheetViewport } = (await import(ORCH_PATH)) as {
+    renderWorksheetViewport: (
+      deps: { ws: Worksheet; styles: Styles; imageCache: Map<string, unknown> },
+      target: unknown,
+      viewport: ViewportRange,
+      opts: { dpr: number; width: number; height: number; fetchImage: () => Promise<Blob> },
+    ) => Promise<void>;
+  };
+  const canvas = new Canvas(W, H);
+  const restoreImg = installImageBitmapShim(factory);
+  const restoreOff = installOffscreenCanvasShim(factory);
+  try {
+    await renderWorksheetViewport(
+      { ws: ws2, styles, imageCache: new Map() },
+      canvas,
+      { row: 1, col: 1, rows: 14, cols: 8 } as ViewportRange,
+      { dpr: 1, width: W, height: H, fetchImage },
+    );
+  } finally {
+    restoreOff();
+    restoreImg();
+  }
+  const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+  const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  return { data: img.data, w: canvas.width, h: canvas.height };
+}
+
+/** Mean RGB over a rectangle. */
+function mean(data: Uint8ClampedArray, w: number, x0: number, y0: number, x1: number, y1: number) {
+  let r = 0, g = 0, b = 0, n = 0;
+  for (let y = y0; y < y1; y++) {
+    for (let x = x0; x < x1; x++) {
+      const i = (y * w + x) * 4;
+      r += data[i]; g += data[i + 1]; b += data[i + 2]; n++;
+    }
+  }
+  return { r: r / n, g: g / n, b: b / n };
+}
+
+describe.skipIf(!skia)('xlsx blip duotone + alphaModFix (issue #880)', () => {
+  it('recolours a white photo to pink (duotone) and composites it over the cell (alphaModFix)', async () => {
+    const raw = await render('raw');
+    const duoOpaque = await render('duotone-opaque');
+    const full = await render('full');
+
+    // Sample a patch well inside the picture rect (cols 1..5 × rows 2..10 in a
+    // 12-col-wide 14-row viewport at ~ (colStart + 1.5 cols, rowStart + 3 rows)).
+    // A 40×40 patch near the picture centre is safely interior.
+    const cx = Math.round(W * 0.35);
+    const cy = Math.round(H * 0.4);
+    const box = [cx - 20, cy - 20, cx + 20, cy + 20] as const;
+    const pRaw = mean(raw.data, raw.w, ...box);
+    const pDuo = mean(duoOpaque.data, duoOpaque.w, ...box);
+    const pFull = mean(full.data, full.w, ...box);
+
+    // 1. Raw white photo is neutral: R ≈ G ≈ B (no colour cast).
+    expect(Math.abs(pRaw.r - pRaw.g)).toBeLessThan(6);
+    expect(Math.abs(pRaw.r - pRaw.b)).toBeLessThan(6);
+    // And it is NOT blue-dominant (the opaque photo hides the blue cell).
+    expect(pRaw.b).toBeLessThan(pRaw.r + 40);
+
+    // 2. Duotone recolours toward light pink FFF3F4: R > G and R > B by a clear
+    //    margin (the pink signature). The mid-grey source lands mid-ramp.
+    expect(pDuo.r).toBeGreaterThan(pDuo.g + 3);
+    expect(pDuo.r).toBeGreaterThan(pDuo.b + 3);
+    // And the recolour actually happened (not left as neutral grey): the
+    // green/blue channels dropped below the raw grey.
+    expect(pDuo.g).toBeLessThan(pRaw.g - 2);
+
+    // 3. alphaModFix (0.7) composites over the pure-blue cell: the full render's
+    //    blue channel is meaningfully higher than the opaque duotone control
+    //    (blue bleeds through), proving the alpha blend is applied.
+    expect(pFull.b).toBeGreaterThan(pDuo.b + 15);
+    // The pink cast survives the blend: red still exceeds green (the blend only
+    // adds blue, so R>G from the duotone is preserved).
+    expect(pFull.r).toBeGreaterThan(pFull.g);
+  });
+});

--- a/packages/ooxml-common/src/blip.rs
+++ b/packages/ooxml-common/src/blip.rs
@@ -139,6 +139,33 @@ pub fn parse_src_rect(blip_fill: Node<'_, '_>) -> Option<SrcRect> {
     }
 }
 
+/// Parse `<a:blip><a:alphaModFix amt="…"/></a:blip>` from a `<*:blipFill>` node
+/// (ECMA-376 §20.1.8.6 CT_AlphaModulateFixedEffect). `amt` is an
+/// ST_PositivePercentage in 1000ths of a percent, so `amt/100000` is the alpha
+/// scale fraction (0.0–1.0). The effect multiplies the picture's opacity by that
+/// fraction — the renderer applies it via `globalAlpha`.
+///
+/// Returns `None` when there is no `alphaModFix` OR when the amount is ≥ ~100%
+/// (fully opaque = nothing to apply), so an unaffected picture never forces the
+/// renderer onto the alpha path. Negative amounts clamp to 0. Shared by the
+/// pptx and xlsx parsers (docx can carry it too) so the three formats read the
+/// blip alpha identically.
+pub fn parse_blip_alpha(blip_fill: Node<'_, '_>) -> Option<f64> {
+    let blip = blip_fill
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "blip")?;
+    let amf = blip
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "alphaModFix")?;
+    let amt: f64 = amf.attribute("amt")?.parse().ok()?;
+    let frac = amt / 100_000.0;
+    if frac >= 0.9999 {
+        None
+    } else {
+        Some(frac.max(0.0))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -247,5 +274,27 @@ mod tests {
         // Case-insensitive, like the raster entries.
         assert_eq!(mime_from_ext("a/b/CHART.WMF"), "image/wmf");
         assert_eq!(mime_from_ext("x.EMF"), "image/emf");
+    }
+
+    #[test]
+    fn parse_blip_alpha_reads_amt_fraction() {
+        // amt=70000 → 0.70 (the sample-9.xlsx alphaModFix).
+        let xml = format!(
+            r#"<a:blipFill xmlns:a="{A_NS}"><a:blip r:embed="rId1" xmlns:r="{R_NS}"><a:alphaModFix amt="70000"/></a:blip></a:blipFill>"#
+        );
+        let doc = Document::parse(&xml).unwrap();
+        let a = parse_blip_alpha(doc.root_element()).expect("alpha present");
+        assert!((a - 0.70).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_blip_alpha_none_when_absent_or_fully_opaque() {
+        let none = format!(r#"<a:blipFill xmlns:a="{A_NS}"><a:blip/></a:blipFill>"#);
+        assert!(parse_blip_alpha(Document::parse(&none).unwrap().root_element()).is_none());
+        // amt=100000 (100%) ⇒ nothing to apply.
+        let opaque = format!(
+            r#"<a:blipFill xmlns:a="{A_NS}"><a:blip><a:alphaModFix amt="100000"/></a:blip></a:blipFill>"#
+        );
+        assert!(parse_blip_alpha(Document::parse(&opaque).unwrap().root_element()).is_none());
     }
 }

--- a/packages/ooxml-common/src/blip.rs
+++ b/packages/ooxml-common/src/blip.rs
@@ -166,6 +166,73 @@ pub fn parse_blip_alpha(blip_fill: Node<'_, '_>) -> Option<f64> {
     }
 }
 
+/// A `<a:duotone>` image effect (ECMA-376 §20.1.8.23) resolved to its two
+/// endpoint colours. `clr1` is the first `EG_ColorChoice` child (the dark
+/// endpoint, luminance 0), `clr2` the second (the light endpoint, luminance 1) —
+/// the spec says the effect "combines clr1 and clr2 through a linear
+/// interpolation" per pixel, so pixel luminance is the interpolation factor.
+/// Both are 6-char uppercase hex WITHOUT a `#`; any per-colour transforms
+/// (lumMod/lumOff/tint/satMod/shade/…) are already baked in by
+/// [`crate::color::parse_color_node`]. Shared across the docx/pptx/xlsx parsers.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Duotone {
+    /// First colour child — dark endpoint. 6-char hex, no `#`.
+    pub clr1: String,
+    /// Second colour child — light endpoint. 6-char hex, no `#`.
+    pub clr2: String,
+}
+
+/// Parse `<a:blipFill>`'s `<a:duotone>` (§20.1.8.23), resolving its two
+/// `EG_ColorChoice` children through the shared DrawingML colour grammar
+/// ([`crate::color::parse_color_node`]) so all per-colour transforms are applied.
+/// `resolver` supplies the host's `<a:schemeClr>` palette lookup and `tint_mode`
+/// selects the Word/PowerPoint `<a:tint>` interpretation, exactly as every other
+/// colour path in the parser does.
+///
+/// `<a:duotone>` is a sibling of `<a:blip>` inside `<a:blipFill>` (it is one of
+/// CT_BlipFillProperties' blip-effect children). Returns `None` when there is no
+/// duotone or fewer than two resolvable colours (a malformed effect is dropped
+/// rather than half-applied). The returned hexes carry NO `#` and are uppercase.
+pub fn parse_blip_duotone<R: crate::color::ThemeResolver + ?Sized>(
+    blip_fill: Node<'_, '_>,
+    resolver: &R,
+    tint_mode: crate::color::TintMode,
+) -> Option<Duotone> {
+    // `<a:duotone>` lives on the blip itself (a blip-effect child), with the
+    // srcRect/stretch/tile as its siblings. Some producers place it directly
+    // under blipFill; accept either by searching descendants of blipFill's
+    // immediate children shallowly.
+    let duotone = blip_fill
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "duotone")
+        .or_else(|| {
+            blip_fill
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "blip")
+                .and_then(|blip| {
+                    blip.children()
+                        .find(|n| n.is_element() && n.tag_name().name() == "duotone")
+                })
+        })?;
+    // The two EG_ColorChoice children, in document order. Each child IS a colour
+    // element (srgbClr/schemeClr/prstClr/…) — not a container wrapping one — so it
+    // is classified with `color_source_from_element` and resolved (transforms and
+    // all) via `resolve_color_source`, reusing the exact colour grammar every
+    // other path uses.
+    let mut colors = duotone
+        .children()
+        .filter(|n| n.is_element())
+        .filter_map(|node| crate::color::color_source_from_element(node))
+        .filter_map(|source| crate::color::resolve_color_source(source, resolver, tint_mode));
+    let clr1 = colors.next()?;
+    let clr2 = colors.next()?;
+    Some(Duotone {
+        clr1: clr1.to_uppercase(),
+        clr2: clr2.to_uppercase(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -276,6 +343,18 @@ mod tests {
         assert_eq!(mime_from_ext("x.EMF"), "image/emf");
     }
 
+    // A minimal ThemeResolver mapping a couple of scheme names, so the duotone
+    // scheme-color path is exercised without a full parser.
+    struct DuoResolver;
+    impl crate::color::ThemeResolver for DuoResolver {
+        fn resolve_scheme_color(&self, name: &str) -> Option<String> {
+            match name {
+                "accent1" => Some("4472C4".to_owned()),
+                _ => None,
+            }
+        }
+    }
+
     #[test]
     fn parse_blip_alpha_reads_amt_fraction() {
         // amt=70000 → 0.70 (the sample-9.xlsx alphaModFix).
@@ -296,5 +375,67 @@ mod tests {
             r#"<a:blipFill xmlns:a="{A_NS}"><a:blip><a:alphaModFix amt="100000"/></a:blip></a:blipFill>"#
         );
         assert!(parse_blip_alpha(Document::parse(&opaque).unwrap().root_element()).is_none());
+    }
+
+    #[test]
+    fn parse_blip_duotone_resolves_two_colours_with_transforms() {
+        // The sample-9.xlsx effect: clr1=black (prstClr), clr2=srgbClr DAB6BA with
+        // lumMod/lumOff/tint/satMod transforms. clr1 is the dark endpoint.
+        let xml = format!(
+            r#"<a:blipFill xmlns:a="{A_NS}">
+                 <a:blip r:embed="rId1" xmlns:r="{R_NS}"/>
+                 <a:duotone>
+                   <a:prstClr val="black"/>
+                   <a:srgbClr val="DAB6BA">
+                     <a:lumMod val="20000"/><a:lumOff val="80000"/>
+                     <a:tint val="45000"/><a:satMod val="400000"/>
+                   </a:srgbClr>
+                 </a:duotone>
+               </a:blipFill>"#
+        );
+        let doc = Document::parse(&xml).unwrap();
+        let duo = parse_blip_duotone(
+            doc.root_element(),
+            &DuoResolver,
+            crate::color::TintMode::PowerPointLinear,
+        )
+        .expect("duotone present");
+        // clr1 = black.
+        assert_eq!(duo.clr1, "000000");
+        // clr2 is DAB6BA lightened by the transforms → a light pink (all channels
+        // high, R the largest). We assert the shape, not an exact hex (the exact
+        // value depends on the shared transform math, reported separately).
+        let r = u8::from_str_radix(&duo.clr2[0..2], 16).unwrap();
+        let g = u8::from_str_radix(&duo.clr2[2..4], 16).unwrap();
+        let b = u8::from_str_radix(&duo.clr2[4..6], 16).unwrap();
+        assert!(r > 200, "clr2 R should be high (light pink), got {r}");
+        assert!(
+            r >= g && r >= b,
+            "clr2 should be pink (R largest): {}",
+            duo.clr2
+        );
+    }
+
+    #[test]
+    fn parse_blip_duotone_none_when_absent_or_single_colour() {
+        let none = format!(
+            r#"<a:blipFill xmlns:a="{A_NS}"><a:blip r:embed="rId1" xmlns:r="{R_NS}"/></a:blipFill>"#
+        );
+        assert!(parse_blip_duotone(
+            Document::parse(&none).unwrap().root_element(),
+            &DuoResolver,
+            crate::color::TintMode::PowerPointLinear
+        )
+        .is_none());
+        // Only one colour child ⇒ not a valid duotone; dropped.
+        let one = format!(
+            r#"<a:blipFill xmlns:a="{A_NS}"><a:duotone><a:srgbClr val="112233"/></a:duotone></a:blipFill>"#
+        );
+        assert!(parse_blip_duotone(
+            Document::parse(&one).unwrap().root_element(),
+            &DuoResolver,
+            crate::color::TintMode::PowerPointLinear
+        )
+        .is_none());
     }
 }

--- a/packages/ooxml-common/src/color.rs
+++ b/packages/ooxml-common/src/color.rs
@@ -456,7 +456,84 @@ pub fn parse_color_node<R: ThemeResolver + ?Sized>(
     resolver: &R,
     tint_mode: TintMode,
 ) -> Option<String> {
-    match extract_color_source(container)? {
+    resolve_color_source(extract_color_source(container)?, resolver, tint_mode)
+}
+
+/// Build a [`ColorSource`] from a node that IS itself a colour element
+/// (`<a:srgbClr>`, `<a:schemeClr>`, `<a:prstClr>`, …), rather than a container
+/// wrapping one. [`extract_color_source`] scans a container's *children*; this
+/// classifies the node directly. Needed where the color elements appear as a
+/// bare list — e.g. `<a:duotone>`'s two `EG_ColorChoice` children (§20.1.8.23),
+/// which are the colour elements themselves. Returns `None` for a non-colour
+/// element (or a `srgbClr`/`prstClr`/`schemeClr` missing its required `val`).
+pub fn color_source_from_element<'a, 'input>(
+    el: Node<'a, 'input>,
+) -> Option<ColorSource<'a, 'input>> {
+    match el.tag_name().name() {
+        "srgbClr" => Some(ColorSource::SrgbClr {
+            val: el.attribute("val")?.to_owned(),
+            node: el,
+        }),
+        "scrgbClr" => {
+            let pct = |name: &str| -> f64 {
+                el.attribute(name)
+                    .and_then(|v| v.parse::<f64>().ok())
+                    .unwrap_or(0.0)
+                    / 100_000.0
+            };
+            Some(ColorSource::ScrgbClr {
+                r: pct("r"),
+                g: pct("g"),
+                b: pct("b"),
+                node: el,
+            })
+        }
+        "hslClr" => Some(ColorSource::HslClr {
+            hue: el
+                .attribute("hue")
+                .and_then(|v| v.parse::<f64>().ok())
+                .unwrap_or(0.0)
+                / 60_000.0
+                / 360.0,
+            sat: el
+                .attribute("sat")
+                .and_then(|v| v.parse::<f64>().ok())
+                .unwrap_or(0.0)
+                / 100_000.0,
+            lum: el
+                .attribute("lum")
+                .and_then(|v| v.parse::<f64>().ok())
+                .unwrap_or(0.0)
+                / 100_000.0,
+            node: el,
+        }),
+        "sysClr" => Some(ColorSource::SysClr {
+            last_clr: el.attribute("lastClr").map(str::to_owned),
+            val: el.attribute("val").map(str::to_owned),
+            node: el,
+        }),
+        "prstClr" => Some(ColorSource::PrstClr {
+            val: el.attribute("val")?.to_owned(),
+            node: el,
+        }),
+        "schemeClr" => Some(ColorSource::SchemeClr {
+            val: el.attribute("val")?.to_owned(),
+            node: el,
+        }),
+        _ => None,
+    }
+}
+
+/// Resolve a located [`ColorSource`] to a hex string (uppercase, no `#`),
+/// applying its EG_ColorTransform children. Split out of [`parse_color_node`] so
+/// callers that already hold a `ColorSource` (e.g. from
+/// [`color_source_from_element`]) can resolve it without re-scanning.
+pub fn resolve_color_source<R: ThemeResolver + ?Sized>(
+    source: ColorSource<'_, '_>,
+    resolver: &R,
+    tint_mode: TintMode,
+) -> Option<String> {
+    match source {
         ColorSource::SrgbClr { val, node } => Some(apply_color_transforms(&val, node, tint_mode)),
         ColorSource::ScrgbClr { r, g, b, node } => {
             // Linear-light r/g/b (0..1) → sRGB display hex, then transforms.

--- a/packages/pptx/parser/src/fill.rs
+++ b/packages/pptx/parser/src/fill.rs
@@ -11,19 +11,12 @@ use crate::{attr, attr_f64, attr_i64, attr_r, child, children_vec};
 use ooxml_common::blip::mime_from_ext;
 use std::collections::HashMap;
 
-/// Parse `<a:blip><a:alphaModFix amt="..."/></a:blip>` from a blipFill node.
-/// Returns fraction (amt / 100000) when present and < 1.0; None otherwise.
-pub(crate) fn parse_blip_alpha(blip_fill: roxmltree::Node<'_, '_>) -> Option<f64> {
-    let blip = child(blip_fill, "blip")?;
-    let amf = child(blip, "alphaModFix")?;
-    let amt: f64 = attr(&amf, "amt")?.parse().ok()?;
-    let frac = amt / 100_000.0;
-    if frac >= 0.9999 {
-        None
-    } else {
-        Some(frac.max(0.0))
-    }
-}
+/// Parse `<a:blip><a:alphaModFix amt="..."/></a:blip>` from a blipFill node
+/// (ECMA-376 §20.1.8.6). Thin re-export of the shared
+/// [`ooxml_common::blip::parse_blip_alpha`] so the three formats read the blip
+/// alpha identically (previously a pptx-local copy). Returns the fraction
+/// `amt/100000` when present and < 1.0; `None` otherwise.
+pub(crate) use ooxml_common::blip::parse_blip_alpha;
 
 /// Parse `<a:stretch><a:fillRect l t r b>` (ECMA-376 §20.1.8.58 / §20.1.8.30).
 /// Edge attributes are ST_Percentage (1000ths of a percent → /100000 gives a

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -6,7 +6,9 @@ use ooxml_common::zip::read_zip_string;
 // `.svg ⇒ image/svg+xml`; `svg_blip_rid` resolves the vector original nested in
 // a blip's `<a:extLst>`. Replaces xlsx's former local `mime_from_ext` (a strict
 // subset that lacked the `svg` arm and so dropped SVG parts).
-use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
+use ooxml_common::blip::{
+    blip_embed_rid, mime_from_ext, parse_blip_alpha, parse_src_rect, svg_blip_rid,
+};
 use ooxml_common::depth::{parse_guarded, DepthGuard};
 use ooxml_common::ns::{attr_ns, is_a_ns, is_xdr_ns, relationships};
 use ooxml_common::units::EMU_PER_PX_96DPI;
@@ -76,6 +78,8 @@ pub(crate) fn parse_drawing_anchors(
         let mut native_ext_cy: i64 = 0;
         // ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop (None ⇒ uncropped).
         let mut src_rect: Option<SrcRect> = None;
+        // ECMA-376 §20.1.8.6 `<a:alphaModFix>` opacity (None ⇒ opaque).
+        let mut alpha: Option<f64> = None;
         // ECMA-376 §20.5.2.33 `twoCellAnchor@editAs`. Possible values:
         // "twoCell" (default), "oneCell", "absolute". With "oneCell" Excel
         // preserves the picture's saved size from <xdr:spPr><a:xfrm><a:ext>
@@ -139,6 +143,8 @@ pub(crate) fn parse_drawing_anchors(
                         }
                         // `<a:srcRect>` is a sibling of `<a:blip>` inside blipFill.
                         src_rect = parse_src_rect(bf);
+                        // §20.1.8.6 `<a:alphaModFix>` overall opacity.
+                        alpha = parse_blip_alpha(bf);
                     }
                     // <xdr:pic><xdr:spPr><a:xfrm><a:ext cx cy>: the picture's
                     // own saved EMU extent. Authoritative when editAs="oneCell".
@@ -206,6 +212,7 @@ pub(crate) fn parse_drawing_anchors(
             mime_type,
             svg_image_path,
             src_rect,
+            alpha,
         });
     }
     anchors
@@ -1160,11 +1167,13 @@ pub(crate) fn collect_shapes(
             let svg_image_path = svg_rid.as_deref().and_then(|r| rid_urls.get(r)).cloned();
             let raster_path = pic_rid.as_deref().and_then(|r| rid_urls.get(r)).cloned();
 
-            // `<a:srcRect>` crop lives in the leaf's `<xdr:blipFill>` (§20.1.8.55).
-            let src_rect = child
+            // `<a:srcRect>` crop and `<a:alphaModFix>` opacity live in the leaf's
+            // `<xdr:blipFill>` (§20.1.8.55 / §20.1.8.6).
+            let leaf_blip_fill = child
                 .descendants()
-                .find(|n| n.is_element() && n.tag_name().name() == "blipFill")
-                .and_then(parse_src_rect);
+                .find(|n| n.is_element() && n.tag_name().name() == "blipFill");
+            let src_rect = leaf_blip_fill.and_then(parse_src_rect);
+            let alpha = leaf_blip_fill.and_then(parse_blip_alpha);
 
             // Prefer the raster as `image_path`; fall back to the SVG when no
             // raster is embedded so an svg-only leaf is never dropped. Drop only
@@ -1205,6 +1214,7 @@ pub(crate) fn collect_shapes(
                     mime_type,
                     svg_image_path,
                     src_rect,
+                    alpha,
                 },
                 text: None,
             });
@@ -1934,6 +1944,8 @@ pub(crate) fn parse_ole_object_anchors(
             mime_type,
             svg_image_path: None,
             src_rect: None,
+            // OLE object previews carry no blip effects.
+            alpha: None,
         });
     }
     anchors
@@ -3159,6 +3171,7 @@ mod blip_svg_tests {
             mime_type: "image/png".to_string(),
             svg_image_path: Some("xl/media/image2.svg".to_string()),
             src_rect: None,
+            alpha: None,
         };
         let json = serde_json::to_string(&anchor).unwrap();
         assert!(json.contains("\"imagePath\":\"xl/media/image1.png\""));
@@ -3179,6 +3192,7 @@ mod blip_svg_tests {
             mime_type: "image/png".to_string(),
             svg_image_path: None,
             src_rect: None,
+            alpha: None,
         };
         let json = serde_json::to_string(&geom).unwrap();
         assert!(json.contains("\"type\":\"image\""));

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -7,7 +7,8 @@ use ooxml_common::zip::read_zip_string;
 // a blip's `<a:extLst>`. Replaces xlsx's former local `mime_from_ext` (a strict
 // subset that lacked the `svg` arm and so dropped SVG parts).
 use ooxml_common::blip::{
-    blip_embed_rid, mime_from_ext, parse_blip_alpha, parse_src_rect, svg_blip_rid,
+    blip_embed_rid, mime_from_ext, parse_blip_alpha, parse_blip_duotone, parse_src_rect,
+    svg_blip_rid,
 };
 use ooxml_common::depth::{parse_guarded, DepthGuard};
 use ooxml_common::ns::{attr_ns, is_a_ns, is_xdr_ns, relationships};
@@ -55,6 +56,9 @@ pub(crate) fn parse_drawing_anchors(
     drawing_rels: &HashMap<String, String>,
     drawing_dir: &str,
     archive: &mut crate::XlsxZip,
+    // Positional clrScheme palette, for resolving a picture's `<a:duotone>`
+    // effect colours (§20.1.8.23).
+    theme_colors: &[String],
 ) -> Vec<ImageAnchor> {
     let Ok(doc) = parse_guarded(drawing_xml) else {
         return Vec::new();
@@ -78,8 +82,10 @@ pub(crate) fn parse_drawing_anchors(
         let mut native_ext_cy: i64 = 0;
         // ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop (None ⇒ uncropped).
         let mut src_rect: Option<SrcRect> = None;
-        // ECMA-376 §20.1.8.6 `<a:alphaModFix>` opacity (None ⇒ opaque).
+        // ECMA-376 §20.1.8.6 `<a:alphaModFix>` opacity (None ⇒ opaque) and
+        // §20.1.8.23 `<a:duotone>` recolour (None ⇒ no effect).
         let mut alpha: Option<f64> = None;
+        let mut duotone: Option<Duotone> = None;
         // ECMA-376 §20.5.2.33 `twoCellAnchor@editAs`. Possible values:
         // "twoCell" (default), "oneCell", "absolute". With "oneCell" Excel
         // preserves the picture's saved size from <xdr:spPr><a:xfrm><a:ext>
@@ -143,8 +149,16 @@ pub(crate) fn parse_drawing_anchors(
                         }
                         // `<a:srcRect>` is a sibling of `<a:blip>` inside blipFill.
                         src_rect = parse_src_rect(bf);
-                        // §20.1.8.6 `<a:alphaModFix>` overall opacity.
+                        // Blip effects: `<a:alphaModFix>` opacity (§20.1.8.6) and
+                        // `<a:duotone>` recolour (§20.1.8.23). The duotone colours
+                        // resolve through the shared DrawingML grammar using the
+                        // sheet's theme palette.
                         alpha = parse_blip_alpha(bf);
+                        duotone = parse_blip_duotone(
+                            bf,
+                            &XlsxSchemeResolver { theme_colors },
+                            ooxml_common::color::TintMode::PowerPointLinear,
+                        );
                     }
                     // <xdr:pic><xdr:spPr><a:xfrm><a:ext cx cy>: the picture's
                     // own saved EMU extent. Authoritative when editAs="oneCell".
@@ -213,6 +227,7 @@ pub(crate) fn parse_drawing_anchors(
             svg_image_path,
             src_rect,
             alpha,
+            duotone,
         });
     }
     anchors
@@ -1167,13 +1182,21 @@ pub(crate) fn collect_shapes(
             let svg_image_path = svg_rid.as_deref().and_then(|r| rid_urls.get(r)).cloned();
             let raster_path = pic_rid.as_deref().and_then(|r| rid_urls.get(r)).cloned();
 
-            // `<a:srcRect>` crop and `<a:alphaModFix>` opacity live in the leaf's
-            // `<xdr:blipFill>` (§20.1.8.55 / §20.1.8.6).
+            // `<a:srcRect>` crop, `<a:alphaModFix>` opacity and `<a:duotone>`
+            // recolour all live in the leaf's `<xdr:blipFill>` (§20.1.8.55 /
+            // §20.1.8.6 / §20.1.8.23).
             let leaf_blip_fill = child
                 .descendants()
                 .find(|n| n.is_element() && n.tag_name().name() == "blipFill");
             let src_rect = leaf_blip_fill.and_then(parse_src_rect);
             let alpha = leaf_blip_fill.and_then(parse_blip_alpha);
+            let duotone = leaf_blip_fill.and_then(|bf| {
+                parse_blip_duotone(
+                    bf,
+                    &XlsxSchemeResolver { theme_colors },
+                    ooxml_common::color::TintMode::PowerPointLinear,
+                )
+            });
 
             // Prefer the raster as `image_path`; fall back to the SVG when no
             // raster is embedded so an svg-only leaf is never dropped. Drop only
@@ -1215,6 +1238,7 @@ pub(crate) fn collect_shapes(
                     svg_image_path,
                     src_rect,
                     alpha,
+                    duotone,
                 },
                 text: None,
             });
@@ -1557,6 +1581,9 @@ pub(crate) fn build_drawing_rid_urls(
 pub(crate) fn load_sheet_images(
     archive: &mut crate::XlsxZip,
     sheet_path: &str, // e.g. "worksheets/sheet1.xml"
+    // Positional clrScheme palette, for resolving a picture's `<a:duotone>`
+    // effect colours (§20.1.8.23) via the shared DrawingML colour grammar.
+    theme_colors: &[String],
 ) -> Vec<ImageAnchor> {
     // sheet rels path:  xl/worksheets/_rels/sheet1.xml.rels
     let Some((sheet_dir, sheet_file)) = sheet_path.rsplit_once('/') else {
@@ -1606,7 +1633,13 @@ pub(crate) fn load_sheet_images(
             .map(|xml| parse_rels_map(&xml))
             .unwrap_or_default();
 
-        let mut anchors = parse_drawing_anchors(&drawing_xml, &drawing_rels, drawing_dir, archive);
+        let mut anchors = parse_drawing_anchors(
+            &drawing_xml,
+            &drawing_rels,
+            drawing_dir,
+            archive,
+            theme_colors,
+        );
         all_anchors.append(&mut anchors);
     }
     all_anchors
@@ -1946,6 +1979,7 @@ pub(crate) fn parse_ole_object_anchors(
             src_rect: None,
             // OLE object previews carry no blip effects.
             alpha: None,
+            duotone: None,
         });
     }
     anchors
@@ -2975,7 +3009,7 @@ mod blip_svg_tests {
         let data = build_media_zip(PNG_1X1, SVG);
         let cursor = Cursor::new(data.clone());
         let mut archive = zip::ZipArchive::new(cursor).unwrap();
-        let anchors = parse_drawing_anchors(&xml, rels, "xl/drawings", &mut archive);
+        let anchors = parse_drawing_anchors(&xml, rels, "xl/drawings", &mut archive, &[]);
         assert_eq!(anchors.len(), 1, "exactly one picture anchor expected");
         anchors.into_iter().next().unwrap()
     }
@@ -3008,7 +3042,7 @@ mod blip_svg_tests {
                 hidden = hidden_attr,
             );
             let mut archive = zip::ZipArchive::new(Cursor::new(data.clone())).unwrap();
-            let anchors = parse_drawing_anchors(&xml, &rels, "xl/drawings", &mut archive);
+            let anchors = parse_drawing_anchors(&xml, &rels, "xl/drawings", &mut archive, &[]);
             assert_eq!(anchors.len(), expect_len, "hidden={hidden_attr}");
         }
     }
@@ -3172,6 +3206,7 @@ mod blip_svg_tests {
             svg_image_path: Some("xl/media/image2.svg".to_string()),
             src_rect: None,
             alpha: None,
+            duotone: None,
         };
         let json = serde_json::to_string(&anchor).unwrap();
         assert!(json.contains("\"imagePath\":\"xl/media/image1.png\""));
@@ -3193,6 +3228,7 @@ mod blip_svg_tests {
             svg_image_path: None,
             src_rect: None,
             alpha: None,
+            duotone: None,
         };
         let json = serde_json::to_string(&geom).unwrap();
         assert!(json.contains("\"type\":\"image\""));
@@ -3891,7 +3927,7 @@ mod strict_namespace_tests {
 
         let data = build_media_zip(PNG_1X1);
         let mut archive = zip::ZipArchive::new(Cursor::new(data)).unwrap();
-        let anchors = parse_drawing_anchors(&xml, &rels, "xl/drawings", &mut archive);
+        let anchors = parse_drawing_anchors(&xml, &rels, "xl/drawings", &mut archive, &[]);
 
         assert_eq!(
             anchors.len(),

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -252,7 +252,7 @@ fn parse_sheet_with(
     };
 
     // Attach any drawing-anchored images and charts for this sheet
-    ws.images = load_sheet_images(archive, &sheet_path);
+    ws.images = load_sheet_images(archive, &sheet_path, theme_colors);
     // Embedded OLE object previews (the `<oleObjects>` collection, §18.3.1.60)
     // draw through the same image
     // list; their preview parts are referenced from the worksheet XML + rels.

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -712,6 +712,10 @@ pub enum ShapeGeom {
         /// the same as a `twoCellAnchor` picture.
         #[serde(skip_serializing_if = "Option::is_none")]
         src_rect: Option<SrcRect>,
+        /// ECMA-376 §20.1.8.6 `<a:alphaModFix@amt>` on the leaf pic (0.0–1.0).
+        /// `None` = opaque. Applied via `globalAlpha`, like the top-level anchor.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        alpha: Option<f64>,
     },
 }
 
@@ -853,6 +857,11 @@ pub struct ImageAnchor {
     /// anchor rect. When set, the renderer draws only the visible sub-rectangle.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub src_rect: Option<SrcRect>,
+    /// ECMA-376 §20.1.8.6 `<a:alphaModFix@amt>` — the blip's overall opacity as a
+    /// fraction (0.0–1.0). `None` = fully opaque. The renderer applies it via
+    /// `globalAlpha` so the picture composites over the cells beneath it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alpha: Option<f64>,
 }
 
 /// ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop, shared across the docx,

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -716,6 +716,10 @@ pub enum ShapeGeom {
         /// `None` = opaque. Applied via `globalAlpha`, like the top-level anchor.
         #[serde(skip_serializing_if = "Option::is_none")]
         alpha: Option<f64>,
+        /// ECMA-376 §20.1.8.23 `<a:duotone>` recolour on the leaf pic. `None` =
+        /// no effect. Remaps the leaf image along the `clr1`→`clr2` ramp.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        duotone: Option<Duotone>,
     },
 }
 
@@ -862,11 +866,20 @@ pub struct ImageAnchor {
     /// `globalAlpha` so the picture composites over the cells beneath it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alpha: Option<f64>,
+    /// ECMA-376 §20.1.8.23 `<a:duotone>` recolour effect, resolved to its two
+    /// endpoint colours. `None` = no duotone (the common case). When set, the
+    /// renderer remaps the image along the `clr1`→`clr2` luminance ramp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duotone: Option<Duotone>,
 }
 
 /// ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop, shared across the docx,
 /// pptx and xlsx parsers (see `ooxml_common::blip`).
 pub use ooxml_common::blip::SrcRect;
+
+/// ECMA-376 §20.1.8.23 `<a:duotone>` image effect, shared across the docx, pptx
+/// and xlsx parsers (see `ooxml_common::blip`).
+pub use ooxml_common::blip::Duotone;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -79,6 +79,7 @@ export type {
   Sparkline,
   // Drawings / shapes (reachable via Worksheet drawings).
   ImageAnchor,
+  Duotone,
   ChartAnchor,
   ShapeAnchor,
   ShapeInfo,

--- a/packages/xlsx/src/render-orchestrator.image.test.ts
+++ b/packages/xlsx/src/render-orchestrator.image.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { prefetchImages, decodeImageSource, closeAndClearImageCache } from './render-orchestrator';
 import type { Worksheet } from './types';
+import type { OffscreenFactory } from '@silurus/ooxml-core';
 
 /**
  * The render orchestrator decodes embedded images lazily by zip path:
@@ -287,5 +288,113 @@ describe('closeAndClearImageCache (teardown GPU-bitmap leak guard)', () => {
   it('is safe to call on an already-empty cache', () => {
     const cache = new Map<string, CanvasImageSource | null>();
     expect(() => closeAndClearImageCache(cache)).not.toThrow();
+  });
+});
+
+// ── <a:duotone> recolour at decode time (§20.1.8.23) ─────────────────────────
+// A picture carrying a duotone effect is decoded once, recoloured along the
+// clr1→clr2 luminance ramp, and cached under a colour-suffixed key so the raw
+// blip and its recoloured variant never collide. `applyDuotone` reads the base
+// bitmap's pixels via getImageData → transform → putImageData → a NEW bitmap, so
+// we inject an offscreen factory + stub createImageBitmap to exercise the path
+// without a real canvas.
+describe('render-orchestrator duotone (§20.1.8.23)', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** An offscreen surface whose getImageData returns a fixed near-white pixel
+   *  grid, and whose putImageData records the mutated buffer so the test can
+   *  confirm the recolour ran. Cast to the core `OffscreenFactory` at the
+   *  boundary (a partial mock — the DOM `ImageBitmapSource` shape is irrelevant
+   *  to the transform under test). */
+  function recordingFactory(record: { out?: Uint8ClampedArray }): OffscreenFactory {
+    return ((w: number, h: number) => ({
+      width: w,
+      height: h,
+      getContext() {
+        return {
+          drawImage() {},
+          getImageData(_sx: number, _sy: number, sw: number, sh: number) {
+            // All near-white opaque pixels (t≈0.96) → should map toward clr2.
+            const data = new Uint8ClampedArray(sw * sh * 4).fill(246);
+            for (let i = 3; i < data.length; i += 4) data[i] = 255; // alpha
+            return { data, width: sw, height: sh } as unknown as ImageData;
+          },
+          putImageData(img: ImageData) {
+            record.out = img.data;
+          },
+        };
+      },
+    })) as unknown as OffscreenFactory;
+  }
+
+  it('recolours a duotone picture and caches it under a colour-suffixed key', async () => {
+    // A fake bitmap exposes width/height so imageNaturalSize sizes the surface.
+    const baseBitmap = { width: 4, height: 4, tag: 'base' } as unknown as ImageBitmap;
+    const recoloured = { width: 4, height: 4, tag: 'duo' } as unknown as ImageBitmap;
+    vi.stubGlobal('createImageBitmap', vi.fn(async (src: unknown) => {
+      // The base decode passes a Blob; applyDuotone passes the offscreen surface.
+      return src instanceof Blob ? baseBitmap : recoloured;
+    }));
+    const fetchImage = vi.fn(async (path: string, mime: string) =>
+      new Blob([new TextEncoder().encode(path)], { type: mime }),
+    );
+    const ws = worksheetWithImages();
+    ws.images = [
+      {
+        fromCol: 0, fromColOff: 0, fromRow: 0, fromRowOff: 0,
+        toCol: 2, toColOff: 0, toRow: 2, toRowOff: 0,
+        nativeExtCx: 0, nativeExtCy: 0,
+        imagePath: 'xl/media/image1.png',
+        mimeType: 'image/png',
+        alpha: 0.7,
+        duotone: { clr1: '000000', clr2: 'FFF3F4' },
+      },
+    ];
+    ws.shapeGroups = [];
+    const record: { out?: Uint8ClampedArray } = {};
+    const cache = new Map<string, CanvasImageSource | null>();
+
+    await prefetchImages(ws, cache, fetchImage, {
+      offscreenFactory: recordingFactory(record),
+    });
+
+    // Cached under path + duotone colours (NOT the bare path).
+    const key = 'xl/media/image1.png|duo:000000:FFF3F4';
+    expect(cache.has(key)).toBe(true);
+    expect(cache.has('xl/media/image1.png')).toBe(false);
+    // The cached source is the recoloured bitmap, not the base.
+    expect(cache.get(key)).toBe(recoloured);
+    // putImageData saw the recoloured buffer: near-white (246) → toward FFF3F4
+    // (R=0xFF=255, G=0xF3=243, B=0xF4=244), so R>G and R>B and all high.
+    expect(record.out).toBeDefined();
+    const out = record.out as Uint8ClampedArray;
+    expect(out[0]).toBeGreaterThan(240); // R
+    expect(out[0]).toBeGreaterThanOrEqual(out[1]); // R>=G
+    expect(out[0]).toBeGreaterThanOrEqual(out[2]); // R>=B
+  });
+
+  it('keeps a duotone variant separate from the same path without duotone', async () => {
+    const baseBitmap = { width: 2, height: 2 } as unknown as ImageBitmap;
+    const recoloured = { width: 2, height: 2, tag: 'duo' } as unknown as ImageBitmap;
+    vi.stubGlobal('createImageBitmap', vi.fn(async (src: unknown) =>
+      src instanceof Blob ? baseBitmap : recoloured,
+    ));
+    const fetchImage = vi.fn(async (path: string, mime: string) =>
+      new Blob([new TextEncoder().encode(path)], { type: mime }),
+    );
+    const ws = worksheetWithImages();
+    ws.images = [
+      { fromCol: 0, fromColOff: 0, fromRow: 0, fromRowOff: 0, toCol: 1, toColOff: 0, toRow: 1, toRowOff: 0, nativeExtCx: 0, nativeExtCy: 0, imagePath: 'xl/media/image1.png', mimeType: 'image/png' },
+      { fromCol: 0, fromColOff: 0, fromRow: 0, fromRowOff: 0, toCol: 1, toColOff: 0, toRow: 1, toRowOff: 0, nativeExtCx: 0, nativeExtCy: 0, imagePath: 'xl/media/image1.png', mimeType: 'image/png', duotone: { clr1: '000000', clr2: 'FFF3F4' } },
+    ];
+    ws.shapeGroups = [];
+    const record: { out?: Uint8ClampedArray } = {};
+    const cache = new Map<string, CanvasImageSource | null>();
+
+    await prefetchImages(ws, cache, fetchImage, { offscreenFactory: recordingFactory(record) });
+
+    expect(cache.has('xl/media/image1.png')).toBe(true); // plain
+    expect(cache.has('xl/media/image1.png|duo:000000:FFF3F4')).toBe(true); // recoloured
+    expect(cache.size).toBe(2);
   });
 });

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -6,12 +6,20 @@ import {
   preferVectorBlip,
   decodeRasterOrMetafile,
   metafileRasterSize,
+  applyDuotone,
+  imageNaturalSize,
   EMU_PER_PT,
   type MathRenderer,
   type SrcRect,
+  type Duotone,
 } from '@silurus/ooxml-core';
 import type { ParsedWorkbook, Worksheet, ViewportRange, RenderViewportOptions } from './types.js';
-import { renderViewport, prepareWorksheetMath, worksheetHasUncachedMath } from './renderer.js';
+import {
+  renderViewport,
+  prepareWorksheetMath,
+  worksheetHasUncachedMath,
+  imageCacheKey,
+} from './renderer.js';
 
 /** What `prefetchImages` needs to decode one picture: the raster `imagePath`
  *  (also the cache key), its `mimeType`, the optional svgBlip vector path, and
@@ -28,6 +36,10 @@ interface ImageRef {
    *  metafile, scales the raster up to the full picture frame so the fractional
    *  crop lands correctly (see `metafileRasterSize`). */
   srcRect?: SrcRect | null;
+  /** The picture's `<a:duotone>` recolour (§20.1.8.23), when present. The base
+   *  bitmap is decoded, then recoloured along the `clr1`→`clr2` ramp; the result
+   *  is cached under {@link imageCacheKey}(imagePath, duotone). */
+  duotone?: Duotone | null;
 }
 
 /** Fetch one image's bytes by zip path and decode them to a drawable
@@ -137,14 +149,21 @@ export async function prefetchImages(
   ws: Worksheet,
   imageCache: Map<string, CanvasImageSource | null>,
   fetchImage: ((path: string, mime: string) => Promise<Blob>) | undefined,
+  // Optional offscreen-surface factory for the `<a:duotone>` pixel transform,
+  // injected in environments without a global `OffscreenCanvas` (or by tests).
+  // Defaults to the real `OffscreenCanvas` when the runtime provides one.
+  opts?: { offscreenFactory?: import('@silurus/ooxml-core').OffscreenFactory },
 ): Promise<void> {
   if (!fetchImage) return;
   const fetch = fetchImage;
   const uncached = new Map<string, ImageRef>();
   if (ws.images) {
     for (const img of ws.images) {
-      if (!imageCache.has(img.imagePath)) {
-        uncached.set(img.imagePath, {
+      // Key by (path + duotone colours) so a recoloured picture is cached and
+      // looked up separately from the raw blip (§20.1.8.23).
+      const key = imageCacheKey(img.imagePath, img.duotone);
+      if (!imageCache.has(key)) {
+        uncached.set(key, {
           imagePath: img.imagePath,
           mimeType: img.mimeType,
           svgImagePath: img.svgImagePath,
@@ -154,6 +173,7 @@ export async function prefetchImages(
           // An `<a:srcRect>` crop forces the raster decode (native pixel grid)
           // and, for a metafile, the full-frame raster size.
           srcRect: img.srcRect ?? null,
+          duotone: img.duotone ?? null,
         });
       }
     }
@@ -161,27 +181,31 @@ export async function prefetchImages(
   if (ws.shapeGroups) {
     for (const grp of ws.shapeGroups) {
       for (const shape of grp.shapes) {
-        if (shape.geom.type === 'image' && !imageCache.has(shape.geom.imagePath)) {
-          uncached.set(shape.geom.imagePath, {
-            imagePath: shape.geom.imagePath,
-            mimeType: shape.geom.mimeType,
-            svgImagePath: shape.geom.svgImagePath,
-            // Group's saved EMU extent scaled by the leaf's normalized w/h → pt.
-            widthPt: grp.nativeExtCx > 0 ? (grp.nativeExtCx * shape.w) / EMU_PER_PT : 0,
-            heightPt: grp.nativeExtCy > 0 ? (grp.nativeExtCy * shape.h) / EMU_PER_PT : 0,
-            // A crop forces the raster decode (native pixel grid for the crop)
-            // and, for a metafile, the full-frame raster size.
-            srcRect: shape.geom.srcRect ?? null,
-          });
+        if (shape.geom.type === 'image') {
+          const key = imageCacheKey(shape.geom.imagePath, shape.geom.duotone);
+          if (!imageCache.has(key)) {
+            uncached.set(key, {
+              imagePath: shape.geom.imagePath,
+              mimeType: shape.geom.mimeType,
+              svgImagePath: shape.geom.svgImagePath,
+              // Group's saved EMU extent scaled by the leaf's normalized w/h → pt.
+              widthPt: grp.nativeExtCx > 0 ? (grp.nativeExtCx * shape.w) / EMU_PER_PT : 0,
+              heightPt: grp.nativeExtCy > 0 ? (grp.nativeExtCy * shape.h) / EMU_PER_PT : 0,
+              // A crop forces the raster decode (native pixel grid for the crop)
+              // and, for a metafile, the full-frame raster size.
+              srcRect: shape.geom.srcRect ?? null,
+              duotone: shape.geom.duotone ?? null,
+            });
+          }
         }
       }
     }
   }
   if (uncached.size === 0) return;
   await Promise.all(
-    [...uncached.values()].map(async (ref) => {
+    [...uncached.entries()].map(async ([key, ref]) => {
       try {
-        const src = await decodeImageSource(
+        let src = await decodeImageSource(
           ref.imagePath,
           ref.mimeType,
           ref.svgImagePath,
@@ -190,13 +214,30 @@ export async function prefetchImages(
           ref.heightPt,
           ref.srcRect,
         );
-        // Cache the decode result keyed by path — INCLUDING a null for an
-        // unsupported metafile (true EMF / geometry-less WMF). Storing the null
-        // (matching pptx's getCachedBitmap) makes `imageCache.has(path)` short-
-        // circuit the per-render prefetch, so the blip is sniffed ONCE instead of
-        // re-fetched + re-sniffed every viewport frame. The renderer already
-        // skips a falsy source, so a cached null draws nothing.
-        imageCache.set(ref.imagePath, src);
+        // Apply a `<a:duotone>` recolour (§20.1.8.23) once, at decode time, so the
+        // per-frame draw stays synchronous. The transform returns a NEW
+        // ImageBitmap recoloured along the clr1→clr2 luminance ramp (or the source
+        // unchanged when the pixel pipeline is unavailable). Uses the decoded
+        // bitmap's native pixel size. Only raster/bitmap sources are recoloured —
+        // an SVG element (vector blip) has no readable pixel grid, so it is left
+        // as-is (a duotone on a vector picture is a rare edge case).
+        if (src && ref.duotone) {
+          const { w, h } = imageNaturalSize(src);
+          if (w > 0 && h > 0) {
+            src = await applyDuotone(src, ref.duotone, {
+              width: w,
+              height: h,
+              offscreenFactory: opts?.offscreenFactory,
+            });
+          }
+        }
+        // Cache the decode result keyed by (path + duotone colours) — INCLUDING a
+        // null for an unsupported metafile (true EMF / geometry-less WMF). Storing
+        // the null (matching pptx's getCachedBitmap) makes `imageCache.has(key)`
+        // short-circuit the per-render prefetch, so the blip is sniffed ONCE
+        // instead of re-fetched + re-sniffed every viewport frame. The renderer
+        // already skips a falsy source, so a cached null draws nothing.
+        imageCache.set(key, src);
       } catch {
         /* leave uncached; renderer skips a missing source */
       }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3364,7 +3364,17 @@ function renderImages(
     if (canvasX + imgW < scrollAreaX || canvasX > scrollAreaX + scrollAreaW) continue;
     if (canvasY + imgH < scrollAreaY || canvasY > scrollAreaY + scrollAreaH) continue;
 
-    drawImageCropped(ctx, img, anchor.srcRect, canvasX, canvasY, imgW, imgH);
+    // ECMA-376 §20.1.8.6 `<a:alphaModFix>`: scale the picture's opacity so it
+    // composites over the cells beneath it. Saved/restored so it never leaks
+    // into a later anchor's draw.
+    if (anchor.alpha != null && anchor.alpha < 1) {
+      ctx.save();
+      ctx.globalAlpha = anchor.alpha;
+      drawImageCropped(ctx, img, anchor.srcRect, canvasX, canvasY, imgW, imgH);
+      ctx.restore();
+    } else {
+      drawImageCropped(ctx, img, anchor.srcRect, canvasX, canvasY, imgW, imgH);
+    }
   }
 
   ctx.restore();
@@ -3563,8 +3573,17 @@ function drawShape(
     const img = loadedImages?.get(shape.geom.imagePath);
     if (img) {
       // Honor an `<a:srcRect>` crop on the leaf pic (oneCellAnchor / grpSp leaf),
-      // same as the top-level anchor path (ECMA-376 §20.1.8.55).
-      drawImageCropped(ctx, img, shape.geom.srcRect, 0, 0, sw, sh);
+      // same as the top-level anchor path (ECMA-376 §20.1.8.55). Apply the leaf's
+      // `<a:alphaModFix>` opacity (§20.1.8.6) via globalAlpha, saved/restored.
+      const leafAlpha = shape.geom.alpha;
+      if (leafAlpha != null && leafAlpha < 1) {
+        ctx.save();
+        ctx.globalAlpha = leafAlpha;
+        drawImageCropped(ctx, img, shape.geom.srcRect, 0, 0, sw, sh);
+        ctx.restore();
+      } else {
+        drawImageCropped(ctx, img, shape.geom.srcRect, 0, 0, sw, sh);
+      }
     }
   }
   // Shape text body (ECMA-376 §20.5.2.34 `<xdr:txBody>`). Drawn after

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3,7 +3,7 @@ import type {
   ViewportRange, RenderViewportOptions, XlsxTextRunInfo,
   CfRule, CellRange, CfStop, CfValue, Dxf, Hyperlink, DefinedName,
   Run, GradientFillSpec, ShapeInfo, SlicerItem,
-  PhoneticRun, PhoneticProperties, PhoneticAlignment,
+  PhoneticRun, PhoneticProperties, PhoneticAlignment, Duotone,
 } from './types.js';
 import { placePhoneticRuns } from './phonetic.js';
 import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
@@ -12,6 +12,19 @@ import { formatCellValueWithColor } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
 import { computeLineVisualOrder, cellBaseRtl, resolveCellBidi } from './bidi-line.js';
 import { parseA1 } from './a1.js';
+
+/** Cache key for a decoded image in the shared `loadedImages` map. A plain
+ *  picture is keyed by its zip `imagePath`; a picture carrying a `<a:duotone>`
+ *  effect (ECMA-376 §20.1.8.23) is keyed by the path PLUS both resolved endpoint
+ *  colours, so a recoloured bitmap is cached and looked up separately from the
+ *  raw blip. The render-orchestrator's `prefetchImages` stores each decoded
+ *  source under this exact key, and the renderer computes it per anchor for the
+ *  synchronous lookup. Kept here (not in the orchestrator) so both the
+ *  synchronous renderer and the async orchestrator share one definition without
+ *  a circular import. */
+export function imageCacheKey(imagePath: string, duotone?: Duotone | null): string {
+  return duotone ? `${imagePath}|duo:${duotone.clr1}:${duotone.clr2}` : imagePath;
+}
 
 // Default font stack. Calibri is the workbook default font in Excel; on
 // systems without Office (macOS / Linux) the browser would otherwise fall
@@ -3321,7 +3334,9 @@ function renderImages(
   ctx.clip();
 
   for (const anchor of ws.images) {
-    const img = loadedImages.get(anchor.imagePath);
+    // A `<a:duotone>` picture was recoloured at decode time and cached under a
+    // colour-suffixed key (§20.1.8.23); look it up with the same key.
+    const img = loadedImages.get(imageCacheKey(anchor.imagePath, anchor.duotone));
     if (!img) continue;
 
     // xdr col/row are 0-indexed; our widths map is 1-indexed.
@@ -3570,7 +3585,7 @@ function drawShape(
     // so we should normally have it in `loadedImages` (keyed by imagePath).
     // If not, fall back to a silent skip — drawing an empty rect would look
     // worse.
-    const img = loadedImages?.get(shape.geom.imagePath);
+    const img = loadedImages?.get(imageCacheKey(shape.geom.imagePath, shape.geom.duotone));
     if (img) {
       // Honor an `<a:srcRect>` crop on the leaf pic (oneCellAnchor / grpSp leaf),
       // same as the top-level anchor path (ECMA-376 §20.1.8.55). Apply the leaf's

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -514,6 +514,9 @@ export type ShapeGeom =
        *  1-b]`). Absent ⇒ the whole blip fills the leaf rect. Honored identically
        *  to the top-level {@link ImageAnchor.srcRect} (raster only). */
       srcRect?: { l: number; t: number; r: number; b: number };
+      /** ECMA-376 §20.1.8.6 `<a:alphaModFix@amt>` opacity fraction (0..1) on the
+       *  leaf pic. Absent ⇒ opaque. Applied via `globalAlpha`. */
+      alpha?: number;
     };
 
 export interface PathInfo {
@@ -575,6 +578,11 @@ export interface ImageAnchor {
    *  cropped sub-rectangle (raster only — a metafile is rasterized to the
    *  display box, so its crop can't be honored faithfully and is skipped). */
   srcRect?: { l: number; t: number; r: number; b: number };
+  /** ECMA-376 §20.1.8.6 `<a:alphaModFix@amt>` — the blip's overall opacity as a
+   *  fraction (0..1). Absent ⇒ opaque. The renderer sets `ctx.globalAlpha` so the
+   *  picture composites over the cells beneath it (e.g. a pink translucent photo
+   *  over a matching cell fill). */
+  alpha?: number;
 }
 
 export interface CellRange {

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -517,7 +517,20 @@ export type ShapeGeom =
       /** ECMA-376 §20.1.8.6 `<a:alphaModFix@amt>` opacity fraction (0..1) on the
        *  leaf pic. Absent ⇒ opaque. Applied via `globalAlpha`. */
       alpha?: number;
+      /** ECMA-376 §20.1.8.23 `<a:duotone>` recolour on the leaf pic. Absent ⇒
+       *  no effect. */
+      duotone?: Duotone;
     };
+
+/** ECMA-376 §20.1.8.23 `<a:duotone>` image effect, resolved to its two endpoint
+ *  colours (mirrors the shared Rust `ooxml_common::blip::Duotone`). `clr1` is the
+ *  dark endpoint (luminance 0), `clr2` the light endpoint (luminance 1); both are
+ *  6-char uppercase hex WITHOUT a leading `#`, with per-colour transforms already
+ *  applied by the parser. */
+export interface Duotone {
+  clr1: string;
+  clr2: string;
+}
 
 export interface PathInfo {
   w: number;
@@ -583,6 +596,10 @@ export interface ImageAnchor {
    *  picture composites over the cells beneath it (e.g. a pink translucent photo
    *  over a matching cell fill). */
   alpha?: number;
+  /** ECMA-376 §20.1.8.23 `<a:duotone>` recolour effect. Absent (the common case)
+   *  ⇒ no effect. When present, the renderer remaps the image along the
+   *  `clr1`→`clr2` luminance ramp before drawing. */
+  duotone?: Duotone;
 }
 
 export interface CellRange {


### PR DESCRIPTION
## Summary

Implements the two DrawingML blip effects that make the bottom-left picture in **sample-9.xlsx** ("Gift budget and tracker") render as **pink and semi-transparent** in Excel, where we previously drew the raw opaque white PNG (issue #880). Two concern-separated commits:

1. **alphaModFix (§20.1.8.6)** — the blip's overall opacity (`amt="70000"` → 0.70), applied via `ctx.globalAlpha`.
2. **duotone (§20.1.8.23)** — recolour along a two-colour luminance ramp; `black` ↔ `srgbClr DAB6BA` (+ lumMod20%/lumOff80%/tint45%/satMod400%) → resolved **clr1=`000000`, clr2=`FFF3F4`**, so the near-white photo becomes light pink.

## Spec basis

- **§20.1.8.6** CT_AlphaModulateFixedEffect: "Effect alpha (opacity) values are multiplied by a fixed percentage." (`amt` is ST_PositivePercentage / 100000.)
- **§20.1.8.23** CT_DuotoneEffect: "For each pixel, combines clr1 and clr2 through a linear interpolation." clr1 = dark endpoint (luminance 0), clr2 = light endpoint (luminance 1); pixel Rec. 601 luminance is the interpolation factor.

## Cross-package (shared-layer) design

- **ooxml-common** `blip.rs`: `parse_blip_alpha` (moved from a pptx-local copy → shared) + new `Duotone` / `parse_blip_duotone`. Colour resolution reuses the shared DrawingML grammar; `color.rs` was refactored to expose `color_source_from_element` + `resolve_color_source` (duotone's children are bare colour elements, not containers) — no duplicated transform logic.
- **core** `image/duotone.ts`: pure `duotoneImageData` (table-tested) + `applyDuotone` (offscreen round-trip → new `ImageBitmap`), with an injectable `OffscreenFactory` so it runs on browser/worker OffscreenCanvas and node/skia alike.
- **xlsx**: parses both effects onto `ImageAnchor` and the `<xdr:grpSp>` leaf `ShapeGeom::Image`; recolour is applied once at decode time and cached under an `imageCacheKey` suffixed with both colours (scroll/re-render reuse, no double-transform). Worker path shares the renderer code.

## Verification

- **sample-9 device pixels (skia):** picture region goes from neutral grey `(250,250,250)` (R−G=0) → pink `(250,238,239)` (R−G≈12), and with alphaModFix composites over the pink cells (a dark band is +13 lighter at α=0.7 vs the opaque control — the alpha blend is active).
- **Tests:** core pixel-transform table tests; ooxml-common parser unit tests (alpha + duotone colour resolution); a fixture-free node skia probe guarding the end-to-end recolour + alpha composite. Full suites green (cargo 216/156/149; xlsx 505; node 64; core image 146), typecheck clean, clippy `-D warnings` clean, ast-grep clean.
- **VRT:** demo references unchanged (only sample-9 among available xlsx samples carries blip effects; all other pictures set neither field). sample-9 has no committed reference (private/gitignored), so no diff to report.

## Follow-up

`Duotone` + `parse_blip_duotone` are shared and ready for pptx/docx pictures, but wiring the recolour into their picture-decode + path-keyed bitmap cache is a separate second integration (out of scope here). Their **alphaModFix rendering is already complete** (pptx applies `el.alpha`/`fill.alpha` via globalAlpha; verified).

Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)