### PR TITLE
refactor(xlsx): consolidate image cache onto shared getCachedBitmapByPath

### DIFF
--- a/packages/core/src/image/bitmap-image-by-path.test.ts
+++ b/packages/core/src/image/bitmap-image-by-path.test.ts
@@ -3,6 +3,7 @@ import {
   getCachedBitmapByPath,
   peekCachedBitmapByPath,
   dropBitmapCacheByPath,
+  acquireBitmapCacheLease,
 } from './bitmap-image-by-path';
 
 /** Build a minimal standard (non-placeable) WMF that draws one polyline, so the
@@ -189,5 +190,134 @@ describe('getCachedBitmapByPath', () => {
     expect(closes.length).toBe(2);
     await getCachedBitmapByPath('word/media/drop-a.png', 'image/png', fetchImage);
     expect(fetchImage).toHaveBeenCalledTimes(3); // cache cleared → fresh decode
+  });
+});
+
+/**
+ * Render-pass lease (`acquireBitmapCacheLease`): a renderer resolves EVERY image
+ * a page/sheet/slide references and then draws from those references. Without a
+ * lease, resolving more images than the LRU cap in one pass evicts — and
+ * GPU-closes — bitmaps the pass still holds, so the draw would paint a closed
+ * bitmap. While a lease is active, evictions/drops still remove the cache entry
+ * (size stays bounded) but the close is deferred to the LAST release.
+ */
+describe('acquireBitmapCacheLease (render-pass liveness)', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async (_blob: Blob) => ({ width: 1, height: 1, close: () => {} }) as unknown as ImageBitmap),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** Flush the close-through-promise microtasks. */
+  const flush = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  it('defers an LRU-eviction close past the cap until the lease is released', async () => {
+    const closed: string[] = [];
+    vi.stubGlobal('createImageBitmap', vi.fn(async (blob: Blob) => {
+      const tag = new Uint8Array(await blob.arrayBuffer())[0];
+      return { width: 1, height: 1, close: () => closed.push(`b${tag}`) } as unknown as ImageBitmap;
+    }));
+    const fetchImage = vi.fn(async (path: string, mime: string) => {
+      // Tag the blob with the path's index so each bitmap is identifiable.
+      const i = Number(/lease-(\d+)/.exec(path)?.[1] ?? 0);
+      return new Blob([new Uint8Array([i % 256])], { type: mime });
+    });
+
+    const release = acquireBitmapCacheLease(fetchImage);
+    // Resolve one more than the cap (257) in a single leased pass, the way a
+    // render pass over a 257-image document would.
+    for (let i = 0; i <= 256; i++) {
+      await getCachedBitmapByPath(`word/media/lease-${i}.png`, 'image/png', fetchImage);
+    }
+    await flush();
+    // The eviction happened (entry removed → a re-resolve would re-fetch), but
+    // the GPU close is deferred: the pass's reference is still drawable.
+    expect(closed).toEqual([]);
+
+    release();
+    await flush();
+    expect(closed).toEqual(['b0']); // the evicted oldest closes at release
+  });
+
+  it('defers a dropBitmapCacheByPath close while leased (drop racing an in-flight render)', async () => {
+    const closes: number[] = [];
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async (_blob: Blob) => ({ width: 1, height: 1, close: () => closes.push(1) }) as unknown as ImageBitmap),
+    );
+    const fetchImage = vi.fn(async (_p: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }));
+
+    const release = acquireBitmapCacheLease(fetchImage);
+    await getCachedBitmapByPath('word/media/leased-drop-a.png', 'image/png', fetchImage);
+    await getCachedBitmapByPath('word/media/leased-drop-b.png', 'image/png', fetchImage);
+    dropBitmapCacheByPath(fetchImage); // e.g. destroy()/re-parse mid-render
+    await flush();
+    expect(closes.length).toBe(0); // still drawable for the in-flight pass
+    // The cache itself was forgotten immediately: a re-resolve re-decodes.
+    await getCachedBitmapByPath('word/media/leased-drop-a.png', 'image/png', fetchImage);
+    expect(fetchImage).toHaveBeenCalledTimes(3);
+
+    release();
+    await flush();
+    expect(closes.length).toBe(2); // the dropped bitmaps close at release
+  });
+
+  it('nested leases (concurrent passes): deferred closes run at the LAST release only', async () => {
+    const closes: number[] = [];
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async (_blob: Blob) => ({ width: 1, height: 1, close: () => closes.push(1) }) as unknown as ImageBitmap),
+    );
+    const fetchImage = vi.fn(async (_p: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }));
+
+    const releaseA = acquireBitmapCacheLease(fetchImage);
+    const releaseB = acquireBitmapCacheLease(fetchImage);
+    await getCachedBitmapByPath('word/media/nested.png', 'image/png', fetchImage);
+    dropBitmapCacheByPath(fetchImage);
+    releaseA();
+    await flush();
+    expect(closes.length).toBe(0); // pass B still holds the document
+    releaseB();
+    await flush();
+    expect(closes.length).toBe(1);
+  });
+
+  it('release is idempotent — a double release neither double-closes nor steals a sibling lease', async () => {
+    const closes: number[] = [];
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async (_blob: Blob) => ({ width: 1, height: 1, close: () => closes.push(1) }) as unknown as ImageBitmap),
+    );
+    const fetchImage = vi.fn(async (_p: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }));
+
+    const releaseA = acquireBitmapCacheLease(fetchImage);
+    const releaseB = acquireBitmapCacheLease(fetchImage);
+    await getCachedBitmapByPath('word/media/idem.png', 'image/png', fetchImage);
+    dropBitmapCacheByPath(fetchImage);
+    releaseA();
+    releaseA(); // double release must NOT decrement B's hold
+    await flush();
+    expect(closes.length).toBe(0);
+    releaseB();
+    await flush();
+    expect(closes.length).toBe(1);
+  });
+
+  it('with no lease active, eviction and drop close immediately (unchanged baseline)', async () => {
+    const closes: number[] = [];
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async (_blob: Blob) => ({ width: 1, height: 1, close: () => closes.push(1) }) as unknown as ImageBitmap),
+    );
+    const fetchImage = vi.fn(async (_p: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }));
+    await getCachedBitmapByPath('word/media/unleased.png', 'image/png', fetchImage);
+    dropBitmapCacheByPath(fetchImage);
+    await flush();
+    expect(closes.length).toBe(1);
   });
 });

--- a/packages/core/src/image/bitmap-image-by-path.ts
+++ b/packages/core/src/image/bitmap-image-by-path.ts
@@ -64,6 +64,86 @@ function bitmapCacheFor(fetchImage: FetchImage): Map<string, BitmapCacheEntry> {
   return cache;
 }
 
+// ── Render-pass leases ────────────────────────────────────────────────────────
+// The renderers resolve every image a page/slide/sheet references through this
+// cache and then DRAW from those references — either synchronously from a
+// non-owning lookup map (docx `preloadImages`, xlsx `prefetchImages`) or right
+// after a per-element await (pptx). The LRU cap, however, is oblivious to that
+// pass: resolving MORE THAN the cap's worth of images in one pass (or a
+// concurrent pass on the same document) evicts — and GPU-closes — bitmaps the
+// in-flight pass still holds, so the draw would paint a closed bitmap.
+//
+// A lease makes the pass's liveness need explicit and structural: while at least
+// one lease is active for a document's `fetchImage`, any close this module (or a
+// sibling per-document cache, via {@link deferBitmapCloseWhileLeased}) would
+// perform — LRU eviction or an explicit drop — is DEFERRED and executed when the
+// last lease is released. Eviction still removes the cache ENTRY immediately
+// (the cache stays size-bounded and the next resolve re-decodes); only the GPU
+// release is deferred, so every reference a leased pass obtained stays drawable
+// for the duration of the pass. Callers MUST release in a `finally` — an
+// unreleased lease keeps its deferred bitmaps alive until the document itself is
+// reclaimed. The SVG cache needs no lease: its eviction revokes an object URL,
+// which does not invalidate an already-decoded HTMLImageElement.
+interface BitmapCacheLeaseState {
+  /** Active (unreleased) leases for this document. */
+  count: number;
+  /** Closes deferred while leased; executed at the last release. */
+  deferred: Array<Promise<ImageBitmap | null>>;
+}
+
+const leasesByFetch = new WeakMap<FetchImage, BitmapCacheLeaseState>();
+
+/**
+ * Hold every decoded bitmap of one document (keyed by `fetchImage`) alive for
+ * the duration of a render pass: while the returned release function has not
+ * been called, LRU evictions and cache drops defer their GPU `.close()` until
+ * the last outstanding lease is released. Acquire before resolving the pass's
+ * images and release in a `finally` after the draw that uses them. Leases nest
+ * (concurrent passes over the same document each take one); the release
+ * function is idempotent.
+ */
+export function acquireBitmapCacheLease(fetchImage: FetchImage): () => void {
+  let state = leasesByFetch.get(fetchImage);
+  if (!state) {
+    state = { count: 0, deferred: [] };
+    leasesByFetch.set(fetchImage, state);
+  }
+  const s = state;
+  s.count++;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    s.count--;
+    if (s.count > 0) return;
+    // Last lease out: run the deferred closes, through each promise (never a raw
+    // bitmap reference) so a still-in-flight decode closes only once it resolves.
+    for (const p of s.deferred) p.then((b) => b?.close()).catch(() => {});
+    s.deferred = [];
+    leasesByFetch.delete(fetchImage);
+  };
+}
+
+/**
+ * Close a document-owned bitmap through its decode promise — or, when a render
+ * pass currently holds a lease on the document (see
+ * {@link acquireBitmapCacheLease}), defer the close to the last lease release so
+ * the pass never draws a closed bitmap. Shared by this module's LRU eviction and
+ * drop paths and by the sibling per-document duotone cache (whose drop is the
+ * only close it performs).
+ */
+export function deferBitmapCloseWhileLeased(
+  fetchImage: FetchImage,
+  promise: Promise<ImageBitmap | null>,
+): void {
+  const lease = leasesByFetch.get(fetchImage);
+  if (lease && lease.count > 0) {
+    lease.deferred.push(promise);
+    return;
+  }
+  promise.then((b) => b?.close()).catch(() => {});
+}
+
 /** Options for {@link getCachedBitmapByPath}. `widthPt`/`heightPt` are the
  *  picture's intended draw size in points and only affect metafile raster
  *  sharpness (a raster blip ignores them), so the path alone keys the cache.
@@ -136,7 +216,10 @@ export function getCachedBitmapByPath(
     const oldestKey = cache.keys().next().value as string;
     const oldest = cache.get(oldestKey);
     cache.delete(oldestKey);
-    oldest?.promise.then((b) => b?.close()).catch(() => {});
+    // Close through the promise — deferred while a render-pass lease is active,
+    // so an in-flight pass that already recorded this bitmap never draws it
+    // closed (the entry is gone either way; the next resolve re-decodes).
+    if (oldest) deferBitmapCloseWhileLeased(fetchImage, oldest.promise);
   }
   return promise;
 }
@@ -159,12 +242,15 @@ export function peekCachedBitmapByPath(
  * Close every decoded bitmap for one document's `fetchImage` and forget the
  * document. Call from the owning viewer's `destroy()` so GPU-backed ImageBitmaps
  * are released promptly rather than waiting for GC. A no-op when the document
- * decoded no raster blips.
+ * decoded no raster blips. When a render pass currently holds a lease (see
+ * {@link acquireBitmapCacheLease} — e.g. a destroy or re-parse racing an
+ * in-flight render), the cache is forgotten immediately but the GPU closes are
+ * deferred to the last lease release, so the pass never draws a closed bitmap.
  */
 export function dropBitmapCacheByPath(fetchImage: FetchImage): void {
   const cache = bitmapCacheByFetch.get(fetchImage);
   if (!cache) return;
-  for (const entry of cache.values()) entry.promise.then((b) => b?.close()).catch(() => {});
+  for (const entry of cache.values()) deferBitmapCloseWhileLeased(fetchImage, entry.promise);
   cache.clear();
   bitmapCacheByFetch.delete(fetchImage);
 }

