### PR TITLE
feat(text): break at no-space SEA↔Latin/CJK/digit transitions and mixed CJK+SEA runs

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -377,9 +377,12 @@ export {
 export {
   type SeaScript,
   type SeaWordSegmenter,
+  type SeaMixedKinsoku,
   isSeaScriptCodePoint,
   containsSeaScript,
   seaWordBreakOffsets,
+  seaTransitionOffsets,
+  seaMixedBreakOffsets,
   fitSeaWordPrefix,
   graphemeClusterOffsets,
   setSeaWordSegmenterForTest,

--- a/packages/core/src/text/sea-break.test.ts
+++ b/packages/core/src/text/sea-break.test.ts
@@ -5,9 +5,12 @@ import {
   graphemeClusterOffsets,
   isSeaScriptCodePoint,
   resetSeaSegmenterForTest,
+  seaMixedBreakOffsets,
+  seaTransitionOffsets,
   seaWordBreakOffsets,
   setSeaWordSegmenterForTest,
 } from './sea-break.js';
+import { DEFAULT_KINSOKU_RULES } from './kinsoku/rules.js';
 
 afterEach(() => resetSeaSegmenterForTest());
 
@@ -133,6 +136,129 @@ describe('seaWordBreakOffsets — graceful fallback + filtering (injected segmen
     const text = 'ก'.repeat(9);
     // index 0 excluded (span-start); index 4 excluded (punctuation); index 5 kept.
     expect(seaWordBreakOffsets(text)).toEqual([5]);
+  });
+});
+
+describe('seaTransitionOffsets (issue #960 — no-space SEA↔non-SEA seams)', () => {
+  it('offsets each SEA↔Latin transition edge (both entering and leaving SEA)', () => {
+    const text = 'เมืองBangkokคือ'; // Thai | Latin | Thai
+    const bangkok = text.indexOf('B'); // Thai→Latin
+    const afterBangkok = bangkok + 'Bangkok'.length; // Latin→Thai
+    expect(seaTransitionOffsets(text)).toEqual([bangkok, afterBangkok]);
+  });
+
+  it('offsets Thai↔digit seams so a price like 1250 can break away from Thai', () => {
+    const text = 'ราคา1250บาท'; // Thai | 1250 | Thai
+    const d = text.indexOf('1');
+    const afterD = d + '1250'.length;
+    expect(seaTransitionOffsets(text)).toEqual([d, afterD]);
+  });
+
+  it('offsets Thai↔CJK seams', () => {
+    const text = 'อาหาร寿司ราเมง'; // Thai | CJK | Thai
+    const cjk = text.indexOf('寿');
+    const afterCjk = text.indexOf('ร', cjk);
+    expect(seaTransitionOffsets(text)).toEqual([cjk, afterCjk]);
+  });
+
+  it('never offsets a seam that touches whitespace (the space is the break)', () => {
+    const text = 'ทดสอบ ABC ภาษา'; // Thai SPACE Latin SPACE Thai
+    // The only SEA↔non-SEA changes are across spaces → no transition offsets.
+    expect(seaTransitionOffsets(text)).toEqual([]);
+  });
+
+  it('is empty for pure SEA and for non-SEA input', () => {
+    expect(seaTransitionOffsets('ภาษาไทย')).toEqual([]);
+    expect(seaTransitionOffsets('Hello123')).toEqual([]);
+    expect(seaTransitionOffsets('')).toEqual([]);
+  });
+
+  it('stays on UTF-16 boundaries after an astral non-SEA char', () => {
+    const text = '😀ภาษา'; // emoji (2 units) → Thai
+    expect(seaTransitionOffsets(text)).toEqual(['😀'.length]);
+  });
+
+  it('every offset is strictly interior and separates SEA from non-SEA', () => {
+    const text = 'เมืองBangkokคือ寿司ราคา1250บาท';
+    for (const o of seaTransitionOffsets(text)) {
+      expect(o).toBeGreaterThan(0);
+      expect(o).toBeLessThan(text.length);
+      const a = isSeaScriptCodePoint(text.codePointAt(o - 1)!);
+      const b = isSeaScriptCodePoint(text.codePointAt(o)!);
+      expect(a).not.toBe(b); // one side SEA, the other not
+    }
+  });
+});
+
+describe('seaMixedBreakOffsets (issue #960 — unified dict ∪ transition ∪ CJK)', () => {
+  it('equals seaWordBreakOffsets for a pure-SEA token (byte-identical wrap)', () => {
+    const text = 'ภาษาไทยเป็นภาษาที่สวยงามมาก';
+    expect(seaMixedBreakOffsets(text)).toEqual(seaWordBreakOffsets(text));
+    expect(seaMixedBreakOffsets(text, { cjk: true })).toEqual(seaWordBreakOffsets(text));
+  });
+
+  it('adds the transition seams on top of the dictionary boundaries (Thai↔Latin)', () => {
+    const text = 'เมืองBangkokคือเมืองหลวงของThailand';
+    const merged = seaMixedBreakOffsets(text);
+    for (const o of seaTransitionOffsets(text)) expect(merged).toContain(o);
+    for (const o of seaWordBreakOffsets(text)) expect(merged).toContain(o);
+    // Sorted, unique, interior.
+    for (let k = 1; k < merged.length; k++) expect(merged[k]).toBeGreaterThan(merged[k - 1]);
+  });
+
+  it('adds CJK per-character opportunities only when cjk:true (mixed CJK+SEA)', () => {
+    const text = '日本語のテキストとภาษาไทยが同じ';
+    const withoutCjk = seaMixedBreakOffsets(text);
+    const withCjk = seaMixedBreakOffsets(text, { cjk: true });
+    expect(withCjk.length).toBeGreaterThan(withoutCjk.length);
+    // A break BEFORE an interior ideograph (e.g. before 本 in 日本) is present.
+    const between = 1; // 日|本
+    expect(isSeaScriptCodePoint(text.codePointAt(0)!)).toBe(false);
+    expect(withCjk).toContain(between);
+    // The SEA span still breaks at its own dictionary boundaries, not mid-cluster.
+    for (const o of seaWordBreakOffsets(text)) expect(withCjk).toContain(o);
+  });
+
+  it('removes kinsoku-illegal positions (no line-start-forbidden char at a head)', () => {
+    // 。is line-start-forbidden: an offset BEFORE it must be dropped.
+    const text = 'ภาษา。日本'; // Thai | 。 | CJK
+    const dot = text.indexOf('。');
+    const withKinsoku = seaMixedBreakOffsets(text, { cjk: true, kinsoku: DEFAULT_KINSOKU_RULES });
+    expect(withKinsoku).not.toContain(dot); // never start a line with 。
+    const withoutKinsoku = seaMixedBreakOffsets(text, { cjk: true });
+    expect(withoutKinsoku).toContain(dot); // the raw seam existed before filtering
+  });
+
+  it('does NOT filter when kinsoku is disabled (§17.3.1.16 <w:kinsoku w:val="0"/>)', () => {
+    const text = 'ภาษา。日本';
+    const dot = text.indexOf('。');
+    const disabled = { ...DEFAULT_KINSOKU_RULES, enabled: false };
+    // enabled:false mirrors the CJK path's `if (!rules.enabled) return` — the
+    // 。 seam survives even though 。 is in the forbidden set.
+    expect(seaMixedBreakOffsets(text, { cjk: true, kinsoku: disabled })).toContain(dot);
+  });
+
+  it('keeps every offset on a grapheme-cluster boundary (no base+mark/VS/ZWJ tear)', () => {
+    // 漢 + VARIATION SELECTOR-1 (U+FE00) is ONE grapheme; the CJK enumerator would
+    // otherwise offer a break at index 1, inside the cluster.
+    const vs = '漢︀ภาษาไทย';
+    const graphemes = new Set(graphemeClusterOffsets(vs));
+    for (const o of seaMixedBreakOffsets(vs, { cjk: true })) expect(graphemes.has(o)).toBe(true);
+    expect(seaMixedBreakOffsets(vs, { cjk: true })).not.toContain(1); // never mid 漢︀
+    // Thai base + ZWJ + Thai: the ZWJ seam (index 1) must not be offered.
+    const zwj = 'ก‍า';
+    for (const o of seaMixedBreakOffsets(zwj, { cjk: true })) expect(new Set(graphemeClusterOffsets(zwj)).has(o)).toBe(true);
+  });
+
+  it('never breaks beside a non-breaking space (NBSP family)', () => {
+    // Thai NBSP Latin — the NBSP is non-breaking, so neither seam is offered.
+    expect(seaTransitionOffsets('ภาษา Bangkok')).toEqual([]);
+    expect(seaTransitionOffsets('ราคา 1250')).toEqual([]);
+  });
+
+  it('is empty for non-SEA input regardless of options', () => {
+    expect(seaMixedBreakOffsets('日本語ABC', { cjk: true })).toEqual([]);
+    expect(seaMixedBreakOffsets('')).toEqual([]);
   });
 });
 

