### PR TITLE
fix(docx): place RTL fitText residual pad in the reading frame (§17.3.2.14)

### DIFF
--- a/packages/docx/scripts/gen-rtl-fittext-fixture.py
+++ b/packages/docx/scripts/gen-rtl-fittext-fixture.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Generate a synthetic .docx that exercises ECMA-376 §17.3.2.14 `w:fitText`
+(Manual Run Width) inside §17.3.1.6 `w:bidi` (RTL) paragraphs, plus LTR controls.
+
+This fixture carries NO private content — it is a self-contained, OSS-safe
+document whose only purpose is to obtain Word-rendered ground truth for the
+RTL fitText gap / residual placement fixed for issue #920.
+
+How to use it for ground truth
+------------------------------
+1.  python3 packages/docx/scripts/gen-rtl-fittext-fixture.py rtl-fittext.docx
+2.  Open `rtl-fittext.docx` in Microsoft Word and export / print to PDF.
+3.  Compare against the viewer's render of the same file (Storybook private
+    story or the node harness). Each fitText region must occupy exactly
+    w:val = 2400 twips = 120 pt (1.667 in). Expected reading-frame layout:
+      * RTL multi-run region: the glyphs read right-to-left with EVEN gaps
+        between every adjacent pair across the run boundary; the logical-last
+        run sits on the visual LEFT.
+      * RTL single-char region: the single glyph sits at the region's LEADING
+        (right) edge and the residual pad fills to its LEFT.
+      * The LTR controls are the mirror image (glyph/pad on the left/right).
+
+Every run property is emitted in CT_RPr (EG_RPrBase) schema order — in
+particular `w:fitText` is written BEFORE `w:rtl` (wml.xsd lines 1773/1775) — so
+a schema-strict round trip cannot mask a parser that ignores element order.
+"""
+import sys
+import zipfile
+
+W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+
+CONTENT_TYPES = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"""
+
+RELS = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"""
+
+
+def rpr(fit_val=None, fit_id=None, rtl=False, cs_font="Arial", ea_font="Yu Mincho"):
+    """A run property block in strict EG_RPrBase order: rFonts, sz, szCs,
+    fitText, rtl. fitText MUST precede rtl (wml.xsd)."""
+    parts = [f'<w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="{cs_font}" w:eastAsia="{ea_font}"/>']
+    parts.append('<w:sz w:val="22"/>')
+    parts.append('<w:szCs w:val="22"/>')
+    if fit_val is not None:
+        if fit_id is not None:
+            parts.append(f'<w:fitText w:val="{fit_val}" w:id="{fit_id}"/>')
+        else:
+            parts.append(f'<w:fitText w:val="{fit_val}"/>')
+    if rtl:
+        parts.append('<w:rtl/>')
+    return "<w:rPr>" + "".join(parts) + "</w:rPr>"
+
+
+def run(text, **kw):
+    # xml:space="preserve" so trailing/leading spaces survive the round trip.
+    return f'<w:r>{rpr(**kw)}<w:t xml:space="preserve">{text}</w:t></w:r>'
+
+
+def para(runs_xml, bidi=False):
+    ppr = "<w:pPr><w:bidi/></w:pPr>" if bidi else ""
+    return f"<w:p>{ppr}{runs_xml}</w:p>"
+
+
+def label(text):
+    return f'<w:p><w:pPr><w:pStyle w:val="Caption"/></w:pPr><w:r><w:rPr><w:i/><w:sz w:val="18"/></w:rPr><w:t xml:space="preserve">{text}</w:t></w:r></w:p>'
+
+
+def build_document():
+    body = []
+
+    body.append(label("1) RTL multi-run fitText region (w:id=1, w:val=2400 = 120pt): logical-last run on the visual LEFT, even cross-run gaps"))
+    body.append(para(
+        run("أبجد", fit_val=2400, fit_id=1, rtl=True)   # أبجد (4)
+        + run("هوز", fit_val=2400, fit_id=1, rtl=True),      # هوز (3)
+        bidi=True,
+    ))
+
+    body.append(label("2) RTL single-char fitText region (w:val=2400 = 120pt): glyph at the LEADING (right) edge, pad to its LEFT"))
+    body.append(para(
+        run("م", fit_val=2400, rtl=True),                             # م
+        bidi=True,
+    ))
+
+    body.append(label("3) LTR control multi-run fitText region (w:id=2, w:val=2400 = 120pt)"))
+    body.append(para(
+        run("氏名又は", fit_val=2400, fit_id=2)            # 氏名又は
+        + run("名", fit_val=2400, fit_id=2)                           # 名
+        + run("称", fit_val=2400, fit_id=2),                          # 称
+    ))
+
+    body.append(label("4) LTR control single-char fitText region (w:val=2400 = 120pt): glyph at the LEFT edge, pad to its RIGHT"))
+    body.append(para(run("A", fit_val=2400)))
+
+    sect = (
+        '<w:sectPr>'
+        '<w:pgSz w:w="12240" w:h="15840"/>'
+        '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/>'
+        '</w:sectPr>'
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f'<w:document xmlns:w="{W}">'
+        f'<w:body>{"".join(body)}{sect}</w:body>'
+        '</w:document>'
+    )
+
+
+def main():
+    out = sys.argv[1] if len(sys.argv) > 1 else "rtl-fittext.docx"
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("[Content_Types].xml", CONTENT_TYPES)
+        z.writestr("_rels/.rels", RELS)
+        z.writestr("word/document.xml", build_document())
+    print(f"wrote {out}")
+    print("Open it in Word and export to PDF to capture RTL fitText ground truth (see module docstring).")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/docx/src/fit-text-rtl.test.ts
+++ b/packages/docx/src/fit-text-rtl.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import { renderDocumentToCanvas, type DocxTextRunInfo } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxDocumentModel,
+  DocxTextRun,
+  SectionProps,
+} from './types.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ECMA-376 §17.3.2.14 `<w:fitText>` (Manual Run Width) inside an RTL paragraph
+// (§17.3.1.6 `<w:bidi>`), resolved against UAX#9 reordering (rule L2).
+//
+// Issue #920 (follow-up from the PR #918 adversarial review): a fit region's
+// residual width and its inter-character gaps were resolved in the LTR segment
+// walk with no RTL fixture to verify the placement under the visual reorder.
+//
+// The reading-frame contract (same class as the docx #830 / pptx #913 tab-stop
+// mirroring):
+//   • The region occupies exactly `w:val`, anchored at the LEADING edge — the
+//     left in an LTR paragraph, the RIGHT in an RTL paragraph.
+//   • The inter-character gaps are distributed EVENLY in reading order; the
+//     region's glyphs pack from the leading edge and the residual pad trails
+//     AFTER the last glyph (to the left under RTL).
+//   • The multi-run region's segments reorder visually (the logical-last run
+//     draws on the visual LEFT), and each segment keeps the same per-gap pitch.
+//
+// The recording canvas uses a fixed-width mock glyph (`fontSize` px), so every
+// x / letterSpacing / direction is exact and font-independent — the same
+// technique the LTR fitText paint test and the #830 RTL tab test use.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface FillCall {
+  text: string;
+  x: number;
+  letterSpacing: number;
+  direction: string;
+}
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[] } {
+  let font = '12px serif';
+  let letterSpacing = '0px';
+  let direction: CanvasDirection = 'ltr';
+  const fills: FillCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(value: string) { letterSpacing = value; },
+    get direction() { return direction; },
+    set direction(value: CanvasDirection) { direction = value; },
+    fontKerning: 'auto',
+    measureText(text: string) {
+      const px = Number(/([\d.]+)px/.exec(font)?.[1] ?? 12);
+      return {
+        width: [...text].length * px,
+        fontBoundingBoxAscent: px * 0.8,
+        fontBoundingBoxDescent: px * 0.2,
+        actualBoundingBoxAscent: px * 0.8,
+        actualBoundingBoxDescent: px * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, scale() {}, translate() {},
+    fillText(text: string, x: number) {
+      fills.push({ text, x, letterSpacing: Number.parseFloat(letterSpacing), direction });
+    },
+    beginPath() {}, closePath() {}, moveTo() {}, lineTo() {}, stroke() {}, fill() {},
+    fillRect() {}, strokeRect() {}, clip() {}, rect() {}, setLineDash() {},
+    drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {}, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills };
+}
+
+function textRun(text: string, extra: Partial<DocxTextRun> = {}): DocxTextRun {
+  return {
+    text,
+    bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 12, color: null, fontFamily: 'serif', isLink: false, background: null,
+    vertAlign: null, ...extra, hyperlink: extra.hyperlink ?? null,
+  };
+}
+
+function paragraph(runs: DocxTextRun[], bidi: boolean): BodyElement {
+  const para: DocParagraph = {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: runs.map((run) => ({ type: 'text', ...run })),
+    defaultFontSize: 12, defaultFontFamily: 'serif', widowControl: false,
+    ...(bidi ? { bidi: true } : {}),
+  } as unknown as DocParagraph;
+  return { type: 'paragraph', ...para };
+}
+
+function section(): SectionProps {
+  return {
+    pageWidth: 600, pageHeight: 400, marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+  } as SectionProps;
+}
+
+async function render(
+  runs: DocxTextRun[],
+  bidi: boolean,
+): Promise<{ fills: FillCall[]; boxes: DocxTextRunInfo[] }> {
+  const { canvas, fills } = makeRecordingCanvas();
+  const boxes: DocxTextRunInfo[] = [];
+  const model = {
+    section: section(),
+    body: [paragraph(runs, bidi)],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { serif: 'roman' },
+  } as unknown as DocxDocumentModel;
+  await renderDocumentToCanvas(model, canvas, 0, {
+    dpr: 1,
+    width: 600,
+    onTextRun: (box) => boxes.push(box),
+  });
+  return { fills, boxes };
+}
+
+// Page is 600 px wide with no margins ⇒ scale 1, content [0, 600]. A 2400-twip
+// region is 120 px. Each mock glyph is 12 px. All positions below are exact.
+const TARGET = 120;
+const RIGHT = 600;
+
+describe('ECMA-376 §17.3.2.14 fitText in an RTL paragraph (issue #920)', () => {
+  it('LTR control: a 3-run region packs from the left, byte-identical to #918', async () => {
+    const fit = { fitTextVal: 2400, fitTextId: -1431456512 };
+    const { fills, boxes } = await render(
+      [textRun('ABCD', fit), textRun('E', fit), textRun('F', fit)],
+      false,
+    );
+    // Six glyphs, five gaps: perGap = (120 − 72) / 5 = 9.6.
+    expect(fills.map((f) => f.letterSpacing)).toEqual([9.6, 9.6, 9.6]);
+    expect(fills.map((f) => f.direction)).toEqual(['ltr', 'ltr', 'ltr']);
+    // Glyphs paint left→right in logical order; the region fills [0, 120].
+    expect(fills.map((f) => f.x)).toEqual([0, 86.4, 108]);
+    expect(boxes.map((b) => b.x)).toEqual([0, 86.4, 108]);
+    expect(boxes.reduce((s, b) => s + b.w, 0)).toBeCloseTo(TARGET, 9);
+  });
+
+  it('RTL: a 2-run region mirrors — logical-last run on the visual LEFT, gaps preserved', async () => {
+    // Same-id linked runs, both cs (§17.3.2.30 w:rtl) Arabic. Region = 120 px.
+    const fit = { fitTextVal: 2400, fitTextId: 7, rtl: true };
+    const { fills, boxes } = await render(
+      [textRun('ابج', fit), textRun('دهو', fit)],
+      true,
+    );
+    // Six glyphs, five gaps: perGap 9.6, same as the LTR control (reading-frame
+    // distribution is direction-independent).
+    expect(fills.map((f) => f.letterSpacing)).toEqual([9.6, 9.6]);
+    expect(fills.map((f) => f.direction)).toEqual(['rtl', 'rtl']);
+    // Visual order: the logical-LAST run ('دهو', the region end) draws on the
+    // visual LEFT; the logical-first ('ابج') on the visual RIGHT.
+    expect(fills.map((f) => f.text)).toEqual(['دهو', 'ابج']);
+    // The region occupies exactly the leading (right) 120 px: [480, 600].
+    // The region-end segment (leftmost) carries NO trailing gap: width
+    // 36 + 2·9.6 = 55.2 ⇒ box [480, 535.2]. The leading segment carries its
+    // cross-run boundary gap: 36 + 3·9.6 = 64.8 ⇒ box [535.2, 600].
+    const sorted = [...boxes].sort((a, b) => a.x - b.x);
+    expect(sorted.map((b) => Number(b.x.toFixed(4)))).toEqual([480, 535.2]);
+    expect(sorted.map((b) => Number(b.w.toFixed(4)))).toEqual([55.2, 64.8]);
+    const left = Math.min(...boxes.map((b) => b.x));
+    const right = Math.max(...boxes.map((b) => b.x + b.w));
+    expect(left).toBeCloseTo(RIGHT - TARGET, 6);
+    expect(right).toBeCloseTo(RIGHT, 6);
+  });
+
+  it('RTL: a 3-run region mirrors with the residual folded into the even gaps', async () => {
+    const fit = { fitTextVal: 2400, fitTextId: 9, rtl: true };
+    const { fills, boxes } = await render(
+      [textRun('ابجد', fit), textRun('ه', fit), textRun('و', fit)],
+      true,
+    );
+    expect(fills.map((f) => f.letterSpacing)).toEqual([9.6, 9.6, 9.6]);
+    // logical [ابجد, ه, و] ⇒ visual [و, ه, ابجد].
+    expect(fills.map((f) => f.text)).toEqual(['و', 'ه', 'ابجد']);
+    const left = Math.min(...boxes.map((b) => b.x));
+    const right = Math.max(...boxes.map((b) => b.x + b.w));
+    expect(left).toBeCloseTo(RIGHT - TARGET, 6);
+    expect(right).toBeCloseTo(RIGHT, 6);
+  });
+
+  it('LTR: a single-char region leaves the residual as trailing pad on the RIGHT', async () => {
+    // One glyph, no gaps: the whole (120 − 12) = 108 px residual is trailing pad.
+    const { fills, boxes } = await render([textRun('A', { fitTextVal: 2400 })], false);
+    expect(fills).toHaveLength(1);
+    // The glyph sits at the leading (left) edge; the pad fills to the right.
+    expect(fills[0].x).toBeCloseTo(0, 6);
+    expect(boxes[0].x).toBeCloseTo(0, 6);
+    expect(boxes[0].w).toBeCloseTo(TARGET, 6);
+  });
+
+  it('RTL: a single-char region puts the glyph at the leading (right) edge, pad to the LEFT', async () => {
+    // The RTL mirror of the LTR case: the glyph must sit at the region's leading
+    // (RIGHT) edge and the 108 px residual pad must trail to its LEFT — NOT sit
+    // at the physical left with the pad bleeding rightward into the line.
+    const { fills, boxes } = await render([textRun('ا', { fitTextVal: 2400, rtl: true })], true);
+    expect(fills).toHaveLength(1);
+    expect(fills[0].direction).toBe('rtl');
+    // The region box is still the leading 120 px: [480, 600].
+    expect(boxes[0].x).toBeCloseTo(RIGHT - TARGET, 6);
+    expect(boxes[0].w).toBeCloseTo(TARGET, 6);
+    // The glyph is drawn at the region's RIGHT edge: leftEdge (480) + pad (108) =
+    // 588, so the 12 px glyph ends on the leading margin 600. Before the fix the
+    // glyph painted at 480 (physical left) with the pad trailing rightward.
+    expect(fills[0].x).toBeCloseTo(RIGHT - TARGET + (TARGET - 12), 6);
+    expect(fills[0].x).toBeCloseTo(588, 6);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7403,11 +7403,23 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           // with §17.3.2.43 `w:w` exactly like the sibling arms: the fixed pitch
           // is divided by `segCharScale` so the ×scale frame reproduces its
           // un-scaled magnitude.
+          // ECMA-376 §17.3.2.14 (Manual Run Width) + UAX#9 rule L2: mirror the
+          // docx #830 RTL tab-stop leading-edge rule. A region's residual pad
+          // trails its LAST glyph in READING order — the physical right under an
+          // LTR base (the pen advance already leaves it there), but the physical
+          // LEFT under an RTL base. So when this region-end segment draws in the
+          // RTL visual frame, shift the glyph origin rightward by the pad so the
+          // glyph sits at the leading (right) edge and the pad falls to its left.
+          // (Non-end / multi-char segments carry trailingPad == 0 ⇒ no shift, and
+          // every LTR segment keeps a zero offset ⇒ byte-identical.)
+          const fitRtl = !!(visual && visual.rtl[si]);
+          const fitPad = s.fitTextTrailingPadPx ?? 0;
+          const fitDrawX = x + (fitRtl ? fitPad : 0);
           const scaled = segCharScale !== 1;
           const prevLetterSpacing = ctx.letterSpacing;
-          if (scaled) { ctx.save(); ctx.translate(x, 0); ctx.scale(segCharScale, 1); }
+          if (scaled) { ctx.save(); ctx.translate(fitDrawX, 0); ctx.scale(segCharScale, 1); }
           ctx.letterSpacing = `${s.fitTextPerGapPx / segCharScale}px`;
-          ctx.fillText(s.text, scaled ? 0 : x, baseline + yOffset);
+          ctx.fillText(s.text, scaled ? 0 : fitDrawX, baseline + yOffset);
           ctx.letterSpacing = prevLetterSpacing;
           if (scaled) ctx.restore();
         } else if (segGridDelta !== 0) {


### PR DESCRIPTION
## Summary

Follow-up from the PR #918 adversarial review: a `w:fitText` (Manual Run Width,
ECMA-376 §17.3.2.14) region inside a `w:bidi` (§17.3.1.6) RTL paragraph resolved
its residual width and inter-character gaps in the LTR segment walk, with no
RTL fixture to verify the placement under the UAX#9 reorder.

A fit region occupies exactly `w:val`, packing its glyphs from the **leading**
edge with the residual pad trailing the last glyph. Under an LTR base the
leading edge is the physical left (pad falls right, where the pen advance
already leaves it); under an RTL base it is the physical right, so the glyph
must sit at the region's right and the pad must trail to its **left**.

## Current behaviour (observed)

Rendering an RTL single-character fit region (the only case with a non-zero
residual pad — multi-char regions spread the whole residual as even
inter-character gaps) painted the glyph at the box's physical-left, so the pad
bled rightward into the line instead of trailing to the left. Multi-run RTL
regions already reorder correctly (logical-last run on the visual left, even
cross-run gaps) via `computeLineVisualOrder`; only the residual-pad side was
wrong.

## Fix

Shift the region-end segment's glyph origin rightward by its trailing pad when
it draws in the RTL visual frame (UAX#9 rule L2), mirroring the docx #830 RTL
tab-stop leading-edge rule. This is the reading-frame principle the task asks
for: gaps/residual are distributed in logical order and visual placement follows
the existing bidi reorder — no heuristics.

- LTR segments keep a **zero** offset ⇒ byte-identical output.
- Multi-char regions carry `pad == 0` ⇒ only the RTL single-char case moves.
- The region box, run decorations and the `onTextRun` extent are unchanged —
  only the glyph moves inside its fixed-width cell.

## Tests / verification

- `fit-text-rtl.test.ts` (new) pins the reading-frame contract with a
  font-free recording canvas (same technique as the LTR fitText paint test and
  the #830 RTL tab test): LTR multi-run/single-char baselines, RTL multi-run
  reorder + even gaps, and the RTL single-char leading-edge pad.
- `fit-text*` + `rtl-tab-stops` suites: 48 pass.
- Full `packages/docx` suite: 1047 pass, 1 skipped.
- Root `pnpm typecheck`: pass.
- A private LTR fixture's fit region still measures exactly **120.00pt**
  (unchanged), confirming LTR non-regression on a real document.
- Parser round-trip guard: the synthetic RTL fixture (below) parses through
  the WASM parser with `w:bidi` on the paragraph and `w:fitText` val/id on the
  runs in logical order.

The parser was not touched (TS-only renderer change).

## Ground truth

Word-rendered ground truth for the exact RTL placement is **not yet captured**.
This change is grounded in the spec (§17.3.2.14 + UAX#9 rule L2) and the docx
#830 RTL leading-edge adjudication. A maintainer can obtain Word ground truth
with the added generator:

```bash
python3 packages/docx/scripts/gen-rtl-fittext-fixture.py rtl-fittext.docx
# open rtl-fittext.docx in Word, export to PDF, compare against the viewer
```

The generator emits an OSS-safe synthetic `.docx` (RTL multi-run + RTL
single-char fit regions + LTR controls) with every run property in CT_RPr
schema order (`w:fitText` before `w:rtl`), so a schema-strict round trip cannot
mask element-order-insensitive parsing.

Closes #920
