### PR TITLE
fix(docx): gate fontTable modern family to monospace on w:pitch=fixed

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -346,7 +346,7 @@ pub fn parse(zip: &mut Zip) -> Result<Document, String> {
         })
         .unwrap_or_else(|| "word/fontTable.xml".to_string());
     let font_table_xml = read_zip_string(zip, &font_table_path).unwrap_or_default();
-    let font_family_classes = parse_font_table(&font_table_xml);
+    let (font_family_classes, font_family_pitches) = parse_font_table(&font_table_xml);
     // ECMA-376 §17.8.3.3-.6 — embedded fonts. The `<w:embed*>` r:ids resolve
     // through the fontTable part's OWN relationships (`word/_rels/fontTable.xml.rels`
     // when the part is `word/fontTable.xml`): insert `_rels/` before the filename
@@ -412,6 +412,7 @@ pub fn parse(zip: &mut Zip) -> Result<Document, String> {
         major_font,
         minor_font,
         font_family_classes,
+        font_family_pitches,
         embedded_fonts,
         revisions,
         comments,
@@ -1017,7 +1018,7 @@ fn find_rel_target(rels_xml: &str, type_suffix: &str) -> Option<String> {
     None
 }
 
-/// Parse `word/fontTable.xml` and build a map from font name to family class.
+/// Parse `word/fontTable.xml` and build maps from font name to family class and pitch.
 ///
 /// ECMA-376 §17.8.3.10 defines `<w:font w:name="…"><w:family w:val="…"/></w:font>`
 /// where val is one of: `roman` (serif), `swiss` (sans-serif), `modern`
@@ -1025,10 +1026,16 @@ fn find_rel_target(rels_xml: &str, type_suffix: &str) -> Option<String> {
 /// this map as the primary source of serif/sans-serif classification, falling
 /// back to name-pattern matching only when the font is absent or classified
 /// as `auto`.
-fn parse_font_table(xml: &str) -> BTreeMap<String, String> {
-    let mut map = BTreeMap::new();
+///
+/// ECMA-376 §17.8.3.29 defines `<w:pitch w:val="…"/>`, whose ST_Pitch value
+/// (§17.18.66) is `fixed` (Fixed Width), `variable` (Proportional Width), or
+/// `default` (no pitch information). An omitted `<w:pitch>` is assumed to be
+/// `default`, so only explicitly declared pitch values are added to the map.
+fn parse_font_table(xml: &str) -> (BTreeMap<String, String>, BTreeMap<String, String>) {
+    let mut classes = BTreeMap::new();
+    let mut pitches = BTreeMap::new();
     let Ok(doc) = parse_guarded(xml) else {
-        return map;
+        return (classes, pitches);
     };
     for font in doc.root_element().descendants().filter(|n| {
         n.is_element() && n.tag_name().name() == "font" && is_w_ns(n.tag_name().namespace())
@@ -1057,10 +1064,58 @@ fn parse_font_table(xml: &str) -> BTreeMap<String, String> {
                 )
             });
         if let Some(f) = family {
-            map.insert(name.to_string(), f.to_string());
+            classes.insert(name.to_string(), f.to_string());
+        }
+        let pitch = font
+            .children()
+            .find(|n| {
+                n.is_element()
+                    && n.tag_name().name() == "pitch"
+                    && is_w_ns(n.tag_name().namespace())
+            })
+            .and_then(|n| {
+                attr_ns(
+                    &n,
+                    wordprocessingml::TRANSITIONAL,
+                    wordprocessingml::STRICT,
+                    "val",
+                )
+            });
+        if let Some(p) = pitch {
+            pitches.insert(name.to_string(), p.to_string());
         }
     }
-    map
+    (classes, pitches)
+}
+
+#[cfg(test)]
+mod font_table_tests {
+    use super::*;
+    use crate::xml_util::W_NS;
+
+    #[test]
+    fn parses_declared_family_and_pitch_without_synthesizing_omitted_pitch() {
+        let xml = format!(
+            r#"<w:fonts xmlns:w="{W_NS}">
+                 <w:font w:name="Meiryo UI">
+                   <w:family w:val="modern"/>
+                   <w:pitch w:val="variable"/>
+                 </w:font>
+                 <w:font w:name="No Pitch">
+                   <w:family w:val="modern"/>
+                 </w:font>
+               </w:fonts>"#,
+        );
+
+        let (classes, pitches) = parse_font_table(&xml);
+
+        assert_eq!(classes.get("Meiryo UI").map(String::as_str), Some("modern"));
+        assert_eq!(
+            pitches.get("Meiryo UI").map(String::as_str),
+            Some("variable")
+        );
+        assert!(!pitches.contains_key("No Pitch"));
+    }
 }
 
 /// Parse the embedded-font references from `word/fontTable.xml` (ECMA-376

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -29,6 +29,16 @@ pub struct Document {
     /// sorted), making the parser output byte-stable for identical input.
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub font_family_classes: BTreeMap<String, String>,
+    /// ECMA-376 §17.8.3.29 — per-font pitch from `word/fontTable.xml`
+    /// (`<w:pitch w:val="…"/>`, ST_Pitch §17.18.66: "fixed" | "variable" |
+    /// "default"). Maps font name → pitch value; a font is present only when it
+    /// declares `<w:pitch>` (an omitted element is assumed "default" per
+    /// §17.8.3.29, which the renderer treats as non-fixed). The renderer uses this
+    /// to decide whether a `family="modern"` (§17.8.3.10) face is genuinely
+    /// monospace: only "fixed" is. Empty when fontTable.xml is absent or declares
+    /// no pitches. BTreeMap for deterministic (byte-stable) JSON key order.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub font_family_pitches: BTreeMap<String, String>,
     /// ECMA-376 §17.8.3.3-.6 — embedded fonts declared in `word/fontTable.xml`
     /// (`<w:embedRegular>` / `embedBold` / `embedItalic` / `embedBoldItalic`),
     /// resolved through `word/_rels/fontTable.xml.rels` to their obfuscated

--- a/packages/docx/src/font-family.test.ts
+++ b/packages/docx/src/font-family.test.ts
@@ -1,5 +1,35 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeFontFamily } from './line-layout.js';
+import { normalizeFontFamily, normalizeFontFamilyUncached } from './line-layout.js';
+
+describe('normalizeFontFamily — modern family respects w:pitch (§17.8.3.29)', () => {
+  it('keeps a variable-pitch modern face on the Meiryo/CJK-sans path', () => {
+    const chain = normalizeFontFamilyUncached(
+      'Meiryo UI',
+      { 'Meiryo UI': 'modern' },
+      { 'Meiryo UI': 'variable' },
+    );
+
+    expect(chain).not.toContain('monospace');
+    expect(chain).toContain('"Meiryo UI"');
+  });
+
+  it('maps a fixed-pitch modern face to monospace', () => {
+    const chain = normalizeFontFamilyUncached(
+      'MonoFace',
+      { MonoFace: 'modern' },
+      { MonoFace: 'fixed' },
+    );
+
+    expect(chain).toContain('"Courier New", monospace');
+  });
+
+  it('does not assume an omitted pitch is fixed', () => {
+    const chain = normalizeFontFamilyUncached('Meiryo UI', { 'Meiryo UI': 'modern' });
+
+    expect(chain).not.toContain('monospace');
+    expect(chain).toContain('"Meiryo UI"');
+  });
+});
 
 describe('normalizeFontFamily — Arabic substitute fonts', () => {
   it('puts the Arabic substitute first so Latin/digits resolve from the same family as Arabic', () => {

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -495,7 +495,8 @@ export function serifTail(cjk: ReturnType<typeof classifyCjkFont>): string {
  *  1. `fontFamilyClasses` map (from `word/fontTable.xml` §17.8.3.10):
  *     - "roman"      → serif
  *     - "swiss"      → sans-serif
- *     - "modern"     → monospace
+ *     - "modern"     → monospace only for `pitch="fixed"` (§17.8.3.29), else
+ *                      fall through to step 2
  *     - "script"/"decorative" → sans-serif fallback
  *     - "auto" / absent       → fall through to step 2
  *  2. Name-pattern matching (fallback for fonts absent from fontTable, or
@@ -516,6 +517,34 @@ export function serifTail(cjk: ReturnType<typeof classifyCjkFont>): string {
  */
 export const fontFamilyNormalizeCache = new WeakMap<Record<string, string>, Map<string, string>>();
 
+/** Companion to {@link fontFamilyNormalizeCache}: maps a `fontFamilyClasses`
+ *  object (stable per-document identity) to the sibling per-font PITCH map
+ *  (ECMA-376 §17.8.3.29 `<w:pitch>`: font name → "fixed" | "variable" |
+ *  "default"). `normalizeFontFamily` reads it to decide whether a
+ *  `family="modern"` (§17.8.3.10) face is genuinely monospace: only "fixed"
+ *  (§17.18.66 Fixed Width) is. Keyed on the classes object so the pitch threads
+ *  for free through every existing `fontFamilyClasses` call site — exactly like
+ *  the normalize cache — with no second map plumbed through the renderer. */
+export const fontFamilyPitchesByClasses = new WeakMap<
+  Record<string, string>,
+  Record<string, string>
+>();
+
+/** Bind the §17.8.3.29 pitch map to the §17.8.3.10 classes object and return the
+ *  classes object (defaulting to `{}`). Call at each renderer site that
+ *  materializes a document's `fontFamilyClasses` for threading, so the classifier
+ *  can read a `modern` face's pitch without a second map plumbed through. */
+export function fontClassesWithPitches(
+  classes: Record<string, string> | undefined,
+  pitches: Record<string, string> | undefined,
+): Record<string, string> {
+  const c = classes ?? {};
+  if (pitches && Object.keys(pitches).length > 0) {
+    fontFamilyPitchesByClasses.set(c, pitches);
+  }
+  return c;
+}
+
 export function normalizeFontFamily(
   family: string | null,
   fontFamilyClasses: Record<string, string> = {},
@@ -532,7 +561,13 @@ export function normalizeFontFamily(
   const key = family ?? '\0null';
   const cached = perDoc.get(key);
   if (cached !== undefined) return cached;
-  const result = normalizeFontFamilyUncached(family, fontFamilyClasses);
+  // The pitch map is registered once against this stable per-document classes
+  // identity, so the result remains a pure function of the memo key.
+  const result = normalizeFontFamilyUncached(
+    family,
+    fontFamilyClasses,
+    fontFamilyPitchesByClasses.get(fontFamilyClasses),
+  );
   perDoc.set(key, result);
   return result;
 }
@@ -540,6 +575,7 @@ export function normalizeFontFamily(
 export function normalizeFontFamilyUncached(
   family: string | null,
   fontFamilyClasses: Record<string, string>,
+  fontFamilyPitches: Record<string, string> = {},
 ): string {
   if (!family) return sansTail(null);
 
@@ -587,8 +623,24 @@ export function normalizeFontFamilyUncached(
         return `${head}, ${serifTail(cjk)}`;
       case 'swiss':
         return `${head}, ${sansTail(cjk)}`;
-      case 'modern':
-        return `${head}, "Courier New", monospace`;
+      case 'modern': {
+        // §17.8.3.10 `modern` is the "modern/monospace" typeface family, but the
+        // family value classifies the DESIGN, not the pitch — §17.8.3.29
+        // `<w:pitch>` states the actual pitch. Treat the face as monospace ONLY
+        // when pitch is "fixed" (§17.18.66 Fixed Width). A "variable"
+        // (proportional) modern face — e.g. Meiryo UI (`family="modern"`,
+        // `pitch="variable"`), a condensed ~0.84em CJK sans — must NOT map to
+        // Courier/monospace: that measures its CJK at a full 1.0em and over-wraps
+        // table cells onto a spurious extra page (issue #855). "default" and an
+        // omitted `<w:pitch>` (assumed "default" per §17.8.3.29) are likewise not
+        // a fixed-width guarantee, so they fall through to the name-pattern /
+        // CJK-sans path below. Genuine monospace faces (Courier, Consolas, 等幅)
+        // are still caught there by name.
+        if (fontFamilyPitches[family] === 'fixed') {
+          return `${head}, "Courier New", monospace`;
+        }
+        break;
+      }
       default:
         // script / decorative — fall through to name-pattern matching
         break;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -130,6 +130,7 @@ import {
   buildFont,
   buildSegments,
   calcEffectiveFontPx,
+  fontClassesWithPitches,
   getDefaultFontSize,
   gridCharDeltaPx,
   gridSegDeltaPx,
@@ -1216,7 +1217,7 @@ async function renderDocumentToCanvasLeased(
   const pages = opts.prebuiltPages ?? paginateWithHeaderFooterReserve(
     layoutDoc,
     ctx,
-    layoutDoc.fontFamilyClasses ?? {},
+    fontClassesWithPitches(layoutDoc.fontFamilyClasses, layoutDoc.fontFamilyPitches),
     layoutSettings,
     layoutDoc.footnotes ?? [],
   );
@@ -1369,7 +1370,7 @@ async function renderDocumentToCanvasLeased(
     sectionLayout,
     storyContext: BODY_STORY_CONTEXT,
     docEastAsian: layoutSettings.documentHasEastAsianText,
-    fontFamilyClasses: doc.fontFamilyClasses ?? {},
+    fontFamilyClasses: fontClassesWithPitches(doc.fontFamilyClasses, doc.fontFamilyPitches),
     kinsoku,
     // §17.15.1.25 — automatic tab interval, resolved once and threaded like
     // `kinsoku` so the measure and draw passes agree.
@@ -3678,7 +3679,7 @@ export function paginateDocument(doc: DocxDocumentModel): PaginatedBodyElement[]
   return paginateWithHeaderFooterReserve(
     layoutDoc,
     ctx,
-    layoutDoc.fontFamilyClasses ?? {},
+    fontClassesWithPitches(layoutDoc.fontFamilyClasses, layoutDoc.fontFamilyPitches),
     layoutSettings,
     layoutDoc.footnotes ?? [],
   );
@@ -3711,7 +3712,7 @@ export function layoutDocument(doc: DocxDocumentModel): DocumentLayout {
   const pages = paginateWithHeaderFooterReserve(
     layoutDoc,
     ctx,
-    layoutDoc.fontFamilyClasses ?? {},
+    fontClassesWithPitches(layoutDoc.fontFamilyClasses, layoutDoc.fontFamilyPitches),
     layoutSettings,
     layoutDoc.footnotes ?? [],
   );

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -20,6 +20,16 @@ export interface DocxDocumentModel {
    * entry is absent or classified as "auto".
    */
   fontFamilyClasses?: Record<string, string>;
+  /**
+   * ECMA-376 §17.8.3.29 — per-font pitch from `word/fontTable.xml`
+   * (`<w:pitch>`, ST_Pitch §17.18.66): font name → "fixed" | "variable" |
+   * "default". Present only for fonts that declare `<w:pitch>`. The renderer
+   * pairs this with {@link fontFamilyClasses}: a `family="modern"` face is
+   * treated as monospace ONLY when its pitch is "fixed"; "variable" /
+   * "default" / absent fall through to name-pattern / CJK-sans classification
+   * (§17.8.3.10 `family` classifies the design, not the pitch — issue #855).
+   */
+  fontFamilyPitches?: Record<string, string>;
   /** ECMA-376 §17.8.3.3-.6 — embedded fonts from `word/fontTable.xml`, resolved
    *  to their `.odttf` part paths + fontKey. The viewer de-obfuscates (§17.8.1)
    *  and registers each as a FontFace before pagination so text measures/draws


### PR DESCRIPTION
## Summary

Refs #855 (partial fix — the issue stays open; see "What this does not fix" below).

`word/fontTable.xml` fonts declared `<w:family w:val="modern"/>` (ECMA-376 §17.8.3.10) were mapped to a `"Courier New", monospace` fallback chain **unconditionally**. Per the spec, `w:family` classifies the typeface *design*, not its spacing — the actual pitch is `<w:pitch w:val="…"/>` (§17.8.3.29; ST_Pitch §17.18.66: `fixed` = Fixed Width, `variable` = Proportional Width, `default` = no information, and an omitted element is assumed `default`).

A proportional "modern" face — e.g. Meiryo UI, which Word's font table records as `family="modern"` + `pitch="variable"` — was therefore measured and drawn against a monospace fallback: fixed-pitch Latin and full 1.0 em CJK advances instead of its proportional sans metrics.

### Changes

- **Parser** (`parser.rs`): `parse_font_table` now also captures `<w:pitch>` into a new `fontFamilyPitches` model field (§17.8.3.29). Only explicitly declared values are recorded; an omitted `<w:pitch>` stays absent (assumed `default` per spec).
- **Classifier** (`line-layout.ts`): the fontTable `modern` branch returns the monospace chain **only when the font's pitch is `fixed`**; `variable` / `default` / absent fall through to the name-pattern / CJK-sans classification, so Meiryo UI now resolves to its proper sans chain (`"Meiryo UI", "Meiryo", "Noto Sans JP", …`). The pitch map rides a WeakMap keyed on the per-document `fontFamilyClasses` identity, so none of the existing `buildFont` call sites change.
- **Renderer** (`renderer.ts`): the four sites that materialize `fontFamilyClasses` register the sibling pitch map via `fontClassesWithPitches`.
- **Tests**: Rust unit test for `<w:pitch>` capture (incl. no synthesis for omitted pitch); three `normalizeFontFamily` tests (modern+variable → not monospace, modern+fixed → monospace, modern+absent → not monospace).

Genuinely fixed-pitch faces keep their monospace fallback: fonts declaring `pitch="fixed"` (e.g. HG Gothic variants in the same document), and Courier/Consolas-style names via the existing name heuristic. pptx/xlsx are unaffected — they classify through the shared name-based core classifier and never consumed `w:family`.

### Measured effect (sample-4, Chrome, same environment as VRT)

| | Meiryo UI resolved chain | CJK advance | page count |
|---|---|---|---|
| before | `…, "Courier New", monospace` | 1.0 em | 2 |
| after | `…, "Meiryo UI", "Meiryo", "Noto Sans JP", …, sans-serif` | 1.0 em | 2 |

The misclassification is fixed (verified via the model's `fontFamilyPitches` and the resolved chain at render time), and Latin/digit runs in `modern`+`variable` faces now render proportionally as Word does.

### What this does not fix

sample-4 still paginates to 2 pages (Word: 1). Word reaches 1 page because real Meiryo UI has a *condensed* CJK advance (~0.84 em); on systems without Meiryo UI installed, the sans substitutes (Noto Sans JP / Hiragino Sans) are em-square (1.0 em — measured identical to the old monospace fallback), so the agenda-table cells still wrap one extra line each and the trailing block still overflows. Closing the remaining gap needs a data-driven advance-width override for metric-compatible fallback (the generalization tracked in #794); `font-metrics.ts` currently corrects line height only.

## Test plan

- `cargo fmt --all --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test` (317) — pass
- WASM rebuilt via the package script (`fontFamilyPitches` verified present in the built artifact)
- `npx vitest run packages/docx` — 152 files, 1175 tests pass
- `pnpm --filter @silurus/ooxml-docx typecheck` — pass
- docx VRT triage — results posted as a PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)