### PR TITLE
Preserve DOCX layout compatibility facts

### DIFF
--- a/docs/docx-layout-context-fragments-design.md
+++ b/docs/docx-layout-context-fragments-design.md
@@ -1,0 +1,637 @@
+# DOCX Layout Context and Measured Fragments Design
+
+## Status
+
+Approved architecture direction. This document defines the target design and the
+staged delivery boundaries. It does not authorize sample-specific heuristics or
+a one-shot renderer rewrite.
+
+## Problem
+
+The DOCX renderer already parses and renders many WordprocessingML layout
+features, but layout policy and measurement are distributed across several
+paths:
+
+- document settings and section properties are copied into mutable render state;
+- body paragraphs, table-cell paragraphs, and text boxes resolve line metrics
+  through different call paths;
+- pagination estimates content, then paint can measure it again;
+- table pagination represents continuation by cloning model objects and adding
+  runtime-only fields such as line and row slices;
+- floating drawing registration, line wrapping, and page placement share mutable
+  state without an explicit layout contract.
+
+These paths can disagree even when each path is locally reasonable. A private,
+local-only fixture exposed one such disagreement, but the defect class is not
+fixture-specific: the renderer lacks one normalized context and one measured
+geometry model for body and table flow.
+
+## Normative Basis
+
+The design follows these ECMA-376 Part 1 rules:
+
+- Section 17.6.5, `docGrid`: a section grid defines line pitch and character
+  pitch behavior.
+- Section 17.18.14, `ST_DocGrid`: `lines` enables the line grid;
+  `linesAndChars` enables line and character grids; `snapToChars` also applies
+  both line and character pitch; `default` disables the document grid.
+- Section 17.3.1.32, paragraph `snapToGrid`: a paragraph uses the section line
+  grid by default and can opt out.
+- Section 17.3.2.34, run `snapToGrid`: a run uses the section character grid by
+  default and can opt out. This property does not control line pitch.
+- Section 17.3.1.33, paragraph `spacing`: paragraph spacing, line spacing, and
+  `auto`, `exact`, and `atLeast` line rules have distinct units and precedence.
+- Section 17.6.5 states that `exact` line spacing overrides the section line
+  pitch.
+- Section 17.15.3.1, `adjustLineHeightInTable`: section line pitch is applied
+  inside table cells only when this compatibility setting is enabled.
+- Section 20.4.2.3, `anchor`: inline drawings participate in line layout;
+  floating drawings are positioned independently from inline flow.
+- Section 20.4.2.15, `wrapNone`: a floating drawing with no wrapping must not
+  constrain text flow.
+
+Microsoft implementation notes and controlled Office output comparisons may be
+used when the standard leaves behavior unspecified. Any such compatibility
+behavior must be isolated, documented, and tested separately from normative
+rules.
+
+## Goals
+
+1. Normalize document, section, story, container, paragraph, and run layout
+   policy into immutable TypeScript contexts.
+2. Preserve Rust parser ownership of style-cascade resolution and TypeScript
+   ownership of runtime layout meaning.
+3. Make paragraph measurement placement-aware, deterministic, and reusable by
+   body flow, table-cell flow, pagination, and paint.
+4. Replace model-object layout stamps with explicit measured fragments owned by
+   a `DocumentLayout` result.
+5. Migrate body paragraphs and table pagination incrementally, with each stage
+   independently testable and reviewable.
+6. Keep existing anchored-drawing and text-box rendering operational while
+   exposing contracts that later migrations can consume.
+
+## Non-Goals
+
+- Rewriting the complete DOCX renderer in one change.
+- Migrating text-box content to the full WordprocessingML body model in this
+  delivery series.
+- Replacing anchored drawing registration, z-order, or positioning in this
+  delivery series.
+- Adding empirical constants or branches for a private fixture.
+- Reinterpreting unrelated Office compatibility behavior while extracting the
+  new layout kernel.
+
+## Architectural Decisions
+
+### Story and container are orthogonal
+
+A table cell is not a document story. A story describes the WordprocessingML
+content source. A container stack describes nested layout environments within
+that story.
+
+```ts
+export type StoryKind =
+  | 'body'
+  | 'header'
+  | 'footer'
+  | 'footnote'
+  | 'endnote'
+  | 'textbox';
+
+export type ContainerFrame =
+  | { readonly kind: 'tableCell' };
+
+export interface StoryContext {
+  readonly story: StoryKind;
+  readonly containers: readonly ContainerFrame[];
+  readonly lineNumberingEligible: boolean;
+}
+```
+
+The stack, rather than a separate depth integer, represents nested tables and
+future combinations such as a table inside a text box. Container rules are
+limited to behavior backed by the specification:
+
+- table-cell line-grid compatibility gating;
+- table-cell isolation from page-level floating wrap constraints;
+- main-story eligibility for section line numbering.
+
+Headers, footers, and notes do not receive hard-coded document-grid exceptions.
+Their paragraph styles, including inherited `snapToGrid`, remain authoritative.
+
+### Parser and renderer responsibilities remain separate
+
+Rust resolves information that depends on the WordprocessingML style cascade:
+
+- document defaults, named styles, table styles, numbering, character styles,
+  and direct formatting;
+- whether line spacing was explicit at a style/direct level;
+- resolved paragraph and run properties.
+
+Rust must additionally retain, without applying layout formulas:
+
+- `w:compat/w:adjustLineHeightInTable` as an optional boolean;
+- run-level `w:snapToGrid` as an optional boolean.
+
+TypeScript resolves behavior that depends on runtime containment or placement:
+
+- section grid activation and units;
+- table-cell compatibility gating;
+- paragraph line-grid and run character-grid participation;
+- physical bidi indents;
+- story/container-specific flow policy;
+- line measurement, placement, fragmentation, and painting.
+
+New parser fields use optional serialization so documents that do not contain
+the properties retain their previous wire representation.
+
+## Layout Contexts
+
+### Document settings
+
+```ts
+export interface DocumentLayoutSettings {
+  readonly kinsoku: KinsokuRules;
+  readonly defaultTabPt: number;
+  readonly characterSpacingControl?: string;
+  readonly mathDefJc?: string;
+  readonly documentHasEastAsianText: boolean;
+  readonly compat: {
+    readonly adjustLineHeightInTable: boolean;
+    readonly useFeLayout: boolean;
+    readonly balanceSingleByteDoubleByteWidth: boolean;
+  };
+}
+
+export function resolveDocumentLayoutSettings(
+  document: DocxDocumentModel,
+): DocumentLayoutSettings;
+```
+
+Absent compatibility flags resolve to `false`. Existing specification defaults,
+including the default tab interval and kinsoku behavior, resolve once here.
+
+### Section context
+
+Line-grid and character-grid policy are separate. This prevents paragraph
+`snapToGrid` from accidentally disabling a run-level character grid, and
+prevents the table-cell line-pitch exception from disabling character pitch.
+
+```ts
+export interface SectionGridContext {
+  readonly kind: 'none' | 'lines' | 'linesAndChars' | 'snapToChars';
+  readonly linePitchPt: number | null;
+  readonly charSpacePt: number | null;
+}
+
+export interface SectionLayoutContext {
+  readonly geometry: SectionGeom;
+  readonly columns: readonly ColumnGeom[];
+  readonly grid: SectionGridContext;
+  readonly textDirection: string;
+  readonly verticalAlignment: string;
+  readonly lineNumbering?: LineNumbering;
+}
+
+export function resolveSectionLayoutContext(
+  settings: DocumentLayoutSettings,
+  section: SectionProps,
+): SectionLayoutContext;
+```
+
+Vertical-page coordinate swapping stays before context resolution. The section
+resolver consumes the already-normalized logical section geometry.
+
+### Paragraph and run contexts
+
+```ts
+export interface LineGridPolicy {
+  readonly active: boolean;
+  readonly pitchPt: number | null;
+}
+
+export interface CharacterGridPolicy {
+  readonly active: boolean;
+  readonly deltaPt: number;
+}
+
+export interface ParagraphLayoutContext {
+  readonly lineGrid: LineGridPolicy;
+  readonly characterGrid: CharacterGridPolicy;
+  readonly physicalIndentLeftPt: number;
+  readonly physicalIndentRightPt: number;
+  readonly firstIndentPt: number;
+  readonly lineSpacing: LineSpacing | null;
+  readonly spaceBeforePt: number;
+  readonly spaceAfterPt: number;
+  readonly baseRtl: boolean;
+  readonly tabStops: readonly TabStop[];
+  readonly hasRuby: boolean;
+  readonly hasEastAsianText: boolean;
+  readonly kinsoku: KinsokuRules;
+  readonly defaultTabPt: number;
+}
+
+export interface RunLayoutContext {
+  readonly characterGrid: CharacterGridPolicy;
+}
+
+export function resolveParagraphLayoutContext(
+  settings: DocumentLayoutSettings,
+  section: SectionLayoutContext,
+  story: StoryContext,
+  paragraph: DocParagraph,
+): ParagraphLayoutContext;
+
+export function resolveRunLayoutContext(
+  paragraph: ParagraphLayoutContext,
+  run: DocxTextRun,
+): RunLayoutContext;
+```
+
+Grid resolution follows this matrix:
+
+| Input | Line grid | Character grid |
+| --- | --- | --- |
+| `docGrid` absent or `type=default` | off | off |
+| `type=lines` | on | off |
+| `type=linesAndChars` | on | on when `charSpace` is present |
+| `type=snapToChars` | on | on when `charSpace` is present |
+| paragraph `snapToGrid=false` | off | unchanged |
+| paragraph `lineRule=exact` | off | unchanged |
+| table cell without `adjustLineHeightInTable` | off | unchanged |
+| run `snapToGrid=false` | unchanged | off for that run |
+
+`atLeast` does not disable the line grid. Its requested minimum and the resolved
+grid minimum both participate in line-box calculation. This behavior change is
+delivered and verified separately from the context extraction.
+
+Existing Office-compatible East Asian cell rounding, ruby line unification, and
+font metric correction move behind this context without semantic changes during
+the extraction stage. Any later change to those behaviors requires its own
+evidence and test boundary.
+
+Paragraph adjacency behavior does not belong in `ParagraphLayoutContext`.
+Spacing collapse, contextual spacing, section-break spacer handling,
+`keepNext`, `keepLines`, and widow/orphan decisions remain flow-placement rules
+because they depend on neighboring content or available page space.
+
+## Placement-Aware Paragraph Measurement
+
+Paragraph measurement is not intrinsic to a paragraph and width. Floating wrap
+geometry can change line width and vertical origin, so the placement is an
+explicit part of the contract.
+
+```ts
+export interface WrapOracle {
+  lineWindow(input: {
+    readonly topYPt: number;
+    readonly minimumStartWidthPt: number;
+    readonly probeHeightPt: number;
+    readonly paragraphXPt: number;
+    readonly maximumWidthPt: number;
+  }): {
+    readonly topYPt: number;
+    readonly xOffsetPt: number;
+    readonly maximumWidthPt: number;
+  };
+
+  skipTopAndBottomBands(yPt: number): number;
+}
+
+export interface ParagraphPlacement {
+  readonly startYPt: number;
+  readonly paragraphXPt: number;
+  readonly availableWidthPt: number;
+  readonly maximumYPt: number;
+  readonly suppressSpaceBefore: boolean;
+  readonly wrap?: WrapOracle;
+}
+
+export interface TextMeasurer {
+  readonly context:
+    | CanvasRenderingContext2D
+    | OffscreenCanvasRenderingContext2D;
+  readonly fontFamilyClasses: Readonly<Record<string, string>>;
+}
+
+export interface MeasuredLine {
+  readonly layout: LayoutLine;
+  readonly topYPt: number;
+  readonly advancePt: number;
+}
+
+export interface MeasuredParagraph {
+  readonly lines: readonly MeasuredLine[];
+  readonly markOnly: boolean;
+  readonly requestedSpaceBeforePt: number;
+  readonly requestedSpaceAfterPt: number;
+  readonly contentStartYPt: number;
+  readonly contentEndYPt: number;
+  readonly placement: Readonly<ParagraphPlacement>;
+}
+
+export function measureParagraph(
+  paragraph: DocParagraph,
+  context: ParagraphLayoutContext,
+  placement: ParagraphPlacement,
+  measurer: TextMeasurer,
+): MeasuredParagraph;
+```
+
+The measurement coordinate system is points at scale 1. `contentStartYPt`
+includes the effective leading spacing selected by the placement, while
+`contentEndYPt` is the end of the measured line content and excludes trailing
+paragraph spacing. The paginator owns trailing spacing collapse and records the
+actual leading and trailing contributions on each fragment, preventing spacing
+from being counted once in measurement and again in placement. Paint scales
+measured geometry; it does not repeat text layout. A measurement is valid only
+for its recorded placement. Moving a paragraph to another page, column, or wrap
+context requires deterministic remeasurement.
+
+The existing float-layout pure functions implement `WrapOracle`. Floating
+drawing discovery and registration stay in the current anchor subsystem. A
+`wrapNone` object never appears in the oracle. Table-cell measurement receives
+no page-level wrap oracle.
+
+Inline drawings remain line segments and continue to affect line width and line
+height inside `measureParagraph`.
+
+## Measured Fragment Model
+
+Fragments belong to a layout result, not to the parsed document model.
+
+```ts
+export interface ParagraphFragment {
+  readonly kind: 'paragraph';
+  readonly source: DocParagraph;
+  readonly measured: MeasuredParagraph;
+  readonly lineStart: number;
+  readonly lineEnd: number;
+  readonly leadingSpacePt: number;
+  readonly trailingSpacePt: number;
+}
+
+export interface CellFragment {
+  readonly source: DocTableCell;
+  readonly blocks: readonly FlowFragment[];
+  readonly verticalMerge: 'none' | 'restart' | 'continue';
+}
+
+export interface RowFragment {
+  readonly source: DocTableRow;
+  readonly sourceRowIndex: number;
+  readonly heightPt: number;
+  readonly cells: readonly CellFragment[];
+  readonly repeatedHeader: boolean;
+}
+
+export interface TableFragment {
+  readonly kind: 'table';
+  readonly source: DocTable;
+  readonly columnWidthsPt: readonly number[];
+  readonly rows: readonly RowFragment[];
+  readonly continuesFromPreviousPage: boolean;
+  readonly continuesOnNextPage: boolean;
+}
+
+export type FlowFragment = ParagraphFragment | TableFragment;
+
+export interface PlacedFragment {
+  readonly fragment: FlowFragment;
+  readonly columnIndex: number;
+  readonly xPt: number;
+  readonly yPt: number;
+  readonly widthPt: number;
+  readonly heightPt: number;
+}
+
+export interface LayoutPage {
+  readonly pageIndex: number;
+  readonly section: SectionLayoutContext;
+  readonly geometry: SectionGeom;
+  readonly fragments: readonly PlacedFragment[];
+}
+
+export interface DocumentLayout {
+  readonly pages: readonly LayoutPage[];
+}
+```
+
+Paragraph continuation uses line ranges over one measured result only while the
+placement remains valid. A continuation page with a different wrap context must
+hold a separate measurement. Table continuation is recursive: a cell contains
+paragraph or nested-table fragments, and each cell has an independent
+continuation point.
+
+Paint consumes `PlacedFragment` and page paint state. For migrated body/table
+paths, paint must not call segment construction, line layout, text measurement,
+or row measurement. Once modules are separated, an ast-grep rule will enforce
+that boundary statically.
+
+## Table Pagination Rules
+
+The fragment paginator retains existing specification-backed table behavior:
+
+- `cantSplit` rows move as a unit when possible;
+- exact-height rows clip rather than split;
+- automatic rows may split at cell block or paragraph-line boundaries;
+- repeated header rows are placed on continuation pages;
+- nested tables fragment recursively;
+- vertical-merge geometry continues across row fragments;
+- vertical-merge content remains owned by the restart cell;
+- break selection never creates an invalid vertical-merge boundary;
+- cell margins and paragraph spacing are measured once and included in row
+  height.
+
+The existing pure table geometry functions remain the source for column widths,
+row-height rules, and vertical-merge span distribution. The migration replaces
+model cloning and runtime stamps, not those validated algorithms.
+
+`keepNext`, `keepLines`, and widow/orphan control are placement decisions over
+measured line arrays. They are extracted as pure slice-selection functions and
+must preserve current behavior before any semantic correction is considered.
+
+## Data Flow
+
+```text
+Rust parser model
+  -> document and section context resolvers
+  -> story/container traversal
+  -> paragraph and run context resolvers
+  -> placement-aware paragraph measurement
+  -> paragraph/table/row/cell fragments
+  -> page and column placement
+  -> fragment-only paint
+```
+
+Anchored drawing registration remains adjacent to page/column placement:
+
+```text
+existing anchor subsystem
+  -> registered wrapping objects
+  -> WrapOracle
+  -> paragraph measurement
+```
+
+This boundary allows body measurement to use correct float constraints without
+including anchor positioning or z-order migration in this delivery series.
+
+## Compatibility Strategy
+
+`paginateDocument` and existing renderer test helpers are internal but heavily
+used. They remain available as compatibility adapters while the production path
+moves to `DocumentLayout`. The adapters are removed only after body and table
+tests consume the new result directly.
+
+During extraction, existing layout results are the characterization baseline.
+Normative behavior changes are isolated so visual differences can be attributed
+to one rule. In particular, documents that previously received table-cell line
+pitch unconditionally will change only in the dedicated compatibility-gating
+delivery.
+
+## Delivery Sequence
+
+The work is delivered as a sequence of reviewable PRs. Each PR starts from the
+then-current `main`, passes CI, and is merge-committed before the next dependent
+stage is opened.
+
+### PR 1: Preserve missing parser facts
+
+- Parse `adjustLineHeightInTable`.
+- Parse run-level `snapToGrid`.
+- Add Rust and TypeScript wire fields.
+- Do not change rendering behavior.
+
+### PR 2: Introduce immutable layout resolvers
+
+- Add document, section, paragraph, and run context modules.
+- Replace duplicated state construction and physical bidi-indent resolution.
+- Preserve existing layout semantics, including the temporarily documented
+  table-cell line-grid deviation.
+- Require zero visual difference.
+
+### PR 3: Apply normative grid corrections
+
+- Gate table-cell line pitch on `adjustLineHeightInTable`.
+- Apply run `snapToGrid=false` to character pitch only.
+- Treat `snapToChars` as both line and character grid.
+- Keep `atLeast` in the line-grid policy and apply both minima.
+- Verify each rule through synthetic matrices and local Office comparison.
+
+### PR 4: Unify paragraph measurement
+
+- Introduce placement-aware `measureParagraph`.
+- Route body height estimation, paragraph page splitting, and cell paragraph
+  measurement through it.
+- Keep existing runtime stamps temporarily as compatibility adapters.
+- Require old/new geometry equivalence outside PR 3's intentional changes.
+
+### PR 5: Introduce body fragments
+
+- Add `DocumentLayout`, paragraph fragments, and placed fragments.
+- Make body pagination produce fragments.
+- Make body paint consume measured lines without remeasurement.
+- Remove paragraph runtime stamps from the migrated path.
+- Add the static paint-boundary rule.
+
+### PR 6: Introduce table fragments
+
+- Add table, row, and cell fragments.
+- Move row sizing, row splitting, nested-table splitting, repeated headers, and
+  vertical merges to fragment ownership.
+- Make table paint consume measured fragments.
+- Remove table runtime stamps from the migrated path.
+
+Text-box and anchored-drawing migrations are follow-up series. Text-box
+migration must first preserve full `txbxContent` block structure instead of the
+current reduced shape-text model.
+
+## Tests and Invariants
+
+### Parser tests
+
+- `adjustLineHeightInTable`: absent, true by empty element, explicit true,
+  explicit false.
+- run `snapToGrid`: absent, explicit true, explicit false, and style inheritance.
+- optional fields do not change unrelated serialized documents.
+
+### Resolver matrix
+
+Cover combinations of:
+
+- grid type: absent, default, lines, linesAndChars, snapToChars;
+- line pitch and character space: absent, positive, and valid negative character
+  space;
+- story: body, header, footer, note, text box contract;
+- container stack: flow, table cell, nested table cell;
+- compatibility flag: off and on;
+- paragraph line rule: absent, inherited auto, explicit auto, exact, atLeast;
+- paragraph and run `snapToGrid`: absent, true, false.
+
+### Measurement invariants
+
+1. Identical paragraph, context, placement, and measurer produce deeply equal
+   measurements.
+2. A measurement is never reused after page, column, width, or wrap placement
+   changes.
+3. Empty and anchor-only paragraphs retain one paragraph-mark line.
+4. Inline drawings affect line geometry; `wrapNone` anchors do not enter the
+   wrap oracle.
+5. Scale-1 measured geometry scaled by `s` matches direct scale-`s` geometry
+   within the established numeric tolerance.
+
+### Pagination and paint invariants
+
+1. Fragment height sums equal paginator cursor advancement.
+2. Paint consumes exactly the fragment line ranges and row ranges selected by
+   pagination.
+3. Migrated paint modules cannot call measurement APIs.
+4. Painting does not mutate the document model, layout result, or fragments.
+5. Pagination row heights equal painted row heights.
+6. Repeated table headers use equivalent measured geometry on every placement.
+7. Vertical-merge content stays with the restart cell across page boundaries.
+8. `cantSplit`, exact row height, nested-table continuation, `keepLines`,
+   `keepNext`, and widow/orphan behavior retain their characterized semantics.
+
+### Regression verification
+
+- Focused resolver, line-box, pagination, table-split, and fragment tests.
+- Full DOCX unit test suite.
+- Rust formatting, clippy, and parser tests.
+- TypeScript project build.
+- Local-only visual comparison against representative private documents and
+  Office-produced references without publishing their contents.
+- Existing public visual references remain unchanged in behavior-preserving PRs.
+
+## Error Handling
+
+- Invalid or unsupported grid enum values resolve to `none`; they do not enable
+  a guessed grid mode.
+- Non-positive or non-finite pitches are inactive and covered by resolver tests.
+- Missing Canvas font metrics continue through the existing deterministic font
+  metric fallback.
+- A fragment placement failure reports the responsible element and placement
+  context in development diagnostics; it does not silently switch to a second
+  paint-time layout algorithm.
+- Compatibility behavior not defined by the standard requires explicit evidence
+  and a separate decision before implementation.
+
+## Acceptance Criteria
+
+The body/table migration series is complete when:
+
+1. the parser preserves the two missing OOXML settings;
+2. body and table-cell paragraph policy is resolved through the same immutable
+   context stack;
+3. body and table-cell paragraphs use the same placement-aware measurement API;
+4. table-cell line pitch follows `adjustLineHeightInTable`;
+5. `snapToChars`, paragraph `snapToGrid`, and run `snapToGrid` affect only their
+   specification-defined grid axes;
+6. body and table pagination produce explicit fragments owned by
+   `DocumentLayout`;
+7. migrated paint paths do not remeasure paragraphs or rows;
+8. existing non-target behavior remains covered by unit, type, Rust, and visual
+   regression checks;
+9. no private fixture name, content, or local environment path appears in public
+   commits, documentation, or PR descriptions.

