### PR TITLE
fix(docx): include run charSpacing and charScale in paint-scale segment advance

### DIFF
--- a/packages/docx/src/charspacing-advance.test.ts
+++ b/packages/docx/src/charspacing-advance.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import {
+  layoutLines,
+  rescaleLayoutLines,
+  charSpacingDeltaPx,
+  segAdvanceWidth,
+  type LayoutSeg,
+  type LayoutLine,
+  type LayoutTextSeg,
+} from './line-layout.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ECMA-376 §17.3.2.35 `<w:spacing>` — run character-spacing pitch must be part of
+// a segment's laid-out ADVANCE at the PAINT scale, not only at the scale-1 stamp.
+//
+// `layoutLines` (the scale-1 paginator stamp) derives each segment's measuredWidth
+// from `segAdvanceWidth`, which adds `cpCount × (w:spacing pt × scale)` on top of
+// the natural `measureText` width. The paint pass, however, does NOT re-run
+// `layoutLines` at the device scale — it reuses the scale-1 stamp through
+// `rescaleLayoutLines`, whose docstring promises the result is "identical to a
+// fresh paint-scale layout of the SAME partition" so that measure == paint.
+//
+// This pins the observed sample-34 defect ("氏名又は名称", where the run bearing
+// `<w:spacing w:val="96"/>` = 4.8 pt is followed by another run): at the paint
+// scale the following run's pen x collapses to the FIRST run's NATURAL width
+// (charSpacing dropped), so the next run is painted on top of the expanded glyphs
+// of the previous run. Because the draw path DOES apply `ctx.letterSpacing`
+// (= charSpacing) inside the run, the run visually widens but the neighbour never
+// gets pushed right → overlap.
+//
+// The width model itself (`segAdvanceWidth`, `charSpacingDeltaPx`) is already
+// correct and unit-tested (run-char-metrics.test.ts). This file instead exercises
+// the PAINT-SCALE reuse path (`rescaleLayoutLines`) end-to-end, which is where the
+// advance loses the spacing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A recording 2D-context stub whose glyph advance is EXACTLY `0.5 · px · n`
+ *  (linear in the font px size). Font-metric ascent/descent are the fixed 0.8/0.2
+ *  em ratios the renderer's fallback uses. Being scale-linear, it isolates the
+ *  advance MODEL (charSpacing) from font-hinting noise — any scale non-linearity
+ *  in the assertions therefore comes from the layout code, not the font. */
+function makeLinearCtx(perPx = 0.5): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const pxOf = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    fontKerning: 'auto',
+    measureText: (s: string) => {
+      const p = pxOf();
+      const per = p * perPx;
+      return {
+        width: [...s].length * per,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function textSeg(text: string, extra: Partial<LayoutTextSeg> = {}): LayoutSeg {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 12, color: null, fontFamily: 'Times New Roman', vertAlign: null,
+    measuredWidth: 0, ...extra,
+  } as LayoutSeg;
+}
+
+function cloneSegs(segs: LayoutSeg[]): LayoutSeg[] {
+  return segs.map((s) => ({ ...s }));
+}
+
+/** sample-34 "氏名又は名称" partition: run1 (4 CJK cps) + run2 (1 cp) both carry
+ *  `<w:spacing>` = 4.8 pt; run3 carries none. All fit on one line here so the
+ *  segment partition (3 text segments) is stable and we can read each segment's
+ *  advance directly. No docGrid (`gridDeltaPx = 0`) so the ONLY per-glyph delta in
+ *  play is §17.3.2.35 character spacing. */
+const SPACING_PT = 4.8;
+function makeSegs(): LayoutSeg[] {
+  return [
+    textSeg('氏名又は', { charSpacing: SPACING_PT }),
+    textSeg('名', { charSpacing: SPACING_PT }),
+    textSeg('称'),
+  ];
+}
+const WIDE = 1000; // pt — wide enough that the paragraph never wraps
+
+function isText(s: LayoutSeg): s is LayoutTextSeg {
+  return 'text' in s && !('isTab' in s) && !('imagePath' in s) && !('mathNodes' in s);
+}
+
+describe('§17.3.2.35 run charSpacing survives into the paint-scale advance', () => {
+  it('the scale-1 stamp already folds charSpacing into the advance (baseline)', () => {
+    const ctx = makeLinearCtx();
+    const stamp = layoutLines(ctx, makeSegs(), WIDE, 0, 1);
+    expect(stamp).toHaveLength(1);
+    const segs = stamp[0].segments.filter(isText);
+    expect(segs).toHaveLength(3);
+    // run1: natural (4 cps × 6px) + 4 × (4.8 pt × scale 1). measure==paint holds
+    // at the paginator scale, so this is not the regression — it anchors the
+    // expected value the paint scale must reproduce.
+    const natural1 = 4 * (12 * 0.5); // 24 px
+    expect(segs[0].measuredWidth).toBeCloseTo(natural1 + 4 * charSpacingDeltaPx(segs[0], 1), 6);
+  });
+
+  it('rescaleLayoutLines keeps charSpacing in the advance at the paint scale', () => {
+    const scale = 2;
+    const ctx = makeLinearCtx();
+    const stamp = layoutLines(ctx, makeSegs(), WIDE, 0, 1);
+    const painted = rescaleLayoutLines(stamp, scale, ctx, {}, 0);
+
+    expect(painted).toHaveLength(1);
+    const segs = painted[0].segments.filter(isText);
+    expect(segs).toHaveLength(3);
+
+    // run1 "氏名又は": the paint-scale advance MUST include the §17.3.2.35 pitch.
+    //   natural(scale 2) = 4 cps × (12·2 × 0.5) = 48 px
+    //   + 4 × (4.8 pt × scale 2 = 9.6 px)      = 38.4 px
+    //   = 86.4 px
+    // Before the fix the reuse path re-derived the advance from the natural
+    // width + docGrid delta only (the deleted `gridWidth` helper) → 48 px,
+    // dropping the 38.4 px of spacing, so this assertion failed.
+    const natural2 = 4 * (12 * scale * 0.5); // 48 px
+    const expected1 = natural2 + 4 * charSpacingDeltaPx(segs[0], scale); // 86.4 px
+    expect(segs[0].measuredWidth).toBeCloseTo(expected1, 6);
+
+    // run2 "名" (1 cp): natural (12 px) + 1 × 9.6 = 21.6 px.
+    const natural2b = 1 * (12 * scale * 0.5); // 12 px
+    expect(segs[1].measuredWidth).toBeCloseTo(
+      natural2b + 1 * charSpacingDeltaPx(segs[1], scale), 6);
+
+    // run3 "称" (no spacing): natural only, unchanged by the fix.
+    expect(segs[2].measuredWidth).toBeCloseTo(1 * (12 * scale * 0.5), 6);
+  });
+
+  it('the following run does not overlap the first run at the paint scale', () => {
+    // The paint pen advances by each segment's measuredWidth; run2 therefore starts
+    // at run1.measuredWidth. run1 is drawn with ctx.letterSpacing = charSpacing, so
+    // its painted right edge is `segAdvanceWidth(run1)`. The two must coincide (the
+    // pen must land where the glyphs end) or run2 is painted over run1's tail.
+    const scale = 2;
+    const ctx = makeLinearCtx();
+    const stamp = layoutLines(ctx, makeSegs(), WIDE, 0, 1);
+    const painted = rescaleLayoutLines(stamp, scale, ctx, {}, 0);
+    const segs = painted[0].segments.filter(isText);
+
+    const run2StartX = segs[0].measuredWidth; // run1 is first on the line
+    const run1PaintedRightEdge = segAdvanceWidth(segs[0], 4 * (12 * scale * 0.5), 0, scale);
+    // No overlap: run2 begins at or after run1's painted right edge.
+    expect(run2StartX).toBeGreaterThanOrEqual(run1PaintedRightEdge - 1e-6);
+  });
+
+  it('§17.3.2.43 w:w (charScale) also survives into the paint-scale advance', () => {
+    // The same reuse path dropped `w:w` too (it multiplies the natural width, so
+    // a 200%-stretched run collapsed back to its natural advance at the paint
+    // scale). Pin it alongside charSpacing: the consolidation must route BOTH
+    // run character metrics through the one advance authority.
+    const scale = 2;
+    const ctx = makeLinearCtx();
+    const stamp = layoutLines(ctx, [
+      textSeg('wide', { charScale: 2 }),
+      textSeg('after'),
+    ], WIDE, 0, 1);
+    const painted = rescaleLayoutLines(stamp, scale, ctx, {}, 0);
+    const segs = painted[0].segments.filter(isText);
+    expect(segs).toHaveLength(2);
+    // "wide" = 4 cps: natural(scale 2) = 4 × (12·2 × 0.5) = 48 px, × w:w 2 = 96 px.
+    expect(segs[0].measuredWidth).toBeCloseTo(96, 6);
+    // "after" (no w:w, 5 cps): natural only = 5 × 12 = 60 px.
+    expect(segs[1].measuredWidth).toBeCloseTo(60, 6);
+  });
+
+  it('the reuse path matches a fresh paint-scale layout of the same partition', () => {
+    // rescaleLayoutLines' contract: "identical to a fresh paint-scale layout of the
+    // SAME partition". A direct layoutLines call at the paint scale uses
+    // segAdvanceWidth (charSpacing included), so every segment advance must agree.
+    const scale = 2;
+    const stampCtx = makeLinearCtx();
+    const stamp = layoutLines(stampCtx, makeSegs(), WIDE, 0, 1);
+    const reused = rescaleLayoutLines(stamp, scale, makeLinearCtx(), {}, 0);
+
+    const freshCtx = makeLinearCtx();
+    const fresh = layoutLines(freshCtx, cloneSegs(makeSegs()), WIDE * scale, 0, scale);
+
+    const reusedSegs = reused[0].segments.filter(isText);
+    const freshSegs = (fresh[0] as LayoutLine).segments.filter(isText);
+    expect(reusedSegs).toHaveLength(freshSegs.length);
+    for (let i = 0; i < reusedSegs.length; i++) {
+      expect(reusedSegs[i].measuredWidth).toBeCloseTo(freshSegs[i].measuredWidth, 6);
+    }
+  });
+});

--- a/packages/docx/src/charspacing-paint.test.ts
+++ b/packages/docx/src/charspacing-paint.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ECMA-376 §17.3.2.35 `<w:spacing>` / §17.3.2.43 `<w:w>` must reach the actual
+// GLYPH DRAW on every paint branch, and the FOLLOWING run's pen position must
+// coincide with the previous run's painted extent (measure==paint at the run
+// boundary, the sample-34 overlap contract). The advance-model unit tests
+// (charspacing-advance.test.ts) derive both sides from segAdvanceWidth, so they
+// cannot catch a paint branch that forgets ctx.letterSpacing or advances glyphs
+// by the natural width — these tests drive renderDocumentToCanvas end-to-end
+// with a recording canvas and assert on the recorded fillText calls instead.
+//
+// Four paint branches (renderer.ts drawLine segment loop):
+//   1. horizontal common single-fillText (no grid, no justify)
+//   2. horizontal docGrid character-grid branch (grid pitch + char spacing)
+//   3. horizontal §17.18.44 justify branch (distributed pitch + char spacing)
+//   4. vertical tbRl branch (drawVerticalRun per-glyph advance)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FONT_PX = 20;
+
+interface FillCall {
+  text: string;
+  x: number;
+  y: number;
+  letterSpacing: string;
+  // Naive accumulation of the raw translate() x arguments in effect at fill
+  // time (save/restore-scoped, rotation ignored). Constant page-level offsets
+  // cancel in the DELTAS between fills of the same line, which is all the
+  // vertical assertions read (drawVerticalRun brackets each upright glyph in
+  // save; translate(cellCenter, baseline); rotate; fillText; restore).
+  translateX: number;
+  scaleX: number;
+  scaleY: number;
+}
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[] } {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const fills: FillCall[] = [];
+  let scaleX = 1;
+  let scaleY = 1;
+  let translateX = 0;
+  const stack: { scaleX: number; scaleY: number; translateX: number }[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(v: string) { letterSpacing = v; },
+    fontKerning: 'auto',
+    measureText: (s: string) => {
+      const p = px();
+      const w = [...s].length * p;
+      return {
+        width: w,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() { stack.push({ scaleX, scaleY, translateX }); },
+    restore() { const s = stack.pop(); if (s) { scaleX = s.scaleX; scaleY = s.scaleY; translateX = s.translateX; } },
+    beginPath() {}, closePath() {}, moveTo() {}, lineTo() {}, stroke() {}, fill() {},
+    fillRect() {}, strokeRect() {}, clip() {}, rect() {}, setLineDash() {},
+    drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    scale(sx: number, sy?: number) { scaleX *= sx; scaleY *= sy ?? sx; },
+    translate(tx: number) { translateX += tx; },
+    rotate() {},
+    fillText(text: string, x: number, y: number) {
+      fills.push({ text, x, y, letterSpacing, translateX, scaleX, scaleY });
+    },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, textBaseline: 'alphabetic' as CanvasTextBaseline,
+    direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills };
+}
+
+function textRun(text: string, extra: Partial<DocxTextRun> = {}): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: FONT_PX, color: null, fontFamily: 'NotInMetrics', isLink: false,
+    background: null, vertAlign: null, hyperlink: null, ...extra,
+  };
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+function para(runs: DocxTextRun[], alignment = 'left'): BodyElement {
+  const p: DocParagraph = {
+    alignment, indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: runs.map((r) => ({ type: 'text', ...r }) as DocRun),
+    defaultFontSize: FONT_PX, defaultFontFamily: 'NotInMetrics', widowControl: false,
+  } as DocParagraph;
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function section(extra: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 600, pageHeight: 600, marginTop: 0, marginRight: 0, marginBottom: 0,
+    marginLeft: 0, headerDistance: 0, footerDistance: 0, titlePage: false,
+    evenAndOddHeaders: false, ...extra,
+  } as SectionProps;
+}
+
+function doc(body: BodyElement[], sec: SectionProps): DocxDocumentModel {
+  return {
+    section: sec, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(
+  body: BodyElement[],
+  sec: SectionProps = section(),
+): Promise<FillCall[]> {
+  const { canvas, fills } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc(body, sec), canvas, 0, { dpr: 1, width: 600 });
+  return fills;
+}
+
+function drawOf(fills: FillCall[], text: string): FillCall {
+  const f = fills.find((c) => c.text === text);
+  expect(f, `a fillText drew ${JSON.stringify(text)}`).toBeDefined();
+  return f as FillCall;
+}
+
+/** Effective x (page space) of the fills the vertical per-glyph draw produced:
+ *  the accumulated translate at fill time. Constant page-level offsets cancel
+ *  when the caller diffs consecutive values. */
+function glyphCenters(fills: FillCall[], chars: string[]): number[] {
+  return chars.map((ch) => drawOf(fills, ch).translateX);
+}
+
+describe('run charSpacing/charScale reach the painted glyphs on every branch', () => {
+  it('horizontal common path: following run starts at the expanded right edge', async () => {
+    // run1 4 cps × (20 natural + 2 spacing) = 88; run2 must start +88 from run1.
+    const fills = await render([para([
+      textRun('あいうえ', { charSpacing: 2 }),
+      textRun('かき'),
+    ])]);
+    const r1 = drawOf(fills, 'あいうえ');
+    const r2 = drawOf(fills, 'かき');
+    expect(r1.letterSpacing).toBe('2px'); // §17.3.2.35 at the glyph draw
+    expect(r2.letterSpacing).toBe('0px');
+    expect(r2.x - r1.x).toBeCloseTo(4 * FONT_PX + 4 * 2, 5);
+  });
+
+  it('docGrid character-grid path: grid pitch and charSpacing combine at the draw', async () => {
+    // §17.6.5 linesAndChars with charSpace 4096 units = 1 pt per EA glyph.
+    // Combined per-glyph pitch = 1 (grid) + 2 (w:spacing) = 3px on run1; the
+    // pure-EA run2 keeps its own 1px grid pitch. run2 starts at run1's celled
+    // advance: 4 × 20 + 4 × 3 = 92.
+    const fills = await render(
+      [para([textRun('あいうえ', { charSpacing: 2 }), textRun('かき')])],
+      section({ docGridType: 'linesAndChars', docGridLinePitch: 24, docGridCharSpace: 4096 }),
+    );
+    const r1 = drawOf(fills, 'あいうえ');
+    const r2 = drawOf(fills, 'かき');
+    expect(r1.letterSpacing).toBe('3px');
+    expect(r2.letterSpacing).toBe('1px');
+    expect(r2.x + r2.translateX - (r1.x + r1.translateX)).toBeCloseTo(4 * FONT_PX + 4 * 3, 5);
+  });
+
+  it('justify path: charSpacing adds to the distributed pitch at the draw', async () => {
+    // A justified ('both') CJK paragraph that wraps: line 1 carries run1 (25 cps,
+    // w:spacing 2) + a 2-cp prefix of run2, with 10px of slack distributed over
+    // the inter-CJK gaps. The FULLY-distributed draw paints each segment with
+    // ctx.letterSpacing = distPerGap + its own charSpacing, so the two segments'
+    // recorded letterSpacing must differ by exactly the 2px charSpacing, and
+    // run1's pitch must exceed its bare charSpacing (distPerGap > 0 — justify
+    // actually engaged).
+    const fills = await render([para(
+      [textRun('あ'.repeat(25), { charSpacing: 2 }), textRun('い'.repeat(10))],
+      'both',
+    )]);
+    const r1 = fills.find((f) => f.text.startsWith('あ'));
+    const r2 = fills.find((f) => f.text.startsWith('い'));
+    expect(r1, 'run1 glyphs painted').toBeDefined();
+    expect(r2, 'run2 first-line glyphs painted').toBeDefined();
+    const p1 = parseFloat((r1 as FillCall).letterSpacing);
+    const p2 = parseFloat((r2 as FillCall).letterSpacing);
+    expect(p1).toBeGreaterThan(2); // distPerGap > 0 on top of the 2px spacing
+    expect(p1 - p2).toBeCloseTo(2, 5); // the §17.3.2.35 component survives justify
+  });
+
+  it('vertical tbRl path: per-glyph advance includes charSpacing (no gap before the next run)', async () => {
+    // ECMA-376 §17.6.20 rotate-layout: the logical line axis is the along-column
+    // advance. layoutLines gives run1 measuredWidth = 4 × 20 + 4 × 2 = 88, so the
+    // pen places run2 at 88. drawVerticalRun must advance each upright glyph by
+    // measure + 2 (the §17.3.2.35 pitch); with the natural-only advance run1's
+    // glyphs end at 80 and an 8px hole opens before run2.
+    const fills = await render(
+      [para([textRun('あいうえ', { charSpacing: 2 }), textRun('かき')])],
+      section({ textDirection: 'tbRl' }),
+    );
+    const [a, i, u, e, ka] = glyphCenters(fills, ['あ', 'い', 'う', 'え', 'か']);
+    // Cell centres of run1's glyphs are (20+2) apart.
+    expect(i - a).toBeCloseTo(22, 5);
+    expect(u - i).toBeCloseTo(22, 5);
+    expect(e - u).toBeCloseTo(22, 5);
+    // Run boundary: run2's first cell centre sits half-cells from run1's last —
+    // (22 + 20) / 2 = 21 — i.e. flush, no hole (pen 88 == painted extent 88).
+    expect(ka - e).toBeCloseTo((22 + 20) / 2, 5);
+  });
+
+  it('vertical tbRl path: w:w scales the along-column advance (measure==paint)', async () => {
+    // §17.3.2.43 w:w in the rotate-layout vertical engine: the layout kernel is
+    // direction-agnostic and has always scaled the LINE-AXIS advance by w:w
+    // (segAdvanceWidth), which after the +90° page rotation IS the along-column
+    // cell extent — so wrap points, run boxes, and find/selection already assume
+    // it. Paint must follow measure: run1 (w:w=50%) cells are 10px, and run2's
+    // pen (= run1 measuredWidth = 40) sits flush against the last cell.
+    const fills = await render(
+      [para([textRun('あいうえ', { charScale: 0.5 }), textRun('かき')])],
+      section({ textDirection: 'tbRl' }),
+    );
+    const [a, i, u, e, ka] = glyphCenters(fills, ['あ', 'い', 'う', 'え', 'か']);
+    expect(i - a).toBeCloseTo(10, 5);
+    expect(u - i).toBeCloseTo(10, 5);
+    expect(e - u).toBeCloseTo(10, 5);
+    // Boundary: (10 + 20) / 2 = 15. With the unscaled per-glyph advance run1's
+    // glyphs overrun their cells and run2 paints INSIDE run1's tail.
+    expect(ka - e).toBeCloseTo((10 + 20) / 2, 5);
+  });
+});

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -701,14 +701,6 @@ export function gridSegDeltaPx(text: string, deltaPx: number): number {
   return eaGlyphCount(text) === cps.length ? cps.length * deltaPx : 0;
 }
 
-/** Single source of truth for a text segment's laid-out advance: the natural
- *  `measureText` width plus the character-grid delta (0 unless an active grid
- *  AND a pure-EA segment). EVERY line-break / advance measurement and every draw
- *  path must derive the segment advance from this, so they cannot diverge. */
-export function gridWidth(naturalWidthPx: number, text: string, deltaPx: number): number {
-  return naturalWidthPx + gridSegDeltaPx(text, deltaPx);
-}
-
 /** Resolve the per-glyph character-grid delta for one text segment. */
 export function segmentCharacterGridDeltaPx(
   seg: LayoutTextSeg,
@@ -731,6 +723,21 @@ export function charSpacingDeltaPx(seg: LayoutTextSeg, scale: number): number {
  *  natural `measureText` width; the paint pass reproduces it with `ctx.scale`. */
 export function charScaleFactor(seg: LayoutTextSeg): number {
   return seg.charScale ?? 1;
+}
+
+/** Canonical advance formula for a text string in a run: natural glyph width
+ *  scaled by ECMA-376 §17.3.2.43 `<w:w>`, plus the §17.6.5 character-grid
+ *  delta, plus one ECMA-376 §17.3.2.35 `<w:spacing>` pitch per code point. */
+function textAdvanceWidth(
+  naturalWidthPx: number,
+  text: string,
+  gridDeltaPx: number,
+  charScale: number,
+  charSpacingPx: number,
+): number {
+  return naturalWidthPx * charScale
+    + gridSegDeltaPx(text, gridDeltaPx)
+    + [...text].length * charSpacingPx;
 }
 
 /** Total per-code-point letter-spacing (px) a segment draws with: the docGrid
@@ -757,8 +764,7 @@ export function segLetterSpacingPx(
  *  and the §17.3.2.35 character spacing, on top of the docGrid delta. The
  *  natural width is scaled first (w:w stretches the glyphs), then the char-spacing
  *  pitch is added per code point (w:spacing adds fixed gaps that w:w does not
- *  stretch), matching Word's independent treatment of the two axes. Reduces to
- *  {@link gridWidth} when the run declares neither attribute. */
+ *  stretch), matching Word's independent treatment of the two axes. */
 export function segAdvanceWidth(
   seg: LayoutTextSeg,
   naturalWidthPx: number,
@@ -776,9 +782,13 @@ export function segAdvanceWidth(
   // rotation — see vertical-text.ts and renderer's page transform.)
   if (seg.tateChuYoko) return seg.fontSize * scale;
   const segmentDelta = segmentCharacterGridDeltaPx(seg, gridDeltaPx);
-  const scaled = naturalWidthPx * charScaleFactor(seg) + gridSegDeltaPx(seg.text, segmentDelta);
-  const cpCount = [...seg.text].length;
-  return scaled + cpCount * charSpacingDeltaPx(seg, scale);
+  return textAdvanceWidth(
+    naturalWidthPx,
+    seg.text,
+    segmentDelta,
+    charScaleFactor(seg),
+    charSpacingDeltaPx(seg, scale),
+  );
 }
 
 export function isGridLineRule(ctx: DocGridCtx | undefined): boolean {
@@ -1146,8 +1156,8 @@ export function fitCJKPrefix(
   text: string,
   maxWidth: number,
   // ECMA-376 §17.6.5 character-grid delta (px per EA glyph, 0 when inactive).
-  // The fit must compare CELL widths so the grid's char count lands per line —
-  // the same `gridWidth` the line box / draw uses, keeping the split consistent.
+  // The fit must compare the same advance model as the line box / draw so the
+  // grid's char count and run character metrics land on the same split.
   gridDeltaPx = 0,
   // WD4 — the run's §17.3.2.43 horizontal glyph scale (1 = 100%) and §17.3.2.35
   // per-code-point character-spacing pitch in px. Threaded so a CJK run that is
@@ -1161,10 +1171,13 @@ export function fitCJKPrefix(
   while (lo < hi) {
     const mid = (lo + hi + 1) >> 1;
     const prefix = chars.slice(0, mid).join('');
-    const advance =
-      ctx.measureText(prefix).width * charScale +
-      gridSegDeltaPx(prefix, gridDeltaPx) +
-      mid * charSpacingPx;
+    const advance = textAdvanceWidth(
+      ctx.measureText(prefix).width,
+      prefix,
+      gridDeltaPx,
+      charScale,
+      charSpacingPx,
+    );
     if (advance <= maxWidth) lo = mid;
     else hi = mid - 1;
   }
@@ -2037,8 +2050,8 @@ export function layoutLines(
   // ON; the CJK overflow path retracts the break to a kinsoku-legal position.
   kinsoku: KinsokuRules = DEFAULT_KINSOKU_RULES,
   // ECMA-376 §17.6.5 docGrid CHARACTER grid: per-EA-glyph cell delta in px (0
-  // when inactive). Folded into every advance via `gridWidth` so line breaking
-  // packs the grid's char count per line; the draw paths add the SAME delta.
+  // when inactive). Folded into every text advance so line breaking packs the
+  // grid's char count per line; the draw paths add the SAME delta.
   gridDeltaPx = 0,
   // ECMA-376 §17.15.1.25 — automatic tab-stop interval (pt). The automatic-stop
   // grid (`nextTabStop`) multiplies this by `scale`; defaults to the spec absent
@@ -2331,9 +2344,7 @@ export function layoutLines(
     const prevKern = setSegKerning(s);
     const natural = ctx.measureText(text).width;
     restoreKerning(prevKern);
-    const segmentDelta = segmentCharacterGridDeltaPx(s, gridDeltaPx);
-    const scaled = natural * charScaleFactor(s) + gridSegDeltaPx(text, segmentDelta);
-    return scaled + [...text].length * charSpacingDeltaPx(s, scale);
+    return segAdvanceWidth({ ...s, text }, natural, gridDeltaPx, scale);
   };
 
   // Width of a queued segment, for right/center tab look-ahead.
@@ -2848,7 +2859,7 @@ export function layoutLines(
  *  the baseline off by up to ~1px vertically, accumulating down the page (seen on
  *  demo/sample-1 p.4). So RE-MEASURE every text segment at the paint scale here —
  *  the exact same per-segment measurement `layoutLines` does (advance via
- *  gridWidth, box via correctedLineMetrics, the §17.3.2.33 small-caps full-size
+ *  segAdvanceWidth, box via correctedLineMetrics, the §17.3.2.33 small-caps full-size
  *  box, the §17.3.3.25 ruby ascent reserve, and the intended-single-line floor) —
  *  so measure == draw byte-for-byte, identical to a fresh paint-scale layout of
  *  the SAME partition. Only WHICH glyphs sit on WHICH line comes from the scale-1
@@ -2884,11 +2895,7 @@ export function rescaleLayoutLines(
     const effPx = calcEffectiveFontPx(s, scale);
     ctx.font = buildFont(s.bold, s.italic, effPx, s.fontFamily, fontFamilyClasses);
     const m = ctx.measureText(s.text);
-    const advance = gridWidth(
-      m.width,
-      s.text,
-      segmentCharacterGridDeltaPx(s, gridDeltaPx),
-    );
+    const advance = segAdvanceWidth(s, m.width, gridDeltaPx, scale);
     // §17.3.2.33 — a small-caps run's LINE BOX follows the FULL run size (measure
     // the box at fullPx, not the 2pt-reduced glyphs); super/subscript keeps its
     // shrunk contribution. Mirrors layoutLines' fullPx / metricEmPx split.

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -10849,9 +10849,9 @@ function paragraphMarkEmPx(para: DocParagraph, scale: number): number {
 // PURE-EA segment. `gridSegDeltaPx` returns the total delta a segment's box
 // gains (`len × Δpx` for a pure-EA segment, else 0 — mixed/Latin segments get
 // no grid effect, sidestepping any contextual-metric or justification drift),
-// and `gridWidth` adds it to the natural `measureText` width. BOTH the layout's
-// `measuredWidth` and every draw path derive the segment's advance from this
-// SAME quantity:
+// and `segAdvanceWidth` folds it into the run's complete advance together with
+// §17.3.2.43 `w:w` and §17.3.2.35 `w:spacing`. BOTH the layout's `measuredWidth`
+// and every draw path derive the segment's advance from this SAME quantity:
 //   • non-justified draw walks the glyphs via `justifiedPiecePositions(cps,
 //     [1..n-1], perGap=0, measure, letterSpacingPx=Δ)`, whose final glyph lands
 //     at `measure(whole) + n·Δ` = the box edge;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -139,6 +139,7 @@ import {
   paragraphMarkLineHeight,
   paragraphSegsStateSensitive,
   rescaleLayoutLines,
+  segLetterSpacingPx,
   shapeRenderState,
   shapeRunToDocRun,
   segmentCharacterGridDeltaPx,
@@ -7306,20 +7307,23 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           );
         } else if (state.verticalCJK) {
           // ECMA-376 §17.6.20 (tbRl) — the run flows DOWN the column (logical
-          // +x). Draw each glyph advancing by its measured horizontal width plus
-          // the per-cell grid delta, counter-rotating upright (CJK) glyphs so
-          // they stand up inside the +90°-rotated page while Latin/digits stay
-          // sideways. The docGrid cell delta (segGridDelta, non-zero only on a
-          // pure-EA segment) becomes the vertical inter-glyph pitch; the
-          // horizontal-only justify slicing (cases below) does not apply in
-          // vertical stage-1 (the sample's columns are start-aligned).
+          // +x). Draw each glyph advancing by its measured horizontal width
+          // (× the §17.3.2.43 `w:w` scale) plus the combined per-glyph pitch —
+          // the docGrid cell delta (non-zero only on a pure-EA segment) plus the
+          // §17.3.2.35 `w:spacing` pitch, the SAME `segLetterSpacingPx` value the
+          // measured advance folds in (measure==paint) — counter-rotating upright
+          // (CJK) glyphs so they stand up inside the +90°-rotated page while
+          // Latin/digits stay sideways. The horizontal-only justify slicing
+          // (cases below) does not apply in vertical stage-1 (the sample's
+          // columns are start-aligned).
           drawVerticalRun(
             ctx,
             s.text,
             x,
             baseline + yOffset,
             effSizePx,
-            segGridDelta !== 0 ? segmentGridDeltaPx : 0,
+            segLetterSpacingPx(s, drawGridDeltaPx, scale),
+            segCharScale,
           );
         } else if (segGridDelta !== 0) {
           const cps = [...s.text]; // code points (handles surrogate pairs)

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -250,8 +250,10 @@ function inkCenterAboveMiddlePx(ctx: Ctx2D, drawStr: string): number {
  * @param x                Logical left edge of the run (px).
  * @param baseline         Logical baseline y of the line (px).
  * @param fontPx           Effective font size in px (for cell centring).
- * @param letterSpacingPx  Per-glyph extra advance (docGrid cell delta or
- *                         justification pitch); 0 for the common path.
+ * @param letterSpacingPx  Per-glyph extra advance: the combined docGrid cell
+ *                         delta + §17.3.2.35 `w:spacing` pitch (the layout's
+ *                         `segLetterSpacingPx`); 0 for the common path.
+ * @param charScale        ECMA-376 §17.3.2.43 `w:w` fraction; 1 by default.
  */
 export function drawVerticalRun(
   ctx: Ctx2D,
@@ -260,6 +262,7 @@ export function drawVerticalRun(
   baseline: number,
   fontPx: number,
   letterSpacingPx: number,
+  charScale = 1,
 ): void {
   const prevAlign = ctx.textAlign;
   const prevBaseline = ctx.textBaseline;
@@ -268,13 +271,22 @@ export function drawVerticalRun(
   // per run (font-level, glyph-independent). Used to re-centre SIDEWAYS glyphs,
   // which are otherwise drawn on their baseline and so land off the centreline.
   const emBoxCenterPx = emBoxCenterAboveBaselinePx(ctx, text, fontPx);
+  // In this rotate-layout architecture the direction-independent layout kernel
+  // applies ECMA-376 §17.3.2.43 `w:w` to the line axis (`segAdvanceWidth`) even
+  // for tbRl; wrapping, selection, and run boxes already depend on that advance,
+  // so paint must follow measure. Sideways glyphs are rotated horizontal text,
+  // making their `w:w` width axis the vertical advance axis directly. Upright
+  // glyphs therefore scale the equivalent local y axis. Tate-chu-yoko is kept
+  // separate: ECMA-376 §17.3.2.10 fixes its advance to one em and uses `w:w` on
+  // the cross axis.
+  const scaled = charScale !== 1;
   let ax = 0; // cumulative advance from run left (logical +x)
   for (const ch of text) {
     const cp = ch.codePointAt(0) ?? 0;
     const mode = verticalDrawMode(cp);
     // Advance/width uses the ORIGINAL code point (measure == draw, and the text
     // model / selection / find keep the original character — see the module doc).
-    const adv = ctx.measureText(ch).width + letterSpacingPx;
+    const adv = ctx.measureText(ch).width * charScale + letterSpacingPx;
     // A vo=Tr bracket with a Unicode vertical presentation form (（）「」〈〉…) is
     // SUBSTITUTED and drawn upright, exactly like the upright cells — UAX#50 §5
     // Tr means "substitute a vertical glyph; rotate only as fallback". Only Tr
@@ -324,6 +336,7 @@ export function drawVerticalRun(
       ctx.save();
       ctx.translate(cx, baseline);
       ctx.rotate(-Math.PI / 2);
+      if (scaled) ctx.scale(1, charScale);
       // In the upright local frame: `center`/`middle` puts the em box on the cell
       // centre; local +x = cross axis, local +y = along-column. `off.dx` nudges
       // ． toward the cell's upper-right corner (cross axis); `alongEm + off.dy`
@@ -342,7 +355,15 @@ export function drawVerticalRun(
       const cx = x + ax + adv / 2;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillText(ch, cx, baseline);
+      if (scaled) {
+        ctx.save();
+        ctx.translate(cx, baseline);
+        ctx.scale(charScale, 1);
+        ctx.fillText(ch, 0, 0);
+        ctx.restore();
+      } else {
+        ctx.fillText(ch, cx, baseline);
+      }
     } else {
       // vo=R (Latin/digit): drawn SIDEWAYS (rotated with the page). Keep the
       // caller's alphabetic baseline and position the glyph's left at the current
@@ -357,7 +378,15 @@ export function drawVerticalRun(
       // measured relative to the alphabetic baseline).
       ctx.textAlign = prevAlign;
       ctx.textBaseline = 'alphabetic';
-      ctx.fillText(ch, x + ax, baseline + emBoxCenterPx);
+      if (scaled) {
+        ctx.save();
+        ctx.translate(x + ax, 0);
+        ctx.scale(charScale, 1);
+        ctx.fillText(ch, 0, baseline + emBoxCenterPx);
+        ctx.restore();
+      } else {
+        ctx.fillText(ch, x + ax, baseline + emBoxCenterPx);
+      }
     }
     ax += adv;
   }


### PR DESCRIPTION
## Root cause

The text-segment advance had two producers that drifted apart:

- `layoutLines` (the scale-1 pagination stamp) derives every segment's `measuredWidth` from `segAdvanceWidth`, which folds in the ECMA-376 §17.3.2.43 `w:w` glyph scale and the §17.3.2.35 `w:spacing` character pitch.
- The paint pass reuses that stamp through `rescaleLayoutLines`, which re-derived the paint-scale advance from the natural `measureText` width plus the docGrid delta only (the old `gridWidth` helper) — dropping **both** run character metrics.

The draw path applies `w:spacing` inside a run via `ctx.letterSpacing`, so an expanded run painted wider than its measured advance, and the following run — placed by `x += seg.measuredWidth` — was painted on top of its trailing glyphs. Same mechanism collapsed a `w:w`-stretched run back to its natural advance at paint scale.

## Fix

Consolidate the advance formula into one authority: a private `textAdvanceWidth` (`natural × w:w + docGrid delta + codePoints × w:spacing`) now backs `segAdvanceWidth`; the substring path (`strAdvance`), the CJK fit binary search (`fitCJKPrefix`), and `rescaleLayoutLines` all route through it. Line breaking, pen advance, justification, find/selection geometry, `measureParagraph`, and the paint-scale reuse now share the single formula and cannot diverge again. The degraded `gridWidth` duplicate is deleted (it was not part of the public package API) and stale comments updated. The §17.3.2.10 tateChuYoko one-em branch is preserved.

`w:fitText` (§17.3.1.13) remains unimplemented and out of scope for this PR.

## Red → Green

`packages/docx/src/charspacing-advance.test.ts` pins the paint-scale advance for both `w:spacing` and `w:w` through `rescaleLayoutLines`, including a case asserting the reuse path matches a fresh paint-scale layout of the same partition (the measure==paint contract). 4 of 5 cases fail before the fix (paint-scale advance = natural width only); all pass after. Red-green verified by reverting and reapplying the fix.

## Verification on the reporting document (local)

Rendered p.1 of the private JP form sample at scale 2 (12 pt CJK runs, `w:spacing` = 96 twips = 4.8 pt) with an `onTextRun` geometry probe:

| run | before x / w | after x / w |
| --- | --- | --- |
| 4-glyph run with spacing | 545.4 / 96.0 (natural only; painted extent 134.4) | 545.4 / 134.4 (= 96 + 4 × 9.6) |
| next run (1 glyph, spacing) | 641.4 / 24.0 — overlaps previous glyphs by 38.4 px | 679.8 / 33.6 — starts exactly at painted right edge |
| final run (no spacing) | 665.4 / 24.0 | 713.4 / 24.0 |

## Checks

- `vitest run packages/docx`: 136 files, 998 passed, 1 skipped
- root `pnpm typecheck`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
