### PR TITLE
fix(pptx): model tabs as inline segments — N cells per line, bidi cells, rendered gaps

### DIFF
--- a/packages/pptx/src/bidi-line.test.ts
+++ b/packages/pptx/src/bidi-line.test.ts
@@ -40,4 +40,47 @@ describe('computeLineVisualOrder', () => {
     const { order } = computeLineVisualOrder([{ text: 'שלום ' }, {}, { text: 'טוב' }], true);
     expect(order).toEqual([2, 1, 0]);
   });
+
+  // ── TAB segments are Bidi_Class S (§17.3.1.37 / UAX#9) — issue #916 item 2 ──
+  // A tab is a Segment Separator, NOT a neutral object. Rules L1/L2 reset it to
+  // the paragraph level and reorder each tab-delimited CELL independently, so an
+  // RTL paragraph's tab-aligned cells appear in mirrored (leading-cell-at-the-
+  // right) order. Mirrors docx bidi-line.ts.
+  it('reorders LTR cells in mirrored order under an RTL base (tab = S)', () => {
+    // logical [A][TAB][B][TAB][C], base RTL → visual [C, TAB, B, TAB, A].
+    const segs = [
+      { text: 'A' },
+      { isTab: true },
+      { text: 'B' },
+      { isTab: true },
+      { text: 'C' },
+    ];
+    const { order } = computeLineVisualOrder(segs, true);
+    expect(order.map((i) => ('isTab' in segs[i] ? 'TAB' : segs[i].text))).toEqual([
+      'C', 'TAB', 'B', 'TAB', 'A',
+    ]);
+  });
+
+  it('keeps tab-delimited LTR cells in logical order under an LTR base', () => {
+    const segs = [{ text: 'A' }, { isTab: true }, { text: 'B' }];
+    const { order } = computeLineVisualOrder(segs, false);
+    expect(order).toEqual([0, 1, 2]);
+  });
+
+  it('reorders MIXED-direction content INSIDE a tab cell (item 2)', () => {
+    // A cell (after a tab) holding a Hebrew word then a Latin word under an RTL
+    // base: the Latin word is visually LEFT of the Hebrew word within the cell.
+    // Old model drew the cell sequentially in logical order (no reorder).
+    const segs = [{ isTab: true }, { text: 'אב' }, { text: 'CD' }];
+    const { order, rtl } = computeLineVisualOrder(segs, true);
+    // visual L→R: [CD, אב, TAB]
+    expect(order.map((i) => ('isTab' in segs[i] ? 'TAB' : segs[i].text))).toEqual([
+      'CD', 'אב', 'TAB',
+    ]);
+    // the Latin cell content resolves LTR, the Hebrew RTL.
+    const hebIdx = 1;
+    const latIdx = 2;
+    expect(rtl[hebIdx]).toBe(true);
+    expect(rtl[latIdx]).toBe(false);
+  });
 });

