### PR TITLE
Re-wrap paragraph continuations into unequal-width columns

### DIFF
--- a/docs/docx-layout-context-fragments-design.md
+++ b/docs/docx-layout-context-fragments-design.md
@@ -362,8 +362,15 @@ paragraph spacing. The paginator owns trailing spacing collapse and records the
 actual leading and trailing contributions on each fragment, preventing spacing
 from being counted once in measurement and again in placement. Paint scales
 measured geometry; it does not repeat text layout. A measurement is valid only
-for its recorded placement. Moving a paragraph to another page, column, or wrap
-context requires deterministic remeasurement.
+while its placement-DETERMINING inputs hold: the line partition and per-line
+geometry are a function of the available width, the wrap context, and the
+content — without a wrap oracle, the X/Y origin is a pure translation recorded
+on the placed fragment, not a layout input. Moving a paragraph to a placement
+with a different available width or a different wrap context therefore requires
+deterministic remeasurement (the §17.6.4 unequal-width continuation re-wrap);
+a same-width, wrap-free move to another page or column reuses the measurement
+with the new origin recorded on `PlacedFragment` — the shipped continuation
+contract in the fragment model section below.
 
 `documentHasEastAsianText` preserves the existing document-level font-axis
 choice for empty and anchor-only paragraph marks. Content-bearing lines continue

--- a/packages/docx/src/fragment-paint.ts
+++ b/packages/docx/src/fragment-paint.ts
@@ -40,7 +40,10 @@ import type { PlacedFragment } from './layout-fragments.js';
  * @param placed  the placed paragraph fragment (its `measured` holds the scale-1 lines).
  * @param state   the page paint state (its `scale`, `ctx`, `contentX/W`, `y` cursor).
  * @param options paint-adjacency inputs the paginator does not own: `suppressSpaceBefore`
- *   (continuation slices / spacing collapse) and the §17.3.1.7 `borderMerge`.
+ *   (continuation slices / spacing collapse), the §17.3.1.7 `borderMerge`, and
+ *   `continuesParagraph` (§17.6.4 remainder re-wrap: this fragment's partition is a
+ *   paragraph CONTINUATION even when it covers the whole re-measured partition, so
+ *   first-slice-only paint work — anchor drawing, the top border edge — must not run).
  */
 export function paintParagraphFragment(
   placed: PlacedFragment,
@@ -48,6 +51,7 @@ export function paintParagraphFragment(
   options: {
     suppressSpaceBefore?: boolean;
     borderMerge?: ParaBorderMerge;
+    continuesParagraph?: boolean;
   } = {},
 ): void {
   const fragment = placed.fragment;
@@ -60,11 +64,19 @@ export function paintParagraphFragment(
   // (empty / anchor-only) paragraph — the renderer's empty-mark branch handles it.
   const scale1Lines = measured.lines.map((line) => line.layout);
   // A full-range fragment paints the whole paragraph (no slice); a continuation
-  // fragment paints only its `[lineStart, lineEnd)` window.
+  // fragment paints only its `[lineStart, lineEnd)` window. A RE-WRAPPED remainder
+  // (issue #908) covers its whole re-measured partition yet is still a continuation:
+  // keep the slice object with `continues` so the draw path mirrors the legacy
+  // element-slice semantics exactly (no re-run of first-slice-only work).
+  const continues = options.continuesParagraph === true;
   const lineSlice =
-    fragment.lineStart === 0 && fragment.lineEnd === measured.lines.length
+    fragment.lineStart === 0 && fragment.lineEnd === measured.lines.length && !continues
       ? undefined
-      : { start: fragment.lineStart, end: fragment.lineEnd };
+      : {
+          start: fragment.lineStart,
+          end: fragment.lineEnd,
+          ...(continues ? { continues: true as const } : {}),
+        };
   renderBodyParagraphLines(
     fragment.source,
     state,

--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -643,3 +643,64 @@ describe('table-cell paint byte-identity — fragment table paint (PR 6)', () =>
     expect(r.drawn).toBeGreaterThan(0);
   });
 });
+
+describe('re-wrapped continuation slices (issue #908) — fragment paint parity', () => {
+  it('draws paragraph anchors ONCE for a re-wrapped continuation (fragment === legacy)', async () => {
+    // A §17.6.4 unequal-width split: col0 keeps the wide partition, col1 gets a
+    // RE-MEASURED remainder whose fragment covers its WHOLE partition (lineStart 0,
+    // lineEnd = length). paintParagraphFragment must not degrade that full-range
+    // continuation slice to "no slice": renderParagraph's first-slice-only work
+    // (anchor drawing, §17.3.1.7 top border) would run again in the destination
+    // column. Legacy paint sees the element's `continues` flag; the fragment path
+    // must thread it through. The anchored no-wrap shape's text is the observable:
+    // its fillText must appear exactly once per page in BOTH paint modes.
+    const anchorShape = {
+      type: 'shape',
+      widthPt: 40, heightPt: 10,
+      anchorXPt: 0, anchorYPt: 0,
+      anchorXFromMargin: false, anchorYFromPara: true,
+      anchorXRelativeFrom: 'column', anchorYRelativeFrom: 'paragraph',
+      zOrder: 0, subpaths: [], presetGeometry: 'rect',
+      fill: null, stroke: null,
+      // No wrap: the shape registers no float band, so the width-mismatch swap
+      // fires (a wrap float would scope the swap out — asserted below).
+      wrapMode: 'none', wrapSide: 'bothSides',
+      distTop: 0, distBottom: 0, distLeft: 0, distRight: 0,
+      textBlocks: [{
+        text: 'ANCHORTEXT', fontSizePt: 8, bold: false, italic: false,
+        color: '000000', fontFamily: 'Times New Roman', alignment: 'left',
+      }],
+      textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+    };
+    const p = para('あ'.repeat(28), { defaultFontSize: 20 });
+    (p.runs as unknown[]).unshift(anchorShape);
+    (p.runs[1] as { fontSize: number }).fontSize = 20;
+    const model = doc([p as unknown as BodyElement], 60);
+    (model.section as SectionProps).columns = {
+      count: 2, spacePt: 32, equalWidth: false, sep: false,
+      cols: [{ widthPt: 100, spacePt: 32 }, { widthPt: 48, spacePt: 0 }],
+    } as SectionProps['columns'];
+
+    const pages = paginateDocument(model);
+    // Non-vacuity: the swap really fired — a col-1 slice carries the remainder
+    // partition marker (if a float had registered, the swap would be scoped out
+    // and this test would be exercising nothing).
+    const slices = pages.flat().filter((el) => el.type === 'paragraph') as
+      (PaginatedBodyElement & { lineSlice?: { start: number; end: number; continues?: boolean } })[];
+    expect(slices.some((s) => s.lineSlice?.continues === true)).toBe(true);
+
+    const production = await renderVariant(model, pages, { fragmentPaint: true, reuse: true });
+    const legacy = await renderVariant(model, pages, { fragmentPaint: false, reuse: true });
+    expect(production.perPage.length).toBe(legacy.perPage.length);
+    for (let pg = 0; pg < production.perPage.length; pg++) {
+      // Byte-identical streams — in particular the anchor's text appears the same
+      // number of times (once) in both modes.
+      const anchorDrawsProduction = production.perPage[pg].filter((c) => c.text === 'ANCHORTEXT').length;
+      const anchorDrawsLegacy = legacy.perPage[pg].filter((c) => c.text === 'ANCHORTEXT').length;
+      expect(anchorDrawsProduction).toBe(anchorDrawsLegacy);
+      expect(production.perPage[pg]).toEqual(legacy.perPage[pg]);
+    }
+    // The anchor really painted (observable non-vacuity).
+    expect(legacy.perPage.flat().some((c) => c.text === 'ANCHORTEXT')).toBe(true);
+  });
+});

--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -645,6 +645,45 @@ describe('table-cell paint byte-identity — fragment table paint (PR 6)', () =>
 });
 
 describe('re-wrapped continuation slices (issue #908) — fragment paint parity', () => {
+  it.each([
+    ['fragment paint', true],
+    ['legacy paint', false],
+  ])('does not re-apply first-line indent while painting a continuation (%s)', async (_label, fragmentPaint) => {
+    const p = para('あ'.repeat(28), { defaultFontSize: 20, indentFirst: 20 });
+    (p.runs[0] as { fontSize: number }).fontSize = 20;
+    const model = doc([p as unknown as BodyElement], 60);
+    (model.section as SectionProps).columns = {
+      count: 2, spacePt: 32, equalWidth: false, sep: false,
+      cols: [{ widthPt: 100, spacePt: 32 }, { widthPt: 48, spacePt: 0 }],
+    } as SectionProps['columns'];
+
+    const pages = paginateDocument(model);
+    const continuationPage = pages.findIndex((page) => page.some((el) => {
+      const slice = el as PaginatedBodyElement & {
+        lineSlice?: { start: number; end: number; continues?: boolean };
+      };
+      return slice.colIndex === 1 && slice.lineSlice?.continues === true;
+    }));
+    expect(continuationPage).toBeGreaterThanOrEqual(0);
+
+    const painted = await renderVariant(model, pages, { fragmentPaint, reuse: true });
+    const col1Origin = model.section.marginLeft + 100 + 32;
+    const lineCalls = painted.perPage[continuationPage]
+      .filter((call) => call.op === 'fill' && call.text.includes('あ') && call.x >= col1Origin);
+    const callsByY = new Map<number, Call[]>();
+    for (const call of lineCalls) {
+      const calls = callsByY.get(call.y);
+      if (calls) calls.push(call);
+      else callsByY.set(call.y, [call]);
+    }
+    const lineStarts = [...callsByY.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([, calls]) => Math.min(...calls.map((call) => call.x)));
+
+    expect(lineStarts.length).toBeGreaterThan(1);
+    expect(lineStarts.slice(1).every((x) => x === lineStarts[0])).toBe(true);
+  });
+
   it('draws paragraph anchors ONCE for a re-wrapped continuation (fragment === legacy)', async () => {
     // A §17.6.4 unequal-width split: col0 keeps the wide partition, col1 gets a
     // RE-MEASURED remainder whose fragment covers its WHOLE partition (lineStart 0,
@@ -698,9 +737,54 @@ describe('re-wrapped continuation slices (issue #908) — fragment paint parity'
       const anchorDrawsProduction = production.perPage[pg].filter((c) => c.text === 'ANCHORTEXT').length;
       const anchorDrawsLegacy = legacy.perPage[pg].filter((c) => c.text === 'ANCHORTEXT').length;
       expect(anchorDrawsProduction).toBe(anchorDrawsLegacy);
+      expect(anchorDrawsProduction).toBe(1);
+      expect(anchorDrawsLegacy).toBe(1);
       expect(production.perPage[pg]).toEqual(legacy.perPage[pg]);
     }
     // The anchor really painted (observable non-vacuity).
     expect(legacy.perPage.flat().some((c) => c.text === 'ANCHORTEXT')).toBe(true);
+  });
+
+  it('draws behindDoc paragraph anchors once for a re-wrapped continuation', async () => {
+    const anchorShape = {
+      type: 'shape',
+      widthPt: 40, heightPt: 10,
+      anchorXPt: 0, anchorYPt: 0,
+      anchorXFromMargin: false, anchorYFromPara: true,
+      anchorXRelativeFrom: 'column', anchorYRelativeFrom: 'paragraph',
+      zOrder: 0, behindDoc: true,
+      subpaths: [], presetGeometry: 'rect',
+      fill: null, stroke: null,
+      wrapMode: 'none', wrapSide: 'bothSides',
+      distTop: 0, distBottom: 0, distLeft: 0, distRight: 0,
+      textBlocks: [{
+        text: 'ANCHORTEXT', fontSizePt: 8, bold: false, italic: false,
+        color: '000000', fontFamily: 'Times New Roman', alignment: 'left',
+      }],
+      textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+    };
+    const p = para('あ'.repeat(28), { defaultFontSize: 20 });
+    (p.runs as unknown[]).unshift(anchorShape);
+    (p.runs[1] as { fontSize: number }).fontSize = 20;
+    const model = doc([p as unknown as BodyElement], 60);
+    (model.section as SectionProps).columns = {
+      count: 2, spacePt: 32, equalWidth: false, sep: false,
+      cols: [{ widthPt: 100, spacePt: 32 }, { widthPt: 48, spacePt: 0 }],
+    } as SectionProps['columns'];
+
+    const pages = paginateDocument(model);
+    const slices = pages.flat().filter((el) => el.type === 'paragraph') as
+      (PaginatedBodyElement & { lineSlice?: { start: number; end: number; continues?: boolean } })[];
+    expect(slices.some((s) => s.lineSlice?.continues === true)).toBe(true);
+
+    const production = await renderVariant(model, pages, { fragmentPaint: true, reuse: true });
+    const legacy = await renderVariant(model, pages, { fragmentPaint: false, reuse: true });
+    expect(production.perPage.length).toBe(legacy.perPage.length);
+    for (let pg = 0; pg < production.perPage.length; pg++) {
+      const anchorDrawsProduction = production.perPage[pg].filter((c) => c.text === 'ANCHORTEXT').length;
+      const anchorDrawsLegacy = legacy.perPage[pg].filter((c) => c.text === 'ANCHORTEXT').length;
+      expect.soft(anchorDrawsProduction).toBe(1);
+      expect.soft(anchorDrawsLegacy).toBe(1);
+    }
   });
 });

