### PR TITLE
Fix DOCX callouts and table flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 !packages/docx/public/demo/
 !packages/docx/public/demo/*.docx
 # Office Open XML spec documents
+/spec
 spec/
 node_modules/
 .claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,16 +30,26 @@ Use this flow for ordinary bug fixes and feature work:
    to another session.
 3. Create a feature branch. Use `codex/<topic>` for Codex work when possible;
    otherwise follow the repository's existing branch naming.
-4. Work with TDD for bug fixes:
+4. When creating or entering a Codex/Claude worktree, make the root checkout's
+   ignored `spec/` directory available from that worktree as a local symlink.
+   For the standard `.claude/worktrees/<name>` layout, run:
+
+   ```bash
+   ln -s ../../../spec spec
+   ```
+
+   If the worktree lives elsewhere, create `spec` as a symlink to the main local
+   checkout's `spec/` directory. Do not copy or commit the specification files.
+5. Work with TDD for bug fixes:
    - explore the failing sample or behavior,
    - add a focused failing test,
    - make it pass,
    - refactor only where it reduces real complexity.
-5. Verify with the narrowest meaningful tests first, then broader checks when the
+6. Verify with the narrowest meaningful tests first, then broader checks when the
    touched surface warrants it.
-6. Commit only the intended source/docs/test files. Do not commit private samples
+7. Commit only the intended source/docs/test files. Do not commit private samples
    or generated local artifacts.
-7. Push the feature branch, create a PR, wait for checks when practical, and merge
+8. Push the feature branch, create a PR, wait for checks when practical, and merge
    with a merge commit. Do not squash.
 
 ## Git and PR Rules
@@ -54,12 +64,15 @@ Use this flow for ordinary bug fixes and feature work:
   - subject: `fix(scope): ...`, `test(scope): ...`, `refactor(scope): ...`, etc.
   - body: explain the root cause, the fix, and verification.
   - include specification sections or observed Office behavior when relevant.
-- Agent-authored commits should include a matching co-author trailer:
-  - Codex: `Co-Authored-By: Codex <noreply@openai.com>`
-  - Claude/Fable: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- Agent-authored commits should include a matching co-author trailer. Include
+  the actual model used for that task; do not hard-code a model name across
+  tasks. Examples:
+  - Codex: `Co-Authored-By: Codex <model-name> <noreply@openai.com>`
+  - Claude/Fable: `Co-Authored-By: Claude <model-name> <noreply@anthropic.com>`
 - If Claude starts or delegates work to Codex, include both trailers in the
-  resulting commit. This preserves the human-readable provenance of the
-  orchestration layer (Claude) and the implementation agent (Codex).
+  resulting commit, including the model each agent actually used for that task.
+  This preserves the human-readable provenance of the orchestration layer and
+  the implementation agent.
 
 ## Verification
 
@@ -92,6 +105,13 @@ assuming the source change is broken.
 
 Be specification-first.
 
+- Before implementing OOXML behavior, consult the relevant documents under the
+  local `spec/` symlink. Prefer ECMA-376 / ISO-29500 for normative behavior, and
+  Microsoft extension notes such as `[MS-DOCX]`, `[MS-XLSX]`, `[MS-PPTX]`, and
+  `[MS-ODRAWXML]` when Office-specific behavior or extensions are involved.
+- Record the relevant specification section, schema element, or observed Office
+  behavior in the commit body or code comment when it materially explains the
+  implementation.
 - Prefer ECMA-376 / ISO-29500 behavior over sample-specific tuning.
 - Do not add heuristics only to improve one VRT/sample number, such as arbitrary
   thresholds, empirical scaling constants, or special-casing a sample path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,10 @@ Claude/Claude Code conventions and overrides.
 After reading this file:
 
 1. Run `pwd` and identify the worktree role from the path.
-2. Read the package-level `CLAUDE.md` for any package you will edit.
-3. Follow the ownership limits below unless the user explicitly asks for a
+2. Ensure `spec` exists in the worktree as a symlink to the main checkout's
+   ignored OOXML specification directory, following `AGENTS.md`.
+3. Read the package-level `CLAUDE.md` for any package you will edit.
+4. Follow the ownership limits below unless the user explicitly asks for a
    cross-package change.
 
 ## Claude Worktree Roles
@@ -52,11 +54,13 @@ to `main`, or anything that conflicts with `AGENTS.md`.
 
 ## Commit Attribution
 
-When Claude/Fable authors a commit, include:
+When Claude authors a commit, include a co-author trailer with the actual model
+used for that task, for example:
 
 ```text
-Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+Co-Authored-By: Claude <model-name> <noreply@anthropic.com>
 ```
 
 If Claude starts or directs Codex for the work, include both the Claude/Fable
-and Codex co-author trailers, as described in `AGENTS.md`.
+and Codex co-author trailers with the models actually used for that task, as
+described in `AGENTS.md`.

--- a/packages/core/src/image/wmf.test.ts
+++ b/packages/core/src/image/wmf.test.ts
@@ -94,16 +94,20 @@ function concat(...parts: Uint8Array[]): Uint8Array {
 // WMF record function codes
 const FN = {
   EOF: 0x0000,
+  SETTEXTALIGN: 0x012e,
+  SETTEXTCOLOR: 0x0209,
   SETPOLYFILLMODE: 0x0106,
   SETWINDOWORG: 0x020b,
   SETWINDOWEXT: 0x020c,
   SELECTOBJECT: 0x012d,
   DELETEOBJECT: 0x01f0,
+  TEXTOUT: 0x0521,
   POLYGON: 0x0324,
   POLYLINE: 0x0325,
   POLYPOLYGON: 0x0538,
   RECTANGLE: 0x041b,
   CREATEPENINDIRECT: 0x02fa,
+  CREATEFONTINDIRECT: 0x02fb,
   CREATEBRUSHINDIRECT: 0x02fc,
   STRETCHDIBITS: 0x0f43,
 } as const;
@@ -112,17 +116,23 @@ const FN = {
 
 interface Call {
   op: string;
-  args: number[];
+  args: Array<number | string>;
 }
 interface MockCtx {
   ctx: CanvasRenderingContext2D;
   calls: Call[];
-  styles: { fill: string[]; stroke: string[]; lineWidth: number[]; fillRules: (string | undefined)[] };
+  styles: { fill: string[]; stroke: string[]; lineWidth: number[]; fillRules: (string | undefined)[]; text: string[] };
 }
 
 function makeRecordingCtx(): MockCtx {
   const calls: Call[] = [];
-  const styles = { fill: [] as string[], stroke: [] as string[], lineWidth: [] as number[], fillRules: [] as (string | undefined)[] };
+  const styles = {
+    fill: [] as string[],
+    stroke: [] as string[],
+    lineWidth: [] as number[],
+    fillRules: [] as (string | undefined)[],
+    text: [] as string[],
+  };
   let _fill = '#000';
   let _stroke = '#000';
   let _lw = 1;
@@ -133,6 +143,9 @@ function makeRecordingCtx(): MockCtx {
     set strokeStyle(v: string) { _stroke = v; },
     get lineWidth() { return _lw; },
     set lineWidth(v: number) { _lw = v; },
+    font: '10px sans-serif',
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'top' as CanvasTextBaseline,
     lineJoin: 'miter' as CanvasLineJoin,
     lineCap: 'butt' as CanvasLineCap,
     save() { calls.push({ op: 'save', args: [] }); },
@@ -151,6 +164,10 @@ function makeRecordingCtx(): MockCtx {
       calls.push({ op: 'fill', args: [] });
       styles.fill.push(_fill);
       styles.fillRules.push(rule);
+    },
+    fillText(t: string, x: number, y: number) {
+      calls.push({ op: 'fillText', args: [t, x, y] });
+      styles.text.push(_fill);
     },
   };
   return { ctx: ctx as unknown as CanvasRenderingContext2D, calls, styles };
@@ -524,6 +541,45 @@ describe('playWmf — object table create / delete / slot reuse', () => {
     playWmf(file, m.ctx, 10, 10);
     expect(m.styles.fill.at(-1)?.toLowerCase()).toBe('#00ff00');
     expect(m.styles.stroke.at(-1)?.toLowerCase()).toBe('#ff0000');
+  });
+});
+
+// ── playWmf: text-out labels ────────────────────────────────────────────────
+
+describe('playWmf — TEXTOUT text labels', () => {
+  it('draws a META_TEXTOUT string with the selected font color at the mapped point', () => {
+    const text = '10';
+    const file = concat(
+      wmfHeader(),
+      record(FN.SETWINDOWORG, (w) => w.i16(0).i16(0)),
+      record(FN.SETWINDOWEXT, (w) => w.i16(100).i16(100)),
+      record(FN.CREATEFONTINDIRECT, (w) => {
+        w.i16(-12).i16(0).i16(0).i16(0).i16(400);
+        w.raw(0, 0, 0, 0, 0, 0, 0, 0);
+        const face = Array.from(Buffer.from('Arial\0', 'latin1'));
+        w.raw(...face);
+        for (let i = face.length; i < 32; i++) w.raw(0);
+      }),
+      record(FN.SELECTOBJECT, (w) => w.u16(0)),
+      record(FN.SETTEXTCOLOR, (w) => w.u32(0x000000ff)), // red
+      record(FN.SETTEXTALIGN, (w) => w.u16(0x0006)), // TA_CENTER
+      record(FN.TEXTOUT, (w) => {
+        w.u16(text.length);
+        w.raw(...Array.from(Buffer.from(text, 'latin1')));
+        w.i16(30).i16(20); // yStart, xStart
+      }),
+      record(FN.EOF, () => {}),
+    );
+
+    const m = makeRecordingCtx();
+    expect(playWmf(file, m.ctx, 100, 100)).toBe(true);
+
+    const texts = m.calls.filter((c) => c.op === 'fillText');
+    expect(texts).toHaveLength(1);
+    expect(texts[0].args).toEqual(['10', 20, 30]);
+    expect(m.styles.text.at(-1)?.toLowerCase()).toBe('#ff0000');
+    expect(m.ctx.textAlign).toBe('center');
+    expect(m.ctx.textBaseline).toBe('top');
   });
 });
 

--- a/packages/core/src/image/wmf.ts
+++ b/packages/core/src/image/wmf.ts
@@ -17,10 +17,11 @@
 //   - All values little-endian. COLORREF = u32 0x00BBGGRR (low byte = R).
 //
 // Implemented records: SETWINDOWORG, SETWINDOWEXT, SETPOLYFILLMODE,
-// CREATEPENINDIRECT, CREATEBRUSHINDIRECT, SELECTOBJECT, DELETEOBJECT,
-// POLYLINE, POLYGON, POLYPOLYGON, RECTANGLE, STRETCHDIBITS (embedded raster DIB
-// via the shared decoder in ./dib.ts), EOF.
-// Ignored (no-op, skipped by size): ESCAPE, SETROP2, SETBKMODE, SETTEXTALIGN,
+// SETTEXTCOLOR, SETTEXTALIGN, CREATEPENINDIRECT, CREATEBRUSHINDIRECT,
+// CREATEFONTINDIRECT, SELECTOBJECT, DELETEOBJECT, POLYLINE, POLYGON,
+// POLYPOLYGON, RECTANGLE, TEXTOUT, STRETCHDIBITS (embedded raster DIB via the
+// shared decoder in ./dib.ts), EOF.
+// Ignored (no-op, skipped by size): ESCAPE, SETROP2, SETBKMODE,
 // SETSTRETCHBLTMODE, SETMAPMODE, DIBBITBLT/DIBSTRETCHBLT (their exact param
 // layout is not decoded here — skipped rather than mis-parsed), and any
 // unrecognized record.
@@ -44,16 +45,21 @@ import { createAuxCanvas } from '../canvas/aux-canvas.js';
 // WMF record function codes (the subset we act on; others are skipped by size).
 const META = {
   EOF: 0x0000,
+  SETBKMODE: 0x0102,
+  SETTEXTALIGN: 0x012e,
+  SETTEXTCOLOR: 0x0209,
   SETPOLYFILLMODE: 0x0106,
   SETWINDOWORG: 0x020b,
   SETWINDOWEXT: 0x020c,
   SELECTOBJECT: 0x012d,
   DELETEOBJECT: 0x01f0,
+  TEXTOUT: 0x0521,
   POLYGON: 0x0324,
   POLYLINE: 0x0325,
   POLYPOLYGON: 0x0538,
   RECTANGLE: 0x041b,
   CREATEPENINDIRECT: 0x02fa,
+  CREATEFONTINDIRECT: 0x02fb,
   CREATEBRUSHINDIRECT: 0x02fc,
   DIBBITBLT: 0x0940,
   DIBSTRETCHBLT: 0x0b41,
@@ -134,7 +140,14 @@ interface Brush {
   kind: 'brush';
   fill: string | null; // null = BS_NULL / hollow (no fill)
 }
-type WmfObject = Pen | Brush;
+interface Font {
+  kind: 'font';
+  height: number; // |lfHeight|, logical units
+  weight: number; // lfWeight (400 normal, 700 bold)
+  italic: boolean;
+  face: string;
+}
+type WmfObject = Pen | Brush | Font;
 
 /** Inserts an object at the FIRST free slot (lowest index whose slot is empty
  *  or was deleted), mirroring the WMF object-table allocation rule. */
@@ -171,6 +184,9 @@ class Cursor {
     this.p += 2;
     return v;
   }
