### PR TITLE
fix(docx): collapse inkless vanished-mark paragraphs to zero height (§17.3.2.41)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2527,6 +2527,13 @@ fn parse_paragraph_cond(
             .keep_next
             .unwrap_or_else(|| base_para.outline_level.is_some()),
         keep_lines: base_para.keep_lines.unwrap_or(false),
+        // ECMA-376 §17.3.1.29 + §17.3.2.41 — the paragraph mark's resolved
+        // `w:vanish`. `mark_run` is the mark-glyph run formatting (style chain +
+        // direct pPr/rPr), the same source that already feeds `default_font_size`
+        // and that the run stripper reads. An inkless paragraph with a vanished
+        // mark is not displayed in the normal/print view, so the renderer
+        // collapses it to zero height.
+        mark_vanish: mark_run.vanish.unwrap_or(false),
         // ECMA-376 §17.3.1.44: widowControl defaults to true when absent.
         widow_control: base_para.widow_control.unwrap_or(true),
         borders: base_para.para_borders.clone(),
@@ -9525,6 +9532,34 @@ mod para_mark_rpr_tests {
             t.bold,
             "the webHidden page number still inherits style bold"
         );
+    }
+
+    // ECMA-376 §17.3.1.29 + §17.3.2.41 — a `<w:vanish/>` on the paragraph-mark
+    // rPr is captured on `mark_vanish`, so the renderer can collapse an inkless
+    // vanished-mark paragraph to zero height in the normal/print view (issue
+    // #868: a run of empty vanished ListParagraphs otherwise forced an extra
+    // page). Absent ⇒ false.
+    #[test]
+    fn para_mark_vanish_is_captured() {
+        let sm = style_map();
+        let hidden = parse_p(r#"<w:pPr><w:rPr><w:vanish/></w:rPr></w:pPr>"#, &sm);
+        assert!(
+            hidden.mark_vanish,
+            "an empty paragraph's vanished mark is recorded"
+        );
+        assert!(hidden.runs.is_empty(), "the paragraph is inkless");
+
+        let visible = parse_p(r#"<w:pPr/><w:r><w:t>x</w:t></w:r>"#, &sm);
+        assert!(!visible.mark_vanish, "no w:vanish on the mark ⇒ false");
+    }
+
+    // §17.3.2.44 webHidden on the paragraph mark is NOT §17.3.2.41 vanish: it
+    // renders in the normal/print view, so it must NOT set `mark_vanish`.
+    #[test]
+    fn para_mark_web_hidden_does_not_set_vanish() {
+        let sm = style_map();
+        let p = parse_p(r#"<w:pPr><w:rPr><w:webHidden/></w:rPr></w:pPr>"#, &sm);
+        assert!(!p.mark_vanish, "webHidden mark is not vanish");
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -592,6 +592,12 @@ pub struct DocParagraph {
     /// Keep all lines of this paragraph on the same page (w:keepLines)
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub keep_lines: bool,
+    /// ECMA-376 §17.3.1.29 + §17.3.2.41 — the paragraph MARK's resolved `w:vanish`
+    /// (hidden text). An inkless paragraph whose mark is vanished collapses to zero
+    /// height in the normal/print view (hidden-text off), the same way a hidden run
+    /// is stripped; the renderer's paginator drops it whole.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub mark_vanish: bool,
     /// Widow/orphan control (w:widowControl). Default per spec: true.
     pub widow_control: bool,
     /// Paragraph borders (w:pBdr)

--- a/packages/docx/src/pagination.test.ts
+++ b/packages/docx/src/pagination.test.ts
@@ -65,6 +65,7 @@ function para(
     spaceBefore?: number;
     spaceAfter?: number;
     indentFirst?: number;
+    markVanish?: boolean;
   } = {},
 ): BodyElement {
   const fontSize = opts.fontSize ?? 20;
@@ -76,6 +77,7 @@ function para(
     widowControl: opts.widowControl,
     keepLines: opts.keepLines,
     keepNext: opts.keepNext,
+    markVanish: opts.markVanish,
   };
   return { type: 'paragraph', ...p } as BodyElement;
 }
@@ -1810,5 +1812,68 @@ describe('computePages — keepNext at a balanced column boundary (§17.3.1.15)'
     const p1 = pages[0].find((e) => textOf(e) === 'p1');
     expect(p1).toBeDefined();
     expect(colOf(p1 as PaginatedBodyElement) ?? 0).toBe(0); // stays in col0
+  });
+});
+
+describe('computePages — vanished (hidden) empty-paragraph mark collapse (§17.3.2.41 / §17.3.1.29)', () => {
+  // ECMA-376 §17.3.1.29: a paragraph's mark has run properties. §17.3.2.41
+  // `w:vanish` hides a run in the normal/print view (hidden-text off, the view a
+  // Word PDF export renders). An INKLESS paragraph whose MARK is vanished is
+  // therefore not displayed at all: it must contribute no mark line and no
+  // paragraph spacing — the mark analogue of the parser stripping hidden runs.
+  // sample-28 (issue #868): a run of empty vanished ListParagraphs otherwise
+  // reserved ~156px and forced one extra page (24 vs Word's 23).
+  //
+  // Content height = pageHeight 140 − margins 40 = 100pt; fontSize 20 → each
+  // single line / empty mark = 20pt (stub font box 0.8/0.2 em, no grid/spacing),
+  // so exactly five single-line paragraphs fill one page.
+  const visible = () => [
+    para({ text: 'a', fontSize: 20 }),
+    para({ text: 'b', fontSize: 20 }),
+    para({ text: 'c', fontSize: 20 }),
+    para({ text: 'd', fontSize: 20 }),
+    para({ text: 'e', fontSize: 20 }),
+  ];
+
+  it('collapses inkless vanished-mark paragraphs to zero height (identical to their absence)', () => {
+    const reference = computePages(
+      [...visible().slice(0, 4), visible()[4]], // 5 visible paragraphs, no empties
+      section(),
+      makeCtx(),
+    );
+    const withVanish = computePages(
+      [
+        ...visible().slice(0, 4),
+        para({ markVanish: true, spaceAfter: 8, fontSize: 20 }),
+        para({ markVanish: true, spaceAfter: 8, fontSize: 20 }),
+        para({ markVanish: true, spaceAfter: 8, fontSize: 20 }),
+        visible()[4],
+      ],
+      section(),
+      makeCtx(),
+    );
+    // The three vanished empties consume nothing: the fifth visible paragraph
+    // lands on the same (single) page it would occupy without them.
+    expect(reference.length).toBe(1);
+    expect(withVanish.length).toBe(reference.length);
+    // The fifth visible paragraph ('e') is on the first (only) page.
+    expect(withVanish[0].some((el) => textOf(el) === 'e')).toBe(true);
+  });
+
+  it('control: ORDINARY empty paragraphs (mark not vanished) still reserve height and add a page', () => {
+    const withOrdinaryEmpties = computePages(
+      [
+        ...visible().slice(0, 4),
+        para({ spaceAfter: 8, fontSize: 20 }),
+        para({ spaceAfter: 8, fontSize: 20 }),
+        para({ spaceAfter: 8, fontSize: 20 }),
+        visible()[4],
+      ],
+      section(),
+      makeCtx(),
+    );
+    // Not a tautology: three non-vanished empties push the fifth visible past the
+    // first page.
+    expect(withOrdinaryEmpties.length).toBeGreaterThan(1);
   });
 });

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2814,6 +2814,21 @@ export function computePages(
         pushTagged(el as PaginatedBodyElement);
         continue;
       }
+      // ECMA-376 §17.3.1.29 + §17.3.2.41: an inkless paragraph whose MARK is
+      // vanished is hidden in the normal/print view (settings hidden-text off) —
+      // it contributes NO mark line, NO spacing, and paints nothing, the mark
+      // analogue of the parser stripping hidden runs. Skip it whole: add no height
+      // and leave prevPara/prevSpaceAfter as the paragraph BEFORE it, so its
+      // neighbours collapse spacing against each other (Word treats it as absent).
+      // Still pushed+stamped so the per-page element sequence is unchanged and the
+      // paint pass mirrors the skip. (sample-28, issue #868: a run of seven
+      // vanished empty ListParagraphs otherwise reserved ~156px and forced one
+      // extra page.)
+      if (isFullyHiddenParagraph(para)) {
+        (el as PaginatedBodyElement).hiddenCollapsed = true;
+        pushTagged(el as PaginatedBodyElement);
+        continue;
+      }
       const suppressBefore = contextual || spacer;
 
       // An empty paragraph that immediately precedes a COLLAPSED continuous spacer
@@ -4358,6 +4373,11 @@ function estimateParagraphHeight(
    *  its bottom edge is suppressed (the box continues) and reserves no extent. */
   nextSharesBottomBorder = false,
 ): number {
+  // ECMA-376 §17.3.1.29 + §17.3.2.41: a fully-hidden paragraph (inkless +
+  // vanished mark) collapses to zero height, so every look-ahead estimate
+  // (keepNext's estimateNextBlockHeight, the inline-image-cluster scan) that
+  // folds one in stays in lockstep with the paginator's whole-skip above.
+  if (isFullyHiddenParagraph(para)) return 0;
   return paragraphHeightFromMeasured(
     measureBodyParagraphAtCursor(state, para, contentWPt, suppressSpaceBefore, paraXPt),
     para,
@@ -6216,6 +6236,22 @@ function isInklessParagraph(p: DocParagraph): boolean {
   });
 }
 
+/**
+ * ECMA-376 §17.3.1.29 + §17.3.2.41 — a paragraph with no visible inline content
+ * whose paragraph MARK is vanished (hidden text). In the normal/print view
+ * (settings hidden-text off — the view a Word PDF export renders) it is not
+ * displayed at all, so it collapses to zero height: no mark line box, no
+ * paragraph spacing, nothing painted. This is the paragraph-mark analogue of the
+ * parser stripping hidden runs (`fmt.vanish` in parser.rs): a run of such empty
+ * vanished paragraphs must not reserve vertical space (sample-28, issue #868 —
+ * seven of them otherwise forced one extra page). A paragraph with VISIBLE
+ * content and a vanished mark is NOT collapsed (it is not inkless): its content
+ * still draws, only the pilcrow is hidden.
+ */
+function isFullyHiddenParagraph(p: DocParagraph): boolean {
+  return p.markVanish === true && isInklessParagraph(p);
+}
+
 function isAnchorOnlyParagraph(p: DocParagraph): boolean {
   let hasAnchor = false;
   for (const r of p.runs ?? []) {
@@ -6510,6 +6546,11 @@ function renderBodyElements(
       // section's first paragraph spaces against that paragraph. Mirrors the
       // paginator's identical skip so fill and paint stay in lockstep.
       if ((el as PaginatedBodyElement).collapsedSpacer) continue;
+      // ECMA-376 §17.3.1.29 + §17.3.2.41: a fully-hidden paragraph (inkless +
+      // vanished mark) the paginator collapsed to zero height paints nothing and
+      // advances y by nothing, leaving prevPara/prevSpaceAfter as the paragraph
+      // BEFORE it — the paint mirror of the paginator's identical skip.
+      if ((el as PaginatedBodyElement).hiddenCollapsed) continue;
       const contextual = contextualSuppressed(prevPara, para);
       // Empty section-break spacer: drop only its own before (see
       // isSectionBreakSpacerAt); contextualSpacing drops the previous after too.

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -438,6 +438,11 @@ export type PaginatedBodyElement = BodyElement & {
    *  paint cannot re-derive the adjacency from its per-page slice. Runtime-only. See
    *  `leadsCollapsedRun` in renderer.ts. */
   leadsCollapsedRun?: boolean;
+  /** ECMA-376 §17.3.1.29 + §17.3.2.41 — a fully-hidden paragraph (inkless AND its
+   *  mark is vanished) that the paginator collapsed to zero height. Stamped so the
+   *  paint pass skips it in lockstep, exactly like `collapsedSpacer`. Runtime-only.
+   *  See `isFullyHiddenParagraph` in renderer.ts. */
+  hiddenCollapsed?: boolean;
   colIndex?: number;
   /** ECMA-376 §17.6.4 — the column geometry of the SECTION this element belongs
    *  to (per-section newspaper columns). Stamped by the paginator so the renderer
@@ -555,6 +560,11 @@ export interface DocParagraph {
   keepNext?: boolean;
   /** Keep all lines of this paragraph on the same page (w:keepLines) */
   keepLines?: boolean;
+  /** ECMA-376 §17.3.1.29 + §17.3.2.41 — the paragraph MARK's resolved `w:vanish`
+   *  (hidden text). An inkless paragraph whose mark is vanished collapses to zero
+   *  height in the normal/print view (hidden-text off), the same way the parser
+   *  strips hidden runs; the paginator drops it whole. Absent = mark is visible. */
+  markVanish?: boolean;
   /** Widow/orphan control (w:widowControl). ECMA-376 default is true. */
   widowControl?: boolean;
   /** Paragraph borders (w:pBdr) */

--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -28,7 +28,7 @@ const DOCX_FILES: { name: string; pageCount: number; width: number }[] = [
   // sample-27 = continuous section-break page-number restart fixture (US Letter, 612pt).
   { name: 'private/sample-27', pageCount: 2, width: 612 },
   // sample-28 = Arabic RTL long-form (A4).
-  { name: 'private/sample-28', pageCount: 24, width: 595 },
+  { name: 'private/sample-28', pageCount: 23, width: 595 },
   // sample-29 = Thai script (A4).
   { name: 'private/sample-29', pageCount: 14, width: 595 },
   // sample-30 = Korean script (A4).


### PR DESCRIPTION
## Problem

A long right-to-left form document rendered **one page longer than its Word PDF
ground truth**. The reworked fragment/split pagination basis (PRs #919/#923/#926)
had changed the symptom since the issue was filed, so the original diagnosis was
re-verified against current `main` before implementing.

Re-diagnosis (page-by-page against the Word PDF): every page aligned up to a point
where our output inserted one extra page carrying only two trailing bullet-list
items. Tracing upward, the real divergence was a **~182px phantom gap** where Word
leaves ~26px — a run of **seven empty paragraphs whose paragraph MARK carries
`<w:vanish/>`** (used as invisible spacers). Word collapses them to zero height in
the normal/print view (hidden text off — the view a PDF export renders); our
renderer reserved a full mark line plus spacing for each, pushing a numbered list
onto the next page and cascading one extra page.

## Root cause

ECMA-376 §17.3.1.29 — a paragraph mark has run properties. §17.3.2.41 `w:vanish`
hides a run in every non-web view. The parser already **strips hidden runs**, but
the symmetric rule for the paragraph MARK was missing: an inkless paragraph whose
mark is vanished should contribute no line box and no spacing at all.

## Fix

- **Parser** (`packages/docx/parser`): expose the resolved paragraph-mark
  `w:vanish` on `DocParagraph.mark_vanish`, from the same style-resolved mark run
  that already feeds the empty-paragraph font metrics.
- **Renderer** (`packages/docx/src/renderer.ts`): `isFullyHiddenParagraph`
  (inkless + `markVanish`) is dropped whole by the paginator — no mark line, no
  spacing, nothing painted — leaving neighbours to collapse spacing against each
  other. This mirrors the existing collapsed-spacer skip in both the fill and
  paint passes. `estimateParagraphHeight` returns 0 for it so keepNext /
  inline-image-cluster look-aheads stay in lockstep.

A paragraph with visible content and a vanished mark is unaffected (not inkless):
its content still draws, only the pilcrow is hidden. Spec-first; no heuristics.

## Verification

- New `computePages` unit tests pin the collapse, plus a control proving ordinary
  empty paragraphs still reserve height; new Rust tests pin `mark_vanish` capture
  and that `webHidden` (§17.3.2.44) does **not** set it.
- The affected document now paginates to the **same page count as its Word PDF**,
  content aligned page for page.
- docx unit suite (1202) green; parser `cargo test` (329) green; `cargo clippy` /
  `cargo fmt` clean; root `pnpm typecheck` green.
- Local docx VRT: only the affected sample moves (by design, toward the Word
  layout — its private references are stale for the shifted pages and need
  regeneration under `UPDATE_REFS=1`, left to the maintainer). One unrelated demo
  page's sub-pixel antialiasing delta was confirmed to reproduce **identically on
  unmodified `main`** in this environment, so it is environmental, not caused by
  this change.

Closes #868