### PR TITLE
Correct DOCX document-grid participation

### DIFF
--- a/packages/docx/src/docgrid-char.test.ts
+++ b/packages/docx/src/docgrid-char.test.ts
@@ -88,7 +88,12 @@ type DocRun = DocParagraph['runs'][number];
 
 function para(
   text: string,
-  opts: { fontSize?: number; alignment?: string; runSnapToGrid?: boolean } = {},
+  opts: {
+    fontSize?: number;
+    alignment?: string;
+    runSnapToGrid?: boolean;
+    paragraphSnapToGrid?: boolean;
+  } = {},
 ): BodyElement {
   const fontSize = opts.fontSize ?? FONT_PX;
   const run = textRun(text, fontSize);
@@ -101,6 +106,9 @@ function para(
     defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics',
     widowControl: false, // keep greedy split deterministic
   };
+  if (opts.paragraphSnapToGrid !== undefined) {
+    p.snapToGrid = opts.paragraphSnapToGrid;
+  }
   return { type: 'paragraph', ...p } as BodyElement;
 }
 
@@ -201,6 +209,16 @@ describe('docGrid character grid — measure==draw invariant (§17.6.5)', () => 
     ]);
     expect(rendered.fillTextCalls.map((call) => call.letterSpacing))
       .toEqual(['0px', '0px', '0px']);
+  });
+
+  it('keeps character-grid spacing when only paragraph line snapping is disabled', async () => {
+    const rendered = await renderRun(
+      [para('あ', { paragraphSnapToGrid: false })],
+      section(charGrid(4096)),
+    );
+
+    expect(rendered.runs[0].w).toBe(FONT_PX + 1);
+    expect(rendered.fillTextCalls[0].letterSpacing).toBe('1px');
   });
 
   // THE core anti-corruption guard. For a CJK string under an active char grid,
@@ -395,5 +413,28 @@ describe('docGrid character grid — packs more chars per line (§17.6.5)', () =
     const text = 'あ'.repeat(22);
     const lineGrid = section({ docGridType: 'lines', docGridLinePitch: 20, docGridCharSpace: -8192, ...ONE_LINE_PAGE });
     expect(linesOf(text, lineGrid)).toBe(linesOf(text, section(ONE_LINE_PAGE)));
+  });
+
+  it('uses natural line height for pagination when paragraph grid snapping is disabled', () => {
+    const bodyParagraph = para('あ', {
+      fontSize: 10,
+      paragraphSnapToGrid: false,
+    }) as BodyElement & DocParagraph;
+    bodyParagraph.runs.push(
+      { type: 'break', breakType: 'line' } as DocRun,
+      { type: 'text', ...textRun('あ', 10) } as DocRun,
+    );
+    const sec = section({
+      pageHeight: 25,
+      docGridType: 'lines',
+      docGridLinePitch: 20,
+    });
+
+    const pages = computePages(
+      [bodyParagraph],
+      sec,
+      makeRecordingCanvas().canvas.getContext('2d') as CanvasRenderingContext2D,
+    );
+    expect(pages).toHaveLength(1);
   });
 });