--- a/packages/pptx/src/bidi-line.ts
+++ b/packages/pptx/src/bidi-line.ts
@@ -14,6 +14,7 @@ import {
   hasStrongRtl,
   OBJECT_PLACEHOLDER,
   buildVisualOrder,
+  type BidiClass,
 } from '@silurus/ooxml-core';
 
 /** A laid-out segment as seen here: only its optional text matters for bidi.
@@ -23,6 +24,9 @@ const segText = (s: unknown): string | undefined => {
   const t = (s as { text?: unknown }).text;
   return typeof t === 'string' ? t : undefined;
 };
+
+/** A DrawingML tab is UAX#9 Bidi_Class S, not a neutral inline object. */
+const segIsTab = (s: unknown): boolean => 'isTab' in (s as object);
 
 /** Cheap test: does this run of segments contain any strong-RTL character? */
 export function segmentsHaveRtl(segments: readonly unknown[]): boolean {
@@ -60,15 +64,23 @@ export function computeLineVisualOrder(
 
   let full = '';
   const segStart: number[] = new Array(n);
+  let classOverride: (BidiClass | null)[] | undefined;
   for (let i = 0; i < n; i++) {
     segStart[i] = full.length;
     const t = segText(segments[i]) ?? '';
     full += t.length > 0 ? t : OBJECT_PLACEHOLDER;
+    if (segIsTab(segments[i])) {
+      classOverride ??= [];
+      while (classOverride.length < full.length) classOverride.push(null);
+      classOverride[segStart[i]] = 'S';
+    }
   }
+  if (classOverride) while (classOverride.length < full.length) classOverride.push(null);
 
   const { levels, paragraphLevel } = getDefaultBidiEngine().computeLevels(
     full,
     baseRtl ? 'rtl' : 'ltr',
+    classOverride,
   );
 
   const { order, segLevels } = buildVisualOrder(levels, paragraphLevel, segStart);

--- a/packages/pptx/src/pptx-multi-tab.test.ts
+++ b/packages/pptx/src/pptx-multi-tab.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody } from './renderer.js';
+import type { TextBody, Paragraph } from './types';
+import type { TextRunData, TabStop } from '@silurus/ooxml-core';
+
+// ECMA-376 §21.1.2.1.x (a:tabLst) + UAX#9 — issue #916: a paragraph line may hold
+// MANY tab-delimited cells (`title\tvalue\tpage`), each resolved against the stop
+// grid in the reading frame and reordered per UAX#9 (tabs are Bidi_Class S). The
+// old single-slot `LayoutLine.tabStop` dropped every cell but the last, bypassed
+// the visual reorder, and never rendered a start-tab gap. These tests pin the
+// multi-cell (item 1), reading-frame (LTR + RTL), and start-tab-gap (item 3)
+// behaviour; the per-cell mixed-direction reorder (item 2) is pinned by
+// bidi-line.test.ts.
+
+const FONT_PX = 20;
+const SCALE = 1 / 12700; // emuToPx(emu, SCALE) = emu·SCALE; 1pt → 1px
+
+function mockCtx(): {
+  ctx: CanvasRenderingContext2D;
+  texts: { text: string; x: number; direction: CanvasDirection }[];
+} {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  let fillStyle = '';
+  let direction: CanvasDirection = 'ltr';
+  const px = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const texts: { text: string; x: number; direction: CanvasDirection }[] = [];
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
+    get direction() { return direction; }, set direction(v: CanvasDirection) { direction = v; },
+    get letterSpacing() { return letterSpacing; }, set letterSpacing(v: string) { letterSpacing = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    fillText: (t: string, x: number) => texts.push({ text: t, x, direction }),
+    strokeText: () => {},
+    fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
+    translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
+    moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
+    setLineDash: () => {}, closePath: () => {}, arc: () => {},
+    strokeStyle: '#000', lineWidth: 1, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, texts };
+}
+
+function run(text: string, color = '000000'): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: FONT_PX, color, fontFamily: 'Serif',
+  } as TextRunData;
+}
+
+function bodyWithTabs(
+  tabStops: TabStop[],
+  runs: TextRunData[],
+  opts: { rtl?: boolean; algn?: string; marR?: number; indent?: number } = {},
+): TextBody {
+  const rtl = opts.rtl ?? false;
+  const para: Paragraph = {
+    alignment: opts.algn ?? (rtl ? 'r' : 'l'),
+    marL: 0, marR: opts.marR ?? 0, indent: opts.indent ?? 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null, defItalic: null,
+    defFontFamily: null, tabStops, rtl, runs,
+  } as unknown as Paragraph;
+  return {
+    verticalAnchor: 't', paragraphs: [para], defaultFontSize: FONT_PX,
+    defaultBold: null, defaultItalic: null,
+    lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'square', vert: 'horz', autoFit: 'none',
+  } as unknown as TextBody;
+}
+
+type RunInfo = { text: string; inShapeX: number; w: number };
+
+function render(body: TextBody, boxW = 600): {
+  texts: { text: string; x: number; direction: CanvasDirection }[];
+  runs: RunInfo[];
+} {
+  const { ctx, texts } = mockCtx();
+  const runs: RunInfo[] = [];
+  renderTextBody(
+    ctx, body, 0, 0, boxW, 400, SCALE,
+    null, 0, false, false, '#000000', undefined,
+    { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+    (r) => runs.push({ text: r.text, inShapeX: r.inShapeX, w: r.w }),
+  );
+  return { texts, runs };
+}
+
+const px = (n: number) => n * 12700;
+
+describe('pptx multi-cell tab lines (issue #916)', () => {
+  // Two right stops at 300 and 560 in a 600px box; content title|value|page.
+  const STOPS: TabStop[] = [{ pos: px(300), algn: 'r' }, { pos: px(560), algn: 'r' }];
+
+  it('LTR: renders ALL THREE cells (item-1 fix), each ending on its stop', () => {
+    const { runs } = render(bodyWithTabs(STOPS, [run('title\tvalue\tpage')]));
+    const title = runs.find((r) => r.text === 'title');
+    const value = runs.find((r) => r.text === 'value');
+    const page = runs.find((r) => r.text === 'page');
+    // Previously only the LAST cell ('page') survived; now all three render.
+    expect(title, 'title cell drawn').toBeTruthy();
+    expect(value, 'value cell drawn (was dropped by the single-slot model)').toBeTruthy();
+    expect(page, 'page cell drawn').toBeTruthy();
+    // title at the leading edge; value ends on stop 300; page ends on stop 560.
+    expect(title!.inShapeX).toBeCloseTo(0, 6);
+    expect(value!.inShapeX + value!.w).toBeCloseTo(300, 6);
+    expect(page!.inShapeX + page!.w).toBeCloseTo(560, 6);
+  });
+
+  it('RTL: mirrors the cells (leading cell rightmost) with each on its mirrored stop', () => {
+    const { runs } = render(bodyWithTabs(STOPS, [run('title\tvalue\tpage')], { rtl: true }));
+    const title = runs.find((r) => r.text === 'title')!;
+    const value = runs.find((r) => r.text === 'value')!;
+    const page = runs.find((r) => r.text === 'page')!;
+    expect(title && value && page, 'all three cells drawn').toBeTruthy();
+    // Reading order reversed: page (last, leftmost) < value < title (leading, rightmost).
+    expect(page.inShapeX).toBeLessThan(value.inShapeX);
+    expect(value.inShapeX).toBeLessThan(title.inShapeX);
+    // right/end cells: TRAILING (left) edge on the mirrored stop (600 − pos).
+    expect(value.inShapeX).toBeCloseTo(600 - 300, 6); // 300
+    expect(page.inShapeX).toBeCloseTo(600 - 560, 6); // 40
+    // leading cell's right edge sits at the leading (right) text edge.
+    expect(title.inShapeX + title.w).toBeCloseTo(600, 6);
+  });
+
+  it('materialises the START-tab gap so the following cell is not contiguous (item-3 fix)', () => {
+    // 'A' then a start(l) tab at 100, then 'B'. Old model collapsed the gap (B at
+    // 20, right after A); now B sits at the stop (100).
+    const stops: TabStop[] = [{ pos: px(100), algn: 'l' }];
+    const { runs } = render(bodyWithTabs(stops, [run('A\tB')]));
+    const a = runs.find((r) => r.text === 'A')!;
+    const b = runs.find((r) => r.text === 'B')!;
+    expect(a.inShapeX).toBeCloseTo(0, 6);
+    expect(b.inShapeX).toBeCloseTo(100, 6); // gap rendered; NOT contiguous at 20
+  });
+
+  it('keeps a cell ON its absolute stop when the first line carries a positive indent', () => {
+    // §21.1.2.1.x: a stop is an ABSOLUTE distance from the leading text-inset
+    // edge — a first-line indent shifts where the CONTENT starts (the reading
+    // pen), not where the stop sits. The resolver's start pen must include the
+    // draw-side first-line indent (textXOffset), or every gap over-shoots by the
+    // indent and the cell slides past its stop.
+    const stops: TabStop[] = [{ pos: px(300), algn: 'r' }];
+    const { runs } = render(
+      bodyWithTabs(stops, [run('title\tvalue')], { indent: px(50) }),
+    );
+    const title = runs.find((r) => r.text === 'title')!;
+    const value = runs.find((r) => r.text === 'value')!;
+    expect(title.inShapeX).toBeCloseTo(50, 6); // first line starts at the indent
+    expect(value.inShapeX + value.w).toBeCloseTo(300, 6); // cell still ENDS on the stop
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -17,7 +17,6 @@ import type {
   Glow,
   RenderOptions,
   DimOptions,
-  TabStop,
 } from './types';
 import { asBullet } from './types';
 import {
@@ -102,6 +101,7 @@ import { justifyLine, type Justified } from './text-justify';
 import { justifiedPiecePositions } from '@silurus/ooxml-core';
 import { resolveTableBorderConflict } from './table-border-conflict.js';
 import { isSmartArtFallbackShape, smartArtFallbackTextColor } from './smartart-fallback-contrast';
+import { resolveTabWidths } from './tab-layout.js';
 
 /** Theme font context threaded through the render call chain. */
 export interface RenderContext {
@@ -359,6 +359,10 @@ export async function prepareSlideMath(slide: Slide, math: MathRenderer): Promis
 type LayoutSegment = {
   text: string;
   font: string;
+  /** Inline DrawingML TAB, classified UAX#9 S during visual ordering (#916). */
+  isTab?: true;
+  /** Reading-frame gap resolved against a:tabLst immediately before paint. */
+  tabWidthPx?: number;
   /**
    * Raw (normalized) font-family requested for this segment's glyphs, kept
    * alongside the composed CSS `font` string so the line-height pass can floor
@@ -411,28 +415,6 @@ type LayoutSegment = {
 
 interface LayoutLine {
   segments: LayoutSegment[];
-  /** Segments aligned at a right/centre tab stop (set when the paragraph
-   *  contains a `\t` resolving to an `algn="r"|"ctr"` stop).
-   *
-   *  KNOWN MODEL LIMITS (pre-existing, LTR and RTL alike — follow-up #916):
-   *  - ONE cell slot per line: a second right/centre tab on the same line
-   *    re-assigns this object with empty `segments`, dropping the text
-   *    collected for the first cell.
-   *  - Cell segments bypass the UAX#9 visual reorder (`computeLineVisualOrder`
-   *    applies to `LayoutLine.segments` only): they are drawn sequentially in
-   *    logical order under a single ctx.direction, so mixed-direction cell
-   *    content does not reorder. docx instead models tabs as inline segments
-   *    classified Bidi_Class S — the shape a fix should take.
-   *  - Start ('l') / 'dec' tabs never populate this slot; they advance the
-   *    layout pen inline and the gap is not rendered. */
-  tabStop?: {
-    /** Stop position in px from the LEADING text-inset edge (logical,
-     *  §21.1.2.1): canvas X = bx + lPad + px under LTR, bx + bw − rPad − px
-     *  under an RTL base. */
-    px: number;
-    algn: string;
-    segments: LayoutSegment[];
-  };
   /** ECMA-376 §21.1.2.2.1 — this line is terminated by a MANUAL line break
    *  (`<a:br>`). In a `just` paragraph it is the end of a logical line and is
    *  left-aligned, not stretched — like the paragraph's last line (§20.1.10.59).
@@ -724,20 +706,18 @@ export function layoutParagraph(
   // sample-2 slide-7 stay on one line even though the bbox is tight).
   let hasWhitespaceOnLine = false;
 
-  // Tab stop state: once we hit a \t we switch to collecting tabStop.segments
-  let tabActive = false;
-  let tabStopPx = 0;   // position of tab stop from text area left (px)
+  // Once a line contains a tab, its cells remain unwrapped on that line.
+  let tabSeen = false;
 
   const newLine = (endsWithBreak = false) => {
     if (endsWithBreak) currentLine.endsWithBreak = true;
     lines.push(currentLine);
     currentLine = { segments: [] };
     lineW = 0;
-    tabActive = false; // reset tab state per line
+    tabSeen = false;
     hasWhitespaceOnLine = false;
   };
 
-  // Push to the active segment list (main or tab-stop group)
   const push = (
     text: string,
     font: string,
@@ -782,6 +762,7 @@ export function layoutParagraph(
     // one set / one missing) force a new segment.
     const sameMeta = (a: LayoutSegment) =>
       !a.math &&
+      !a.isTab &&
       a.font === font &&
       a.color === color &&
       a.underline === underline &&
@@ -796,22 +777,12 @@ export function layoutParagraph(
       (a.highlight ?? '') === (highlight ?? '') &&
       (a.fontFamily ?? '') === (fontFamily ?? '') &&
       hyperlinkKey(a.hyperlink) === hyperlinkKey(hyperlink);
-    if (tabActive && currentLine.tabStop) {
-      const segs = currentLine.tabStop.segments;
-      const last = segs.at(-1);
-      if (last && sameMeta(last)) {
-        last.text += text;
-      } else {
-        segs.push({ text, font, fontFamily, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, outline, highlight, hyperlink });
-      }
+    lineW += w;
+    const last = currentLine.segments.at(-1);
+    if (last && sameMeta(last)) {
+      last.text += text;
     } else {
-      lineW += w;
-      const last = currentLine.segments.at(-1);
-      if (last && sameMeta(last)) {
-        last.text += text;
-      } else {
-        currentLine.segments.push({ text, font, fontFamily, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, outline, highlight, hyperlink });
-      }
+      currentLine.segments.push({ text, font, fontFamily, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, outline, highlight, hyperlink });
     }
   };
 
@@ -978,40 +949,21 @@ export function layoutParagraph(
 
       // ── Tab character ────────────────────────────────────────────────────
       if (/^\t+$/.test(token)) {
-        // Pen position from the LEADING text-inset edge, measured in READING
-        // order: an LTR paragraph advances rightward from the left inset (leading
-        // indent = marL); a BIDI (RTL) paragraph advances leftward from the right
-        // inset (leading indent = marR). Tab stops (§21.1.2.1.x) are logical
-        // distances from that leading edge, so the same "first stop past the pen"
-        // rule selects the stop in either frame (mirrors docx #830 nextTabStopRtl;
-        // the draw pass then mirrors the chosen stop into the RTL frame).
-        const leadIndentPx = para.rtl ? emuToPx(para.marR, scale) : marLPx;
-        const currentAbsW = leadIndentPx + lineW;
-        const ts = (para.tabStops ?? []).find(
-          (t: TabStop) => emuToPx(t.pos, scale) > currentAbsW
-        );
-        if (ts) {
-          tabStopPx = emuToPx(ts.pos, scale);
-          if (ts.algn === 'r' || ts.algn === 'ctr') {
-            // Switch to tab-stop accumulation mode
-            tabActive = true;
-            currentLine.tabStop = { px: tabStopPx, algn: ts.algn, segments: [] };
-          } else {
-            // Start tab ('l'; 'dec' is treated as start — decimal alignment is
-            // unimplemented): advance the READING-order pen to the stop. The pen
-            // is the reading-frame distance from the leading indent, so the
-            // advance is `pos − leadIndentPx` under BOTH bases (LTR:
-            // leadIndentPx === marLPx, byte-identical). No cell group is opened
-            // for start tabs — the gap is not materialized as a drawn segment in
-            // either direction (pre-existing inline-advance model, see the
-            // LayoutLine.tabStop doc); the advance drives wrapping and later
-            // stop selection only.
-            lineW = tabStopPx - leadIndentPx;
-          }
-        } else {
-          // No matching tab stop — treat as a single space
-          push(' ', font, sizePx, color, segUnderline, run.strikethrough, undefined, segExtras);
+        // §21.1.2.1.x: retain every tab inline. Gap resolution is deferred until
+        // paint, when every cell width is known; UAX#9 S then reorders cells.
+        for (const _ of token) {
+          currentLine.segments.push({
+            text: '',
+            isTab: true,
+            font,
+            fontFamily: family,
+            sizePx,
+            color,
+            underline: false,
+            strikethrough: false,
+          });
         }
+        tabSeen = true;
         continue;
       }
 
@@ -1019,8 +971,8 @@ export function layoutParagraph(
       const tokW = ctx.measureText(token).width;
       const isWhitespace = /^\s+$/.test(token);
 
-      // If already in tab mode, collect all text into tabStop.segments (no wrap)
-      if (tabActive) {
+      // Tab-delimited cells stay on one line; tab gaps are resolved as a unit.
+      if (tabSeen) {
         push(token, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         continue;
       }
@@ -3268,6 +3220,46 @@ export function renderTextBody(
     // line carries strong-RTL characters, so LTR slides keep their exact path.
     const baseRtl = entry.para.rtl === true;
     const paraNeedsBidi = baseRtl || segmentsHaveRtl(line.segments);
+    const hasTab = line.segments.some((seg) => seg.isTab);
+
+    if (hasTab) {
+      // §21.1.2.1.x: resolve every inline tab in the logical READING frame.
+      // UAX#9 L2 later mirrors the resulting cells physically for an RTL base.
+      const marLPxE = emuToPx(entry.para.marL, scale);
+      const marRPxE = emuToPx(entry.para.marR, scale);
+      // The reading pen starts at the leading indent PLUS the draw-side
+      // first-line indent (textXOffset): a stop is an ABSOLUTE distance from the
+      // leading text-inset edge (§21.1.2.1), so the indent moves where content
+      // STARTS, not where a stop sits — omitting it would widen every gap by the
+      // indent and slide the cells past their stops. textXOffset only shifts the
+      // LTR pen (the RTL draw right-anchors and never applies it), so it joins
+      // the LTR frame only.
+      const leadingIndentPx = baseRtl ? marRPxE : marLPxE + textXOffset;
+      const limitPx = textMaxW + marLPxE + marRPxE;
+      const tabFontSeg = line.segments.find((seg) => seg.isTab) as LayoutSegment;
+      ctx.font = tabFontSeg.font;
+      const spaceW = ctx.measureText(' ').width;
+      const items = line.segments.map((seg) => {
+        if (seg.isTab) return { isTab: true, width: 0 };
+        if (seg.math) return { isTab: false, width: seg.math.width };
+        ctx.font = seg.font;
+        const ls = seg.letterSpacingPx ?? 0;
+        return {
+          isTab: false,
+          width: seg.text
+            ? ctx.measureText(seg.text).width + ls * codePointCount(seg.text)
+            : 0,
+        };
+      });
+      const stops = (entry.para.tabStops ?? []).map((stop) => ({
+        pos: emuToPx(stop.pos, scale),
+        algn: stop.algn,
+      }));
+      const widths = resolveTabWidths(items, stops, leadingIndentPx, limitPx, spaceW);
+      for (let i = 0; i < line.segments.length; i++) {
+        if (line.segments[i].isTab) line.segments[i].tabWidthPx = widths[i];
+      }
+    }
 
     // Measure line for alignment AND baseline ascent in one pass.
     // actualBoundingBoxAscent gives the real font ascent for the rendered glyphs,
@@ -3276,6 +3268,10 @@ export function renderTextBody(
     let lineWidth = 0;
     let maxAscent = lineHeight * 0.8; // fallback when no segments
     for (const seg of line.segments) {
+      if (seg.isTab) {
+        lineWidth += seg.tabWidthPx ?? 0;
+        continue;
+      }
       if (seg.math) {
         lineWidth += seg.math.width;
         maxAscent = Math.max(maxAscent, seg.math.ascent);
@@ -3369,16 +3365,24 @@ export function renderTextBody(
 
     const effectiveTextX = textX + textXOffset;
     let penX: number;
-    if (alignment === 'ctr') {
-      penX = effectiveTextX + (textMaxW - textXOffset - lineWidth) / 2;
-    } else if (alignment === 'r') {
-      // Reading-frame (#930): an RTL marker leads at the right edge, so the text
-      // right-aligns to `leadingEdge − markerAdvance` (contiguous with the
-      // marker). `rtlMarkerReservePx` is 0 for non-list / marker-less lines, so
-      // plain RTL paragraphs keep `leadingEdge − lineWidth` (byte-identical).
-      penX = textX + textMaxW - rtlMarkerReservePx - lineWidth;
+    if (hasTab) {
+      // Tab stops are absolute from the leading text-inset edge; paragraph
+      // alignment must not add a second offset (#913/#916).
+      penX = baseRtl
+        ? textX + textMaxW - rtlMarkerReservePx - lineWidth
+        : effectiveTextX;
     } else {
-      penX = effectiveTextX;
+      if (alignment === 'ctr') {
+        penX = effectiveTextX + (textMaxW - textXOffset - lineWidth) / 2;
+      } else if (alignment === 'r') {
+        // Reading-frame (#930): an RTL marker leads at the right edge, so the text
+        // right-aligns to `leadingEdge − markerAdvance` (contiguous with the
+        // marker). `rtlMarkerReservePx` is 0 for non-list / marker-less lines, so
+        // plain RTL paragraphs keep `leadingEdge − lineWidth` (byte-identical).
+        penX = textX + textMaxW - rtlMarkerReservePx - lineWidth;
+      } else {
+        penX = effectiveTextX;
+      }
     }
 
     // Justified alignment (ECMA-376 §20.1.10.59 ST_TextAlignType): just/justLow
@@ -3392,15 +3396,13 @@ export function renderTextBody(
       alignment === 'just' || alignment === 'justLow' ? 'just' as const
       : alignment === 'dist' || alignment === 'thaiDist' ? 'dist' as const
       : null;
-    // A line broken at a right/centre tab stop keeps its pre-tab text natural:
-    // justifying it would spread that text across the whole column and overlap
-    // the tab-aligned remainder drawn after this loop. Skip justify for it.
-    const hasTabStop = !!line.tabStop && line.tabStop.segments.length > 0;
+    // Tab-delimited cells keep their natural widths; the inline gaps provide
+    // their stop alignment and must not participate in justification.
     // A `just` line ended by a manual <a:br> is left-aligned like the last line
     // (§20.1.10.59 + §21.1.2.2.1); `dist` ignores this and fills every line
     // (justifyLine only suppresses the last line for `just`).
     const endsLogicalLine = isLastLine || (line.endsWithBreak ?? false);
-    const drawSegs = justifyMode && !paraNeedsBidi && !hasTabStop
+    const drawSegs = justifyMode && !paraNeedsBidi && !hasTab
       ? justifyLine(line.segments, textMaxW - textXOffset, lineWidth, justifyMode, endsLogicalLine)
       : null;
     const segs: (LayoutSegment & Partial<Justified>)[] = drawSegs ?? line.segments;
@@ -3417,6 +3419,10 @@ export function renderTextBody(
       const seg = segs[li];
       const segRtl = visual ? visual.rtl[li] : false;
       if (paraNeedsBidi) ctx.direction = segRtl ? 'rtl' : 'ltr';
+      if (seg.isTab) {
+        penX += seg.tabWidthPx ?? 0;
+        continue;
+      }
       // Justification advance after this piece (0 when not justifying). Added to
       // the pen, and folded into the trailing edge of underline / strikethrough
       // and the reported onTextRun width, so decorations and the text layer span
@@ -3632,113 +3638,7 @@ export function renderTextBody(
       penX += segW;
       penX += jext;
     }
-    if (paraNeedsBidi) ctx.direction = 'ltr'; // reset before tab-stop / next line
-
-    // ── Tab-stop segments (right-aligned or centred at tab stop position) ──
-    if (line.tabStop && line.tabStop.segments.length > 0) {
-      let totalTabW = 0;
-      for (const seg of line.tabStop.segments) {
-        ctx.font = seg.font;
-        const ls = seg.letterSpacingPx ?? 0;
-        totalTabW += ctx.measureText(seg.text).width + ls * codePointCount(seg.text);
-      }
-      // ECMA-376 §21.1.2.1.x tab stops are LOGICAL: `pos` is the distance from the
-      // LEADING text-inset edge. LTR base ⇒ leading edge = left inset
-      // (`bx + lPad`), pen advances rightward; BIDI (RTL) base ⇒ leading edge =
-      // right inset (`bx + bw − rPad`), pen advances LEFT, so the stop mirrors and
-      // the trailing cell flips visual side. The LTR-frame math below dropped an
-      // RTL cell on the wrong side (issue #831). This mirrors the docx fix (#830 /
-      // #835: `layoutBidiTabStops` / `nextTabStopRtl` resolve stops against the
-      // leading text margin in the reading frame). DrawingML tabs carry no leader,
-      // so — unlike docx — there is nothing to paint across the gap. Known model
-      // limits (ONE cell per line; cell contents bypass the UAX#9 reorder): see
-      // the LayoutLine.tabStop doc — follow-up #916.
-      let tabPenX: number;
-      if (baseRtl) {
-        const tabAbsX = bx + bw - rPad - line.tabStop.px;
-        // Only 'r'/'ctr' stops reach this block — layoutParagraph opens a tab
-        // cell solely for those two; a start ('l') or 'dec' tab advances the pen
-        // inline (reading frame) and never builds a cell (see the tab token
-        // branch in layoutParagraph).
-        if (line.tabStop.algn === 'ctr') {
-          tabPenX = tabAbsX - totalTabW / 2;
-        } else {
-          // end/trailing (§21.1.2.1: physical `r` = logical end under RTL): the
-          // cell's TRAILING (left) edge sits on the stop, cell extends rightward.
-          tabPenX = tabAbsX;
-        }
-        // A stop past the trailing (left) text edge pins the cell AT that edge —
-        // the docx layoutBidiTabStops clamp (#835: Word never pushes the cell
-        // off the text area). Unclamped, a mirrored stop with pos > the text
-        // width would land at a negative x, drawing outside the shape.
-        const trailingEdgePx = bx + lPad;
-        if (tabPenX < trailingEdgePx) tabPenX = trailingEdgePx;
-      } else {
-        const tabAbsX = bx + lPad + line.tabStop.px;
-        if (line.tabStop.algn === 'r') {
-          tabPenX = tabAbsX - totalTabW;
-        } else if (line.tabStop.algn === 'ctr') {
-          tabPenX = tabAbsX - totalTabW / 2;
-        } else {
-          tabPenX = tabAbsX;
-        }
-      }
-      // Shape the cell's glyphs in reading order under an RTL base (Arabic
-      // joining, digit shaping). `ctx.textAlign` stays 'left' (set once for the
-      // whole body), so tabPenX remains the cell's left edge — only glyph shaping
-      // differs. Reset to 'ltr' after the cell so later lines are unaffected.
-      if (baseRtl) ctx.direction = 'rtl';
-      for (const seg of line.tabStop.segments) {
-        ctx.font = seg.font;
-        ctx.fillStyle = seg.color;
-        const tabLs = seg.letterSpacingPx ?? 0;
-        // Highlight box behind tab-stop-aligned glyphs (ECMA-376 §21.1.2.3.4).
-        // No justification stretch on tab-stop runs, so the advance is just
-        // glyph measure + letter spacing.
-        if (seg.highlight && seg.text) {
-          const hlW = ctx.measureText(seg.text).width + tabLs * codePointCount(seg.text);
-          paintHighlight(ctx, tabPenX, baseline, hlW, seg.sizePx, seg.highlight, seg.color);
-        }
-        if (tabLs > 0 && seg.text.length > 1) {
-          // rPr @spc (§21.1.2.3.x): draw the whole CONTEXTUALLY-shaped string in
-          // ONE fillText with canvas letterSpacing, mirroring drawWithFont (PR
-          // #627) / docGrid (docx #626). The old per-glyph `measure(ch)+tabLs`
-          // summed ISOLATED advances and overran the contextual box `tabSegW` at
-          // 約物半角 punctuation (opening brackets collapse to half-width only in
-          // context), pulling later glyphs into the next tab segment. ctx.
-          // letterSpacing keeps the drawn advance == measure(seg.text)[contextual]
-          // + tabLs·codePointCount == tabSegW.
-          const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
-          const prev = lctx.letterSpacing;
-          try { lctx.letterSpacing = `${tabLs}px`; } catch { /* older engines */ }
-          ctx.fillText(seg.text, tabPenX, baseline);
-          try { lctx.letterSpacing = prev; } catch { /* ignore */ }
-        } else {
-          ctx.fillText(seg.text, tabPenX, baseline);
-        }
-        ctx.font = seg.font;
-        const tabSegW = ctx.measureText(seg.text).width + tabLs * codePointCount(seg.text);
-        if (onTextRun && seg.text) {
-          onTextRun({
-            text: seg.text,
-            inShapeX: tabPenX - bx,
-            inShapeY: cursorY - by,
-            w: tabSegW,
-            h: lineHeight,
-            fontSize: seg.sizePx,
-            font: seg.font,
-            shapeX: bx,
-            shapeY: by,
-            shapeW: bw,
-            shapeH: bh,
-            rotation: shapeRotation,
-            hyperlink: seg.hyperlink,
-          });
-        }
-        tabPenX += tabSegW;
-      }
-      if (baseRtl) ctx.direction = 'ltr';
-    }
+    if (paraNeedsBidi) ctx.direction = 'ltr';
 
     cursorY += linePx;
   }

--- a/packages/pptx/src/rtl-tab-stops.test.ts
+++ b/packages/pptx/src/rtl-tab-stops.test.ts
@@ -68,8 +68,8 @@ function run(text: string, color = '000000'): TextRunData {
   } as TextRunData;
 }
 
-/** A paragraph carrying `tabStops`. The run text must contain a `\t` so layout
- *  switches into tab-stop accumulation mode.
+/** A paragraph carrying `tabStops`. The run text contains a `\t` so layout
+ *  emits an inline tab segment (#916 multi-cell model).
  *
  *  `alignment` follows the PARSER's resolution order (parser/src/text.rs:617):
  *  explicit `pPr@algn` → inherited body/layout/master default (not modelled
@@ -154,16 +154,20 @@ describe('pptx RTL tab stops resolve in the reading frame (issue #831, mirrors d
     expect(cell.inShapeX).toBeCloseTo(RTL_STOP_X - CELL_W / 2, 6); // 200 − 20 = 180
   });
 
-  // (3) RTL cell glyphs are painted with ctx.direction = 'rtl' so bidi content in
-  //     the cell shapes in reading order (textAlign stays 'left', so the pen X is
-  //     unchanged — only glyph shaping/joining differs).
-  it('draws the RTL tab cell with ctx.direction = rtl', () => {
+  // (3) ITEM-2 CORRECTION (issue #916): tab-cell content now flows through the
+  //     per-segment UAX#9 pass (`computeLineVisualOrder`) instead of a blanket
+  //     `ctx.direction='rtl'` for the whole cell. A DIGITS cell ("12") is
+  //     Bidi_Class EN → even (LTR) level even under an RTL base, so it is drawn
+  //     with ctx.direction='ltr' (digits read left-to-right in Arabic too). The
+  //     old model's unconditional 'rtl' was the item-2 defect; mixed-direction
+  //     cell reordering is pinned by bidi-line.test.ts / pptx-multi-tab.test.ts.
+  it('draws a digits tab cell with ctx.direction = ltr (per-segment bidi, item 2)', () => {
     const { texts } = render(
       bodyWithTab([{ pos: TAB_POS_EMU, algn: 'r' }], [run(`\t${CELL}`)], { rtl: true }),
       BOX_W,
     );
     const cellDraw = texts.find((t) => t.text === CELL)!;
-    expect(cellDraw.direction).toBe('rtl');
+    expect(cellDraw.direction).toBe('ltr');
   });
 
   // (4) An EXPLICIT `pPr@algn="l"` on an rtl="1" paragraph (the parser resolution
@@ -179,16 +183,22 @@ describe('pptx RTL tab stops resolve in the reading frame (issue #831, mirrors d
     expect(cell.inShapeX).toBeCloseTo(RTL_STOP_X, 6);
   });
 
-  // (5) A start ('l') tab opens NO cell — it advances the PEN inline (the gap is
-  //     not rendered; pre-existing model, both directions). Under an RTL base the
-  //     advance must live in the READING frame (distance from the leading indent,
-  //     = marR), like the stop selection: mixing frames (selection from marR,
-  //     advance from marL) overshoots the pen when marR > marL and a later stop
-  //     becomes unreachable. Stops: start@100px, end@140px; marR=50px; 'A'=20px.
-  //     Reading frame: pen 50→(start tab)→100, +A→120 → the end stop at 140 is
-  //     still ahead ⇒ '\t12' opens the cell, trailing edge on 600−140=460.
-  //     Mixed-frame (the bug): lineW=100−marL(0)=100, +A→120 → selection pen
-  //     50+120=170 > 140 ⇒ no stop ⇒ the tab degrades to a space (no cell).
+  // (5) A start ('l') tab advances the reading-frame pen so a later end stop stays
+  //     reachable. Stops: start@100px, end@140px; marR=50px; 'A'=20px. Reading
+  //     frame (pen from the leading indent = marR): pen 50→(start tab)→100, +A→120
+  //     ⇒ the end stop at 140 is still ahead ⇒ the '\t12' cell EXISTS. This is the
+  //     reachability property case (5) has always verified.
+  //
+  //     ITEM-3 CORRECTION (issue #916): the start-tab gap is now MATERIALISED
+  //     (previously it silently advanced the pen without rendering), so the line
+  //     is laid out cumulatively. The end stop at reading 140 is BEHIND the pen
+  //     (120) once its 40-wide cell is placed (target 140−40 = 100 < 120), so the
+  //     end tab collapses per the no-backward-tab clamp — the same behaviour as
+  //     docx `layoutBidiTabStops`. The cell's trailing (left) edge therefore lands
+  //     at the cumulative pen, not the absolute mirrored stop: content width = 50
+  //     (start gap) + 20 (A) + 0 (collapsed end tab) + 40 (cell) = 110, so the
+  //     RTL-anchored cell sits at (600 − marR − 110) = 440, with 'A' at 480 (the
+  //     rendered start gap pulls it off the leading edge — the visible item-3 fix).
   it('advances a start tab in the reading frame so a later end stop stays reachable', () => {
     const stops: TabStop[] = [
       { pos: 100 * 12700, algn: 'l' },
@@ -200,7 +210,11 @@ describe('pptx RTL tab stops resolve in the reading frame (issue #831, mirrors d
     );
     const cell = runs.find((r) => r.text === CELL);
     expect(cell, 'end-stop cell exists (start-tab advance did not overshoot)').toBeTruthy();
-    expect(cell!.inShapeX).toBeCloseTo(BOX_W - 140, 6); // 460
+    expect(cell!.inShapeX).toBeCloseTo(440, 6);
+    // The start-tab gap is now rendered: 'A' is pulled off the leading (right)
+    // text edge (was flush at 530 in the pre-fix inline-advance model).
+    const a = runs.find((r) => r.text === 'A')!;
+    expect(a.inShapeX).toBeCloseTo(480, 6);
   });
 
   // (6) A stop past the TRAILING (left) text edge pins the cell at that edge —

--- a/packages/pptx/src/tab-layout.test.ts
+++ b/packages/pptx/src/tab-layout.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { resolveTabWidths, type TabItem, type TabStopPx } from './tab-layout.js';
+
+// ECMA-376 §21.1.2.1.x (a:tabLst / a:tab @pos @algn) — resolve each inline TAB
+// segment's GAP WIDTH against the stop grid, in the READING frame (issue #916,
+// generalising the #913 single-cell RTL semantics to N cells).
+//
+// All coordinates are reading-frame px measured from the LEADING text-inset edge
+// (LTR: left inset; RTL: right inset). Content starts at `startPen` (the leading
+// indent). A tab's gap makes the FOLLOWING cell end (`r`/`dec`), centre (`ctr`),
+// or start (`l`) on the selected stop. The same math serves LTR and RTL: the
+// physical mirroring falls out of the visual L2 reorder + cumulative draw
+// (mirrors docx `layoutBidiTabStops`). Non-tab items keep their input width.
+
+const S = (pos: number, algn: string): TabStopPx => ({ pos, algn });
+const text = (width: number): TabItem => ({ isTab: false, width });
+const tab = (): TabItem => ({ isTab: true, width: 0 });
+
+describe('resolveTabWidths — inline tab gap resolution (§21.1.2.1.x)', () => {
+  it('LTR single right stop: gap makes the following cell END on the stop', () => {
+    // [TAB][text(40)], stop r@400 ⇒ cell right edge on 400 ⇒ gap 360.
+    const out = resolveTabWidths([tab(), text(40)], [S(400, 'r')], 0, 600, 0);
+    expect(out).toEqual([360, 40]);
+  });
+
+  it('supports N tab cells per line (the #916 item-1 fix)', () => {
+    // [text(50)][TAB][text(40)][TAB][text(40)], stops r@200, r@400.
+    const items = [text(50), tab(), text(40), tab(), text(40)];
+    const out = resolveTabWidths(items, [S(200, 'r'), S(400, 'r')], 0, 600, 0);
+    // gaps 110 and 160 ⇒ cells end exactly on 200 and 400.
+    expect(out).toEqual([50, 110, 40, 160, 40]);
+    // cumulative pen reaches each stop:
+    expect(50 + out[1] + 40).toBeCloseTo(200, 6); // cell 1 right edge
+    expect(50 + out[1] + 40 + out[3] + 40).toBeCloseTo(400, 6); // cell 2 right edge
+  });
+
+  it('centre stop centres the following cell on the stop', () => {
+    // [TAB][text(40)], ctr@400 ⇒ gap = 400 − 40/2 = 380.
+    const out = resolveTabWidths([tab(), text(40)], [S(400, 'ctr')], 0, 600, 0);
+    expect(out).toEqual([380, 40]);
+  });
+
+  it('start (l) tab MATERIALISES the gap (the #916 item-3 fix)', () => {
+    // [TAB][text(30)], l@100, pen 0 ⇒ gap 100 (previously never rendered).
+    const out = resolveTabWidths([tab(), text(30)], [S(100, 'l')], 0, 600, 0);
+    expect(out).toEqual([100, 30]);
+  });
+
+  it('dec tab aligns like right (frac 1; no decimal-point split) and renders the gap', () => {
+    const out = resolveTabWidths([tab(), text(40)], [S(400, 'dec')], 0, 600, 0);
+    expect(out).toEqual([360, 40]);
+  });
+
+  it('no reachable stop → the tab collapses to the fallback gap (degrade to a space)', () => {
+    const out = resolveTabWidths([tab(), text(30)], [], 0, 600, 20);
+    expect(out).toEqual([20, 30]);
+  });
+
+  it('clamps a cell that would overflow the trailing text edge (#835)', () => {
+    // stop r@700 in a 600px area, cell 40 ⇒ target 660 → clamp so cell ends at 600.
+    const out = resolveTabWidths([tab(), text(40)], [S(700, 'r')], 0, 600, 0);
+    expect(out).toEqual([560, 40]); // cell spans [560, 600]
+  });
+
+  it('never moves the pen backwards: a right stop behind the pen collapses the tab', () => {
+    // start@100 then A(20) leaves pen at 120; end@140 with a 40-wide cell wants
+    // target 100 < pen ⇒ gap 0 (the cell continues from the pen). Matches docx
+    // layoutBidiTabStops and the #913 case (5) reachability contract.
+    const items = [tab(), text(20), tab(), text(40)];
+    const out = resolveTabWidths(items, [S(100, 'l'), S(140, 'r')], 50, 600, 0);
+    expect(out).toEqual([50, 20, 0, 40]);
+  });
+
+  it('selects the nearest stop strictly past the pen, custom order-agnostic', () => {
+    // Stops given out of order; pen 0 picks 200, then pen past 200 picks 400.
+    const items = [tab(), text(10), tab(), text(10)];
+    const out = resolveTabWidths(items, [S(400, 'l'), S(200, 'l')], 0, 600, 0);
+    expect(out).toEqual([200, 10, 190, 10]);
+  });
+});

--- a/packages/pptx/src/tab-layout.ts
+++ b/packages/pptx/src/tab-layout.ts
@@ -1,0 +1,92 @@
+/** One entry of a line's LOGICAL-order segment sequence, as seen by
+ *  {@link resolveTabWidths}: a tab (its gap is computed) or content (its
+ *  measured advance in px). */
+export interface TabItem {
+  isTab: boolean;
+  width: number;
+}
+
+/** An `a:tab` from `a:pPr > a:tabLst` (§21.1.2.1.x) in reading-frame px:
+ *  `pos` is the distance from the LEADING text-inset edge (logical, not
+ *  physical — the right inset under an RTL base), `algn` is `l|ctr|r|dec`. */
+export interface TabStopPx {
+  pos: number;
+  algn: string;
+}
+
+/**
+ * ECMA-376 §21.1.2.1.x — resolve each inline TAB segment's GAP width against
+ * the paragraph's custom stop grid, in READING-frame px measured from the
+ * leading text-inset edge (issue #916, generalising the #913 single-cell
+ * semantics to N cells; mirrors docx `layoutBidiTabStops`).
+ *
+ * The walk is base-agnostic: the pen advances through `items` in LOGICAL
+ * order from `startPen` (the leading indent, plus any first-line indent); a
+ * tab jumps to the nearest stop strictly past the pen, placing the FOLLOWING
+ * cell (the content run up to the next tab / line end) so it ends on (`r`,
+ * `dec`), centres on (`ctr`), or starts at (`l`) the stop. Under an RTL base
+ * the SAME reading-frame gaps apply — UAX#9 L2 (tabs are Bidi_Class S, see
+ * bidi-line.ts) reverses cells and tabs together, so each logical gap IS its
+ * visual gap and the cumulative draw reproduces the mirrored stops.
+ *
+ * `dec` aligns like `r` (frac 1): true decimal-point splitting is not
+ * implemented — the same approximation docx uses. DrawingML defines no
+ * automatic tab grid (there is no `defTabSz` support in this parser), so a
+ * tab with no reachable stop degrades to `noStopGap` (a space width,
+ * preserving the pre-#916 behaviour). Two clamps mirror docx: a cell whose
+ * far edge would cross `limit` (the trailing text-inset edge) is pinned to it
+ * (#835 — Word never pushes a cell off the text area), and a tab never moves
+ * the pen backwards.
+ *
+ * @returns one width per LOGICAL index (non-tabs keep their input width).
+ */
+export function resolveTabWidths(
+  items: readonly TabItem[],
+  stops: readonly TabStopPx[],
+  startPen: number,
+  limit: number,
+  noStopGap: number,
+): number[] {
+  const widths = items.map((item) => item.width);
+  const followW = (from: number): number => {
+    let width = 0;
+    for (let i = from; i < items.length && !items[i].isTab; i++) {
+      width += widths[i];
+    }
+    return width;
+  };
+
+  let pen = startPen;
+  for (let i = 0; i < items.length; i++) {
+    if (!items[i].isTab) {
+      pen += widths[i];
+      continue;
+    }
+
+    let stop: TabStopPx | null = null;
+    for (const candidate of stops) {
+      if (candidate.pos > pen && (stop === null || candidate.pos < stop.pos)) {
+        stop = candidate;
+      }
+    }
+    if (stop === null) {
+      widths[i] = noStopGap;
+      pen += noStopGap;
+      continue;
+    }
+
+    const followingWidth = followW(i + 1);
+    const fraction = stop.algn === 'ctr'
+      ? 0.5
+      : stop.algn === 'r' || stop.algn === 'dec'
+        ? 1
+        : 0;
+    let target = stop.pos - followingWidth * fraction;
+    if (target + followingWidth > limit) target = limit - followingWidth;
+    if (target < pen) target = pen;
+    widths[i] = target - pen;
+    pen = target;
+  }
+
+  return widths;
+}

--- a/packages/pptx/src/tab-stop-spc.test.ts
+++ b/packages/pptx/src/tab-stop-spc.test.ts
@@ -7,12 +7,13 @@ import type { TextRunData, TabStop } from '@silurus/ooxml-core';
 // TAB-STOP draw path, the pptx analog of PR #627 (drawWithFont) and docx #626
 // (docGrid §17.6.5).
 //
-// A right-/centre-aligned tab stop (pPr > tabLst, §21.1.2.1.x) collects the text
-// after a `\t` into `line.tabStop.segments`. Each tab segment is measured
-// CONTEXTUALLY: `tabSegW = measureText(seg.text) + ls·codePointCount`. The
-// browser's 約物半角 contextual shaping collapses an opening bracket "［" to
-// half-width when it is FOLLOWED by an East-Asian glyph WITHIN the measured
-// string (`measureText("［あ") < measureText("［") + measureText("あ")`).
+// A right-/centre-aligned tab stop (pPr > tabLst, §21.1.2.1.x) places the text
+// after a `\t` at the stop (since #916, as ordinary inline segments after an
+// inline tab segment). Each segment is measured CONTEXTUALLY:
+// `segW = measureText(seg.text) + ls·codePointCount`. The browser's 約物半角
+// contextual shaping collapses an opening bracket "［" to half-width when it is
+// FOLLOWED by an East-Asian glyph WITHIN the measured string
+// (`measureText("［あ") < measureText("［") + measureText("あ")`).
 //
 // The bug: the tab-stop @spc branch painted the segment glyph-by-glyph,
 // advancing the pen by the ISOLATED `measureText(ch) + ls` of each code point.
@@ -105,9 +106,8 @@ function run(text: string, letterSpacing?: number, color = '000000'): TextRunDat
 }
 
 /** A paragraph carrying a right-aligned tab stop at `tabPosEmu` EMU. The runs'
- *  text must contain a leading `\t` so the layout switches into tab-stop
- *  accumulation mode (`currentLine.tabStop`) and collects the following text
- *  into `tabStop.segments`. */
+ *  text carries a leading `\t` so the layout emits an inline tab segment whose
+ *  resolved gap places the following text at the stop (#916 multi-cell model). */
 function bodyWithTab(tabPosEmu: number, algn: string, runs: TextRunData[]): TextBody {
   const tabStops: TabStop[] = [{ pos: tabPosEmu, algn }];
   const para: Paragraph = {


### PR DESCRIPTION
## Summary

Restructures the pptx tab-stop model from a single right/centre cell per line to
**N inline tab segments per line**, fixing the three pre-existing limitations
tracked in #916 (follow-up to #831 / #913):

1. **Single cell per line → multi-cell.** The old `LayoutLine.tabStop` held one
   right/centre cell; a second `\t` overwrote it, dropping the first cell's text
   (`label\tcol1\tcol2` rendered only `col2`). Tabs are now inline segments of
   `line.segments`, so any number of tab-delimited cells render.
2. **Cell content now goes through the UAX#9 visual reorder.** Tab segments are
   classified Bidi_Class **S** (Segment Separator) in `bidi-line.ts`, so rules
   L1/L2 reset each tab to the paragraph level and reorder each tab-delimited
   **cell** independently — mixed-direction cell content (Arabic + Latin + digits)
   now mirrors correctly instead of drawing in logical order under a blanket
   `ctx.direction`.
3. **Start (`l`) and `dec` tabs now render their gap.** A start/decimal tab used
   to advance the layout pen without materialising the gap, so cells drew
   contiguously. The gap is now a real (blank) inline segment with a resolved
   width. `algn="dec"` aligns like `right` (frac 1; no decimal-point split — same
   approximation as docx).

This mirrors the docx `line-layout.ts` / `bidi-line.ts` model and generalises the
#913 RTL reading-frame, clamp, and leading-edge semantics to N cells.

## Design

- **New pure helper `packages/pptx/src/tab-layout.ts` (`resolveTabWidths`)** resolves
  each tab's gap in the READING frame (base-agnostic — the physical RTL mirroring
  falls out of the visual L2 reorder + cumulative draw), with the #835 trailing-edge
  clamp and the no-backward-tab clamp. Unit-tested in `tab-layout.test.ts`.
- **`bidi-line.ts`** gains a `segIsTab` predicate and a UAX#9 §4.3 HL1 class override
  forcing the tab placeholder to `S` (mirrors docx). No core change.
- **`renderer.ts`**: `layoutParagraph` emits inline tab segments (dropping the
  single-slot `tabStop`, `tabActive`); the paint loop resolves tab widths in the
  reading frame before line-width/anchoring, folds them into `lineWidth`, draws each
  tab as a blank gap in visual order, and deletes the separate tab-cell paint block.

### Shared vs parallel

The **UAX#9 S / L1 / L2 kernel is already shared** in `packages/core/src/text/bidi`
(`computeLevels(text, base, classOverride)`, the L1 S-reset, and `buildVisualOrder`)
and already consumed by both docx and pptx — the only per-package addition is setting
the `S` class override on tab segments (~5 lines). No core change was needed.

The gap-resolution math is kept **parallel** in pptx (`tab-layout.ts`) rather than
extracting docx's `nextTabStop`/`layoutBidiTabStops` to core, because: (a) pptx has no
automatic-grid (`defTabSz`) so docx's interval grid — the main shared value of those
functions — is unused; (b) the two packages have different segment models (docx stores
`measuredWidth` on `LayoutTabSeg` with an entangled wrap queue; pptx re-measures at
paint), so resolution wires into each package's own loop; (c) editing `packages/core`
from a package worktree risks docx's direct-call tests and parallel sessions. The
algorithm-defining kernel (bidi S/L1/L2) is the correct shared boundary and is already
shared; `resolveTabWidths` is a small pure function whose intent — not code — mirrors
docx, kept independently testable.

## Tests

- `tab-layout.test.ts` — `resolveTabWidths` unit contract (multi-cell, centre, start-gap,
  dec, no-stop fallback, #835 clamp, no-backward-tab, order-agnostic stop selection).
- `bidi-line.test.ts` — tabs classified S: cells reorder independently under RTL,
  logical under LTR, and mixed-direction content inside a cell reorders (item 2).
- `pptx-multi-tab.test.ts` — `title\tvalue\tpage` renders all three cells LTR and RTL
  (item 1); start-tab gap rendered (item 3); first-line indent kept out of the stop
  frame (a stop is an ABSOLUTE distance from the leading text-inset edge, so the
  resolver's start pen includes the draw-side indent — otherwise every gap
  over-shoots by the indent and cells slide past their stops).
- `rtl-tab-stops.test.ts` — cases 1/2/4/6/7 unchanged; case 3 updated (a digits cell now
  draws `ctx.direction='ltr'` via per-segment bidi — the item-2 correction) and case 5
  updated (the start-tab gap is now materialised, so the cumulative layout places the
  end cell at 440 with `A` pulled off the leading edge — the item-3 correction). Both
  still assert the property each case exists for.
- LTR non-tab paragraphs are byte-identical (no path change when no tab is present).
- **A/B pixel probe on real content**: every slide of a local tab-using deck (five
  `label\tNN%` right-tab lines plus two no-stop tabs) rendered headlessly (skia,
  1280px) with the base (`origin/main`) and branch renderers — **0 differing pixels
  on all 5 slides** (921,600 px each), so the multi-cell model reproduces the
  existing single-cell behaviour exactly where it was already correct.
- Full pptx suite green (63 files / 411 tests) and root typecheck green on the
  rebased head.

Design reviewed with an independent model before implementation.

Closes #916. Refs #831, #913.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
