### PR TITLE
feat(core,docx): per-font advance model — condensed-face profiles + Canvas-vs-Word bias

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -475,6 +475,17 @@ export {
   intendedSingleLinePx,
   correctLineMetrics,
 } from './text/line-metrics';
+// Format-agnostic requested-font horizontal advance profiles and Canvas-vs-Word
+// line-fit bias. Consumers keep their layout/paint wiring local, while the
+// metric provenance and normalized family matching remain shared data.
+export {
+  fontAdvanceScriptClass,
+  fontScriptAdvanceScale,
+  splitFontAdvanceRuns,
+  fontAdvanceBiasEm,
+  type FontAdvanceScriptClass,
+  type FontAdvanceRun,
+} from './text/font-advance-metrics';
 // IX2 in-document text search (findText). Format-agnostic index + match →
 // run-slice resolution (buildTextIndex/findMatches), the pure highlight-extent
 // helper (sliceHorizontalExtent), the active-match cursor arithmetic behind

--- a/packages/core/src/text/font-advance-metrics.test.ts
+++ b/packages/core/src/text/font-advance-metrics.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fontAdvanceBiasEm,
+  fontScriptAdvanceScale,
+  splitFontAdvanceRuns,
+} from './font-advance-metrics.js';
+
+describe('fontScriptAdvanceScale', () => {
+  it('returns Meiryo UI hmtx advance ratios by script class', () => {
+    expect(fontScriptAdvanceScale('Meiryo UI', 'ひ')).toBeCloseTo(0.7775, 10);
+    expect(fontScriptAdvanceScale('Meiryo UI', 'カ')).toBeCloseTo(0.7438, 10);
+    expect(fontScriptAdvanceScale('Meiryo UI', '。')).toBeCloseTo(0.7214, 10);
+    expect(fontScriptAdvanceScale('Meiryo UI', '漢')).toBe(1);
+    expect(fontScriptAdvanceScale('Meiryo UI', 'Ａ')).toBe(1);
+  });
+
+  it('does not condense plain Meiryo or untabled families', () => {
+    expect(fontScriptAdvanceScale('Meiryo', 'ひ')).toBe(1);
+    expect(fontScriptAdvanceScale('serif', 'ひ')).toBe(1);
+    expect(fontScriptAdvanceScale(null, 'ひ')).toBe(1);
+  });
+});
+
+describe('splitFontAdvanceRuns', () => {
+  it('splits a tabled face into homogeneous scale runs', () => {
+    expect(splitFontAdvanceRuns('Meiryo UI', '漢ひらカナ。Ａ')).toEqual([
+      { text: '漢', scale: 1 },
+      { text: 'ひら', scale: 0.7775 },
+      { text: 'カナ', scale: 0.7438 },
+      { text: '。', scale: 0.7214 },
+      { text: 'Ａ', scale: 1 },
+    ]);
+  });
+
+  it('keeps untabled text byte-stable as one no-op run', () => {
+    expect(splitFontAdvanceRuns('Yu Gothic', '漢ひらカナ。Ａ')).toEqual([
+      { text: '漢ひらカナ。Ａ', scale: 1 },
+    ]);
+  });
+});
+
+describe('fontAdvanceBiasEm', () => {
+  it('returns the Chromium-vs-Word Georgia bias and zero for near-real/unknown faces', () => {
+    expect(fontAdvanceBiasEm('Georgia')).toBe(0.0105);
+    expect(fontAdvanceBiasEm('  "georgia" ')).toBe(0.0105);
+    expect(fontAdvanceBiasEm('Times New Roman')).toBe(0);
+    expect(fontAdvanceBiasEm('serif')).toBe(0);
+    expect(fontAdvanceBiasEm(undefined)).toBe(0);
+  });
+});

