### PR TITLE
refactor(parser): unify MCE AlternateContent selection on ECMA-376 Part 3 §9.3

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3711,7 +3711,7 @@ fn parse_run_inner(
                 // understood, so the live chartex chart wins and its rendered-PNG
                 // Fallback is correctly NOT re-emitted (no double draw).
                 if let Some(selected) =
-                    select_mce_alternate_content(child, &docx_understands_drawing_ns)
+                    ooxml_common::mce::select_alternate_content(child, &docx_understands_drawing_ns)
                 {
                     for inner in selected.children().filter(|n| n.is_element()) {
                         if inner.tag_name().name() == "drawing" {
@@ -3950,46 +3950,6 @@ fn docx_understands_drawing_ns(ns: &str) -> bool {
         | "http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
         | "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"
     )
-}
-
-/// Select the active branch of an `<mc:AlternateContent>` per the MCE reference
-/// processing model (ECMA-376 Part 3 §9.3, Step 2):
-///
-/// - A `<mc:Choice>` is selected iff EVERY namespace named by its `Requires`
-///   attribute is understood (`understood`) AND no preceding sibling Choice was
-///   already selected. `Requires` is a whitespace-delimited list of namespace
-///   *prefixes*, resolved to URIs against the element's in-scope xmlns via
-///   `lookup_namespace_uri`. An empty / all-whitespace `Requires` (non-conformant
-///   — the schema requires ≥1 prefix) is treated as not-understood.
-/// - If no Choice is selected, the `<mc:Fallback>` (if present) is selected.
-///
-/// Returns the selected element node, or `None` when there is neither a
-/// selectable Choice nor a Fallback.
-fn select_mce_alternate_content<'a, 'i>(
-    ac: roxmltree::Node<'a, 'i>,
-    understood: &dyn Fn(&str) -> bool,
-) -> Option<roxmltree::Node<'a, 'i>> {
-    for choice in ac
-        .children()
-        .filter(|n| n.is_element() && n.tag_name().name() == "Choice")
-    {
-        let requires = choice.attribute("Requires").unwrap_or("");
-        let prefixes: Vec<&str> = requires.split_whitespace().collect();
-        // §9.3(1): each Requires prefix must resolve to an understood namespace.
-        // A conformant Choice has ≥1 prefix; an empty list can never be selected.
-        let all_understood = !prefixes.is_empty()
-            && prefixes.iter().all(|prefix| {
-                choice
-                    .lookup_namespace_uri(Some(*prefix))
-                    .is_some_and(understood)
-            });
-        if all_understood {
-            return Some(choice);
-        }
-    }
-    // §9.3: no Choice selected → the Fallback (if any) is selected.
-    ac.children()
-        .find(|n| n.is_element() && n.tag_name().name() == "Fallback")
 }
 
 fn parse_inline_drawing(

--- a/packages/ooxml-common/src/lib.rs
+++ b/packages/ooxml-common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod depth;
 pub mod drawing;
 pub mod fill;
 pub mod math;
+pub mod mce;
 pub mod ns;
 pub mod rels;
 pub mod text;

--- a/packages/ooxml-common/src/mce.rs
+++ b/packages/ooxml-common/src/mce.rs
@@ -1,0 +1,248 @@
+//! Markup Compatibility and Extensibility (MCE) — the `<mc:AlternateContent>`
+//! reference processing model shared by the docx, pptx and xlsx parsers.
+//!
+//! ECMA-376 Part 3 (Markup Compatibility and Extensibility), §9.3 "Step 2:
+//! Processing the AlternateContent, Choice and Fallback Elements" defines which
+//! branch of an `<mc:AlternateContent>` a consumer selects, verbatim:
+//!
+//! > A Choice element shall be marked as selected if the following conditions
+//! > are satisfied:
+//! > 1) Each of the namespaces specified by the Requires attribute of this
+//! >    element is included in the given application configuration;
+//! > 2) No preceding sibling Choice element is marked as selected; and
+//! > 3) The element is not a descendant of an application-defined extension
+//! >    element.
+//! > A Fallback element shall be marked as selected if the following conditions
+//! > are satisfied:
+//! > 1) No preceding sibling Choice element is marked as selected; and
+//! > 2) The element is not a descendant of an application-defined extension
+//! >    element.
+//!
+//! The "given application configuration" is the set of namespaces the consumer
+//! understands — i.e. those it has a handler that produces renderable output
+//! for. Each parser passes its own membership test as the `understood`
+//! predicate; the algorithm here is format-agnostic. Condition (3) concerns
+//! MCE's own nested-extension elements, which none of these host schemas emit
+//! around Choice/Fallback, so it needs no special handling: we only ever walk
+//! the direct Choice/Fallback children of one AlternateContent.
+//!
+//! This unifies three previously divergent local behaviours (issue #787): docx
+//! already implemented §9.3, pptx guessed via output-emptiness (never inspected
+//! `Requires`), and xlsx always took the Choice (never the Fallback), so an
+//! un-understood Choice with a renderable Fallback silently dropped content.
+
+use roxmltree::Node;
+
+/// Select the active branch of an `<mc:AlternateContent>` per ECMA-376 Part 3
+/// §9.3 (Step 2), returning the selected `<mc:Choice>` / `<mc:Fallback>` element
+/// node, or `None` when neither a selectable Choice nor a Fallback exists.
+///
+/// - A `<mc:Choice>` is selected iff EVERY namespace named by its `Requires`
+///   attribute is understood AND no preceding sibling Choice was already
+///   selected. `Requires` is a whitespace-delimited list of namespace *prefixes*
+///   (Part 3 §7.6), each resolved to a URI against the element's in-scope
+///   `xmlns` declarations via `lookup_namespace_uri`; the URI is then tested
+///   with `understood`. Resolving prefixes (not raw strings) means both the
+///   Transitional and Strict conformance classes work, and an arbitrary
+///   producer prefix (`cx`, `cx1`, …) binds to the same URI.
+/// - The schema requires `Requires` to list ≥1 prefix (§7.6); a missing or
+///   whitespace-only value is non-conformant and can never satisfy §9.3(1)
+///   ("*each* of the namespaces … is included"), so such a Choice is never
+///   selected.
+/// - If no Choice is selected, the `<mc:Fallback>` (if present) is selected.
+///
+/// `understood(ns_uri) -> bool` is the consumer's membership test for its
+/// application configuration: return `true` only for namespaces the caller can
+/// actually render, so an un-understood Choice correctly yields the Fallback.
+pub fn select_alternate_content<'a, 'i>(
+    ac: Node<'a, 'i>,
+    understood: &dyn Fn(&str) -> bool,
+) -> Option<Node<'a, 'i>> {
+    for choice in ac
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "Choice")
+    {
+        let requires = choice.attribute("Requires").unwrap_or("");
+        let prefixes: Vec<&str> = requires.split_whitespace().collect();
+        // §9.3(1): each Requires prefix must resolve, via an in-scope namespace
+        // declaration, to an understood namespace. A conformant Choice lists ≥1
+        // prefix; an empty list can never be "all understood".
+        let all_understood = !prefixes.is_empty()
+            && prefixes.iter().all(|prefix| {
+                choice
+                    .lookup_namespace_uri(Some(*prefix))
+                    .is_some_and(understood)
+            });
+        if all_understood {
+            // §9.3(2): first matching Choice wins; later Choices are ignored.
+            return Some(choice);
+        }
+    }
+    // §9.3: no Choice selected → the Fallback (if any) is selected.
+    ac.children()
+        .find(|n| n.is_element() && n.tag_name().name() == "Fallback")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse an `<mc:AlternateContent>` document, run §9.3 selection with the
+    /// given understood-URI set, and return the selected branch's `id` attribute
+    /// (each Choice/Fallback in the fixtures is tagged with a distinct `id`), or
+    /// `None` when nothing is selected.
+    fn select_id(xml: &str, understood: &[&str]) -> Option<String> {
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let ac = doc.root_element();
+        let pred = |ns: &str| understood.contains(&ns);
+        select_alternate_content(ac, &pred).and_then(|n| n.attribute("id").map(str::to_string))
+    }
+
+    // Fixtures bind prefixes to distinct URIs (mixing the Transitional-style and
+    // an unrelated "urn:" form to prove URI — not prefix-string — matching).
+    const NS: &str = concat!(
+        r#"xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" "#,
+        r#"xmlns:k1="urn:known:one" "#,
+        r#"xmlns:k2="urn:known:two" "#,
+        r#"xmlns:kalt="urn:known:one" "#, // second prefix, SAME URI as k1
+        r#"xmlns:u1="urn:unknown:one""#,
+    );
+
+    #[test]
+    fn understood_single_choice_selected() {
+        let xml = format!(
+            r#"<mc:AlternateContent {NS}>
+                 <mc:Choice id="c1" Requires="k1"><x/></mc:Choice>
+                 <mc:Fallback id="fb"><x/></mc:Fallback>
+               </mc:AlternateContent>"#
+        );
+        assert_eq!(select_id(&xml, &["urn:known:one"]).as_deref(), Some("c1"));
+    }
+
+    #[test]
+    fn unknown_only_choice_falls_back() {
+        let xml = format!(
+            r#"<mc:AlternateContent {NS}>
+                 <mc:Choice id="c1" Requires="u1"><x/></mc:Choice>
+                 <mc:Fallback id="fb"><x/></mc:Fallback>
+               </mc:AlternateContent>"#
+        );
+        assert_eq!(select_id(&xml, &["urn:known:one"]).as_deref(), Some("fb"));
+    }
+
+    #[test]
+    fn multi_namespace_requires_needs_all_understood() {
+        let xml = format!(
+            r#"<mc:AlternateContent {NS}>
+                 <mc:Choice id="c1" Requires="k1 u1"><x/></mc:Choice>
+                 <mc:Fallback id="fb"><x/></mc:Fallback>
+               </mc:AlternateContent>"#
+        );
+        // Only k1 understood → the "k1 u1" Choice is NOT all-understood → Fallback.
+        assert_eq!(select_id(&xml, &["urn:known:one"]).as_deref(), Some("fb"));
+        // Both understood → the Choice is selected.
+        assert_eq!(
+            select_id(&xml, &["urn:known:one", "urn:unknown:one"]).as_deref(),
+            Some("c1")
+        );
+    }
+
+    #[test]
+    fn second_choice_selected_when_first_not_understood() {
+        let xml = format!(
+            r#"<mc:AlternateContent {NS}>
+                 <mc:Choice id="c1" Requires="u1"><x/></mc:Choice>
+                 <mc:Choice id="c2" Requires="k1"><x/></mc:Choice>
+                 <mc:Fallback id="fb"><x/></mc:Fallback>
+               </mc:AlternateContent>"#
+        );
+        assert_eq!(select_id(&xml, &["urn:known:one"]).as_deref(), Some("c2"));
+    }
+
+    #[test]
+    fn first_understood_choice_wins_over_later() {
+        let xml = format!(
+            r#"<mc:AlternateContent {NS}>
+                 <mc:Choice id="c1" Requires="k1"><x/></mc:Choice>
+                 <mc:Choice id="c2" Requires="k2"><x/></mc:Choice>
+                 <mc:Fallback id="fb"><x/></mc:Fallback>
+               </mc:AlternateContent>"#
+        );
+        // §9.3(2): the FIRST understood Choice is selected even when a later
+        // Choice is also understood.
+        assert_eq!(
+            select_id(&xml, &["urn:known:one", "urn:known:two"]).as_deref(),
+            Some("c1")
+        );
+    }
+
+    #[test]
+    fn prefix_resolves_by_uri_not_spelling() {
+        // `kalt` is a different prefix bound to the SAME URI as `k1`. Selection
+        // is by resolved URI, so a Choice `Requires="kalt"` is understood.
+        let xml = format!(
+            r#"<mc:AlternateContent {NS}>
+                 <mc:Choice id="c1" Requires="kalt"><x/></mc:Choice>
+                 <mc:Fallback id="fb"><x/></mc:Fallback>
+               </mc:AlternateContent>"#
+        );
+        assert_eq!(select_id(&xml, &["urn:known:one"]).as_deref(), Some("c1"));
+    }
+
+    #[test]
+    fn missing_requires_is_never_selected() {
+        // Non-conformant: no Requires attribute at all → can't be all-understood.
+        let xml = format!(
+            r#"<mc:AlternateContent {NS}>
+                 <mc:Choice id="c1"><x/></mc:Choice>
+                 <mc:Fallback id="fb"><x/></mc:Fallback>
+               </mc:AlternateContent>"#
+        );
+        assert_eq!(select_id(&xml, &["urn:known:one"]).as_deref(), Some("fb"));
+    }
+
+    #[test]
+    fn blank_requires_is_never_selected() {
+        // Non-conformant: whitespace-only Requires → empty prefix list → not
+        // selectable (an empty list can never be "each … is included").
+        let xml = format!(
+            r#"<mc:AlternateContent {NS}>
+                 <mc:Choice id="c1" Requires="   "><x/></mc:Choice>
+                 <mc:Fallback id="fb"><x/></mc:Fallback>
+               </mc:AlternateContent>"#
+        );
+        assert_eq!(select_id(&xml, &["urn:known:one"]).as_deref(), Some("fb"));
+    }
+
+    #[test]
+    fn no_selectable_choice_and_no_fallback_returns_none() {
+        let xml = format!(
+            r#"<mc:AlternateContent {NS}>
+                 <mc:Choice id="c1" Requires="u1"><x/></mc:Choice>
+               </mc:AlternateContent>"#
+        );
+        assert_eq!(select_id(&xml, &["urn:known:one"]), None);
+    }
+
+    #[test]
+    fn understood_choice_with_no_fallback_still_selected() {
+        let xml = format!(
+            r#"<mc:AlternateContent {NS}>
+                 <mc:Choice id="c1" Requires="k1"><x/></mc:Choice>
+               </mc:AlternateContent>"#
+        );
+        assert_eq!(select_id(&xml, &["urn:known:one"]).as_deref(), Some("c1"));
+    }
+
+    #[test]
+    fn empty_understood_set_always_falls_back() {
+        let xml = format!(
+            r#"<mc:AlternateContent {NS}>
+                 <mc:Choice id="c1" Requires="k1"><x/></mc:Choice>
+                 <mc:Choice id="c2" Requires="k2"><x/></mc:Choice>
+                 <mc:Fallback id="fb"><x/></mc:Fallback>
+               </mc:AlternateContent>"#
+        );
+        assert_eq!(select_id(&xml, &[]).as_deref(), Some("fb"));
+    }
+}

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -26,6 +26,17 @@ use ooxml_common::ns::{is_diagram_uri, is_pml_ole_uri};
 use ooxml_common::units::EMU_PER_PX_96DPI;
 use std::collections::HashMap;
 
+/// ECMA-376 Part 3 §9.3 "given application configuration" for the pptx parser:
+/// the extension namespaces whose `<mc:Choice>` content the parser actually
+/// renders. chartEx (any dated version — the chart path renders them via the
+/// existing `uri.contains("chartex")` gate) and the Microsoft 2010 drawing
+/// extensions (a14) that wrap ordinary `<p:sp>`/`<p:pic>`. Deliberately EXCLUDES
+/// PowerPoint-2010 (`p14`, ink `<p:contentPart>`) and VML (`v`), which we cannot
+/// render, so a Choice requiring them yields the Fallback preview.
+pub(crate) fn pptx_understands_ns(ns: &str) -> bool {
+    ns.contains("chartex") || ns == "http://schemas.microsoft.com/office/drawing/2010/main"
+}
+
 /// Read the chartStyle part (`styleN.xml`) associated with a chart part at
 /// `chart_path` (e.g. `ppt/charts/chart1.xml`), following that part's own
 /// relationships (`ppt/charts/_rels/chart1.xml.rels`) to the
@@ -1805,26 +1816,27 @@ pub(crate) fn parse_sp_tree_node(
             }
         }
         "AlternateContent" => {
-            // mc:AlternateContent wraps modern elements (e.g. chartEx inside grpSp,
-            // or p:contentPart for ink/handwriting). Try Choice first; if it produces
-            // nothing (Choice contains an element we don't render, like contentPart),
-            // fall back to Fallback which usually carries a rasterized p:pic alternative.
             let before = out.len();
-            let choice_node = node
+            // ECMA-376 Part 3 §9.3 — select the first Choice whose Requires namespaces
+            // are all understood, else the Fallback (replaces the old output-emptiness
+            // heuristic that never inspected Requires — issue #787).
+            let selected = ooxml_common::mce::select_alternate_content(node, &pptx_understands_ns);
+            // Ink/handwriting: a `<p:contentPart>` in any Choice is InkML PowerPoint
+            // renders directly and we cannot; its `p14` Choice is not understood, so the
+            // Fallback PNG is selected. Detect it so the PNG is drawn at its natural size
+            // (a few px for empty/single-tap strokes) rather than stretched to the box.
+            let is_ink = node
                 .children()
-                .find(|n| n.is_element() && n.tag_name().name() == "Choice");
-            // Choice contains p:contentPart → ink/handwriting. PowerPoint renders the
-            // InkML directly; the Fallback PNG is a low-resolution rasterization at
-            // the stroke's actual pixel extent. For empty/single-tap strokes the PNG
-            // is only a few pixels and should not be stretched to the bounding box.
-            let is_ink_fallback = choice_node.is_some_and(|c| {
-                c.descendants()
-                    .any(|n| n.is_element() && n.tag_name().name() == "contentPart")
-            });
-            if let Some(choice_node) = choice_node {
-                for child_node in choice_node.children().filter(|n| n.is_element()) {
-                    // `mc:AlternateContent` is a transparent wrapper, not a group
-                    // level — pass `depth` through unchanged.
+                .filter(|n| n.is_element() && n.tag_name().name() == "Choice")
+                .any(|c| {
+                    c.descendants()
+                        .any(|n| n.is_element() && n.tag_name().name() == "contentPart")
+                });
+            let selected_is_fallback = selected.is_some_and(|s| s.tag_name().name() == "Fallback");
+            if let Some(sel) = selected {
+                for child_node in sel.children().filter(|n| n.is_element()) {
+                    // `mc:AlternateContent` is a transparent wrapper, not a group level —
+                    // pass `depth` through unchanged.
                     parse_sp_tree_node(
                         child_node,
                         lph,
@@ -1840,46 +1852,24 @@ pub(crate) fn parse_sp_tree_node(
                     );
                 }
             }
-            if out.len() == before {
-                if let Some(fallback_node) = node
-                    .children()
-                    .find(|n| n.is_element() && n.tag_name().name() == "Fallback")
-                {
-                    for child_node in fallback_node.children().filter(|n| n.is_element()) {
-                        parse_sp_tree_node(
-                            child_node,
-                            lph,
-                            slide_dir,
-                            rels,
-                            smartart_drawings,
-                            zip,
-                            theme,
-                            out,
-                            skip_placeholders,
-                            group_fill,
-                            depth,
-                        );
-                    }
-                }
-                if is_ink_fallback {
-                    // Render the fallback PNG at its natural pixel size centered
-                    // inside the original bounding box, so a 6×6 px empty-stroke
-                    // PNG is drawn as a 6×6 px dot rather than stretched into a
-                    // blocky cross. Visible strokes whose PNG natural size already
-                    // matches the box keep their existing extent.
-                    for el in &mut out[before..] {
-                        if let SlideElement::Picture(p) = el {
-                            if let (Some(nat_w_px), Some(nat_h_px)) =
-                                (p.intrinsic_width_px, p.intrinsic_height_px)
-                            {
-                                let nat_w = (nat_w_px as i64) * EMU_PER_PX_96DPI;
-                                let nat_h = (nat_h_px as i64) * EMU_PER_PX_96DPI;
-                                if nat_w < p.width && nat_h < p.height {
-                                    p.x += (p.width - nat_w) / 2;
-                                    p.y += (p.height - nat_h) / 2;
-                                    p.width = nat_w;
-                                    p.height = nat_h;
-                                }
+            if is_ink && selected_is_fallback {
+                // Render the fallback PNG at its natural pixel size centered
+                // inside the original bounding box, so a 6×6 px empty-stroke
+                // PNG is drawn as a 6×6 px dot rather than stretched into a
+                // blocky cross. Visible strokes whose PNG natural size already
+                // matches the box keep their existing extent.
+                for el in &mut out[before..] {
+                    if let SlideElement::Picture(p) = el {
+                        if let (Some(nat_w_px), Some(nat_h_px)) =
+                            (p.intrinsic_width_px, p.intrinsic_height_px)
+                        {
+                            let nat_w = (nat_w_px as i64) * EMU_PER_PX_96DPI;
+                            let nat_h = (nat_h_px as i64) * EMU_PER_PX_96DPI;
+                            if nat_w < p.width && nat_h < p.height {
+                                p.x += (p.width - nat_w) / 2;
+                                p.y += (p.height - nat_h) / 2;
+                                p.width = nat_w;
+                                p.height = nat_h;
                             }
                         }
                     }
@@ -2518,6 +2508,111 @@ mod ole_tests {
             DepthGuard::root(),
         );
         out
+    }
+
+    // ── MCE AlternateContent selection (ECMA-376 Part 3 §9.3) ───────────────
+    //
+    // A `<p:pic>` whose `<a:blip r:embed>` names `embed`, sized so
+    // `parse_picture` yields a `SlideElement::Picture` with `image_path`
+    // `ppt/media/<embed>.png`. Used to tell which MCE branch was selected.
+    fn mce_pic(embed: &str) -> String {
+        format!(
+            r#"<p:pic>
+                 <p:nvPicPr><p:cNvPr id="7" name="P"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+                 <p:blipFill><a:blip r:embed="{embed}"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>
+                 <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>
+                   <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+               </p:pic>"#
+        )
+    }
+
+    /// `<mc:AlternateContent>` whose Choice carries `mce_pic("choice")` behind the
+    /// given `requires` prefix, and whose Fallback carries `mce_pic("fallback")`.
+    /// The `unk`/`a14`/`p14` prefixes are declared so `Requires` resolves. Returns
+    /// the single emitted picture's `image_path` (or a marker string).
+    fn mce_selected_pic_path(requires: &str, choice_inner: &str) -> Vec<SlideElement> {
+        let mut rels = HashMap::new();
+        rels.insert("rIdChoice".to_string(), "../media/choice.png".to_string());
+        rels.insert(
+            "rIdFallback".to_string(),
+            "../media/fallback.png".to_string(),
+        );
+        let mut zip = zip_with(&[
+            ("ppt/media/choice.png", &tiny_png()),
+            ("ppt/media/fallback.png", &tiny_png()),
+        ]);
+        let xml = format!(
+            r#"<mc:AlternateContent {ns}
+                 xmlns:unk="http://example.com/an/extension/we/do/not/understand"
+                 xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main"
+                 xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main"
+                 xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex">
+                 <mc:Choice Requires="{requires}">{choice_inner}</mc:Choice>
+                 <mc:Fallback>{fallback}</mc:Fallback>
+               </mc:AlternateContent>"#,
+            ns = ns(),
+            requires = requires,
+            choice_inner = choice_inner,
+            fallback = mce_pic("rIdFallback"),
+        );
+        run(&xml, &mut zip, &rels)
+    }
+
+    fn only_pic_path(out: &[SlideElement]) -> String {
+        let pics: Vec<&String> = out
+            .iter()
+            .filter_map(|e| match e {
+                SlideElement::Picture(p) => Some(&p.image_path),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(pics.len(), 1, "expected exactly one Picture, got {out:?}");
+        pics[0].clone()
+    }
+
+    /// ECMA-376 Part 3 §9.3(1) — a `<mc:Choice>` is selected only when EVERY
+    /// namespace in its `Requires` is understood. `unk` is a namespace the pptx
+    /// shape walker has no handler for; although the Choice's `<p:pic>` WOULD
+    /// render, the consumer must NOT select an un-understood Choice — it selects
+    /// the `<mc:Fallback>` instead. The old output-emptiness heuristic wrongly
+    /// kept the Choice because its picture produced output; this pins §9.3.
+    #[test]
+    fn mce_unhandled_choice_selects_fallback_picture() {
+        let out = mce_selected_pic_path("unk", &mce_pic("rIdChoice"));
+        assert_eq!(
+            only_pic_path(&out),
+            "ppt/media/fallback.png",
+            "un-understood Choice must yield the Fallback picture, not the Choice's"
+        );
+    }
+
+    /// §9.3(1) — the drawing-2010 (`a14`) namespace IS understood by the pptx
+    /// shape walker (Word/PowerPoint wrap ordinary `<p:sp>`/`<p:pic>` carrying an
+    /// a14 extension in `<mc:Choice Requires="a14">`, e.g. sample-8's 115 such
+    /// choices). The understood Choice must be selected and its picture kept, the
+    /// Fallback dropped — guarding against a regression on those real slides.
+    #[test]
+    fn mce_understood_a14_choice_selected_over_fallback() {
+        let out = mce_selected_pic_path("a14", &mce_pic("rIdChoice"));
+        assert_eq!(
+            only_pic_path(&out),
+            "ppt/media/choice.png",
+            "understood a14 Choice must be selected, Fallback dropped"
+        );
+    }
+
+    /// §9.3 + the "understood = renderable" contract — `p14`
+    /// (PowerPoint-2010, ink `<p:contentPart>`) is NOT rendered by the shape
+    /// walker, so a `Requires="p14"` Choice must not be selected: the Fallback
+    /// preview picture is drawn instead. (Matches sample-3's ink slides.)
+    #[test]
+    fn mce_ink_p14_contentpart_choice_falls_back_to_picture() {
+        let out = mce_selected_pic_path("p14", r#"<p:contentPart r:id="rIdInk"/>"#);
+        assert_eq!(
+            only_pic_path(&out),
+            "ppt/media/fallback.png",
+            "un-rendered ink Choice must yield the Fallback picture"
+        );
     }
 
     /// ECMA-376 §21.1.2.3.5 — a `<p:cNvPr><a:hlinkClick @r:id>` on a shape makes

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -556,14 +556,14 @@ pub(crate) fn push_math_runs(
                 }
             }
         }
-        // mc:AlternateContent → take the a14 `Choice` (the live equation) and
-        // ignore mc:Fallback (a rasterized picture PowerPoint emits for old apps).
         "AlternateContent" => {
-            if let Some(choice) = node
-                .children()
-                .find(|n| n.is_element() && n.tag_name().name() == "Choice")
-            {
-                for c in choice.children().filter(|n| n.is_element()) {
+            // §9.3 — take the understood Choice's live equation, else the Fallback
+            // (which for math is a raster this walker ignores).
+            if let Some(sel) = ooxml_common::mce::select_alternate_content(
+                node,
+                &crate::shape::pptx_understands_ns,
+            ) {
+                for c in sel.children().filter(|n| n.is_element()) {
                     push_math_runs(c, font_size, theme, runs);
                 }
             }

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -19,6 +19,18 @@ use std::collections::HashMap;
 #[cfg(test)]
 use std::io::Cursor;
 
+/// ECMA-376 Part 3 §9.3 "given application configuration" for the xlsx parser:
+/// the Microsoft 2010 drawing extensions (a14 — wraps ordinary shapes/charts and
+/// OMML `a14:m` equations) and the 2009/9 spreadsheet extensions (x14 — slicers
+/// and the OLE `objectPr` image preview). Both have real render paths here.
+pub(crate) fn xlsx_understands_ns(ns: &str) -> bool {
+    matches!(
+        ns,
+        "http://schemas.microsoft.com/office/drawing/2010/main"
+            | "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"
+    )
+}
+
 /// True when an `<xdr:sp>` / `<xdr:pic>` / `<xdr:grpSp>` (or `<xdr:cxnSp>`)
 /// node's own `<xdr:cNvPr hidden="1">` marks it hidden (ECMA-376 §20.1.2.2.8
 /// `CT_NonVisualDrawingProps@hidden`, `xsd:boolean`, default `false`). Only the
@@ -551,14 +563,11 @@ fn push_math_runs_shape(
                 }
             }
         }
-        // mc:AlternateContent → the a14 `Choice` holds the live equation; the
-        // `Fallback` holds a rasterized picture we must NOT also draw.
         "AlternateContent" => {
-            if let Some(choice) = node
-                .children()
-                .find(|n| n.is_element() && n.tag_name().name() == "Choice")
+            if let Some(sel) =
+                ooxml_common::mce::select_alternate_content(node, &xlsx_understands_ns)
             {
-                for c in choice.children().filter(|n| n.is_element()) {
+                for c in sel.children().filter(|n| n.is_element()) {
                     push_math_runs_shape(c, theme_colors, runs);
                 }
             }
@@ -1324,18 +1333,14 @@ pub(crate) fn parse_shape_anchors(
 
         // Excel wraps a modern shape in an anchor-level `<mc:AlternateContent>`
         // (`<mc:Choice Requires="…">` = the live shape, `<mc:Fallback>` = a
-        // legacy fallback). Unwrap to the Choice's content so the grpSp/sp/pic
-        // lookups below see the real shape; otherwise the whole drawing — and
-        // any equation in it — is silently dropped. (Equations inside the shape
-        // text body are handled separately by `push_math_runs_shape`; this is
-        // the distinct, shape-level wrapper.)
+        // legacy fallback). Per ECMA-376 Part 3 §9.3, unwrap the first understood
+        // Choice or fall through to the Fallback so the grpSp/sp/pic lookups below
+        // see the selected shape. (Equations inside the shape text body are handled
+        // separately by `push_math_runs_shape`; this is the shape-level wrapper.)
         let content = anchor
             .children()
             .find(|n| n.is_element() && n.tag_name().name() == "AlternateContent")
-            .and_then(|ac| {
-                ac.children()
-                    .find(|n| n.is_element() && n.tag_name().name() == "Choice")
-            })
+            .and_then(|ac| ooxml_common::mce::select_alternate_content(ac, &xlsx_understands_ns))
             .unwrap_or(anchor);
 
         // Two top-level layouts ECMA-376 allows under <xdr:twoCellAnchor>:
@@ -1872,17 +1877,12 @@ pub(crate) fn parse_ole_object_anchors(
         return Vec::new();
     };
 
-    // Collect the (non-Fallback) oleObjects up front so we can decide whether to
-    // read the vmlDrawing at all.
+    // Collect the ECMA-376 Part 3 §9.3-selected oleObjects up front so we can
+    // decide whether to read the vmlDrawing at all.
     let ole_objects: Vec<roxmltree::Node> = doc
         .descendants()
         .filter(|n| n.is_element() && n.tag_name().name() == "oleObject")
-        // Skip the AlternateContent Fallback twin so a Choice+Fallback pair
-        // yields one anchor, not two.
-        .filter(|n| {
-            !n.ancestors()
-                .any(|a| a.is_element() && a.tag_name().name() == "Fallback")
-        })
+        .filter(|n| ole_object_in_selected_mce_branch(*n))
         .collect();
     if ole_objects.is_empty() {
         return Vec::new();
@@ -1983,6 +1983,29 @@ pub(crate) fn parse_ole_object_anchors(
         });
     }
     anchors
+}
+
+/// True when `ole` (an `<oleObject>`) is not wrapped in `<mc:AlternateContent>`,
+/// or lies inside the Choice/Fallback branch that ECMA-376 Part 3 §9.3 selects.
+/// Replaces the old blanket "skip anything under a Fallback" rule so an
+/// un-understood Choice correctly yields the Fallback's oleObject (issue #787).
+fn ole_object_in_selected_mce_branch(ole: roxmltree::Node) -> bool {
+    let Some(ac) = ole
+        .ancestors()
+        .find(|a| a.is_element() && a.tag_name().name() == "AlternateContent")
+    else {
+        return true; // bare oleObject, not under MCE
+    };
+    let branch = ole
+        .ancestors()
+        .find(|a| a.is_element() && matches!(a.tag_name().name(), "Choice" | "Fallback"));
+    match (
+        ooxml_common::mce::select_alternate_content(ac, &xlsx_understands_ns),
+        branch,
+    ) {
+        (Some(sel), Some(b)) => sel == b,
+        _ => false,
+    }
 }
 
 /// Load a sheet's OLE-object preview images (the `<oleObjects>` collection,
@@ -2698,6 +2721,90 @@ mod hidden_tests {
         }
     }
 
+    // ── MCE AlternateContent selection (ECMA-376 Part 3 §9.3) ───────────────
+
+    /// A `<xdr:sp>` with the given solid `fill` colour — used to tell which MCE
+    /// branch the shape-unwrap site selected.
+    fn filled_sp(fill: &str) -> String {
+        format!(
+            r#"<xdr:sp>
+                 <xdr:nvSpPr><xdr:cNvPr id="2" name="S"/><xdr:cNvSpPr/></xdr:nvSpPr>
+                 <xdr:spPr>
+                   <a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>
+                   <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+                   <a:solidFill><a:srgbClr val="{fill}"/></a:solidFill>
+                 </xdr:spPr>
+               </xdr:sp>"#
+        )
+    }
+
+    /// A `<xdr:twoCellAnchor>` whose `<mc:AlternateContent>` Choice (behind
+    /// `requires`) carries a red-filled shape and whose Fallback carries a
+    /// blue-filled one. The fill colour of the emitted shape reveals the branch.
+    fn alt_content_shape_anchor(requires: &str) -> String {
+        format!(
+            r#"<xdr:wsDr {NS}
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main"
+                 xmlns:unk="http://example.com/an/extension/we/do/not/understand">
+              <xdr:twoCellAnchor>
+                <xdr:from><xdr:col>1</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>1</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+                <xdr:to><xdr:col>4</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>6</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>
+                <mc:AlternateContent>
+                  <mc:Choice Requires="{requires}">{choice}</mc:Choice>
+                  <mc:Fallback>{fallback}</mc:Fallback>
+                </mc:AlternateContent>
+                <xdr:clientData/>
+              </xdr:twoCellAnchor></xdr:wsDr>"#,
+            NS = NS,
+            requires = requires,
+            choice = filled_sp("FF0000"),
+            fallback = filled_sp("0000FF"),
+        )
+    }
+
+    /// ECMA-376 Part 3 §9.3(1) — the anchor-level shape wrapper: a Choice whose
+    /// `Requires` names an un-understood namespace must not be selected even
+    /// though its shape would render; the `<mc:Fallback>` shape is drawn instead.
+    /// The old code always unwrapped to the Choice.
+    #[test]
+    fn mce_shape_unhandled_choice_selects_fallback() {
+        let anchors = parse_shape_anchors(
+            &alt_content_shape_anchor("unk"),
+            &theme(),
+            &[6_350],
+            &HashMap::new(),
+        );
+        assert_eq!(anchors.len(), 1, "one anchor");
+        assert_eq!(anchors[0].shapes.len(), 1, "one shape");
+        assert_eq!(
+            anchors[0].shapes[0].fill_color.as_deref(),
+            Some("#0000FF"),
+            "un-understood Choice must yield the Fallback (blue) shape, not the Choice (red)"
+        );
+    }
+
+    /// §9.3(1) — `a14` (drawing 2010) IS understood; the real
+    /// `<mc:Choice Requires="a14">` that Excel wraps ordinary shapes in
+    /// (sample-1 / sample-28) is selected, the Fallback dropped. Guards those
+    /// slides against a regression.
+    #[test]
+    fn mce_shape_understood_a14_choice_selected() {
+        let anchors = parse_shape_anchors(
+            &alt_content_shape_anchor("a14"),
+            &theme(),
+            &[6_350],
+            &HashMap::new(),
+        );
+        assert_eq!(anchors.len(), 1, "one anchor");
+        assert_eq!(anchors[0].shapes.len(), 1, "one shape");
+        assert_eq!(
+            anchors[0].shapes[0].fill_color.as_deref(),
+            Some("#FF0000"),
+            "understood a14 Choice must be selected (red), Fallback dropped"
+        );
+    }
+
     #[test]
     fn hidden_group_elides_children() {
         // A visible group with one hidden and one visible child leaf emits only
@@ -3400,8 +3507,87 @@ mod ole_object_tests {
     const OLE_NS: &str = concat!(
         r#"xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" "#,
         r#"xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" "#,
-        r#"xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006""#,
+        r#"xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" "#,
+        // x14 (spreadsheet 2009/9) is the namespace Excel binds on the real
+        // `<mc:Choice Requires="x14">` around an OLE object; unk is a namespace
+        // no parser understands. Declaring both lets `select_alternate_content`
+        // resolve the Requires prefixes to URIs.
+        r#"xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" "#,
+        r#"xmlns:unk="http://example.com/an/extension/we/do/not/understand""#,
     );
+
+    /// A `<mc:AlternateContent>` OLE wrapper whose Choice (behind `requires`) and
+    /// Fallback each carry an `<oleObject>` with a resolvable image `objectPr`
+    /// preview — `rIdChoice` → choice.emf, `rIdFallback` → fallback.emf. Returns
+    /// the emitted anchors so a test can assert WHICH branch was selected.
+    fn ole_alt_content_anchors(requires: &str) -> Vec<ImageAnchor> {
+        let object = |rid_prev: &str| {
+            format!(
+                r#"<oleObject progId="Excel.Sheet.12" shapeId="1025" r:id="rIdData">
+                     <objectPr defaultSize="0" r:id="{rid_prev}">
+                       <anchor moveWithCells="1">
+                         <from><xdr:col>1</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>2</xdr:row><xdr:rowOff>0</xdr:rowOff></from>
+                         <to><xdr:col>4</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>7</xdr:row><xdr:rowOff>0</xdr:rowOff></to>
+                       </anchor>
+                     </objectPr>
+                   </oleObject>"#
+            )
+        };
+        let sheet_xml = format!(
+            r#"<worksheet {ns}><sheetData/>
+              <oleObjects>
+                <mc:AlternateContent>
+                  <mc:Choice Requires="{requires}">{choice}</mc:Choice>
+                  <mc:Fallback>{fallback}</mc:Fallback>
+                </mc:AlternateContent>
+              </oleObjects>
+            </worksheet>"#,
+            ns = OLE_NS,
+            requires = requires,
+            choice = object("rIdChoice"),
+            fallback = object("rIdFallback"),
+        );
+        let mut rels = HashMap::new();
+        rels.insert("rIdChoice".to_string(), "../media/choice.emf".to_string());
+        rels.insert(
+            "rIdFallback".to_string(),
+            "../media/fallback.emf".to_string(),
+        );
+        let mut archive = archive_with(&[
+            ("xl/media/choice.emf", b"emf-c"),
+            ("xl/media/fallback.emf", b"emf-f"),
+        ]);
+        parse_ole_object_anchors(&sheet_xml, &rels, "xl/worksheets", &mut archive)
+    }
+
+    /// ECMA-376 Part 3 §9.3(1) — an `<oleObject>` Choice whose `Requires` names a
+    /// namespace the parser does NOT understand must not be selected, even though
+    /// its `objectPr` preview resolves; the `<mc:Fallback>`'s (equally drawable)
+    /// oleObject is selected instead. The old collector always took the
+    /// non-Fallback twin, silently dropping a renderable Fallback.
+    #[test]
+    fn ole_unhandled_choice_selects_fallback_preview() {
+        let anchors = ole_alt_content_anchors("unk");
+        assert_eq!(anchors.len(), 1, "exactly one preview anchor");
+        assert_eq!(
+            anchors[0].image_path, "xl/media/fallback.emf",
+            "un-understood Choice must yield the Fallback preview, not the Choice's"
+        );
+    }
+
+    /// §9.3(1) — the `x14` namespace IS understood by the xlsx parser (it drives
+    /// slicers and the OLE `objectPr` preview), so a real
+    /// `<mc:Choice Requires="x14">` is selected and the Fallback dropped. Guards
+    /// against a regression on Excel's canonical OLE output.
+    #[test]
+    fn ole_understood_x14_choice_selected_over_fallback() {
+        let anchors = ole_alt_content_anchors("x14");
+        assert_eq!(anchors.len(), 1, "exactly one preview anchor");
+        assert_eq!(
+            anchors[0].image_path, "xl/media/choice.emf",
+            "understood x14 Choice must be selected, Fallback dropped"
+        );
+    }
 
     /// A worksheet `<oleObjects>` wrapped in `mc:AlternateContent` where the
     /// Choice carries `<oleObject><objectPr r:id><anchor><from>/<to>>` and the


### PR DESCRIPTION
Closes #787

## Summary

Unify MCE `<mc:AlternateContent>` branch selection across the three Rust parsers on the ECMA-376 Part 3 §9.3 reference processing model: select the **first `<mc:Choice>` whose `Requires` namespaces are all understood** by the consumer, **else the `<mc:Fallback>`**.

- **New shared kernel** — `ooxml_common::mce::select_alternate_content(ac, understood)` (`packages/ooxml-common/src/mce.rs`). Resolves each `Requires` prefix to a namespace URI via the element's in-scope `xmlns` declarations and tests the URI against the caller's understood-namespace predicate, exactly as §9.3 specifies (the §9.3 selection rules are quoted verbatim in the module doc from the local spec PDF). A missing/blank `Requires` (non-conformant per §7.6, which requires ≥1 prefix) is never selectable. 11 table-style unit tests cover understood/unknown single Choice, multi-namespace `Requires` (all-or-nothing), first-match-wins ordering, second-Choice selection, prefix-vs-URI resolution, missing/blank `Requires`, no-Fallback cases, and the empty configuration.
- **docx** — pure refactor: the §9.3-correct local `select_mce_alternate_content` from #785 is deleted and the call site now uses the shared kernel with the unchanged `docx_understands_drawing_ns` predicate. Behavior identical (all 316 docx tests unchanged and green, including the five `mce_*` tests and the sample-24 chartEx end-to-end test).
- **pptx** — replaces the output-emptiness heuristic (try first Choice; use Fallback only if nothing was emitted) at the `parse_sp_tree_node` AlternateContent arm, and the take-first-Choice rule in `push_math_runs`, with §9.3 selection driven by a new `pptx_understands_ns` (chartEx any-version + `a14` drawing-2010; deliberately excludes `p14` ink `contentPart` and `v` VML, which we cannot render). The ink-fallback natural-size rescale is preserved and now keyed on "Fallback actually selected".
- **xlsx** — three sites now consult §9.3 with a new `xlsx_understands_ns` (`a14` drawing-2010 + `x14` spreadsheet-2009/9): the anchor-level shape unwrap and the OMML math arm previously **always took the Choice and never fell through to the Fallback** (the latent content-drop class the issue describes), and the worksheet `<oleObjects>` collector previously skipped anything under a `Fallback` unconditionally — it now keeps exactly the oleObjects living in the §9.3-selected branch.

## Old vs new behavior

The divergence is only observable when a Choice requires a namespace the parser does not understand (or, for pptx, when an un-understood Choice still produced output):

| site | old | new (§9.3) |
| --- | --- | --- |
| pptx sp-tree / math | first Choice if it emitted anything, else Fallback | first all-understood Choice, else Fallback |
| xlsx shape unwrap / math | always first Choice, Fallback unreachable | first all-understood Choice, else Fallback |
| xlsx oleObjects | every non-Fallback oleObject | oleObjects in the selected branch only |
| docx run-level drawing | already §9.3 (#785) | unchanged, now shared |

New parser-level regression tests pin both directions per format: un-understood Choice → Fallback content is rendered (previously failing), and understood Choice (`a14`/`x14`) → Choice selected, Fallback dropped (guarding the real-corpus wire formats: `Requires="a14"` shape wraps, `Requires="x14"` OLE wraps, `Requires="p14"` ink, chartEx `cx`/`cx1`).

## Verification

- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace` green: ooxml-common 227 (+11), docx 316 (±0), pptx 161 (+3), xlsx 153 (+4), mcp-server 41.
- All three WASM artifacts rebuilt via the package `wasm` scripts; root `pnpm typecheck` and root `pnpm test` (vitest) green.
- Before/after smoke over the full private corpus (39 docx + 18 pptx + 32 xlsx files, headless Node + rebuilt WASM, pretty-printed parser JSON diffed): **byte-identical for every sample**. Every real-world `AlternateContent` in the corpus (`wps`/`wpg`/`wp14`/`cx` in docx, `a14`/`p14`/`cx1` in pptx, `a14` in xlsx) selects the same branch as before — the behavioral fix only engages for the latent un-understood-Choice cases the new tests cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
