### PR TITLE
test(docx): correct the Thai VRT fixture's page count to 11

### DIFF
--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -29,8 +29,11 @@ const DOCX_FILES: { name: string; pageCount: number; width: number }[] = [
   { name: 'private/sample-27', pageCount: 2, width: 612 },
   // sample-28 = Arabic RTL long-form (A4).
   { name: 'private/sample-28', pageCount: 23, width: 595 },
-  // sample-29 = Thai script (A4).
-  { name: 'private/sample-29', pageCount: 14, width: 595 },
+  // sample-29 = Thai script (A4). 11 pages since the #989 baseline-grazing
+  // page fit (adjudicated best-fidelity state in the #981 follow-up); a stale
+  // higher count silently clamps out-of-range page requests back to page 0,
+  // snapshotting duplicate first pages.
+  { name: 'private/sample-29', pageCount: 11, width: 595 },
   // sample-30 = Korean script (A4).
   { name: 'private/sample-30', pageCount: 4, width: 595 },
   // sample-31 = Russian / Cyrillic (A4).


### PR DESCRIPTION
Housekeeping found by the reference-regeneration run: the Thai private VRT entry still declared \`pageCount: 14\`, but the document paginates to 11 pages since #989 (adjudicated in the #981 follow-up — visible content matches the Word PDF on all pages; only the trailing blank page is absent). Out-of-range page requests silently clamp to page 0, so the harness was snapshotting duplicate first pages for the phantom pages.

Spec-constant-only change; no renderer code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)