### PR TITLE
fix(pptx): seat RTL list marker at the leading edge, not |indent| past it

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -3250,17 +3250,50 @@ export function renderTextBody(
     }
     const baseline = cursorY + maxAscent;
 
-    // Draw bullet. Under RTL the bullet hangs in the right gutter: mirror its
-    // LTR offset (textX − bulletX, i.e. the bullet→text gap) about the text
-    // column's right edge.
+    // Reading-frame marker placement under an RTL base (issue #930, same class as
+    // the docx #830 / pptx #913 leading-edge mirroring). PowerPoint seats a list
+    // marker's LEADING edge — the RIGHT edge in RTL — at the line's leading
+    // (right) edge and lays the text CONTIGUOUSLY to its left, so `text right =
+    // leadingEdge − markerAdvance` (verified on the sample PDF: the "1." and "•"
+    // markers share one right edge, each text right edge = that edge minus the
+    // marker's own width). The prior code mirrored the LTR hanging gutter about
+    // the text's right edge — `+ (textX − bulletX)` = `+|indent|` — which pushed
+    // the marker |indent| PAST the leading edge into the right margin (the
+    // far-frame over-indent this fixes), most visibly for a NARROW bullet whose
+    // gap to the text then equalled the whole hanging indent.
+    //
+    // `leadingEdgeX` is the RTL reading start (= the `algn:'r'` right edge). The
+    // marker advance is reserved so the pen below right-aligns the text to
+    // `leadingEdgeX − reserve`; 0 for LTR / marker-less lines keeps them
+    // byte-identical.
+    const leadingEdgeX = textX + textMaxW;
+    let rtlMarkerReservePx = 0;
+    let rtlBulletBmp: ReturnType<typeof peekCachedBitmapByPath> | null = null;
+    if (paraNeedsBidi && baseRtl) {
+      if (bulletLabel) {
+        ctx.font = bulletFont;
+        rtlMarkerReservePx = ctx.measureText(bulletLabel).width;
+      } else if (bulletImage && fetchImage) {
+        rtlBulletBmp = peekCachedBitmapByPath(bulletImage.imagePath, fetchImage);
+        if (rtlBulletBmp) {
+          const h = bulletImage.sizePx;
+          rtlMarkerReservePx = rtlBulletBmp.height > 0
+            ? h * (rtlBulletBmp.width / rtlBulletBmp.height)
+            : h;
+        }
+      }
+    }
+
+    // Draw bullet.
     if (bulletLabel) {
       ctx.font = bulletFont;
       ctx.fillStyle = bulletColor;
       if (paraNeedsBidi && baseRtl) {
         const prevDir = ctx.direction;
         ctx.direction = 'rtl';
-        const bulletW = ctx.measureText(bulletLabel).width;
-        ctx.fillText(bulletLabel, textX + textMaxW + (textX - bulletX) - bulletW, baseline);
+        // Marker RIGHT edge at the leading edge; its left edge tucks the text
+        // that the pen shifts left by `rtlMarkerReservePx` (= this width).
+        ctx.fillText(bulletLabel, leadingEdgeX - rtlMarkerReservePx, baseline);
         ctx.direction = prevDir;
       } else {
         ctx.fillText(bulletLabel, bulletX, baseline);
@@ -3284,9 +3317,9 @@ export function renderTextBody(
         const w = bmp.height > 0 ? h * (bmp.width / bmp.height) : h;
         const imgY = baseline - h; // bottom-aligned to the baseline
         if (paraNeedsBidi && baseRtl) {
-          // Mirror into the right gutter, matching the char-bullet RTL offset.
-          const imgX = textX + textMaxW + (textX - bulletX) - w;
-          ctx.drawImage(bmp, imgX, imgY, w, h);
+          // Marker RIGHT edge at the leading edge (matching the char-bullet
+          // reading-frame placement above); the text pen reserves this width.
+          ctx.drawImage(bmp, leadingEdgeX - w, imgY, w, h);
         } else {
           ctx.drawImage(bmp, bulletX, imgY, w, h);
         }
@@ -3298,7 +3331,11 @@ export function renderTextBody(
     if (alignment === 'ctr') {
       penX = effectiveTextX + (textMaxW - textXOffset - lineWidth) / 2;
     } else if (alignment === 'r') {
-      penX = textX + textMaxW - lineWidth;
+      // Reading-frame (#930): an RTL marker leads at the right edge, so the text
+      // right-aligns to `leadingEdge − markerAdvance` (contiguous with the
+      // marker). `rtlMarkerReservePx` is 0 for non-list / marker-less lines, so
+      // plain RTL paragraphs keep `leadingEdge − lineWidth` (byte-identical).
+      penX = textX + textMaxW - rtlMarkerReservePx - lineWidth;
     } else {
       penX = effectiveTextX;
     }

--- a/packages/pptx/src/rtl-bullet-indent.test.ts
+++ b/packages/pptx/src/rtl-bullet-indent.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody } from './renderer.js';
+import type { TextBody, Paragraph, Bullet } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+// ECMA-376 §21.1.2.2.7 (a:pPr@rtl) + §21.1.2.4.x (a:buChar / a:buAutoNum) — a list
+// MARKER in a right-to-left paragraph must lead at the RIGHT (the reading start),
+// with the text following CONTIGUOUSLY to its left. Issue #930 (same reading-frame
+// class as the RTL tab-stop fix #831/#913 and docx #830): the marker draw mirrored
+// the LTR hanging gutter about the text's right edge —
+// `textX + textMaxW + (textX − bulletX) − markerW`, i.e. it added the whole
+// `|indent|` — which pushed the marker |indent| PAST the leading edge into the
+// right margin (the "far-frame over-indent"). PowerPoint instead seats the
+// marker's RIGHT edge on the line's leading (right) edge and right-aligns the text
+// to `leadingEdge − markerAdvance`, so the words render adjacent to the marker.
+//
+// The bug was most visible for a NARROW bullet (its gap to the text equalled the
+// full hanging indent) but applied to autoNum markers too; the fix corrects both.
+//
+// The mock ctx measures every glyph at the active font's px size, so widths and
+// x are exact. It also records the font at each fillText so the marker's advance
+// (and hence its right edge) is recoverable.
+
+const FONT_PX = 20;
+const SCALE = 1 / 12700; // emuToPx(emu) = emu·SCALE; 12700 EMU = 1 pt → 1 px
+
+interface Fill { text: string; x: number; direction: CanvasDirection; fontPx: number }
+
+function mockCtx(): { ctx: CanvasRenderingContext2D; fills: Fill[] } {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  let fillStyle = '';
+  let direction: CanvasDirection = 'ltr';
+  const px = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const fills: Fill[] = [];
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
+    get direction() { return direction; }, set direction(v: CanvasDirection) { direction = v; },
+    get letterSpacing() { return letterSpacing; }, set letterSpacing(v: string) { letterSpacing = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    fillText: (t: string, x: number) => fills.push({ text: t, x, direction, fontPx: px() }),
+    strokeText: () => {}, fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
+    translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
+    moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
+    setLineDash: () => {}, closePath: () => {}, arc: () => {},
+    strokeStyle: '#000', lineWidth: 1, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fills };
+}
+
+function run(text: string): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: FONT_PX, color: '000000', fontFamily: 'Serif',
+  } as TextRunData;
+}
+
+// marL / indent = ±MARK_EMU (a hanging gutter); at SCALE, MARK_EMU/12700 px.
+const MARK_EMU = 342900; // 27 px at this SCALE
+const MARK_PX = MARK_EMU * SCALE; // 27
+
+function body(bullet: Bullet, text: string, rtl: boolean): TextBody {
+  const para: Paragraph = {
+    alignment: rtl ? 'r' : 'l',
+    marL: MARK_EMU, marR: 0, indent: -MARK_EMU,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet, defFontSize: null, defColor: null, defBold: null, defItalic: null,
+    defFontFamily: null, tabStops: [], rtl, runs: [run(text)],
+  } as unknown as Paragraph;
+  return {
+    verticalAnchor: 't', paragraphs: [para], defaultFontSize: FONT_PX,
+    defaultBold: null, defaultItalic: null,
+    lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'square', vert: 'horz', autoFit: 'none',
+  } as unknown as TextBody;
+}
+
+interface RunInfo { text: string; inShapeX: number; w: number }
+const BOX_W = 600;
+
+function render(b: TextBody): { fills: Fill[]; runs: RunInfo[] } {
+  const { ctx, fills } = mockCtx();
+  const runs: RunInfo[] = [];
+  renderTextBody(
+    ctx, b, 0, 0, BOX_W, 400, SCALE,
+    null, 0, false, false, '#000000', undefined,
+    { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+    (r) => runs.push({ text: r.text, inShapeX: r.inShapeX, w: r.w }),
+  );
+  return { fills, runs };
+}
+
+// Geometry: box 600px, no insets, marR=0 ⇒ the RTL leading edge (where a plain
+// RTL paragraph's text right-aligns) is textX + textMaxW = 600.
+const LEADING_EDGE = BOX_W; // 600
+const charBullet: Bullet = { type: 'char', char: '•', color: null, sizePct: null, fontFamily: null };
+const autoNumBullet: Bullet = { type: 'autoNum', numType: 'arabicPeriod', startAt: null } as unknown as Bullet;
+
+/** The marker fill (a non-text glyph run drawn before the paragraph text). */
+function markerFill(fills: Fill[], text: string, runText: string): Fill | undefined {
+  return fills.find((f) => f.text !== runText && f.text.trim() !== '' && (text ? f.text.includes(text) : true));
+}
+
+describe('§21.1.2.4 RTL list marker leads at the right edge (issue #930)', () => {
+  it('char bullet: marker RIGHT edge sits on the leading edge, text reserved to its left', () => {
+    const { fills, runs } = render(body(charBullet, 'ابج', true));
+    const marker = fills.find((f) => f.text.includes('•'))!;
+    expect(marker, 'bullet marker drawn').toBeTruthy();
+    expect(marker.direction).toBe('rtl');
+    const markerW = [...marker.text].length * marker.fontPx;
+    const markerRight = marker.x + markerW;
+    // (1) marker's RIGHT edge is on the leading (right) edge — NOT |indent| past it.
+    //     Before the fix markerRight = LEADING_EDGE + |indent| (27 px over).
+    expect(markerRight).toBeCloseTo(LEADING_EDGE, 3);
+    // (2) the text is right-aligned to leadingEdge − markerW (contiguous with the
+    //     marker's left edge). Before the fix the text stayed at the leading edge
+    //     and the marker floated in the right margin.
+    const textRight = Math.max(...runs.map((r) => r.inShapeX + r.w));
+    expect(textRight).toBeCloseTo(marker.x, 2);
+    expect(textRight).toBeLessThan(LEADING_EDGE);
+  });
+
+  it('autoNum marker: also leads at the right edge (not pushed into the margin)', () => {
+    const { fills } = render(body(autoNumBullet, 'ابج', true));
+    // The autoNum label is the only non-text, non-empty fill (e.g. "1.").
+    const marker = fills.find((f) => /\d/.test(f.text))!;
+    expect(marker, 'autoNum marker drawn').toBeTruthy();
+    const markerW = [...marker.text].length * marker.fontPx;
+    expect(marker.x + markerW).toBeCloseTo(LEADING_EDGE, 3);
+  });
+
+  it('LTR control: a char bullet still hangs at the left gutter (byte-identical)', () => {
+    const { fills } = render(body(charBullet, 'abc', false));
+    const marker = fills.find((f) => f.text.includes('•'))!;
+    // bulletX = textX + indent = marL − |indent| = 0 (the left gutter edge).
+    expect(marker.x).toBeCloseTo(0, 3);
+    expect(marker.direction).not.toBe('rtl');
+  });
+});


### PR DESCRIPTION
## Problem

In an RTL (`a:pPr@rtl`, §21.1.2.2.7) list the marker is placed at the far-right frame edge with an oversized marker-to-text gap; PowerPoint keeps the marker adjacent to its text at the reading start. The over-indent is most visible for a `a:buChar` bullet (its gap to the text equals the whole hanging indent), but it applies to `a:buAutoNum` numbers and `a:buBlip` picture bullets too.

## Root cause

The marker draw mirrored the LTR hanging gutter about the text column's **right** edge — `textX + textMaxW + (textX − bulletX) − markerW`, i.e. it added the full `|indent|` — which pushed the marker `|indent|` **past** the leading (right) edge into the right margin. The text meanwhile right-aligned to the leading edge, so a narrow bullet floated far out in the gutter.

## Fix

Reading-frame placement (same class as the RTL tab-stop mirroring #831/#913 and docx #830): PowerPoint seats a marker's **leading** edge — the right edge under RTL — on the line's leading edge, and lays the text **contiguously** to its left, so `text right = leadingEdge − markerAdvance`. Reserve the marker advance once per first line, draw the marker with its right edge on the leading edge, and right-align the text to `leadingEdge − reserve`. LTR lists and marker-less / plain RTL paragraphs keep a zero reserve and their exact previous geometry (byte-identical).

## Verification

- **Unit (committed):** `packages/pptx/src/rtl-bullet-indent.test.ts` — the RTL char-bullet and autoNum markers' right edge lands on the leading edge (not `+ |indent|`) and the text is reserved contiguously to their left; the LTR control still hangs at the left gutter. Fails against the pre-fix renderer.
- **skia render vs PowerPoint PDF:** on the affected slide, both the numbers and the bullets now share the leading edge with the text adjacent, matching the PDF (previously the markers sat out in the right margin).
- **Regression:** full pptx unit suite (391 tests) green; the change is gated to RTL list first lines.

Closes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)