### PR TITLE
fix(xlsx): step the built-in +/- zoom buttons along the shared ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ changes that remain compatible with existing API surfaces.
 
 **Viewers / interaction**
 
+- **XlsxViewer built-in +/- zoom buttons now walk the shared zoom ladder:**
+  the tab-bar steppers step through the IX9 `ZoomableViewer` presets
+  (25 → 33 → 50 → 67 → 75 → 90 → 100 → 110 → 125 → 150 → 175 → 200 → 250 →
+  300 → 400 %), exactly like the contract's `zoomIn()`/`zoomOut()`, instead of
+  the previous linear ±10 %. Behaviour change for existing users of the
+  built-in chrome: from 100 %, "+" still lands on 110 %, but subsequent steps
+  now follow the presets (125 %, 150 %, …) and an off-preset wheel-zoomed scale
+  snaps onto the ladder on the first step. The slider and `setScale` are
+  unchanged. (#842, IX9)
+
 - **Disable hyperlink interactivity:** every hyperlink-supporting viewer
   (`DocxViewer`, `DocxScrollViewer`, `PptxViewer`, `PptxScrollViewer`,
   `XlsxViewer`) now accepts an `enableHyperlinks?: boolean` constructor option

--- a/packages/xlsx/src/viewer-zoom-contract.test.ts
+++ b/packages/xlsx/src/viewer-zoom-contract.test.ts
@@ -358,6 +358,65 @@ describe('XlsxViewer IX9 zoom contract', () => {
 });
 
 /**
+ * Issue #842 — the viewer's OWN +/- chrome must step exactly like the IX9
+ * contract methods: along the shared ladder (`ZOOM_STEP_LADDER` via
+ * `nextZoomStep`/`prevZoomStep`), not the pre-IX9 linear ±0.1. A host wiring
+ * its own buttons to `zoomIn`/`zoomOut` and a user clicking the built-in
+ * buttons now land on the same scales.
+ */
+describe('XlsxViewer built-in +/- buttons follow the shared ladder (issue #842)', () => {
+  function mountWithButtons(opts: ConstructorParameters<typeof XlsxViewer>[1] = {}) {
+    installDom();
+    const container = makeContainer();
+    const v = new XlsxViewer(container as unknown as HTMLElement, opts);
+    const priv = v as unknown as Priv;
+    priv.currentWorksheet = makeSheet();
+    priv.canvasArea.clientWidth = 400;
+    priv.canvasArea.clientHeight = 300;
+    const minus = container.querySelector('button[aria-label="Zoom out"]');
+    const plus = container.querySelector('button[aria-label="Zoom in"]');
+    if (!minus || !plus) throw new Error('built-in zoom buttons not found');
+    return { v, minus, plus };
+  }
+
+  it('the + button steps to the next ladder rung, not +0.1', () => {
+    const { v, plus } = mountWithButtons({ cellScale: 1.25 });
+    plus.dispatch('click');
+    expect(v.getScale()).toBe(1.5); // linear would give 1.35
+    plus.dispatch('click');
+    expect(v.getScale()).toBe(1.75);
+  });
+
+  it('the − button steps to the previous ladder rung, not −0.1', () => {
+    const { v, minus } = mountWithButtons();
+    minus.dispatch('click');
+    expect(v.getScale()).toBe(0.9);
+    minus.dispatch('click');
+    expect(v.getScale()).toBe(0.75); // linear would give 0.8
+  });
+
+  it('an off-ladder (wheel-zoomed) scale snaps onto the ladder', () => {
+    const { v, plus } = mountWithButtons({ cellScale: 1.03 });
+    plus.dispatch('click');
+    expect(v.getScale()).toBe(1.1); // linear would give 1.13
+  });
+
+  it('the − button holds at the bottom rung instead of sliding below it', () => {
+    const { v, minus } = mountWithButtons({ cellScale: 0.25 });
+    minus.dispatch('click');
+    expect(v.getScale()).toBe(0.25); // linear would give 0.15
+  });
+
+  it('button steps and contract zoomIn land on identical scales', () => {
+    const a = mountWithButtons({ cellScale: 1.25 });
+    const b = mountWithButtons({ cellScale: 1.25 });
+    a.plus.dispatch('click');
+    b.v.zoomIn();
+    expect(a.v.getScale()).toBe(b.v.getScale());
+  });
+});
+
+/**
  * Non-regression: the pre-IX9 slider position ↔ scale mapping (PR #315's
  * "100% dead-center piecewise-linear" behaviour) is unchanged. These call the
  * private helpers directly so a future contract change can't silently alter the

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -3053,7 +3053,11 @@ export class XlsxViewer implements ZoomableViewer {
       `display:flex;align-items:center;flex-shrink:0;gap:2px;` +
       `padding:0 10px;height:100%;color:#555;font-size:12px;user-select:none;`;
 
-    const mkBtn = (glyph: string, label: string, delta: number): HTMLButtonElement => {
+    // The steppers walk the shared IX9 zoom ladder (ZOOM_STEP_LADDER via
+    // zoomIn/zoomOut) so the built-in chrome and a host's own buttons wired to
+    // the ZoomableViewer contract land on identical scales (issue #842).
+    // Pre-IX9 these stepped ±0.1 linearly.
+    const mkBtn = (glyph: string, label: string, step: () => void): HTMLButtonElement => {
       const b = document.createElement('button');
       b.textContent = glyph;
       b.setAttribute('aria-label', label);
@@ -3061,7 +3065,7 @@ export class XlsxViewer implements ZoomableViewer {
       b.style.cssText =
         `width:18px;height:18px;padding:0;border:none;background:transparent;` +
         `color:#555;font-size:14px;line-height:1;cursor:pointer;border-radius:3px;`;
-      b.addEventListener('click', () => this.setScale((this.opts.cellScale ?? 1) + delta));
+      b.addEventListener('click', step);
       return b;
     };
 
@@ -3087,9 +3091,9 @@ export class XlsxViewer implements ZoomableViewer {
     label.textContent = `${Math.round(cur * 100)}%`;
     label.style.cssText = `min-width:42px;margin-left:6px;text-align:right;font-variant-numeric:tabular-nums;`;
 
-    wrap.appendChild(mkBtn('−', 'Zoom out', -0.1));
+    wrap.appendChild(mkBtn('−', 'Zoom out', () => this.zoomOut()));
     wrap.appendChild(slider);
-    wrap.appendChild(mkBtn('+', 'Zoom in', 0.1));
+    wrap.appendChild(mkBtn('+', 'Zoom in', () => this.zoomIn()));
     wrap.appendChild(label);
 
     this.zoomSlider = slider;


### PR DESCRIPTION
## Summary

Closes #842.

`XlsxViewer`'s built-in tab-bar +/- steppers changed `cellScale` by a linear ±0.1 (pre-IX9 behaviour kept verbatim per #315), while the IX9 `ZoomableViewer` contract methods `zoomIn()`/`zoomOut()` snap along the shared `ZOOM_STEP_LADDER` (…100 → 110 → 125 → 150…). A host wiring its own buttons to the contract stepped differently from the viewer's own chrome.

The built-in buttons are now re-pointed at `this.zoomIn()` / `this.zoomOut()`, so both paths walk the identical shared ladder:

- presets instead of ±10 % (e.g. 125 % → "+" → 150 %, not 135 %),
- an off-ladder (Ctrl/⌘-wheel-zoomed) scale snaps onto the ladder on the first step,
- the "−" button holds at the bottom rung (25 %) instead of sliding below it linearly.

The slider's piecewise-linear mapping (#315) and `setScale`'s clamp-and-snap are unchanged (pinned by the existing non-regression tests).

This is a visual behaviour change for existing users of the built-in chrome, so it is noted under **Unreleased → Viewers / interaction** in `CHANGELOG.md`, as the issue requests.

## Tests

- `packages/xlsx/src/viewer-zoom-contract.test.ts`: new describe drives the actual built-in buttons through the fake-DOM click path (TDD — all 5 failed with the exact linear values 1.35 / 0.8 / 1.13 / 0.15 before the fix): ladder stepping in both directions, off-ladder snap, bottom-rung hold, and button-vs-contract parity.
- Full xlsx TS suite: 56 files / 524 tests pass.
- Root `pnpm typecheck` passes; `ast-grep scan` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)