### PR TITLE
fix(docx): resolve table border conflicts per span-edge sub-segment

### DIFF
--- a/packages/docx/src/cell-border-conflict-render.test.ts
+++ b/packages/docx/src/cell-border-conflict-render.test.ts
@@ -285,4 +285,46 @@ describe('§17.4.66 — adjacent cell border conflict, end-to-end render', () =>
     expect(horizontalAt(strokes, 0)).toHaveLength(1);
     expect(horizontalAt(strokes, 20)).toHaveLength(1);
   });
+  it('§17.4.66 (#815): a colSpan cell resolves EACH below sub-segment against its own neighbour', async () => {
+    // A title cell spanning both columns faces TWO below cells with DIFFERENT
+    // top borders. The shared horizontal edge must be split at the column
+    // boundary: left half → the left neighbour's border, right half → the right
+    // neighbour's border. Before the fix only the span-origin (left) neighbour
+    // was consulted and the right half's border was dropped.
+    const title = cell('title');
+    title.colSpan = 2;
+    const strokes = await render(tableOf([
+      rowOf([title]),
+      rowOf([
+        cell('l', { top: bs({ style: 'single', width: 1, color: '111111' }) }),
+        cell('r', { top: bs({ style: 'thick', width: 4, color: '222222' }) }),
+      ]),
+    ]));
+    const seg = horizontalAt(strokes, 20);
+    const left = seg.filter((s) => Math.min(s.x1, s.x2) < 30);
+    const right = seg.filter((s) => Math.max(s.x1, s.x2) > 90);
+    expect(left.some((s) => s.color.toLowerCase().includes('111111'))).toBe(true);
+    expect(right.some((s) => s.color.toLowerCase().includes('222222'))).toBe(true);
+  });
+
+  it('§17.4.66 (#815): a vMerge cell resolves EACH right sub-segment against its own neighbour', async () => {
+    // A tall cell (vMerge restart) spanning both rows faces TWO right neighbours
+    // with DIFFERENT left borders. Its shared vertical edge must be split at the
+    // row boundary: top half → the upper neighbour's border, bottom half → the
+    // lower neighbour's border. Before the fix only the span-origin (upper)
+    // neighbour was consulted and the bottom half's border was dropped.
+    const tall = cell('tall');
+    tall.vMerge = true;
+    const cont = cell('');
+    cont.vMerge = false;
+    const strokes = await render(tableOf([
+      rowOf([tall, cell('u', { left: bs({ style: 'single', width: 1, color: '111111' }) })]),
+      rowOf([cont, cell('d', { left: bs({ style: 'thick', width: 4, color: '222222' }) })]),
+    ]));
+    const seg = verticalAt(strokes, 60);
+    const top = seg.filter((s) => Math.min(s.y1, s.y2) < 10);
+    const bot = seg.filter((s) => Math.max(s.y1, s.y2) > 30);
+    expect(top.some((s) => s.color.toLowerCase().includes('111111'))).toBe(true);
+    expect(bot.some((s) => s.color.toLowerCase().includes('222222'))).toBe(true);
+  });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -10699,6 +10699,19 @@ function drawTableRows(
   // neighbour that owns that gridline consults this cell's spec as the opponent.
   const ctx = state.ctx;
   const dpr = state.dpr;
+  // ECMA-376 §17.4.66 (#815) — physical positions of the grid-line boundaries so a
+  // shared interior edge can be SUBDIVIDED at neighbour-cell boundaries: a merged
+  // cell (gridSpan/vMerge) faces several finer neighbours along one edge, and each
+  // sub-segment must be resolved against its OWN opposing cell. colOff/rowOff are
+  // LTR cumulative sizes; colBoundaryX folds the bidiVisual flip (§17.4.1), while
+  // row positions are never mirrored.
+  const colOff: number[] = [0];
+  for (const cw of colWidths) colOff.push(colOff[colOff.length - 1] + cw);
+  const rowOff: number[] = [0];
+  for (const rh of rowHeights) rowOff.push(rowOff[rowOff.length - 1] + rh);
+  const colBoundaryX = (c: number): number =>
+    mirror ? tableX + tableW - colOff[c] : tableX + colOff[c];
+  const rowBoundaryY = (r: number): number => startY + rowOff[r];
   for (const j of jobs) {
     const { x, y, w, h } = j;
     const own = resolveCellEdges(j.cell.borders, table.borders, j.edges, mirror);
@@ -10724,61 +10737,77 @@ function drawTableRows(
       const spec = paintable(own.left?.spec ?? null);
       if (spec) drawBorderLine(ctx, x, y, x, y + h, spec, scale, dpr);
     }
-    // BOTTOM: outer bottom → own spec; interior → resolve vs the below neighbour's
+    // BOTTOM: outer bottom → own spec; interior → resolve vs each below neighbour's
     // top and draw the winner (this ABOVE cell owns the shared horizontal line).
-    {
+    if (j.edges.bottomRow) {
+      // Mid-row page cut (fidelity round, measured ground truth): the cut is
+      // a SHARED horizontal edge between this piece's cell bottom and the
+      // continuation piece's cell top on the next page — resolve it with the
+      // ordinary §17.4.66 conflict against a SYNTHETIC continuation sibling
+      // built from the SAME source-row cell specs, whose top resolves as the
+      // next slice-table's OUTER top (cell.top ?? table.top). This explains
+      // both measured classes: none ∨ single → single (the form label column
+      // with no bottom border still shows the full-width cut rule), and a
+      // borderless table draws nothing. The sibling exists only here — it is
+      // never inserted into pagination, fragments, or occupancy — and the
+      // continuation piece still draws its own outer top on its page.
+      // Row-boundary cuts carry no marker and keep the plain outer bottom.
       let spec: BorderSpec | null;
-      let x1 = x;
-      let x2 = x + w;
-      if (j.edges.bottomRow) {
-        // Mid-row page cut (fidelity round, measured ground truth): the cut is
-        // a SHARED horizontal edge between this piece's cell bottom and the
-        // continuation piece's cell top on the next page — resolve it with the
-        // ordinary §17.4.66 conflict against a SYNTHETIC continuation sibling
-        // built from the SAME source-row cell specs, whose top resolves as the
-        // next slice-table's OUTER top (cell.top ?? table.top). This explains
-        // both measured classes: none ∨ single → single (the form label column
-        // with no bottom border still shows the full-width cut rule), and a
-        // borderless table draws nothing. The sibling exists only here — it is
-        // never inserted into pagination, fragments, or occupancy — and the
-        // continuation piece still draws its own outer top on its page.
-        // Row-boundary cuts carry no marker and keep the plain outer bottom.
-        const cutRow = table.rows[j.lastRi] as DocTableRow & { pageCutBottom?: boolean };
-        if (cutRow?.pageCutBottom === true) {
-          const siblingTop = resolveCellEdges(
-            j.cell.borders,
-            table.borders,
-            { ...j.edges, topRow: true },
-            mirror,
-          ).top;
-          spec = resolveSharedEdge(own.bottom, siblingTop);
-        } else {
-          spec = paintable(own.bottom?.spec ?? null);
-        }
+      const cutRow = table.rows[j.lastRi] as DocTableRow & { pageCutBottom?: boolean };
+      if (cutRow?.pageCutBottom === true) {
+        const siblingTop = resolveCellEdges(
+          j.cell.borders,
+          table.borders,
+          { ...j.edges, topRow: true },
+          mirror,
+        ).top;
+        spec = resolveSharedEdge(own.bottom, siblingTop);
       } else {
-        const below = neighbourJob(jobs, occupancy, j.lastRi + 1, j.ci);
-        const belowEdges = below ? resolveCellEdges(below.cell.borders, table.borders, below.edges, mirror) : null;
-        const winner = resolveBorderConflict(own.bottom, belowEdges?.top ?? null);
-        spec = winner ? paintable(winner.spec) : null;
-        if (winner && below && winner === belowEdges?.top) {
-          x1 = below.x;
-          x2 = below.x + below.w;
-        }
+        spec = paintable(own.bottom?.spec ?? null);
       }
-      if (spec) drawBorderLine(ctx, x1, y + h, x2, y + h, spec, scale, dpr);
+      if (spec) drawBorderLine(ctx, x, y + h, x + w, y + h, spec, scale, dpr);
+    } else {
+      // ECMA-376 §17.4.66 (#815) — the shared horizontal edge below this cell may
+      // face SEVERAL finer below-cells (this cell is wider via gridSpan). Subdivide
+      // the edge at the below-cells' column boundaries and resolve EACH sub-segment
+      // against its OWN below neighbour, drawing a per-segment winner rather than
+      // resolving the whole edge against the span-origin neighbour alone.
+      const belowRi = j.lastRi + 1;
+      let cj = j.ci;
+      while (cj < j.ci + j.span) {
+        const idx = occupancy[belowRi][cj];
+        let cEnd = cj + 1;
+        while (cEnd < j.ci + j.span && occupancy[belowRi][cEnd] === idx) cEnd++;
+        const below = neighbourJob(jobs, occupancy, belowRi, cj);
+        const belowEdges = below
+          ? resolveCellEdges(below.cell.borders, table.borders, below.edges, mirror)
+          : null;
+        const spec = resolveSharedEdge(own.bottom, belowEdges?.top ?? null);
+        if (spec) drawBorderLine(ctx, colBoundaryX(cj), y + h, colBoundaryX(cEnd), y + h, spec, scale, dpr);
+        cj = cEnd;
+      }
     }
     // PHYSICAL RIGHT: outer-right → own spec; interior → resolve vs the physically-
-    // right neighbour's left and draw the winner (this cell owns the shared
-    // vertical line as its physical right edge — so each line is drawn once).
-    {
-      let spec: BorderSpec | null;
-      if (physRightOuter) {
-        spec = paintable(own.right?.spec ?? null);
-      } else {
-        const right = neighbourEdges(jobs, occupancy, j.ri, physRightCi, mirror, table.borders);
-        spec = resolveSharedEdge(own.right, right?.left ?? null);
-      }
+    // right neighbour's left and draw the winner (this cell owns the shared vertical
+    // line as its physical right edge — so each line is drawn once).
+    if (physRightOuter) {
+      const spec = paintable(own.right?.spec ?? null);
       if (spec) drawBorderLine(ctx, x + w, y, x + w, y + h, spec, scale, dpr);
+    } else {
+      // ECMA-376 §17.4.66 (#815) — a vMerge cell's physical-right edge may face
+      // SEVERAL finer right-neighbours down the rows it spans. Subdivide the edge at
+      // those neighbours' row boundaries and resolve EACH sub-segment against its OWN
+      // neighbour's facing (left) edge, drawing a per-segment winner.
+      let rj = j.ri;
+      while (rj <= j.lastRi) {
+        const idx = occupancy[rj][physRightCi];
+        let rEnd = rj;
+        while (rEnd + 1 <= j.lastRi && occupancy[rEnd + 1][physRightCi] === idx) rEnd++;
+        const right = neighbourEdges(jobs, occupancy, rj, physRightCi, mirror, table.borders);
+        const spec = resolveSharedEdge(own.right, right?.left ?? null);
+        if (spec) drawBorderLine(ctx, x + w, rowBoundaryY(rj), x + w, rowBoundaryY(rEnd + 1), spec, scale, dpr);
+        rj = rEnd + 1;
+      }
     }
   }
   return y;


### PR DESCRIPTION
## Summary

Follow-up from the PR #811 review (#815). ECMA-376 §17.4.66 adjacent-cell
border-conflict resolution consulted only the **span-origin** neighbour when a
merged cell (`vMerge`/`gridSpan`) shared one interior gridline with several
finer-grained neighbours. The whole shared edge was resolved against a single
opposing cell, so the other neighbours' borders were dropped (or the wrong
winner spanned the full edge).

Per §17.4.66 each **sub-segment** of a shared edge should be resolved against
its actual opposing cell, potentially yielding a different winner per segment.

## Changes

- `drawTableRows` now subdivides a shared interior edge at the opposing cells'
  boundaries and resolves **each sub-segment** independently:
  - a wide cell's interior **bottom** edge is split at the below-cells' column
    boundaries; each run resolves against its own below neighbour's top.
  - a tall (`vMerge`) cell's interior physical-**right** edge is split at the
    right-neighbours' row boundaries; each run resolves against its own
    neighbour's facing (left) edge.
- `colBoundaryX` / `rowBoundaryY` compute per-segment extents from the column /
  row cumulative offsets, folding the `bidiVisual` flip for horizontal segments.
- The existing `resolveBorderConflict` kernel (weight → precedence → luminance →
  reading order) is reused unchanged; only its per-segment application is new.

## Tests

- Two new render tests in `cell-border-conflict-render.test.ts` cover
  colspan/rowspan shared edges whose opposing cells carry **differing** borders
  (previously no rowspan/colspan shared-edge render coverage existed). Both were
  Red before the change and Green after.
- Full docx suite: 1174 passed; root `tsc --build` typecheck clean.

## Cross-package note

The pptx `<a:tbl>` renderer has the same class of limitation (issue #824) and is
fixed in a separate PR. The two renderers use different cell-edge data models
(docx `ResolvedCellEdges` + §17.4.66 kernel vs. pptx `Stroke` + a spec-silent
kernel) and each PR branches independently from `main`, so the subdivision logic
is implemented in parallel in each package rather than shared, following the
#913 precedent.

Closes #815

## VRT triage (pre-merge, local)

Full docx VRT (`playwright test`, 89 checks: 82 fidelity pages + 7 functional) run twice
on the same machine/references — base = `origin/main` (8312297) and this branch — with
raw per-page diff-pixel counts vs the references compared check-by-check. Reference
images were **not** modified (verified byte-identical after the runs).

- **Pass/fail parity**: identical sets on base and branch — 52 passed / 35 failed /
  2 skipped on BOTH. All 35 failures are pre-existing private-baseline mismatches
  already failing on `origin/main`; none is introduced or altered by this PR.
- **Raw diff-pixel counts**: 79 of 80 compared pages have *exactly equal* counts
  (deterministic renders). Exactly **one** page changed:

  | check | base diff px | branch diff px | direction |
  |---|---|---|---|
  | `private/sample-28` page 17 | 514 | **0** | toward reference (now exact match) |

  sample-28 is the Arabic RTL (`bidiVisual`) document with 63 `gridSpan`s. The changed
  band (x 36–382, y 223–252) is a table gridline region: on base, part of the horizontal
  rule across a merged row's shared edge was dropped (span-origin-only resolution);
  the branch draws the full rule per sub-segment and lands pixel-exact on the reference.
- Span-heavy samples watched per triage focus (sample-3: vMerge 24 / gridSpan 66,
  sample-28: gridSpan 63, sample-29: vMerge 32, sample-4/30): all unchanged except the
  sample-28 improvement above.
- No check moved away from its reference.
