### PR TITLE
feat(docx): vertical text boxes — <wps:bodyPr vert> vert/vert270/eaVert (§20.1.10.83)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -5316,6 +5316,7 @@ fn parse_wsp_shape(
         text_blocks,
         text_anchor,
         text_autofit,
+        text_vert,
         text_inset_l,
         text_inset_t,
         text_inset_r,
@@ -5348,6 +5349,7 @@ fn parse_wsp_shape(
         default_text_color,
         text_anchor,
         text_autofit,
+        text_vert,
         text_inset_l,
         text_inset_t,
         text_inset_r,
@@ -5411,8 +5413,23 @@ fn parse_preset_adj(prst_geom: roxmltree::Node) -> Vec<Option<f64>> {
     out
 }
 
+/// The `<wps:txbx>`/`<wps:bodyPr>` body parsed off a shape:
+/// `(blocks, anchor, autofit, vert, inset_l, inset_t, inset_r, inset_b)`.
+/// `vert` is the ECMA-376 §20.1.10.83 text-flow direction; the four insets are pt.
+type ShapeTextBody = (
+    Vec<ShapeText>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    f64,
+    f64,
+    f64,
+    f64,
+);
+
 /// Extract text blocks and bodyPr from a wsp shape.
-/// Returns (blocks, anchor, inset_l, inset_t, inset_r, inset_b).
+/// Returns a `ShapeTextBody` =
+/// `(blocks, anchor, autofit, vert, inset_l, inset_t, inset_r, inset_b)`.
 ///
 /// Per ECMA-376 §21.1.2.1.1, lIns/tIns/rIns/bIns are the distance from
 /// the rendered (page-space) bounding-box edge to the text, measured in
@@ -5427,15 +5444,7 @@ fn parse_shape_text_body(
     wsp: roxmltree::Node,
     theme: &ThemeColors,
     media_map: &HashMap<String, String>,
-) -> (
-    Vec<ShapeText>,
-    Option<String>,
-    Option<String>,
-    f64,
-    f64,
-    f64,
-    f64,
-) {
+) -> ShapeTextBody {
     let txbx = wsp
         .children()
         .find(|n| n.is_element() && n.tag_name().name() == "txbx");
@@ -5445,6 +5454,12 @@ fn parse_shape_text_body(
 
     let anchor = body_pr
         .and_then(|b| b.attribute("anchor"))
+        .map(|s| s.to_string());
+    // ECMA-376 §20.1.10.83 `<wps:bodyPr vert>` (ST_TextVerticalType) — the text
+    // body's flow direction. Carried verbatim; the renderer maps the recognised
+    // values (vert / vert270 / eaVert) and falls unknown ones back to horizontal.
+    let vert = body_pr
+        .and_then(|b| b.attribute("vert"))
         .map(|s| s.to_string());
     // ECMA-376 §21.1.2.1.1 auto-fit: the bodyPr's autofit is a CHILD element,
     // one of <a:noAutofit/> / <a:spAutoFit/> / <a:normAutofit/>. Normalize it to
@@ -5495,7 +5510,7 @@ fn parse_shape_text_body(
         })
         .unwrap_or_default();
 
-    (blocks, anchor, autofit, l, t, r, b)
+    (blocks, anchor, autofit, vert, l, t, r, b)
 }
 
 /// Reduce a <w:p> inside <w:txbxContent> to a single ShapeText. Pulls
@@ -14040,15 +14055,7 @@ mod txbx_inline_image_tests {
         wsp: roxmltree::Node,
         theme: &ThemeColors,
         media_map: &HashMap<String, String>,
-    ) -> (
-        Vec<ShapeText>,
-        Option<String>,
-        Option<String>,
-        f64,
-        f64,
-        f64,
-        f64,
-    ) {
+    ) -> super::ShapeTextBody {
         let mut num_map = NumberingMap::default();
         super::parse_shape_text_body(style_map, &mut num_map, wsp, theme, media_map)
     }
@@ -14099,7 +14106,7 @@ mod txbx_inline_image_tests {
         let mut media = HashMap::new();
         media.insert("rIdImg".to_string(), "word/media/image1.emf".to_string());
 
-        let (blocks, _anchor, _autofit, _l, _t, _r, _b) = parse_shape_text_body(
+        let (blocks, _anchor, _autofit, _vert, _l, _t, _r, _b) = parse_shape_text_body(
             &StyleMap::default(),
             doc.root_element(),
             &ThemeColors::default(),
@@ -14175,6 +14182,49 @@ mod txbx_inline_image_tests {
             Some("sp")
         );
         assert_eq!(autofit_of(wsp(r#"<wps:bodyPr/>"#)), None);
+    }
+
+    /// `parse_shape_text_body` carries the `<wps:bodyPr vert>` attribute
+    /// (ECMA-376 §20.1.10.83 ST_TextVerticalType) verbatim; an absent `vert`
+    /// (or an absent bodyPr) ⇒ None (horizontal). The renderer maps the value.
+    #[test]
+    fn parse_shape_text_body_records_vert_direction() {
+        let wsp = |body_pr: &str| {
+            format!(
+                r#"<wps:wsp
+                     xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+                     xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                     xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                     <wps:txbx><w:txbxContent><w:p><w:r><w:t>x</w:t></w:r></w:p></w:txbxContent></wps:txbx>
+                     {body_pr}
+                   </wps:wsp>"#
+            )
+        };
+        let vert_of = |xml: String| {
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            parse_shape_text_body(
+                &StyleMap::default(),
+                doc.root_element(),
+                &ThemeColors::default(),
+                &HashMap::new(),
+            )
+            .3
+        };
+        assert_eq!(
+            vert_of(wsp(r#"<wps:bodyPr vert="eaVert"/>"#)).as_deref(),
+            Some("eaVert")
+        );
+        assert_eq!(
+            vert_of(wsp(r#"<wps:bodyPr vert="vert270"/>"#)).as_deref(),
+            Some("vert270")
+        );
+        assert_eq!(
+            vert_of(wsp(r#"<wps:bodyPr vert="vert"/>"#)).as_deref(),
+            Some("vert")
+        );
+        // Absent vert ⇒ None (horizontal); absent bodyPr ⇒ None.
+        assert_eq!(vert_of(wsp(r#"<wps:bodyPr/>"#)), None);
+        assert_eq!(vert_of(wsp("")), None);
     }
 
     /// An image-only paragraph (empty text) must NOT be dropped — the prior

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1082,6 +1082,14 @@ pub struct ShapeRun {
     /// treats as the spec default: overflow visible / no clip).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_autofit: Option<String>,
+    /// Text-body flow direction from `<wps:bodyPr vert>` (ECMA-376 §20.1.10.83
+    /// ST_TextVerticalType): "vert" (all glyphs 90° CW, chars T→B, lines R→L),
+    /// "vert270" (all glyphs 270° CW = 90° CCW, chars B→T, lines L→R), "eaVert"
+    /// (East-Asian upright: CJK stands upright, non-EA rotated 90°). "horz"/absent
+    /// ⇒ None (horizontal). Other values ("mongolianVert", "wordArtVert", …) are
+    /// carried verbatim; the renderer falls them back to horizontal until handled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_vert: Option<String>,
     /// Body-pr text insets in pt (left/top/right/bottom). Default 0 each.
     #[serde(skip_serializing_if = "is_zero_f64")]
     pub text_inset_l: f64,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -9385,7 +9385,19 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
   if (w < 0 || h < 0) return;
   if (isLineGeom ? w === 0 && h === 0 : w === 0 || h === 0) return;
 
-  if (!isLineGeom && shape.textAutofit === 'sp' && shape.textBlocks && shape.textBlocks.length > 0) {
+  if (
+    !isLineGeom &&
+    shape.textAutofit === 'sp' &&
+    shape.textBlocks &&
+    shape.textBlocks.length > 0 &&
+    // §20.1.10.83 vertical text box: `measureShapeTextAutoFitHeight` grows the
+    // PHYSICAL HEIGHT to fit the horizontal line stack, but a vertical box grows
+    // its PHYSICAL WIDTH (the line-stacking axis is the cross axis after the ±90°
+    // rotation). Re-measuring here would grow the wrong axis, so vertical boxes
+    // keep their declared `<wp:extent>` (correct for the common explicit-extent
+    // case; cross-axis auto-grow is a follow-up — see `verticalTextboxMode`).
+    verticalTextboxMode(shape.textVert) === null
+  ) {
     const fitH = measureShapeTextAutoFitHeight(
       shape,
       w,
@@ -9584,6 +9596,17 @@ function shapeTextHorizontalInsetsPx(shape: ShapeRun, scale: number): { lIns: nu
   };
 }
 
+/** ECMA-376 §20.1.10.83 ST_TextVerticalType — the IMPLEMENTED vertical text-box
+ *  directions (`<wps:bodyPr vert>`), or `null` for horizontal / not-yet-handled
+ *  values. `eaVert` keeps East-Asian glyphs upright (per-glyph UAX#50); `vert`
+ *  and `vert270` rotate EVERY glyph (their spec meaning), so the whole-box ±90°
+ *  rotation already produces them with no per-glyph work. `mongolianVert`
+ *  (top→bottom but lines L→R — not a pure rotation of the R→L frame) and the
+ *  WordArt stacked variants are deferred and treated as horizontal. */
+function verticalTextboxMode(vert: string | null | undefined): 'vert' | 'vert270' | 'eaVert' | null {
+  return vert === 'vert' || vert === 'vert270' || vert === 'eaVert' ? vert : null;
+}
+
 /** Measure a shape text body's fitted height for `<a:spAutoFit/>`.
  *  Returns px, including bodyPr top/bottom insets and paragraph spacing. */
 export function measureShapeTextAutoFitHeight(
@@ -9746,6 +9769,48 @@ export function renderShapeText(
   // runs never produce — so the minimal state is exact for text-box content).
   state?: RenderState,
 ): void {
+  // ECMA-376 §20.1.10.83 `<wps:bodyPr vert>` — a VERTICAL text box. Lay the body
+  // out with the SAME horizontal engine (buildSegments + layoutLines, so
+  // kinsoku/bidi/justify/tabs are reused), rotated ±90° about the box centre with
+  // width/height swapped — the section-level tbRl "rotate-layout" approach,
+  // mirroring pptx `renderTextBody`. `vert`/`vert270` rotate EVERY glyph (their
+  // spec meaning), so a plain draw in the rotated frame already IS that rotation;
+  // `eaVert` additionally counter-rotates East-Asian glyphs per code point so CJK
+  // stands upright (the `eaVertUpright` flag routes text runs through
+  // {@link drawVerticalRun} below). The shape PANEL (fill/stroke) is drawn by the
+  // caller BEFORE this call and stays unrotated; only the body text rotates. The
+  // horizontal path is byte-identical when `vmode === null`.
+  //
+  // The §21.1.2.1.1 bodyPr insets (lIns/tIns/rIns/bIns) travel UNCHANGED into the
+  // rotated frame — lIns bounds the flow-left of the (rotated) text body, not the
+  // physical page left — matching the Word/PowerPoint-verified pptx `renderTextBody`
+  // (packages/pptx/src/renderer.ts, which re-enters the rotated layout with the
+  // body's insets unchanged). This is the DrawingML text-frame semantics: the
+  // insets belong to the text body's own rectangle, which rotates with `vert`.
+  //
+  // Deferred (fall back to the horizontal draw of the affected element): a
+  // shape's own `rotation` is not composed with the text-body rotation (already
+  // true before this change — the panel-rotation restore precedes this call), and
+  // an inline image inside a vertical text-box paragraph rotates with the frame
+  // rather than being uprighted like the section tbRl path — both are follow-ups.
+  const vmode = verticalTextboxMode(shape.textVert);
+  const eaVertUpright = vmode === 'eaVert';
+  if (vmode) {
+    const boxW = w;
+    const boxH = h;
+    ctx.save();
+    ctx.translate(x + boxW / 2, y + boxH / 2);
+    // +90° (vert/eaVert): chars advance T→B (local +x → device +y), lines stack
+    // R→L (local +y → device −x, first line at the right edge). −90° (vert270):
+    // chars B→T, lines L→R (first line at the left edge). The swapped LOGICAL box
+    // — width = physical height (the column length), height = physical width (the
+    // line-stacking extent) — is drawn centred on the pivot.
+    ctx.rotate((vmode === 'vert270' ? -1 : 1) * (Math.PI / 2));
+    x = -boxH / 2;
+    y = -boxW / 2;
+    w = boxH;
+    h = boxW;
+  }
   const effState: RenderState =
     state ?? shapeRenderState(ctx, scale, fontFamilyClasses, images);
   // Default glyph colour for a run/leader that carries no explicit colour.
@@ -10212,7 +10277,14 @@ export function renderShapeText(
           const markerW = ctx.measureText(markerText).width;
           const lvlJc = block.numbering.jc || 'left';
           const markerShift = lvlJc === 'right' ? -markerW : lvlJc === 'center' ? -markerW / 2 : 0;
-          ctx.fillText(markerText, innerX + ind.leftPx + ind.markerFirstPx + markerShift, baseline);
+          const markerX = innerX + ind.leftPx + ind.markerFirstPx + markerShift;
+          if (eaVertUpright) {
+            // §20.1.10.83 eaVert — the list marker stands upright too (mirrors the
+            // body vertical marker path), advancing down the column like its cell.
+            drawVerticalRun(ctx, markerText, markerX, baseline, block.fontSizePt * scale, 0);
+          } else {
+            ctx.fillText(markerText, markerX, baseline);
+          }
         }
 
         if (applyJustify) {
@@ -10294,6 +10366,33 @@ export function renderShapeText(
           // document/theme default (black). A color-less run in a fontRef text
           // box (sample-28's white cover banner) thus draws in the fontRef color.
           ctx.fillStyle = s.color ? `#${s.color}` : defaultColor;
+          if (eaVertUpright) {
+            // ECMA-376 §20.1.10.83 eaVert — East-Asian upright vertical text box.
+            // Draw the run's glyphs advancing DOWN the column (local +x) with CJK
+            // counter-rotated UPRIGHT and Latin/digits kept sideways, via the SAME
+            // per-glyph UAX#50 helper the section tbRl body path uses. §17.3.2.43
+            // `w:w` and §17.3.2.35 `w:spacing` pitch are threaded in exactly as the
+            // body does. §17.18.44 justify / kashida slicing (the branches below)
+            // is NOT applied inside an eaVert cell — vertical text boxes flow their
+            // columns start-aligned, the same stage limitation as the body tbRl
+            // path — so the segment advances by its NATURAL `measuredWidth` (the
+            // width drawVerticalRun paints), NOT the justify/kashida-expanded
+            // `internalStretch`, keeping paint==advance. A whole-line center/right
+            // `alignOffset` still applies via the starting `x`. Ruby and inline
+            // images inside an eaVert run are a follow-up (drawVerticalRun paints
+            // base glyphs only; vertical furigana placement is not yet ported).
+            drawVerticalRun(
+              ctx,
+              s.text,
+              x,
+              baseline + yOffset,
+              effSizePx,
+              segLetterSpacingPx(s, 0, scale),
+              s.charScale ?? 1,
+            );
+            x += s.measuredWidth;
+            continue;
+          }
           // Draw the glyphs (§17.18.44). Anchor each justified piece to the
           // WHOLE-string cumulative advance plus accumulated pitch, the SAME core
           // helper the body uses, so contextual CJK packing (約物半角) is honoured
@@ -10415,6 +10514,9 @@ export function renderShapeText(
   }
   if (clipToBox) ctx.restore();
   ctx.direction = 'ltr'; // reset for subsequent draws
+  // Undo the §20.1.10.83 vertical-text-box page rotation (paired with the save at
+  // the top). The `noAutofit` clip (`clipToBox`) restore above is nested inside.
+  if (vmode) ctx.restore();
 }
 
 /**

--- a/packages/docx/src/textbox-vertical-render.test.ts
+++ b/packages/docx/src/textbox-vertical-render.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { renderShapeText } from './renderer';
+import type { ShapeRun, ShapeText, ShapeTextRun } from './types';
+
+// ECMA-376 §20.1.10.83 ST_TextVerticalType — a DrawingML text-box body direction
+// (`<wps:bodyPr vert>`). Word writes it on a Word text box (`<wps:txbx>` shape):
+//   - `vert`    : ALL glyphs rotated 90° CW  (chars T→B, lines R→L).
+//   - `vert270` : ALL glyphs rotated 270° CW (= 90° CCW; chars B→T, lines L→R).
+//   - `eaVert`  : East-Asian upright vertical — CJK stands UPRIGHT, non-EA glyphs
+//                 rotated 90° (chars T→B, lines R→L). Mirrors the section-level
+//                 tbRl per-glyph path (UAX#50 vo) and pptx's verified eaVert.
+//   - `horz` / absent : horizontal (unchanged legacy path).
+//
+// The renderer laies the box out with the SAME horizontal engine, rotated ±90°
+// about the box centre with width/height swapped, so the layout/kinsoku/bidi are
+// reused. Because the text box does NOT emit `onTextRun`, we verify by recording
+// the Canvas transform at every glyph draw and asserting each glyph's NET
+// rotation (the angle its local +x axis makes in device space).
+
+interface GlyphCall {
+  text: string;
+  /** Net rotation of the drawn glyph in device space, degrees (atan2(b,a)). */
+  angleDeg: number;
+  /** Device-space position of the draw origin (local (x,y) mapped by the CTM). */
+  devX: number;
+  devY: number;
+}
+
+/** Recording 2D context that tracks the full affine CTM (a,b,c,d,e,f) across
+ *  save/restore/translate/rotate/scale, so a glyph's net orientation is
+ *  recoverable at fillText time. measureText gives every code point the current
+ *  font px as advance (1 em / CJK), with symmetric font/ink boxes. */
+function makeMatrixCtx(): { ctx: CanvasRenderingContext2D; glyphs: GlyphCall[] } {
+  let m = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
+  const stack: (typeof m)[] = [];
+  let font = '10px serif';
+  let textAlign = 'start';
+  let textBaseline = 'alphabetic';
+  let letterSpacing = '0px';
+  let fillStyle = '#000';
+  let direction = 'ltr';
+  let fontKerning = 'auto';
+  const glyphs: GlyphCall[] = [];
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get textAlign() { return textAlign; },
+    set textAlign(v: string) { textAlign = v; },
+    get textBaseline() { return textBaseline; },
+    set textBaseline(v: string) { textBaseline = v; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(v: string) { letterSpacing = v; },
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string) { fillStyle = v; },
+    get direction() { return direction; },
+    set direction(v: string) { direction = v; },
+    get fontKerning() { return fontKerning; },
+    set fontKerning(v: string) { fontKerning = v; },
+    strokeStyle: '#000',
+    lineWidth: 1,
+    globalAlpha: 1,
+    save() { stack.push({ ...m }); },
+    restore() { const s = stack.pop(); if (s) m = s; },
+    translate(tx: number, ty: number) {
+      m = { ...m, e: m.e + m.a * tx + m.c * ty, f: m.f + m.b * tx + m.d * ty };
+    },
+    rotate(t: number) {
+      const cos = Math.cos(t), sin = Math.sin(t);
+      m = {
+        a: m.a * cos + m.c * sin,
+        b: m.b * cos + m.d * sin,
+        c: -m.a * sin + m.c * cos,
+        d: -m.b * sin + m.d * cos,
+        e: m.e,
+        f: m.f,
+      };
+    },
+    scale(sx: number, sy: number) {
+      m = { ...m, a: m.a * sx, b: m.b * sx, c: m.c * sy, d: m.d * sy };
+    },
+    beginPath() {}, closePath() {}, moveTo() {}, lineTo() {}, rect() {},
+    fill() {}, stroke() {}, clip() {}, fillRect() {}, strokeRect() {}, clearRect() {},
+    setTransform() {}, resetTransform() {},
+    measureText(s: string) {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    fillText(text: string, x: number, y: number) {
+      const angleDeg = (Math.atan2(m.b, m.a) * 180) / Math.PI;
+      const devX = m.a * x + m.c * y + m.e;
+      const devY = m.b * x + m.d * y + m.f;
+      glyphs.push({ text, angleDeg, devX, devY });
+    },
+    strokeText() {},
+    drawImage() {},
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, glyphs };
+}
+
+function richTextbox(
+  runs: ShapeTextRun[],
+  textVert?: string | null,
+  alignment = 'left',
+): ShapeRun {
+  const block: ShapeText = {
+    text: runs.map((r) => r.text).join(''),
+    fontSizePt: runs[0]?.fontSizePt ?? 10,
+    alignment,
+    runs,
+  };
+  return {
+    type: 'shape', zOrder: 0, subpaths: [], presetGeometry: 'rect', fill: null, stroke: null,
+    textBlocks: [block], textAnchor: 't',
+    textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+    textVert: textVert ?? null,
+  } as unknown as ShapeRun;
+}
+
+const CJK = '経'; // UAX#50 vo=U (upright)
+const LAT = 'A'; // vo=R (sideways)
+const NEAR = (a: number, b: number, tol = 1e-6) => Math.abs(a - b) <= tol;
+// Normalise an angle to (-180, 180].
+const norm = (deg: number) => ((((deg + 180) % 360) + 360) % 360) - 180;
+
+describe('§20.1.10.83 textbox <wps:bodyPr vert> — vertical text-box rendering', () => {
+  const run = (text: string): ShapeTextRun => ({ text, fontSizePt: 10, fontFamily: 'NotInMetrics' });
+
+  it('horz (absent vert): no rotation — glyphs upright, CTM identity (legacy path)', () => {
+    const { ctx, glyphs } = makeMatrixCtx();
+    renderShapeText(richTextbox([run(CJK + LAT)]), 0, 0, 200, 100, ctx, 1, {});
+    const drawn = glyphs.filter((g) => g.text.includes(CJK) || g.text.includes(LAT) || /経|A/.test(g.text));
+    expect(drawn.length).toBeGreaterThan(0);
+    for (const g of drawn) expect(NEAR(norm(g.angleDeg), 0)).toBe(true);
+  });
+
+  it('vert: every glyph rotated +90° CW (all-rotate; CJK included)', () => {
+    const { ctx, glyphs } = makeMatrixCtx();
+    renderShapeText(richTextbox([run(CJK + LAT)], 'vert'), 0, 0, 200, 100, ctx, 1, {});
+    expect(glyphs.length).toBeGreaterThan(0);
+    for (const g of glyphs) expect(NEAR(norm(g.angleDeg), 90), `${g.text}@${g.angleDeg}`).toBe(true);
+  });
+
+  it('vert270: every glyph rotated −90° (270° CW)', () => {
+    const { ctx, glyphs } = makeMatrixCtx();
+    renderShapeText(richTextbox([run(CJK + LAT)], 'vert270'), 0, 0, 200, 100, ctx, 1, {});
+    expect(glyphs.length).toBeGreaterThan(0);
+    for (const g of glyphs) expect(NEAR(norm(g.angleDeg), -90), `${g.text}@${g.angleDeg}`).toBe(true);
+  });
+
+  it('eaVert: CJK stands UPRIGHT (net 0°) while Latin stays sideways (net +90°)', () => {
+    const { ctx, glyphs } = makeMatrixCtx();
+    renderShapeText(richTextbox([run(CJK), run(LAT)], 'eaVert'), 0, 0, 200, 100, ctx, 1, {});
+    const cjk = glyphs.find((g) => g.text.includes(CJK));
+    const lat = glyphs.find((g) => g.text.includes(LAT));
+    expect(cjk, 'CJK glyph drawn').toBeDefined();
+    expect(lat, 'Latin glyph drawn').toBeDefined();
+    expect(NEAR(norm(cjk!.angleDeg), 0), `CJK @${cjk!.angleDeg}`).toBe(true);
+    expect(NEAR(norm(lat!.angleDeg), 90), `Latin @${lat!.angleDeg}`).toBe(true);
+  });
+
+  it('rotated glyphs land INSIDE the physical box (transform pivots on box centre)', () => {
+    // A vert box of physical 200×100: after the +90° rotation about the centre,
+    // every drawn glyph's device origin must still fall within the physical box.
+    const { ctx, glyphs } = makeMatrixCtx();
+    renderShapeText(richTextbox([run(CJK + CJK + LAT)], 'vert'), 0, 0, 200, 100, ctx, 1, {});
+    expect(glyphs.length).toBeGreaterThan(0);
+    for (const g of glyphs) {
+      expect(g.devX, `${g.text} devX in [0,200]`).toBeGreaterThanOrEqual(-1);
+      expect(g.devX).toBeLessThanOrEqual(201);
+      expect(g.devY, `${g.text} devY in [0,100]`).toBeGreaterThanOrEqual(-1);
+      expect(g.devY).toBeLessThanOrEqual(101);
+    }
+  });
+
+  it('eaVert justified (both) column advances by NATURAL width — no §17.18.44 stretch drift', () => {
+    // A justified (`both`) eaVert paragraph that WRAPS: the first column has slack
+    // (a long Latin word can't break mid-word, so it wraps whole), which the
+    // horizontal justify pass would distribute into inter-segment gaps. Inside an
+    // eaVert cell that distribution must NOT be painted — the column flows
+    // start-aligned by its natural measured widths — so the four CJK cells on the
+    // first column stay UNIFORMLY spaced across the two-run boundary. (The prior
+    // bug advanced by the justify-expanded width, opening a gap at the run seam.)
+    const { ctx, glyphs } = makeMatrixCtx();
+    const two: ShapeTextRun[] = [run('経経'), run('済済'), run('ABCDEFGHIJ')];
+    const block: ShapeText = {
+      text: '経経済済ABCDEFGHIJ',
+      fontSizePt: 10,
+      alignment: 'both',
+      runs: two,
+    };
+    const shape = {
+      type: 'shape', zOrder: 0, subpaths: [], presetGeometry: 'rect', fill: null, stroke: null,
+      textBlocks: [block], textAnchor: 't',
+      textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+      textVert: 'eaVert',
+    } as unknown as ShapeRun;
+    // Box 200×100 → logical column length 100 → 10 cells of the 10px font. The
+    // first column holds 経経済済 (4 cells); ABCDEFGHIJ (10 cells) wraps whole.
+    renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {});
+    const cjk = glyphs.filter((g) => /[経済]/.test(g.text) && [...g.text].length === 1);
+    expect(cjk.length, 'four upright CJK cells on the justified first column').toBe(4);
+    // The along-column axis is device +y (the +90° frame maps local +x → +y).
+    const dys = cjk.map((g) => g.devY).sort((a, b) => a - b);
+    const gaps = dys.slice(1).map((v, i) => v - dys[i]);
+    const minGap = Math.min(...gaps);
+    const maxGap = Math.max(...gaps);
+    // All three inter-cell gaps equal (uniform natural pitch); the bug widened the
+    // run1→run2 gap by the distributed slack.
+    expect(maxGap - minGap, `uniform cell pitch, gaps=${gaps}`).toBeLessThan(0.5);
+  });
+
+  it('vert vs vert270 stack lines to OPPOSITE sides of the box centre', () => {
+    // Two lines (a hard wrap via two blocks) → the second line sits on the
+    // opposite cross-side for vert (R→L, leftwards) vs vert270 (L→R, rightwards).
+    const two = (v: string) => {
+      const { ctx, glyphs } = makeMatrixCtx();
+      const block2: ShapeText = { text: CJK, fontSizePt: 10, alignment: 'left', runs: [run(CJK)] };
+      const shape = richTextbox([run(CJK)], v);
+      (shape as unknown as { textBlocks: ShapeText[] }).textBlocks.push(block2);
+      renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {});
+      return glyphs;
+    };
+    const gv = two('vert');
+    const g270 = two('vert270');
+    // Box centre is at device x = 100 (w=200). vert: lines go R→L, so line 1 sits
+    // right of centre, line 2 left. vert270: L→R, mirrored.
+    expect(gv[0].devX).toBeGreaterThan(gv[gv.length - 1].devX);
+    expect(g270[0].devX).toBeLessThan(g270[g270.length - 1].devX);
+  });
+});

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -942,6 +942,14 @@ export interface ShapeRun {
   textInsetT?: number;  // pt
   textInsetR?: number;  // pt
   textInsetB?: number;  // pt
+  /** ECMA-376 §20.1.10.83 ST_TextVerticalType — the text-body flow direction from
+   *  `<wps:bodyPr vert>` / `<a:bodyPr vert>`. Recognised vertical values:
+   *  "vert" (all glyphs 90° CW, chars T→B, lines R→L), "vert270" (all glyphs 270°
+   *  CW = 90° CCW, chars B→T, lines L→R), and "eaVert" (East-Asian upright: CJK
+   *  stands upright, non-EA rotated 90°, chars T→B, lines R→L). "horz"/absent ⇒
+   *  horizontal (unchanged). Unrecognised values ("mongolianVert", "wordArtVert",
+   *  …) fall back to horizontal until implemented. */
+  textVert?: string | null;
   /** ECMA-376 Part 4 §19.1.2.23 `<v:textpath>` — WordArt text laid on the
    *  shape path (a text watermark). When set the renderer draws this string,
    *  scaled to fill the box (`fitshape`), rotated by {@link ShapeRun.rotation},


### PR DESCRIPTION
## Summary

Implements DrawingML **vertical text boxes** for docx — `<wps:bodyPr vert>`
(ECMA-376 §20.1.10.83 `ST_TextVerticalType`) — one of the deferred items from
the vertical-writing stage-2 tracking issue #771. A Word text box (`<wps:txbx>`)
whose body declares a vertical direction now renders vertically instead of
horizontally.

Supported values:

| `vert` value | Behaviour |
|---|---|
| `vert` | all glyphs rotated 90° CW (chars T→B, lines R→L) |
| `vert270` | all glyphs rotated 270° CW = 90° CCW (chars B→T, lines L→R) |
| `eaVert` | East-Asian upright: **CJK stands upright**, non-EA rotated 90° (chars T→B, lines R→L) |
| `horz` / absent | horizontal (unchanged) |

## Approach

Reuses the section-level tbRl **rotate-layout** machinery and mirrors the
Word/PowerPoint-verified **pptx `renderTextBody`** (#968):

- `renderShapeText` rotates the ctx ±90° about the box centre and swaps
  width/height, then lays the body out with the **same** horizontal engine
  (`buildSegments` + `layoutLines`), so kinsoku / bidi / tabs are reused.
- `vert`/`vert270` need **no per-glyph work** — their spec meaning is to rotate
  every glyph, which the frame rotation already produces.
- `eaVert` routes each text segment and the list marker through the existing
  `drawVerticalRun` (UAX#50 vo) so CJK stands upright and Latin stays sideways,
  advancing by the natural measured width (paint == advance).
- `spAutoFit` skips the horizontal height re-measure for a vertical box (it grows
  the wrong axis); the box keeps its declared `<wp:extent>`.
- Rust parser reads `vert` into `ShapeRun.text_vert` (serde camelCase → TS
  `textVert`); unknown values pass through and fall back to horizontal.

## Verification

docx text boxes do **not** fire `onTextRun`, so this uses a transform-recording
mock that asserts each glyph's net rotation from the CTM:

- `vert` → +90° for every glyph; `vert270` → −90°; `eaVert` → CJK net 0° +
  Latin +90°; `horz` → CTM identity (legacy path untouched).
- R→L vs L→R line stacking; in-box containment; a **justified-eaVert no-drift**
  regression (proven to fail before the fix).
- Rust unit test: `vert` attr → `text_vert` (eaVert / vert270 / vert / absent→None).
- Full docx vitest **1290 pass**; docx + root typecheck clean; `cargo fmt` +
  `clippy -D warnings` clean.

Gated entirely on the new `textVert` field, so **every existing fixture renders
byte-identically** (no demo/private sample uses a `vert` text box — verified).

## Independent review

Reviewed by a separate read-only Codex `gpt-5.6-sol` pass. It confirmed the
rotation geometry and save/restore balance, and flagged the justify/kashida
advance drift (fixed + regression test). Its inset-remap suggestion was
**declined** after checking the verified pptx reference, which applies bodyPr
insets unchanged in the rotated frame (DrawingML text-frame semantics) — a
code comment documents the decision.

## Scope of #771 (for the tracking issue)

Already landed in earlier PRs (not this one): the two flagged heuristics
(`+0.12em` upright nudge → measured ink-centring; comma/period nudge → U+FE10–12
substitution), UAX#50 vo glyph orientation, and 縦中横 tate-chū-yoko.

**This PR:** textbox `<wps:bodyPr vert>` = `vert` / `vert270` / `eaVert`.

**Still deferred** (documented in code; several need Word ground-truth fixtures):
`btLr` section direction, paragraph-relative `positionV` anchors in tbRl,
vertical header/footer, the vertical-table cell clip, `mongolianVert` / WordArt
text-box directions, cross-axis vertical autofit, `eaVert` ruby, and uprighting
inline images inside a vertical text box.

Part of #771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