--- a/packages/docx/src/docgrid-char.test.ts
+++ b/packages/docx/src/docgrid-char.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { computePages, renderDocumentToCanvas, type DocxTextRunInfo } from './renderer.js';
+import {
+  segAdvanceWidth,
+  segLetterSpacingPx,
+  type LayoutTextSeg,
+} from './line-layout.js';
 import type {
   BodyElement,
   DocParagraph,
@@ -81,13 +86,18 @@ function textRun(text: string, fontSize: number, fontFamily = 'NotInMetrics'): D
 
 type DocRun = DocParagraph['runs'][number];
 
-function para(text: string, opts: { fontSize?: number; alignment?: string } = {}): BodyElement {
+function para(
+  text: string,
+  opts: { fontSize?: number; alignment?: string; runSnapToGrid?: boolean } = {},
+): BodyElement {
   const fontSize = opts.fontSize ?? FONT_PX;
+  const run = textRun(text, fontSize);
+  if (opts.runSnapToGrid !== undefined) run.snapToGrid = opts.runSnapToGrid;
   const p: DocParagraph = {
     alignment: opts.alignment ?? 'left',
     indentLeft: 0, indentRight: 0, indentFirst: 0,
     spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
-    runs: [{ type: 'text', ...textRun(text, fontSize) } as DocRun],
+    runs: [{ type: 'text', ...run } as DocRun],
     defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics',
     widowControl: false, // keep greedy split deterministic
   };
@@ -144,6 +154,40 @@ async function renderRun(
 }
 
 describe('docGrid character grid — measure==draw invariant (§17.6.5)', () => {
+  it('lets an individual run opt out of character-grid advance and paint spacing', () => {
+    const base: LayoutTextSeg = {
+      text: 'あ',
+      bold: false,
+      italic: false,
+      underline: false,
+      strikethrough: false,
+      fontSize: FONT_PX,
+      color: null,
+      fontFamily: null,
+      vertAlign: null,
+      measuredWidth: 0,
+    };
+    const optedOut = {
+      ...base,
+      snapToCharacterGrid: false,
+    } as unknown as LayoutTextSeg;
+
+    expect(segAdvanceWidth(base, FONT_PX, 1, 1)).toBe(FONT_PX + 1);
+    expect(segAdvanceWidth(optedOut, FONT_PX, 1, 1)).toBe(FONT_PX);
+    expect(segLetterSpacingPx(optedOut, 1, 1)).toBe(0);
+  });
+
+  it('carries run-level character-grid opt-out through measurement and paint', async () => {
+    const sec = section(charGrid(4096));
+    const snapped = await renderRun([para('あ')], sec);
+    const optedOut = await renderRun([para('あ', { runSnapToGrid: false })], sec);
+
+    expect(snapped.runs[0].w).toBe(FONT_PX + 1);
+    expect(snapped.fillTextCalls[0].letterSpacing).toBe('1px');
+    expect(optedOut.runs[0].w).toBe(FONT_PX);
+    expect(optedOut.fillTextCalls[0].letterSpacing).toBe('0px');
+  });
+
   // THE core anti-corruption guard. For a CJK string under an active char grid,
   // the measured segment box (onTextRun.w) and the painted advance must be
   // derived from the SAME per-char cell width fontPx + Δpx. A no-justify pure-EA

--- a/packages/docx/src/docgrid-char.test.ts
+++ b/packages/docx/src/docgrid-char.test.ts
@@ -188,6 +188,21 @@ describe('docGrid character grid — measure==draw invariant (§17.6.5)', () => 
     expect(optedOut.fillTextCalls[0].letterSpacing).toBe('0px');
   });
 
+  it('keeps every segment of an opted-out mixed-script run off the grid', async () => {
+    const rendered = await renderRun(
+      [para('あA本', { runSnapToGrid: false })],
+      section(charGrid(4096)),
+    );
+
+    expect(rendered.runs.map((run) => [run.text, run.w])).toEqual([
+      ['あ', FONT_PX],
+      ['A', FONT_PX],
+      ['本', FONT_PX],
+    ]);
+    expect(rendered.fillTextCalls.map((call) => call.letterSpacing))
+      .toEqual(['0px', '0px', '0px']);
+  });
+
   // THE core anti-corruption guard. For a CJK string under an active char grid,
   // the measured segment box (onTextRun.w) and the painted advance must be
   // derived from the SAME per-char cell width fontPx + Δpx. A no-justify pure-EA
@@ -309,6 +324,18 @@ describe('docGrid character grid — measure==draw invariant (§17.6.5)', () => 
     const seg = runs.find((r) => r.text === text)!;
     // charSpace present but type is "lines" ⇒ the CHARACTER grid is inactive.
     expect(seg.w).toBeCloseTo(n * FONT_PX, 6);
+  });
+
+  it('type="snapToChars" applies the character-grid delta', async () => {
+    const sec = section({
+      docGridType: 'snapToChars',
+      docGridLinePitch: 20,
+      docGridCharSpace: 4096,
+    });
+    const { runs, fillTextCalls } = await renderRun([para('あ')], sec);
+
+    expect(runs[0].w).toBe(FONT_PX + 1);
+    expect(fillTextCalls[0].letterSpacing).toBe('1px');
   });
 
   it('an absent charSpace leaves EA glyphs at natural advance even under linesAndChars', async () => {

--- a/packages/docx/src/layout-context.test.ts
+++ b/packages/docx/src/layout-context.test.ts
@@ -6,6 +6,7 @@ import type {
   SectionProps,
 } from './types.js';
 import {
+  enterTableCellStoryContext,
   resolveDocumentLayoutSettings,
   resolveParagraphLayoutContext,
   resolveRunLayoutContext,
@@ -81,6 +82,18 @@ const cellStory: StoryContext = {
 };
 
 describe('layout context resolvers', () => {
+  it('preserves nested table-cell container depth', () => {
+    const outerCell = enterTableCellStoryContext(bodyStory);
+    const innerCell = enterTableCellStoryContext(outerCell);
+
+    expect(outerCell.containers).toEqual([{ kind: 'tableCell' }]);
+    expect(innerCell.containers).toEqual([
+      { kind: 'tableCell' },
+      { kind: 'tableCell' },
+    ]);
+    expect(innerCell.lineNumberingEligible).toBe(false);
+  });
+
   it('normalizes document settings and detects East Asian body text once', () => {
     const run = textRun({ text: 'あ' });
     const settings = resolveDocumentLayoutSettings(documentModel({

--- a/packages/docx/src/layout-context.ts
+++ b/packages/docx/src/layout-context.ts
@@ -65,6 +65,14 @@ export interface StoryContext {
   readonly lineNumberingEligible: boolean;
 }
 
+export function enterTableCellStoryContext(parent: StoryContext): StoryContext {
+  return {
+    story: parent.story,
+    containers: [...parent.containers, { kind: 'tableCell' }],
+    lineNumberingEligible: false,
+  };
+}
+
 export interface LineGridPolicy {
   readonly active: boolean;
   readonly pitchPt: number | null;

--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -12,6 +12,11 @@ import type { LineSpacing } from './types.js';
 
 const exact = (value: number): LineSpacing => ({ value, rule: 'exact', explicit: true });
 const auto = (value: number): LineSpacing => ({ value, rule: 'auto', explicit: true });
+const atLeast = (value: number): LineSpacing => ({
+  value,
+  rule: 'atLeast',
+  explicit: true,
+});
 
 describe('lineBoxHeight — degenerate zero line spacing', () => {
   // ascent 12 + descent 3 = 15px natural single-line height (no grid).
@@ -52,6 +57,18 @@ describe('lineBoxHeight — snapToChars line-grid participation', () => {
 
   it('applies the line pitch as well as the character-grid behavior', () => {
     expect(lineBoxHeight(null, 8, 2, 1, grid20, false, 0, true)).toBe(20);
+  });
+});
+
+describe('lineBoxHeight — atLeast with an active line grid', () => {
+  const grid20 = { type: 'lines', linePitchPt: 20 } as const;
+
+  it('retains the active grid minimum when the authored minimum is smaller', () => {
+    expect(lineBoxHeight(atLeast(18), 10, 2, 1, grid20)).toBe(20);
+  });
+
+  it('retains the authored minimum when it is larger than the grid minimum', () => {
+    expect(lineBoxHeight(atLeast(24), 10, 2, 1, grid20)).toBe(24);
   });
 });
 

--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { lineBoxHeight } from './line-layout.js';
+import { isGridLineRule, lineBoxHeight } from './line-layout.js';
 import type { LineSpacing } from './types.js';
 
 // Regression: some generators emit <w:spacing w:line="0" w:lineRule="exact"/> on
@@ -40,6 +40,18 @@ describe('lineBoxHeight — degenerate zero line spacing', () => {
   });
   it('unspecified spacing is single (natural)', () => {
     expect(lineBoxHeight(null, 12, 3, 1, undefined)).toBe(15);
+  });
+});
+
+describe('lineBoxHeight — snapToChars line-grid participation', () => {
+  const grid20 = { type: 'snapToChars', linePitchPt: 20 } as const;
+
+  it('recognizes snapToChars as an active line-grid rule', () => {
+    expect(isGridLineRule(grid20)).toBe(true);
+  });
+
+  it('applies the line pitch as well as the character-grid behavior', () => {
+    expect(lineBoxHeight(null, 8, 2, 1, grid20, false, 0, true)).toBe(20);
   });
 });
 

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -115,6 +115,9 @@ export interface LayoutTextSeg {
    *  overlay can build a clickable region; it does NOT affect measurement, line
    *  breaking, or the drawn glyphs. Absent for a non-link run. */
   hyperlink?: HyperlinkTarget;
+  /** ECMA-376 §17.3.2.34 `<w:snapToGrid>` — false opts this run out of the
+   *  section character grid without changing paragraph line-grid policy. */
+  snapToCharacterGrid?: boolean;
   /** ECMA-376 §17.3.2.35 `<w:spacing>` — character-spacing pitch in POINTS
    *  (signed), added after every character of the run. Applied as a per-glyph
    *  `ctx.letterSpacing` delta on BOTH measure and paint (measure==paint), on top
@@ -667,6 +670,14 @@ export function gridWidth(naturalWidthPx: number, text: string, deltaPx: number)
   return naturalWidthPx + gridSegDeltaPx(text, deltaPx);
 }
 
+/** Resolve the per-glyph character-grid delta for one text segment. */
+export function segmentCharacterGridDeltaPx(
+  seg: LayoutTextSeg,
+  gridDeltaPx: number,
+): number {
+  return seg.snapToCharacterGrid === false ? 0 : gridDeltaPx;
+}
+
 /** ECMA-376 §17.3.2.35 `<w:spacing>` — the per-GLYPH character-spacing pitch in
  *  px for a segment (its authored points × the paint scale). Unlike the docGrid
  *  delta this applies to EVERY code point of the run, not just East-Asian ones
@@ -698,7 +709,8 @@ export function segLetterSpacingPx(
   gridDeltaPx: number,
   scale: number,
 ): number {
-  const grid = gridSegDeltaPx(seg.text, gridDeltaPx) === 0 ? 0 : gridDeltaPx;
+  const segmentDelta = segmentCharacterGridDeltaPx(seg, gridDeltaPx);
+  const grid = gridSegDeltaPx(seg.text, segmentDelta) === 0 ? 0 : segmentDelta;
   return grid + charSpacingDeltaPx(seg, scale);
 }
 
@@ -724,7 +736,8 @@ export function segAdvanceWidth(
   // logical-horizontal advance IS the vertical column advance after the page
   // rotation — see vertical-text.ts and renderer's page transform.)
   if (seg.tateChuYoko) return seg.fontSize * scale;
-  const scaled = naturalWidthPx * charScaleFactor(seg) + gridSegDeltaPx(seg.text, gridDeltaPx);
+  const segmentDelta = segmentCharacterGridDeltaPx(seg, gridDeltaPx);
+  const scaled = naturalWidthPx * charScaleFactor(seg) + gridSegDeltaPx(seg.text, segmentDelta);
   const cpCount = [...seg.text].length;
   return scaled + cpCount * charSpacingDeltaPx(seg, scale);
 }
@@ -1715,6 +1728,7 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         // IX1 — resolved hyperlink target of the originating run, for the
         // text-layer clickable overlay. Does not affect layout or drawing.
         hyperlink,
+        snapToCharacterGrid: r.snapToGrid !== false,
         // WD4 — run character metrics (§17.3.2.35 spacing / §17.3.2.43 w /
         // §17.3.2.24 position / §17.3.2.19 kern). Uniform across the run, so
         // every emitted segment carries the same values; the measure and paint
@@ -2250,7 +2264,8 @@ export function layoutLines(
     const prevKern = setSegKerning(s);
     const natural = ctx.measureText(text).width;
     restoreKerning(prevKern);
-    const scaled = natural * charScaleFactor(s) + gridSegDeltaPx(text, gridDeltaPx);
+    const segmentDelta = segmentCharacterGridDeltaPx(s, gridDeltaPx);
+    const scaled = natural * charScaleFactor(s) + gridSegDeltaPx(text, segmentDelta);
     return scaled + [...text].length * charSpacingDeltaPx(s, scale);
   };
 
@@ -2644,7 +2659,7 @@ export function layoutLines(
       //  binary-search + the cross-run 追い出し below. Don't naively unify them.)
       const available = availW() - currentWidth;
       ctx.font = buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses);
-      const rawPrefix = available > 0 ? fitCJKPrefix(ctx, s.text, available, gridDeltaPx, charScaleFactor(s), charSpacingDeltaPx(s, scale)) : '';
+      const rawPrefix = available > 0 ? fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), charScaleFactor(s), charSpacingDeltaPx(s, scale)) : '';
       // Apply kinsoku to the break position: retract leftwards so the tail
       // never begins with a 行頭禁則 char and the head never ends with a
       // 行末禁則 char (ECMA-376 §17.15.1.58–.60). When the current line
@@ -2722,7 +2737,7 @@ export function layoutLines(
       const available = availW();
       ctx.font = buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses);
       const allChars = [...s.text];
-      let split = available > 0 ? [...fitCJKPrefix(ctx, s.text, available, gridDeltaPx, charScaleFactor(s), charSpacingDeltaPx(s, scale))].length : 0;
+      let split = available > 0 ? [...fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), charScaleFactor(s), charSpacingDeltaPx(s, scale))].length : 0;
       if (split < 1) split = 1;
       if (split >= allChars.length) {
         // The visible glyphs actually fit (only a trailing space pushed it over the
@@ -2802,7 +2817,11 @@ export function rescaleLayoutLines(
     const effPx = calcEffectiveFontPx(s, scale);
     ctx.font = buildFont(s.bold, s.italic, effPx, s.fontFamily, fontFamilyClasses);
     const m = ctx.measureText(s.text);
-    const advance = gridWidth(m.width, s.text, gridDeltaPx);
+    const advance = gridWidth(
+      m.width,
+      s.text,
+      segmentCharacterGridDeltaPx(s, gridDeltaPx),
+    );
     // §17.3.2.33 — a small-caps run's LINE BOX follows the FULL run size (measure
     // the box at fullPx, not the 2pt-reduced glyphs); super/subscript keeps its
     // shrunk contribution. Mirrors layoutLines' fullPx / metricEmPx split.

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -758,7 +758,7 @@ export function isGridLineRule(ctx: DocGridCtx | undefined): boolean {
  *             multiplier applies against the grid pitch instead, with a
  *             floor of the natural line height.
  *   exact   → value in pt, converted to px (ignores font and grid).
- *   atLeast → max(natural, value in pt × scale).
+ *   atLeast → max(natural, authored minimum, active grid minimum).
  *   null    → natural, or grid pitch if the section defines one.
  *
  * Exported for unit tests only — not part of the package API (not
@@ -845,7 +845,13 @@ export function lineBoxHeight(
     return natural * ls.value;
   }
   if (ls.rule === 'exact') return ls.value * scale;
-  if (ls.rule === 'atLeast') return Math.max(natural, ls.value * scale);
+  if (ls.rule === 'atLeast') {
+    return Math.max(
+      natural,
+      ls.value * scale,
+      hasGrid ? gridSingleCell() : 0,
+    );
+  }
   return natural;
 }
 

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -744,7 +744,9 @@ export function segAdvanceWidth(
 
 export function isGridLineRule(ctx: DocGridCtx | undefined): boolean {
   if (!ctx || !ctx.linePitchPt || ctx.linePitchPt <= 0) return false;
-  return ctx.type === 'lines' || ctx.type === 'linesAndChars';
+  return ctx.type === 'lines'
+    || ctx.type === 'linesAndChars'
+    || ctx.type === 'snapToChars';
 }
 
 /**
@@ -752,7 +754,7 @@ export function isGridLineRule(ctx: DocGridCtx | undefined): boolean {
  * (fontBoundingBoxAscent + fontBoundingBoxDescent) per ECMA-376 §17.3.1.33.
  *
  *   auto    → natural × value ("single" = 1 natural line, "double" = 2).
- *             When docGrid type=lines|linesAndChars is active, the
+ *             When the docGrid line axis is active, the
  *             multiplier applies against the grid pitch instead, with a
  *             floor of the natural line height.
  *   exact   → value in pt, converted to px (ignores font and grid).

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3751,10 +3751,10 @@ function gridForParagraphContext(
 }
 
 function paraGrid(para: DocParagraph, state: RenderState): DocGridCtx {
-  if (state.storyContext?.containers.some((container) => container.kind === 'tableCell')) {
-    return gridForParagraphContext(state, resolveStateParagraphLayoutContext(state, para));
-  }
-  return para.snapToGrid === false ? { type: null, linePitchPt: null } : state.docGrid;
+  return gridForParagraphContext(
+    state,
+    resolveStateParagraphLayoutContext(state, para),
+  );
 }
 
 /** Lay out a paragraph's lines, then walk the line list distributing them
@@ -3853,6 +3853,7 @@ function splitParagraphAcrossPages(
   // the paint pass (layoutBidiTabStops measures stops from the text margin)
   // and re-introduce a paginate/render disagreement.
   const paragraphContext = resolveBodyParagraphLayoutContext(measureState, para);
+  const grid = paraGrid(para, measureState);
   const indLeft = paragraphContext.physicalIndentLeftPt;
   const indRight = paragraphContext.physicalIndentRightPt;
   const paraW = Math.max(1, contentWPt - indLeft - indRight);
@@ -3882,10 +3883,10 @@ function splitParagraphAcrossPages(
     startPageY: measureState.y,
     paraX,
     floats: measureState.floats,
-    lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, measureState.docGrid, paragraphContext.hasRuby, is ?? 0, paragraphContext.hasEastAsianText),
+    lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, grid, paragraphContext.hasRuby, is ?? 0, paragraphContext.hasEastAsianText),
     pageH: measureState.pageH,
   } : undefined;
-  const lines = layoutLines(measureState.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, measureState.fontFamilyClasses, indLeft, measureState.kinsoku, gridCharDeltaPx(paraGrid(para, measureState), 1), measureState.defaultTabPt, paraW + indRight, para.bidi === true);
+  const lines = layoutLines(measureState.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, measureState.fontFamilyClasses, indLeft, measureState.kinsoku, gridCharDeltaPx(grid, 1), measureState.defaultTabPt, paraW + indRight, para.bidi === true);
   if (lines.length === 0) {
     // Anchor-only paragraph: no inline lines, but the paragraph mark still
     // occupies one (possibly relocated) line (§17.3.1.29).
@@ -3899,9 +3900,9 @@ function splitParagraphAcrossPages(
   // See paragraphSegsStateSensitive.
   const stampLines = !paragraphSegsStateSensitive(para);
 
-  const perLineH = (l: typeof lines[number]) => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, measureState.docGrid, paraHasRuby, l.intendedSingle, paragraphContext.hasEastAsianText);
+  const perLineH = (l: typeof lines[number]) => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, grid, paraHasRuby, l.intendedSingle, paragraphContext.hasEastAsianText);
   const uniformH = paraHasRuby
-    ? snapParaLineToGrid(Math.max(0, ...lines.map(perLineH)), measureState.docGrid, 1)
+    ? snapParaLineToGrid(Math.max(0, ...lines.map(perLineH)), grid, 1)
     : 0;
   const lineHeights = lines.map(l => paraHasRuby ? uniformH : perLineH(l));
   const spaceBefore = suppressSpaceBefore ? 0 : para.spaceBefore;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -294,6 +294,8 @@ export interface RenderState {
   layoutSettings: DocumentLayoutSettings;
   /** Active section geometry and grid policy normalized for this state. */
   sectionLayout: SectionLayoutContext;
+  /** Active WordprocessingML story and nested text-container stack. */
+  storyContext: StoryContext;
   /** True when the document body contains East Asian text. Gates docGrid line-
    *  cell rounding of empty / anchor-only paragraph marks (see
    *  paragraphMarkLineHeight), which carry no text to classify themselves. */
@@ -433,6 +435,15 @@ const BODY_STORY_CONTEXT: StoryContext = {
   lineNumberingEligible: true,
 };
 
+function tableCellStoryContext(state: Pick<RenderState, 'storyContext'>): StoryContext {
+  const parent = state.storyContext ?? BODY_STORY_CONTEXT;
+  return {
+    story: parent.story,
+    containers: [...parent.containers, { kind: 'tableCell' }],
+    lineNumberingEligible: false,
+  };
+}
+
 export function resolveBodyParagraphLayoutContext(
   state: Pick<RenderState, 'layoutSettings' | 'sectionLayout'>,
   paragraph: DocParagraph,
@@ -441,6 +452,30 @@ export function resolveBodyParagraphLayoutContext(
     state.layoutSettings,
     state.sectionLayout,
     BODY_STORY_CONTEXT,
+    paragraph,
+  );
+}
+
+function resolveStateParagraphLayoutContext(
+  state: Pick<RenderState, 'layoutSettings' | 'sectionLayout' | 'storyContext'>,
+  paragraph: DocParagraph,
+): ParagraphLayoutContext {
+  return resolveParagraphLayoutContext(
+    state.layoutSettings,
+    state.sectionLayout,
+    state.storyContext ?? BODY_STORY_CONTEXT,
+    paragraph,
+  );
+}
+
+function resolveTableCellParagraphLayoutContext(
+  state: Pick<RenderState, 'layoutSettings' | 'sectionLayout' | 'storyContext'>,
+  paragraph: DocParagraph,
+): ParagraphLayoutContext {
+  return resolveParagraphLayoutContext(
+    state.layoutSettings,
+    state.sectionLayout,
+    tableCellStoryContext(state),
     paragraph,
   );
 }
@@ -1268,6 +1303,7 @@ export async function renderDocumentToCanvas(
     docGrid: toLegacyDocGridContext(sectionLayout),
     layoutSettings,
     sectionLayout,
+    storyContext: BODY_STORY_CONTEXT,
     docEastAsian: layoutSettings.documentHasEastAsianText,
     fontFamilyClasses: doc.fontFamilyClasses ?? {},
     kinsoku,
@@ -3570,6 +3606,7 @@ function buildMeasureState(
     docGrid: toLegacyDocGridContext(sectionLayout),
     layoutSettings,
     sectionLayout,
+    storyContext: BODY_STORY_CONTEXT,
     docEastAsian: layoutSettings.documentHasEastAsianText,
     fontFamilyClasses,
     kinsoku: layoutSettings.kinsoku,
@@ -3711,7 +3748,22 @@ function snapParaLineToGrid(h: number, grid: DocGridCtx | undefined, scale: numb
 /** The docGrid that governs a paragraph's line heights. ECMA-376 §17.3.1.32:
  *  a paragraph with `w:snapToGrid` explicitly off ignores the section grid, so
  *  its lines use natural font metrics / the spacing multiplier directly. */
+function gridForParagraphContext(
+  state: Pick<RenderState, 'docGrid'>,
+  context: ParagraphLayoutContext,
+): DocGridCtx {
+  return {
+    type: state.docGrid.type,
+    linePitchPt: context.lineGrid.active ? context.lineGrid.pitchPt : null,
+    charSpacePt:
+      context.characterGrid.active ? context.characterGrid.deltaPt : null,
+  };
+}
+
 function paraGrid(para: DocParagraph, state: RenderState): DocGridCtx {
+  if (state.storyContext?.containers.some((container) => container.kind === 'tableCell')) {
+    return gridForParagraphContext(state, resolveStateParagraphLayoutContext(state, para));
+  }
   return para.snapToGrid === false ? { type: null, linePitchPt: null } : state.docGrid;
 }
 
@@ -4403,8 +4455,8 @@ function layoutCellParagraphForRowSplit(
 ): { lines: LayoutLine[]; lineHeights: number[]; inputs: Parameters<typeof stampParagraphLines>[2] } | null {
   const segs = buildSegments(para.runs, state);
   if (segs.length === 0) return null;
-  const grid = paraGrid(para, state);
-  const paragraphContext = resolveBodyParagraphLayoutContext(state, para);
+  const paragraphContext = resolveTableCellParagraphLayoutContext(state, para);
+  const grid = gridForParagraphContext(state, paragraphContext);
   const paraHasRuby = paragraphContext.hasRuby;
   const indLeft = paragraphContext.physicalIndentLeftPt;
   const indRight = paragraphContext.physicalIndentRightPt;
@@ -5972,7 +6024,7 @@ function renderParagraph(
   borderMerge?: ParaBorderMerge,
 ): void {
   const { ctx, scale, contentX, contentW, defaultColor, dryRun, fontFamilyClasses } = state;
-  const paragraphContext = resolveBodyParagraphLayoutContext(state, para);
+  const paragraphContext = resolveStateParagraphLayoutContext(state, para);
   // Capture Y before spaceBefore — used for paragraph-relative anchor image positioning
   const paragraphStartY = state.y;
 
@@ -9697,9 +9749,9 @@ function measureParaHeight(
   scale: number,
 ): number {
   const segs = buildSegments(para.runs, state);
-  const paragraphContext = resolveBodyParagraphLayoutContext(state, para);
+  const paragraphContext = resolveTableCellParagraphLayoutContext(state, para);
   const paraHasRuby = paragraphContext.hasRuby;
-  const grid = paraGrid(para, state);
+  const grid = gridForParagraphContext(state, paragraphContext);
   if (segs.length === 0) {
     // ECMA-376 §17.3.1.29: an empty (or anchor-only) paragraph still produces one
     // paragraph-mark line box. Size it with the SAME `paragraphMarkLineHeight`
@@ -9923,6 +9975,7 @@ function renderCell(
     contentX: x + ml,
     contentW: w - ml - mr,
     y: y + mt,
+    storyContext: tableCellStoryContext(state),
     // ECMA-376 §17.6.8 numbers the MAIN document story only — table-cell lines are
     // never numbered. Clear any inherited line-numbering config/counter.
     lineNumbering: undefined,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -139,6 +139,7 @@ import {
   rescaleLayoutLines,
   shapeRenderState,
   shapeRunToDocRun,
+  segmentCharacterGridDeltaPx,
   splitTextForLayout,
 } from './line-layout.js';
 import type {
@@ -6940,7 +6941,8 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
         //   2. Justified inter-CJK pitch only (no grid): the existing
         //      `justifiedPiecePositions` slice-at-gaps path.
         //   3. Neither: a single fillText (the common path).
-        const segGridDelta = gridSegDeltaPx(s.text, drawGridDeltaPx);
+        const segmentGridDeltaPx = segmentCharacterGridDeltaPx(s, drawGridDeltaPx);
+        const segGridDelta = gridSegDeltaPx(s.text, segmentGridDeltaPx);
         if (state.verticalCJK && s.tateChuYoko) {
           // ECMA-376 §17.3.2.10 縦中横 (horizontal-in-vertical): draw the whole run
           // horizontally, side by side, inside ONE cell of the vertical column.
@@ -6973,7 +6975,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             x,
             baseline + yOffset,
             effSizePx,
-            segGridDelta !== 0 ? drawGridDeltaPx : 0,
+            segGridDelta !== 0 ? segmentGridDeltaPx : 0,
           );
         } else if (segGridDelta !== 0) {
           const cps = [...s.text]; // code points (handles surrogate pairs)
@@ -7003,7 +7005,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           // includes the accumulated pitch of the glyphs before it) and as
           // `ctx.letterSpacing` (so the canvas adds it WITHIN each piece) —
           // together glyph i lands at measure(prefix)+i·pitch (measure==paint).
-          const gridPlusSpacing = drawGridDeltaPx + segCharSpacingPx;
+          const gridPlusSpacing = segmentGridDeltaPx + segCharSpacingPx;
           // ECMA-376 §17.3.2.43 `<w:w>` (issue #816): the MEASURE pass scaled the
           // natural glyph advance by `segCharScale` (segAdvanceWidth) but left the
           // fixed per-cell pitches (grid delta, char spacing, justify slack)
@@ -7177,7 +7179,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             stretch.splitBefore.length === [...s.text].length - 1;
           const markPitch =
             segGridDelta !== 0
-              ? drawGridDeltaPx
+              ? segmentGridDeltaPx
               : fullyDistributed
                 ? distPerGap
                 : 0;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -129,6 +129,7 @@ import {
   gridCharDeltaPx,
   gridSegDeltaPx,
   hasCJKBreakOpportunity,
+  isGridLineRule,
   kinsokuRulesEquivalent,
   layoutLines,
   lineBoxHeight,
@@ -3734,9 +3735,8 @@ function estimateParagraphHeight(
  *  the grid pitch widens to accommodate the tallest required line, and
  *  every line in the paragraph then uses that widened pitch. */
 function snapParaLineToGrid(h: number, grid: DocGridCtx | undefined, scale: number): number {
-  if (!grid || !grid.linePitchPt || grid.linePitchPt <= 0) return h;
-  if (grid.type !== 'lines' && grid.type !== 'linesAndChars') return h;
-  const pitchPx = grid.linePitchPt * scale;
+  if (!isGridLineRule(grid)) return h;
+  const pitchPx = grid!.linePitchPt! * scale;
   if (pitchPx <= 0) return h;
   if (h <= pitchPx) return pitchPx;
   return Math.ceil(h / pitchPx) * pitchPx;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -102,6 +102,7 @@ import {
 } from './table-geometry.js';
 import {
   computeSectionColumns as computeColumns,
+  enterTableCellStoryContext,
   resolveDocumentLayoutSettings,
   resolveParagraphLayoutContext,
   resolveSectionLayoutContext,
@@ -437,15 +438,6 @@ const BODY_STORY_CONTEXT: StoryContext = {
   lineNumberingEligible: true,
 };
 
-function tableCellStoryContext(state: Pick<RenderState, 'storyContext'>): StoryContext {
-  const parent = state.storyContext ?? BODY_STORY_CONTEXT;
-  return {
-    story: parent.story,
-    containers: [...parent.containers, { kind: 'tableCell' }],
-    lineNumberingEligible: false,
-  };
-}
-
 export function resolveBodyParagraphLayoutContext(
   state: Pick<RenderState, 'layoutSettings' | 'sectionLayout'>,
   paragraph: DocParagraph,
@@ -470,16 +462,13 @@ function resolveStateParagraphLayoutContext(
   );
 }
 
-function resolveTableCellParagraphLayoutContext(
-  state: Pick<RenderState, 'layoutSettings' | 'sectionLayout' | 'storyContext'>,
-  paragraph: DocParagraph,
-): ParagraphLayoutContext {
-  return resolveParagraphLayoutContext(
-    state.layoutSettings,
-    state.sectionLayout,
-    tableCellStoryContext(state),
-    paragraph,
-  );
+function withTableCellStory(state: RenderState): RenderState {
+  return {
+    ...state,
+    storyContext: enterTableCellStoryContext(
+      state.storyContext ?? BODY_STORY_CONTEXT,
+    ),
+  };
 }
 
 /** Information about a rendered text segment for building a transparent selection overlay. */
@@ -4456,7 +4445,7 @@ function layoutCellParagraphForRowSplit(
 ): { lines: LayoutLine[]; lineHeights: number[]; inputs: Parameters<typeof stampParagraphLines>[2] } | null {
   const segs = buildSegments(para.runs, state);
   if (segs.length === 0) return null;
-  const paragraphContext = resolveTableCellParagraphLayoutContext(state, para);
+  const paragraphContext = resolveStateParagraphLayoutContext(state, para);
   const grid = gridForParagraphContext(state, paragraphContext);
   const paraHasRuby = paragraphContext.hasRuby;
   const indLeft = paragraphContext.physicalIndentLeftPt;
@@ -4768,6 +4757,7 @@ function splitRowByCellLines(
   let ci = 0;
 
   for (const cell of row.cells) {
+    const cellState = withTableCellStory(state);
     const span = Math.min(cell.colSpan, colWidthsPt.length - ci);
     const cellWPt = colWidthsPt.slice(ci, ci + span).reduce((s, w) => s + w, 0);
     ci += span;
@@ -4777,7 +4767,7 @@ function splitRowByCellLines(
       trimTrailingStructuralMarker(cell.content),
       cellWPt - margins.left - margins.right,
       maxContentH,
-      state,
+      cellState,
     );
     if (!split) return null;
     beforeCells.push({ ...cell, content: split.before });
@@ -7437,7 +7427,7 @@ type PaginatedElementWithLines = PaginatedBodyElement & {
  *  that produced them onto the paragraph object, so the paint pass can reuse the
  *  wrap partition instead of re-running {@link layoutLines} (compute-once). Used
  *  by both the BODY split path ({@link splitParagraphAcrossPages}, Stage 1) and
- *  the table-CELL measure path ({@link measureParaHeight}, T2). Only ever called
+ *  the table-CELL measure path ({@link measureCellParagraphHeight}, T2). Only ever called
  *  at scale 1 (the paginator's pt space), so every recorded number is already in
  *  pt and the paint gate compares against it without rescaling — see the
  *  self-verifying reuse gate in {@link renderParagraph}, which fires ONLY when its
@@ -9313,6 +9303,7 @@ function measureCellContentHeightPx(
   scale: number,
   state: RenderState,
 ): number {
+  const cellState = withTableCellStory(state);
   const cm = effCellMargins(cell, table);
   const contentW = cellW - (cm.left + cm.right) * scale;
   // ECMA-376 §17.4.7 requires every <w:tc> to end with a <w:p>. When the cell's
@@ -9332,7 +9323,7 @@ function measureCellContentHeightPx(
   // paint pass's renderCellContent. Spacing is converted from pt to px with `scale`.
   return (cm.top + cm.bottom) * scale + sumCellContentHeight(
     measured,
-    (ce) => measureCellElementHeight(state, ce, contentW, scale),
+    (ce) => measureCellElementHeight(cellState, ce, contentW, scale),
     scale,
   );
 }
@@ -9744,14 +9735,14 @@ export function calculateRowHeight(
   );
 }
 
-function measureParaHeight(
+function measureCellParagraphHeight(
   state: RenderState,
   para: DocParagraph,
   maxWidth: number,
   scale: number,
 ): number {
   const segs = buildSegments(para.runs, state);
-  const paragraphContext = resolveTableCellParagraphLayoutContext(state, para);
+  const paragraphContext = resolveStateParagraphLayoutContext(state, para);
   const paraHasRuby = paragraphContext.hasRuby;
   const grid = gridForParagraphContext(state, paragraphContext);
   if (segs.length === 0) {
@@ -9838,7 +9829,7 @@ function measureParaHeight(
   // as `contentW/scale − ind…`. The paint-scale calls of this function
   // (vAlign-centering measure in renderCell, and the dryRun measureCellContent
   // path) MUST NOT overwrite the scale-1 stamp with paint-scale lines, so they are
-  // skipped here. `hasFloats` is always false: measureParaHeight passes `undefined`
+  // skipped here. `hasFloats` is always false: measureCellParagraphHeight passes `undefined`
   // for the layoutLines wrap context (cell paragraphs are never wrapped around
   // floats in the measure), and when a cell is painted inside a live float band
   // renderParagraph takes its float path (case 3) and ignores this no-float stamp.
@@ -9854,7 +9845,7 @@ function measureParaHeight(
   // paragraphs (page/numPages fields, note refs) are excluded exactly as the body
   // stamp excludes them — their segment text resolves against the real paint page.
   // Nested tables recurse through the same path (measureCellElementHeight →
-  // estimateTableHeight → measureParaHeight at scale 1), so their inner cell
+  // estimateTableHeight → measureCellParagraphHeight at scale 1), so their inner cell
   // paragraphs get stamped and reused by the same mechanism.
   if (scale === 1 && !paragraphSegsStateSensitive(para)) {
     stampParagraphLines(para, lines, {
@@ -9906,12 +9897,13 @@ function measureCellContent(
   scale: number,
   state: RenderState,
 ): void {
+  const cellState = withTableCellStory(state);
   const cm = effCellMargins(cell, table);
   const ml = cm.left * scale;
   const mr = cm.right * scale;
   const innerW = cellW - ml - mr;
   for (const ce of cell.content) {
-    measureCellElementHeight(state, ce, innerW, scale);
+    measureCellElementHeight(cellState, ce, innerW, scale);
   }
 }
 
@@ -9930,7 +9922,7 @@ function measureCellElementHeight(
     // content clears a drawn bottom border. Mirror it here, or a bordered cell
     // paragraph paints taller than the cell measures (B2: single measurer).
     // renderCellContent never passes a borderMerge, so no suppression term.
-    return measureParaHeight(state, para, innerWPx, scale)
+    return measureCellParagraphHeight(state, para, innerWPx, scale)
       + (para.spaceBefore + Math.max(para.spaceAfter, bottomBorderExtentPt(para.borders))) * scale;
   }
   // Nested table — estimateTableHeight works in pt; convert to px.
@@ -9977,7 +9969,9 @@ function renderCell(
     contentX: x + ml,
     contentW: w - ml - mr,
     y: y + mt,
-    storyContext: tableCellStoryContext(state),
+    storyContext: enterTableCellStoryContext(
+      state.storyContext ?? BODY_STORY_CONTEXT,
+    ),
     // ECMA-376 §17.6.8 numbers the MAIN document story only — table-cell lines are
     // never numbered. Clear any inherited line-numbering config/counter.
     lineNumbering: undefined,

--- a/packages/docx/src/table-cell-docgrid.test.ts
+++ b/packages/docx/src/table-cell-docgrid.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveSectionLayoutContext,
+  toLegacyDocGridContext,
+  type DocumentLayoutSettings,
+} from './layout-context.js';
+import { calculateRowHeight } from './renderer.js';
+import type {
+  DocParagraph,
+  DocTable,
+  DocTableCell,
+  DocTableRow,
+} from './types.js';
+
+type MeasureState = Parameters<typeof calculateRowHeight>[4];
+
+function makeMeasureState(adjustLineHeightInTable: boolean): MeasureState {
+  let font = '10px serif';
+  const ctx = {
+    get font() {
+      return font;
+    },
+    set font(value: string) {
+      font = value;
+    },
+    letterSpacing: '0px',
+    measureText: (text: string) => ({
+      width: [...text].length * 10,
+      fontBoundingBoxAscent: 8,
+      fontBoundingBoxDescent: 2,
+      actualBoundingBoxAscent: 8,
+      actualBoundingBoxDescent: 2,
+    }) as TextMetrics,
+    save() {},
+    restore() {},
+  };
+  const kinsoku = {
+    enabled: false,
+    lineStartForbidden: new Set<number>(),
+    lineEndForbidden: new Set<number>(),
+  };
+  const layoutSettings: DocumentLayoutSettings = {
+    kinsoku,
+    defaultTabPt: 36,
+    documentHasEastAsianText: true,
+    compat: {
+      adjustLineHeightInTable,
+      useFeLayout: false,
+      balanceSingleByteDoubleByteWidth: false,
+    },
+  };
+  const sectionLayout = resolveSectionLayoutContext(layoutSettings, {
+    pageWidth: 200,
+    pageHeight: 300,
+    marginTop: 20,
+    marginRight: 20,
+    marginBottom: 20,
+    marginLeft: 20,
+    headerDistance: 10,
+    footerDistance: 10,
+    titlePage: false,
+    evenAndOddHeaders: false,
+    docGridType: 'lines',
+    docGridLinePitch: 20,
+  });
+
+  return {
+    ctx: ctx as unknown as CanvasRenderingContext2D,
+    scale: 1,
+    fontFamilyClasses: {},
+    docGrid: toLegacyDocGridContext(sectionLayout),
+    layoutSettings,
+    sectionLayout,
+    docEastAsian: true,
+    kinsoku,
+    defaultTabPt: 36,
+  } as unknown as MeasureState;
+}
+
+function paragraph(): DocParagraph {
+  return {
+    alignment: 'left',
+    indentLeft: 0,
+    indentRight: 0,
+    indentFirst: 0,
+    spaceBefore: 0,
+    spaceAfter: 0,
+    lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    runs: [{
+      type: 'text',
+      text: 'あ',
+      bold: false,
+      italic: false,
+      underline: false,
+      strikethrough: false,
+      fontSize: 10,
+      color: null,
+      fontFamily: 'serif',
+      fontFamilyEastAsia: 'serif',
+      isLink: false,
+      background: null,
+      vertAlign: null,
+      hyperlink: null,
+    }],
+    defaultFontSize: 10,
+    defaultFontFamily: 'serif',
+    widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function cell(): DocTableCell {
+  return {
+    content: [{ type: 'paragraph', ...paragraph() }],
+    colSpan: 1,
+    vMerge: null,
+    borders: {
+      top: null,
+      bottom: null,
+      left: null,
+      right: null,
+      insideH: null,
+      insideV: null,
+    },
+    background: null,
+    vAlign: 'top',
+    widthPt: 100,
+    marginTop: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    marginRight: 0,
+  } as unknown as DocTableCell;
+}
+
+function row(): DocTableRow {
+  return {
+    cells: [cell()],
+    rowHeight: null,
+    rowHeightRule: 'auto',
+    isHeader: false,
+  } as unknown as DocTableRow;
+}
+
+function table(): DocTable {
+  return {
+    colWidths: [100],
+    rows: [],
+    borders: {
+      top: null,
+      bottom: null,
+      left: null,
+      right: null,
+      insideH: null,
+      insideV: null,
+    },
+    cellMarginTop: 0,
+    cellMarginBottom: 0,
+    cellMarginLeft: 0,
+    cellMarginRight: 0,
+    jc: 'left',
+  } as unknown as DocTable;
+}
+
+describe('table-cell line grid compatibility', () => {
+  it('keeps cell text at natural height when compatibility is disabled', () => {
+    expect(calculateRowHeight(row(), table(), [100], 1, makeMeasureState(false))).toBe(10);
+  });
+
+  it('applies the section line pitch when compatibility is enabled', () => {
+    expect(calculateRowHeight(row(), table(), [100], 1, makeMeasureState(true))).toBe(20);
+  });
+});

--- a/packages/docx/src/table-cell-docgrid.test.ts
+++ b/packages/docx/src/table-cell-docgrid.test.ts
@@ -14,7 +14,10 @@ import type {
 
 type MeasureState = Parameters<typeof calculateRowHeight>[4];
 
-function makeMeasureState(adjustLineHeightInTable: boolean): MeasureState {
+function makeMeasureState(
+  adjustLineHeightInTable: boolean,
+  docGridType: 'lines' | 'snapToChars' = 'lines',
+): MeasureState {
   let font = '10px serif';
   const ctx = {
     get font() {
@@ -60,7 +63,7 @@ function makeMeasureState(adjustLineHeightInTable: boolean): MeasureState {
     footerDistance: 10,
     titlePage: false,
     evenAndOddHeaders: false,
-    docGridType: 'lines',
+    docGridType,
     docGridLinePitch: 20,
   });
 
@@ -169,5 +172,22 @@ describe('table-cell line grid compatibility', () => {
 
   it('applies the section line pitch when compatibility is enabled', () => {
     expect(calculateRowHeight(row(), table(), [100], 1, makeMeasureState(true))).toBe(20);
+  });
+
+  it('gates the line axis of snapToChars by the same compatibility setting', () => {
+    expect(calculateRowHeight(
+      row(),
+      table(),
+      [100],
+      1,
+      makeMeasureState(false, 'snapToChars'),
+    )).toBe(10);
+    expect(calculateRowHeight(
+      row(),
+      table(),
+      [100],
+      1,
+      makeMeasureState(true, 'snapToChars'),
+    )).toBe(20);
   });
 });


### PR DESCRIPTION
## Root cause

The renderer's legacy grid consumers did not preserve all of the independent OOXML policy axes normalized by the layout-context resolver:

- Table-cell line measurement consumed section pitch without checking the table compatibility setting.
- Run-level character-grid opt-out was parsed but discarded before measurement and paint.
- `snapToChars` activated character spacing but was omitted from the line-grid predicate.
- `atLeast` line spacing ignored the active grid minimum.
- Table-cell context was entered while resolving paragraphs instead of at the container boundary, so nested measurement depth could diverge from paint depth.

## Result

- Enter table-cell story context at measurement, row-splitting, and paint boundaries.
- Gate table-cell line pitch through `adjustLineHeightInTable` while keeping character-grid policy independent.
- Carry run character-grid participation on layout segments and share one delta gate across measurement, splitting, rescaling, and paint.
- Apply both line and character axes for `snapToChars`.
- Resolve `atLeast` as the maximum of natural, authored, and active-grid minima.
- Add focused integration coverage for nested cells, mixed-script run opt-out, and both `snapToChars` axes.

## Specification

The corrections follow ECMA-376 Part 1 sections 17.3.1.32, 17.3.1.33, 17.3.2.34, 17.6.5, 17.15.3.1, and 17.18.14.

## Review

Claude Opus 4.8 performed a read-only review of the public diff and relevant ECMA-376 excerpts. It found no confirmed defect in the four normative corrections. A container-depth risk from the review was addressed by moving table-cell story transitions to container boundaries and adding nested-context coverage.

Claude Fable 5 then independently reviewed the final PR diff. It identified that the body bridge treated paragraph line-grid opt-out as disabling both grid axes. The follow-up commit routes body pagination and paint through the shared paragraph policy, preserving run-controlled character spacing while disabling only line pitch.

## Verification

- `cargo test -p docx-parser` (309 tests)
- `pnpm vitest run packages/docx/src` (128 files, 936 tests)
- `pnpm typecheck`
- `pnpm lint` (exit 0; existing warning-only tripwires remain)
- `pnpm build:wasm`
- Tracked visual regression cases, worker equivalence, selection, and overlay checks passed
- Local-only visual cases produced the same scores and pixel counts as pre-change `main`
- No tracked visual reference was regenerated or changed
- `git diff --check origin/main...HEAD`
- Added-line privacy scan for local paths and private fixture references
