### PR TITLE
fix(docx): size docGrid line cells from the run em, not the glyph box

### DIFF
--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isGridLineRule, lineBoxHeight } from './line-layout.js';
+import { docGridLineCells, isGridLineRule, lineBoxHeight } from './line-layout.js';
 import type { LineSpacing } from './types.js';
 
 // Regression: some generators emit <w:spacing w:line="0" w:lineRule="exact"/> on
@@ -72,33 +72,77 @@ describe('lineBoxHeight — atLeast with an active line grid', () => {
   });
 });
 
-// ECMA-376 §17.6.5 / §17.3.1.32 only define docGrid line height for natural <=
-// pitch. Word's runtime behaviour for taller lines (verified via pdftotext -bbox
-// of the sample-9 Word PDF: a 20pt CJK title on a 20pt pitch is 40px = 2 cells)
-// rounds East Asian lines UP to whole grid cells, while Latin-only lines keep
-// their natural height above a one-cell floor (demo/sample-1's 18pt heading on
-// an 18pt pitch stays ~natural, not 2 cells). The `eastAsian` flag gates it.
+// ECMA-376 §17.6.5 / §17.3.1.32 define the line pitch as the height of ONE
+// single-spaced line; how many whole grid CELLS a single-spaced East Asian line
+// occupies is Word runtime behaviour. That cell count is a function of the run's
+// EM (font size) — NOT the substituted-font glyph box (fontBoundingBox, ~1.6em),
+// which over-counts every EA line whose em is comfortably inside one pitch.
+//
+// Word-PDF ground truth (pdftotext -bbox):
+//   • sample-35: docGrid pitch 18pt; a 12pt centred CJK heading is 1 cell (18pt),
+//     and the 10.5pt body lines are 1 cell — even though 12×1.6 = 19.2 > 18.
+//   • sample-9 : docGrid pitch 20pt; a 20pt CJK title is 2 cells (40pt).
+// `ceil(em/pitch)` fits the first two but fails the 20-on-20 boundary (→1, want
+// 2). `floor(em/pitch)+1` fits ALL three: a single-spaced EA line whose em-square
+// exactly fills k pitches still needs its inter-line leading, spilling into the
+// (k+1)-th cell. Latin-only lines are NOT cell-rounded (§17.6.5 leaves them at
+// default spacing); the `eastAsian` flag gates the rule.
+describe('docGridLineCells — em-based East Asian grid cell count (§17.6.5)', () => {
+  it('a sub-pitch em occupies a single cell (12pt heading / 18pt pitch → 1)', () => {
+    expect(docGridLineCells(12, 18)).toBe(1);
+  });
+  it('a 13pt em on an 18pt pitch is still a single cell', () => {
+    expect(docGridLineCells(13, 18)).toBe(1);
+  });
+  it('a 10.5pt body em on an 18pt pitch is a single cell', () => {
+    expect(docGridLineCells(10.5, 18)).toBe(1);
+  });
+  it('an em equal to the pitch occupies TWO cells (20pt / 20pt → 2)', () => {
+    expect(docGridLineCells(20, 20)).toBe(2);
+  });
+  it('the pitch boundary rounds up (18pt em / 18pt pitch → 2)', () => {
+    expect(docGridLineCells(18, 18)).toBe(2);
+  });
+  it('an em between one and two pitches occupies two cells', () => {
+    expect(docGridLineCells(30, 20)).toBe(2);
+  });
+  it('an em at exactly two pitches occupies three cells', () => {
+    expect(docGridLineCells(40, 20)).toBe(3);
+  });
+});
+
 describe('lineBoxHeight — docGrid line-cell rounding (East Asian vs Latin)', () => {
+  const grid18 = { type: 'lines', linePitchPt: 18 } as const;
   const grid20 = { type: 'lines', linePitchPt: 20 } as const;
 
-  it('rounds an East Asian line taller than the pitch UP to whole cells', () => {
-    // glyph natural 22px > 20px pitch → ceil(22/20) = 2 cells = 40px.
-    expect(lineBoxHeight(null, 17.6, 4.4, 1, grid20, false, 0, true)).toBe(40);
+  // Yu Mincho reports fontBoundingBox ≈ 1.602 em, so a 12pt run's glyph box is
+  // ~19.22px (asc 15.38 + desc 3.84) — over the 18pt pitch. The OLD rule
+  // ceil(19.22/18) = 2 cells over-counted; the em (12pt) → floor(12/18)+1 = 1
+  // cell = 18px is what Word renders (sample-35 heading).
+  it('snaps a sub-pitch EA line to ONE cell by its em, not its inflated glyph box', () => {
+    expect(lineBoxHeight(null, 15.38, 3.84, 1, grid18, false, 0, true, 12)).toBe(18);
   });
-  it('keeps a Latin line at natural height (one-cell floor), NOT rounded to 2 cells', () => {
-    // Same 22px natural, Latin → max(22, 20) = 22px (Word does not cell-round it).
-    expect(lineBoxHeight(null, 17.6, 4.4, 1, grid20, false, 0, false)).toBe(22);
+  it('rounds an EA line whose em equals the pitch UP to two cells (20/20 → 40)', () => {
+    // glyph box 32.04px (25.63 + 6.41); em 20 on pitch 20 → floor(20/20)+1 = 2.
+    expect(lineBoxHeight(null, 25.63, 6.41, 1, grid20, false, 0, true, 20)).toBe(40);
   });
-  it('puts a short East Asian line in a single cell (natural <= pitch)', () => {
-    // glyph natural 13px <= 20px pitch → ceil(13/20) = 1 cell = 20px.
-    expect(lineBoxHeight(null, 10.4, 2.6, 1, grid20, false, 0, true)).toBe(20);
+  it('rounds an EA line whose em exceeds the pitch to two cells (30/20 → 40)', () => {
+    expect(lineBoxHeight(null, 24, 6, 1, grid20, false, 0, true, 30)).toBe(40);
   });
-  it('rounds an East Asian line over two pitches up to three cells', () => {
-    // glyph natural 41px → ceil(41/20) = 3 cells = 60px.
-    expect(lineBoxHeight(null, 32.8, 8.2, 1, grid20, false, 0, true)).toBe(60);
+  it('keeps a Latin line at natural height (one-cell floor), NOT cell-rounded', () => {
+    // 22px natural, Latin → max(22, 20) = 22px (Word does not cell-round it).
+    expect(lineBoxHeight(null, 17.6, 4.4, 1, grid20, false, 0, false, 22)).toBe(22);
+  });
+  it('a RUBY EA line reserves its measured furigana height, NOT the em cell count', () => {
+    // sample-5: a 13.5pt ruby base + 8pt rt on an 18pt pitch reserves the base +
+    // annotation glyph box (~41px = asc 33 + desc 8), which Word spreads over
+    // whole cells (ceil(41/18) = 3 cells = 54px). The em (13.5pt) would collapse
+    // it to one cell (18px) and clip the furigana, so the em rule must NOT apply
+    // to ruby lines — hasRuby (arg 6) keeps them on the measured glyph box.
+    expect(lineBoxHeight(null, 33, 8, 1, grid18, true, 0, true, 13.5)).toBe(54);
   });
   it('does not cell-round when no docGrid is active (East Asian, off grid)', () => {
-    expect(lineBoxHeight(null, 17.6, 4.4, 1, undefined, false, 0, true)).toBe(22);
+    expect(lineBoxHeight(null, 17.6, 4.4, 1, undefined, false, 0, true, 22)).toBe(22);
   });
   it('defaults to Latin (no cell rounding) when the flag is omitted', () => {
     expect(lineBoxHeight(null, 17.6, 4.4, 1, grid20)).toBe(22);

--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -61,6 +61,7 @@ describe('lineBoxHeight — snapToChars line-grid participation', () => {
 });
 
 describe('lineBoxHeight — atLeast with an active line grid', () => {
+  const grid18 = { type: 'lines', linePitchPt: 18 } as const;
   const grid20 = { type: 'lines', linePitchPt: 20 } as const;
 
   it('retains the active grid minimum when the authored minimum is smaller', () => {
@@ -69,6 +70,28 @@ describe('lineBoxHeight — atLeast with an active line grid', () => {
 
   it('retains the authored minimum when it is larger than the grid minimum', () => {
     expect(lineBoxHeight(atLeast(24), 10, 2, 1, grid20)).toBe(24);
+  });
+
+  // BEHAVIOUR PIN, not Word-verified ground truth. For an East Asian atLeast
+  // line the grid-minimum term is the em-based single cell (docGridLineCells),
+  // no longer the glyph-box cell rounding: a 12pt line whose substituted glyph
+  // box is 19.22px on an 18pt pitch resolves to its natural 19.22px (max of
+  // natural / authored 18 / em cell 18) — previously 36px (glyph box rounded to
+  // 2 cells). No corpus sample exercises atLeast inside an active line grid and
+  // a Word fixture export could not be captured when this was pinned, so Word's
+  // exact atLeast-on-grid height is UNVERIFIED; the pin makes any future change
+  // to this resolution deliberate rather than accidental. Ruby lines keep the
+  // measured-glyph-box minimum (they reserve real furigana height).
+  it('[pin] EA atLeast takes max(natural, authored, em single cell) — unverified vs Word', () => {
+    expect(lineBoxHeight(atLeast(18), 15.38, 3.84, 1, grid18, false, 0, true, 12)).toBeCloseTo(19.22, 6);
+  });
+  it('[pin] EA atLeast still snaps to the em cell when it exceeds natural and authored', () => {
+    // em 20 on pitch 18 → 2 cells = 36 > natural 12 and authored 18.
+    expect(lineBoxHeight(atLeast(18), 10, 2, 1, grid18, false, 0, true, 20)).toBe(36);
+  });
+  it('[pin] a RUBY EA atLeast line keeps the measured glyph-box minimum', () => {
+    // glyph box 41px (base + furigana reserve) → ceil(41/18) = 3 cells = 54.
+    expect(lineBoxHeight(atLeast(18), 33, 8, 1, grid18, true, 0, true, 13.5)).toBe(54);
   });
 });
 

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -317,7 +317,7 @@ export interface WrapLayoutCtx {
     maximumWidthPt: number;
   };
   /** Per-line box-height resolver (line natural ascent+descent → total px box height). */
-  lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number) => number;
+  lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number, emPx?: number) => number;
   /** Hard cap on Y to keep layout from running past the page. */
   pageH: number;
 }
@@ -826,6 +826,22 @@ export function isGridLineRule(ctx: DocGridCtx | undefined): boolean {
 }
 
 /**
+ * ECMA-376 §17.6.5 docGrid line grid — number of whole grid CELLS a
+ * single-spaced East Asian line of em `emPx` occupies on a pitch of `pitchPx`.
+ *
+ * Word uses `cells = floor(emPx / pitchPx) + 1`: 10.5pt and 12pt lines on an
+ * 18pt pitch occupy one cell, while a 20pt line on a 20pt pitch occupies two.
+ * `ceil(em / pitch)` misses the exact boundary because an em square that fills
+ * k pitches still needs inter-line leading and therefore spills into cell k+1.
+ * ECMA-376 defines `linePitch` as one single-spaced line; rounding taller lines
+ * to whole cells is Word runtime behaviour. Returns at least 1 for every finite
+ * `emPx >= 0`.
+ */
+export function docGridLineCells(emPx: number, pitchPx: number): number {
+  return pitchPx > 0 ? Math.floor(emPx / pitchPx) + 1 : 1;
+}
+
+/**
  * Compute the total line-box height in px from a line's natural font metrics
  * (fontBoundingBoxAscent + fontBoundingBoxDescent) per ECMA-376 §17.3.1.33.
  *
@@ -849,6 +865,7 @@ export function lineBoxHeight(
   hasRuby?: boolean,
   intendedSinglePx = 0,
   eastAsian = false,
+  emPx = 0,
 ): number {
   const glyphNatural = ascentPx + descentPx;
   // For `auto`/single spacing the multiplier applies to the intended font's
@@ -869,27 +886,22 @@ export function lineBoxHeight(
   // ESSAY (9 pt, no explicit line) at ~1 pitch (~18 pt) while a 1.33×
   // body paragraph with line="320" renders at pitch × 1.33 = ~24 pt.
   //
-  // Note on ruby paragraphs: an earlier version of this function snapped
-  // ruby lines up to the next integer grid pitch on the theory that Word
-  // reserves whole grid slots for them. Empirical comparison against Word
-  // PNG exports of sample-5 (13.5pt base + 8pt rt on pitch=18) showed
-  // Word does NOT snap to integer pitches — the actual line height lands
-  // around 2.3× the pitch, which is what `natural` produces directly when
-  // the rt reserve in buildSegments is set generously enough. So the
-  // ruby-aware logic now lives entirely in the segment-level ascent
-  // reservation, and lineBoxHeight stays format-agnostic.
   // A single-spaced line on a docGrid snaps to whole grid CELLS in East Asian
-  // text: Word rounds its height UP to the next pitch multiple, so a line taller
-  // than one pitch reserves two (or more). sample-9 (pdftotext -bbox of the Word
-  // PDF): a 20pt CJK title on a 20pt pitch is 40px = 2 cells; an 11pt body is
-  // 20px = 1 cell. A Latin-only line is NOT cell-rounded — it keeps its natural
+  // text. The number of cells is derived from the run em rather than the Canvas
+  // glyph bounding box; see docGridLineCells for the boundary rule and Word
+  // observations. A Latin-only line is NOT cell-rounded — it keeps its natural
   // height above a one-cell floor (demo/sample-1: an 18pt heading on an 18pt
   // pitch stays ~20.7px, not 36). ECMA-376 Part 1 only defines the natural ≤
   // pitch case (§17.6.5 / §17.3.1.32); the East-Asian cell rounding for taller
   // lines is Word runtime behaviour, so it is gated on the line's script.
-  const gridSingleCell = (): number => eastAsian
-    ? Math.max(pitchPx, Math.ceil(glyphNatural / pitchPx) * pitchPx)
-    : Math.max(glyphNatural, pitchPx);
+  const gridSingleCell = (): number => {
+    if (!eastAsian) return Math.max(glyphNatural, pitchPx);
+    // Ruby lines reserve real furigana height (base + rt); honor the measured
+    // glyph box so the annotation is not clipped. Plain EA lines discount the
+    // substituted font's ~1.6em leading and snap by the run EM.
+    if (hasRuby) return Math.max(pitchPx, Math.ceil(glyphNatural / pitchPx) * pitchPx);
+    return docGridLineCells(emPx, pitchPx) * pitchPx;
+  };
   const inheritedOnly = ls !== null && ls.explicit !== true;
   if (!ls) {
     // No explicit spacing → single line. Use the intended single-line height
@@ -1013,7 +1025,7 @@ export function paragraphMarkLineHeight(
   } else {
     ({ asc, desc } = emptyLineNaturalPx(fs, scale));
   }
-  return lineBoxHeight(effectiveLineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSingleForScriptPx(para, scale, eastAsian), eastAsian);
+  return lineBoxHeight(effectiveLineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSingleForScriptPx(para, scale, eastAsian), eastAsian, fs * scale);
 }
 
 /**
@@ -2371,7 +2383,7 @@ export function layoutLines(
       endsWithBreak: brTerminated,
     });
     if (wrapCtx) {
-      currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle);
+      currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle, h * scale);
     }
     currentLine = [];
     currentWidth = 0;

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -280,6 +280,10 @@ export interface LayoutLine {
   /** Set when at least one segment on this line carries a ruby annotation —
    *  enables docGrid pitch snapping in lineBoxHeight. */
   hasRuby?: boolean;
+  /** §17.6.5 — a text segment on this line contains an East Asian code point
+   *  (EAST_ASIAN_RE), enabling docGrid line-cell rounding. Undefined/false for
+   *  synthesized textless lines. */
+  eastAsian?: boolean;
   /** ECMA-376 §17.3.3.1 — this line is terminated by a MANUAL line break
    *  (`<w:br w:type="textWrapping"/>`). In a justified (`both`) paragraph it is
    *  the end of a logical line and must be left-aligned, not stretched — exactly
@@ -317,7 +321,7 @@ export interface WrapLayoutCtx {
     maximumWidthPt: number;
   };
   /** Per-line box-height resolver (line natural ascent+descent → total px box height). */
-  lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number, emPx?: number) => number;
+  lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number, emPx?: number, eastAsian?: boolean) => number;
   /** Hard cap on Y to keep layout from running past the page. */
   pageH: number;
 }
@@ -829,10 +833,18 @@ export function isGridLineRule(ctx: DocGridCtx | undefined): boolean {
  * ECMA-376 §17.6.5 docGrid line grid — number of whole grid CELLS a
  * single-spaced East Asian line of em `emPx` occupies on a pitch of `pitchPx`.
  *
- * Word uses `cells = floor(emPx / pitchPx) + 1`: 10.5pt and 12pt lines on an
- * 18pt pitch occupy one cell, while a 20pt line on a 20pt pitch occupies two.
- * `ceil(em / pitch)` misses the exact boundary because an em square that fills
- * k pitches still needs inter-line leading and therefore spills into cell k+1.
+ * Measured in Word PDF output (`pdftotext -bbox`): 10.5pt and 12pt lines on an
+ * 18pt pitch occupy one cell (the sub-pitch region), while a 20pt line on a
+ * 20pt pitch occupies two (the em == pitch boundary). The k >= 2 region — for
+ * example an em of two pitches occupying three cells — extrapolates
+ * `floor(em / pitch) + 1` beyond the measured range because the boundary rule
+ * is scale-free: an em square that fills k pitches still needs inter-line
+ * leading and therefore spills into cell k+1. No Word measurement covers that
+ * region yet.
+ *
+ * For a mixed-size line, callers supply the tallest run's em. This conservative
+ * anti-clipping choice follows the tallest-run line-box rule (§17.3.1.33); it is
+ * not a Word-measured mixed-size grid behaviour.
  * ECMA-376 defines `linePitch` as one single-spaced line; rounding taller lines
  * to whole cells is Word runtime behaviour. Returns at least 1 for every finite
  * `emPx >= 0`.
@@ -2361,9 +2373,12 @@ export function layoutLines(
   };
 
   let lineHasRuby = false;
+  let lineEastAsian = false;
   const flush = (forceHeight?: number, brTerminated = false) => {
     applyBidiTabs();
-    const h = forceHeight !== undefined ? forceHeight : (lineHeight || 10);
+    // §17.3.3.1 — the break is one run among the line's runs: its own size
+    // participates in the line height but must not override a taller peer.
+    const h = forceHeight !== undefined ? Math.max(lineHeight, forceHeight) : (lineHeight || 10);
     // If the line has no measured content (empty/line-break line), synthesize
     // stable ascent/descent from the effective font size so wrap/baseline math
     // stays consistent with non-empty lines.
@@ -2380,10 +2395,11 @@ export function layoutLines(
       availWidth: lineMaxWidth,
       topY: wrapCtx ? currentLineTopY : undefined,
       hasRuby: lineHasRuby,
+      eastAsian: lineEastAsian,
       endsWithBreak: brTerminated,
     });
     if (wrapCtx) {
-      currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle, h * scale);
+      currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle, h * scale, lineEastAsian);
     }
     currentLine = [];
     currentWidth = 0;
@@ -2393,6 +2409,7 @@ export function layoutLines(
     lineDescent = 0;
     lineIntendedSingle = 0;
     lineHasRuby = false;
+    lineEastAsian = false;
     isFirst = false;
     startLine(minLineStartWidth());
   };
@@ -2414,6 +2431,7 @@ export function layoutLines(
     if (!('isTab' in s) && !('imagePath' in s) && !('mathNodes' in s)) {
       const ts = s as LayoutTextSeg;
       if (ts.ruby) lineHasRuby = true;
+      if (!lineEastAsian && EAST_ASIAN_RE.test(ts.text)) lineEastAsian = true;
       // Intended single-line height for fonts whose substituted Canvas metrics
       // understate Word's line spacing (font-metrics.ts). 0 for untabled fonts.
       // Small caps (non-super/sub) keep the FULL run size here so the line box

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -222,7 +222,7 @@ export function measureParagraph(
         columnWidthPt: placement.availableWidthPt,
         floats: [],
         lineWindow: (input) => placement.wrap!.lineWindow(input),
-        lineBoxH: (ascent, descent, _hasRuby, intendedSingle) => lineBoxHeight(
+        lineBoxH: (ascent, descent, _hasRuby, intendedSingle, emPx) => lineBoxHeight(
           context.lineSpacing,
           ascent,
           descent,
@@ -231,6 +231,7 @@ export function measureParagraph(
           context.hasRuby,
           intendedSingle ?? 0,
           context.hasEastAsianText,
+          emPx,
         ),
         pageH: placement.maximumYPt,
       }
@@ -264,6 +265,7 @@ export function measureParagraph(
           true,
           line.intendedSingle,
           context.hasEastAsianText,
+          line.height,
         ))),
         grid,
       )
@@ -284,6 +286,7 @@ export function measureParagraph(
           false,
           line.intendedSingle,
           context.hasEastAsianText,
+          line.height,
         );
     measuredLines.push({ layout: line, topYPt, advancePt });
     cursorPt = topYPt + advancePt;

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -222,7 +222,7 @@ export function measureParagraph(
         columnWidthPt: placement.availableWidthPt,
         floats: [],
         lineWindow: (input) => placement.wrap!.lineWindow(input),
-        lineBoxH: (ascent, descent, _hasRuby, intendedSingle, emPx) => lineBoxHeight(
+        lineBoxH: (ascent, descent, _hasRuby, intendedSingle, emPx, eastAsian) => lineBoxHeight(
           context.lineSpacing,
           ascent,
           descent,
@@ -230,7 +230,9 @@ export function measureParagraph(
           grid,
           context.hasRuby,
           intendedSingle ?? 0,
-          context.hasEastAsianText,
+          // §17.6.5 cell rounding follows this line's script, matching text boxes;
+          // ruby paragraphs retain their established uniform paragraph resolver.
+          context.hasRuby ? context.hasEastAsianText : (eastAsian ?? false),
           emPx,
         ),
         pageH: placement.maximumYPt,
@@ -285,7 +287,9 @@ export function measureParagraph(
           grid,
           false,
           line.intendedSingle,
-          context.hasEastAsianText,
+          // §17.6.5 cell rounding is gated by the line's script; a Latin-only
+          // line in a CJK paragraph keeps its natural height.
+          line.eastAsian ?? false,
           line.height,
         );
     measuredLines.push({ layout: line, topYPt, advancePt });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6487,7 +6487,7 @@ function resolveFrameBox(
   const contentH = lines.reduce(
     (s, l) =>
       s +
-      lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, paraHasRuby, l.intendedSingle, paragraphContext.hasEastAsianText),
+      lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, paraHasRuby, l.intendedSingle, paragraphContext.hasEastAsianText, l.height * scale),
     0,
   );
 
@@ -6803,7 +6803,7 @@ function renderParagraph(
     columnXPt: contentX,
     columnWidthPt: contentW,
     floats: state.floats,
-    lineBoxH: (a, d, _h, is) => lineBoxHeight(para.lineSpacing, a, d, scale, grid, paraHasRuby, is ?? 0, paragraphContext.hasEastAsianText),
+    lineBoxH: (a, d, _h, is, emPx) => lineBoxHeight(para.lineSpacing, a, d, scale, grid, paraHasRuby, is ?? 0, paragraphContext.hasEastAsianText, emPx),
     pageH: state.pageH,
   } : undefined;
 
@@ -6979,7 +6979,7 @@ function renderParagraph(
   // else just the max natural.
   const uniformLineH = paraHasRuby
     ? snapParaLineToGrid(
-        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, paragraphContext.hasEastAsianText))),
+        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, paragraphContext.hasEastAsianText, l.height * scale))),
         grid,
         scale,
       )
@@ -6987,7 +6987,7 @@ function renderParagraph(
   const lineHForLine = (l: typeof lines[number]): number =>
     paraHasRuby
       ? uniformLineH
-      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, paragraphContext.hasEastAsianText);
+      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, paragraphContext.hasEastAsianText, l.height * scale);
 
   // Slice bounds — when the paginator split this paragraph across pages,
   // only render lines in [sliceStart, sliceEnd). The first line we paint
@@ -8981,7 +8981,7 @@ export function measureShapeTextAutoFitHeight(
       ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
       : null;
     const eastAsian = EAST_ASIAN_RE.test(lineText);
-    return lineBoxHeight(ls, c.ascent, c.descent, scale, effState.docGrid, false, floorPx, eastAsian);
+    return lineBoxHeight(ls, c.ascent, c.descent, scale, effState.docGrid, false, floorPx, eastAsian, fontPx);
   };
 
   const spBefore = blocks.map((b) => (b.spaceBefore ?? 0) * scale);
@@ -9205,7 +9205,7 @@ export function renderShapeText(
     const ls: LineSpacing | null = b.lineSpacingRule
       ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
       : null;
-    const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, grid, false, intended, eastAsian);
+    const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, grid, false, intended, eastAsian, fontPx);
     // Word centers the font's GLYPH box within the (possibly expanded) line box
     // (half-leading): when line-spacing or the design-line floor grows the box
     // the extra space is split above and below the glyph box, so the baseline is
@@ -10721,7 +10721,7 @@ function measureCellParagraphHeight(
     const uniformLineH = paraHasRuby
       ? snapParaLineToGrid(
           Math.max(0, ...paintLines.map((l) => lineBoxHeight(
-            para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, eastAsian,
+            para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, eastAsian, l.height * scale,
           ))),
           grid,
           scale,
@@ -10730,7 +10730,7 @@ function measureCellParagraphHeight(
     const lineHForLine = (l: LayoutLine): number =>
       paraHasRuby
         ? uniformLineH
-        : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, eastAsian);
+        : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, eastAsian, l.height * scale);
     return paintedParagraphHeight(paintLines, 0, paintLines.length, 0, lineHForLine);
   }
 }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6487,7 +6487,19 @@ function resolveFrameBox(
   const contentH = lines.reduce(
     (s, l) =>
       s +
-      lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, paraHasRuby, l.intendedSingle, paragraphContext.hasEastAsianText, l.height * scale),
+      lineBoxHeight(
+        para.lineSpacing,
+        l.ascent,
+        l.descent,
+        scale,
+        grid,
+        paraHasRuby,
+        l.intendedSingle,
+        // §17.6.5 cell rounding follows this line's script, matching text boxes;
+        // ruby paragraphs retain their established uniform paragraph resolver.
+        paraHasRuby ? paragraphContext.hasEastAsianText : (l.eastAsian ?? false),
+        l.height * scale,
+      ),
     0,
   );
 
@@ -6803,7 +6815,19 @@ function renderParagraph(
     columnXPt: contentX,
     columnWidthPt: contentW,
     floats: state.floats,
-    lineBoxH: (a, d, _h, is, emPx) => lineBoxHeight(para.lineSpacing, a, d, scale, grid, paraHasRuby, is ?? 0, paragraphContext.hasEastAsianText, emPx),
+    lineBoxH: (a, d, _h, is, emPx, ea) => lineBoxHeight(
+      para.lineSpacing,
+      a,
+      d,
+      scale,
+      grid,
+      paraHasRuby,
+      is ?? 0,
+      // §17.6.5 cell rounding follows this line's script, matching text boxes;
+      // ruby paragraphs retain their established uniform paragraph resolver.
+      paraHasRuby ? paragraphContext.hasEastAsianText : (ea ?? false),
+      emPx,
+    ),
     pageH: state.pageH,
   } : undefined;
 
@@ -6987,7 +7011,9 @@ function renderParagraph(
   const lineHForLine = (l: typeof lines[number]): number =>
     paraHasRuby
       ? uniformLineH
-      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, paragraphContext.hasEastAsianText, l.height * scale);
+      // §17.6.5 cell rounding is gated by the line's script; a Latin-only line
+      // in a CJK paragraph keeps its natural height, matching the text-box path.
+      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, l.eastAsian ?? false, l.height * scale);
 
   // Slice bounds — when the paginator split this paragraph across pages,
   // only render lines in [sliceStart, sliceEnd). The first line we paint
@@ -8981,7 +9007,9 @@ export function measureShapeTextAutoFitHeight(
       ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
       : null;
     const eastAsian = EAST_ASIAN_RE.test(lineText);
-    return lineBoxHeight(ls, c.ascent, c.descent, scale, effState.docGrid, false, floorPx, eastAsian, fontPx);
+    // Ruby lines reserve real furigana height, so use the measured glyph box,
+    // mirroring the body path.
+    return lineBoxHeight(ls, c.ascent, c.descent, scale, effState.docGrid, line.hasRuby ?? false, floorPx, eastAsian, fontPx);
   };
 
   const spBefore = blocks.map((b) => (b.spaceBefore ?? 0) * scale);
@@ -9165,6 +9193,7 @@ export function renderShapeText(
     lineFloorPx?: number,
     grid?: DocGridCtx,
     eastAsian = false,
+    hasRuby = false,
   ): { lineH: number; baselineOffset: number } => {
     // Floor the single-line box by the TALLEST design line among the run's
     // declared faces (ascii §17.3.2.26 + eastAsia). The common Japanese encoding
@@ -9205,7 +9234,9 @@ export function renderShapeText(
     const ls: LineSpacing | null = b.lineSpacingRule
       ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
       : null;
-    const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, grid, false, intended, eastAsian, fontPx);
+    // Ruby lines reserve real furigana height, so use the measured glyph box,
+    // mirroring the body path.
+    const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, grid, hasRuby, intended, eastAsian, fontPx);
     // Word centers the font's GLYPH box within the (possibly expanded) line box
     // (half-leading): when line-spacing or the design-line floor grows the box
     // the extra space is split above and below the glyph box, so the baseline is
@@ -9262,6 +9293,7 @@ export function renderShapeText(
       floorPx,
       effState.docGrid,
       eastAsian,
+      line.hasRuby ?? false,
     );
   };
 
@@ -10730,7 +10762,9 @@ function measureCellParagraphHeight(
     const lineHForLine = (l: LayoutLine): number =>
       paraHasRuby
         ? uniformLineH
-        : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, eastAsian, l.height * scale);
+        // §17.6.5 cell rounding is gated by the line's script; a Latin-only line
+        // in a CJK paragraph keeps its natural height, matching the text-box path.
+        : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, l.eastAsian ?? false, l.height * scale);
     return paintedParagraphHeight(paintLines, 0, paintLines.length, 0, lineHForLine);
   }
 }

