### PR TITLE
fix(storybook): keep intro lead text inline to avoid nested paragraphs

### DIFF
--- a/.storybook/Introduction.mdx
+++ b/.storybook/Introduction.mdx
@@ -81,11 +81,7 @@ import pptxImg from '../docs/images/pptx.png';
 
 <div className="sb-intro-hero">
   <h1>office-open-xml-viewer</h1>
-  <p className="lead">
-    A browser-based viewer for Office Open XML documents (<code>.docx</code>, <code>.xlsx</code>, <code>.pptx</code>)
-    that renders to an HTML Canvas. Parsers are written in Rust and compiled to WebAssembly;
-    the renderers use the Canvas 2D API.
-  </p>
+  <p className="lead">A browser-based viewer for Office Open XML documents (<code>.docx</code>, <code>.xlsx</code>, <code>.pptx</code>) that renders to an HTML Canvas. Parsers are written in Rust and compiled to WebAssembly; the renderers use the Canvas 2D API.</p>
   <div className="sb-intro-badges">
     <a href="https://www.npmjs.com/package/@silurus/ooxml" target="_blank" rel="noreferrer">
       <img src="https://img.shields.io/npm/v/@silurus/ooxml.svg" alt="npm version" />


### PR DESCRIPTION
## Summary

- `.storybook/Introduction.mdx`'s hero lead paragraph (`<p className="lead">`) wrapped its text across multiple lines as JSX children. MDX wraps multi-line JSX children in a markdown paragraph, so this produced a generated inner `<p>` nested inside the outer `<p className="lead">` — invalid HTML that triggered React hydration-error warnings in the browser console on every load of the Introduction docs page.
- Fix: keep the semantic `<p className="lead">` element, but put its entire text content on a single line with the opening/closing tags, so MDX treats the children as inline text and does not synthesize an inner paragraph.
- A `<div>` wrapper was considered instead and rejected: the generated inner `<p>` would then inherit sbdocs' default paragraph styles (smaller font-size, different margins), breaking the intended lead styling defined by the `.sb-intro-hero p.lead` CSS rule — which is unchanged by this fix and still applies correctly.

## Verification

Verified on a live Storybook build: two full page reloads of the Introduction docs page after the fix appended zero new hydration warnings to the console (previously ~8 warnings per load). The DOM shows no nested `<p>` inside the lead element, and computed lead styles are unchanged (font-size 16.8px = 1.05rem, color rgb(75,85,99) = #4b5563, margin-bottom 20px).

## Test plan

- [x] `git diff --check` clean (no whitespace issues)
- [x] Manually verified in a running Storybook: no hydration warnings across repeated reloads, no nested `<p>`, lead styling unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)