### PR TITLE
fix(docx): pin lineRule=auto baseline at natural ascent (extra leading below)

### DIFF
--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1149,14 +1149,24 @@ export function paragraphMarkLineHeight(
 }
 
 /**
- * ECMA-376 §17.3.1.29 / §17.3.1.33 — the extent (px) of an empty paragraph's mark
- * line that sits BELOW its baseline (descent + half of any auto/atLeast leading).
- * Word centers the natural line within the box, so the baseline lies at
- * `top + (advance − (ascent + descent)) / 2 + ascent`; the portion below it is
- * `(advance − ascent + descent) / 2`. This is the whitespace a trailing empty
- * paragraph may let overflow the bottom content edge (it paints no ink there),
- * matching Word's baseline-based page fit. Mirrors {@link drawParagraphLine}'s
- * `baseline = state.y + (lineH − naturalLineH) / 2 + line.ascent`.
+ * §17.3.1.29 / §17.3.1.33 — the extent (px) of a line that sits BELOW its
+ * baseline (descent + half of any auto/atLeast leading), using the HALF-LEADING
+ * (centred) baseline `top + (advance − (ascent + descent)) / 2 + ascent`, so the
+ * portion below it is `(advance − ascent + descent) / 2`.
+ *
+ * Called for BOTH a paragraph's last visible line (paragraph-measure.ts, the
+ * `lastLineBelowBaselinePt` field) and — via {@link paragraphMarkBelowBaselinePt}
+ * — an empty paragraph's mark line. Its ONE consumer (renderer.ts
+ * `trailingMarkOverflow`) reads it only for an inkless trailing MARK: the
+ * whitespace such a paragraph may let overflow the bottom content edge, matching
+ * Word's measured page fit (#981).
+ *
+ * NOTE: this stays the CENTRED baseline even though VISIBLE lineRule=auto content
+ * lines now draw a PINNED baseline ({@link drawParagraphLine} / #990: multiplier
+ * leading placed entirely below the glyphs). The pagination consumer is inkless
+ * (mark-only), so the pinned glyph baseline never reaches it, and the #981 page
+ * fit was verified against Word with this half-leading extent — changing it would
+ * move page boundaries. The pin is therefore intentionally DRAW-ONLY.
  */
 export function lineBelowBaselinePx(advancePx: number, ascentPx: number, descentPx: number): number {
   return Math.max(0, (advancePx - ascentPx + descentPx) / 2);

--- a/packages/docx/src/line-spacing-baseline.test.ts
+++ b/packages/docx/src/line-spacing-baseline.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxDocumentModel,
+  DocxTextRun,
+  LineSpacing,
+  SectionProps,
+  ShapeRun,
+  ShapeText,
+} from './types';
+
+// ECMA-376 §17.3.1.33 `<w:spacing w:lineRule>` — baseline placement inside the
+// line box.
+//
+//   auto  → MULTIPLE spacing: `w:line` is a 240ths-of-a-line multiplier. Word
+//           pins the baseline at the NATURAL ascent from the box top and places
+//           the multiplier's extra leading ENTIRELY BELOW the glyphs. It does
+//           NOT centre the natural line in the enlarged box. (Measured against
+//           Word's PDF export during the #981 / #990 follow-up: a 2.0× 48pt
+//           title was displaced ~22pt when centred.)
+//   exact / atLeast → the extra space (value − natural) stays split half above /
+//           half below the glyphs (centred). Unchanged by #990.
+//
+// Draw-only: the line BOX height (lineBoxHeight, §17.3.1.33) is identical either
+// way, so pagination is unaffected — this pins only WHERE the glyphs sit inside
+// the box. The line pitch (baseline-to-baseline) is therefore invariant.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+// ---------- recording 2D context ----------
+interface FillTextCall { text: string; x: number; y: number; font: string; }
+
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fillTextCalls: FillTextCall[];
+} {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const fillTextCalls: FillTextCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText(text: string, x: number, y: number) {
+      fillTextCalls.push({ text, x, y, font });
+    },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, fillTextCalls };
+}
+
+// A SYNTHETIC, untabled font: the mock canvas reports a clean 1.0 em box
+// (ascent 0.8 / descent 0.2) for it, so these tests isolate the line-spacing
+// MULTIPLIER from the substituted-font single-line FLOOR (intendedSingleLinePx).
+const TEST_FONT = 'Synthetic Untabled Serif';
+
+function textRun(text: string): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 10, color: null, fontFamily: TEST_FONT, fontFamilyEastAsia: '',
+    isLink: false, background: null, vertAlign: null, hyperlink: null,
+  } as DocxTextRun;
+}
+
+function paragraph(text: string, lineSpacing: LineSpacing | null): BodyElement {
+  return {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing,
+    numbering: null, tabStops: [],
+    runs: [{ type: 'text', ...textRun(text) } as DocParagraph['runs'][number]],
+    defaultFontSize: 10, defaultFontFamily: TEST_FONT,
+    widowControl: false,
+  } as unknown as BodyElement;
+}
+
+function docWith(...body: BodyElement[]): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: 400, pageHeight: 4000,
+      marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+      headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { [TEST_FONT]: 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function renderAndRead(...body: BodyElement[]) {
+  const { canvas, fillTextCalls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(docWith(...body), canvas, 0, {
+    dpr: 1,
+    width: 400, // scale = 400/400 = 1 (px per pt) ⇒ asserts are in pt-equivalent units
+  });
+  return fillTextCalls;
+}
+
+const auto = (v: number): LineSpacing => ({ value: v, rule: 'auto', explicit: true });
+const exact = (pt: number): LineSpacing => ({ value: pt, rule: 'exact', explicit: true });
+const atLeast = (pt: number): LineSpacing => ({ value: pt, rule: 'atLeast', explicit: true });
+
+// Synthetic 10pt untabled metrics at scale 1: ascent 8, descent 2, natural 10.
+const ASCENT = 8;
+const NATURAL = 10;
+const TOL = 0.05;
+
+describe('lineRule=auto (multiple spacing) pins the baseline at natural ascent — extra leading below (§17.3.1.33, #990)', () => {
+  it('1.0× places the baseline at top + ascent (no extra)', async () => {
+    const calls = await renderAndRead(paragraph('T', auto(1.0)));
+    const t = calls.find((c) => c.text === 'T');
+    expect(t).toBeDefined();
+    expect(t!.y).toBeCloseTo(ASCENT, TOL); // 8
+  });
+
+  it('1.5× keeps the baseline at top + ascent (extra 0.5× leading below, NOT centred)', async () => {
+    const calls = await renderAndRead(paragraph('T', auto(1.5)));
+    const t = calls.find((c) => c.text === 'T');
+    expect(t).toBeDefined();
+    // Centring would give top + (15 − 10)/2 + 8 = 10.5; Word pins at 8.
+    expect(t!.y).toBeCloseTo(ASCENT, TOL); // 8, not 10.5
+  });
+
+  it('2.0× keeps the baseline at top + ascent (extra 1.0× leading below, NOT centred)', async () => {
+    const calls = await renderAndRead(paragraph('T', auto(2.0)));
+    const t = calls.find((c) => c.text === 'T');
+    expect(t).toBeDefined();
+    // Centring would give top + (20 − 10)/2 + 8 = 13; Word pins at 8.
+    expect(t!.y).toBeCloseTo(ASCENT, TOL); // 8, not 13
+  });
+
+  it('line PITCH (baseline-to-baseline) equals the full box height — pagination invariant', async () => {
+    // Two words, each 300px wide at 10px/char in a 400px column ⇒ two lines.
+    const w = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+    const calls = await renderAndRead(paragraph(w, auto(2.0)));
+    const line1 = calls.find((c) => c.text.startsWith('A'));
+    const line2 = calls.find((c) => c.text.startsWith('B'));
+    expect(line1).toBeDefined();
+    expect(line2).toBeDefined();
+    // First line baseline pinned at ascent.
+    expect(line1!.y).toBeCloseTo(ASCENT, TOL); // 8
+    // Box height = natural × 2 = 20; line pitch is that regardless of placement.
+    expect(line2!.y - line1!.y).toBeCloseTo(NATURAL * 2, TOL); // 20
+  });
+});
+
+describe('lineRule=exact / atLeast keep the centred placement (regression guard, unchanged by #990)', () => {
+  it('exact 20pt centres the glyph box (half-leading above and below)', async () => {
+    const calls = await renderAndRead(paragraph('T', exact(20)));
+    const t = calls.find((c) => c.text === 'T');
+    expect(t).toBeDefined();
+    // Centred: top + (20 − 10)/2 + 8 = 13.
+    expect(t!.y).toBeCloseTo(13, TOL);
+  });
+
+  it('atLeast 20pt centres the glyph box (half-leading above and below)', async () => {
+    const calls = await renderAndRead(paragraph('T', atLeast(20)));
+    const t = calls.find((c) => c.text === 'T');
+    expect(t).toBeDefined();
+    // atLeast → max(natural 10, 20) = 20; centred: top + (20 − 10)/2 + 8 = 13.
+    expect(t!.y).toBeCloseTo(13, TOL);
+  });
+
+  it('atLeast below natural collapses to natural (no extra, baseline at ascent)', async () => {
+    const calls = await renderAndRead(paragraph('T', atLeast(5)));
+    const t = calls.find((c) => c.text === 'T');
+    expect(t).toBeDefined();
+    // max(natural 10, 5) = 10 ⇒ no extra ⇒ baseline at ascent 8.
+    expect(t!.y).toBeCloseTo(ASCENT, TOL);
+  });
+
+  it('sub-single multiplier (0.5×) keeps the baseline pinned at ascent (negative leading)', async () => {
+    const calls = await renderAndRead(paragraph('T', auto(0.5)));
+    const t = calls.find((c) => c.text === 'T');
+    expect(t).toBeDefined();
+    // lineH = 10 × 0.5 = 5 < singleBox 10; the baseline stays at the natural
+    // ascent (8) and the shortfall is negative leading (lines overlap), not a
+    // re-centring inside the shrunken box.
+    expect(t!.y).toBeCloseTo(ASCENT, TOL);
+  });
+});
+
+describe('lineRule=auto — the substituted-font single-line FLOOR is centred; only the multiplier extra goes below', () => {
+  // Times New Roman is tabled (font-metrics.ts design floor 2355/2048 ≈ 1.1499 em
+  // ⇒ 11.499px for 10pt), while the mock canvas reports a naive 1.0 em (10px)
+  // glyph box. So intendedSingle 11.499 > glyphNatural 10: the floor half-leading
+  // ((11.499−10)/2 = 0.75) is centred, and the multiplier's extra falls BELOW.
+  const timesPara = (ls: LineSpacing): BodyElement => {
+    const p = paragraph('T', ls) as Any;
+    p.defaultFontFamily = 'Times New Roman';
+    p.runs[0].fontFamily = 'Times New Roman';
+    p.runs[0].fontFamilyEastAsia = '';
+    return p as BodyElement;
+  };
+  const timesDoc = (ls: LineSpacing): DocxDocumentModel => {
+    const d = docWith(timesPara(ls)) as Any;
+    d.fontFamilyClasses = { 'Times New Roman': 'roman' };
+    return d as DocxDocumentModel;
+  };
+  const readTimes = async (ls: LineSpacing): Promise<number> => {
+    const { canvas, fillTextCalls } = makeRecordingCanvas();
+    await renderDocumentToCanvas(timesDoc(ls), canvas, 0, { dpr: 1, width: 400 });
+    const t = fillTextCalls.find((c) => c.text === 'T');
+    expect(t).toBeDefined();
+    return t!.y;
+  };
+
+  it('the multiplier does NOT move the baseline over the floor (auto 1.0× ≡ auto 2.0× baseline)', async () => {
+    const y1 = await readTimes(auto(1.0));
+    const y2 = await readTimes(auto(2.0));
+    // Floor centred (0.75 below box top over the ascent) is present in both; the
+    // 2.0× multiplier's extra (11.499) all falls below, so the baseline is equal.
+    expect(y2).toBeCloseTo(y1, TOL);
+    // And it is the floor-centred position (≈ (11.499−10)/2 + 8 = 8.75), not the
+    // old full-box centring (which for 2.0× would be (22.998−10)/2 + 8 = 14.5).
+    expect(y1).toBeCloseTo((11.499 - 10) / 2 + 8, 0.1);
+  });
+});
+
+describe('lineRule=auto on an ACTIVE docGrid keeps the full-box centring (grid gate)', () => {
+  const gridDoc = (ls: LineSpacing): DocxDocumentModel => {
+    const d = docWith(paragraph('T', ls)) as Any;
+    d.section.docGridType = 'lines';
+    d.section.docGridLinePitch = 18; // pt
+    return d as DocxDocumentModel;
+  };
+  it('a gridded auto 2.0× line stays centred in the grid-snapped box (NOT pinned)', async () => {
+    const { canvas, fillTextCalls } = makeRecordingCanvas();
+    await renderDocumentToCanvas(gridDoc(auto(2.0)), canvas, 0, { dpr: 1, width: 400 });
+    const t = fillTextCalls.find((c) => c.text === 'T');
+    expect(t).toBeDefined();
+    // Gridded auto: lineH = max(glyphNatural 10, pitch 18 × 2 = 36) = 36. The grid
+    // gate excludes it from the pin, so the glyph is CENTRED: (36 − 10)/2 + 8 = 21.
+    // A pinned baseline would sit at 8 — the assertion distinguishes the two.
+    expect(t!.y).toBeCloseTo(21, 0.2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Text-box (shape) path — shapeLineMetrics mirrors the body baseline rule.
+// ---------------------------------------------------------------------------
+
+function textboxDoc(rule: 'auto' | 'exact' | 'atLeast' | null, val: number): DocxDocumentModel {
+  const block = {
+    text: 'T', fontSizePt: 10, fontFamily: TEST_FONT, fontFamilyEastAsia: TEST_FONT,
+    alignment: 'left', spaceBefore: 0, spaceAfter: 0,
+    ...(rule ? { lineSpacingRule: rule, lineSpacingVal: val } : {}),
+  } as unknown as ShapeText;
+  const shape = {
+    type: 'shape',
+    widthPt: 300, heightPt: 200,
+    anchorXPt: 0, anchorYPt: 0,
+    anchorXFromMargin: false, anchorYFromPara: true,
+    anchorXRelativeFrom: 'column', anchorYRelativeFrom: 'paragraph',
+    presetGeometry: 'rect', wrapMode: 'none', textAnchor: 't',
+    textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+    textBlocks: [block],
+  } as unknown as ShapeRun;
+  const para = {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [shape as unknown as DocParagraph['runs'][number]],
+    defaultFontSize: 10, defaultFontFamily: TEST_FONT, widowControl: false,
+  } as unknown as DocParagraph;
+  return {
+    section: {
+      pageWidth: 400, pageHeight: 600,
+      marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+      headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [para as unknown as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { [TEST_FONT]: 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function renderTextbox(rule: 'auto' | 'exact' | 'atLeast' | null, val: number): Promise<number> {
+  const { canvas, fillTextCalls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(textboxDoc(rule, val), canvas, 0, { dpr: 1, width: 400 });
+  const t = fillTextCalls.find((c) => c.text === 'T');
+  expect(t).toBeDefined();
+  return t!.y;
+}
+
+describe('text-box (shape) lineRule=auto pins the baseline — extra leading below (mirrors the body, #990)', () => {
+  it('the auto multiplier does NOT move the first-line baseline (top-anchored box, extra below)', async () => {
+    // A top-anchored text box: the first line's box top is fixed by the anchor +
+    // inset, so a pinned baseline = boxTop + ascent is invariant to the auto
+    // multiplier. Centring would push the 2.0× baseline down by the extra/2.
+    const yAuto1 = await renderTextbox('auto', 1.0);
+    const yAuto2 = await renderTextbox('auto', 2.0);
+    const yNone = await renderTextbox(null, 0);
+    expect(yAuto2).toBeCloseTo(yAuto1, TOL);
+    expect(yAuto1).toBeCloseTo(yNone, TOL); // 1.0× auto ≡ single spacing
+  });
+
+  it('exact spacing still centres the glyph box (regression guard, unchanged by #990)', async () => {
+    // exact 20pt expands the box; the glyph stays centred, so its baseline sits
+    // BELOW the pinned auto baseline by the half-leading (extra/2 = 5).
+    const yAuto1 = await renderTextbox('auto', 1.0);
+    const yExact = await renderTextbox('exact', 20);
+    expect(yExact - yAuto1).toBeCloseTo((20 - NATURAL) / 2, TOL); // +5
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7651,7 +7651,7 @@ function renderParagraph(
   // glyph lands on the box edge, so the painted advance equals measuredWidth by
   // construction. See the gridCharDeltaPx / gridSegDeltaPx header.
   const drawGridDeltaPx = gridCharDeltaPx(grid, scale);
-  const drawCtx: ParagraphLineDrawCtx = { ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses, contentX, contentW, lines, grid, paraX, firstLineX, paraW, indLeft, indFirst, continuesParagraph: lineSlice?.continues === true, baseRtl, hasMarker, markerUsesBodyOffset, numTab, numBodyOffset, markerJcShiftPx, picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi, decimalAutoTabPx, drawGridDeltaPx, lineHForLine };
+  const drawCtx: ParagraphLineDrawCtx = { ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses, contentX, contentW, lines, grid, paraHasRuby, paraX, firstLineX, paraW, indLeft, indFirst, continuesParagraph: lineSlice?.continues === true, baseRtl, hasMarker, markerUsesBodyOffset, numTab, numBodyOffset, markerJcShiftPx, picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi, decimalAutoTabPx, drawGridDeltaPx, lineHForLine };
   for (let li = sliceStart; li < paintEnd; li++) {
     drawParagraphLine(li, drawCtx);
   }
@@ -7788,6 +7788,10 @@ interface ParagraphLineDrawCtx {
   contentW: number;
   lines: LayoutLine[];
   grid: DocGridCtx;
+  /** Any line in the paragraph carries a ruby annotation → every line uses the
+   *  uniform (max-natural) box height and keeps the centred baseline grid, so the
+   *  lineRule=auto "extra leading below" rule (§17.3.1.33, #990) is not applied. */
+  paraHasRuby: boolean;
   paraX: number;
   firstLineX: number;
   paraW: number;
@@ -7816,7 +7820,7 @@ interface ParagraphLineDrawCtx {
 function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
   const {
     ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses,
-    contentX, contentW, lines, grid, paraX, firstLineX, paraW, indLeft,
+    contentX, contentW, lines, grid, paraHasRuby, paraX, firstLineX, paraW, indLeft,
     indFirst, continuesParagraph, baseRtl, hasMarker, markerUsesBodyOffset, numTab, numBodyOffset, markerJcShiftPx,
     picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi,
     decimalAutoTabPx, drawGridDeltaPx, lineHForLine,
@@ -7832,14 +7836,39 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     // Honor wrap-computed line topY (may push past topAndBottom floats).
     if (line.topY !== undefined && line.topY > state.y) state.y = line.topY;
 
-    // Word centers the font's natural line (ascent+descent) within the expanded
-    // line box — extra space from auto/exact/atLeast goes half above and half
-    // below the glyphs. Baseline = top + halfExtra + ascent. For ruby
-    // paragraphs every line uses the same height (the max natural line) so
-    // ruby- and non-ruby-bearing lines share a baseline grid.
+    // Baseline placement inside the line box. §17.3.1.33 defines the box SIZE
+    // (line/lineRule); the placement WITHIN the box below is Word's OBSERVED
+    // behaviour, measured against its PDF export (#990), not an ECMA rule:
+    //   • lineRule="auto" is MULTIPLE spacing — `w:line` is a 240ths-of-a-line
+    //     multiplier. Word pins the baseline at the natural ascent from the box
+    //     top and places the multiplier's extra leading ENTIRELY BELOW the
+    //     glyphs; it does NOT centre the natural line in the enlarged box.
+    //     (Measured in the #981/#990 follow-up: a 2.0× 48pt title was displaced
+    //     ~22pt when centred.) The substituted-font single-line FLOOR
+    //     (intendedSingle) still centres the glyph box within the single design
+    //     line (half-leading), so a Meiryo single-spaced line is byte-for-byte
+    //     unchanged. A sub-single multiplier (0 < value < 1) makes lineH <
+    //     singleBox: the baseline stays pinned at the natural ascent and the
+    //     shortfall is NEGATIVE leading (consecutive lines overlap), matching
+    //     Word's compressed sub-single spacing.
+    //   • exact/atLeast keep the extra space split half above / half below
+    //     (centred). docGrid line rules snap to whole cells and ruby paragraphs
+    //     use a uniform box — both have their own within-box placement, so they
+    //     keep the full-box centring too.
+    // Draw-only: lineHForLine (the box advance) is identical either way, so the
+    // line pitch and pagination are unaffected — this pins only WHERE the glyphs
+    // sit inside the box. (The trailing-empty-mark page-fit reads a SEPARATE
+    // centred below-baseline extent that is deliberately left unchanged; see
+    // lineBelowBaselinePx in line-layout.ts.)
     const lineH = lineHForLine(line);
-    const naturalLineH = line.ascent + line.descent;
-    const baseline = state.y + (lineH - naturalLineH) / 2 + line.ascent;
+    const glyphNatural = line.ascent + line.descent;
+    const autoMultiple =
+      para.lineSpacing?.rule === 'auto' && !paraHasRuby && !isGridLineRule(grid);
+    // For auto multiple spacing, centre the glyph only within the single design-
+    // line box (= max(glyphNatural, intendedSingle), matching lineBoxHeight's
+    // `natural`); the multiplier's extra (lineH − singleBox) then falls below.
+    const centerBox = autoMultiple ? Math.max(glyphNatural, line.intendedSingle) : lineH;
+    const baseline = state.y + (centerBox - glyphNatural) / 2 + line.ascent;
 
     // Per-line X range (may be narrower than paraW when wrapping around floats).
     const lineLeft = paraX + line.xOffset;
@@ -10015,15 +10044,24 @@ export function renderShapeText(
     // Ruby lines reserve real furigana height, so use the measured glyph box,
     // mirroring the body path.
     const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, grid, hasRuby, intended, eastAsian, fontPx);
-    // Word centers the font's GLYPH box within the (possibly expanded) line box
-    // (half-leading): when line-spacing or the design-line floor grows the box
-    // the extra space is split above and below the glyph box, so the baseline is
-    // (lineH − glyphNatural)/2 below the box top plus the ascent. With no
-    // expansion (glyphNatural == lineH) this reduces to c.ascent. This is the
-    // SAME math as the body draw baseline (naturalLineH = ascent+descent, NOT
-    // floor-inflated) — so an inflated box floats the glyphs centered with real
-    // half-leading instead of top-pinning them.
-    const baselineOffset = (lineH - glyphNatural) / 2 + c.ascent;
+    // Baseline placement inside the line box, mirroring the body draw path
+    // (~7859). §17.3.1.33 sizes the box; the placement is Word's OBSERVED
+    // behaviour (#990), not an ECMA rule:
+    //   • lineRule="auto" is MULTIPLE spacing — Word pins the baseline at the
+    //     natural ascent and places the multiplier's extra leading ENTIRELY BELOW
+    //     the glyph box, rather than centring it in the enlarged box (#990). The
+    //     design-line FLOOR (intended > glyphNatural, font substitution) still
+    //     centres the glyph within the single design line (half-leading), so a
+    //     single-spaced Meiryo text box (sample-6's banner) is unchanged.
+    //   • exact/atLeast (and docGrid/ruby, sized separately) keep the full-box
+    //     centring: baseline = (lineH − glyphNatural)/2 below the box top + ascent
+    //     (reduces to c.ascent when the box is not expanded).
+    const autoMultiple = ls?.rule === 'auto' && !hasRuby && !isGridLineRule(grid);
+    // For auto multiple spacing, centre only within the single design-line box
+    // (= max(glyphNatural, intended), matching lineBoxHeight's `natural`); the
+    // multiplier's extra (lineH − singleBox) then falls below.
+    const centerBox = autoMultiple ? Math.max(glyphNatural, intended) : lineH;
+    const baselineOffset = (centerBox - glyphNatural) / 2 + c.ascent;
     return { lineH, baselineOffset };
   };
   // Per-line shape metrics over the line's laid-out segments. The line-box FLOOR


### PR DESCRIPTION
## Summary

`<w:spacing w:lineRule="auto"/>` is **multiple** line spacing (`w:line` is a 240ths-of-a-line multiplier). The docx renderer was **centring** the natural line inside the enlarged line box, but Word instead **pins the baseline at the natural ascent** and places the multiplier's extra leading **entirely below** the glyphs. On a large multiple-spaced title this displaced the text noticeably (issue #990).

This change pins the baseline for `lineRule="auto"` in both draw paths:
- **body** — `drawParagraphLine` (renderer.ts)
- **text box** — `shapeLineMetrics` (renderer.ts)

`exact`/`atLeast`, active `docGrid` line rules, and ruby paragraphs keep the previous half-leading (centred) placement. The substituted-font single-line floor (`intendedSingle`) is still centred within the single design line, so a single-spaced Meiryo line is byte-for-byte unchanged — only the multiplier's extra moves below.

`§17.3.1.33` defines the box **size**; the within-box **placement** is Word's observed behaviour (measured against its PDF export), not a normative ECMA rule — the comments say so.

## Draw-only / pagination invariant

The line-box height (`lineHForLine`) is unchanged, so line pitch and pagination stay put. The trailing-empty-mark page-fit reads a **separate** centred below-baseline extent (`lineBelowBaselinePx`) that is deliberately left unchanged to preserve the #981 pagination; its sole consumer is inkless (mark-only), so the pinned glyph baseline never reaches it.

## Validation

- **New characterization test** `line-spacing-baseline.test.ts` (body + text box): auto 1.0×/1.5×/2.0× pin at the natural ascent; `exact`/`atLeast` stay centred; sub-single (0.5×) pins with negative leading; the `intendedSingle` floor is centred while the multiplier extra goes below; an active `docGrid` keeps full-box centring.
- **Real Word PDF** (private Thai fixture): the cover title's ink top moves toward Word's position; line pitch (~19.4pt) and the pagination (11 pages) are unchanged.
- **Cross-package**: pptx (`baseline = boxTop + maxAscent`) and xlsx (wrapped lines drawn at a `'top'` baseline) already pin — no change needed there.
- CI gates green: full unit suite, root typecheck, ast-grep lint, smoke, worker-equivalence (0.000% main-vs-worker diff).

## Local demo VRT note (needs a reference refresh)

The local-only `visual.spec.ts` demo VRT for `demo/sample-1` page 5 shifts by ~0.5% because a **footnote** there inherits `docDefault` `line=276` (1.15× multiple) and is non-gridded, so the fix correctly pins it (moves it toward Word). The demo references are self-generated snapshots of the renderer's own output, so this is an intended change and the page-5 reference/score should be refreshed (as in #401/#404). It is **not** refreshed here — reference-image updates require explicit owner approval. Demo VRT is local-only and not a CI gate.

Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)