### PR TITLE
fix(docx): keep a trailing empty paragraph whose mark grazes the bottom margin (#981)

### DIFF
--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1077,7 +1077,17 @@ export function correctedLineMetrics(
  * `effectiveLineSpacing` lets resolved paragraph context override the source
  * value; omitting it preserves the existing `para.lineSpacing` behavior.
  */
-export function paragraphMarkLineHeight(
+/** The natural ascent/descent (px) and the resolved line-box advance (px) of an
+ *  empty paragraph's mark line. Shared by {@link paragraphMarkLineHeight} (which
+ *  returns only the advance) and {@link paragraphMarkBelowBaselinePt} (which needs
+ *  the ascent/descent to locate the mark baseline within the box). */
+export interface MarkLineMetrics {
+  readonly advancePx: number;
+  readonly ascentPx: number;
+  readonly descentPx: number;
+}
+
+export function paragraphMarkLineMetrics(
   para: DocParagraph,
   scale: number,
   grid: DocGridCtx | undefined,
@@ -1086,7 +1096,7 @@ export function paragraphMarkLineHeight(
   ctx?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   fontFamilyClasses: Record<string, string> = {},
   effectiveLineSpacing: LineSpacing | null = para.lineSpacing,
-): number {
+): MarkLineMetrics {
   const fs = getDefaultFontSize(para);
   const family = getDefaultFontFamily(para, eastAsian);
   let asc: number;
@@ -1119,7 +1129,53 @@ export function paragraphMarkLineHeight(
   } else {
     ({ asc, desc } = emptyLineNaturalPx(fs, scale));
   }
-  return lineBoxHeight(effectiveLineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSingleForScriptPx(para, scale, eastAsian), eastAsian, fs * scale);
+  const advancePx = lineBoxHeight(effectiveLineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSingleForScriptPx(para, scale, eastAsian), eastAsian, fs * scale);
+  return { advancePx, ascentPx: asc, descentPx: desc };
+}
+
+export function paragraphMarkLineHeight(
+  para: DocParagraph,
+  scale: number,
+  grid: DocGridCtx | undefined,
+  paraHasRuby: boolean,
+  eastAsian = false,
+  ctx?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  fontFamilyClasses: Record<string, string> = {},
+  effectiveLineSpacing: LineSpacing | null = para.lineSpacing,
+): number {
+  return paragraphMarkLineMetrics(
+    para, scale, grid, paraHasRuby, eastAsian, ctx, fontFamilyClasses, effectiveLineSpacing,
+  ).advancePx;
+}
+
+/**
+ * ECMA-376 §17.3.1.29 / §17.3.1.33 — the extent (px) of an empty paragraph's mark
+ * line that sits BELOW its baseline (descent + half of any auto/atLeast leading).
+ * Word centers the natural line within the box, so the baseline lies at
+ * `top + (advance − (ascent + descent)) / 2 + ascent`; the portion below it is
+ * `(advance − ascent + descent) / 2`. This is the whitespace a trailing empty
+ * paragraph may let overflow the bottom content edge (it paints no ink there),
+ * matching Word's baseline-based page fit. Mirrors {@link drawParagraphLine}'s
+ * `baseline = state.y + (lineH − naturalLineH) / 2 + line.ascent`.
+ */
+export function lineBelowBaselinePx(advancePx: number, ascentPx: number, descentPx: number): number {
+  return Math.max(0, (advancePx - ascentPx + descentPx) / 2);
+}
+
+export function paragraphMarkBelowBaselinePt(
+  para: DocParagraph,
+  grid: DocGridCtx | undefined,
+  paraHasRuby: boolean,
+  eastAsian: boolean,
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | undefined,
+  fontFamilyClasses: Record<string, string>,
+  effectiveLineSpacing: LineSpacing | null,
+): number {
+  // Measured at scale 1 so the returned px value is already in points.
+  const m = paragraphMarkLineMetrics(
+    para, 1, grid, paraHasRuby, eastAsian, ctx, fontFamilyClasses, effectiveLineSpacing,
+  );
+  return lineBelowBaselinePx(m.advancePx, m.ascentPx, m.descentPx);
 }
 
 /**

--- a/packages/docx/src/paginate-trailing-empty-mark-fit.test.ts
+++ b/packages/docx/src/paginate-trailing-empty-mark-fit.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { paginateDocument } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// Issue #981 (dense-page bottom fill).
+//
+// Word's page-break test is baseline-based: a line whose baseline sits within the
+// text area may let its below-baseline whitespace (descent + half of any leading)
+// extend into the bottom margin. An empty paragraph's mark line paints no ink, so an
+// empty paragraph that would otherwise be the last line on a page is KEPT on the page
+// when only that invisible whitespace overflows the bottom content edge — rather than
+// pushed to the next page's top, which would cascade the following visible content
+// down by ~one line (the Thai reference put a formula paragraph and a table row one
+// page late on three boundaries). This is Word runtime behaviour, reconstructed from
+// its output; ECMA-376 §17.3.1.29 requires the mark line box to exist but neither it
+// nor §17.3.1.33 specifies baseline-based pagination.
+//
+// The allowance is tightly scoped — it is taken ONLY when it is both observable and
+// invisible. These synthetic cases pin each gate (canvas mock with glyph metrics
+// exactly linear in the font px size; four single-line paragraphs fill the content
+// band and the fifth element grazes the bottom edge — its box overflows the band but
+// its baseline stays within it). Confirmed to fail before the fix: the grazing case
+// packs 4 elements on page 1 and pushes the empty, so pages[0].length is 4 not 5.
+
+interface Call { text: string; x: number; y: number; }
+
+/** Recording canvas: glyph width linear in font px; fontBoundingBox a fixed
+ *  0.8 / 0.2 em split so the below-baseline extent is a clean fraction of the box. */
+function makeLinearCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
+  let font = '10px serif';
+  const calls: Call[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, x: number, y: number) { calls.push({ text: s, x, y }); },
+    strokeText(s: string, x: number, y: number) { calls.push({ text: s, x, y }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, calls };
+}
+
+(globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+  getContext() { return makeLinearCanvas().canvas.getContext('2d'); }
+};
+
+function para(text: string, extra: Partial<DocParagraph> = {}): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: text
+      ? [{
+          type: 'text', text, bold: false, italic: false, underline: false,
+          strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+          fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+        }]
+      : [],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+    ...extra,
+  } as unknown as DocParagraph;
+}
+
+function doc(body: BodyElement[], pageHeight: number): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 200, pageHeight,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage', columns: null,
+  } as SectionProps;
+  return {
+    section, body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    footnotes: [],
+  } as unknown as DocxDocumentModel;
+}
+
+const B = (...ps: DocParagraph[]): BodyElement[] => ps.map((p) => p as unknown as BodyElement);
+
+// Content band = pageHeight − 2·margin = 57pt holds four single-line paragraphs
+// (~12pt each → y = 48) exactly; the fifth element's ~12pt box then spans [48, 60],
+// overflowing the band bottom (57) while its baseline (57) is still within it.
+const PAGE_HEIGHT = 77;
+
+describe('paginateDocument — trailing empty-paragraph mark grazes the bottom margin (issue #981)', () => {
+  it('KEEPS an inkless empty paragraph on the page when ink-bearing content follows and only its below-baseline whitespace overflows', () => {
+    // a,b,c,d fill page 1; the empty grazes the bottom (baseline within the band) and
+    // is KEPT (page 1 = a,b,c,d,empty = 5); the following visible "e" flows to page 2.
+    const pages = paginateDocument(doc(B(para('a'), para('b'), para('c'), para('d'), para(''), para('e')), PAGE_HEIGHT));
+    expect(pages.length).toBe(2);
+    expect(pages[0].length).toBe(5); // was 4 before the fix (empty pushed to page 2 top)
+    expect(pages[1].length).toBe(1);
+  });
+
+  it('does NOT graze a document-terminal empty run (no following ink) — Word keeps the trailing blank page', () => {
+    // No visible content follows the empty, so pushing it changes nothing observable;
+    // the empty is paginated normally (pushed to page 2). This preserves Word's
+    // trailing blank page — the allowance must not silently drop terminal pages.
+    const pages = paginateDocument(doc(B(para('a'), para('b'), para('c'), para('d'), para('')), PAGE_HEIGHT));
+    expect(pages.length).toBe(2);
+    expect(pages[0].length).toBe(4);
+  });
+
+  it('does NOT graze an empty paragraph that paints shading (its box paints ink)', () => {
+    // A shaded empty paragraph fills its whole mark box, so grazing would push visible
+    // fill into the bottom margin. It is treated as a normal box: pushed to page 2.
+    const pages = paginateDocument(doc(B(para('a'), para('b'), para('c'), para('d'), para('', { shading: 'ff0000' }), para('e')), PAGE_HEIGHT));
+    expect(pages.length).toBe(2);
+    expect(pages[0].length).toBe(4);
+  });
+
+  it('does NOT graze a VISIBLE last line — its glyphs must fit the full box', () => {
+    // The fifth element carries text, so it is not a mark line; it must fit its full
+    // box and is pushed to page 2 (proving the allowance is scoped to empty marks).
+    const pages = paginateDocument(doc(B(para('a'), para('b'), para('c'), para('d'), para('e'), para('f')), PAGE_HEIGHT));
+    expect(pages.length).toBe(2);
+    expect(pages[0].length).toBe(4);
+  });
+
+  it('does NOT graze an empty when a hard page break separates it from the following ink', () => {
+    // A forced page break starts "e" on a fresh page regardless of whether the empty
+    // is kept, so there is no cascade to justify grazing — the empty is paginated
+    // normally (pushed), leaving page 1 = a,b,c,d. Without the forced-boundary guard
+    // the look-ahead would find "e" past the break and wrongly graze the empty
+    // (page 1 = a,b,c,d,empty). (Codex review of the #981 fix.)
+    const pageBreak = { type: 'pageBreak' } as unknown as BodyElement;
+    const pages = paginateDocument(
+      doc([...B(para('a'), para('b'), para('c'), para('d'), para('')), pageBreak, ...B(para('e'))], PAGE_HEIGHT),
+    );
+    expect(pages[0].length).toBe(4);
+  });
+});

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -9,7 +9,9 @@ import {
   getDefaultFontSize,
   isGridLineRule,
   layoutLines,
+  lineBelowBaselinePx,
   lineBoxHeight,
+  paragraphMarkBelowBaselinePt,
   paragraphMarkLineHeight,
   type DocGridCtx,
   type LineBoundary,
@@ -120,6 +122,16 @@ export interface MeasuredParagraph {
   readonly uniformRubyAdvancePt: number;
   readonly contentStartYPt: number;
   readonly contentEndYPt: number;
+  /**
+   * ECMA-376 §17.3.1.29 / §17.3.1.33 — the extent (pt) of the LAST line's box that
+   * lies below its baseline (descent + half of any auto/atLeast leading). Word's
+   * page fit is baseline-based: a line whose baseline sits within the text area may
+   * let this below-baseline whitespace extend into the bottom margin. The paginator
+   * uses it (for an empty paragraph, whose mark line paints no ink there) so a
+   * trailing empty paragraph is not pushed to the next page merely because its
+   * invisible mark box grazes past the bottom content edge.
+   */
+  readonly lastLineBelowBaselinePt: number;
   readonly placement: Readonly<ParagraphPlacement>;
 }
 
@@ -213,6 +225,15 @@ export function measureParagraph(
       uniformRubyAdvancePt: 0,
       contentStartYPt: markTopPt,
       contentEndYPt: markTopPt + markAdvancePt,
+      lastLineBelowBaselinePt: paragraphMarkBelowBaselinePt(
+        paragraph,
+        grid,
+        context.hasRuby,
+        environment.documentHasEastAsianText === true,
+        measurer.context,
+        fontFamilyClasses,
+        context.lineSpacing,
+      ),
       placement: recordedPlacement,
     };
   };