--- a/packages/docx/src/table-cell-docgrid.test.ts
+++ b/packages/docx/src/table-cell-docgrid.test.ts
@@ -113,6 +113,36 @@ function paragraph(): DocParagraph {
   } as unknown as DocParagraph;
 }
 
+/** A paragraph with caller-supplied runs (fontSize in pt; text runs get the
+ *  same inert defaults as {@link paragraph}). */
+function paragraphWithRuns(runs: Record<string, unknown>[]): DocParagraph {
+  const base = paragraph() as unknown as { runs: unknown[] };
+  base.runs = runs.map((r) => (
+    r.type === 'break'
+      ? r
+      : {
+          type: 'text',
+          bold: false, italic: false, underline: false, strikethrough: false,
+          color: null, fontFamily: 'serif', fontFamilyEastAsia: 'serif',
+          isLink: false, background: null, vertAlign: null, hyperlink: null,
+          ...r,
+        }
+  ));
+  return base as unknown as DocParagraph;
+}
+
+function cellWith(para: DocParagraph): DocTableCell {
+  const c = cell() as unknown as { content: unknown[] };
+  c.content = [{ type: 'paragraph', ...para }];
+  return c as unknown as DocTableCell;
+}
+
+function rowWith(para: DocParagraph): DocTableRow {
+  const r = row() as unknown as { cells: unknown[] };
+  r.cells = [cellWith(para)];
+  return r as unknown as DocTableRow;
+}
+
 function cell(): DocTableCell {
   return {
     content: [{ type: 'paragraph', ...paragraph() }],
@@ -189,5 +219,46 @@ describe('table-cell line grid compatibility', () => {
       1,
       makeMeasureState(true, 'snapToChars'),
     )).toBe(20);
+  });
+});
+
+// The docGrid line-cell count (docGridLineCells) is derived from the line's em
+// — the TALLEST run on the line (ECMA-376 §17.6.5; the grid reserves whole
+// cells for the line box, which the tallest run governs). These integration
+// cases pin two call-path properties the pure lineBoxHeight tests cannot see:
+// which em the layout hands over, and which script gate each LINE uses. The
+// grid is active in a cell via adjustLineHeightInTable (§17.15.3.1); pitch =
+// 20 pt; the mock font box is a fixed 8+2 px, so every height difference below
+// comes from the em / script routing alone.
+describe('docGrid line-cell integration through the cell measure path', () => {
+  it('a manual line break in a SMALLER run does not shrink the line em (tallest governs)', () => {
+    // Line 1: 'あ' at 20 pt + 'い' at 10 pt, terminated by a <w:br> whose
+    // nearby size resolves to 10 pt (§17.3.3.1; findNearbyFontSize looks at the
+    // preceding run). Line 2: 'う' at 10 pt. The break must NOT overwrite the
+    // line's tallest em (20 pt → floor(20/20)+1 = 2 cells = 40) with its own
+    // 10 pt (1 cell = 20).
+    const para = paragraphWithRuns([
+      { text: 'あ', fontSize: 20 },
+      { text: 'い', fontSize: 10 },
+      { type: 'break', breakType: 'line' },
+      { text: 'う', fontSize: 10 },
+    ]);
+    expect(calculateRowHeight(rowWith(para), table(), [100], 1, makeMeasureState(true)))
+      .toBe(60); // 40 (2 cells) + 20 (1 cell)
+  });
+
+  it('the East Asian cell rounding is gated per LINE, not per paragraph', () => {
+    // Line 1: CJK 10 pt → 1 cell (20). Line 2: Latin-only 'Hello' at 22 pt —
+    // Word does not cell-round Latin lines; they keep their natural height
+    // above a one-cell floor (mock natural = 10 px → floor = 20), NOT the em
+    // cell count floor(22/20)+1 = 2 cells = 40 that a paragraph-level East
+    // Asian flag would apply.
+    const para = paragraphWithRuns([
+      { text: 'あ', fontSize: 10 },
+      { type: 'break', breakType: 'line' },
+      { text: 'Hello', fontSize: 22 },
+    ]);
+    expect(calculateRowHeight(rowWith(para), table(), [100], 1, makeMeasureState(true)))
+      .toBe(40); // 20 (CJK, 1 cell) + 20 (Latin, one-cell floor)
   });
 });

