### PR TITLE
fix(pptx,docx): make find/hyperlink/selection overlays track the canvas's actual CSS size

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -460,6 +460,6 @@ export {
   type TextMatch,
   type FindMatchesOptions,
 } from './search/text-index';
-export { sliceHorizontalExtent } from './search/highlight-rect';
+export { sliceHorizontalExtent, overlayPercent } from './search/highlight-rect';
 export { nextActive, prevActive, clampActive } from './search/find-cursor';
 export type { FindMatch } from './search/find-match';

--- a/packages/core/src/search/highlight-rect.test.ts
+++ b/packages/core/src/search/highlight-rect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sliceHorizontalExtent } from './highlight-rect.js';
+import { sliceHorizontalExtent, overlayPercent } from './highlight-rect.js';
 
 /**
  * IX2 highlight geometry. `sliceHorizontalExtent` measures the two prefixes of a
@@ -39,5 +39,25 @@ describe('sliceHorizontalExtent', () => {
     // Degenerate slice (start === end).
     const { width } = sliceHorizontalExtent('Hello', 3, 3, mono);
     expect(width).toBe(0);
+  });
+});
+
+describe('overlayPercent', () => {
+  it('expresses a coordinate as a percentage of the basis', () => {
+    expect(overlayPercent(480, 960)).toBe('50%');
+    expect(overlayPercent(0, 960)).toBe('0%');
+    expect(overlayPercent(960, 960)).toBe('100%');
+  });
+
+  it('is scale-invariant — a fraction reads the same regardless of the basis', () => {
+    // The same fractional position yields the same % whatever the intended box
+    // size is, which is why a %-placed overlay tracks a scaled canvas.
+    expect(overlayPercent(240, 960)).toBe(overlayPercent(120, 480));
+  });
+
+  it('yields 0% for a non-positive basis instead of NaN%/Infinity%', () => {
+    // Nothing laid out yet (basis 0) must not emit `NaN%`.
+    expect(overlayPercent(10, 0)).toBe('0%');
+    expect(overlayPercent(10, -5)).toBe('0%');
   });
 });

--- a/packages/core/src/search/highlight-rect.ts
+++ b/packages/core/src/search/highlight-rect.ts
@@ -34,3 +34,30 @@ export function sliceHorizontalExtent(
   const endX = end >= runText.length ? measure(runText) : measure(runText.slice(0, end));
   return { x, width: Math.max(0, endX - x) };
 }
+
+/**
+ * Express an overlay coordinate as a CSS **percentage** of the content box it is
+ * measured against, e.g. `overlayPercent(480, 960) === '50%'`.
+ *
+ * The find-highlight / text-selection / hyperlink overlays (docx + pptx) place
+ * their boxes over a `<canvas>` that a consumer may scale down with external CSS
+ * (`width:100%!important; height:auto`). If the overlay's coordinates were literal
+ * px (the slide's *intended* size) while the canvas rendered smaller, the boxes
+ * would overshoot the wrapper and push a scrollbar onto an ancestor's scroll area
+ * (the reported bug). Positioning every box as a `%` of the intended CSS box
+ * (`cssWidth`/`cssHeight`) instead makes it resolve against the container's
+ * ACTUAL rendered size — the wrapper is `display:inline-block`, so it tracks the
+ * scaled canvas, and each `%`-placed child scales with it. At 1× (no external
+ * scaling) the box lands on exactly the same pixels as the old px placement.
+ *
+ * A `0`/negative denominator (nothing laid out yet) yields `'0%'` so the caller
+ * never emits `NaN%`.
+ *
+ * @param value  the coordinate/length in the intended CSS-px space.
+ * @param basis  the intended CSS-px extent it is a fraction of (`cssWidth` for the
+ *               x axis, `cssHeight` for the y axis).
+ */
+export function overlayPercent(value: number, basis: number): string {
+  if (!(basis > 0)) return '0%';
+  return `${(value / basis) * 100}%`;
+}

--- a/packages/docx/src/Examples.stories.ts
+++ b/packages/docx/src/Examples.stories.ts
@@ -95,7 +95,11 @@ export const ScrollView: LayoutStory = {
 
           const runs: DocxTextRunInfo[] = [];
           await doc.renderPage(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
-          buildDocxTextLayer(textLayer, runs, '100%', '100%');
+          // Pass the page's intended CSS box (px) as the % denominators. The
+          // canvas is scaled responsively (width:100%;max-width:700px), and the
+          // overlay's %-placed spans track that actual rendered size.
+          const cssHeight = parseFloat(canvas.style.height) || canvas.height;
+          buildDocxTextLayer(textLayer, runs, widthPx, cssHeight);
         }
         status.textContent = `Loaded ${doc.pageCount} pages`;
       })

--- a/packages/docx/src/find-highlight-layer.test.ts
+++ b/packages/docx/src/find-highlight-layer.test.ts
@@ -71,18 +71,23 @@ describe('buildDocxHighlightLayer', () => {
       layer as unknown as HTMLDivElement,
       runs,
       matches,
-      '700px',
-      '900px',
+      700,
+      900,
       measureForFont,
     );
+    // The overlay container keeps its `width:100%;height:100%` so it tracks the
+    // canvas's actual rendered box; the build must not pin it to literal px.
+    expect(layer.style.width ?? '').toBe('');
+    expect(layer.style.height ?? '').toBe('');
     expect(layer.children).toHaveLength(1);
     const box = layer.children[0];
-    // left = run.x (100) + prefix "the " width (4*7=28) = 128.
-    expect(box.style.left).toBe('128px');
-    expect(box.style.top).toBe('50px');
-    // width = "quick" (5*7=35).
-    expect(box.style.width).toBe('35px');
-    expect(box.style.height).toBe('16px');
+    // Box positioned as a PERCENTAGE of cssWidth/cssHeight so it scales with the
+    // container: left = (run.x 100 + prefix "the " 28) / 700; top = 50 / 900;
+    // width = 35 / 700; height = 16 / 900.
+    expect(box.style.left).toBe(`${(128 / 700) * 100}%`);
+    expect(box.style.top).toBe(`${(50 / 900) * 100}%`);
+    expect(box.style.width).toBe(`${(35 / 700) * 100}%`);
+    expect(box.style.height).toBe(`${(16 / 900) * 100}%`);
     expect(box.style.background).toBe(DEFAULT_FIND_HIGHLIGHT);
     expect(box.style['pointer-events']).toBe('none');
   });
@@ -94,7 +99,7 @@ describe('buildDocxHighlightLayer', () => {
     const matches: DocxHighlightMatch[] = [
       { slices: [{ runIndex: 0, start: 0, end: 3 }], active: true },
     ];
-    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 1, 1, measureForFont);
     expect(layer.children[0].style.background).toBe(DEFAULT_FIND_ACTIVE_HIGHLIGHT);
   });
 
@@ -111,10 +116,11 @@ describe('buildDocxHighlightLayer', () => {
         active: false,
       },
     ];
-    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    // cssWidth = 100 so the percentage reads directly as the px value.
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 100, 100, measureForFont);
     expect(layer.children).toHaveLength(2);
-    expect(layer.children[0].style.left).toBe('0px'); // run 0 origin
-    expect(layer.children[1].style.left).toBe('21px'); // run 1 origin
+    expect(layer.children[0].style.left).toBe('0%'); // run 0 origin (0/100)
+    expect(layer.children[1].style.left).toBe(`${(21 / 100) * 100}%`); // run 1 origin
   });
 
   it('carries the run transform for a vertical (tbRl) page', () => {
@@ -124,7 +130,7 @@ describe('buildDocxHighlightLayer', () => {
     const matches: DocxHighlightMatch[] = [
       { slices: [{ runIndex: 0, start: 0, end: 3 }], active: false },
     ];
-    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 1, 1, measureForFont);
     expect(layer.children[0].style.transform).toBe('rotate(90deg)');
   });
 
@@ -143,12 +149,13 @@ describe('buildDocxHighlightLayer', () => {
     const matches: DocxHighlightMatch[] = [
       { slices: [{ runIndex: 0, start: 0, end: 2 }], active: false },
     ];
-    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    // cssWidth = 100 so a percentage reads directly as the px value.
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 100, 100, measureForFont);
     expect(layer.children).toHaveLength(1);
     const box = layer.children[0];
     // Clamped: box starts at the run origin and spans exactly the one-em cell.
-    expect(box.style.left).toBe('30px');
-    expect(box.style.width).toBe('7px'); // the cell, NOT 14px natural
+    expect(box.style.left).toBe(`${(30 / 100) * 100}%`);
+    expect(box.style.width).toBe(`${(7 / 100) * 100}%`); // the cell, NOT 14px natural
     // The rotate transform (vertical page) is preserved.
     expect(box.style.transform).toBe('rotate(90deg)');
   });
