### PR TITLE
docs(agents): make AGENTS.md the shared workflow contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,242 @@
+# Agent Instructions
+
+This file is the canonical workflow for AI coding agents working on this
+repository. Tool-specific files such as `CLAUDE.md` may add supplements, but they
+must not contradict this file.
+
+## Project
+
+`office-open-xml-viewer` renders OOXML documents (`docx`, `xlsx`, `pptx`) to
+browser Canvas. The implementation is a Rust/WASM parser layer plus TypeScript
+Canvas renderers and viewers.
+
+Important directories:
+
+- `packages/core/` — shared rendering primitives and shared TypeScript helpers.
+- `packages/ooxml-common/` — shared Rust parsing/model helpers.
+- `packages/docx/` — DOCX parser, renderer, viewer, and tests.
+- `packages/xlsx/` — XLSX parser, renderer, viewer, and tests.
+- `packages/pptx/` — PPTX parser, renderer, viewer, and tests.
+- `site/` — public site.
+- `.storybook/` — unified Storybook config.
+
+## Standard Development Flow
+
+Use this flow for ordinary bug fixes and feature work:
+
+1. Start from `main` and run `git pull --ff-only`.
+2. If the checkout is dirty, preserve unrelated work before switching or pulling.
+   Prefer `git stash push -u -m <clear-message>` for work that appears to belong
+   to another session.
+3. Create a feature branch. Use `codex/<topic>` for Codex work when possible;
+   otherwise follow the repository's existing branch naming.
+4. Work with TDD for bug fixes:
+   - explore the failing sample or behavior,
+   - add a focused failing test,
+   - make it pass,
+   - refactor only where it reduces real complexity.
+5. Verify with the narrowest meaningful tests first, then broader checks when the
+   touched surface warrants it.
+6. Commit only the intended source/docs/test files. Do not commit private samples
+   or generated local artifacts.
+7. Push the feature branch, create a PR, wait for checks when practical, and merge
+   with a merge commit. Do not squash.
+
+## Git and PR Rules
+
+- Never push directly to `main`.
+- Use PRs for integration into `main`.
+- Do not squash merge. Use `gh pr merge <number> --merge` unless the user
+  explicitly asks for another non-squash strategy.
+- Before `git push`, set `git config http.postBuffer 524288000` if large pushes
+  are expected.
+- Commit messages should match the repository style:
+  - subject: `fix(scope): ...`, `test(scope): ...`, `refactor(scope): ...`, etc.
+  - body: explain the root cause, the fix, and verification.
+  - include specification sections or observed Office behavior when relevant.
+- Agent-authored commits should include a matching co-author trailer:
+  - Codex: `Co-Authored-By: Codex <noreply@openai.com>`
+  - Claude/Fable: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- If Claude starts or delegates work to Codex, include both trailers in the
+  resulting commit. This preserves the human-readable provenance of the
+  orchestration layer (Claude) and the implementation agent (Codex).
+
+## Verification
+
+Prefer focused verification tied to the change. Common commands:
+
+```bash
+pnpm test
+pnpm typecheck
+pnpm build:wasm
+pnpm storybook
+pnpm build-storybook
+```
+
+For a narrow DOCX renderer fix, a good verification set is:
+
+```bash
+./node_modules/.bin/vitest run \
+  packages/docx/src/cell-border-conflict.test.ts \
+  packages/docx/src/cell-border-conflict-render.test.ts \
+  packages/docx/src/column-widths.test.ts
+
+./node_modules/.pnpm/typescript@*/node_modules/typescript/bin/tsc --build --pretty false
+git diff --check
+```
+
+If a check fails because ignored/generated WASM is stale, rebuild WASM before
+assuming the source change is broken.
+
+## OOXML Implementation Policy
+
+Be specification-first.
+
+- Prefer ECMA-376 / ISO-29500 behavior over sample-specific tuning.
+- Do not add heuristics only to improve one VRT/sample number, such as arbitrary
+  thresholds, empirical scaling constants, or special-casing a sample path.
+- A user report like "this line is too long" or "this object is missing" is a hint
+  that an OOXML rule is missing or mis-modeled. Identify the related section and
+  implement the rule for the whole class of documents.
+- When behavior differs from Word/Excel/PowerPoint, first check whether the parser
+  discarded necessary information during parsing, inheritance, or style merging.
+  If information is missing, extend the parser/model instead of guessing in the
+  renderer.
+- If Office behavior is not fully specified and requires reverse engineering,
+  explain that explicitly and ask for user approval before adding a compatibility
+  heuristic.
+- If a temporary heuristic is unavoidable, mark it clearly in code with the
+  missing spec/implementation work and track it for removal.
+
+## Cross-Package Integration
+
+DOCX, XLSX, and PPTX share many ECMA-376 concepts: DrawingML images, `srcRect`,
+text runs, paragraph properties, themes, fills, effects, and shape presets.
+
+- Treat one package's bug as a signal to inspect the sibling packages.
+- If the concept is shared, fix the shared layer (`packages/ooxml-common` or
+  `packages/core`) where possible.
+- Do not duplicate pure parsing predicates or common type definitions across
+  packages unless the format truly diverges.
+- Avoid false abstraction. Renderer logic that is tightly coupled to a package's
+  layout model may stay local.
+- Cross-package fixes may touch `core` / `ooxml-common` and multiple packages in
+  one PR when that is the coherent unit of work.
+
+## Private Samples and Storybook
+
+Private Office samples and local-only sample stories are gitignored and must not
+be committed.
+
+Typical local-only paths:
+
+- `packages/docx/public/private/`
+- `packages/xlsx/public/private/`
+- `packages/pptx/public/private/`
+- `packages/*/src/*privateDemo.stories.ts`
+- `packages/*/src/wasm/`
+
+When using a Codex/Claude worktree, copy local private stories/samples from the
+main local checkout if needed. Avoid copying `.DS_Store`, temporary Office lock
+files, screenshots, VRT diffs, or private reference images unless the user
+explicitly asks.
+
+Before using Storybook for parser-backed samples, rebuild WASM from the current
+worktree source:
+
+```bash
+pnpm build:wasm
+```
+
+or per package:
+
+```bash
+cd packages/docx/parser && wasm-pack build --target web --out-dir ../src/wasm && node ../../../scripts/append-wasm-reinit.mjs ../src/wasm/docx_parser.js
+cd packages/xlsx/parser && wasm-pack build --target web --out-dir ../src/wasm && node ../../../scripts/append-wasm-reinit.mjs ../src/wasm/xlsx_parser.js
+cd packages/pptx/parser && wasm-pack build --target web --out-dir ../src/wasm && node ../../../scripts/append-wasm-reinit.mjs ../src/wasm/pptx_parser.js
+```
+
+Storybook is unified at the repository root. Static prefixes are:
+
+- `packages/docx/public/` → `/docx/`
+- `packages/xlsx/public/` → `/xlsx/`
+- `packages/pptx/public/` → `/pptx/`
+
+Use those prefixes when fetching sample files.
+
+In sandboxed agent environments, Storybook's port detection may fail with
+`EPERM` while probing `0.0.0.0`. Running Storybook outside the sandbox for local
+verification is acceptable when the user asks to view it.
+
+## Visual Regression Tests
+
+VRT is local-only because private samples are not redistributable.
+
+```bash
+pnpm build:wasm
+pnpm vrt
+pnpm --filter @silurus/ooxml-docx vrt
+pnpm --filter @silurus/ooxml-xlsx vrt
+pnpm --filter @silurus/ooxml-pptx vrt
+```
+
+Only update references when the user explicitly asks:
+
+```bash
+UPDATE_REFS=1 pnpm vrt
+```
+
+Do not automatically update files under `packages/*/tests/visual/references/`.
+
+## Documentation and Public Examples
+
+Public docs and commit messages should be written in English.
+
+README, docs, and Storybook public-facing code examples should:
+
+- use `as Type` assertions instead of postfix non-null assertions,
+- use `canvas` for canvas-backed viewers (`DocxViewer`, `PptxViewer`),
+- use `container` for container-backed viewers (`XlsxViewer`),
+- avoid documenting private/local-only sample paths as public API.
+
+## Release Workflow
+
+When the user asks for a release, prepare a dedicated PR named
+`release/<version>` and do all release changes there.
+
+Release checklist:
+
+1. Update README screenshots in `docs/images/{pptx,docx,xlsx}.png`.
+2. Review README against the current implementation:
+   - ESM-only package format,
+   - install/import examples,
+   - feature support table,
+   - bundle-size notes,
+   - deprecated API or stale version references.
+3. Sync public API documentation:
+   - `site/src/lib/api-reference.ts`,
+   - `site/src/components/Capabilities.astro` when capabilities changed.
+4. Add a new top `CHANGELOG.md` section:
+   `## 0.x.0 — YYYY-MM-DD`.
+5. Bump all versions consistently:
+   - root `package.json`,
+   - `packages/{core,pptx,xlsx,docx,markdown,node,vscode-extension}/package.json`,
+   - `site/package.json`,
+   - `packages/mcp-server/Cargo.toml`.
+6. Run `cargo check -p ooxml-mcp-server` after bumping the MCP server so
+   `Cargo.lock` follows.
+7. Open PR `chore(release): 0.x.0`.
+8. Merge with `gh pr merge <number> --merge` or another non-squash strategy.
+9. Pull main, create and push the annotated tag:
+   `git tag -a v0.x.0 -m "v0.x.0"` and `git push origin v0.x.0`.
+10. Create the GitHub Release with notes based on the changelog and a full
+    changelog comparison link.
+
+Reference images under `tests/visual/references/` are outside the release
+checklist unless the user explicitly asks to update them.
+
+## VS Code Extension Release
+
+The VS Code extension version should match the npm library version. Pushing a
+`v*` tag triggers `.github/workflows/publish-vscode-extension.yml` to publish the
+extension. For manual packaging checks, use the workflow dispatch dry run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,156 +1,62 @@
-# CLAUDE.md (monorepo root)
+# CLAUDE.md
 
