### PR TITLE
feat: dictionary line breaking for Thai/Lao/Khmer via Intl.Segmenter

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -362,6 +362,23 @@ export {
   crossRunKinsokuRetract,
 } from './text/kinsoku';
 export { isCjkBreakChar, isLatinWordCodePoint } from './text/cjk-ranges';
+// Dictionary-based line breaking for no-inter-word-space SEA scripts (Thai / Lao
+// / Khmer, issue #797): the ICU-backed word-break offset enumerator plus the
+// shared greedy whole-word fit kernel, consumed by all three renderers' wrap
+// loops. Graceful fallback to cluster/character wrap when Intl.Segmenter is
+// unavailable. `setSeaWordSegmenterForTest`/`resetSeaSegmenterForTest` are test
+// seams only.
+export {
+  type SeaScript,
+  type SeaWordSegmenter,
+  isSeaScriptCodePoint,
+  containsSeaScript,
+  seaWordBreakOffsets,
+  fitSeaWordPrefix,
+  graphemeClusterOffsets,
+  setSeaWordSegmenterForTest,
+  resetSeaSegmenterForTest,
+} from './text/sea-break';
 // UAX #50 Vertical_Orientation (vo): how a code point orients in vertical text
 // (tbRl / eaVert). Consumed by the vertical-text draw paths across packages.
 export {

--- a/packages/core/src/text/sea-break.test.ts
+++ b/packages/core/src/text/sea-break.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  containsSeaScript,
+  fitSeaWordPrefix,
+  graphemeClusterOffsets,
+  isSeaScriptCodePoint,
+  resetSeaSegmenterForTest,
+  seaWordBreakOffsets,
+  setSeaWordSegmenterForTest,
+} from './sea-break.js';
+
+afterEach(() => resetSeaSegmenterForTest());
+
+describe('isSeaScriptCodePoint', () => {
+  const cases: [number, boolean][] = [
+    [0x0dff, false], // just below Thai
+    [0x0e00, true], // Thai start
+    [0x0e33, true], // THAI SARA AM
+    [0x0e50, true], // THAI DIGIT ZERO
+    [0x0e7f, true], // Thai end
+    [0x0e80, true], // Lao start
+    [0x0eff, true], // Lao end
+    [0x0f00, false], // Tibetan — out of scope
+    [0x177f, false], // just below Khmer
+    [0x1780, true], // Khmer start
+    [0x17d2, true], // KHMER SIGN COENG
+    [0x17ff, true], // Khmer end
+    [0x1800, false], // just above Khmer
+    [0x0041, false], // Latin A
+    [0x3042, false], // Hiragana — CJK, not SEA
+  ];
+  for (const [cp, expected] of cases) {
+    it(`U+${cp.toString(16).toUpperCase().padStart(4, '0')} → ${expected}`, () => {
+      expect(isSeaScriptCodePoint(cp)).toBe(expected);
+    });
+  }
+});
+
+describe('containsSeaScript', () => {
+  it('true for Thai / Lao / Khmer text', () => {
+    expect(containsSeaScript('ภาษาไทย')).toBe(true);
+    expect(containsSeaScript('ພາສາລາວ')).toBe(true);
+    expect(containsSeaScript('ភាសាខ្មែរ')).toBe(true);
+  });
+  it('true when SEA is embedded in Latin', () => {
+    expect(containsSeaScript('Hello ภาษา world')).toBe(true);
+  });
+  it('false for pure Latin / CJK / empty', () => {
+    expect(containsSeaScript('Hello, world!')).toBe(false);
+    expect(containsSeaScript('日本語のテキスト')).toBe(false);
+    expect(containsSeaScript('')).toBe(false);
+  });
+});
+
+describe('seaWordBreakOffsets — platform ICU', () => {
+  it('returns interior grapheme-boundary offsets for a Thai sentence', () => {
+    const text = 'ภาษาไทยเป็นภาษาที่สวยงามมาก';
+    const offsets = seaWordBreakOffsets(text);
+    expect(offsets.length).toBeGreaterThan(0);
+    // Ascending, strictly interior (never 0 or text.length).
+    for (let k = 1; k < offsets.length; k++) expect(offsets[k]).toBeGreaterThan(offsets[k - 1]);
+    for (const o of offsets) {
+      expect(o).toBeGreaterThan(0);
+      expect(o).toBeLessThan(text.length);
+    }
+    // Every offset is a grapheme-cluster boundary (never mid-cluster).
+    const graphemes = new Set(graphemeClusterOffsets(text));
+    for (const o of offsets) expect(graphemes.has(o)).toBe(true);
+    // Every offset falls between two SEA-script characters (interior to the span).
+    for (const o of offsets) {
+      expect(isSeaScriptCodePoint(text.codePointAt(o - 1)!)).toBe(true);
+      expect(isSeaScriptCodePoint(text.codePointAt(o)!)).toBe(true);
+    }
+  });
+
+  it('dictionary-breaks Lao and Khmer too', () => {
+    expect(seaWordBreakOffsets('ພາສາລາວແມ່ນພາສາທີ່ສວຍງາມ').length).toBeGreaterThan(0);
+    expect(seaWordBreakOffsets('ភាសាខ្មែរជាភាសាដ៏ស្រស់ស្អាត').length).toBeGreaterThan(0);
+  });
+
+  it('never adds a break touching non-SEA text (mixed Thai + Latin + digits)', () => {
+    const text = 'ทดสอบ ABC 123 ภาษาไทย';
+    for (const o of seaWordBreakOffsets(text)) {
+      // Both sides of every returned offset must be SEA — no Latin/space/digit edge.
+      expect(isSeaScriptCodePoint(text.codePointAt(o - 1)!)).toBe(true);
+      expect(isSeaScriptCodePoint(text.codePointAt(o)!)).toBe(true);
+    }
+  });
+
+  it('offsets are correct after an astral (surrogate-pair) non-SEA prefix (UTF-16 units)', () => {
+    const emoji = '😀'; // U+1F600, 2 UTF-16 units
+    const thai = 'ภาษาไทยเป็นภาษา';
+    const text = emoji + thai;
+    const offsets = seaWordBreakOffsets(text);
+    expect(offsets.length).toBeGreaterThan(0);
+    for (const o of offsets) {
+      expect(o).toBeGreaterThanOrEqual(emoji.length); // never inside the emoji
+      expect(isSeaScriptCodePoint(text.codePointAt(o)!)).toBe(true);
+    }
+  });
+
+  it('returns [] for non-SEA / empty input', () => {
+    expect(seaWordBreakOffsets('Hello world')).toEqual([]);
+    expect(seaWordBreakOffsets('')).toEqual([]);
+  });
+});
+
+describe('seaWordBreakOffsets — graceful fallback + filtering (injected segmenter)', () => {
+  it('returns [] when the segmenter is unavailable', () => {
+    setSeaWordSegmenterForTest(null);
+    expect(seaWordBreakOffsets('ภาษาไทยเป็นภาษา')).toEqual([]);
+  });
+
+  it('returns [] when segmentation throws', () => {
+    setSeaWordSegmenterForTest(() => {
+      throw new Error('boom');
+    });
+    expect(seaWordBreakOffsets('ภาษาไทยเป็นภาษา')).toEqual([]);
+  });
+
+  it('excludes non-word (punctuation) segment starts, keeps word starts', () => {
+    // Fake: split the span into fixed segments; one is punctuation (isWordLike:false).
+    // span "AAAA.BBBB" (all treated as one SEA span by the test text below).
+    setSeaWordSegmenterForTest((span) => {
+      // segment boundaries at 0 (word), 4 (punct '.'), 5 (word)
+      return [
+        { index: 0, isWordLike: true },
+        { index: 4, isWordLike: false },
+        { index: 5, isWordLike: true },
+      ];
+    });
+    // Use real Thai so containsSeaScript passes; the fake decides the offsets.
+    const text = 'ก'.repeat(9);
+    // index 0 excluded (span-start); index 4 excluded (punctuation); index 5 kept.
+    expect(seaWordBreakOffsets(text)).toEqual([5]);
+  });
+});
+
+describe('fitSeaWordPrefix', () => {
+  // Each char is width 10; offsets at 2,5,7 (word boundaries), text length 9.
+  const text = 'abcdefghi';
+  const offsets = [2, 5, 7];
+  const measure = (s: string) => s.length * 10;
+
+  it('returns the largest word boundary whose prefix fits', () => {
+    // avail 55 → prefixes: [0,2)=20, [0,5)=50, [0,7)=70(overflow) → best 5.
+    expect(fitSeaWordPrefix(text, offsets, 0, 55, measure)).toBe(5);
+  });
+  it('returns text.length when the whole remainder fits', () => {
+    expect(fitSeaWordPrefix(text, offsets, 0, 999, measure)).toBe(9);
+  });
+  it('returns start (no progress) when even the first word overflows', () => {
+    // avail 15 < first word [0,2)=20 → start.
+    expect(fitSeaWordPrefix(text, offsets, 0, 15, measure)).toBe(0);
+  });
+  it('respects a non-zero start (continuation of a wrapped word run)', () => {
+    // from start 5: boundaries >5 = [7]; avail 15 → [5,7)=20 overflow → best 5.
+    expect(fitSeaWordPrefix(text, offsets, 5, 15, measure)).toBe(5);
+    // avail 45 → [5,7)=20 ok, [5,9)=40 ok → 9.
+    expect(fitSeaWordPrefix(text, offsets, 5, 45, measure)).toBe(9);
+  });
+  it('treats the final segment (past the last offset) as a whole-remainder word', () => {
+    // from start 7: no offsets >7; [7,9)=20; avail 25 → 9; avail 15 → 7 (no progress).
+    expect(fitSeaWordPrefix(text, offsets, 7, 25, measure)).toBe(9);
+    expect(fitSeaWordPrefix(text, offsets, 7, 15, measure)).toBe(7);
+  });
+
+  it('keeps a later-fitting boundary when advance is non-monotone (negative spacing)', () => {
+    // Simulate strong negative letter spacing: a longer prefix can be NARROWER
+    // than a shorter one, so an early-return greedy would wrongly stop short.
+    // widths: [0,2)=30, [0,5)=10, [0,7)=40, whole [0,9)=50; avail 15 → best 5.
+    const w: Record<number, number> = { 2: 30, 5: 10, 7: 40, 9: 50 };
+    const nonMono = (s: string) => w[s.length] ?? s.length;
+    expect(fitSeaWordPrefix(text, offsets, 0, 15, nonMono)).toBe(5);
+  });
+});
+
+describe('graphemeClusterOffsets', () => {
+  it('keeps a base + combining/tone mark together (Thai SARA AM cluster)', () => {
+    // U+0E33 SARA AM is a single code point but base+mark cluster candidates like
+    // นํ (NO NU + NIKHAHIT) must not split. Use กำ = ก + SARA AM already atomic;
+    // test the classic ก + tone mark ่ (U+0E48) cluster instead.
+    const text = 'ก่ข้'; // ก+MAI EK, ข+MAI THO → two clusters
+    const offsets = graphemeClusterOffsets(text);
+    // Exactly one interior boundary, between the two clusters (after index 2).
+    expect(offsets).toEqual([2]);
+  });
+  it('returns interior offsets only (excludes 0 and length)', () => {
+    const offsets = graphemeClusterOffsets('abc');
+    for (const o of offsets) {
+      expect(o).toBeGreaterThan(0);
+      expect(o).toBeLessThan(3);
+    }
+  });
+});