@@ -164,10 +171,11 @@ describe('buildDocxHighlightLayer', () => {
     const matches: DocxHighlightMatch[] = [
       { slices: [{ runIndex: 0, start: 1, end: 2 }], active: false },
     ];
-    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    // cssWidth = 100 so a percentage reads directly as the px value.
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 100, 100, measureForFont);
     const box = layer.children[0];
-    expect(box.style.left).toBe('3.5px');
-    expect(box.style.width).toBe('3.5px');
+    expect(box.style.left).toBe(`${(3.5 / 100) * 100}%`);
+    expect(box.style.width).toBe(`${(3.5 / 100) * 100}%`);
   });
 
   it('leaves a non-eastAsianVert run measured at natural width (unchanged)', () => {
@@ -179,8 +187,9 @@ describe('buildDocxHighlightLayer', () => {
     const matches: DocxHighlightMatch[] = [
       { slices: [{ runIndex: 0, start: 0, end: 2 }], active: false },
     ];
-    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
-    expect(layer.children[0].style.width).toBe('14px');
+    // cssWidth = 100 so the 14px natural extent reads as 14%.
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 100, 100, measureForFont);
+    expect(layer.children[0].style.width).toBe(`${(14 / 100) * 100}%`);
   });
 
   it('clears the layer and skips zero-width slices', () => {
@@ -191,7 +200,7 @@ describe('buildDocxHighlightLayer', () => {
     const matches: DocxHighlightMatch[] = [
       { slices: [{ runIndex: 0, start: 1, end: 1 }], active: false }, // degenerate
     ];
-    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, '1px', '1px', measureForFont);
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 1, 1, measureForFont);
     expect(layer.innerHTML).toBe('');
     expect(layer.children).toHaveLength(0);
   });

--- a/packages/docx/src/find-highlight-layer.ts
+++ b/packages/docx/src/find-highlight-layer.ts
@@ -20,7 +20,7 @@
  * distinct emphasis colour so the user can tell it apart from the other hits,
  * matching a browser find bar's current-vs-other highlighting.
  */
-import { sliceHorizontalExtent, type MatchRunSlice } from '@silurus/ooxml-core';
+import { sliceHorizontalExtent, overlayPercent, type MatchRunSlice } from '@silurus/ooxml-core';
 import type { DocxTextRunInfo } from './renderer';
 import { tateChuYokoOverlayScale } from './tate-chu-yoko-overlay';
 
@@ -47,11 +47,17 @@ export interface DocxHighlightColors {
 /**
  * Populate a highlight overlay layer with one box per matched run-slice.
  *
- * @param layer    the overlay div (cleared and re-sized to the canvas here).
+ * Every box is positioned as a PERCENTAGE of `cssWidth`/`cssHeight`, and the
+ * container's own size is left untouched (`width:100%;height:100%` from the
+ * caller), so the highlights track the canvas's ACTUAL rendered box even when a
+ * consumer scales the canvas down with external CSS — mirroring
+ * {@link buildDocxTextLayer}.
+ *
+ * @param layer    the overlay div (cleared here; sized `100%` by the caller).
  * @param runs     the page's runs (same array the page was rendered/text-layered from).
  * @param matches  the page's matches (run-slices + active flag).
- * @param canvasCssWidth  the rendered canvas's CSS width (e.g. `"700px"`).
- * @param canvasCssHeight the rendered canvas's CSS height.
+ * @param cssWidth  the page's intended CSS width (px, number) — the x-axis % denominator.
+ * @param cssHeight the page's intended CSS height (px, number) — the y-axis % denominator.
  * @param measureForFont  returns a width-measurer primed with a run's `font`
  *                        (the viewer closes over a canvas 2d context). Kept as a
  *                        factory so the font is set once per run, not per glyph.
@@ -61,14 +67,12 @@ export function buildDocxHighlightLayer(
   layer: HTMLDivElement,
   runs: DocxTextRunInfo[],
   matches: DocxHighlightMatch[],
-  canvasCssWidth: string,
-  canvasCssHeight: string,
+  cssWidth: number,
+  cssHeight: number,
   measureForFont: (font: string) => (s: string) => number,
   colors: DocxHighlightColors = {},
 ): void {
   layer.innerHTML = '';
-  layer.style.width = canvasCssWidth;
-  layer.style.height = canvasCssHeight;
 
   const matchColor = colors.match ?? DEFAULT_FIND_HIGHLIGHT;
   const activeColor = colors.active ?? DEFAULT_FIND_ACTIVE_HIGHLIGHT;
@@ -98,10 +102,14 @@ export function buildDocxHighlightLayer(
       const transform = run.transform
         ? `transform:${run.transform};transform-origin:top left;`
         : '';
+      // Positioned as a % of the page's intended CSS box so the box scales with
+      // the container under external CSS scaling. A vertical (tbRl) run's
+      // transform is about `top left`, so the %-placed origin rotates into the
+      // column exactly as before at 1× scale.
       box.style.cssText =
         `position:absolute;` +
-        `left:${run.x + x}px;top:${run.y}px;` +
-        `width:${width}px;height:${run.h}px;` +
+        `left:${overlayPercent(run.x + x, cssWidth)};top:${overlayPercent(run.y, cssHeight)};` +
+        `width:${overlayPercent(width, cssWidth)};height:${overlayPercent(run.h, cssHeight)};` +
         transform +
         `background:${fill};pointer-events:none;`;
       layer.appendChild(box);

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -954,7 +954,7 @@ describe('DocxScrollViewer — text selection (T5)', () => {
     v.destroy();
   });
 
-  it('main mode: sizes the overlay to the slot canvas CSS size', async () => {
+  it('leaves the overlay container at 100% so it tracks the slot box', async () => {
     installDom();
     const container = makeContainer(200, 400);
     const engine = new FakeDocxEngine(1, [{ widthPt: 100, heightPt: 200 }]);
@@ -970,15 +970,15 @@ describe('DocxScrollViewer — text selection (T5)', () => {
     await Promise.resolve();
     await Promise.resolve();
     const wrapper = findSlotWrapper(scrollHost);
-    const canvas = wrapper.children.find((c) => c.tag === 'canvas') as FakeEl;
     const textLayer = findTextLayer(wrapper);
-    // buildDocxTextLayer sizes the layer to the canvas CSS width/height. The
-    // main renderPage owns the canvas so its CSS size falls back to
-    // `${canvas.width}px` — either way the overlay must match the canvas.
-    const expectW = canvas.style.width || `${canvas.width}px`;
-    const expectH = canvas.style.height || `${canvas.height}px`;
-    expect(textLayer.style.width).toBe(expectW);
-    expect(textLayer.style.height).toBe(expectH);
+    // buildDocxTextLayer no longer pins the overlay to a literal px size: the
+    // container keeps its creation `width:100%;height:100%` so it tracks the
+    // slot wrapper's actual box (which the slot sizes in px), and every
+    // %-placed span scales with a canvas a consumer shrinks via external CSS.
+    expect(textLayer.style.width).toBe('100%');
+    expect(textLayer.style.height).toBe('100%');
+    // The wrapper IS sized to the page CSS box, so `100%` resolves to it.
+    expect(wrapper.style.width).toBe('180px'); // 100pt × PT_TO_PX (1.8) — see _pageWidthPx
     v.destroy();
   });
 

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -821,11 +821,12 @@ export class DocxScrollViewer implements ZoomableViewer {
         // so a subsequent zoom preview stretches from HERE.
         slot.renderedScale = scale;
         if (wantOverlay && slot.textLayer) {
+          const { width, height } = this._canvasCssPx(slot.canvas);
           buildDocxTextLayer(
             slot.textLayer,
             runs,
-            slot.canvas.style.width || `${slot.canvas.width}px`,
-            slot.canvas.style.height || `${slot.canvas.height}px`,
+            width,
+            height,
             this._hyperlinkHandler(),
             (font) => this._measureForFont(font),
           );
@@ -876,6 +877,16 @@ export class DocxScrollViewer implements ZoomableViewer {
     if (!ctx) return (s) => s.length;
     ctx.font = font;
     return (s) => ctx.measureText(s).width;
+  }
+
+  /** A canvas's intended CSS box in px (the % denominators the overlay builders
+   *  expect). Reads the inline `style.width`/`height` set by the render path,
+   *  falling back to the backing-store size when unset; tolerates the `px` suffix. */
+  private _canvasCssPx(canvas: HTMLCanvasElement): { width: number; height: number } {
+    return {
+      width: parseFloat(canvas.style.width) || canvas.width,
+      height: parseFloat(canvas.style.height) || canvas.height,
+    };
   }
 
   /** Route an async render failure to `onError`, or `console.error` when none is
@@ -983,11 +994,12 @@ export class DocxScrollViewer implements ZoomableViewer {
         slot.textLayer.style.transform = '';
         slot.textLayer.style.transformOrigin = '';
         if (wantOverlay) {
+          const { width, height } = this._canvasCssPx(slot.canvas);
           buildDocxTextLayer(
             slot.textLayer,
             runs,
-            slot.canvas.style.width || `${slot.canvas.width}px`,
-            slot.canvas.style.height || `${slot.canvas.height}px`,
+            width,
+            height,
             this._hyperlinkHandler(),
             (font) => this._measureForFont(font),
           );
@@ -1394,11 +1406,12 @@ export class DocxScrollViewer implements ZoomableViewer {
           slot.textLayer.style.transform = '';
           slot.textLayer.style.transformOrigin = '';
           if (wantOverlay) {
+            const { width, height } = this._canvasCssPx(spare);
             buildDocxTextLayer(
               slot.textLayer,
               runs,
-              spare.style.width || `${spare.width}px`,
-              spare.style.height || `${spare.height}px`,
+              width,
+              height,
               this._hyperlinkHandler(),
               (font) => this._measureForFont(font),
             );

--- a/packages/docx/src/text-layer-hyperlink.test.ts
+++ b/packages/docx/src/text-layer-hyperlink.test.ts
@@ -89,8 +89,8 @@ describe('buildDocxTextLayer — IX1 clickable hyperlinks', () => {
     buildDocxTextLayer(
       layer as unknown as HTMLDivElement,
       runs,
-      '700px',
-      '900px',
+      700,
+      900,
       onHyperlinkClick,
     );
 
@@ -126,8 +126,8 @@ describe('buildDocxTextLayer — IX1 clickable hyperlinks', () => {
     buildDocxTextLayer(
       layer as unknown as HTMLDivElement,
       [run({ text: 'jump', hyperlink: internal })],
-      '700px',
-      '900px',
+      700,
+      900,
       onHyperlinkClick,
     );
 
@@ -145,8 +145,8 @@ describe('buildDocxTextLayer — IX1 clickable hyperlinks', () => {
     buildDocxTextLayer(
       layer as unknown as HTMLDivElement,
       [run({ text: 'link', hyperlink: EXTERNAL })],
-      '700px',
-      '900px',
+      700,
+      900,
     );
 
     const [span] = layer.children;

--- a/packages/docx/src/text-layer.test.ts
+++ b/packages/docx/src/text-layer.test.ts
@@ -63,14 +63,17 @@ function run(partial: Partial<DocxTextRunInfo>): DocxTextRunInfo {
 }
 
 describe('buildDocxTextLayer (extracted from DocxViewer._buildTextLayer)', () => {
-  it('sizes the layer to the passed canvas dimensions and clears prior content', () => {
+  it('does not pin the layer to a literal px size and clears prior content', () => {
     vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
     const layer = makeEl('div');
     layer.innerHTML = 'STALE';
-    buildDocxTextLayer(layer as unknown as HTMLDivElement, [], '640px', '480px');
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, [], 640, 480);
     expect(layer.innerHTML).toBe(''); // cleared
-    expect(layer.style.width).toBe('640px');
-    expect(layer.style.height).toBe('480px');
+    // The overlay container keeps its creation `width:100%;height:100%` so it
+    // tracks the canvas's ACTUAL rendered box (external CSS may scale the canvas
+    // responsively). The build must NOT overwrite it with a literal px size.
+    expect(layer.style.width ?? '').toBe('');
+    expect(layer.style.height ?? '').toBe('');
     expect(layer.children.length).toBe(0);
   });
 
@@ -81,17 +84,19 @@ describe('buildDocxTextLayer (extracted from DocxViewer._buildTextLayer)', () =>
       run({ text: 'Hello', x: 12, y: 34, h: 16, font: 'bold 14px Arial' }),
       run({ text: 'World', x: 50, y: 34, h: 16, font: '14px Arial' }),
     ];
-    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, '700px', '900px');
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, 700, 900);
 
     expect(layer.children.length).toBe(2);
     const [a, b] = layer.children;
     expect(a.tag).toBe('span');
     expect(a.textContent).toBe('Hello');
-    // Shipped style contract: absolute position from run.x/run.y, the CSS `font`
-    // shorthand BEFORE line-height, letter-spacing reset, transparent selectable text.
+    // Shipped style contract: absolute position from run.x/run.y expressed as a
+    // PERCENTAGE of cssWidth/cssHeight (so the span tracks the canvas's actual
+    // rendered size), the CSS `font` shorthand BEFORE line-height, letter-spacing
+    // reset, transparent selectable text.
     expect(a.style.position).toBe('absolute');
-    expect(a.style.left).toBe('12px');
-    expect(a.style.top).toBe('34px');
+    expect(a.style.left).toBe(`${(12 / 700) * 100}%`);
+    expect(a.style.top).toBe(`${(34 / 900) * 100}%`);
     expect(a.style.font).toBe('bold 14px Arial');
     expect(a.style['line-height']).toBe('16px');
     expect(a.style['letter-spacing']).toBe('0');
@@ -105,7 +110,7 @@ describe('buildDocxTextLayer (extracted from DocxViewer._buildTextLayer)', () =>
     // the raw string.
     expect(a.style.cssText).toMatch(/font:[^;]+;line-height:/);
     expect(b.textContent).toBe('World');
-    expect(b.style.left).toBe('50px');
+    expect(b.style.left).toBe(`${(50 / 700) * 100}%`);
   });
 
   // ECMA-376 §17.3.2.10 縦中横 (#836): a tate-chu-yoko run is drawn compressed into
@@ -121,7 +126,7 @@ describe('buildDocxTextLayer (extracted from DocxViewer._buildTextLayer)', () =>
       run({ text: '２９', x: 30, y: 40, w: 7, h: 16, fontSize: 7, font: '7px serif', eastAsianVert: true, transform: 'rotate(90deg)' }),
     ];
     const measureForFont = () => (s: string) => [...s].length * 7;
-    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, '1px', '1px', undefined, measureForFont);
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, 1, 1, undefined, measureForFont);
     const span = layer.children[0];
     // The rotate is preceded by scaleX(0.5) so the natural 14px width compresses to
     // the 7px cell BEFORE rotating into the column (transform-origin top-left).
@@ -135,7 +140,7 @@ describe('buildDocxTextLayer (extracted from DocxViewer._buildTextLayer)', () =>
     const runs = [
       run({ text: '２９', w: 7, fontSize: 7, eastAsianVert: true, transform: 'rotate(90deg)' }),
     ];
-    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, '1px', '1px');
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, 1, 1);
     // No measurer ⇒ the scale cannot be computed; the span keeps the bare rotate
     // (byte-identical to the pre-#836 overlay — no regression when the caller
     // does not thread a measurer).
@@ -147,7 +152,7 @@ describe('buildDocxTextLayer (extracted from DocxViewer._buildTextLayer)', () =>
     const layer = makeEl('div');
     const runs = [run({ text: 'Hello', x: 12, font: '14px Arial' })];
     const measureForFont = () => (s: string) => s.length * 8;
-    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, '1px', '1px', undefined, measureForFont);
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, 1, 1, undefined, measureForFont);
     // Ordinary run: no transform at all (horizontal page), so no scaleX sneaks in.
     expect(layer.children[0].style.transform ?? '').toBe('');
   });

--- a/packages/docx/src/text-layer.ts
+++ b/packages/docx/src/text-layer.ts
@@ -1,5 +1,5 @@
 import type { DocxTextRunInfo } from './renderer';
-import type { HyperlinkTarget } from '@silurus/ooxml-core';
+import { overlayPercent, type HyperlinkTarget } from '@silurus/ooxml-core';
 import { tateChuYokoOverlayScale } from './tate-chu-yoko-overlay';
 
 /**
@@ -13,11 +13,21 @@ import { tateChuYokoOverlayScale } from './tate-chu-yoko-overlay';
  * the same `DocxTextRunInfo[]` off-thread and ships it back beside the bitmap, so
  * the overlay is built from identical geometry regardless of thread.
  *
- * @param layer            the overlay div (position:relative parent expected).
+ * Every span is positioned as a PERCENTAGE of `cssWidth`/`cssHeight` (the page's
+ * intended CSS-px box), never literal px, and the container's own width/height are
+ * left untouched (the caller sizes it `width:100%;height:100%`). This lets the
+ * overlay track the canvas's ACTUAL rendered box even when a consumer scales the
+ * canvas down with external CSS (`width:100%!important; height:auto`): the
+ * `display:inline-block` wrapper shrinks with the canvas, the `100%` container
+ * follows, and every `%`-placed span scales with it, so nothing overflows the
+ * wrapper into an ancestor's scroll area.
+ *
+ * @param layer            the overlay div (sized `width:100%;height:100%` by the caller).
  * @param runs             per-run geometry from `renderPage({ onTextRun })`.
- * @param canvasCssWidth   the rendered canvas's CSS width (e.g. `"700px"`), used
- *                         to size the overlay to match the canvas.
- * @param canvasCssHeight  the rendered canvas's CSS height.
+ * @param cssWidth         the page's intended CSS width (px, number) — the %
+ *                         denominator for the x axis.
+ * @param cssHeight        the page's intended CSS height (px, number) — the %
+ *                         denominator for the y axis.
  * @param onHyperlinkClick IX1 — invoked when a run carrying a resolved
  *                         {@link HyperlinkTarget} is clicked. A hyperlink run's
  *                         span keeps its transparent glyphs (the visible link
@@ -40,14 +50,12 @@ import { tateChuYokoOverlayScale } from './tate-chu-yoko-overlay';
 export function buildDocxTextLayer(
   layer: HTMLDivElement,
   runs: DocxTextRunInfo[],
-  canvasCssWidth: string,
-  canvasCssHeight: string,
+  cssWidth: number,
+  cssHeight: number,
   onHyperlinkClick?: (target: HyperlinkTarget) => void,
   measureForFont?: (font: string) => (s: string) => number,
 ): void {
   layer.innerHTML = '';
-  layer.style.width = canvasCssWidth;
-  layer.style.height = canvasCssHeight;
 
   for (const run of runs) {
     const span = document.createElement('span');
@@ -85,9 +93,15 @@ export function buildDocxTextLayer(
     // identical to a plain run. A non-link run is byte-identical to before.
     const link = onHyperlinkClick ? run.hyperlink : undefined;
     const cursor = link ? 'pointer' : 'text';
+    // Position the span as a % of the page's intended CSS box so it tracks the
+    // canvas's actual rendered size under external CSS scaling. `font` /
+    // `line-height` stay px (the glyph metrics of the transparent hit text laid
+    // out inside the box); the box position is what must track the canvas. A
+    // vertical (tbRl) run's rotate is about `top left`, so the %-placed origin
+    // rotates into the column exactly as before at 1× scale.
     span.style.cssText =
       `position:absolute;` +
-      `left:${run.x}px;top:${run.y}px;` +
+      `left:${overlayPercent(run.x, cssWidth)};top:${overlayPercent(run.y, cssHeight)};` +
       `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
       transform +
       `white-space:pre;color:transparent;cursor:${cursor};pointer-events:all;`;

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -536,17 +536,26 @@ export class DocxViewer implements ZoomableViewer {
   private _buildHighlightLayer(runs: DocxTextRunInfo[]): void {
     const layer = this._highlightLayer;
     if (!layer) return;
-    const cssWidth = this._canvas.style.width || this._canvas.width + 'px';
-    const cssHeight = this._canvas.style.height || this._canvas.height + 'px';
+    const { width, height } = this._canvasCssPx();
     const highlights: DocxHighlightMatch[] = this._find.pageHighlights(this._currentPage);
     buildDocxHighlightLayer(
       layer,
       runs,
       highlights,
-      cssWidth,
-      cssHeight,
+      width,
+      height,
       (font) => this._measureForFont(font),
     );
+  }
+
+  /** The canvas's intended CSS box in px (the % denominators the overlay builders
+   *  expect). Reads the inline `style.width`/`height` set by the render path
+   *  (which mirror the render's logical size), falling back to the backing-store
+   *  dimensions when unset. Parsing tolerates the trailing `px`. */
+  private _canvasCssPx(): { width: number; height: number } {
+    const w = parseFloat(this._canvas.style.width) || this._canvas.width;
+    const h = parseFloat(this._canvas.style.height) || this._canvas.height;
+    return { width: w, height: h };
   }
 
   /** A width-measurer primed with `font`, backed by a private 1×1 canvas so it
@@ -585,11 +594,12 @@ export class DocxViewer implements ZoomableViewer {
   }
 
   private _buildTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): void {
+    const { width, height } = this._canvasCssPx();
     buildDocxTextLayer(
       layer,
       runs,
-      this._canvas.style.width || this._canvas.width + 'px',
-      this._canvas.style.height || this._canvas.height + 'px',
+      width,
+      height,
       this._hyperlinkHandler(),
       // §17.3.2.10 縦中横 (#836) — the same measurer the highlight overlay uses,
       // so a tate-chu-yoko selection span is clamped to its drawn one-em cell.

--- a/packages/docx/tests/visual/responsive-overlay-fixture.html
+++ b/packages/docx/tests/visual/responsive-overlay-fixture.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    /* A scrollable stage with a fixed max-height, holding a viewer whose canvas
+       is scaled DOWN by external CSS (the recommended responsive pattern). The
+       `!important` overrides mimic a consumer's responsive stylesheet. */
+    #stage {
+      max-width: 480px;
+      max-height: 600px;
+      overflow: auto;      /* the ancestor whose scroll{Width,Height} we assert */
+      border: 1px solid #ccc;
+      padding: 11px 22px;  /* asymmetric padding */
+    }
+    #stage canvas {
+      display: block !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      height: auto !important;
+      background: #fff;
+    }
+  </style>
+</head>
+<body>
+  <!-- Regression twin of the pptx responsive-overlay fixture: the docx
+       find-highlight + text-selection overlays must track the canvas's ACTUAL
+       (externally scaled) CSS size, so they never overflow the wrapper and push a
+       scrollbar onto the #stage scroll area. -->
+  <div id="stage"></div>
+  <script type="module">
+    import { DocxViewer } from '/src/index.ts';
+
+    const params = new URLSearchParams(location.search);
+    const name = params.get('docx') ?? 'demo/sample-1';
+    const query = params.get('q') ?? 'the';
+
+    try {
+      const stage = document.getElementById('stage');
+      const canvas = document.createElement('canvas');
+      stage.appendChild(canvas);
+
+      const resp = await fetch(`/${name}.docx`);
+      if (!resp.ok) throw new Error(`fetch ${name}.docx -> ${resp.status}`);
+      const buf = await resp.arrayBuffer();
+
+      // width: 794 ≈ an A4 page at 96dpi (the intended CSS box). The external CSS
+      // scales the rendered canvas down to fit #stage.
+      const viewer = new DocxViewer(canvas, {
+        width: 794,
+        enableTextSelection: true,
+        useGoogleFonts: true,
+      });
+      await viewer.load(buf);
+      await viewer.findText(query);
+      await viewer.findNext();
+
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+      const wrapper = canvas.parentElement;
+      const overlayLayers = [...wrapper.children].filter((c) => c.tagName === 'DIV');
+      const overlayRects = overlayLayers.map((l) => {
+        const r = l.getBoundingClientRect();
+        return { w: Math.round(r.width), h: Math.round(r.height) };
+      });
+      const canvasRect = canvas.getBoundingClientRect();
+
+      document.body.dataset.result = JSON.stringify({
+        stageScrollWidth: stage.scrollWidth,
+        stageClientWidth: stage.clientWidth,
+        stageScrollHeight: stage.scrollHeight,
+        stageClientHeight: stage.clientHeight,
+        canvasCssWidth: Math.round(canvasRect.width),
+        canvasCssHeight: Math.round(canvasRect.height),
+        overlayRects,
+      });
+      viewer.destroy();
+      document.body.dataset.status = 'ready';
+    } catch (err) {
+      document.body.dataset.status = 'error';
+      document.body.dataset.errorMessage = err.message;
+      console.error('[responsive-overlay-fixture] error:', err);
+    }
+  </script>
+</body>
+</html>