--- a/docs/docx-layout-context-fragments-implementation-plan.md
+++ b/docs/docx-layout-context-fragments-implementation-plan.md
@@ -1,0 +1,1337 @@
+# DOCX Layout Context and Measured Fragments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make DOCX body and table layout resolve OOXML policy through immutable contexts, share one placement-aware paragraph measurement API, and paginate and paint explicit measured fragments.
+
+**Architecture:** Rust preserves style-resolved OOXML facts, while TypeScript resolves document, section, story, container, paragraph, and run layout policy. Measurement produces point-space geometry for a specific placement, pagination owns immutable fragments, and migrated paint paths scale those fragments without repeating line or row measurement.
+
+**Tech Stack:** Rust 2021, serde, TypeScript 6, Canvas 2D, Vitest 4, pnpm 10, ast-grep, Storybook 10, Playwright.
+
+## Global Constraints
+
+- Start every PR from updated `main`; integrate only through a merge-commit PR after CI passes.
+- Use TDD: focused failing test, observed failure, minimal implementation, focused pass, broader verification, refactor.
+- Treat ECMA-376 Part 1 sections 17.3.1.32, 17.3.1.33, 17.3.2.34, 17.6.5, 17.15.3.1, 17.18.14, 20.4.2.3, and 20.4.2.15 as normative.
+- Keep private fixtures, their filenames, their contents, local paths, and generated visual artifacts out of commits and PR text.
+- Preserve non-target rendering in behavior-preserving PRs; intentional visual changes belong only to the normative grid-correction PR.
+- Use optional serde fields so unrelated parser output remains unchanged.
+- Do not add sample-specific thresholds, constants, or path branches.
+- Every agent-authored commit includes the actual model in its co-author trailer.
+- Build WASM before local Storybook or private visual verification.
+
+---
+
+## PR 1: Preserve Missing OOXML Facts
+
+Branch: `codex/docx-layout-context`.
+
+### Task 1: Parse the table line-height compatibility flag
+
+**Files:**
+- Modify: `packages/docx/parser/src/types.rs`
+- Modify: `packages/docx/parser/src/parser.rs`
+- Modify: `packages/docx/src/types.ts`
+
+**Interfaces:**
+- Produces Rust field: `DocumentSettings.adjust_line_height_in_table: Option<bool>`.
+- Produces wire field: `DocSettings.adjustLineHeightInTable?: boolean`.
+- Rendering behavior remains unchanged in this PR.
+
+- [ ] **Step 1: Add failing parser tests**
+
+Add tests beside `settings_east_asian_compat_flags_surface`:
+
+```rust
+#[test]
+fn settings_adjust_line_height_in_table_surfaces() {
+    let xml = format!(
+        r#"<w:settings xmlns:w="{w}"><w:compat><w:adjustLineHeightInTable/></w:compat></w:settings>"#,
+        w = W_NS,
+    );
+    let settings = parse_document_settings(&xml).expect("compat setting");
+    assert_eq!(settings.adjust_line_height_in_table, Some(true));
+}
+
+#[test]
+fn settings_adjust_line_height_in_table_false_surfaces() {
+    let xml = format!(
+        r#"<w:settings xmlns:w="{w}"><w:compat><w:adjustLineHeightInTable w:val="0"/></w:compat></w:settings>"#,
+        w = W_NS,
+    );
+    let settings = parse_document_settings(&xml).expect("compat setting");
+    assert_eq!(settings.adjust_line_height_in_table, Some(false));
+}
+```
+
+- [ ] **Step 2: Run the focused test and observe the missing-field failure**
+
+Run:
+
+```bash
+cargo test -p docx-parser settings_adjust_line_height_in_table -- --nocapture
+```
+
+Expected: compile failure because `adjust_line_height_in_table` does not exist.
+
+- [ ] **Step 3: Add the optional Rust and TypeScript fields**
+
+Add to `DocumentSettings`:
+
+```rust
+/// ECMA-376 §17.15.3.1: apply the section line grid inside table cells.
+#[serde(skip_serializing_if = "Option::is_none")]
+pub adjust_line_height_in_table: Option<bool>,
+```
+
+Add to `DocSettings`:
+
+```ts
+/** §17.15.3.1: apply section line pitch inside table cells. */
+adjustLineHeightInTable?: boolean;
+```
+
+- [ ] **Step 4: Parse and materialize the compatibility flag**
+
+In `parse_document_settings`, add:
+
+```rust
+let adjust_line_height_in_table = compat_bool("adjustLineHeightInTable");
+```
+
+Include the field in both the all-fields-absent check and `DocumentSettings` construction.
+
+- [ ] **Step 5: Run parser verification**
+
+Run:
+
+```bash
+cargo test -p docx-parser settings_adjust_line_height_in_table -- --nocapture
+cargo fmt --all --check
+```
+
+Expected: both focused tests pass and formatting is clean.
+
+- [ ] **Step 6: Commit the setting parser change**
+
+Commit subject:
+
+```text
+feat(docx): preserve table line-grid compatibility setting
+```
+
+The body records the missing parser fact, ECMA-376 §17.15.3.1, unchanged rendering, focused tests, and the actual co-author model.
+
+### Task 2: Parse run-level character-grid participation
+
+**Files:**
+- Modify: `packages/docx/parser/src/styles.rs`
+- Modify: `packages/docx/parser/src/types.rs`
+- Modify: `packages/docx/parser/src/parser.rs`
+- Modify: `packages/docx/src/types.ts`
+
+**Interfaces:**
+- Produces `RunFmt.snap_to_grid: Option<bool>`.
+- Produces `TextRun.snap_to_grid: Option<bool>` and wire field `DocxTextRun.snapToGrid?: boolean`.
+- The field controls character-grid participation only in a later PR.
+
+- [ ] **Step 1: Add failing direct and inherited run tests**
+
+Use the existing `run_of` and `run_of_with_styles` helpers:
+
+```rust
+#[test]
+fn run_snap_to_grid_false_surfaces() {
+    let run = run_of(r#"<w:r><w:rPr><w:snapToGrid w:val="0"/></w:rPr><w:t>x</w:t></w:r>"#);
+    assert_eq!(run.snap_to_grid, Some(false));
+}
+
+#[test]
+fn run_snap_to_grid_inherits_from_character_style() {
+    let styles = r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:style w:type="character" w:styleId="NoCharGrid"><w:rPr><w:snapToGrid w:val="0"/></w:rPr></w:style>
+    </w:styles>"#;
+    let run = run_of_with_styles(
+        styles,
+        r#"<w:r><w:rPr><w:rStyle w:val="NoCharGrid"/></w:rPr><w:t>x</w:t></w:r>"#,
+    );
+    assert_eq!(run.snap_to_grid, Some(false));
+}
+```
+
+- [ ] **Step 2: Run the focused test and observe the missing-field failure**
+
+Run:
+
+```bash
+cargo test -p docx-parser run_snap_to_grid -- --nocapture
+```
+
+Expected: compile failure because run formatting and `TextRun` lack the field.
+
+- [ ] **Step 3: Extend run formatting and its canonical merge**
+
+Add to `RunFmt`:
+
+```rust
+/// ECMA-376 §17.3.2.34: run participation in the character grid.
+pub snap_to_grid: Option<bool>,
+```
+
+In `parse_run_fmt` assign:
+
+```rust
+fmt.snap_to_grid = bool_prop(rpr, "snapToGrid");
+```
+
+In `apply_run` copy only explicit values:
+
+```rust
+if src.snap_to_grid.is_some() {
+    dst.snap_to_grid = src.snap_to_grid;
+}
+```
+
+- [ ] **Step 4: Carry the resolved value to the wire model**
+
+Add to Rust `TextRun`:
+
+```rust
+#[serde(skip_serializing_if = "Option::is_none")]
+pub snap_to_grid: Option<bool>,
+```
+
+Populate it from the resolved `RunFmt` at every `TextRun` construction path. Add to TypeScript `DocxTextRun`:
+
+```ts
+/** §17.3.2.34: false opts this run out of character-grid spacing. */
+snapToGrid?: boolean;
+```
+
+- [ ] **Step 5: Verify parser, formatting, clippy, and TypeScript**
+
+Run:
+
+```bash
+cargo test -p docx-parser run_snap_to_grid -- --nocapture
+cargo fmt --all --check
+cargo clippy -p docx-parser --all-targets -- -D warnings
+pnpm --filter @silurus/ooxml-docx typecheck
+```
+
+Expected: focused tests pass; formatting, clippy, and typecheck exit 0.
+
+- [ ] **Step 6: Commit the run parser change**
+
+Commit subject:
+
+```text
+feat(docx): preserve run character-grid participation
+```
+
+### Task 3: Verify and merge PR 1
+
+**Files:**
+- Verify: `docs/docx-layout-context-fragments-design.md`
+- Verify: `docs/docx-layout-context-fragments-implementation-plan.md`
+- Verify: parser and TypeScript files changed in Tasks 1-2.
+
+**Interfaces:**
+- PR 1 changes parser facts only; renderer output must remain unchanged.
+
+- [ ] **Step 1: Run full PR verification**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test -p docx-parser
+pnpm --filter @silurus/ooxml-docx typecheck
+pnpm vitest run packages/docx/src/line-box-height.test.ts packages/docx/src/docgrid-char.test.ts packages/docx/src/pagination.test.ts packages/docx/src/table-split.test.ts
+git diff --check main...HEAD
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Push and create the public PR**
+
+Use an OSS-safe title such as `Preserve DOCX layout compatibility settings`. The body describes parser information loss, relevant specification sections, unchanged renderer behavior, and sanitized commands only.
+
+- [ ] **Step 3: Wait for all GitHub Actions checks**
+
+Run:
+
+```bash
+gh pr checks --watch
+```
+
+Expected: every required check passes.
+
+- [ ] **Step 4: Merge through the PR**
+
+Run:
+
+```bash
+gh pr merge --merge
+```
+
+Expected: merge commit created on `main`; no direct push.
+
+---
+
+## PR 2: Introduce Immutable Layout Resolvers
+
+Branch: `codex/docx-layout-resolvers` from updated `main`.
+
+### Task 4: Add pure document, section, paragraph, and run resolvers
+
+**Files:**
+- Create: `packages/docx/src/layout-context.ts`
+- Create: `packages/docx/src/layout-context.test.ts`
+- Modify: `packages/docx/src/types.ts`
+
+**Interfaces:**
+- Produces the context types and resolver functions approved in the design.
+- Does not depend on `renderer.ts` or mutable `RenderState`.
+
+- [ ] **Step 1: Add failing resolver matrix tests**
+
+Define complete local builders in the new test file:
+
+```ts
+const section = (overrides: Partial<SectionProps> = {}): SectionProps => ({
+  pageWidth: 200,
+  pageHeight: 300,
+  marginTop: 20,
+  marginRight: 20,
+  marginBottom: 20,
+  marginLeft: 20,
+  headerDistance: 10,
+  footerDistance: 10,
+  titlePage: false,
+  evenAndOddHeaders: false,
+  ...overrides,
+});
+
+const paragraph = (overrides: Partial<DocParagraph> = {}): DocParagraph => ({
+  alignment: 'left',
+  indentLeft: 12,
+  indentRight: 6,
+  indentFirst: 0,
+  spaceBefore: 0,
+  spaceAfter: 0,
+  lineSpacing: null,
+  numbering: null,
+  tabStops: [],
+  runs: [],
+  ...overrides,
+});
+
+const bodyStory: StoryContext = {
+  story: 'body',
+  containers: [],
+  lineNumberingEligible: true,
+};
+const cellStory: StoryContext = {
+  story: 'body',
+  containers: [{ kind: 'tableCell' }],
+  lineNumberingEligible: false,
+};
+```
+
+Construct settings through `resolveDocumentLayoutSettings` from a minimal document, then assert:
+
+```ts
+const layoutSettings = (adjustLineHeightInTable = false): DocumentLayoutSettings => ({
+  kinsoku: DEFAULT_KINSOKU_RULES,
+  defaultTabPt: 36,
+  documentHasEastAsianText: true,
+  compat: {
+    adjustLineHeightInTable,
+    useFeLayout: false,
+    balanceSingleByteDoubleByteWidth: false,
+  },
+});
+
+const defaultGrid = resolveSectionLayoutContext(
+  layoutSettings(),
+  section({ docGridType: 'default', docGridLinePitch: 20 }),
+);
+expect(defaultGrid.grid.kind).toBe('none');
+
+const snapGrid = resolveSectionLayoutContext(
+  layoutSettings(),
+  section({ docGridType: 'snapToChars', docGridLinePitch: 20 }),
+);
+expect(snapGrid.grid.kind).toBe('snapToChars');
+
+const bidiParagraph = paragraph({ bidi: true });
+const bidiContext = resolveParagraphLayoutContext(
+  layoutSettings(),
+  snapGrid,
+  bodyStory,
+  bidiParagraph,
+);
+expect(bidiContext.physicalIndentLeftPt).toBe(bidiParagraph.indentRight);
+
+const cellContext = resolveParagraphLayoutContext(
+  layoutSettings(false),
+  snapGrid,
+  cellStory,
+  paragraph(),
+);
+expect(cellContext.lineGrid.active).toBe(false);
+
+const textRun = {
+  text: 'x', bold: false, italic: false, underline: false,
+  strikethrough: false, fontSize: 10, color: null, fontFamily: null,
+  isLink: false, background: null, vertAlign: null, hyperlink: null,
+  snapToGrid: false,
+} satisfies DocxTextRun;
+expect(resolveRunLayoutContext(bidiContext, textRun).characterGrid.active).toBe(false);
+```
+
+- [ ] **Step 2: Run the tests and observe the missing-module failure**
+
+```bash
+pnpm vitest run packages/docx/src/layout-context.test.ts
+```
+
+Expected: import failure for `layout-context.js`.
+
+- [ ] **Step 3: Implement immutable context types and resolvers**
+
+Export these contracts from `layout-context.ts`:
+
+```ts
+export interface DocumentLayoutSettings {
+  readonly kinsoku: KinsokuRules;
+  readonly defaultTabPt: number;
+  readonly characterSpacingControl?: string;
+  readonly mathDefJc?: string;
+  readonly documentHasEastAsianText: boolean;
+  readonly compat: {
+    readonly adjustLineHeightInTable: boolean;
+    readonly useFeLayout: boolean;
+    readonly balanceSingleByteDoubleByteWidth: boolean;
+  };
+}
+
+export interface SectionGridContext {
+  readonly kind: 'none' | 'lines' | 'linesAndChars' | 'snapToChars';
+  readonly linePitchPt: number | null;
+  readonly charSpacePt: number | null;
+}
+
+export interface LineGridPolicy {
+  readonly active: boolean;
+  readonly pitchPt: number | null;
+}
+
+export interface CharacterGridPolicy {
+  readonly active: boolean;
+  readonly deltaPt: number;
+}
+
+export type StoryKind =
+  | 'body'
+  | 'header'
+  | 'footer'
+  | 'footnote'
+  | 'endnote'
+  | 'textbox';
+
+export type ContainerFrame = { readonly kind: 'tableCell' };
+
+export interface StoryContext {
+  readonly story: StoryKind;
+  readonly containers: readonly ContainerFrame[];
+  readonly lineNumberingEligible: boolean;
+}
+
+export interface SectionLayoutContext {
+  readonly geometry: SectionGeom;
+  readonly columns: readonly ColumnGeom[];
+  readonly grid: SectionGridContext;
+  readonly textDirection: string;
+  readonly verticalAlignment: string;
+  readonly lineNumbering?: LineNumbering;
+}
+
+export interface ParagraphLayoutContext {
+  readonly lineGrid: LineGridPolicy;
+  readonly characterGrid: CharacterGridPolicy;
+  readonly physicalIndentLeftPt: number;
+  readonly physicalIndentRightPt: number;
+  readonly firstIndentPt: number;
+  readonly lineSpacing: LineSpacing | null;
+  readonly spaceBeforePt: number;
+  readonly spaceAfterPt: number;
+  readonly baseRtl: boolean;
+  readonly tabStops: readonly TabStop[];
+  readonly hasRuby: boolean;
+  readonly hasEastAsianText: boolean;
+  readonly kinsoku: KinsokuRules;
+  readonly defaultTabPt: number;
+}
+
+export interface RunLayoutContext {
+  readonly characterGrid: CharacterGridPolicy;
+}
+
+export function resolveDocumentLayoutSettings(
+  document: DocxDocumentModel,
+): DocumentLayoutSettings;
+
+export function resolveSectionLayoutContext(
+  settings: DocumentLayoutSettings,
+  section: SectionProps,
+): SectionLayoutContext;
+
+export function resolveParagraphLayoutContext(
+  settings: DocumentLayoutSettings,
+  section: SectionLayoutContext,
+  story: StoryContext,
+  paragraph: DocParagraph,
+): ParagraphLayoutContext;
+
+export function resolveRunLayoutContext(
+  paragraph: ParagraphLayoutContext,
+  run: DocxTextRun,
+): RunLayoutContext;
+```
+
+Implement the policy classifiers as pure functions:
+
+```ts
+export function isSectionLineGrid(kind: SectionGridContext['kind']): boolean {
+  return kind === 'lines' || kind === 'linesAndChars' || kind === 'snapToChars';
+}
+
+export function isSectionCharacterGrid(kind: SectionGridContext['kind']): boolean {
+  return kind === 'linesAndChars' || kind === 'snapToChars';
+}
+```
+
+`resolveParagraphLayoutContext` applies paragraph `snapToGrid`, `lineRule=exact`, and table-cell compatibility gating. `resolveRunLayoutContext` applies only run character-grid gating. While legacy callers still require `DocGridCtx`, map `SectionGridContext.kind` to `DocGridCtx.type` without renaming or reinterpreting values; remove that bridge when all callers consume the resolved policies.
+
+Move the existing recursive `documentHasEastAsian` helper into the resolver module and call it once from `resolveDocumentLayoutSettings`; do not add a second body scan at renderer entry points.
+
+- [ ] **Step 4: Run resolver tests and typecheck**
+
+```bash
+pnpm vitest run packages/docx/src/layout-context.test.ts
+pnpm --filter @silurus/ooxml-docx typecheck
+```
+
+Expected: resolver tests and typecheck pass.
+
+- [ ] **Step 5: Commit the pure resolver kernel**
+
+Commit subject:
+
+```text
+feat(docx): add immutable layout context resolvers
+```
+
+### Task 5: Route body layout through resolvers without changing output
+
+**Files:**
+- Modify: `packages/docx/src/renderer.ts`
+- Modify: `packages/docx/src/line-layout.ts`
+- Modify: `packages/docx/src/layout-context.test.ts`
+- Modify: `packages/docx/src/pagination.test.ts`
+
+**Interfaces:**
+- `RenderState` temporarily carries resolved document/section contexts.
+- Body paragraph code reads physical indents from `ParagraphLayoutContext` and carries its grid policy for later use.
+- Table cells remain on the existing path until PR 3, isolating intentional visual changes.
+
+- [ ] **Step 1: Add a failing body resolver integration test**
+
+Add a synthetic bidi paragraph with unequal logical indents and assert pagination and paint use the same physical width and line count with resolver instrumentation enabled.
+
+- [ ] **Step 2: Run the focused integration tests**
+
+```bash
+pnpm vitest run packages/docx/src/pagination.test.ts packages/docx/src/measure-column-geometry.test.ts packages/docx/src/rtl-tab-stops.test.ts
+```
+
+Expected: the new resolver-use assertion fails before integration.
+
+- [ ] **Step 3: Replace duplicate body policy resolution**
+
+At document entry, resolve document settings once. At each active section, resolve section context once. For body paragraphs, replace direct calls that swap bidi indents or construct `DocGridCtx` with:
+
+```ts
+const paragraphContext = resolveParagraphLayoutContext(
+  state.layoutSettings,
+  state.sectionLayout,
+  BODY_STORY_CONTEXT,
+  para,
+);
+```
+
+Keep current line metrics and float functions unchanged. Do not route table-cell paragraphs yet.
+In particular, line-box height must continue through the existing `DocGridCtx` and `isGridLineRule` behavior in this PR. Do not consume `ParagraphLayoutContext.lineGrid.active` until PR 3, because the resolver already expresses the corrected `snapToChars` semantics while this PR is required to remain pixel-identical.
+
+- [ ] **Step 4: Run focused and broad renderer tests**
+
+```bash
+pnpm vitest run packages/docx/src/layout-context.test.ts packages/docx/src/pagination.test.ts packages/docx/src/measure-column-geometry.test.ts packages/docx/src/rtl-tab-stops.test.ts packages/docx/src/line-box-height.test.ts
+pnpm --filter @silurus/ooxml-docx typecheck
+git diff --check
+```
+
+Expected: all tests pass with unchanged expectations.
+
+- [ ] **Step 5: Commit the body integration**
+
+Commit subject:
+
+```text
+refactor(docx): resolve body layout policy once
+```
+
+### Task 6: Verify and merge PR 2
+
+**Files:** all PR 2 files.
+
+**Interfaces:** PR 2 is behavior-preserving and requires zero public VRT difference.
+
+- [ ] **Step 1: Run unit, type, build, and local visual verification**
+
+```bash
+pnpm --filter @silurus/ooxml-docx typecheck
+pnpm vitest run packages/docx/src/layout-context.test.ts packages/docx/src/pagination.test.ts packages/docx/src/line-box-height.test.ts packages/docx/src/docgrid-char.test.ts packages/docx/src/table-split.test.ts
+pnpm build:wasm
+pnpm --filter @silurus/ooxml-docx vrt
+git diff --check main...HEAD
+```
+
+Expected: all commands pass; behavior-preserving visual references have no changed pixels.
+
+- [ ] **Step 2: Push, open an OSS-safe PR, wait for CI, and merge with `--merge`**
+
+The PR describes duplicated policy resolution and immutable resolver adoption. It does not mention local-only fixture identities or content.
+
+---
+
+## PR 3: Apply Normative Document-Grid Corrections
+
+Branch: `codex/docx-grid-context-fixes` from updated `main`.
+
+### Task 7: Correct line-grid and character-grid participation
+
+**Files:**
+- Modify: `packages/docx/src/layout-context.ts`
+- Modify: `packages/docx/src/layout-context.test.ts`
+- Modify: `packages/docx/src/line-layout.ts`
+- Modify: `packages/docx/src/renderer.ts`
+- Modify: `packages/docx/src/line-box-height.test.ts`
+- Modify: `packages/docx/src/docgrid-char.test.ts`
+- Create: `packages/docx/src/table-cell-docgrid.test.ts`
+
+**Interfaces:**
+- `snapToChars` participates in both line and character grids.
+- Table cells receive line pitch only when `adjustLineHeightInTable` is true.
+- Paragraph `snapToGrid=false` and exact line spacing disable line pitch only.
+- Run `snapToGrid=false` disables character pitch for that run only.
+- `atLeast` preserves both the authored minimum and active grid minimum.
+
+- [ ] **Step 1: Add failing normative matrix tests**
+
+Pin the following results using public kernel functions and the builders from `layout-context.test.ts`:
+
+```ts
+expect(isGridLineRule({ type: 'snapToChars', linePitchPt: 20 })).toBe(true);
+
+const cellWithoutCompat = resolveParagraphLayoutContext(
+  layoutSettings(false),
+  sectionContext({ docGridType: 'lines', docGridLinePitch: 20 }),
+  cellStory,
+  paragraph(),
+);
+expect(cellWithoutCompat.lineGrid.active).toBe(false);
+
+const cellWithCompat = resolveParagraphLayoutContext(
+  layoutSettings(true),
+  sectionContext({ docGridType: 'lines', docGridLinePitch: 20 }),
+  cellStory,
+  paragraph(),
+);
+expect(cellWithCompat.lineGrid.active).toBe(true);
+
+expect(lineBoxHeight({ value: 18, rule: 'atLeast', explicit: true }, 10, 2, 1, grid20)).toBe(20);
+
+expect(segAdvanceWidth({ ...eaSegment, snapToCharacterGrid: true }, 20, 1, 1)).toBe(21);
+expect(segAdvanceWidth({ ...eaSegment, snapToCharacterGrid: false }, 20, 1, 1)).toBe(20);
+```
+
+Define the remaining values in the test without implicit helpers:
+
+```ts
+const grid20 = { type: 'lines', linePitchPt: 20 } as const;
+const eaSegment: LayoutTextSeg = {
+  text: 'あ',
+  bold: false,
+  italic: false,
+  underline: false,
+  strikethrough: false,
+  fontSize: 20,
+  color: null,
+  fontFamily: null,
+  vertAlign: null,
+  measuredWidth: 0,
+};
+```
+
+Keep this PR's tests self-contained by defining exact local builders:
+
+```ts
+const layoutSettings = (adjustLineHeightInTable = false): DocumentLayoutSettings => ({
+  kinsoku: DEFAULT_KINSOKU_RULES,
+  defaultTabPt: 36,
+  documentHasEastAsianText: true,
+  compat: {
+    adjustLineHeightInTable,
+    useFeLayout: false,
+    balanceSingleByteDoubleByteWidth: false,
+  },
+});
+
+const section = (overrides: Partial<SectionProps> = {}): SectionProps => ({
+  pageWidth: 200,
+  pageHeight: 300,
+  marginTop: 20,
+  marginRight: 20,
+  marginBottom: 20,
+  marginLeft: 20,
+  headerDistance: 10,
+  footerDistance: 10,
+  titlePage: false,
+  evenAndOddHeaders: false,
+  ...overrides,
+});
+
+const paragraph = (overrides: Partial<DocParagraph> = {}): DocParagraph => ({
+  alignment: 'left',
+  indentLeft: 12,
+  indentRight: 6,
+  indentFirst: 0,
+  spaceBefore: 0,
+  spaceAfter: 0,
+  lineSpacing: null,
+  numbering: null,
+  tabStops: [],
+  runs: [],
+  ...overrides,
+});
+
+const cellStory: StoryContext = {
+  story: 'body',
+  containers: [{ kind: 'tableCell' }],
+  lineNumberingEligible: false,
+};
+
+const sectionContext = (overrides: Partial<SectionProps> = {}) =>
+  resolveSectionLayoutContext(layoutSettings(), section(overrides));
+```
+
+- [ ] **Step 2: Run and observe the four independent failures**
+
+```bash
+pnpm vitest run packages/docx/src/layout-context.test.ts packages/docx/src/line-box-height.test.ts packages/docx/src/docgrid-char.test.ts packages/docx/src/table-cell-docgrid.test.ts
+```
+
+Expected: failures identify snapToChars line activation, table-cell gating, atLeast grid minimum, and per-run character spacing.
+
+- [ ] **Step 3: Route table cells through a table-cell story context**
+
+Create the cell story by appending `{ kind: 'tableCell' }` to the current container stack. Pass its resolved paragraph context through row measurement, row splitting, and cell paint. Remove direct table-cell use of the section `state.docGrid`.
+
+- [ ] **Step 4: Gate character-grid delta per text segment**
+
+Add to `LayoutTextSeg`:
+
+```ts
+snapToCharacterGrid?: boolean;
+```
+
+Set it from `DocxTextRun.snapToGrid !== false` in `buildSegments`. Gate the delta inside the shared advance helpers so every caller observes the same rule:
+
+```ts
+const segmentGridDelta = seg.snapToCharacterGrid === false ? 0 : gridDeltaPx;
+```
+
+Use `segmentGridDelta` inside `segAdvanceWidth` and `segLetterSpacingPx` before calling `gridSegDeltaPx`; make `gridWidth` accept the already-gated delta or add the same segment-aware gate to its caller. The paint letter-spacing path must call the same helper rather than duplicate the condition.
+
+- [ ] **Step 5: Correct line-grid activation and atLeast minimum**
+
+Include `snapToChars` in `isGridLineRule`. For `atLeast`, return the maximum of natural height, authored minimum, and active grid-resolved single-line height. Keep exact spacing independent of a positive grid.
+
+- [ ] **Step 6: Run focused tests, full DOCX tests, and local comparison**
+
+```bash
+pnpm vitest run packages/docx/src/layout-context.test.ts packages/docx/src/line-box-height.test.ts packages/docx/src/docgrid-char.test.ts packages/docx/src/table-cell-docgrid.test.ts packages/docx/src/pagination.test.ts packages/docx/src/table-split.test.ts
+pnpm --filter @silurus/ooxml-docx typecheck
+pnpm build:wasm
+pnpm --filter @silurus/ooxml-docx vrt
+```
+
+Expected: unit/type checks pass. Any intentional local visual difference is attributable to one of the four normative rules and is reviewed without updating references automatically.
+
+- [ ] **Step 7: Commit each behavior correction separately**
+
+Use these subjects, omitting a commit only if its code is inseparable from the preceding one:
+
+```text
+fix(docx): gate table cell line pitch by compatibility
+fix(docx): honor run character-grid participation
+fix(docx): apply snap-to-chars line pitch
+fix(docx): retain the grid minimum for at-least spacing
+```
+
+### Task 8: Verify and merge PR 3
+
+- [ ] **Step 1: Run full verification and review intentional visual differences**
+
+```bash
+cargo test -p docx-parser
+pnpm vitest run packages/docx/src/layout-context.test.ts packages/docx/src/line-box-height.test.ts packages/docx/src/docgrid-char.test.ts packages/docx/src/table-cell-docgrid.test.ts packages/docx/src/pagination.test.ts packages/docx/src/table-split.test.ts
+pnpm --filter @silurus/ooxml-docx typecheck
+pnpm build:wasm
+pnpm --filter @silurus/ooxml-docx vrt
+git diff --check main...HEAD
+```
+
+Expected: all non-visual checks pass. Review each visual difference against the four normative rule changes without updating references automatically.
+
+- [ ] **Step 2: Gate public visual-reference changes on explicit approval**
+
+List every changed tracked visual reference and attribute it to one of the four normative corrections. Do not regenerate, stage, or merge a changed public reference without explicit user approval. Local-only comparison artifacts remain untracked.
+
+- [ ] **Step 3: Ask Opus 4.8 for a read-only specification review**
+
+Provide only the public diff and specification sections. Require findings with file/line references and prohibit edits, private fixture names, and local paths.
+
+- [ ] **Step 4: Resolve valid findings, rerun verification, push, open the PR, wait for CI, and merge with `--merge`**
+
+The PR body explains each OOXML mismatch and its general document class.
+
+---
+
+## PR 4: Unify Placement-Aware Paragraph Measurement
+
+Branch: `codex/docx-paragraph-measurement` from updated `main`.
+
+### Task 9: Add the measurement kernel
+
+**Files:**
+- Create: `packages/docx/src/paragraph-measure.ts`
+- Create: `packages/docx/src/paragraph-measure.test.ts`
+- Modify: `packages/docx/src/line-layout.ts`
+- Modify: `packages/docx/src/float-layout.ts`
+
+**Interfaces:**
+- Produces the placement-aware contracts below without importing renderer state.
+- A result is valid only for its recorded placement.
+- Coordinates and measurement use scale 1 points.
+
+- [ ] **Step 1: Add failing placement tests**
+
+Test no-float, float-window, empty-mark, anchor-only, ruby, bidi, inline-image, exact spacing, and changed-start-Y cases. The changed placement test asserts two calls with different `startYPt` do not share the same result object and can produce different line windows.
+
+- [ ] **Step 2: Run and observe the missing-module failure**
+
+```bash
+pnpm vitest run packages/docx/src/paragraph-measure.test.ts
+```
+
+- [ ] **Step 3: Implement a line-layout environment independent of paint state**
+
+Extract the fields read by segment construction and field resolution into a narrow interface:
+
+```ts
+export interface LineLayoutEnvironment {
+  readonly pageIndex: number;
+  readonly totalPages: number;
+  readonly displayPageNumber?: number;
+  readonly pageNumberFormat?: NumberFormat;
+  readonly currentDateMs?: number;
+  readonly noteNumbers?: ReadonlyMap<string, number>;
+  readonly currentNoteNumber?: number;
+  readonly verticalCJK?: boolean;
+}
+```
+
+Change `buildSegments` and `resolveFieldText` to accept this interface. The current `buildSegments` implementation reads only `verticalCJK`, note numbering, and `resolveFieldText`'s page/date fields from state; keep font classes on `TextMeasurer` and grid, kinsoku, tabs, and spacing on `ParagraphLayoutContext`. Verify this boundary with a `state.` usage scan and typecheck. Because `verticalCJK` remains optional, existing `RenderState` is structurally compatible.
+
+Define the measurement boundary explicitly:
+
+```ts
+export interface WrapOracle {
+  lineWindow(input: {
+    readonly topYPt: number;
+    readonly minimumStartWidthPt: number;
+    readonly probeHeightPt: number;
+    readonly paragraphXPt: number;
+    readonly maximumWidthPt: number;
+  }): {
+    readonly topYPt: number;
+    readonly xOffsetPt: number;
+    readonly maximumWidthPt: number;
+  };
+  skipTopAndBottomBands(yPt: number): number;
+}
+
+export interface TextMeasurer {
+  readonly context:
+    | CanvasRenderingContext2D
+    | OffscreenCanvasRenderingContext2D;
+  readonly fontFamilyClasses: Readonly<Record<string, string>>;
+}
+
+export interface ParagraphPlacement {
+  readonly startYPt: number;
+  readonly paragraphXPt: number;
+  readonly availableWidthPt: number;
+  readonly maximumYPt: number;
+  readonly suppressSpaceBefore: boolean;
+  readonly wrap?: WrapOracle;
+}
+
+export interface MeasuredLine {
+  readonly layout: LayoutLine;
+  readonly topYPt: number;
+  readonly advancePt: number;
+}
+
+export interface MeasuredParagraph {
+  readonly lines: readonly MeasuredLine[];
+  readonly markOnly: boolean;
+  readonly requestedSpaceBeforePt: number;
+  readonly requestedSpaceAfterPt: number;
+  readonly contentStartYPt: number;
+  readonly contentEndYPt: number;
+  readonly placement: Readonly<ParagraphPlacement>;
+}
+
+export function measureParagraph(
+  paragraph: DocParagraph,
+  context: ParagraphLayoutContext,
+  placement: ParagraphPlacement,
+  measurer: TextMeasurer,
+): MeasuredParagraph;
+```
+
+- [ ] **Step 4: Implement `WrapOracle` over existing pure float functions**
+
+The adapter delegates to `resolveLineFloatWindow` and `skipPastTopAndBottom`. Keep object registration and one-inch compatibility behavior outside the interface.
+
+- [ ] **Step 5: Implement `measureParagraph` by moving existing calculations verbatim**
+
+Use `buildSegments`, `layoutLines`, `lineBoxHeight`, `paragraphMarkLineHeight`, and the resolved paragraph context. Return measured line top and advance values plus content start/end; exclude trailing paragraph spacing.
+
+- [ ] **Step 6: Run measurement tests and typecheck**
+
+```bash
+pnpm vitest run packages/docx/src/paragraph-measure.test.ts packages/docx/src/line-box-height.test.ts packages/docx/src/layout-lines-scale-invariance.test.ts
+pnpm --filter @silurus/ooxml-docx typecheck
+```
+
+- [ ] **Step 7: Commit the measurement kernel**
+
+```text
+refactor(docx): add placement-aware paragraph measurement
+```
+
+### Task 10: Route body pagination and table-cell measurement through one API
+
+**Files:**
+- Modify: `packages/docx/src/renderer.ts`
+- Modify: `packages/docx/src/pagination.test.ts`
+- Modify: `packages/docx/src/cell-paragraph-line-reuse.test.ts`
+- Modify: `packages/docx/src/paginate-paint-line-count.test.ts`
+
+**Interfaces:**
+- `estimateParagraphHeight`, `splitParagraphAcrossPages`, `measureParaHeight`, and `layoutCellParagraphForRowSplit` consume `measureParagraph`.
+- Runtime line stamps remain temporarily for paint compatibility.
+
+- [ ] **Step 1: Add old/new geometry equivalence tests**
+
+For representative synthetic paragraphs, capture page count, line ranges, top positions, and cell heights. Add a test-only legacy toggle so the same model can run through old and new callers during migration.
+
+- [ ] **Step 2: Run and verify the equivalence test fails before routing**
+
+```bash
+pnpm vitest run packages/docx/src/pagination.test.ts packages/docx/src/cell-paragraph-line-reuse.test.ts packages/docx/src/paginate-paint-line-count.test.ts
+```
+
+- [ ] **Step 3: Replace each mirrored calculation with `measureParagraph`**
+
+Body estimation passes the active wrap oracle and placement. Cell measurement passes the table-cell context with no page wrap oracle. Paragraph splitting slices `MeasuredLine[]` and applies `keepLines` and widow/orphan rules without recalculating line advances.
+
+- [ ] **Step 4: Remove the test-only legacy toggle after equality passes**
+
+Keep characterization assertions, remove the alternate production code path, and ensure only one line measurement implementation remains.
+
+- [ ] **Step 5: Run focused and broad verification**
+
+```bash
+pnpm vitest run packages/docx/src/paragraph-measure.test.ts packages/docx/src/pagination.test.ts packages/docx/src/cell-paragraph-line-reuse.test.ts packages/docx/src/paginate-paint-line-count.test.ts packages/docx/src/table-split.test.ts
+pnpm --filter @silurus/ooxml-docx typecheck
+git diff --check
+```
+
+- [ ] **Step 6: Commit the caller migration**
+
+```text
+refactor(docx): share paragraph measurement across flow paths
+```
+
+### Task 11: Verify and merge PR 4
+
+- [ ] **Step 1: Run full DOCX tests, typecheck, WASM build, and local VRT**
+
+```bash
+cargo test -p docx-parser
+pnpm test
+pnpm typecheck
+pnpm build:wasm
+pnpm --filter @silurus/ooxml-docx vrt
+git diff --check main...HEAD
+```
+
+Expected: every command exits 0 and behavior-preserving visual references are unchanged.
+
+- [ ] **Step 2: Ask Sonnet 5 for a read-only measure/paint divergence review**
+
+Run Claude Code with `--model claude-sonnet-5`, read-only tools, and a prompt that requests findings with file/line references for duplicate measurement, placement reuse, field resolution, and missing tests. Do not grant edit or network tools.
+
+- [ ] **Step 3: Resolve findings, rerun checks, push, open an OSS-safe PR, wait for CI, and merge with `--merge`**
+
+Rerun Step 1 after every accepted finding. Then use `git push -u origin codex/docx-paragraph-measurement`, create the PR, `gh pr checks --watch`, and `gh pr merge --merge`.
+
+---
+
+## PR 5: Produce and Paint Body Fragments
+
+Branch: `codex/docx-body-fragments` from updated `main`.
+
+### Task 12: Add fragment types and body layout output
+
+**Files:**
+- Create: `packages/docx/src/layout-fragments.ts`
+- Create: `packages/docx/src/document-layout.ts`
+- Create: `packages/docx/src/document-layout.test.ts`
+- Modify: `packages/docx/src/types.ts`
+- Modify: `packages/docx/src/renderer.ts`
+
+**Interfaces:**
+- Produces `ParagraphFragment`, `PlacedFragment`, `LayoutPage`, and `DocumentLayout`.
+- Adds `layoutDocument(doc): DocumentLayout`.
+- Keeps `paginateDocument` as a temporary compatibility adapter.
+
+- [ ] **Step 1: Add failing body fragment tests**
+
+Assert source identity, immutable line ranges, placement coordinates, page geometry, section context, paragraph continuation, and changed-wrap remeasurement. Add an invariant that cursor advancement equals `leadingSpacePt + measured line advances + trailingSpacePt`, proving paragraph spacing is owned and added exactly once.
+
+- [ ] **Step 2: Run and observe the missing-layout failure**
+
+```bash
+pnpm vitest run packages/docx/src/document-layout.test.ts
+```
+
+- [ ] **Step 3: Implement immutable fragment and page types**
+
+Export the initial body-fragment contracts explicitly:
+
+```ts
+export interface ParagraphFragment {
+  readonly kind: 'paragraph';
+  readonly source: DocParagraph;
+  readonly measured: MeasuredParagraph;
+  readonly lineStart: number;
+  readonly lineEnd: number;
+  readonly leadingSpacePt: number;
+  readonly trailingSpacePt: number;
+}
+
+export type FlowFragment = ParagraphFragment;
+
+export interface PlacedFragment {
+  readonly fragment: FlowFragment;
+  readonly columnIndex: number;
+  readonly xPt: number;
+  readonly yPt: number;
+  readonly widthPt: number;
+  readonly heightPt: number;
+}
+
+export interface LayoutPage {
+  readonly pageIndex: number;
+  readonly section: SectionLayoutContext;
+  readonly geometry: SectionGeom;
+  readonly fragments: readonly PlacedFragment[];
+}
+
+export interface DocumentLayout {
+  readonly pages: readonly LayoutPage[];
+}
+```
+
+PR 6 adds `TableFragment` to `FlowFragment` when its complete contract is introduced. Freeze layout results in tests and ensure no field is added to `DocParagraph`.
+
+- [ ] **Step 4: Make body pagination emit `DocumentLayout`**
+
+Move page, column, and section stamps from parsed elements into `LayoutPage` and `PlacedFragment`. Use `ParagraphFragment.leadingSpacePt` and `trailingSpacePt` for spacing collapse and continuation ownership.
+
+- [ ] **Step 5: Implement the compatibility adapter**
+
+`paginateDocument` projects fragments to the current `PaginatedBodyElement[][]` shape only for unmigrated callers. Production rendering uses `DocumentLayout`.
+
+- [ ] **Step 6: Run body layout tests and existing pagination tests**
+
+```bash
+pnpm vitest run packages/docx/src/document-layout.test.ts packages/docx/src/pagination.test.ts packages/docx/src/paginate-column-anchor.test.ts packages/docx/src/page-anchor-prescan.test.ts
+pnpm --filter @silurus/ooxml-docx typecheck
+```
+
+- [ ] **Step 7: Commit body fragment production**
+
+```text
+refactor(docx): paginate body paragraphs as fragments
+```
+
+### Task 13: Paint body fragments without remeasurement
+
+**Files:**
+- Create: `packages/docx/src/fragment-paint.ts`
+- Create: `packages/docx/src/fragment-paint.test.ts`
+- Modify: `packages/docx/src/renderer.ts`
+- Modify: `packages/docx/src/layout-lines-reuse-identity.test.ts`
+- Create: `rules/no-docx-measurement-in-fragment-paint.yml`
+- Create: `rule-tests/no-docx-measurement-in-fragment-paint-test.yml`
+- Modify: `sgconfig.yml` only if the existing rule directory configuration requires no automatic discovery.
+
+**Interfaces:**
+- `paintParagraphFragment(fragment, pageState)` scales stored geometry only.
+- The body fragment paint module cannot import or call `buildSegments`, `layoutLines`, `measureParagraph`, `measureText`, or row measurement.
+
+- [ ] **Step 1: Add a failing paint-purity test**
+
+Use a Canvas stub whose `measureText` throws. Paint a premeasured paragraph fragment and assert text draw calls and coordinates complete without invoking measurement.
+
+- [ ] **Step 2: Run and observe current paint-time measurement failure**
+
+```bash
+pnpm vitest run packages/docx/src/fragment-paint.test.ts
+```
+
+- [ ] **Step 3: Implement fragment-only paragraph paint**
+
+Move line drawing inputs needed by body paint into the fragment or resolved page paint context. Draw only `lineStart..lineEnd`; draw paragraph-level anchors once on the first fragment while retaining the existing anchor subsystem.
+
+- [ ] **Step 4: Add the ast-grep boundary rule and rule tests**
+
+The rule matches prohibited imports or calls inside `packages/docx/src/fragment-paint.ts`. Its valid fixture paints supplied geometry; invalid fixtures import `layoutLines` or call `measureText`.
+
+- [ ] **Step 5: Remove paragraph runtime stamps from production body paint**
+
+Delete migrated use of `layoutLinesInputs` and stamped `LayoutLine[]`. Keep compatibility fields only where table paint still needs them before PR 6.
+
+- [ ] **Step 6: Run paint, lint, type, and identity tests**
+
+```bash
+pnpm vitest run packages/docx/src/fragment-paint.test.ts packages/docx/src/layout-lines-reuse-identity.test.ts packages/docx/src/paginate-paint-line-count.test.ts
+pnpm lint
+pnpm lint:test
+pnpm --filter @silurus/ooxml-docx typecheck
+```
+
+- [ ] **Step 7: Commit body fragment paint and static enforcement**
+
+```text
+refactor(docx): paint body fragments without remeasurement
+```
+
+### Task 14: Verify and merge PR 5
+
+- [ ] **Step 1: Run full DOCX tests, lint, typecheck, WASM build, and local VRT**
+
+```bash
+pnpm test
+pnpm typecheck
+pnpm lint
+pnpm lint:test
+pnpm build:wasm
+pnpm --filter @silurus/ooxml-docx vrt
+git diff --check main...HEAD
+```
+
+Expected: every command exits 0; body fragment paint invokes no measurement and visual references remain unchanged.
+
+- [ ] **Step 2: Ask Opus 4.8 for a read-only fragment ownership and immutability review**
+
+Run Claude Code with `--model claude-opus-4-8`, read-only tools, and a prompt focused on model mutation, stale placement reuse, hidden paint-time measurement, and missing section/page geometry. Require file/line findings.
+
+- [ ] **Step 3: Resolve findings, rerun checks, push, open an OSS-safe PR, wait for CI, and merge with `--merge`**
+
+Rerun Step 1 after every accepted finding. Then use `git push -u origin codex/docx-body-fragments`, create the PR, `gh pr checks --watch`, and `gh pr merge --merge`.
+
+---
+
+## PR 6: Produce and Paint Table Fragments
+
+Branch: `codex/docx-table-fragments` from updated `main`.
+
+### Task 15: Fragment table rows and cell content
+
+**Files:**
+- Modify: `packages/docx/src/layout-fragments.ts`
+- Create: `packages/docx/src/table-fragments.ts`
+- Create: `packages/docx/src/table-fragments.test.ts`
+- Modify: `packages/docx/src/document-layout.ts`
+- Modify: `packages/docx/src/renderer.ts`
+- Modify: `packages/docx/src/table-split.test.ts`
+
+**Interfaces:**
+- Produces `CellFragment`, `RowFragment`, and `TableFragment`.
+- Reuses `resolveTableRowHeights`, `resolveSingleRowHeight`, and `findMergeEndRow`.
+- Cell content recursively contains paragraph or nested-table fragments.
+
+- [ ] **Step 1: Add failing table fragment tests**
+
+Cover ordinary row breaks, `cantSplit`, exact height, auto-height line splits, block splits, nested tables, repeated headers, vertical merges, and independent per-cell continuation points.
+
+- [ ] **Step 2: Run and observe missing table fragment behavior**
+
+```bash
+pnpm vitest run packages/docx/src/table-fragments.test.ts packages/docx/src/table-split.test.ts
+```
+
+- [ ] **Step 3: Implement recursive cell and row measurement**
+
+Measure each cell with the table-cell story context and no page wrap oracle. Construct immutable cell blocks, row heights, and vertical-merge state without cloning `DocTableRow` or adding `lineSlice` fields.
+
+- [ ] **Step 4: Implement page slicing over row fragments**
+
+Preserve `cantSplit`, exact-height clipping, repeated-header placement, nested-table continuation, and vertical-merge-safe boundaries. Each continuation table records both continuation flags.
+
+- [ ] **Step 5: Route `layoutDocument` table elements to table fragments**
+
+Place table fragments in the same page and column cursor used for paragraph fragments. Floating tables remain on the existing anchored table path in this PR.
+
+- [ ] **Step 6: Run focused table and document layout tests**
+
+```bash
+pnpm vitest run packages/docx/src/table-fragments.test.ts packages/docx/src/table-split.test.ts packages/docx/src/document-layout.test.ts packages/docx/src/table-row-height.test.ts packages/docx/src/table-layout-reuse.test.ts
+pnpm --filter @silurus/ooxml-docx typecheck
+```
+
+- [ ] **Step 7: Commit table fragment pagination**
+
+```text
+refactor(docx): paginate table rows as measured fragments
+```
+
+### Task 16: Paint table fragments and remove table stamps
+
+**Files:**
+- Modify: `packages/docx/src/fragment-paint.ts`
+- Modify: `packages/docx/src/fragment-paint.test.ts`
+- Modify: `packages/docx/src/renderer.ts`
+- Modify: `packages/docx/src/types.ts`
+- Modify: `rules/no-docx-measurement-in-fragment-paint.yml`
+- Modify: `rule-tests/no-docx-measurement-in-fragment-paint-test.yml`
+
+**Interfaces:**
+- Table paint consumes stored column widths, row heights, cell fragments, and border jobs.
+- Parsed model and fragments remain immutable during paint.
+- `tableColWidthsPt`, `tableRowHeightsPt`, `tableLayoutInputs`, and migrated cell line stamps are removed.
+
+- [ ] **Step 1: Add a failing table paint-purity test**
+
+Paint a premeasured table fragment with a Canvas stub whose `measureText` throws. Assert cell text, backgrounds, borders, repeated headers, and vertical merge geometry render without measurement.
+
+- [ ] **Step 2: Run and observe current table paint measurement failure**
+
+```bash
+pnpm vitest run packages/docx/src/fragment-paint.test.ts
+```
+
+- [ ] **Step 3: Paint stored table geometry**
+
+Use fragment column widths and row heights directly. Render each cell's stored paragraph or nested-table fragments. Preserve existing border conflict resolution and vertical alignment using measured content height.
+
+- [ ] **Step 4: Remove runtime table stamps and fallback recomputation**
+
+Delete the migrated runtime fields from `PaginatedBodyElement` and remove paint-time table layout fallback from the production `DocumentLayout` path. Retain compatibility adapters only until their tests are migrated in the same commit.
+
+- [ ] **Step 5: Extend static enforcement and run all focused checks**
+
+```bash
+pnpm vitest run packages/docx/src/fragment-paint.test.ts packages/docx/src/table-fragments.test.ts packages/docx/src/table-layout-reuse.test.ts packages/docx/src/cell-paragraph-line-reuse.test.ts packages/docx/src/table-split.test.ts
+pnpm lint
+pnpm lint:test
+pnpm --filter @silurus/ooxml-docx typecheck
+git diff --check
+```
+
+- [ ] **Step 6: Commit table fragment paint**
+
+```text
+refactor(docx): paint table fragments without remeasurement
+```
+
+### Task 17: Final regression verification and PR 6 merge
+
+**Files:** all body/table layout files and tests from PRs 1-6.
+
+- [ ] **Step 1: Run complete Rust and TypeScript verification**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+pnpm typecheck
+pnpm test
+pnpm lint
+pnpm lint:test
+git diff --check main...HEAD
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Build WASM and run visual verification**
+
+```bash
+pnpm build:wasm
+pnpm --filter @silurus/ooxml-docx vrt
+```
+
+Review public and local-only documents without updating references automatically. Confirm the targeted document class uses the expected table line pitch and pagination, and representative unrelated DOCX layouts do not regress.
+
+- [ ] **Step 3: Start Storybook for user verification**
+
+```bash
+pnpm storybook
+```
+
+Report the selected local port and keep the server running until the user finishes verification.
+
+- [ ] **Step 4: Request a final read-only review**
+
+Use Claude Fable 5 or Opus 4.8 to review the public diff for specification compliance, fragment ownership, hidden remeasurement, table split invariants, and missing tests. Resolve valid findings and rerun Steps 1-2.
+
+- [ ] **Step 5: Push, open the final OSS-safe PR, and wait for CI**
+
+The PR describes the shared measurement/fragment implementation and specification gaps. It contains no private fixture identity, content, local path, or personal environment detail.
+
+- [ ] **Step 6: Merge through the PR**
+
+```bash
+gh pr merge --merge
+```
+
+Expected: all required checks pass and the merge commit lands on `main`; no direct push and no squash.

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2970,6 +2970,7 @@ fn text_runs_mergeable(a: &TextRun, b: &TextRun) -> bool {
         && a.bold_cs == b.bold_cs
         && a.italic_cs == b.italic_cs
         && a.lang_bidi == b.lang_bidi
+        && a.snap_to_grid == b.snap_to_grid
 }
 
 // Same parse-context threading as handle_run_in_para.
