### PR TITLE
fix(pptx): composite translucent WordArt warp strips once (#879)

### DIFF
--- a/packages/node/src/pptx-text-warp.probe.test.ts
+++ b/packages/node/src/pptx-text-warp.probe.test.ts
@@ -52,7 +52,7 @@ const warpFactory: NodeCanvasFactory | undefined = skia
 const EMU_PER_PX = 9525; // 96 dpi
 const px = (n: number) => Math.round(n * EMU_PER_PX);
 
-function warpShape(preset: string): ShapeElement {
+function warpShape(preset: string, color = '000000'): ShapeElement {
   const para: Paragraph = {
     alignment: 'ctr',
     marL: 0,
@@ -79,7 +79,7 @@ function warpShape(preset: string): ShapeElement {
         underline: false,
         strikethrough: false,
         fontSize: 40,
-        color: '000000',
+        color,
         fontFamily: 'Arial',
       } as Paragraph['runs'][number],
     ],
@@ -126,12 +126,12 @@ function warpShape(preset: string): ShapeElement {
   };
 }
 
-function buildSlide(preset: string): Presentation {
+function buildSlide(preset: string, color = '000000'): Presentation {
   const slide: Slide = {
     index: 0,
     slideNumber: 1,
     background: null,
-    elements: [warpShape(preset)],
+    elements: [warpShape(preset, color)],
   };
   return {
     slideWidth: px(400),
@@ -182,6 +182,70 @@ async function renderInk(preset: string): Promise<{
     return null;
   };
   return { topRow, bottomRow, width: W, height: H };
+}
+
+/**
+ * Luminance histogram of a TRANSLUCENT warped WordArt render (issue #879).
+ *
+ * The paired-edge warp draws each glyph as overlapping strips (a 1-device-px
+ * clip overlap hides the shared-edge AA seam). Painting an opaque colour over
+ * itself in that band is idempotent, but a TRANSLUCENT fill composed twice
+ * DARKENS it: over the slide's opaque white background a single composite of a
+ * fill at alpha `a` yields luminance L1 = 255 − a·(255 − Lfill), while the
+ * double-composed band yields L2 = 255 − a(2−a)·(255 − Lfill) < L1 — a visible
+ * darker pinstripe (Inflate ≈28%, CirclePour ≈71% of ink columns in the issue's
+ * browser measurement). Antialiased glyph edges only ever composite LESS ink, so
+ * they are LIGHTER than L1; the sole source of a pixel darker than L1 is the
+ * double composition. The #879 fix paints the strips opaque into a per-glyph
+ * device layer and composites it once, so every ink pixel lands at L1.
+ *
+ * Renders `<colorHex>` (8-digit RRGGBBAA) at dpr 2 and returns, over the solid
+ * ink pixels, the fraction darker than the L1/L2 midpoint (the double-composed
+ * band fraction) and the darkest ink luminance seen. band ≈ 0 / minLum ≈ L1 when
+ * the composite is uniform; band large / minLum ≈ L2 when the overlap darkens.
+ */
+async function warpTranslucentBand(
+  preset: string,
+  colorHex: string,
+): Promise<{ ink: number; bandFraction: number; minLum: number; l1: number; l2: number }> {
+  const width = 400;
+  const height = 240;
+  const dpr = 2;
+  const canvas = new Canvas(width * dpr, height * dpr);
+  await renderSlideNode(
+    canvas as unknown as Parameters<typeof renderSlideNode>[0],
+    buildSlide(preset, colorHex),
+    0,
+    { width, dpr, factory: warpFactory },
+  );
+  const ctx = canvas.getContext('2d');
+  const W = width * dpr;
+  const H = height * dpr;
+  const data = ctx.getImageData(0, 0, W, H).data as unknown as Uint8ClampedArray;
+  const lumAt = (p: number): number =>
+    0.299 * data[p * 4] + 0.587 * data[p * 4 + 1] + 0.114 * data[p * 4 + 2];
+  // Fill colour + alpha from the 8-digit hex; single (L1) and double (L2)
+  // composite luminance over the white background.
+  const fr = parseInt(colorHex.slice(0, 2), 16);
+  const fg = parseInt(colorHex.slice(2, 4), 16);
+  const fb = parseInt(colorHex.slice(4, 6), 16);
+  const a = parseInt(colorHex.slice(6, 8), 16) / 255;
+  const lFill = 0.299 * fr + 0.587 * fg + 0.114 * fb;
+  const l1 = 255 - a * (255 - lFill); // single composite
+  const l2 = 255 - a * (2 - a) * (255 - lFill); // double composite (band)
+  const bandCut = (l1 + l2) / 2; // darker than this ⇒ double-composed
+  const inkCut = (l1 + 255) / 2; // darker than this ⇒ solid ink (not AA fringe / bg)
+  let ink = 0;
+  let band = 0;
+  let minLum = 255;
+  for (let p = 0; p < W * H; p++) {
+    const l = lumAt(p);
+    if (l >= inkCut) continue; // background or faint AA edge
+    ink++;
+    if (l < minLum) minLum = l;
+    if (l < bandCut) band++;
+  }
+  return { ink, bandFraction: ink > 0 ? band / ink : 0, minLum, l1, l2 };
 }
 
 /** Min top-inked row across a column band [c0, c1). */
@@ -477,6 +541,32 @@ describe.skipIf(!skia)('node WordArt text-warp geometry (prstTxWarp)', () => {
       // eslint-disable-next-line no-console
       console.log(`${preset}: inkPx=${inkPx} components=${comps}`);
       expect(comps).toBeLessThanOrEqual(8);
+    }
+  });
+
+  it('translucent warp fill lands at a uniform alpha — no strip-overlap band (#879)', async () => {
+    // A 50%-alpha fill (RRGGBBAA = 1F4E7980, alpha byte 0x80) through the strip
+    // overlap band double-composed to ~75% opacity before #879, striping the ink
+    // with higher-opacity pinstripes (Inflate ≈28%, CirclePour ≈71% of ink
+    // columns in the issue's browser measurement). Two presets — a low-curvature
+    // (Inflate) and a high-curvature (CirclePour, many strips ⇒ many seams) —
+    // must now composite to a uniform single-composite alpha: essentially no ink
+    // pixel exceeds the single/double midpoint, and the peak alpha stays near the
+    // single level rather than the doubled one.
+    for (const preset of ['textInflate', 'textCirclePour']) {
+      const { ink, bandFraction, minLum, l1, l2 } = await warpTranslucentBand(preset, '1F4E7980');
+      // eslint-disable-next-line no-console
+      console.log(
+        `${preset}: ink=${ink} band=${(bandFraction * 100).toFixed(2)}% minLum=${minLum.toFixed(1)} (L1=${l1.toFixed(1)} L2=${l2.toFixed(1)})`,
+      );
+      expect(ink, `${preset}: has translucent ink`).toBeGreaterThan(2000);
+      // Double-composed band pixels: a whole-glyph raster would stripe a large
+      // fraction; the layer composite drives this to ~0. A hair of slack absorbs
+      // the odd self-overlapping outline corner.
+      expect(bandFraction, `${preset}: double-composed band fraction`).toBeLessThan(0.01);
+      // Darkest ink stays near the single composite L1, nowhere near the doubled
+      // L2 the overlap band would reach.
+      expect(minLum, `${preset}: darkest ink near single composite`).toBeGreaterThan((l1 + l2) / 2);
     }
   });
 });

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1418,10 +1418,14 @@ const WARP_STRIP_DEVICE_PX = 8;
 // additionally diverge by up to 2·budget at the ink extremes. Overlapping the
 // clips makes strip i paint the boundary band at FULL coverage before strip
 // i+1's partial-coverage edge lands on top; painting the same opaque colour
-// over itself is idempotent, so the seam vanishes. (For a translucent fill the
-// 2-px band composes twice and darkens slightly — the same trade-off the
-// earlier bitmap overlap had.) The overlap is symmetric, so it does not bias
-// the mapping.
+// over itself is idempotent, so the seam vanishes. That idempotence only holds
+// for an OPAQUE composite: a translucent fill (alpha < 1, from an 8-digit
+// RRGGBBAA run colour or an inherited shape opacity) composes the 2-px band
+// TWICE and darkens it (issue #879 — a visible pinstripe/moiré). The translucent
+// branch of drawWarpedGlyphStrips fixes that by painting the strips OPAQUE into a
+// per-glyph device-resolution layer (where the overlap is idempotent again) and
+// compositing the layer ONCE with the effective alpha. The overlap is symmetric,
+// so it does not bias the mapping.
 const WARP_STRIP_OVERLAP_DEVICE_PX = 1;
 // Max deviation (device px) of any painted slab corner from the EXACT envelope
 // map, enforced by the adaptive loop. Derivation: the true map places the
@@ -1506,6 +1510,7 @@ function drawWarpedGlyphStrips(
   bandFrac: number,
   boxX: number,
   boxY: number,
+  color: string,
 ): void {
   if (chW <= 0) return;
   // Ink extremes about the baseline (css px), from real metrics — this is where
@@ -1514,6 +1519,11 @@ function drawWarpedGlyphStrips(
   const m = ctx.measureText(ch);
   const asc = m.actualBoundingBoxAscent > 0 ? m.actualBoundingBoxAscent : chW;
   const desc = m.actualBoundingBoxDescent > 0 ? m.actualBoundingBoxDescent : chW * 0.25;
+  // Horizontal ink extremes about the pen origin (css px). Used only to bound the
+  // translucent compositing layer (issue #879) tightly around real ink, so
+  // side-bearing overhang on the outward-unbounded end strips still fits.
+  const inkL = m.actualBoundingBoxLeft > 0 ? m.actualBoundingBoxLeft : 0;
+  const inkR = m.actualBoundingBoxRight > 0 ? m.actualBoundingBoxRight : chW;
 
   // ── Adaptive strip count ──────────────────────────────────────────────────
   // Start from the width criterion (one strip per WARP_STRIP_DEVICE_PX of the
@@ -1568,30 +1578,148 @@ function drawWarpedGlyphStrips(
   const ov = WARP_STRIP_OVERLAP_DEVICE_PX / (hScale * devScale);
 
   const last = strips.length - 1;
+  // Glyph-local clip interval [x0, x1] of strip `i` (flat css px, origin at the
+  // strip centre): interior boundaries sit at the shared s0/s1 (± the overlap);
+  // the outer edges of the first/last strips are unbounded so side-bearing
+  // overhang ink is not cut.
+  const stripClipX0 = (i: number, s0: number, centre: number): number =>
+    i === 0 ? -CLIP_Y : s0 - centre - ov;
+  const stripClipX1 = (i: number, s1: number, centre: number): number =>
+    i === last ? CLIP_Y : s1 - centre + ov;
+
+  // Paint the whole strip stack onto `target` in `fillStyle`. The transform
+  // chain per strip is the single-affine per-glyph draw anchored at the STRIP
+  // centre so vScale/shear/angle track this slice's u.
+  const paintStrips = (target: CanvasRenderingContext2D, fillStyle: string): void => {
+    target.fillStyle = fillStyle;
+    for (let i = 0; i <= last; i++) {
+      const { s0, s1, g } = strips[i];
+      const centre = (s0 + s1) / 2;
+      target.save();
+      target.translate(boxX + g.x, boxY + g.y);
+      target.rotate(g.angle);
+      if (g.shear !== 0) target.transform(1, 0, g.shear, 1, 0, 0);
+      if (hScale !== 1 || g.vScale !== 1) target.scale(hScale, g.vScale);
+      target.beginPath();
+      const x0 = stripClipX0(i, s0, centre);
+      const x1 = stripClipX1(i, s1, centre);
+      target.rect(x0, -CLIP_Y, x1 - x0, 2 * CLIP_Y);
+      target.clip();
+      // Pen origin sits at local −centre; the ls/2 shift centres the ink inside
+      // its letter-spaced advance, matching the flat draw's origin convention.
+      target.fillText(ch, -centre + ls / 2, 0);
+      target.restore();
+    }
+  };
+
+  // ── Composite path selection (issue #879) ──────────────────────────────────
+  // The overlapping strip clips are idempotent only for a FULLY OPAQUE composite.
+  // Effective opacity = the fill's own alpha × the inherited ctx.globalAlpha
+  // (shape opacity). When both are 1 the direct draw is exact and byte-identical
+  // to the pre-#879 path — the overwhelmingly common WordArt case, zero
+  // allocation. Otherwise the 1-device-px overlap band would double-compose and
+  // darken, so route through the layer below.
+  const fillAlpha = rgbaAlpha(color);
+  const destAlpha = typeof ctx.globalAlpha === 'number' ? ctx.globalAlpha : 1;
+  if (fillAlpha >= 1 && destAlpha >= 1) {
+    paintStrips(ctx, color);
+    return;
+  }
+  if (fillAlpha <= 0 || destAlpha <= 0) return; // fully transparent — nothing to draw
+
+  // Translucent: paint the strips OPAQUE into a per-glyph device-resolution layer
+  // (so the overlap band is idempotent again) and composite the layer ONCE with
+  // the effective alpha. The layer is rasterised under the SAME device transform
+  // as the live canvas, so there is no re-magnification of any raster — the fix
+  // the issue calls for. Falls back to the direct draw (today's slightly darker
+  // band) when no auxiliary canvas or live transform is available (a headless
+  // mock ctx), which is never pixel-verified anyway.
+  const base = typeof ctx.getTransform === 'function' ? ctx.getTransform() : null;
+  if (!base) {
+    paintStrips(ctx, color);
+    return;
+  }
+
+  // Device-space AABB of the actual ink: per strip, the visible ink is the
+  // measured ink rectangle intersected with the strip's clip interval, mapped
+  // through the strip affine and the live (css→device) transform. Bounding by
+  // measured ink — not the ±CLIP_Y clip — keeps the layer glyph-tight.
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
   for (let i = 0; i <= last; i++) {
     const { s0, s1, g } = strips[i];
     const centre = (s0 + s1) / 2;
-    ctx.save();
-    // Same transform chain as the single-affine per-glyph draw, but anchored at
-    // the STRIP centre so vScale/shear/angle track this slice's u.
-    ctx.translate(boxX + g.x, boxY + g.y);
-    ctx.rotate(g.angle);
-    if (g.shear !== 0) ctx.transform(1, 0, g.shear, 1, 0, 0);
-    if (hScale !== 1 || g.vScale !== 1) ctx.scale(hScale, g.vScale);
-    // Strip clip in glyph-local coordinates (origin at the strip centre): the
-    // interior boundaries sit at the shared flat-x values s0/s1 (± the
-    // overlap); the glyph's outer edges are unbounded outward so side-bearing
-    // overhang ink is not cut.
-    const x0 = i === 0 ? -CLIP_Y : s0 - centre - ov;
-    const x1 = i === last ? CLIP_Y : s1 - centre + ov;
-    ctx.beginPath();
-    ctx.rect(x0, -CLIP_Y, x1 - x0, 2 * CLIP_Y);
-    ctx.clip();
-    // Pen origin sits at local −centre; the ls/2 shift centres the ink inside
-    // its letter-spaced advance, matching the flat draw's origin convention.
-    ctx.fillText(ch, -centre + ls / 2, 0);
-    ctx.restore();
+    const textX = -centre + ls / 2;
+    const x0 = Math.max(stripClipX0(i, s0, centre), textX - inkL);
+    const x1 = Math.min(stripClipX1(i, s1, centre), textX + inkR);
+    if (x1 <= x0) continue; // no ink in this strip's clip
+    for (const [lx, ly] of [
+      [x0, -asc],
+      [x1, -asc],
+      [x0, desc],
+      [x1, desc],
+    ] as const) {
+      const p = mapWarpLocalPoint(g, hScale, lx, ly);
+      const cx = boxX + p.x;
+      const cy = boxY + p.y;
+      const dx = base.a * cx + base.c * cy + base.e;
+      const dy = base.b * cx + base.d * cy + base.f;
+      if (dx < minX) minX = dx;
+      if (dx > maxX) maxX = dx;
+      if (dy < minY) minY = dy;
+      if (dy > maxY) maxY = dy;
+    }
   }
+  if (!(maxX > minX && maxY > minY)) return; // no ink mapped — nothing to composite
+
+  const pad = 2; // device px, for AA/rounding slack around the ink AABB
+  const originX = Math.floor(minX - pad);
+  const originY = Math.floor(minY - pad);
+  const layerW = Math.ceil(maxX + pad) - originX;
+  const layerH = Math.ceil(maxY + pad) - originY;
+  const aux = createAuxCanvas(layerW, layerH);
+  const auxCtx = aux ? (aux.getContext('2d') as CanvasRenderingContext2D | null) : null;
+  if (!aux || !auxCtx) {
+    paintStrips(ctx, color);
+    return;
+  }
+  // The layer's own transform is the live transform translated by −origin (a
+  // pure device-space shift, so it just subtracts origin from the base
+  // translation — no DOMMatrix multiply needed), placing device pixels on the
+  // same grid as the main canvas but offset into the layer.
+  auxCtx.font = ctx.font;
+  auxCtx.textAlign = 'left';
+  auxCtx.textBaseline = 'alphabetic';
+  auxCtx.setTransform(base.a, base.b, base.c, base.d, base.e - originX, base.f - originY);
+  paintStrips(auxCtx, opaqueRgba(color));
+
+  // Composite the opaque layer once at the effective alpha, at identity so the
+  // (already device-oriented) layer blits 1:1. save/restore preserves the live
+  // transform, clip, and globalAlpha for the next glyph.
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.globalAlpha = destAlpha * fillAlpha;
+  ctx.drawImage(aux, originX, originY);
+  ctx.restore();
+}
+
+/** Alpha (0..1) of an `rgb()/rgba()` colour string. The pptx text pipeline emits
+ *  colours via {@link hexToRgba} (`rgba(r,g,b,a)`); a 3-component `rgb()` or any
+ *  unparseable value is treated as opaque so it never routes into the #879 layer. */
+function rgbaAlpha(color: string): number {
+  const m = /^rgba?\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*([\d.]+)\s*\)$/i.exec(color);
+  if (!m) return 1;
+  const a = parseFloat(m[1]);
+  return Number.isFinite(a) ? Math.min(1, Math.max(0, a)) : 1;
+}
+
+/** Drop the alpha channel of an `rgb()/rgba()` colour, yielding an opaque
+ *  `rgb(r,g,b)`. Used to paint the #879 compositing layer at full opacity. */
+function opaqueRgba(color: string): string {
+  const m = /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/i.exec(color);
+  return m ? `rgb(${m[1]}, ${m[2]}, ${m[3]})` : color;
 }
 
 /** One strip of a glyph: flat sub-range `[s0, s1]` (css px from the glyph's flat
@@ -1894,6 +2022,7 @@ function renderWarpedText(
             bandFrac,
             boxX,
             boxY,
+            seg.color,
           );
           penW += chW;
           continue;

--- a/packages/pptx/tests/visual/warp-quality-fixture.html
+++ b/packages/pptx/tests/visual/warp-quality-fixture.html
@@ -24,13 +24,13 @@
     const BOX_W = 6.2 * 96;
     const BOX_H = 1.5 * 96;
 
-    function slideFor(preset, text, boxH) {
+    function slideFor(preset, text, boxH, color = '1F4E79') {
       const para = {
         alignment: 'ctr', marL: 0, marR: 0, indent: 0, spaceBefore: null, spaceAfter: null,
         spaceLine: null, lvl: 0, bullet: { type: 'none' }, defFontSize: null, defColor: null,
         defBold: null, defItalic: null, defFontFamily: null, tabStops: [], eaLnBrk: true,
         runs: [{ type: 'text', text, bold: true, italic: null, underline: false,
-          strikethrough: false, fontSize: 40, color: '1F4E79', fontFamily: 'Arial' }],
+          strikethrough: false, fontSize: 40, color, fontFamily: 'Arial' }],
       };
       const textBody = {
         verticalAnchor: 'ctr', paragraphs: [para], defaultFontSize: 40,
@@ -55,20 +55,24 @@
     }
 
     const CASES = [
-      // [id, preset (null = flat control), text, box height css px]
+      // [id, preset (null = flat control), text, box height css px, color]
       ['flat', null, 'Inflate', BOX_H],
       ['inflate', 'textInflate', 'Inflate', BOX_H],
       ['deflate', 'textDeflate', 'Deflate', BOX_H],
       ['cascade', 'textCascadeUp', 'Cascade', BOX_H],
       ['wave1', 'textWave1', 'Wave One', BOX_H],
       ['circlepour', 'textCirclePour', 'Round', 3 * 96],
+      // Translucent fills (8-digit RRGGBBAA, alpha 0x80 ≈ 50%) — the strip
+      // overlap must NOT double-compose into a darker band (issue #879).
+      ['inflate_a50', 'textInflate', 'Inflate', BOX_H, '1F4E7980'],
+      ['circlepour_a50', 'textCirclePour', 'Round', 3 * 96, '1F4E7980'],
     ];
 
     try {
       await document.fonts.ready;
       const timings = {};
-      for (const [id, preset, text, boxH] of CASES) {
-        const { slide, w, h } = slideFor(preset, text, boxH);
+      for (const [id, preset, text, boxH, color] of CASES) {
+        const { slide, w, h } = slideFor(preset, text, boxH, color);
         const canvas = document.createElement('canvas');
         canvas.id = id;
         document.body.appendChild(canvas);

--- a/packages/pptx/tests/visual/warp-strip-quality.spec.ts
+++ b/packages/pptx/tests/visual/warp-strip-quality.spec.ts
@@ -124,6 +124,51 @@ async function metricsFor(page: import('@playwright/test').Page, id: string): Pr
   }, id);
 }
 
+/**
+ * Double-composition band fraction of a TRANSLUCENT warped fill (issue #879).
+ *
+ * Over the opaque white page, a fill at alpha `a` composites once to luminance
+ * L1 = 255 − a·(255 − Lfill); the 1-device-px strip-overlap band composed it
+ * TWICE to L2 = 255 − a(2−a)·(255 − Lfill) < L1 before #879 (a darker pinstripe,
+ * measured across 28 % of Inflate / 71 % of CirclePour ink columns). Antialiased
+ * glyph edges only ever composite LESS ink so they are LIGHTER than L1 — the only
+ * source of a pixel darker than L1 is the double composition. Returns the
+ * fraction of solid ink darker than the L1/L2 midpoint (the band) and the darkest
+ * ink luminance. `fill` is the 6-digit hex the fixture drew at `alpha`.
+ */
+async function bandFractionFor(
+  page: import('@playwright/test').Page,
+  id: string,
+  fill: { r: number; g: number; b: number; a: number },
+): Promise<{ ink: number; band: number; minLum: number; l1: number; l2: number }> {
+  return page.evaluate(
+    ({ canvasId, f }) => {
+      const canvas = document.getElementById(canvasId) as HTMLCanvasElement;
+      const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+      const W = canvas.width;
+      const H = canvas.height;
+      const data = ctx.getImageData(0, 0, W, H).data;
+      const lFill = 0.299 * f.r + 0.587 * f.g + 0.114 * f.b;
+      const l1 = 255 - f.a * (255 - lFill);
+      const l2 = 255 - f.a * (2 - f.a) * (255 - lFill);
+      const bandCut = (l1 + l2) / 2;
+      const inkCut = (l1 + 255) / 2;
+      let ink = 0;
+      let band = 0;
+      let minLum = 255;
+      for (let p = 0; p < W * H; p++) {
+        const l = 0.299 * data[p * 4] + 0.587 * data[p * 4 + 1] + 0.114 * data[p * 4 + 2];
+        if (l >= inkCut) continue;
+        ink++;
+        if (l < minLum) minLum = l;
+        if (l < bandCut) band++;
+      }
+      return { ink, band: ink > 0 ? band / ink : 0, minLum, l1, l2 };
+    },
+    { canvasId: id, f: fill },
+  );
+}
+
 test('warp strips render clean in a real browser (stray ink / sharpness / seams)', async ({ page }) => {
   await page.goto('/tests/visual/warp-quality-fixture.html');
   await page.waitForFunction(() => document.body.dataset.status === 'ready', undefined, {
@@ -159,4 +204,35 @@ test('warp strips render clean in a real browser (stray ink / sharpness / seams)
   //    fan of radial slivers ("Round" = 5 single-piece letters; warped letters
   //    may merge or split at hairline joins, slivers are dozens).
   expect(results.circlepour.components, 'circlepour: ink components').toBeLessThanOrEqual(10);
+});
+
+test('translucent warp fill composites at a uniform alpha — no strip-overlap band (#879)', async ({
+  page,
+}) => {
+  await page.goto('/tests/visual/warp-quality-fixture.html');
+  await page.waitForFunction(() => document.body.dataset.status === 'ready', undefined, {
+    timeout: 30_000,
+  });
+
+  // The fixture drew these at RRGGBBAA = 1F4E7980 → rgb(31,78,121), alpha 128/255.
+  const fill = { r: 0x1f, g: 0x4e, b: 0x79, a: 0x80 / 255 };
+  const band: Record<string, Awaited<ReturnType<typeof bandFractionFor>>> = {};
+  for (const id of ['inflate_a50', 'circlepour_a50']) {
+    band[id] = await bandFractionFor(page, id, fill);
+  }
+  // eslint-disable-next-line no-console
+  console.log('[warp-quality-a50]', JSON.stringify(band, null, 1));
+
+  for (const id of ['inflate_a50', 'circlepour_a50']) {
+    const m = band[id];
+    expect(m.ink, `${id}: has translucent ink`).toBeGreaterThan(500);
+    // The double-composed overlap band is eliminated: essentially no ink pixel is
+    // darker than the single/double-composite midpoint. (Pre-#879 this was ~28 %
+    // of Inflate / ~71 % of CirclePour ink.)
+    expect(m.band, `${id}: double-composed band fraction`).toBeLessThan(0.02);
+    // Darkest ink stays near the single composite L1, never near the doubled L2.
+    expect(m.minLum, `${id}: darkest ink near single composite`).toBeGreaterThan(
+      (m.l1 + m.l2) / 2,
+    );
+  }
 });


### PR DESCRIPTION
## Problem

The paired-edge WordArt warp (`<a:prstTxWarp>`, ECMA-376 §20.1.9.19) draws each
glyph as vertical strips whose clip rects overlap by 1 device px to hide the
shared-edge antialiasing seam (introduced in #876). Painting an **opaque** colour
over itself in that overlap band is idempotent, so the band is seamless — but a
**translucent** fill (alpha < 1, from an 8-digit `RRGGBBAA` run colour or an
inherited shape opacity) composes the band **twice** and darkens it into a
visible pinstripe / moiré.

Measured over the opaque page background, a fill at alpha `a` composites once to
`L1 = 255 − a·(255 − Lfill)`, while the double-composed band reaches
`L2 = 255 − a(2−a)·(255 − Lfill) < L1`. A headless skia probe measures ~64% of
Inflate ink darkened at 50% alpha, matching the issue's browser report (28% of
Inflate / 71% of CirclePour ink columns).

## Fix

When the **effective** opacity (`fill alpha × ctx.globalAlpha`) is `< 1`, paint
the strips **opaque** into a per-glyph **device-resolution compositing layer**
(where the overlap is idempotent again) and composite the layer **once** with the
effective alpha — the direction the issue's adversarial review pointed at.

- The layer is rasterised under the **same device transform** as the live canvas
  (its origin is the base transform's device translation minus the ink AABB
  origin), so there is **no auxiliary-canvas re-magnification** — the layer is
  painted at final device resolution under the final transforms.
- The layer is bounded tightly to the measured ink rectangle **intersected with
  each strip's clip interval**, so side-bearing overhang on the outward-unbounded
  end strips still fits.
- **Fully-opaque WordArt** (the overwhelming majority) keeps the direct,
  zero-allocation strip draw **byte-identical**. A headless mock `ctx` with no
  aux canvas / live transform falls back to the direct draw too.

## Verification

| harness | preset | before | after |
|---|---|---|---|
| node skia probe (dpr 2) | Inflate | band 63.9%, minLum 80.4 | **band 0.00%, minLum 161.6 (= L1)** |
| node skia probe (dpr 2) | CirclePour | (banded) | **band 0.00%, minLum 161.5** |
| real browser (chromium, dpr 2) | Inflate / CirclePour | — | **band 0.00%, minLum 159.6** |

- `packages/pptx/tests/visual/warp-strip-quality.spec.ts` (the permanent browser
  gate from #876) now asserts a translucent Inflate/CirclePour fill composites to
  a uniform single alpha — verified passing in a real browser.
- `packages/node/src/pptx-text-warp.probe.test.ts` asserts the same headlessly
  (Red/Green confirmed by forcing the pre-fix direct path).
- Full pptx unit suite (388 tests) and the 6 opaque warp probes pass unchanged
  (opaque path is byte-identical); `tsc --build` clean; no new ast-grep warnings.

Closes #879