### PR TITLE
docs: use type assertions instead of non-null in public examples

### DIFF
--- a/.storybook/Introduction.mdx
+++ b/.storybook/Introduction.mdx
@@ -133,7 +133,8 @@ npm install @silurus/ooxml
 ```typescript
 import { PptxViewer } from '@silurus/ooxml/pptx';
 
-const viewer = new PptxViewer(document.getElementById('container')!);
+const canvas = document.getElementById('pptx-canvas') as HTMLCanvasElement;
+const viewer = new PptxViewer(canvas);
 const buf = await fetch('/deck.pptx').then(r => r.arrayBuffer());
 await viewer.load(buf);
 viewer.nextSlide();
@@ -156,7 +157,7 @@ import { PptxPresentation, autoResize } from '@silurus/ooxml/pptx';
 const pres = await PptxPresentation.load('/deck.pptx');
 const detach = autoResize(
   (width) => pres.renderSlide(canvas, 0, { width }),
-  canvas.parentElement!, // observe the container so canvas can fill it
+  canvas.parentElement as HTMLElement, // observe the container so canvas can fill it
 );
 
 // teardown

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ const current = ref(0);
 const total   = ref(0);
 
 onMounted(async () => {
-  viewer = new PptxViewer(canvas.value!, {
+  viewer = new PptxViewer(canvas.value as HTMLCanvasElement, {
     onSlideChange: (i, t) => { current.value = i; total.value = t; },
   });
   await viewer.load(props.src);


### PR DESCRIPTION
## Summary

Root `CLAUDE.md`'s "コード例の規約" requires public-facing code examples to use `as Type` assertions instead of postfix non-null `!`, and prescribes `canvas` / `container` naming based on what the viewer's constructor actually accepts.

Verified the real constructor signatures before touching anything:
- `PptxViewer(canvas: HTMLCanvasElement, opts?)`
- `DocxViewer(canvas: HTMLCanvasElement, opts?)`
- `XlsxViewer(container: HTMLElement, opts?)`
- `autoResize(render, element: Element, opts?)`

Fixes:
- `.storybook/Introduction.mdx` Quick start — `new PptxViewer(document.getElementById('container')!)` was both the wrong element name *and* relied on `!`. `PptxViewer` takes a canvas, not a container. Replaced with a `canvas` variable (`document.getElementById('pptx-canvas') as HTMLCanvasElement`), matching the README's existing Quick Start convention.
- `.storybook/Introduction.mdx` Responsive rendering — `canvas.parentElement!` → `canvas.parentElement as HTMLElement`.
- `README.md` Vue 3.5 example — `canvas.value!` → `canvas.value as HTMLCanvasElement` (`canvas.value` is `HTMLCanvasElement | null` from `useTemplateRef`).

Swept `README.md`, `packages/*/README.md`, `.storybook/*.mdx`, tracked `packages/*/src/*.stories.ts`, and `site/` (Astro components, `site/src/lib/api-reference.ts`, `demo-snippets.ts`, `live.ts`, `demos.ts`, `try.ts`). No other genuine postfix non-null assertions found — remaining `!` hits in those files were boolean negation, `!==`, markdown `![image]` syntax, or `<!-- comments -->`.

Two intentionally left untouched, with rationale in the commit message:
- README's SolidJS ref example `let canvasEl!: HTMLCanvasElement;` — a TypeScript *definite-assignment assertion* (different language feature from postfix non-null), and the canonical SolidJS idiom.
- `site/src/components/CodeTabs.astro` / `LiveShowcase.astro` — non-null assertions on `querySelector` results, but that's the site's own runtime implementation code, not a public-facing library-usage example.

An ast-grep rule banning this pattern in `*.stories.ts` (`no-non-null-assertion-in-examples`) already existed from a prior PR — no `.stories.ts` file needed a fix, and `npx ast-grep scan` passes with no errors, so no new lint rule was added here.

## Test plan
- [x] `npx ast-grep scan` — exit 0, no errors (existing `no-non-null-assertion-in-examples` rule)
- [x] `git diff --check` — clean
- [x] No `.stories.ts` files changed, so root `pnpm typecheck` was skipped per the pure-markdown/mdx carve-out
- [x] Rebased onto latest `origin/main` (picked up an unrelated concurrent Storybook intro fix with no overlap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)