### PR TITLE
Produce and paint DOCX body fragments

### DIFF
--- a/packages/docx/src/document-layout.test.ts
+++ b/packages/docx/src/document-layout.test.ts
@@ -233,5 +233,9 @@ describe('layoutDocument — body paragraph fragments (PR 5 Task 12)', () => {
     expect(Object.isFrozen(layout.pages[0])).toBe(true);
     expect(Object.isFrozen(layout.pages[0].fragments)).toBe(true);
     expect(Object.isFrozen(layout.pages[0].fragments[0])).toBe(true);
+    // The inner ParagraphFragment is frozen too — its measured lines, line range and
+    // spacing are immutable, so paint can never mutate the layout result (design
+    // §"Pagination and paint invariants" 4).
+    expect(Object.isFrozen(layout.pages[0].fragments[0].fragment)).toBe(true);
   });
 });

--- a/packages/docx/src/document-layout.test.ts
+++ b/packages/docx/src/document-layout.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { layoutDocument } from './document-layout.js';
+import {
+  fragmentLineAdvancesPt,
+  paragraphFragmentAdvancePt,
+  type ParagraphFragment,
+} from './layout-fragments.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps } from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR 5 Task 12 — body layout fragments.
+//
+// `layoutDocument(doc)` produces an immutable `DocumentLayout`: pages of
+// `PlacedFragment`s wrapping `ParagraphFragment`s. Each fragment references its
+// SOURCE paragraph (never a mutated copy), a placement-aware `MeasuredParagraph`,
+// and a `[lineStart, lineEnd)` line range. This suite pins the fragment model
+// contract (design doc §"Measured Fragment Model" / §"Pagination and paint
+// invariants"): source identity, immutable line ranges, placement coordinates,
+// page geometry, section context, paragraph continuation across pages, and the
+// spacing-ownership invariant
+//   cursor advancement == leadingSpacePt + measured line advances + trailingSpacePt.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** OffscreenCanvas polyfill with a linear glyph metric (width = fontPx * 0.5),
+ *  matching the other renderer suites so `layoutDocument`'s scale-1 measurement is
+ *  deterministic in node. */
+function makeStubCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      const per = p * 0.5;
+      return {
+        width: [...s].length * per,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+    getContext() { return makeStubCtx(); }
+  };
+});
+
+function para(text: string, over: Partial<DocParagraph> = {}): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+    ...over,
+  } as unknown as DocParagraph;
+}
+
+function doc(body: BodyElement[], pageHeight = 400): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 200, pageHeight,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage', columns: null,
+  } as SectionProps;
+  return {
+    section, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    footnotes: [],
+  } as unknown as DocxDocumentModel;
+}
+
+/** Every paragraph fragment on every page, in document order. */
+function allFragments(model: DocxDocumentModel) {
+  const layout = layoutDocument(model);
+  return layout.pages.flatMap((page) =>
+    page.fragments.map((placed) => ({ page, placed, fragment: placed.fragment as ParagraphFragment })),
+  );
+}
+
+describe('layoutDocument — body paragraph fragments (PR 5 Task 12)', () => {
+  it('emits one placed paragraph fragment per body paragraph, referencing the SOURCE paragraph', () => {
+    const p1 = para('alpha');
+    const p2 = para('beta');
+    const model = doc([p1 as unknown as BodyElement, p2 as unknown as BodyElement]);
+    const layout = layoutDocument(model);
+
+    expect(layout.pages.length).toBe(1);
+    const frags = layout.pages[0].fragments;
+    expect(frags.length).toBe(2);
+    // Source identity: the fragment points at the parsed paragraph, not a clone.
+    expect(frags[0].fragment.source).toBe(p1);
+    expect(frags[1].fragment.source).toBe(p2);
+    expect(frags[0].fragment.kind).toBe('paragraph');
+  });
+
+  it('keeps fragment state OFF the source paragraph (no fragment fields added to DocParagraph)', () => {
+    // The paginator's established PaginatedBodyElement runtime stamps (colIndex,
+    // colGeom, sectionGeom, ...) are pre-existing and out of scope; this pins that
+    // the NEW fragment model never writes its fields onto the parsed paragraph — the
+    // measurement/line-range/spacing live in the layout result, keyed off-object.
+    const p1 = para('gamma');
+    layoutDocument(doc([p1 as unknown as BodyElement]));
+    const record = p1 as unknown as Record<string, unknown>;
+    for (const field of ['measured', 'lineStart', 'lineEnd', 'leadingSpacePt', 'trailingSpacePt', 'fragment', 'placedFragment']) {
+      expect(record[field]).toBeUndefined();
+    }
+  });
+
+  it('records immutable line ranges covering the whole paragraph', () => {
+    const p = para(Array.from({ length: 40 }, () => 'w').join(' '));
+    const layout = layoutDocument(doc([p as unknown as BodyElement]));
+    const frag = layout.pages[0].fragments[0].fragment as ParagraphFragment;
+    expect(frag.lineStart).toBe(0);
+    expect(frag.lineEnd).toBe(frag.measured.lines.length);
+    expect(frag.lineEnd).toBeGreaterThan(1); // actually wrapped
+  });
+
+  it('places fragments with page-absolute coordinates and the content-band width', () => {
+    const p1 = para('one');
+    const p2 = para('two');
+    const layout = layoutDocument(doc([p1 as unknown as BodyElement, p2 as unknown as BodyElement]));
+    const [f1, f2] = layout.pages[0].fragments;
+    // contentX = marginLeft, width = pageWidth - marginLeft - marginRight.
+    expect(f1.xPt).toBeCloseTo(10, 6);
+    expect(f1.widthPt).toBeCloseTo(180, 6);
+    expect(f1.columnIndex).toBe(0);
+    // The first fragment starts at the top content inset; the second stacks below it.
+    expect(f1.yPt).toBeCloseTo(10, 6);
+    expect(f2.yPt).toBeGreaterThan(f1.yPt);
+    expect(f2.yPt).toBeCloseTo(f1.yPt + f1.heightPt, 6);
+  });
+
+  it('exposes page geometry and the resolved section context', () => {
+    const layout = layoutDocument(doc([para('x') as unknown as BodyElement]));
+    const page = layout.pages[0];
+    expect(page.pageIndex).toBe(0);
+    expect(page.geometry.pageWidth).toBe(200);
+    expect(page.geometry.pageHeight).toBe(400);
+    expect(page.geometry.marginLeft).toBe(10);
+    // SectionLayoutContext carries the resolved grid policy (docGrid absent => none).
+    expect(page.section.grid.kind).toBe('none');
+  });
+
+  it('splits a long paragraph into continuation fragments over one source', () => {
+    // Force several pages: short page height, a long wrapping paragraph.
+    const p = para(Array.from({ length: 300 }, () => 'w').join(' '));
+    const layout = layoutDocument(doc([p as unknown as BodyElement], 60));
+    const frags = allFragments(doc([p as unknown as BodyElement], 60));
+
+    expect(layout.pages.length).toBeGreaterThan(1);
+    // All continuation fragments share ONE source paragraph.
+    for (const f of frags) expect(f.fragment.source).toBe((frags[0].fragment).source);
+
+    // Line ranges are disjoint and contiguous, covering every measured line.
+    const totalLines = frags[0].fragment.measured.lines.length;
+    let cursor = 0;
+    for (const f of frags) {
+      expect(f.fragment.lineStart).toBe(cursor);
+      expect(f.fragment.lineEnd).toBeGreaterThan(f.fragment.lineStart);
+      cursor = f.fragment.lineEnd;
+    }
+    expect(cursor).toBe(totalLines);
+
+    // Leading spacing only on the first fragment; trailing only on the last.
+    expect(frags[frags.length - 1].fragment.trailingSpacePt).toBeGreaterThanOrEqual(0);
+    for (let i = 1; i < frags.length; i++) {
+      expect(frags[i].fragment.leadingSpacePt).toBe(0);
+    }
+    for (let i = 0; i < frags.length - 1; i++) {
+      expect(frags[i].fragment.trailingSpacePt).toBe(0);
+    }
+  });
+
+  it('remeasures at a changed wrap width: a fragment measurement matches its own placement', () => {
+    const p = para(Array.from({ length: 40 }, () => 'w').join(' '));
+    const wide = layoutDocument(doc([p as unknown as BodyElement])); // width 180
+    const narrowModel = doc([p as unknown as BodyElement]);
+    (narrowModel.section as SectionProps).pageWidth = 120; // width 100
+    const narrow = layoutDocument(narrowModel);
+
+    const wf = wide.pages[0].fragments[0].fragment as ParagraphFragment;
+    const nf = narrow.pages[0].fragments[0].fragment as ParagraphFragment;
+    // Each fragment's measurement reflects its own available width (no stale reuse).
+    expect(wf.measured.placement.availableWidthPt).toBeCloseTo(180, 6);
+    expect(nf.measured.placement.availableWidthPt).toBeCloseTo(100, 6);
+    // A narrower band wraps to more lines.
+    expect(nf.measured.lines.length).toBeGreaterThan(wf.measured.lines.length);
+  });
+
+  it('INVARIANT: cursor advancement == leadingSpacePt + line advances + trailingSpacePt', () => {
+    const p1 = para(Array.from({ length: 30 }, () => 'w').join(' '), { spaceBefore: 6, spaceAfter: 8 });
+    const p2 = para('tail', { spaceBefore: 4, spaceAfter: 3 });
+    const frags = allFragments(doc([p1 as unknown as BodyElement, p2 as unknown as BodyElement]));
+    for (const { placed, fragment } of frags) {
+      // Height the paginator charged equals the spacing-owned decomposition.
+      expect(placed.heightPt).toBeCloseTo(paragraphFragmentAdvancePt(fragment), 6);
+      // Line advances sum to the measured content span (no double count) for a full range.
+      if (fragment.lineStart === 0 && fragment.lineEnd === fragment.measured.lines.length && !fragment.measured.markOnly) {
+        expect(fragmentLineAdvancesPt(fragment)).toBeCloseTo(
+          fragment.measured.contentEndYPt - fragment.measured.contentStartYPt, 6,
+        );
+        // Leading spacing equals the gap the measurement placed above the first line.
+        expect(fragment.leadingSpacePt).toBeCloseTo(
+          fragment.measured.contentStartYPt - fragment.measured.placement.startYPt, 6,
+        );
+      }
+    }
+  });
+
+  it('freezes the layout result and its fragment arrays', () => {
+    const layout = layoutDocument(doc([para('x') as unknown as BodyElement]));
+    expect(Object.isFrozen(layout)).toBe(true);
+    expect(Object.isFrozen(layout.pages)).toBe(true);
+    expect(Object.isFrozen(layout.pages[0])).toBe(true);
+    expect(Object.isFrozen(layout.pages[0].fragments)).toBe(true);
+    expect(Object.isFrozen(layout.pages[0].fragments[0])).toBe(true);
+  });
+});

--- a/packages/docx/src/document-layout.ts
+++ b/packages/docx/src/document-layout.ts
@@ -1,0 +1,21 @@
+/**
+ * Body {@link DocumentLayout} production for the DOCX renderer (PR 5).
+ *
+ * `layoutDocument(doc)` returns the immutable fragment layout for the document body:
+ * pages of {@link PlacedFragment}s over body paragraphs, each carrying the
+ * placement-aware {@link MeasuredParagraph} the paginator measured. The measurement
+ * and page-assignment engine lives in `renderer.ts` (it needs the renderer's private
+ * measure state, section resolution and float registration); this module is the
+ * public entry point for the fragment result and the natural home for future
+ * body-flow composition as the migration proceeds (PR 6 adds table fragments).
+ *
+ * See docs/docx-layout-context-fragments-design.md §"Measured Fragment Model".
+ */
+export { layoutDocument } from './renderer.js';
+export type {
+  DocumentLayout,
+  LayoutPage,
+  PlacedFragment,
+  FlowFragment,
+  ParagraphFragment,
+} from './layout-fragments.js';

