### PR TITLE
fix(chart): vary bar colors by point for single-series bar charts

### DIFF
--- a/packages/core/src/chart/legend-color.test.ts
+++ b/packages/core/src/chart/legend-color.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import type { ChartSeries } from '../types/chart';
-import { legendEntryColor, CHART_PALETTE } from './renderer.js';
+import type { ChartSeries, ChartModel } from '../types/chart';
+import { legendEntryColor, chartVariesColorsByPoint, CHART_PALETTE } from './renderer.js';
 
 function series(partial: Partial<ChartSeries>): ChartSeries {
   return { name: '', color: null, values: [], ...partial };
@@ -61,5 +61,65 @@ describe('legendEntryColor', () => {
       expect(legendEntryColor('doughnut', s, 1)).toBe(pal(1));
       expect(legendEntryColor('doughnut', s, 2)).toBe('#CC0000');
     });
+  });
+
+  describe('§21.2.2.227 varyColors single-series bar — one legend entry per point', () => {
+    // The `varyByPoint` flag makes a bar legend resolve per DATA POINT of the
+    // first series (like a pie) instead of per series (issue #931). The parser
+    // sets the accents into `dataPointColors`; here we assert the resolution.
+    const s: ChartSeries[] = [
+      series({ name: 'Region', color: '4472C4', values: [10, 20, 30, 40] }),
+    ];
+
+    it('falls back to the per-point palette when varyByPoint is set', () => {
+      expect(legendEntryColor('clusteredBar', s, 0, true)).toBe(pal(0));
+      expect(legendEntryColor('clusteredBar', s, 1, true)).toBe(pal(1));
+      expect(legendEntryColor('clusteredBar', s, 2, true)).toBe(pal(2));
+      // Distinct colors, not all the single series color.
+      expect(legendEntryColor('clusteredBar', s, 0, true)).not.toBe(
+        legendEntryColor('clusteredBar', s, 1, true),
+      );
+    });
+
+    it('honors accent/dPt colors resolved into dataPointColors', () => {
+      const withAccents: ChartSeries[] = [
+        series({
+          name: 'Region',
+          color: '4472C4',
+          values: [10, 20, 30, 40],
+          dataPointColors: ['4472C4', 'ED7D31', 'A5A5A5', 'FFC000'],
+        }),
+      ];
+      expect(legendEntryColor('clusteredBar', withAccents, 0, true)).toBe('#4472C4');
+      expect(legendEntryColor('clusteredBar', withAccents, 2, true)).toBe('#A5A5A5');
+    });
+
+    it('without varyByPoint, a bar legend stays per-series', () => {
+      expect(legendEntryColor('clusteredBar', s, 0)).toBe(pal(0));
+      expect(legendEntryColor('clusteredBar', s, 1)).toBe(pal(1));
+    });
+  });
+});
+
+describe('chartVariesColorsByPoint', () => {
+  const model = (partial: Partial<ChartModel>): ChartModel =>
+    ({ chartType: 'clusteredBar', series: [], varyColors: false, ...partial }) as ChartModel;
+  const oneSeries = [{ name: 'A', color: null, values: [1, 2, 3] }] as ChartSeries[];
+  const twoSeries = [
+    { name: 'A', color: null, values: [1, 2] },
+    { name: 'B', color: null, values: [3, 4] },
+  ] as ChartSeries[];
+
+  it('is true for a single-series bar/column with varyColors set', () => {
+    expect(chartVariesColorsByPoint(model({ chartType: 'clusteredBar', series: oneSeries, varyColors: true }))).toBe(true);
+    expect(chartVariesColorsByPoint(model({ chartType: 'clusteredBarH', series: oneSeries, varyColors: true }))).toBe(true);
+    expect(chartVariesColorsByPoint(model({ chartType: 'stackedBar', series: oneSeries, varyColors: true }))).toBe(true);
+  });
+
+  it('is false without the flag, for multi-series, or for non-bar types', () => {
+    expect(chartVariesColorsByPoint(model({ series: oneSeries, varyColors: false }))).toBe(false);
+    expect(chartVariesColorsByPoint(model({ series: twoSeries, varyColors: true }))).toBe(false);
+    expect(chartVariesColorsByPoint(model({ chartType: 'line', series: oneSeries, varyColors: true }))).toBe(false);
+    expect(chartVariesColorsByPoint(model({ chartType: 'pie', series: oneSeries, varyColors: true }))).toBe(false);
   });
 });

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -105,6 +105,26 @@ function legendIsCategoryDriven(chartType: string | undefined): boolean {
   return chartType === 'pie' || chartType === 'doughnut';
 }
 