--- a/packages/core/src/image/bitmap-image-by-path.ts
+++ b/packages/core/src/image/bitmap-image-by-path.ts
@@ -93,6 +93,21 @@ interface BitmapCacheLeaseState {
 
 const leasesByFetch = new WeakMap<FetchImage, BitmapCacheLeaseState>();
 
+// Every GPU close this module (and the sibling per-document caches routing
+// through {@link deferBitmapCloseWhileLeased}) performs is funneled through
+// here. The WeakSet deduplicates closes PER BITMAP: two cache layers can
+// resolve to the same bitmap (a second-layer pass-through entry still in its
+// in-flight window when both caches are dropped resolves to the base bitmap
+// the base cache also closes), and the dedup removes any reliance on
+// `ImageBitmap.close()` idempotence across engines.
+const closedBitmaps = new WeakSet<ImageBitmap>();
+
+function closeBitmapOnce(bmp: ImageBitmap | null | undefined): void {
+  if (!bmp || closedBitmaps.has(bmp)) return;
+  closedBitmaps.add(bmp);
+  bmp.close();
+}
+
 /**
  * Hold every decoded bitmap of one document (keyed by `fetchImage`) alive for
  * the duration of a render pass: while the returned release function has not
@@ -118,7 +133,7 @@ export function acquireBitmapCacheLease(fetchImage: FetchImage): () => void {
     if (s.count > 0) return;
     // Last lease out: run the deferred closes, through each promise (never a raw
     // bitmap reference) so a still-in-flight decode closes only once it resolves.
-    for (const p of s.deferred) p.then((b) => b?.close()).catch(() => {});
+    for (const p of s.deferred) p.then((b) => closeBitmapOnce(b)).catch(() => {});
     s.deferred = [];
     leasesByFetch.delete(fetchImage);
   };
@@ -129,8 +144,10 @@ export function acquireBitmapCacheLease(fetchImage: FetchImage): () => void {
  * pass currently holds a lease on the document (see
  * {@link acquireBitmapCacheLease}), defer the close to the last lease release so
  * the pass never draws a closed bitmap. Shared by this module's LRU eviction and
- * drop paths and by the sibling per-document duotone cache (whose drop is the
- * only close it performs).
+ * drop paths and by the sibling per-document caches (core duotone, docx
+ * clrChange) whose drops are the only closes they perform. Closes are
+ * deduplicated per bitmap (see {@link closeBitmapOnce}), so two layers that
+ * resolve to the same bitmap close it exactly once.
  */
 export function deferBitmapCloseWhileLeased(
   fetchImage: FetchImage,
@@ -141,7 +158,7 @@ export function deferBitmapCloseWhileLeased(
     lease.deferred.push(promise);
     return;
   }
-  promise.then((b) => b?.close()).catch(() => {});
+  promise.then((b) => closeBitmapOnce(b)).catch(() => {});
 }
 
 /** Options for {@link getCachedBitmapByPath}. `widthPt`/`heightPt` are the

--- a/packages/core/src/image/duotone-bitmap-by-path.test.ts
+++ b/packages/core/src/image/duotone-bitmap-by-path.test.ts
@@ -4,7 +4,11 @@ import {
   duotoneCacheKey,
   dropDuotoneBitmapCache,
 } from './duotone-bitmap-by-path';
-import { dropBitmapCacheByPath } from './bitmap-image-by-path';
+import {
+  getCachedBitmapByPath,
+  dropBitmapCacheByPath,
+  acquireBitmapCacheLease,
+} from './bitmap-image-by-path';
 import type { OffscreenFactory } from './duotone';
 
 /**
@@ -125,5 +129,84 @@ describe('getCachedDuotoneBitmapByPath', () => {
     expect(duotoneCacheKey('word/media/image1.png', { clr1: '000000', clr2: 'DAB6BA' })).toBe(
       'word/media/image1.png|duo:000000:DAB6BA',
     );
+  });
+
+  // ── Second-layer × base-eviction interaction ────────────────────────────────
+  // A PASS-THROUGH entry (the pixel pipeline was unavailable, so the recolour
+  // resolved to the base bitmap itself) must not outlive the base: the base LRU
+  // protects itself by removing the entry at eviction so the next resolve
+  // re-decodes, but a lingering second-layer entry would bypass that re-decode
+  // and keep serving the (now closed) base bitmap.
+  it('a pass-through entry never outlives the base: after base LRU eviction, a re-resolve returns a live bitmap', async () => {
+    // No offscreenFactory and no OffscreenCanvas in this env → applyDuotone
+    // returns the base unchanged (pass-through).
+    const made: Array<{ closed: boolean }> = [];
+    vi.stubGlobal('createImageBitmap', vi.fn(async () => {
+      const bmp = { width: 2, height: 2, closed: false, close(): void { this.closed = true; } };
+      made.push(bmp);
+      return bmp as unknown as ImageBitmap;
+    }));
+    const fetchImage = vi.fn(
+      async (_p: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }),
+    );
+    const duotone = { clr1: '000000', clr2: 'DAB6BA' };
+    const path = 'ppt/media/duo-passthrough-evict.png';
+
+    const first = await getCachedDuotoneBitmapByPath(path, 'image/png', duotone, fetchImage, {});
+    expect(first).toBe(made[0] as unknown as ImageBitmap); // pass-through: the base itself
+
+    // Evict the base entry with LRU pressure (256 more distinct paths, no lease
+    // held) — the base bitmap is closed.
+    for (let i = 0; i < 256; i++) {
+      await getCachedBitmapByPath(`ppt/media/duo-pressure-${i}.png`, 'image/png', fetchImage);
+    }
+    await new Promise((r) => setTimeout(r, 0));
+    expect(made[0].closed).toBe(true);
+
+    // The next render pass re-resolves the same (path, duotone): it must NOT be
+    // served the stale pass-through entry (a closed bitmap) — the base
+    // re-decodes and the pass-through re-derives from the live base.
+    const second = await getCachedDuotoneBitmapByPath(path, 'image/png', duotone, fetchImage, {});
+    expect(second).not.toBeNull();
+    expect((second as unknown as { closed: boolean }).closed).toBe(false);
+
+    dropDuotoneBitmapCache(fetchImage);
+    dropBitmapCacheByPath(fetchImage);
+  });
+
+  it('dropping BOTH caches around an in-flight pass-through closes the shared bitmap exactly once', async () => {
+    // A pass-through entry still in flight at drop time resolves to the base
+    // bitmap, so both the duotone drop and the base drop would target the SAME
+    // bitmap. The funneled close dedupe (closeBitmapOnce) must close it exactly
+    // once — whichever interleaving occurs — with no reliance on
+    // ImageBitmap.close() idempotence.
+    const closes: number[] = [];
+    vi.stubGlobal('createImageBitmap', vi.fn(async () => ({
+      width: 2,
+      height: 2,
+      close: () => closes.push(1),
+    }) as unknown as ImageBitmap));
+    const fetchImage = vi.fn(
+      async (_p: string, mime: string) => new Blob([new Uint8Array([1])], { type: mime }),
+    );
+    const duotone = { clr1: '000000', clr2: 'DAB6BA' };
+    const path = 'ppt/media/duo-double-close.png';
+
+    const release = acquireBitmapCacheLease(fetchImage);
+    // Settle the base first so the duotone wrapper reaches its second-layer
+    // entry creation promptly.
+    await getCachedBitmapByPath(path, 'image/png', fetchImage);
+    const p = getCachedDuotoneBitmapByPath(path, 'image/png', duotone, fetchImage, {});
+    // Nudge one microtask so the second-layer entry may exist (created after the
+    // base await) but its pass-through self-evict may not have run, then drop
+    // BOTH caches while leased.
+    await Promise.resolve();
+    dropDuotoneBitmapCache(fetchImage);
+    dropBitmapCacheByPath(fetchImage);
+    await p;
+    release();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(closes.length).toBe(1);
   });
 });

--- a/packages/core/src/image/duotone-bitmap-by-path.ts
+++ b/packages/core/src/image/duotone-bitmap-by-path.ts
@@ -19,7 +19,11 @@
 // so on destroy it must be closed (see `dropDuotoneBitmapCache`), the same
 // GPU-lifecycle discipline the base cache follows through its promise.
 
-import { getCachedBitmapByPath, type CachedBitmapOptions } from './bitmap-image-by-path';
+import {
+  getCachedBitmapByPath,
+  deferBitmapCloseWhileLeased,
+  type CachedBitmapOptions,
+} from './bitmap-image-by-path';
 import { applyDuotone, type Duotone, type OffscreenFactory } from './duotone';
 import { imageNaturalSize } from './crop';
 
@@ -114,11 +118,14 @@ export async function getCachedDuotoneBitmapByPath(
  * `dropBitmapCacheByPath`, but `ImageBitmap.close()` is idempotent, so closing
  * it a second time here is harmless. Closing through the promise (never a raw
  * reference) means a still-in-flight recolour is closed only once it resolves.
+ * While a render pass holds a lease on this document (`acquireBitmapCacheLease`),
+ * the closes are deferred to the last release — same contract as the base cache
+ * — so a drop racing an in-flight render never closes a bitmap mid-draw.
  */
 export function dropDuotoneBitmapCache(fetchImage: FetchImage): void {
   const cache = duotoneByFetch.get(fetchImage);
   if (!cache) return;
-  for (const p of cache.values()) p.then((b) => b?.close()).catch(() => {});
+  for (const p of cache.values()) deferBitmapCloseWhileLeased(fetchImage, p);
   cache.clear();
   duotoneByFetch.delete(fetchImage);
 }

--- a/packages/core/src/image/duotone-bitmap-by-path.ts
+++ b/packages/core/src/image/duotone-bitmap-by-path.ts
@@ -1,6 +1,6 @@
 // Second-layer cache for the DrawingML `<a:duotone>` recolour (ECMA-376
-// §20.1.8.23) of a raster/metafile blip, shared by the docx and pptx renderers
-// (xlsx keeps its own worksheet-scoped `loadedImages` map with the same keying).
+// §20.1.8.23) of a raster/metafile blip, shared by the docx, pptx and xlsx
+// renderers (xlsx routes through it since the #781 consolidation).
 //
 // The base, colour-FREE bitmap comes from the path-keyed
 // `getCachedBitmapByPath` — shared across every reference to a path and
@@ -100,6 +100,23 @@ export async function getCachedDuotoneBitmapByPath(
     })();
     // Don't poison the cache if the recolour pass rejects; let the next call retry.
     hit.catch(() => cache.delete(key));
+    // A PASS-THROUGH result (degenerate size, or the pixel pipeline was
+    // unavailable so `applyDuotone` returned the base unchanged) must not be
+    // memoized beyond its in-flight window: the resolved value IS the base
+    // bitmap, whose lifetime the BASE cache owns — the base LRU may evict and
+    // GPU-close it later, and a lingering second-layer entry would keep serving
+    // the closed bitmap (the base layer protects itself by removing the entry
+    // at eviction so the next resolve re-decodes; a stale second-layer hit
+    // would bypass that re-decode). Drop the entry once it resolves to the
+    // base: the next pass re-resolves through the base cache and always sees a
+    // live bitmap, while concurrent callers inside the in-flight window still
+    // dedupe on this promise (the base is live for them — their pass holds it).
+    // A fresh recolour raster stays memoized: it is owned ONLY by this cache.
+    void hit
+      .then((bmp) => {
+        if (bmp === base) cache.delete(key);
+      })
+      .catch(() => {});
     cache.set(key, hit);
   }
   return hit;
