### PR TITLE
Fix DOCX anchor-only text box flow

### DIFF
--- a/packages/docx/src/anchor-paragraph-spacebefore.test.ts
+++ b/packages/docx/src/anchor-paragraph-spacebefore.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderDocumentToCanvas } from './renderer.js';
-import type { BodyElement, DocParagraph, DocxDocumentModel, ImageRun, SectionProps } from './types';
+import type { BodyElement, DocParagraph, DocxDocumentModel, ImageRun, SectionProps, ShapeRun } from './types';
 
 // ECMA-376 §20.4.3.5 ST_RelFromV "paragraph": a `<wp:positionV relativeFrom=
 // "paragraph">` float is positioned "relative to the paragraph which contains the
@@ -14,10 +14,12 @@ import type { BodyElement, DocParagraph, DocxDocumentModel, ImageRun, SectionPro
 // drawn float Y at the paragraph's pre-spaceBefore top for a wrapSquare image.
 
 interface DrawCall { y: number; }
+interface TextCall { text: string; y: number; }
 
-function makeRecordingCanvas(): { canvas: HTMLCanvasElement; draws: DrawCall[] } {
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; draws: DrawCall[]; texts: TextCall[] } {
   let font = '10px serif';
   const draws: DrawCall[] = [];
+  const texts: TextCall[] = [];
   const ctx = {
     get font() { return font; },
     set font(v: string) { font = v; },
@@ -37,13 +39,15 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; draws: DrawCall[] }
     bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
     // No srcRect ⇒ 5-arg form drawImage(img, dx, dy, dw, dh): dy is the 3rd arg.
     drawImage(_img: unknown, _dx: number, dy: number) { draws.push({ y: dy }); },
-    fillText() {}, strokeText() {},
+    fillText(text: string, _x: number, y: number) { texts.push({ text, y }); },
+    strokeText() {},
     fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
     textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
     globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
   };
   const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
-  return { canvas: canvas as unknown as HTMLCanvasElement, draws };
+  return { canvas: canvas as unknown as HTMLCanvasElement, draws, texts };
 }
 
 function squareFloat(): ImageRun {
@@ -67,6 +71,57 @@ function paraWithFloat(spaceBefore: number): DocParagraph {
              strikethrough: false, fontSize: 11, color: null, fontFamily: 'Times New Roman',
              fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null,
              hyperlink: null } as DocParagraph['runs'][number]],
+    defaultFontSize: 11, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function squareTextBox(text: string, y: number, height: number): ShapeRun & { type: 'shape' } {
+  return {
+    type: 'shape',
+    widthPt: 400,
+    heightPt: height,
+    anchorXPt: 0,
+    anchorYPt: y,
+    anchorXFromMargin: false,
+    anchorYFromPara: true,
+    anchorXRelativeFrom: 'column',
+    anchorYRelativeFrom: 'paragraph',
+    zOrder: 0,
+    subpaths: [],
+    presetGeometry: 'rect',
+    fill: { fillType: 'solid', color: '4F2683' },
+    stroke: null,
+    wrapMode: 'square',
+    wrapSide: 'bothSides',
+    distTop: 0,
+    distBottom: 0,
+    distLeft: 0,
+    distRight: 0,
+    textBlocks: [{
+      text,
+      fontSizePt: 10,
+      color: 'FFFFFF',
+      fontFamily: 'Times New Roman',
+      alignment: 'left',
+      runs: [{ text, fontSizePt: 10, color: 'FFFFFF', fontFamily: 'Times New Roman' }],
+    }],
+    textInsetL: 0,
+    textInsetT: 0,
+    textInsetR: 0,
+    textInsetB: 0,
+  } as unknown as ShapeRun & { type: 'shape' };
+}
+
+function anchorOnlyParaWithStackedTextBoxes(): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [
+      squareTextBox('LOWER', 40, 120),
+      squareTextBox('TITLE', 6, 20),
+    ] as unknown as DocParagraph['runs'],
     defaultFontSize: 11, defaultFontFamily: 'Times New Roman', widowControl: false,
   } as unknown as DocParagraph;
 }
