### PR TITLE
Produce and paint DOCX table fragments

### DIFF
--- a/packages/docx/src/cell-height-scale-metrics.test.ts
+++ b/packages/docx/src/cell-height-scale-metrics.test.ts
@@ -284,4 +284,31 @@ describe('Finding 1 — cell content height uses real-scale (rescaled) Canvas me
       __test_setFragmentPaintEnabled(prevFrag);
     }
   });
+
+  it('PR 6 — a vAlign table (fragment-paint gate-excluded) still reuses the paginator scale-1 geometry in production', async () => {
+    // A vAlign=center cell excludes its table from fragment paint (the §17.4.84
+    // centring re-measures content), so it takes the LEGACY renderTable path — which,
+    // in production (table reuse ON), must draw the PAGINATOR's scale-1 row height
+    // × scale exactly as the pre-PR6 stamp reuse did. PR 6 removed the stamp from the
+    // non-split parsed table (model-mutation removal), so computeTableLayout must
+    // source the same geometry from the attached TableFragment instead; without that,
+    // the fallback recomputes at paint-scale metrics and the drawn row height shifts
+    // under non-linear metrics (observed as a raw-pixel VRT delta on a private
+    // multi-table document). Defaults untouched: fragment paint ON, table reuse ON.
+    const t = tableOf(row(
+      cell([paraOf('aa'), paraOf('bb'), paraOf('cc')], 'center', 'abcdef'),
+      null,
+      'auto',
+    ));
+    const { fillRectCalls } = await renderAndRead(t);
+    const bg = fillRectCalls.find((r) => r.fillStyle === '#abcdef');
+    expect(bg).toBeDefined();
+    // The paginator resolved the row at scale 1: 3 one-line paragraphs at 12pt with
+    // the mock's scale-1 glyph box (asc+desc at p=12), so the production-drawn row
+    // height is that scale-1 height × SCALE — NOT the paint-scale recompute (which
+    // under the non-linear mock is measurably shorter).
+    const { asc, desc } = glyphMetrics(12);
+    const scale1RowHeightPt = 3 * (asc + desc);
+    expect(bg!.h).toBeCloseTo(scale1RowHeightPt * SCALE, 1);
+  });
 });

--- a/packages/docx/src/cell-height-scale-metrics.test.ts
+++ b/packages/docx/src/cell-height-scale-metrics.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   renderDocumentToCanvas,
   __test_setTableReuseEnabled,