+/** §21.2.2.227 `<c:varyColors val="1"/>` on a SINGLE-series bar/column chart:
+ *  Office colors each bar from the theme/palette sequence (like a pie's slices)
+ *  and lists one legend entry per data point. Restricted to the bar family with
+ *  exactly one series — the only case Office varies this way, and the only case
+ *  the shared parser sets `varyColors` for. Pie/doughnut are already
+ *  category-driven via {@link legendIsCategoryDriven}; this covers the bar case
+ *  so the plot fill and the legend agree on the same per-point resolution. */
+export function chartVariesColorsByPoint(chart: {
+  chartType?: string | null;
+  series: unknown[];
+  varyColors?: boolean | null;
+}): boolean {
+  return (
+    !!chart.varyColors &&
+    chart.series.length === 1 &&
+    typeof chart.chartType === 'string' &&
+    /Bar/.test(chart.chartType)
+  );
+}
+
 /** Resolve the color for legend entry `entryIndex`, matching the marks the
  *  plot actually draws.
  *
@@ -121,8 +141,9 @@ export function legendEntryColor(
   chartType: string | undefined,
   series: ChartSeries[],
   entryIndex: number,
+  varyByPoint = false,
 ): string {
-  if (legendIsCategoryDriven(chartType)) {
+  if (varyByPoint || legendIsCategoryDriven(chartType)) {
     const first = series[0];
     if (first) return pieSliceColor(entryIndex, first);
     return `#${CHART_PALETTE[entryIndex % CHART_PALETTE.length]}`;
@@ -326,15 +347,19 @@ function buildLegendEntries(
   series: ChartSeries[],
   chartType: string | undefined,
   scatterStyle?: string | null,
+  varyByPoint = false,
 ): LegendEntry[] {
-  if (legendIsCategoryDriven(chartType)) {
+  if (varyByPoint || legendIsCategoryDriven(chartType)) {
+    // Category-driven: one entry per data point of the first series, labeled by
+    // its category and colored exactly like the mark the plot draws for that
+    // point (pie slice, or a varyColors bar). §21.2.2.227.
     const first = series[0];
     const n = first ? first.values.length : 0;
     const cats = first?.categories ?? [];
     return Array.from({ length: n }, (_, i) => ({
       label: (cats[i] ?? `Item ${i + 1}`).toString(),
-      color: legendEntryColor(chartType, series, i),
-      marker: null, // pie/doughnut keys are always filled swatches.
+      color: legendEntryColor(chartType, series, i, varyByPoint),
+      marker: null, // pie/doughnut/varyColors keys are always filled swatches.
     }));
   }
   return series.map((s, i) => ({
@@ -370,10 +395,11 @@ function drawLegend(
   chartType?: string,
   style: LegendTextStyle = DEFAULT_LEGEND_STYLE,
   scatterStyle?: string | null,
+  varyByPoint = false,
 ): void {
   const sw = 10; const gap = 4;
   const swatchStyle = legendSwatchStyle(chartType);
-  const entries = buildLegendEntries(series, chartType, scatterStyle);
+  const entries = buildLegendEntries(series, chartType, scatterStyle, varyByPoint);
   const boldPrefix = style.bold ? 'bold ' : '';
   if (orient === 'horizontal') {
     // Excel lays a bottom/top legend as a single horizontal row, centered.
@@ -448,6 +474,9 @@ function drawLegendForLayout(
 ): void {
   if (!leg) return;
   const legStyle = legendTextStyle(chart);
+  // §21.2.2.227 varyColors single-series bar: the legend lists one entry per
+  // data point (colored like each bar), so the legend and the plot fill agree.
+  const varyByPoint = chartVariesColorsByPoint(chart);
   // `<c:legend><c:manualLayout>` (§21.2.2.31) wins over the default side-based
   // rectangle. We honor the `edge` placement mode — fractions are measured
   // from the top-left of the chart space — which matches what Excel's built-in
@@ -463,21 +492,21 @@ function drawLegendForLayout(
     // when on left/right. A manual box wider than tall implies horizontal —
     // matches Excel's one-row legend rendering for top/bottom manual layouts.
     const orient = lw >= lh ? 'horizontal' : 'vertical';
-    drawLegend(ctx, chart.series, lx, ly, lw, lh, orient, chart.chartType, legStyle, chart.scatterStyle);
+    drawLegend(ctx, chart.series, lx, ly, lw, lh, orient, chart.chartType, legStyle, chart.scatterStyle, varyByPoint);
     return;
   }
   switch (leg.side) {
     case 'r':
-      drawLegend(ctx, chart.series, x + w - leg.reserveW + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle, chart.scatterStyle);
+      drawLegend(ctx, chart.series, x + w - leg.reserveW + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle, chart.scatterStyle, varyByPoint);
       break;
     case 'l':
-      drawLegend(ctx, chart.series, x + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle, chart.scatterStyle);
+      drawLegend(ctx, chart.series, x + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle, chart.scatterStyle, varyByPoint);
       break;
     case 't':
-      drawLegend(ctx, chart.series, px0, y + topBand, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle, chart.scatterStyle);
+      drawLegend(ctx, chart.series, px0, y + topBand, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle, chart.scatterStyle, varyByPoint);
       break;
     case 'b':
-      drawLegend(ctx, chart.series, px0, y + h - leg.reserveH, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle, chart.scatterStyle);
+      drawLegend(ctx, chart.series, px0, y + h - leg.reserveH, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle, chart.scatterStyle, varyByPoint);
       break;
   }
 }
@@ -1066,6 +1095,14 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const n = cats.length;
   if (n === 0) return;
 
+  // §21.2.2.227 varyColors on a single-series bar: color each bar per DATA
+  // POINT (its category index) from the palette/theme sequence instead of the
+  // one series color — `pieSliceColor` honors an explicit `dPt` fill first,
+  // then the accent/palette for that point. Only ever true for a single bar
+  // series (see {@link chartVariesColorsByPoint}), so combo/multi-series bars
+  // are byte-identical.
+  const varyByPoint = chartVariesColorsByPoint(chart);
+
   // Honor the XML-specified title font size when present; otherwise fall back
   // to the proportional heuristic. Reserve the title band based on the actual
   // drawn height so the plot shrinks to avoid overlap.
@@ -1481,7 +1518,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       // a percentStacked chart reaches below the zero line).
       const sv = pct ? (raw / stackSum) * 100 : raw;
       const negative = sv < 0;
-      const color = chartColor(si, s);
+      const color = varyByPoint ? pieSliceColor(ci, s) : chartColor(si, s);
 
       if (!isH) {
         const bx = stacked

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -309,6 +309,14 @@ export interface ChartModel {
   title: string | null;
   categories: string[];
   series: ChartSeries[];
+  /**
+   * §21.2.2.227 `<c:varyColors val="1"/>` on a SINGLE-series bar/column chart:
+   * color each data point (bar) from the theme/palette sequence and list one
+   * legend entry per point, matching Office. Set by the shared parser ONLY for
+   * that non-pie, single-series case (pie/doughnut already vary by point via
+   * `chartType` + `dataPointColors`); absent/false otherwise.
+   */
+  varyColors?: boolean | null;
   /** Show data labels on bars / points / slices. */
   showDataLabels: boolean;
   /** Explicit Y-axis minimum (OOXML `<c:valAx><c:min>`). */

