### PR TITLE
test(docx): fail the VRT loudly when a requested page index is out of range

### DIFF
--- a/packages/docx/tests/visual/fixture.html
+++ b/packages/docx/tests/visual/fixture.html
@@ -22,6 +22,12 @@
 
   try {
     const doc = await DocxDocument.load('/' + file);
+    // Report the renderer's REAL page count so the VRT spec can assert the
+    // requested page index is in range. renderPage() silently clamps an
+    // out-of-range index back to page 0 (renderer.ts: `pages[pageIndex] ??
+    // pages[0]`), so without this the harness cannot tell a genuine page from a
+    // duplicated first page (see the #993 Thai-sample regression).
+    document.body.dataset.pageCount = String(doc.pageCount);
     await doc.renderPage(canvas, page, { width, dpr: 1 });
     document.body.dataset.status = 'ready';
   } catch (e) {

--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -105,6 +105,32 @@ test.describe('docx visual regression', () => {
           throw new Error(`Fixture error on ${name} page ${pageNum}: ${msg}`);
         }
 
+        // Loud out-of-range page guard. `i` is the requested page index and
+        // `pageCount` above is this VRT's DECLARED count; the fixture reports the
+        // renderer's REAL page count via dataset.pageCount. renderPage() silently
+        // clamps an out-of-range index back to page 0 (renderer.ts:
+        // `pages[pageIndex] ?? pages[0]`), so a stale declared count that exceeds
+        // the real pagination keeps snapshotting duplicate first pages under a
+        // green status — the #993 regression, where a private sample dropped
+        // 14→11 pages yet ~15 PRs of VRT stayed green on triplicated page-0 refs.
+        // Fail the moment a requested index is out of range. This runs BEFORE the
+        // UPDATE_REFS branch below on purpose: the silent duplication happened
+        // during reference refreshes, so the guard must fire there too.
+        const actualPageCount = Number(await page.evaluate(() => document.body.dataset.pageCount));
+        if (!Number.isInteger(actualPageCount) || actualPageCount <= 0) {
+          throw new Error(
+            `${name}: fixture did not report a valid page count (got "${actualPageCount}")`
+          );
+        }
+        if (i >= actualPageCount) {
+          throw new Error(
+            `${name}: requested page index ${i} (page ${pageNum}) is out of range — the renderer ` +
+            `produced only ${actualPageCount} page(s). renderPage() would clamp it back to page 0 ` +
+            `and snapshot a duplicate first page. Lower the DOCX_FILES pageCount for ${name} to ` +
+            `${actualPageCount}.`
+          );
+        }
+
         await page.waitForTimeout(200);
 
         const dataUrl = await page.evaluate(() => {


### PR DESCRIPTION
## What

Make the docx VRT harness **fail loudly** when a requested page index exceeds the renderer's real page count, instead of silently snapshotting a duplicate first page.

## Why (the #993 regression)

A private sample's real page count dropped 14→11 while the `DOCX_FILES` declared `pageCount` stayed 14. `DocxDocument.renderPage()` clamps an out-of-range page index back to page 0 (`renderer.ts`: `const elements = pages[pageIndex] ?? pages[0] ?? []`), so page requests for the phantom indices rendered a **duplicate of page 0** — and `UPDATE_REFS` runs wrote those duplicates as references. The VRT stayed green across ~15 PRs and nobody noticed. #993 corrected the count cosmetically; this PR prevents the class of regression.

## How

The renderer's clamp is legitimate public-API leniency, so it's left intact. The requested-page contract is enforced at the **fixture/spec layer**:

- `fixture.html` reports the renderer's real page count via `dataset.pageCount`.
- `visual.spec.ts` fails the moment a requested page index `i >= actualPageCount`. The guard runs **before** the `UPDATE_REFS` early-return on purpose — the silent duplication happened during reference refreshes, so it must fire there too.

## Scope decision

Guard is scoped to the exact #993 failure mode (requested index out of range). An equality check (`declared == actual`) would additionally trip on a **separate, pre-existing renderer over-pagination bug**: `private/sample-4` renders 2 pages although the Word ground-truth PDF is 1 page. That's a distinct renderer-fidelity issue, out of scope for this VRT-housekeeping change, and coupling green to it would be wrong. Flagged separately.

## Verification

- **Red**: over-declaring a demo sample's count fails on the phantom page in both plain and `UPDATE_REFS` mode; confirmed no duplicate reference PNG is written.
- **Green**: full VRT is green with correct counts (13 passed, 72 private pages skipped for absent local refs — the guard still ran and passed for all 72).
- Read-only review by Codex gpt-5.6-sol: approved, no blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)