--- a/packages/docx/tests/visual/responsive-overlay.spec.ts
+++ b/packages/docx/tests/visual/responsive-overlay.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression twin of the pptx responsive-overlay spec (same reported bug on
+ * https://ooxml.silurus.dev): the docx find-highlight / text-selection overlays
+ * placed literal-px boxes sized to the page's INTENDED CSS box over a `<canvas>`
+ * a consumer had scaled DOWN with external CSS, so the oversized overlay pushed a
+ * scrollbar onto the ancestor scroll area.
+ *
+ * The fix positions every overlay box as a PERCENTAGE of the intended CSS box and
+ * leaves the container at `width:100%;height:100%` so it tracks the canvas's
+ * ACTUAL rendered size. This spec asserts the stage never gains a scrollbar and
+ * the overlay layers match the scaled canvas — not the intended box.
+ */
+test('find/selection overlays do not overflow a scaled-canvas scroll area › demo/sample-1', async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.goto('/tests/visual/responsive-overlay-fixture.html?docx=demo/sample-1&q=the');
+  await page.waitForFunction(
+    () => document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
+    { timeout: 90_000 },
+  );
+  const status = await page.evaluate(() => document.body.dataset.status);
+  if (status === 'error') {
+    throw new Error(await page.evaluate(() => document.body.dataset.errorMessage ?? ''));
+  }
+
+  const r = JSON.parse(await page.evaluate(() => document.body.dataset.result ?? '{}')) as {
+    stageScrollWidth: number;
+    stageClientWidth: number;
+    stageScrollHeight: number;
+    stageClientHeight: number;
+    canvasCssWidth: number;
+    canvasCssHeight: number;
+    overlayRects: { w: number; h: number }[];
+  };
+
+  // Precondition: the canvas really was scaled DOWN below its intended 794px box.
+  expect(r.canvasCssWidth).toBeLessThan(794);
+  expect(r.canvasCssWidth).toBeGreaterThan(0);
+
+  // The reported symptom is a HORIZONTAL scrollbar from the oversized overlay
+  // (width 794 while the canvas rendered ~480): the horizontal scroll area must
+  // NOT overflow (±1px layout slack). Vertical scrolling is legitimate here — a
+  // docx page is genuinely taller than the stage — so it is asserted via the
+  // overlay-tracks-canvas check below, which pins BOTH axes of the overlay to the
+  // scaled canvas (an over-tall overlay would fail it) without conflating with the
+  // page's own height.
+  expect(r.stageScrollWidth).toBeLessThanOrEqual(r.stageClientWidth + 1);
+
+  // The overlay layers track the SCALED canvas on BOTH axes, not the intended
+  // 794px box — this is the direct fix assertion: an overlay pinned to the
+  // intended box (the bug) would be wider AND taller than the scaled canvas.
+  expect(r.overlayRects.length).toBeGreaterThan(0);
+  for (const rect of r.overlayRects) {
+    expect(Math.abs(rect.w - r.canvasCssWidth)).toBeLessThanOrEqual(1);
+    expect(Math.abs(rect.h - r.canvasCssHeight)).toBeLessThanOrEqual(1);
+  }
+});

