### PR TITLE
fix(docx): resolve style-inherited run properties for shape textbox runs

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -5480,6 +5480,25 @@ fn extract_simple_paragraph_text(
             .or_else(|| theme.default_east_asia_font_ref())
     };
 
+    let style_id = child_w(p, "pPr")
+        .and_then(|ppr| child_w(ppr, "pStyle"))
+        .and_then(|s| attr_w(s, "val"));
+    // ECMA-376 §17.7.2 — resolve the paragraph style chain once. The
+    // paragraph half feeds layout below; the run half is the docDefaults +
+    // paragraph-style rPr baseline for every run in this paragraph.
+    let (style_para, base_run) = style_map.resolve_para(style_id.as_deref(), None);
+    let resolve_run_fmt = |rpr_node: Option<roxmltree::Node>| -> RunFmt {
+        let mut fmt = base_run.clone();
+        if let Some(rpr) = rpr_node {
+            // §17.3.2.29 character style, then direct rPr; direct values win.
+            if let Some(rs) = child_w(rpr, "rStyle").and_then(|n| attr_w(n, "val")) {
+                apply_direct_run(&mut fmt, &style_map.resolve_run_style(&rs));
+            }
+            apply_direct_run(&mut fmt, &parse_run_fmt(rpr));
+        }
+        fmt
+    };
+
     let mut text = String::new();
     // Per-run formatting (one entry per `<w:r>` carrying text). Preserves mixed
     // bold/non-bold runs so the renderer can lay the paragraph out as rich text;
@@ -5545,11 +5564,7 @@ fn extract_simple_paragraph_text(
                         }
                     }
                     if base_fmt.is_none() {
-                        base_fmt = Some(
-                            child_w(rb_run, "rPr")
-                                .map(parse_run_fmt)
-                                .unwrap_or_default(),
-                        );
+                        base_fmt = Some(resolve_run_fmt(child_w(rb_run, "rPr")));
                     }
                 }
                 if base_text.is_empty() {
@@ -5584,7 +5599,7 @@ fn extract_simple_paragraph_text(
                 run_text.push_str(text_node);
             }
         }
-        let fmt = child_w(r, "rPr").map(parse_run_fmt).unwrap_or_default();
+        let fmt = resolve_run_fmt(child_w(r, "rPr"));
         out.push((run_text, fmt, None));
         out
     };
