### PR TITLE
fix(docx): anchor RTL numbered hanging first line at the start indent

### DIFF
--- a/packages/docx/src/layout-context.test.ts
+++ b/packages/docx/src/layout-context.test.ts
@@ -220,6 +220,47 @@ describe('layout context resolvers', () => {
     expect(context.lineGrid).toEqual({ active: true, pitchPt: 20 });
   });
 
+  it('measures an RTL suff=tab numbered first line at the indentLeft tab stop (§17.9.28)', () => {
+    const settings = resolveDocumentLayoutSettings(documentModel());
+    const sectionContext = resolveSectionLayoutContext(settings, section());
+    const num = (overrides: Record<string, unknown> = {}) => ({
+      numId: 1, level: 0, format: 'bullet', text: '•',
+      indentLeft: 12, tab: 9, suff: 'tab', ...overrides,
+    }) as unknown as DocParagraph['numbering'];
+
+    // §17.9.28 + §17.3.1.6: a suff=tab marker's RTL first-line body advances to the
+    // indentLeft tab stop, so the measured first-line indent is 0 — mirroring the
+    // paint pass — NOT the raw −hanging (which would widen the first line and let a
+    // split paragraph disagree with paint on line count).
+    const rtlTab = resolveParagraphLayoutContext(settings, sectionContext, bodyStory,
+      paragraph({ bidi: true, indentFirst: -9, numbering: num() }));
+    expect(rtlTab.firstIndentPt).toBe(0);
+
+    // LTR is byte-identical: keeps raw indentFirst (its pre-existing measure/paint
+    // marker approximation is untouched by this RTL fix).
+    const ltrTab = resolveParagraphLayoutContext(settings, sectionContext, bodyStory,
+      paragraph({ bidi: false, indentFirst: -9, numbering: num() }));
+    expect(ltrTab.firstIndentPt).toBe(-9);
+
+    // suff=space/nothing under RTL is out of scope → keeps legacy raw indentFirst.
+    const rtlNothing = resolveParagraphLayoutContext(settings, sectionContext, bodyStory,
+      paragraph({ bidi: true, indentFirst: -9, numbering: num({ suff: 'nothing' }) }));
+    expect(rtlNothing.firstIndentPt).toBe(-9);
+
+    // An RTL numbering level with no marker glyph (empty text, no picture bullet) is
+    // not a marker — the hanging indent applies to the body as usual.
+    const rtlNoMarker = resolveParagraphLayoutContext(settings, sectionContext, bodyStory,
+      paragraph({ bidi: true, indentFirst: -9, numbering: num({ text: '' }) }));
+    expect(rtlNoMarker.firstIndentPt).toBe(-9);
+
+    // A non-hanging (positive) first-line indent is not the §17.3.1.12 hanging-list
+    // shape the tab-stop body placement targets — keep raw indentFirst (matches the
+    // paint gate, which also requires indFirst < 0), so measure and paint agree.
+    const rtlPositive = resolveParagraphLayoutContext(settings, sectionContext, bodyStory,
+      paragraph({ bidi: true, indentFirst: 9, numbering: num() }));
+    expect(rtlPositive.firstIndentPt).toBe(9);
+  });
+
   it('gates only line-grid policy for paragraphs and table cells', () => {
     const noCompat = resolveDocumentLayoutSettings(documentModel());
     const withCompat = resolveDocumentLayoutSettings(documentModel({

--- a/packages/docx/src/layout-context.ts
+++ b/packages/docx/src/layout-context.ts
@@ -257,6 +257,36 @@ export function resolveParagraphLayoutContext(
     && section.grid.charSpacePt != null;
   const baseRtl = paragraph.bidi === true;
 
+  // ECMA-376 §17.9.28 (`<w:suff>`, default "tab") + §17.3.1.6 (`<w:ind>` is logical
+  // under `<w:bidi>`): a suff=tab numbering marker with a HANGING first-line indent
+  // advances the first-line body to the indentLeft tab stop, so the first line's
+  // effective indent is 0 — the marker occupies the hanging margin, mirrored to the
+  // physical-right start edge in an RTL paragraph. The PAINT pass positions the RTL
+  // suff=tab body with that marker-aware indent (renderer.ts `markerUsesBodyOffset` →
+  // `numBodyOffset`, which is 0 whenever the marker fits the hanging indent), so the
+  // MEASURE/paginate pass must use the same effective first-line width or the two
+  // disagree on line count for a paragraph split across pages (the paginator's
+  // `lineSlice` indices would then reference a different partition). Align them for
+  // the RTL hanging suff=tab case here.
+  //
+  // Scope matches the paint gate exactly: RTL only, suff=tab only, and a genuine
+  // hanging indent (`indentFirst < 0`). LTR keeps raw `indentFirst` (byte-identical
+  // pagination; its long-standing measure/paint marker approximation is untouched);
+  // a non-hanging or suff=space/nothing marker also keeps raw `indentFirst`, staying
+  // consistent with paint. numBodyOffset needs marker font metrics (only resolved in
+  // the renderer), so the rare suff=tab marker-OVERRUN sub-case — where a marker
+  // wider than the hanging indent advances the body PAST the tab stop (§17.3.1.37) —
+  // keeps a small bounded residual here; 0 still matches the common case exactly and
+  // is far closer than the raw −hanging it replaces.
+  const numbering = paragraph.numbering;
+  const hasNumberingMarker =
+    numbering != null && (numbering.text !== '' || numbering.picBulletImagePath != null);
+  const rtlHangingSuffTabMarker =
+    baseRtl
+    && hasNumberingMarker
+    && (numbering!.suff || 'tab') === 'tab'
+    && paragraph.indentFirst < 0;
+
   return {
     lineGrid: {
       active: lineGridActive,
@@ -268,7 +298,7 @@ export function resolveParagraphLayoutContext(
     },
     physicalIndentLeftPt: baseRtl ? paragraph.indentRight : paragraph.indentLeft,
     physicalIndentRightPt: baseRtl ? paragraph.indentLeft : paragraph.indentRight,
-    firstIndentPt: paragraph.indentFirst,
+    firstIndentPt: rtlHangingSuffTabMarker ? 0 : paragraph.indentFirst,
     lineSpacing: paragraph.lineSpacing,
     spaceBeforePt: paragraph.spaceBefore,
     spaceAfterPt: paragraph.spaceAfter,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7137,6 +7137,24 @@ function renderParagraph(
   const firstLineX = paraX + indFirst;
   const paraW = contentW - indLeft - indRight;
 
+  // ECMA-376 §17.9.28 (`<w:suff>`) governs where a numbering marker's first-line
+  // body starts. With suff=tab (default) the body advances to the indentLeft tab
+  // stop (`numBodyOffset`); §17.3.1.6 makes `<w:ind>` logical under `<w:bidi>`, so
+  // this applies to the RTL body's start (physical-right) edge just as it does to
+  // the LTR body's left edge.
+  //
+  // The RTL branch is gated to a genuine HANGING indent (`indFirst < 0`) — the only
+  // shape a real numbered/bulleted list uses (§17.3.1.12: the marker sits in the
+  // hanging margin). A non-hanging RTL marker (positive/zero first-line indent, a
+  // degenerate authoring) keeps its legacy raw-`indFirst` handling so it stays
+  // consistent with the measure pass (which cannot recompute `numBodyOffset`), and
+  // suff=space/nothing (body abuts the marker) is likewise EXCLUDED — its RTL
+  // mirror is a follow-up. LTR is unaffected by these RTL-only guards (it already
+  // used numBodyOffset for every suffix and indent), so LTR stays byte-identical.
+  const markerUsesBodyOffset =
+    hasMarker
+    && (!baseRtl || ((para.numbering?.suff || 'tab') === 'tab' && indFirst < 0));
+
   // Collect all text segments with formatting (resolving field runs against page context)
   const segments = buildSegments(para.runs, state);
   // Word renders ruby paragraphs with consistent line spacing — every line
@@ -7230,8 +7248,17 @@ function renderParagraph(
   // only the marker. With suff=space/nothing the body abuts the marker instead
   // (numBodyOffset, computed above). Non-numbered paragraphs apply the first-line
   // indent (positive firstLine, or a bare negative hanging without a marker) to
-  // the body as usual. RTL lists keep their existing start-edge handling.
-  const firstLineIndent = hasMarker && !baseRtl ? numBodyOffset : firstLineX - paraX;
+  // the body as usual.
+  //
+  // §17.3.1.6 makes `<w:ind>` (and its hanging first-line component) logical under
+  // `<w:bidi>`, so this whole construction is direction-symmetric: an RTL list
+  // mirrors it to the physical RIGHT — the marker sits in the hanging margin past
+  // the start (right) edge and the suff=tab body still starts at the indentLeft tab
+  // stop. So a suff=tab marker uses `numBodyOffset` for BOTH directions
+  // (`markerUsesBodyOffset`); the RTL start-edge placement then falls out of
+  // `effAvailW` (the negative first-line indent must NOT widen the body, only
+  // position the marker).
+  const firstLineIndent = markerUsesBodyOffset ? numBodyOffset : firstLineX - paraX;
   const paintGridDeltaPx = gridCharDeltaPx(grid, scale);
   // Phase 4-1 B2 Stage 2 — compute-once, ZOOM-INVARIANT reuse. When the paginator
   // split this paragraph it stamped the scale-1 lines it laid out
@@ -7278,7 +7305,7 @@ function renderParagraph(
     - (inFrame ? 0 : paragraphContext.physicalIndentLeftPt)
     - (inFrame ? 0 : paragraphContext.physicalIndentRightPt);
   const indLeft1 = inFrame ? 0 : paragraphContext.physicalIndentLeftPt;
-  const firstIndent1 = hasMarker && !baseRtl ? numBodyOffset / scale : para.indentFirst;
+  const firstIndent1 = markerUsesBodyOffset ? numBodyOffset / scale : para.indentFirst;
   const gridDelta1 = gridCharDeltaPx(grid, 1);
   const reuse =
     lineReuseEnabled &&
@@ -7463,7 +7490,7 @@ function renderParagraph(
   // glyph lands on the box edge, so the painted advance equals measuredWidth by
   // construction. See the gridCharDeltaPx / gridSegDeltaPx header.
   const drawGridDeltaPx = gridCharDeltaPx(grid, scale);
-  const drawCtx: ParagraphLineDrawCtx = { ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses, contentX, contentW, lines, grid, paraX, firstLineX, paraW, indLeft, indFirst, continuesParagraph: lineSlice?.continues === true, baseRtl, hasMarker, numTab, numBodyOffset, markerJcShiftPx, picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi, decimalAutoTabPx, drawGridDeltaPx, lineHForLine };
+  const drawCtx: ParagraphLineDrawCtx = { ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses, contentX, contentW, lines, grid, paraX, firstLineX, paraW, indLeft, indFirst, continuesParagraph: lineSlice?.continues === true, baseRtl, hasMarker, markerUsesBodyOffset, numTab, numBodyOffset, markerJcShiftPx, picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi, decimalAutoTabPx, drawGridDeltaPx, lineHForLine };
   for (let li = sliceStart; li < paintEnd; li++) {
     drawParagraphLine(li, drawCtx);
   }
@@ -7608,6 +7635,7 @@ interface ParagraphLineDrawCtx {
   continuesParagraph: boolean;
   baseRtl: boolean;
   hasMarker: boolean;
+  markerUsesBodyOffset: boolean;
   numTab: number;
   numBodyOffset: number;
   markerJcShiftPx: number;
@@ -7628,7 +7656,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
   const {
     ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses,
     contentX, contentW, lines, grid, paraX, firstLineX, paraW, indLeft,
-    indFirst, continuesParagraph, baseRtl, hasMarker, numTab, numBodyOffset, markerJcShiftPx,
+    indFirst, continuesParagraph, baseRtl, hasMarker, markerUsesBodyOffset, numTab, numBodyOffset, markerJcShiftPx,
     picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi,
     decimalAutoTabPx, drawGridDeltaPx, lineHForLine,
   } = c;
@@ -7663,7 +7691,19 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     // space/nothing); indFirst only pulls the marker into the hanging margin
     // (drawn below). Non-numbered first lines apply indFirst to the body directly.
     let x = firstLine && !baseRtl ? (hasMarker ? lineLeft + numBodyOffset : lineLeft + indFirst) : lineLeft;
-    const effAvailW = baseRtl && firstLine ? lineAvailW - indFirst : lineAvailW;
+    // RTL first-line width. For a bare (non-marker) indent the raw first-line
+    // indent narrows (positive firstLine) or widens (hanging) the line, so the
+    // body's start (right) edge tracks the indent — mirror of the LTR x-shift.
+    // But a suff=tab numbering marker follows §17.9.28: the negative hanging indent
+    // positions only the marker, and the body starts at the indentLeft tab stop, so
+    // the first line's text region equals the continuation lines' — use
+    // `numBodyOffset` (0 for suff=tab), NOT the raw `indFirst`, so the body does NOT
+    // hang one `hanging` past the start edge. `markerUsesBodyOffset` also excludes
+    // the suff=space/nothing RTL case (kept on legacy `indFirst` here — out of
+    // scope), keeping this consistent with the `firstLineIndent` used for breaking.
+    const effAvailW = baseRtl && firstLine
+      ? lineAvailW - (markerUsesBodyOffset ? numBodyOffset : indFirst)
+      : lineAvailW;
 
     // Visual draw order. Under bidi we reorder the line's segments per UAX#9
     // (rule L2) and draw each with ctx.direction matching its resolved

--- a/packages/docx/src/rtl-numbered-hanging.test.ts
+++ b/packages/docx/src/rtl-numbered-hanging.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { DocParagraph, DocxDocumentModel, SectionProps } from './types.js';
+
+// ECMA-376 §17.3.1.12 (hanging) + §17.3.1.38 (a hanging indent implicitly creates
+// a tab stop at indentLeft) + §17.9.28 (`<w:suff>`, default "tab"): in a
+// hanging-indent numbered paragraph the marker sits in the hanging margin and the
+// suff=tab that follows it advances the BODY to the indentLeft tab stop, so the
+// first line's text region matches the continuation lines' region. This holds
+// regardless of the paragraph's base direction — §17.3.1.6 makes w:ind (and its
+// hanging first-line component) logical under w:bidi, so a `w:bidi` (RTL) paragraph
+// mirrors the whole construction to the physical RIGHT: the body's start (right)
+// edge lands at the paragraph's start indent, and the marker's right edge sits
+// `w:hanging` further out.
+//
+// Regression: RTL let the raw negative first-line indent (−hanging) flow into the
+// first line, widening it by `hanging`, so the body's right edge — and the marker
+// beyond it — were pushed one `hanging` too far toward the margin.
+//
+// The recording canvas measures each glyph at fontSize px, so widths are exact and
+// the drawn x of the body and the marker can be pinned.
+
+interface FillCall { text: string; x: number }
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const fills: FillCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, rect() {}, clip() {}, scale() {},
+    translate() {}, setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; }, drawImage() {},
+    fillText(text: string, x: number) { fills.push({ text, x }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills };
+}
+
+// A single RTL word — no spaces so it is one segment; the recording canvas ignores
+// shaping and measures it as codePoints × fontSize.
+const RTL_BODY = 'سلام'; // 4 code points → 40 px at fontSize 10
+
+function bulletItem(overrides: Partial<DocParagraph> = {}): DocParagraph {
+  return {
+    alignment: 'left', // start-aligned; under RTL this is the physical RIGHT edge
+    bidi: true,
+    indentLeft: 57.6, indentRight: 0, indentFirst: -18, // hanging 18 pt
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, tabStops: [],
+    numbering: {
+      numId: 3, level: 0, format: 'bullet', text: '•', indentLeft: 57.6,
+      tab: 18, suff: 'tab', jc: 'left', fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+    },
+    runs: [{
+      type: 'text', text: RTL_BODY, bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+      isLink: false, background: null, vertAlign: null, hyperlink: null,
+    }],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+    ...overrides,
+  } as unknown as DocParagraph;
+}
+
+function doc(paras: DocParagraph[]): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: 400, pageHeight: 400,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: paras.map((p) => ({ type: 'paragraph', ...p })),
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+describe('RTL numbered hanging indent (§17.9.28 suff=tab)', () => {
+  // Page 400, margins 0 ⇒ contentX = 0, contentW = 400.
+  // RTL swaps physical indents: physicalLeft = indentRight = 0,
+  // physicalRight = indentLeft = 57.6. paraX = 0, paraW = 400 − 57.6 = 342.4.
+  // The start (right) edge of the text region — where continuation lines end and
+  // where the first-line body must also end — is paraX + paraW = 342.4.
+  const START_EDGE = 342.4;
+  const HANGING = 18; // = numbering.tab
+  const BODY_W = 40; // 4 code points × 10 px
+
+  it('first-line body ends at the start indent, marker hangs one w:hanging beyond', async () => {
+    const { canvas, fills } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc([bulletItem()]), canvas, 0, { dpr: 1, width: 400 });
+
+    const bodyFill = fills.find((f) => f.text === RTL_BODY);
+    const markerFill = fills.find((f) => f.text === '•');
+    expect(bodyFill, 'RTL body drawn').toBeDefined();
+    expect(markerFill, 'bullet marker drawn').toBeDefined();
+
+    // The body's right edge sits AT the paragraph's start indent — it does NOT
+    // hang out by `hanging`. (Pre-fix it landed at START_EDGE + HANGING.)
+    const bodyRightEdge = bodyFill!.x + BODY_W;
+    expect(bodyRightEdge).toBeCloseTo(START_EDGE, 2);
+
+    // The marker's right edge sits exactly `w:hanging` past the body's start edge
+    // (the hanging margin the marker+tab occupy).
+    const markerRightEdge = markerFill!.x + 10; // 1 code point × 10 px
+    expect(markerRightEdge).toBeCloseTo(START_EDGE + HANGING, 2);
+  });
+});


### PR DESCRIPTION
## Problem

In a right-to-left (`w:bidi`) numbered or bulleted paragraph with a hanging
indent, the first line's body — and the number/bullet marker beyond it — were
drawn shifted one full `w:hanging` too far toward the physical-right start
margin. Left-to-right paragraphs were already correct.

Root cause: the raw negative first-line indent (`= −hanging`) flowed straight
into the RTL first line, widening it, whereas the LTR path applied the
ECMA-376 §17.9.28 marker-aware first-line indent. The asymmetry was three
`!baseRtl` guards in the renderer.

## Fix

Apply the same §17.9.28 semantics in both directions:

- §17.3.1.12 — the marker sits in the hanging margin at `firstLineX`.
- §17.3.1.38 — a hanging indent implicitly creates a tab stop at `indentLeft`.
- §17.9.28 — with the default `suff="tab"`, the tab after the marker advances
  the **body** to that `indentLeft` tab stop, so the first line's text region
  equals the continuation lines'.
- §17.3.1.6 — `<w:ind>` (and its hanging first-line component) is **logical**
  under `<w:bidi>`, so the whole construction mirrors to the physical-right
  start edge for RTL: the body lands at the start indent and the negative
  hanging positions only the marker.

Scope guards (RTL-only, so **LTR is byte-identical**): the marker-aware indent
is applied only for `suff="tab"` **and** a genuine hanging indent
(`indentFirst < 0`) — the shape every real list uses. `suff="space"/"nothing"`
and non-hanging RTL markers keep their legacy path.

The measure/paginate pass (`layout-context.ts`) is aligned with paint for the
RTL hanging `suff="tab"` case, so a paragraph split across pages measures the
same line count paint renders (otherwise the paginator's `lineSlice` indices
reference a different partition than paint recomputes).

## Verification

- **Unit (Red→Green):** `rtl-numbered-hanging.test.ts` pins the RTL bullet body
  start edge and marker edge; fails pre-fix (body one `hanging` too far out),
  passes post-fix. `layout-context.test.ts` locks the measure-side gate
  (RTL hanging `suff=tab` → 0; LTR / non-hanging / `suff=nothing` / no-marker →
  raw `indentFirst`).
- **Full docx suite:** 1234 passing. Root `pnpm typecheck`: clean.
- **Word ground truth** (a private Arabic RTL sample, A4, measured against the
  Word-exported PDF): a bulleted item's body start edge moved from 556.8 pt to
  542.9 pt (Word 543.3), and a `1.2` heading's text edge from 523.4 pt to
  494.3 pt (Word ~494.4) with its number at 523.0 pt (Word 523.4) — all within
  ~0.4 pt, down from a full-`hanging` offset before.
- **VRT:** demo (`demo/sample-1`) non-regressing (LTR, byte-identical). The
  private RTL sample's references are gitignored; its diff is the intended
  correction toward the Word PDF and was triaged numerically above (references
  not updated).

## Cross-package check

pptx and xlsx are **immune**: both clamp a negative (hanging) first-line indent
to 0 (`firstLineIndentPxFor` / `Math.max(0, indentPx)`) and right-anchor RTL
text without adding the first-line offset, so no negative hanging ever flows
into an RTL first line. No matching asymmetry exists there.

## Reviewed

Reviewed by Codex (gpt-5.6-sol, read-only) across four passes; LTR byte-identity,
RTL geometry, the measure/paint partition agreement, and cross-package scope all
confirmed.

## Follow-ups (out of scope)

- `suff="space"/"nothing"` RTL marker mirror (body abutting the marker).
- Justified RTL list marker anchored to the unstretched line width.
- Exact `suff="tab"` marker-overrun first-indent in the measure pass (currently a
  small bounded residual vs. the exact value paint computes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