--- a/packages/docx/src/textbox-docgrid-line-pitch.test.ts
+++ b/packages/docx/src/textbox-docgrid-line-pitch.test.ts
@@ -95,6 +95,33 @@ function firstLineHeight(fillTexts: FillTextEvent[]): number {
   return ys[1] - ys[0];
 }
 
+/** A text box whose every run carries a ruby annotation (§17.3.3.25), base
+ *  18 pt on an 18 pt pitch. Three 3-char ruby runs — the mock measureText is
+ *  chars × px, so each 3 × 18 pt run exactly fills the 60 pt width and lands on
+ *  its own line, and every line carries a ruby-bearing segment (layoutLines
+ *  attaches the annotation to a run's first segment). */
+function rubyTextbox(): ShapeRun {
+  const mkRun = (text: string) => ({
+    text, fontSizePt: 18, fontFamily: '游明朝', fontFamilyEastAsia: '游明朝',
+    ruby: { text: 'るび', fontSizePt: 9 },
+  });
+  const block: ShapeText = {
+    text: 'あいうかきくさしす',
+    fontSizePt: 18,
+    alignment: 'left',
+    runs: [mkRun('あいう'), mkRun('かきく'), mkRun('さしす')],
+  } as ShapeText;
+  return {
+    type: 'shape',
+    zOrder: 0, subpaths: [], presetGeometry: 'rect',
+    fill: null, stroke: null,
+    behindDoc: false, wrapMode: 'none',
+    widthPt: 60, heightPt: 400,
+    textBlocks: [block], textAnchor: 't',
+    textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+  } as unknown as ShapeRun;
+}
+
 describe('text-box lines snap to the section docGrid line pitch (ECMA-376 §17.6.5)', () => {
   const PITCH = 18;      // 360 twips
   const NATURAL = 10;    // mock 1.0×em at 10 pt
@@ -127,5 +154,39 @@ describe('text-box lines snap to the section docGrid line pitch (ECMA-376 §17.6
     expect(lineCount).toBeGreaterThanOrEqual(2);
     expect(hGrid).toBeCloseTo(lineCount * PITCH, 3);
     expect(hGrid).toBeGreaterThan(hFlat + 0.5);
+  });
+
+  // §17.3.3.25 ruby in a text box flows through the SAME shared line engine as
+  // body ruby, so a ruby line must take lineBoxHeight's ruby branch (measured
+  // glyph box), NOT the plain-EA em cell count. With the mock's 1.0×em box an
+  // 18 pt ruby base on an 18 pt pitch measures exactly one cell — the em rule
+  // (floor(18/18)+1 = 2 cells = 36 pt) would open a spurious extra cell under
+  // every ruby line. `line.hasRuby` (built by layoutLines from the run's ruby
+  // annotation) must reach lineBoxHeight in BOTH text-box paths.
+  it('renderShapeText keeps a ruby line on its measured glyph box (1 cell), not the em cell count', () => {
+    const { ctx, fillTexts } = makeRecordingCanvas();
+    renderShapeText(rubyTextbox(), 0, 0, 60, 400, ctx, 1, {}, new Map(),
+      stateWithGrid(ctx, { type: 'lines', linePitchPt: PITCH }));
+    // Ruby annotations draw at their own y; measure the BASE lines only (18 px
+    // mock font). Base baselines are 18 pt apart (1 cell), not 36 (2 cells).
+    const baseYs = [...new Set(
+      fillTexts.filter((f) => f.text !== 'るび').map((f) => f.y),
+    )].sort((a, b) => a - b);
+    expect(baseYs.length).toBeGreaterThanOrEqual(2);
+    expect(baseYs[1] - baseYs[0]).toBeCloseTo(PITCH, 3);
+  });
+
+  it('measureShapeTextAutoFitHeight totals ruby lines at the measured glyph box (1 cell each)', () => {
+    const { ctx } = makeRecordingCanvas();
+    const shape = rubyTextbox();
+    const gridState = stateWithGrid(ctx, { type: 'lines', linePitchPt: PITCH });
+    const flatState = stateWithGrid(ctx, { type: 'default', linePitchPt: null });
+    const hGrid = measureShapeTextAutoFitHeight(shape, 60, ctx, 1, {}, new Map(), gridState);
+    const hFlat = measureShapeTextAutoFitHeight(shape, 60, ctx, 1, {}, new Map(), flatState);
+    // Off-grid each 18 pt line is its 18 px natural box, so the line count is
+    // hFlat / 18; on-grid each ruby line is ONE 18 pt cell — identical total.
+    const lineCount = Math.round(hFlat / 18);
+    expect(lineCount).toBeGreaterThanOrEqual(2);
+    expect(hGrid).toBeCloseTo(lineCount * PITCH, 3);
   });
 });


