### PR TITLE
feat(core): substitute vertical forms for ：；〖〗 in vertical text (#969)

### DIFF
--- a/packages/core/src/text/vertical-orientation.test.ts
+++ b/packages/core/src/text/vertical-orientation.test.ts
@@ -87,9 +87,10 @@ describe('verticalFormSubstitute (UAX #50 §5 vertical-form glyph substitution)'
     expect(verticalFormSubstitute(0xff1f)).toBeNull(); // ？
   });
 
-  it('returns null for non-Tu punctuation (Tr rotates, R stays sideways — no substitute)', () => {
-    // ：； and 〖〗 are vo=Tr: the renderer's rotate branch never substitutes.
-    // Substitute-first Tr (FE13/FE14/FE17/FE18) is the #790/#771 follow-up.
+  it('returns null for non-Tu punctuation (Tr substitutes via the OTHER map, R stays sideways)', () => {
+    // ：； and 〖〗 are vo=Tr, so their vertical forms (FE13/FE14/FE17/FE18) live in
+    // verticalBracketFormSubstitute (the Tr map), NOT here — this Tu-only map stays
+    // null for them so the renderer never draws a Tr form on the upright(Tu) path.
     expect(verticalFormSubstitute(0xff1a)).toBeNull(); // ：
     expect(verticalFormSubstitute(0xff1b)).toBeNull(); // ；
     expect(verticalFormSubstitute(0x3016)).toBeNull(); // 〖
@@ -111,7 +112,7 @@ describe('verticalFormSubstitute (UAX #50 §5 vertical-form glyph substitution)'
   });
 });
 
-describe('verticalBracketFormSubstitute (UAX #50 Tr brackets → U+FE30 vertical forms)', () => {
+describe('verticalBracketFormSubstitute (UAX #50 Tr code points → U+FE1x/FE3x vertical forms)', () => {
   it('maps each fullwidth bracket/paren/brace to its U+FE3x vertical form', () => {
     expect(verticalBracketFormSubstitute(0xff08)).toBe(0xfe35); // （ → ︵
     expect(verticalBracketFormSubstitute(0xff09)).toBe(0xfe36); // ） → ︶
@@ -129,6 +130,21 @@ describe('verticalBracketFormSubstitute (UAX #50 Tr brackets → U+FE30 vertical
     expect(verticalBracketFormSubstitute(0x300d)).toBe(0xfe42); // 」 → ﹂
     expect(verticalBracketFormSubstitute(0x300e)).toBe(0xfe43); // 『 → ﹃
     expect(verticalBracketFormSubstitute(0x300f)).toBe(0xfe44); // 』 → ﹄
+  });
+
+  it('maps the vo=Tr fullwidth colon/semicolon and white lenticular brackets to their U+FE1x form (issue #969)', () => {
+    // Word/PowerPoint ground truth (Yu Mincho tbRl + eaVert, PDF-adjudicated):
+    // these vo=Tr code points SUBSTITUTE their U+FE1x vertical presentation form
+    // and draw UPRIGHT — NOT the rotate fallback. The fullwidth colon/semicolon are
+    // vo=Tr punctuation (not brackets) but share the same substitute-first behaviour,
+    // so they live in this Tr map. FE13/FE14 decompose (UnicodeData `<vertical>`) to
+    // the ASCII 003A/003B; vertical Japanese carries the FULLWIDTH forms, so — like
+    // FE10 ← FF0C — the map keys on FF1A/FF1B. FE17/FE18 are the exact `<vertical>`
+    // inverses of the white lenticular brackets 3016/3017.
+    expect(verticalBracketFormSubstitute(0xff1a)).toBe(0xfe13); // ： → ︓ vertical colon
+    expect(verticalBracketFormSubstitute(0xff1b)).toBe(0xfe14); // ； → ︔ vertical semicolon
+    expect(verticalBracketFormSubstitute(0x3016)).toBe(0xfe17); // 〖 → ︗ vertical left white lenticular
+    expect(verticalBracketFormSubstitute(0x3017)).toBe(0xfe18); // 〗 → ︘ vertical right white lenticular
   });
 
   it('returns null for Tr code points with no U+FE30 vertical form (ー, quotes)', () => {

--- a/packages/core/src/text/vertical-orientation.ts
+++ b/packages/core/src/text/vertical-orientation.ts
@@ -91,11 +91,10 @@ export function verticalOrientation(cp: number): VerticalOrientation {
  *     (Hiragino ink at +0.31em cross-axis), so substituting them pushed ！／？ to
  *     the right of the column — the sample-26 "！ shifted right" defect (#771).
  *     PDF ground truth: Word centres ！ (+0.03em), matching the upright original.
- *   • ：FF1A / ；FF1B and 〖3016 / 〗3017 are vo=Tr — the Tr draw branch rotates
- *     them and never consults this map. Making Tr substitute-first (FE13/FE14/
- *     FE17/FE18 here, plus the U+FE35+ forms for fullwidth parens/brackets —
- *     UAX#50's Tr means "substitute a vertical glyph, rotate only as fallback")
- *     is tracked as follow-up in issues #790 / #771.
+ *   • ：FF1A / ；FF1B and 〖3016 / 〗3017 are vo=Tr, so their vertical forms
+ *     (FE13/FE14/FE17/FE18) live in {@link verticalBracketFormSubstitute} (the Tr
+ *     map), NOT here — the Tr draw branch consults that map, and this Tu-only map
+ *     stays null for them (issue #969, following #790 / #771).
  *   • … U+2026 is vo=R — the sideways branch rotates it 90° with the page, so
  *     its three dots already stack vertically, visually equivalent to Word's
  *     vertical ellipsis; no substitution is needed.
@@ -135,16 +134,25 @@ const VERTICAL_FORM_MAP: ReadonlyMap<number, number> = new Map<number, number>([
 ]);
 
 /**
- * DRAW-TIME vertical-form substitution for vo=Tr BRACKETS: the U+FE35–U+FE44
- * "Presentation Forms For Vertical" glyph for a fullwidth paren / corner
- * bracket / angle bracket / brace / lenticular bracket, or `null` when the code
- * point is not one of them (or is a Tr code point with no vertical form).
+ * DRAW-TIME vertical-form substitution for a vo=Tr code point: the U+FE1x/FE3x
+ * vertical presentation glyph to paint instead of `cp`, or `null` when the code
+ * point is not one that has a form (or is a Tr code point with no vertical form).
+ *
+ * Covers, keyed by their horizontal form:
+ *   • the fullwidth parens / corner / angle / brace / tortoise-shell / black-
+ *     lenticular brackets → U+FE35–U+FE44 ("Presentation Forms For Vertical");
+ *   • the fullwidth colon ： / semicolon ； and the WHITE lenticular brackets 〖〗
+ *     → U+FE13/FE14/FE17/FE18 (the U+FE1x "Vertical Forms" block, issue #969).
+ *     The colon/semicolon are vo=Tr PUNCTUATION, not brackets, but they share the
+ *     substitute-first / rotate-fallback behaviour this map encodes, so they live
+ *     here. Word and PowerPoint substitute all four upright (PDF-adjudicated).
  *
  * WHY this is separate from {@link verticalFormSubstitute} (the Tu map): the two
  * fallbacks differ. A Tu code point with no vertical form draws UPRIGHT; a Tr
  * one ROTATES. Keeping the maps distinct lets each draw branch pick the right
  * fallback (see the docx renderer's `drawVerticalRun`) without conflating the
- * two UAX #50 transform classes.
+ * two UAX #50 transform classes. (The name says "Bracket" for its original scope;
+ * it is really "the vo=Tr vertical-form map" — brackets plus ：；.)
  *
  * WHY substitute a Tr bracket at all: UAX #50 §5 defines the Tr transform as
  * "substitute a vertical glyph variant; ROTATE only as the fallback when none is
@@ -160,29 +168,50 @@ const VERTICAL_FORM_MAP: ReadonlyMap<number, number> = new Map<number, number>([
  * `measureText` does NOT expose (it reports the advance box, not the tight ink
  * box). So substitution is what makes metric-driven cell-centring possible.
  *
- * Deliberately NOT here (they are vo=Tr but have no U+FE3x vertical form, so the
- * renderer keeps the rotate fallback):
+ * Deliberately NOT here (they are vo=Tr but have no Unicode vertical presentation
+ * form, so the renderer keeps the rotate fallback):
  *   • ー U+30FC prolonged sound mark
  *   • “ ” U+201C/201D double quotation marks
  *
  * Mapping source: the UnicodeData.txt `<vertical>` compatibility decompositions
- * of the U+FE30 block (each vertical form decomposes to its horizontal bracket).
+ * of the U+FE10 and U+FE30 blocks (each vertical form decomposes to its horizontal
+ * source). FE17/FE18 decompose exactly to 〖/〗; FE13/FE14 decompose to the ASCII
+ * colon/semicolon, but vertical Japanese carries the fullwidth forms, so the map
+ * keys on FF1A/FF1B (as verticalFormSubstitute keys FE10 on FF0C).
  *
  * Renderers apply this ONLY at glyph-draw time (glyph selection): the advance/
  * width, text model, selection, and find/highlight all keep the ORIGINAL code
- * point, so searching for （ still matches a substituted （.
+ * point, so searching for （ or ： still matches a substituted （ / ：.
  *
  * @param cp A Unicode scalar value.
- * @returns The U+FE3x vertical presentation-form code point, or null.
+ * @returns The U+FE1x/FE3x vertical presentation-form code point, or null.
  */
 export function verticalBracketFormSubstitute(cp: number): number | null {
   return VERTICAL_BRACKET_FORM_MAP.get(cp) ?? null;
 }
 
-// vo=Tr fullwidth brackets → U+FE35–U+FE44 "Presentation Forms For Vertical".
-// Keyed on the horizontal bracket; values from the UnicodeData `<vertical>`
-// decompositions. ー (30FC) and the double quotes (201C/201D) are vo=Tr with no
-// vertical form and are absent, so the renderer rotates them.
+// vo=Tr code points → their U+FE1x/FE3x vertical presentation form (drawn upright,
+// rotate only as the fallback for the entries NOT listed here). Values are the
+// UnicodeData `<vertical>` decompositions read backwards.
+//
+// Two groups share this map because they share the vo=Tr substitute-first / rotate-
+// fallback BEHAVIOUR — which is what the renderer keys on — even though the second
+// group is punctuation, not brackets:
+//   1. Fullwidth brackets / parens / braces → U+FE35–FE44 ("Presentation Forms For
+//      Vertical" block). Keyed on the horizontal bracket.
+//   2. The fullwidth colon / semicolon ：； and the white lenticular brackets 〖〗
+//      → the U+FE13/FE14/FE17/FE18 forms in the U+FE1x "Vertical Forms" block
+//      (issue #969). Word and PowerPoint substitute these upright too (Yu Mincho
+//      tbRl + eaVert, PDF-adjudicated): the colon becomes two side-by-side dots
+//      (FE13 — which *looks* rotated but is the vertical form), the semicolon stays
+//      an upright dot-over-comma (FE14 — a 90° rotation could never produce that,
+//      proving substitution), and the lenticular brackets become horizontal bracket
+//      forms (FE17/FE18). FE13/FE14 decompose to the ASCII colon/semicolon
+//      (003A/003B); vertical Japanese carries the FULLWIDTH forms, so — exactly like
+//      FE10 ← FF0C in verticalFormSubstitute — the map keys on FF1A/FF1B.
+//
+// ー (30FC) and the double quotes (201C/201D) are vo=Tr with NO vertical form and are
+// absent, so the renderer rotates them.
 const VERTICAL_BRACKET_FORM_MAP: ReadonlyMap<number, number> = new Map<number, number>([
   [0xff08, 0xfe35], // （ fullwidth left parenthesis  → ︵
   [0xff09, 0xfe36], // ） fullwidth right parenthesis → ︶
@@ -200,4 +229,9 @@ const VERTICAL_BRACKET_FORM_MAP: ReadonlyMap<number, number> = new Map<number, n
   [0x300d, 0xfe42], // 」 right corner bracket         → ﹂
   [0x300e, 0xfe43], // 『 left white corner bracket    → ﹃
   [0x300f, 0xfe44], // 』 right white corner bracket   → ﹄
+  // vo=Tr punctuation + white lenticular brackets in the U+FE1x block (issue #969).
+  [0xff1a, 0xfe13], // ： fullwidth colon              → ︓ vertical colon
+  [0xff1b, 0xfe14], // ； fullwidth semicolon          → ︔ vertical semicolon
+  [0x3016, 0xfe17], // 〖 left white lenticular        → ︗ vertical left white lenticular
+  [0x3017, 0xfe18], // 〗 right white lenticular       → ︘ vertical right white lenticular
 ]);

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -268,6 +268,22 @@ describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin side
     expect(fills.every((f) => f.x === 0 && f.y === 0)).toBe(true);
   });
 
+  it('substitutes the vo=Tr colon/semicolon and white lenticular brackets, drawn UPRIGHT (issue #969)', () => {
+    // Word/PowerPoint ground truth (PDF-adjudicated): ：；〖〗 are vo=Tr with a
+    // U+FE1x vertical form, so they substitute-first and draw upright like the other
+    // brackets — NOT the rotate fallback (the semicolon staying an upright dot-over-
+    // comma is the proof; a rotation could not produce that).
+    const { ctx, ops } = mockCtx();
+    drawVerticalRun(ctx, '：；〖〗', 0, 0, 12, 0);
+    const fills = ops.filter((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fills.map((f) => f.text)).toEqual(['︓', '︔', '︗', '︘']); // FE13/FE14/FE17/FE18
+    // All four are counter-rotated −90° (upright), centred on the column.
+    const rotates = ops.filter((o): o is Extract<Op, { op: 'rotate' }> => o.op === 'rotate');
+    expect(rotates).toHaveLength(4);
+    expect(rotates.every((r) => Math.abs(r.a - -Math.PI / 2) < 1e-9)).toBe(true);
+    expect(fills.every((f) => f.align === 'center' && f.baseline === 'middle')).toBe(true);
+  });
+
   it('substitutes a Tu comma/period with its vertical presentation form (、→︑, 。→︒)', () => {
     const { ctx, ops } = mockCtx();
     drawVerticalRun(ctx, '、。', 0, 0, 12, 0);

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -22,13 +22,15 @@
 //     corner-designed in many fonts and would shift ！？ off-column). Where no
 //     form exists (．, small kana) we draw the original upright unchanged (．
 //     keeps a corner-nudge fallback).
-//   • vo=Tr (transform, fallback rotate): （「」〈〉“”：；〖〗 and the ー prolonged
-//     sound mark. UAX#50's fallback (no vertical glyph available to a Canvas —
-//     the font's `vert`/`vrt2` OpenType feature is not reachable via `fillText`)
-//     is to ROTATE the glyph 90° CW. A plain `fillText` in the +90° page frame is
-//     already that rotation; we draw the glyph CENTRED on the column axis (these
-//     are full-width cells) so the rotated bracket/長音符 sits mid-column.
-//     Substitute-first Tr (FE13/FE14/FE17/FE18, FE35+) is the #790/#771 follow-up.
+//   • vo=Tr (transform, fallback rotate): the fullwidth brackets （「」〈〉【】…, the
+//     white lenticular brackets 〖〗, and the fullwidth colon/semicolon ：； have a
+//     U+FE1x/FE3x vertical presentation form (core `verticalBracketFormSubstitute`);
+//     UAX#50 §5 makes Tr "substitute a vertical glyph, ROTATE only as fallback", so
+//     we SUBSTITUTE and draw them upright (Word/PowerPoint-verified, #969). Only Tr
+//     code points with NO vertical form — the ー prolonged sound mark and the quotes
+//     “” — take the ROTATE fallback: a plain `fillText` in the +90° page frame is
+//     already that 90° CW rotation, drawn CENTRED on the column axis so ー sits
+//     mid-column.
 //   • vo=R  (rotated): Latin letters, Western digits, Latin punctuation. Stay
 //     SIDEWAYS (rotated with the page) — the conventional "縦中横 not applied"
 //     appearance — drawn as an ordinary contextual `fillText` at the alphabetic
@@ -287,7 +289,8 @@ export function drawVerticalRun(
     // Advance/width uses the ORIGINAL code point (measure == draw, and the text
     // model / selection / find keep the original character — see the module doc).
     const adv = ctx.measureText(ch).width * charScale + letterSpacingPx;
-    // A vo=Tr bracket with a Unicode vertical presentation form (（）「」〈〉…) is
+    // A vo=Tr code point with a Unicode vertical presentation form — the brackets
+    // （）「」〈〉… and the colon/semicolon/white-lenticular ：；〖〗 (#969) — is
     // SUBSTITUTED and drawn upright, exactly like the upright cells — UAX#50 §5
     // Tr means "substitute a vertical glyph; rotate only as fallback". Only Tr
     // code points with NO vertical form (ー, quotes “”) keep the rotate fallback.

--- a/packages/pptx/src/eavert-glyph-orientation.test.ts
+++ b/packages/pptx/src/eavert-glyph-orientation.test.ts
@@ -38,6 +38,13 @@ const TR_BRACKET_FE = String.fromCodePoint(0xfe35); // ︵
 const TU_COMMA = '、'; // vo=Tu → substitute U+FE11, upright
 const TU_COMMA_FE = String.fromCodePoint(0xfe11);
 const TR_ROTATE = 'ー'; // vo=Tr, no vertical form → rotate 90°
+// vo=Tr punctuation / white lenticular brackets with a U+FE1x form (issue #969).
+const TR_VFORMS: Array<[string, string]> = [
+  ['：', String.fromCodePoint(0xfe13)], // fullwidth colon → ︓
+  ['；', String.fromCodePoint(0xfe14)], // fullwidth semicolon → ︔
+  ['〖', String.fromCodePoint(0xfe17)], // left white lenticular → ︗
+  ['〗', String.fromCodePoint(0xfe18)], // right white lenticular → ︘
+];
 
 interface DrawCall {
   text: string;
@@ -177,6 +184,17 @@ describe('pptx eaVert — UAX#50 per-glyph orientation (§20.1.10.83, issue #790
     expect(fe.length, 'the U+FE11 vertical form is painted').toBe(1);
     expect(norm(fe[0].rot)).toBeCloseTo(UPRIGHT, 5);
   });
+
+  it.each(TR_VFORMS)(
+    'SUBSTITUTES the vo=Tr colon/semicolon/lenticular %s with its U+FE1x vertical form, drawn upright (issue #969)',
+    (orig, fe) => {
+      const calls = renderEaVert(orig);
+      expect(calls.some((c) => c.text === orig), `original ${orig} is not painted`).toBe(false);
+      const sub = calls.filter((c) => c.text === fe);
+      expect(sub.length, `the vertical form ${fe} is painted`).toBe(1);
+      expect(norm(sub[0].rot), 'substituted form is upright').toBeCloseTo(UPRIGHT, 5);
+    },
+  );
 
   it('ROTATES a vo=Tr glyph with no vertical form (ー U+30FC) with the page (+90°)', () => {
     const calls = renderEaVert(TR_ROTATE);

--- a/packages/pptx/src/vertical-text.ts
+++ b/packages/pptx/src/vertical-text.ts
@@ -17,12 +17,13 @@
 //     `verticalFormSubstitute`) and drawn upright, so the font supplies the
 //     designed upper-right placement; ！？ and small kana have no form and draw
 //     upright unchanged.
-//   • vo=Tr (transform, fallback rotate): the fullwidth brackets （「」〈〉【】…
-//     have a U+FE35–FE44 vertical presentation form (core
-//     `verticalBracketFormSubstitute`); UAX#50 §5 makes Tr "substitute a vertical
-//     glyph, ROTATE only as fallback", so we substitute and draw them upright.
-//     The prolonged sound mark ー (U+30FC) and the quotation marks “” have no
-//     vertical form, so they take the rotate fallback (drawn with the page).
+//   • vo=Tr (transform, fallback rotate): the fullwidth brackets （「」〈〉【】…, the
+//     white lenticular brackets 〖〗, and the fullwidth colon/semicolon ：； have a
+//     U+FE1x/FE3x vertical presentation form (core `verticalBracketFormSubstitute`);
+//     UAX#50 §5 makes Tr "substitute a vertical glyph, ROTATE only as fallback", so
+//     we substitute and draw them upright (Word/PowerPoint-verified, #969). The
+//     prolonged sound mark ー (U+30FC) and the quotation marks “” have no vertical
+//     form, so they take the rotate fallback (drawn with the page).
 //   • vo=R  (rotated): Latin letters, Western digits, Latin punctuation stay
 //     SIDEWAYS (rotated with the page) — the conventional "縦中横 not applied" look.
 //
@@ -141,7 +142,8 @@ export function drawEaVertRun(
     // Advance/width uses the ORIGINAL code point (measure == draw; the text model,
     // selection and find keep the original character — substitution is glyph-only).
     const adv = ctx.measureText(ch).width + letterSpacingPx;
-    // A vo=Tr bracket with a Unicode vertical presentation form is substituted and
+    // A vo=Tr code point with a Unicode vertical presentation form — brackets （「」…
+    // and the colon/semicolon/white-lenticular ：；〖〗 (#969) — is substituted and
     // drawn UPRIGHT (UAX#50 §5 substitute-first); only Tr code points with NO form
     // (ー, quotes) take the rotate fallback.
     const bracketCp = vo === 'Tr' ? verticalBracketFormSubstitute(cp) : null;

--- a/packages/xlsx/src/stacked-glyph-orientation.test.ts
+++ b/packages/xlsx/src/stacked-glyph-orientation.test.ts
@@ -32,6 +32,15 @@ const TR_BRACKET_FE = String.fromCodePoint(0xfe35); // ︵
 const TU_COMMA = '、';
 const TU_COMMA_FE = String.fromCodePoint(0xfe11);
 const TR_ROTATE = 'ー'; // U+30FC — no vertical form → rotate
+// vo=Tr punctuation / white lenticular brackets with a U+FE1x form (issue #969).
+// XLSX has no Excel ground-truth image; it follows the Word/PowerPoint verdict
+// (docx tbRl + pptx eaVert, PDF-adjudicated) since the classifier is shared.
+const TR_VFORMS: Array<[string, string]> = [
+  ['：', String.fromCodePoint(0xfe13)], // fullwidth colon → ︓
+  ['；', String.fromCodePoint(0xfe14)], // fullwidth semicolon → ︔
+  ['〖', String.fromCodePoint(0xfe17)], // left white lenticular → ︗
+  ['〗', String.fromCodePoint(0xfe18)], // right white lenticular → ︘
+];
 
 interface DrawCall {
   text: string;
@@ -106,6 +115,16 @@ describe('xlsx stacked text — UAX#50 per-glyph orientation (textRotation=255, 
     expect(calls[0].text).toBe(TU_COMMA_FE);
     expect(norm(calls[0].rot)).toBeCloseTo(UPRIGHT, 5);
   });
+
+  it.each(TR_VFORMS)(
+    'SUBSTITUTES the vo=Tr colon/semicolon/lenticular %s with its U+FE1x vertical form, upright (issue #969)',
+    (orig, fe) => {
+      const calls = draw(orig);
+      expect(calls.length).toBe(1);
+      expect(calls[0].text, `the vertical form ${fe} replaces ${orig}`).toBe(fe);
+      expect(norm(calls[0].rot)).toBeCloseTo(UPRIGHT, 5);
+    },
+  );
 
   it('ROTATES a vo=Tr glyph with no vertical form (ー) by 90°', () => {
     const calls = draw(TR_ROTATE);

--- a/packages/xlsx/src/vertical-text.ts
+++ b/packages/xlsx/src/vertical-text.ts
@@ -13,9 +13,11 @@
 //   • vo=Tu with a U+FE10–FE12 vertical form (、。，) → SUBSTITUTE that form
 //     (core `verticalFormSubstitute`), drawn upright so the font hangs it in the
 //     cell's upper-right corner; ！？ and small kana have no form and draw upright.
-//   • vo=Tr with a U+FE35–FE44 vertical form (（）「」〈〉【】…) → SUBSTITUTE that form
-//     (core `verticalBracketFormSubstitute`), drawn upright (UAX#50 §5
-//     "substitute a vertical glyph, rotate only as fallback").
+//   • vo=Tr with a U+FE1x/FE3x vertical form — the brackets （）「」〈〉【】…, the white
+//     lenticular brackets 〖〗, and the fullwidth colon/semicolon ：； (#969) →
+//     SUBSTITUTE that form (core `verticalBracketFormSubstitute`), drawn upright
+//     (UAX#50 §5 "substitute a vertical glyph, rotate only as fallback"). XLSX has
+//     no Excel ground-truth image, so ：；〖〗 follow the Word/PowerPoint verdict.
 //   • vo=Tr with NO vertical form (ー U+30FC, quotes “”) → ROTATE the glyph 90° CW
 //     (the Tr fallback) so ー becomes the vertical bar Excel draws.
 
@@ -57,9 +59,10 @@ export function drawStackedVerticalChar(
   const vo = verticalOrientation(cp);
 
   if (vo === 'Tr') {
-    // Substitute-first: a fullwidth bracket has a U+FE35–FE44 vertical form drawn
-    // UPRIGHT (UAX#50 §5). It fills the cell like an ideograph, so the caller's
-    // center/top placement lands it correctly.
+    // Substitute-first: a fullwidth bracket, white lenticular bracket, or the
+    // colon/semicolon ：；〖〗 (#969) has a U+FE1x/FE3x vertical form drawn UPRIGHT
+    // (UAX#50 §5). It fills the cell like an ideograph, so the caller's center/top
+    // placement lands it correctly.
     const bracket = verticalBracketFormSubstitute(cp);
     if (bracket !== null) {
       ctx.fillText(String.fromCodePoint(bracket), centerX, cellTopY);


### PR DESCRIPTION
## Summary

Adds the vertical presentation forms for the fullwidth colon/semicolon and the white lenticular brackets to the shared UAX#50 vo=Tr substitution map, so all three vertical-text renderers substitute them upright instead of falling back to rotation:

- `：` U+FF1A → FE13 (vertical colon)
- `；` U+FF1B → FE14 (vertical semicolon)
- `〖` U+3016 → FE17 (vertical left white lenticular)
- `〗` U+3017 → FE18 (vertical right white lenticular)

The docx tbRl, pptx eaVert, and xlsx stacked renderers already route vo=Tr through `verticalBracketFormSubstitute` and draw the substituted form upright, so a single core-map addition flips all three consumers. No consumer logic changed.

## Ground-truth adjudication

Rendered synthetic Word `tbRl` and PowerPoint `eaVert` fixtures (Yu Mincho) to PDF and inspected every punctuation glyph at 300 dpi against the settled controls (、。「」ー) in the same column, plus tight ink-box measurement.

**Verdict: all four are SUBSTITUTED (U+FE1x vertical form, upright) — not rotated, not left as original. Word and PowerPoint agree exactly.**

| char | renders as | interior ink AR | form |
|------|-----------|-----------------|------|
| `：` | two dots side-by-side, centred | 3.67 (horizontal) | FE13 |
| `；` | dot-over-comma, upright | 0.23 (vertical) | FE14 |
| `〖` | horizontal bracket (leading edge) | 3.00 (horizontal) | FE17 |
| `〗` | horizontal bracket (trailing edge) | 3.69 (horizontal) | FE18 |

**Why substitution, not rotation.** The semicolon is decisive: it stays an upright dot-over-comma, which a 90° rotation could never produce, so the renderer is not applying the Tr rotate fallback. The colon is the trap the fixture notes flagged — FE13 is designed as two *horizontal* dots, so a substituted colon *looks* rotated, but its shape is FE13, not the upright original FF1A (two *vertical* dots). Matches UAX#50 §5 (Tr = substitute-first, rotate only as fallback). No Word/PowerPoint deviation from the Tr default was observed. Full measurement record: issue #969 comment.

## XLSX note

XLSX (Excel stacked, `textRotation=255`) has no Excel ground-truth image. Since the classifier is shared and Word/PowerPoint agree, XLSX follows the same verdict; documented in the code and tests.

## Tests / gates

- Core map: new assertions FF1A→FE13, FF1B→FE14, 3016→FE17, 3017→FE18 (TDD Red→Green).
- Per-consumer draw tests: docx `drawVerticalRun`, pptx `drawEaVertRun` (+ full eaVert render), xlsx `drawStackedVerticalChar` each assert the four substitute upright.
- `pnpm typecheck` green; ast-grep lint clean (no new warnings).
- Full vitest for core/docx/pptx/xlsx green (3 unrelated compute-heavy tests were load-flaky timeouts; pass in isolation).
- docx demo VRT (10) + pptx demo VRT (14) green — horizontal path byte-identical (the map is only consulted on the vertical draw branches). No VRT baseline can change: the only vertical VRT sample (docx sample-26) contains none of the four code points.
- Independent review by Codex gpt-5.6-sol (read-only): no blockers, no should-fix; confirmed mappings correct/not transposed, original code points preserved for measure/selection/find, surrogates intact, horizontal unchanged. One nit (imprecise "U+FE3x" comment) fixed.

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)
