### PR TITLE
fix(pptx): resolve table border conflicts per span-edge sub-segment

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -4777,41 +4777,58 @@ export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, sca
     // BOTTOM: outer bottom → own spec; interior → resolve THIS cell's bottom
     // against the below neighbour's top and draw the single winner.
     {
-      let spec: Stroke | null;
       if (j.lastRi === el.rows.length - 1) {
-        spec = cell.borderB;
+        const spec = cell.borderB;
+        if (spec) strokeSeg(spec, colX, rowY + cellH, colX + cellW, rowY + cellH);
       } else {
-        // KNOWN LATENT LIMITATION: span vs subdivided neighbour with differing
-        // borders resolves only the origin slot — a gridSpan cell whose bottom
-        // faces MULTIPLE below-cells with different borderT specs (e.g.
-        // [thin, thick]) picks the winner from slot (lastRi+1, ci) alone and
-        // strokes the whole span with it, dropping the non-origin slots' specs.
-        // Zero occurrences in the private corpus; segment-wise resolution
-        // tracked in issue #824.
-        const below = jobAt(j.lastRi + 1, j.ci);
-        spec = resolveTableBorderConflict(cell.borderB, below ? below.cell.borderT : null);
+        // #824 — the shared horizontal edge below this cell may face SEVERAL finer
+        // below-cells with differing borderT (this cell is wider via gridSpan).
+        // Subdivide the edge at those cells' column boundaries and resolve EACH
+        // sub-segment against its OWN below neighbour, drawing a per-segment winner
+        // rather than resolving the whole span against the origin slot alone.
+        const belowRi = j.lastRi + 1;
+        const y = rowY + cellH;
+        const cEndMax = Math.min(j.ci + j.span, numCols);
+        let cj = j.ci;
+        while (cj < cEndMax) {
+          const idx = occupancy[belowRi][cj];
+          let cEnd = cj + 1;
+          while (cEnd < cEndMax && occupancy[belowRi][cEnd] === idx) cEnd++;
+          const below = jobAt(belowRi, cj);
+          const spec = resolveTableBorderConflict(cell.borderB, below ? below.cell.borderT : null);
+          if (spec) {
+            const segLeft = spannedLeft(cj, cEnd - cj);
+            const segW = spannedWidth(cj, cEnd - cj);
+            strokeSeg(spec, segLeft, y, segLeft + segW, y);
+          }
+          cj = cEnd;
+        }
       }
-      if (spec) strokeSeg(spec, colX, rowY + cellH, colX + cellW, rowY + cellH);
     }
     // PHYSICAL RIGHT: outer-right → own spec; interior → resolve THIS cell's
     // physical-right line against the physically-right neighbour's facing edge
     // (so each shared vertical line is drawn once).
     {
-      let spec: Stroke | null;
       if (physRightOuter) {
-        spec = physRightSpec;
+        const spec = physRightSpec;
+        if (spec) strokeSeg(spec, colX + cellW, rowY, colX + cellW, rowY + cellH);
       } else {
-        // KNOWN LATENT LIMITATION: span vs subdivided neighbour with differing
-        // borders resolves only the origin slot — a rowSpan cell whose physical-
-        // right edge faces MULTIPLE right-neighbours with different facing specs
-        // picks the winner from slot (ri, physRightNbrCi) alone and strokes the
-        // whole span with it, dropping the non-origin slots' specs. Zero
-        // occurrences in the private corpus; segment-wise resolution tracked in
-        // issue #824.
-        const right = jobAt(j.ri, physRightNbrCi);
-        spec = resolveTableBorderConflict(physRightSpec, right ? nbrPhysLeftSpec(right.cell) : null);
+        // #824 — a rowSpan cell's physical-right edge may face SEVERAL finer
+        // right-neighbours down the rows it spans, with differing facing specs.
+        // Subdivide the edge at those neighbours' row boundaries and resolve EACH
+        // sub-segment against its OWN neighbour's facing (physical-left) edge.
+        const x = colX + cellW;
+        let rj = j.ri;
+        while (rj <= j.lastRi) {
+          const idx = occupancy[rj][physRightNbrCi];
+          let rEnd = rj;
+          while (rEnd + 1 <= j.lastRi && occupancy[rEnd + 1][physRightNbrCi] === idx) rEnd++;
+          const right = jobAt(rj, physRightNbrCi);
+          const spec = resolveTableBorderConflict(physRightSpec, right ? nbrPhysLeftSpec(right.cell) : null);
+          if (spec) strokeSeg(spec, x, rowTop[rj], x, rowTop[rEnd] + rowHeights[rEnd]);
+          rj = rEnd + 1;
+        }
       }
-      if (spec) strokeSeg(spec, colX + cellW, rowY, colX + cellW, rowY + cellH);
     }
 
     // Diagonal borders: top-left→bottom-right and bottom-left→top-right. These

--- a/packages/pptx/src/table-border-single-draw.test.ts
+++ b/packages/pptx/src/table-border-single-draw.test.ts
@@ -222,4 +222,39 @@ describe('DrawingML <a:tbl> — shared interior gridline drawn once (spec-silent
     const shared = horizontalAt(strokes, 20).filter((s) => Math.min(s.x1, s.x2) >= 59);
     expect(shared).toHaveLength(1);
   });
