### PR TITLE
fix(docx): restore wrap-time measurement-bias tolerance on justified lines

### DIFF
--- a/packages/docx/src/justify-shrink-overshoot.test.ts
+++ b/packages/docx/src/justify-shrink-overshoot.test.ts
@@ -9,23 +9,30 @@ import type {
 } from './types';
 
 // ECMA-376 §17.18.44 (ST_Jc `both`/`distribute`) — the Knuth-Plass space-shrink
-// fit tolerance (`SPACE_SHRINK_RATIO`) must NOT admit an extra word onto a line
-// that the draw pass will JUSTIFY, and MUST keep doing so on a line the draw pass
-// treats as non-justified. The gate is per LINE, mirroring the paint predicate
-// (renderer.ts: `applyJustify = isJustified && (!endsLogicalLine || stretchLastLine)`):
+// fit tolerance (`SPACE_SHRINK_RATIO`) ideally must NOT admit an extra word onto
+// a line that the draw pass will JUSTIFY, and must remain available on a line the
+// draw pass treats as non-justified. The per-line gate that mirrored the paint
+// predicate is currently disabled as an interim measure:
 //
 // - A line that WILL justify (a non-final, non-manual-break line of a
 //   `both`/kashida paragraph, or ANY line of `distribute`/`thaiDistribute`)
 //   redistributes its slack by EXPANDING inter-word spaces — it is never drawn
 //   compressed below natural width, so a candidate word whose natural advance
 //   overflows the column must wrap. Observed Word behaviour (issue #698, PDF
-//   ground truth): in a narrow justified column the tolerance pulled one word up
-//   per affected line where Word breaks at natural fit.
+//   ground truth) still stands: in a narrow justified column Word breaks at
+//   natural fit rather than pulling up one more word.
 // - A line the draw pass does NOT justify — the paragraph's true last line and a
 //   line ending at a manual `<w:br/>` (§17.3.3.1) under `both`/kashida, and every
 //   line of a non-justified paragraph — is drawn with the shrink-fit compression
 //   the budget promises (`shrinkFitCompression`), so the measurement-bias
 //   tolerance stays: measure and paint spend the SAME budget (measure==paint).
+// - The current uniform tolerance also compensates for per-font advance bias
+//   between browser measurement and Word. The tracked public Latin demo, whose
+//   `docDefaults` use `w:jc="both"`, matches Word only with that tolerance. Until
+//   issue #794 supplies a per-font advance-bias model, that ground truth cannot
+//   coexist with #698 under one ratio, so the public demo takes interim priority.
+//   Once #794 lands, restore the §17.18.44 gate and the Word-verified expectations
+//   below (3 tokens on the first line, across 2 lines).
 
 const FONT_PX = 12; // linear stub: each code point advances FONT_PX at scale 1
 
@@ -144,14 +151,18 @@ const TEXT4 = 'AAAA AAAA AAAA AAAA';      // marginal word is the paragraph-FINA
 const TEXT5 = 'AAAA AAAA AAAA AAAA AAAA'; // marginal word is followed by more content
 const COLUMN = 225;
 
