### PR TITLE
docs(agents): document public PR wording rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,17 @@ Use this flow for ordinary bug fixes and feature work:
   - subject: `fix(scope): ...`, `test(scope): ...`, `refactor(scope): ...`, etc.
   - body: explain the root cause, the fix, and verification.
   - include specification sections or observed Office behavior when relevant.
+- PR titles, PR descriptions, commit messages, and public docs must be safe for
+  an OSS repository:
+  - do not include local absolute paths, usernames, home directories, machine
+    names, or other personal environment details;
+  - do not quote or summarize the concrete contents of private or copyrighted
+    samples;
+  - describe private-sample-driven work in terms of the implementation problem,
+    the OOXML/Office behavior mismatch, the general class of affected documents,
+    and the verification command or local-only comparison that was performed;
+  - keep local-only sample filenames and visual details out of public PR text
+    unless the user explicitly approves publishing that information.
 - Agent-authored commits should include a matching co-author trailer. Include
   the actual model used for that task; do not hard-code a model name across
   tasks. Examples:


### PR DESCRIPTION
## Summary
- Add OSS-safe writing guidance for PR titles, PR descriptions, commit messages, and public docs.
- Require agents to avoid local environment details and private sample contents in public repository text.
- Direct sample-driven fixes to be described through implementation problems, OOXML or Office behavior mismatches, affected document classes, and sanitized verification notes.

## Verification
- `git diff --check`
