### PR TITLE
feat: wire the blip duotone effect into pptx & docx pictures (§20.1.8.23)

### DIFF
--- a/packages/core/src/image/duotone-bitmap-by-path.test.ts
+++ b/packages/core/src/image/duotone-bitmap-by-path.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  getCachedDuotoneBitmapByPath,
+  duotoneCacheKey,
+  dropDuotoneBitmapCache,
+} from './duotone-bitmap-by-path';
+import { dropBitmapCacheByPath } from './bitmap-image-by-path';
+import type { OffscreenFactory } from './duotone';
+
+/**
+ * The core second-layer duotone cache: decode the base blip once (shared
+ * path-keyed cache), then run the `<a:duotone>` recolour once per (path +
+ * colours). Shared by the docx and pptx renderers. The recolour reads the base
+ * bitmap's pixels via getImageData → transform → putImageData → a NEW bitmap, so
+ * we inject an offscreen factory + stub createImageBitmap to exercise the path
+ * without a real canvas.
+ */
+describe('getCachedDuotoneBitmapByPath', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** An offscreen surface whose getImageData returns a near-white pixel buffer;
+   *  putImageData records the recoloured bytes so a test can confirm the ramp ran. */
+  function recordingFactory(record: { out?: Uint8ClampedArray }): OffscreenFactory {
+    return ((w: number, h: number) => ({
+      width: w,
+      height: h,
+      getContext() {
+        return {
+          drawImage() {},
+          getImageData(_sx: number, _sy: number, sw: number, sh: number) {
+            // One near-white opaque pixel (luminance ≈ 1 → maps to clr2).
+            const data = new Uint8ClampedArray(sw * sh * 4).fill(255);
+            return { data, width: sw, height: sh } as unknown as ImageData;
+          },
+          putImageData(img: ImageData) {
+            record.out = img.data;
+          },
+        };
+      },
+    })) as unknown as OffscreenFactory;
+  }
+
+  it('decodes the base once and recolours once per colour pair, caching both', async () => {
+    const path = 'ppt/media/duo-cachehit-a.png';
+    const baseBitmap = { width: 4, height: 4, close() {} } as unknown as ImageBitmap;
+    const recoloured = { width: 4, height: 4, tag: 'duo', close() {} } as unknown as ImageBitmap;
+    const cib = vi.fn(async (src: unknown) => {
+      // The base decode passes a Blob; applyDuotone passes the offscreen surface.
+      return src instanceof Blob ? baseBitmap : recoloured;
+    });
+    vi.stubGlobal('createImageBitmap', cib);
+
+    const fetchImage = vi.fn(
+      async (_p: string, mime: string) => new Blob([new Uint8Array([1, 2, 3])], { type: mime }),
+    );
+    const duotone = { clr1: '000000', clr2: 'DAB6BA' };
+    const record: { out?: Uint8ClampedArray } = {};
+    const opts = { offscreenFactory: recordingFactory(record) };
+
+    const first = await getCachedDuotoneBitmapByPath(path, 'image/png', duotone, fetchImage, opts);
+    const second = await getCachedDuotoneBitmapByPath(path, 'image/png', duotone, fetchImage, opts);
+
+    // Both calls return the SAME recoloured bitmap (memoized), the base blip was
+    // fetched + decoded once, and the recolour ran once.
+    expect(first).toBe(recoloured);
+    expect(second).toBe(recoloured);
+    expect(fetchImage).toHaveBeenCalledTimes(1);
+    // createImageBitmap: once for the base decode + once for the recolour = 2.
+    expect(cib).toHaveBeenCalledTimes(2);
+    // The recolour mapped a near-white pixel toward clr2 (DAB6BA): R≈0xDA, not 0.
+    expect(record.out?.[0]).toBeGreaterThan(200);
+
+    dropDuotoneBitmapCache(fetchImage);
+    dropBitmapCacheByPath(fetchImage);
+  });
+
+  it('passes through to the base cache (no recolour) when duotone is null', async () => {
+    const path = 'ppt/media/duo-passthrough-b.png';
+    const baseBitmap = { width: 2, height: 2, close() {} } as unknown as ImageBitmap;
+    const cib = vi.fn(async () => baseBitmap);
+    vi.stubGlobal('createImageBitmap', cib);
+    const fetchImage = vi.fn(
+      async (_p: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }),
+    );
+
+    const out = await getCachedDuotoneBitmapByPath(path, 'image/png', null, fetchImage, {});
+
+    // Returns the base bitmap directly; no second recolour decode.
+    expect(out).toBe(baseBitmap);
+    expect(cib).toHaveBeenCalledTimes(1);
+
+    dropBitmapCacheByPath(fetchImage);
+  });
+
+  it('keys separate colour pairs independently (same path, two duotones)', async () => {
+    const path = 'ppt/media/duo-two-c.png';
+    const baseBitmap = { width: 2, height: 2, close() {} } as unknown as ImageBitmap;
+    let n = 0;
+    const cib = vi.fn(async (src: unknown) =>
+      src instanceof Blob
+        ? baseBitmap
+        : ({ width: 2, height: 2, tag: `duo${n++}`, close() {} } as unknown as ImageBitmap),
+    );
+    vi.stubGlobal('createImageBitmap', cib);
+    const fetchImage = vi.fn(
+      async (_p: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }),
+    );
+    const record: { out?: Uint8ClampedArray } = {};
+    const opts = { offscreenFactory: recordingFactory(record) };
+
+    const a = await getCachedDuotoneBitmapByPath(path, 'image/png', { clr1: '000000', clr2: 'FF0000' }, fetchImage, opts);
+    const b = await getCachedDuotoneBitmapByPath(path, 'image/png', { clr1: '000000', clr2: '00FF00' }, fetchImage, opts);
+
+    // Two distinct recolour results, but the base was decoded only once.
+    expect(a).not.toBe(b);
+    expect(fetchImage).toHaveBeenCalledTimes(1);
+
+    dropDuotoneBitmapCache(fetchImage);
+    dropBitmapCacheByPath(fetchImage);
+  });
+
+  it('duotoneCacheKey suffixes the path with both colours only when a duotone is set', () => {
+    expect(duotoneCacheKey('word/media/image1.png')).toBe('word/media/image1.png');
+    expect(duotoneCacheKey('word/media/image1.png', null)).toBe('word/media/image1.png');
+    expect(duotoneCacheKey('word/media/image1.png', { clr1: '000000', clr2: 'DAB6BA' })).toBe(
+      'word/media/image1.png|duo:000000:DAB6BA',
+    );
+  });
+});