--- a/packages/docx/src/line-boundary.test.ts
+++ b/packages/docx/src/line-boundary.test.ts
@@ -56,7 +56,10 @@ interface Fixture {
   readonly segs: () => LayoutSeg[];
   readonly tabStops?: TabStop[];
   readonly kinsoku?: KinsokuRules;
+  readonly baseRtl?: boolean;
   readonly hasTrailingBreak?: boolean;
+  readonly expectedMidSegmentIndex?: number;
+  readonly fitTextRegion?: { readonly firstSegIndex: number; readonly lastSegIndex: number };
 }
 
 const crossRunKinsoku: KinsokuRules = {
@@ -75,6 +78,7 @@ const fixtures: Fixture[] = [
     name: 'CJK per-glyph split',
     width: 25,
     segs: () => [textSeg('あ'.repeat(18))],
+    expectedMidSegmentIndex: 0,
   },
   {
     name: 'kinsoku cross-run retraction',
@@ -106,6 +110,7 @@ const fixtures: Fixture[] = [
     name: 'over-long Latin overflow-wrap',
     width: 20,
     segs: () => [textSeg('abcdefghijklmnopqrst')],
+    expectedMidSegmentIndex: 0,
   },
   {
     name: 'small-caps glued group',
@@ -118,7 +123,69 @@ const fixtures: Fixture[] = [
       textSeg('words'),
     ],
   },
+  {
+    name: 'bidi RTL ordinary tab',
+    width: 70,
+    tabStops: [{ pos: 50, alignment: 'left', leader: 'dot' }],
+    baseRtl: true,
+    segs: () => [
+      textSeg('פתיחה', { rtl: true }),
+      lineBreak(),
+      textSeg('כותרת ', { rtl: true }),
+      { isTab: true, fontSize: 10, measuredWidth: 0 },
+      textSeg('12', { rtl: true }),
+      lineBreak(),
+      textSeg('סיום', { rtl: true }),
+    ],
+  },
+  {
+    name: 'atomic fitText region',
+    width: 30,
+    fitTextRegion: { firstSegIndex: 1, lastSegIndex: 2 },
+    segs: () => [
+      textSeg('lead '),
+      textSeg('ab', {
+        fitTextRegionIndex: 7,
+        fitTextRegionStart: true,
+      }),
+      textSeg('cd', {
+        fitTextRegionIndex: 7,
+        fitTextRegionEnd: true,
+      }),
+      textSeg(' tail tail tail'),
+    ],
+  },
+  {
+    name: 'ruby ascent reserve',
+    width: 30,
+    segs: () => [
+      textSeg('lead '),
+      textSeg('ruby', { ruby: { text: 'ルビ', fontSizePt: 8 } }),
+      textSeg(' tail tail tail'),
+    ],
+  },
+  {
+    name: 'astral CJK split',
+    width: 12,
+    segs: () => [textSeg('𠀋'.repeat(12))],
+    expectedMidSegmentIndex: 0,
+  },
+  {
+    name: 'Latin lead with glued breakable CJK follower',
+    width: 30,
+    segs: () => [
+      textSeg('intro'),
+      lineBreak(),
+      textSeg('Roman'),
+      textSeg('、あいうえお', { joinPrev: true }),
+      textSeg(' tail'),
+    ],
+    expectedMidSegmentIndex: 3,
+  },
 ];
+
+// Vertical text does not enter this horizontal breaking loop, and state-sensitive
+// fields are resolved before LayoutSegs exist, so neither belongs in this layer's corpus.
 
 function layoutFixture(fixture: Fixture, startBoundary?: LineBoundary): LayoutLine[] {
   const segs = fixture.segs().map((seg) => ({ ...seg })) as LayoutSeg[];
@@ -136,9 +203,39 @@ function layoutFixture(fixture: Fixture, startBoundary?: LineBoundary): LayoutLi
     0,
     36,
     fixture.width,
-    false,
+    fixture.baseRtl ?? false,
     startBoundary,
   );
+}
+
+function lineStructure(lines: LayoutLine[]) {
+  return lines.map((line) => ({
+    segments: line.segments.map((segment) => {
+      if ('text' in segment) {
+        return { kind: 'text' as const, text: segment.text, measuredWidth: segment.measuredWidth };
+      }
+      if ('isTab' in segment) {
+        return {
+          kind: 'tab' as const,
+          measuredWidth: segment.measuredWidth,
+          leader: segment.leader,
+        };
+      }
+      if ('imagePath' in segment) {
+        return { kind: 'image' as const, measuredWidth: segment.measuredWidth };
+      }
+      return { kind: 'math' as const, measuredWidth: segment.measuredWidth };
+    }),
+    height: line.height,
+    ascent: line.ascent,
+    descent: line.descent,
+    intendedSingle: line.intendedSingle,
+    xOffset: line.xOffset,
+    availWidth: line.availWidth,
+    hasRuby: line.hasRuby === true,
+    endsWithBreak: line.endsWithBreak === true,
+    consumedEnd: line.consumedEnd,
+  }));
 }
 
 function textSequence(lines: LayoutLine[]): string[] {
@@ -156,15 +253,45 @@ describe('layoutLines consumed-content boundaries', () => {
   for (const fixture of fixtures) {
     it(`reproduces every content-bearing suffix for ${fixture.name}`, () => {
       const lines = layoutFixture(fixture);
-      expect(lines.length).toBeGreaterThan(0);
+      expect(lines.length).toBeGreaterThanOrEqual(2);
+      if (fixture.expectedMidSegmentIndex !== undefined) {
+        const original = fixture.segs();
+        expect(lines.some((line) => {
+          const boundary = line.consumedEnd;
+          if (
+            !boundary
+            || boundary.segIndex !== fixture.expectedMidSegmentIndex
+            || boundary.charOffset <= 0
+          ) return false;
+          const segment = original[boundary.segIndex];
+          return segment !== undefined
+            && 'text' in segment
+            && boundary.charOffset < segment.text.length;
+        })).toBe(true);
+      }
+      if (fixture.fitTextRegion) {
+        const { firstSegIndex, lastSegIndex } = fixture.fitTextRegion;
+        expect(lines.every((line) => {
+          const segIndex = line.consumedEnd?.segIndex;
+          return segIndex === undefined || segIndex <= firstSegIndex || segIndex > lastSegIndex;
+        })).toBe(true);
+      }
+      if (fixture.baseRtl) {
+        expect(lines.some((line) => line.segments.some((segment) =>
+          'isTab' in segment && segment.measuredWidth > 0,
+        ))).toBe(true);
+      }
+      if (fixture.name === 'ruby ascent reserve') {
+        expect(lines.some((line) => line.hasRuby === true)).toBe(true);
+      }
 
       for (let i = 0; i < lines.length; i++) {
         const boundary = lines[i].consumedEnd;
         expect(boundary).toBeDefined();
         if (!boundary) continue;
 
-        const expected = textSequence(lines.slice(i + 1));
-        const suffix = textSequence(layoutFixture(fixture, boundary));
+        const expected = lineStructure(lines.slice(i + 1));
+        const suffix = lineStructure(layoutFixture(fixture, boundary));
 
         // A trailing manual break creates a final zero-content line. Its
         // predecessor and that empty line both necessarily end at the same
@@ -172,7 +299,7 @@ describe('layoutLines consumed-content boundaries', () => {
         // states. The mid-stream boundary below still proves that suffix layout
         // preserves and re-emits the trailing empty line.
         if (fixture.hasTrailingBreak && isEnd(boundary, fixture.segs().length) && expected.length > 0) {
-          expect(expected).toEqual(['']);
+          expect(expected[0].segments).toEqual([]);
           expect(suffix).toEqual([]);
           continue;
         }
@@ -203,6 +330,7 @@ describe('layoutLines consumed-content boundaries', () => {
   for (const fixture of fixtures) {
     it(`records monotonic boundaries ending at END for ${fixture.name}`, () => {
       const segCount = fixture.segs().length;
+      const original = fixture.segs();
       const boundaries = layoutFixture(fixture).map((line) => line.consumedEnd);
       expect(boundaries.every((boundary) => boundary !== undefined)).toBe(true);
 
@@ -213,6 +341,17 @@ describe('layoutLines consumed-content boundaries', () => {
           current.segIndex > previous.segIndex
             || (current.segIndex === previous.segIndex && current.charOffset >= previous.charOffset),
         ).toBe(true);
+      }
+      for (const boundary of boundaries) {
+        if (!boundary) continue;
+        const segment = original[boundary.segIndex];
+        if (!segment || !('text' in segment)) continue;
+        const offset = boundary.charOffset;
+        const previous = segment.text[offset - 1] ?? '';
+        const current = segment.text[offset] ?? '';
+        expect(
+          /[\uD800-\uDBFF]/.test(previous) && /[\uDC00-\uDFFF]/.test(current),
+        ).toBe(false);
       }
       expect(boundaries.at(-1)).toEqual({ segIndex: segCount, charOffset: 0 });
     });

--- a/packages/docx/src/line-boundary.test.ts
+++ b/packages/docx/src/line-boundary.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_KINSOKU_RULES,
+  type KinsokuRules,
+} from '@silurus/ooxml-core';
+import {
+  layoutLines,
+  type LayoutLine,
+  type LayoutSeg,
+  type LayoutTextSeg,
+  type LineBoundary,
+} from './line-layout.js';
+import type { TabStop } from './types.js';
+
+function makeLinearCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const fontSize = (): number => Number.parseFloat(/([\d.]+)px/.exec(font)?.[1] ?? '10');
+  return {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    letterSpacing: '0px',
+    measureText: (text: string) => {
+      const size = fontSize();
+      return {
+        width: [...text].length * size * 0.5,
+        fontBoundingBoxAscent: size * 0.8,
+        fontBoundingBoxDescent: size * 0.2,
+        actualBoundingBoxAscent: size * 0.8,
+        actualBoundingBoxDescent: size * 0.2,
+      } as TextMetrics;
+    },
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function textSeg(text: string, extra: Partial<LayoutTextSeg> = {}): LayoutTextSeg {
+  return {
+    text,
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    fontSize: 10,
+    color: null,
+    fontFamily: 'Times New Roman',
+    vertAlign: null,
+    measuredWidth: 0,
+    ...extra,
+  };
+}
+
+const lineBreak = (): LayoutSeg => ({ lineBreak: true, fontSize: 10, measuredWidth: 0 });
+
+interface Fixture {
+  readonly name: string;
+  readonly width: number;
+  readonly segs: () => LayoutSeg[];
+  readonly tabStops?: TabStop[];
+  readonly kinsoku?: KinsokuRules;
+  readonly hasTrailingBreak?: boolean;
+}
+
+const crossRunKinsoku: KinsokuRules = {
+  enabled: true,
+  lineStartForbidden: new Set(['。'.codePointAt(0)!]),
+  lineEndForbidden: new Set(),
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'plain Latin words',
+    width: 35,
+    segs: () => ['alpha ', 'bravo ', 'charlie ', 'delta ', 'echo ', 'foxtrot '].map((text) => textSeg(text)),
+  },
+  {
+    name: 'CJK per-glyph split',
+    width: 25,
+    segs: () => [textSeg('あ'.repeat(18))],
+  },
+  {
+    name: 'kinsoku cross-run retraction',
+    width: 20,
+    segs: () => [textSeg('あいうえ'), textSeg('。かきくけこさしす')],
+    kinsoku: crossRunKinsoku,
+  },
+  {
+    name: 'manual breaks including a trailing break',
+    width: 200,
+    segs: () => [textSeg('first'), lineBreak(), textSeg('second'), lineBreak()],
+    hasTrailingBreak: true,
+  },
+  {
+    name: 'right-aligned custom tab with committed trailing text',
+    width: 60,
+    tabStops: [{ pos: 40, alignment: 'right', leader: 'dot' }],
+    segs: () => [
+      textSeg('name'),
+      { isTab: true, fontSize: 10, measuredWidth: 0 },
+      textSeg('99'),
+      lineBreak(),
+      textSeg('tail '),
+      textSeg('words '),
+      textSeg('wrap'),
+    ],
+  },
+  {
+    name: 'over-long Latin overflow-wrap',
+    width: 20,
+    segs: () => [textSeg('abcdefghijklmnopqrst')],
+  },
+  {
+    name: 'small-caps glued group',
+    width: 55,
+    segs: () => [
+      textSeg('Lead '),
+      textSeg('I', { smallCaps: true }),
+      textSeg('NTRODUCTION', { smallCaps: true, joinPrev: true }),
+      textSeg(' tail '),
+      textSeg('words'),
+    ],
+  },
+];
+
+function layoutFixture(fixture: Fixture, startBoundary?: LineBoundary): LayoutLine[] {
+  const segs = fixture.segs().map((seg) => ({ ...seg })) as LayoutSeg[];
+  return layoutLines(
+    makeLinearCtx(),
+    segs,
+    fixture.width,
+    0,
+    1,
+    fixture.tabStops,
+    undefined,
+    {},
+    0,
+    fixture.kinsoku ?? DEFAULT_KINSOKU_RULES,
+    0,
+    36,
+    fixture.width,
+    false,
+    startBoundary,
+  );
+}
+
+function textSequence(lines: LayoutLine[]): string[] {
+  return lines.map((line) => line.segments
+    .filter((segment): segment is LayoutTextSeg => 'text' in segment)
+    .map((segment) => segment.text)
+    .join(''));
+}
+
+function isEnd(boundary: LineBoundary, segCount: number): boolean {
+  return boundary.segIndex === segCount && boundary.charOffset === 0;
+}
+
+describe('layoutLines consumed-content boundaries', () => {
+  for (const fixture of fixtures) {
+    it(`reproduces every content-bearing suffix for ${fixture.name}`, () => {
+      const lines = layoutFixture(fixture);
+      expect(lines.length).toBeGreaterThan(0);
+
+      for (let i = 0; i < lines.length; i++) {
+        const boundary = lines[i].consumedEnd;
+        expect(boundary).toBeDefined();
+        if (!boundary) continue;
+
+        const expected = textSequence(lines.slice(i + 1));
+        const suffix = textSequence(layoutFixture(fixture, boundary));
+
+        // A trailing manual break creates a final zero-content line. Its
+        // predecessor and that empty line both necessarily end at the same
+        // two-field END coordinate, so END cannot distinguish those two entry
+        // states. The mid-stream boundary below still proves that suffix layout
+        // preserves and re-emits the trailing empty line.
+        if (fixture.hasTrailingBreak && isEnd(boundary, fixture.segs().length) && expected.length > 0) {
+          expect(expected).toEqual(['']);
+          expect(suffix).toEqual([]);
+          continue;
+        }
+        expect(suffix).toEqual(expected);
+      }
+    });
+  }
+
+  it('places a cross-run kinsoku boundary inside the retracted source segment', () => {
+    const fixture = fixtures.find((candidate) => candidate.name === 'kinsoku cross-run retraction')!;
+    const lines = layoutFixture(fixture);
+
+    expect(lines.some((line) =>
+      line.consumedEnd?.segIndex === 0 && line.consumedEnd.charOffset > 0,
+    )).toBe(true);
+  });
+
+  it('re-emits a trailing-break empty line from an earlier original-stream boundary', () => {
+    const fixture = fixtures.find((candidate) => candidate.hasTrailingBreak)!;
+    const lines = layoutFixture(fixture);
+    const boundary = lines[0].consumedEnd;
+
+    expect(boundary).toBeDefined();
+    expect(textSequence(lines)).toEqual(['first', 'second', '']);
+    expect(textSequence(layoutFixture(fixture, boundary))).toEqual(['second', '']);
+  });
+
+  for (const fixture of fixtures) {
+    it(`records monotonic boundaries ending at END for ${fixture.name}`, () => {
+      const segCount = fixture.segs().length;
+      const boundaries = layoutFixture(fixture).map((line) => line.consumedEnd);
+      expect(boundaries.every((boundary) => boundary !== undefined)).toBe(true);
+
+      for (let i = 1; i < boundaries.length; i++) {
+        const previous = boundaries[i - 1]!;
+        const current = boundaries[i]!;
+        expect(
+          current.segIndex > previous.segIndex
+            || (current.segIndex === previous.segIndex && current.charOffset >= previous.charOffset),
+        ).toBe(true);
+      }
+      expect(boundaries.at(-1)).toEqual({ segIndex: segCount, charOffset: 0 });
+    });
+  }
+});

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -47,7 +47,16 @@ import {
   wordMinLineStartPx,
 } from './float-layout.js';
 
-export interface LayoutTextSeg {
+export interface LineBoundary {
+  segIndex: number;
+  charOffset: number;
+}
+
+interface LayoutSegSource {
+  src?: LineBoundary;
+}
+
+export interface LayoutTextSeg extends LayoutSegSource {
   text: string;
   bold: boolean;
   italic: boolean;
@@ -173,7 +182,7 @@ export interface LayoutTextSeg {
  * Horizontal tab. Width is resolved during layout against paragraph tab stops
  * (or the default 36pt interval if no explicit stop is configured).
  */
-export interface LayoutTabSeg {
+export interface LayoutTabSeg extends LayoutSegSource {
   isTab: true;
   fontSize: number;  // pt — for line-height purposes
   measuredWidth: number;
@@ -194,7 +203,7 @@ export interface LayoutTabSeg {
   };
 }
 
-export interface LayoutImageSeg {
+export interface LayoutImageSeg extends LayoutSegSource {
   /** Zip path of the blip — also the `'imagePath' in seg` discriminant that
    *  distinguishes an image segment from text/math/tab segments. */
   imagePath: string;
@@ -236,7 +245,7 @@ export interface LayoutImageSeg {
 }
 
 /** An inline OMML equation. Measured + drawn via the core math engine. */
-export interface LayoutMathSeg {
+export interface LayoutMathSeg extends LayoutSegSource {
   mathNodes: import('@silurus/ooxml-core').MathNode[];
   display: boolean;
   fontSize: number;  // pt
@@ -254,7 +263,7 @@ export interface LayoutMathSeg {
 }
 
 /** Sentinel that forces a new line when encountered in layoutLines. */
-export interface LayoutLineBreak {
+export interface LayoutLineBreak extends LayoutSegSource {
   lineBreak: true;
   fontSize: number;  // pt — used to set line height on empty lines
   measuredWidth: 0;
@@ -285,6 +294,13 @@ export interface LayoutLine {
    *  the end of a logical line and must be left-aligned, not stretched — exactly
    *  like the paragraph's final line (§17.18.44). */
   endsWithBreak?: boolean;
+  /** Issue #908 — the consumed-content END boundary of this line in the ORIGINAL
+   *  `segs` stream of the layoutLines call that produced it (see LineBoundary).
+   *  Break-aware: a manual-break-terminated line consumes its sentinel. Laying out
+   *  the suffix from this boundary (same width, firstIndent 0) reproduces the
+   *  following lines exactly; at a different width it re-wraps — the remainder
+   *  re-measure seam. */
+  consumedEnd?: LineBoundary;
 }
 
 /** Additional context passed to layoutLines so it can honor floats on the current page. */
@@ -2207,6 +2223,7 @@ export function layoutLines(
   // tabs do not trigger the LTR right/center/overflow wrap paths. Default false
   // ⇒ the LTR tab paths run unchanged (byte-identical output).
   baseRtl = false,
+  startBoundary?: LineBoundary,
 ): LayoutLine[] {
   const lines: LayoutLine[] = [];
   let currentLine: (LayoutTextSeg | LayoutImageSeg | LayoutMathSeg | LayoutTabSeg)[] = [];
@@ -2349,7 +2366,11 @@ export function layoutLines(
   };
 
   let lineHasRuby = false;
-  const flush = (forceHeight?: number, brTerminated = false) => {
+  const flush = (
+    forceHeight?: number,
+    brTerminated = false,
+    nextStart?: LineBoundary,
+  ) => {
     applyBidiTabs();
     const h = forceHeight !== undefined ? forceHeight : (lineHeight || 10);
     // If the line has no measured content (empty/line-break line), synthesize
@@ -2369,6 +2390,7 @@ export function layoutLines(
       topY: wrapCtx ? currentLineTopY : undefined,
       hasRuby: lineHasRuby,
       endsWithBreak: brTerminated,
+      consumedEnd: nextStart ?? queue[0]?.src ?? endBoundary,
     });
     if (wrapCtx) {
       currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle);
@@ -2461,11 +2483,45 @@ export function layoutLines(
     return m;
   };
 
+  const endBoundary: LineBoundary = { segIndex: segs.length, charOffset: 0 };
+  const sourcedSegs = segs.map((seg, segIndex) => {
+    seg.src = { segIndex, charOffset: 0 };
+    return seg;
+  });
+  let queue: LayoutSeg[];
+  if (!startBoundary) {
+    queue = sourcedSegs;
+  } else if (startBoundary.segIndex >= sourcedSegs.length) {
+    queue = [];
+  } else {
+    const first = sourcedSegs[startBoundary.segIndex];
+    if (startBoundary.charOffset > 0) {
+      if (!('text' in first) || startBoundary.charOffset > first.text.length) {
+        queue = [];
+      } else {
+        const text = first.text.slice(startBoundary.charOffset);
+        queue = text
+          ? [
+              {
+                ...first,
+                text,
+                measuredWidth: 0,
+                src: { ...startBoundary },
+              },
+              ...sourcedSegs.slice(startBoundary.segIndex + 1),
+            ]
+          : sourcedSegs.slice(startBoundary.segIndex + 1);
+      }
+    } else {
+      queue = sourcedSegs.slice(startBoundary.segIndex);
+    }
+  }
+
   // Resolve §17.3.2.14 from RAW natural advances at this exact layout scale.
   // The resulting per-gap is folded into segAdvanceWidth below, so the line
   // breaker and paint pen use one width authority. Cached w:spacing is ignored.
   resolveFitTextSegments(
-    segs.filter((seg): seg is LayoutTextSeg => 'text' in seg),
+    queue.filter((seg): seg is LayoutTextSeg => 'text' in seg),
     scale,
     (segment) => measureText(segment).width,
   );
@@ -2500,9 +2556,6 @@ export function layoutLines(
     if ('lineBreak' in q) return 0;
     return segAdvance(q);
   };
-
-  // Use an explicit queue so CJK split-tails can be re-queued
-  const queue: LayoutSeg[] = [...segs];
 
   // A `<w:br/>` always starts a new line (§17.3.3.1) — when it is the LAST
   // content of the paragraph that new line is an EMPTY line that still
@@ -2586,7 +2639,7 @@ export function layoutLines(
         // content) to a fresh line — unless the line is empty (nowhere to wrap).
         if (tabW <= 0) {
           if (currentLine.length > 0) {
-            flush();
+            flush(undefined, false, seg.src);
             queue.unshift(seg);
             continue;
           }
@@ -2682,12 +2735,12 @@ export function layoutLines(
       if (stop) seg.leader = stop.leader;
       // Clamp to avoid negative widths; if tab would overflow the line, wrap instead
       if (tabWidth <= 0) {
-        flush();
+        flush(undefined, false, seg.src);
         queue.unshift(seg);
         continue;
       }
       if (currentWidth + tabWidth > availW() && currentLine.length > 0) {
-        flush();
+        flush(undefined, false, seg.src);
         queue.unshift(seg);
         continue;
       }
@@ -2703,7 +2756,9 @@ export function layoutLines(
       const h = seg.heightPt;
       const asc = seg.heightPt * scale;
       seg.measuredWidth = w;
-      if (currentLine.length > 0 && currentWidth + w > availW()) flush();
+      if (currentLine.length > 0 && currentWidth + w > availW()) {
+        flush(undefined, false, seg.src);
+      }
       addToLine(seg, w, h, asc, 0);
       continue;
     }
@@ -2721,7 +2776,9 @@ export function layoutLines(
         seg.measuredWidth = w;
         seg.mathAscent = asc;
         seg.mathDescent = desc;
-        if (currentLine.length > 0 && currentWidth + w > availW()) flush();
+        if (currentLine.length > 0 && currentWidth + w > availW()) {
+          flush(undefined, false, seg.src);
+        }
         addToLine(seg, w, seg.fontSize, Math.max(asc, emPx * 0.8), Math.max(desc, emPx * 0.2));
         continue;
       }
@@ -2742,7 +2799,9 @@ export function layoutLines(
       // does (tall math — fractions, big operators — keeps its larger ink box).
       const lineAsc = Math.max(asc, emPx * 0.8);
       const lineDesc = Math.max(desc, emPx * 0.2);
-      if (currentLine.length > 0 && currentWidth + w > availW()) flush();
+      if (currentLine.length > 0 && currentWidth + w > availW()) {
+        flush(undefined, false, seg.src);
+      }
       addToLine(seg, w, seg.fontSize, lineAsc, lineDesc);
       continue;
     }
@@ -2806,7 +2865,9 @@ export function layoutLines(
           if (!('text' in queued) || queued.fitTextRegionIndex !== s.fitTextRegionIndex) break;
           regionWidth += segAdvance(queued);
         }
-        if (currentLine.length > 0 && currentWidth + regionWidth > availW()) flush();
+        if (currentLine.length > 0 && currentWidth + regionWidth > availW()) {
+          flush(undefined, false, s.src);
+        }
       }
       s.measuredWidth = w;
       addToLine(s, w, h, asc, desc);
@@ -2887,7 +2948,9 @@ export function layoutLines(
         const ft = f.text.replace(/ +$/, '');
         groupTrail = f.text.endsWith(' ') ? fw - strAdvance(f, ft) : 0;
       }
-      if (currentWidth + (groupW - groupTrail) > availW() + shrinkBudget) flush();
+      if (currentWidth + (groupW - groupTrail) > availW() + shrinkBudget) {
+        flush(undefined, false, s.src);
+      }
     }
 
     if (currentWidth + wForFit <= availW() + shrinkBudget) {
@@ -2920,7 +2983,17 @@ export function layoutLines(
         const headSeg: LayoutTextSeg = { ...s, text: prefix, measuredWidth: pw };
         addToLine(headSeg, pw, h, asc, desc);
         const tail = s.text.slice(prefix.length);
-        if (tail) queue.unshift({ ...s, text: tail, measuredWidth: 0 });
+        if (tail) {
+          queue.unshift({
+            ...s,
+            text: tail,
+            measuredWidth: 0,
+            src: {
+              segIndex: s.src!.segIndex,
+              charOffset: s.src!.charOffset + prefix.length,
+            },
+          });
+        }
       } else if (currentLine.length > 0) {
         // No prefix of `s` fits. If `s` would lead the next line with a 行頭禁則
         // char, kinsokuAdjustedSplit can't fix it from within `s` (the offending
@@ -2939,7 +3012,15 @@ export function layoutLines(
           if (k > 0) {
             const headText = chars.slice(0, chars.length - k).join('');
             const tailText = chars.slice(chars.length - k).join('');
-            retracted = { ...lastText, text: tailText, measuredWidth: strAdvance(lastText, tailText) };
+            retracted = {
+              ...lastText,
+              text: tailText,
+              measuredWidth: strAdvance(lastText, tailText),
+              src: {
+                segIndex: lastText.src!.segIndex,
+                charOffset: lastText.src!.charOffset + headText.length,
+              },
+            };
             if (headText) {
               const headW = strAdvance(lastText, headText);
               currentWidth -= lastText.measuredWidth - headW;
@@ -2953,7 +3034,7 @@ export function layoutLines(
             }
           }
         }
-        flush();
+        flush(undefined, false, retracted?.src ?? s.src);
         queue.unshift(s);
         if (retracted) queue.unshift(retracted);
       } else {
@@ -2964,7 +3045,17 @@ export function layoutLines(
           const headSeg: LayoutTextSeg = { ...s, text: firstChar, measuredWidth: fw };
           addToLine(headSeg, fw, h, asc, desc);
           const tail = s.text.slice(firstChar.length);
-          if (tail) queue.unshift({ ...s, text: tail, measuredWidth: 0 });
+          if (tail) {
+            queue.unshift({
+              ...s,
+              text: tail,
+              measuredWidth: 0,
+              src: {
+                segIndex: s.src!.segIndex,
+                charOffset: s.src!.charOffset + firstChar.length,
+              },
+            });
+          }
         }
       }
     } else if (currentLine.length === 0) {
@@ -2990,7 +3081,15 @@ export function layoutLines(
         const prefix = allChars.slice(0, split).join('');
         const pw = strAdvance(s, prefix);
         addToLine({ ...s, text: prefix, measuredWidth: pw }, pw, h, asc, desc);
-        queue.unshift({ ...s, text: allChars.slice(split).join(''), measuredWidth: 0 });
+        queue.unshift({
+          ...s,
+          text: allChars.slice(split).join(''),
+          measuredWidth: 0,
+          src: {
+            segIndex: s.src!.segIndex,
+            charOffset: s.src!.charOffset + prefix.length,
+          },
+        });
       }
     } else {
       // Latin word does not fit on the current (non-empty) line: move it to a fresh
@@ -2998,7 +3097,7 @@ export function layoutLines(
       // whole column — the empty-line branch above breaks it at the character level
       // (overflow-wrap). Re-queueing rather than force-adding is what lets that
       // over-long-word path run instead of letting the word spill the column.
-      flush();
+      flush(undefined, false, s.src);
       queue.unshift(s);
     }
   }

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computePages, computeColumns } from './renderer.js';
+import { bodyFragmentFor, computePages, computeColumns } from './renderer.js';
 import type {
   BodyElement, CellElement, DocParagraph, DocxTextRun, ShapeRun, SectionProps, PaginatedBodyElement, DocTable, DocTableRow,
 } from './types';
@@ -64,11 +64,12 @@ function para(
     keepNext?: boolean;
     spaceBefore?: number;
     spaceAfter?: number;
+    indentFirst?: number;
   } = {},
 ): BodyElement {
   const fontSize = opts.fontSize ?? 20;
   const p: DocParagraph = {
-    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: opts.indentFirst ?? 0,
     spaceBefore: opts.spaceBefore ?? 0, spaceAfter: opts.spaceAfter ?? 0, lineSpacing: null, numbering: null, tabStops: [],
     runs: opts.text ? [textRun(opts.text, fontSize)] : [],
     defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics',
@@ -456,16 +457,14 @@ describe('computePages — shared paragraph measurement migration geometry', () 
   // `lineIdx > 0`) advances into the NARROW column WITHOUT re-wrapping, so the
   // remainder keeps the wide column's line breaks and overflows the narrow column.
   //
-  // GROUNDED RED — OBSERVED failing (2026-07-10): the col1 continuation line is
-  // 100pt wide (col0 geometry) vs. the 48pt column → "expected 100 to be less than
-  // or equal to 48.000001" at the width assertion below. SKIPPED pending
-  // orchestrator adjudication: a spec-faithful remainder re-wrap needs `layoutLines`
-  // to expose per-line consumed-content boundaries (break-aware, in field-resolved
-  // segment-stream coordinates), which the line model does NOT record — see the
-  // "Escape-hatch design analysis" section in .superpowers/sdd/progress.md for the
-  // required seam and why a forced geometric approximation is not acceptable. Remove
-  // `.skip` when the boundary-provenance seam lands.
-  it.skip('re-wraps a paragraph continuation into a narrower unequal-width column', () => {
+  // Fixed by the issue-#908 boundary-provenance seam: `layoutLines` records each
+  // line's consumed-content END boundary (break-aware, in field-resolved segment-
+  // stream coordinates), `measureParagraph` lays out a remainder suffix from such a
+  // boundary (first-line indent suppressed per §17.3.1.12 — a continuation is not a
+  // first line), and `splitParagraphAcrossPages` re-measures the remainder when the
+  // destination placement mismatches the recorded one (same-width continuations keep
+  // the exact single-measurement path).
+  it('re-wraps a paragraph continuation into a narrower unequal-width column', () => {
     // col0 = 100pt wide (5 CJK glyphs/line at 20pt), col1 = 48pt wide (2/line).
     // 100 + 12 + 48 = 160 = content width; both bands are 100pt tall (5 lines).
     const unequalColumns = section({
@@ -530,6 +529,154 @@ describe('computePages — shared paragraph measurement migration geometry', () 
     expect(col1Lines.reduce((sum, l) => sum + lineChars(l), 0)).toBe(10);
     for (const s of slices.filter((sl) => sl.colIndex === 1)) {
       expect(s.layoutLinesInputs?.paraW).toBe(48);
+    }
+  });
+
+  type RuntimeLine = { segments: { measuredWidth?: number; text?: string }[] };
+  type RuntimeSlice = PaginatedBodyElement & {
+    lineSlice?: { start: number; end: number; continues?: boolean };
+    layoutLines?: RuntimeLine[];
+    layoutLinesInputs?: { paraW: number };
+  };
+  const paragraphSlices = (pages: PaginatedBodyElement[][]): RuntimeSlice[] =>
+    pages.flat().filter((el) => el.type === 'paragraph') as RuntimeSlice[];
+  const paintedLines = (slice: RuntimeSlice): RuntimeLine[] => {
+    const lines = slice.layoutLines ?? [];
+    return slice.lineSlice
+      ? lines.slice(slice.lineSlice.start, slice.lineSlice.end)
+      : lines;
+  };
+  const lineWidth = (line: RuntimeLine): number =>
+    line.segments.reduce((sum, segment) => sum + (segment.measuredWidth ?? 0), 0);
+  const lineChars = (line: RuntimeLine): number =>
+    line.segments.reduce(
+      (sum, segment) => sum + (segment.text ? [...segment.text].length : 0),
+      0,
+    );
+
+  it('keeps equal-width column continuations on the original line partition', () => {
+    const equalColumns = section({
+      columns: {
+        count: 2,
+        spacePt: 20,
+        equalWidth: true,
+        sep: false,
+        cols: [],
+      },
+    });
+    const sharedWidth = computeColumns(equalColumns)[0].wPt;
+    const pages = computePages(
+      [para({ text: 'あ'.repeat(35), fontSize: 20, widowControl: false })],
+      equalColumns,
+      makeCtx(),
+    );
+    const slices = paragraphSlices(pages);
+    const col1Slices = slices.filter((slice) => slice.colIndex === 1);
+
+    expect(col1Slices.length).toBeGreaterThan(0);
+    expect(col1Slices.every((slice) => (slice.lineSlice?.start ?? 0) > 0)).toBe(true);
+    expect(slices.every((slice) => slice.lineSlice?.continues === undefined)).toBe(true);
+    expect(new Set(slices.map((slice) => slice.layoutLines)).size).toBe(1);
+    expect(slices.every((slice) => slice.layoutLinesInputs?.paraW === sharedWidth)).toBe(true);
+  });
+
+  it('composes remainder boundaries across three unequal-width columns', () => {
+    // 100 + 6 + 48 + 6 + 30 = 190pt, exactly the section content width.
+    const unequalColumns = section({
+      pageWidth: 230,
+      columns: {
+        count: 3,
+        spacePt: 0,
+        equalWidth: false,
+        sep: false,
+        cols: [
+          { widthPt: 100, spacePt: 6 },
+          { widthPt: 48, spacePt: 6 },
+          { widthPt: 30, spacePt: 0 },
+        ],
+      },
+    });
+    const pages = computePages(
+      [para({ text: 'あ'.repeat(40), fontSize: 20, widowControl: false })],
+      unequalColumns,
+      makeCtx(),
+    );
+    const slices = paragraphSlices(pages);
+    const col1Lines = slices.filter((slice) => slice.colIndex === 1).flatMap(paintedLines);
+    const col2Slices = slices.filter((slice) => slice.colIndex === 2);
+    const col2Lines = col2Slices.flatMap(paintedLines);
+
+    expect(col1Lines.length).toBeGreaterThan(0);
+    expect(col2Lines.length).toBeGreaterThan(0);
+    expect(col1Lines.every((line) => lineWidth(line) <= 48 + 1e-6)).toBe(true);
+    expect(col2Lines.every((line) => lineWidth(line) <= 30 + 1e-6)).toBe(true);
+    expect(slices.flatMap(paintedLines).reduce((sum, line) => sum + lineChars(line), 0)).toBe(40);
+    expect(col2Slices.every((slice) => slice.layoutLinesInputs?.paraW === 30)).toBe(true);
+  });
+
+  it('does not re-apply first-line indent when re-wrapping a continuation', () => {
+    const unequalColumns = section({
+      columns: {
+        count: 2,
+        spacePt: 0,
+        equalWidth: false,
+        sep: false,
+        cols: [
+          { widthPt: 100, spacePt: 12 },
+          { widthPt: 48, spacePt: 0 },
+        ],
+      },
+    });
+    const pages = computePages(
+      [para({
+        text: 'あ'.repeat(35),
+        fontSize: 20,
+        widowControl: false,
+        indentFirst: 20,
+      })],
+      unequalColumns,
+      makeCtx(),
+    );
+    const col1Lines = paragraphSlices(pages)
+      .filter((slice) => slice.colIndex === 1)
+      .flatMap(paintedLines);
+    const glyphCounts = col1Lines.map(lineChars);
+
+    expect(glyphCounts.length).toBeGreaterThan(1);
+    expect(glyphCounts.every((count) => count === glyphCounts[0])).toBe(true);
+    expect(col1Lines.every((line) => lineWidth(line) <= 48 + 1e-6)).toBe(true);
+  });
+
+  it('does not re-charge leading spacing on a re-wrapped continuation', () => {
+    const unequalColumns = section({
+      columns: {
+        count: 2,
+        spacePt: 0,
+        equalWidth: false,
+        sep: false,
+        cols: [
+          { widthPt: 100, spacePt: 12 },
+          { widthPt: 48, spacePt: 0 },
+        ],
+      },
+    });
+    const pages = computePages(
+      [para({
+        text: 'あ'.repeat(35),
+        fontSize: 20,
+        widowControl: false,
+        spaceBefore: 30,
+      })],
+      unequalColumns,
+      makeCtx(),
+    );
+    const firstCol1Slice = paragraphSlices(pages).find((slice) => slice.colIndex === 1);
+    const placed = firstCol1Slice ? bodyFragmentFor(firstCol1Slice) : undefined;
+
+    expect(firstCol1Slice?.lineSlice?.continues).toBe(true);
+    expect(placed?.fragment.kind).toBe('paragraph');
+    if (placed?.fragment.kind === 'paragraph') {
+      expect(placed.fragment.leadingSpacePt).toBe(0);
     }
   });
 });

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -532,6 +532,77 @@ describe('computePages — shared paragraph measurement migration geometry', () 
     }
   });
 
+  it('keeps state-sensitive continuations on the original partition', () => {
+    const unequalColumns = section({
+      columns: {
+        count: 2,
+        spacePt: 0,
+        equalWidth: false,
+        sep: false,
+        cols: [
+          { widthPt: 100, spacePt: 12 },
+          { widthPt: 48, spacePt: 0 },
+        ],
+      },
+    });
+    const fieldPara = para({
+      text: 'あ'.repeat(35),
+      fontSize: 20,
+      widowControl: false,
+    }) as unknown as DocParagraph;
+    (fieldPara.runs as unknown[]).push({
+      type: 'field', fieldType: 'numPages', instruction: 'NUMPAGES', fallbackText: '?',
+      bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', background: null,
+    });
+
+    const slices = paragraphSlices(computePages(
+      [fieldPara as unknown as BodyElement],
+      unequalColumns,
+      makeCtx(),
+    ));
+    const col1Slices = slices.filter((slice) => slice.colIndex === 1);
+
+    expect(col1Slices.length).toBeGreaterThan(0);
+    expect.soft(slices.every((slice) => slice.lineSlice?.continues === undefined)).toBe(true);
+    expect.soft(col1Slices.every((slice) => (slice.lineSlice?.start ?? 0) > 0)).toBe(true);
+  });
+
+  it('keeps numbered continuations on the original partition', () => {
+    const unequalColumns = section({
+      columns: {
+        count: 2,
+        spacePt: 0,
+        equalWidth: false,
+        sep: false,
+        cols: [
+          { widthPt: 100, spacePt: 12 },
+          { widthPt: 48, spacePt: 0 },
+        ],
+      },
+    });
+    const numberedPara = para({
+      text: 'あ'.repeat(35),
+      fontSize: 20,
+      widowControl: false,
+    }) as unknown as DocParagraph;
+    numberedPara.numbering = {
+      numId: 1, level: 0, format: 'decimal', text: '1.',
+      indentLeft: 0, tab: 18, suff: 'tab', jc: 'left',
+    } as unknown as DocParagraph['numbering'];
+
+    const slices = paragraphSlices(computePages(
+      [numberedPara as unknown as BodyElement],
+      unequalColumns,
+      makeCtx(),
+    ));
+    const col1Slices = slices.filter((slice) => slice.colIndex === 1);
+
+    expect(col1Slices.length).toBeGreaterThan(0);
+    expect.soft(slices.every((slice) => slice.lineSlice?.continues === undefined)).toBe(true);
+    expect.soft(col1Slices.every((slice) => (slice.lineSlice?.start ?? 0) > 0)).toBe(true);
+  });
+
   type RuntimeLine = { segments: { measuredWidth?: number; text?: string }[] };
   type RuntimeSlice = PaginatedBodyElement & {
     lineSlice?: { start: number; end: number; continues?: boolean };

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -131,6 +131,7 @@ describe('measureParagraph', () => {
     expect(result.contentEndYPt).toBe(23);
     expect(result.requestedSpaceBeforePt).toBe(3);
     expect(result.requestedSpaceAfterPt).toBe(4);
+    expect(result.uniformRubyAdvancePt).toBe(0);
     expect(result.placement).toEqual(placement());
   });
 
@@ -245,6 +246,60 @@ describe('measureParagraph', () => {
 
     expect(result.lines.length).toBeGreaterThan(1);
     expect(new Set(result.lines.map((line) => line.advancePt))).toEqual(new Set([30]));
+  });
+
+  it('carries the paragraph-wide ruby advance through continuations', () => {
+    const doc = paragraph({
+      spaceBefore: 0,
+      runs: [
+        { type: 'text', ...textRun('aa', { ruby: { text: 'ruby', fontSizePt: 12 } }) },
+        { type: 'text', ...textRun(' bb cc dd ee ff gg') },
+      ],
+    });
+    const context = layoutContext({
+      lineGrid: { active: true, pitchPt: 10 },
+      spaceBeforePt: 0,
+      hasRuby: true,
+    });
+    const position = placement({ startYPt: 0, availableWidthPt: 18 });
+    const full = measureParagraph(doc, context, position, measurer, environment());
+    const uniformAdvancePt = full.lines[0].advancePt;
+
+    expect(full.lines.length).toBeGreaterThanOrEqual(3);
+    expect(new Set(full.lines.map((line) => line.advancePt)))
+      .toEqual(new Set([uniformAdvancePt]));
+
+    const continuation = measureParagraph(
+      doc,
+      context,
+      position,
+      measurer,
+      environment(),
+      {
+        boundary: full.lines[0].layout.consumedEnd!,
+        uniformRubyAdvancePt: uniformAdvancePt,
+      },
+    );
+
+    expect(continuation.lines.every((line) => line.advancePt === uniformAdvancePt)).toBe(true);
+    expect(full.uniformRubyAdvancePt).toBe(uniformAdvancePt);
+    expect(continuation.uniformRubyAdvancePt).toBe(uniformAdvancePt);
+
+    const secondContinuation = measureParagraph(
+      doc,
+      context,
+      position,
+      measurer,
+      environment(),
+      {
+        boundary: continuation.lines[0].layout.consumedEnd!,
+        uniformRubyAdvancePt: continuation.uniformRubyAdvancePt,
+      },
+    );
+
+    expect(continuation.lines.length).toBeGreaterThan(1);
+    expect(secondContinuation.lines.every((line) => line.advancePt === uniformAdvancePt)).toBe(true);
+    expect(secondContinuation.uniformRubyAdvancePt).toBe(uniformAdvancePt);
   });
 
   it('passes bidi policy through to RTL tab layout', () => {

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -10,6 +10,7 @@ import {
   type WrapOracle,
 } from './paragraph-measure.js';
 import type { ParagraphLayoutContext } from './layout-context.js';
+import type { LayoutTextSeg } from './line-layout.js';
 import type { DocParagraph, DocxTextRun, FieldRun, ImageRun } from './types.js';
 
 function makeContext(ascentRatio = 0.8, descentRatio = 0.2): CanvasRenderingContext2D {
@@ -104,6 +105,13 @@ const placement = (overrides: Partial<ParagraphPlacement> = {}): ParagraphPlacem
   suppressSpaceBefore: false,
   ...overrides,
 });
+
+const measuredTextSequence = (
+  measured: ReturnType<typeof measureParagraph>,
+): string[] => measured.lines.map((line) => line.layout.segments
+  .filter((segment): segment is LayoutTextSeg => 'text' in segment)
+  .map((segment) => segment.text)
+  .join(''));
 
 describe('measureParagraph', () => {
   it('measures a no-float paragraph and excludes trailing spacing from contentEndYPt', () => {
@@ -382,5 +390,120 @@ describe('measureParagraph', () => {
     expect(first.lines[0].layout.availWidth).toBe(20);
     expect(second.lines[0].layout.availWidth).toBe(100);
     expect(first.lines.length).toBeGreaterThan(second.lines.length);
+  });
+
+  it('reproduces the same-width suffix from a consumed line boundary', () => {
+    const doc = paragraph({
+      spaceBefore: 0,
+      runs: [{
+        type: 'text',
+        ...textRun('alpha bravo charlie delta echo foxtrot golf hotel india juliet'),
+      }],
+    });
+    const context = layoutContext({ spaceBeforePt: 0 });
+    const position = placement({ startYPt: 0, availableWidthPt: 45 });
+    const full = measureParagraph(doc, context, position, measurer, environment());
+    const boundary = full.lines[0].layout.consumedEnd!;
+
+    expect(full.lines.length).toBeGreaterThan(2);
+    const continuation = measureParagraph(
+      doc,
+      context,
+      position,
+      measurer,
+      environment(),
+      { boundary },
+    );
+
+    expect(measuredTextSequence(continuation)).toEqual(measuredTextSequence(full).slice(1));
+  });
+
+  it('suppresses first-line indent when measuring a continuation', () => {
+    const doc = paragraph({
+      indentFirst: 20,
+      spaceBefore: 0,
+      runs: [{ type: 'text', ...textRun('a a a a a a a a a a a a a a a a a a') }],
+    });
+    const context = layoutContext({ firstIndentPt: 20, spaceBeforePt: 0 });
+    const position = placement({ startYPt: 0, availableWidthPt: 50 });
+    const full = measureParagraph(doc, context, position, measurer, environment());
+    const boundary = full.lines[0].layout.consumedEnd!;
+    const continuation = measureParagraph(
+      doc,
+      context,
+      position,
+      measurer,
+      environment(),
+      { boundary },
+    );
+    const fullText = measuredTextSequence(full);
+    const continuationText = measuredTextSequence(continuation);
+
+    expect(continuationText[0]).toBe(fullText[1]);
+    expect(continuationText[0].length).toBeGreaterThan(fullText[0].length);
+  });
+
+  it('re-wraps a continuation at a narrower width without losing text', () => {
+    const doc = paragraph({
+      spaceBefore: 0,
+      runs: [{ type: 'text', ...textRun('あ'.repeat(32)) }],
+    });
+    const context = layoutContext({ spaceBeforePt: 0 });
+    const full = measureParagraph(
+      doc,
+      context,
+      placement({ startYPt: 0, availableWidthPt: 40 }),
+      measurer,
+      environment(),
+    );
+    const boundary = full.lines[0].layout.consumedEnd!;
+    const continuation = measureParagraph(
+      doc,
+      context,
+      placement({ startYPt: 0, availableWidthPt: 20 }),
+      measurer,
+      environment(),
+      { boundary },
+    );
+
+    for (const line of continuation.lines) {
+      expect(line.layout.segments.reduce((sum, segment) => sum + segment.measuredWidth, 0))
+        .toBeLessThanOrEqual(20);
+    }
+    expect(measuredTextSequence(continuation).join(''))
+      .toBe(measuredTextSequence(full).slice(1).join(''));
+    expect(continuation.lines.length).toBeGreaterThan(full.lines.length - 1);
+  });
+
+  it('composes continuation boundaries in original segment coordinates', () => {
+    const doc = paragraph({
+      spaceBefore: 0,
+      runs: [{
+        type: 'text',
+        ...textRun('alpha bravo charlie delta echo foxtrot golf hotel india juliet'),
+      }],
+    });
+    const context = layoutContext({ spaceBeforePt: 0 });
+    const position = placement({ startYPt: 0, availableWidthPt: 45 });
+    const full = measureParagraph(doc, context, position, measurer, environment());
+    const first = measureParagraph(
+      doc,
+      context,
+      position,
+      measurer,
+      environment(),
+      { boundary: full.lines[0].layout.consumedEnd! },
+    );
+    const second = measureParagraph(
+      doc,
+      context,
+      position,
+      measurer,
+      environment(),
+      { boundary: first.lines[0].layout.consumedEnd! },
+    );
+
+    expect(first.lines.length).toBeGreaterThan(1);
+    expect(measuredTextSequence(second)).toEqual(measuredTextSequence(first).slice(1));
   });
 });

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -115,6 +115,9 @@ export interface MeasuredParagraph {
   readonly markOnly: boolean;
   readonly requestedSpaceBeforePt: number;
   readonly requestedSpaceAfterPt: number;
+  /** ECMA-376 §17.3.3.25 paragraph-wide uniform line advance in points, snapped
+   *  to the docGrid. Zero when the paragraph has no ruby. */
+  readonly uniformRubyAdvancePt: number;
   readonly contentStartYPt: number;
   readonly contentEndYPt: number;
   readonly placement: Readonly<ParagraphPlacement>;
@@ -143,7 +146,10 @@ export function measureParagraph(
   placement: ParagraphPlacement,
   measurer: TextMeasurer,
   environment: ParagraphMeasurementEnvironment,
-  continuation?: { readonly boundary: LineBoundary },
+  continuation?: {
+    readonly boundary: LineBoundary;
+    readonly uniformRubyAdvancePt?: number;
+  },
 ): MeasuredParagraph {
   const grid = paragraphGrid(context);
   const paragraphWidthPt = Math.max(
@@ -204,6 +210,7 @@ export function measureParagraph(
       markOnly: true,
       requestedSpaceBeforePt,
       requestedSpaceAfterPt,
+      uniformRubyAdvancePt: 0,
       contentStartYPt: markTopPt,
       contentEndYPt: markTopPt + markAdvancePt,
       placement: recordedPlacement,
@@ -258,7 +265,7 @@ export function measureParagraph(
   );
   if (lines.length === 0) return measureMarkOnly();
 
-  const uniformRubyAdvancePt = context.hasRuby
+  let uniformRubyAdvancePt = context.hasRuby
     ? snapParagraphLineToGrid(
         Math.max(0, ...lines.map((line) => lineBoxHeight(
           context.lineSpacing,
@@ -273,6 +280,12 @@ export function measureParagraph(
         grid,
       )
     : 0;
+  if (context.hasRuby && continuation?.uniformRubyAdvancePt !== undefined) {
+    uniformRubyAdvancePt = Math.max(
+      uniformRubyAdvancePt,
+      continuation.uniformRubyAdvancePt,
+    );
+  }
   const measuredLines: MeasuredLine[] = [];
   for (const line of lines) {
     const topYPt = line.topY !== undefined && line.topY > cursorPt
@@ -299,6 +312,7 @@ export function measureParagraph(
     markOnly: false,
     requestedSpaceBeforePt,
     requestedSpaceAfterPt,
+    uniformRubyAdvancePt,
     contentStartYPt: measuredLines[0].topYPt,
     contentEndYPt: cursorPt,
     placement: recordedPlacement,

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -12,6 +12,7 @@ import {
   lineBoxHeight,
   paragraphMarkLineHeight,
   type DocGridCtx,
+  type LineBoundary,
   type LayoutLine,
   type LineLayoutEnvironment,
   type WrapLayoutCtx,
@@ -142,6 +143,7 @@ export function measureParagraph(
   placement: ParagraphPlacement,
   measurer: TextMeasurer,
   environment: ParagraphMeasurementEnvironment,
+  continuation?: { readonly boundary: LineBoundary },
 ): MeasuredParagraph {
   const grid = paragraphGrid(context);
   const paragraphWidthPt = Math.max(
@@ -239,7 +241,9 @@ export function measureParagraph(
     measurer.context,
     segments,
     paragraphWidthPt,
-    context.firstIndentPt,
+    // ECMA-376 §17.3.1.12: first-line and hanging indents apply only to the
+    // paragraph's first line, not to a continuation measured in another column.
+    continuation ? 0 : context.firstIndentPt,
     1,
     [...context.tabStops],
     wrapContext,
@@ -250,6 +254,7 @@ export function measureParagraph(
     context.defaultTabPt,
     paragraphWidthPt + context.physicalIndentRightPt,
     context.baseRtl,
+    continuation?.boundary,
   );
   if (lines.length === 0) return measureMarkOnly();
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -149,6 +149,7 @@ import {
 } from './line-layout.js';
 import type {
   DocGridCtx,
+  LineBoundary,
   LayoutImageSeg,
   LayoutLine,
   LayoutMathSeg,
@@ -4435,6 +4436,7 @@ function splitParagraphAcrossPages(
     const indLeft = paragraphContext.physicalIndentLeftPt;
     const indRight = paragraphContext.physicalIndentRightPt;
     let paraW = Math.max(1, contentWPt() - indLeft - indRight);
+    let remainderBoundary: LineBoundary | null = null;
     const measureAtCurrentPlacement = (suppressLeadingSpace: boolean) => measureParagraph(
       para,
       paragraphContext,
@@ -4443,7 +4445,7 @@ function splitParagraphAcrossPages(
         paragraphXPt: paragraphXPt(),
         availableWidthPt: contentWPt(),
         maximumYPt: measureState.pageH,
-        suppressSpaceBefore: suppressLeadingSpace,
+        suppressSpaceBefore: remainderBoundary !== null ? true : suppressLeadingSpace,
         wrap: measureState.floats.length > 0
           ? createFloatWrapOracle(measureState.floats)
           : undefined,
@@ -4453,6 +4455,7 @@ function splitParagraphAcrossPages(
         fontFamilyClasses: measureState.fontFamilyClasses,
       },
       paragraphMeasurementEnvironment(measureState),
+      remainderBoundary !== null ? { boundary: remainderBoundary } : undefined,
     );
     let measured = measureAtCurrentPlacement(suppressSpaceBefore);
     const placeMarkOnly = (): { endY: number } => {
@@ -4502,6 +4505,34 @@ function splitParagraphAcrossPages(
     );
 
     let lineIdx = 0;
+    let paragraphContinued = false;
+    // §17.6.4 — a continuation must wrap to ITS column's width. When the destination
+    // band differs from the measured placement (unequal-width columns), re-measure the
+    // REMAINDER from the last placed line's consumed boundary at the destination;
+    // same-width continuations keep the single measurement, byte-identical.
+    const maybeSwapToRemainder = (): void => {
+      if (lineIdx === 0) return;
+      if (measureState.floats.length > 0) return;
+      if (measured.placement.wrap !== undefined) return;
+      const destW = contentWPt();
+      const eps = 1e-6 * Math.max(1, Math.abs(destW));
+      if (Math.abs(measured.placement.availableWidthPt - destW) <= eps) return;
+      const boundary = lines[lineIdx - 1].consumedEnd;
+      if (!boundary) return;
+      const previous = { measured, lines, lineExtents, paraW, boundary: remainderBoundary };
+      remainderBoundary = boundary;
+      const next = measureAtCurrentPlacement(true);
+      if (next.markOnly || next.lines.length === 0) {
+        remainderBoundary = previous.boundary;
+        return;
+      }
+      measured = next;
+      paraW = Math.max(1, measured.placement.availableWidthPt - indLeft - indRight);
+      lines = measured.lines.map((line) => line.layout);
+      lineExtents = measuredLineExtents();
+      lineIdx = 0;
+      paragraphContinued = true;
+    };
     let cursorY = initialY;
     while (lineIdx < lines.length) {
       const remaining = colBot() - cursorY;
@@ -4517,6 +4548,7 @@ function splitParagraphAcrossPages(
           newPage(cursorY);
           cursorY = colTop();
           if (lineIdx === 0) remeasureBeforeFirstLine();
+          else maybeSwapToRemainder();
           continue;
         }
         lastFitting = firstFitting + 1;
@@ -4539,11 +4571,18 @@ function splitParagraphAcrossPages(
       const sliceEl = {
         ...(para as object),
         type: 'paragraph',
-        lineSlice: { start: firstFitting, end: lastFitting },
+        lineSlice: {
+          start: firstFitting,
+          end: lastFitting,
+          ...(paragraphContinued ? { continues: true } : {}),
+        },
       } as PaginatedElementWithLines;
       if (stampLines) {
         stampParagraphLines(sliceEl, lines, {
           paraW,
+          // A remainder is laid out with firstIndent=0, but this stamp is the legacy
+          // paint path's cache key. Keep what paint reconstructs so it reuses the
+          // stored remainder partition — the only correct lines for this slice.
           firstIndent: para.indentFirst,
           tabOriginPx: indLeft,
           gridDeltaPx: gridCharDeltaPx(grid, 1),
@@ -4565,7 +4604,7 @@ function splitParagraphAcrossPages(
           measured,
           firstFitting,
           lastFitting,
-          firstFitting === 0,
+          firstFitting === 0 && !paragraphContinued,
           isFinalSlice,
           trailingExtent,
         );
@@ -4583,6 +4622,7 @@ function splitParagraphAcrossPages(
       if (!isFinalSlice) {
         newPage(cursorY);
         cursorY = colTop();
+        maybeSwapToRemainder();
       }
     }
     return { endY: cursorY };
@@ -6197,7 +6237,7 @@ function renderBodyElements(
       // earlier slice already consumed it on the previous page. Likewise
       // mid-paragraph slices (slice.end < total) suppress spaceAfter — only
       // the slice covering the FINAL line of the paragraph emits it.
-      const isContinuation = !!slice && slice.start > 0;
+      const isContinuation = (!!slice && slice.start > 0) || slice?.continues === true;
       // ECMA-376 §17.3.1.7 paragraph-border merge: suppress this paragraph's TOP
       // edge when the previous IN-FLOW paragraph (already null on column/section
       // change, table/frame boundary — exactly the run-breaking cases) shares its
@@ -6221,6 +6261,11 @@ function renderBodyElements(
         paintParagraphFragment(placedFragment, state, {
           suppressSpaceBefore: suppress || isContinuation,
           borderMerge,
+          // §17.6.4 remainder re-wrap — a re-measured continuation covers its whole
+          // partition (fragment range [0, len)), so the fragment cannot see that it
+          // is a continuation; thread the element slice's marker through so the
+          // fragment path mirrors the legacy path's first-slice-only guards.
+          continuesParagraph: slice?.continues === true,
         });
       } else {
         renderParagraph(para, state, suppress || isContinuation, slice, false, borderMerge);
@@ -6337,7 +6382,7 @@ function renderEmptyMarkParagraph(
     markTop: number;
     /** Total laid-out line count (0 here); used by the slice guards. */
     totalLines: number;
-    lineSlice?: { start: number; end: number };
+    lineSlice?: { start: number; end: number; continues?: boolean };
     /** §17.3.1.7 paragraph-border merge (suppress top/bottom edges). */
     borderMerge?: ParaBorderMerge;
   },
@@ -6375,7 +6420,7 @@ function renderEmptyMarkParagraph(
   // shapes are themselves the float band, so they stay anchored to the original
   // paragraph top (§20.4.3.5) instead of following the paragraph mark's flow.
   // Only the first slice draws them (a continuation slice already did on its page).
-  if (!lineSlice || lineSlice.start === 0) {
+  if (!lineSlice || (lineSlice.start === 0 && !lineSlice.continues)) {
     renderAnchorImages(para, state, paragraphStartY + flowShift, 'front', paragraphStartY);
   }
 }
@@ -6652,7 +6697,7 @@ function renderParagraph(
   suppressSpaceBefore = false,
   /** When set, render only `lines[start, end)` of the laid-out paragraph,
    *  used by the paginator to split paragraphs that don't fit on one page. */
-  lineSlice?: { start: number; end: number },
+  lineSlice?: { start: number; end: number; continues?: boolean },
   /** True when this call is the redirected draw of a `<w:framePr>` frame
    *  paragraph (from {@link renderFrameParagraph}). It suppresses the in-flow
    *  cursor bookkeeping that the frame path handles itself: anchor-float
@@ -7075,7 +7120,7 @@ function renderParagraph(
   // Anchor images are absolutely positioned — draw after inline flow.
   // Skip this for continuation slices: anchor positioning is paragraph-relative
   // and the first slice already painted them.
-  if (!lineSlice || lineSlice.start === 0) {
+  if (!lineSlice || (lineSlice.start === 0 && !lineSlice.continues)) {
     renderAnchorImages(para, state, paragraphStartY);
   }
 }
@@ -7161,7 +7206,7 @@ export function renderBodyParagraphLines(
   state: RenderState,
   scale1Lines: readonly LayoutLine[],
   suppressSpaceBefore: boolean,
-  lineSlice: { start: number; end: number } | undefined,
+  lineSlice: { start: number; end: number; continues?: boolean } | undefined,
   borderMerge: ParaBorderMerge | undefined,
 ): void {
   renderParagraph(source, state, suppressSpaceBefore, lineSlice, false, borderMerge, scale1Lines);

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4437,6 +4437,7 @@ function splitParagraphAcrossPages(
     const indRight = paragraphContext.physicalIndentRightPt;
     let paraW = Math.max(1, contentWPt() - indLeft - indRight);
     let remainderBoundary: LineBoundary | null = null;
+    let remainderUniformRubyPt: number | undefined;
     const measureAtCurrentPlacement = (suppressLeadingSpace: boolean) => measureParagraph(
       para,
       paragraphContext,
@@ -4455,7 +4456,9 @@ function splitParagraphAcrossPages(
         fontFamilyClasses: measureState.fontFamilyClasses,
       },
       paragraphMeasurementEnvironment(measureState),
-      remainderBoundary !== null ? { boundary: remainderBoundary } : undefined,
+      remainderBoundary !== null
+        ? { boundary: remainderBoundary, uniformRubyAdvancePt: remainderUniformRubyPt }
+        : undefined,
     );
     let measured = measureAtCurrentPlacement(suppressSpaceBefore);
     const placeMarkOnly = (): { endY: number } => {
@@ -4527,11 +4530,20 @@ function splitParagraphAcrossPages(
       if (Math.abs(measured.placement.availableWidthPt - destW) <= eps) return;
       const boundary = lines[lineIdx - 1].consumedEnd;
       if (!boundary) return;
-      const previous = { measured, lines, lineExtents, paraW, boundary: remainderBoundary };
+      const previous = {
+        measured,
+        lines,
+        lineExtents,
+        paraW,
+        boundary: remainderBoundary,
+        uniformRubyAdvancePt: remainderUniformRubyPt,
+      };
       remainderBoundary = boundary;
+      remainderUniformRubyPt = measured.uniformRubyAdvancePt;
       const next = measureAtCurrentPlacement(true);
       if (next.markOnly || next.lines.length === 0) {
         remainderBoundary = previous.boundary;
+        remainderUniformRubyPt = previous.uniformRubyAdvancePt;
         return;
       }
       measured = next;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4512,6 +4512,14 @@ function splitParagraphAcrossPages(
     // same-width continuations keep the single measurement, byte-identical.
     const maybeSwapToRemainder = (): void => {
       if (lineIdx === 0) return;
+      // Numbered paint recomputes numBodyOffset and the marker, so a local suffix would redraw both.
+      if (para.numbering != null) return;
+      // State-sensitive paragraphs have no line stamp; legacy paint would index the rebuilt full partition.
+      if (paragraphSegsStateSensitive(para)) return;
+      // Vertical text is outside fragment/reuse migration and must remain on its single partition.
+      if (measureState.verticalCJK) return;
+      // Accepted residual: these paint-excluded classes retain the pre-existing unequal-width
+      // overflow until marker-/state-aware remainder paint (and vertical migration) exists.
       if (measureState.floats.length > 0) return;
       if (measured.placement.wrap !== undefined) return;
       const destW = contentWPt();
@@ -6744,7 +6752,11 @@ function renderParagraph(
   if (!inFrame) registerAnchorFloats(para, state, paragraphStartY);
 
   // behindDoc shapes must render before text so they appear behind it.
-  renderAnchorImages(para, state, paragraphStartY, 'behind');
+  // Float registration above remains unconditional per-slice bookkeeping; only
+  // the paragraph-level anchor DRAW is restricted to the original first slice.
+  if (!lineSlice || (lineSlice.start === 0 && !lineSlice.continues)) {
+    renderAnchorImages(para, state, paragraphStartY, 'behind');
+  }
 
   // If any topAndBottom float already extends past state.y, skip past it before
   // text starts. Scoped to this paragraph's column band (§20.4.2.20 / §17.6.4):
@@ -7091,7 +7103,7 @@ function renderParagraph(
   // glyph lands on the box edge, so the painted advance equals measuredWidth by
   // construction. See the gridCharDeltaPx / gridSegDeltaPx header.
   const drawGridDeltaPx = gridCharDeltaPx(grid, scale);
-  const drawCtx: ParagraphLineDrawCtx = { ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses, contentX, contentW, lines, grid, paraX, firstLineX, paraW, indLeft, indFirst, baseRtl, hasMarker, numTab, numBodyOffset, markerJcShiftPx, picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi, decimalAutoTabPx, drawGridDeltaPx, lineHForLine };
+  const drawCtx: ParagraphLineDrawCtx = { ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses, contentX, contentW, lines, grid, paraX, firstLineX, paraW, indLeft, indFirst, continuesParagraph: lineSlice?.continues === true, baseRtl, hasMarker, numTab, numBodyOffset, markerJcShiftPx, picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi, decimalAutoTabPx, drawGridDeltaPx, lineHForLine };
   for (let li = sliceStart; li < paintEnd; li++) {
     drawParagraphLine(li, drawCtx);
   }
@@ -7233,6 +7245,7 @@ interface ParagraphLineDrawCtx {
   paraW: number;
   indLeft: number;
   indFirst: number;
+  continuesParagraph: boolean;
   baseRtl: boolean;
   hasMarker: boolean;
   numTab: number;
@@ -7255,14 +7268,14 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
   const {
     ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses,
     contentX, contentW, lines, grid, paraX, firstLineX, paraW, indLeft,
-    indFirst, baseRtl, hasMarker, numTab, numBodyOffset, markerJcShiftPx,
+    indFirst, continuesParagraph, baseRtl, hasMarker, numTab, numBodyOffset, markerJcShiftPx,
     picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi,
     decimalAutoTabPx, drawGridDeltaPx, lineHForLine,
   } = c;
     const line = lines[li];
     // First-line indent and numbering prefix only apply to the paragraph's
     // ORIGINAL first line, not the first line of a continuation slice.
-    const firstLine = li === 0;
+    const firstLine = li === 0 && !continuesParagraph;
     // Last-line justification flips off only at the paragraph's true end —
     // mid-paragraph slices keep justifying through to the slice boundary.
     const isLastLine = li === lines.length - 1;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4513,6 +4513,16 @@ function splitParagraphAcrossPages(
     // band differs from the measured placement (unequal-width columns), re-measure the
     // REMAINDER from the last placed line's consumed boundary at the destination;
     // same-width continuations keep the single measurement, byte-identical.
+    //
+    // Placement-validity adjudication (PR #923 review): the gate compares the
+    // placement-DETERMINING inputs only. A measurement's line partition and per-line
+    // geometry are a function of (available width, wrap context, content); without a
+    // wrap oracle the X/Y origin is a pure translation, recorded per slice on its
+    // PlacedFragment — not a layout input. So a same-width, wrap-free column/page hop
+    // keeps the measurement valid (the design doc's fragment-continuation contract and
+    // the PR 5 shipped behavior), while a width or wrap change forces the remainder
+    // remeasure below. See docs/docx-layout-context-fragments-design.md
+    // §"Placement-Aware Paragraph Measurement" (validity definition).
     const maybeSwapToRemainder = (): void => {
       if (lineIdx === 0) return;
       // Numbered paint recomputes numBodyOffset and the marker, so a local suffix would redraw both.

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -396,7 +396,14 @@ export type BodyElement =
  *  the element was placed in (ECMA-376 §17.6.4); absent / 0 for single-column
  *  sections. */
 export type PaginatedBodyElement = BodyElement & {
-  lineSlice?: { start: number; end: number };
+  lineSlice?: {
+    start: number;
+    end: number;
+    /** §17.6.4 remainder re-wrap: indices refer to the slice's OWN re-measured
+     *  partition, and `continues` marks that this partition is a paragraph
+     *  continuation even though `start === 0`. */
+    continues?: boolean;
+  };
   /** An empty paragraph that carries a section break (an inkless paragraph
    *  immediately followed by a `sectionBreak` element) has its spacing-BEFORE
    *  suppressed — Word/LibreOffice render it flush below the preceding paragraph.


### PR DESCRIPTION
## Re-wrap paragraph continuations at their destination column width

Closes #908. ECMA-376 §17.6.4: a newspaper column is a text region of a DEFINED width —
with `equalWidth=false`, each `<w:col w:w>` sets its own. A paragraph continuing from a
wide column into a narrower one kept the source column's line breaks (`splitParagraphAcrossPages`
measured once and sliced one partition), overflowing the destination band. The pinned Red
(a 100pt line in a 48pt column) is now un-skipped and green.

Three seams, one commit each (the design analysis that adjudicated this approach — and
rejected geometric width rescaling, segment re-flattening, and run-coordinate mapping as
forbidden shortcuts — is summarized in the first commit body):

1. **`feat(docx): record consumed-content boundaries in line layout`** — every laid-out
   line records its consumed-content END boundary in the resolved segment stream
   (break-aware; derived split pieces carry offset provenance through all four split
   sites including the kinsoku cross-run retraction, where the boundary moves backward
   into the previous line's last segment). A new optional `startBoundary` lays out a
   suffix with original-coordinate provenance so continuations compose. Metadata only:
   wrap decisions are bit-identical. Self-validating suite: for a 7-fixture corpus
   covering every split path, EVERY line's suffix re-layout at the same width must
   reproduce the following lines exactly.
2. **`feat(docx): measure paragraph continuations from a consumed boundary`** —
   `measureParagraph(..., continuation)` measures the remainder from a boundary with the
   first-line/hanging indent suppressed (§17.3.1.12 — a continuation is not a first
   line). Unused by production until seam 3.
3. **`fix(docx): re-wrap paragraph continuations at their destination column width`** —
   a WIDTH-GATED remainder swap at both continuation advances. Same-width continuations
   (equal columns, page breaks) take the literal existing path (paragraph X alone
   differing is not a mismatch — without floats X does not affect wrapping); float
   contexts never swap (their paint-scale re-layout is a separate pre-existing
   mechanism). Re-wrapped slices record the DESTINATION placement on fragments and
   stamps, and carry a `lineSlice.continues` marker so paint's first-slice-only work
   (space-before, anchor drawing) does not re-run — threaded through the fragment paint
   path too (Red-first: an anchored shape was drawn twice before the pass-through).

### Review fixes (adversarial review, request-changes → all 6 addressed)

- **[high] Remainder first line painted as the paragraph's first line**: the draw loop's
  `firstLine = li === 0` re-applied the §17.3.1.12 first-line/hanging indent, the RTL
  effective width, and the numbering marker to a remainder partition's line 0 at paint.
  The slice's `continues` marker now threads into the draw context
  (`firstLine = li === 0 && !continuesParagraph`); every first-line-derived site audited.
  Red: the first destination-column line painted +indentFirst right of its siblings.
- **[high] Swap scope-outs**: numbered, state-sensitive (PAGE/NUMPAGES), and vertical
  paragraphs are excluded from the remainder swap — paint cannot consume a remainder
  partition for those classes (no stamp / marker recompute), so they keep the
  pre-existing behavior (documented residual). Red: those fixtures carried `continues`
  with remainder-local indices.
- **[medium] behindDoc anchors**: the behind draw phase now has the same first-slice
  guard as the front phase (was drawn once per same-page slice). Red: absolute count 2;
  the earlier parity-only anchor assertion was tightened to absolute counts.
- **[medium] Placement-validity contract**: adjudicated contract-side — the design doc
  now defines validity by the placement-DETERMINING inputs (width + wrap; X/Y is a
  translation recorded on `PlacedFragment`), matching the shipped PR 5 continuation
  contract; rationale at the gate. No behavior change.
- **[medium] Ruby uniform line height**: `MeasuredParagraph.uniformRubyAdvancePt` is now
  carried into continuation measures (max of prefix/suffix, composing across swaps), so
  a destination column keeps the paragraph-wide §17.3.3.25 line pitch even when the
  tallest ruby line was consumed in the source column. Red: continuation advances shrank
  to the suffix-wide max.
- **[medium/test] Property test deepened**: the suffix-reproduction property now
  deep-compares per-segment structure and line geometry plus the consumedEnd composition
  invariant, over 12 fixtures (adds bidi/RTL tab, fitText, ruby, astral/surrogate with a
  never-splits-a-surrogate assertion, glued CJK group). Vertical text / field resolution
  are outside this function's input domain — scoped in a comment, not faked.

Full gate re-run after the fixes: workspace 3633 passed; VRT pixel counts line-for-line
identical to the pre-fix run (i.e. still byte-identical to the base merge commit).

### Verification

- Full workspace `pnpm test`: 361 files, 3617 passed (0 docx skips — the #908 pin now
  runs). Root `pnpm typecheck`, `pnpm lint`, `pnpm lint:test`, `cargo fmt --check`,
  `git diff --check`: clean.
- New coverage: the un-skipped §17.6.4 pin; equal-width fast-path non-vacuity (single
  partition, no remainder marker); three-column composition (two swaps through
  original-stream boundaries); first-line-indent suppression end-to-end; leading spacing
  not re-charged; fragment/legacy paint parity for re-wrapped slices.
- Local pixel VRT (private fixtures): this branch is **byte-identical to its base** on
  all 89 checks — the known-failure group reproduces its exact recorded pixel counts,
  and the handful of checks that differ from the older local references differ
  IDENTICALLY at the base merge commit (they come from the parallel character-spacing
  and fitText fixes, not from this branch). No sample in the suite uses unequal-width
  columns, so the fix's behavioral surface is covered by the synthetic suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)