-## Worktree 起動時チェックリスト
+Claude-specific supplement. All agents should read `AGENTS.md` first; that file
+is the canonical workflow for this repository. This file only records
+Claude/Claude Code conventions and overrides.
 
-この CLAUDE.md を読んだら、以下を実行してロールを確定せよ:
+## Worktree Startup Checklist
 
-1. `pwd` → パスから worktree ロールを判定
-   - `.claude/worktrees/pptx` または `ooxml-pptx` → PPTX session（packages/pptx のみ編集可）
-2. 各パッケージの `CLAUDE.md` を必ず読む（パッケージ固有の詳細ルール）
-3. 他 package のファイルは読み取り OK、編集は禁止
+After reading this file:
 
-## プロジェクト概要
+1. Run `pwd` and identify the worktree role from the path.
+2. Read the package-level `CLAUDE.md` for any package you will edit.
+3. Follow the ownership limits below unless the user explicitly asks for a
+   cross-package change.
 
-OOXML (pptx/docx/xlsx) をブラウザ Canvas に描画するライブラリ群。
-Rust/WASM parser + TypeScript Canvas renderer 構成。
+## Claude Worktree Roles
 
-## ディレクトリ
+Some Claude sessions run in package-scoped worktrees:
 
-- `packages/core/` — 共有レンダリングプリミティブ + 共有型
-- `packages/pptx/` — PPTX 固有（Session A 所有）
-- `packages/docx/` — DOCX 固有（Session B 所有）
-- `packages/xlsx/` — XLSX 固有（Session C 所有）
+- `.claude/worktrees/pptx` or `ooxml-pptx` → PPTX session; edit
+  `packages/pptx` only unless the task requires shared code.
+- DOCX-focused worktrees should primarily edit `packages/docx`.
+- XLSX-focused worktrees should primarily edit `packages/xlsx`.
 