+  u8(): number {
+    return this.b[this.p++];
+  }
   u32(): number {
     const v =
       (this.b[this.p] |
@@ -180,6 +196,15 @@ class Cursor {
       0;
     this.p += 4;
     return v;
+  }
+  bytes(n: number): Uint8Array {
+    const end = Math.min(this.p + Math.max(0, n), this.end);
+    const out = this.b.subarray(this.p, end);
+    this.p = end;
+    return out;
+  }
+  skip(n: number): void {
+    this.p = Math.min(this.p + Math.max(0, n), this.end);
   }
 }
 
@@ -201,6 +226,9 @@ interface PlayState {
   objects: (WmfObject | null)[];
   curPen: Pen | null;
   curBrush: Brush | null;
+  curFont: Font | null;
+  textColor: string;
+  textAlign: number;
   fillRule: CanvasFillRule; // from SETPOLYFILLMODE
   drew: boolean;
   // When true, strokes whose edge lies on the window/device boundary are
@@ -430,6 +458,57 @@ function createBrush(c: Cursor): Brush {
   return { kind: 'brush', fill };
 }
 
+function decodeSingleByteText(bytes: Uint8Array): string {
+  const end = bytes.indexOf(0);
+  const body = end >= 0 ? bytes.subarray(0, end) : bytes;
+  if (body.length === 0) return '';
+  try {
+    return new TextDecoder('shift_jis').decode(body);
+  } catch {
+    return String.fromCharCode(...body);
+  }
+}
+
+function createFont(c: Cursor): Font {
+  const height = Math.abs(c.i16());
+  c.i16(); // lfWidth
+  c.i16(); // lfEscapement (rotation is not replayed by the WMF player yet)
+  c.i16(); // lfOrientation
+  const weight = c.i16();
+  const italic = c.u8() !== 0;
+  c.u8(); // lfUnderline
+  c.u8(); // lfStrikeOut
+  c.u8(); // lfCharSet
+  c.u8(); // lfOutPrecision
+  c.u8(); // lfClipPrecision
+  c.u8(); // lfQuality
+  c.u8(); // lfPitchAndFamily
+  const face = decodeSingleByteText(c.bytes(Math.min(32, c.remaining)));
+  return { kind: 'font', height, weight, italic, face };
+}
+
+function drawTextOut(s: PlayState, text: string, x: number, y: number): void {
+  if (text.length === 0) return;
+  const font = s.curFont;
+  const logicalHeight = font?.height || 12;
+  const px = Math.abs(mapY(s, s.orgY + logicalHeight) - mapY(s, s.orgY));
+  if (!Number.isFinite(px) || px < 1) return;
+  const { ctx } = s;
+  try {
+    ctx.fillStyle = s.textColor;
+    const weight = font && font.weight >= 700 ? 'bold ' : '';
+    const italic = font?.italic ? 'italic ' : '';
+    ctx.font = `${italic}${weight}${px}px ${font?.face || 'sans-serif'}`;
+    const horiz = s.textAlign & 0x6;
+    ctx.textAlign = horiz === 0x2 ? 'right' : horiz === 0x6 ? 'center' : 'left';
+    ctx.textBaseline = (s.textAlign & 0x18) === 0x18 ? 'alphabetic' : 'top';
+    ctx.fillText(text, mapX(s, x), mapY(s, y));
+    s.drew = true;
+  } catch {
+    // Some test or server-side contexts may not implement fillText.
+  }
+}
+
 // ── core record-replay loop (pure; testable with a mock ctx) ────────────────
 
 /**
@@ -474,6 +553,9 @@ export function playWmf(
     objects: [],
     curPen: null,
     curBrush: null,
+    curFont: null,
+    textColor: '#000000',
+    textAlign: 0,
     fillRule: 'nonzero',
     drew: false,
     suppressBoundaryFrame,
@@ -515,6 +597,14 @@ export function playWmf(
         s.fillRule = mode === 1 ? 'evenodd' : 'nonzero';
         break;
       }
+      case META.SETTEXTCOLOR: {
+        s.textColor = colorRefToCss(c.u32());
+        break;
+      }
+      case META.SETTEXTALIGN: {
+        s.textAlign = c.u16();
+        break;
+      }
       case META.CREATEPENINDIRECT: {
         insertObject(s.objects, createPen(c));
         break;
@@ -523,11 +613,16 @@ export function playWmf(
         insertObject(s.objects, createBrush(c));
         break;
       }
+      case META.CREATEFONTINDIRECT: {
+        insertObject(s.objects, createFont(c));
+        break;
+      }
       case META.SELECTOBJECT: {
         const idx = c.u16();
         const obj = s.objects[idx];
         if (obj?.kind === 'pen') s.curPen = obj;
         else if (obj?.kind === 'brush') s.curBrush = obj;
+        else if (obj?.kind === 'font') s.curFont = obj;
         break;
       }
       case META.DELETEOBJECT: {
@@ -536,6 +631,7 @@ export function playWmf(
         if (obj) {
           if (obj === s.curPen) s.curPen = null;
           if (obj === s.curBrush) s.curBrush = null;
+          if (obj === s.curFont) s.curFont = null;
           s.objects[idx] = null;
         }
         break;
@@ -566,6 +662,17 @@ export function playWmf(
           [mapX(s, right), mapY(s, bottom)],
           [mapX(s, left), mapY(s, bottom)],
         ]);
+        break;
+      }
+      case META.TEXTOUT: {
+        // META_TEXTOUT params: u16 StringLength, String bytes padded to a WORD
+        // boundary, then i16 yStart and i16 xStart.
+        const len = c.u16();
+        const text = decodeSingleByteText(c.bytes(len));
+        if (len % 2 !== 0) c.skip(1);
+        const y = c.i16();
+        const x = c.i16();
+        drawTextOut(s, text, x, y);
         break;
       }
       case META.STRETCHDIBITS: {
@@ -602,6 +709,7 @@ export function playWmf(
       }
       case META.DIBSTRETCHBLT:
       case META.DIBBITBLT:
+      case META.SETBKMODE:
         // META_DIBBITBLT / META_DIBSTRETCHBLT ([MS-WMF] 2.3.1.2 / 2.3.1.3) also
         // carry a packed DIB, but with a different (raster-op-dependent) preamble
         // whose exact layout we do not decode here. Skipping is safer than

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -206,8 +206,8 @@ pub fn parse(zip: &mut Zip) -> Result<Document, String> {
     // capture it here and stamp it onto the section below.
     let mut even_and_odd_headers = false;
     if let Ok(settings_xml) = read_zip_string(zip, &settings_path) {
-        if let Some(lang) = parse_theme_font_bidi_lang(&settings_xml) {
-            theme.fill_default_cs_font(&lang);
+        if let Some(langs) = parse_theme_font_langs(&settings_xml) {
+            theme.apply_theme_font_langs(&langs);
         }
         document_settings = parse_document_settings(&settings_xml);
         even_and_odd_headers = parse_even_and_odd_headers(&settings_xml);
@@ -615,6 +615,12 @@ pub struct ThemeColors {
     /// rFonts @asciiTheme / @hAnsiTheme / @eastAsiaTheme / @cstheme.
     /// Keys: "minor" + "major" crossed with "latin"/"ea"/"cs".
     fonts: HashMap<String, String>,
+    /// Supplemental language/script-specific theme fonts from
+    /// `<a:majorFont|minorFont><a:font script="Jpan" typeface="…"/>`.
+    /// Keys: "minor/Jpan", "major/Arab", etc. ECMA-376 §17.15.1.88 maps
+    /// w:themeFontLang languages to these script fonts for major/minor theme
+    /// references before falling back to the generic latin/ea/cs elements.
+    script_fonts: HashMap<String, String>,
     /// Raw theme XML, retained so wps:style/fillRef → fillStyleLst /
     /// bgFillStyleLst lookups (ECMA-376 §20.1.4.1.7) can be resolved on demand.
     /// Re-parsing per shape is fine — the cover usually has only a handful of
@@ -634,6 +640,7 @@ impl ThemeColors {
     fn parse(xml: &str) -> Self {
         let mut map: HashMap<String, String> = HashMap::new();
         let mut fonts: HashMap<String, String> = HashMap::new();
+        let mut script_fonts: HashMap<String, String> = HashMap::new();
         let theme_xml = Some(xml.to_string());
 
         // Color slots: shared clrScheme parse; docx uppercases each hex and keys
@@ -659,9 +666,34 @@ impl ThemeColors {
             }
         }
 
+        if let Ok(doc) = parse_guarded(xml) {
+            for (group_name, prefix) in [("majorFont", "major"), ("minorFont", "minor")] {
+                if let Some(group) = doc
+                    .descendants()
+                    .find(|n| n.is_element() && n.tag_name().name() == group_name)
+                {
+                    for font in group
+                        .children()
+                        .filter(|n| n.is_element() && n.tag_name().name() == "font")
+                    {
+                        let Some(script) = font.attribute("script").filter(|s| !s.is_empty())
+                        else {
+                            continue;
+                        };
+                        let Some(typeface) = font.attribute("typeface").filter(|s| !s.is_empty())
+                        else {
+                            continue;
+                        };
+                        script_fonts.insert(format!("{prefix}/{script}"), typeface.to_string());
+                    }
+                }
+            }
+        }
+
         Self {
             map,
             fonts,
+            script_fonts,
             theme_xml,
             ..Default::default()
         }
@@ -741,6 +773,33 @@ impl ThemeColors {
         }
     }
 
+    /// Apply §17.15.1.88 `w:themeFontLang`: a theme reference such as
+    /// `minorEastAsia` uses the theme `<a:font script="…">` matching the
+    /// configured East Asian language before falling back to `<a:ea>`.
+    pub fn apply_theme_font_langs(&mut self, langs: &ThemeFontLangs) {
+        if let Some(script) = langs.latin.as_deref().and_then(theme_script_for_lang) {
+            self.apply_script_font_to_axis(script, "latin");
+        }
+        if let Some(script) = langs.east_asia.as_deref().and_then(theme_script_for_lang) {
+            self.apply_script_font_to_axis(script, "ea");
+        }
+        if let Some(script) = langs.bidi.as_deref().and_then(theme_script_for_lang) {
+            self.apply_script_font_to_axis(script, "cs");
+        }
+        if let Some(bidi) = langs.bidi.as_deref() {
+            self.fill_default_cs_font(bidi);
+        }
+    }
+
+    fn apply_script_font_to_axis(&mut self, script: &str, axis: &str) {
+        for group in ["minor", "major"] {
+            if let Some(typeface) = self.script_fonts.get(&format!("{group}/{script}")) {
+                self.fonts
+                    .insert(format!("{group}/{axis}"), typeface.clone());
+            }
+        }
+    }
+
     /// Resolve an rFonts theme reference (e.g. "minorHAnsi" → minor.latin,
     /// "minorEastAsia" → minor.ea, "majorHAnsi" → major.latin). Returns None
     /// when the reference is unknown or the theme has no matching typeface.
@@ -758,14 +817,67 @@ impl ThemeColors {
     }
 }
 
-/// Extract `<w:themeFontLang w:bidi="…"/>` from word/settings.xml (§17.15.1.88).
-fn parse_theme_font_bidi_lang(settings_xml: &str) -> Option<String> {
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ThemeFontLangs {
+    latin: Option<String>,
+    east_asia: Option<String>,
+    bidi: Option<String>,
+}
+
+/// Extract `<w:themeFontLang …/>` from word/settings.xml (§17.15.1.88).
+fn parse_theme_font_langs(settings_xml: &str) -> Option<ThemeFontLangs> {
     let doc = parse_guarded(settings_xml).ok()?;
     let node = doc
         .root_element()
         .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "themeFontLang")?;
-    attr_w(node, "bidi").filter(|s| !s.is_empty())
+    Some(ThemeFontLangs {
+        latin: attr_w(node, "val").filter(|s| !s.is_empty()),
+        east_asia: attr_w(node, "eastAsia").filter(|s| !s.is_empty()),
+        bidi: attr_w(node, "bidi").filter(|s| !s.is_empty()),
+    })
+}
+
+/// Back-compat helper for older parser tests that only care about bidi.
+#[cfg(test)]
+fn parse_theme_font_bidi_lang(settings_xml: &str) -> Option<String> {
+    parse_theme_font_langs(settings_xml).and_then(|langs| langs.bidi)
+}
+
+fn theme_script_for_lang(lang: &str) -> Option<&'static str> {
+    let lower = lang.to_ascii_lowercase();
+    let primary = lower.split('-').next().unwrap_or("");
+    match primary {
+        "ja" => Some("Jpan"),
+        "ko" => Some("Hang"),
+        "zh" => {
+            let is_traditional = lower.contains("-hant")
+                || lower.ends_with("-tw")
+                || lower.ends_with("-hk")
+                || lower.ends_with("-mo");
+            Some(if is_traditional { "Hant" } else { "Hans" })
+        }
+        "ar" => Some("Arab"),
+        "he" => Some("Hebr"),
+        "th" => Some("Thai"),
+        "hi" | "mr" | "ne" | "sa" => Some("Deva"),
+        "bn" | "as" => Some("Beng"),
+        "gu" => Some("Gujr"),
+        "kn" => Some("Knda"),
+        "pa" => Some("Guru"),
+        "ta" => Some("Taml"),
+        "te" => Some("Telu"),
+        "ml" => Some("Mlym"),
+        "or" => Some("Orya"),
+        "km" => Some("Khmr"),
+        "lo" => Some("Laoo"),
+        "si" => Some("Sinh"),
+        "bo" => Some("Tibt"),
+        "mn" => Some("Mong"),
+        "ug" => Some("Uigh"),
+        "vi" => Some("Viet"),
+        _ => None,
+    }
 }
 
 /// ECMA-376 §17.10.1 `<w:evenAndOddHeaders/>` — a document-wide
@@ -832,6 +944,24 @@ fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentS
         .and_then(|n| attr_w(n, "val"))
         .map(|s| twips_to_pt(&s));
 
+    // ECMA-376 §17.15.1.18 `<w:characterSpacingControl>` — document-wide
+    // East Asian punctuation / character-spacing mode.
+    let character_spacing_control = root
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "characterSpacingControl")
+        .and_then(|n| attr_w(n, "val").map(|s| s.to_string()));
+
+    // ECMA-376 §17.15.3.1 compatibility settings live under `<w:compat>`.
+    let compat = root
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "compat");
+    let compat_bool = |name: &str| -> Option<bool> {
+        bool_prop(compat?, name)
+    };
+    let use_fe_layout = compat_bool("useFELayout");
+    let balance_single_byte_double_byte_width =
+        compat_bool("balanceSingleByteDoubleByteWidth");
+
     // ECMA-376 §22.1.2.30 `m:mathPr/m:defJc@m:val` — document-wide default math
     // justification (math namespace, bare `val` fallback).
     let math_def_jc = root
@@ -850,6 +980,9 @@ fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentS
         && no_line_breaks_after.is_none()
         && math_def_jc.is_none()
         && default_tab_stop.is_none()
+        && character_spacing_control.is_none()
+        && use_fe_layout.is_none()
+        && balance_single_byte_double_byte_width.is_none()
     {
         return None;
     }
@@ -859,6 +992,9 @@ fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentS
         no_line_breaks_after,
         math_def_jc,
         default_tab_stop,
+        character_spacing_control,
+        use_fe_layout,
+        balance_single_byte_double_byte_width,
     })
 }
 
@@ -1324,16 +1460,22 @@ fn split_para_on_page_breaks(para: DocParagraph) -> Vec<ParaPiece> {
     // (Word's anchored shapes paragraph at the cover commonly does this
     // to force the cover onto its own page; the trailing empty chunk
     // would otherwise emit an extra blank paragraph + page break).
-    let (chunks, seps): (Vec<Vec<DocRun>>, Vec<ParaPiece>) = {
+    let (chunks, seps, trailing_seps): (Vec<Vec<DocRun>>, Vec<ParaPiece>, Vec<ParaPiece>) = {
         let mut c = chunks;
         let mut s = seps;
+        let mut trailing = Vec::new();
         while c.last().map(|r| !has_visible(r)).unwrap_or(false) && c.len() > 1 {
             c.pop();
-            // Each pop also drops the break that produced this empty trailing
-            // chunk (seps[k] is the break BEFORE chunk[k+1]).
-            s.pop();
+            // Each pop removes the empty chunk produced AFTER a hard break at
+            // the paragraph end, but the break itself remains authoritative:
+            // Para(visible), PageBreak is exactly how Word authors anchored
+            // cover/photo callouts. Preserve the separator and emit it after the
+            // last visible chunk below.
+            if let Some(sep) = s.pop() {
+                trailing.push(sep);
+            }
         }
-        (c, s)
+        (c, s, trailing)
     };
 
     let mut out: Vec<ParaPiece> = Vec::new();
@@ -1367,6 +1509,12 @@ fn split_para_on_page_breaks(para: DocParagraph) -> Vec<ParaPiece> {
         let mut chunk = para.clone();
         chunk.runs = runs;
         out.push(ParaPiece::Para(chunk));
+    }
+    for sep in trailing_seps.into_iter().rev() {
+        out.push(match sep {
+            ParaPiece::ColumnBreak => ParaPiece::ColumnBreak,
+            _ => ParaPiece::PageBreak,
+        });
     }
     if out.is_empty() {
         out.push(ParaPiece::Para(para));
@@ -2253,7 +2401,8 @@ fn parse_paragraph_cond(
     // Parse runs
     let mut runs = vec![];
     parse_para_content(
-        node, &base_run, style_map, media_map, chart_map, rel_map, theme, &mut runs, None, field,
+        node, &base_run, style_map, num_map, media_map, chart_map, rel_map, theme, &mut runs, None,
+        field,
     );
 
     // ECMA-376 §17.13.6.2 — bookmark destinations that start inside this
@@ -2338,6 +2487,7 @@ fn parse_paragraph_cond(
         default_font_family: theme
             .resolve_font_ref(mark_run.font_family_ascii.clone())
             .or_else(|| theme.resolve_font_ref(mark_run.font_family_east_asia.clone())),
+        default_font_family_east_asia: theme.resolve_font_ref(mark_run.font_family_east_asia.clone()),
         outline_level: base_para.outline_level,
         // ECMA-376 §17.3.1.6 — RTL paragraph flag resolved through the style
         // chain + direct pPr. The renderer reads it as the paragraph base
@@ -2407,6 +2557,7 @@ fn parse_para_content(
     node: roxmltree::Node,
     base_run: &RunFmt,
     style_map: &StyleMap,
+    num_map: &mut NumberingMap,
     media_map: &HashMap<String, String>,
     chart_map: &HashMap<String, ooxml_common::chart::ChartModel>,
     rel_map: &HashMap<String, String>,
@@ -2423,8 +2574,8 @@ fn parse_para_content(
         match child.tag_name().name() {
             "r" => {
                 handle_run_in_para(
-                    child, base_run, style_map, media_map, chart_map, theme, runs, field, None,
-                    None, revision,
+                    child, base_run, style_map, num_map, media_map, chart_map, theme, runs, field,
+                    None, None, revision,
                 );
             }
             "hyperlink" => {
@@ -2450,6 +2601,7 @@ fn parse_para_content(
                         r,
                         base_run,
                         style_map,
+                        num_map,
                         media_map,
                         chart_map,
                         theme,
@@ -2480,6 +2632,7 @@ fn parse_para_content(
                     child,
                     base_run,
                     style_map,
+                    num_map,
                     media_map,
                     chart_map,
                     rel_map,
@@ -2491,8 +2644,8 @@ fn parse_para_content(
             }
             "smartTag" => {
                 parse_para_content(
-                    child, base_run, style_map, media_map, chart_map, rel_map, theme, runs,
-                    revision, field,
+                    child, base_run, style_map, num_map, media_map, chart_map, rel_map, theme,
+                    runs, revision, field,
                 );
             }
             "fldSimple" => {
@@ -2564,6 +2717,7 @@ fn handle_run_in_para(
     r_node: roxmltree::Node,
     base_run: &RunFmt,
     style_map: &StyleMap,
+    num_map: &mut NumberingMap,
     media_map: &HashMap<String, String>,
     chart_map: &HashMap<String, ooxml_common::chart::ChartModel>,
     theme: &ThemeColors,
@@ -2686,6 +2840,7 @@ fn handle_run_in_para(
         r_node,
         base_run,
         style_map,
+        num_map,
         media_map,
         chart_map,
         theme,
@@ -2822,6 +2977,7 @@ fn parse_run_inner(
     node: roxmltree::Node,
     base_run: &RunFmt,
     style_map: &StyleMap,
+    num_map: &mut NumberingMap,
     media_map: &HashMap<String, String>,
     chart_map: &HashMap<String, ooxml_common::chart::ChartModel>,
     theme: &ThemeColors,
@@ -3343,6 +3499,7 @@ fn parse_run_inner(
                             inner,
                             &fmt,
                             style_map,
+                            num_map,
                             media_map,
                             chart_map,
                             theme,
@@ -3368,7 +3525,9 @@ fn parse_run_inner(
                 }
             }
             "drawing" => {
-                for r in parse_inline_drawing(style_map, child, media_map, chart_map, theme) {
+                for r in
+                    parse_inline_drawing(style_map, num_map, child, media_map, chart_map, theme)
+                {
                     runs.push(r);
                 }
             }
@@ -3455,9 +3614,9 @@ fn parse_run_inner(
                 {
                     for inner in selected.children().filter(|n| n.is_element()) {
                         if inner.tag_name().name() == "drawing" {
-                            for r in
-                                parse_inline_drawing(style_map, inner, media_map, chart_map, theme)
-                            {
+                            for r in parse_inline_drawing(
+                                style_map, num_map, inner, media_map, chart_map, theme,
+                            ) {
                                 runs.push(r);
                             }
                         }
@@ -3478,7 +3637,9 @@ fn parse_run_inner(
                 // mistaken for an (empty) text-box panel.
                 if let Some(img) = parse_vml_pict_image(child, media_map) {
                     runs.push(DocRun::Image(img));
-                } else if let Some(shp) = parse_vml_pict(style_map, child, theme, media_map) {
+                } else if let Some(shp) =
+                    parse_vml_pict(style_map, num_map, child, theme, media_map)
+                {
                     runs.push(DocRun::Shape(Box::new(shp)));
                 }
             }
@@ -3501,7 +3662,9 @@ fn parse_run_inner(
                     .children()
                     .find(|n| n.is_element() && n.tag_name().name() == "drawing");
                 if let Some(drawing) = drawing {
-                    for r in parse_inline_drawing(style_map, drawing, media_map, chart_map, theme) {
+                    for r in parse_inline_drawing(
+                        style_map, num_map, drawing, media_map, chart_map, theme,
+                    ) {
                         runs.push(r);
                     }
                 } else if let Some(img) = parse_object_ole_image(child, media_map) {
@@ -3730,6 +3893,7 @@ fn select_mce_alternate_content<'a, 'i>(
 
 fn parse_inline_drawing(
     style_map: &StyleMap,
+    num_map: &mut NumberingMap,
     node: roxmltree::Node,
     media_map: &HashMap<String, String>,
     chart_map: &HashMap<String, ooxml_common::chart::ChartModel>,
@@ -3885,6 +4049,13 @@ fn parse_inline_drawing(
     let (pct_h, pct_v, rel_h, rel_v) = parse_anchor_pct_pos(&container);
     let (size_w_pct, size_h_pct, size_w_rel, size_h_rel) = parse_anchor_size_rel(&container);
     let anchor_meta = parse_anchor_wrap(&container);
+    // ECMA-376 §20.4.2.3 wp:anchor/@relativeHeight — stacking order among
+    // floating drawings. Word emits large values here for front-layer shapes;
+    // lower values paint first, higher values paint on top.
+    let anchor_z_order = container
+        .attribute("relativeHeight")
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(0);
 
     // behindDoc="1" flag — renderer uses this to draw shapes before text
     let behind_doc = container
@@ -3994,6 +4165,7 @@ fn parse_inline_drawing(
         }
         for mut shp in parse_wgp_shapes(
             style_map,
+            num_map,
             wgp,
             theme,
             media_map,
@@ -4002,6 +4174,7 @@ fn parse_inline_drawing(
             pos_y,
             y_from_para,
             &anchor_meta,
+            anchor_z_order,
         ) {
             shp.behind_doc = behind_doc;
             apply_pos_meta(&mut shp);
@@ -4017,6 +4190,7 @@ fn parse_inline_drawing(
     {
         if let Some(mut shp) = parse_wsp_shape(
             style_map,
+            num_map,
             wsp,
             theme,
             media_map,
@@ -4029,7 +4203,8 @@ fn parse_inline_drawing(
             1.0,
             0.0,
             0.0,
-            0,
+            false,
+            anchor_z_order,
         ) {
             shp.behind_doc = behind_doc;
             apply_pos_meta(&mut shp);
@@ -4645,6 +4820,7 @@ fn group_xfrm<'a, 'i>(group: roxmltree::Node<'a, 'i>) -> Option<roxmltree::Node<
 #[allow(clippy::too_many_arguments)]
 fn parse_wgp_shapes(
     style_map: &StyleMap,
+    num_map: &mut NumberingMap,
     wgp: roxmltree::Node,
     theme: &ThemeColors,
     media_map: &HashMap<String, String>,
@@ -4653,6 +4829,7 @@ fn parse_wgp_shapes(
     anchor_pos_y: f64,
     y_from_para: bool,
     anchor_meta: &AnchorMeta,
+    anchor_z_order: u32,
 ) -> Vec<ShapeRun> {
     // Base transform = the outermost wgp grpSpPr/xfrm (chOff/chExt → off/ext).
     let base = match group_xfrm(wgp) {
@@ -4680,6 +4857,7 @@ fn parse_wgp_shapes(
     let mut z_order: u32 = 0;
     walk_group_children(
         style_map,
+        num_map,
         wgp,
         base,
         theme,
@@ -4691,6 +4869,7 @@ fn parse_wgp_shapes(
         anchor_meta,
         group_w_pt,
         group_h_pt,
+        anchor_z_order,
         &mut z_order,
         &mut results,
     );
@@ -4705,6 +4884,7 @@ fn parse_wgp_shapes(
 #[allow(clippy::too_many_arguments)]
 fn walk_group_children(
     style_map: &StyleMap,
+    num_map: &mut NumberingMap,
     group: roxmltree::Node,
     xform: GroupTransform,
     theme: &ThemeColors,
@@ -4716,6 +4896,7 @@ fn walk_group_children(
     anchor_meta: &AnchorMeta,
     group_w_pt: f64,
     group_h_pt: f64,
+    anchor_z_order: u32,
     z_order: &mut u32,
     results: &mut Vec<ShapeRun>,
 ) {
@@ -4731,6 +4912,7 @@ fn walk_group_children(
                 *z_order += 1;
                 if let Some(mut shape) = parse_wsp_shape(
                     style_map,
+                    num_map,
                     child,
                     theme,
                     media_map,
@@ -4743,7 +4925,8 @@ fn walk_group_children(
                     xform.scale_y,
                     xform.off_x_emu / 12700.0,
                     xform.off_y_emu / 12700.0,
-                    idx,
+                    true,
+                    anchor_z_order.saturating_add(idx),
                 ) {
                     shape.group_width_pt = Some(group_w_pt);
                     shape.group_height_pt = Some(group_h_pt);
@@ -4758,6 +4941,7 @@ fn walk_group_children(
                 };
                 walk_group_children(
                     style_map,
+                    num_map,
                     child,
                     child_xform,
                     theme,
@@ -4769,6 +4953,7 @@ fn walk_group_children(
                     anchor_meta,
                     group_w_pt,
                     group_h_pt,
+                    anchor_z_order,
                     z_order,
                     results,
                 );
@@ -4781,13 +4966,17 @@ fn walk_group_children(
 /// Parse a single wps:wsp into ShapeRun. `sx,sy` scale the shape's spPr/xfrm
 /// from group child coord space to page EMU; `group_off_pt_*` are the group origin
 /// on the page (in pt) so the shape's off.x/off.y (in child coord space) can be
-/// translated to page-relative pt. For a standalone wsp (no wgp), pass sx=sy=1, group_off=0.
+/// translated to page-relative pt. For a standalone wsp (no wgp), pass sx=sy=1,
+/// group_off=0 and `include_xfrm_offset=false`: the enclosing wp:anchor
+/// positionH/V already places the DrawingML object, while the shape's
+/// a:xfrm/off is its local DrawingML transform.
 // Carries the accumulated anchor/group coordinate transform (offsets, scale,
 // relative-from flags, z-order) needed to place a wsp shape in page space;
 // these are interdependent transform parameters, not an arbitrary bag.
 #[allow(clippy::too_many_arguments)]
 fn parse_wsp_shape(
     style_map: &StyleMap,
+    num_map: &mut NumberingMap,
     wsp: roxmltree::Node,
     theme: &ThemeColors,
     media_map: &HashMap<String, String>,
@@ -4800,6 +4989,7 @@ fn parse_wsp_shape(
     sy: f64,
     group_off_pt_x: f64,
     group_off_pt_y: f64,
+    include_xfrm_offset: bool,
     z_order: u32,
 ) -> Option<ShapeRun> {
     let sp_pr = wsp
@@ -4855,8 +5045,10 @@ fn parse_wsp_shape(
 
     let width_pt = cx * sx / 12700.0;
     let height_pt = cy * sy / 12700.0;
-    let anchor_x_pt = anchor_pos_x + group_off_pt_x + ox * sx / 12700.0;
-    let anchor_y_pt = anchor_pos_y + group_off_pt_y + oy * sy / 12700.0;
+    let local_x_pt = if include_xfrm_offset { ox * sx / 12700.0 } else { 0.0 };
+    let local_y_pt = if include_xfrm_offset { oy * sy / 12700.0 } else { 0.0 };
+    let anchor_x_pt = anchor_pos_x + group_off_pt_x + local_x_pt;
+    let anchor_y_pt = anchor_pos_y + group_off_pt_y + local_y_pt;
 
     let cust_geom = sp_pr
         .children()
@@ -4877,22 +5069,7 @@ fn parse_wsp_shape(
             .and_then(|n| n.attribute("prst"))
             .unwrap_or("rect")
             .to_string();
-        let adj_values = prst_node
-            .and_then(|p| {
-                p.children()
-                    .find(|n| n.is_element() && n.tag_name().name() == "avLst")
-            })
-            .map(|av| {
-                av.children()
-                    .filter(|n| n.is_element() && n.tag_name().name() == "gd")
-                    .filter_map(|gd| {
-                        gd.attribute("fmla")
-                            .and_then(|f| f.strip_prefix("val "))
-                            .and_then(|s| s.parse::<f64>().ok())
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
+        let adj_values = prst_node.map(parse_preset_adj).unwrap_or_default();
         (Vec::new(), Some(prst), adj_values)
     };
     if subpaths.is_empty() && preset_geometry.is_none() {
@@ -4905,40 +5082,66 @@ fn parse_wsp_shape(
     // recolored using the schemeClr embedded in the fillRef. But §20.1.8.44:
     // an explicit `<a:noFill/>` is itself a direct fill property and overrides
     // the style reference, so only fall back to fillRef when the fill is Absent.
+    let style_node = wsp
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "style");
+
     let fill = match parse_shape_fill(sp_pr, theme) {
         FillSpec::Explicit(f) => Some(f),
         FillSpec::NoFill => None,
-        FillSpec::Absent => wsp
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "style")
+        FillSpec::Absent => style_node
             .and_then(|st| {
                 st.children()
                     .find(|n| n.is_element() && n.tag_name().name() == "fillRef")
             })
             .and_then(|fr| resolve_fill_ref(fr, theme)),
     };
+    let style_stroke: Option<(String, f64)> = style_node
+        .and_then(|st| {
+            st.children()
+                .find(|n| n.is_element() && n.tag_name().name() == "lnRef")
+        })
+        .and_then(|lr| {
+            let idx = lr.attribute("idx")?.parse::<usize>().ok()?;
+            if idx == 0 {
+                return None;
+            }
+            let color = resolve_color_element(lr, theme)?;
+            let width_emu = theme
+                .theme_xml
+                .as_deref()
+                .map(ooxml_common::theme::parse_ln_style_widths)
+                .and_then(|widths| widths.get(idx - 1).copied())
+                .unwrap_or(9525);
+            Some((color, width_emu as f64 / 12700.0))
+        });
     let ln_node = sp_pr
         .children()
         .find(|n| n.is_element() && n.tag_name().name() == "ln");
-    let (stroke, stroke_width) = ln_node
-        .map(|ln| {
+    let (stroke, stroke_width) = match ln_node {
+        Some(ln) => {
             let has_no_fill = ln
                 .children()
                 .any(|n| n.is_element() && n.tag_name().name() == "noFill");
             if has_no_fill {
-                return (None, 0.0);
+                (None, 0.0)
+            } else {
+                let color = ln
+                    .children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
+                    .and_then(|sf| resolve_color_element(sf, theme));
+                let direct_w = ln.attribute("w").and_then(|v| v.parse::<f64>().ok());
+                match (color, style_stroke) {
+                    (Some(c), _) => (Some(c), direct_w.unwrap_or(9525.0) / 12700.0),
+                    (None, Some((c, style_w))) => {
+                        (Some(c), direct_w.map(|w| w / 12700.0).unwrap_or(style_w))
+                    }
+                    (None, None) => (None, 0.0),
+                }
             }
-            let color = ln
-                .children()
-                .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
-                .and_then(|sf| resolve_color_element(sf, theme));
-            let w_emu = ln
-                .attribute("w")
-                .and_then(|v| v.parse::<f64>().ok())
-                .unwrap_or(9525.0);
-            (color, w_emu / 12700.0)
-        })
-        .unwrap_or((None, 0.0));
+        }
+        None => style_stroke.map_or((None, 0.0), |(c, w)| (Some(c), w)),
+    };
     // ECMA-376 §20.1.8.48 prstDash and §20.1.8.3 head/tail line-end decorations.
     let stroke_dash = ln_node.and_then(|ln| {
         ln.children()
@@ -4978,9 +5181,7 @@ fn parse_wsp_shape(
     // tint), including any lumMod/lumOff/shade transforms on the inner color.
     // The `@idx` (major/minor/none) font-face selection is intentionally ignored
     // here — this axis carries only the color (fonts resolve via rFonts/docDefaults).
-    let default_text_color = wsp
-        .children()
-        .find(|n| n.is_element() && n.tag_name().name() == "style")
+    let default_text_color = style_node
         .and_then(|st| {
             st.children()
                 .find(|n| n.is_element() && n.tag_name().name() == "fontRef")
@@ -4997,7 +5198,7 @@ fn parse_wsp_shape(
         text_inset_t,
         text_inset_r,
         text_inset_b,
-    ) = parse_shape_text_body(style_map, wsp, theme, media_map);
+    ) = parse_shape_text_body(style_map, num_map, wsp, theme, media_map);
 
     Some(ShapeRun {
         width_pt,
@@ -5033,6 +5234,61 @@ fn parse_wsp_shape(
     })
 }
 
+/// Parse the adjust handles from a `<a:prstGeom>`'s `<a:avLst>` into an
+/// `adj1..adj8`-ordered vector. ECMA-376 §20.1.9.5: each
+/// `<a:gd name="adjN" fmla="val X"/>` supplies one handle. Matching is by name
+/// (`adj`/`adj1`, `adj2`, …) with a positional fallback for legacy unnamed
+/// lists, mirroring the pptx/xlsx parsers so the shared preset engine receives
+/// identical inputs. Trailing `None`s are trimmed.
+fn parse_preset_adj(prst_geom: roxmltree::Node) -> Vec<Option<f64>> {
+    let av = prst_geom
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "avLst");
+    let Some(av) = av else {
+        return Vec::new();
+    };
+    let gd_nodes: Vec<roxmltree::Node> = av
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "gd")
+        .collect();
+    if gd_nodes.is_empty() {
+        return Vec::new();
+    }
+
+    let parse_val = |gd: &roxmltree::Node| -> Option<f64> {
+        gd.attribute("fmla")
+            .and_then(|f| f.strip_prefix("val "))
+            .and_then(|s| s.trim().parse::<f64>().ok())
+    };
+
+    let named = gd_nodes.iter().any(|n| n.attribute("name").is_some());
+    let mut out: Vec<Option<f64>> = (1..=8)
+        .map(|i| {
+            if named {
+                let key = format!("adj{i}");
+                gd_nodes
+                    .iter()
+                    .find(|n| {
+                        let name = n.attribute("name");
+                        if i == 1 {
+                            matches!(name, Some("adj") | Some("adj1"))
+                        } else {
+                            name == Some(key.as_str())
+                        }
+                    })
+                    .and_then(parse_val)
+            } else {
+                gd_nodes.get(i - 1).and_then(parse_val)
+            }
+        })
+        .collect();
+
+    while matches!(out.last(), Some(None)) {
+        out.pop();
+    }
+    out
+}
+
 /// Extract text blocks and bodyPr from a wsp shape.
 /// Returns (blocks, anchor, inset_l, inset_t, inset_r, inset_b).
 ///
@@ -5045,6 +5301,7 @@ fn parse_wsp_shape(
 /// tIns=bIns=45720 EMU (0.05in = 3.6pt).
 fn parse_shape_text_body(
     style_map: &StyleMap,
+    num_map: &mut NumberingMap,
     wsp: roxmltree::Node,
     theme: &ThemeColors,
     media_map: &HashMap<String, String>,
@@ -5109,7 +5366,9 @@ fn parse_shape_text_body(
         .map(|content| {
             children_w_flat(content, "p")
                 .into_iter()
-                .filter_map(|p| extract_simple_paragraph_text(style_map, p, theme, media_map))
+                .filter_map(|p| {
+                    extract_simple_paragraph_text(style_map, num_map, p, theme, media_map)
+                })
                 .collect()
         })
         .unwrap_or_default();
@@ -5131,6 +5390,7 @@ fn parse_shape_text_body(
 /// paragraph (empty text) still yields a block so the picture is not dropped.
 fn extract_simple_paragraph_text(
     style_map: &StyleMap,
+    num_map: &mut NumberingMap,
     p: roxmltree::Node,
     theme: &ThemeColors,
     media_map: &HashMap<String, String>,
@@ -5184,10 +5444,90 @@ fn extract_simple_paragraph_text(
     // per-run ascii axis so the legacy single-`font_family` behaviour is
     // unchanged).
     let mut first_run_fmt: Option<RunFmt> = None;
-    for r in p
-        .descendants()
-        .filter(|n| n.is_element() && n.tag_name().name() == "r")
-    {
+    let mut push_text_run = |run_text: String, fmt: RunFmt, ruby: Option<RubyAnnotation>| {
+        if run_text.is_empty() {
+            return;
+        }
+        text.push_str(&run_text);
+        runs.push(ShapeTextRun {
+            text: run_text,
+            font_size_pt: fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE),
+            color: fmt.color.clone(),
+            font_family: resolve_ascii_axis(&fmt),
+            font_family_east_asia: resolve_east_asia_axis(&fmt),
+            bold: fmt.bold.unwrap_or(false),
+            italic: fmt.italic.unwrap_or(false),
+            ruby,
+        });
+        if first_run_fmt.is_none() {
+            first_run_fmt = Some(fmt);
+        }
+    };
+
+    let collect_run_node = |r: roxmltree::Node| -> Vec<(String, RunFmt, Option<RubyAnnotation>)> {
+        let mut out = Vec::new();
+        let ruby_nodes: Vec<_> = r
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "ruby")
+            .collect();
+        if !ruby_nodes.is_empty() {
+            for ruby_node in ruby_nodes {
+                let rt_text = child_w(ruby_node, "rt")
+                    .map(|rt| {
+                        rt.descendants()
+                            .filter(|n| n.is_element() && n.tag_name().name() == "t")
+                            .filter_map(|n| n.text())
+                            .collect::<String>()
+                    })
+                    .unwrap_or_default();
+                let Some(rb) = child_w(ruby_node, "rubyBase") else {
+                    continue;
+                };
+                let mut base_text = String::new();
+                let mut base_fmt: Option<RunFmt> = None;
+                for rb_run in rb
+                    .children()
+                    .filter(|n| n.is_element() && n.tag_name().name() == "r")
+                {
+                    for t in rb_run
+                        .descendants()
+                        .filter(|n| n.is_element() && n.tag_name().name() == "t")
+                    {
+                        if let Some(text_node) = t.text() {
+                            base_text.push_str(text_node);
+                        }
+                    }
+                    if base_fmt.is_none() {
+                        base_fmt = Some(
+                            child_w(rb_run, "rPr")
+                                .map(parse_run_fmt)
+                                .unwrap_or_default(),
+                        );
+                    }
+                }
+                if base_text.is_empty() {
+                    continue;
+                }
+                let fmt = base_fmt.unwrap_or_default();
+                let ruby = if rt_text.is_empty() {
+                    None
+                } else {
+                    let font_size_pt = child_w(ruby_node, "rubyPr")
+                        .and_then(|rp| child_w(rp, "hps"))
+                        .and_then(|hps| attr_w(hps, "val"))
+                        .and_then(|v| v.parse::<f64>().ok())
+                        .map(|hp| hp / 2.0)
+                        .unwrap_or_else(|| fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE) / 2.0);
+                    Some(RubyAnnotation {
+                        text: rt_text,
+                        font_size_pt,
+                    })
+                };
+                out.push((base_text, fmt, ruby));
+            }
+            return out;
+        }
+
         let mut run_text = String::new();
         for t in r
             .descendants()
@@ -5197,22 +5537,35 @@ fn extract_simple_paragraph_text(
                 run_text.push_str(text_node);
             }
         }
-        if run_text.is_empty() {
-            continue;
-        }
-        text.push_str(&run_text);
         let fmt = child_w(r, "rPr").map(parse_run_fmt).unwrap_or_default();
-        runs.push(ShapeTextRun {
-            text: run_text,
-            font_size_pt: fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE),
-            color: fmt.color.clone(),
-            font_family: resolve_ascii_axis(&fmt),
-            font_family_east_asia: resolve_east_asia_axis(&fmt),
-            bold: fmt.bold.unwrap_or(false),
-            italic: fmt.italic.unwrap_or(false),
-        });
-        if first_run_fmt.is_none() {
-            first_run_fmt = Some(fmt);
+        out.push((run_text, fmt, None));
+        out
+    };
+
+    for child in p.children().filter(|n| n.is_element()) {
+        match child.tag_name().name() {
+            "r" => {
+                for (run_text, fmt, ruby) in collect_run_node(child) {
+                    push_text_run(run_text, fmt, ruby);
+                }
+            }
+            "hyperlink" => {
+                for r in child
+                    .children()
+                    .filter(|n| n.is_element() && n.tag_name().name() == "r")
+                {
+                    for (run_text, fmt, ruby) in collect_run_node(r) {
+                        push_text_run(run_text, fmt, ruby);
+                    }
+                }
+            }
+            "oMath" | "oMathPara" => {
+                let math_text = omml_plain_text(child);
+                if !math_text.is_empty() {
+                    push_text_run(math_text, RunFmt::default(), None);
+                }
+            }
+            _ => {}
         }
     }
 
@@ -5272,17 +5625,97 @@ fn extract_simple_paragraph_text(
     // list-independently), unlike the pptx/xlsx shape paths which clamp because
     // they have no list marker to hang.
     let direct_ind = child_w(p, "pPr").map(parse_para_fmt).unwrap_or_default();
-    let indent_left = direct_ind
-        .indent_left
-        .or(style_para.indent_left)
-        .unwrap_or(0.0);
+    let numbering = direct_ind.num_id.or(style_para.num_id).and_then(|num_id| {
+        if num_id == 0 {
+            return None;
+        }
+        let num_level = direct_ind.num_level.or(style_para.num_level).unwrap_or(0);
+        let first_fmt = first_run_fmt.clone().unwrap_or_default();
+        let (format, ind_left, tab, suff, lvl_jc, marker_ascii, marker_ea, pic_bullet) = num_map
+            .get_level(num_id, num_level)
+            .map(|l| {
+                let mut marker_fmt = first_fmt.clone();
+                apply_direct_run(&mut marker_fmt, &l.rpr);
+                (
+                    l.format.clone(),
+                    l.indent_left,
+                    l.tab,
+                    l.suff.clone(),
+                    l.lvl_jc.clone(),
+                    theme.resolve_font_ref(marker_fmt.font_family_ascii.clone()),
+                    theme.resolve_font_ref(marker_fmt.font_family_east_asia.clone()),
+                    l.pic_bullet.clone(),
+                )
+            })
+            .unwrap_or_else(|| {
+                (
+                    "decimal".to_string(),
+                    36.0,
+                    18.0,
+                    "tab".to_string(),
+                    "left".to_string(),
+                    theme.resolve_font_ref(first_fmt.font_family_ascii.clone()),
+                    theme.resolve_font_ref(first_fmt.font_family_east_asia.clone()),
+                    None,
+                )
+            });
+        let counter = num_map.advance(num_id, num_level);
+        let text = num_map.resolve_text(num_id, num_level, counter);
+        let (
+            pic_bullet_image_path,
+            pic_bullet_mime_type,
+            pic_bullet_width_pt,
+            pic_bullet_height_pt,
+        ) = match pic_bullet {
+            Some(pb) => (
+                Some(pb.image_path),
+                Some(pb.mime_type),
+                pb.width_pt,
+                pb.height_pt,
+            ),
+            None => (None, None, None, None),
+        };
+        Some(Box::new(NumberingInfo {
+            num_id,
+            level: num_level,
+            format,
+            text,
+            indent_left: ind_left,
+            tab,
+            suff,
+            jc: lvl_jc,
+            font_family: marker_ascii,
+            font_family_east_asia: marker_ea,
+            pic_bullet_image_path,
+            pic_bullet_mime_type,
+            pic_bullet_width_pt,
+            pic_bullet_height_pt,
+        }))
+    });
+    let level = numbering
+        .as_ref()
+        .and_then(|num| num_map.get_level(num.num_id, num.level));
+    let (indent_left, indent_first) = if let Some(l) = level {
+        (
+            direct_ind.indent_left.unwrap_or(l.indent_left),
+            direct_ind.indent_first.unwrap_or(l.indent_first),
+        )
+    } else {
+        (
+            direct_ind
+                .indent_left
+                .or(style_para.indent_left)
+                .unwrap_or(0.0),
+            direct_ind
+                .indent_first
+                .or(style_para.indent_first)
+                .unwrap_or(0.0),
+        )
+    };
     let indent_right = direct_ind
         .indent_right
+        .or_else(|| level.and_then(|l| l.indent_right))
         .or(style_para.indent_right)
-        .unwrap_or(0.0);
-    let indent_first = direct_ind
-        .indent_first
-        .or(style_para.indent_first)
         .unwrap_or(0.0);
 
     // ECMA-376 §17.3.1.33 — the txbxContent paragraph's own `<w:spacing>` is
@@ -5375,6 +5808,7 @@ fn extract_simple_paragraph_text(
         bold,
         italic,
         runs,
+        numbering,
         alignment: normalize_align(&alignment).to_string(),
         space_before,
         space_after,
@@ -5391,6 +5825,41 @@ fn extract_simple_paragraph_text(
         image_width_pt,
         image_height_pt,
     })
+}
+
+fn omml_plain_text(node: roxmltree::Node) -> String {
+    if !node.is_element() {
+        return String::new();
+    }
+    match node.tag_name().name() {
+        "t" => node.text().unwrap_or_default().to_string(),
+        "r" => {
+            let text: String = node.children().map(omml_plain_text).collect();
+            if omml_operator_takes_spacing(text.as_str()) {
+                format!(" {text} ")
+            } else {
+                text
+            }
+        }
+        "rad" => {
+            let radicand = node
+                .children()
+                .find(|n| n.is_element() && n.tag_name().name() == "e")
+                .map(omml_plain_text)
+                .unwrap_or_default();
+            if radicand.is_empty() {
+                String::new()
+            } else {
+                format!("√{radicand}")
+            }
+        }
+        "oMathParaPr" | "radPr" | "ctrlPr" | "deg" => String::new(),
+        _ => node.children().map(omml_plain_text).collect(),
+    }
+}
+
+fn omml_operator_takes_spacing(text: &str) -> bool {
+    matches!(text, "+" | "-" | "−" | "=" | "±" | "×" | "÷")
 }
 
 /// Parse a legacy VML `<w:pict>` text box (ECMA-376 Part 4 §14.1) into a
@@ -5413,6 +5882,7 @@ fn extract_simple_paragraph_text(
 /// handled separately; see `parse_object_ole_image`.
 fn parse_vml_pict(
     style_map: &StyleMap,
+    num_map: &mut NumberingMap,
     pict: roxmltree::Node,
     theme: &ThemeColors,
     media_map: &HashMap<String, String>,
@@ -5532,7 +6002,9 @@ fn parse_vml_pict(
             .map(|content| {
                 children_w_flat(content, "p")
                     .into_iter()
-                    .filter_map(|p| extract_simple_paragraph_text(style_map, p, theme, media_map))
+                    .filter_map(|p| {
+                        extract_simple_paragraph_text(style_map, num_map, p, theme, media_map)
+                    })
                     .collect()
             })
             .unwrap_or_default()
@@ -6800,6 +7272,7 @@ fn parse_table_row(
         .and_then(|h| attr_w(h, "hRule"))
         .unwrap_or_else(|| "auto".to_string());
     let is_header = tr_pr.and_then(|p| child_w(p, "tblHeader")).is_some();
+    let cant_split = tr_pr.and_then(|p| bool_prop(p, "cantSplit")).unwrap_or(false);
 
     let mut cells = vec![];
     for (i, tc_node) in children_w_flat(node, "tc").into_iter().enumerate() {
@@ -6824,6 +7297,7 @@ fn parse_table_row(
         row_height,
         row_height_rule,
         is_header,
+        cant_split,
     }
 }
 
@@ -7698,10 +8172,12 @@ mod tests {
         let theme = ThemeColors::default();
         let mut runs = Vec::new();
         let mut field = FieldState::default();
+        let mut num_map = NumberingMap::default();
         parse_para_content(
             doc.root_element(),
             base_run,
             styles,
+            &mut num_map,
             &media,
             &HashMap::new(),
             &rels,
@@ -8539,6 +9015,22 @@ mod math_jc_tests {
         assert_eq!(p.bookmarks, vec!["dup".to_string()]);
     }
 
+    // ECMA-376 §17.3.1.29 + §17.3.2.26 — the paragraph mark has run properties,
+    // including independent ASCII and East Asian font axes. Empty paragraphs
+    // need the eastAsia axis later when an East Asian document grid measures the
+    // mark line.
+    #[test]
+    fn paragraph_mark_default_east_asia_font_surfaces() {
+        let p = parse_p(
+            r#"<w:pPr><w:rPr><w:rFonts w:ascii="Century" w:eastAsia="ＭＳ 明朝"/></w:rPr></w:pPr>"#,
+        );
+        assert_eq!(p.default_font_family.as_deref(), Some("Century"));
+        assert_eq!(
+            p.default_font_family_east_asia.as_deref(),
+            Some("ＭＳ 明朝")
+        );
+    }
+
     // ECMA-376 §22.1.2.30 `m:defJc` — document-wide default math justification in
     // `word/settings.xml` `m:mathPr` surfaces as `math_def_jc`; absent ⇒ None.
     #[test]
@@ -8571,6 +9063,29 @@ mod math_jc_tests {
 
         let empty = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>"#;
         assert!(parse_document_settings(empty).is_none());
+    }
+
+    // ECMA-376 §17.15.1.18 / §17.15.3.1 — East Asian compatibility settings
+    // must surface to the renderer instead of being discarded at parse time.
+    #[test]
+    fn settings_east_asian_compat_flags_surface() {
+        let xml = format!(
+            r#"<w:settings xmlns:w="{w}">
+                 <w:characterSpacingControl w:val="compressPunctuation"/>
+                 <w:compat>
+                   <w:useFELayout/>
+                   <w:balanceSingleByteDoubleByteWidth w:val="0"/>
+                 </w:compat>
+               </w:settings>"#,
+            w = W_NS
+        );
+        let s = parse_document_settings(&xml).expect("settings present (EA compat)");
+        assert_eq!(
+            s.character_spacing_control.as_deref(),
+            Some("compressPunctuation")
+        );
+        assert_eq!(s.use_fe_layout, Some(true));
+        assert_eq!(s.balance_single_byte_double_byte_width, Some(false));
     }
 
     // ECMA-376 §22.1.2.88 + §17.3.1.13 `w:jc` — a display-math paragraph with no
@@ -9135,6 +9650,45 @@ mod theme_cs_tests {
         assert_eq!(theme.resolve_font("majorBidi").as_deref(), Some("Arial"));
         // Latin axes untouched
         assert_eq!(theme.resolve_font("minorHAnsi").as_deref(), Some("Calibri"));
+    }
+
+    #[test]
+    fn theme_font_lang_east_asia_uses_japanese_script_font_when_ea_is_empty() {
+        // ECMA-376 §17.15.1.88 maps minorEastAsia through the theme font element
+        // for themeFontLang@eastAsia. sample-33 has <a:ea typeface=""> plus
+        // <a:font script="Jpan" typeface="ＭＳ 明朝"/>, so docDefaults
+        // w:eastAsiaTheme="minorEastAsia" must resolve to ＭＳ 明朝 (then the
+        // renderer's name heuristic classifies it as serif).
+        let theme_xml = r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <a:themeElements><a:fontScheme name="Office">
+            <a:majorFont>
+              <a:latin typeface="Arial"/><a:ea typeface=""/><a:cs typeface=""/>
+              <a:font script="Jpan" typeface="ＭＳ ゴシック"/>
+            </a:majorFont>
+            <a:minorFont>
+              <a:latin typeface="Century"/><a:ea typeface=""/><a:cs typeface=""/>
+              <a:font script="Jpan" typeface="ＭＳ 明朝"/>
+            </a:minorFont>
+          </a:fontScheme></a:themeElements></a:theme>"#;
+        let settings = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:themeFontLang w:val="en-US" w:eastAsia="ja-JP"/></w:settings>"#;
+        let mut theme = ThemeColors::parse(theme_xml);
+        assert_eq!(theme.resolve_font("minorEastAsia"), None);
+        let langs = parse_theme_font_langs(settings).expect("themeFontLang");
+        theme.apply_theme_font_langs(&langs);
+        assert_eq!(
+            theme.resolve_font("minorEastAsia").as_deref(),
+            Some("ＭＳ 明朝")
+        );
+        assert_eq!(
+            theme.resolve_font("majorEastAsia").as_deref(),
+            Some("ＭＳ ゴシック")
+        );
+        assert_eq!(
+            theme.resolve_font("minorHAnsi").as_deref(),
+            Some("Century"),
+            "latin theme remains the default because w:val is en-US"
+        );
     }
 
     #[test]
@@ -10966,6 +11520,17 @@ mod anchor_image_relative_from_tests {
     use super::*;
     use std::io::Cursor;
 
+    fn parse_inline_drawing(
+        style_map: &StyleMap,
+        node: roxmltree::Node,
+        media_map: &HashMap<String, String>,
+        chart_map: &HashMap<String, ooxml_common::chart::ChartModel>,
+        theme: &ThemeColors,
+    ) -> Vec<DocRun> {
+        let mut num_map = NumberingMap::default();
+        super::parse_inline_drawing(style_map, &mut num_map, node, media_map, chart_map, theme)
+    }
+
     // Tiny valid PNG (1x1) so resolve_inline_blip's extent+blip contract holds.
     const PNG_1X1: &[u8] = &[
         0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
@@ -11012,6 +11577,19 @@ mod anchor_image_relative_from_tests {
                 _ => None,
             })
             .expect("expected one anchor image")
+    }
+
+    fn first_shape(doc: &Document) -> &ShapeRun {
+        doc.body
+            .iter()
+            .find_map(|el| match el {
+                BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                    DocRun::Shape(s) => Some(s.as_ref()),
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .expect("expected one anchor shape")
     }
 
     /// Body XML for an anchor image with the given `<wp:positionH>` and
@@ -11090,6 +11668,74 @@ mod anchor_image_relative_from_tests {
         let img = first_image(&doc);
         assert_eq!(img.anchor_x_relative_from.as_deref(), Some("page"));
         assert_eq!(img.anchor_y_relative_from.as_deref(), Some("page"));
+    }
+
+    /// ECMA-376 §20.4.2.3 `wp:anchor/@relativeHeight` carries the drawing's
+    /// stacking order. sample-33's board-plan paragraph contains several
+    /// independent anchors where a later low-relativeHeight rectangle must paint
+    /// below earlier high-relativeHeight marks.
+    #[test]
+    fn anchor_relative_height_surfaces_as_shape_z_order() {
+        let body = r#"<w:p><w:r><w:drawing>
+  <wp:anchor xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+             behindDoc="0" relativeHeight="251651072">
+    <wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>
+    <wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>
+    <wp:extent cx="127000" cy="127000"/>
+    <wp:wrapNone/>
+    <wp:docPr id="1" name="shape"/>
+    <a:graphic><a:graphicData>
+      <wps:wsp>
+        <wps:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="127000" cy="127000"/></a:xfrm>
+          <a:prstGeom prst="rect"/>
+        </wps:spPr>
+      </wps:wsp>
+    </a:graphicData></a:graphic>
+  </wp:anchor>
+</w:drawing></w:r></w:p>"#;
+        let data = build_docx(body);
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
+        assert_eq!(first_shape(&doc).z_order, 251651072);
+    }
+
+    /// ECMA-376 §20.4.2.3/§20.4.3.5 — a standalone `wps:wsp` inside
+    /// `<wp:anchor>` is positioned by the anchor's `<wp:positionH/V>`. The
+    /// shape's own `<a:xfrm><a:off>` is its DrawingML transform, not an extra
+    /// paragraph-relative anchor offset. sample-33 callouts carry
+    /// `positionV relativeFrom="paragraph" posOffset="20320"` (1.6pt) and an
+    /// `a:xfrm/off@y` around 398pt; adding both drops the callout to the bottom
+    /// of the page instead of beside its anchor paragraph.
+    #[test]
+    fn standalone_wps_anchor_uses_wp_position_not_shape_xfrm_offset() {
+        let body = r#"<w:p><w:r><w:drawing>
+  <wp:anchor xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+             behindDoc="0" relativeHeight="1">
+    <wp:positionH relativeFrom="column"><wp:posOffset>25400</wp:posOffset></wp:positionH>
+    <wp:positionV relativeFrom="paragraph"><wp:posOffset>20320</wp:posOffset></wp:positionV>
+    <wp:extent cx="1270000" cy="635000"/>
+    <wp:wrapNone/>
+    <wp:docPr id="1" name="callout"/>
+    <a:graphic><a:graphicData>
+      <wps:wsp>
+        <wps:spPr>
+          <a:xfrm><a:off x="3171825" y="5057775"/><a:ext cx="1270000" cy="635000"/></a:xfrm>
+          <a:prstGeom prst="accentBorderCallout2"/>
+        </wps:spPr>
+      </wps:wsp>
+    </a:graphicData></a:graphic>
+  </wp:anchor>
+</w:drawing></w:r></w:p>"#;
+        let data = build_docx(body);
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
+        let shape = first_shape(&doc);
+        assert!((shape.anchor_x_pt - 2.0).abs() < 1e-6, "anchor_x_pt={}", shape.anchor_x_pt);
+        assert!((shape.anchor_y_pt - 1.6).abs() < 1e-6, "anchor_y_pt={}", shape.anchor_y_pt);
+        assert!(shape.anchor_y_from_para, "positionV relativeFrom=paragraph must survive");
     }
 
     /// Inline images carry no positionH/V at all — both relativeFrom fields
@@ -12490,6 +13136,26 @@ mod column_tests {
         assert!(matches!(body[2], BodyElement::Paragraph(_)));
     }
 
+    /// ECMA-376 §17.3.1.20 — a hard page break at the END of a paragraph still
+    /// advances the following paragraph. sample-33 has a visible anchored shape
+    /// followed by `<w:br w:type="page"/>`; the trailing empty chunk must be
+    /// dropped without dropping the break itself.
+    #[test]
+    fn trailing_page_break_after_visible_run_still_advances_page() {
+        let body = body_from(
+            r#"<w:p>
+                 <w:r><w:t>shape-anchor</w:t></w:r>
+                 <w:r><w:br w:type="page"/></w:r>
+               </w:p>
+               <w:p><w:r><w:t>after</w:t></w:r></w:p>"#,
+        );
+        // Para(shape-anchor), PageBreak, Para(after).
+        assert_eq!(body.len(), 3);
+        assert!(matches!(body[0], BodyElement::Paragraph(_)));
+        assert!(matches!(body[1], BodyElement::PageBreak { .. }));
+        assert!(matches!(body[2], BodyElement::Paragraph(_)));
+    }
+
     /// The leading-break rule preserves the break KIND: a paragraph that opens with a
     /// `<w:br w:type="column"/>` yields ColumnBreak, Para(...) — not PageBreak.
     #[test]
@@ -12944,6 +13610,34 @@ mod column_tests {
 #[cfg(test)]
 mod txbx_inline_image_tests {
     use super::*;
+
+    fn parse_shape_text_body(
+        style_map: &StyleMap,
+        wsp: roxmltree::Node,
+        theme: &ThemeColors,
+        media_map: &HashMap<String, String>,
+    ) -> (
+        Vec<ShapeText>,
+        Option<String>,
+        Option<String>,
+        f64,
+        f64,
+        f64,
+        f64,
+    ) {
+        let mut num_map = NumberingMap::default();
+        super::parse_shape_text_body(style_map, &mut num_map, wsp, theme, media_map)
+    }
+
+    fn extract_simple_paragraph_text(
+        style_map: &StyleMap,
+        p: roxmltree::Node,
+        theme: &ThemeColors,
+        media_map: &HashMap<String, String>,
+    ) -> Option<ShapeText> {
+        let mut num_map = NumberingMap::default();
+        super::extract_simple_paragraph_text(style_map, &mut num_map, p, theme, media_map)
+    }
 
     /// A `<wps:wsp>` whose `<w:txbx><w:txbxContent>` holds (a) a paragraph that
     /// is just an inline `<w:drawing>` (a WMF chart) and (b) a caption
@@ -13448,6 +14142,127 @@ mod txbx_inline_image_tests {
         assert!(!block.runs[1].bold);
     }
 
+    /// ECMA-376 §17.3.3.25 — ruby inside a legacy VML/text-box paragraph must
+    /// remain attached to the rubyBase run. Flattening all descendant `<w:t>`
+    /// nodes used to turn `rt` text into visible inline text ("こんごう根号..."),
+    /// which is exactly what sample-33 shows on the board-plan title.
+    #[test]
+    fn extract_simple_paragraph_text_preserves_ruby_runs() {
+        let xml = r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:r><w:ruby>
+                <w:rubyPr><w:hps w:val="10"/></w:rubyPr>
+                <w:rt><w:r><w:t>こんごう</w:t></w:r></w:rt>
+                <w:rubyBase><w:r><w:t>根号</w:t></w:r></w:rubyBase>
+              </w:ruby></w:r>
+              <w:r><w:t>を含む式の</w:t></w:r>
+              <w:r><w:ruby>
+                <w:rubyPr><w:hps w:val="10"/></w:rubyPr>
+                <w:rt><w:r><w:t>か</w:t></w:r></w:rt>
+                <w:rubyBase><w:r><w:t>加</w:t></w:r></w:rubyBase>
+              </w:ruby></w:r>
+              <w:r><w:ruby>
+                <w:rubyPr><w:hps w:val="10"/></w:rubyPr>
+                <w:rt><w:r><w:t>げん</w:t></w:r></w:rt>
+                <w:rubyBase><w:r><w:t>減</w:t></w:r></w:rubyBase>
+              </w:ruby></w:r>
+            </w:p>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let block = extract_simple_paragraph_text(
+            &StyleMap::default(),
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .expect("ruby paragraph yields a text block");
+
+        assert_eq!(block.text, "根号を含む式の加減");
+        assert_eq!(block.runs[0].text, "根号");
+        assert_eq!(
+            block.runs[0].ruby.as_ref().map(|r| r.text.as_str()),
+            Some("こんごう")
+        );
+        assert_eq!(
+            block.runs[0].ruby.as_ref().map(|r| r.font_size_pt),
+            Some(5.0)
+        );
+        assert_eq!(block.runs[2].text, "加");
+        assert_eq!(
+            block.runs[2].ruby.as_ref().map(|r| r.text.as_str()),
+            Some("か")
+        );
+        assert_eq!(block.runs[3].text, "減");
+        assert_eq!(
+            block.runs[3].ruby.as_ref().map(|r| r.text.as_str()),
+            Some("げん")
+        );
+    }
+
+    #[test]
+    fn extract_simple_paragraph_text_surfaces_numbering_marker() {
+        let xml = r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="5"/></w:numPr></w:pPr>
+              <w:r><w:t>加法、減法の言葉に合った数式を生徒に考えさせる。</w:t></w:r>
+            </w:p>"#;
+        let numbering = r#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:abstractNum w:abstractNumId="3">
+                <w:lvl w:ilvl="0">
+                  <w:numFmt w:val="bullet"/>
+                  <w:lvlText w:val="※"/>
+                  <w:lvlJc w:val="left"/>
+                  <w:pPr><w:ind w:left="720" w:hanging="720"/></w:pPr>
+                  <w:rPr><w:rFonts w:ascii="ＭＳ ゴシック" w:eastAsia="ＭＳ ゴシック" w:hAnsi="ＭＳ ゴシック"/></w:rPr>
+                </w:lvl>
+              </w:abstractNum>
+              <w:num w:numId="5"><w:abstractNumId w:val="3"/></w:num>
+            </w:numbering>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let mut num_map = NumberingMap::parse(numbering, &HashMap::new());
+        let block = super::extract_simple_paragraph_text(
+            &StyleMap::default(),
+            &mut num_map,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .expect("numbered text-box paragraph yields text");
+
+        assert_eq!(
+            block.text,
+            "加法、減法の言葉に合った数式を生徒に考えさせる。"
+        );
+        let numbering = block.numbering.expect("numbering is surfaced");
+        assert_eq!(numbering.text, "※");
+        assert_eq!(numbering.num_id, 5);
+        assert_eq!(numbering.level, 0);
+        assert!((block.indent_left - 36.0).abs() < 1e-6);
+        assert!((block.indent_first + 36.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn extract_simple_paragraph_text_includes_inline_omml_radicals() {
+        let xml = r#"<w:p
+              xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+              xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">
+              <m:oMath>
+                <m:rad><m:radPr><m:degHide m:val="1"/></m:radPr><m:deg/><m:e><m:r><m:t>9</m:t></m:r></m:e></m:rad>
+                <m:r><m:t>+</m:t></m:r>
+                <m:rad><m:radPr><m:degHide m:val="1"/></m:radPr><m:deg/><m:e><m:r><m:t>16</m:t></m:r></m:e></m:rad>
+              </m:oMath>
+              <w:r><w:t>の計算の仕方を考えよう</w:t></w:r>
+            </w:p>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let block = extract_simple_paragraph_text(
+            &StyleMap::default(),
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .expect("math text-box paragraph yields text");
+
+        assert_eq!(block.text, "√9 + √16の計算の仕方を考えよう");
+        assert_eq!(block.runs[0].text, "√9 + √16");
+    }
+
     /// A run carrying no text (e.g. a `<w:r>` holding only a `<w:tab/>`) is not
     /// emitted as a run, so an image-only paragraph keeps `runs` empty and the
     /// image path / single-field fallback is unchanged.
@@ -13612,6 +14427,150 @@ mod txbx_inline_image_tests {
     }
 }
 
+// ECMA-376 §20.1.9.18 `<a:prstGeom>` — DOCX shapes use the same DrawingML
+// preset geometry catalog as PPTX/XLSX. Adjustment guides must be carried in
+// adj1..adj8 order, with omitted named guides preserved as holes, so core's
+// shared preset renderer can apply the preset defaults per index.
+#[cfg(test)]
+mod shape_preset_geometry_tests {
+    use super::*;
+
+    fn shape_with_prst_geom(prst_geom: &str) -> ShapeRun {
+        shape_with_sppr_and_style(prst_geom, "", &ThemeColors::default())
+    }
+
+    fn theme_with_ln_styles() -> ThemeColors {
+        ThemeColors::parse(
+            r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                 <a:themeElements>
+                   <a:clrScheme name="t">
+                     <a:dk1><a:srgbClr val="000000"/></a:dk1>
+                     <a:lt1><a:srgbClr val="FFFFFF"/></a:lt1>
+                     <a:dk2><a:srgbClr val="111111"/></a:dk2>
+                     <a:lt2><a:srgbClr val="EEEEEE"/></a:lt2>
+                     <a:accent1><a:srgbClr val="4472C4"/></a:accent1>
+                   </a:clrScheme>
+                   <a:fmtScheme name="s">
+                     <a:fillStyleLst/>
+                     <a:lnStyleLst>
+                       <a:ln w="9525"/>
+                       <a:ln w="25400"/>
+                     </a:lnStyleLst>
+                     <a:effectStyleLst/>
+                     <a:bgFillStyleLst/>
+                   </a:fmtScheme>
+                 </a:themeElements>
+               </a:theme>"#,
+        )
+    }
+
+    fn shape_with_sppr_and_style(sp_pr_body: &str, style: &str, theme: &ThemeColors) -> ShapeRun {
+        let xml = format!(
+            r#"<wps:wsp
+                 xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                 <wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="2540000" cy="1270000"/></a:xfrm>
+                   {sp_pr_body}</wps:spPr>
+                 {style}
+               </wps:wsp>"#
+        );
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let mut num_map = NumberingMap::default();
+        parse_wsp_shape(
+            &StyleMap::default(),
+            &mut num_map,
+            doc.root_element(),
+            theme,
+            &HashMap::new(),
+            0.0,
+            true,
+            0.0,
+            true,
+            &AnchorMeta::default(),
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            false,
+            0,
+        )
+        .expect("shape parses")
+    }
+
+    #[test]
+    fn callout_adjust_values_keep_adj1_to_adj6() {
+        let shape = shape_with_prst_geom(
+            r#"<a:prstGeom prst="accentBorderCallout2"><a:avLst>
+                 <a:gd name="adj1" fmla="val 18750"/>
+                 <a:gd name="adj2" fmla="val -2129"/>
+                 <a:gd name="adj3" fmla="val 47825"/>
+                 <a:gd name="adj4" fmla="val -10565"/>
+                 <a:gd name="adj5" fmla="val 117684"/>
+                 <a:gd name="adj6" fmla="val -34190"/>
+               </a:avLst></a:prstGeom>"#,
+        );
+
+        assert_eq!(
+            shape.preset_geometry.as_deref(),
+            Some("accentBorderCallout2")
+        );
+        assert_eq!(
+            shape.adj_values,
+            vec![
+                Some(18750.0),
+                Some(-2129.0),
+                Some(47825.0),
+                Some(-10565.0),
+                Some(117684.0),
+                Some(-34190.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn named_adjust_values_preserve_missing_guides_as_none() {
+        let shape = shape_with_prst_geom(
+            r#"<a:prstGeom prst="wedgeRectCallout"><a:avLst>
+                 <a:gd name="adj1" fmla="val 25000"/>
+                 <a:gd name="adj3" fmla="val 16667"/>
+               </a:avLst></a:prstGeom>"#,
+        );
+
+        assert_eq!(shape.adj_values, vec![Some(25000.0), None, Some(16667.0)]);
+    }
+
+    #[test]
+    fn direct_line_without_fill_inherits_lnref_color_and_keeps_arrow() {
+        let theme = theme_with_ln_styles();
+        let shape = shape_with_sppr_and_style(
+            r#"<a:prstGeom prst="accentBorderCallout2"><a:avLst/></a:prstGeom>
+               <a:ln w="19050"><a:tailEnd type="triangle" w="med" len="med"/></a:ln>"#,
+            r#"<wps:style><a:lnRef idx="2"><a:schemeClr val="accent1"/></a:lnRef></wps:style>"#,
+            &theme,
+        );
+
+        assert_eq!(shape.stroke.as_deref(), Some("4472C4"));
+        assert!((shape.stroke_width - 1.5).abs() < 1e-6);
+        assert_eq!(
+            shape.tail_end.as_ref().map(|e| e.r#type.as_str()),
+            Some("triangle")
+        );
+    }
+
+    #[test]
+    fn lnref_without_direct_line_supplies_theme_width() {
+        let theme = theme_with_ln_styles();
+        let shape = shape_with_sppr_and_style(
+            r#"<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>"#,
+            r#"<wps:style><a:lnRef idx="2"><a:schemeClr val="accent1"/></a:lnRef></wps:style>"#,
+            &theme,
+        );
+
+        assert_eq!(shape.stroke.as_deref(), Some("4472C4"));
+        assert!((shape.stroke_width - 2.0).abs() < 1e-6);
+    }
+}
+
 // ECMA-376 §20.1.4.1.17 `<wps:style><a:fontRef>` — the shape's DEFAULT text
 // color. A `<wps:txbx>` run that sets no `<w:color>` of its own inherits this
 // (sample-28's white Arabic cover banner: the runs carry no color, so Word draws
@@ -13652,8 +14611,10 @@ mod shape_fontref_color_tests {
                </wps:wsp>"#
         );
         let doc = roxmltree::Document::parse(&xml).unwrap();
+        let mut num_map = NumberingMap::default();
         parse_wsp_shape(
             &StyleMap::default(),
+            &mut num_map,
             doc.root_element(),
             &theme(),
             &HashMap::new(),
@@ -13666,6 +14627,7 @@ mod shape_fontref_color_tests {
             1.0,
             0.0,
             0.0,
+            false,
             0,
         )
         .expect("shape parses")

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -955,12 +955,9 @@ fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentS
     let compat = root
         .children()
         .find(|n| n.is_element() && n.tag_name().name() == "compat");
-    let compat_bool = |name: &str| -> Option<bool> {
-        bool_prop(compat?, name)
-    };
+    let compat_bool = |name: &str| -> Option<bool> { bool_prop(compat?, name) };
     let use_fe_layout = compat_bool("useFELayout");
-    let balance_single_byte_double_byte_width =
-        compat_bool("balanceSingleByteDoubleByteWidth");
+    let balance_single_byte_double_byte_width = compat_bool("balanceSingleByteDoubleByteWidth");
 
     // ECMA-376 §22.1.2.30 `m:mathPr/m:defJc@m:val` — document-wide default math
     // justification (math namespace, bare `val` fallback).
@@ -2487,7 +2484,8 @@ fn parse_paragraph_cond(
         default_font_family: theme
             .resolve_font_ref(mark_run.font_family_ascii.clone())
             .or_else(|| theme.resolve_font_ref(mark_run.font_family_east_asia.clone())),
-        default_font_family_east_asia: theme.resolve_font_ref(mark_run.font_family_east_asia.clone()),
+        default_font_family_east_asia: theme
+            .resolve_font_ref(mark_run.font_family_east_asia.clone()),
         outline_level: base_para.outline_level,
         // ECMA-376 §17.3.1.6 — RTL paragraph flag resolved through the style
         // chain + direct pPr. The renderer reads it as the paragraph base
@@ -5045,8 +5043,16 @@ fn parse_wsp_shape(
 
     let width_pt = cx * sx / 12700.0;
     let height_pt = cy * sy / 12700.0;
-    let local_x_pt = if include_xfrm_offset { ox * sx / 12700.0 } else { 0.0 };
-    let local_y_pt = if include_xfrm_offset { oy * sy / 12700.0 } else { 0.0 };
+    let local_x_pt = if include_xfrm_offset {
+        ox * sx / 12700.0
+    } else {
+        0.0
+    };
+    let local_y_pt = if include_xfrm_offset {
+        oy * sy / 12700.0
+    } else {
+        0.0
+    };
     let anchor_x_pt = anchor_pos_x + group_off_pt_x + local_x_pt;
     let anchor_y_pt = anchor_pos_y + group_off_pt_y + local_y_pt;
 
@@ -7272,7 +7278,9 @@ fn parse_table_row(
         .and_then(|h| attr_w(h, "hRule"))
         .unwrap_or_else(|| "auto".to_string());
     let is_header = tr_pr.and_then(|p| child_w(p, "tblHeader")).is_some();
-    let cant_split = tr_pr.and_then(|p| bool_prop(p, "cantSplit")).unwrap_or(false);
+    let cant_split = tr_pr
+        .and_then(|p| bool_prop(p, "cantSplit"))
+        .unwrap_or(false);
 
     let mut cells = vec![];
     for (i, tc_node) in children_w_flat(node, "tc").into_iter().enumerate() {
@@ -11733,9 +11741,20 @@ mod anchor_image_relative_from_tests {
         let data = build_docx(body);
         let doc = parse_from_bytes(&data).expect("parse must succeed");
         let shape = first_shape(&doc);
-        assert!((shape.anchor_x_pt - 2.0).abs() < 1e-6, "anchor_x_pt={}", shape.anchor_x_pt);
-        assert!((shape.anchor_y_pt - 1.6).abs() < 1e-6, "anchor_y_pt={}", shape.anchor_y_pt);
-        assert!(shape.anchor_y_from_para, "positionV relativeFrom=paragraph must survive");
+        assert!(
+            (shape.anchor_x_pt - 2.0).abs() < 1e-6,
+            "anchor_x_pt={}",
+            shape.anchor_x_pt
+        );
+        assert!(
+            (shape.anchor_y_pt - 1.6).abs() < 1e-6,
+            "anchor_y_pt={}",
+            shape.anchor_y_pt
+        );
+        assert!(
+            shape.anchor_y_from_para,
+            "positionV relativeFrom=paragraph must survive"
+        );
     }
 
     /// Inline images carry no positionH/V at all — both relativeFrom fields

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -119,6 +119,18 @@ pub struct DocumentSettings {
     /// twips (0.5" = 36pt), which the renderer applies.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_tab_stop: Option<f64>,
+    /// §17.15.1.18 `w:characterSpacingControl@w:val` — document-wide East Asian
+    /// punctuation compression / spacing control.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub character_spacing_control: Option<String>,
+    /// §17.15.3.1 `w:compat` / `w:useFELayout` — enable Far East layout
+    /// compatibility behavior.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_fe_layout: Option<bool>,
+    /// §17.15.3.1 `w:compat` / `w:balanceSingleByteDoubleByteWidth` — balance
+    /// single-byte and double-byte character widths in East Asian layout.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub balance_single_byte_double_byte_width: Option<bool>,
 }
 
 /// Single track-changes event extracted from a body `<w:ins>` / `<w:del>`.
@@ -584,6 +596,12 @@ pub struct DocParagraph {
     /// résumé "bar" must reserve Meiryo's tall line box). None when unresolved.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_font_family: Option<String>,
+    /// Default East Asian font family resolved from the style chain + direct
+    /// pPr/rPr. The paragraph mark has run properties (§17.3.1.29), and in an
+    /// East Asian document its mark glyph must use the eastAsia axis rather than
+    /// the ASCII fallback.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_font_family_east_asia: Option<String>,
     /// ECMA-376 §17.3.1.20 `<w:outlineLvl w:val="N">` (0–8). Resolved through
     /// the style chain: explicit pPr → linked paragraph style → docDefaults.
     /// `None` for body paragraphs that don't appear in the document outline.
@@ -944,8 +962,9 @@ pub struct ShapeRun {
     /// should draw background shapes BEFORE body text.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub behind_doc: bool,
-    /// Document order within the wp:anchor (for correct z-ordering among shapes
-    /// sharing the same behindDoc value). Lower value = drawn first.
+    /// ECMA-376 §20.4.2.3 `wp:anchor/@relativeHeight`: stacking order among
+    /// anchors sharing the same behindDoc value. Lower value = drawn first.
+    /// Group children add their document-order index to the anchor value.
     pub z_order: u32,
     /// normalized [0,1] custom path commands (one or more sub-paths). Empty
     /// when `preset_geometry` is set; the renderer chooses between
@@ -953,12 +972,13 @@ pub struct ShapeRun {
     pub subpaths: Vec<Vec<PathCmd>>,
     /// OOXML <a:prstGeom prst="..."> name (e.g. "rect", "ellipse",
     /// "roundRect", "rtTriangle"). Empty when the shape is custGeom.
-    /// `adj_values` carries up to four <a:gd name="adj{n}"> values (0–100000
-    /// scale) for shapes that support adjustment handles (trapezoid, callouts).
+    /// `adj_values` carries <a:gd name="adj{n}"> values in adj1..adj8 order
+    /// (0–100000 scale), preserving omitted named guides as `None` so the shared
+    /// preset engine can fall back to the preset's declared default per index.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preset_geometry: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub adj_values: Vec<f64>,
+    pub adj_values: Vec<Option<f64>>,
     /// Fill (solid or gradient). None = no fill.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<ShapeFill>,
@@ -1423,6 +1443,12 @@ pub struct ShapeTextRun {
     pub bold: bool,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub italic: bool,
+    /// ECMA-376 §17.3.3.25 w:ruby inside VML/text-box content. Carried through
+    /// the same shape rich-text path as normal run formatting so the renderer can
+    /// center the annotation above the base glyphs instead of flattening it into
+    /// the paragraph text.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ruby: Option<RubyAnnotation>,
 }
 
 /// One paragraph of text rendered inside a shape (`<wps:txbx><w:txbxContent>`).
@@ -1450,6 +1476,12 @@ pub struct ShapeText {
     /// when non-empty.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub runs: Vec<ShapeTextRun>,
+    /// ECMA-376 §17.9 numbering for text-box paragraphs. Word applies the same
+    /// paragraph numbering model inside `<w:txbxContent>` as in the body, so list
+    /// markers (for example sample-33's `※`) must travel separately from the run
+    /// text and render in the hanging margin.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub numbering: Option<Box<NumberingInfo>>,
     /// Paragraph alignment ("left" | "center" | "right" | "both").
     pub alignment: String,
     /// ECMA-376 §17.3.1.33 `<w:spacing w:before>` of this text-box paragraph, in
@@ -1823,6 +1855,9 @@ pub struct DocTableRow {
     /// renderer can branch without re-parsing.
     pub row_height_rule: String,
     pub is_header: bool,
+    /// ECMA-376 §17.4.6 w:cantSplit. When true, this row must not be split
+    /// across page boundaries.
+    pub cant_split: bool,
 }
 
 /// One block-level entry inside a table cell. ECMA-376 §17.4.7 (w:tc) allows

--- a/packages/docx/src/anchor-align.test.ts
+++ b/packages/docx/src/anchor-align.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveAnchorY } from './anchor-geometry.js';
+import { resolveAnchorX, resolveAnchorY } from './anchor-geometry.js';
 
 // resolveAnchorY reads only { scale, marginTop, marginBottom, pageH } of
 // RenderState (via yContainer); cast a minimal stand-in like the other geometry
@@ -7,11 +7,26 @@ import { resolveAnchorY } from './anchor-geometry.js';
 // container band is [72, 728], the "page" band is [0, 800].
 interface MinState {
   scale: number;
+  pageWidth: number;
+  marginLeft: number;
+  marginRight: number;
+  contentX: number;
+  contentW: number;
   marginTop: number;
   marginBottom: number;
   pageH: number;
 }
-const state: MinState = { scale: 1, marginTop: 72, marginBottom: 72, pageH: 800 };
+const state: MinState = {
+  scale: 1,
+  pageWidth: 600,
+  marginLeft: 60,
+  marginRight: 40,
+  contentX: 60,
+  contentW: 500,
+  marginTop: 72,
+  marginBottom: 72,
+  pageH: 800,
+};
 
 // resolveAnchorY(align, fromPara, offsetPt, heightPx, paragraphTopPx, state, relativeFrom)
 const y = (align: string, relativeFrom: string, h = 100): number =>
@@ -46,5 +61,19 @@ describe('resolveAnchorY — ST_AlignV inside/outside (ECMA-376 §20.4.3.1)', ()
     expect(y('top', 'page')).toBe(0);
     expect(y('bottom', 'page')).toBe(700);
     expect(y('center', 'page')).toBe((800 - 100) / 2);
+  });
+});
+
+describe('resolveAnchorX — wp:align choice ignores standalone posOffset', () => {
+  it('right-aligns a standalone shape without adding anchorXPt/simplePos fallback', () => {
+    const x = resolveAnchorX('right', true, 200, 100, state as never, 'margin', null, null);
+
+    expect(x).toBe(460);
+  });
+
+  it('still adds the child offset when aligning a grouped shape by group width', () => {
+    const x = resolveAnchorX('right', true, 20, 50, state as never, 'margin', null, 200);
+
+    expect(x).toBe(380);
   });
 });

--- a/packages/docx/src/anchor-geometry.ts
+++ b/packages/docx/src/anchor-geometry.ts
@@ -90,9 +90,13 @@ export function yContainer(
 }
 
 /** Resolve the page X for an anchor or anchor-group child. `offsetPx` carries
- *  the shape's offset (within the group for wgp children, 0 for standalone
- *  anchors). `alignWidthPx` is the width used when aligning — the GROUP's
- *  width for wgp children, the shape's own width for standalone anchors. */
+ *  the shape's offset for explicit posOffset anchors, or the within-group child
+ *  offset when `alignWidthPt` is set. For standalone `<wp:align>` anchors it is
+ *  ignored: ECMA-376 §20.4.3.1 uses `<wp:align>` / `<wp:posOffset>` as a choice,
+ *  and Word commonly leaves a duplicate a:xfrm/simplePos fallback that must not
+ *  be added to the aligned position. `alignWidthPt` is the width used when
+ *  aligning — the GROUP's width for wgp children, the shape's own width for
+ *  standalone anchors. */
 export function resolveAnchorX(
   align: string | null | undefined,
   fromMargin: boolean,
@@ -114,13 +118,14 @@ export function resolveAnchorX(
   }
   const containerW = c.end - c.start;
   const aw = alignWidthPt != null ? alignWidthPt * scale : widthPx;
+  const alignOffsetPx = alignWidthPt != null ? offsetPx : 0;
   switch (align) {
-    case 'center': return c.start + (containerW - aw) / 2 + offsetPx;
+    case 'center': return c.start + (containerW - aw) / 2 + alignOffsetPx;
     case 'right':
-    case 'outside': return c.end - aw + offsetPx;
+    case 'outside': return c.end - aw + alignOffsetPx;
     case 'inside':
     case 'left':
-    default:        return c.start + offsetPx;
+    default:        return c.start + alignOffsetPx;
   }
 }
 
@@ -146,8 +151,9 @@ export function resolveAnchorY(
   }
   const containerH = c.end - c.start;
   const ah = alignHeightPt != null ? alignHeightPt * scale : heightPx;
+  const alignOffsetPx = alignHeightPt != null ? offsetPx : 0;
   switch (align) {
-    case 'center': return c.start + (containerH - ah) / 2 + offsetPx;
+    case 'center': return c.start + (containerH - ah) / 2 + alignOffsetPx;
     // ECMA-376 §20.4.3.1 ST_AlignV: "inside"/"outside" are page-binding-
     // relative. Mirroring resolveAnchorX (and the insideMargin/outsideMargin
     // approximation in yContainer/xContainer): on an odd page the binding edge
@@ -156,9 +162,9 @@ export function resolveAnchorY(
     // pages mirror the binding edge) is not implemented. Update this when that
     // approximation is removed.
     case 'bottom':
-    case 'outside': return c.end - ah + offsetPx;
+    case 'outside': return c.end - ah + alignOffsetPx;
     case 'top':
     case 'inside':
-    default:        return c.start + offsetPx;
+    default:        return c.start + alignOffsetPx;
   }
 }

--- a/packages/docx/src/callout-arrowhead-render.test.ts
+++ b/packages/docx/src/callout-arrowhead-render.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps, ShapeRun } from './types';
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: number } {
+  let fills = 0;
+  let font = '11px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, bezierCurveTo() {}, quadraticCurveTo() {},
+    arc() {}, ellipse() {}, rect() {}, clip() {},
+    translate() {}, rotate() {}, scale() {}, setLineDash() {},
+    clearRect() {}, fillRect() {}, strokeRect() {}, drawImage() {},
+    stroke() {},
+    fill() { fills += 1; },
+    fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    lineCap: 'butt' as CanvasLineCap,
+    lineJoin: 'miter' as CanvasLineJoin,
+    textAlign: 'left' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return {
+    canvas: canvas as unknown as HTMLCanvasElement,
+    get fills() { return fills; },
+  };
+}
+
+function para(runs: DocParagraph['runs']): BodyElement {
+  return {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 0,
+    indentRight: 0,
+    indentFirst: 0,
+    spaceBefore: 0,
+    spaceAfter: 0,
+    lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    runs,
+    defaultFontSize: 11,
+    defaultFontFamily: 'Arial',
+    widowControl: false,
+  } as unknown as BodyElement;
+}
+
+function calloutWithTailArrow(): ShapeRun & { type: 'shape' } {
+  return {
+    type: 'shape',
+    zOrder: 0,
+    subpaths: [],
+    presetGeometry: 'accentBorderCallout2',
+    adjValues: [null, null, null, null, null, null, null, null],
+    fill: null,
+    stroke: '000000',
+    strokeWidth: 1.5,
+    tailEnd: { type: 'triangle', w: 'med', len: 'med' },
+    widthPt: 120,
+    heightPt: 80,
+    anchorXPt: 40,
+    anchorYPt: 40,
+    anchorXFromMargin: false,
+    anchorYFromPara: true,
+    anchorXRelativeFrom: 'column',
+    anchorYRelativeFrom: 'paragraph',
+    wrapMode: 'none',
+    behindDoc: false,
+  } as unknown as ShapeRun & { type: 'shape' };
+}
+
+function docWith(body: BodyElement[]): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: 300,
+      pageHeight: 220,
+      marginTop: 20,
+      marginRight: 20,
+      marginBottom: 20,
+      marginLeft: 20,
+      headerDistance: 10,
+      footerDistance: 10,
+      titlePage: false,
+      evenAndOddHeaders: false,
+    } as SectionProps,
+    body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { Arial: 'swiss' },
+  } as unknown as DocxDocumentModel;
+}
+
+describe('callout line-end rendering', () => {
+  it('draws a triangle tailEnd on the callout leader tip', async () => {
+    const rec = makeRecordingCanvas();
+
+    await renderDocumentToCanvas(
+      docWith([para([calloutWithTailArrow()])]),
+      rec.canvas,
+      0,
+      { dpr: 1, width: 300 },
+    );
+
+    expect(rec.fills).toBeGreaterThan(0);
+  });
+});

