### PR TITLE
fix(docx): snap text-box lines to the section docGrid line pitch

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -125,6 +125,7 @@ export { computeColumns };
 // a TYPE only (erased), so there is no runtime cycle.
 import {
   DEFAULT_TAB_PT,
+  EAST_ASIAN_RE,
   buildFont,
   buildSegments,
   calcEffectiveFontPx,
@@ -8573,9 +8574,11 @@ export function measureShapeTextAutoFitHeight(
   const lineHeightFor = (b: ShapeText, line: LayoutLine): number => {
     let tallest: LayoutTextSeg | null = null;
     let floorPx = 0;
+    let lineText = '';
     for (const seg of line.segments) {
       if (!('text' in seg)) continue;
       const ts = seg as LayoutTextSeg;
+      lineText += ts.text;
       if (!tallest || ts.fontSize > tallest.fontSize) tallest = ts;
       const segPx = ts.fontSize * scale;
       floorPx = Math.max(
@@ -8605,7 +8608,8 @@ export function measureShapeTextAutoFitHeight(
     const ls: LineSpacing | null = b.lineSpacingRule
       ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
       : null;
-    return lineBoxHeight(ls, c.ascent, c.descent, scale, undefined, false, floorPx, false);
+    const eastAsian = EAST_ASIAN_RE.test(lineText);
+    return lineBoxHeight(ls, c.ascent, c.descent, scale, effState.docGrid, false, floorPx, eastAsian);
   };
 
   const spBefore = blocks.map((b) => (b.spaceBefore ?? 0) * scale);
@@ -8787,6 +8791,8 @@ export function renderShapeText(
     // floor falls back to this run's own ascii+eastAsia faces. Either way it is a
     // FLOOR (0 for all-untabled lines ⇒ unchanged).
     lineFloorPx?: number,
+    grid?: DocGridCtx,
+    eastAsian = false,
   ): { lineH: number; baselineOffset: number } => {
     // Floor the single-line box by the TALLEST design line among the run's
     // declared faces (ascii §17.3.2.26 + eastAsia). The common Japanese encoding
@@ -8827,7 +8833,7 @@ export function renderShapeText(
     const ls: LineSpacing | null = b.lineSpacingRule
       ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
       : null;
-    const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, undefined, false, intended, false);
+    const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, grid, false, intended, eastAsian);
     // Word centers the font's GLYPH box within the (possibly expanded) line box
     // (half-leading): when line-spacing or the design-line floor grows the box
     // the extra space is split above and below the glyph box, so the baseline is
@@ -8849,9 +8855,11 @@ export function renderShapeText(
   const lineMetricsFor = (b: ShapeText, line: LayoutLine): { lineH: number; baselineOffset: number } => {
     let tallest: LayoutTextSeg | null = null;
     let floorPx = 0;
+    let lineText = '';
     for (const seg of line.segments) {
       if (!('text' in seg)) continue;
       const ts = seg as LayoutTextSeg;
+      lineText += ts.text;
       if (!tallest || ts.fontSize > tallest.fontSize) tallest = ts;
       // Design-line FLOOR is the MAX intendedSingleLinePx over EVERY segment's
       // ascii AND declared eastAsia face (§17.3.2.26), at that segment's size —
@@ -8867,6 +8875,7 @@ export function renderShapeText(
       );
     }
     const fontPx = (tallest?.fontSize ?? b.fontSizePt) * scale;
+    const eastAsian = EAST_ASIAN_RE.test(lineText);
     return shapeLineMetrics(
       tallest?.fontFamily ?? b.fontFamily,
       tallest?.bold ?? b.bold ?? false,
@@ -8879,6 +8888,8 @@ export function renderShapeText(
       // passed explicitly, so a shorter tabled segment still raises the box.
       tallest?.eaFloorFamily ?? b.fontFamily,
       floorPx,
+      effState.docGrid,
+      eastAsian,
     );
   };
 

--- a/packages/docx/src/textbox-docgrid-line-pitch.test.ts
+++ b/packages/docx/src/textbox-docgrid-line-pitch.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { measureShapeTextAutoFitHeight, renderShapeText } from './renderer.js';
+import { shapeRenderState } from './line-layout.js';
+import type { RenderState } from './renderer.js';
+import type { ShapeRun, ShapeText } from './types';
+
+// ECMA-376 §17.6.5 `<w:docGrid w:type="lines" w:linePitch>` — a document with a
+// line grid snaps EACH text line to the grid pitch (auto / single spacing). The
+// BODY renderer already routes this through `lineBoxHeight`'s grid argument, but
+// text INSIDE a DrawingML text box (`<wps:txbx><w:txbxContent>`) was measured
+// with `grid=undefined`, so its lines stayed at the font's natural single-line
+// height instead of the grid pitch. In a Japanese template (pitch = 360 twips =
+// 18 pt) a 10 pt run's natural Yu Mincho line box (~1.60 em ≈ 16 pt) rendered
+// ~2 pt SHORT per line, tightening every text-box line and — under the bodyPr
+// `anchor="ctr"` — leaving a large empty band above the (now-shorter) content.
+//
+// Word applies the same section line grid to text-box content: the reference PDF
+// of the reported private fixture puts every text-box line on an exact 18 pt
+// pitch (measured by pdftotext -bbox / pdftoppm), matching the body. These tests
+// lock the text-box path onto the grid via the SAME `lineBoxHeight` cell-snap the
+// body uses, and prove it is inert when the section declares no line grid.
+
+interface FillTextEvent { text: string; x: number; y: number }
+
+/** A recording 2D context whose substituted-font natural box is a flat 1.0×em
+ *  (ascent 0.8 + descent 0.2). No family is in the metric table, so any line-box
+ *  growth beyond 1.0×em must come from the grid snap under test. */
+function makeRecordingCanvas(): { ctx: CanvasRenderingContext2D; fillTexts: FillTextEvent[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const fillTexts: FillTextEvent[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setLineDash() {}, drawImage() {}, clearRect() {},
+    arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    fillRect() {}, strokeRect() {},
+    fillText(text: string, x: number, y: number) { fillTexts.push({ text, x, y }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fillTexts };
+}
+
+/** A no-fill/no-line 10 pt text box whose single EA block wraps into ≥2 lines in
+ *  a narrow box (mock measureText is chars × px). The text is CJK so the line is
+ *  classified East Asian for docGrid cell rounding (EAST_ASIAN_RE). */
+function eaTextbox(): ShapeRun {
+  const text = 'あいうえおかきくけこさしすせそたちつてと';
+  const block: ShapeText = {
+    text,
+    fontSizePt: 10,
+    alignment: 'left',
+    runs: [{ text, fontSizePt: 10, fontFamily: '游明朝', fontFamilyEastAsia: '游明朝' }],
+  } as ShapeText;
+  return {
+    type: 'shape',
+    zOrder: 0, subpaths: [], presetGeometry: 'rect',
+    fill: null, stroke: null,
+    behindDoc: false, wrapMode: 'none',
+    widthPt: 60, heightPt: 400,
+    textBlocks: [block], textAnchor: 't',
+    textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+  } as unknown as ShapeRun;
+}
+
+/** State carrying the section docGrid (like the production render threads). */
+function stateWithGrid(
+  ctx: CanvasRenderingContext2D,
+  grid: { type: string | null; linePitchPt: number | null } | undefined,
+): RenderState {
+  const base = shapeRenderState(ctx, 1, {}, new Map());
+  return { ...base, docGrid: grid } as unknown as RenderState;
+}
+
+/** Vertical delta between the first two DISTINCT baseline y values = the first
+ *  wrapped line's line-box height. */
+function firstLineHeight(fillTexts: FillTextEvent[]): number {
+  const ys = [...new Set(fillTexts.map((f) => f.y))].sort((a, b) => a - b);
+  expect(ys.length).toBeGreaterThanOrEqual(2);
+  return ys[1] - ys[0];
+}
+
+describe('text-box lines snap to the section docGrid line pitch (ECMA-376 §17.6.5)', () => {
+  const PITCH = 18;      // 360 twips
+  const NATURAL = 10;    // mock 1.0×em at 10 pt
+
+  it('renderShapeText snaps each EA line to the grid pitch (was natural, too tight)', () => {
+    const { ctx, fillTexts } = makeRecordingCanvas();
+    renderShapeText(eaTextbox(), 0, 0, 60, 400, ctx, 1, {}, new Map(),
+      stateWithGrid(ctx, { type: 'lines', linePitchPt: PITCH }));
+    // Each line occupies exactly one grid cell (18 pt), NOT the 10 pt natural box.
+    expect(firstLineHeight(fillTexts)).toBeCloseTo(PITCH, 3);
+  });
+
+  it('is inert when the section declares no line grid (natural spacing preserved)', () => {
+    const { ctx, fillTexts } = makeRecordingCanvas();
+    renderShapeText(eaTextbox(), 0, 0, 60, 400, ctx, 1, {}, new Map(),
+      stateWithGrid(ctx, { type: 'default', linePitchPt: null }));
+    expect(firstLineHeight(fillTexts)).toBeCloseTo(NATURAL, 3);
+  });
+
+  it('measureShapeTextAutoFitHeight totals the grid-snapped line heights', () => {
+    const { ctx } = makeRecordingCanvas();
+    const shape = eaTextbox();
+    const gridState = stateWithGrid(ctx, { type: 'lines', linePitchPt: PITCH });
+    const flatState = stateWithGrid(ctx, { type: 'default', linePitchPt: null });
+    const hGrid = measureShapeTextAutoFitHeight(shape, 60, ctx, 1, {}, new Map(), gridState);
+    const hFlat = measureShapeTextAutoFitHeight(shape, 60, ctx, 1, {}, new Map(), flatState);
+    // The grid total is a whole number of 18 pt cells; the flat total is the same
+    // line count at 10 pt — so the grid path is strictly taller by 8 pt / line.
+    const lineCount = Math.round(hFlat / NATURAL);
+    expect(lineCount).toBeGreaterThanOrEqual(2);
+    expect(hGrid).toBeCloseTo(lineCount * PITCH, 3);
+    expect(hGrid).toBeGreaterThan(hFlat + 0.5);
+  });
+});


### PR DESCRIPTION
## Problem

ECMA-376 §17.6.5 `<w:docGrid w:type="lines" w:linePitch>` defines a section line grid: a paragraph with single/auto line spacing snaps each text line to the grid pitch. The body renderer already applies this through `lineBoxHeight`'s grid argument (with a per-line East-Asian flag), but text inside a DrawingML text box (`<wps:txbx><w:txbxContent>`) was measured with `grid = undefined` / `eastAsian = false`, so its lines kept the font's natural single-line height and ignored the grid.

On a typical Japanese template (pitch 360 twips = 18 pt) a 10 pt run whose face has a ~1.60 em design line box rendered at ~16 pt per line instead of the grid's 18 pt. Every text-box line came out ~2 pt too tight, and under a `bodyPr anchor="ctr"` the shortened content left a large empty band above it. Word applies the same section grid to text-box content, so its lines sit on the exact grid pitch — matching the body.

## Fix

Thread the section `docGrid` and a per-line East-Asian flag (the `EAST_ASIAN_RE` content predicate the body already uses) into the `lineBoxHeight` calls of both text-box paths:

- `renderShapeText` (draw path) — added `grid` / `eastAsian` params to the local `shapeLineMetrics` helper and computes the per-line flag in `lineMetricsFor`.
- `measureShapeTextAutoFitHeight` (auto-fit measure path) — same per-line flag + `effState.docGrid`.

The half-leading baseline math is unchanged, so the glyph box is centered within the possibly grid-inflated line box. The change is inert when the section declares no line grid (`isGridLineRule` false) — the synthesized shape state and non-grid documents keep byte-identical output.

## Verification

Measured against a private Japanese fixture with a fixed-size anchored text box, rendering the page with the real document font and measuring line bands by pixel vs `pdftoppm`/`pdftotext` of the Word reference PDF:

| metric | before | after | Word |
| --- | --- | --- | --- |
| text-box line pitch | 16.0 pt | **18.0 pt** | 18.0 pt |
| interior top gap | 16.4 pt | **6.4 pt** | 6.4 pt |
| interior bottom gap | 17.4 pt | **7.4 pt** | 7.4 pt |

Matches Word within ~0.1 pt.

- New unit test `textbox-docgrid-line-pitch.test.ts` locks the grid snap on the draw and measure paths plus the no-grid inert case.
- Full docx suite: 1045 tests pass (1 skipped).
- Root `pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)