### PR TITLE
Split restart-merge rows mid-page and open the page-cut edges

### DIFF
--- a/packages/docx/src/line-fit-policy.test.ts
+++ b/packages/docx/src/line-fit-policy.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { adjustForWidowOrphan, selectLargestFittingEnd } from './line-fit-policy.js';
+
+describe('§17.4.6/§17.3.1.44-.45 selectLargestFittingEnd', () => {
+  it('returns an empty selection when the candidate range is empty', () => {
+    expect(selectLargestFittingEnd(3, 3, 100, () => 1)).toEqual({ end: 3, height: 0 });
+  });
+
+  it('includes an end whose height exactly equals the available height', () => {
+    expect(selectLargestFittingEnd(1, 3, 5, (end) => end === 2 ? 5 : 8)).toEqual({ end: 2, height: 5 });
+  });
+
+  it('returns end === start when the first line does not fit', () => {
+    expect(selectLargestFittingEnd(2, 4, 6, () => 7)).toEqual({ end: 2, height: 0 });
+  });
+
+  it('stops at the first overflow even if a later end would fit', () => {
+    const visited: number[] = [];
+    const heights = new Map([[1, 4], [2, 7], [3, 5]]);
+
+    const selection = selectLargestFittingEnd(0, 3, 5, (end) => {
+      visited.push(end);
+      return heights.get(end) as number;
+    });
+
+    expect(selection).toEqual({ end: 1, height: 4 });
+    expect(visited).toEqual([1, 2]);
+  });
+});
+
+describe('§17.3.1.44-.45 adjustForWidowOrphan', () => {
+  const input = {
+    widowControl: true,
+    start: 0,
+    end: 3,
+    totalLines: 4,
+    belowColumnTop: false,
+  };
+
+  it('drops the last selected line only for a one-line remainder after keeping at least two lines', () => {
+    expect(adjustForWidowOrphan(input)).toEqual({ kind: 'dropLastLine' });
+    expect(adjustForWidowOrphan({ ...input, end: 2 })).toEqual({ kind: 'keep' });
+    expect(adjustForWidowOrphan({ ...input, start: 2 })).toEqual({ kind: 'keep' });
+  });
+
+  it('relocates only a lone first line selected below the column top', () => {
+    const orphan = { ...input, end: 1, belowColumnTop: true };
+
+    expect(adjustForWidowOrphan(orphan)).toEqual({ kind: 'relocate' });
+    expect(adjustForWidowOrphan({ ...orphan, start: 1, end: 2 })).toEqual({ kind: 'keep' });
+    expect(adjustForWidowOrphan({ ...orphan, end: 2 })).toEqual({ kind: 'keep' });
+    expect(adjustForWidowOrphan({ ...orphan, belowColumnTop: false })).toEqual({ kind: 'keep' });
+  });
+
+  it('keeps the greedy selection when widow control is disabled', () => {
+    expect(adjustForWidowOrphan({ ...input, widowControl: false })).toEqual({ kind: 'keep' });
+    expect(adjustForWidowOrphan({
+      ...input,
+      widowControl: false,
+      end: 1,
+      belowColumnTop: true,
+    })).toEqual({ kind: 'keep' });
+  });
+});

--- a/packages/docx/src/line-fit-policy.test.ts
+++ b/packages/docx/src/line-fit-policy.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { adjustForWidowOrphan, selectLargestFittingEnd } from './line-fit-policy.js';
 