--- a/packages/docx/src/empty-paragraph-mark-height.test.ts
+++ b/packages/docx/src/empty-paragraph-mark-height.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { renderDocumentToCanvas } from './renderer.js';
+import { paragraphMarkLineHeight } from './line-layout.js';
 import type {
   BodyElement,
   DocParagraph,
@@ -131,5 +132,32 @@ describe('empty paragraph mark line height (§17.3.1.29 / §17.3.1.33)', () => {
     // empty mark line used a synthetic 1-em box while the text lines used the
     // 1.15-em stub box.
     expect(subjGap).toBeCloseTo(refGap, 2);
+  });
+
+  it('uses the paragraph mark eastAsia font axis in East Asian document-grid context', () => {
+    const p = {
+      ...para(''),
+      defaultFontFamily: 'Century',
+      defaultFontFamilyEastAsia: 'ＭＳ 明朝',
+    } as DocParagraph;
+    let font = '';
+    const ctx = {
+      get font() { return font; },
+      set font(v: string) { font = v; },
+      measureText: () => {
+        const ea = font.includes('ＭＳ 明朝');
+        const total = ea ? 30 : 10;
+        return {
+          width: 0,
+          fontBoundingBoxAscent: total * 0.8,
+          fontBoundingBoxDescent: total * 0.2,
+          actualBoundingBoxAscent: total * 0.8,
+          actualBoundingBoxDescent: total * 0.2,
+        } as TextMetrics;
+      },
+    } as unknown as CanvasRenderingContext2D;
+
+    expect(paragraphMarkLineHeight(p, 1, { type: null, linePitchPt: null }, false, false, ctx, {})).toBe(10);
+    expect(paragraphMarkLineHeight(p, 1, { type: null, linePitchPt: null }, false, true, ctx, {})).toBe(30);
   });
 });