-describe('§17.18.44 — space-shrink fit tolerance is gated per justified LINE (issue #698)', () => {
-  it('wraps the marginal word off a line that WILL justify (more content follows)', async () => {
-    // Word PDF ground truth (issue #698, narrow justified column): the justified
-    // line breaks at natural fit — the marginal word is not pulled up. Line 1
-    // must hold exactly 3 tokens; the old paragraph-wide tolerance admitted a 4th.
+describe('§17.18.44 — interim uniform space-shrink fit tolerance (#794 pending)', () => {
+  it('INTERIM (#794 pending): admits the marginal word on a line that will justify', async () => {
+    // Word PDF ground truth for #698's narrow justified column still shows a
+    // natural-fit break (3 tokens). That cannot currently coexist with the
+    // tracked public Latin demo (`docDefaults w:jc="both"`), whose wrapping
+    // matches Word only with the uniform measurement-bias tolerance. The interim
+    // decision favors the public demo GT, so the tolerance admits token 4. Issue
+    // #794's per-font advance-bias correction will let the §17.18.44 gate return
+    // and this expectation flip back to Word's verified 3 tokens across 2 lines.
     const lines = await renderLines(textPara(TEXT5, 'both'), COLUMN);
     expect(lines.length).toBe(2);
-    expect(tokens(lines[0])).toBe(3);
+    expect(tokens(lines[0])).toBe(4);
   });
 
   it('keeps the SAME marginal word on a non-justified line (bias tolerance retained)', async () => {
@@ -193,12 +204,18 @@ describe('§17.18.44 — space-shrink fit tolerance is gated per justified LINE 
     expect(lines[1]).toContain('BBBB');
   });
 
-  it('suppresses the budget on EVERY `distribute` line, including the last (stretchLastLine)', async () => {
-    // §17.18.44 `distribute` stretches every line — the paragraph-final line is
-    // justified too (paint: stretchLastLine), so its marginal word must wrap.
+  it('INTERIM (#794 pending): keeps the uniform budget on a `distribute` last line', async () => {
+    // Word PDF ground truth for #698 still requires the natural-fit break here:
+    // §17.18.44 `distribute` stretches the final line, yielding 3 tokens across
+    // 2 lines. Under the current single-ratio model that conflicts with the
+    // tracked public Latin demo (`docDefaults w:jc="both"`), whose Word wrapping
+    // requires the uniform measurement-bias tolerance. The interim decision
+    // favors that public demo GT, so all 4 tokens fit on one line. Issue #794's
+    // per-font advance-bias correction is the principled fix; then the justified
+    // per-line gate returns and this flips back to Word's verified 3 / 2 result.
     const lines = await renderLines(textPara(TEXT4, 'distribute'), COLUMN);
-    expect(lines.length).toBe(2);
-    expect(tokens(lines[0])).toBe(3);
+    expect(lines.length).toBe(1);
+    expect(tokens(lines[0])).toBe(4);
   });
 
   it('does not force a wrap when the justified content genuinely fits at natural width', async () => {

--- a/packages/docx/src/layout-context.ts
+++ b/packages/docx/src/layout-context.ts
@@ -7,7 +7,6 @@ import {
   resolveDefaultTabPt,
   type DocGridCtx,
 } from './line-layout.js';
-import { jcIsFullyJustified, jcStretchesLastLine } from './bidi-line.js';
 import type {
   BodyElement,
   ColumnGeom,
@@ -94,8 +93,6 @@ export interface ParagraphLayoutContext {
   readonly spaceBeforePt: number;
   readonly spaceAfterPt: number;
   readonly baseRtl: boolean;
-  readonly isJustified: boolean;
-  readonly stretchLastLine: boolean;
   readonly tabStops: readonly TabStop[];
   readonly hasRuby: boolean;
   readonly hasEastAsianText: boolean;
@@ -276,8 +273,6 @@ export function resolveParagraphLayoutContext(
     spaceBeforePt: paragraph.spaceBefore,
     spaceAfterPt: paragraph.spaceAfter,
     baseRtl,
-    isJustified: jcIsFullyJustified(paragraph.alignment),
-    stretchLastLine: jcStretchesLastLine(paragraph.alignment),
     tabStops: [...paragraph.tabStops],
     hasRuby: paragraphHasRuby(paragraph),
     hasEastAsianText: paragraphHasEastAsianText(paragraph),

--- a/packages/docx/src/line-boundary.test.ts
+++ b/packages/docx/src/line-boundary.test.ts
@@ -204,8 +204,6 @@ function layoutFixture(fixture: Fixture, startBoundary?: LineBoundary): LayoutLi
     36,
     fixture.width,
     fixture.baseRtl ?? false,
-    false,
-    false,
     startBoundary,
   );
 }

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -2337,18 +2337,6 @@ export function layoutLines(
   // tabs do not trigger the LTR right/center/overflow wrap paths. Default false
   // ⇒ the LTR tab paths run unchanged (byte-identical output).
   baseRtl = false,
-  // ECMA-376 §17.18.44 — whether the paragraph uses a fully justified mode.
-  // The shrink tolerance is gated per line below: lines paint will justify get
-  // no budget, while true-last/manual-break lines left non-justified keep it.
-  // `stretchLastLine` distinguishes those modes. See issue #698.
-  isJustified = false,
-  // ECMA-376 §17.18.44 — `distribute`/`thaiDistribute` stretch EVERY line
-  // including the paragraph's last (jcStretchesLastLine); `both`/kashida leave
-  // the last line and manual-break lines (§17.3.3.1) non-justified. Threaded so
-  // the per-candidate shrink gate below mirrors the paint predicate
-  // `applyJustify = isJustified && (!endsLogicalLine || stretchLastLine)`
-  // (renderer.ts) — measure and paint must classify each LINE identically.
-  stretchLastLine = false,
   startBoundary?: LineBoundary,
 ): LayoutLine[] {
   const lines: LayoutLine[] = [];
@@ -2356,11 +2344,8 @@ export function layoutLines(
   let currentWidth = 0;
   // Sum of trailing-space widths of every text token on the current line.
   // Used for two things:
-  //   1. Knuth-Plass-style shrink tolerance: lines the paint pass leaves
-  //      non-justified may compress spaces by up to SPACE_SHRINK_RATIO. Per
-  //      §17.18.44 it is suppressed for lines the paint pass fully justifies:
-  //      non-final/non-manual-break lines of `both`/kashida, and every line of
-  //      `distribute`/`thaiDistribute` (measure == paint; issue #698).
+  //   1. Knuth-Plass-style shrink tolerance: every line may consume up to
+  //      SPACE_SHRINK_RATIO of its accumulated trailing-space width.
   //   2. Trailing-space collapse at line end — the last token's trailing
   //      space disappears when no further word is added, so when deciding
   //      whether a candidate word fits we treat it as if it would become the
@@ -3018,23 +3003,14 @@ export function layoutLines(
     // and `wForFit` on the one advance model (`strAdvance` == the model behind `w`).
     const trailingSpaceW = s.text.endsWith(' ') ? w - strAdvance(s, trimmed) : 0;
     const wForFit = w - trailingSpaceW;
-    // Shrink budget for a candidate whose admission would CLOSE the current line
-    // with `next` as the first following segment (the budget only matters for a
-    // MARGINAL candidate — one that fills the line past availW(), so nothing more
-    // fits after it). Mirrors the paint pass's per-line justify predicate
-    // (renderer.ts `applyJustify = isJustified && (!endsLogicalLine || stretchLastLine)`):
-    // a line the draw pass will JUSTIFY (§17.18.44 expands its inter-word spaces,
-    // never compresses below natural width) gets NO budget and breaks at natural
-    // fit (issue #698, Word PDF ground truth); a line the draw pass leaves
-    // non-justified — the paragraph's true last line (queue exhausted) or a manual
-    // `<w:br/>` line (§17.3.3.1) under `both`/kashida — keeps the measurement-bias
-    // budget, because paint draws it with the promised shrink-fit compression.
-    const shrinkBudgetFor = (next: LayoutSeg | undefined): number => {
-      const closesLogicalLine = next === undefined || 'lineBreak' in next;
-      const lineWillJustify = isJustified && (!closesLogicalLine || stretchLastLine);
-      return lineWillJustify ? 0 : lineTotalTrailingW * SPACE_SHRINK_RATIO;
-    };
-    const shrinkBudget = shrinkBudgetFor(queue[0]);
+    // INTERIM: use one uniform measurement-bias budget even when the paint pass
+    // fully justifies the line. ECMA-376 §17.18.44 and Word-verified issue #698
+    // say those lines should break at natural fit, but the gate cannot coexist
+    // with the tracked public demo under the current single-ratio font metrics.
+    // Re-enable it after issue #794 adds per-font advance-bias correction. The
+    // #934 `isJustified`/`stretchLastLine` layout plumbing is removed meanwhile
+    // to keep the live API minimal; #794 should re-thread it with the real model.
+    const shrinkBudget = lineTotalTrailingW * SPACE_SHRINK_RATIO;
 
     // Atomic glued group: when THIS segment starts a glued group (its followers
     // in the queue are `joinPrev` pieces — small-caps case-pieces of the SAME
@@ -3093,7 +3069,7 @@ export function layoutLines(
         const ft = f.text.replace(/ +$/, '');
         groupTrail = f.text.endsWith(' ') ? fw - strAdvance(f, ft) : 0;
       }
-      if (currentWidth + (groupW - groupTrail) > availW() + shrinkBudgetFor(queue[groupEnd])) {
+      if (currentWidth + (groupW - groupTrail) > availW() + shrinkBudget) {
         flush(undefined, false, s.src);
       }
     }

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -89,8 +89,6 @@ const layoutContext = (
   spaceBeforePt: 3,
   spaceAfterPt: 4,
   baseRtl: false,
-  isJustified: false,
-  stretchLastLine: false,
   tabStops: [],
   hasRuby: false,
   hasEastAsianText: false,

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -264,8 +264,6 @@ export function measureParagraph(
     context.defaultTabPt,
     paragraphWidthPt + context.physicalIndentRightPt,
     context.baseRtl,
-    context.isJustified,
-    context.stretchLastLine,
     continuation?.boundary,
   );
   if (lines.length === 0) return measureMarkOnly();

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7285,9 +7285,9 @@ function renderParagraph(
     : reuse
     ? rescaleLayoutLines(stamped.layoutLines as LayoutLine[], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx)
     : wrapCtx
-      ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx, baseRtl, jcIsFullyJustified(para.alignment), jcStretchesLastLine(para.alignment))
+      ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx, baseRtl)
       : rescaleLayoutLines(
-          layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt, marginRightPx1, baseRtl, jcIsFullyJustified(para.alignment), jcStretchesLastLine(para.alignment)),
+          layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt, marginRightPx1, baseRtl),
           scale, ctx, state.fontFamilyClasses, paintGridDeltaPx,
         );
 
@@ -9444,8 +9444,6 @@ export function measureShapeTextAutoFitHeight(
         effState.defaultTabPt,
         ind.paraW,
         baseRtl,
-        jcIsFullyJustified(b.alignment),
-        jcStretchesLastLine(b.alignment),
       );
       contentH += lines.reduce((sum, line) => sum + lineHeightFor(b, line), 0);
     }
@@ -9737,8 +9735,6 @@ export function renderShapeText(
       effState.defaultTabPt,
       ind.paraW, // marginRightPx: block text has no separate right-indent origin
       baseRtl,
-      jcIsFullyJustified(b.alignment),
-      jcStretchesLastLine(b.alignment),
     );
     const metrics = lines.map((line) => lineMetricsFor(b, line));
     return {


### PR DESCRIPTION
## Summary

Merge-commit bisection of a five-page fidelity-ratchet failure on the tracked public demo ground truth (`demo/sample-1`) attributed the regression to #934 (`fix/docx-justify-shrink-overshoot`). This PR applies the maintainer-approved interim resolution: restore the uniform wrap-time space-shrink tolerance on justified lines, keeping the tracked public demo ground truth green until the principled fix (#794) lands.

## Bisection (docx VRT, `demo/sample-1` fidelity match %)

Committed reference PNGs, `scores.json`, and the VRT fixture are byte-identical across the whole range, so the movement is purely renderer behavior. WASM was rebuilt at every parser-source boundary.

| merge | PR | p2 | p3 | p4 | p5 | p6 | verdict |
|---|---|---|---|---|---|---|---|
| a178457 | #911 (base) | 99.1 | 99.2 | 100 | 99.4 | 100 | good |
| 597984e | #922 | 99.1 | 99.2 | 100 | 99.4 | 100 | good |
| 85caea3 | #926 | 99.1 | 99.2 | 100 | 99.4 | 100 | good |
| 364345f | #935 | 99.1 | 99.2 | 100 | 99.4 | 100 | good |
| ef71d6f | #934 | 94.9 | 89.8 | 90.8 | 82.4 | 95.8 | **first bad** |
| b291a21 | #942 (HEAD at triage) | 94.9 | 89.8 | 90.8 | 82.4 | 95.8 | bad |

## Root cause and the ground-truth conflict

#934 zeroed the Knuth-Plass space-shrink fit tolerance (`SPACE_SHRINK_RATIO`) at wrap time for lines the paint pass fully justifies. Per ECMA-376 §17.18.44 that gate is spec-correct — a justified line only expands inter-word spaces, so it should break at natural fit, which is exactly what the Word PDF ground truth of #698 shows in a narrow justified column.

However, that same wrap-time budget is currently the only mechanism absorbing the ~0.1–0.3 px/glyph advance-width bias between Chromium canvas `measureText` and Word's internal layout. `demo/sample-1` sets `docDefaults` `w:jc="both"`, so nearly every body paragraph is justified: with the gate active, every justified paragraph wraps one word early and pages 2–6 reflow (page 5: 100% → 82.44%).

Under a single global ratio the two Word ground truths are mutually exclusive. The principled resolution is #794 (per-font advance-bias / metric-compatible fallback model): once measurement bias is corrected per font, the §17.18.44 gate can return and both ground truths should hold simultaneously. The interim decision favors the tracked public demo ground truth.

## Changes

- `line-layout.ts`: the shrink budget is uniform again for every candidate line (both the marginal-candidate and glued-group checks). The interim rationale, the §17.18.44/#698 spec position, and the #794 re-enable condition are documented at the site.
- The #934-only measurement plumbing (`isJustified`/`stretchLastLine` parameters and their threading through `layout-context.ts`, `paragraph-measure.ts`, `renderer.ts`) is removed to keep the live API minimal; #794 re-adds it together with the real bias model. The paint pass's own justify predicates (`jcIsFullyJustified`/`jcStretchesLastLine` uses that predate #934) are untouched.
- `justify-shrink-overshoot.test.ts`: the two cases that pinned the gate are rewritten as explicit interim pins — the Word-verified expectations (3 tokens across 2 lines) are recorded in-place for restoration when #794 lands. The four budget-retention cases (true last line, manual `<w:br/>`, left/center, natural fit) are unchanged and still pass.

## Verification

- Red first: the two rewritten pins failed against the unmodified source, then passed after the change (6/6).
- Full docx unit suite: 155 files / 1200 tests green; `ast-grep` lint clean; root typecheck clean.
- DOCX VRT: `demo/sample-1` returns exactly to its recorded fidelity scores (page 4 and page 6 back to 100%, page 5 to its pre-regression value); no other public check moved.
- Locally verified against the private corpus: justified long-form documents reflow back to their pre-#934 wrap as expected (their local-only references are regenerated separately); the narrow justified-column divergence documented in #698 returns and remains tracked there as a #794 acceptance case.

Refs #698 #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