-## 横断統合の原則（重要）
+Reading other packages is fine. Editing other packages should happen only for a
+coherent cross-package fix described in `AGENTS.md`.
 
-docx / xlsx / pptx は同じ ECMA-376 / ISO-29500 の概念（DrawingML の blip・srcRect、段落・テキスト、図形 preset 等）をそれぞれ実装している。**あるパッケージで不具合を見つけ、それが共有構造上ほかのパッケージでも起こりうると判明したら、見つけたパッケージだけを直して終わらせない。3パッケージ（と core / ooxml-common の共有層）を横断して統合的に解決する。**
+## Parallel Session Safety
 
-- **1つの不具合は「他フォーマットにも同じ穴がある」シグナル**として扱う。バグ修正時は必ず「これは他フォーマットでも起きうる共通概念か？」を問い、Yes なら他2パッケージも点検・修正する。
-- **重複ロジックは共有層に集約する。** 共通の型・パース・判定ロジックは `ooxml-common`（Rust）/ `core`（TS）に寄せ、各パッケージはそれを import する。ただし周辺ロジックが本当に分岐するもの（例: 描画 math は各レンダラーの effect/clip 処理と密結合）は無理に共有しない（false-abstraction を避ける。共有するのは型 + パース + 純粋な述語まで）。
-- 横断修正は core / ooxml-common に触れるため、各 package 所有セッションの編集制限の例外として、main を狙う1本の協調的 PR にまとめてよい（commit は「1関心=1commit」で分ける）。
-- 実例: `<a:srcRect>` 画像トリミング。xlsx で発見 → docx は raster crop が全無効化・pptx は cropped metafile を double-crop する潜在バグと判明 → `SrcRect`/`parse_src_rect` を ooxml-common に集約、`isMetafileMime` を core に追加し、docx/pptx を同時修正（PR #576）。
+Multiple Claude/Codex sessions may run at once.
 
