### PR TITLE
feat(pptx,xlsx): UAX#50 vertical glyph orientation in eaVert / stacked paths

### DIFF
--- a/packages/pptx/src/eavert-glyph-orientation.test.ts
+++ b/packages/pptx/src/eavert-glyph-orientation.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody } from './renderer.js';
+import { drawEaVertRun } from './vertical-text.js';
+import type { TextBody, Paragraph } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+// ECMA-376 §20.1.10.83 ST_TextVerticalType `eaVert` ("East Asian Vertical"):
+// "some fonts are displayed as if rotated by 90 degrees while some fonts (mostly
+// East Asian) are displayed vertical." The renderer rotates the whole text body
+// +90° and lays it out horizontally in the rotated frame — so a plain fillText
+// paints each glyph lying on its side (rotated with the page). Before this fix
+// EVERY glyph, including CJK ideographs/kana (UAX#50 vo=U), was left sideways —
+// the issue #790 defect. The fix drives each glyph through the core UAX#50
+// classifier (`verticalOrientation` + the two vertical-form substitution maps):
+//   • vo=U / vo=Tu  → UPRIGHT: counter-rotate −90° about the cell centre so the
+//     glyph stands up (net rotation 0), substituting the U+FE1x vertical form for
+//     the corner-hanging comma / full stop.
+//   • vo=Tr with a U+FE3x vertical form (（）「」…) → SUBSTITUTE that form, drawn
+//     UPRIGHT (UAX#50 §5 Tr = "substitute a vertical glyph, rotate only as
+//     fallback").
+//   • vo=Tr with NO vertical form (ー U+30FC, quotes) → ROTATE with the page
+//     (net rotation +90°, the fallback).
+//   • vo=R (Latin / digits) → stay SIDEWAYS (net rotation +90°), the conventional
+//     "縦中横 not applied" appearance.
+// `vert` / `vert270` are unchanged (all glyphs rotate — that IS their spec
+// meaning), and the horizontal path is byte-identical (all of this is gated on
+// the eaVert flow).
+
+const FONT_PX = 20;
+const SCALE = 1 / 12700; // emuToPx(emu, SCALE) = emu·SCALE; PT_TO_EMU=12700 ⇒ 1pt → 1px
+
+// Representative glyphs, one per UAX#50 class (verified against the core table).
+const U_CJK = '国'; // vo=U  → upright
+const U_KANA = 'あ'; // vo=U  → upright
+const R_LATIN = 'A'; // vo=R  → sideways
+const TR_BRACKET = '（'; // vo=Tr → substitute U+FE35 ︵, upright
+const TR_BRACKET_FE = String.fromCodePoint(0xfe35); // ︵
+const TU_COMMA = '、'; // vo=Tu → substitute U+FE11, upright
+const TU_COMMA_FE = String.fromCodePoint(0xfe11);
+const TR_ROTATE = 'ー'; // vo=Tr, no vertical form → rotate 90°
+
+interface DrawCall {
+  text: string;
+  x: number;
+  y: number;
+  /** Net canvas rotation in effect at draw time, normalised to (−π, π]. */
+  rot: number;
+  /** Accumulated translate-x in effect at draw time — the along-column cell
+   *  centre for an upright glyph (translate(cx, …) precedes its fillText). */
+  tx: number;
+}
+
+/** Normalise an angle to (−π, π] so 0 (upright) and π/2 (sideways) compare cleanly. */
+function norm(a: number): number {
+  return Math.atan2(Math.sin(a), Math.cos(a));
+}
+
+/** Recording 2D context that tracks the accumulated rotation through a
+ *  save/restore stack, so each fillText records the NET rotation the glyph is
+ *  painted under — 0 ≈ upright, +π/2 ≈ sideways/rotated. */
+function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
+  let font = `${FONT_PX}px serif`;
+  let fillStyle = '';
+  let letterSpacing = '0px';
+  let direction: CanvasDirection = 'ltr';
+  let textAlign: CanvasTextAlign = 'left';
+  let textBaseline: CanvasTextBaseline = 'alphabetic';
+  let rotation = 0;
+  let tx = 0;
+  const stack: { rotation: number; tx: number }[] = [];
+  const px = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const calls: DrawCall[] = [];
+  const metricsFor = (s: string): TextMetrics => {
+    const p = px();
+    // Full-width EA glyphs advance one em; ASCII ~half em.
+    let w = 0;
+    for (const ch of s) w += (ch.codePointAt(0) ?? 0) < 0x80 ? p * 0.5 : p;
+    return {
+      width: w,
+      actualBoundingBoxAscent: p * 0.8,
+      actualBoundingBoxDescent: p * 0.2,
+      fontBoundingBoxAscent: p * 0.8,
+      fontBoundingBoxDescent: p * 0.2,
+    } as TextMetrics;
+  };
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
+    get letterSpacing() { return letterSpacing; }, set letterSpacing(v: string) { letterSpacing = v; },
+    get direction() { return direction; }, set direction(v: CanvasDirection) { direction = v; },
+    get textAlign() { return textAlign; }, set textAlign(v: CanvasTextAlign) { textAlign = v; },
+    get textBaseline() { return textBaseline; }, set textBaseline(v: CanvasTextBaseline) { textBaseline = v; },
+    measureText: (s: string) => metricsFor(s),
+    fillText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, tx }),
+    strokeText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, tx }),
+    save: () => { stack.push({ rotation, tx }); },
+    restore: () => { const s = stack.pop(); if (s) { rotation = s.rotation; tx = s.tx; } },
+    translate: (x: number) => { tx += x; },
+    rotate: (a: number) => { rotation += a; },
+    scale: () => {},
+    beginPath: () => {}, moveTo: () => {}, lineTo: () => {}, stroke: () => {},
+    clip: () => {}, rect: () => {}, fillRect: () => {}, drawImage: () => {},
+    setLineDash: () => {}, closePath: () => {}, arc: () => {},
+    strokeStyle: '#000', lineWidth: 1, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+function run(text: string): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: 20, color: '000000', fontFamily: 'Serif',
+  } as TextRunData;
+}
+
+function eaVertBody(text: string, alignment: Paragraph['alignment'] = 'l'): TextBody {
+  const para: Paragraph = {
+    alignment, marL: 0, marR: 0, indent: 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null, defItalic: null,
+    defFontFamily: null, tabStops: [], eaLnBrk: true, runs: [run(text)],
+  } as Paragraph;
+  return {
+    verticalAnchor: 't', paragraphs: [para], defaultFontSize: 20,
+    defaultBold: null, defaultItalic: null,
+    lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'none', vert: 'eaVert', autoFit: 'none',
+  };
+}
+
+function renderEaVert(text: string, alignment: Paragraph['alignment'] = 'l', boxH = 400): DrawCall[] {
+  const { ctx, calls } = mockCtx();
+  // In eaVert the column length is the box HEIGHT; a tall box lets a `dist` line
+  // stretch. bw is the cross-axis (column thickness).
+  renderTextBody(ctx, eaVertBody(text, alignment), 0, 0, 200, boxH, SCALE);
+  return calls;
+}
+
+const UPRIGHT = 0;
+const SIDEWAYS = Math.PI / 2;
+
+describe('pptx eaVert — UAX#50 per-glyph orientation (§20.1.10.83, issue #790)', () => {
+  it('draws vo=U CJK ideographs UPRIGHT (net rotation 0), not sideways', () => {
+    const calls = renderEaVert(U_CJK);
+    const cjk = calls.filter((c) => c.text === U_CJK);
+    expect(cjk.length, 'the ideograph is painted as its own glyph').toBe(1);
+    expect(norm(cjk[0].rot), 'CJK stands upright (net rotation ≈ 0)').toBeCloseTo(UPRIGHT, 5);
+  });
+
+  it('draws vo=U kana UPRIGHT (net rotation 0)', () => {
+    const calls = renderEaVert(U_KANA);
+    const kana = calls.filter((c) => c.text === U_KANA);
+    expect(kana.length).toBe(1);
+    expect(norm(kana[0].rot)).toBeCloseTo(UPRIGHT, 5);
+  });
+
+  it('leaves vo=R Latin SIDEWAYS (net rotation +90°)', () => {
+    const calls = renderEaVert(R_LATIN);
+    const latin = calls.filter((c) => c.text === R_LATIN);
+    expect(latin.length).toBe(1);
+    expect(norm(latin[0].rot), 'Latin rotates with the page (sideways)').toBeCloseTo(SIDEWAYS, 5);
+  });
+
+  it('SUBSTITUTES a vo=Tr fullwidth bracket with its vertical form, drawn upright', () => {
+    const calls = renderEaVert(TR_BRACKET);
+    // No un-substituted fullwidth bracket is painted.
+    expect(calls.some((c) => c.text === TR_BRACKET), 'original （ is not painted').toBe(false);
+    const fe = calls.filter((c) => c.text === TR_BRACKET_FE);
+    expect(fe.length, 'the U+FE35 vertical form ︵ is painted').toBe(1);
+    expect(norm(fe[0].rot), 'substituted bracket is upright').toBeCloseTo(UPRIGHT, 5);
+  });
+
+  it('SUBSTITUTES a vo=Tu comma with its U+FE11 vertical form, drawn upright', () => {
+    const calls = renderEaVert(TU_COMMA);
+    expect(calls.some((c) => c.text === TU_COMMA), 'original 、 is not painted').toBe(false);
+    const fe = calls.filter((c) => c.text === TU_COMMA_FE);
+    expect(fe.length, 'the U+FE11 vertical form is painted').toBe(1);
+    expect(norm(fe[0].rot)).toBeCloseTo(UPRIGHT, 5);
+  });
+
+  it('ROTATES a vo=Tr glyph with no vertical form (ー U+30FC) with the page (+90°)', () => {
+    const calls = renderEaVert(TR_ROTATE);
+    const mark = calls.filter((c) => c.text === TR_ROTATE);
+    expect(mark.length, 'ー is painted as its own glyph').toBe(1);
+    expect(norm(mark[0].rot), 'ー rotates 90° (the Tr fallback)').toBeCloseTo(SIDEWAYS, 5);
+  });
+
+  it('orients a mixed column: CJK upright, Latin sideways, bracket substituted, comma substituted, ー rotated', () => {
+    const calls = renderEaVert(`${U_CJK}${R_LATIN}${TR_BRACKET}${TU_COMMA}${TR_ROTATE}`);
+    const at = (t: string) => calls.find((c) => c.text === t);
+    expect(norm(at(U_CJK)!.rot)).toBeCloseTo(UPRIGHT, 5);
+    expect(norm(at(R_LATIN)!.rot)).toBeCloseTo(SIDEWAYS, 5);
+    expect(at(TR_BRACKET_FE), 'bracket substituted').toBeTruthy();
+    expect(norm(at(TR_BRACKET_FE)!.rot)).toBeCloseTo(UPRIGHT, 5);
+    expect(at(TU_COMMA_FE), 'comma substituted').toBeTruthy();
+    expect(norm(at(TU_COMMA_FE)!.rot)).toBeCloseTo(UPRIGHT, 5);
+    expect(norm(at(TR_ROTATE)!.rot)).toBeCloseTo(SIDEWAYS, 5);
+  });
+});
+
+// Justified / distributed vertical columns: `dist` (and `just` on a non-last
+// pure-CJK line) opens a uniform pitch between glyphs to fill the column length.
+// The eaVert draw must apply that pitch so the column SPREADS instead of bunching
+// at the top (issue #790 codex review, finding 2 — the fully-distributed case).
+describe('pptx eaVert — distributed columns spread the glyph pitch', () => {
+  it('draws a `dist` pure-CJK column with a wider cell pitch than a left-aligned one', () => {
+    const TEXT = 'あいうえお';
+    const leftCol = renderEaVert(TEXT, 'l', 400).filter((c) => norm(c.rot) === 0 && [...TEXT].includes(c.text));
+    const distCol = renderEaVert(TEXT, 'dist', 400).filter((c) => norm(c.rot) === 0 && [...TEXT].includes(c.text));
+    expect(leftCol.length, 'all CJK glyphs upright').toBe(5);
+    expect(distCol.length).toBe(5);
+    const pitch = (col: DrawCall[]) => col[1].tx - col[0].tx; // along-column cell-centre step
+    // Left-aligned: natural pitch ≈ one em (FONT_PX). Distributed: stretched to
+    // fill the 400px column, so the pitch is materially larger.
+    expect(pitch(leftCol)).toBeCloseTo(FONT_PX, 2);
+    expect(pitch(distCol), 'distributed pitch fills the column').toBeGreaterThan(FONT_PX * 1.5);
+  });
+});
+
+// Focused unit test of the draw helper in isolation (no page rotation installed,
+// so the helper's OWN counter-rotation is what stands the glyph up). Here an
+// upright glyph nets −90° (the helper's counter-rotation) and a sideways glyph
+// nets 0 (the helper leaves it as the page would have drawn it).
+describe('drawEaVertRun — per-glyph orientation helper', () => {
+  function runHelper(text: string): DrawCall[] {
+    const { ctx, calls } = mockCtx();
+    drawEaVertRun(ctx, text, 0, 100, FONT_PX, 0, 'fill');
+    return calls;
+  }
+  it('counter-rotates vo=U glyphs by −90° (upright in the +90° page frame)', () => {
+    const calls = runHelper(U_CJK);
+    expect(norm(calls[0].rot)).toBeCloseTo(-Math.PI / 2, 5);
+    expect(calls[0].text).toBe(U_CJK);
+  });
+  it('does not counter-rotate vo=R Latin (stays with the page)', () => {
+    const calls = runHelper(R_LATIN);
+    expect(norm(calls[0].rot)).toBeCloseTo(0, 5);
+    expect(calls[0].text).toBe(R_LATIN);
+  });
+  it('substitutes vo=Tr brackets and vo=Tu commas, counter-rotated upright', () => {
+    expect(runHelper(TR_BRACKET)[0].text).toBe(TR_BRACKET_FE);
+    expect(norm(runHelper(TR_BRACKET)[0].rot)).toBeCloseTo(-Math.PI / 2, 5);
+    expect(runHelper(TU_COMMA)[0].text).toBe(TU_COMMA_FE);
+    expect(norm(runHelper(TU_COMMA)[0].rot)).toBeCloseTo(-Math.PI / 2, 5);
+  });
+  it('leaves vo=Tr ー rotated with the page (no counter-rotation, no substitution)', () => {
+    const calls = runHelper(TR_ROTATE);
+    expect(calls[0].text).toBe(TR_ROTATE);
+    expect(norm(calls[0].rot)).toBeCloseTo(0, 5);
+  });
+  it('advances each cell by measure + letterSpacingPx (the justification pitch)', () => {
+    const { ctx: c0, calls: k0 } = mockCtx();
+    drawEaVertRun(c0, '国国', 0, 100, FONT_PX, 0, 'fill');
+    const { ctx: c1, calls: k1 } = mockCtx();
+    drawEaVertRun(c1, '国国', 0, 100, FONT_PX, 8, 'fill');
+    // Cell-centre step = advance = measure(国)=FONT_PX plus the per-glyph pitch.
+    expect(k0[1].tx - k0[0].tx).toBeCloseTo(FONT_PX, 5);
+    expect(k1[1].tx - k1[0].tx).toBeCloseTo(FONT_PX + 8, 5);
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -102,6 +102,7 @@ import { justifiedPiecePositions } from '@silurus/ooxml-core';
 import { resolveTableBorderConflict } from './table-border-conflict.js';
 import { isSmartArtFallbackShape, smartArtFallbackTextColor } from './smartart-fallback-contrast';
 import { resolveTabWidths } from './tab-layout.js';
+import { drawEaVertRun } from './vertical-text.js';
 
 /** Theme font context threaded through the render call chain. */
 export interface RenderContext {
@@ -2698,6 +2699,13 @@ export function renderTextBody(
   onTextRun?: TextRunCallback,
   measureOnly = false,
   fetchImage?: FetchImage,
+  // ECMA-376 §20.1.10.83 `eaVert` ("East Asian Vertical"): CJK glyphs stand
+  // UPRIGHT while Latin rotates. Set true ONLY when re-entering horizontally
+  // inside the +90°-rotated `eaVert` frame (below), so the run-draw loop applies
+  // per-glyph UAX#50 orientation via `drawEaVertRun`. False for `horz` and for
+  // `vert`/`vert270` (whose spec meaning IS to rotate every glyph), keeping those
+  // paths byte-identical.
+  eaVertUpright = false,
 ): number | void {
   // Vertical text: rotate rendering context so text flows top-to-bottom.
   // "vert" and "eaVert" both approximate to 90° clockwise rotation.
@@ -2745,8 +2753,11 @@ export function renderTextBody(
     ctx.save();
     ctx.translate(cx, cy);
     ctx.rotate(isVert270 ? -Math.PI / 2 : Math.PI / 2);
-    // After rotation the "width" direction of the new frame is the original height
-    renderTextBody(ctx, { ...body, vert: 'horz' }, -bh / 2, -bw / 2, bh, bw, scale, shapeDefaultTextColor, 0, false, false, themeDefaultColor, slideNumber, rc, wrappedOnTextRun, false, fetchImage);
+    // After rotation the "width" direction of the new frame is the original height.
+    // `eaVert` re-enters with per-glyph uprighting (UAX#50): CJK stands up, Latin
+    // stays sideways. `vert`/`vert270` re-enter WITHOUT it — their spec meaning is
+    // to rotate every glyph — so those stay byte-identical to before.
+    renderTextBody(ctx, { ...body, vert: 'horz' }, -bh / 2, -bw / 2, bh, bw, scale, shapeDefaultTextColor, 0, false, false, themeDefaultColor, slideNumber, rc, wrappedOnTextRun, false, fetchImage, body.vert === 'eaVert');
     ctx.restore();
     return;
   }
@@ -3540,6 +3551,22 @@ export function renderTextBody(
       const fullyDistributed =
         !!splitBefore && splitBefore.length === cps.length - 1 && cps.length > 1;
       const drawRun = (op: 'fill' | 'stroke'): void => {
+        if (eaVertUpright) {
+          // ECMA-376 §20.1.10.83 eaVert: paint each glyph with its UAX#50 vertical
+          // orientation (CJK/kana upright, Latin sideways, brackets/comma
+          // substituted, ー rotated). The segment's cell positions are already set
+          // by the horizontal layout (penX / segW), so only the glyph orientation
+          // changes. A FULLY-DISTRIBUTED line (algn just/dist opening a gap at every
+          // inter-glyph boundary — e.g. 均等割り付け of a pure-CJK column) carries its
+          // uniform justification pitch in `segPerGap`; fold it into the per-glyph
+          // advance so the column SPREADS to fill the length instead of bunching at
+          // the top (mirrors the horizontal fully-distributed fast-path below).
+          // Partial `just` distribution (mixed Latin/CJK pieces) is a rare eaVert
+          // edge and is not redistributed here.
+          const eaPitch = fullyDistributed ? ls + segPerGap : ls;
+          drawEaVertRun(ctx, seg.text, penX, segBaseline, seg.sizePx, eaPitch, op);
+          return;
+        }
         if (fullyDistributed) {
           const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
           const prev = lctx.letterSpacing;

--- a/packages/pptx/src/vertical-text.ts
+++ b/packages/pptx/src/vertical-text.ts
@@ -1,0 +1,194 @@
+// ECMA-376 §20.1.10.83 ST_TextVerticalType `eaVert` ("East Asian Vertical") —
+// per-glyph orientation for a text body laid out in the +90°-rotated frame.
+//
+// The renderer draws an eaVert body by rotating the whole context +90° clockwise
+// and re-running the HORIZONTAL layout inside that rotated frame (see
+// `renderTextBody`): a plain `ctx.fillText` then advances DOWN the column (logical
+// +x → physical +y), which is the character progression a vertical line wants —
+// but every glyph is left lying on its right side (rotated with the page). Which
+// glyphs must be stood back UP is decided by the Unicode UAX#50
+// Vertical_Orientation (vo) property (core `verticalOrientation`), NOT an ad-hoc
+// CJK-vs-Latin guess:
+//   • vo=U  (upright): CJK ideographs, kana, Hangul, fullwidth forms/digits. Drawn
+//     with a local −90° counter-rotation about the cell centre, cancelling the
+//     page rotation so the glyph stands upright while still advancing down.
+//   • vo=Tu (transform, fallback upright): the corner-hanging comma/full stop
+//     、。， are SUBSTITUTED with their U+FE10–FE12 vertical form (core
+//     `verticalFormSubstitute`) and drawn upright, so the font supplies the
+//     designed upper-right placement; ！？ and small kana have no form and draw
+//     upright unchanged.
+//   • vo=Tr (transform, fallback rotate): the fullwidth brackets （「」〈〉【】…
+//     have a U+FE35–FE44 vertical presentation form (core
+//     `verticalBracketFormSubstitute`); UAX#50 §5 makes Tr "substitute a vertical
+//     glyph, ROTATE only as fallback", so we substitute and draw them upright.
+//     The prolonged sound mark ー (U+30FC) and the quotation marks “” have no
+//     vertical form, so they take the rotate fallback (drawn with the page).
+//   • vo=R  (rotated): Latin letters, Western digits, Latin punctuation stay
+//     SIDEWAYS (rotated with the page) — the conventional "縦中横 not applied" look.
+//
+// This mirrors the docx tbRl vertical draw (packages/docx/src/vertical-text.ts):
+// the geometry is the same rotate-layout, and both consume the SAME core UAX#50
+// classifier — no new shared abstraction is introduced (issue #790). The XLSX
+// stacked path is DIFFERENT geometry (no page rotation), so it keeps its own tiny
+// helper; only the classifier is shared across the three formats.
+
+import {
+  verticalOrientation,
+  verticalFormSubstitute,
+  verticalBracketFormSubstitute,
+} from '@silurus/ooxml-core';
+
+type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+/**
+ * Cross-axis (column-thickness) offset, in px, from the alphabetic baseline to
+ * the font's EM-BOX CENTRE — `(fontBoundingBoxAscent − fontBoundingBoxDescent)/2`.
+ *
+ * In the rotated eaVert frame the horizontal layout hands us the run's ALPHABETIC
+ * baseline; the column's cross-axis centre (where the sideways glyphs' ink already
+ * sits and where the upright cells must centre) is this many px ABOVE it. Using
+ * the font metric keeps upright and sideways glyphs sharing one centreline.
+ *
+ * Falls back to `0.38 × fontPx` when the Canvas does not report `fontBoundingBox*`.
+ */
+function emBoxCenterAboveBaselinePx(ctx: Ctx2D, sample: string, fontPx: number): number {
+  const prevBaseline = ctx.textBaseline;
+  ctx.textBaseline = 'alphabetic';
+  const m = ctx.measureText(sample);
+  ctx.textBaseline = prevBaseline;
+  const asc = m.fontBoundingBoxAscent;
+  const desc = m.fontBoundingBoxDescent;
+  if (typeof asc === 'number' && typeof desc === 'number' && (asc !== 0 || desc !== 0)) {
+    return (asc - desc) / 2;
+  }
+  return 0.38 * fontPx;
+}
+
+/**
+ * Along-column offset, in px, from a glyph's own cell centre to its INK centre
+ * when drawn UPRIGHT — `(actualBoundingBoxAscent − actualBoundingBoxDescent)/2`
+ * measured with a `middle` textBaseline. For an ordinary ideograph/kana this is
+ * ≈0; for a substituted vertical bracket (︵ ︶ ﹁ ﹂, whose ink hugs one cell end)
+ * it is the shift that re-centres the ink so the two halves sit a full cell apart.
+ *
+ * Returns 0 when the Canvas does not report `actualBoundingBox*` (older engines).
+ */
+function inkCenterAboveMiddlePx(ctx: Ctx2D, drawStr: string): number {
+  const prevAlign = ctx.textAlign;
+  const prevBaseline = ctx.textBaseline;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  const m = ctx.measureText(drawStr);
+  ctx.textAlign = prevAlign;
+  ctx.textBaseline = prevBaseline;
+  const asc = m.actualBoundingBoxAscent;
+  const desc = m.actualBoundingBoxDescent;
+  if (typeof asc === 'number' && typeof desc === 'number') {
+    return (asc - desc) / 2;
+  }
+  return 0;
+}
+
+/**
+ * Paint one run's glyphs for an `eaVert` text body. The context is assumed to be
+ * in the page's +90°-rotated frame already (installed by `renderTextBody`), so an
+ * ordinary `fillText` advances DOWN the column. Each glyph occupies a cell of
+ * width = its horizontal advance (`ctx.measureText`) plus `letterSpacingPx`, so
+ * the total advance equals the run's measured width (measure == draw). The glyph
+ * is stood upright / substituted / rotated / left sideways per its UAX#50 class.
+ *
+ * Glyphs are painted one code point at a time (as in docx's `drawVerticalRun`):
+ * each upright cell needs its own counter-rotation, and a uniform per-glyph
+ * advance keeps measure==draw at the segment boundary. Contextual shaping of a
+ * consecutive SIDEWAYS (Latin) run — kerning / ligatures — is therefore not
+ * preserved; an accepted tradeoff for vertical East-Asian text, where Latin runs
+ * are short and their advances are context-free enough at these sizes.
+ *
+ * @param ctx              2D context, already in the rotated eaVert frame.
+ *                         `ctx.font`/`ctx.fillStyle`/`ctx.strokeStyle` are the
+ *                         caller's.
+ * @param text             The run's text.
+ * @param x                Along-column left edge of the run (px; logical +x).
+ * @param baseline         Along-column ALPHABETIC baseline y of the line (px) —
+ *                         the same value the horizontal draw path uses.
+ * @param fontPx           Effective font size in px (for cell centring).
+ * @param letterSpacingPx  Per-glyph extra advance (rPr @spc pitch); 0 for the
+ *                         common path.
+ * @param paint            `'fill'` or `'stroke'` (run outline, rPr > a:ln).
+ */
+export function drawEaVertRun(
+  ctx: Ctx2D,
+  text: string,
+  x: number,
+  baseline: number,
+  fontPx: number,
+  letterSpacingPx: number,
+  paint: 'fill' | 'stroke' = 'fill',
+): void {
+  const prevAlign = ctx.textAlign;
+  const prevBaseline = ctx.textBaseline;
+  const draw = paint === 'stroke' ? ctx.strokeText.bind(ctx) : ctx.fillText.bind(ctx);
+  // Cross-axis (column-thickness) centre of the column, measured once per run.
+  // The alphabetic `baseline` sits this many px BELOW the em-box centre; the
+  // sideways (Latin) glyphs already centre their ink there, so the upright cells
+  // centre on the same line by drawing at `crossCenterY`.
+  const emBoxCenterPx = emBoxCenterAboveBaselinePx(ctx, text, fontPx);
+  const crossCenterY = baseline - emBoxCenterPx;
+  let ax = 0; // cumulative advance from the run's left (logical +x)
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) ?? 0;
+    const vo = verticalOrientation(cp);
+    // Advance/width uses the ORIGINAL code point (measure == draw; the text model,
+    // selection and find keep the original character — substitution is glyph-only).
+    const adv = ctx.measureText(ch).width + letterSpacingPx;
+    // A vo=Tr bracket with a Unicode vertical presentation form is substituted and
+    // drawn UPRIGHT (UAX#50 §5 substitute-first); only Tr code points with NO form
+    // (ー, quotes) take the rotate fallback.
+    const bracketCp = vo === 'Tr' ? verticalBracketFormSubstitute(cp) : null;
+    const upright = vo === 'U' || vo === 'Tu' || bracketCp !== null;
+    if (upright) {
+      // vo=U / vo=Tu, or a substituted Tr bracket. Counter-rotate −90° about the
+      // cell centre so the glyph (which the page rotation would lay on its side)
+      // stands upright. Corner-hanging Tu punctuation (、。， → U+FE10–FE12) and Tr
+      // brackets (（）「」… → U+FE35–FE44) are drawn as their vertical form so the
+      // font supplies the vertical shape; ！？ and small kana draw upright unchanged.
+      const puncCp = bracketCp !== null ? null : (vo === 'Tu' ? verticalFormSubstitute(cp) : null);
+      const drawCp = bracketCp !== null ? bracketCp : puncCp;
+      const drawStr = drawCp !== null ? String.fromCodePoint(drawCp) : ch;
+      const cx = x + ax + adv / 2;
+      // Along-column ink re-centring: an upright glyph's VERTICAL ink extent maps to
+      // the column axis. ≈0 for an ideograph/kana (cells unchanged); the needed
+      // correction for a substituted bracket whose ink hugs one cell end. NOT applied
+      // to a substituted comma/full stop (FE10–FE12): those are DESIGNED with their
+      // ink in the cell's upper-right corner, so em-box-centring preserves it.
+      const isPunctSubstitute = puncCp !== null;
+      const alongEm = isPunctSubstitute ? 0 : inkCenterAboveMiddlePx(ctx, drawStr) / fontPx;
+      ctx.save();
+      ctx.translate(cx, crossCenterY);
+      ctx.rotate(-Math.PI / 2);
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      draw(drawStr, 0, alongEm * fontPx);
+      ctx.restore();
+    } else if (vo === 'Tr') {
+      // vo=Tr with NO vertical form (ー U+30FC, quotes “”). The Tr fallback is to
+      // ROTATE 90° CW — a plain draw in the +90° page frame IS that rotation; centre
+      // it on the column with `center`/`middle` at the cell centre.
+      const cx = x + ax + adv / 2;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      draw(ch, cx, crossCenterY);
+    } else {
+      // vo=R (Latin/digits): stay SIDEWAYS (rotated with the page). Draw at the
+      // alphabetic baseline; its ink already centres on the column centreline the
+      // upright cells use (crossCenterY = baseline − emBoxCenterPx), so no cross-axis
+      // shift is needed — byte-identical to the horizontal path's per-glyph draw.
+      ctx.textAlign = prevAlign;
+      ctx.textBaseline = 'alphabetic';
+      draw(ch, x + ax, baseline);
+    }
+    ax += adv;
+  }
+  ctx.textAlign = prevAlign;
+  ctx.textBaseline = prevBaseline;
+}

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -12,6 +12,7 @@ import { formatCellValueWithColor } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
 import { computeLineVisualOrder, cellBaseRtl, resolveCellBidi } from './bidi-line.js';
 import { parseA1 } from './a1.js';
+import { drawStackedVerticalChar } from './vertical-text.js';
 
 /** Cache key for a decoded image in the shared `loadedImages` map. A plain
  *  picture is keyed by its zip `imagePath`; a picture carrying a `<a:duotone>`
@@ -2584,14 +2585,21 @@ function renderQuadrant(
       // Stacked text (textRotation=255): draw each character on its own line
       if (isStacked) {
         const charH = vMetricPx(font.size, cs, 1.1);
-        const totalH = text.length * charH;
+        // One stacked slot per CODE POINT (the draw loop iterates code points), so
+        // an astral character reserves one slot, keeping center/bottom anchoring
+        // correct (issue #790 codex review, finding 3).
+        const stackedCount = [...text].length;
+        const totalH = stackedCount * charH;
         let charY = alignV === 'top' ? cy + paddingY
           : alignV === 'center' ? cy + (cellH - totalH) / 2
           : cy + cellH - totalH - paddingY;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
         for (const ch of text) {
-          ctx.fillText(ch, cx + cellW / 2, charY);
+          // UAX#50 per-glyph orientation (issue #790): CJK/Latin stay upright,
+          // 、。 substitute their vertical form, fullwidth brackets substitute
+          // their U+FE3x form, and ー rotates 90° to a vertical bar.
+          drawStackedVerticalChar(ctx, ch, cx + cellW / 2, charY, charH);
           charY += charH;
         }
         ctx.restore();

--- a/packages/xlsx/src/stacked-glyph-orientation.test.ts
+++ b/packages/xlsx/src/stacked-glyph-orientation.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { drawStackedVerticalChar } from './vertical-text.js';
+
+// ECMA-376 §18.8.1 alignment `textRotation="255"` — Excel "stacked" vertical
+// text: each character is stacked upright, one per line, top to bottom. Before
+// this fix every character was drawn upright with no orientation logic, so:
+//   • vo=Tr fullwidth brackets （）「」… kept their HORIZONTAL shape (Excel shows
+//     the vertical presentation form), and
+//   • vo=Tr ー (U+30FC prolonged sound mark) stayed a horizontal dash instead of
+//     the vertical bar Excel draws, and
+//   • vo=Tu commas / full stops 、。 were not swapped for their upper-right
+//     corner-hanging vertical form.
+// The fix routes each stacked glyph through the core UAX#50 classifier:
+//   • vo=U  (CJK / kana / fullwidth digits) → upright, unchanged (Excel stacks
+//     these upright).
+//   • vo=R  (Latin / ASCII digits) → upright, unchanged (Excel stacks Latin
+//     upright too — NOT rotated, unlike pptx/docx eaVert).
+//   • vo=Tu with a U+FE1x form (、。，) → SUBSTITUTE that vertical form (upright).
+//   • vo=Tr with a U+FE3x form (（）「」…) → SUBSTITUTE that vertical form (upright,
+//     "substitute-first" per UAX#50 §5).
+//   • vo=Tr with NO vertical form (ー, quotes) → ROTATE the glyph 90° (the Tr
+//     fallback).
+
+const CENTER_X = 50;
+const CELL_TOP = 10;
+const CHAR_H = 20;
+
+const U_CJK = '国';
+const R_LATIN = 'A';
+const TR_BRACKET = '（';
+const TR_BRACKET_FE = String.fromCodePoint(0xfe35); // ︵
+const TU_COMMA = '、';
+const TU_COMMA_FE = String.fromCodePoint(0xfe11);
+const TR_ROTATE = 'ー'; // U+30FC — no vertical form → rotate
+
+interface DrawCall {
+  text: string;
+  x: number;
+  y: number;
+  /** Net canvas rotation in effect at draw time, normalised to (−π, π]. */
+  rot: number;
+}
+
+function norm(a: number): number {
+  return Math.atan2(Math.sin(a), Math.cos(a));
+}
+
+function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
+  let font = '20px serif';
+  let textAlign: CanvasTextAlign = 'center';
+  let textBaseline: CanvasTextBaseline = 'top';
+  let rotation = 0;
+  const stack: number[] = [];
+  const calls: DrawCall[] = [];
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    get textAlign() { return textAlign; }, set textAlign(v: CanvasTextAlign) { textAlign = v; },
+    get textBaseline() { return textBaseline; }, set textBaseline(v: CanvasTextBaseline) { textBaseline = v; },
+    measureText: (s: string) => ({ width: [...s].length * 20 }) as TextMetrics,
+    fillText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation }),
+    save: () => { stack.push(rotation); },
+    restore: () => { rotation = stack.pop() ?? rotation; },
+    translate: () => {},
+    rotate: (a: number) => { rotation += a; },
+    fillStyle: '#000',
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+function draw(ch: string): DrawCall[] {
+  const { ctx, calls } = mockCtx();
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  drawStackedVerticalChar(ctx, ch, CENTER_X, CELL_TOP, CHAR_H);
+  return calls;
+}
+
+const UPRIGHT = 0;
+const ROTATED = Math.PI / 2;
+
+describe('xlsx stacked text — UAX#50 per-glyph orientation (textRotation=255, issue #790)', () => {
+  it('keeps vo=U CJK upright (unchanged)', () => {
+    const calls = draw(U_CJK);
+    expect(calls.length).toBe(1);
+    expect(calls[0].text).toBe(U_CJK);
+    expect(norm(calls[0].rot)).toBeCloseTo(UPRIGHT, 5);
+  });
+
+  it('keeps vo=R Latin upright (Excel stacks Latin upright, not rotated)', () => {
+    const calls = draw(R_LATIN);
+    expect(calls.length).toBe(1);
+    expect(calls[0].text).toBe(R_LATIN);
+    expect(norm(calls[0].rot)).toBeCloseTo(UPRIGHT, 5);
+  });
+
+  it('SUBSTITUTES a vo=Tr fullwidth bracket with its vertical form, upright', () => {
+    const calls = draw(TR_BRACKET);
+    expect(calls.length).toBe(1);
+    expect(calls[0].text, 'the U+FE35 vertical form ︵ replaces （').toBe(TR_BRACKET_FE);
+    expect(norm(calls[0].rot)).toBeCloseTo(UPRIGHT, 5);
+  });
+
+  it('SUBSTITUTES a vo=Tu comma with its U+FE11 vertical form, upright', () => {
+    const calls = draw(TU_COMMA);
+    expect(calls.length).toBe(1);
+    expect(calls[0].text).toBe(TU_COMMA_FE);
+    expect(norm(calls[0].rot)).toBeCloseTo(UPRIGHT, 5);
+  });
+
+  it('ROTATES a vo=Tr glyph with no vertical form (ー) by 90°', () => {
+    const calls = draw(TR_ROTATE);
+    expect(calls.length).toBe(1);
+    expect(calls[0].text).toBe(TR_ROTATE);
+    expect(norm(calls[0].rot), 'ー is rotated to a vertical bar').toBeCloseTo(ROTATED, 5);
+  });
+});

--- a/packages/xlsx/src/vertical-text.ts
+++ b/packages/xlsx/src/vertical-text.ts
@@ -1,0 +1,84 @@
+// ECMA-376 §18.8.1 alignment `textRotation="255"` — Excel "stacked" vertical
+// text: each character is stacked upright, one per line, top to bottom. Which
+// glyphs stay literally upright and which must be substituted / rotated is decided
+// by the Unicode UAX#50 Vertical_Orientation (vo) property (core
+// `verticalOrientation`), the SAME classifier the pptx eaVert and docx tbRl paths
+// use (issue #790) — only the geometry differs (xlsx has no page rotation).
+//
+//   • vo=U  (CJK / kana / Hangul / fullwidth forms & digits) → upright, drawn as
+//     the caller set up (center / top). Excel stacks these upright.
+//   • vo=R  (Latin letters, ASCII digits, Latin punctuation) → upright, unchanged.
+//     Unlike pptx/docx eaVert (where Latin rotates), Excel stacks Latin UPRIGHT,
+//     one letter per line.
+//   • vo=Tu with a U+FE10–FE12 vertical form (、。，) → SUBSTITUTE that form
+//     (core `verticalFormSubstitute`), drawn upright so the font hangs it in the
+//     cell's upper-right corner; ！？ and small kana have no form and draw upright.
+//   • vo=Tr with a U+FE35–FE44 vertical form (（）「」〈〉【】…) → SUBSTITUTE that form
+//     (core `verticalBracketFormSubstitute`), drawn upright (UAX#50 §5
+//     "substitute a vertical glyph, rotate only as fallback").
+//   • vo=Tr with NO vertical form (ー U+30FC, quotes “”) → ROTATE the glyph 90° CW
+//     (the Tr fallback) so ー becomes the vertical bar Excel draws.
+
+import {
+  verticalOrientation,
+  verticalFormSubstitute,
+  verticalBracketFormSubstitute,
+} from '@silurus/ooxml-core';
+
+type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+/**
+ * Draw one character of an Excel stacked (`textRotation="255"`) cell into its
+ * vertical cell slot. The caller stacks the cells top-to-bottom and sets
+ * `textAlign='center'` / `textBaseline='top'`; this routes each glyph through the
+ * UAX#50 classifier to draw it upright, substituted, or rotated.
+ *
+ * Substitution and rotation are GLYPH-only: the caller's cell height / advance and
+ * everything the model reports (selection, find) keep the ORIGINAL character.
+ *
+ * @param ctx       2D context; `ctx.font`/`ctx.fillStyle` and (for the upright
+ *                  path) `textAlign='center'` / `textBaseline='top'` are the
+ *                  caller's.
+ * @param ch        One character (single code point) of the cell text.
+ * @param centerX   Horizontal centre of the cell (px) — the upright glyph's x.
+ * @param cellTopY  Top y of this character's cell slot (px) — the upright glyph's
+ *                  `top`-baseline y.
+ * @param charH     Height of one stacked cell slot (px) — used to centre a rotated
+ *                  glyph within its slot.
+ */
+export function drawStackedVerticalChar(
+  ctx: Ctx2D,
+  ch: string,
+  centerX: number,
+  cellTopY: number,
+  charH: number,
+): void {
+  const cp = ch.codePointAt(0) ?? 0;
+  const vo = verticalOrientation(cp);
+
+  if (vo === 'Tr') {
+    // Substitute-first: a fullwidth bracket has a U+FE35–FE44 vertical form drawn
+    // UPRIGHT (UAX#50 §5). It fills the cell like an ideograph, so the caller's
+    // center/top placement lands it correctly.
+    const bracket = verticalBracketFormSubstitute(cp);
+    if (bracket !== null) {
+      ctx.fillText(String.fromCodePoint(bracket), centerX, cellTopY);
+      return;
+    }
+    // Fallback: no vertical form (ー U+30FC, quotes) → rotate 90° CW, centred in the
+    // cell slot. save/restore also restores the caller's textAlign/textBaseline.
+    ctx.save();
+    ctx.translate(centerX, cellTopY + charH / 2);
+    ctx.rotate(Math.PI / 2);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(ch, 0, 0);
+    ctx.restore();
+    return;
+  }
+
+  // vo=U / vo=R → upright unchanged; vo=Tu → substitute a vertical form when one
+  // exists (、。，), else upright unchanged (！？, small kana).
+  const sub = vo === 'Tu' ? verticalFormSubstitute(cp) : null;
+  ctx.fillText(sub !== null ? String.fromCodePoint(sub) : ch, centerX, cellTopY);
+}


### PR DESCRIPTION
## Summary

Follow-up to #789. Wires the shared core UAX#50 classifier (`verticalOrientation` / `verticalFormSubstitute` / `verticalBracketFormSubstitute`) into the two vertical-text paths that lacked per-glyph orientation, per **issue #790**. Reuses the existing core classifier — **no new shared abstraction** — with format-local draw geometry.

### pptx `eaVert` (ECMA-376 §20.1.10.83)
Previously the body was rotated +90° and laid out horizontally, so **every** glyph — including CJK ideographs/kana (`vo=U`) — was left **sideways**. New `packages/pptx/src/vertical-text.ts` `drawEaVertRun`:
- `vo=U` / `vo=Tu` → counter-rotate −90° **upright** (substituting U+FE10–FE12 for 、。，)
- `vo=Tr` with a vertical form (（）「」…) → **substitute** U+FE35–FE44, drawn upright (UAX#50 §5 substitute-first)
- `vo=Tr` with no form (ー, quotes) → **rotate** with the page (the fallback)
- `vo=R` (Latin/digits) → stay **sideways**

Mirrors the docx tbRl rotate-layout draw. Gated on a new `eaVertUpright` flag set **only** for `body.vert === 'eaVert'`, so `horz` / `vert` / `vert270` stay byte-identical.

### xlsx stacked (`textRotation=255`)
Previously each character was drawn upright with no orientation logic. New `packages/xlsx/src/vertical-text.ts` `drawStackedVerticalChar` substitutes `Tr` brackets and `Tu` commas upright, rotates `Tr`-no-form (ー) 90° to a vertical bar, and keeps `U`/`R` upright (Excel stacks Latin upright too).

## Verification
- New TDD suites (`eavert-glyph-orientation.test.ts`, `stacked-glyph-orientation.test.ts`) assert the four UAX#50 classes via net-rotation + substitution on a recording canvas; RED on the pre-fix renderer, GREEN after.
- Full **pptx + xlsx vitest: 960 passing**. Root **typecheck** clean. `ast-grep` clean on the new modules.
- **VRT** (demo references — the only ones present in-tree): pptx 9/9 and xlsx 5/5 pass with the fidelity ratchet held. The demo samples contain no `eaVert`/stacked text, and the change is strictly code-path-gated, so the horizontal path is unaffected.
- Rendered a private `eaVert` sample in the browser (real Hiragino fonts) and diffed against its PowerPoint PDF ground truth: vertical CJK now stands upright, matching Word.

## Independent review
Codex (gpt-5.6-sol, read-only) confirmed the class dispatch, substitutions and rotation signs are correct and the horizontal path is strictly gated. Addressed its findings:
- **Justification**: a fully-distributed (`algn` just/dist) `eaVert` column now folds `segPerGap` into the per-glyph pitch so it spreads instead of bunching (new test).
- **Astral safety**: xlsx stacked `totalH` now counts code points, not UTF-16 units.

Known/scoped limitations (documented inline): contextual shaping of consecutive sideways Latin runs is not preserved (docx-parity tradeoff; Latin runs in vertical EA text are short); `eaVert` + `prstTxWarp` keeps the warp path's own glyph mapping; substitute-first for colon/semicolon/lenticular (U+FE13/14/17/18) is deferred as it needs a core map change affecting docx.

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)