### PR TITLE
Unify DOCX paragraph measurement across flow paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,11 @@ git diff --check
 If a check fails because ignored/generated WASM is stale, rebuild WASM before
 assuming the source change is broken.
 
+Before running parser-backed integration tests, Storybook, or VRT, rebuild
+generated WASM (`pnpm build:wasm` or the per-package command) whenever parser
+(Rust) source has changed or `packages/*/src/wasm/` may be stale — stale
+generated WASM can both hide real parser defects and fabricate failures.
+
 ## OOXML Implementation Policy
 
 Be specification-first.

--- a/docs/docx-layout-context-fragments-design.md
+++ b/docs/docx-layout-context-fragments-design.md
@@ -283,6 +283,21 @@ geometry can change line width and vertical origin, so the placement is an
 explicit part of the contract.
 
 ```ts
+export interface LineLayoutEnvironment {
+  readonly pageIndex: number;
+  readonly totalPages: number;
+  readonly displayPageNumber?: number;
+  readonly pageNumberFormat?: NumberFormat;
+  readonly currentDateMs?: number;
+  readonly noteNumbers?: ReadonlyMap<string, number>;
+  readonly currentNoteNumber?: number;
+  readonly verticalCJK?: boolean;
+}
+
+export interface ParagraphMeasurementEnvironment extends LineLayoutEnvironment {
+  readonly documentHasEastAsianText: boolean;
+}
+
 export interface WrapOracle {
   lineWindow(input: {
     readonly topYPt: number;
@@ -336,6 +351,7 @@ export function measureParagraph(
   context: ParagraphLayoutContext,
   placement: ParagraphPlacement,
   measurer: TextMeasurer,
+  environment: ParagraphMeasurementEnvironment,
 ): MeasuredParagraph;
 ```
 
@@ -349,10 +365,17 @@ measured geometry; it does not repeat text layout. A measurement is valid only
 for its recorded placement. Moving a paragraph to another page, column, or wrap
 context requires deterministic remeasurement.
 
-The existing float-layout pure functions implement `WrapOracle`. Floating
-drawing discovery and registration stay in the current anchor subsystem. A
-`wrapNone` object never appears in the oracle. Table-cell measurement receives
-no page-level wrap oracle.
+`documentHasEastAsianText` preserves the existing document-level font-axis
+choice for empty and anchor-only paragraph marks. Content-bearing lines continue
+to use `ParagraphLayoutContext.hasEastAsianText`; the two inputs are intentionally
+not interchangeable for an empty paragraph. Measurement callers populate this
+required field from document layout settings.
+
+`createFloatWrapOracle` in the paragraph-measurement module adapts the existing
+float-layout pure functions to `WrapOracle`. Floating drawing discovery and
+registration stay in the current anchor subsystem. A `wrapNone` object never
+appears in the oracle. Table-cell measurement receives no page-level wrap
+oracle.
 
 Inline drawings remain line segments and continue to affect line width and line
 height inside `measureParagraph`.

--- a/docs/docx-layout-context-fragments-implementation-plan.md
+++ b/docs/docx-layout-context-fragments-implementation-plan.md
@@ -862,9 +862,13 @@ export interface LineLayoutEnvironment {
   readonly currentNoteNumber?: number;
   readonly verticalCJK?: boolean;
 }
+
+export interface ParagraphMeasurementEnvironment extends LineLayoutEnvironment {
+  readonly documentHasEastAsianText: boolean;
+}
 ```
 
-Change `buildSegments` and `resolveFieldText` to accept this interface. The current `buildSegments` implementation reads only `verticalCJK`, note numbering, and `resolveFieldText`'s page/date fields from state; keep font classes on `TextMeasurer` and grid, kinsoku, tabs, and spacing on `ParagraphLayoutContext`. Verify this boundary with a `state.` usage scan and typecheck. Because `verticalCJK` remains optional, existing `RenderState` is structurally compatible.
+Change `buildSegments` and `resolveFieldText` to accept `LineLayoutEnvironment`. The current `buildSegments` implementation reads only `verticalCJK`, note numbering, and `resolveFieldText`'s page/date fields from state; keep font classes on `TextMeasurer` and grid, kinsoku, tabs, and spacing on `ParagraphLayoutContext`. `ParagraphMeasurementEnvironment.documentHasEastAsianText` preserves the existing document-level font-axis choice for empty and anchor-only paragraph marks; content lines continue to use `ParagraphLayoutContext.hasEastAsianText`. Measurement callers must populate it from document layout settings. Verify this boundary with a `state.` usage scan and typecheck.
 
 Define the measurement boundary explicitly:
 
@@ -921,6 +925,7 @@ export function measureParagraph(
   context: ParagraphLayoutContext,
   placement: ParagraphPlacement,
   measurer: TextMeasurer,
+  environment: ParagraphMeasurementEnvironment,
 ): MeasuredParagraph;
 ```
 

--- a/docs/docx-layout-context-fragments-implementation-plan.md
+++ b/docs/docx-layout-context-fragments-implementation-plan.md
@@ -954,9 +954,11 @@ refactor(docx): add placement-aware paragraph measurement
 
 **Files:**
 - Modify: `packages/docx/src/renderer.ts`
+- Modify: `packages/docx/src/float-layout.ts`
 - Modify: `packages/docx/src/pagination.test.ts`
 - Modify: `packages/docx/src/cell-paragraph-line-reuse.test.ts`
 - Modify: `packages/docx/src/paginate-paint-line-count.test.ts`
+- Modify: `packages/docx/src/float-line-start-one-inch.test.ts`
 
 **Interfaces:**
 - `estimateParagraphHeight`, `splitParagraphAcrossPages`, `measureParaHeight`, and `layoutCellParagraphForRowSplit` consume `measureParagraph`.
@@ -976,6 +978,8 @@ pnpm vitest run packages/docx/src/pagination.test.ts packages/docx/src/cell-para
 
 Body estimation passes the active wrap oracle and placement. Cell measurement passes the table-cell context with no page wrap oracle. Paragraph splitting slices `MeasuredLine[]` and applies `keepLines` and widow/orphan rules without recalculating line advances.
 
+Preserving the first line's measured top displacement can expose page-scoped square floats registered in another newspaper column. Per §20.4.2.17, apply square wrapping only when the virtual wrap rectangle intersects the paragraph's horizontal line area; `wrapText` then selects the permitted side within that intersecting area.
+
 - [ ] **Step 4: Remove the test-only legacy toggle after equality passes**
 
 Keep characterization assertions, remove the alternate production code path, and ensure only one line measurement implementation remains.
