### PR TITLE
feat(pptx): support buSzPts absolute bullet size (§21.1.2.4.10)

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -241,10 +241,17 @@ export type SpaceLine =
   | { type: 'pct'; val: number }   // val: e.g. 100000 = 100%, 150000 = 150%
   | { type: 'pts'; val: number };  // val in points
 
+/**
+ * A paragraph's bullet marker. For `char`, the marker size is EITHER `sizePct`
+ * (a percentage of the run size — ECMA-376 §21.1.2.4.9 `<a:buSzPct>`) OR `sizePts`
+ * (an absolute size in points — §21.1.2.4.10 `<a:buSzPts>`), never both: they are
+ * the one `EG_TextBulletSize` xsd:choice. `sizePts` is optional (absent when no
+ * `<a:buSzPts>` was declared); when present it takes precedence over `sizePct`.
+ */
 export type Bullet =
   | { type: 'none' }
   | { type: 'inherit' }
-  | { type: 'char'; char: string; color: string | null; sizePct: number | null; fontFamily: string | null }
+  | { type: 'char'; char: string; color: string | null; sizePct: number | null; sizePts?: number; fontFamily: string | null }
   | { type: 'autoNum'; numType: string; startAt: number | null; color: string | null };
 
 export interface TabStop {

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -2064,6 +2064,72 @@ mod tests {
         );
     }
 
