### PR TITLE
fix(site): reveal sections taller than the viewport

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -37,7 +37,7 @@ const base = import.meta.env.BASE_URL;
             }
           }
         },
-        { threshold: 0.12 }
+        { threshold: 0, rootMargin: '0px 0px -12% 0px' }
       );
       document.querySelectorAll('[data-reveal]').forEach((el) => io.observe(el));
     </script>


### PR DESCRIPTION
The scroll-reveal IntersectionObserver in Base.astro used `threshold: 0.12` — an element much taller than the viewport can never reach 12% visibility (the ratio caps at viewportH/elementH), so it stays at `opacity: 0` forever. #890 grew the API-reference section to ~13,000px (viewport ≈ 800px → max ratio ≈ 6%), which made the API docs on /pptx/, /docx/ and /xlsx/ render as blank space. No console error, which is why CI/build checks stayed green.

Fix: `{ threshold: 0, rootMargin: '0px 0px -12% 0px' }` — fire on first intersection, with the bottom margin preserving the slight scroll-in delay for normal-sized sections.

Verified on a local production build (astro preview): API section reveals with opacity 1 on scroll on all three format pages; small sections keep the staggered fade-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)