--- a/packages/docx/src/front-float-zorder.test.ts
+++ b/packages/docx/src/front-float-zorder.test.ts
@@ -81,6 +81,39 @@ function shapePara(markerText: string): DocParagraph {
   } as unknown as DocParagraph;
 }
 
+function zShape(markerText: string, zOrder: number): ShapeRun {
+  return {
+    type: 'shape',
+    widthPt: 200, heightPt: 40,
+    anchorXPt: 0, anchorYPt: 0,
+    anchorXFromMargin: false, anchorYFromPara: true,
+    anchorXRelativeFrom: 'column', anchorYRelativeFrom: 'paragraph',
+    presetGeometry: 'rect',
+    wrapMode: 'none',
+    zOrder,
+    subpaths: [],
+    fill: { fillType: 'solid', color: 'FFFFFF' },
+    stroke: null,
+    textAnchor: 't',
+    textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+    textBlocks: [{ text: markerText, fontSizePt: 11, fontFamily: 'Times New Roman', alignment: 'left' }],
+  } as unknown as ShapeRun;
+}
+
+function twoShapePara(): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [
+      zShape('HIGH_Z', 20) as unknown as DocParagraph['runs'][number],
+      zShape('LOW_Z', 10) as unknown as DocParagraph['runs'][number],
+    ],
+    defaultFontSize: 11, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
 describe('front float z-order (§20.4.2.10)', () => {
   it('a front-anchored shape paints ON TOP of a following paragraph (after it)', async () => {
     const section: SectionProps = {
@@ -109,5 +142,27 @@ describe('front float z-order (§20.4.2.10)', () => {
     // The front shape, anchored to the FIRST paragraph, must be painted AFTER the
     // later body text so it lands on top (deferred to the page's front layer).
     expect(shapeIdx).toBeGreaterThan(bodyIdx);
+  });
+
+  it('orders front shapes by wp:anchor relativeHeight, not paragraph run order', async () => {
+    const section: SectionProps = {
+      pageWidth: 400, pageHeight: 600,
+      marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+      headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps;
+    const doc = {
+      section,
+      body: [twoShapePara() as unknown as BodyElement],
+      headers: { default: null, first: null, even: null },
+      footers: { default: null, first: null, even: null },
+      fontFamilyClasses: { 'Times New Roman': 'roman' },
+    } as unknown as DocxDocumentModel;
+
+    const { canvas, texts } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, canvas, 0, { dpr: 1, width: 400 });
+
+    expect(texts.indexOf('LOW_Z')).toBeGreaterThanOrEqual(0);
+    expect(texts.indexOf('HIGH_Z')).toBeGreaterThanOrEqual(0);
+    expect(texts.indexOf('HIGH_Z')).toBeGreaterThan(texts.indexOf('LOW_Z'));
   });
 });

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -222,6 +222,8 @@ export interface LayoutMathSeg {
   display: boolean;
   fontSize: number;  // pt
   color: string | null;
+  /** Plain-text fallback used when the async math renderer has not prepared an image. */
+  fallbackText: string;
   measuredWidth: number;
   /** px ascent/descent of the laid-out box at scale, cached during measurement. */
   mathAscent: number;
@@ -597,11 +599,12 @@ export function getDefaultFontSize(para: DocParagraph): number {
  *  Empty paragraphs (no runs) fall back to the paragraph's style-resolved
  *  default font so e.g. an empty Meiryo cell that forms a résumé "bar" reserves
  *  Meiryo's tall line box rather than the generic fallback's. */
-export function getDefaultFontFamily(para: DocParagraph): string | null {
+export function getDefaultFontFamily(para: DocParagraph, eastAsian = false): string | null {
   for (const run of para.runs) {
     if (run.type === 'text') return (run as unknown as DocxTextRun).fontFamily;
     if (run.type === 'field') return (run as unknown as FieldRun).fontFamily;
   }
+  if (eastAsian && para.defaultFontFamilyEastAsia) return para.defaultFontFamilyEastAsia;
   return para.defaultFontFamily ?? null;
 }
 
@@ -609,6 +612,12 @@ export function getDefaultFontFamily(para: DocParagraph): string | null {
  *  font's win line-height ratio. 0 when the font is not in the metrics table. */
 export function emptyIntendedSinglePx(para: DocParagraph, scale: number): number {
   return intendedSingleLinePx(getDefaultFontFamily(para), getDefaultFontSize(para) * scale);
+}
+
+/** Intended single-line height (px) for an empty paragraph in the script axis
+ *  used to draw its paragraph mark. */
+function emptyIntendedSingleForScriptPx(para: DocParagraph, scale: number, eastAsian: boolean): number {
+  return intendedSingleLinePx(getDefaultFontFamily(para, eastAsian), getDefaultFontSize(para) * scale);
 }
 
 /** Code points whose presence marks a line as East Asian for docGrid line-cell
@@ -873,7 +882,7 @@ export function paragraphMarkLineHeight(
   fontFamilyClasses: Record<string, string> = {},
 ): number {
   const fs = getDefaultFontSize(para);
-  const family = getDefaultFontFamily(para);
+  const family = getDefaultFontFamily(para, eastAsian);
   let asc: number;
   let desc: number;
   if (ctx) {
@@ -904,7 +913,7 @@ export function paragraphMarkLineHeight(
   } else {
     ({ asc, desc } = emptyLineNaturalPx(fs, scale));
   }
-  return lineBoxHeight(para.lineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSinglePx(para, scale), eastAsian);
+  return lineBoxHeight(para.lineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSingleForScriptPx(para, scale, eastAsian), eastAsian);
 }
 
 /**
@@ -1001,6 +1010,56 @@ export function resolveFieldText(f: FieldRun, state: RenderState): string {
     return f.fallbackText;
   }
   return f.fallbackText;
+}
+
+const MATH_SPACED_OPERATORS = new Set(['+', '-', '−', '=', '±', '×', '÷']);
+
+function mathRunPlainText(text: string): string {
+  return MATH_SPACED_OPERATORS.has(text) ? ` ${text} ` : text;
+}
+
+export function mathPlainText(nodes: MathNode[]): string {
+  const renderNode = (node: MathNode): string => {
+    switch (node.kind) {
+      case 'run':
+        return mathRunPlainText(node.text);
+      case 'fraction':
+        return `${mathPlainText(node.num)}/${mathPlainText(node.den)}`;
+      case 'sup':
+        return `${mathPlainText(node.base)}^${mathPlainText(node.sup ?? [])}`;
+      case 'sub':
+        return `${mathPlainText(node.base)}_${mathPlainText(node.sub ?? [])}`;
+      case 'subSup':
+        return `${mathPlainText(node.base)}_${mathPlainText(node.sub ?? [])}^${mathPlainText(node.sup ?? [])}`;
+      case 'nary':
+        return `${node.op}${mathPlainText(node.sub ?? [])}${mathPlainText(node.sup ?? [])}${mathPlainText(node.body)}`;
+      case 'delimiter':
+        return `${node.begChar}${node.items.map(mathPlainText).join(',')}${node.endChar}`;
+      case 'radical':
+        return `${node.index && node.index.length > 0 ? mathPlainText(node.index) : ''}√${mathPlainText(node.radicand)}`;
+      case 'limit':
+        return `${mathPlainText(node.base)}${mathPlainText(node.lower ?? [])}${mathPlainText(node.upper ?? [])}`;
+      case 'array':
+        return node.rows.map((row) => row.map(mathPlainText).join(' ')).join(' ');
+      case 'groupChr':
+        return `${node.char}${mathPlainText(node.base)}`;
+      case 'bar':
+      case 'box':
+      case 'borderBox':
+        return mathPlainText(node.base);
+      case 'accent':
+        return `${node.char}${mathPlainText(node.base)}`;
+      case 'func':
+        return `${mathPlainText(node.name)}(${mathPlainText(node.arg)})`;
+      case 'group':
+        return mathPlainText(node.items);
+      case 'phant':
+        return node.show ? mathPlainText(node.base) : '';
+      case 'sPre':
+        return `${mathPlainText(node.sub)}${mathPlainText(node.sup)}${mathPlainText(node.base)}`;
+    }
+  };
+  return nodes.map(renderNode).join('').replace(/[ \t]{2,}/g, ' ');
 }
 
 /** Returns true when any code point of `text` permits a line break between
@@ -1841,6 +1900,7 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         display: run.display,
         fontSize,
         color: null,
+        fallbackText: mathPlainText(run.nodes),
         measuredWidth: 0,
         mathAscent: 0,
         mathDescent: 0,
@@ -2413,7 +2473,20 @@ export function layoutLines(
     // ── Math segment ─────────────────────────────────────
     if ('mathNodes' in seg) {
       const render = mathRenders.get(seg.mathNodes);
-      if (!render) { seg.measuredWidth = 0; continue; }
+      if (!render) {
+        const emPx = seg.fontSize * scale;
+        setMeasureFont(buildFont(false, false, emPx, null, fontFamilyClasses));
+        const m = ctx.measureText(seg.fallbackText);
+        const w = m.width;
+        const asc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? emPx * 0.8;
+        const desc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? emPx * 0.2;
+        seg.measuredWidth = w;
+        seg.mathAscent = asc;
+        seg.mathDescent = desc;
+        if (currentLine.length > 0 && currentWidth + w > availW()) flush();
+        addToLine(seg, w, seg.fontSize, Math.max(asc, emPx * 0.8), Math.max(desc, emPx * 0.2));
+        continue;
+      }
       const emPx = seg.fontSize * scale;
       const w = render.widthEm * emPx;
       const asc = render.ascentEm * emPx;
@@ -2814,8 +2887,8 @@ export function rescaleLayoutLines(
  *  {@link layoutLines}) — giving them kinsoku (§17.15.1.58–.60), UAX#9 bidi,
  *  §17.18.44 justification and §17.3.1.37 tab stops. A `ShapeTextRun` carries a
  *  strict SUBSET of `DocxTextRun`'s formatting (text, size, colour, the ascii +
- *  eastAsia font axes §17.3.2.26, bold, italic); every field the shape model
- *  lacks (underline/strike/highlight/border/ruby/rtl/cs/…) takes its neutral
+ *  eastAsia font axes §17.3.2.26, bold, italic, ruby); every field the shape model
+ *  lacks (underline/strike/highlight/border/rtl/cs/…) takes its neutral
  *  default, so the run behaves exactly like a plain body text run. */
 export function shapeRunToDocRun(run: ShapeTextRun): DocRun {
   return {
@@ -2836,6 +2909,7 @@ export function shapeRunToDocRun(run: ShapeTextRun): DocRun {
     background: null,
     vertAlign: null,
     hyperlink: null,
+    ruby: run.ruby ?? undefined,
   } as unknown as DocRun;
 }
 

--- a/packages/docx/src/math-fallback-layout.test.ts
+++ b/packages/docx/src/math-fallback-layout.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { buildSegments, layoutLines, type LayoutMathSeg } from './line-layout.js';
+import type { RenderState } from './renderer.js';
+import type { DocRun } from './types.js';
+
+function makeLinearCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const pxOf = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  return {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = pxOf();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('layoutLines math fallback', () => {
+  it('measures inline OMML as plain text when the math renderer has not prepared an image', () => {
+    const runs: DocRun[] = [
+      {
+        type: 'math',
+        display: false,
+        fontSize: 11,
+        nodes: [
+          { kind: 'radical', radicand: [{ kind: 'run', text: '9', style: 'italic' }] },
+          { kind: 'run', text: '、', style: 'italic' },
+          { kind: 'radical', radicand: [{ kind: 'run', text: '16', style: 'italic' }] },
+        ],
+      },
+    ];
+    const segs = buildSegments(runs, {} as RenderState);
+    const lines = layoutLines(makeLinearCtx(), segs, 300, 0, 1);
+    const math = lines[0].segments[0] as LayoutMathSeg;
+
+    expect(math.fallbackText).toBe('√9、√16');
+    expect(math.measuredWidth).toBeGreaterThan(0);
+  });
+});

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { computePages, computeColumns } from './renderer.js';
 import type {
-  BodyElement, DocParagraph, DocxTextRun, ShapeRun, SectionProps, PaginatedBodyElement, DocTable, DocTableRow,
+  BodyElement, CellElement, DocParagraph, DocxTextRun, ShapeRun, SectionProps, PaginatedBodyElement, DocTable, DocTableRow,
 } from './types';
 
 // Unit tests for computePages pagination behaviour that the renderer-path VRT
@@ -56,12 +56,20 @@ function textRun(text: string, fontSize: number): DocRun {
 type DocRun = DocParagraph['runs'][number];
 
 function para(
-  opts: { text?: string; fontSize?: number; widowControl?: boolean; keepLines?: boolean; keepNext?: boolean } = {},
+  opts: {
+    text?: string;
+    fontSize?: number;
+    widowControl?: boolean;
+    keepLines?: boolean;
+    keepNext?: boolean;
+    spaceBefore?: number;
+    spaceAfter?: number;
+  } = {},
 ): BodyElement {
   const fontSize = opts.fontSize ?? 20;
   const p: DocParagraph = {
     alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
-    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    spaceBefore: opts.spaceBefore ?? 0, spaceAfter: opts.spaceAfter ?? 0, lineSpacing: null, numbering: null, tabStops: [],
     runs: opts.text ? [textRun(opts.text, fontSize)] : [],
     defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics',
     widowControl: opts.widowControl,
@@ -121,6 +129,17 @@ function paraWith(runs: DocRun[], opts: { fontSize?: number } = {}): BodyElement
   return { type: 'paragraph', ...p } as BodyElement;
 }
 
+function inlineImageRun(widthPt: number, heightPt: number): DocRun {
+  return {
+    type: 'image',
+    imagePath: 'word/media/image.png',
+    mimeType: 'image/png',
+    widthPt,
+    heightPt,
+    anchor: false,
+  } as DocRun;
+}
+
 /** A single-column block table whose rows each have a fixed `exact` height (pt),
  *  so its measured height is deterministic and independent of cell-content
  *  measurement (resolveTableRowHeights short-circuits on rowHeightRule="exact"). */
@@ -151,6 +170,109 @@ function fixedTable(rowHeightsPt: number[]): BodyElement {
   return { type: 'table', ...t } as BodyElement;
 }
 
+function autoTableWithTallRow(blockCount: number, rowOverrides: Partial<DocTableRow> = {}): BodyElement {
+  const content = Array.from({ length: blockCount }, (_, i) =>
+    para({ text: `row ${i}`, fontSize: 20 }) as CellElement,
+  );
+  const row: DocTableRow = {
+    cells: [
+      {
+        content,
+        colSpan: 1,
+        vMerge: null,
+        borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+        background: null,
+        vAlign: 'top',
+        widthPt: null,
+      },
+    ],
+    rowHeight: null,
+    rowHeightRule: 'auto',
+    isHeader: false,
+    ...rowOverrides,
+  };
+  const t: DocTable = {
+    colWidths: [160],
+    rows: [row],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left',
+  };
+  return { type: 'table', ...t } as BodyElement;
+}
+
+function autoTableWithSingleWrappedParagraph(charCount: number, rowOverrides: Partial<DocTableRow> = {}): BodyElement {
+  const row: DocTableRow = {
+    cells: [
+      {
+        content: [para({ text: 'あ'.repeat(charCount), fontSize: 20 }) as CellElement],
+        colSpan: 1,
+        vMerge: null,
+        borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+        background: null,
+        vAlign: 'top',
+        widthPt: null,
+      },
+    ],
+    rowHeight: null,
+    rowHeightRule: 'auto',
+    isHeader: false,
+    ...rowOverrides,
+  };
+  const t: DocTable = {
+    colWidths: [160],
+    rows: [row],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left',
+  };
+  return { type: 'table', ...t } as BodyElement;
+}
+
+function autoTableWithIntroRowThenSingleWrappedParagraph(charCount: number): BodyElement {
+  const first = (fixedTable([40]) as unknown as DocTable).rows[0];
+  const second = (autoTableWithSingleWrappedParagraph(charCount) as unknown as DocTable).rows[0];
+  const t: DocTable = {
+    colWidths: [160],
+    rows: [first, second],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left',
+  };
+  return { type: 'table', ...t } as BodyElement;
+}
+
+function autoTableWithIntroRowThenSpacedWrappedParagraph(): BodyElement {
+  const first = (fixedTable([45]) as unknown as DocTable).rows[0];
+  const second: DocTableRow = {
+    cells: [
+      {
+        content: [
+          para({ text: 'first', fontSize: 20, spaceAfter: 10 }) as CellElement,
+          para({ text: 'あ'.repeat(32), fontSize: 20, spaceBefore: 8 }) as CellElement,
+        ],
+        colSpan: 1,
+        vMerge: null,
+        borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+        background: null,
+        vAlign: 'top',
+        widthPt: null,
+      },
+    ],
+    rowHeight: null,
+    rowHeightRule: 'auto',
+    isHeader: false,
+  };
+  const t: DocTable = {
+    colWidths: [160],
+    rows: [first, second],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left',
+  };
+  return { type: 'table', ...t } as BodyElement;
+}
+
 const sliceOf = (el: PaginatedBodyElement) =>
   (el as { lineSlice?: { start: number; end: number } }).lineSlice;
 
@@ -158,6 +280,7 @@ const colOf = (el: PaginatedBodyElement) => el.colIndex;
 
 /** A body-level column break (ECMA-376 §17.3.1.20, hoisted by the parser). */
 const colBreak = (): BodyElement => ({ type: 'columnBreak' } as BodyElement);
+const pageBreak = (): BodyElement => ({ type: 'pageBreak' } as BodyElement);
 
 /** A body-level section break (ECMA-376 §17.6.x). `columns` is the ENDING
  *  section's `<w:cols>` (null/undefined ⇒ single full-width column). */
@@ -208,6 +331,87 @@ describe('computePages — tall header/footer reserve indexing (§17.6.11)', () 
     // the body genuinely spans several pages where the clamp matters.
     expect(short[0].length).toBe(4);
     expect(short.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe('computePages — over-tall table row splitting (§17.4 table pagination)', () => {
+  it('splits an auto-height row by cell block boundaries instead of overflowing the footer band', () => {
+    const pages = computePages([autoTableWithTallRow(8)], section(), makeCtx());
+    const tables = pages.flatMap((page) => page.filter((el) => el.type === 'table'));
+
+    expect(tables.length).toBeGreaterThan(1);
+    expect(tables.flatMap((t) => (t as unknown as DocTable).rows).length).toBe(2);
+    for (const table of tables) {
+      const h = (table.tableRowHeightsPt ?? []).reduce((sum, rowH) => sum + rowH, 0);
+      expect(h).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('splits a splittable auto-height row into the remaining page band before continuing', () => {
+    const pages = computePages([para(), para(), autoTableWithTallRow(4)], section(), makeCtx());
+    const firstPageTable = pages[0].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+    const secondPageTable = pages[1].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+
+    expect(firstPageTable).toBeDefined();
+    expect(secondPageTable).toBeDefined();
+
+    const firstSliceBlocks = firstPageTable?.rows[0]?.cells[0]?.content.length ?? 0;
+    const secondSliceBlocks = secondPageTable?.rows[0]?.cells[0]?.content.length ?? 0;
+    expect(firstSliceBlocks).toBeGreaterThan(0);
+    expect(firstSliceBlocks).toBeLessThan(4);
+    expect(firstSliceBlocks + secondSliceBlocks).toBe(4);
+  });
+
+  it('keeps a cantSplit row intact when it does not fit the remaining page band', () => {
+    const pages = computePages([para(), para(), autoTableWithTallRow(4, { cantSplit: true })], section(), makeCtx());
+
+    expect(pages[0].some((el) => el.type === 'table')).toBe(false);
+    const secondPageTable = pages[1].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+    expect(secondPageTable?.rows[0]?.cells[0]?.content.length).toBe(4);
+  });
+
+  it('splits a single cell paragraph in a splittable row at line boundaries', () => {
+    const pages = computePages([para(), para(), autoTableWithSingleWrappedParagraph(32)], section(), makeCtx());
+    const firstPageTable = pages[0].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+    const secondPageTable = pages[1].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+
+    expect(firstPageTable).toBeDefined();
+    expect(secondPageTable).toBeDefined();
+
+    const firstPara = firstPageTable?.rows[0]?.cells[0]?.content[0] as (CellElement & { lineSlice?: { start: number; end: number } }) | undefined;
+    const secondPara = secondPageTable?.rows[0]?.cells[0]?.content[0] as (CellElement & { lineSlice?: { start: number; end: number } }) | undefined;
+    expect(firstPara?.lineSlice).toEqual({ start: 0, end: 3 });
+    expect(secondPara?.lineSlice).toEqual({ start: 3, end: 4 });
+  });
+
+  it('splits the next row when it overflows after earlier rows filled part of the page', () => {
+    const pages = computePages([autoTableWithIntroRowThenSingleWrappedParagraph(32)], section(), makeCtx());
+    const firstPageTable = pages[0].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+    const secondPageTable = pages[1].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+
+    expect(firstPageTable?.rows.length).toBe(2);
+    expect(secondPageTable?.rows.length).toBe(1);
+
+    const splitPara = firstPageTable?.rows[1]?.cells[0]?.content[0] as (CellElement & { lineSlice?: { start: number; end: number } }) | undefined;
+    const restPara = secondPageTable?.rows[0]?.cells[0]?.content[0] as (CellElement & { lineSlice?: { start: number; end: number } }) | undefined;
+    expect(splitPara?.lineSlice).toEqual({ start: 0, end: 3 });
+    expect(restPara?.lineSlice).toEqual({ start: 3, end: 4 });
+  });
+
+  it('uses collapsed paragraph spacing when fitting a cell paragraph line into a split row', () => {
+    const pages = computePages([autoTableWithIntroRowThenSpacedWrappedParagraph()], section(), makeCtx());
+    const firstPageTable = pages[0].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+    const secondPageTable = pages[1].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+
+    expect(firstPageTable?.rows.length).toBe(2);
+    expect(firstPageTable?.rows[1]?.cells[0]?.content.map((el) => el.type === 'paragraph' ? textOf(el as unknown as PaginatedBodyElement) : el.type)).toEqual(['first', 'あ'.repeat(32)]);
+
+    const splitPara = firstPageTable?.rows[1]?.cells[0]?.content[1] as (CellElement & { lineSlice?: { start: number; end: number } }) | undefined;
+    const restSlices = secondPageTable?.rows
+      .map((row) => row.cells[0]?.content[0] as (CellElement & { lineSlice?: { start: number; end: number } }) | undefined)
+      .map((el) => el?.lineSlice);
+    expect(splitPara?.lineSlice).toEqual({ start: 0, end: 1 });
+    expect(restSlices).toEqual([{ start: 1, end: 3 }, { start: 3, end: 4 }]);
   });
 });
 
@@ -270,6 +474,152 @@ describe('computePages — anchored wrap-shape float exclusion (B: §20.4.2.16)'
     ];
     const pages = computePages(body, section(), makeCtx());
     expect(pages.length).toBe(1);
+  });
+
+  it('does not reserve flow height for a front non-callout wrapNone shape before a following inline image', () => {
+    const imagePara = paraWith([inlineImageRun(80, 30)]);
+    const body = [
+      paraWith([shapeRun({ widthPt: 160, heightPt: 80, wrapMode: 'none' })]),
+      imagePara,
+    ];
+
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages).toHaveLength(1);
+    expect(pages[0].some((el) =>
+      el.type === 'paragraph' &&
+      (el as unknown as DocParagraph).runs.some((r) => r.type === 'image'),
+    )).toBe(true);
+  });
+
+  it('does not let a wrapNone callout shape force a page break', () => {
+    const imagePara = paraWith([inlineImageRun(80, 30)]);
+    const callout = {
+      ...shapeRun({ widthPt: 160, heightPt: 80, wrapMode: 'none' }),
+      presetGeometry: 'accentBorderCallout2',
+    } as DocRun;
+    const body = [
+      paraWith([callout]),
+      imagePara,
+    ];
+
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages).toHaveLength(1);
+  });
+
+  it('does not move an anchor-only wrapNone callout to the next page to fit its box', () => {
+    const calloutAnchor = paraWith([
+      {
+        ...shapeRun({ widthPt: 160, heightPt: 50, wrapMode: 'none', anchorYFromPara: true }),
+        presetGeometry: 'accentBorderCallout2',
+      } as DocRun,
+    ]);
+    const body = [
+      ...Array.from({ length: 4 }, () => para()),
+      calloutAnchor,
+    ];
+
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages).toHaveLength(1);
+    expect(pages[0]).toContain(calloutAnchor as PaginatedBodyElement);
+  });
+
+  it('does not count a front wrapNone shape as flow height when grouping following inline images', () => {
+    const smallImage = paraWith([inlineImageRun(80, 10)]);
+    const photo = paraWith([inlineImageRun(80, 30)]);
+    const body = [
+      paraWith([shapeRun({ widthPt: 160, heightPt: 60, wrapMode: 'none' })]),
+      smallImage,
+      para(),
+      photo,
+    ];
+
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages).toHaveLength(1);
+    expect(pages[0]).toContain(smallImage as PaginatedBodyElement);
+    expect(pages[0].some((el) =>
+      el.type === 'paragraph' &&
+      (el as unknown as DocParagraph).runs.some((r) => r.type === 'image'),
+    )).toBe(true);
+  });
+
+  it('moves an inline-image paragraph to a fresh page when it no longer fits', () => {
+    const photo = paraWith([inlineImageRun(80, 30)]);
+    const body = [
+      ...Array.from({ length: 4 }, () => para()),
+      photo,
+    ];
+
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages).toHaveLength(2);
+    expect(pages[0]).not.toContain(photo as PaginatedBodyElement);
+    expect(pages[1].some((el) =>
+      el.type === 'paragraph' &&
+      (el as unknown as DocParagraph).runs.some((r) => r.type === 'image'),
+    )).toBe(true);
+  });
+});
+
+describe('computePages — paragraph anchor before explicit page break (§20.4.3.5 + §17.3.1.20)', () => {
+  it('keeps a paragraph-anchored wrapNone shape on the pre-break page when a hard page break follows', () => {
+    // Four empty paragraphs consume 80pt of the 100pt body. The following
+    // wrapNone callout is 50pt tall from its paragraph top, so the generic
+    // keep-on-page float rule would normally relocate it to a fresh page. But
+    // the source immediately follows this anchor paragraph with a hard page
+    // break: Word keeps the pre-break anchor on the pre-break page, then starts
+    // the next paragraph after the authored break. sample-33 has this exact
+    // shape after the "当日の板書" photo.
+    const anchorPara = paraWith([
+      shapeRun({ widthPt: 80, heightPt: 50, wrapMode: 'none', anchorYFromPara: true }),
+    ]);
+    const body = [
+      ...Array.from({ length: 4 }, () => para()),
+      anchorPara,
+      pageBreak(),
+      para({ text: 'after', fontSize: 20 }),
+    ];
+
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages).toHaveLength(2);
+    expect(pages[0]).toContain(anchorPara as PaginatedBodyElement);
+    expect(textOf(pages[1][0])).toBe('after');
+  });
+
+  it('does not push an anchor-only pre-break paragraph to a new page just for its empty mark', () => {
+    const anchorPara = paraWith([
+      shapeRun({ widthPt: 80, heightPt: 50, wrapMode: 'none', anchorYFromPara: true }),
+    ]);
+    const body = [
+      ...Array.from({ length: 5 }, () => para()),
+      anchorPara,
+      pageBreak(),
+      para({ text: 'after', fontSize: 20 }),
+    ];
+
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages).toHaveLength(2);
+    expect(pages[0]).toContain(anchorPara as PaginatedBodyElement);
+    expect(textOf(pages[1][0])).toBe('after');
+  });
+
+  it('moves a preceding image with its pre-break callout when the pair only fits fresh', () => {
+    const imagePara = paraWith([inlineImageRun(80, 40)]);
+    const anchorPara = paraWith([
+      shapeRun({ widthPt: 80, heightPt: 50, wrapMode: 'none', anchorYFromPara: true }),
+    ]);
+    const body = [
+      ...Array.from({ length: 3 }, () => para()),
+      imagePara,
+      anchorPara,
+      pageBreak(),
+      para({ text: 'after', fontSize: 20 }),
+    ];
+
+    const pages = computePages(body, section(), makeCtx());
+    expect(pages).toHaveLength(3);
+    expect(pages[0]).not.toContain(imagePara as PaginatedBodyElement);
+    expect(pages[1]).toContain(imagePara as PaginatedBodyElement);
+    expect(pages[1]).toContain(anchorPara as PaginatedBodyElement);
+    expect(textOf(pages[2][0])).toBe('after');
   });
 });
 
@@ -431,6 +781,21 @@ describe('computePages — explicit column break (§17.3.1.20)', () => {
     expect(colOf(pages[0].filter((e) => e.type === 'paragraph')[1])).toBe(1); // b
     expect(textOf(pages[1][0])).toBe('c');
     expect(colOf(pages[1][0])).toBe(0); // c on page 2, column 0
+  });
+
+  it('ignores a trailing column break when no following content exists', () => {
+    const body = [
+      para({ text: 'a', fontSize: 20 }),
+      colBreak(),
+      para({ text: 'b', fontSize: 20 }),
+      colBreak(),
+    ];
+    const pages = computePages(body, twoCol(), makeCtx());
+    expect(pages.length).toBe(1);
+    const paras = pages[0].filter((e) => e.type === 'paragraph');
+    expect(paras.map(textOf)).toEqual(['a', 'b']);
+    expect(colOf(paras[0])).toBe(0);
+    expect(colOf(paras[1])).toBe(1);
   });
 });
 

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -273,6 +273,34 @@ function autoTableWithIntroRowThenSpacedWrappedParagraph(): BodyElement {
   return { type: 'table', ...t } as BodyElement;
 }
 
+function autoTableWithNestedFixedTable(rowHeightsPt: number[]): BodyElement {
+  const nested = fixedTable(rowHeightsPt) as unknown as DocTable;
+  const row: DocTableRow = {
+    cells: [
+      {
+        content: [{ type: 'table', ...nested } as unknown as CellElement],
+        colSpan: 1,
+        vMerge: null,
+        borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+        background: null,
+        vAlign: 'top',
+        widthPt: null,
+      },
+    ],
+    rowHeight: null,
+    rowHeightRule: 'auto',
+    isHeader: false,
+  };
+  const t: DocTable = {
+    colWidths: [160],
+    rows: [row],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left',
+  };
+  return { type: 'table', ...t } as BodyElement;
+}
+
 const sliceOf = (el: PaginatedBodyElement) =>
   (el as { lineSlice?: { start: number; end: number } }).lineSlice;
 
@@ -412,6 +440,20 @@ describe('computePages — over-tall table row splitting (§17.4 table paginatio
       .map((el) => el?.lineSlice);
     expect(splitPara?.lineSlice).toEqual({ start: 0, end: 1 });
     expect(restSlices).toEqual([{ start: 1, end: 3 }, { start: 3, end: 4 }]);
+  });
+
+  it('splits a nested table inside a cell at inner row boundaries', () => {
+    const pages = computePages([autoTableWithNestedFixedTable([30, 30, 30, 30])], section(), makeCtx());
+    expect(pages.length).toBe(2);
+    const firstPageTable = pages[0].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+    const secondPageTable = pages[1].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+
+    const firstNested = firstPageTable?.rows[0]?.cells[0]?.content[0] as (CellElement & DocTable) | undefined;
+    const secondNested = secondPageTable?.rows[0]?.cells[0]?.content[0] as (CellElement & DocTable) | undefined;
+    expect(firstNested?.type).toBe('table');
+    expect(secondNested?.type).toBe('table');
+    expect(firstNested?.rows.length).toBe(3);
+    expect(secondNested?.rows.length).toBe(1);
   });
 });
 

