### PR TITLE
feat(pptx): apply duotone to picture-fill blips (#889)

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -2,6 +2,7 @@
 // All positions and sizes are in EMUs (English Metric Units).
 
 import type { MathNode } from './math';
+import type { Duotone } from '../image/duotone';
 
 export type PathCmd =
   | { cmd: 'moveTo';     x: number; y: number }
@@ -114,6 +115,14 @@ export interface ImageFill {
   tile?: TileInfo;
   /** `a:blip > a:alphaModFix@amt` as a fraction (0.0–1.0). Absent = opaque. */
   alpha?: number;
+  /**
+   * ECMA-376 §20.1.8.23 `<a:duotone>` recolour, resolved to its two endpoint
+   * colours (through the slide theme). Absent ⇒ no duotone. When present the
+   * renderer maps the blip's luminance ramp between the two colours (core
+   * `applyDuotone`) — the same recolour a `<p:pic>` duotone applies, wired onto
+   * the picture-FILL path (§20.1.8.14) by issue #889.
+   */
+  duotone?: Duotone;
 }
 
 export interface Shadow {

--- a/packages/node/src/duotone-render.test.ts
+++ b/packages/node/src/duotone-render.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { renderSlideNode } from './render';
 import type { NodeCanvasFactory } from './render';
-import type { Presentation, Slide, PictureElement } from '@silurus/ooxml-pptx';
+import type { Presentation, Slide, PictureElement, ImageFill } from '@silurus/ooxml-pptx';
 import { loadSkiaForTests } from './test-imports';
 
 // End-to-end pixel check for the DrawingML `<a:duotone>` recolour (§20.1.8.23)
@@ -53,6 +53,28 @@ function buildDuotoneSlide(duotone?: { clr1: string; clr2: string }): Presentati
     ...(duotone ? { duotone } : {}),
   };
   const slide: Slide = { index: 0, slideNumber: 1, background: null, elements: [pic] };
+  return {
+    slideWidth: px(400),
+    slideHeight: px(400),
+    slides: [slide],
+    defaultTextColor: null,
+    majorFont: null,
+    minorFont: null,
+  };
+}
+
+/** A slide whose whole-slide BACKGROUND is a stretched picture fill
+ *  (`Fill::Image`, §20.1.8.14), carrying (or not) a `<a:duotone>` recolour —
+ *  the latent path wired by issue #889. No elements: the background IS the ink. */
+function buildDuotoneBackgroundSlide(duotone?: { clr1: string; clr2: string }): Presentation {
+  const px = (n: number) => Math.round(n * EMU_PER_PX);
+  const background: ImageFill = {
+    fillType: 'image',
+    imagePath: PIC_IMAGE_PATH,
+    mimeType: 'image/png',
+    ...(duotone ? { duotone } : {}),
+  };
+  const slide: Slide = { index: 0, slideNumber: 1, background, elements: [] };
   return {
     slideWidth: px(400),
     slideHeight: px(400),
@@ -143,6 +165,44 @@ describe.skipIf(!skia)('node duotone picture rendering (§20.1.8.23)', () => {
     expect(Math.abs(dd[i + 2] - expected[2])).toBeLessThan(10);
     // Sanity: the recolour actually happened (moved away from neutral grey) and
     // is a pink (red channel dominant), matching the clr2 endpoint hue.
+    expect(dd[i]).toBeGreaterThan(dd[i + 1]);
+    expect(dd[i]).toBeGreaterThan(dd[i + 2]);
+    expect(Math.abs(dd[i] - 128)).toBeGreaterThan(15);
+  });
+
+  it('remaps a picture-FILL background along the luminance ramp (#889)', async () => {
+    // Same ramp math as the picture case, but the duotone rides a shape/background
+    // picture fill (Fill::Image) rather than a <p:pic>. This is the latent path
+    // #889 wires: before the fix the background decoded through the plain cache
+    // and stayed neutral grey.
+    const src = [128, 128, 128];
+    const t = luminance601(src[0], src[1], src[2]);
+    const clr1 = [0x00, 0x00, 0x00]; // black
+    const clr2 = [0xda, 0xb6, 0xba]; // light pink
+    const expected = clr1.map((d, i) => Math.round(d + (clr2[i] - d) * t));
+
+    const pngBytes = await flatPngBytes(16, 16, '#808080');
+    const plain = await renderToRgba(buildDuotoneBackgroundSlide(), pngBytes);
+    const duo = await renderToRgba(
+      buildDuotoneBackgroundSlide({ clr1: '000000', clr2: 'DAB6BA' }),
+      pngBytes,
+    );
+
+    // Sample the slide centre (px 200,200) — covered by the stretched background.
+    const { data: pd, width } = plain;
+    const { data: dd } = duo;
+    const i = (200 * width + 200) * 4;
+
+    // Plain background shows the untouched grey.
+    expect(Math.abs(pd[i] - 128)).toBeLessThan(6);
+    expect(Math.abs(pd[i + 1] - 128)).toBeLessThan(6);
+    expect(Math.abs(pd[i + 2] - 128)).toBeLessThan(6);
+
+    // Duotone background shows the ramp interpolation: a red-dominant pink within
+    // tolerance of the expected duotone value.
+    expect(Math.abs(dd[i] - expected[0])).toBeLessThan(10);
+    expect(Math.abs(dd[i + 1] - expected[1])).toBeLessThan(10);
+    expect(Math.abs(dd[i + 2] - expected[2])).toBeLessThan(10);
     expect(dd[i]).toBeGreaterThan(dd[i + 1]);
     expect(dd[i]).toBeGreaterThan(dd[i + 2]);
     expect(Math.abs(dd[i] - 128)).toBeGreaterThan(15);

--- a/packages/pptx/parser/src/fill.rs
+++ b/packages/pptx/parser/src/fill.rs
@@ -8,7 +8,7 @@
 use crate::theme::PptxSchemeResolver;
 use crate::types::*;
 use crate::{attr, attr_f64, attr_i64, attr_r, child, children_vec};
-use ooxml_common::blip::mime_from_ext;
+use ooxml_common::blip::{mime_from_ext, parse_blip_duotone};
 use std::collections::HashMap;
 
 /// Parse `<a:blip><a:alphaModFix amt="..."/></a:blip>` from a blipFill node
@@ -167,14 +167,26 @@ pub(crate) fn parse_fill(
 ///
 /// When neither child is present the blip defaults to full-box placement
 /// (stretch with no fillRect).
+///
+/// `theme` resolves the `<a:duotone>` (§20.1.8.23) endpoint colours through the
+/// slide palette (PowerPoint linear tint), so a picture FILL recolours exactly
+/// like a `<p:pic>` picture element does.
 pub(crate) fn parse_blip_fill<F: FnMut(&str) -> Option<String>>(
     blip_fill: roxmltree::Node<'_, '_>,
+    theme: &HashMap<String, String>,
     resolve_blip: &mut F,
 ) -> Option<Fill> {
     let r_id = child(blip_fill, "blip").and_then(|b| attr_r(&b, "embed"))?;
     let image_path = resolve_blip(&r_id)?;
     let mime_type = mime_from_ext(&image_path).to_owned();
     let alpha = parse_blip_alpha(blip_fill);
+    // §20.1.8.23 duotone recolour, resolved through the theme with PowerPoint's
+    // linear tint (same call the `<p:pic>` paths use). `None` ⇒ no effect.
+    let duotone = parse_blip_duotone(
+        blip_fill,
+        &PptxSchemeResolver { theme },
+        ooxml_common::color::TintMode::PowerPointLinear,
+    );
     // §20.1.8.58 tile takes precedence when present (stretch/tile are an
     // either-or choice in CT_BlipFillProperties).
     if let Some(tile_node) = child(blip_fill, "tile") {
@@ -184,6 +196,7 @@ pub(crate) fn parse_blip_fill<F: FnMut(&str) -> Option<String>>(
             fill_rect: None,
             tile: Some(parse_tile(tile_node)),
             alpha,
+            duotone,
         });
     }
     let fill_rect = child(blip_fill, "stretch").and_then(parse_fill_rect);
@@ -193,6 +206,7 @@ pub(crate) fn parse_blip_fill<F: FnMut(&str) -> Option<String>>(
         fill_rect,
         tile: None,
         alpha,
+        duotone,
     })
 }
 
@@ -560,7 +574,7 @@ pub(crate) fn parse_background<F: FnMut(&str) -> Option<String>>(
         // first so the embedded blip is resolved; fall back to the generic
         // solid/gradient/pattern parser for non-image bgPr fills.
         if let Some(blip_fill) = child(bg_pr, "blipFill") {
-            if let Some(fill) = parse_blip_fill(blip_fill, resolve_blip) {
+            if let Some(fill) = parse_blip_fill(blip_fill, theme, resolve_blip) {
                 return Some(fill);
             }
         }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1787,6 +1787,7 @@ mod tests {
             fill_rect: None,
             tile: None,
             alpha: None,
+            duotone: None,
         };
         let json = serde_json::to_string(&fill).unwrap();
         assert!(
@@ -2288,6 +2289,7 @@ mod tests {
                 fill_rect,
                 tile,
                 alpha,
+                duotone: _,
             } => {
                 assert_eq!(image_path, "ppt/media/image1.jpeg");
                 assert_eq!(mime_type, "image/jpeg");
@@ -2297,6 +2299,71 @@ mod tests {
                 assert!(is_zero_f64(&fr.l) && is_zero_f64(&fr.r));
                 assert!(tile.is_none(), "stretch fill must not carry tile");
                 assert!((alpha.expect("alpha") - 0.8).abs() < 1e-6);
+            }
+            other => panic!("expected Fill::Image, got {other:?}"),
+        }
+    }
+
+    /// ECMA-376 §20.1.8.23 — a background `<a:blipFill>` whose `<a:blip>` carries
+    /// a `<a:duotone>` surfaces the resolved endpoint colours onto
+    /// `Fill::Image.duotone` (through the theme), so a picture FILL recolours like
+    /// a `<p:pic>`. Guards issue #889 (duotone was latent on the Fill::Image path).
+    #[test]
+    fn test_parse_background_blip_fill_duotone() {
+        let xml = r#"<p:cSld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+            <p:bg><p:bgPr>
+                <a:blipFill>
+                    <a:blip r:embed="rId2">
+                        <a:duotone>
+                            <a:prstClr val="black"/>
+                            <a:schemeClr val="accent1"/>
+                        </a:duotone>
+                    </a:blip>
+                    <a:stretch><a:fillRect/></a:stretch>
+                </a:blipFill>
+            </p:bgPr></p:bg>
+        </p:cSld>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let mut theme = HashMap::new();
+        theme.insert("accent1".to_string(), "4472C4".to_string());
+        let mut resolve = |rid: &str| -> Option<String> {
+            assert_eq!(rid, "rId2");
+            Some("ppt/media/image1.png".to_owned())
+        };
+        let fill = parse_background(doc.root_element(), &theme, &mut resolve)
+            .expect("blip background should resolve to Fill::Image");
+        match fill {
+            Fill::Image { duotone, .. } => {
+                let duo = duotone.expect("duotone must surface on the Fill::Image");
+                assert_eq!(duo.clr1, "000000", "clr1 = black prstClr");
+                assert_eq!(duo.clr2, "4472C4", "clr2 = accent1 resolved from theme");
+            }
+            other => panic!("expected Fill::Image, got {other:?}"),
+        }
+    }
+
+    /// A background `<a:blipFill>` without a `<a:duotone>` leaves
+    /// `Fill::Image.duotone` None, so non-duotone backgrounds stay byte-identical.
+    #[test]
+    fn test_parse_background_blip_fill_without_duotone_is_none() {
+        let xml = r#"<p:cSld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+            <p:bg><p:bgPr>
+                <a:blipFill><a:blip r:embed="rId2"/><a:stretch><a:fillRect/></a:stretch></a:blipFill>
+            </p:bgPr></p:bg>
+        </p:cSld>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let theme = HashMap::new();
+        let mut resolve =
+            |_rid: &str| -> Option<String> { Some("ppt/media/image1.png".to_owned()) };
+        let fill = parse_background(doc.root_element(), &theme, &mut resolve)
+            .expect("blip background should resolve to Fill::Image");
+        match fill {
+            Fill::Image { duotone, .. } => {
+                assert!(duotone.is_none(), "duotone must be None when absent");
             }
             other => panic!("expected Fill::Image, got {other:?}"),
         }

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -15,13 +15,13 @@ use crate::text::{
     merge_level_bullets, merge_level_indents, merge_level_sizes, read_level_bullets,
     read_level_font_sizes, read_level_indents, LevelBullets, LevelFontSizes, LevelIndents,
 };
-use crate::theme::{bake_clr_map, parse_theme_colors};
+use crate::theme::{bake_clr_map, parse_theme_colors, PptxSchemeResolver};
 use crate::types::*;
 use crate::{
     attr, attr_f64, attr_i64, attr_r, build_smartart_drawings, child, find_rel_target_by_type,
     note_layout_master_parse, parse_rels, read_zip_str, resolve_path, PptxZip,
 };
-use ooxml_common::blip::{mime_from_ext, parse_src_rect, SrcRect};
+use ooxml_common::blip::{mime_from_ext, parse_blip_duotone, parse_src_rect, Duotone, SrcRect};
 use ooxml_common::depth::parse_guarded;
 use std::collections::HashMap;
 
@@ -127,6 +127,10 @@ pub(crate) struct InheritedBlipFill {
     pub(crate) mime_type: String,
     pub(crate) src_rect: Option<SrcRect>,
     pub(crate) alpha: Option<f64>,
+    /// ECMA-376 §20.1.8.23 `<a:duotone>` recolour on the layout placeholder's
+    /// blipFill, resolved through the theme. Inherited onto the slide picture
+    /// placeholder that omits its own blipFill (see `shape.rs`).
+    pub(crate) duotone: Option<Duotone>,
 }
 
 impl LayoutPlaceholders {
@@ -1171,6 +1175,13 @@ pub(crate) fn parse_layout_placeholders(
                 mime_type,
                 src_rect: parse_src_rect(bf),
                 alpha: parse_blip_alpha(bf),
+                // §20.1.8.23 duotone on the layout placeholder blipFill, resolved
+                // through the theme; inherited onto the slide picture placeholder.
+                duotone: parse_blip_duotone(
+                    bf,
+                    &PptxSchemeResolver { theme },
+                    ooxml_common::color::TintMode::PowerPointLinear,
+                ),
             })
         });
 

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -1698,13 +1698,11 @@ pub(crate) fn parse_sp_tree_node(
                                     prst_adjust: None,
                                     src_rect: bf.src_rect,
                                     alpha: bf.alpha,
-                                    // An inherited layout-placeholder blipFill
-                                    // (LayoutPlaceholders::lookup_blip_fill) does not
-                                    // yet carry a `<a:duotone>`; picture placeholders
-                                    // with a duotone are rare, so None matches prior
-                                    // behaviour (thread it through BlipFill if a
-                                    // sample needs it, alongside svg_image_path above).
-                                    duotone: None,
+                                    // §20.1.8.23 duotone inherited from the layout
+                                    // placeholder's blipFill (resolved through the
+                                    // theme in InheritedBlipFill); the PictureElement
+                                    // render applies it via the shared core cache.
+                                    duotone: bf.duotone,
                                     cust_geom: None,
                                     shadow: None,
                                     inner_shadow: None,

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -686,6 +686,14 @@ pub(crate) enum Fill {
         /// `a:blip > a:alphaModFix@amt` as a fraction (0.0–1.0). None = opaque.
         #[serde(skip_serializing_if = "Option::is_none")]
         alpha: Option<f64>,
+        /// ECMA-376 §20.1.8.23 `<a:duotone>` recolour effect, resolved to its two
+        /// endpoint colours through the slide theme (PowerPoint linear tint).
+        /// `None` = no duotone. When present the renderer maps the blip's
+        /// luminance ramp between the two colours (core `applyDuotone`), matching
+        /// how a `<p:pic>` duotone recolours — a shared blip effect that a
+        /// picture FILL (§20.1.8.14) may carry just as a picture element can.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        duotone: Option<Duotone>,
     },
 }
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -1182,9 +1182,13 @@ async function renderBackground(
     try {
       // Size the metafile raster from the fill box (canvasW/H are CSS px;
       // scale is px-per-EMU, so px/scale = EMU, /PT_TO_EMU = pt).
-      const bitmap = await getCachedBitmapByPath(
+      // §20.1.8.23 duotone recolour on the raster blip (issue #889): route
+      // through the shared duotone cache (keyed by path + colours). No duotone ⇒
+      // this is exactly the former `getCachedBitmapByPath` decode, byte-identical.
+      const bitmap = await getCachedDuotoneBitmapByPath(
         fill.imagePath,
         fill.mimeType,
+        fill.duotone,
         fetchImage,
         {
           widthPt: canvasW / scale / PT_TO_EMU,


### PR DESCRIPTION
## Problem

PR #888 wired the shared blip-duotone layer (§20.1.8.23) into `<p:pic>` picture
elements in all three formats, but pptx **picture fills** never applied it:

- **`Fill::Image`** — shape / slide-background blip fills (`<a:blipFill>`,
  §20.1.8.14) — carried no `duotone`.
- The **inherited layout-placeholder blipFill** path (`shape.rs`) carried a
  literal `duotone: None` with a "rare, so None" comment.

A duotone outside a `<p:pic>` is **latent** (zero corpus occurrences across the
full fixture scans in #885/#888), but the shared parser
(`ooxml_common::blip::parse_blip_duotone`) makes the wiring thin, so a real file
now recolours instead of silently dropping the effect.

## Fix

**Parser**
- `Fill::Image` gains a `duotone` field; `parse_blip_fill` resolves `<a:duotone>`
  through the theme with PowerPoint's linear tint (the exact call the `<p:pic>`
  paths use), threading the theme from `parse_background`.
- `InheritedBlipFill` gains a `duotone` field, resolved where the layout
  placeholder blipFill is parsed; `shape.rs` now inherits `bf.duotone` onto the
  slide picture placeholder's `PictureElement` instead of `None`.

**Renderer**
- The background image-fill decode routes through the shared
  `getCachedDuotoneBitmapByPath` (keyed by path + colours, under the #915 lease
  contract), and core `ImageFill` gains the `duotone` field. The
  inherited-placeholder case reuses the existing `PictureElement` duotone render.
- **No duotone ⇒ both paths are byte-identical** to the former plain-cache decode
  (`getCachedDuotoneBitmapByPath` passes straight through the base cache).

## Verification

- **Rust unit tests**: a background `<a:blipFill>` with `<a:duotone>` surfaces the
  two theme-resolved endpoints on `Fill::Image.duotone` (`black`→`accent1` =
  `000000`→`4472C4`); without one it stays `None`. `cargo test` **160 passed**,
  `cargo fmt --check` clean, `cargo clippy -D warnings` clean, `wasm-pack build`
  clean.
- **Node skia render probe**: a picture-FILL background carrying `black↔#DAB6BA`
  over a mid-grey source renders the exact luminance-ramp interpolation (measured
  R≈109, t≈0.502) — **Red/Green confirmed** by reverting the renderer to the
  plain cache (grey stays 128, fails).
- **core+pptx vitest (1941) pass**; root `tsc --build` clean; no new ast-grep
  warnings. The `duotone` field is `skip_serializing_if = "Option::is_none"`, so
  non-duotone parse output stays byte-identical (demo VRT non-regression by
  construction — latent effect, no corpus occurrences).

Closes #889