### PR TITLE
test(docx): add multi-column float sample to pixel VRT

### DIFF
--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -9,6 +9,11 @@ const DOCX_FILES: { name: string; pageCount: number; width: number }[] = [
   { name: 'private/sample-3', pageCount: 3, width: 595 },
   { name: 'private/sample-4', pageCount: 1, width: 595 },
   { name: 'private/sample-5', pageCount: 7, width: 595 },
+  // Multi-column (§17.6.4) section carrying both wrapTopAndBottom (§20.4.2.20,
+  // anchored in the single-column title area) and column-anchored wrapSquare
+  // floats — pixel coverage for the float column-scope semantics (#907).
+  // Reference is private (gitignored) and generated locally with UPDATE_REFS=1.
+  { name: 'private/sample-10', pageCount: 2, width: 595 },
   // CH13 chart coverage: sample-24 p.3 carries a stockChart (hi-lo-close);
   // sample-25 is a pie3DChart. References are private (gitignored) and generated
   // locally with UPDATE_REFS=1 — they are never committed.


### PR DESCRIPTION
## Summary
- Wires `private/sample-10` into the DOCX pixel-VRT array (`DOCX_FILES` in `packages/docx/tests/visual/visual.spec.ts`).
- The fixture is a multi-column (§17.6.4) section carrying both a `wrapTopAndBottom` float (§20.4.2.20, anchored in the single-column title area) and column-anchored `wrapSquare` floats, adding pixel coverage for the float column-scope semantics shipped in #907.
- References for this sample are local-only (`private/`, gitignored) and were generated from the current renderer with explicit user approval via `UPDATE_REFS=1`. No fixture content is included in this PR — only the test-array entry and an explanatory comment.

## Notes
- This is test-infrastructure only; no renderer/parser code changes.
- Pixel VRT is local-only and does not run in CI (private samples can't be redistributed), so this change is CI-neutral — no CI job exercises it.

## Test plan
- [x] `npx playwright test --config playwright.config.ts -g "sample-10"` from `packages/docx/` — 2/2 passed, 100.0% pixel match on both pages, against local references.
- [x] `tsc --noEmit -p packages/docx/tsconfig.json` clean.
- [x] `git diff --check` clean (no whitespace errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)