### PR TITLE
feat(docx): implement w:fitText manual run width (ECMA-376 §17.3.2.14)

### DIFF
--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -7,30 +7,17 @@ use std::collections::{HashMap, HashSet};
 
 /// Parse a single VML CSS length (e.g. `width:9pt`) from a `style` attribute
 /// into pt. Supports the units Word emits for picture-bullet shapes: `pt`
-/// (1pt), `in` (72pt), `pc` (12pt), `cm` (28.3465pt), `mm` (2.83465pt). A bare
-/// number with no unit is treated as pt (VML's default user unit for shapes is
-/// the point). Returns `None` when the property is absent or unparseable.
+/// (1pt), `in` (72pt), `pc`/`pi` (12pt), `cm` (28.3465pt), `mm` (2.83465pt). A
+/// bare number with no unit is treated as pt (VML's default user unit for
+/// shapes is the point). Returns `None` when the property is absent or
+/// unparseable.
 fn vml_style_len(style: &str, prop: &str) -> Option<f64> {
     for decl in style.split(';') {
         let (k, v) = decl.split_once(':')?;
         if k.trim() != prop {
             continue;
         }
-        let v = v.trim();
-        let (num, factor) = if let Some(n) = v.strip_suffix("pt") {
-            (n, 1.0)
-        } else if let Some(n) = v.strip_suffix("in") {
-            (n, 72.0)
-        } else if let Some(n) = v.strip_suffix("pc") {
-            (n, 12.0)
-        } else if let Some(n) = v.strip_suffix("mm") {
-            (n, 2.834_645_7)
-        } else if let Some(n) = v.strip_suffix("cm") {
-            (n, 28.346_457)
-        } else {
-            (v, 1.0)
-        };
-        return num.trim().parse::<f64>().ok().map(|n| n * factor);
+        return parse_measure_to_pt(v, 1.0);
     }
     None
 }

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2977,6 +2977,16 @@ fn text_runs_mergeable(a: &TextRun, b: &TextRun) -> bool {
         && a.italic_cs == b.italic_cs
         && a.lang_bidi == b.lang_bidi
         && a.snap_to_grid == b.snap_to_grid
+        // Character metrics change measured or painted geometry, so every one
+        // must match before a noBreakHyphen run can be folded into its neighbour.
+        && a.char_spacing == b.char_spacing
+        && a.fit_text_val == b.fit_text_val
+        && a.fit_text_id == b.fit_text_id
+        && a.char_scale == b.char_scale
+        && a.position == b.position
+        && a.kerning == b.kerning
+        && a.east_asian_vert == b.east_asian_vert
+        && a.east_asian_vert_compress == b.east_asian_vert_compress
 }
 
 // Same parse-context threading as handle_run_in_para.