--- a/packages/core/src/text/sea-break.ts
+++ b/packages/core/src/text/sea-break.ts
@@ -19,8 +19,13 @@
 //     offsets and the caller keeps its current cluster/character behaviour.
 //
 // Scope: Thai U+0E00–0E7F, Lao U+0E80–0EFF, Khmer U+1780–17FF — exactly the
-// ranges named in the issue. Myanmar/Tibetan and the no-space Thai↔Latin/CJK
-// script-transition boundary are intentionally out of scope (follow-ups).
+// ranges named in the issue. Myanmar/Tibetan remain out of scope (follow-up
+// #961). The no-space SEA↔Latin/CJK/digit script-transition boundary (#960) is
+// added by {@link seaTransitionOffsets}; {@link seaMixedBreakOffsets} unions the
+// dictionary, transition and CJK per-character opportunities for a single run
+// that mixes SEA with Latin/digits/CJK.
+
+import { isCjkBreakChar } from './cjk-ranges.js';
 
 /** Southeast-Asian dictionary-break script tags used to pick the ICU dictionary.
  *  ICU dispatches the dictionary by the character's SCRIPT, not by this locale,
@@ -181,6 +186,156 @@ export function seaWordBreakOffsets(text: string): number[] {
     i = j;
   }
   return offsets;
+}
+
+// ── Script-transition break opportunities (issue #960) ───────────────────────
+
+/**
+ * Break-before offsets at the EDGES of every maximal SEA span — the SEA↔non-SEA
+ * script transitions that carry NO intervening whitespace (issue #960). Word
+ * treats these transitions as line-break opportunities (adjudicated against the
+ * Word-exported ground truth sample-45.pdf: a line broke exactly at the Thai→
+ * Latin boundary `…ของ | Thailand`, carrying the Latin word whole to the next
+ * line; digit groups `1250`/`990` break away from the surrounding Thai the same
+ * way). {@link seaWordBreakOffsets} deliberately restricts itself to boundaries
+ * INTERIOR to a SEA span, so the transition edges were previously unbreakable —
+ * a spaceless mix like `เมืองBangkok…Thailand` had no legal break at the script
+ * seam. This adds exactly those seams.
+ *
+ * Returns UTF-16 offsets `i` (a break is permitted immediately BEFORE `text[i]`),
+ * strictly interior (`0 < i < text.length`), ascending and unique. A transition
+ * where either side is whitespace is skipped — a space is already an inter-word
+ * break, so the seam beside it needs no extra opportunity. Returns `[]` when
+ * `text` has no SEA character (byte-identical non-SEA path).
+ */
+export function seaTransitionOffsets(text: string): number[] {
+  if (!containsSeaScript(text)) return [];
+  const offsets: number[] = [];
+  const len = text.length;
+  let prevCp = text.codePointAt(0)!;
+  let i = prevCp > 0xffff ? 2 : 1;
+  while (i < len) {
+    const cp = text.codePointAt(i)!;
+    const step = cp > 0xffff ? 2 : 1;
+    const prevSea = isSeaScriptCodePoint(prevCp);
+    const curSea = isSeaScriptCodePoint(cp);
+    // A SEA↔non-SEA change is a transition. Skip when either side is whitespace
+    // (the space itself is the break opportunity, handled by the caller).
+    if (prevSea !== curSea && !isBreakInertSpaceCp(prevCp) && !isBreakInertSpaceCp(cp)) {
+      offsets.push(i);
+    }
+    prevCp = cp;
+    i += step;
+  }
+  return offsets;
+}
+
+/** Code points beside which a SEA↔non-SEA seam must NOT gain a break: real
+ *  whitespace (the space itself already IS the break) and the non-breaking space
+ *  family (NBSP U+00A0, figure space U+2007, narrow NBSP U+202F, word joiner
+ *  U+2060, ZWNBSP/BOM U+FEFF), which are explicitly NON-breaking (UAX#14 GL/WJ). */
+function isBreakInertSpaceCp(cp: number): boolean {
+  return (
+    cp === 0x20 || cp === 0x09 || cp === 0x0a || cp === 0x0d || cp === 0x3000 ||
+    cp === 0x00a0 || cp === 0x2007 || cp === 0x202f || cp === 0x2060 || cp === 0xfeff
+  );
+}
+
+/** Kinsoku sets used to drop line-break positions that would leave a
+ *  line-start-forbidden char at a line head or a line-end-forbidden char at a
+ *  line tail (ECMA-376 §17.15.1.58–.60). Shape-compatible with the renderers'
+ *  `KinsokuRules`; only the two membership sets are consulted. */
+export interface SeaMixedKinsoku {
+  /** When `false`, the document turned kinsoku OFF (§17.3.1.16 `<w:kinsoku
+   *  w:val="0"/>`) and NO position is dropped — matching the CJK path's own
+   *  `if (!rules.enabled) return` short-circuit. Absent/`true` ⇒ filter. */
+  enabled?: boolean;
+  lineStartForbidden: ReadonlySet<number>;
+  lineEndForbidden: ReadonlySet<number>;
+}
+
+/**
+ * The UNIFIED break-before offset set for a single run/segment that contains SEA
+ * script but may also mix Latin, digits and CJK (issue #960). Unions three
+ * opportunity sources so each script keeps its own rule inside one contiguous
+ * token:
+ *   • SEA dictionary word boundaries — {@link seaWordBreakOffsets};
+ *   • SEA↔non-SEA transitions — {@link seaTransitionOffsets};
+ *   • CJK per-character boundaries when `opts.cjk` — every position whose char,
+ *     or the char before it, is a {@link isCjkBreakChar} ideograph, so the CJK
+ *     side breaks at each character exactly as its dedicated path does.
+ *
+ * When `opts.kinsoku` is supplied, positions that would orphan a
+ * line-start-forbidden char at a line head, or leave a line-end-forbidden char
+ * at a line tail, are removed (the offset-set equivalent of the CJK path's
+ * retract). This is what lets a mixed CJK+SEA token — which previously fell
+ * wholly onto the CJK path and so treated its SEA interior as unbreakable — wrap
+ * with BOTH the CJK per-char opportunities and the SEA dictionary/transition
+ * opportunities merged.
+ *
+ * Offsets are ascending, unique, strictly interior. For a pure-SEA token with no
+ * kinsoku char this equals {@link seaWordBreakOffsets} (byte-identical wrap).
+ */
+export function seaMixedBreakOffsets(
+  text: string,
+  opts?: { cjk?: boolean; kinsoku?: SeaMixedKinsoku },
+): number[] {
+  if (!containsSeaScript(text)) return [];
+  const len = text.length;
+  // Dictionary boundaries are ALWAYS grapheme-cluster boundaries (ICU never
+  // splits a base + mark), so seed the set with them directly.
+  const set = new Set<number>(seaWordBreakOffsets(text));
+  // The transition and CJK offsets are enumerated per code point, so they could
+  // land INSIDE a grapheme cluster (a base + variation selector / ZWJ / tone
+  // mark). Collect them separately and keep only those that coincide with a
+  // grapheme boundary — a code-point split there would tear the cluster.
+  const graphemeSafe = new Set<number>(graphemeClusterOffsets(text));
+  const addGraphemeSafe = (o: number): void => {
+    if (graphemeSafe.has(o)) set.add(o);
+  };
+  for (const o of seaTransitionOffsets(text)) addGraphemeSafe(o);
+  if (opts?.cjk) {
+    let prevCp = text.codePointAt(0)!;
+    let i = prevCp > 0xffff ? 2 : 1;
+    while (i < len) {
+      const cp = text.codePointAt(i)!;
+      // A break may fall before an ideograph or after one (CJK is break-eligible
+      // on both edges; the grapheme test above drops a variation-selector tear,
+      // and the kinsoku pass below removes the illegal ones).
+      if (isCjkBreakChar(cp) || isCjkBreakChar(prevCp)) addGraphemeSafe(i);
+      prevCp = cp;
+      i += cp > 0xffff ? 2 : 1;
+    }
+  }
+  const k = opts?.kinsoku;
+  // §17.3.1.16 — a document that turned kinsoku OFF drops NO position (mirrors
+  // the CJK split path's `if (!rules.enabled) return`).
+  const filterKinsoku = k != null && k.enabled !== false;
+  const out: number[] = [];
+  for (const o of set) {
+    if (o <= 0 || o >= len) continue;
+    if (filterKinsoku) {
+      const at = text.codePointAt(o)!;
+      const before = codePointEndingAt(text, o);
+      if (before !== undefined && k!.lineEndForbidden.has(before)) continue;
+      if (k!.lineStartForbidden.has(at)) continue;
+    }
+    out.push(o);
+  }
+  out.sort((a, b) => a - b);
+  return out;
+}
+
+/** The code point that ENDS immediately before UTF-16 offset `o` (handles a
+ *  trailing surrogate pair). `undefined` when `o` is at or before the start. */
+function codePointEndingAt(text: string, o: number): number | undefined {
+  if (o <= 0) return undefined;
+  const lo = text.charCodeAt(o - 1);
+  if (lo >= 0xdc00 && lo <= 0xdfff && o >= 2) {
+    const hi = text.charCodeAt(o - 2);
+    if (hi >= 0xd800 && hi <= 0xdbff) return text.codePointAt(o - 2)!;
+  }
+  return lo;
 }
 
 // ── Greedy whole-word line fit (shared kernel) ───────────────────────────────

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -32,7 +32,7 @@ import {
   isCjkBreakChar,
   isUax14NoBreakPair,
   containsSeaScript,
-  seaWordBreakOffsets,
+  seaMixedBreakOffsets,
   fitSeaWordPrefix,
   graphemeClusterOffsets,
   classifyFontGeneric,
@@ -2673,11 +2673,17 @@ export function layoutLines(
   const endBoundary: LineBoundary = { segIndex: segs.length, charOffset: 0 };
   const sourcedSegs = segs.map((seg, segIndex) => {
     seg.src = { segIndex, charOffset: 0 };
-    // Issue #797 — attach the SEA (Thai/Lao/Khmer) dictionary word-break offsets
-    // ONCE per segment (perf: never per line/char). Only for SEA text; non-SEA
-    // segments keep `seaBreaks` absent so their wrap path is byte-identical.
+    // Issue #797 / #960 — attach the SEA (Thai/Lao/Khmer) break offsets ONCE per
+    // segment (perf: never per line/char). Only for SEA text; non-SEA segments
+    // keep `seaBreaks` absent so their wrap path is byte-identical. The set now
+    // UNIONS the dictionary word boundaries (#797) with the no-space SEA↔non-SEA
+    // script transitions and, for a mixed CJK+SEA run (a `<w:cs/>` run keeps CJK
+    // in the same cs segment), the CJK per-character opportunities — so each
+    // script keeps its own break rule inside one contiguous segment (#960). The
+    // layout kinsoku set (§17.15.1.58–.60) drops positions that would orphan a
+    // forbidden char at a line head/tail, replacing the CJK path's retract.
     if ('text' in seg && containsSeaScript(seg.text)) {
-      seg.seaBreaks = seaWordBreakOffsets(seg.text);
+      seg.seaBreaks = seaMixedBreakOffsets(seg.text, { cjk: true, kinsoku });
     }
     return seg;
   });
@@ -3162,8 +3168,12 @@ export function layoutLines(
       // Fits on current line as-is
       s.measuredWidth = w;
       addToLine(s, w, h, asc, desc, trailingSpaceW);
-    } else if (hasCJKBreakOpportunity(s.text)) {
+    } else if (hasCJKBreakOpportunity(s.text) && s.seaBreaks === undefined) {
       // CJK overflow: split at the maximum prefix that fits, re-queue the tail.
+      // A segment that ALSO contains SEA (a mixed CJK+SEA `<w:cs/>` run) is routed
+      // to the SEA branch below instead — its `seaBreaks` already merges the CJK
+      // per-character opportunities with the SEA dictionary/transition ones
+      // (issue #960), so both scripts break by their own rule from one offset set.
       // (pptx's analogous CJK fit is cjk-wrap.ts `fitCjkLine`, kept intentionally
       //  separate: it sums per-char advances, whereas this path uses substring
       //  binary-search + the cross-run 追い出し below. Don't naively unify them.)
@@ -3271,17 +3281,19 @@ export function layoutLines(
         }
       }
     } else if (s.seaBreaks !== undefined) {
-      // SEA (Thai/Lao/Khmer) dictionary line wrap (issue #797). These scripts
-      // have no inter-word spaces, so this ONE segment is a whole run of words;
-      // break it only at a segmenter word boundary (`s.seaBreaks`). Entered for
-      // ANY SEA segment (even one with no dictionary boundary — a single word
-      // wider than the column, or Segmenter unavailable) so the emergency split
-      // below stays GRAPHEME-safe instead of falling to the code-point path.
-      // No kinsoku runs here — SEA scripts have no 行頭/行末禁則 sets and a
-      // dictionary boundary is already a legal break (choosing an earlier legal
-      // offset is the only adjustment, which fitSeaWordPrefix already does). The
-      // run stays one contiguous draw per line (measure==paint); the tail
-      // re-queues with its offsets rebased.
+      // SEA (Thai/Lao/Khmer) line wrap (issue #797 / #960). These scripts have no
+      // inter-word spaces, so this ONE segment is a whole run; break it only at a
+      // member of `s.seaBreaks` — the UNION of dictionary word boundaries, the
+      // no-space SEA↔non-SEA script transitions, and (for a mixed CJK+SEA `<w:cs/>`
+      // run) the CJK per-character opportunities, already kinsoku-filtered by
+      // `seaMixedBreakOffsets`. Entered for ANY SEA segment (even one with no
+      // boundary — a single word wider than the column, or Segmenter unavailable)
+      // so the emergency split below stays GRAPHEME-safe instead of falling to the
+      // code-point path. Kinsoku 行頭/行末禁則 was applied when the offsets were
+      // built (so a forbidden CJK char never heads/tails a line); choosing an
+      // earlier legal offset is the only remaining adjustment, which
+      // fitSeaWordPrefix already does. The run stays one contiguous draw per line
+      // (measure==paint); the tail re-queues with its offsets rebased.
       const available = availW() - currentWidth;
       const measureSub = (sub: string): number => strAdvance(s, sub);
       const split = fitSeaWordPrefix(s.text, s.seaBreaks, 0, available, measureSub);
@@ -3300,10 +3312,47 @@ export function layoutLines(
           });
         }
       } else if (currentLine.length > 0) {
-        // No whole dictionary word fits the remaining band — move the run to a
-        // fresh line and re-process (Latin-word style).
-        flush(undefined, false, s.src);
+        // No whole word fits the remaining band — move the run to a fresh line and
+        // re-process (Latin-word style). If `s` would then LEAD the next line with
+        // a 行頭禁則 char (a mixed CJK+SEA run whose first glyph is a forbidden
+        // leader — #960 routes it here, where the offset set cannot fix a
+        // segment-initial char), pull trailing graphemes of the current line's
+        // last text segment down so they lead ahead of `s` — the same cross-run
+        // 追い出し (§17.3.1.16) the CJK branch does.
+        let retracted: LayoutTextSeg | null = null;
+        const sFirstCp = s.text.codePointAt(0);
+        const lastSeg = currentLine[currentLine.length - 1];
+        if (sFirstCp !== undefined && kinsoku.lineStartForbidden.has(sFirstCp) && 'text' in lastSeg) {
+          const lastText = lastSeg as LayoutTextSeg;
+          const chars = [...lastText.text];
+          const minKeep = currentLine.length > 1 ? 0 : 1;
+          const k = crossRunKinsokuRetract(chars, kinsoku, minKeep);
+          if (k > 0) {
+            const headText = chars.slice(0, chars.length - k).join('');
+            const tailText = chars.slice(chars.length - k).join('');
+            retracted = {
+              ...lastText,
+              text: tailText,
+              measuredWidth: strAdvance(lastText, tailText),
+              src: {
+                segIndex: lastText.src!.segIndex,
+                charOffset: lastText.src!.charOffset + headText.length,
+              },
+              seaBreaks: rebaseSeaBreaks(lastText.seaBreaks, headText.length),
+            };
+            if (headText) {
+              const headW = strAdvance(lastText, headText);
+              currentWidth -= lastText.measuredWidth - headW;
+              currentLine[currentLine.length - 1] = { ...lastText, text: headText, measuredWidth: headW };
+            } else {
+              currentWidth -= lastText.measuredWidth;
+              currentLine.pop();
+            }
+          }
+        }
+        flush(undefined, false, retracted?.src ?? s.src);
         queue.unshift(s);
+        if (retracted) queue.unshift(retracted);
       } else {
         // Empty line and the first dictionary word is wider than the whole
         // column: emergency GRAPHEME-safe split (a code-point split would tear a

--- a/packages/docx/src/sea-transition-line-break.test.ts
+++ b/packages/docx/src/sea-transition-line-break.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_KINSOKU_RULES,
+  seaMixedBreakOffsets,
+  seaTransitionOffsets,
+} from '@silurus/ooxml-core';
+import { layoutLines, type LayoutLine, type LayoutSeg, type LayoutTextSeg } from './line-layout.js';
+
+// Issue #960 — no-space SEA↔Latin/CJK/digit script-transition boundaries, and
+// mixed CJK+SEA runs. Adjudicated against Word-exported ground truth
+// (sample-45.pdf, private): Word breaks at these transitions (it did NOT carry
+// the whole cross-script unit down — a Thai→Latin seam `…ของ | Thailand` fell on
+// a line boundary), and in a single run mixing CJK and Thai each script keeps
+// its own break rule (CJK per-character, Thai at cluster/dictionary boundaries).
+//
+// All four Thai fixtures carry `<w:cs/>`, so buildSegments keeps the whole
+// no-space paragraph in ONE complex-script segment — which is exactly why the
+// two gaps manifest. The stub metric is 5px per code point (makeLinearCtx), so
+// the fitter is deterministic w.r.t. width; the WORD boundaries come from the
+// platform ICU dictionary, so we assert the PROPERTY (every break is a legal
+// merged offset; the transitions ARE used) rather than exact offsets.
+
+function makeLinearCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const fontSize = (): number => Number.parseFloat(/([\d.]+)px/.exec(font)?.[1] ?? '10');
+  return {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    letterSpacing: '0px',
+    measureText: (text: string) => {
+      const size = fontSize();
+      return {
+        width: [...text].length * size * 0.5,
+        fontBoundingBoxAscent: size * 0.8,
+        fontBoundingBoxDescent: size * 0.2,
+        actualBoundingBoxAscent: size * 0.8,
+        actualBoundingBoxDescent: size * 0.2,
+      } as TextMetrics;
+    },
+  } as unknown as CanvasRenderingContext2D;
+}
+function textSeg(text: string): LayoutTextSeg {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 10, color: null, fontFamily: 'T', vertAlign: null, measuredWidth: 0,
+  } as unknown as LayoutTextSeg;
+}
+function lay(text: string, width: number): LayoutLine[] {
+  return layoutLines(
+    makeLinearCtx(), [textSeg(text)], width, 0, 1, [], undefined, {}, 0,
+    DEFAULT_KINSOKU_RULES, 0, 36, width, false,
+  );
+}
+const lineTexts = (lines: LayoutLine[]): string[] =>
+  lines.map((l) => l.segments.filter((s): s is LayoutTextSeg => 'text' in s).map((s) => s.text).join(''));
+
+/** Cumulative UTF-16 offset at the END of every non-final line = each break. */
+function breakOffsets(texts: string[]): number[] {
+  const out: number[] = [];
+  let acc = 0;
+  for (let i = 0; i < texts.length - 1; i++) { acc += texts[i].length; out.push(acc); }
+  return out;
+}
+
+describe('SEA↔non-SEA no-space transitions in docx layoutLines (#960)', () => {
+  const A1 = 'เมืองBangkokคือเมืองหลวงของThailandมีชื่อเต็มยาวว่าKrungThepMahaNakhon';
+  const A2 = 'ราคาสินค้า1250บาทลดเหลือ990บาทประหยัด260บาทหรือ21เปอร์เซ็นต์ต่อชิ้น';
+  const A3 = 'อาหารญี่ปุ่น寿司และราเมงラーメンเป็นที่นิยมในไทยข้าวปั้นおにぎりมากขึ้น';
+  const B = '日本語のテキストとภาษาไทยが同じ';
+
+  const legal = (t: string): Set<number> =>
+    new Set(seaMixedBreakOffsets(t, { cjk: true, kinsoku: DEFAULT_KINSOKU_RULES }));
+
+  it('a1 Thai↔Latin: breaks only at legal merged offsets, and USES a transition seam', () => {
+    // Width 110 (22 cp) > the widest unit between two seams (KrungThepMahaNakhon,
+    // 19 cp) so no emergency char-split occurs — every break is a legal offset.
+    const texts = lineTexts(lay(A1, 110));
+    expect(texts.join('')).toBe(A1); // nothing lost/duplicated
+    expect(texts.length).toBeGreaterThan(1);
+    const legalSet = legal(A1);
+    for (const b of breakOffsets(texts)) expect(legalSet.has(b)).toBe(true);
+    // At least one break is a genuine SEA↔non-SEA transition (the #960 fix).
+    const transitions = new Set(seaTransitionOffsets(A1));
+    expect(breakOffsets(texts).some((b) => transitions.has(b))).toBe(true);
+  });
+
+  it('a2 Thai↔digit: breaks at the digit seams, never mid-Thai-cluster and never mid-number', () => {
+    const texts = lineTexts(lay(A2, 60));
+    expect(texts.join('')).toBe(A2);
+    expect(texts.length).toBeGreaterThan(1);
+    const legalSet = legal(A2);
+    for (const b of breakOffsets(texts)) expect(legalSet.has(b)).toBe(true);
+    // A price like "1250"/"990"/"260"/"21" is a single European-digit group; a
+    // break must never fall between two digits (that would split the number).
+    for (const b of breakOffsets(texts)) {
+      const prev = A2.codePointAt(b - 1)!;
+      const at = A2.codePointAt(b)!;
+      const isDigit = (c: number) => c >= 0x30 && c <= 0x39;
+      expect(isDigit(prev) && isDigit(at)).toBe(false);
+    }
+    // And the transition seams are actually exercised.
+    const transitions = new Set(seaTransitionOffsets(A2));
+    expect(breakOffsets(texts).some((b) => transitions.has(b))).toBe(true);
+  });
+
+  it('a3 Thai↔CJK: Thai breaks at dictionary boundaries, CJK per character', () => {
+    const texts = lineTexts(lay(A3, 60));
+    expect(texts.join('')).toBe(A3);
+    expect(texts.length).toBeGreaterThan(1);
+    const legalSet = legal(A3);
+    for (const b of breakOffsets(texts)) expect(legalSet.has(b)).toBe(true);
+  });
+
+  it('cross-run kinsoku: a mixed run led by 。 is not orphaned at a line head', () => {
+    // A prior Latin word fills the line; the following mixed CJK+SEA run starts
+    // with 。 (行頭禁則). Routing it through the SEA branch must still pull a
+    // trailing grapheme of the previous segment down so 。 never heads a line
+    // (§17.3.1.16 cross-run 追い出し), exactly as the CJK branch does.
+    const lines = layoutLines(
+      makeLinearCtx(), [textSeg('abcd'), textSeg('。ภาษาไทย')], 25, 0, 1, [], undefined, {}, 0,
+      DEFAULT_KINSOKU_RULES, 0, 36, 25, false,
+    );
+    const texts = lineTexts(lines);
+    expect(texts.join('')).toBe('abcd。ภาษาไทย');
+    for (const t of texts) expect(t.startsWith('。')).toBe(false);
+  });
+
+  it('b CJK+Thai one run: each side keeps its rule — the Thai span is never torn', () => {
+    // 「ภาษาไทย」 is a short Thai span embedded in CJK. With the transition seam
+    // now legal, Word (and now we) break at と|ภาษาไทย and keep the Thai whole,
+    // instead of tearing it mid-cluster (ภาษ|าไทย) on the old CJK-only path.
+    const texts = lineTexts(lay(B, 60));
+    expect(texts.join('')).toBe(B);
+    expect(texts.length).toBeGreaterThan(1);
+    const legalSet = legal(B);
+    for (const b of breakOffsets(texts)) expect(legalSet.has(b)).toBe(true);
+    // The contiguous Thai cluster run stays intact on ONE line.
+    expect(texts.some((t) => t.includes('ภาษาไทย'))).toBe(true);
+    // CJK still breaks at a character boundary (日本語… wraps per glyph as needed).
+    // The break set is non-empty and a CJK-adjacent offset is used.
+    expect(breakOffsets(texts).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -63,7 +63,7 @@ import {
   isCjkBreakChar,
   isUax14NoBreakPair,
   containsSeaScript,
-  seaWordBreakOffsets,
+  seaMixedBreakOffsets,
   fitSeaWordPrefix,
   graphemeClusterOffsets,
   getCachedSvgImageByPath,
@@ -1021,7 +1021,16 @@ export function layoutParagraph(
       // declared an explicit East Asian typeface (rPr > ea); other characters
       // keep the Latin font so the latin/ea boundary mid-token stays clean.
       const hasCJK = tokenHasCjk(token);
-      if (hasCJK) {
+      // Issue #960 — a token that mixes CJK with SEA (Thai/Lao/Khmer) must NOT
+      // take the CJK-only path (which tears the SEA interior at arbitrary
+      // character boundaries): route it to the unified SEA branch below, whose
+      // offset set merges the CJK per-character opportunities with the SEA
+      // dictionary/transition ones so each script keeps its own break rule. The
+      // exception is `eaLnBrk=false` (§21.1.2.2.7), which forbids breaking the
+      // East Asian word at all — keep that on the CJK path so the token stays
+      // whole. A CJK token with no SEA is unchanged.
+      const routeCjk = hasCJK && (!containsSeaScript(token) || para.eaLnBrk === false);
+      if (routeCjk) {
         // Measure each grapheme with its per-char font (latin/ea boundary stays
         // clean), then place chars according to a:pPr@eaLnBrk (ECMA-376
         // §21.1.2.2.7, "East Asian Line Break"):
@@ -1076,21 +1085,61 @@ export function layoutParagraph(
         continue;
       }
 
-      // SEA (Thai/Lao/Khmer) dictionary line breaking (issue #797). These scripts
-      // have no inter-word spaces, so `token` is a whole run of words; break it
-      // only at a segmenter word boundary. Each fitted line-piece is pushed as
-      // ONE contiguous string — pptx's `push` sums per-call measured widths into
-      // `lineW`, so per-word pushes would drift the wrap width from the merged
-      // paint width (measure==paint). CJK is handled above; a mixed CJK+SEA token
-      // stays on the CJK path (no regression). A SEA token with no dictionary
-      // break (single over-long word / Segmenter unavailable) still routes here
-      // so its emergency split stays grapheme-safe.
+      // SEA (Thai/Lao/Khmer) line breaking (issue #797 / #960). These scripts have
+      // no inter-word spaces, so `token` is a whole run; break it only at a member
+      // of `seaBreaks` — the UNION of dictionary word boundaries, the no-space
+      // SEA↔non-SEA script transitions, and (for a mixed CJK+SEA token routed here
+      // from above) the CJK per-character opportunities, kinsoku-filtered. A SEA
+      // token with no boundary (single over-long word / Segmenter unavailable)
+      // still routes here so its emergency split stays grapheme-safe.
       if (containsSeaScript(token)) {
-        const seaBreaks = seaWordBreakOffsets(token);
-        ctx.font = font;
-        // Match push's advance model: it adds `lsPx * codePointCount` (a:spc), so
-        // the fit measure must too or a spaced run mis-wraps (measure==paint).
-        const measureSub = (sub: string): number => ctx.measureText(sub).width + lsPx * codePointCount(sub);
+        const seaBreaks = seaMixedBreakOffsets(token, { cjk: true, kinsoku: DEFAULT_KINSOKU_RULES });
+        // A line-piece may mix a Thai run (Latin/Thai `font`) with a CJK run
+        // (`fontEa` when an East Asian typeface is declared). Measure each maximal
+        // same-font sub-run WHOLE — per-char measurement would break Thai shaping —
+        // and push each with its own font so CJK glyphs get `fontEa`. For a
+        // pure-SEA piece (or `familyEa` absent / resolving to the SAME font) this
+        // is one run with `font`: whole-string measure + single push, i.e.
+        // byte-identical to the pre-#960 path. The split is taken ONLY when the
+        // EA font actually differs — otherwise measuring per-run and re-merging
+        // identical-font pushes could disagree on cross-boundary shaping.
+        const eaDiffers = familyEa != null && fontEa !== font;
+        const isEaCh = (ch: string): boolean => eaDiffers && isCjkBreakChar(ch.codePointAt(0) ?? 0);
+        const measureSub = (sub: string): number => {
+          let w = lsPx * codePointCount(sub);
+          let runText = '';
+          let runEa: boolean | null = null;
+          const flush = (): void => {
+            if (runText === '') return;
+            ctx.font = runEa ? (fontEa as string) : font;
+            w += ctx.measureText(runText).width;
+            runText = '';
+          };
+          for (const ch of sub) {
+            const ea = isEaCh(ch);
+            if (runEa === null || ea === runEa) { runText += ch; runEa = ea; }
+            else { flush(); runText = ch; runEa = ea; }
+          }
+          flush();
+          return w;
+        };
+        const pushPiece = (piece: string): void => {
+          let runText = '';
+          let runEa: boolean | null = null;
+          const flush = (): void => {
+            if (runText === '') return;
+            const pFont = runEa ? (fontEa as string) : font;
+            const pFamily = runEa ? (familyEa as string) : family;
+            push(runText, pFont, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, { ...segExtras, fontFamily: pFamily });
+            runText = '';
+          };
+          for (const ch of piece) {
+            const ea = isEaCh(ch);
+            if (runEa === null || ea === runEa) { runText += ch; runEa = ea; }
+            else { flush(); runText = ch; runEa = ea; }
+          }
+          flush();
+        };
         const N = token.length;
         let start = 0;
         while (start < N) {
@@ -1106,7 +1155,7 @@ export function layoutParagraph(
             if (g <= 0) g = graphemes.length > 0 ? graphemes[0] : firstWord.length;
             end = start + g;
           }
-          push(token.slice(start, end), font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
+          pushPiece(token.slice(start, end));
           start = end;
           if (start < N) newLine();
         }

--- a/packages/pptx/src/sea-transition-line-break.test.ts
+++ b/packages/pptx/src/sea-transition-line-break.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_KINSOKU_RULES,
+  seaMixedBreakOffsets,
+  seaTransitionOffsets,
+} from '@silurus/ooxml-core';
+import { layoutParagraph } from './renderer.js';
+import type { Paragraph } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+// Issue #960 — pptx counterpart of the docx transition/mixed-run fix. A run that
+// mixes SEA (Thai) with Latin/digit/CJK and has no spaces takes ONE token; the
+// no-space script transitions must be break opportunities, and a mixed CJK+SEA
+// token must break the CJK side per-character while keeping the Thai side at
+// dictionary/cluster boundaries (adjudicated against Word/PowerPoint GT). char =
+// 10px in the mock, so the fitter is deterministic; boundaries come from ICU.
+
+function mockCtx() {
+  let font = '';
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    measureText: (s: string) => ({ width: [...s].length * 10 }),
+    fillRect() {}, fillText() {},
+    fillStyle: '', strokeStyle: '',
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+function run(text: string, over: Partial<TextRunData> = {}): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: 20, color: '000000', fontFamily: 'Arial', ...over,
+  };
+}
+function para(runs: TextRunData[]): Paragraph {
+  return {
+    alignment: 'l', marL: 0, marR: 0, indent: 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null,
+    defItalic: null, defFontFamily: null, tabStops: [], eaLnBrk: true, runs,
+  } as Paragraph;
+}
+const lineText = (line: { segments: { text: string }[] }): string =>
+  line.segments.map((s) => s.text).join('');
+function breakOffsets(texts: string[]): number[] {
+  const out: number[] = [];
+  let acc = 0;
+  for (let i = 0; i < texts.length - 1; i++) { acc += texts[i].length; out.push(acc); }
+  return out;
+}
+const legal = (t: string): Set<number> =>
+  new Set(seaMixedBreakOffsets(t, { cjk: true, kinsoku: DEFAULT_KINSOKU_RULES }));
+
+describe('pptx SEA↔non-SEA no-space transitions and mixed CJK+SEA (#960)', () => {
+  const A2 = 'ราคาสินค้า1250บาทลดเหลือ990บาทประหยัด260บาทหรือ21เปอร์เซ็นต์ต่อชิ้น';
+  const B = '日本語のテキストとภาษาไทยが同じ';
+
+  it('a2 Thai↔digit: breaks at the digit seams, never mid-number', () => {
+    const lines = layoutParagraph(mockCtx(), para([run(A2)]), 130, 20, '000000', 1, 0);
+    const texts = lines.map(lineText);
+    expect(texts.join('')).toBe(A2);
+    expect(texts.length).toBeGreaterThan(1);
+    const legalSet = legal(A2);
+    for (const b of breakOffsets(texts)) expect(legalSet.has(b)).toBe(true);
+    for (const b of breakOffsets(texts)) {
+      const isDigit = (c: number) => c >= 0x30 && c <= 0x39;
+      expect(isDigit(A2.codePointAt(b - 1)!) && isDigit(A2.codePointAt(b)!)).toBe(false);
+    }
+    const transitions = new Set(seaTransitionOffsets(A2));
+    expect(breakOffsets(texts).some((b) => transitions.has(b))).toBe(true);
+  });
+
+  it('b CJK+Thai one run: each side keeps its rule — Thai span never torn', () => {
+    const lines = layoutParagraph(mockCtx(), para([run(B)]), 100, 20, '000000', 1, 0);
+    const texts = lines.map(lineText);
+    expect(texts.join('')).toBe(B);
+    expect(texts.length).toBeGreaterThan(1);
+    const legalSet = legal(B);
+    for (const b of breakOffsets(texts)) expect(legalSet.has(b)).toBe(true);
+    // The contiguous Thai cluster run stays intact on ONE line.
+    expect(texts.some((t) => t.includes('ภาษาไทย'))).toBe(true);
+  });
+});

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -6,7 +6,7 @@ import type {
   PhoneticRun, PhoneticProperties, PhoneticAlignment, Duotone,
 } from './types.js';
 import { placePhoneticRuns } from './phonetic.js';
-import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, seaWordBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
+import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, seaMixedBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValueWithColor } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -953,7 +953,12 @@ export function wrapParagraphLines(ctx: CanvasRenderingContext2D, paragraph: str
       // wraps it at legal points. Wrapped lines re-concatenate into one drawn
       // string, so this only ADDS break opportunities (measure==paint). Non-SEA
       // words and SEA words with no usable break stay a single token.
-      const seaBreaks = containsSeaScript(word) ? seaWordBreakOffsets(word) : null;
+      // Issue #797 / #960 — dictionary word boundaries UNIONED with the no-space
+      // SEA↔non-SEA script transitions (Thai↔Latin/digit), so a price like
+      // "…1250…" or an embedded Latin word can wrap away from the surrounding
+      // Thai. CJK is already its own token here (split above), so the mixed CJK
+      // path is not needed.
+      const seaBreaks = containsSeaScript(word) ? seaMixedBreakOffsets(word) : null;
       if (seaBreaks && seaBreaks.length > 0) {
         let s = 0;
         for (const b of seaBreaks) { tokens.push(word.slice(s, b)); s = b; }
@@ -1156,7 +1161,9 @@ export function layoutRichTextLines(
   // contiguous string (via `push`) to keep measure==paint. A single word wider
   // than the cell falls back to a grapheme-safe emergency split.
   const pushSeaToken = (text: string, font: CellFont): void => {
-    const seaBreaks = seaWordBreakOffsets(text);
+    // #797 dictionary boundaries ∪ #960 SEA↔non-SEA transitions (CJK is a
+    // separate token in this path, so no mixed-CJK offsets are needed here).
+    const seaBreaks = seaMixedBreakOffsets(text);
     if (seaBreaks.length === 0) { push(text, font); return; }
     ctx.font = buildFont(vertAlignDrawFont(font), cs);
     const measureSub = (sub: string): number => ctx.measureText(sub).width;

--- a/packages/xlsx/src/sea-line-break.test.ts
+++ b/packages/xlsx/src/sea-line-break.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { seaWordBreakOffsets } from '@silurus/ooxml-core';
+import { seaMixedBreakOffsets, seaTransitionOffsets, seaWordBreakOffsets } from '@silurus/ooxml-core';
 import { wrapParagraphLines, layoutRichTextLines } from './renderer.js';
 import type { CellFont, Run } from './types.js';
 
@@ -77,5 +77,33 @@ describe('xlsx layoutRichTextLines — SEA (Thai) dictionary breaking', () => {
   it('does not change non-SEA wrapping (plain CJK parity)', () => {
     const lines = layoutRichTextLines(ctx, [{ text: 'あいうえお' }] as Run[], baseFont, 1, 30);
     expect(richText(lines)).toEqual(['あいう', 'えお']);
+  });
+});
+
+// Issue #960 — no-space SEA↔Latin/digit transitions are break opportunities.
+// xlsx splits CJK into its own tokens, so only the transition (gap 1) applies.
+describe('xlsx SEA↔non-SEA no-space transitions (#960)', () => {
+  const A2 = 'ราคาสินค้า1250บาทลดเหลือ990บาทประหยัด260บาทหรือ21เปอร์เซ็นต์ต่อชิ้น';
+  const legalSet = new Set(seaMixedBreakOffsets(A2));
+  const transitions = new Set(seaTransitionOffsets(A2));
+
+  it('wrapParagraphLines breaks at the Thai↔digit seams, never mid-number', () => {
+    const out = wrapParagraphLines(ctx, A2, 120);
+    expect(out.join('')).toBe(A2);
+    expect(out.length).toBeGreaterThan(1);
+    for (const b of breakOffsets(out)) expect(legalSet.has(b)).toBe(true);
+    for (const b of breakOffsets(out)) {
+      const isDigit = (c: number) => c >= 0x30 && c <= 0x39;
+      expect(isDigit(A2.codePointAt(b - 1)!) && isDigit(A2.codePointAt(b)!)).toBe(false);
+    }
+    expect(breakOffsets(out).some((b) => transitions.has(b))).toBe(true);
+  });
+
+  it('layoutRichTextLines breaks at the transition seams too', () => {
+    const lines = layoutRichTextLines(ctx, [{ text: A2 }] as Run[], baseFont, 1, 120);
+    const texts = richText(lines);
+    expect(texts.join('')).toBe(A2);
+    for (const b of breakOffsets(texts)) expect(legalSet.has(b)).toBe(true);
+    expect(breakOffsets(texts).some((b) => transitions.has(b))).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #960 (follow-up to #797 / #955).

## Adjudication (Word / PowerPoint ground truth)

Measured the Word-exported PDFs for the no-space transition fixtures (LTR Thai and RTL Arabic, narrow 2.5in column) with `pdftotext -bbox` + `pdftoppm` visual confirmation. Findings ([full record on the issue](https://github.com/yukiyokotani/office-open-xml-viewer/issues/960#issuecomment-4946145806)):

- **(a) A no-space script transition IS a break opportunity** — Word breaks AT the boundary (a Thai→Latin seam `…ของ | Thailand` fell on a line boundary, carrying the Latin word whole). It does not carry the whole cross-script unit down; for an over-long glued unit it also breaks at the character level.
- **(b) Mixed CJK+SEA run — each side keeps its own rule** — CJK breaks per character; the Thai spans stay intact as cluster units.
- **(c) RTL is consistent** — the Arabic transitions behave the same (break at the seam, Latin word kept whole).

## Implementation

Closes the two gaps #955 left open:

**core** — `seaTransitionOffsets(text)` enumerates the SEA↔non-SEA span edges; `seaMixedBreakOffsets(text, {cjk, kinsoku})` unions dictionary word boundaries + transitions + (opt-in) CJK per-character opportunities, keeps every offset on a **grapheme-cluster boundary** (no base+mark / VS / ZWJ tear), skips the **non-breaking-space** family, and drops kinsoku-illegal positions while honouring `KinsokuRules.enabled`.

**docx / pptx** — a SEA-containing token/segment (even one with CJK, from a `<w:cs/>` run) now routes through the SEA branch with the merged offset set, so the CJK side breaks per character while the SEA side keeps its dictionary/cluster boundaries. docx preserves cross-run 追い出し (§17.3.1.16) for a mixed run led by a 行頭禁則 char; pptx dispatches CJK glyphs to `fontEa` per same-font sub-run (measure==paint).

**xlsx** — merges the transition offsets only; CJK is already isolated into its own token in that path.

## Tests / gates

- New: `core/text/sea-break.test.ts` (transitions, mixed union, grapheme-safety, NBSP, kinsoku enable/disable), `docx/pptx sea-transition-line-break.test.ts` (property tests + cross-run kinsoku), plus xlsx transition cases. Verified Red on pre-fix docx (all 4 fail), Green after.
- core + docx + pptx + xlsx vitest: all pass. Root `pnpm typecheck`: clean.
- docx demo VRT: non-regression (identical match% — non-SEA wrapping untouched). Private Thai references are gitignored and absent in CI; the SEA fixtures are covered by the deterministic unit/integration tests above.
- Independent review by Codex gpt-5.6-sol (read-only) raised 4 issues (grapheme-safety, `KinsokuRules.enabled`, cross-run kinsoku retract, pptx same-font measure drift) — all addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)