@@ -3106,6 +3107,7 @@ fn parse_run_inner(
     let bold_cs = fmt.bold_cs;
     let italic_cs = fmt.italic_cs;
     let lang_bidi = fmt.lang_bidi.clone();
+    let snap_to_grid = fmt.snap_to_grid;
     // Run character metrics (ECMA-376 §17.3.2.35 spacing / §17.3.2.43 w /
     // §17.3.2.24 position / §17.3.2.19 kern), resolved through the style chain
     // into `fmt`. The renderer applies char_spacing via ctx.letterSpacing,
@@ -3177,6 +3179,7 @@ fn parse_run_inner(
                         bold_cs,
                         italic_cs,
                         lang_bidi: lang_bidi.clone(),
+                        snap_to_grid,
                         char_spacing,
                         char_scale,
                         position,
@@ -3254,6 +3257,7 @@ fn parse_run_inner(
                         bold_cs,
                         italic_cs,
                         lang_bidi: lang_bidi.clone(),
+                        snap_to_grid,
                         char_spacing,
                         char_scale,
                         position,
@@ -3301,6 +3305,7 @@ fn parse_run_inner(
                     bold_cs,
                     italic_cs,
                     lang_bidi: lang_bidi.clone(),
+                    snap_to_grid,
                     char_spacing,
                     char_scale,
                     position,
@@ -3393,6 +3398,7 @@ fn parse_run_inner(
                     bold_cs,
                     italic_cs,
                     lang_bidi: lang_bidi.clone(),
+                    snap_to_grid,
                     char_spacing,
                     char_scale,
                     position,
@@ -3587,6 +3593,7 @@ fn parse_run_inner(
                     bold_cs,
                     italic_cs,
                     lang_bidi: lang_bidi.clone(),
+                    snap_to_grid,
                     char_spacing,
                     char_scale,
                     position,
@@ -9581,6 +9588,27 @@ mod cs_toggle_tests {
             run_of(r#"<w:p><w:r><w:rPr><w:rFonts w:cs="Arial"/></w:rPr><w:t>x</w:t></w:r></w:p>"#);
         assert_eq!(run.cs, None);
         assert_eq!(run.font_family_cs.as_deref(), Some("Arial"));
+    }
+
+    #[test]
+    fn run_snap_to_grid_false_surfaces() {
+        let run =
+            run_of(r#"<w:p><w:r><w:rPr><w:snapToGrid w:val="0"/></w:rPr><w:t>x</w:t></w:r></w:p>"#);
+        assert_eq!(run.snap_to_grid, Some(false));
+    }
+
+    #[test]
+    fn run_snap_to_grid_inherits_from_character_style() {
+        let styles = r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+            <w:style w:type="character" w:styleId="NoCharGrid">
+                <w:rPr><w:snapToGrid w:val="0"/></w:rPr>
+            </w:style>
+        </w:styles>"#;
+        let run = run_of_with_styles(
+            styles,
+            r#"<w:p><w:r><w:rPr><w:rStyle w:val="NoCharGrid"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+        );
+        assert_eq!(run.snap_to_grid, Some(false));
     }
 
     // run_of (above) covers only the DIRECT-rPr path (apply_direct_run). The two

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -958,6 +958,7 @@ fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentS
     let compat_bool = |name: &str| -> Option<bool> { bool_prop(compat?, name) };
     let use_fe_layout = compat_bool("useFELayout");
     let balance_single_byte_double_byte_width = compat_bool("balanceSingleByteDoubleByteWidth");
+    let adjust_line_height_in_table = compat_bool("adjustLineHeightInTable");
 
     // ECMA-376 §22.1.2.30 `m:mathPr/m:defJc@m:val` — document-wide default math
     // justification (math namespace, bare `val` fallback).
@@ -980,6 +981,7 @@ fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentS
         && character_spacing_control.is_none()
         && use_fe_layout.is_none()
         && balance_single_byte_double_byte_width.is_none()
+        && adjust_line_height_in_table.is_none()
     {
         return None;
     }
@@ -992,6 +994,7 @@ fn parse_document_settings(settings_xml: &str) -> Option<crate::types::DocumentS
         character_spacing_control,
         use_fe_layout,
         balance_single_byte_double_byte_width,
+        adjust_line_height_in_table,
     })
 }
 
@@ -9094,6 +9097,26 @@ mod math_jc_tests {
         );
         assert_eq!(s.use_fe_layout, Some(true));
         assert_eq!(s.balance_single_byte_double_byte_width, Some(false));
+    }
+
+    #[test]
+    fn settings_adjust_line_height_in_table_surfaces() {
+        let xml = format!(
+            r#"<w:settings xmlns:w="{w}"><w:compat><w:adjustLineHeightInTable/></w:compat></w:settings>"#,
+            w = W_NS,
+        );
+        let settings = parse_document_settings(&xml).expect("compat setting");
+        assert_eq!(settings.adjust_line_height_in_table, Some(true));
+    }
+
+    #[test]
+    fn settings_adjust_line_height_in_table_false_surfaces() {
+        let xml = format!(
+            r#"<w:settings xmlns:w="{w}"><w:compat><w:adjustLineHeightInTable w:val="0"/></w:compat></w:settings>"#,
+            w = W_NS,
+        );
+        let settings = parse_document_settings(&xml).expect("compat setting");
+        assert_eq!(settings.adjust_line_height_in_table, Some(false));
     }
 
     // ECMA-376 §22.1.2.88 + §17.3.1.13 `w:jc` — a display-math paragraph with no

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -73,6 +73,9 @@ pub struct RunFmt {
     /// renderer uses it to force complex-script shaping and feed the UAX#9
     /// reordering / `ctx.direction = 'rtl'` mirroring pass.
     pub rtl: Option<bool>,
+    /// ECMA-376 §17.3.2.34 `<w:snapToGrid>` — whether this run participates in
+    /// the section character grid. `None` inherits; explicit false opts out.
+    pub snap_to_grid: Option<bool>,
     /// ECMA-376 §17.3.2.7 `<w:cs/>` — treat the run as complex-script,
     /// applying the cs formatting axis to ALL its characters (§17.3.2.26).
     pub cs_toggle: Option<bool>,
@@ -946,6 +949,9 @@ pub(crate) fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
     if src.rtl.is_some() {
         dst.rtl = src.rtl;
     }
+    if src.snap_to_grid.is_some() {
+        dst.snap_to_grid = src.snap_to_grid;
+    }
     // §17.3.2.7 <w:cs/> — complex-script run toggle. Must mirror
     // apply_direct_run; without this arm a style-chain <w:cs/> (set in a
     // paragraph/character style rPr by parse_run_fmt) is silently dropped.
@@ -1464,6 +1470,8 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
 
     // Complex-script / RTL run (ECMA-376 §17.3.2.30 w:rtl). On-off toggle.
     fmt.rtl = bool_prop(rpr, "rtl");
+    // Character-grid participation (ECMA-376 §17.3.2.34 w:snapToGrid).
+    fmt.snap_to_grid = bool_prop(rpr, "snapToGrid");
     // §17.3.2.7 w:cs — complex-script run toggle (distinct from rFonts@cs,
     // which is only a font SLOT and must not force cs formatting).
     fmt.cs_toggle = bool_prop(rpr, "cs");

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1331,6 +1331,10 @@ pub struct TextRun {
     /// Arabic/Hebrew digit ordering). `None` when unspecified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lang_bidi: Option<String>,
+    /// ECMA-376 §17.3.2.34 `<w:snapToGrid>` — run participation in the section
+    /// character grid. `Some(false)` opts this run out; `None` inherits.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snap_to_grid: Option<bool>,
     /// ECMA-376 §17.3.2.35 `<w:spacing w:val>` — character-spacing adjustment in
     /// POINTS (signed): the extra pitch added after each character before the
     /// next. The renderer feeds it to `ctx.letterSpacing` on BOTH the measure and

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -131,6 +131,10 @@ pub struct DocumentSettings {
     /// single-byte and double-byte character widths in East Asian layout.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub balance_single_byte_double_byte_width: Option<bool>,
+    /// §17.15.3.1 `w:compat` / `w:adjustLineHeightInTable` — apply the section
+    /// document-grid line pitch to text in table cells.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adjust_line_height_in_table: Option<bool>,
 }
 
 /// Single track-changes event extracted from a body `<w:ins>` / `<w:del>`.

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1116,6 +1116,9 @@ export interface DocxTextRun {
   /** ECMA-376 §17.3.2.20 `<w:lang w:bidi>` — complex-script (RTL) language tag,
    *  lower-cased (e.g. "ar-sa", "ae-ar"). Drives Word's AN digit ordering. */
   langBidi?: string;
+  /** ECMA-376 §17.3.2.34 `<w:snapToGrid>` — false opts this run out of the
+   *  section character grid; absent inherits participation. */
+  snapToGrid?: boolean;
   /** ECMA-376 §17.3.2.35 `<w:spacing w:val>` — character-spacing adjustment in
    *  POINTS (signed): the extra pitch added after each character before the next
    *  is rendered. The renderer feeds it to `ctx.letterSpacing` on BOTH the

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -88,6 +88,9 @@ export interface DocSettings {
   /** §17.15.3.1 `w:compat/w:balanceSingleByteDoubleByteWidth` — balance
    *  single-byte and double-byte widths for East Asian layout. */
   balanceSingleByteDoubleByteWidth?: boolean;
+  /** §17.15.3.1 `w:compat/w:adjustLineHeightInTable` — apply the section
+   *  document-grid line pitch to text in table cells. */
+  adjustLineHeightInTable?: boolean;
 }
 
 export interface DocRevision {


### PR DESCRIPTION
## Summary

- document the staged layout-context and measured-fragment architecture
- preserve the table line-grid compatibility setting from document settings
- preserve run-level character-grid participation through the style cascade

## Root cause

The parser discarded two OOXML facts required by later layout policy resolution: the document compatibility flag that governs line pitch in table cells, and the run property that opts text out of character-grid spacing. Downstream code therefore could not implement the specification without inferring missing state.

## Result

Both values now survive as optional parser and TypeScript model fields, including explicit false values and character-style inheritance. Absent values remain omitted from serialized output. Renderer behavior is intentionally unchanged in this PR so parser information retention is isolated from later normative layout corrections.

## Specification

- ECMA-376 Part 1 section 17.15.3.1
- ECMA-376 Part 1 section 17.3.2.34

## Verification

- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p docx-parser
- pnpm --filter @silurus/ooxml-docx typecheck
- pnpm vitest run packages/docx/src/line-box-height.test.ts packages/docx/src/docgrid-char.test.ts packages/docx/src/pagination.test.ts packages/docx/src/table-split.test.ts
