### PR TITLE
feat(docx): render decimalEnclosedCircle and aiueo(FullWidth) list numbering

### DIFF
--- a/packages/core/src/text/number-format.test.ts
+++ b/packages/core/src/text/number-format.test.ts
@@ -245,13 +245,11 @@ describe('formatOrdinalNumber — ECMA-376 §17.18.59 ST_NumberFormat', () => {
 
       // ── Enclosed / CJK sequence formats ─────────────────────────────────
       // decimalEnclosedCircle: §17.18.59 tables 1–20 → U+2460–U+2473 (①..⑳);
-      // Word continues the sequence with Unicode's enclosed-number blocks
-      // (21–35 → U+3251–U+325F ㉑..㉟, 36–50 → U+32B1–U+32BF ㊱..㊿) and only
-      // then falls back to decimal (51+). Boundaries 20/21, 35/36, 50/51.
+      // "for values greater than the size of the set, the items fall back to
+      // the decimal format" (spec example: …, ⑲, ⑳, 21, …). Boundary 20/21.
       ['decimalEnclosedCircle', [
         [1, '①'], [2, '②'], [3, '③'], [10, '⑩'],
-        [20, '⑳'], [21, '㉑'], [35, '㉟'], [36, '㊱'],
-        [50, '㊿'], [51, '51'], [100, '100'],
+        [20, '⑳'], [21, '21'], [100, '100'],
       ]],
       // aiueoFullWidth: §17.18.59 full-width katakana in a-i-u-e-o order. The
       // spec's ENUMERATED 48-code-point list includes the archaic ヰ/ヱ (so wo/n

--- a/packages/core/src/text/number-format.test.ts
+++ b/packages/core/src/text/number-format.test.ts
@@ -242,6 +242,32 @@ describe('formatOrdinalNumber — ECMA-376 §17.18.59 ST_NumberFormat', () => {
       ['decimalZero', [
         [1, '01'], [9, '09'], [10, '10'], [99, '99'], [100, '100'],
       ]],
+
+      // ── Enclosed / CJK sequence formats ─────────────────────────────────
+      // decimalEnclosedCircle: §17.18.59 tables 1–20 → U+2460–U+2473 (①..⑳);
+      // Word continues the sequence with Unicode's enclosed-number blocks
+      // (21–35 → U+3251–U+325F ㉑..㉟, 36–50 → U+32B1–U+32BF ㊱..㊿) and only
+      // then falls back to decimal (51+). Boundaries 20/21, 35/36, 50/51.
+      ['decimalEnclosedCircle', [
+        [1, '①'], [2, '②'], [3, '③'], [10, '⑩'],
+        [20, '⑳'], [21, '㉑'], [35, '㉟'], [36, '㊱'],
+        [50, '㊿'], [51, '51'], [100, '100'],
+      ]],
+      // aiueoFullWidth: §17.18.59 full-width katakana in a-i-u-e-o order. The
+      // spec's ENUMERATED 48-code-point list includes the archaic ヰ/ヱ (so wo/n
+      // land at 47/48); repeat scheme past 48. Field example: 1 \* AIUEO -> ア.
+      ['aiueoFullWidth', [
+        [1, 'ア'], [2, 'イ'], [5, 'オ'], [16, 'タ'],
+        [44, 'ワ'], [45, 'ヰ'], [46, 'ヱ'], [47, 'ヲ'],
+        [48, 'ン'], [49, 'アア'], [96, 'ンン'],
+        [97, 'アアア'],
+      ]],
+      // aiueo: §17.18.59 half-width katakana, positions 1–46 (U+FF71–U+FF9C,
+      // U+FF66 ｦ, U+FF9D ﾝ — no archaic forms). Spec example: ｱ, ｲ, …, ｦ, ﾝ, ｱｱ.
+      ['aiueo', [
+        [1, 'ｱ'], [5, 'ｵ'], [44, 'ﾜ'], [45, 'ｦ'],
+        [46, 'ﾝ'], [47, 'ｱｱ'], [92, 'ﾝﾝ'],
+      ]],
     ];
 
     for (const [fmt, rows] of cases) {

--- a/packages/core/src/text/number-format.ts
+++ b/packages/core/src/text/number-format.ts
@@ -243,7 +243,11 @@ function rangeChars(fromCp: number, toCp: number): string[] {
 // a copy/paste artifact from the half-width `aiueo` entry (which legitimately has
 // 46 because half-width forms of ヰ/ヱ do not exist); we follow the explicit
 // enumerated character list, which is the concrete normative data a consumer maps
-// "respectively". Only values ≥ 45 are affected by the choice.
+// "respectively". Only values ≥ 45 are affected by the choice. Katakana (not
+// hiragana) is also what Word emits: [MS-OE376] §2.1.580 note (b) records that
+// where the (1st-edition Part 4) standard said "hiragana characters", "Word uses
+// these numbering formats to specify sequences that will consist of Katakana
+// characters" — matching the 5th-edition code-point list implemented here.
 const KATAKANA_FULLWIDTH: readonly string[] = [
   '\u{30A2}', '\u{30A4}', '\u{30A6}', '\u{30A8}', '\u{30AA}', '\u{30AB}',
   '\u{30AD}', '\u{30AF}', '\u{30B1}', '\u{30B3}', '\u{30B5}', '\u{30B7}',
@@ -258,7 +262,8 @@ const KATAKANA_FULLWIDTH: readonly string[] = [
 // §17.18.59 aiueo "AIUEO Order Half-Width Katakana" — positions 1–46 =
 // U+FF71–U+FF9C (ｱ..ﾜ), then U+FF66 (ｦ wo), then U+FF9D (ﾝ n). No archaic ヰ/ヱ
 // (they have no half-width forms). Same repeat scheme; spec example ｱ, ｲ, …, ｦ,
-// ﾝ, ｱｱ confirms wo/n at 45/46 and the wrap at 47.
+// ﾝ, ｱｱ confirms wo/n at 45/46 and the wrap at 47. Katakana per [MS-OE376]
+// §2.1.580 note (b) — see KATAKANA_FULLWIDTH above.
 const KATAKANA_HALFWIDTH: readonly string[] = [
   ...rangeChars(0xff71, 0xff9c),
   '\u{FF66}',
@@ -266,21 +271,17 @@ const KATAKANA_HALFWIDTH: readonly string[] = [
 ];
 
 // §17.18.59 decimalEnclosedCircle "Decimal Numbers Enclosed in a Circle": the
-// spec tables ONLY 1–20 → U+2460–U+2473 (①..⑳) and says values past the set
-// "fall back to the decimal format". Word, however, continues the visual sequence
-// with Unicode's own enclosed-number blocks — 21–35 → U+3251–U+325F (㉑..㉟) and
-// 36–50 → U+32B1–U+32BF (㊱..㊿) — and only degrades to decimal at 51+. We
-// reproduce Word's behaviour: the ranges are contiguous in value and use
-// Unicode's dedicated "Circled Number Twenty One … Fifty" code points, so this is
-// a deterministic extension of the tabled 1–20, not a tuned heuristic. Caller
+// spec tables 1–20 → U+2460–U+2473 (①..⑳) and states that "for values greater
+// than the size of the set, the items fall back to the decimal format" (its
+// example: …, ⑲, ⑳, 21, …). Unicode does carry follow-on enclosed-number blocks
+// (㉑..㉟ U+3251–U+325F, ㊱..㊿ U+32B1–U+32BF), but neither §17.18.59 nor the
+// Word implementation notes ([MS-OE376] §2.1.580, which records this section's
+// sibling deviations in detail) documents Word continuing the circled sequence
+// past 20 — so we stay with the specified decimal fallback at 21+ until primary
+// evidence (real Word output or an implementation note) shows otherwise. Caller
 // guarantees n ≥ 1.
 function toEnclosedCircle(n: number): string {
-  let cp: number;
-  if (n <= 20) cp = 0x2460 + (n - 1);
-  else if (n <= 35) cp = 0x3251 + (n - 21);
-  else if (n <= 50) cp = 0x32b1 + (n - 36);
-  else return String(n); // 51+ : §17.18.59 decimal fallback.
-  return String.fromCodePoint(cp);
+  return n <= 20 ? String.fromCodePoint(0x2460 + (n - 1)) : String(n);
 }
 
 // ── Positional digit substitution ───────────────────────────────────────────

--- a/packages/core/src/text/number-format.ts
+++ b/packages/core/src/text/number-format.ts
@@ -70,6 +70,10 @@ export type NumberFormat =
   | 'ganada'
   | 'hindiVowels'
   | 'hindiConsonants'
+  // Enclosed decimals + katakana a-i-u-e-o sequences (§17.18.59).
+  | 'decimalEnclosedCircle'
+  | 'aiueoFullWidth'
+  | 'aiueo'
   // Hebrew (positional gematria / alphabet-with-ת-suffix — NOT the repeat scheme).
   | 'hebrew1'
   | 'hebrew2'
@@ -230,6 +234,55 @@ function rangeChars(fromCp: number, toCp: number): string[] {
   return out;
 }
 
+// §17.18.59 aiueoFullWidth "AIUEO Order Full-Width Katakana" — the full-width
+// katakana in the traditional a-i-u-e-o order, using the SAME repeat scheme as
+// the letter alphabets above (value maps into 1..N, repeated once per full N
+// subtracted). §17.18.59 ENUMERATES these 48 code points explicitly — note it
+// includes the archaic ヰ (U+30F0) and ヱ (U+30F1), so wo (ヲ) / n (ン) sit at
+// positions 47/48. The section's prose says "positions 1–46", but that count is
+// a copy/paste artifact from the half-width `aiueo` entry (which legitimately has
+// 46 because half-width forms of ヰ/ヱ do not exist); we follow the explicit
+// enumerated character list, which is the concrete normative data a consumer maps
+// "respectively". Only values ≥ 45 are affected by the choice.
+const KATAKANA_FULLWIDTH: readonly string[] = [
+  '\u{30A2}', '\u{30A4}', '\u{30A6}', '\u{30A8}', '\u{30AA}', '\u{30AB}',
+  '\u{30AD}', '\u{30AF}', '\u{30B1}', '\u{30B3}', '\u{30B5}', '\u{30B7}',
+  '\u{30B9}', '\u{30BB}', '\u{30BD}', '\u{30BF}', '\u{30C1}', '\u{30C4}',
+  '\u{30C6}', '\u{30C8}', '\u{30CA}', '\u{30CB}', '\u{30CC}', '\u{30CD}',
+  '\u{30CE}', '\u{30CF}', '\u{30D2}', '\u{30D5}', '\u{30D8}', '\u{30DB}',
+  '\u{30DE}', '\u{30DF}', '\u{30E0}', '\u{30E1}', '\u{30E2}', '\u{30E4}',
+  '\u{30E6}', '\u{30E8}', '\u{30E9}', '\u{30EA}', '\u{30EB}', '\u{30EC}',
+  '\u{30ED}', '\u{30EF}', '\u{30F0}', '\u{30F1}', '\u{30F2}', '\u{30F3}',
+];
+
+// §17.18.59 aiueo "AIUEO Order Half-Width Katakana" — positions 1–46 =
+// U+FF71–U+FF9C (ｱ..ﾜ), then U+FF66 (ｦ wo), then U+FF9D (ﾝ n). No archaic ヰ/ヱ
+// (they have no half-width forms). Same repeat scheme; spec example ｱ, ｲ, …, ｦ,
+// ﾝ, ｱｱ confirms wo/n at 45/46 and the wrap at 47.
+const KATAKANA_HALFWIDTH: readonly string[] = [
+  ...rangeChars(0xff71, 0xff9c),
+  '\u{FF66}',
+  '\u{FF9D}',
+];
+
+// §17.18.59 decimalEnclosedCircle "Decimal Numbers Enclosed in a Circle": the
+// spec tables ONLY 1–20 → U+2460–U+2473 (①..⑳) and says values past the set
+// "fall back to the decimal format". Word, however, continues the visual sequence
+// with Unicode's own enclosed-number blocks — 21–35 → U+3251–U+325F (㉑..㉟) and
+// 36–50 → U+32B1–U+32BF (㊱..㊿) — and only degrades to decimal at 51+. We
+// reproduce Word's behaviour: the ranges are contiguous in value and use
+// Unicode's dedicated "Circled Number Twenty One … Fifty" code points, so this is
+// a deterministic extension of the tabled 1–20, not a tuned heuristic. Caller
+// guarantees n ≥ 1.
+function toEnclosedCircle(n: number): string {
+  let cp: number;
+  if (n <= 20) cp = 0x2460 + (n - 1);
+  else if (n <= 35) cp = 0x3251 + (n - 21);
+  else if (n <= 50) cp = 0x32b1 + (n - 36);
+  else return String(n); // 51+ : §17.18.59 decimal fallback.
+  return String.fromCodePoint(cp);
+}
+
 // ── Positional digit substitution ───────────────────────────────────────────
 // §17.18.59 decimalFullWidth/thaiNumbers/hindiNumbers/ideographDigital/… : a
 // base-10 positional system with a fixed 10-glyph digit set (index 0 is the zero
@@ -331,6 +384,14 @@ export function formatOrdinalNumber(n: number, fmt: NumberFormat | undefined): s
       return n >= 1 ? repeatAlphabet(n, HINDI_VOWELS) : String(n);
     case 'hindiConsonants':
       return n >= 1 ? repeatAlphabet(n, HINDI_CONSONANTS) : String(n);
+    // Katakana a-i-u-e-o sequences (repeat scheme, like the letter alphabets).
+    case 'aiueoFullWidth':
+      return n >= 1 ? repeatAlphabet(n, KATAKANA_FULLWIDTH) : String(n);
+    case 'aiueo':
+      return n >= 1 ? repeatAlphabet(n, KATAKANA_HALFWIDTH) : String(n);
+    // Enclosed decimals (bounded set → decimal fallback past the range).
+    case 'decimalEnclosedCircle':
+      return n >= 1 ? toEnclosedCircle(n) : String(n);
     // Hebrew.
     case 'hebrew1':
       return n >= 1 ? toHebrewGematria(n) : String(n);

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -731,7 +731,10 @@ fn repeat_alphabet(n: u32, glyphs: &[&str]) -> String {
 // alphabets. §17.18.59 ENUMERATES these 48 code points (incl. the archaic ヰ
 // U+30F0 and ヱ U+30F1, so wo/n land at 47/48). The section's "positions 1–46"
 // prose is a copy/paste artifact from the half-width `aiueo` entry; we follow the
-// explicit enumerated character list. Mirrors TS `KATAKANA_FULLWIDTH`.
+// explicit enumerated character list. Katakana (not hiragana) is also what Word
+// emits: [MS-OE376] §2.1.580 note (b) records that where the (1st-edition Part 4)
+// standard said "hiragana characters", Word uses katakana — matching the
+// 5th-edition code-point list implemented here. Mirrors TS `KATAKANA_FULLWIDTH`.
 const KATAKANA_FULLWIDTH: &[&str] = &[
     "\u{30A2}", "\u{30A4}", "\u{30A6}", "\u{30A8}", "\u{30AA}", "\u{30AB}", "\u{30AD}", "\u{30AF}",
     "\u{30B1}", "\u{30B3}", "\u{30B5}", "\u{30B7}", "\u{30B9}", "\u{30BB}", "\u{30BD}", "\u{30BF}",
@@ -743,7 +746,8 @@ const KATAKANA_FULLWIDTH: &[&str] = &[
 
 // §17.18.59 aiueo "AIUEO Order Half-Width Katakana" — positions 1–46 =
 // U+FF71–U+FF9C (ｱ..ﾜ), then U+FF66 (ｦ), then U+FF9D (ﾝ). No archaic ヰ/ヱ (no
-// half-width forms). Mirrors TS `KATAKANA_HALFWIDTH`.
+// half-width forms). Katakana per [MS-OE376] §2.1.580 note (b) — see
+// `KATAKANA_FULLWIDTH` above. Mirrors TS `KATAKANA_HALFWIDTH`.
 const KATAKANA_HALFWIDTH: &[&str] = &[
     "\u{FF71}", "\u{FF72}", "\u{FF73}", "\u{FF74}", "\u{FF75}", "\u{FF76}", "\u{FF77}", "\u{FF78}",
     "\u{FF79}", "\u{FF7A}", "\u{FF7B}", "\u{FF7C}", "\u{FF7D}", "\u{FF7E}", "\u{FF7F}", "\u{FF80}",
@@ -753,23 +757,23 @@ const KATAKANA_HALFWIDTH: &[&str] = &[
     "\u{FF99}", "\u{FF9A}", "\u{FF9B}", "\u{FF9C}", "\u{FF66}", "\u{FF9D}",
 ];
 
-/// §17.18.59 decimalEnclosedCircle: the spec tables ONLY 1–20 → U+2460–U+2473
-/// (①..⑳) with a decimal fallback past the set, but Word continues the sequence
-/// with Unicode's enclosed-number blocks — 21–35 → U+3251–U+325F (㉑..㉟), 36–50 →
-/// U+32B1–U+32BF (㊱..㊿) — degrading to decimal only at 51+. Deterministic
-/// extension of the tabled range (Unicode's own code points, contiguous in
-/// value), not a tuned heuristic. Mirrors TS `toEnclosedCircle`. Caller guarantees
-/// n ≥ 1 (n = 0 is handled by the early return in `format_counter`).
+/// §17.18.59 decimalEnclosedCircle: the spec tables 1–20 → U+2460–U+2473 (①..⑳)
+/// and states that "for values greater than the size of the set, the items fall
+/// back to the decimal format" (its example: …, ⑲, ⑳, 21, …). Unicode does carry
+/// follow-on enclosed-number blocks (㉑..㉟ U+3251–U+325F, ㊱..㊿ U+32B1–U+32BF),
+/// but neither §17.18.59 nor the Word implementation notes ([MS-OE376] §2.1.580,
+/// which records this section's sibling deviations in detail) documents Word
+/// continuing the circled sequence past 20 — so we stay with the specified
+/// decimal fallback at 21+ until primary evidence (real Word output or an
+/// implementation note) shows otherwise. Mirrors TS `toEnclosedCircle`. Caller
+/// guarantees n ≥ 1 (n = 0 is handled by the early return in `format_counter`).
 fn to_enclosed_circle(n: u32) -> String {
-    let cp = match n {
-        1..=20 => 0x2460 + (n - 1),
-        21..=35 => 0x3251 + (n - 21),
-        36..=50 => 0x32B1 + (n - 36),
-        _ => return n.to_string(), // 51+ : §17.18.59 decimal fallback.
-    };
-    char::from_u32(cp)
-        .map(String::from)
-        .unwrap_or_else(|| n.to_string())
+    match n {
+        1..=20 => char::from_u32(0x2460 + (n - 1))
+            .map(String::from)
+            .unwrap_or_else(|| n.to_string()),
+        _ => n.to_string(), // 21+ : §17.18.59 decimal fallback.
+    }
 }
 
 // Positional digit sets, index 0 = zero glyph … index 9 (§17.18.59).
@@ -1429,20 +1433,11 @@ mod tests {
                 &[(1, "01"), (9, "09"), (10, "10"), (100, "100")],
             ),
             // Enclosed decimals + katakana a-i-u-e-o sequences (§17.18.59).
-            // decimalEnclosedCircle: boundaries 20/21, 35/36, 50/51 (Word extends
-            // the tabled 1–20 through U+3251–U+325F and U+32B1–U+32BF, then decimal).
+            // decimalEnclosedCircle: 1–20 tabled (①..⑳); 21+ falls back to
+            // decimal per the spec example "…, ⑲, ⑳, 21, …". Boundary 20/21.
             (
                 "decimalEnclosedCircle",
-                &[
-                    (1, "①"),
-                    (20, "⑳"),
-                    (21, "㉑"),
-                    (35, "㉟"),
-                    (36, "㊱"),
-                    (50, "㊿"),
-                    (51, "51"),
-                    (100, "100"),
-                ],
+                &[(1, "①"), (20, "⑳"), (21, "21"), (100, "100")],
             ),
             // aiueoFullWidth: 48-entry enumerated set incl. archaic ヰ/ヱ, so wo/n
             // sit at 47/48; repeat past 48.

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -565,6 +565,11 @@ fn format_counter(n: u32, format: &str) -> String {
         "ganada" => repeat_alphabet(n, KOREAN_GANADA),
         "hindiVowels" => repeat_alphabet(n, HINDI_VOWELS),
         "hindiConsonants" => repeat_alphabet(n, HINDI_CONSONANTS),
+        // Katakana a-i-u-e-o sequences (repeat scheme, like the letter alphabets).
+        "aiueoFullWidth" => repeat_alphabet(n, KATAKANA_FULLWIDTH),
+        "aiueo" => repeat_alphabet(n, KATAKANA_HALFWIDTH),
+        // Enclosed decimals (bounded set → decimal fallback past the range).
+        "decimalEnclosedCircle" => to_enclosed_circle(n),
         // Hebrew: positional gematria / alphabet-with-ת-suffix (NOT repeat).
         "hebrew1" => to_hebrew_gematria(n),
         "hebrew2" => to_hebrew2(n),
@@ -719,6 +724,52 @@ fn repeat_alphabet(n: u32, glyphs: &[&str]) -> String {
     let repeats = (n - 1) / size + 1;
     let glyph = glyphs[((n - 1) % size) as usize];
     glyph.repeat(repeats as usize)
+}
+
+// §17.18.59 aiueoFullWidth "AIUEO Order Full-Width Katakana" — the full-width
+// katakana in a-i-u-e-o order, using the SAME repeat scheme as the letter
+// alphabets. §17.18.59 ENUMERATES these 48 code points (incl. the archaic ヰ
+// U+30F0 and ヱ U+30F1, so wo/n land at 47/48). The section's "positions 1–46"
+// prose is a copy/paste artifact from the half-width `aiueo` entry; we follow the
+// explicit enumerated character list. Mirrors TS `KATAKANA_FULLWIDTH`.
+const KATAKANA_FULLWIDTH: &[&str] = &[
+    "\u{30A2}", "\u{30A4}", "\u{30A6}", "\u{30A8}", "\u{30AA}", "\u{30AB}", "\u{30AD}", "\u{30AF}",
+    "\u{30B1}", "\u{30B3}", "\u{30B5}", "\u{30B7}", "\u{30B9}", "\u{30BB}", "\u{30BD}", "\u{30BF}",
+    "\u{30C1}", "\u{30C4}", "\u{30C6}", "\u{30C8}", "\u{30CA}", "\u{30CB}", "\u{30CC}", "\u{30CD}",
+    "\u{30CE}", "\u{30CF}", "\u{30D2}", "\u{30D5}", "\u{30D8}", "\u{30DB}", "\u{30DE}", "\u{30DF}",
+    "\u{30E0}", "\u{30E1}", "\u{30E2}", "\u{30E4}", "\u{30E6}", "\u{30E8}", "\u{30E9}", "\u{30EA}",
+    "\u{30EB}", "\u{30EC}", "\u{30ED}", "\u{30EF}", "\u{30F0}", "\u{30F1}", "\u{30F2}", "\u{30F3}",
+];
+
+// §17.18.59 aiueo "AIUEO Order Half-Width Katakana" — positions 1–46 =
+// U+FF71–U+FF9C (ｱ..ﾜ), then U+FF66 (ｦ), then U+FF9D (ﾝ). No archaic ヰ/ヱ (no
+// half-width forms). Mirrors TS `KATAKANA_HALFWIDTH`.
+const KATAKANA_HALFWIDTH: &[&str] = &[
+    "\u{FF71}", "\u{FF72}", "\u{FF73}", "\u{FF74}", "\u{FF75}", "\u{FF76}", "\u{FF77}", "\u{FF78}",
+    "\u{FF79}", "\u{FF7A}", "\u{FF7B}", "\u{FF7C}", "\u{FF7D}", "\u{FF7E}", "\u{FF7F}", "\u{FF80}",
+    "\u{FF81}", "\u{FF82}", "\u{FF83}", "\u{FF84}", "\u{FF85}", "\u{FF86}", "\u{FF87}", "\u{FF88}",
+    "\u{FF89}", "\u{FF8A}", "\u{FF8B}", "\u{FF8C}", "\u{FF8D}", "\u{FF8E}", "\u{FF8F}", "\u{FF90}",
+    "\u{FF91}", "\u{FF92}", "\u{FF93}", "\u{FF94}", "\u{FF95}", "\u{FF96}", "\u{FF97}", "\u{FF98}",
+    "\u{FF99}", "\u{FF9A}", "\u{FF9B}", "\u{FF9C}", "\u{FF66}", "\u{FF9D}",
+];
+
+/// §17.18.59 decimalEnclosedCircle: the spec tables ONLY 1–20 → U+2460–U+2473
+/// (①..⑳) with a decimal fallback past the set, but Word continues the sequence
+/// with Unicode's enclosed-number blocks — 21–35 → U+3251–U+325F (㉑..㉟), 36–50 →
+/// U+32B1–U+32BF (㊱..㊿) — degrading to decimal only at 51+. Deterministic
+/// extension of the tabled range (Unicode's own code points, contiguous in
+/// value), not a tuned heuristic. Mirrors TS `toEnclosedCircle`. Caller guarantees
+/// n ≥ 1 (n = 0 is handled by the early return in `format_counter`).
+fn to_enclosed_circle(n: u32) -> String {
+    let cp = match n {
+        1..=20 => 0x2460 + (n - 1),
+        21..=35 => 0x3251 + (n - 21),
+        36..=50 => 0x32B1 + (n - 36),
+        _ => return n.to_string(), // 51+ : §17.18.59 decimal fallback.
+    };
+    char::from_u32(cp)
+        .map(String::from)
+        .unwrap_or_else(|| n.to_string())
 }
 
 // Positional digit sets, index 0 = zero glyph … index 9 (§17.18.59).
@@ -1376,6 +1427,43 @@ mod tests {
             (
                 "decimalZero",
                 &[(1, "01"), (9, "09"), (10, "10"), (100, "100")],
+            ),
+            // Enclosed decimals + katakana a-i-u-e-o sequences (§17.18.59).
+            // decimalEnclosedCircle: boundaries 20/21, 35/36, 50/51 (Word extends
+            // the tabled 1–20 through U+3251–U+325F and U+32B1–U+32BF, then decimal).
+            (
+                "decimalEnclosedCircle",
+                &[
+                    (1, "①"),
+                    (20, "⑳"),
+                    (21, "㉑"),
+                    (35, "㉟"),
+                    (36, "㊱"),
+                    (50, "㊿"),
+                    (51, "51"),
+                    (100, "100"),
+                ],
+            ),
+            // aiueoFullWidth: 48-entry enumerated set incl. archaic ヰ/ヱ, so wo/n
+            // sit at 47/48; repeat past 48.
+            (
+                "aiueoFullWidth",
+                &[
+                    (1, "ア"),
+                    (44, "ワ"),
+                    (45, "ヰ"),
+                    (46, "ヱ"),
+                    (47, "ヲ"),
+                    (48, "ン"),
+                    (49, "アア"),
+                    (97, "アアア"),
+                ],
+            ),
+            // aiueo: half-width katakana, 46-entry set (no archaic forms), wo/n at
+            // 45/46; repeat past 46.
+            (
+                "aiueo",
+                &[(1, "ｱ"), (44, "ﾜ"), (45, "ｦ"), (46, "ﾝ"), (47, "ｱｱ")],
             ),
             // Documented residual / spell-outs fall back to decimal.
             ("cardinalText", &[(5, "5")]),


### PR DESCRIPTION
## Summary

Implements three previously-unrendered ECMA-376 **§17.18.59 `ST_NumberFormat`** list-marker systems in the shared numbering kernel. Numbered lists that use these formats previously degraded to the decimal fallback (`1.`, `2.`, …); they now render their intended glyphs.

- **`decimalEnclosedCircle`** (①②③…) — §17.18.59 tables 1–20 → `U+2460–U+2473` (①..⑳) and states that "for values greater than the size of the set, the items fall back to the decimal format" (spec example: …, ⑲, ⑳, 21, 22, …). Implemented exactly as specified: 1–20 circled, decimal at 21+. Unicode carries follow-on enclosed-number blocks (㉑..㉟ `U+3251–U+325F`, ㊱..㊿ `U+32B1–U+32BF`), but neither §17.18.59 nor the Word implementation notes ([MS-OE376] §2.1.580, which records this section's sibling deviations in detail) documents Word continuing the circled sequence past 20 — that possible extension is recorded in a code comment, gated on primary evidence (real Word output or an implementation note). The 20/21 boundary is pinned by tests.
- **`aiueoFullWidth`** — full-width katakana in a-i-u-e-o order (repeat scheme). §17.18.59 **enumerates 48 code points**, including the archaic ヰ (`U+30F0`) and ヱ (`U+30F1`); the section's "positions 1–46" prose is a copy/paste artifact from the half-width entry, so wo/n land at 47/48. The explicit enumerated character list is followed, and the discrepancy is documented in a code comment. Katakana (not hiragana) is corroborated by [MS-OE376] §2.1.580 note (b): where the 1st-edition Part 4 wording said "hiragana characters", Word uses katakana — matching the 5th-edition code-point list implemented here.
- **`aiueo`** — half-width katakana (`U+FF71–U+FF9C`, `U+FF66`, `U+FF9D`), 46 glyphs (no archaic forms). Added as the trivial parallel.

## Twin-implementation discipline

List markers resolve to a final string at **parse time** (the `%1.%2` composition happens in Rust), so the numbering kernel is duplicated and the two copies MUST stay byte-identical, per the mutual-mirror contract documented in both files' headers:

- TS (reference values): `packages/core/src/text/number-format.ts` — `formatOrdinalNumber` + `NumberFormat` union.
- Rust: `packages/docx/parser/src/numbering.rs` — `format_counter`.

Both sides use `\u{…}` code-point escapes for the katakana tables to avoid glyph-transcription drift.

## Review history

An independent review flagged the initial revision's extension of `decimalEnclosedCircle` through 21–50 via Unicode's enclosed-number blocks. Adjudicated against [MS-OE376] §2.1.580 (which lists this section's Word deviations exhaustively and has no note for this format): withdrawn in the follow-up commit in favor of the spec's decimal fallback at 21+, per the repository's spec-first policy.

## Verification

- `npx vitest run packages/core/src/text` — **509 pass** (new table-driven rows incl. the 20/21 boundary + zero/negative fallback).
- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test` (docx parser) — **310 pass**.
- `pnpm typecheck` — clean.
- WASM rebuilt; a parse-only Node probe over a Word-authored document using `decimalEnclosedCircle` confirmed its two lists render **①..⑪** and **①..③** end-to-end (Rust `format_counter` → JSON → TS model), where the decimal fallback previously produced `1..11` / `1..3`. The throwaway probe was removed after the run.

## Out of scope

- The pptx `circleNum*` autonumbering path is a separate follow-up.
- `decimalEnclosedCircleChinese` / `ideographEnclosedCircle` (spec: "Identical to decimalEnclosedCircle" / ideograph variant — though [MS-OE376] §2.1.580 note (c) records Word rendering the latter in parentheses) are follow-ups, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