--- a/packages/docx/tests/visual/worker-selection-fixture.html
+++ b/packages/docx/tests/visual/worker-selection-fixture.html
@@ -32,26 +32,43 @@
       const wrapper = host.querySelector('div'); // the viewer's positioned wrapper
       return wrapper ? [...wrapper.children].filter((c) => c.tagName === 'DIV') : [];
     };
+    // Read RESOLVED pixel geometry (getBoundingClientRect), relative to the
+    // wrapper's top-left, rather than parsing the inline `style.left` string.
+    // The overlay coordinates are CSS PERCENTAGES (so the overlay tracks a canvas
+    // a consumer scales down), and a percentage is scale-invariant — it would not
+    // follow the zoom if read verbatim. The laid-out px position DOES follow the
+    // zoom (page geometry px = pt × scale), which is what this spec asserts, and
+    // is identical whether the CSS is px or %.
+    const wrapperRect = (host) => host.querySelector('div').getBoundingClientRect();
     // Wrapper stacking order: [canvas, textLayer, highlightLayer].
     const serializeOverlay = (host) => {
       const layer = layersOf(host)[0];
       const spans = layer ? [...layer.querySelectorAll('span')] : [];
-      return spans.map((s) => ({
-        text: s.textContent,
-        left: Math.round(parseFloat(s.style.left) || 0),
-        top: Math.round(parseFloat(s.style.top) || 0),
-      }));
+      const wr = wrapperRect(host);
+      return spans.map((s) => {
+        const r = s.getBoundingClientRect();
+        return {
+          text: s.textContent,
+          left: Math.round(r.left - wr.left),
+          top: Math.round(r.top - wr.top),
+        };
+      });
     };