--- a/packages/node/src/verify-chart-regressions.probe.test.ts
+++ b/packages/node/src/verify-chart-regressions.probe.test.ts
@@ -21,8 +21,11 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '../../..');
 const SAMPLE_14 = resolve(ROOT, 'packages/pptx/public/private/sample-14.pptx');
 const SAMPLE_30 = resolve(ROOT, 'packages/xlsx/public/private/sample-30.xlsx');
+const SAMPLE_17 = resolve(ROOT, 'packages/pptx/public/private/sample-17.pptx');
+const SAMPLE_18 = resolve(ROOT, 'packages/pptx/public/private/sample-18.pptx');
 
-const pptxMod = skia && existsSync(SAMPLE_14)
+const varySamples = [SAMPLE_17, SAMPLE_18].filter((p) => existsSync(p));
+const pptxMod = skia && (existsSync(SAMPLE_14) || varySamples.length > 0)
   ? await importForTests(() => import('./pptx.ts'), './pptx.ts (pptx WASM)')
   : null;
 const xlsxMod = skia && existsSync(SAMPLE_30)
@@ -124,7 +127,7 @@ function renderCapture(
   return { texts, seriesStrokes, legendKeys };
 }
 
-describe.skipIf(!pptxMod || !coreMod)('sample-14 slide-7 pie: white percent-only labels', () => {
+describe.skipIf(!pptxMod || !coreMod || !existsSync(SAMPLE_14))('sample-14 slide-7 pie: white percent-only labels', () => {
   it('renders bare percentages in white (no black category names)', () => {
     const { parsePptx } = pptxMod as Any;
     const { renderChart } = coreMod as Any;
@@ -198,3 +201,78 @@ describe.skipIf(!xlsxMod || !coreMod)('sample-30 sheet-1 scatter: markers only (
     expect(sawMarker, 'a scatter draws a marker legend key').toBe(true);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #931 — §21.2.2.227 varyColors on a single-series bar/column chart. sample-17
+// and sample-18 slide 4 each carry a lone column series with NO <c:varyColors>
+// element; Office varies each bar by the theme/palette sequence and lists one
+// legend entry per data point (four vs. our former one). This probe renders the
+// REAL decks and asserts four distinct bar fills plus a per-point legend.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Render a chart and collect every fillRect color and fillText string. */
+function captureBars(
+  chart: ChartModel,
+  renderChart: (ctx: unknown, c: ChartModel, r: unknown, p?: number) => void,
+): { rectFills: string[]; texts: string[] } {
+  const canvas = new Canvas(700, 460);
+  const raw = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+  const rectFills: string[] = [];
+  const texts: string[] = [];
+  const proxy = new Proxy(raw, {
+    get(t, p: string) {
+      if (p === 'fillRect') {
+        return (x: number, y: number, w: number, h: number) => {
+          rectFills.push(String((raw as Any).fillStyle).toLowerCase());
+          return (raw.fillRect as Any)(x, y, w, h);
+        };
+      }
+      if (p === 'fillText') {
+        return (s: string, x: number, y: number) => { texts.push(s); return (raw.fillText as Any)(s, x, y); };
+      }
+      const v = (t as Any)[p];
+      return typeof v === 'function' ? v.bind(t) : v;
+    },
+    set(t, p: string, v) { (t as Any)[p] = v; return true; },
+  }) as unknown as CanvasRenderingContext2D;
+  renderChart(proxy, chart, { x: 0, y: 0, w: 700, h: 460 }, 1.05);
+  return { rectFills, texts };
+}
+
+describe.skipIf(!pptxMod || !coreMod || varySamples.length === 0)(
+  '#931 single-series bar varyColors (sample-17/18 slide 4)',
+  () => {
+    it('renders four distinct bar colors and a per-point legend', () => {
+      const { parsePptx } = pptxMod as Any;
+      const { renderChart } = coreMod as Any;
+      for (const path of varySamples) {
+        const pres = parsePptx(readFileSync(path));
+        const slide4 = pres.slides[3];
+        const charts: ChartModel[] = [];
+        collectCharts(slide4, charts);
+        const bar = charts.find(
+          (c) => typeof c.chartType === 'string' && /Bar/.test(c.chartType) && c.series.length === 1,
+        );
+        expect(bar, `${path}: slide 4 has a single-series bar`).toBeTruthy();
+        const chart = bar as ChartModel;
+        // The parser flags default vary-by-point (element absent) as varyColors.
+        expect(chart.varyColors, 'single-series bar varies by default').toBe(true);
+
+        const { rectFills, texts } = captureBars(chart, renderChart);
+        const distinct = [...new Set(rectFills)];
+        // Four categories → four distinct bar fills (was one before the fix).
+        expect(
+          distinct.length,
+          `${path}: at least ${chart.categories.length} distinct bar colors`,
+        ).toBeGreaterThanOrEqual(chart.categories.length);
+        // Each category label now appears twice — once on the axis, once in the
+        // per-point legend (the pre-fix legend held only the series name).
+        for (const cat of chart.categories) {
+          if (!cat) continue;
+          const occurrences = texts.filter((s) => s === cat).length;
+          expect(occurrences, `${path}: "${cat}" drawn as axis label + legend entry`).toBeGreaterThanOrEqual(2);
+        }
+      }
+    });
+  },
+);

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -323,6 +323,14 @@ pub struct ChartModel {
     /// the renderer then falls back to its own `CHART_PALETTE`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chartex_accents: Option<Vec<String>>,
+    /// §21.2.2.227 `<c:varyColors val="1"/>` on a SINGLE-series bar/column
+    /// chart: color each data point (bar) from the theme/palette sequence and
+    /// list one legend entry per point (like a pie). `Some(true)` only for that
+    /// non-pie, single-series case the core renderer consumes; the pie family
+    /// already varies by point via `chart_type` + `data_point_colors`, so it
+    /// stays `None` here (byte-stable wire for every existing chart).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vary_colors: Option<bool>,
 }
 
 /// Mirror of TS `ChartSeries`.
@@ -2141,6 +2149,10 @@ pub fn parse_chartex_part(
         title: chartex_title,
         categories,
         series,
+        // chartEx layouts color by branch/series index, not §21.2.2.227
+        // varyColors (a `<c:>` chart-group element that chartEx has no analog
+        // of), so the flag never applies here.
+        vary_colors: None,
         val_max: None,
         val_min: None,
         subtotal_indices,
@@ -3505,6 +3517,12 @@ pub fn parse_chart_part(
         .map(|s| s.to_string())
     };
 
+    // Total series in the plot. §21.2.2.227 varyColors on a NON-pie chart
+    // varies each data point by color only for a single-series plot (Office
+    // keeps per-series colors when several series share the axes); captured
+    // here so the per-series closure can gate the accent fill on it.
+    let series_count = ser_nodes.len();
+
     let series: Vec<ChartSeries> = ser_nodes
         .iter()
         .map(|ser| {
@@ -3721,20 +3739,29 @@ pub fn parse_chart_part(
             // renderer consumes `data_point_colors`, and a multi-series pie (rare)
             // still varies by point within series[0].
             let is_pie_family = chart_type == "pie" || chart_type == "doughnut";
+            let is_bar_family = chart_type.contains("Bar");
+            // §21.2.2.227 `<c:varyColors>` — CT_Boolean (bare element ⇒ true).
+            // "Vary colors by point" is the effective default for the pie family
+            // AND for a SINGLE-series bar/column chart (Word/Excel/PowerPoint
+            // draw a lone series' bars in the rotating theme palette and keep an
+            // explicit `<c:varyColors val="0"/>` when the user forces one color
+            // — verified against the sample-17/18 decks, whose single-series
+            // columns render four accent-colored bars with the element ABSENT).
+            // A multi-series plot keeps per-series colors, so it never varies by
+            // point even with `val="1"`. When ON, each data point takes the
+            // accent for its POINT index (i); `dPt` fills already sit in
+            // `data_point_colors` and are never overwritten (explicit per-point
+            // color keeps priority, §21.2.2.52).
+            let qualifies_for_vary = is_pie_family || (is_bar_family && series_count == 1);
+            let vary = group
+                .and_then(|g| bool_child(g, "varyColors"))
+                .unwrap_or(true);
+            let vary_by_point = qualifies_for_vary && vary;
             let mut data_point_colors = data_point_colors;
-            if is_pie_family {
-                // §21.2.2.203 `<c:varyColors>` — CT_Boolean (bare element ⇒ true).
-                // For the pie family the effective default is also "vary" when
-                // the element is ABSENT, so both the bare-present and absent cases
-                // resolve to true here.
-                let vary = group
-                    .and_then(|g| bool_child(g, "varyColors"))
-                    .unwrap_or(true);
-                if vary {
-                    for (i, slot) in data_point_colors.iter_mut().enumerate() {
-                        if slot.is_none() {
-                            *slot = color_resolver.resolve_series_accent(i);
-                        }
+            if vary_by_point {
+                for (i, slot) in data_point_colors.iter_mut().enumerate() {
+                    if slot.is_none() {
+                        *slot = color_resolver.resolve_series_accent(i);
                     }
                 }
             }
@@ -4286,11 +4313,38 @@ pub fn parse_chart_part(
         .and_then(|t| child(t, "layout"))
         .and_then(extract_manual_layout);
 
+    // §21.2.2.227 varyColors chart-level flag. Emitted (`Some(true)`) for a
+    // SINGLE-series bar/column chart that varies by point — the case where the
+    // core renderer must color each bar per point and list one legend entry per
+    // point. "Vary by point" is the default for a lone bar series, so an ABSENT
+    // `<c:varyColors>` resolves to `true` here; an explicit `val="0"` (the way
+    // Office records "force one color") leaves it `None`. The pie family already
+    // varies by point via `chart_type` + `data_point_colors`, so it stays `None`
+    // to keep the wire byte-identical for every existing pie/doughnut chart.
+    let vary_colors = {
+        let is_pie_family = chart_type == "pie" || chart_type == "doughnut";
+        let is_bar_family = chart_type.contains("Bar");
+        if !is_pie_family && is_bar_family && series_count == 1 {
+            let vary = ser_nodes[0]
+                .parent()
+                .and_then(|g| bool_child(g, "varyColors"))
+                .unwrap_or(true);
+            if vary {
+                Some(true)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    };
+
     Some(ChartModel {
         chart_type,
         title,
         categories,
         series,
+        vary_colors,
         val_max,
         val_min,
         subtotal_indices: vec![],
@@ -4500,6 +4554,7 @@ mod tests {
                 trend_lines: None,
                 line_hidden: None,
             }],
+            vary_colors: None,
             show_data_labels: false,
             val_min: None,
             val_max: None,
@@ -7209,18 +7264,99 @@ mod tests {
         assert_eq!(colors2[2], None);
     }
 
-    /// A NON-pie chart (bar) never gets varyColors slice accents even when the
-    /// resolver supplies them — only the pie renderer consumes
-    /// `data_point_colors`, so a bar's slice palette must stay empty (`None`).
+    /// A SINGLE-series bar chart with `<c:varyColors>` ABSENT varies by point by
+    /// default (issue #931): each data point takes the accent for its index and
+    /// the chart-level flag is set. This is the sample-17/18 shape — a lone
+    /// column series whose four bars render in the rotating theme palette even
+    /// though the file carries no `<c:varyColors>` element.
     #[test]
-    fn parse_chart_part_bar_no_vary_colors_slice_fill() {
+    fn parse_chart_part_bar_single_series_varies_by_default() {
         let group = format!(
             r#"<c:barChart><c:barDir val="col"/><c:grouping val="clustered"/>{CH13_SER}</c:barChart>"#
         );
         let xml = chart_space_with_group(&group);
         let d = chart_space_of(&xml);
         let m = parse_chart_part(d.root_element(), &AccentResolver).expect("bar parses");
+        assert_eq!(m.vary_colors, Some(true));
+        let colors = m.series[0]
+            .data_point_colors
+            .as_ref()
+            .expect("default vary populates per-point palette");
+        assert_eq!(colors[0].as_deref(), Some("4472C4")); // accent1
+        assert_eq!(colors[1].as_deref(), Some("ED7D31")); // accent2
+    }
+
+    /// A SINGLE-series bar chart with an explicit `<c:varyColors val="0"/>`
+    /// keeps its one per-series color (Office records the forced-single-color
+    /// choice this way — sample-1.xlsx / sample-14 chart8/9). No per-point fill,
+    /// no chart-level flag.
+    #[test]
+    fn parse_chart_part_bar_single_series_vary_off_keeps_series_color() {
+        let group = format!(
+            r#"<c:barChart><c:barDir val="col"/><c:grouping val="clustered"/><c:varyColors val="0"/>{CH13_SER}</c:barChart>"#
+        );
+        let xml = chart_space_with_group(&group);
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &AccentResolver).expect("bar parses");
+        assert_eq!(m.vary_colors, None);
         assert!(m.series[0].data_point_colors.is_none());
+    }
+
+    /// §21.2.2.227 varyColors on a SINGLE-series bar/column chart: each data
+    /// point (bar) without an explicit `<c:dPt>` fill takes the theme accent for
+    /// its point index, and the chart-level `vary_colors` flag is set so the
+    /// core renderer colors each bar per point and lists one legend entry per
+    /// point (issue #931). The point that carries a `<c:dPt>` fill keeps it.
+    #[test]
+    fn parse_chart_part_bar_vary_colors_single_series_fills_accents() {
+        let ser = r#"<c:ser><c:idx val="0"/>
+            <c:dPt><c:idx val="0"/><c:spPr><a:solidFill><a:srgbClr val="112233"/></a:solidFill></c:spPr></c:dPt>
+            <c:cat><c:strCache>
+              <c:pt idx="0"><c:v>A</c:v></c:pt><c:pt idx="1"><c:v>B</c:v></c:pt>
+              <c:pt idx="2"><c:v>C</c:v></c:pt><c:pt idx="3"><c:v>D</c:v></c:pt>
+            </c:strCache></c:cat>
+            <c:val><c:numCache>
+              <c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt>
+              <c:pt idx="2"><c:v>3</c:v></c:pt><c:pt idx="3"><c:v>4</c:v></c:pt>
+            </c:numCache></c:val></c:ser>"#;
+        let group = format!(
+            r#"<c:barChart><c:barDir val="col"/><c:grouping val="clustered"/><c:varyColors val="1"/>{ser}</c:barChart>"#
+        );
+        let xml = chart_space_with_group(&group);
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &AccentResolver).expect("bar parses");
+        assert_eq!(m.vary_colors, Some(true));
+        let colors = m.series[0]
+            .data_point_colors
+            .as_ref()
+            .expect("varyColors populates per-point palette");
+        assert_eq!(colors[0].as_deref(), Some("112233")); // explicit dPt wins
+        assert_eq!(colors[1].as_deref(), Some("ED7D31")); // accent2
+        assert_eq!(colors[2].as_deref(), Some("A5A5A5")); // accent3
+        assert_eq!(colors[3].as_deref(), Some("FFC000")); // accent4
+    }
+
+    /// §21.2.2.227 varyColors on a MULTI-series bar chart is a no-op for the
+    /// per-point fill: Office keeps per-series colors when several series share
+    /// the axes, so neither the per-point palette nor the chart-level flag is
+    /// emitted. Only the single-series case (issue #931) varies by point.
+    #[test]
+    fn parse_chart_part_bar_vary_colors_multi_series_keeps_series_colors() {
+        let ser0 = r#"<c:ser><c:idx val="0"/>
+            <c:cat><c:strCache><c:pt idx="0"><c:v>A</c:v></c:pt><c:pt idx="1"><c:v>B</c:v></c:pt></c:strCache></c:cat>
+            <c:val><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt></c:numCache></c:val></c:ser>"#;
+        let ser1 = r#"<c:ser><c:idx val="1"/>
+            <c:cat><c:strCache><c:pt idx="0"><c:v>A</c:v></c:pt><c:pt idx="1"><c:v>B</c:v></c:pt></c:strCache></c:cat>
+            <c:val><c:numCache><c:pt idx="0"><c:v>3</c:v></c:pt><c:pt idx="1"><c:v>4</c:v></c:pt></c:numCache></c:val></c:ser>"#;
+        let group = format!(
+            r#"<c:barChart><c:barDir val="col"/><c:grouping val="clustered"/><c:varyColors val="1"/>{ser0}{ser1}</c:barChart>"#
+        );
+        let xml = chart_space_with_group(&group);
+        let d = chart_space_of(&xml);
+        let m = parse_chart_part(d.root_element(), &AccentResolver).expect("bar parses");
+        assert_eq!(m.vary_colors, None);
+        assert!(m.series[0].data_point_colors.is_none());
+        assert!(m.series[1].data_point_colors.is_none());
     }
 
     /// A named single series in `<c:tx>` — reused by the auto-title tests. `idx`


### PR DESCRIPTION
## Summary

A single-series bar/column chart rendered every bar in one series color and listed a single legend entry, while Office colors each data point from the theme/palette sequence and lists one legend entry per point (4 categories → 4 distinct bars + 4 legend entries). Chart parsing is shared across formats (CH5 unification), so this is fixed in the shared parser + core renderer and applies to PPTX/DOCX/XLSX hosts.

Closes #931.

## Root cause

The reference decks' single-series columns carry **no `<c:varyColors>` element at all**, yet Office renders four accent-colored bars. Per ECMA-376 §21.2.2.227, "vary colors by point" is the effective default for a lone bar/column series; Office records the *force-one-color* choice by writing an explicit `<c:varyColors val="0"/>`. The parser previously only varied the pie family, so single-series bars stayed mono.

## Changes

- **`packages/ooxml-common` (shared CH5 parser)**
  - Resolve `varyColors` for a single-series bar/column: an **absent** element defaults **ON**, an explicit **`val="0"`** forces one color.
  - Emit a chart-level `varyColors` flag and fill per-point accents into `dataPointColors` for that case. Explicit `<c:dPt>` fills keep priority (§21.2.2.52).
  - The pie family is unchanged (it already varies by point via `chartType` + `dataPointColors`), so the wire stays byte-identical for every existing chart.
- **`packages/core` renderer**
  - `chartVariesColorsByPoint(chart)` gates the new behavior (bar family + single series + flag).
  - Each bar is colored per data point via `pieSliceColor`, and the legend is driven per data point. Multi-series and non-varying charts render byte-identically.

## Verification

- Rust: `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` (219 pass) incl. new parse tests for the absent-default-on, explicit-`val="0"`-off, explicit-`val="1"`, and multi-series (no vary) cases.
- TS: root `pnpm typecheck`; core chart (276), pptx (386), xlsx (524), docx (1167), node (67) suites all pass.
- End-to-end node probe on the two reference decks' single-series columns: four distinct bar fills + a four-entry legend, matching the Office PDFs' direction.
- Non-regression: every existing mono single-series bar in the fixtures (VRT demo + protected samples) carries an explicit `<c:varyColors val="0"/>`, so it is untouched.

## Notes

- PPTX charts use the built-in `CHART_PALETTE` (not exact theme accents) for all chart colors by pre-existing design, so bar hues differ slightly from the PDF's accent1–4; that is orthogonal to this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)