--- a/packages/core/src/text/font-advance-metrics.ts
+++ b/packages/core/src/text/font-advance-metrics.ts
@@ -1,0 +1,184 @@
+/**
+ * Horizontal advance corrections for document fonts whose real metrics differ
+ * materially from the browser fallback used when the requested face is absent.
+ *
+ * Values in this module describe fonts, not samples. A family belongs here only
+ * when its source metric has a documented provenance; unknown families remain a
+ * strict 1/0 no-op so existing layout is byte-stable.
+ */
+
+export type FontAdvanceScriptClass =
+  | 'ideograph'
+  | 'hiragana'
+  | 'katakana'
+  | 'fullwidthPunctuation'
+  | 'fullwidthLatin'
+  | 'other';
+
+export interface FontAdvanceRun {
+  readonly text: string;
+  readonly scale: number;
+}
+
+interface FontAdvanceProfile {
+  readonly family: string;
+  readonly scale: Readonly<Record<FontAdvanceScriptClass, number>>;
+}
+
+const NO_ADVANCE_CORRECTION: Readonly<Record<FontAdvanceScriptClass, number>> = {
+  ideograph: 1,
+  hiragana: 1,
+  katakana: 1,
+  fullwidthPunctuation: 1,
+  fullwidthLatin: 1,
+  other: 1,
+};
+
+/**
+ * Meiryo UI Regular horizontal advances harvested from `meiryo.ttc` with
+ * fontTools (`hmtx`, unitsPerEm 2048). The values are class means over the
+ * representative repertoire used for the harvest:
+ *
+ * - ideographs and fullwidth Latin: 1.0000 em;
+ * - Hiragana: 0.7775 em (individual glyphs 0.50–0.89 em);
+ * - Katakana: 0.7438 em (individual glyphs 0.69–0.82 em);
+ * - fullwidth punctuation `、。「」（）`: 0.7214 em.
+ *
+ * Plain Meiryo is deliberately absent: its corresponding glyphs are uniformly
+ * full-width. These class means correct a full-width substitute toward the real
+ * requested face; they are not visual-regression tuning constants.
+ */
+const FONT_ADVANCE_PROFILES: ReadonlyArray<FontAdvanceProfile> = [
+  {
+    family: 'meiryo ui',
+    scale: {
+      ideograph: 1,
+      hiragana: 0.7775,
+      katakana: 0.7438,
+      fullwidthPunctuation: 0.7214,
+      fullwidthLatin: 1,
+      other: 1,
+    },
+  },
+  {
+    family: 'メイリオ ui',
+    scale: {
+      ideograph: 1,
+      hiragana: 0.7775,
+      katakana: 0.7438,
+      fullwidthPunctuation: 0.7214,
+      fullwidthLatin: 1,
+      other: 1,
+    },
+  },
+];
+
+interface FontBiasProfile {
+  readonly test: (family: string) => boolean;
+  readonly biasEm: number;
+}
+
+/**
+ * Canvas-vs-Word horizontal advance bias in em per glyph. This is independent
+ * of the real-font script profiles above: it is a line-fit allowance for the
+ * gap between Canvas `measureText` advances and Word's own layout advances for
+ * the SAME face, not a glyph transform. The allowance is backend-agnostic by
+ * design; the committed Georgia value below is calibrated on the Chromium VRT.
+ *
+ * Georgia: the tracked public demo's justified body face (issue #794). The
+ * The Chromium VRT's Canvas-vs-Word accumulated excess measures at roughly
+ * 0.1–0.3 px per glyph
+ * at the demo's 10–11 px body em — an em-fraction band of ~0.009–0.028. The
+ * committed value is fixed INSIDE that measured band by the public demo's
+ * Word-reference wrap positions (demo/sample-1 fidelity ratchet, scanned at
+ * 0.009/0.0105/0.0115/0.012/0.013/0.02): 0.009 under-admits words Word keeps
+ * (pages 4–5 regress) and 0.012+ over-admits words Word wraps (pages 3/5);
+ * 0.0105 reproduces every Word-verified wrap. Times New Roman (measures
+ * ~0.03 px/glyph, effectively zero), CSS generics, and unknown families
+ * intentionally fall through to zero.
+ */
+const FONT_BIAS_PROFILES: ReadonlyArray<FontBiasProfile> = [
+  {
+    test: (family) => family === 'georgia',
+    biasEm: 0.0105,
+  },
+];
+
+function normalizeFamily(family: string | null | undefined): string {
+  return (family ?? '')
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+function advanceProfile(family: string | null | undefined): FontAdvanceProfile | null {
+  const normalized = normalizeFamily(family);
+  return FONT_ADVANCE_PROFILES.find((profile) => profile.family === normalized) ?? null;
+}
+
+/** Classify one Unicode code point for a horizontal font-advance profile. */
+export function fontAdvanceScriptClass(char: string): FontAdvanceScriptClass {
+  const cp = char.codePointAt(0);
+  if (cp === undefined) return 'other';
+  if (cp >= 0x3040 && cp <= 0x309f) return 'hiragana';
+  if (cp >= 0x30a0 && cp <= 0x30ff) return 'katakana';
+  if ('、。「」（）'.includes(char)) return 'fullwidthPunctuation';
+  if (
+    (cp >= 0x3400 && cp <= 0x4dbf)
+    || (cp >= 0x4e00 && cp <= 0x9fff)
+    || (cp >= 0xf900 && cp <= 0xfaff)
+    || (cp >= 0x20000 && cp <= 0x323af)
+  ) return 'ideograph';
+  if ((cp >= 0xff21 && cp <= 0xff3a) || (cp >= 0xff41 && cp <= 0xff5a)) {
+    return 'fullwidthLatin';
+  }
+  return 'other';
+}
+
+/** Real requested-face advance scale for a character, or 1 for a no-op. */
+export function fontScriptAdvanceScale(
+  family: string | null | undefined,
+  char: string,
+): number {
+  const profile = advanceProfile(family);
+  if (profile === null) return 1;
+  return profile.scale[fontAdvanceScriptClass(char)] ?? NO_ADVANCE_CORRECTION.other;
+}
+
+/**
+ * Split text into maximal runs with one uniform requested-font advance scale.
+ * Untabled families are returned untouched as one no-op run.
+ */
+export function splitFontAdvanceRuns(
+  family: string | null | undefined,
+  text: string,
+): FontAdvanceRun[] {
+  const profile = advanceProfile(family);
+  if (profile === null || text.length === 0) return [{ text, scale: 1 }];
+  const runs: FontAdvanceRun[] = [];
+  let currentText = '';
+  let currentScale: number | null = null;
+  for (const char of text) {
+    const scale = profile.scale[fontAdvanceScriptClass(char)];
+    if (currentScale === null || scale === currentScale) {
+      currentText += char;
+      currentScale = scale;
+    } else {
+      runs.push({ text: currentText, scale: currentScale });
+      currentText = char;
+      currentScale = scale;
+    }
+  }
+  if (currentText.length > 0) runs.push({ text: currentText, scale: currentScale ?? 1 });
+  return runs;
+}
+
+/** Expected Canvas-over-Word advance bias, in em per glyph. */
+export function fontAdvanceBiasEm(family: string | null | undefined): number {
+  const normalized = normalizeFamily(family);
+  for (const profile of FONT_BIAS_PROFILES) {
+    if (profile.test(normalized)) return profile.biasEm;
+  }
+  return 0;
+}

--- a/packages/docx/src/emphasis-mark-render.test.ts
+++ b/packages/docx/src/emphasis-mark-render.test.ts
@@ -29,10 +29,11 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; rec: Recording } {
     letterSpacing: '0px',
     measureText: (s: string) => {
       const p = px();
+      const advanceEm = s === 'あアかカ' ? 1 : 0.5;
       return {
         // Each code point advances a fixed half-em, so glyph i centre is
         // predictable: penX + (i + 0.5) * p * 0.5.
-        width: [...s].length * p * 0.5,
+        width: [...s].length * p * advanceEm,
         fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
         actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
       } as TextMetrics;
@@ -152,6 +153,18 @@ describe('docx emphasis mark (§17.3.2.12 w:em) draw path', () => {
     const xs = rec.arcs.map((a) => a.cx);
     expect(xs[1] - xs[0]).toBeCloseTo(xs[2] - xs[1], 3);
     expect(xs[1] - xs[0]).toBeGreaterThan(0);
+  });
+
+  it('scales multi-kana mark centres with the condensed glyph draw', async () => {
+    const rec = await render({
+      emphasisMark: 'dot',
+      fontFamily: 'Meiryo UI',
+      fontFamilyEastAsia: 'Meiryo UI',
+    }, 'あい');
+    const xs = rec.arcs.map((a) => a.cx);
+
+    expect(xs).toHaveLength(2);
+    expect(xs[1] - xs[0]).toBeCloseTo(40 * 0.5 * 0.7775, 6);
   });
 
   it('mark radius scales with the run font size (~0.07 em)', async () => {

--- a/packages/docx/src/find-highlight-layer.test.ts
+++ b/packages/docx/src/find-highlight-layer.test.ts
@@ -192,6 +192,34 @@ describe('buildDocxHighlightLayer', () => {
     expect(layer.children[0].style.width).toBe(`${(14 / 100) * 100}%`);
   });
 
+  it('scales a horizontal run slice offset and width by the composed glyph scale', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({ text: 'かな文字', x: 10, glyphScaleX: 0.75 })];
+    const matches: DocxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 1, end: 3 }], active: false },
+    ];
+
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 100, 100, measureForFont);
+
+    const box = layer.children[0];
+    expect(box.style.left).toBe(`${((10 + 7 * 0.75) / 100) * 100}%`);
+    expect(box.style.width).toBe(`${((14 * 0.75) / 100) * 100}%`);
+  });
+
+  it('keeps the existing eastAsianVert clamp authoritative over glyphScaleX', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({ text: '２９', w: 7, fontSize: 7, eastAsianVert: true, glyphScaleX: 0.25 })];
+    const matches: DocxHighlightMatch[] = [
+      { slices: [{ runIndex: 0, start: 0, end: 2 }], active: false },
+    ];
+
+    buildDocxHighlightLayer(layer as unknown as HTMLDivElement, runs, matches, 100, 100, measureForFont);
+
+    expect(layer.children[0].style.width).toBe('7.000000000000001%');
+  });
+
   it('clears the layer and skips zero-width slices', () => {
     vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
     const layer = makeEl('div');

--- a/packages/docx/src/find-highlight-layer.ts
+++ b/packages/docx/src/find-highlight-layer.ts
@@ -91,13 +91,14 @@ export function buildDocxHighlightLayer(
       const end = Math.min(slice.end, [...run.text].length);
       const pitchedX = extent.x + slice.start * pitch;
       const pitchedWidth = extent.width + Math.max(0, end - slice.start - 1) * pitch;
-      // ECMA-376 §17.3.2.10 縦中横 (#836): a tate-chu-yoko run is drawn compressed
-      // into one em cell (`run.w`), so its natural per-glyph extents overshoot the
-      // drawn box. Scale the slice offset + width by `run.w / naturalWidth` so the
-      // highlight lands on the compressed cell (a no-op factor of 1 for every
-      // ordinary run — see tate-chu-yoko-overlay.ts). Applying one factor keeps a
-      // partial match proportional within the cell.
-      const k = tateChuYokoOverlayScale(run, measure);
+      // 縦中横 keeps its established one-em clamp. Ordinary horizontal runs use
+      // the composed Canvas glyph scale reported by the renderer. Applying the
+      // factor after pitch composition preserves the same approximation as the
+      // 縦中横 path: fixed pitch is scaled with the slice rather than modelled as
+      // a second coordinate axis, while offsets and widths remain proportional.
+      const k = run.eastAsianVert
+        ? tateChuYokoOverlayScale(run, measure)
+        : (run.glyphScaleX ?? 1);
       const x = pitchedX * k;
       const width = pitchedWidth * k;
       if (width <= 0) continue;

--- a/packages/docx/src/font-advance-layout.test.ts
+++ b/packages/docx/src/font-advance-layout.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSegments,
+  layoutLines,
+  segGlyphScaleFactor,
+  type LayoutSeg,
+  type LayoutTextSeg,
+} from './line-layout.js';
+import type { DocRun, DocxTextRun } from './types.js';
+
+const ENV = { pageIndex: 0, totalPages: 1 };
+
+type AdvanceStampedSeg = LayoutTextSeg & {
+  fontAdvanceScaleCandidate?: number;
+  fontAdvanceScale?: number;
+};
+
+function textRun(text: string, extra: Partial<DocxTextRun> = {}): DocRun {
+  return {
+    type: 'text',
+    text,
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    fontSize: 12,
+    color: null,
+    fontFamily: 'Meiryo UI',
+    fontFamilyEastAsia: 'Meiryo UI',
+    isLink: false,
+    background: null,
+    vertAlign: null,
+    allCaps: false,
+    smallCaps: false,
+    doubleStrikethrough: false,
+    ...extra,
+  } as unknown as DocRun;
+}
+
+function measuringCtx(kanaEm: number): CanvasRenderingContext2D {
+  let font = '12px serif';
+  const ctx = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    letterSpacing: '0px',
+    fontKerning: 'auto',
+    measureText(text: string) {
+      const px = Number(/([\d.]+)px/.exec(font)?.[1] ?? 12);
+      return {
+        width: [...text].length * px * kanaEm,
+        fontBoundingBoxAscent: px * 0.8,
+        fontBoundingBoxDescent: px * 0.2,
+        actualBoundingBoxAscent: px * 0.8,
+        actualBoundingBoxDescent: px * 0.2,
+      } as TextMetrics;
+    },
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+function textSegments(segs: LayoutSeg[]): AdvanceStampedSeg[] {
+  return segs.filter((seg): seg is AdvanceStampedSeg => 'text' in seg);
+}
+
+describe('requested-font horizontal advance substitution probe', () => {
+  it('keeps the profile only for a full-width substitute, not an installed condensed face', () => {
+    const condensed = textSegments(buildSegments([textRun('ひら')], ENV));
+    expect(condensed).toHaveLength(1);
+    expect(condensed[0].fontAdvanceScaleCandidate).toBeCloseTo(0.7775, 10);
+    const condensedLines = layoutLines(measuringCtx(0.78), condensed, 1000, 0, 1);
+    const condensedSeg = textSegments(condensedLines[0].segments)[0];
+    expect(condensedSeg.fontAdvanceScale).toBe(1);
+    expect(condensedSeg.measuredWidth).toBeCloseTo(2 * 12 * 0.78, 9);
+
+    // Use the localized alias so the module-level resolution cache has a distinct
+    // built-font key while exercising the same harvested profile.
+    const substitute = textSegments(buildSegments([
+      textRun('ひら', { fontFamily: 'メイリオ UI', fontFamilyEastAsia: 'メイリオ UI' }),
+    ], ENV));
+    const substituteLines = layoutLines(measuringCtx(1), substitute, 1000, 0, 1);
+    const substituteSeg = textSegments(substituteLines[0].segments)[0];
+    expect(substituteSeg.fontAdvanceScale).toBeCloseTo(0.7775, 10);
+    expect(substituteSeg.measuredWidth).toBeCloseTo(2 * 12 * 0.7775, 9);
+  });
+
+  it('leaves vertical CJK kana at full-em advances', () => {
+    const segs = textSegments(buildSegments([textRun('ひら')], { ...ENV, verticalCJK: true }));
+    expect(segs).toHaveLength(1);
+    expect(segs[0].fontAdvanceScaleCandidate).toBeUndefined();
+
+    const lines = layoutLines(measuringCtx(1), segs, 1000, 0, 1);
+    const laidOut = textSegments(lines[0].segments)[0];
+    expect(segGlyphScaleFactor(laidOut)).toBe(1);
+    expect(laidOut.measuredWidth).toBe(24);
+  });
+
+  it('keeps a mixed-script ruby base in one unscaled segment', () => {
+    const segs = textSegments(buildSegments([
+      textRun('漢かな', { ruby: { text: 'かん', fontSizePt: 6 } }),
+    ], ENV));
+
+    expect(segs).toHaveLength(1);
+    expect(segs[0].text).toBe('漢かな');
+    expect(segs[0].ruby?.text).toBe('かん');
+    expect(segs[0].fontAdvanceScaleCandidate).toBeUndefined();
+    expect(segGlyphScaleFactor(segs[0])).toBe(1);
+  });
+
+  it('uses the resolved glyph scale when fitting a Meiryo UI region to w:fitText', () => {
+    const segs = buildSegments([
+      textRun('ひら', {
+        fontFamily: 'メイリオ UI',
+        fontFamilyEastAsia: 'メイリオ UI',
+        fitTextVal: 2400,
+      }),
+    ], ENV);
+    const lines = layoutLines(measuringCtx(1), segs, 1000, 0, 1);
+    const fitted = textSegments(lines[0].segments);
+
+    expect(fitted.reduce((sum, seg) => sum + seg.measuredWidth, 0)).toBeCloseTo(120, 9);
+  });
+});

--- a/packages/docx/src/justify-shrink-overshoot.test.ts
+++ b/packages/docx/src/justify-shrink-overshoot.test.ts
@@ -8,11 +8,13 @@ import type {
   SectionProps,
 } from './types';
 
-// ECMA-376 §17.18.44 (ST_Jc `both`/`distribute`) — the Knuth-Plass space-shrink
-// fit tolerance (`SPACE_SHRINK_RATIO`) ideally must NOT admit an extra word onto
-// a line that the draw pass will JUSTIFY, and must remain available on a line the
-// draw pass treats as non-justified. The per-line gate that mirrored the paint
-// predicate is currently disabled as an interim measure:
+// Word-observed `both`/`distribute` line-fit behavior (issue #698 PDF) — the
+// Knuth-Plass space-shrink drawable-space tolerance (`SPACE_SHRINK_RATIO`) must
+// NOT admit an extra word onto a line that the draw pass will justify, and must
+// remain available on a line the draw pass treats as non-justified. §17.18.44
+// classifies ST_Jc values but does not mandate this fit gate. A separate per-font
+// bias applies exclusively on justified lines; this synthetic `serif` face has
+// zero bias:
 //
 // - A line that WILL justify (a non-final, non-manual-break line of a
 //   `both`/kashida paragraph, or ANY line of `distribute`/`thaiDistribute`)
@@ -24,15 +26,13 @@ import type {
 // - A line the draw pass does NOT justify — the paragraph's true last line and a
 //   line ending at a manual `<w:br/>` (§17.3.3.1) under `both`/kashida, and every
 //   line of a non-justified paragraph — is drawn with the shrink-fit compression
-//   the budget promises (`shrinkFitCompression`), so the measurement-bias
-//   tolerance stays: measure and paint spend the SAME budget (measure==paint).
-// - The current uniform tolerance also compensates for per-font advance bias
-//   between browser measurement and Word. The tracked public Latin demo, whose
-//   `docDefaults` use `w:jc="both"`, matches Word only with that tolerance. Until
-//   issue #794 supplies a per-font advance-bias model, that ground truth cannot
-//   coexist with #698 under one ratio, so the public demo takes interim priority.
-//   Once #794 lands, restore the §17.18.44 gate and the Word-verified expectations
-//   below (3 tokens on the first line, across 2 lines).
+//   the budget promises (`shrinkFitCompression`).
+// - The allowances are exclusive per line: justified lines receive only the
+//   Canvas-vs-Word face bias; non-justified lines receive only drawable trailing-
+//   space shrink. Demo p3/p6 space-collapse evidence shows that adding both
+//   double-counts tolerance and admits words the paint pass cannot fit. Georgia
+//   retains its calibrated bias on justified demo lines; generic `serif` and
+//   Times remain at zero for the #698 natural-fit gate.
 
 const FONT_PX = 12; // linear stub: each code point advances FONT_PX at scale 1
 
@@ -76,11 +76,11 @@ function makeLinearCanvas(): HTMLCanvasElement {
   return canvas as unknown as HTMLCanvasElement;
 }
 
-function textRun(text: string): DocxTextRun {
+function textRun(text: string, extra: Partial<DocxTextRun> = {}): DocxTextRun {
   return {
     text, bold: false, italic: false, underline: false, strikethrough: false,
     fontSize: FONT_PX, color: null, fontFamily: 'serif', isLink: false, background: null,
-    vertAlign: null, hyperlink: null,
+    vertAlign: null, hyperlink: null, ...extra,
   };
 }
 
@@ -151,24 +151,20 @@ const TEXT4 = 'AAAA AAAA AAAA AAAA';      // marginal word is the paragraph-FINA
 const TEXT5 = 'AAAA AAAA AAAA AAAA AAAA'; // marginal word is followed by more content
 const COLUMN = 225;
 
-describe('§17.18.44 — interim uniform space-shrink fit tolerance (#794 pending)', () => {
-  it('INTERIM (#794 pending): admits the marginal word on a line that will justify', async () => {
+describe('§17.18.44 — per-font advance bias and drawable space shrink', () => {
+  it('wraps the marginal word on a line that will justify', async () => {
     // Word PDF ground truth for #698's narrow justified column still shows a
-    // natural-fit break (3 tokens). That cannot currently coexist with the
-    // tracked public Latin demo (`docDefaults w:jc="both"`), whose wrapping
-    // matches Word only with the uniform measurement-bias tolerance. The interim
-    // decision favors the public demo GT, so the tolerance admits token 4. Issue
-    // #794's per-font advance-bias correction will let the §17.18.44 gate return
-    // and this expectation flip back to Word's verified 3 tokens across 2 lines.
+    // natural-fit break (3 tokens). Generic `serif` has no per-font bias, and
+    // this line will justify, so it gets no drawable-space budget either.
     const lines = await renderLines(textPara(TEXT5, 'both'), COLUMN);
     expect(lines.length).toBe(2);
-    expect(tokens(lines[0])).toBe(4);
+    expect(tokens(lines[0])).toBe(3);
   });
 
-  it('keeps the SAME marginal word on a non-justified line (bias tolerance retained)', async () => {
+  it('keeps the SAME marginal word on a non-justified line (drawable shrink retained)', async () => {
     // left/center lines are drawn at (or compressed toward) natural spacing, so
-    // the 3px overflow is absorbed as measurement bias — this is what keeps a
-    // substituted-font centred title on a single row (sample-10 p1 class).
+    // the 3px overflow is absorbed by drawable trailing-space compression. The
+    // same path guards centred single-line titles such as sample-10 p1.
     for (const alignment of ['left', 'center'] as const) {
       const lines = await renderLines(textPara(TEXT5, alignment), COLUMN);
       expect(lines.length, alignment).toBe(2);
@@ -204,22 +200,33 @@ describe('§17.18.44 — interim uniform space-shrink fit tolerance (#794 pendin
     expect(lines[1]).toContain('BBBB');
   });
 
-  it('INTERIM (#794 pending): keeps the uniform budget on a `distribute` last line', async () => {
+  it('wraps the marginal word on a `distribute` last line', async () => {
     // Word PDF ground truth for #698 still requires the natural-fit break here:
     // §17.18.44 `distribute` stretches the final line, yielding 3 tokens across
-    // 2 lines. Under the current single-ratio model that conflicts with the
-    // tracked public Latin demo (`docDefaults w:jc="both"`), whose Word wrapping
-    // requires the uniform measurement-bias tolerance. The interim decision
-    // favors that public demo GT, so all 4 tokens fit on one line. Issue #794's
-    // per-font advance-bias correction is the principled fix; then the justified
-    // per-line gate returns and this flips back to Word's verified 3 / 2 result.
+    // 2 lines. `distribute` stretches even the logical last line, so the
+    // drawable-space budget is suppressed; generic `serif` contributes no bias.
     const lines = await renderLines(textPara(TEXT4, 'distribute'), COLUMN);
-    expect(lines.length).toBe(1);
-    expect(tokens(lines[0])).toBe(4);
+    expect(lines.length).toBe(2);
+    expect(tokens(lines[0])).toBe(3);
   });
 
   it('does not force a wrap when the justified content genuinely fits at natural width', async () => {
     const lines = await renderLines(textPara(TEXT4, 'both'), 240);
     expect(lines.length).toBe(1);
+  });
+
+  it('scales the justified Georgia bias budget by authored w:w', async () => {
+    const el = para(
+      [{
+        type: 'text',
+        ...textRun('AAAA AAAA AAAA AAAA', { fontFamily: 'Georgia', charScale: 0.5 }),
+      } as DocRun],
+      'both',
+    );
+
+    // Natural end = 84px. Correct scaled bias = 0.882px (83 + 0.882 < 84)
+    // so the third token wraps; the old unscaled 1.764px budget over-admitted it.
+    const lines = await renderLines(el, 83);
+    expect(tokens(lines[0])).toBe(2);
   });
 });

--- a/packages/docx/src/layout-context.ts
+++ b/packages/docx/src/layout-context.ts
@@ -7,6 +7,7 @@ import {
   resolveDefaultTabPt,
   type DocGridCtx,
 } from './line-layout.js';
+import { jcIsFullyJustified, jcStretchesLastLine } from './bidi-line.js';
 import type {
   BodyElement,
   ColumnGeom,
@@ -93,6 +94,8 @@ export interface ParagraphLayoutContext {
   readonly spaceBeforePt: number;
   readonly spaceAfterPt: number;
   readonly baseRtl: boolean;
+  readonly isJustified: boolean;
+  readonly stretchLastLine: boolean;
   readonly tabStops: readonly TabStop[];
   readonly hasRuby: boolean;
   readonly hasEastAsianText: boolean;
@@ -303,6 +306,8 @@ export function resolveParagraphLayoutContext(
     spaceBeforePt: paragraph.spaceBefore,
     spaceAfterPt: paragraph.spaceAfter,
     baseRtl,
+    isJustified: jcIsFullyJustified(paragraph.alignment),
+    stretchLastLine: jcStretchesLastLine(paragraph.alignment),
     tabStops: [...paragraph.tabStops],
     hasRuby: paragraphHasRuby(paragraph),
     hasEastAsianText: paragraphHasEastAsianText(paragraph),

--- a/packages/docx/src/line-boundary.test.ts
+++ b/packages/docx/src/line-boundary.test.ts
@@ -204,6 +204,8 @@ function layoutFixture(fixture: Fixture, startBoundary?: LineBoundary): LayoutLi
     36,
     fixture.width,
     fixture.baseRtl ?? false,
+    false,
+    false,
     startBoundary,
   );
 }

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -43,6 +43,8 @@ import {
   parseFieldFormatSwitch,
   formatDateTimePicture,
   parseDateTimePictureSwitch,
+  splitFontAdvanceRuns,
+  fontAdvanceBiasEm,
 } from '@silurus/ooxml-core';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
 import { groupFitTextRegions, type FitTextRun } from './fit-text.js';
@@ -143,6 +145,14 @@ export interface LayoutTextSeg extends LayoutSegSource {
    *  under `ctx.scale(charScale, 1)`; decorations follow the scaled extent.
    *  Absent ⇒ 1 (100%). */
   charScale?: number;
+  /** Candidate horizontal advance scale harvested for the requested family.
+   *  {@link layoutLines} resolves it against the host's actual face resolution
+   *  before any width is measured. Absent for vertical CJK and ruby bases. */
+  fontAdvanceScaleCandidate?: number;
+  /** Resolved horizontal font-advance scale. A full-width substitute keeps the
+   *  candidate; an installed condensed face resolves to 1. Paint reads this
+   *  stamp directly, so it never performs a second face-resolution probe. */
+  fontAdvanceScale?: number;
   /** ECMA-376 §17.3.2.14 `<w:fitText>` — target width in TWIPS and optional
    *  link id (wire strings plus numeric synthetic inputs). All segments emitted
    *  from one tab-delimited source-run fragment retain the same fragment/region
@@ -828,6 +838,63 @@ export function charScaleFactor(seg: LayoutTextSeg): number {
   return seg.charScale ?? 1;
 }
 
+/**
+ * Horizontal glyph scale composed from the authored §17.3.2.43 `w:w` value and
+ * the requested face's real per-script advance profile. `buildSegments` splits
+ * tabled fonts into homogeneous scale runs, so one Canvas transform reproduces
+ * the same correction in measure and paint without per-glyph shaping loss.
+ */
+export function segGlyphScaleFactor(seg: LayoutTextSeg): number {
+  return charScaleFactor(seg) * (seg.fontAdvanceScale ?? 1);
+}
+
+const FONT_ADVANCE_PROBE_TEXT = 'あアかカ';
+const FONT_ADVANCE_PROBE_PX = 100;
+const FULL_WIDTH_SUBSTITUTE_MIN_EM = 0.92;
+const fontAdvanceSubstitutionProbeCache = new Map<string, boolean>();
+
+/** Clear host-face probe results. Production callers do not need this; tests
+ *  use it when swapping synthetic measuring contexts in one module instance. */
+export function resetFontAdvanceSubstitutionProbeCache(): void {
+  fontAdvanceSubstitutionProbeCache.clear();
+}
+
+/** Resolve candidate family profiles against the face Canvas actually selected.
+ *  A real Meiryo UI face already exposes condensed kana advances, while its
+ *  common substitute is full-width. Probe once per normalized Canvas font string
+ *  and stamp the result onto the segment before fitText or line measurement. */
+function resolveFontAdvanceScaleCandidates(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  segments: readonly LayoutTextSeg[],
+  fontFamilyClasses: Record<string, string>,
+): void {
+  const previousFont = ctx.font;
+  try {
+    for (const segment of segments) {
+      const candidate = segment.fontAdvanceScaleCandidate;
+      if (candidate === undefined) continue;
+      const probeFont = buildFont(
+        false,
+        false,
+        FONT_ADVANCE_PROBE_PX,
+        segment.fontFamily,
+        fontFamilyClasses,
+      );
+      let fullWidthSubstitute = fontAdvanceSubstitutionProbeCache.get(probeFont);
+      if (fullWidthSubstitute === undefined) {
+        ctx.font = probeFont;
+        const perGlyphEm = ctx.measureText(FONT_ADVANCE_PROBE_TEXT).width
+          / ([...FONT_ADVANCE_PROBE_TEXT].length * FONT_ADVANCE_PROBE_PX);
+        fullWidthSubstitute = perGlyphEm >= FULL_WIDTH_SUBSTITUTE_MIN_EM;
+        fontAdvanceSubstitutionProbeCache.set(probeFont, fullWidthSubstitute);
+      }
+      segment.fontAdvanceScale = fullWidthSubstitute ? candidate : 1;
+    }
+  } finally {
+    ctx.font = previousFont;
+  }
+}
+
 /** Canonical advance formula for a text string in a run: natural glyph width
  *  scaled by ECMA-376 §17.3.2.43 `<w:w>`, plus the §17.6.5 character-grid
  *  delta, plus one ECMA-376 §17.3.2.35 `<w:spacing>` pitch per code point. */
@@ -878,7 +945,7 @@ export function segAdvanceWidth(
   if (seg.fitTextPerGapPx !== undefined) {
     const charCount = [...seg.text].length;
     const gapCount = seg.fitTextRegionEnd ? Math.max(0, charCount - 1) : charCount;
-    return naturalWidthPx * charScaleFactor(seg)
+    return naturalWidthPx * segGlyphScaleFactor(seg)
       + gapCount * seg.fitTextPerGapPx
       + (seg.fitTextTrailingPadPx ?? 0);
   }
@@ -897,7 +964,7 @@ export function segAdvanceWidth(
     naturalWidthPx,
     seg.text,
     segmentDelta,
-    charScaleFactor(seg),
+    segGlyphScaleFactor(seg),
     charSpacingDeltaPx(seg, scale),
   );
 }
@@ -1889,7 +1956,7 @@ function resolveFitTextSegments(
     let naturalWidthPx = 0;
     let charCount = 0;
     for (const segment of members) {
-      naturalWidthPx += measureNaturalWidthPx(segment) * charScaleFactor(segment);
+      naturalWidthPx += measureNaturalWidthPx(segment) * segGlyphScaleFactor(segment);
       charCount += [...segment.text].length;
     }
 
@@ -2121,7 +2188,22 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
         }
         return;
       }
-      pushSeg(word, cs, fontFamily);
+      // The harvested profiles describe horizontal hmtx advances. Vertical CJK
+      // uses full-em cells, so it must retain the pre-profile segmentation and
+      // widths. Ruby annotations ride only the first emitted base segment; a
+      // profile split would detach the annotation from the rest of its base, so
+      // ruby-carrying runs intentionally keep the pre-#794 substitute advances.
+      if (environment.verticalCJK || baseRuby) {
+        pushSeg(word, cs, fontFamily);
+        return;
+      }
+      for (const part of splitFontAdvanceRuns(fontFamily, word)) {
+        const start = segs.length;
+        pushSeg(part.text, cs, fontFamily);
+        if (part.scale !== 1) {
+          (segs[start] as LayoutTextSeg).fontAdvanceScaleCandidate = part.scale;
+        }
+      }
     };
 
     // A non-complex-script slice still mixes scripts at the CJK boundary: emit
@@ -2409,6 +2491,12 @@ export function layoutLines(
   // tabs do not trigger the LTR right/center/overflow wrap paths. Default false
   // ⇒ the LTR tab paths run unchanged (byte-identical output).
   baseRtl = false,
+  // ECMA-376 §17.18.44 paragraph classification. The fit budget is gated per
+  // prospective line with the same predicate the paint pass uses.
+  isJustified = false,
+  // `distribute`/`thaiDistribute` stretch the logical last line; `both` and
+  // kashida modes leave true-last/manual-break lines non-justified.
+  stretchLastLine = false,
   startBoundary?: LineBoundary,
 ): LayoutLine[] {
   const lines: LayoutLine[] = [];
@@ -2423,6 +2511,9 @@ export function layoutLines(
   //      whether a candidate word fits we treat it as if it would become the
   //      final word (its own trailing spaces collapsible).
   let lineTotalTrailingW = 0;
+  // Incremental Canvas-vs-Word bias of the text already committed to this line.
+  // Candidate checks add only the prospective text, avoiding a hot-loop rescan.
+  let lineBiasBudget = 0;
   let lineHeight = 0;   // pt
   let lineAscent = 0;   // px
   let lineDescent = 0;  // px
@@ -2465,6 +2556,7 @@ export function layoutLines(
   // Word flows a line that cannot start beside a floating object (there is no
   // ECMA-376 §x.x.x for this trigger — see resolveLineFloatWindow / issue #676).
   const startLine = (minWidth: number = 0): void => {
+    lineBiasBudget = 0;
     lineXOffset = 0;
     lineMaxWidth = maxWidth;
     if (!wrapCtx) return;
@@ -2583,6 +2675,7 @@ export function layoutLines(
     currentLine = [];
     currentWidth = 0;
     lineTotalTrailingW = 0;
+    lineBiasBudget = 0;
     lineHeight = 0;
     lineAscent = 0;
     lineDescent = 0;
@@ -2592,6 +2685,12 @@ export function layoutLines(
     isFirst = false;
     startLine(minLineStartWidth());
   };
+
+  const biasBudgetContribution = (s: LayoutTextSeg, text: string = s.text): number =>
+    fontAdvanceBiasEm(s.fontFamily)
+      * calcEffectiveFontPx(s, scale)
+      * charScaleFactor(s)
+      * [...text].length;
 
   const addToLine = (
     s: LayoutTextSeg | LayoutImageSeg | LayoutMathSeg | LayoutTabSeg,
@@ -2604,6 +2703,9 @@ export function layoutLines(
     currentLine.push(s);
     currentWidth += w;
     lineTotalTrailingW += trailingSpaceW;
+    if ('text' in s) {
+      lineBiasBudget += biasBudgetContribution(s);
+    }
     if (h > lineHeight) lineHeight = h;
     if (asc > lineAscent) lineAscent = asc;
     if (desc > lineDescent) lineDescent = desc;
@@ -2713,11 +2815,16 @@ export function layoutLines(
     }
   }
 
+  const queuedTextSegments = queue.filter((seg): seg is LayoutTextSeg => 'text' in seg);
+  // Resolve requested-face advance candidates before fitText derives its natural
+  // width. The resolved stamp is then shared by every measure and paint path.
+  resolveFontAdvanceScaleCandidates(ctx, queuedTextSegments, fontFamilyClasses);
+
   // Resolve §17.3.2.14 from RAW natural advances at this exact layout scale.
   // The resulting per-gap is folded into segAdvanceWidth below, so the line
   // breaker and paint pen use one width authority. Cached w:spacing is ignored.
   resolveFitTextSegments(
-    queue.filter((seg): seg is LayoutTextSeg => 'text' in seg),
+    queuedTextSegments,
     scale,
     (segment) => measureText(segment).width,
   );
@@ -3084,14 +3191,27 @@ export function layoutLines(
     // and `wForFit` on the one advance model (`strAdvance` == the model behind `w`).
     const trailingSpaceW = s.text.endsWith(' ') ? w - strAdvance(s, trimmed) : 0;
     const wForFit = w - trailingSpaceW;
-    // INTERIM: use one uniform measurement-bias budget even when the paint pass
-    // fully justifies the line. ECMA-376 §17.18.44 and Word-verified issue #698
-    // say those lines should break at natural fit, but the gate cannot coexist
-    // with the tracked public demo under the current single-ratio font metrics.
-    // Re-enable it after issue #794 adds per-font advance-bias correction. The
-    // #934 `isJustified`/`stretchLastLine` layout plumbing is removed meanwhile
-    // to keep the live API minimal; #794 should re-thread it with the real model.
-    const shrinkBudget = lineTotalTrailingW * SPACE_SHRINK_RATIO;
+    // The two fit-tolerance roles are EXCLUSIVE per line, mirroring paint's
+    // per-line predicate `isJustified && (!endsLogicalLine || stretchLastLine)`
+    // (`next` is the first segment after the prospective closing candidate):
+    //
+    //  - A line the paint pass will JUSTIFY stretches to the column edge. Word-
+    //    observed issue #698 behavior admits only the backend-agnostic Canvas-vs-
+    //    Word per-font bias there; the trailing-space allowance is suppressed.
+    //  - A line left NON-justified keeps the classic Knuth-Plass trailing-space
+    //    shrink allowance, whose 25 % promise the draw pass actually spends
+    //    (`shrinkFitCompression`). Demo/sample-1 p3/p6 space-collapse evidence
+    //    shows that ADDING the bias double-counts tolerance and admits words the
+    //    non-justified paint path cannot fit.
+    const shrinkBudgetFor = (next: LayoutSeg | undefined, biasBudget: number): number => {
+      const closesLogicalLine = next === undefined || 'lineBreak' in next;
+      const lineWillJustify = isJustified && (!closesLogicalLine || stretchLastLine);
+      return lineWillJustify ? biasBudget : lineTotalTrailingW * SPACE_SHRINK_RATIO;
+    };
+    const shrinkBudget = shrinkBudgetFor(
+      queue[0],
+      lineBiasBudget + biasBudgetContribution(s, trimmed),
+    );
 
     // Atomic glued group: when THIS segment starts a glued group (its followers
     // in the queue are `joinPrev` pieces — small-caps case-pieces of the SAME
@@ -3122,6 +3242,17 @@ export function layoutLines(
       let groupW = w;
       let groupTrail = trailingSpaceW;
       let groupEnd = 0;
+      let groupBiasBudget = lineBiasBudget;
+      // Keep one pending member so only the final member is trimmed. Committing
+      // each previous member left-to-right preserves the former prospective-array
+      // summation order exactly, without cloning or rescanning the current line.
+      let pendingGroupBiasSeg = s;
+      let pendingGroupBiasText = s.text;
+      const advanceGroupBias = (member: LayoutTextSeg, text: string = member.text): void => {
+        groupBiasBudget += biasBudgetContribution(pendingGroupBiasSeg, pendingGroupBiasText);
+        pendingGroupBiasSeg = member;
+        pendingGroupBiasText = text;
+      };
       for (; groupEnd < queue.length && (queue[groupEnd] as LayoutTextSeg).joinPrev; groupEnd++) {
         const f = queue[groupEnd] as LayoutTextSeg;
         // A CJK-BREAKABLE follower (e.g. "Roman" + "、あるいは…用いる。") is NOT
@@ -3142,7 +3273,9 @@ export function layoutLines(
             // Breakable rest exists past the leading non-starters: glue only the
             // prefix (it may be empty — then "Roman" is effectively unglued and
             // wraps on its own) and end the atomic group here.
-            groupW += strAdvance(f, chars.slice(0, p).join(''));
+            const prefix = chars.slice(0, p).join('');
+            groupW += strAdvance(f, prefix);
+            if (prefix.length > 0) advanceGroupBias(f, prefix);
             groupTrail = 0;
             break;
           }
@@ -3150,10 +3283,18 @@ export function layoutLines(
         }
         const fw = segAdvance(f);
         groupW += fw;
+        advanceGroupBias(f);
         const ft = f.text.replace(/ +$/, '');
         groupTrail = f.text.endsWith(' ') ? fw - strAdvance(f, ft) : 0;
       }
-      if (currentWidth + (groupW - groupTrail) > availW() + shrinkBudget) {
+      groupBiasBudget += biasBudgetContribution(
+        pendingGroupBiasSeg,
+        pendingGroupBiasText.replace(/ +$/, ''),
+      );
+      if (
+        currentWidth + (groupW - groupTrail)
+        > availW() + shrinkBudgetFor(queue[groupEnd], groupBiasBudget)
+      ) {
         flush(undefined, false, s.src);
       }
     }
@@ -3169,7 +3310,7 @@ export function layoutLines(
       //  binary-search + the cross-run 追い出し below. Don't naively unify them.)
       const available = availW() - currentWidth;
       ctx.font = buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses);
-      const rawPrefix = available > 0 ? fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), charScaleFactor(s), charSpacingDeltaPx(s, scale)) : '';
+      const rawPrefix = available > 0 ? fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), segGlyphScaleFactor(s), charSpacingDeltaPx(s, scale)) : '';
       // Apply kinsoku to the break position: retract leftwards so the tail
       // never begins with a 行頭禁則 char and the head never ends with a
       // 行末禁則 char (ECMA-376 §17.15.1.58–.60). When the current line
@@ -3339,7 +3480,7 @@ export function layoutLines(
       const available = availW();
       ctx.font = buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses);
       const allChars = [...s.text];
-      let split = available > 0 ? [...fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), charScaleFactor(s), charSpacingDeltaPx(s, scale))].length : 0;
+      let split = available > 0 ? [...fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), segGlyphScaleFactor(s), charSpacingDeltaPx(s, scale))].length : 0;
       if (split < 1) split = 1;
       split = extendThroughTrailingIdeographicSpaces(allChars, split);
       if (split >= allChars.length) {

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -89,6 +89,8 @@ const layoutContext = (
   spaceBeforePt: 3,
   spaceAfterPt: 4,
   baseRtl: false,
+  isJustified: false,
+  stretchLastLine: false,
   tabStops: [],
   hasRuby: false,
   hasEastAsianText: false,

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -264,6 +264,8 @@ export function measureParagraph(
     context.defaultTabPt,
     paragraphWidthPt + context.physicalIndentRightPt,
     context.baseRtl,
+    context.isJustified,
+    context.stretchLastLine,
     continuation?.boundary,
   );
   if (lines.length === 0) return measureMarkOnly();

--- a/packages/docx/src/renderer.textbox-image.test.ts
+++ b/packages/docx/src/renderer.textbox-image.test.ts
@@ -22,21 +22,36 @@ interface DrawImageCall {
   w: number;
   h: number;
 }
+interface FillTextCall {
+  text: string;
+  x: number;
+  y: number;
+  font: string;
+  fillStyle: string;
+  scaleX: number;
+  translateX: number;
+}
 function makeRecordingCtx(): {
   ctx: CanvasRenderingContext2D;
   drawImageCalls: DrawImageCall[];
-  fillTextCalls: { text: string; x: number; y: number; font: string; fillStyle: string }[];
+  fillTextCalls: FillTextCall[];
 } {
   let font = '10px serif';
   let fillStyle = '#000';
+  let letterSpacing = '0px';
+  let scaleX = 1;
+  let translateX = 0;
+  const stack: { scaleX: number; translateX: number }[] = [];
   const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
   const drawImageCalls: DrawImageCall[] = [];
-  const fillTextCalls: { text: string; x: number; y: number; font: string; fillStyle: string }[] = [];
+  const fillTextCalls: FillTextCall[] = [];
   const ctx = {
     get font() { return font; },
     set font(v: string) { font = v; },
     get fillStyle() { return fillStyle; },
     set fillStyle(v: string) { fillStyle = v; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(v: string) { letterSpacing = v; },
     measureText: (s: string) => {
       const p = px();
       return {
@@ -47,10 +62,17 @@ function makeRecordingCtx(): {
         actualBoundingBoxDescent: p * 0.2,
       } as TextMetrics;
     },
-    save() {}, restore() {}, beginPath() {},
+    save() { stack.push({ scaleX, translateX }); },
+    restore() {
+      const saved = stack.pop();
+      if (saved) ({ scaleX, translateX } = saved);
+    },
+    scale(sx: number) { scaleX *= sx; },
+    translate(tx: number) { translateX += tx * scaleX; },
+    beginPath() {},
     moveTo() {}, lineTo() {}, stroke() {}, fillRect() {},
     fillText(text: string, x: number, y: number) {
-      fillTextCalls.push({ text, x, y, font, fillStyle });
+      fillTextCalls.push({ text, x, y, font, fillStyle, scaleX, translateX });
     },
     strokeText() {},
     drawImage(bmp: unknown, x: number, y: number, w: number, h: number) {
@@ -447,6 +469,25 @@ describe('textbox rich text — per-run formatting', () => {
     for (const c of fillTextCalls.filter((t) => t.text.trim().length > 0)) {
       expect(c.font).toContain('"Yu Mincho"');
     }
+  });
+
+  it('condenses Meiryo UI kana in a text box to the same edge layout measures', () => {
+    const { ctx, fillTextCalls } = makeRecordingCtx();
+    const shape = richTextbox([
+      {
+        text: 'ひら漢',
+        fontSizePt: 10,
+        fontFamily: 'Meiryo UI',
+        fontFamilyEastAsia: 'Meiryo UI',
+      },
+    ]);
+    renderShapeText(shape, 0, 0, 2000, 400, ctx, 1, {}, new Map());
+
+    const kana = fillTextCalls.find((call) => call.text === 'ひら');
+    const kanji = fillTextCalls.find((call) => call.text === '漢');
+    expect(kana?.scaleX).toBeCloseTo(0.7775, 9);
+    const paintedRight = kana!.translateX + kana!.scaleX * (kana!.x + 2 * 10);
+    expect(paintedRight).toBeCloseTo(kanji!.x + kanji!.translateX, 6);
   });
 });
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -150,6 +150,7 @@ import {
   paragraphSegsStateSensitive,
   rescaleLayoutLines,
   segAdvanceWidth,
+  segGlyphScaleFactor,
   segLetterSpacingPx,
   shapeRenderState,
   shapeRunToDocRun,
@@ -588,6 +589,10 @@ export interface DocxTextRunInfo {
   /** Uniform per-code-point pitch in CSS px used to draw a horizontal run.
    *  Absent when the pitch is zero or the run uses vertical / 縦中横 paint. */
   letterSpacingPx?: number;
+  /** Composed horizontal glyph transform (`w:w` × resolved font advance
+   *  profile). Horizontal selection/find overlays apply the same scale so their
+   *  natural DOM/text metrics do not overrun the Canvas glyphs. */
+  glyphScaleX?: number;
   /** ECMA-376 §17.6.20 (tbRl) — when the page is vertical the canvas is the
    *  physical landscape page rotated +90° at paint, so this run's `x`/`y` are the
    *  PHYSICAL top-left the overlay span must sit at, and `transform` is the CSS
@@ -6865,6 +6870,10 @@ function resolveFrameBox(
           state.kinsoku,
           gridCharDeltaPx(grid, scale),
           state.defaultTabPt,
+          measureW,
+          paragraphContext.baseRtl,
+          paragraphContext.isJustified,
+          paragraphContext.stretchLastLine,
         );
   const contentW =
     lines.length === 0
@@ -7357,9 +7366,9 @@ function renderParagraph(
     : reuse
     ? rescaleLayoutLines(stamped.layoutLines as LayoutLine[], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx)
     : wrapCtx
-      ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx, baseRtl)
+      ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx, baseRtl, jcIsFullyJustified(para.alignment), jcStretchesLastLine(para.alignment))
       : rescaleLayoutLines(
-          layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt, marginRightPx1, baseRtl),
+          layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt, marginRightPx1, baseRtl, jcIsFullyJustified(para.alignment), jcStretchesLastLine(para.alignment)),
           scale, ctx, state.fontFamilyClasses, paintGridDeltaPx,
         );
 
@@ -8080,7 +8089,11 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
         // the glyph draw so paint == measure. §17.3.2.19 `<w:kern>` sets
         // `ctx.fontKerning` to match the measure pass exactly (see line-layout's
         // `setSegKerning`); restored after the glyph block.
-        const segCharScale = s.charScale ?? 1;
+        // Compose authored §17.3.2.43 w:w with the requested font's real
+        // per-script horizontal advance. segAdvanceWidth uses this same factor;
+        // every fixed pitch below is divided inside the scaled frame so paint
+        // reproduces the measured box exactly.
+        const segCharScale = segGlyphScaleFactor(s);
         const segCharSpacingPx = s.fitTextPerGapPx ?? (s.charSpacing ?? 0) * scale;
         const prevFontKerning = ctx.fontKerning;
         if (s.kerning != null) {
@@ -8575,7 +8588,11 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
               : fullyDistributed
                 ? distPerGap
                 : 0;
-          const measureMark = (str: string): number => ctx.measureText(str).width;
+          // Prefix glyph advances live inside the same composed horizontal
+          // transform as the text. Fixed grid/justify pitches remain in
+          // `markPitch`, outside the scale, mirroring the glyph paint path.
+          const measureMark = (str: string): number =>
+            ctx.measureText(str).width * segCharScale;
           const centers = emphasisMarkCenters(s.text, measureMark, x, markPitch);
           // Above marks sit a small gap above the glyph box top (the same
           // ~0.85em ascent the box decorations use); below marks (underDot) sit
@@ -8634,6 +8651,9 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           const letterSpacingPx = !state.verticalCJK && !s.tateChuYoko
             ? segLetterSpacingPx(s, drawGridDeltaPx, scale)
             : 0;
+          const glyphScaleX = !state.verticalCJK && !s.tateChuYoko
+            ? segGlyphScaleFactor(s)
+            : 1;
           state.onTextRun({
             text: s.text,
             x: place ? place.left : x,
@@ -8643,6 +8663,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             fontSize: effSizePx,
             font: ctx.font,
             ...(letterSpacingPx !== 0 ? { letterSpacingPx } : {}),
+            ...(glyphScaleX !== 1 ? { glyphScaleX } : {}),
             transform: place?.transform,
             // IX1 — hand the resolved hyperlink target to the overlay so a link
             // run becomes clickable. Undefined for non-link runs (no payload
@@ -9602,6 +9623,8 @@ export function measureShapeTextAutoFitHeight(
         effState.defaultTabPt,
         ind.paraW,
         baseRtl,
+        jcIsFullyJustified(b.alignment),
+        jcStretchesLastLine(b.alignment),
       );
       contentH += lines.reduce((sum, line) => sum + lineHeightFor(b, line), 0);
     }
@@ -9893,6 +9916,8 @@ export function renderShapeText(
       effState.defaultTabPt,
       ind.paraW, // marginRightPx: block text has no separate right-indent origin
       baseRtl,
+      jcIsFullyJustified(b.alignment),
+      jcStretchesLastLine(b.alignment),
     );
     const metrics = lines.map((line) => lineMetricsFor(b, line));
     return {
@@ -10235,9 +10260,12 @@ export function renderShapeText(
               glyphDrawX = x + rtlWsShiftPx;
             }
           }
+          // Same composed requested-font + authored w:w scale as the body draw
+          // loop and segAdvanceWidth (measure == paint in text boxes). Fixed
+          // spacing stays outside that glyph scale in every branch below.
+          const segCharScale = segGlyphScaleFactor(s);
+          const segCharSpacingPx = segLetterSpacingPx(s, 0, scale);
           if (kashida) {
-            const segCharScale = s.charScale ?? 1;
-            const segCharSpacingPx = segLetterSpacingPx(s, 0, scale);
             const prevKerning = ctx.fontKerning;
             if (s.kerning != null) {
               ctx.fontKerning = s.fontSize >= s.kerning ? 'normal' : 'none';
@@ -10271,19 +10299,50 @@ export function renderShapeText(
             // the rtl-marked EA-punctuation corner where bidi justification is
             // already approximate. Same argument as the body loop.
             const cps = [...s.text];
+            const scaled = segCharScale !== 1;
+            const originX = scaled ? 0 : x;
+            const prevLetterSpacing = ctx.letterSpacing;
+            if (scaled) {
+              ctx.save();
+              ctx.translate(x, 0);
+              ctx.scale(segCharScale, 1);
+            }
             if (stretch.splitBefore.length === cps.length - 1) {
               // Fully distributed (pure-CJK): uniform pitch via letterSpacing so
               // the contextually-shaped run keeps its packing (PR #626 analog).
-              const prevLetterSpacing = ctx.letterSpacing;
-              ctx.letterSpacing = `${distPerGap}px`;
-              ctx.fillText(s.text, x, baseline + yOffset);
-              ctx.letterSpacing = prevLetterSpacing;
+              ctx.letterSpacing = `${(distPerGap + segCharSpacingPx) / segCharScale}px`;
+              ctx.fillText(s.text, originX, baseline + yOffset);
             } else {
               const measure = (str: string): number => ctx.measureText(str).width;
-              for (const { text: piece, dx } of justifiedPiecePositions(cps, stretch.splitBefore, distPerGap, measure)) {
-                ctx.fillText(piece, x + dx, baseline + yOffset);
+              for (const { text: piece, dx } of justifiedPiecePositions(
+                cps,
+                stretch.splitBefore,
+                distPerGap / segCharScale,
+                measure,
+                segCharSpacingPx / segCharScale,
+              )) {
+                ctx.letterSpacing = `${segCharSpacingPx / segCharScale}px`;
+                ctx.fillText(piece, originX + dx, baseline + yOffset);
               }
             }
+            ctx.letterSpacing = prevLetterSpacing;
+            if (scaled) ctx.restore();
+          } else if (segCharScale !== 1) {
+            ctx.save();
+            ctx.translate(glyphDrawX, 0);
+            ctx.scale(segCharScale, 1);
+            const prevLetterSpacing = ctx.letterSpacing;
+            if (segCharSpacingPx !== 0) {
+              ctx.letterSpacing = `${segCharSpacingPx / segCharScale}px`;
+            }
+            ctx.fillText(glyphText, 0, baseline + yOffset);
+            ctx.letterSpacing = prevLetterSpacing;
+            ctx.restore();
+          } else if (segCharSpacingPx !== 0) {
+            const prevLetterSpacing = ctx.letterSpacing;
+            ctx.letterSpacing = `${segCharSpacingPx}px`;
+            ctx.fillText(glyphText, glyphDrawX, baseline + yOffset);
+            ctx.letterSpacing = prevLetterSpacing;
           } else {
             ctx.fillText(glyphText, glyphDrawX, baseline + yOffset);
           }

--- a/packages/docx/src/run-char-metrics.test.ts
+++ b/packages/docx/src/run-char-metrics.test.ts
@@ -3,6 +3,8 @@ import {
   charScaleFactor,
   charSpacingDeltaPx,
   segAdvanceWidth,
+  segGlyphScaleFactor,
+  segLetterSpacingPx,
   type LayoutTextSeg,
 } from './line-layout.js';
 
@@ -94,5 +96,25 @@ describe('WD4 run character-metric width helpers', () => {
     // byte-identical.
     const s = seg({ text: '２９', fontSize: 12, charScale: 0.67 });
     expect(segAdvanceWidth(s, 100, 0, 1)).toBeCloseTo(67, 10);
+  });
+
+  it('composes a resolved Meiryo UI advance stamp with authored w:w but leaves fixed spacing unscaled', () => {
+    const s = seg({
+      text: 'ひら',
+      fontFamily: 'Meiryo UI',
+      fontAdvanceScale: 0.7775,
+      charScale: 0.8,
+      charSpacing: 0.5,
+    });
+    const glyphScale = 0.8 * 0.7775;
+    expect(segGlyphScaleFactor(s)).toBeCloseTo(glyphScale, 10);
+    expect(segLetterSpacingPx(s, 0, 2)).toBe(1);
+    expect(segAdvanceWidth(s, 100, 0, 2)).toBeCloseTo(100 * glyphScale + 2, 10);
+  });
+
+  it('keeps non-condensed fonts on the existing advance path', () => {
+    const s = seg({ text: 'ひら', fontFamily: 'Meiryo', charScale: 0.8 });
+    expect(segGlyphScaleFactor(s)).toBe(0.8);
+    expect(segAdvanceWidth(s, 100, 0, 1)).toBe(80);
   });
 });

--- a/packages/docx/src/run-char-scale-grid-justify.test.ts
+++ b/packages/docx/src/run-char-scale-grid-justify.test.ts
@@ -155,6 +155,32 @@ function paintedInkExtent(fills: FillCall[], expectedText: string): { left: numb
 }
 
 describe('WD4 #816 — w:w charScale reaches paint under an active docGrid / justify (measure==paint)', () => {
+  it('Meiryo UI kana advance profile paints ink to the measured segment edge', async () => {
+    const kana = 'ひら';
+    const following = '漢';
+    const metricScale = 0.7775;
+    const { runs, fills } = await render(
+      [para([textRun(`${kana}${following}`, {
+        fontFamily: 'Meiryo UI',
+        fontFamilyEastAsia: 'Meiryo UI',
+      })])],
+      section(),
+    );
+
+    const kanaRun = runs.find((r) => r.text === kana);
+    const followingRun = runs.find((r) => r.text === following);
+    expect(kanaRun).toBeDefined();
+    expect(followingRun).toBeDefined();
+    expect(kanaRun!.glyphScaleX).toBeCloseTo(metricScale, 9);
+    expect(kanaRun!.w).toBeCloseTo([...kana].length * FONT_PX * metricScale, 6);
+
+    const kanaFill = fills.find((fill) => fill.text === kana);
+    expect(kanaFill?.scaleX).toBeCloseTo(metricScale, 9);
+    const paintedRight = kanaFill!.translateX
+      + kanaFill!.scaleX * (kanaFill!.x + [...kana].length * FONT_PX);
+    expect(paintedRight).toBeCloseTo(followingRun!.x, 5);
+  });
+
   // Reviewer's probe (grid arm): a pure-EA run with w:w=0.5 in a linesAndChars
   // grid. The measured box scales natural width by 0.5 and adds the cell delta;
   // the paint must draw the glyphs at 0.5× so the ink fills exactly that box.

--- a/packages/docx/src/text-layer.test.ts
+++ b/packages/docx/src/text-layer.test.ts
@@ -156,4 +156,29 @@ describe('buildDocxTextLayer (extracted from DocxViewer._buildTextLayer)', () =>
     // Ordinary run: no transform at all (horizontal page), so no scaleX sneaks in.
     expect(layer.children[0].style.transform ?? '').toBe('');
   });
+
+  it('scales a horizontal selection span by the composed glyph scale', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({ text: 'ひら', glyphScaleX: 0.7775 })];
+
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, 100, 100);
+
+    expect(layer.children[0].style.transform).toBe('scaleX(0.7775)');
+    expect(layer.children[0].style.cssText).toContain('transform-origin:top left');
+  });
+
+  it('keeps the existing eastAsianVert scale branch authoritative', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const runs = [run({
+      text: '２９', w: 7, fontSize: 7, eastAsianVert: true,
+      transform: 'rotate(90deg)', glyphScaleX: 0.25,
+    })];
+    const measureForFont = () => (s: string) => [...s].length * 7;
+
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, runs, 1, 1, undefined, measureForFont);
+
+    expect(layer.children[0].style.transform).toBe('rotate(90deg) scaleX(0.5)');
+  });
 });

--- a/packages/docx/src/text-layer.ts
+++ b/packages/docx/src/text-layer.ts
@@ -38,8 +38,12 @@ import { tateChuYokoOverlayScale } from './tate-chu-yoko-overlay';
  *                         the browser's own navigation can never bypass the
  *                         caller's URL sanitisation. When omitted, link runs are
  *                         rendered exactly like plain runs (no click affordance).
+ * Horizontal runs carrying `glyphScaleX` compose that factor directly into the
+ * span transform so selection follows condensed Canvas glyphs. The existing
+ * §17.3.2.10 縦中横 branch remains authoritative for eastAsianVert runs.
+ *
  * @param measureForFont   optional width-measurer factory (primed with a run's
- *                         `font`), used ONLY to clamp a §17.3.2.10 縦中横
+ *                         `font`), used to clamp a §17.3.2.10 縦中横
  *                         (eastAsianVert) span to its drawn one-em cell (#836):
  *                         the span composes a `scaleX(run.w / naturalWidth)` so
  *                         its selection extent matches the compressed glyphs
@@ -82,6 +86,8 @@ export function buildDocxTextLayer(
     if (measureForFont && run.eastAsianVert) {
       const k = tateChuYokoOverlayScale(run, measureForFont(run.font));
       if (k !== 1) transformValue = `${transformValue ? `${transformValue} ` : ''}scaleX(${k})`;
+    } else if (!run.eastAsianVert && run.glyphScaleX !== undefined && run.glyphScaleX !== 1) {
+      transformValue = `${transformValue ? `${transformValue} ` : ''}scaleX(${run.glyphScaleX})`;
     }
     const transform = transformValue
       ? `transform:${transformValue};transform-origin:top left;`

--- a/packages/node/src/docx-font-advance-bias.probe.test.ts
+++ b/packages/node/src/docx-font-advance-bias.probe.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Issue #794 acceptance harness — per-font advance-bias model.
+ *
+ * These five criteria must hold SIMULTANEOUSLY once the model lands (issue #794
+ * implementation brief, 2026-07-11):
+ *   1. sample-15 p1 copyright block wraps to Word's 7 lines (Times small print,
+ *      near-zero bias ⇒ the +2.83px marginal word WRAPS; §17.18.44 justify gate).
+ *   3. sample-10 p1 centred title stays on ONE line (Century substituted ⇒ larger
+ *      bias absorbs the +5.96px overflow).
+ *   4. sample-4 paginates to ONE page (Meiryo UI ≈ per-script condensed advance:
+ *      hiragana ~0.78em / katakana ~0.74em vs the substitute's 1.0em).
+ * (2 = demo/sample-1 fidelity ratchet and 5 = #796 Thai/Korean corpus are checked
+ *  in the Playwright VRT, not here.)
+ *
+ * Environment: fonts are deliberately NOT registered — this is the absent-font
+ * substitute environment the model must correct. macOS-gated (the VRT reference
+ * environment); skia + WASM gated like the other probes.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  installImageBitmapShim,
+  installOffscreenCanvasShim,
+  type NodeCanvasFactory,
+} from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, loadImage } = (skia ?? {}) as Skia;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (async (buf: ArrayBuffer | Uint8Array | Buffer) =>
+    loadImage(Buffer.from(buf as Uint8Array))) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../..');
+const RENDERER_PATH = resolve(ROOT, 'packages/docx/src/renderer.ts');
+const docxMod = skia ? await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)') : null;
+const rendererMod = skia
+  ? await importForTests(() => import(RENDERER_PATH), 'packages/docx/src/renderer.ts')
+  : null;
+
+const samplePath = (n: number) => resolve(ROOT, `packages/docx/public/private/sample-${n}.docx`);
+const have = (n: number) => existsSync(samplePath(n));
+
+interface Run { text: string; x: number; y: number; w: number; h: number; fontSize: number }
+
+interface RendererMod {
+  parseDocxAvailable?: boolean;
+  paginateDocument: (doc: unknown) => unknown[][];
+  renderDocumentToCanvas: (
+    doc: unknown,
+    canvas: unknown,
+    pageIndex: number,
+    opts: Record<string, unknown>,
+  ) => Promise<void>;
+}
+
+function parse(n: number): unknown {
+  const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => unknown };
+  return parseDocx(readFileSync(samplePath(n)));
+}
+
+/** Page count via the pure paginator (needs the OffscreenCanvas shim). */
+function pageCount(n: number, width = 595): number {
+  const restore = [installOffscreenCanvasShim(factory), installImageBitmapShim(factory)];
+  try {
+    const { paginateDocument } = rendererMod as unknown as RendererMod;
+    return paginateDocument(parse(n)).length;
+  } finally {
+    restore.forEach((r) => r());
+  }
+}
+
+/** A recording ctx proxy over a real skia 2D context: forwards every property /
+ *  method to the real ctx (so `measureText`, transforms, fills all behave as in
+ *  production) but captures each `fillText`/`strokeText` call as a drawn text run
+ *  in ABSOLUTE page coordinates (via the live CTM). Unlike `onTextRun` this also
+ *  captures DrawingML textbox (`wps:txbx`) text, which the copyright block
+ *  (sample-15) and centred title (sample-10) live in. */
+function recordingCtx(real: CanvasRenderingContext2D, sink: Run[]): CanvasRenderingContext2D {
+  return new Proxy(real, {
+    get(target, prop, receiver) {
+      if (prop === 'fillText' || prop === 'strokeText') {
+        return (text: string, x: number, y: number, maxW?: number) => {
+          if (text) {
+            const m = target.getTransform();
+            const ax = m.a * x + m.c * y + m.e;
+            const ay = m.b * x + m.d * y + m.f;
+            const w = target.measureText(text).width * m.a;
+            sink.push({ text, x: ax, y: ay, w, h: 0, fontSize: 0 });
+          }
+          return (target[prop as 'fillText'] as (t: string, x: number, y: number, mw?: number) => void)
+            .call(target, text, x, y, maxW as number);
+        };
+      }
+      const v = Reflect.get(target, prop, target);
+      return typeof v === 'function' ? v.bind(target) : v;
+    },
+    set(target, prop, value) {
+      return Reflect.set(target, prop, value, target);
+    },
+  }) as unknown as CanvasRenderingContext2D;
+}
+
+/** Visual lines of page `page` (0-based), top-to-bottom, each the concatenated
+ *  drawn text sharing a baseline y (captured at the fillText level so textbox
+ *  content is included). Column-aware (splits on gutter x-gaps). */
+async function pageLines(n: number, page: number, width = 595): Promise<string[]> {
+  const restore = [installOffscreenCanvasShim(factory), installImageBitmapShim(factory)];
+  try {
+    const { paginateDocument, renderDocumentToCanvas } = rendererMod as unknown as RendererMod;
+    const doc = parse(n);
+    const pages = paginateDocument(doc);
+    const runs: Run[] = [];
+    const canvas = new Canvas(Math.round(width * 1.5), Math.round(width * 2));
+    const realCtx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+    const recCtx = recordingCtx(realCtx, runs);
+    // Return the recording ctx from getContext (leave native canvas.width/height
+    // setters intact so skia's private fields are untouched by a Proxy).
+    (canvas as unknown as { getContext: () => unknown }).getContext = () => recCtx;
+    await renderDocumentToCanvas(doc, canvas as unknown as never, page, {
+      width,
+      dpr: 1,
+      prebuiltPages: pages,
+      totalPages: pages.length,
+    });
+    // Column-aware line reconstruction: bucket by baseline y, then within a row
+    // split into separate visual lines wherever x jumps by more than ~15% of the
+    // page width (a column gutter). A 2-column paper (sample-15) otherwise merges
+    // its left/right columns into one string per y.
+    const gap = width * 0.15;
+    const byY = new Map<number, Run[]>();
+    for (const r of runs) {
+      const key = Math.round(r.y);
+      let arr = byY.get(key);
+      if (!arr) { arr = []; byY.set(key, arr); }
+      arr.push(r);
+    }
+    const out: { x: number; y: number; text: string }[] = [];
+    for (const [y, rs] of byY) {
+      const sorted = rs.slice().sort((p, q) => p.x - q.x);
+      let cur: Run[] = [];
+      let lastRight = -Infinity;
+      const flush = () => {
+        if (cur.length) out.push({ x: cur[0].x, y, text: cur.map((r) => r.text).join('') });
+        cur = [];
+      };
+      for (const r of sorted) {
+        if (cur.length && r.x - lastRight > gap) flush();
+        cur.push(r);
+        lastRight = r.x + r.w;
+      }
+      flush();
+    }
+    // Order the reconstructed lines by column (x band) then y: left column top→
+    // bottom, then right column. This keeps a paragraph's lines contiguous.
+    return out
+      .sort((a, b) => (a.x < width * 0.5 ? 0 : 1) - (b.x < width * 0.5 ? 0 : 1) || a.y - b.y)
+      .map((l) => l.text);
+  } finally {
+    restore.forEach((r) => r());
+  }
+}
+
+const macos = process.platform === 'darwin';
+const gate = !!skia && !!docxMod && !!rendererMod && macos;
+
+describe.skipIf(!gate)('issue #794 — per-font advance-bias acceptance', () => {
+  it.skipIf(!have(4))('CRITERION 4: sample-4 paginates to 1 page (Meiryo UI condensed advance)', () => {
+    const pages = pageCount(4);
+    // eslint-disable-next-line no-console
+    console.log(`[#794 C4] sample-4 pageCount = ${pages} (Word: 1)`);
+    expect(pages).toBe(1);
+  });
+
+  // CRITERION 1 (sample-15 #698 narrow justified column) is encoded as the
+  // synthetic Word-verified gate in packages/docx/src/justify-shrink-overshoot.test.ts
+  // (the two `INTERIM (#794 pending)` pins flip to 3 tokens / 2 lines). The real
+  // sample-15 copyright block is a page-bottom-anchored <wps:txbx> that this body
+  // render path does not draw, so it cannot be line-counted here; the synthetic
+  // gate + demo/sample-1 VRT ratchet are its acceptance.
+
+  it.skipIf(!have(10))('CRITERION 3: sample-10 p1 centred title stays on one line', async () => {
+    const lines = await pageLines(10, 0, 595);
+    const norm = (l: string) => l.replace(/\s+/g, '');
+    // Word truth (sample-10.pdf p1): the centred main title is one line:
+    //   「第 11 回横幹連合コンファレンスサンプル原稿」
+    // A substituted MS Mincho over-measures the CJK title by ~+5.96px; Word keeps
+    // it on ONE line, so the model must admit that overflow. Failure mode on main:
+    // the tail 「サンプル原稿」 wraps to a second line.
+    const titleLine = lines.find((l) => norm(l).includes('横幹連合コンファレンスサンプル原稿'));
+    // eslint-disable-next-line no-console
+    console.log(`[#794 C3] sample-10 title one-line? ${!!titleLine}\n` +
+      lines.slice(0, 8).map((l, i) => `  ${i}: ${JSON.stringify(l)}`).join('\n'));
+    expect(titleLine, 'full title 第…コンファレンスサンプル原稿 on a single visual line').toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Implements the per-font advance model from #794: our canvas-measured advances differ from Word's real font advances per font, and the renderer's single flat wrap-fit tolerance (`SPACE_SHRINK_RATIO × Σtrailing-space`) conflated two unrelated roles — absorbing per-font measurement bias AND emulating drawable space compression — so the tracked public demo GT and the Word-verified narrow-column wrap (#698) could not hold simultaneously (the #934/#944 episode).

### Regime B — real per-script advance profiles (`packages/core/src/text/font-advance-metrics.ts`)
- Meiryo UI's condensed kana advances harvested from the real face's `hmtx` (unitsPerEm 2048): hiragana **0.7775 em**, katakana **0.7438 em**, fullwidth punctuation **0.7214 em**; ideographs/fullwidth Latin 1.0 (no-op). Every reachable substitute measures kana at 1.0 em (verified in both Chromium and skia), which inflated width-constrained layouts.
- A memoized **substitution probe** (per built font string) gates the profile: it applies only when the resolved face measures full-width, so a host with the real face installed is never double-scaled.
- `buildSegments` splits tabled families into homogeneous script runs (skipped for vertical `tbRl` text — the harvested data is horizontal `hmtx`, vertical cells are full-em — and for ruby bases); `segGlyphScaleFactor` composes the profile with authored `w:w`; measure (`segAdvanceWidth`, fitText §17.3.2.14 resolution, `fitCJKPrefix`) and paint (body + textbox glyph loops via one canvas transform, emphasis-mark centers, selection/find overlays via `glyphScaleX`) share the composed factor — measure == paint everywhere.

### Regime A — per-line §17.18.44 gate + per-font Canvas-vs-Word bias
- `layoutLines` regains `isJustified`/`stretchLastLine`; measure classifies each line exactly like the paint predicate `applyJustify = isJustified && (!endsLogicalLine || stretchLastLine)` across the paginator, body paint, frames, and both textbox paths.
- The fit budget is **exclusive per line**: a line the paint pass will justify gets only the per-font bias budget (`fontAdvanceBiasEm × em × glyphs × w:w`; Georgia **0.0105 em**, calibrated inside the measured 0.009–0.028 band against the public demo ratchet — 0.009 under-admits, 0.012+ over-admits); a non-justified line keeps exactly the old trailing-space allowance (byte-stable). Adding both double-counts and over-admits words Word wraps (observed as collapsed inter-word spaces on centred/table lines).
- The two Word-verified #698 pins flip back: a justified line breaks at natural fit (3 tokens / 2 lines), including the `distribute` last line.

### Independent review
Reviewed by a separate read-only session; all findings addressed: substitution-probe gating (double-scale on real-face hosts), vertical-text suppression, fitText scale unification, ruby-base split protection, selection/find overlay scaling, emphasis-mark centers, `w:w` bias composition, incremental O(n) bias accounting, comment accuracy.

## Acceptance evidence (before → after)

| Criterion | main | this PR | Word GT |
|---|---|---|---|
| sample-15 #698 justified natural-fit break (synthetic Word-verified pins) | interim 4 tokens/1 line | **3 tokens / 2 lines** | 3 tokens / 2 lines |
| demo/sample-1 fidelity (p1…p6) | 99.82/99.1/99.58/100/100/100 | **99.8 / 99.1 / 99.2 / 100 / 99.5 / 100** (ratchet holds; p4/p6 exact) | ratchet floor −0.5pt |
| sample-10 p1 centred title | 1 line | **1 line** (regression guard) | 1 line |
| sample-4 page count | 2 | **1** | **1** |
| corpus page counts (26/28/29/30/31) | 1/23/13/4/12 | unchanged | 1/23/12*/4/12 |

\* sample-29 (Thai) needs its own advance-profile data (Leelawadee/Angsana New binaries are not harvestable on this host) — mechanism now exists; tracked as a follow-up.

## Verification
- docx unit suite: 165 files / 1271 tests; core: 1633 tests; root `pnpm typecheck` green.
- Full docx VRT (isolated port; parallel-worktree 5180 avoided): demo ratchet green, 0 failures.
- Node acceptance probe (`packages/node/src/docx-font-advance-bias.probe.test.ts`): sample-4 = 1 page, sample-10 title single line.
- Private VRT references intentionally untouched (owner regenerates baselines).

Closes #794
Closes #698
Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)