### PR TITLE
Share paragraph line-break selection between body and cells

### DIFF
--- a/packages/docx/src/line-fit-policy.test.ts
+++ b/packages/docx/src/line-fit-policy.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { adjustForWidowOrphan, selectLargestFittingEnd } from './line-fit-policy.js';
+
+describe('§17.4.6/§17.3.1.44-.45 selectLargestFittingEnd', () => {
+  it('returns an empty selection when the candidate range is empty', () => {
+    expect(selectLargestFittingEnd(3, 3, 100, () => 1)).toEqual({ end: 3, height: 0 });
+  });
+
+  it('includes an end whose height exactly equals the available height', () => {
+    expect(selectLargestFittingEnd(1, 3, 5, (end) => end === 2 ? 5 : 8)).toEqual({ end: 2, height: 5 });
+  });
+
+  it('returns end === start when the first line does not fit', () => {
+    expect(selectLargestFittingEnd(2, 4, 6, () => 7)).toEqual({ end: 2, height: 0 });
+  });
+
+  it('stops at the first overflow even if a later end would fit', () => {
+    const visited: number[] = [];
+    const heights = new Map([[1, 4], [2, 7], [3, 5]]);
+
+    const selection = selectLargestFittingEnd(0, 3, 5, (end) => {
+      visited.push(end);
+      return heights.get(end) as number;
+    });
+
+    expect(selection).toEqual({ end: 1, height: 4 });
+    expect(visited).toEqual([1, 2]);
+  });
+});
+
+describe('§17.3.1.44-.45 adjustForWidowOrphan', () => {
+  const input = {
+    widowControl: true,
+    start: 0,
+    end: 3,
+    totalLines: 4,
+    belowColumnTop: false,
+  };
+
+  it('drops the last selected line only for a one-line remainder after keeping at least two lines', () => {
+    expect(adjustForWidowOrphan(input)).toEqual({ kind: 'dropLastLine' });
+    expect(adjustForWidowOrphan({ ...input, end: 2 })).toEqual({ kind: 'keep' });
+    expect(adjustForWidowOrphan({ ...input, start: 2 })).toEqual({ kind: 'keep' });
+  });
+
+  it('relocates only a lone first line selected below the column top', () => {
+    const orphan = { ...input, end: 1, belowColumnTop: true };
+
+    expect(adjustForWidowOrphan(orphan)).toEqual({ kind: 'relocate' });
+    expect(adjustForWidowOrphan({ ...orphan, start: 1, end: 2 })).toEqual({ kind: 'keep' });
+    expect(adjustForWidowOrphan({ ...orphan, end: 2 })).toEqual({ kind: 'keep' });
+    expect(adjustForWidowOrphan({ ...orphan, belowColumnTop: false })).toEqual({ kind: 'keep' });
+  });
+
+  it('keeps the greedy selection when widow control is disabled', () => {
+    expect(adjustForWidowOrphan({ ...input, widowControl: false })).toEqual({ kind: 'keep' });
+    expect(adjustForWidowOrphan({
+      ...input,
+      widowControl: false,
+      end: 1,
+      belowColumnTop: true,
+    })).toEqual({ kind: 'keep' });
+  });
+});

--- a/packages/docx/src/line-fit-policy.test.ts
+++ b/packages/docx/src/line-fit-policy.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { adjustForWidowOrphan, selectLargestFittingEnd } from './line-fit-policy.js';
 