-    // IX2 highlight boxes (absolutely positioned divs in the LAST layer).
+    // IX2 highlight boxes (absolutely positioned divs in the LAST layer). Read
+    // resolved px relative to the wrapper.
     const serializeHighlights = (host) => {
       const layers = layersOf(host);
       const layer = layers[layers.length - 1];
       const boxes = layer ? [...layer.children] : [];
-      return boxes.map((b) => ({
-        left: Math.round(parseFloat(b.style.left) || 0),
-        top: Math.round(parseFloat(b.style.top) || 0),
-        width: Math.round(parseFloat(b.style.width) || 0),
-      }));
+      const wr = wrapperRect(host);
+      return boxes.map((b) => {
+        const r = b.getBoundingClientRect();
+        return {
+          left: Math.round(r.left - wr.left),
+          top: Math.round(r.top - wr.top),
+          width: Math.round(r.width),
+        };
+      });
     };
 
     const capture = (host, viewer, canvas) => ({

--- a/packages/node/src/docx-find-highlight.test.ts
+++ b/packages/node/src/docx-find-highlight.test.ts
@@ -174,8 +174,8 @@ describe.skipIf(!skia || !docxMod || !rendererMod || !findMod || !highlightMod |
           layer: unknown,
           runs: Run[],
           matches: { slices: { runIndex: number; start: number; end: number }[]; active: boolean }[],
-          w: string,
-          h: string,
+          w: number,
+          h: number,
           measureForFont: (font: string) => (s: string) => number,
         ) => void;
       };
@@ -209,8 +209,8 @@ describe.skipIf(!skia || !docxMod || !rendererMod || !findMod || !highlightMod |
           layer as unknown as HTMLDivElement,
           runs,
           highlights,
-          '800px',
-          '1000px',
+          800,
+          1000,
           measureForFont,
         );
       } finally {
@@ -222,13 +222,20 @@ describe.skipIf(!skia || !docxMod || !rendererMod || !findMod || !highlightMod |
       // right ≤ run.x + run.w (+1px slack for sub-pixel rounding), top == run.y,
       // and a positive width. This is the pixel-level "highlight lands on the
       // glyphs" assertion.
+      //
+      // buildDocxHighlightLayer positions each box as a PERCENTAGE of the
+      // cssWidth/cssHeight passed above (800/1000) — the % denominators — so
+      // convert the parsed percentage back to px against that same basis before
+      // comparing to the run's real (px) render geometry.
+      const CSS_W = 800;
+      const CSS_H = 1000;
       const firstSlice = highlights.find((h) => h.slices.length)?.slices[0];
       expect(firstSlice).toBeDefined();
       const run = runs[firstSlice!.runIndex];
       const box = layer.children[0];
-      const left = parseFloat(box.style.left);
-      const width = parseFloat(box.style.width);
-      const top = parseFloat(box.style.top);
+      const left = (parseFloat(box.style.left) / 100) * CSS_W;
+      const width = (parseFloat(box.style.width) / 100) * CSS_W;
+      const top = (parseFloat(box.style.top) / 100) * CSS_H;
       expect(width).toBeGreaterThan(0);
       expect(left).toBeGreaterThanOrEqual(run.x - 0.5);
       expect(left + width).toBeLessThanOrEqual(run.x + run.w + 1);

--- a/packages/node/src/pptx-find-highlight.test.ts
+++ b/packages/node/src/pptx-find-highlight.test.ts
@@ -209,9 +209,13 @@ describe.skipIf(!skia || !pptxMod || !rendererMod || !findMod || !highlightMod |
       const shapeDiv = layer.children.find((d) => d.children.length > 0);
       expect(shapeDiv).toBeDefined();
       const box = shapeDiv!.children[0];
-      const left = parseFloat(box.style.left);
-      const width = parseFloat(box.style.width);
-      const top = parseFloat(box.style.top);
+      // buildPptxHighlightLayer positions a box as a PERCENTAGE of its shape
+      // frame (run.shapeW/run.shapeH) — the % denominators — so convert the
+      // parsed percentage back to px against that same basis before comparing
+      // to the run's real (px) in-shape geometry.
+      const left = (parseFloat(box.style.left) / 100) * run.shapeW;
+      const width = (parseFloat(box.style.width) / 100) * run.shapeW;
+      const top = (parseFloat(box.style.top) / 100) * run.shapeH;
       // The box sits in the shape's own frame at inShapeX + slice extent.
       expect(width).toBeGreaterThan(0);
       expect(left).toBeGreaterThanOrEqual(run.inShapeX - 0.5);

--- a/packages/pptx/src/find-highlight-layer.test.ts
+++ b/packages/pptx/src/find-highlight-layer.test.ts
@@ -75,16 +75,23 @@ describe('buildPptxHighlightLayer', () => {
       { slices: [{ runIndex: 0, start: 4, end: 9 }], active: false }, // "quick"
     ];
     buildPptxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 960, 540, measureForFont);
+    // The overlay container must NOT be pinned to a literal px size — it keeps
+    // its `width:100%;height:100%` so it tracks the canvas's actual rendered box.
+    expect(layer.style.width ?? '').toBe('');
+    expect(layer.style.height ?? '').toBe('');
     // One shape div, containing one box.
     expect(layer.children).toHaveLength(1);
     const shapeDiv = layer.children[0];
     expect(shapeDiv.children).toHaveLength(1);
     const box = shapeDiv.children[0];
-    // left = inShapeX (5) + "the " (28) = 33; top = inShapeY (8); width = 35.
-    expect(box.style.left).toBe('33px');
-    expect(box.style.top).toBe('8px');
-    expect(box.style.width).toBe('35px');
-    expect(box.style.height).toBe('16px');
+    // Box is placed as a PERCENTAGE of the shape frame (shapeW=100, shapeH=50)
+    // so it scales with the (percentage-sized, rotatable) group.
+    // left = (inShapeX 5 + "the " 28) / 100; top = inShapeY 8 / 50;
+    // width = 35 / 100; height = 16 / 50.
+    expect(box.style.left).toBe(`${(33 / 100) * 100}%`);
+    expect(box.style.top).toBe(`${(8 / 50) * 100}%`);
+    expect(box.style.width).toBe(`${(35 / 100) * 100}%`);
+    expect(box.style.height).toBe(`${(16 / 50) * 100}%`);
     expect(box.style.background).toBe(DEFAULT_FIND_HIGHLIGHT);
   });
 

--- a/packages/pptx/src/find-highlight-layer.ts
+++ b/packages/pptx/src/find-highlight-layer.ts
@@ -14,7 +14,7 @@
  * coordinate frame (`inShapeX`/`inShapeY`), so the shape div's `rotate()` lays
  * them along the glyphs. The active match uses a distinct emphasis colour.
  */
-import { sliceHorizontalExtent, type MatchRunSlice } from '@silurus/ooxml-core';
+import { sliceHorizontalExtent, overlayPercent, type MatchRunSlice } from '@silurus/ooxml-core';
 import type { PptxTextRunInfo } from './renderer';
 
 export interface PptxHighlightMatch {
@@ -36,11 +36,16 @@ export interface PptxHighlightColors {
  * by shape frame (with the shape's rotation) so each box lands on the drawn
  * glyphs.
  *
- * @param layer     the overlay div (cleared + re-sized here).
+ * All coordinates are PERCENTAGES of `cssWidth`/`cssHeight`, and the container's
+ * own size is left untouched (`width:100%;height:100%` from the caller), so the
+ * highlights track the canvas's ACTUAL rendered box even when a consumer scales
+ * the canvas down with external CSS — mirroring {@link buildPptxTextLayer}.
+ *
+ * @param layer     the overlay div (cleared here; sized `100%` by the caller).
  * @param runs      the slide's runs (same array the slide was rendered from).
  * @param matches   the slide's matches (run-slices + active flag).
- * @param cssWidth  rendered canvas CSS width (px, number).
- * @param cssHeight rendered canvas CSS height (px, number).
+ * @param cssWidth  the slide's intended CSS width (px, number) — the % denominator.
+ * @param cssHeight the slide's intended CSS height (px, number) — the % denominator.
  * @param measureForFont returns a width-measurer primed with a run's font.
  * @param colors    optional colour overrides.
  */
@@ -54,34 +59,36 @@ export function buildPptxHighlightLayer(
   colors: PptxHighlightColors = {},
 ): void {
   layer.innerHTML = '';
-  layer.style.width = `${cssWidth}px`;
-  layer.style.height = `${cssHeight}px`;
 
   const matchColor = colors.match ?? DEFAULT_FIND_HIGHLIGHT;
   const activeColor = colors.active ?? DEFAULT_FIND_ACTIVE_HIGHLIGHT;
 
   // One positioned + rotated div per shape frame (keyed like the text layer), so
   // boxes inside it inherit the shape's rotation. Reused across matches/slices.
-  const shapeMap = new Map<string, HTMLDivElement>();
-  const shapeDiv = (run: PptxTextRunInfo): HTMLDivElement => {
+  // The frame is placed as a % of the slide box (so it tracks the scaled canvas)
+  // with % width/height too, so the boxes inside (positioned as % of THIS frame)
+  // scale with it under the shape's rotate().
+  const shapeMap = new Map<string, { div: HTMLDivElement; w: number; h: number }>();
+  const shapeDiv = (run: PptxTextRunInfo): { div: HTMLDivElement; w: number; h: number } => {
     const totalRot = run.rotation + (run.textBodyRotation ?? 0);
     const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot}`;
-    let div = shapeMap.get(key);
-    if (!div) {
-      div = document.createElement('div');
+    let entry = shapeMap.get(key);
+    if (!entry) {
+      const div = document.createElement('div');
       div.style.cssText =
         `position:absolute;` +
-        `left:${run.shapeX}px;top:${run.shapeY}px;` +
-        `width:${run.shapeW}px;height:${run.shapeH}px;` +
+        `left:${overlayPercent(run.shapeX, cssWidth)};top:${overlayPercent(run.shapeY, cssHeight)};` +
+        `width:${overlayPercent(run.shapeW, cssWidth)};height:${overlayPercent(run.shapeH, cssHeight)};` +
         `pointer-events:none;overflow:hidden;`;
       if (totalRot !== 0) {
         div.style.transformOrigin = 'center center';
         div.style.transform = `rotate(${totalRot}deg)`;
       }
-      shapeMap.set(key, div);
+      entry = { div, w: run.shapeW, h: run.shapeH };
+      shapeMap.set(key, entry);
       layer.appendChild(div);
     }
-    return div;
+    return entry;
   };
 
   for (const match of matches) {
@@ -92,13 +99,16 @@ export function buildPptxHighlightLayer(
       const measure = measureForFont(run.font);
       const { x, width } = sliceHorizontalExtent(run.text, slice.start, slice.end, measure);
       if (width <= 0) continue;
+      const shape = shapeDiv(run);
       const box = document.createElement('div');
+      // Placed as a % of the shape frame (shapeW/shapeH), so the box scales with
+      // the frame when the whole overlay is scaled down by external CSS.
       box.style.cssText =
         `position:absolute;` +
-        `left:${run.inShapeX + x}px;top:${run.inShapeY}px;` +
-        `width:${width}px;height:${run.h}px;` +
+        `left:${overlayPercent(run.inShapeX + x, shape.w)};top:${overlayPercent(run.inShapeY, shape.h)};` +
+        `width:${overlayPercent(width, shape.w)};height:${overlayPercent(run.h, shape.h)};` +
         `background:${fill};pointer-events:none;`;
-      shapeDiv(run).appendChild(box);
+      shape.div.appendChild(box);
     }
   }
 }

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1084,11 +1084,15 @@ describe('PptxScrollViewer — text selection (T5)', () => {
     await Promise.resolve();
     const wrapper = findSlotWrapper(scrollHost);
     const textLayer = findTextLayer(wrapper);
-    // Finding B: the overlay is sized to the CSS box (round(widthPx)/round(
-    // slideHeightPx)), NOT the canvas backing store. At base scale 1.0 the slide is
-    // 200px wide, 120px tall — assert those LITERAL numbers, not a fallback echo.
-    expect(textLayer.style.width).toBe('200px');
-    expect(textLayer.style.height).toBe('120px');
+    // The overlay container is NOT pinned to a literal px size: it keeps its
+    // creation `width:100%;height:100%` so it tracks the wrapper's actual box
+    // even when a consumer scales the canvas down with external CSS (the reported
+    // scrollbar bug). The wrapper IS sized to the CSS box (200×120 at base scale
+    // 1.0), NOT the canvas backing store — so `100%` resolves to the CSS box.
+    expect(textLayer.style.width).toBe('100%');
+    expect(textLayer.style.height).toBe('100%');
+    expect(wrapper.style.width).toBe('200px');
+    expect(wrapper.style.height).toBe('120px');
     v.destroy();
   });
 
@@ -1121,9 +1125,14 @@ describe('PptxScrollViewer — text selection (T5)', () => {
     // The canvas backing store IS 2× (dpr 2): 400×240.
     expect(canvas.width).toBe(400);
     expect(canvas.height).toBe(240);
-    // …but the overlay is the CSS box, 200×120 — half the backing store.
-    expect(textLayer.style.width).toBe('200px');
-    expect(textLayer.style.height).toBe('120px');
+    // …but the overlay container stays `100%` of the wrapper, and the wrapper is
+    // the CSS box (200×120) — half the backing store. `100%` of that box never
+    // copies the 2× backing store, so the overlay does not overflow the wrapper /
+    // inflate the scroll area.
+    expect(textLayer.style.width).toBe('100%');
+    expect(textLayer.style.height).toBe('100%');
+    expect(wrapper.style.width).toBe('200px');
+    expect(wrapper.style.height).toBe('120px');
     v.destroy();
   });
 

--- a/packages/pptx/src/text-layer.test.ts
+++ b/packages/pptx/src/text-layer.test.ts
@@ -74,24 +74,32 @@ describe('buildPptxTextLayer (extracted from PptxViewer._buildTextLayer)', () =>
     buildPptxTextLayer(layer as unknown as HTMLDivElement, runs, 960, 540);
 
     expect(layer.innerHTML).toBe('');
-    expect(layer.style.width).toBe('960px');
-    expect(layer.style.height).toBe('540px');
+    // The overlay container must NOT be pinned to a literal px size: it stays at
+    // its creation `width:100%;height:100%` so it tracks the canvas's ACTUAL
+    // rendered box (external CSS may scale the canvas down responsively). The
+    // build must leave the container size untouched.
+    expect(layer.style.width ?? '').toBe('');
+    expect(layer.style.height ?? '').toBe('');
     // Same shape frame + rotation ⇒ ONE group div, holding both spans.
     expect(layer.children.length).toBe(1);
     const shapeDiv = layer.children[0];
     expect(shapeDiv.tag).toBe('div');
     expect(shapeDiv.style.position).toBe('absolute');
-    expect(shapeDiv.style.left).toBe('10px');
-    expect(shapeDiv.style.top).toBe('20px');
-    expect(shapeDiv.style.width).toBe('200px');
-    expect(shapeDiv.style.height).toBe('80px');
+    // The shape frame is placed as a PERCENTAGE of cssWidth/cssHeight so it
+    // scales with the container: left 10/960, top 20/540, w 200/960, h 80/540.
+    expect(shapeDiv.style.left).toBe(`${(10 / 960) * 100}%`);
+    expect(shapeDiv.style.top).toBe(`${(20 / 540) * 100}%`);
+    expect(shapeDiv.style.width).toBe(`${(200 / 960) * 100}%`);
+    expect(shapeDiv.style.height).toBe(`${(80 / 540) * 100}%`);
     expect(shapeDiv.style.overflow).toBe('hidden');
     expect(shapeDiv.children.map((c) => c.textContent)).toEqual(['A', 'B']);
     // Span uses the shipped `font` shorthand + line-height + letter-spacing reset.
+    // Its position inside the shape div is a PERCENTAGE of the shape's own
+    // box (shapeW/shapeH), so it scales with the rotated group.
     const spanA = shapeDiv.children[0];
     expect(spanA.style.position).toBe('absolute');
-    expect(spanA.style.left).toBe('2px');
-    expect(spanA.style.top).toBe('4px');
+    expect(spanA.style.left).toBe(`${(2 / 200) * 100}%`);
+    expect(spanA.style.top).toBe(`${(4 / 80) * 100}%`);
     expect(spanA.style.font).toBe('12px serif');
     expect(spanA.style['line-height']).toBe('12px');
     expect(spanA.style['letter-spacing']).toBe('0');

--- a/packages/pptx/src/text-layer.ts
+++ b/packages/pptx/src/text-layer.ts
@@ -1,4 +1,4 @@
-import type { HyperlinkTarget } from '@silurus/ooxml-core';
+import { overlayPercent, type HyperlinkTarget } from '@silurus/ooxml-core';
 import type { PptxTextRunInfo } from './renderer';
 
 /**
@@ -20,10 +20,19 @@ import type { PptxTextRunInfo } from './renderer';
  * (no hyperlink) is byte-identical to before. A JS click handler is used rather
  * than an `<a href>` so the URL never bypasses the viewer's sanitisation.
  *
- * @param layer     the overlay div.
+ * The overlay's coordinates are all PERCENTAGES of `cssWidth`/`cssHeight` (the
+ * slide's intended CSS-px box), never literal px, and the container's own
+ * `width`/`height` are left untouched (the caller sizes it `width:100%;
+ * height:100%` so it fills the wrapper). This lets the overlay track the canvas's
+ * ACTUAL rendered box even when a consumer scales the canvas down with external
+ * CSS (e.g. `width:100%!important;height:auto`): the wrapper (and therefore the
+ * `100%` container) shrinks with the canvas, and every `%`-placed child scales
+ * with it, so nothing overflows the wrapper into an ancestor's scroll area.
+ *
+ * @param layer     the overlay div (sized `width:100%;height:100%` by the caller).
  * @param runs      per-run + per-shape geometry from `renderSlide({ onTextRun })`.
- * @param cssWidth  the rendered canvas's CSS width (px, number).
- * @param cssHeight the rendered canvas's CSS height (px, number).
+ * @param cssWidth  the slide's intended CSS width (px, number) — the % denominator.
+ * @param cssHeight the slide's intended CSS height (px, number) — the % denominator.
  * @param onHyperlinkClick called with the run's resolved {@link HyperlinkTarget}
  *                         when a hyperlink span is clicked. Omit to leave links
  *                         non-interactive (spans stay plain, selectable text).
@@ -36,8 +45,6 @@ export function buildPptxTextLayer(
   onHyperlinkClick?: (target: HyperlinkTarget) => void,
 ): void {
   layer.innerHTML = '';
-  layer.style.width = `${cssWidth}px`;
-  layer.style.height = `${cssHeight}px`;
 
   // Group runs by shape (same shapeX/shapeY/rotation)
   type ShapeKey = string;
@@ -48,10 +55,15 @@ export function buildPptxTextLayer(
     const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot}`;
     if (!shapeMap.has(key)) {
       const div = document.createElement('div');
+      // The shape frame is placed as a % of the slide box so it tracks the
+      // canvas's actual rendered size; its width/height are % too, so the child
+      // spans (positioned as % of THIS box) scale with it. rotate() is applied to
+      // the %-sized box unchanged — the rotation centre is within the box, so it
+      // composes with the outer scale.
       div.style.cssText =
         `position:absolute;` +
-        `left:${run.shapeX}px;top:${run.shapeY}px;` +
-        `width:${run.shapeW}px;height:${run.shapeH}px;` +
+        `left:${overlayPercent(run.shapeX, cssWidth)};top:${overlayPercent(run.shapeY, cssHeight)};` +
+        `width:${overlayPercent(run.shapeW, cssWidth)};height:${overlayPercent(run.shapeH, cssHeight)};` +
         `pointer-events:all;overflow:hidden;`;
       if (totalRot !== 0) {
         div.style.transformOrigin = 'center center';
@@ -76,9 +88,14 @@ export function buildPptxTextLayer(
     // underline) — the span only supplies the hit region. `cursor:text` stays
     // the default for plain runs so selection UX is unchanged.
     const link = onHyperlinkClick ? run.hyperlink : undefined;
+    // Position the span as a % of its shape frame (shapeW/shapeH) so it tracks
+    // the frame when the whole overlay is scaled by external CSS. `font` /
+    // `line-height` stay px: they set the glyph metrics of the transparent hit
+    // text, which the browser lays out inside the box; the box position is what
+    // must track the canvas (byte-identical to the prior overlay at 100% scale).
     span.style.cssText =
       `position:absolute;` +
-      `left:${run.inShapeX}px;top:${run.inShapeY}px;` +
+      `left:${overlayPercent(run.inShapeX, shape.w)};top:${overlayPercent(run.inShapeY, shape.h)};` +
       `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
       `white-space:pre;color:transparent;cursor:${link ? 'pointer' : 'text'};`;
     if (link && onHyperlinkClick) {

--- a/packages/pptx/tests/visual/responsive-overlay-fixture.html
+++ b/packages/pptx/tests/visual/responsive-overlay-fixture.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    /* Reproduce the ooxml.silurus.dev demo layout: a scrollable stage with a
+       fixed max-height, holding a viewer whose canvas is scaled DOWN by external
+       CSS (the recommended responsive pattern). The `!important` overrides mimic
+       the site's `.demo-page { width:100%!important; height:auto!important }`. */
+    #stage {
+      max-width: 640px;
+      max-height: 360px;
+      overflow: auto;      /* the ancestor whose scroll{Width,Height} we assert */
+      border: 1px solid #ccc;
+      padding: 11px 22px;  /* asymmetric padding, like the site */
+    }
+    /* The consumer scales the canvas responsively — its rendered box (e.g.
+       ~596×335) is much smaller than the viewer's intended 960×540. */
+    #stage canvas {
+      display: block !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      height: auto !important;
+      background: #fff;
+    }
+  </style>
+</head>
+<body>
+  <!-- Regression for the reported "single viewer with navigation" scrollbar bug:
+       the find-highlight + text-selection overlays must track the canvas's ACTUAL
+       (externally scaled) CSS size, so they never overflow the wrapper and push a
+       scrollbar onto the #stage scroll area. The spec reads document.body.dataset
+       measurements taken AFTER a find highlight + selection overlay are built. -->
+  <div id="stage"></div>
+  <script type="module">
+    import { PptxViewer } from '/src/index.ts';
+
+    const params = new URLSearchParams(location.search);
+    const name = params.get('pptx') ?? 'demo/sample-1';
+    const query = params.get('q') ?? 'a';
+
+    try {
+      const stage = document.getElementById('stage');
+      const canvas = document.createElement('canvas');
+      stage.appendChild(canvas);
+
+      const resp = await fetch(`/${name}.pptx`);
+      if (!resp.ok) throw new Error(`fetch ${name}.pptx -> ${resp.status}`);
+      const buf = await resp.arrayBuffer();
+
+      // width: 960 = the slide's intended CSS box; the external CSS scales the
+      // rendered canvas down to fit #stage. enableTextSelection builds the text
+      // overlay; findText builds the highlight overlay.
+      const viewer = new PptxViewer(canvas, {
+        width: 960,
+        enableTextSelection: true,
+        useGoogleFonts: true,
+      });
+      await viewer.load(buf);
+      await viewer.findText(query);
+      await viewer.findNext();
+
+      // Let layout settle so scrollWidth/scrollHeight reflect the final overlay.
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+      // The overlay layers live inside the viewer's positioned wrapper (the
+      // canvas's parent). Read their laid-out size to prove they track the SCALED
+      // canvas, not the intended 960×540.
+      const wrapper = canvas.parentElement;
+      const overlayLayers = [...wrapper.children].filter((c) => c.tagName === 'DIV');
+      const overlayRects = overlayLayers.map((l) => {
+        const r = l.getBoundingClientRect();
+        return { w: Math.round(r.width), h: Math.round(r.height) };
+      });
+      const canvasRect = canvas.getBoundingClientRect();
+
+      document.body.dataset.result = JSON.stringify({
+        stageScrollWidth: stage.scrollWidth,
+        stageClientWidth: stage.clientWidth,
+        stageScrollHeight: stage.scrollHeight,
+        stageClientHeight: stage.clientHeight,
+        canvasCssWidth: Math.round(canvasRect.width),
+        canvasCssHeight: Math.round(canvasRect.height),
+        overlayRects,
+      });
+      viewer.destroy();
+      document.body.dataset.status = 'ready';
+    } catch (err) {
+      document.body.dataset.status = 'error';
+      document.body.dataset.errorMessage = err.message;
+      console.error('[responsive-overlay-fixture] error:', err);
+    }
+  </script>
+</body>
+</html>

--- a/packages/pptx/tests/visual/responsive-overlay.spec.ts
+++ b/packages/pptx/tests/visual/responsive-overlay.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression for the reported "Single viewer with navigation" scrollbar bug on
+ * https://ooxml.silurus.dev/pptx/ : the find-highlight / text-selection overlays
+ * placed literal-px boxes sized to the slide's INTENDED CSS box (e.g. 960×540)
+ * over a `<canvas>` that a consumer had scaled DOWN with external CSS
+ * (`width:100%!important; height:auto`). The oversized overlay overflowed the
+ * viewer's wrapper and pushed a scrollbar onto the ancestor scroll area
+ * (`scrollWidth`/`scrollHeight` > `clientWidth`/`clientHeight`).
+ *
+ * The fix positions every overlay box as a PERCENTAGE of the intended CSS box and
+ * leaves the overlay container at `width:100%;height:100%`, so it tracks the
+ * canvas's ACTUAL rendered size. This spec loads a real `PptxViewer` with a find
+ * highlight + selection overlay inside an `overflow:auto` stage that scales the
+ * canvas down, and asserts the stage never gains a scrollbar and the overlay
+ * layers match the scaled canvas — not the 960×540 intended box.
+ *
+ * Runs in a real browser (jsdom cannot lay out `%` against a scaled ancestor), so
+ * it catches exactly what the unit tests cannot: the resolved geometry.
+ */
+test('find/selection overlays do not overflow a scaled-canvas scroll area › demo/sample-1', async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.goto('/tests/visual/responsive-overlay-fixture.html?pptx=demo/sample-1&q=a');
+  await page.waitForFunction(
+    () => document.body.dataset.status === 'ready' || document.body.dataset.status === 'error',
+    { timeout: 90_000 },
+  );
+  const status = await page.evaluate(() => document.body.dataset.status);
+  if (status === 'error') {
+    throw new Error(await page.evaluate(() => document.body.dataset.errorMessage ?? ''));
+  }
+
+  const r = JSON.parse(await page.evaluate(() => document.body.dataset.result ?? '{}')) as {
+    stageScrollWidth: number;
+    stageClientWidth: number;
+    stageScrollHeight: number;
+    stageClientHeight: number;
+    canvasCssWidth: number;
+    canvasCssHeight: number;
+    overlayRects: { w: number; h: number }[];
+  };
+
+  // Precondition: the canvas really was scaled DOWN below its intended 960×540
+  // box (otherwise the test would not exercise the bug at all).
+  expect(r.canvasCssWidth).toBeLessThan(960);
+  expect(r.canvasCssWidth).toBeGreaterThan(0);
+
+  // The core assertion (the reported symptom): the scroll area does NOT overflow.
+  // Before the fix, stageScrollWidth ≈ 960 + padding while clientWidth ≈ 640, so
+  // a horizontal scrollbar appeared; likewise vertically. Allow a 1px slack for
+  // sub-pixel rounding in the browser's layout.
+  expect(r.stageScrollWidth).toBeLessThanOrEqual(r.stageClientWidth + 1);
+  expect(r.stageScrollHeight).toBeLessThanOrEqual(r.stageClientHeight + 1);
+
+  // And the overlay layers track the SCALED canvas, not the intended 960×540 box:
+  // each overlay layer's laid-out width equals the canvas's rendered width (±1).
+  expect(r.overlayRects.length).toBeGreaterThan(0);
+  for (const rect of r.overlayRects) {
+    expect(Math.abs(rect.w - r.canvasCssWidth)).toBeLessThanOrEqual(1);
+    expect(Math.abs(rect.h - r.canvasCssHeight)).toBeLessThanOrEqual(1);
+  }
+});

--- a/packages/pptx/tests/visual/worker-selection-fixture.html
+++ b/packages/pptx/tests/visual/worker-selection-fixture.html
@@ -33,21 +33,36 @@
     // between the main <canvas> and the worker OffscreenCanvas must not fail an
     // exact-equality assertion). The run GEOMETRY is computed identically in both
     // modes (same renderer), so the rounded boxes must match exactly.
+    // Read RESOLVED pixel geometry (getBoundingClientRect), relative to the
+    // wrapper's top-left, rather than parsing the inline `style.left` string.
+    // The overlay coordinates are CSS PERCENTAGES (so the overlay tracks a
+    // canvas a consumer scales down), and a percentage is scale-invariant — it
+    // would not follow the zoom if read verbatim. The laid-out px position DOES
+    // follow the zoom (slide geometry px = EMU × scale), which is what this spec
+    // asserts, and is identical whether the CSS is px or %.
+    const wrapperRect = (host) => {
+      const wrapper = host.querySelector('div');
+      return wrapper.getBoundingClientRect();
+    };
     // Wrapper stacking order: [canvas, textLayer, highlightLayer].
     const serializeOverlay = (host) => {
       const textLayer = layersOf(host)[0];
       const out = [];
       if (textLayer) {
+        const wr = wrapperRect(host);
         for (const shape of textLayer.children) {
-          const sx = Math.round(parseFloat(shape.style.left) || 0);
-          const sy = Math.round(parseFloat(shape.style.top) || 0);
+          const sr = shape.getBoundingClientRect();
+          const sx = Math.round(sr.left - wr.left);
+          const sy = Math.round(sr.top - wr.top);
           for (const span of shape.querySelectorAll('span')) {
+            const spr = span.getBoundingClientRect();
             out.push({
               text: span.textContent,
               shapeLeft: sx,
               shapeTop: sy,
-              inLeft: Math.round(parseFloat(span.style.left) || 0),
-              inTop: Math.round(parseFloat(span.style.top) || 0),
+              // In-shape offset as resolved px (span rect relative to shape rect).
+              inLeft: Math.round(spr.left - sr.left),
+              inTop: Math.round(spr.top - sr.top),
             });
           }
         }
@@ -56,18 +71,22 @@
     };
     // IX2 highlight boxes (absolutely positioned divs in the LAST layer; pptx
     // groups them per shape like the text layer, so walk to the leaf divs that
-    // carry a background).
+    // carry a background). Read resolved px relative to the wrapper.
     const serializeHighlights = (host) => {
       const layers = layersOf(host);
       const layer = layers[layers.length - 1];
       if (!layer) return [];
+      const wr = wrapperRect(host);
       return [...layer.querySelectorAll('div')]
         .filter((b) => b.style.background)
-        .map((b) => ({
-          left: Math.round(parseFloat(b.style.left) || 0),
-          top: Math.round(parseFloat(b.style.top) || 0),
-          width: Math.round(parseFloat(b.style.width) || 0),
-        }));
+        .map((b) => {
+          const r = b.getBoundingClientRect();
+          return {
+            left: Math.round(r.left - wr.left),
+            top: Math.round(r.top - wr.top),
+            width: Math.round(r.width),
+          };
+        });
     };
 
     const capture = (host, viewer, canvas) => ({

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -17,8 +17,8 @@ declare function acquireVsCodeApi(): {
 };
 
 import { XlsxViewer, type CellRange } from '@silurus/ooxml-xlsx';
-import { DocxDocument, type DocxTextRunInfo } from '@silurus/ooxml-docx';
-import { PptxPresentation, type PptxTextRunInfo } from '@silurus/ooxml-pptx';
+import { DocxDocument, buildDocxTextLayer, type DocxTextRunInfo } from '@silurus/ooxml-docx';
+import { PptxPresentation, buildPptxTextLayer, type PptxTextRunInfo } from '@silurus/ooxml-pptx';
 import { svgExtents } from '@silurus/ooxml-core';
 // Side-effect import: bundles the self-contained MathJax + STIX Two Math engine
 // into the webview and sets globalThis.__ooxmlStix2. The library renders OMML
@@ -121,23 +121,17 @@ async function initXlsx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
 }
 
 // ── DOCX (scroll view) ───────────────────────────────────────────────────────
-
-function buildDocxTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[]): void {
-  layer.replaceChildren();
-  for (const run of runs) {
-    const span = document.createElement('span');
-    span.textContent = run.text;
-    // Mirror the canvas font (incl. weight / style / family) so glyph widths
-    // line up. `letter-spacing` is reset so parent CSS cannot drift the
-    // selection edge. Kerning / ligatures are left at the browser default
-    // because canvas applies them by default too.
-    span.style.cssText =
-      `position:absolute;left:${run.x}px;top:${run.y}px;` +
-      `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
-      `white-space:pre;color:transparent;cursor:text;pointer-events:all;`;
-    layer.appendChild(span);
-  }
-}
+//
+// The text-selection overlay is built by the shared, public buildDocxTextLayer
+// (imported above) rather than a local duplicate: this webview's `.page-canvas`
+// is `width:100%` of `.page-wrapper` (itself capped by an inline `max-width`),
+// so it IS responsively scaled by the editor pane's width, exactly the pattern
+// the shared builder now guards (an overlay pinned to literal px would overflow
+// `.page-wrapper` under a narrow pane, pushing scroll onto an ancestor — the same
+// bug fixed for PptxViewer/DocxViewer). buildDocxTextLayer takes the page's
+// intended CSS box (px, numbers) as the `%` denominators and leaves the
+// `.text-layer` container's own `width:100%;height:100%` (set by CSS class)
+// untouched.
 
 async function initDocx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<void> {
   const doc = await DocxDocument.load(buffer, { math, useGoogleFonts });
@@ -164,51 +158,21 @@ async function initDocx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
 
     const runs: DocxTextRunInfo[] = [];
     await doc.renderPage(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
-    buildDocxTextLayer(textLayer, runs);
+    const cssHeight = parseFloat(canvas.style.height) || canvas.height;
+    buildDocxTextLayer(textLayer, runs, widthPx, cssHeight);
   }
 
   hideStatus();
 }
 
 // ── PPTX (scroll view) ───────────────────────────────────────────────────────
-
-function buildPptxTextLayer(
-  layer: HTMLDivElement,
-  runs: PptxTextRunInfo[],
-  cssWidth: number,
-  cssHeight: number,
-): void {
-  layer.replaceChildren();
-  layer.style.width = `${cssWidth}px`;
-  layer.style.height = `${cssHeight}px`;
-
-  const shapeMap = new Map<string, HTMLDivElement>();
-  for (const run of runs) {
-    const totalRot = run.rotation + (run.textBodyRotation ?? 0);
-    const key = `${run.shapeX},${run.shapeY},${run.shapeW},${run.shapeH},${totalRot}`;
-    let shape = shapeMap.get(key);
-    if (!shape) {
-      shape = document.createElement('div');
-      shape.style.cssText =
-        `position:absolute;left:${run.shapeX}px;top:${run.shapeY}px;` +
-        `width:${run.shapeW}px;height:${run.shapeH}px;pointer-events:all;overflow:hidden;`;
-      if (totalRot !== 0) {
-        shape.style.transformOrigin = 'center center';
-        shape.style.transform = `rotate(${totalRot}deg)`;
-      }
-      shapeMap.set(key, shape);
-      layer.appendChild(shape);
-    }
-    const span = document.createElement('span');
-    span.textContent = run.text;
-    // See buildDocxTextLayer: mirror canvas font, only reset letter-spacing.
-    span.style.cssText =
-      `position:absolute;left:${run.inShapeX}px;top:${run.inShapeY}px;` +
-      `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
-      `white-space:pre;color:transparent;cursor:text;`;
-    shape.appendChild(span);
-  }
-}
+//
+// Same rationale as the docx section above: the shared, public
+// buildPptxTextLayer (imported above) replaces the former local duplicate,
+// which pinned `.text-layer`'s width/height and every shape frame / span to
+// literal px — the same responsive-overflow bug fixed for PptxViewer, and a
+// live one here too (`.page-canvas` is `width:100%` of `.page-wrapper`, capped
+// by an inline `max-width`, so it IS responsively scaled by the editor pane).
 
 async function initPptx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<void> {
   const pres = await PptxPresentation.load(buffer, { math, useGoogleFonts });


### PR DESCRIPTION
## Symptom

On https://ooxml.silurus.dev/pptx/ the "Single viewer with navigation" demo grows a scrollbar inside the viewer region, even though the viewer is not meant to scroll.

## Root cause

`PptxViewer`/`DocxViewer` wrap the canvas in a `position:relative;display:inline-block` wrapper and add the find-highlight layer (always) and text-selection layer (when enabled) as `position:absolute;width:100%;height:100%` children. But on every render the overlay builders overwrote that and pinned each layer + child box to the slide/page's **intended** CSS box in **literal px**:

- `buildPptxTextLayer` / `buildPptxHighlightLayer` (`packages/pptx/src/{text-layer,find-highlight-layer}.ts`) set `layer.style.width = ${cssWidth}px` and placed shape frames / spans / boxes in px.
- `buildDocxTextLayer` / `buildDocxHighlightLayer` (`packages/docx/src/{text-layer,find-highlight-layer}.ts`) did the same with `"700px"`-style strings.

This assumes the canvas always renders at exactly the viewer's intended CSS size. When a consumer scales the canvas down with external CSS — the recommended responsive pattern, as the site itself does with `width:100%!important; height:auto!important` — the canvas renders smaller (e.g. 596×335) while the overlay stayed 960×540. The oversized absolute overlay overflowed the wrapper and pushed a scrollbar onto the ancestor scroll area.

Measured on the live page: `.demo-stage` (`max-height:560px; overflow:auto`), canvas scaled to 612×344, `highlightLayer` still 960×540 → `scrollWidth = 982` vs `clientWidth = 656` → horizontal scrollbar.

`xlsx` is unaffected (container-based design with in-canvas JS hit-testing, no absolute overlay).

## Fix (general — no site/preset-specific hack)

Leave the overlay container at its `width:100%;height:100%` (it already tracks the `inline-block` wrapper, which tracks the scaled canvas) and position every shape frame / span / highlight box as a **percentage** of the intended CSS box, via a new shared core helper `overlayPercent(value, basis)` (added beside `sliceHorizontalExtent`, the module that already owns the overlays' shared geometry). A rotated shape's `rotate()` / a tbRl run's `rotate(90deg)` about `top left` composes with the outer scale unchanged, because the rotation centre is within the %-sized box.

Both packages fixed identically (cross-package integrative fix). The docx builders now take `cssWidth`/`cssHeight` as **numbers** (matching the pptx builders) for the % denominators; all callers (`DocxViewer`, the three `DocxScrollViewer` overlay build sites, the ScrollView story) thread the numeric CSS box through a shared `_canvasCssPx()` reader.

At 1× (no external scaling) every box resolves to exactly the same pixels as before, so the demo VRT is byte-identical and worker↔main geometry parity holds.

An independent review additionally found this exact pattern duplicated in the VS Code extension webview (`packages/vscode-extension/src/webview/bootstrap.ts`): a hand-rolled `buildDocxTextLayer`/`buildPptxTextLayer` predating the shared-builder extraction, with the same literal-px overflow bug — not just a duplication smell, since `.page-canvas` is `width:100%` of `.page-wrapper` there too (responsively scaled by the editor pane width). Replaced both local duplicates with the shared, now-fixed `buildDocxTextLayer`/`buildPptxTextLayer` imports.

## Alternative considered

Outer container `overflow:hidden` + an inner literal-px child with `transform: scale(actualWidth/cssWidth)` read from `getBoundingClientRect()` post-render. Rejected: it forces a reflow read on every render and complicates hyperlink hit-test coordinate mapping, whereas `%` placement needs neither.

## Verification (TDD + real-DOM Playwright)

- **Unit (red→green)**: `text-layer` / `find-highlight-layer` tests (pptx + docx) now assert the container is left un-pinned (`width` stays `''`/`100%`) and each box is `%`, plus a new `overlayPercent` test in core (incl. scale-invariance + `0%` for a non-positive basis).
- **Real-DOM regression** (`tests/visual/responsive-overlay.spec.ts`, pptx + docx): a real viewer with a find highlight + selection overlay inside an `overflow:auto` stage that scales the canvas down with `!important` CSS. Confirmed **red on the current code, green after**:
  - pptx: `stageScrollWidth` 982 → ≤ `clientWidth` 639; overlay layers now match the scaled canvas, not 960×540.
  - docx: `stageScrollWidth` 816 → ≤ `clientWidth` 479; overlay layers match the scaled canvas on both axes (a docx page is legitimately taller than the stage, so vertical scrolling is asserted via the overlay-tracks-canvas check, not a raw scroll-height assertion).
- **Coordinate precision**: the existing `worker-selection-equivalence` specs (which assert exact overlay + highlight geometry and that it follows an IX9 zoom) still pass — their fixtures now read resolved px via `getBoundingClientRect` instead of parsing the (now-`%`) inline style, confirming the `%` placement lands on the same laid-out pixels.
- **Gates (repo-wide, matching CI's scope)**: `vitest` **3332/3343 passed, 11 skipped, 0 failed** (the 11 skips are pre-existing private-sample gates, unrelated to this change); root `tsc --build` 0 errors; `markdown`/`node`/`vscode-extension` typecheck clean; `ast-grep scan` clean; full pptx VRT 16 passed / 3 private skipped; full docx VRT 10 passed / 3 private skipped (demo references byte-identical); `vscode-extension` esbuild bundles cleanly with the shared `%`-based builder in the output.

An earlier version of this PR under-reported the vitest scope (per-package 2748/2748) and missed two `packages/node` integration tests that still called the overlay builders with the OLD string/px contract, which made CI's `typecheck` job (which also runs the full unit-test suite) genuinely red (3343 run, 2 failed). Both were migrated to the new numeric-%-contract in a follow-up commit, verified red→green locally before pushing, and confirmed against `gh pr checks 894`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)