-## Git ワークフロー
+- Treat unexpected dirty files as user or peer-agent work.
+- Do not revert or overwrite unrelated changes.
+- Preserve dirty work before switching branches or pulling.
+- Private samples, local sample stories, WASM outputs, VRT screenshots, and
+  reference images remain local/generated unless the user explicitly asks to
+  commit them.
 
-**複数セッションが並列で作業するため、main への直接 push は禁止。**
+## Claude Autonomous Work
 
-- 作業は必ず feature branch で行う（例: `feature/xlsx-xxx`、`feature/pptx-xxx`）
-- `git push origin <branch>` して GitHub で PR を作成し、PR 経由で main へマージする
-- `git push origin main` は絶対に行わない（直接 push 禁止）
-- **squash merge は使わない。** merge commit（`--no-ff`）または rebase merge を使うこと。squash すると feature branch の commit 粒度が失われ、bisect / revert の単位が粗くなる
-- `git push` 前に `git config http.postBuffer 524288000` を設定すること
+Between 01:00 and 09:00 local time, Claude sessions may proceed without asking
+for confirmation for non-destructive work:
 
-## 自律作業の原則
+- code changes,
+- tests,
+- WASM builds,
+- feature-branch commits and pushes,
+- package scripts.
 
-- AM1時〜AM9時はユーザー確認不要。破壊的操作以外はすべて自律的に進めること。
-- 確認なしで進めてよい作業: コード修正・WASM ビルド・テスト実行・commit/push（feature branch のみ）・Python/npm スクリプト実行。
-- 参照画像（`packages/*/tests/visual/references/`）はユーザー指示のみ更新。絶対に自動更新しない。
-- pptx/xlsx/docx ファイルは git にコミットしない。
+Still ask before destructive operations, reference image updates, direct changes
+to `main`, or anything that conflicts with `AGENTS.md`.
 
-## 実装方針: ヒューリスティックより仕様忠実を優先
+## Commit Attribution
 
