### PR TITLE
fix(docx): scope topAndBottom float wrap to overlapped columns

### DIFF
--- a/packages/docx/src/float-layout.ts
+++ b/packages/docx/src/float-layout.ts
@@ -149,6 +149,26 @@ export function isWrapFloat(mode?: string | null): boolean {
   return mode === 'square' || mode === 'topAndBottom' || mode === 'tight' || mode === 'through';
 }
 
+/**
+ * Does float `f`'s horizontal extent overlap the paragraph/column text band
+ * [paraXLeft, paraXRight]? Touching edges (within FLOAT_OVERLAP_EPS) do not count.
+ *
+ * ECMA-376 §20.4.2.17 (wrapSquare) and §20.4.2.20 (wrapTopAndBottom) both exclude
+ * text only where the object is horizontally placed ("text shall wrap around …
+ * THIS OBJECT"). Floats are registered in ABSOLUTE page coordinates and the page
+ * float set is shared across a section's newspaper columns (§17.6.4), so a float
+ * anchored in one column must be filtered out for a line laid out in another
+ * column that it does not horizontally overlap. Both wrap modes route through
+ * this one predicate so they share identical column-scoping semantics.
+ */
+export function floatOverlapsColumnX(
+  f: FloatRect,
+  paraXLeft: number,
+  paraXRight: number,
+): boolean {
+  return f.xRight > paraXLeft + FLOAT_OVERLAP_EPS && f.xLeft < paraXRight - FLOAT_OVERLAP_EPS;
+}
+
 /** Two exclusion rects intersect (strict overlap, touching edges allowed). */
 export function rectsOverlap(
   aL: number, aR: number, aT: number, aB: number,
@@ -221,23 +241,36 @@ export function resolveLineFloatWindow(
   maxWidth: number,
   floats: FloatRect[],
 ): { topY: number; xOffset: number; maxWidth: number } {
+  const paraXLeft = paraX;
+  const paraXRight = paraX + maxWidth;
+
   // 1. Keep pushing past any topAndBottom block we sit inside.
+  //
+  // §20.4.2.20 (wrapTopAndBottom) excludes text only where THIS OBJECT is
+  // horizontally placed. A page-scoped float anchored in another newspaper
+  // column (§17.6.4) must not push this column's line below an unrelated
+  // vertical band, so it is gated by `floatOverlapsColumnX` exactly as the
+  // square sweep in step 2 is — both wrap modes share one column-scope
+  // predicate. Within a column the object DOES overlap it still blocks the full
+  // width (topY is advanced to the band bottom, no side gap is computed), per
+  // "text must wrap around neither side of this object."
   //
   // ASSUMPTION (M3): step 1 runs ONCE, before the square sweep, and is not
   // re-checked after a square push in step 2. This relies on "no topAndBottom
   // float sits below a square float in the same column band." topAndBottom
-  // objects span the full content width (ECMA-376 §20.4.2.16) and are normally
-  // anchored above/below the square-wrapped region, so the square push in step 2
-  // lands in float-free space below the band. If a document ever places a
-  // topAndBottom strictly below a square the pushed line could clip into it; the
-  // spec-correct fix is to make steps 1+2 a single fixpoint loop. Left as a
-  // documented assumption here to preserve current behavior (no observed sample
+  // objects span the full column width where they sit (ECMA-376 §20.4.2.20) and
+  // are normally anchored above/below the square-wrapped region, so the square
+  // push in step 2 lands in float-free space below the band. If a document ever
+  // places a topAndBottom strictly below a square the pushed line could clip into
+  // it; the spec-correct fix is to make steps 1+2 a single fixpoint loop. Left as
+  // a documented assumption here to preserve current behavior (no observed sample
   // exercises the inverted ordering).
   for (let guard = 0; guard < 16; guard++) {
     const lineBot = topY + probeH;
     let skip: number | null = null;
     for (const f of floats) {
       if (f.mode !== 'topAndBottom') continue;
+      if (!floatOverlapsColumnX(f, paraXLeft, paraXRight)) continue;
       if (lineBot > f.yTop && topY < f.yBottom) {
         skip = skip === null ? f.yBottom : Math.max(skip, f.yBottom);
       }
@@ -247,8 +280,6 @@ export function resolveLineFloatWindow(
   }
 
   // 2. Horizontal constraint from square floats.
-  const paraXLeft = paraX;
-  const paraXRight = paraX + maxWidth;
   // A gap must be at least `requiredWidth` wide to host a line start. Every docx
   // caller passes Word's 1-inch rule already reduced by its rounding tolerance,
   // `wordMinLineStartPx(scale)` (= (WORD_MIN_LINE_START_PT − LINE_START_GAP_EPS_PT)
@@ -267,11 +298,9 @@ export function resolveLineFloatWindow(
       // §20.4.2.17 excludes text only where the square wrap rectangle overlaps
       // its line area. A page-scoped float in another newspaper column must not
       // turn this column's full width into a sub-inch "side gap" and push the
-      // line below an unrelated vertical band.
-      if (
-        f.xRight <= paraXLeft + FLOAT_OVERLAP_EPS ||
-        f.xLeft >= paraXRight - FLOAT_OVERLAP_EPS
-      ) continue;
+      // line below an unrelated vertical band. Same column-scope predicate as
+      // the topAndBottom sweep in step 1.
+      if (!floatOverlapsColumnX(f, paraXLeft, paraXRight)) continue;
       intersecting.push(f);
       switch (f.side) {
         // Text may sit only on the LEFT of the float ⇒ everything from the
@@ -409,12 +438,25 @@ export function resolveFloatOverlap(
   return { x, y };
 }
 
-/** If y is inside a topAndBottom float, return the float bottom; otherwise return y. */
-export function skipPastTopAndBottom(y: number, floats: FloatRect[]): number {
+/**
+ * If y is inside a topAndBottom float that horizontally overlaps the paragraph's
+ * column band [paraXLeft, paraXRight], return that float's bottom; otherwise
+ * return y. Mirrors `resolveLineFloatWindow` step 1: §20.4.2.20 excludes text
+ * only where THIS OBJECT is placed, so a float anchored in another newspaper
+ * column (§17.6.4) — the page float set is shared across columns — is filtered
+ * out via the shared `floatOverlapsColumnX` predicate.
+ */
+export function skipPastTopAndBottom(
+  y: number,
+  floats: FloatRect[],
+  paraXLeft: number,
+  paraXRight: number,
+): number {
   for (let guard = 0; guard < 16; guard++) {
     let next = y;
     for (const f of floats) {
       if (f.mode !== 'topAndBottom') continue;
+      if (!floatOverlapsColumnX(f, paraXLeft, paraXRight)) continue;
       if (y >= f.yTop && y < f.yBottom) next = Math.max(next, f.yBottom);
     }
     if (next === y) return y;

--- a/packages/docx/src/float-layout.ts
+++ b/packages/docx/src/float-layout.ts
@@ -240,6 +240,14 @@ export function resolveLineFloatWindow(
   paraX: number,
   maxWidth: number,
   floats: FloatRect[],
+  // The paragraph's RAW COLUMN band, distinct from the indented text band
+  // [paraX, paraX + maxWidth]. Step 1 (topAndBottom) gates by the COLUMN band —
+  // §20.4.2.20 blocks the FULL column where the object sits, including the
+  // paragraph's indent margins — while step 2 (square side-gap) keeps gating by
+  // the narrower indented text band (§20.4.2.17). Defaults to the indented band
+  // so a direct unit caller that has no separate column band stays correct.
+  columnXLeftPt: number = paraX,
+  columnXRightPt: number = paraX + maxWidth,
 ): { topY: number; xOffset: number; maxWidth: number } {
   const paraXLeft = paraX;
   const paraXRight = paraX + maxWidth;
@@ -249,11 +257,13 @@ export function resolveLineFloatWindow(
   // §20.4.2.20 (wrapTopAndBottom) excludes text only where THIS OBJECT is
   // horizontally placed. A page-scoped float anchored in another newspaper
   // column (§17.6.4) must not push this column's line below an unrelated
-  // vertical band, so it is gated by `floatOverlapsColumnX` exactly as the
-  // square sweep in step 2 is — both wrap modes share one column-scope
-  // predicate. Within a column the object DOES overlap it still blocks the full
-  // width (topY is advanced to the band bottom, no side gap is computed), per
-  // "text must wrap around neither side of this object."
+  // vertical band, so it is gated by `floatOverlapsColumnX` against the RAW
+  // COLUMN band — NOT the indented text band step 2 uses. §20.4.2.20 blocks the
+  // whole column where the object sits ("text must wrap around neither side of
+  // this object"), so a topAndBottom float in this column's indent margin still
+  // pushes an indented paragraph's lines below it even though it does not overlap
+  // the narrower indented band. Within a column the object DOES overlap it blocks
+  // the full width (topY is advanced to the band bottom, no side gap is computed).
   //
   // ASSUMPTION (M3): step 1 runs ONCE, before the square sweep, and is not
   // re-checked after a square push in step 2. This relies on "no topAndBottom
@@ -270,7 +280,7 @@ export function resolveLineFloatWindow(
     let skip: number | null = null;
     for (const f of floats) {
       if (f.mode !== 'topAndBottom') continue;
-      if (!floatOverlapsColumnX(f, paraXLeft, paraXRight)) continue;
+      if (!floatOverlapsColumnX(f, columnXLeftPt, columnXRightPt)) continue;
       if (lineBot > f.yTop && topY < f.yBottom) {
         skip = skip === null ? f.yBottom : Math.max(skip, f.yBottom);
       }
@@ -298,8 +308,10 @@ export function resolveLineFloatWindow(
       // §20.4.2.17 excludes text only where the square wrap rectangle overlaps
       // its line area. A page-scoped float in another newspaper column must not
       // turn this column's full width into a sub-inch "side gap" and push the
-      // line below an unrelated vertical band. Same column-scope predicate as
-      // the topAndBottom sweep in step 1.
+      // line below an unrelated vertical band. Unlike step 1 (which gates by the
+      // raw COLUMN band for a full-column block), the square side-gap math is
+      // relative to the actual text band, so it gates by the INDENTED band
+      // [paraXLeft, paraXRight].
       if (!floatOverlapsColumnX(f, paraXLeft, paraXRight)) continue;
       intersecting.push(f);
       switch (f.side) {

--- a/packages/docx/src/layout-lines-scale-invariance.test.ts
+++ b/packages/docx/src/layout-lines-scale-invariance.test.ts
@@ -253,6 +253,8 @@ describe('layoutLines scale-invariance (Phase 4-1 B2 Stage 1) — LINEAR font, t
     const mkWrap = (s: number): WrapLayoutCtx => ({
       startPageY: 0 * s,
       paraX: 0 * s,
+      columnXPt: 0 * s,
+      columnWidthPt: 120 * s,
       floats: [{
         mode: 'square', side: 'bothSides',
         xLeft: 0 * s, xRight: 30 * s, yTop: 0 * s, yBottom: 24 * s,

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -274,7 +274,14 @@ export interface LayoutLine {
 /** Additional context passed to layoutLines so it can honor floats on the current page. */
 export interface WrapLayoutCtx {
   startPageY: number;   // absolute canvas Y where the first line should start
-  paraX: number;        // absolute canvas X of the paragraph's content left edge
+  paraX: number;        // absolute canvas X of the paragraph's INDENTED text left edge
+  /** Absolute canvas X of the paragraph's raw COLUMN left edge. Distinct from
+   *  `paraX` when the paragraph has a left indent: the topAndBottom wrap gate
+   *  (§20.4.2.20 full-column block) is scoped to the COLUMN band, while the
+   *  square side-gap math (§20.4.2.17) is scoped to the indented `paraX` band. */
+  columnXPt: number;
+  /** Absolute px width of the paragraph's raw COLUMN band. See columnXPt. */
+  columnWidthPt: number;
   floats: FloatRect[];  // legacy float geometry supplied directly by renderer paths
   /** Placement-aware wrap boundary used by paragraph measurement. */
   lineWindow?: (input: {
@@ -283,6 +290,11 @@ export interface WrapLayoutCtx {
     probeHeightPt: number;
     paragraphXPt: number;
     maximumWidthPt: number;
+    /** The paragraph's raw COLUMN band, scoping the topAndBottom gate
+     *  (§20.4.2.20 / §17.6.4). Distinct from paragraphXPt/maximumWidthPt (the
+     *  indented text band the square side-gap math uses). */
+    columnXPt: number;
+    columnWidthPt: number;
   }) => {
     topYPt: number;
     xOffsetPt: number;
@@ -2119,6 +2131,8 @@ export function layoutLines(
         probeHeightPt: probeH,
         paragraphXPt: wrapCtx.paraX,
         maximumWidthPt: maxWidth,
+        columnXPt: wrapCtx.columnXPt,
+        columnWidthPt: wrapCtx.columnWidthPt,
       });
       currentLineTopY = win.topYPt;
       lineXOffset = win.xOffsetPt;
@@ -2126,6 +2140,7 @@ export function layoutLines(
     } else {
       const win = resolveLineFloatWindow(
         currentLineTopY, minWidth, probeH, wrapCtx.paraX, maxWidth, wrapCtx.floats,
+        wrapCtx.columnXPt, wrapCtx.columnXPt + wrapCtx.columnWidthPt,
       );
       currentLineTopY = win.topY;
       lineXOffset = win.xOffset;

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -308,7 +308,7 @@ describe('measureParagraph', () => {
       lineWindow: ({ topYPt, maximumWidthPt }) => topYPt < 50
         ? { topYPt, xOffsetPt: 10, maximumWidthPt: 20 }
         : { topYPt, xOffsetPt: 0, maximumWidthPt },
-      skipTopAndBottomBands: (yPt) => yPt,
+      skipTopAndBottomBands: ({ yPt }) => yPt,
     };
     const doc = paragraph({
       spaceBefore: 0,

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -303,6 +303,61 @@ describe('measureParagraph', () => {
     expect(result.lines[0].layout.segments[0]).toMatchObject({ text: '42' });
   });
 
+  it('hands the RAW column band (not the indented text band) to the wrap oracle', () => {
+    // §20.4.2.20 / §17.6.4: the topAndBottom gate must see the COLUMN band, so
+    // measure and paint scope a page-shared float to the same column. With a
+    // physical left indent the indented text band (paragraphXPt) differs from the
+    // column band (placement.paragraphXPt / availableWidthPt); both the one-time
+    // pre-paragraph skip AND the per-line window must be handed the column band.
+    const lineWindowColumns: Array<{
+      columnXPt: number;
+      columnWidthPt: number;
+      paragraphXPt: number;
+      maximumWidthPt: number;
+    }> = [];
+    const skipColumns: Array<{ columnXPt: number; columnWidthPt: number }> = [];
+    const wrap: WrapOracle = {
+      lineWindow: (input) => {
+        lineWindowColumns.push({
+          columnXPt: input.columnXPt,
+          columnWidthPt: input.columnWidthPt,
+          paragraphXPt: input.paragraphXPt,
+          maximumWidthPt: input.maximumWidthPt,
+        });
+        return { topYPt: input.topYPt, xOffsetPt: 0, maximumWidthPt: input.maximumWidthPt };
+      },
+      skipTopAndBottomBands: (input) => {
+        skipColumns.push({ columnXPt: input.columnXPt, columnWidthPt: input.columnWidthPt });
+        return input.yPt;
+      },
+    };
+
+    measureParagraph(
+      paragraph({ spaceBefore: 0, runs: [{ type: 'text', ...textRun('hello world') }] }),
+      layoutContext({ spaceBeforePt: 0, physicalIndentLeftPt: 100, physicalIndentRightPt: 0 }),
+      placement({ paragraphXPt: 60, availableWidthPt: 228, wrap }),
+      measurer,
+      environment(),
+    );
+
+    // Column band = placement (60, 228). Indented text band = 60 + 100 = 160,
+    // width 228 − 100 = 128. The oracle must be scoped to the COLUMN band.
+    expect(skipColumns.length).toBeGreaterThan(0);
+    for (const c of skipColumns) {
+      expect(c.columnXPt).toBe(60);
+      expect(c.columnWidthPt).toBe(228);
+    }
+    expect(lineWindowColumns.length).toBeGreaterThan(0);
+    for (const c of lineWindowColumns) {
+      expect(c.columnXPt).toBe(60);
+      expect(c.columnWidthPt).toBe(228);
+      // The indented text band handed alongside (for the square side-gap math) is
+      // distinct — this is exactly the seam the finding is about.
+      expect(c.paragraphXPt).toBe(160);
+      expect(c.maximumWidthPt).toBe(128);
+    }
+  });
+
   it('remeasures at a changed start Y and records the exact placement', () => {
     const wrap: WrapOracle = {
       lineWindow: ({ topYPt, maximumWidthPt }) => topYPt < 50

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -31,6 +31,11 @@ export interface WrapOracle {
     readonly probeHeightPt: number;
     readonly paragraphXPt: number;
     readonly maximumWidthPt: number;
+    /** The paragraph's COLUMN band, scoping the topAndBottom gate (§20.4.2.20 /
+     *  §17.6.4) to the column the float is anchored in — NOT the indented text
+     *  band `paragraphXPt`/`maximumWidthPt` the square side-gap math uses. */
+    readonly columnXPt: number;
+    readonly columnWidthPt: number;
   }): {
     readonly topYPt: number;
     readonly xOffsetPt: number;
@@ -58,6 +63,8 @@ export function createFloatWrapOracle(floats: readonly FloatRect[]): WrapOracle 
       probeHeightPt,
       paragraphXPt,
       maximumWidthPt,
+      columnXPt,
+      columnWidthPt,
     }) => {
       const window = resolveLineFloatWindow(
         topYPt,
@@ -66,6 +73,8 @@ export function createFloatWrapOracle(floats: readonly FloatRect[]): WrapOracle 
         paragraphXPt,
         maximumWidthPt,
         activeFloats,
+        columnXPt,
+        columnXPt + columnWidthPt,
       );
       return {
         topYPt: window.topY,
@@ -172,6 +181,10 @@ export function measureParagraph(
         probeHeightPt: 10,
         paragraphXPt,
         maximumWidthPt: paragraphWidthPt,
+        // §20.4.2.20 / §17.6.4 column scope: the topAndBottom gate sees the raw
+        // COLUMN band, not the indented mark band above.
+        columnXPt: placement.paragraphXPt,
+        columnWidthPt: placement.availableWidthPt,
       }).topYPt;
     }
     const markAdvancePt = paragraphMarkLineHeight(
@@ -202,6 +215,11 @@ export function measureParagraph(
     ? {
         startPageY: cursorPt,
         paraX: paragraphXPt,
+        // Raw COLUMN band (placement) for the topAndBottom gate; paraX above is
+        // the indented text band for the square side-gap math (§20.4.2.20 vs
+        // §20.4.2.17). See WrapLayoutCtx.columnXPt.
+        columnXPt: placement.paragraphXPt,
+        columnWidthPt: placement.availableWidthPt,
         floats: [],
         lineWindow: (input) => placement.wrap!.lineWindow(input),
         lineBoxH: (ascent, descent, _hasRuby, intendedSingle) => lineBoxHeight(

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -36,7 +36,14 @@ export interface WrapOracle {
     readonly xOffsetPt: number;
     readonly maximumWidthPt: number;
   };
-  skipTopAndBottomBands(yPt: number): number;
+  skipTopAndBottomBands(input: {
+    readonly yPt: number;
+    /** The paragraph's COLUMN band (colX()/colW()), used to scope a topAndBottom
+     *  float to the column it is anchored in (§20.4.2.20 / §17.6.4) — NOT the
+     *  indented text band `lineWindow` uses. */
+    readonly columnXPt: number;
+    readonly columnWidthPt: number;
+  }): number;
 }
 
 /** Adapt registered scale-1 float rectangles to the placement-aware paragraph
@@ -66,7 +73,8 @@ export function createFloatWrapOracle(floats: readonly FloatRect[]): WrapOracle 
         maximumWidthPt: window.maxWidth,
       };
     },
-    skipTopAndBottomBands: (yPt) => skipPastTopAndBottom(yPt, activeFloats),
+    skipTopAndBottomBands: ({ yPt, columnXPt, columnWidthPt }) =>
+      skipPastTopAndBottom(yPt, activeFloats, columnXPt, columnXPt + columnWidthPt),
   };
 }
 
@@ -142,7 +150,17 @@ export function measureParagraph(
   let cursorPt = placement.startYPt
     + (placement.suppressSpaceBefore ? 0 : requestedSpaceBeforePt);
   if (placement.wrap) {
-    cursorPt = placement.wrap.skipTopAndBottomBands(cursorPt);
+    // §20.4.2.20 / §17.6.4 column scope: pass this paragraph's COLUMN band
+    // (placement.paragraphXPt / availableWidthPt = colX()/colW()), NOT the
+    // indented text band, so measure agrees bit-for-bit with the paint pass,
+    // which scopes the same skip against state.contentX/contentW (the column
+    // band). A topAndBottom float anchored in another newspaper column is
+    // filtered out in both passes.
+    cursorPt = placement.wrap.skipTopAndBottomBands({
+      yPt: cursorPt,
+      columnXPt: placement.paragraphXPt,
+      columnWidthPt: placement.availableWidthPt,
+    });
   }
 
   const measureMarkOnly = (): MeasuredParagraph => {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6355,6 +6355,10 @@ function renderParagraph(
     const probeH = 10 * scale;
     const win = resolveLineFloatWindow(
       textAreaTopY, paragraphMarkEmPx(para, scale), probeH, paraX, paraW, state.floats,
+      // Raw COLUMN band for the topAndBottom gate (§20.4.2.20 / §17.6.4): an
+      // empty mark under a topAndBottom float in this column's indent margin
+      // still flows below it, matching the measure pass (measureMarkOnly).
+      contentX, contentX + contentW,
     );
     return win.topY;
   };
@@ -6372,6 +6376,13 @@ function renderParagraph(
   const wrapCtx: WrapLayoutCtx | undefined = state.floats.length > 0 ? {
     startPageY: state.y,
     paraX,
+    // Raw COLUMN band for the topAndBottom gate (§20.4.2.20 / §17.6.4). `paraX`
+    // above is the indented text band; the two diverge under a left indent, and
+    // a topAndBottom float in this column's indent margin must still push text
+    // below it. state.contentX/contentW is this element's column band (set per
+    // column by the paint loop), matching the measure pass.
+    columnXPt: contentX,
+    columnWidthPt: contentW,
     floats: state.floats,
     lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, scale, grid, paraHasRuby, is ?? 0, paragraphContext.hasEastAsianText),
     pageH: state.pageH,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6283,8 +6283,13 @@ function renderParagraph(
   // behindDoc shapes must render before text so they appear behind it.
   renderAnchorImages(para, state, paragraphStartY, 'behind');
 
-  // If any topAndBottom float already extends past state.y, skip past it before text starts.
-  state.y = skipPastTopAndBottom(state.y, state.floats);
+  // If any topAndBottom float already extends past state.y, skip past it before
+  // text starts. Scoped to this paragraph's column band (§20.4.2.20 / §17.6.4):
+  // a topAndBottom float anchored in another newspaper column must not push this
+  // column's text down — state.floats is page-scoped across columns, and
+  // state.contentX/contentW is this element's column band (set per column by the
+  // paint loop).
+  state.y = skipPastTopAndBottom(state.y, state.floats, contentX, contentX + contentW);
 
   const textAreaTopY = state.y;
 

--- a/packages/docx/src/topandbottom-column-scope.test.ts
+++ b/packages/docx/src/topandbottom-column-scope.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveLineFloatWindow,
+  skipPastTopAndBottom,
+  wordMinLineStartPx,
+  type FloatRect,
+} from './float-layout.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A `wrapTopAndBottom` float (ECMA-376 §20.4.2.20, = §20.4.2.16 in the 1st
+// edition) must affect text ONLY where the object is horizontally placed.
+//
+// GROUND TRUTH (spec):
+//   §20.4.2.20 wrapTopAndBottom: "This element specifies that text shall wrap
+//   around the top and bottom of THIS OBJECT, but not its left or right edges."
+//   The exclusion is relative to the object's own extent; distT/distB are "the
+//   minimum distance … between the [top/bottom] edge of THIS drawing object and
+//   any subsequent text." Within a band the object overlaps, "text must wrap
+//   around neither side of this object" — i.e. it blocks the FULL column width
+//   (no side-by-side text).
+//   §17.6.4 cols: a section's columns are distinct text regions of defined
+//   width. Text laid out in a newspaper column the object does NOT horizontally
+//   overlap is a separate flow region and must be unaffected.
+//
+// Floats are registered in ABSOLUTE page coordinates and `state.floats` is
+// page-scoped (shared across columns — see measure-column-geometry.test.ts). The
+// square-wrap path (§20.4.2.17) already gates on horizontal overlap so a float
+// in one column does not reshape another column's line (float-line-start-one-
+// inch.test.ts "ignores square wrap rectangles wholly outside … the column").
+// topAndBottom must share that horizontal-overlap semantics: a topAndBottom
+// float anchored in column 1 must NOT push down a line laid out in column 2.
+//
+// A 2-column page modeled at scale 1 (px == pt), mirroring
+// measure-column-geometry.test.ts:
+//   content band [60, 540]; col 0 = [60, 288] (w=228), col 1 = [312, 540] (w=228).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const COL0 = { xLeft: 60, xRight: 288, width: 228 };
+const COL1 = { xLeft: 312, xRight: 540, width: 228 };
+
+/** A topAndBottom exclusion band (no dist padding) over an absolute rectangle. */
+function topAndBottomBand(r: {
+  xLeft: number;
+  xRight: number;
+  yTop: number;
+  yBottom: number;
+}): FloatRect {
+  return {
+    kind: 'shape',
+    mode: 'topAndBottom',
+    imageKey: 'x',
+    imageX: r.xLeft,
+    imageY: r.yTop,
+    imageW: r.xRight - r.xLeft,
+    imageH: r.yBottom - r.yTop,
+    xLeft: r.xLeft,
+    xRight: r.xRight,
+    yTop: r.yTop,
+    yBottom: r.yBottom,
+    side: 'bothSides',
+    distLeft: 0,
+    distRight: 0,
+    distTop: 0,
+    distBottom: 0,
+    paraId: 1,
+    drawn: false,
+  } as FloatRect;
+}
+
+// A line whose vertical range [120, 130] falls inside the float band [100, 200].
+const LINE_TOP = 120;
+const PROBE_H = 10;
+
+/** resolveLineFloatWindow topY for a line laid out in the given column band. */
+function windowTopY(col: { xLeft: number; width: number }, floats: FloatRect[]): number {
+  return resolveLineFloatWindow(
+    LINE_TOP,
+    wordMinLineStartPx(1),
+    PROBE_H,
+    col.xLeft,
+    col.width,
+    floats,
+  ).topY;
+}
+
+describe('resolveLineFloatWindow — topAndBottom float column scope (§20.4.2.20 / §17.6.4)', () => {
+  const floatInCol0 = topAndBottomBand({
+    xLeft: COL0.xLeft,
+    xRight: COL0.xRight,
+    yTop: 100,
+    yBottom: 200,
+  });
+
+  it('does NOT push a line in the non-overlapped column (column 2 unaffected)', () => {
+    // The float is wholly inside column 1's horizontal band; a column-2 line at
+    // the same vertical range does not intersect the object horizontally, so per
+    // §20.4.2.20 it is not "this object's" top/bottom and must stay put.
+    expect(windowTopY(COL1, [floatInCol0])).toBe(LINE_TOP);
+  });
+
+  it('DOES push a line in the overlapped column below the band (column 1 blocked)', () => {
+    // Same object, a line in its own column: pushed to the band bottom.
+    expect(windowTopY(COL0, [floatInCol0])).toBe(200);
+  });
+
+  it('blocks the FULL column width even when the float is narrower than the column', () => {
+    // §20.4.2.20 "text must wrap around neither side of this object": a narrow
+    // topAndBottom float that overlaps only part of column 1 still pushes the
+    // whole column-1 line below it (no side-by-side text), and still leaves
+    // column 2 untouched.
+    const narrow = topAndBottomBand({ xLeft: COL0.xLeft, xRight: 150, yTop: 100, yBottom: 200 });
+    expect(windowTopY(COL0, [narrow])).toBe(200);
+    expect(windowTopY(COL1, [narrow])).toBe(LINE_TOP);
+  });
+
+  it('a float straddling BOTH columns pushes lines in both', () => {
+    const straddle = topAndBottomBand({ xLeft: 200, xRight: 400, yTop: 100, yBottom: 200 });
+    expect(windowTopY(COL0, [straddle])).toBe(200);
+    expect(windowTopY(COL1, [straddle])).toBe(200);
+  });
+
+  it('single full-width column: a full-band topAndBottom float still pushes (unchanged)', () => {
+    const single = { xLeft: 60, width: 480 };
+    const fullBand = topAndBottomBand({ xLeft: 60, xRight: 540, yTop: 100, yBottom: 200 });
+    expect(windowTopY(single, [fullBand])).toBe(200);
+  });
+});
+
+describe('skipPastTopAndBottom — topAndBottom float column scope (§20.4.2.20 / §17.6.4)', () => {
+  const floatInCol0 = topAndBottomBand({
+    xLeft: COL0.xLeft,
+    xRight: COL0.xRight,
+    yTop: 100,
+    yBottom: 200,
+  });
+
+  it('does NOT skip a cursor in the non-overlapped column (column 2 unaffected)', () => {
+    expect(skipPastTopAndBottom(LINE_TOP, [floatInCol0], COL1.xLeft, COL1.xRight)).toBe(LINE_TOP);
+  });
+
+  it('DOES skip a cursor in the overlapped column past the band', () => {
+    expect(skipPastTopAndBottom(LINE_TOP, [floatInCol0], COL0.xLeft, COL0.xRight)).toBe(200);
+  });
+
+  it('a float straddling both columns skips a cursor in either column', () => {
+    const straddle = topAndBottomBand({ xLeft: 200, xRight: 400, yTop: 100, yBottom: 200 });
+    expect(skipPastTopAndBottom(LINE_TOP, [straddle], COL0.xLeft, COL0.xRight)).toBe(200);
+    expect(skipPastTopAndBottom(LINE_TOP, [straddle], COL1.xLeft, COL1.xRight)).toBe(200);
+  });
+
+  it('single full-width column: a full-band float still skips (unchanged)', () => {
+    const fullBand = topAndBottomBand({ xLeft: 60, xRight: 540, yTop: 100, yBottom: 200 });
+    expect(skipPastTopAndBottom(LINE_TOP, [fullBand], 60, 540)).toBe(200);
+  });
+});

--- a/packages/docx/src/topandbottom-column-scope.test.ts
+++ b/packages/docx/src/topandbottom-column-scope.test.ts
@@ -126,6 +126,90 @@ describe('resolveLineFloatWindow — topAndBottom float column scope (§20.4.2.2
   });
 });
 
+describe('resolveLineFloatWindow — topAndBottom gate uses the COLUMN band, not the indented text band', () => {
+  // An indented paragraph's text band starts INSIDE its column (indentLeft > 0).
+  // Step 1 (topAndBottom, §20.4.2.20 "text must wrap around neither side of this
+  // object" — a full-COLUMN block) must be gated by the raw COLUMN band, while
+  // step 2 (square side-gap, §20.4.2.17) keeps gating by the narrower indented
+  // text band. A topAndBottom float sitting in the column's LEFT indent margin
+  // (inside the column, left of the indented text) therefore still pushes the
+  // paragraph's lines below it even though it does not overlap the indented band.
+  const COLUMN = { xLeft: 60, xRight: 288 };
+  const INDENT_LEFT = 160; // indentLeft = 100 within the column band [60, 288]
+  const INDENT_WIDTH = 128; // indented text band [160, 288]
+  // [60, 140] ⊂ column band, ∩ indented text band = ∅ (140 < 160).
+  const floatInIndentMargin = topAndBottomBand({
+    xLeft: 60,
+    xRight: 140,
+    yTop: 100,
+    yBottom: 200,
+  });
+
+  it('pushes an indented line below a topAndBottom float in the column indent margin', () => {
+    // Reviewer repro: line at y=95 (band [100,200]); column band [60,288] passed
+    // as columnXLeft/columnXRight, indented band [160,288] as paraX/maxWidth.
+    const topY = resolveLineFloatWindow(
+      95,
+      0,
+      PROBE_H,
+      INDENT_LEFT,
+      INDENT_WIDTH,
+      [floatInIndentMargin],
+      COLUMN.xLeft,
+      COLUMN.xRight,
+    ).topY;
+    expect(topY).toBe(200);
+  });
+
+  it('leaves the line put when no column band is supplied (defaults to the indented band)', () => {
+    // Safe default for direct unit callers: without a column band the float —
+    // outside the indented band — is not seen by step 1, so nothing is pushed.
+    const topY = resolveLineFloatWindow(
+      95,
+      0,
+      PROBE_H,
+      INDENT_LEFT,
+      INDENT_WIDTH,
+      [floatInIndentMargin],
+    ).topY;
+    expect(topY).toBe(95);
+  });
+});
+
+describe('resolveLineFloatWindow — topAndBottom float in the inter-column gutter pushes neither column', () => {
+  // Content band [60, 540]; col 0 = [60, 288], col 1 = [312, 540]; gutter
+  // (288, 312). A float wholly inside the gutter overlaps neither column.
+  const gutterFloat = topAndBottomBand({ xLeft: 292, xRight: 308, yTop: 100, yBottom: 200 });
+
+  it('does not push a line in column 0', () => {
+    const topY = resolveLineFloatWindow(
+      LINE_TOP,
+      wordMinLineStartPx(1),
+      PROBE_H,
+      COL0.xLeft,
+      COL0.width,
+      [gutterFloat],
+      COL0.xLeft,
+      COL0.xRight,
+    ).topY;
+    expect(topY).toBe(LINE_TOP);
+  });
+
+  it('does not push a line in column 1', () => {
+    const topY = resolveLineFloatWindow(
+      LINE_TOP,
+      wordMinLineStartPx(1),
+      PROBE_H,
+      COL1.xLeft,
+      COL1.width,
+      [gutterFloat],
+      COL1.xLeft,
+      COL1.xRight,
+    ).topY;
+    expect(topY).toBe(LINE_TOP);
+  });
+});
+
 describe('skipPastTopAndBottom — topAndBottom float column scope (§20.4.2.20 / §17.6.4)', () => {
   const floatInCol0 = topAndBottomBand({
     xLeft: COL0.xLeft,


### PR DESCRIPTION
## Problem

A `wrapTopAndBottom` (ECMA-376 §20.4.2.20) floating object anchored in one newspaper column (§17.6.4) displaced lines in OTHER columns — the wrap check used vertical intersection only. The sibling square-wrap defect (§20.4.2.17) was fixed earlier; this closes the explicitly-deferred topAndBottom side.

## Fix

One shared horizontal-overlap predicate (`floatOverlapsColumnX`) for both wrap modes. The per-line topAndBottom gate uses the RAW column band (full-column blocking within an overlapped column — no side text) while square side-gap math keeps the indented text band. Measurement and paint pass identical column scope (oracle: placement paragraphX/availableWidth; paint: content box).

## Review hardening

An independent review caught that the first cut gated per-line checks by the indented paragraph band, regressing indented paragraphs against floats in the column's indent margin — fixed and pinned (reviewer's repro is now a test).

## Verification

- `pnpm test` (full workspace): 359 files passed / 1 skipped, 3451 tests passed / 3 skipped
- `pnpm typecheck` (root + markdown/node/vscode-extension): clean
- `pnpm lint` / `pnpm lint:test`: clean (0 new findings; 4/4 ast-grep rule tests pass)
- docx package: 993 tests incl. 14 new wrap-scoping cases
- Local VRT (`pnpm --filter @silurus/ooxml-docx vrt`, freshly rebuilt WASM): 70 passed / 17 failed, byte-identical raw pixel-diff counts against the pre-existing baseline for every one of the 17 pre-existing failures — zero regressions, zero new failures, zero disappeared failures. References untouched.

## Attribution

Implemented by Claude (Opus 4.8, Sonnet 5, Fable 5); per-commit trailers carry exact models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