+  __test_setFragmentPaintEnabled,
 } from './renderer.js';
 import type {
   BodyElement,
@@ -259,6 +260,10 @@ describe('Finding 1 — cell content height uses real-scale (rescaled) Canvas me
     // Auto height → the row height IS the measured cell content height. Disable the
     // stamped-layout reuse so computeTableLayout runs the fresh real-scale fallback
     // (the exact path Finding 1 flags), not the paginator's scale-1 stamp × scale.
+    // PR 6 — also disable the fragment paint path (which, like the reuse, draws the
+    // paginator's scale-1 row height × scale); the legacy `renderTable` recompute is
+    // the path this Finding characterizes.
+    const prevFrag = __test_setFragmentPaintEnabled(false);
     const prev = __test_setTableReuseEnabled(false);
     try {
       const t = tableOf(row(
@@ -276,6 +281,7 @@ describe('Finding 1 — cell content height uses real-scale (rescaled) Canvas me
       expect(bg!.h).toBeCloseTo(bottom - top, 1);
     } finally {
       __test_setTableReuseEnabled(prev);
+      __test_setFragmentPaintEnabled(prevFrag);
     }
   });
 });

--- a/packages/docx/src/cell-paragraph-line-reuse.test.ts
+++ b/packages/docx/src/cell-paragraph-line-reuse.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { renderDocumentToCanvas, paginateDocument, __test_setLineReuseEnabled } from './renderer.js';
+import {
+  renderDocumentToCanvas,
+  paginateDocument,
+  __test_setFragmentPaintEnabled,
+  __test_setLineReuseEnabled,
+} from './renderer.js';
 import type { BodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, DocxDocumentModel, SectionProps, PaginatedBodyElement } from './types';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -182,18 +187,23 @@ async function renderAll(model: DocxDocumentModel, pages: PaginatedBodyElement[]
 /** Paginate once, then paint with reuse OFF and ON at `width`; assert byte-identical
  *  streams and report the measure counts. */
 async function reuseVsRecompute(model: DocxDocumentModel, width = 300): Promise<{ pages: number; drawn: number; on: number; off: number; streams: Call[][] }> {
-  const pages = paginateDocument(model);
-  const prev = __test_setLineReuseEnabled(false);
-  let off: { perPage: Call[][]; measures: number };
-  try { off = await renderAll(model, pages, width); } finally { __test_setLineReuseEnabled(prev); }
-  const on = await renderAll(model, pages, width);
-  expect(on.perPage.length).toBe(off.perPage.length);
-  let drawn = 0;
-  for (let p = 0; p < on.perPage.length; p++) {
-    expect(on.perPage[p]).toEqual(off.perPage[p]); // exact stream identity
-    drawn += on.perPage[p].filter((c) => c.op !== 'img').length;
+  const prevFragmentPaint = __test_setFragmentPaintEnabled(false);
+  try {
+    const pages = paginateDocument(model);
+    const prev = __test_setLineReuseEnabled(false);
+    let off: { perPage: Call[][]; measures: number };
+    try { off = await renderAll(model, pages, width); } finally { __test_setLineReuseEnabled(prev); }
+    const on = await renderAll(model, pages, width);
+    expect(on.perPage.length).toBe(off.perPage.length);
+    let drawn = 0;
+    for (let p = 0; p < on.perPage.length; p++) {
+      expect(on.perPage[p]).toEqual(off.perPage[p]); // exact stream identity
+      drawn += on.perPage[p].filter((c) => c.op !== 'img').length;
+    }
+    return { pages: pages.length, drawn, on: on.measures, off: off.measures, streams: on.perPage };
+  } finally {
+    __test_setFragmentPaintEnabled(prevFragmentPaint);
   }
-  return { pages: pages.length, drawn, on: on.measures, off: off.measures, streams: on.perPage };
 }
 
 function tableMeasurementGeometry() {

--- a/packages/docx/src/document-layout.test.ts
+++ b/packages/docx/src/document-layout.test.ts
@@ -158,6 +158,23 @@ describe('layoutDocument — body paragraph fragments (PR 5 Task 12)', () => {
     expect(page.geometry.marginLeft).toBe(10);
     // SectionLayoutContext carries the resolved grid policy (docGrid absent => none).
     expect(page.section.grid.kind).toBe('none');
+    // M-2 — a single-column section exposes one column spanning the content band.
+    expect(page.section.columns.length).toBe(1);
+    expect(page.section.columns[0].wPt).toBeCloseTo(180, 6);
+  });
+
+  it('M-2: exposes the §17.6.4 per-page column geometry the paginator resolved', () => {
+    const model = doc([para('x') as unknown as BodyElement, para('y') as unknown as BodyElement]);
+    (model.section as SectionProps).columns = {
+      count: 2, spacePt: 20, equalWidth: true, sep: false, cols: [],
+    } as SectionProps['columns'];
+    const page = layoutDocument(model).pages[0];
+    // Two newspaper columns: content band 180pt minus 20pt gutter → 80pt each.
+    expect(page.section.columns.length).toBe(2);
+    expect(page.section.columns[0].wPt).toBeCloseTo(80, 6);
+    expect(page.section.columns[1].wPt).toBeCloseTo(80, 6);
+    // A fragment records which column it is placed in.
+    for (const f of page.fragments) expect([0, 1]).toContain(f.columnIndex);
   });
 
   it('splits a long paragraph into continuation fragments over one source', () => {

--- a/packages/docx/src/float-table-width.test.ts
+++ b/packages/docx/src/float-table-width.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computePages } from './renderer.js';
+import { bodyFragmentFor, computePages } from './renderer.js';
 import type {
   BodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell,
   DocxTextRun, SectionProps, TblpPr, PaginatedBodyElement,
@@ -104,9 +104,13 @@ function table(
 }
 
 const isTable = (e: PaginatedBodyElement): boolean => e.type === 'table';
-const stampedWidth = (pages: PaginatedBodyElement[][]): number => {
+const resolvedWidth = (pages: PaginatedBodyElement[][]): number => {
   const el = pages.flat().find(isTable);
   expect(el).toBeDefined();
+  const placed = bodyFragmentFor(el as PaginatedBodyElement);
+  if (placed?.fragment.kind === 'table') {
+    return placed.fragment.columnWidthsPt.reduce((s, w) => s + w, 0);
+  }
   return ((el as PaginatedBodyElement).tableColWidthsPt ?? []).reduce((s, w) => s + w, 0);
 };
 
@@ -117,7 +121,7 @@ describe('floating-table width cap (§17.4.57) — page width, not the column ba
       [table([200, 120, 200], { layout: 'fixed', float: true })],
       section(), makeCtx(),
     );
-    expect(stampedWidth(pages)).toBeCloseTo(520, 1);
+    expect(resolvedWidth(pages)).toBeCloseTo(520, 1);
   });
 
   it('keeps an AUTOFIT floating table with a preferred tblW at its full grid width (sample-28 p.17)', () => {
@@ -126,7 +130,7 @@ describe('floating-table width cap (§17.4.57) — page width, not the column ba
       [table([200, 120, 200], { widthPt: 520, float: true })],
       section(), makeCtx(),
     );
-    expect(stampedWidth(pages)).toBeCloseTo(520, 1);
+    expect(resolvedWidth(pages)).toBeCloseTo(520, 1);
   });
 
   it('clamps a floating table wider than the PAGE to the page width', () => {
@@ -135,7 +139,7 @@ describe('floating-table width cap (§17.4.57) — page width, not the column ba
       [table([300, 100, 300], { layout: 'fixed', float: true })],
       section(), makeCtx(),
     );
-    expect(stampedWidth(pages)).toBeCloseTo(600, 1);
+    expect(resolvedWidth(pages)).toBeCloseTo(600, 1);
   });
 
   it('still scales a NON-floating fixed table down to the column band (block-table cap unchanged)', () => {
@@ -143,7 +147,7 @@ describe('floating-table width cap (§17.4.57) — page width, not the column ba
       [table([200, 120, 200], { layout: 'fixed' })],
       section(), makeCtx(),
     );
-    expect(stampedWidth(pages)).toBeCloseTo(450, 1);
+    expect(resolvedWidth(pages)).toBeCloseTo(450, 1);
   });
 
   it('leaves a floating table narrower than the band untouched (cap never bites)', () => {
@@ -151,6 +155,6 @@ describe('floating-table width cap (§17.4.57) — page width, not the column ba
       [table([100, 100], { layout: 'fixed', float: true })],
       section(), makeCtx(),
     );
-    expect(stampedWidth(pages)).toBeCloseTo(200, 1);
+    expect(resolvedWidth(pages)).toBeCloseTo(200, 1);
   });
 });

--- a/packages/docx/src/fragment-paint.test.ts
+++ b/packages/docx/src/fragment-paint.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { renderDocumentToCanvas, paginateDocument } from './renderer.js';
-import type { BodyElement, DocParagraph, DocxDocumentModel, PaginatedBodyElement, SectionProps } from './types';
+import type {
+  BodyElement,
+  CellElement,
+  DocParagraph,
+  DocTable,
+  DocTableCell,
+  DocTableRow,
+  DocxDocumentModel,
+  PaginatedBodyElement,
+  SectionProps,
+} from './types';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PR 5 Task 13 — body fragment paint purity.
@@ -112,6 +122,77 @@ function doc(body: BodyElement[], pageHeight = 400): DocxDocumentModel {
     footnotes: [],
   } as unknown as DocxDocumentModel;
 }
+
+// ---- Table builders (PR 6 Task 16) --------------------------------------------
+function eb() {
+  return { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null };
+}
+function tcell(content: CellElement[], over: Partial<DocTableCell> = {}): DocTableCell {
+  return {
+    content, colSpan: 1, vMerge: null, borders: eb(),
+    background: null, vAlign: 'top', widthPt: null, ...over,
+  } as unknown as DocTableCell;
+}
+function textCell(text: string, over: Partial<DocTableCell> = {}): DocTableCell {
+  return tcell([{ type: 'paragraph', ...para(text) } as unknown as CellElement], over);
+}
+function trow(cells: DocTableCell[], over: Partial<DocTableRow> = {}): DocTableRow {
+  return { cells, rowHeight: null, rowHeightRule: 'auto', isHeader: false, ...over } as unknown as DocTableRow;
+}
+function tbl(rows: DocTableRow[], colWidths: number[], over: Partial<DocTable> = {}): DocTable {
+  return {
+    type: 'table', colWidths, rows, borders: eb(),
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left', layout: 'fixed', ...over,
+  } as unknown as DocTable;
+}
+
+describe('table fragment paint purity (PR 6 Task 16)', () => {
+  it('paints a table with a NESTED table + vMerge at scale 1 without calling measureText', async () => {
+    // A nested table currently RECOMPUTES its layout at paint (computeTableLayout →
+    // resolveTableRowHeights → measureParagraph), so this is Red on the stamp path.
+    // After the fragment migration the nested table is painted from its stored
+    // TableFragment, measure-free.
+    const inner = tbl([trow([textCell('inner one'), textCell('inner two')])], [40, 40]);
+    const outer = tbl(
+      [
+        trow([textCell('a', { vMerge: true }), textCell('top')]),
+        trow([textCell('', { vMerge: false }), tcell([{ type: 'table', ...inner } as unknown as CellElement])]),
+      ],
+      [60, 100],
+    );
+    const model = doc([outer as unknown as BodyElement]);
+    const pages = paginateDocument(model);
+    const paint = makeThrowingPaintCanvas();
+    await expect(
+      renderDocumentToCanvas(model, paint.canvas, 0, { dpr: 1, width: 200, prebuiltPages: pages }),
+    ).resolves.not.toThrow();
+    expect(paint.measured()).toBe(0);
+    // Non-vacuity: outer + inner cell text were drawn.
+    expect(paint.calls.some((c) => c.text.includes('top'))).toBe(true);
+    expect(paint.calls.some((c) => c.text.includes('inner'))).toBe(true);
+  });
+
+  it('paints a page-split table with a repeated header at scale 1, measure-free', async () => {
+    const bodyRows = Array.from({ length: 12 }, (_v, i) => trow([textCell(`row ${i}`)]));
+    const rows = [trow([textCell('HEADER')], { isHeader: true }), ...bodyRows];
+    const model = doc([tbl(rows, [120]) as unknown as BodyElement], 120);
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(1);
+    for (let p = 0; p < pages.length; p++) {
+      const paint = makeThrowingPaintCanvas();
+      await expect(
+        renderDocumentToCanvas(model, paint.canvas, p, { dpr: 1, width: 200, prebuiltPages: pages }),
+      ).resolves.not.toThrow();
+      expect(paint.measured()).toBe(0);
+      expect(paint.calls.length).toBeGreaterThan(0);
+    }
+    // The header text is repeated on the continuation page.
+    const paint2 = makeThrowingPaintCanvas();
+    await renderDocumentToCanvas(model, paint2.canvas, 1, { dpr: 1, width: 200, prebuiltPages: pages });
+    expect(paint2.calls.some((c) => c.text.includes('HEADER'))).toBe(true);
+  });
+});
 
 describe('fragment paint purity (PR 5 Task 13)', () => {
   it('paints a premeasured body paragraph at scale 1 without ever calling measureText', async () => {

--- a/packages/docx/src/fragment-paint.ts
+++ b/packages/docx/src/fragment-paint.ts
@@ -25,7 +25,12 @@
  *
  * See docs/docx-layout-context-fragments-design.md §"Measured Fragment Model".
  */
-import { renderBodyParagraphLines, type ParaBorderMerge, type RenderState } from './renderer.js';
+import {
+  renderBodyParagraphLines,
+  renderTableFragment,
+  type ParaBorderMerge,
+  type RenderState,
+} from './renderer.js';
 import type { PlacedFragment } from './layout-fragments.js';
 
 /**
@@ -68,4 +73,22 @@ export function paintParagraphFragment(
     lineSlice,
     options.borderMerge,
   );
+}
+
+/**
+ * Paint a block-table {@link PlacedFragment} produced by {@link layoutDocument} / the
+ * paginator: the table's geometry (column widths, row heights) and cell content
+ * (paragraph + nested-table fragments) are drawn from the stored {@link TableFragment}
+ * WITHOUT re-laying-out or re-measuring. At the paint scale of 1 no `measureText` is
+ * called at all. Like {@link paintParagraphFragment}, this owns the fragment boundary
+ * and delegates the draw to the renderer's shared table paint through a supplied-geometry
+ * entry (`renderTableFragment`), so the paint stream is byte-identical to the legacy
+ * `renderTable` acquisition for the migrated (in-flow, top-aligned) table class.
+ */
+export function paintTableFragment(placed: PlacedFragment, state: RenderState): void {
+  const fragment = placed.fragment;
+  // Table fragment paint only; the migration gate never routes a paragraph fragment
+  // here, so this narrow is defensive and a no-op in production.
+  if (fragment.kind !== 'table') return;
+  renderTableFragment(fragment, state);
 }

--- a/packages/docx/src/fragment-paint.ts
+++ b/packages/docx/src/fragment-paint.ts
@@ -46,6 +46,10 @@ export function paintParagraphFragment(
   } = {},
 ): void {
   const fragment = placed.fragment;
+  // Body paragraph paint only. A table fragment is painted by the table-fragment
+  // path; the migration gate ({@link isFragmentPaintableParagraph}) never routes one
+  // here, so this narrow is defensive and a no-op in production.
+  if (fragment.kind !== 'paragraph') return;
   const measured = fragment.measured;
   // The stored scale-1 line partition for the whole paragraph. Empty for a markOnly
   // (empty / anchor-only) paragraph — the renderer's empty-mark branch handles it.

--- a/packages/docx/src/layout-fragments.ts
+++ b/packages/docx/src/layout-fragments.ts
@@ -14,10 +14,12 @@
  * All coordinates are points at scale 1 — the measurement coordinate system. Paint
  * scales the stored geometry; it never repeats text layout.
  *
- * PR 6 will widen {@link FlowFragment} to also include a `TableFragment`. This module
- * intentionally exposes only the paragraph fragment contract for PR 5.
+ * PR 6 widens {@link FlowFragment} to also include a {@link TableFragment}: a table
+ * fragments recursively into {@link RowFragment}s → {@link CellFragment}s → nested
+ * {@link FlowFragment}s (paragraph or nested-table fragments), so body and table flow
+ * share one immutable fragment result (design §"Measured Fragment Model").
  */
-import type { DocParagraph, SectionGeom } from './types';
+import type { DocParagraph, DocTable, DocTableRow, DocTableCell, SectionGeom } from './types';
 import type { MeasuredParagraph } from './paragraph-measure.js';
 import type { SectionLayoutContext } from './layout-context.js';
 
@@ -45,7 +47,67 @@ export interface ParagraphFragment {
   readonly trailingSpacePt: number;
 }
 
-export type FlowFragment = ParagraphFragment;
+/**
+ * A measured table cell (ECMA-376 §17.4.7 `<w:tc>`). Its content is a recursive list
+ * of {@link FlowFragment}s — paragraph fragments and nested-table fragments in document
+ * order — so a cell's paragraphs are painted from their own stored line partition
+ * exactly like body paragraphs, and a nested table fragments recursively.
+ *
+ * `verticalMerge` mirrors the parsed cell's §17.4.85 `<w:vMerge>` role:
+ *   - `restart` — the cell owns the merged span's content; the span's geometry is
+ *     distributed across its rows by the row-height resolver.
+ *   - `continue` — the cell renders no content (its `blocks` is empty); it exists so
+ *     the grid/border geometry is complete.
+ *   - `none` — an ordinary single-row cell.
+ */
+export interface CellFragment {
+  readonly source: DocTableCell;
+  readonly blocks: readonly FlowFragment[];
+  readonly verticalMerge: 'none' | 'restart' | 'continue';
+}
+
+/**
+ * A measured table row placed on one page (ECMA-376 §17.4.6 `<w:tr>`).
+ *
+ * `sourceRowIndex` is the row's index in the ORIGINAL {@link DocTable.rows}; `source`
+ * is the (possibly cell-content-sliced) row this fragment renders — a table split
+ * across pages by cell-block boundaries already produces a per-page slice of a source
+ * row (renderer `splitRowByCellBlocks`). The model deliberately does NOT assume a
+ * source row maps to exactly one `RowFragment`: a future mid-row / mid-cell page split
+ * (§17.4.6 `cantSplit` default = splittable) may emit several `RowFragment`s that share
+ * one `sourceRowIndex`, each carrying its own vertical portion via `heightPt` and its
+ * cells' partial `blocks`. This PR does not implement that split; it only keeps the
+ * contract open to it.
+ *
+ * `repeatedHeader` marks a leading `<w:tblHeader>` row re-emitted at the top of a
+ * continuation page (§17.4.78). `heightPt` is the scale-1 point height the paginator
+ * charged for this row.
+ */
+export interface RowFragment {
+  readonly source: DocTableRow;
+  readonly sourceRowIndex: number;
+  readonly heightPt: number;
+  readonly cells: readonly CellFragment[];
+  readonly repeatedHeader: boolean;
+}
+
+/**
+ * A measured table (ECMA-376 §17.4.4 `<w:tbl>`) placed on one page. `columnWidthsPt`
+ * is the resolved scale-1 grid (constant across a page-split); `rows` are the row
+ * fragments on THIS page. `continuesFromPreviousPage` / `continuesOnNextPage` record
+ * whether the source table spilled a page boundary into / out of this fragment, so a
+ * consumer can render header repetition and continuation without re-deriving the split.
+ */
+export interface TableFragment {
+  readonly kind: 'table';
+  readonly source: DocTable;
+  readonly columnWidthsPt: readonly number[];
+  readonly rows: readonly RowFragment[];
+  readonly continuesFromPreviousPage: boolean;
+  readonly continuesOnNextPage: boolean;
+}
+
+export type FlowFragment = ParagraphFragment | TableFragment;
 
 export interface PlacedFragment {
   readonly fragment: FlowFragment;
@@ -113,4 +175,24 @@ export function paragraphFragmentAdvancePt(fragment: ParagraphFragment): number 
     fragmentLineAdvancesPt(fragment) +
     fragment.trailingSpacePt
   );
+}
+
+/**
+ * The flow height (scale-1 pt) a table fragment charges: the sum of its row-fragment
+ * heights. Each {@link RowFragment.heightPt} is the ST_HeightRule + §17.4.85 vMerge
+ * span height the paginator resolved, so this equals the cursor advancement the
+ * paginator charged for the placed slice (design §"Pagination and paint invariants" 1).
+ */
+export function tableFragmentHeightPt(fragment: TableFragment): number {
+  let sum = 0;
+  for (const row of fragment.rows) sum += row.heightPt;
+  return sum;
+}
+
+/** Flow height (scale-1 pt) of any {@link FlowFragment}: a paragraph fragment's
+ *  leading + line advances + trailing, or a table fragment's summed row heights. */
+export function flowFragmentAdvancePt(fragment: FlowFragment): number {
+  return fragment.kind === 'table'
+    ? tableFragmentHeightPt(fragment)
+    : paragraphFragmentAdvancePt(fragment);
 }

--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -430,6 +430,7 @@ describe('body paint byte-identity — fragment paint and compute-once line reus
     paginateDocument(narrowModel);
     const stale = bodyFragmentFor(paginateDocument(narrowModel)[0][0]);
     if (!stale) throw new Error('expected a narrow fragment to capture');
+    if (stale.fragment.kind !== 'paragraph') throw new Error('expected a paragraph fragment');
     expect(stale.fragment.measured.placement.availableWidthPt).toBeCloseTo(100, 6);
     expect(stale.fragment.source).toBe(p); // same source paragraph, different placement
     // Re-paginate wide LAST so p's element stamps + prebuiltPages are the width-180 layout.

--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -6,8 +6,17 @@ import {
   __test_setBodyFragment,
   __test_setLineReuseEnabled,
   __test_setFragmentPaintEnabled,
+  __test_tableRequiresLegacyPaint,
 } from './renderer.js';
-import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps, PaginatedBodyElement } from './types';
+import type {
+  BodyElement,
+  CellElement,
+  DocParagraph,
+  DocTable,
+  DocxDocumentModel,
+  SectionProps,
+  PaginatedBodyElement,
+} from './types';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Body paint byte-identity — the compute-once line reuse (Phase 4-1 B2 Stage 1)
@@ -471,18 +480,99 @@ function cellOf(content: unknown[], widthPt: number): Record<string, unknown> {
   };
 }
 
-function tableOf(cellContent: unknown[]): BodyElement {
+function tableOf(
+  cellContent: unknown[],
+  overrides: {
+    colWidths?: number[];
+    widthPt?: number;
+    tblInd?: number;
+    jc?: string;
+    layout?: string;
+  } = {},
+): BodyElement {
+  const colWidths = overrides.colWidths ?? [180];
+  const widthPt = overrides.widthPt ?? colWidths[0] ?? 180;
   return {
     type: 'table',
-    colWidths: [180],
-    rows: [{ cells: [cellOf(cellContent, 180)], rowHeight: null, rowHeightRule: 'auto', isHeader: false }],
+    colWidths,
+    rows: [{ cells: [cellOf(cellContent, widthPt)], rowHeight: null, rowHeightRule: 'auto', isHeader: false }],
     borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
     cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
-    jc: 'left', layout: 'fixed',
+    jc: overrides.jc ?? 'left', layout: overrides.layout ?? 'fixed',
+    ...(overrides.tblInd == null ? {} : { tblInd: overrides.tblInd }),
   } as unknown as BodyElement;
 }
 
+describe('table fragment-paint legacy gate', () => {
+  it('excludes only negative leading tblInd tables, including nested tables', () => {
+    const negative = tableOf([para('negative')], { tblInd: -30 }) as unknown as DocTable;
+    const nestedNegative = tableOf([para('nested')], { tblInd: -12 }) as unknown as DocTable;
+    const outer = tableOf([nestedNegative]) as unknown as DocTable;
+    const positive = tableOf([para('positive')], { tblInd: 12 }) as unknown as DocTable;
+    const centeredNegative = tableOf([para('centered')], {
+      tblInd: -30,
+      jc: 'center',
+    }) as unknown as DocTable;
+
+    expect(__test_tableRequiresLegacyPaint(negative)).toBe(true);
+    expect(__test_tableRequiresLegacyPaint(outer)).toBe(true);
+    expect(__test_tableRequiresLegacyPaint(positive)).toBe(false);
+    expect(__test_tableRequiresLegacyPaint(centeredNegative)).toBe(false);
+  });
+
+  it('excludes a table containing a sliced cell paragraph', () => {
+    const sliced = {
+      ...para('sliced'),
+      lineSlice: { start: 0, end: 2 },
+    } as unknown as CellElement;
+    const table = tableOf([sliced]) as unknown as DocTable;
+
+    expect(__test_tableRequiresLegacyPaint(table)).toBe(true);
+  });
+
+  it('excludes production row slices emitted from a tall cell paragraph', () => {
+    const cellPara = para(Array.from({ length: 40 }, () => 'wrap').join(' '));
+    const pages = paginateDocument(doc([tableOf([cellPara])], 60));
+    const sliceTables = pages
+      .flatMap((page) => page)
+      .filter((el): el is PaginatedBodyElement & DocTable => el.type === 'table');
+    const slicedTables = sliceTables.filter((table) =>
+      table.rows.some((row) =>
+        row.cells.some((cell) =>
+          cell.content.some(
+            (ce) =>
+              ce.type === 'paragraph' &&
+              (ce as CellElement & { lineSlice?: unknown }).lineSlice !== undefined,
+          ),
+        ),
+      ),
+    );
+
+    expect(sliceTables.length).toBeGreaterThan(1);
+    expect(slicedTables.length).toBeGreaterThan(0);
+    for (const table of slicedTables) {
+      expect(__test_tableRequiresLegacyPaint(table)).toBe(true);
+    }
+  });
+});
+
 describe('table-cell paint byte-identity — fragment table paint (PR 6)', () => {
+  it('negative leading tblInd table: fragment paint falls back to the page-width legacy budget', async () => {
+    const cellPara = para(Array.from({ length: 50 }, () => 'wide').join(' '));
+    const model = doc([
+      tableOf([cellPara], {
+        colWidths: [220],
+        widthPt: 220,
+        tblInd: -30,
+        jc: 'left',
+        layout: 'fixed',
+      }),
+    ], 400);
+
+    const r = await assertPaintIdentical(model);
+    expect(r.drawn).toBeGreaterThan(0);
+  });
+
   it('numbered paragraph inside a table cell: fragment paint === legacy (marker indent)', async () => {
     // Legacy cell paint recomputes a NUMBERED paragraph with the marker-aware
     // numBodyOffset first-line indent (the stamp gate rejects it); the fragment's

--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -452,3 +452,104 @@ describe('body paint byte-identity — fragment paint and compute-once line reus
     expect(production.perPage[0].filter((c) => c.op !== 'img').length).toBeGreaterThan(1);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR 6 Task 16 — TABLE-CELL paint byte-identity. A migrated block table paints its
+// cell paragraphs from CellFragment blocks; the per-block gate must exclude the SAME
+// divergence classes the PR 5 body gate excludes (marker firstLineIndent /
+// state-sensitive fields / in-cell float wrap), falling back to the legacy
+// renderParagraph — otherwise the fragment paints a partition the legacy paint would
+// never draw. Pinned against sample class: numbered paragraph inside a table cell
+// (the §17.9.28 marker's numBodyOffset ≠ para.indentFirst).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function cellOf(content: unknown[], widthPt: number): Record<string, unknown> {
+  return {
+    content, colSpan: 1, vMerge: null,
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    background: null, vAlign: 'top', widthPt,
+  };
+}
+
+function tableOf(cellContent: unknown[]): BodyElement {
+  return {
+    type: 'table',
+    colWidths: [180],
+    rows: [{ cells: [cellOf(cellContent, 180)], rowHeight: null, rowHeightRule: 'auto', isHeader: false }],
+    borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left', layout: 'fixed',
+  } as unknown as BodyElement;
+}
+
+describe('table-cell paint byte-identity — fragment table paint (PR 6)', () => {
+  it('numbered paragraph inside a table cell: fragment paint === legacy (marker indent)', async () => {
+    // Legacy cell paint recomputes a NUMBERED paragraph with the marker-aware
+    // numBodyOffset first-line indent (the stamp gate rejects it); the fragment's
+    // stored lines were measured with para.indentFirst. The per-block gate must fall
+    // back to legacy renderParagraph for numbered cell paragraphs.
+    const numbering = { numId: 1, level: 0, format: 'decimal', text: '1.',
+      indentLeft: 36, tab: 36, suff: 'tab', jc: 'left' } as unknown as DocParagraph['numbering'];
+    const cellPara = {
+      type: 'paragraph',
+      ...para(Array.from({ length: 30 }, () => 'w').join(' '), {
+        numbering, indentLeft: 36, indentFirst: -18,
+      }),
+    };
+    const model = doc([tableOf([cellPara])], 400);
+    const r = await assertPaintIdentical(model);
+    expect(r.drawn).toBeGreaterThan(0);
+    // Non-vacuity: the marker itself was drawn.
+    expect(r.streams.some((page) => page.some((c) => c.text === '1.'))).toBe(true);
+  });
+
+  it('NUMPAGES field inside a table cell: fragment paint === legacy (state-sensitive)', async () => {
+    // The fragment's segments freeze the measure-time totalPages (1); legacy paint
+    // re-resolves the field against the real page context. The per-block gate must
+    // fall back for paragraphSegsStateSensitive cell paragraphs.
+    const fieldPara = {
+      type: 'paragraph',
+      ...para('total pages:'),
+    } as unknown as DocParagraph;
+    (fieldPara.runs as unknown[]).push({
+      type: 'field', fieldType: 'numPages', instruction: 'NUMPAGES', fallbackText: '?',
+      bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', background: null,
+    });
+    // A long body paragraph AFTER the table forces a second page, so the real
+    // totalPages (2) differs from the measure-time value (1).
+    const filler = para(Array.from({ length: 120 }, () => 'w').join(' '));
+    const model = doc([tableOf([fieldPara]), filler as unknown as BodyElement], 100);
+    const r = await assertPaintIdentical(model);
+    expect(r.pages).toBeGreaterThan(1);
+    // The REAL page count was drawn (not the frozen measure-time "1").
+    expect(r.streams.some((page) => page.some((c) => c.text === String(r.pages)))).toBe(true);
+  });
+
+  it('cell paragraph after an in-cell wrap float: fragment paint === legacy (wrap context)', async () => {
+    // Cell paragraph 1 carries an anchored square-wrap image (registered into the
+    // cell's isolated float set during paint); paragraph 2's legacy paint re-lays-out
+    // around it (wrap context), while its fragment lines were measured with no wrap
+    // oracle. The per-block gate must fall back when the cell's float set is non-empty.
+    const imgPara = {
+      type: 'paragraph',
+      ...para(''),
+    } as unknown as DocParagraph;
+    (imgPara.runs as unknown[]).push({
+      type: 'image',
+      imagePath: 'word/media/test1.png', mimeType: 'image/png',
+      widthPt: 80, heightPt: 40,
+      anchor: true, anchorXPt: 100, anchorYPt: 0,
+      anchorXFromMargin: false, anchorYFromPara: true,
+      wrapMode: 'square', wrapSide: 'bothSides',
+      anchorXRelativeFrom: 'column', anchorYRelativeFrom: 'paragraph',
+    });
+    const wrapPara = {
+      type: 'paragraph',
+      ...para(Array.from({ length: 40 }, () => 'w').join(' ')),
+    };
+    const model = doc([tableOf([imgPara, wrapPara])], 400);
+    const r = await assertPaintIdentical(model);
+    expect(r.drawn).toBeGreaterThan(0);
+  });
+});

--- a/packages/docx/src/per-section-page-geometry.test.ts
+++ b/packages/docx/src/per-section-page-geometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computePages, paginateDocument, renderDocumentToCanvas } from './renderer.js';
+import { bodyFragmentFor, computePages, paginateDocument, renderDocumentToCanvas } from './renderer.js';
 import type {
   BodyElement, DocParagraph, DocxTextRun, SectionProps, DocxDocumentModel,
   SectionGeom, PaginatedBodyElement, HeaderFooter,
@@ -437,8 +437,8 @@ describe('page-size fact (§17.6.13/§17.6.11) — paginateDocument sectionGeom'
 // ECMA-376 §17.6.11 (pgMar) + §17.6.13 (pgSz) — a newspaper-column band's WIDTH
 // and x-origin derive from the OWNING section's page geometry, not the body-level
 // section. `computeColumns` is fed by `sectionColumnsFrom`; the paginator sizes a
-// table to the active column band (`colW()`), so the stamped `tableColWidthsPt`
-// is the observable proxy for the band width the fix corrects.
+// table to the active column band (`colW()`), so the table fragment's stored column
+// widths are the observable proxy for the band width the fix corrects.
 function cellPara(text: string): DocParagraph {
   return {
     alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
@@ -455,8 +455,8 @@ function cellPara(text: string): DocParagraph {
 
 // A single-row, single-column FIXED-layout table whose `<w:tblGrid>` width is
 // `gridWidthPt`. Fixed layout uses the grid verbatim and only scales DOWN when the
-// grid overflows the available band (resolveColumnWidths §17.4.52), so the stamped
-// `tableColWidthsPt` equals `gridWidthPt` iff the band is ≥ that width.
+// grid overflows the available band (resolveColumnWidths §17.4.52), so the fragment's
+// `columnWidthsPt` equals `gridWidthPt` iff the band is ≥ that width.
 function fixedTable(gridWidthPt: number): DocTable {
   const cell: DocTableCell = {
     content: [{ type: 'paragraph', ...cellPara('x') }],
@@ -506,9 +506,13 @@ describe('per-section newspaper-column band (§17.6.11/§17.6.13) — paginator'
     } as unknown as DocxDocumentModel;
     const pages = computePages(doc.body, doc.section, makeCtx());
     const tbl = pages[0].find((e) => e.type === 'table') as PaginatedBodyElement;
-    const stampedTotal = (tbl.tableColWidthsPt ?? []).reduce((s, w) => s + w, 0);
+    const placed = bodyFragmentFor(tbl);
+    expect(placed?.fragment.kind).toBe('table');
+    const resolvedTotal = placed?.fragment.kind === 'table'
+      ? placed.fragment.columnWidthsPt.reduce((s, w) => s + w, 0)
+      : 0;
     // The table belongs to the first section (band 550), so its columns sum to 550 —
     // NOT the body-level band 450 the bug clamps them to.
-    expect(stampedTotal).toBeCloseTo(550, 5);
+    expect(resolvedTotal).toBeCloseTo(550, 5);
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -172,12 +172,13 @@ import {
   type PlacedFragment,
   type FlowFragment,
   type TableFragment,
+  type CellFragment,
 } from './layout-fragments.js';
 import { buildTableFragment } from './table-fragments.js';
 // PR 5 — body fragment paint. renderer <-> fragment-paint is a deliberate import
 // cycle: both sides use the other only inside function bodies (never at module
 // evaluation), so ESM live bindings resolve them at call time.
-import { paintParagraphFragment } from './fragment-paint.js';
+import { paintParagraphFragment, paintTableFragment } from './fragment-paint.js';
 import {
   drawVerticalRun,
   drawTateChuYokoRun,
@@ -3311,6 +3312,7 @@ export function computePages(
               sliceEl as unknown as DocTable,
               tblColWidthsPt,
               meta.heightsPt,
+              tblContentWPt,
               measureState,
               {
                 columnIndex: sliceEl.colIndex ?? 0,
@@ -3330,14 +3332,17 @@ export function computePages(
         // §17.6.4 column balancing (wantsBalanceBreak) OR a table that doesn't fit
         // the rest of this column ⇒ advance to the next column / page.
         if (wantsBalanceBreak(h) || y + h > tableContentH) nextColumnOrPage(i);
-        // B2 table stage 1b — stamp the whole-table scale-1 layout for paint reuse.
-        stampTableLayout(tableEl, tblColWidthsPt, rowHs, tblContentWPt);
-        // PR 6 — the fragment for the whole-table placement (no page continuation).
+        // PR 6 — a whole (non-split) block table paints from its fragment, so it is NOT
+        // stamped: `tableEl` is the PARSED DocTable when the table was not row-split, and
+        // stamping it would mutate the parsed model (the defect class this migration
+        // closes). A gate-rejected non-split table (e.g. negative `tblInd`) recomputes
+        // through the legacy `computeTableLayout`, byte-identical to the removed reuse.
         attachTableFragment(
           tableEl,
           tableEl as unknown as DocTable,
           tblColWidthsPt,
           rowHs,
+          tblContentWPt,
           measureState,
           {
             columnIndex: colIndex,
@@ -3966,6 +3971,14 @@ function buildTableCellBlocks(
   return blocks;
 }
 
+/** Side table: emitted table element -> the scale-1 content-band width its fragment
+ *  was resolved at. The fragment-paint gate reuses the fragment only when this paint's
+ *  band matches (mirroring the removed `tableLayoutInputs.contentWPt` stamp gate — a
+ *  negative-`tblInd` table paints at the page-width budget, not the column band, so it
+ *  must recompute on the legacy path). Renderer-internal; not part of the public
+ *  {@link TableFragment}. */
+const tableFragmentBandPt = new WeakMap<object, number>();
+
 /** Build and attach the {@link TableFragment} for one placed table (whole table or one
  *  page slice) to the emitted element's side-table entry. `table` supplies the rows to
  *  fragment (the SOURCE table for a whole-table push; the slice for a split). Never
@@ -3975,6 +3988,7 @@ function attachTableFragment(
   table: DocTable,
   colWidthsPt: number[],
   rowHeightsPt: number[],
+  contentWPt: number,
   measureState: RenderState,
   placement: {
     columnIndex: number;
@@ -4008,6 +4022,56 @@ function attachTableFragment(
       heightPt: tableFragmentHeightPt(fragment),
     }),
   );
+  tableFragmentBandPt.set(el as object, contentWPt);
+}
+
+/** A table (or any table nested in its cells) stays on the LEGACY paint path when it
+ *  needs re-measurement or an out-of-flow path the fragment paint does not yet cover:
+ *   - a `vAlign` of center/bottom re-measures cell content to centre the inked block
+ *     (ECMA-376 §17.4.84);
+ *   - a nested floating table (§17.4.57 `<w:tblpPr>`) is drawn out of flow.
+ *  Top-aligned in-flow tables — the common case — carry no re-measurement and paint
+ *  measure-free from their fragment. Recursion covers nested tables (painted from their
+ *  own fragment). Tracked: migrate vAlign and nested-floating tables in a follow-up. */
+function tableRequiresLegacyPaint(table: DocTable): boolean {
+  for (const row of table.rows) {
+    for (const cell of row.cells) {
+      if (cell.vAlign === 'center' || cell.vAlign === 'bottom') return true;
+      for (const ce of cell.content) {
+        if (ce.type === 'table') {
+          const nested = ce as unknown as DocTable;
+          if (nested.tblpPr != null || tableRequiresLegacyPaint(nested)) return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+/** PR 6 — a block table paints from its {@link TableFragment} when the migration gate
+ *  holds: the fragment is present, the table is in flow (not a §17.4.57 floating
+ *  table), it has no vAlign-center/bottom re-measurement, the story is horizontal, and
+ *  this paint's content band matches the band the fragment was resolved at. Otherwise
+ *  the legacy `renderTable` recompute path runs (byte-identical). */
+function isFragmentPaintableTable(
+  table: DocTable,
+  placed: PlacedFragment | undefined,
+  state: RenderState,
+): placed is PlacedFragment {
+  if (
+    !fragmentPaintEnabled ||
+    placed === undefined ||
+    placed.fragment.kind !== 'table' ||
+    table.tblpPr != null ||
+    state.verticalCJK ||
+    tableRequiresLegacyPaint(table)
+  ) {
+    return false;
+  }
+  const bandPt = tableFragmentBandPt.get(table as object);
+  if (bandPt === undefined) return false;
+  const paintBandPt = state.contentW / state.scale;
+  return Math.abs(bandPt - paintBandPt) <= 1e-6 * Math.max(1, Math.abs(paintBandPt));
 }
 
 /** Master switch for the M-1 fit-check measurement reuse. Always ON in production; the
@@ -6062,7 +6126,15 @@ function renderBodyElements(
       // prevPara/spaceAfter untouched (the following content spaces against the
       // paragraph BEFORE the table, exactly like a frame paragraph). A block
       // table resets them (it ends the previous spacing context).
-      renderTable(tbl, state);
+      // PR 6 — a migrated block table paints from its stored fragment (geometry +
+      // cell content, no re-layout). Floating / vAlign / band-mismatch tables fall
+      // through to the legacy `renderTable` recompute path.
+      const placedTable = bodyFragmentFor(el);
+      if (isFragmentPaintableTable(tbl, placedTable, state)) {
+        paintTableFragment(placedTable, state);
+      } else {
+        renderTable(tbl, state);
+      }
       if (!tbl.tblpPr) {
         prevPara = null;
         prevSpaceAfter = 0;
@@ -9964,6 +10036,10 @@ interface TableCellPaintJob {
   ri: number;
   span: number;
   lastRi: number;
+  /** PR 6 — the measured cell fragment for this cell (when the table is painted from
+   *  its {@link TableFragment}); its content is drawn from stored fragments instead of
+   *  being re-laid-out. Absent on the legacy recompute path. */
+  cellFragment?: CellFragment;
 }
 
 function drawTableRows(
@@ -9974,6 +10050,10 @@ function drawTableRows(
   tableX: number,
   startY: number,
   state: RenderState,
+  /** PR 6 — when present, cell content is painted from the matching
+   *  {@link CellFragment}s (measure-free) instead of re-laid-out by {@link renderCell}.
+   *  Aligned 1:1 with `table.rows` / `row.cells`. */
+  fragment?: TableFragment,
 ): number {
   const { scale, dryRun } = state;
   // ECMA-376 §17.4.1 `<w:bidiVisual>`: lay the grid columns right-to-left, so
@@ -10003,11 +10083,15 @@ function drawTableRows(
   let y = startY;
   for (let ri = 0; ri < table.rows.length; ri++) {
     const row = table.rows[ri];
+    const rowFragment = fragment?.rows[ri];
     const rowH = rowHeights[ri];
     let x = tableX;
     let ci = 0;
+    let cellIdx = 0;
 
     for (const cell of row.cells) {
+      const cellFragment = rowFragment?.cells[cellIdx];
+      cellIdx++;
       const span = Math.min(cell.colSpan, colWidths.length - ci);
       const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);
       // Physical left edge of this cell. LTR: cumulative from the left (`x`).
@@ -10049,7 +10133,7 @@ function drawTableRows(
         if (dryRun) measureCellContent(cell, table, cellW, scale, state);
         else {
           const jobIndex = jobs.length;
-          jobs.push({ cell, x: leadX, y, w: cellW, h: drawH, edges, clipExact, ci, ri, span, lastRi: lastRowOfCell });
+          jobs.push({ cell, x: leadX, y, w: cellW, h: drawH, edges, clipExact, ci, ri, span, lastRi: lastRowOfCell, cellFragment });
           // ECMA-376 §17.4.66 — record this cell's grid footprint so interior-edge
           // neighbour lookups resolve to it. A vMerge=restart cell owns every row it
           // spans; a colSpan cell owns every column in its span.
@@ -10073,7 +10157,7 @@ function drawTableRows(
   // physical side a logical border maps to, so it is consulted in the border
   // pass alone.
   for (const j of jobs) {
-    renderCell(j.cell, table, j.x, j.y, j.w, j.h, state, j.clipExact);
+    renderCell(j.cell, table, j.x, j.y, j.w, j.h, state, j.clipExact, j.cellFragment);
   }
 
   // ECMA-376 §17.4.66 — adjacent-cell border conflict resolution. Each SHARED
@@ -10514,6 +10598,11 @@ function renderCell(
   h: number,
   state: RenderState,
   clipExact = false,
+  /** PR 6 — when present, this cell's content is painted from its stored
+   *  {@link CellFragment} blocks (measure-free) rather than re-laid-out. Only supplied
+   *  by the fragment paint path, which the migration gate limits to top-aligned tables,
+   *  so the vAlign centring branch below is not reached for a fragment cell. */
+  cellFragment?: CellFragment,
 ): void {
   const { ctx, scale } = state;
 
@@ -10646,10 +10735,12 @@ function renderCell(
     // fixture; when they are, tighten this to the logical content width.
     ctx.rect(0, y, ctx.canvas.width, h);
     ctx.clip();
-    renderCellContent(cell.content, cellState);
+    if (cellFragment) renderCellContentFragment(cellFragment, cellState);
+    else renderCellContent(cell.content, cellState);
     ctx.restore();
   } else {
-    renderCellContent(cell.content, cellState);
+    if (cellFragment) renderCellContentFragment(cellFragment, cellState);
+    else renderCellContent(cell.content, cellState);
   }
 }
 
@@ -10693,6 +10784,77 @@ function renderCellContent(content: CellElement[], state: RenderState): void {
       prevSpaceAfter = 0;
     }
   }
+}
+
+/**
+ * PR 6 — paint a cell's content from its {@link CellFragment} blocks, WITHOUT
+ * re-laying-out. Mirrors {@link renderCellContent} exactly: paragraph blocks draw from
+ * their stored scale-1 line partition (rescaled through the same bridge body fragment
+ * paint uses; measure-free at scale 1), nested-table blocks from their own
+ * {@link TableFragment}, with the SAME §17.3.1.9 contextualSpacing / spaceBefore-after
+ * overlap collapse. Cell paragraphs are drawn whole (no line slice), identically to
+ * `renderCellContent`.
+ */
+function renderCellContentFragment(cellFragment: CellFragment, state: RenderState): void {
+  let prevPara: DocParagraph | null = null;
+  let prevSpaceAfter = 0;
+  for (const block of cellFragment.blocks) {
+    if (block.kind === 'paragraph') {
+      const para = block.source;
+      const suppress = contextualSuppressed(prevPara, para);
+      const effBefore = suppress ? 0 : para.spaceBefore;
+      const overlap = suppress ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
+      state.y -= overlap * state.scale;
+      renderBodyParagraphLines(
+        para,
+        state,
+        block.measured.lines.map((line) => line.layout),
+        suppress,
+        undefined,
+        undefined,
+      );
+      prevPara = para;
+      prevSpaceAfter = para.spaceAfter;
+    } else {
+      renderTableFragment(block, state);
+      prevPara = null;
+      prevSpaceAfter = 0;
+    }
+  }
+}
+
+/**
+ * PR 6 — paint a block table from its {@link TableFragment}: geometry from the stored
+ * scale-1 column widths + per-row heights (× scale), cell content from the cell
+ * fragments (measure-free at scale 1). Mirrors {@link renderTable}'s in-flow block path
+ * (ECMA-376 §17.4.63/§17.4.50 jc + positive `tblInd`, §17.4.1 bidiVisual origin);
+ * negative `tblInd` and floating tables are gate-excluded ({@link isFragmentPaintableTable})
+ * and stay on the legacy recompute path, so this handles only the fragment-migrated
+ * class. Advances `state.y` past the table exactly as `renderTable` does.
+ */
+export function renderTableFragment(fragment: TableFragment, state: RenderState): void {
+  const table = fragment.source;
+  const { contentX, contentW, scale } = state;
+  const colWidths = fragment.columnWidthsPt.map((w) => w * scale);
+  const tableW = colWidths.reduce((s, w) => s + w, 0);
+  const rowHeights = fragment.rows.map((r) => r.heightPt * scale);
+
+  const applyInd = table.tblInd != null && table.jc === 'left';
+  let tableX =
+    table.jc === 'center'
+      ? contentX + Math.max(0, (contentW - tableW) / 2)
+      : table.jc === 'right'
+        ? contentX + Math.max(0, contentW - tableW)
+        : contentX;
+  if (applyInd) {
+    const indPx = (table.tblInd as number) * scale;
+    tableX =
+      table.bidiVisual === true
+        ? contentX + contentW - indPx - tableW
+        : contentX + indPx;
+  }
+
+  state.y = drawTableRows(table, colWidths, tableW, rowHeights, tableX, state.y, state, fragment);
 }
 
 /** Which grid edges of the table this cell touches, so {@link resolveCellEdges}

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -165,11 +165,15 @@ import {
 } from './paragraph-measure.js';
 import {
   paragraphFragmentAdvancePt,
+  tableFragmentHeightPt,
   type DocumentLayout,
   type LayoutPage,
   type ParagraphFragment,
   type PlacedFragment,
+  type FlowFragment,
+  type TableFragment,
 } from './layout-fragments.js';
+import { buildTableFragment } from './table-fragments.js';
 // PR 5 — body fragment paint. renderer <-> fragment-paint is a deliberate import
 // cycle: both sides use the other only inside function bodies (never at module
 // evaluation), so ESM live bindings resolve them at call time.
@@ -3298,6 +3302,26 @@ export function computePages(
           // widths + contentWPt are constant across the split.
           { colWidthsPt: tblColWidthsPt, contentWPt: tblContentWPt },
           { colWidthsPt: tblColWidthsPt, state: measureState },
+          // PR 6 — attach each slice's table fragment (byte-identical additive step:
+          // paint is unmigrated in Task 15). The slice IS the table (its rows are the
+          // slice's rows); column widths are constant across the split.
+          (sliceEl, meta) =>
+            attachTableFragment(
+              sliceEl,
+              sliceEl as unknown as DocTable,
+              tblColWidthsPt,
+              meta.heightsPt,
+              measureState,
+              {
+                columnIndex: sliceEl.colIndex ?? 0,
+                xPt: columns[sliceEl.colIndex ?? 0]?.xPt ?? colX(),
+                yPt: sliceEl.colTopPt ?? measureState.y,
+                continuesFromPreviousPage: meta.continuesFromPreviousPage,
+                continuesOnNextPage: meta.continuesOnNextPage,
+                repeatedHeaderRowCount: meta.repeatedHeaderRowCount,
+                sourceRowIndexOf: meta.sourceRowIndexOf,
+              },
+            ),
         );
         y = endY;
         measureState.y = bodyTopPt() + endY;
@@ -3308,6 +3332,22 @@ export function computePages(
         if (wantsBalanceBreak(h) || y + h > tableContentH) nextColumnOrPage(i);
         // B2 table stage 1b — stamp the whole-table scale-1 layout for paint reuse.
         stampTableLayout(tableEl, tblColWidthsPt, rowHs, tblContentWPt);
+        // PR 6 — the fragment for the whole-table placement (no page continuation).
+        attachTableFragment(
+          tableEl,
+          tableEl as unknown as DocTable,
+          tblColWidthsPt,
+          rowHs,
+          measureState,
+          {
+            columnIndex: colIndex,
+            xPt: colX(),
+            yPt: measureState.y,
+            continuesFromPreviousPage: false,
+            continuesOnNextPage: false,
+            repeatedHeaderRowCount: 0,
+          },
+        );
         pushTagged(tableEl);
         y += h;
         measureState.y += h;
@@ -3584,15 +3624,23 @@ export function paginateDocument(doc: DocxDocumentModel): PaginatedBodyElement[]
 }
 
 /**
- * PR 5 — produce the immutable body {@link DocumentLayout}: pages of
- * {@link PlacedFragment}s over body paragraphs. Pagination is the SAME engine
+ * Produce the immutable body {@link DocumentLayout}: pages of {@link PlacedFragment}s
+ * over body paragraphs (PR 5) and block tables (PR 6). Pagination is the SAME engine
  * `paginateDocument` runs (so page assignment, splitting, sections and columns are
- * identical); this projects the fragments the paginator attached to each body
- * paragraph element into a frozen result. Tables, headers/footers and floating
- * content stay on the `PaginatedBodyElement[][]` path until PR 6, so a page's
- * `fragments` cover its body PARAGRAPHS only (`FlowFragment` is paragraph-only in
- * PR 5). The section context and page geometry come from each page's stamped section
- * (a mid-document section break changes them), falling back to the body section.
+ * identical); this projects the fragments the paginator attached to each emitted body
+ * element into a frozen result. Headers/footers and floating content (floating tables,
+ * anchored drawings) stay on the `PaginatedBodyElement[][]` path, so a page's
+ * `fragments` cover its in-flow body paragraphs and block tables.
+ *
+ * Per page (M-2 — complete the DocumentLayout contract): the page geometry and section
+ * context come from the section the paginator stamped on the page's FIRST element
+ * (`sectionGeom` for page size + margins, `colGeom` for the §17.6.4 column geometry),
+ * falling back to the body section for an empty page. The DOCX model carries one
+ * body-level section geometry (#513), so only the per-region column set actually varies;
+ * a continuous section break that changes the column count MID-page is bounded by the
+ * one-section-per-`LayoutPage` contract — `LayoutPage.section` reflects the region at
+ * the page top, and each `PlacedFragment.columnIndex` locates its fragment within those
+ * columns.
  */
 export function layoutDocument(doc: DocxDocumentModel): DocumentLayout {
   const ctx = new OffscreenCanvas(1, 1).getContext('2d');
@@ -3607,11 +3655,19 @@ export function layoutDocument(doc: DocxDocumentModel): DocumentLayout {
     layoutDoc.footnotes ?? [],
   );
   const layoutPages: LayoutPage[] = pages.map((elements, pageIndex) => {
-    const geomOverride = (elements[0] as PaginatedBodyElement | undefined)?.sectionGeom;
+    const firstEl = elements[0] as PaginatedBodyElement | undefined;
+    const geomOverride = firstEl?.sectionGeom;
     const sectionProps: SectionProps = geomOverride
       ? { ...layoutDoc.section, ...geomOverride }
       : layoutDoc.section;
-    const section = resolveSectionLayoutContext(layoutSettings, sectionProps);
+    const resolvedSection = resolveSectionLayoutContext(layoutSettings, sectionProps);
+    // M-2 — the paginator stamped the resolved §17.6.4 column geometry active at this
+    // page's top on `colGeom`; prefer it over the body section's columns so a page in a
+    // continuous multi-column region exposes its real column set (the body section
+    // resolves the body-level columns only).
+    const section: SectionLayoutContext = firstEl?.colGeom
+      ? { ...resolvedSection, columns: firstEl.colGeom }
+      : resolvedSection;
     const geometry: SectionGeom = {
       pageWidth: sectionProps.pageWidth,
       pageHeight: sectionProps.pageHeight,
@@ -3624,7 +3680,7 @@ export function layoutDocument(doc: DocxDocumentModel): DocumentLayout {
     };
     const fragments: PlacedFragment[] = [];
     for (const el of elements) {
-      const placed = bodyParagraphFragments.get(el as object);
+      const placed = bodyFlowFragments.get(el as object);
       if (placed) fragments.push(placed);
     }
     return Object.freeze({
@@ -3734,15 +3790,16 @@ function paragraphMeasurementEnvironment(
 // unmigrated caller (tables, headers/footers, the vertical-text prebuilt-pages swap)
 // is unaffected.
 
-/** Side table: emitted body element -> its placed paragraph fragment. WeakMap so an
- *  element that is garbage collected drops its entry, and so the parsed `DocParagraph`
- *  is never mutated (a non-split paragraph element is the source object itself). */
-const bodyParagraphFragments = new WeakMap<object, PlacedFragment>();
+/** Side table: emitted body element -> its placed flow fragment (a paragraph fragment
+ *  in PR 5, or a table fragment in PR 6). WeakMap so an element that is garbage
+ *  collected drops its entry, and so the parsed `DocParagraph` / `DocTable` is never
+ *  mutated (a non-split paragraph element is the source object itself). */
+const bodyFlowFragments = new WeakMap<object, PlacedFragment>();
 
 /** Read the placed fragment the paginator associated with an emitted body element,
- *  if any (paragraph elements the fragment migration covers). */
+ *  if any (paragraph or table elements the fragment migration covers). */
 export function bodyFragmentFor(el: PaginatedBodyElement): PlacedFragment | undefined {
-  return bodyParagraphFragments.get(el as object);
+  return bodyFlowFragments.get(el as object);
 }
 
 /** TEST ONLY — inject a placed fragment into the body-fragment side table for an
@@ -3754,7 +3811,7 @@ export const __test_setBodyFragment = (
   el: PaginatedBodyElement,
   placed: PlacedFragment,
 ): void => {
-  bodyParagraphFragments.set(el as object, placed);
+  bodyFlowFragments.set(el as object, placed);
 };
 
 /** Build an immutable body paragraph fragment. `source` is the PARSED paragraph
@@ -3803,6 +3860,154 @@ function placeParagraphFragment(
     widthPt,
     heightPt: paragraphFragmentAdvancePt(fragment),
   });
+}
+
+// ===== Table layout fragments (PR 6) =====
+//
+// A body table emits a {@link TableFragment} at each of its placement points (the
+// whole-table push, or one slice per page from {@link splitTableAcrossPages}), attached
+// to the emitted table element in the SAME `bodyFlowFragments` side table body
+// paragraphs use — so {@link layoutDocument} collects paragraph AND table fragments from
+// one map, and the parsed `DocTable` is never mutated. Production paint is unchanged in
+// PR 6 Task 15 (fragments are produced, not yet consumed); Task 16 routes table paint
+// through them.
+
+/** Measure a table-cell paragraph at scale 1 in the cell story context, no page wrap
+ *  oracle (a cell is isolated from page floats, §17.4.57). Mirrors the scale-1
+ *  measurement {@link measureCellParagraphHeight} performs, but returns the
+ *  {@link MeasuredParagraph} so a {@link ParagraphFragment} can own the line partition
+ *  instead of stamping it onto the parsed paragraph. `contentWPt` is the cell's content
+ *  width (spanned columns minus the cell margins). */
+function measureCellParagraphScale1(
+  cellState: RenderState,
+  para: DocParagraph,
+  contentWPt: number,
+): MeasuredParagraph {
+  const paragraphContext = resolveStateParagraphLayoutContext(cellState, para);
+  return measureParagraph(
+    para,
+    paragraphContext,
+    {
+      startYPt: 0,
+      paragraphXPt: 0,
+      availableWidthPt: contentWPt,
+      maximumYPt: cellState.pageH,
+      suppressSpaceBefore: true,
+    },
+    {
+      context: cellState.ctx,
+      fontFamilyClasses: cellState.fontFamilyClasses,
+    },
+    paragraphMeasurementEnvironment(cellState),
+  );
+}
+
+/** Build the recursive content fragments of one table cell (the {@link buildTableFragment}
+ *  {@link BuildCellBlocks} callback): a paragraph fragment per `<w:p>` and a nested-table
+ *  fragment per `<w:tbl>`, in document order, measured at scale 1 in the cell story.
+ *  `outerState` is the enclosing scale-1 measure state (body, or the parent cell for a
+ *  nested table); this enters THIS cell's story once. `cellTotalWidthPt` is the sum of
+ *  the grid columns the cell spans (before its own margins). */
+function buildTableCellBlocks(
+  cell: DocTableCell,
+  table: DocTable,
+  cellTotalWidthPt: number,
+  outerState: RenderState,
+): FlowFragment[] {
+  const cellState = withTableCellStory(outerState);
+  const cm = effCellMargins(cell, table);
+  const contentWPt = Math.max(0, cellTotalWidthPt - (cm.left + cm.right));
+  const blocks: FlowFragment[] = [];
+  for (const ce of cell.content) {
+    if (ce.type === 'paragraph') {
+      const para = ce as unknown as DocParagraph;
+      const measured = measureCellParagraphScale1(cellState, para, contentWPt);
+      const trailingExtentPt = Math.max(
+        measured.requestedSpaceAfterPt,
+        bottomBorderExtentPt(para.borders),
+      );
+      const fullLineEnd = measured.markOnly ? 0 : measured.lines.length;
+      // A row-split-by-lines slice element carries a `lineSlice`; the fragment paints
+      // that sub-range of the one measurement (the whole paragraph is measured at the
+      // cell width, so the slice indexes it directly). Absent ⇒ the whole paragraph.
+      const lineSlice = (ce as unknown as { lineSlice?: { start: number; end: number } }).lineSlice;
+      const lineStart = lineSlice ? lineSlice.start : 0;
+      const lineEnd = lineSlice ? Math.min(lineSlice.end, fullLineEnd) : fullLineEnd;
+      blocks.push(
+        buildParagraphFragment(
+          para,
+          measured,
+          lineStart,
+          lineEnd,
+          lineStart === 0,
+          lineEnd >= fullLineEnd,
+          trailingExtentPt,
+        ),
+      );
+    } else if (ce.type === 'table') {
+      const inner = ce as unknown as DocTable;
+      const innerCols = resolveColumnWidths(inner, contentWPt, cellState);
+      const innerRowHs = resolveTableRowHeights(inner, innerCols, 1, (c, w) =>
+        measureCellContentHeightPx(c, inner, w, 1, cellState),
+      );
+      blocks.push(
+        buildTableFragment({
+          table: inner,
+          columnWidthsPt: innerCols,
+          rowHeightsPt: innerRowHs,
+          continuesFromPreviousPage: false,
+          continuesOnNextPage: false,
+          repeatedHeaderRowCount: 0,
+          buildCellBlocks: (c, w) => buildTableCellBlocks(c, inner, w, cellState),
+        }),
+      );
+    }
+  }
+  return blocks;
+}
+
+/** Build and attach the {@link TableFragment} for one placed table (whole table or one
+ *  page slice) to the emitted element's side-table entry. `table` supplies the rows to
+ *  fragment (the SOURCE table for a whole-table push; the slice for a split). Never
+ *  mutates the parsed model. */
+function attachTableFragment(
+  el: PaginatedBodyElement,
+  table: DocTable,
+  colWidthsPt: number[],
+  rowHeightsPt: number[],
+  measureState: RenderState,
+  placement: {
+    columnIndex: number;
+    xPt: number;
+    yPt: number;
+    continuesFromPreviousPage: boolean;
+    continuesOnNextPage: boolean;
+    repeatedHeaderRowCount: number;
+    sourceRowIndexOf?: (fragmentRowIndex: number) => number;
+  },
+): void {
+  const fragment = buildTableFragment({
+    table,
+    columnWidthsPt: colWidthsPt,
+    rowHeightsPt,
+    continuesFromPreviousPage: placement.continuesFromPreviousPage,
+    continuesOnNextPage: placement.continuesOnNextPage,
+    repeatedHeaderRowCount: placement.repeatedHeaderRowCount,
+    sourceRowIndexOf: placement.sourceRowIndexOf,
+    buildCellBlocks: (cell, w) => buildTableCellBlocks(cell, table, w, measureState),
+  });
+  const widthPt = colWidthsPt.reduce((s, w) => s + w, 0);
+  bodyFlowFragments.set(
+    el,
+    Object.freeze({
+      fragment,
+      columnIndex: placement.columnIndex,
+      xPt: placement.xPt,
+      yPt: placement.yPt,
+      widthPt,
+      heightPt: tableFragmentHeightPt(fragment),
+    }),
+  );
 }
 
 /** Master switch for the M-1 fit-check measurement reuse. Always ON in production; the
@@ -3880,7 +4085,7 @@ function attachBodyParagraphFragment(
     true,
     trailingExtentPt,
   );
-  bodyParagraphFragments.set(el, placeParagraphFragment(
+  bodyFlowFragments.set(el, placeParagraphFragment(
     fragment,
     placement.columnIndex,
     placement.paragraphXPt,
@@ -4221,7 +4426,7 @@ function splitParagraphAcrossPages(
           isFinalSlice,
           trailingExtent,
         );
-        bodyParagraphFragments.set(sliceEl, placeParagraphFragment(
+        bodyFlowFragments.set(sliceEl, placeParagraphFragment(
           fragment,
           tagColIndex ? tagColIndex() : 0,
           paragraphXPt(),
@@ -5112,6 +5317,21 @@ export function splitTableAcrossPages(
   /** Optional row-block splitter used by computePages. Direct unit tests can omit
    *  this and exercise only row-boundary splitting. */
   rowSplit?: { colWidthsPt: number[]; state: RenderState },
+  /** PR 6 — invoked once per emitted slice to attach its {@link TableFragment}. The
+   *  caller closes over the column widths / measure state and builds the fragment
+   *  (the slice element carries the rows + `colIndex`); `meta` supplies the slice's
+   *  per-row heights, page-continuation flags, repeated-header count, and the
+   *  fragment→source row-index map. Omitted (direct unit tests) ⇒ no fragment. */
+  emitTableFragment?: (
+    sliceEl: PaginatedBodyElement,
+    meta: {
+      heightsPt: number[];
+      continuesFromPreviousPage: boolean;
+      continuesOnNextPage: boolean;
+      repeatedHeaderRowCount: number;
+      sourceRowIndexOf: (fragmentRowIndex: number) => number;
+    },
+  ) => void,
 ): number {
   const colTop = columnTop ?? (() => 0);
   let workTable = table;
@@ -5223,11 +5443,29 @@ export function splitTableAcrossPages(
     // B2 table stage 1b — stamp this slice's own row heights (repeated header rows
     // prepended on continuations, matching `sliceRows`) so the paint pass reuses
     // them 1:1 instead of re-measuring the slice.
+    const sliceHeightsPt = isContinuation
+      ? [...headerHeightsPt, ...workRowHs.slice(start, end)]
+      : workRowHs.slice(start, end);
     if (tableStamp) {
-      const sliceHeightsPt = isContinuation
-        ? [...headerHeightsPt, ...workRowHs.slice(start, end)]
-        : workRowHs.slice(start, end);
       stampTableLayout(sliceEl, tableStamp.colWidthsPt, sliceHeightsPt, tableStamp.contentWPt);
+    }
+    if (emitTableFragment) {
+      // §17.4.78 — a continuation slice prepends the repeated header rows; the body
+      // rows begin at `start` in workRows. Map each fragment row back to its source
+      // index: a repeated header keeps its original 0-based header index; a body row
+      // is `start + (i − headerCount)` (workRows-relative, identity to the original
+      // table for a row-boundary split). Page continuation is derived from the slice
+      // window: it continues from a previous page whenever it does not start the
+      // table, and onto the next whenever rows remain.
+      const headerPrepend = isContinuation ? headerCount : 0;
+      emitTableFragment(sliceEl, {
+        heightsPt: sliceHeightsPt,
+        continuesFromPreviousPage: start > 0,
+        continuesOnNextPage: end < n,
+        repeatedHeaderRowCount: headerPrepend,
+        sourceRowIndexOf: (i) =>
+          i < headerPrepend ? i : start + (i - headerPrepend),
+      });
     }
     pages[pages.length - 1].push(sliceEl);
 
@@ -6708,6 +6946,7 @@ function isFragmentPaintableParagraph(
   if (
     !fragmentPaintEnabled ||
     placed === undefined ||
+    placed.fragment.kind !== 'paragraph' ||
     para.numbering != null ||
     state.floats.length !== 0 ||
     state.verticalCJK ||

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3917,7 +3917,17 @@ function measureCellParagraphScale1(
  *  fragment per `<w:tbl>`, in document order, measured at scale 1 in the cell story.
  *  `outerState` is the enclosing scale-1 measure state (body, or the parent cell for a
  *  nested table); this enters THIS cell's story once. `cellTotalWidthPt` is the sum of
- *  the grid columns the cell spans (before its own margins). */
+ *  the grid columns the cell spans (before its own margins).
+ *
+ *  KNOWN COST (PR 6, review-acknowledged): this measures cell content a SECOND time —
+ *  the paginator already measured every cell through `computeTablePtLayout` /
+ *  `resolveTableRowHeights` for the row heights, and repeated header rows are re-built
+ *  per continuation slice. The duplication exists because the row-height path measures
+ *  HEIGHTS through `measureCellContentHeightPx` (which does not retain the line
+ *  partitions) while fragments need the full {@link MeasuredParagraph}. It is resolved
+ *  when the legacy measure path is retired and row heights are derived FROM the
+ *  fragments (tracked with the stamp-field removal follow-up); pagination-time only,
+ *  paint is unaffected. */
 function buildTableCellBlocks(
   cell: DocTableCell,
   table: DocTable,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4027,18 +4027,30 @@ function attachTableFragment(
 
 /** A table (or any table nested in its cells) stays on the LEGACY paint path when it
  *  needs re-measurement or an out-of-flow path the fragment paint does not yet cover:
+ *   - a negative leading `tblInd` (§17.4.50) on a left-justified table widens the
+ *     legacy layout budget from the column band to the page width;
  *   - a `vAlign` of center/bottom re-measures cell content to centre the inked block
  *     (ECMA-376 §17.4.84);
- *   - a nested floating table (§17.4.57 `<w:tblpPr>`) is drawn out of flow.
- *  Top-aligned in-flow tables — the common case — carry no re-measurement and paint
+ *   - a nested floating table (§17.4.57 `<w:tblpPr>`) is drawn out of flow;
+ *   - a sliced cell paragraph records `[lineStart, lineEnd)` in the fragment contract,
+ *     but current cell paint draws the full partition (as legacy does). Until range
+ *     painting lands, sliced tables stay on the byte-identical legacy path.
+ *  Eligible top-aligned, in-flow, unsliced tables carry no re-measurement and paint
  *  measure-free from their fragment. Recursion covers nested tables (painted from their
- *  own fragment). Tracked: migrate vAlign and nested-floating tables in a follow-up. */
+ *  own fragment). Tracked: migrate negative-indent layout, vAlign, nested-floating
+ *  tables, and sliced-range cell paint in follow-ups. */
 function tableRequiresLegacyPaint(table: DocTable): boolean {
+  if (table.tblInd != null && table.tblInd < 0 && table.jc === 'left') return true;
   for (const row of table.rows) {
     for (const cell of row.cells) {
       if (cell.vAlign === 'center' || cell.vAlign === 'bottom') return true;
       for (const ce of cell.content) {
-        if (ce.type === 'table') {
+        if (
+          ce.type === 'paragraph' &&
+          (ce as { lineSlice?: unknown }).lineSlice !== undefined
+        ) {
+          return true;
+        } else if (ce.type === 'table') {
           const nested = ce as unknown as DocTable;
           if (nested.tblpPr != null || tableRequiresLegacyPaint(nested)) return true;
         }
@@ -4050,9 +4062,10 @@ function tableRequiresLegacyPaint(table: DocTable): boolean {
 
 /** PR 6 — a block table paints from its {@link TableFragment} when the migration gate
  *  holds: the fragment is present, the table is in flow (not a §17.4.57 floating
- *  table), it has no vAlign-center/bottom re-measurement, the story is horizontal, and
- *  this paint's content band matches the band the fragment was resolved at. Otherwise
- *  the legacy `renderTable` recompute path runs (byte-identical). */
+ *  table), it has no negative leading indent, vAlign-center/bottom re-measurement, or
+ *  sliced cell paragraph, the story is horizontal, and this paint's content band
+ *  matches the band the fragment was resolved at. Otherwise the legacy `renderTable`
+ *  recompute path runs (byte-identical). */
 function isFragmentPaintableTable(
   table: DocTable,
   placed: PlacedFragment | undefined,
@@ -9519,6 +9532,10 @@ export const __test_setFragmentPaintEnabled = (v: boolean): boolean => {
   return prev;
 };
 
+/** Exported for focused fragment-paint migration-gate tests. */
+export const __test_tableRequiresLegacyPaint = (table: DocTable): boolean =>
+  tableRequiresLegacyPaint(table);
+
 /** Exported for the M-1 double-measurement non-vacuity test. Toggles whether a
  *  non-relocated body paragraph's fragment reuses the fit-decision measurement or
  *  measures again, so the test can paginate the SAME document both ways and assert the
@@ -10852,7 +10869,8 @@ function isFragmentPaintableCellBlock(
  * paint uses; measure-free at scale 1), nested-table blocks from their own
  * {@link TableFragment}, with the SAME §17.3.1.9 contextualSpacing / spaceBefore-after
  * overlap collapse. Cell paragraphs are drawn whole (no line slice), identically to
- * `renderCellContent`. A block the per-block gate excludes
+ * `renderCellContent`; sliced tables never reach this function because
+ * {@link tableRequiresLegacyPaint} excludes them. A block the per-block gate excludes
  * ({@link isFragmentPaintableCellBlock}) is drawn by the legacy `renderParagraph` —
  * the exact call `renderCellContent` makes — so marker / field / wrap divergences
  * paint byte-identically to the unmigrated path.

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -9937,6 +9937,28 @@ function computeTableLayout(
   // both passes resolve kinsoku from the same immutable doc.settings.
   const stamped = table as PaginatedBodyElement;
   const contentWPt1 = contentWPx / scale;
+  // PR 6 — fragment-geometry reuse. A non-split block table is no longer stamped (the
+  // stamp mutated the PARSED DocTable); its paginator-resolved geometry lives on the
+  // attached TableFragment (side-table keyed, model untouched). When THIS paint is the
+  // legacy path for such a table (fragment-paint gate exclusions: vAlign centring,
+  // nested floating tables, band mismatch never reaches here since the band gate below
+  // re-verifies), reuse the fragment's scale-1 column widths / row heights exactly as
+  // the removed stamp reuse did — same source values, same `× scale`, byte-identical.
+  const placedFragment = bodyFlowFragments.get(table as object);
+  const fragmentBandPt = tableFragmentBandPt.get(table as object);
+  if (
+    tableReuseEnabled &&
+    placedFragment !== undefined &&
+    placedFragment.fragment.kind === 'table' &&
+    fragmentBandPt !== undefined &&
+    placedFragment.fragment.rows.length === table.rows.length &&
+    Math.abs(fragmentBandPt - contentWPt1) <= 1e-6 * Math.max(1, Math.abs(contentWPt1))
+  ) {
+    const fragment = placedFragment.fragment;
+    const colWidths = fragment.columnWidthsPt.map((w) => w * scale);
+    const rowHeights = fragment.rows.map((r) => r.heightPt * scale);
+    return { colWidths, tableW: colWidths.reduce((s, w) => s + w, 0), rowHeights };
+  }
   const reuseInputs = stamped.tableLayoutInputs;
   const reuse =
     tableReuseEnabled &&
@@ -10787,13 +10809,53 @@ function renderCellContent(content: CellElement[], state: RenderState): void {
 }
 
 /**
+ * PR 6 — the per-block twin of {@link isFragmentPaintableParagraph} for a table-cell
+ * paragraph block: a cell paragraph paints from its stored fragment lines only when the
+ * SAME divergence classes the PR 5 body gate excludes are absent —
+ *   - a numbered paragraph paints its body at the §17.9.28 marker-aware numBodyOffset
+ *     first-line indent, which differs from the measured para.indentFirst partition;
+ *   - a state-sensitive paragraph (PAGE / NUMPAGES / date fields) must re-resolve its
+ *     segment text against the real paint-time page context;
+ *   - a non-empty cell float set (an anchor registered by a PRECEDING block in this
+ *     cell — the cell's floats start empty, §17.4.57 isolation) puts the legacy paint
+ *     in a wrap context the no-oracle cell measurement never saw;
+ *   - a placement-width mismatch means the fragment belongs to another layout of this
+ *     cell (defensive; mirrors the PR 5 placement sanity guard).
+ * Excluded blocks fall back to the legacy `renderParagraph`, which recomputes exactly
+ * as `renderCellContent` would — byte-identical (pinned by
+ * layout-lines-reuse-identity.test.ts "table-cell paint byte-identity").
+ */
+function isFragmentPaintableCellBlock(
+  block: ParagraphFragment,
+  state: RenderState,
+): boolean {
+  const para = block.source;
+  if (
+    para.numbering != null ||
+    state.floats.length !== 0 ||
+    paragraphSegsStateSensitive(para)
+  ) {
+    return false;
+  }
+  const paintAvailableWidthPt = state.contentW / state.scale;
+  const recordedWidthPt = block.measured.placement.availableWidthPt;
+  return (
+    Math.abs(recordedWidthPt - paintAvailableWidthPt) <=
+    1e-6 * Math.max(1, Math.abs(paintAvailableWidthPt))
+  );
+}
+
+/**
  * PR 6 — paint a cell's content from its {@link CellFragment} blocks, WITHOUT
  * re-laying-out. Mirrors {@link renderCellContent} exactly: paragraph blocks draw from
  * their stored scale-1 line partition (rescaled through the same bridge body fragment
  * paint uses; measure-free at scale 1), nested-table blocks from their own
  * {@link TableFragment}, with the SAME §17.3.1.9 contextualSpacing / spaceBefore-after
  * overlap collapse. Cell paragraphs are drawn whole (no line slice), identically to
- * `renderCellContent`.
+ * `renderCellContent`. A block the per-block gate excludes
+ * ({@link isFragmentPaintableCellBlock}) is drawn by the legacy `renderParagraph` —
+ * the exact call `renderCellContent` makes — so marker / field / wrap divergences
+ * paint byte-identically to the unmigrated path.
  */
 function renderCellContentFragment(cellFragment: CellFragment, state: RenderState): void {
   let prevPara: DocParagraph | null = null;
@@ -10805,14 +10867,18 @@ function renderCellContentFragment(cellFragment: CellFragment, state: RenderStat
       const effBefore = suppress ? 0 : para.spaceBefore;
       const overlap = suppress ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
       state.y -= overlap * state.scale;
-      renderBodyParagraphLines(
-        para,
-        state,
-        block.measured.lines.map((line) => line.layout),
-        suppress,
-        undefined,
-        undefined,
-      );
+      if (isFragmentPaintableCellBlock(block, state)) {
+        renderBodyParagraphLines(
+          para,
+          state,
+          block.measured.lines.map((line) => line.layout),
+          suppress,
+          undefined,
+          undefined,
+        );
+      } else {
+        renderParagraph(para, state, suppress);
+      }
       prevPara = para;
       prevSpaceAfter = para.spaceAfter;
     } else {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3265,7 +3265,8 @@ export function computePages(
       );
       const pageTable = splitRows?.table ?? tbl;
       const rowHs = splitRows?.rowHs ?? measuredRowHs;
-      const tableEl = (splitRows ? { ...pageTable, type: 'table' } : el) as PaginatedBodyElement;
+      const sourceRowIndexByRow = splitRows?.sourceRowIndexByRow;
+      const tableEl = { ...pageTable, type: 'table' } as PaginatedBodyElement;
       const h = rowHs.reduce((s, x) => s + x, 0);
       const commitTableReserve = () => {
         if (!haveFootnotes || tblNewRefIds.length === 0) return;
@@ -3303,6 +3304,7 @@ export function computePages(
           // widths + contentWPt are constant across the split.
           { colWidthsPt: tblColWidthsPt, contentWPt: tblContentWPt },
           { colWidthsPt: tblColWidthsPt, state: measureState },
+          sourceRowIndexByRow,
           // PR 6 — attach each slice's table fragment (byte-identical additive step:
           // paint is unmigrated in Task 15). The slice IS the table (its rows are the
           // slice's rows); column widths are constant across the split.
@@ -3332,11 +3334,11 @@ export function computePages(
         // §17.6.4 column balancing (wantsBalanceBreak) OR a table that doesn't fit
         // the rest of this column ⇒ advance to the next column / page.
         if (wantsBalanceBreak(h) || y + h > tableContentH) nextColumnOrPage(i);
-        // PR 6 — a whole (non-split) block table paints from its fragment, so it is NOT
-        // stamped: `tableEl` is the PARSED DocTable when the table was not row-split, and
-        // stamping it would mutate the parsed model (the defect class this migration
-        // closes). A gate-rejected non-split table (e.g. negative `tblInd`) recomputes
-        // through the legacy `computeTableLayout`, byte-identical to the removed reuse.
+        // PR 6 — a whole block table paints from its fragment and is always emitted as
+        // a shallow clone. This gives each pagination run a unique side-table key and
+        // lets pushTagged add placement fields without mutating the parsed DocTable.
+        // A gate-rejected table (e.g. negative `tblInd`) recomputes through the legacy
+        // `computeTableLayout`, byte-identical to the removed reuse.
         attachTableFragment(
           tableEl,
           tableEl as unknown as DocTable,
@@ -3351,6 +3353,9 @@ export function computePages(
             continuesFromPreviousPage: false,
             continuesOnNextPage: false,
             repeatedHeaderRowCount: 0,
+            sourceRowIndexOf: sourceRowIndexByRow
+              ? (fragmentRowIndex) => sourceRowIndexByRow[fragmentRowIndex]
+              : undefined,
           },
         );
         pushTagged(tableEl);
@@ -3951,6 +3956,10 @@ function buildTableCellBlocks(
       );
     } else if (ce.type === 'table') {
       const inner = ce as unknown as DocTable;
+      const nestedSlice = ce as CellElement & {
+        nestedSliceContinuesFromPrevious?: boolean;
+        nestedSliceContinuesOnNext?: boolean;
+      };
       const innerCols = resolveColumnWidths(inner, contentWPt, cellState);
       const innerRowHs = resolveTableRowHeights(inner, innerCols, 1, (c, w) =>
         measureCellContentHeightPx(c, inner, w, 1, cellState),
@@ -3960,8 +3969,8 @@ function buildTableCellBlocks(
           table: inner,
           columnWidthsPt: innerCols,
           rowHeightsPt: innerRowHs,
-          continuesFromPreviousPage: false,
-          continuesOnNextPage: false,
+          continuesFromPreviousPage: nestedSlice.nestedSliceContinuesFromPrevious ?? false,
+          continuesOnNextPage: nestedSlice.nestedSliceContinuesOnNext ?? false,
           repeatedHeaderRowCount: 0,
           buildCellBlocks: (c, w) => buildTableCellBlocks(c, inner, w, cellState),
         }),
@@ -3980,9 +3989,9 @@ function buildTableCellBlocks(
 const tableFragmentBandPt = new WeakMap<object, number>();
 
 /** Build and attach the {@link TableFragment} for one placed table (whole table or one
- *  page slice) to the emitted element's side-table entry. `table` supplies the rows to
- *  fragment (the SOURCE table for a whole-table push; the slice for a split). Never
- *  mutates the parsed model. */
+ *  page slice) to the emitted element's side-table entry. `table` is the emitted clone
+ *  whose rows should be fragmented; its rows retain parsed identity unless pagination
+ *  sliced their content. Never mutates the parsed model. */
 function attachTableFragment(
   el: PaginatedBodyElement,
   table: DocTable,
@@ -5037,6 +5046,10 @@ function tableCellElementSliceByRows(table: DocTable, start: number, end: number
     ...(table as object),
     type: 'table',
     rows: table.rows.slice(start, end),
+    // Renderer-runtime provenance for nested-table cell slices. These flags live
+    // only on emitted clones; they are not fields of the parsed DocTable model.
+    nestedSliceContinuesFromPrevious: start > 0,
+    nestedSliceContinuesOnNext: end < table.rows.length,
   } as unknown as CellElement;
 }
 
@@ -5316,10 +5329,11 @@ function splitRowsTallerThanPage(
   colWidthsPt: number[],
   pageContentHeightPt: number,
   state: RenderState,
-): { table: DocTable; rowHs: number[] } | null {
+): { table: DocTable; rowHs: number[]; sourceRowIndexByRow: number[] } | null {
   let changed = false;
   const rows: DocTableRow[] = [];
   const heights: number[] = [];
+  const sourceRowIndexByRow: number[] = [];
   for (let ri = 0; ri < table.rows.length; ri++) {
     const row = table.rows[ri];
     const rowH = rowHeightsPt[ri];
@@ -5328,14 +5342,18 @@ function splitRowsTallerThanPage(
       if (split) {
         rows.push(...split.rows);
         heights.push(...split.heights);
+        sourceRowIndexByRow.push(...split.rows.map(() => ri));
         changed = true;
         continue;
       }
     }
     rows.push(row);
     heights.push(rowH);
+    sourceRowIndexByRow.push(ri);
   }
-  return changed ? { table: { ...table, rows }, rowHs: heights } : null;
+  return changed
+    ? { table: { ...table, rows }, rowHs: heights, sourceRowIndexByRow }
+    : null;
 }
 
 /**
@@ -5394,6 +5412,9 @@ export function splitTableAcrossPages(
   /** Optional row-block splitter used by computePages. Direct unit tests can omit
    *  this and exercise only row-boundary splitting. */
   rowSplit?: { colWidthsPt: number[]; state: RenderState },
+  /** Original parsed-table row index for each incoming `table.rows` entry. Row
+   *  pieces created before this call share an index. Omitted ⇒ identity. */
+  sourceRowIndexByRow?: number[],
   /** PR 6 — invoked once per emitted slice to attach its {@link TableFragment}. The
    *  caller closes over the column widths / measure state and builds the fragment
    *  (the slice element carries the rows + `colIndex`); `meta` supplies the slice's
@@ -5414,11 +5435,14 @@ export function splitTableAcrossPages(
   let workTable = table;
   let workRows = table.rows;
   let workRowHs = rowHs;
+  let workSourceRowIndices = sourceRowIndexByRow?.slice()
+    ?? workRows.map((_row, index) => index);
   let n = workRows.length;
   // Leading tblHeader rows repeat on each continuation page.
   let headerCount = 0;
   while (headerCount < n && workRows[headerCount].isHeader) headerCount++;
   const headerRows = workRows.slice(0, headerCount);
+  const headerSourceRowIndices = workSourceRowIndices.slice(0, headerCount);
   const headerH = workRowHs.slice(0, headerCount).reduce((s, h) => s + h, 0);
   const headerHeightsPt = workRowHs.slice(0, headerCount);
 
@@ -5435,6 +5459,7 @@ export function splitTableAcrossPages(
     if (rowSplit && firstRowH > avail && rowAvail > 0 && start >= headerCount) {
       const split = splitRowForHeight(workTable, workRows[start], rowSplit.colWidthsPt, rowAvail, rowSplit.state);
       if (split && split.heights[0] <= rowAvail) {
+        const sourceRowIndex = workSourceRowIndices[start];
         workRows = [
           ...workRows.slice(0, start),
           ...split.rows,
@@ -5444,6 +5469,11 @@ export function splitTableAcrossPages(
           ...workRowHs.slice(0, start),
           ...split.heights,
           ...workRowHs.slice(start + 1),
+        ];
+        workSourceRowIndices = [
+          ...workSourceRowIndices.slice(0, start),
+          ...split.rows.map(() => sourceRowIndex),
+          ...workSourceRowIndices.slice(start + 1),
         ];
         workTable = { ...workTable, rows: workRows };
         n = workRows.length;
@@ -5475,6 +5505,7 @@ export function splitTableAcrossPages(
               rowSplit.state,
             );
             if (split && split.heights[0] <= remainingForNextRow) {
+              const sourceRowIndex = workSourceRowIndices[end];
               workRows = [
                 ...workRows.slice(0, end),
                 ...split.rows,
@@ -5484,6 +5515,11 @@ export function splitTableAcrossPages(
                 ...workRowHs.slice(0, end),
                 ...split.heights,
                 ...workRowHs.slice(end + 1),
+              ];
+              workSourceRowIndices = [
+                ...workSourceRowIndices.slice(0, end),
+                ...split.rows.map(() => sourceRowIndex),
+                ...workSourceRowIndices.slice(end + 1),
               ];
               workTable = { ...workTable, rows: workRows };
               n = workRows.length;
@@ -5529,11 +5565,11 @@ export function splitTableAcrossPages(
     if (emitTableFragment) {
       // §17.4.78 — a continuation slice prepends the repeated header rows; the body
       // rows begin at `start` in workRows. Map each fragment row back to its source
-      // index: a repeated header keeps its original 0-based header index; a body row
-      // is `start + (i − headerCount)` (workRows-relative, identity to the original
-      // table for a row-boundary split). Page continuation is derived from the slice
-      // window: it continues from a previous page whenever it does not start the
-      // table, and onto the next whenever rows remain.
+      // index: repeated headers read their saved original indices; body rows read the
+      // parallel workRows provenance map, whose entries are duplicated whenever a row
+      // is split. Page continuation is derived from the slice window: it continues
+      // from a previous page whenever it does not start the table, and onto the next
+      // whenever rows remain.
       const headerPrepend = isContinuation ? headerCount : 0;
       emitTableFragment(sliceEl, {
         heightsPt: sliceHeightsPt,
@@ -5541,7 +5577,9 @@ export function splitTableAcrossPages(
         continuesOnNextPage: end < n,
         repeatedHeaderRowCount: headerPrepend,
         sourceRowIndexOf: (i) =>
-          i < headerPrepend ? i : start + (i - headerPrepend),
+          i < headerPrepend
+            ? headerSourceRowIndices[i]
+            : workSourceRowIndices[start + (i - headerPrepend)],
       });
     }
     pages[pages.length - 1].push(sliceEl);

--- a/packages/docx/src/table-fragments.test.ts
+++ b/packages/docx/src/table-fragments.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { layoutDocument } from './document-layout.js';
+import { buildTableFragment } from './table-fragments.js';
+import {
+  tableFragmentHeightPt,
+  flowFragmentAdvancePt,
+  type TableFragment,
+  type RowFragment,
+  type CellFragment,
+  type ParagraphFragment,
+  type FlowFragment,
+  type PlacedFragment,
+} from './layout-fragments.js';
+import type {
+  BodyElement,
+  CellElement,
+  DocParagraph,
+  DocTable,
+  DocTableCell,
+  DocTableRow,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR 6 Task 15 — table layout fragments.
+//
+// A table fragments into `TableFragment` → `RowFragment` → `CellFragment` →
+// recursive `FlowFragment` (paragraph fragments + nested-table fragments), so body
+// and table flow share one immutable fragment result (design §"Measured Fragment
+// Model"). This suite pins:
+//   • the pure `buildTableFragment` contract (row/cell recursion, vMerge roles,
+//     repeated-header marking, continuation flags, source provenance, freezing);
+//   • `layoutDocument` producing table fragments on the body pages, reusing the
+//     paginator's real cell measurement (ordinary row breaks, auto-height splits,
+//     repeated headers, nested tables, vertical merges, per-cell continuation).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** OffscreenCanvas polyfill with a linear glyph metric (width = fontPx * 0.5) so
+ *  `layoutDocument`'s scale-1 measurement is deterministic in node. Mirrors
+ *  document-layout.test.ts. */
+function makeStubCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      const per = p * 0.5;
+      return {
+        width: [...s].length * per,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+  };
+  (ctx as unknown as { canvas: unknown }).canvas = { width: 2000, height: 2000 };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+    getContext() { return makeStubCtx(); }
+  };
+});
+
+// ---- Model builders -----------------------------------------------------------
+
+function emptyBorders() {
+  return { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null };
+}
+
+function para(text: string, over: Partial<DocParagraph> = {}): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: text === '' ? [] : [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+    ...over,
+  } as unknown as DocParagraph;
+}
+
+function cell(content: CellElement[], over: Partial<DocTableCell> = {}): DocTableCell {
+  return {
+    content, colSpan: 1, vMerge: null, borders: emptyBorders(),
+    background: null, vAlign: 'top', widthPt: null,
+    ...over,
+  } as unknown as DocTableCell;
+}
+
+/** Cell holding one text paragraph. */
+function textCell(text: string, over: Partial<DocTableCell> = {}): DocTableCell {
+  return cell([{ type: 'paragraph', ...para(text) } as unknown as CellElement], over);
+}
+
+function row(cells: DocTableCell[], over: Partial<DocTableRow> = {}): DocTableRow {
+  return {
+    cells, rowHeight: null, rowHeightRule: 'auto', isHeader: false,
+    ...over,
+  } as unknown as DocTableRow;
+}
+
+function table(rows: DocTableRow[], colWidths: number[], over: Partial<DocTable> = {}): DocTable {
+  return {
+    type: 'table',
+    colWidths, rows, borders: emptyBorders(),
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left', layout: 'fixed',
+    ...over,
+  } as unknown as DocTable;
+}
+
+function doc(body: BodyElement[], pageHeight = 400): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 200, pageHeight,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage', columns: null,
+  } as SectionProps;
+  return {
+    section, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    footnotes: [],
+  } as unknown as DocxDocumentModel;
+}
+
+/** Every placed table fragment on every page, in document order. */
+function allTables(model: DocxDocumentModel): { placed: PlacedFragment; table: TableFragment }[] {
+  const layout = layoutDocument(model);
+  const out: { placed: PlacedFragment; table: TableFragment }[] = [];
+  for (const page of layout.pages) {
+    for (const placed of page.fragments) {
+      if (placed.fragment.kind === 'table') out.push({ placed, table: placed.fragment });
+    }
+  }
+  return out;
+}
+
+function firstParagraphBlock(cf: CellFragment): ParagraphFragment {
+  const block = cf.blocks[0];
+  if (!block || block.kind !== 'paragraph') throw new Error('expected a paragraph block');
+  return block;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildTableFragment — pure contract
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildTableFragment — pure recursion contract', () => {
+  /** A recognizable stub paragraph fragment so blocks are identity-checkable
+   *  without invoking real measurement. */
+  function stubBlock(tag: string): FlowFragment {
+    return { kind: 'paragraph', source: { tag } as unknown as DocParagraph } as unknown as FlowFragment;
+  }
+
+  it('produces one RowFragment per row and one CellFragment per cell, in order', () => {
+    const t = table(
+      [row([textCell('a'), textCell('b')]), row([textCell('c'), textCell('d')])],
+      [30, 30],
+    );
+    const calls: number[] = [];
+    const frag = buildTableFragment({
+      table: t,
+      columnWidthsPt: [30, 30],
+      rowHeightsPt: [12, 18],
+      continuesFromPreviousPage: false,
+      continuesOnNextPage: false,
+      repeatedHeaderRowCount: 0,
+      buildCellBlocks: (_c, w) => { calls.push(w); return [stubBlock('x')]; },
+    });
+    expect(frag.kind).toBe('table');
+    expect(frag.source).toBe(t);
+    expect(frag.columnWidthsPt).toEqual([30, 30]);
+    expect(frag.rows).toHaveLength(2);
+    expect(frag.rows[0].cells).toHaveLength(2);
+    expect(frag.rows[0].source).toBe(t.rows[0]);
+    expect(frag.rows[0].sourceRowIndex).toBe(0);
+    expect(frag.rows[1].sourceRowIndex).toBe(1);
+    // each cell measured at its single-column width
+    expect(calls).toEqual([30, 30, 30, 30]);
+  });
+
+  it('records per-row heightPt and the summed table height', () => {
+    const t = table([row([textCell('a')]), row([textCell('b')])], [40]);
+    const frag = buildTableFragment({
+      table: t, columnWidthsPt: [40], rowHeightsPt: [15, 25],
+      continuesFromPreviousPage: false, continuesOnNextPage: false, repeatedHeaderRowCount: 0,
+      buildCellBlocks: () => [],
+    });
+    expect(frag.rows.map((r) => r.heightPt)).toEqual([15, 25]);
+    expect(tableFragmentHeightPt(frag)).toBe(40);
+    expect(flowFragmentAdvancePt(frag)).toBe(40);
+  });
+
+  it('sums the spanned column widths for a gridSpan cell', () => {
+    const t = table([row([textCell('wide', { colSpan: 2 }), textCell('c')])], [20, 20, 30]);
+    const widths: number[] = [];
+    buildTableFragment({
+      table: t, columnWidthsPt: [20, 20, 30], rowHeightsPt: [12],
+      continuesFromPreviousPage: false, continuesOnNextPage: false, repeatedHeaderRowCount: 0,
+      buildCellBlocks: (_c, w) => { widths.push(w); return []; },
+    });
+    expect(widths).toEqual([40, 30]); // spanned 20+20, then 30
+  });
+
+  it('classifies vMerge roles and renders no content for a continue cell', () => {
+    const t = table(
+      [
+        row([textCell('r', { vMerge: true }), textCell('a')]),
+        row([textCell('', { vMerge: false }), textCell('b')]),
+      ],
+      [30, 30],
+    );
+    const measured: string[] = [];
+    const frag = buildTableFragment({
+      table: t, columnWidthsPt: [30, 30], rowHeightsPt: [12, 12],
+      continuesFromPreviousPage: false, continuesOnNextPage: false, repeatedHeaderRowCount: 0,
+      buildCellBlocks: (c, _w) => {
+        const p = c.content[0] as unknown as { runs?: { text: string }[] };
+        measured.push(p.runs?.[0]?.text ?? '');
+        return [stubBlock('m')];
+      },
+    });
+    expect(frag.rows[0].cells[0].verticalMerge).toBe('restart');
+    expect(frag.rows[0].cells[1].verticalMerge).toBe('none');
+    expect(frag.rows[1].cells[0].verticalMerge).toBe('continue');
+    expect(frag.rows[1].cells[0].blocks).toEqual([]); // continue: no content
+    // the continue cell was never measured
+    expect(measured).toEqual(['r', 'a', 'b']);
+  });
+
+  it('marks repeated header rows and maps slice rows back to source indices', () => {
+    const t = table(
+      [row([textCell('H')], { isHeader: true }), row([textCell('x')]), row([textCell('y')])],
+      [40],
+    );
+    const frag = buildTableFragment({
+      table: t, columnWidthsPt: [40], rowHeightsPt: [10, 12, 12],
+      continuesFromPreviousPage: true, continuesOnNextPage: false,
+      repeatedHeaderRowCount: 1,
+      sourceRowIndexOf: (i) => (i === 0 ? 0 : i + 3),
+      buildCellBlocks: () => [],
+    });
+    expect(frag.continuesFromPreviousPage).toBe(true);
+    expect(frag.rows[0].repeatedHeader).toBe(true);
+    expect(frag.rows[1].repeatedHeader).toBe(false);
+    expect(frag.rows.map((r) => r.sourceRowIndex)).toEqual([0, 4, 5]);
+  });
+
+  it('deep-freezes the fragment, its rows, cells, and column widths (M-3)', () => {
+    const t = table([row([textCell('a')])], [40]);
+    const frag = buildTableFragment({
+      table: t, columnWidthsPt: [40], rowHeightsPt: [12],
+      continuesFromPreviousPage: false, continuesOnNextPage: false, repeatedHeaderRowCount: 0,
+      buildCellBlocks: () => [],
+    });
+    expect(Object.isFrozen(frag)).toBe(true);
+    expect(Object.isFrozen(frag.rows)).toBe(true);
+    expect(Object.isFrozen(frag.rows[0])).toBe(true);
+    expect(Object.isFrozen(frag.rows[0].cells)).toBe(true);
+    expect(Object.isFrozen(frag.rows[0].cells[0])).toBe(true);
+    expect(Object.isFrozen(frag.columnWidthsPt)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// layoutDocument — table fragments on body pages (real measurement)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('layoutDocument — table fragments', () => {
+  it('emits a placed table fragment for a body table, referencing the SOURCE table', () => {
+    const t = table([row([textCell('a'), textCell('b')])], [80, 80]);
+    const tables = allTables(doc([t as unknown as BodyElement]));
+    expect(tables).toHaveLength(1);
+    expect(tables[0].table.source).toBe(t);
+    expect(tables[0].table.rows).toHaveLength(1);
+    expect(tables[0].table.continuesFromPreviousPage).toBe(false);
+    expect(tables[0].table.continuesOnNextPage).toBe(false);
+    // column widths sum to the table width the paginator resolved (≤ content band)
+    const sum = tables[0].table.columnWidthsPt.reduce((s, w) => s + w, 0);
+    expect(sum).toBeGreaterThan(0);
+    expect(sum).toBeLessThanOrEqual(180 + 1e-6);
+  });
+
+  it('keeps fragment state OFF the parsed table (no fragment fields on DocTable)', () => {
+    const t = table([row([textCell('a')])], [120]);
+    allTables(doc([t as unknown as BodyElement]));
+    expect('kind' in (t as unknown as Record<string, unknown>)).toBe(false);
+    expect('columnWidthsPt' in (t as unknown as Record<string, unknown>)).toBe(false);
+  });
+
+  it('builds each cell paragraph as a ParagraphFragment referencing the source cell paragraph', () => {
+    const cellPara = para('hello');
+    const c = cell([{ type: 'paragraph', ...cellPara } as unknown as CellElement]);
+    const t = table([row([c])], [120]);
+    const { table: tf } = allTables(doc([t as unknown as BodyElement]))[0];
+    const block = firstParagraphBlock(tf.rows[0].cells[0]);
+    // the block's source is the cell's paragraph content element (same runs)
+    expect(block.kind).toBe('paragraph');
+    expect(block.source.runs[0]).toBeDefined();
+    expect((block.source.runs[0] as { text: string }).text).toBe('hello');
+  });
+
+  it('splits a tall table across pages into continuation fragments (auto rows)', () => {
+    const rows = Array.from({ length: 12 }, (_v, i) => row([textCell(`row ${i}`)]));
+    const t = table(rows, [120]);
+    // page height 120 with 10pt margins → ~100pt body; each auto row ~ MIN 10pt+
+    const tables = allTables(doc([t as unknown as BodyElement], 120));
+    expect(tables.length).toBeGreaterThanOrEqual(2);
+    expect(tables[0].table.continuesOnNextPage).toBe(true);
+    expect(tables[0].table.continuesFromPreviousPage).toBe(false);
+    const last = tables[tables.length - 1].table;
+    expect(last.continuesOnNextPage).toBe(false);
+    expect(last.continuesFromPreviousPage).toBe(true);
+    // every source row appears exactly once across the slices, in order
+    const seen = tables.flatMap((x) => x.table.rows.map((r) => r.sourceRowIndex));
+    expect(seen).toEqual(rows.map((_v, i) => i));
+  });
+
+  it('repeats a leading header row on every continuation slice (§17.4.78)', () => {
+    const bodyRows = Array.from({ length: 12 }, (_v, i) => row([textCell(`b${i}`)]));
+    const rows = [row([textCell('HEADER')], { isHeader: true }), ...bodyRows];
+    const t = table(rows, [120]);
+    const tables = allTables(doc([t as unknown as BodyElement], 120));
+    expect(tables.length).toBeGreaterThanOrEqual(2);
+    // continuation slices lead with a repeated-header RowFragment referencing the source header row
+    for (let i = 1; i < tables.length; i++) {
+      const head = tables[i].table.rows[0];
+      expect(head.repeatedHeader).toBe(true);
+      expect(head.sourceRowIndex).toBe(0);
+    }
+    // the first slice's header is NOT marked as repeated
+    expect(tables[0].table.rows[0].repeatedHeader).toBe(false);
+  });
+
+  it('fragments a nested table as a TableFragment cell block', () => {
+    const inner = table([row([textCell('inner')])], [80]);
+    const outerCell = cell([{ type: 'table', ...inner } as unknown as CellElement]);
+    const t = table([row([outerCell])], [120]);
+    const { table: tf } = allTables(doc([t as unknown as BodyElement]))[0];
+    const block = tf.rows[0].cells[0].blocks[0];
+    expect(block).toBeDefined();
+    expect(block.kind).toBe('table');
+    if (block.kind === 'table') {
+      expect(block.rows).toHaveLength(1);
+      expect(firstParagraphBlock(block.rows[0].cells[0]).source.runs[0]).toBeDefined();
+    }
+  });
+
+  it('carries vertical-merge roles across the merged span', () => {
+    const t = table(
+      [
+        row([textCell('m', { vMerge: true }), textCell('a')]),
+        row([textCell('', { vMerge: false }), textCell('b')]),
+      ],
+      [60, 60],
+    );
+    const { table: tf } = allTables(doc([t as unknown as BodyElement]))[0];
+    expect(tf.rows[0].cells[0].verticalMerge).toBe('restart');
+    expect(tf.rows[1].cells[0].verticalMerge).toBe('continue');
+    expect(tf.rows[1].cells[0].blocks).toEqual([]);
+  });
+
+  it('INVARIANT: placed.heightPt equals the summed row heights of the fragment', () => {
+    const rows = Array.from({ length: 3 }, (_v, i) => row([textCell(`r${i}`)]));
+    const t = table(rows, [120]);
+    for (const { placed, table: tf } of allTables(doc([t as unknown as BodyElement]))) {
+      expect(placed.heightPt).toBeCloseTo(tableFragmentHeightPt(tf), 6);
+    }
+  });
+});

--- a/packages/docx/src/table-fragments.test.ts
+++ b/packages/docx/src/table-fragments.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { layoutDocument } from './document-layout.js';
+import { bodyFragmentFor, computePages } from './renderer.js';
 import { buildTableFragment } from './table-fragments.js';
 import {
   tableFragmentHeightPt,
@@ -284,11 +285,12 @@ describe('buildTableFragment — pure recursion contract', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('layoutDocument — table fragments', () => {
-  it('emits a placed table fragment for a body table, referencing the SOURCE table', () => {
+  it('emits a placed table fragment from a clone that preserves parsed row identity', () => {
     const t = table([row([textCell('a'), textCell('b')])], [80, 80]);
     const tables = allTables(doc([t as unknown as BodyElement]));
     expect(tables).toHaveLength(1);
-    expect(tables[0].table.source).toBe(t);
+    expect(tables[0].table.source).not.toBe(t);
+    expect(tables[0].table.source.rows).toBe(t.rows);
     expect(tables[0].table.rows).toHaveLength(1);
     expect(tables[0].table.continuesFromPreviousPage).toBe(false);
     expect(tables[0].table.continuesOnNextPage).toBe(false);
@@ -300,9 +302,32 @@ describe('layoutDocument — table fragments', () => {
 
   it('keeps fragment state OFF the parsed table (no fragment fields on DocTable)', () => {
     const t = table([row([textCell('a')])], [120]);
+    const keysBeforePagination = Object.keys(t);
     allTables(doc([t as unknown as BodyElement]));
+    expect(Object.keys(t)).toEqual(keysBeforePagination);
     expect('kind' in (t as unknown as Record<string, unknown>)).toBe(false);
     expect('columnWidthsPt' in (t as unknown as Record<string, unknown>)).toBe(false);
+  });
+
+  it('keeps table fragment side-table entries isolated across pagination runs', () => {
+    const t = table([row([textCell('a')])], [200]);
+    const body = [t as unknown as BodyElement];
+    const wideSection = doc(body).section;
+    const narrowSection = { ...wideSection, pageWidth: 150 };
+
+    const widePages = computePages(body, wideSection, makeStubCtx());
+    const wideElement = widePages.flat().find((element) => element.type === 'table');
+    expect(wideElement).toBeDefined();
+
+    const narrowPages = computePages(body, narrowSection, makeStubCtx());
+    const narrowElement = narrowPages.flat().find((element) => element.type === 'table');
+    expect(narrowElement).toBeDefined();
+
+    expect(bodyFragmentFor(wideElement as NonNullable<typeof wideElement>)?.widthPt)
+      .toBeCloseTo(180, 6);
+    expect(bodyFragmentFor(narrowElement as NonNullable<typeof narrowElement>)?.widthPt)
+      .toBeCloseTo(130, 6);
+    expect(wideElement).not.toBe(narrowElement);
   });
 
   it('builds each cell paragraph as a ParagraphFragment referencing the source cell paragraph', () => {
@@ -333,6 +358,25 @@ describe('layoutDocument — table fragments', () => {
     expect(seen).toEqual(rows.map((_v, i) => i));
   });
 
+  it('keeps original row indices when a row taller than the page is split into pieces', () => {
+    const tallCell = cell([
+      { type: 'paragraph', ...para('あ'.repeat(400)) } as unknown as CellElement,
+    ]);
+    const t = table(
+      [row([tallCell]), row([textCell('following row')])],
+      [120],
+    );
+    const tables = allTables(doc([t as unknown as BodyElement], 120));
+    const fragmentRows = tables.flatMap(({ table: fragment }) => fragment.rows);
+
+    // Sanity: splitRowsTallerThanPage expanded the first parsed row into pieces.
+    expect(fragmentRows.length).toBeGreaterThan(t.rows.length);
+    expect(fragmentRows.at(-1)?.source).toBe(t.rows[1]);
+    expect(fragmentRows.slice(0, -1).map((fragment) => fragment.sourceRowIndex))
+      .toEqual(Array.from({ length: fragmentRows.length - 1 }, () => 0));
+    expect(fragmentRows.at(-1)?.sourceRowIndex).toBe(1);
+  });
+
   it('repeats a leading header row on every continuation slice (§17.4.78)', () => {
     const bodyRows = Array.from({ length: 12 }, (_v, i) => row([textCell(`b${i}`)]));
     const rows = [row([textCell('HEADER')], { isHeader: true }), ...bodyRows];
@@ -361,6 +405,35 @@ describe('layoutDocument — table fragments', () => {
       expect(block.rows).toHaveLength(1);
       expect(firstParagraphBlock(block.rows[0].cells[0]).source.runs[0]).toBeDefined();
     }
+  });
+
+  it('marks continuation on nested table fragments split at inner row boundaries', () => {
+    const inner = table(
+      Array.from({ length: 4 }, (_unused, index) =>
+        row([textCell(`inner ${index}`)], { rowHeight: 30, rowHeightRule: 'exact' }),
+      ),
+      [80],
+    );
+    const outerCell = cell([{ type: 'table', ...inner } as unknown as CellElement]);
+    const outer = table([row([outerCell])], [120]);
+    const outerFragments = allTables(doc([outer as unknown as BodyElement], 120));
+    const nestedFragments: TableFragment[] = [];
+    for (const { table: outerFragment } of outerFragments) {
+      for (const outerRow of outerFragment.rows) {
+        for (const cellFragment of outerRow.cells) {
+          for (const block of cellFragment.blocks) {
+            if (block.kind === 'table') nestedFragments.push(block);
+          }
+        }
+      }
+    }
+
+    expect(nestedFragments.length).toBeGreaterThan(1);
+    expect(nestedFragments[0].continuesFromPreviousPage).toBe(false);
+    expect(nestedFragments[0].continuesOnNextPage).toBe(true);
+    const last = nestedFragments.at(-1) as TableFragment;
+    expect(last.continuesFromPreviousPage).toBe(true);
+    expect(last.continuesOnNextPage).toBe(false);
   });
 
   it('carries vertical-merge roles across the merged span', () => {

--- a/packages/docx/src/table-fragments.ts
+++ b/packages/docx/src/table-fragments.ts
@@ -80,8 +80,12 @@ function verticalMergeRole(cell: DocTableCell): CellFragment['verticalMerge'] {
 
 /**
  * Produce the immutable {@link TableFragment} for one placed table (whole table or one
- * page slice). Deep-freezes the fragment and its nested row/cell/column arrays (M-3),
- * so a consumer can rely on the layout result being immutable.
+ * page slice). STRUCTURALLY freezes the fragment and its nested row/cell/column arrays
+ * (M-3): every wrapper object and array this module creates is frozen, so the layout
+ * result's shape cannot be mutated. The freeze is structural, not deep — the referenced
+ * parsed model objects and the measured paragraph internals (`MeasuredParagraph.lines`
+ * and its line objects) stay shared and unfrozen, exactly as the PR 5 body fragments
+ * document.
  */
 export function buildTableFragment(input: BuildTableFragmentInput): TableFragment {
   const {

--- a/packages/docx/src/table-fragments.ts
+++ b/packages/docx/src/table-fragments.ts
@@ -1,0 +1,136 @@
+/**
+ * Table layout fragment production (PR 6 of the layout-context / fragments migration;
+ * see docs/docx-layout-context-fragments-design.md §"Measured Fragment Model").
+ *
+ * `buildTableFragment` turns a (possibly page-sliced) {@link DocTable} plus its resolved
+ * scale-1 geometry into an immutable {@link TableFragment}: rows fragment into
+ * {@link RowFragment}s, cells into {@link CellFragment}s, and each cell's content into a
+ * recursive list of {@link FlowFragment}s (paragraph fragments + nested-table fragments).
+ * A fragment belongs to the {@link import('./layout-fragments.js').DocumentLayout} result,
+ * never to the parsed model — the parsed {@link DocTable} is never mutated.
+ *
+ * This module is deliberately PURE and renderer-agnostic. The renderer-coupled work —
+ * measuring a cell paragraph at scale 1, and resolving/recursing a nested table's
+ * geometry — is supplied by the caller through {@link BuildCellBlocks}, so the builder
+ * has no import cycle with renderer.ts and is unit-testable with a stub callback.
+ *
+ * Row heights and the vMerge span extension are resolved by the caller (renderer, via
+ * `resolveTableRowHeights` / `resolveSingleRowHeight` / `findMergeEndRow` in
+ * table-geometry.ts) and passed in as `rowHeightsPt`. They are NOT recomputed here:
+ * a page slice can cut a §17.4.85 vMerge span, and the whole-table span extension grows
+ * a different row than a slice-local recompute would, so only the caller — which holds
+ * the whole-table context and the split — can produce heights that match the paginator's
+ * cursor advancement.
+ */
+import type { DocTable, DocTableCell } from './types';
+import type {
+  CellFragment,
+  FlowFragment,
+  RowFragment,
+  TableFragment,
+} from './layout-fragments.js';
+
+/**
+ * Build the recursive content fragments of one cell laid out at `cellTotalWidthPt`
+ * (the sum of the grid columns the cell spans, BEFORE the cell's own margins are
+ * removed). Returns the cell's blocks in document order — a paragraph fragment per
+ * `<w:p>`, a nested-table fragment per `<w:tbl>`. Supplied by the renderer, which owns
+ * cell-paragraph measurement and nested-table geometry. A `vMerge=continue` cell is
+ * never passed here (it renders no content); the builder gives it an empty block list.
+ */
+export type BuildCellBlocks = (
+  cell: DocTableCell,
+  cellTotalWidthPt: number,
+) => readonly FlowFragment[];
+
+export interface BuildTableFragmentInput {
+  /** The (possibly page-sliced / row-split) table to fragment. Rows align 1:1 with
+   *  `rowHeightsPt`. */
+  readonly table: DocTable;
+  /** The resolved scale-1 grid — every column of the table, constant across a
+   *  page-split. */
+  readonly columnWidthsPt: readonly number[];
+  /** Per-row scale-1 point heights, aligned 1:1 with `table.rows` (a continuation
+   *  slice's repeated-header heights are already prepended by the caller). */
+  readonly rowHeightsPt: readonly number[];
+  /** The source table spilled a page boundary INTO this fragment (a continuation
+   *  slice). */
+  readonly continuesFromPreviousPage: boolean;
+  /** The source table spills a page boundary OUT of this fragment (more rows follow
+   *  on a later page). */
+  readonly continuesOnNextPage: boolean;
+  /** Number of leading rows that are REPEATED headers on this slice (§17.4.78). 0 on
+   *  the first slice / a non-continuation table. */
+  readonly repeatedHeaderRowCount: number;
+  /** Map a fragment row index to its index in the ORIGINAL table (a continuation
+   *  slice prepends header rows; a row-split reuses one source index for several
+   *  slice rows). Defaults to identity. */
+  readonly sourceRowIndexOf?: (fragmentRowIndex: number) => number;
+  /** Renderer-supplied cell content builder (see {@link BuildCellBlocks}). */
+  readonly buildCellBlocks: BuildCellBlocks;
+}
+
+/** The §17.4.85 `<w:vMerge>` role of a cell (its parsed `vMerge`: `true`=restart,
+ *  `false`=continue, `null`=none). A continue cell renders no content. */
+function verticalMergeRole(cell: DocTableCell): CellFragment['verticalMerge'] {
+  if (cell.vMerge === true) return 'restart';
+  if (cell.vMerge === false) return 'continue';
+  return 'none';
+}
+
+/**
+ * Produce the immutable {@link TableFragment} for one placed table (whole table or one
+ * page slice). Deep-freezes the fragment and its nested row/cell/column arrays (M-3),
+ * so a consumer can rely on the layout result being immutable.
+ */
+export function buildTableFragment(input: BuildTableFragmentInput): TableFragment {
+  const {
+    table,
+    columnWidthsPt,
+    rowHeightsPt,
+    continuesFromPreviousPage,
+    continuesOnNextPage,
+    repeatedHeaderRowCount,
+    buildCellBlocks,
+  } = input;
+  const sourceRowIndexOf = input.sourceRowIndexOf ?? ((i: number) => i);
+  const columns = Object.freeze([...columnWidthsPt]) as readonly number[];
+
+  const rows: RowFragment[] = table.rows.map((sourceRow, ri) => {
+    let ci = 0;
+    const cells: CellFragment[] = sourceRow.cells.map((sourceCell) => {
+      const span = Math.min(sourceCell.colSpan, columns.length - ci);
+      let cellTotalWidthPt = 0;
+      for (let cj = ci; cj < ci + span; cj++) cellTotalWidthPt += columns[cj] ?? 0;
+      ci += span;
+      const role = verticalMergeRole(sourceCell);
+      // A continue cell renders no content (§17.4.85); a restart / none cell builds
+      // its recursive blocks at the spanned width.
+      const blocks =
+        role === 'continue'
+          ? (Object.freeze([]) as readonly FlowFragment[])
+          : (Object.freeze([...buildCellBlocks(sourceCell, cellTotalWidthPt)]) as readonly FlowFragment[]);
+      return Object.freeze({
+        source: sourceCell,
+        blocks,
+        verticalMerge: role,
+      }) as CellFragment;
+    });
+    return Object.freeze({
+      source: sourceRow,
+      sourceRowIndex: sourceRowIndexOf(ri),
+      heightPt: rowHeightsPt[ri] ?? 0,
+      cells: Object.freeze(cells) as readonly CellFragment[],
+      repeatedHeader: ri < repeatedHeaderRowCount,
+    }) as RowFragment;
+  });
+
+  return Object.freeze({
+    kind: 'table',
+    source: table,
+    columnWidthsPt: columns,
+    rows: Object.freeze(rows) as readonly RowFragment[],
+    continuesFromPreviousPage,
+    continuesOnNextPage,
+  }) as TableFragment;
+}

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -464,37 +464,31 @@ export type PaginatedBodyElement = BodyElement & {
    *  format. `null` ⇒ the section has no `<w:pgNumType>` (numbering continues;
    *  decimal). Runtime-only — never emitted by the parser. */
   sectionPageNumType?: PageNumType | null;
-  /** B2 table stage 1b — compute-once table layout. When this element is a table
-   *  (`type === 'table'`), the paginator stamps the per-grid-column widths (pt) it
-   *  resolved via {@link resolveColumnWidths}. The paint pass ({@link computeTableLayout})
-   *  reuses them (× the paint scale) instead of re-running the column-fit — which
-   *  re-measures the min-content width of every token in every cell — whenever its
-   *  own layout inputs match `tableLayoutInputs`. Column widths are resolved purely
-   *  in pt (scale-independent), so `× scale` reproduces the paint-scale result
-   *  exactly. Absent ⇒ the paint pass resolves the columns itself (the pre-reuse
-   *  behaviour). Runtime-only — never emitted by the parser. */
+  /** B2 table stage 1b — compute-once table layout for the LEGACY paint path
+   *  (floating tables, and the fallback for a block table the fragment-paint gate does
+   *  not cover). When this element is a table, the paginator stamps the per-grid-column
+   *  widths (pt) it resolved via {@link resolveColumnWidths}; the legacy paint pass
+   *  ({@link computeTableLayout}) reuses them (× the paint scale) when its own layout
+   *  inputs match `tableLayoutInputs`. PR 6 — a migrated block table paints from its
+   *  {@link import('./layout-fragments.js').TableFragment} instead, so it is NOT stamped
+   *  and its parsed element is never mutated with this runtime state; the stamp remains
+   *  for floating/fallback tables (whose slice elements are fresh clones, not the parsed
+   *  model). Absent ⇒ the legacy path resolves the columns itself. Runtime-only. */
   tableColWidthsPt?: number[];
   /** B2 table stage 1b — the per-row heights (pt) the paginator resolved via
-   *  {@link resolveTableRowHeights} (ST_HeightRule + §17.4.85 vMerge span). For a
-   *  table split across pages this holds the heights of THIS slice's rows only (the
-   *  leading repeated `tblHeader` rows of a continuation slice included), in slice
-   *  row order, so it aligns 1:1 with the slice's `rows`. The paint pass reuses
-   *  them (× scale) when `tableLayoutInputs` matches. Absent ⇒ recompute. Runtime-
-   *  only — never emitted by the parser. */
+   *  {@link resolveTableRowHeights} (ST_HeightRule + §17.4.85 vMerge span), for the
+   *  LEGACY paint path only (see `tableColWidthsPt`). For a floating table split across
+   *  pages this holds THIS slice's rows' heights, in slice row order. A migrated block
+   *  table carries the heights on its {@link import('./layout-fragments.js').TableFragment}
+   *  instead. Runtime-only — never emitted by the parser. */
   tableRowHeightsPt?: number[];
-  /** B2 table stage 1b — the scale-1 (pt-space) inputs the paginator resolved the
-   *  stamped table layout with. The paint pass reuses `tableColWidthsPt` /
-   *  `tableRowHeightsPt` ONLY when its OWN inputs reconstruct to these values in the
-   *  paginator's scale-1 space — a self-verifying gate mirroring the paragraph
-   *  `layoutLinesInputs` gate. `contentWPt` is the content-band width the columns
-   *  were fit to; `hasFloats` excludes a float-wrap context (a floating table takes
-   *  the out-of-flow path and never carries this stamp anyway). Runtime-only. */
+  /** B2 table stage 1b — the scale-1 (pt-space) inputs the LEGACY paint reuse gate
+   *  verifies before reusing `tableColWidthsPt` / `tableRowHeightsPt`. `contentWPt` is
+   *  the content-band width the columns were fit to. Runtime-only. */
   tableLayoutInputs?: {
-    /** Always 1 (paginator space). Present so the gate can assert it, matching the
-     *  paragraph `layoutLinesInputs.scale` convention. */
+    /** Always 1 (paginator space). Present so the gate can assert it. */
     scale: number;
-    /** The pt content-band width `resolveColumnWidths` was fit to. Compared with a
-     *  magnitude-relative epsilon against the paint pass's `contentW / scale`. */
+    /** The pt content-band width `resolveColumnWidths` was fit to. */
     contentWPt: number;
   };
 };

--- a/rule-tests/no-docx-measurement-in-fragment-paint-test.yml
+++ b/rule-tests/no-docx-measurement-in-fragment-paint-test.yml
@@ -22,6 +22,9 @@ invalid:
   - "const layout = computeTableLayout(table, contentW, state);"
   - "const rowHeight = calculateRowHeight(tableRow, table, cols, scale, state);"
   - "const h = measureCellContentHeightPx(cell, table, cellW, scale, state);"
+  # Namespace-member form (`import * as ns` evasion of the named-import regex).
+  - "const cols = geometry.resolveColumnWidths(table, contentWPt, state);"
+  - "const m = renderer.measureParagraph(para, context, placement, measurer, environment);"
   # Importing a forbidden symbol.
   - "import { layoutLines } from './line-layout.js';"
   - "import { measureParagraph } from './paragraph-measure.js';"

--- a/rule-tests/no-docx-measurement-in-fragment-paint-test.yml
+++ b/rule-tests/no-docx-measurement-in-fragment-paint-test.yml
@@ -6,6 +6,7 @@ valid:
   - "ctx.drawImage(bmp, x, y, w, h);"
   - "renderBodyParagraphLines(fragment.source, state, scale1Lines, suppress, slice, borderMerge);"
   - "const advances = fragment.measured.lines.map((line) => line.layout);"
+  - "for (const row of fragment.rows) ctx.strokeRect(tableX, row.yPt, tableW, row.heightPt);"
 invalid:
   # Re-running line layout / segment construction / paragraph measurement.
   - "const segs = buildSegments(para.runs, environment);"
@@ -14,9 +15,19 @@ invalid:
   # Measuring text at paint.
   - "const w = ctx.measureText(seg.text).width;"
   - "const w2 = measureText(seg.text).width;"
-  # Row measurement.
+  # Table layout / measurement.
+  - "const cols = resolveColumnWidths(table, contentWPt, state);"
   - "const rows = resolveTableRowHeights(table, cols, 1, measurer);"
+  - "const row = resolveSingleRowHeight(tableRow, cols, 1, measurer);"
+  - "const layout = computeTableLayout(table, contentW, state);"
+  - "const rowHeight = calculateRowHeight(tableRow, table, cols, scale, state);"
   - "const h = measureCellContentHeightPx(cell, table, cellW, scale, state);"
   # Importing a forbidden symbol.
   - "import { layoutLines } from './line-layout.js';"
   - "import { measureParagraph } from './paragraph-measure.js';"
+  - "import { resolveColumnWidths } from './renderer.js';"
+  - "import { resolveTableRowHeights } from './table-geometry.js';"
+  - "import { resolveSingleRowHeight } from './table-geometry.js';"
+  - "import { computeTableLayout } from './renderer.js';"
+  - "import { calculateRowHeight } from './renderer.js';"
+  - "import { measureCellContentHeightPx } from './renderer.js';"

--- a/rules/no-docx-measurement-in-fragment-paint.yml
+++ b/rules/no-docx-measurement-in-fragment-paint.yml
@@ -25,20 +25,30 @@ note: |
   the display scale, never the wrap points.
 rule:
   any:
-    # Segment construction / line layout / paragraph measurement.
+    # Segment construction / line layout / paragraph measurement (bare or
+    # namespace-member form — `import * as ns` would evade the import regex).
     - pattern: buildSegments($$$ARGS)
+    - pattern: $OBJ.buildSegments($$$ARGS)
     - pattern: layoutLines($$$ARGS)
+    - pattern: $OBJ.layoutLines($$$ARGS)
     - pattern: measureParagraph($$$ARGS)
+    - pattern: $OBJ.measureParagraph($$$ARGS)
     # Canvas text measurement (bare or method form).
     - pattern: measureText($$$ARGS)
     - pattern: $OBJ.measureText($$$ARGS)
-    # Table layout / measurement.
+    # Table layout / measurement (bare or namespace-member form).
     - pattern: resolveColumnWidths($$$ARGS)
+    - pattern: $OBJ.resolveColumnWidths($$$ARGS)
     - pattern: resolveTableRowHeights($$$ARGS)
+    - pattern: $OBJ.resolveTableRowHeights($$$ARGS)
     - pattern: resolveSingleRowHeight($$$ARGS)
+    - pattern: $OBJ.resolveSingleRowHeight($$$ARGS)
     - pattern: computeTableLayout($$$ARGS)
+    - pattern: $OBJ.computeTableLayout($$$ARGS)
     - pattern: calculateRowHeight($$$ARGS)
+    - pattern: $OBJ.calculateRowHeight($$$ARGS)
     - pattern: measureCellContentHeightPx($$$ARGS)
+    - pattern: $OBJ.measureCellContentHeightPx($$$ARGS)
     # Importing any of the forbidden layout/measurement symbols.
     - kind: import_specifier
       has:

--- a/rules/no-docx-measurement-in-fragment-paint.yml
+++ b/rules/no-docx-measurement-in-fragment-paint.yml
@@ -3,24 +3,26 @@ language: TypeScript
 severity: error
 message: >-
   fragment-paint.ts paints stored fragment geometry only — it must not measure or
-  re-lay-out. Do not call buildSegments / layoutLines / measureParagraph /
-  measureText / row measurement here (PR 5 body-paint boundary).
+  re-lay-out. Do not call paragraph or table layout/measurement APIs here
+  (PR 6 fragment-paint module boundary).
 note: |
   A body paragraph fragment carries its measured scale-1 geometry; paint scales it
   (rescaleLayoutLines) and draws it. Re-running line layout or measuring text at paint
   would defeat the fragment model (double measurement, stale placement) — the exact
-  divergence the migration removes. Keep segment construction, line layout, paragraph
-  measurement, text measurement and row measurement out of this file; consume the
-  fragment's stored lines instead.
+  divergence the migration removes. A table fragment likewise carries its resolved
+  column widths, row heights and cell-content fragments; paintTableFragment delegates
+  that supplied geometry to renderTableFragment in renderer.ts. Keep segment
+  construction, line layout, paragraph measurement, text measurement and table layout
+  measurement out of this file; consume the fragment's stored geometry instead.
 
-  BOUNDARY SCOPE (PR 5): this rule enforces the measurement-free boundary for the
-  fragment-paint MODULE only. The shared draw path it delegates to (renderParagraph in
-  renderer.ts) still constructs segments (bidi / tab detection) and, at a paint scale
-  != 1, RE-MEASURES each stored line's glyph geometry via rescaleLayoutLines — by
-  design: the fragment stores the scale-1 line PARTITION (break decisions), and only
-  glyph metrics are re-derived at the display scale, never the wrap points. Full static
-  enforcement across the whole body-paint path lands when body paint is separated into
-  its own module (PR 6+ scope).
+  BOUNDARY SCOPE (PR 6): this rule enforces the measurement-free boundary for the
+  fragment-paint MODULE only. It deliberately does not flag renderer.ts: the actual
+  table drawing lives there, and its legacy fallback path legitimately performs table
+  layout measurement. The shared paragraph draw path in renderer.ts also constructs
+  segments (bidi / tab detection) and, at a paint scale != 1, re-measures each stored
+  line's glyph geometry via rescaleLayoutLines — by design: the fragment stores the
+  scale-1 line PARTITION (break decisions), and only glyph metrics are re-derived at
+  the display scale, never the wrap points.
 rule:
   any:
     # Segment construction / line layout / paragraph measurement.
@@ -30,13 +32,17 @@ rule:
     # Canvas text measurement (bare or method form).
     - pattern: measureText($$$ARGS)
     - pattern: $OBJ.measureText($$$ARGS)
-    # Table row measurement.
+    # Table layout / measurement.
+    - pattern: resolveColumnWidths($$$ARGS)
     - pattern: resolveTableRowHeights($$$ARGS)
+    - pattern: resolveSingleRowHeight($$$ARGS)
+    - pattern: computeTableLayout($$$ARGS)
+    - pattern: calculateRowHeight($$$ARGS)
     - pattern: measureCellContentHeightPx($$$ARGS)
     # Importing any of the forbidden layout/measurement symbols.
     - kind: import_specifier
       has:
         field: name
-        regex: "^(buildSegments|layoutLines|measureParagraph|resolveTableRowHeights|measureCellContentHeightPx)$"
+        regex: "^(buildSegments|layoutLines|measureParagraph|resolveColumnWidths|resolveTableRowHeights|resolveSingleRowHeight|computeTableLayout|calculateRowHeight|measureCellContentHeightPx)$"
 files:
   - "**/fragment-paint.ts"


### PR DESCRIPTION
## PR 6 — Produce and paint DOCX table fragments

Sixth stage of the DOCX layout-context / measured-fragments migration
(`docs/docx-layout-context-fragments-design.md`, `…-implementation-plan.md` §"PR 6").
Body block tables were the last in-flow content class still stamping runtime layout
state onto the parsed model and re-laying-out at paint. This PR gives them the same
immutable measured-fragment treatment PR 5 gave body paragraphs.

### Task 15 — table layout fragments (`refactor(docx): paginate table rows as measured fragments`)

- `layout-fragments.ts`: add `CellFragment` / `RowFragment` / `TableFragment` and widen
  `FlowFragment` to `ParagraphFragment | TableFragment`. A table fragments into
  `TableFragment → RowFragment → CellFragment → recursive FlowFragment` (cell paragraphs
  and nested-table fragments), so body and table flow share one `DocumentLayout`.
  `RowFragment` carries `sourceRowIndex` + `heightPt` and deliberately does not assume a
  source row maps to exactly one `RowFragment`, leaving room for a later mid-row page split.
- `table-fragments.ts` (new): pure `buildTableFragment` — recurses rows/cells, classifies
  §17.4.85 vMerge roles (restart owns content, continue renders none), marks §17.4.78
  repeated headers, records page-continuation flags, deep-freezes the nested structures
  (M-3). Renderer-coupled cell measurement is a `buildCellBlocks` callback so the module
  stays renderer-agnostic. Row heights are supplied by the caller (not recomputed) because
  a page slice can cut a vMerge span and only the whole-table context reproduces the
  paginator's charged height.
- `renderer.ts`: attach a placed table fragment at both emission points (the whole-table
  push and each `splitTableAcrossPages` slice — repeated headers, continuation flags,
  source-row provenance) keyed by the emitted element in the same side table body
  paragraphs use, so the parsed model is untouched.
- `layoutDocument`: collect table fragments alongside paragraph fragments, and complete the
  per-page contract (**M-2**) — page geometry and §17.6.4 column geometry come from the
  section stamped on the page's first element, so a continuous multi-column region exposes
  its real column set; the one-section-per-`LayoutPage` bound for a mid-page column change
  is documented.

### Task 16 — paint table fragments (`refactor(docx): paint table fragments without remeasurement`)

- A migrated **block** table paints from its `TableFragment`: geometry from the stored
  column widths + per-row heights, cell content from the cell fragments (paragraphs via the
  shared body-fragment draw bridge, nested tables recursively), preserving the §17.4.66
  border-conflict pass unchanged. At paint scale 1 this invokes **no** `measureText` — a
  nested-table cell, which the legacy path re-lays-out at paint, is the purity Red this
  closes.
- Migration gate (`isFragmentPaintableTable`, mirroring the PR 5 body gate + fallback):
  in-flow, top-aligned, band-matching tables paint from the fragment; floating tables,
  vAlign-center/bottom tables (re-measure to centre the inked block, §17.4.84), nested
  floating tables, and band-mismatch tables (e.g. negative `tblInd`) fall back to the
  legacy `renderTable` recompute path — byte-identical to the removed reuse.
- The non-split whole-table layout **stamp on the parsed element is removed** (its target
  is the parsed `DocTable`): the fragment is the paint source, so the paginator no longer
  mutates the parsed model for the common non-split block table.

### Byte-identity hardening (`fix(docx): keep fragment-gated tables byte-identical to stamp reuse`)

Raw-pixel VRT against the recorded ground truth caught two divergences in the first
Task 16 cut (one private multi-table page drifted by a few hundred diff px; a bisect
pinned it to the paint commit):

- Cell paragraph blocks missed the PR 5 divergence exclusions — a **numbered** cell
  paragraph paints at the §17.9.28 marker-aware first-line indent, a **state-sensitive**
  one (PAGE/NUMPAGES) re-resolves against the real page context, and a paragraph after an
  **in-cell anchored wrap object** lays out in a wrap context the no-oracle cell
  measurement never saw. New per-block gate `isFragmentPaintableCellBlock` (the cell twin
  of the PR 5 body gate) falls back to the exact legacy `renderParagraph` call.
- The legacy fallback for a gate-excluded non-split table (vAlign center/bottom) silently
  changed from stamp reuse to a paint-scale recompute once the model-mutating stamp was
  removed. `computeTableLayout` now sources the same scale-1 geometry from the attached
  `TableFragment` (side-table keyed — the parsed model stays unmutated), restoring the
  old values exactly.

Both were pinned Red-first (3 identity cases + a non-linear-metrics reuse case).

### Review fixes (independent review, request-changes -> addressed)

- **Negative `tblInd` gate hole (blocking)**: legacy paint widens a left-justified
  negative-indent table's layout budget to the page width (§17.4.50); the fragment held
  column-band geometry. Such tables (incl. nested) are now gate-excluded, pinned by a
  direct gate test and an end-to-end byte-identity case (Red re-observed by reverting
  the gate line).
- **Sliced cell paragraphs (blocking)**: the fragment records `[lineStart, lineEnd)` but
  cell paint draws the full partition (as legacy does). Tables containing a sliced cell
  paragraph are gate-excluded until range painting lands; the legacy defect itself is
  tracked separately.
- **`sourceRowIndex` provenance (medium)**: an original-index array now travels through
  `splitRowsTallerThanPage` and both `splitTableAcrossPages` splice sites, so row pieces
  share their source row's index and later rows do not shift; repeated headers report
  their saved indices. Nested-table slices now carry real continuation flags.
- **Per-emission identity (medium)**: a non-split table is emitted as a shallow clone,
  giving each pagination run a unique fragment side-table key (a re-pagination can no
  longer silently serve a newer measurement to older prebuilt pages) and removing the
  last pagination stamps from the parsed table object.
- **Docs/lint tier**: freeze wording corrected to STRUCTURAL freeze; the pagination-time
  double measurement is documented with its resolution path; the ast-grep boundary rule
  now also catches namespace-member calls (`ns.resolveColumnWidths(...)`).

All fixes were verified with the full gate re-run, ending in a full local pixel VRT with
every raw diff-pixel count again byte-identical to the recorded ground truth.

### Verification

- `pnpm build:wasm` → `pnpm test` (full workspace): 360 files / 3501 tests passed.
- root `pnpm typecheck` clean; `pnpm lint` exit 0; `pnpm lint:test` 4/4 (extended rule
  25/25 fixtures); `cargo fmt --all --check` clean (no parser change in this PR);
  `git diff --check` clean.
- `pnpm --filter @silurus/ooxml-docx vrt` (local, private fixtures): 89 checks =
  72 pass / 17 known baseline failures, with **every raw diff-pixel count byte-identical**
  to the recorded ground truth (the two known failing groups reproduce their exact
  recorded values; all passing checks keep their exact prior diffs). References untouched.

### Scope kept explicit (design-doc bounded, tracked follow-ups)

- Floating tables stay on the existing anchored path (per plan); vAlign-center/bottom and
  nested-floating tables stay on legacy paint (each has a real measure/paint divergence).
- The compute-once layout stamps `tableColWidthsPt` / `tableRowHeightsPt` / `tableLayoutInputs`
  and the cell-paragraph line stamps are retained for the **legacy fallback + floating-table**
  paths (their slice objects are fresh clones, not the parsed model). Fully removing the
  fields entails refactoring the floating-table geometry passing and migrating the reuse
  characterization tests; deferred to keep this PR byte-identical.
- The ast-grep boundary rule remains module-scoped to `fragment-paint.ts` (the actual table
  paint lives in `renderer.ts`, which legitimately measures on the legacy path); full static
  enforcement lands when body/table paint separates into its own module.
- **M-3** deep-freeze covers the new table-fragment structures; the shared `MeasuredParagraph`
  internals stay shared/unfrozen as documented in PR 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)