-- VRT を一時的に良くするためだけのヒューリスティック（「M > 2 なら grid snap」「auto > 720 は atLeast と見なす」「body は natural × M で heading は max(natural, pitch × M)」等）を**入れない**。
-  短期的に数字が上がっても別サンプルで後退し、理由を書けない挙動が積み重なる。
-- まず ECMA-376 / ISO-29500 の該当節を読み、Word が実際にどう解釈しているか（docGrid の snap ルール、line rule の各意味、paragraph mark sz の扱い、spacing 継承の各属性、compat フラグなど）を突き止める。
-- 仕様との差の原因が分からないときは、parser 側で情報を捨てていないか（inherit / merge で潰れていないか）を先に疑う。情報が足りなければ parser を拡張するのが正道。
-- 工数が増えても spec に忠実な実装を選ぶ。empirical な定数（1.15、0.25、ceiling 付きの条件分岐など）を入れそうになったら、いったん手を止めて「どの §x.x.x の挙動なのか」を書き出す。書き出せないなら実装しない。
-- Excel / PowerPoint / Word の UI 挙動（spec に書かれていないランタイム autofit 等）を reverse-engineering して合わせる場合は、事前にユーザー承認を得ること。迷ったら spec 通りを選ぶ。
-- 既存コードに上の原則に反するコードが残っている場合は、触る機会があったら正道に寄せる。
-- **ユーザーからの「ここがズレている」「これが描画されない」という指摘は、未実装仕様をあぶり出すヒントとして扱う。**
-  指摘箇所だけをピンポイントで合わせ込む（sample-N に合致する定数を入れる、特定パスでのみ仕様を守る、など）対応は禁止。
-  まず「どの ECMA-376 / ISO-29500 §x.x.x が関係しているか」「parser がその情報を捨てていないか」を特定し、仕様を完全な範囲で実装する。
-- 「特定の条件下でだけヒントを信用する」（例: ruby 段落でのみ `lastRenderedPageBreak` を honor する）系のゲートは、根本となる自前計算の不備を隠蔽するヒューリスティックである。
-  短期的にそのゲートが必要な場合は必ずコードコメントで「これはヒューリスティック。§x.x.x の自前計算修正が完了し次第撤去する」と明記し、issue 化して追跡すること。
+When Claude/Fable authors a commit, include:
 