### PR DESCRIPTION
## Problem

In an ECMA-376 §17.6.5 document-grid section (`<w:docGrid w:type="lines" …>`),
each single-spaced East Asian line snaps to a whole number of grid cells. The
cell **count** was derived from the Canvas glyph box
(`fontBoundingBoxAscent + fontBoundingBoxDescent`), which for CJK faces is
~1.602 em. So a 12 pt run on an 18 pt line pitch computed
`ceil(12 * 1.602 / 18) = 2` cells = 36 pt, while Word snaps it to **1 cell =
18 pt**. Every over-counted line pushed the following content ~18 pt down, so
body paragraphs above an anchored object drifted below their Word positions.

## Fix

The cell count is a function of the run **em** (font size), not the substituted
font's leading. This adds a pure helper and threads the line em into
`lineBoxHeight`:

```
docGridLineCells(emPx, pitchPx) = floor(emPx / pitchPx) + 1
```

### Why `floor(em/pitch) + 1`

Word PDF exports (`pdftotext -bbox`) give three data points:

| em | pitch | Word cells |
|----|-------|-----------|
| 10.5 pt | 18 pt | 1 |
| 12 pt | 18 pt | 1 |
| 20 pt | 20 pt | 2 |

`ceil(em/pitch)` fails the `em == pitch` boundary (gives 1, Word wants 2).
`floor(em/pitch) + 1` fits all three: an em square that exactly fills *k*
pitches still needs its inter-line leading and spills into cell *k+1*. The
sub-pitch region and the `em == pitch` boundary are measured; the `k ≥ 2`
region extrapolates the scale-free boundary rule (no Word measurement covers
it yet — recorded as such in the contract comment). ECMA-376 §17.6.5 defines
`linePitch` as the height of one single-spaced line; the whole-cell rounding of
taller lines is Word runtime behaviour (no empirical thresholds or ratio
constants are introduced).