-describe('§17.4.6/§17.3.1.44-.45 selectLargestFittingEnd', () => {
+describe('selectLargestFittingEnd — greedy break selection (layout convention; §17.4.6 gates live in the callers)', () => {
   it('returns an empty selection when the candidate range is empty', () => {
-    expect(selectLargestFittingEnd(3, 3, 100, () => 1)).toEqual({ end: 3, height: 0 });
+    expect(selectLargestFittingEnd(3, 3, 100, () => 1)).toEqual({ end: 3, fitValue: 0 });
   });
 
   it('includes an end whose height exactly equals the available height', () => {
-    expect(selectLargestFittingEnd(1, 3, 5, (end) => end === 2 ? 5 : 8)).toEqual({ end: 2, height: 5 });
+    expect(selectLargestFittingEnd(1, 3, 5, (end) => end === 2 ? 5 : 8)).toEqual({ end: 2, fitValue: 5 });
   });
 
   it('returns end === start when the first line does not fit', () => {
-    expect(selectLargestFittingEnd(2, 4, 6, () => 7)).toEqual({ end: 2, height: 0 });
+    expect(selectLargestFittingEnd(2, 4, 6, () => 7)).toEqual({ end: 2, fitValue: 0 });
   });
 
   it('stops at the first overflow even if a later end would fit', () => {
@@ -23,18 +23,18 @@ describe('§17.4.6/§17.3.1.44-.45 selectLargestFittingEnd', () => {
       return heights.get(end) as number;
     });
 
-    expect(selection).toEqual({ end: 1, height: 4 });
+    expect(selection).toEqual({ end: 1, fitValue: 4 });
     expect(visited).toEqual([1, 2]);
   });
 });
 
-describe('§17.3.1.44-.45 adjustForWidowOrphan', () => {
+describe('§17.3.1.44 widowControl — adjustForWidowOrphan', () => {
   const input = {
     widowControl: true,
     start: 0,
     end: 3,
     totalLines: 4,
-    belowColumnTop: false,
+    canRelocate: false,
   };
 
   it('drops the last selected line only for a one-line remainder after keeping at least two lines', () => {
@@ -44,12 +44,12 @@ describe('§17.3.1.44-.45 adjustForWidowOrphan', () => {
   });
 
   it('relocates only a lone first line selected below the column top', () => {
-    const orphan = { ...input, end: 1, belowColumnTop: true };
+    const orphan = { ...input, end: 1, canRelocate: true };
 
     expect(adjustForWidowOrphan(orphan)).toEqual({ kind: 'relocate' });
     expect(adjustForWidowOrphan({ ...orphan, start: 1, end: 2 })).toEqual({ kind: 'keep' });
     expect(adjustForWidowOrphan({ ...orphan, end: 2 })).toEqual({ kind: 'keep' });
-    expect(adjustForWidowOrphan({ ...orphan, belowColumnTop: false })).toEqual({ kind: 'keep' });
+    expect(adjustForWidowOrphan({ ...orphan, canRelocate: false })).toEqual({ kind: 'keep' });
   });
 
   it('keeps the greedy selection when widow control is disabled', () => {
@@ -58,7 +58,7 @@ describe('§17.3.1.44-.45 adjustForWidowOrphan', () => {
       ...input,
       widowControl: false,
       end: 1,
-      belowColumnTop: true,
+      canRelocate: true,
     })).toEqual({ kind: 'keep' });
   });
 });

--- a/packages/docx/src/line-fit-policy.ts
+++ b/packages/docx/src/line-fit-policy.ts
@@ -1,0 +1,43 @@
+/**
+ * ECMA-376 §17.4.6 and §17.3.1.44-.45 line-break selection: returns the
+ * largest `end` in (start, limitEnd] whose caller-model cumulative height for
+ * [start, end) fits `available`. The walk stops at the first non-fitting end.
+ */
+export function selectLargestFittingEnd(
+  start: number,
+  limitEnd: number,
+  available: number,
+  heightAt: (end: number) => number,
+): { end: number; height: number } {
+  let end = start;
+  let height = 0;
+  for (let candidate = start + 1; candidate <= limitEnd; candidate++) {
+    const candidateHeight = heightAt(candidate);
+    if (!(candidateHeight <= available)) break;
+    end = candidate;
+    height = candidateHeight;
+  }
+  return { end, height };
+}
+
+/**
+ * ECMA-376 §17.3.1.44-.45 widow-orphan adjustment following greedy line
+ * selection. This pure decision mirrors the existing body pagination policy;
+ * §17.4.6 governs whether the analogous containing table row may split.
+ */
+export function adjustForWidowOrphan(input: {
+  widowControl: boolean;
+  start: number;
+  end: number;
+  totalLines: number;
+  belowColumnTop: boolean;
+}): { kind: 'keep' } | { kind: 'dropLastLine' } | { kind: 'relocate' } {
+  if (!input.widowControl || input.end >= input.totalLines) return { kind: 'keep' };
+  if (input.totalLines - input.end === 1 && input.end - input.start >= 2) {
+    return { kind: 'dropLastLine' };
+  }
+  if (input.start === 0 && input.end - input.start === 1 && input.belowColumnTop) {
+    return { kind: 'relocate' };
+  }
+  return { kind: 'keep' };
+}

--- a/packages/docx/src/line-fit-policy.ts
+++ b/packages/docx/src/line-fit-policy.ts
@@ -1,42 +1,77 @@
 /**
- * ECMA-376 §17.4.6 and §17.3.1.44-.45 line-break selection: returns the
- * largest `end` in (start, limitEnd] whose caller-model cumulative height for
- * [start, end) fits `available`. The walk stops at the first non-fitting end.
+ * Greedy line-break selection shared by the body paragraph splitter and the
+ * table-cell content splitter: returns the largest `end` in (start, limitEnd]
+ * whose caller-model cumulative fit measure for lines [start, end) fits
+ * `available`. The walk stops at the FIRST non-fitting end (both callers'
+ * measures are monotone; preserving the early stop keeps their historical
+ * float-comparison order bit-identical).
+ *
+ * ECMA-376 does not prescribe a line-selection algorithm for page/row filling;
+ * greedy forward filling is this renderer's established layout convention
+ * (§17.4.6 `cantSplit` and the header/exact-row rules gate WHETHER a row may
+ * split and are enforced by the callers, not here).
+ *
+ * CONTRACTS:
+ * - `fitAt` is invoked with STRICTLY INCREASING `end` values (start+1 ..
+ *   limitEnd, no gaps until the walk stops), so a caller may accumulate its
+ *   measure incrementally across calls — the body caller does, keeping the
+ *   whole selection O(n).
+ * - `fitAt` must return FINITE numbers. Line extents and collapsed spacing are
+ *   finite by construction in both callers; non-finite values are outside the
+ *   contract. (The `!(value <= available)` form stops the walk on NaN as a
+ *   fail-safe — matching the body caller's historical `<=` loop condition; the
+ *   cell caller's historical `>` break would have kept walking on NaN, an
+ *   unreachable difference under this contract, resolved in favor of
+ *   stopping.)
  */
 export function selectLargestFittingEnd(
   start: number,
   limitEnd: number,
   available: number,
-  heightAt: (end: number) => number,
-): { end: number; height: number } {
+  fitAt: (end: number) => number,
+): { end: number; fitValue: number } {
   let end = start;
-  let height = 0;
+  let fitValue = 0;
   for (let candidate = start + 1; candidate <= limitEnd; candidate++) {
-    const candidateHeight = heightAt(candidate);
-    if (!(candidateHeight <= available)) break;
+    const candidateValue = fitAt(candidate);
+    if (!(candidateValue <= available)) break;
     end = candidate;
-    height = candidateHeight;
+    fitValue = candidateValue;
   }
-  return { end, height };
+  return { end, fitValue };
 }
 
 /**
- * ECMA-376 §17.3.1.44-.45 widow-orphan adjustment following greedy line
- * selection. This pure decision mirrors the existing body pagination policy;
- * §17.4.6 governs whether the analogous containing table row may split.
+ * ECMA-376 §17.3.1.44 (`widowControl`) widow/orphan adjustment following the
+ * greedy selection. Pure decision mirroring the body pagination policy:
+ * - drop the selection's last line when exactly ONE line would remain for the
+ *   next page (a widow) and the selection keeps at least two lines;
+ * - relocate the whole paragraph when only its FIRST line was selected (an
+ *   orphan) and relocating can gain space (`canRelocate`).
+ * Side effects (extent bookkeeping, the page advance and remeasure) stay with
+ * the caller.
  */
 export function adjustForWidowOrphan(input: {
   widowControl: boolean;
   start: number;
   end: number;
   totalLines: number;
-  belowColumnTop: boolean;
+  /** Whether moving the paragraph to the next column/page can gain space. The
+   *  body caller passes its HISTORICAL condition `cursorY > 0` — the cursor
+   *  sits below the PAGE content top. This is deliberately NOT "below the
+   *  column top": in a continuous mid-page section (`colTop() > 0`) a
+   *  paragraph sitting exactly at the column top still relocates, as it always
+   *  did — preserving byte-identity with the pre-extraction behavior (which is
+   *  why the VRT pixel baseline holds). Whether a column-relative condition is
+   *  the better spec reading for mid-page regions is a separate question,
+   *  tracked outside this refactor. */
+  canRelocate: boolean;
 }): { kind: 'keep' } | { kind: 'dropLastLine' } | { kind: 'relocate' } {
   if (!input.widowControl || input.end >= input.totalLines) return { kind: 'keep' };
   if (input.totalLines - input.end === 1 && input.end - input.start >= 2) {
     return { kind: 'dropLastLine' };
   }
-  if (input.start === 0 && input.end - input.start === 1 && input.belowColumnTop) {
+  if (input.start === 0 && input.end - input.start === 1 && input.canRelocate) {
     return { kind: 'relocate' };
   }
   return { kind: 'keep' };

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4569,12 +4569,21 @@ function splitParagraphAcrossPages(
     while (lineIdx < lines.length) {
       const remaining = colBot() - cursorY;
       const firstFitting = lineIdx;
+      // O(n) running accumulation: the policy calls `fitAt` with strictly
+      // increasing `end` (its documented contract), so extending the previous
+      // sum by the newly covered extents reproduces the historical incremental
+      // loop's exact left-to-right float-addition order — bit-identical fit
+      // comparisons without re-summing from the start per candidate.
+      let accumulatedH = 0;
+      let accumulatedEnd = firstFitting;
       const fitting = selectLargestFittingEnd(firstFitting, lines.length, remaining, (end) => {
-        let height = 0;
-        for (let i = firstFitting; i < end; i++) height += lineExtents[i];
-        return height;
+        while (accumulatedEnd < end) {
+          accumulatedH += lineExtents[accumulatedEnd];
+          accumulatedEnd++;
+        }
+        return accumulatedH;
       });
-      let usedH = fitting.height;
+      let usedH = fitting.fitValue;
       let lastFitting = fitting.end;
       if (lastFitting === firstFitting) {
         if (cursorY > 0) {
@@ -4592,7 +4601,7 @@ function splitParagraphAcrossPages(
         start: firstFitting,
         end: lastFitting,
         totalLines: lines.length,
-        belowColumnTop: cursorY > 0,
+        canRelocate: cursorY > 0,
       });
       if (widowOrphan.kind === 'dropLastLine') {
         lastFitting--;
@@ -4602,7 +4611,7 @@ function splitParagraphAcrossPages(
           start: firstFitting,
           end: lastFitting,
           totalLines: lines.length,
-          belowColumnTop: cursorY > 0,
+          canRelocate: cursorY > 0,
         });
       }
       if (widowOrphan.kind === 'relocate') {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -102,6 +102,7 @@ import {
   resolveTableRowHeights,
   resolveSingleRowHeight,
 } from './table-geometry.js';
+import { adjustForWidowOrphan, selectLargestFittingEnd } from './line-fit-policy.js';
 import {
   computeSectionColumns as computeColumns,
   enterTableCellStoryContext,
@@ -4567,13 +4568,14 @@ function splitParagraphAcrossPages(
     let cursorY = initialY;
     while (lineIdx < lines.length) {
       const remaining = colBot() - cursorY;
-      let usedH = 0;
       const firstFitting = lineIdx;
-      let lastFitting = lineIdx;
-      while (lastFitting < lines.length && usedH + lineExtents[lastFitting] <= remaining) {
-        usedH += lineExtents[lastFitting];
-        lastFitting++;
-      }
+      const fitting = selectLargestFittingEnd(firstFitting, lines.length, remaining, (end) => {
+        let height = 0;
+        for (let i = firstFitting; i < end; i++) height += lineExtents[i];
+        return height;
+      });
+      let usedH = fitting.height;
+      let lastFitting = fitting.end;
       if (lastFitting === firstFitting) {
         if (cursorY > 0) {
           newPage(cursorY);
@@ -4585,17 +4587,29 @@ function splitParagraphAcrossPages(
         lastFitting = firstFitting + 1;
         usedH += lineExtents[firstFitting];
       }
-      if (para.widowControl !== false && lastFitting < lines.length) {
-        if (lines.length - lastFitting === 1 && lastFitting - firstFitting >= 2) {
-          lastFitting--;
-          usedH -= lineExtents[lastFitting];
-        }
-        if (firstFitting === 0 && lastFitting - firstFitting === 1 && cursorY > 0) {
-          newPage(cursorY);
-          cursorY = colTop();
-          remeasureBeforeFirstLine();
-          continue;
-        }
+      let widowOrphan = adjustForWidowOrphan({
+        widowControl: para.widowControl !== false,
+        start: firstFitting,
+        end: lastFitting,
+        totalLines: lines.length,
+        belowColumnTop: cursorY > 0,
+      });
+      if (widowOrphan.kind === 'dropLastLine') {
+        lastFitting--;
+        usedH -= lineExtents[lastFitting];
+        widowOrphan = adjustForWidowOrphan({
+          widowControl: true,
+          start: firstFitting,
+          end: lastFitting,
+          totalLines: lines.length,
+          belowColumnTop: cursorY > 0,
+        });
+      }
+      if (widowOrphan.kind === 'relocate') {
+        newPage(cursorY);
+        cursorY = colTop();
+        remeasureBeforeFirstLine();
+        continue;
       }
       const isFinalSlice = lastFitting === lines.length;
       if (isFinalSlice) usedH += trailingExtent;
@@ -5350,19 +5364,24 @@ function splitCellContentByHeight(
     }
 
     const splitPara = para ?? ce as unknown as DocParagraph;
-    let endLine = 0;
-    let sliceH = 0;
-    let sliceAddH = 0;
     const sliceStart = currentSlice?.start ?? 0;
     const sliceEnd = currentSlice?.end ?? layout.lines.length;
-    for (let end = sliceStart + 1; end <= sliceEnd; end++) {
-      const h = paragraphLineSliceHeight(splitPara, layout.lineHeights, sliceStart, end);
-      const addH = additionHeight(ce, h, { start: sliceStart, end });
-      if (beforeHeight + addH > maxContentHeightPt) break;
-      endLine = end;
-      sliceH = h;
-      sliceAddH = addH;
-    }
+    const fitting = selectLargestFittingEnd(
+      sliceStart,
+      sliceEnd,
+      maxContentHeightPt,
+      (end) => {
+        const h = paragraphLineSliceHeight(splitPara, layout.lineHeights, sliceStart, end);
+        return beforeHeight + additionHeight(ce, h, { start: sliceStart, end });
+      },
+    );
+    const endLine = fitting.end === sliceStart ? 0 : fitting.end;
+    const sliceH = endLine === 0
+      ? 0
+      : paragraphLineSliceHeight(splitPara, layout.lineHeights, sliceStart, endLine);
+    const sliceAddH = endLine === 0
+      ? 0
+      : additionHeight(ce, sliceH, { start: sliceStart, end: endLine });
     if (endLine === 0) {
       const after = content.slice(i);
       const afterHeight = sumContentHeightForSplit(after);


### PR DESCRIPTION
## Share paragraph line-break selection between body and cells

Stage B of the mid-page table-row-break series (per the staged design: A = the merged
table-fragment migration #919; C = ordinary mid-page row splitting, next). Pure
byte-identical refactor — no behavior change.

The body paragraph splitter (`splitParagraphAcrossPages`) and the table-cell content
splitter (`splitCellContentByHeight`) carried two copies of the same break-selection
policy (greedy forward walk, last fitting end, first-overflow stop; the body side adds
the §17.3.1.44/.45 widow/orphan adjustment). Both now route through a new pure
`line-fit-policy.ts`:

- `selectLargestFittingEnd` — the greedy selection over a caller-supplied cumulative
  height model (`<=` fit semantics, `end === start` when nothing fits);
- `adjustForWidowOrphan` — the widow-drop / orphan-relocate decision, side effects
  staying with the caller.

Byte-identity by construction: the body's height callback sums the line extents in the
exact left-to-right order of the previous incremental accumulation (bit-identical fit
comparisons and used heights); the cell callback reproduces the old per-candidate
`paragraphLineSliceHeight` + spacing-collapse evaluation order; the widow
drop-then-relocate sequencing re-evaluates against the decremented end exactly as the
old block did.

Policy unit tests were written Red-first against the loops' spec (exact-boundary fit,
nothing-fits sentinel, first-overflow stop, widow/orphan boundary conditions).

### Review fixes (no blockers; five findings, all addressed)

- **[medium] O(n²) body selection** → O(n) running accumulation backed by the policy's
  documented strictly-increasing-`end` contract (bit-identical float order).
- **[medium] `belowColumnTop` contract mismatch** → renamed to `canRelocate` with the
  historical page-relative condition (`cursorY > 0`) documented as deliberate (why the
  VRT byte-identity holds); the column-relative spec question tracked separately.
- **[low] NaN semantics** → finite-fit-measure contract documented; the NaN fail-safe
  matches the body caller's historical form, the cell caller's divergent historical
  form noted as unreachable under the contract.
- **[low] Spec citations** → §17.3.1.44 = widowControl (§17.3.1.45 is wordWrap,
  removed); §17.4.6 = cantSplit, a caller-side gate — comments and test names fixed.
- **[low] `{end, height}`** → `{end, fitValue}` (caller-model cumulative measure).

Full gate re-run: docx 1127 tests green; VRT 89 checks byte-identical to base.

### Verification

- Full docx suite 144 files / 1127 tests, 0 failed (pixel-exact paginate-paint goldens,
  the §17.6.4 re-wrap suite, table-split and cell-reuse suites included); docx tsc
  clean; `pnpm lint` 0; `pnpm lint:test` 4/4; `git diff --check` clean.
- Local pixel VRT: byte-identical to the base merge commit on all 89 checks (the two
  checks that moved against the previous branch's log reproduce EXACTLY at base — they
  belong to the parallel shape-text-spacing and RTL-fitText merges, not this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
