### PR TITLE
fix(docx): color numbering markers from lvl rPr and paragraph mark

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -2332,35 +2332,56 @@ fn parse_paragraph_cond(
             // theme refs. A bare `<w:rFonts w:hint="eastAsia"/>` carries no
             // typeface, so the marker simply inherits the paragraph's ascii (e.g.
             // Times → the auto-number renders serif) and eastAsia (e.g. MS Gothic).
-            let (format, ind_left, tab, suff, lvl_jc, marker_ascii, marker_ea, pic_bullet) =
-                num_map
-                    .get_level(num_id, num_level)
-                    .map(|l| {
-                        let mut marker_fmt = base_run.clone();
-                        apply_direct_run(&mut marker_fmt, &l.rpr);
-                        (
-                            l.format.clone(),
-                            l.indent_left,
-                            l.tab,
-                            l.suff.clone(),
-                            l.lvl_jc.clone(),
-                            theme.resolve_font_ref(marker_fmt.font_family_ascii.clone()),
-                            theme.resolve_font_ref(marker_fmt.font_family_east_asia.clone()),
-                            l.pic_bullet.clone(),
-                        )
-                    })
-                    .unwrap_or_else(|| {
-                        (
-                            "decimal".to_string(),
-                            36.0,
-                            18.0,
-                            "tab".to_string(),
-                            "left".to_string(),
-                            theme.resolve_font_ref(base_run.font_family_ascii.clone()),
-                            theme.resolve_font_ref(base_run.font_family_east_asia.clone()),
-                            None,
-                        )
-                    });
+            // §17.9.24 — the level rPr's own `<w:color>` also rides along
+            // (`marker_color` + `marker_color_auto`; parse_run_fmt maps an
+            // explicit auto to None + color_auto, §17.3.2.6). Kept UNMERGED
+            // from the run formatting: the paragraph-mark fallback lives in
+            // `paragraph_mark_color` below and the renderer resolves the
+            // precedence (lvl → mark → default ink; explicit auto stops the
+            // fallback at the default ink).
+            let (
+                format,
+                ind_left,
+                tab,
+                suff,
+                lvl_jc,
+                marker_ascii,
+                marker_ea,
+                marker_color,
+                marker_color_auto,
+                pic_bullet,
+            ) = num_map
+                .get_level(num_id, num_level)
+                .map(|l| {
+                    let mut marker_fmt = base_run.clone();
+                    apply_direct_run(&mut marker_fmt, &l.rpr);
+                    (
+                        l.format.clone(),
+                        l.indent_left,
+                        l.tab,
+                        l.suff.clone(),
+                        l.lvl_jc.clone(),
+                        theme.resolve_font_ref(marker_fmt.font_family_ascii.clone()),
+                        theme.resolve_font_ref(marker_fmt.font_family_east_asia.clone()),
+                        l.rpr.color.clone(),
+                        l.rpr.color_auto,
+                        l.pic_bullet.clone(),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    (
+                        "decimal".to_string(),
+                        36.0,
+                        18.0,
+                        "tab".to_string(),
+                        "left".to_string(),
+                        theme.resolve_font_ref(base_run.font_family_ascii.clone()),
+                        theme.resolve_font_ref(base_run.font_family_east_asia.clone()),
+                        None,
+                        false,
+                        None,
+                    )
+                });
             let counter = num_map.advance(num_id, num_level);
             let text = num_map.resolve_text(num_id, num_level, counter);
             let (
@@ -2392,6 +2413,8 @@ fn parse_paragraph_cond(
                 jc: lvl_jc,
                 font_family: marker_ascii,
                 font_family_east_asia: marker_ea,
+                color: marker_color,
+                color_auto: marker_color_auto,
                 pic_bullet_image_path,
                 pic_bullet_mime_type,
                 pic_bullet_width_pt,
@@ -2557,6 +2580,13 @@ fn parse_paragraph_cond(
             .or_else(|| theme.resolve_font_ref(mark_run.font_family_east_asia.clone())),
         default_font_family_east_asia: theme
             .resolve_font_ref(mark_run.font_family_east_asia.clone()),
+        // §17.3.1.29 — the mark's resolved color from the SAME `mark_run`
+        // chain as `default_font_size` (direct pPr/rPr → pStyle chain →
+        // docDefaults; an explicit auto already collapsed to None). Word
+        // layers the numbering level rPr (§17.9.24) over these mark run
+        // properties, so this is the marker-color fallback when the level
+        // rPr names no color.
+        paragraph_mark_color: mark_run.color.clone(),
         outline_level: base_para.outline_level,
         // ECMA-376 §17.3.1.6 — RTL paragraph flag resolved through the style
         // chain + direct pPr. The renderer reads it as the paragraph base
@@ -5733,7 +5763,18 @@ fn extract_simple_paragraph_text(
         }
         let num_level = direct_ind.num_level.or(style_para.num_level).unwrap_or(0);
         let first_fmt = first_run_fmt.clone().unwrap_or_default();
-        let (format, ind_left, tab, suff, lvl_jc, marker_ascii, marker_ea, pic_bullet) = num_map
+        let (
+            format,
+            ind_left,
+            tab,
+            suff,
+            lvl_jc,
+            marker_ascii,
+            marker_ea,
+            marker_color,
+            marker_color_auto,
+            pic_bullet,
+        ) = num_map
             .get_level(num_id, num_level)
             .map(|l| {
                 let mut marker_fmt = first_fmt.clone();
@@ -5746,6 +5787,8 @@ fn extract_simple_paragraph_text(
                     l.lvl_jc.clone(),
                     theme.resolve_font_ref(marker_fmt.font_family_ascii.clone()),
                     theme.resolve_font_ref(marker_fmt.font_family_east_asia.clone()),
+                    l.rpr.color.clone(),
+                    l.rpr.color_auto,
                     l.pic_bullet.clone(),
                 )
             })
@@ -5758,6 +5801,8 @@ fn extract_simple_paragraph_text(
                     "left".to_string(),
                     theme.resolve_font_ref(first_fmt.font_family_ascii.clone()),
                     theme.resolve_font_ref(first_fmt.font_family_east_asia.clone()),
+                    None,
+                    false,
                     None,
                 )
             });
@@ -5788,6 +5833,8 @@ fn extract_simple_paragraph_text(
             jc: lvl_jc,
             font_family: marker_ascii,
             font_family_east_asia: marker_ea,
+            color: marker_color,
+            color_auto: marker_color_auto,
             pic_bullet_image_path,
             pic_bullet_mime_type,
             pic_bullet_width_pt,
@@ -16276,6 +16323,226 @@ mod numbering_marker_font_tests {
         assert_eq!(bottom.color.as_deref(), Some("ff0000"));
         // The cell left no insideH inline ⇒ it comes from the firstRow condition (nil).
         assert_eq!(b.inside_h.as_ref().map(|x| x.style.as_str()), Some("nil"));
+    }
+}
+
+#[cfg(test)]
+mod numbering_marker_color_tests {
+    //! ECMA-376 §17.9.24 (Numbering Symbol Run Properties) + §17.3.1.29 (Run
+    //! Properties for the Paragraph Mark). Word formats a numbering marker with
+    //! the level's rPr layered over the PARAGRAPH MARK's run properties — the
+    //! mark's `<w:color>` tints the bullet/number when the level rPr names no
+    //! color (observed Word output; the level rPr itself "affects only the
+    //! numbering text itself, not the remainder of runs in the numbered
+    //! paragraph", §17.9.24). The parser therefore surfaces BOTH sources:
+    //! `NumberingInfo::color` (level rPr) and
+    //! `DocParagraph::paragraph_mark_color` (mark rPr, style-chain resolved).
+    use super::*;
+
+    const NS: &str = " xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"";
+
+    /// numbering.xml with one bullet level whose rPr is `lvl_rpr` (may be "").
+    fn numbering_xml(lvl_rpr: &str) -> String {
+        format!(
+            r#"<w:numbering{NS}>
+              <w:abstractNum w:abstractNumId="0">
+                <w:lvl w:ilvl="0">
+                  <w:start w:val="1"/>
+                  <w:numFmt w:val="bullet"/>
+                  <w:lvlText w:val="•"/>
+                  {lvl_rpr}
+                </w:lvl>
+              </w:abstractNum>
+              <w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>
+            </w:numbering>"#
+        )
+    }
+
+    /// Parse one numbered paragraph against `numbering_xml(lvl_rpr)` and
+    /// `styles_xml`. `ppr_head` sits BEFORE `<w:numPr>` (a `<w:pStyle>`) and
+    /// `ppr_tail` AFTER it (the mark `<w:rPr>`), honoring the CT_PPr sequence
+    /// (pStyle < numPr < rPr).
+    fn bullet_para(
+        lvl_rpr: &str,
+        ppr_head: &str,
+        ppr_tail: &str,
+        styles_xml: &str,
+    ) -> DocParagraph {
+        let body_xml = format!(
+            r#"<w:document{NS}><w:body>
+              <w:p>
+                <w:pPr>
+                  {ppr_head}
+                  <w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>
+                  {ppr_tail}
+                </w:pPr>
+                <w:r><w:t>item</w:t></w:r>
+              </w:p>
+            </w:body></w:document>"#
+        );
+        let doc = roxmltree::Document::parse(&body_xml).unwrap();
+        let body = doc
+            .root_element()
+            .descendants()
+            .find(|n| n.tag_name().name() == "body")
+            .unwrap();
+        let style_map = StyleMap::parse(styles_xml);
+        let mut num_map = NumberingMap::parse(&numbering_xml(lvl_rpr), &HashMap::new());
+        parse_body_elements(
+            body,
+            &style_map,
+            &mut num_map,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .into_iter()
+        .find_map(|e| match e {
+            BodyElement::Paragraph(p) => Some(p),
+            _ => None,
+        })
+        .expect("bullet paragraph present")
+    }
+
+    /// §17.9.24 — a concrete `<w:color>` in the level rPr surfaces on
+    /// `NumberingInfo::color` (hex 6, lowercased like run colors).
+    #[test]
+    fn lvl_rpr_color_surfaces_on_numbering_info() {
+        let p = bullet_para(r#"<w:rPr><w:color w:val="FF0000"/></w:rPr>"#, "", "", "");
+        let num = p.numbering.as_ref().expect("numbered paragraph");
+        assert_eq!(num.color.as_deref(), Some("ff0000"));
+        // No mark rPr anywhere ⇒ no paragraph-mark color.
+        assert_eq!(p.paragraph_mark_color, None);
+    }
+
+    /// §17.9.24 + ST_HexColorAuto (§17.18.39) — `val="auto"` names no concrete
+    /// color (`color` stays `None`) but is NOT "unset": it surfaces as
+    /// `color_auto` so the renderer can break the paragraph-mark fallback
+    /// (§17.3.2.6 — an explicit auto overrides an inherited concrete color).
+    /// An absent `<w:color>` is `None` WITHOUT `color_auto` (pure fallback).
+    #[test]
+    fn lvl_rpr_color_auto_and_absent_are_distinct() {
+        let auto = bullet_para(
+            r#"<w:rPr><w:color w:val="auto"/></w:rPr>"#,
+            "",
+            r#"<w:rPr><w:color w:val="FF0000"/></w:rPr>"#,
+            "",
+        );
+        let num = auto.numbering.as_ref().unwrap();
+        assert_eq!(num.color, None);
+        assert!(num.color_auto, "explicit auto must surface");
+        // The mark color still surfaces — suppressing it is the renderer's job.
+        assert_eq!(auto.paragraph_mark_color.as_deref(), Some("ff0000"));
+
+        let absent = bullet_para("", "", "", "");
+        let num = absent.numbering.as_ref().unwrap();
+        assert_eq!(num.color, None);
+        assert!(!num.color_auto, "absent w:color is not auto");
+    }
+
+    /// §17.3.1.29 — the paragraph mark's DIRECT `pPr/rPr` color surfaces as
+    /// `paragraph_mark_color` (the acceptance shape: mark rPr FF0000, level rPr
+    /// without color ⇒ Word draws the bullet red). The content run's own color
+    /// must NOT leak into either field (§17.9.24: marker formatting is separate
+    /// from the paragraph's runs).
+    #[test]
+    fn paragraph_mark_direct_color_surfaces() {
+        let body_xml = format!(
+            r#"<w:document{NS}><w:body>
+              <w:p>
+                <w:pPr>
+                  <w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>
+                  <w:rPr><w:color w:val="FF0000"/></w:rPr>
+                </w:pPr>
+                <w:r><w:rPr><w:color w:val="00B050"/></w:rPr><w:t>item</w:t></w:r>
+              </w:p>
+            </w:body></w:document>"#
+        );
+        let doc = roxmltree::Document::parse(&body_xml).unwrap();
+        let body = doc
+            .root_element()
+            .descendants()
+            .find(|n| n.tag_name().name() == "body")
+            .unwrap();
+        let style_map = StyleMap::parse("");
+        let mut num_map = NumberingMap::parse(&numbering_xml(""), &HashMap::new());
+        let p = parse_body_elements(
+            body,
+            &style_map,
+            &mut num_map,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .into_iter()
+        .find_map(|e| match e {
+            BodyElement::Paragraph(p) => Some(p),
+            _ => None,
+        })
+        .unwrap();
+        assert_eq!(p.paragraph_mark_color.as_deref(), Some("ff0000"));
+        // Level rPr has no color ⇒ the lvl field stays None (the renderer falls
+        // back to the mark color).
+        assert_eq!(p.numbering.as_ref().unwrap().color, None);
+    }
+
+    /// Both sources present: each field carries its own value — precedence
+    /// (lvl over mark) is the renderer's job.
+    #[test]
+    fn lvl_and_mark_colors_surface_independently() {
+        let p = bullet_para(
+            r#"<w:rPr><w:color w:val="00B050"/></w:rPr>"#,
+            "",
+            r#"<w:rPr><w:color w:val="FF0000"/></w:rPr>"#,
+            "",
+        );
+        assert_eq!(
+            p.numbering.as_ref().unwrap().color.as_deref(),
+            Some("00b050")
+        );
+        assert_eq!(p.paragraph_mark_color.as_deref(), Some("ff0000"));
+    }
+
+    /// §17.3.1.29 resolves through the SAME style chain as the mark's other run
+    /// properties (`default_font_size` et al.): a pStyle rPr color reaches
+    /// `paragraph_mark_color` without any direct pPr/rPr.
+    #[test]
+    fn paragraph_mark_color_resolves_through_style_chain() {
+        let styles = format!(
+            r#"<w:styles{NS}>
+              <w:style w:type="paragraph" w:styleId="RedList">
+                <w:name w:val="Red List"/>
+                <w:rPr><w:color w:val="C00000"/></w:rPr>
+              </w:style>
+            </w:styles>"#
+        );
+        let p = bullet_para("", r#"<w:pStyle w:val="RedList"/>"#, "", &styles);
+        assert_eq!(p.paragraph_mark_color.as_deref(), Some("c00000"));
+    }
+
+    /// An explicit `<w:color w:val="auto"/>` on the mark rPr breaks a style
+    /// chain color (§17.3.2.6): the mark color surfaces as None.
+    #[test]
+    fn paragraph_mark_color_auto_breaks_style_color() {
+        let styles = format!(
+            r#"<w:styles{NS}>
+              <w:style w:type="paragraph" w:styleId="RedList">
+                <w:name w:val="Red List"/>
+                <w:rPr><w:color w:val="C00000"/></w:rPr>
+              </w:style>
+            </w:styles>"#
+        );
+        let p = bullet_para(
+            "",
+            r#"<w:pStyle w:val="RedList"/>"#,
+            r#"<w:rPr><w:color w:val="auto"/></w:rPr>"#,
+            &styles,
+        );
+        assert_eq!(p.paragraph_mark_color, None);
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -622,6 +622,16 @@ pub struct DocParagraph {
     /// the ASCII fallback.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_font_family_east_asia: Option<String>,
+    /// ECMA-376 §17.3.1.29 — the paragraph MARK run's resolved `<w:color>`
+    /// (direct `pPr/rPr` → pStyle chain → docDefaults, the same `mark_run`
+    /// resolution that feeds `default_font_size`; hex 6 lowercased; an
+    /// explicit `auto` breaks the chain and surfaces as `None`, §17.3.2.6).
+    /// Word formats a numbering marker with the level rPr (§17.9.24) layered
+    /// over the mark's run properties, so a mark-colored list item tints its
+    /// bullet/number even when the level rPr carries no color — the renderer
+    /// reads this as the marker-color fallback after `NumberingInfo::color`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub paragraph_mark_color: Option<String>,
     /// ECMA-376 §17.3.1.20 `<w:outlineLvl w:val="N">` (0–8). Resolved through
     /// the style chain: explicit pPr → linked paragraph style → docDefaults.
     /// `None` for body paragraphs that don't appear in the document outline.
@@ -809,6 +819,23 @@ pub struct NumberingInfo {
     /// bullet) with this family. `None` ⇒ renderer falls back to `font_family`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub font_family_east_asia: Option<String>,
+    /// ECMA-376 §17.9.24 — the numbering level rPr's `<w:color w:val>` (hex 6,
+    /// lowercased like run colors). Colors the marker glyph only, never the
+    /// paragraph's runs. `None` (absent `<w:color>`) lets the renderer fall
+    /// back to the paragraph MARK's resolved color
+    /// (`DocParagraph::paragraph_mark_color`, §17.3.1.29 — Word layers the
+    /// level rPr over the mark's run properties), and finally to its default
+    /// ink. An explicit `val="auto"` is `None` + `color_auto` below.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    /// ECMA-376 §17.3.2.6 / ST_HexColorAuto (§17.18.39) — true when the level
+    /// rPr carries an EXPLICIT `<w:color w:val="auto"/>`. Auto names no
+    /// concrete color but is NOT "unset": layered over the paragraph mark
+    /// (§17.9.24 over §17.3.1.29) it breaks an inherited concrete mark color,
+    /// so the renderer must NOT fall back to `paragraph_mark_color` and draws
+    /// the automatic (default) ink instead.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub color_auto: bool,
     /// ECMA-376 §17.9.9/§17.9.20 — when the level uses a `<w:lvlPicBulletId>`,
     /// the marker is this image (zip path, e.g. `word/media/image1.gif`) drawn in
     /// place of `text`. `None` ⇒ ordinary text/glyph marker.

--- a/packages/docx/src/numbering-marker-color.test.ts
+++ b/packages/docx/src/numbering-marker-color.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas, renderShapeText } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+  NumberingInfo,
+  ShapeRun,
+  ShapeText,
+} from './types';
+
+// ECMA-376 §17.9.24 (Numbering Symbol Run Properties) + §17.3.1.29 (Run
+// Properties for the Paragraph Mark). Word draws a list marker with the level
+// rPr layered over the PARAGRAPH MARK's run properties: a concrete lvl-rPr
+// color wins, else the mark's resolved color tints the bullet/number, else the
+// default ink. Before the fix the renderer hardcoded `defaultColor`, so every
+// marker drew black even when Word draws it red (mark rPr FF0000, lvl rPr
+// without color). The body runs' own color never reaches the marker
+// (§17.9.24: the level rPr "affects only the numbering text itself").
+
+/** Recording 2D context. Records each fillText WITH the active fillStyle so
+ *  the numbering marker's ink (drawn via fillText, not reported through
+ *  onTextRun) can be inspected. Glyph advance = charCount × fontPx. */
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fillTextCalls: { text: string; fillStyle: string }[];
+} {
+  let font = '16px serif';
+  let fillStyle: string | object = '#000';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '16');
+  const fillTextCalls: { text: string; fillStyle: string }[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string | object) { fillStyle = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText(text: string) { fillTextCalls.push({ text, fillStyle: String(fillStyle) }); },
+    strokeText() {},
+    strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fillTextCalls };
+}
+
+function run(text: string, color: string | null = null): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 16, color, fontFamily: null,
+    isLink: false, background: null, vertAlign: null, hyperlink: null,
+  } as unknown as DocxTextRun;
+}
+
+function numbering(color?: string, colorAuto?: boolean): NumberingInfo {
+  // suff:'space' so the marker draws without a tab-stop dependency.
+  return {
+    numId: 1, level: 0, format: 'bullet', text: '•',
+    indentLeft: 36, tab: 18, suff: 'space',
+    ...(color ? { color } : {}),
+    ...(colorAuto ? { colorAuto } : {}),
+  };
+}
+
+function doc(p: Partial<DocParagraph>, section: Partial<SectionProps> = {}): DocxDocumentModel {
+  const para: DocParagraph = {
+    alignment: 'left',
+    indentLeft: 36, indentRight: 0, indentFirst: -18,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{ type: 'text', ...run('item') } as DocParagraph['runs'][number]],
+    defaultFontSize: 16,
+    widowControl: false,
+    ...p,
+  };
+  return {
+    section: {
+      pageWidth: 400, pageHeight: 400,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+      ...section,
+    } as SectionProps,
+    body: [{ type: 'paragraph', ...para } as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+async function markerFill(
+  p: Partial<DocParagraph>,
+  section: Partial<SectionProps> = {},
+): Promise<string | undefined> {
+  const { canvas, fillTextCalls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc(p, section), canvas, 0, { dpr: 1, width: 400 });
+  return fillTextCalls.find((c) => c.text === '•')?.fillStyle;
+}
+
+describe('numbering marker color (§17.9.24 / §17.3.1.29)', () => {
+  it('draws the marker with the level rPr color when present', async () => {
+    expect(await markerFill({ numbering: numbering('ff0000') })).toBe('#ff0000');
+  });
+
+  it('falls back to the paragraph MARK color when the level rPr has none', async () => {
+    // The acceptance shape: mark rPr FF0000, lvl rPr without color — Word
+    // draws the bullet red.
+    expect(
+      await markerFill({ numbering: numbering(), paragraphMarkColor: 'ff0000' }),
+    ).toBe('#ff0000');
+  });
+
+  it('level rPr color wins over the paragraph mark color', async () => {
+    expect(
+      await markerFill({ numbering: numbering('00b050'), paragraphMarkColor: 'ff0000' }),
+    ).toBe('#00b050');
+  });
+
+  it('keeps the default ink when neither source names a color', async () => {
+    expect(await markerFill({ numbering: numbering() })).toBe('#000000');
+  });
+
+  it('never tints the marker from a body run color (§17.9.24 separation)', async () => {
+    const fill = await markerFill({
+      numbering: numbering(),
+      runs: [{ type: 'text', ...run('item', '00b050') } as DocParagraph['runs'][number]],
+    });
+    expect(fill).toBe('#000000');
+  });
+
+  it('applies the mark color to an RTL marker too (same fill path)', async () => {
+    // The RTL branch shares the fillStyle set before the LTR/RTL split — the
+    // acceptance document is an RTL (Arabic) list with a red paragraph mark.
+    expect(
+      await markerFill({
+        numbering: numbering(),
+        paragraphMarkColor: 'ff0000',
+        bidi: true,
+      }),
+    ).toBe('#ff0000');
+  });
+
+  it('does not repaint following body text with the marker color', async () => {
+    const { canvas, fillTextCalls } = makeRecordingCanvas();
+    await renderDocumentToCanvas(
+      doc({ numbering: numbering(), paragraphMarkColor: 'ff0000' }),
+      canvas, 0, { dpr: 1, width: 400 },
+    );
+    const body = fillTextCalls.find((c) => c.text.includes('item'));
+    expect(body).toBeDefined();
+    expect(body!.fillStyle).toBe('#000000');
+  });
+
+  it('explicit level w:color="auto" breaks the mark fallback (§17.3.2.6)', async () => {
+    // Auto names the AUTOMATIC color, it is not "unset": a red paragraph mark
+    // must NOT tint the marker through the fallback; the default ink wins.
+    expect(
+      await markerFill({
+        numbering: numbering(undefined, true),
+        paragraphMarkColor: 'ff0000',
+      }),
+    ).toBe('#000000');
+  });
+
+  it('applies the mark color on the vertical (tbRl) marker path too', async () => {
+    // §17.6.20 rotate-layout: the marker goes through drawVerticalRun, which
+    // inherits the fillStyle set before the LTR/RTL/vertical split.
+    expect(
+      await markerFill(
+        { numbering: numbering(), paragraphMarkColor: 'ff0000' },
+        { textDirection: 'tbRl' } as Partial<SectionProps>,
+      ),
+    ).toBe('#ff0000');
+  });
+});
+
+describe('text-box marker color (§17.9.24)', () => {
+  function shapeWith(blocks: ShapeText[]): ShapeRun {
+    return {
+      type: 'shape',
+      presetGeometry: 'rect', wrapMode: 'none', textAnchor: 't',
+      textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+      textBlocks: blocks,
+    } as unknown as ShapeRun;
+  }
+
+  function bulletBlock(extra: Partial<ShapeText>): ShapeText {
+    return {
+      text: 'item', fontSizePt: 10, alignment: 'left',
+      runs: [{ text: 'item', fontSizePt: 10 }],
+      numbering: { numId: 1, level: 0, format: 'bullet', text: '•', indentLeft: 18, tab: 9, suff: 'space' },
+      ...extra,
+    } as unknown as ShapeText;
+  }
+
+  function textboxMarkerFill(extra: Partial<ShapeText>): string | undefined {
+    const { canvas, fillTextCalls } = makeRecordingCanvas();
+    const ctx = (canvas as unknown as { getContext(): CanvasRenderingContext2D }).getContext();
+    renderShapeText(shapeWith([bulletBlock(extra)]), 0, 0, 200, 200, ctx, 1, {});
+    return fillTextCalls.find((c) => c.text === '•')?.fillStyle;
+  }
+
+  it('level rPr color wins over the block color', () => {
+    const fill = textboxMarkerFill({
+      color: '00b050',
+      numbering: { numId: 1, level: 0, format: 'bullet', text: '•', indentLeft: 18, tab: 9, suff: 'space', color: 'ff0000' },
+    });
+    expect(fill).toBe('#ff0000');
+  });
+
+  it('keeps the pre-existing block-color fallback when the level has no color', () => {
+    expect(textboxMarkerFill({ color: '00b050' })).toBe('#00b050');
+  });
+
+  it('explicit level auto stops at the default ink, not the block color', () => {
+    const fill = textboxMarkerFill({
+      color: '00b050',
+      numbering: { numId: 1, level: 0, format: 'bullet', text: '•', indentLeft: 18, tab: 9, suff: 'space', colorAuto: true },
+    });
+    expect(fill).toBe('#000000');
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7809,7 +7809,18 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
         // eastAsia axis for a CJK marker. Replaces the old hardcoded sans-serif,
         // which forced every number/bullet sans regardless of the heading's font.
         ctx.font = buildFont(false, false, numFontSize, markerFontFamily(para.numbering!), fontFamilyClasses);
-        ctx.fillStyle = defaultColor;
+        // Marker ink (§17.9.24 + §17.3.1.29): the level rPr's own color wins;
+        // absent that, Word layers the level rPr over the PARAGRAPH MARK's run
+        // properties, so the mark's resolved color tints the bullet/number;
+        // else the default ink. An EXPLICIT `w:color w:val="auto"` on the
+        // level (colorAuto, §17.3.2.6) breaks that mark fallback — auto is a
+        // named automatic color, not "unset" — and lands on the default ink.
+        // Body-run colors never reach the marker (§17.9.24: the level rPr
+        // "affects only the numbering text itself, not the remainder of runs
+        // in the numbered paragraph").
+        const markerColor = para.numbering!.color
+          ?? (para.numbering!.colorAuto ? null : para.paragraphMarkColor);
+        ctx.fillStyle = markerColor ? `#${markerColor}` : defaultColor;
         if (baseRtl) {
           // The RTL list marker is laid out INLINE at the line's start (right)
           // edge: its right edge sits numTab (w:hanging) to the right of the
@@ -7842,6 +7853,10 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             ctx.fillText(markerText, markerX, baseline);
           }
         }
+        // Restore the default ink: everything after the marker previously ran
+        // with fillStyle === defaultColor, and fills that don't set their own
+        // style must keep seeing it.
+        ctx.fillStyle = defaultColor;
       }
     }
 
@@ -10042,7 +10057,15 @@ export function renderShapeText(
         if (isFirstLine && block.numbering) {
           const markerSize = block.fontSizePt * scale;
           ctx.font = buildFont(false, false, markerSize, markerFontFamily(block.numbering), fontFamilyClasses);
-          const markerColor = block.color ?? block.runs?.find((r) => r.color)?.color ?? null;
+          // §17.9.24 — a color on the numbering level rPr wins for the marker
+          // glyph (same precedence as the body path), and an explicit
+          // level `auto` (§17.3.2.6) stops at the default ink; the block/run
+          // colors remain the textbox fallback (the textbox model carries no
+          // paragraph-mark color — a known, narrower approximation).
+          const markerColor = block.numbering.color
+            ?? (block.numbering.colorAuto
+              ? null
+              : block.color ?? block.runs?.find((r) => r.color)?.color ?? null);
           ctx.fillStyle = markerColor ? `#${markerColor}` : defaultColor;
           const markerText = markerDisplayText(block.numbering);
           const markerW = ctx.measureText(markerText).width;

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -580,6 +580,13 @@ export interface DocParagraph {
    *  anchor-only paragraph marks in East Asian documents use this axis for line
    *  metrics instead of the ASCII fallback. */
   defaultFontFamilyEastAsia?: string | null;
+  /** ECMA-376 §17.3.1.29 — the paragraph MARK run's resolved `w:color` (direct
+   *  pPr/rPr → pStyle chain → docDefaults; hex 6 without `#`, lowercased; an
+   *  explicit `auto` surfaces as absent, §17.3.2.6). Word formats a numbering
+   *  marker with the level rPr (§17.9.24) layered over the mark's run
+   *  properties, so the renderer uses this as the marker-color fallback when
+   *  {@link NumberingInfo.color} is absent. */
+  paragraphMarkColor?: string | null;
   /**
    * ECMA-376 §17.3.1.6 `<w:bidi>` — right-to-left paragraph. `true` = RTL,
    * `false` = explicitly LTR, absent = unspecified (inherit). The renderer uses
@@ -719,6 +726,19 @@ export interface NumberingInfo {
    *  this family. Absent ⇒ the renderer falls back to
    *  {@link NumberingInfo.fontFamily}. */
   fontFamilyEastAsia?: string | null;
+  /** ECMA-376 §17.9.24 — the numbering level rPr's `w:color` (hex 6 without
+   *  `#`, lowercased). Colors the marker glyph only, never the paragraph's
+   *  runs. Absent ⇒ the renderer falls back to
+   *  {@link DocParagraph.paragraphMarkColor} (§17.3.1.29 — Word layers the
+   *  level rPr over the paragraph mark's run properties) and finally to its
+   *  default ink. An explicit `w:val="auto"` is absent here + {@link colorAuto}. */
+  color?: string | null;
+  /** ECMA-376 §17.3.2.6 / ST_HexColorAuto (§17.18.39) — true when the level
+   *  rPr carries an EXPLICIT `w:color w:val="auto"`. Auto names no concrete
+   *  color but is not "unset": it breaks the paragraph-mark fallback, so the
+   *  marker draws the automatic (default) ink instead of
+   *  {@link DocParagraph.paragraphMarkColor}. */
+  colorAuto?: boolean;
   /** ECMA-376 §17.9.9/§17.9.20 — when the level uses a `<w:lvlPicBulletId>`,
    *  the marker is this image (zip path, e.g. `word/media/image1.gif`), drawn in
    *  place of {@link NumberingInfo.text}. Absent ⇒ ordinary text/glyph marker. */


### PR DESCRIPTION
## Problem

docx numbering/bullet markers were always drawn with the default (black) ink: the renderer hardcoded `fillStyle = defaultColor`, the parser never surfaced any marker color, and `NumberingInfo` had no color field.

Word consults two sources for the marker's formatting: the numbering level's rPr (ECMA-376 §17.9.24 — applied to the numbering text only, independent of the paragraph's runs) layered over the **paragraph mark's run properties** (§17.3.1.29, style-chain resolved). A document whose list paragraphs carry a red mark rPr with no color on the level rPr renders red bullets in Word — we drew them black.

## Fix

**Parser (Rust)**
- `NumberingInfo.color` — the level rPr's `w:color` (hex 6 lowercased, same convention as run colors).
- `NumberingInfo.colorAuto` — an explicit `w:val="auto"` (§17.3.2.6 / ST_HexColorAuto §17.18.39). Auto names the *automatic* color; layered over the mark it must break an inherited concrete mark color rather than read as "unset".
- `DocParagraph.paragraphMarkColor` — the mark run's resolved color from the same `mark_run` chain (direct `pPr/rPr` → pStyle chain → docDefaults) that already feeds `defaultFontSize`/`defaultFontFamily`.

**Renderer (TS)**
- Body marker ink: `level color → paragraph mark color → default ink`; explicit level auto stops at the default ink. The fill is restored to the default afterwards, so all following draws are unchanged.
- Text-box marker path now honors a level color / explicit auto ahead of its pre-existing block/run-color fallback. (The text-box model carries no paragraph-mark color; that narrower fallback is unchanged and documented in-code.)
- Marker size/font axes and picture bullets are untouched; body-run colors still never reach the body marker (§17.9.24 separation).

## Cross-package check

- **pptx**: `<a:buClr>` on character bullets and the buClrTx-style run-color inheritance default (§21.1.2.4.4 / §21.1.2.4.10) are already implemented. Found one gap: an explicit `buClr` next to `<a:buAutoNum>` is dropped at parse (`Bullet::AutoNum` has no color field) — filed as a follow-up task for the pptx-scoped session.
- **xlsx**: SpreadsheetML cell rich text has no bullet/numbering mechanism (§18 defines none); nothing to do.

## Verification

- TDD: new Rust parser tests (level color / auto-vs-absent distinction / mark direct + style-chain resolution / content-run color non-leak) and TS renderer tests (precedence table incl. RTL, vertical tbRl, text-box precedence, fill restore, body non-repaint) — all failing on the previous behavior, green now.
- Pixel probe on a private RTL (Arabic) fixture: the two page-1 bullets now render exactly (255,0,0), matching the Word PDF ground truth (previously (0,0,0)); no previously-red pixel changed.
- docx VRT: demo suite non-regressed (references untouched). The only private-baseline delta from this change is the expected 26 px marker recolor on that fixture's first page (within threshold). Pre-existing private baseline mismatches on one other fixture were confirmed unrelated: its pages render byte-identical (0 px diff) between this branch and main.
- `cargo fmt --check` / `clippy -D warnings` / `cargo test`, WASM rebuilt via the package script, full docx vitest (1232), root `pnpm typecheck` — all green.
- Reviewed by Codex (gpt-5.6-sol); the explicit-auto cascade finding and test-coverage gaps from that review are addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)