--- a/packages/core/src/text/sea-break.ts
+++ b/packages/core/src/text/sea-break.ts
@@ -1,0 +1,268 @@
+// Dictionary-based line breaking for Southeast-Asian (SEA) scripts that write
+// without inter-word spaces: Thai, Lao and Khmer (GitHub issue #797). Word
+// boundaries in these scripts are not marked by whitespace and cannot be derived
+// from Unicode ranges alone; they require a dictionary. We use the platform ICU
+// dictionary via `Intl.Segmenter({ granularity: 'word' })` to enumerate the
+// break opportunities INTERIOR to each SEA-script span, and expose a pure,
+// package-agnostic kernel that every renderer's wrap loop consumes.
+//
+// Design invariants (shared with the docx/pptx/xlsx breakers):
+//   • ADD break opportunities only; never change glyphs or advances. The run is
+//     split only at the ACTUAL line break, so within a line the text stays one
+//     contiguous draw (measure==paint).
+//   • Restrict added opportunities to boundaries INTERIOR to a maximal SEA span,
+//     between two dictionary WORDS. A boundary that touches non-SEA text (Latin,
+//     digits, CJK, whitespace) is left to the existing whitespace/Latin/CJK
+//     logic, so non-SEA content stays byte-identical.
+//   • Graceful fallback: when `Intl.Segmenter` is unavailable (old runtimes, a
+//     `small-icu` build without the SEA dictionaries) or throws, we return no
+//     offsets and the caller keeps its current cluster/character behaviour.
+//
+// Scope: Thai U+0E00–0E7F, Lao U+0E80–0EFF, Khmer U+1780–17FF — exactly the
+// ranges named in the issue. Myanmar/Tibetan and the no-space Thai↔Latin/CJK
+// script-transition boundary are intentionally out of scope (follow-ups).
+
+/** Southeast-Asian dictionary-break script tags used to pick the ICU dictionary.
+ *  ICU dispatches the dictionary by the character's SCRIPT, not by this locale,
+ *  so it is only a hint; we still pick per-span for clarity/forward-safety. */
+export type SeaScript = 'th' | 'lo' | 'km';
+
+/**
+ * True when `cp` belongs to one of the no-inter-word-space SEA scripts (Thai,
+ * Lao, Khmer). This is a SCRIPT-membership test, not a break predicate: the
+ * blocks include combining marks, tone marks, digits and punctuation that are
+ * NOT independently breakable — the actual break opportunities come from
+ * {@link seaWordBreakOffsets}. Used to detect SEA spans and as the cheap gate in
+ * {@link containsSeaScript}.
+ *
+ * @param cp A Unicode scalar value (e.g. from `String.prototype.codePointAt`).
+ */
+export function isSeaScriptCodePoint(cp: number): boolean {
+  return (
+    (cp >= 0x0e00 && cp <= 0x0e7f) || // Thai
+    (cp >= 0x0e80 && cp <= 0x0eff) || // Lao
+    (cp >= 0x1780 && cp <= 0x17ff) // Khmer
+  );
+}
+
+/** The SEA script of a code point already known to be SEA (see
+ *  {@link isSeaScriptCodePoint}). Used to pick the per-span ICU dictionary. */
+function seaScriptOf(cp: number): SeaScript {
+  if (cp <= 0x0e7f) return 'th';
+  if (cp <= 0x0eff) return 'lo';
+  return 'km';
+}
+
+/**
+ * Cheap presence gate: true when any code point of `text` is SEA-script. Used by
+ * the renderers to skip all segmentation work for the overwhelmingly common
+ * non-SEA input (zero `Intl.Segmenter` cost), mirroring docx's
+ * `hasCJKBreakOpportunity`.
+ */
+export function containsSeaScript(text: string): boolean {
+  for (const ch of text) {
+    if (isSeaScriptCodePoint(ch.codePointAt(0)!)) return true;
+  }
+  return false;
+}
+
+// ── Segmenter plumbing (cached + test-injectable) ────────────────────────────
+
+/** Minimal shape of one `Intl.Segments` entry we rely on. */
+interface SeaSegment {
+  index: number;
+  isWordLike?: boolean;
+}
+/** A word segmenter: text (a single SEA span) → its word segments. Injected in
+ *  tests for determinism / to exercise the unavailable + throwing paths. */
+export type SeaWordSegmenter = (text: string, script: SeaScript) => Iterable<SeaSegment>;
+
+// `undefined` = use the platform ICU segmenter; `null` = force unavailable
+// (test); a function = use it (test).
+let wordSegmenterOverride: SeaWordSegmenter | null | undefined;
+
+const intlWordCache = new Map<SeaScript, Intl.Segmenter | null>();
+
+function intlWordSegmenter(script: SeaScript): Intl.Segmenter | null {
+  const cached = intlWordCache.get(script);
+  if (cached !== undefined) return cached;
+  let seg: Intl.Segmenter | null = null;
+  try {
+    if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
+      seg = new Intl.Segmenter(script, { granularity: 'word' });
+    }
+  } catch {
+    seg = null;
+  }
+  intlWordCache.set(script, seg);
+  return seg;
+}
+
+function wordSegmenterFor(script: SeaScript): ((span: string) => Iterable<SeaSegment>) | null {
+  if (wordSegmenterOverride === null) return null; // forced unavailable (test)
+  if (typeof wordSegmenterOverride === 'function') {
+    const fn = wordSegmenterOverride;
+    return (span) => fn(span, script);
+  }
+  const intl = intlWordSegmenter(script);
+  return intl ? (span) => intl.segment(span) as Iterable<SeaSegment> : null;
+}
+
+/** Test seam: override the word segmenter. `null` forces the unavailable path;
+ *  a function supplies deterministic segments; call {@link resetSeaSegmenterForTest}
+ *  to restore the platform ICU segmenter. Not for production use. */
+export function setSeaWordSegmenterForTest(fn: SeaWordSegmenter | null): void {
+  wordSegmenterOverride = fn;
+}
+/** Test seam: restore the default platform ICU segmenter and clear caches. */
+export function resetSeaSegmenterForTest(): void {
+  wordSegmenterOverride = undefined;
+  intlWordCache.clear();
+  graphemeSegmenter = undefined;
+}
+
+// ── Word break offsets ───────────────────────────────────────────────────────
+
+/**
+ * Enumerate dictionary word-break opportunities in `text`, as UTF-16 offsets `i`
+ * such that a line break is permitted immediately BEFORE `text[i]`.
+ *
+ * Only boundaries that are (1) interior to a maximal SEA-script span and (2) the
+ * START of a word-like segment are returned — so we never break before intra-SEA
+ * punctuation (Khmer `។`, Thai `๚`) nor at a SEA↔non-SEA transition (left to the
+ * existing logic). The offsets are always at grapheme-cluster boundaries (ICU
+ * word breaks never split a base + combining mark).
+ *
+ * Returns `[]` (graceful fallback) when `text` has no SEA character, when
+ * `Intl.Segmenter` is unavailable, or when segmentation throws. Segment ONCE per
+ * logical string and cache/slice the result; do not call this per line.
+ */
+export function seaWordBreakOffsets(text: string): number[] {
+  if (!containsSeaScript(text)) return [];
+  const offsets: number[] = [];
+  const len = text.length;
+  let i = 0;
+  while (i < len) {
+    const cp = text.codePointAt(i)!;
+    const step = cp > 0xffff ? 2 : 1;
+    if (!isSeaScriptCodePoint(cp)) {
+      i += step;
+      continue;
+    }
+    // Maximal SEA span [i, j). The span's dictionary is picked from its first
+    // character; ICU still dispatches per-script internally within the span.
+    const script = seaScriptOf(cp);
+    let j = i + step;
+    while (j < len) {
+      const c = text.codePointAt(j)!;
+      if (!isSeaScriptCodePoint(c)) break;
+      j += c > 0xffff ? 2 : 1;
+    }
+    const segFn = wordSegmenterFor(script);
+    if (segFn) {
+      const span = text.slice(i, j);
+      // Accumulate this span's offsets in a temp buffer and commit them only
+      // after the iterator completes, so a mid-iteration `segment()` failure
+      // leaves NO partial offsets (all-or-nothing graceful fallback per span).
+      const spanOffsets: number[] = [];
+      try {
+        for (const g of segFn(span)) {
+          // index>0 keeps the offset interior to the span (never span-start,
+          // which is a SEA↔non-SEA edge or the string start). isWordLike keeps
+          // it a break-before-a-WORD (never before punctuation). Fake segmenters
+          // may omit isWordLike → treat as word-like.
+          if (g.index > 0 && (g.isWordLike ?? true)) spanOffsets.push(i + g.index);
+        }
+        for (const o of spanOffsets) offsets.push(o);
+      } catch {
+        // segment() failure on this span → add no offsets (graceful fallback).
+      }
+    }
+    i = j;
+  }
+  return offsets;
+}
+
+// ── Greedy whole-word line fit (shared kernel) ───────────────────────────────
+
+/**
+ * Greedy whole-word line fit for SEA dictionary breaking, shared by all three
+ * renderers so the break decision is defined once.
+ *
+ * Returns the largest `end` with `start < end <= text.length` such that
+ *   (a) `end === text.length` OR `end` is a member of `offsets` (a legal word
+ *       boundary), AND
+ *   (b) `measure(text.slice(start, end)) <= avail`.
+ * If not even the first candidate word fits within `avail`, returns `start`
+ * (no progress) so the caller can wrap to a fresh line first, or — on an already
+ * empty line — fall back to a grapheme-safe emergency split.
+ *
+ * Every candidate is measured (no early return): advance width is NOT guaranteed
+ * monotone in the prefix length because Word/PowerPoint allow NEGATIVE character
+ * spacing (`w:spacing` / `a:spc`), so a longer prefix can fit after a shorter one
+ * overflowed. We keep the largest boundary (or the full remainder) that fits.
+ *
+ * `offsets` MUST be sorted ascending (as produced by {@link seaWordBreakOffsets}
+ * or {@link graphemeClusterOffsets}). `measure` supplies the caller's exact
+ * advance model (so measure==paint). Pure — no canvas/DOM.
+ */
+export function fitSeaWordPrefix(
+  text: string,
+  offsets: readonly number[],
+  start: number,
+  avail: number,
+  measure: (sub: string) => number,
+): number {
+  const len = text.length;
+  if (start >= len) return start;
+  let best = start;
+  for (const b of offsets) {
+    if (b <= start || b >= len) continue;
+    if (measure(text.slice(start, b)) <= avail) best = b;
+  }
+  if (measure(text.slice(start, len)) <= avail) best = len;
+  return best;
+}
+
+// ── Grapheme clusters (emergency over-long-word split) ───────────────────────
+
+let graphemeSegmenter: Intl.Segmenter | null | undefined;
+
+function getGraphemeSegmenter(): Intl.Segmenter | null {
+  if (graphemeSegmenter !== undefined) return graphemeSegmenter;
+  let seg: Intl.Segmenter | null = null;
+  try {
+    if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
+      seg = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+    }
+  } catch {
+    seg = null;
+  }
+  graphemeSegmenter = seg;
+  return seg;
+}
+
+/**
+ * Grapheme-cluster break-before offsets (UTF-16, interior — excludes 0 and
+ * `text.length`). Used for the last-resort emergency split of a single SEA word
+ * wider than the whole line/cell: a code-point split would tear a base +
+ * combining/tone mark (both are BMP, so "SEA is BMP therefore safe" is false),
+ * whereas a grapheme boundary keeps the cluster intact. Falls back to code-point
+ * boundaries when `Intl.Segmenter` is unavailable.
+ */
+export function graphemeClusterOffsets(text: string): number[] {
+  const out: number[] = [];
+  const seg = getGraphemeSegmenter();
+  if (seg) {
+    for (const g of seg.segment(text)) {
+      if (g.index > 0) out.push(g.index);
+    }
+    return out;
+  }
+  for (let i = 0; i < text.length; ) {
+    const cp = text.codePointAt(i)!;
+    i += cp > 0xffff ? 2 : 1;
+    if (i < text.length) out.push(i);
+  }
+  return out;
+}

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -30,6 +30,10 @@ import {
   kinsokuAdjustedSplit,
   crossRunKinsokuRetract,
   isCjkBreakChar,
+  containsSeaScript,
+  seaWordBreakOffsets,
+  fitSeaWordPrefix,
+  graphemeClusterOffsets,
   classifyFontGeneric,
   isComplexScriptCodePoint,
   isSymbolFontFamily,
@@ -176,6 +180,13 @@ export interface LayoutTextSeg extends LayoutSegSource {
    *  the horizontally-laid-out run so it fits the line height. Only meaningful
    *  when {@link tateChuYoko} is set. */
   tateChuYokoCompress?: boolean;
+  /** Issue #797 — dictionary word-break offsets (seg-local UTF-16 indices, from
+   *  core `seaWordBreakOffsets`) for a Thai/Lao/Khmer segment, which has no
+   *  inter-word spaces. Populated by {@link layoutLines} for SEA text; the wrap
+   *  path breaks such a segment only at one of these boundaries (never mid-word)
+   *  and re-queues the tail with the offsets rebased. Absent ⇒ not SEA text, or
+   *  Intl.Segmenter unavailable (falls back to grapheme-safe emergency split). */
+  seaBreaks?: readonly number[];
 }
 
 /**
@@ -1264,6 +1275,20 @@ export function hasCJKBreakOpportunity(text: string): boolean {
     i += cp > 0xffff ? 2 : 1;
   }
   return false;
+}
+
+/** Shift a SEA break-offset list (issue #797) onto a suffix that drops the first
+ *  `cut` UTF-16 units: keep offsets strictly greater than `cut` and rebase them.
+ *  Used when a Thai/Lao/Khmer segment is split (line wrap) or resumed at a
+ *  pagination boundary. A non-SEA segment (`offsets === undefined`) stays
+ *  non-SEA; a SEA segment stays SEA-flagged (returns `[]` when no dictionary
+ *  boundary remains, so an over-long FINAL word still takes the SEA path and is
+ *  split grapheme-safely rather than by code point). */
+function rebaseSeaBreaks(offsets: readonly number[] | undefined, cut: number): readonly number[] | undefined {
+  if (offsets === undefined) return undefined;
+  const out: number[] = [];
+  for (const o of offsets) if (o > cut) out.push(o - cut);
+  return out;
 }
 
 /**
@@ -2601,6 +2626,12 @@ export function layoutLines(
   const endBoundary: LineBoundary = { segIndex: segs.length, charOffset: 0 };
   const sourcedSegs = segs.map((seg, segIndex) => {
     seg.src = { segIndex, charOffset: 0 };
+    // Issue #797 — attach the SEA (Thai/Lao/Khmer) dictionary word-break offsets
+    // ONCE per segment (perf: never per line/char). Only for SEA text; non-SEA
+    // segments keep `seaBreaks` absent so their wrap path is byte-identical.
+    if ('text' in seg && containsSeaScript(seg.text)) {
+      seg.seaBreaks = seaWordBreakOffsets(seg.text);
+    }
     return seg;
   });
   let queue: LayoutSeg[];
@@ -2622,6 +2653,9 @@ export function layoutLines(
                 text,
                 measuredWidth: 0,
                 src: { ...startBoundary },
+                // Rebase the SEA break offsets onto the resumed (sliced) text so
+                // a paginated Thai paragraph still breaks at word boundaries.
+                seaBreaks: rebaseSeaBreaks(first.seaBreaks, startBoundary.charOffset),
               },
               ...sourcedSegs.slice(startBoundary.segIndex + 1),
             ]
@@ -3033,7 +3067,10 @@ export function layoutLines(
       !s.joinPrev &&
       currentLine.length > 0 &&
       (queue[0] as LayoutTextSeg | undefined)?.joinPrev &&
-      !hasCJKBreakOpportunity(s.text)
+      !hasCJKBreakOpportunity(s.text) &&
+      // A SEA (Thai/Lao/Khmer) lead with usable word breaks is NOT atomic — the
+      // run splits at a dictionary boundary (issue #797), mirroring the CJK gate.
+      !(s.seaBreaks && s.seaBreaks.length > 0)
     ) {
       let groupW = w;
       let groupTrail = trailingSpaceW;
@@ -3184,6 +3221,63 @@ export function layoutLines(
               },
             });
           }
+        }
+      }
+    } else if (s.seaBreaks !== undefined) {
+      // SEA (Thai/Lao/Khmer) dictionary line wrap (issue #797). These scripts
+      // have no inter-word spaces, so this ONE segment is a whole run of words;
+      // break it only at a segmenter word boundary (`s.seaBreaks`). Entered for
+      // ANY SEA segment (even one with no dictionary boundary — a single word
+      // wider than the column, or Segmenter unavailable) so the emergency split
+      // below stays GRAPHEME-safe instead of falling to the code-point path.
+      // No kinsoku runs here — SEA scripts have no 行頭/行末禁則 sets and a
+      // dictionary boundary is already a legal break (choosing an earlier legal
+      // offset is the only adjustment, which fitSeaWordPrefix already does). The
+      // run stays one contiguous draw per line (measure==paint); the tail
+      // re-queues with its offsets rebased.
+      const available = availW() - currentWidth;
+      const measureSub = (sub: string): number => strAdvance(s, sub);
+      const split = fitSeaWordPrefix(s.text, s.seaBreaks, 0, available, measureSub);
+      if (split > 0) {
+        const prefix = s.text.slice(0, split);
+        const pw = strAdvance(s, prefix);
+        addToLine({ ...s, text: prefix, measuredWidth: pw }, pw, h, asc, desc);
+        const tail = s.text.slice(split);
+        if (tail) {
+          queue.unshift({
+            ...s,
+            text: tail,
+            measuredWidth: 0,
+            src: { segIndex: s.src!.segIndex, charOffset: s.src!.charOffset + split },
+            seaBreaks: rebaseSeaBreaks(s.seaBreaks, split),
+          });
+        }
+      } else if (currentLine.length > 0) {
+        // No whole dictionary word fits the remaining band — move the run to a
+        // fresh line and re-process (Latin-word style).
+        flush(undefined, false, s.src);
+        queue.unshift(s);
+      } else {
+        // Empty line and the first dictionary word is wider than the whole
+        // column: emergency GRAPHEME-safe split (a code-point split would tear a
+        // base + tone/combining mark, both BMP). Guarantee ≥1 cluster of progress.
+        const firstWordEnd = s.seaBreaks[0] ?? s.text.length;
+        const firstWord = s.text.slice(0, firstWordEnd);
+        const graphemes = graphemeClusterOffsets(firstWord);
+        let gsplit = fitSeaWordPrefix(firstWord, graphemes, 0, available, measureSub);
+        if (gsplit <= 0) gsplit = graphemes.length > 0 ? graphemes[0] : firstWord.length;
+        const prefix = s.text.slice(0, gsplit);
+        const pw = strAdvance(s, prefix);
+        addToLine({ ...s, text: prefix, measuredWidth: pw }, pw, h, asc, desc);
+        const tail = s.text.slice(gsplit);
+        if (tail) {
+          queue.unshift({
+            ...s,
+            text: tail,
+            measuredWidth: 0,
+            src: { segIndex: s.src!.segIndex, charOffset: s.src!.charOffset + gsplit },
+            seaBreaks: rebaseSeaBreaks(s.seaBreaks, gsplit),
+          });
         }
       }
     } else if (currentLine.length === 0) {

--- a/packages/docx/src/sea-line-break.test.ts
+++ b/packages/docx/src/sea-line-break.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_KINSOKU_RULES, seaWordBreakOffsets } from '@silurus/ooxml-core';
+import { layoutLines, type LayoutLine, type LayoutSeg, type LayoutTextSeg } from './line-layout.js';
+
+// Issue #797 — dictionary-based line breaking for Thai/Lao/Khmer (no inter-word
+// spaces). The docx wrap loop must break a SEA run only at a segmenter word
+// boundary, never mid-word, and never lose/duplicate text. The stub metric is
+// 5px per code point (see makeLinearCtx), so break points are deterministic w.r.t.
+// widths; the WORD boundaries come from the platform ICU dictionary, and we
+// assert the PROPERTY (every break ∈ seaWordBreakOffsets) rather than exact
+// offsets so the test is robust to ICU version drift.
+
+function makeLinearCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const fontSize = (): number => Number.parseFloat(/([\d.]+)px/.exec(font)?.[1] ?? '10');
+  return {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    letterSpacing: '0px',
+    measureText: (text: string) => {
+      const size = fontSize();
+      return {
+        width: [...text].length * size * 0.5,
+        fontBoundingBoxAscent: size * 0.8,
+        fontBoundingBoxDescent: size * 0.2,
+        actualBoundingBoxAscent: size * 0.8,
+        actualBoundingBoxDescent: size * 0.2,
+      } as TextMetrics;
+    },
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function textSeg(text: string): LayoutTextSeg {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 10, color: null, fontFamily: 'T', vertAlign: null, measuredWidth: 0,
+  } as unknown as LayoutTextSeg;
+}
+
+function lay(segs: LayoutSeg[], width: number): LayoutLine[] {
+  return layoutLines(
+    makeLinearCtx(), segs, width, 0, 1, [], undefined, {}, 0,
+    DEFAULT_KINSOKU_RULES, 0, 36, width, false,
+  );
+}
+
+const lineTexts = (lines: LayoutLine[]): string[] =>
+  lines.map((l) => l.segments.filter((s): s is LayoutTextSeg => 'text' in s).map((s) => s.text).join(''));
+
+/** Cumulative UTF-16 offset at the END of each non-final line — i.e. every point
+ *  where the paragraph was broken. */
+function breakOffsets(texts: string[]): number[] {
+  const out: number[] = [];
+  let acc = 0;
+  for (let i = 0; i < texts.length - 1; i++) {
+    acc += texts[i].length;
+    out.push(acc);
+  }
+  return out;
+}
+
+describe('SEA (Thai) dictionary line breaking in docx layoutLines', () => {
+  const thai = 'ภาษาไทยเป็นภาษาที่สวยงามมาก'; // one spaceless Thai run
+  const wordStarts = new Set(seaWordBreakOffsets(thai)); // legal break-before offsets
+
+  it('has dictionary break opportunities to work with', () => {
+    expect(wordStarts.size).toBeGreaterThan(1);
+  });
+
+  it('breaks only at dictionary word boundaries and preserves the text', () => {
+    const lines = lay([textSeg(thai)], 50); // 10 code points fit per line
+    const texts = lineTexts(lines);
+    expect(texts.length).toBeGreaterThan(1); // it actually wrapped
+    expect(texts.join('')).toBe(thai); // nothing lost or duplicated
+    for (const b of breakOffsets(texts)) {
+      expect(wordStarts.has(b)).toBe(true); // never mid-word
+    }
+  });
+
+  it('packs as many whole words as fit before each break', () => {
+    // Width 50 = 10 code points. First line takes the widest word run ≤ 10 cp.
+    const lines = lay([textSeg(thai)], 50);
+    const texts = lineTexts(lines);
+    for (const t of texts.slice(0, -1)) {
+      expect([...t].length).toBeLessThanOrEqual(10);
+    }
+    // And it packed more than a single (short) first word onto line 1.
+    expect([...texts[0]].length).toBeGreaterThan(4);
+  });
+
+  it('makes progress and preserves text when the band is narrower than one word (emergency split)', () => {
+    // Width 8 < first word (ภาษา = 4 cp = 20px): grapheme-safe emergency split.
+    const lines = lay([textSeg(thai)], 8);
+    const texts = lineTexts(lines);
+    expect(texts.join('')).toBe(thai);
+    expect(texts.every((t) => t.length > 0)).toBe(true); // no empty line / infinite loop
+  });
+
+  it('keeps a Thai run that fits on one line as a single contiguous segment (measure==paint)', () => {
+    const lines = lay([textSeg(thai)], 200); // 27 cp = 135px < 200 — fits
+    expect(lines).toHaveLength(1);
+    const segs = lines[0].segments.filter((s): s is LayoutTextSeg => 'text' in s);
+    expect(segs).toHaveLength(1); // ONE draw, not fragmented per word
+    expect(segs[0].text).toBe(thai);
+  });
+
+  it('splits a single over-long SEA word (no dictionary boundary) grapheme-safely', () => {
+    const word = 'ภาษา'; // one Thai dictionary word → seaWordBreakOffsets = []
+    expect(seaWordBreakOffsets(word)).toEqual([]); // precondition: no interior break
+    const lines = lay([textSeg(word)], 8); // 8px < 4 cp × 5px = 20px
+    const texts = lineTexts(lines);
+    expect(texts.join('')).toBe(word); // text preserved
+    expect(texts.every((t) => t.length > 0)).toBe(true); // progress, no infinite loop
+  });
+
+  it('does not alter non-SEA (Latin) wrapping', () => {
+    // Two Latin words; 'hello ' fit-width collapses trailing space. Byte-identical
+    // to the pre-existing behavior (no SEA code path entered).
+    const lines = lay([textSeg('hello '), textSeg('world')], 30);
+    expect(lineTexts(lines).join('')).toContain('hello');
+    expect(lineTexts(lines).join('')).toContain('world');
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -62,6 +62,10 @@ import {
   NON_CJK_SERIF_FALLBACKS,
   DEFAULT_KINSOKU_RULES,
   isCjkBreakChar,
+  containsSeaScript,
+  seaWordBreakOffsets,
+  fitSeaWordPrefix,
+  graphemeClusterOffsets,
   getCachedSvgImageByPath,
   getCachedBitmapByPath,
   getCachedDuotoneBitmapByPath,
@@ -1114,6 +1118,43 @@ export function layoutParagraph(
           }
           rest = rest.slice(n);
           if (rest.length > 0) newLine();
+        }
+        continue;
+      }
+
+      // SEA (Thai/Lao/Khmer) dictionary line breaking (issue #797). These scripts
+      // have no inter-word spaces, so `token` is a whole run of words; break it
+      // only at a segmenter word boundary. Each fitted line-piece is pushed as
+      // ONE contiguous string — pptx's `push` sums per-call measured widths into
+      // `lineW`, so per-word pushes would drift the wrap width from the merged
+      // paint width (measure==paint). CJK is handled above; a mixed CJK+SEA token
+      // stays on the CJK path (no regression). A SEA token with no dictionary
+      // break (single over-long word / Segmenter unavailable) still routes here
+      // so its emergency split stays grapheme-safe.
+      if (containsSeaScript(token)) {
+        const seaBreaks = seaWordBreakOffsets(token);
+        ctx.font = font;
+        // Match push's advance model: it adds `lsPx * codePointCount` (a:spc), so
+        // the fit measure must too or a spaced run mis-wraps (measure==paint).
+        const measureSub = (sub: string): number => ctx.measureText(sub).width + lsPx * codePointCount(sub);
+        const N = token.length;
+        let start = 0;
+        while (start < N) {
+          const avail = lineMaxW() - lineW;
+          let end = fitSeaWordPrefix(token, seaBreaks, start, avail, measureSub);
+          if (end <= start) {
+            if (lineW > 0) { newLine(); continue; } // wrap first, retry empty line
+            // Empty line, first word wider than the shape: grapheme-safe split.
+            const firstWordEnd = seaBreaks.find((b) => b > start) ?? N;
+            const firstWord = token.slice(start, firstWordEnd);
+            const graphemes = graphemeClusterOffsets(firstWord);
+            let g = fitSeaWordPrefix(firstWord, graphemes, 0, avail, measureSub);
+            if (g <= 0) g = graphemes.length > 0 ? graphemes[0] : firstWord.length;
+            end = start + g;
+          }
+          push(token.slice(start, end), font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
+          start = end;
+          if (start < N) newLine();
         }
         continue;
       }

--- a/packages/pptx/src/sea-line-break.test.ts
+++ b/packages/pptx/src/sea-line-break.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { seaWordBreakOffsets } from '@silurus/ooxml-core';
+import { layoutParagraph } from './renderer.js';
+import type { Paragraph } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+// Issue #797 — dictionary line breaking for Thai/Lao/Khmer in pptx. A spaceless
+// Thai run must wrap at segmenter word boundaries (never mid-word), and each
+// line's SEA text must stay ONE segment (measure==paint — pptx sums per-push
+// widths into the wrap accumulator). char = 10px in the mock, so widths are
+// deterministic; word boundaries come from the platform ICU dictionary.
+
+function mockCtx() {
+  let font = '';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    measureText: (s: string) => ({ width: s.length * 10 }),
+    fillRect() {}, fillText() {},
+    fillStyle: '', strokeStyle: '',
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function run(text: string, over: Partial<TextRunData> = {}): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: 20, color: '000000', fontFamily: 'Arial', ...over,
+  };
+}
+
+function para(runs: TextRunData[]): Paragraph {
+  return {
+    alignment: 'l', marL: 0, marR: 0, indent: 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null,
+    defItalic: null, defFontFamily: null, tabStops: [], eaLnBrk: true, runs,
+  } as Paragraph;
+}
+
+const lineText = (line: { segments: { text: string }[] }): string =>
+  line.segments.map((s) => s.text).join('');
+
+function breakOffsets(texts: string[]): number[] {
+  const out: number[] = [];
+  let acc = 0;
+  for (let i = 0; i < texts.length - 1; i++) { acc += texts[i].length; out.push(acc); }
+  return out;
+}
+
+describe('pptx SEA (Thai) dictionary line breaking', () => {
+  const thai = 'ภาษาไทยเป็นภาษาที่สวยงามมาก';
+  const wordStarts = new Set(seaWordBreakOffsets(thai));
+
+  it('breaks only at dictionary word boundaries and preserves the text', () => {
+    const lines = layoutParagraph(mockCtx(), para([run(thai)]), 100, 20, '000000', 1, 0);
+    const texts = lines.map(lineText);
+    expect(texts.length).toBeGreaterThan(1);
+    expect(texts.join('')).toBe(thai);
+    for (const b of breakOffsets(texts)) expect(wordStarts.has(b)).toBe(true);
+  });
+
+  it('keeps each wrapped line SEA text as a single segment (measure==paint)', () => {
+    const lines = layoutParagraph(mockCtx(), para([run(thai)]), 100, 20, '000000', 1, 0);
+    for (const ln of lines) {
+      const textSegs = ln.segments.filter((s) => s.text.length > 0);
+      // At most one text segment per line (all same-font Thai merges / is one push).
+      expect(textSegs.length).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('makes progress and preserves text when the shape is narrower than one word', () => {
+    const lines = layoutParagraph(mockCtx(), para([run(thai)]), 15, 20, '000000', 1, 0);
+    const texts = lines.map(lineText);
+    expect(texts.join('')).toBe(thai);
+    expect(texts.every((t) => t.length > 0)).toBe(true);
+  });
+
+  it('lays a Thai run that fits on one line without fragmenting', () => {
+    const lines = layoutParagraph(mockCtx(), para([run(thai)]), 400, 20, '000000', 1, 0);
+    expect(lines).toHaveLength(1);
+    const textSegs = lines[0].segments.filter((s) => s.text.length > 0);
+    expect(textSegs).toHaveLength(1);
+    expect(textSegs[0].text).toBe(thai);
+  });
+});

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -6,7 +6,7 @@ import type {
   PhoneticRun, PhoneticProperties, PhoneticAlignment, Duotone,
 } from './types.js';
 import { placePhoneticRuns } from './phonetic.js';
-import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
+import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, containsSeaScript, seaWordBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValueWithColor } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -911,7 +911,21 @@ export function wrapParagraphLines(ctx: CanvasRenderingContext2D, paragraph: str
         if (c === ' ' || isCjkBreakChar(p)) break;
         j += p > 0xFFFF ? 2 : 1;
       }
-      tokens.push(paragraph.slice(i, j));
+      const word = paragraph.slice(i, j);
+      // SEA (Thai/Lao/Khmer) dictionary breaking (issue #797): these scripts have
+      // no inter-word spaces, so this whole word-run is one token. Split it at
+      // segmenter word boundaries into sub-word tokens so the greedy fitter below
+      // wraps it at legal points. Wrapped lines re-concatenate into one drawn
+      // string, so this only ADDS break opportunities (measure==paint). Non-SEA
+      // words and SEA words with no usable break stay a single token.
+      const seaBreaks = containsSeaScript(word) ? seaWordBreakOffsets(word) : null;
+      if (seaBreaks && seaBreaks.length > 0) {
+        let s = 0;
+        for (const b of seaBreaks) { tokens.push(word.slice(s, b)); s = b; }
+        tokens.push(word.slice(s));
+      } else {
+        tokens.push(word);
+      }
       i = j;
     }
   }
@@ -1086,6 +1100,36 @@ export function layoutRichTextLines(
     if (font.size > curMaxSize) { curMaxSize = font.size; curMaxFamily = font.name; }
   };
 
+  // Issue #797 — push a SEA (Thai/Lao/Khmer) token, breaking it at segmenter word
+  // boundaries. Unlike the plain `wrapParagraphLines`, the rich draw path paints
+  // every segment separately, so each fitted line-piece is pushed as ONE
+  // contiguous string (via `push`) to keep measure==paint. A single word wider
+  // than the cell falls back to a grapheme-safe emergency split.
+  const pushSeaToken = (text: string, font: CellFont): void => {
+    const seaBreaks = seaWordBreakOffsets(text);
+    if (seaBreaks.length === 0) { push(text, font); return; }
+    ctx.font = buildFont(vertAlignDrawFont(font), cs);
+    const measureSub = (sub: string): number => ctx.measureText(sub).width;
+    const N = text.length;
+    let start = 0;
+    while (start < N) {
+      const avail = maxWidth - curW;
+      let end = fitSeaWordPrefix(text, seaBreaks, start, avail, measureSub);
+      if (end <= start) {
+        if (curW > 0) { flush(); continue; } // wrap first, retry on an empty line
+        const firstWordEnd = seaBreaks.find((b) => b > start) ?? N;
+        const firstWord = text.slice(start, firstWordEnd);
+        const graphemes = graphemeClusterOffsets(firstWord);
+        let g = fitSeaWordPrefix(firstWord, graphemes, 0, avail, measureSub);
+        if (g <= 0) g = graphemes.length > 0 ? graphemes[0] : firstWord.length;
+        end = start + g;
+      }
+      push(text.slice(start, end), font); // the piece fits → append (no re-split)
+      start = end;
+      if (start < N) flush();
+    }
+  };
+
   for (const run of runs) {
     const font = applyRunFont(baseFont, run);
     // Tokenize: runs of non-space latin, spaces, or individual CJK chars
@@ -1123,6 +1167,7 @@ export function layoutRichTextLines(
       // inside `push`) keeps the same index — UAX#9 P1: only a hard break starts
       // a new bidi paragraph.
       if (tok === '\n') { flushRegion(); paraIdx++; }
+      else if (containsSeaScript(tok)) pushSeaToken(tok, font);
       else push(tok, font);
     }
   }

--- a/packages/xlsx/src/sea-line-break.test.ts
+++ b/packages/xlsx/src/sea-line-break.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { seaWordBreakOffsets } from '@silurus/ooxml-core';
+import { wrapParagraphLines, layoutRichTextLines } from './renderer.js';
+import type { CellFont, Run } from './types.js';
+
+// Issue #797 — dictionary line breaking for Thai/Lao/Khmer in xlsx. Both the
+// plain path (`wrapParagraphLines`, lines re-concatenated into one drawn string)
+// and the rich path (`layoutRichTextLines`, one fillText per segment) must wrap a
+// spaceless SEA run at segmenter word boundaries without tearing a word, and the
+// rich path must keep each line's SEA text as ONE segment (measure==paint).
+// char = 10px in the stub; word boundaries come from the platform ICU dictionary.
+
+const ctx = {
+  font: '',
+  measureText: (s: string) => ({ width: [...s].length * 10 }),
+} as unknown as CanvasRenderingContext2D;
+
+const baseFont: CellFont = {
+  bold: false, italic: false, underline: false, strike: false, size: 11, color: null, name: null,
+};
+
+const richText = (lines: ReturnType<typeof layoutRichTextLines>): string[] =>
+  lines.map((l) => l.segments.map((s) => s.text).join(''));
+
+function breakOffsets(texts: string[]): number[] {
+  const out: number[] = [];
+  let acc = 0;
+  for (let i = 0; i < texts.length - 1; i++) { acc += texts[i].length; out.push(acc); }
+  return out;
+}
+
+const thai = 'ภาษาไทยเป็นภาษาที่สวยงามมาก';
+const wordStarts = new Set(seaWordBreakOffsets(thai));
+
+describe('xlsx wrapParagraphLines — SEA (Thai) dictionary breaking', () => {
+  it('breaks only at dictionary word boundaries and preserves the text', () => {
+    const out = wrapParagraphLines(ctx, thai, 100); // 10 cp per line
+    expect(out.length).toBeGreaterThan(1);
+    expect(out.join('')).toBe(thai);
+    for (const b of breakOffsets(out)) expect(wordStarts.has(b)).toBe(true);
+  });
+
+  it('keeps a Thai run that fits on one line intact', () => {
+    expect(wrapParagraphLines(ctx, thai, 400)).toEqual([thai]);
+  });
+
+  it('does not change non-SEA wrapping (plain CJK parity)', () => {
+    expect(wrapParagraphLines(ctx, 'あいうえお', 30)).toEqual(['あいう', 'えお']);
+  });
+});
+
+describe('xlsx layoutRichTextLines — SEA (Thai) dictionary breaking', () => {
+  it('breaks only at word boundaries, preserves text, one segment per wrapped line', () => {
+    const lines = layoutRichTextLines(ctx, [{ text: thai }] as Run[], baseFont, 1, 100);
+    const texts = richText(lines);
+    expect(texts.length).toBeGreaterThan(1);
+    expect(texts.join('')).toBe(thai);
+    for (const b of breakOffsets(texts)) expect(wordStarts.has(b)).toBe(true);
+    // Each line is a single contiguous draw (measure==paint), not per-word segments.
+    for (const l of lines) expect(l.segments.length).toBeLessThanOrEqual(1);
+  });
+
+  it('lays a Thai run that fits on one line as a single segment', () => {
+    const lines = layoutRichTextLines(ctx, [{ text: thai }] as Run[], baseFont, 1, 400);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].segments).toHaveLength(1);
+    expect(lines[0].segments[0].text).toBe(thai);
+  });
+
+  it('makes progress and preserves text when the cell is narrower than one word', () => {
+    const lines = layoutRichTextLines(ctx, [{ text: thai }] as Run[], baseFont, 1, 15);
+    const texts = richText(lines);
+    expect(texts.join('')).toBe(thai);
+    expect(texts.every((t) => t.length > 0)).toBe(true);
+  });
+
+  it('does not change non-SEA wrapping (plain CJK parity)', () => {
+    const lines = layoutRichTextLines(ctx, [{ text: 'あいうえお' }] as Run[], baseFont, 1, 30);
+    expect(richText(lines)).toEqual(['あいう', 'えお']);
+  });
+});


### PR DESCRIPTION
## Problem

Thai, Lao and Khmer are written without inter-word spaces, so a line-break opportunity requires dictionary segmentation. The docx/pptx/xlsx line breakers only knew ASCII whitespace, per-character CJK breaks and Latin word boundaries, so a spaceless Thai run was treated as one unbreakable "word" — it overflowed the column/shape/cell or was split at an arbitrary code point, wrong against any Word/PowerPoint/Excel output.

## Fix

A shared core kernel `packages/core/src/text/sea-break.ts` uses the platform ICU dictionary via `Intl.Segmenter({ granularity: 'word' })` to enumerate the break opportunities **interior to each maximal SEA-script span** (Thai U+0E00–0E7F, Lao U+0E80–0EFF, Khmer U+1780–17FF), plus a pure greedy whole-word fit consumed by all three renderers:

- **core** — `isSeaScriptCodePoint`, `containsSeaScript`, `seaWordBreakOffsets` (word-to-word only, `isWordLike`-filtered so we never break before intra-SEA punctuation; restricted to SEA spans so non-SEA text is untouched), `fitSeaWordPrefix` (measures every candidate — advance is non-monotone under negative `w:spacing`/`a:spc`), and `graphemeClusterOffsets` for the grapheme-safe emergency split of a word wider than the whole band.
- **docx** — a wrap branch after the CJK branch that snaps the fit to a dictionary boundary and re-queues the tail with rebased offsets (including pagination resume); the run stays one contiguous draw per line.
- **pptx** — a branch parallel to the CJK path; each fitted line-piece is pushed as one contiguous string (push sums per-call widths, including `a:spc` letter spacing).
- **xlsx** — the plain tokenizer emits dictionary sub-word tokens (lines re-concatenate to one draw); the rich path splits in place per line-piece.

### Invariants
- **measure==paint** — a run is split only at the actual line break, so within a line the text is one contiguous draw with no glyph/width change.
- **non-SEA byte-identical** — all new code is gated behind `containsSeaScript`; non-SEA text takes the identical pre-existing path.
- **graceful fallback** — a missing/failing `Intl.Segmenter` (old runtime, small-icu without the SEA dictionaries) degrades to grapheme-safe cluster wrapping.
- CJK-first ordering is preserved (a mixed CJK+SEA token stays on the CJK path).

### Out of scope (follow-ups)
- Justified SEA distribution (`thaiDistribute`), now that breaking is correct.
- The no-space SEA↔Latin/CJK script-transition boundary.
- Myanmar/Tibetan.

## Verification

- New core + per-package unit tests assert breaks land only at dictionary boundaries, text is preserved, wrapped SEA lines stay a single segment (measure==paint), non-SEA wrapping is unchanged, and over-long single words split grapheme-safely.
- Full suites (3727 tests), `pnpm typecheck` and `pnpm lint` pass.
- Parsing the local Thai corpus samples confirms the fix segments real spaceless paragraphs (e.g. a 217-character run with no spaces) into linguistically correct words.
- Browser VRT / headless render were not runnable in this environment (no Chrome / skia-canvas); the wrap logic is covered by the unit tests that exercise the same layout functions used at render time.

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)