### PR TITLE
fix(docx): render text-box runs wrapped in content controls (§17.5.2)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -5666,7 +5666,9 @@ fn extract_simple_paragraph_text(
         out
     };
 
-    for child in p.children().filter(|n| n.is_element()) {
+    // ECMA-376 §17.5.2: SDTs transparently wrap inline content. Flattening restores
+    // pre-a183723 behavior after the direct-child scan dropped text-box SDT runs.
+    for child in element_children_flat(p) {
         match child.tag_name().name() {
             "r" => {
                 for (run_text, fmt, ruby) in collect_run_node(child) {
@@ -14648,6 +14650,35 @@ mod txbx_inline_image_tests {
         assert!(block.runs[0].bold);
         assert_eq!(block.runs[1].text, "This document describes.");
         assert!(!block.runs[1].bold);
+    }
+
+    /// ECMA-376 §17.5.2 — content-control runs inside a text box remain in
+    /// document order. This guards the sample-5 cover regression from a183723.
+    #[test]
+    fn extract_simple_paragraph_text_includes_content_control_runs() {
+        let xml = r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:r><w:t>[</w:t></w:r>
+              <w:sdt><w:sdtContent><w:r><w:t>会社名</w:t></w:r></w:sdtContent></w:sdt>
+              <w:r><w:t>]</w:t></w:r>
+            </w:p>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let block = extract_simple_paragraph_text(
+            &StyleMap::default(),
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .expect("content-control text yields a block");
+
+        assert_eq!(block.text, "[会社名]");
+        assert_eq!(
+            block
+                .runs
+                .iter()
+                .map(|run| run.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["[", "会社名", "]"]
+        );
     }
 
     /// ECMA-376 §17.3.3.25 — ruby inside a legacy VML/text-box paragraph must


### PR DESCRIPTION
## Summary

Restores a **user-reported rendering regression**: a cover-page document lost its title and placeholder text. Those strings live inside floating DrawingML text boxes, wrapped in Word content controls (`<w:sdt>`), and stopped rendering while plain `<w:r>` text in the same boxes still drew.

## Root cause (bisected)

`extract_simple_paragraph_text` (`packages/docx/parser/src/parser.rs`) collects a text-box paragraph's runs. Commit `a183723` ("render sample 33 callouts and table flow", 2026-07-09) rewrote its run collection from a `p.descendants().filter(name == "r")` scan — which naturally reached `<w:r>` nested inside `<w:sdt><w:sdtContent>` — to a direct-child loop:

```rust
for child in p.children().filter(|n| n.is_element()) {
    match child.tag_name().name() {
        "r" => { ... }
        "hyperlink" => { ... }
        "oMath" | "oMathPara" => { ... }
        _ => {}   // <w:sdt> falls here and is dropped
    }
}
```

Because `<w:sdt>` (ECMA-376 §17.5.2 structured document tag / content control) is not a matched arm, every content-control-wrapped run was silently dropped. A bisecting probe confirms the text renders at `a183723^` and disappears from `a183723` onward.

> Note: this was investigated in the context of the recent §17.3.2.41 vanished-mark pagination work (Refs #868, PR #947), but the bisect shows the true cause is `a183723`, unrelated to vanished text (the affected document contains no `w:vanish`).

## Fix

Iterate `element_children_flat(p)` instead — the existing `xml_util` helper the **body path already uses** to transparently unwrap `<w:sdt>/<w:sdtContent>`. Content-control runs are now processed inline, in document order, exactly as before `a183723`. For a paragraph with no `<w:sdt>` child the helper yields the identical child sequence, so extraction is byte-for-byte unchanged for every other document.

## Verification

- New Rust test `extract_simple_paragraph_text_includes_content_control_runs` pins that an sdt-wrapped text-box run is kept in order (`[<w:sdt>会社名</w:sdt>]` → `[会社名]`).
- Parser `cargo test`: **330 passed**, 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --all --check` clean.
- docx unit suite (`vitest`): **1207 passed**.
- Root `pnpm typecheck`: green.
- End-to-end probe on the affected cover page: title + placeholder text draw again (were dropped on `main`).
- Pagination is untouched: the §17.3.2.41 vanished-empty-paragraph collapse from PR #947 is unaffected — the long-form RTL sample stays at its 23-page count (its text boxes contain no `<w:sdt>`, so extraction output is unchanged).

## VRT triage

Across all sample docx files, only **two** contain `<w:sdt>` inside a text box, and only one is in the VRT set. That sample's reference PNGs were regenerated while the regression was live (post-`a183723`), so its cover page will now diff against the stale reference — a correct improvement toward the Word ground truth. The reference should be regenerated after merge (not auto-updated, per the reference-image policy). No other VRT sample is affected.

Refs #868