--- a/packages/docx/src/renderer.textbox-image.test.ts
+++ b/packages/docx/src/renderer.textbox-image.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { preloadImages, renderShapeText } from './renderer';
+import { measureShapeTextAutoFitHeight, preloadImages, renderShapeText } from './renderer';
 import type { DocxDocumentModel, ShapeRun, ShapeText, ShapeTextRun } from './types';
 
 /**
@@ -220,6 +220,34 @@ describe('textbox inline images — rendering', () => {
     const ink = fillTextCalls.map((c) => c.text).join('').replace(/\s/g, '');
     expect(ink).toBe('aaaabbbbccccddddeeee');
   });
+
+  it('spAutoFit text boxes keep Word default horizontal margins when wrapping', () => {
+    const { ctx, fillTextCalls } = makeRecordingCtx();
+    const shape = {
+      type: 'shape', zOrder: 0, subpaths: [], presetGeometry: 'rect', fill: null, stroke: null,
+      textBlocks: [{ text: 'aaaaaaaaa bbbbbbbb', fontSizePt: 10, alignment: 'left' }],
+      textAnchor: 't', textInsetL: 7.2, textInsetT: 0, textInsetR: 7.2, textInsetB: 0,
+      textAutofit: 'sp',
+    } as unknown as ShapeRun;
+
+    renderShapeText(shape, 0, 0, 200, 400, ctx, 1, {}, new Map());
+
+    expect(fillTextCalls.map((c) => c.text)).toEqual(['aaaaaaaaa ', 'bbbbbbbb']);
+  });
+
+  it('measureShapeTextAutoFitHeight returns content height plus bodyPr insets', () => {
+    const { ctx } = makeRecordingCtx();
+    const shape = {
+      type: 'shape', zOrder: 0, subpaths: [], presetGeometry: 'rect', fill: null, stroke: null,
+      textBlocks: [{ text: 'fit', fontSizePt: 10, alignment: 'left' }],
+      textAnchor: 't', textInsetL: 2, textInsetT: 3, textInsetR: 2, textInsetB: 4,
+      textAutofit: 'sp',
+    } as unknown as ShapeRun;
+
+    const measured = measureShapeTextAutoFitHeight(shape, 200, ctx, 1, {}, new Map());
+
+    expect(measured).toBeCloseTo(17, 5);
+  });
 });
 
 describe('textbox rich text — per-run formatting', () => {
@@ -259,6 +287,72 @@ describe('textbox rich text — per-run formatting', () => {
     expect(bodyToks.length).toBeGreaterThan(0);
     for (const t of labelToks) expect(isBoldFont(t.font)).toBe(true);
     for (const t of bodyToks) expect(isBoldFont(t.font)).toBe(false);
+  });
+
+  it('draws ruby annotations above text-box base glyphs', () => {
+    const { ctx, fillTextCalls } = makeRecordingCtx();
+    const shape = richTextbox([
+      {
+        text: '根号',
+        fontSizePt: 22,
+        fontFamily: 'MS Mincho',
+        fontFamilyEastAsia: 'MS Mincho',
+        ruby: { text: 'こんごう', fontSizePt: 5 },
+      },
+      { text: 'を含む式の', fontSizePt: 22 },
+      { text: '加', fontSizePt: 22, ruby: { text: 'か', fontSizePt: 5 } },
+      { text: '減', fontSizePt: 22, ruby: { text: 'げん', fontSizePt: 5 } },
+    ]);
+
+    renderShapeText(shape, 0, 0, 500, 120, ctx, 1, {}, new Map());
+
+    const root = fillTextCalls.find((c) => c.text === '根号');
+    const rootRuby = fillTextCalls.find((c) => c.text === 'こんごう');
+    const add = fillTextCalls.find((c) => c.text === '加');
+    const addRuby = fillTextCalls.find((c) => c.text === 'か');
+    const sub = fillTextCalls.find((c) => c.text === '減');
+    const subRuby = fillTextCalls.find((c) => c.text === 'げん');
+
+    expect(root).toBeDefined();
+    expect(rootRuby).toBeDefined();
+    expect(add).toBeDefined();
+    expect(addRuby).toBeDefined();
+    expect(sub).toBeDefined();
+    expect(subRuby).toBeDefined();
+    expect(rootRuby!.y).toBeLessThan(root!.y);
+    expect(addRuby!.y).toBeLessThan(add!.y);
+    expect(subRuby!.y).toBeLessThan(sub!.y);
+    expect(fillTextCalls.map((c) => c.text).join('')).toBe('根号こんごうを含む式の加か減げん');
+  });
+
+  it('draws a numbered marker for text-box paragraphs', () => {
+    const { ctx, fillTextCalls } = makeRecordingCtx();
+    const shape = richTextbox([{ text: '加法、減法の言葉に合った数式を生徒に考えさせる。', fontSizePt: 10, color: '000000' }]);
+    shape.defaultTextColor = 'FFFFFF';
+    shape.textBlocks![0].indentLeft = 36;
+    shape.textBlocks![0].indentFirst = -36;
+    shape.textBlocks![0].numbering = {
+      numId: 5,
+      level: 0,
+      format: 'bullet',
+      text: '※',
+      indentLeft: 36,
+      tab: 36,
+      suff: 'tab',
+      jc: 'left',
+      fontFamily: 'MS Gothic',
+      fontFamilyEastAsia: 'MS Gothic',
+    };
+
+    renderShapeText(shape, 0, 0, 260, 120, ctx, 1, {}, new Map());
+
+    const marker = fillTextCalls.find((c) => c.text === '※');
+    const body = fillTextCalls.find((c) => c.text.includes('加法'));
+    expect(marker).toBeDefined();
+    expect(body).toBeDefined();
+    expect(marker!.fillStyle).toBe('#000000');
+    expect(marker!.x).toBeLessThan(body!.x);
+    expect(marker!.y).toBe(body!.y);
   });
 
   it('keeps each run its own font when mixed-run text wraps across lines', () => {

--- a/packages/docx/src/renderer.textbox-image.test.ts
+++ b/packages/docx/src/renderer.textbox-image.test.ts
@@ -221,18 +221,18 @@ describe('textbox inline images — rendering', () => {
     expect(ink).toBe('aaaabbbbccccddddeeee');
   });
 
-  it('spAutoFit text boxes keep Word default horizontal margins when wrapping', () => {
+  it('spAutoFit text boxes use serialized bodyPr horizontal insets once', () => {
     const { ctx, fillTextCalls } = makeRecordingCtx();
     const shape = {
       type: 'shape', zOrder: 0, subpaths: [], presetGeometry: 'rect', fill: null, stroke: null,
-      textBlocks: [{ text: 'aaaaaaaaa bbbbbbbb', fontSizePt: 10, alignment: 'left' }],
+      textBlocks: [{ text: 'fit', fontSizePt: 10, alignment: 'left' }],
       textAnchor: 't', textInsetL: 7.2, textInsetT: 0, textInsetR: 7.2, textInsetB: 0,
       textAutofit: 'sp',
     } as unknown as ShapeRun;
 
-    renderShapeText(shape, 0, 0, 200, 400, ctx, 1, {}, new Map());
+    renderShapeText(shape, 10, 0, 200, 400, ctx, 1, {}, new Map());
 
-    expect(fillTextCalls.map((c) => c.text)).toEqual(['aaaaaaaaa ', 'bbbbbbbb']);
+    expect(fillTextCalls[0]?.x).toBeCloseTo(17.2, 5);
   });
 
   it('measureShapeTextAutoFitHeight returns content height plus bodyPr insets', () => {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -297,6 +297,12 @@ export interface RenderState {
    *  the DRAW pass; falls back to {@link DEFAULT_TAB_PT} (720 twips = 36pt) when
    *  the document omits the element. */
   defaultTabPt: number;
