### PR TITLE
fix(docx): break over-tall vMerge spans across pages (§17.4.6/§17.4.85)

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -5123,10 +5123,74 @@ export function resolveColumnWidths(table: DocTable, contentWPt: number, state: 
 
 /** A page break before row `ri` is unsafe when `ri` continues a vertical merge
  *  started above (ECMA-376 §17.4.85): splitting there would orphan the merged
- *  cell's continuation. Such a row carries at least one `vMerge=false` cell. */
+ *  cell's continuation. Such a row carries at least one `vMerge=false` cell.
+ *
+ *  When an over-tall vMerge span is broken at an interior boundary (see the
+ *  {@link splitTableAcrossPages} relaxation), the continuation slice re-opens the
+ *  merged cell via {@link reopenMergedCellsInRow} so this rule is re-satisfied for
+ *  the slice as its own table. */
 function tableBreakAllowedBefore(table: DocTable, ri: number): boolean {
   if (ri <= 0) return true;
   return !table.rows[ri].cells.some((c) => c.vMerge === false);
+}
+
+/** The cell whose gridSpan covers logical column `targetCi` in `row`, or `null`.
+ *  Pure grid walk (gridSpan-aware), mirroring {@link findMergeEndRow}'s column
+ *  scan (ECMA-376 §17.4.85). */
+function cellAtGridColumn(row: DocTableRow, targetCi: number): DocTableCell | null {
+  let ci = 0;
+  for (const cell of row.cells) {
+    if (targetCi >= ci && targetCi < ci + cell.colSpan) return cell;
+    ci += cell.colSpan;
+  }
+  return null;
+}
+
+/** ECMA-376 §17.4.85 — re-open a vMerge span that crosses INTO a continuation
+ *  slice. When an over-tall span is broken at an interior row boundary, the
+ *  slice's first body row (`rows[start]`) inherits `vMerge=continue` cells whose
+ *  `restart` sits on an earlier page. {@link drawTableRows} skips a bare continue
+ *  cell ("drawn by its restart partner"), so without this the re-opened cell box
+ *  would not be painted at all. For each such continue cell, walk UP `rows` to its
+ *  owning restart and:
+ *   - if that restart is a REPEATED header row already prepended to this slice
+ *     (`restartRi < headerCount`, and headers repeat), leave the continue cell as
+ *     is — the prepended header restart already spans the body rows, so promoting
+ *     here would draw a SECOND box (review finding, §17.4.78);
+ *   - otherwise promote it to `restart`, cloning the OWNING RESTART cell's
+ *     presentation (background / borders / vAlign) so the continuation box matches
+ *     Word — which paints the whole merged span from the restart cell — rather than
+ *     the continue cell's own (usually empty) properties. Content is dropped: the
+ *     merged content stayed with the restart row on the first piece, so the re-
+ *     opened box is empty (no duplication). The grid footprint (`colSpan`) is kept
+ *     from the continue cell so the row's column math is unchanged.
+ *  Runtime-only clone: the parsed rows/cells are never mutated. */
+function reopenMergedCellsInRow(
+  rows: DocTableRow[],
+  start: number,
+  headerCount: number,
+  headersPrepended: boolean,
+): DocTableRow {
+  const row = rows[start];
+  let ci = 0;
+  const cells = row.cells.map((cell) => {
+    const gridCi = ci;
+    ci += cell.colSpan;
+    if (cell.vMerge !== false) return cell;
+    // Walk up to the restart that owns this continue cell's column.
+    let restartRi = -1;
+    let restartCell: DocTableCell | null = null;
+    for (let r = start - 1; r >= 0; r--) {
+      const above = cellAtGridColumn(rows[r], gridCi);
+      if (!above) break;
+      if (above.vMerge === true) { restartRi = r; restartCell = above; break; }
+      if (above.vMerge !== false) break; // column left the span — malformed; bail
+    }
+    if (!restartCell) return cell; // no restart found (defensive) — leave unchanged
+    if (headersPrepended && restartRi < headerCount) return cell; // header owns it
+    return { ...restartCell, colSpan: cell.colSpan, vMerge: true as const, content: [] };
+  });
+  return { ...row, cells };
 }
 
 /** B2 table stage 1b — stamp a table element (whole table or one page slice) with
@@ -5850,19 +5914,34 @@ export function splitTableAcrossPages(
     const firstRowH = (isContinuation ? headerH : 0) + workRowHs[start];
     const freshAvail = contentH - colTop();
     const rowAvail = avail - (isContinuation ? headerH : 0);
-    // §17.4.85 + §17.4.6 — the UNBREAKABLE group starting at `start`: a restart
-    // row chained to its continue rows admits no internal break, so when the
-    // group as a whole overflows the band the only spec-faithful relief is
-    // splitting its (splittable) HEAD row — the group head is the restart row,
-    // which the relaxed splitter gate accepts; the remainder group then flows
-    // to the next page, where this same check re-splits the re-opened restart
-    // piece if the remaining span STILL exceeds a fresh page (the review's
-    // "re-split the restart piece" requirement). A single-row group reduces to
-    // the historical first-row check, so vMerge-free tables are byte-identical.
+    // The vMerge group starting at `start`: a restart row chained to its continue
+    // rows. This renderer keeps such a group together across page breaks (Word's
+    // observed behavior; ECMA-376 §17.4.85 defines the merge STRUCTURE but does not
+    // itself declare the span page-atomic, and §17.4.6 makes rows splittable by
+    // default). Two reliefs apply when the group overflows:
+    //   • split its (splittable) HEAD row — the group head is the restart row,
+    //     which the relaxed splitter gate accepts (PR #926 mid-row content split);
+    //   • when the group cannot fit even a FULL page's content band
+    //     (`groupH > contentH`), the atomicity invariant is impossible to honor, so
+    //     page breaks at the group's INTERIOR row boundaries are permitted (private
+    //     sample-42: a 900pt span in a 648pt band). Each continuation slice then
+    //     re-opens the merged cell (reopenMergedCellsInRow), and this same check
+    //     re-evaluates the re-opened span against the next full page. A group that
+    //     fits a full page keeps `relaxSpanBreak === false`, so its handling is
+    //     byte-identical to before this change (vMerge-free tables, and spans small
+    //     enough to stay atomic, are unaffected). NB: the threshold is `contentH`
+    //     (the full page/section content band), NOT `freshAvail` (the CURRENT
+    //     column region, which a mid-page continuous section shrinks) — a span that
+    //     merely overflows a short mid-page region still relocates whole to the next
+    //     full page rather than splitting inside the region.
     let groupEnd = start;
     while (groupEnd + 1 < n && !tableBreakAllowedBefore(workTable, groupEnd + 1)) groupEnd++;
     let groupH = isContinuation ? headerH : 0;
     for (let r = start; r <= groupEnd; r++) groupH += workRowHs[r];
+    const relaxSpanBreak = groupH > contentH;
+    const breakAllowedBefore = (ri: number): boolean =>
+      tableBreakAllowedBefore(workTable, ri) ||
+      (relaxSpanBreak && ri > start && ri <= groupEnd);
     if (rowSplit && (firstRowH > avail || groupH > avail) && rowAvail > 0 && start >= headerCount) {
       const split = splitRowForHeight(workTable, workRows[start], rowSplit.colWidthsPt, rowAvail, rowSplit.state);
       if (split && split.heights[0] <= rowAvail) {
@@ -5907,7 +5986,7 @@ export function splitTableAcrossPages(
     while (end < n) {
       const h = workRowHs[end];
       if (end > start && used + h > avail) {
-        if (tableBreakAllowedBefore(workTable, end)) {
+        if (breakAllowedBefore(end)) {
           const remainingForNextRow = avail - used;
           if (rowSplit && remainingForNextRow > 0 && end >= headerCount) {
             const split = splitRowForHeight(
@@ -5952,7 +6031,7 @@ export function splitTableAcrossPages(
           break;
         }
       }
-      if (end > start && tableBreakAllowedBefore(workTable, end)) {
+      if (end > start && breakAllowedBefore(end)) {
         lastSafeEnd = end;
         lastSafeUsed = used;
       }
@@ -5961,7 +6040,16 @@ export function splitTableAcrossPages(
     }
 
     const bodyRows = workRows.slice(start, end);
-    const sliceRows = isContinuation ? [...headerRows, ...bodyRows] : bodyRows;
+    // §17.4.85 — a slice that STARTS inside a vMerge span (its first body row is a
+    // `vMerge=continue` row, because an over-tall span was broken at an interior
+    // boundary above) re-opens the merged cell so the paint pass draws its box on
+    // this page. Runtime-only clone; only the leading body row is rewritten, and a
+    // column already re-opened by a prepended repeated header is left untouched.
+    const reopenedBody =
+      start > 0 && bodyRows.length > 0 && bodyRows[0].cells.some((c) => c.vMerge === false)
+        ? [reopenMergedCellsInRow(workRows, start, headerCount, isContinuation), ...bodyRows.slice(1)]
+        : bodyRows;
+    const sliceRows = isContinuation ? [...headerRows, ...reopenedBody] : reopenedBody;
     const sliceEl = { ...workTable, type: 'table', rows: sliceRows } as PaginatedBodyElement;
     if (tagColIndex) sliceEl.colIndex = tagColIndex();
     if (colGeom) sliceEl.colGeom = colGeom;

--- a/packages/docx/src/table-split.test.ts
+++ b/packages/docx/src/table-split.test.ts
@@ -4,15 +4,22 @@ import type { DocTable, DocTableRow, PaginatedBodyElement } from './types';
 
 // Minimal row/table builders — splitTableAcrossPages only reads rows/cells
 // (vMerge, isHeader) and the precomputed rowHs, never measures.
-function row(opts: { isHeader?: boolean; vMergeContinue?: boolean } = {}): DocTableRow {
+function row(
+  opts: {
+    isHeader?: boolean;
+    vMergeContinue?: boolean;
+    vMergeRestart?: boolean;
+    bg?: string | null;
+  } = {},
+): DocTableRow {
   return {
     cells: [
       {
         content: [],
         colSpan: 1,
-        vMerge: opts.vMergeContinue ? false : null,
+        vMerge: opts.vMergeRestart ? true : opts.vMergeContinue ? false : null,
         borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
-        background: null,
+        background: opts.bg ?? null,
         vAlign: 'top',
         widthPt: null,
       },
@@ -129,5 +136,80 @@ describe('splitTableAcrossPages', () => {
     const { pages } = run(t, rowHs, 0, 350);
 
     expect(pages.map((p) => rowsOf(p[0]).length)).toEqual([2, 3]);
+  });
+
+  it('breaks an over-tall vMerge span at a row boundary when it exceeds a fresh page', () => {
+    // A 3-row vMerge span (restart + 2 continue), each row 300pt = 900pt total,
+    // exceeds the 648pt content band even on a FRESH page (private sample-42).
+    // ECMA-376 §17.4.6 (cantSplit default = splittable): the span must break at
+    // whole-row boundaries rather than dumping 900pt onto one page and losing the
+    // continuation rows. Starting 100pt down leaves 548pt: only row 0 fits before
+    // the merge-end rows overflow, so the break lands after row 0.
+    const rows = [row({ vMergeRestart: true }), row({ vMergeContinue: true }), row({ vMergeContinue: true })];
+    const t = table(rows);
+    const rowHs = [300, 300, 300];
+    const { pages } = run(t, rowHs, 100, 648);
+
+    expect(pages.length).toBe(2);
+    expect(pages.map((p) => rowsOf(p[0]).length)).toEqual([1, 2]);
+    // No row lost or duplicated.
+    expect(pages.reduce((s, p) => s + rowsOf(p[0]).length, 0)).toBe(3);
+    // §17.4.85 — the continuation slice re-opens the merged cell so the paint pass
+    // draws its box (a leading `vMerge=continue` cell would otherwise be skipped as
+    // "rendered by its restart partner", which is on the previous page).
+    expect(rowsOf(pages[1][0])[0].cells[0].vMerge).toBe(true);
+    // The re-opened cell carries NO content (the restart content stayed on page 1),
+    // so it draws an empty box rather than duplicating the merged content.
+    expect(rowsOf(pages[1][0])[0].cells[0].content).toEqual([]);
+    // The parsed model is never mutated — only the emitted slice clone is re-opened.
+    expect(t.rows[1].cells[0].vMerge).toBe(false);
+  });
+
+  it('re-opens the merged cell with the RESTART cell presentation, not the continue cell', () => {
+    // §17.4.85 — Word paints the whole merged span from the RESTART cell, so the
+    // continuation box must carry the restart cell's shading/borders, not the
+    // (usually empty) continue cell's. The restart cell here is shaded; the continue
+    // cells are not.
+    const rows = [
+      row({ vMergeRestart: true, bg: 'FFCC00' }),
+      row({ vMergeContinue: true }),
+      row({ vMergeContinue: true }),
+    ];
+    const t = table(rows);
+    const rowHs = [300, 300, 300];
+    const { pages } = run(t, rowHs, 100, 648);
+
+    const reopened = rowsOf(pages[1][0])[0].cells[0];
+    expect(reopened.vMerge).toBe(true);
+    expect(reopened.content).toEqual([]);
+    // Presentation is inherited from the restart cell (shaded), NOT the continue cell.
+    expect(reopened.background).toBe('FFCC00');
+    // Parsed model untouched: restart still shaded, continue still unshaded.
+    expect(t.rows[0].cells[0].background).toBe('FFCC00');
+    expect(t.rows[1].cells[0].background).toBe(null);
+  });
+
+  it('keeps a vMerge span atomic when it fits a fresh page (no internal break)', () => {
+    // The same span structure but each row 100pt = 300pt total fits the 350pt band
+    // on a fresh page, so §17.4.85 atomicity is preserved: it moves whole to the
+    // next page rather than breaking internally. (Contrast the over-tall case
+    // above.) Rows 0..2 are the span; row 3 follows it.
+    const rows = [
+      row({ vMergeRestart: true }),
+      row({ vMergeContinue: true }),
+      row({ vMergeContinue: true }),
+      row(),
+    ];
+    const t = table(rows);
+    const rowHs = Array(4).fill(100);
+    // 350pt page, start at 0: rows 0..2 (300) fit; row 3 (100) overflows and the
+    // break before it (a safe boundary) moves it alone to page 2. The span never
+    // breaks internally.
+    const { pages } = run(t, rowHs, 0, 350);
+    expect(pages.map((p) => rowsOf(p[0]).length)).toEqual([3, 1]);
+    // No continuation slice starts on a vMerge continuation row.
+    for (let i = 1; i < pages.length; i++) {
+      expect(rowsOf(pages[i][0])[0].cells.some((c) => c.vMerge === false)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Problem

A vertically-merged (`<w:vMerge>`) table span **taller than a full page's content band** was kept atomic and dumped onto a single page: it overflowed past the bottom margin and its continuation rows were lost, leaving later pages blank. Word instead breaks such a span at whole-row boundaries and re-resolves the restart cell's vAlign within the row set that lands on each page.

Reproduced with a private adjudication fixture: two Letter tables, each a 3-row `vMerge=restart` span (`trHeight atLeast 300pt × 3 = 900pt`) in a 648pt content band. Word paginates table 1 as `P1=row0` / `P2=rows1+2` and table 2 as `P3=rows0+1` / `P4=row2`, and re-aligns the restart cell per on-page piece (center → middle of row0's band ~322pt; bottom → bottom of the rows0+1 band ~701pt). We rendered all 900pt on one page and blanked the following page.

## Fix

Both changes are in `splitTableAcrossPages`:

1. **Relaxation.** When the unbreakable vMerge group cannot fit even a **full page** content band (`groupH > contentH`), permit page breaks at the group's interior row boundaries. ECMA-376 §17.4.6 makes rows splittable by default; §17.4.85 defines the merge *structure* but does not require the span to be page-atomic — atomicity is a renderer invariant (Word-observed) that we relax only when it is impossible to honor. A group that fits a full page keeps `relaxSpanBreak === false`, so its handling is byte-identical to before. The threshold is the full-page band, **not** the current column region, so a span overflowing only a short mid-page continuous-section region still relocates whole to the next full page.

2. **Re-open.** A continuation slice that starts inside a span re-opens the merged cell so `drawTableRows` paints its box (a bare `vMerge=continue` cell is otherwise skipped as "drawn by its restart partner", which is on the previous page). The re-opened cell inherits the owning **restart** cell's presentation (shading/borders/vAlign) — matching Word, which paints the whole span from the restart cell — with content dropped (no duplication) and the span re-closed over the following continue rows via `findMergeEndRow`. A column already re-opened by a prepended repeated header (§17.4.78) is left untouched. All slice rewrites are runtime-only clones; the parsed model is never mutated.

Per-piece vAlign then falls out for free: the restart cell's drawn box spans only the rows present in its slice, so its content centers/bottoms within the on-page piece band.

## Verification

- **Unit** (`table-split.test.ts`): over-tall span breaks `[1, 2]` rows across two pages; continuation slice re-opens the merged cell (`vMerge=true`, empty content, restart-cell shading inherited); parsed model unmutated; and a span that fits a fresh page stays atomic (`[3, 1]`). Existing "never break before a vMerge continuation" / "back up to the previous safe boundary" tests remain green.
- **Full docx suite**: 1282 tests pass. `tsc --build` clean.
- **Fixture render** (headless skia): the private fixture now paginates `P1=row0 / P2=rows1+2 / P3=rows0+1 / P4=row2` matching the Word-exported PDF, restart marker centered in row0's band and bottom-aligned in the rows0+1 band.
- **VRT non-regression (proven by construction)**: no Chrome in this environment to run Playwright, so instead the entire demo+private corpus was rendered through the renderer — the relaxation predicate fires for **no sample except the fixture** (which is not VRT-covered). For every VRT document `breakAllowedBefore` is byte-identical to the prior predicate and the re-open path is dormant, so demo and private baselines are unaffected.
- Independently reviewed by Codex GPT-5.6-sol (read-only); its findings (full-page vs region threshold, repeated-header re-open guard, restart-cell presentation inheritance, comment accuracy) are all incorporated.

## Cross-package

pptx (`a:tbl`, slide = single page) and xlsx have no cross-page table row split, so no cross-package change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)