@@ -111,16 +128,18 @@ export async function getCachedDuotoneBitmapByPath(
  * `dropBitmapCacheByPath` (base bitmaps) so both caches release their GPU
  * backing promptly. A no-op when the document decoded no duotone picture.
  *
- * Almost every stored value is a fresh recolour raster owned ONLY by this cache,
- * so it must be closed here. The rare exception is a pass-through (the pixel
- * pipeline was unavailable, so `applyDuotone` returned the unchanged base
- * bitmap): that bitmap is also owned by the base cache and closed by
- * `dropBitmapCacheByPath`, but `ImageBitmap.close()` is idempotent, so closing
- * it a second time here is harmless. Closing through the promise (never a raw
- * reference) means a still-in-flight recolour is closed only once it resolves.
- * While a render pass holds a lease on this document (`acquireBitmapCacheLease`),
- * the closes are deferred to the last release — same contract as the base cache
- * — so a drop racing an in-flight render never closes a bitmap mid-draw.
+ * Every SETTLED entry here is a fresh recolour raster owned ONLY by this cache
+ * (a pass-through entry — one that resolved to the base bitmap — self-evicts on
+ * resolution; see getCachedDuotoneBitmapByPath), so it must be closed here. The
+ * one overlap left is an entry still IN FLIGHT at drop time that then resolves
+ * to the base: its close would target a bitmap the base cache also closes —
+ * `deferBitmapCloseWhileLeased` deduplicates closes per bitmap, so it closes
+ * exactly once with no reliance on `ImageBitmap.close()` idempotence. Closing
+ * through the promise (never a raw reference) means a still-in-flight recolour
+ * is closed only once it resolves. While a render pass holds a lease on this
+ * document (`acquireBitmapCacheLease`), the closes are deferred to the last
+ * release — same contract as the base cache — so a drop racing an in-flight
+ * render never closes a bitmap mid-draw.
  */
 export function dropDuotoneBitmapCache(fetchImage: FetchImage): void {
   const cache = duotoneByFetch.get(fetchImage);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,10 +125,17 @@ export { getCachedSvgImageByPath, dropSvgImageCache } from './image/svg-image-by
 // re-renders / page revisits instead of re-decoding every frame. `peek…` serves
 // the synchronous picture-bullet draw; `drop…` closes a document's bitmaps on
 // its viewer's `destroy()`.
+// `acquireBitmapCacheLease` pins a render pass's decoded bitmaps: while held,
+// LRU evictions / drops defer their GPU close to the last release, so a pass
+// resolving more images than the cap never draws a closed bitmap.
+// `deferBitmapCloseWhileLeased` is for sibling PER-DOCUMENT bitmap caches (e.g.
+// docx's a:clrChange recolour layer) so their drops honor the same lease.
 export {
   getCachedBitmapByPath,
   peekCachedBitmapByPath,
   dropBitmapCacheByPath,
+  acquireBitmapCacheLease,
+  deferBitmapCloseWhileLeased,
   type CachedBitmapOptions,
 } from './image/bitmap-image-by-path';
 // Shared WMF (Windows Metafile) player + the raster/metafile decoder all three

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -8,9 +8,15 @@
  * Single-document contract: the proxy issues one `parse` and then renders.
  */
 import init, { DocxArchive, reinit } from './wasm/docx_parser.js';
-import { decodeDataUrl, preloadGoogleFonts, WasmParserHost } from '@silurus/ooxml-core';
+import {
+  decodeDataUrl,
+  preloadGoogleFonts,
+  WasmParserHost,
+  dropBitmapCacheByPath,
+  dropSvgImageCache,
+} from '@silurus/ooxml-core';
 import type { DocxDocumentModel, PaginatedBodyElement } from './types';
-import { paginateDocument, renderDocumentToCanvas, physicalPageSizePt, type DocxTextRunInfo } from './renderer';
+import { paginateDocument, renderDocumentToCanvas, physicalPageSizePt, dropColorReplacedCache, type DocxTextRunInfo } from './renderer';
 import { buildBookmarkPageMap } from './bookmark-nav';
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
 import { loadEmbeddedFonts } from './embedded-fonts';
@@ -62,6 +68,16 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
       // Cached blobs belong to the previous document; serving them after a
       // re-parse would silently return the wrong file's image.
       imageCache.clear();
+      // A re-parse starts a fresh document: also drop the shared, per-`getImage`
+      // decoded caches (base raster, a:clrChange/duotone recolour, SVG object
+      // URLs), symmetric with DocxDocument.destroy(). The worker's `getImage`
+      // closure is a stable module-level identity, so without this a new document
+      // sharing a zip path (e.g. word/media/image1.png) would be served the
+      // previous file's decoded bitmap, and the GPU/URL handles would linger past
+      // the LRU cap. Symmetric across docx/pptx/xlsx render workers (issue #781).
+      dropBitmapCacheByPath(getImage);
+      dropColorReplacedCache(getImage);
+      dropSvgImageCache(getImage);
       const max =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -897,6 +897,19 @@ export async function decodeRaster(
     })();
     // Don't poison the cache if the recolor pass rejects; let the next call retry.
     hit.catch(() => cache.delete(key));
+    // A PASS-THROUGH result (duotone-only with a degenerate size or an
+    // unavailable pixel pipeline — `applyDuotone` returned the base unchanged)
+    // must not be memoized beyond its in-flight window: the resolved value IS
+    // the base bitmap, whose lifetime the shared base cache owns (its LRU may
+    // evict and GPU-close it later), and a lingering second-layer entry would
+    // keep serving the closed bitmap while bypassing the base layer's
+    // remove-on-evict → re-decode protection. Same rule as core's
+    // getCachedDuotoneBitmapByPath; a fresh recolour raster stays memoized.
+    void hit
+      .then((bmp) => {
+        if (bmp === base) cache.delete(key);
+      })
+      .catch(() => {});
     cache.set(key, hit);
   }
   return hit;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -39,6 +39,8 @@ import {
   isComplexScriptCodePoint,
   getCachedBitmapByPath,
   dropBitmapCacheByPath,
+  acquireBitmapCacheLease,
+  deferBitmapCloseWhileLeased,
   applyDuotone,
   imageNaturalSize,
   drawImageCropped,
@@ -655,12 +657,15 @@ function colorReplacedCacheFor(fetchImage: DocxFetchImage): Map<string, Promise<
  * forget the document. Call from `DocxDocument.destroy()` alongside
  * `dropBitmapCacheByPath` (base bitmaps) and `dropSvgImageCache` (SVG object
  * URLs) so all three per-document image caches release promptly. A no-op when no
- * clrChange image was decoded.
+ * clrChange image was decoded. While a render pass holds a lease on this
+ * document (core `acquireBitmapCacheLease`), the closes are deferred to the last
+ * release — the same contract as the shared base/duotone caches — so a drop
+ * racing an in-flight render never closes a bitmap mid-draw.
  */
 export function dropColorReplacedCache(fetchImage: DocxFetchImage): void {
   const cache = colorReplacedByFetch.get(fetchImage);
   if (!cache) return;
-  for (const p of cache.values()) p.then((b) => b.close()).catch(() => {});
+  for (const p of cache.values()) deferBitmapCloseWhileLeased(fetchImage, p);
   cache.clear();
   colorReplacedByFetch.delete(fetchImage);
 }
@@ -1124,6 +1129,31 @@ function drawParseErrorPlaceholder(
 }
 
 export async function renderDocumentToCanvas(
+  doc: DocxDocumentModel,
+  canvas: HTMLCanvasElement | OffscreenCanvas,
+  pageIndex: number,
+  opts: RenderDocumentOptions = {},
+): Promise<void> {
+  // Render-pass lease (core acquireBitmapCacheLease): `preloadImages` resolves
+  // EVERY image the document references into a non-owning lookup map and the
+  // page paint then draws from it synchronously. The shared bitmap cache is
+  // LRU-bounded, so a document referencing more images than the cap — or a
+  // concurrent render of another page of the same document — would otherwise
+  // evict AND GPU-close bitmaps this pass's map still holds before the paint.
+  // Under the lease the eviction still removes the cache entry (bounded size;
+  // the next pass re-decodes), but the close is deferred until this pass ends,
+  // so the paint never draws a closed bitmap.
+  const releaseLease = opts.fetchImage ? acquireBitmapCacheLease(opts.fetchImage) : undefined;
+  try {
+    await renderDocumentToCanvasLeased(doc, canvas, pageIndex, opts);
+  } finally {
+    releaseLease?.();
+  }
+}
+
+/** {@link renderDocumentToCanvas}'s body, verbatim; runs under the caller's
+ *  render-pass lease. */
+async function renderDocumentToCanvasLeased(
   doc: DocxDocumentModel,
   canvas: HTMLCanvasElement | OffscreenCanvas,
   pageIndex: number,

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -15,7 +15,14 @@ import { renderSlide, type PptxTextRunInfo } from './renderer';
 import { selectNotes } from './notes';
 import { findMimeTypeForPath } from './media-mime';
 import { PPTX_GOOGLE_FONTS, pptxFontPreloadNames } from './google-fonts';
-import { preloadGoogleFonts, decodeDataUrl, WasmParserHost } from '@silurus/ooxml-core';
+import {
+  preloadGoogleFonts,
+  decodeDataUrl,
+  WasmParserHost,
+  dropBitmapCacheByPath,
+  dropDuotoneBitmapCache,
+  dropSvgImageCache,
+} from '@silurus/ooxml-core';
 import type { RenderWorkerRequest, RenderWorkerResponse, PresentationMeta } from './worker-protocol';
 
 // RB6: same self-poison + auto-respawn as the parse-only worker. A trap during
@@ -93,6 +100,16 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
       // re-parse would silently return the wrong file's media/image.
       mediaCache.clear();
       imageCache.clear();
+      // A re-parse starts a fresh document: also drop the shared, per-`getImage`
+      // decoded caches (base raster, a:duotone recolour, SVG object URLs),
+      // symmetric with PptxPresentation.destroy(). The worker's `getImage` closure
+      // is a stable module-level identity, so without this a new deck sharing a
+      // zip path (e.g. ppt/media/image1.png) would be served the previous file's
+      // decoded bitmap, and the GPU/URL handles would linger past the LRU cap.
+      // Symmetric across docx/pptx/xlsx render workers (issue #781).
+      dropBitmapCacheByPath(getImage);
+      dropDuotoneBitmapCache(getImage);
+      dropSvgImageCache(getImage);
       const max =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -65,6 +65,7 @@ import {
   getCachedSvgImageByPath,
   getCachedBitmapByPath,
   getCachedDuotoneBitmapByPath,
+  acquireBitmapCacheLease,
   peekCachedBitmapByPath,
   dropBitmapCacheByPath,
   preferVectorBlip,
@@ -4854,6 +4855,32 @@ function drawParseErrorPlaceholder(
  * Returns the canvas for convenience.
  */
 export async function renderSlide(
+  canvas: HTMLCanvasElement | OffscreenCanvas,
+  slide: Slide,
+  slideWidth: number,
+  slideHeight: number,
+  opts: SlideRenderOptions = {},
+  onTextRun?: TextRunCallback,
+): Promise<HTMLCanvasElement | OffscreenCanvas> {
+  // Render-pass lease (core acquireBitmapCacheLease): the warm pass below fires
+  // a decode for every picture on the slide and the draw loop then awaits each
+  // element's bitmap and draws it. The shared bitmap cache is LRU-bounded, so a
+  // slide referencing more images than the cap — or a concurrent render on the
+  // same deck — could evict AND GPU-close a bitmap between the draw loop's await
+  // and its drawImage. Under the lease the eviction still removes the cache
+  // entry (bounded size; a later resolve re-decodes), but the close is deferred
+  // until this pass ends, so no draw ever receives a closed bitmap.
+  const releaseLease = opts.fetchImage ? acquireBitmapCacheLease(opts.fetchImage) : undefined;
+  try {
+    return await renderSlideLeased(canvas, slide, slideWidth, slideHeight, opts, onTextRun);
+  } finally {
+    releaseLease?.();
+  }
+}
+
+/** {@link renderSlide}'s body, verbatim; runs under the caller's render-pass
+ *  lease. */
+async function renderSlideLeased(
   canvas: HTMLCanvasElement | OffscreenCanvas,
   slide: Slide,
   slideWidth: number,

--- a/packages/xlsx/src/render-orchestrator.image.test.ts
+++ b/packages/xlsx/src/render-orchestrator.image.test.ts
@@ -5,6 +5,7 @@ import {
   dropBitmapCacheByPath,
   dropDuotoneBitmapCache,
   dropSvgImageCache,
+  getCachedBitmapByPath,
   type OffscreenFactory,
 } from '@silurus/ooxml-core';
 
@@ -653,5 +654,53 @@ describe('render-pass lease: >cap prefetch never draws a closed bitmap', () => {
     fail = true;
     await prefetchImages(ws, cache, fetchImage);
     expect(cache.has('xl/media/image1.png')).toBe(false);
+  });
+
+  it('replaces a duotone pass-through bitmap after base-cache eviction between passes', async () => {
+    vi.stubGlobal('createImageBitmap', vi.fn(async () => {
+      const bmp = {
+        width: 4,
+        height: 4,
+        closed: false,
+        close(): void { this.closed = true; },
+      };
+      return bmp as unknown as ImageBitmap;
+    }));
+    const fetchImage = vi.fn(async (path: string, mime: string) =>
+      new Blob([new TextEncoder().encode(path)], { type: mime }),
+    );
+    const ws = worksheetWithImages();
+    ws.images = [
+      {
+        fromCol: 0, fromColOff: 0, fromRow: 0, fromRowOff: 0,
+        toCol: 2, toColOff: 0, toRow: 2, toRowOff: 0,
+        nativeExtCx: 0, nativeExtCy: 0,
+        imagePath: 'xl/media/image1.png',
+        mimeType: 'image/png',
+        duotone: { clr1: '000000', clr2: 'FFF3F4' },
+      },
+    ];
+    ws.shapeGroups = [];
+    const cache = new Map<string, CanvasImageSource | null>();
+    const key = 'xl/media/image1.png|duo:000000:FFF3F4';
+
+    await prefetchImages(ws, cache, fetchImage);
+    const pass1 = cache.get(key) as ImageBitmap & { closed: boolean };
+    expect(pass1).toBeDefined();
+    expect(pass1.closed).toBe(false);
+
+    for (let i = 0; i < 256; i++) {
+      await getCachedBitmapByPath(`xl/media/pressure-${i}.png`, 'image/png', fetchImage);
+    }
+    await flush();
+    expect(pass1.closed).toBe(true);
+
+    await prefetchImages(ws, cache, fetchImage);
+    const pass2 = cache.get(key) as ImageBitmap & { closed: boolean };
+    expect(pass2).toBeDefined();
+    expect(pass2.closed).toBe(false);
+
+    dropDuotoneBitmapCache(fetchImage);
+    dropBitmapCacheByPath(fetchImage);
   });
 });

--- a/packages/xlsx/src/render-orchestrator.image.test.ts
+++ b/packages/xlsx/src/render-orchestrator.image.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { prefetchImages, decodeImageSource } from './render-orchestrator';
-import type { Worksheet } from './types';
+import { prefetchImages, decodeImageSource, renderWorksheetViewport } from './render-orchestrator';
+import type { Worksheet, ParsedWorkbook, ImageAnchor } from './types';
 import {
   dropBitmapCacheByPath,
   dropDuotoneBitmapCache,
@@ -509,5 +509,149 @@ describe('render-orchestrator duotone (§20.1.8.23)', () => {
     expect(cache.has('xl/media/image1.png')).toBe(true); // plain
     expect(cache.has('xl/media/image1.png|duo:000000:FFF3F4')).toBe(true); // recoloured
     expect(cache.size).toBe(2);
+  });
+});
+
+// ── Render-pass liveness: LRU eviction must never hand the draw a closed bitmap ─
+// The shared base cache is LRU-bounded (256): a single prefetch pass resolving
+// MORE images than the cap evicts — and GPU-closes — bitmaps decoded earlier in
+// the SAME pass, while the lookup map still references them for the synchronous
+// draw. renderWorksheetViewport therefore holds a core render-pass lease
+// (acquireBitmapCacheLease) across prefetch→draw: evictions still remove cache
+// entries (bounded size), but their closes are deferred until the pass ends. The
+// failure path is pinned too: a re-resolve that fails must DELETE the stale
+// lookup entry (the prior bitmap may have been evicted+closed), because the
+// renderer skips only a missing/falsy source, not a closed one.
+describe('render-pass lease: >cap prefetch never draws a closed bitmap', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** A fake HTMLCanvas + proxy 2D context whose drawImage records the closed
+   *  state of every image it is handed AT DRAW TIME. All other context members
+   *  no-op (the resize-test pattern). */
+  function makeRecordingCanvas(drawn: { closedAtDraw: boolean[] }) {
+    const target: Record<string, unknown> = {
+      drawImage: (img: unknown) => {
+        drawn.closedAtDraw.push(Boolean((img as { closed?: boolean }).closed));
+      },
+      measureText: (s: string) => ({ width: [...String(s)].length * 7 }),
+      createLinearGradient: () => ({ addColorStop() {} }),
+      createPattern: () => null,
+      getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+      setTransform: () => undefined,
+    };
+    const ctx = new Proxy(target, {
+      get(t, prop: string) {
+        if (prop in t) return t[prop];
+        return () => undefined;
+      },
+      set(t, prop: string, value: unknown) {
+        t[prop] = value;
+        return true;
+      },
+    });
+    const canvas = {
+      width: 0,
+      height: 0,
+      clientWidth: 800,
+      clientHeight: 600,
+      style: {} as Record<string, string>,
+      getContext: () => ctx as unknown as CanvasRenderingContext2D,
+    };
+    return canvas as unknown as HTMLCanvasElement;
+  }
+
+  const STYLES = {
+    fonts: [], fills: [], borders: [], cellXfs: [], numFmts: {},
+  } as unknown as ParsedWorkbook['styles'];
+
+  it('draws 300 images (cap 256) in one pass with every bitmap still open; evicted ones close after the pass', async () => {
+    // Each decode yields a bitmap with a live `closed` flag the recording
+    // drawImage reads at draw time.
+    const bitmaps: Array<{ closed: boolean }> = [];
+    vi.stubGlobal('createImageBitmap', vi.fn(async () => {
+      const bmp = {
+        width: 4,
+        height: 4,
+        closed: false,
+        close() { this.closed = true; },
+      };
+      bitmaps.push(bmp);
+      return bmp as unknown as ImageBitmap;
+    }));
+    const fetchImage = vi.fn(async (path: string, mime: string) =>
+      new Blob([new TextEncoder().encode(path)], { type: mime }),
+    );
+
+    const N = 300; // > IMAGE_BITMAP_CACHE_MAX (256) → forces mid-pass evictions
+    const images: ImageAnchor[] = [];
+    for (let i = 0; i < N; i++) {
+      images.push({
+        fromCol: 0, fromColOff: 0, fromRow: 0, fromRowOff: 0,
+        toCol: 2, toColOff: 0, toRow: 2, toRowOff: 0,
+        nativeExtCx: 0, nativeExtCy: 0,
+        imagePath: `xl/media/lease-${i}.png`,
+        mimeType: 'image/png',
+      } as ImageAnchor);
+    }
+    const ws = {
+      name: 'S', rows: [], colWidths: {}, rowHeights: {},
+      defaultColWidth: 64, defaultRowHeight: 20,
+      mergeCells: [], freezeRows: 0, freezeCols: 0,
+      conditionalFormats: [], charts: [], images, shapeGroups: [],
+    } as unknown as Worksheet;
+
+    const drawn = { closedAtDraw: [] as boolean[] };
+    const canvas = makeRecordingCanvas(drawn);
+    const imageCache = new Map<string, CanvasImageSource | null>();
+
+    await renderWorksheetViewport(
+      { ws, styles: STYLES, imageCache },
+      canvas,
+      { row: 1, col: 1, rows: 10, cols: 10 },
+      { fetchImage, width: 800, height: 600, dpr: 1 },
+    );
+
+    // Sanity: the pass really decoded past the cap and really drew the anchors.
+    expect(bitmaps.length).toBe(N);
+    expect(drawn.closedAtDraw.length).toBe(N);
+    // The pinned property: NO bitmap handed to drawImage was closed at draw time.
+    expect(drawn.closedAtDraw.every((c) => c === false)).toBe(true);
+
+    // After the pass (lease released), the mid-pass evictions' deferred closes
+    // run: exactly N − cap bitmaps close, proving eviction did happen and was
+    // deferred (not suppressed).
+    await flush();
+    const closedAfter = bitmaps.filter((b) => b.closed).length;
+    expect(closedAfter).toBe(N - 256);
+
+    dropBitmapCacheByPath(fetchImage);
+  });
+
+  it('prefetchImages deletes the stale lookup entry when a re-resolve fails', async () => {
+    vi.stubGlobal('createImageBitmap', vi.fn(async () => ({
+      width: 4, height: 4, close() {},
+    }) as unknown as ImageBitmap));
+    let fail = false;
+    const fetchImage = vi.fn(async (path: string, mime: string) => {
+      if (fail) throw new Error('byte source unavailable');
+      return new Blob([new TextEncoder().encode(path)], { type: mime });
+    });
+    const ws = worksheetWithImages();
+    ws.shapeGroups = [];
+    const cache = new Map<string, CanvasImageSource | null>();
+
+    // Pass 1: healthy decode lands in the lookup map.
+    await prefetchImages(ws, cache, fetchImage);
+    expect(cache.has('xl/media/image1.png')).toBe(true);
+
+    // The shared entry is evicted+closed (LRU pressure / drop) …
+    dropBitmapCacheByPath(fetchImage);
+    await flush();
+    // … and the re-resolve on the next pass fails. The stale lookup entry MUST
+    // be deleted — its bitmap may be closed, and the renderer only skips a
+    // missing/falsy source.
+    fail = true;
+    await prefetchImages(ws, cache, fetchImage);
+    expect(cache.has('xl/media/image1.png')).toBe(false);
   });
 });

--- a/packages/xlsx/src/render-orchestrator.image.test.ts
+++ b/packages/xlsx/src/render-orchestrator.image.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { prefetchImages, decodeImageSource, closeAndClearImageCache } from './render-orchestrator';
+import { prefetchImages, decodeImageSource } from './render-orchestrator';
 import type { Worksheet } from './types';
-import type { OffscreenFactory } from '@silurus/ooxml-core';
+import {
+  dropBitmapCacheByPath,
+  dropDuotoneBitmapCache,
+  dropSvgImageCache,
+  type OffscreenFactory,
+} from '@silurus/ooxml-core';
 
 /**
  * The render orchestrator decodes embedded images lazily by zip path:
@@ -10,14 +15,23 @@ import type { OffscreenFactory } from '@silurus/ooxml-core';
  * HTMLImageElement for SVG via core's `getCachedSvgImageByPath`).
  * `prefetchImages` collects every image path from BOTH `ws.images` (top-level
  * `twoCellAnchor` pictures) AND the image leaves inside `ws.shapeGroups`,
- * fetches each once, and stores the decoded source in the shared cache keyed by
- * `imagePath`. Mirrors the pptx/docx renderer decode swap.
+ * resolves each against the SHARED, per-`fetchImage` core caches
+ * (`getCachedBitmapByPath` for raster/metafile, `getCachedDuotoneBitmapByPath`
+ * for a `<a:duotone>` recolour, `getCachedSvgImageByPath` for an SVG vector
+ * original), and records the drawable in the passed lookup map keyed by
+ * `imageCacheKey`. The map is a pure synchronous-lookup layer; ownership of the
+ * decoded bitmaps lives in the shared caches (dropped per document on
+ * destroy / re-parse), the same split docx/pptx use.
  */
 
 // A minimal stand-in for a decoded raster bitmap.
 class FakeBitmap {
   constructor(public readonly tag: string) {}
 }
+
+/** Flush pending microtasks so a drop's close-through-promise (`promise.then(b =>
+ *  b.close())`) has run before the assertion — mirrors core's own cache tests. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
 
 /** Build a minimal standard (non-placeable) WMF that draws one polyline, so the
  *  shared core player produces non-empty geometry (→ a non-null bitmap). */
@@ -64,6 +78,32 @@ function stubOffscreenCanvas(): void {
       }
     },
   );