-describe('§17.4.6/§17.3.1.44-.45 selectLargestFittingEnd', () => {
+describe('selectLargestFittingEnd — greedy break selection (layout convention; §17.4.6 gates live in the callers)', () => {
   it('returns an empty selection when the candidate range is empty', () => {
-    expect(selectLargestFittingEnd(3, 3, 100, () => 1)).toEqual({ end: 3, height: 0 });
+    expect(selectLargestFittingEnd(3, 3, 100, () => 1)).toEqual({ end: 3, fitValue: 0 });
   });
 
   it('includes an end whose height exactly equals the available height', () => {
-    expect(selectLargestFittingEnd(1, 3, 5, (end) => end === 2 ? 5 : 8)).toEqual({ end: 2, height: 5 });
+    expect(selectLargestFittingEnd(1, 3, 5, (end) => end === 2 ? 5 : 8)).toEqual({ end: 2, fitValue: 5 });
   });
 
   it('returns end === start when the first line does not fit', () => {
-    expect(selectLargestFittingEnd(2, 4, 6, () => 7)).toEqual({ end: 2, height: 0 });
+    expect(selectLargestFittingEnd(2, 4, 6, () => 7)).toEqual({ end: 2, fitValue: 0 });
   });
 
   it('stops at the first overflow even if a later end would fit', () => {
@@ -23,18 +23,18 @@ describe('§17.4.6/§17.3.1.44-.45 selectLargestFittingEnd', () => {
       return heights.get(end) as number;
     });
 
-    expect(selection).toEqual({ end: 1, height: 4 });
+    expect(selection).toEqual({ end: 1, fitValue: 4 });
     expect(visited).toEqual([1, 2]);
   });
 });
 
-describe('§17.3.1.44-.45 adjustForWidowOrphan', () => {
+describe('§17.3.1.44 widowControl — adjustForWidowOrphan', () => {
   const input = {
     widowControl: true,
     start: 0,
     end: 3,
     totalLines: 4,
-    belowColumnTop: false,
+    canRelocate: false,
   };
 
   it('drops the last selected line only for a one-line remainder after keeping at least two lines', () => {
@@ -44,12 +44,12 @@ describe('§17.3.1.44-.45 adjustForWidowOrphan', () => {
   });
 
   it('relocates only a lone first line selected below the column top', () => {
-    const orphan = { ...input, end: 1, belowColumnTop: true };
+    const orphan = { ...input, end: 1, canRelocate: true };
 
     expect(adjustForWidowOrphan(orphan)).toEqual({ kind: 'relocate' });
     expect(adjustForWidowOrphan({ ...orphan, start: 1, end: 2 })).toEqual({ kind: 'keep' });
     expect(adjustForWidowOrphan({ ...orphan, end: 2 })).toEqual({ kind: 'keep' });
-    expect(adjustForWidowOrphan({ ...orphan, belowColumnTop: false })).toEqual({ kind: 'keep' });
+    expect(adjustForWidowOrphan({ ...orphan, canRelocate: false })).toEqual({ kind: 'keep' });
   });
 
   it('keeps the greedy selection when widow control is disabled', () => {
@@ -58,7 +58,7 @@ describe('§17.3.1.44-.45 adjustForWidowOrphan', () => {
       ...input,
       widowControl: false,
       end: 1,
-      belowColumnTop: true,
+      canRelocate: true,
     })).toEqual({ kind: 'keep' });
   });
 });

--- a/packages/docx/src/line-fit-policy.ts
+++ b/packages/docx/src/line-fit-policy.ts
@@ -1,0 +1,43 @@
+/**
+ * ECMA-376 §17.4.6 and §17.3.1.44-.45 line-break selection: returns the
+ * largest `end` in (start, limitEnd] whose caller-model cumulative height for
+ * [start, end) fits `available`. The walk stops at the first non-fitting end.
+ */
+export function selectLargestFittingEnd(
+  start: number,
+  limitEnd: number,
+  available: number,
+  heightAt: (end: number) => number,
+): { end: number; height: number } {
+  let end = start;
+  let height = 0;
+  for (let candidate = start + 1; candidate <= limitEnd; candidate++) {
+    const candidateHeight = heightAt(candidate);
+    if (!(candidateHeight <= available)) break;
+    end = candidate;
+    height = candidateHeight;
+  }
+  return { end, height };
+}
+
+/**
+ * ECMA-376 §17.3.1.44-.45 widow-orphan adjustment following greedy line
+ * selection. This pure decision mirrors the existing body pagination policy;
+ * §17.4.6 governs whether the analogous containing table row may split.
+ */
+export function adjustForWidowOrphan(input: {
+  widowControl: boolean;
+  start: number;
+  end: number;
+  totalLines: number;
+  belowColumnTop: boolean;
+}): { kind: 'keep' } | { kind: 'dropLastLine' } | { kind: 'relocate' } {
+  if (!input.widowControl || input.end >= input.totalLines) return { kind: 'keep' };
+  if (input.totalLines - input.end === 1 && input.end - input.start >= 2) {
+    return { kind: 'dropLastLine' };
+  }
+  if (input.start === 0 && input.end - input.start === 1 && input.belowColumnTop) {
+    return { kind: 'relocate' };
+  }
+  return { kind: 'keep' };
+}

--- a/packages/docx/src/line-fit-policy.ts
+++ b/packages/docx/src/line-fit-policy.ts
@@ -1,42 +1,77 @@
 /**
- * ECMA-376 §17.4.6 and §17.3.1.44-.45 line-break selection: returns the
- * largest `end` in (start, limitEnd] whose caller-model cumulative height for
- * [start, end) fits `available`. The walk stops at the first non-fitting end.
+ * Greedy line-break selection shared by the body paragraph splitter and the
+ * table-cell content splitter: returns the largest `end` in (start, limitEnd]
+ * whose caller-model cumulative fit measure for lines [start, end) fits
+ * `available`. The walk stops at the FIRST non-fitting end (both callers'
+ * measures are monotone; preserving the early stop keeps their historical
+ * float-comparison order bit-identical).
+ *
+ * ECMA-376 does not prescribe a line-selection algorithm for page/row filling;
+ * greedy forward filling is this renderer's established layout convention
+ * (§17.4.6 `cantSplit` and the header/exact-row rules gate WHETHER a row may
+ * split and are enforced by the callers, not here).
+ *
+ * CONTRACTS:
+ * - `fitAt` is invoked with STRICTLY INCREASING `end` values (start+1 ..
+ *   limitEnd, no gaps until the walk stops), so a caller may accumulate its
+ *   measure incrementally across calls — the body caller does, keeping the
+ *   whole selection O(n).
+ * - `fitAt` must return FINITE numbers. Line extents and collapsed spacing are
+ *   finite by construction in both callers; non-finite values are outside the
+ *   contract. (The `!(value <= available)` form stops the walk on NaN as a
+ *   fail-safe — matching the body caller's historical `<=` loop condition; the
+ *   cell caller's historical `>` break would have kept walking on NaN, an
+ *   unreachable difference under this contract, resolved in favor of
+ *   stopping.)
  */
 export function selectLargestFittingEnd(
   start: number,
   limitEnd: number,
   available: number,
-  heightAt: (end: number) => number,
-): { end: number; height: number } {
+  fitAt: (end: number) => number,
+): { end: number; fitValue: number } {
   let end = start;
-  let height = 0;
+  let fitValue = 0;
   for (let candidate = start + 1; candidate <= limitEnd; candidate++) {
-    const candidateHeight = heightAt(candidate);
-    if (!(candidateHeight <= available)) break;
+    const candidateValue = fitAt(candidate);
+    if (!(candidateValue <= available)) break;
     end = candidate;
-    height = candidateHeight;
+    fitValue = candidateValue;
   }
-  return { end, height };
+  return { end, fitValue };
 }
 
 /**
- * ECMA-376 §17.3.1.44-.45 widow-orphan adjustment following greedy line
- * selection. This pure decision mirrors the existing body pagination policy;
- * §17.4.6 governs whether the analogous containing table row may split.
+ * ECMA-376 §17.3.1.44 (`widowControl`) widow/orphan adjustment following the
+ * greedy selection. Pure decision mirroring the body pagination policy:
+ * - drop the selection's last line when exactly ONE line would remain for the
+ *   next page (a widow) and the selection keeps at least two lines;
+ * - relocate the whole paragraph when only its FIRST line was selected (an
+ *   orphan) and relocating can gain space (`canRelocate`).
+ * Side effects (extent bookkeeping, the page advance and remeasure) stay with
+ * the caller.
  */
 export function adjustForWidowOrphan(input: {
   widowControl: boolean;
   start: number;
   end: number;
   totalLines: number;
-  belowColumnTop: boolean;
+  /** Whether moving the paragraph to the next column/page can gain space. The
+   *  body caller passes its HISTORICAL condition `cursorY > 0` — the cursor
+   *  sits below the PAGE content top. This is deliberately NOT "below the
+   *  column top": in a continuous mid-page section (`colTop() > 0`) a
+   *  paragraph sitting exactly at the column top still relocates, as it always
+   *  did — preserving byte-identity with the pre-extraction behavior (which is
+   *  why the VRT pixel baseline holds). Whether a column-relative condition is
+   *  the better spec reading for mid-page regions is a separate question,
+   *  tracked outside this refactor. */
+  canRelocate: boolean;
 }): { kind: 'keep' } | { kind: 'dropLastLine' } | { kind: 'relocate' } {
   if (!input.widowControl || input.end >= input.totalLines) return { kind: 'keep' };
   if (input.totalLines - input.end === 1 && input.end - input.start >= 2) {
     return { kind: 'dropLastLine' };
   }
-  if (input.start === 0 && input.end - input.start === 1 && input.belowColumnTop) {
+  if (input.start === 0 && input.end - input.start === 1 && input.canRelocate) {
     return { kind: 'relocate' };
   }
   return { kind: 'keep' };

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -894,15 +894,15 @@ describe('computePages — over-tall table row splitting (§17.4 table paginatio
 // ─────────────────────────────────────────────────────────────────────────────
 describe('computePages — mid-page split of rows with vMerge restart cells (§17.4.85 + §17.4.6)', () => {
   const emptyBorders = () => ({ top: null, bottom: null, left: null, right: null, insideH: null, insideV: null });
-  const mkCell = (content: CellElement[], vMerge: boolean | null): DocTableCell => ({
-    content, colSpan: 1, vMerge, borders: emptyBorders(), background: null, vAlign: 'top', widthPt: null,
+  const mkCell = (content: CellElement[], vMerge: boolean | null, vAlign: 'top' | 'center' | 'bottom' = 'top'): DocTableCell => ({
+    content, colSpan: 1, vMerge, borders: emptyBorders(), background: null, vAlign, widthPt: null,
   } as unknown as DocTableCell);
   const shortPara = (text: string) => para({ text, fontSize: 20 }) as CellElement;
   /** [40pt label col | 120pt content col]; row0 = restart label + wrapping
    *  content (24 glyphs at 6/line ⇒ 4 lines = 80pt); rows 1-2 = continue label +
    *  short cell (20pt each). */
-  const restartSpanTable = (labelParas: number): BodyElement => {
-    const label = mkCell(Array.from({ length: labelParas }, (_v, i) => shortPara(`L${i}`)), true);
+  const restartSpanTable = (labelParas: number, labelVAlign: 'top' | 'center' | 'bottom' = 'top'): BodyElement => {
+    const label = mkCell(Array.from({ length: labelParas }, (_v, i) => shortPara(`L${i}`)), true, labelVAlign);
     const content = mkCell([para({ text: 'あ'.repeat(24), fontSize: 20 }) as CellElement], null);
     const contRow = (t: string): DocTableRow => ({
       cells: [mkCell([para({}) as CellElement], false), mkCell([shortPara(t)], null)],
@@ -977,6 +977,95 @@ describe('computePages — mid-page split of rows with vMerge restart cells (§1
     expect(second?.rows[0]?.cells[0]?.content).toHaveLength(3);
     expect(cellSlice(first, 0, 1)).toEqual({ start: 0, end: 3 });
     expect(cellSlice(second, 0, 1)).toEqual({ start: 3, end: 4 });
+    // Review note: this fixture's 120pt restart content coincidentally equals
+    // the base span height (extension zero). The band bound below keeps the
+    // case honest either way; the nonzero-extension regression lives in the
+    // dedicated double-counting test.
+    for (const pg of pages) {
+      const el = tblOn(pg);
+      if (!el) continue;
+      const placed = bodyFragmentFor(el as PaginatedBodyElement);
+      if (placed?.fragment.kind !== 'table') throw new Error('expected a table fragment');
+      expect(placed.heightPt).toBeLessThanOrEqual(100 + 1e-6);
+    }
+  });
+
+  it('re-derives the span extension once after the split (no double counting)', () => {
+    // Review repro (§17.4.85): restart content 200pt, normal cell 80pt (4
+    // lines), two 20pt continue rows, 100pt page body. The ORIGINAL heights
+    // resolver extended the merge-END row by 200 − (80+20+20) = 80pt; after
+    // the split that extension must be RE-DERIVED against the remaining
+    // restart content, not left in place while the pieces also carry the
+    // fitted content — the double count overflowed the body band and leaked
+    // an extra page.
+    const pages = computePages([restartSpanTable(10)], section(), makeCtx());
+
+    // Every page's table charges at most the 100pt body band.
+    for (const pg of pages) {
+      const el = tblOn(pg);
+      if (!el) continue;
+      const placed = bodyFragmentFor(el as PaginatedBodyElement);
+      if (placed?.fragment.kind !== 'table') throw new Error('expected a table fragment');
+      expect(placed.heightPt).toBeLessThanOrEqual(100 + 1e-6);
+    }
+
+    // Content appears exactly once: all 10 label paragraphs and the 4 content
+    // lines are placed with no duplication and no loss.
+    const labelTexts = pages.flatMap((pg) => pg.filter((el) => el.type === 'table'))
+      .flatMap((el) => (el as unknown as DocTable).rows)
+      .flatMap((r) => (r.cells[0]?.content ?? []))
+      .map((ce) => textOf(ce as unknown as PaginatedBodyElement));
+    expect(labelTexts.filter((t) => t.length > 0).sort()).toEqual(
+      Array.from({ length: 10 }, (_v, i) => `L${i}`).sort(),
+    );
+    const contentEls = pages.flatMap((pg) => pg.filter((el) => el.type === 'table'))
+      .flatMap((el) => (el as unknown as DocTable).rows)
+      .flatMap((r) => (r.cells[1]?.content ?? []))
+      .filter((ce) => textOf(ce as unknown as PaginatedBodyElement).startsWith('あ'));
+    const contentSlices = contentEls
+      .map((ce) => (ce as CellElement & { lineSlice?: { start: number; end: number } }).lineSlice)
+      .filter((s): s is { start: number; end: number } => s !== undefined);
+    if (contentSlices.length > 0) {
+      // Sliced: the 4 content lines cover [0,4) exactly once across all slices.
+      const covered = contentSlices
+        .flatMap((s) => Array.from({ length: s.end - s.start }, (_v, k) => s.start + k))
+        .sort();
+      expect(covered).toEqual([0, 1, 2, 3]);
+      expect(contentEls).toHaveLength(contentSlices.length);
+    } else {
+      // Whole: the content paragraph was placed exactly once.
+      expect(contentEls).toHaveLength(1);
+    }
+  });
+
+  it('splits a row whose restart label is vAlign=center (target-class shape; placement Word-unverified)', () => {
+    // The target document class centres its restart label cells. The split must
+    // still fire (excluding center/bottom would push the whole span to the next
+    // page and regress the class); each PIECE then re-centres its own fitted
+    // content within its page-local box. Word ground truth for the per-piece
+    // vertical placement is NOT available — this pins the STRUCTURE (split
+    // occurs, content once, band respected) and documents the placement as
+    // unverified rather than asserting unknown Y positions.
+    for (const labelParas of [2, 6]) {
+      const pages = computePages([para(), para(), restartSpanTable(labelParas, 'center')], section(), makeCtx());
+      const first = tblOn(pages[0]);
+      const second = tblOn(pages[1]);
+      expect(first?.rows[0]?.cells[0]?.vMerge).toBe(true);
+      expect(second?.rows[0]?.cells[0]?.vMerge).toBe(true);
+      const labels = pages.flatMap((pg) => pg.filter((el) => el.type === 'table'))
+        .flatMap((el) => (el as unknown as DocTable).rows)
+        .flatMap((r) => (r.cells[0]?.content ?? []))
+        .map((ce) => textOf(ce as unknown as PaginatedBodyElement))
+        .filter((t) => t.length > 0);
+      expect(labels.sort()).toEqual(Array.from({ length: labelParas }, (_v, i) => `L${i}`).sort());
+      for (const pg of pages) {
+        const el = tblOn(pg);
+        if (!el) continue;
+        const placed = bodyFragmentFor(el as PaginatedBodyElement);
+        if (placed?.fragment.kind !== 'table') throw new Error('expected a table fragment');
+        expect(placed.heightPt).toBeLessThanOrEqual(100 + 1e-6);
+      }
+    }
   });
 
   it('still refuses to split a row containing a CONTINUE cell', () => {

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { bodyFragmentFor, computePages, computeColumns } from './renderer.js';
 import type {
-  BodyElement, CellElement, DocParagraph, DocxTextRun, ShapeRun, SectionProps, PaginatedBodyElement, DocTable, DocTableRow,
+  BodyElement, CellElement, DocParagraph, DocTableCell, DocxTextRun, ShapeRun, SectionProps, PaginatedBodyElement, DocTable, DocTableRow,
 } from './types';
 
 // Unit tests for computePages pagination behaviour that the renderer-path VRT
@@ -880,6 +880,139 @@ describe('computePages — over-tall table row splitting (§17.4 table paginatio
     expect(secondNested?.type).toBe('table');
     expect(firstNested?.rows.length).toBe(3);
     expect(secondNested?.rows.length).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mid-page splitting of a row whose cells START a vertical merge (§17.4.85 +
+// §17.4.6). A `restart` cell begins its span in THIS row: its content fits the
+// page band like any cell, the page-1 piece keeps `restart` (its truncated box
+// ends at the page cut) and the page-2 piece keeps `restart` too, so the
+// following `continue` rows chain onto it — the span re-opens on the next page
+// exactly as Word draws it. Only a `continue` cell (span owned by an EARLIER
+// row) forbids the split.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('computePages — mid-page split of rows with vMerge restart cells (§17.4.85 + §17.4.6)', () => {
+  const emptyBorders = () => ({ top: null, bottom: null, left: null, right: null, insideH: null, insideV: null });
+  const mkCell = (content: CellElement[], vMerge: boolean | null): DocTableCell => ({
+    content, colSpan: 1, vMerge, borders: emptyBorders(), background: null, vAlign: 'top', widthPt: null,
+  } as unknown as DocTableCell);
+  const shortPara = (text: string) => para({ text, fontSize: 20 }) as CellElement;
+  /** [40pt label col | 120pt content col]; row0 = restart label + wrapping
+   *  content (24 glyphs at 6/line ⇒ 4 lines = 80pt); rows 1-2 = continue label +
+   *  short cell (20pt each). */
+  const restartSpanTable = (labelParas: number): BodyElement => {
+    const label = mkCell(Array.from({ length: labelParas }, (_v, i) => shortPara(`L${i}`)), true);
+    const content = mkCell([para({ text: 'あ'.repeat(24), fontSize: 20 }) as CellElement], null);
+    const contRow = (t: string): DocTableRow => ({
+      cells: [mkCell([para({}) as CellElement], false), mkCell([shortPara(t)], null)],
+      rowHeight: null, rowHeightRule: 'auto', isHeader: false,
+    } as unknown as DocTableRow);
+    const t: DocTable = {
+      colWidths: [40, 120],
+      rows: [
+        { cells: [label, content], rowHeight: null, rowHeightRule: 'auto', isHeader: false } as unknown as DocTableRow,
+        contRow('x'), contRow('y'),
+      ],
+      borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+      jc: 'left', layout: 'fixed',
+    } as unknown as DocTable;
+    return { type: 'table', ...t } as BodyElement;
+  };
+  const tblOn = (pg: PaginatedBodyElement[]) =>
+    pg.find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable) | undefined;
+  const cellSlice = (t: (PaginatedBodyElement & DocTable) | undefined, ri: number, ci: number) =>
+    (t?.rows[ri]?.cells[ci]?.content[0] as (CellElement & { lineSlice?: { start: number; end: number } }) | undefined)?.lineSlice;
+
+  it('splits a restart-cell row mid-page and re-opens the span on the next page', () => {
+    // 2 filler paragraphs (40pt) leave 60pt: the content cell fits 3 of its 4
+    // lines; the 2-paragraph label (40pt) fits page 1 entirely.
+    const pages = computePages([para(), para(), restartSpanTable(2)], section(), makeCtx());
+
+    const first = tblOn(pages[0]);
+    const second = tblOn(pages[1]);
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+
+    // Page 1: one piece row — restart label (whole) + content lines [0, 3).
+    expect(first?.rows).toHaveLength(1);
+    expect(first?.rows[0]?.cells[0]?.vMerge).toBe(true);
+    expect(first?.rows[0]?.cells[0]?.content).toHaveLength(2);
+    expect(cellSlice(first, 0, 1)).toEqual({ start: 0, end: 3 });
+
+    // Page 2: the continuation piece KEEPS restart (span re-opens) with the
+    // fully-consumed label continuing as EMPTY content, then the continue rows
+    // stay chained on the same page (§17.4.85 — no break before a continue row).
+    expect(second?.rows).toHaveLength(3);
+    expect(second?.rows[0]?.cells[0]?.vMerge).toBe(true);
+    expect(second?.rows[0]?.cells[0]?.content).toHaveLength(0);
+    expect(cellSlice(second, 0, 1)).toEqual({ start: 3, end: 4 });
+    expect(second?.rows[1]?.cells[0]?.vMerge).toBe(false);
+    expect(second?.rows[2]?.cells[0]?.vMerge).toBe(false);
+
+    // Fragment layer: pieces share sourceRowIndex 0; the continuation slice's
+    // roles are restart/continue/continue.
+    const placedFirst = bodyFragmentFor(first as PaginatedBodyElement);
+    const placedSecond = bodyFragmentFor(second as PaginatedBodyElement);
+    if (placedFirst?.fragment.kind === 'table' && placedSecond?.fragment.kind === 'table') {
+      expect(placedFirst.fragment.rows.map((r) => r.sourceRowIndex)).toEqual([0]);
+      expect(placedSecond.fragment.rows.map((r) => r.sourceRowIndex)).toEqual([0, 1, 2]);
+      expect(placedSecond.fragment.rows.map((r) => r.cells[0]?.verticalMerge)).toEqual([
+        'restart', 'continue', 'continue',
+      ]);
+    } else {
+      throw new Error('expected table fragments on both pages');
+    }
+  });
+
+  it('splits the restart cell content itself when it exceeds the page-1 band', () => {
+    // 6 label paragraphs (120pt) cannot fit the 60pt band: 3 land on page 1 and
+    // 3 continue inside the re-opened span — independently of the content cell.
+    const pages = computePages([para(), para(), restartSpanTable(6)], section(), makeCtx());
+
+    const first = tblOn(pages[0]);
+    const second = tblOn(pages[1]);
+    expect(first?.rows[0]?.cells[0]?.content).toHaveLength(3);
+    expect(second?.rows[0]?.cells[0]?.content).toHaveLength(3);
+    expect(cellSlice(first, 0, 1)).toEqual({ start: 0, end: 3 });
+    expect(cellSlice(second, 0, 1)).toEqual({ start: 3, end: 4 });
+  });
+
+  it('still refuses to split a row containing a CONTINUE cell', () => {
+    // Make the CONTINUE row overflow: its non-merge cell wraps to 4 lines. The
+    // row belongs to a span started ABOVE it, so it must move whole.
+    const label = mkCell([shortPara('L0')], true);
+    const content = mkCell([shortPara('c0')], null);
+    const tallContinue: DocTableRow = {
+      cells: [
+        mkCell([para({}) as CellElement], false),
+        mkCell([para({ text: 'あ'.repeat(24), fontSize: 20 }) as CellElement], null),
+      ],
+      rowHeight: null, rowHeightRule: 'auto', isHeader: false,
+    } as unknown as DocTableRow;
+    const t: DocTable = {
+      colWidths: [40, 120],
+      rows: [
+        { cells: [label, content], rowHeight: null, rowHeightRule: 'auto', isHeader: false } as unknown as DocTableRow,
+        tallContinue,
+      ],
+      borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+      jc: 'left', layout: 'fixed',
+    } as unknown as DocTable;
+    const pages = computePages(
+      [para(), para(), para(), para(), { type: 'table', ...t } as BodyElement],
+      section(),
+      makeCtx(),
+    );
+    // The continue row never splits: no cell of any emitted slice of it carries
+    // a lineSlice.
+    const allRows = pages.flatMap((pg) => pg.filter((el) => el.type === 'table'))
+      .flatMap((el) => (el as unknown as DocTable).rows);
+    const sliced = allRows.some((r) => r.cells.some((c) =>
+      c.content.some((ce) => (ce as CellElement & { lineSlice?: unknown }).lineSlice !== undefined)));
+    expect(sliced).toBe(false);
   });
 });
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5127,6 +5127,13 @@ function splitRowByCellBlocks(
     heights.push(Number.isFinite(bestHeight) ? bestHeight : measureSingleTableRowPt(slice, table, colWidthsPt, state));
     start = bestEnd;
   }
+  if (rows.length > 1) {
+    // Runtime-only cut markers (see splitRowByCellLines): every piece except
+    // the LAST ends at an intra-row cut, whose edge Word leaves open.
+    for (let i = 0; i < rows.length - 1; i++) {
+      (rows[i] as DocTableRow & { pageCutBottom?: boolean }).pageCutBottom = true;
+    }
+  }
   return rows.length > 1 ? { rows, heights } : null;
 }
 
@@ -5480,7 +5487,10 @@ function splitRowByCellLines(
     : 0;
   return {
     rows: [
-      { ...row, cells: beforeCells, rowHeight: null, rowHeightRule: 'auto' },
+      // Runtime-only marker on the CLONE (never the parsed model): the leading
+      // piece's bottom edge is a PAGE CUT through the row, not a row boundary —
+      // Word leaves it open (stage D; drawTableRows suppresses the edge).
+      { ...row, cells: beforeCells, rowHeight: null, rowHeightRule: 'auto', pageCutBottom: true } as DocTableRow,
       { ...row, cells: afterCells, rowHeight: null, rowHeightRule: 'auto' },
     ],
     heights: [
@@ -10549,7 +10559,14 @@ function drawTableRows(
       let x1 = x;
       let x2 = x + w;
       if (j.edges.bottomRow) {
-        spec = paintable(own.bottom?.spec ?? null);
+        // Stage D — a row piece created by a MID-ROW page cut has no bottom
+        // boundary: the row visually continues on the next page (or in the next
+        // stacked piece), so the cut edge draws nothing. Word's ground truth for
+        // the split-form class shows the page-1 piece open at the cut while the
+        // continuation draws its own top edge. Row-boundary cuts are unaffected
+        // (their rows carry no marker).
+        const cutRow = table.rows[j.lastRi] as DocTableRow & { pageCutBottom?: boolean };
+        spec = cutRow?.pageCutBottom === true ? null : paintable(own.bottom?.spec ?? null);
       } else {
         const below = neighbourJob(jobs, occupancy, j.lastRi + 1, j.ci);
         const belowEdges = below ? resolveCellEdges(below.cell.borders, table.borders, below.edges, mirror) : null;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4569,12 +4569,21 @@ function splitParagraphAcrossPages(
     while (lineIdx < lines.length) {
       const remaining = colBot() - cursorY;
       const firstFitting = lineIdx;
+      // O(n) running accumulation: the policy calls `fitAt` with strictly
+      // increasing `end` (its documented contract), so extending the previous
+      // sum by the newly covered extents reproduces the historical incremental
+      // loop's exact left-to-right float-addition order — bit-identical fit
+      // comparisons without re-summing from the start per candidate.
+      let accumulatedH = 0;
+      let accumulatedEnd = firstFitting;
       const fitting = selectLargestFittingEnd(firstFitting, lines.length, remaining, (end) => {
-        let height = 0;
-        for (let i = firstFitting; i < end; i++) height += lineExtents[i];
-        return height;
+        while (accumulatedEnd < end) {
+          accumulatedH += lineExtents[accumulatedEnd];
+          accumulatedEnd++;
+        }
+        return accumulatedH;
       });
-      let usedH = fitting.height;
+      let usedH = fitting.fitValue;
       let lastFitting = fitting.end;
       if (lastFitting === firstFitting) {
         if (cursorY > 0) {
@@ -4592,7 +4601,7 @@ function splitParagraphAcrossPages(
         start: firstFitting,
         end: lastFitting,
         totalLines: lines.length,
-        belowColumnTop: cursorY > 0,
+        canRelocate: cursorY > 0,
       });
       if (widowOrphan.kind === 'dropLastLine') {
         lastFitting--;
@@ -4602,7 +4611,7 @@ function splitParagraphAcrossPages(
           start: firstFitting,
           end: lastFitting,
           totalLines: lines.length,
-          belowColumnTop: cursorY > 0,
+          canRelocate: cursorY > 0,
         });
       }
       if (widowOrphan.kind === 'relocate') {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5103,6 +5103,12 @@ function splitRowByCellBlocks(
   // deviation: the split decision fits a restart cell's content into the band
   // like a normal cell, whereas §17.4.85 row sizing excludes restart content
   // from its first row — the pieces are band-limited, so this cannot overflow.
+  // vAlign note (PR #926 review): center/bottom cells re-centre their fitted
+  // content within each PIECE's page-local box. Word ground truth for the
+  // per-piece vertical placement is unavailable; the target document class
+  // centres its restart labels, so excluding center/bottom would regress the
+  // class — the structural behavior is pinned in tests and the placement is
+  // documented as Word-unverified rather than guessed.
   if (row.cells.some((cell) => cell.vMerge === false)) return null;
   const blockCount = Math.max(0, ...row.cells.map((cell) => cell.content.length));
   if (blockCount <= 1) return null;
@@ -5436,7 +5442,16 @@ function splitRowByCellLines(
   colWidthsPt: number[],
   maxHeightPt: number,
   state: RenderState,
-): { rows: DocTableRow[]; heights: number[] } | null {
+): {
+  rows: DocTableRow[];
+  heights: number[];
+  /** §17.4.85 — the FINAL piece's remaining restart-cell content heights
+   *  (margins included), keyed by GRID column. The final piece's own height
+   *  EXCLUDES restart remainders (they distribute over the re-opened span);
+   *  the caller re-derives the span extension once from these after splicing
+   *  (see repairSpanExtensionAfterRowSplit). */
+  restartRemainders?: Map<number, number>;
+} | null {
   if (row.isHeader || row.cantSplit || row.rowHeightRule === 'exact') return null;
   // §17.4.85 — only a `continue` cell forbids the split: its box belongs to a
   // span that STARTS in an earlier row, so cutting here would slice a box this
@@ -5449,12 +5464,19 @@ function splitRowByCellLines(
   // deviation: the split decision fits a restart cell's content into the band
   // like a normal cell, whereas §17.4.85 row sizing excludes restart content
   // from its first row — the pieces are band-limited, so this cannot overflow.
+  // vAlign note (PR #926 review): center/bottom cells re-centre their fitted
+  // content within each PIECE's page-local box. Word ground truth for the
+  // per-piece vertical placement is unavailable; the target document class
+  // centres its restart labels, so excluding center/bottom would regress the
+  // class — the structural behavior is pinned in tests and the placement is
+  // documented as Word-unverified rather than guessed.
   if (row.cells.some((cell) => cell.vMerge === false)) return null;
 
   const beforeCells: DocTableCell[] = [];
   const afterCells: DocTableCell[] = [];
   const beforeCellHeights: number[] = [];
   const afterCellHeights: number[] = [];
+  const restartRemainders = new Map<number, number>();
   let madeProgress = false;
   let hasRemainder = false;
   let ci = 0;
@@ -5463,6 +5485,7 @@ function splitRowByCellLines(
     const cellState = withTableCellStory(state);
     const span = Math.min(cell.colSpan, colWidthsPt.length - ci);
     const cellWPt = colWidthsPt.slice(ci, ci + span).reduce((s, w) => s + w, 0);
+    const gridCi = ci;
     ci += span;
     const margins = effCellMargins(cell, table);
     const maxContentH = Math.max(0, maxHeightPt - margins.top - margins.bottom);
@@ -5476,7 +5499,19 @@ function splitRowByCellLines(
     beforeCells.push({ ...cell, content: split.before });
     afterCells.push({ ...cell, content: split.after });
     beforeCellHeights.push(margins.top + margins.bottom + split.beforeHeight);
-    afterCellHeights.push(margins.top + margins.bottom + split.afterHeight);
+    if (cell.vMerge === true) {
+      // §17.4.85 — a RESTART cell's remainder distributes over the re-opened
+      // span (exactly like restart content in normal row sizing), so it does
+      // NOT drive the final piece's own height; report it for the caller's
+      // span-extension repair instead. (The LEADING piece keeps the fitted
+      // restart content in ITS height: it is the span's truncated last row on
+      // its page, so the fitted content is exactly its visible box.)
+      if (split.after.length > 0) {
+        restartRemainders.set(gridCi, margins.top + margins.bottom + split.afterHeight);
+      }
+    } else {
+      afterCellHeights.push(margins.top + margins.bottom + split.afterHeight);
+    }
     madeProgress ||= split.before.length > 0;
     hasRemainder ||= split.after.length > 0;
   }
@@ -5497,6 +5532,7 @@ function splitRowByCellLines(
       Math.max(floor, ...beforeCellHeights),
       Math.max(0, ...afterCellHeights),
     ],
+    restartRemainders: restartRemainders.size > 0 ? restartRemainders : undefined,
   };
 }
 
@@ -5506,9 +5542,87 @@ function splitRowForHeight(
   colWidthsPt: number[],
   maxHeightPt: number,
   state: RenderState,
-): { rows: DocTableRow[]; heights: number[] } | null {
+): { rows: DocTableRow[]; heights: number[]; restartRemainders?: Map<number, number> } | null {
   return splitRowByCellLines(table, row, colWidthsPt, maxHeightPt, state)
     ?? splitRowByCellBlocks(table, row, colWidthsPt, maxHeightPt, state);
+}
+
+/**
+ * §17.4.85 span-extension repair after a restart-row split. The ORIGINAL row
+ * heights carried the vMerge span extension computed for the UNSPLIT row (the
+ * resolver grew the span's LAST row by the restart content overflow,
+ * table-geometry.ts). After the split, the LEADING piece carries the fitted
+ * restart content in its own height (it is the span's truncated last row on
+ * its page), and the FINAL piece re-opens the span over the following
+ * `continue` rows — so the old extension left on the merge-end row would count
+ * the restart content a SECOND time (review of PR #926: a 100pt body produced
+ * a 160pt page). This pass re-derives the extension exactly once:
+ *   1. tail rows (after the final piece, through the deepest merge-end
+ *      reachable from it, fixpoint-extended) are reset to their BASE heights
+ *      via resolveSingleRowHeight — erasing the stale extension (tail rows are
+ *      original rows, never line-sliced pieces, so re-measuring is safe);
+ *   2. the §17.4.85 extension is re-applied in row-major order for every
+ *      restart cell of the final piece and the tail: the final piece's
+ *      remaining restart content uses the splitter-reported remainder heights
+ *      (its cell content is line-sliced and must not be re-measured whole);
+ *      tail restarts re-measure their full cells like the resolver does.
+ * A span with no following continue rows degenerates to growing the final
+ * piece itself (the span's last row), matching the resolver's semantics.
+ */
+function repairSpanExtensionAfterRowSplit(
+  workTable: DocTable,
+  workRowHs: number[],
+  finalPieceIdx: number,
+  colWidthsPt: number[],
+  state: RenderState,
+  restartRemainders: Map<number, number> | undefined,
+): void {
+  const rows = workTable.rows;
+  const finalPiece = rows[finalPieceIdx];
+  if (!finalPiece) return;
+  // Deepest merge-end reachable from the final piece, fixpoint-extended by
+  // restarts that START inside the tail (a span crossing INTO the split row is
+  // impossible: continue cells there would have refused the split).
+  let maxEnd = finalPieceIdx;
+  const scanRow = (ri: number): void => {
+    let ci = 0;
+    for (const cell of rows[ri].cells) {
+      const span = Math.min(cell.colSpan, colWidthsPt.length - ci);
+      if (cell.vMerge === true) {
+        const e = findMergeEndRow(workTable, ri, ci);
+        if (e > maxEnd) maxEnd = e;
+      }
+      ci += span;
+    }
+  };
+  scanRow(finalPieceIdx);
+  for (let ri = finalPieceIdx + 1; ri <= maxEnd && ri < rows.length; ri++) scanRow(ri);
+
+  // 1) Reset tail rows to base heights (erases the stale extension).
+  for (let ri = finalPieceIdx + 1; ri <= maxEnd && ri < rows.length; ri++) {
+    workRowHs[ri] = measureSingleTableRowPt(rows[ri], workTable, colWidthsPt, state);
+  }
+  // 2) Re-apply the extension per restart cell, row-major (resolver order).
+  for (let ri = finalPieceIdx; ri <= maxEnd && ri < rows.length; ri++) {
+    let ci = 0;
+    for (const cell of rows[ri].cells) {
+      const span = Math.min(cell.colSpan, colWidthsPt.length - ci);
+      if (cell.vMerge === true) {
+        const cellW = colWidthsPt.slice(ci, ci + span).reduce((s, w) => s + w, 0);
+        const contentH = ri === finalPieceIdx
+          ? (restartRemainders?.get(ci)
+              ?? measureCellContentHeightPx(cell, workTable, cellW, 1, state))
+          : measureCellContentHeightPx(cell, workTable, cellW, 1, state);
+        const endRi = findMergeEndRow(workTable, ri, ci);
+        let spanH = 0;
+        for (let rj = ri; rj <= endRi; rj++) spanH += workRowHs[rj] ?? 0;
+        if (contentH > spanH && endRi < workRowHs.length) {
+          workRowHs[endRi] += contentH - spanH;
+        }
+      }
+      ci += span;
+    }
+  }
 }
 
 function splitRowsTallerThanPage(
@@ -5522,6 +5636,7 @@ function splitRowsTallerThanPage(
   const rows: DocTableRow[] = [];
   const heights: number[] = [];
   const sourceRowIndexByRow: number[] = [];
+  const repairs: { finalPieceIdx: number; restartRemainders?: Map<number, number> }[] = [];
   for (let ri = 0; ri < table.rows.length; ri++) {
     const row = table.rows[ri];
     const rowH = rowHeightsPt[ri];
@@ -5531,6 +5646,7 @@ function splitRowsTallerThanPage(
         rows.push(...split.rows);
         heights.push(...split.heights);
         sourceRowIndexByRow.push(...split.rows.map(() => ri));
+        repairs.push({ finalPieceIdx: rows.length - 1, restartRemainders: split.restartRemainders });
         changed = true;
         continue;
       }
@@ -5539,9 +5655,16 @@ function splitRowsTallerThanPage(
     heights.push(rowH);
     sourceRowIndexByRow.push(ri);
   }
-  return changed
-    ? { table: { ...table, rows }, rowHs: heights, sourceRowIndexByRow }
-    : null;
+  if (!changed) return null;
+  const outTable = { ...table, rows };
+  // §17.4.85 — re-derive the span extension once per split (the tail rows are
+  // appended after the loop, so the repair runs over the assembled arrays).
+  for (const repair of repairs) {
+    repairSpanExtensionAfterRowSplit(
+      outTable, heights, repair.finalPieceIdx, colWidthsPt, state, repair.restartRemainders,
+    );
+  }
+  return { table: outTable, rowHs: heights, sourceRowIndexByRow };
 }
 
 /**
@@ -5644,7 +5767,20 @@ export function splitTableAcrossPages(
     const firstRowH = (isContinuation ? headerH : 0) + workRowHs[start];
     const freshAvail = contentH - colTop();
     const rowAvail = avail - (isContinuation ? headerH : 0);
-    if (rowSplit && firstRowH > avail && rowAvail > 0 && start >= headerCount) {
+    // §17.4.85 + §17.4.6 — the UNBREAKABLE group starting at `start`: a restart
+    // row chained to its continue rows admits no internal break, so when the
+    // group as a whole overflows the band the only spec-faithful relief is
+    // splitting its (splittable) HEAD row — the group head is the restart row,
+    // which the relaxed splitter gate accepts; the remainder group then flows
+    // to the next page, where this same check re-splits the re-opened restart
+    // piece if the remaining span STILL exceeds a fresh page (the review's
+    // "re-split the restart piece" requirement). A single-row group reduces to
+    // the historical first-row check, so vMerge-free tables are byte-identical.
+    let groupEnd = start;
+    while (groupEnd + 1 < n && !tableBreakAllowedBefore(workTable, groupEnd + 1)) groupEnd++;
+    let groupH = isContinuation ? headerH : 0;
+    for (let r = start; r <= groupEnd; r++) groupH += workRowHs[r];
+    if (rowSplit && (firstRowH > avail || groupH > avail) && rowAvail > 0 && start >= headerCount) {
       const split = splitRowForHeight(workTable, workRows[start], rowSplit.colWidthsPt, rowAvail, rowSplit.state);
       if (split && split.heights[0] <= rowAvail) {
         const sourceRowIndex = workSourceRowIndices[start];
@@ -5665,6 +5801,12 @@ export function splitTableAcrossPages(
         ];
         workTable = { ...workTable, rows: workRows };
         n = workRows.length;
+        // §17.4.85 — re-derive the span extension once over the new structure
+        // (the original heights carried it for the UNSPLIT row).
+        repairSpanExtensionAfterRowSplit(
+          workTable, workRowHs, start + split.rows.length - 1,
+          rowSplit.colWidthsPt, rowSplit.state, split.restartRemainders,
+        );
         continue;
       }
     }
@@ -5711,6 +5853,11 @@ export function splitTableAcrossPages(
               ];
               workTable = { ...workTable, rows: workRows };
               n = workRows.length;
+              // §17.4.85 — re-derive the span extension once (see site above).
+              repairSpanExtensionAfterRowSplit(
+                workTable, workRowHs, end + split.rows.length - 1,
+                rowSplit.colWidthsPt, rowSplit.state, split.restartRemainders,
+              );
               continue;
             }
           }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -102,6 +102,7 @@ import {
   resolveTableRowHeights,
   resolveSingleRowHeight,
 } from './table-geometry.js';
+import { adjustForWidowOrphan, selectLargestFittingEnd } from './line-fit-policy.js';
 import {
   computeSectionColumns as computeColumns,
   enterTableCellStoryContext,
@@ -4567,13 +4568,14 @@ function splitParagraphAcrossPages(
     let cursorY = initialY;
     while (lineIdx < lines.length) {
       const remaining = colBot() - cursorY;
-      let usedH = 0;
       const firstFitting = lineIdx;
-      let lastFitting = lineIdx;
-      while (lastFitting < lines.length && usedH + lineExtents[lastFitting] <= remaining) {
-        usedH += lineExtents[lastFitting];
-        lastFitting++;
-      }
+      const fitting = selectLargestFittingEnd(firstFitting, lines.length, remaining, (end) => {
+        let height = 0;
+        for (let i = firstFitting; i < end; i++) height += lineExtents[i];
+        return height;
+      });
+      let usedH = fitting.height;
+      let lastFitting = fitting.end;
       if (lastFitting === firstFitting) {
         if (cursorY > 0) {
           newPage(cursorY);
@@ -4585,17 +4587,29 @@ function splitParagraphAcrossPages(
         lastFitting = firstFitting + 1;
         usedH += lineExtents[firstFitting];
       }
-      if (para.widowControl !== false && lastFitting < lines.length) {
-        if (lines.length - lastFitting === 1 && lastFitting - firstFitting >= 2) {
-          lastFitting--;
-          usedH -= lineExtents[lastFitting];
-        }
-        if (firstFitting === 0 && lastFitting - firstFitting === 1 && cursorY > 0) {
-          newPage(cursorY);
-          cursorY = colTop();
-          remeasureBeforeFirstLine();
-          continue;
-        }
+      let widowOrphan = adjustForWidowOrphan({
+        widowControl: para.widowControl !== false,
+        start: firstFitting,
+        end: lastFitting,
+        totalLines: lines.length,
+        belowColumnTop: cursorY > 0,
+      });
+      if (widowOrphan.kind === 'dropLastLine') {
+        lastFitting--;
+        usedH -= lineExtents[lastFitting];
+        widowOrphan = adjustForWidowOrphan({
+          widowControl: true,
+          start: firstFitting,
+          end: lastFitting,
+          totalLines: lines.length,
+          belowColumnTop: cursorY > 0,
+        });
+      }
+      if (widowOrphan.kind === 'relocate') {
+        newPage(cursorY);
+        cursorY = colTop();
+        remeasureBeforeFirstLine();
+        continue;
       }
       const isFinalSlice = lastFitting === lines.length;
       if (isFinalSlice) usedH += trailingExtent;
@@ -5350,19 +5364,24 @@ function splitCellContentByHeight(
     }
 
     const splitPara = para ?? ce as unknown as DocParagraph;
-    let endLine = 0;
-    let sliceH = 0;
-    let sliceAddH = 0;
     const sliceStart = currentSlice?.start ?? 0;
     const sliceEnd = currentSlice?.end ?? layout.lines.length;
-    for (let end = sliceStart + 1; end <= sliceEnd; end++) {
-      const h = paragraphLineSliceHeight(splitPara, layout.lineHeights, sliceStart, end);
-      const addH = additionHeight(ce, h, { start: sliceStart, end });
-      if (beforeHeight + addH > maxContentHeightPt) break;
-      endLine = end;
-      sliceH = h;
-      sliceAddH = addH;
-    }
+    const fitting = selectLargestFittingEnd(
+      sliceStart,
+      sliceEnd,
+      maxContentHeightPt,
+      (end) => {
+        const h = paragraphLineSliceHeight(splitPara, layout.lineHeights, sliceStart, end);
+        return beforeHeight + additionHeight(ce, h, { start: sliceStart, end });
+      },
+    );
+    const endLine = fitting.end === sliceStart ? 0 : fitting.end;
+    const sliceH = endLine === 0
+      ? 0
+      : paragraphLineSliceHeight(splitPara, layout.lineHeights, sliceStart, endLine);
+    const sliceAddH = endLine === 0
+      ? 0
+      : additionHeight(ce, sliceH, { start: sliceStart, end: endLine });
     if (endLine === 0) {
       const after = content.slice(i);
       const afterHeight = sumContentHeightForSplit(after);

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5092,7 +5092,18 @@ function splitRowByCellBlocks(
   state: RenderState,
 ): { rows: DocTableRow[]; heights: number[] } | null {
   if (row.isHeader || row.cantSplit || row.rowHeightRule === 'exact') return null;
-  if (row.cells.some((cell) => cell.vMerge !== null)) return null;
+  // §17.4.85 — only a `continue` cell forbids the split: its box belongs to a
+  // span that STARTS in an earlier row, so cutting here would slice a box this
+  // row does not own. A RESTART cell starts its span in THIS row: its content
+  // fits the page band like any cell's, the page-1 piece keeps `restart` (its
+  // truncated box ends at the page cut), and the page-2 piece keeps `restart`
+  // too, so the following `continue` rows chain onto it via findMergeEndRow and
+  // the span re-opens on the next page exactly as Word draws it (the piece
+  // assembly below preserves `vMerge` through the cell spread). Accepted height
+  // deviation: the split decision fits a restart cell's content into the band
+  // like a normal cell, whereas §17.4.85 row sizing excludes restart content
+  // from its first row — the pieces are band-limited, so this cannot overflow.
+  if (row.cells.some((cell) => cell.vMerge === false)) return null;
   const blockCount = Math.max(0, ...row.cells.map((cell) => cell.content.length));
   if (blockCount <= 1) return null;
 
@@ -5420,7 +5431,18 @@ function splitRowByCellLines(
   state: RenderState,
 ): { rows: DocTableRow[]; heights: number[] } | null {
   if (row.isHeader || row.cantSplit || row.rowHeightRule === 'exact') return null;
-  if (row.cells.some((cell) => cell.vMerge !== null)) return null;
+  // §17.4.85 — only a `continue` cell forbids the split: its box belongs to a
+  // span that STARTS in an earlier row, so cutting here would slice a box this
+  // row does not own. A RESTART cell starts its span in THIS row: its content
+  // fits the page band like any cell's, the page-1 piece keeps `restart` (its
+  // truncated box ends at the page cut), and the page-2 piece keeps `restart`
+  // too, so the following `continue` rows chain onto it via findMergeEndRow and
+  // the span re-opens on the next page exactly as Word draws it (the piece
+  // assembly below preserves `vMerge` through the cell spread). Accepted height
+  // deviation: the split decision fits a restart cell's content into the band
+  // like a normal cell, whereas §17.4.85 row sizing excludes restart content
+  // from its first row — the pieces are band-limited, so this cannot overflow.
+  if (row.cells.some((cell) => cell.vMerge === false)) return null;
 
   const beforeCells: DocTableCell[] = [];
   const afterCells: DocTableCell[] = [];

--- a/packages/docx/src/table-split-borders.test.ts
+++ b/packages/docx/src/table-split-borders.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { renderDocumentToCanvas, paginateDocument } from './renderer.js';
+import type {
+  BodyElement,
+  CellElement,
+  DocParagraph,
+  DocTable,
+  DocTableRow,
+  DocxDocumentModel,
+  PaginatedBodyElement,
+  SectionProps,
+  BorderSpec,
+} from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Split-edge border semantics for a MID-ROW page cut (stage D of the row-split
+// series). When a row is split at a cell line boundary across a page break, the
+// page-1 piece's bottom edge is a PAGE CUT, not a row boundary: Word leaves it
+// OPEN (no bottom rule — the row visually continues), while the continuation
+// piece on the next page draws its top edge as usual. A ROW-BOUNDARY page cut
+// (whole rows per page) keeps its existing border behavior — only the mid-row
+// cut suppresses the bottom edge.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface StrokeSeg { x1: number; y1: number; x2: number; y2: number; width: number; color: string }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; strokes: StrokeSeg[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const strokes: StrokeSeg[] = [];
+  let cur = { x: 0, y: 0 };
+  let pending: { x1: number; y1: number; x2: number; y2: number } | null = null;
+  let lineWidth = 1;
+  let strokeStyle = '#000000';
+  let fillStyle = '#000000';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get lineWidth() { return lineWidth; },
+    set lineWidth(v: number) { lineWidth = v; },
+    get strokeStyle() { return strokeStyle; },
+    set strokeStyle(v: string) { strokeStyle = v; },
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string) { fillStyle = v; },
+    textAlign: 'left' as CanvasTextAlign,
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() { pending = null; }, closePath() {},
+    moveTo(x: number, y: number) { cur = { x, y }; },
+    lineTo(x: number, y: number) { pending = { x1: cur.x, y1: cur.y, x2: x, y2: y }; cur = { x, y }; },
+    stroke() {
+      if (pending) strokes.push({ ...pending, width: lineWidth, color: strokeStyle });
+    },
+    fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText() {}, strokeText() {},
+    direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, strokes };
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+    getContext() { return makeRecordingCanvas().canvas.getContext('2d'); }
+  };
+});
+
+const bs = (): BorderSpec => ({ style: 'single', width: 1, color: null } as BorderSpec);
+const allEdges = () => ({ top: bs(), bottom: bs(), left: bs(), right: bs(), insideH: bs(), insideV: bs() });
+
+function para(text: string): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 20, color: null, fontFamily: 'T',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 20, defaultFontFamily: 'T', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+/** One-row bordered table whose single cell wraps to 4 lines (64 glyphs at 16/line, 80pt) — page body
+ *  60pt tall, so the row splits mid-page at 3 lines. Grid 160pt == page width. */
+function splitDoc(rows: DocTableRow[], pageHeight: number): DocxDocumentModel {
+  const t: DocTable = {
+    colWidths: [160], rows, borders: allEdges(),
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left', layout: 'fixed',
+  } as unknown as DocTable;
+  return {
+    section: {
+      pageWidth: 160, pageHeight,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [{ type: 'table', ...t } as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { T: 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+const wrappingRow = (): DocTableRow => ({
+  cells: [{
+    content: [{ type: 'paragraph', ...para('あ'.repeat(64)) } as unknown as CellElement],
+    colSpan: 1, vMerge: null, borders: allEdges(), background: null, vAlign: 'top', widthPt: null,
+  }],
+  rowHeight: null, rowHeightRule: 'auto', isHeader: false,
+} as unknown as DocTableRow);
+
+const shortRow = (text: string): DocTableRow => ({
+  cells: [{
+    content: [{ type: 'paragraph', ...para(text) } as unknown as CellElement],
+    colSpan: 1, vMerge: null, borders: allEdges(), background: null, vAlign: 'top', widthPt: null,
+  }],
+  rowHeight: null, rowHeightRule: 'auto', isHeader: false,
+} as unknown as DocTableRow);
+
+async function renderPage(model: DocxDocumentModel, pages: PaginatedBodyElement[][], pageIndex: number): Promise<StrokeSeg[]> {
+  const { canvas, strokes } = makeRecordingCanvas();
+  await renderDocumentToCanvas(model, canvas, pageIndex, { dpr: 1, width: 160, prebuiltPages: pages });
+  return strokes;
+}
+
+const horizontals = (strokes: StrokeSeg[]) =>
+  strokes.filter((s) => Math.abs(s.y1 - s.y2) < 0.5 && Math.abs(s.x2 - s.x1) > 10);
+
+describe('mid-row page-cut border semantics (stage D)', () => {
+  it('leaves the page-1 piece bottom OPEN and draws the continuation top', async () => {
+    // 4-line cell (80pt) into a 60pt page body: p.1 piece = 3 lines, cut at y=60.
+    const model = splitDoc([wrappingRow()], 60);
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(1);
+    // Fixture sanity: the split really is MID-ROW (a lineSlice exists on p.1).
+    const p1Table = pages[0].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable);
+    const p1Cut = (p1Table.rows[0].cells[0].content[0] as CellElement & { lineSlice?: unknown }).lineSlice;
+    expect(p1Cut).toBeDefined();
+
+    const p1 = await renderPage(model, pages, 0);
+    const p2 = await renderPage(model, pages, 1);
+
+    const p1H = horizontals(p1);
+    // Top frame at y=0 present…
+    expect(p1H.some((s) => Math.abs(s.y1 - 0) <= 1)).toBe(true);
+    // …but NO horizontal rule at the page cut (y=60): the row continues.
+    expect(p1H.filter((s) => Math.abs(s.y1 - 60) <= 1)).toHaveLength(0);
+
+    // The continuation piece draws its top edge on page 2 (y=0).
+    const p2H = horizontals(p2);
+    expect(p2H.some((s) => Math.abs(s.y1 - 0) <= 1)).toBe(true);
+  });
+
+  it('keeps the row-boundary page cut borders unchanged', async () => {
+    // Three 20pt single-line rows in a 40pt page body: the cut falls BETWEEN
+    // rows (no mid-row slice) — the existing behavior (whatever the resolved
+    // row-boundary edges draw today) must not change. Pin: a horizontal rule IS
+    // drawn at the page-1 bottom (y=40) — the row's own boundary edge.
+    const model = splitDoc([shortRow('a'), shortRow('b'), shortRow('c')], 40);
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(1);
+    const p1Table = pages[0].find((el) => el.type === 'table') as (PaginatedBodyElement & DocTable);
+    const sliced = p1Table.rows.some((r) => r.cells.some((c) =>
+      c.content.some((ce) => (ce as CellElement & { lineSlice?: unknown }).lineSlice !== undefined)));
+    expect(sliced).toBe(false);
+
+    const p1 = await renderPage(model, pages, 0);
+    const p1H = horizontals(p1);
+    expect(p1H.filter((s) => Math.abs(s.y1 - 40) <= 1).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Split rows that start a vertical merge; leave mid-row page cuts open

Stages C/D of the mid-page table-row-break series (stage B = #925). Two findings from
the target document class (a multi-page government form; described here without private
fixture details) drove this:

### 1. Rows beginning a §17.4.85 vertical merge never split (`fix(docx): split rows that start a vertical merge across the page band`)

Mid-page row splitting already ships for ordinary rows, but BOTH row splitters rejected
any vMerge involvement — so a tall form row with narrow `vMerge=restart` label columns
and a long content cell moved to the next page whole, underfilling the source page where
Word splits at a cell line boundary (§17.4.6: splittable by default).

The spec-faithful gate distinguishes the two §17.4.85 roles: a CONTINUE cell's box is
owned by an earlier row (still excluded); a RESTART cell starts its span in THIS row —
its content fits the band like any cell's, the page-1 piece keeps `restart` (truncated
box ends at the cut), the page-2 piece keeps `restart` too, so the following `continue`
rows chain onto it via `findMergeEndRow` and the span re-opens on the continuation page
exactly as Word draws it. `tableBreakAllowedBefore` keeps the re-opened span attached to
its continue rows. Pinned Red-first with a synthetic mirror of the class (both label
variants: fully-consumed → empty continuation, and label splitting alongside the content
cell), fragment provenance (`sourceRowIndex` shared, restart/continue/continue roles),
and the continue-cell refusal.

Verified against the target document (local render probe vs its Word PDF): the row now
splits mid-page with the span re-opening on page 2 — structurally matching Word. The
exact split line differs by ~2 lines and the label column's line pitch differs (accumulated
font-metric/line-spacing drift over the preceding ~750pt, pre-existing), left for
fidelity adjudication.

### 2. Mid-row page-cut edges drew row borders (`fix(docx): leave mid-row page-cut edges open`)

A page cut THROUGH a row is not a row boundary: Word leaves the page-1 piece's bottom
edge open (the row continues) and the continuation draws its own top edge — the target
document's PDF shows exactly this. Our renderer closed the cut with the piece's resolved
bottom border. Cut pieces now carry a runtime-only marker (on the row clone, never the
parsed model) consumed by the shared border pass; row-boundary cuts are untouched
(pinned). The §17.4.66 ownership convention also collapses the would-be rule between two
pieces stacked on one page.

### Review fixes (High blocking + Low, both addressed; branch rebased onto #925's tip)

- **[High] Span-extension double counting**: after a restart-row split, the pieces
  carried the fitted restart content while the merge-end row kept the §17.4.85
  extension resolved for the UNSPLIT row (the reviewer's 100pt-body repro produced a
  160pt page). The final piece's height now EXCLUDES restart remainders (they
  distribute over the re-opened span; the splitter reports them per grid column since
  the piece content is line-sliced and must not be re-measured whole), and a repair
  pass at all three splice sites resets the tail rows to base heights and re-applies
  the extension exactly once in resolver order. The slice-start trigger is now
  unbreakable-GROUP aware, so an over-tall restart+continue group splits its head into
  the remaining band and the re-opened piece re-splits on the next page when the
  remaining span still exceeds a fresh page. Red-first with the review's repro shape
  (every page ≤ the body band; every label paragraph and content line placed exactly
  once, whole or sliced).
- **[Low] vAlign coverage**: the target class centres its restart labels, so excluding
  center/bottom would regress it. Structure pinned for both label variants
  (split fires, content once, band bound); the per-piece re-centring is documented as
  Word-unverified at both splitter gates instead of asserting unknown Y positions.

Full gate re-run: docx 1134 tests green; VRT unchanged from the pre-fix branch state
(the only delta vs base remains the border commit's known-fail-page improvement; the
span repair itself is pixel-inert across all 89 checks).

### Verification

- Full workspace `pnpm test` green (docx 145 files / 1125 tests); root typecheck, lint,
  lint:test, `cargo fmt --check`, `git diff --check` all clean.
- Local pixel VRT (89 checks): ONE check moved vs the base merge commit — a known-fail
  page improved by 478 diff px (its table contains a pre-existing mid-row split whose
  cut edge is now open; bisect attributes the delta to the border commit, with the
  restart-split commit byte-identical across all 89). Everything else reproduces the
  base pixel counts exactly. References untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
