### PR TITLE
fix(docx): resolve bCs/iCs as independent complex-script toggles (#937)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -10511,12 +10511,13 @@ mod rtl_tests {
     }
 
     /// ECMA-376 §17.3.2.4 w:bCs / §17.3.2.6 w:iCs are INDEPENDENT toggles from
-    /// §17.3.2.3 w:b / §17.3.2.5 w:i AT THE PARSER LEVEL: a run that sets only
-    /// `w:b` (no `w:bCs`) surfaces `bold_cs == None`. NOTE: the renderer's cs
-    /// axis intentionally MIRRORS the non-cs value when bCs is absent
-    /// (`csBold = boldCs ?? base.bold`) — PDF sample-7 page-1 headings carry
-    /// `w:b` without `w:bCs` and render BOLD in Word. So `None` here means
-    /// "not set on the cs axis at the parser level", not "renders non-bold".
+    /// §17.3.2.3 w:b / §17.3.2.5 w:i: a run that sets only `w:b` (no `w:bCs`)
+    /// surfaces `bold_cs == None`, and the renderer resolves the cs axis as
+    /// `csBold = boldCs ?? false` — an absent bCs defaults OFF and does NOT
+    /// inherit the Latin `w:b`. Adjudicated in issue #937 against Word: sample-7's
+    /// `w:rtl`+`w:cs`+`w:b` (no `w:bCs`) Arabic headings render at REGULAR weight
+    /// (not bold), and sample-41's cs-italic Case A/C render upright. So `None`
+    /// here means "not set on the cs axis", which the renderer paints non-bold.
     #[test]
     fn complex_script_bold_is_independent_of_non_cs_bold() {
         let body = body_from(
@@ -10543,8 +10544,9 @@ mod rtl_tests {
         // `w:b` sets the non-CS bold…
         assert!(run.bold, "w:b sets non-CS bold");
         // …and `w:bCs` is absent, so the parser leaves the CS bold axis None.
-        // The renderer mirrors it from `bold` (boldCs ?? bold) per the PDF-
-        // verified sample-7 page-1 behaviour; that fallback lives in renderer.ts.
+        // The renderer resolves an absent bCs as OFF (boldCs ?? false), an
+        // independent toggle per the #937 adjudication; that lives in
+        // line-layout.ts / renderer.ts.
         assert_eq!(
             run.bold_cs, None,
             "absent w:bCs stays None at the parser level"

--- a/packages/docx/src/italic-render.test.ts
+++ b/packages/docx/src/italic-render.test.ts
@@ -24,13 +24,17 @@ import type {
 // whose `font` payload is the exact ctx.font the glyph draw used (buildFont
 // output: "<style> <weight> <size>px <family…>").
 //
-// DELIBERATELY NOT PINNED: a force-CS run carrying `w:i` with `w:iCs` ABSENT.
-// It currently inherits italic through the `italicCs ?? italic` fallback, but
-// §17.3.2.17 reads as an independent toggle (compare the adjudicated bold-side
-// note above buildSegments' axis docs: absent `bCs` does not inherit `b`), so
-// whether the fallback matches Word is pending adjudication in issue #937.
-// Pinning it here would pre-empt that adjudication. The `rtl` case below pins
-// CURRENT behavior for the same fallback and should be revisited with #937.
+// ADJUDICATED (issue #937): a force-CS run carrying `w:i`/`w:b` with `w:iCs`/
+// `w:bCs` ABSENT paints UPRIGHT / non-bold. §17.3.2.17 `w:iCs` and §17.3.2.3
+// `w:bCs` are INDEPENDENT toggles — the non-CS `w:i`/`w:b` value governs only
+// the Latin axis and does NOT inherit onto the complex-script axis. Word's
+// ground truth (fixture sample-41 cs-italic-toggle): Case A (`w:cs`+`w:i`, no
+// `w:iCs`, Latin) and Case C (`w:rtl`+`w:i`, no `w:iCs`, Arabic) both render
+// upright — identical to Case B (`w:iCs=0` explicit OFF) — while Case D (plain
+// `w:i`, Latin axis) renders italic. The bold side is the same: sample-7's
+// `w:rtl`+`w:cs`+`w:b` (no `w:bCs`) Arabic headings render at regular weight in
+// Word's PDF, not bold. The renderer therefore resolves the CS axis as
+// `italicCs ?? false` / `boldCs ?? false`, NOT `?? base.italic`/`?? base.bold`.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const FONT_PX = 20;
@@ -149,13 +153,36 @@ describe('run italic axis at paint time (§17.3.2.16 w:i / §17.3.2.17 w:iCs)', 
     expect(fonts.get('курсив')).toMatch(/^normal normal /);
   });
 
-  it('w:rtl run with w:i and absent w:iCs paints italic (current fallback)', async () => {
-    // CURRENT behavior pin: the CS axis falls back `italicCs ?? italic` when
-    // w:iCs is absent. Whether Word agrees for an absent toggle is pending
-    // adjudication in issue #937; revisit this pin with that issue.
+  it('force-CS run (w:cs) with w:i and absent w:iCs paints upright (#937 Case A)', async () => {
+    // §17.3.2.7 <w:cs/> routes the run onto the CS axis; §17.3.2.17 `w:iCs` is
+    // an INDEPENDENT toggle, so an ABSENT `w:iCs` defaults OFF and `w:i` (Latin
+    // axis) does not leak through. Word ground truth: sample-41 Case A renders
+    // upright, identical to the explicit-OFF Case B above. Adjudicated in #937.
+    const fonts = await paintFonts([para([
+      textRun('курсив', { italic: true, cs: true, fontSizeCs: FONT_PX }),
+    ])]);
+    expect(fonts.get('курсив')).toMatch(/^normal normal /);
+  });
+
+  it('w:rtl run with w:i and absent w:iCs paints upright (#937 Case C)', async () => {
+    // The rtl (§17.3.2.30) sibling of Case A: same absent-`w:iCs` fallback.
+    // Word ground truth: sample-41 Case C (Arabic) renders upright, not oblique.
+    // Previously pinned to italic (`italicCs ?? italic`); flipped by the #937
+    // adjudication to the independent-toggle reading (`italicCs ?? false`).
     const fonts = await paintFonts([para([
       textRun('نص', { italic: true, rtl: true, fontSizeCs: FONT_PX, langBidi: 'ar-sa' }),
     ])]);
-    expect(fonts.get('نص')).toMatch(/^italic /);
+    expect(fonts.get('نص')).toMatch(/^normal /);
+  });
+
+  it('force-CS run with w:b and absent w:bCs paints non-bold (#937 bold symmetry)', async () => {
+    // §17.3.2.3 `w:bCs` mirrors §17.3.2.17 `w:iCs`: an INDEPENDENT toggle whose
+    // absence defaults OFF, so `w:b` (Latin axis) does not force CS bold. Word
+    // ground truth: sample-7's w:rtl+w:cs+w:b (no w:bCs) Arabic headings render
+    // at regular weight, not bold. `csBold = boldCs ?? false`. Adjudicated #937.
+    const fonts = await paintFonts([para([
+      textRun('نص', { bold: true, rtl: true, fontSizeCs: FONT_PX, langBidi: 'ar-sa' }),
+    ])]);
+    expect(fonts.get('نص')).toMatch(/^normal normal /);
   });
 });

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1116,9 +1116,13 @@ export function paragraphMarkLineHeight(
  * `iCs` (italic), §17.3.2.26 `rFonts@cs` (typeface), §17.3.2.39 `szCs` (size) —
  * instead of the non-CS `b`/`i`/`rFonts@ascii`/`sz`, which apply to
  * non-complex (Latin/CJK) text. `bCs`/`iCs` are INDEPENDENT toggles: an absent
- * `bCs` does not inherit `b`'s value, so a complex-script run that carries only
- * `w:b` renders non-bold. (sample-7's date cells carry `b` without `bCs`, and
- * Word draws them at regular weight; the header carries both and is bold.)
+ * `bCs`/`iCs` does not inherit `b`/`i`'s value, so a complex-script run that
+ * carries only `w:b`/`w:i` renders non-bold/upright (`csBold = boldCs ?? false`,
+ * `csItalic = italicCs ?? false`). Adjudicated in issue #937 against Word: the
+ * numbered Arabic headings in sample-7 carry `w:rtl`+`w:cs`+`w:b` WITHOUT
+ * `w:bCs` and Word draws them at regular weight; sample-41's cs-italic Case A/C
+ * carry `w:i` without `w:iCs` and render upright, matching the explicit-OFF
+ * Case B (only Case D's plain Latin `w:i` renders italic).
  */
 /**
  * Split a `w:smallCaps` (§17.3.2.33) run into maximal pieces by character class
@@ -1966,14 +1970,20 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
     // renders at w:sz=24; forcing cs blew its size up to 26pt.
     const forceCs = r.rtl === true || r.cs === true;
 
-    // Complex-script (cs) formatting sources, each falling back to its Latin
-    // counterpart when the cs-specific property is absent (the parser already
-    // resolves szCs through the full style chain, mirroring a directly-set
-    // `w:sz` per §17.3.2.18; bCs/iCs per §17.3.2.3/§17.3.2.17).
+    // Complex-script (cs) formatting sources. SIZE (§17.3.2.39 szCs) and TYPEFACE
+    // (§17.3.2.26 rFonts@cs) fall back to their Latin counterpart when absent —
+    // the parser resolves szCs through the full style chain, mirroring a
+    // directly-set `w:sz` per §17.3.2.18. But BOLD (§17.3.2.3 bCs) and ITALIC
+    // (§17.3.2.17 iCs) are INDEPENDENT toggles: an absent `bCs`/`iCs` defaults
+    // OFF and must NOT inherit the Latin-axis `w:b`/`w:i` (which govern only
+    // non-complex content). Adjudicated in issue #937 against Word ground truth —
+    // sample-41 Case A/C (`w:i`, no `w:iCs`) render upright like the explicit-OFF
+    // Case B (contrast Case D's plain Latin `w:i` = italic); sample-7's
+    // `w:rtl`+`w:cs`+`w:b` (no `w:bCs`) Arabic headings render at regular weight.
     const csFontSize = r.fontSizeCs ?? base.fontSize;
     const csFontFamily = r.fontFamilyCs ?? base.fontFamily;
-    const csBold = r.boldCs ?? base.bold;
-    const csItalic = r.italicCs ?? base.italic;
+    const csBold = r.boldCs ?? false;
+    const csItalic = r.italicCs ?? false;
 
     // ECMA-376 §17.3.2.26 eastAsia axis. Within a non-complex-script slice, CJK
     // code points take the eastAsia face while Latin/digits keep the ascii face

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -4853,14 +4853,18 @@ function cellMinContentPt(cell: DocTableCell, table: DocTable, state: RenderStat
       // Resolve the complex-script (cs) axis the same way `buildSegments` does
       // (ECMA-376 §17.3.2.3/§17.3.2.17/§17.3.2.18): a run forcing cs (w:rtl or
       // the §17.3.2.7 <w:cs/> toggle) measures with the cs bold/italic/size/
-      // family, each falling back to its Latin counterpart when absent. We pick
+      // family. SIZE (szCs) and FAMILY (rFonts@cs) fall back to their Latin
+      // counterpart when absent, but BOLD (bCs) and ITALIC (iCs) are INDEPENDENT
+      // toggles that default OFF (issue #937), so an absent bCs/iCs must NOT
+      // inherit the Latin `w:b`/`w:i` — mirror buildSegments exactly or the
+      // measured min-content width would drift from the painted glyphs. We pick
       // the cs axis for the min-content estimate when the run forces cs so wide
       // Arabic/Hebrew tokens reserve enough column width; otherwise the Latin
       // axis. NOTE rFonts@cs alone is just a font SLOT — it must not force cs
       // (a Latin heading whose style defines cstheme would wrongly take szCs).
       const forceCs = t.rtl === true || t.cs === true;
-      const effBold = forceCs ? (t.boldCs ?? t.bold) : t.bold;
-      const effItalic = forceCs ? (t.italicCs ?? t.italic) : t.italic;
+      const effBold = forceCs ? (t.boldCs ?? false) : t.bold;
+      const effItalic = forceCs ? (t.italicCs ?? false) : t.italic;
       const effFontSize = forceCs ? (t.fontSizeCs ?? t.fontSize) : t.fontSize;
       const effFontFamily = forceCs ? (t.fontFamilyCs ?? t.fontFamily) : t.fontFamily;
       // Measure in pt-space (font size in pt, scale 1) so the result composes


### PR DESCRIPTION
## Summary

Resolves the four Word adjudications in issue #937 and PRs #924/#926/#943. Of the four, **only the CS bold/italic toggle (#937) needed a code change** — the other three current implementations already match Word ground truth (see adjudication table below).

§17.3.2.3 `w:bCs` and §17.3.2.17 `w:iCs` are **independent** complex-script toggles: an absent `bCs`/`iCs` defaults **OFF** and must not inherit the Latin-axis `w:b`/`w:i`. The renderer previously mirrored the Latin value (`csBold = boldCs ?? base.bold`, `csItalic = italicCs ?? base.italic`), painting bold/italic where Word paints regular/upright.

### Word ground truth (PDF exports)
- **sample-41 (cs-italic-toggle):** Case A (`w:cs`+`w:i`, no `w:iCs`, Latin) and Case C (`w:rtl`+`w:i`, no `w:iCs`, Arabic) render **upright** — identical to the explicit-OFF Case B (`w:iCs=0`); only Case D (plain Latin `w:i`) renders italic.
- **sample-7 / sample-36 / sample-37:** `w:rtl`/`w:cs` + `w:b` (no `w:bCs`) Arabic and Thai headings/labels/table-headers render at **regular weight**, not bold.

## Changes
- `line-layout.ts` `buildSegments`: `csBold = boldCs ?? false`, `csItalic = italicCs ?? false` (size/family keep their Latin fallback).
- `renderer.ts` `cellMinContentPt`: mirror the same resolution so the column min-content measurement matches the painted glyphs.
- `italic-render.test.ts`: pin the previously-unpinned #937 Case A/C cases plus a bold-symmetry case.
- `parser.rs`: correct the docstring that had asserted the mirror behaviour.

## Adjudication summary (all four)
| # | Fixture | Question | Word measurement | Current impl | Action |
|---|---|---|---|---|---|
| 1 | sample-40 kashida | positions uniform vs priority; elongation stages | Priority positions (~1/word), **stable** across low/med/high; elongation scales low<med<high (50<106<131 tatweel units) | uniform round-robin, cap 1/2/∞ | **Deferred** — matching Word needs an undocumented (non-ECMA-376) kashida priority table; deriving it from one fixture would be sample-fitted. See PR #943 thread. |
| 2 | sample-41 cs-italic | absent `iCs` inherit or independent | **Independent** — absent → upright | `italicCs ?? italic` (inherit) | **Fixed here** |
| 3 | sample-42 vAlign split | per-piece vs whole-span | **Per-piece** (first on-page piece) | per-piece | No change (correct) |
| 4 | sample-43 atLeast grid | cell-multiple vs raw | `max(gridCell, atLeast)` = 18/18/24pt (NOT 18/18/36) | `max(natural, authored, 1-cell)` | No change (correct) |

## Verification
- docx suite: 1209 passed; docx typecheck clean; Rust fmt + touched test pass.
- End-to-end probe (real docx → WASM `parse_docx` → renderer paint font): sample-41 A/B/C upright + D italic; sample-7 `cs+b` headings non-bold.
- VRT triage (style-resolved flips): only sample-7 (36), sample-36 (6), sample-37 (6), sample-41 (2) change — each verified against its Word PDF as a correction toward regular/upright. sample-14 and sample-28 are 0px (their cs toggles come from styles).

Closes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)