### Scope

- The rule is gated **per line**, on the line's script (`EAST_ASIAN_RE` over
  its text segments) — a Latin-only line inside a CJK paragraph keeps its
  natural height above a one-cell floor, matching the text-box paths.
- The line's em is the **tallest run** on the line (a conservative
  anti-clipping choice consistent with §17.3.1.33); a manual line break's run
  size participates in the line height but no longer overrides a taller peer.
- **Ruby lines** (body and text-box) are excluded: their measured glyph box
  reserves the base text plus the raised furigana annotation, which the em
  would collapse and clip — they keep the measured-glyph-box cell rounding.
  Ruby paragraphs also keep their paragraph-uniform line height unchanged.
- Latin, off-grid, `exact` / `auto`, and non-grid paths are unchanged.
- `atLeast` on an active grid **changes**: its grid-minimum term is now the
  em-based single cell instead of the glyph-box rounding, so a 12 pt line with
  a 19.22 px glyph box on an 18 pt pitch resolves to its natural 19.22 px
  (previously 36 px). No corpus sample exercises this combination and a Word
  fixture export could not be captured, so the exact Word behaviour is
  unverified; the current resolution is pinned by dedicated `[pin]` tests so
  any future change is deliberate.

## Review follow-ups (second commit set)

An adversarial review of the first commit found three call-path regressions,
each now pinned by a failing-first unit test:

