### PR TITLE
fix(docx): distribute thaiDistribute across Thai grapheme clusters

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -378,6 +378,7 @@ export {
   type SeaScript,
   type SeaWordSegmenter,
   isSeaScriptCodePoint,
+  isSeaGraphemeExtend,
   containsSeaScript,
   seaWordBreakOffsets,
   fitSeaWordPrefix,

--- a/packages/core/src/text/line-distribute.test.ts
+++ b/packages/core/src/text/line-distribute.test.ts
@@ -278,3 +278,114 @@ describe('distributeLineSlack — injected whitespace predicate (pptx parity)', 
     expect(r).toBeNull();
   });
 });
+
+// ── SEA grapheme-cluster distribution (thaiDistribute / thaiDist) ─────────────
+//
+// WordprocessingML `thaiDistribute` (§17.18.44 "Thai Language Justification") and
+// DrawingML `thaiDist` (§20.1.10.59, "each character is treated as a word")
+// distribute the line's slack across Thai/Lao/Khmer text at GRAPHEME-CLUSTER
+// granularity, NOT at inter-word spaces (there are none) nor at dictionary word
+// boundaries. `both`/`distribute`/`just`/`dist` do NOT: a SEA line under those
+// values reaches no inter-CJK/space gap and stays natural (ragged).
+//
+// Ground truth (the adjudication fixture, measured with pdftotext/pdfplumber on
+// the Word-exported PDF, narrow 2.5in column, Leelawadee UI 14pt):
+//   • jc=both / distribute over continuous Thai (no spaces): interior glyph gaps
+//     stay at the natural ~0.04pt — no cluster distribution; line ends ragged.
+//   • jc=thaiDistribute over the SAME text: every inter-CLUSTER gap widens
+//     uniformly (0.14–0.29pt on a nearly-full line; 7–13pt on a short line) so the
+//     line reaches the right text margin, while a combining vowel/tone mark stays
+//     glued to its base consonant (no slack inside a cluster).
+// The `seaClusterGaps` option reproduces this: a gap opens at each UAX#29 grapheme
+// boundary interior to a SEA span; a boundary before a combining mark opens none.
+describe('distributeLineSlack — SEA grapheme-cluster gaps (thaiDistribute)', () => {
+  // "กิน" = ก (base) + ◌ิ (U+0E34 above-vowel, combining) + น (base). Extended
+  // grapheme clusters: [กิ][น] — ONE interior boundary, before น (offset 2). The
+  // slack lands at that boundary; NO gap opens before the combining ◌ิ.
+  it('opens a gap at the cluster boundary, never before a combining mark', () => {
+    const r = distributeLineSlack([seg('กิน')], 30, {
+      firstContentSi: 0,
+      lastDrawnSi: 1, // sentinel: do not exclude the sole segment
+      seaClusterGaps: true,
+    });
+    expect(r).not.toBeNull();
+    const s = r!.perSeg.get(0)!;
+    expect(s.splitBefore).toEqual([2]); // before น only — ◌ิ stays glued to ก
+    expect(s.trailingGap).toBe(false);
+    expect(r!.perGap).toBeCloseTo(30, 6);
+    expect(totalStretch(r!)).toBeCloseTo(30, 6);
+  });
+
+  // "เมือง" = เ(U+0E40 leading vowel) ม(base) ◌ื(U+0E37 combining) อ(base) ง(base).
+  // Clusters: [เ][มื][อ][ง] — three interior boundaries before offsets 1, 3, 4.
+  // The leading vowel เ is its OWN cluster (a gap opens after it), and ◌ื stays
+  // glued to ม (no gap before offset 2).
+  it('treats a Thai leading vowel as its own cluster and keeps marks glued', () => {
+    const r = distributeLineSlack([seg('เมือง')], 30, {
+      firstContentSi: 0,
+      lastDrawnSi: 1,
+      seaClusterGaps: true,
+    });
+    expect(r).not.toBeNull();
+    const s = r!.perSeg.get(0)!;
+    expect(s.splitBefore).toEqual([1, 3, 4]); // after เ, after ◌ื, after อ
+    expect(r!.perGap).toBeCloseTo(10, 6); // 30 / 3 gaps
+    expect(totalStretch(r!)).toBeCloseTo(30, 6);
+  });
+
+  // Without seaClusterGaps, the SAME Thai text is NOT distributed: Thai is not
+  // CJK and has no inter-word space, so no gap opens → null. This pins the
+  // adjudication distinction that `both`/`distribute` leave Thai ragged; only
+  // `thaiDistribute` opts into cluster distribution.
+  it('leaves Thai untouched when seaClusterGaps is off (both / distribute)', () => {
+    expect(
+      distributeLineSlack([seg('เมือง')], 30, { firstContentSi: 0, lastDrawnSi: 1 }),
+    ).toBeNull();
+  });
+
+  // Slack distributes ACROSS a colour change: two Thai segments of one phrase get
+  // a cluster gap at the segment boundary too (clustering is evaluated over the
+  // whole line's code-point stream, so a style split mid-phrase does not swallow a
+  // boundary). "กา"|"งาน" — both segments SEA, boundary ก|า is intra… actually
+  // า(U+0E32) is a spacing vowel = its own cluster, so ก|า, า|ง, ง|า, า|น are all
+  // cluster boundaries; the า|ง boundary falls between the two segments.
+  it('opens a cross-segment cluster gap (trailingGap) between SEA segments', () => {
+    const r = distributeLineSlack([seg('กา'), seg('งาน')], 40, {
+      firstContentSi: 0,
+      lastDrawnSi: 2, // sentinel: exclude no segment
+      seaClusterGaps: true,
+    });
+    expect(r).not.toBeNull();
+    const s0 = r!.perSeg.get(0)!;
+    const s1 = r!.perSeg.get(1)!;
+    // seg0 "กา": interior gap before า (offset 1) + trailing gap into seg1.
+    expect(s0.splitBefore).toEqual([1]);
+    expect(s0.trailingGap).toBe(true);
+    // seg1 "งาน": interior gaps before า (1) and น (2); no trailing (line end).
+    expect(s1.splitBefore).toEqual([1, 2]);
+    expect(s1.trailingGap).toBe(false);
+    // 4 gaps total across the two segments.
+    expect(totalStretch(r!)).toBeCloseTo(40, 6);
+    expect(r!.perGap).toBeCloseTo(10, 6);
+  });
+
+  // A non-SEA boundary inside a seaClusterGaps line still follows the ordinary
+  // rules: Latin|Latin opens nothing, so "abค" (Latin a,b then Thai ค) gets ONE
+  // cluster gap — but only at the SEA a… the b|ค boundary is Latin|Thai (mixed),
+  // not both-SEA, so it opens no cluster gap; ค is the last content unit anyway.
+  it('restricts cluster gaps to boundaries where BOTH sides are SEA', () => {
+    // "กขา" is all Thai: ก(base) ข(base) า(spacing vowel). Clusters [ก][ข][า] →
+    // gaps before offsets 1 and 2. Mixed content "ab" prefix (Latin) opens no gap.
+    const r = distributeLineSlack([seg('abกขา')], 30, {
+      firstContentSi: 0,
+      lastDrawnSi: 1,
+      seaClusterGaps: true,
+    });
+    expect(r).not.toBeNull();
+    const s = r!.perSeg.get(0)!;
+    // Only the Thai cluster boundaries (before ข at offset 3, before า at offset 4)
+    // open; a|b and b|ก (Latin|Thai) open nothing.
+    expect(s.splitBefore).toEqual([3, 4]);
+    expect(r!.perGap).toBeCloseTo(15, 6);
+  });
+});