@@ -104,5 +159,20 @@ describe('paragraph-anchored wrap float Y (§20.4.3.5)', () => {
     // float must draw at y≈0, NOT y≈24 (the post-spaceBefore text area).
     expect(draws.length).toBeGreaterThan(0);
     expect(draws[0].y).toBeCloseTo(0, 2);
+  });
+
+  it('does not shift wrapSquare text boxes when an anchor-only mark flows below another same-paragraph float', async () => {
+    const { canvas, texts } = makeRecordingCanvas();
+    await renderDocumentToCanvas(docOf(anchorOnlyParaWithStackedTextBoxes()), canvas, 0, {
+      dpr: 1, width: 400,
+      fetchImage: async (path: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }),
+    });
+
+    const title = texts.find((call) => call.text === 'TITLE');
+    expect(title).toBeDefined();
+    // ECMA-376 §20.4.3.5: the wrapSquare text box stays relative to its anchor
+    // paragraph's original top. The empty paragraph mark may flow below a float,
+    // but that flow shift applies to wrapNone anchors, not to wrap floats.
+    expect(title!.y).toBeLessThan(40);
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5032,10 +5032,12 @@ function renderEmptyMarkParagraph(
   // wrapNone anchor images anchor relative to the paragraph (ayFromPara); when
   // the mark line flowed below a float band the paragraph (and its wrapNone
   // image) drops by the same amount, so shift the anchor base by flowShift while
-  // keeping the un-flowed base (paragraphStartY) otherwise unchanged. Only the
-  // first slice draws them (a continuation slice already did on its page).
+  // keeping the un-flowed base (paragraphStartY) otherwise unchanged. Wrap
+  // shapes are themselves the float band, so they stay anchored to the original
+  // paragraph top (§20.4.3.5) instead of following the paragraph mark's flow.
+  // Only the first slice draws them (a continuation slice already did on its page).
   if (!lineSlice || lineSlice.start === 0) {
-    renderAnchorImages(para, state, paragraphStartY + flowShift);
+    renderAnchorImages(para, state, paragraphStartY + flowShift, 'front', paragraphStartY);
   }
 }
 
@@ -6879,6 +6881,7 @@ function renderAnchorImages(
   state: RenderState,
   paragraphTopPx: number,
   phase: 'behind' | 'front' = 'front',
+  wrapFloatParagraphTopPx = paragraphTopPx,
 ): void {
   if (state.dryRun) return;
   if (phase === 'behind') {
@@ -6888,7 +6891,11 @@ function renderAnchorImages(
       .slice()
       .sort((a, b) =>
         ((a as unknown as ShapeRun).zOrder ?? 0) - ((b as unknown as ShapeRun).zOrder ?? 0));
-    for (const s of shapes) renderAnchorShape(s as unknown as ShapeRun, state, paragraphTopPx);
+    for (const s of shapes) {
+      const shape = s as unknown as ShapeRun;
+      const top = isWrapFloat(shape.wrapMode) ? wrapFloatParagraphTopPx : paragraphTopPx;
+      renderAnchorShape(shape, state, top);
+    }
     return;
   }
   // Front floats (behindDoc="0"): defer to the page's top layer so a later inline
@@ -6904,7 +6911,7 @@ function renderAnchorImages(
       state.contentX = cx;
       state.contentW = cw;
       state.deferFront = null; // draw in place this time
-      renderAnchorImages(para, state, paragraphTopPx, 'front');
+      renderAnchorImages(para, state, paragraphTopPx, 'front', wrapFloatParagraphTopPx);
       state.contentX = sx;
       state.contentW = sw;
       state.deferFront = sd;
@@ -6915,7 +6922,8 @@ function renderAnchorImages(
     if (run.type === 'shape') {
       const s = run as unknown as ShapeRun;
       if (s.behindDoc) continue;
-      renderAnchorShape(s, state, paragraphTopPx);
+      const top = isWrapFloat(s.wrapMode) ? wrapFloatParagraphTopPx : paragraphTopPx;
+      renderAnchorShape(s, state, top);
       continue;
     }
     if (run.type === 'chart') {
@@ -9623,4 +9631,3 @@ function paragraphMarkEmPx(para: DocParagraph, scale: number): number {
 // from `measuredWidth` by construction — there is no separate per-glyph sum to
 // drift against the whole-string measure (約物半角 contextual collapse stays
 // honoured). See packages/core/src/text/justify-positions.ts.
-


### PR DESCRIPTION
## Summary
- Keep wrap-float text boxes anchored to the original paragraph top when an anchor-only paragraph mark flows below same-paragraph floats.
- Preserve the existing behavior where wrapNone anchors follow the flowed empty mark.
- Add a regression test for stacked paragraph-anchored text boxes that exercise the anchor-origin mismatch without relying on redistributed private samples.

## Root Cause
The renderer shifted the anchor base for all anchored shapes after an empty paragraph mark flowed below a float band. For wrapSquare text boxes, that reused the mark's shifted origin instead of the ECMA-376 paragraph-relative anchor origin, so paragraph-anchored text boxes could be laid out lower than Word places them.

## Verification
- `pnpm vitest run packages/docx/src/anchor-paragraph-spacebefore.test.ts packages/docx/src/textbox-eastasia-line-floor.test.ts packages/docx/src/anchored-textbox-render.test.ts`
- `tsc --build --pretty false`
- Rebuilt DOCX WASM locally and verified the affected local-only sample against its Word-exported reference without publishing sample content or local paths.
