### PR TITLE
docs(xlsx): record the #877 won't-fix verdict at the equation draw site

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -4147,13 +4147,17 @@ export function drawShapeText(
       // For a lone display equation in a top-anchored box (anchor="t", tIns=0),
       // line.ascent === seg.ascent, so `baseline - seg.ascent === lineTop` and
       // the raster is drawn TOP-FLUSH to the box — matching how Excel autofits
-      // the box to the equation and top-anchors it (issue #877). Any residual is
-      // NOT a downward shift: our STIX Two Math typeset is ~17% SHORTER than the
-      // Cambria Math box the file was authored against (measured on sample-28:
-      // MathJax 39.6 px vs the autofit ext cy 48.0 px for the same Fourier
-      // series), so the gap surfaces as unused space at the box BOTTOM while the
-      // top and every baseline sit at or above Excel's. Closing that gap is a
-      // metric-compatible-fallback question (#794), not a positioning fix.
+      // the box to the equation and top-anchors it (issue #877). Any size
+      // residual against the authored spAutoFit box is NOT a downward shift and
+      // is NOT fixable here: it is a construct-specific difference between the
+      // two math typesetting systems (MathJax + STIX Two Math vs Office +
+      // Cambria Math MATH-table constants — display-operator variant ladders,
+      // limit/fraction shift minima). Measured Office/ours ink-height ratios
+      // even flip sign per construct (~1.17x for a display sum with limits,
+      // ~0.89x for display fractions + radicals, ~1.0x for plain scripts), so
+      // no font-metrics-derived scale factor exists and emulating Cambria
+      // Math's constants is out of policy. Adjudicated won't-fix in #877 — see
+      // the measurement comment there before re-litigating.
       ctx.textBaseline = 'alphabetic';
       const baseline = lineTop + line.ascent;
       for (const seg of line.segs) {


### PR DESCRIPTION
## Summary

Comment-only follow-up to the #877 adjudication (won't-fix). The equation
draw-site comment in `packages/xlsx/src/renderer.ts` attributed the
equation-box size residual to the metric-compatible font fallback program
(#794) as a closable gap. The measurements recorded in
[#877's attribution comment](https://github.com/yukiyokotani/office-open-xml-viewer/issues/877#issuecomment-4947101281)
disproved that framing:

- The residual is a construct-specific difference between the two math
  typesetting systems (MathJax + STIX Two Math vs Office + Cambria Math
  MATH-table constants — display-operator variant ladders, limit/fraction
  shift minima).
- Measured Office/ours ink-height ratios flip sign per construct
  (~1.17x display sum with limits, ~0.89x display fractions + radicals,
  ~1.0x plain scripts), so no font-metrics-derived scale factor exists.
- Emulating Cambria Math's constants is out of policy, hence won't-fix.

The comment now records that verdict so the residual is not re-litigated
as a positioning or fallback-metrics fix. No behavior change.

## Gates

- `npx vitest run packages/xlsx`: 59 files / 550 tests passed
- root `pnpm typecheck`: passed

Refs #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)