1. **Text-box ruby** — both text-box height paths hard-coded `hasRuby=false`;
   they now forward `LayoutLine.hasRuby` so §17.3.3.25 ruby lines keep their
   furigana reserve (render + `spAutoFit` measure).
2. **Manual line break** — `<w:br>` overwrote the line's tallest run size with
   the break run's own size, shrinking the em (20 pt CJK line with a 10 pt
   break run: 2 cells → 1). Fixed with `Math.max`.
3. **Per-line script gate** — body call sites used the paragraph-level East
   Asian flag; a per-line flag now feeds every non-ruby resolution.

## Verification

- `@silurus/ooxml-docx` unit suite: **1088 passed** (new cell-count, ruby,
  manual-break, per-line-gate, and atLeast-pin cases included).
- Root `tsc --build`: **0 errors**.
- Headless render (real Yu Mincho) of a line-grid East Asian document matches
  the Word baselines: the top line unchanged, the heading and following lines
  rise onto Word's grid (band deltas 36.0 / 18.0 / 18.0 pt vs Word's
  35.6 / 18.5 / 17.9).
- A line-grid document with a 20 pt title stays 2 cells (40 pt/line).
- Before/after render of the line-grid visual-regression samples: non-East-
  Asian and ruby grid content is byte-identical; a vertical (tbRl) line-grid
  sample moves toward its Word reference; **no page moves away**. Unchanged
  after the review follow-ups.

Note: the committed Playwright VRT targets Google Chrome (`channel: "chrome"`),
which is not installed in this environment, so the browser VRT itself was not
executed; the direction was verified with the headless render comparison above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)