### PR TITLE
fix(ci): cache Playwright browsers to avoid apt-mirror smoke timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,9 +189,36 @@ jobs:
       # catches engine-specific pipeline breakage a Chrome-only run would miss.
       # Chrome is handled by the guarded step above (system Google Chrome), so we
       # install only the two bundled engines here.
+      #
+      # `playwright install --with-deps` bundled the apt-based OS dependency
+      # install and the browser binary download into one step; the apt install
+      # against the Azure mirror is what intermittently stalls past a short
+      # timeout, and it isn't cacheable across runs. Split the two so the
+      # (cacheable) browser binaries can be restored from cache and skip the
+      # download entirely on a hit, while the apt step keeps its own generous
+      # timeout to absorb mirror slowness.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(grep -m1 "^  '@playwright/test@" pnpm-lock.yaml | sed -E "s/^  '@playwright\/test@([^']+)':$/\1/")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install WebKit + Firefox OS dependencies
+        timeout-minutes: 15
+        run: pnpm exec playwright install-deps webkit firefox
+
       - name: Install Playwright WebKit + Firefox
-        timeout-minutes: 5
-        run: pnpm exec playwright install webkit firefox --with-deps
+        timeout-minutes: 15
+        run: pnpm exec playwright install webkit firefox
       - name: Smoke tests
         run: pnpm smoke
 


### PR DESCRIPTION
## Problem

The `smoke` job's "Install Playwright WebKit + Firefox" step
(`playwright install webkit firefox --with-deps`) intermittently
timed out at its fixed 5-minute budget when the Azure apt mirror used
for OS-dependency installation was slow, failing CI on otherwise-green
PRs.

Observed failures:
- Run [29100360301](https://github.com/yukiyokotani/office-open-xml-viewer/actions/runs/29100360301) (job [86387346276](https://github.com/yukiyokotani/office-open-xml-viewer/actions/runs/29100360301/job/86387346276)) — step timed out after 5 minutes.
- Run [29133241382](https://github.com/yukiyokotani/office-open-xml-viewer/actions/runs/29133241382) attempt 1 (job 86387346276 on the retried run) — same failure; attempt 2 passed on re-run.

## Fix

`--with-deps` bundles two unrelated concerns into one step with one
timeout:
1. `apt`-based OS dependency install (not cacheable, and the actual
   source of the mirror-latency flakiness).
2. Browser binary download (cacheable across runs).

This PR splits them and adds caching:

- **`Resolve Playwright version`** — greps the pinned
  `@playwright/test` version out of `pnpm-lock.yaml` (currently
  `1.59.1`) so the cache key tracks the exact resolved version rather
  than the whole lockfile hash (avoids invalidating the browser cache
  on unrelated dependency bumps).
- **`Cache Playwright browsers`** (`actions/cache@v6`) — caches
  `~/.cache/ms-playwright` on `key: <runner.os>-playwright-<version>`
  with `restore-keys: <runner.os>-playwright-` as a partial fallback
  (Playwright installs per-revision-named folders, so a partial/older
  cache hit is still safe to build on top of).
- **`Install WebKit + Firefox OS dependencies`** —
  `playwright install-deps webkit firefox`, always runs (not
  cacheable), `timeout-minutes: 15`.
- **`Install Playwright WebKit + Firefox`** — now just
  `playwright install webkit firefox` (no `--with-deps`); on a cache
  hit this is a fast no-op, `timeout-minutes: 15`.

Both split steps get the raised timeout as insurance: the deps step
against residual apt-mirror slowness, the install step against a
cache miss needing a full download.

No other jobs or steps in `ci.yml` were touched.

## Verification

- `actionlint` (installed via `brew install actionlint`) passes clean
  on `.github/workflows/ci.yml` and on all other workflow files in
  `.github/workflows/` (no regressions).
- Manually verified the version-resolution command against the
  worktree's `pnpm-lock.yaml`: resolves to `1.59.1`, matching
  `@playwright/test: ^1.59.1` in `package.json`.
- Not yet observed passing in this PR's own CI run — please watch the
  `smoke` job here to confirm the cache step behaves as expected (cold
  cache on first run, then a hit on a subsequent run/rerun).

## Test plan

- [ ] `smoke` job succeeds on this PR's CI run
- [ ] `Cache Playwright browsers` step reports a cache miss on first
      run and saves a cache
- [ ] A rerun (or a follow-up PR) shows a cache hit and a
      near-instant "Install Playwright WebKit + Firefox" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)