### PR TITLE
fix(docx): anchor RTL trailing whitespace in the text-box draw loop

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -10142,6 +10142,46 @@ export function renderShapeText(
           // helper the body uses, so contextual CJK packing (約物半角) is honoured
           // and the painted advance equals the segment box. A non-justified
           // segment is a single fillText.
+          // ECMA-376 §17.3.1.6 <w:bidi> (issue #929) — mirror of the BODY loop's
+          // rtlWsShiftPx fix for Word shape/text-box text (the SECOND
+          // computeLineVisualOrder consumer, explicitly scoped OUT of PR #949).
+          // An RTL segment's TRAILING inter-word space must sit on its physical
+          // LEFT under the RTL visual frame; ctx.direction='rtl' does that in
+          // Chrome but skia-canvas (server/VRT/MCP backend) strands it on the
+          // physical RIGHT, collapsing the gap to the reading-next word. Draw the
+          // whitespace-TRIMMED glyphs (`glyphText`) shifted right by the whitespace
+          // advance (`rtlWsShiftPx`) so the space always falls on the box's LEFT —
+          // backend-identical. The shift is derived from the SAME segAdvanceWidth
+          // authority the layout MEASURE pass used (§17.3.2.43 w:w scale + one
+          // §17.3.2.35 per-code-point pitch), NOT a paint-letterSpacing re-measure,
+          // so measure==paint. Shape text never uses a docGrid ⇒ gridDeltaPx = 0.
+          // Consumed by the plain branch and the kashida sub-branches (w:w /
+          // w:spacing / plain); the §17.18.44 split-piece branch is EXEMPT (see its
+          // note). LTR / whitespace-less segments keep glyphText===drawText and
+          // glyphDrawX===x (byte-identical).
+          let glyphText = drawText;
+          let glyphDrawX = x;
+          let rtlWsShiftPx = 0;
+          if (
+            visual &&
+            visual.rtl[si] === true &&
+            !effState.verticalCJK &&
+            /\s$/u.test(drawText)
+          ) {
+            const trimmed = drawText.replace(/\s+$/u, '');
+            if (trimmed.length > 0) {
+              const prevLetterSpacing = ctx.letterSpacing;
+              ctx.letterSpacing = '0px';
+              const naturalFull = ctx.measureText(drawText).width;
+              const naturalTrimmed = ctx.measureText(trimmed).width;
+              ctx.letterSpacing = prevLetterSpacing;
+              rtlWsShiftPx =
+                segAdvanceWidth({ ...s, text: drawText }, naturalFull, 0, scale) -
+                segAdvanceWidth({ ...s, text: trimmed }, naturalTrimmed, 0, scale);
+              glyphText = trimmed;
+              glyphDrawX = x + rtlWsShiftPx;
+            }
+          }
           if (kashida) {
             const segCharScale = s.charScale ?? 1;
             const segCharSpacingPx = segLetterSpacingPx(s, 0, scale);
@@ -10151,25 +10191,32 @@ export function renderShapeText(
             }
             if (segCharScale !== 1) {
               ctx.save();
-              ctx.translate(x, 0);
+              ctx.translate(glyphDrawX, 0);
               ctx.scale(segCharScale, 1);
               const prevLetterSpacing = ctx.letterSpacing;
               if (segCharSpacingPx !== 0) {
                 ctx.letterSpacing = `${segCharSpacingPx / segCharScale}px`;
               }
-              ctx.fillText(drawText, 0, baseline + yOffset);
+              ctx.fillText(glyphText, 0, baseline + yOffset);
               ctx.letterSpacing = prevLetterSpacing;
               ctx.restore();
             } else if (segCharSpacingPx !== 0) {
               const prevLetterSpacing = ctx.letterSpacing;
               ctx.letterSpacing = `${segCharSpacingPx}px`;
-              ctx.fillText(drawText, x, baseline + yOffset);
+              ctx.fillText(glyphText, glyphDrawX, baseline + yOffset);
               ctx.letterSpacing = prevLetterSpacing;
             } else {
-              ctx.fillText(drawText, x, baseline + yOffset);
+              ctx.fillText(glyphText, glyphDrawX, baseline + yOffset);
             }
             if (s.kerning != null) ctx.fontKerning = prevKerning;
           } else if (stretch && stretch.splitBefore.length > 0) {
+            // §17.18.44 inter-CJK justify split. EXEMPT from the RTL trailing-
+            // whitespace shift above: `splitBefore` is only non-empty when the
+            // segment carries CJK content with inter-ideograph split points,
+            // which resolves to an even (LTR) bidi level — an RTL-direction
+            // segment (visual.rtl[si]===true) cannot reach this branch outside
+            // the rtl-marked EA-punctuation corner where bidi justification is
+            // already approximate. Same argument as the body loop.
             const cps = [...s.text];
             if (stretch.splitBefore.length === cps.length - 1) {
               // Fully distributed (pure-CJK): uniform pitch via letterSpacing so
@@ -10185,7 +10232,7 @@ export function renderShapeText(
               }
             }
           } else {
-            ctx.fillText(s.text, x, baseline + yOffset);
+            ctx.fillText(glyphText, glyphDrawX, baseline + yOffset);
           }
           if (s.ruby) {
             const spanW = s.measuredWidth + internalStretch;

--- a/packages/docx/src/rtl-run-boundary-space-textbox.test.ts
+++ b/packages/docx/src/rtl-run-boundary-space-textbox.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import { renderShapeText } from './renderer.js';
+import type { ShapeRun, ShapeText, ShapeTextRun } from './types.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ECMA-376 §17.3.1.6 `<w:bidi>` — inter-word space at a run/segment boundary in
+// Word shape/text-box text (issue #929, text-box mirror of PR #949).
+//
+// PR #949 fixed the BODY paragraph draw loop, but explicitly scoped out the
+// second `computeLineVisualOrder` consumer inside `renderShapeText`. That loop
+// still drew an RTL segment's WHOLE logical string, including its trailing
+// inter-word space, with one `fillText`. Chrome moves that edge whitespace to
+// the segment's physical LEFT under `ctx.direction='rtl'`; skia-canvas does not,
+// leaving the space on the physical RIGHT and collapsing the gap to the next
+// reading word on the left.
+//
+// These tests drive `renderShapeText` directly and use fixed-width mock glyphs.
+// Since shape text has no `onTextRun` callback, all geometry comes from recorded
+// `fillText` device positions. The recording context tracks translate/scale and
+// honors `letterSpacing` in `measureText`, matching the BODY regression test's
+// backend-independent measurement model.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface FillCall {
+  text: string;
+  /** Device x after the active translate/scale transform. */
+  x: number;
+  direction: CanvasDirection;
+  letterSpacingPx: number;
+}
+
+function makeRecordingCanvas(): { ctx: CanvasRenderingContext2D; fills: FillCall[] } {
+  let font = '10px serif';
+  let letterSpacing = '0px';
+  let direction: CanvasDirection = 'ltr';
+  let tx = 0;
+  let sx = 1;
+  const stack: { tx: number; sx: number }[] = [];
+  const fills: FillCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(value: string) { letterSpacing = value; },
+    get direction() { return direction; },
+    set direction(value: CanvasDirection) { direction = value; },
+    fontKerning: 'auto',
+    measureText(text: string) {
+      const px = Number(/([\d.]+)px/.exec(font)?.[1] ?? 10);
+      const spacing = Number.parseFloat(letterSpacing) || 0;
+      const cps = [...text].length;
+      return {
+        width: cps * px + cps * spacing,
+        fontBoundingBoxAscent: px * 0.8,
+        fontBoundingBoxDescent: px * 0.2,
+        actualBoundingBoxAscent: px * 0.8,
+        actualBoundingBoxDescent: px * 0.2,
+      } as TextMetrics;
+    },
+    save() { stack.push({ tx, sx }); },
+    restore() {
+      const frame = stack.pop();
+      if (frame) ({ tx, sx } = frame);
+    },
+    scale(fx: number) { sx *= fx; },
+    translate(dx: number) { tx += dx * sx; },
+    fillText(text: string, x: number) {
+      fills.push({
+        text,
+        x: tx + sx * x,
+        direction,
+        letterSpacingPx: Number.parseFloat(letterSpacing) || 0,
+      });
+    },
+    beginPath() {}, closePath() {}, moveTo() {}, lineTo() {}, stroke() {}, fill() {},
+    fillRect() {}, strokeRect() {}, clip() {}, rect() {}, setLineDash() {},
+    drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    rotate() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fills };
+}
+
+const SHAPE_X = 100;
+const SHAPE_Y = 50;
+const SHAPE_W = 200;
+const SHAPE_H = 100;
+const FONT_SIZE = 10;
+const W1 = 'ابج';
+const W2 = 'دهو';
+const SPACE_WIDTH = FONT_SIZE;
+
+function shapeWith(blocks: ShapeText[]): ShapeRun {
+  return {
+    type: 'shape',
+    presetGeometry: 'rect',
+    wrapMode: 'none',
+    textAnchor: 't',
+    textInsetL: 0,
+    textInsetT: 0,
+    textInsetR: 0,
+    textInsetB: 0,
+    textBlocks: blocks,
+  } as unknown as ShapeRun;
+}
+
+function textRun(text: string): ShapeTextRun {
+  return { text, fontSizePt: FONT_SIZE, fontFamily: 'serif' };
+}
+
+function block(text: string, runs: ShapeTextRun[], bidi: boolean): ShapeText {
+  return {
+    text,
+    runs,
+    fontSizePt: FONT_SIZE,
+    fontFamily: 'serif',
+    alignment: 'left',
+    bidi,
+  } as unknown as ShapeText;
+}
+
+function render(blocks: ShapeText[]): FillCall[] {
+  const { ctx, fills } = makeRecordingCanvas();
+  renderShapeText(
+    shapeWith(blocks),
+    SHAPE_X,
+    SHAPE_Y,
+    SHAPE_W,
+    SHAPE_H,
+    ctx,
+    1,
+  );
+  return fills;
+}
+
+function wordFill(fills: FillCall[], word: string): FillCall {
+  const fill = fills.find((event) => event.text.trim() === word);
+  expect(fill).toBeDefined();
+  return fill as FillCall;
+}
+
+function expectFullRtlGap(fills: FillCall[]): void {
+  const w1 = wordFill(fills, W1);
+  const w2 = wordFill(fills, W2);
+
+  expect(w1.direction).toBe('rtl');
+  expect(w2.direction).toBe('rtl');
+  expect(/\s$/u.test(w1.text)).toBe(false);
+
+  const w2Right = w2.x + [...W2].length * FONT_SIZE;
+  expect(w1.x - w2Right).toBeCloseTo(SPACE_WIDTH, 6);
+}
+
+describe('ECMA-376 §17.3.1.6 RTL inter-word space in shape text (issue #929 / PR #949 scope-out)', () => {
+  it('keeps one full visual gap between adjacent RTL runs', () => {
+    const fills = render([
+      block(`${W1} ${W2}`, [textRun(`${W1} `), textRun(W2)], true),
+    ]);
+
+    expectFullRtlGap(fills);
+  });
+
+  it('keeps one full visual gap when the main line engine splits a single RTL run', () => {
+    const fills = render([
+      block(`${W1} ${W2}`, [textRun(`${W1} ${W2}`)], true),
+    ]);
+
+    expectFullRtlGap(fills);
+  });
+
+  it('leaves the LTR trailing-space fast path byte-identical', () => {
+    const fills = render([
+      block('ABC DEF', [textRun('ABC DEF')], false),
+    ]);
+    const abc = wordFill(fills, 'ABC');
+
+    expect(abc.text).toBe('ABC ');
+    expect(abc.direction).toBe('ltr');
+    expect(abc.x).toBeCloseTo(SHAPE_X, 6);
+    expect(abc.letterSpacingPx).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

`renderShapeText` holds the **second** `computeLineVisualOrder` consumer in `packages/docx/src/renderer.ts`. PR #949 fixed the trailing-whitespace bug (issue #929) only in the body paragraph loop and explicitly scoped this text-box loop out — so it still carried the same defect.

For an RTL-direction segment whose logical string ends in an inter-word space, the loop painted the **whole** string (including that trailing space) with a single `fillText`, relying on `ctx.direction='rtl'` to move the space to the segment's physical **left** (toward the next reading word). Chrome's Canvas reorders it, but **skia-canvas** — the server / VRT / MCP rendering backend — left-anchors the logical string and leaves the space on the physical **right**. In an RTL paragraph the reading-next word sits to the left, so the space lands on the wrong (outer) side and the inter-word gap collapses — most visible in a two-word Arabic label such as a text-box cover banner.

## Fix

Mirror the body loop's `rtlWsShiftPx` fix. For an RTL-direction segment that ends in whitespace, draw the trailing-whitespace-**trimmed** glyphs shifted right by the whitespace advance so the space always occupies the box's left edge — identical output in Chrome and skia.

The shift is derived from the same `segAdvanceWidth` authority the layout measure pass used (natural glyph width folded with the §17.3.2.43 `w:w` scale and the §17.3.2.35 per-code-point pitch), **not** a re-measure under a paint `letterSpacing`, so `measure == paint` holds under every pitch combination. `gridDeltaPx` is `0` because shape text never uses a docGrid.

Applied to:
- the plain (non-kashida) branch, and
- the kashida `w:w` / `w:spacing` / plain sub-branches.

The §17.18.44 inter-CJK split-piece branch is left **exempt**, with a rationale comment: its `splitBefore` points only exist for CJK content, which resolves to an even (LTR) bidi level, so an RTL-direction segment cannot reach it (the same argument the body loop makes). LTR and whitespace-less segments keep `glyphText === drawText` / `glyphDrawX === x` (byte-identical).

## Tests

Adds `packages/docx/src/rtl-run-boundary-space-textbox.test.ts`, a text-box regression test that drives `renderShapeText` through a recording canvas which models skia's non-reordering behavior (shape text emits no `onTextRun` boxes, so geometry is read from `fillText` device positions). It asserts the backend-independent invariant: an RTL run's reading-first word draws with no trailing whitespace and keeps exactly one space-width gap before the reading-next word. Confirmed **red** on the pre-fix code (the trailing space was still painted; the gap collapsed) and **green** after the fix. An LTR control pins the fast path as unchanged.

## Verification

- New test: 3/3 pass (red → green confirmed against the pre-fix renderer).
- Existing `rtl-run-boundary-space` (#949 body) and `textbox-main-engine` tests: 10/10 pass.
- Full DOCX unit suite: 1210/1210 pass (no regressions).
- Typecheck (`tsc --build`): clean.

Note: `sample-36` was checked for a live skia probe but contains no text box (its `w:bidi` / `w:rtl` are body-only, already covered by #949), so its probe is N/A; the fix's real-world target is Arabic text-box content. The recording-canvas test reproduces the exact skia backend behavior.

Refs #929, #949