@@ -5609,7 +5624,7 @@ fn extract_simple_paragraph_text(
             "oMath" | "oMathPara" => {
                 let math_text = omml_plain_text(child);
                 if !math_text.is_empty() {
-                    push_text_run(math_text, RunFmt::default(), None);
+                    push_text_run(math_text, base_run.clone(), None);
                 }
             }
             _ => {}
@@ -5651,13 +5666,6 @@ fn extract_simple_paragraph_text(
     let direct_jc = child_w(p, "pPr")
         .and_then(|ppr| child_w(ppr, "jc"))
         .and_then(|jc| attr_w(jc, "val"));
-    let style_id = child_w(p, "pPr")
-        .and_then(|ppr| child_w(ppr, "pStyle"))
-        .and_then(|s| attr_w(s, "val"));
-    // Style-chain-resolved ParaFmt (incl. docDefaults) — reused for BOTH the
-    // alignment fallback and the indent resolution below (resolve_para is called
-    // once, not per attribute).
-    let style_para = style_map.resolve_para(style_id.as_deref(), None).0;
     let alignment = direct_jc
         .or_else(|| style_para.alignment.clone())
         .unwrap_or_else(|| "left".to_string());
@@ -13973,6 +13981,208 @@ mod txbx_inline_image_tests {
         assert_eq!(block.text, "Abstract");
         // Latin-first run with no explicit face → the default ascii font, NOT None.
         assert_eq!(block.font_family.as_deref(), Some("Century"));
+    }
+
+    /// ECMA-376 §17.7.2 — a text-box run inherits color from its paragraph
+    /// style's run properties, and the block-level fallback follows that run.
+    #[test]
+    fn extract_simple_paragraph_text_inherits_paragraph_style_run_color() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="paragraph" w:styleId="Red">
+                <w:rPr><w:color w:val="FF0000"/></w:rPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        let doc = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:pPr><w:pStyle w:val="Red"/></w:pPr>
+                 <w:r><w:t>x</w:t></w:r>
+               </w:p>"#,
+        )
+        .unwrap();
+        let block = extract_simple_paragraph_text(
+            &styles,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(block.runs[0].color.as_deref(), Some("ff0000"));
+        assert_eq!(block.color.as_deref(), Some("ff0000"));
+    }
+
+    /// ECMA-376 §17.7.2 and §17.3.2.29 — a text-box run resolves its
+    /// character style on top of the paragraph run-format baseline.
+    #[test]
+    fn extract_simple_paragraph_text_inherits_character_style_run_color() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="character" w:styleId="Green">
+                <w:rPr><w:color w:val="00FF00"/></w:rPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        let doc = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:r><w:rPr><w:rStyle w:val="Green"/></w:rPr><w:t>x</w:t></w:r>
+               </w:p>"#,
+        )
+        .unwrap();
+        let block = extract_simple_paragraph_text(
+            &styles,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(block.runs[0].color.as_deref(), Some("00ff00"));
+    }
+
+    /// ECMA-376 §17.7.2 — a text-box run with no color inherits the
+    /// document's `rPrDefault` color.
+    #[test]
+    fn extract_simple_paragraph_text_inherits_doc_default_run_color() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:docDefaults><w:rPrDefault><w:rPr>
+                <w:color w:val="112233"/>
+              </w:rPr></w:rPrDefault></w:docDefaults>
+            </w:styles>"#,
+        );
+        let doc = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:r><w:t>x</w:t></w:r>
+               </w:p>"#,
+        )
+        .unwrap();
+        let block = extract_simple_paragraph_text(
+            &styles,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(block.runs[0].color.as_deref(), Some("112233"));
+    }
+
+    /// ECMA-376 §17.7.2 — direct text-box run properties override the
+    /// paragraph style's inherited run properties.
+    #[test]
+    fn extract_simple_paragraph_text_direct_run_color_overrides_paragraph_style() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="paragraph" w:styleId="Red">
+                <w:rPr><w:color w:val="FF0000"/></w:rPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        let doc = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:pPr><w:pStyle w:val="Red"/></w:pPr>
+                 <w:r><w:rPr><w:color w:val="0000FF"/></w:rPr><w:t>x</w:t></w:r>
+               </w:p>"#,
+        )
+        .unwrap();
+        let block = extract_simple_paragraph_text(
+            &styles,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(block.runs[0].color.as_deref(), Some("0000ff"));
+    }
+
+    /// ECMA-376 §17.7.2 — a text-box run inherits its font size from the
+    /// paragraph style's run properties.
+    #[test]
+    fn extract_simple_paragraph_text_inherits_paragraph_style_run_size() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="paragraph" w:styleId="Large">
+                <w:rPr><w:sz w:val="48"/></w:rPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        let doc = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:pPr><w:pStyle w:val="Large"/></w:pPr>
+                 <w:r><w:t>x</w:t></w:r>
+               </w:p>"#,
+        )
+        .unwrap();
+        let block = extract_simple_paragraph_text(
+            &styles,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(block.runs[0].font_size_pt, 24.0);
+    }
+
+    /// ECMA-376 §17.7.2 — a text-box run inherits bold from the paragraph
+    /// style's run properties.
+    #[test]
+    fn extract_simple_paragraph_text_inherits_paragraph_style_run_bold() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="paragraph" w:styleId="Bold">
+                <w:rPr><w:b/></w:rPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        let doc = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:pPr><w:pStyle w:val="Bold"/></w:pPr>
+                 <w:r><w:t>x</w:t></w:r>
+               </w:p>"#,
+        )
+        .unwrap();
+        let block = extract_simple_paragraph_text(
+            &styles,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        assert!(block.runs[0].bold);
+    }
+
+    /// ECMA-376 §17.7.2 and §17.3.2.6 — direct `auto` color breaks
+    /// inheritance of a concrete paragraph-style color.
+    #[test]
+    fn extract_simple_paragraph_text_auto_run_color_breaks_style_inheritance() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="paragraph" w:styleId="Red">
+                <w:rPr><w:color w:val="FF0000"/></w:rPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        let doc = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:pPr><w:pStyle w:val="Red"/></w:pPr>
+                 <w:r><w:rPr><w:color w:val="auto"/></w:rPr><w:t>x</w:t></w:r>
+               </w:p>"#,
+        )
+        .unwrap();
+        let block = extract_simple_paragraph_text(
+            &styles,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(block.runs[0].color, None);
     }
 
     /// ECMA-376 §17.7.2 — a text-box paragraph's alignment resolves through its


### PR DESCRIPTION
## Summary

Runs inside a shape text box (`<wps:txbx>` / `<v:textbox>`, handled by `extract_simple_paragraph_text` in `packages/docx/parser/src/parser.rs`) resolved their formatting from the **direct `<w:rPr>` only**. Any run property supplied by the ECMA-376 §17.7.2 style cascade — `docDefaults`/`rPrDefault`, the paragraph style `rPr`, or an `rStyle` character style — was silently dropped.