--- a/packages/core/src/image/duotone-bitmap-by-path.ts
+++ b/packages/core/src/image/duotone-bitmap-by-path.ts
@@ -1,0 +1,124 @@
+// Second-layer cache for the DrawingML `<a:duotone>` recolour (ECMA-376
+// §20.1.8.23) of a raster/metafile blip, shared by the docx and pptx renderers
+// (xlsx keeps its own worksheet-scoped `loadedImages` map with the same keying).
+//
+// The base, colour-FREE bitmap comes from the path-keyed
+// `getCachedBitmapByPath` — shared across every reference to a path and
+// reclaimed with the document. The duotone pixel pass (getImageData →
+// luminance remap → putImageData → ImageBitmap, expensive) then runs ONCE per
+// (imagePath, clr1, clr2) triple and its ImageBitmap is memoized here, so
+// revisiting a page/slide re-runs NEITHER the decode NOR the recolour. This is
+// the exact two-layer shape docx already used for its `a:clrChange`
+// (colorReplaced) cache, lifted to core so pptx reuses it verbatim.
+//
+// Keyed FIRST by the document's `fetchImage` closure (one stable identity per
+// document/deck), then by `duotoneCacheKey(imagePath, duotone)` — mirroring the
+// core base cache's per-document namespacing so two documents sharing a zip path
+// + duotone don't cross-contaminate, and the whole map is reclaimed with the
+// document. The stored value is an ImageBitmap (a fresh OffscreenCanvas raster),
+// so on destroy it must be closed (see `dropDuotoneBitmapCache`), the same
+// GPU-lifecycle discipline the base cache follows through its promise.
+
+import { getCachedBitmapByPath, type CachedBitmapOptions } from './bitmap-image-by-path';
+import { applyDuotone, type Duotone, type OffscreenFactory } from './duotone';
+import { imageNaturalSize } from './crop';
+
+type FetchImage = (path: string, mime: string) => Promise<Blob>;
+
+/** Cache key for a decoded bitmap that may carry a `<a:duotone>` recolour. A
+ *  plain picture is keyed by its zip `imagePath`; a duotone picture is keyed by
+ *  the path PLUS both resolved endpoint colours, so the recoloured bitmap is
+ *  cached and looked up separately from the raw blip. Callers compute this both
+ *  when warming the cache and when drawing, so the two agree without sharing a
+ *  cache reference. Mirrors xlsx's `imageCacheKey` and docx's former
+ *  `imageKey(path, colorReplaceFrom)`. */
+export function duotoneCacheKey(imagePath: string, duotone?: Duotone | null): string {
+  return duotone ? `${imagePath}|duo:${duotone.clr1}:${duotone.clr2}` : imagePath;
+}
+
+const duotoneByFetch = new WeakMap<FetchImage, Map<string, Promise<ImageBitmap | null>>>();
+
+function duotoneCacheFor(fetchImage: FetchImage): Map<string, Promise<ImageBitmap | null>> {
+  let cache = duotoneByFetch.get(fetchImage);
+  if (!cache) {
+    cache = new Map();
+    duotoneByFetch.set(fetchImage, cache);
+  }
+  return cache;
+}
+
+/**
+ * Decode a raster/metafile blip at `imagePath` and, when `duotone` is set,
+ * recolour it along the `clr1`→`clr2` luminance ramp (§20.1.8.23), returning a
+ * drawable source cached per document then by `duotoneCacheKey`.
+ *
+ * With NO duotone this is a thin pass-through to {@link getCachedBitmapByPath}
+ * (the shared base cache) — no second-layer entry is created, so a non-duotone
+ * picture behaves byte-for-byte as before. With a duotone the base bitmap is
+ * decoded (and cached) once, then the recolour runs once per colour pair and is
+ * memoized here.
+ *
+ * The recolour needs a readable pixel grid, so it only applies to a decoded
+ * raster/metafile bitmap; a `null` base (an unsupported metafile — true EMF /
+ * geometry-less WMF) propagates as `null` and the draw site skips it. When the
+ * offscreen pixel pipeline is unavailable, {@link applyDuotone} returns the base
+ * unchanged, so the picture still draws (just without the recolour).
+ *
+ * @param opts.offscreenFactory optional surface factory for environments without
+ *   a global `OffscreenCanvas` (node); forwarded to {@link applyDuotone}.
+ */
+export async function getCachedDuotoneBitmapByPath(
+  imagePath: string,
+  mimeType: string,
+  duotone: Duotone | null | undefined,
+  fetchImage: FetchImage,
+  opts: CachedBitmapOptions & { offscreenFactory?: OffscreenFactory } = {},
+): Promise<ImageBitmap | null> {
+  const { offscreenFactory, ...bitmapOpts } = opts;
+  // Base, colour-free bitmap from the shared path-keyed cache.
+  const base = await getCachedBitmapByPath(imagePath, mimeType, fetchImage, bitmapOpts);
+  // No duotone → return the base directly (no second-layer entry). A `null`
+  // (unsupported metafile) propagates unchanged.
+  if (!duotone || !base) return base;
+  const cache = duotoneCacheFor(fetchImage);
+  const key = duotoneCacheKey(imagePath, duotone);
+  let hit = cache.get(key);
+  if (!hit) {
+    // The recolour reads the SHARED base bitmap and produces a fresh independent
+    // raster, so the base is never mutated and stays reusable for other draws.
+    hit = (async () => {
+      const { w, h } = imageNaturalSize(base);
+      if (w <= 0 || h <= 0) return base;
+      const recoloured = await applyDuotone(base, duotone, { width: w, height: h, offscreenFactory });
+      // `applyDuotone` returns a CanvasImageSource; when the pixel pipeline ran
+      // it is a fresh ImageBitmap, otherwise it is the (unchanged) base bitmap.
+      return recoloured as ImageBitmap;
+    })();
+    // Don't poison the cache if the recolour pass rejects; let the next call retry.
+    hit.catch(() => cache.delete(key));
+    cache.set(key, hit);
+  }
+  return hit;
+}
+
+/**
+ * Close every duotone-recoloured ImageBitmap for one document's `fetchImage` and
+ * forget the document. Call from the owning viewer's `destroy()` alongside
+ * `dropBitmapCacheByPath` (base bitmaps) so both caches release their GPU
+ * backing promptly. A no-op when the document decoded no duotone picture.
+ *
+ * Almost every stored value is a fresh recolour raster owned ONLY by this cache,
+ * so it must be closed here. The rare exception is a pass-through (the pixel
+ * pipeline was unavailable, so `applyDuotone` returned the unchanged base
+ * bitmap): that bitmap is also owned by the base cache and closed by
+ * `dropBitmapCacheByPath`, but `ImageBitmap.close()` is idempotent, so closing
+ * it a second time here is harmless. Closing through the promise (never a raw
+ * reference) means a still-in-flight recolour is closed only once it resolves.
+ */
+export function dropDuotoneBitmapCache(fetchImage: FetchImage): void {
+  const cache = duotoneByFetch.get(fetchImage);
+  if (!cache) return;
+  for (const p of cache.values()) p.then((b) => b?.close()).catch(() => {});
+  cache.clear();
+  duotoneByFetch.delete(fetchImage);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -181,6 +181,15 @@ export {
   type OffscreenFactory,
   type OffscreenSurface,
 } from './image/duotone';
+// Second-layer path-keyed cache that decodes a blip (shared base cache) then
+// applies its `<a:duotone>` recolour once per (path + colours). Shared by the
+// docx and pptx renderers so a duotone picture decodes + recolours once and is
+// reused across page/slide revisits. xlsx keeps its own worksheet-scoped map.
+export {
+  getCachedDuotoneBitmapByPath,
+  duotoneCacheKey,
+  dropDuotoneBitmapCache,
+} from './image/duotone-bitmap-by-path';
 // Shared vector-vs-raster blip gate: prefer the Microsoft asvg:svgBlip vector
 // original except when an <a:srcRect> crop is present (then the raster's native
 // pixel grid is required for the fractional crop math). Used by all three

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1,4 +1,6 @@
-use ooxml_common::blip::{blip_embed_rid, mime_from_ext, parse_src_rect, svg_blip_rid};
+use ooxml_common::blip::{
+    blip_embed_rid, mime_from_ext, parse_blip_duotone, parse_src_rect, svg_blip_rid, Duotone,
+};
 use ooxml_common::depth::{parse_guarded, DepthGuard};
 use ooxml_common::ns::{attr_ns, is_w_ns, math, relationships, wordprocessingml};
 use ooxml_common::zip::read_zip_string;
@@ -3551,6 +3553,9 @@ struct InlineBlip {
     svg_image_path: Option<String>,
     /// ECMA-376 §20.1.8.55 `<a:srcRect>` crop (fractions 0..1), or `None`.
     src_rect: Option<SrcRect>,
+    /// ECMA-376 §20.1.8.23 `<a:duotone>` recolour resolved through the theme,
+    /// or `None`.
+    duotone: Option<Duotone>,
     width_pt: f64,
     height_pt: f64,
 }
@@ -3574,11 +3579,15 @@ struct InlineBlip {
 fn resolve_inline_blip(
     node: roxmltree::Node,
     media_map: &HashMap<String, String>,
+    theme: &ThemeColors,
 ) -> Option<InlineBlip> {
     let blip = node.descendants().find(|n| n.tag_name().name() == "blip")?;
     let (image_path, mime_type, svg_image_path) = resolve_blip_urls(blip, media_map)?;
-    // The shared parser takes the `<*:blipFill>` (the blip's parent).
-    let src_rect = blip.parent().and_then(parse_src_rect);
+    // The shared parsers take the `<*:blipFill>` (the blip's parent).
+    let blip_fill = blip.parent();
+    let src_rect = blip_fill.and_then(parse_src_rect);
+    // §20.1.8.23 duotone recolour, resolved through the document theme.
+    let duotone = blip_fill.and_then(|bf| parse_blip_duotone_docx(bf, theme));
     let extent = node
         .descendants()
         .find(|n| n.tag_name().name() == "extent")?;
@@ -3589,6 +3598,7 @@ fn resolve_inline_blip(
         mime_type,
         svg_image_path,
         src_rect,
+        duotone,
         width_pt: cx / 12700.0,
         height_pt: cy / 12700.0,
     })
@@ -3808,9 +3818,10 @@ fn parse_inline_drawing(
             mime_type,
             svg_image_path,
             src_rect,
+            duotone,
             width_pt,
             height_pt,
-        } = match resolve_inline_blip(container, media_map) {
+        } = match resolve_inline_blip(container, media_map, theme) {
             Some(b) => b,
             None => return vec![],
         };
@@ -3827,6 +3838,7 @@ fn parse_inline_drawing(
             anchor_x_from_margin: false,
             anchor_y_from_para: false,
             color_replace_from: None,
+            duotone,
             wrap_mode: None,
             dist_top: 0.0,
             dist_bottom: 0.0,
@@ -3962,6 +3974,7 @@ fn parse_inline_drawing(
         for img in parse_wgp_images(
             wgp,
             media_map,
+            theme,
             pos_x,
             x_from_margin,
             pos_y,
@@ -4024,9 +4037,10 @@ fn parse_inline_drawing(
         mime_type,
         svg_image_path,
         src_rect,
+        duotone,
         width_pt,
         height_pt,
-    } = match resolve_inline_blip(container, media_map) {
+    } = match resolve_inline_blip(container, media_map, theme) {
         Some(b) => b,
         None => return vec![],
     };
@@ -4043,6 +4057,7 @@ fn parse_inline_drawing(
         anchor_x_from_margin: x_from_margin,
         anchor_y_from_para: y_from_para,
         color_replace_from: None,
+        duotone,
         wrap_mode: anchor_meta.wrap_mode.clone(),
         dist_top: anchor_meta.dist_top,
         dist_bottom: anchor_meta.dist_bottom,
@@ -4302,9 +4317,11 @@ fn parse_anchor_size_rel(
 
 /// Expand a wp:wgp group into individual ImageRun entries.
 /// Each pic child gets page-relative coordinates: group anchor origin + child offset within group.
+#[allow(clippy::too_many_arguments)]
 fn parse_wgp_images(
     wgp: roxmltree::Node,
     media_map: &HashMap<String, String>,
+    theme: &ThemeColors,
     anchor_pos_x: f64,
     x_from_margin: bool,
     anchor_pos_y: f64,
@@ -4328,6 +4345,7 @@ fn parse_wgp_images(
         wgp,
         base,
         media_map,
+        theme,
         anchor_pos_x,
         x_from_margin,
         anchor_pos_y,
@@ -4348,6 +4366,7 @@ fn walk_group_images(
     group: roxmltree::Node,
     xform: GroupTransform,
     media_map: &HashMap<String, String>,
+    theme: &ThemeColors,
     anchor_pos_x: f64,
     x_from_margin: bool,
     anchor_pos_y: f64,
@@ -4366,6 +4385,7 @@ fn walk_group_images(
                     child,
                     xform,
                     media_map,
+                    theme,
                     anchor_pos_x,
                     x_from_margin,
                     anchor_pos_y,
@@ -4384,6 +4404,7 @@ fn walk_group_images(
                     child,
                     child_xform,
                     media_map,
+                    theme,
                     anchor_pos_x,
                     x_from_margin,
                     anchor_pos_y,
@@ -4408,6 +4429,7 @@ fn parse_group_pic(
     pic: roxmltree::Node,
     xform: GroupTransform,
     media_map: &HashMap<String, String>,
+    theme: &ThemeColors,
     anchor_pos_x: f64,
     x_from_margin: bool,
     anchor_pos_y: f64,
@@ -4448,8 +4470,12 @@ fn parse_group_pic(
     let (image_path, mime_type, svg_image_path) = resolve_blip_urls(blip, media_map)?;
     // ECMA-376 §20.1.8.55 — source-rectangle crop (sibling of <a:blip> under
     // <pic:blipFill>), shared with the inline/anchor paths.
-    // The shared parser takes the `<*:blipFill>` (the blip's parent).
+    // The shared parsers take the `<*:blipFill>` (the blip's parent).
     let src_rect = blip.parent().and_then(parse_src_rect);
+    // §20.1.8.23 duotone recolour, resolved through the document theme.
+    let duotone = blip
+        .parent()
+        .and_then(|bf| parse_blip_duotone_docx(bf, theme));
 
     // Parse a:clrChange if present — used to make a specific color transparent.
     // clrFrom specifies the source color; clrTo with alpha=0 means replace with transparent.
@@ -4475,6 +4501,7 @@ fn parse_group_pic(
         anchor_x_from_margin: x_from_margin,
         anchor_y_from_para: y_from_para,
         color_replace_from,
+        duotone,
         wrap_mode: anchor_meta.wrap_mode.clone(),
         dist_top: anchor_meta.dist_top,
         dist_bottom: anchor_meta.dist_bottom,
@@ -5182,7 +5209,7 @@ fn extract_simple_paragraph_text(
     // parseable extent are present, which simply leaves this an image-less
     // paragraph (the drop-if-no-text-and-no-image check below still applies).
     let (image_path, mime_type, svg_image_path, image_width_pt, image_height_pt) =
-        match resolve_inline_blip(p, media_map) {
+        match resolve_inline_blip(p, media_map, theme) {
             Some(b) => (
                 Some(b.image_path),
                 Some(b.mime_type),
@@ -5711,6 +5738,7 @@ fn parse_vml_pict_image(
         anchor_x_from_margin: false,
         anchor_y_from_para: false,
         color_replace_from: None,
+        duotone: None,
         wrap_mode: None,
         dist_top: 0.0,
         dist_bottom: 0.0,
@@ -5797,6 +5825,7 @@ fn parse_object_ole_image(
         anchor_x_from_margin: false,
         anchor_y_from_para: false,
         color_replace_from: None,
+        duotone: None,
         wrap_mode: None,
         dist_top: 0.0,
         dist_bottom: 0.0,
@@ -6111,6 +6140,20 @@ fn resolve_color_element_with_phclr(
     ooxml_common::color::parse_color_node(
         container,
         &DocxSchemeResolver { theme, ph_clr },
+        ooxml_common::color::TintMode::WordLiteral,
+    )
+}
+
+/// Parse a `<*:blipFill>`'s ECMA-376 §20.1.8.23 `<a:duotone>` effect, resolving
+/// its two `EG_ColorChoice` endpoints through the shared parser with Word's
+/// theme-slot lookup ([`DocxSchemeResolver`], no phClr substitution) and Word's
+/// literal tint — the SAME colour grammar every other docx path uses. `None`
+/// when there is no duotone (the common case). Shared across the inline/anchor
+/// and group picture paths.
+fn parse_blip_duotone_docx(blip_fill: roxmltree::Node, theme: &ThemeColors) -> Option<Duotone> {
+    parse_blip_duotone(
+        blip_fill,
+        &DocxSchemeResolver { theme, ph_clr: "" },
         ooxml_common::color::TintMode::WordLiteral,
     )
 }
@@ -8192,6 +8235,7 @@ mod tests {
             anchor_x_from_margin: false,
             anchor_y_from_para: false,
             color_replace_from: None,
+            duotone: None,
             wrap_mode: None,
             dist_top: 0.0,
             dist_bottom: 0.0,
@@ -8289,9 +8333,11 @@ mod wgp_image_tests {
         let mut media = HashMap::new();
         media.insert("rId1".to_string(), "word/media/image1.png".to_string());
         let meta = AnchorMeta::default();
+        let theme = ThemeColors::default();
         let imgs = parse_wgp_images(
             doc.root_element(),
             &media,
+            &theme,
             0.0,   // anchor_pos_x
             false, // x_from_margin
             0.0,   // anchor_pos_y
@@ -10340,6 +10386,7 @@ mod svg_blip_tests {
             anchor_x_from_margin: false,
             anchor_y_from_para: false,
             color_replace_from: None,
+            duotone: None,
             wrap_mode: None,
             dist_top: 0.0,
             dist_bottom: 0.0,
@@ -10680,6 +10727,66 @@ mod svg_blip_tests {
                 img.src_rect
             );
         }
+    }
+
+    /// ECMA-376 §20.1.8.23 — an inline picture whose `<a:blip>` carries a
+    /// `<a:duotone>` (a CT_Blip effect child, per the XSD sequence) populates
+    /// `ImageRun.duotone` with the two resolved endpoints. `clr1` is the dark
+    /// endpoint, `clr2` the light endpoint; both resolve through the shared
+    /// DrawingML colour grammar (here plain srgbClr, so no theme is needed).
+    #[test]
+    fn inline_drawing_duotone_populates_endpoints() {
+        let body = r#"<w:p><w:r><w:drawing>
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <wp:extent cx="304800" cy="304800"/>
+    <a:graphic><a:graphicData>
+      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:blipFill>
+          <a:blip r:embed="rIdPng">
+            <a:duotone>
+              <a:prstClr val="black"/>
+              <a:srgbClr val="DAB6BA"/>
+            </a:duotone>
+          </a:blip>
+          <a:stretch><a:fillRect/></a:stretch>
+        </pic:blipFill>
+      </pic:pic>
+    </a:graphicData></a:graphic>
+  </wp:inline>
+</w:drawing></w:r></w:p>"#;
+        let data = build_docx_with_media(body);
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
+        let img = only_image(&doc);
+        let duo = img
+            .duotone
+            .as_ref()
+            .expect("a <a:duotone> must populate the duotone field");
+        assert_eq!(duo.clr1, "000000", "clr1 = black prstClr (dark endpoint)");
+        assert_eq!(duo.clr2, "DAB6BA", "clr2 = srgbClr (light endpoint)");
+    }
+
+    /// A picture without a `<a:duotone>` leaves `duotone` None — guards the new
+    /// branch from firing spuriously, so non-duotone pictures stay unchanged.
+    #[test]
+    fn inline_drawing_no_duotone_is_none() {
+        let body = r#"<w:p><w:r><w:drawing>
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <wp:extent cx="304800" cy="304800"/>
+    <a:graphic><a:graphicData>
+      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:blipFill><a:blip r:embed="rIdPng"/><a:stretch/></pic:blipFill>
+      </pic:pic>
+    </a:graphicData></a:graphic>
+  </wp:inline>
+</w:drawing></w:r></w:p>"#;
+        let data = build_docx_with_media(body);
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
+        let img = only_image(&doc);
+        assert!(img.duotone.is_none(), "duotone must be None when absent");
     }
 
     /// Regression for the `PathCmd::ArcTo` serde naming bug (mirrors pptx #489).

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1,5 +1,6 @@
 use ooxml_common::blip::{
-    blip_embed_rid, mime_from_ext, parse_blip_duotone, parse_src_rect, svg_blip_rid, Duotone,
+    blip_embed_rid, mime_from_ext, parse_blip_alpha, parse_blip_duotone, parse_src_rect,
+    svg_blip_rid, Duotone,
 };
 use ooxml_common::depth::{parse_guarded, DepthGuard};
 use ooxml_common::ns::{attr_ns, is_w_ns, math, relationships, wordprocessingml};
@@ -3556,6 +3557,9 @@ struct InlineBlip {
     /// ECMA-376 §20.1.8.23 `<a:duotone>` recolour resolved through the theme,
     /// or `None`.
     duotone: Option<Duotone>,
+    /// ECMA-376 §20.1.8.6 `<a:alphaModFix@amt>` opacity fraction (0.0–1.0), or
+    /// `None` when opaque.
+    alpha: Option<f64>,
     width_pt: f64,
     height_pt: f64,
 }
@@ -3588,6 +3592,8 @@ fn resolve_inline_blip(
     let src_rect = blip_fill.and_then(parse_src_rect);
     // §20.1.8.23 duotone recolour, resolved through the document theme.
     let duotone = blip_fill.and_then(|bf| parse_blip_duotone_docx(bf, theme));
+    // §20.1.8.6 alphaModFix opacity (fraction, or None when opaque).
+    let alpha = blip_fill.and_then(parse_blip_alpha);
     let extent = node
         .descendants()
         .find(|n| n.tag_name().name() == "extent")?;
@@ -3599,6 +3605,7 @@ fn resolve_inline_blip(
         svg_image_path,
         src_rect,
         duotone,
+        alpha,
         width_pt: cx / 12700.0,
         height_pt: cy / 12700.0,
     })
@@ -3819,6 +3826,7 @@ fn parse_inline_drawing(
             svg_image_path,
             src_rect,
             duotone,
+            alpha,
             width_pt,
             height_pt,
         } = match resolve_inline_blip(container, media_map, theme) {
@@ -3839,6 +3847,7 @@ fn parse_inline_drawing(
             anchor_y_from_para: false,
             color_replace_from: None,
             duotone,
+            alpha,
             wrap_mode: None,
             dist_top: 0.0,
             dist_bottom: 0.0,
@@ -4038,6 +4047,7 @@ fn parse_inline_drawing(
         svg_image_path,
         src_rect,
         duotone,
+        alpha,
         width_pt,
         height_pt,
     } = match resolve_inline_blip(container, media_map, theme) {
@@ -4058,6 +4068,7 @@ fn parse_inline_drawing(
         anchor_y_from_para: y_from_para,
         color_replace_from: None,
         duotone,
+        alpha,
         wrap_mode: anchor_meta.wrap_mode.clone(),
         dist_top: anchor_meta.dist_top,
         dist_bottom: anchor_meta.dist_bottom,
@@ -4476,6 +4487,8 @@ fn parse_group_pic(
     let duotone = blip
         .parent()
         .and_then(|bf| parse_blip_duotone_docx(bf, theme));
+    // §20.1.8.6 alphaModFix opacity (fraction, or None when opaque).
+    let alpha = blip.parent().and_then(parse_blip_alpha);
 
     // Parse a:clrChange if present — used to make a specific color transparent.
     // clrFrom specifies the source color; clrTo with alpha=0 means replace with transparent.
@@ -4502,6 +4515,7 @@ fn parse_group_pic(
         anchor_y_from_para: y_from_para,
         color_replace_from,
         duotone,
+        alpha,
         wrap_mode: anchor_meta.wrap_mode.clone(),
         dist_top: anchor_meta.dist_top,
         dist_bottom: anchor_meta.dist_bottom,
@@ -5739,6 +5753,7 @@ fn parse_vml_pict_image(
         anchor_y_from_para: false,
         color_replace_from: None,
         duotone: None,
+        alpha: None,
         wrap_mode: None,
         dist_top: 0.0,
         dist_bottom: 0.0,
@@ -5826,6 +5841,7 @@ fn parse_object_ole_image(
         anchor_y_from_para: false,
         color_replace_from: None,
         duotone: None,
+        alpha: None,
         wrap_mode: None,
         dist_top: 0.0,
         dist_bottom: 0.0,
@@ -8236,6 +8252,7 @@ mod tests {
             anchor_y_from_para: false,
             color_replace_from: None,
             duotone: None,
+            alpha: None,
             wrap_mode: None,
             dist_top: 0.0,
             dist_bottom: 0.0,
@@ -10387,6 +10404,7 @@ mod svg_blip_tests {
             anchor_y_from_para: false,
             color_replace_from: None,
             duotone: None,
+            alpha: None,
             wrap_mode: None,
             dist_top: 0.0,
             dist_bottom: 0.0,
@@ -10787,6 +10805,64 @@ mod svg_blip_tests {
         let doc = parse_from_bytes(&data).expect("parse must succeed");
         let img = only_image(&doc);
         assert!(img.duotone.is_none(), "duotone must be None when absent");
+    }
+
+    /// ECMA-376 §20.1.8.6 — an inline picture whose `<a:blip>` carries an
+    /// `<a:alphaModFix amt="…">` populates `ImageRun.alpha` with the fraction
+    /// `amt/100000`. `amt=60000` ⇒ 0.60. An opaque (or absent) blip leaves it
+    /// None so the renderer keeps its full-opacity fast path.
+    #[test]
+    fn inline_drawing_alpha_mod_fix_populates_alpha() {
+        let body = r#"<w:p><w:r><w:drawing>
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <wp:extent cx="304800" cy="304800"/>
+    <a:graphic><a:graphicData>
+      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:blipFill>
+          <a:blip r:embed="rIdPng"><a:alphaModFix amt="60000"/></a:blip>
+          <a:stretch><a:fillRect/></a:stretch>
+        </pic:blipFill>
+      </pic:pic>
+    </a:graphicData></a:graphic>
+  </wp:inline>
+</w:drawing></w:r></w:p>"#;
+        let data = build_docx_with_media(body);
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
+        let img = only_image(&doc);
+        let a = img.alpha.expect("alphaModFix must populate alpha");
+        assert!((a - 0.60).abs() < 1e-9, "alpha={a}");
+    }
+
+    /// A picture without an `<a:alphaModFix>` (and one at 100%) leaves `alpha`
+    /// None — the opaque fast path stays unchanged.
+    #[test]
+    fn inline_drawing_no_or_opaque_alpha_is_none() {
+        for amf in ["", r#"<a:alphaModFix amt="100000"/>"#] {
+            let body = format!(
+                r#"<w:p><w:r><w:drawing>
+  <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <wp:extent cx="304800" cy="304800"/>
+    <a:graphic><a:graphicData>
+      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:blipFill><a:blip r:embed="rIdPng">{amf}</a:blip><a:stretch/></pic:blipFill>
+      </pic:pic>
+    </a:graphicData></a:graphic>
+  </wp:inline>
+</w:drawing></w:r></w:p>"#
+            );
+            let data = build_docx_with_media(&body);
+            let doc = parse_from_bytes(&data).expect("parse must succeed");
+            let img = only_image(&doc);
+            assert!(
+                img.alpha.is_none(),
+                "amf={amf:?} must yield None, got {:?}",
+                img.alpha
+            );
+        }
     }
 
     /// Regression for the `PathCmd::ArcTo` serde naming bug (mirrors pptx #489).

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1524,7 +1524,7 @@ pub struct ShapeText {
 
 /// ECMA-376 §20.1.8.55 `<a:srcRect>` source-image crop, shared across the docx,
 /// pptx and xlsx parsers (see `ooxml_common::blip`).
-pub use ooxml_common::blip::SrcRect;
+pub use ooxml_common::blip::{Duotone, SrcRect};
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -1566,6 +1566,13 @@ pub struct ImageRun {
     /// When set, the renderer should replace all pixels of this hex color (e.g. "FFFFFF") with
     /// full transparency. Used to implement a:clrChange (make-background-transparent).
     pub color_replace_from: Option<String>,
+    /// ECMA-376 §20.1.8.23 `<a:duotone>` recolour effect, resolved to its two
+    /// endpoint colours through the document theme. `None` = no duotone (the
+    /// common case). When set, the renderer remaps the decoded raster along the
+    /// `clr1`→`clr2` luminance ramp at decode time (shared core `applyDuotone`),
+    /// matching Word's picture recolour.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duotone: Option<Duotone>,
     /// Wrap mode for anchor images. One of:
     ///   "square" | "topAndBottom" | "none" | "tight" | "through"
     /// Inline images and anchors without an explicit wrap element use "none".

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1573,6 +1573,12 @@ pub struct ImageRun {
     /// matching Word's picture recolour.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duotone: Option<Duotone>,
+    /// ECMA-376 §20.1.8.6 `<a:blip><a:alphaModFix@amt>` opacity as a fraction
+    /// (0.0–1.0). `None` = fully opaque (the common case). When set, the renderer
+    /// multiplies the picture's `globalAlpha` by this fraction, exactly as the
+    /// pptx/xlsx picture paths do.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alpha: Option<f64>,
     /// Wrap mode for anchor images. One of:
     ///   "square" | "topAndBottom" | "none" | "tight" | "through"
     /// Inline images and anchors without an explicit wrap element use "none".

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -19,7 +19,7 @@ import type {
   DocParagraph, DocRun, DocxTextRun, ImageRun, ShapeTextRun, FieldRun,
   LineSpacing, TabStop, DocxRunBorder, DocSettings, EmphasisMark,
 } from './types';
-import type { MathNode, KinsokuRules, ChartModel, HyperlinkTarget } from '@silurus/ooxml-core';
+import type { MathNode, KinsokuRules, ChartModel, HyperlinkTarget, Duotone } from '@silurus/ooxml-core';
 import type { RenderState, DecodedImage } from './renderer.js';
 import {
   classifyCjkFont,
@@ -191,6 +191,13 @@ export interface LayoutImageSeg {
   anchorYFromPara: boolean;
   /** When set, pixels matching this hex color are replaced with alpha=0 before drawing. */
   colorReplaceFrom?: string;
+  /** ECMA-376 §20.1.8.23 `<a:duotone>` recolour (two endpoint colours). Part of
+   *  the image cache key so the recoloured raster is looked up (draws through
+   *  the same `imageKey(imagePath, colorReplaceFrom, duotone)` the prefetch used). */
+  duotone?: Duotone;
+  /** ECMA-376 §20.1.8.6 `<a:alphaModFix@amt>` opacity as 0..1. When < 1 the
+   *  inline draw multiplies `globalAlpha` by it. `undefined` ⇒ fully opaque. */
+  alpha?: number;
   /** ECMA-376 §20.1.8.55 `<a:srcRect>` source-rectangle crop (fractions 0..1 of
    *  the decoded bitmap). When present the draw paths use the 9-arg
    *  `drawImage` to blit only `[l, t, 1−r, 1−b]` of the bitmap into the display
@@ -1784,6 +1791,8 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         anchorXFromMargin: img.anchorXFromMargin ?? false,
         anchorYFromPara: img.anchorYFromPara ?? false,
         colorReplaceFrom: img.colorReplaceFrom,
+        duotone: img.duotone,
+        alpha: img.alpha,
         srcRect: img.srcRect ?? undefined,
         measuredWidth: 0,
       });

--- a/packages/docx/src/renderer.image.test.ts
+++ b/packages/docx/src/renderer.image.test.ts
@@ -149,6 +149,66 @@ describe('docx lazy image bytes', () => {
     }
   });
 
+  it('decodeRaster applies a <a:duotone> recolour on the raster: base decode + one recolour, memoized', async () => {
+    stubOffscreen();
+    const fetchImage = vi.fn(
+      async (_path: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }),
+    );
+    const duotone = { clr1: '000000', clr2: 'DAB6BA' };
+    try {
+      const a = await decodeRaster('word/media/duo.png', 'image/png', undefined, fetchImage, 0, 0, duotone);
+      // Base blob decode + the duotone OffscreenCanvas → 2 createImageBitmap calls.
+      expect((globalThis.createImageBitmap as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(2);
+      const b = await decodeRaster('word/media/duo.png', 'image/png', undefined, fetchImage, 0, 0, duotone);
+      // Repeat: memoized recolour reused, base fetched once, no further decode.
+      expect(b).toBe(a);
+      expect(fetchImage).toHaveBeenCalledTimes(1);
+      expect((globalThis.createImageBitmap as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(2);
+    } finally {
+      dropColorReplacedCache(fetchImage);
+      dropBitmapCacheByPath(fetchImage);
+    }
+  });
+
+  it('preloadImages keys a duotone picture separately from the raw blip (distinct map keys, shared base)', async () => {
+    stubOffscreen();
+    const fetchImage = vi.fn(
+      async (_path: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }),
+    );
+    const path = 'word/media/duo2.png';
+    const doc = {
+      body: [
+        {
+          type: 'paragraph',
+          runs: [
+            { type: 'image', imagePath: path, mimeType: 'image/png', widthPt: 10, heightPt: 10 },
+            {
+              type: 'image',
+              imagePath: path,
+              mimeType: 'image/png',
+              widthPt: 10,
+              heightPt: 10,
+              duotone: { clr1: '000000', clr2: 'DAB6BA' },
+            },
+          ],
+        },
+      ],
+      headers: {},
+      footers: {},
+    } as unknown as DocxDocumentModel;
+    try {
+      const map = await preloadImages(doc, fetchImage);
+      // Two distinct keys: the raw path + the duotone-suffixed variant.
+      expect(map.has(path)).toBe(true);
+      expect(map.has(`${path}|duo:000000:DAB6BA`)).toBe(true);
+      // Shared base → ONE fetch for both refs.
+      expect(fetchImage).toHaveBeenCalledTimes(1);
+    } finally {
+      dropColorReplacedCache(fetchImage);
+      dropBitmapCacheByPath(fetchImage);
+    }
+  });
+
   it('preloadImages with no fetchImage yields an empty map (no byte source)', async () => {
     const doc = {
       body: [

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -40,6 +40,8 @@ import {
   isComplexScriptCodePoint,
   getCachedBitmapByPath,
   dropBitmapCacheByPath,
+  applyDuotone,
+  imageNaturalSize,
   drawImageCropped,
   metafileRasterSize,
   symbolFontToUnicode,
@@ -50,7 +52,7 @@ import {
   drawUnderline,
   renderChart,
 } from '@silurus/ooxml-core';
-import type { MathNode, MathRenderer, KinsokuRules, HyperlinkTarget, NumberFormat } from '@silurus/ooxml-core';
+import type { MathNode, MathRenderer, KinsokuRules, HyperlinkTarget, NumberFormat, Duotone } from '@silurus/ooxml-core';
 import { computePageNumbering } from './page-numbering.js';
 import { docxUnderlineToDrawingML } from './underline-map.js';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
@@ -499,6 +501,11 @@ interface ImagePair {
    */
   svgImagePath?: string;
   colorReplaceFrom?: string;
+  /** ECMA-376 §20.1.8.23 `<a:duotone>` recolour, resolved to its two endpoint
+   *  colours. When set, the decode remaps the raster along the `clr1`→`clr2`
+   *  luminance ramp; the map key includes both colours so a duotone picture is
+   *  cached separately from the raw blip. */
+  duotone?: Duotone;
   /**
    * Largest intended draw size (pt) over every reference to this key. Only used
    * to pick a raster target resolution for vector metafiles (WMF/EMF), which
@@ -521,25 +528,34 @@ function resolveCurrentDateMs(currentDate: Date | number | undefined): number {
   return typeof currentDate === 'number' ? currentDate : currentDate.getTime();
 }
 
-/** Returns a stable map key for an (imagePath, colorReplaceFrom) pair. */
-function imageKey(imagePath: string, colorReplaceFrom?: string): string {
-  return colorReplaceFrom ? `${imagePath}|clr:${colorReplaceFrom}` : imagePath;
+/** Returns a stable map key for an (imagePath, colorReplaceFrom, duotone)
+ *  triple. A plain picture is keyed by its zip path; an `a:clrChange`
+ *  (colorReplaceFrom) and/or a `<a:duotone>` each append a suffix, so a
+ *  recoloured variant is cached and looked up separately from the raw blip and
+ *  from any other recolour combination. */
+function imageKey(imagePath: string, colorReplaceFrom?: string, duotone?: Duotone): string {
+  let key = imagePath;
+  if (colorReplaceFrom) key += `|clr:${colorReplaceFrom}`;
+  if (duotone) key += `|duo:${duotone.clr1}:${duotone.clr2}`;
+  return key;
 }
 
 type DocxFetchImage = (path: string, mime: string) => Promise<Blob>;
 
-// Second-layer cache for the `a:clrChange` (colorReplaceFrom) result. The core
-// path-keyed cache (getCachedBitmapByPath) holds the color-replacement-FREE
-// bitmap — shared across every reference to a path and reclaimed with the
-// document. The make-transparent pass (getImageData + putImageData, expensive)
-// then runs once per (imagePath, colorReplaceFrom) pair and its ImageBitmap is
-// kept here, so revisiting a page re-runs neither the decode NOR the recolor.
+// Second-layer cache for a picture's RECOLOUR result — the `a:clrChange`
+// (colorReplaceFrom, §20.1.8.11) make-transparent pass and/or the `<a:duotone>`
+// (§20.1.8.23) luminance ramp. The core path-keyed cache (getCachedBitmapByPath)
+// holds the recolour-FREE bitmap — shared across every reference to a path and
+// reclaimed with the document. The recolour pass (getImageData + putImageData,
+// expensive) then runs once per (imagePath, colorReplaceFrom, duotone) triple
+// and its ImageBitmap is kept here, so revisiting a page re-runs neither the
+// decode NOR the recolour.
 //
 // Keyed FIRST by the document's `fetchImage` closure (one stable identity per
-// DocxDocument), then by imageKey(imagePath, colorReplaceFrom) — mirroring the
-// core cache's per-document namespacing so two documents sharing a zip path +
-// replace colour don't cross-contaminate, and the whole map is reclaimed with
-// the document. The stored value is an ImageBitmap (a fresh OffscreenCanvas
+// DocxDocument), then by imageKey(imagePath, colorReplaceFrom, duotone) —
+// mirroring the core cache's per-document namespacing so two documents sharing a
+// zip path + recolour don't cross-contaminate, and the whole map is reclaimed
+// with the document. The stored value is an ImageBitmap (a fresh OffscreenCanvas
 // raster), so on destroy it must be closed (see dropColorReplacedCache), the
 // same GPU-lifecycle discipline the core cache follows through its promise.
 const colorReplacedByFetch = new WeakMap<DocxFetchImage, Map<string, Promise<ImageBitmap>>>();
@@ -598,7 +614,7 @@ function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
   // intended draw size so a vector metafile is rasterized sharply enough for its
   // largest occurrence — only meaningful for WMF/EMF).
   const record = (pair: ImagePair) => {
-    const key = imageKey(pair.imagePath, pair.colorReplaceFrom);
+    const key = imageKey(pair.imagePath, pair.colorReplaceFrom, pair.duotone);
     const existing = seen.get(key);
     if (!existing) {
       seen.set(key, pair);
@@ -639,6 +655,7 @@ function collectImagePairs(doc: DocxDocumentModel): ImagePair[] {
           mimeType: img.mimeType,
           svgImagePath: img.svgImagePath,
           colorReplaceFrom: img.colorReplaceFrom,
+          duotone: img.duotone,
           ...metafileRasterSize(img.mimeType, img.srcRect, img.widthPt ?? 0, img.heightPt ?? 0),
           hasCrop: img.srcRect != null,
         });
@@ -756,6 +773,7 @@ export async function decodeRaster(
   fetchImage: (path: string, mime: string) => Promise<Blob>,
   widthPt = 0,
   heightPt = 0,
+  duotone?: Duotone,
 ): Promise<ImageBitmap | null> {
   // Base bitmap (no colour replacement): shared, path-keyed, per-document cache.
   const base = await getCachedBitmapByPath(imagePath, mimeType, fetchImage, {
@@ -769,15 +787,28 @@ export async function decodeRaster(
   // null rather than throw so this expected outcome never travels the exception
   // path (a transient fetch/decode failure still rejects and is caught upstream).
   if (!base) return null;
-  if (!colorReplaceFrom) return base;
-  // Second layer: memoize the make-transparent result per (path, colour). The
-  // recolor reads the SHARED base bitmap and produces a fresh independent raster,
+  if (!colorReplaceFrom && !duotone) return base;
+  // Second layer: memoize the recolour result per (path, colour, duotone). The
+  // recolour reads the SHARED base bitmap and produces a fresh independent raster,
   // so the base is never mutated and stays reusable for other references / draws.
+  // clrChange (§20.1.8.11 make-transparent) is applied BEFORE the duotone
+  // (§20.1.8.23 luminance ramp): the ramp leaves fully-transparent pixels
+  // untouched, so a colour keyed transparent stays transparent under the recolour.
   const cache = colorReplacedCacheFor(fetchImage);
-  const key = imageKey(imagePath, colorReplaceFrom);
+  const key = imageKey(imagePath, colorReplaceFrom, duotone);
   let hit = cache.get(key);
   if (!hit) {
-    hit = applyColorReplacement(base, colorReplaceFrom);
+    hit = (async () => {
+      let bmp: ImageBitmap = base;
+      if (colorReplaceFrom) bmp = await applyColorReplacement(bmp, colorReplaceFrom);
+      if (duotone) {
+        const { w, h } = imageNaturalSize(bmp);
+        if (w > 0 && h > 0) {
+          bmp = (await applyDuotone(bmp, duotone, { width: w, height: h })) as ImageBitmap;
+        }
+      }
+      return bmp;
+    })();
     // Don't poison the cache if the recolor pass rejects; let the next call retry.
     hit.catch(() => cache.delete(key));
     cache.set(key, hit);
@@ -827,9 +858,11 @@ export async function preloadImages(
           try {
             img = await getCachedSvgImageByPath(blip.svgImagePath, fetch);
           } catch {
+            // The raster fallback carries the §20.1.8.23 duotone recolour; an SVG
+            // vector original has no readable pixel grid, so it stays un-recoloured.
             img = dataIsSvg
               ? await getCachedSvgImageByPath(pair.imagePath, fetch)
-              : await decodeRaster(pair.imagePath, pair.mimeType, pair.colorReplaceFrom, fetch, pair.widthPt, pair.heightPt);
+              : await decodeRaster(pair.imagePath, pair.mimeType, pair.colorReplaceFrom, fetch, pair.widthPt, pair.heightPt, pair.duotone);
           }
         } else if (dataIsSvg) {
           // svg-only picture (no svgImagePath surfaced — e.g. a non-svgBlip
@@ -837,11 +870,11 @@ export async function preloadImages(
           // through the path-keyed <img>-based SVG path.
           img = await getCachedSvgImageByPath(pair.imagePath, fetch);
         } else {
-          img = await decodeRaster(pair.imagePath, pair.mimeType, pair.colorReplaceFrom, fetch, pair.widthPt, pair.heightPt);
+          img = await decodeRaster(pair.imagePath, pair.mimeType, pair.colorReplaceFrom, fetch, pair.widthPt, pair.heightPt, pair.duotone);
         }
         // Undrawable metafile → drop the entry (draw sites skip a missing key).
         if (!img) return null;
-        return [imageKey(pair.imagePath, pair.colorReplaceFrom), img];
+        return [imageKey(pair.imagePath, pair.colorReplaceFrom, pair.duotone), img];
       } catch {
         return null;
       }
@@ -6824,9 +6857,16 @@ function renderInlineImage(
     );
     return;
   }
-  const bmp = images.get(imageKey(seg.imagePath, seg.colorReplaceFrom));
+  const bmp = images.get(imageKey(seg.imagePath, seg.colorReplaceFrom, seg.duotone));
   if (!bmp) return;
+  // §20.1.8.6 alphaModFix — multiply the picture's opacity for the draw.
+  const hasAlpha = seg.alpha != null && seg.alpha < 1;
+  if (hasAlpha) {
+    ctx.save();
+    ctx.globalAlpha *= seg.alpha as number;
+  }
   paint((dx, dy, dw, dh) => drawImageCropped(ctx, bmp, seg.srcRect, dx, dy, dw, dh));
+  if (hasAlpha) ctx.restore();
 }
 
 /** Collect and draw anchor images with wrapMode='none' (or unspecified).
@@ -6916,7 +6956,7 @@ function renderAnchorImages(
     const img = run as unknown as ImageRun;
     if (!img.anchor) continue;
     if (isWrapFloat(img.wrapMode)) continue;  // drawn as a float
-    const bmp = state.images.get(imageKey(img.imagePath, img.colorReplaceFrom));
+    const bmp = state.images.get(imageKey(img.imagePath, img.colorReplaceFrom, img.duotone));
     if (!bmp) continue;
 
     // wrapNone images anchor against the paragraph's pre-spaceBefore top
@@ -6928,6 +6968,12 @@ function renderAnchorImages(
     // does not displace text and is not displaced by other floats), so dist* is
     // unused here.
     const { x: pageX, y: pageY, w, h } = resolveAnchorBox(img, state, paragraphTopPx);
+    // §20.1.8.6 alphaModFix — multiply the picture's opacity.
+    const hasAlpha = img.alpha != null && img.alpha < 1;
+    if (hasAlpha) {
+      state.ctx.save();
+      state.ctx.globalAlpha *= img.alpha as number;
+    }
     if (state.verticalCJK) {
       // §17.6.20 (tbRl) — an anchored image is not text: keep it UPRIGHT inside
       // the +90°-rotated page by counter-rotating about its box centre.
@@ -6937,6 +6983,7 @@ function renderAnchorImages(
     } else {
       drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, pageX, pageY, w, h);
     }
+    if (hasAlpha) state.ctx.restore();
   }
 }
 
@@ -8183,7 +8230,7 @@ function registerImageFloat(
   // gate under allowOverlap=true, and the right-then-down re-seat using dist
   // padding as the float-to-float gap. See resolveFloatOverlap header.
   const allowOverlap = img.allowOverlap ?? true;
-  const key = imageKey(img.imagePath, img.colorReplaceFrom);
+  const key = imageKey(img.imagePath, img.colorReplaceFrom, img.duotone);
   const rect = pushFloatRect(state, {
     x: box.x,
     y: box.y,
@@ -8201,6 +8248,12 @@ function registerImageFloat(
   if (!state.dryRun) {
     const bmp = state.images.get(key);
     if (bmp) {
+      // §20.1.8.6 alphaModFix — multiply the picture's opacity.
+      const hasAlpha = img.alpha != null && img.alpha < 1;
+      if (hasAlpha) {
+        state.ctx.save();
+        state.ctx.globalAlpha *= img.alpha as number;
+      }
       if (state.verticalCJK) {
         // §17.6.20 (tbRl) — keep the floated image UPRIGHT inside the rotated page.
         drawUprightBox(state.ctx, rect.imageX, rect.imageY, rect.imageW, rect.imageH, (dx, dy, dw, dh) =>
@@ -8209,6 +8262,7 @@ function registerImageFloat(
       } else {
         drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
       }
+      if (hasAlpha) state.ctx.restore();
     }
     rect.drawn = true;
   }

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1,6 +1,6 @@
 // ===== Output JSON model (mirrors Rust types) =====
 
-import type { MathNode, ChartModel } from '@silurus/ooxml-core';
+import type { MathNode, ChartModel, Duotone } from '@silurus/ooxml-core';
 
 export interface DocxDocumentModel {
   section: SectionProps;
@@ -1220,6 +1220,19 @@ export interface ImageRun {
    * transparency. Implements a:clrChange (make-background-transparent).
    */
   colorReplaceFrom?: string;
+  /**
+   * ECMA-376 §20.1.8.23 `<a:duotone>` recolour, resolved to its two endpoint
+   * colours (through the document theme). Absent ⇒ no duotone. When present the
+   * renderer decodes the raster once, remaps it along the `clr1`→`clr2`
+   * luminance ramp, and caches the recoloured bitmap under a colour-suffixed key.
+   */
+  duotone?: Duotone;
+  /**
+   * ECMA-376 §20.1.8.6 `<a:alphaModFix@amt>` opacity as 0..1. Absent ⇒ fully
+   * opaque. When present the renderer multiplies the picture's `globalAlpha` by
+   * this fraction.
+   */
+  alpha?: number;
   /**
    * Wrap mode for anchor images:
    *   "square" | "topAndBottom" | "none" | "tight" | "through"

--- a/packages/node/src/docx-duotone-alpha.probe.test.ts
+++ b/packages/node/src/docx-duotone-alpha.probe.test.ts
@@ -1,0 +1,234 @@
+/**
+ * End-to-end pixel probe for the DrawingML `<a:duotone>` recolour (§20.1.8.23)
+ * and `<a:alphaModFix>` opacity (§20.1.8.6) on a docx inline picture. A parser
+ * round-trip is not proof the effects draw, so this builds a synthetic `.docx`
+ * (in-memory STORED zip, no file committed) with a mid-grey PNG picture, parses
+ * it through the real docx WASM, renders it through the docx renderer (skia +
+ * the node OffscreenCanvas / createImageBitmap shims), and measures the image
+ * region against the expected recolour / alpha composite.
+ */
+import { describe, it, expect } from 'vitest';
+import { crc32 } from 'node:zlib';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, loadImage } = (skia ?? {}) as Skia;
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
+const rendererMod = await importForTests(
+  () => import('./../../docx/src/renderer.ts'),
+  'packages/docx/src/renderer.ts',
+);
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  // skia's loadImage wants a Buffer; the shim may hand us an ArrayBuffer/Uint8Array.
+  loadImage: ((buf: ArrayBuffer | Uint8Array | Buffer) =>
+    loadImage(Buffer.isBuffer(buf) ? buf : Buffer.from(buf as ArrayBuffer))) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+  'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ' +
+  'xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" ' +
+  'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" ' +
+  'xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"';
+
+/** Minimal STORED zip supporting binary entries (Uint8Array) as well as text. */
+function storedZip(files: Record<string, string | Uint8Array>): Uint8Array {
+  const enc = new TextEncoder();
+  const chunks: number[] = [];
+  const central: number[] = [];
+  const u16 = (n: number) => [n & 0xff, (n >> 8) & 0xff];
+  const u32 = (n: number) => [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff];
+  let offset = 0;
+  for (const [name, content] of Object.entries(files)) {
+    const nameBytes = [...enc.encode(name)];
+    const data = [...(typeof content === 'string' ? enc.encode(content) : content)];
+    const crc = crc32(Uint8Array.from(data)) >>> 0;
+    const local = [
+      ...u32(0x04034b50), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...nameBytes, ...data,
+    ];
+    central.push(
+      ...u32(0x02014b50), ...u16(20), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...u16(0), ...u16(0), ...u16(0), ...u32(0), ...u32(offset),
+      ...nameBytes,
+    );
+    chunks.push(...local);
+    offset += local.length;
+  }
+  const centralOffset = offset;
+  const end = [
+    ...u32(0x06054b50), ...u16(0), ...u16(0),
+    ...u16(Object.keys(files).length), ...u16(Object.keys(files).length),
+    ...u32(central.length), ...u32(centralOffset), ...u16(0),
+  ];
+  return Uint8Array.from([...chunks, ...central, ...end]);
+}
+
+/** A `<w:drawing>` inline picture, optionally carrying a duotone and/or an
+ *  alphaModFix on its blip. cx/cy in EMU (12700 EMU/pt). */
+function inlinePicXml(opts: { duotone?: boolean; alpha?: string }): string {
+  const cx = 200 * 12700; // 200pt square
+  const effects =
+    (opts.duotone
+      ? '<a:duotone><a:srgbClr val="000000"/><a:srgbClr val="DAB6BA"/></a:duotone>'
+      : '') + (opts.alpha ? `<a:alphaModFix amt="${opts.alpha}"/>` : '');
+  return (
+    '<w:p><w:r><w:drawing>' +
+    `<wp:inline><wp:extent cx="${cx}" cy="${cx}"/>` +
+    '<a:graphic><a:graphicData>' +
+    '<pic:pic><pic:blipFill>' +
+    `<a:blip r:embed="rIdImg">${effects}</a:blip>` +
+    '<a:stretch><a:fillRect/></a:stretch>' +
+    '</pic:blipFill>' +
+    '<pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="' + cx + '" cy="' + cx + '"/></a:xfrm>' +
+    '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr></pic:pic>' +
+    '</a:graphicData></a:graphic></wp:inline>' +
+    '</w:drawing></w:r></w:p>'
+  );
+}
+
+function buildDocx(pngBytes: Uint8Array, opts: { duotone?: boolean; alpha?: string }): Uint8Array {
+  const contentTypes =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Default Extension="png" ContentType="image/png"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '</Types>';
+  const rootRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+    '</Relationships>';
+  const docRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rIdImg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>' +
+    '</Relationships>';
+  const document =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document ${NS}><w:body>` +
+    inlinePicXml(opts) +
+    '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/>' +
+    '<w:pgMar w:top="720" w:right="720" w:bottom="720" w:left="720" w:header="0" w:footer="0" w:gutter="0"/>' +
+    '</w:sectPr></w:body></w:document>';
+  return storedZip({
+    '[Content_Types].xml': contentTypes,
+    '_rels/.rels': rootRels,
+    'word/_rels/document.xml.rels': docRels,
+    'word/document.xml': document,
+    'word/media/image1.png': pngBytes,
+  });
+}
+
+async function flatPngBytes(w: number, h: number, color: string): Promise<Uint8Array> {
+  const c = new Canvas(w, h);
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, w, h);
+  return new Uint8Array(await c.toBuffer('png'));
+}
+
+interface Rendered {
+  data: Uint8ClampedArray;
+  w: number;
+  h: number;
+}
+
+async function render(docxBytes: Uint8Array, pngBytes: Uint8Array): Promise<Rendered> {
+  const { parseDocx } = docxMod as {
+    parseDocx: (b: Uint8Array) => { section: { pageWidth: number; pageHeight: number } };
+  };
+  const doc = parseDocx(docxBytes);
+  const { renderDocumentToCanvas } = rendererMod as {
+    renderDocumentToCanvas: (
+      doc: unknown,
+      canvas: unknown,
+      pageIndex: number,
+      opts: {
+        dpr: number;
+        width: number;
+        fetchImage: (path: string, mime: string) => Promise<Blob>;
+      },
+    ) => Promise<void>;
+  };
+  const widthPx = doc.section.pageWidth;
+  const heightPx = doc.section.pageHeight;
+  const canvas = new Canvas(Math.round(widthPx), Math.round(heightPx));
+  const restoreImg = installImageBitmapShim(factory);
+  const restoreOff = installOffscreenCanvasShim(factory);
+  try {
+    await renderDocumentToCanvas(doc, canvas, 0, {
+      dpr: 1,
+      width: widthPx,
+      fetchImage: async (_path: string, mime: string) =>
+        new Blob([pngBytes as BlobPart], { type: mime }),
+    });
+  } finally {
+    restoreOff();
+    restoreImg();
+  }
+  const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+  const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  return { data: img.data, w: canvas.width, h: canvas.height };
+}
+
+function lum(r: number, g: number, b: number): number {
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+/** Sample the picture interior. The inline picture sits at the top-left content
+ *  origin (~720 twip = 48px margin), 200pt square, so a point ~60px inside the
+ *  margin is safely inside the image. */
+function sampleInside(r: Rendered): [number, number, number] {
+  const x = 48 + 40;
+  const y = 48 + 40;
+  const i = (y * r.w + x) * 4;
+  return [r.data[i], r.data[i + 1], r.data[i + 2]];
+}
+
+describe.skipIf(!skia || !docxMod || !rendererMod)('docx duotone + alphaModFix picture render', () => {
+  it('duotone remaps a mid-grey picture along the clr1→clr2 ramp (§20.1.8.23)', async () => {
+    const png = await flatPngBytes(16, 16, '#808080');
+    const t = lum(128, 128, 128);
+    const c1 = [0x00, 0x00, 0x00];
+    const c2 = [0xda, 0xb6, 0xba];
+    const expected = c1.map((d, i) => Math.round(d + (c2[i] - d) * t));
+
+    const plain = sampleInside(await render(buildDocx(png, {}), png));
+    const duo = sampleInside(await render(buildDocx(png, { duotone: true }), png));
+
+    // Plain: untouched grey.
+    expect(Math.abs(plain[0] - 128)).toBeLessThan(8);
+    expect(Math.abs(plain[1] - 128)).toBeLessThan(8);
+    // Duotone: the luminance-ramp interpolation (a light pink, R dominant).
+    expect(Math.abs(duo[0] - expected[0])).toBeLessThan(12);
+    expect(Math.abs(duo[1] - expected[1])).toBeLessThan(12);
+    expect(Math.abs(duo[2] - expected[2])).toBeLessThan(12);
+    expect(duo[0]).toBeGreaterThan(duo[1]);
+    expect(duo[0]).toBeGreaterThan(duo[2]);
+  });
+
+  it('alphaModFix composites a semi-transparent picture over the white page (§20.1.8.6)', async () => {
+    // amt=50000 → 0.5 opacity. A mid-grey (128) picture over white (255) at 0.5
+    // composites to 0.5*128 + 0.5*255 ≈ 191.5 on every channel.
+    const png = await flatPngBytes(16, 16, '#808080');
+    const opaque = sampleInside(await render(buildDocx(png, {}), png));
+    const semi = sampleInside(await render(buildDocx(png, { alpha: '50000' }), png));
+
+    // Opaque baseline is the flat grey; the semi-transparent draw is lighter
+    // (composited toward white) by a clear margin.
+    expect(Math.abs(opaque[0] - 128)).toBeLessThan(8);
+    const expectedComposite = Math.round(0.5 * 128 + 0.5 * 255);
+    expect(Math.abs(semi[0] - expectedComposite)).toBeLessThan(14);
+    expect(semi[0]).toBeGreaterThan(opaque[0] + 30);
+  });
+});

--- a/packages/node/src/duotone-render.test.ts
+++ b/packages/node/src/duotone-render.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { renderSlideNode } from './render';
+import type { NodeCanvasFactory } from './render';
+import type { Presentation, Slide, PictureElement } from '@silurus/ooxml-pptx';
+import { loadSkiaForTests } from './test-imports';
+
+// End-to-end pixel check for the DrawingML `<a:duotone>` recolour (§20.1.8.23)
+// on a pptx picture. A parser round-trip is NOT proof the effect draws, so this
+// renders a synthetic slide whose picture carries a duotone through the real
+// node render path (skia + the OffscreenCanvas / createImageBitmap shims) and
+// measures the drawn pixels against the expected luminance-ramp interpolation.
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, loadImage } = (skia ?? {}) as Skia;
+
+const factory: NodeCanvasFactory | null =
+  Canvas && loadImage
+    ? {
+        createCanvas: (w, h) =>
+          new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+        loadImage: (buf) =>
+          loadImage(buf as Buffer) as unknown as ReturnType<NodeCanvasFactory['loadImage']>,
+      }
+    : null;
+
+async function flatPngBytes(w: number, h: number, color: string): Promise<Uint8Array> {
+  const c = new Canvas(w, h);
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, w, h);
+  return new Uint8Array(await c.toBuffer('png'));
+}
+
+const EMU_PER_PX = 9525; // 96 dpi
+const PIC_IMAGE_PATH = 'ppt/media/image1.png';
+
+/** A 300×300 px picture centred on a 400×400 px slide, carrying (or not) a
+ *  `<a:duotone>` recolour. */
+function buildDuotoneSlide(duotone?: { clr1: string; clr2: string }): Presentation {
+  const px = (n: number) => Math.round(n * EMU_PER_PX);
+  const pic: PictureElement = {
+    type: 'picture',
+    x: px(50),
+    y: px(50),
+    width: px(300),
+    height: px(300),
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+    imagePath: PIC_IMAGE_PATH,
+    mimeType: 'image/png',
+    stroke: null,
+    ...(duotone ? { duotone } : {}),
+  };
+  const slide: Slide = { index: 0, slideNumber: 1, background: null, elements: [pic] };
+  return {
+    slideWidth: px(400),
+    slideHeight: px(400),
+    slides: [slide],
+    defaultTextColor: null,
+    majorFont: null,
+    minorFont: null,
+  };
+}
+
+async function renderToRgba(
+  presentation: Presentation,
+  pngBytes: Uint8Array,
+): Promise<{ data: Uint8ClampedArray; width: number }> {
+  const width = 400;
+  const canvas = new Canvas(width, 400);
+  const g2 = globalThis as unknown as { createImageBitmap?: unknown };
+  const prevBitmap = g2.createImageBitmap;
+  g2.createImageBitmap = async (source: Blob | ArrayBuffer | Uint8Array | { toBuffer?: unknown }) => {
+    // The base decode passes a Blob; applyDuotone passes the offscreen (skia)
+    // canvas surface — loadImage handles a canvas by rasterizing it.
+    if (source && typeof (source as { toBuffer?: unknown }).toBuffer === 'function') {
+      return source; // a skia Canvas is already a valid drawImage source
+    }
+    let buf: ArrayBuffer | Uint8Array;
+    if (source instanceof Uint8Array || source instanceof ArrayBuffer) buf = source;
+    else buf = await (source as Blob).arrayBuffer();
+    return loadImage(Buffer.from(buf as ArrayBuffer));
+  };
+  try {
+    await renderSlideNode(
+      canvas as unknown as Parameters<typeof renderSlideNode>[0],
+      presentation,
+      0,
+      {
+        width,
+        dpr: 1,
+        fetchImage: async (_path: string, mime: string) =>
+          new Blob([pngBytes as BlobPart], { type: mime }),
+        ...(factory ? { factory } : {}),
+      },
+    );
+  } finally {
+    g2.createImageBitmap = prevBitmap as typeof globalThis.createImageBitmap;
+  }
+  const ctx = canvas.getContext('2d');
+  const img = ctx.getImageData(0, 0, width, 400);
+  return { data: img.data as unknown as Uint8ClampedArray, width };
+}
+
+/** Rec. 601 luminance (0..1) of an sRGB byte triple — the exact ramp factor the
+ *  core duotone transform uses. */
+function luminance601(r: number, g: number, b: number): number {
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+describe.skipIf(!skia)('node duotone picture rendering (§20.1.8.23)', () => {
+  it('remaps a mid-grey picture along the clr1→clr2 luminance ramp', async () => {
+    // Uniform mid-grey source: luminance ≈ 0.502 → interpolates ~half-way from
+    // clr1 (black) to clr2 (a light pink).
+    const src = [128, 128, 128];
+    const t = luminance601(src[0], src[1], src[2]);
+    const clr1 = [0x00, 0x00, 0x00]; // black
+    const clr2 = [0xda, 0xb6, 0xba]; // light pink
+    const expected = clr1.map((d, i) => Math.round(d + (clr2[i] - d) * t));
+
+    const pngBytes = await flatPngBytes(16, 16, '#808080');
+    const plain = await renderToRgba(buildDuotoneSlide(), pngBytes);
+    const duo = await renderToRgba(
+      buildDuotoneSlide({ clr1: '000000', clr2: 'DAB6BA' }),
+      pngBytes,
+    );
+
+    // Sample the picture centre (px 200,200 on the 400×400 slide).
+    const { data: pd, width } = plain;
+    const { data: dd } = duo;
+    const i = (200 * width + 200) * 4;
+
+    // Plain render shows the untouched grey.
+    expect(Math.abs(pd[i] - 128)).toBeLessThan(6);
+    expect(Math.abs(pd[i + 1] - 128)).toBeLessThan(6);
+    expect(Math.abs(pd[i + 2] - 128)).toBeLessThan(6);
+
+    // Duotone render shows the ramp interpolation: pink (R > G ≈ B), each channel
+    // within a small tolerance of the expected duotone value.
+    expect(Math.abs(dd[i] - expected[0])).toBeLessThan(10);
+    expect(Math.abs(dd[i + 1] - expected[1])).toBeLessThan(10);
+    expect(Math.abs(dd[i + 2] - expected[2])).toBeLessThan(10);
+    // Sanity: the recolour actually happened (moved away from neutral grey) and
+    // is a pink (red channel dominant), matching the clr2 endpoint hue.
+    expect(dd[i]).toBeGreaterThan(dd[i + 1]);
+    expect(dd[i]).toBeGreaterThan(dd[i + 2]);
+    expect(Math.abs(dd[i] - 128)).toBeGreaterThan(15);
+  });
+});

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1744,6 +1744,7 @@ mod tests {
             prst_adjust: None,
             src_rect: None,
             alpha: None,
+            duotone: None,
             cust_geom: None,
             shadow: None,
             inner_shadow: None,
@@ -4957,6 +4958,86 @@ mod tests {
             pic.svg_image_path.is_none(),
             "svg_image_path must be None without an svgBlip extension"
         );
+    }
+
+    /// ECMA-376 §20.1.8.23 — a `<p:pic>` whose `<a:blip>` carries a
+    /// `<a:duotone>` (a CT_Blip effect child, per the XSD sequence) parses its
+    /// two `EG_ColorChoice` endpoints through the slide theme, resolving a
+    /// `<a:schemeClr>` against the theme palette. `clr1` is the dark endpoint,
+    /// `clr2` the light endpoint.
+    #[test]
+    fn picture_duotone_resolves_two_colours_through_theme() {
+        const PNG_1X1: &[u8] = &[
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48,
+            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00,
+            0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78,
+            0x9C, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+            0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+        ];
+        // <a:blip> holds the duotone (CT_Blip effect); clr1 = black prstClr,
+        // clr2 = accent1 schemeClr (resolved from the theme map).
+        let pic_xml = r#"<p:pic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:nvPicPr><p:cNvPr id="5" name="DuoPic"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+  <p:blipFill>
+    <a:blip r:embed="rIdPng">
+      <a:duotone>
+        <a:prstClr val="black"/>
+        <a:schemeClr val="accent1"/>
+      </a:duotone>
+    </a:blip>
+    <a:stretch><a:fillRect/></a:stretch>
+  </p:blipFill>
+  <p:spPr><a:xfrm><a:off x="100" y="200"/><a:ext cx="300000" cy="300000"/></a:xfrm>
+    <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+</p:pic>"#;
+        let doc = roxmltree::Document::parse(pic_xml).unwrap();
+        let pic_node = doc.root_element();
+        let mut rels = HashMap::new();
+        rels.insert("rIdPng".to_string(), "../media/image1.png".to_string());
+        let mut theme = HashMap::new();
+        theme.insert("accent1".to_string(), "4472C4".to_string());
+        let data = build_blip_media_zip(PNG_1X1, b"<svg/>");
+        let cursor = Cursor::new(data.clone());
+        let mut zip = zip::ZipArchive::new(cursor).unwrap();
+        let pic = parse_picture(pic_node, "ppt/slides", &rels, &theme, &mut zip)
+            .expect("parse_picture should succeed for a duotone picture");
+        let duo = pic.duotone.expect("duotone must be surfaced");
+        assert_eq!(duo.clr1, "000000", "clr1 = black prstClr");
+        assert_eq!(duo.clr2, "4472C4", "clr2 = accent1 resolved from theme");
+    }
+
+    /// A `<p:pic>` without a `<a:duotone>` leaves `duotone` None — guards the new
+    /// branch from firing spuriously, so non-duotone pictures stay byte-identical.
+    #[test]
+    fn picture_without_duotone_is_none() {
+        const PNG_1X1: &[u8] = &[
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48,
+            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00,
+            0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78,
+            0x9C, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+            0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+        ];
+        let pic_xml = r#"<p:pic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:nvPicPr><p:cNvPr id="5" name="PngPic"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+  <p:blipFill><a:blip r:embed="rIdPng"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>
+  <p:spPr><a:xfrm><a:off x="100" y="200"/><a:ext cx="300000" cy="300000"/></a:xfrm>
+    <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+</p:pic>"#;
+        let doc = roxmltree::Document::parse(pic_xml).unwrap();
+        let pic_node = doc.root_element();
+        let mut rels = HashMap::new();
+        rels.insert("rIdPng".to_string(), "../media/image1.png".to_string());
+        let theme = HashMap::new();
+        let data = build_blip_media_zip(PNG_1X1, b"<svg/>");
+        let cursor = Cursor::new(data.clone());
+        let mut zip = zip::ZipArchive::new(cursor).unwrap();
+        let pic = parse_picture(pic_node, "ppt/slides", &rels, &theme, &mut zip)
+            .expect("parse_picture should succeed");
+        assert!(pic.duotone.is_none(), "duotone must be None when absent");
     }
 
     /// A `<p:pic>` whose `<a:blip>` carries ONLY the `asvg:svgBlip` extension —

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -14,12 +14,13 @@ use crate::master::LayoutPlaceholders;
 use crate::text::{
     empty_level_bullets, parse_text_body, LevelBullets, LevelFontSizes, LevelIndents, ShapeKind,
 };
+use crate::theme::PptxSchemeResolver;
 use crate::types::*;
 use crate::{
     attr, attr_f64, attr_i64, attr_r, child, find_rel_target_by_type, read_zip_str, resolve_path,
     table_style_presets, PptxZip, TableStyleDef,
 };
-use ooxml_common::blip::{mime_from_ext, parse_src_rect, svg_blip_rid};
+use ooxml_common::blip::{mime_from_ext, parse_blip_duotone, parse_src_rect, svg_blip_rid};
 use ooxml_common::depth::{parse_guarded, DepthGuard};
 use ooxml_common::ns::{is_diagram_uri, is_pml_ole_uri};
 use ooxml_common::units::EMU_PER_PX_96DPI;
@@ -776,6 +777,13 @@ pub(crate) fn parse_picture(
         prst_adjust,
         src_rect: parse_src_rect(blip_fill),
         alpha: parse_blip_alpha(blip_fill),
+        // §20.1.8.23 `<a:duotone>` recolour, resolved through the slide's theme
+        // palette with PowerPoint's linear tint. `None` ⇒ no effect.
+        duotone: parse_blip_duotone(
+            blip_fill,
+            &PptxSchemeResolver { theme },
+            ooxml_common::color::TintMode::PowerPointLinear,
+        ),
         cust_geom,
         shadow,
         inner_shadow,
@@ -798,7 +806,7 @@ pub(crate) fn parse_ole_preview_picture(
     gf: &Transform,
     slide_dir: &str,
     rels: &HashMap<String, String>,
-    _theme: &HashMap<String, String>,
+    theme: &HashMap<String, String>,
     zip: &mut PptxZip,
 ) -> Option<PictureElement> {
     if gf.cx == 0 || gf.cy == 0 {
@@ -833,6 +841,11 @@ pub(crate) fn parse_ole_preview_picture(
         prst_adjust: None,
         src_rect: parse_src_rect(blip_fill),
         alpha: parse_blip_alpha(blip_fill),
+        duotone: parse_blip_duotone(
+            blip_fill,
+            &PptxSchemeResolver { theme },
+            ooxml_common::color::TintMode::PowerPointLinear,
+        ),
         cust_geom: None,
         shadow: None,
         inner_shadow: None,
@@ -1614,6 +1627,13 @@ pub(crate) fn parse_sp_tree_node(
                                     prst_adjust,
                                     src_rect: blip_fill_node.and_then(parse_src_rect),
                                     alpha: blip_fill_node.and_then(parse_blip_alpha),
+                                    duotone: blip_fill_node.and_then(|bf| {
+                                        parse_blip_duotone(
+                                            bf,
+                                            &PptxSchemeResolver { theme },
+                                            ooxml_common::color::TintMode::PowerPointLinear,
+                                        )
+                                    }),
                                     cust_geom,
                                     shadow,
                                     inner_shadow,
@@ -1678,6 +1698,13 @@ pub(crate) fn parse_sp_tree_node(
                                     prst_adjust: None,
                                     src_rect: bf.src_rect,
                                     alpha: bf.alpha,
+                                    // An inherited layout-placeholder blipFill
+                                    // (LayoutPlaceholders::lookup_blip_fill) does not
+                                    // yet carry a `<a:duotone>`; picture placeholders
+                                    // with a duotone are rare, so None matches prior
+                                    // behaviour (thread it through BlipFill if a
+                                    // sample needs it, alongside svg_image_path above).
+                                    duotone: None,
                                     cust_geom: None,
                                     shadow: None,
                                     inner_shadow: None,
@@ -1756,6 +1783,13 @@ pub(crate) fn parse_sp_tree_node(
                                         prst_adjust: None,
                                         src_rect: blip_fill.and_then(parse_src_rect),
                                         alpha: blip_fill.and_then(parse_blip_alpha),
+                                        duotone: blip_fill.and_then(|bf| {
+                                            parse_blip_duotone(
+                                                bf,
+                                                &PptxSchemeResolver { theme },
+                                                ooxml_common::color::TintMode::PowerPointLinear,
+                                            )
+                                        }),
                                         cust_geom: None,
                                         shadow: None,
                                         inner_shadow: None,

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -2,7 +2,7 @@
 //! helpers and pure transform types. Extracted verbatim from `lib.rs`; `lib.rs`
 //! re-exports these via `pub use types::*`.
 
-use ooxml_common::blip::SrcRect;
+use ooxml_common::blip::{Duotone, SrcRect};
 use ooxml_common::math::MathNode;
 use ooxml_common::text::SpaceLine;
 use serde::{Deserialize, Serialize};
@@ -477,6 +477,13 @@ pub(crate) struct PictureElement {
     /// a:blip > a:alphaModFix@amt (0.0–1.0). None = fully opaque.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) alpha: Option<f64>,
+    /// ECMA-376 §20.1.8.23 `<a:duotone>` recolour effect, resolved to its two
+    /// endpoint colours (through the slide's theme palette). `None` = no duotone
+    /// (the common case). When set, the renderer remaps the decoded raster along
+    /// the `clr1`→`clr2` luminance ramp at decode time (see the shared core
+    /// `applyDuotone`), matching PowerPoint's recolour.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) duotone: Option<Duotone>,
     /// `<p:spPr><a:custGeom>` — custom geometry path used as a clip on the
     /// blitted image. Same shape model as `ShapeElement.cust_geom` (one or more
     /// `<a:path>` whose coordinates are normalized into [0,1] of the bbox).

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -1,5 +1,5 @@
 import type { DimOptions, MediaElement, Presentation, WorkerRequest, WorkerResponse } from './types';
-import { renderSlide, dropImageBitmapCache, type TextRunCallback, type PptxTextRunInfo } from './renderer';
+import { renderSlide, dropImageBitmapCache, dropDuotoneBitmapCache, type TextRunCallback, type PptxTextRunInfo } from './renderer';
 import { createPresentationHandle, type PresentationHandle } from './presentation-handle';
 import { selectNotes } from './notes';
 import { selectHidden } from './hidden';
@@ -587,9 +587,11 @@ export class PptxPresentation {
       unloadGoogleFonts(this._googleFontFaces);
       this._googleFontFaces = [];
     }
-    // Release this deck's decoded raster bitmaps (GPU-backed) and SVG object
-    // URLs promptly; both caches are keyed by `_fetchImage`.
+    // Release this deck's decoded raster bitmaps (GPU-backed), duotone-recoloured
+    // rasters, and SVG object URLs promptly; all three caches are keyed by
+    // `_fetchImage`.
     dropImageBitmapCache(this._fetchImage);
+    dropDuotoneBitmapCache(this._fetchImage);
     dropSvgImageCache(this._fetchImage);
   }
 }

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -64,6 +64,7 @@ import {
   isCjkBreakChar,
   getCachedSvgImageByPath,
   getCachedBitmapByPath,
+  getCachedDuotoneBitmapByPath,
   peekCachedBitmapByPath,
   dropBitmapCacheByPath,
   preferVectorBlip,
@@ -3452,6 +3453,9 @@ export {
   getCachedBitmapByPath as getCachedBitmap,
   peekCachedBitmapByPath as peekCachedBitmap,
   dropBitmapCacheByPath as dropImageBitmapCache,
+  // Second-layer duotone (§20.1.8.23) recolour cache; dropped alongside the base
+  // bitmap cache on deck teardown.
+  dropDuotoneBitmapCache,
 } from '@silurus/ooxml-core';
 
 
@@ -3882,17 +3886,23 @@ async function renderPicture(
       try {
         bitmap = await getCachedSvgImageByPath(el.svgImagePath, fetchImage);
       } catch {
+        // §20.1.8.23 duotone recolour applies only to the raster fallback — an
+        // SVG vector original has no readable pixel grid (matches xlsx).
         bitmap = dataIsSvg
           ? await getCachedSvgImageByPath(el.imagePath, fetchImage)
-          : await getCachedBitmapByPath(el.imagePath, el.mimeType, fetchImage, { widthPt, heightPt });
+          : await getCachedDuotoneBitmapByPath(el.imagePath, el.mimeType, el.duotone, fetchImage, { widthPt, heightPt });
       }
     } else if (dataIsSvg) {
       // SVG-only picture (here either because it has a crop, or — defensively —
       // because no svgImagePath was surfaced): decode through the SVG path since
-      // createImageBitmap can't.
+      // createImageBitmap can't. A duotone on a vector picture is a rare edge
+      // case left un-recoloured (no readable pixel grid), matching xlsx.
       bitmap = await getCachedSvgImageByPath(el.imagePath, fetchImage);
     } else {
-      bitmap = await getCachedBitmapByPath(el.imagePath, el.mimeType, fetchImage, { widthPt, heightPt });
+      // §20.1.8.23 duotone recolour on the raster blip (once, at decode time,
+      // cached under a colour-suffixed key). No duotone ⇒ this is exactly the
+      // former `getCachedBitmapByPath` decode.
+      bitmap = await getCachedDuotoneBitmapByPath(el.imagePath, el.mimeType, el.duotone, fetchImage, { widthPt, heightPt });
     }
     // Skip a picture whose blip is an unsupported metafile (null bitmap), the
     // same way an SVG-decode failure that also fails its raster fallback would
@@ -4959,7 +4969,10 @@ export async function renderSlide(
           p.width / PT_TO_EMU,
           p.height / PT_TO_EMU,
         );
-        void getCachedBitmapByPath(p.imagePath, p.mimeType, opts.fetchImage, {
+        // Warm through the duotone cache so a §20.1.8.23 recolour picture warms
+        // its recoloured variant (keyed by path + colours); no duotone ⇒ this is
+        // the plain base-bitmap warm, byte-identical to before.
+        void getCachedDuotoneBitmapByPath(p.imagePath, p.mimeType, p.duotone, opts.fetchImage, {
           widthPt: warm.widthPt,
           heightPt: warm.heightPt,
         }).catch(() => undefined);

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -18,7 +18,7 @@ export type {
 // All positions and sizes are in EMUs (English Metric Units).
 // 914400 EMU = 1 inch, 12700 EMU = 1 pt
 
-import type { Bullet as CoreBullet, Fill, Stroke, TextBody as CoreTextBody, Paragraph as CoreParagraph, Shadow, Glow, SoftEdge, Reflection, PathCmd, ChartModel } from '@silurus/ooxml-core';
+import type { Bullet as CoreBullet, Fill, Stroke, TextBody as CoreTextBody, Paragraph as CoreParagraph, Shadow, Glow, SoftEdge, Reflection, PathCmd, ChartModel, Duotone } from '@silurus/ooxml-core';
 
 /**
  * Picture bullet — ECMA-376 §21.1.2.4.2 `<a:buBlip><a:blip r:embed>`. The
@@ -533,6 +533,13 @@ export interface PictureElement {
   srcRect?: { l: number; t: number; r: number; b: number };
   /** a:blip > a:alphaModFix@amt as 0..1. Undefined = fully opaque. */
   alpha?: number;
+  /**
+   * ECMA-376 §20.1.8.23 `<a:duotone>` recolour, resolved to its two endpoint
+   * colours (through the slide theme). Undefined ⇒ no duotone. When present the
+   * renderer decodes the raster once, remaps it along the `clr1`→`clr2`
+   * luminance ramp, and caches the recoloured bitmap under a colour-suffixed key.
+   */
+  duotone?: Duotone;
   /**
    * `<p:spPr><a:custGeom>` clipping path. Same `PathCmd` model as
    * `ShapeElement.custGeom` (one entry per `<a:path>`; coords normalized


### PR DESCRIPTION
Closes #886.

Wires the shared blip-duotone layer (`ooxml_common::blip::{Duotone, parse_blip_duotone}` + core `applyDuotone`, completed in #885 with the xlsx wiring) into the **pptx** and **docx** picture paths, following the xlsx precedent. Also wires docx **picture alphaModFix** (`§20.1.8.6`), which docx dropped entirely.

## Parsers
- **pptx** (`shape.rs`/`types.rs`): every `<p:pic>` and blipFill-painted shape resolves `<a:duotone>` through the slide theme (`PptxSchemeResolver`, PowerPoint linear tint) onto `PictureElement.duotone`.
- **docx** (`parser.rs`/`types.rs`): every inline / anchored / grouped `<pic:pic>` resolves `<a:duotone>` through the document theme (`DocxSchemeResolver`, Word literal tint) onto `ImageRun.duotone`; theme threaded through `resolve_inline_blip` + the group picture walk. **Separate commit**: `<a:alphaModFix>` opacity onto `ImageRun.alpha`.

## Renderers
- **core**: new `getCachedDuotoneBitmapByPath` — a second layer over the path-keyed base cache that recolours once per (path + colours), keyed by `duotoneCacheKey`. Lifts docx's existing two-layer recolour-cache shape into core so pptx reuses it. No duotone ⇒ byte-identical pass-through.
- **pptx**: picture decode routes through the core cache; prefetch warms the recoloured variant; deck teardown drops it. Only the raster blip is recoloured (SVG has no readable pixel grid), matching xlsx. Same path in main/worker/node.
- **docx**: extends its `decodeRaster`/`imageKey` to compose clrChange + duotone, keyed by `(path, colorReplaceFrom, duotone)`; applies `alphaModFix` via `globalAlpha` at the inline / wrapNone-anchor / wrap-float draw sites.

## Verification
- **Synthetic-fixture render probes (not committed)**: pptx & docx render a mid-grey picture with `black↔#DAB6BA` duotone → measured **RGB (109,91,93)** = the exact luminance-ramp interpolation (t≈0.502); docx `alphaModFix amt=50000` → measured **(191,191,191)** = `0.5·128 + 0.5·255` over white. Parser round-trip alone is not treated as proof.
- **Parse dump md5 invariance**: pptx & docx demo-sample parse output is **byte-identical** between origin/main and this branch (added fields are `skip_serializing_if = "Option::is_none"`).
- **Demo VRT byte-identical + worker-equivalent**: pptx 15 passed / docx 9 passed; docx worker-vs-main diff **0.000%**.
- **Gates**: `cargo fmt --check` clean · `clippy -D warnings` clean · Rust tests (pptx 158 / docx 292 / common 216) · root `tsc --build` clean · vitest (core+pptx+docx 1387, node render probes 3) · `ast-grep scan` (no new warnings).

Synthetic fixtures use XSD-`sequence`-correct `<a:blip><a:duotone>…</a:blip>` placement; no Office files committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)