### PR TITLE
feat(docx): wrap body text around anchored charts

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -4073,6 +4073,18 @@ fn parse_inline_drawing(
                                     anchor_y_pt: 0.0,
                                     anchor_x_from_margin: false,
                                     anchor_y_from_para: false,
+                                    // Inline: anchor-only fields absent.
+                                    wrap_mode: None,
+                                    dist_top: 0.0,
+                                    dist_bottom: 0.0,
+                                    dist_left: 0.0,
+                                    dist_right: 0.0,
+                                    wrap_side: None,
+                                    allow_overlap: true,
+                                    anchor_x_align: None,
+                                    anchor_y_align: None,
+                                    anchor_x_relative_from: None,
+                                    anchor_y_relative_from: None,
                                 }))];
                             }
                         }
@@ -4195,9 +4207,9 @@ fn parse_inline_drawing(
     // container is `<wp:anchor>`. Detect it BEFORE the wgp/wsp/blip fallbacks —
     // a chart graphicData has no `<a:blip>`, so without this it would fall all
     // the way through to `resolve_inline_blip` and silently drop (issue #752).
-    // The parsed `pos_x`/`pos_y` + `x_from_margin`/`y_from_para` are carried on
-    // the ChartRun exactly like the anchor ImageRun path, so the renderer draws
-    // the chart at the same absolute page coordinates a floating picture uses.
+    // The ChartRun carries the full position and wrap metadata parsed above,
+    // exactly like the anchor ImageRun path, so the renderer can position the
+    // chart and reserve its text-wrap exclusion band with picture parity.
     if let Some(graphic_data) = container
         .descendants()
         .find(|n| n.tag_name().name() == "graphicData")
@@ -4238,6 +4250,17 @@ fn parse_inline_drawing(
                                 anchor_y_pt: pos_y,
                                 anchor_x_from_margin: x_from_margin,
                                 anchor_y_from_para: y_from_para,
+                                wrap_mode: anchor_meta.wrap_mode.clone(),
+                                dist_top: anchor_meta.dist_top,
+                                dist_bottom: anchor_meta.dist_bottom,
+                                dist_left: anchor_meta.dist_left,
+                                dist_right: anchor_meta.dist_right,
+                                wrap_side: anchor_meta.wrap_side.clone(),
+                                allow_overlap: anchor_meta.allow_overlap,
+                                anchor_x_align: x_align.clone(),
+                                anchor_y_align: y_align.clone(),
+                                anchor_x_relative_from: rel_h.clone(),
+                                anchor_y_relative_from: rel_v.clone(),
                             }))];
                         }
                     }
@@ -12456,6 +12479,90 @@ mod anchor_image_relative_from_tests {
             none.is_empty(),
             "unresolvable anchored chart rId must emit nothing"
         );
