### PR TITLE
feat(core): grapheme-fill line breaking for Myanmar and Tibetan (#961)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -381,6 +381,7 @@ export {
   isSeaScriptCodePoint,
   isSeaGraphemeExtend,
   containsSeaScript,
+  isGraphemeFillText,
   seaWordBreakOffsets,
   seaTransitionOffsets,
   seaMixedBreakOffsets,

--- a/packages/core/src/text/sea-break.test.ts
+++ b/packages/core/src/text/sea-break.test.ts
@@ -3,6 +3,7 @@ import {
   containsSeaScript,
   fitSeaWordPrefix,
   graphemeClusterOffsets,
+  isGraphemeFillText,
   isSeaGraphemeExtend,
   isSeaScriptCodePoint,
   resetSeaSegmenterForTest,
@@ -23,13 +24,26 @@ describe('isSeaScriptCodePoint', () => {
     [0x0e50, true], // THAI DIGIT ZERO
     [0x0e7f, true], // Thai end
     [0x0e80, true], // Lao start
-    [0x0eff, true], // Lao end
-    [0x0f00, false], // Tibetan — out of scope
+    [0x0eff, true], // Lao end (Tibetan begins immediately at 0x0F00 — no gap)
+    [0x0f00, true], // Tibetan start (grapheme-fill, #961)
+    [0x0f0b, true], // TIBETAN MARK INTERSYLLABIC TSHEG
+    [0x0f0d, true], // TIBETAN MARK SHAD
+    [0x0fff, true], // Tibetan end
+    [0x1000, true], // Myanmar start (grapheme-fill, #961)
+    [0x1031, true], // MYANMAR VOWEL SIGN E
+    [0x103c, true], // MYANMAR CONSONANT SIGN MEDIAL RA
+    [0x109f, true], // Myanmar end
+    [0x10a0, false], // just above Myanmar (Georgian)
     [0x177f, false], // just below Khmer
     [0x1780, true], // Khmer start
     [0x17d2, true], // KHMER SIGN COENG
     [0x17ff, true], // Khmer end
     [0x1800, false], // just above Khmer
+    [0xa9e0, true], // Myanmar Extended-B start (grapheme-fill)
+    [0xa9ff, true], // Myanmar Extended-B end
+    [0xaa60, true], // Myanmar Extended-A start (grapheme-fill)
+    [0xaa7f, true], // Myanmar Extended-A end
+    [0xaa80, false], // just above Myanmar Extended-A
     [0x0041, false], // Latin A
     [0x3042, false], // Hiragana — CJK, not SEA
   ];
@@ -96,6 +110,10 @@ describe('containsSeaScript', () => {
     expect(containsSeaScript('ພາສາລາວ')).toBe(true);
     expect(containsSeaScript('ភាសាខ្មែរ')).toBe(true);
   });
+  it('true for Myanmar / Tibetan text (grapheme-fill scripts, #961)', () => {
+    expect(containsSeaScript('မြန်မာဘာသာ')).toBe(true);
+    expect(containsSeaScript('བོད་ཡིག')).toBe(true);
+  });
   it('true when SEA is embedded in Latin', () => {
     expect(containsSeaScript('Hello ภาษา world')).toBe(true);
   });
@@ -156,6 +174,57 @@ describe('seaWordBreakOffsets — platform ICU', () => {
   it('returns [] for non-SEA / empty input', () => {
     expect(seaWordBreakOffsets('Hello world')).toEqual([]);
     expect(seaWordBreakOffsets('')).toEqual([]);
+  });
+});
+
+describe('seaWordBreakOffsets — grapheme-fill (Myanmar / Tibetan, #961)', () => {
+  // Word (macOS) breaks these at EVERY grapheme cluster, not dictionary words nor
+  // the Tibetan tsheg (sample-46 ground truth). So the offsets must be exactly the
+  // interior grapheme-cluster boundaries — every one, never a dictionary subset,
+  // never mid-cluster.
+  const myanmar = 'မြန်မာဘာသာစကားကိုစာလုံး'; // spaceless Myanmar run
+  const tibetan = 'བོད་ཡིག་ནི་ཚིག'; // tsheg-separated Tibetan run
+
+  for (const [name, text] of [['Myanmar', myanmar], ['Tibetan', tibetan]] as const) {
+    it(`${name}: offsets == interior grapheme-cluster boundaries`, () => {
+      const offsets = seaWordBreakOffsets(text);
+      expect(offsets.length).toBeGreaterThan(1);
+      // Ascending and strictly interior.
+      for (let k = 1; k < offsets.length; k++) expect(offsets[k]).toBeGreaterThan(offsets[k - 1]);
+      for (const o of offsets) {
+        expect(o).toBeGreaterThan(0);
+        expect(o).toBeLessThan(text.length);
+      }
+      // EXACTLY the interior grapheme boundaries (not a dictionary subset).
+      expect(offsets).toEqual(graphemeClusterOffsets(text));
+      // Both sides of every break are the same-script (interior to the span).
+      for (const o of offsets) {
+        expect(isSeaScriptCodePoint(text.codePointAt(o - 1)!)).toBe(true);
+        expect(isSeaScriptCodePoint(text.codePointAt(o)!)).toBe(true);
+      }
+    });
+  }
+
+  it('Myanmar break offsets do NOT collapse to the coarser ICU dictionary set', () => {
+    // Property proof that this is grapheme-fill, not dictionary: there are strictly
+    // more grapheme boundaries than ICU 'my' word-like boundaries for this run.
+    const graphemeCount = seaWordBreakOffsets(myanmar).length;
+    let wordLike = 0;
+    for (const s of new Intl.Segmenter('my', { granularity: 'word' }).segment(myanmar)) {
+      if (s.index > 0 && s.isWordLike) wordLike++;
+    }
+    expect(graphemeCount).toBeGreaterThan(wordLike);
+  });
+
+  it('keeps dictionary (Thai) and grapheme-fill (Myanmar) spans separate when adjacent', () => {
+    // A Thai↔Myanmar no-space boundary must not be a break (SEA↔SEA cross-class
+    // edge is left to the caller); Thai stays dictionary, Myanmar stays grapheme.
+    const mixed = 'ไทยမြန်မာ'; // Thai 'ไทย' then Myanmar 'မြန်မာ', no space
+    const thaiLen = 'ไทย'.length;
+    for (const o of seaWordBreakOffsets(mixed)) {
+      // No break exactly at the class boundary.
+      expect(o).not.toBe(thaiLen);
+    }
   });
 });
 
@@ -348,7 +417,63 @@ describe('fitSeaWordPrefix', () => {
     // widths: [0,2)=30, [0,5)=10, [0,7)=40, whole [0,9)=50; avail 15 → best 5.
     const w: Record<number, number> = { 2: 30, 5: 10, 7: 40, 9: 50 };
     const nonMono = (s: string) => w[s.length] ?? s.length;
+    // Default (full scan) keeps the non-monotone contract.
     expect(fitSeaWordPrefix(text, offsets, 0, 15, nonMono)).toBe(5);
+  });
+});
+
+describe('fitSeaWordPrefix — assumeMonotone binary-search fast path (#961)', () => {
+  // For grapheme-fill scripts the offsets are DENSE (one per cluster). The
+  // monotone binary search must return the SAME boundary as the full scan for any
+  // monotone measure, at O(log n) measure calls instead of O(n).
+  const text = 'abcdefghij'; // len 10
+  const denseOffsets = [1, 2, 3, 4, 5, 6, 7, 8, 9]; // every interior boundary
+  const measure = (s: string) => s.length * 10; // monotone: 10px/char
+
+  it('matches the full scan for a monotone measure at every avail', () => {
+    for (let avail = 0; avail <= 120; avail += 5) {
+      const fast = fitSeaWordPrefix(text, denseOffsets, 0, avail, measure, true);
+      const slow = fitSeaWordPrefix(text, denseOffsets, 0, avail, measure, false);
+      expect(fast).toBe(slow);
+    }
+  });
+
+  it('respects a non-zero start under binary search', () => {
+    // from start 4: avail 30 → [4,7)=30 ok, [4,8)=40 no → 7.
+    expect(fitSeaWordPrefix(text, denseOffsets, 4, 30, measure, true)).toBe(7);
+    expect(fitSeaWordPrefix(text, denseOffsets, 4, 30, measure, false)).toBe(7);
+  });
+
+  it('returns len when the whole remainder fits, and start when nothing does', () => {
+    expect(fitSeaWordPrefix(text, denseOffsets, 0, 999, measure, true)).toBe(10);
+    expect(fitSeaWordPrefix(text, denseOffsets, 0, 5, measure, true)).toBe(0); // < 1 char
+  });
+
+  it('uses O(log n) measure calls, not O(n) — the perf fix', () => {
+    // 1000 dense boundaries; count measure invocations. Full scan ≈ n; binary
+    // search ≈ log2(n) (+ the whole-remainder probe). Assert a tight log bound.
+    const big = 'x'.repeat(1000);
+    const bigOffsets = Array.from({ length: 999 }, (_, k) => k + 1);
+    let calls = 0;
+    const counting = (s: string) => { calls++; return s.length * 10; };
+    fitSeaWordPrefix(big, bigOffsets, 0, 155, counting, true); // fits ~15 chars
+    expect(calls).toBeLessThan(20); // ~log2(1000)=10, plus a couple probes
+  });
+});
+
+describe('isGraphemeFillText (#961)', () => {
+  it('true for Myanmar / Tibetan text (drives the monotone fit)', () => {
+    expect(isGraphemeFillText('မြန်မာ')).toBe(true);
+    expect(isGraphemeFillText('བོད་ཡིག')).toBe(true);
+    expect(isGraphemeFillText('Hello မြန်မာ')).toBe(true); // first no-space char is Myanmar
+  });
+  it('false for dictionary (Thai/Lao/Khmer) and non-no-space text', () => {
+    expect(isGraphemeFillText('ภาษาไทย')).toBe(false); // dictionary — keep full scan
+    expect(isGraphemeFillText('ພາສາລາວ')).toBe(false);
+    expect(isGraphemeFillText('ភាសាខ្មែរ')).toBe(false);
+    expect(isGraphemeFillText('Hello world')).toBe(false);
+    expect(isGraphemeFillText('日本語')).toBe(false);
+    expect(isGraphemeFillText('')).toBe(false);
   });
 });
 

--- a/packages/core/src/text/sea-break.ts
+++ b/packages/core/src/text/sea-break.ts
@@ -1,52 +1,80 @@
-// Dictionary-based line breaking for Southeast-Asian (SEA) scripts that write
-// without inter-word spaces: Thai, Lao and Khmer (GitHub issue #797). Word
-// boundaries in these scripts are not marked by whitespace and cannot be derived
-// from Unicode ranges alone; they require a dictionary. We use the platform ICU
-// dictionary via `Intl.Segmenter({ granularity: 'word' })` to enumerate the
-// break opportunities INTERIOR to each SEA-script span, and expose a pure,
-// package-agnostic kernel that every renderer's wrap loop consumes.
+// Line breaking for scripts written WITHOUT inter-word spaces, where a line may
+// break between two characters that have no whitespace between them. Two families
+// need different opportunity sources, both funnelled through the same wrap kernel
+// ({@link fitSeaWordPrefix}) so every renderer's wrap loop consumes one contract:
+//
+//   • DICTIONARY scripts — Thai U+0E00–0E7F, Lao U+0E80–0EFF, Khmer U+1780–17FF
+//     (GitHub #797 / #955). Word boundaries here are lexical and cannot be
+//     derived from Unicode ranges; they require a dictionary. We enumerate them
+//     with the platform ICU dictionary via `Intl.Segmenter({granularity:'word'})`.
+//
+//   • GRAPHEME-FILL scripts — Myanmar U+1000–109F (+ Extended-A U+AA60–AA7F,
+//     Extended-B U+A9E0–A9FF) and Tibetan U+0F00–0FFF (GitHub #961). Word (macOS
+//     layout) does NOT break these at dictionary words nor at the Tibetan tsheg
+//     `་`: ground-truth measurement (Word export of sample-46) shows it fills each
+//     line to the column edge and breaks at ANY grapheme-cluster boundary — 4 of 6
+//     observed Tibetan breaks and 1 of 5 Myanmar breaks split a syllable/word
+//     mid-cluster (e.g. the Myanmar word `သည်` broken `သ`|`ည်`), and it ships a
+//     Burmese dictionary it declines to use. So the break opportunities for these
+//     scripts are EVERY interior grapheme-cluster boundary; the sole invariant is
+//     "never split a base + stacked/combining cluster". Routing them here — rather
+//     than the renderers' generic over-long-word splitter, which splits at
+//     CODE-POINT granularity and can tear a cluster (Myanmar `တို`→`တိ`|`ု`) —
+//     upgrades that split to grapheme granularity, matching Word.
 //
 // Design invariants (shared with the docx/pptx/xlsx breakers):
 //   • ADD break opportunities only; never change glyphs or advances. The run is
 //     split only at the ACTUAL line break, so within a line the text stays one
 //     contiguous draw (measure==paint).
-//   • Restrict added opportunities to boundaries INTERIOR to a maximal SEA span,
-//     between two dictionary WORDS. A boundary that touches non-SEA text (Latin,
-//     digits, CJK, whitespace) is left to the existing whitespace/Latin/CJK
-//     logic, so non-SEA content stays byte-identical.
+//   • Restrict added opportunities to boundaries INTERIOR to a maximal same-class
+//     no-space span — between two dictionary WORDS (dictionary scripts) or between
+//     two grapheme CLUSTERS (grapheme-fill scripts). A boundary that touches
+//     non-SEA text (Latin, digits, CJK, whitespace) is left to the existing
+//     whitespace/Latin/CJK logic, so non-SEA content stays byte-identical.
 //   • Graceful fallback: when `Intl.Segmenter` is unavailable (old runtimes, a
-//     `small-icu` build without the SEA dictionaries) or throws, we return no
-//     offsets and the caller keeps its current cluster/character behaviour.
+//     `small-icu` build without the dictionaries) or throws, dictionary scripts
+//     return no offsets and grapheme-fill scripts fall back to code-point
+//     boundaries; the caller keeps its current cluster/character behaviour.
 //
-// Scope: Thai U+0E00–0E7F, Lao U+0E80–0EFF, Khmer U+1780–17FF — exactly the
-// ranges named in the issue. Myanmar/Tibetan remain out of scope (follow-up
-// #961). The no-space SEA↔Latin/CJK/digit script-transition boundary (#960) is
-// added by {@link seaTransitionOffsets}; {@link seaMixedBreakOffsets} unions the
-// dictionary, transition and CJK per-character opportunities for a single run
-// that mixes SEA with Latin/digits/CJK.
+// The no-space SEA↔Latin/CJK/digit script-transition boundary (#960) is added by
+// {@link seaTransitionOffsets}; {@link seaMixedBreakOffsets} unions the dictionary
+// (or grapheme-fill) word/cluster boundaries, the transition boundaries and the
+// CJK per-character opportunities for a single run that mixes these scripts with
+// Latin/digits/CJK.
 
 import { isCjkBreakChar } from './cjk-ranges.js';
 
-/** Southeast-Asian dictionary-break script tags used to pick the ICU dictionary.
- *  ICU dispatches the dictionary by the character's SCRIPT, not by this locale,
- *  so it is only a hint; we still pick per-span for clarity/forward-safety. */
-export type SeaScript = 'th' | 'lo' | 'km';
+/** No-inter-word-space script tag. Dictionary scripts (`th`/`lo`/`km`) pick the
+ *  ICU dictionary — ICU dispatches by the character's SCRIPT, not this locale, so
+ *  it is only a hint. Grapheme-fill scripts (`my`/`bo`, #961) take no dictionary:
+ *  every grapheme-cluster boundary is a break opportunity. */
+export type SeaScript = 'th' | 'lo' | 'km' | 'my' | 'bo';
+
+/** Grapheme-fill scripts (Myanmar, Tibetan): break at every interior grapheme
+ *  cluster, never a dictionary word (Word ground truth, #961). */
+function isGraphemeFillScript(s: SeaScript): boolean {
+  return s === 'my' || s === 'bo';
+}
 
 /**
- * True when `cp` belongs to one of the no-inter-word-space SEA scripts (Thai,
- * Lao, Khmer). This is a SCRIPT-membership test, not a break predicate: the
- * blocks include combining marks, tone marks, digits and punctuation that are
- * NOT independently breakable — the actual break opportunities come from
- * {@link seaWordBreakOffsets}. Used to detect SEA spans and as the cheap gate in
- * {@link containsSeaScript}.
+ * True when `cp` belongs to a no-inter-word-space script — the dictionary scripts
+ * Thai/Lao/Khmer or the grapheme-fill scripts Myanmar/Tibetan. This is a SCRIPT-
+ * membership test, not a break predicate: the blocks include combining marks,
+ * tone/stacked marks, digits and punctuation that are NOT independently
+ * breakable — the actual break opportunities come from {@link seaWordBreakOffsets}.
+ * Used to detect spans and as the cheap gate in {@link containsSeaScript}.
  *
  * @param cp A Unicode scalar value (e.g. from `String.prototype.codePointAt`).
  */
 export function isSeaScriptCodePoint(cp: number): boolean {
   return (
-    (cp >= 0x0e00 && cp <= 0x0e7f) || // Thai
-    (cp >= 0x0e80 && cp <= 0x0eff) || // Lao
-    (cp >= 0x1780 && cp <= 0x17ff) // Khmer
+    (cp >= 0x0e00 && cp <= 0x0e7f) || // Thai (dictionary)
+    (cp >= 0x0e80 && cp <= 0x0eff) || // Lao (dictionary)
+    (cp >= 0x1780 && cp <= 0x17ff) || // Khmer (dictionary)
+    (cp >= 0x1000 && cp <= 0x109f) || // Myanmar (grapheme-fill)
+    (cp >= 0xaa60 && cp <= 0xaa7f) || // Myanmar Extended-A (grapheme-fill)
+    (cp >= 0xa9e0 && cp <= 0xa9ff) || // Myanmar Extended-B (grapheme-fill)
+    (cp >= 0x0f00 && cp <= 0x0fff) // Tibetan (grapheme-fill)
   );
 }
 
@@ -83,23 +111,44 @@ export function isSeaGraphemeExtend(cp: number): boolean {
   );
 }
 
