### PR TITLE
Row-split fidelity: line partitions, sliced-piece paint, page-cut borders

### DIFF
--- a/packages/docx/src/fragment-paint.ts
+++ b/packages/docx/src/fragment-paint.ts
@@ -95,7 +95,8 @@ export function paintParagraphFragment(
  * called at all. Like {@link paintParagraphFragment}, this owns the fragment boundary
  * and delegates the draw to the renderer's shared table paint through a supplied-geometry
  * entry (`renderTableFragment`), so the paint stream is byte-identical to the legacy
- * `renderTable` acquisition for the migrated (in-flow, top-aligned) table class.
+ * `renderTable` acquisition for the migrated in-flow table class, including supported
+ * center/bottom-aligned and sliced cell fragments.
  */
 export function paintTableFragment(placed: PlacedFragment, state: RenderState): void {
   const fragment = placed.fragment;

--- a/packages/docx/src/ideographic-space-fit.test.ts
+++ b/packages/docx/src/ideographic-space-fit.test.ts
@@ -67,6 +67,18 @@ describe('trailing U+3000 line-end allowance', () => {
     expect(texts.some((t) => [...t].every((c) => c === '　'))).toBe(false);
   });
 
+  it('hangs the trailing U+3000 even when the glyph alone overflows the band (force-fit)', () => {
+    // The real form label's cell content band is NARROWER than one glyph
+    // (21pt cell minus default margins ≈ 10pt < a 12pt glyph): every glyph is
+    // force-fitted alone. The following fullwidth space must ride the SAME
+    // line (hanging) — otherwise it force-fits onto its own line and doubles
+    // the pitch. Width 4 < glyph 5 at the stub metric.
+    const lines = lay([textSeg('申　請　事')], 4);
+    const texts = lineTexts(lines);
+    expect(texts.map((t) => [...t][0])).toEqual(['申', '請', '事']);
+    expect(texts.some((t) => [...t].every((c) => c === '　'))).toBe(false);
+  });
+
   it('keeps interior U+3000 width-bearing (two glyphs + space fit together)', () => {
     const lines = lay([textSeg('申　請')], 16); // 5+5+5=15 <= 16 — one line
     expect(lineTexts(lines)).toEqual(['申　請']);

--- a/packages/docx/src/ideographic-space-fit.test.ts
+++ b/packages/docx/src/ideographic-space-fit.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_KINSOKU_RULES } from '@silurus/ooxml-core';
+import { layoutLines, type LayoutLine, type LayoutSeg, type LayoutTextSeg } from './line-layout.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Trailing IDEOGRAPHIC SPACE (U+3000) line-end allowance. A vertical one-glyph
+// column authored as "char + U+3000" pairs (a common Japanese form-label idiom:
+// "申　請　事　項…" in a one-glyph-wide cell) must produce ONE VISIBLE GLYPH PER
+// LINE: Word lets the trailing fullwidth space hang past the line end (JLReq
+// line-end ideographic-space handling; UAX #14 treats the break opportunity
+// after it) instead of wrapping it, so the next line starts at the next visible
+// character. Charging the trailing U+3000's advance doubled the label pitch
+// (alternating glyph/space lines) in the split-form document class.
+// ECMA-376 §17.3.1.16 enables kinsoku but does not govern this; the allowance
+// is deliberately scoped to TRAILING U+3000 only — leading/interior fullwidth
+// spaces keep their width (authors indent with them), and ASCII space handling
+// is untouched.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeLinearCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const fontSize = (): number => Number.parseFloat(/([\d.]+)px/.exec(font)?.[1] ?? '10');
+  return {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    letterSpacing: '0px',
+    measureText: (text: string) => {
+      const size = fontSize();
+      return {
+        width: [...text].length * size * 0.5,
+        fontBoundingBoxAscent: size * 0.8,
+        fontBoundingBoxDescent: size * 0.2,
+        actualBoundingBoxAscent: size * 0.8,
+        actualBoundingBoxDescent: size * 0.2,
+      } as TextMetrics;
+    },
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function textSeg(text: string): LayoutTextSeg {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 10, color: null, fontFamily: 'T', vertAlign: null, measuredWidth: 0,
+  } as unknown as LayoutTextSeg;
+}
+
+function lay(segs: LayoutSeg[], width: number): LayoutLine[] {
+  return layoutLines(
+    makeLinearCtx(), segs, width, 0, 1, [], undefined, {}, 0,
+    DEFAULT_KINSOKU_RULES, 0, 36, width, false,
+  );
+}
+
+const lineTexts = (lines: LayoutLine[]): string[] =>
+  lines.map((l) => l.segments.filter((s): s is LayoutTextSeg => 'text' in s).map((s) => s.text).join(''));
+
+describe('trailing U+3000 line-end allowance', () => {
+  it('lays a char+U+3000 label out one visible glyph per line (the trailing space hangs)', () => {
+    // Glyph = 5pt at the stub metric; width 6pt fits ONE glyph but not glyph+space.
+    const lines = lay([textSeg('申　請　事　項　及　び　理　由')], 6);
+    const texts = lineTexts(lines);
+    // 8 lines, each starting with its visible glyph; the trailing space rides
+    // its glyph's line instead of wrapping onto its own.
+    expect(texts).toHaveLength(8);
+    expect(texts.map((t) => [...t][0])).toEqual(['申', '請', '事', '項', '及', 'び', '理', '由']);
+    // No line consists of the fullwidth space alone.
+    expect(texts.some((t) => [...t].every((c) => c === '　'))).toBe(false);
+  });
+
+  it('keeps interior U+3000 width-bearing (two glyphs + space fit together)', () => {
+    const lines = lay([textSeg('申　請')], 16); // 5+5+5=15 <= 16 — one line
+    expect(lineTexts(lines)).toEqual(['申　請']);
+  });
+
+  it('keeps leading U+3000 width-bearing (authored fullwidth indent)', () => {
+    const lines = lay([textSeg('　申')], 16); // 5+5 <= 16 — one line, space kept
+    expect(lineTexts(lines)).toEqual(['　申']);
+  });
+
+  it('does not change ASCII trailing-space behavior', () => {
+    const lines = lay([textSeg('ab '), textSeg('cd')], 12); // 'ab ' fit-width 10 (trailing collapse), cd next
+    const texts = lineTexts(lines);
+    expect(texts[0].startsWith('ab')).toBe(true);
+  });
+});

--- a/packages/docx/src/layout-fragments.ts
+++ b/packages/docx/src/layout-fragments.ts
@@ -64,6 +64,11 @@ export interface CellFragment {
   readonly source: DocTableCell;
   readonly blocks: readonly FlowFragment[];
   readonly verticalMerge: 'none' | 'restart' | 'continue';
+  /** Scale-1 point height of this cell's page-local row piece. This is the same
+   *  post-repair row height the paginator charged and {@link RowFragment.heightPt}
+   *  records; fragment-backed vAlign paint centres against it without deriving
+   *  geometry again from the unsplit source cell. */
+  readonly boxHeightPt?: number;
 }
 
 /**
@@ -186,6 +191,21 @@ export function paragraphFragmentAdvancePt(fragment: ParagraphFragment): number 
 export function tableFragmentHeightPt(fragment: TableFragment): number {
   let sum = 0;
   for (const row of fragment.rows) sum += row.heightPt;
+  return sum;
+}
+
+/** Piece-local content height (scale-1 pt) owned by a cell fragment. Paragraph
+ * blocks contribute only their recorded `[lineStart, lineEnd)` advancement plus
+ * fragment-owned spacing; nested tables contribute their already-resolved row
+ * heights. This is deliberately a pure fragment fold: paint must not call a cell
+ * or paragraph measurer to recover geometry the paginator already produced. */
+export function cellFragmentContentHeightPt(fragment: CellFragment): number {
+  let sum = 0;
+  for (const block of fragment.blocks) {
+    sum += block.kind === 'table'
+      ? tableFragmentHeightPt(block)
+      : paragraphFragmentAdvancePt(block);
+  }
   return sum;
 }
 

--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -520,17 +520,17 @@ describe('table fragment-paint legacy gate', () => {
     expect(__test_tableRequiresLegacyPaint(centeredNegative)).toBe(false);
   });
 
-  it('excludes a table containing a sliced cell paragraph', () => {
+  it('permits a table containing a sliced cell paragraph', () => {
     const sliced = {
       ...para('sliced'),
       lineSlice: { start: 0, end: 2 },
     } as unknown as CellElement;
     const table = tableOf([sliced]) as unknown as DocTable;
 
-    expect(__test_tableRequiresLegacyPaint(table)).toBe(true);
+    expect(__test_tableRequiresLegacyPaint(table)).toBe(false);
   });
 
-  it('excludes production row slices emitted from a tall cell paragraph', () => {
+  it('permits production row slices emitted from a tall cell paragraph', () => {
     const cellPara = para(Array.from({ length: 40 }, () => 'wrap').join(' '));
     const pages = paginateDocument(doc([tableOf([cellPara])], 60));
     const sliceTables = pages
@@ -551,7 +551,7 @@ describe('table fragment-paint legacy gate', () => {
     expect(sliceTables.length).toBeGreaterThan(1);
     expect(slicedTables.length).toBeGreaterThan(0);
     for (const table of slicedTables) {
-      expect(__test_tableRequiresLegacyPaint(table)).toBe(true);
+      expect(__test_tableRequiresLegacyPaint(table)).toBe(false);
     }
   });
 });

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1218,6 +1218,21 @@ export function hasCJKBreakOpportunity(text: string): boolean {
  * Binary-search the longest prefix of `text` whose rendered width fits in `maxWidth`.
  * Used for CJK overflow splitting.
  */
+/** Extend an accepted split point through IMMEDIATELY FOLLOWING IDEOGRAPHIC
+ *  SPACES (U+3000): the fullwidth space belongs to the line it ends, hanging
+ *  past the band (JLReq line-end ideographic-space handling — the same
+ *  allowance fitCJKPrefix's fit predicate applies), so a split must never
+ *  strand it at the head of the next line — including the FORCE-FIT paths
+ *  where the band is narrower than a single glyph (a one-glyph-wide form
+ *  label column). A zero split (whole-run move / kinsoku retraction) is left
+ *  untouched. */
+function extendThroughTrailingIdeographicSpaces(chars: string[], split: number): number {
+  if (split <= 0) return split;
+  let s = split;
+  while (s < chars.length && chars[s] === '\u3000') s++;
+  return s;
+}
+
 export function fitCJKPrefix(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   text: string,
@@ -3023,7 +3038,10 @@ export function layoutLines(
       const allChars = [...s.text];
       const rawSplit = [...rawPrefix].length;
       const minSplit = currentLine.length > 0 ? 0 : 1;
-      const split = kinsokuAdjustedSplit(allChars, rawSplit, kinsoku, minSplit);
+      const split = extendThroughTrailingIdeographicSpaces(
+        allChars,
+        kinsokuAdjustedSplit(allChars, rawSplit, kinsoku, minSplit),
+      );
       const prefix = allChars.slice(0, split).join('');
       if (prefix.length > 0) {
         // Grid advance for the head piece — the same model as the line box / draw.
@@ -3087,7 +3105,11 @@ export function layoutLines(
         if (retracted) queue.unshift(retracted);
       } else {
         // Empty line and not even one char fits — force-fit one char to guarantee progress
-        const firstChar = [...s.text][0] ?? '';
+        const forcedChars = [...s.text];
+        const forcedSplit = forcedChars.length > 0
+          ? extendThroughTrailingIdeographicSpaces(forcedChars, 1)
+          : 0;
+        const firstChar = forcedChars.slice(0, forcedSplit).join('');
         if (firstChar) {
           const fw = strAdvance(s, firstChar);
           const headSeg: LayoutTextSeg = { ...s, text: firstChar, measuredWidth: fw };
@@ -3120,6 +3142,7 @@ export function layoutLines(
       const allChars = [...s.text];
       let split = available > 0 ? [...fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), charScaleFactor(s), charSpacingDeltaPx(s, scale))].length : 0;
       if (split < 1) split = 1;
+      split = extendThroughTrailingIdeographicSpaces(allChars, split);
       if (split >= allChars.length) {
         // The visible glyphs actually fit (only a trailing space pushed it over the
         // fit test) — place the word whole.

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1234,10 +1234,23 @@ export function fitCJKPrefix(
   charSpacingPx = 0,
 ): string {
   const chars = [...text]; // spread handles surrogate pairs
-  let lo = 0, hi = chars.length;
-  while (lo < hi) {
-    const mid = (lo + hi + 1) >> 1;
-    const prefix = chars.slice(0, mid).join('');
+  // Trailing IDEOGRAPHIC SPACE (U+3000) line-end allowance: a candidate that
+  // overflows ONLY because it ends in fullwidth spaces still fits — the spaces
+  // hang past the line end (JLReq line-end ideographic-space handling; Word
+  // does the same, which is what keeps a "char + U+3000" form label at one
+  // visible glyph per line instead of alternating glyph/space lines). The
+  // accepted range KEEPS the trailing spaces, so the next line starts at the
+  // following visible character. Scope: trailing U+3000 in the candidate only —
+  // leading/interior fullwidth spaces stay width-bearing (authored indents),
+  // and ASCII-space handling is a separate, untouched mechanism. The predicate
+  // stays monotone in the candidate length (appending a U+3000 never changes
+  // the visible advance; appending a visible char only grows it), so the
+  // binary search remains valid.
+  const fitsWithHang = (endExclusive: number): boolean => {
+    let visibleEnd = endExclusive;
+    while (visibleEnd > 0 && chars[visibleEnd - 1] === '\u3000') visibleEnd--;
+    const prefix = chars.slice(0, visibleEnd).join('');
+    if (prefix.length === 0) return true;
     const advance = textAdvanceWidth(
       ctx.measureText(prefix).width,
       prefix,
@@ -1245,7 +1258,12 @@ export function fitCJKPrefix(
       charScale,
       charSpacingPx,
     );
-    if (advance <= maxWidth) lo = mid;
+    return advance <= maxWidth;
+  };
+  let lo = 0, hi = chars.length;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (fitsWithHang(mid)) lo = mid;
     else hi = mid - 1;
   }
   return chars.slice(0, lo).join('');

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -170,6 +170,7 @@ import {
   type ParagraphMeasurementEnvironment,
 } from './paragraph-measure.js';
 import {
+  cellFragmentContentHeightPt,
   paragraphFragmentAdvancePt,
   tableFragmentHeightPt,
   type DocumentLayout,
@@ -4095,31 +4096,20 @@ function attachTableFragment(
 }
 
 /** A table (or any table nested in its cells) stays on the LEGACY paint path when it
- *  needs re-measurement or an out-of-flow path the fragment paint does not yet cover:
+ *  needs placement geometry or an out-of-flow path the fragment paint does not cover:
  *   - a negative leading `tblInd` (§17.4.50) on a left-justified table widens the
  *     legacy layout budget from the column band to the page width;
- *   - a `vAlign` of center/bottom re-measures cell content to centre the inked block
- *     (ECMA-376 §17.4.84);
  *   - a nested floating table (§17.4.57 `<w:tblpPr>`) is drawn out of flow;
- *   - a sliced cell paragraph records `[lineStart, lineEnd)` in the fragment contract,
- *     but current cell paint draws the full partition (as legacy does). Until range
- *     painting lands, sliced tables stay on the byte-identical legacy path.
- *  Eligible top-aligned, in-flow, unsliced tables carry no re-measurement and paint
- *  measure-free from their fragment. Recursion covers nested tables (painted from their
- *  own fragment). Tracked: migrate negative-indent layout, vAlign, nested-floating
- *  tables, and sliced-range cell paint in follow-ups. */
+ *  Supported center/bottom cells and sliced cell paragraphs are fragment-paintable:
+ *  their piece-local box height and `[lineStart, lineEnd)` ranges are authoritative,
+ *  so paint neither remeasures nor expands them. Recursion keeps unsupported nested
+ *  placement classes on the legacy path. */
 function tableRequiresLegacyPaint(table: DocTable): boolean {
   if (table.tblInd != null && table.tblInd < 0 && table.jc === 'left') return true;
   for (const row of table.rows) {
     for (const cell of row.cells) {
-      if (cell.vAlign === 'center' || cell.vAlign === 'bottom') return true;
       for (const ce of cell.content) {
-        if (
-          ce.type === 'paragraph' &&
-          (ce as { lineSlice?: unknown }).lineSlice !== undefined
-        ) {
-          return true;
-        } else if (ce.type === 'table') {
+        if (ce.type === 'table') {
           const nested = ce as unknown as DocTable;
           if (nested.tblpPr != null || tableRequiresLegacyPaint(nested)) return true;
         }
@@ -4129,12 +4119,11 @@ function tableRequiresLegacyPaint(table: DocTable): boolean {
   return false;
 }
 
-/** PR 6 — a block table paints from its {@link TableFragment} when the migration gate
- *  holds: the fragment is present, the table is in flow (not a §17.4.57 floating
- *  table), it has no negative leading indent, vAlign-center/bottom re-measurement, or
- *  sliced cell paragraph, the story is horizontal, and this paint's content band
- *  matches the band the fragment was resolved at. Otherwise the legacy `renderTable`
- *  recompute path runs (byte-identical). */
+/** PR 6 — a block table paints from its {@link TableFragment} when the fragment is
+ *  present, the table is in flow, no unsupported nested placement class requires the
+ *  legacy path, the story is horizontal, and this paint's content band matches the
+ *  band the fragment was resolved at. Center/bottom alignment and sliced cell ranges
+ *  are owned by the fragment and therefore do not exclude the whole table. */
 function isFragmentPaintableTable(
   table: DocTable,
   placed: PlacedFragment | undefined,
@@ -6518,8 +6507,8 @@ function renderBodyElements(
       // paragraph BEFORE the table, exactly like a frame paragraph). A block
       // table resets them (it ends the previous spacing context).
       // PR 6 — a migrated block table paints from its stored fragment (geometry +
-      // cell content, no re-layout). Floating / vAlign / band-mismatch tables fall
-      // through to the legacy `renderTable` recompute path.
+      // cell content, no re-layout). Floating, unsupported nested-placement, and
+      // band-mismatch tables fall through to the legacy `renderTable` recompute path.
       const placedTable = bodyFragmentFor(el);
       if (isFragmentPaintableTable(tbl, placedTable, state)) {
         paintTableFragment(placedTable, state);
@@ -10451,8 +10440,8 @@ function computeTableLayout(
   // PR 6 — fragment-geometry reuse. A non-split block table is no longer stamped (the
   // stamp mutated the PARSED DocTable); its paginator-resolved geometry lives on the
   // attached TableFragment (side-table keyed, model untouched). When THIS paint is the
-  // legacy path for such a table (fragment-paint gate exclusions: vAlign centring,
-  // nested floating tables, band mismatch never reaches here since the band gate below
+  // legacy path for such a table (fragment-paint gate exclusions: unsupported nested
+  // placement classes; a band mismatch never reaches here since the band gate below
   // re-verifies), reuse the fragment's scale-1 column widths / row heights exactly as
   // the removed stamp reuse did — same source values, same `× scale`, byte-identical.
   const placedFragment = bodyFlowFragments.get(table as object);
@@ -10980,6 +10969,24 @@ function measureCellParagraphHeight(
   maxWidth: number,
   scale: number,
 ): number {
+  return measureCellParagraphWindow(state, para, maxWidth, scale).heightPx;
+}
+
+/** Slice-aware twin of {@link measureCellParagraphHeight}: measures only the
+ *  `[range.start, range.end)` line window (a mid-row split piece's slice) with
+ *  the SAME real-scale rescale machinery, and reports the paragraph's total
+ *  line count so the caller can tell whether the window covers the paragraph
+ *  end (trailing-spacing ownership). No range ⇒ the full paragraph — byte-
+ *  identical to the historical behavior. The rescale (not a geometric ×scale)
+ *  is the Finding-1 invariant: the vAlign centring height must equal what
+ *  paint actually draws at this scale. */
+function measureCellParagraphWindow(
+  state: RenderState,
+  para: DocParagraph,
+  maxWidth: number,
+  scale: number,
+  range?: { start: number; end: number },
+): { heightPx: number; totalLines: number } {
   {
     const paragraphContext = resolveStateParagraphLayoutContext(state, para);
     const grid = gridForParagraphContext(state, paragraphContext);
@@ -11027,21 +11034,42 @@ function measureCellParagraphHeight(
     // vAlign centring (renderCell) and the content-driven row-height fallback
     // (computeTableLayout → resolveTableRowHeights).
     const scale1ContentHeight = measured.contentEndYPt - measured.placement.startYPt;
-    if (scale === 1) return scale1ContentHeight;
+    const totalLines = measured.markOnly ? 0 : measured.lines.length;
+    const windowStart = range ? Math.max(0, range.start) : 0;
+    const windowEnd = range ? Math.min(totalLines, range.end) : totalLines;
+    if (scale === 1) {
+      if (!range || measured.markOnly || measured.lines.length === 0) {
+        return { heightPx: scale1ContentHeight, totalLines };
+      }
+      // Windowed scale-1 content height: the same per-line extents the
+      // paginator charges (advance + any non-negative gap to the previous
+      // line's bottom; cells carry no wrap oracle, so gaps are zero).
+      let sum = 0;
+      for (let i = windowStart; i < windowEnd; i++) {
+        const line = measured.lines[i];
+        if (i === windowStart) { sum += line.advancePt; continue; }
+        const previous = measured.lines[i - 1];
+        sum += Math.max(0, line.topYPt - (previous.topYPt + previous.advancePt)) + line.advancePt;
+      }
+      return { heightPx: sum, totalLines };
+    }
     const paraHasRuby = paragraphContext.hasRuby;
     const eastAsian = paragraphContext.hasEastAsianText;
     if (measured.markOnly || measured.lines.length === 0) {
       // Empty / anchor-only paragraph mark (§17.3.1.29): renderEmptyMarkParagraph
       // reserves the mark-line height at the PAINT scale, not scale-1 × scale.
-      return paragraphMarkLineHeight(
-        para,
-        scale,
-        grid,
-        paraHasRuby,
-        state.docEastAsian,
-        state.ctx,
-        state.fontFamilyClasses,
-      );
+      return {
+        heightPx: paragraphMarkLineHeight(
+          para,
+          scale,
+          grid,
+          paraHasRuby,
+          state.docEastAsian,
+          state.ctx,
+          state.fontFamilyClasses,
+        ),
+        totalLines,
+      };
     }
     // Rehydrate the scale-1 line PARTITION to the paint scale exactly as
     // renderParagraph does (re-measure every line's glyph geometry), then advance
@@ -11071,7 +11099,10 @@ function measureCellParagraphHeight(
         // §17.6.5 cell rounding is gated by the line's script; a Latin-only line
         // in a CJK paragraph keeps its natural height, matching the text-box path.
         : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, l.eastAsian ?? false, l.height * scale);
-    return paintedParagraphHeight(paintLines, 0, paintLines.length, 0, lineHForLine);
+    return {
+      heightPx: paintedParagraphHeight(paintLines, windowStart, windowEnd, 0, lineHForLine),
+      totalLines,
+    };
   }
 }
 
@@ -11123,8 +11154,19 @@ function measureCellElementHeight(
     // content clears a drawn bottom border. Mirror it here, or a bordered cell
     // paragraph paints taller than the cell measures (B2: single measurer).
     // renderCellContent never passes a borderMerge, so no suppression term.
-    return measureCellParagraphHeight(state, para, innerWPx, scale)
-      + (para.spaceBefore + Math.max(para.spaceAfter, bottomBorderExtentPt(para.borders))) * scale;
+    //
+    // Mid-row split pieces: a sliced cell paragraph (runtime `lineSlice` on the
+    // piece clone) measures ONLY its window — leading spacing belongs to the
+    // slice that starts the paragraph, trailing spacing to the slice that ends
+    // it (the split walk charges them the same way). An unsliced element is
+    // byte-identical to the historical measure.
+    const slice = (ce as CellElement & { lineSlice?: { start: number; end: number } }).lineSlice;
+    const { heightPx, totalLines } = measureCellParagraphWindow(state, para, innerWPx, scale, slice);
+    const leading = !slice || slice.start === 0 ? para.spaceBefore : 0;
+    const trailing = !slice || slice.end >= totalLines
+      ? Math.max(para.spaceAfter, bottomBorderExtentPt(para.borders))
+      : 0;
+    return heightPx + (leading + trailing) * scale;
   }
   // Nested table — estimateTableHeight works in pt; convert to px.
   const tbl = ce as unknown as DocTable;
@@ -11140,10 +11182,8 @@ function renderCell(
   h: number,
   state: RenderState,
   clipExact = false,
-  /** PR 6 — when present, this cell's content is painted from its stored
-   *  {@link CellFragment} blocks (measure-free) rather than re-laid-out. Only supplied
-   *  by the fragment paint path, which the migration gate limits to top-aligned tables,
-   *  so the vAlign centring branch below is not reached for a fragment cell. */
+  /** PR 6 — when present, this cell's content and piece-local box geometry are
+   *  painted from its stored {@link CellFragment} without re-layout. */
   cellFragment?: CellFragment,
 ): void {
   const { ctx, scale } = state;
@@ -11214,6 +11254,13 @@ function renderCell(
     // rendering of resume "bar chart" cells. Skip a single trailing empty
     // paragraph after a non-paragraph block.
     const visibleContent = trimTrailingStructuralMarker(cell.content);
+    // ONE vAlign content authority for split and unsplit cells alike: the
+    // slice-aware, real-scale measure (measureCellElementHeight honors a piece
+    // clone's `lineSlice`, so a mid-row piece centres its OWN window — the
+    // Finding-1 invariant keeps the rescale machinery, never a scale-1 sum
+    // × scale). The box is the DRAWN cell box `h` (for a vMerge restart piece
+    // that is the span box on this page, which is exactly what Word centres
+    // against — measured on the split-form ground truth).
     let contentH = visibleContent.reduce(
       (s, ce) => s + measureCellElementHeight(cellState, ce, w - ml - mr, scale), 0);
     // ECMA-376 §17.3.1.33 + §17.4.84 (vAlign): Word collapses the FIRST
@@ -11230,15 +11277,26 @@ function renderCell(
     // contextual / max-overlap rules inside the paint pass).
     const firstEl = visibleContent[0];
     const lastEl = visibleContent[visibleContent.length - 1];
+    const sliceOf = (el: CellElement | undefined) =>
+      (el as (CellElement & { lineSlice?: { start: number; end: number } }) | undefined)?.lineSlice;
     // Leading space-before (first paragraph only). Nested table first ⇒ 0.
+    // A continuation slice (start > 0) charged no space-before in the measure,
+    // so there is nothing to trim (and renderParagraph suppresses it too).
+    const firstSlice = sliceOf(firstEl);
     const firstSpaceBefore =
-      firstEl && firstEl.type === 'paragraph'
+      firstEl && firstEl.type === 'paragraph' && (!firstSlice || firstSlice.start === 0)
         ? (firstEl as unknown as DocParagraph).spaceBefore * scale
         : 0;
     contentH -= firstSpaceBefore;
-    // Trailing space-after (last paragraph only). Nested table last ⇒ 0.
+    // Trailing space-after (last paragraph only). Nested table last ⇒ 0. A
+    // NON-final slice charged no space-after in the measure — nothing to trim.
     if (lastEl && lastEl.type === 'paragraph') {
-      contentH -= (lastEl as unknown as DocParagraph).spaceAfter * scale;
+      const lastSlice = sliceOf(lastEl);
+      const lastIsFinal = !lastSlice
+        || lastSlice.end >= measureCellParagraphWindow(
+          cellState, lastEl as unknown as DocParagraph, w - ml - mr, scale, lastSlice,
+        ).totalLines;
+      if (lastIsFinal) contentH -= (lastEl as unknown as DocParagraph).spaceAfter * scale;
     }
     // `renderParagraph` will re-consume the first paragraph's spaceBefore (it
     // unconditionally adds `para.spaceBefore * scale` to `state.y`). Pull
@@ -11310,14 +11368,21 @@ function renderCellContent(content: CellElement[], state: RenderState): void {
   for (const ce of content) {
     if (ce.type === 'paragraph') {
       const para = ce as unknown as DocParagraph;
-      const suppress = contextualSuppressed(prevPara, para);
-      const effBefore = suppress ? 0 : para.spaceBefore;
+      const slice = (ce as CellElement & {
+        lineSlice?: { start: number; end: number; continues?: boolean };
+      }).lineSlice;
+      const continues = slice?.start != null && slice.start > 0;
+      const lineSlice = slice
+        ? { ...slice, ...(continues ? { continues: true as const } : {}) }
+        : undefined;
+      const suppress = !continues && contextualSuppressed(prevPara, para);
+      const effBefore = suppress || continues ? 0 : para.spaceBefore;
       // §17.3.1.9 contextualSpacing: between two same-style paragraphs that both
       // set it, BOTH the previous after and this before are dropped (gap = 0), not
       // just collapsed — so e.g. a code listing's lines sit tight.
       const overlap = suppress ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
       state.y -= overlap * state.scale;
-      renderParagraph(para, state, suppress);
+      renderParagraph(para, state, suppress || continues, lineSlice);
       prevPara = para;
       prevSpaceAfter = para.spaceAfter;
     } else if (ce.type === 'table') {
@@ -11371,12 +11436,11 @@ function isFragmentPaintableCellBlock(
  * their stored scale-1 line partition (rescaled through the same bridge body fragment
  * paint uses; measure-free at scale 1), nested-table blocks from their own
  * {@link TableFragment}, with the SAME §17.3.1.9 contextualSpacing / spaceBefore-after
- * overlap collapse. Cell paragraphs are drawn whole (no line slice), identically to
- * `renderCellContent`; sliced tables never reach this function because
- * {@link tableRequiresLegacyPaint} excludes them. A block the per-block gate excludes
- * ({@link isFragmentPaintableCellBlock}) is drawn by the legacy `renderParagraph` —
- * the exact call `renderCellContent` makes — so marker / field / wrap divergences
- * paint byte-identically to the unmigrated path.
+ * overlap collapse. Every paragraph consumes its actual `[lineStart, lineEnd)` range;
+ * continuation ranges also carry the first-slice suppression marker. A block the
+ * per-block gate excludes ({@link isFragmentPaintableCellBlock}) receives the same
+ * range through legacy `renderParagraph`, so marker / field / wrap divergences cannot
+ * expand back to the full paragraph.
  */
 function renderCellContentFragment(cellFragment: CellFragment, state: RenderState): void {
   let prevPara: DocParagraph | null = null;
@@ -11384,8 +11448,25 @@ function renderCellContentFragment(cellFragment: CellFragment, state: RenderStat
   for (const block of cellFragment.blocks) {
     if (block.kind === 'paragraph') {
       const para = block.source;
-      const suppress = contextualSuppressed(prevPara, para);
-      const effBefore = suppress ? 0 : para.spaceBefore;
+      // Mirror renderCellContent's slice semantics EXACTLY: a full-range block
+      // corresponds to an UNSLICED cell element, whose legacy paint passes NO
+      // lineSlice — in particular the gate-excluded fallback below re-lays the
+      // paragraph out (e.g. around an in-cell wrap float) into a partition with
+      // a DIFFERENT line count, and a spurious [0, measuredLen) window would
+      // truncate it. Only a genuine mid-row slice carries its window (plus the
+      // continuation marker for start > 0).
+      const continues = block.lineStart > 0;
+      const fullRange =
+        block.lineStart === 0 && block.lineEnd === block.measured.lines.length;
+      const lineSlice = fullRange
+        ? undefined
+        : {
+            start: block.lineStart,
+            end: block.lineEnd,
+            ...(continues ? { continues: true as const } : {}),
+          };
+      const suppress = !continues && contextualSuppressed(prevPara, para);
+      const effBefore = suppress || continues ? 0 : para.spaceBefore;
       const overlap = suppress ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
       state.y -= overlap * state.scale;
       if (isFragmentPaintableCellBlock(block, state)) {
@@ -11393,12 +11474,12 @@ function renderCellContentFragment(cellFragment: CellFragment, state: RenderStat
           para,
           state,
           block.measured.lines.map((line) => line.layout),
-          suppress,
-          undefined,
+          suppress || continues,
+          lineSlice,
           undefined,
         );
       } else {
-        renderParagraph(para, state, suppress);
+        renderParagraph(para, state, suppress || continues, lineSlice);
       }
       prevPara = para;
       prevSpaceAfter = para.spaceAfter;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -10727,14 +10727,30 @@ function drawTableRows(
       let x1 = x;
       let x2 = x + w;
       if (j.edges.bottomRow) {
-        // Stage D — a row piece created by a MID-ROW page cut has no bottom
-        // boundary: the row visually continues on the next page (or in the next
-        // stacked piece), so the cut edge draws nothing. Word's ground truth for
-        // the split-form class shows the page-1 piece open at the cut while the
-        // continuation draws its own top edge. Row-boundary cuts are unaffected
-        // (their rows carry no marker).
+        // Mid-row page cut (fidelity round, measured ground truth): the cut is
+        // a SHARED horizontal edge between this piece's cell bottom and the
+        // continuation piece's cell top on the next page — resolve it with the
+        // ordinary §17.4.66 conflict against a SYNTHETIC continuation sibling
+        // built from the SAME source-row cell specs, whose top resolves as the
+        // next slice-table's OUTER top (cell.top ?? table.top). This explains
+        // both measured classes: none ∨ single → single (the form label column
+        // with no bottom border still shows the full-width cut rule), and a
+        // borderless table draws nothing. The sibling exists only here — it is
+        // never inserted into pagination, fragments, or occupancy — and the
+        // continuation piece still draws its own outer top on its page.
+        // Row-boundary cuts carry no marker and keep the plain outer bottom.
         const cutRow = table.rows[j.lastRi] as DocTableRow & { pageCutBottom?: boolean };
-        spec = cutRow?.pageCutBottom === true ? null : paintable(own.bottom?.spec ?? null);
+        if (cutRow?.pageCutBottom === true) {
+          const siblingTop = resolveCellEdges(
+            j.cell.borders,
+            table.borders,
+            { ...j.edges, topRow: true },
+            mirror,
+          ).top;
+          spec = resolveSharedEdge(own.bottom, siblingTop);
+        } else {
+          spec = paintable(own.bottom?.spec ?? null);
+        }
       } else {
         const below = neighbourJob(jobs, occupancy, j.lastRi + 1, j.ci);
         const belowEdges = below ? resolveCellEdges(below.cell.borders, table.borders, below.edges, mirror) : null;

--- a/packages/docx/src/table-fragments.test.ts
+++ b/packages/docx/src/table-fragments.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { layoutDocument } from './document-layout.js';
 import { bodyFragmentFor, computePages } from './renderer.js';
 import { buildTableFragment } from './table-fragments.js';
+import * as layoutFragments from './layout-fragments.js';
 import {
+  paragraphFragmentAdvancePt,
   tableFragmentHeightPt,
   flowFragmentAdvancePt,
   type TableFragment,
@@ -205,8 +207,57 @@ describe('buildTableFragment — pure recursion contract', () => {
       buildCellBlocks: () => [],
     });
     expect(frag.rows.map((r) => r.heightPt)).toEqual([15, 25]);
+    expect(frag.rows.map((r) => r.cells[0].boxHeightPt)).toEqual([15, 25]);
     expect(tableFragmentHeightPt(frag)).toBe(40);
     expect(flowFragmentAdvancePt(frag)).toBe(40);
+  });
+
+  it('sums only fragment-owned ranged paragraph advances and nested-table heights', () => {
+    const rangedParagraph = {
+      kind: 'paragraph',
+      source: para('ignored'),
+      measured: {
+        markOnly: false,
+        lines: [
+          { topYPt: 0, advancePt: 10 },
+          { topYPt: 12, advancePt: 10 },
+          { topYPt: 25, advancePt: 10 },
+        ],
+      },
+      lineStart: 1,
+      lineEnd: 3,
+      leadingSpacePt: 2,
+      trailingSpacePt: 4,
+    } as unknown as ParagraphFragment;
+    const nestedTable = {
+      kind: 'table',
+      source: table([], []),
+      columnWidthsPt: [],
+      rows: [
+        { heightPt: 7 },
+        { heightPt: 8 },
+      ],
+      continuesFromPreviousPage: false,
+      continuesOnNextPage: false,
+    } as unknown as TableFragment;
+    const fragment = {
+      source: textCell('ignored'),
+      blocks: [rangedParagraph, nestedTable],
+      verticalMerge: 'none',
+      boxHeightPt: 50,
+    } as CellFragment;
+    const contentHeight = (
+      layoutFragments as unknown as {
+        cellFragmentContentHeightPt?: (cellFragment: CellFragment) => number;
+      }
+    ).cellFragmentContentHeightPt;
+
+    expect(contentHeight).toBeTypeOf('function');
+    if (!contentHeight) return;
+    expect(contentHeight(fragment)).toBe(
+      paragraphFragmentAdvancePt(rangedParagraph) + tableFragmentHeightPt(nestedTable),
+    );
+    expect(contentHeight(fragment)).toBe(44);
   });
 
   it('sums the spanned column widths for a gridSpan cell', () => {

--- a/packages/docx/src/table-fragments.ts
+++ b/packages/docx/src/table-fragments.ts
@@ -118,6 +118,7 @@ export function buildTableFragment(input: BuildTableFragmentInput): TableFragmen
         source: sourceCell,
         blocks,
         verticalMerge: role,
+        boxHeightPt: rowHeightsPt[ri] ?? 0,
       }) as CellFragment;
     });
     return Object.freeze({

--- a/packages/docx/src/table-row-split-fidelity.test.ts
+++ b/packages/docx/src/table-row-split-fidelity.test.ts
@@ -1,0 +1,262 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  __test_setFragmentPaintEnabled,
+  paginateDocument,
+  renderDocumentToCanvas,
+} from './renderer.js';
+import type {
+  BodyElement,
+  CellElement,
+  DocParagraph,
+  DocTable,
+  DocTableRow,
+  DocxDocumentModel,
+  PaginatedBodyElement,
+  SectionProps,
+} from './types';
+
+interface TextCall {
+  readonly text: string;
+  readonly x: number;
+  readonly y: number;
+  readonly font: string;
+}
+
+interface StrokeSegment {
+  readonly x1: number;
+  readonly y1: number;
+  readonly x2: number;
+  readonly y2: number;
+}
+
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  texts: TextCall[];
+  strokes: StrokeSegment[];
+  measureCount: () => number;
+} {
+  let font = '10px serif';
+  let measures = 0;
+  let current = { x: 0, y: 0 };
+  let pending: StrokeSegment | null = null;
+  let lineWidth = 1;
+  let strokeStyle = '#000000';
+  let fillStyle = '#000000';
+  const texts: TextCall[] = [];
+  const strokes: StrokeSegment[] = [];
+  const fontPx = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    get lineWidth() { return lineWidth; },
+    set lineWidth(value: number) { lineWidth = value; },
+    get strokeStyle() { return strokeStyle; },
+    set strokeStyle(value: string) { strokeStyle = value; },
+    get fillStyle() { return fillStyle; },
+    set fillStyle(value: string) { fillStyle = value; },
+    letterSpacing: '0px',
+    textAlign: 'left' as CanvasTextAlign,
+    direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1,
+    lineCap: 'butt' as CanvasLineCap,
+    lineJoin: 'miter' as CanvasLineJoin,
+    measureText(text: string) {
+      measures++;
+      const px = fontPx();
+      return {
+        width: [...text].length * px * 0.5,
+        fontBoundingBoxAscent: px * 0.8,
+        fontBoundingBoxDescent: px * 0.2,
+        actualBoundingBoxAscent: px * 0.8,
+        actualBoundingBoxDescent: px * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, closePath() {}, fill() {}, fillRect() {}, strokeRect() {},
+    clip() {}, rect() {}, scale() {}, translate() {}, rotate() {}, setLineDash() {},
+    clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {}, drawImage() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    beginPath() { pending = null; },
+    moveTo(x: number, y: number) { current = { x, y }; },
+    lineTo(x: number, y: number) {
+      pending = { x1: current.x, y1: current.y, x2: x, y2: y };
+      current = { x, y };
+    },
+    stroke() {
+      if (pending) strokes.push(pending);
+    },
+    fillText(text: string, x: number, y: number) { texts.push({ text, x, y, font }); },
+    strokeText(text: string, x: number, y: number) { texts.push({ text, x, y, font }); },
+  };
+  const canvas = {
+    width: 0,
+    height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return {
+    canvas: canvas as unknown as HTMLCanvasElement,
+    texts,
+    strokes,
+    measureCount: () => measures,
+  };
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+    getContext() { return makeRecordingCanvas().canvas.getContext('2d'); }
+  };
+});
+
+function border() {
+  return { style: 'single', width: 1, color: null } as const;
+}
+
+function borders() {
+  return {
+    top: border(), bottom: border(), left: border(), right: border(),
+    insideH: border(), insideV: border(),
+  };
+}
+
+function paragraph(text: string): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 20, color: null, fontFamily: 'T',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null,
+      hyperlink: null,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 20, defaultFontFamily: 'T', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function row(
+  text: string,
+  vAlign: 'top' | 'center' | 'bottom',
+  rowHeight: number | null = null,
+  rowHeightRule: 'auto' | 'exact' = 'auto',
+): DocTableRow {
+  return {
+    cells: [{
+      content: [{ type: 'paragraph', ...paragraph(text) } as unknown as CellElement],
+      colSpan: 1, vMerge: null, borders: borders(), background: null, vAlign, widthPt: null,
+    }],
+    rowHeight,
+    rowHeightRule,
+    isHeader: false,
+  } as unknown as DocTableRow;
+}
+
+function documentWithRow(tableRow: DocTableRow, pageHeight: number): DocxDocumentModel {
+  const table: DocTable = {
+    colWidths: [160], rows: [tableRow], borders: borders(),
+    cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
+    jc: 'left', layout: 'fixed',
+  } as unknown as DocTable;
+  return {
+    section: {
+      pageWidth: 160, pageHeight,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [{ type: 'table', ...table } as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { T: 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function renderPage(
+  model: DocxDocumentModel,
+  pages: PaginatedBodyElement[][],
+  pageIndex: number,
+  fragmentPaint: boolean,
+) {
+  const previous = __test_setFragmentPaintEnabled(fragmentPaint);
+  const recording = makeRecordingCanvas();
+  try {
+    await renderDocumentToCanvas(model, recording.canvas, pageIndex, {
+      dpr: 1,
+      width: 160,
+      prebuiltPages: pages,
+    });
+    return recording;
+  } finally {
+    __test_setFragmentPaintEnabled(previous);
+  }
+}
+
+function firstSliceOnPage(pages: PaginatedBodyElement[][], pageIndex: number) {
+  const table = pages[pageIndex].find((element) => element.type === 'table') as
+    (PaginatedBodyElement & DocTable) | undefined;
+  const paragraph = table?.rows[0]?.cells[0]?.content[0] as
+    (CellElement & { lineSlice?: { start: number; end: number } }) | undefined;
+  return paragraph?.lineSlice;
+}
+
+const splitText =
+  '甲'.repeat(16) +
+  '乙'.repeat(16) +
+  '丙'.repeat(16) +
+  '丁'.repeat(16);
+
+describe('table row split fidelity — fragment-owned paint geometry', () => {
+  it.each([
+    ['fragment paint', true],
+    ['legacy fallback', false],
+  ])('paints only the continuation [k, n) line window with %s', async (_label, fragmentPaint) => {
+    const model = documentWithRow(row(splitText, 'top'), 60);
+    const pages = paginateDocument(model);
+    expect(pages).toHaveLength(2);
+    expect(firstSliceOnPage(pages, 0)).toEqual({ start: 0, end: 3 });
+    expect(firstSliceOnPage(pages, 1)).toEqual({ start: 3, end: 4 });
+
+    const page2 = await renderPage(model, pages, 1, fragmentPaint);
+    const paintedText = page2.texts.map((call) => call.text).join('');
+    expect(paintedText).toBe('丁'.repeat(16));
+    expect(paintedText).not.toContain('甲');
+    expect(paintedText).not.toContain('乙');
+    expect(paintedText).not.toContain('丙');
+  });
+
+  it('keeps every centered continuation baseline at or below its row-top rule', async () => {
+    const model = documentWithRow(row(splitText, 'center'), 60);
+    const pages = paginateDocument(model);
+    expect(pages).toHaveLength(2);
+    expect(firstSliceOnPage(pages, 1)).toEqual({ start: 3, end: 4 });
+
+    const page2 = await renderPage(model, pages, 1, true);
+    const topRule = page2.strokes.find(
+      (stroke) => Math.abs(stroke.y1 - stroke.y2) < 0.5 && Math.abs(stroke.x2 - stroke.x1) > 100,
+    );
+    expect(topRule).toBeDefined();
+    expect(page2.texts.length).toBeGreaterThan(0);
+    const minimumBaseline = Math.min(...page2.texts.map((call) => call.y));
+    expect(minimumBaseline).toBeGreaterThanOrEqual(topRule?.y1 ?? 0);
+  });
+
+  it('keeps an unsplit centered cell byte-identical between fragment and legacy paint', async () => {
+    // Design amendment (Finding-1 invariant, cell-height-scale-metrics.test.ts):
+    // vAlign centring must use the slice-aware REAL-SCALE measure — the height
+    // paint actually draws — not a scale-1 fragment sum × scale. Fragment paint
+    // therefore measures exactly like the legacy path for vAlign cells (equal
+    // measure counts); the fragment's contribution here is the slice-aware
+    // window + the piece geometry, pinned by the split cases above.
+    const model = documentWithRow(row('CENTER', 'center', 60, 'exact'), 80);
+    const pages = paginateDocument(model);
+    expect(pages).toHaveLength(1);
+
+    const fragment = await renderPage(model, pages, 0, true);
+    const legacy = await renderPage(model, pages, 0, false);
+    expect(fragment.texts).toEqual(legacy.texts);
+    expect(fragment.texts.map(({ text, x, y }) => ({ text, x, y }))).toEqual([
+      { text: 'CENTER', x: 0, y: 36 },
+    ]);
+    expect(fragment.measureCount()).toBe(legacy.measureCount());
+  });
+});

--- a/packages/docx/src/table-split-borders.test.ts
+++ b/packages/docx/src/table-split-borders.test.ts
@@ -13,13 +13,16 @@ import type {
 } from './types';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Split-edge border semantics for a MID-ROW page cut (stage D of the row-split
-// series). When a row is split at a cell line boundary across a page break, the
-// page-1 piece's bottom edge is a PAGE CUT, not a row boundary: Word leaves it
-// OPEN (no bottom rule — the row visually continues), while the continuation
-// piece on the next page draws its top edge as usual. A ROW-BOUNDARY page cut
-// (whole rows per page) keeps its existing border behavior — only the mid-row
-// cut suppresses the bottom edge.
+// Split-edge border semantics for a MID-ROW page cut (fidelity round, agreed
+// design). Measured Word ground truth across two document classes: a bordered
+// form table DRAWS a full-width rule at the page-1 cut (even over a column
+// whose cell has NO bottom border but a single top border), while a completely
+// borderless table draws NOTHING at its cut. The unifying rule is ECMA-376
+// §17.4.66: the cut is a shared horizontal edge between the leading piece's
+// cell bottoms and a SYNTHETIC continuation sibling's cell tops (same source
+// row specs, resolved as the next page's outer top) — none∨single → single,
+// none∨none → nothing. The continuation piece still draws its own outer top on
+// the next page. Row-boundary page cuts are untouched.
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface StrokeSeg { x1: number; y1: number; x2: number; y2: number; width: number; color: string }
@@ -140,8 +143,8 @@ async function renderPage(model: DocxDocumentModel, pages: PaginatedBodyElement[
 const horizontals = (strokes: StrokeSeg[]) =>
   strokes.filter((s) => Math.abs(s.y1 - s.y2) < 0.5 && Math.abs(s.x2 - s.x1) > 10);
 
-describe('mid-row page-cut border semantics (stage D)', () => {
-  it('leaves the page-1 piece bottom OPEN and draws the continuation top', async () => {
+describe('mid-row page-cut border semantics (§17.4.66 conflict at the cut)', () => {
+  it('draws the §17.4.66 winner at the page-1 cut and the continuation top on page 2', async () => {
     // 4-line cell (80pt) into a 60pt page body: p.1 piece = 3 lines, cut at y=60.
     const model = splitDoc([wrappingRow()], 60);
     const pages = paginateDocument(model);
@@ -157,12 +160,39 @@ describe('mid-row page-cut border semantics (stage D)', () => {
     const p1H = horizontals(p1);
     // Top frame at y=0 present…
     expect(p1H.some((s) => Math.abs(s.y1 - 0) <= 1)).toBe(true);
-    // …but NO horizontal rule at the page cut (y=60): the row continues.
-    expect(p1H.filter((s) => Math.abs(s.y1 - 60) <= 1)).toHaveLength(0);
+    // …and the cut draws the conflict winner (single ∨ single) at y=60, full width.
+    const cut = p1H.filter((s) => Math.abs(s.y1 - 60) <= 1);
+    expect(cut.length).toBe(1);
+    expect(Math.min(cut[0].x1, cut[0].x2)).toBeLessThanOrEqual(1);
+    expect(Math.max(cut[0].x1, cut[0].x2)).toBeGreaterThanOrEqual(159);
 
-    // The continuation piece draws its top edge on page 2 (y=0).
+    // The continuation piece draws its own outer top on page 2 (y=0).
     const p2H = horizontals(p2);
     expect(p2H.some((s) => Math.abs(s.y1 - 0) <= 1)).toBe(true);
+  });
+
+  it('draws the cut rule over a NO-BOTTOM-border cell when its top border wins the conflict', async () => {
+    // The decisive ground-truth datum: the form label cell has top/left/right
+    // single but NO bottom — the cut still shows a full-width rule because the
+    // synthetic continuation sibling's TOP (single) wins none ∨ single.
+    const row = wrappingRow();
+    (row.cells[0].borders as { bottom: BorderSpec | null }).bottom = null;
+    const model = splitDoc([row], 60);
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(1);
+    const p1H = horizontals(await renderPage(model, pages, 0));
+    expect(p1H.filter((s) => Math.abs(s.y1 - 60) <= 1)).toHaveLength(1);
+  });
+
+  it('draws NOTHING at the cut of a borderless table', async () => {
+    const row = wrappingRow();
+    (row.cells[0] as { borders: unknown }).borders = { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null };
+    const model = splitDoc([row], 60);
+    (model.body[0] as unknown as DocTable).borders = { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null } as DocTable['borders'];
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(1);
+    const p1H = horizontals(await renderPage(model, pages, 0));
+    expect(p1H.filter((s) => Math.abs(s.y1 - 60) <= 1)).toHaveLength(0);
   });
 
   it('keeps the row-boundary page cut borders unchanged', async () => {


### PR DESCRIPTION
## Row-split fidelity: line partitions, sliced-piece paint, and page-cut borders

Fidelity round for the mid-page row-split series, driven by user-reported residuals on a
multi-page government-form document class and a design session against measured Word PDF
ground truth (150dpi raster + text bbox). Four commits, landing in the agreed order.

### 1. Trailing ideographic spaces hang past the line end (2 commits)

A one-glyph-wide label column authored as "char + U+3000" pairs laid out at DOUBLE its
`w:line="400" w:lineRule="exact"` pitch: the CJK fit charged the fullwidth space's
advance, wrapped it to the next line, and every glyph consumed two lines. Word hangs the
line-end ideographic space (JLReq line-end handling; ECMA-376 §17.3.1.16 enables kinsoku
but does not govern this). The fit predicate now applies the allowance, and — the second
commit — all three CJK/overflow split-point selections carry immediately following
U+3000s onto the ending line, covering the force-fit paths where the band is narrower
than a single glyph (the real label geometry). Scope: trailing U+3000 only; leading and
interior fullwidth spaces stay width-bearing; ASCII handling untouched.
Ground truth met: all eight label glyphs on page 1 at the exact 20pt pitch.

### 2. Cell fragments are the paint authority for sliced pieces

Two defects shared a root — paint ignored a mid-row piece's line window:
- the continuation page re-painted the full paragraph (its label restarted from the
  first glyph instead of continuing with the remainder); both paint paths now forward
  the real `[lineStart, lineEnd)` window (a full-range block deliberately passes no
  slice so the gate-excluded fallback can re-wrap, e.g. around an in-cell float);
- vAlign=center/bottom pieces centred against a FULL-paragraph measure, pushing content
  above the piece's top rule. The vAlign measure is now slice-aware via a windowed twin
  of the cell paragraph measure, keeping the REAL-SCALE rescale machinery (a design
  amendment: the session's scale-1 fragment-sum × scale would have reintroduced the
  geometric-scaling anti-pattern the existing Finding-1 tests pin against at zoom); the
  centring box is the drawn cell box (the re-opened span box for a vMerge restart
  piece, matching the measured ground truth).
The sliced-cell and vAlign fragment-gate exclusions are lifted accordingly.
Ground truth met: the continuation page paints only the remainder, centred in the
re-opened span.

### 3. Page-cut borders are §17.4.66 conflicts (ground-truth correction)

Re-measured PDFs corrected the earlier "open cut" rule: the bordered form class DRAWS a
full-width rule at the page-1 cut — including over a column whose cell has NO bottom
border but a single top — while a fully borderless table draws nothing. The unifying
rule: the cut is a shared edge between the leading piece's cell bottoms and a SYNTHETIC
continuation sibling's cell tops (same source-row specs, resolved as the next page's
outer top), fed through the ordinary §17.4.66 conflict machinery. "Piece bottom alone"
fails the no-bottom-border column; insideH (§17.4.39) fails because the document defines
none yet the rule is drawn. The sibling exists only inside the border pass; the
continuation page keeps its own outer top rule.

### Verification

- Full workspace `pnpm test`: 379 files / 3682 passed. Root typecheck, lint, lint:test,
  `cargo fmt --check`, `git diff --check` all clean.
- Local pixel VRT (89 checks): exactly three checks moved vs the base merge commit —
  all IMPROVEMENTS toward the references (−120 / −860 / −1,924 diff px), on precisely
  the affected classes (a CJK document line and the two pages carrying the pre-existing
  mid-row split); base attribution verified per check. Everything else byte-identical.
  References untouched.
- Acceptance probes on the target document: label pitch/distribution and the
  continuation remainder match the Word PDF structurally; the cut rule paints
  full-width at the page-1 bottom. Remaining absolute-offset residuals (~20-30pt
  accumulated upstream, page-count drift) are outside this round's scope and recorded
  in the local ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