+    }
+
+    /// ECMA-376 §20.4.2.3 and §20.4.2.16: anchored charts carry the same
+    /// positioning and text-wrap metadata as anchored pictures. In particular,
+    /// `<wp:align>` must not collapse to a zero offset without preserving the
+    /// alignment, and wrapSquare must retain its exclusion distances and side.
+    #[test]
+    fn anchor_chart_drawing_emits_full_anchor_wrap_metadata() {
+        let xml = r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:r><w:drawing>
+            <wp:anchor xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+                       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                       xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                       behindDoc="0" distT="91440" distB="45720" distL="114300" distR="114300"
+                       locked="0" layoutInCell="1" allowOverlap="0" relativeHeight="1">
+              <wp:simplePos x="0" y="0"/>
+              <wp:positionH relativeFrom="margin"><wp:align>right</wp:align></wp:positionH>
+              <wp:positionV relativeFrom="paragraph"><wp:posOffset>457200</wp:posOffset></wp:positionV>
+              <wp:extent cx="5029200" cy="2743200"/>
+              <wp:wrapSquare wrapText="left"/>
+              <wp:docPr id="1" name="Chart 1"/>
+              <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+                <c:chart r:id="rIdChart"/>
+              </a:graphicData></a:graphic>
+            </wp:anchor>
+          </w:drawing></w:r>
+        </w:p>"#;
+        let doc = XmlDoc::parse(xml).unwrap();
+        let drawing = doc
+            .descendants()
+            .find(|n| n.tag_name().name() == "drawing")
+            .unwrap();
+        let style_map = StyleMap::parse("");
+        let media: HashMap<String, String> = HashMap::new();
+        let theme = ThemeColors::default();
+
+        let model = parse_docx_chart(
+            r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <c:chart><c:plotArea><c:barChart>
+                <c:barDir val="col"/><c:grouping val="clustered"/>
+                <c:ser><c:idx val="0"/><c:order val="0"/>
+                  <c:val><c:numRef><c:numCache><c:ptCount val="1"/>
+                    <c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val>
+                </c:ser><c:axId val="1"/><c:axId val="2"/>
+              </c:barChart></c:plotArea></c:chart></c:chartSpace>"#,
+            None,
+            &theme,
+        )
+        .expect("model");
+        let mut chart_map: HashMap<String, ooxml_common::chart::ChartModel> = HashMap::new();
+        chart_map.insert("rIdChart".to_string(), model);
+
+        let runs = parse_inline_drawing(&style_map, drawing, &media, &chart_map, &theme);
+        assert_eq!(runs.len(), 1, "one anchored chart run expected");
+        match &runs[0] {
+            DocRun::Chart(c) => {
+                assert_eq!(c.wrap_mode.as_deref(), Some("square"));
+                assert_eq!(c.wrap_side.as_deref(), Some("left"));
+                assert!((c.dist_top - 7.2).abs() < 1e-6, "dist_top={}", c.dist_top);
+                assert!(
+                    (c.dist_bottom - 3.6).abs() < 1e-6,
+                    "dist_bottom={}",
+                    c.dist_bottom
+                );
+                assert!(
+                    (c.dist_left - 9.0).abs() < 1e-6,
+                    "dist_left={}",
+                    c.dist_left
+                );
+                assert!(
+                    (c.dist_right - 9.0).abs() < 1e-6,
+                    "dist_right={}",
+                    c.dist_right
+                );
+                assert!(!c.allow_overlap);
+                assert_eq!(c.anchor_x_align.as_deref(), Some("right"));
+                assert_eq!(c.anchor_y_align, None);
+                assert_eq!(c.anchor_x_relative_from.as_deref(), Some("margin"));
+                assert_eq!(c.anchor_y_relative_from.as_deref(), Some("paragraph"));
+            }
+            other => panic!("expected DocRun::Chart, got {other:?}"),
+        }
     }
 
     /// CH14 end-to-end — `private/sample-24.docx` has 6 `<w:drawing>` chart

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1704,6 +1704,10 @@ fn is_zero_f64(v: &f64) -> bool {
     *v == 0.0
 }
 
+fn is_true(v: &bool) -> bool {
+    *v
+}
+
 /// A DrawingML chart embedded in the run flow (ECMA-376 §21.2). Positioned like
 /// a picture: the `<wp:extent cx/cy>` natural size in points governs the box
 /// the chart is drawn into. The `chart` payload is the shared