--- a/packages/core/src/text/line-distribute.ts
+++ b/packages/core/src/text/line-distribute.ts
@@ -33,6 +33,7 @@
 // and packages/docx/src/text-distribute.ts for the format adapters.
 
 import { isCjkBreakChar } from './cjk-ranges.js';
+import { isSeaScriptCodePoint, isSeaGraphemeExtend } from './sea-break.js';
 
 /** A laid-out segment as the distributor sees it. Only the optional text matters;
  *  an undefined `text` marks a non-text inline atom (image / math / tab) — one
@@ -101,6 +102,16 @@ export interface DistributeOptions {
    *  Whitespace is classified FIRST, so an ideographic space is one inter-word
    *  gap and never reaches `isGapChar`. */
   isWhitespace?: (cp: number) => boolean;
+  /** WordprocessingML `thaiDistribute` (§17.18.44) / DrawingML `thaiDist`
+   *  (§20.1.10.59). When true, a gap ALSO opens at every UAX#29 grapheme-cluster
+   *  boundary INTERIOR to a Southeast-Asian span (Thai/Lao/Khmer), so a line of
+   *  space-free SEA text is justified by widening inter-CLUSTER gaps — a combining
+   *  vowel/tone mark stays glued to its base (no slack inside a cluster). Off by
+   *  default: `both`/`distribute`/`just`/`dist` do NOT distribute SEA text (Word/
+   *  PowerPoint leave it ragged). Only boundaries whose BOTH sides are SEA open
+   *  this way; non-SEA boundaries keep the ordinary space/CJK rules. Verified
+   *  against the Word-exported adjudication fixture (issue #959). */
+  seaClusterGaps?: boolean;
 }
 
 /** Default inter-word whitespace (WordprocessingML): ASCII space + ideographic
@@ -141,6 +152,7 @@ export function distributeLineSlack<T extends DistributeSeg>(
   const minPerGap = opts.minPerGap ?? -Infinity;
   const isGapChar = opts.isGapChar ?? isCjkBreakChar;
   const isWhitespace = opts.isWhitespace ?? defaultIsWhitespace;
+  const seaClusterGaps = opts.seaClusterGaps ?? false;
 
   // Flatten the eligible segments to a code-point stream. Segments before
   // `firstContentSi` (leading indent) are skipped; the rest — INCLUDING the
@@ -184,7 +196,9 @@ export function distributeLineSlack<T extends DistributeSeg>(
   // stretches). Whitespace → one inter-word gap (each space stretches).
   // Non-space → an inter-CJK gap only when the boundary to the next NON-space
   // unit satisfies `isGapChar` on either side; a boundary INTO whitespace is
-  // already counted by that whitespace, so it is not double-counted.
+  // already counted by that whitespace, so it is not double-counted. Under
+  // seaClusterGaps a boundary between two SEA code points ALSO opens when it is a
+  // grapheme-cluster start (never before a combining mark).
   const gapAfter = new Array<boolean>(units.length).fill(false);
   let total = 0;
   for (let k = first; k < last; k++) {
@@ -201,7 +215,18 @@ export function distributeLineSlack<T extends DistributeSeg>(
     const rc = nx.cp;
     if (
       (lc !== undefined && isGapChar(lc)) ||
-      (rc !== undefined && isGapChar(rc))
+      (rc !== undefined && isGapChar(rc)) ||
+      // thaiDistribute: a grapheme-cluster boundary interior to a SEA span. For
+      // two adjacent SEA code points the boundary is a cluster start iff the RIGHT
+      // side is NOT an Extend/SpacingMark (the SEA blocks have no Prepend), so a
+      // base + combining vowel/tone mark is never split. This code-point-local
+      // test needs no `Intl.Segmenter`, so it stays correct on every runtime.
+      (seaClusterGaps &&
+        lc !== undefined &&
+        rc !== undefined &&
+        isSeaScriptCodePoint(lc) &&
+        isSeaScriptCodePoint(rc) &&
+        !isSeaGraphemeExtend(rc))
     ) {
       gapAfter[k] = true;
       total++;

--- a/packages/core/src/text/sea-break.test.ts
+++ b/packages/core/src/text/sea-break.test.ts
@@ -3,6 +3,7 @@ import {
   containsSeaScript,
   fitSeaWordPrefix,
   graphemeClusterOffsets,
+  isSeaGraphemeExtend,
   isSeaScriptCodePoint,
   resetSeaSegmenterForTest,
   seaWordBreakOffsets,
@@ -34,6 +35,56 @@ describe('isSeaScriptCodePoint', () => {
       expect(isSeaScriptCodePoint(cp)).toBe(expected);
     });
   }
+});
+
+describe('isSeaGraphemeExtend', () => {
+  const cases: [number, boolean][] = [
+    [0x0e01, false], // THAI CHARACTER KO KAI (base consonant) — cluster start
+    [0x0e31, true], //  THAI MAI HAN-AKAT (above vowel) — extend
+    [0x0e33, true], //  THAI SARA AM — clusters onto its base (UAX#29 non-break)
+    [0x0e34, true], //  THAI SARA I (above vowel) — extend
+    [0x0e3a, true], //  THAI PHINTHU — extend
+    [0x0e3b, false], // unassigned gap between vowel block and currency — not extend
+    [0x0e40, false], // THAI SARA E (leading vowel, spacing) — its own cluster
+    [0x0e48, true], //  THAI MAI EK (tone mark) — extend
+    [0x0e4e, true], //  THAI YAMAKKAN — extend
+    [0x0e50, false], // THAI DIGIT ZERO — cluster start
+    [0x0eb1, true], //  LAO VOWEL SIGN MAI KAN — extend
+    [0x0ec8, true], //  LAO TONE MAI EK — extend
+    [0x17b6, true], //  KHMER VOWEL SIGN AA (spacing mark) — extend
+    [0x17d2, true], //  KHMER SIGN COENG (subscript former) — extend
+    [0x17dd, true], //  KHMER SIGN ATTHACAN — extend
+    [0x1780, false], // KHMER LETTER KA (base) — cluster start
+    [0x0041, false], // Latin A — not SEA, not extend
+  ];
+  for (const [cp, expected] of cases) {
+    it(`U+${cp.toString(16).toUpperCase().padStart(4, '0')} → ${expected}`, () => {
+      expect(isSeaGraphemeExtend(cp)).toBe(expected);
+    });
+  }
+
+  // The predicate must agree with the platform grapheme segmenter for every SEA
+  // code point: for two adjacent SEA code points a UAX#29 grapheme break falls
+  // before the right one iff it is NOT extend (the SEA blocks have no Prepend),
+  // so this is the sole cluster rule the thaiDistribute justifier relies on — and
+  // unlike the segmenter it needs no `Intl.Segmenter`, staying correct in the
+  // graceful-fallback runtimes.
+  it('matches Intl.Segmenter grapheme clustering across all SEA code points', () => {
+    if (typeof Intl?.Segmenter !== 'function') return; // environment lacks the segmenter
+    const seg = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+    const clustersOne = (s: string): boolean => [...seg.segment(s)].length === 1;
+    for (const [lo, hi] of [
+      [0x0e00, 0x0e7f],
+      [0x0e80, 0x0eff],
+      [0x1780, 0x17ff],
+    ]) {
+      for (let cp = lo; cp <= hi; cp++) {
+        // "ก" + cp is one cluster exactly when cp extends the preceding base.
+        const segmenterSaysExtend = clustersOne('ก' + String.fromCodePoint(cp));
+        expect(isSeaGraphemeExtend(cp), `U+${cp.toString(16)}`).toBe(segmenterSaysExtend);
+      }
+    }
+  });
 });
 
 describe('containsSeaScript', () => {

--- a/packages/core/src/text/sea-break.ts
+++ b/packages/core/src/text/sea-break.ts
@@ -45,6 +45,39 @@ export function isSeaScriptCodePoint(cp: number): boolean {
   );
 }
 
+/**
+ * True when `cp` is a Southeast-Asian (Thai/Lao/Khmer) combining mark that
+ * EXTENDS the preceding grapheme cluster rather than starting a new one — i.e.
+ * its UAX#29 Grapheme_Cluster_Break is `Extend` or `SpacingMark` (above/below
+ * vowel signs, tone marks, the Khmer COENG subscript-former, etc.). These are
+ * exactly the code points a `thaiDistribute` justifier must NOT open a gap
+ * before, so a base consonant keeps its marks glued.
+ *
+ * For a boundary between two SEA code points this predicate is sufficient to
+ * decide grapheme clustering: the SEA blocks contain no `Prepend` characters
+ * (verified against UCD), so a break falls before every SEA code point EXCEPT an
+ * Extend/SpacingMark. Ranges derived from the Unicode Character Database
+ * (Grapheme_Cluster_Break), cross-checked against `Intl.Segmenter` grapheme
+ * output — so this stays correct even where the platform `Intl.Segmenter` is
+ * unavailable (the {@link graphemeClusterOffsets} code-point fallback is NOT
+ * cluster-safe and must not gate SEA distribution).
+ */
+export function isSeaGraphemeExtend(cp: number): boolean {
+  return (
+    // Thai (U+0E00–0E7F): MAI HAN-AKAT; SARA AM..PHINTHU; MAITAIKHU..YAMAKKAN.
+    cp === 0x0e31 ||
+    (cp >= 0x0e33 && cp <= 0x0e3a) ||
+    (cp >= 0x0e47 && cp <= 0x0e4e) ||
+    // Lao (U+0E80–0EFF): MAI KAN; SIGN PALI VIRAMA..semivowel signs; tone marks.
+    cp === 0x0eb1 ||
+    (cp >= 0x0eb3 && cp <= 0x0ebc) ||
+    (cp >= 0x0ec8 && cp <= 0x0ece) ||
+    // Khmer (U+1780–17FF): vowel signs, COENG, robat, signs (17B4–17D3) + ATTHACAN.
+    (cp >= 0x17b4 && cp <= 0x17d3) ||
+    cp === 0x17dd
+  );
+}
+
 /** The SEA script of a code point already known to be SEA (see
  *  {@link isSeaScriptCodePoint}). Used to pick the per-span ICU dictionary. */
 function seaScriptOf(cp: number): SeaScript {

--- a/packages/docx/src/bidi-line.test.ts
+++ b/packages/docx/src/bidi-line.test.ts
@@ -81,9 +81,11 @@ describe('jcIsFullyJustified (§17.18.44)', () => {
 });
 
 describe('jcStretchesLastLine (§17.18.44)', () => {
-  it('stretches the last line only for distribute + thaiDistribute', () => {
+  it('stretches the last line only for distribute', () => {
     expect(jcStretchesLastLine('distribute')).toBe(true);
-    expect(jcStretchesLastLine('thaiDistribute')).toBe(true);
+    // thaiDistribute leaves its final line ragged like `both` (Word GT, #959):
+    // only non-final lines get the Thai cluster distribution.
+    expect(jcStretchesLastLine('thaiDistribute')).toBe(false);
     // both/justify/kashida leave the last line as-is.
     for (const jc of ['both', 'justify', 'lowKashida', 'mediumKashida', 'highKashida', 'left', undefined]) {
       expect(jcStretchesLastLine(jc), String(jc)).toBe(false);

--- a/packages/docx/src/bidi-line.ts
+++ b/packages/docx/src/bidi-line.ts
@@ -250,9 +250,12 @@ export function jcIsFullyJustified(alignment: string | undefined): boolean {
 }
 
 /** ECMA-376 §17.18.44 — whether a `w:jc` value also stretches the paragraph's
- *  LAST line (unlike `both`, whose final line is left as-is). `distribute` and
- *  its Thai optimization `thaiDistribute` both spread every line, including the
- *  last. */
+ *  LAST line. `distribute` fills its final line too (unlike `both`). But
+ *  `thaiDistribute` does NOT: measured against the Word-exported ground truth
+ *  (issue #959 adjudication fixture), a thaiDistribute paragraph's final line is
+ *  left flush-left and ragged — reaching only its natural width — exactly like
+ *  `both`, while its non-final lines are fully justified across the Thai clusters.
+ *  So only `distribute` stretches the last line. */
 export function jcStretchesLastLine(alignment: string | undefined): boolean {
-  return alignment === 'distribute' || alignment === 'thaiDistribute';
+  return alignment === 'distribute';
 }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7465,11 +7465,12 @@ function renderParagraph(
   }
 
   // ECMA-376 §17.18.44 ST_Jc: "both" / "justify" / "distribute" (and the kashida
-  // + thaiDistribute variants) fully justify the line by expanding inter-word
-  // spaces. The last line of a "both" paragraph is traditionally left-aligned
-  // (not stretched); "distribute"/"thaiDistribute" also stretch the last line. We
-  // count whitespace chars in trailing positions of each segment and divide the
-  // slack proportionally across them. (jc classification lives in bidi-line so the
+  // + thaiDistribute variants) fully justify each line by expanding inter-word
+  // spaces (and, for expansion, inter-CJK boundaries; thaiDistribute also opens
+  // Thai grapheme-cluster boundaries). The last line is traditionally left-
+  // aligned (not stretched) for "both"/kashida AND "thaiDistribute" (Word GT,
+  // issue #959); only "distribute" also stretches the last line. The slack is
+  // divided across the eligible gaps. (jc classification lives in bidi-line so the
   // §17.18.44 knowledge stays single-source.)
   const isJustified = jcIsFullyJustified(para.alignment);
   const stretchLastLine = jcStretchesLastLine(para.alignment);
@@ -7964,6 +7965,10 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
         paraNeedsBidi ? lastDrawnSi : segCount,
         minPerGap,
         residualSlack > 0,
+        // §17.18.44 thaiDistribute: on expansion, also open a gap at every Thai/
+        // Lao/Khmer grapheme-cluster boundary so a space-free SEA line justifies
+        // by inter-cluster pitch (Word GT: issue #959). `both`/`distribute` don't.
+        para.alignment === 'thaiDistribute' && residualSlack > 0,
       );
       segStretch = dist ? dist.perSeg : null;
       distPerGap = dist ? dist.perGap : 0;
@@ -9999,7 +10004,7 @@ export function renderShapeText(
       // ruby is carried through the shared line engine and painted above the base
       // glyphs like body text ruby (§17.3.3.25).
       const { lines: lineList, baseRtl, ind } = layout;
-      // 'distribute'/'thaiDistribute' spread every line; 'both'/'justify'/kashida
+      // 'distribute' spreads every line; 'both'/'justify'/kashida/'thaiDistribute'
       // spread all but the logical-last; otherwise resolve the physical edge from
       // the block alignment + base dir. (§17.18.44 classification in bidi-line.)
       const alignEdge = jcIsFullyJustified(layout.alignment)
@@ -10146,6 +10151,9 @@ export function renderShapeText(
             paraNeedsBidi ? lastDrawnSi : segCount,
             minPerGap,
             residualSlack > 0,
+            // §17.18.44 thaiDistribute: open Thai/Lao/Khmer cluster gaps on
+            // expansion so a space-free SEA line justifies (issue #959).
+            layout.alignment === 'thaiDistribute' && residualSlack > 0,
           );
           segStretch = dist ? dist.perSeg : null;
           distPerGap = dist ? dist.perGap : 0;

--- a/packages/docx/src/text-distribute.ts
+++ b/packages/docx/src/text-distribute.ts
@@ -84,6 +84,13 @@ export type {
  *                       — used for COMPRESSION (negative slack), where shrinking a
  *                       space is legitimate but overlapping two ideographs is not,
  *                       so the renderer passes includeCJK = slack > 0.
+ * @param seaClusterGaps When true (jc=thaiDistribute, §17.18.44 "Thai Language
+ *                       Justification"), a gap ALSO opens at every UAX#29
+ *                       grapheme-cluster boundary interior to a Southeast-Asian
+ *                       span (Thai/Lao/Khmer) whose both sides are SEA, so a
+ *                       space-free Thai line is justified by widening inter-cluster
+ *                       gaps (a combining mark stays glued to its base). Off for
+ *                       `both`/`distribute`, which leave SEA text ragged (Word GT).
  * @returns The distribution, or `null` when nothing stretches.
  */
 export function distributeLineSlack(
@@ -93,11 +100,13 @@ export function distributeLineSlack(
   lastDrawnSi: number,
   minPerGap = -Infinity,
   includeCJK = true,
+  seaClusterGaps = false,
 ): DistributeResult | null {
   return distributeLineSlackCore(segments, slack, {
     firstContentSi,
     lastDrawnSi,
     minPerGap,
+    seaClusterGaps,
     // Compression (includeCJK=false) opens spaces only; never widen an inter-CJK
     // boundary, which would overlap ideographs. The kernel default isGapChar
     // (core.isCjkBreakChar) handles expansion.

--- a/packages/docx/src/thai-distribute.test.ts
+++ b/packages/docx/src/thai-distribute.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type { DocParagraph, DocxDocumentModel, SectionProps, DocRun } from './types.js';
+
+// ECMA-376 §17.18.44 `thaiDistribute` ("Thai Language Justification") — issue
+// #959. Thai has no inter-word spaces, so `both`/`distribute` reach no gap on a
+// continuous-Thai line and leave it ragged. `thaiDistribute` instead distributes
+// the line's slack across every GRAPHEME-CLUSTER boundary (a combining vowel/tone
+// mark stays glued to its base), justifying the non-final lines to the right text
+// margin. Verified against the Word-exported adjudication fixture:
+//   • both / distribute over continuous Thai: interior gaps stay natural, ragged.
+//   • thaiDistribute: every inter-cluster gap widens uniformly → line fills the
+//     margin; the paragraph's FINAL line stays flush-left / ragged (like `both`).
+// These end-to-end tests drive the docx renderer with a recording canvas (each
+// code point measured at a fixed px) and read back the drawn glyph x-positions.
+
+interface FillCall {
+  text: string;
+  x: number;
+  y: number;
+}
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[] } {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const fills: FillCall[] = [];
+  const ctx = {
+    get font() {
+      return font;
+    },
+    set font(v: string) {
+      font = v;
+    },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {}, strokeRect() {},
+    rect() {}, clip() {}, scale() {}, translate() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(text: string, x: number, y: number) { fills.push({ text, x, y }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills };
+}
+
+const PAGE_W = 240;
+const FS = 10; // px per code point; scale = 1 px/pt, zero margins
+
+// A continuous Thai sentence (no spaces) long enough to wrap to several lines in
+// the narrow column. "การเขียนภาษาไทย…" repeated.
+const THAI = 'การเขียนภาษาไทยไม่ใช้ช่องว่างระหว่างคำแต่ใช้ช่องว่างเฉพาะเมื่อจบประโยค';
+
+function textRun(text: string): DocRun {
+  return {
+    type: 'text', text,
+    bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: FS, color: null, fontFamily: 'Leelawadee UI', fontFamilyEastAsia: 'Leelawadee UI',
+    isLink: false, background: null, vertAlign: null, hyperlink: null,
+  } as unknown as DocRun;
+}
+
+function thaiPara(alignment: string): DocParagraph {
+  return {
+    alignment,
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null,
+    tabStops: [],
+    runs: [textRun(THAI)],
+    defaultFontSize: FS, defaultFontFamily: 'Leelawadee UI', widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function doc(p: DocParagraph): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: PAGE_W, pageHeight: 800,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [{ type: 'paragraph', ...p }],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Leelawadee UI': 'sansSerif' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function render(alignment: string): Promise<FillCall[]> {
+  const { canvas, fills } = makeRecordingCanvas();
+  await renderDocumentToCanvas(doc(thaiPara(alignment)), canvas, 0, { dpr: 1, width: PAGE_W });
+  return fills;
+}
+
+/** Group drawn glyph pieces by baseline y (one group per rendered line) and
+ *  return each line's rightmost drawn edge px, ordered top→bottom. */
+function lineRightEdges(fills: FillCall[]): number[] {
+  const byY = new Map<number, number>();
+  for (const f of fills) {
+    const key = Math.round(f.y);
+    const right = f.x + [...f.text].length * FS;
+    byY.set(key, Math.max(byY.get(key) ?? -Infinity, right));
+  }
+  return [...byY.entries()].sort((a, b) => a[0] - b[0]).map(([, r]) => r);
+}
+
+describe('thaiDistribute justifies continuous Thai at cluster granularity (§17.18.44, #959)', () => {
+  it('fills non-final lines to the right margin under thaiDistribute', async () => {
+    const edges = lineRightEdges(await render('thaiDistribute'));
+    expect(edges.length).toBeGreaterThan(1);
+    // Every line EXCEPT the last reaches the right text margin (justified).
+    for (let i = 0; i < edges.length - 1; i++) {
+      expect(edges[i], `line ${i} right edge`).toBeCloseTo(PAGE_W, 1);
+    }
+    // The paragraph's FINAL line stays ragged (natural width < margin).
+    expect(edges[edges.length - 1]).toBeLessThan(PAGE_W - FS);
+  });
+
+  it('leaves the same Thai ragged under `both` (no cluster distribution)', async () => {
+    const edges = lineRightEdges(await render('both'));
+    expect(edges.length).toBeGreaterThan(1);
+    // No line — not even a non-final one — is stretched to the margin: Thai has no
+    // inter-word space and `both` never splits clusters, so each line ends at its
+    // natural width, short of the margin.
+    for (let i = 0; i < edges.length; i++) {
+      expect(edges[i], `both line ${i} right edge`).toBeLessThan(PAGE_W);
+    }
+  });
+
+  it('leaves the same Thai ragged under `distribute` too (unit is the token, not the cluster)', async () => {
+    const edges = lineRightEdges(await render('distribute'));
+    expect(edges.length).toBeGreaterThan(1);
+    for (let i = 0; i < edges.length; i++) {
+      expect(edges[i], `distribute line ${i} right edge`).toBeLessThan(PAGE_W);
+    }
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -3433,7 +3433,8 @@ export function renderTextBody(
     // (the `else` above). Disabled under bidi (visual≠logical order).
     const justifyMode =
       alignment === 'just' || alignment === 'justLow' ? 'just' as const
-      : alignment === 'dist' || alignment === 'thaiDist' ? 'dist' as const
+      : alignment === 'thaiDist' ? 'thaiDist' as const
+      : alignment === 'dist' ? 'dist' as const
       : null;
     // Tab-delimited cells keep their natural widths; the inline gaps provide
     // their stop alignment and must not participate in justification.

--- a/packages/pptx/src/text-justify.test.ts
+++ b/packages/pptx/src/text-justify.test.ts
@@ -31,6 +31,22 @@ describe('justifyLine', () => {
     expect(annot(r)).toEqual([['日本語', 0, [1, 2], 30]]);
   });
 
+  // §20.1.10.59 thaiDist ("each character is treated as a word"): a space-free
+  // Thai span distributes its slack across every grapheme-cluster boundary, with a
+  // combining mark glued to its base. "เมือง" = [เ][มื][อ][ง] → 3 interior
+  // boundaries before offsets 1, 3, 4 (◌ื at offset 2 stays glued to ม).
+  it("'thaiDist' distributes space-free Thai at grapheme-cluster boundaries", () => {
+    const r = justifyLine<Seg>([{ text: 'เมือง' }], 90, 60, 'thaiDist', false);
+    expect(annot(r)).toEqual([['เมือง', 0, [1, 3, 4], 10]]);
+  });
+
+  // 'dist' (the non-Thai variant) reaches NO gap on the same space-free Thai —
+  // Thai is not CJK and has no inter-word space — so it leaves the line ragged.
+  // This pins that thaiDist is NOT an alias of dist.
+  it("'dist' leaves space-free Thai ragged (no cluster gaps)", () => {
+    expect(justifyLine<Seg>([{ text: 'เมือง' }], 90, 60, 'dist', false)).toBeNull();
+  });
+
   it('pure Latin: widens inter-word spaces (kernel splits before the space-following word)', () => {
     // "Hello world foo": gaps fall before 'w' (code-point 6) and before 'f' (12).
     // slack 100, 2 gaps → perGap 50, no trailing gap.

--- a/packages/pptx/src/text-justify.ts
+++ b/packages/pptx/src/text-justify.ts
@@ -6,9 +6,13 @@
 // paragraph's LAST line natural (the spec notes it "does not justify
 // sentences which are short"); `dist` and `thaiDist` distribute the same way
 // but justify EVERY line, the last included ("Distributes the text words
-// across an entire text line"). justLow/thaiDist are the low-quality variants
-// — same distribution, only the kashida/glyph-stretch sophistication differs,
-// which Canvas cannot reproduce — so we treat just≡justLow and dist≡thaiDist.
+// across an entire text line"). `just`≡`justLow` (the low-quality variant only
+// changes the Arabic kashida sophistication, which Canvas cannot reproduce).
+// `thaiDist` distributes like `dist` but at a FINER granularity for Thai/Lao/
+// Khmer: the spec says "each character is treated as a word" (§20.1.10.59), so
+// its slack falls at every grapheme-CLUSTER boundary of a space-free SEA span,
+// not only at inter-word spaces / inter-CJK boundaries. It is therefore NOT an
+// alias of `dist` (which leaves such SEA text ragged); see the `thaiDist` mode.
 //
 // `just` and `dist` use the SAME gap selection (inter-word AND inter-CJK) and
 // differ ONLY in the last line (just: natural, dist: filled). This is
@@ -59,7 +63,7 @@ import { distributeLineSlack, isCjkBreakChar, type DistributeSeg } from '@siluru
  *  get the segment back with `jext` (and optionally `splitBefore`/`perGap`). */
 export type JustifySeg = DistributeSeg;
 
-export type JustifyMode = 'just' | 'dist';
+export type JustifyMode = 'just' | 'dist' | 'thaiDist';
 
 /** Justification annotation added to each segment of a line. The renderer reads
  *  these to widen the segment's contribution to the line: `jext` advances the
@@ -94,7 +98,9 @@ const isWsCp = (cp: number): boolean => /\s/.test(String.fromCodePoint(cp));
  *                    renderer disables justification under bidi).
  * @param availWidth  Content width to fill, px.
  * @param naturalWidth Sum of the segments' natural advance widths, px.
- * @param mode        'just' (last line stays natural) or 'dist' (every line).
+ * @param mode        'just' (last line stays natural), 'dist' (every line), or
+ *                    'thaiDist' ('dist' plus Thai/Lao/Khmer grapheme-cluster gaps
+ *                    — §20.1.10.59 "each character is treated as a word").
  * @param isLastLine  Whether this is the paragraph's final line.
  * @returns The same segments (shallow copies) with `jext`/`splitBefore`/`perGap`
  *          added, or `null` when no justification applies (last line under
@@ -128,6 +134,9 @@ export function justifyLine<T extends JustifySeg>(
     lastDrawnSi: segments.length,
     isGapChar: isCjkBreakChar,
     isWhitespace: isWsCp,
+    // `thaiDist` also opens a gap at every Thai/Lao/Khmer grapheme-cluster
+    // boundary, so space-free SEA text is distributed per §20.1.10.59.
+    seaClusterGaps: mode === 'thaiDist',
   });
   if (!dist) return null;
 


### PR DESCRIPTION
## Problem

WordprocessingML `thaiDistribute` (ECMA-376 §17.18.44, "Thai Language Justification") and DrawingML `thaiDist` (§20.1.10.59, "each character is treated as a word") must justify space-free Thai/Lao/Khmer (SEA) text by distributing the line's slack at **grapheme-cluster** granularity. Both mapped onto the generic justify path, which opens gaps only at inter-word spaces and inter-CJK boundaries — a continuous Thai line reached no gap and rendered ragged.

Closes #959.

## Adjudication (Word ground truth)

Measured a Word-exported PDF of a narrow-column Thai fixture (pdfplumber char boxes), one continuous Thai sentence under each of `both` / `distribute` / `thaiDistribute`, in a no-space and a phrase-spaced specimen. Full gap tables in the issue thread. Key findings:

- **Glyph advances are identical across all three jc values** — only inter-glyph gaps change, so no kashida/glyph elongation is involved.
- `both`: inter-word only; with no mid-line space, Thai stays ragged/left.
- `distribute`: space-delimited-token granularity + leading/trailing end-padding; does **not** split Thai clusters.
- `thaiDistribute`: slack spread **uniformly across every grapheme-cluster boundary**, non-final lines reach the right margin, combining marks never separated.
- Last line: `both` ragged; `distribute` filled/centered; **`thaiDistribute` ragged** (like `both`).

The issue's open question ("dictionary word gaps vs grapheme clusters") resolves to **grapheme clusters** (every cluster boundary, not dictionary word boundaries).

## Change

- **core** — new `seaClusterGaps` option in the shared slack distributor (`line-distribute.ts`). For two adjacent SEA code points a UAX#29 grapheme break falls before every code point **except** an Extend/SpacingMark (the SEA blocks have no Prepend), so the boundary is decided by a pure code-point predicate `isSeaGraphemeExtend` (UCD Grapheme_Cluster_Break ranges for Thai/Lao/Khmer). No `Intl.Segmenter` dependency → correct on every runtime; a test sweeps **every** SEA code point and pins the predicate to the platform segmenter.
- **docx** — `thaiDistribute` opts into `seaClusterGaps` on expansion at both draw call sites; `both`/`distribute` do not. `jcStretchesLastLine` now returns true only for `distribute` (thaiDistribute's final line stays ragged, per GT).
- **pptx** — de-alias `thaiDist` from `dist` into its own `JustifyMode` passing `seaClusterGaps`; last-line policy unchanged (DrawingML fills every line). All non-`thaiDist` alignments are byte-identical.

## Cross-package notes

- **pptx** is wired here because the shared kernel and the DrawingML spec ("each character is treated as a word") make the distribution unit identical; no PowerPoint Thai VRT sample exists, so the change is verified by unit tests and is a pure opt-in de-alias.
- **xlsx** `distributed` (§18.18.40) uses uniform `letterSpacing` (a distinct, Excel-governed mechanism, not the shared kernel), which spaces every code point and would detach Thai combining marks. Fixing it needs a positioned-draw refactor and Excel ground truth — tracked as a follow-up, out of this PR's scope.
- **line-layout.ts** shrink-budget comments still describe the eventual `#698`/`#794` gate as "every line of distribute/thaiDistribute"; that region is owned by the in-flight #794 track and the gate is currently disabled, so it is left untouched. When re-enabled, thaiDistribute should follow the `both`/non-final rule per this PR's last-line policy.

## Verification

- core + docx + pptx `vitest`, root `pnpm typecheck` — all green.
- Independent review by Codex (gpt-5.6-sol, high) — no functional issues; the initial blocking concern (segmenter-fallback cluster split) was resolved by moving to the pure predicate.
- docx VRT: only the Thai `thaiDistribute` sample moves. Triaged toward the Word ground truth — e.g. the multi-line heading's first line moves from **23px-short → 4px-short** of the Word margin (Word 537 / new 533 / old 514, at render scale); single-line and final lines are unchanged; no reflow. References left frozen per policy (the frozen baseline captured the pre-fix ragged rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
