### PR TITLE
fix(docx): suppress space-shrink fit tolerance on justified lines (§17.18.44)

### DIFF
--- a/packages/docx/src/justify-shrink-overshoot.test.ts
+++ b/packages/docx/src/justify-shrink-overshoot.test.ts
@@ -8,28 +8,30 @@ import type {
   SectionProps,
 } from './types';
 
-// ECMA-376 §17.18.44 (ST_Jc `both`) — the Knuth-Plass space-shrink fit tolerance
-// (`SPACE_SHRINK_RATIO`) must NOT admit an extra word onto a FULLY-JUSTIFIED line.
+// ECMA-376 §17.18.44 (ST_Jc `both`/`distribute`) — the Knuth-Plass space-shrink
+// fit tolerance (`SPACE_SHRINK_RATIO`) must NOT admit an extra word onto a line
+// that the draw pass will JUSTIFY, and MUST keep doing so on a line the draw pass
+// treats as non-justified. The gate is per LINE, mirroring the paint predicate
+// (renderer.ts: `applyJustify = isJustified && (!endsLogicalLine || stretchLastLine)`):
 //
-// Word's line breaker is greedy and identical for justified and non-justified
-// paragraphs; justification redistributes the residual slack by EXPANDING the
-// inter-word spaces, and (in its default mode) never COMPRESSES a line below its
-// natural width to admit one more word. So on a justified line a candidate word
-// whose natural advance overflows the column must wrap — even if the overflow is
-// smaller than the line's total inter-word shrink budget. The shrink tolerance
-// exists only to absorb the Chromium-`measureText` vs Word advance-width bias on
-// a line that will be drawn at (or compressed toward) its natural spacing, i.e. a
-// NON-justified line (e.g. a substituted-font centred title that Word keeps on one
-// row). See issue #698: in sample-15 p1's narrow (8.4 cm) justified copyright
-// column the tolerance pulled "citation" up onto the "…and the full" line, where
-// Word (PDF ground truth) breaks after "full".
+// - A line that WILL justify (a non-final, non-manual-break line of a
+//   `both`/kashida paragraph, or ANY line of `distribute`/`thaiDistribute`)
+//   redistributes its slack by EXPANDING inter-word spaces — it is never drawn
+//   compressed below natural width, so a candidate word whose natural advance
+//   overflows the column must wrap. Observed Word behaviour (issue #698, PDF
+//   ground truth): in a narrow justified column the tolerance pulled one word up
+//   per affected line where Word breaks at natural fit.
+// - A line the draw pass does NOT justify — the paragraph's true last line and a
+//   line ending at a manual `<w:br/>` (§17.3.3.1) under `both`/kashida, and every
+//   line of a non-justified paragraph — is drawn with the shrink-fit compression
+//   the budget promises (`shrinkFitCompression`), so the measurement-bias
+//   tolerance stays: measure and paint spend the SAME budget (measure==paint).
 
 const FONT_PX = 12; // linear stub: each code point advances FONT_PX at scale 1
 
 /** Linear recording canvas: measureText advances FONT_PX per code point (space
  *  included), so a token's trailing-space width is exactly one FONT_PX. This makes
- *  the fit arithmetic explicit: a word overflowing the column by < the old
- *  `SPACE_SHRINK_RATIO · Σspace` budget was silently admitted before the fix. */
+ *  the fit arithmetic explicit — see TEXT4/TEXT5 below. */
 function makeLinearCanvas(): HTMLCanvasElement {
   let font = `${FONT_PX}px serif`;
   let letterSpacing = '0px';
@@ -77,16 +79,20 @@ function textRun(text: string): DocxTextRun {
 
 type DocRun = DocParagraph['runs'][number];
 
-function para(text: string, alignment: DocParagraph['alignment']): BodyElement {
+function para(runs: DocRun[], alignment: DocParagraph['alignment']): BodyElement {
   const p: DocParagraph = {
     alignment,
     indentLeft: 0, indentRight: 0, indentFirst: 0,
     spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
-    runs: [{ type: 'text', ...textRun(text) } as DocRun],
+    runs,
     defaultFontSize: FONT_PX, defaultFontFamily: 'serif',
     widowControl: false,
   };
   return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function textPara(text: string, alignment: DocParagraph['alignment']): BodyElement {
+  return para([{ type: 'text', ...textRun(text) } as DocRun], alignment);
 }
 
 function section(pageWidth: number): SectionProps {
@@ -106,41 +112,97 @@ function doc(el: BodyElement, sec: SectionProps): DocxDocumentModel {
   } as unknown as DocxDocumentModel;
 }
 
-/** Render one paragraph and return the number of visual text lines (distinct
- *  baseline y values reported by onTextRun). */
-async function lineCount(text: string, alignment: DocParagraph['alignment'], pageWidth: number): Promise<number> {
+/** Render one paragraph and return its visual lines, top-to-bottom: each line is
+ *  the concatenated text of the onTextRun segments sharing a baseline y. */
+async function renderLines(el: BodyElement, pageWidth: number): Promise<string[]> {
   const runs: DocxTextRunInfo[] = [];
-  await renderDocumentToCanvas(doc(para(text, alignment), section(pageWidth)), makeLinearCanvas(), 0, {
+  await renderDocumentToCanvas(doc(el, section(pageWidth)), makeLinearCanvas(), 0, {
     dpr: 1,
     width: pageWidth, // scale = 1 px/pt
     onTextRun: (r) => { if (r.text && r.text.trim()) runs.push(r); },
   });
-  return new Set(runs.map((r) => Math.round(r.y))).size;
+  const byY = new Map<number, DocxTextRunInfo[]>();
+  for (const r of runs) {
+    const key = Math.round(r.y);
+    let arr = byY.get(key);
+    if (!arr) { arr = []; byY.set(key, arr); }
+    arr.push(r);
+  }
+  return [...byY.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, rs]) => rs.slice().sort((p, q) => p.x - q.x).map((r) => r.text).join(''));
 }
 
-// Four 4-glyph words: natural width = 4·(4·12) + 3·(12) = 192 + 36 = 228 px.
-// Column = 225 px ⇒ the 4th word overflows by 3 px. The line carries 3 trailing
-// spaces (Σspace = 36 px), so the OLD budget = 0.25·36 = 9 px ≥ 3 px admitted it.
-const TEXT = 'AAAA AAAA AAAA AAAA';
+const tokens = (line: string): number => (line.match(/AAAA/g) ?? []).length;
+
+// Fit arithmetic (linear stub): each "AAAA " token advances 5·12 = 60px, the
+// bare word 48px, its trailing space 12px. Testing the 4th word on a line
+// already holding three tokens: currentWidth = 180, wForFit = 48 ⇒ natural end
+// 228. Column = 225 ⇒ overflow 3px. The line carries Σ trailing-space = 36px, so
+// the shrink budget (0.25·36 = 9px) admits the word WHEN the tolerance applies.
+const TEXT4 = 'AAAA AAAA AAAA AAAA';      // marginal word is the paragraph-FINAL word
+const TEXT5 = 'AAAA AAAA AAAA AAAA AAAA'; // marginal word is followed by more content
 const COLUMN = 225;
 
-describe('§17.18.44 — space-shrink fit tolerance is suppressed on justified lines (issue #698)', () => {
-  it('wraps a justified paragraph whose last word overflows the column at natural width', async () => {
-    // Word breaks here (the overflow is a genuine word, not measurement bias);
-    // the shrink budget must not pull it up. RED before the fix: 1 line.
-    expect(await lineCount(TEXT, 'both', COLUMN)).toBe(2);
+describe('§17.18.44 — space-shrink fit tolerance is gated per justified LINE (issue #698)', () => {
+  it('wraps the marginal word off a line that WILL justify (more content follows)', async () => {
+    // Word PDF ground truth (issue #698, narrow justified column): the justified
+    // line breaks at natural fit — the marginal word is not pulled up. Line 1
+    // must hold exactly 3 tokens; the old paragraph-wide tolerance admitted a 4th.
+    const lines = await renderLines(textPara(TEXT5, 'both'), COLUMN);
+    expect(lines.length).toBe(2);
+    expect(tokens(lines[0])).toBe(3);
   });
 
-  it('keeps the SAME overflow on ONE line for a non-justified paragraph (bias tolerance retained)', async () => {
-    // A left-aligned paragraph will be drawn at (or compressed toward) natural
-    // spacing, so the small overflow is absorbed as measurement bias — this is the
-    // behaviour that keeps sample-10 p1's centred title on a single row.
-    expect(await lineCount(TEXT, 'left', COLUMN)).toBe(1);
-    expect(await lineCount(TEXT, 'center', COLUMN)).toBe(1);
+  it('keeps the SAME marginal word on a non-justified line (bias tolerance retained)', async () => {
+    // left/center lines are drawn at (or compressed toward) natural spacing, so
+    // the 3px overflow is absorbed as measurement bias — this is what keeps a
+    // substituted-font centred title on a single row (sample-10 p1 class).
+    for (const alignment of ['left', 'center'] as const) {
+      const lines = await renderLines(textPara(TEXT5, alignment), COLUMN);
+      expect(lines.length, alignment).toBe(2);
+      expect(tokens(lines[0]), alignment).toBe(4); // budget admits the 4th; 5th wraps
+    }
+  });
+
+  it("keeps the budget on a `both` paragraph's TRUE LAST line (paint draws it non-justified)", async () => {
+    // The marginal word is the paragraph's final word: admitting it makes this
+    // the paragraph's last line, which the draw pass does NOT justify
+    // (applyJustify excludes endsLogicalLine for `both`) — it is drawn with the
+    // shrink-fit compression the budget promises. Measure must therefore admit
+    // within the same budget (measure==paint), keeping the old behaviour.
+    const lines = await renderLines(textPara(TEXT4, 'both'), COLUMN);
+    expect(lines.length).toBe(1);
+    expect(tokens(lines[0])).toBe(4);
+  });
+
+  it('keeps the budget on a `both` line ending at a manual <w:br/> (§17.3.3.1)', async () => {
+    // A manual break terminates the logical line, which `both` leaves
+    // non-justified exactly like the paragraph's last line — same budget rule.
+    const el = para(
+      [
+        { type: 'text', ...textRun(TEXT4) } as DocRun,
+        { type: 'break', breakType: 'line' } as DocRun,
+        { type: 'text', ...textRun('BBBB') } as DocRun,
+      ],
+      'both',
+    );
+    const lines = await renderLines(el, COLUMN);
+    expect(lines.length).toBe(2); // "AAAA ×4" ‖ "BBBB" — the break-line keeps its 4th token
+    expect(tokens(lines[0])).toBe(4);
+    expect(lines[1]).toContain('BBBB');
+  });
+
+  it('suppresses the budget on EVERY `distribute` line, including the last (stretchLastLine)', async () => {
+    // §17.18.44 `distribute` stretches every line — the paragraph-final line is
+    // justified too (paint: stretchLastLine), so its marginal word must wrap.
+    const lines = await renderLines(textPara(TEXT4, 'distribute'), COLUMN);
+    expect(lines.length).toBe(2);
+    expect(tokens(lines[0])).toBe(3);
   });
 
   it('does not force a wrap when the justified content genuinely fits at natural width', async () => {
-    // Widen the column past the natural width: no wrap, no spurious break.
-    expect(await lineCount(TEXT, 'both', 240)).toBe(1);
+    const lines = await renderLines(textPara(TEXT4, 'both'), 240);
+    expect(lines.length).toBe(1);
   });
 });

--- a/packages/docx/src/justify-shrink-overshoot.test.ts
+++ b/packages/docx/src/justify-shrink-overshoot.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas, type DocxTextRunInfo } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// ECMA-376 §17.18.44 (ST_Jc `both`) — the Knuth-Plass space-shrink fit tolerance
+// (`SPACE_SHRINK_RATIO`) must NOT admit an extra word onto a FULLY-JUSTIFIED line.
+//
+// Word's line breaker is greedy and identical for justified and non-justified
+// paragraphs; justification redistributes the residual slack by EXPANDING the
+// inter-word spaces, and (in its default mode) never COMPRESSES a line below its
+// natural width to admit one more word. So on a justified line a candidate word
+// whose natural advance overflows the column must wrap — even if the overflow is
+// smaller than the line's total inter-word shrink budget. The shrink tolerance
+// exists only to absorb the Chromium-`measureText` vs Word advance-width bias on
+// a line that will be drawn at (or compressed toward) its natural spacing, i.e. a
+// NON-justified line (e.g. a substituted-font centred title that Word keeps on one
+// row). See issue #698: in sample-15 p1's narrow (8.4 cm) justified copyright
+// column the tolerance pulled "citation" up onto the "…and the full" line, where
+// Word (PDF ground truth) breaks after "full".
+
+const FONT_PX = 12; // linear stub: each code point advances FONT_PX at scale 1
+
+/** Linear recording canvas: measureText advances FONT_PX per code point (space
+ *  included), so a token's trailing-space width is exactly one FONT_PX. This makes
+ *  the fit arithmetic explicit: a word overflowing the column by < the old
+ *  `SPACE_SHRINK_RATIO · Σspace` budget was silently admitted before the fix. */
+function makeLinearCanvas(): HTMLCanvasElement {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  const px = () => Number(/([\d.]+)px/.exec(font)?.[1] ?? FONT_PX);
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(v: string) { letterSpacing = v; },
+    fontKerning: 'auto',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0, style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return canvas as unknown as HTMLCanvasElement;
+}
+
+function textRun(text: string): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: FONT_PX, color: null, fontFamily: 'serif', isLink: false, background: null,
+    vertAlign: null, hyperlink: null,
+  };
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+function para(text: string, alignment: DocParagraph['alignment']): BodyElement {
+  const p: DocParagraph = {
+    alignment,
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: [{ type: 'text', ...textRun(text) } as DocRun],
+    defaultFontSize: FONT_PX, defaultFontFamily: 'serif',
+    widowControl: false,
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function section(pageWidth: number): SectionProps {
+  return {
+    pageWidth, pageHeight: 400,
+    marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    docGridCharSpace: undefined,
+  } as SectionProps;
+}
+
+function doc(el: BodyElement, sec: SectionProps): DocxDocumentModel {
+  return {
+    section: sec, body: [el],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+/** Render one paragraph and return the number of visual text lines (distinct
+ *  baseline y values reported by onTextRun). */
+async function lineCount(text: string, alignment: DocParagraph['alignment'], pageWidth: number): Promise<number> {
+  const runs: DocxTextRunInfo[] = [];
+  await renderDocumentToCanvas(doc(para(text, alignment), section(pageWidth)), makeLinearCanvas(), 0, {
+    dpr: 1,
+    width: pageWidth, // scale = 1 px/pt
+    onTextRun: (r) => { if (r.text && r.text.trim()) runs.push(r); },
+  });
+  return new Set(runs.map((r) => Math.round(r.y))).size;
+}
+
+// Four 4-glyph words: natural width = 4·(4·12) + 3·(12) = 192 + 36 = 228 px.
+// Column = 225 px ⇒ the 4th word overflows by 3 px. The line carries 3 trailing
+// spaces (Σspace = 36 px), so the OLD budget = 0.25·36 = 9 px ≥ 3 px admitted it.
+const TEXT = 'AAAA AAAA AAAA AAAA';
+const COLUMN = 225;
+
+describe('§17.18.44 — space-shrink fit tolerance is suppressed on justified lines (issue #698)', () => {
+  it('wraps a justified paragraph whose last word overflows the column at natural width', async () => {
+    // Word breaks here (the overflow is a genuine word, not measurement bias);
+    // the shrink budget must not pull it up. RED before the fix: 1 line.
+    expect(await lineCount(TEXT, 'both', COLUMN)).toBe(2);
+  });
+
+  it('keeps the SAME overflow on ONE line for a non-justified paragraph (bias tolerance retained)', async () => {
+    // A left-aligned paragraph will be drawn at (or compressed toward) natural
+    // spacing, so the small overflow is absorbed as measurement bias — this is the
+    // behaviour that keeps sample-10 p1's centred title on a single row.
+    expect(await lineCount(TEXT, 'left', COLUMN)).toBe(1);
+    expect(await lineCount(TEXT, 'center', COLUMN)).toBe(1);
+  });
+
+  it('does not force a wrap when the justified content genuinely fits at natural width', async () => {
+    // Widen the column past the natural width: no wrap, no spurious break.
+    expect(await lineCount(TEXT, 'both', 240)).toBe(1);
+  });
+});

--- a/packages/docx/src/layout-context.ts
+++ b/packages/docx/src/layout-context.ts
@@ -7,7 +7,7 @@ import {
   resolveDefaultTabPt,
   type DocGridCtx,
 } from './line-layout.js';
-import { jcIsFullyJustified } from './bidi-line.js';
+import { jcIsFullyJustified, jcStretchesLastLine } from './bidi-line.js';
 import type {
   BodyElement,
   ColumnGeom,
@@ -95,6 +95,7 @@ export interface ParagraphLayoutContext {
   readonly spaceAfterPt: number;
   readonly baseRtl: boolean;
   readonly isJustified: boolean;
+  readonly stretchLastLine: boolean;
   readonly tabStops: readonly TabStop[];
   readonly hasRuby: boolean;
   readonly hasEastAsianText: boolean;
@@ -276,6 +277,7 @@ export function resolveParagraphLayoutContext(
     spaceAfterPt: paragraph.spaceAfter,
     baseRtl,
     isJustified: jcIsFullyJustified(paragraph.alignment),
+    stretchLastLine: jcStretchesLastLine(paragraph.alignment),
     tabStops: [...paragraph.tabStops],
     hasRuby: paragraphHasRuby(paragraph),
     hasEastAsianText: paragraphHasEastAsianText(paragraph),

--- a/packages/docx/src/layout-context.ts
+++ b/packages/docx/src/layout-context.ts
@@ -7,6 +7,7 @@ import {
   resolveDefaultTabPt,
   type DocGridCtx,
 } from './line-layout.js';
+import { jcIsFullyJustified } from './bidi-line.js';
 import type {
   BodyElement,
   ColumnGeom,
@@ -93,6 +94,7 @@ export interface ParagraphLayoutContext {
   readonly spaceBeforePt: number;
   readonly spaceAfterPt: number;
   readonly baseRtl: boolean;
+  readonly isJustified: boolean;
   readonly tabStops: readonly TabStop[];
   readonly hasRuby: boolean;
   readonly hasEastAsianText: boolean;
@@ -273,6 +275,7 @@ export function resolveParagraphLayoutContext(
     spaceBeforePt: paragraph.spaceBefore,
     spaceAfterPt: paragraph.spaceAfter,
     baseRtl,
+    isJustified: jcIsFullyJustified(paragraph.alignment),
     tabStops: [...paragraph.tabStops],
     hasRuby: paragraphHasRuby(paragraph),
     hasEastAsianText: paragraphHasEastAsianText(paragraph),

--- a/packages/docx/src/line-boundary.test.ts
+++ b/packages/docx/src/line-boundary.test.ts
@@ -205,6 +205,7 @@ function layoutFixture(fixture: Fixture, startBoundary?: LineBoundary): LayoutLi
     fixture.width,
     fixture.baseRtl ?? false,
     false,
+    false,
     startBoundary,
   );
 }

--- a/packages/docx/src/line-boundary.test.ts
+++ b/packages/docx/src/line-boundary.test.ts
@@ -204,6 +204,7 @@ function layoutFixture(fixture: Fixture, startBoundary?: LineBoundary): LayoutLi
     36,
     fixture.width,
     fixture.baseRtl ?? false,
+    false,
     startBoundary,
   );
 }

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1448,9 +1448,10 @@ export const DEFAULT_TAB_PT = 36;
  *  standard typography (TeX, InDesign, Word) and lets the layout absorb the
  *  canvas `measureText` vs Word advance-width discrepancy (~0.1–0.3 px/glyph)
  *  that would otherwise push a trailing word to the next line. Per ECMA-376
- *  §17.18.44, this tolerance is suppressed for fully-justified paragraphs;
- *  justification expands residual slack instead of shrinking below natural fit
- *  to admit another word (issue #698).
+ *  §17.18.44, this tolerance is suppressed per line when the draw pass will
+ *  fully justify it: non-final/non-manual-break lines of `both`/kashida, and
+ *  every line of `distribute`/`thaiDistribute`. Lines the paint pass leaves
+ *  non-justified keep the budget so measurement and paint agree (issue #698).
  *
  *  For eligible non-justified lines this is the ONE budget shared by both sides
  *  of the fit contract: the wrap judgment below admits a word when the line's
@@ -2251,14 +2252,18 @@ export function layoutLines(
   // tabs do not trigger the LTR right/center/overflow wrap paths. Default false
   // ⇒ the LTR tab paths run unchanged (byte-identical output).
   baseRtl = false,
-  // ECMA-376 §17.18.44 — a fully-justified paragraph (`jc` both/distribute/…)
-  // redistributes slack by EXPANDING inter-word spaces; Word never compresses a
-  // line below its natural width to admit an extra word. So the Knuth-Plass
-  // space-shrink fit tolerance (SPACE_SHRINK_RATIO) is suppressed here — a
-  // justified line breaks at natural fit. The trailing-space-collapse allowance
-  // (the other role of lineTotalTrailingW) is unaffected. See issue #698
-  // (sample-15 p1 justified copyright column pulling "citation" up one line).
+  // ECMA-376 §17.18.44 — whether the paragraph uses a fully justified mode.
+  // The shrink tolerance is gated per line below: lines paint will justify get
+  // no budget, while true-last/manual-break lines left non-justified keep it.
+  // `stretchLastLine` distinguishes those modes. See issue #698.
   isJustified = false,
+  // ECMA-376 §17.18.44 — `distribute`/`thaiDistribute` stretch EVERY line
+  // including the paragraph's last (jcStretchesLastLine); `both`/kashida leave
+  // the last line and manual-break lines (§17.3.3.1) non-justified. Threaded so
+  // the per-candidate shrink gate below mirrors the paint predicate
+  // `applyJustify = isJustified && (!endsLogicalLine || stretchLastLine)`
+  // (renderer.ts) — measure and paint must classify each LINE identically.
+  stretchLastLine = false,
   startBoundary?: LineBoundary,
 ): LayoutLine[] {
   const lines: LayoutLine[] = [];
@@ -2266,14 +2271,11 @@ export function layoutLines(
   let currentWidth = 0;
   // Sum of trailing-space widths of every text token on the current line.
   // Used for two things:
-  //   1. Knuth-Plass-style shrink tolerance: a non-justified line may compress
-  //      inter-word spaces by up to SPACE_SHRINK_RATIO, so a candidate word
-  //      whose "natural" width would overflow by less than that total shrink
-  //      budget is allowed to fit. This is the standard typographic approach
-  //      to line-breaking and lets us absorb the ~0.1–0.3 px/glyph advance
-  //      bias between Chromium canvas and Word's internal text layout,
-  //      matching Word's wrap on long paragraphs. Per ECMA-376 §17.18.44, the
-  //      tolerance is suppressed for fully-justified paragraphs (issue #698).
+  //   1. Knuth-Plass-style shrink tolerance: lines the paint pass leaves
+  //      non-justified may compress spaces by up to SPACE_SHRINK_RATIO. Per
+  //      §17.18.44 it is suppressed for lines the paint pass fully justifies:
+  //      non-final/non-manual-break lines of `both`/kashida, and every line of
+  //      `distribute`/`thaiDistribute` (measure == paint; issue #698).
   //   2. Trailing-space collapse at line end — the last token's trailing
   //      space disappears when no further word is added, so when deciding
   //      whether a candidate word fits we treat it as if it would become the
@@ -2920,11 +2922,10 @@ export function layoutLines(
     //   1. Trailing-space collapse: if this word becomes the last on the
     //      line, its trailing space (if any) collapses. We subtract it from
     //      the width used to test fit.
-    //   2. Knuth-Plass shrink tolerance: a non-justified line may compress each
-    //      inter-word space by up to SPACE_SHRINK_RATIO (25%) of its natural
-    //      width. Per ECMA-376 §17.18.44 this tolerance is suppressed for a
-    //      fully-justified paragraph (issue #698); the trailing-space-collapse
-    //      allowance above remains unchanged. See the constant doc above.
+    //   2. Knuth-Plass shrink tolerance: lines the paint pass leaves
+    //      non-justified keep the budget. Per §17.18.44, lines the paint pass
+    //      fully justifies get no budget: non-final/non-manual-break `both`/kashida
+    //      lines, and every `distribute`/`thaiDistribute` line (issue #698).
     const trimmed = s.text.replace(/ +$/, '');
     // Subtract the full-model advance of the trimmed text (not the natural width)
     // so the grid delta, w:w scale and w:spacing pitch on the retained glyphs all
@@ -2932,7 +2933,23 @@ export function layoutLines(
     // and `wForFit` on the one advance model (`strAdvance` == the model behind `w`).
     const trailingSpaceW = s.text.endsWith(' ') ? w - strAdvance(s, trimmed) : 0;
     const wForFit = w - trailingSpaceW;
-    const shrinkBudget = isJustified ? 0 : lineTotalTrailingW * SPACE_SHRINK_RATIO;
+    // Shrink budget for a candidate whose admission would CLOSE the current line
+    // with `next` as the first following segment (the budget only matters for a
+    // MARGINAL candidate — one that fills the line past availW(), so nothing more
+    // fits after it). Mirrors the paint pass's per-line justify predicate
+    // (renderer.ts `applyJustify = isJustified && (!endsLogicalLine || stretchLastLine)`):
+    // a line the draw pass will JUSTIFY (§17.18.44 expands its inter-word spaces,
+    // never compresses below natural width) gets NO budget and breaks at natural
+    // fit (issue #698, Word PDF ground truth); a line the draw pass leaves
+    // non-justified — the paragraph's true last line (queue exhausted) or a manual
+    // `<w:br/>` line (§17.3.3.1) under `both`/kashida — keeps the measurement-bias
+    // budget, because paint draws it with the promised shrink-fit compression.
+    const shrinkBudgetFor = (next: LayoutSeg | undefined): number => {
+      const closesLogicalLine = next === undefined || 'lineBreak' in next;
+      const lineWillJustify = isJustified && (!closesLogicalLine || stretchLastLine);
+      return lineWillJustify ? 0 : lineTotalTrailingW * SPACE_SHRINK_RATIO;
+    };
+    const shrinkBudget = shrinkBudgetFor(queue[0]);
 
     // Atomic glued group: when THIS segment starts a glued group (its followers
     // in the queue are `joinPrev` pieces — small-caps case-pieces of the SAME
@@ -2959,8 +2976,9 @@ export function layoutLines(
     ) {
       let groupW = w;
       let groupTrail = trailingSpaceW;
-      for (let k = 0; k < queue.length && (queue[k] as LayoutTextSeg).joinPrev; k++) {
-        const f = queue[k] as LayoutTextSeg;
+      let groupEnd = 0;
+      for (; groupEnd < queue.length && (queue[groupEnd] as LayoutTextSeg).joinPrev; groupEnd++) {
+        const f = queue[groupEnd] as LayoutTextSeg;
         // A CJK-BREAKABLE follower (e.g. "Roman" + "、あるいは…用いる。") is NOT
         // atomic: only its LEADING run of line-start-forbidden chars would orphan
         // at a line head (UAX#14 LB13 / §17.3.1.16); the rest splits at an
@@ -2990,7 +3008,7 @@ export function layoutLines(
         const ft = f.text.replace(/ +$/, '');
         groupTrail = f.text.endsWith(' ') ? fw - strAdvance(f, ft) : 0;
       }
-      if (currentWidth + (groupW - groupTrail) > availW() + shrinkBudget) {
+      if (currentWidth + (groupW - groupTrail) > availW() + shrinkBudgetFor(queue[groupEnd])) {
         flush(undefined, false, s.src);
       }
     }

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1447,13 +1447,17 @@ export const DEFAULT_TAB_PT = 36;
  *  ECMA-376 prescribes no line-breaking algorithm — tolerance-based fit is
  *  standard typography (TeX, InDesign, Word) and lets the layout absorb the
  *  canvas `measureText` vs Word advance-width discrepancy (~0.1–0.3 px/glyph)
- *  that would otherwise push a trailing word to the next line.
+ *  that would otherwise push a trailing word to the next line. Per ECMA-376
+ *  §17.18.44, this tolerance is suppressed for fully-justified paragraphs;
+ *  justification expands residual slack instead of shrinking below natural fit
+ *  to admit another word (issue #698).
  *
- *  This is the ONE budget shared by both sides of the fit contract: the wrap
- *  judgment below admits a word when the line's overflow Δ ≤ SPACE_SHRINK_RATIO ·
- *  Σ(trailing-space widths), and the renderer's draw pass squeezes the same
- *  spaces by the same fraction so the admitted line lands inside its box instead
- *  of overrunning the clip (see `shrinkFitCompression` in text-distribute.ts). */
+ *  For eligible non-justified lines this is the ONE budget shared by both sides
+ *  of the fit contract: the wrap judgment below admits a word when the line's
+ *  overflow Δ ≤ SPACE_SHRINK_RATIO · Σ(trailing-space widths), and the renderer's
+ *  draw pass squeezes the same spaces by the same fraction so the admitted line
+ *  lands inside its box instead of overrunning the clip (see
+ *  `shrinkFitCompression` in text-distribute.ts). */
 export const SPACE_SHRINK_RATIO = 0.25;
 
 /** ECMA-376 §17.15.1.25 — resolve the document's automatic tab-stop interval
@@ -2247,6 +2251,14 @@ export function layoutLines(
   // tabs do not trigger the LTR right/center/overflow wrap paths. Default false
   // ⇒ the LTR tab paths run unchanged (byte-identical output).
   baseRtl = false,
+  // ECMA-376 §17.18.44 — a fully-justified paragraph (`jc` both/distribute/…)
+  // redistributes slack by EXPANDING inter-word spaces; Word never compresses a
+  // line below its natural width to admit an extra word. So the Knuth-Plass
+  // space-shrink fit tolerance (SPACE_SHRINK_RATIO) is suppressed here — a
+  // justified line breaks at natural fit. The trailing-space-collapse allowance
+  // (the other role of lineTotalTrailingW) is unaffected. See issue #698
+  // (sample-15 p1 justified copyright column pulling "citation" up one line).
+  isJustified = false,
   startBoundary?: LineBoundary,
 ): LayoutLine[] {
   const lines: LayoutLine[] = [];
@@ -2254,13 +2266,14 @@ export function layoutLines(
   let currentWidth = 0;
   // Sum of trailing-space widths of every text token on the current line.
   // Used for two things:
-  //   1. Knuth-Plass-style shrink tolerance: a justified line may compress
+  //   1. Knuth-Plass-style shrink tolerance: a non-justified line may compress
   //      inter-word spaces by up to SPACE_SHRINK_RATIO, so a candidate word
   //      whose "natural" width would overflow by less than that total shrink
   //      budget is allowed to fit. This is the standard typographic approach
   //      to line-breaking and lets us absorb the ~0.1–0.3 px/glyph advance
   //      bias between Chromium canvas and Word's internal text layout,
-  //      matching Word's wrap on long paragraphs.
+  //      matching Word's wrap on long paragraphs. Per ECMA-376 §17.18.44, the
+  //      tolerance is suppressed for fully-justified paragraphs (issue #698).
   //   2. Trailing-space collapse at line end — the last token's trailing
   //      space disappears when no further word is added, so when deciding
   //      whether a candidate word fits we treat it as if it would become the
@@ -2907,12 +2920,11 @@ export function layoutLines(
     //   1. Trailing-space collapse: if this word becomes the last on the
     //      line, its trailing space (if any) collapses. We subtract it from
     //      the width used to test fit.
-    //   2. Knuth-Plass shrink tolerance: a line may compress each inter-word
-    //      space by up to SPACE_SHRINK_RATIO (25%) of its natural width without
-    //      harming readability — the module constant, shared with the draw pass
-    //      so a line admitted here is squeezed by the same budget when painted
-    //      (shrinkFitCompression in text-distribute.ts) rather than overrunning
-    //      its box. See the SPACE_SHRINK_RATIO doc above.
+    //   2. Knuth-Plass shrink tolerance: a non-justified line may compress each
+    //      inter-word space by up to SPACE_SHRINK_RATIO (25%) of its natural
+    //      width. Per ECMA-376 §17.18.44 this tolerance is suppressed for a
+    //      fully-justified paragraph (issue #698); the trailing-space-collapse
+    //      allowance above remains unchanged. See the constant doc above.
     const trimmed = s.text.replace(/ +$/, '');
     // Subtract the full-model advance of the trimmed text (not the natural width)
     // so the grid delta, w:w scale and w:spacing pitch on the retained glyphs all
@@ -2920,7 +2932,7 @@ export function layoutLines(
     // and `wForFit` on the one advance model (`strAdvance` == the model behind `w`).
     const trailingSpaceW = s.text.endsWith(' ') ? w - strAdvance(s, trimmed) : 0;
     const wForFit = w - trailingSpaceW;
-    const shrinkBudget = lineTotalTrailingW * SPACE_SHRINK_RATIO;
+    const shrinkBudget = isJustified ? 0 : lineTotalTrailingW * SPACE_SHRINK_RATIO;
 
     // Atomic glued group: when THIS segment starts a glued group (its followers
     // in the queue are `joinPrev` pieces — small-caps case-pieces of the SAME

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -90,6 +90,7 @@ const layoutContext = (
   spaceAfterPt: 4,
   baseRtl: false,
   isJustified: false,
+  stretchLastLine: false,
   tabStops: [],
   hasRuby: false,
   hasEastAsianText: false,

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -89,6 +89,7 @@ const layoutContext = (
   spaceBeforePt: 3,
   spaceAfterPt: 4,
   baseRtl: false,
+  isJustified: false,
   tabStops: [],
   hasRuby: false,
   hasEastAsianText: false,

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -265,6 +265,7 @@ export function measureParagraph(
     paragraphWidthPt + context.physicalIndentRightPt,
     context.baseRtl,
     context.isJustified,
+    context.stretchLastLine,
     continuation?.boundary,
   );
   if (lines.length === 0) return measureMarkOnly();

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -264,6 +264,7 @@ export function measureParagraph(
     context.defaultTabPt,
     paragraphWidthPt + context.physicalIndentRightPt,
     context.baseRtl,
+    context.isJustified,
     continuation?.boundary,
   );
   if (lines.length === 0) return measureMarkOnly();

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7226,9 +7226,9 @@ function renderParagraph(
     : reuse
     ? rescaleLayoutLines(stamped.layoutLines as LayoutLine[], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx)
     : wrapCtx
-      ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx, baseRtl, jcIsFullyJustified(para.alignment))
+      ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx, baseRtl, jcIsFullyJustified(para.alignment), jcStretchesLastLine(para.alignment))
       : rescaleLayoutLines(
-          layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt, marginRightPx1, baseRtl, jcIsFullyJustified(para.alignment)),
+          layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt, marginRightPx1, baseRtl, jcIsFullyJustified(para.alignment), jcStretchesLastLine(para.alignment)),
           scale, ctx, state.fontFamilyClasses, paintGridDeltaPx,
         );
 
@@ -9356,6 +9356,7 @@ export function measureShapeTextAutoFitHeight(
         ind.paraW,
         baseRtl,
         jcIsFullyJustified(b.alignment),
+        jcStretchesLastLine(b.alignment),
       );
       contentH += lines.reduce((sum, line) => sum + lineHeightFor(b, line), 0);
     }
@@ -9648,6 +9649,7 @@ export function renderShapeText(
       ind.paraW, // marginRightPx: block text has no separate right-indent origin
       baseRtl,
       jcIsFullyJustified(b.alignment),
+      jcStretchesLastLine(b.alignment),
     );
     const metrics = lines.map((line) => lineMetricsFor(b, line));
     return {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7226,9 +7226,9 @@ function renderParagraph(
     : reuse
     ? rescaleLayoutLines(stamped.layoutLines as LayoutLine[], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx)
     : wrapCtx
-      ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx, baseRtl)
+      ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx, baseRtl, jcIsFullyJustified(para.alignment))
       : rescaleLayoutLines(
-          layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt, marginRightPx1, baseRtl),
+          layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt, marginRightPx1, baseRtl, jcIsFullyJustified(para.alignment)),
           scale, ctx, state.fontFamilyClasses, paintGridDeltaPx,
         );
 
@@ -9355,6 +9355,7 @@ export function measureShapeTextAutoFitHeight(
         effState.defaultTabPt,
         ind.paraW,
         baseRtl,
+        jcIsFullyJustified(b.alignment),
       );
       contentH += lines.reduce((sum, line) => sum + lineHeightFor(b, line), 0);
     }
@@ -9646,6 +9647,7 @@ export function renderShapeText(
       effState.defaultTabPt,
       ind.paraW, // marginRightPx: block text has no separate right-indent origin
       baseRtl,
+      jcIsFullyJustified(b.alignment),
     );
     const metrics = lines.map((line) => lineMetricsFor(b, line));
     return {

--- a/packages/docx/src/shrink-fit-draw.test.ts
+++ b/packages/docx/src/shrink-fit-draw.test.ts
@@ -152,27 +152,32 @@ describe('shrink-fit draw — text-box (shape) path', () => {
   });
 
   it('does NOT double-compress a justified (both) line — its own §17.18.44 path owns the slack', () => {
-    // A `both` paragraph that WRAPS: line 1 is a justify candidate (not the last
-    // line), so applyJustify is true and the shrink-fit branch (gated on
-    // !applyJustify) is SKIPPED — the justified path alone distributes its slack.
-    // "AAAA BBBB CCCC DDDD EEEE" at W=138 wraps with line 1 = "AAAA BBBB CCCC ".
-    const evs = renderShape([block('AAAA BBBB CCCC DDDD EEEE', { alignment: 'both' })], W, 400);
+    // ECMA-376 §17.18.44 (issue #698): a `both` line breaks at its NATURAL fit —
+    // the space-shrink tolerance is suppressed for justified paragraphs, so a
+    // justified line never overflows its box and is never admitted with negative
+    // slack. Line 1 is therefore a justify candidate with POSITIVE slack that the
+    // justify path alone EXPANDS evenly; the shrink-fit branch (gated on
+    // !applyJustify) stays off, so the gaps are single-application, not squeezed.
+    // "AAAA BBBB CCCC DDDD EEEE" at WJ=160 breaks with line 1 = "AAAA BBBB CCCC "
+    // (natural 140 ≤ 160), "DDDD" wrapping (140+40 > 160).
+    const WJ = 160;
+    const evs = renderShape([block('AAAA BBBB CCCC DDDD EEEE', { alignment: 'both' })], WJ, 400);
     const ys = [...new Set(evs.map((e) => e.y))].sort((a, b) => a - b);
     expect(ys.length).toBeGreaterThanOrEqual(2); // it wrapped
     const line1 = evs.filter((e) => e.y === ys[0]).sort((a, b) => a.x - b.x);
     expect(line1.map((e) => e.text.replace(/ +$/, '')).join(' ')).toBe('AAAA BBBB CCCC');
-    // Justify signature: the inter-word gaps are compressed by an EQUAL amount
-    // (Σ distributed evenly), so the two realised gaps match. If the shrink-fit
-    // path ALSO fired, this line would be compressed twice — either uneven or
-    // pulled well inside — so equal, single-budget gaps prove single application.
+    // Justify signature: the inter-word gaps are EXPANDED by an EQUAL amount
+    // (Σ slack distributed evenly), so the two realised gaps match. If the shrink-
+    // fit path ALSO fired it would compress the gaps below their natural width or
+    // distribute unevenly — so equal gaps WIDER than one space prove that only the
+    // justify pass ran.
     const [a, b, c] = line1; // "AAAA ", "BBBB ", "CCCC "
     const gap1 = b.x - (a.x + 4 * FONT_PX); // realised inter-word gap 1
     const gap2 = c.x - (b.x + 4 * FONT_PX); // realised inter-word gap 2
     expect(gap1).toBeCloseTo(gap2, 3);      // even distribution (justify)
-    // Compressed from the natural 10px but by a SINGLE justify pass — the gap is
-    // still positive (not squeezed twice below the floor) and within one space.
-    expect(gap1).toBeGreaterThan(0);
-    expect(gap1).toBeLessThan(FONT_PX);
+    // Expanded from the natural 10px by a SINGLE justify pass (positive slack),
+    // never squeezed by the shrink-fit branch.
+    expect(gap1).toBeGreaterThan(FONT_PX);
   });
 
   it('holds the squeeze at a non-unit zoom (scale = 0.75) — line stays inside the scaled box', () => {


### PR DESCRIPTION
## Problem

`layoutLines` admits a candidate word onto the current line whenever its natural
overflow fits within the Knuth-Plass space-shrink budget
(`Σ trailing-space widths × SPACE_SHRINK_RATIO`, ratio `0.25`). That tolerance is
meant to absorb the Chromium `measureText` vs Word advance-width bias on a line
drawn at (or compressed toward) natural spacing. It was applied to **fully
justified** paragraphs too.

In a narrow justified column the absolute shrink budget is a large fraction of a
single word, so the tolerance pulled one extra word onto a line where Word
breaks earlier, shifting several wrap points within the paragraph relative to the
Word ground truth. (Surfaced after text boxes moved onto the main layout engine,
so the tolerance began applying to text-box lines as well.)

## Fix

ECMA-376 §17.18.44 (`ST_Jc` `both`/`distribute`): Word's line breaker is greedy
and identical for justified and non-justified paragraphs; justification
redistributes the residual slack by **expanding** inter-word spaces and never
compresses a line below its natural width to admit an extra word.

So the space-shrink tolerance is now **suppressed for fully-justified
paragraphs** (`shrinkBudget = 0`) — a justified line breaks at natural fit. The
separate trailing-space-collapse allowance and **all non-justified behaviour are
unchanged**, so a centred/left title that overruns its box only by measurement
bias still stays on one line.

- `line-layout.ts`: thread an `isJustified` flag into `layoutLines`; gate the
  shrink budget.
- `layout-context.ts`: carry `isJustified` on `ParagraphLayoutContext` (classified
  via `jcIsFullyJustified`) so the paginator measure pass and the paint pass make
  the same break decisions.
- `paragraph-measure.ts` / `renderer.ts`: pass the paragraph's justified flag at
  every `layoutLines` call (body paint, autofit measure, and both text-box paths).

## Verification

Measured against the Word PDF ground truth (`pdftotext -bbox`) and the renderer's
`onTextRun`/line geometry at scale 1:

- A narrow (~8.4 cm) justified small-print column now wraps **exactly** as Word
  does — every line boundary matches the PDF, where before one word was pulled up
  per affected line.
- A centred substituted-font title still stays on a **single line** (unchanged).

Empirically, forcing `shrinkBudget = 0` for justified paragraphs reproduced Word's
exact wrapping for the justified column while leaving the centred title on one
row — no special case keyed to any document.

Gates: new focused test `justify-shrink-overshoot.test.ts` (RED before the fix)
plus the updated §17.18.44 draw test; full docx unit suite (1152 tests) and docx
`tsc --noEmit` pass.

Closes #698