@@ -3120,8 +3130,11 @@ fn parse_run_inner(
     // char_scale as a horizontal glyph stretch, position as a baseline y-offset,
     // and kern as the ctx.fontKerning threshold (all measure==paint).
     let char_spacing = fmt.char_spacing;
-    let fit_text_val = fmt.fit_text_val;
-    let fit_text_id = fmt.fit_text_id;
+    let fit_text_val = fmt.fit_text.as_ref().map(|fit_text| fit_text.val);
+    let fit_text_id = fmt
+        .fit_text
+        .as_ref()
+        .and_then(|fit_text| fit_text.id.clone());
     let char_scale = fmt.char_scale;
     let position = fmt.position;
     let kerning = fmt.kerning;
@@ -3190,7 +3203,7 @@ fn parse_run_inner(
                         snap_to_grid,
                         char_spacing,
                         fit_text_val,
-                        fit_text_id,
+                        fit_text_id: fit_text_id.clone(),
                         char_scale,
                         position,
                         kerning,
@@ -3270,7 +3283,7 @@ fn parse_run_inner(
                         snap_to_grid,
                         char_spacing,
                         fit_text_val,
-                        fit_text_id,
+                        fit_text_id: fit_text_id.clone(),
                         char_scale,
                         position,
                         kerning,
@@ -3320,7 +3333,7 @@ fn parse_run_inner(
                     snap_to_grid,
                     char_spacing,
                     fit_text_val,
-                    fit_text_id,
+                    fit_text_id: fit_text_id.clone(),
                     char_scale,
                     position,
                     kerning,
@@ -3415,7 +3428,7 @@ fn parse_run_inner(
                     snap_to_grid,
                     char_spacing,
                     fit_text_val,
-                    fit_text_id,
+                    fit_text_id: fit_text_id.clone(),
                     char_scale,
                     position,
                     kerning,
@@ -3612,7 +3625,7 @@ fn parse_run_inner(
                     snap_to_grid,
                     char_spacing,
                     fit_text_val,
-                    fit_text_id,
+                    fit_text_id: fit_text_id.clone(),
                     char_scale,
                     position,
                     kerning,
@@ -8741,6 +8754,37 @@ mod tests {
         );
     }
 
+    // ECMA-376 §17.3.2.14: a fitText run renders at a MANUAL width, so merging
+    // a plain noBreakHyphen run into it (or vice versa) would silently extend
+    // the fixed-width region over glyphs that must lay out naturally. The
+    // `text_runs_mergeable` gate must treat `fit_text_val`/`fit_text_id` like
+    // every other formatting field.
+    #[test]
+    fn no_break_hyphen_does_not_merge_across_a_fit_text_change() {
+        let base = RunFmt::default();
+        let runs = parse_para(
+            concat!(
+                r#"<w:r><w:rPr><w:fitText w:val="2400" w:id="9"/></w:rPr><w:t>999</w:t></w:r>"#,
+                r#"<w:r><w:noBreakHyphen/><w:t>99</w:t></w:r>"#,
+            ),
+            &base,
+            &StyleMap::parse(""),
+        );
+        let texts: Vec<&str> = runs
+            .iter()
+            .filter_map(|r| match r {
+                DocRun::Text(t) => Some(t.text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            texts,
+            vec!["999", "-99"],
+            "a fitText difference must block the noBreakHyphen merge — the \
+             fixed-width \"999\" and the plain \"-99\" stay separate runs"
+        );
+    }
+
     /// Pins the `"type"` discriminant every `DocRun` variant serializes to on
     /// the wire, so a `#[serde(rename_all = "camelCase")]` heuristic mismatch
     /// (like the `PTab` → `"pTab"` bug fixed alongside this test — serde
@@ -9491,7 +9535,7 @@ mod cs_toggle_tests {
                </w:rPr><w:t>氏名</w:t></w:r></w:p>"#,
         );
         assert_eq!(run.fit_text_val, Some(2400.0));
-        assert_eq!(run.fit_text_id, Some(-1431456512));
+        assert_eq!(run.fit_text_id.as_deref(), Some("-1431456512"));
     }
 
     /// §17.3.2.40 `<w:u w:val>` → ST_Underline (§17.18.99). All 18 enum values

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3120,6 +3120,8 @@ fn parse_run_inner(
     // char_scale as a horizontal glyph stretch, position as a baseline y-offset,
     // and kern as the ctx.fontKerning threshold (all measure==paint).
     let char_spacing = fmt.char_spacing;
+    let fit_text_val = fmt.fit_text_val;
+    let fit_text_id = fmt.fit_text_id;
     let char_scale = fmt.char_scale;
     let position = fmt.position;
     let kerning = fmt.kerning;
@@ -3187,6 +3189,8 @@ fn parse_run_inner(
                         lang_bidi: lang_bidi.clone(),
                         snap_to_grid,
                         char_spacing,
+                        fit_text_val,
+                        fit_text_id,
                         char_scale,
                         position,
                         kerning,
@@ -3265,6 +3269,8 @@ fn parse_run_inner(
                         lang_bidi: lang_bidi.clone(),
                         snap_to_grid,
                         char_spacing,
+                        fit_text_val,
+                        fit_text_id,
                         char_scale,
                         position,
                         kerning,
@@ -3313,6 +3319,8 @@ fn parse_run_inner(
                     lang_bidi: lang_bidi.clone(),
                     snap_to_grid,
                     char_spacing,
+                    fit_text_val,
+                    fit_text_id,
                     char_scale,
                     position,
                     kerning,
@@ -3406,6 +3414,8 @@ fn parse_run_inner(
                     lang_bidi: lang_bidi.clone(),
                     snap_to_grid,
                     char_spacing,
+                    fit_text_val,
+                    fit_text_id,
                     char_scale,
                     position,
                     kerning,
@@ -3601,6 +3611,8 @@ fn parse_run_inner(
                     lang_bidi: lang_bidi.clone(),
                     snap_to_grid,
                     char_spacing,
+                    fit_text_val,
+                    fit_text_id,
                     char_scale,
                     position,
                     kerning,
@@ -9467,6 +9479,19 @@ mod cs_toggle_tests {
         assert!((run.char_scale.unwrap() - 0.67).abs() < 1e-9); // 67%
         assert_eq!(run.position, Some(-5.0)); // -10 half-pt = -5 pt (lowered)
         assert_eq!(run.kerning, Some(14.0)); // 28 half-pt = 14 pt threshold
+    }
+
+    #[test]
+    fn fit_text_flows_to_text_run_model() {
+        // ECMA-376 §17.3.2.14: preserve twips and the signed link id all the way
+        // from direct rPr to the camelCase-serialized TextRun model.
+        let run = run_of(
+            r#"<w:p><w:r><w:rPr>
+                 <w:fitText w:val="2400" w:id="-1431456512"/>
+               </w:rPr><w:t>氏名</w:t></w:r></w:p>"#,
+        );
+        assert_eq!(run.fit_text_val, Some(2400.0));
+        assert_eq!(run.fit_text_id, Some(-1431456512));
     }
 
     /// §17.3.2.40 `<w:u w:val>` → ST_Underline (§17.18.99). All 18 enum values

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -110,6 +110,13 @@ pub struct RunFmt {
     /// measure and paint so wrapping/pagination stay measure==paint. `None` =
     /// inherit (no additional pitch when never set in the style hierarchy).
     pub char_spacing: Option<f64>,
+    /// ECMA-376 §17.3.2.14 `<w:fitText w:val>` — target manual run width.
+    /// Stored in TWIPS (ST_TwipsMeasure, 1/20 pt) so the layout layer can apply
+    /// its px-per-pt scale exactly once. `None` = no manual run width.
+    pub fit_text_val: Option<f64>,
+    /// ECMA-376 §17.3.2.14 `<w:fitText w:id>` — signed identifier linking
+    /// consecutive fitText runs into one region. `None` keeps the run standalone.
+    pub fit_text_id: Option<i64>,
     /// ECMA-376 §17.3.2.43 `<w:w w:val>` — horizontal Expanded/Compressed text
     /// scale. ST_TextScale is a percentage of the normal (100%) character width
     /// (1%–600%), stored here as a FRACTION (e.g. `w:val="67"` or `"67%"` →
@@ -970,12 +977,18 @@ pub(crate) fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
     if src.lang_bidi.is_some() {
         dst.lang_bidi = src.lang_bidi.clone();
     }
-    // Run character-metric axes (§17.3.2.35 spacing / §17.3.2.43 w / §17.3.2.24
-    // position / §17.3.2.19 kern). Each carries the same "if omitted, inherit;
-    // if set, override" rule as the other run properties, so a level that names
-    // the attribute wins and absence inherits.
+    // Run character-metric axes (§17.3.2.14 fitText / §17.3.2.35 spacing /
+    // §17.3.2.43 w / §17.3.2.24 position / §17.3.2.19 kern). Each carries the
+    // same "if omitted, inherit; if set, override" rule as the other run
+    // properties, so a level that names the attribute wins and absence inherits.
     if src.char_spacing.is_some() {
         dst.char_spacing = src.char_spacing;
+    }
+    if src.fit_text_val.is_some() {
+        dst.fit_text_val = src.fit_text_val;
+    }
+    if src.fit_text_id.is_some() {
+        dst.fit_text_id = src.fit_text_id;
     }
     if src.char_scale.is_some() {
         dst.char_scale = src.char_scale;
@@ -1487,6 +1500,16 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
         if let Some(v) = attr_w(sp, "val") {
             fmt.char_spacing = Some(twips_to_pt(&v));
         }
+    }
+
+    // Manual run width (ECMA-376 §17.3.2.14 `<w:fitText>`). Keep w:val in
+    // ST_TwipsMeasure units; unlike w:spacing it is not converted to points here.
+    // ST_DecimalNumber is signed, and Word uses large negative ids in practice.
+    if let Some(fit_text) = child_w(rpr, "fitText") {
+        fmt.fit_text_val = attr_w(fit_text, "val")
+            .and_then(|value| value.parse::<f64>().ok())
+            .filter(|value| *value > 0.0);
+        fmt.fit_text_id = attr_w(fit_text, "id").and_then(|value| value.parse::<i64>().ok());
     }
 
     // Expanded/Compressed text scale (ECMA-376 §17.3.2.43 `<w:w w:val>`).
@@ -2300,6 +2323,15 @@ mod tests {
     }
 
     #[test]
+    fn fit_text_parses_twips_and_signed_id() {
+        // ECMA-376 §17.3.2.14: w:val is ST_TwipsMeasure and remains in twips;
+        // w:id is ST_DecimalNumber and may therefore be a large signed value.
+        let f = run_fmt_from(r#"<w:fitText w:val="2400" w:id="-1431456512"/>"#);
+        assert_eq!(f.fit_text_val, Some(2400.0));
+        assert_eq!(f.fit_text_id, Some(-1431456512));
+    }
+
+    #[test]
     fn run_spacing_does_not_collide_with_para_spacing() {
         // The paragraph `<w:spacing before/after/line>` (§17.3.1.33) must never
         // populate the run char_spacing, and the run `<w:spacing w:val>` must
@@ -2369,15 +2401,22 @@ mod tests {
         // The four axes follow the shared "set overrides, absent inherits" rule
         // in `apply_run` (used by both the style cascade and apply_direct_run).
         let mut base = run_fmt_from(
-            r#"<w:spacing w:val="200"/><w:w w:val="90"/><w:position w:val="4"/><w:kern w:val="24"/>"#,
+            r#"<w:fitText w:val="2400" w:id="-10"/><w:spacing w:val="200"/><w:w w:val="90"/><w:position w:val="4"/><w:kern w:val="24"/>"#,
         );
         // A later level that only re-sets spacing must keep the inherited w /
         // position / kern.
         let over = run_fmt_from(r#"<w:spacing w:val="-20"/>"#);
         apply_run(&mut base, &over);
         assert_eq!(base.char_spacing, Some(-1.0)); // overridden
+        assert_eq!(base.fit_text_val, Some(2400.0)); // inherited
+        assert_eq!(base.fit_text_id, Some(-10)); // inherited
         assert_eq!(base.char_scale, Some(0.90)); // inherited
         assert_eq!(base.position, Some(2.0)); // inherited (8 half-pt = 4 pt? no: val=4 → 2pt)
         assert_eq!(base.kerning, Some(12.0)); // inherited (24 half-pt = 12 pt)
+
+        let fit_override = run_fmt_from(r#"<w:fitText w:val="1200" w:id="-20"/>"#);
+        apply_run(&mut base, &fit_override);
+        assert_eq!(base.fit_text_val, Some(1200.0));
+        assert_eq!(base.fit_text_id, Some(-20));
     }
 }

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -2,6 +2,16 @@ use crate::xml_util::*;
 use ooxml_common::depth::parse_guarded;
 use std::collections::HashMap;
 
+/// ECMA-376 §17.3.2.14 `<w:fitText>` as one cascaded run property.
+#[derive(Clone, PartialEq, Debug)]
+pub struct FitTextSpec {
+    /// Target manual run width in TWIPS (`ST_TwipsMeasure`, 1/20 pt).
+    pub val: f64,
+    /// Raw, trimmed `ST_DecimalNumber` identifier. Its arbitrary-precision XSD
+    /// integer domain is preserved because it is used only for equality linking.
+    pub id: Option<String>,
+}
+
 /// Resolved run (character) formatting.
 #[derive(Debug, Clone, Default)]
 pub struct RunFmt {
@@ -110,13 +120,10 @@ pub struct RunFmt {
     /// measure and paint so wrapping/pagination stay measure==paint. `None` =
     /// inherit (no additional pitch when never set in the style hierarchy).
     pub char_spacing: Option<f64>,
-    /// ECMA-376 §17.3.2.14 `<w:fitText w:val>` — target manual run width.
-    /// Stored in TWIPS (ST_TwipsMeasure, 1/20 pt) so the layout layer can apply
-    /// its px-per-pt scale exactly once. `None` = no manual run width.
-    pub fit_text_val: Option<f64>,
-    /// ECMA-376 §17.3.2.14 `<w:fitText w:id>` — signed identifier linking
-    /// consecutive fitText runs into one region. `None` keeps the run standalone.
-    pub fit_text_id: Option<i64>,
+    /// ECMA-376 §17.3.2.14 `<w:fitText>` — manual run width and optional link
+    /// id. The element cascades as one composite property, so a direct element
+    /// without `w:id` clears an inherited id instead of retaining it.
+    pub fit_text: Option<FitTextSpec>,
     /// ECMA-376 §17.3.2.43 `<w:w w:val>` — horizontal Expanded/Compressed text
     /// scale. ST_TextScale is a percentage of the normal (100%) character width
     /// (1%–600%), stored here as a FRACTION (e.g. `w:val="67"` or `"67%"` →
@@ -984,11 +991,8 @@ pub(crate) fn apply_run(dst: &mut RunFmt, src: &RunFmt) {
     if src.char_spacing.is_some() {
         dst.char_spacing = src.char_spacing;
     }
-    if src.fit_text_val.is_some() {
-        dst.fit_text_val = src.fit_text_val;
-    }
-    if src.fit_text_id.is_some() {
-        dst.fit_text_id = src.fit_text_id;
+    if src.fit_text.is_some() {
+        dst.fit_text.clone_from(&src.fit_text);
     }
     if src.char_scale.is_some() {
         dst.char_scale = src.char_scale;
@@ -1502,14 +1506,22 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
         }
     }
 
-    // Manual run width (ECMA-376 §17.3.2.14 `<w:fitText>`). Keep w:val in
-    // ST_TwipsMeasure units; unlike w:spacing it is not converted to points here.
-    // ST_DecimalNumber is signed, and Word uses large negative ids in practice.
+    // Manual run width (ECMA-376 §17.3.2.14 `<w:fitText>`). The whole element is
+    // one cascaded property. Keep w:val in ST_TwipsMeasure units; suffixed
+    // ST_PositiveUniversalMeasure values are normalized back to twips. Preserve
+    // w:id as its trimmed lexical XSD integer because it has arbitrary precision
+    // and is used only for equality linking.
     if let Some(fit_text) = child_w(rpr, "fitText") {
-        fmt.fit_text_val = attr_w(fit_text, "val")
-            .and_then(|value| value.parse::<f64>().ok())
-            .filter(|value| *value > 0.0);
-        fmt.fit_text_id = attr_w(fit_text, "id").and_then(|value| value.parse::<i64>().ok());
+        fmt.fit_text = attr_w(fit_text, "val")
+            .and_then(|value| parse_measure_to_pt(&value, 1.0 / 20.0))
+            .map(|points| points * 20.0)
+            .filter(|value| *value >= 0.0)
+            .map(|val| FitTextSpec {
+                val,
+                id: attr_w(fit_text, "id")
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty()),
+            });
     }
 
     // Expanded/Compressed text scale (ECMA-376 §17.3.2.43 `<w:w w:val>`).
@@ -2327,8 +2339,60 @@ mod tests {
         // ECMA-376 §17.3.2.14: w:val is ST_TwipsMeasure and remains in twips;
         // w:id is ST_DecimalNumber and may therefore be a large signed value.
         let f = run_fmt_from(r#"<w:fitText w:val="2400" w:id="-1431456512"/>"#);
-        assert_eq!(f.fit_text_val, Some(2400.0));
-        assert_eq!(f.fit_text_id, Some(-1431456512));
+        let fit_text = f.fit_text.expect("fitText");
+        assert_eq!(fit_text.val, 2400.0);
+        assert_eq!(fit_text.id.as_deref(), Some("-1431456512"));
+    }
+
+    #[test]
+    fn fit_text_cascades_as_one_composite_property() {
+        // ECMA-376 §17.3.2.14: a direct `<w:fitText>` ELEMENT replaces the
+        // inherited one as a UNIT. Omitting `w:id` on the direct element means
+        // "this run does not link with any other run" — the style level's id
+        // must NOT survive underneath the direct val (val and id are one
+        // composite property, not two independently-cascading axes).
+        let mut base = run_fmt_from(r#"<w:fitText w:val="2400" w:id="7"/>"#);
+        let over = run_fmt_from(r#"<w:fitText w:val="1200"/>"#);
+        apply_run(&mut base, &over);
+        assert_eq!(
+            base.fit_text.as_ref().map(|fit_text| fit_text.val),
+            Some(1200.0)
+        );
+        assert!(
+            base.fit_text.and_then(|fit_text| fit_text.id).is_none(),
+            "a direct fitText WITHOUT w:id must clear the inherited id"
+        );
+    }
+
+    #[test]
+    fn fit_text_id_preserves_arbitrary_precision_decimals() {
+        // §17.18.10 ST_DecimalNumber is an XSD integer with NO range facet —
+        // arbitrary precision. An id wider than i64 / an f64 mantissa must
+        // still survive parsing so equality linking of consecutive runs works.
+        let f = run_fmt_from(r#"<w:fitText w:val="2400" w:id="123456789012345678901234567890"/>"#);
+        assert!(
+            f.fit_text.and_then(|fit_text| fit_text.id).is_some(),
+            "an arbitrary-precision w:id must be preserved for equality linking"
+        );
+    }
+
+    #[test]
+    fn fit_text_val_accepts_positive_universal_measures() {
+        // ST_TwipsMeasure (§22.9.2.14) = ST_UnsignedDecimalNumber |
+        // ST_PositiveUniversalMeasure — a plain number is twips, but the
+        // suffixed forms ('1in', '12pt', '2cm', …) are equally valid.
+        let inch = run_fmt_from(r#"<w:fitText w:val="1in" w:id="1"/>"#);
+        assert_eq!(
+            inch.fit_text.map(|fit_text| fit_text.val),
+            Some(1440.0),
+            "1in = 1440 twips"
+        );
+        let pt = run_fmt_from(r#"<w:fitText w:val="12pt" w:id="1"/>"#);
+        assert_eq!(
+            pt.fit_text.map(|fit_text| fit_text.val),
+            Some(240.0),
+            "12pt = 240 twips"
+        );
     }
 
     #[test]
@@ -2408,15 +2472,29 @@ mod tests {
         let over = run_fmt_from(r#"<w:spacing w:val="-20"/>"#);
         apply_run(&mut base, &over);
         assert_eq!(base.char_spacing, Some(-1.0)); // overridden
-        assert_eq!(base.fit_text_val, Some(2400.0)); // inherited
-        assert_eq!(base.fit_text_id, Some(-10)); // inherited
+        assert_eq!(
+            base.fit_text.as_ref().map(|fit_text| fit_text.val),
+            Some(2400.0)
+        ); // inherited
+        assert_eq!(
+            base.fit_text
+                .as_ref()
+                .and_then(|fit_text| fit_text.id.as_deref()),
+            Some("-10")
+        ); // inherited
         assert_eq!(base.char_scale, Some(0.90)); // inherited
         assert_eq!(base.position, Some(2.0)); // inherited (8 half-pt = 4 pt? no: val=4 → 2pt)
         assert_eq!(base.kerning, Some(12.0)); // inherited (24 half-pt = 12 pt)
 
         let fit_override = run_fmt_from(r#"<w:fitText w:val="1200" w:id="-20"/>"#);
         apply_run(&mut base, &fit_override);
-        assert_eq!(base.fit_text_val, Some(1200.0));
-        assert_eq!(base.fit_text_id, Some(-20));
+        assert_eq!(
+            base.fit_text.as_ref().map(|fit_text| fit_text.val),
+            Some(1200.0)
+        );
+        assert_eq!(
+            base.fit_text.and_then(|fit_text| fit_text.id),
+            Some("-20".to_string())
+        );
     }
 }

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1342,6 +1342,14 @@ pub struct TextRun {
     /// pitch.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub char_spacing: Option<f64>,
+    /// ECMA-376 §17.3.2.14 `<w:fitText w:val>` — manual run-width target in
+    /// TWIPS (1/20 pt). Consecutive runs with the same `fit_text_id` form one
+    /// region; an id-less run is standalone.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fit_text_val: Option<f64>,
+    /// ECMA-376 §17.3.2.14 `<w:fitText w:id>` — signed fit-region identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fit_text_id: Option<i64>,
     /// ECMA-376 §17.3.2.43 `<w:w w:val>` — horizontal text scale as a FRACTION of
     /// normal character width (e.g. 0.67 = 67%, 2.0 = 200%). Stretches each
     /// glyph's width (not the gap). `None` = 100%.

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1347,9 +1347,10 @@ pub struct TextRun {
     /// region; an id-less run is standalone.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fit_text_val: Option<f64>,
-    /// ECMA-376 §17.3.2.14 `<w:fitText w:id>` — signed fit-region identifier.
+    /// ECMA-376 §17.3.2.14 `<w:fitText w:id>` — arbitrary-precision signed
+    /// XSD integer serialized as a string for exact equality linking.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fit_text_id: Option<i64>,
+    pub fit_text_id: Option<String>,
     /// ECMA-376 §17.3.2.43 `<w:w w:val>` — horizontal text scale as a FRACTION of
     /// normal character width (e.g. 0.67 = 67%, 2.0 = 200%). Stretches each
     /// glyph's width (not the gap). `None` = 100%.

--- a/packages/docx/parser/src/xml_util.rs
+++ b/packages/docx/parser/src/xml_util.rs
@@ -62,6 +62,39 @@ pub fn attr_w(node: Node, name: &str) -> Option<String> {
     .map(|s| s.to_string())
 }
 
+/// Parse a bare decimal or an ECMA-376 universal measure into points.
+///
+/// Suffixed values use the fixed physical-unit conversions from
+/// `ST_UniversalMeasure` (`pt`, `in`, `pc`/`pi`, `mm`, `cm`). The meaning of a
+/// bare number is context-dependent, so callers supply its points-per-unit
+/// scale: VML shape lengths use `1.0`, while `ST_TwipsMeasure` uses `1.0 / 20.0`.
+pub(crate) fn parse_measure_to_pt(value: &str, unitless_scale: f64) -> Option<f64> {
+    let value = value.trim();
+    let (number, scale) = if let Some(number) = value.strip_suffix("pt") {
+        (number, 1.0)
+    } else if let Some(number) = value.strip_suffix("in") {
+        (number, 72.0)
+    } else if let Some(number) = value
+        .strip_suffix("pc")
+        .or_else(|| value.strip_suffix("pi"))
+    {
+        (number, 12.0)
+    } else if let Some(number) = value.strip_suffix("mm") {
+        (number, 72.0 / 25.4)
+    } else if let Some(number) = value.strip_suffix("cm") {
+        (number, 72.0 / 2.54)
+    } else {
+        (value, unitless_scale)
+    };
+
+    number
+        .trim()
+        .parse::<f64>()
+        .ok()
+        .filter(|number| number.is_finite())
+        .map(|number| number * scale)
+}
+
 /// Parse twips (1/20 pt) string to f64 pt.
 pub fn twips_to_pt(s: &str) -> f64 {
     s.parse::<f64>().unwrap_or(0.0) / 20.0

--- a/packages/docx/src/find-highlight-layer.ts
+++ b/packages/docx/src/find-highlight-layer.ts
@@ -84,6 +84,13 @@ export function buildDocxHighlightLayer(
       if (!run) continue;
       const measure = measureForFont(run.font);
       const extent = sliceHorizontalExtent(run.text, slice.start, slice.end, measure);
+      // Canvas draws glyph i at measure(prefix_i) + i*pitch. Keep the shared
+      // natural-width slice intact and compose the DOCX-only pitch before the
+      // 縦中横 scale; no pitch follows the slice's final glyph.
+      const pitch = run.letterSpacingPx ?? 0;
+      const end = Math.min(slice.end, [...run.text].length);
+      const pitchedX = extent.x + slice.start * pitch;
+      const pitchedWidth = extent.width + Math.max(0, end - slice.start - 1) * pitch;
       // ECMA-376 §17.3.2.10 縦中横 (#836): a tate-chu-yoko run is drawn compressed
       // into one em cell (`run.w`), so its natural per-glyph extents overshoot the
       // drawn box. Scale the slice offset + width by `run.w / naturalWidth` so the
@@ -91,8 +98,8 @@ export function buildDocxHighlightLayer(
       // ordinary run — see tate-chu-yoko-overlay.ts). Applying one factor keeps a
       // partial match proportional within the cell.
       const k = tateChuYokoOverlayScale(run, measure);
-      const x = extent.x * k;
-      const width = extent.width * k;
+      const x = pitchedX * k;
+      const width = pitchedWidth * k;
       if (width <= 0) continue;
       const box = document.createElement('div');
       // A vertical (tbRl) page reports the run at its physical top-left and

--- a/packages/docx/src/fit-text-fixes.test.ts
+++ b/packages/docx/src/fit-text-fixes.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  buildSegments,
+  layoutLines,
+  type LayoutSeg,
+  type LayoutTextSeg,
+} from './line-layout.js';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { DocxTextRunInfo } from './renderer.js';
+import { buildDocxTextLayer } from './text-layer.js';
+import { buildDocxHighlightLayer, type DocxHighlightMatch } from './find-highlight-layer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ECMA-376 §17.3.2.14 `<w:fitText>` — review-fix contracts (PR #918 follow-up).
+//
+// Each block pins one adjudicated finding of the fitText adversarial review:
+//   1. a SINGLE-character region still occupies exactly `w:val` (the glyph sits
+//      at the region start at its natural width; the cell pads to the target —
+//      glyph stretching is deferred until compression ground truth exists),
+//   2. a TAB inside a fitText run splits the region at the tab boundary (a tab
+//      advance is not a glyph advance): each text fragment is its own region,
+//   3. fitted geometry reaches the selection/find overlays: `onTextRun` reports
+//      the drawn per-glyph letter-spacing, the text layer applies it to the
+//      selection span, and the find-highlight layer offsets slice extents by it,
+//   4. small-caps case transforms that CHANGE the code-point count (ß → SS)
+//      count the EMITTED text, keeping the region advance pinned to `w:val`,
+//   7. a fit region inside a justified (§17.18.44) line contributes NO internal
+//      gaps to the paragraph-justify distribution, so the line still reaches
+//      the right margin and the region's internal pitch stays the region's own.
+// (Finding numbers follow the review; 5/6/8 are Rust-side and pinned in
+// styles.rs / parser.rs.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ENV = { pageIndex: 0, totalPages: 1 };
+
+function modelRun(text: string, extra: Partial<DocxTextRun> = {}): DocxTextRun & { type: 'text' } {
+  return {
+    type: 'text',
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 12, color: null, fontFamily: 'serif', isLink: false,
+    background: null, vertAlign: null, hyperlink: null, allCaps: false,
+    smallCaps: false, doubleStrikethrough: false, ...extra,
+  } as DocxTextRun & { type: 'text' };
+}
+
+/** Linear ctx: every code point advances exactly the font px (12pt → 12px). */
+function makeLinearCtx(): CanvasRenderingContext2D {
+  let font = '12px serif';
+  const ctx = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    letterSpacing: '0px',
+    fontKerning: 'auto',
+    measureText(text: string) {
+      const px = Number(/([\d.]+)px/.exec(font)?.[1] ?? 12);
+      return {
+        width: [...text].length * px,
+        fontBoundingBoxAscent: px * 0.8,
+        fontBoundingBoxDescent: px * 0.2,
+        actualBoundingBoxAscent: px * 0.8,
+        actualBoundingBoxDescent: px * 0.2,
+      } as TextMetrics;
+    },
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function textSegments(segs: LayoutSeg[]): LayoutTextSeg[] {
+  return segs.filter((seg): seg is LayoutTextSeg => 'text' in seg);
+}
+
+describe('§17.3.2.14 single-character region (finding 1)', () => {
+  it('a one-glyph region occupies exactly w:val (advance = target, glyph at region start)', () => {
+    // One run "氏" (1 cp, 12 px natural), val=2400 twips = 120 pt. §17.3.2.14
+    // displays the contents "in the width specified": the region cell is 120 px
+    // even though no inter-character gap exists. The glyph is NOT stretched
+    // (compression/stretch ground truth pending); the cell pads after it.
+    const lines = layoutLines(
+      makeLinearCtx(),
+      buildSegments([modelRun('氏', { fitTextVal: 2400 })], ENV),
+      1000, 0, 1,
+    );
+    const segs = textSegments(lines[0].segments);
+    expect(segs).toHaveLength(1);
+    expect(segs[0].measuredWidth).toBeCloseTo(120, 9);
+  });
+
+  it('a following run starts at the single-glyph region target edge', () => {
+    const lines = layoutLines(
+      makeLinearCtx(),
+      buildSegments([
+        modelRun('氏', { fitTextVal: 2400 }),
+        modelRun('あと'),
+      ], ENV),
+      1000, 0, 1,
+    );
+    const segs = textSegments(lines[0].segments);
+    expect(segs).toHaveLength(2);
+    // Pen space: seg 0 advance is the full 120 px cell, so 'あと' begins at 120.
+    expect(segs[0].measuredWidth).toBeCloseTo(120, 9);
+  });
+});
+
+describe('§17.3.2.14 tab inside a fitText run (finding 2)', () => {
+  it('a tab splits the region: each text fragment is its own full region', () => {
+    // "AB\tCD" with val=2400: a tab advance is resolved against tab stops, not
+    // glyph advances, so it cannot participate in a fit region. The region is
+    // split at the tab boundary; each fragment fits `w:val` independently
+    // (adjudicated contract — Word's behaviour for this degenerate input is
+    // unobserved). Neither fragment's charCount may include the tab.
+    const lines = layoutLines(
+      makeLinearCtx(),
+      buildSegments([modelRun('AB\tCD', { fitTextVal: 2400, fitTextId: 5 })], ENV),
+      1000, 0, 1,
+    );
+    const segs = textSegments(lines[0].segments);
+    expect(segs.map((s) => s.text)).toEqual(['AB', 'CD']);
+    // Each fragment is a self-consistent region: natural 24 + gaps = 120.
+    expect(segs[0].measuredWidth).toBeCloseTo(120, 9);
+    expect(segs[1].measuredWidth).toBeCloseTo(120, 9);
+    // Fragments are SEPARATE regions (no cross-tab boundary gap linking them).
+    expect(segs[0].fitTextRegionIndex).not.toBe(segs[1].fitTextRegionIndex);
+  });
+});
+
+describe('§17.3.2.33 small caps changing the code-point count (finding 4)', () => {
+  it('ß → SS: the region charCount follows the EMITTED text and the advance stays w:val', () => {
+    // "aß" small-caps emits "ASS" (3 cps) — one more code point than the source
+    // run text (2 cps). The per-gap divisor must count the emitted glyphs or the
+    // folded advance overshoots the target.
+    const lines = layoutLines(
+      makeLinearCtx(),
+      buildSegments([modelRun('aß', { fitTextVal: 2400, smallCaps: true })], ENV),
+      1000, 0, 1,
+    );
+    const segs = textSegments(lines[0].segments);
+    expect(segs.map((s) => s.text).join('')).toBe('ASS');
+    expect(segs.reduce((sum, s) => sum + s.measuredWidth, 0)).toBeCloseTo(120, 9);
+  });
+});
+
+// ── Paint-level contracts (recording canvas, model → renderDocumentToCanvas) ──
+
+const FONT_PX = 20;
+
+interface FillCall {
+  text: string;
+  x: number;
+  y: number;
+  letterSpacing: string;
+  translateX: number;
+  scaleX: number;
+  scaleY: number;
+}
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[] } {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const fills: FillCall[] = [];
+  let scaleX = 1;
+  let scaleY = 1;
+  let translateX = 0;
+  const stack: { scaleX: number; scaleY: number; translateX: number }[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(v: string) { letterSpacing = v; },
+    fontKerning: 'auto',
+    measureText: (s: string) => {
+      const p = px();
+      const w = [...s].length * p;
+      return {
+        width: w,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() { stack.push({ scaleX, scaleY, translateX }); },
+    restore() { const s = stack.pop(); if (s) { scaleX = s.scaleX; scaleY = s.scaleY; translateX = s.translateX; } },
+    beginPath() {}, closePath() {}, moveTo() {}, lineTo() {}, stroke() {}, fill() {},
+    fillRect() {}, strokeRect() {}, clip() {}, rect() {}, setLineDash() {},
+    drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    scale(sx: number, sy?: number) { scaleX *= sx; scaleY *= sy ?? sx; },
+    translate(tx: number) { translateX += tx; },
+    rotate() {},
+    fillText(text: string, x: number, y: number) {
+      fills.push({ text, x, y, letterSpacing, translateX, scaleX, scaleY });
+    },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, textBaseline: 'alphabetic' as CanvasTextBaseline,
+    direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills };
+}
+
+function paintRun(text: string, extra: Partial<DocxTextRun> = {}): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: FONT_PX, color: null, fontFamily: 'NotInMetrics', isLink: false,
+    background: null, vertAlign: null, hyperlink: null, ...extra,
+  };
+}
+
+type ParaRun = DocParagraph['runs'][number];
+
+function para(runs: DocxTextRun[], alignment = 'left'): BodyElement {
+  const p: DocParagraph = {
+    alignment, indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: runs.map((r) => ({ type: 'text', ...r }) as ParaRun),
+    defaultFontSize: FONT_PX, defaultFontFamily: 'NotInMetrics', widowControl: false,
+  } as DocParagraph;
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function section(extra: Partial<SectionProps> = {}): SectionProps {
+  return {
+    pageWidth: 590, pageHeight: 600, marginTop: 0, marginRight: 0, marginBottom: 0,
+    marginLeft: 0, headerDistance: 0, footerDistance: 0, titlePage: false,
+    evenAndOddHeaders: false, ...extra,
+  } as SectionProps;
+}
+
+function doc(body: BodyElement[], sec: SectionProps): DocxDocumentModel {
+  return {
+    section: sec, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(
+  body: BodyElement[],
+  sec: SectionProps = section(),
+  onTextRun?: (r: DocxTextRunInfo) => void,
+): Promise<FillCall[]> {
+  const { canvas, fills } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc(body, sec), canvas, 0, {
+    dpr: 1, width: sec.pageWidth, ...(onTextRun ? { onTextRun } : {}),
+  });
+  return fills;
+}
+
+describe('§17.18.44 justify around a fit region (finding 7)', () => {
+  it('paragraph justify excludes region-internal gaps and the line reaches the right margin', async () => {
+    // Page 590 wide, margins 0, jc=both. Line 1: fit region "あい" (val=1600 =
+    // 80 pt cell, natural 40, per-gap 40) + 25 of the following CJK run's glyphs
+    // (25 × 20 = 500) → natural line 580, slack 10. The fit region's INTERNAL
+    // boundary must NOT receive a share of the paragraph slack (its pitch is
+    // fixed by §17.3.2.14); the slack goes to the legal inter-CJK gaps so the
+    // line's last glyph lands on the right margin (590).
+    const fills = await render(
+      [para([
+        paintRun('あい', { fitTextVal: 1600 }),
+        paintRun('い'.repeat(40)),
+      ], 'both')],
+    );
+    const fit = fills.find((f) => f.text === 'あい');
+    expect(fit, 'fit region painted as one contextual fillText').toBeDefined();
+    // The region's internal pitch stays the region per-gap — 40 px exactly, no
+    // justify pollution on top.
+    expect(parseFloat((fit as FillCall).letterSpacing)).toBeCloseTo(40, 6);
+
+    const line1Tail = fills.find((f) => f.text.startsWith('い') && f.y === (fit as FillCall).y);
+    expect(line1Tail, 'line-1 tail of the following run painted').toBeDefined();
+    const tail = line1Tail as FillCall;
+    const cps = [...tail.text].length;
+    const pitch = parseFloat(tail.letterSpacing);
+    // Right edge of the justified line: tail natural + internal pitch must end
+    // at the right margin (590).
+    expect(tail.x + cps * FONT_PX + (cps - 1) * pitch).toBeCloseTo(590, 4);
+  });
+});
+
+describe('fitted geometry reaches onTextRun (finding 3)', () => {
+  it('onTextRun reports the drawn per-glyph letter-spacing of a fit segment', async () => {
+    const infos: DocxTextRunInfo[] = [];
+    await render(
+      [para([paintRun('あい', { fitTextVal: 1600 }), paintRun('かき')])],
+      section(),
+      (r) => infos.push(r),
+    );
+    const fit = infos.find((r) => r.text === 'あい');
+    const plain = infos.find((r) => r.text === 'かき');
+    expect(fit).toBeDefined();
+    expect(plain).toBeDefined();
+    // Contract: DocxTextRunInfo.letterSpacingPx = the uniform per-code-point
+    // pitch the run was DRAWN with (the §17.3.2.14 region per-gap here), so the
+    // selection / find overlays can reproduce the fitted glyph geometry.
+    expect((fit as DocxTextRunInfo & { letterSpacingPx?: number }).letterSpacingPx)
+      .toBeCloseTo(40, 6);
+    expect((plain as DocxTextRunInfo & { letterSpacingPx?: number }).letterSpacingPx ?? 0)
+      .toBeCloseTo(0, 6);
+    // The reported width stays the fitted advance (cell width for the whole
+    // region: natural 40 + 1 gap × 40 = 80).
+    expect((fit as DocxTextRunInfo).w).toBeCloseTo(80, 6);
+  });
+});
+
+// ── Overlay contracts (fake DOM, node env) ──
+
+interface FakeEl {
+  tag: string;
+  textContent: string;
+  innerHTML: string;
+  style: Record<string, string> & { cssText: string };
+  children: FakeEl[];
+  appendChild(c: FakeEl): void;
+  addEventListener(): void;
+  title?: string;
+}
+
+function makeEl(tag: string): FakeEl {
+  const style: Record<string, string> = {};
+  const el: FakeEl = {
+    tag,
+    textContent: '',
+    innerHTML: '',
+    children: [],
+    style: new Proxy(style as Record<string, string> & { cssText: string }, {
+      set(target, prop: string, value: string) {
+        if (prop === 'cssText') {
+          for (const decl of value.split(';')) {
+            const idx = decl.indexOf(':');
+            if (idx > 0) target[decl.slice(0, idx).trim()] = decl.slice(idx + 1).trim();
+          }
+          target.cssText = value;
+        } else {
+          target[prop] = value;
+        }
+        return true;
+      },
+    }),
+    appendChild(c: FakeEl) { this.children.push(c); },
+    addEventListener() {},
+  };
+  return el;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+function runInfo(partial: Record<string, unknown>): DocxTextRunInfo {
+  return {
+    text: 'X', x: 0, y: 0, w: 10, h: 12, fontSize: 12, font: '12px serif',
+    ...partial,
+  } as DocxTextRunInfo;
+}
+
+describe('selection span uses the drawn letter-spacing (finding 3)', () => {
+  it('a run with letterSpacingPx renders its span with that CSS letter-spacing', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    buildDocxTextLayer(
+      layer as unknown as HTMLDivElement,
+      [runInfo({ text: '氏名', letterSpacingPx: 9.6 })],
+      700, 900,
+    );
+    expect(layer.children).toHaveLength(1);
+    expect(layer.children[0].style['letter-spacing']).toBe('9.6px');
+  });
+
+  it('a run without letterSpacingPx keeps the letter-spacing reset (0)', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    buildDocxTextLayer(
+      layer as unknown as HTMLDivElement,
+      [runInfo({ text: 'plain' })],
+      700, 900,
+    );
+    expect(layer.children[0].style['letter-spacing']).toBe('0');
+  });
+});
+
+describe('find-highlight slices use the fitted advance (finding 3)', () => {
+  // Monospace measurer: each char 12 px.
+  const measureForFont = () => (s: string) => [...s].length * 12;
+
+  it('a partial match inside a fitted run is offset and widened by the per-glyph pitch', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    // Drawn geometry with letterSpacingPx=10: glyph i starts at 12·i + 10·i.
+    // Slice [1,3) ("BC"): left = 12 + 10 = 22; right = measure("ABC") + 2·10
+    // = 36 + 20 = 56 → width = 34.
+    const runs = [runInfo({ text: 'ABCD', x: 100, y: 50, h: 16, letterSpacingPx: 10 })];
+    const matches: DocxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 1, end: 3 }], active: false },
+    ];
+    buildDocxHighlightLayer(
+      layer as unknown as HTMLDivElement,
+      runs, matches, 700, 900, measureForFont,
+    );
+    expect(layer.children).toHaveLength(1);
+    const box = layer.children[0];
+    expect(box.style.left).toBe(`${((100 + 22) / 700) * 100}%`);
+    expect(box.style.width).toBe(`${(34 / 700) * 100}%`);
+  });
+
+  it('a full-run match spans exactly the fitted width (no trailing gap)', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    // Full slice [0,4): width = natural 48 + (4−1)·10 = 78 — the region-end
+    // fitted advance (no pitch after the last glyph).
+    const runs = [runInfo({ text: 'ABCD', x: 100, y: 50, h: 16, letterSpacingPx: 10 })];
+    const matches: DocxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 0, end: 4 }], active: false },
+    ];
+    buildDocxHighlightLayer(
+      layer as unknown as HTMLDivElement,
+      runs, matches, 700, 900, measureForFont,
+    );
+    const box = layer.children[0];
+    expect(box.style.left).toBe(`${(100 / 700) * 100}%`);
+    expect(box.style.width).toBe(`${(78 / 700) * 100}%`);
+  });
+});

--- a/packages/docx/src/fit-text-layout.test.ts
+++ b/packages/docx/src/fit-text-layout.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSegments,
+  layoutLines,
+  rescaleLayoutLines,
+  type LayoutSeg,
+  type LayoutTextSeg,
+} from './line-layout.js';
+import type { DocRun, DocxTextRun } from './types.js';
+
+function textRun(text: string, extra: Partial<DocxTextRun> = {}): DocRun {
+  return {
+    type: 'text',
+    text,
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    fontSize: 12,
+    color: null,
+    fontFamily: 'serif',
+    isLink: false,
+    background: null,
+    vertAlign: null,
+    allCaps: false,
+    smallCaps: false,
+    doubleStrikethrough: false,
+    ...extra,
+  } as unknown as DocRun;
+}
+
+function makeLinearCtx(): CanvasRenderingContext2D {
+  let font = '12px serif';
+  const ctx = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    letterSpacing: '0px',
+    fontKerning: 'auto',
+    measureText(text: string) {
+      const px = Number(/([\d.]+)px/.exec(font)?.[1] ?? 12);
+      return {
+        width: [...text].length * px,
+        fontBoundingBoxAscent: px * 0.8,
+        fontBoundingBoxDescent: px * 0.2,
+        actualBoundingBoxAscent: px * 0.8,
+        actualBoundingBoxDescent: px * 0.2,
+      } as TextMetrics;
+    },
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function textSegments(segs: LayoutSeg[]): LayoutTextSeg[] {
+  return segs.filter((seg): seg is LayoutTextSeg => 'text' in seg);
+}
+
+const ID = -1431456512;
+const ENV = { pageIndex: 0, totalPages: 1 };
+
+function fitRuns(prefix = false): DocRun[] {
+  const fit = { fitTextVal: 2400, fitTextId: ID, charSpacing: 4.8 };
+  return [
+    ...(prefix ? [textRun('X')] : []),
+    textRun('氏名又は', fit),
+    textRun('名', fit),
+    textRun('称', fit),
+  ];
+}
+
+describe('ECMA-376 §17.3.2.14 fitText layout integration', () => {
+  it('assigns one stable run-level region across script-split segments', () => {
+    const segs = textSegments(buildSegments([
+      textRun('AB氏', { fitTextVal: 2400, fitTextId: ID }),
+      textRun('名', { fitTextVal: 2400, fitTextId: ID }),
+    ], ENV));
+
+    expect(segs).toHaveLength(3); // latin + eastAsia from run 0, eastAsia from run 1
+    expect(new Set(segs.map((seg) => seg.fitTextRegionIndex)).size).toBe(1);
+    expect(segs[0].fitTextRunIndex).toBe(segs[1].fitTextRunIndex);
+    expect(segs[2].fitTextRunIndex).not.toBe(segs[0].fitTextRunIndex);
+    expect(segs.map((seg) => seg.joinPrev)).toEqual([undefined, true, true]);
+  });
+
+  it('folds one cross-run per-gap into the canonical segment advances', () => {
+    const lines = layoutLines(makeLinearCtx(), buildSegments(fitRuns(), ENV), 1000, 0, 1);
+    const segs = textSegments(lines[0].segments);
+
+    expect(lines).toHaveLength(1);
+    expect(segs).toHaveLength(3);
+    expect(segs.map((seg) => seg.fitTextPerGapPx)).toEqual([9.6, 9.6, 9.6]);
+    expect(segs[0].measuredWidth).toBeCloseTo(86.4, 9);
+    expect(segs[1].measuredWidth).toBeCloseTo(21.6, 9);
+    expect(segs[2].measuredWidth).toBeCloseTo(12, 9);
+    expect(segs.reduce((sum, seg) => sum + seg.measuredWidth, 0)).toBeCloseTo(120, 9);
+  });
+
+  it('moves the fixed-width region as one atomic unit', () => {
+    const lines = layoutLines(makeLinearCtx(), buildSegments(fitRuns(true), ENV), 125, 0, 1);
+
+    expect(lines).toHaveLength(2);
+    expect(textSegments(lines[0].segments).map((seg) => seg.text)).toEqual(['X']);
+    expect(textSegments(lines[1].segments).map((seg) => seg.text)).toEqual(['氏名又は', '名', '称']);
+    expect(textSegments(lines[1].segments).reduce((sum, seg) => sum + seg.measuredWidth, 0))
+      .toBeCloseTo(120, 9);
+  });
+
+  it('recomputes the scale-relative per-gap for stamp reuse', () => {
+    const stamp = layoutLines(makeLinearCtx(), buildSegments(fitRuns(), ENV), 1000, 0, 1);
+    const painted = rescaleLayoutLines(stamp, 2, makeLinearCtx(), {}, 0);
+    const segs = textSegments(painted[0].segments);
+
+    expect(segs[0].fitTextPerGapPx).toBeCloseTo(19.2, 9);
+    expect(segs.reduce((sum, seg) => sum + seg.measuredWidth, 0)).toBeCloseTo(240, 9);
+  });
+});

--- a/packages/docx/src/fit-text-layout.test.ts
+++ b/packages/docx/src/fit-text-layout.test.ts
@@ -112,4 +112,18 @@ describe('ECMA-376 §17.3.2.14 fitText layout integration', () => {
     expect(segs[0].fitTextPerGapPx).toBeCloseTo(19.2, 9);
     expect(segs.reduce((sum, seg) => sum + seg.measuredWidth, 0)).toBeCloseTo(240, 9);
   });
+
+  it('recomputes a single-glyph region cell at paint scale', () => {
+    const stamp = layoutLines(
+      makeLinearCtx(),
+      buildSegments([textRun('氏', { fitTextVal: 2400 })], ENV),
+      1000,
+      0,
+      1,
+    );
+    const painted = rescaleLayoutLines(stamp, 2, makeLinearCtx(), {}, 0);
+
+    expect(textSegments(stamp[0].segments)[0].measuredWidth).toBeCloseTo(120, 9);
+    expect(textSegments(painted[0].segments)[0].measuredWidth).toBeCloseTo(240, 9);
+  });
 });

--- a/packages/docx/src/fit-text-paint.test.ts
+++ b/packages/docx/src/fit-text-paint.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import { renderDocumentToCanvas, type DocxTextRunInfo } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxDocumentModel,
+  DocxTextRun,
+  SectionProps,
+} from './types.js';
+
+interface FillCall {
+  text: string;
+  letterSpacing: number;
+  scaleX: number;
+}
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[] } {
+  let font = '12px serif';
+  let letterSpacing = '0px';
+  let scaleX = 1;
+  const stack: number[] = [];
+  const fills: FillCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(value: string) { letterSpacing = value; },
+    fontKerning: 'auto',
+    measureText(text: string) {
+      const px = Number(/([\d.]+)px/.exec(font)?.[1] ?? 12);
+      return {
+        width: [...text].length * px,
+        fontBoundingBoxAscent: px * 0.8,
+        fontBoundingBoxDescent: px * 0.2,
+        actualBoundingBoxAscent: px * 0.8,
+        actualBoundingBoxDescent: px * 0.2,
+      } as TextMetrics;
+    },
+    save() { stack.push(scaleX); },
+    restore() { scaleX = stack.pop() ?? 1; },
+    scale(x: number) { scaleX *= x; },
+    translate() {},
+    fillText(text: string) {
+      fills.push({ text, letterSpacing: Number.parseFloat(letterSpacing), scaleX });
+    },
+    beginPath() {}, closePath() {}, moveTo() {}, lineTo() {}, stroke() {}, fill() {},
+    fillRect() {}, strokeRect() {}, clip() {}, rect() {}, setLineDash() {},
+    drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {}, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills };
+}
+
+function textRun(text: string, extra: Partial<DocxTextRun> = {}): DocxTextRun {
+  return {
+    text,
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    fontSize: 12,
+    color: null,
+    fontFamily: 'serif',
+    isLink: false,
+    background: null,
+    vertAlign: null,
+    ...extra,
+    hyperlink: extra.hyperlink ?? null,
+  };
+}
+
+function paragraph(runs: DocxTextRun[]): BodyElement {
+  const para: DocParagraph = {
+    alignment: 'left',
+    indentLeft: 0,
+    indentRight: 0,
+    indentFirst: 0,
+    spaceBefore: 0,
+    spaceAfter: 0,
+    lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    runs: runs.map((run) => ({ type: 'text', ...run })),
+    defaultFontSize: 12,
+    defaultFontFamily: 'serif',
+    widowControl: false,
+  };
+  return { type: 'paragraph', ...para };
+}
+
+function section(): SectionProps {
+  return {
+    pageWidth: 600,
+    pageHeight: 400,
+    marginTop: 0,
+    marginRight: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    headerDistance: 0,
+    footerDistance: 0,
+    titlePage: false,
+    evenAndOddHeaders: false,
+  } as SectionProps;
+}
+
+async function render(runs: DocxTextRun[]): Promise<{ fills: FillCall[]; boxes: DocxTextRunInfo[] }> {
+  const { canvas, fills } = makeRecordingCanvas();
+  const boxes: DocxTextRunInfo[] = [];
+  const model = {
+    section: section(),
+    body: [paragraph(runs)],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+  await renderDocumentToCanvas(model, canvas, 0, {
+    dpr: 1,
+    width: 600,
+    onTextRun: (box) => boxes.push(box),
+  });
+  return { fills, boxes };
+}
+
+describe('ECMA-376 §17.3.2.14 fitText paint', () => {
+  it('draws the cross-run resolved gap and reports the fixed-width boxes', async () => {
+    const fit = { fitTextVal: 2400, fitTextId: -1431456512, charSpacing: 4.8 };
+    const { fills, boxes } = await render([
+      textRun('氏名又は', fit),
+      textRun('名', fit),
+      textRun('称', fit),
+    ]);
+
+    expect(fills.map((fill) => fill.letterSpacing)).toEqual([9.6, 9.6, 9.6]);
+    expect(boxes.reduce((sum, box) => sum + box.w, 0)).toBeCloseTo(120, 9);
+    expect(boxes.map((box) => box.x)).toEqual([0, 86.4, 108]);
+  });
+
+  it('composes the gap with w:w in the scaled draw frame', async () => {
+    const fit = { fitTextVal: 2400, fitTextId: -1431456510, charScale: 0.66, charSpacing: 0.9 };
+    const { fills, boxes } = await render([
+      textRun('並びに法人の場合は', fit),
+      textRun('代表者の氏名', fit),
+    ]);
+    const perGap = (120 - 15 * 12 * 0.66) / 14;
+
+    expect(fills).toHaveLength(2);
+    expect(fills.every((fill) => Math.abs(fill.scaleX - 0.66) < 1e-9)).toBe(true);
+    expect(fills[0].letterSpacing).toBeCloseTo(perGap / 0.66, 9);
+    expect(boxes.reduce((sum, box) => sum + box.w, 0)).toBeCloseTo(120, 9);
+  });
+});

--- a/packages/docx/src/fit-text.test.ts
+++ b/packages/docx/src/fit-text.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import { groupFitTextRegions } from './fit-text.js';
+import type { FitTextRun } from './fit-text.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ECMA-376 §17.3.2.14 `<w:fitText>` — "Manual Run Width".
+//
+// A run's contents are displayed within the width given by `w:val` (twips). When
+// several CONSECUTIVE runs carry the SAME `w:id`, they are treated as ONE fit
+// region whose combined contents fill `w:val` together (the spec's example: a
+// 1-inch region split across three runs occupies one inch in total, not one inch
+// each). An id-less fitText run never links to a neighbour. A non-fitText run
+// breaks adjacency, so two same-id runs separated by a plain run do NOT merge.
+//
+// Word's observed geometry (private fixture, Word-generated PDF): the glyphs keep
+// their natural advance (incl. §17.3.2.43 `w:w` glyph scaling) and the extra /
+// negative slack `(w:val − Σnatural)` is distributed EVENLY as inter-character
+// gaps — one gap between every adjacent glyph pair across run boundaries, and NO
+// gap after the region's last glyph. Any cached §17.3.2.35 `w:spacing` on the runs
+// is IGNORED inside a fit region (Word recomputes the spacing from `w:val`).
+//
+// This kernel is the pure numeric heart. Each run reports its natural glyph-advance
+// SUM in px (pre-`w:w`, without any `w:spacing`), its code-point count, its `w:w`
+// fraction, and the target `w:val` in twips. It groups consecutive linked runs and
+// returns the resolved regions + the per-gap the renderer feeds into the existing
+// justify (`justifiedPiecePositions` / `ctx.letterSpacing`) draw path.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A CJK glyph's natural advance in px at scale 1 for `sz=24` (12 pt). */
+const EM = 12;
+
+/** Build a fitText run of `n` glyphs each `EM` px wide (scale-1 default). */
+function fitRun(
+  n: number,
+  fitTextValTwips: number,
+  fitTextId: number | undefined,
+  extra: Partial<FitTextRun> = {},
+): FitTextRun {
+  return {
+    fitTextValTwips,
+    fitTextId,
+    charCount: n,
+    naturalWidthPx: n * EM,
+    ...extra,
+  };
+}
+
+/** A plain (non-fitText) run of `n` glyphs — breaks fit-region adjacency. */
+function plainRun(n: number): FitTextRun {
+  return { charCount: n, naturalWidthPx: n * EM };
+}
+
+describe('groupFitTextRegions — ECMA-376 §17.3.2.14 fit-region math', () => {
+  it('distributes (val − Σnatural)/(n−1) as the inter-character gap, no trailing gap', () => {
+    // One run, 6 glyphs (12 px each ⇒ Σ = 72), val = 2400 twips = 120 pt.
+    // per-gap = (120 − 72) / (6 − 1) = 9.6 px.
+    const regions = groupFitTextRegions([fitRun(6, 2400, undefined)], 1);
+    expect(regions).toHaveLength(1);
+    const r = regions[0];
+    expect(r.start).toBe(0);
+    expect(r.end).toBe(1);
+    expect(r.targetPx).toBeCloseTo(120, 9);
+    expect(r.naturalPx).toBeCloseTo(72, 9);
+    expect(r.charCount).toBe(6);
+    expect(r.perGapPx).toBeCloseTo(9.6, 9);
+    // No trailing gap: natural + (n−1)·perGap === target exactly.
+    expect(r.naturalPx + (r.charCount - 1) * r.perGapPx).toBeCloseTo(r.targetPx, 9);
+  });
+
+  it('merges CONSECUTIVE same-id runs into one region (氏名/名/称 → 6 glyphs, per-gap 9.6)', () => {
+    // Line 1 shape: three runs with the same id, 4 + 1 + 1 glyphs = 6, each val=2400.
+    const id = -1431456512;
+    const regions = groupFitTextRegions(
+      [fitRun(4, 2400, id), fitRun(1, 2400, id), fitRun(1, 2400, id)],
+      1,
+    );
+    expect(regions).toHaveLength(1);
+    const r = regions[0];
+    expect(r.start).toBe(0);
+    expect(r.end).toBe(3);
+    expect(r.charCount).toBe(6);
+    expect(r.naturalPx).toBeCloseTo(72, 9);
+    // Word's recomputed per-gap is 9.6 px — NOT the cached w:spacing=96 twips (4.8 pt)
+    // on the runs, which a fit region ignores (§17.3.2.14 recomputes from w:val).
+    expect(r.perGapPx).toBeCloseTo(9.6, 9);
+  });
+
+  it('applies the general formula to a 4-glyph region (及び/住/所 → per-gap 24)', () => {
+    // Line 2 shape: 2 + 1 + 1 glyphs = 4, val=2400. per-gap = (120 − 48)/3 = 24 px.
+    const id = -1431456511;
+    const regions = groupFitTextRegions(
+      [fitRun(2, 2400, id), fitRun(1, 2400, id), fitRun(1, 2400, id)],
+      1,
+    );
+    expect(regions).toHaveLength(1);
+    const r = regions[0];
+    expect(r.charCount).toBe(4);
+    expect(r.naturalPx).toBeCloseTo(48, 9);
+    expect(r.perGapPx).toBeCloseTo(24, 9);
+  });
+
+  it('composes §17.3.2.43 w:w glyph scaling into the natural width (並びに… line, charScale 0.66)', () => {
+    // Line 3 shape: 15 glyphs, all runs val=2400 AND w:w=66% (0.66). Natural width =
+    // 15 × 12 × 0.66 = 118.8 px, so per-gap = (120 − 118.8)/14 ≈ 0.0857 px — the same
+    // general formula, no special branch. Cached w:spacing (0.9 pt on some runs) is
+    // ignored. Model as two same-id runs (10 + 5) to also exercise the merge.
+    const id = -1431456510;
+    const regions = groupFitTextRegions(
+      [
+        fitRun(10, 2400, id, { charScale: 0.66 }),
+        fitRun(5, 2400, id, { charScale: 0.66 }),
+      ],
+      1,
+    );
+    expect(regions).toHaveLength(1);
+    const r = regions[0];
+    expect(r.charCount).toBe(15);
+    expect(r.naturalPx).toBeCloseTo(118.8, 6);
+    expect(r.perGapPx).toBeCloseTo(1.2 / 14, 9);
+    // Region advance stays pinned to the target (≈ 120 pt) regardless of w:w.
+    expect(r.naturalPx + (r.charCount - 1) * r.perGapPx).toBeCloseTo(120, 6);
+  });
+
+  it('does NOT merge two same-id runs separated by a plain run (adjacency required)', () => {
+    // Same id on runs 0 and 2, but run 1 is plain ⇒ two independent regions.
+    const id = 42;
+    const regions = groupFitTextRegions(
+      [fitRun(3, 2400, id), plainRun(2), fitRun(3, 2400, id)],
+      1,
+    );
+    expect(regions).toHaveLength(2);
+    expect(regions[0].start).toBe(0);
+    expect(regions[0].end).toBe(1);
+    expect(regions[1].start).toBe(2);
+    expect(regions[1].end).toBe(3);
+  });
+
+  it('does NOT merge adjacent runs with DIFFERENT ids', () => {
+    const regions = groupFitTextRegions(
+      [fitRun(3, 2400, 7), fitRun(3, 2400, 8)],
+      1,
+    );
+    expect(regions).toHaveLength(2);
+    expect(regions[0].end).toBe(1);
+    expect(regions[1].start).toBe(1);
+  });
+
+  it('treats an id-less fitText run as a standalone region (never links, even to another id-less run)', () => {
+    const regions = groupFitTextRegions(
+      [fitRun(3, 2400, undefined), fitRun(3, 2400, undefined)],
+      1,
+    );
+    expect(regions).toHaveLength(2);
+    expect(regions[0].start).toBe(0);
+    expect(regions[0].end).toBe(1);
+    expect(regions[1].start).toBe(1);
+    expect(regions[1].end).toBe(2);
+  });
+
+  it('converts w:val twips → px through the layout scale', () => {
+    // scale = 2 px/pt: 6 glyphs at 24 px natural (Σ = 144), val=2400 (120 pt) ⇒
+    // target = 240 px, per-gap = (240 − 144)/5 = 19.2 px.
+    const runs: FitTextRun[] = [
+      { fitTextValTwips: 2400, charCount: 6, naturalWidthPx: 144 },
+    ];
+    const regions = groupFitTextRegions(runs, 2);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].targetPx).toBeCloseTo(240, 9);
+    expect(regions[0].naturalPx).toBeCloseTo(144, 9);
+    expect(regions[0].perGapPx).toBeCloseTo(19.2, 9);
+  });
+
+  it('yields a NEGATIVE per-gap when the natural width exceeds the target (compression)', () => {
+    // 6 glyphs (Σ = 72 px) into a 1000-twip (50 pt) region ⇒ per-gap = (50 − 72)/5 = −4.4 px.
+    const regions = groupFitTextRegions([fitRun(6, 1000, undefined)], 1);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].perGapPx).toBeCloseTo(-4.4, 9);
+    expect(regions[0].perGapPx).toBeLessThan(0);
+  });
+
+  it('uses per-gap 0 for a single-glyph region (no division by zero)', () => {
+    const regions = groupFitTextRegions([fitRun(1, 2400, undefined)], 1);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].charCount).toBe(1);
+    expect(regions[0].perGapPx).toBe(0);
+  });
+
+  it('returns no regions when no run carries fitText', () => {
+    const regions = groupFitTextRegions([plainRun(3), plainRun(2)], 1);
+    expect(regions).toHaveLength(0);
+  });
+});

--- a/packages/docx/src/fit-text.ts
+++ b/packages/docx/src/fit-text.ts
@@ -3,7 +3,7 @@ export interface FitTextRun {
   fitTextValTwips?: number;
   /** §17.3.2.14 w:id — links CONSECUTIVE fitText runs into ONE region. undefined ⇒
    *  standalone region (an id-less fitText run never links to any neighbour). */
-  fitTextId?: number;
+  fitTextId?: number | string;
   /** Code-point count of the run. */
   charCount: number;
   /** Natural glyph-advance SUM of the run in px (at the layout scale), BEFORE the
@@ -20,6 +20,7 @@ export interface FitTextRegion {
   naturalPx: number;
   charCount: number;
   perGapPx: number;
+  trailingPadPx: number;
 }
 
 /** ECMA-376 §17.3.2.14. `scale` is px-per-pt. */
@@ -53,13 +54,18 @@ export function groupFitTextRegions(runs: FitTextRun[], scale: number): FitTextR
     }
 
     const targetPx = (first.fitTextValTwips / 20) * scale;
-    // ECMA-376 §17.3.2.14 describes compression as “decreasing the size of each
-    // character”. Word-observed expansion uses inter-character gaps; until a
-    // compression ground truth is available, use the same general gap formula.
-    // A future ground-truth sample may require changing compression to char scale.
+    // ECMA-376 §17.3.2.14 requires the region to occupy exactly w:val and
+    // describes compression as “decreasing the size of each character”.
+    // Word-observed multi-character expansion uses inter-character gaps; until
+    // compression ground truth is available, keep every glyph at its natural
+    // width and use the same gap formula. A one-character region has no gap, so
+    // its residual becomes cell padding AFTER the glyph instead of stretching or
+    // shrinking the glyph. A future ground-truth sample may replace that padding
+    // (and negative-gap compression) with character scaling.
     const perGapPx = charCount > 1 ? (targetPx - naturalPx) / (charCount - 1) : 0;
+    const trailingPadPx = targetPx - naturalPx - Math.max(0, charCount - 1) * perGapPx;
 
-    regions.push({ start, end, targetPx, naturalPx, charCount, perGapPx });
+    regions.push({ start, end, targetPx, naturalPx, charCount, perGapPx, trailingPadPx });
     start = end;
   }
 

--- a/packages/docx/src/fit-text.ts
+++ b/packages/docx/src/fit-text.ts
@@ -1,0 +1,67 @@
+export interface FitTextRun {
+  /** §17.3.2.14 w:val — target region width in TWIPS. undefined ⇒ not a fitText run. */
+  fitTextValTwips?: number;
+  /** §17.3.2.14 w:id — links CONSECUTIVE fitText runs into ONE region. undefined ⇒
+   *  standalone region (an id-less fitText run never links to any neighbour). */
+  fitTextId?: number;
+  /** Code-point count of the run. */
+  charCount: number;
+  /** Natural glyph-advance SUM of the run in px (at the layout scale), BEFORE the
+   *  §17.3.2.43 w:w scale and WITHOUT any §17.3.2.35 w:spacing pitch. */
+  naturalWidthPx: number;
+  /** §17.3.2.43 w:w horizontal glyph scale as a FRACTION (0.66 = 66%). undefined ⇒ 1. */
+  charScale?: number;
+}
+
+export interface FitTextRegion {
+  start: number;
+  end: number;
+  targetPx: number;
+  naturalPx: number;
+  charCount: number;
+  perGapPx: number;
+}
+
+/** ECMA-376 §17.3.2.14. `scale` is px-per-pt. */
+export function groupFitTextRegions(runs: FitTextRun[], scale: number): FitTextRegion[] {
+  const regions: FitTextRegion[] = [];
+
+  for (let start = 0; start < runs.length; ) {
+    const first = runs[start];
+    if (first.fitTextValTwips === undefined) {
+      start += 1;
+      continue;
+    }
+
+    let end = start + 1;
+    if (first.fitTextId !== undefined) {
+      while (
+        end < runs.length &&
+        runs[end].fitTextValTwips !== undefined &&
+        runs[end].fitTextId === first.fitTextId
+      ) {
+        end += 1;
+      }
+    }
+
+    let naturalPx = 0;
+    let charCount = 0;
+    for (let index = start; index < end; index += 1) {
+      const run = runs[index];
+      naturalPx += run.naturalWidthPx * (run.charScale ?? 1);
+      charCount += run.charCount;
+    }
+
+    const targetPx = (first.fitTextValTwips / 20) * scale;
+    // ECMA-376 §17.3.2.14 describes compression as “decreasing the size of each
+    // character”. Word-observed expansion uses inter-character gaps; until a
+    // compression ground truth is available, use the same general gap formula.
+    // A future ground-truth sample may require changing compression to char scale.
+    const perGapPx = charCount > 1 ? (targetPx - naturalPx) / (charCount - 1) : 0;
+
+    regions.push({ start, end, targetPx, naturalPx, charCount, perGapPx });
+    start = end;
+  }
+
+  return regions;
+}

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -40,6 +40,7 @@ import {
   parseDateTimePictureSwitch,
 } from '@silurus/ooxml-core';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
+import { groupFitTextRegions, type FitTextRun } from './fit-text.js';
 import {
   type FloatRect,
   resolveLineFloatWindow,
@@ -128,6 +129,19 @@ export interface LayoutTextSeg {
    *  under `ctx.scale(charScale, 1)`; decorations follow the scaled extent.
    *  Absent ⇒ 1 (100%). */
   charScale?: number;
+  /** ECMA-376 §17.3.2.14 `<w:fitText>` — target width in TWIPS and optional
+   *  signed link id. All segments emitted from one source run retain the same
+   *  run/region indices so script and small-caps splitting cannot create a new
+   *  fit region. */
+  fitTextVal?: number;
+  fitTextId?: number;
+  fitTextRegionIndex?: number;
+  fitTextRunIndex?: number;
+  fitTextRunCharCount?: number;
+  /** Scale-resolved gap shared by the canonical advance and paint paths. */
+  fitTextPerGapPx?: number;
+  fitTextRegionStart?: boolean;
+  fitTextRegionEnd?: boolean;
   /** ECMA-376 §17.3.2.24 `<w:position>` — baseline raise(+)/lower(−) in POINTS,
    *  applied as a y-offset to the glyphs and decorations without changing the
    *  font size or the line box. Absent ⇒ 0. */
@@ -715,6 +729,9 @@ export function segmentCharacterGridDeltaPx(
  *  ("the amount of character pitch … added after each character in this run").
  *  0 when the run declares no `w:spacing`. */
 export function charSpacingDeltaPx(seg: LayoutTextSeg, scale: number): number {
+  // §17.3.2.14 fitText replaces cached §17.3.2.35 spacing with the resolved
+  // region gap. The paint path already reads this authority.
+  if (seg.fitTextPerGapPx !== undefined) return seg.fitTextPerGapPx;
   return (seg.charSpacing ?? 0) * scale;
 }
 
@@ -755,6 +772,7 @@ export function segLetterSpacingPx(
   gridDeltaPx: number,
   scale: number,
 ): number {
+  if (seg.fitTextPerGapPx !== undefined) return seg.fitTextPerGapPx;
   const segmentDelta = segmentCharacterGridDeltaPx(seg, gridDeltaPx);
   const grid = gridSegDeltaPx(seg.text, segmentDelta) === 0 ? 0 : segmentDelta;
   return grid + charSpacingDeltaPx(seg, scale);
@@ -771,6 +789,11 @@ export function segAdvanceWidth(
   gridDeltaPx: number,
   scale: number,
 ): number {
+  if (seg.fitTextPerGapPx !== undefined) {
+    const charCount = [...seg.text].length;
+    const gapCount = seg.fitTextRegionEnd ? Math.max(0, charCount - 1) : charCount;
+    return naturalWidthPx * charScaleFactor(seg) + gapCount * seg.fitTextPerGapPx;
+  }
   // ECMA-376 §17.3.2.10 縦中横 (horizontal-in-vertical): the whole run is written
   // horizontally inside ONE cell of the vertical line ("keeping the text on the
   // same line"), so its advance ALONG the column is exactly one em (one cell),
@@ -1677,12 +1700,76 @@ export function paragraphSegsStateSensitive(para: DocParagraph): boolean {
   return false;
 }
 
+/** Resolve §17.3.2.14 region gaps after raw Canvas advances are available.
+ *  Source-run aggregation is deliberate: a run split into Latin/CJK/small-caps
+ *  segments still contributes one kernel input and cannot become multiple
+ *  id-less regions. */
+function resolveFitTextSegments(
+  segments: LayoutTextSeg[],
+  scale: number,
+  measureNaturalWidthPx: (segment: LayoutTextSeg) => number,
+): void {
+  const regionSegments = new Map<number, LayoutTextSeg[]>();
+  for (const segment of segments) {
+    if (segment.fitTextRegionIndex === undefined) continue;
+    const members = regionSegments.get(segment.fitTextRegionIndex) ?? [];
+    members.push(segment);
+    regionSegments.set(segment.fitTextRegionIndex, members);
+  }
+
+  for (const members of regionSegments.values()) {
+    const runInputs = new Map<number, FitTextRun>();
+    for (const segment of members) {
+      const runIndex = segment.fitTextRunIndex;
+      if (runIndex === undefined || segment.fitTextVal === undefined) continue;
+      const input = runInputs.get(runIndex) ?? {
+        fitTextValTwips: segment.fitTextVal,
+        fitTextId: segment.fitTextId,
+        charCount: segment.fitTextRunCharCount ?? [...segment.text].length,
+        naturalWidthPx: 0,
+        charScale: segment.charScale,
+      };
+      input.naturalWidthPx += measureNaturalWidthPx(segment);
+      runInputs.set(runIndex, input);
+    }
+
+    const resolved = groupFitTextRegions([...runInputs.values()], scale)[0];
+    if (!resolved) continue;
+    members.forEach((segment, index) => {
+      segment.fitTextPerGapPx = resolved.perGapPx;
+      segment.fitTextRegionStart = index === 0 ? true : undefined;
+      segment.fitTextRegionEnd = index === members.length - 1 ? true : undefined;
+    });
+  }
+}
+
 export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment): LayoutSeg[] {
   const segs: LayoutSeg[] = [];
+  // Group §17.3.2.14 adjacency over SOURCE RUNS before any script/font, word, or
+  // small-caps segmentation. Widths are deliberately zero here; the same pure
+  // kernel resolves the real natural widths at layout scale below.
+  const fitTextRegionByRun = new Map<number, number>();
+  const fitTextRuns: FitTextRun[] = runs.map((run) => {
+    if (run.type !== 'text') return { charCount: 0, naturalWidthPx: 0 };
+    return {
+      fitTextValTwips: run.fitTextVal,
+      fitTextId: run.fitTextId,
+      charCount: [...run.text].length,
+      naturalWidthPx: 0,
+      charScale: run.charScale,
+    };
+  });
+  groupFitTextRegions(fitTextRuns, 1).forEach((region, regionIndex) => {
+    for (let runIndex = region.start; runIndex < region.end; runIndex += 1) {
+      fitTextRegionByRun.set(runIndex, regionIndex);
+    }
+  });
   const pushTextPiece = (
     text: string,
     base: DocxTextRun | FieldRun,
     vertAlign: 'super' | 'sub' | null,
+    sourceRunIndex: number,
+    sourceRunCharCount?: number,
   ) => {
     // §17.3.2.33 small caps are sized per character: lowercase LETTERS render two
     // points smaller, uppercase letters and non-alphabetic characters at the full
@@ -1700,6 +1787,7 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
     const revision = (base as DocxTextRun).revision;
     const r = base as DocxTextRun;
     const rtl = r.rtl === true ? true : undefined;
+    const fitTextRegionIndex = fitTextRegionByRun.get(sourceRunIndex);
 
     // IX1 — resolve the run's hyperlink target ONCE (§17.16.22 external URL /
     // §17.16.23 internal anchor). An external URL (`r.hyperlink`) wins over the
@@ -1799,6 +1887,11 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
         // passes apply them identically (measure==paint).
         charSpacing: r.charSpacing,
         charScale: r.charScale,
+        fitTextVal: fitTextRegionIndex === undefined ? undefined : r.fitTextVal,
+        fitTextId: fitTextRegionIndex === undefined ? undefined : r.fitTextId,
+        fitTextRegionIndex,
+        fitTextRunIndex: fitTextRegionIndex === undefined ? undefined : sourceRunIndex,
+        fitTextRunCharCount: fitTextRegionIndex === undefined ? undefined : sourceRunCharCount,
         position: r.position,
         kerning: r.kerning,
         // ECMA-376 §17.3.2.10 eastAsianLayout — 縦中横 is meaningful ONLY in a
@@ -1889,7 +1982,7 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
     }
   };
 
-  for (const run of runs) {
+  for (const [runIndex, run] of runs.entries()) {
     if (run.type === 'text') {
       const t = run as unknown as DocxTextRun & { type: 'text' };
       // ECMA-376 §17.11: substitute a footnote/endnote reference marker's glyph
@@ -1904,13 +1997,17 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
           : undefined;
       if (t.noteRef) {
         const label = noteText != null ? String(noteText) : (t.text || '');
-        if (label.length > 0) pushTextPiece(label, t, t.vertAlign ?? 'super');
+        if (label.length > 0) {
+          pushTextPiece(label, t, t.vertAlign ?? 'super', runIndex, [...t.text].length);
+        }
         continue;
       }
       // Split on tab chars so tab alignment can be resolved during layout.
       const parts = t.text.split('\t');
       for (let i = 0; i < parts.length; i++) {
-        if (parts[i].length > 0) pushTextPiece(parts[i], t, t.vertAlign);
+        if (parts[i].length > 0) {
+          pushTextPiece(parts[i], t, t.vertAlign, runIndex, [...t.text].length);
+        }
         if (i < parts.length - 1) {
           segs.push({ isTab: true, fontSize: t.fontSize, measuredWidth: 0, bold: t.bold, italic: t.italic });
         }
@@ -1968,7 +2065,7 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
     } else if (run.type === 'field') {
       const f = run as unknown as FieldRun & { type: 'field' };
       const text = resolveFieldText(f, environment);
-      if (text) pushTextPiece(text, f, f.vertAlign);
+      if (text) pushTextPiece(text, f, f.vertAlign, runIndex);
     } else if (run.type === 'math') {
       // The parser resolves the paragraph font size; fall back to a nearby run only
       // if it is somehow absent.
@@ -2029,6 +2126,19 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
     // space is a legal break, so the mark may legitimately start the line).
     if (!('text' in prev) || /\s$/.test(prev.text)) continue;
     cur.joinPrev = true;
+  }
+
+  // §17.3.2.14 fitText is a fixed-width, non-wrapping unit. Glue every segment
+  // after the first in the RUN-grouped region, including script/small-caps
+  // pieces emitted from the same source run.
+  const seenFitTextRegions = new Set<number>();
+  for (const seg of segs) {
+    if (!('text' in seg) || seg.fitTextRegionIndex === undefined) continue;
+    if (seenFitTextRegions.has(seg.fitTextRegionIndex)) seg.joinPrev = true;
+    else {
+      seg.fitTextRegionStart = true;
+      seenFitTextRegions.add(seg.fitTextRegionIndex);
+    }
   }
 
   return segs;
@@ -2324,6 +2434,15 @@ export function layoutLines(
     restoreKerning(prevKern);
     return m;
   };
+
+  // Resolve §17.3.2.14 from RAW natural advances at this exact layout scale.
+  // The resulting per-gap is folded into segAdvanceWidth below, so the line
+  // breaker and paint pen use one width authority. Cached w:spacing is ignored.
+  resolveFitTextSegments(
+    segs.filter((seg): seg is LayoutTextSeg => 'text' in seg),
+    scale,
+    (segment) => measureText(segment).width,
+  );
 
   // The segment's laid-out ADVANCE (= its measuredWidth): natural width plus the
   // character-grid delta, the §17.3.2.43 horizontal glyph scale (w:w) and the
@@ -2648,6 +2767,25 @@ export function layoutLines(
     if (s.ruby) {
       asc = asc + s.ruby.fontSizePt * scale * 1.5;
     }
+
+    // ECMA-376 §17.3.2.14: a fit region is an atomic fixed-width cell. The
+    // first segment judges the WHOLE resolved region; after an optional flush,
+    // every member is added without entering the CJK/overlong-word split paths.
+    // This also handles a target wider than the line: it overflows as one unit
+    // instead of violating the required internal non-wrap boundary.
+    if (s.fitTextRegionIndex !== undefined) {
+      if (s.fitTextRegionStart) {
+        let regionWidth = w;
+        for (const queued of queue) {
+          if (!('text' in queued) || queued.fitTextRegionIndex !== s.fitTextRegionIndex) break;
+          regionWidth += segAdvance(queued);
+        }
+        if (currentLine.length > 0 && currentWidth + regionWidth > availW()) flush();
+      }
+      s.measuredWidth = w;
+      addToLine(s, w, h, asc, desc);
+      continue;
+    }
     // Wrap-fit check uses two standard typographic allowances:
     //   1. Trailing-space collapse: if this word becomes the last on the
     //      line, its trailing space (if any) collapses. We subtract it from
@@ -2922,7 +3060,20 @@ export function rescaleLayoutLines(
     let desc = 0;
     let intended = 0;
     let hasText = false;
-    const segments = l.segments.map((s) => {
+    const scaledSource = l.segments.map((segment) => ({ ...segment })) as LayoutSeg[];
+    // Recompute the region gap from paint-scale natural metrics. Reusing the
+    // scale-1 gap would break measure==paint because targetPx and font advances
+    // are both scale-relative (and font hinting need not be linearly scalable).
+    resolveFitTextSegments(
+      scaledSource.filter((segment): segment is LayoutTextSeg => 'text' in segment),
+      scale,
+      (segment) => {
+        const effPx = calcEffectiveFontPx(segment, scale);
+        ctx.font = buildFont(segment.bold, segment.italic, effPx, segment.fontFamily, fontFamilyClasses);
+        return ctx.measureText(segment.text).width;
+      },
+    );
+    const segments = scaledSource.map((s) => {
       if ('isTab' in s) {
         // Tab advance is position-dependent (pen → next stop) and box-neutral; a
         // ×scale reproduces the scale-1 tab-to-stop advance scaled to paint space

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -130,16 +130,18 @@ export interface LayoutTextSeg {
    *  Absent ⇒ 1 (100%). */
   charScale?: number;
   /** ECMA-376 §17.3.2.14 `<w:fitText>` — target width in TWIPS and optional
-   *  signed link id. All segments emitted from one source run retain the same
-   *  run/region indices so script and small-caps splitting cannot create a new
-   *  fit region. */
+   *  link id (wire strings plus numeric synthetic inputs). All segments emitted
+   *  from one tab-delimited source-run fragment retain the same fragment/region
+   *  indices so script and small-caps splitting cannot create a new fit region. */
   fitTextVal?: number;
-  fitTextId?: number;
+  fitTextId?: number | string;
   fitTextRegionIndex?: number;
+  /** Flattened tab-delimited source-fragment index (historical field name). */
   fitTextRunIndex?: number;
-  fitTextRunCharCount?: number;
   /** Scale-resolved gap shared by the canonical advance and paint paths. */
   fitTextPerGapPx?: number;
+  /** Region residual carried after its final glyph; scale-resolved like the gap. */
+  fitTextTrailingPadPx?: number;
   fitTextRegionStart?: boolean;
   fitTextRegionEnd?: boolean;
   /** ECMA-376 §17.3.2.24 `<w:position>` — baseline raise(+)/lower(−) in POINTS,
@@ -792,7 +794,9 @@ export function segAdvanceWidth(
   if (seg.fitTextPerGapPx !== undefined) {
     const charCount = [...seg.text].length;
     const gapCount = seg.fitTextRegionEnd ? Math.max(0, charCount - 1) : charCount;
-    return naturalWidthPx * charScaleFactor(seg) + gapCount * seg.fitTextPerGapPx;
+    return naturalWidthPx * charScaleFactor(seg)
+      + gapCount * seg.fitTextPerGapPx
+      + (seg.fitTextTrailingPadPx ?? 0);
   }
   // ECMA-376 §17.3.2.10 縦中横 (horizontal-in-vertical): the whole run is written
   // horizontally inside ONE cell of the vertical line ("keeping the text on the
@@ -1700,10 +1704,11 @@ export function paragraphSegsStateSensitive(para: DocParagraph): boolean {
   return false;
 }
 
-/** Resolve §17.3.2.14 region gaps after raw Canvas advances are available.
- *  Source-run aggregation is deliberate: a run split into Latin/CJK/small-caps
- *  segments still contributes one kernel input and cannot become multiple
- *  id-less regions. */
+/** Resolve §17.3.2.14 region geometry after raw Canvas advances are available.
+ *  Region membership was fixed over tab-delimited source fragments in
+ *  {@link buildSegments}; width and code-point count are deliberately derived
+ *  here from the emitted segments so script/case transformations cannot create
+ *  a second source of truth. */
 function resolveFitTextSegments(
   segments: LayoutTextSeg[],
   scale: number,
@@ -1718,25 +1723,27 @@ function resolveFitTextSegments(
   }
 
   for (const members of regionSegments.values()) {
-    const runInputs = new Map<number, FitTextRun>();
+    const first = members.find((segment) => segment.fitTextVal !== undefined);
+    if (!first || first.fitTextVal === undefined) continue;
+
+    let naturalWidthPx = 0;
+    let charCount = 0;
     for (const segment of members) {
-      const runIndex = segment.fitTextRunIndex;
-      if (runIndex === undefined || segment.fitTextVal === undefined) continue;
-      const input = runInputs.get(runIndex) ?? {
-        fitTextValTwips: segment.fitTextVal,
-        fitTextId: segment.fitTextId,
-        charCount: segment.fitTextRunCharCount ?? [...segment.text].length,
-        naturalWidthPx: 0,
-        charScale: segment.charScale,
-      };
-      input.naturalWidthPx += measureNaturalWidthPx(segment);
-      runInputs.set(runIndex, input);
+      naturalWidthPx += measureNaturalWidthPx(segment) * charScaleFactor(segment);
+      charCount += [...segment.text].length;
     }
 
-    const resolved = groupFitTextRegions([...runInputs.values()], scale)[0];
+    const resolved = groupFitTextRegions([{
+      fitTextValTwips: first.fitTextVal,
+      charCount,
+      naturalWidthPx,
+    }], scale)[0];
     if (!resolved) continue;
     members.forEach((segment, index) => {
       segment.fitTextPerGapPx = resolved.perGapPx;
+      segment.fitTextTrailingPadPx = index === members.length - 1
+        ? resolved.trailingPadPx
+        : undefined;
       segment.fitTextRegionStart = index === 0 ? true : undefined;
       segment.fitTextRegionEnd = index === members.length - 1 ? true : undefined;
     });
@@ -1745,23 +1752,38 @@ function resolveFitTextSegments(
 
 export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment): LayoutSeg[] {
   const segs: LayoutSeg[] = [];
-  // Group §17.3.2.14 adjacency over SOURCE RUNS before any script/font, word, or
-  // small-caps segmentation. Widths are deliberately zero here; the same pure
-  // kernel resolves the real natural widths at layout scale below.
-  const fitTextRegionByRun = new Map<number, number>();
-  const fitTextRuns: FitTextRun[] = runs.map((run) => {
-    if (run.type !== 'text') return { charCount: 0, naturalWidthPx: 0 };
-    return {
-      fitTextValTwips: run.fitTextVal,
-      fitTextId: run.fitTextId,
-      charCount: [...run.text].length,
-      naturalWidthPx: 0,
-      charScale: run.charScale,
-    };
-  });
+  // Group §17.3.2.14 adjacency over SOURCE RUNS before script/font, word, or
+  // small-caps segmentation, but model each tab-delimited fragment as its own
+  // source unit. A tab is a position-dependent advance rather than a glyph, so a
+  // non-fit kernel entry at every tab boundary prevents same-id fragments from
+  // linking across it. Width/count placeholders are resolved from emitted text
+  // at layout scale below.
+  const fitTextFragmentEntryByKey = new Map<string, number>();
+  const fitTextRuns: FitTextRun[] = [];
+  for (const [runIndex, run] of runs.entries()) {
+    if (run.type !== 'text') {
+      fitTextRuns.push({ charCount: 0, naturalWidthPx: 0 });
+      continue;
+    }
+    const fragments = run.text.split('\t');
+    for (let fragmentIndex = 0; fragmentIndex < fragments.length; fragmentIndex += 1) {
+      fitTextFragmentEntryByKey.set(`${runIndex}:${fragmentIndex}`, fitTextRuns.length);
+      fitTextRuns.push({
+        fitTextValTwips: run.fitTextVal,
+        fitTextId: run.fitTextId,
+        charCount: [...fragments[fragmentIndex]].length,
+        naturalWidthPx: 0,
+        charScale: run.charScale,
+      });
+      if (fragmentIndex < fragments.length - 1) {
+        fitTextRuns.push({ charCount: 0, naturalWidthPx: 0 });
+      }
+    }
+  }
+  const fitTextRegionByEntry = new Map<number, number>();
   groupFitTextRegions(fitTextRuns, 1).forEach((region, regionIndex) => {
-    for (let runIndex = region.start; runIndex < region.end; runIndex += 1) {
-      fitTextRegionByRun.set(runIndex, regionIndex);
+    for (let entryIndex = region.start; entryIndex < region.end; entryIndex += 1) {
+      fitTextRegionByEntry.set(entryIndex, regionIndex);
     }
   });
   const pushTextPiece = (
@@ -1769,7 +1791,7 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
     base: DocxTextRun | FieldRun,
     vertAlign: 'super' | 'sub' | null,
     sourceRunIndex: number,
-    sourceRunCharCount?: number,
+    sourceFragmentIndex?: number,
   ) => {
     // §17.3.2.33 small caps are sized per character: lowercase LETTERS render two
     // points smaller, uppercase letters and non-alphabetic characters at the full
@@ -1787,7 +1809,12 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
     const revision = (base as DocxTextRun).revision;
     const r = base as DocxTextRun;
     const rtl = r.rtl === true ? true : undefined;
-    const fitTextRegionIndex = fitTextRegionByRun.get(sourceRunIndex);
+    const fitTextFragmentEntryIndex = sourceFragmentIndex === undefined
+      ? undefined
+      : fitTextFragmentEntryByKey.get(`${sourceRunIndex}:${sourceFragmentIndex}`);
+    const fitTextRegionIndex = fitTextFragmentEntryIndex === undefined
+      ? undefined
+      : fitTextRegionByEntry.get(fitTextFragmentEntryIndex);
 
     // IX1 — resolve the run's hyperlink target ONCE (§17.16.22 external URL /
     // §17.16.23 internal anchor). An external URL (`r.hyperlink`) wins over the
@@ -1890,8 +1917,7 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
         fitTextVal: fitTextRegionIndex === undefined ? undefined : r.fitTextVal,
         fitTextId: fitTextRegionIndex === undefined ? undefined : r.fitTextId,
         fitTextRegionIndex,
-        fitTextRunIndex: fitTextRegionIndex === undefined ? undefined : sourceRunIndex,
-        fitTextRunCharCount: fitTextRegionIndex === undefined ? undefined : sourceRunCharCount,
+        fitTextRunIndex: fitTextRegionIndex === undefined ? undefined : fitTextFragmentEntryIndex,
         position: r.position,
         kerning: r.kerning,
         // ECMA-376 §17.3.2.10 eastAsianLayout — 縦中横 is meaningful ONLY in a
@@ -1998,7 +2024,7 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
       if (t.noteRef) {
         const label = noteText != null ? String(noteText) : (t.text || '');
         if (label.length > 0) {
-          pushTextPiece(label, t, t.vertAlign ?? 'super', runIndex, [...t.text].length);
+          pushTextPiece(label, t, t.vertAlign ?? 'super', runIndex, 0);
         }
         continue;
       }
@@ -2006,7 +2032,7 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
       const parts = t.text.split('\t');
       for (let i = 0; i < parts.length; i++) {
         if (parts[i].length > 0) {
-          pushTextPiece(parts[i], t, t.vertAlign, runIndex, [...t.text].length);
+          pushTextPiece(parts[i], t, t.vertAlign, runIndex, i);
         }
         if (i < parts.length - 1) {
           segs.push({ isTab: true, fontSize: t.fontSize, measuredWidth: 0, bold: t.bold, italic: t.italic });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7120,7 +7120,9 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
       // drawing. `spanW` (the glyph advance + internalStretch) covers every glyph
       // and the interior pitch; `decoW` (below) additionally covers the segment's
       // own widened trailing SPACE so run decorations stay gap-free under `both`.
-      const stretch = segStretch?.get(si);
+      // §17.3.2.14 fitText is already a fixed-width cell; paragraph
+      // justification must not stretch its internal glyph gaps a second time.
+      const stretch = s.fitTextRegionIndex === undefined ? segStretch?.get(si) : undefined;
       const internalStretch = stretch?.internalStretch ?? 0;
       if (!dryRun) {
         const effSizePx = calcEffectiveFontPx(s, scale);
@@ -7145,7 +7147,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
         // `ctx.fontKerning` to match the measure pass exactly (see line-layout's
         // `setSegKerning`); restored after the glyph block.
         const segCharScale = s.charScale ?? 1;
-        const segCharSpacingPx = (s.charSpacing ?? 0) * scale;
+        const segCharSpacingPx = s.fitTextPerGapPx ?? (s.charSpacing ?? 0) * scale;
         const prevFontKerning = ctx.fontKerning;
         if (s.kerning != null) {
           ctx.fontKerning = s.fontSize >= s.kerning ? 'normal' : 'none';
@@ -7273,19 +7275,21 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           glyphColor = defaultColor;
         }
         ctx.fillStyle = glyphColor;
-        // Draw the glyphs. Three cases, all anchored to the WHOLE-string
+        // Draw the glyphs. Four cases, all anchored to the WHOLE-string
         // cumulative advance so the browser's contextual CJK metrics (most
         // visibly 約物半角, the half-width collapse of （「」。）) are honoured and
         // the painted advance equals the segment's box exactly:
-        //   1. Character grid active on a pure-EA segment (segGridDelta !== 0):
+        //   1. §17.3.2.14 fitText: resolved per-gap, with no trailing gap after
+        //      the region's last glyph and no cached w:spacing contribution.
+        //   2. Character grid active on a pure-EA segment (segGridDelta !== 0):
         //      walk every glyph, advancing each to its cell start
         //      `measure(prefix) + i·Δ + justGaps·perGap`. The final glyph lands so
         //      the segment edge is measure(whole) + len·Δ + nGaps·perGap =
         //      measuredWidth + internalStretch — measure==draw by construction
         //      (§17.6.5). Folds in any justification pitch at the same time.
-        //   2. Justified inter-CJK pitch only (no grid): the existing
+        //   3. Justified inter-CJK pitch only (no grid): the existing
         //      `justifiedPiecePositions` slice-at-gaps path.
-        //   3. Neither: a single fillText (the common path).
+        //   4. Neither: a single fillText (the common path).
         const segmentGridDeltaPx = segmentCharacterGridDeltaPx(s, drawGridDeltaPx);
         const segGridDelta = gridSegDeltaPx(s.text, segmentGridDeltaPx);
         if (state.verticalCJK && s.tateChuYoko) {
@@ -7325,6 +7329,28 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             segLetterSpacingPx(s, drawGridDeltaPx, scale),
             segCharScale,
           );
+        } else if (s.fitTextPerGapPx !== undefined) {
+          // ECMA-376 §17.3.2.14 Manual Run Width. Same draw model as the
+          // §17.18.44 FULLY-distributed arm below: the resolved region gap opens
+          // at EVERY internal code-point boundary, so the whole
+          // contextually-shaped string is painted in ONE fillText with a uniform
+          // `ctx.letterSpacing = perGap` — glyph i lands at
+          // measure(prefix_i) + i·perGap and the final glyph reaches
+          // measure(whole) + (n−1)·perGap, the segment's canonical advance
+          // (measure==paint; no piece slicing is needed when every boundary is a
+          // gap). The canonical measuredWidth already includes one trailing
+          // boundary gap on every NON-last region segment and none on the last;
+          // the normal pen advance supplies that cross-segment gap. Composed
+          // with §17.3.2.43 `w:w` exactly like the sibling arms: the fixed pitch
+          // is divided by `segCharScale` so the ×scale frame reproduces its
+          // un-scaled magnitude.
+          const scaled = segCharScale !== 1;
+          const prevLetterSpacing = ctx.letterSpacing;
+          if (scaled) { ctx.save(); ctx.translate(x, 0); ctx.scale(segCharScale, 1); }
+          ctx.letterSpacing = `${s.fitTextPerGapPx / segCharScale}px`;
+          ctx.fillText(s.text, scaled ? 0 : x, baseline + yOffset);
+          ctx.letterSpacing = prevLetterSpacing;
+          if (scaled) ctx.restore();
         } else if (segGridDelta !== 0) {
           const cps = [...s.text]; // code points (handles surrogate pairs)
           // Draw each CONTIGUOUS piece (sliced only at justify gaps) as ONE

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -504,6 +504,9 @@ export interface DocxTextRunInfo {
   fontSize: number;
   /** CSS `font` shorthand used for canvas drawing (e.g. `"bold 16px Arial"`). */
   font: string;
+  /** Uniform per-code-point pitch in CSS px used to draw a horizontal run.
+   *  Absent when the pitch is zero or the run uses vertical / 縦中横 paint. */
+  letterSpacingPx?: number;
   /** ECMA-376 §17.6.20 (tbRl) — when the page is vertical the canvas is the
    *  physical landscape page rotated +90° at paint, so this run's `x`/`y` are the
    *  PHYSICAL top-left the overlay span must sit at, and `transform` is the CSS
@@ -6888,7 +6891,11 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     let shrinkDelta = 0;
     if (!applyJustify && lineSlack < 0) {
       const distSegs = line.segments.map(seg =>
-        'text' in seg ? { text: (seg as LayoutTextSeg).text } : {},
+        // §17.3.2.14 fixes fit-region pitch; §17.18.44 must therefore treat the
+        // region like a non-text object so none of its internal gaps get slack.
+        'text' in seg && (seg as LayoutTextSeg).fitTextRegionIndex === undefined
+          ? { text: (seg as LayoutTextSeg).text }
+          : {},
       );
       const shrinkDist = shrinkFitCompression(
         distSegs,
@@ -7026,7 +7033,11 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
       // Expansion opens inter-CJK boundaries; compression touches only spaces
       // (shrinking a space is fine, overlapping ideographs is not).
       const distSegs = line.segments.map(seg =>
-        'text' in seg ? { text: (seg as LayoutTextSeg).text } : {},
+        // §17.3.2.14 fixes fit-region pitch; §17.18.44 must therefore treat the
+        // region like a non-text object so none of its internal gaps get slack.
+        'text' in seg && (seg as LayoutTextSeg).fitTextRegionIndex === undefined
+          ? { text: (seg as LayoutTextSeg).text }
+          : {},
       );
       const dist = distributeLineSlack(
         distSegs,
@@ -7123,6 +7134,11 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
       // §17.3.2.14 fitText is already a fixed-width cell; paragraph
       // justification must not stretch its internal glyph gaps a second time.
       const stretch = s.fitTextRegionIndex === undefined ? segStretch?.get(si) : undefined;
+      // A fit region contributes an opaque atom to §17.18.44 distribution. Its
+      // INTERNAL pitch stays suppressed above, but a legal boundary AFTER that
+      // atom is paragraph slack, not §17.3.2.14 fit pitch, and must still advance
+      // the following segment.
+      const trailingDistributionGap = segStretch?.get(si)?.trailingGap ?? false;
       const internalStretch = stretch?.internalStretch ?? 0;
       if (!dryRun) {
         const effSizePx = calcEffectiveFontPx(s, scale);
@@ -7610,6 +7626,12 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           const place = verticalTextLayerPlacement(
             x, state.y, state.verticalPhys?.cssWidthPx ?? 0, !!state.verticalCJK,
           );
+          // Reuse the paint path's single pitch authority so selection and find
+          // overlays reproduce §17.3.2.14 fitText or docGrid + §17.3.2.35 spacing.
+          // Vertical / 縦中横 runs retain their existing payload and geometry.
+          const letterSpacingPx = !state.verticalCJK && !s.tateChuYoko
+            ? segLetterSpacingPx(s, drawGridDeltaPx, scale)
+            : 0;
           state.onTextRun({
             text: s.text,
             x: place ? place.left : x,
@@ -7618,6 +7640,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             h: lineH,
             fontSize: effSizePx,
             font: ctx.font,
+            ...(letterSpacingPx !== 0 ? { letterSpacingPx } : {}),
             transform: place?.transform,
             // IX1 — hand the resolved hyperlink target to the overlay so a link
             // run becomes clickable. Undefined for non-link runs (no payload
@@ -7722,7 +7745,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
       // shifted. distributeLineSlack only sets trailingGap on gap-opening
       // segments — never the visually-final segment or a leading-indent segment —
       // so the final glyph still lands on the margin (Σgaps == slack).
-      if (stretch?.trailingGap) x += distPerGap;
+      if (trailingDistributionGap) x += distPerGap;
     }
     // End of line closes any open run-border group: a frame never spans lines
     // (each line wrap starts a fresh box on the next line).
@@ -9032,7 +9055,11 @@ export function renderShapeText(
         let shrinkDelta = 0;
         if (!applyJustify && lineSlack < 0) {
           const distSegs = line.segments.map((seg) =>
-            'text' in seg ? { text: (seg as LayoutTextSeg).text } : {},
+            // §17.3.2.14 fixes fit-region pitch; §17.18.44 must therefore treat
+            // the region like a non-text object with no distributable gaps.
+            'text' in seg && (seg as LayoutTextSeg).fitTextRegionIndex === undefined
+              ? { text: (seg as LayoutTextSeg).text }
+              : {},
           );
           const shrinkDist = shrinkFitCompression(
             distSegs,
@@ -9077,7 +9104,11 @@ export function renderShapeText(
         if (applyJustify) {
           const minPerGap = -line.ascent * 0.25;
           const distSegs = line.segments.map((seg) =>
-            'text' in seg ? { text: (seg as LayoutTextSeg).text } : {},
+            // §17.3.2.14 fixes fit-region pitch; §17.18.44 must therefore treat
+            // the region like a non-text object with no distributable gaps.
+            'text' in seg && (seg as LayoutTextSeg).fitTextRegionIndex === undefined
+              ? { text: (seg as LayoutTextSeg).text }
+              : {},
           );
           const dist = distributeLineSlack(
             distSegs,

--- a/packages/docx/src/text-layer.ts
+++ b/packages/docx/src/text-layer.ts
@@ -93,6 +93,9 @@ export function buildDocxTextLayer(
     // identical to a plain run. A non-link run is byte-identical to before.
     const link = onHyperlinkClick ? run.hyperlink : undefined;
     const cursor = link ? 'pointer' : 'text';
+    const letterSpacing = run.letterSpacingPx !== undefined
+      ? `${run.letterSpacingPx}px`
+      : '0';
     // Position the span as a % of the page's intended CSS box so it tracks the
     // canvas's actual rendered size under external CSS scaling. `font` /
     // `line-height` stay px (the glyph metrics of the transparent hit text laid
@@ -102,7 +105,7 @@ export function buildDocxTextLayer(
     span.style.cssText =
       `position:absolute;` +
       `left:${overlayPercent(run.x, cssWidth)};top:${overlayPercent(run.y, cssHeight)};` +
-      `font:${run.font};line-height:${run.h}px;letter-spacing:0;` +
+      `font:${run.font};line-height:${run.h}px;letter-spacing:${letterSpacing};` +
       transform +
       `white-space:pre;color:transparent;cursor:${cursor};pointer-events:all;`;
     if (link && onHyperlinkClick) {

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1125,6 +1125,11 @@ export interface DocxTextRun {
    *  measure and paint passes so line breaking / pagination stay consistent.
    *  Absent ⇒ no extra pitch. */
   charSpacing?: number;
+  /** ECMA-376 §17.3.2.14 `<w:fitText>` — manual run-width target in TWIPS
+   *  (`w:val`, 1/20 pt) plus the optional signed `w:id` that links consecutive
+   *  runs into one region. An id-less run is always standalone. */
+  fitTextVal?: number;
+  fitTextId?: number;
   /** ECMA-376 §17.3.2.43 `<w:w w:val>` — horizontal text scale as a FRACTION of
    *  normal character width (0.67 = 67%, 2.0 = 200%). Stretches each glyph's
    *  width, not the gap between glyphs. Absent ⇒ 100%. */

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1126,10 +1126,12 @@ export interface DocxTextRun {
    *  Absent ⇒ no extra pitch. */
   charSpacing?: number;
   /** ECMA-376 §17.3.2.14 `<w:fitText>` — manual run-width target in TWIPS
-   *  (`w:val`, 1/20 pt) plus the optional signed `w:id` that links consecutive
-   *  runs into one region. An id-less run is always standalone. */
+   *  (`w:val`, 1/20 pt) plus the optional `w:id` that links consecutive runs
+   *  into one region. The arbitrary-precision XSD integer id is serialized as a
+   *  string; numeric synthetic inputs remain supported for layout tests and
+   *  direct model construction. An id-less run is always standalone. */
   fitTextVal?: number;
-  fitTextId?: number;
+  fitTextId?: string | number;
   /** ECMA-376 §17.3.2.43 `<w:w w:val>` — horizontal text scale as a FRACTION of
    *  normal character width (0.67 = 67%, 2.0 = 200%). Stretches each glyph's
    *  width, not the gap between glyphs. Absent ⇒ 100%. */


### PR DESCRIPTION
## Summary

Implements ECMA-376 §17.3.2.14 `<w:fitText>` (Manual Run Width) for the DOCX renderer: a run's contents are displayed within the width given by `w:val` (twips), and **consecutive runs carrying the same `w:id` merge into one fit region** that fills `w:val` together (the spec's example: a 1-inch region split across three runs occupies one inch in total). An id-less fitText run never links to a neighbour, and a non-fitText run breaks adjacency.

Previously the element was ignored entirely, so fitted labels (common in Japanese government/business forms, where a column of headings is aligned to one fixed width) rendered at their natural width plus whatever stale `w:spacing` Word had cached — misaligning the whole label column.

## Geometry

Measured from a private fixture's Word-generated PDF (the acceptance ground truth):

- Glyphs keep their **natural advance** (including the §17.3.2.43 `w:w` horizontal glyph scale).
- The slack `(val − Σnatural)` is distributed **evenly as inter-character gaps** — one gap between every adjacent glyph pair across run boundaries, **no gap after the region's last glyph**:

  ```
  perGap = (targetPx − naturalPx) / (charCount − 1)
  ```

- Cached §17.3.2.35 `w:spacing` on the runs is **ignored** inside a fit region: Word recomputes the pitch from `w:val`, and the fixture's cached value demonstrably disagrees with its own PDF.
- Compression (`Σnatural > val`) uses the same formula with a negative gap. The spec phrases compression as "decreasing the size of each character"; this is recorded in-code so a charScale-based approach can be swapped in if compression ground truth appears.
- A fit region is an **atomic, non-wrapping unit** (a fixed-width cell of width `val`).

## Implementation

- **Parser (Rust)**: `<w:fitText w:val w:id>` → `TextRun.fitTextVal` (kept in twips so the layout layer applies its px-per-pt scale exactly once) + `fitTextId` (signed ST_DecimalNumber). Follows the shared run-property cascade (set overrides, absent inherits) beside the §17.3.2.35/43/24/19 axes.
- **Kernel (`fit-text.ts`)**: pure `groupFitTextRegions(runs, scale)` — the single source of region grouping and per-gap math, pinned by 12 standalone unit tests (merge, adjacency break, id-less standalone, twips→px scale, `w:w` composition, negative gap, single-glyph, no-fitText).
- **Layout (`line-layout.ts`)**: regions are grouped over **source runs** in `buildSegments` (script/small-caps segmentation cannot fork a region), resolved from raw Canvas advances at the exact layout scale, and folded into the existing advance authority (`segAdvanceWidth` / `segLetterSpacingPx` / `charSpacingDeltaPx`) — no parallel width system. Non-last region segments carry one trailing boundary gap; the last carries none, so the region sums to `val` exactly. The line breaker treats the region as one glued, atomically-fitted unit, and `rescaleLayoutLines` re-resolves the gap from paint-scale metrics so measure == paint.
- **Paint (`renderer.ts`)**: a fit segment draws through the same uniform `ctx.letterSpacing` model as the §17.18.44 fully-distributed justify arm, composed with `w:w` exactly like the sibling arms (fixed pitch divided by the glyph scale inside the ×scale frame). Paragraph justification does not re-stretch a fit region's internal gaps. Find/selection coordinates (`onTextRun`) and run decorations follow the fitted advance automatically via `measuredWidth`.

## Verification

- fitText suites: 17/17 (12 pinned kernel + layout integration + recording-canvas paint).
- Full docx suite: 141 files, 1031 passed, 1 skipped — no regressions.
- Root `pnpm typecheck`: pass. Rust: `cargo fmt --check`, `clippy -D warnings`, 312 tests pass. WASM rebuilt via the package script (reinit export verified).
- Node probe (skia) against the private fixture's Word PDF, three fit regions (`val=2400` = 120 pt):

  | Region | before advance (pt) | after advance (pt) | Word PDF |
  |---|---|---|---|
  | 6 glyphs, 3 runs | 96.00 | **120.00** | 120.00 |
  | 4 glyphs, 3 runs | 84.00 | **120.00** | 120.00 |
  | 15 glyphs, `w:w`=66% | 119.70 | **120.00** | 120.00 |

  Head-run advance 86.40 pt (= 48 + 4×9.6, the recomputed per-gap — not the cached `w:spacing`), region right edge within 0.06 pt of the PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)