-/** The SEA script of a code point already known to be SEA (see
- *  {@link isSeaScriptCodePoint}). Used to pick the per-span ICU dictionary. */
+/** The no-space script of a code point already known to be one (see
+ *  {@link isSeaScriptCodePoint}). Dictionary scripts pick the per-span ICU
+ *  dictionary; grapheme-fill scripts pick the grapheme path. */
 function seaScriptOf(cp: number): SeaScript {
-  if (cp <= 0x0e7f) return 'th';
-  if (cp <= 0x0eff) return 'lo';
-  return 'km';
+  if (cp <= 0x0e7f) return 'th'; // 0E00–0E7F Thai
+  if (cp <= 0x0eff) return 'lo'; // 0E80–0EFF Lao
+  if (cp <= 0x0fff) return 'bo'; // 0F00–0FFF Tibetan
+  if (cp <= 0x109f) return 'my'; // 1000–109F Myanmar
+  if (cp <= 0x17ff) return 'km'; // 1780–17FF Khmer
+  return 'my'; // AA60–AA7F / A9E0–A9FF Myanmar Extended-A/B
 }
 
 /**
- * Cheap presence gate: true when any code point of `text` is SEA-script. Used by
- * the renderers to skip all segmentation work for the overwhelmingly common
- * non-SEA input (zero `Intl.Segmenter` cost), mirroring docx's
- * `hasCJKBreakOpportunity`.
+ * Cheap presence gate: true when any code point of `text` is a no-inter-word-space
+ * script (Thai/Lao/Khmer or Myanmar/Tibetan). Used by the renderers to skip all
+ * segmentation work for the overwhelmingly common non-SEA input (zero
+ * `Intl.Segmenter` cost), mirroring docx's `hasCJKBreakOpportunity`.
  */
 export function containsSeaScript(text: string): boolean {
   for (const ch of text) {
     if (isSeaScriptCodePoint(ch.codePointAt(0)!)) return true;
+  }
+  return false;
+}
+
+/**
+ * True when `text`'s no-space script is grapheme-fill (Myanmar/Tibetan) rather
+ * than dictionary (Thai/Lao/Khmer) — decided by its FIRST no-space character
+ * (a segment produced by the renderers is a single same-class span). Callers pass
+ * this as {@link fitSeaWordPrefix}'s `assumeMonotone` so a grapheme-fill run — whose
+ * break offsets are dense (one per cluster) — takes the O(log n) binary-search fit
+ * instead of the O(n) full scan the dictionary path needs. Returns false for pure
+ * dictionary text (keep the safe full scan) and for non-no-space text.
+ */
+export function isGraphemeFillText(text: string): boolean {
+  for (const ch of text) {
+    const cp = ch.codePointAt(0)!;
+    if (isSeaScriptCodePoint(cp)) return isGraphemeFillScript(seaScriptOf(cp));
   }
   return false;
 }