+  /** ECMA-376 §17.15.1.18 — East Asian punctuation / character-spacing mode. */
+  characterSpacingControl?: string;
+  /** ECMA-376 §17.15.3.1 `w:compat/w:useFELayout`. */
+  useFeLayout?: boolean;
+  /** ECMA-376 §17.15.3.1 `w:compat/w:balanceSingleByteDoubleByteWidth`. */
+  balanceSingleByteDoubleByteWidth?: boolean;
   /** ECMA-376 §22.1.2.30 `m:mathPr/m:defJc` — document-wide default math
    *  justification (ST_Jc math). `undefined` ⇒ spec default `centerGroup`.
    *  Threaded from `doc.settings.mathDefJc` like `kinsoku`; consumed by the
@@ -1231,6 +1237,9 @@ export async function renderDocumentToCanvas(
     // §17.15.1.25 — automatic tab interval, resolved once and threaded like
     // `kinsoku` so the measure and draw passes agree.
     defaultTabPt: resolveDefaultTabPt(doc.settings),
+    characterSpacingControl: doc.settings?.characterSpacingControl,
+    useFeLayout: doc.settings?.useFeLayout,
+    balanceSingleByteDoubleByteWidth: doc.settings?.balanceSingleByteDoubleByteWidth,
     mathDefJc: doc.settings?.mathDefJc,
     onTextRun: opts.onTextRun,
     showTrackChanges: opts.showTrackChanges ?? true,
@@ -1435,8 +1444,9 @@ function measureNoteBlockForDraw(
   docEastAsian: boolean,
   // §17.15.1.25 — keep the note measure pass on the same automatic tab interval.
   defaultTabPt: number = DEFAULT_TAB_PT,
+  settings?: DocSettings,
 ): { total: number; trailingSpaceAfter: number } {
-  const measure = buildMeasureState(ctx, sec, fontFamilyClasses, kinsoku, docEastAsian, defaultTabPt);
+  const measure = buildMeasureState(ctx, sec, fontFamilyClasses, kinsoku, docEastAsian, defaultTabPt, settings);
   const contentWPt = sec.pageWidth - sec.marginLeft - sec.marginRight;
   return measureFootnoteBlockPt(note, measure, contentWPt);
 }
@@ -1478,7 +1488,7 @@ function drawPageFootnotes(
   for (const id of ids) {
     const note = noteById.get(id);
     if (!note) continue;
-    const m = measureNoteBlockForDraw(note, baseState.ctx, sec, baseState.fontFamilyClasses, baseState.kinsoku, baseState.docEastAsian, baseState.defaultTabPt);
+    const m = measureNoteBlockForDraw(note, baseState.ctx, sec, baseState.fontFamilyClasses, baseState.kinsoku, baseState.docEastAsian, baseState.defaultTabPt, doc.settings);
     totalPt += m.total;
     lastTrailingPt = m.trailingSpaceAfter;
   }
@@ -1832,6 +1842,8 @@ export function computePages(
    *  pagination measure pass advances tabs identically to the draw pass; defaults
    *  to the spec absent value when a caller has no document settings. */
   defaultTabPt: number = DEFAULT_TAB_PT,