--- a/packages/docx/src/fit-measure-reuse.test.ts
+++ b/packages/docx/src/fit-measure-reuse.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { layoutDocument } from './document-layout.js';
+import { __test_setFitMeasureReuseEnabled } from './renderer.js';
+import type { ParagraphFragment } from './layout-fragments.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps } from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// M-1 — avoid the double measurement per non-split body paragraph.
+//
+// The paginator measures each body paragraph once for the fit decision
+// (measureBodyParagraphAtCursor) and, before M-1, measured it AGAIN at its final
+// placement to build the fragment. When a paragraph is not relocated after the
+// estimate its final placement is identical, so the fragment now REUSES the fit
+// measurement. This suite pins non-vacuity — pagination makes strictly fewer
+// measureText calls with the reuse ON than OFF — and equivalence: the fragment line
+// partitions and placements are identical either way (keyed on placement equality,
+// so correctness never depends on the optimization).
+// ─────────────────────────────────────────────────────────────────────────────
+
+let measureCount = 0;
+
+/** OffscreenCanvas polyfill whose measureText increments a shared counter (linear
+ *  glyph metric = fontPx * 0.5, matching the other renderer suites). */
+function makeCountingCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      measureCount++;
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      const per = p * 0.5;
+      return {
+        width: [...s].length * per,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+    getContext() { return makeCountingCtx(); }
+  };
+});
+
+function para(text: string, over: Partial<DocParagraph> = {}): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+    ...over,
+  } as unknown as DocParagraph;
+}
+
+function doc(body: BodyElement[], pageHeight = 400): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 200, pageHeight,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage', columns: null,
+  } as SectionProps;
+  return {
+    section, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    footnotes: [],
+  } as unknown as DocxDocumentModel;
+}
+
+/** A serialisable projection of a layout's fragment partitions + placements — enough
+ *  to prove the reuse produced the SAME layout as a fresh measurement. */
+function projection(model: DocxDocumentModel) {
+  return layoutDocument(model).pages.map((page) =>
+    page.fragments.map((placed) => {
+      const f = placed.fragment as ParagraphFragment;
+      return {
+        lineStart: f.lineStart,
+        lineEnd: f.lineEnd,
+        lines: f.measured.lines.length,
+        availW: f.measured.placement.availableWidthPt,
+        startY: f.measured.placement.startYPt,
+        heightPt: placed.heightPt,
+        advances: f.measured.lines.map((l) => l.advancePt),
+      };
+    }),
+  );
+}
+
+describe('M-1 fit-check measurement reuse for non-split body fragments', () => {
+  it('reuses the fit measurement (fewer measureText calls) and produces the identical layout', () => {
+    // Several short, non-splitting, float-free paragraphs on a tall page — each is
+    // measured for the fit decision and then attached at the SAME placement, so the
+    // reuse fires for every one of them.
+    const model = doc([
+      para('alpha beta gamma delta') as unknown as BodyElement,
+      para('one two three four five six') as unknown as BodyElement,
+      para('lorem ipsum dolor sit amet consectetur') as unknown as BodyElement,
+      para('the quick brown fox jumps over') as unknown as BodyElement,
+    ]);
+
+    __test_setFitMeasureReuseEnabled(true);
+    measureCount = 0;
+    const onProjection = projection(model);
+    const onCount = measureCount;
+
+    __test_setFitMeasureReuseEnabled(false);
+    measureCount = 0;
+    const offProjection = projection(model);
+    const offCount = measureCount;
+
+    __test_setFitMeasureReuseEnabled(true); // restore production default
+
+    // Non-vacuity: the reuse genuinely avoided a second measurement of every
+    // non-relocated paragraph, so pagination measured strictly less text.
+    expect(onCount).toBeGreaterThan(0);
+    expect(onCount).toBeLessThan(offCount);
+
+    // Equivalence: reusing the fit measurement yields the byte-same fragment layout as
+    // measuring twice — correctness does not depend on the optimization.
+    expect(onProjection).toEqual(offProjection);
+  });
+
+  it('does not affect a RELOCATED paragraph (placement changed → remeasured, layout still correct)', () => {
+    // A tall paragraph with keepLines that must move to a fresh page: its fit estimate
+    // is taken at a mid-page cursor, then the paragraph relocates, so the placement no
+    // longer matches and the fragment remeasures. Toggling the reuse must not change
+    // the resulting layout.
+    const filler = para(Array.from({ length: 20 }, () => 'w').join(' '));
+    const keep = para(Array.from({ length: 20 }, () => 'w').join(' '), { keepLines: true });
+    const model = doc([filler as unknown as BodyElement, keep as unknown as BodyElement], 80);
+
+    __test_setFitMeasureReuseEnabled(true);
+    const on = projection(model);
+    __test_setFitMeasureReuseEnabled(false);
+    const off = projection(model);
+    __test_setFitMeasureReuseEnabled(true);
+
+    expect(on).toEqual(off);
+  });
+});

