### PR TITLE
Fix DOCX table border extent for spanned cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **This entire codebase — Rust parsers, TypeScript renderers, tests, and tooling — was implemented by [Claude](https://claude.ai)** (Anthropic's AI assistant) through iterative prompting. No human-written application code exists in this repository.
+> **This entire codebase — Rust parsers, TypeScript renderers, tests, and tooling — is implemented by AI coding agents, primarily [Claude](https://claude.ai) and [Codex](https://openai.com/codex/)**, through iterative prompting. No human-written application code exists in this repository.
 
 <details>
 <summary><b>Why this project exists — a note from the author</b></summary>
@@ -11,7 +11,7 @@ In practice, it didn't happen. For more than a decade, no free, open-source libr
 
 Generative AI changed that. A viewer is an unusually good fit for AI-driven iterative development ("vibe coding"): there is a spec to read and a correct output to aim for, so the work comes down to interpreting the specification and refining the rendering until it matches. Limiting the scope to viewing also avoids the most serious risk an Office library can carry — corrupting a user's files.
 
-So I'm building this library with Claude, spec-first, and keeping it free to use. For some documents it already reproduces the desktop Office applications more faithfully than commercial libraries — and sometimes even the official Microsoft 365 web apps.
+So I'm building this library with AI coding agents, spec-first, and keeping it free to use. For some documents it already reproduces the desktop Office applications more faithfully than commercial libraries — and sometimes even the official Microsoft 365 web apps.
 
 </details>
 

--- a/packages/docx/src/cell-border-conflict-render.test.ts
+++ b/packages/docx/src/cell-border-conflict-render.test.ts
@@ -100,7 +100,7 @@ function tableOf(rows: DocTableRow[], tableBorders: Partial<Edges> = {}): DocTab
   // Fixed 60 pt columns (one per logical column of the widest row). The page is
   // sized to the grid sum below so autofit never stretches the columns — the
   // shared interior vertical gridline then sits at a known x (60 for two cols).
-  const cols = Math.max(...rows.map((r) => r.cells.length));
+  const cols = Math.max(...rows.map((r) => r.cells.reduce((sum, c) => sum + c.colSpan, 0)));
   return {
     colWidths: new Array(cols).fill(60), rows,
     borders: { ...NO_BORDERS, ...tableBorders },
@@ -236,6 +236,21 @@ describe('§17.4.66 — adjacent cell border conflict, end-to-end render', () =>
     const colors = shared.map((s) => s.color.toLowerCase());
     expect(colors.some((c) => c.includes('00ff00'))).toBe(true);  // dashed wins
     expect(colors.some((c) => c.includes('ff0000'))).toBe(false); // thick loses
+  });
+
+  it('uses the winning below-cell top edge extent when the above cell spans wider', async () => {
+    const title = cell('title');
+    title.colSpan = 2;
+    const strokes = await render(tableOf([
+      rowOf([title]),
+      rowOf([
+        cell('work', { top: bs({ width: 1, color: '123456' }) }),
+        cell('gap'),
+      ]),
+    ]));
+    const shared = horizontalAt(strokes, 20).filter((s) => s.color.toLowerCase().includes('123456'));
+    expect(shared).toHaveLength(1);
+    expect(Math.abs(shared[0].x2 - shared[0].x1)).toBeCloseTo(60, 5);
   });
 
   it('bidiVisual: shared vertical gridline still drawn once with the winner', async () => {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -8435,6 +8435,24 @@ function measureCellContentHeightPx(
  *  and floating paths. Honors bidiVisual, vMerge span heights, and exact-row
  *  clipping exactly as the original inline loop did. In dryRun, measures cell
  *  content instead of drawing. */
+interface TableCellPaintJob {
+  cell: DocTableCell;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  edges: CellEdgeFlags;
+  clipExact: boolean;
+  /** ECMA-376 §17.4.66 — this cell's grid footprint, so the border pass can find
+   *  the cells that share each interior gridline (its right/bottom neighbours).
+   *  `ci`/`ri` are the logical top-left grid slot; `span` the column span; `lastRi`
+   *  the last row the cell occupies (vMerge-span aware). */
+  ci: number;
+  ri: number;
+  span: number;
+  lastRi: number;
+}
+
 function drawTableRows(
   table: DocTable,
   colWidths: number[],
@@ -8462,23 +8480,7 @@ function drawTableRows(
   // this made a shared vertical rule look like its thickness changed row to row.
   // So walk the grid ONCE to collect every cell's paint box, then paint in TWO
   // passes: all backgrounds + content first, all borders second.
-  const jobs: Array<{
-    cell: DocTableCell;
-    x: number;
-    y: number;
-    w: number;
-    h: number;
-    edges: CellEdgeFlags;
-    clipExact: boolean;
-    /** ECMA-376 §17.4.66 — this cell's grid footprint, so the border pass can find
-     *  the cells that share each interior gridline (its right/bottom neighbours).
-     *  `ci`/`ri` are the logical top-left grid slot; `span` the column span; `lastRi`
-     *  the last row the cell occupies (vMerge-span aware). */
-    ci: number;
-    ri: number;
-    span: number;
-    lastRi: number;
-  }> = [];
+  const jobs: TableCellPaintJob[] = [];
   // ECMA-376 §17.4.66 — grid-slot → job index occupancy, so an interior edge can
   // look up the adjacent cell. A vMerge/colSpan cell fills every slot it covers
   // (its restart job index), so a neighbour query on any slot resolves to the
@@ -8603,13 +8605,21 @@ function drawTableRows(
     // top and draw the winner (this ABOVE cell owns the shared horizontal line).
     {
       let spec: BorderSpec | null;
+      let x1 = x;
+      let x2 = x + w;
       if (j.edges.bottomRow) {
         spec = paintable(own.bottom?.spec ?? null);
       } else {
-        const below = neighbourEdges(jobs, occupancy, j.lastRi + 1, j.ci, mirror, table.borders);
-        spec = resolveSharedEdge(own.bottom, below?.top ?? null);
+        const below = neighbourJob(jobs, occupancy, j.lastRi + 1, j.ci);
+        const belowEdges = below ? resolveCellEdges(below.cell.borders, table.borders, below.edges, mirror) : null;
+        const winner = resolveBorderConflict(own.bottom, belowEdges?.top ?? null);
+        spec = winner ? paintable(winner.spec) : null;
+        if (winner && below && winner === belowEdges?.top) {
+          x1 = below.x;
+          x2 = below.x + below.w;
+        }
       }
-      if (spec) drawBorderLine(ctx, x, y + h, x + w, y + h, spec, scale, dpr);
+      if (spec) drawBorderLine(ctx, x1, y + h, x2, y + h, spec, scale, dpr);
     }
     // PHYSICAL RIGHT: outer-right → own spec; interior → resolve vs the physically-
     // right neighbour's left and draw the winner (this cell owns the shared
@@ -8675,19 +8685,28 @@ function resolveCellEdges(
 /** Resolve the neighbour cell at grid slot (ri, ci) and return its resolved
  *  edges, or `null` when the slot is empty/out of range. */
 function neighbourEdges(
-  jobs: ReadonlyArray<{ cell: DocTableCell; edges: CellEdgeFlags }>,
+  jobs: ReadonlyArray<TableCellPaintJob>,
   occupancy: number[][],
   ri: number,
   ci: number,
   mirror: boolean,
   table: TableBorders,
 ): ResolvedCellEdges | null {
+  const nb = neighbourJob(jobs, occupancy, ri, ci);
+  return nb ? resolveCellEdges(nb.cell.borders, table, nb.edges, mirror) : null;
+}
+
+function neighbourJob(
+  jobs: ReadonlyArray<TableCellPaintJob>,
+  occupancy: number[][],
+  ri: number,
+  ci: number,
+): TableCellPaintJob | null {
   if (ri < 0 || ri >= occupancy.length) return null;
   if (ci < 0 || ci >= occupancy[ri].length) return null;
   const idx = occupancy[ri][ci];
   if (idx < 0) return null;
-  const nb = jobs[idx];
-  return resolveCellEdges(nb.cell.borders, table, nb.edges, mirror);
+  return jobs[idx] ?? null;
 }
 
 /** ECMA-376 §17.4.66 — pick the winning border for a shared interior edge from


### PR DESCRIPTION
## Summary
- Draw shared horizontal table borders using the winning cell edge extent when the winning top border comes from a narrower cell below a spanned cell
- Add an end-to-end render regression test for the spanned-cell case
- Update README attribution to include Codex contributions

## Tests
- ./node_modules/.bin/vitest run packages/docx/src/cell-border-conflict.test.ts packages/docx/src/cell-border-conflict-render.test.ts packages/docx/src/column-widths.test.ts
- ./node_modules/.pnpm/typescript@6.0.3/node_modules/typescript/bin/tsc --build --pretty false
- git diff --check