The reported symptom (issue #829) is color: a textbox run whose color comes solely from a character/paragraph style fell through to the shape `fontRef` default (or black) instead of the style color. The audit requested by the issue confirmed the same gap affected **size, bold, and font** inheritance.

## Fix

Route textbox runs through the **same cascade the body path uses** (`parse_run_inner`):

1. Resolve the paragraph style chain once into its run baseline — `resolve_para(style_id, None).1` = docDefaults + paragraph-style `rPr` (the paragraph half was already used for alignment/indent/spacing; only the run half was discarded).
2. Per run: start from that `base_run`, apply the character style (`rStyle`, §17.3.2.29), then the direct `rPr` — direct values win.

The normal run, the ruby-base run, and the OMML plain-text fallback all share the resolved baseline, so no property is special-cased. A direct `auto` color still breaks inheritance (§17.3.2.6), keeping a color-less run at `color: None` so the renderer's §20.1.4.1.17 `fontRef` default continues to apply.

## Audit outcome (size / bold / fonts)

The single shared fix closes the whole gap, not just color. Verified by diffing parser output across the private sample corpus before/after — every shift is a §17.7.2 correction toward the style Word applies, checked against the actual style definitions:

- **Size**: size-less textbox runs now inherit each document's real default (e.g. sample-9/32 `sz=22` → 11pt, sample-35 10.5pt) instead of the flat 10pt fallback.
- **Font (eastAsia)**: sample-5's title inherits its paragraph style's explicit `eastAsia="Meiryo UI"` (was the docDefault theme font).
- **Font (ascii) + size**: sample-13's masthead inherits `mJournalHomePageLink`'s `ascii="Arial"` `sz=18` (9pt) (was Times New Roman 10pt).
- **Bold**: sample-28's heading inherits its paragraph style's `<w:b/>`.

No explicit direct run value was changed, and **no `color` field changed in any existing sample** (consistent with the issue note that no current fixture triggers the color case — that path is covered by the new synthetic tests).

## Tests

Seven new parser tests: pStyle / rStyle / docDefaults color inheritance, direct-over-style override, size inheritance, bold inheritance, and the `auto` reset.

Gates: `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (all pass), docx WASM rebuilt, `npx vitest run packages/docx` (1172 pass), docx package `tsc --noEmit` clean.

Closes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## VRT triage (branch vs base, same machine)

Protocol: port 5180 verified free (`lsof`), `pnpm --filter @silurus/ooxml-docx vrt` run twice in the same worktree/environment — once on this branch, once detached at base `origin/main` (8312297) with the docx WASM rebuilt for each. Reference images were **not** updated.

**Topline (identical on both runs):** 52 passed / 35 failed / 2 skipped (`private/sample-10` has no reference image on either run).

**Per-check raw pixel diff vs reference — 80 measured checks:**

| Category | Checks | Verdict |
|---|---|---|
| Byte-identical pixel count, base = branch | 78 / 80 | Not affected by this branch |
| — incl. all 35 failing checks (sample-2 p1, sample-29 p2–14, sample-30 p1–4, sample-31 p1–12, demo/sample-1 p2–6) | 35 | Pre-existing baseline/environment mismatch: identical diff-pixel counts on base and branch |
| Moved by this branch | 2 / 80 | See below |

**The 2 branch-origin diffs (both PASS all VRT gates; both move numerically *away* from the stored reference):**

| Check | Base px | Branch px | Delta | Region | Ground-truth direction |
|---|---|---|---|---|---|
| `private/sample-28` p2 | 0 | 98 (0.02%) | +98 | single 68×30 px word — the divider heading | Word PDF renders the heading **bold** (pStyle `<w:b/>`); branch = bold matches the PDF, base = regular does not |
| `private/sample-5` p1 | 1,716 | 1,760 (0.35%) | +44 | two textbox title bands (rows 83–94, 694–707) | Word PDF renders the title in a **gothic (uniform-stroke)** face per the pStyle `eastAsia="Meiryo UI"`; branch = gothic matches the PDF, base = mincho (theme 游明朝) does not |

Both regions were pinpointed by pixel bounding-box analysis of branch-vs-base screenshots and compared at 6× zoom against the Word-generated PDF (`pdftoppm -r 72`, same pt=px scale). In both cases the branch output matches the PDF glyph rendering and the base does not — the moves away from the reference occur because the private references are pre-fix renderer self-snapshots (generated locally with `UPDATE_REFS=1`), so a fidelity correction necessarily diffs against them.

**Formal verdict per triage rule (any check moving away from the reference ⇒ held): HELD** — 2 checks move away from the stored reference, though both are verified toward the Word ground truth. No reference images were touched; regenerating `private/sample-5` and `private/sample-28` references after merge (owner-approved only) would re-zero these two checks.
