### PR TITLE
docs: add Unicode License v3 notice for bundled UCD data files

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -92,14 +92,86 @@ remains entirely MIT / Apache-2.0, with no copyleft licenses:
 cargo license --manifest-path packages/mcp-server/Cargo.toml --avoid-dev-deps
 ```
 
+## Unicode Character Database data
+
+The line-breaking, vertical-orientation and Arabic-shaping logic is driven
+by tables generated from the Unicode Character Database (UCD), © Unicode,
+Inc., licensed under the [Unicode License v3](#unicode-license-v3-full-text)
+(SPDX: `Unicode-3.0`), which expressly permits copying, modification and
+redistribution of the data files with this notice.
+
+Checked into this repository (generator inputs, each retaining its original
+Unicode copyright header; not part of the npm tarball):
+
+- `packages/core/scripts/VerticalOrientation.txt` (UAX #50
+  Vertical_Orientation, UCD 17.0.0)
+- `packages/docx/scripts/ArabicShaping.txt` (Joining_Type / Joining_Group,
+  UCD 17.0.0)
+- `packages/docx/scripts/DerivedJoiningType.txt` (UCD 17.0.0)
+
+Shipped in `dist/` as UCD-derived data compiled from the above and from
+`LineBreak.txt` / `DerivedGeneralCategory.txt` (fetched at generation time,
+not checked in): the `*.generated.ts` tables under `packages/core/src/text/`
+and `packages/docx/src/` (line-break classes, vertical orientation, bidi
+character data, Arabic joining classes).
+
+The `unicode-ident` Rust crate listed above also carries `Unicode-3.0` in
+its SPDX expression for the same reason (embedded UCD-derived tables).
+
 ## License texts
 
 - **MIT** — see [LICENSE](./LICENSE) (this repository's own license; the
   MIT-licensed dependencies above use the same standard text with their own
   copyright holder).
+- **Unicode License v3** — canonical text at
+  <https://www.unicode.org/license.txt>, reproduced below.
 - **Apache License, Version 2.0** — full text at
   <https://www.apache.org/licenses/LICENSE-2.0>, reproduced below for
   convenience.
+
+### Unicode License v3 (full text)
+
+```
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2026 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+```
 
 ### Apache License 2.0 (full text)
 


### PR DESCRIPTION
## Summary

#943/#964/#970 checked three UCD 17.0.0 data files into the repository as generator inputs (`packages/core/scripts/VerticalOrientation.txt`, `packages/docx/scripts/ArabicShaping.txt`, `packages/docx/scripts/DerivedJoiningType.txt`), and the tables generated from them (plus from `LineBreak.txt`/`DerivedGeneralCategory.txt`, fetched at generation time) ship in `dist/`.

Redistribution of UCD data files is expressly permitted by the [Unicode License v3](https://www.unicode.org/license.txt) (SPDX `Unicode-3.0`), conditioned on the copyright and permission notice appearing with the copies or in associated documentation. The checked-in files retain their original `© Unicode®, Inc.` headers; this PR completes strict compliance by adding a dedicated UCD section and the full Unicode License v3 text to `THIRD_PARTY_NOTICES.md`, which is included in the npm tarball — so the notice travels with both the repository copies and the shipped derived tables.

Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)