+    /// §21.1.2.4.10 (buSzPts): an absolute-point bullet size on the paragraph is
+    /// parsed as `sizePts` (points; the `ST_TextFontSize` val 1800 = 18pt) and is
+    /// exclusive with `sizePct` — a `buSzPts` marker carries no `sizePct` (the two
+    /// are members of the same `EG_TextBulletSize` xsd:choice).
+    #[test]
+    fn bullet_buszpts_parsed_as_absolute_points() {
+        let data = build_align_pptx(
+            &body_sp_with_ppr(r#"<a:buSzPts val="1800"/><a:buChar char="X"/>"#),
+            "",
+            "",
+        );
+        let b = first_para_bullet(&data);
+        assert_eq!(b["type"], "char");
+        assert_eq!(b["char"], "X");
+        assert_eq!(b["sizePts"], 18.0, "buSzPts val=1800 → 18pt");
+        assert!(
+            b["sizePct"].is_null(),
+            "buSzPts is exclusive with buSzPct (same xsd:choice), got {:?}",
+            b["sizePct"]
+        );
+    }
+
+    /// §21.1.2.4.10 (buSzPts) cascade: the master declares the marker while the
+    /// slide paragraph overrides only the char — a lower-tier `buSzPts` must carry
+    /// onto the new char (the size group inherits independently of the marker).
+    #[test]
+    fn bullet_cascade_new_char_inherits_lower_tier_buszpts() {
+        let data = build_align_pptx(
+            &body_sp_with_ppr(r#"<a:buChar char="X"/>"#),
+            "",
+            &txstyles_body_lvl1(r#"<a:buSzPts val="1800"/><a:buChar char="•"/>"#),
+        );
+        let b = first_para_bullet(&data);
+        assert_eq!(b["type"], "char");
+        assert_eq!(b["char"], "X");
+        assert_eq!(
+            b["sizePts"], 18.0,
+            "absolute-point size inherited independently of the marker"
+        );
+        assert!(b["sizePct"].is_null(), "no percent size in the cascade");
+    }
+
+    /// §21.1.2.4.9/.10 cross-group precedence: a higher-tier `buSzPts` BLOCKS a
+    /// lower-tier `buSzPct` (both are the single size choice group, so the primary
+    /// tier's explicit absolute size wins and the inherited percent is dropped).
+    #[test]
+    fn bullet_buszpts_blocks_lower_tier_buszpct() {
+        let data = build_align_pptx(
+            &body_sp_with_ppr(r#"<a:buSzPts val="2400"/><a:buChar char="X"/>"#),
+            "",
+            &txstyles_body_lvl1(r#"<a:buSzPct val="50000"/><a:buChar char="•"/>"#),
+        );
+        let b = first_para_bullet(&data);
+        assert_eq!(b["type"], "char");
+        assert_eq!(b["char"], "X");
+        assert_eq!(
+            b["sizePts"], 24.0,
+            "primary-tier buSzPts wins the size group"
+        );
+        assert!(
+            b["sizePct"].is_null(),
+            "the inherited lower-tier buSzPct is blocked, got {:?}",
+            b["sizePct"]
+        );
+    }
+
     /// §21.1.2.4.8 (buNone): an explicit `<a:buNone/>` on the slide paragraph
     /// suppresses the inherited master marker — the marker group's explicit
     /// "no bullet" value blocks a lower-tier char. Regression guard for the
@@ -2111,6 +2177,7 @@ mod tests {
                 ch,
                 color,
                 size_pct,
+                size_pts,
                 font_family,
             } => {
                 assert_eq!(ch, "›");
@@ -2119,6 +2186,7 @@ mod tests {
                     "buClrTx collapses to follow-text (None) at the leaf"
                 );
                 assert_eq!(size_pct, Some(80.0));
+                assert_eq!(size_pts, None, "a Pct size carries no absolute points");
                 assert_eq!(font_family, Some("Wingdings".to_string()));
             }
             other => panic!("expected Char, got {other:?}"),
@@ -2145,6 +2213,38 @@ mod tests {
         assert_eq!(parse_bu_sz_pct(" 111% "), Some(111.0));
         assert_eq!(parse_bu_sz_pct("62.5%"), Some(62.5));
         assert_eq!(parse_bu_sz_pct("garbage"), None);
+    }
+
+    /// §21.1.2.4.10 — `<a:buSzPts val>` is `ST_TextFontSize` (hundredths of a
+    /// point); `parse_bu_sz_pts` divides by 100 to yield points, like the run
+    /// `sz`. A non-numeric value yields `None` (no size specified at this tier).
+    #[test]
+    fn parse_bu_sz_pts_is_hundredths_of_a_point() {
+        assert_eq!(parse_bu_sz_pts("1800"), Some(18.0));
+        assert_eq!(parse_bu_sz_pts("2400"), Some(24.0));
+        assert_eq!(parse_bu_sz_pts(" 100 "), Some(1.0));
+        assert_eq!(parse_bu_sz_pts("garbage"), None);
+    }
+
+    /// §21.1.2.4.10 — a `BuSize::Pts` size collapses to the resolved bullet's
+    /// `size_pts` (absolute points) and leaves `size_pct` `None`; the two size
+    /// fields are mutually exclusive at the leaf.
+    #[test]
+    fn bullet_props_pts_size_resolves_to_size_pts() {
+        let props = BulletProps {
+            marker: Some(BuMarker::Char("•".into())),
+            size: Some(BuSize::Pts(18.0)),
+            ..Default::default()
+        };
+        match props.resolve() {
+            Bullet::Char {
+                size_pct, size_pts, ..
+            } => {
+                assert_eq!(size_pts, Some(18.0), "Pts collapses to absolute points");
+                assert_eq!(size_pct, None, "Pts carries no percent size");
+            }
+            other => panic!("expected Char, got {other:?}"),
+        }
     }
 
     /// The master `or_insert` edge (codex review): a master body placeholder
@@ -2700,7 +2800,7 @@ mod tests {
 
     /// ECMA-376 §21.1.2.4.2 — a paragraph `<a:pPr><a:buBlip><a:blip r:embed>`
     /// resolves into `Bullet::Blip` carrying the blip's zip path + mime. The
-    /// `<a:buSzPct val>` (§21.1.2.4.3, thousandths of a percent) becomes a plain
+    /// `<a:buSzPct val>` (§21.1.2.4.9, thousandths of a percent) becomes a plain
     /// percentage on the bullet.
     #[test]
     fn test_parse_bullet_blip_resolves_embed_and_size() {
@@ -2720,10 +2820,12 @@ mod tests {
                 image_path,
                 mime_type,
                 size_pct,
+                size_pts,
             } => {
                 assert_eq!(image_path, "ppt/media/image3.png");
                 assert_eq!(mime_type, "image/png");
                 assert!((size_pct.expect("size_pct") - 80.0).abs() < 1e-9);
+                assert_eq!(size_pts, None, "a buSzPct blip carries no absolute points");
             }
             other => panic!("expected Bullet::Blip, got {other:?}"),
         }
@@ -2746,10 +2848,12 @@ mod tests {
                 image_path,
                 mime_type,
                 size_pct,
+                size_pts,
             } => {
                 assert_eq!(image_path, "ppt/media/image1.jpeg");
                 assert_eq!(mime_type, "image/jpeg");
                 assert!(size_pct.is_none());
+                assert!(size_pts.is_none());
             }
             other => panic!("expected Bullet::Blip, got {other:?}"),
         }

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -169,24 +169,24 @@ pub(crate) enum BuFont {
     Font(String),
 }
 
-/// Bullet size group (EG_TextBulletSize): `<a:buSzPct>` percent-of-text or
-/// `<a:buSzTx>` follow-text. Absence = inherit (enclosing `Option`).
+/// Bullet size group (EG_TextBulletSize): `<a:buSzTx>` follow-text,
+/// `<a:buSzPct>` percent-of-text, or `<a:buSzPts>` absolute point size. Absence =
+/// inherit (enclosing `Option`). The three are members of one `xsd:choice`, so at
+/// most one is present at a level; whichever is present BLOCKS a lower-tier size.
 ///
-/// `<a:buSzPts>` (§21.1.2.4.10, absolute point size) is deliberately NOT modelled
-/// here: the resolved [`Bullet`] contract carries only a percentage (`sizePct`),
-/// and an absolute point size cannot be expressed as a percentage without the run
-/// size (which the parser does not know). Rather than record `buSzPts` as an
-/// override that BLOCKS an inherited lower-tier `buSzPct` but then renders at the
-/// default 100% — a behaviour change from before this cascade existed — we leave
-/// `buSzPts` unparsed (identical to prior behaviour) so a lower-tier `buSzPct`
-/// still inherits. Honouring absolute-point bullet sizes needs a renderer +
-/// contract extension and is tracked as follow-up work.
+/// `Pct` and `Pts` are separate variants (never both) because they collapse to
+/// distinct resolved fields — `sizePct` (percent of the run size, resolved at
+/// draw time) and `sizePts` (absolute points, run-independent) — on the [`Bullet`]
+/// contract. Keeping them apart lets the renderer honour absolute-point bullets
+/// (§21.1.2.4.10) while the cascade still treats the whole size group uniformly.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum BuSize {
     /// `<a:buSzTx>` (§21.1.2.4.11) — follow the text run's size.
     FollowText,
     /// `<a:buSzPct val>` (§21.1.2.4.9) — percentage of text size (100.0 = 100%).
     Pct(f64),
+    /// `<a:buSzPts val>` (§21.1.2.4.10) — absolute size in points (18.0 = 18pt).
+    Pts(f64),
 }
 
 /// A paragraph's bullet as FOUR independent choice groups (ECMA-376 §21.1.2.4:
@@ -234,7 +234,9 @@ impl BulletProps {
     /// follow-text-vs-inherit distinction is preserved while merging:
     /// - colour: `Color(c)` → `Some(c)`; `FollowText`/inherit → `None` (the
     ///   renderer already treats `None` as "follow the run's colour");
-    /// - size: `Pct(p)` → `Some(p)`; `FollowText`/inherit → `None`;
+    /// - size: `Pct(p)` → `size_pct = Some(p)`; `Pts(p)` → `size_pts = Some(p)`
+    ///   (§21.1.2.4.10, absolute points); `FollowText`/inherit → both `None`. The
+    ///   two size fields are mutually exclusive (one `xsd:choice`);
     /// - font: `Font(f)` → `Some(f)`; `FollowText`/inherit → `None`.
     ///   Auto-number and picture markers carry no font/size in the `Bullet`
     ///   contract (the renderer draws numbers in the run font and pictures as a
@@ -248,6 +250,12 @@ impl BulletProps {
             Some(BuSize::Pct(v)) => Some(*v),
             _ => None,
         };
+        // Absolute-point size (§21.1.2.4.10). Exclusive with `size_pct` above (one
+        // `xsd:choice`), so at most one of the two is `Some` on a resolved bullet.
+        let size_pts = match &self.size {
+            Some(BuSize::Pts(v)) => Some(*v),
+            _ => None,
+        };
         let font_family = match &self.font {
             Some(BuFont::Font(f)) => Some(f.clone()),
             _ => None,
@@ -259,6 +267,7 @@ impl BulletProps {
                 ch: ch.clone(),
                 color,
                 size_pct,
+                size_pts,
                 font_family,
             },
             Some(BuMarker::AutoNum { num_type, start_at }) => Bullet::AutoNum {
@@ -273,6 +282,7 @@ impl BulletProps {
                 image_path: image_path.clone(),
                 mime_type: mime_type.clone(),
                 size_pct,
+                size_pts,
             },
         }
     }
@@ -1072,12 +1082,20 @@ pub(crate) fn parse_bu_sz_pct(val: &str) -> Option<f64> {
     }
 }
 
+/// Parse a `<a:buSzPts val>` value into an absolute size in points. ECMA-376's
+/// attribute type is `ST_TextFontSize` (§21.1.2.4.10 CT_TextBulletSizePoint):
+/// an integer in hundredths of a point (`"1800"` = 18pt), exactly like the run
+/// `<a:rPr sz>` the parser already divides by 100 elsewhere.
+pub(crate) fn parse_bu_sz_pts(val: &str) -> Option<f64> {
+    val.trim().parse::<f64>().ok().map(|n| n / 100.0)
+}
+
 /// Parse a paragraph's four bullet choice groups (ECMA-376 §21.1.2.4) from a
 /// `<a:pPr>` / `<a:lvlNpPr>` node into a [`BulletProps`]. Each group is read
 /// independently so the cascade can merge them per-property:
 /// - colour (EG_TextBulletColor): `<a:buClrTx>` (follow text) or `<a:buClr>`;
-/// - size (EG_TextBulletSize): `<a:buSzTx>` (follow text) or `<a:buSzPct>`
-///   (percent of text). `<a:buSzPts>` is intentionally not read — see [`BuSize`];
+/// - size (EG_TextBulletSize): `<a:buSzTx>` (follow text), `<a:buSzPct>` (percent
+///   of text) or `<a:buSzPts>` (absolute points, §21.1.2.4.10) — see [`BuSize`];
 /// - typeface (EG_TextBulletTypeface): `<a:buFontTx>` (follow text) or `<a:buFont>`;
 /// - marker (EG_TextBullet): see [`parse_bullet_marker`].
 ///
@@ -1103,16 +1121,22 @@ pub(crate) fn parse_bullet_props<F: FnMut(&str) -> Option<String>>(
             .map(BuColor::Color)
     };
 
-    // Size group (EG_TextBulletSize): buSzTx (§21.1.2.4.11) follow-text; buSzPct
-    // (§21.1.2.4.9) percent-of-text. buSzPts (§21.1.2.4.10) is intentionally
-    // ignored — see [`BuSize`].
+    // Size group (EG_TextBulletSize xsd:choice): buSzTx (§21.1.2.4.11) follow-text;
+    // buSzPct (§21.1.2.4.9) percent-of-text; buSzPts (§21.1.2.4.10) absolute points.
+    // At most one is present; check them in schema order so a well-formed level
+    // reads deterministically (a stray second element is ignored).
     let size = if child(p_pr, "buSzTx").is_some() {
         Some(BuSize::FollowText)
+    } else if let Some(pct) = child(p_pr, "buSzPct")
+        .and_then(|n| attr(&n, "val"))
+        .and_then(|v| parse_bu_sz_pct(&v))
+    {
+        Some(BuSize::Pct(pct))
     } else {
-        child(p_pr, "buSzPct")
+        child(p_pr, "buSzPts")
             .and_then(|n| attr(&n, "val"))
-            .and_then(|v| parse_bu_sz_pct(&v))
-            .map(BuSize::Pct)
+            .and_then(|v| parse_bu_sz_pts(&v))
+            .map(BuSize::Pts)
     };
 
     // Typeface group (EG_TextBulletTypeface): buFontTx (§21.1.2.4.7) follow-text;

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -896,6 +896,14 @@ pub(crate) enum Bullet {
         color: Option<String>,
         /// Size as % of text size (100.0 = same size)
         size_pct: Option<f64>,
+        /// `<a:buSzPts>` (ECMA-376 §21.1.2.4.10) — an ABSOLUTE marker size in
+        /// points (18.0 = 18pt), independent of the run size. Mutually exclusive
+        /// with `size_pct` (both are the one `EG_TextBulletSize` choice). Omitted
+        /// from the JSON when absent (serde skip), so existing bullets that carry
+        /// no `buSzPts` serialize byte-identically.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default)]
+        size_pts: Option<f64>,
         font_family: Option<String>,
     },
     /// Auto-numbered bullet (buAutoNum)
@@ -913,7 +921,7 @@ pub(crate) enum Bullet {
     /// r:embed="rIdN"/></a:buBlip>`. The `r:embed` is resolved to the blip's
     /// embedded **zip path** (e.g. "ppt/media/image1.png") + mime at parse time,
     /// exactly like `Fill::Image`; the renderer fetches the bytes lazily by path.
-    /// `size_pct` carries `<a:buSzPct>` (§21.1.2.4.3) as a fraction of 100 (e.g.
+    /// `size_pct` carries `<a:buSzPct>` (§21.1.2.4.9) as a fraction of 100 (e.g.
     /// 80.0 = 80% of the text size); None means the spec default of 100%.
     #[serde(rename_all = "camelCase")]
     Blip {
@@ -924,6 +932,12 @@ pub(crate) enum Bullet {
         /// `<a:buSzPct val>` as a percentage (100.0 = same size as text). None
         /// when no explicit `<a:buSzPct>` is present (renderer uses 100%).
         size_pct: Option<f64>,
+        /// `<a:buSzPts val>` (ECMA-376 §21.1.2.4.10) — an ABSOLUTE marker size in
+        /// points, independent of the text size. Mutually exclusive with
+        /// `size_pct`. Omitted from the JSON when absent (serde skip).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default)]
+        size_pts: Option<f64>,
     },
 }
 

--- a/packages/pptx/src/bullet-image.test.ts
+++ b/packages/pptx/src/bullet-image.test.ts
@@ -191,7 +191,7 @@ describe('renderTextBody — picture bullet (buBlip) draws the bitmap', () => {
     expect(d.w).toBeCloseTo(d.h * SENTINEL_RATIO, 6);
   });
 
-  it('scales the bullet by buSzPct (§21.1.2.4.3)', async () => {
+  it('scales the bullet by buSzPct (§21.1.2.4.9)', async () => {
     const path = 'ppt/media/bullet-sized.png';
     await getCachedBitmap(path, 'image/png', fetchImage);
 
@@ -212,6 +212,54 @@ describe('renderTextBody — picture bullet (buBlip) draws the bitmap', () => {
     // Height = 20px text × 50% = 10px; width preserves the 2:1 aspect ratio.
     expect(draws[0].h).toBeCloseTo(10, 6);
     expect(draws[0].w).toBeCloseTo(10 * SENTINEL_RATIO, 6);
+  });
+
+  it('sizes the bullet by buSzPts absolutely (§21.1.2.4.10), independent of the run', async () => {
+    const path = 'ppt/media/bullet-pts.png';
+    await getCachedBitmap(path, 'image/png', fetchImage);
+
+    const { ctx, draws } = mockCtx();
+    renderTextBody(
+      ctx,
+      // Run is 20pt; buSzPts = 40pt → the bullet box is 40px (40pt at this
+      // scale), NOT the 20px run height — the size is absolute, not relative.
+      bodyWithBullet(blipBullet({ imagePath: path, sizePts: 40 })),
+      0, 0, 4000, 2000,
+      SCALE,
+      null, 0, false, false, '#000000', 1,
+      { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+      undefined,
+      false,
+      fetchImage,
+    );
+
+    expect(draws).toHaveLength(1);
+    expect(draws[0].h).toBeCloseTo(40, 6);
+    expect(draws[0].w).toBeCloseTo(40 * SENTINEL_RATIO, 6);
+  });
+
+  it('prefers buSzPts over a co-present buSzPct on a picture bullet', async () => {
+    const path = 'ppt/media/bullet-pts-over-pct.png';
+    await getCachedBitmap(path, 'image/png', fetchImage);
+
+    const { ctx, draws } = mockCtx();
+    renderTextBody(
+      ctx,
+      // Absolute 30pt → 30px wins over 200% × 20pt run (= 40px): the two are the
+      // one EG_TextBulletSize choice, and the absolute size takes precedence.
+      bodyWithBullet(blipBullet({ imagePath: path, sizePts: 30, sizePct: 200 })),
+      0, 0, 4000, 2000,
+      SCALE,
+      null, 0, false, false, '#000000', 1,
+      { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+      undefined,
+      false,
+      fetchImage,
+    );
+
+    expect(draws).toHaveLength(1);
+    expect(draws[0].h).toBeCloseTo(30, 6);
+    expect(draws[0].w).toBeCloseTo(30 * SENTINEL_RATIO, 6);
   });
 
   it('draws nothing (no throw) when the bullet image is not yet decoded', () => {

--- a/packages/pptx/src/buszpts-bullet-size.test.ts
+++ b/packages/pptx/src/buszpts-bullet-size.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody } from './renderer.js';
+import type { TextBody, Paragraph, Bullet } from './types';
+import type { TextRunData } from '@silurus/ooxml-core';
+
+// ECMA-376 §21.1.2.4.10 (buSzPts) — an ABSOLUTE point size for the bullet
+// marker. Unlike `buSzPct` (§21.1.2.4.9, a percentage of the run size), a
+// `buSzPts` marker is sized in points independent of the run, so the marker
+// font must be `sizePts` pt (× scale) rather than `sizePct` × the run size.
+//
+// The mock ctx records the `font` string active at each fillText so the marker
+// glyph's pixel size is recoverable independently of the run font.
+
+const FONT_PX = 20;
+// emuToPx(emu) = emu·SCALE; PT_TO_EMU = 12700, so with SCALE = 1/12700 a point
+// value maps 1:1 to px (20pt run → 20px, 40pt marker → 40px).
+const SCALE = 1 / 12700;
+
+interface Fill { text: string; fontPx: number }
+
+function mockCtx(): { ctx: CanvasRenderingContext2D; fills: Fill[] } {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  let fillStyle = '';
+  let direction: CanvasDirection = 'ltr';
+  const px = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const fills: Fill[] = [];
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
+    get direction() { return direction; }, set direction(v: CanvasDirection) { direction = v; },
+    get letterSpacing() { return letterSpacing; }, set letterSpacing(v: string) { letterSpacing = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    fillText: (t: string) => fills.push({ text: t, fontPx: px() }),
+    strokeText: () => {}, fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
+    translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
+    moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
+    setLineDash: () => {}, closePath: () => {}, arc: () => {},
+    strokeStyle: '#000', lineWidth: 1, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fills };
+}
+
+function run(text: string): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: FONT_PX, color: '000000', fontFamily: 'Serif',
+  } as TextRunData;
+}
+
+// marL / indent = a hanging gutter so the marker draws in its gutter.
+const MARK_EMU = 342900; // 27 px at this SCALE
+
+// A plain Unicode bullet glyph (U+25C6 ◆) with no symbol font, so
+// symbolFontToUnicode passes it through unchanged and the marker fill's text
+// equals the char.
+const BULLET_CHAR = '◆';
+
+function charBullet(opts: { sizePct?: number | null; sizePts?: number }): Bullet {
+  return {
+    type: 'char', char: BULLET_CHAR, color: null,
+    sizePct: opts.sizePct ?? null, sizePts: opts.sizePts,
+    fontFamily: null,
+  } as unknown as Bullet;
+}
+
+function body(bullet: Bullet): TextBody {
+  const para: Paragraph = {
+    alignment: 'l',
+    marL: MARK_EMU, marR: 0, indent: -MARK_EMU,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet, defFontSize: null, defColor: null, defBold: null, defItalic: null,
+    defFontFamily: null, tabStops: [], rtl: false, runs: [run('item')],
+  } as unknown as Paragraph;
+  return {
+    verticalAnchor: 't', paragraphs: [para], defaultFontSize: FONT_PX,
+    defaultBold: null, defaultItalic: null,
+    lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'square', vert: 'horz', autoFit: 'none',
+  } as unknown as TextBody;
+}
+
+const BOX_W = 600;
+
+function render(b: TextBody): Fill[] {
+  const { ctx, fills } = mockCtx();
+  renderTextBody(
+    ctx, b, 0, 0, BOX_W, 400, SCALE,
+    null, 0, false, false, '#000000', undefined,
+    { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+    () => {},
+  );
+  return fills;
+}
+
+// The marker fill is the one whose text is the bullet glyph.
+function markerPx(fills: Fill[]): number | undefined {
+  return fills.find((f) => f.text === BULLET_CHAR)?.fontPx;
+}
+
+describe('§21.1.2.4.10 buSzPts sizes the bullet marker in absolute points', () => {
+  it('uses the absolute point size (× scale), NOT the run size', () => {
+    // buSzPts = 40pt; run = 20pt. The marker must be 40px (40pt at this scale),
+    // independent of the run — not the 20px run baseline.
+    const px = markerPx(render(body(charBullet({ sizePts: 40 }))));
+    expect(px, 'char marker drawn').toBeDefined();
+    expect(px).toBeCloseTo(40, 5);
+  });
+
+  it('buSzPts wins over a co-present buSzPct', () => {
+    // Absolute size (30pt → 30px) takes precedence over the percentage path
+    // (200% × 20pt run = 40px), so the marker is 30px, not 40px.
+    const px = markerPx(render(body(charBullet({ sizePts: 30, sizePct: 200 }))));
+    expect(px).toBeCloseTo(30, 5);
+  });
+
+  it('falls back to buSzPct × run size when no buSzPts is present', () => {
+    // Control: 200% of the 20pt run = 40px, via the existing percentage path.
+    const px = markerPx(render(body(charBullet({ sizePct: 200 }))));
+    expect(px).toBeCloseTo(40, 5);
+  });
+
+  it('falls back to the run size when neither buSzPts nor buSzPct is present', () => {
+    // Control: the marker inherits the 20pt first-run size (§21.1.2.4.13).
+    const px = markerPx(render(body(charBullet({}))));
+    expect(px).toBeCloseTo(20, 5);
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -3004,9 +3004,15 @@ export function renderTextBody(
     const bullet = asBullet(para.bullet);
     if (bullet.type === 'char') {
       const b = bullet;
-      const bSizePx = b.sizePct != null
-        ? bulletBaseSizePx * (b.sizePct / 100)
-        : bulletBaseSizePx;
+      // ECMA-376 §21.1.2.4.10 (buSzPts): an ABSOLUTE point size sizes the marker
+      // independent of the run — convert pt → px like any run size
+      // (PT_TO_EMU·scale·fontScale). It wins over §21.1.2.4.9 (buSzPct, percent of
+      // the run size); with neither, the marker takes the run size (§21.1.2.4.13).
+      const bSizePx = b.sizePts != null
+        ? b.sizePts * PT_TO_EMU * scale * fontScale
+        : b.sizePct != null
+          ? bulletBaseSizePx * (b.sizePct / 100)
+          : bulletBaseSizePx;
       // If the char was mapped to a Unicode symbol, use sans-serif for reliable rendering.
       // Otherwise use the specified font (e.g. Wingdings on systems that have it).
       const convertedFamily = bulletLabel !== b.char ? 'sans-serif' : normalizeFontFamily(b.fontFamily ?? null, rc);
@@ -3022,13 +3028,17 @@ export function renderTextBody(
     } else if (bullet.type === 'blip') {
       // ECMA-376 §21.1.2.4.2 picture bullet. The bitmap is drawn as a square
       // sized to the text (the bullet's em box), scaled by `<a:buSzPct>`
-      // (§21.1.2.4.3; default 100%). It's not a glyph, so there is no label —
+      // (§21.1.2.4.9; default 100%). It's not a glyph, so there is no label —
       // an empty paragraph still draws no marker (bulletLabel stays '' and the
       // draw site gates the image on the first line having content).
+      // §21.1.2.4.10 (buSzPts): an absolute point size overrides the §21.1.2.4.9
+      // percentage, matching the char-bullet branch above.
       const b = bullet;
-      const sizePx = b.sizePct != null
-        ? bulletBaseSizePx * (b.sizePct / 100)
-        : bulletBaseSizePx;
+      const sizePx = b.sizePts != null
+        ? b.sizePts * PT_TO_EMU * scale * fontScale
+        : b.sizePct != null
+          ? bulletBaseSizePx * (b.sizePct / 100)
+          : bulletBaseSizePx;
       bulletImage = { imagePath: b.imagePath, mimeType: b.mimeType, sizePx };
     }
 

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -36,11 +36,18 @@ export interface BlipBullet {
   /** MIME type of the blip at {@link BlipBullet.imagePath} (e.g. `image/png`). */
   mimeType: string;
   /**
-   * `<a:buSzPct val>` (ECMA-376 §21.1.2.4.3) as a percentage of the text size
+   * `<a:buSzPct val>` (ECMA-376 §21.1.2.4.9) as a percentage of the text size
    * (100 = same size). `null` when no explicit `<a:buSzPct>` is present, in
    * which case the renderer uses the spec default of 100%.
    */
   sizePct: number | null;
+  /**
+   * `<a:buSzPts val>` (ECMA-376 §21.1.2.4.10) — an ABSOLUTE marker size in
+   * points, independent of the text size. Mutually exclusive with {@link
+   * BlipBullet.sizePct} (both are the one `EG_TextBulletSize` choice). Omitted
+   * when no explicit `<a:buSzPts>` is present; when present it takes precedence.
+   */
+  sizePts?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds support for `<a:buSzPts>` (ECMA-376 §21.1.2.4.10) — an **absolute point size** for a PowerPoint bullet marker — to the pptx bullet contract and renderer.

Previously `buSzPts` was deliberately left unparsed: the resolved `Bullet` contract carried only `sizePct` (percent of the run size), and a point size cannot be expressed as a percentage without knowing the run size at parse time. As a result a `buSzPts` level silently inherited a lower-tier `buSzPct` instead of overriding it. This change makes `buSzPts` a first-class member of the `EG_TextBulletSize` `xsd:choice` so it takes part in the property-wise bullet cascade (#972) like `buSzPct` / `buSzTx`.

## Changes

- **parser** (`packages/pptx/parser/src/text.rs`): add `BuSize::Pts` and `parse_bu_sz_pts`. `val` is `ST_TextFontSize` (hundredths of a point → `/100`). A higher-tier `buSzPts` now **blocks** a lower-tier `buSzPct`; a lower-tier `buSzPts` inherits onto a higher-tier marker. `sizePct` and `sizePts` are mutually exclusive at the leaf.
- **contract** (`packages/pptx/parser/src/types.rs`, `packages/core/src/types/common.ts`, `packages/pptx/src/types.ts`): add `sizePts` to the resolved `Char` / `Blip` bullet variants (`Option<f64>` with serde `skip_serializing_if`, so bullets without `buSzPts` serialize **byte-identically**) and to the core / pptx TS bullet types (`sizePts?: number`).
- **renderer** (`packages/pptx/src/renderer.ts`): size the char and picture markers by the absolute point size (`pt × PT_TO_EMU × scale × fontScale`) when `sizePts` is present, else fall back to the existing `sizePct` × run-size path. `sizePts` takes precedence.
- Corrects the `buSzPct` spec citation (§21.1.2.4.9, not §21.1.2.4.3) in the surrounding picture-bullet docs/tests.

## Tests

TDD (Red → Green). New coverage:
- **parser** (`lib.rs`): `buSzPts` parse (val 1800 → 18pt), cross-tier cascade inheritance, `buSzPts` blocking a lower-tier `buSzPct`, `parse_bu_sz_pts` units, and `BuSize::Pts` resolution.
- **renderer** (`buszpts-bullet-size.test.ts`, `bullet-image.test.ts`): absolute char- and picture-marker sizing, `sizePts` precedence over `sizePct`, and the existing percentage / run-size fallbacks.

## Verification

- `cargo fmt --all --check`, `cargo clippy -D warnings`, `cargo test` (179 passed)
- WASM rebuilt via the package script
- pptx `vitest` (446 passed), root `pnpm typecheck` clean
- pptx demo VRT non-regressive (14 passed; bullets without `buSzPts` render byte-identically)
- Independent read-only review by Codex (gpt-5.6-sol): approved, no correctness defects; both findings (blip renderer coverage, spec-citation nit) addressed.

Closes #973