+}
+
+/** An offscreen surface whose getImageData returns a fixed near-white pixel grid
+ *  and whose putImageData records the mutated buffer, so a duotone recolour can
+ *  run (and be observed) without a real canvas. Cast to the core
+ *  `OffscreenFactory` at the boundary (a partial mock). Shared by the duotone
+ *  ownership and recolour tests. */
+function recordingFactory(record: { out?: Uint8ClampedArray }): OffscreenFactory {
+  return ((w: number, h: number) => ({
+    width: w,
+    height: h,
+    getContext() {
+      return {
+        drawImage() {},
+        getImageData(_sx: number, _sy: number, sw: number, sh: number) {
+          // All near-white opaque pixels (t≈0.96) → should map toward clr2.
+          const data = new Uint8ClampedArray(sw * sh * 4).fill(246);
+          for (let i = 3; i < data.length; i += 4) data[i] = 255; // alpha
+          return { data, width: sw, height: sh } as unknown as ImageData;
+        },
+        putImageData(img: ImageData) {
+          record.out = img.data;
+        },
+      };
+    },
+  })) as unknown as OffscreenFactory;
 }
 
 /** Build a Worksheet with one top-level image and one group-leaf image, each at
@@ -133,20 +173,25 @@ describe('render-orchestrator image decode (lazy bytes)', () => {
     expect(fetchImage).toHaveBeenCalledWith('xl/media/image2.png', 'image/png');
   });
 
-  it('prefetchImages skips already-cached paths (no re-fetch)', async () => {
+  it('prefetchImages does not re-fetch an already-decoded path (shared cache hit, not a stale map entry)', async () => {
     vi.stubGlobal('createImageBitmap', vi.fn(async (blob: Blob) => new FakeBitmap(blob.type)));
     const fetchImage = vi.fn(async (path: string, mime: string) =>
       new Blob([new TextEncoder().encode(path)], { type: mime }),
     );
     const ws = worksheetWithImages();
     const cache = new Map<string, CanvasImageSource>();
-    cache.set('xl/media/image1.png', new FakeBitmap('preexisting') as unknown as CanvasImageSource);
 
+    // First pass warms the shared path-keyed cache (both images fetched once).
     await prefetchImages(ws, cache, fetchImage);
+    expect(fetchImage).toHaveBeenCalledTimes(2);
 
-    // image1 was already cached → only image2 is fetched.
-    expect(fetchImage).toHaveBeenCalledTimes(1);
-    expect(fetchImage).toHaveBeenCalledWith('xl/media/image2.png', 'image/png');
+    // Second pass re-resolves every referenced image (the way docx/pptx do, so an
+    // LRU eviction of a still-referenced path is re-decoded rather than served
+    // stale/closed) — but each hits the shared cache, so NO byte is re-fetched.
+    await prefetchImages(ws, cache, fetchImage);
+    expect(fetchImage).toHaveBeenCalledTimes(2);
+
+    dropBitmapCacheByPath(fetchImage);
   });
 
   it('prefetchImages is a no-op when fetchImage is absent (cache stays empty)', async () => {
@@ -252,42 +297,136 @@ describe('render-orchestrator image decode (lazy bytes)', () => {
   });
 });
 
-describe('closeAndClearImageCache (teardown GPU-bitmap leak guard)', () => {
-  it('closes every cached ImageBitmap before clearing the map', () => {
-    const closeA = vi.fn();
-    const closeB = vi.fn();
-    const bmpA = { close: closeA } as unknown as ImageBitmap;
-    const bmpB = { close: closeB } as unknown as ImageBitmap;
-    const cache = new Map<string, CanvasImageSource | null>([
-      ['xl/media/image1.png', bmpA],
-      ['xl/media/image2.png', bmpB],
-    ]);
+// ── Teardown ownership: the shared caches own the bitmaps, not the map ────────
+// After #781, xlsx decodes through the SAME per-`fetchImage` core caches
+// docx/pptx use, so the passed lookup map only ever holds references; the
+// GPU-backed ImageBitmaps are released by dropping the shared caches keyed by
+// `fetchImage`. These tests pin that ownership (dropping the shared cache closes
+// the decoded bitmap — i.e. #779's teardown leak is not reintroduced) and that
+// the lookup map is a pure, non-owning layer (clearing it never closes).
+describe('shared-cache consolidation (teardown ownership / no leak)', () => {
+  afterEach(() => vi.unstubAllGlobals());
 
-    closeAndClearImageCache(cache);
-
-    expect(closeA).toHaveBeenCalledTimes(1);
-    expect(closeB).toHaveBeenCalledTimes(1);
-    expect(cache.size).toBe(0);
-  });
-
-  it('skips a cached null (unsupported metafile) without throwing', () => {
-    const cache = new Map<string, CanvasImageSource | null>([['xl/media/diagram.emf', null]]);
-    expect(() => closeAndClearImageCache(cache)).not.toThrow();
-    expect(cache.size).toBe(0);
-  });
-
-  it('skips a non-closeable CanvasImageSource (e.g. the SVG HTMLImageElement branch)', () => {
-    // The svgBlip vector branch decodes to an HTMLImageElement via
-    // getCachedSvgImageByPath, which has no `.close()` — must not throw.
-    const img = {} as unknown as HTMLImageElement;
-    const cache = new Map<string, CanvasImageSource | null>([['xl/media/image1.svg', img]]);
-    expect(() => closeAndClearImageCache(cache)).not.toThrow();
-    expect(cache.size).toBe(0);
-  });
-
-  it('is safe to call on an already-empty cache', () => {
+  it('prefetchImages decodes the base raster into the SHARED path-keyed cache; dropBitmapCacheByPath closes it', async () => {
+    const close = vi.fn();
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 1, height: 1, close }) as unknown as ImageBitmap),
+    );
+    const fetchImage = vi.fn(async (path: string, mime: string) =>
+      new Blob([new TextEncoder().encode(path)], { type: mime }),
+    );
+    const ws = worksheetWithImages(); // two distinct PNG paths
     const cache = new Map<string, CanvasImageSource | null>();
-    expect(() => closeAndClearImageCache(cache)).not.toThrow();
+
+    await prefetchImages(ws, cache, fetchImage);
+
+    // The lookup map exposes the drawable for the synchronous grid draw …
+    expect(cache.get('xl/media/image1.png')).toBeTruthy();
+    expect(cache.get('xl/media/image2.png')).toBeTruthy();
+    // … but ownership is the shared cache: no bitmap was closed yet.
+    expect(close).not.toHaveBeenCalled();
+
+    // Dropping the shared cache (destroy / re-parse) closes every GPU bitmap —
+    // proving the decode landed in getCachedBitmapByPath, not an orphaned map.
+    dropBitmapCacheByPath(fetchImage);
+    await flush();
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it('the lookup map is non-owning: clearing it never closes a bitmap (no double close)', async () => {
+    const close = vi.fn();
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 1, height: 1, close }) as unknown as ImageBitmap),
+    );
+    const fetchImage = vi.fn(async (path: string, mime: string) =>
+      new Blob([new TextEncoder().encode(path)], { type: mime }),
+    );
+    const ws = worksheetWithImages();
+    const cache = new Map<string, CanvasImageSource | null>();
+
+    await prefetchImages(ws, cache, fetchImage);
+    cache.clear(); // dropping lookup references must NOT close the shared bitmap
+    await flush();
+    expect(close).not.toHaveBeenCalled();
+
+    // The shared cache still owns and closes them exactly once.
+    dropBitmapCacheByPath(fetchImage);
+    await flush();
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it('a <a:duotone> recolour is owned by the shared duotone cache; dropDuotoneBitmapCache closes it', async () => {
+    const baseClose = vi.fn();
+    const duoClose = vi.fn();
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async (src: unknown) =>
+        (src instanceof Blob
+          ? { width: 4, height: 4, close: baseClose }
+          : { width: 4, height: 4, close: duoClose }) as unknown as ImageBitmap,
+      ),
+    );
+    const fetchImage = vi.fn(async (path: string, mime: string) =>
+      new Blob([new TextEncoder().encode(path)], { type: mime }),
+    );
+    const record: { out?: Uint8ClampedArray } = {};
+    const ws = worksheetWithImages();
+    ws.images = [
+      {
+        fromCol: 0, fromColOff: 0, fromRow: 0, fromRowOff: 0,
+        toCol: 2, toColOff: 0, toRow: 2, toRowOff: 0,
+        nativeExtCx: 0, nativeExtCy: 0,
+        imagePath: 'xl/media/image1.png',
+        mimeType: 'image/png',
+        duotone: { clr1: '000000', clr2: 'FFF3F4' },
+      },
+    ];
+    ws.shapeGroups = [];
+    const cache = new Map<string, CanvasImageSource | null>();
+
+    await prefetchImages(ws, cache, fetchImage, { offscreenFactory: recordingFactory(record) });
+
+    // The recoloured variant is what the draw site looks up (colour-suffixed key).
+    expect(cache.get('xl/media/image1.png|duo:000000:FFF3F4')).toBeTruthy();
+
+    // The recolour raster is owned by the duotone cache …
+    dropDuotoneBitmapCache(fetchImage);
+    await flush();
+    expect(duoClose).toHaveBeenCalledTimes(1);
+    // … and the colour-free base by the base cache.
+    dropBitmapCacheByPath(fetchImage);
+    await flush();
+    expect(baseClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('an SVG vector original is owned by the shared SVG cache (dropSvgImageCache clears it)', async () => {
+    // Route the picture through the SVG decoder: an svg mime with no separate
+    // raster blip. getCachedSvgImageByPath decodes via <img>, which node lacks,
+    // so the decode rejects and prefetchImages swallows it — the point here is
+    // that the SVG object-URL cache is keyed by `fetchImage` and released by
+    // dropSvgImageCache, not by the lookup map.
+    const fetchImage = vi.fn(async (path: string, mime: string) =>
+      new Blob([new TextEncoder().encode(path)], { type: mime }),
+    );
+    const ws = worksheetWithImages();
+    ws.images = [
+      {
+        fromCol: 0, fromColOff: 0, fromRow: 0, fromRowOff: 0,
+        toCol: 2, toColOff: 0, toRow: 2, toRowOff: 0,
+        nativeExtCx: 0, nativeExtCy: 0,
+        imagePath: 'xl/media/image1.svg',
+        mimeType: 'image/svg+xml',
+      },
+    ];
+    ws.shapeGroups = [];
+    const cache = new Map<string, CanvasImageSource | null>();
+
+    await expect(prefetchImages(ws, cache, fetchImage)).resolves.toBeUndefined();
+    // Releasing the SVG cache for this fetchImage must not throw (no leak of the
+    // per-document object URLs).
+    expect(() => dropSvgImageCache(fetchImage)).not.toThrow();
   });
 });
 
@@ -300,32 +439,6 @@ describe('closeAndClearImageCache (teardown GPU-bitmap leak guard)', () => {
 // without a real canvas.
 describe('render-orchestrator duotone (§20.1.8.23)', () => {
   afterEach(() => vi.unstubAllGlobals());
-
-  /** An offscreen surface whose getImageData returns a fixed near-white pixel
-   *  grid, and whose putImageData records the mutated buffer so the test can
-   *  confirm the recolour ran. Cast to the core `OffscreenFactory` at the
-   *  boundary (a partial mock — the DOM `ImageBitmapSource` shape is irrelevant
-   *  to the transform under test). */
-  function recordingFactory(record: { out?: Uint8ClampedArray }): OffscreenFactory {
-    return ((w: number, h: number) => ({
-      width: w,
-      height: h,
-      getContext() {
-        return {
-          drawImage() {},
-          getImageData(_sx: number, _sy: number, sw: number, sh: number) {
-            // All near-white opaque pixels (t≈0.96) → should map toward clr2.
-            const data = new Uint8ClampedArray(sw * sh * 4).fill(246);
-            for (let i = 3; i < data.length; i += 4) data[i] = 255; // alpha
-            return { data, width: sw, height: sh } as unknown as ImageData;
-          },
-          putImageData(img: ImageData) {
-            record.out = img.data;
-          },
-        };
-      },
-    })) as unknown as OffscreenFactory;
-  }
 
   it('recolours a duotone picture and caches it under a colour-suffixed key', async () => {
     // A fake bitmap exposes width/height so imageNaturalSize sizes the surface.

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -4,6 +4,7 @@ import {
   clampCanvasSize,
   getCachedSvgImageByPath,
   getCachedDuotoneBitmapByPath,
+  acquireBitmapCacheLease,
   preferVectorBlip,
   metafileRasterSize,
   EMU_PER_PT,
@@ -213,7 +214,12 @@ export async function prefetchImages(
         // metafile, so the renderer skips a falsy source without a re-fetch).
         imageCache.set(key, src);
       } catch {
-        /* transient failure: leave any prior entry; renderer skips a missing source */
+        // Transient failure: DELETE any prior lookup entry rather than leaving
+        // it. A prior entry is re-resolved precisely because its shared-cache
+        // backing may be gone (LRU-evicted and GPU-closed); when the re-resolve
+        // fails we cannot vouch for that bitmap's liveness, and the renderer
+        // skips only a missing/falsy source — it would draw a closed one.
+        imageCache.delete(key);
       }
     }),
   );