+  it('#824: a gridSpan cell resolves EACH below sub-segment against its own neighbour', () => {
+    // A cell spanning both columns (gridSpan=2, no bottom border) faces TWO below
+    // cells with DIFFERENT top borders. The shared horizontal edge must be split at
+    // the column boundary: left half → the left neighbour's border, right half →
+    // the right neighbour's. Before the fix only the span-origin (left) neighbour
+    // was consulted and the right half's border was dropped.
+    const strokes = render(tableOf([
+      [cell({ gridSpan: 2 }), cell({ hMerge: true })],
+      [cell({ borderT: ln({ width: EMU, color: '111111' }) }),
+       cell({ borderT: ln({ width: 3 * EMU, color: '222222' }) })],
+    ], [COL, COL]));
+    const seg = horizontalAt(strokes, 20);
+    const left = seg.filter((s) => Math.min(s.x1, s.x2) < 30);
+    const right = seg.filter((s) => Math.max(s.x1, s.x2) > 90);
+    expect(left.some((s) => s.color === rgba('111111'))).toBe(true);
+    expect(right.some((s) => s.color === rgba('222222'))).toBe(true);
+  });
+
+  it('#824: a rowSpan cell resolves EACH right sub-segment against its own neighbour', () => {
+    // A cell spanning both rows (rowSpan=2, no right border) faces TWO right
+    // neighbours with DIFFERENT left borders. Its shared vertical edge must be split
+    // at the row boundary: top half → the upper neighbour's border, bottom half →
+    // the lower neighbour's. Before the fix only the span-origin (upper) neighbour
+    // was consulted and the bottom half's border was dropped.
+    const strokes = render(tableOf([
+      [cell({ rowSpan: 2 }), cell({ borderL: ln({ width: EMU, color: '111111' }) })],
+      [cell({ vMerge: true }), cell({ borderL: ln({ width: 3 * EMU, color: '222222' }) })],
+    ], [COL, COL]));
+    const seg = verticalAt(strokes, 60);
+    const top = seg.filter((s) => Math.min(s.y1, s.y2) < 10);
+    const bot = seg.filter((s) => Math.max(s.y1, s.y2) > 30);
+    expect(top.some((s) => s.color === rgba('111111'))).toBe(true);
+    expect(bot.some((s) => s.color === rgba('222222'))).toBe(true);
+  });
+
 });


### PR DESCRIPTION
## Summary

Latent limitation found by the PR #817 review (#824). A DrawingML `<a:tbl>` span
cell (`gridSpan`/`rowSpan`) facing a **subdivided** neighbour whose cells carry
differing `<a:ln>` specs resolved only the **origin slot's** edge and stroked a
single winner across the full span, so the non-origin slots' borders were
dropped (e.g. `gridSpan=2` above `[thin, thick]` drew one thin line across the
span; the thick half was lost).

## Changes

The border "Pass 2" loop now subdivides each shared interior edge at the opposing
cells' boundaries and resolves **each sub-segment** independently (spec-silent
rule: null loses → wider wins → darker wins → owner):

- a `gridSpan` cell's interior **bottom** edge is split at the below-cells'
  column boundaries; each run resolves against its own below neighbour's top.
- a `rowSpan` cell's interior physical-**right** edge is split at the
  right-neighbours' row boundaries; each run resolves against its own
  neighbour's facing (physical-left) edge.
- Segment extents reuse the existing `spannedLeft` / `spannedWidth` / `rowTop`
  geometry, so the RTL (`§21.1.3.13`) coordinate flip is inherited unchanged.
- The `resolveTableBorderConflict` kernel is reused as-is; only its per-segment
  application is new. The now-resolved "KNOWN LATENT LIMITATION" comments landed
  with #817 are removed.

## Tests

- Two new render tests in `table-border-single-draw.test.ts` cover
  gridSpan/rowSpan shared edges whose opposing cells carry **differing** borders.
  Both were Red before the change and Green after.
- Full pptx suite: 388 passed; root `tsc --build` typecheck clean.

## Cross-package note

Same class as docx #815 (fixed in a separate PR). The two renderers use
different cell-edge data models (docx `ResolvedCellEdges` + the §17.4.66 kernel
vs. pptx `Stroke` + the spec-silent kernel) and each PR branches independently
from `main`, so the subdivision logic is implemented in parallel in each package
rather than shared, following the #913 precedent.

Closes #824

## VRT triage (pre-merge, local)

pptx VRT text rendering carries ~1–2 px of run-to-run browser noise, so this triage
compares the branch against a **base run** (`origin/main`-identical pptx tree, same
machine/references), not against the references alone, plus a deterministic headless
probe. Reference images were **not** modified (verified byte-identical after the runs).

- **Full pptx VRT** (`playwright test`, 79 checks: 69 fidelity slides + 10 functional):
  **79/79 pass on both base and branch**, and all **69 slides have exactly equal raw
  diff-pixel counts** base vs branch (no noise materialized between these runs; zero
  branch-attributable delta).
- **Table-bearing corpus slides** (private/sample-2 slides 6/9/15, private/sample-4
  slide 10, private/sample-6 slide 2, demo/sample-1 slide 6): the base and branch
  browser screenshots are **byte-identical** for all six.
- **Deterministic node probe** (noise-free discriminator): each of those six slides was
  also rendered headlessly (skia-canvas, WASM parse, dpr=1, width 960) on base and
  branch; all six **sha256 hashes are identical** (probe re-run confirmed the pipeline
  itself is deterministic).

This matches expectation: the VRT corpus contains **zero** `gridSpan`/`rowSpan` table
cells, and for span-free cells the subdivision loop degenerates to the exact pre-PR
geometry — so the corpus must be (and is) a rendering no-op. The changed behaviour
(span vs subdivided neighbour) is exercised by the two new unit render tests.
