### PR TITLE
fix(pptx): derive a contrast-aware default text colour for the SmartArt fallback

### DIFF
--- a/packages/pptx/parser/src/smartart_fallback.rs
+++ b/packages/pptx/parser/src/smartart_fallback.rs
@@ -34,6 +34,14 @@
 //! A missing `r:dm` relationship, a missing data part, or unparsable XML emits
 //! **nothing** (same as before this fallback existed): a broken reference is
 //! never turned into spurious output.
+//!
+//! Text colour: the data model rarely carries run colours (the real diagram
+//! derives them from `colors*.xml` / `quickStyle*.xml`, which this fallback
+//! intentionally discards), so runs are emitted with `color: null`. The
+//! renderer gives THIS synthetic shape a contrast-aware default against the
+//! slide background — a documented UX choice, not ECMA-376 semantics (the
+//! spec defines no text colour for a diagram without its drawing part). See
+//! `packages/pptx/src/smartart-fallback-contrast.ts`.
 
 use crate::text::{empty_level_bullets, parse_text_body, ShapeKind};
 use crate::types::*;

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -97,6 +97,7 @@ import { fitCjkLine, type MeasuredChar } from './cjk-wrap.js';
 import { justifyLine, type Justified } from './text-justify';
 import { justifiedPiecePositions } from '@silurus/ooxml-core';
 import { resolveTableBorderConflict } from './table-border-conflict.js';
+import { isSmartArtFallbackShape, smartArtFallbackTextColor } from './smartart-fallback-contrast';
 
 /** Theme font context threaded through the render call chain. */
 export interface RenderContext {
@@ -114,6 +115,15 @@ export interface RenderContext {
    * `?? 1` fallback (aligns with docx's required `RenderState.dpr`).
    */
   dpr: number;
+  /**
+   * Contrast-aware default text colour for THIS slide's synthetic SmartArt
+   * fallback shape (issue #805), pre-derived by `renderSlide` from the
+   * slide-background luminance via {@link smartArtFallbackTextColor}. Null /
+   * absent = keep the ordinary theme default. Consumed only by
+   * {@link shapeDefaultTextColor} for shapes matching
+   * {@link isSmartArtFallbackShape}; every other shape ignores it.
+   */
+  smartArtFallbackTextColor?: string | null;
 }
 
 /** Information about a rendered text segment for building a transparent selection overlay. */
@@ -1960,6 +1970,23 @@ function presetTextRect(
   }
 }
 
+/**
+ * The shape-level default text colour passed to {@link renderTextBody} (used
+ * by runs whose colour resolves to null). A style-derived `defaultTextColor`
+ * (p:style > fontRef) always wins; the synthetic SmartArt fallback shape —
+ * which never carries one — takes the slide's contrast-aware default from
+ * {@link RenderContext.smartArtFallbackTextColor} so its data-model text is
+ * legible on a dark background (issue #805). All other shapes: null (theme
+ * default applies downstream).
+ */
+function shapeDefaultTextColor(el: ShapeElement, rc: RenderContext): string | null {
+  if (el.defaultTextColor) return hexToRgba(el.defaultTextColor);
+  if (rc.smartArtFallbackTextColor != null && isSmartArtFallbackShape(el)) {
+    return rc.smartArtFallbackTextColor;
+  }
+  return null;
+}
+
 function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: number, themeDefaultColor = '#000000', slideNumber?: number, rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 }, onTextRun?: TextRunCallback, fetchImage?: FetchImage) {
   const x = emuToPx(el.x, scale);
   const y = emuToPx(el.y, scale);
@@ -1979,7 +2006,7 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
       ctx.restore();
     }
     if (el.textBody) {
-      const defaultTextColor = el.defaultTextColor ? hexToRgba(el.defaultTextColor) : null;
+      const defaultTextColor = shapeDefaultTextColor(el, rc);
       renderTextBody(ctx, el.textBody, x, y, w, h, scale, defaultTextColor, el.rotation, el.flipH, el.flipV, themeDefaultColor, slideNumber, rc, onTextRun, false, fetchImage);
     }
     return;