@@ -229,8 +235,33 @@ export interface RenderDeps {
 
 /** The full per-frame orchestration: preload uncached images, pre-rasterize
  *  equations, size the target, draw. Shared verbatim by the main-thread
- *  XlsxWorkbook and the render worker. */
+ *  XlsxWorkbook and the render worker.
+ *
+ *  The whole pass (prefetch → synchronous draw) runs under a core render-pass
+ *  lease ({@link acquireBitmapCacheLease}): the shared bitmap cache is
+ *  LRU-bounded, so a pass resolving more images than the cap — or a concurrent
+ *  pass on the same workbook — would otherwise evict AND GPU-close bitmaps this
+ *  pass's lookup map still references before the draw runs. Under the lease the
+ *  eviction still removes the cache entry (size stays bounded; the next pass
+ *  re-decodes), but the close is deferred until the lease is released after the
+ *  draw, so drawImage never receives a closed bitmap. */
 export async function renderWorksheetViewport(
+  deps: RenderDeps,
+  target: HTMLCanvasElement | OffscreenCanvas,
+  viewport: ViewportRange,
+  opts: RenderViewportOptions = {},
+): Promise<void> {
+  const releaseLease = opts.fetchImage ? acquireBitmapCacheLease(opts.fetchImage) : undefined;
+  try {
+    await renderWorksheetViewportLeased(deps, target, viewport, opts);
+  } finally {
+    releaseLease?.();
+  }
+}
+
+/** {@link renderWorksheetViewport}'s body, verbatim; runs under the caller's
+ *  render-pass lease. */
+async function renderWorksheetViewportLeased(
   deps: RenderDeps,
   target: HTMLCanvasElement | OffscreenCanvas,
   viewport: ViewportRange,

--- a/packages/xlsx/src/render-orchestrator.ts
+++ b/packages/xlsx/src/render-orchestrator.ts
@@ -3,15 +3,14 @@ import {
   isHTMLCanvas,
   clampCanvasSize,
   getCachedSvgImageByPath,
+  getCachedDuotoneBitmapByPath,
   preferVectorBlip,
-  decodeRasterOrMetafile,
   metafileRasterSize,
-  applyDuotone,
-  imageNaturalSize,
   EMU_PER_PT,
   type MathRenderer,
   type SrcRect,
   type Duotone,
+  type OffscreenFactory,
 } from '@silurus/ooxml-core';
 import type { ParsedWorkbook, Worksheet, ViewportRange, RenderViewportOptions } from './types.js';
 import {
@@ -42,7 +41,7 @@ interface ImageRef {
   duotone?: Duotone | null;
 }
 
-/** Fetch one image's bytes by zip path and decode them to a drawable
+/** Fetch one image's bytes by zip path and resolve them to a drawable
  *  `CanvasImageSource`, preferring the Microsoft svgBlip vector original
  *  (MS-ODRAWXML). Unified across the top-level twoCellAnchor picture
  *  (`ImageAnchor`) and the `<xdr:grpSp>` leaf (`ShapeGeom` image) — both carry a
@@ -52,19 +51,27 @@ interface ImageRef {
  *  because the renderer's crop math needs the decoded bitmap's native pixel grid
  *  (an SVG element has none).
  *
- *  Raster decodes to an `ImageBitmap` through core's
- *  {@link decodeRasterOrMetafile} (which content-sniffs the bytes: a WMF, which
- *  `createImageBitmap` can't decode, is rasterized by the shared minimal player
- *  at a size derived from `widthPt`/`heightPt`; a true EMF — or a WMF with no
- *  geometry — resolves to `null`, so the picture is skipped rather than
- *  crashing). The SVG vector original decodes to an `HTMLImageElement` via
- *  core's path-keyed `getCachedSvgImageByPath`, because `createImageBitmap`
- *  cannot rasterize SVG in every browser. Bytes are fetched lazily by zip path
- *  through `fetchImage` (twin of pptx/docx's `fetchImage`) instead of being
- *  inlined as base64.
+ *  All three decode paths go through the SAME per-`fetchImage` core caches that
+ *  docx and pptx use (issue #781), so xlsx no longer keeps its own owned bitmap
+ *  map:
+ *   - raster/metafile (+ any `<a:duotone>` recolour, §20.1.8.23) →
+ *     {@link getCachedDuotoneBitmapByPath}, a thin two-layer wrapper over the
+ *     path-keyed `getCachedBitmapByPath` (content-sniffs the bytes: a WMF, which
+ *     `createImageBitmap` can't decode, is rasterized by the shared minimal
+ *     player at a size derived from `widthPt`/`heightPt`; a true EMF — or a WMF
+ *     with no geometry — resolves to `null`, so the picture is skipped rather
+ *     than crashing). With no duotone this is exactly the base-bitmap decode.
+ *   - SVG vector original → `getCachedSvgImageByPath` (decodes to an
+ *     `HTMLImageElement`, because `createImageBitmap` cannot rasterize SVG in
+ *     every browser).
+ *  Bytes are fetched lazily by zip path through `fetchImage` (twin of
+ *  pptx/docx's `fetchImage`) instead of being inlined as base64; the decoded
+ *  bitmaps are owned by those shared caches (LRU-bounded, closed on eviction and
+ *  on the per-document `drop*` at destroy / re-parse) rather than by the caller's
+ *  lookup map.
  *
- *  Returns `null` for an unsupported metafile so the caller leaves the path
- *  uncached and the renderer skips a missing source. */
+ *  Returns `null` for an unsupported metafile so the renderer skips a missing
+ *  source. */
 export async function decodeImageSource(
   imagePath: string,
   mimeType: string,
@@ -73,18 +80,21 @@ export async function decodeImageSource(
   widthPt = 0,
   heightPt = 0,
   srcRect: SrcRect | null = null,
+  duotone: Duotone | null = null,
+  offscreenFactory?: OffscreenFactory,
 ): Promise<CanvasImageSource | null> {
-  const decodeRaster = async (path: string, mime: string): Promise<CanvasImageSource | null> => {
-    // A cropped metafile must rasterize at its FULL picture frame, not the
-    // visible sub-rect, so the fractional crop lands correctly; raster blips and
-    // uncropped metafiles pass the box through unchanged.
-    const sized = metafileRasterSize(mime, srcRect, widthPt, heightPt);
-    return decodeRasterOrMetafile(await fetchImage(path, mime), {
+  const dataIsSvg = mimeType === 'image/svg+xml';
+  // A cropped metafile must rasterize at its FULL picture frame, not the visible
+  // sub-rect, so the fractional crop lands correctly; raster blips and uncropped
+  // metafiles pass the box through unchanged. The shared base cache is path-keyed
+  // ("first size wins"), matching pptx/docx.
+  const sized = metafileRasterSize(mimeType, srcRect, widthPt, heightPt);
+  const decodeRaster = (): Promise<ImageBitmap | null> =>
+    getCachedDuotoneBitmapByPath(imagePath, mimeType, duotone, fetchImage, {
       widthPt: sized.widthPt,
       heightPt: sized.heightPt,
+      offscreenFactory,
     });
-  };
-  const dataIsSvg = mimeType === 'image/svg+xml';
   // Shared vector-vs-raster gate (see core preferVectorBlip). When it returns
   // true, `blip.svgImagePath` is narrowed to string.
   const blip = { svgImagePath, srcRect };
@@ -92,13 +102,13 @@ export async function decodeImageSource(
     // No crop: prefer the vector original; fall back to the raster on decode
     // failure (or, when `imagePath` is itself the SVG, the SVG decoder again).
     // A cropped picture skips this branch so the crop math (below, in the
-    // renderer) runs on the raster bitmap's native pixel dimensions.
+    // renderer) runs on the raster bitmap's native pixel dimensions. §20.1.8.23
+    // duotone applies only to the raster fallback — an SVG vector original has no
+    // readable pixel grid (matches docx/pptx).
     try {
       return await getCachedSvgImageByPath(blip.svgImagePath, fetchImage);
     } catch {
-      return dataIsSvg
-        ? getCachedSvgImageByPath(imagePath, fetchImage)
-        : decodeRaster(imagePath, mimeType);
+      return dataIsSvg ? getCachedSvgImageByPath(imagePath, fetchImage) : decodeRaster();
     }
   }
   if (dataIsSvg) {
@@ -106,43 +116,28 @@ export async function decodeImageSource(
     // raster decoder (createImageBitmap) can't rasterize SVG.
     return getCachedSvgImageByPath(imagePath, fetchImage);
   }
-  return decodeRaster(imagePath, mimeType);
+  return decodeRaster();
 }
 
-/** Close every `ImageBitmap` held in a decoded-image cache, then clear it.
+/** Collect every embedded image referenced by a worksheet, resolve each against
+ *  the shared per-`fetchImage` core caches, and record the drawable in
+ *  `imageCache` under {@link imageCacheKey}(path, duotone) — the renderer's
+ *  synchronous lookup key. Images appear either as a top-level twoCellAnchor
+ *  `<xdr:pic>` (in `ws.images`) or as a leaf inside an `<xdr:grpSp>` (a
+ *  `ShapeGeom` with `type: 'image'`); BOTH are collected so the renderer never
+ *  hits a missing source during the synchronous draw. De-duped by lookup key so a
+ *  path shared across anchors is resolved once per pass.
  *
- *  Unlike docx/pptx (which decode through core's path-keyed
- *  `getCachedBitmapByPath`/`dropBitmapCacheByPath`, so eviction/teardown always
- *  closes the GPU-backed bitmap), xlsx's `imageCache` is a plain per-instance
- *  `Map<string, CanvasImageSource | null>` populated directly by
- *  `decodeImageSource` (see {@link prefetchImages}). A bare `.clear()` on that
- *  map drops the last reference to each decoded `ImageBitmap` WITHOUT calling
- *  `.close()`, leaking its GPU backing until GC — worse, GC timing for
- *  GPU-backed objects is not guaranteed, so repeated load/destroy or
- *  reparse cycles can accumulate live bitmaps. `HTMLImageElement` (the SVG
- *  vector-blip branch, via `getCachedSvgImageByPath`) and a cached `null`
- *  (unsupported metafile) pass through untouched — only `ImageBitmap` values
- *  own a `.close()` method.
+ *  `imageCache` is a pure synchronous-lookup layer, NOT the owner of the decoded
+ *  bitmaps: every image is re-resolved through `decodeImageSource` on each pass
+ *  (the way docx/pptx do), so a still-referenced blip whose bitmap was
+ *  LRU-evicted (and closed) by the shared cache is transparently re-decoded
+ *  rather than served stale/closed — a resolved bitmap always comes from a live
+ *  shared-cache entry. A shared-cache hit re-fetches no bytes and re-runs no
+ *  decode, so a steady-state pass only awaits already-settled promises. Storing
+ *  `null` for an unsupported metafile (true EMF / geometry-less WMF) lets the
+ *  renderer skip a falsy source without a re-fetch.
  *
- *  Shared by {@link XlsxWorkbook.destroy} (main-thread cache) and the
- *  render-worker's module-level cache (closed both on re-`parse` and, via the
- *  realm tearing down, at worker termination). */
-export function closeAndClearImageCache(imageCache: Map<string, CanvasImageSource | null>): void {
-  for (const src of imageCache.values()) {
-    if (src && typeof (src as ImageBitmap).close === 'function') {
-      (src as ImageBitmap).close();
-    }
-  }
-  imageCache.clear();
-}
-
-/** Collect every embedded image referenced by a worksheet and decode the ones
- *  not already in `imageCache`, storing each decoded `CanvasImageSource` under
- *  its zip `imagePath` (the renderer's lookup key). Images appear either as a
- *  top-level twoCellAnchor `<xdr:pic>` (in `ws.images`) or as a leaf inside an
- *  `<xdr:grpSp>` (a `ShapeGeom` with `type: 'image'`); BOTH are collected so the
- *  renderer never hits a missing source during the synchronous draw. De-duped
- *  by `imagePath` so a path shared across anchors is fetched + decoded once.
  *  A no-op when `fetchImage` is absent (no byte source). Per-image failures are
  *  swallowed so one broken picture doesn't sink the grid. */
 export async function prefetchImages(
@@ -152,60 +147,58 @@ export async function prefetchImages(
   // Optional offscreen-surface factory for the `<a:duotone>` pixel transform,
   // injected in environments without a global `OffscreenCanvas` (or by tests).
   // Defaults to the real `OffscreenCanvas` when the runtime provides one.
-  opts?: { offscreenFactory?: import('@silurus/ooxml-core').OffscreenFactory },
+  opts?: { offscreenFactory?: OffscreenFactory },
 ): Promise<void> {
   if (!fetchImage) return;
   const fetch = fetchImage;
-  const uncached = new Map<string, ImageRef>();
+  const refs = new Map<string, ImageRef>();
   if (ws.images) {
     for (const img of ws.images) {
-      // Key by (path + duotone colours) so a recoloured picture is cached and
-      // looked up separately from the raw blip (§20.1.8.23).
-      const key = imageCacheKey(img.imagePath, img.duotone);
-      if (!imageCache.has(key)) {
-        uncached.set(key, {
-          imagePath: img.imagePath,
-          mimeType: img.mimeType,
-          svgImagePath: img.svgImagePath,
-          // Saved EMU extent → pt sizes a metafile raster (0 ⇒ decoder fallback).
-          widthPt: img.nativeExtCx > 0 ? img.nativeExtCx / EMU_PER_PT : 0,
-          heightPt: img.nativeExtCy > 0 ? img.nativeExtCy / EMU_PER_PT : 0,
-          // An `<a:srcRect>` crop forces the raster decode (native pixel grid)
-          // and, for a metafile, the full-frame raster size.
-          srcRect: img.srcRect ?? null,
-          duotone: img.duotone ?? null,
-        });
-      }
+      // Key by (path + duotone colours) so a recoloured picture is looked up
+      // separately from the raw blip (§20.1.8.23).
+      refs.set(imageCacheKey(img.imagePath, img.duotone), {
+        imagePath: img.imagePath,
+        mimeType: img.mimeType,
+        svgImagePath: img.svgImagePath,
+        // Saved EMU extent → pt sizes a metafile raster (0 ⇒ decoder fallback).
+        widthPt: img.nativeExtCx > 0 ? img.nativeExtCx / EMU_PER_PT : 0,
+        heightPt: img.nativeExtCy > 0 ? img.nativeExtCy / EMU_PER_PT : 0,
+        // An `<a:srcRect>` crop forces the raster decode (native pixel grid)
+        // and, for a metafile, the full-frame raster size.
+        srcRect: img.srcRect ?? null,
+        duotone: img.duotone ?? null,
+      });
     }
   }
   if (ws.shapeGroups) {
     for (const grp of ws.shapeGroups) {
       for (const shape of grp.shapes) {
         if (shape.geom.type === 'image') {
-          const key = imageCacheKey(shape.geom.imagePath, shape.geom.duotone);
-          if (!imageCache.has(key)) {
-            uncached.set(key, {
-              imagePath: shape.geom.imagePath,
-              mimeType: shape.geom.mimeType,
-              svgImagePath: shape.geom.svgImagePath,
-              // Group's saved EMU extent scaled by the leaf's normalized w/h → pt.
-              widthPt: grp.nativeExtCx > 0 ? (grp.nativeExtCx * shape.w) / EMU_PER_PT : 0,
-              heightPt: grp.nativeExtCy > 0 ? (grp.nativeExtCy * shape.h) / EMU_PER_PT : 0,
-              // A crop forces the raster decode (native pixel grid for the crop)
-              // and, for a metafile, the full-frame raster size.
-              srcRect: shape.geom.srcRect ?? null,
-              duotone: shape.geom.duotone ?? null,
-            });
-          }
+          refs.set(imageCacheKey(shape.geom.imagePath, shape.geom.duotone), {
+            imagePath: shape.geom.imagePath,
+            mimeType: shape.geom.mimeType,
+            svgImagePath: shape.geom.svgImagePath,
+            // Group's saved EMU extent scaled by the leaf's normalized w/h → pt.
+            widthPt: grp.nativeExtCx > 0 ? (grp.nativeExtCx * shape.w) / EMU_PER_PT : 0,
+            heightPt: grp.nativeExtCy > 0 ? (grp.nativeExtCy * shape.h) / EMU_PER_PT : 0,
+            // A crop forces the raster decode (native pixel grid for the crop)
+            // and, for a metafile, the full-frame raster size.
+            srcRect: shape.geom.srcRect ?? null,
+            duotone: shape.geom.duotone ?? null,
+          });
         }
       }
     }
   }
-  if (uncached.size === 0) return;
+  if (refs.size === 0) return;
   await Promise.all(
-    [...uncached.entries()].map(async ([key, ref]) => {
+    [...refs.entries()].map(async ([key, ref]) => {
       try {
-        let src = await decodeImageSource(
+        // The §20.1.8.23 duotone recolour is applied inside the shared decode
+        // (getCachedDuotoneBitmapByPath) and cached under a colour-suffixed key,
+        // so the per-frame draw stays synchronous. Only raster/bitmap sources are
+        // recoloured — an SVG element (vector blip) has no readable pixel grid.
+        const src = await decodeImageSource(
           ref.imagePath,
           ref.mimeType,
           ref.svgImagePath,
@@ -213,33 +206,14 @@ export async function prefetchImages(
           ref.widthPt,
           ref.heightPt,
           ref.srcRect,
+          ref.duotone,
+          opts?.offscreenFactory,
         );
-        // Apply a `<a:duotone>` recolour (§20.1.8.23) once, at decode time, so the
-        // per-frame draw stays synchronous. The transform returns a NEW
-        // ImageBitmap recoloured along the clr1→clr2 luminance ramp (or the source
-        // unchanged when the pixel pipeline is unavailable). Uses the decoded
-        // bitmap's native pixel size. Only raster/bitmap sources are recoloured —
-        // an SVG element (vector blip) has no readable pixel grid, so it is left
-        // as-is (a duotone on a vector picture is a rare edge case).
-        if (src && ref.duotone) {
-          const { w, h } = imageNaturalSize(src);
-          if (w > 0 && h > 0) {
-            src = await applyDuotone(src, ref.duotone, {
-              width: w,
-              height: h,
-              offscreenFactory: opts?.offscreenFactory,
-            });
-          }
-        }
-        // Cache the decode result keyed by (path + duotone colours) — INCLUDING a
-        // null for an unsupported metafile (true EMF / geometry-less WMF). Storing
-        // the null (matching pptx's getCachedBitmap) makes `imageCache.has(key)`
-        // short-circuit the per-render prefetch, so the blip is sniffed ONCE
-        // instead of re-fetched + re-sniffed every viewport frame. The renderer
-        // already skips a falsy source, so a cached null draws nothing.
+        // Record the resolved drawable (INCLUDING a null for an unsupported
+        // metafile, so the renderer skips a falsy source without a re-fetch).
         imageCache.set(key, src);
       } catch {
-        /* leave uncached; renderer skips a missing source */
+        /* transient failure: leave any prior entry; renderer skips a missing source */
       }
     }),
   );

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -10,8 +10,15 @@
  * stale sheets / images.
  */
 import init, { XlsxArchive, reinit } from './wasm/xlsx_parser.js';
-import { decodeDataUrl, preloadGoogleFonts, WasmParserHost } from '@silurus/ooxml-core';
-import { renderWorksheetViewport, closeAndClearImageCache } from './render-orchestrator.js';
+import {
+  decodeDataUrl,
+  preloadGoogleFonts,
+  WasmParserHost,
+  dropBitmapCacheByPath,
+  dropDuotoneBitmapCache,
+  dropSvgImageCache,
+} from '@silurus/ooxml-core';
+import { renderWorksheetViewport } from './render-orchestrator.js';
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import { resolveSharedStrings } from './shared-strings.js';
 import type { ParsedWorkbook, Worksheet } from './types.js';
@@ -37,6 +44,10 @@ let workbook: ParsedWorkbook | null = null;
  *  release — only the sequencing (fonts landed before first paint) matters. */
 let fontsLoaded: Promise<unknown> = Promise.resolve();
 const sheetCache = new Map<number, Worksheet>();
+// Synchronous-lookup map for the draw pass, keyed by imageCacheKey(path, duotone).
+// A pure lookup layer — the decoded bitmaps are owned by the shared, per-`getImage`
+// core caches; this is refreshed each frame by prefetchImages and dropped (along
+// with those shared caches) on re-parse.
 const imageCache = new Map<string, CanvasImageSource | null>();
 // Fetched image *bytes* (as Blobs) keyed by zip path. Twin of the docx render
 // worker's `imageCache`; kept separate from the decoded-source `imageCache`
@@ -100,11 +111,19 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
     await host.ensureReady();
     if (req.type === 'parse') {
       // A re-parse starts a fresh document: drop any cached sheets / images so
-      // we never serve stale data from a previous load. closeAndClearImageCache
-      // closes each cached ImageBitmap's GPU backing first — a bare `.clear()`
-      // would leak it (same fix as XlsxWorkbook.destroy(); see there for why).
+      // we never serve stale data from a previous load. `imageCache` is now a
+      // pure lookup map into the shared, per-`getImage` core caches (base raster,
+      // duotone recolour, SVG); clearing it drops lookup references, and dropping
+      // the three shared caches keyed by the module-level `getImage` closure
+      // releases the GPU-backed ImageBitmaps and SVG object URLs AND prevents the
+      // next document from being served a stale bitmap for an identically-named
+      // zip path. Symmetric with XlsxWorkbook.destroy() and the docx/pptx render
+      // workers (issue #781).
       sheetCache.clear();
-      closeAndClearImageCache(imageCache);
+      imageCache.clear();
+      dropBitmapCacheByPath(getImage);
+      dropDuotoneBitmapCache(getImage);
+      dropSvgImageCache(getImage);
       imageBlobCache.clear();
       const max =
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0

--- a/packages/xlsx/src/workbook-destroy.test.ts
+++ b/packages/xlsx/src/workbook-destroy.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { WorkerBridge, preloadGoogleFonts, type WorkerLike, type FontPreloadEntry } from '@silurus/ooxml-core';
+import {
+  WorkerBridge,
+  preloadGoogleFonts,
+  getCachedBitmapByPath,
+  getCachedDuotoneBitmapByPath,
+  type WorkerLike,
+  type FontPreloadEntry,
+  type OffscreenFactory,
+} from '@silurus/ooxml-core';
 import { XlsxWorkbook } from './workbook.js';
 
 /**
@@ -21,6 +29,9 @@ class SilentWorker implements WorkerLike {
     this.terminated = true;
   }
 }
+
+/** Flush pending microtasks so a drop's close-through-promise has run. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
 
 interface DestroyProbe {
   destroy(): void;
@@ -109,65 +120,118 @@ describe('XlsxWorkbook.destroy() — rejects in-flight worker requests', () => {
 });
 
 /**
- * `destroy()` must close every cached `ImageBitmap` (GPU-backed) before
- * dropping `imageCache`, not just `.clear()` it — a bare `.clear()` drops the
- * last reference without releasing the GPU backing, leaking it until GC (which
- * is not guaranteed to run promptly for GPU-backed objects). See
- * `closeAndClearImageCache` in render-orchestrator.ts.
+ * After #781 the decoded bitmaps are owned by the shared, per-`_fetchImage` core
+ * caches (base raster via getCachedBitmapByPath, `<a:duotone>` recolour via
+ * getCachedDuotoneBitmapByPath), NOT by the per-instance `imageCache` lookup map.
+ * `destroy()` must therefore drop those shared caches — a bare `imageCache.clear()`
+ * would drop only lookup references and leak the GPU backing until GC (which is
+ * not guaranteed to run promptly for GPU-backed objects). This is the same
+ * teardown discipline #779 fixed, expressed through the shared cache the way
+ * docx/pptx do. Pins the wiring: after a decode has landed in the shared caches
+ * keyed by the instance's `_fetchImage`, destroy() closes those bitmaps.
  */
-describe('XlsxWorkbook.destroy() — closes cached ImageBitmaps (GPU-leak guard)', () => {
-  function makeWorkbookWithImageCache(imageCache: Map<string, CanvasImageSource | null>) {
+describe('XlsxWorkbook.destroy() — drops the shared image caches (GPU-leak guard)', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function makeWorkbook(fetchImage: (path: string, mime: string) => Promise<Blob>) {
     const worker = new SilentWorker();
-    const bridge = new WorkerBridge<{ id?: number }>(worker, {
-      correlate: (r) => r.id,
-    });
+    const bridge = new WorkerBridge<{ id?: number }>(worker, { correlate: (r) => r.id });
     const instance = Object.create(XlsxWorkbook.prototype) as Record<string, unknown>;
     instance.bridge = bridge;
     instance.sheetCache = new Map();
-    instance.imageCache = imageCache;
+    instance.imageCache = new Map();
     instance.imageBlobCache = new Map();
     instance.googleFontFaces = [];
-    instance._fetchImage = () => Promise.resolve(new Blob());
-    return instance as unknown as DestroyProbe;
+    instance._fetchImage = fetchImage;
+    return instance as unknown as DestroyProbe & { imageCache: Map<string, unknown> };
   }
 
-  it('calls .close() on each cached ImageBitmap and empties the cache', () => {
-    const close1 = vi.fn();
-    const close2 = vi.fn();
-    const bmp1 = { close: close1 } as unknown as ImageBitmap;
-    const bmp2 = { close: close2 } as unknown as ImageBitmap;
-    const imageCache = new Map<string, CanvasImageSource | null>([
-      ['xl/media/image1.png', bmp1],
-      ['xl/media/image2.png', bmp2],
-    ]);
-    const wb = makeWorkbookWithImageCache(imageCache);
+  /** An offscreen surface for the duotone pixel pass in node (no OffscreenCanvas). */
+  function recordingFactory(): OffscreenFactory {
+    return ((w: number, h: number) => ({
+      width: w,
+      height: h,
+      getContext: () => ({
+        drawImage() {},
+        getImageData(_x: number, _y: number, sw: number, sh: number) {
+          const data = new Uint8ClampedArray(sw * sh * 4).fill(246);
+          for (let i = 3; i < data.length; i += 4) data[i] = 255;
+          return { data, width: sw, height: sh } as unknown as ImageData;
+        },
+        putImageData() {},
+      }),
+    })) as unknown as OffscreenFactory;
+  }
 
-    wb.destroy();
-
-    expect(close1).toHaveBeenCalledTimes(1);
-    expect(close2).toHaveBeenCalledTimes(1);
-    expect(imageCache.size).toBe(0);
-  });
-
-  it('skips a cached null (unsupported metafile) without throwing', () => {
-    const imageCache = new Map<string, CanvasImageSource | null>([
-      ['xl/media/diagram.emf', null],
-    ]);
-    const wb = makeWorkbookWithImageCache(imageCache);
-    expect(() => wb.destroy()).not.toThrow();
-    expect(imageCache.size).toBe(0);
-  });
-
-  it('is safe to destroy() twice — the second call does not re-close an already-closed bitmap', () => {
+  it('closes a base ImageBitmap decoded into the shared cache and empties the lookup map', async () => {
     const close = vi.fn();
-    const bmp = { close } as unknown as ImageBitmap;
-    const imageCache = new Map<string, CanvasImageSource | null>([['xl/media/image1.png', bmp]]);
-    const wb = makeWorkbookWithImageCache(imageCache);
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 1, height: 1, close }) as unknown as ImageBitmap),
+    );
+    const fetchImage = vi.fn(async (path: string, mime: string) =>
+      new Blob([new TextEncoder().encode(path)], { type: mime }),
+    );
+    const wb = makeWorkbook(fetchImage);
+    // Warm the shared cache the same way prefetchImages does — keyed by _fetchImage.
+    await getCachedBitmapByPath('xl/media/image1.png', 'image/png', fetchImage);
+    wb.imageCache.set('xl/media/image1.png', {});
+
+    wb.destroy();
+    await flush(); // the drop closes through the settled promise (a microtask)
+
+    expect(close).toHaveBeenCalledTimes(1); // dropBitmapCacheByPath closed it
+    expect(wb.imageCache.size).toBe(0);
+  });
+
+  it('closes a duotone recolour decoded into the shared duotone cache', async () => {
+    const baseClose = vi.fn();
+    const duoClose = vi.fn();
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async (src: unknown) =>
+        (src instanceof Blob
+          ? { width: 4, height: 4, close: baseClose }
+          : { width: 4, height: 4, close: duoClose }) as unknown as ImageBitmap,
+      ),
+    );
+    const fetchImage = vi.fn(async (path: string, mime: string) =>
+      new Blob([new TextEncoder().encode(path)], { type: mime }),
+    );
+    const wb = makeWorkbook(fetchImage);
+    await getCachedDuotoneBitmapByPath(
+      'xl/media/image1.png',
+      'image/png',
+      { clr1: '000000', clr2: 'FFF3F4' },
+      fetchImage,
+      { offscreenFactory: recordingFactory() },
+    );
+
+    wb.destroy();
+    await flush();
+
+    // dropDuotoneBitmapCache closed the recolour; dropBitmapCacheByPath the base.
+    expect(duoClose).toHaveBeenCalledTimes(1);
+    expect(baseClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('is safe to destroy() twice (dropping an already-dropped shared cache is a no-op)', async () => {
+    const close = vi.fn();
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 1, height: 1, close }) as unknown as ImageBitmap),
+    );
+    const fetchImage = vi.fn(async (path: string, mime: string) =>
+      new Blob([new TextEncoder().encode(path)], { type: mime }),
+    );
+    const wb = makeWorkbook(fetchImage);
+    await getCachedBitmapByPath('xl/media/image1.png', 'image/png', fetchImage);
 
     wb.destroy();
     expect(() => wb.destroy()).not.toThrow();
-    // The map is empty after the first destroy(), so the second pass has
-    // nothing to iterate — close() is called exactly once total.
+    await flush();
+    // The shared cache was forgotten on the first destroy(), so the second pass
+    // has nothing to close — close() runs exactly once total.
     expect(close).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/xlsx/src/workbook-fetchimage-identity.test.ts
+++ b/packages/xlsx/src/workbook-fetchimage-identity.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RenderViewportOptions, Worksheet } from './types.js';
+
+const { renderWorksheetViewport } = vi.hoisted(() => ({
+  renderWorksheetViewport: vi.fn(async (..._args: unknown[]) => undefined),
+}));
+
+vi.mock('./render-orchestrator.js', () => ({ renderWorksheetViewport }));
+
+import { XlsxWorkbook } from './workbook.js';
+
+describe('XlsxWorkbook.renderViewport() fetchImage identity', () => {
+  /**
+   * The stable instance closure keys the shared image caches, render-pass lease
+   * counter, and destroy-time cache drops. A per-call closure would split that
+   * namespace and leave its decoded images alive after destroy().
+   */
+  it('uses the instance fetchImage closure even when the caller supplies one', async () => {
+    const stableClosure = vi.fn(async () => new Blob());
+    const callerClosure = vi.fn(async () => new Blob());
+    const minimalWorksheet = {} as Worksheet;
+    const instance = Object.create(XlsxWorkbook.prototype) as Record<string, unknown>;
+    instance._mode = 'main';
+    instance.parsedWorkbook = { styles: {} };
+    instance.sheetCache = new Map([[0, minimalWorksheet]]);
+    instance.imageCache = new Map();
+    instance._fetchImage = stableClosure;
+
+    await (instance as unknown as XlsxWorkbook).renderViewport(
+      {} as HTMLCanvasElement,
+      0,
+      { row: 1, col: 1, rows: 1, cols: 1 },
+      { fetchImage: callerClosure },
+    );
+
+    const opts = renderWorksheetViewport.mock.calls[0]?.[3] as RenderViewportOptions;
+    expect(opts.fetchImage).toBe(stableClosure);
+    expect(opts.fetchImage).not.toBe(callerClosure);
+  });
+});

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -5,6 +5,8 @@ import {
   unloadGoogleFonts,
   WorkerBridge,
   defaultDpr,
+  dropBitmapCacheByPath,
+  dropDuotoneBitmapCache,
   dropSvgImageCache,
   resolveOoxmlContainer,
   toArrayBuffer,
@@ -13,7 +15,7 @@ import {
 } from '@silurus/ooxml-core';
 import type { ParsedWorkbook, Worksheet, ViewportRange, RenderViewportOptions, WorkerRequest, WorkerResponse, Cell, SheetVisibility } from './types.js';
 import { selectSheetVisibility } from './sheet-visibility.js';
-import { renderWorksheetViewport, closeAndClearImageCache } from './render-orchestrator.js';
+import { renderWorksheetViewport } from './render-orchestrator.js';
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import { formatCellValue } from './number-format.js';
 import { resolveSharedStrings } from './shared-strings.js';
@@ -447,13 +449,19 @@ export class XlsxWorkbook {
       unloadGoogleFonts(this.googleFontFaces);
       this.googleFontFaces = [];
     }
-    // Closes each cached ImageBitmap's GPU backing before dropping the map —
-    // see closeAndClearImageCache for why a bare `.clear()` would leak.
-    closeAndClearImageCache(this.imageCache);
-    this.imageBlobCache.clear();
-    // Revoke this workbook's decoded-SVG object URLs (raster sources live in the
-    // per-instance imageCache closed above).
+    // The per-instance imageCache is a pure synchronous-lookup map into the
+    // shared, per-`_fetchImage` core caches (base raster via getCachedBitmapByPath,
+    // duotone recolour via getCachedDuotoneBitmapByPath, SVG via
+    // getCachedSvgImageByPath) — the same ownership split docx/pptx use. Clearing
+    // the map only drops lookup references; the GPU-backed ImageBitmaps and SVG
+    // object URLs are released by dropping the three shared caches keyed by
+    // `_fetchImage`, so a discarded workbook frees its GPU/URL handles promptly
+    // rather than waiting for GC.
+    this.imageCache.clear();
+    dropBitmapCacheByPath(this._fetchImage);
+    dropDuotoneBitmapCache(this._fetchImage);
     dropSvgImageCache(this._fetchImage);
+    this.imageBlobCache.clear();
     this.rawData = null;
   }
 }

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -379,6 +379,14 @@ export class XlsxWorkbook {
     return formatCellValue(cell, this.parsedWorkbook.styles, null, ws.date1904);
   }
 
+  /**
+   * Render a sheet viewport into `target`. Note: `opts.fetchImage` is ignored
+   * here — image bytes always come from this workbook's own archive through its
+   * stable per-instance loader, whose closure identity keys the shared decoded
+   * caches, the render-pass lease, and {@link destroy}'s cache drops. Callers
+   * needing a custom byte source should use the standalone
+   * `renderWorksheetViewport` orchestrator directly.
+   */
   async renderViewport(
     target: HTMLCanvasElement | OffscreenCanvas,
     sheetIndex: number,
@@ -399,9 +407,15 @@ export class XlsxWorkbook {
       { ws, styles: this.parsedWorkbook.styles, imageCache: this.imageCache, math: this.math },
       target,
       viewport,
-      // Supply the lazy byte loader so the orchestrator can decode embedded
-      // images on demand; an explicit caller-provided fetchImage still wins.
-      { fetchImage: this._fetchImage, ...opts },
+      // Always render with THIS instance's stable `_fetchImage` closure (placed
+      // after the spread so it wins over a caller-supplied one, matching
+      // docx/pptx). The closure's identity is the namespace key for the shared
+      // per-document caches AND the render-pass lease counter, and destroy()
+      // drops exactly `_fetchImage`'s namespaces — a per-call closure would
+      // split the cache/lease namespace every render and leave its bitmaps
+      // undropped at destroy(). Callers who need a custom byte source use the
+      // orchestrator's renderWorksheetViewport directly.
+      { ...opts, fetchImage: this._fetchImage },
     );
   }
 


### PR DESCRIPTION
## Summary

Follow-up to the #779 review. #779 fixed the xlsx `ImageBitmap` teardown
leak with a local close-loop (`closeAndClearImageCache`); this consolidates
xlsx onto the shared, per-`fetchImage` core caches that docx and pptx
already use, then adds the symmetric re-parse teardown across all three
render workers. Closes #781.

## Design (shared-API contract, no xlsx-only branch)

xlsx previously decoded blips into a plain `Map<string, CanvasImageSource | null>`
that **owned** the resulting `ImageBitmap`s and needed a bespoke
`closeAndClearImageCache` to `.close()` them on destroy / re-parse. docx and
pptx instead decode through core's shared caches, which own the GPU-backed
bitmaps, bound them with an LRU, close them on eviction, and release them
per document via matching `drop*` calls:

- base raster / metafile → `getCachedBitmapByPath`
- `<a:duotone>` recolour (§20.1.8.23) → `getCachedDuotoneBitmapByPath`
- SVG vector original → `getCachedSvgImageByPath`

Changes:

- **`render-orchestrator.ts`** — `decodeImageSource` now routes the raster
  path through `getCachedDuotoneBitmapByPath` (a thin two-layer wrapper over
  `getCachedBitmapByPath`), folding the former standalone `applyDuotone`
  step into the shared decode; the SVG branch stays on
  `getCachedSvgImageByPath`. `prefetchImages` re-resolves every referenced
  image against the shared caches each pass — the way docx/pptx do — so a
  still-referenced blip whose bitmap was LRU-evicted (and closed) is
  transparently re-decoded rather than served closed. A shared-cache hit
  re-fetches no bytes and re-runs no decode.
- **The per-instance / per-worker `imageCache` map** becomes a pure
  synchronous-lookup layer for the grid draw, keyed by `imageCacheKey`,
  exactly like docx's `preloadImages` map. It no longer owns the bitmaps,
  so **the two synchronous lookup sites in `renderer.ts` need no change** —
  they still read that map by key. (The issue's "repoint 2 sites" assumed a
  peek-into-shared-cache design, but xlsx's fully-synchronous grid draw
  needs a mixed-type lookup covering raster + SVG + duotone, which
  `peekCachedBitmapByPath` doesn't cover; keeping the lookup map is docx's
  exact idiom for a synchronous draw.)
- **`closeAndClearImageCache` removed.** `XlsxWorkbook.destroy()` and the
  render worker's re-parse clear the lookup map and drop the three shared
  caches keyed by their `fetchImage` closure (`dropBitmapCacheByPath`,
  `dropDuotoneBitmapCache`, `dropSvgImageCache`).

No shared-API branch was added for xlsx: `getCachedDuotoneBitmapByPath`
already existed in core (used by pptx), and its own doc-comment noted xlsx
had not yet adopted it. xlsx's `<a:srcRect>` full-frame metafile sizing
stays in the xlsx caller as the `metafileRasterSize` opts it feeds the
shared decode — the same idiom pptx uses.

## Secondary (cross-package, separate commit)

None of the docx/pptx/xlsx render workers evicted the shared worker-mode
decoded caches on re-parse (byte caches only). Because each worker's
`getImage` closure is a stable module-level identity, a reused worker
re-parsing a document with an identically-named zip path could be served
the previous file's decoded bitmap, and the GPU / object-URL handles
lingered until the LRU cap. All three workers now drop the same caches
their `destroy()` drops, keyed by `getImage`.

## Eviction semantics pinned by tests (no #779 regression)

- After `prefetchImages`, dropping the shared **base** / **duotone** caches
  closes the decoded bitmaps (proving ownership moved to the shared cache —
  no teardown leak); clearing the lookup map never closes (non-owning, no
  double close).
- `XlsxWorkbook.destroy()` closes a base bitmap and a duotone recolour that
  were decoded into the shared caches keyed by the instance's `_fetchImage`,
  and empties the lookup map; safe to call twice.
- A second `prefetchImages` pass re-fetches nothing (shared-cache hit).

## Verification

- `vitest run packages/xlsx` — 510 passed.
- `vitest run packages/docx packages/pptx` — 1347 passed, 1 pre-existing skip.
- Node device-pixel probe `xlsx-blip-duotone-alpha.probe.test.ts` (renders
  a duotone + `alphaModFix` blip through the refactored orchestrator with
  skia) passes unchanged — pixel behaviour is identical, as expected for a
  pure refactor.
- Root `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)