@@ -1713,9 +1717,12 @@ fn is_zero_f64(v: &f64) -> bool {
 ///
 /// Both placements are drawn: an inline chart (`anchor == false`) flows with the
 /// text like an inline picture, and an anchored (floating) chart
-/// (`anchor == true`, §20.4.2.3 `<wp:anchor>`) carries the same anchor fields an
-/// `ImageRun` does and is painted at its absolute page box by the renderer's
-/// anchor path (issue #752).
+/// (`anchor == true`, §20.4.2.3 `<wp:anchor>`) carries the same anchor and
+/// text-wrap fields an `ImageRun` does — align/relativeFrom placement
+/// (§20.4.3.x) plus the wrap mode/side, dist* padding, and allowOverlap the
+/// float-exclusion machinery consumes (§20.4.2.16/.17) — so the renderer
+/// positions it and wraps body text around it with picture parity
+/// (issues #752, #788).
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ChartRun {
@@ -1739,6 +1746,61 @@ pub struct ChartRun {
     pub anchor_x_from_margin: bool,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub anchor_y_from_para: bool,
+    /// ECMA-376 §20.4.2.16/.17 text-wrap mode for anchor charts. One of:
+    ///   "square" | "topAndBottom" | "none" | "tight" | "through"
+    /// Inline charts and anchors without an explicit wrap element use "none".
+    /// "tight" and "through" fall back to "square" rendering in the MVP.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wrap_mode: Option<String>,
+    /// ECMA-376 §20.4.2.3 distT (top padding, pt). Anchor-only.
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub dist_top: f64,
+    /// ECMA-376 §20.4.2.3 distB (bottom padding, pt). Anchor-only.
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub dist_bottom: f64,
+    /// ECMA-376 §20.4.2.3 distL (left padding, pt). Anchor-only.
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub dist_left: f64,
+    /// ECMA-376 §20.4.2.3 distR (right padding, pt). Anchor-only.
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub dist_right: f64,
+    /// ECMA-376 §20.4.2.16/.17 wrapSquare/wrapTight `wrapText` attribute:
+    /// "bothSides" | "left" | "right" | "largest". Defaults to
+    /// "bothSides" (equivalent).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wrap_side: Option<String>,
+    /// ECMA-376 §20.4.2.3 `wp:anchor/@allowOverlap` — whether this floating
+    /// object may overlap other floats. Spec default is true (attribute optional);
+    /// `false` mandates the renderer reposition the object to prevent any overlap.
+    /// Inline charts carry true (the no-constraint value), which is omitted from
+    /// JSON; the TypeScript side reads an absent value with `?? true`.
+    #[serde(skip_serializing_if = "is_true")]
+    pub allow_overlap: bool,
+    /// ECMA-376 §20.4.3.1 wp:align (positionH/wp:align). When present the
+    /// renderer centers / left-aligns / right-aligns the chart within the
+    /// container indicated by `anchor_x_from_margin`. Values: "left",
+    /// "center", "right" (others fall back to "left"). Mirrors
+    /// `ImageRun::anchor_x_align`. `None` for inline charts and offset-based
+    /// anchors.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_x_align: Option<String>,
+    /// Vertical equivalent of anchor_x_align (positionV/wp:align).
+    /// Values: "top", "center", "bottom".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_y_align: Option<String>,
+    /// ECMA-376 §20.4.3.4 ST_RelFromH / §20.4.3.5 ST_RelFromV raw
+    /// `@relativeFrom` string — names the container the offset or align is
+    /// measured against ("page", "margin", "paragraph", "line",
+    /// "leftMargin", "rightMargin", "topMargin", "bottomMargin",
+    /// "insideMargin", "outsideMargin", "column", "character"). Mirrors
+    /// `ImageRun::anchor_x_relative_from` / `anchor_y_relative_from`. `None`
+    /// for inline charts and for anchors that didn't carry a positionH/V
+    /// (preserve the legacy boolean hints `anchor_x_from_margin` /
+    /// `anchor_y_from_para`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_x_relative_from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_y_relative_from: Option<String>,
 }
 
 #[derive(Serialize, Debug, Clone, PartialEq)]

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -8989,28 +8989,14 @@ function renderAnchorImages(
       continue;
     }
     if (run.type === 'chart') {
-      // ECMA-376 §20.4.2.3 (`<wp:anchor>`) + §21.2 (chart) — a floating chart is
-      // placed at the same absolute page box a floating picture uses, then
-      // painted with the shared core `renderChart` (identical to the inline
-      // chart draw at renderInlineImage). Only `anchor === true` charts reach
-      // here; inline charts flow as segments and are drawn during line layout.
+      // ECMA-376 §20.4.2.3 (`<wp:anchor>`) + §21.2 (chart) — wrap-mode
+      // charts are painted by registerChartFloat after their exclusion rect is
+      // registered. This branch paints only wrapNone/no-wrap anchors through
+      // the same box resolver and core chart renderer.
       const chartRun = run as unknown as ChartRun & { type: 'chart' };
       if (!chartRun.anchor) continue;
-      // resolveAnchorBox reads only the box + anchor-placement fields, all of
-      // which the ChartRun carries (widthPt/heightPt/anchorXPt/anchorYPt/
-      // anchorXFromMargin/anchorYFromPara). The image-specific fields
-      // (align/relativeFrom/dist*/srcRect) are absent → the `?? 0`/`?? null`
-      // defaults inside resolveAnchorBox fall back to the plain offset path,
-      // matching how the parser emits an anchored chart (posOffset only).
-      const boxSrc = {
-        widthPt: chartRun.widthPt,
-        heightPt: chartRun.heightPt,
-        anchorXPt: chartRun.anchorXPt,
-        anchorYPt: chartRun.anchorYPt,
-        anchorXFromMargin: chartRun.anchorXFromMargin,
-        anchorYFromPara: chartRun.anchorYFromPara,
-      } as unknown as ImageRun;
-      const { x: pageX, y: pageY, w, h } = resolveAnchorBox(boxSrc, state, paragraphTopPx);
+      if (isWrapFloat(chartRun.wrapMode)) continue;
+      const { x: pageX, y: pageY, w, h } = resolveAnchorBox(chartRun, state, paragraphTopPx);
       const chart = chartRun.chart;
       if (state.verticalCJK) {
         // §17.6.20 (tbRl) — a chart is a graphic, not text: keep it upright.
@@ -10405,8 +10391,17 @@ function physicalAnchorState(state: RenderState): RenderState {
   };
 }
 
+type AnchorBoxSource = Pick<ImageRun,
+  | 'widthPt' | 'heightPt'
+  | 'anchorXPt' | 'anchorYPt'
+  | 'anchorXFromMargin' | 'anchorYFromPara'
+  | 'anchorXAlign' | 'anchorYAlign'
+  | 'anchorXRelativeFrom' | 'anchorYRelativeFrom'
+  | 'distTop' | 'distBottom' | 'distLeft' | 'distRight'
+>;
+
 function resolveAnchorBox(
-  img: ImageRun,
+  img: AnchorBoxSource,
   state: RenderState,
   paraBaseY: number,
 ): { x: number; y: number; w: number; h: number; dl: number; dr: number; dt: number; db: number } {
@@ -10498,15 +10493,15 @@ function isPageLevelAnchorY(rf: string | null | undefined, fromPara: boolean): b
  *  {@link isPageLevelAnchorY}. `isWrapFloat` already filters inline images
  *  (their `wrapMode` is undefined) and non-wrapping anchors, so an extra
  *  `anchor` check is redundant here. */
-function isPageLevelWrapFloat(run: ImageRun | ShapeRun): boolean {
+function isPageLevelWrapFloat(run: ImageRun | ChartRun | ShapeRun): boolean {
   if (!isWrapFloat(run.wrapMode)) return false;
   return isPageLevelAnchorY(run.anchorYRelativeFrom ?? null, run.anchorYFromPara ?? false);
 }
 
-/** Register floats from a paragraph's anchor images and shapes. Anchor images
- *  are drawn immediately; anchor shapes are NOT drawn here (renderAnchorShape
- *  paints them separately) — we only reserve their float-exclusion band so body
- *  text wraps around them (ECMA-376 §20.4.2.16/.17), exactly like images.
+/** Register floats from a paragraph's anchored images, charts, and shapes.
+ *  Images and charts are drawn immediately; anchor shapes are NOT drawn here
+ *  (renderAnchorShape paints them separately) — we reserve their float-exclusion
+ *  bands so body text wraps around them (ECMA-376 §20.4.2.16/.17).
  *
  *  Page-level floats (positionV relativeFrom ∈ {page, margin, *Margin, column},
  *  ECMA-376 §20.4.3.2/§20.4.3.5) are skipped when this paragraph was already
@@ -10525,6 +10520,10 @@ function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphA
       const img = run as unknown as ImageRun;
       if (prescanned && isPageLevelWrapFloat(img)) continue;
       registerImageFloat(img, state, paragraphAnchorY, paraId);
+    } else if (run.type === 'chart') {
+      const chart = run as unknown as ChartRun;
+      if (prescanned && isPageLevelWrapFloat(chart)) continue;
+      registerChartFloat(chart, state, paragraphAnchorY, paraId);
     } else if (run.type === 'shape') {
       const shp = run as unknown as ShapeRun;
       if (prescanned && isPageLevelWrapFloat(shp)) continue;
@@ -10576,6 +10575,8 @@ function preRegisterPageFloats(
     for (const run of para.runs) {
       if (run.type === 'image') {
         if (isPageLevelWrapFloat(run as unknown as ImageRun)) { hasPageLevel = true; break; }
+      } else if (run.type === 'chart') {
+        if (isPageLevelWrapFloat(run as unknown as ChartRun)) { hasPageLevel = true; break; }
       } else if (run.type === 'shape') {
         if (isPageLevelWrapFloat(run as unknown as ShapeRun)) { hasPageLevel = true; break; }
       }
@@ -10591,6 +10592,10 @@ function preRegisterPageFloats(
         const img = run as unknown as ImageRun;
         if (!isPageLevelWrapFloat(img)) continue;
         registerImageFloat(img, state, 0, paraId);
+      } else if (run.type === 'chart') {
+        const chart = run as unknown as ChartRun;
+        if (!isPageLevelWrapFloat(chart)) continue;
+        registerChartFloat(chart, state, 0, paraId);
       } else if (run.type === 'shape') {
         const shp = run as unknown as ShapeRun;
         if (!isPageLevelWrapFloat(shp)) continue;
@@ -10661,6 +10666,52 @@ function registerImageFloat(
         drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
       }
       if (hasAlpha) state.ctx.restore();
+    }
+    rect.drawn = true;
+  }
+}
+
+/** Reserve the float-exclusion rect for one anchored wrap-chart and paint the
+ *  chart at the overlap-resolved box (ECMA-376 §20.4.2.3/.16/.17). */
+function registerChartFloat(
+  chart: ChartRun,
+  state: RenderState,
+  paragraphAnchorY: number,
+  paraId: number,
+): void {
+  if (!chart.anchor || !isWrapFloat(chart.wrapMode)) return;
+
+  const box = resolveAnchorBox(chart, state, paragraphAnchorY);
+  const { w, h, dl, dr, dt, db } = box;
+  if (w <= 0 || h <= 0) return;
+
+  const rect = pushFloatRect(state, {
+    x: box.x,
+    y: box.y,
+    w, h, dl, dr, dt, db,
+    kind: 'shape',
+    mode: chart.wrapMode === 'topAndBottom' ? 'topAndBottom' : 'square',
+    side: chart.wrapSide ?? 'bothSides',
+    allowOverlap: chart.allowOverlap ?? true,
+    avoidOverlap: true,
+    paraId,
+    imageKey: '',
+    drawn: false,
+  });
+
+  if (!state.dryRun) {
+    const paint = (x: number, y: number, width: number, height: number): void =>
+      renderChart(
+        state.ctx as CanvasRenderingContext2D,
+        chart.chart,
+        { x, y, w: width, h: height },
+        state.scale,
+      );
+    if (state.verticalCJK) {
+      // ECMA-376 §17.6.20 (tbRl) — a chart is a graphic, so keep it upright.
+      drawUprightBox(state.ctx, rect.imageX, rect.imageY, rect.imageW, rect.imageH, paint);
+    } else {
+      paint(rect.imageX, rect.imageY, rect.imageW, rect.imageH);
     }
     rect.drawn = true;
   }

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -747,8 +747,9 @@ export type DocRun =
  *  core `renderChart` consumes (identical to what pptx/xlsx pass), so a docx
  *  chart draws at the same quality through the same code path. `widthPt`/
  *  `heightPt` are the `<wp:extent>` natural size. An inline chart flows as an
- *  inline box of that size; an anchored chart (§20.4.2.3) is painted at its
- *  absolute page box by `renderAnchorImages` — both via `renderChart`. */
+ *  inline box of that size; an anchored chart (§20.4.2.3) is painted via
+ *  `registerAnchorFloats` when it wraps text, or by `renderAnchorImages` for
+ *  wrapNone/no-wrap anchors — all paths use `renderChart`. */
 export interface ChartRun {
   chart: ChartModel;
   widthPt: number;
@@ -760,6 +761,39 @@ export interface ChartRun {
   anchorYPt?: number;
   anchorXFromMargin?: boolean;
   anchorYFromPara?: boolean;
+  /**
+   * Wrap mode for anchored charts (ECMA-376 §20.4.2.16/.17):
+   *   "square" | "topAndBottom" | "none" | "tight" | "through"
+   * Inline charts and undetermined cases leave this undefined. The renderer
+   * treats "tight" and "through" as "square", matching anchored images.
+   */
+  wrapMode?: string;
+  /** Padding top (pt). Anchor-only (ECMA-376 §20.4.2.16/.17). */
+  distTop?: number;
+  /** Padding bottom (pt). Anchor-only (ECMA-376 §20.4.2.16/.17). */
+  distBottom?: number;
+  /** Padding left (pt). Anchor-only (ECMA-376 §20.4.2.16/.17). */
+  distLeft?: number;
+  /** Padding right (pt). Anchor-only (ECMA-376 §20.4.2.16/.17). */
+  distRight?: number;
+  /** wrapText attribute: "bothSides" | "left" | "right" | "largest". */
+  wrapSide?: string;
+  /**
+   * ECMA-376 §20.4.2.3 `wp:anchor/@allowOverlap`. The parser omits this
+   * field when true, so renderers must read it as `allowOverlap ?? true`.
+   */
+  allowOverlap?: boolean;
+  /** ECMA-376 §20.4.3.1 wp:align horizontal: "left" | "center" | "right" |
+   *  "inside" | "outside". */
+  anchorXAlign?: string | null;
+  /** Vertical equivalent of anchorXAlign: "top" | "center" | "bottom". */
+  anchorYAlign?: string | null;
+  /**
+   * ECMA-376 §20.4.3.2 `<wp:positionH/@relativeFrom>` / §20.4.3.5
+   * `<wp:positionV/@relativeFrom>` — the raw anchor placement containers.
+   */
+  anchorXRelativeFrom?: string | null;
+  anchorYRelativeFrom?: string | null;
 }
 
 /** ECMA-376 §17.3.3.23 `<w:ptab>` — an absolute-position tab. Advances to a

--- a/packages/node/src/docx-anchored-chart-wrap.probe.test.ts
+++ b/packages/node/src/docx-anchored-chart-wrap.probe.test.ts
@@ -1,0 +1,284 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { crc32, deflateRawSync } from 'node:zlib';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  installImageBitmapShim,
+  installOffscreenCanvasShim,
+  type NodeCanvasFactory,
+} from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+// skia-canvas is a devDependency. Absent → skip cleanly (local), while
+// OOXML_REQUIRE_SKIA=1 makes its absence a hard failure for this probe.
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, loadImage } = (skia ?? {}) as Skia;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (async (buf: ArrayBuffer | Uint8Array | Buffer) =>
+    loadImage(Buffer.from(buf as Uint8Array))) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const RENDERER_PATH = resolve(ROOT, 'packages/docx/src/renderer.ts');
+
+const docxMod = skia ? await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)') : null;
+const rendererMod = skia
+  ? await importForTests(() => import(RENDERER_PATH), 'packages/docx/src/renderer.ts')
+  : null;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+// ---- minimal ZIP (store + deflate) writer -------------------------------------
+// The Rust `zip` crate reads deflated (method 8) entries. Each OOXML part is
+// raw-DEFLATE compressed, then wrapped in local and central directory records.
+interface Entry { name: string; data: Buffer; }
+
+function u16(n: number): Buffer { const b = Buffer.alloc(2); b.writeUInt16LE(n >>> 0, 0); return b; }
+function u32(n: number): Buffer { const b = Buffer.alloc(4); b.writeUInt32LE(n >>> 0, 0); return b; }
+
+function buildZip(entries: Entry[]): Buffer {
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name, 'utf8');
+    const compressed = deflateRawSync(entry.data);
+    const crc = crc32(entry.data) >>> 0;
+    const local = Buffer.concat([
+      u32(0x04034b50), u16(20), u16(0), u16(8),
+      u16(0), u16(0), u32(crc), u32(compressed.length), u32(entry.data.length),
+      u16(name.length), u16(0), name, compressed,
+    ]);
+    locals.push(local);
+    centrals.push(Buffer.concat([
+      u32(0x02014b50), u16(20), u16(20), u16(0), u16(8),
+      u16(0), u16(0), u32(crc), u32(compressed.length), u32(entry.data.length),
+      u16(name.length), u16(0), u16(0), u16(0), u16(0), u32(0),
+      u32(offset), name,
+    ]));
+    offset += local.length;
+  }
+  const localData = Buffer.concat(locals);
+  const centralDir = Buffer.concat(centrals);
+  const eocd = Buffer.concat([
+    u32(0x06054b50), u16(0), u16(0),
+    u16(entries.length), u16(entries.length),
+    u32(centralDir.length), u32(localData.length), u16(0),
+  ]);
+  return Buffer.concat([localData, centralDir, eocd]);
+}
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
+</Types>`;
+
+const ROOT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+const DOCUMENT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdChart" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="charts/chart1.xml"/>
+</Relationships>`;
+
+// Minimal legacy DrawingML chart, matching the parser's anchored-chart unit
+// fixture: one clustered bar series is enough to produce substantial ink.
+const CHART_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea><c:barChart>
+    <c:barDir val="col"/><c:grouping val="clustered"/>
+    <c:ser><c:idx val="0"/><c:order val="0"/>
+      <c:val><c:numRef><c:numCache><c:ptCount val="3"/>
+        <c:pt idx="0"><c:v>3</c:v></c:pt>
+        <c:pt idx="1"><c:v>7</c:v></c:pt>
+        <c:pt idx="2"><c:v>5</c:v></c:pt>
+      </c:numCache></c:numRef></c:val>
+    </c:ser><c:axId val="1"/><c:axId val="2"/>
+  </c:barChart></c:plotArea></c:chart>
+</c:chartSpace>`;
+
+const TEXT = 'alpha beta gamma delta epsilon zeta eta theta iota kappa';
+
+function documentXml(): string {
+  const textParagraphs = Array.from({ length: 16 }, (_, i) => `
+    <w:p>
+      <w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr>
+      <w:r><w:t>Line ${i + 1}: ${TEXT}</w:t></w:r>
+    </w:p>`).join('');
+
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+            xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p>
+      <w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr>
+      <w:r><w:drawing>
+        <wp:anchor distT="91440" distB="91440" distL="228600" distR="91440"
+                   simplePos="0" relativeHeight="1" behindDoc="0" locked="0"
+                   layoutInCell="1" allowOverlap="1">
+          <wp:simplePos x="0" y="0"/>
+          <wp:positionH relativeFrom="margin"><wp:align>right</wp:align></wp:positionH>
+          <wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>
+          <wp:extent cx="2743200" cy="1828800"/>
+          <wp:wrapSquare wrapText="left"/>
+          <wp:docPr id="1" name="Chart 1"/>
+          <a:graphic>
+            <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+              <c:chart r:id="rIdChart"/>
+            </a:graphicData>
+          </a:graphic>
+        </wp:anchor>
+      </w:drawing></w:r>
+    </w:p>${textParagraphs}
+    <w:sectPr>
+      <w:pgSz w:w="12240" w:h="15840"/>
+      <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"
+               w:header="720" w:footer="720" w:gutter="0"/>
+    </w:sectPr>
+  </w:body>
+</w:document>`;
+}
+
+function makeDocx(): Uint8Array {
+  return buildZip([
+    { name: '[Content_Types].xml', data: Buffer.from(CONTENT_TYPES, 'utf8') },
+    { name: '_rels/.rels', data: Buffer.from(ROOT_RELS, 'utf8') },
+    { name: 'word/document.xml', data: Buffer.from(documentXml(), 'utf8') },
+    { name: 'word/_rels/document.xml.rels', data: Buffer.from(DOCUMENT_RELS, 'utf8') },
+    { name: 'word/charts/chart1.xml', data: Buffer.from(CHART_XML, 'utf8') },
+  ]);
+}
+
+function collectRuns(body: Any[], type: string): Any[] {
+  const runs: Any[] = [];
+  for (const element of body) {
+    if (element.type === 'paragraph' || (element.runs && !element.rows)) {
+      for (const run of element.runs ?? []) if (run.type === type) runs.push(run);
+    }
+  }
+  return runs;
+}
+
+async function renderPage(doc: Any): Promise<{ data: Uint8ClampedArray; w: number; h: number }> {
+  const { renderDocumentToCanvas } = rendererMod as {
+    renderDocumentToCanvas: (
+      doc: Any,
+      canvas: unknown,
+      pageIndex: number,
+      opts: { dpr: number; width: number },
+    ) => Promise<void>;
+  };
+  const canvas = new Canvas(doc.section.pageWidth, doc.section.pageHeight);
+  const restoreImage = installImageBitmapShim(factory);
+  const restoreOffscreen = installOffscreenCanvasShim(factory);
+  try {
+    await renderDocumentToCanvas(doc, canvas, 0, { dpr: 1, width: doc.section.pageWidth });
+  } finally {
+    restoreOffscreen();
+    restoreImage();
+  }
+  const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+  const image = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  return { data: image.data, w: canvas.width, h: canvas.height };
+}
+
+function nonWhiteInRect(
+  data: Uint8ClampedArray,
+  w: number,
+  h: number,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+): number {
+  let count = 0;
+  const xa = Math.max(0, Math.floor(x0));
+  const xb = Math.min(w, Math.ceil(x1));
+  const ya = Math.max(0, Math.floor(y0));
+  const yb = Math.min(h, Math.ceil(y1));
+  for (let y = ya; y < yb; y++) {
+    for (let x = xa; x < xb; x++) {
+      const i = (y * w + x) * 4;
+      if (data[i] < 250 || data[i + 1] < 250 || data[i + 2] < 250) count++;
+    }
+  }
+  return count;
+}
+
+describe.skipIf(!skia || !docxMod || !rendererMod)(
+  'anchored wrapSquare chart parse + render probe (#788 Stage 2)',
+  () => {
+    let doc: Any;
+    let chart: Any;
+    let rendered: { data: Uint8ClampedArray; w: number; h: number };
+
+    beforeAll(async () => {
+      const { parseDocx } = docxMod as { parseDocx: (bytes: Uint8Array) => Any };
+      doc = parseDocx(makeDocx());
+      [chart] = collectRuns(doc.body, 'chart');
+      rendered = await renderPage(doc);
+    });
+
+    it('parses full anchor and square-wrap metadata across the WASM boundary', () => {
+      expect(chart).toBeTruthy();
+      expect(chart.anchor).toBe(true);
+      expect(chart.wrapMode).toBe('square');
+      expect(chart.wrapSide).toBe('left');
+      expect(chart.distTop).toBeCloseTo(7.2, 6);
+      expect(chart.distBottom).toBeCloseTo(7.2, 6);
+      expect(chart.distLeft).toBeCloseTo(18, 6);
+      expect(chart.distRight).toBeCloseTo(7.2, 6);
+      expect(chart.anchorXAlign).toBe('right');
+      expect(chart.anchorXRelativeFrom).toBe('margin');
+      expect(chart.anchorYRelativeFrom).toBe('paragraph');
+    });
+
+    // Letter page, 72pt margins: right-aligned 216pt chart occupies x=324..540.
+    // Its paragraph-relative zero Y starts at the 72pt body top (§20.4.3.1/.2).
+    const chartLeft = 324;
+    const chartRight = 540;
+    const chartTop = 72;
+    const chartBottom = 216;
+
+    it('paints substantial chart ink in the right-aligned margin box', () => {
+      const ink = nonWhiteInRect(
+        rendered.data, rendered.w, rendered.h,
+        chartLeft, chartTop, chartRight, chartBottom,
+      );
+      expect(ink).toBeGreaterThan(3000);
+    });
+
+    it('keeps body text flowing in the left third beside the chart', () => {
+      const ink = nonWhiteInRect(
+        rendered.data, rendered.w, rendered.h,
+        72, chartTop + 12, 228, chartBottom,
+      );
+      expect(ink).toBeGreaterThan(300);
+    });
+
+    it('keeps the distL exclusion band clear of text ink', () => {
+      // Ignore 2px at both edges to avoid glyph antialiasing / chart-border
+      // contact: the interior of the §20.4.2.16 18pt band must remain white.
+      const ink = nonWhiteInRect(
+        rendered.data, rendered.w, rendered.h,
+        chartLeft - 18 + 2, chartTop, chartLeft - 2, chartBottom,
+      );
+      expect(ink).toBe(0);
+    });
+  },
+);


### PR DESCRIPTION
Closes #788 (follow-up to #784 / #752).

## Problem

An anchored (floating) `ChartRun` only carried `anchorXPt`/`anchorYPt` plus the
coarse `anchorXFromMargin`/`anchorYFromPara` booleans, while an anchored
`ImageRun` models the full anchor contract:

- `<wp:align>` (ECMA-376 §20.4.3.1) — a chart with `positionH/wp:align`
  collapsed to `posOffset=0` and was drawn at the container's left/top edge;
- the raw `relativeFrom` containers (§20.4.3.4 ST_RelFromH / §20.4.3.5
  ST_RelFromV) — non-margin/page bases degraded to the boolean hints;
- `distT/B/L/R`, wrap mode/side, and `allowOverlap` (§20.4.2.3,
  §20.4.2.16/.17) — no float-exclusion band was registered, so body text did
  not wrap around a `wrapSquare` floating chart and overlapped it.

## Fix

No parallel chart implementation — the anchored chart rides the same
anchor/wrap data path anchored pictures use, end to end:

- **Parser (Rust)**: `ChartRun` now carries the ImageRun-parity fields
  (`wrapMode`, `distTop/Bottom/Left/Right`, `wrapSide`, `allowOverlap`,
  `anchorXAlign`/`anchorYAlign`, `anchorXRelativeFrom`/`anchorYRelativeFrom`).
  The anchor-chart branch of `parse_inline_drawing` fills them from the same
  already-parsed `positionH/V` + `parse_anchor_wrap` values the ImageRun and
  ShapeRun branches consume. `allowOverlap` is omitted from JSON when `true`
  (spec default); the TS side reads it with `?? true`.
- **Renderer (TS)**: `resolveAnchorBox` is retyped to a structural
  `AnchorBoxSource` subset so both run kinds share the exact same
  box/dist/align/relativeFrom resolution. A wrap-mode anchored chart is
  registered by the new `registerChartFloat` — same `pushFloatRect` flags,
  overlap displacement, and paint-at-displaced-box behavior as
  `registerImageFloat`, painting through the shared core `renderChart`
  (upright in vertical-text sections). Page-level floats (`positionV
  relativeFrom` ∈ page/margin/*Margin/column) join the page-start pre-scan via
  the widened `isPageLevelWrapFloat`, so earlier paragraphs on the page wrap
  around the chart exactly as they do for pictures. `renderAnchorImages` keeps
  painting wrapNone/no-wrap anchored charts, now through the full
  align/relativeFrom resolution instead of the offset-only subset.

## Tests

- Rust: `anchor_chart_drawing_emits_full_anchor_wrap_metadata` — anchored chart
  with `wp:align=right relativeFrom="margin"`, `wrapSquare wrapText="left"`,
  non-zero dist*, `allowOverlap="0"` parses every new field (Red before the
  parser change).
- Node probe: new `docx-anchored-chart-wrap.probe.test.ts` builds a fully
  synthetic .docx (schema-ordered `wp:anchor`, minimal bar-chart part) with a
  right-aligned `wrapSquare` floating chart amid body text and pixel-probes the
  render: chart ink lands in the right-margin-aligned box, text keeps flowing
  beside it, and the `distL` exclusion band stays free of ink. Red before the
  renderer change (chart painted at offset 0; text overlapped the band), Green
  after.

## Verification

- `cargo fmt --all` / `cargo clippy --workspace --all-targets -- -D warnings` /
  `cargo test -p docx-parser` (328 passed)
- docx WASM rebuilt; full docx TS suite: 155 files / 1200 tests passed
- root `pnpm typecheck` and `pnpm lint` clean
- Existing anchored-chart probe: the #752 absolute-page-box test passes. (A
  local-only timeout in that file's render-all-pages ink test reproduces
  identically on unmodified code in the same environment — pre-existing,
  untouched by this change.)
- docx VRT: per-page diff counts are identical between this branch and
  unmodified code across all 89 pages — documents without anchored wrap charts
  are pixel-unaffected. The single fidelity-ratchet failure (a public demo
  page) also reproduces identically on unmodified code in this environment —
  pre-existing; references were not updated.

## Follow-up (out of scope)

- The paginator's `anchoredFloatBottomOffset` (relocating an anchor paragraph
  so its paragraph-anchored float stays on one page) still enumerates only
  images/shapes; extending it to charts is deferred because that pagination
  region is being reworked concurrently (#868).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