@@ -2348,7 +2375,7 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
 
   // Render text inside the rotation context so text follows shape rotation
   if (el.textBody) {
-    const defaultTextColor = el.defaultTextColor ? hexToRgba(el.defaultTextColor) : null;
+    const defaultTextColor = shapeDefaultTextColor(el, rc);
     ctx.save();
     if (el.flipH || el.flipV) {
       const cx = x + w / 2;
@@ -5008,6 +5035,10 @@ async function renderSlideLeased(
     return canvas;
   }
 
+  const themeDefaultColor = opts.defaultTextColor
+    ? `#${opts.defaultTextColor}`
+    : '#000000';
+
   const rc: RenderContext = {
     themeMajorFont: opts.majorFont ?? null,
     themeMinorFont: opts.minorFont ?? null,
@@ -5015,6 +5046,9 @@ async function renderSlideLeased(
     // The backing store may have been clamped below `canvasSize × dpr`; downstream
     // crisp-offset math must use the SAME effective dpr the ctx was scaled by.
     dpr: effectiveDpr,
+    // Issue #805 — legible default for the synthetic SmartArt fallback shape's
+    // null-colour runs, derived once per slide from the background luminance.
+    smartArtFallbackTextColor: smartArtFallbackTextColor(slide.background, themeDefaultColor),
   };
 
   await renderBackground(ctx, slide.background, canvasW, canvasH, scale, opts.fetchImage);
@@ -5025,10 +5059,6 @@ async function renderSlideLeased(
   // here; without it, equations are skipped and the asset never enters the bundle.
   if (opts.math) await prepareSlideMath(slide, opts.math);
   if (superseded()) return canvas;
-
-  const themeDefaultColor = opts.defaultTextColor
-    ? `#${opts.defaultTextColor}`
-    : '#000000';
 
   const slideNumber = slide.slideNumber;
 

--- a/packages/pptx/src/smartart-fallback-contrast.test.ts
+++ b/packages/pptx/src/smartart-fallback-contrast.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect } from 'vitest';
+import {
+  backgroundLuminance,
+  isSmartArtFallbackShape,
+  smartArtFallbackTextColor,
+} from './smartart-fallback-contrast';
+import { renderSlide } from './renderer';
+import type { Fill } from '@silurus/ooxml-core';
+import type { Paragraph, ShapeElement, Slide, TextBody } from './types';
+
+/**
+ * Issue #805: the SmartArt data-model fallback (a synthetic shape emitted by
+ * the Rust parser when no drawing part is stored) renders its node texts with
+ * `color: null`, falling to the renderer's theme default (dk1 — dark). On a
+ * dark slide background the list is invisible. The renderer now derives a
+ * contrast-aware default for that synthetic shape from the slide-background
+ * luminance. Ordinary shapes are untouched.
+ */
+
+// ── pure helpers ───────────────────────────────────────────────────────────
+
+describe('backgroundLuminance', () => {
+  it('is dark for a solid navy background and light for solid white', () => {
+    const navy: Fill = { fillType: 'solid', color: '1F3864' };
+    const white: Fill = { fillType: 'solid', color: 'FFFFFF' };
+    expect(backgroundLuminance(navy)).not.toBeNull();
+    expect(backgroundLuminance(navy)!).toBeLessThan(0.5);
+    expect(backgroundLuminance(white)).toBeCloseTo(1, 5);
+  });
+
+  it('integrates gradient stops piecewise-linearly over [0,1]', () => {
+    // black@0 → white@1: mean luma of the linear ramp is 0.5.
+    const ramp: Fill = {
+      fillType: 'gradient',
+      gradType: 'linear',
+      angle: 90,
+      stops: [
+        { position: 0, color: '000000' },
+        { position: 1, color: 'FFFFFF' },
+      ],
+    };
+    expect(backgroundLuminance(ramp)).toBeCloseTo(0.5, 5);
+    // Both stops dark navy → dark; end stops extend to the 0/1 edges.
+    const navyRamp: Fill = {
+      fillType: 'gradient',
+      gradType: 'linear',
+      angle: 90,
+      stops: [
+        { position: 0.2, color: '1F3864' },
+        { position: 0.8, color: '0A1430' },
+      ],
+    };
+    expect(backgroundLuminance(navyRamp)!).toBeLessThan(0.3);
+  });
+
+  it('composites an 8-char RRGGBBAA solid over the white canvas base', () => {
+    // Black at 0% alpha is effectively the white base.
+    const clear: Fill = { fillType: 'solid', color: '00000000' };
+    expect(backgroundLuminance(clear)).toBeCloseTo(1, 5);
+    // Black at full alpha stays black.
+    const opaque: Fill = { fillType: 'solid', color: '000000FF' };
+    expect(backgroundLuminance(opaque)).toBeCloseTo(0, 5);
+  });
+
+  it('returns null (unknown) for image/pattern/none/absent backgrounds', () => {
+    expect(backgroundLuminance(null)).toBeNull();
+    expect(backgroundLuminance({ fillType: 'none' })).toBeNull();
+    expect(
+      backgroundLuminance({
+        fillType: 'image',
+        imagePath: 'ppt/media/image1.png',
+        mimeType: 'image/png',
+      } as Fill),
+    ).toBeNull();
+    expect(
+      backgroundLuminance({
+        fillType: 'pattern',
+        fg: '000000',
+        bg: 'FFFFFF',
+        preset: 'pct50',
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('smartArtFallbackTextColor', () => {
+  const navy: Fill = { fillType: 'solid', color: '1F3864' };
+  const white: Fill = { fillType: 'solid', color: 'FFFFFF' };
+
+  it('turns white on a dark background when the theme default is dark', () => {
+    expect(smartArtFallbackTextColor(navy, '#383838')).toBe('#FFFFFF');
+  });
+
+  it('keeps the existing default on a light background', () => {
+    expect(smartArtFallbackTextColor(white, '#383838')).toBeNull();
+  });
+
+  it('keeps the existing default when the background is unknown', () => {
+    expect(smartArtFallbackTextColor(null, '#383838')).toBeNull();
+  });
+
+  it('keeps a theme default that is already light (legible on dark)', () => {
+    expect(smartArtFallbackTextColor(navy, '#EEEEEE')).toBeNull();
+  });
+});
+
+describe('isSmartArtFallbackShape', () => {
+  it('matches the parser-synthesized fingerprint (name, no cNvPr id)', () => {
+    expect(isSmartArtFallbackShape({ name: 'SmartArt' })).toBe(true);
+  });
+
+  it('rejects real shapes (cNvPr id present or another name)', () => {
+    expect(isSmartArtFallbackShape({ name: 'SmartArt', id: '4' })).toBe(false);
+    expect(isSmartArtFallbackShape({ name: 'Rectangle 5' })).toBe(false);
+    expect(isSmartArtFallbackShape({})).toBe(false);
+  });
+});
+
+// ── renderSlide integration ────────────────────────────────────────────────
+
+interface FillTextCall {
+  text: string;
+  fillStyle: string;
+}
+
+/** A minimal recording 2D context capturing fillStyle at each fillText. */
+function recordingCtx(): { ctx: CanvasRenderingContext2D; fillTexts: FillTextCall[] } {
+  const fillTexts: FillTextCall[] = [];
+  const noop = () => {};
+  const ctx: Record<string, unknown> = {
+    // state + transforms
+    save: noop,
+    restore: noop,
+    scale: noop,
+    translate: noop,
+    rotate: noop,
+    setTransform: noop,
+    transform: noop,
+    getTransform: () => ({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 }),
+    // path building
+    beginPath: noop,
+    closePath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    bezierCurveTo: noop,
+    quadraticCurveTo: noop,
+    arc: noop,
+    arcTo: noop,
+    ellipse: noop,
+    rect: noop,
+    clip: noop,
+    // paint
+    fill: noop,
+    stroke: noop,
+    fillRect: noop,
+    strokeRect: noop,
+    clearRect: noop,
+    strokeText: noop,
+    drawImage: noop,
+    setLineDash: noop,
+    createLinearGradient: () => ({ addColorStop: noop }),
+    createRadialGradient: () => ({ addColorStop: noop }),
+    createPattern: () => null,
+    // text
+    fillText(text: string) {
+      fillTexts.push({ text, fillStyle: String(this.fillStyle) });
+    },
+    measureText: (t: string) => ({
+      width: t.length * 6,
+      actualBoundingBoxAscent: 8,
+      actualBoundingBoxDescent: 2,
+      fontBoundingBoxAscent: 9,
+      fontBoundingBoxDescent: 3,
+    }),
+    // style props (assigned by the renderer)
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    miterLimit: 10,
+    globalAlpha: 1,
+    font: '',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    letterSpacing: '0px',
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fillTexts };
+}
+
+function stubCanvas(ctx: CanvasRenderingContext2D): HTMLCanvasElement {
+  const canvas = {
+    width: 0,
+    height: 0,
+    style: {} as CSSStyleDeclaration,
+    offsetWidth: 960,
+    getContext: () => ctx,
+  } as unknown as HTMLCanvasElement;
+  // Back-reference used by the renderer's effect-canvas sizing.
+  (ctx as unknown as { canvas: HTMLCanvasElement }).canvas = canvas;
+  return canvas;
+}
+
+function paragraph(text: string): Paragraph {
+  return {
+    alignment: 'l',
+    marL: 0,
+    marR: 0,
+    indent: 0,
+    spaceBefore: null,
+    spaceAfter: null,
+    spaceLine: null,
+    lvl: 0,
+    bullet: { type: 'none' },
+    defFontSize: null,
+    defColor: null,
+    defBold: null,
+    defItalic: null,
+    defFontFamily: null,
+    tabStops: [],
+    eaLnBrk: true,
+    runs: [
+      {
+        type: 'text',
+        text,
+        bold: null,
+        italic: null,
+        underline: false,
+        strikethrough: false,
+        fontSize: 18,
+        color: null,
+        fontFamily: null,
+      },
+    ],
+  };
+}
+
+function textBody(text: string): TextBody {
+  return {
+    verticalAnchor: 't',
+    paragraphs: [paragraph(text)],
+    defaultFontSize: 18,
+    defaultBold: null,
+    defaultItalic: null,
+    lIns: 91440,
+    rIns: 91440,
+    tIns: 45720,
+    bIns: 45720,
+    wrap: 'square',
+    vert: 'horz',
+    autoFit: 'none',
+    numCol: 1,
+    spcCol: 0,
+  };
+}
+
+/** The shape the Rust SmartArt fallback synthesizes (see smartart_fallback.rs
+ *  `text_list_shape`): name "SmartArt", no cNvPr id, no style-derived default
+ *  text colour. */
+function fallbackShape(text: string, overrides: Partial<ShapeElement> = {}): ShapeElement {
+  return {
+    type: 'shape',
+    x: 914400,
+    y: 914400,
+    width: 4572000,
+    height: 2286000,
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+    geometry: 'rect',
+    fill: null,
+    stroke: null,
+    textBody: textBody(text),
+    defaultTextColor: null,
+    custGeom: null,
+    adj: null,
+    adj2: null,
+    adj3: null,
+    adj4: null,
+    adj5: null,
+    adj6: null,
+    adj7: null,
+    adj8: null,
+    shadow: null,
+    name: 'SmartArt',
+    ...overrides,
+  };
+}
+
+function slideWith(background: Fill | null, elements: ShapeElement[]): Slide {
+  return {
+    index: 0,
+    slideNumber: 1,
+    background,
+    elements,
+  };
+}
+
+const DARK_BG: Fill = { fillType: 'solid', color: '1F3864' };
+
+async function renderAndCollect(slide: Slide): Promise<FillTextCall[]> {
+  const { ctx, fillTexts } = recordingCtx();
+  const canvas = stubCanvas(ctx);
+  await renderSlide(canvas, slide, 9_144_000, 6_858_000, {
+    width: 960,
+    dpr: 1,
+    defaultTextColor: '383838',
+  });
+  return fillTexts;
+}
+
+describe('renderSlide SmartArt fallback contrast (issue #805)', () => {
+  it('renders null-colour fallback runs white on a dark background', async () => {
+    const calls = await renderAndCollect(slideWith(DARK_BG, [fallbackShape('Task one')]));
+    const run = calls.find((c) => c.text.includes('Task one'));
+    expect(run).toBeDefined();
+    expect(run!.fillStyle).toBe('#FFFFFF');
+  });
+
+  it('keeps the theme default on a light background (unchanged behaviour)', async () => {
+    const calls = await renderAndCollect(
+      slideWith({ fillType: 'solid', color: 'FFFFFF' }, [fallbackShape('Task one')]),
+    );
+    const run = calls.find((c) => c.text.includes('Task one'));
+    expect(run).toBeDefined();
+    expect(run!.fillStyle).toBe('#383838');
+  });
+
+  it('does not touch ordinary shapes on a dark background', async () => {
+    const calls = await renderAndCollect(
+      slideWith(DARK_BG, [fallbackShape('Plain box', { name: 'Rectangle 5', id: '4' })]),
+    );
+    const run = calls.find((c) => c.text.includes('Plain box'));
+    expect(run).toBeDefined();
+    expect(run!.fillStyle).toBe('#383838');
+  });
+
+  it('leaves explicit run colours alone on the fallback shape', async () => {
+    const shape = fallbackShape('Orange label');
+    const runData = shape.textBody!.paragraphs[0].runs[0];
+    if (runData.type === 'text') runData.color = 'ED7D31';
+    const calls = await renderAndCollect(slideWith(DARK_BG, [shape]));
+    const run = calls.find((c) => c.text.includes('Orange label'));
+    expect(run).toBeDefined();
+    expect(run!.fillStyle).not.toBe('#FFFFFF');
+  });
+});

--- a/packages/pptx/src/smartart-fallback-contrast.ts
+++ b/packages/pptx/src/smartart-fallback-contrast.ts
@@ -1,0 +1,106 @@
+// Contrast-aware default text colour for the synthetic SmartArt fallback
+// (issue #805).
+//
+// When a pptx stores no prebaked SmartArt drawing part, the Rust parser
+// (`smartart_fallback.rs`) synthesizes a bulleted-list shape from the diagram
+// data model (`ppt/diagrams/dataN.xml`). That data model rarely carries run
+// colours — the real colours live in `colors*.xml` / `quickStyle*.xml`, which
+// the fallback deliberately discards — so the runs resolve to `color: null`
+// and fall to the renderer's theme default (dk1, dark). On a dark slide
+// background the whole list is invisible (dark-on-dark).
+//
+// This module derives a legible default for THAT SYNTHETIC SHAPE ONLY, from
+// the slide-background luminance: light background → keep the dark theme
+// default (unchanged output), dark background → white. This is a UX choice
+// for an already-synthetic representation — ECMA-376 defines no text colour
+// for a diagram whose drawing part is absent — closest in spirit to
+// PowerPoint's own dk1/lt1 text autocolour. Explicit run colours (and a
+// style-derived `defaultTextColor`) always take precedence and are never
+// touched.
+
+import { hex6ToRgb, luminance601 } from '@silurus/ooxml-core';
+import type { Fill } from '@silurus/ooxml-core';
+
+/**
+ * Rec. 601 luma (0–1) of a 6- or 8-char hex colour (no leading `#`). An
+ * 8-char `RRGGBBAA` value is composited over white first — the canvas base
+ * every render paints behind a translucent background — so a mostly
+ * transparent dark colour reads as the light surface it actually shows as.
+ * Returns null for malformed input.
+ */
+function hexLuma(hex: string): number | null {
+  const rgb = hex6ToRgb(hex.length === 8 ? hex.slice(0, 6) : hex);
+  if (!rgb) return null;
+  const base = luminance601(rgb[0], rgb[1], rgb[2]);
+  if (hex.length !== 8) return base;
+  const a = Number.parseInt(hex.slice(6, 8), 16);
+  if (Number.isNaN(a)) return null;
+  const alpha = a / 255;
+  return alpha * base + (1 - alpha); // over the white base (luma 1)
+}
+
+/**
+ * Overall luminance (0–1) of a slide background fill, or null when it cannot
+ * be derived statically:
+ *
+ * - solid → the colour's luma;
+ * - gradient → the piecewise-linear integral of stop luma over [0,1] (the
+ *   average brightness of the ramp; end stops extend to the edges exactly as
+ *   canvas gradients clamp them);
+ * - image / pattern / none / absent → null. An image's brightness would need
+ *   a decode, a preset pattern's fg/bg mix depends on the preset bitmap, and
+ *   a missing background shows the host page. Unknown means "change nothing".
+ */
+export function backgroundLuminance(fill: Fill | null): number | null {
+  if (!fill) return null;
+  if (fill.fillType === 'solid') return hexLuma(fill.color);
+  if (fill.fillType === 'gradient') {
+    const stops = fill.stops
+      .map((s) => ({ p: Math.min(1, Math.max(0, s.position)), l: hexLuma(s.color) }))
+      .filter((s): s is { p: number; l: number } => s.l !== null)
+      .sort((a, b) => a.p - b.p);
+    if (stops.length === 0) return null;
+    const first = stops[0];
+    const last = stops[stops.length - 1];
+    let area = first.l * first.p + last.l * (1 - last.p);
+    for (let i = 0; i + 1 < stops.length; i++) {
+      area += ((stops[i].l + stops[i + 1].l) / 2) * (stops[i + 1].p - stops[i].p);
+    }
+    return area;
+  }
+  return null;
+}
+
+/**
+ * True for the shape the Rust SmartArt fallback synthesizes
+ * (`smartart_fallback.rs` `text_list_shape`): it is the only shape the parser
+ * emits with `name: "SmartArt"` and NO `id` — a real shape's `<p:cNvPr>`
+ * carries a schema-required `id` attribute, so a file-authored shape that
+ * happens to be named "SmartArt" still has one.
+ */
+export function isSmartArtFallbackShape(el: { name?: string; id?: string }): boolean {
+  return el.name === 'SmartArt' && el.id === undefined;
+}
+
+/**
+ * The default text colour the SmartArt fallback shape's null-colour runs
+ * should use on this slide, or null to keep the ordinary theme default.
+ *
+ * The 0.5 threshold is the Rec. 601 luma midpoint: the crossover at which
+ * black and white text are equidistant from the background — below it, white
+ * text has the larger luma separation. A theme default that is itself light
+ * (≥ 0.5, e.g. a dark-designed theme whose dk1 maps light) is already legible
+ * on a dark background and is kept, so this only ever REPLACES an illegible
+ * dark-on-dark default, never a working one.
+ */
+export function smartArtFallbackTextColor(
+  background: Fill | null,
+  themeDefaultColor: string,
+): string | null {
+  const bg = backgroundLuminance(background);
+  if (bg === null || bg >= 0.5) return null;
+  const themeLuma = hexLuma(themeDefaultColor.replace(/^#/, ''));
+  if (themeLuma !== null && themeLuma >= 0.5) return null;
+  // lt1's spec default and the maximum-contrast choice on a dark background.
+  return '#FFFFFF';
+}

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -284,6 +284,14 @@ export interface ShapeElement {
   /** `<a:sp3d>` 3D shape properties (ECMA-376 §20.1.5.12). Parsed but not
    *  rendered in Phase A. */
   sp3d?: Sp3d;
+  /** `<p:nvSpPr><p:cNvPr @id>` — DrawingML cNvPr id. Present for file-authored
+   *  shapes (the attribute is schema-required); absent on parser-synthesized
+   *  shapes such as the SmartArt data-model fallback. */
+  id?: string;
+  /** `<p:nvSpPr><p:cNvPr @name>` — author-visible shape name (e.g. "Title 1").
+   *  The SmartArt data-model fallback synthesizes `name: "SmartArt"` with no
+   *  {@link ShapeElement.id} (see smartart-fallback-contrast.ts). */
+  name?: string;
   /** Shape-level hyperlink target resolved from `<p:cNvPr><a:hlinkClick @r:id>`
    *  via slide _rels (ECMA-376 §21.1.2.3.5). For an external link this is the
    *  URL; for an internal slide jump it is the resolved internal part name.


### PR DESCRIPTION
## Summary

Closes #805.

The SmartArt data-model fallback (the synthetic bulleted-list shape emitted when a pptx stores no prebaked drawing part) renders its node texts with `color: null`, falling to the renderer's theme default (dk1 — dark). On a dark slide background the whole list was invisible (dark-on-dark, observed on sample-9: lvl1 task texts on navy).

`renderSlide` now derives a per-slide default text colour for that synthetic shape from the slide-background luminance and threads it through `RenderContext`:

- **Luminance source** — the shared Rec. 601 `luminance601` from `@silurus/ooxml-core` (the same weighting the duotone effect uses). Solid fills use the colour's luma (8-char `RRGGBBAA` composited over the white canvas base); gradients use the piecewise-linear integral of stop luma over [0,1] (end stops extended exactly as canvas gradients clamp them); image / pattern / absent backgrounds are *unknown* → no behaviour change.
- **Threshold** — the 0.5 luma midpoint: the crossover at which black and white text are equidistant from the background; below it white text has the larger separation. Dark background + dark theme default → `#FFFFFF` (lt1's spec default and the maximum-contrast choice). A theme default that is itself light (a dark-designed theme) is already legible and kept.
- **Scope** — explicit run colours, style-derived `defaultTextColor`, and every non-fallback shape are untouched. The fallback shape is identified by its parser-synthesized fingerprint: `name: "SmartArt"` with **no** cNvPr `id` (the `id` attribute is schema-required, so every file-authored shape carries one). The `id`/`name` fields the Rust parser already serializes are now declared on the TS `ShapeElement` contract.

This is a UX choice for an already-synthetic representation — ECMA-376 defines no text colour for a diagram whose drawing part is absent — documented as such in the TS module and in the Rust `smartart_fallback.rs` module doc (comment-only Rust change; no codegen impact).

## Tests

- `packages/pptx/src/smartart-fallback-contrast.test.ts` (new, 14 tests): pure-unit coverage of `backgroundLuminance` / `smartArtFallbackTextColor` / `isSmartArtFallbackShape`, plus `renderSlide` integration against a recording 2D context asserting: white on dark bg, unchanged theme default on light/unknown bg, ordinary shapes untouched, explicit run colours untouched.
- Full pptx TS suite: 60 files / 386 tests pass.
- Root `pnpm typecheck` passes; `ast-grep scan` clean for the new files; `cargo fmt --check` and `cargo clippy -p pptx-parser --all-targets -- -D warnings` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)