-## コード例の規約
-
-README・ドキュメント・Storybook の public-facing なコード例では以下のルールを守る:
-
-- **型アサーションは `as Type` を使う。後置 `!` (non-null assertion) は使わない。**
-  ```typescript
-  // OK
-  const canvas = document.getElementById('my-canvas') as HTMLCanvasElement;
-  // NG
-  const canvas = document.getElementById('my-canvas')!;
-  ```
-- **変数名**: canvas を受け取る viewer (`DocxViewer`, `PptxViewer`) には `canvas`、container を受け取る viewer (`XlsxViewer`) には `container` を使う。
-
-## WASM ビルド手順
-
-**必ずパッケージの `wasm` npm script を使う**（生の `wasm-pack build` を直接叩かない）。各 script は `wasm-pack build` の後に `scripts/append-wasm-reinit.mjs` を実行して glue に `reinit` export を注入する。この post-build ステップを飛ばすと、WASM trap 自己回復（RB6）が使う `reinit` が存在せず、**worker が "Worker error" で無言に壊れる**（手動 `wasm-pack build && cp` の落とし穴）。
-
-```bash
-# パッケージ別（reinit 注入を含む）
-pnpm --filter @silurus/ooxml-pptx wasm
-pnpm --filter @silurus/ooxml-xlsx wasm
-pnpm --filter @silurus/ooxml-docx wasm
-
-# 全パッケージ一括（上記 3 つを順に実行）
-pnpm build:wasm
+```text
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
 ```
 
-## Storybook
-
-Storybook はルートに一本化（port 6006）。各パッケージのストーリーは `packages/*/src/*.stories.ts` に置く。
-
-静的ファイルのパスプレフィックス（`.storybook/main.ts` の `staticDirs` で定義）:
-- `packages/pptx/public/` → `/pptx/`
-- `packages/xlsx/public/` → `/xlsx/`
-- `packages/docx/public/` → `/docx/`
-
-サンプルファイルを fetch する際は必ずプレフィックスを付ける（例: `/pptx/sample-1.pptx`, `/xlsx/sample-1.xlsx`）。
-
-ローカル専用のサンプルストーリーは各パッケージの `Samples.sample.stories.ts` に置き、title は `<Viewer>/Samples` でネストさせる（例: `PptxViewer/Samples`）。`.gitignore` 済みなのでコミット対象外。
-
-```bash
-pnpm storybook        # dev server (port 6006)
-pnpm build-storybook  # storybook-static/ にビルド
-pnpm build:wasm       # 全パッケージの WASM をビルド（Storybook ビルド前に必要）
-```
-
-## テスト実行 (VRT)
-
-VRT は **ローカル専用**。CI では走らない（`private/sample-*` が再配布禁止で repo に含められないため）。`demo/sample-*` の reference 画像のみ `packages/*/tests/visual/references/demo/` にコミットされており、`private/*` の reference は手元生成かつ gitignore。
-
-```bash
-pnpm build:wasm                 # 必須: 各 parser を最新ソースから再ビルド
-pnpm vrt                        # 全パッケージ (pptx + docx + xlsx) の VRT 実行
-UPDATE_REFS=1 pnpm vrt          # 現状のレンダリング結果で reference を一括更新
-pnpm --filter @silurus/ooxml-pptx vrt   # 単一パッケージ
-```
-
-`UPDATE_REFS=1` は意図的に reference を上書きするときだけ使う（renderer 改善後 / 新規サンプル追加時 / 大幅リファクタ後）。日常テストでは付けない。
-
-## リリース手順
-
-ユーザーから「リリースして」と指示されたとき、以下を1つの PR にまとめて実行する。squash merge 禁止ルールに従い、`gh pr merge <N> --merge` でマージする。
-
-1. **README のスクリーンショット更新**（メインタスク）
-   - `docs/images/{pptx,docx,xlsx}.png` の 3 枚を撮り直す。
-   - Storybook を起動して代表的なサンプルを表示し、Playwright / Claude Preview などでスクリーンショット取得。
-   - 構図は既存画像と揃える（viewer + サンプル）。ファイル名は固定。
-2. **README の対応表更新**（メインタスク）
-   - 前リリース以降にマージされた PR を `git log --oneline` で拾い、機能追加があれば `## Feature Support` の該当行を ❌ → ✅ に反転、または新しい行を追加する。
-   - bug fix / 精度向上だけなら対応表は動かさず、根拠は CHANGELOG に書く。
-   - **紹介サイトの API リファレンス同期**（メインタスク）: 公開 API（各 `*Viewer` のオプション／メソッド、`*Presentation`・`*Document` の headless API）が前リリースから変わっていたら `site/src/lib/api-reference.ts` を実装に合わせて更新する。型は手動抽出なので放置すると陳腐化する。併せて新フォーマット機能があれば `site/src/components/Capabilities.astro` の該当列にも追記する。サイト自体のデプロイは `v*` タグで `deploy-pages.yml` が自動実行する（site を `/`、Storybook を `/storybook/` に統合配信）。
-3. **README 整合性検証**（メインタスク・必須）: タグ公開前に README 全体を実装の現状と突き合わせて検証する。npm の README はバージョン公開時にしか更新されないため、誤記が残ると次リリースまで直せない。最低限、以下を毎回確認する:
-   - **Bundle size note / パッケージ形式の記述**: 現在 `@silurus/ooxml` は **ESM 専用（`.mjs`）**。「ES + CJS 合算」「CJS を tree-shaking で落とす」等の古い記述が残っていないか。サイズ数値（数式エンジン ≈3 MB 等）が実態と合っているか。
-   - **install / import 例**: `require(...)` ではなく `import`（ESM）になっているか。公開単位が `@silurus/ooxml` 本体＋サブパス（`./docx` `./pptx` `./xlsx`）であることと矛盾しないか（サブパッケージは `private:true`）。
-   - **Feature Support 表**: 新機能の行が追加・反転されているか（このリリースの変更と一致するか）。
-   - **バージョン依存の記述**: 廃止 API・旧バージョン番号への言及が残っていないか。
-4. **CHANGELOG 追記**: `CHANGELOG.md` の先頭に `## 0.x.0 — YYYY-MM-DD` セクションを追加し、docx/pptx/xlsx/charts ごとに 1〜3 行の bullet で要点を書く。ECMA-376 節番号や PR 番号を適宜併記。
-5. **バージョン bump**: 以下を同じバージョンへ揃える（リリース番号は単一系列で進める）。
-   - **npm パッケージ (計 8 ファイル)**: ルート `package.json` と `packages/{core,pptx,xlsx,docx,markdown,node,vscode-extension}/package.json`。node は private パッケージだが、バージョンは全パッケージで統一する。`@silurus/ooxml-markdown`（`toMarkdown()` の low-level API + `ooxml-md` CLI）は **公開対象**（`private` を外し済み・`publishConfig` あり）だが、その WASM は同一 workspace の parser package（いずれも `private`）の `./wasm-binary` export に依存するため、実際に npm へ standalone 公開するには parser package の公開も要る（現行の `publish.yml` はルート `@silurus/ooxml` のみ publish）。当面はバージョンだけ揃える。VS Code 拡張も npm ライブラリと同じ番号で進めるため、機能変更がない月でも minor を上げる。
-   - **`site/package.json`**: 紹介サイト。private だが同一系列で揃える。
-   - **`packages/mcp-server/Cargo.toml`**: MCP サーバーの crate バージョン。rmcp が `initialize` ハンドシェイクで `CARGO_PKG_VERSION`（＝この `version`）を server version として MCP クライアントへ報告するため、npm 系列と揃える意義がある。bump 後は `cargo check -p ooxml-mcp-server` を実行してルート `Cargo.lock` の該当エントリを追従させ、その差分も同じコミットに含める。
-6. **PR 作成**: ブランチ名は `release/0.x.0`。PR タイトルは `chore(release): 0.x.0`。マージは必ず `--merge` か `--rebase`（squash 禁止）。
-7. **タグ作成**: PR マージ後、main を pull して `git tag -a v0.x.0 -m "v0.x.0"` → `git push origin v0.x.0`。
-8. **GitHub Release 作成**: `gh release create v0.x.0 --title v0.x.0 --notes "..."` でリリースノート公開。本文は CHANGELOG の該当セクションを要約し、末尾に `**Full Changelog**: https://github.com/yukiyokotani/office-open-xml-viewer/compare/v0.(x-1).0...v0.x.0` を追記する。既存 v0.12.0 のフォーマットを踏襲すること (`gh release view v0.12.0` で確認可能)。
-
-参照画像（`tests/visual/references/`）はこの手順の対象外。README のスクリーンショットは `docs/images/` 配下のみ。
-
-## VS Code 拡張のリリース
-
-`packages/vscode-extension` は npm ライブラリと**同じバージョン番号**で揃える。`v*` タグを push すると `.github/workflows/publish-vscode-extension.yml` が自動で走り、`vsce publish` が VS Code Marketplace に公開する。`VSCE_PAT` は repo secrets に登録済み前提。
-
-手動で `.vsix` を確認したいときは workflow_dispatch で `dry_run=true` を選ぶと、build と package のみ実行して artifact をアップロードする。
+If Claude starts or directs Codex for the work, include both the Claude/Fable
+and Codex co-author trailers, as described in `AGENTS.md`.


### PR DESCRIPTION
## Summary
- Add AGENTS.md as the canonical workflow for Codex, Claude, and other agents
- Move shared repo rules there: pull-first flow, TDD, PR/merge policy, spec-first OOXML work, private samples, Storybook/WASM, VRT, docs, and release notes
- Reduce CLAUDE.md to Claude-specific worktree and attribution guidance

## Verification
- git diff --check