@@ -159,20 +208,24 @@ export function resetSeaSegmenterForTest(): void {
   graphemeSegmenter = undefined;
 }
 
-// ── Word break offsets ───────────────────────────────────────────────────────
+// ── Break offsets ────────────────────────────────────────────────────────────
 
 /**
- * Enumerate dictionary word-break opportunities in `text`, as UTF-16 offsets `i`
+ * Enumerate no-space line-break opportunities in `text`, as UTF-16 offsets `i`
  * such that a line break is permitted immediately BEFORE `text[i]`.
  *
- * Only boundaries that are (1) interior to a maximal SEA-script span and (2) the
- * START of a word-like segment are returned — so we never break before intra-SEA
- * punctuation (Khmer `។`, Thai `๚`) nor at a SEA↔non-SEA transition (left to the
- * existing logic). The offsets are always at grapheme-cluster boundaries (ICU
- * word breaks never split a base + combining mark).
+ * For DICTIONARY scripts (Thai/Lao/Khmer) the offsets are dictionary WORD starts:
+ * boundaries that are (1) interior to a maximal same-class span and (2) the start
+ * of a word-like segment — so we never break before intra-script punctuation
+ * (Khmer `។`, Thai `๚`). For GRAPHEME-FILL scripts (Myanmar/Tibetan, #961) the
+ * offsets are EVERY interior grapheme-cluster boundary (Word's grapheme-fill;
+ * no dictionary, no tsheg). Either way the offsets are grapheme-cluster
+ * boundaries — a base + stacked/combining cluster is never split — and a
+ * SEA↔non-SEA transition is left to the existing logic.
  *
- * Returns `[]` (graceful fallback) when `text` has no SEA character, when
- * `Intl.Segmenter` is unavailable, or when segmentation throws. Segment ONCE per
+ * Returns `[]` (graceful fallback) when `text` has no no-space character. A
+ * dictionary span adds no offsets when `Intl.Segmenter` is unavailable or throws;
+ * a grapheme-fill span falls back to code-point boundaries. Segment ONCE per
  * logical string and cache/slice the result; do not call this per line.
  */
 export function seaWordBreakOffsets(text: string): number[] {
@@ -187,33 +240,44 @@ export function seaWordBreakOffsets(text: string): number[] {
       i += step;
       continue;
     }
-    // Maximal SEA span [i, j). The span's dictionary is picked from its first
-    // character; ICU still dispatches per-script internally within the span.
+    // Maximal SAME-CLASS span [i, j): keep dictionary scripts (th/lo/km) and
+    // grapheme-fill scripts (my/bo) in separate spans so each gets the right
+    // treatment; a dictionary span's dictionary is picked from its first char
+    // (ICU still dispatches per-script internally within it).
     const script = seaScriptOf(cp);
+    const fill = isGraphemeFillScript(script);
     let j = i + step;
     while (j < len) {
       const c = text.codePointAt(j)!;
       if (!isSeaScriptCodePoint(c)) break;
+      if (isGraphemeFillScript(seaScriptOf(c)) !== fill) break;
       j += c > 0xffff ? 2 : 1;
     }
-    const segFn = wordSegmenterFor(script);
-    if (segFn) {
-      const span = text.slice(i, j);
-      // Accumulate this span's offsets in a temp buffer and commit them only
-      // after the iterator completes, so a mid-iteration `segment()` failure
-      // leaves NO partial offsets (all-or-nothing graceful fallback per span).
-      const spanOffsets: number[] = [];
-      try {
-        for (const g of segFn(span)) {
-          // index>0 keeps the offset interior to the span (never span-start,
-          // which is a SEA↔non-SEA edge or the string start). isWordLike keeps
-          // it a break-before-a-WORD (never before punctuation). Fake segmenters
-          // may omit isWordLike → treat as word-like.
-          if (g.index > 0 && (g.isWordLike ?? true)) spanOffsets.push(i + g.index);
+    const span = text.slice(i, j);
+    if (fill) {
+      // Grapheme-fill (Myanmar/Tibetan): every interior grapheme-cluster boundary
+      // is a legal break (Word ground truth, #961). graphemeClusterOffsets is
+      // grapheme-safe and degrades to code-point boundaries without a segmenter.
+      for (const off of graphemeClusterOffsets(span)) offsets.push(i + off);
+    } else {
+      const segFn = wordSegmenterFor(script);
+      if (segFn) {
+        // Accumulate this span's offsets in a temp buffer and commit them only
+        // after the iterator completes, so a mid-iteration `segment()` failure
+        // leaves NO partial offsets (all-or-nothing graceful fallback per span).
+        const spanOffsets: number[] = [];
+        try {
+          for (const g of segFn(span)) {
+            // index>0 keeps the offset interior to the span (never span-start,
+            // which is a SEA↔non-SEA edge or the string start). isWordLike keeps
+            // it a break-before-a-WORD (never before punctuation). Fake segmenters
+            // may omit isWordLike → treat as word-like.
+            if (g.index > 0 && (g.isWordLike ?? true)) spanOffsets.push(i + g.index);
+          }
+          for (const o of spanOffsets) offsets.push(o);
+        } catch {
+          // segment() failure on this span → add no offsets (graceful fallback).
         }
-        for (const o of spanOffsets) offsets.push(o);
-      } catch {
-        // segment() failure on this span → add no offsets (graceful fallback).
       }
     }
     i = j;
@@ -371,11 +435,12 @@ function codePointEndingAt(text: string, o: number): number | undefined {
   return lo;
 }
 
-// ── Greedy whole-word line fit (shared kernel) ───────────────────────────────
+// ── Greedy whole-prefix line fit (shared kernel) ─────────────────────────────
 
 /**
- * Greedy whole-word line fit for SEA dictionary breaking, shared by all three
- * renderers so the break decision is defined once.
+ * Greedy line fit for no-space breaking (dictionary words or grapheme clusters),
+ * shared by all three renderers so the break decision is defined once. `offsets`
+ * are the legal break-before positions from {@link seaWordBreakOffsets}.
  *
  * Returns the largest `end` with `start < end <= text.length` such that
  *   (a) `end === text.length` OR `end` is a member of `offsets` (a legal word
@@ -385,10 +450,20 @@ function codePointEndingAt(text: string, o: number): number | undefined {
  * (no progress) so the caller can wrap to a fresh line first, or — on an already
  * empty line — fall back to a grapheme-safe emergency split.
  *
- * Every candidate is measured (no early return): advance width is NOT guaranteed
- * monotone in the prefix length because Word/PowerPoint allow NEGATIVE character
- * spacing (`w:spacing` / `a:spc`), so a longer prefix can fit after a shorter one
- * overflowed. We keep the largest boundary (or the full remainder) that fits.
+ * By default EVERY candidate is measured (no early return): advance width is NOT
+ * guaranteed monotone in the prefix length because Word/PowerPoint allow NEGATIVE
+ * character spacing (`w:spacing` / `a:spc`), so a longer prefix can fit after a
+ * shorter one overflowed. We keep the largest boundary (or the full remainder)
+ * that fits. This full scan is O(#offsets) measures per call — fine for the sparse
+ * dictionary-word offsets of Thai/Lao/Khmer.
+ *
+ * `assumeMonotone` switches to an O(log #offsets) BINARY SEARCH for callers whose
+ * advance IS monotone in the prefix length — the grapheme-fill scripts
+ * Myanmar/Tibetan (#961), whose `offsets` are EVERY grapheme boundary (dense: one
+ * per cluster), where a per-line full scan would be O(n²) down a long run. This
+ * matches the monotone assumption {@link fitCJKPrefix} already makes for CJK. Do
+ * NOT set it for a run that can carry glyph-overlapping negative spacing (the
+ * dictionary path keeps the safe full scan).
  *
  * `offsets` MUST be sorted ascending (as produced by {@link seaWordBreakOffsets}
  * or {@link graphemeClusterOffsets}). `measure` supplies the caller's exact
@@ -400,9 +475,31 @@ export function fitSeaWordPrefix(
   start: number,
   avail: number,
   measure: (sub: string) => number,
+  assumeMonotone = false,
 ): number {
   const len = text.length;
   if (start >= len) return start;
+  if (assumeMonotone) {
+    // Monotone advance: "fits" is downward-closed over the boundary position, so
+    // the whole remainder is the max if it fits, else binary-search the interior
+    // offsets (ascending) for the largest fitting one. Offsets ≤ start form a
+    // prefix and ≥ len a suffix of the sorted array; the search skips both.
+    if (measure(text.slice(start, len)) <= avail) return len;
+    let lo = 0;
+    let hi = offsets.length - 1;
+    let ans = start;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      const b = offsets[mid];
+      if (b <= start) lo = mid + 1;
+      else if (b >= len) hi = mid - 1;
+      else if (measure(text.slice(start, b)) <= avail) {
+        ans = b;
+        lo = mid + 1;
+      } else hi = mid - 1;
+    }
+    return ans;
+  }
   let best = start;
   for (const b of offsets) {
     if (b <= start || b >= len) continue;
@@ -436,17 +533,24 @@ function getGraphemeSegmenter(): Intl.Segmenter | null {
  * wider than the whole line/cell: a code-point split would tear a base +
  * combining/tone mark (both are BMP, so "SEA is BMP therefore safe" is false),
  * whereas a grapheme boundary keeps the cluster intact. Falls back to code-point
- * boundaries when `Intl.Segmenter` is unavailable.
+ * boundaries when `Intl.Segmenter` is unavailable OR `segment()`/its iterator
+ * throws (a `small-icu` build, an exotic runtime) — never propagates, so the
+ * grapheme-fill wrap (#961) degrades to a safe code-point split instead of failing.
  */
 export function graphemeClusterOffsets(text: string): number[] {
-  const out: number[] = [];
   const seg = getGraphemeSegmenter();
   if (seg) {
-    for (const g of seg.segment(text)) {
-      if (g.index > 0) out.push(g.index);
+    try {
+      const out: number[] = [];
+      for (const g of seg.segment(text)) {
+        if (g.index > 0) out.push(g.index);
+      }
+      return out;
+    } catch {
+      // fall through to the code-point boundaries below (graceful fallback)
     }
-    return out;
   }
+  const out: number[] = [];
   for (let i = 0; i < text.length; ) {
     const cp = text.codePointAt(i)!;
     i += cp > 0xffff ? 2 : 1;

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -32,6 +32,7 @@ import {
   isCjkBreakChar,
   isUax14NoBreakPair,
   containsSeaScript,
+  isGraphemeFillText,
   seaMixedBreakOffsets,
   fitSeaWordPrefix,
   graphemeClusterOffsets,
@@ -3281,22 +3282,27 @@ export function layoutLines(
         }
       }
     } else if (s.seaBreaks !== undefined) {
-      // SEA (Thai/Lao/Khmer) line wrap (issue #797 / #960). These scripts have no
-      // inter-word spaces, so this ONE segment is a whole run; break it only at a
-      // member of `s.seaBreaks` — the UNION of dictionary word boundaries, the
-      // no-space SEA↔non-SEA script transitions, and (for a mixed CJK+SEA `<w:cs/>`
-      // run) the CJK per-character opportunities, already kinsoku-filtered by
-      // `seaMixedBreakOffsets`. Entered for ANY SEA segment (even one with no
-      // boundary — a single word wider than the column, or Segmenter unavailable)
-      // so the emergency split below stays GRAPHEME-safe instead of falling to the
-      // code-point path. Kinsoku 行頭/行末禁則 was applied when the offsets were
-      // built (so a forbidden CJK char never heads/tails a line); choosing an
-      // earlier legal offset is the only remaining adjustment, which
-      // fitSeaWordPrefix already does. The run stays one contiguous draw per line
-      // (measure==paint); the tail re-queues with its offsets rebased.
+      // No-inter-word-space line wrap: Thai/Lao/Khmer dictionary words (#797) or
+      // Myanmar/Tibetan grapheme clusters (#961). This ONE segment is a whole run;
+      // break it only at a member of `s.seaBreaks` — the UNION (#960) of the
+      // dictionary word (or grapheme-cluster) boundaries, the no-space SEA↔non-SEA
+      // script transitions, and (for a mixed CJK+SEA `<w:cs/>` run) the CJK
+      // per-character opportunities, already kinsoku-filtered by
+      // `seaMixedBreakOffsets`. Entered for ANY such segment (even one with no
+      // interior boundary — a single word/cluster wider than the column, or
+      // Segmenter unavailable) so the emergency split below stays GRAPHEME-safe
+      // instead of falling to the code-point path. Kinsoku 行頭/行末禁則 was applied
+      // when the offsets were built (so a forbidden CJK char never heads/tails a
+      // line); choosing an earlier legal offset is the only remaining adjustment,
+      // which fitSeaWordPrefix already does. The run stays one contiguous draw per
+      // line (measure==paint); the tail re-queues with its offsets rebased.
       const available = availW() - currentWidth;
       const measureSub = (sub: string): number => strAdvance(s, sub);
-      const split = fitSeaWordPrefix(s.text, s.seaBreaks, 0, available, measureSub);
+      // Grapheme-fill runs (Myanmar/Tibetan) have DENSE offsets (one per cluster),
+      // so use the monotone binary-search fit — a per-line full scan would be O(n²)
+      // down a long run. Dictionary runs keep the negative-spacing-safe full scan.
+      const monotone = isGraphemeFillText(s.text);
+      const split = fitSeaWordPrefix(s.text, s.seaBreaks, 0, available, measureSub, monotone);
       if (split > 0) {
         const prefix = s.text.slice(0, split);
         const pw = strAdvance(s, prefix);
@@ -3360,7 +3366,7 @@ export function layoutLines(
         const firstWordEnd = s.seaBreaks[0] ?? s.text.length;
         const firstWord = s.text.slice(0, firstWordEnd);
         const graphemes = graphemeClusterOffsets(firstWord);
-        let gsplit = fitSeaWordPrefix(firstWord, graphemes, 0, available, measureSub);
+        let gsplit = fitSeaWordPrefix(firstWord, graphemes, 0, available, measureSub, monotone);
         if (gsplit <= 0) gsplit = graphemes.length > 0 ? graphemes[0] : firstWord.length;
         const prefix = s.text.slice(0, gsplit);
         const pw = strAdvance(s, prefix);

--- a/packages/docx/src/sea-line-break.test.ts
+++ b/packages/docx/src/sea-line-break.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_KINSOKU_RULES, seaWordBreakOffsets } from '@silurus/ooxml-core';
+import { DEFAULT_KINSOKU_RULES, graphemeClusterOffsets, seaWordBreakOffsets } from '@silurus/ooxml-core';
 import { layoutLines, type LayoutLine, type LayoutSeg, type LayoutTextSeg } from './line-layout.js';
 
 // Issue #797 — dictionary-based line breaking for Thai/Lao/Khmer (no inter-word
@@ -119,5 +119,65 @@ describe('SEA (Thai) dictionary line breaking in docx layoutLines', () => {
     const lines = lay([textSeg('hello '), textSeg('world')], 30);
     expect(lineTexts(lines).join('')).toContain('hello');
     expect(lineTexts(lines).join('')).toContain('world');
+  });
+});
+
+// Issue #961 — Myanmar and Tibetan write without inter-word spaces. Word (macOS)
+// ground truth (sample-46) breaks them at GRAPHEME-cluster boundaries with maximal
+// line fill — NOT dictionary words (Myanmar) and NOT the tsheg rule (Tibetan) —
+// and never splits a base + stacked/combining cluster. Before this fix the wrap
+// fell to the generic over-long-word splitter, which cut at CODE-POINT granularity
+// and could tear a cluster (e.g. Myanmar `တို` → `တိ` | `ု`).
+describe('Myanmar / Tibetan grapheme-fill line breaking in docx layoutLines', () => {
+  const myanmar = 'မြန်မာဘာသာစကားကိုစာလုံးများအကြားတွင်ကွက်လပ်မထားဘဲဆက်တိုက်ရေးသားလေ့ရှိသည်';
+  const tibetan = 'བོད་ཡིག་ནི་ཚིག་གྲུབ་སོ་སོའི་བར་དུ་ཚེག་ཅེས་པའི་རྟགས།';
+
+  for (const [name, text] of [['Myanmar', myanmar], ['Tibetan', tibetan]] as const) {
+    it(`${name}: every break lands on a grapheme-cluster boundary (never tears a cluster)`, () => {
+      const texts = lineTexts(lay([textSeg(text)], 90)); // ~18 cp/line → several wraps
+      expect(texts.length).toBeGreaterThan(2); // it actually wrapped
+      expect(texts.join('')).toBe(text); // nothing lost or duplicated
+      const clusterStarts = new Set(graphemeClusterOffsets(text));
+      for (const b of breakOffsets(texts)) {
+        expect(clusterStarts.has(b)).toBe(true); // grapheme-safe, never mid-cluster
+      }
+    });
+
+    it(`${name}: packs multiple clusters per line (maximal fill, not one-per-line)`, () => {
+      const texts = lineTexts(lay([textSeg(text)], 90));
+      // A per-cluster (unfilled) break would leave lines of ~1 cluster; maximal fill
+      // packs many code points before each break.
+      for (const t of texts.slice(0, -1)) expect(t.length).toBeGreaterThan(6);
+    });
+
+    it(`${name}: keeps a run that fits on one line as a single contiguous draw`, () => {
+      const lines = lay([textSeg(text)], 2000); // wide enough for the whole run
+      expect(lines).toHaveLength(1);
+      const segs = lines[0].segments.filter((s): s is LayoutTextSeg => 'text' in s);
+      expect(segs).toHaveLength(1); // ONE draw (measure==paint), not fragmented
+      expect(segs[0].text).toBe(text);
+    });
+
+    it(`${name}: makes progress in a band narrower than one cluster (grapheme emergency split)`, () => {
+      const texts = lineTexts(lay([textSeg(text)], 3)); // < one cluster's width
+      expect(texts.join('')).toBe(text);
+      expect(texts.every((t) => t.length > 0)).toBe(true); // no empty line / infinite loop
+    });
+  }
+
+  it('does not use the ICU dictionary for Myanmar (breaks are grapheme, not word)', () => {
+    // Guard against regressing to dictionary breaking: the wrap breaks at grapheme
+    // boundaries, which are strictly denser than the ICU 'my' word boundaries.
+    const texts = lineTexts(lay([textSeg(myanmar)], 90));
+    const breaks = breakOffsets(texts);
+    const wordStarts = new Set<number>();
+    for (const s of new Intl.Segmenter('my', { granularity: 'word' }).segment(myanmar)) {
+      if (s.index > 0 && s.isWordLike) wordStarts.add(s.index);
+    }
+    expect(wordStarts.size).toBeGreaterThan(0);
+    // At least one break falls at a grapheme boundary that is NOT a dictionary word
+    // start (proves grapheme-fill, not dictionary). Robust to ICU drift: a maximal
+    // fill over ~18 cp/line reliably produces a non-word grapheme break.
+    expect(breaks.some((b) => !wordStarts.has(b))).toBe(true);
   });
 });

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -63,6 +63,7 @@ import {
   isCjkBreakChar,
   isUax14NoBreakPair,
   containsSeaScript,
+  isGraphemeFillText,
   seaMixedBreakOffsets,
   fitSeaWordPrefix,
   graphemeClusterOffsets,
@@ -1140,18 +1141,22 @@ export function layoutParagraph(
           }
           flush();
         };
+        // Grapheme-fill runs (Myanmar/Tibetan, #961) have dense per-cluster offsets:
+        // use the O(log n) monotone binary-search fit. Dictionary runs keep the
+        // negative-spacing-safe full scan.
+        const monotone = isGraphemeFillText(token);
         const N = token.length;
         let start = 0;
         while (start < N) {
           const avail = lineMaxW() - lineW;
-          let end = fitSeaWordPrefix(token, seaBreaks, start, avail, measureSub);
+          let end = fitSeaWordPrefix(token, seaBreaks, start, avail, measureSub, monotone);
           if (end <= start) {
             if (lineW > 0) { newLine(); continue; } // wrap first, retry empty line
             // Empty line, first word wider than the shape: grapheme-safe split.
             const firstWordEnd = seaBreaks.find((b) => b > start) ?? N;
             const firstWord = token.slice(start, firstWordEnd);
             const graphemes = graphemeClusterOffsets(firstWord);
-            let g = fitSeaWordPrefix(firstWord, graphemes, 0, avail, measureSub);
+            let g = fitSeaWordPrefix(firstWord, graphemes, 0, avail, measureSub, monotone);
             if (g <= 0) g = graphemes.length > 0 ? graphemes[0] : firstWord.length;
             end = start + g;
           }

--- a/packages/pptx/src/sea-line-break.test.ts
+++ b/packages/pptx/src/sea-line-break.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { seaWordBreakOffsets } from '@silurus/ooxml-core';
+import { graphemeClusterOffsets, seaWordBreakOffsets } from '@silurus/ooxml-core';
 import { layoutParagraph } from './renderer.js';
 import type { Paragraph } from './types';
 import type { TextRunData } from '@silurus/ooxml-core';
@@ -83,4 +83,23 @@ describe('pptx SEA (Thai) dictionary line breaking', () => {
     expect(textSegs).toHaveLength(1);
     expect(textSegs[0].text).toBe(thai);
   });
+});
+
+// Issue #961 — Myanmar/Tibetan grapheme-fill in pptx (same cross-package fix as
+// docx): break at grapheme-cluster boundaries with maximal fill, never tearing a
+// base + stacked cluster (previously the per-code-point over-long split could).
+describe('pptx Myanmar / Tibetan grapheme-fill line breaking', () => {
+  for (const [name, text] of [
+    ['Myanmar', 'မြန်မာဘာသာစကားကိုစာလုံးများအကြားတွင်ကွက်လပ်မထား'],
+    ['Tibetan', 'བོད་ཡིག་ནི་ཚིག་གྲུབ་སོ་སོའི་བར་དུ་ཚེག'],
+  ] as const) {
+    it(`${name}: wraps at grapheme boundaries, preserving the text`, () => {
+      const lines = layoutParagraph(mockCtx(), para([run(text)]), 120, 20, '000000', 1, 0);
+      const texts = lines.map(lineText);
+      expect(texts.length).toBeGreaterThan(1);
+      expect(texts.join('')).toBe(text);
+      const clusterStarts = new Set(graphemeClusterOffsets(text));
+      for (const b of breakOffsets(texts)) expect(clusterStarts.has(b)).toBe(true);
+    });
+  }
 });

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -6,7 +6,7 @@ import type {
   PhoneticRun, PhoneticProperties, PhoneticAlignment, Duotone,
 } from './types.js';
 import { placePhoneticRuns } from './phonetic.js';
-import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, seaMixedBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
+import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, isGraphemeFillText, seaMixedBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValueWithColor } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -1167,17 +1167,20 @@ export function layoutRichTextLines(
     if (seaBreaks.length === 0) { push(text, font); return; }
     ctx.font = buildFont(vertAlignDrawFont(font), cs);
     const measureSub = (sub: string): number => ctx.measureText(sub).width;
+    // Grapheme-fill runs (Myanmar/Tibetan, #961) have dense per-cluster offsets:
+    // O(log n) monotone binary-search fit. Dictionary runs keep the full scan.
+    const monotone = isGraphemeFillText(text);
     const N = text.length;
     let start = 0;
     while (start < N) {
       const avail = maxWidth - curW;
-      let end = fitSeaWordPrefix(text, seaBreaks, start, avail, measureSub);
+      let end = fitSeaWordPrefix(text, seaBreaks, start, avail, measureSub, monotone);
       if (end <= start) {
         if (curW > 0) { flush(); continue; } // wrap first, retry on an empty line
         const firstWordEnd = seaBreaks.find((b) => b > start) ?? N;
         const firstWord = text.slice(start, firstWordEnd);
         const graphemes = graphemeClusterOffsets(firstWord);
-        let g = fitSeaWordPrefix(firstWord, graphemes, 0, avail, measureSub);
+        let g = fitSeaWordPrefix(firstWord, graphemes, 0, avail, measureSub, monotone);
         if (g <= 0) g = graphemes.length > 0 ? graphemes[0] : firstWord.length;
         end = start + g;
       }

--- a/packages/xlsx/src/sea-line-break.test.ts
+++ b/packages/xlsx/src/sea-line-break.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { seaMixedBreakOffsets, seaTransitionOffsets, seaWordBreakOffsets } from '@silurus/ooxml-core';
+import { graphemeClusterOffsets, seaMixedBreakOffsets, seaTransitionOffsets, seaWordBreakOffsets } from '@silurus/ooxml-core';
 import { wrapParagraphLines, layoutRichTextLines } from './renderer.js';
 import type { CellFont, Run } from './types.js';
 
@@ -106,4 +106,28 @@ describe('xlsx SEA↔non-SEA no-space transitions (#960)', () => {
     for (const b of breakOffsets(texts)) expect(legalSet.has(b)).toBe(true);
     expect(breakOffsets(texts).some((b) => transitions.has(b))).toBe(true);
   });
+});
+
+// Issue #961 — Myanmar/Tibetan grapheme-fill in xlsx (same cross-package fix):
+// wrap at grapheme-cluster boundaries with maximal fill, never tearing a cluster.
+describe('xlsx Myanmar / Tibetan grapheme-fill breaking', () => {
+  for (const [name, text] of [
+    ['Myanmar', 'မြန်မာဘာသာစကားကိုစာလုံးများအကြားတွင်ကွက်လပ်မထား'],
+    ['Tibetan', 'བོད་ཡིག་ནི་ཚིག་གྲུབ་སོ་སོའི་བར་དུ་ཚེག'],
+  ] as const) {
+    it(`${name}: plain path wraps grapheme-safely and preserves text`, () => {
+      const out = wrapParagraphLines(ctx, text, 120);
+      expect(out.length).toBeGreaterThan(1);
+      expect(out.join('')).toBe(text);
+      const clusterStarts = new Set(graphemeClusterOffsets(text));
+      for (const b of breakOffsets(out)) expect(clusterStarts.has(b)).toBe(true);
+    });
+    it(`${name}: rich path wraps grapheme-safely and preserves text`, () => {
+      const texts = richText(layoutRichTextLines(ctx, [{ text }] as Run[], baseFont, 1, 120));
+      expect(texts.length).toBeGreaterThan(1);
+      expect(texts.join('')).toBe(text);
+      const clusterStarts = new Set(graphemeClusterOffsets(text));
+      for (const b of breakOffsets(texts)) expect(clusterStarts.has(b)).toBe(true);
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Extends no-inter-word-space line breaking to **Myanmar** (U+1000–109F, + Extended-A/B) and **Tibetan** (U+0F00–0FFF), following #955 (Thai/Lao/Khmer). Driven by Word ground truth rather than the original "dictionary breaking" premise.

## Adjudication (Word / macOS ground truth)

Measured Word's actual line-break positions from a narrow-column export (per-glyph `pdftotext -bbox`, one paragraph per script). Full measurement is recorded on issue #961.

- **Tibetan** — 6 breaks: all land on grapheme-cluster boundaries; only **2/6** fall after a tsheg `་`; **4/6 split a syllable mid-cluster** (e.g. `ཅེ|ས`, `ཡི|ན`). ICU `bo` word boundaries and the tsheg-after rule are both refuted.
- **Myanmar** — 5 breaks: all on grapheme boundaries; **4/5** coincide with an ICU `my` word boundary, but one splits the single word `သည்` as `သ|ည`, which no dictionary would do. ICU ships a Burmese dictionary Word declines to use.

**Verdict:** Word breaks both scripts at **grapheme-cluster boundaries with maximal fill** — not dictionary words, not the tsheg — and never splits a base + stacked cluster. Adding them to the ICU dictionary path would diverge from Word.

## Implementation

- Classify Myanmar/Tibetan as **grapheme-fill** no-space scripts. `seaWordBreakOffsets` returns every interior grapheme-cluster boundary for their spans (instead of ICU word starts); they then flow through the existing shared wrap kernel and break at grapheme clusters, matching Word. Thai/Lao/Khmer dictionary breaking is unchanged; spans are kept same-class so dictionary and grapheme-fill text never merge.
- **Fixes a pre-existing defect:** the generic over-long-run splitter cut at code-point granularity and could tear a base + combining cluster (leaving a floating vowel sign at a line head) — in all three renderers.
- **Perf:** grapheme-fill offsets are dense (one per cluster), so `fitSeaWordPrefix` gains an `assumeMonotone` O(log n) binary-search fast path (matching the monotone assumption `fitCJKPrefix` already makes). Without it a long run wrapped in O(n²): a 2600-cluster run went from ~6.5s to ~47ms. Dictionary scripts keep the negative-spacing-safe full scan. Wired into docx/pptx/xlsx via a new `isGraphemeFillText` predicate.
- Hardened `graphemeClusterOffsets` to fall back to code-point boundaries if the grapheme segmenter throws (not only when absent).

## Testing

- New unit tests: core (`isSeaScriptCodePoint` ranges, grapheme-fill offsets, `assumeMonotone` parity + call-count guard, `isGraphemeFillText`), and docx/pptx/xlsx wrap tests asserting grapheme-safe breaks + text preservation.
- `vitest run` (core + docx + pptx + xlsx): all pass. Full suite green.
- Root `pnpm typecheck`: clean.
- docx demo VRT: non-regression (byte-identical — demo carries no SEA content).
- Independent read-only review by Codex (gpt-5.6-sol); its performance finding drove the binary-search fast path.

Closes #961