+  /** ECMA-376 §17.15.1.* — document-wide layout settings. */
+  settings?: DocSettings,
 ): PaginatedBodyElement[][] {
   // ECMA-376 §17.6.11: the body is inset from each page edge by the margin's MAGNITUDE
   // (a negative margin measures the body |margin| from the edge and overlaps the
@@ -1846,7 +1858,7 @@ export function computePages(
   const bodyTopPt = () => bodyMarginInsetPt(currentSectionGeom.marginTop);
   const bodyBottomPt = () => bodyMarginInsetPt(currentSectionGeom.marginBottom);
   const fullContentH = () => currentSectionGeom.pageHeight - bodyTopPt() - bodyBottomPt();
-  const measureState = buildMeasureState(ctx, section, fontFamilyClasses, kinsoku, documentHasEastAsian(body), defaultTabPt);
+  const measureState = buildMeasureState(ctx, section, fontFamilyClasses, kinsoku, documentHasEastAsian(body), defaultTabPt, settings);
   const noteById = indexNotes(footnotes);
   const haveFootnotes = noteById.size > 0;
   // Per-page reserved footnote height (pt). Index 0 = first page. Grows as
@@ -2313,6 +2325,8 @@ export function computePages(
         // so sizeRelV / wgp-group scaling is honored. measureState is scale 1 (pt),
         // so box.h is already in pt.
         const shp = run as unknown as ShapeRun;
+        const preset = (shp.presetGeometry ?? '').toLowerCase();
+        if (preset.includes('callout') && shp.wrapMode === 'none') continue;
         if (!shp.anchorYFromPara) continue;
         const box = resolveShapeBox(shp, measureState, measureState.y);
         if (box.h <= 0) continue;
@@ -2345,6 +2359,25 @@ export function computePages(
     return 0;
   };
 
+  const estimateFollowingInlineImageClusterHeight = (startIdx: number): number => {
+    let total = 0;
+    for (let j = startIdx; j < body.length; j++) {
+      const nxt = body[j];
+      if (!nxt || nxt.type === 'pageBreak' || nxt.type === 'sectionBreak' || nxt.type === 'columnBreak') return 0;
+      if (nxt.type !== 'paragraph') return 0;
+      const p = nxt as unknown as DocParagraph;
+      if (isInklessParagraph(p)) {
+        total += estimateParagraphHeight(measureState, p, colW(), false);
+        continue;
+      }
+      if (hasInlineImage(p)) {
+        return total + estimateParagraphHeight(measureState, p, colW(), false);
+      }
+      return 0;
+    }
+    return 0;
+  };
+
   // Stamp the active newspaper column (index + this section's geometry) on an
   // element and push it onto the current page. For single-column sections
   // colIndex is always 0 (the renderer treats 0/absent identically) and colGeom
@@ -2367,6 +2400,14 @@ export function computePages(
   // the common single-section document.
   setupBalancing(0);
 
+  const hasFollowingFlowContent = (startIdx: number): boolean => {
+    for (let j = startIdx; j < body.length; j++) {
+      const nxt = body[j];
+      if (nxt.type === 'paragraph' || nxt.type === 'table') return true;
+    }
+    return false;
+  };
+
   for (let i = 0; i < body.length; i++) {
     const el = body[i];
     if (el.type === 'columnBreak') {
@@ -2375,6 +2416,7 @@ export function computePages(
       // on an empty page, so a column break in the last column of an as-yet-empty
       // page simply stays put). Page-start index = the body element AFTER the
       // break (i + 1) since the break itself emits no content on the new page.
+      if (!hasFollowingFlowContent(i + 1)) continue;
       nextColumnOrPage(i + 1);
       continue;
     }
@@ -2678,7 +2720,35 @@ export function computePages(
       const floatBottomOff = anchoredFloatBottomOffset(para);
       const floatOverflowsHere = floatBottomOff > 0 && y + floatBottomOff > effContentH();
       const floatFitsFresh = floatBottomOff > 0 && floatBottomOff <= effContentH();
-      const breakForFloat = y > 0 && floatOverflowsHere && floatFitsFresh;
+      // If the author placed a hard page break immediately after this paragraph,
+      // the paragraph-anchored drawing belongs to the pre-break page. Do not move
+      // the anchor paragraph to the post-break page solely to satisfy the generic
+      // keep-on-page float rule; the following pageBreak is the source boundary.
+      const followedByHardPageBreak = nextEl?.type === 'pageBreak';
+      const breakForFloat = !followedByHardPageBreak && y > 0 && floatOverflowsHere && floatFitsFresh;
+      const nextAnchorBeforeHardBreak =
+        hasInlineImage(para) &&
+        nextEl?.type === 'paragraph' &&
+        body[i + 2]?.type === 'pageBreak' &&
+        isAnchorOnlyParagraph(nextEl as unknown as DocParagraph)
+          ? (nextEl as unknown as DocParagraph)
+          : null;
+      const nextAnchorBottomOff = nextAnchorBeforeHardBreak
+        ? anchoredFloatBottomOffset(nextAnchorBeforeHardBreak)
+        : 0;
+      const breakForTrailingAnchor =
+        nextAnchorBottomOff > 0 &&
+        y > 0 &&
+        y + fitHeight + nextAnchorBottomOff > effContentH() &&
+        fitHeight + nextAnchorBottomOff <= effContentH();
+      const followingImageClusterH = hasInlineImage(para)
+        ? estimateFollowingInlineImageClusterHeight(i + 1)
+        : 0;
+      const breakForFollowingImageCluster =
+        followingImageClusterH > 0 &&
+        y > 0 &&
+        y + fitHeight + followingImageClusterH > effContentH() &&
+        fitHeight + followingImageClusterH <= effContentH();
       // Does the content (+ keepNext look-ahead + newly-referenced footnote
       // bodies) overflow the space left on this page? spaceAfter is trailing
       // whitespace allowed to spill past the bottom margin, so it is excluded.
@@ -2727,7 +2797,7 @@ export function computePages(
         wantsBalanceBreak(fitHeight + needNext) &&
         fitHeight + needNext <= balanceColH;
       const balanceBreak = balanceBreakKeepLines || balanceBreakKeepNext;
-      if (breakForFloat || balanceBreak || (overflowsHere && keepIntact && needed <= effContentH())) {
+      if (breakForFloat || breakForTrailingAnchor || breakForFollowingImageCluster || balanceBreak || (overflowsHere && keepIntact && needed <= effContentH())) {
         const pagesBeforeRelocate = pages.length;
         // Relocating THIS paragraph to a fresh page: pre-scan from `i` so the
         // new page starts with THIS paragraph's own page-level floats counted.
@@ -2752,6 +2822,18 @@ export function computePages(
           measureState.floatParaSeq = floatSeqBefore;
           registerAnchorFloats(para, measureState, measureState.y);
         }
+      }
+      if (followedByHardPageBreak && isAnchorOnlyParagraph(para)) {
+        // A shape-only anchor paragraph immediately before a hard page break is a
+        // drawing attachment point for the pre-break page, not a visible empty
+        // line that should be pushed to the post-break page when the body is full
+        // (sample-33's photo callout). The break element following this paragraph
+        // will advance to the next page; keep this anchor on the current one and
+        // avoid adding paragraph-mark height.
+        pushTagged(el as PaginatedBodyElement);
+        prevPara = para;
+        prevSpaceAfter = 0;
+        continue;
       }
 
       // ECMA-376 places no "a paragraph must fit on one page" requirement — Word
@@ -2816,7 +2898,6 @@ export function computePages(
         y += h;
         measureState.y += h;
       }
-
       // Commit the footnote reserve onto the page the paragraph landed on.
       if (haveFootnotes && newRefIds.length > 0) {
         const idx = pages.length - 1;
@@ -3072,9 +3153,8 @@ export function computePages(
       // full content band. Resolve columns + row heights together (one min-content
       // scan) so both can be stamped for the paint pass (B2 table stage 1b).
       const tblContentWPt = colW();
-      const { colWidthsPt: tblColWidthsPt, rowHeightsPt: rowHs } =
+      const { colWidthsPt: tblColWidthsPt, rowHeightsPt: measuredRowHs } =
         computeTablePtLayout(measureState, tbl, tblContentWPt);
-      const h = rowHs.reduce((s, x) => s + x, 0);
       // ECMA-376 §17.11.10 — a footnote referenced from inside a table cell is
       // drawn at the bottom of the page holding the table, so the body area must
       // shrink by the note height just as it does for a body-paragraph reference
@@ -3098,6 +3178,17 @@ export function computePages(
       // table's own footnote reserve is subtracted on top so the note clears the
       // table content.
       const tableContentH = effContentH() - tblReservePt;
+      const splitRows = splitRowsTallerThanPage(
+        tbl,
+        measuredRowHs,
+        tblColWidthsPt,
+        tableContentH,
+        measureState,
+      );
+      const pageTable = splitRows?.table ?? tbl;
+      const rowHs = splitRows?.rowHs ?? measuredRowHs;
+      const tableEl = (splitRows ? { ...pageTable, type: 'table' } : el) as PaginatedBodyElement;
+      const h = rowHs.reduce((s, x) => s + x, 0);
       const commitTableReserve = () => {
         if (!haveFootnotes || tblNewRefIds.length === 0) return;
         // Re-filter against the landing page (a split may have advanced pages, so
@@ -3108,12 +3199,15 @@ export function computePages(
         footnoteReservePt[idx] = (footnoteReservePt[idx] ?? 0) + addPt;
         for (const id of tblNewRefIds) pageNoteIds.add(id);
       };
-      if (h > tableContentH) {
-        // Taller than a full column: split row-by-row so the overflow continues
-        // into the next column / page instead of being clipped (ECMA-376 table
-        // pagination). Tables that fit keep the simple place-whole path below.
+      const overflowsCurrentColumn = y + h > tableContentH;
+      if (h > tableContentH || (!wantsBalanceBreak(h) && overflowsCurrentColumn)) {
+        // Split row-by-row so overflow continues into the next column / page
+        // instead of leaving the current page under-filled. If the first
+        // overflowing row is auto-height and splittable (no w:cantSplit), the
+        // splitter may also divide that row by cell block boundaries, matching
+        // Word's default table-row pagination.
         const endY = splitTableAcrossPages(
-          tbl, rowHs, y, tableContentH, pages,
+          pageTable, rowHs, y, tableContentH, pages,
           // Table slices belong to THIS table element, so the new page's
           // pre-scan starts at `i` (this table's body index). The just-filled
           // column bottom folds into `maxColBottomY` so a following continuous
@@ -3130,6 +3224,7 @@ export function computePages(
           // paint pass reuses it. Each slice records ITS rows' heights; the column
           // widths + contentWPt are constant across the split.
           { colWidthsPt: tblColWidthsPt, contentWPt: tblContentWPt },
+          { colWidthsPt: tblColWidthsPt, state: measureState },
         );
         y = endY;
         measureState.y = bodyTopPt() + endY;
@@ -3139,8 +3234,8 @@ export function computePages(
         // the rest of this column ⇒ advance to the next column / page.
         if (wantsBalanceBreak(h) || y + h > tableContentH) nextColumnOrPage(i);
         // B2 table stage 1b — stamp the whole-table scale-1 layout for paint reuse.
-        stampTableLayout(el as PaginatedBodyElement, tblColWidthsPt, rowHs, tblContentWPt);
-        pushTagged(el as PaginatedBodyElement);
+        stampTableLayout(tableEl, tblColWidthsPt, rowHs, tblContentWPt);
+        pushTagged(tableEl);
         y += h;
         measureState.y += h;
         commitTableReserve();
@@ -3342,8 +3437,8 @@ function paginateWithHeaderFooterReserve(
   // §17.15.1.25 — resolve once here so both pagination passes and the
   // reserve-measure state share the document's automatic tab interval.
   const defaultTabPt = resolveDefaultTabPt(doc.settings);
-  const pass1 = computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes, [], defaultTabPt);
-  const measure = buildMeasureState(ctx, doc.section, fontFamilyClasses, kinsoku, documentHasEastAsian(doc.body), defaultTabPt);
+  const pass1 = computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes, [], defaultTabPt, doc.settings);
+  const measure = buildMeasureState(ctx, doc.section, fontFamilyClasses, kinsoku, documentHasEastAsian(doc.body), defaultTabPt, doc.settings);
   const footerReserves = computeFooterReserves(pass1, doc, measure);
   const headerReserves = computeHeaderReserves(pass1, doc, measure);
   const overflows = (rs: number[]): boolean => rs.some((r) => r > MIN_MARGIN_OVERFLOW_PT);
@@ -3352,7 +3447,7 @@ function paginateWithHeaderFooterReserve(
     top: headerReserves[i] ?? 0,
     bottom: footerReserves[i] ?? 0,
   }));
-  return computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes, pageReserves, defaultTabPt);
+  return computePages(doc.body, doc.section, ctx, fontFamilyClasses, kinsoku, footnotes, pageReserves, defaultTabPt, doc.settings);
 }
 
 /** Paginate with a throwaway measure context (a fresh OffscreenCanvas, scale 1).
@@ -3402,6 +3497,7 @@ function buildMeasureState(
   // §17.15.1.25 — threaded so the measure pass uses the SAME automatic tab
   // interval as the draw pass; defaults to the spec absent value when no doc.
   defaultTabPt: number = DEFAULT_TAB_PT,
+  settings?: DocSettings,
 ): RenderState {
   return {
     ctx,
@@ -3447,6 +3543,9 @@ function buildMeasureState(
     fontFamilyClasses,
     kinsoku,
     defaultTabPt,
+    characterSpacingControl: settings?.characterSpacingControl,
+    useFeLayout: settings?.useFeLayout,
+    balanceSingleByteDoubleByteWidth: settings?.balanceSingleByteDoubleByteWidth,
     showTrackChanges: false,
   };
 }
@@ -4246,6 +4345,396 @@ function stampTableLayout(
   el.tableLayoutInputs = { scale: 1, contentWPt };
 }
 
+function measureSingleTableRowPt(
+  row: DocTableRow,
+  table: DocTable,
+  colWidthsPt: number[],
+  state: RenderState,
+): number {
+  return resolveSingleRowHeight(row, colWidthsPt, 1, (cell, cellW) =>
+    measureCellContentHeightPx(cell, table, cellW, 1, state),
+  );
+}
+
+function rowSliceByCellContent(row: DocTableRow, start: number, end: number): DocTableRow {
+  return {
+    ...row,
+    cells: row.cells.map((cell) => ({
+      ...cell,
+      content: cell.content.slice(start, end),
+    })),
+  };
+}
+
+function splitRowByCellBlocks(
+  table: DocTable,
+  row: DocTableRow,
+  colWidthsPt: number[],
+  maxHeightPt: number,
+  state: RenderState,
+): { rows: DocTableRow[]; heights: number[] } | null {
+  if (row.isHeader || row.cantSplit || row.rowHeightRule === 'exact') return null;
+  if (row.cells.some((cell) => cell.vMerge !== null)) return null;
+  const blockCount = Math.max(0, ...row.cells.map((cell) => cell.content.length));
+  if (blockCount <= 1) return null;
+
+  const rows: DocTableRow[] = [];
+  const heights: number[] = [];
+  let start = 0;
+  while (start < blockCount) {
+    let bestEnd = start + 1;
+    let bestHeight = Number.POSITIVE_INFINITY;
+    for (let end = start + 1; end <= blockCount; end++) {
+      const candidate = rowSliceByCellContent(row, start, end);
+      const h = measureSingleTableRowPt(candidate, table, colWidthsPt, state);
+      if (h <= maxHeightPt || bestHeight === Number.POSITIVE_INFINITY) {
+        bestEnd = end;
+        bestHeight = h;
+      }
+      if (h > maxHeightPt) break;
+    }
+    const slice = rowSliceByCellContent(row, start, bestEnd);
+    rows.push(slice);
+    heights.push(Number.isFinite(bestHeight) ? bestHeight : measureSingleTableRowPt(slice, table, colWidthsPt, state));
+    start = bestEnd;
+  }
+  return rows.length > 1 ? { rows, heights } : null;
+}
+
+function layoutCellParagraphForRowSplit(
+  para: DocParagraph,
+  innerWPt: number,
+  state: RenderState,
+): { lines: LayoutLine[]; lineHeights: number[]; inputs: Parameters<typeof stampParagraphLines>[2] } | null {
+  const segs = buildSegments(para.runs, state);
+  if (segs.length === 0) return null;
+  const grid = paraGrid(para, state);
+  const paraHasRuby = paragraphHasRuby(para);
+  const indLeft = para.bidi === true ? para.indentRight : para.indentLeft;
+  const indRight = para.bidi === true ? para.indentLeft : para.indentRight;
+  const paraW = Math.max(1, innerWPt - indLeft - indRight);
+  const gridDeltaPx = gridCharDeltaPx(grid, 1);
+  const lines = layoutLines(
+    state.ctx,
+    segs,
+    paraW,
+    para.indentFirst,
+    1,
+    para.tabStops,
+    undefined,
+    state.fontFamilyClasses,
+    indLeft,
+    state.kinsoku,
+    gridDeltaPx,
+    state.defaultTabPt,
+    para.bidi === true ? paraW + indRight : paraW,
+    para.bidi === true,
+  );
+  if (lines.length === 0) return null;
+  const perLineH = (l: LayoutLine) =>
+    lineBoxHeight(
+      para.lineSpacing,
+      l.ascent,
+      l.descent,
+      1,
+      grid,
+      paraHasRuby,
+      l.intendedSingle,
+      paragraphIsEastAsian(para),
+    );
+  const uniformH = paraHasRuby
+    ? snapParaLineToGrid(Math.max(0, ...lines.map(perLineH)), grid, 1)
+    : 0;
+  return {
+    lines,
+    lineHeights: lines.map((l) => (paraHasRuby ? uniformH : perLineH(l))),
+    inputs: {
+      paraW,
+      firstIndent: para.indentFirst,
+      tabOriginPx: indLeft,
+      gridDeltaPx,
+      hasFloats: false,
+      kinsoku: state.kinsoku,
+    },
+  };
+}
+
+function paragraphLineSliceHeight(
+  para: DocParagraph,
+  lineHeights: number[],
+  start: number,
+  end: number,
+): number {
+  let h = 0;
+  for (let i = start; i < end; i++) h += lineHeights[i] ?? 0;
+  if (start === 0) h += para.spaceBefore;
+  if (end >= lineHeights.length) h += Math.max(para.spaceAfter, bottomBorderExtentPt(para.borders));
+  return h;
+}
+
+function paragraphLineSliceElement(
+  para: DocParagraph,
+  layout: NonNullable<ReturnType<typeof layoutCellParagraphForRowSplit>>,
+  start: number,
+  end: number,
+): CellElement {
+  const slice = {
+    ...(para as object),
+    type: 'paragraph',
+    lineSlice: { start, end },
+  } as unknown as CellElement;
+  if (!paragraphSegsStateSensitive(para)) {
+    stampParagraphLines(slice as unknown as PaginatedElementWithLines, layout.lines, layout.inputs);
+  }
+  return slice;
+}
+
+function splitCellContentByHeight(
+  content: CellElement[],
+  innerWPt: number,
+  maxContentHeightPt: number,
+  state: RenderState,
+): { before: CellElement[]; after: CellElement[]; beforeHeight: number; afterHeight: number } | null {
+  const before: CellElement[] = [];
+  let beforeHeight = 0;
+  let prevPara: DocParagraph | null = null;
+  let prevSpaceAfter = 0;
+  type LineSlice = { start: number; end: number };
+  const cellLineSlice = (ce: CellElement): LineSlice | undefined =>
+    (ce as CellElement & { lineSlice?: LineSlice }).lineSlice;
+
+  const additionHeight = (ce: CellElement, rawHeight: number, slice = cellLineSlice(ce)): number => {
+    if (ce.type !== 'paragraph') return rawHeight;
+    const para = ce as unknown as DocParagraph;
+    const continuationSlice = !!slice && slice.start > 0;
+    const rawBefore = continuationSlice ? 0 : para.spaceBefore;
+    const suppress = !continuationSlice && contextualSuppressed(prevPara, para);
+    const effBefore = suppress ? 0 : rawBefore;
+    const overlap = suppress ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
+    return rawHeight
+      - (suppress ? rawBefore : 0)
+      - overlap;
+  };
+  const appendBefore = (ce: CellElement, rawHeight: number, slice = cellLineSlice(ce), totalLines?: number): void => {
+    before.push(ce);
+    beforeHeight += additionHeight(ce, rawHeight, slice);
+    if (ce.type === 'paragraph') {
+      const para = ce as unknown as DocParagraph;
+      prevPara = para;
+      prevSpaceAfter = !slice || totalLines == null || slice.end >= totalLines
+        ? para.spaceAfter
+        : 0;
+    } else {
+      prevPara = null;
+      prevSpaceAfter = 0;
+    }
+  };
+  const measureSplitElement = (ce: CellElement): { rawHeight: number; slice?: LineSlice; totalLines?: number } => {
+    if (ce.type !== 'paragraph') {
+      return { rawHeight: measureCellElementHeight(state, ce, innerWPt, 1) };
+    }
+    const para = ce as unknown as DocParagraph;
+    const layout = layoutCellParagraphForRowSplit(para, innerWPt, state);
+    if (!layout) return { rawHeight: measureCellElementHeight(state, ce, innerWPt, 1) };
+    const existingSlice = cellLineSlice(ce);
+    const slice = {
+      start: Math.max(0, existingSlice?.start ?? 0),
+      end: Math.min(layout.lines.length, existingSlice?.end ?? layout.lines.length),
+    };
+    return {
+      rawHeight: paragraphLineSliceHeight(para, layout.lineHeights, slice.start, slice.end),
+      slice,
+      totalLines: layout.lines.length,
+    };
+  };
+  const sumContentHeightForSplit = (items: CellElement[]): number => {
+    let h = 0;
+    let localPrevPara: DocParagraph | null = null;
+    let localPrevSpaceAfter = 0;
+    for (const item of items) {
+      const measured = measureSplitElement(item);
+      if (item.type !== 'paragraph') {
+        h += measured.rawHeight;
+        localPrevPara = null;
+        localPrevSpaceAfter = 0;
+        continue;
+      }
+      const para = item as unknown as DocParagraph;
+      const continuationSlice = !!measured.slice && measured.slice.start > 0;
+      const rawBefore = continuationSlice ? 0 : para.spaceBefore;
+      const suppress = !continuationSlice && contextualSuppressed(localPrevPara, para);
+      const effBefore = suppress ? 0 : rawBefore;
+      const overlap = suppress ? localPrevSpaceAfter : Math.min(localPrevSpaceAfter, effBefore);
+      h += measured.rawHeight - (suppress ? rawBefore : 0) - overlap;
+      localPrevPara = para;
+      localPrevSpaceAfter = !measured.slice || measured.totalLines == null || measured.slice.end >= measured.totalLines
+        ? para.spaceAfter
+        : 0;
+    }
+    return h;
+  };
+
+  for (let i = 0; i < content.length; i++) {
+    const ce = content[i];
+    const para = ce.type === 'paragraph' ? ce as unknown as DocParagraph : null;
+    const layout = para ? layoutCellParagraphForRowSplit(para, innerWPt, state) : null;
+    const existingSlice = cellLineSlice(ce);
+    const currentSlice = layout
+      ? {
+        start: Math.max(0, existingSlice?.start ?? 0),
+        end: Math.min(layout.lines.length, existingSlice?.end ?? layout.lines.length),
+      }
+      : existingSlice;
+    const fullH = para && layout
+      ? paragraphLineSliceHeight(para, layout.lineHeights, currentSlice?.start ?? 0, currentSlice?.end ?? layout.lines.length)
+      : measureCellElementHeight(state, ce, innerWPt, 1);
+    const fullAddH = additionHeight(ce, fullH, currentSlice);
+    if (beforeHeight + fullAddH <= maxContentHeightPt) {
+      appendBefore(ce, fullH, currentSlice, layout?.lines.length);
+      continue;
+    }
+
+    if (ce.type !== 'paragraph') {
+      const after = content.slice(i);
+      const afterHeight = sumContentHeightForSplit(after);
+      return before.length > 0 ? { before, after, beforeHeight, afterHeight } : null;
+    }
+
+    if (!layout) {
+      const after = content.slice(i);
+      const afterHeight = sumContentHeightForSplit(after);
+      return before.length > 0 ? { before, after, beforeHeight, afterHeight } : null;
+    }
+
+    const splitPara = para ?? ce as unknown as DocParagraph;
+    let endLine = 0;
+    let sliceH = 0;
+    let sliceAddH = 0;
+    const sliceStart = currentSlice?.start ?? 0;
+    const sliceEnd = currentSlice?.end ?? layout.lines.length;
+    for (let end = sliceStart + 1; end <= sliceEnd; end++) {
+      const h = paragraphLineSliceHeight(splitPara, layout.lineHeights, sliceStart, end);
+      const addH = additionHeight(ce, h, { start: sliceStart, end });
+      if (beforeHeight + addH > maxContentHeightPt) break;
+      endLine = end;
+      sliceH = h;
+      sliceAddH = addH;
+    }
+    if (endLine === 0) {
+      const after = content.slice(i);
+      const afterHeight = sumContentHeightForSplit(after);
+      return before.length > 0 ? { before, after, beforeHeight, afterHeight } : null;
+    }
+    if (endLine >= sliceEnd) {
+      appendBefore(ce, fullH, currentSlice, layout.lines.length);
+      continue;
+    }
+
+    before.push(paragraphLineSliceElement(splitPara, layout, sliceStart, endLine));
+    beforeHeight += sliceAddH;
+    const afterPara = paragraphLineSliceElement(splitPara, layout, endLine, sliceEnd);
+    const after = [afterPara, ...content.slice(i + 1)];
+    const afterHeight = sumContentHeightForSplit(after);
+    return { before, after, beforeHeight, afterHeight };
+  }
+
+  return { before, after: [], beforeHeight, afterHeight: 0 };
+}
+
+function splitRowByCellLines(
+  table: DocTable,
+  row: DocTableRow,
+  colWidthsPt: number[],
+  maxHeightPt: number,
+  state: RenderState,
+): { rows: DocTableRow[]; heights: number[] } | null {
+  if (row.isHeader || row.cantSplit || row.rowHeightRule === 'exact') return null;
+  if (row.cells.some((cell) => cell.vMerge !== null)) return null;
+
+  const beforeCells: DocTableCell[] = [];
+  const afterCells: DocTableCell[] = [];
+  const beforeCellHeights: number[] = [];
+  const afterCellHeights: number[] = [];
+  let madeProgress = false;
+  let hasRemainder = false;
+  let ci = 0;
+
+  for (const cell of row.cells) {
+    const span = Math.min(cell.colSpan, colWidthsPt.length - ci);
+    const cellWPt = colWidthsPt.slice(ci, ci + span).reduce((s, w) => s + w, 0);
+    ci += span;
+    const margins = effCellMargins(cell, table);
+    const maxContentH = Math.max(0, maxHeightPt - margins.top - margins.bottom);
+    const split = splitCellContentByHeight(
+      trimTrailingStructuralMarker(cell.content),
+      cellWPt - margins.left - margins.right,
+      maxContentH,
+      state,
+    );
+    if (!split) return null;
+    beforeCells.push({ ...cell, content: split.before });
+    afterCells.push({ ...cell, content: split.after });
+    beforeCellHeights.push(margins.top + margins.bottom + split.beforeHeight);
+    afterCellHeights.push(margins.top + margins.bottom + split.afterHeight);
+    madeProgress ||= split.before.length > 0;
+    hasRemainder ||= split.after.length > 0;
+  }
+
+  if (!madeProgress || !hasRemainder) return null;
+  const floor = row.rowHeight != null && (row.rowHeightRule === 'atLeast' || row.rowHeightRule === 'auto')
+    ? row.rowHeight
+    : 0;
+  return {
+    rows: [
+      { ...row, cells: beforeCells, rowHeight: null, rowHeightRule: 'auto' },
+      { ...row, cells: afterCells, rowHeight: null, rowHeightRule: 'auto' },
+    ],
+    heights: [
+      Math.max(floor, ...beforeCellHeights),
+      Math.max(0, ...afterCellHeights),
+    ],
+  };
+}
+
+function splitRowForHeight(
+  table: DocTable,
+  row: DocTableRow,
+  colWidthsPt: number[],
+  maxHeightPt: number,
+  state: RenderState,
+): { rows: DocTableRow[]; heights: number[] } | null {
+  return splitRowByCellLines(table, row, colWidthsPt, maxHeightPt, state)
+    ?? splitRowByCellBlocks(table, row, colWidthsPt, maxHeightPt, state);
+}
+
+function splitRowsTallerThanPage(
+  table: DocTable,
+  rowHeightsPt: number[],
+  colWidthsPt: number[],
+  pageContentHeightPt: number,
+  state: RenderState,
+): { table: DocTable; rowHs: number[] } | null {
+  let changed = false;
+  const rows: DocTableRow[] = [];
+  const heights: number[] = [];
+  for (let ri = 0; ri < table.rows.length; ri++) {
+    const row = table.rows[ri];
+    const rowH = rowHeightsPt[ri];
+    if (rowH > pageContentHeightPt) {
+      const split = splitRowForHeight(table, row, colWidthsPt, pageContentHeightPt, state);
+      if (split) {
+        rows.push(...split.rows);
+        heights.push(...split.heights);
+        changed = true;
+        continue;
+      }
+    }
+    rows.push(row);
+    heights.push(rowH);
+  }
+  return changed ? { table: { ...table, rows }, rowHs: heights } : null;
+}
+
 /**
  * Split a table that is taller than one page across page boundaries, row by
  * row (ECMA-376 table pagination). Each page receives a {@link DocTable} slice
@@ -4299,15 +4788,21 @@ export function splitTableAcrossPages(
    *  prepended on continuations so the stamp aligns 1:1 with the slice's rows).
    *  Omitted (direct unit tests) ⇒ slices carry no table stamp and paint recomputes. */
   tableStamp?: { colWidthsPt: number[]; contentWPt: number },
+  /** Optional row-block splitter used by computePages. Direct unit tests can omit
+   *  this and exercise only row-boundary splitting. */
+  rowSplit?: { colWidthsPt: number[]; state: RenderState },
 ): number {
   const colTop = columnTop ?? (() => 0);
-  const n = table.rows.length;
+  let workTable = table;
+  let workRows = table.rows;
+  let workRowHs = rowHs;
+  let n = workRows.length;
   // Leading tblHeader rows repeat on each continuation page.
   let headerCount = 0;
-  while (headerCount < n && table.rows[headerCount].isHeader) headerCount++;
-  const headerRows = table.rows.slice(0, headerCount);
-  const headerH = rowHs.slice(0, headerCount).reduce((s, h) => s + h, 0);
-  const headerHeightsPt = rowHs.slice(0, headerCount);
+  while (headerCount < n && workRows[headerCount].isHeader) headerCount++;
+  const headerRows = workRows.slice(0, headerCount);
+  const headerH = workRowHs.slice(0, headerCount).reduce((s, h) => s + h, 0);
+  const headerHeightsPt = workRowHs.slice(0, headerCount);
 
   let y = startY;
   let start = 0;
@@ -4316,19 +4811,73 @@ export function splitTableAcrossPages(
   while (start < n) {
     const isContinuation = !firstSlice && headerCount > 0 && start >= headerCount;
     const avail = contentH - y;
+    const firstRowH = (isContinuation ? headerH : 0) + workRowHs[start];
+    const freshAvail = contentH - colTop();
+    const rowAvail = avail - (isContinuation ? headerH : 0);
+    if (rowSplit && firstRowH > avail && rowAvail > 0 && start >= headerCount) {
+      const split = splitRowForHeight(workTable, workRows[start], rowSplit.colWidthsPt, rowAvail, rowSplit.state);
+      if (split && split.heights[0] <= rowAvail) {
+        workRows = [
+          ...workRows.slice(0, start),
+          ...split.rows,
+          ...workRows.slice(start + 1),
+        ];
+        workRowHs = [
+          ...workRowHs.slice(0, start),
+          ...split.heights,
+          ...workRowHs.slice(start + 1),
+        ];
+        workTable = { ...workTable, rows: workRows };
+        n = workRows.length;
+        continue;
+      }
+    }
+    if (firstRowH > avail && y > colTop() && firstRowH <= freshAvail) {
+      newPage(y);
+      y = colTop();
+      firstSlice = false;
+      continue;
+    }
     let used = isContinuation ? headerH : 0;
     let end = start;
     // Always place at least one row to guarantee forward progress.
     while (end < n) {
-      const h = rowHs[end];
-      if (end > start && used + h > avail && tableBreakAllowedBefore(table, end)) break;
+      const h = workRowHs[end];
+      if (end > start && used + h > avail && tableBreakAllowedBefore(workTable, end)) {
+        const remainingForNextRow = avail - used;
+        if (rowSplit && remainingForNextRow > 0 && end >= headerCount) {
+          const split = splitRowForHeight(
+            workTable,
+            workRows[end],
+            rowSplit.colWidthsPt,
+            remainingForNextRow,
+            rowSplit.state,
+          );
+          if (split && split.heights[0] <= remainingForNextRow) {
+            workRows = [
+              ...workRows.slice(0, end),
+              ...split.rows,
+              ...workRows.slice(end + 1),
+            ];
+            workRowHs = [
+              ...workRowHs.slice(0, end),
+              ...split.heights,
+              ...workRowHs.slice(end + 1),
+            ];
+            workTable = { ...workTable, rows: workRows };
+            n = workRows.length;
+            continue;
+          }
+        }
+        break;
+      }
       used += h;
       end++;
     }
 
-    const bodyRows = table.rows.slice(start, end);
+    const bodyRows = workRows.slice(start, end);
     const sliceRows = isContinuation ? [...headerRows, ...bodyRows] : bodyRows;
-    const sliceEl = { ...table, type: 'table', rows: sliceRows } as PaginatedBodyElement;
+    const sliceEl = { ...workTable, type: 'table', rows: sliceRows } as PaginatedBodyElement;
     if (tagColIndex) sliceEl.colIndex = tagColIndex();
     if (colGeom) sliceEl.colGeom = colGeom;
     // Front-loaded layout: stamp the region top (page-absolute pt) so the paint
@@ -4342,8 +4891,8 @@ export function splitTableAcrossPages(
     // them 1:1 instead of re-measuring the slice.
     if (tableStamp) {
       const sliceHeightsPt = isContinuation
-        ? [...headerHeightsPt, ...rowHs.slice(start, end)]
-        : rowHs.slice(start, end);
+        ? [...headerHeightsPt, ...workRowHs.slice(start, end)]
+        : workRowHs.slice(start, end);
       stampTableLayout(sliceEl, tableStamp.colWidthsPt, sliceHeightsPt, tableStamp.contentWPt);
     }
     pages[pages.length - 1].push(sliceEl);
@@ -4584,6 +5133,31 @@ function isInklessParagraph(p: DocParagraph): boolean {
     if (run.type === 'text') return (run.text ?? '').length > 0;
     return true; // image / shape / math / break runs are visible content
   });
+}
+
+function isAnchorOnlyParagraph(p: DocParagraph): boolean {
+  let hasAnchor = false;
+  for (const r of p.runs ?? []) {
+    if (r.type === 'text' && ((r as DocxTextRun).text ?? '').length === 0) continue;
+    if (r.type === 'shape') {
+      hasAnchor = true;
+      continue;
+    }
+    if (r.type === 'image' && !!(r as unknown as ImageRun).anchor) {
+      hasAnchor = true;
+      continue;
+    }
+    if (r.type === 'chart' && !!(r as unknown as ChartRun).anchor) {
+      hasAnchor = true;
+      continue;
+    }
+    return false;
+  }
+  return hasAnchor;
+}
+
+function hasInlineImage(p: DocParagraph): boolean {
+  return (p.runs ?? []).some((r) => r.type === 'image' && !(r as unknown as ImageRun).anchor);
 }
 
 /**
@@ -6061,6 +6635,10 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           const h = (render.ascentEm + render.descentEm) * emPx;
           const top = baseline - render.ascentEm * emPx;
           ctx.drawImage(render.img, x, top, w, h);
+        } else if (!dryRun && seg.fallbackText) {
+          ctx.font = buildFont(false, false, seg.fontSize * scale, null, fontFamilyClasses);
+          ctx.fillStyle = seg.color ?? defaultColor;
+          ctx.fillText(seg.fallbackText, x, baseline);
         }
         x += seg.measuredWidth;
         continue;
@@ -6875,7 +7453,9 @@ function renderInlineImage(
  * Wrap floats (square/topAndBottom/tight/through) are drawn by registerAnchorFloats.
  *
  * `phase` = 'behind' draws only shapes with behindDoc=true (sorted by zOrder asc);
- * `phase` = 'front' draws shapes without behindDoc + all anchor images. */
+ * `phase` = 'front' draws shapes without behindDoc + all anchor images. Front
+ * shapes are sorted by `wp:anchor/@relativeHeight` (lower first, higher on top)
+ * while non-shape anchors keep their legacy run-order fallback. */
 function renderAnchorImages(
   para: DocParagraph,
   state: RenderState,
@@ -6918,7 +7498,19 @@ function renderAnchorImages(
     });
     return;
   }
-  for (const run of para.runs) {
+  const frontRuns = para.runs
+    .map((run, index) => {
+      const shapeZ = run.type === 'shape'
+        ? (run as unknown as ShapeRun).zOrder
+        : null;
+      return {
+        run,
+        index,
+        z: typeof shapeZ === 'number' && Number.isFinite(shapeZ) ? shapeZ : index,
+      };
+    })
+    .sort((a, b) => a.z - b.z || a.index - b.index);
+  for (const { run } of frontRuns) {
     if (run.type === 'shape') {
       const s = run as unknown as ShapeRun;
       if (s.behindDoc) continue;
@@ -7147,7 +7739,7 @@ export function drawWatermarkTextPath(
 
 function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: number): void {
   const { ctx, scale } = state;
-  const { x, y, w, h } = resolveShapeBox(shape, state, paragraphTopPx);
+  let { x, y, w, h } = resolveShapeBox(shape, state, paragraphTopPx);
   // Line/connector presets (ECMA-376 §20.1.9.18) are valid with a degenerate
   // bounding box — a horizontal line has h==0, a vertical line w==0. Stroking
   // such a path still draws a visible segment, so only bail when there is truly
@@ -7158,16 +7750,45 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
     preset.startsWith('straightconnector') ||
     preset.startsWith('bentconnector') ||
     preset.startsWith('curvedconnector');
+  const isCalloutGeom =
+    preset === 'callout1' ||
+    preset === 'callout2' ||
+    preset === 'callout3' ||
+    preset === 'bordercallout1' ||
+    preset === 'bordercallout2' ||
+    preset === 'bordercallout3' ||
+    preset === 'accentcallout1' ||
+    preset === 'accentcallout2' ||
+    preset === 'accentcallout3' ||
+    preset === 'accentbordercallout1' ||
+    preset === 'accentbordercallout2' ||
+    preset === 'accentbordercallout3';
   // Straight / bent connectors whose leader we re-stroke retracted from filled
-  // line-end decorations (so the line stops at the arrow base). Curved
-  // connectors are excluded — their Bézier leader can't be retracted from a
-  // polyline vertex without straightening it, so they keep the preset leader.
+  // line-end decorations (so the line stops at the arrow base). Callout leader
+  // lines are emitted by the preset engine as their trailing path, so they can
+  // use the same retract/re-stroke path. Curved connectors are excluded — their
+  // Bézier leader can't be retracted from a polyline vertex without
+  // straightening it, so they keep the preset leader.
   const isRetractableLeader =
+    isCalloutGeom ||
     preset === 'line' ||
     preset.startsWith('straightconnector') ||
     preset.startsWith('bentconnector');
   if (w < 0 || h < 0) return;
   if (isLineGeom ? w === 0 && h === 0 : w === 0 || h === 0) return;
+
+  if (!isLineGeom && shape.textAutofit === 'sp' && shape.textBlocks && shape.textBlocks.length > 0) {
+    const fitH = measureShapeTextAutoFitHeight(
+      shape,
+      w,
+      ctx as CanvasRenderingContext2D,
+      scale,
+      state.fontFamilyClasses,
+      state.images,
+      state,
+    );
+    if (Number.isFinite(fitH) && fitH > 0) h = fitH;
+  }
 
   // ECMA-376 Part 4 §19.1.2.23 `<v:textpath>` — a WordArt text watermark. It
   // draws stretched, rotated, semi-transparent text filling the shape box
@@ -7275,15 +7896,15 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
     if (strokeCb) strokeCb();
   }
 
-  // Line-end decorations (ECMA-376 §20.1.8.3). Only connector/line presets
-  // expose head/tail tips with a well-defined tangent; for those we place the
-  // arrow heads at the path endpoints with the path's outgoing direction. The
-  // preset engine does not draw connector arrow heads, so this runs whether or
-  // not the body went through it. Gate on `isLineGeom` (mirroring the pptx
-  // renderer's CONNECTOR_GEOMS set): getConnectorAnchors resolves path[0] of
-  // *any* preset, so a filled shape carrying an <a:ln> head/tail end would
-  // otherwise get spurious arrow heads at its first subpath's endpoints.
-  if (coreStroke && (coreStroke.headEnd || coreStroke.tailEnd) && isLineGeom) {
+  // Line-end decorations (ECMA-376 §20.1.8.3). Connector/line presets and the
+  // callout family both expose head/tail tips with a well-defined tangent; for
+  // callouts these decorate the leader line (the geometry's trailing path), not
+  // the text rectangle or accent bar. The preset engine does not draw line ends,
+  // so this runs whether or not the body went through it. Gate on connector /
+  // callout presets only: getConnectorAnchors resolves the last path of any
+  // preset, so an arbitrary filled shape carrying an <a:ln> head/tail end would
+  // otherwise get spurious arrow heads.
+  if (coreStroke && (coreStroke.headEnd || coreStroke.tailEnd) && (isLineGeom || isCalloutGeom)) {
     const anchors = getConnectorAnchors(
       preset, x, y, w, h,
       shape.adjValues ?? [],
@@ -7348,6 +7969,146 @@ function fitShapeImage(
   return { w: innerW, h: natH * s };
 }
 
+const WORD_DEFAULT_TEXTBOX_INSET_PT = 7.2;
+
+function isWordDefaultTextboxInset(v: number | undefined): boolean {
+  return v != null && Math.abs(v - WORD_DEFAULT_TEXTBOX_INSET_PT) < 0.01;
+}
+
+function shapeTextHorizontalInsetsPx(shape: ShapeRun, scale: number): { lIns: number; rIns: number } {
+  const baseL = (shape.textInsetL ?? 0) * scale;
+  const baseR = (shape.textInsetR ?? 0) * scale;
+  // Word wraps spAutoFit text boxes with the serialized DrawingML default
+  // lIns/rIns (0.1in) plus the legacy text-box default margin. This only applies
+  // to the emitted default; zero/custom insets keep their literal OOXML width.
+  const extraL = shape.textAutofit === 'sp' && isWordDefaultTextboxInset(shape.textInsetL)
+    ? WORD_DEFAULT_TEXTBOX_INSET_PT * scale
+    : 0;
+  const extraR = shape.textAutofit === 'sp' && isWordDefaultTextboxInset(shape.textInsetR)
+    ? WORD_DEFAULT_TEXTBOX_INSET_PT * scale
+    : 0;
+  return { lIns: baseL + extraL, rIns: baseR + extraR };
+}
+
+/** Measure a shape text body's fitted height for `<a:spAutoFit/>`.
+ *  Returns px, including bodyPr top/bottom insets and paragraph spacing. */
+export function measureShapeTextAutoFitHeight(
+  shape: ShapeRun,
+  w: number,
+  ctx: CanvasRenderingContext2D,
+  scale: number,
+  fontFamilyClasses: Record<string, string> = {},
+  images: Map<string, DecodedImage> = new Map(),
+  state?: RenderState,
+): number {
+  const effState = state ?? shapeRenderState(ctx, scale, fontFamilyClasses, images);
+  const blocks = shape.textBlocks ?? [];
+  const { lIns, rIns } = shapeTextHorizontalInsetsPx(shape, scale);
+  const tIns = (shape.textInsetT ?? 0) * scale;
+  const bIns = (shape.textInsetB ?? 0) * scale;
+  const innerW = Math.max(0, w - lIns - rIns);
+
+  const indentOf = (b: ShapeText) => {
+    const leftPx = (b.indentLeft ?? 0) * scale;
+    const rightPx = (b.indentRight ?? 0) * scale;
+    const rawFirstPx = (b.indentFirst ?? 0) * scale;
+    const firstPx = b.numbering && rawFirstPx < 0 ? 0 : rawFirstPx;
+    const paraW = Math.max(0, innerW - leftPx - rightPx);
+    const firstLineW = Math.max(0, paraW - firstPx);
+    return { leftPx, firstPx, paraW, firstLineW };
+  };
+
+  const lineHeightFor = (b: ShapeText, line: LayoutLine): number => {
+    let tallest: LayoutTextSeg | null = null;
+    let floorPx = 0;
+    for (const seg of line.segments) {
+      if (!('text' in seg)) continue;
+      const ts = seg as LayoutTextSeg;
+      if (!tallest || ts.fontSize > tallest.fontSize) tallest = ts;
+      const segPx = ts.fontSize * scale;
+      floorPx = Math.max(
+        floorPx,
+        intendedSingleLinePx(ts.fontFamily ?? null, segPx),
+        intendedSingleLinePx(ts.eaFloorFamily ?? null, segPx),
+      );
+    }
+    const fontPt = tallest?.fontSize ?? b.fontSizePt;
+    const fontPx = fontPt * scale;
+    const family = tallest?.fontFamily ?? b.fontFamily ?? null;
+    const eaFamily = tallest?.eaFloorFamily ?? b.fontFamily ?? null;
+    const asciiIntended = intendedSingleLinePx(family, fontPx);
+    const eaIntended = intendedSingleLinePx(eaFamily, fontPx);
+    const measureFamily = eaIntended > asciiIntended ? eaFamily : family;
+    ctx.font = buildFont(
+      tallest?.bold ?? b.bold ?? false,
+      tallest?.italic ?? b.italic ?? false,
+      fontPx,
+      measureFamily,
+      fontFamilyClasses,
+    );
+    const m = ctx.measureText('Mg');
+    const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fontPx * 0.8;
+    const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fontPx * 0.2;
+    const c = correctLineMetrics(measureFamily, fontPx, rawAsc, rawDesc);
+    const ls: LineSpacing | null = b.lineSpacingRule
+      ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
+      : null;
+    return lineBoxHeight(ls, c.ascent, c.descent, scale, undefined, false, floorPx, false);
+  };
+
+  const spBefore = blocks.map((b) => (b.spaceBefore ?? 0) * scale);
+  const spAfter = blocks.map((b) => (b.spaceAfter ?? 0) * scale);
+  const gapBefore = (i: number): number =>
+    i > 0 ? Math.max(spBefore[i], spAfter[i - 1]) : spBefore[i];
+
+  ctx.save();
+  try {
+    let contentH = 0;
+    for (let i = 0; i < blocks.length; i++) {
+      const b = blocks[i];
+      const ind = indentOf(b);
+      contentH += gapBefore(i);
+      if (b.imagePath) {
+        contentH += fitShapeImage(b.imageWidthPt ?? 0, b.imageHeightPt ?? 0, ind.firstLineW, scale).h;
+        continue;
+      }
+      const runs: ShapeTextRun[] =
+        b.runs && b.runs.length > 0
+          ? b.runs
+          : [{
+              text: b.text,
+              fontSizePt: b.fontSizePt,
+              color: b.color,
+              fontFamily: b.fontFamily,
+              bold: b.bold,
+              italic: b.italic,
+            } as ShapeTextRun];
+      const segs = buildSegments(runs.map(shapeRunToDocRun), effState);
+      const baseRtl = resolveBaseDirection(b.bidi, b.text) === 'rtl';
+      const lines = layoutLines(
+        ctx,
+        segs,
+        ind.paraW,
+        ind.firstPx,
+        scale,
+        b.tabStops ?? [],
+        undefined,
+        fontFamilyClasses,
+        ind.leftPx,
+        effState.kinsoku,
+        0,
+        effState.defaultTabPt,
+        ind.paraW,
+        baseRtl,
+      );
+      contentH += lines.reduce((sum, line) => sum + lineHeightFor(b, line), 0);
+    }
+    return tIns + contentH + bIns;
+  } finally {
+    ctx.restore();
+  }
+}
+
 /** Render a shape's body text inside its bounding box, honoring lIns/tIns/
  *  rIns/bIns and the wps:bodyPr @anchor (t / ctr / b). Alignment within each
  *  line is read from the per-block paragraph alignment.
@@ -7400,9 +8161,8 @@ export function renderShapeText(
     ? `#${shape.defaultTextColor}`
     : documentDefaultColor;
   const blocks = shape.textBlocks ?? [];
-  const lIns = (shape.textInsetL ?? 0) * scale;
+  const { lIns, rIns } = shapeTextHorizontalInsetsPx(shape, scale);
   const tIns = (shape.textInsetT ?? 0) * scale;
-  const rIns = (shape.textInsetR ?? 0) * scale;
   const bIns = (shape.textInsetB ?? 0) * scale;
   const innerX = x + lIns;
   const innerW = Math.max(0, w - lIns - rIns);
@@ -7420,10 +8180,11 @@ export function renderShapeText(
   const indentOf = (b: ShapeText) => {
     const leftPx = (b.indentLeft ?? 0) * scale;
     const rightPx = (b.indentRight ?? 0) * scale;
-    const firstPx = (b.indentFirst ?? 0) * scale; // SIGNED
+    const rawFirstPx = (b.indentFirst ?? 0) * scale; // SIGNED
+    const firstPx = b.numbering && rawFirstPx < 0 ? 0 : rawFirstPx;
     const paraW = Math.max(0, innerW - leftPx - rightPx);
     const firstLineW = Math.max(0, paraW - firstPx);
-    return { leftPx, firstPx, paraW, firstLineW };
+    return { leftPx, firstPx, markerFirstPx: rawFirstPx, paraW, firstLineW };
   };
 
   // First pass: lay out each block. Text blocks WRAP to the inner width
@@ -7431,7 +8192,7 @@ export function renderShapeText(
   // breaks onto multiple lines instead of overflowing the page; image blocks
   // reserve their fitted height. The computed layout drives both vertical
   // anchoring (totalH) and the draw pass (no re-wrapping).
-  type BlockIndent = { leftPx: number; firstPx: number; paraW: number; firstLineW: number };
+  type BlockIndent = { leftPx: number; firstPx: number; markerFirstPx: number; paraW: number; firstLineW: number };
   // A text-box paragraph laid out by the MAIN engine: `lines` are the shared
   // LayoutLine[] (from buildSegments → layoutLines, so kinsoku / bidi / justify /
   // tabs all apply), `lineHeights`/`baselineOffsets` give each line its shape
@@ -7719,9 +8480,11 @@ export function renderShapeText(
       // line carries the signed first-line indent), reorder segments per UAX#9
       // (§17.18.44 bidi, base = block `<w:bidi>` / first-strong), distribute
       // §17.18.44 justification slack on `both`/`distribute` lines, and honor tab
-      // widths (already resolved onto each tab seg by layoutLines). Numbering /
-      // floats / decimal-auto-tab / run decorations (body-only) do not apply —
-      // ShapeTextRun carries no underline/border/highlight/ruby/revision.
+      // widths (already resolved onto each tab seg by layoutLines). Text-box
+      // paragraph numbering is drawn in the hanging margin; floats /
+      // decimal-auto-tab / body-only decorations do not apply, but ShapeTextRun
+      // ruby is carried through the shared line engine and painted above the base
+      // glyphs like body text ruby (§17.3.3.25).
       const { lines: lineList, baseRtl, ind } = layout;
       // 'distribute'/'thaiDistribute' spread every line; 'both'/'justify'/kashida
       // spread all but the logical-last; otherwise resolve the physical edge from
@@ -7813,6 +8576,18 @@ export function renderShapeText(
         }
         let x = regionLeft + alignOffset;
 
+        if (isFirstLine && block.numbering) {
+          const markerSize = block.fontSizePt * scale;
+          ctx.font = buildFont(false, false, markerSize, markerFontFamily(block.numbering), fontFamilyClasses);
+          const markerColor = block.color ?? block.runs?.find((r) => r.color)?.color ?? null;
+          ctx.fillStyle = markerColor ? `#${markerColor}` : defaultColor;
+          const markerText = markerDisplayText(block.numbering);
+          const markerW = ctx.measureText(markerText).width;
+          const lvlJc = block.numbering.jc || 'left';
+          const markerShift = lvlJc === 'right' ? -markerW : lvlJc === 'center' ? -markerW / 2 : 0;
+          ctx.fillText(markerText, innerX + ind.leftPx + ind.markerFirstPx + markerShift, baseline);
+        }
+
         if (applyJustify) {
           const minPerGap = -line.ascent * 0.25;
           const distSegs = line.segments.map((seg) =>
@@ -7885,6 +8660,18 @@ export function renderShapeText(
             }
           } else {
             ctx.fillText(s.text, x, baseline + yOffset);
+          }
+          if (s.ruby) {
+            const spanW = s.measuredWidth + internalStretch;
+            const rubySizePx = s.ruby.fontSizePt * scale;
+            const rubyFont = buildFont(s.bold, s.italic, rubySizePx, s.fontFamily, fontFamilyClasses);
+            ctx.save();
+            ctx.font = rubyFont;
+            const rubyW = ctx.measureText(s.ruby.text).width;
+            const rubyX = x + (spanW - rubyW) / 2;
+            const rubyBaseline = baseline + yOffset - effSizePx * 0.85 - rubySizePx * 0.1;
+            ctx.fillText(s.ruby.text, rubyX, rubyBaseline);
+            ctx.restore();
           }
           x += s.measuredWidth + internalStretch;
           // A trailing space this segment OWNS absorbs one inter-word gap on a

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4489,6 +4489,54 @@ function paragraphLineSliceElement(
   return slice;
 }
 
+function tableCellElementSliceByRows(table: DocTable, start: number, end: number): CellElement {
+  return {
+    ...(table as object),
+    type: 'table',
+    rows: table.rows.slice(start, end),
+  } as unknown as CellElement;
+}
+
+function splitNestedTableByHeight(
+  table: DocTable,
+  contentWPt: number,
+  maxHeightPt: number,
+  state: RenderState,
+): { before: CellElement; after: CellElement; beforeHeight: number; afterHeight: number } | null {
+  const { rowHeightsPt } = computeTablePtLayout(state, table, contentWPt);
+  if (rowHeightsPt.length <= 1) return null;
+
+  let used = 0;
+  let end = 0;
+  let lastSafeEnd = 0;
+  let lastSafeUsed = 0;
+  while (end < rowHeightsPt.length) {
+    const h = rowHeightsPt[end];
+    if (end > 0 && used + h > maxHeightPt) {
+      if (tableBreakAllowedBefore(table, end)) break;
+      if (lastSafeEnd > 0) {
+        end = lastSafeEnd;
+        used = lastSafeUsed;
+        break;
+      }
+    }
+    if (end > 0 && tableBreakAllowedBefore(table, end)) {
+      lastSafeEnd = end;
+      lastSafeUsed = used;
+    }
+    used += h;
+    end++;
+  }
+  if (end <= 0 || end >= table.rows.length || !tableBreakAllowedBefore(table, end)) return null;
+
+  return {
+    before: tableCellElementSliceByRows(table, 0, end),
+    after: tableCellElementSliceByRows(table, end, table.rows.length),
+    beforeHeight: used,
+    afterHeight: rowHeightsPt.slice(end).reduce((sum, h) => sum + h, 0),
+  };
+}
+
 function splitCellContentByHeight(
   content: CellElement[],
   innerWPt: number,
@@ -4595,6 +4643,17 @@ function splitCellContentByHeight(
     }
 
     if (ce.type !== 'paragraph') {
+      if (ce.type === 'table') {
+        const remaining = maxContentHeightPt - beforeHeight;
+        const nestedSplit = splitNestedTableByHeight(ce as unknown as DocTable, innerWPt, remaining, state);
+        if (nestedSplit) {
+          before.push(nestedSplit.before);
+          beforeHeight += nestedSplit.beforeHeight;
+          const after = [nestedSplit.after, ...content.slice(i + 1)];
+          const afterHeight = nestedSplit.afterHeight + sumContentHeightForSplit(content.slice(i + 1));
+          return { before, after, beforeHeight, afterHeight };
+        }
+      }
       const after = content.slice(i);
       const afterHeight = sumContentHeightForSplit(after);
       return before.length > 0 ? { before, after, beforeHeight, afterHeight } : null;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -8041,25 +8041,11 @@ function fitShapeImage(
   return { w: innerW, h: natH * s };
 }
 
-const WORD_DEFAULT_TEXTBOX_INSET_PT = 7.2;
-
-function isWordDefaultTextboxInset(v: number | undefined): boolean {
-  return v != null && Math.abs(v - WORD_DEFAULT_TEXTBOX_INSET_PT) < 0.01;
-}
-
 function shapeTextHorizontalInsetsPx(shape: ShapeRun, scale: number): { lIns: number; rIns: number } {
-  const baseL = (shape.textInsetL ?? 0) * scale;
-  const baseR = (shape.textInsetR ?? 0) * scale;
-  // Word wraps spAutoFit text boxes with the serialized DrawingML default
-  // lIns/rIns (0.1in) plus the legacy text-box default margin. This only applies
-  // to the emitted default; zero/custom insets keep their literal OOXML width.
-  const extraL = shape.textAutofit === 'sp' && isWordDefaultTextboxInset(shape.textInsetL)
-    ? WORD_DEFAULT_TEXTBOX_INSET_PT * scale
-    : 0;
-  const extraR = shape.textAutofit === 'sp' && isWordDefaultTextboxInset(shape.textInsetR)
-    ? WORD_DEFAULT_TEXTBOX_INSET_PT * scale
-    : 0;
-  return { lIns: baseL + extraL, rIns: baseR + extraR };
+  return {
+    lIns: (shape.textInsetL ?? 0) * scale,
+    rIns: (shape.textInsetR ?? 0) * scale,
+  };
 }
 
 /** Measure a shape text body's fitted height for `<a:spAutoFit/>`.

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4840,36 +4840,49 @@ export function splitTableAcrossPages(
     }
     let used = isContinuation ? headerH : 0;
     let end = start;
+    let lastSafeEnd = start;
+    let lastSafeUsed = used;
     // Always place at least one row to guarantee forward progress.
     while (end < n) {
       const h = workRowHs[end];
-      if (end > start && used + h > avail && tableBreakAllowedBefore(workTable, end)) {
-        const remainingForNextRow = avail - used;
-        if (rowSplit && remainingForNextRow > 0 && end >= headerCount) {
-          const split = splitRowForHeight(
-            workTable,
-            workRows[end],
-            rowSplit.colWidthsPt,
-            remainingForNextRow,
-            rowSplit.state,
-          );
-          if (split && split.heights[0] <= remainingForNextRow) {
-            workRows = [
-              ...workRows.slice(0, end),
-              ...split.rows,
-              ...workRows.slice(end + 1),
-            ];
-            workRowHs = [
-              ...workRowHs.slice(0, end),
-              ...split.heights,
-              ...workRowHs.slice(end + 1),
-            ];
-            workTable = { ...workTable, rows: workRows };
-            n = workRows.length;
-            continue;
+      if (end > start && used + h > avail) {
+        if (tableBreakAllowedBefore(workTable, end)) {
+          const remainingForNextRow = avail - used;
+          if (rowSplit && remainingForNextRow > 0 && end >= headerCount) {
+            const split = splitRowForHeight(
+              workTable,
+              workRows[end],
+              rowSplit.colWidthsPt,
+              remainingForNextRow,
+              rowSplit.state,
+            );
+            if (split && split.heights[0] <= remainingForNextRow) {
+              workRows = [
+                ...workRows.slice(0, end),
+                ...split.rows,
+                ...workRows.slice(end + 1),
+              ];
+              workRowHs = [
+                ...workRowHs.slice(0, end),
+                ...split.heights,
+                ...workRowHs.slice(end + 1),
+              ];
+              workTable = { ...workTable, rows: workRows };
+              n = workRows.length;
+              continue;
+            }
           }
+          break;
         }
-        break;
+        if (lastSafeEnd > start) {
+          end = lastSafeEnd;
+          used = lastSafeUsed;
+          break;
+        }
+      }
+      if (end > start && tableBreakAllowedBefore(workTable, end)) {
+        lastSafeEnd = end;
+        lastSafeUsed = used;
       }
       used += h;
       end++;

--- a/packages/docx/src/table-split.test.ts
+++ b/packages/docx/src/table-split.test.ts
@@ -72,6 +72,19 @@ describe('splitTableAcrossPages', () => {
     expect(pages.reduce((s, p) => s + rowsOf(p[0]).length, 0)).toBe(6);
   });
 
+  it('moves a row to the next page when it cannot fit in the remaining band', () => {
+    const t = table(Array.from({ length: 4 }, () => row()));
+    const rowHs = Array(4).fill(100);
+    // Only 50pt remains on the current page. A 100pt row fits on a fresh page, so
+    // it must not be emitted into the footer/page-number band of the current one.
+    const { pages } = run(t, rowHs, 300, 350);
+
+    expect(pages[0]).toHaveLength(0);
+    expect(pages[1]).toHaveLength(1);
+    expect(rowsOf(pages[1][0]).length).toBe(3);
+    expect(rowsOf(pages[2][0]).length).toBe(1);
+  });
+
   it('repeats leading tblHeader rows at the top of every continuation page', () => {
     const header = row({ isHeader: true });
     const body = Array.from({ length: 8 }, () => row());

--- a/packages/docx/src/table-split.test.ts
+++ b/packages/docx/src/table-split.test.ts
@@ -118,4 +118,16 @@ describe('splitTableAcrossPages', () => {
       expect(firstRow.cells.some((c) => c.vMerge === false)).toBe(false);
     }
   });
+
+  it('backs up to the previous safe boundary instead of overflowing before a vMerge continuation', () => {
+    // Row 2 starts a vertical merge and row 3 continues it. A 350pt page can fit
+    // rows 0..2 but cannot also fit row 3. ECMA-376 §17.4.85 makes a break before
+    // row 3 unsafe, so the paginator must break earlier, before the merged span.
+    const rows = [row(), row(), row(), row({ vMergeContinue: true }), row()];
+    const t = table(rows);
+    const rowHs = Array(5).fill(100);
+    const { pages } = run(t, rowHs, 0, 350);
+
+    expect(pages.map((p) => rowsOf(p[0]).length)).toEqual([2, 3]);
+  });
 });

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -80,6 +80,14 @@ export interface DocSettings {
    *  tab stops generated after all custom stops. `undefined` ⇒ the renderer
    *  uses the spec default of 720 twips (36pt). */
   defaultTabStop?: number;
+  /** §17.15.1.18 `w:characterSpacingControl@w:val` — East Asian punctuation /
+   *  character-spacing control. */
+  characterSpacingControl?: string;
+  /** §17.15.3.1 `w:compat/w:useFELayout` — Far East layout compatibility. */
+  useFeLayout?: boolean;
+  /** §17.15.3.1 `w:compat/w:balanceSingleByteDoubleByteWidth` — balance
+   *  single-byte and double-byte widths for East Asian layout. */
+  balanceSingleByteDoubleByteWidth?: boolean;
 }
 
 export interface DocRevision {
@@ -544,6 +552,10 @@ export interface DocParagraph {
   /** Default font family resolved from the style chain. Used to size empty
    *  paragraphs (no runs) with the intended font's line metrics. */
   defaultFontFamily?: string | null;
+  /** Default East Asian font family resolved from the style chain. Empty /
+   *  anchor-only paragraph marks in East Asian documents use this axis for line
+   *  metrics instead of the ASCII fallback. */
+  defaultFontFamilyEastAsia?: string | null;
   /**
    * ECMA-376 §17.3.1.6 `<w:bidi>` — right-to-left paragraph. `true` = RTL,
    * `false` = explicitly LTR, absent = unspecified (inherit). The renderer uses
@@ -791,7 +803,7 @@ export interface ShapeRun {
   groupHeightPt?: number | null;
   /** Draw behind text when true (wp:anchor behindDoc="1"). */
   behindDoc?: boolean;
-  /** Document-order index within a group; lower values render first. */
+  /** ECMA-376 §20.4.2.3 `wp:anchor/@relativeHeight`: lower values render first. */
   zOrder: number;
   /** Normalized [0,1] custom-geometry sub-paths. Empty when `presetGeometry`
    *  is set; the renderer chooses between buildCustomPath and buildShapePath. */
@@ -799,8 +811,10 @@ export interface ShapeRun {
   /** OOXML <a:prstGeom prst> name (e.g. "rect", "ellipse", "rtTriangle").
    *  When set the renderer calls core's buildShapePath with `adjValues`. */
   presetGeometry?: string | null;
-  /** Up to four <a:gd name="adj{n}"> values from prstGeom/avLst (0–100000). */
-  adjValues?: number[];
+  /** <a:gd name="adj{n}"> values from prstGeom/avLst in adj1..adj8 order.
+   *  `null` preserves omitted named guides so the preset engine can use the
+   *  geometry's default for that index. */
+  adjValues?: Array<number | null>;
   fill: ShapeFill | null;
   stroke: string | null;
   strokeWidth?: number;
@@ -904,6 +918,8 @@ export interface ShapeTextRun {
   fontFamilyEastAsia?: string | null;
   bold?: boolean;
   italic?: boolean;
+  /** ECMA-376 §17.3.3.25 ruby annotation (furigana) for text-box runs. */
+  ruby?: RubyAnnotation | null;
 }
 
 export interface ShapeText {
@@ -919,6 +935,8 @@ export interface ShapeText {
    *  (image blocks / legacy single-format paragraphs). Absent for image-only
    *  paragraphs. */
   runs?: ShapeTextRun[];
+  /** ECMA-376 §17.9 paragraph numbering for text-box paragraphs. */
+  numbering?: NumberingInfo | null;
   alignment: string;
   /** ECMA-376 §17.3.1.33 `<w:spacing w:before>` of this text-box paragraph, in
    *  pt — reserved ABOVE the paragraph inside the box. Absent/0 ⇒ no offset. */
@@ -1385,6 +1403,9 @@ export interface DocTableRow {
    *  lower bound; "exact" = fixed clip. */
   rowHeightRule: 'auto' | 'atLeast' | 'exact' | string;
   isHeader: boolean;
+  /** ECMA-376 §17.4.6 `<w:cantSplit>` — when true, the row must not be split
+   *  across page boundaries. Omitted/false rows may split at page boundaries. */
+  cantSplit?: boolean;
 }
 
 /** ECMA-376 §17.4.7: a table cell may contain paragraphs AND nested tables. */

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -569,7 +569,7 @@ pub(crate) fn resolve_color_attrs(
     // rgb attribute (ARGB: 8 chars, drop alpha; or 6-char RGB)
     if let Some(rgb) = rgb {
         if rgb.len() == 8 {
-            return Some(format!("#{}", &rgb[2..].to_uppercase()));
+            return Some(format!("#{}", rgb[2..].to_uppercase()));
         }
         return Some(format!("#{}", rgb.to_uppercase()));
     }


### PR DESCRIPTION
## Summary
- Align DOCX anchored drawing and text-box rendering more closely with OOXML semantics for callout geometry, text box content, rich text, and leader arrowheads.
- Improve DOCX pagination and table fragmentation so split rows, nested tables, vertical-merge boundaries, and front/back floating anchors are measured more consistently.
- Update shared agent workflow docs from the earlier accepted workflow changes.

## Verification
- `OOXML_REQUIRE_SKIA=1 pnpm vitest run packages/core/src/image/wmf.test.ts packages/docx/src/pagination.test.ts packages/docx/src/renderer.textbox-image.test.ts packages/docx/src/callout-arrowhead-render.test.ts packages/docx/src/empty-paragraph-mark-height.test.ts packages/docx/src/front-float-zorder.test.ts packages/docx/src/anchor-align.test.ts packages/docx/src/table-split.test.ts packages/docx/src/math-fallback-layout.test.ts --reporter=dot`
- `cargo test -p docx-parser`
- GitHub Actions passed: `audit`, `rust`, `smoke`, `typecheck`

## Recovery note
- `origin/main` was restored to `6f1a99e` after an accidental direct push; this PR carries the restored changes through the required review and CI path.