@@ -984,6 +988,8 @@ Keep characterization assertions, remove the alternate production code path, and
 
 ```bash
 pnpm vitest run packages/docx/src/paragraph-measure.test.ts packages/docx/src/pagination.test.ts packages/docx/src/cell-paragraph-line-reuse.test.ts packages/docx/src/paginate-paint-line-count.test.ts packages/docx/src/table-split.test.ts
+pnpm vitest run packages/docx/src/float-line-start-one-inch.test.ts packages/docx/src/float-table-page-fit.test.ts
+pnpm vitest run packages/docx/src
 pnpm --filter @silurus/ooxml-docx typecheck
 git diff --check
 ```

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1233,8 +1233,9 @@ fn parse_body_elements(
                 // A lone page/column break paragraph collapses to the break marker.
                 // (Use a fall-through `match` rather than an early `continue` so the
                 // `cover_break_after` push at the loop tail is still reached when a
-                // cover's last child is itself a lone break — rare, but it must not
-                // silently drop the cover's standalone-page break.)
+                // cover's last child is itself a lone break. A final column break
+                // still needs the synthetic page break; a final hard page break is
+                // deduplicated by apply_cover_page_breaks.)
                 match lone_break {
                     Some(BreakType::Page) => body.push(BodyElement::PageBreak { parity: None }),
                     Some(BreakType::Column) => body.push(BodyElement::ColumnBreak),
@@ -1307,10 +1308,10 @@ fn parse_body_elements(
 }
 
 /// Drop a cover's synthetic page break (emitted at `cover_break_positions` by the
-/// `parse_body_elements` walk) when the cover's content is ALREADY followed by a
-/// construct that starts a new page — a hard `<w:br w:type="page"/>` (PageBreak)
-/// or a section boundary (SectionBreak). In that case the cover stands alone via
-/// that construct, and the extra page break would leave a spurious BLANK page
+/// `parse_body_elements` walk) when the cover's content ALREADY ends in a hard
+/// `<w:br w:type="page"/>`, or is immediately followed by a page-advancing
+/// construct — a PageBreak or section boundary. In either case the cover stands
+/// alone via that construct, and the extra page break would leave a spurious BLANK page
 /// between the cover and the body (the renderer's pageBreak / page-advancing
 /// sectionBreak handlers push a page unconditionally — only `newPage()` coalesces
 /// an empty page). The common case (cover followed by a content paragraph, e.g.
@@ -1335,10 +1336,15 @@ fn apply_cover_page_breaks(
     let drop: Vec<usize> = cover_break_positions
         .into_iter()
         .filter(|&pos| {
-            matches!(
-                body.get(pos + 1),
-                Some(BodyElement::PageBreak { .. }) | Some(BodyElement::SectionBreak { .. })
-            )
+            let cover_ends_with_hard_break = pos
+                .checked_sub(1)
+                .and_then(|index| body.get(index))
+                .is_some_and(|element| matches!(element, BodyElement::PageBreak { .. }));
+            cover_ends_with_hard_break
+                || matches!(
+                    body.get(pos + 1),
+                    Some(BodyElement::PageBreak { .. }) | Some(BodyElement::SectionBreak { .. })
+                )
         })
         .collect();
     if drop.is_empty() {
@@ -13340,6 +13346,29 @@ mod column_tests {
         assert!(matches!(body[2], BodyElement::Paragraph(_)));
     }
 
+    /// A hard page break authored as the cover building block's LAST child also
+    /// makes the following body start on a new page. The synthetic cover break
+    /// must therefore be removed just as it is when the hard-break paragraph is
+    /// the next sibling outside the building block.
+    #[test]
+    fn cover_ending_in_hard_pagebreak_does_not_double_break() {
+        let body = body_from(
+            r#"<w:sdt>
+                 <w:sdtPr><w:docPartObj><w:docPartGallery w:val="Cover Pages"/></w:docPartObj></w:sdtPr>
+                 <w:sdtContent>
+                   <w:p><w:r><w:t>cover</w:t></w:r></w:p>
+                   <w:p><w:r><w:br w:type="page"/></w:r></w:p>
+                 </w:sdtContent>
+               </w:sdt>
+               <w:p><w:r><w:t>body</w:t></w:r></w:p>"#,
+        );
+        // Para(cover), PageBreak (the authored one only), Para(body).
+        assert_eq!(body.len(), 3);
+        assert!(matches!(body[0], BodyElement::Paragraph(_)));
+        assert!(matches!(body[1], BodyElement::PageBreak { .. }));
+        assert!(matches!(body[2], BodyElement::Paragraph(_)));
+    }
+
     /// Likewise when the cover is immediately followed by a section boundary: the
     /// section break advances the page, so the synthetic cover break is dropped to
     /// avoid a blank page between the cover and the next section.
@@ -13361,11 +13390,10 @@ mod column_tests {
         assert!(matches!(body[2], BodyElement::Paragraph(_)));
     }
 
-    /// Even when the cover's LAST content child is itself a lone break, the
-    /// standalone-page break is still emitted (the fall-through `match` reaches the
-    /// `cover_break_after` push). Here the cover ends with a column break; the
-    /// synthetic page break still follows, and is kept because real body content
-    /// (not another page/section break) comes next.
+    /// When the cover's LAST content child is a lone column break, the standalone
+    /// page break is still required (the fall-through `match` reaches the
+    /// `cover_break_after` push). Unlike a hard page break, a column break alone
+    /// does not guarantee that the following body starts on a new physical page.
     #[test]
     fn cover_ending_in_lone_break_still_emits_standalone_pagebreak() {
         let body = body_from(

--- a/packages/docx/src/cell-height-scale-metrics.test.ts
+++ b/packages/docx/src/cell-height-scale-metrics.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderDocumentToCanvas,
+  __test_setTableReuseEnabled,
+} from './renderer.js';
+import type {
+  BodyElement,
+  CellElement,
+  DocParagraph,
+  DocTable,
+  DocTableCell,
+  DocTableRow,
+  DocxDocumentModel,
+  DocxTextRun,
+  SectionProps,
+} from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Finding 1 — cell height measurement must use REAL-SCALE Canvas metrics.
+//
+// The cell-height path (measureCellParagraphHeight → measureCellElementHeight →
+// measureCellContentHeightPx) measures a cell paragraph at scale 1 and then does
+// a geometric `× scale` on the scale-1 point height. That is the exact anti-
+// pattern `rescaleLayoutLines` exists to avoid: a real (hinted) font's Canvas
+// metrics are NOT scale-linear, so `metric(pt · s) ≠ s · metric(pt)`. The paint
+// path (renderParagraph) rehydrates the scale-1 line PARTITION to the paint scale
+// by RE-MEASURING every line at that scale (rescaleLayoutLines), so the painted
+// content occupies a height the naive `× scale` cannot reproduce. When the two
+// disagree, a vAlign=center/bottom cell centres its content off the true middle,
+// and the content-driven row-height fallback reserves the wrong height.
+//
+// These tests mock a NON-LINEAR `measureText` — a sub-linear ascent/descent, the
+// direction real font hinting bends (glyphs proportionally shorter at larger
+// sizes) — so `metric(12·s) ≠ s·metric(12)`. They then render at scale = 4/3
+// (≈1.333, the renderer's default cssWidth/physWidth ratio) and assert the cell
+// content height that vAlign / row layout USES equals the height the paint side
+// actually PRODUCES, read back through the public render seam.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Sub-linear single-glyph vertical metrics in px at font size `p` px. The
+ *  ascent/descent shrink proportionally as `p` grows, so `metric(p·s) ≠ s·metric(p)`
+ *  — the hinting-like non-linearity `rescaleLayoutLines` re-measures for. Width is
+ *  kept linear (charCount · p · 0.5) so the line PARTITION never changes with
+ *  scale; only the per-line BOX height is scale-non-linear, which is exactly the
+ *  quantity that drives a cell's measured height. */
+function glyphMetrics(p: number): { asc: number; desc: number } {
+  return { asc: p * (0.8 - 0.01 * p), desc: p * (0.2 - 0.005 * p) };
+}
+
+interface FillTextCall { text: string; x: number; y: number; font: string; }
+interface FillRectCall { x: number; y: number; w: number; h: number; fillStyle: string; }
+
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fillTextCalls: FillTextCall[];
+  fillRectCalls: FillRectCall[];
+} {
+  let font = '10px serif';
+  let fillStyle = '#000';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const fillTextCalls: FillTextCall[] = [];
+  const fillRectCalls: FillRectCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string) { fillStyle = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      const { asc, desc } = glyphMetrics(p);
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: asc,
+        fontBoundingBoxDescent: desc,
+        actualBoundingBoxAscent: asc,
+        actualBoundingBoxDescent: desc,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {},
+    fillRect(x: number, y: number, w: number, h: number) {
+      fillRectCalls.push({ x, y, w, h, fillStyle });
+    },
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText(text: string, x: number, y: number) {
+      fillTextCalls.push({ text, x, y, font });
+    },
+    strokeText() {},
+    strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  // `clipExact` rows (ST_HeightRule exact) read `ctx.canvas.width`; wire the
+  // back-reference so the exact-height cells below render.
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, fillTextCalls, fillRectCalls };
+}
+
+// An untabled synthetic font so the font-metrics single-line FLOOR
+// (intendedSingleLinePx) is 0 and the line box is exactly the mock's ascent +
+// descent — isolating the scale non-linearity under test.
+const TEST_FONT = 'Synthetic Untabled Serif';
+
+function textRun(text: string): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 12, color: null, fontFamily: TEST_FONT, fontFamilyEastAsia: '',
+    isLink: false, background: null, vertAlign: null, hyperlink: null,
+  };
+}
+
+function paraOf(text: string, opts: Partial<DocParagraph> = {}): CellElement {
+  return {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{ type: 'text', ...textRun(text) } as DocParagraph['runs'][number]],
+    defaultFontSize: 12, defaultFontFamily: TEST_FONT,
+    widowControl: false,
+    ...opts,
+  } as unknown as CellElement;
+}
+
+function cell(
+  content: CellElement[],
+  vAlign: 'top' | 'center' | 'bottom',
+  background: string | null = null,
+): DocTableCell {
+  return {
+    content,
+    colSpan: 1,
+    vMerge: null,
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    background,
+    vAlign,
+    widthPt: 300,
+  } as DocTableCell;
+}
+
+function row(c: DocTableCell, rowHeight: number | null, rule: 'auto' | 'atLeast' | 'exact'): DocTableRow {
+  return {
+    cells: [c],
+    rowHeight,
+    rowHeightRule: rule,
+    isHeader: false,
+  } as DocTableRow;
+}
+
+function tableOf(r: DocTableRow): DocTable {
+  return {
+    colWidths: [300],
+    rows: [r],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left',
+  } as DocTable;
+}
+
+function docWithTable(t: DocTable): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: 300, pageHeight: 600,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [{ type: 'table', ...t } as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { [TEST_FONT]: 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+// scale = cssWidth / pageWidthPt = 400 / 300 = 4/3 ≈ 1.333.
+const CSS_WIDTH = 400;
+const PAGE_WIDTH = 300;
+const SCALE = CSS_WIDTH / PAGE_WIDTH;
+const FONT_PX = 12 * SCALE; // 16 exactly
+
+async function renderAndRead(t: DocTable) {
+  const rec = makeRecordingCanvas();
+  await renderDocumentToCanvas(docWithTable(t), rec.canvas, 0, {
+    dpr: 1,
+    width: CSS_WIDTH,
+  });
+  return rec;
+}
+
+/** Painted inked-block extent (px) of a set of one-line paragraphs, read from the
+ *  fillText baselines and the mock's paint-scale glyph box. This is the height the
+ *  paint side actually PRODUCES — the reference every measured height is compared
+ *  against. */
+function paintedExtent(calls: FillTextCall[], firstText: string, lastText: string): { top: number; bottom: number } {
+  const first = calls.find((c) => c.text === firstText);
+  const last = calls.find((c) => c.text === lastText);
+  expect(first).toBeDefined();
+  expect(last).toBeDefined();
+  const { asc, desc } = glyphMetrics(FONT_PX);
+  return { top: first!.y - asc, bottom: last!.y + desc };
+}
+
+describe('Finding 1 — cell content height uses real-scale (rescaled) Canvas metrics', () => {
+  it('sanity: the mock ascent/descent is scale-NON-linear (else the test is vacuous)', () => {
+    const one = glyphMetrics(12);
+    const s = glyphMetrics(12 * SCALE);
+    const oneH = one.asc + one.desc;
+    const scaledH = s.asc + s.desc;
+    // A geometric ×scale of the scale-1 box must MISS the real paint-scale box by
+    // a clearly observable margin — this is the divergence Finding 1 is about.
+    expect(Math.abs(oneH * SCALE - scaledH)).toBeGreaterThan(0.5);
+  });
+
+  it('vAlign=center: the inked block is centred using the PAINTED content height', async () => {
+    // Three single-line paragraphs, no spacing. Exact 120 pt row → drawn height is
+    // exactly 120·scale px (resolveSingleRowHeight, ST_HeightRule exact) and is
+    // NOT content-measured, so this isolates the vAlign centring consumer. The
+    // content (~3 lines) fits well within the row, leaving centring room.
+    const t = tableOf(row(
+      cell(
+        [paraOf('aa'), paraOf('bb'), paraOf('cc')],
+        'center',
+      ),
+      120,
+      'exact',
+    ));
+    const { fillTextCalls } = await renderAndRead(t);
+    const { top, bottom } = paintedExtent(fillTextCalls, 'aa', 'cc');
+    const inkedMid = (top + bottom) / 2;
+    const cellMid = (120 * SCALE) / 2; // row at y=0, exact height 120·scale.
+    // measure == paint: the vAlign offset used the true painted content height, so
+    // the painted block's midpoint lands on the cell midpoint. With the geometric
+    // ×scale bug the block is off-centre by ~1.4 px here.
+    expect(inkedMid).toBeCloseTo(cellMid, 1);
+  });
+
+  it('vAlign=bottom: the inked block bottom hugs the cell bottom (painted height)', async () => {
+    const t = tableOf(row(
+      cell([paraOf('aa'), paraOf('bb'), paraOf('cc')], 'bottom'),
+      120,
+      'exact',
+    ));
+    const { fillTextCalls } = await renderAndRead(t);
+    const { bottom } = paintedExtent(fillTextCalls, 'aa', 'cc');
+    // mb = 0 → the inked bottom sits on the cell bottom (120·scale). A geometric
+    // ×scale measured height would seat it short of / past the true bottom.
+    expect(bottom).toBeCloseTo(120 * SCALE, 1);
+  });
+
+  it('auto row height fallback: reserved row height equals the painted content height', async () => {
+    // Auto height → the row height IS the measured cell content height. Disable the
+    // stamped-layout reuse so computeTableLayout runs the fresh real-scale fallback
+    // (the exact path Finding 1 flags), not the paginator's scale-1 stamp × scale.
+    const prev = __test_setTableReuseEnabled(false);
+    try {
+      const t = tableOf(row(
+        cell([paraOf('aa'), paraOf('bb'), paraOf('cc')], 'top', 'abcdef'),
+        null,
+        'auto',
+      ));
+      const { fillTextCalls, fillRectCalls } = await renderAndRead(t);
+      const bg = fillRectCalls.find((r) => r.fillStyle === '#abcdef');
+      expect(bg).toBeDefined();
+      const { top, bottom } = paintedExtent(fillTextCalls, 'aa', 'cc');
+      // Zero cell margins → the reserved (drawn) row height must equal the painted
+      // content extent. The geometric ×scale fallback reserves the scale-1 height
+      // × scale, which misses the painted height under non-linear metrics.
+      expect(bg!.h).toBeCloseTo(bottom - top, 1);
+    } finally {
+      __test_setTableReuseEnabled(prev);
+    }
+  });
+});

--- a/packages/docx/src/cell-paragraph-line-reuse.test.ts
+++ b/packages/docx/src/cell-paragraph-line-reuse.test.ts
@@ -196,7 +196,41 @@ async function reuseVsRecompute(model: DocxDocumentModel, width = 300): Promise<
   return { pages: pages.length, drawn, on: on.measures, off: off.measures, streams: on.perPage };
 }
 
+function tableMeasurementGeometry() {
+  const pages = paginateDocument(doc([wrapTable(8) as unknown as BodyElement]));
+  const tables = pages.flatMap((page) => page.filter((el) => el.type === 'table'));
+  return {
+    pageCount: pages.length,
+    rowHeightsPt: tables.flatMap((table) => table.tableRowHeightsPt ?? []),
+    cellLineCounts: tables.flatMap((table) =>
+      (table as unknown as DocTable).rows.flatMap((tableRow) =>
+        tableRow.cells.flatMap((tableCell) => tableCell.content.map((element) =>
+          (element as unknown as { layoutLines?: unknown[] }).layoutLines?.length ?? null,
+        )),
+      ),
+    ),
+  };
+}
+
 describe('table-cell paragraph line reuse — B2 T2', () => {
+  it('preserves table-cell heights and reusable line counts', () => {
+    const geometry = tableMeasurementGeometry();
+
+    expect(geometry.pageCount).toBe(2);
+    expect(geometry.rowHeightsPt).toEqual([
+      22.998046875,
+      22.998046875,
+      22.998046875,
+      22.998046875,
+      22.998046875,
+      22.998046875,
+      22.998046875,
+      11.4990234375,
+      11.4990234375,
+    ]);
+    expect(geometry.cellLineCounts).toEqual(Array.from({ length: 18 }, () => 2));
+  });
+
   it('(a) cell paragraphs reuse the paginator stamp: fewer paint measures, identical stream', async () => {
     const r = await reuseVsRecompute(doc([wrapTable(16) as unknown as BodyElement]));
     expect(r.pages).toBeGreaterThan(1); // table split across pages

--- a/packages/docx/src/cell-ptab-margin-indent.test.ts
+++ b/packages/docx/src/cell-ptab-margin-indent.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  CellElement,
+  DocParagraph,
+  DocRun,
+  DocTable,
+  DocTableCell,
+  DocTableRow,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Finding 4 — LTR table-cell paragraph: `<w:ptab w:relativeTo="margin">` resolves
+// against the text margin (paraW + right indent), matching the paint side.
+//
+// ECMA-376 §17.3.3.23 (ptab) + §17.18.73 (ST_PTabRelativeTo): `relativeTo="margin"`
+// positions the absolute tab against the TEXT-MARGIN box, which is independent of
+// the paragraph's own left/right indents; `relativeTo="indent"` positions it
+// against the (indented) content box.
+//
+// The old cell-specific measurer deliberately passed `marginRightPx = paraW`
+// (NOT paraW + indRight) for LTR cell paragraphs, documented as a deferred ptab
+// limitation. The unified placement-aware `measureParagraph` now passes
+// `paragraphWidthPt + physicalIndentRightPt` — the SAME `marginRightPx = paraW +
+// indRight` the paint side (renderParagraph) uses — so a cell paragraph's measured
+// line geometry and its painted geometry resolve the margin ptab identically. When
+// the paginator stamps a cell paragraph's scale-1 lines, the paint pass reuses
+// them, so a measure/paint disagreement here would surface directly in the painted
+// x. These tests pin the unified margin+indRight semantics end to end.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface FillCall { text: string; x: number; }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const fills: FillCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {}, strokeRect() {},
+    rect() {}, clip() {}, scale() {}, translate() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(text: string, x: number) { fills.push({ text, x }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills };
+}
+
+function textRun(text: string): DocRun {
+  return {
+    type: 'text', text,
+    bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 10, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+    isLink: false, background: null, vertAlign: null, hyperlink: null,
+  } as unknown as DocRun;
+}
+
+function ptabRun(alignment: 'left' | 'center' | 'right', relativeTo: 'margin' | 'indent'): DocRun {
+  return { type: 'ptab', alignment, relativeTo, leader: 'none', fontSize: 10 } as unknown as DocRun;
+}
+
+function cellPara(runs: DocRun[], indentRight: number): CellElement {
+  return {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 0, indentRight, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs,
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+  } as unknown as CellElement;
+}
+
+const PAGE_W = 300;
+const FS = 10; // glyph width px; scale = 1 px/pt (canvas width == pageWidth)
+
+function docWithCellPara(el: CellElement): DocxDocumentModel {
+  const cell = {
+    content: [el],
+    colSpan: 1, vMerge: null,
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    background: null, vAlign: 'top', widthPt: PAGE_W,
+  } as DocTableCell;
+  const row = { cells: [cell], rowHeight: null, rowHeightRule: 'auto', isHeader: false } as DocTableRow;
+  const table = {
+    colWidths: [PAGE_W], rows: [row],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0, jc: 'left',
+  } as DocTable;
+  return {
+    section: {
+      pageWidth: PAGE_W, pageHeight: 400,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [{ type: 'table', ...table } as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(el: CellElement): Promise<FillCall[]> {
+  const { canvas, fills } = makeRecordingCanvas();
+  await renderDocumentToCanvas(docWithCellPara(el), canvas, 0, { dpr: 1, width: PAGE_W });
+  return fills;
+}
+
+describe('table-cell ptab (§17.3.3.23) resolves margin against paraW + right indent', () => {
+  // Cell content box = full 300 pt (zero cell margins). Paragraph has a 40 pt right
+  // indent, so paraW = 260 and the TEXT MARGIN right edge = paraW + indRight = 300
+  // (the cell content-box edge), independent of the indent.
+  const INDENT_RIGHT = 40;
+
+  it('right ptab relativeTo="margin" right-aligns to the cell text margin, ignoring the right indent', async () => {
+    const fills = await render(cellPara([ptabRun('right', 'margin'), textRun('99')], INDENT_RIGHT));
+    const f = fills.find((c) => c.text === '99');
+    expect(f, '"99" must be drawn').toBeDefined();
+    // Margin right edge = paraW(260) + indRight(40) = 300 → 2-glyph number ends
+    // there ⇒ starts at 300 − 20 = 280. The old cell measurer would have resolved
+    // the margin at paraW (260), landing it at 240; the unified marginRightPx makes
+    // the measured stamp and the painted line agree at the true margin.
+    expect(f!.x + 2 * FS).toBeCloseTo(PAGE_W, 3);
+  });
+
+  it('right ptab relativeTo="indent" aligns to the INDENTED content box (contrast)', async () => {
+    const fills = await render(cellPara([ptabRun('right', 'indent'), textRun('99')], INDENT_RIGHT));
+    const f = fills.find((c) => c.text === '99');
+    expect(f, '"99" must be drawn').toBeDefined();
+    // Content box right edge = paraW = 260 (right indent excluded) ⇒ 260 − 20 = 240.
+    // This confirms the two relativeTo modes are distinguished in a cell: margin
+    // includes the right indent, indent does not.
+    expect(f!.x + 2 * FS).toBeCloseTo(PAGE_W - INDENT_RIGHT, 3);
+  });
+
+  it('center ptab relativeTo="margin" centers on the cell text-margin midpoint', async () => {
+    const fills = await render(cellPara([ptabRun('center', 'margin'), textRun('AB')], INDENT_RIGHT));
+    const f = fills.find((c) => c.text === 'AB');
+    expect(f, '"AB" must be drawn').toBeDefined();
+    // Margin box [0, 300] midpoint = 150 → 2-glyph text starts at 150 − (2·FS)/2 = 140.
+    expect(f!.x).toBeCloseTo(PAGE_W / 2 - (2 * FS) / 2, 3);
+  });
+});

--- a/packages/docx/src/float-layout.ts
+++ b/packages/docx/src/float-layout.ts
@@ -264,6 +264,14 @@ export function resolveLineFloatWindow(
     for (const f of floats) {
       if (f.mode !== 'square') continue;
       if (lineBot <= f.yTop || topY >= f.yBottom) continue;
+      // §20.4.2.17 excludes text only where the square wrap rectangle overlaps
+      // its line area. A page-scoped float in another newspaper column must not
+      // turn this column's full width into a sub-inch "side gap" and push the
+      // line below an unrelated vertical band.
+      if (
+        f.xRight <= paraXLeft + FLOAT_OVERLAP_EPS ||
+        f.xLeft >= paraXRight - FLOAT_OVERLAP_EPS
+      ) continue;
       intersecting.push(f);
       switch (f.side) {
         // Text may sit only on the LEFT of the float ⇒ everything from the

--- a/packages/docx/src/float-line-start-one-inch.test.ts
+++ b/packages/docx/src/float-line-start-one-inch.test.ts
@@ -141,6 +141,35 @@ describe('resolveLineFloatWindow — Word 1-inch line-start gate (issue #676)', 
     expect(placeLine(71.9, 1).beside).toBe(false);
     expect(placeLine(72.0, 1).beside).toBe(true);
   });
+
+  it('ignores square wrap rectangles wholly outside either side of the paragraph column', () => {
+    const outsideRanges = [
+      { xLeft: 20, xRight: 100 },
+      { xLeft: 190, xRight: 270 },
+    ];
+
+    for (const side of ['bothSides', 'left', 'right', 'largest']) {
+      for (const range of outsideRanges) {
+        const outsideColumn = {
+          ...leftBand(80, 120),
+          ...range,
+          imageX: range.xLeft,
+          imageW: range.xRight - range.xLeft,
+          side,
+        };
+        const win = resolveLineFloatWindow(
+          20,
+          wordMinLineStartPx(1),
+          10,
+          110,
+          70,
+          [outsideColumn],
+        );
+
+        expect(win).toEqual({ topY: 20, xOffset: 0, maxWidth: 70 });
+      }
+    }
+  });
 });
 
 // ── layoutLines integration ──────────────────────────────────────────────────

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -19,7 +19,7 @@ import type {
   DocParagraph, DocRun, DocxTextRun, ImageRun, ShapeTextRun, FieldRun,
   LineSpacing, TabStop, DocxRunBorder, DocSettings, EmphasisMark,
 } from './types';
-import type { MathNode, KinsokuRules, ChartModel, HyperlinkTarget, Duotone } from '@silurus/ooxml-core';
+import type { MathNode, KinsokuRules, ChartModel, HyperlinkTarget, NumberFormat, Duotone } from '@silurus/ooxml-core';
 import type { RenderState, DecodedImage } from './renderer.js';
 import {
   classifyCjkFont,
@@ -275,7 +275,19 @@ export interface LayoutLine {
 export interface WrapLayoutCtx {
   startPageY: number;   // absolute canvas Y where the first line should start
   paraX: number;        // absolute canvas X of the paragraph's content left edge
-  floats: FloatRect[];  // floats active on the current page
+  floats: FloatRect[];  // legacy float geometry supplied directly by renderer paths
+  /** Placement-aware wrap boundary used by paragraph measurement. */
+  lineWindow?: (input: {
+    topYPt: number;
+    minimumStartWidthPt: number;
+    probeHeightPt: number;
+    paragraphXPt: number;
+    maximumWidthPt: number;
+  }) => {
+    topYPt: number;
+    xOffsetPt: number;
+    maximumWidthPt: number;
+  };
   /** Per-line box-height resolver (line natural ascent+descent → total px box height). */
   lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number) => number;
   /** Hard cap on Y to keep layout from running past the page. */
@@ -301,6 +313,21 @@ export interface DocGridCtx {
    *  charSpace; the character grid is then inactive even if `type` is
    *  linesAndChars/snapToChars. See {@link gridCharDeltaPx}. */
   charSpacePt?: number | null;
+}
+
+/** Page/document values that can change segment text or vertical-text behavior.
+ * Canvas/font measurement belongs to the caller's TextMeasurer instead. The
+ * document-level East Asian flag is used only for content-less paragraph-mark
+ * metrics; content lines use ParagraphLayoutContext.hasEastAsianText. */
+export interface LineLayoutEnvironment {
+  readonly pageIndex: number;
+  readonly totalPages: number;
+  readonly displayPageNumber?: number;
+  readonly pageNumberFormat?: NumberFormat;
+  readonly currentDateMs?: number;
+  readonly noteNumbers?: ReadonlyMap<string, number>;
+  readonly currentNoteNumber?: number;
+  readonly verticalCJK?: boolean;
 }
 
 // ── Math (OMML) rendering via MathJax ───────────────────────────────────────
@@ -892,6 +919,8 @@ export function correctedLineMetrics(
  * suppress that paragraph-mark line. This is the height used both by the
  * literal empty-paragraph path and by paragraphs whose only segments are
  * wrap-float anchors (which `layoutLines` skips, yielding zero lines).
+ * `effectiveLineSpacing` lets resolved paragraph context override the source
+ * value; omitting it preserves the existing `para.lineSpacing` behavior.
  */
 export function paragraphMarkLineHeight(
   para: DocParagraph,
@@ -901,6 +930,7 @@ export function paragraphMarkLineHeight(
   eastAsian = false,
   ctx?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   fontFamilyClasses: Record<string, string> = {},
+  effectiveLineSpacing: LineSpacing | null = para.lineSpacing,
 ): number {
   const fs = getDefaultFontSize(para);
   const family = getDefaultFontFamily(para, eastAsian);
@@ -934,7 +964,7 @@ export function paragraphMarkLineHeight(
   } else {
     ({ asc, desc } = emptyLineNaturalPx(fs, scale));
   }
-  return lineBoxHeight(para.lineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSingleForScriptPx(para, scale, eastAsian), eastAsian);
+  return lineBoxHeight(effectiveLineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSingleForScriptPx(para, scale, eastAsian), eastAsian);
 }
 
 /**
@@ -993,16 +1023,16 @@ export function findNearbyFontSize(runs: DocRun[], idx: number): number {
   return 10; // pt fallback
 }
 
-export function resolveFieldText(f: FieldRun, state: RenderState): string {
+export function resolveFieldText(f: FieldRun, environment: LineLayoutEnvironment): string {
   if (f.fieldType === 'page') {
     // ECMA-376 §17.16.5.44 PAGE — "the number of the current page". Use the
     // per-section DISPLAY number (§17.6.12 `w:start` restart), falling back to the
     // raw physical index for a single-section document without `<w:pgNumType>`.
-    const n = state.displayPageNumber ?? state.pageIndex + 1;
+    const n = environment.displayPageNumber ?? environment.pageIndex + 1;
     // §17.16.4.3.1 — the field's own general-formatting switch (`\* roman`, …)
     // OVERRIDES the section format (§17.6.12 `w:fmt`); it is authored ON the field.
     // No switch ⇒ the section format (or decimal for a single-section document).
-    const fmt = parseFieldFormatSwitch(f.instruction) ?? state.pageNumberFormat ?? 'decimal';
+    const fmt = parseFieldFormatSwitch(f.instruction) ?? environment.pageNumberFormat ?? 'decimal';
     return formatOrdinalNumber(n, fmt);
   }
   // ECMA-376 §17.16.5.42 NUMPAGES — "the number of pages in the current document".
@@ -1011,11 +1041,11 @@ export function resolveFieldText(f: FieldRun, state: RenderState): string {
   // subject to the field's own `\*` format switch.
   if (f.fieldType === 'numPages') {
     const fmt = parseFieldFormatSwitch(f.instruction) ?? 'decimal';
-    return formatOrdinalNumber(state.totalPages, fmt);
+    return formatOrdinalNumber(environment.totalPages, fmt);
   }
   // ECMA-376 §17.16.5.16 DATE / §17.16.5.72 TIME — display the CURRENT date/time
   // filtered through the field's `\@` date-time picture (§17.16.4.1). The
-  // "current" instant is injected via `state.currentDateMs` (default = real time,
+  // "current" instant is injected via `environment.currentDateMs` (default = real time,
   // set at the render entry point) so the output is deterministic under test.
   // A field with NO `\@` picture, or one whose picture uses an unimplemented
   // token, falls back to the authored cached result (§17.16.4.1: with no picture
@@ -1024,7 +1054,7 @@ export function resolveFieldText(f: FieldRun, state: RenderState): string {
   if (f.fieldType === 'date' || f.fieldType === 'time') {
     const picture = parseDateTimePictureSwitch(f.instruction);
     if (picture) {
-      const now = new Date(state.currentDateMs ?? Date.now());
+      const now = new Date(environment.currentDateMs ?? Date.now());
       const formatted = formatDateTimePicture(picture, now);
       if (formatted !== null) return formatted;
     }
@@ -1594,10 +1624,10 @@ export function kinsokuRulesEquivalent(a: KinsokuRules, b: KinsokuRules): boolea
  *  the segment text depends on per-page render context rather than on the runs
  *  alone. Exactly two sources exist today:
  *    - `field` runs of type page / numPages: {@link resolveFieldText} returns
- *      `state.pageIndex + 1` / `state.totalPages`, and the measure state is
+ *      `environment.pageIndex + 1` / `environment.totalPages`, and the measure environment is
  *      frozen at pageIndex 0 / totalPages 1 (buildMeasureState);
- *    - `noteRef` text runs: the label resolves via `state.noteNumbers` /
- *      `state.currentNoteNumber`, which only the paint state carries
+ *    - `noteRef` text runs: the label resolves via `environment.noteNumbers` /
+ *      `environment.currentNoteNumber`, which only the paint environment carries
  *      (renderDocumentToCanvas builds the map; the measure state never does).
  *  Such a paragraph must NOT stamp its measured lines: the stamped segments
  *  would carry the measure-time text (a stale page number / note label) and the
@@ -1609,10 +1639,11 @@ export function paragraphSegsStateSensitive(para: DocParagraph): boolean {
   for (const run of para.runs) {
     if (run.type === 'field') {
       const ft = (run as unknown as FieldRun).fieldType;
-      // page / numPages depend on the per-page render context. date / time depend
-      // on the injected `state.currentDateMs`, which the measure state does not
-      // carry (buildMeasureState) — so these too must recompute rather than stamp
-      // a measure-time value (§17.16.4.1 DATE/TIME resolve at paint).
+      // page / numPages depend on the per-page render context. DATE / TIME can
+      // depend on `environment.currentDateMs`; although LineLayoutEnvironment
+      // permits that value, current pagination environments may omit it. Keep
+      // these fields on the paint-time recompute path so a pagination fallback
+      // instant is never stamped as the final field text (§17.16.4.1).
       if (ft === 'page' || ft === 'numPages' || ft === 'date' || ft === 'time') return true;
     } else if (run.type === 'text' && (run as unknown as DocxTextRun).noteRef) {
       return true;
@@ -1621,7 +1652,7 @@ export function paragraphSegsStateSensitive(para: DocParagraph): boolean {
   return false;
 }
 
-export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
+export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment): LayoutSeg[] {
   const segs: LayoutSeg[] = [];
   const pushTextPiece = (
     text: string,
@@ -1747,12 +1778,12 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
         kerning: r.kerning,
         // ECMA-376 §17.3.2.10 eastAsianLayout — 縦中横 is meaningful ONLY in a
         // vertical (tbRl) page, so fold the vertical gate in HERE at build time
-        // (buildSegments has RenderState). Measure/paint then read a single
+        // (buildSegments receives it through LineLayoutEnvironment). Measure/paint then read a single
         // pre-gated flag. `vertCompress` rides only when `vert` is set (spec: it
         // is ignored otherwise).
-        tateChuYoko: state.verticalCJK && r.eastAsianVert === true ? true : undefined,
+        tateChuYoko: environment.verticalCJK && r.eastAsianVert === true ? true : undefined,
         tateChuYokoCompress:
-          state.verticalCJK && r.eastAsianVert === true && r.eastAsianVertCompress === true
+          environment.verticalCJK && r.eastAsianVert === true && r.eastAsianVertCompress === true
             ? true
             : undefined,
       });
@@ -1843,8 +1874,8 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
       const noteText =
         t.noteRef
           ? (t.noteRef.id
-              ? state.noteNumbers?.get(`${t.noteRef.kind}:${t.noteRef.id}`)
-              : state.currentNoteNumber)
+              ? environment.noteNumbers?.get(`${t.noteRef.kind}:${t.noteRef.id}`)
+              : environment.currentNoteNumber)
           : undefined;
       if (t.noteRef) {
         const label = noteText != null ? String(noteText) : (t.text || '');
@@ -1911,7 +1942,7 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
       // page/column breaks handled at the document level (splitPages)
     } else if (run.type === 'field') {
       const f = run as unknown as FieldRun & { type: 'field' };
-      const text = resolveFieldText(f, state);
+      const text = resolveFieldText(f, environment);
       if (text) pushTextPiece(text, f, f.vertAlign);
     } else if (run.type === 'math') {
       // The parser resolves the paragraph font size; fall back to a nearby run only
@@ -1959,7 +1990,7 @@ export function buildSegments(runs: DocRun[], state: RenderState): LayoutSeg[] {
   // REPLACES the default East-Asian table for a language and so must NOT be able
   // to drop the ASCII non-starters and re-orphan a Latin comma). The document's
   // kinsoku settings still govern the separate per-character CJK retract paths
-  // (kinsokuAdjustedSplit / crossRunKinsokuRetract), which read `state.kinsoku`.
+  // (kinsokuAdjustedSplit / crossRunKinsokuRetract), which read the layout kinsoku argument.
   // The ASCII non-starters (!),.:;?]}) live in that default table (core
   // rules.ts), so one membership test covers Latin and (incidentally) CJK forms.
   for (let i = 1; i < segs.length; i++) {
@@ -2081,12 +2112,25 @@ export function layoutLines(
     // Small fixed probe height for float intersection (matches the historical
     // wrap behaviour for the topAndBottom skip and horizontal-gap scan).
     const probeH = 10 * scale;
-    const win = resolveLineFloatWindow(
-      currentLineTopY, minWidth, probeH, wrapCtx.paraX, maxWidth, wrapCtx.floats,
-    );
-    currentLineTopY = win.topY;
-    lineXOffset = win.xOffset;
-    lineMaxWidth = win.maxWidth;
+    if (wrapCtx.lineWindow) {
+      const win = wrapCtx.lineWindow({
+        topYPt: currentLineTopY,
+        minimumStartWidthPt: minWidth,
+        probeHeightPt: probeH,
+        paragraphXPt: wrapCtx.paraX,
+        maximumWidthPt: maxWidth,
+      });
+      currentLineTopY = win.topYPt;
+      lineXOffset = win.xOffsetPt;
+      lineMaxWidth = win.maximumWidthPt;
+    } else {
+      const win = resolveLineFloatWindow(
+        currentLineTopY, minWidth, probeH, wrapCtx.paraX, maxWidth, wrapCtx.floats,
+      );
+      currentLineTopY = win.topY;
+      lineXOffset = win.xOffset;
+      lineMaxWidth = win.maxWidth;
+    }
   };
 
   const availW = () => lineMaxWidth - (isFirst ? firstIndent : 0);

--- a/packages/docx/src/paginate-paint-line-count.test.ts
+++ b/packages/docx/src/paginate-paint-line-count.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renderDocumentToCanvas } from './renderer.js';
+import { paginateDocument, renderDocumentToCanvas } from './renderer.js';
 import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps } from './types';
 
 // ECMA-376 §17.6.4 (newspaper columns) + the renderer's scale-independent
@@ -63,6 +63,10 @@ function makeNonLinearCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
   return { canvas: canvas as unknown as HTMLCanvasElement, calls };
 }
 
+(globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+  getContext() { return makeNonLinearCanvas().canvas.getContext('2d'); }
+};
+
 function longPara(text: string): DocParagraph {
   return {
     type: 'paragraph', alignment: 'left',
@@ -95,6 +99,29 @@ function doc(body: BodyElement[], pageHeight: number): DocxDocumentModel {
   } as unknown as DocxDocumentModel;
 }
 
+async function paintedParagraphGeometry() {
+  const paragraph = longPara(Array.from({ length: 180 }, () => 'w').join(' '));
+  paragraph.spaceBefore = 6;
+  paragraph.spaceAfter = 4;
+  const model = doc([paragraph as unknown as BodyElement], 80);
+  const pages = paginateDocument(model);
+  const paintedPages: Array<{ lineCount: number; topYPx: number | null }> = [];
+  for (let pageIndex = 0; pageIndex < pages.length; pageIndex++) {
+    const { canvas, calls } = makeNonLinearCanvas();
+    await renderDocumentToCanvas(model, canvas, pageIndex, {
+      dpr: 1,
+      width: 200,
+      prebuiltPages: pages,
+    });
+    const textCalls = calls.filter((call) => call.text.includes('w'));
+    paintedPages.push({
+      lineCount: textCalls.length,
+      topYPx: textCalls.length > 0 ? textCalls[0].y : null,
+    });
+  }
+  return { pageCount: pages.length, paintedPages };
+}
+
 describe('paginate/paint line-count divergence — paint never indexes a phantom line (ECMA-376 §17.6.4)', () => {
   // A long paragraph of single-letter "words" (each followed by a space so the
   // line breaker has wrap opportunities). Narrow page + short page height force
@@ -103,6 +130,18 @@ describe('paginate/paint line-count divergence — paint never indexes a phantom
   // line count.
   const text = Array.from({ length: 400 }, () => 'w').join(' ');
   const body = (): BodyElement[] => [longPara(text) as unknown as BodyElement];
+
+  it('preserves page count, painted line counts, and continuation top positions', async () => {
+    const geometry = await paintedParagraphGeometry();
+
+    expect(geometry).toEqual({
+      pageCount: 2,
+      paintedPages: [
+        { lineCount: 84, topYPx: 24.74951171875 },
+        { lineCount: 96, topYPx: 18.74951171875 },
+      ],
+    });
+  });
 
   it('renders the final continuation slice without throwing when the paint scale wraps to fewer lines', async () => {
     // Render at width 400 over a 200pt page → scale 2. The non-linear mock fits

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -326,6 +326,124 @@ const textOf = (el: PaginatedBodyElement): string =>
         .join('')
     : '';
 
+function bodyPaginationGeometry(pages: PaginatedBodyElement[][]) {
+  return {
+    pageCount: pages.length,
+    pages: pages.map((page) => page.map((el) => {
+      const runtime = el as PaginatedBodyElement & {
+        layoutLines?: Array<{ topY?: number }>;
+        layoutLinesInputs?: { hasFloats: boolean };
+      };
+      return {
+        type: el.type,
+        lineSlice: sliceOf(el) ?? null,
+        columnIndex: el.colIndex ?? null,
+        columnTopPt: el.colTopPt ?? null,
+        measuredLineTopsPt: runtime.layoutLines?.map((line) => line.topY ?? null) ?? null,
+        measuredWithFloats: runtime.layoutLinesInputs?.hasFloats ?? null,
+      };
+    })),
+  };
+}
+
+describe('computePages — shared paragraph measurement migration geometry', () => {
+  it('preserves body page count, line ranges, and measured float top placement', () => {
+    const longText = 'あ'.repeat(72);
+    const followingText = '終'.repeat(16);
+    const body = [
+      paraWith([
+        shapeRun({ widthPt: 160, heightPt: 35, anchorYPt: 0, wrapMode: 'topAndBottom' }),
+      ]),
+      para({
+        text: longText,
+        fontSize: 20,
+        widowControl: false,
+        spaceBefore: 5,
+        spaceAfter: 7,
+      }),
+      para({ text: followingText, fontSize: 20 }),
+    ];
+    const pages = computePages(body, section(), makeCtx());
+    const geometry = bodyPaginationGeometry(pages);
+
+    expect(geometry.pageCount).toBe(3);
+    expect(geometry.pages.map((page) => page.map((el) => el.lineSlice))).toEqual([
+      [null, { start: 0, end: 2 }],
+      [{ start: 2, end: 7 }],
+      [{ start: 7, end: 9 }, null],
+    ]);
+    const measuredTops = Array.from({ length: 9 }, (_, index) => 80 + index * 20);
+    expect(geometry.pages.flatMap((page) => page)
+      .filter((el) => el.lineSlice !== null)
+      .map((el) => el.measuredLineTopsPt)).toEqual([
+      measuredTops,
+      measuredTops,
+      measuredTops,
+    ]);
+    expect(pages.findIndex((page) => page.some((el) => textOf(el) === followingText))).toBe(2);
+  });
+
+  it('remeasures destination placement when the first line cannot fit beside a page float', () => {
+    const targetText = 'あ'.repeat(16);
+    const body = [
+      paraWith([
+        shapeRun({ widthPt: 160, heightPt: 35, anchorYPt: 0, wrapMode: 'topAndBottom' }),
+      ]),
+      para({
+        text: targetText,
+        fontSize: 20,
+        widowControl: false,
+        spaceBefore: 30,
+      }),
+    ];
+
+    const pages = computePages(body, section(), makeCtx());
+    const geometry = bodyPaginationGeometry(pages);
+    const target = geometry.pages[1]?.find((el) => el.lineSlice?.start === 0);
+
+    expect(geometry.pageCount).toBe(2);
+    expect(target?.lineSlice).toEqual({ start: 0, end: 2 });
+    expect(target?.measuredWithFloats).toBe(false);
+    expect(target?.measuredLineTopsPt).toEqual([null, null]);
+  });
+
+  it('remeasures an unplaced paragraph at the next unequal-width column', () => {
+    const targetText = 'あ'.repeat(4);
+    const unequalColumns = section({
+      columns: {
+        count: 2,
+        spacePt: 0,
+        equalWidth: false,
+        sep: false,
+        cols: [
+          { widthPt: 100, spacePt: 12 },
+          { widthPt: 48, spacePt: 0 },
+        ],
+      },
+    });
+    const body = [
+      ...Array.from({ length: 4 }, () => para({ text: 'a', fontSize: 20 })),
+      para({ text: 'b', fontSize: 10 }),
+      para({ text: targetText, fontSize: 20, widowControl: false }),
+    ];
+
+    const pages = computePages(body, unequalColumns, makeCtx());
+    const target = pages[0]?.find((el) => textOf(el) === targetText) as
+      | (PaginatedBodyElement & {
+          layoutLinesInputs?: { paraW: number };
+          layoutLines?: Array<{ topY?: number }>;
+        })
+      | undefined;
+
+    expect(pages).toHaveLength(1);
+    expect(target?.colIndex).toBe(1);
+    expect(target?.colTopPt).toBe(20);
+    expect(target?.lineSlice).toEqual({ start: 0, end: 2 });
+    expect(target?.layoutLinesInputs?.paraW).toBe(48);
+    expect(target?.layoutLines?.map((line) => line.topY ?? null)).toEqual([null, null]);
+  });
+});
+
 describe('computePages — empty-paragraph relocation (C2: §17.3.1.29)', () => {
   it('moves an unsplittable mark-only paragraph to the next page instead of overflowing the bottom margin', () => {
     // content height = 140 - 40 = 100; each empty mark = 20px → exactly 5 per page.

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_KINSOKU_RULES } from '@silurus/ooxml-core';
+import type { FloatRect } from './float-layout.js';
+import {
+  createFloatWrapOracle,
+  measureParagraph,
+  type ParagraphMeasurementEnvironment,
+  type ParagraphPlacement,
+  type TextMeasurer,
+  type WrapOracle,
+} from './paragraph-measure.js';
+import type { ParagraphLayoutContext } from './layout-context.js';
+import type { DocParagraph, DocxTextRun, FieldRun, ImageRun } from './types.js';
+
+function makeContext(ascentRatio = 0.8, descentRatio = 0.2): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const fontSize = (): number => Number.parseFloat(/([\d.]+)px/.exec(font)?.[1] ?? '10');
+  return {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    letterSpacing: '0px',
+    measureText: (text: string) => {
+      const size = fontSize();
+      return {
+        width: [...text].length * size * 0.5,
+        fontBoundingBoxAscent: size * ascentRatio,
+        fontBoundingBoxDescent: size * descentRatio,
+        actualBoundingBoxAscent: size * ascentRatio,
+        actualBoundingBoxDescent: size * descentRatio,
+      } as TextMetrics;
+    },
+  } as unknown as CanvasRenderingContext2D;
+}
+
+const measurer: TextMeasurer = {
+  context: makeContext(),
+  fontFamilyClasses: {},
+};
+
+const environment = (
+  overrides: Partial<ParagraphMeasurementEnvironment> = {},
+): ParagraphMeasurementEnvironment => ({
+  pageIndex: 0,
+  totalPages: 1,
+  documentHasEastAsianText: false,
+  ...overrides,
+});
+
+const paragraph = (overrides: Partial<DocParagraph> = {}): DocParagraph => ({
+  alignment: 'left',
+  indentLeft: 0,
+  indentRight: 0,
+  indentFirst: 0,
+  spaceBefore: 3,
+  spaceAfter: 4,
+  lineSpacing: null,
+  numbering: null,
+  tabStops: [],
+  runs: [],
+  ...overrides,
+});
+
+const textRun = (text: string, overrides: Partial<DocxTextRun> = {}): DocxTextRun => ({
+  text,
+  bold: false,
+  italic: false,
+  underline: false,
+  strikethrough: false,
+  fontSize: 10,
+  color: null,
+  fontFamily: null,
+  isLink: false,
+  background: null,
+  vertAlign: null,
+  hyperlink: null,
+  ...overrides,
+});
+
+const layoutContext = (
+  overrides: Partial<ParagraphLayoutContext> = {},
+): ParagraphLayoutContext => ({
+  lineGrid: { active: false, pitchPt: null },
+  characterGrid: { active: false, deltaPt: 0 },
+  physicalIndentLeftPt: 0,
+  physicalIndentRightPt: 0,
+  firstIndentPt: 0,
+  lineSpacing: null,
+  spaceBeforePt: 3,
+  spaceAfterPt: 4,
+  baseRtl: false,
+  tabStops: [],
+  hasRuby: false,
+  hasEastAsianText: false,
+  kinsoku: DEFAULT_KINSOKU_RULES,
+  defaultTabPt: 36,
+  ...overrides,
+});
+
+const placement = (overrides: Partial<ParagraphPlacement> = {}): ParagraphPlacement => ({
+  startYPt: 10,
+  paragraphXPt: 0,
+  availableWidthPt: 200,
+  maximumYPt: 300,
+  suppressSpaceBefore: false,
+  ...overrides,
+});
+
+describe('measureParagraph', () => {
+  it('measures a no-float paragraph and excludes trailing spacing from contentEndYPt', () => {
+    const result = measureParagraph(
+      paragraph({ runs: [{ type: 'text', ...textRun('hello') }] }),
+      layoutContext(),
+      placement(),
+      measurer,
+      environment(),
+    );
+
+    expect(result.markOnly).toBe(false);
+    expect(result.lines).toHaveLength(1);
+    expect(result.lines[0].topYPt).toBe(13);
+    expect(result.lines[0].advancePt).toBe(10);
+    expect(result.contentStartYPt).toBe(13);
+    expect(result.contentEndYPt).toBe(23);
+    expect(result.requestedSpaceBeforePt).toBe(3);
+    expect(result.requestedSpaceAfterPt).toBe(4);
+    expect(result.placement).toEqual(placement());
+  });
+
+  it('uses a float-backed wrap window for line placement and width', () => {
+    const float: FloatRect = {
+      kind: 'shape', mode: 'square', imageKey: 'float',
+      imageX: 0, imageY: 10, imageW: 80, imageH: 30,
+      xLeft: 0, xRight: 80, yTop: 10, yBottom: 40,
+      side: 'bothSides', distLeft: 0, distRight: 0, distTop: 0, distBottom: 0,
+      paraId: 1, drawn: false,
+    };
+
+    const result = measureParagraph(
+      paragraph({ spaceBefore: 0, runs: [{ type: 'text', ...textRun('wrapped') }] }),
+      layoutContext({ spaceBeforePt: 0 }),
+      placement({ wrap: createFloatWrapOracle([float]) }),
+      measurer,
+      environment(),
+    );
+
+    expect(result.lines[0].topYPt).toBe(10);
+    expect(result.lines[0].layout.xOffset).toBe(80);
+    expect(result.lines[0].layout.availWidth).toBe(120);
+  });
+
+  it('reserves one paragraph-mark line for an empty paragraph', () => {
+    const result = measureParagraph(
+      paragraph(), layoutContext(), placement(), measurer, environment(),
+    );
+
+    expect(result.markOnly).toBe(true);
+    expect(result.lines).toEqual([]);
+    expect(result.contentStartYPt).toBe(13);
+    expect(result.contentEndYPt).toBe(23);
+  });
+
+  it('uses resolved context line spacing for an empty paragraph mark', () => {
+    const authoredSpacing = { value: 6, rule: 'exact' as const, explicit: true };
+    const resolvedSpacing = { value: 18, rule: 'exact' as const, explicit: true };
+    const result = measureParagraph(
+      paragraph({ spaceBefore: 0, lineSpacing: authoredSpacing }),
+      layoutContext({ spaceBeforePt: 0, lineSpacing: resolvedSpacing }),
+      placement({ startYPt: 0 }),
+      measurer,
+      environment(),
+    );
+
+    expect(result.markOnly).toBe(true);
+    expect(result.contentEndYPt).toBe(18);
+  });
+
+  it('uses document-level East Asian metrics for an empty paragraph mark', () => {
+    const tallMeasurer: TextMeasurer = {
+      context: makeContext(0.9, 0.2),
+      fontFamilyClasses: {},
+    };
+    const eastAsianMetrics = measureParagraph(
+      paragraph({ defaultFontSize: 20 }),
+      layoutContext({
+        lineGrid: { active: true, pitchPt: 20 },
+        spaceBeforePt: 0,
+      }),
+      placement({ startYPt: 0 }),
+      tallMeasurer,
+      environment({ documentHasEastAsianText: true }),
+    );
+    const paragraphOnlyMetrics = measureParagraph(
+      paragraph({ defaultFontSize: 20 }),
+      layoutContext({
+        lineGrid: { active: true, pitchPt: 20 },
+        spaceBeforePt: 0,
+      }),
+      placement({ startYPt: 0 }),
+      tallMeasurer,
+      environment({ documentHasEastAsianText: false }),
+    );
+
+    expect(eastAsianMetrics.contentEndYPt).toBe(40);
+    expect(paragraphOnlyMetrics.contentEndYPt).toBe(22);
+  });
+
+  it('treats an anchor-only paragraph as a paragraph mark', () => {
+    const anchor: ImageRun = {
+      imagePath: 'word/media/anchor.png', mimeType: 'image/png',
+      widthPt: 40, heightPt: 30, anchor: true,
+    };
+    const result = measureParagraph(
+      paragraph({ runs: [{ type: 'image', ...anchor }] }),
+      layoutContext(), placement(), measurer, environment(),
+    );
+
+    expect(result.markOnly).toBe(true);
+    expect(result.lines).toEqual([]);
+    expect(result.contentEndYPt).toBe(23);
+  });
+
+  it('uses one uniform snapped advance for every line in a ruby paragraph', () => {
+    const result = measureParagraph(
+      paragraph({
+        spaceBefore: 0,
+        runs: [{ type: 'text', ...textRun('aa aa', { ruby: { text: 'ruby', fontSizePt: 8 } }) }],
+      }),
+      layoutContext({
+        lineGrid: { active: true, pitchPt: 10 },
+        spaceBeforePt: 0,
+        hasRuby: true,
+      }),
+      placement({ availableWidthPt: 12 }),
+      measurer,
+      environment(),
+    );
+
+    expect(result.lines.length).toBeGreaterThan(1);
+    expect(new Set(result.lines.map((line) => line.advancePt))).toEqual(new Set([30]));
+  });
+
+  it('passes bidi policy through to RTL tab layout', () => {
+    const result = measureParagraph(
+      paragraph({
+        spaceBefore: 0,
+        tabStops: [{ pos: 50, alignment: 'left', leader: 'none' }],
+        runs: [{ type: 'text', ...textRun('A\tB') }],
+        bidi: true,
+      }),
+      layoutContext({
+        spaceBeforePt: 0,
+        baseRtl: true,
+        tabStops: [{ pos: 50, alignment: 'left', leader: 'none' }],
+      }),
+      placement({ availableWidthPt: 100 }),
+      measurer,
+      environment(),
+    );
+
+    const tab = result.lines[0].layout.segments.find((segment) => 'isTab' in segment);
+    expect(tab?.measuredWidth).toBe(45);
+  });
+
+  it('includes an inline image in line height', () => {
+    const image: ImageRun = {
+      imagePath: 'word/media/inline.png', mimeType: 'image/png',
+      widthPt: 20, heightPt: 24, anchor: false,
+    };
+    const result = measureParagraph(
+      paragraph({ spaceBefore: 0, runs: [{ type: 'image', ...image }] }),
+      layoutContext({ spaceBeforePt: 0 }), placement(), measurer, environment(),
+    );
+
+    expect(result.markOnly).toBe(false);
+    expect(result.lines[0].advancePt).toBe(24);
+  });
+
+  it('preserves exact line spacing verbatim', () => {
+    const exact = { value: 18, rule: 'exact' as const, explicit: true };
+    const result = measureParagraph(
+      paragraph({ spaceBefore: 0, lineSpacing: exact, runs: [{ type: 'text', ...textRun('exact') }] }),
+      layoutContext({ spaceBeforePt: 0, lineSpacing: exact }),
+      placement(), measurer, environment(),
+    );
+
+    expect(result.lines[0].advancePt).toBe(18);
+  });
+
+  it('resolves fields from the explicit line-layout environment', () => {
+    const field: FieldRun = {
+      fieldType: 'page', instruction: 'PAGE', fallbackText: '1',
+      bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: null, background: null,
+      vertAlign: null,
+    };
+    const result = measureParagraph(
+      paragraph({ spaceBefore: 0, runs: [{ type: 'field', ...field }] }),
+      layoutContext({ spaceBeforePt: 0 }), placement(),
+      measurer,
+      environment({ pageIndex: 8, totalPages: 12, displayPageNumber: 42 }),
+    );
+
+    expect(result.lines[0].layout.segments[0]).toMatchObject({ text: '42' });
+  });
+
+  it('remeasures at a changed start Y and records the exact placement', () => {
+    const wrap: WrapOracle = {
+      lineWindow: ({ topYPt, maximumWidthPt }) => topYPt < 50
+        ? { topYPt, xOffsetPt: 10, maximumWidthPt: 20 }
+        : { topYPt, xOffsetPt: 0, maximumWidthPt },
+      skipTopAndBottomBands: (yPt) => yPt,
+    };
+    const doc = paragraph({
+      spaceBefore: 0,
+      runs: [{ type: 'text', ...textRun('abcdefghijklmnopqrst') }],
+    });
+    const context = layoutContext({ spaceBeforePt: 0 });
+    const firstPlacement = placement({ startYPt: 10, availableWidthPt: 100, wrap });
+    const secondPlacement = placement({ startYPt: 60, availableWidthPt: 100, wrap });
+
+    const first = measureParagraph(doc, context, firstPlacement, measurer, environment());
+    const second = measureParagraph(doc, context, secondPlacement, measurer, environment());
+
+    expect(first).not.toBe(second);
+    expect(first.placement).toEqual(firstPlacement);
+    expect(second.placement).toEqual(secondPlacement);
+    expect(first.lines[0].layout.availWidth).toBe(20);
+    expect(second.lines[0].layout.availWidth).toBe(100);
+    expect(first.lines.length).toBeGreaterThan(second.lines.length);
+  });
+});

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -1,0 +1,265 @@
+import type { ParagraphLayoutContext } from './layout-context.js';
+import {
+  resolveLineFloatWindow,
+  skipPastTopAndBottom,
+  type FloatRect,
+} from './float-layout.js';
+import {
+  buildSegments,
+  getDefaultFontSize,
+  isGridLineRule,
+  layoutLines,
+  lineBoxHeight,
+  paragraphMarkLineHeight,
+  type DocGridCtx,
+  type LayoutLine,
+  type LineLayoutEnvironment,
+  type WrapLayoutCtx,
+} from './line-layout.js';
+import type { DocParagraph } from './types.js';
+
+export type { LineLayoutEnvironment } from './line-layout.js';
+
+export interface ParagraphMeasurementEnvironment extends LineLayoutEnvironment {
+  readonly documentHasEastAsianText: boolean;
+}
+
+export interface WrapOracle {
+  lineWindow(input: {
+    readonly topYPt: number;
+    readonly minimumStartWidthPt: number;
+    readonly probeHeightPt: number;
+    readonly paragraphXPt: number;
+    readonly maximumWidthPt: number;
+  }): {
+    readonly topYPt: number;
+    readonly xOffsetPt: number;
+    readonly maximumWidthPt: number;
+  };
+  skipTopAndBottomBands(yPt: number): number;
+}
+
+/** Adapt registered scale-1 float rectangles to the placement-aware paragraph
+ * measurement boundary. Float discovery, registration, and compatibility
+ * behavior remain owned by the renderer. */
+export function createFloatWrapOracle(floats: readonly FloatRect[]): WrapOracle {
+  const activeFloats = [...floats];
+  return {
+    lineWindow: ({
+      topYPt,
+      minimumStartWidthPt,
+      probeHeightPt,
+      paragraphXPt,
+      maximumWidthPt,
+    }) => {
+      const window = resolveLineFloatWindow(
+        topYPt,
+        minimumStartWidthPt,
+        probeHeightPt,
+        paragraphXPt,
+        maximumWidthPt,
+        activeFloats,
+      );
+      return {
+        topYPt: window.topY,
+        xOffsetPt: window.xOffset,
+        maximumWidthPt: window.maxWidth,
+      };
+    },
+    skipTopAndBottomBands: (yPt) => skipPastTopAndBottom(yPt, activeFloats),
+  };
+}
+
+export interface TextMeasurer {
+  readonly context:
+    | CanvasRenderingContext2D
+    | OffscreenCanvasRenderingContext2D;
+  readonly fontFamilyClasses: Readonly<Record<string, string>>;
+}
+
+export interface ParagraphPlacement {
+  readonly startYPt: number;
+  readonly paragraphXPt: number;
+  readonly availableWidthPt: number;
+  readonly maximumYPt: number;
+  readonly suppressSpaceBefore: boolean;
+  readonly wrap?: WrapOracle;
+}
+
+export interface MeasuredLine {
+  readonly layout: LayoutLine;
+  readonly topYPt: number;
+  readonly advancePt: number;
+}
+
+export interface MeasuredParagraph {
+  readonly lines: readonly MeasuredLine[];
+  readonly markOnly: boolean;
+  readonly requestedSpaceBeforePt: number;
+  readonly requestedSpaceAfterPt: number;
+  readonly contentStartYPt: number;
+  readonly contentEndYPt: number;
+  readonly placement: Readonly<ParagraphPlacement>;
+}
+
+function paragraphGrid(context: ParagraphLayoutContext): DocGridCtx {
+  return {
+    type: context.lineGrid.active ? 'lines' : null,
+    linePitchPt: context.lineGrid.active ? context.lineGrid.pitchPt : null,
+    charSpacePt: context.characterGrid.active ? context.characterGrid.deltaPt : null,
+  };
+}
+
+/** Preserve the renderer's paragraph-wide ruby/docGrid height calculation. */
+function snapParagraphLineToGrid(heightPt: number, grid: DocGridCtx): number {
+  if (!isGridLineRule(grid)) return heightPt;
+  const pitchPt = grid.linePitchPt!;
+  if (pitchPt <= 0) return heightPt;
+  if (heightPt <= pitchPt) return pitchPt;
+  return Math.ceil(heightPt / pitchPt) * pitchPt;
+}
+
+export function measureParagraph(
+  paragraph: DocParagraph,
+  context: ParagraphLayoutContext,
+  placement: ParagraphPlacement,
+  measurer: TextMeasurer,
+  environment: ParagraphMeasurementEnvironment,
+): MeasuredParagraph {
+  const grid = paragraphGrid(context);
+  const paragraphWidthPt = Math.max(
+    1,
+    placement.availableWidthPt
+      - context.physicalIndentLeftPt
+      - context.physicalIndentRightPt,
+  );
+  const paragraphXPt = placement.paragraphXPt + context.physicalIndentLeftPt;
+  const requestedSpaceBeforePt = context.spaceBeforePt;
+  const requestedSpaceAfterPt = context.spaceAfterPt;
+  const recordedPlacement = Object.freeze({ ...placement });
+  const fontFamilyClasses = measurer.fontFamilyClasses as Record<string, string>;
+
+  let cursorPt = placement.startYPt
+    + (placement.suppressSpaceBefore ? 0 : requestedSpaceBeforePt);
+  if (placement.wrap) {
+    cursorPt = placement.wrap.skipTopAndBottomBands(cursorPt);
+  }
+
+  const measureMarkOnly = (): MeasuredParagraph => {
+    let markTopPt = cursorPt;
+    if (placement.wrap) {
+      markTopPt = placement.wrap.lineWindow({
+        topYPt: markTopPt,
+        minimumStartWidthPt: getDefaultFontSize(paragraph),
+        probeHeightPt: 10,
+        paragraphXPt,
+        maximumWidthPt: paragraphWidthPt,
+      }).topYPt;
+    }
+    const markAdvancePt = paragraphMarkLineHeight(
+      paragraph,
+      1,
+      grid,
+      context.hasRuby,
+      environment.documentHasEastAsianText === true,
+      measurer.context,
+      fontFamilyClasses,
+      context.lineSpacing,
+    );
+    return {
+      lines: [],
+      markOnly: true,
+      requestedSpaceBeforePt,
+      requestedSpaceAfterPt,
+      contentStartYPt: markTopPt,
+      contentEndYPt: markTopPt + markAdvancePt,
+      placement: recordedPlacement,
+    };
+  };
+
+  const segments = buildSegments(paragraph.runs, environment);
+  if (segments.length === 0) return measureMarkOnly();
+
+  const wrapContext: WrapLayoutCtx | undefined = placement.wrap
+    ? {
+        startPageY: cursorPt,
+        paraX: paragraphXPt,
+        floats: [],
+        lineWindow: (input) => placement.wrap!.lineWindow(input),
+        lineBoxH: (ascent, descent, _hasRuby, intendedSingle) => lineBoxHeight(
+          context.lineSpacing,
+          ascent,
+          descent,
+          1,
+          grid,
+          context.hasRuby,
+          intendedSingle ?? 0,
+          context.hasEastAsianText,
+        ),
+        pageH: placement.maximumYPt,
+      }
+    : undefined;
+  const lines = layoutLines(
+    measurer.context,
+    segments,
+    paragraphWidthPt,
+    context.firstIndentPt,
+    1,
+    [...context.tabStops],
+    wrapContext,
+    fontFamilyClasses,
+    context.physicalIndentLeftPt,
+    context.kinsoku,
+    context.characterGrid.active ? context.characterGrid.deltaPt : 0,
+    context.defaultTabPt,
+    paragraphWidthPt + context.physicalIndentRightPt,
+    context.baseRtl,
+  );
+  if (lines.length === 0) return measureMarkOnly();
+
+  const uniformRubyAdvancePt = context.hasRuby
+    ? snapParagraphLineToGrid(
+        Math.max(0, ...lines.map((line) => lineBoxHeight(
+          context.lineSpacing,
+          line.ascent,
+          line.descent,
+          1,
+          grid,
+          true,
+          line.intendedSingle,
+          context.hasEastAsianText,
+        ))),
+        grid,
+      )
+    : 0;
+  const measuredLines: MeasuredLine[] = [];
+  for (const line of lines) {
+    const topYPt = line.topY !== undefined && line.topY > cursorPt
+      ? line.topY
+      : cursorPt;
+    const advancePt = context.hasRuby
+      ? uniformRubyAdvancePt
+      : lineBoxHeight(
+          context.lineSpacing,
+          line.ascent,
+          line.descent,
+          1,
+          grid,
+          false,
+          line.intendedSingle,
+          context.hasEastAsianText,
+        );
+    measuredLines.push({ layout: line, topYPt, advancePt });
+    cursorPt = topYPt + advancePt;
+  }
+
+  return {
+    lines: measuredLines,
+    markOnly: false,
+    requestedSpaceBeforePt,
+    requestedSpaceAfterPt,
+    contentStartYPt: measuredLines[0].topYPt,
+    contentEndYPt: cursorPt,
+    placement: recordedPlacement,
+  };
+}

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3831,7 +3831,11 @@ function splitParagraphAcrossPages(
     );
     let measured = measureAtCurrentPlacement(suppressSpaceBefore);
     const placeMarkOnly = (): { endY: number } => {
-      measured = measureAtCurrentPlacement(suppressSpaceBefore);
+      // Reuse the entry measurement: nothing that measureAtCurrentPlacement reads
+      // (measureState.y, floats, width, pageH, suppressSpaceBefore) changes between
+      // it and the single call site below, and measurement is deterministic for
+      // identical inputs — so a re-measure here would return the same result. The
+      // page-overflow branch re-measures because newPage() changes the placement.
       const measuredHeight = () => measured.contentEndYPt - measured.placement.startYPt
         + Math.max(
           measured.requestedSpaceAfterPt,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -9693,7 +9693,60 @@ function measureCellParagraphHeight(
         },
       );
     }
-    return (measured.contentEndYPt - measured.placement.startYPt) * scale;
+    // measureParagraph works in scale-1 points (its contract). A geometric
+    // `× scale` of that height is the exact anti-pattern rescaleLayoutLines
+    // exists to avoid: a real (hinted) font's Canvas metrics are NOT scale-linear
+    // (`metric(pt·s) ≠ s·metric(pt)`; see rescaleLayoutLines' header and
+    // layout-lines-scale-invariance.test.ts), so `scale1Height × scale` drifts
+    // from the height the paint pass (renderParagraph) actually draws. Reproduce
+    // the SAME scale-1-partition → paint-scale bridge paint uses, so the measured
+    // cell height equals the painted height at `scale` — the height that feeds
+    // vAlign centring (renderCell) and the content-driven row-height fallback
+    // (computeTableLayout → resolveTableRowHeights).
+    const scale1ContentHeight = measured.contentEndYPt - measured.placement.startYPt;
+    if (scale === 1) return scale1ContentHeight;
+    const paraHasRuby = paragraphContext.hasRuby;
+    const eastAsian = paragraphContext.hasEastAsianText;
+    if (measured.markOnly || measured.lines.length === 0) {
+      // Empty / anchor-only paragraph mark (§17.3.1.29): renderEmptyMarkParagraph
+      // reserves the mark-line height at the PAINT scale, not scale-1 × scale.
+      return paragraphMarkLineHeight(
+        para,
+        scale,
+        grid,
+        paraHasRuby,
+        state.docEastAsian,
+        state.ctx,
+        state.fontFamilyClasses,
+      );
+    }
+    // Rehydrate the scale-1 line PARTITION to the paint scale exactly as
+    // renderParagraph does (re-measure every line's glyph geometry), then advance
+    // by the per-line box height with the SAME ruby/docGrid/lineSpacing resolver
+    // (§17.3.1.33). A table cell carries no page-level float wrap oracle, so no
+    // line has a topY jump; the painted content height is Σ lineHForLine over the
+    // whole, unsliced paragraph.
+    const paintLines = rescaleLayoutLines(
+      measured.lines.map((line) => line.layout),
+      scale,
+      state.ctx,
+      state.fontFamilyClasses,
+      gridCharDeltaPx(grid, scale),
+    );
+    const uniformLineH = paraHasRuby
+      ? snapParaLineToGrid(
+          Math.max(0, ...paintLines.map((l) => lineBoxHeight(
+            para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, eastAsian,
+          ))),
+          grid,
+          scale,
+        )
+      : 0;
+    const lineHForLine = (l: LayoutLine): number =>
+      paraHasRuby
+        ? uniformLineH
+        : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, eastAsian);
+    return paintedParagraphHeight(paintLines, 0, paintLines.length, 0, lineHForLine);
   }
 }
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -158,6 +158,11 @@ import {
   emphasisMarkGeometry,
 } from './emphasis-mark.js';
 import {
+  createFloatWrapOracle,
+  measureParagraph,
+  type ParagraphMeasurementEnvironment,
+} from './paragraph-measure.js';
+import {
   drawVerticalRun,
   drawTateChuYokoRun,
   drawUprightBox,
@@ -2904,7 +2909,7 @@ export function computePages(
       const remainingH = columnBottomLimit() - y;
       if (fitHeight > remainingH && splittable) {
         const placed = splitParagraphAcrossPages(
-          measureState, para, colW(), suppressBefore, colX(),
+          measureState, para, colW, suppressBefore, colX,
           y, pageContentH, pages,
           // Overflow during the split advances to the next column first, then a
           // new page (newspaper fill). The just-filled column's bottom is folded
@@ -3610,6 +3615,33 @@ function buildMeasureState(
   };
 }
 
+function paragraphMeasurementEnvironment(
+  state: Pick<
+    RenderState,
+    | 'pageIndex'
+    | 'totalPages'
+    | 'displayPageNumber'
+    | 'pageNumberFormat'
+    | 'currentDateMs'
+    | 'noteNumbers'
+    | 'currentNoteNumber'
+    | 'verticalCJK'
+    | 'docEastAsian'
+  >,
+): ParagraphMeasurementEnvironment {
+  return {
+    pageIndex: state.pageIndex,
+    totalPages: state.totalPages,
+    displayPageNumber: state.displayPageNumber,
+    pageNumberFormat: state.pageNumberFormat,
+    currentDateMs: state.currentDateMs,
+    noteNumbers: state.noteNumbers,
+    currentNoteNumber: state.currentNoteNumber,
+    verticalCJK: state.verticalCJK,
+    documentHasEastAsianText: state.docEastAsian,
+  };
+}
+
 function estimateParagraphHeight(
   state: RenderState,
   para: DocParagraph,
@@ -3620,103 +3652,30 @@ function estimateParagraphHeight(
    *  its bottom edge is suppressed (the box continues) and reserves no extent. */
   nextSharesBottomBorder = false,
 ): number {
-  // ECMA-376 §17.3.1.12 / Part 4 §14.11.2 — the transitional left/right indent
-  // attributes are logical start/end, so they swap physical sides in a bidi
-  // paragraph. Resolve the PHYSICAL indents once and use them for the float
-  // window (paraX), the tab origin and the text-margin right edge below, so
-  // this measure pass agrees with renderParagraph's paint pass (a bidi
-  // paragraph's tab stops anchor at the text margin — layoutBidiTabStops —
-  // and a mismatched tabOrigin/marginRight here would wrap differently).
   const paragraphContext = resolveBodyParagraphLayoutContext(state, para);
-  const indLeft = paragraphContext.physicalIndentLeftPt;
-  const indRight = paragraphContext.physicalIndentRightPt;
-  const paraW = Math.max(1, contentWPt - indLeft - indRight);
-  const paraX = paraXPt + indLeft;
-  const segs = buildSegments(para.runs, state);
-  // Word renders ruby paragraphs with consistent line spacing — every line
-  // in a paragraph that carries ANY furigana snaps to the same pitch
-  // multiple, otherwise mixed-ruby paragraphs jitter and pagination drifts.
-  const paraHasRuby = paragraphContext.hasRuby;
-  const grid = paraGrid(para, state);
-  // Mirror renderParagraph's vertical advancement EXACTLY so the paginator's
-  // page-fill tracker matches where the renderer actually draws each line. With
-  // anchor floats active a paragraph's text (and even an empty paragraph mark)
-  // is pushed BELOW the float band (ECMA-376 §20.4.2.x; resolveLineFloatWindow /
-  // skipPastTopAndBottom), and that vertical displacement — not just the line
-  // heights — consumes page space. The previous estimate summed only the line
-  // heights, so the paginator under-counted full-width-float pages and packed
-  // far too much onto them (sample-9 page-4: the photo block displaced the body
-  // text, but the paginator ignored the gap and let the bullet list spill past
-  // the bottom margin). Reproduce the renderer's cursor walk:
-  //   spaceBefore → skipPastTopAndBottom → per line: max(topY) then += lineH
-  //   (empty/anchor-only: flow the mark line below the band) → spaceAfter.
-  // When no floats are active skipPastTopAndBottom is a no-op and no line carries
-  // a topY, so this collapses to spaceBefore + Σ lineHeights + spaceAfter — the
-  // exact previous value, leaving float-free documents unchanged.
-  const hasFloats = state.floats.length > 0;
-  const startY = state.y;
-  let cursor = startY + (suppressSpaceBefore ? 0 : para.spaceBefore);
-  if (hasFloats) cursor = skipPastTopAndBottom(cursor, state.floats);
-  const flowMarkLine = (): void => {
-    // Empty / anchor-only paragraph: one paragraph-mark line box, flowed below a
-    // full-width float band exactly like renderEmptyMarkParagraph. An empty mark
-    // uses the pilcrow-em threshold (paragraphMarkEmPx; scale 1 here in the
-    // paginator's pt-space mirror), NOT the 1-inch content-line rule — Word keeps
-    // the mark beside the float whenever the gap holds the pilcrow and drops it
-    // below only for a full-width band (sample-9 p.4 / sample-12 p.2, the #676 regression).
-    // Mirrors the paint pass's resolveEmptyMarkTop so the two agree.
-    if (hasFloats) {
-      const win = resolveLineFloatWindow(cursor, paragraphMarkEmPx(para, 1), 10, paraX, paraW, state.floats);
-      if (win.topY > cursor) cursor = win.topY;
-    }
-    cursor += paragraphMarkLineHeight(para, 1, grid, paraHasRuby, state.docEastAsian, state.ctx, state.fontFamilyClasses);
-  };
-  if (segs.length === 0) {
-    flowMarkLine();
-  } else {
-    // Same WrapLayoutCtx the renderer uses (startPageY is the post-spaceBefore,
-    // post-skip top — matching renderParagraph) so the laid-out line `topY`s
-    // and line count agree with the paint pass.
-    const wrapCtx: WrapLayoutCtx | undefined = hasFloats ? {
-      startPageY: cursor,
-      paraX,
-      floats: state.floats,
-      lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, grid, paraHasRuby, is ?? 0, paragraphContext.hasEastAsianText),
-      pageH: state.pageH,
-    } : undefined;
-    const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, gridCharDeltaPx(grid, 1), state.defaultTabPt, paraW + indRight, para.bidi === true);
-    if (lines.length === 0) {
-      // Anchor-only paragraph: no inline content, but the paragraph mark still
-      // occupies one (possibly flowed) line (§17.3.1.29).
-      flowMarkLine();
-    } else if (paraHasRuby) {
-      // Word uses the same line height for every line in a ruby paragraph,
-      // snapped to an integer docGrid pitch.
-      const uniform = snapParaLineToGrid(
-        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, grid, true, l.intendedSingle, paragraphContext.hasEastAsianText))),
-        grid,
-        1,
-      );
-      for (const l of lines) {
-        if (l.topY !== undefined && l.topY > cursor) cursor = l.topY;
-        cursor += uniform;
-      }
-    } else {
-      for (const l of lines) {
-        if (l.topY !== undefined && l.topY > cursor) cursor = l.topY;
-        cursor += lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, grid, false, l.intendedSingle, paragraphContext.hasEastAsianText);
-      }
-    }
-  }
-  // §17.3.1.7: a BOTTOM border extends `space + width/2` below the text box; the
-  // next paragraph must clear it (bottomBorderExtentPt). spaceAfter (trailing
-  // whitespace) already pushes content down, so reserve only the amount by which
-  // the border pokes PAST spaceAfter — MAX, not SUM — matching Word (which does not
-  // stack the border extent on top of a larger spaceAfter). Suppressed when a
-  // same-border paragraph follows (the box continues; no bottom edge is drawn).
+  const startYPt = state.y;
+  const measured = measureParagraph(
+    para,
+    paragraphContext,
+    {
+      startYPt,
+      paragraphXPt: paraXPt,
+      availableWidthPt: contentWPt,
+      maximumYPt: state.pageH,
+      suppressSpaceBefore,
+      wrap: state.floats.length > 0
+        ? createFloatWrapOracle(state.floats)
+        : undefined,
+    },
+    {
+      context: state.ctx,
+      fontFamilyClasses: state.fontFamilyClasses,
+    },
+    paragraphMeasurementEnvironment(state),
+  );
   const bottomExtent = nextSharesBottomBorder ? 0 : bottomBorderExtentPt(para.borders);
-  cursor += Math.max(para.spaceAfter, bottomExtent);
-  return cursor - startY;
+  return measured.contentEndYPt - startYPt
+    + Math.max(measured.requestedSpaceAfterPt, bottomExtent);
 }
 
 /** Snap a paragraph's uniform line height up to an integer multiple of the
@@ -3770,9 +3729,9 @@ function paraGrid(para: DocParagraph, state: RenderState): DocGridCtx {
 function splitParagraphAcrossPages(
   measureState: RenderState,
   para: DocParagraph,
-  contentWPt: number,
+  contentWPt: () => number,
   suppressSpaceBefore: boolean,
-  marginLeftPt: number,
+  paragraphXPt: () => number,
   initialY: number,
   contentH: number,
   pages: PaginatedBodyElement[][],
@@ -3845,162 +3804,134 @@ function splitParagraphAcrossPages(
     if (tagSectionPageNumType) el.sectionPageNumType = tagSectionPageNumType();
     return el;
   };
-  // Mirror renderParagraph's PHYSICAL indents (ECMA-376 §17.3.1.12; the
-  // left/right indents swap to physical sides in a bidi paragraph, Part 4
-  // §14.11.2). They feed the float-window X (paraX), the tab origin and the
-  // text-margin right edge passed to layoutLines below — a logical/physical
-  // mismatch there would anchor a bidi paragraph's tab stops differently from
-  // the paint pass (layoutBidiTabStops measures stops from the text margin)
-  // and re-introduce a paginate/render disagreement.
-  const paragraphContext = resolveBodyParagraphLayoutContext(measureState, para);
-  const grid = paraGrid(para, measureState);
-  const indLeft = paragraphContext.physicalIndentLeftPt;
-  const indRight = paragraphContext.physicalIndentRightPt;
-  const paraW = Math.max(1, contentWPt - indLeft - indRight);
-  const paraX = marginLeftPt + indLeft;
-  // A paragraph with no layoutable inline lines (literally empty, or only
-  // wrap-float anchors) is a single paragraph-mark line (§17.3.1.29) that cannot
-  // be split. If it doesn't fit in the space left on this page, relocate it
-  // whole to the next page — matching the wholesale break the paginator applies
-  // to unsplittable paragraphs — instead of letting the mark overflow the bottom
-  // margin (which the prior unconditional break never allowed).
-  const placeMarkOnly = (): { endY: number } => {
-    let markH = estimateParagraphHeight(measureState, para, contentWPt, suppressSpaceBefore, marginLeftPt);
-    let top = initialY;
-    if (initialY > 0 && initialY + markH - para.spaceAfter > colBot()) {
-      newPage(initialY);
-      top = colTop();
-      markH = estimateParagraphHeight(measureState, para, contentWPt, suppressSpaceBefore, marginLeftPt);
-    }
-    pages[pages.length - 1].push(stamp(para as PaginatedBodyElement));
-    return { endY: top + markH };
-  };
-  const segs = buildSegments(para.runs, measureState);
-  if (segs.length === 0) {
-    return placeMarkOnly();
-  }
-  const wrapCtx: WrapLayoutCtx | undefined = measureState.floats.length > 0 ? {
-    startPageY: measureState.y,
-    paraX,
-    floats: measureState.floats,
-    lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, 1, grid, paragraphContext.hasRuby, is ?? 0, paragraphContext.hasEastAsianText),
-    pageH: measureState.pageH,
-  } : undefined;
-  const lines = layoutLines(measureState.ctx, segs, paraW, para.indentFirst, 1, para.tabStops, wrapCtx, measureState.fontFamilyClasses, indLeft, measureState.kinsoku, gridCharDeltaPx(grid, 1), measureState.defaultTabPt, paraW + indRight, para.bidi === true);
-  if (lines.length === 0) {
-    // Anchor-only paragraph: no inline lines, but the paragraph mark still
-    // occupies one (possibly relocated) line (§17.3.1.29).
-    return placeMarkOnly();
-  }
-  const paraHasRuby = paragraphContext.hasRuby;
+  {
+    const paragraphContext = resolveBodyParagraphLayoutContext(measureState, para);
+    const grid = gridForParagraphContext(measureState, paragraphContext);
+    const indLeft = paragraphContext.physicalIndentLeftPt;
+    const indRight = paragraphContext.physicalIndentRightPt;
+    let paraW = Math.max(1, contentWPt() - indLeft - indRight);
+    const measureAtCurrentPlacement = (suppressLeadingSpace: boolean) => measureParagraph(
+      para,
+      paragraphContext,
+      {
+        startYPt: measureState.y,
+        paragraphXPt: paragraphXPt(),
+        availableWidthPt: contentWPt(),
+        maximumYPt: measureState.pageH,
+        suppressSpaceBefore: suppressLeadingSpace,
+        wrap: measureState.floats.length > 0
+          ? createFloatWrapOracle(measureState.floats)
+          : undefined,
+      },
+      {
+        context: measureState.ctx,
+        fontFamilyClasses: measureState.fontFamilyClasses,
+      },
+      paragraphMeasurementEnvironment(measureState),
+    );
+    let measured = measureAtCurrentPlacement(suppressSpaceBefore);
+    const placeMarkOnly = (): { endY: number } => {
+      measured = measureAtCurrentPlacement(suppressSpaceBefore);
+      const measuredHeight = () => measured.contentEndYPt - measured.placement.startYPt
+        + Math.max(
+          measured.requestedSpaceAfterPt,
+          bottomBorderExtentPt(para.borders),
+        );
+      let markH = measuredHeight();
+      let top = initialY;
+      if (initialY > 0 && initialY + markH - measured.requestedSpaceAfterPt > colBot()) {
+        newPage(initialY);
+        top = colTop();
+        measured = measureAtCurrentPlacement(suppressSpaceBefore);
+        markH = measuredHeight();
+      }
+      pages[pages.length - 1].push(stamp(para as PaginatedBodyElement));
+      return { endY: top + markH };
+    };
+    if (measured.markOnly || measured.lines.length === 0) return placeMarkOnly();
 
-  // Compute-once eligibility, once per paragraph: a paragraph whose segment
-  // TEXT depends on the paint state (page/numPages fields, note references)
-  // must not ship its measure-time lines — the stamped text would be stale.
-  // See paragraphSegsStateSensitive.
-  const stampLines = !paragraphSegsStateSensitive(para);
+    const measuredLineExtents = (): number[] => measured.lines.map((line, index) => {
+      if (index === 0) {
+        return line.topYPt - measured.placement.startYPt + line.advancePt;
+      }
+      const previous = measured.lines[index - 1];
+      const previousBottomYPt = previous.topYPt + previous.advancePt;
+      return Math.max(0, line.topYPt - previousBottomYPt) + line.advancePt;
+    });
+    let lines = measured.lines.map((line) => line.layout);
+    let lineExtents = measuredLineExtents();
+    const remeasureBeforeFirstLine = (): void => {
+      measured = measureAtCurrentPlacement(suppressSpaceBefore);
+      paraW = Math.max(1, measured.placement.availableWidthPt - indLeft - indRight);
+      lines = measured.lines.map((line) => line.layout);
+      lineExtents = measuredLineExtents();
+    };
+    const stampLines = !paragraphSegsStateSensitive(para);
+    const trailingExtent = Math.max(
+      measured.requestedSpaceAfterPt,
+      bottomBorderExtentPt(para.borders),
+    );
 
-  const perLineH = (l: typeof lines[number]) => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, 1, grid, paraHasRuby, l.intendedSingle, paragraphContext.hasEastAsianText);
-  const uniformH = paraHasRuby
-    ? snapParaLineToGrid(Math.max(0, ...lines.map(perLineH)), grid, 1)
-    : 0;
-  const lineHeights = lines.map(l => paraHasRuby ? uniformH : perLineH(l));
-  const spaceBefore = suppressSpaceBefore ? 0 : para.spaceBefore;
-  const spaceAfter = para.spaceAfter;
-
-  let lineIdx = 0;
-  let cursorY = initialY;
-  let isFirstSliceOnPage = true; // first slice carries spaceBefore
-  while (lineIdx < lines.length) {
-    // Available space in the current column from cursorY downward (balance target
-    // for a non-last balanced column; the page bottom otherwise).
-    const remaining = colBot() - cursorY;
-    // First slice on a page reserves spaceBefore; the LAST slice (covering
-    // the final line) reserves spaceAfter.
-    const sliceLeading = isFirstSliceOnPage ? spaceBefore : 0;
-    let usedH = sliceLeading;
-    let firstFitting = lineIdx;
-    let lastFitting = lineIdx;
-    while (lastFitting < lines.length && usedH + lineHeights[lastFitting] <= remaining) {
-      usedH += lineHeights[lastFitting];
-      lastFitting++;
-    }
-    if (lastFitting === firstFitting) {
-      // Not even one line fits on this page — flush to a new page and retry.
-      // Guard against infinite loop: if we're already at the start of a
-      // fresh page (cursorY ≈ 0) and still don't fit, force-emit one line.
-      if (cursorY > 0) {
+    let lineIdx = 0;
+    let cursorY = initialY;
+    while (lineIdx < lines.length) {
+      const remaining = colBot() - cursorY;
+      let usedH = 0;
+      const firstFitting = lineIdx;
+      let lastFitting = lineIdx;
+      while (lastFitting < lines.length && usedH + lineExtents[lastFitting] <= remaining) {
+        usedH += lineExtents[lastFitting];
+        lastFitting++;
+      }
+      if (lastFitting === firstFitting) {
+        if (cursorY > 0) {
+          newPage(cursorY);
+          cursorY = colTop();
+          if (lineIdx === 0) remeasureBeforeFirstLine();
+          continue;
+        }
+        lastFitting = firstFitting + 1;
+        usedH += lineExtents[firstFitting];
+      }
+      if (para.widowControl !== false && lastFitting < lines.length) {
+        if (lines.length - lastFitting === 1 && lastFitting - firstFitting >= 2) {
+          lastFitting--;
+          usedH -= lineExtents[lastFitting];
+        }
+        if (firstFitting === 0 && lastFitting - firstFitting === 1 && cursorY > 0) {
+          newPage(cursorY);
+          cursorY = colTop();
+          remeasureBeforeFirstLine();
+          continue;
+        }
+      }
+      const isFinalSlice = lastFitting === lines.length;
+      if (isFinalSlice) usedH += trailingExtent;
+      const sliceEl = {
+        ...(para as object),
+        type: 'paragraph',
+        lineSlice: { start: firstFitting, end: lastFitting },
+      } as PaginatedElementWithLines;
+      if (stampLines) {
+        stampParagraphLines(sliceEl, lines, {
+          paraW,
+          firstIndent: para.indentFirst,
+          tabOriginPx: indLeft,
+          gridDeltaPx: gridCharDeltaPx(grid, 1),
+          hasFloats: measured.placement.wrap !== undefined,
+          kinsoku: measureState.kinsoku,
+        });
+      }
+      pages[pages.length - 1].push(stamp(sliceEl));
+      lineIdx = lastFitting;
+      cursorY += usedH;
+      if (!isFinalSlice) {
         newPage(cursorY);
         cursorY = colTop();
-        isFirstSliceOnPage = true;
-        continue;
-      }
-      // First page, first line doesn't fit — force-emit it and let it overflow.
-      lastFitting = firstFitting + 1;
-      usedH += lineHeights[firstFitting];
-    }
-    // ECMA-376 §17.3.1.44 widowControl (default ON): keep at least two lines of
-    // the paragraph together across a page break — never strand a single trailing
-    // line on a later page (widow) nor a single leading line at a page bottom
-    // (orphan). Skipped when w:widowControl is explicitly off
-    // (para.widowControl === false). Only applies when lines actually carry over
-    // (lastFitting < lines.length); the final slice can legally be one line.
-    if (para.widowControl !== false && lastFitting < lines.length) {
-      // Widow: this slice would leave exactly one line for a later page. Pull one
-      // line down with it so ≥2 carry over — provided this slice keeps ≥1 line.
-      if (lines.length - lastFitting === 1 && lastFitting - firstFitting >= 2) {
-        lastFitting--;
-        usedH -= lineHeights[lastFitting];
-      }
-      // Orphan: the paragraph's first line would sit alone at this page's bottom
-      // (more lines follow). Relocate the paragraph start to the next page so it
-      // begins with ≥2 lines — only when there is room above to break from
-      // (cursorY > 0); a lone line at a fresh page top cannot be helped. Also
-      // catches the case the widow pull above just reduced to a single line.
-      if (firstFitting === 0 && lastFitting - firstFitting === 1 && cursorY > 0) {
-        newPage(cursorY);
-        cursorY = colTop();
-        isFirstSliceOnPage = true;
-        continue;
       }
     }
-    const isFinalSlice = lastFitting === lines.length;
-    if (isFinalSlice) usedH += spaceAfter;
-    const sliceEl = {
-      ...(para as object),
-      type: 'paragraph',
-      lineSlice: { start: firstFitting, end: lastFitting },
-    } as PaginatedElementWithLines;
-    // Phase 4-1 B2 Stage 1 — hand the paint pass the scale-1 lines this split
-    // already computed so it can skip re-running layoutLines (compute-once).
-    // The FULL array is stamped on every slice (not `lines.slice(...)`) because
-    // the paint loop indexes by absolute line number; `lineSlice` still selects
-    // the sub-range to paint. The same immutable array is shared across slices
-    // and across repeated renderPage calls — the draw path only reads it. The
-    // recorded inputs let the paint pass verify its own layout would be
-    // identical before reusing (see renderParagraph's reuse gate). Skipped for
-    // state-sensitive segments (stampLines above): those keep the recompute
-    // path so field text resolves against the real page context.
-    if (stampLines) {
-      stampParagraphLines(sliceEl, lines, {
-        paraW,
-        firstIndent: para.indentFirst,
-        tabOriginPx: indLeft,
-        gridDeltaPx: gridCharDeltaPx(paraGrid(para, measureState), 1),
-        hasFloats: wrapCtx !== undefined,
-        kinsoku: measureState.kinsoku,
-      });
-    }
-    pages[pages.length - 1].push(stamp(sliceEl));
-    lineIdx = lastFitting;
-    cursorY += usedH;
-    if (!isFinalSlice) {
-      newPage(cursorY);
-      cursorY = colTop();
-      isFirstSliceOnPage = true;
-    }
+    return { endY: cursorY };
   }
-  return { endY: cursorY };
 }
 
 /** Per-row heights (pt) used by both pagination and the keep-with-next height
@@ -4444,58 +4375,42 @@ function layoutCellParagraphForRowSplit(
   innerWPt: number,
   state: RenderState,
 ): { lines: LayoutLine[]; lineHeights: number[]; inputs: Parameters<typeof stampParagraphLines>[2] } | null {
-  const segs = buildSegments(para.runs, state);
-  if (segs.length === 0) return null;
-  const paragraphContext = resolveStateParagraphLayoutContext(state, para);
-  const grid = gridForParagraphContext(state, paragraphContext);
-  const paraHasRuby = paragraphContext.hasRuby;
-  const indLeft = paragraphContext.physicalIndentLeftPt;
-  const indRight = paragraphContext.physicalIndentRightPt;
-  const paraW = Math.max(1, innerWPt - indLeft - indRight);
-  const gridDeltaPx = gridCharDeltaPx(grid, 1);
-  const lines = layoutLines(
-    state.ctx,
-    segs,
-    paraW,
-    para.indentFirst,
-    1,
-    para.tabStops,
-    undefined,
-    state.fontFamilyClasses,
-    indLeft,
-    state.kinsoku,
-    gridDeltaPx,
-    state.defaultTabPt,
-    para.bidi === true ? paraW + indRight : paraW,
-    para.bidi === true,
-  );
-  if (lines.length === 0) return null;
-  const perLineH = (l: LayoutLine) =>
-    lineBoxHeight(
-      para.lineSpacing,
-      l.ascent,
-      l.descent,
-      1,
-      grid,
-      paraHasRuby,
-      l.intendedSingle,
-      paragraphContext.hasEastAsianText,
+  {
+    const paragraphContext = resolveStateParagraphLayoutContext(state, para);
+    const grid = gridForParagraphContext(state, paragraphContext);
+    const indLeft = paragraphContext.physicalIndentLeftPt;
+    const indRight = paragraphContext.physicalIndentRightPt;
+    const paraW = Math.max(1, innerWPt - indLeft - indRight);
+    const measured = measureParagraph(
+      para,
+      paragraphContext,
+      {
+        startYPt: 0,
+        paragraphXPt: 0,
+        availableWidthPt: innerWPt,
+        maximumYPt: state.pageH,
+        suppressSpaceBefore: true,
+      },
+      {
+        context: state.ctx,
+        fontFamilyClasses: state.fontFamilyClasses,
+      },
+      paragraphMeasurementEnvironment(state),
     );
-  const uniformH = paraHasRuby
-    ? snapParaLineToGrid(Math.max(0, ...lines.map(perLineH)), grid, 1)
-    : 0;
-  return {
-    lines,
-    lineHeights: lines.map((l) => (paraHasRuby ? uniformH : perLineH(l))),
-    inputs: {
-      paraW,
-      firstIndent: para.indentFirst,
-      tabOriginPx: indLeft,
-      gridDeltaPx,
-      hasFloats: false,
-      kinsoku: state.kinsoku,
-    },
-  };
+    if (measured.markOnly || measured.lines.length === 0) return null;
+    return {
+      lines: measured.lines.map((line) => line.layout),
+      lineHeights: measured.lines.map((line) => line.advancePt),
+      inputs: {
+        paraW,
+        firstIndent: para.indentFirst,
+        tabOriginPx: indLeft,
+        gridDeltaPx: gridCharDeltaPx(grid, 1),
+        hasFloats: false,
+        kinsoku: state.kinsoku,
+      },
+    };
+  }
 }
 
 function paragraphLineSliceHeight(
@@ -9742,137 +9657,44 @@ function measureCellParagraphHeight(
   maxWidth: number,
   scale: number,
 ): number {
-  const segs = buildSegments(para.runs, state);
-  const paragraphContext = resolveStateParagraphLayoutContext(state, para);
-  const paraHasRuby = paragraphContext.hasRuby;
-  const grid = gridForParagraphContext(state, paragraphContext);
-  if (segs.length === 0) {
-    // ECMA-376 §17.3.1.29: an empty (or anchor-only) paragraph still produces one
-    // paragraph-mark line box. Size it with the SAME `paragraphMarkLineHeight`
-    // (ctx-based, correctedLineMetrics) the paint pass draws with
-    // (renderEmptyMarkParagraph) — NOT the synthetic 0.8/0.2-em `emptyLineNaturalPx`,
-    // which under-measures every substituted (e.g. Latin ~1.15em) mark font and so
-    // reserved a shorter row than the mark actually paints. Using the drawn height
-    // makes this row measurer measure == draw for empty cell paragraphs, closing
-    // the measure/paint gap that the paginator's `estimateParagraphHeight` (which
-    // already used `paragraphMarkLineHeight`) did not share with the paint side.
-    return paragraphMarkLineHeight(
+  {
+    const paragraphContext = resolveStateParagraphLayoutContext(state, para);
+    const grid = gridForParagraphContext(state, paragraphContext);
+    const availableWidthPt = maxWidth / scale;
+    const measured = measureParagraph(
       para,
-      scale,
-      grid,
-      paraHasRuby,
-      state.docEastAsian,
-      state.ctx,
-      state.fontFamilyClasses,
+      paragraphContext,
+      {
+        startYPt: 0,
+        paragraphXPt: 0,
+        availableWidthPt,
+        maximumYPt: state.pageH / scale,
+        suppressSpaceBefore: true,
+      },
+      {
+        context: state.ctx,
+        fontFamilyClasses: state.fontFamilyClasses,
+      },
+      paragraphMeasurementEnvironment(state),
     );
+    if (scale === 1 && !measured.markOnly && !paragraphSegsStateSensitive(para)) {
+      const indLeft = paragraphContext.physicalIndentLeftPt;
+      const indRight = paragraphContext.physicalIndentRightPt;
+      stampParagraphLines(
+        para,
+        measured.lines.map((line) => line.layout),
+        {
+          paraW: Math.max(1, availableWidthPt - indLeft - indRight),
+          firstIndent: para.indentFirst,
+          tabOriginPx: indLeft,
+          gridDeltaPx: gridCharDeltaPx(grid, 1),
+          hasFloats: false,
+          kinsoku: state.kinsoku,
+        },
+      );
+    }
+    return (measured.contentEndYPt - measured.placement.startYPt) * scale;
   }
-  // ECMA-376 §17.3.1.12 (`<w:ind>`): the paragraph's own left/right indent
-  // narrows the wrap width and `firstLine` insets the first line — exactly as
-  // the paint pass (renderParagraph) and the paginator (estimateParagraphHeight)
-  // lay it out. The row-height measurer MUST honor them too: without the indent,
-  // a cell paragraph that carries a first-line/left indent (e.g. sample-11's
-  // table cells, firstLine=21.6 pt) is measured for fewer wrapped lines than it
-  // paints, so the row is sized too short and the overflow ("Town" /
-  // "University") bleeds into the next row. `maxWidth` is the cell's inner width
-  // (cell margins already removed by the caller); the paragraph indents come off
-  // it here. `tabOriginPx = indentLeft` mirrors layoutLines' tab origin in the
-  // paint/paginate paths.
-  //
-  // NOTE: like `estimateParagraphHeight` (the paginator), this passes the raw
-  // `indentFirst` and does NOT model a numbering marker's `numBodyOffset` (the
-  // hanging-indent first-line geometry `renderParagraph` applies for a numbered
-  // paragraph). The two non-paint measurers therefore stay consistent with each
-  // other, but a NUMBERED paragraph inside a cell that wraps can still measure
-  // slightly differently from the paint pass. No such cell exists in the covered
-  // samples; revisit together with estimateParagraphHeight if list-in-cell
-  // fidelity is needed.
-  // PHYSICAL indents (§17.3.1.12 / Part 4 §14.11.2 — logical start/end swap
-  // sides under a bidi paragraph), matching renderParagraph's paint pass so a
-  // bidi cell paragraph's tab origin / text-margin edge agree between the row
-  // measurer and the paint (LTR values are untouched).
-  const indLeftPx = paragraphContext.physicalIndentLeftPt * scale;
-  const indRightPx = paragraphContext.physicalIndentRightPt * scale;
-  const paraW = Math.max(1, maxWidth - indLeftPx - indRightPx);
-  // RESERVATION: no `marginRightPx` argument is passed here, so a
-  // `<w:ptab w:relativeTo="margin">` inside a table cell resolves its target
-  // against the DEFAULT (`= paraW`, the cell's INNER content box after
-  // margins/indents) rather than the true text-margin right edge
-  // (`paraW + indRightPx`, matching how `renderParagraph`'s paint pass
-  // computes `marginRightPx`/`marginRightPx1` — see its "§17.3.3.23" comment
-  // a few hundred lines up). Left unwired deliberately: this scale-1 call is
-  // also where `stampParagraphLines` below caches the partition for
-  // `renderParagraph`'s paint-time reuse gate, and that gate's
-  // `layoutLinesInputs` (types + comparison, ~L4667–4689/L5632–5644) does NOT
-  // track `marginRightPx` at all — adding it correctly here means widening
-  // both the stamp payload and the reuse-equality check, not just this call
-  // site, to keep the two in sync. That's a real change to the Phase 4-1 B2
-  // compute-once mechanism for a narrow case (a ptab inside a cell, relative
-  // to the margin rather than the indent), so it's deferred rather than
-  // threaded through opportunistically. Revisit together with any other
-  // measure/paint mismatch cleanup in this area.
-  // marginRightPx: LTR keeps the deliberate `paraW` reservation above (ptab in a
-  // cell). A BIDI cell paragraph needs the true text-margin edge — its tab stops
-  // anchor there (layoutBidiTabStops) — so pass `paraW + indRightPx` only then;
-  // LTR cell layout is byte-identical.
-  const lines = layoutLines(state.ctx, segs, paraW, para.indentFirst * scale, scale, para.tabStops, undefined, state.fontFamilyClasses, indLeftPx, state.kinsoku, gridCharDeltaPx(grid, scale), state.defaultTabPt, para.bidi === true ? paraW + indRightPx : paraW, para.bidi === true);
-  // Phase 4-1 B2 T2 — compute-once for TABLE-CELL paragraphs. This is the ONLY
-  // point a cell paragraph's lines are laid out at scale 1: the paginator sizes
-  // every table row through computeTablePtLayout → resolveTableRowHeights →
-  // measureCellContentHeightPx → measureCellElementHeight → here (scale 1). Stamp
-  // those lines + inputs onto the paragraph so `renderParagraph`'s existing reuse
-  // gate (Stage 2) skips re-running layoutLines at paint. A cell paragraph is a
-  // PaginatedBodyElement in nothing but name (it is never split across pages), yet
-  // it IS a DocParagraph, so the same private line stamp rides on it and the same
-  // gate consumes it — no renderer-side change beyond this stamp is needed.
-  //
-  // Only at scale 1: the gate requires `layoutLinesInputs.scale === 1`, and the
-  // stamped numbers are the paginator's pt values that the paint gate reconstructs
-  // as `contentW/scale − ind…`. The paint-scale calls of this function
-  // (vAlign-centering measure in renderCell, and the dryRun measureCellContent
-  // path) MUST NOT overwrite the scale-1 stamp with paint-scale lines, so they are
-  // skipped here. `hasFloats` is always false: measureCellParagraphHeight passes `undefined`
-  // for the layoutLines wrap context (cell paragraphs are never wrapped around
-  // floats in the measure), and when a cell is painted inside a live float band
-  // renderParagraph takes its float path (case 3) and ignores this no-float stamp.
-  //
-  // Multiple scale-1 measures of the SAME cell (keepNext lookahead's
-  // estimateTableHeight, column-balancing's measureSectionColumnHeight, and the
-  // authoritative computeTablePtLayout that places the table) all reach here;
-  // last-writer-wins and the authoritative placement measure runs LAST, so its
-  // stamp — resolved at the SAME column width the paint pass uses — is the one that
-  // survives. Correctness never depends on which won: the paint gate re-derives the
-  // paragraph's width in scale-1 space and reuses the stamp ONLY when its recorded
-  // `paraW`/indent/grid/kinsoku match, else it recomputes (case 2). State-sensitive
-  // paragraphs (page/numPages fields, note refs) are excluded exactly as the body
-  // stamp excludes them — their segment text resolves against the real paint page.
-  // Nested tables recurse through the same path (measureCellElementHeight →
-  // estimateTableHeight → measureCellParagraphHeight at scale 1), so their inner cell
-  // paragraphs get stamped and reused by the same mechanism.
-  if (scale === 1 && !paragraphSegsStateSensitive(para)) {
-    stampParagraphLines(para, lines, {
-      paraW,
-      firstIndent: para.indentFirst,
-      tabOriginPx: indLeftPx, // == the PHYSICAL left indent at scale 1 (bidi swaps sides)
-      gridDeltaPx: gridCharDeltaPx(grid, 1),
-      hasFloats: false,
-      kinsoku: state.kinsoku,
-    });
-  }
-  if (paraHasRuby) {
-    // Ruby paragraph (§17.3.3.25 / §17.6.5): the paint pass (renderParagraph) and
-    // the paginator (estimateParagraphHeight) give EVERY line the same height —
-    // the tallest line's natural box snapped up to an integer docGrid pitch — so
-    // ruby-bearing and ruby-free lines share one baseline grid. Mirror that here
-    // (the row measurer previously summed each line's independent box, which
-    // under/over-measured a wrapped ruby cell relative to what it paints).
-    const uniform = snapParaLineToGrid(
-      Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, paragraphContext.hasEastAsianText))),
-      grid,
-      scale,
-    );
-    return lines.length * uniform;
-  }
-  return lines.reduce((s, l) => s + lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, paragraphContext.hasEastAsianText), 0);
 }
 
 /** Effective cell margins (pt). Per-cell `<w:tcMar>` overrides (ECMA-376


### PR DESCRIPTION
## What

Stage 4 (PR 4) of the DOCX layout-context/fragments migration described in
`docs/docx-layout-context-fragments-design.md` and
`docs/docx-layout-context-fragments-implementation-plan.md`.

Adds a placement-aware paragraph measurement kernel, `measureParagraph`
(`packages/docx/src/paragraph-measure.ts`). All of its coordinates are
scale-1 points, and a resulting `MeasuredParagraph` is only valid for the
placement (destination column/cell, width, starting Y, wrap oracle) it was
measured against — it is not a cacheable, placement-independent value.

Migrates the four previously duplicated paragraph-flow paths onto this single
API:

- `estimateParagraphHeight` (body pagination estimate)
- `splitParagraphAcrossPages` (paragraph splitting across page/column breaks)
- `layoutCellParagraphForRowSplit` (table row splitting)
- `measureCellParagraphHeight` (table-cell height measurement)

Paint-time line stamps are intentionally kept for now; removing the
duplicate paint-side layout is scoped to the PR 5 follow-up ("Produce and
Paint Body Fragments").

## Also included

- **§20.4.2.17 float square-wrap horizontal-intersection gate.** Preserving
  the migrated measurement's first-line top displacement exposed a
  page-scoped square-wrapped float registered in another newspaper column
  being treated as a sub-inch side gap in the current column. Square wrap is
  now only applied when the float's wrap rectangle horizontally intersects
  the paragraph's line area, per §20.4.2.17, closing a cross-column wrap
  leak. `wrapText` side selection inside the intersecting area is
  unchanged.
- **Parser: deduplicate an authored trailing hard break vs. the synthetic
  cover break.** The parser previously dropped the synthetic standalone-page
  break only when a page-advancing element followed the cover building
  block. When an authored hard page break was the cover's last child, both
  the authored and synthetic breaks survived, producing a blank page and
  shifting later section parity. The synthetic break is now dropped only
  when it immediately follows an authored page break; a synthetic break
  after a column break, and the existing next-sibling page/section-break
  dedup, are unaffected.
- **Cell heights measured with real-scale canvas metrics (review finding).**
  `measureCellParagraphHeight` measured through the scale-1 kernel and then
  scaled the result geometrically (`× scale`). Real (hinted) font metrics
  are not scale-linear, so this could diverge from what paint actually
  produces. It now rehydrates the measured scale-1 line partition to the
  paint scale via the same rescale bridge the paint path uses, matching
  vertical-alignment and row-height behavior exactly instead of
  approximating it. At scale 1 this is the identity, so the paginator's
  own scale-1 measurement is unaffected.
- **Redundant re-measure removal.** A mark-placement helper reused inside
  paragraph splitting re-measured a paragraph immediately after the caller
  had already measured and gated on it, with nothing relevant changing in
  between. The duplicate measurement is removed; the re-measure needed after
  an actual page/column advance is unchanged.
- **Characterization test for cell ptab margin+indent resolution
  (§17.3.3.23).** Pins that a margin-relative absolute paragraph tab inside
  a table cell resolves against the cell's text margin (paragraph width plus
  right indent) identically for measurement and paint, distinguishing
  `relativeTo="margin"` from `relativeTo="indent"` (§17.18.73).
- **AGENTS.md:** requires rebuilding generated parser WASM before running
  parser-backed tests, Storybook, or VRT whenever Rust parser source has
  changed, closing an ordering gap where stale WASM could hide a real
  parser defect (the cover hard-break issue above) or fabricate a failure.

## Verification

- `cargo test -p docx-parser`: 310 tests pass.
- `pnpm test` (full workspace): 3419 tests pass.
- `pnpm typecheck` (root).
- `cargo fmt --all -- --check`.
- `git diff --check`.
- DOCX VRT (local-only, not run in CI) against a freshly rebuilt-WASM
  baseline from current `main`: zero regressions. Remaining local failures
  were classified as pre-existing reference/WASM baseline mismatches that
  fail identically on `main` with the same rebuilt WASM. Six previously
  failing local checks now render byte-identical to their references — an
  improvement produced by this migration. Visual reference images under
  `tests/visual/references/` are unchanged by this PR.

## Follow-ups (tracked in the implementation plan)

- Mid-paragraph continuation across unequal-width newspaper columns still
  reuses the first placement's line geometry rather than remeasuring at the
  new column width (pre-existing behavior). The design scopes the
  remeasure-before-line-zero fix to PR 5.
- §20.4.2.16 `topAndBottom` wrap cross-column audit, for consistency with
  the square-wrap fix above.

## Attribution

Implemented across Codex GPT-5.6 Sol and Claude (Opus 4.8, Sonnet 5,
Fable 5); per-commit `Co-Authored-By` trailers name the exact models that
contributed to each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