@@ -316,6 +337,7 @@ export function measureParagraph(
     cursorPt = topYPt + advancePt;
   }
 
+  const lastLine = measuredLines[measuredLines.length - 1];
   return {
     lines: measuredLines,
     markOnly: false,
@@ -324,6 +346,11 @@ export function measureParagraph(
     uniformRubyAdvancePt,
     contentStartYPt: measuredLines[0].topYPt,
     contentEndYPt: cursorPt,
+    lastLineBelowBaselinePt: lineBelowBaselinePx(
+      lastLine.advancePt,
+      lastLine.layout.ascent,
+      lastLine.layout.descent,
+    ),
     placement: recordedPlacement,
   };
 }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2592,6 +2592,30 @@ export function computePages(
     }
     return false;
   };
+  // Issue #981 — does INK-BEARING flow content follow `startIdx` that would CASCADE
+  // through this position? A table, or a paragraph that draws something (visible text
+  // / image / shape / math). Used to gate the trailing-empty-mark grazing allowance:
+  // keeping a trailing empty paragraph on the page only matters when later visible
+  // content would otherwise be pushed down by one line. A document-terminal run of
+  // empty paragraphs has NO following ink, so it is paginated normally and Word's
+  // trailing blank page is preserved. A FORCED pagination boundary (hard page/column
+  // break, a page-starting section break, or a `pageBreakBefore` paragraph) starts the
+  // following content on a fresh page/column regardless of whether the empty is kept,
+  // so it cannot cascade — stop the scan there (Codex review of this fix).
+  const hasFollowingInkContent = (startIdx: number): boolean => {
+    for (let j = startIdx; j < body.length; j++) {
+      const nxt = body[j];
+      if (nxt.type === 'pageBreak' || nxt.type === 'columnBreak') return false;
+      if (nxt.type === 'sectionBreak' && sectionKindFrom(j + 1) !== 'continuous') return false;
+      if (nxt.type === 'table') return true;
+      if (nxt.type === 'paragraph') {
+        const p = nxt as unknown as DocParagraph;
+        if (p.pageBreakBefore) return false;
+        if (!isInklessParagraph(p)) return true;
+      }
+    }
+    return false;
+  };
 
   for (let i = 0; i < body.length; i++) {
     const el = body[i];
@@ -2914,7 +2938,44 @@ export function computePages(
       // `w:spacing/@w:after` land flush against the bottom margin.
       const needNext = para.keepNext ? estimateNextBlockHeight(i + 1) : 0;
       const fitHeight = h - para.spaceAfter;
-      const needed = fitHeight + needNext + addReservePt;
+      // Issue #981 — a TRAILING empty paragraph whose mark line's box would overflow
+      // the bottom content edge by no more than its below-baseline whitespace
+      // (descent + half leading) is KEPT on the page rather than pushed to the next
+      // page's top. This mirrors Word's observed page-fit, which is baseline-based:
+      // the last line stays if its BASELINE is within the text area, letting the
+      // descent hang into the bottom margin. Pushing such an empty paragraph forward
+      // cascades every following line down by ~one line and spilled dense-page
+      // content one page late in the reference (a formula paragraph, a table row).
+      // NOTE: this is Word RUNTIME behaviour reconstructed from its output — ECMA-376
+      // §17.3.1.29 requires the mark line box to exist, but neither it nor §17.3.1.33
+      // specifies baseline-based pagination or bottom-margin overflow.
+      //
+      // Tightly scoped so the allowance is only taken where it is BOTH observable and
+      // invisible:
+      //   • fitMeasured.markOnly + isInklessParagraph — an empty paragraph mark, not a
+      //     visible last line and not an anchor-only paragraph (which carries a drawing).
+      //   • no shading / borders — those paint the FULL mark box, so its overflow would
+      //     put visible fill/border into the bottom margin (finding: markOnly ≠ no ink).
+      //   • hasFollowingInkContent(i+1) — later visible content exists whose pagination
+      //     would cascade; a document-terminal empty run has none, so it paginates
+      //     normally and Word's trailing blank page is preserved (no page-count change).
+      //   • no keepNext block / footnote-or-footer reserve on this page — the empty is
+      //     truly the last line and it grazes the PHYSICAL bottom margin, not a reserved
+      //     footnote/tall-footer band (which is not invisible).
+      const pageBottomReserve = reserveAt(pages.length - 1).bottom
+        + (footnoteReservePt[pages.length - 1] ?? 0);
+      const trailingMarkGrazes =
+        fitMeasured.markOnly
+        && isInklessParagraph(para)
+        && !para.shading
+        && !para.borders
+        && needNext === 0
+        && addReservePt === 0
+        && pageBottomReserve === 0
+        && hasFollowingInkContent(i + 1);
+      const trailingMarkOverflow = trailingMarkGrazes ? fitMeasured.lastLineBelowBaselinePt : 0;
+      const fitHeightForBreak = fitHeight - trailingMarkOverflow;
+      const needed = fitHeightForBreak + needNext + addReservePt;
       // A paragraph-anchored float must fit below the paragraph's top on the
       // same page. If it overflows the bottom margin here but would fit when the
       // paragraph starts a fresh page, displace the paragraph (Word's float
@@ -3063,8 +3124,15 @@ export function computePages(
         balanceColH != null && colIndex < columns.length - 1
           ? Math.min(effContentH(), colTopY + balanceColH)
           : effContentH();
-      const remainingH = columnBottomLimit() - y;
-      if (fitHeight > remainingH && splittable) {
+      const bottomLimit = columnBottomLimit();
+      const remainingH = bottomLimit - y;
+      // Issue #981 — apply the trailing-empty-mark grazing allowance ONLY when the
+      // active limit is the real page-content bottom. At a NON-last balanced-column
+      // target (§17.6.4) the limit is the artificial `colTopY + balanceColH`, which
+      // is not a physical margin the descent may hang into — use the full box there
+      // so the empty mark does not sink the first column below the balance target.
+      const splitFitHeight = bottomLimit === effContentH() ? fitHeightForBreak : fitHeight;
+      if (splitFitHeight > remainingH && splittable) {
         const placed = splitParagraphAcrossPages(
           measureState, para, colW, suppressBefore, colX,
           y, pageContentH, pages,


### PR DESCRIPTION
Closes #981.

## Problem

On dense pages, Word fit one more line/row at the page bottom than we did. Measured
against a Word-exported PDF of a private multi-page fixture, 3 of 12 page boundaries
were one line/row short (two were the same one-line paragraph that begins a
calculation block; one was a table row); the other 9 matched exactly. Line pitch and
paragraph spacing already matched Word — the divergence lived entirely in the
vertical page-fill threshold.

## Root cause

Word's page-break test is **baseline-based**: the last line on a page stays if its
*baseline* is within the text area, letting the descent hang into the bottom margin.
An empty paragraph's mark line paints no ink, so Word keeps such a trailing mark on
the page. Our paginator pushed it to the next page's top whenever its *full box*
overflowed the content band by even a fraction (~2–4pt = its own below-baseline
whitespace). That pushed empty paragraph then cascaded every following visible line
down by ~one line, spilling a single-line paragraph or a table row onto the next
page.

## Fix

Expose the last line's below-baseline extent from the paragraph measurement
(`paragraphMarkLineMetrics` / `lineBelowBaselinePx`; `MeasuredParagraph.lastLineBelowBaselinePt`)
and subtract it from the paginator's fit test — but only for a **trailing empty
paragraph that is both invisible and observable**:

- `markOnly` + `isInklessParagraph` — an empty mark, not a visible last line and not
  an anchor-only paragraph carrying a drawing;
- no shading / borders — those paint the full mark box, which would put visible
  fill/border into the margin;
- ink-bearing flow content follows **and** no forced page/column/section break or
  `pageBreakBefore` separates it — a document-terminal empty run (or ink past a hard
  break) has no cascade, so it paginates normally and a trailing blank page is
  preserved;
- no `keepNext` block, and no footnote or tall-footer reserve on the page — the mark
  grazes the physical bottom margin, not a reserved band.

The baseline-adjusted height is used in both the whole-paragraph overflow test and
the line-split test, and only when the active limit is the real page-content bottom
(full box at a non-last balanced-column target, §17.6.4).

This is Word **runtime** behavior reconstructed from its output — ECMA-376 §17.3.1.29
requires the mark line box to exist but neither it nor §17.3.1.33 specifies
baseline-based pagination or bottom-margin overflow.

## Verification

- The 3 target boundaries now match the Word reference; every content-bearing page
  first-line aligns with the Word PDF.
- **Corpus page counts (48 private samples): 47 unchanged, 1 changed 12 → 11.** The
  one change drops a *trailing blank page*: that fixture's large centered
  title-block lines measure taller than Word's, seating the page's content ~19pt
  high, so a bottom empty overflows by only ~2pt (correctly grazed) where Word's
  overflows by a full line and is pushed. No monotonic baseline-grazing rule can
  accept the required ~4pt boundary grazes while rejecting the ~2pt one — the
  residual is an **orthogonal, pre-existing line-height gap** for large blocks that
  the tighter packing merely exposes; all visible content on that document still
  matches Word. (Follow-up: correct the large-block line heights to restore the
  trailing blank page.)
- 1301 docx unit tests (incl. a new 5-case regression suite pinning the positive
  grazing case and the terminal / shaded / visible-line / hard-break exclusions) and
  root `pnpm typecheck` pass; the demo VRT fidelity ratchet is byte-identical
  before/after.
- Reviewed independently by Codex (gpt-5.6-sol, high effort); its findings (scope to
  a real cascade, exclude ink-painting empties, gate on total page reserve, guard
  balanced columns, disclaim spec-normativity, strengthen tests, stop the look-ahead
  at forced breaks) are all addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
