### PR TITLE
docx vertical sections: btLr routing + horizontal header/footer + kinsoku pin (#988)

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1089,18 +1089,28 @@ const renderTokens = new WeakMap<HTMLCanvasElement | OffscreenCanvas, number>();
  *  approximates the `V` variants' non-EA rotation the same as `tbRl`, which the
  *  glyph path already draws Latin sideways for).
  *
- *  Two values are VERTICAL but NOT handled by this stage-1 path, so they return
- *  false (parsed and carried, but rendered as horizontal until implemented):
- *    - `btLr`  (≡ Strict `lr`)  — vertical, but lines flow LEFT→RIGHT and glyphs
- *                                 stack BOTTOM→TOP: needs the opposite page
- *                                 rotation/flow, a separate follow-up.
- *  And two are HORIZONTAL (glyphs upright, lines top→bottom) ⇒ false:
+ *    - `btLr`  (≡ Strict `lr`)  — its NOMINAL semantics are bottom-to-top /
+ *                                 left-to-right, but Word ground truth (issue #988
+ *                                 batch-3 adjudication ①) shows Word renders a
+ *                                 SECTION-level `btLr` IDENTICALLY to `tbRl`:
+ *                                 CJK upright stacked top→bottom, Latin/digits
+ *                                 rotated 90° CW (sideways), columns right→left —
+ *                                 it does NOT honor the literal bottom-to-top /
+ *                                 left-to-right flow. So it routes through the
+ *                                 same +90° vertical path as `tbRl`. (The per-
+ *                                 SECTION mixing that fixture also exercises —
+ *                                 a `btLr` non-final section beside a horizontal
+ *                                 final section — needs per-section text-direction
+ *                                 surfacing and remains a follow-up; a document
+ *                                 whose body section is `btLr` renders vertically
+ *                                 here already.)
+ *  Two are HORIZONTAL (glyphs upright, lines top→bottom) ⇒ false:
  *    - `lrTb`  (≡ Strict `tb`, the default) — dropped to null by the parser.
  *    - `lrTbV` (≡ Strict `tbV`) — horizontal, EA glyphs rotated 270°; still a
  *                                 horizontal flow, so not this vertical path. */
 function isVerticalSection(s: SectionProps): boolean {
   const td = s.textDirection;
-  return td === 'tbRl' || td === 'tbRlV' || td === 'tbLrV';
+  return td === 'tbRl' || td === 'tbRlV' || td === 'tbLrV' || td === 'btLr';
 }
 
 /** Map a vertical (tbRl) section's PHYSICAL page geometry to the SWAPPED LOGICAL

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1153,6 +1153,25 @@ function verticalLayoutDoc(doc: DocxDocumentModel): DocxDocumentModel {
   return { ...doc, section: verticalLayoutSection(doc.section) };
 }
 
+/** Inverse of {@link verticalLayoutSection}: map a vertical section's SWAPPED
+ *  LOGICAL geometry back to its PHYSICAL page geometry. Used to render a vertical
+ *  section's header/footer, which — per Word ground truth (issue #988) — stay
+ *  HORIZONTAL at the physical top/bottom margins and do NOT rotate with the tbRl
+ *  body. Applying `verticalLayoutSection` then this returns the original section
+ *  (a quarter-turn each way): physical margin{Top,Right,Bottom,Left} =
+ *  logical margin{Left,Top,Right,Bottom}; header/footer distances are preserved. */
+function physicalLayoutSection(logical: SectionProps): SectionProps {
+  return {
+    ...logical,
+    pageWidth: logical.pageHeight,
+    pageHeight: logical.pageWidth,
+    marginTop: logical.marginLeft,
+    marginRight: logical.marginTop,
+    marginBottom: logical.marginRight,
+    marginLeft: logical.marginBottom,
+  };
+}
+
 /** Map a page's stamped `sectionGeom` width/height back to PHYSICAL page size.
  *  Pagination for a vertical (tbRl) section runs on the SWAPPED logical geometry
  *  (`verticalLayoutDoc`), so a page's stamped `pageWidth`/`pageHeight` are the
@@ -1496,33 +1515,83 @@ async function renderDocumentToCanvasLeased(
   // the SAME resolvers as the reserve pass (computeHeaderReserves / computeFooterReserves)
   // so the body's start/end can never drift from the gap pagination reserved.
 
-  // Header: top of page, starting at headerDistance. A header taller than its
-  // top-margin allowance (§17.6.11) overflows the content area downward; the body
-  // was already paginated to clear it (paginateWithHeaderFooterReserve), and its
-  // start y is pushed down by the same overflow so no body line sits over the header.
   const header = resolvePageHeader(pages, pageIndex, doc);
-  let headerReservePx = 0;
-  if (header) {
-    const headerHeight = measureHeaderFooterHeight(header, baseState);
-    renderHeaderFooter(header, sec.headerDistance * scale, baseState);
-    // §17.6.11 overflow in device px (headerHeight is at canvas scale), via the shared
-    // formula so the body start matches the pagination reserve exactly.
-    headerReservePx = headerOverflowPt(headerHeight, sec.marginTop * scale, sec.headerDistance * scale);
-  }
-
-  // Footer: anchored from bottom, rising by its measured height. A footer taller
-  // than its bottom-margin allowance (§17.6.11) overflows the content area; the body
-  // was already paginated to clear it (paginateWithHeaderFooterReserve), and the same
-  // overflow raises the footnote block below so notes clear it too.
   const footer = resolvePageFooter(pages, pageIndex, doc);
+  let headerReservePx = 0;
   let footerReservePx = 0;
-  if (footer) {
-    const footerHeight = measureHeaderFooterHeight(footer, baseState);
-    const footerTopY = cssHeight - sec.footerDistance * scale - footerHeight;
-    renderHeaderFooter(footer, footerTopY, baseState);
-    // §17.6.11 overflow in device px (footerHeight is at canvas scale), via the shared
-    // formula so the footnote clearance matches the pagination reserve exactly.
-    footerReservePx = footerOverflowPt(footerHeight, sec.marginBottom * scale, sec.footerDistance * scale);
+
+  if (vertical) {
+    // ECMA-376 §17.6.20 + §17.10.1 (issue #988 batch-3 adjudication): a vertical
+    // (tbRl) section's header/footer stay HORIZONTAL at the PHYSICAL top/bottom
+    // margins — Word does NOT rotate them with the body. The body is laid out in
+    // the swapped logical `sec` under the +90° page paint (applied above); the
+    // header/footer are drawn back in the physical page frame recovered by
+    // `physicalLayoutSection`, with the ctx transform reset to physical (no +90°)
+    // and a horizontal (`verticalCJK: false`) state.
+    //
+    // The reserves stay 0: the header/footer occupy the physical top/bottom band,
+    // which maps to the LOGICAL flow-start (column top) axis rather than the
+    // logical `y` the horizontal reserve shifts, and Word's fixtures fit them
+    // within their margins. Pushing the vertical body for an OVER-margin
+    // header/footer is a documented follow-up.
+    if (header || footer) {
+      // The header/footer are drawn HORIZONTALLY, so the layout context they use is
+      // horizontal — clear `textDirection` on the physical section (else the derived
+      // SectionLayoutContext would carry the body's `tbRl`, contradicting the
+      // `verticalCJK: false` state below).
+      const physSec: SectionProps = { ...physicalLayoutSection(sec), textDirection: null };
+      const physSectionLayout = resolveSectionLayoutContext(layoutSettings, physSec);
+      const physBaseState: RenderState = {
+        ...baseState,
+        contentX: physSec.marginLeft * scale,
+        contentW: (physPageWidth - physSec.marginLeft - physSec.marginRight) * scale,
+        marginLeft: physSec.marginLeft,
+        marginRight: physSec.marginRight,
+        marginTop: bodyMarginInsetPt(physSec.marginTop),
+        marginBottom: bodyMarginInsetPt(physSec.marginBottom),
+        pageWidth: physPageWidth,
+        pageH: physPageHeight * scale,
+        docGrid: toLegacyDocGridContext(physSectionLayout),
+        sectionLayout: physSectionLayout,
+        verticalCJK: false,
+        verticalPhys: undefined,
+      };
+      ctx.save();
+      // Drop the +90° page paint so the header/footer land in physical space.
+      ctx.setTransform(effectiveDpr, 0, 0, effectiveDpr, 0, 0);
+      if (header) renderHeaderFooter(header, physSec.headerDistance * scale, physBaseState);
+      if (footer) {
+        const footerHeight = measureHeaderFooterHeight(footer, physBaseState);
+        const footerTopY = cssHeight - physSec.footerDistance * scale - footerHeight;
+        renderHeaderFooter(footer, footerTopY, physBaseState);
+      }
+      ctx.restore();
+    }
+  } else {
+    // Header: top of page, starting at headerDistance. A header taller than its
+    // top-margin allowance (§17.6.11) overflows the content area downward; the body
+    // was already paginated to clear it (paginateWithHeaderFooterReserve), and its
+    // start y is pushed down by the same overflow so no body line sits over the header.
+    if (header) {
+      const headerHeight = measureHeaderFooterHeight(header, baseState);
+      renderHeaderFooter(header, sec.headerDistance * scale, baseState);
+      // §17.6.11 overflow in device px (headerHeight is at canvas scale), via the shared
+      // formula so the body start matches the pagination reserve exactly.
+      headerReservePx = headerOverflowPt(headerHeight, sec.marginTop * scale, sec.headerDistance * scale);
+    }
+
+    // Footer: anchored from bottom, rising by its measured height. A footer taller
+    // than its bottom-margin allowance (§17.6.11) overflows the content area; the body
+    // was already paginated to clear it (paginateWithHeaderFooterReserve), and the same
+    // overflow raises the footnote block below so notes clear it too.
+    if (footer) {
+      const footerHeight = measureHeaderFooterHeight(footer, baseState);
+      const footerTopY = cssHeight - sec.footerDistance * scale - footerHeight;
+      renderHeaderFooter(footer, footerTopY, baseState);
+      // §17.6.11 overflow in device px (footerHeight is at canvas scale), via the shared
+      // formula so the footnote clearance matches the pagination reserve exactly.
+      footerReservePx = footerOverflowPt(footerHeight, sec.marginBottom * scale, sec.footerDistance * scale);
+    }
   }
 
   // Body. ECMA-376 §17.6.4: lay out body text in EACH section's newspaper columns
@@ -3785,6 +3854,15 @@ function paginateWithHeaderFooterReserve(
     doc.settings,
     layoutSettings,
   );
+  // ECMA-376 §17.6.20 + §17.10.1 (issue #988): a vertical (tbRl) section lays its
+  // header/footer out HORIZONTALLY in physical space with NO body reserve (see the
+  // paint path, which sets headerReservePx/footerReservePx = 0). `doc` here is the
+  // SWAPPED logical doc, so measuring a header against its logical marginTop/Bottom
+  // (physical right/left) and reserving on the logical `y` axis would mismatch the
+  // paint. Skip the reserve entirely for vertical sections so pagination and paint
+  // agree. (Physical-axis body-push for an over-margin vertical header/footer is a
+  // documented follow-up, matching the paint path's TODO.)
+  if (isVerticalSection(doc.section)) return pass1;
   const measure = buildMeasureState(ctx, doc.section, fontFamilyClasses, layoutSettings);
   const footerReserves = computeFooterReserves(pass1, doc, measure);
   const headerReserves = computeHeaderReserves(pass1, doc, measure);
@@ -10660,6 +10738,14 @@ export const __test_resolveAnchorBox = (
   paraBaseY: number,
 ): { x: number; y: number; w: number; h: number; dl: number; dr: number; dt: number; db: number } =>
   resolveAnchorBox(img, state, paraBaseY);
+
+/** Exported for the vertical header/footer test (ECMA-376 §17.6.20 + §17.10.1,
+ *  issue #988): pins the inverse-of-`verticalLayoutSection` page/margin mapping a
+ *  vertical section's HORIZONTAL header/footer are laid out in. */
+export const __test_physicalLayoutSection = (logical: SectionProps): SectionProps =>
+  physicalLayoutSection(logical);
+export const __test_verticalLayoutSection = (phys: SectionProps): SectionProps =>
+  verticalLayoutSection(phys);
 
 /** Exported for the page-anchor pre-scan test (ECMA-376 §20.4.3.2/§20.4.3.5):
  *  drives {@link preRegisterPageFloats} from a unit test against a stub

--- a/packages/docx/src/vertical-header-footer.test.ts
+++ b/packages/docx/src/vertical-header-footer.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  __test_physicalLayoutSection as physicalLayoutSection,
+  __test_verticalLayoutSection as verticalLayoutSection,
+} from './renderer.js';
+import type { SectionProps } from './types.js';
+
+// ECMA-376 §17.6.20 + §17.10.1 — a vertical (tbRl) section's header/footer stay
+// HORIZONTAL at the physical top/bottom margins (Word ground truth, issue #988's
+// batch-3 adjudication). The body is laid out in the SWAPPED logical geometry and
+// the page paint is rotated +90°; the header/footer must be drawn back in the
+// physical page frame, which `physicalLayoutSection` (the inverse of
+// `verticalLayoutSection`) recovers.
+
+function makeSection(over: Partial<SectionProps>): SectionProps {
+  return {
+    pageWidth: 612,
+    pageHeight: 792,
+    marginTop: 72,
+    marginRight: 90,
+    marginBottom: 108,
+    marginLeft: 126,
+    headerDistance: 36,
+    footerDistance: 36,
+    titlePage: false,
+    evenAndOddHeaders: false,
+    textDirection: 'tbRl',
+    ...over,
+  };
+}
+
+describe('vertical header/footer physical frame (§17.6.20)', () => {
+  it('physicalLayoutSection inverts verticalLayoutSection (round-trip)', () => {
+    const phys = makeSection({});
+    const round = physicalLayoutSection(verticalLayoutSection(phys));
+    expect(round.pageWidth).toBe(phys.pageWidth);
+    expect(round.pageHeight).toBe(phys.pageHeight);
+    expect(round.marginTop).toBe(phys.marginTop);
+    expect(round.marginRight).toBe(phys.marginRight);
+    expect(round.marginBottom).toBe(phys.marginBottom);
+    expect(round.marginLeft).toBe(phys.marginLeft);
+    expect(round.headerDistance).toBe(phys.headerDistance);
+    expect(round.footerDistance).toBe(phys.footerDistance);
+  });
+
+  it('recovers the physical page box + margins from the logical (swapped) section', () => {
+    // The renderer lays a vertical section out in `verticalLayoutSection(phys)`;
+    // the header/footer path takes THAT logical section and must recover the
+    // physical page box (612×792) with the four margins on their physical edges.
+    const phys = makeSection({});
+    const logical = verticalLayoutSection(phys);
+    // Sanity: the logical section is swapped (width = physical height).
+    expect(logical.pageWidth).toBe(792);
+    expect(logical.pageHeight).toBe(612);
+
+    const recovered = physicalLayoutSection(logical);
+    // Physical page box: portrait letter.
+    expect(recovered.pageWidth).toBe(612);
+    expect(recovered.pageHeight).toBe(792);
+    // Physical margins land on their original edges.
+    expect(recovered.marginTop).toBe(72);
+    expect(recovered.marginRight).toBe(90);
+    expect(recovered.marginBottom).toBe(108);
+    expect(recovered.marginLeft).toBe(126);
+  });
+
+  it('preserves non-geometry fields (textDirection, docGrid) so the frame stays vertical-aware', () => {
+    const phys = makeSection({ docGridType: 'lines', docGridLinePitch: 18 });
+    const recovered = physicalLayoutSection(verticalLayoutSection(phys));
+    expect(recovered.textDirection).toBe('tbRl');
+    expect(recovered.docGridType).toBe('lines');
+    expect(recovered.docGridLinePitch).toBe(18);
+  });
+});

--- a/packages/node/src/docx-btlr-vertical.probe.test.ts
+++ b/packages/node/src/docx-btlr-vertical.probe.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Section-level `btLr` renders identically to `tbRl` — ECMA-376 §17.6.20,
+ * issue #988 batch-3 adjudication ①.
+ *
+ * Word ground truth: a section whose `<w:textDirection w:val="btLr"/>` is applied
+ * at SECTION level is laid out the same as `tbRl` (CJK upright stacked top→bottom,
+ * Latin/digits sideways 90° CW, columns right→left) — Word does NOT honor btLr's
+ * nominal bottom-to-top / left-to-right flow. This probe renders the SAME body
+ * once as `btLr` and once as `tbRl` and asserts the two produce byte-identical
+ * text-run layouts (position + rotation), pinning that `btLr` routes through the
+ * vertical path.
+ *
+ * CI-safe: gated on docx WASM + skia-canvas; skips when absent, hard-fails under
+ * OOXML_REQUIRE_SKIA=1.
+ */
+import { describe, it, expect } from 'vitest';
+import { crc32 } from 'node:zlib';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
+const rendererMod = await importForTests(
+  () => import('./../../docx/src/renderer.ts'),
+  'packages/docx/src/renderer.ts',
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+function storedZip(files: Record<string, string>): Uint8Array {
+  const enc = new TextEncoder();
+  const chunks: number[] = [];
+  const central: number[] = [];
+  const u16 = (n: number) => [n & 0xff, (n >> 8) & 0xff];
+  const u32 = (n: number) => [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff];
+  let offset = 0;
+  for (const [name, content] of Object.entries(files)) {
+    const nameBytes = [...enc.encode(name)];
+    const data = [...enc.encode(content)];
+    const crc = crc32(Uint8Array.from(data)) >>> 0;
+    const local = [
+      ...u32(0x04034b50), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...nameBytes, ...data,
+    ];
+    central.push(
+      ...u32(0x02014b50), ...u16(20), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...u16(0), ...u16(0), ...u16(0), ...u32(0), ...u32(offset),
+      ...nameBytes,
+    );
+    chunks.push(...local);
+    offset += local.length;
+  }
+  const centralOffset = offset;
+  const end = [
+    ...u32(0x06054b50), ...u16(0), ...u16(0),
+    ...u16(Object.keys(files).length), ...u16(Object.keys(files).length),
+    ...u32(central.length), ...u32(centralOffset), ...u16(0),
+  ];
+  return Uint8Array.from([...chunks, ...central, ...end]);
+}
+
+function verticalDocx(dir: 'btLr' | 'tbRl'): Uint8Array {
+  const contentTypes =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '</Types>';
+  const rootRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+    '</Relationships>';
+  const para = (t: string) =>
+    `<w:p><w:r><w:rPr><w:sz w:val="28"/></w:rPr><w:t>${t}</w:t></w:r></w:p>`;
+  const document =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document ${NS}><w:body>` +
+    para('縦横ABC混在123テスト') +
+    para('日本語Wordと英語Englishの並び') +
+    '<w:sectPr>' +
+    '<w:pgSz w:w="12240" w:h="15840"/>' +
+    '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/>' +
+    `<w:textDirection w:val="${dir}"/>` +
+    '</w:sectPr></w:body></w:document>';
+  return storedZip({
+    '[Content_Types].xml': contentTypes,
+    '_rels/.rels': rootRels,
+    'word/document.xml': document,
+  });
+}
+
+interface Run { t: string; x: number; y: number; w: number; h: number; tr: string }
+
+async function renderRuns(dir: 'btLr' | 'tbRl'): Promise<Run[]> {
+  const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
+  const { renderDocumentToCanvas } = rendererMod as Any;
+  const doc = parseDocx(verticalDocx(dir));
+  const canvas = new Canvas(Math.round(doc.section.pageWidth), Math.round(doc.section.pageHeight));
+  const runs: Run[] = [];
+  const rImg = installImageBitmapShim(factory);
+  const rOff = installOffscreenCanvasShim(factory);
+  try {
+    await renderDocumentToCanvas(doc, canvas, 0, {
+      dpr: 1,
+      width: doc.section.pageWidth,
+      onTextRun: (r: Any) =>
+        runs.push({
+          t: r.text,
+          x: Math.round(r.x),
+          y: Math.round(r.y),
+          w: Math.round(r.w),
+          h: Math.round(r.h),
+          tr: r.transform ?? '',
+        }),
+    });
+  } finally {
+    rOff();
+    rImg();
+  }
+  return runs;
+}
+
+describe.skipIf(!skia || !docxMod || !rendererMod)('docx section btLr ≡ tbRl (§17.6.20)', () => {
+  it('renders a btLr section identically to tbRl (vertical, same run layout)', async () => {
+    // Sequential — each render installs/restores global OffscreenCanvas +
+    // createImageBitmap shims; running them concurrently could restore out of order.
+    const btlr = await renderRuns('btLr');
+    const tbrl = await renderRuns('tbRl');
+    // Both must actually be vertical (rotate transform present).
+    expect(btlr.length, 'btLr produced runs').toBeGreaterThan(0);
+    expect(btlr.every((r) => /rotate/.test(r.tr)), 'btLr runs are vertical').toBe(true);
+    expect(tbrl.every((r) => /rotate/.test(r.tr)), 'tbRl runs are vertical').toBe(true);
+    // And identical layout: same texts, positions, and rotation.
+    expect(btlr).toEqual(tbrl);
+  });
+});

--- a/packages/node/src/docx-vertical-header-footer.probe.test.ts
+++ b/packages/node/src/docx-vertical-header-footer.probe.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Vertical (tbRl) header/footer render probe — ECMA-376 §17.6.20 + §17.10.1,
+ * issue #988 batch-3 adjudication.
+ *
+ * Word ground truth: a section with `<w:textDirection w:val="tbRl"/>` flows its
+ * BODY vertically (glyphs stack top→bottom, columns right→left) but keeps its
+ * header/footer HORIZONTAL at the PHYSICAL top/bottom margins, centred, with the
+ * PAGE field horizontal — the section direction does NOT propagate to them.
+ *
+ * The synthetic `.docx` (built in-memory, no file committed) is a tbRl section
+ * with CJK body text plus a centred header ("HEADERMARK") and footer
+ * ("FOOTERMARK"). We capture the renderer's `onTextRun` reports and assert:
+ *   - the header run is HORIZONTAL (no `rotate(90deg)` transform) at the physical
+ *     top band, horizontally centred on the page;
+ *   - the footer run is HORIZONTAL at the physical bottom band, centred;
+ *   - the BODY runs ARE vertical (carry the `rotate(90deg)` transform), proving
+ *     the section really is vertical — so the header/footer horizontality is the
+ *     tested behaviour, not a non-vertical page.
+ *
+ * CI-safe: gated on the docx WASM (built by `pnpm build:wasm`) + skia-canvas
+ * (devDependency). Skips when either is absent; hard-fails under OOXML_REQUIRE_SKIA=1.
+ */
+import { describe, it, expect } from 'vitest';
+import { crc32 } from 'node:zlib';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
+const rendererMod = await importForTests(
+  () => import('./../../docx/src/renderer.ts'),
+  'packages/docx/src/renderer.ts',
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+  'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"';
+
+function storedZip(files: Record<string, string>): Uint8Array {
+  const enc = new TextEncoder();
+  const chunks: number[] = [];
+  const central: number[] = [];
+  const u16 = (n: number) => [n & 0xff, (n >> 8) & 0xff];
+  const u32 = (n: number) => [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff];
+  let offset = 0;
+  for (const [name, content] of Object.entries(files)) {
+    const nameBytes = [...enc.encode(name)];
+    const data = [...enc.encode(content)];
+    const crc = crc32(Uint8Array.from(data)) >>> 0;
+    const local = [
+      ...u32(0x04034b50), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...nameBytes, ...data,
+    ];
+    central.push(
+      ...u32(0x02014b50), ...u16(20), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...u16(0), ...u16(0), ...u16(0), ...u32(0), ...u32(offset),
+      ...nameBytes,
+    );
+    chunks.push(...local);
+    offset += local.length;
+  }
+  const centralOffset = offset;
+  const end = [
+    ...u32(0x06054b50), ...u16(0), ...u16(0),
+    ...u16(Object.keys(files).length), ...u16(Object.keys(files).length),
+    ...u32(central.length), ...u32(centralOffset), ...u16(0),
+  ];
+  return Uint8Array.from([...chunks, ...central, ...end]);
+}
+
+interface DocxOpts {
+  /** Include a header + footer part & references. */
+  hf: boolean;
+  /** Body paragraph repeat count (drives page count). */
+  paras?: number;
+  /** pgMar attributes — default asymmetric so a logical-axis reserve would show. */
+  pgMar?: string;
+}
+
+function verticalHeaderFooterDocx(opts: DocxOpts): Uint8Array {
+  const hf = opts.hf;
+  const paras = opts.paras ?? 2;
+  const pgMar =
+    opts.pgMar ??
+    'w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"';
+  const hfOverrides = hf
+    ? '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>' +
+      '<Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>'
+    : '';
+  const contentTypes =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    hfOverrides +
+    '</Types>';
+  const rootRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+    '</Relationships>';
+  const docRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    (hf
+      ? '<Relationship Id="rIdHdr" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>' +
+        '<Relationship Id="rIdFtr" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer" Target="footer1.xml"/>'
+      : '') +
+    '</Relationships>';
+  const bodyPara =
+    '<w:p><w:r><w:rPr><w:sz w:val="24"/></w:rPr>' +
+    '<w:t>縦書き本文の段落。縦書き本文の段落。縦書き本文の段落。</w:t></w:r></w:p>';
+  const hfRefs = hf
+    ? '<w:headerReference w:type="default" r:id="rIdHdr"/><w:footerReference w:type="default" r:id="rIdFtr"/>'
+    : '';
+  const document =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document ${NS}><w:body>` +
+    bodyPara.repeat(paras) +
+    // sectPr in XSD sequence order: headerReference → footerReference → pgSz →
+    // pgMar → textDirection.
+    '<w:sectPr>' +
+    hfRefs +
+    '<w:pgSz w:w="12240" w:h="15840"/>' +
+    `<w:pgMar ${pgMar}/>` +
+    '<w:textDirection w:val="tbRl"/>' +
+    '</w:sectPr></w:body></w:document>';
+  const header =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:hdr ${NS}>` +
+    '<w:p><w:pPr><w:jc w:val="center"/></w:pPr>' +
+    '<w:r><w:rPr><w:sz w:val="24"/></w:rPr><w:t>HEADERMARK</w:t></w:r></w:p></w:hdr>';
+  const footer =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:ftr ${NS}>` +
+    '<w:p><w:pPr><w:jc w:val="center"/></w:pPr>' +
+    '<w:r><w:rPr><w:sz w:val="24"/></w:rPr><w:t>FOOTERMARK</w:t></w:r></w:p></w:ftr>';
+  const files: Record<string, string> = {
+    '[Content_Types].xml': contentTypes,
+    '_rels/.rels': rootRels,
+    'word/_rels/document.xml.rels': docRels,
+    'word/document.xml': document,
+  };
+  if (hf) {
+    files['word/header1.xml'] = header;
+    files['word/footer1.xml'] = footer;
+  }
+  return storedZip(files);
+}
+
+interface Run { t: string; x: number; y: number; w: number; h: number; tr?: string }
+
+async function renderRuns(): Promise<{ runs: Run[]; physW: number; physH: number }> {
+  const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
+  const { renderDocumentToCanvas, physicalPageSizePt } = rendererMod as Any;
+  const doc = parseDocx(verticalHeaderFooterDocx({ hf: true }));
+  const phys = physicalPageSizePt(doc.section, doc.section.pageWidth, doc.section.pageHeight);
+  // Physical letter portrait: width 612 (=pageWidth), height 792 (=pageHeight).
+  const canvas = new Canvas(Math.round(doc.section.pageWidth), Math.round(doc.section.pageHeight));
+  const runs: Run[] = [];
+  const restoreImg = installImageBitmapShim(factory);
+  const restoreOff = installOffscreenCanvasShim(factory);
+  try {
+    await renderDocumentToCanvas(doc, canvas, 0, {
+      dpr: 1,
+      width: doc.section.pageWidth, // scale 1 px/pt on the physical page
+      onTextRun: (r: Any) =>
+        runs.push({ t: r.text, x: r.x, y: r.y, w: r.w, h: r.h, tr: r.transform }),
+    });
+  } finally {
+    restoreOff();
+    restoreImg();
+  }
+  return { runs, physW: phys.widthPt, physH: phys.heightPt };
+}
+
+describe.skipIf(!skia || !docxMod || !rendererMod)(
+  'docx vertical header/footer stay horizontal at physical top/bottom (§17.6.20 + §17.10.1)',
+  () => {
+    it('draws the header horizontal at the physical top, the footer at the bottom, body vertical', async () => {
+      const { runs } = await renderRuns();
+      const pageW = 612; // physical letter width (pt == px at scale 1)
+      const pageH = 792;
+      const center = pageW / 2;
+
+      const header = runs.find((r) => r.t.includes('HEADERMARK'));
+      const footer = runs.find((r) => r.t.includes('FOOTERMARK'));
+      const body = runs.find((r) => r.t.includes('縦書き'));
+
+      expect(header, 'header run reported').toBeTruthy();
+      expect(footer, 'footer run reported').toBeTruthy();
+      expect(body, 'body run reported').toBeTruthy();
+      if (!header || !footer || !body) return;
+
+      const isRotated = (tr?: string) => !!tr && /rotate/.test(tr);
+
+      // Header: horizontal (no rotate), physical top band, centred.
+      expect(isRotated(header.tr), 'header must be horizontal (no rotate)').toBe(false);
+      expect(header.y, 'header near physical top').toBeLessThan(pageH * 0.12);
+      const headerMid = header.x + header.w / 2;
+      expect(Math.abs(headerMid - center), 'header centred horizontally').toBeLessThan(pageW * 0.1);
+
+      // Footer: horizontal, physical bottom band, centred.
+      expect(isRotated(footer.tr), 'footer must be horizontal (no rotate)').toBe(false);
+      expect(footer.y, 'footer near physical bottom').toBeGreaterThan(pageH * 0.85);
+      const footerMid = footer.x + footer.w / 2;
+      expect(Math.abs(footerMid - center), 'footer centred horizontally').toBeLessThan(pageW * 0.1);
+
+      // Body: vertical (rotate transform present) — the section really is tbRl.
+      expect(isRotated(body.tr), 'body must be vertical (rotate present)').toBe(true);
+    });
+
+    it('paginates a vertical section independently of its header/footer (asymmetric margins)', () => {
+      // The header/footer occupy the PHYSICAL top/bottom band and reserve no body
+      // space (issue #988). The paginator runs on the swapped logical geometry, so a
+      // logical-axis reserve — comparing header height against the logical marginTop
+      // (physical RIGHT) — would spuriously fire with asymmetric margins and add
+      // pages the paint (reserve 0) does not expect. Assert the page count is the
+      // same with and without the header/footer, on an asymmetric-margin page.
+      const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
+      const { paginateDocument } = rendererMod as Any;
+      const margins =
+        'w:top="2880" w:right="720" w:bottom="2880" w:left="720" w:header="360" w:footer="360" w:gutter="0"';
+      const withHF = parseDocx(verticalHeaderFooterDocx({ hf: true, paras: 40, pgMar: margins }));
+      const noHF = parseDocx(verticalHeaderFooterDocx({ hf: false, paras: 40, pgMar: margins }));
+      const rImg = installImageBitmapShim(factory);
+      const rOff = installOffscreenCanvasShim(factory);
+      let withPages = 0;
+      let noPages = 0;
+      try {
+        withPages = paginateDocument(withHF).length;
+        noPages = paginateDocument(noHF).length;
+      } finally {
+        rOff();
+        rImg();
+      }
+      expect(withPages, 'multi-page body').toBeGreaterThan(1);
+      expect(withPages, 'header/footer do not perturb vertical pagination').toBe(noPages);
+    });
+  },
+);

--- a/packages/node/src/docx-vertical-kinsoku.probe.test.ts
+++ b/packages/node/src/docx-vertical-kinsoku.probe.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Vertical (tbRl) line-head kinsoku probe — ECMA-376 §17.6.20 + §17.15.1.58–.60,
+ * issue #988 batch-3 adjudication item ⑤ (verify-only).
+ *
+ * Word ground truth: in a vertical section the line-head prohibition (行頭禁則)
+ * still applies, so closing punctuation (、 。 」 ，) never sits at the HEAD (top)
+ * of a column. The renderer reuses the horizontal kinsoku line-breaker under the
+ * +90° page rotation, so this is correct-by-construction; this probe pins it.
+ *
+ * The synthetic `.docx` (built in-memory, no file committed) is a tbRl section
+ * whose single paragraph is a long CJK string densely seeded with 、。」 so it
+ * wraps into several columns. Grouping the renderer's `onTextRun` reports by
+ * physical column x, the top (min physical y) glyph of every column is checked to
+ * be a non-closing character. `onTextRun` reports ORIGINAL code points (not the
+ * FE1x vertical-form substitutes), so the closing set is the plain marks.
+ *
+ * CI-safe: gated on docx WASM + skia-canvas; skips when absent, hard-fails under
+ * OOXML_REQUIRE_SKIA=1. Font-independent: the line-head RULE holds regardless of
+ * which JP fallback face measures the wrap.
+ */
+import { describe, it, expect } from 'vitest';
+import { crc32 } from 'node:zlib';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
+const rendererMod = await importForTests(
+  () => import('./../../docx/src/renderer.ts'),
+  'packages/docx/src/renderer.ts',
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+function storedZip(files: Record<string, string>): Uint8Array {
+  const enc = new TextEncoder();
+  const chunks: number[] = [];
+  const central: number[] = [];
+  const u16 = (n: number) => [n & 0xff, (n >> 8) & 0xff];
+  const u32 = (n: number) => [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff];
+  let offset = 0;
+  for (const [name, content] of Object.entries(files)) {
+    const nameBytes = [...enc.encode(name)];
+    const data = [...enc.encode(content)];
+    const crc = crc32(Uint8Array.from(data)) >>> 0;
+    const local = [
+      ...u32(0x04034b50), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...nameBytes, ...data,
+    ];
+    central.push(
+      ...u32(0x02014b50), ...u16(20), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...u16(0), ...u16(0), ...u16(0), ...u32(0), ...u32(offset),
+      ...nameBytes,
+    );
+    chunks.push(...local);
+    offset += local.length;
+  }
+  const centralOffset = offset;
+  const end = [
+    ...u32(0x06054b50), ...u16(0), ...u16(0),
+    ...u16(Object.keys(files).length), ...u16(Object.keys(files).length),
+    ...u32(central.length), ...u32(centralOffset), ...u16(0),
+  ];
+  return Uint8Array.from([...chunks, ...central, ...end]);
+}
+
+function verticalKinsokuDocx(): Uint8Array {
+  const contentTypes =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '</Types>';
+  const rootRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+    '</Relationships>';
+  // A long CJK run seeded densely with closing marks so kinsoku must push them off
+  // column heads while wrapping into many columns.
+  const seg = 'あいう、えお。かきく」さしす、たちつ。なにぬ」はひふ、';
+  const text = seg.repeat(12);
+  const document =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document ${NS}><w:body>` +
+    `<w:p><w:r><w:rPr><w:sz w:val="28"/></w:rPr><w:t>${text}</w:t></w:r></w:p>` +
+    '<w:sectPr>' +
+    '<w:pgSz w:w="12240" w:h="15840"/>' +
+    '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/>' +
+    '<w:textDirection w:val="tbRl"/>' +
+    '<w:docGrid w:type="lines" w:linePitch="360"/>' +
+    '</w:sectPr></w:body></w:document>';
+  return storedZip({
+    '[Content_Types].xml': contentTypes,
+    '_rels/.rels': rootRels,
+    'word/document.xml': document,
+  });
+}
+
+// Closing / line-head-forbidden marks (ECMA-376 §17.15.1.58 line-start set).
+const HEAD_FORBIDDEN = new Set(['、', '。', '」', '』', '，', '．', '・', '）', '｝', '］']);
+
+describe.skipIf(!skia || !docxMod || !rendererMod)(
+  'docx vertical line-head kinsoku (§17.6.20 + §17.15.1.58)',
+  () => {
+    it('never places closing punctuation at a column head', async () => {
+      const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
+      const { renderDocumentToCanvas } = rendererMod as Any;
+      const doc = parseDocx(verticalKinsokuDocx());
+      const canvas = new Canvas(Math.round(doc.section.pageWidth), Math.round(doc.section.pageHeight));
+      const runs: Any[] = [];
+      const rImg = installImageBitmapShim(factory);
+      const rOff = installOffscreenCanvasShim(factory);
+      try {
+        await renderDocumentToCanvas(doc, canvas, 0, {
+          dpr: 1,
+          width: doc.section.pageWidth,
+          onTextRun: (r: Any) => runs.push(r),
+        });
+      } finally {
+        rOff();
+        rImg();
+      }
+      // Group runs by physical column x; the column head is the run with the
+      // smallest physical y. Its first code point must not be a closing mark.
+      const byCol = new Map<number, Any[]>();
+      for (const r of runs) {
+        if (!r.text) continue;
+        const key = Math.round(r.x);
+        const arr = byCol.get(key) ?? [];
+        arr.push(r);
+        byCol.set(key, arr);
+      }
+      expect(byCol.size, 'text wrapped into several columns').toBeGreaterThan(3);
+      const heads: string[] = [];
+      for (const arr of byCol.values()) {
+        arr.sort((a, b) => a.y - b.y);
+        const head = (arr[0].text as string).charAt(0);
+        heads.push(head);
+      }
+      const violations = heads.filter((h) => HEAD_FORBIDDEN.has(h));
+      expect(violations, `no closing mark at any column head; heads=${heads.join('')}`).toEqual([]);
+    });
+  },
+);


### PR DESCRIPTION
Implements the tractable, ground-truth-gated portion of the issue #988 batch-3 vertical-text remainder. Each Word-exported fixture was measured (`pdftotext -bbox` / `pdftoppm`) and the rulings posted to #988; this PR ships the items whose fix is self-contained.

## What's in
- **Section-level `btLr` → vertical (§17.6.20, item ①).** Measured GT: Word renders a section-level `btLr` **identically to `tbRl`** (CJK upright top→bottom, Latin/digits sideways 90° CW, columns right→left) — it does not honor the nominal bottom-to-top / left-to-right flow. `isVerticalSection` now routes `btLr` through the same +90° path. A document whose body section is `btLr` renders vertically; the per-section mixing (a non-final `btLr` section beside a horizontal final section) needs per-section text-direction surfacing and is a follow-up.
- **Vertical-section header/footer render horizontally (§17.6.20 + §17.10.1, item ③).** Measured GT: a tbRl section keeps its header/footer **horizontal at the physical top/bottom margins, centred**, PAGE field horizontal + incrementing; the section direction does not propagate to them. Previously they were painted in the rotated logical space (vertical, footer off-page). Now they render in physical space via `physicalLayoutSection` (the inverse of `verticalLayoutSection`) with the ctx transform reset to physical and a horizontal state. Reserves stay 0 (physical top/bottom band ≠ logical body axis); `paginateWithHeaderFooterReserve` skips the reserve for vertical sections too, so pagination and paint agree even with asymmetric margins.
- **Vertical line-head kinsoku pin (§17.6.20 + §17.15.1.58, item ⑤, verify-only).** Confirmed correct-by-construction against GT (no closing punctuation `、。」` at any column head) and pinned with a synthetic-docx probe.

## Tests
- `packages/docx/src/vertical-header-footer.test.ts` — pure inverse-section mapping.
- `packages/node/src/docx-vertical-header-footer.probe.test.ts` — synthetic vertical docx: header/footer horizontal at physical top/bottom centred, body vertical, and pagination independent of header/footer under asymmetric margins.
- `packages/node/src/docx-btlr-vertical.probe.test.ts` — `btLr` section renders byte-identically to `tbRl`.
- `packages/node/src/docx-vertical-kinsoku.probe.test.ts` — no closing mark at any column head.

Full docx suite (1311) green; root typecheck clean. Horizontal path is byte-identical (verified: demo VRT diffs match the baseline render exactly). Independently reviewed by Codex (gpt-5.6-sol, high) read-only; its findings (pagination-reserve axis mismatch, test shim-restore ordering, layout-context `textDirection` cleanliness) are addressed.

## Deferred follow-ups (adjudicated, rulings on #988)
- **positionV under tbRl (item ②)** — GT: anchors resolve against the physical vertical axis, unrotated. Our shape/paragraph-relative anchor resolution under vertical is off (needs the shape-anchor physical path + physical `paraBaseY`).
- **Vertical table cell clip (item ④)** — GT: cells render horizontal text, fixed `tcW`→physical width, `trHeight exact`→clip, `auto`→grow; table block placement in a vertical section is Word-idiosyncratic.
- **Per-section `btLr`+horizontal in one document (item ①, mixed)** — needs per-section text-direction surfacing (parser + pagination + per-page rotation).

Refs #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
