### PR TITLE
fix(pptx): color auto-number markers from an explicit buClr

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -245,7 +245,7 @@ export type Bullet =
   | { type: 'none' }
   | { type: 'inherit' }
   | { type: 'char'; char: string; color: string | null; sizePct: number | null; fontFamily: string | null }
-  | { type: 'autoNum'; numType: string; startAt: number | null };
+  | { type: 'autoNum'; numType: string; startAt: number | null; color: string | null };
 
 export interface TabStop {
   /** Position in EMU from the LEADING text-inset edge of the text area —

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -2531,6 +2531,51 @@ mod tests {
         ));
     }
 
+    /// §21.1.2.4.4 (buClr) — an explicit `<a:buClr>` sibling of `<a:buAutoNum>`
+    /// colours the auto-number marker, exactly as it does a `<a:buChar>` bullet
+    /// (§21.1.2.4.10 buClrTx is the default only when no buClr is present). The
+    /// child order follows CT_TextParagraphProperties' xsd:sequence: buClr →
+    /// buSzPct → buFont → buAutoNum. Regression: the buAutoNum branch used to drop
+    /// the sibling buClr, forcing the marker onto the inherited first-run colour.
+    #[test]
+    fn test_parse_bullet_autonum_reads_buclr() {
+        let xml = r#"<a:pPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+            <a:buClr><a:srgbClr val="C00000"/></a:buClr>
+            <a:buSzPct val="100000"/>
+            <a:buFont typeface="+mj-lt"/>
+            <a:buAutoNum type="arabicPeriod"/>
+        </a:pPr>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let theme = HashMap::new();
+        let mut resolve = |_: &str| -> Option<String> { None };
+        let bullet = parse_bullet(Some(doc.root_element()), &theme, &mut resolve);
+        let v = serde_json::to_value(&bullet).unwrap();
+        assert_eq!(v["type"], "autoNum");
+        assert_eq!(v["numType"], "arabicPeriod");
+        // The buClr resolves to the srgbClr literal (uppercase hex, no '#').
+        assert_eq!(v["color"], "C00000");
+    }
+
+    /// §21.1.2.4.10 (buClrTx) — with no explicit `<a:buClr>` the auto-number
+    /// marker carries no own colour (`None`), so the renderer falls back to the
+    /// default (the first run's colour). The `color` field must be absent/null,
+    /// not silently defaulted to some literal.
+    #[test]
+    fn test_parse_bullet_autonum_without_buclr_has_no_color() {
+        let xml = r#"<a:pPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+            <a:buAutoNum type="arabicPeriod"/>
+        </a:pPr>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let theme = HashMap::new();
+        let mut resolve = |_: &str| -> Option<String> { None };
+        let bullet = parse_bullet(Some(doc.root_element()), &theme, &mut resolve);
+        let v = serde_json::to_value(&bullet).unwrap();
+        assert_eq!(v["type"], "autoNum");
+        assert_eq!(v["color"], serde_json::Value::Null);
+    }
+
     /// §19.7.10 / §21.1.2.4.2 — a picture bullet declared on a master/list-style
     /// `<a:lvlNpPr>` is captured per level by `read_level_bullets`, so a slide
     /// paragraph at that level inherits the image marker.

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -919,7 +919,14 @@ pub(crate) fn parse_bullet<F: FnMut(&str) -> Option<String>>(
     if let Some(bu_auto) = child(p_pr, "buAutoNum") {
         let num_type = attr(&bu_auto, "type").unwrap_or_else(|| "arabicPeriod".into());
         let start_at = attr(&bu_auto, "startAt").and_then(|v| v.parse().ok());
-        return Bullet::AutoNum { num_type, start_at };
+        // §21.1.2.4.4 — a sibling `<a:buClr>` colours the auto-number marker,
+        // exactly as it does a `<a:buChar>` bullet above.
+        let color = child(p_pr, "buClr").and_then(|n| parse_color_node(n, theme));
+        return Bullet::AutoNum {
+            num_type,
+            start_at,
+            color,
+        };
     }
 
     Bullet::Inherit

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -903,6 +903,11 @@ pub(crate) enum Bullet {
     AutoNum {
         num_type: String,
         start_at: Option<u32>,
+        /// `<a:buClr>` (ECMA-376 §21.1.2.4.4) — the marker colour. `None` means
+        /// no explicit buClr, so the renderer falls back to the buClrTx default
+        /// (§21.1.2.4.10 — the first run's colour). Always serialized (like the
+        /// `Char` variant's `color`) so the TS side sees a stable `color` key.
+        color: Option<String>,
     },
     /// Picture bullet (buBlip) — ECMA-376 §21.1.2.4.2 `<a:buBlip><a:blip
     /// r:embed="rIdN"/></a:buBlip>`. The `r:embed` is resolved to the blip's

--- a/packages/pptx/src/autonum-bullet-color.test.ts
+++ b/packages/pptx/src/autonum-bullet-color.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody } from './renderer.js';
+import type { TextBody, Paragraph, Bullet } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+// ECMA-376 §21.1.2.4.4 (buClr) — an explicit `<a:buClr>` sibling of
+// `<a:buAutoNum>` colours the AUTO-NUMBER marker, just as it does a `<a:buChar>`
+// bullet. §21.1.2.4.10 (buClrTx) only supplies the default (the first run's
+// colour) when NO buClr is present. Regression: the auto-number marker always
+// used the inherited first-run colour, dropping the explicit buClr. This mirrors
+// the char-bullet colour path (renderer.ts `bullet.type === 'char'`).
+//
+// The mock ctx records the `fillStyle` active at each fillText so the marker's
+// colour is recoverable independently of the run colours.
+
+const FONT_PX = 20;
+const SCALE = 1 / 12700; // emuToPx(emu) = emu·SCALE; 12700 EMU = 1 pt → 1 px
+
+interface Fill { text: string; fillStyle: string }
+
+function mockCtx(): { ctx: CanvasRenderingContext2D; fills: Fill[] } {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  let fillStyle = '';
+  let direction: CanvasDirection = 'ltr';
+  const px = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const fills: Fill[] = [];
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
+    get direction() { return direction; }, set direction(v: CanvasDirection) { direction = v; },
+    get letterSpacing() { return letterSpacing; }, set letterSpacing(v: string) { letterSpacing = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    fillText: (t: string) => fills.push({ text: t, fillStyle }),
+    strokeText: () => {}, fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
+    translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
+    moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
+    setLineDash: () => {}, closePath: () => {}, arc: () => {},
+    strokeStyle: '#000', lineWidth: 1, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fills };
+}
+
+function run(text: string, color: string): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: FONT_PX, color, fontFamily: 'Serif',
+  } as TextRunData;
+}
+
+// marL / indent = a hanging gutter so the auto-number marker draws in its gutter.
+const MARK_EMU = 342900; // 27 px at this SCALE
+
+function body(bullet: Bullet, runColor: string): TextBody {
+  const para: Paragraph = {
+    alignment: 'l',
+    marL: MARK_EMU, marR: 0, indent: -MARK_EMU,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet, defFontSize: null, defColor: null, defBold: null, defItalic: null,
+    defFontFamily: null, tabStops: [], rtl: false, runs: [run('item', runColor)],
+  } as unknown as Paragraph;
+  return {
+    verticalAnchor: 't', paragraphs: [para], defaultFontSize: FONT_PX,
+    defaultBold: null, defaultItalic: null,
+    lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'square', vert: 'horz', autoFit: 'none',
+  } as unknown as TextBody;
+}
+
+const BOX_W = 600;
+
+function render(b: TextBody): Fill[] {
+  const { ctx, fills } = mockCtx();
+  renderTextBody(
+    ctx, b, 0, 0, BOX_W, 400, SCALE,
+    null, 0, false, false, '#000000', undefined,
+    { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+    () => {},
+  );
+  return fills;
+}
+
+// The auto-number label is the only fill that contains a digit (e.g. "1.").
+function markerFill(fills: Fill[]): Fill | undefined {
+  return fills.find((f) => /\d/.test(f.text));
+}
+
+const autoNum = (color: string | null): Bullet =>
+  ({ type: 'autoNum', numType: 'arabicPeriod', startAt: null, color } as unknown as Bullet);
+
+describe('§21.1.2.4.4 auto-number marker honours an explicit buClr', () => {
+  it('uses the explicit buClr colour, not the inherited first-run colour', () => {
+    // buClr = red (C00000); first run = blue. The marker must be red.
+    const marker = markerFill(render(body(autoNum('C00000'), '0000FF')));
+    expect(marker, 'auto-number marker drawn').toBeTruthy();
+    expect(marker!.fillStyle).toBe('rgba(192,0,0,1)');
+  });
+
+  it('falls back to the first-run colour when no buClr is present (buClrTx)', () => {
+    // No buClr; first run = blue. The marker inherits the blue first-run colour.
+    const marker = markerFill(render(body(autoNum(null), '0000FF')));
+    expect(marker, 'auto-number marker drawn').toBeTruthy();
+    expect(marker!.fillStyle).toBe('rgba(0,0,255,1)');
+  });
+});

--- a/packages/pptx/src/empty-bullet.test.ts
+++ b/packages/pptx/src/empty-bullet.test.ts
@@ -36,7 +36,7 @@ const brk = (): TextRun => ({ type: 'break' });
 const math = (): TextRun => ({ type: 'math', nodes: [], display: false });
 
 const autoNum = (numType = 'arabicPeriod', startAt: number | null = null): Bullet =>
-  ({ type: 'autoNum', numType, startAt });
+  ({ type: 'autoNum', numType, startAt, color: null });
 const charBullet = (char = '•'): Bullet =>
   ({ type: 'char', char, color: null, sizePct: null, fontFamily: null });
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2925,7 +2925,11 @@ export function renderTextBody(
       bulletColor = b.color ? hexToRgba(b.color) : bulletInheritedColor;
     } else if (bullet.type === 'autoNum') {
       bulletFont  = buildFont(false, false, bulletBaseSizePx, 'sans-serif', rc);
-      bulletColor = bulletInheritedColor;
+      // ECMA-376 §21.1.2.4.4 (buClr): an explicit `<a:buClr>` colours the
+      // auto-number marker, mirroring the char-bullet branch above. Only when it
+      // is absent does the marker fall back to the buClrTx default
+      // (§21.1.2.4.10 — the inherited first-run colour).
+      bulletColor = bullet.color ? hexToRgba(bullet.color) : bulletInheritedColor;
     } else if (bullet.type === 'blip') {
       // ECMA-376 §21.1.2.4.2 picture bullet. The bitmap is drawn as a square
       // sized to the text (the bullet's em box), scaled by `<a:buSzPct>`


### PR DESCRIPTION
## Problem

An explicit `<a:buClr>` sibling of `<a:buAutoNum>` was silently dropped by the pptx parser, so **auto-number list markers ignored their explicit colour** and always fell back to the inherited first-run colour. ECMA-376 §21.1.2.4.4 (`buClr`) applies to auto-number bullets, not just character bullets — §21.1.2.4.10 (`buClrTx`) is the default *only* when no `buClr` is present. The `buChar` branch already read the sibling `buClr`; the `buAutoNum` branch read only `type`/`startAt`.

## Fix

Mirrors the char-bullet colour path end-to-end:

- **Parser** (`text.rs`): the `buAutoNum` branch now parses the sibling `<a:buClr>` with `parse_color_node`, exactly like `buChar`.
- **Type** (`types.rs`): `Bullet::AutoNum` gains `color: Option<String>`, serialized like the `Char` variant's `color` (always present; `null` when absent).
- **Core type** (`core/common.ts`): the shared `autoNum` `Bullet` union member gains `color: string | null`. docx/xlsx neither produce nor construct auto-number bullets, so they are unaffected.
- **Renderer** (`renderer.ts`): the `autoNum` branch applies `hexToRgba(bullet.color)` when present, else the inherited first-run colour (buClrTx default).

Mirrors the docx numbering marker color fix (#963).

## Tests (TDD Red → Green)

- **Parser** (`lib.rs`): `buAutoNum` + sibling `buClr` → `color` surfaces (`C00000`); no `buClr` → `color` is null. Synthetic XML follows the `CT_TextParagraphProperties` xsd:sequence (`buClr → buSzPct → buFont → buAutoNum`).
- **Renderer** (`autonum-bullet-color.test.ts`): the marker `fillStyle` is the explicit `buClr` colour, not the first-run colour; falls back to the first-run colour when no `buClr`.
- Verified failing on the pre-fix tree, passing after.

## Gates

- `cargo fmt --check`, `clippy -D warnings`, `cargo test` (165 pass)
- WASM rebuilt via the package script
- pptx vitest: 413 pass; root `pnpm typecheck` clean
- pptx VRT: demo slides non-regression (only pre-existing ~1-3% text noise; the change is pixel-neutral on demo slides, which carry no buClr-coloured numbered lists)

## Known follow-up (out of scope)

Bullet sub-properties (`buClr`/`buFont`/`buSzPct`) do not cascade **property-wise** across the master/layout/slide style tiers — `merge_level_bullets` merges at whole-`Bullet` granularity. A `buClr` on one tier + `buAutoNum` on another still loses the colour. This is a pre-existing limitation that affects char bullets identically; this PR brings auto-number to full parity with char. Tracked separately.