### PR TITLE
fix(pptx): resolve a:tabLst stops in the RTL reading frame (mirror docx #830)

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -239,7 +239,10 @@ export type Bullet =
   | { type: 'autoNum'; numType: string; startAt: number | null };
 
 export interface TabStop {
-  /** Position in EMU from the left edge of the text area (after lIns) */
+  /** Position in EMU from the LEADING text-inset edge of the text area —
+   *  logical, not physical (ECMA-376 §21.1.2.1): the left edge (after lIns)
+   *  in an LTR paragraph, the right edge (before rIns) in an RTL
+   *  (`<a:pPr rtl="1">`) paragraph. */
   pos: number;
   /** Alignment: "l" | "r" | "ctr" | "dec" */
   algn: string;

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -967,8 +967,16 @@ export function layoutParagraph(
             tabActive = true;
             currentLine.tabStop = { px: tabStopPx, algn: ts.algn, segments: [] };
           } else {
-            // Left-aligned tab: advance lineW to the tab stop
-            lineW = tabStopPx - marLPx;
+            // Start tab ('l'; 'dec' is treated as start — decimal alignment is
+            // unimplemented): advance the READING-order pen to the stop. The pen
+            // is the reading-frame distance from the leading indent, so the
+            // advance is `pos − leadIndentPx` under BOTH bases (LTR:
+            // leadIndentPx === marLPx, byte-identical). No cell group is opened
+            // for start tabs — the gap is not materialized as a drawn segment in
+            // either direction (pre-existing inline-advance model, see the
+            // LayoutLine.tabStop doc); the advance drives wrapping and later
+            // stop selection only.
+            lineW = tabStopPx - leadIndentPx;
           }
         } else {
           // No matching tab stop — treat as a single space
@@ -3392,15 +3400,16 @@ export function renderTextBody(
       let tabPenX: number;
       if (baseRtl) {
         const tabAbsX = bx + bw - rPad - line.tabStop.px;
-        if (line.tabStop.algn === 'r') {
+        // Only 'r'/'ctr' stops reach this block — layoutParagraph opens a tab
+        // cell solely for those two; a start ('l') or 'dec' tab advances the pen
+        // inline (reading frame) and never builds a cell (see the tab token
+        // branch in layoutParagraph).
+        if (line.tabStop.algn === 'ctr') {
+          tabPenX = tabAbsX - totalTabW / 2;
+        } else {
           // end/trailing (§21.1.2.1: physical `r` = logical end under RTL): the
           // cell's TRAILING (left) edge sits on the stop, cell extends rightward.
           tabPenX = tabAbsX;
-        } else if (line.tabStop.algn === 'ctr') {
-          tabPenX = tabAbsX - totalTabW / 2;
-        } else {
-          // start/leading: the cell's LEADING (right) edge sits on the stop.
-          tabPenX = tabAbsX - totalTabW;
         }
       } else {
         const tabAbsX = bx + lPad + line.tabStop.px;

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -948,8 +948,15 @@ export function layoutParagraph(
 
       // ── Tab character ────────────────────────────────────────────────────
       if (/^\t+$/.test(token)) {
-        // Find first tab stop whose position (from text area left) is beyond the current pen
-        const currentAbsW = marLPx + lineW; // current position from text area left
+        // Pen position from the LEADING text-inset edge, measured in READING
+        // order: an LTR paragraph advances rightward from the left inset (leading
+        // indent = marL); a BIDI (RTL) paragraph advances leftward from the right
+        // inset (leading indent = marR). Tab stops (§21.1.2.1.x) are logical
+        // distances from that leading edge, so the same "first stop past the pen"
+        // rule selects the stop in either frame (mirrors docx #830 nextTabStopRtl;
+        // the draw pass then mirrors the chosen stop into the RTL frame).
+        const leadIndentPx = para.rtl ? emuToPx(para.marR, scale) : marLPx;
+        const currentAbsW = leadIndentPx + lineW;
         const ts = (para.tabStops ?? []).find(
           (t: TabStop) => emuToPx(t.pos, scale) > currentAbsW
         );
@@ -3367,21 +3374,49 @@ export function renderTextBody(
 
     // ── Tab-stop segments (right-aligned or centred at tab stop position) ──
     if (line.tabStop && line.tabStop.segments.length > 0) {
-      const tabAbsX = bx + lPad + line.tabStop.px;
       let totalTabW = 0;
       for (const seg of line.tabStop.segments) {
         ctx.font = seg.font;
         const ls = seg.letterSpacingPx ?? 0;
         totalTabW += ctx.measureText(seg.text).width + ls * codePointCount(seg.text);
       }
+      // ECMA-376 §21.1.2.1.x tab stops are LOGICAL: `pos` is the distance from the
+      // LEADING text-inset edge. LTR base ⇒ leading edge = left inset
+      // (`bx + lPad`), pen advances rightward; BIDI (RTL) base ⇒ leading edge =
+      // right inset (`bx + bw − rPad`), pen advances LEFT, so the stop mirrors and
+      // the trailing cell flips visual side. The LTR-frame math below dropped an
+      // RTL cell on the wrong side (issue #831). This mirrors the docx fix (#830 /
+      // #835: `layoutBidiTabStops` / `nextTabStopRtl` resolve stops against the
+      // leading text margin in the reading frame). DrawingML tabs carry no leader,
+      // so — unlike docx — there is nothing to paint across the gap.
       let tabPenX: number;
-      if (line.tabStop.algn === 'r') {
-        tabPenX = tabAbsX - totalTabW;
-      } else if (line.tabStop.algn === 'ctr') {
-        tabPenX = tabAbsX - totalTabW / 2;
+      if (baseRtl) {
+        const tabAbsX = bx + bw - rPad - line.tabStop.px;
+        if (line.tabStop.algn === 'r') {
+          // end/trailing (§21.1.2.1: physical `r` = logical end under RTL): the
+          // cell's TRAILING (left) edge sits on the stop, cell extends rightward.
+          tabPenX = tabAbsX;
+        } else if (line.tabStop.algn === 'ctr') {
+          tabPenX = tabAbsX - totalTabW / 2;
+        } else {
+          // start/leading: the cell's LEADING (right) edge sits on the stop.
+          tabPenX = tabAbsX - totalTabW;
+        }
       } else {
-        tabPenX = tabAbsX;
+        const tabAbsX = bx + lPad + line.tabStop.px;
+        if (line.tabStop.algn === 'r') {
+          tabPenX = tabAbsX - totalTabW;
+        } else if (line.tabStop.algn === 'ctr') {
+          tabPenX = tabAbsX - totalTabW / 2;
+        } else {
+          tabPenX = tabAbsX;
+        }
       }
+      // Shape the cell's glyphs in reading order under an RTL base (Arabic
+      // joining, digit shaping). `ctx.textAlign` stays 'left' (set once for the
+      // whole body), so tabPenX remains the cell's left edge — only glyph shaping
+      // differs. Reset to 'ltr' after the cell so later lines are unaffected.
+      if (baseRtl) ctx.direction = 'rtl';
       for (const seg of line.tabStop.segments) {
         ctx.font = seg.font;
         ctx.fillStyle = seg.color;
@@ -3431,6 +3466,7 @@ export function renderTextBody(
         }
         tabPenX += tabSegW;
       }
+      if (baseRtl) ctx.direction = 'ltr';
     }
 
     cursorY += linePx;

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -3411,6 +3411,12 @@ export function renderTextBody(
           // cell's TRAILING (left) edge sits on the stop, cell extends rightward.
           tabPenX = tabAbsX;
         }
+        // A stop past the trailing (left) text edge pins the cell AT that edge —
+        // the docx layoutBidiTabStops clamp (#835: Word never pushes the cell
+        // off the text area). Unclamped, a mirrored stop with pos > the text
+        // width would land at a negative x, drawing outside the shape.
+        const trailingEdgePx = bx + lPad;
+        if (tabPenX < trailingEdgePx) tabPenX = trailingEdgePx;
       } else {
         const tabAbsX = bx + lPad + line.tabStop.px;
         if (line.tabStop.algn === 'r') {

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -396,9 +396,24 @@ type LayoutSegment = {
 
 interface LayoutLine {
   segments: LayoutSegment[];
-  /** Segments right-aligned at a tab stop (set when paragraph contains \t and a right-aligned tabStop) */
+  /** Segments aligned at a right/centre tab stop (set when the paragraph
+   *  contains a `\t` resolving to an `algn="r"|"ctr"` stop).
+   *
+   *  KNOWN MODEL LIMITS (pre-existing, LTR and RTL alike — follow-up #916):
+   *  - ONE cell slot per line: a second right/centre tab on the same line
+   *    re-assigns this object with empty `segments`, dropping the text
+   *    collected for the first cell.
+   *  - Cell segments bypass the UAX#9 visual reorder (`computeLineVisualOrder`
+   *    applies to `LayoutLine.segments` only): they are drawn sequentially in
+   *    logical order under a single ctx.direction, so mixed-direction cell
+   *    content does not reorder. docx instead models tabs as inline segments
+   *    classified Bidi_Class S — the shape a fix should take.
+   *  - Start ('l') / 'dec' tabs never populate this slot; they advance the
+   *    layout pen inline and the gap is not rendered. */
   tabStop?: {
-    /** Tab stop position in px from the left edge of the text area (bx + lPad + tabStop.px = canvas X) */
+    /** Stop position in px from the LEADING text-inset edge (logical,
+     *  §21.1.2.1): canvas X = bx + lPad + px under LTR, bx + bw − rPad − px
+     *  under an RTL base. */
     px: number;
     algn: string;
     segments: LayoutSegment[];
@@ -3396,7 +3411,9 @@ export function renderTextBody(
       // RTL cell on the wrong side (issue #831). This mirrors the docx fix (#830 /
       // #835: `layoutBidiTabStops` / `nextTabStopRtl` resolve stops against the
       // leading text margin in the reading frame). DrawingML tabs carry no leader,
-      // so — unlike docx — there is nothing to paint across the gap.
+      // so — unlike docx — there is nothing to paint across the gap. Known model
+      // limits (ONE cell per line; cell contents bypass the UAX#9 reorder): see
+      // the LayoutLine.tabStop doc — follow-up #916.
       let tabPenX: number;
       if (baseRtl) {
         const tabAbsX = bx + bw - rPad - line.tabStop.px;

--- a/packages/pptx/src/rtl-tab-stops.test.ts
+++ b/packages/pptx/src/rtl-tab-stops.test.ts
@@ -179,7 +179,31 @@ describe('pptx RTL tab stops resolve in the reading frame (issue #831, mirrors d
     expect(cell.inShapeX).toBeCloseTo(RTL_STOP_X, 6);
   });
 
-  // (5) REGRESSION GUARD — the LTR path is byte-identical: an LTR right tab still
+  // (5) A start ('l') tab opens NO cell — it advances the PEN inline (the gap is
+  //     not rendered; pre-existing model, both directions). Under an RTL base the
+  //     advance must live in the READING frame (distance from the leading indent,
+  //     = marR), like the stop selection: mixing frames (selection from marR,
+  //     advance from marL) overshoots the pen when marR > marL and a later stop
+  //     becomes unreachable. Stops: start@100px, end@140px; marR=50px; 'A'=20px.
+  //     Reading frame: pen 50→(start tab)→100, +A→120 → the end stop at 140 is
+  //     still ahead ⇒ '\t12' opens the cell, trailing edge on 600−140=460.
+  //     Mixed-frame (the bug): lineW=100−marL(0)=100, +A→120 → selection pen
+  //     50+120=170 > 140 ⇒ no stop ⇒ the tab degrades to a space (no cell).
+  it('advances a start tab in the reading frame so a later end stop stays reachable', () => {
+    const stops: TabStop[] = [
+      { pos: 100 * 12700, algn: 'l' },
+      { pos: 140 * 12700, algn: 'r' },
+    ];
+    const { runs } = render(
+      bodyWithTab(stops, [run(`\tA\t${CELL}`)], { rtl: true, marR: 50 * 12700 }),
+      BOX_W,
+    );
+    const cell = runs.find((r) => r.text === CELL);
+    expect(cell, 'end-stop cell exists (start-tab advance did not overshoot)').toBeTruthy();
+    expect(cell!.inShapeX).toBeCloseTo(BOX_W - 140, 6); // 460
+  });
+
+  // (6) REGRESSION GUARD — the LTR path is byte-identical: an LTR right tab still
   //     anchors at the LTR stop with the cell's RIGHT edge on it (x = 400 − 40).
   it('leaves the LTR right-tab path unchanged (cell right edge on the LTR stop)', () => {
     const { texts, runs } = render(

--- a/packages/pptx/src/rtl-tab-stops.test.ts
+++ b/packages/pptx/src/rtl-tab-stops.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody } from './renderer.js';
+import type { TextBody, Paragraph } from './types';
+import type { TextRunData, TabStop } from '@silurus/ooxml-core';
+
+// ECMA-376 §21.1.2.2.7 (a:pPr@rtl) + §21.1.2.1.x (a:tabLst / a:tab @pos @algn) +
+// UAX#9 (bidi reordering) — a right-/centre-aligned tab stop in a RIGHT-TO-LEFT
+// paragraph must resolve in the RTL READING FRAME, not the LTR absolute one.
+//
+// The bug (issue #831, latent — no RTL+tabLst fixture shipped): the tab-stop
+// draw path anchored the stop at `bx + lPad + pos` (LTR: measured LEFTWARD from
+// the LEFT text-inset edge) and placed the trailing cell with LTR math
+// (`tabAbsX − totalTabW` for @algn="r"). Under an RTL base a tab advances the pen
+// in READING order — from the LEADING (right) inset edge, moving LEFT — so the
+// stop sits at `(bx + bw − rIns) − pos` and the cell mirrors: an @algn="r" (end)
+// cell puts its TRAILING (left) edge on the stop. The LTR path dropped the cell
+// on the wrong visual side. This mirrors the docx fix (#830 / #835:
+// `layoutBidiTabStops` / `nextTabStopRtl`, resolving stops against the leading
+// text margin in the reading frame). DrawingML tabs carry no leader, so unlike
+// docx there is nothing to paint across the gap.
+//
+// The mock ctx measures every glyph at FONT_PX (no contextual collapse here — we
+// use plain Latin/digits), so widths are exact and the cell X is deterministic.
+
+const FONT_PX = 20;
+const SCALE = 1 / 12700; // emuToPx(emu, SCALE) = emu·SCALE; PT_TO_EMU=12700 ⇒ 1pt → 1px
+
+function mockCtx(): {
+  ctx: CanvasRenderingContext2D;
+  texts: { text: string; x: number; direction: CanvasDirection }[];
+} {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  let fillStyle = '';
+  let direction: CanvasDirection = 'ltr';
+  const px = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const texts: { text: string; x: number; direction: CanvasDirection }[] = [];
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
+    get direction() { return direction; }, set direction(v: CanvasDirection) { direction = v; },
+    get letterSpacing() { return letterSpacing; }, set letterSpacing(v: string) { letterSpacing = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    fillText: (t: string, x: number) => texts.push({ text: t, x, direction }),
+    strokeText: () => {},
+    fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
+    translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
+    moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
+    setLineDash: () => {}, closePath: () => {}, arc: () => {},
+    strokeStyle: '#000', lineWidth: 1, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, texts };
+}
+
+function run(text: string, color = '000000'): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: FONT_PX, color, fontFamily: 'Serif',
+  } as TextRunData;
+}
+
+/** A paragraph carrying one tab stop at `tabPosEmu` EMU with alignment `algn`.
+ *  `rtl` sets `<a:pPr rtl="1">` and (mirroring the parser) flips the default
+ *  paragraph alignment l→r. The run text must contain a leading `\t` so layout
+ *  switches into tab-stop accumulation mode. */
+function bodyWithTab(
+  tabPosEmu: number,
+  algn: string,
+  runs: TextRunData[],
+  rtl: boolean,
+): TextBody {
+  const tabStops: TabStop[] = [{ pos: tabPosEmu, algn }];
+  const para: Paragraph = {
+    alignment: rtl ? 'r' : 'l',
+    marL: 0, marR: 0, indent: 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null, defItalic: null,
+    defFontFamily: null, tabStops, rtl, runs,
+  } as unknown as Paragraph;
+  return {
+    verticalAnchor: 't', paragraphs: [para], defaultFontSize: FONT_PX,
+    defaultBold: null, defaultItalic: null,
+    lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'square', vert: 'horz', autoFit: 'none',
+  } as unknown as TextBody;
+}
+
+type RunInfo = { text: string; inShapeX: number; w: number };
+
+function render(body: TextBody, boxW = 600): {
+  texts: { text: string; x: number; direction: CanvasDirection }[];
+  runs: RunInfo[];
+} {
+  const { ctx, texts } = mockCtx();
+  const runs: RunInfo[] = [];
+  renderTextBody(
+    ctx, body, 0, 0, boxW, 400, SCALE,
+    null, 0, false, false, '#000000', undefined,
+    { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+    (r) => runs.push({ text: r.text, inShapeX: r.inShapeX, w: r.w }),
+  );
+  return { texts, runs };
+}
+
+// Box 600px wide, no insets/margins. Tab stop 400px from the LEADING inset edge.
+// LTR leading edge = left = 0 ⇒ stop canvas X = 0 + 400 = 400.
+// RTL leading edge = right = boxW − rIns = 600 ⇒ stop canvas X = 600 − 400 = 200.
+const BOX_W = 600;
+const TAB_POS_PX = 400;
+const TAB_POS_EMU = TAB_POS_PX * 12700;
+const CELL = '12'; // 2 glyphs → 40px
+const CELL_W = [...CELL].length * FONT_PX;
+const LTR_STOP_X = TAB_POS_PX; // 400
+const RTL_STOP_X = BOX_W - TAB_POS_PX; // 200
+
+describe('pptx RTL tab stops resolve in the reading frame (issue #831, mirrors docx #830/#835)', () => {
+  // (1) @algn="r" (end) in an RTL paragraph: the cell's TRAILING (left) edge lands
+  //     ON the mirrored stop and the cell extends rightward. The LTR path put the
+  //     cell's RIGHT edge on the LTR stop (x = 400 − 40 = 360) — the wrong side.
+  it('places a right-aligned tab cell at the mirrored stop (trailing edge on the stop)', () => {
+    const { runs } = render(bodyWithTab(TAB_POS_EMU, 'r', [run(`\t${CELL}`)], true), BOX_W);
+    const cell = runs.find((r) => r.text === CELL)!;
+    expect(cell, 'cell run reported').toBeTruthy();
+    // RTL: trailing(left) edge on the stop ⇒ pen = stopX = 200.
+    expect(cell.inShapeX).toBeCloseTo(RTL_STOP_X, 6);
+    // Guard against the LTR-frame regression (360).
+    expect(cell.inShapeX).not.toBeCloseTo(LTR_STOP_X - CELL_W, 3);
+  });
+
+  // (2) @algn="ctr" in an RTL paragraph: the cell centres on the mirrored stop.
+  it('centres a centre-aligned tab cell on the mirrored stop', () => {
+    const { runs } = render(bodyWithTab(TAB_POS_EMU, 'ctr', [run(`\t${CELL}`)], true), BOX_W);
+    const cell = runs.find((r) => r.text === CELL)!;
+    expect(cell.inShapeX).toBeCloseTo(RTL_STOP_X - CELL_W / 2, 6); // 200 − 20 = 180
+  });
+
+  // (3) RTL cell glyphs are painted with ctx.direction = 'rtl' so bidi content in
+  //     the cell shapes in reading order (textAlign stays 'left', so the pen X is
+  //     unchanged — only glyph shaping/joining differs).
+  it('draws the RTL tab cell with ctx.direction = rtl', () => {
+    const { texts } = render(bodyWithTab(TAB_POS_EMU, 'r', [run(`\t${CELL}`)], true), BOX_W);
+    const cellDraw = texts.find((t) => t.text === CELL)!;
+    expect(cellDraw.direction).toBe('rtl');
+  });
+
+  // (4) REGRESSION GUARD — the LTR path is byte-identical: an LTR right tab still
+  //     anchors at the LTR stop with the cell's RIGHT edge on it (x = 400 − 40).
+  it('leaves the LTR right-tab path unchanged (cell right edge on the LTR stop)', () => {
+    const { texts, runs } = render(bodyWithTab(TAB_POS_EMU, 'r', [run(`\t${CELL}`)], false), BOX_W);
+    const cell = runs.find((r) => r.text === CELL)!;
+    expect(cell.inShapeX).toBeCloseTo(LTR_STOP_X - CELL_W, 6); // 360
+    const cellDraw = texts.find((t) => t.text === CELL)!;
+    expect(cellDraw.direction).toBe('ltr');
+  });
+});

--- a/packages/pptx/src/rtl-tab-stops.test.ts
+++ b/packages/pptx/src/rtl-tab-stops.test.ts
@@ -203,7 +203,21 @@ describe('pptx RTL tab stops resolve in the reading frame (issue #831, mirrors d
     expect(cell!.inShapeX).toBeCloseTo(BOX_W - 140, 6); // 460
   });
 
-  // (6) REGRESSION GUARD — the LTR path is byte-identical: an LTR right tab still
+  // (6) A stop past the TRAILING (left) text edge pins the cell at that edge —
+  //     the docx layoutBidiTabStops clamp (#835: Word never pushes the cell off
+  //     the text area). Unclamped, the mirrored stop 600−700 = −100 would draw
+  //     the cell at a NEGATIVE x, outside the shape.
+  it('pins the cell at the trailing text edge when the stop overflows the text area', () => {
+    const { runs } = render(
+      bodyWithTab([{ pos: 700 * 12700, algn: 'r' }], [run(`\t${CELL}`)], { rtl: true }),
+      BOX_W,
+    );
+    const cell = runs.find((r) => r.text === CELL)!;
+    expect(cell, 'cell run reported').toBeTruthy();
+    expect(cell.inShapeX).toBeCloseTo(0, 6); // bx + lPad = 0 — never negative
+  });
+
+  // (7) REGRESSION GUARD — the LTR path is byte-identical: an LTR right tab still
   //     anchors at the LTR stop with the cell's RIGHT edge on it (x = 400 − 40).
   it('leaves the LTR right-tab path unchanged (cell right edge on the LTR stop)', () => {
     const { texts, runs } = render(

--- a/packages/pptx/src/rtl-tab-stops.test.ts
+++ b/packages/pptx/src/rtl-tab-stops.test.ts
@@ -68,20 +68,25 @@ function run(text: string, color = '000000'): TextRunData {
   } as TextRunData;
 }
 
-/** A paragraph carrying one tab stop at `tabPosEmu` EMU with alignment `algn`.
- *  `rtl` sets `<a:pPr rtl="1">` and (mirroring the parser) flips the default
- *  paragraph alignment l→r. The run text must contain a leading `\t` so layout
- *  switches into tab-stop accumulation mode. */
+/** A paragraph carrying `tabStops`. The run text must contain a `\t` so layout
+ *  switches into tab-stop accumulation mode.
+ *
+ *  `alignment` follows the PARSER's resolution order (parser/src/text.rs:617):
+ *  explicit `pPr@algn` → inherited body/layout/master default (not modelled
+ *  here) → fallback `"r"` when `rtl="1"`, else `"l"`. Pass `opts.algn` to model
+ *  an EXPLICIT paragraph alignment; omit it for the parser fallback. Tab-stop
+ *  mirroring must follow the BASE DIRECTION (`rtl`), never the visual
+ *  alignment. `opts.marR` (EMU) is the paragraph's logical-leading (physical
+ *  RIGHT) margin under an RTL base. */
 function bodyWithTab(
-  tabPosEmu: number,
-  algn: string,
+  tabStops: TabStop[],
   runs: TextRunData[],
-  rtl: boolean,
+  opts: { rtl?: boolean; algn?: string; marR?: number } = {},
 ): TextBody {
-  const tabStops: TabStop[] = [{ pos: tabPosEmu, algn }];
+  const rtl = opts.rtl ?? false;
   const para: Paragraph = {
-    alignment: rtl ? 'r' : 'l',
-    marL: 0, marR: 0, indent: 0,
+    alignment: opts.algn ?? (rtl ? 'r' : 'l'),
+    marL: 0, marR: opts.marR ?? 0, indent: 0,
     spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
     bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null, defItalic: null,
     defFontFamily: null, tabStops, rtl, runs,
@@ -127,7 +132,10 @@ describe('pptx RTL tab stops resolve in the reading frame (issue #831, mirrors d
   //     ON the mirrored stop and the cell extends rightward. The LTR path put the
   //     cell's RIGHT edge on the LTR stop (x = 400 − 40 = 360) — the wrong side.
   it('places a right-aligned tab cell at the mirrored stop (trailing edge on the stop)', () => {
-    const { runs } = render(bodyWithTab(TAB_POS_EMU, 'r', [run(`\t${CELL}`)], true), BOX_W);
+    const { runs } = render(
+      bodyWithTab([{ pos: TAB_POS_EMU, algn: 'r' }], [run(`\t${CELL}`)], { rtl: true }),
+      BOX_W,
+    );
     const cell = runs.find((r) => r.text === CELL)!;
     expect(cell, 'cell run reported').toBeTruthy();
     // RTL: trailing(left) edge on the stop ⇒ pen = stopX = 200.
@@ -138,7 +146,10 @@ describe('pptx RTL tab stops resolve in the reading frame (issue #831, mirrors d
 
   // (2) @algn="ctr" in an RTL paragraph: the cell centres on the mirrored stop.
   it('centres a centre-aligned tab cell on the mirrored stop', () => {
-    const { runs } = render(bodyWithTab(TAB_POS_EMU, 'ctr', [run(`\t${CELL}`)], true), BOX_W);
+    const { runs } = render(
+      bodyWithTab([{ pos: TAB_POS_EMU, algn: 'ctr' }], [run(`\t${CELL}`)], { rtl: true }),
+      BOX_W,
+    );
     const cell = runs.find((r) => r.text === CELL)!;
     expect(cell.inShapeX).toBeCloseTo(RTL_STOP_X - CELL_W / 2, 6); // 200 − 20 = 180
   });
@@ -147,15 +158,34 @@ describe('pptx RTL tab stops resolve in the reading frame (issue #831, mirrors d
   //     the cell shapes in reading order (textAlign stays 'left', so the pen X is
   //     unchanged — only glyph shaping/joining differs).
   it('draws the RTL tab cell with ctx.direction = rtl', () => {
-    const { texts } = render(bodyWithTab(TAB_POS_EMU, 'r', [run(`\t${CELL}`)], true), BOX_W);
+    const { texts } = render(
+      bodyWithTab([{ pos: TAB_POS_EMU, algn: 'r' }], [run(`\t${CELL}`)], { rtl: true }),
+      BOX_W,
+    );
     const cellDraw = texts.find((t) => t.text === CELL)!;
     expect(cellDraw.direction).toBe('rtl');
   });
 
-  // (4) REGRESSION GUARD — the LTR path is byte-identical: an LTR right tab still
+  // (4) An EXPLICIT `pPr@algn="l"` on an rtl="1" paragraph (the parser resolution
+  //     keeps the explicit value; the r-fallback applies only when algn is absent)
+  //     must NOT turn off the mirroring: the stop frame follows the BASE
+  //     DIRECTION, not the visual alignment.
+  it('mirrors the stop under rtl even when the paragraph alignment is explicitly "l"', () => {
+    const { runs } = render(
+      bodyWithTab([{ pos: TAB_POS_EMU, algn: 'r' }], [run(`\t${CELL}`)], { rtl: true, algn: 'l' }),
+      BOX_W,
+    );
+    const cell = runs.find((r) => r.text === CELL)!;
+    expect(cell.inShapeX).toBeCloseTo(RTL_STOP_X, 6);
+  });
+
+  // (5) REGRESSION GUARD — the LTR path is byte-identical: an LTR right tab still
   //     anchors at the LTR stop with the cell's RIGHT edge on it (x = 400 − 40).
   it('leaves the LTR right-tab path unchanged (cell right edge on the LTR stop)', () => {
-    const { texts, runs } = render(bodyWithTab(TAB_POS_EMU, 'r', [run(`\t${CELL}`)], false), BOX_W);
+    const { texts, runs } = render(
+      bodyWithTab([{ pos: TAB_POS_EMU, algn: 'r' }], [run(`\t${CELL}`)]),
+      BOX_W,
+    );
     const cell = runs.find((r) => r.text === CELL)!;
     expect(cell.inShapeX).toBeCloseTo(LTR_STOP_X - CELL_W, 6); // 360
     const cellDraw = texts.find((t) => t.text === CELL)!;


### PR DESCRIPTION
## Problem (issue #831)

The pptx renderer resolved `<a:tabLst>` tab stops in an **LTR absolute frame**: the stop was anchored at `bx + lPad + pos` (leftward from the left text-inset edge), and a right/centre-aligned tab cell was placed with LTR math (`tabAbsX − totalTabW`), bypassing bidi reorder. In a `<a:pPr rtl="1">` paragraph a tab advances the pen in **reading order** — from the leading (right) inset edge, moving left — so the stop mirrors and the trailing cell flips visual side. A right/centre tab cell (a TOC page number, a footer field, …) landed on the **wrong side**.

Latent today (no RTL + `tabLst` fixture ships). Same class of bug docx carried before #830 / #835.

## Fix (ECMA-376 §21.1.2.1.x + §21.1.2.2.7 + UAX#9)

Gated on the paragraph base direction — **the LTR path is byte-identical**:

- **Draw pass** (`renderTextBody`): under `baseRtl`, anchor the stop at the right inset edge (`bx + bw − rPad − pos`) and mirror the alignment **logically** — physical `r` (= logical *end*) puts the cell's trailing (left) edge on the stop; `ctr` centres. (Only `r`/`ctr` stops open a tab cell — `layoutParagraph` gates on those two.) A stop past the trailing (left) text edge **pins the cell at that edge** (the docx `layoutBidiTabStops` clamp — never drawn off-shape). The cell is drawn with `ctx.direction = 'rtl'` (`textAlign` stays `left`, so the pen X is unchanged — only Arabic joining / digit shaping differ), reset after.
- **Stop selection + inline advance** (`layoutParagraph`): the pen is measured from the leading edge in reading order (leading indent = `marR` under RTL, `marL` under LTR), for both the "first stop past the pen" selection **and** the start-tab (`l`, and `dec`-treated-as-start) inline advance — one consistent reading frame.

## docx correspondence — same semantics, implemented locally

This mirrors the semantics of docx **#830 / #835** (`layoutBidiTabStops` / `nextTabStopRtl`: resolve stops against the leading text margin in the RTL reading frame; a right/`end` cell's trailing edge lands on the stop; overflow pins at the trailing margin).

The docx code was **not** extracted to a shared `core` helper:

- docx's model is an **inline multi-tab segment sequence** walked through the UAX#9 *S*-class reorder in `computeLineVisualOrder`, and it carries dot/underscore **leaders**.
- pptx has a **separate, single right/centre tab-cell group** and DrawingML tabs have **no leader** concept.

Feeding pptx's simpler model through the docx whole-line walk would be a large, unnatural restructuring for no shared surface. Per AGENTS.md ("avoid false abstraction; renderer logic tightly coupled to a package's layout model may stay local") the same reading-frame semantics are implemented in the pptx renderer.

## Review follow-ups (independent review, adjudicated)

- **[high] `algn="l"` consistency**: the draw-side RTL `l` branch was unreachable (`layoutParagraph` opens a cell only for `r`/`ctr`) — dead code removed. The inline start-tab advance mixed frames under RTL (selection from `marR`, advance from `marL`), so with `marR > marL` the pen overshot and a later stop became unreachable; the advance now uses the same reading frame (`pos − leadIndent`; LTR byte-identical). `dec` is explicitly documented as treated-as-start (decimal alignment unimplemented). RTL start tabs are **not** given a mirrored rendered gap — the gap is not rendered in LTR either (pre-existing inline-advance model, #916).
- **[medium] Overflow clamp**: mirrored stops with `pos` past the text width pinned at the trailing (left) text edge, matching docx #835; test pins x ≥ 0.
- **[low] Test helper**: alignment now follows the parser's resolution order (explicit `pPr@algn` → fallback `r` only when `rtl="1"` and no algn); a case pins that an explicit `algn="l"` under `rtl="1"` does not disable mirroring.
- **[low] `core` doc comment**: `TabStop.pos` documented as measured from the **leading** text-inset edge (logical, §21.1.2.1) — comment-only.

## Known limitations (pre-existing, explicitly out of scope — follow-up #916)

These predate this PR and affect LTR and RTL alike; they are documented at `LayoutLine.tabStop` and tracked in #916:

1. **One tab cell per line**: a second right/centre tab on the same line re-assigns the single `LayoutLine.tabStop` slot and drops the first cell's collected text.
2. **No UAX#9 reorder inside a cell**: cell segments draw sequentially in logical order under one `ctx.direction`; mixed-direction cell content does not reorder (docx classifies tabs Bidi_Class S and reorders per cell).
3. **Start (`l`) / `dec` tabs advance inline without rendering the gap** (and `dec` has no decimal alignment).

## Tests (TDD, Red → Green)

`packages/pptx/src/rtl-tab-stops.test.ts` constructs the paragraph model — the convention docx #830/#835 used, faithful to the parser's `rtl` + `tabLst` output (`parser/src/text.rs:604/707`) — and drives `renderTextBody` with a metric-stub ctx:

- right-aligned cell mirrors to the stop (trailing edge on it), **not** the LTR position — was `360`, now `200`;
- centre-aligned cell centres on the mirrored stop (`180`);
- RTL cell painted with `ctx.direction = 'rtl'`;
- explicit `algn="l"` + `rtl="1"` still mirrors (base direction, not visual alignment, drives the frame);
- start-tab advance stays in the reading frame (a later end stop remains reachable; red = the tab degraded to a space);
- overflowing stop pins at the trailing text edge (red = cell at x −100, off-shape);
- **regression guard**: LTR right-tab unchanged (cell right edge on the LTR stop `360`, direction `ltr`).

Verification:
- every fix commit's test was confirmed Red on the prior state → Green after;
- full pptx suite: **361 passing** (58 files);
- docx RTL tab tests + full core suite: **1527 passing** (85 files) — the `core` change is a doc comment only;
- typecheck: clean except the expected missing generated-WASM module errors (gitignored `packages/*/src/wasm/`, not built in this worktree).

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)