--- a/packages/docx/src/fragment-paint.test.ts
+++ b/packages/docx/src/fragment-paint.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { renderDocumentToCanvas, paginateDocument } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, PaginatedBodyElement, SectionProps } from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR 5 Task 13 — body fragment paint purity.
+//
+// A migrated body paragraph paints from its stored measured fragment
+// (fragment-paint.ts). At the paint scale of 1 the stored scale-1 geometry needs no
+// rescale, so the paint pass must draw the paragraph's lines WITHOUT calling
+// measureText at all — no line layout, no segment measurement, no remeasurement.
+//
+// This is proved end-to-end through the real production flow: pages are paginated
+// with a normal OffscreenCanvas metric, then painted at scale 1 onto a canvas whose
+// measureText THROWS. If any part of the migrated paragraph paint tried to measure,
+// the render would throw; instead it completes and draws the paragraph text.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Call { text: string; x: number; y: number; }
+
+/** Pagination-side canvas with a normal linear glyph metric. */
+function makeMeasuringCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      const per = p * 0.5;
+      return {
+        width: [...s].length * per,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+    getContext() { return makeMeasuringCtx(); }
+  };
+});
+
+/** Paint-side recording canvas whose measureText THROWS — any measurement during
+ *  paint fails the test loudly. Records every text draw for the content assertion. */
+function makeThrowingPaintCanvas(): { canvas: HTMLCanvasElement; calls: Call[]; measured: () => number } {
+  let font = '10px serif';
+  const calls: Call[] = [];
+  let measured = 0;
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (_s: string) => {
+      measured++;
+      throw new Error('measureText must not be called during fragment paint');
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, x: number, y: number) { calls.push({ text: s, x, y }); },
+    strokeText(s: string, x: number, y: number) { calls.push({ text: s, x, y }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, calls, measured: () => measured };
+}
+
+function para(text: string, over: Partial<DocParagraph> = {}): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+    ...over,
+  } as unknown as DocParagraph;
+}
+
+function doc(body: BodyElement[], pageHeight = 400): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 200, pageHeight,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage', columns: null,
+  } as SectionProps;
+  return {
+    section, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    footnotes: [],
+  } as unknown as DocxDocumentModel;
+}
+
+describe('fragment paint purity (PR 5 Task 13)', () => {
+  it('paints a premeasured body paragraph at scale 1 without ever calling measureText', async () => {
+    const model = doc([para('hello world one two three') as unknown as BodyElement]);
+    const pages = paginateDocument(model); // measured with the normal OffscreenCanvas
+    const paint = makeThrowingPaintCanvas();
+
+    // Paint scale 1 (render width == page width). A migrated paragraph draws its
+    // stored fragment lines; nothing measures.
+    await expect(
+      renderDocumentToCanvas(model, paint.canvas, 0, { dpr: 1, width: 200, prebuiltPages: pages }),
+    ).resolves.not.toThrow();
+
+    expect(paint.measured()).toBe(0);
+    // Non-vacuity: the paragraph's words were actually drawn.
+    const drewText = paint.calls.some((c) => c.text.includes('hello'));
+    expect(drewText).toBe(true);
+  });
+
+  it('paints a paragraph that SPLITS across pages from fragments, still measure-free', async () => {
+    // A long paragraph over a short page splits; each continuation slice paints from
+    // the shared measured fragment window without remeasuring.
+    const long = Array.from({ length: 120 }, () => 'w').join(' ');
+    const model = doc([para(long) as unknown as BodyElement], 60);
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(1);
+    const split = pages.some((pg) => pg.some((el) => (el as PaginatedBodyElement).lineSlice));
+    expect(split).toBe(true);
+
+    for (let p = 0; p < pages.length; p++) {
+      const paint = makeThrowingPaintCanvas();
+      await expect(
+        renderDocumentToCanvas(model, paint.canvas, p, { dpr: 1, width: 200, prebuiltPages: pages }),
+      ).resolves.not.toThrow();
+      expect(paint.measured()).toBe(0);
+      expect(paint.calls.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/docx/src/fragment-paint.ts
+++ b/packages/docx/src/fragment-paint.ts
@@ -1,0 +1,58 @@
+/**
+ * Body paragraph fragment paint (PR 5 Task 13).
+ *
+ * `paintParagraphFragment` draws a {@link PlacedFragment} produced by
+ * {@link layoutDocument} / the paginator: it hands the fragment's stored scale-1
+ * line partition to the renderer's shared paragraph draw path, which rescales it to
+ * the paint scale through the existing `rescaleLayoutLines` bridge and draws only the
+ * fragment's `[lineStart, lineEnd)` range. No line layout, segment construction, text
+ * measurement, or paragraph re-measurement happens here — the geometry is already
+ * measured. A scale-1 paint therefore invokes no `measureText` at all (the rescale
+ * bridge returns the partition unchanged at scale 1).
+ *
+ * This module is the static body-paint boundary: the ast-grep rule
+ * `no-docx-measurement-in-fragment-paint` forbids importing or calling `buildSegments`,
+ * `layoutLines`, `measureParagraph`, `measureText`, or row measurement from this file.
+ *
+ * See docs/docx-layout-context-fragments-design.md §"Measured Fragment Model".
+ */
+import { renderBodyParagraphLines, type ParaBorderMerge, type RenderState } from './renderer.js';
+import type { PlacedFragment } from './layout-fragments.js';
+
+/**
+ * Paint a body paragraph fragment at the current render cursor, drawing its stored
+ * lines (rescaled) without remeasuring.
+ *
+ * @param placed  the placed paragraph fragment (its `measured` holds the scale-1 lines).
+ * @param state   the page paint state (its `scale`, `ctx`, `contentX/W`, `y` cursor).
+ * @param options paint-adjacency inputs the paginator does not own: `suppressSpaceBefore`
+ *   (continuation slices / spacing collapse) and the §17.3.1.7 `borderMerge`.
+ */
+export function paintParagraphFragment(
+  placed: PlacedFragment,
+  state: RenderState,
+  options: {
+    suppressSpaceBefore?: boolean;
+    borderMerge?: ParaBorderMerge;
+  } = {},
+): void {
+  const fragment = placed.fragment;
+  const measured = fragment.measured;
+  // The stored scale-1 line partition for the whole paragraph. Empty for a markOnly
+  // (empty / anchor-only) paragraph — the renderer's empty-mark branch handles it.
+  const scale1Lines = measured.lines.map((line) => line.layout);
+  // A full-range fragment paints the whole paragraph (no slice); a continuation
+  // fragment paints only its `[lineStart, lineEnd)` window.
+  const lineSlice =
+    fragment.lineStart === 0 && fragment.lineEnd === measured.lines.length
+      ? undefined
+      : { start: fragment.lineStart, end: fragment.lineEnd };
+  renderBodyParagraphLines(
+    fragment.source,
+    state,
+    scale1Lines,
+    options.suppressSpaceBefore ?? false,
+    lineSlice,
+    options.borderMerge,
+  );
+}

--- a/packages/docx/src/fragment-paint.ts
+++ b/packages/docx/src/fragment-paint.ts
@@ -14,6 +14,15 @@
  * `no-docx-measurement-in-fragment-paint` forbids importing or calling `buildSegments`,
  * `layoutLines`, `measureParagraph`, `measureText`, or row measurement from this file.
  *
+ * BOUNDARY SCOPE (PR 5): the rule enforces the measurement-free boundary for THIS
+ * module only. The shared draw path this delegates to (`renderBodyParagraphLines` →
+ * `renderParagraph` in renderer.ts) still constructs segments (bidi/tab detection) and,
+ * at a paint scale ≠ 1, re-measures each stored line's glyph geometry via
+ * `rescaleLayoutLines` — by design (the fragment stores the scale-1 line PARTITION; only
+ * glyph metrics are re-derived at the display scale, never the wrap points). Full static
+ * enforcement across the whole body-paint path lands when body paint is separated into
+ * its own module (PR 6+ scope).
+ *
  * See docs/docx-layout-context-fragments-design.md §"Measured Fragment Model".
  */
 import { renderBodyParagraphLines, type ParaBorderMerge, type RenderState } from './renderer.js';

--- a/packages/docx/src/layout-fragments.ts
+++ b/packages/docx/src/layout-fragments.ts
@@ -1,0 +1,116 @@
+/**
+ * Measured layout fragments for the DOCX body flow (PR 5 of the layout-context /
+ * fragments migration; see docs/docx-layout-context-fragments-design.md §"Measured
+ * Fragment Model").
+ *
+ * A fragment belongs to a {@link DocumentLayout} result, NOT to the parsed document
+ * model — the parsed {@link DocParagraph} is never mutated with layout state. A
+ * {@link ParagraphFragment} references its source paragraph plus the placement-aware
+ * {@link MeasuredParagraph} that was produced for its recorded placement, and a
+ * `[lineStart, lineEnd)` half-open range selecting the lines this fragment paints
+ * (a paragraph split across pages/columns is represented by several fragments over
+ * one measured result, each with its own range).
+ *
+ * All coordinates are points at scale 1 — the measurement coordinate system. Paint
+ * scales the stored geometry; it never repeats text layout.
+ *
+ * PR 6 will widen {@link FlowFragment} to also include a `TableFragment`. This module
+ * intentionally exposes only the paragraph fragment contract for PR 5.
+ */
+import type { DocParagraph, SectionGeom } from './types';
+import type { MeasuredParagraph } from './paragraph-measure.js';
+import type { SectionLayoutContext } from './layout-context.js';
+
+export interface ParagraphFragment {
+  readonly kind: 'paragraph';
+  /** The parsed source paragraph. Immutable — never stamped with layout state. */
+  readonly source: DocParagraph;
+  /** The placement-aware measurement whose lines this fragment paints. Valid only
+   *  for `measured.placement`; a fragment on a different page/column/wrap context
+   *  holds a separate measurement. */
+  readonly measured: MeasuredParagraph;
+  /** Half-open range `[lineStart, lineEnd)` into `measured.lines` this fragment
+   *  paints. A markOnly measurement (empty / anchor-only paragraph) uses
+   *  `lineStart === lineEnd === 0` and paints its single paragraph-mark line box. */
+  readonly lineStart: number;
+  readonly lineEnd: number;
+  /** Points of paragraph spacing the paginator added ABOVE this fragment's first
+   *  painted line (effective space-before + any float top-skip on the first
+   *  fragment; 0 on a continuation fragment). Owned by the paginator so paragraph
+   *  spacing is counted exactly once. */
+  readonly leadingSpacePt: number;
+  /** Points of paragraph spacing the paginator reserved BELOW this fragment's last
+   *  painted line (max of space-after and drawn bottom-border extent on the final
+   *  fragment; 0 on a non-final fragment). */
+  readonly trailingSpacePt: number;
+}
+
+export type FlowFragment = ParagraphFragment;
+
+export interface PlacedFragment {
+  readonly fragment: FlowFragment;
+  /** ECMA-376 §17.6.4 newspaper column (0-based). */
+  readonly columnIndex: number;
+  /** Page-absolute point coordinates (scale 1). `yPt` is the top of the fragment's
+   *  leading spacing; `heightPt` is the cursor advancement the paginator charged for
+   *  this fragment (== leadingSpacePt + line advances + trailingSpacePt). */
+  readonly xPt: number;
+  readonly yPt: number;
+  readonly widthPt: number;
+  readonly heightPt: number;
+}
+
+export interface LayoutPage {
+  readonly pageIndex: number;
+  readonly section: SectionLayoutContext;
+  readonly geometry: SectionGeom;
+  readonly fragments: readonly PlacedFragment[];
+}
+
+export interface DocumentLayout {
+  readonly pages: readonly LayoutPage[];
+}
+
+/**
+ * Sum of the measured line advances this fragment paints, in scale-1 points.
+ *
+ * For a content fragment this is `measured.lines[i].advancePt` for the first line
+ * in range plus, for each subsequent line, the (non-negative) inter-line gap to the
+ * previous line's bottom followed by its advance — the same per-line extent the
+ * paginator charges. For a markOnly fragment it is the paragraph-mark line box
+ * height. It excludes the fragment's leading and trailing paragraph spacing (those
+ * are `leadingSpacePt` / `trailingSpacePt`), so spacing is never double-counted.
+ */
+export function fragmentLineAdvancesPt(fragment: ParagraphFragment): number {
+  const measured = fragment.measured;
+  if (measured.markOnly || measured.lines.length === 0) {
+    return measured.contentEndYPt - measured.contentStartYPt;
+  }
+  let sum = 0;
+  for (let i = fragment.lineStart; i < fragment.lineEnd; i++) {
+    const line = measured.lines[i];
+    if (!line) break;
+    if (i === fragment.lineStart) {
+      sum += line.advancePt;
+      continue;
+    }
+    const previous = measured.lines[i - 1];
+    const previousBottom = previous.topYPt + previous.advancePt;
+    sum += Math.max(0, line.topYPt - previousBottom) + line.advancePt;
+  }
+  return sum;
+}
+
+/**
+ * The cursor advancement a paragraph fragment charges: its leading spacing, plus the
+ * measured line advances it paints, plus its trailing spacing. This is the invariant
+ * a paginator's per-fragment height must equal — proving paragraph spacing is owned
+ * by the fragment and added exactly once (design §"Pagination and paint invariants" 1).
+ */
+export function paragraphFragmentAdvancePt(fragment: ParagraphFragment): number {
+  return (
+    fragment.leadingSpacePt +
+    fragmentLineAdvancesPt(fragment) +
+    fragment.trailingSpacePt
+  );
+}

--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -1,29 +1,38 @@
 import { describe, it, expect } from 'vitest';
-import { renderDocumentToCanvas, paginateDocument, __test_setLineReuseEnabled } from './renderer.js';
+import {
+  renderDocumentToCanvas,
+  paginateDocument,
+  __test_setLineReuseEnabled,
+  __test_setFragmentPaintEnabled,
+} from './renderer.js';
 import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps, PaginatedBodyElement } from './types';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Phase 4-1 B2 Stage 1 — pixel-identity of the compute-once line reuse.
+// Body paint byte-identity — the compute-once line reuse (Phase 4-1 B2 Stage 1)
+// AND the PR 5 body fragment paint.
 //
-// renderParagraph reuses the paginator's stamped scale-1 lines instead of
-// re-running layoutLines (see the reuse gate in renderer.ts). This suite pins
-// that the reuse is behaviour-PRESERVING: rendering the exact same page with
-// reuse ON and with reuse OFF must emit a byte-identical paint call stream
-// (every fillText / strokeText / drawImage with identical text, x, y and font).
+// A migrated body paragraph now paints from its stored measured fragment
+// (fragment-paint.ts → renderBodyParagraphLines): the fragment's scale-1 line
+// partition is rescaled to the paint scale and drawn, with NO re-run of layoutLines.
+// Marker / float / state-sensitive paragraphs stay on the legacy renderParagraph
+// acquisition (its own scale-1 reuse gate). This suite pins that both mechanisms are
+// behaviour-PRESERVING: rendering the exact same page three ways —
+//   (1) production      : fragment paint ON,  reuse ON
+//   (2) legacy reuse    : fragment paint OFF, reuse ON
+//   (3) legacy recompute: fragment paint OFF, reuse OFF
+// must emit a byte-identical paint call stream (every fillText / strokeText /
+// drawImage with identical text, x, y and font). It also pins NON-VACUITY: fragment
+// paint (or, for non-migrated paragraphs, the legacy reuse gate) actually avoided
+// re-laying-out the paragraph, so production makes FEWER measureText calls than the
+// legacy recompute — except where the paragraph is legitimately excluded from both
+// fast paths (a numbered list's firstLineIndent, a NUMPAGES field), where the counts
+// are equal.
 //
 // The pages are built with `paginateDocument` (a fresh OffscreenCanvas(1,1)) and
 // handed to `renderDocumentToCanvas` via `prebuiltPages` — the SAME cross-context
-// flow the public `DocxDocument.renderPage` uses, so the test exercises the real
-// production reuse path (paginate ctx ≠ paint ctx), not a same-ctx shortcut. The
-// render width equals the page width so the paint scale is exactly 1 and the
-// reuse gate actually fires.
-//
-// Coverage: a long single-column paragraph that splits across pages (reuse fires),
-// a justified paragraph (per-line slack distribution reads the reused segments),
-// a CJK paragraph (per-glyph wrap), and a NUMBERED list that splits (reuse must
-// NOT fire — the firstLineIndent gate rejects it — yet the recompute path is
-// still identical to itself). Also pins that painting the same page twice is
-// identical (the shared stamped array is never mutated by the draw path).
+// flow the public `DocxDocument.renderPage` uses. The render width equals the page
+// width so the paint scale is exactly 1 (fragment rescale is then a no-op → a
+// migrated paragraph paints with zero measureText calls).
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface Call { op: 'fill' | 'stroke' | 'img'; text: string; x: number; y: number; font: string; }
@@ -148,87 +157,111 @@ async function renderAllPages(model: DocxDocumentModel, pages: PaginatedBodyElem
   return { perPage, measures };
 }
 
-/** Assert reuse ON and reuse OFF paint an identical stream on every page, and
- *  report how many measureText calls each variant made so the caller can pin
- *  whether the reuse actually fired (fewer measures) or the gate rejected it
- *  (equal measures). */
-async function assertReuseIdentical(model: DocxDocumentModel): Promise<{ pages: number; drawn: number; split: boolean; measuresOn: number; measuresOff: number; streams: Call[][] }> {
-  const pages = paginateDocument(model);
-  // Sanity: this document actually split a paragraph, so stamped lines exist.
-  const split = pages.some((pg) => pg.some((el) => (el as PaginatedBodyElement).lineSlice));
-
-  const prev = __test_setLineReuseEnabled(false);
-  let off: { perPage: Call[][]; measures: number };
-  try { off = await renderAllPages(model, pages); } finally { __test_setLineReuseEnabled(prev); }
-
-  const on = await renderAllPages(model, pages);
-
-  expect(on.perPage.length).toBe(off.perPage.length);
-  let drawn = 0;
-  for (let p = 0; p < on.perPage.length; p++) {
-    // Exact stream identity — same ops, text, positions, fonts, in the same order.
-    expect(on.perPage[p]).toEqual(off.perPage[p]);
-    drawn += on.perPage[p].filter((c) => c.op !== 'img').length;
+/** Render every page under an explicit (fragmentPaint, reuse) configuration, then
+ *  restore the previous flags. */
+async function renderVariant(
+  model: DocxDocumentModel,
+  pages: PaginatedBodyElement[][],
+  cfg: { fragmentPaint: boolean; reuse: boolean },
+): Promise<{ perPage: Call[][]; measures: number }> {
+  const prevFragment = __test_setFragmentPaintEnabled(cfg.fragmentPaint);
+  const prevReuse = __test_setLineReuseEnabled(cfg.reuse);
+  try {
+    return await renderAllPages(model, pages);
+  } finally {
+    __test_setLineReuseEnabled(prevReuse);
+    __test_setFragmentPaintEnabled(prevFragment);
   }
-  return { pages: pages.length, drawn, split, measuresOn: on.measures, measuresOff: off.measures, streams: on.perPage };
 }
 
-describe('compute-once line reuse — pixel identity (Phase 4-1 B2 Stage 1)', () => {
-  it('long single-column paragraph that splits across pages: reuse ON === reuse OFF', async () => {
+/** Assert the production paint (fragment ON, reuse ON) is byte-identical to the
+ *  legacy paint (fragment OFF) both with reuse ON and with reuse OFF, on every page.
+ *  Reports measureText counts so the caller can pin non-vacuity (a fast path really
+ *  fired, or was legitimately rejected). */
+async function assertPaintIdentical(model: DocxDocumentModel): Promise<{ pages: number; drawn: number; split: boolean; measuresProduction: number; measuresRecompute: number; streams: Call[][] }> {
+  const pages = paginateDocument(model);
+  // Sanity: this document actually split a paragraph, so continuation slices exist.
+  const split = pages.some((pg) => pg.some((el) => (el as PaginatedBodyElement).lineSlice));
+
+  const production = await renderVariant(model, pages, { fragmentPaint: true, reuse: true });
+  const legacyReuse = await renderVariant(model, pages, { fragmentPaint: false, reuse: true });
+  const legacyRecompute = await renderVariant(model, pages, { fragmentPaint: false, reuse: false });
+
+  expect(production.perPage.length).toBe(legacyReuse.perPage.length);
+  expect(production.perPage.length).toBe(legacyRecompute.perPage.length);
+  let drawn = 0;
+  for (let p = 0; p < production.perPage.length; p++) {
+    // Exact stream identity — same ops, text, positions, fonts, in the same order —
+    // across fragment paint AND both legacy variants.
+    expect(production.perPage[p]).toEqual(legacyReuse.perPage[p]);
+    expect(production.perPage[p]).toEqual(legacyRecompute.perPage[p]);
+    drawn += production.perPage[p].filter((c) => c.op !== 'img').length;
+  }
+  return {
+    pages: pages.length,
+    drawn,
+    split,
+    measuresProduction: production.measures,
+    measuresRecompute: legacyRecompute.measures,
+    streams: production.perPage,
+  };
+}
+
+describe('body paint byte-identity — fragment paint and compute-once line reuse', () => {
+  it('long single-column paragraph that splits across pages: fragment paint === legacy', async () => {
     const text = Array.from({ length: 120 }, () => 'w').join(' ');
-    const r = await assertReuseIdentical(doc([para(text) as unknown as BodyElement]));
+    const r = await assertPaintIdentical(doc([para(text) as unknown as BodyElement]));
     expect(r.pages).toBeGreaterThan(1); // really split
-    expect(r.split).toBe(true);         // stamped lines present
+    expect(r.split).toBe(true);         // continuation slices present
     expect(r.drawn).toBeGreaterThan(0); // really painted
-    // The reuse actually fired: the paint pass skipped its own wrap-loop
-    // measureText calls, so ON made strictly fewer than OFF.
-    expect(r.measuresOn).toBeLessThan(r.measuresOff);
+    // Non-vacuity: fragment paint skipped the paragraph re-layout, so production
+    // made strictly fewer measureText calls than the legacy recompute.
+    expect(r.measuresProduction).toBeLessThan(r.measuresRecompute);
   });
 
-  it('justified paragraph (both): slack distribution over reused segments is identical', async () => {
+  it('justified paragraph (both): slack distribution over fragment segments is identical', async () => {
     const text = Array.from({ length: 120 }, (_, i) => (i % 3 === 0 ? 'lorem' : 'ipsum')).join(' ');
-    const r = await assertReuseIdentical(doc([para(text, { alignment: 'both' }) as unknown as BodyElement]));
+    const r = await assertPaintIdentical(doc([para(text, { alignment: 'both' }) as unknown as BodyElement]));
     expect(r.pages).toBeGreaterThan(1);
     expect(r.drawn).toBeGreaterThan(0);
-    expect(r.measuresOn).toBeLessThan(r.measuresOff); // reuse fired
+    expect(r.measuresProduction).toBeLessThan(r.measuresRecompute); // fragment paint fired
   });
 
-  it('CJK paragraph (per-glyph wrap) that splits: reuse ON === reuse OFF', async () => {
+  it('CJK paragraph (per-glyph wrap) that splits: fragment paint === legacy', async () => {
     const text = 'あ'.repeat(200);
-    const r = await assertReuseIdentical(doc([para(text) as unknown as BodyElement]));
+    const r = await assertPaintIdentical(doc([para(text) as unknown as BodyElement]));
     expect(r.pages).toBeGreaterThan(1);
     expect(r.drawn).toBeGreaterThan(0);
-    expect(r.measuresOn).toBeLessThan(r.measuresOff); // reuse fired
+    expect(r.measuresProduction).toBeLessThan(r.measuresRecompute); // fragment paint fired
   });
 
-  it('numbered list that splits: reuse gate rejects it (firstLineIndent) yet paint is identical', async () => {
-    // A numbered paragraph: measure lays out with para.indentFirst, paint with
-    // numBodyOffset — the gate's firstIndent check fails, so reuse does NOT fire.
-    // The recompute path must still be self-identical (this is the control that
-    // proves the gate's rejection is safe and that toggling reuse is a no-op here).
+  it('numbered list that splits: excluded from fragment paint (firstLineIndent) yet paint is identical', async () => {
+    // A numbered paragraph: the placement-aware measurement lays out with
+    // para.indentFirst, but paint positions the body at numBodyOffset — so the
+    // fragment's scale-1 lines would NOT reproduce the paint. isFragmentPaintable
+    // excludes it (numbering != null) and the legacy reuse gate also rejects it, so
+    // production falls back to the recompute path — which must still be identical to
+    // itself. This is the control proving the exclusion is safe.
     const numbering = { numId: 1, level: 0, format: 'decimal', text: '1.',
       indentLeft: 36, tab: 36, suff: 'tab', jc: 'left' } as unknown as DocParagraph['numbering'];
     const text = Array.from({ length: 120 }, () => 'w').join(' ');
     const p = para(text, {
       numbering, indentLeft: 36, indentFirst: -18,
     });
-    const r = await assertReuseIdentical(doc([p as unknown as BodyElement]));
+    const r = await assertPaintIdentical(doc([p as unknown as BodyElement]));
     expect(r.pages).toBeGreaterThan(1);
     expect(r.drawn).toBeGreaterThan(0);
-    // The gate REJECTED reuse for the numbered list (firstLineIndent derivation
-    // differs between measure and paint), so ON and OFF recomputed identically —
-    // the measure counts are equal. This is what makes the gate non-vacuous: it
-    // proves the reuse did NOT silently fire on a paragraph whose measure lines
-    // would have painted wrong.
-    expect(r.measuresOn).toBe(r.measuresOff);
+    // Neither fast path fired (fragment paint excluded, reuse rejected), so
+    // production and the recompute path made the same number of measures.
+    expect(r.measuresProduction).toBe(r.measuresRecompute);
   });
 
-  it('NUMPAGES field in a splitting paragraph: never stamped — field text resolves against the real page context', async () => {
+  it('NUMPAGES field in a splitting paragraph: excluded from fragment paint — field text resolves against the real page context', async () => {
     // resolveFieldText is paint-state-dependent: numPages → state.totalPages,
     // which is 1 in the paginator's measure state but the real count at paint.
-    // Stamped measure-time lines would freeze the stale "1" into the drawn text,
-    // so paragraphSegsStateSensitive excludes such paragraphs from stamping —
-    // they stay on the recompute path (the pre-reuse behaviour).
+    // The fragment's line segments freeze the stale "1", so paragraphSegsStateSensitive
+    // excludes such paragraphs from BOTH the fragment path and the reuse stamp —
+    // they recompute their segments against the real page context.
     const text = Array.from({ length: 120 }, () => 'w').join(' ');
     const p = para(text);
     (p.runs as unknown[]).push({
@@ -236,32 +269,31 @@ describe('compute-once line reuse — pixel identity (Phase 4-1 B2 Stage 1)', ()
       bold: false, italic: false, underline: false, strikethrough: false,
       fontSize: 10, color: null, fontFamily: 'Times New Roman', background: null,
     });
-    const r = await assertReuseIdentical(doc([p as unknown as BodyElement]));
+    const r = await assertPaintIdentical(doc([p as unknown as BodyElement]));
     expect(r.pages).toBeGreaterThan(1);
     expect(r.split).toBe(true);
-    // No stamp → no reuse: ON and OFF recomputed identically.
-    expect(r.measuresOn).toBe(r.measuresOff);
+    // No fast path: production and recompute made the same number of measures.
+    expect(r.measuresProduction).toBe(r.measuresRecompute);
     // And the CURRENT total page count was drawn (not the measure-time "1" —
     // with pages > 1 the real count is distinguishable from the stale value).
     const drewTotal = r.streams.some((page) => page.some((c) => c.text === String(r.pages)));
     expect(drewTotal).toBe(true);
   });
 
-  it('custom kinsoku settings: fresh-but-value-equal rule objects still reuse (=== alone would reject)', async () => {
+  it('custom kinsoku settings: fragment paint stays identical across fresh-but-value-equal rule objects', async () => {
     // The prebuiltPages production path resolves resolveKinsokuRules(doc.settings)
-    // TWICE — once in paginateDocument, once in renderDocumentToCanvas — and the
-    // resolver builds fresh Set objects per call. With custom settings the rules
-    // are non-default on both sides yet reference-distinct; the gate's value
-    // equivalence must still let the reuse fire.
+    // TWICE — once in paginateDocument, once in renderDocumentToCanvas — building
+    // fresh Set objects per call. The fragment's lines were laid out under the
+    // paginate-time rules; the paint stays byte-identical.
     const text = Array.from({ length: 120 }, () => 'w').join(' ');
     const model = doc([para(text) as unknown as BodyElement], 60,
       { kinsoku: true, noLineBreaksBefore: '、。！' , noLineBreaksAfter: '（「' });
-    const r = await assertReuseIdentical(model);
+    const r = await assertPaintIdentical(model);
     expect(r.pages).toBeGreaterThan(1);
-    expect(r.measuresOn).toBeLessThan(r.measuresOff); // reuse fired across fresh rule objects
+    expect(r.measuresProduction).toBeLessThan(r.measuresRecompute); // fragment paint fired
   });
 
-  it('same page rendered twice is identical (shared stamped array is never mutated)', async () => {
+  it('same page rendered twice is identical (the shared measured line array is never mutated by paint)', async () => {
     const text = Array.from({ length: 120 }, () => 'w').join(' ');
     const model = doc([para(text) as unknown as BodyElement]);
     const pages = paginateDocument(model);

--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -176,6 +176,33 @@ async function renderVariant(
   }
 }
 
+/** Render every page at the DEFAULT CSS scale (PT_TO_PX = 4/3, `width` OMITTED so
+ *  scale = 4/3 ≠ 1) under an explicit (fragmentPaint, reuse) configuration; restore
+ *  the flags after. At this scale the fragment path and the legacy reuse path both
+ *  RESCALE their stored scale-1 partition (rescaleLayoutLines re-measures each line at
+ *  the paint scale), so their streams must be byte-identical. */
+async function renderVariantScaled(
+  model: DocxDocumentModel,
+  pages: PaginatedBodyElement[][],
+  cfg: { fragmentPaint: boolean; reuse: boolean },
+): Promise<Call[][]> {
+  const prevFragment = __test_setFragmentPaintEnabled(cfg.fragmentPaint);
+  const prevReuse = __test_setLineReuseEnabled(cfg.reuse);
+  try {
+    const perPage: Call[][] = [];
+    for (let p = 0; p < pages.length; p++) {
+      const rec = makeRecordingCanvas();
+      // No `width` → cssWidth = pageWidth · PT_TO_PX (4/3), so the paint scale is 4/3.
+      await renderDocumentToCanvas(model, rec.canvas, p, { dpr: 1, prebuiltPages: pages });
+      perPage.push(rec.calls);
+    }
+    return perPage;
+  } finally {
+    __test_setLineReuseEnabled(prevReuse);
+    __test_setFragmentPaintEnabled(prevFragment);
+  }
+}
+
 /** Assert the production paint (fragment ON, reuse ON) is byte-identical to the
  *  legacy paint (fragment OFF) both with reuse ON and with reuse OFF, on every page.
  *  Reports measureText counts so the caller can pin non-vacuity (a fast path really
@@ -292,6 +319,81 @@ describe('body paint byte-identity — fragment paint and compute-once line reus
       { kinsoku: true, noLineBreaksBefore: '、。！' , noLineBreaksAfter: '（「' });
     const r = await assertPaintIdentical(model);
     expect(r.pages).toBeGreaterThan(1);
+    expect(r.measuresProduction).toBeLessThan(r.measuresRecompute); // fragment paint fired
+  });
+
+  it('zoom (default 4/3 scale): fragment paint === legacy stamp-reuse over the same scale-1 partition', async () => {
+    // A long paragraph that SPLITS: pagination stamps its scale-1 line partition
+    // (stampParagraphLines) AND builds the fragment from the SAME measured result, so
+    // the legacy reuse path genuinely rescales the STAMP. At a paint scale ≠ 1 the
+    // production fragment path and the legacy reuse path both rescale that one scale-1
+    // partition, so their paint streams must be byte-identical (design invariant:
+    // "paint scales measured geometry; it does not repeat text layout"). Identity vs
+    // the full-RECOMPUTE path is intentionally NOT asserted here — recompute measures
+    // at the paint scale (a documented pre-existing property), not this PR's concern.
+    const text = Array.from({ length: 120 }, () => 'w').join(' ');
+    const model = doc([para(text) as unknown as BodyElement]); // pageHeight 60 → splits
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(1);
+    expect(pages.some((pg) => pg.some((el) => (el as PaginatedBodyElement).lineSlice))).toBe(true);
+
+    const production = await renderVariantScaled(model, pages, { fragmentPaint: true, reuse: true });
+    const reuse = await renderVariantScaled(model, pages, { fragmentPaint: false, reuse: true });
+    expect(production.length).toBe(reuse.length);
+    for (let p = 0; p < production.length; p++) {
+      expect(production[p]).toEqual(reuse[p]);
+    }
+    // Non-vacuity: the paint really ran at scale 4/3 — a fractional glyph px size in
+    // the recorded font proves the geometry was rescaled off scale 1 (a scale-1 paint
+    // would only ever show the integer '10px').
+    const scaled = production.flat().some((c) => c.op !== 'img' && /\d+\.\d+px/.test(c.font));
+    expect(scaled).toBe(true);
+    expect(production.some((pg) => pg.length > 0)).toBe(true);
+  });
+
+  it('first-line AND hanging indents: fragment paint === legacy (3-way)', async () => {
+    const text = Array.from({ length: 120 }, () => 'w').join(' ');
+    // First-line indent (positive indentFirst) with left + right indents.
+    const firstLine = await assertPaintIdentical(
+      doc([para(text, { indentLeft: 24, indentRight: 12, indentFirst: 18 }) as unknown as BodyElement]),
+    );
+    expect(firstLine.drawn).toBeGreaterThan(0);
+    expect(firstLine.measuresProduction).toBeLessThan(firstLine.measuresRecompute); // fragment paint fired
+    // Hanging indent (negative first-line) WITHOUT numbering — still fragment-paintable
+    // (the numbering exclusion is about numBodyOffset, not a bare hanging indent).
+    const hanging = await assertPaintIdentical(
+      doc([para(text, { indentLeft: 36, indentFirst: -18 }) as unknown as BodyElement]),
+    );
+    expect(hanging.drawn).toBeGreaterThan(0);
+    expect(hanging.measuresProduction).toBeLessThan(hanging.measuresRecompute);
+  });
+
+  it('explicit tab stops + tab runs: fragment paint === legacy (3-way)', async () => {
+    // A run with embedded tab characters (\t) and custom tab stops. layoutLines splits
+    // on '\t' and advances to the stops (left + right-aligned with a dot leader); the
+    // fragment's stored lines carry the tabbed geometry, painted without re-tabbing.
+    const cell = Array.from({ length: 6 }, () => 'w').join(' ');
+    const tabbed = `${cell}\t${cell}\t${cell}`;
+    const tabStops = [
+      { pos: 60, alignment: 'left', leader: 'none' },
+      { pos: 130, alignment: 'right', leader: 'dot' },
+    ] as unknown as DocParagraph['tabStops'];
+    const p = para(Array.from({ length: 16 }, () => tabbed).join(' '), { tabStops });
+    const r = await assertPaintIdentical(doc([p as unknown as BodyElement]));
+    expect(r.drawn).toBeGreaterThan(0);
+    expect(r.measuresProduction).toBeLessThan(r.measuresRecompute); // fragment paint fired
+  });
+
+  it('two-column section: fragment paint === legacy (3-way)', async () => {
+    // ECMA-376 §17.6.4 newspaper columns — the body flows through 2 equal columns.
+    // Each column-slice fragment records its column band width; paint sets contentW
+    // per column, and the placement guard's width check passes (equal columns).
+    const columns = { count: 2, spacePt: 12, equalWidth: true, sep: false, cols: [] } as unknown as SectionProps['columns'];
+    const text = Array.from({ length: 200 }, () => 'w').join(' ');
+    const model = doc([para(text) as unknown as BodyElement]);
+    (model.section as SectionProps).columns = columns;
+    const r = await assertPaintIdentical(model);
+    expect(r.drawn).toBeGreaterThan(0);
     expect(r.measuresProduction).toBeLessThan(r.measuresRecompute); // fragment paint fired
   });
 

--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   renderDocumentToCanvas,
   paginateDocument,
+  bodyFragmentFor,
+  __test_setBodyFragment,
   __test_setLineReuseEnabled,
   __test_setFragmentPaintEnabled,
 } from './renderer.js';
@@ -300,5 +302,50 @@ describe('body paint byte-identity — fragment paint and compute-once line reus
     const first = await renderAllPages(model, pages);
     const second = await renderAllPages(model, pages);
     for (let p = 0; p < first.perPage.length; p++) expect(second.perPage[p]).toEqual(first.perPage[p]);
+  });
+
+  it('stale-placement fragment (a NEWER narrower measurement) → placement guard falls back to legacy, output correct', async () => {
+    // Design invariant: "a measurement is valid only for its recorded placement".
+    // A fragment measured for one placement must never be painted at another. Here the
+    // width-180 prebuiltPages carry the paragraph p (its element stamps say the column
+    // is 180 pt wide), but the side table is poisoned with a fragment measured at
+    // width 100 (a 3-line partition) whose SOURCE is still p. Painting it would draw
+    // the wrong (narrower) line breaks; the placement guard in
+    // isFragmentPaintableParagraph detects the fragment's recorded availableWidthPt
+    // (100) ≠ the paint column width (180) and falls back to legacy renderParagraph,
+    // which reproduces the correct width-180 layout.
+    //
+    // The stale fragment is INJECTED rather than produced by a second pagination:
+    // re-paginating the same p rewrites its colGeom/section stamps too, so the paint
+    // width would track the stale fragment and no mismatch would be observable — a
+    // faithful reproduction of "a stale side-table entry from a newer re-pagination
+    // paints older prebuiltPages" without corrupting the element geometry.
+    const p = para(Array.from({ length: 30 }, () => 'w').join(' '));
+    const wideModel = doc([p as unknown as BodyElement], 600); // colW 180
+    // A narrow pagination of the SAME p yields a width-100 fragment whose source is p.
+    const narrowModel = doc([p as unknown as BodyElement], 600);
+    (narrowModel.section as SectionProps).pageWidth = 120; // colW 100
+    paginateDocument(narrowModel);
+    const stale = bodyFragmentFor(paginateDocument(narrowModel)[0][0]);
+    if (!stale) throw new Error('expected a narrow fragment to capture');
+    expect(stale.fragment.measured.placement.availableWidthPt).toBeCloseTo(100, 6);
+    expect(stale.fragment.source).toBe(p); // same source paragraph, different placement
+    // Re-paginate wide LAST so p's element stamps + prebuiltPages are the width-180 layout.
+    const pagesWide = paginateDocument(wideModel);
+    // Poison the side table for p's element with the stale width-100 fragment.
+    __test_setBodyFragment(pagesWide[0][0], stale);
+
+    const production = await renderVariant(wideModel, pagesWide, { fragmentPaint: true, reuse: true });
+    const legacy = await renderVariant(wideModel, pagesWide, { fragmentPaint: false, reuse: true });
+    expect(production.perPage.length).toBe(legacy.perPage.length);
+    for (let pg = 0; pg < production.perPage.length; pg++) {
+      // Guard falls back to legacy renderParagraph, so production === legacy (the
+      // correct width-180 layout). Without the guard, production paints the width-100
+      // fragment's 3-line partition and diverges — this is the Red case.
+      expect(production.perPage[pg]).toEqual(legacy.perPage[pg]);
+    }
+    // Non-vacuity: the paragraph wrapped (multiple painted lines), so the stale
+    // width-100 fragment would have been a visible divergence had the guard not fired.
+    expect(production.perPage[0].filter((c) => c.op !== 'img').length).toBeGreaterThan(1);
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -170,6 +170,10 @@ import {
   type ParagraphFragment,
   type PlacedFragment,
 } from './layout-fragments.js';
+// PR 5 — body fragment paint. renderer <-> fragment-paint is a deliberate import
+// cycle: both sides use the other only inside function bodies (never at module
+// evaluation), so ESM live bindings resolve them at call time.
+import { paintParagraphFragment } from './fragment-paint.js';
 import {
   drawVerticalRun,
   drawTateChuYokoRun,
@@ -5722,7 +5726,20 @@ function renderBodyElements(
               suppressBottom: parasShareBorderBox(para, nextFlowParaInColumn(elIdx)),
             }
           : undefined;
-      renderParagraph(para, state, suppress || isContinuation, slice, false, borderMerge);
+      // PR 5 — a migrated body paragraph paints from its stored fragment (no
+      // re-layout). Marker / float paragraphs (and any element the paginator did
+      // not fragment) fall through to the legacy `renderParagraph` acquisition.
+      // The fragment already carries this element's slice, so `slice` is not
+      // re-passed; suppression and border-merge are paint-adjacency inputs.
+      const placedFragment = bodyFragmentFor(el);
+      if (isFragmentPaintableParagraph(para, placedFragment, state)) {
+        paintParagraphFragment(placedFragment, state, {
+          suppressSpaceBefore: suppress || isContinuation,
+          borderMerge,
+        });
+      } else {
+        renderParagraph(para, state, suppress || isContinuation, slice, false, borderMerge);
+      }
       prevPara = para;
       prevSpaceAfter = para.spaceAfter;
     } else if (el.type === 'table') {
@@ -6157,6 +6174,16 @@ function renderParagraph(
    *  renderParaList), which knows in-flow adjacency. Absent ⇒ draw the full box
    *  (a standalone bordered paragraph). */
   borderMerge?: ParaBorderMerge,
+  /** PR 5 — pre-measured scale-1 line partition supplied by body fragment paint
+   *  ({@link paintParagraphFragment}). When provided (even empty), the paragraph's
+   *  lines are the SUPPLIED partition rescaled to the paint scale — the reuse gate,
+   *  the scale-1 recompute, and the float re-layout are all bypassed. This makes
+   *  paint consume stored geometry without re-running {@link layoutLines}. The
+   *  paint pass is byte-identical to the legacy acquisition because the fragment
+   *  holds exactly the scale-1 lines the legacy non-float path would compute
+   *  (migration is gated to non-float, non-marker paragraphs). Empty ⇒ the
+   *  markOnly / anchor-only paragraph, handled by the existing empty-mark branch. */
+  suppliedScale1Lines?: readonly LayoutLine[],
 ): void {
   const { ctx, scale, contentX, contentW, defaultColor, dryRun, fontFamilyClasses } = state;
   const paragraphContext = resolveStateParagraphLayoutContext(state, para);
@@ -6370,7 +6397,13 @@ function renderParagraph(
   const indRight1 = inFrame ? 0 : paragraphContext.physicalIndentRightPt;
   const marginRightPx = paraW + indRight;
   const marginRightPx1 = paraW1 + indRight1;
-  const lines = reuse
+  const lines = suppliedScale1Lines !== undefined
+    // Body fragment paint: use the fragment's scale-1 partition, rescaled to the
+    // paint scale via the same bridge the reuse gate uses. No re-layout, so paint
+    // scales stored geometry only (scale 1 returns the partition unchanged, so a
+    // scale-1 paint invokes no measureText).
+    ? rescaleLayoutLines([...suppliedScale1Lines], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx)
+    : reuse
     ? rescaleLayoutLines(stamped.layoutLines as LayoutLine[], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx)
     : wrapCtx
       ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx, baseRtl)
@@ -6536,6 +6569,66 @@ function renderParagraph(
   if (!lineSlice || lineSlice.start === 0) {
     renderAnchorImages(para, state, paragraphStartY);
   }
+}
+
+/** Master switch for body fragment paint (PR 5). Always ON in production; the
+ *  byte-identity characterization test (layout-lines-reuse-identity.test.ts) flips
+ *  it OFF to paint the migrated paragraphs through the legacy `renderParagraph`
+ *  acquisition and assert an IDENTICAL paint stream. Module-local. */
+let fragmentPaintEnabled = true;
+
+/** PR 5 — true when a body paragraph may be painted from its stored fragment. It
+ *  excludes the two cases where the fragment's scale-1 line partition would NOT
+ *  reproduce the legacy paint byte-for-byte:
+ *   - numbering markers: paint derives the first-line indent from `numBodyOffset`,
+ *     which differs from the placement-aware measurement's `para.indentFirst`;
+ *   - floating-wrap context: float paragraphs are laid out at the PAINT scale
+ *     against page-absolute float rectangles (renderParagraph case 3), which a
+ *     scale-1 fragment cannot reproduce (its measurement carries a wrap oracle).
+ *  It also excludes state-sensitive paragraphs (a NUMPAGES/page-ref field whose
+ *  resolved TEXT depends on the paint page context): the fragment's line segments
+ *  bake in the pagination-time field text, so those must recompute their segments at
+ *  paint — the same exclusion the legacy reuse stamp applies (`stampLines`).
+ *  Finally it excludes vertical (tbRl) text: the paginator's measure state has no
+ *  `verticalCJK`, so its fragment is laid out HORIZONTALLY (no 縦中横 grouping,
+ *  §17.3.2.10), whereas paint recomputes the lines vertically. Vertical text is
+ *  migrated with the vertical-text follow-up.
+ *  Excluded paragraphs stay on the legacy `renderParagraph` path; they are migrated
+ *  with markers / floats / table cells in later work. */
+function isFragmentPaintableParagraph(
+  para: DocParagraph,
+  placed: PlacedFragment | undefined,
+  state: RenderState,
+): placed is PlacedFragment {
+  return (
+    fragmentPaintEnabled &&
+    placed !== undefined &&
+    para.numbering == null &&
+    state.floats.length === 0 &&
+    !state.verticalCJK &&
+    placed.fragment.measured.placement.wrap === undefined &&
+    !paragraphSegsStateSensitive(para)
+  );
+}
+
+/**
+ * PR 5 — render a body paragraph from its fragment's stored scale-1 line partition,
+ * WITHOUT re-running line layout. Shares the exact draw path of
+ * {@link renderParagraph} (via its supplied-lines parameter), so the paint stream is
+ * byte-identical to the legacy acquisition for the migrated (non-marker, non-float)
+ * class. Called by {@link paintParagraphFragment} in fragment-paint.ts, which owns
+ * the fragment boundary; the scale-1 → paint-scale rescale happens inside
+ * `renderParagraph` through the existing `rescaleLayoutLines` bridge.
+ */
+export function renderBodyParagraphLines(
+  source: DocParagraph,
+  state: RenderState,
+  scale1Lines: readonly LayoutLine[],
+  suppressSpaceBefore: boolean,
+  lineSlice: { start: number; end: number } | undefined,
+  borderMerge: ParaBorderMerge | undefined,
+): void {
+  renderParagraph(source, state, suppressSpaceBefore, lineSlice, false, borderMerge, scale1Lines);
 }
 
 /** Per-line draw context for {@link drawParagraphLine}. Bundles the read-only
@@ -8987,6 +9080,17 @@ export const __test_setLineReuseEnabled = (v: boolean): boolean => {
   return prev;
 };
 
+/** Exported for the body fragment-paint byte-identity test (PR 5). Toggles whether
+ *  migrated body paragraphs paint from their stored fragment or fall back to the
+ *  legacy `renderParagraph` acquisition, so the test can render the SAME page both
+ *  ways and assert the paint call streams are byte-identical. Returns the previous
+ *  value so the test can restore it. */
+export const __test_setFragmentPaintEnabled = (v: boolean): boolean => {
+  const prev = fragmentPaintEnabled;
+  fragmentPaintEnabled = v;
+  return prev;
+};
+
 /** Exported for the compute-once table-layout characterization test (B2 table
  *  stage 1b). Toggles the stamped column-width/row-height reuse in
  *  computeTableLayout so the test can resolve the SAME stamped table with reuse ON
@@ -10326,7 +10430,7 @@ function drawBorderLine(
  * `suppressBottom` when one follows. When `suppressTop` is set the `between`
  * edge (if defined) is drawn at the top join instead of the `top` edge.
  */
-interface ParaBorderMerge {
+export interface ParaBorderMerge {
   /** A same-border paragraph is adjacent above ⇒ don't draw this `top` edge
    *  (draw `between` at the top join instead, when defined). */
   suppressTop?: boolean;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -160,8 +160,16 @@ import {
 import {
   createFloatWrapOracle,
   measureParagraph,
+  type MeasuredParagraph,
   type ParagraphMeasurementEnvironment,
 } from './paragraph-measure.js';
+import {
+  paragraphFragmentAdvancePt,
+  type DocumentLayout,
+  type LayoutPage,
+  type ParagraphFragment,
+  type PlacedFragment,
+} from './layout-fragments.js';
 import {
   drawVerticalRun,
   drawTateChuYokoRun,
@@ -2941,6 +2949,14 @@ export function computePages(
           addReservePt = sumReserve(newRefIds);
         }
       } else {
+        // PR 5 — attach the placement-aware fragment for this non-split paragraph
+        // (measured at its FINAL placement, `measureState.y`, after any relocation).
+        attachBodyParagraphFragment(el as PaginatedElementWithLines, para, measureState, {
+          paragraphXPt: colX(),
+          availableWidthPt: colW(),
+          suppressSpaceBefore: suppressBefore,
+          columnIndex: colIndex,
+        });
         pushTagged(el as PaginatedBodyElement);
         y += h;
         measureState.y += h;
@@ -3557,6 +3573,60 @@ export function paginateDocument(doc: DocxDocumentModel): PaginatedBodyElement[]
   );
 }
 
+/**
+ * PR 5 — produce the immutable body {@link DocumentLayout}: pages of
+ * {@link PlacedFragment}s over body paragraphs. Pagination is the SAME engine
+ * `paginateDocument` runs (so page assignment, splitting, sections and columns are
+ * identical); this projects the fragments the paginator attached to each body
+ * paragraph element into a frozen result. Tables, headers/footers and floating
+ * content stay on the `PaginatedBodyElement[][]` path until PR 6, so a page's
+ * `fragments` cover its body PARAGRAPHS only (`FlowFragment` is paragraph-only in
+ * PR 5). The section context and page geometry come from each page's stamped section
+ * (a mid-document section break changes them), falling back to the body section.
+ */
+export function layoutDocument(doc: DocxDocumentModel): DocumentLayout {
+  const ctx = new OffscreenCanvas(1, 1).getContext('2d');
+  if (!ctx) return Object.freeze({ pages: Object.freeze([]) });
+  const layoutDoc = verticalLayoutDoc(doc);
+  const layoutSettings = resolveDocumentLayoutSettings(layoutDoc);
+  const pages = paginateWithHeaderFooterReserve(
+    layoutDoc,
+    ctx,
+    layoutDoc.fontFamilyClasses ?? {},
+    layoutSettings,
+    layoutDoc.footnotes ?? [],
+  );
+  const layoutPages: LayoutPage[] = pages.map((elements, pageIndex) => {
+    const geomOverride = (elements[0] as PaginatedBodyElement | undefined)?.sectionGeom;
+    const sectionProps: SectionProps = geomOverride
+      ? { ...layoutDoc.section, ...geomOverride }
+      : layoutDoc.section;
+    const section = resolveSectionLayoutContext(layoutSettings, sectionProps);
+    const geometry: SectionGeom = {
+      pageWidth: sectionProps.pageWidth,
+      pageHeight: sectionProps.pageHeight,
+      marginTop: sectionProps.marginTop,
+      marginRight: sectionProps.marginRight,
+      marginBottom: sectionProps.marginBottom,
+      marginLeft: sectionProps.marginLeft,
+      headerDistance: sectionProps.headerDistance,
+      footerDistance: sectionProps.footerDistance,
+    };
+    const fragments: PlacedFragment[] = [];
+    for (const el of elements) {
+      const placed = bodyParagraphFragments.get(el as object);
+      if (placed) fragments.push(placed);
+    }
+    return Object.freeze({
+      pageIndex,
+      section,
+      geometry,
+      fragments: Object.freeze(fragments) as readonly PlacedFragment[],
+    });
+  });
+  return Object.freeze({ pages: Object.freeze(layoutPages) as readonly LayoutPage[] });
+}
+
 function buildMeasureState(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   section: SectionProps,
@@ -3640,6 +3710,134 @@ function paragraphMeasurementEnvironment(
     verticalCJK: state.verticalCJK,
     documentHasEastAsianText: state.docEastAsian,
   };
+}
+
+// ===== Body layout fragments (PR 5) =====
+//
+// The paginator associates an immutable {@link PlacedFragment} with each body
+// paragraph element it emits, keyed by the element object in a side table (never a
+// field on the element, because a NON-split paragraph element IS the parsed
+// `DocParagraph` — writing a field would mutate the source model). {@link layoutDocument}
+// assembles those into a {@link DocumentLayout}; body paint (PR 5 Task 13) consumes
+// the fragment's stored scale-1 geometry without re-laying-out the paragraph. This
+// leaves the existing `PaginatedBodyElement[][]` shape byte-identical, so every
+// unmigrated caller (tables, headers/footers, the vertical-text prebuilt-pages swap)
+// is unaffected.
+
+/** Side table: emitted body element -> its placed paragraph fragment. WeakMap so an
+ *  element that is garbage collected drops its entry, and so the parsed `DocParagraph`
+ *  is never mutated (a non-split paragraph element is the source object itself). */
+const bodyParagraphFragments = new WeakMap<object, PlacedFragment>();
+
+/** Read the placed fragment the paginator associated with an emitted body element,
+ *  if any (paragraph elements the fragment migration covers). */
+export function bodyFragmentFor(el: PaginatedBodyElement): PlacedFragment | undefined {
+  return bodyParagraphFragments.get(el as object);
+}
+
+/** Build an immutable body paragraph fragment. `source` is the PARSED paragraph
+ *  (never a slice clone); `measured` is its placement-aware measurement;
+ *  `[lineStart, lineEnd)` selects the painted lines. Leading spacing is charged only
+ *  on the first slice and trailing only on the final slice, so paragraph spacing is
+ *  owned by the fragment and counted exactly once (design §"Measured Fragment Model"). */
+function buildParagraphFragment(
+  source: DocParagraph,
+  measured: MeasuredParagraph,
+  lineStart: number,
+  lineEnd: number,
+  isFirstSlice: boolean,
+  isFinalSlice: boolean,
+  trailingExtentPt: number,
+): ParagraphFragment {
+  const leadingSpacePt = isFirstSlice
+    ? measured.contentStartYPt - measured.placement.startYPt
+    : 0;
+  const trailingSpacePt = isFinalSlice ? trailingExtentPt : 0;
+  return Object.freeze({
+    kind: 'paragraph',
+    source,
+    measured,
+    lineStart,
+    lineEnd,
+    leadingSpacePt,
+    trailingSpacePt,
+  });
+}
+
+/** Place a paragraph fragment at page-absolute scale-1 coordinates. `heightPt` is the
+ *  cursor advancement (leadingSpacePt + measured line advances + trailingSpacePt). */
+function placeParagraphFragment(
+  fragment: ParagraphFragment,
+  columnIndex: number,
+  xPt: number,
+  yPt: number,
+  widthPt: number,
+): PlacedFragment {
+  return Object.freeze({
+    fragment,
+    columnIndex,
+    xPt,
+    yPt,
+    widthPt,
+    heightPt: paragraphFragmentAdvancePt(fragment),
+  });
+}
+
+/** Measure a NON-split body paragraph at its final placement (the same measurement
+ *  {@link estimateParagraphHeight} makes for the fit decision) and attach its placed
+ *  fragment covering the whole line range. */
+function attachBodyParagraphFragment(
+  el: PaginatedElementWithLines,
+  source: DocParagraph,
+  measureState: RenderState,
+  placement: {
+    paragraphXPt: number;
+    availableWidthPt: number;
+    suppressSpaceBefore: boolean;
+    columnIndex: number;
+  },
+): void {
+  const paragraphContext = resolveBodyParagraphLayoutContext(measureState, source);
+  const measured = measureParagraph(
+    source,
+    paragraphContext,
+    {
+      startYPt: measureState.y,
+      paragraphXPt: placement.paragraphXPt,
+      availableWidthPt: placement.availableWidthPt,
+      maximumYPt: measureState.pageH,
+      suppressSpaceBefore: placement.suppressSpaceBefore,
+      wrap: measureState.floats.length > 0
+        ? createFloatWrapOracle(measureState.floats)
+        : undefined,
+    },
+    {
+      context: measureState.ctx,
+      fontFamilyClasses: measureState.fontFamilyClasses,
+    },
+    paragraphMeasurementEnvironment(measureState),
+  );
+  const trailingExtentPt = Math.max(
+    measured.requestedSpaceAfterPt,
+    bottomBorderExtentPt(source.borders),
+  );
+  const lineEnd = measured.markOnly ? 0 : measured.lines.length;
+  const fragment = buildParagraphFragment(
+    source,
+    measured,
+    0,
+    lineEnd,
+    true,
+    true,
+    trailingExtentPt,
+  );
+  bodyParagraphFragments.set(el, placeParagraphFragment(
+    fragment,
+    placement.columnIndex,
+    placement.paragraphXPt,
+    measured.placement.startYPt,
+    placement.availableWidthPt,
+  ));
 }
 
 function estimateParagraphHeight(
@@ -3925,6 +4123,32 @@ function splitParagraphAcrossPages(
           hasFloats: measured.placement.wrap !== undefined,
           kinsoku: measureState.kinsoku,
         });
+      }
+      // PR 5 — attach this slice's placement-aware fragment. All slices share the
+      // paragraph measurement; `[firstFitting, lastFitting)` selects the painted
+      // lines, leading spacing rides the first slice and trailing the last. The
+      // slice top is page-absolute: the section body inset plus the content-relative
+      // cursor (matching `stamp`'s `colTopPt` convention).
+      {
+        const topInset = tagSectionGeom
+          ? bodyMarginInsetPt(tagSectionGeom().marginTop)
+          : measureState.marginTop;
+        const fragment = buildParagraphFragment(
+          para,
+          measured,
+          firstFitting,
+          lastFitting,
+          firstFitting === 0,
+          isFinalSlice,
+          trailingExtent,
+        );
+        bodyParagraphFragments.set(sliceEl, placeParagraphFragment(
+          fragment,
+          tagColIndex ? tagColIndex() : 0,
+          paragraphXPt(),
+          topInset + cursorY,
+          contentWPt(),
+        ));
       }
       pages[pages.length - 1].push(stamp(sliceEl));
       lineIdx = lastFitting;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3739,6 +3739,18 @@ export function bodyFragmentFor(el: PaginatedBodyElement): PlacedFragment | unde
   return bodyParagraphFragments.get(el as object);
 }
 
+/** TEST ONLY — inject a placed fragment into the body-fragment side table for an
+ *  emitted element, isolating a MISMATCHED (stale-placement) fragment to exercise the
+ *  placement guard. Re-paginating the same paragraph cannot isolate this: it rewrites
+ *  the element's colGeom/section stamps too, so the paint width tracks the stale
+ *  fragment and no mismatch is observable. */
+export const __test_setBodyFragment = (
+  el: PaginatedBodyElement,
+  placed: PlacedFragment,
+): void => {
+  bodyParagraphFragments.set(el as object, placed);
+};
+
 /** Build an immutable body paragraph fragment. `source` is the PARSED paragraph
  *  (never a slice clone); `measured` is its placement-aware measurement;
  *  `[lineStart, lineEnd)` selects the painted lines. Leading spacing is charged only
@@ -5732,7 +5744,7 @@ function renderBodyElements(
       // The fragment already carries this element's slice, so `slice` is not
       // re-passed; suppression and border-merge are paint-adjacency inputs.
       const placedFragment = bodyFragmentFor(el);
-      if (isFragmentPaintableParagraph(para, placedFragment, state)) {
+      if (isFragmentPaintableParagraph(para, placedFragment, state, slice === undefined)) {
         paintParagraphFragment(placedFragment, state, {
           suppressSpaceBefore: suppress || isContinuation,
           borderMerge,
@@ -6594,21 +6606,47 @@ let fragmentPaintEnabled = true;
  *  §17.3.2.10), whereas paint recomputes the lines vertically. Vertical text is
  *  migrated with the vertical-text follow-up.
  *  Excluded paragraphs stay on the legacy `renderParagraph` path; they are migrated
- *  with markers / floats / table cells in later work. */
+ *  with markers / floats / table cells in later work.
+ *
+ *  PLACEMENT SANITY GUARD (design §"Placement-Aware Paragraph Measurement": "a
+ *  measurement is valid only for its recorded placement"). The fragment is associated
+ *  through a WeakMap keyed by the emitted element; the paint pass trusts that
+ *  association. As a cheap safety net against a STALE entry (e.g. a newer
+ *  re-pagination overwrote the side table while these older prebuiltPages are being
+ *  painted), verify the fragment still matches THIS paint's placement before trusting
+ *  it: its recorded `availableWidthPt` must equal the current paint column width
+ *  (state.contentW rescaled to scale-1 pt), and — for a NON-split paragraph, whose
+ *  emitted element IS the parsed paragraph — its `source` must be this very paragraph
+ *  (a split slice's source is intentionally the ORIGINAL paragraph, not the slice
+ *  element, so that identity is skipped for slices). On any mismatch we fall through
+ *  to the correct-but-slower legacy `renderParagraph` path; we never throw. */
 function isFragmentPaintableParagraph(
   para: DocParagraph,
   placed: PlacedFragment | undefined,
   state: RenderState,
+  isNonSplitElement: boolean,
 ): placed is PlacedFragment {
-  return (
-    fragmentPaintEnabled &&
-    placed !== undefined &&
-    para.numbering == null &&
-    state.floats.length === 0 &&
-    !state.verticalCJK &&
-    placed.fragment.measured.placement.wrap === undefined &&
-    !paragraphSegsStateSensitive(para)
-  );
+  if (
+    !fragmentPaintEnabled ||
+    placed === undefined ||
+    para.numbering != null ||
+    state.floats.length !== 0 ||
+    state.verticalCJK ||
+    placed.fragment.measured.placement.wrap !== undefined ||
+    paragraphSegsStateSensitive(para)
+  ) {
+    return false;
+  }
+  // Placement guard: the fragment's recorded band width must equal this paint's
+  // column width (both in scale-1 pt; state.contentW = colW·scale). A magnitude-
+  // relative epsilon absorbs float round-off between the two derivations.
+  const paintAvailableWidthPt = state.contentW / state.scale;
+  const recordedWidthPt = placed.fragment.measured.placement.availableWidthPt;
+  const widthMatches =
+    Math.abs(recordedWidthPt - paintAvailableWidthPt) <=
+    1e-6 * Math.max(1, Math.abs(paintAvailableWidthPt));
+  const sourceMatches = !isNonSplitElement || placed.fragment.source === para;
+  return widthMatches && sourceMatches;
 }
 
 /**

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2741,7 +2741,11 @@ export function computePages(
       const nextEl = body[i + 1];
       const nextShares = nextEl?.type === 'paragraph'
         && parasShareBorderBox(para, nextEl);
-      const h = estimateParagraphHeight(measureState, para, colW(), suppressBefore, colX(), nextShares);
+      // M-1 — take the fit-decision measurement ONCE and reuse it for the fragment
+      // when this paragraph is not relocated (attachBodyParagraphFragment re-checks
+      // placement equality before trusting it).
+      const fitMeasured = measureBodyParagraphAtCursor(measureState, para, colW(), suppressBefore, colX());
+      const h = paragraphHeightFromMeasured(fitMeasured, para, nextShares);
 
       // ECMA-376 §17.11: a footnote shares the page with its reference, so the
       // body must stop short of the footnote area. Measure the footnotes this
@@ -2955,12 +2959,14 @@ export function computePages(
       } else {
         // PR 5 — attach the placement-aware fragment for this non-split paragraph
         // (measured at its FINAL placement, `measureState.y`, after any relocation).
+        // M-1: hand it the fit-decision measurement; it is reused only if the final
+        // placement still matches (no relocation), else remeasured.
         attachBodyParagraphFragment(el as PaginatedElementWithLines, para, measureState, {
           paragraphXPt: colX(),
           availableWidthPt: colW(),
           suppressSpaceBefore: suppressBefore,
           columnIndex: colIndex,
-        });
+        }, fitMeasured);
         pushTagged(el as PaginatedBodyElement);
         y += h;
         measureState.y += h;
@@ -3799,9 +3805,24 @@ function placeParagraphFragment(
   });
 }
 
-/** Measure a NON-split body paragraph at its final placement (the same measurement
- *  {@link estimateParagraphHeight} makes for the fit decision) and attach its placed
- *  fragment covering the whole line range. */
+/** Master switch for the M-1 fit-check measurement reuse. Always ON in production; the
+ *  non-vacuity test flips it OFF to force a second measurement and assert the reuse
+ *  really avoided one (fewer measureText calls during pagination) with identical output.
+ *  Module-local. */
+let fitMeasureReuseEnabled = true;
+
+/** Measure a NON-split body paragraph at its final placement and attach its placed
+ *  fragment covering the whole line range.
+ *
+ *  M-1 — the fit decision already measured this paragraph at the cursor placement
+ *  ({@link measureBodyParagraphAtCursor}). When the paragraph was NOT relocated after
+ *  that estimate its final placement is identical, so `fitMeasured` is reused instead
+ *  of measuring a second time. The reuse is keyed on placement VALUE equality (start Y,
+ *  paragraph X, width, page limit, space-before suppression), never on paragraph
+ *  identity: a relocation to the next column/page changes `measureState.y` (and X), so
+ *  the gate rejects the stale estimate and remeasures at the new placement. Only the
+ *  float-free case is reused — a paragraph in a float context always remeasures, since
+ *  its wrap window depends on the live float set. */
 function attachBodyParagraphFragment(
   el: PaginatedElementWithLines,
   source: DocParagraph,
@@ -3812,27 +3833,39 @@ function attachBodyParagraphFragment(
     suppressSpaceBefore: boolean;
     columnIndex: number;
   },
+  fitMeasured?: MeasuredParagraph,
 ): void {
   const paragraphContext = resolveBodyParagraphLayoutContext(measureState, source);
-  const measured = measureParagraph(
-    source,
-    paragraphContext,
-    {
-      startYPt: measureState.y,
-      paragraphXPt: placement.paragraphXPt,
-      availableWidthPt: placement.availableWidthPt,
-      maximumYPt: measureState.pageH,
-      suppressSpaceBefore: placement.suppressSpaceBefore,
-      wrap: measureState.floats.length > 0
-        ? createFloatWrapOracle(measureState.floats)
-        : undefined,
-    },
-    {
-      context: measureState.ctx,
-      fontFamilyClasses: measureState.fontFamilyClasses,
-    },
-    paragraphMeasurementEnvironment(measureState),
-  );
+  const measured =
+    fitMeasured !== undefined &&
+    fitMeasureReuseEnabled &&
+    measureState.floats.length === 0 &&
+    fitMeasured.placement.wrap === undefined &&
+    fitMeasured.placement.startYPt === measureState.y &&
+    fitMeasured.placement.paragraphXPt === placement.paragraphXPt &&
+    fitMeasured.placement.availableWidthPt === placement.availableWidthPt &&
+    fitMeasured.placement.maximumYPt === measureState.pageH &&
+    fitMeasured.placement.suppressSpaceBefore === placement.suppressSpaceBefore
+      ? fitMeasured
+      : measureParagraph(
+          source,
+          paragraphContext,
+          {
+            startYPt: measureState.y,
+            paragraphXPt: placement.paragraphXPt,
+            availableWidthPt: placement.availableWidthPt,
+            maximumYPt: measureState.pageH,
+            suppressSpaceBefore: placement.suppressSpaceBefore,
+            wrap: measureState.floats.length > 0
+              ? createFloatWrapOracle(measureState.floats)
+              : undefined,
+          },
+          {
+            context: measureState.ctx,
+            fontFamilyClasses: measureState.fontFamilyClasses,
+          },
+          paragraphMeasurementEnvironment(measureState),
+        );
   const trailingExtentPt = Math.max(
     measured.requestedSpaceAfterPt,
     bottomBorderExtentPt(source.borders),
@@ -3856,23 +3889,24 @@ function attachBodyParagraphFragment(
   ));
 }
 
-function estimateParagraphHeight(
+/** Measure a body paragraph at the CURRENT cursor placement (`state.y`, `paraXPt`,
+ *  `contentWPt`) — the placement the fit decision walks. Returns the placement-aware
+ *  {@link MeasuredParagraph} so a NON-relocated non-split paragraph can hand this same
+ *  measurement to its fragment instead of measuring a second time (M-1). Pure over the
+ *  measurer; does not mutate `state`. */
+function measureBodyParagraphAtCursor(
   state: RenderState,
   para: DocParagraph,
   contentWPt: number,
-  suppressSpaceBefore = false,
-  paraXPt = 0,
-  /** §17.3.1.7: the next in-flow paragraph shares this paragraph's border box, so
-   *  its bottom edge is suppressed (the box continues) and reserves no extent. */
-  nextSharesBottomBorder = false,
-): number {
+  suppressSpaceBefore: boolean,
+  paraXPt: number,
+): MeasuredParagraph {
   const paragraphContext = resolveBodyParagraphLayoutContext(state, para);
-  const startYPt = state.y;
-  const measured = measureParagraph(
+  return measureParagraph(
     para,
     paragraphContext,
     {
-      startYPt,
+      startYPt: state.y,
       paragraphXPt: paraXPt,
       availableWidthPt: contentWPt,
       maximumYPt: state.pageH,
@@ -3887,9 +3921,38 @@ function estimateParagraphHeight(
     },
     paragraphMeasurementEnvironment(state),
   );
+}
+
+/** The estimated flow height of an already-measured body paragraph: its content span
+ *  from the measurement's recorded start, plus trailing space (spaceAfter or the
+ *  §17.3.1.7 bottom-border extent, unless the next in-flow paragraph shares the border
+ *  box). `measured.placement.startYPt` equals the `state.y` the measurement was taken
+ *  at, so this reproduces the original `contentEndYPt − startYPt + …` formula. */
+function paragraphHeightFromMeasured(
+  measured: MeasuredParagraph,
+  para: DocParagraph,
+  nextSharesBottomBorder: boolean,
+): number {
   const bottomExtent = nextSharesBottomBorder ? 0 : bottomBorderExtentPt(para.borders);
-  return measured.contentEndYPt - startYPt
+  return measured.contentEndYPt - measured.placement.startYPt
     + Math.max(measured.requestedSpaceAfterPt, bottomExtent);
+}
+
+function estimateParagraphHeight(
+  state: RenderState,
+  para: DocParagraph,
+  contentWPt: number,
+  suppressSpaceBefore = false,
+  paraXPt = 0,
+  /** §17.3.1.7: the next in-flow paragraph shares this paragraph's border box, so
+   *  its bottom edge is suppressed (the box continues) and reserves no extent. */
+  nextSharesBottomBorder = false,
+): number {
+  return paragraphHeightFromMeasured(
+    measureBodyParagraphAtCursor(state, para, contentWPt, suppressSpaceBefore, paraXPt),
+    para,
+    nextSharesBottomBorder,
+  );
 }
 
 /** Snap a paragraph's uniform line height up to an integer multiple of the
@@ -9126,6 +9189,17 @@ export const __test_setLineReuseEnabled = (v: boolean): boolean => {
 export const __test_setFragmentPaintEnabled = (v: boolean): boolean => {
   const prev = fragmentPaintEnabled;
   fragmentPaintEnabled = v;
+  return prev;
+};
+
+/** Exported for the M-1 double-measurement non-vacuity test. Toggles whether a
+ *  non-relocated body paragraph's fragment reuses the fit-decision measurement or
+ *  measures again, so the test can paginate the SAME document both ways and assert the
+ *  reuse path makes fewer measureText calls with identical fragments. Returns the
+ *  previous value so the test can restore it. */
+export const __test_setFitMeasureReuseEnabled = (v: boolean): boolean => {
+  const prev = fitMeasureReuseEnabled;
+  fitMeasureReuseEnabled = v;
   return prev;
 };
 

--- a/rule-tests/no-docx-measurement-in-fragment-paint-test.yml
+++ b/rule-tests/no-docx-measurement-in-fragment-paint-test.yml
@@ -1,0 +1,22 @@
+id: no-docx-measurement-in-fragment-paint
+valid:
+  # Painting supplied geometry: scale the stored lines and draw them.
+  - "const lines = rescaleLayoutLines([...scale1Lines], scale, ctx, classes, delta);"
+  - "ctx.fillText(seg.text, x, baseline);"
+  - "ctx.drawImage(bmp, x, y, w, h);"
+  - "renderBodyParagraphLines(fragment.source, state, scale1Lines, suppress, slice, borderMerge);"
+  - "const advances = fragment.measured.lines.map((line) => line.layout);"
+invalid:
+  # Re-running line layout / segment construction / paragraph measurement.
+  - "const segs = buildSegments(para.runs, environment);"
+  - "const ls = layoutLines(ctx, segs, w, fi, scale, tabs, wrap, classes, il, k, d, dt, mr, rtl);"
+  - "const m = measureParagraph(para, context, placement, measurer, environment);"
+  # Measuring text at paint.
+  - "const w = ctx.measureText(seg.text).width;"
+  - "const w2 = measureText(seg.text).width;"
+  # Row measurement.
+  - "const rows = resolveTableRowHeights(table, cols, 1, measurer);"
+  - "const h = measureCellContentHeightPx(cell, table, cellW, scale, state);"
+  # Importing a forbidden symbol.
+  - "import { layoutLines } from './line-layout.js';"
+  - "import { measureParagraph } from './paragraph-measure.js';"

--- a/rules/no-docx-measurement-in-fragment-paint.yml
+++ b/rules/no-docx-measurement-in-fragment-paint.yml
@@ -1,0 +1,33 @@
+id: no-docx-measurement-in-fragment-paint
+language: TypeScript
+severity: error
+message: >-
+  fragment-paint.ts paints stored fragment geometry only — it must not measure or
+  re-lay-out. Do not call buildSegments / layoutLines / measureParagraph /
+  measureText / row measurement here (PR 5 body-paint boundary).
+note: |
+  A body paragraph fragment carries its measured scale-1 geometry; paint scales it
+  (rescaleLayoutLines) and draws it. Re-running line layout or measuring text at paint
+  would defeat the fragment model (double measurement, stale placement) — the exact
+  divergence the migration removes. Keep segment construction, line layout, paragraph
+  measurement, text measurement and row measurement out of this file; consume the
+  fragment's stored lines instead.
+rule:
+  any:
+    # Segment construction / line layout / paragraph measurement.
+    - pattern: buildSegments($$$ARGS)
+    - pattern: layoutLines($$$ARGS)
+    - pattern: measureParagraph($$$ARGS)
+    # Canvas text measurement (bare or method form).
+    - pattern: measureText($$$ARGS)
+    - pattern: $OBJ.measureText($$$ARGS)
+    # Table row measurement.
+    - pattern: resolveTableRowHeights($$$ARGS)
+    - pattern: measureCellContentHeightPx($$$ARGS)
+    # Importing any of the forbidden layout/measurement symbols.
+    - kind: import_specifier
+      has:
+        field: name
+        regex: "^(buildSegments|layoutLines|measureParagraph|resolveTableRowHeights|measureCellContentHeightPx)$"
+files:
+  - "**/fragment-paint.ts"

--- a/rules/no-docx-measurement-in-fragment-paint.yml
+++ b/rules/no-docx-measurement-in-fragment-paint.yml
@@ -12,6 +12,15 @@ note: |
   divergence the migration removes. Keep segment construction, line layout, paragraph
   measurement, text measurement and row measurement out of this file; consume the
   fragment's stored lines instead.
+
+  BOUNDARY SCOPE (PR 5): this rule enforces the measurement-free boundary for the
+  fragment-paint MODULE only. The shared draw path it delegates to (renderParagraph in
+  renderer.ts) still constructs segments (bidi / tab detection) and, at a paint scale
+  != 1, RE-MEASURES each stored line's glyph geometry via rescaleLayoutLines — by
+  design: the fragment stores the scale-1 line PARTITION (break decisions), and only
+  glyph metrics are re-derived at the display scale, never the wrap points. Full static
+  enforcement across the whole body-paint path lands when body paint is separated into
+  its own module (PR 6+ scope).
 rule:
   any:
     # Segment construction / line layout / paragraph measurement.


### PR DESCRIPTION
## What

Stage 5 (PR 5) of the DOCX layout-context/fragments migration described in
`docs/docx-layout-context-fragments-design.md` and
`docs/docx-layout-context-fragments-implementation-plan.md`.

Body paragraphs are now paginated as immutable fragments — `ParagraphFragment`,
`PlacedFragment`, `LayoutPage`, `DocumentLayout`, produced by a new
`layoutDocument` entry point — instead of being mutated in place during
pagination. A `WeakMap`-backed side table keeps the parsed document model
itself unmutated; fragments carry their own placement and geometry.

Painting a fragment no longer re-runs line layout. A dedicated
`fragment-paint.ts` module paints straight from the already-computed line
partition (via a `suppliedScale1Lines` bypass threaded through the shared
draw path), instead of re-measuring the paragraph at paint time. An
ast-grep rule (`no-docx-measurement-in-fragment-paint`) enforces this
boundary statically: paint code under `fragment-paint.ts` may not call the
paragraph measurement kernel.

`paginateDocument` remains as the compatibility adapter for callers that
still expect the pre-fragment shape.

## Scope guard

Several paragraph categories intentionally stay on the legacy
measure-and-paint path for this PR, because their measure/paint behavior has
divergences from the fragment path that aren't closed yet:

- numbered-marker paragraphs
- float-adjacent paragraphs
- vertical-text paragraphs
- state-sensitive-field paragraphs (e.g. fields whose rendered content
  depends on evaluation state)
- table-cell paragraphs (table fragments are PR 6)

These exclusions are documented in-code at the fragment/legacy branch point.

## Hardening from review

- **Placement sanity guard with legacy fallback.** Design invariant: a
  measurement is only valid for the exact placement it was produced against
  (destination column/cell, width, starting Y, wrap oracle). A guard checks
  this at paint time and falls back to the legacy measure-and-paint path if
  a fragment's recorded placement doesn't match what it's about to be
  painted into, rather than silently painting stale geometry.
- **Equivalence coverage extended** to non-1x zoom (asserting fragment-paint
  and stamp-reuse produce byte-identical output at scale ≠ 1), paragraph
  indents, tab stops, and two-column sections.
- **Inner-fragment freeze assertion** — a test pins that fragment internals
  stay structurally frozen after production, guarding the immutability
  invariant the design relies on.
- **Fit-check measurement reuse.** The pagination fit-check now calls
  `measureParagraph` at most once per non-split body paragraph, keyed on
  placement value-equality, instead of re-measuring the same paragraph
  multiple times during the same fit check.
- **Module-scope note** added on the fragment-paint boundary rule clarifying
  its intended scope honestly (what it does and does not statically
  guarantee).

## Verification

- `pnpm test` (full workspace): 3437 passed, 3 skipped (358 files passed, 1
  skipped).
- `pnpm typecheck` (root): clean.
- `pnpm lint`: clean (only pre-existing, non-blocking tripwire warnings on
  `as unknown as` double-casts predating this branch).
- `pnpm lint:test`: 4/4 ast-grep rule tests pass, including the new
  `no-docx-measurement-in-fragment-paint` boundary rule.
- `git diff --check origin/main...HEAD`: clean.
- DOCX VRT (local-only, not run in CI): 70 passed / 17 failed, out of 87
  checks. Local VRT is byte-identical to the pre-branch baseline — every
  failing check's raw diff-pixel count is identical to the recorded
  baseline (same failing set, same pixel counts on every check, zero new
  failures, zero disappeared failures). Visual reference images under
  `tests/visual/references/` are unchanged by this PR.

## Follow-ups (tracked in the implementation plan)

- Complete `DocumentLayout` for continuous sections, plus deep-freeze
  coverage (PR 6, alongside table fragments).
- Remeasure-before-line-zero for paragraph continuation across
  unequal-width newspaper columns (§17.6.4), rather than reusing the first
  placement's line geometry.
- §20.4.2.16 `topAndBottom` wrap cross-column audit, for consistency with
  the square-wrap fix landed in the prior PR in this series.

## Attribution

Implemented by Claude (Opus 4.8, Sonnet 5, Fable 5); per-commit
`Co-Authored-By` trailers name the exact models that contributed to each
commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
