### PR TITLE
feat(docx): mongolianVert, vertical ruby, upright text-box images (#988)

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -9576,11 +9576,17 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
     shape.textBlocks &&
     shape.textBlocks.length > 0 &&
     // §20.1.10.83 vertical text box: `measureShapeTextAutoFitHeight` grows the
-    // PHYSICAL HEIGHT to fit the horizontal line stack, but a vertical box grows
-    // its PHYSICAL WIDTH (the line-stacking axis is the cross axis after the ±90°
-    // rotation). Re-measuring here would grow the wrong axis, so vertical boxes
-    // keep their declared `<wp:extent>` (correct for the common explicit-extent
-    // case; cross-axis auto-grow is a follow-up — see `verticalTextboxMode`).
+    // PHYSICAL HEIGHT to fit the horizontal line stack, but a vertical box's
+    // block-progression (line-stacking) axis is the CROSS axis (physical WIDTH)
+    // after the ±90° rotation — that is the axis `<a:spAutoFit/>` resizes, NOT the
+    // height (Word-verified: the batch-3 GT / issue #988 shows the column-length
+    // = physical height stays the fixed wrap dimension). Re-measuring height here
+    // would grow the wrong axis. The GT also shows Word placing the columns at the
+    // box's AUTHORED `<wp:extent>` edges (a shrink-to-content cross fit would move
+    // the reading-start edge), so vertical boxes keep their declared extent — this
+    // reproduces the fixture exactly. Cross-axis auto-GROW for a box whose content
+    // overflows its authored cross extent remains a verify-only follow-up (needs a
+    // fixture that overflows AND carries a panel to disambiguate the anchored edge).
     verticalTextboxMode(shape.textVert) === null
   ) {
     const fitH = measureShapeTextAutoFitHeight(
@@ -9785,11 +9791,18 @@ function shapeTextHorizontalInsetsPx(shape: ShapeRun, scale: number): { lIns: nu
  *  directions (`<wps:bodyPr vert>`), or `null` for horizontal / not-yet-handled
  *  values. `eaVert` keeps East-Asian glyphs upright (per-glyph UAX#50); `vert`
  *  and `vert270` rotate EVERY glyph (their spec meaning), so the whole-box ±90°
- *  rotation already produces them with no per-glyph work. `mongolianVert`
- *  (top→bottom but lines L→R — not a pure rotation of the R→L frame) and the
- *  WordArt stacked variants are deferred and treated as horizontal. */
-function verticalTextboxMode(vert: string | null | undefined): 'vert' | 'vert270' | 'eaVert' | null {
-  return vert === 'vert' || vert === 'vert270' || vert === 'eaVert' ? vert : null;
+ *  rotation already produces them with no per-glyph work. `mongolianVert` shares
+ *  `eaVert`'s per-glyph orientation (CJK upright, Latin sideways) but stacks its
+ *  columns LEFT→RIGHT instead of right→left (Word-verified, the batch-3
+ *  adjudication fixtures / issue #988) — the renderer draws it exactly like
+ *  `eaVert` and then reflects each line's cross-position within the box (see
+ *  `mongolianLineFlip`). The WordArt stacked variants remain deferred (horizontal). */
+function verticalTextboxMode(
+  vert: string | null | undefined,
+): 'vert' | 'vert270' | 'eaVert' | 'mongolianVert' | null {
+  return vert === 'vert' || vert === 'vert270' || vert === 'eaVert' || vert === 'mongolianVert'
+    ? vert
+    : null;
 }
 
 /** Measure a shape text body's fitted height for `<a:spAutoFit/>`.
@@ -9975,22 +9988,34 @@ export function renderShapeText(
   //
   // Deferred (fall back to the horizontal draw of the affected element): a
   // shape's own `rotation` is not composed with the text-body rotation (already
-  // true before this change — the panel-rotation restore precedes this call), and
-  // an inline image inside a vertical text-box paragraph rotates with the frame
-  // rather than being uprighted like the section tbRl path — both are follow-ups.
+  // true before this change — the panel-rotation restore precedes this call).
   const vmode = verticalTextboxMode(shape.textVert);
-  const eaVertUpright = vmode === 'eaVert';
+  // §20.1.10.83 — East-Asian upright per-glyph orientation (CJK upright, non-EA
+  // rotated 90°): both `eaVert` and `mongolianVert`. They differ ONLY in the
+  // column-stacking direction, handled by `mongolianLineFlip` below.
+  const eaVertUpright = vmode === 'eaVert' || vmode === 'mongolianVert';
+  // §20.1.10.83 `mongolianVert` stacks columns LEFT→RIGHT — the MIRROR of the
+  // `eaVert`/`vert` R→L frame. It is not a pure rotation of that frame (chars stay
+  // top→bottom while lines reverse), so it reuses the +90° CW eaVert draw and then
+  // reflects each line's cross-position within the inner box (see the draw loop).
+  const mongolianLineFlip = vmode === 'mongolianVert';
+  // Sign of the page rotation: +1 for the +90° CW frames (vert/eaVert/
+  // mongolianVert), −1 for vert270's −90° frame. An UPRIGHT inline image must
+  // counter-rotate by `-rotSign * 90°` to cancel it (drawing it with the shared
+  // +90°-only `drawUprightBox` would leave a vert270 image at −180°, upside down).
+  const rotSign = vmode === 'vert270' ? -1 : 1;
   if (vmode) {
     const boxW = w;
     const boxH = h;
     ctx.save();
     ctx.translate(x + boxW / 2, y + boxH / 2);
-    // +90° (vert/eaVert): chars advance T→B (local +x → device +y), lines stack
-    // R→L (local +y → device −x, first line at the right edge). −90° (vert270):
-    // chars B→T, lines L→R (first line at the left edge). The swapped LOGICAL box
-    // — width = physical height (the column length), height = physical width (the
-    // line-stacking extent) — is drawn centred on the pivot.
-    ctx.rotate((vmode === 'vert270' ? -1 : 1) * (Math.PI / 2));
+    // +90° (vert/eaVert/mongolianVert): chars advance T→B (local +x → device +y),
+    // lines stack R→L (local +y → device −x, first line at the right edge; for
+    // mongolianVert the per-line cross reflection re-stacks them L→R). −90°
+    // (vert270): chars B→T, lines L→R (first line at the left edge). The swapped
+    // LOGICAL box — width = physical height (the column length), height = physical
+    // width (the line-stacking extent) — is drawn centred on the pivot.
+    ctx.rotate(rotSign * (Math.PI / 2));
     x = -boxH / 2;
     y = -boxW / 2;
     w = boxH;
@@ -10019,6 +10044,17 @@ export function renderShapeText(
   const innerW = Math.max(0, w - lIns - rIns);
   const innerY = y + tIns;
   const innerH = Math.max(0, h - tIns - bIns);
+
+  // §20.1.10.83 `mongolianVert` — reflect a block that occupies the cross-axis
+  // (line-stacking) interval `[top, top + extent]` about the inner box's cross
+  // centre, so its columns stack LEFT→RIGHT (device) instead of the eaVert R→L.
+  // The reflection moves ONLY the cross position; each line's own glyphs (drawn
+  // upright/sideways by drawVerticalRun, inline axis = local +x) are untouched, so
+  // the reading order within a column and the glyph orientation stay identical to
+  // eaVert — the batch-3 GT shows the label column at the box's physical LEFT and
+  // later columns to its right. Identity for every non-mongolian mode.
+  const flipBlockTop = (top: number, extent: number): number =>
+    mongolianLineFlip ? 2 * innerY + innerH - top - extent : top;
 
   // ECMA-376 §17.3.1.12 — per-paragraph indent (px). `leftPx`/`rightPx` shrink
   // the text column from the inner box edges; `firstPx` is the SIGNED first-line
@@ -10050,8 +10086,14 @@ export function renderShapeText(
   // line-box height + centred baseline (PR #640 discipline, computed over the
   // line's segments), and `baseRtl` is the paragraph base direction (§17.3.1.6
   // `<w:bidi>` when set, else first-strong of the block text).
+  // For a HORIZONTAL box `fitW`/`fitH` are the image's draw width/height and it
+  // reserves `fitH` down the block flow. For a VERTICAL box (§20.1.10.83) the
+  // image is drawn UPRIGHT (a graphic keeps its physical orientation — the
+  // batch-3 GT / issue #988), so `fitW`/`fitH` stay the PHYSICAL width/height and
+  // `crossExtent` (= physical width) is what it reserves along the column-stacking
+  // axis; the along-column placement uses `fitH` (physical height).
   type BlockLayout =
-    | { kind: 'image'; fitW: number; fitH: number; ind: BlockIndent }
+    | { kind: 'image'; fitW: number; fitH: number; crossExtent?: number; ind: BlockIndent }
     | {
         kind: 'text';
         lines: LayoutLine[];
@@ -10204,6 +10246,18 @@ export function renderShapeText(
   const layouts: BlockLayout[] = blocks.map((b) => {
     const ind = indentOf(b);
     if (b.imagePath) {
+      if (vmode) {
+        // §20.1.10.83 vertical box — draw the image UPRIGHT. The along-column
+        // available space is `firstLineW` (= the column-length axis in the swapped
+        // frame), so the image's PHYSICAL HEIGHT is fitted to it; the physical
+        // WIDTH is the cross (line-stacking) extent it reserves. `fitShapeImage`
+        // fits its first arg to the constraint, so pass (heightPt, widthPt) and
+        // read the fitted physical height/width back.
+        const fit = fitShapeImage(b.imageHeightPt ?? 0, b.imageWidthPt ?? 0, ind.firstLineW, scale);
+        const physH = fit.w; // fitted physical height (≤ column length)
+        const physW = fit.h; // physical width (cross extent)
+        return { kind: 'image', fitW: physW, fitH: physH, crossExtent: physW, ind };
+      }
       // The image occupies the FIRST line, so it fits to firstLineW (= paraW −
       // signed first-line indent), not the full inner width.
       const { w: fitW, h: fitH } = fitShapeImage(b.imageWidthPt ?? 0, b.imageHeightPt ?? 0, ind.firstLineW, scale);
@@ -10266,7 +10320,9 @@ export function renderShapeText(
     };
   });
   const blockHeight = (l: BlockLayout): number => {
-    if (l.kind === 'image') return l.fitH;
+    // A vertical box's upright image reserves its CROSS extent (physical width)
+    // along the column-stacking axis, not its `fitH` (physical height).
+    if (l.kind === 'image') return l.crossExtent ?? l.fitH;
     return l.lineHeights.reduce((s, h) => s + h, 0);
   };
   // ECMA-376 §17.3.1.33 — each text-box paragraph's own spaceBefore/After is
@@ -10334,6 +10390,37 @@ export function renderShapeText(
       const regionLeft = innerX + ind.leftPx + ind.firstPx;
       const regionW = ind.firstLineW;
       const bmp = block.imagePath ? images.get(imageKey(block.imagePath)) : undefined;
+      if (vmode) {
+        // §20.1.10.83 vertical box — draw the image UPRIGHT (a graphic keeps its
+        // physical orientation, matching the section-level tbRl image path and the
+        // batch-3 GT / issue #988). The image occupies one column: `fitH` is the
+        // physical height placed DOWN the column (along-column, local +x from
+        // regionLeft) and `crossExtent` (= physical width) is its extent across the
+        // stacking axis (local +y, reflected for mongolianVert). `drawUprightBox`
+        // counter-rotates −90° about the box centre so the +90° page rotation is
+        // cancelled and the raster paints in its native orientation.
+        const crossExt = layout.crossExtent ?? fitW;
+        const alongExt = fitH;
+        // Centre the image along its column region (paragraph alignment collapses
+        // to centred for a lone figure, matching the horizontal default).
+        let alongStart = regionLeft + Math.max(0, (regionW - alongExt) / 2);
+        if (block.alignment === 'left' || block.alignment === 'both') alongStart = regionLeft;
+        else if (block.alignment === 'right') alongStart = regionLeft + Math.max(0, regionW - alongExt);
+        const crossTop = flipBlockTop(cursorY, crossExt);
+        if (bmp) {
+          // Counter-rotate about the image-column centre by `-rotSign*90°` to
+          // cancel the page frame (drawUprightBox hardcodes −90°, correct only for
+          // the +90° modes; vert270 needs +90°). In the cancelled frame the image
+          // is upright with physical width = crossExt and physical height = alongExt.
+          ctx.save();
+          ctx.translate(alongStart + alongExt / 2, crossTop + crossExt / 2);
+          ctx.rotate((-rotSign * Math.PI) / 2);
+          ctx.drawImage(bmp, -crossExt / 2, -alongExt / 2, crossExt, alongExt);
+          ctx.restore();
+        }
+        cursorY += crossExt;
+        continue;
+      }
       if (bmp) {
         let drawX = regionLeft + Math.max(0, (regionW - fitW) / 2); // default: centered
         if (block.alignment === 'left' || block.alignment === 'both') {
@@ -10374,7 +10461,11 @@ export function renderShapeText(
         const isFirstLine = li === 0;
         const isLastLine = li === lineList.length - 1;
         const lineH = layout.lineHeights[li];
-        const baseline = cursorY + layout.baselineOffsets[li];
+        // §20.1.10.83 mongolianVert reflects the line's cross (stacking) position
+        // within the inner box (L→R columns); no-op for every other mode. The
+        // baseline keeps its offset from the (reflected) line top, so the glyphs
+        // sit inside the line box exactly as eaVert draws them.
+        const baseline = flipBlockTop(cursorY, lineH) + layout.baselineOffsets[li];
         // Per-line indented region (§17.3.1.12): content-left = innerX + leftPx,
         // shifted by the signed first-line indent on the first line; width =
         // firstLineW (first) / paraW (continuation).
@@ -10572,9 +10663,7 @@ export function renderShapeText(
             // path — so the segment advances by its NATURAL `measuredWidth` (the
             // width drawVerticalRun paints), NOT the justify/kashida-expanded
             // `internalStretch`, keeping paint==advance. A whole-line center/right
-            // `alignOffset` still applies via the starting `x`. Ruby and inline
-            // images inside an eaVert run are a follow-up (drawVerticalRun paints
-            // base glyphs only; vertical furigana placement is not yet ported).
+            // `alignOffset` still applies via the starting `x`.
             drawVerticalRun(
               ctx,
               s.text,
@@ -10584,6 +10673,46 @@ export function renderShapeText(
               segLetterSpacingPx(s, 0, scale),
               s.charScale ?? 1,
             );
+            // ECMA-376 §17.3.3.25 ruby (furigana) on a vertical text-box run. Word
+            // sets the annotation on the RIGHT side of the vertical base column
+            // (the batch-3 GT / issue #988): in the +90° CW frame the physical
+            // RIGHT is device +x, i.e. a SMALLER local +y than the base baseline.
+            // The GT cross offset (base-column centre → ruby-column centre) is
+            // effSize/2 + rubySize (≈ one base em when ruby is the usual half size).
+            // Each ruby glyph stands upright (kana ⇒ UAX#50 vo=U) and advances DOWN
+            // the column, distributed over the base segment's along-column span
+            // (rubyAlign="distributeSpace"); when the ruby run is wider than the
+            // base it is centred. Ruby shares the base glyph colour.
+            //
+            // MONORUBY em-cell model (JIS X 4051 §4): each ruby CODE POINT occupies
+            // one `rubyPx` cell along the column. This is exact for the furigana
+            // this path serves (upright kana, one square cell each) and matches
+            // Word's distributeSpace cell layout; it does not attempt per-advance
+            // shaping for the rare non-kana / proportional / combining-mark ruby
+            // (those would need measured advances — a follow-up, not seen in the GT).
+            if (s.ruby && s.ruby.text.length > 0) {
+              const rubyPx = s.ruby.fontSizePt * scale;
+              const rubyChars = [...s.ruby.text];
+              const spanAlong = s.measuredWidth;
+              const rubyCross = baseline + yOffset - (effSizePx / 2 + rubyPx);
+              const natural = rubyChars.length * rubyPx;
+              const along0 = natural <= spanAlong ? x : x + (spanAlong - natural) / 2;
+              const step = natural <= spanAlong ? spanAlong / rubyChars.length : rubyPx;
+              // ctx.save()/restore() preserves font/textAlign/textBaseline.
+              ctx.save();
+              ctx.font = buildFont(s.bold, s.italic, rubyPx, s.fontFamily, fontFamilyClasses);
+              ctx.textAlign = 'center';
+              ctx.textBaseline = 'middle';
+              for (let ri = 0; ri < rubyChars.length; ri++) {
+                const alongCenter = along0 + step * (ri + 0.5);
+                ctx.save();
+                ctx.translate(alongCenter, rubyCross);
+                ctx.rotate(-Math.PI / 2);
+                ctx.fillText(rubyChars[ri], 0, 0);
+                ctx.restore();
+              }
+              ctx.restore();
+            }
             x += s.measuredWidth;
             continue;
           }

--- a/packages/docx/src/textbox-vertical-render.test.ts
+++ b/packages/docx/src/textbox-vertical-render.test.ts
@@ -26,11 +26,26 @@ interface GlyphCall {
   devY: number;
 }
 
+interface ImageCall {
+  /** Net rotation of the drawn image in device space, degrees (atan2(b,a)). */
+  angleDeg: number;
+  /** Device-space position of the draw origin (local (x,y) mapped by the CTM). */
+  devX: number;
+  devY: number;
+  /** Local draw width/height (before the CTM). */
+  w: number;
+  h: number;
+}
+
 /** Recording 2D context that tracks the full affine CTM (a,b,c,d,e,f) across
  *  save/restore/translate/rotate/scale, so a glyph's net orientation is
  *  recoverable at fillText time. measureText gives every code point the current
  *  font px as advance (1 em / CJK), with symmetric font/ink boxes. */
-function makeMatrixCtx(): { ctx: CanvasRenderingContext2D; glyphs: GlyphCall[] } {
+function makeMatrixCtx(): {
+  ctx: CanvasRenderingContext2D;
+  glyphs: GlyphCall[];
+  images: ImageCall[];
+} {
   let m = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
   const stack: (typeof m)[] = [];
   let font = '10px serif';
@@ -41,6 +56,7 @@ function makeMatrixCtx(): { ctx: CanvasRenderingContext2D; glyphs: GlyphCall[] }
   let direction = 'ltr';
   let fontKerning = 'auto';
   const glyphs: GlyphCall[] = [];
+  const images: ImageCall[] = [];
   const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
   const ctx = {
     get font() { return font; },
@@ -99,9 +115,14 @@ function makeMatrixCtx(): { ctx: CanvasRenderingContext2D; glyphs: GlyphCall[] }
       glyphs.push({ text, angleDeg, devX, devY });
     },
     strokeText() {},
-    drawImage() {},
+    drawImage(_bmp: unknown, x: number, y: number, w: number, h: number) {
+      const angleDeg = (Math.atan2(m.b, m.a) * 180) / Math.PI;
+      const devX = m.a * x + m.c * y + m.e;
+      const devY = m.b * x + m.d * y + m.f;
+      images.push({ angleDeg, devX, devY, w, h });
+    },
   };
-  return { ctx: ctx as unknown as CanvasRenderingContext2D, glyphs };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, glyphs, images };
 }
 
 function richTextbox(
@@ -233,5 +254,142 @@ describe('§20.1.10.83 textbox <wps:bodyPr vert> — vertical text-box rendering
     // right of centre, line 2 left. vert270: L→R, mirrored.
     expect(gv[0].devX).toBeGreaterThan(gv[gv.length - 1].devX);
     expect(g270[0].devX).toBeLessThan(g270[g270.length - 1].devX);
+  });
+
+  // ── (a) mongolianVert (§20.1.10.83) ──────────────────────────────────────
+  // GT (batch-3 adjudication): identical per-glyph orientation to eaVert (CJK
+  // UPRIGHT, Latin sideways 90° CW), but the line/column progression is the
+  // MIRROR of eaVert — columns advance LEFT→RIGHT instead of right→left.
+  it('mongolianVert: CJK upright (0°) while Latin stays sideways (+90°) — same as eaVert', () => {
+    const { ctx, glyphs } = makeMatrixCtx();
+    renderShapeText(richTextbox([run(CJK), run(LAT)], 'mongolianVert'), 0, 0, 200, 100, ctx, 1, {});
+    const cjk = glyphs.find((g) => g.text.includes(CJK));
+    const lat = glyphs.find((g) => g.text.includes(LAT));
+    expect(cjk, 'CJK glyph drawn').toBeDefined();
+    expect(lat, 'Latin glyph drawn').toBeDefined();
+    expect(NEAR(norm(cjk!.angleDeg), 0), `CJK @${cjk!.angleDeg}`).toBe(true);
+    expect(NEAR(norm(lat!.angleDeg), 90), `Latin @${lat!.angleDeg}`).toBe(true);
+  });
+
+  it('mongolianVert stacks columns LEFT→RIGHT (mirror of eaVert R→L)', () => {
+    // Two blocks (two columns). eaVert puts the first column on the RIGHT and the
+    // second to its left; mongolianVert mirrors it — first column on the LEFT,
+    // second to its right.
+    const twoCols = (v: string) => {
+      const { ctx, glyphs } = makeMatrixCtx();
+      const block2: ShapeText = { text: CJK, fontSizePt: 10, alignment: 'left', runs: [run(CJK)] };
+      const shape = richTextbox([run(CJK)], v);
+      (shape as unknown as { textBlocks: ShapeText[] }).textBlocks.push(block2);
+      renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {});
+      return glyphs;
+    };
+    const ea = twoCols('eaVert');
+    const mn = twoCols('mongolianVert');
+    // eaVert: first column right of the last. mongolianVert: first column LEFT.
+    expect(ea[0].devX).toBeGreaterThan(ea[ea.length - 1].devX);
+    expect(mn[0].devX, `mongolianVert first col @${mn[0].devX} < last @${mn[mn.length - 1].devX}`)
+      .toBeLessThan(mn[mn.length - 1].devX);
+  });
+
+  // ── (b) eaVert + ruby (§17.3.3.25) ───────────────────────────────────────
+  // GT: furigana sits on the RIGHT side of the vertical base column, upright,
+  // running top→bottom. In the +90° CW frame the physical RIGHT is device +x.
+  it('eaVert ruby draws furigana upright on the device-RIGHT of the base column', () => {
+    const { ctx, glyphs } = makeMatrixCtx();
+    const baseRun: ShapeTextRun = {
+      text: '漢字',
+      fontSizePt: 10,
+      fontFamily: 'NotInMetrics',
+      ruby: { text: 'かんじ', fontSizePt: 5 },
+    };
+    renderShapeText(richTextbox([baseRun], 'eaVert'), 0, 0, 200, 100, ctx, 1, {});
+    const base = glyphs.filter((g) => /[漢字]/.test(g.text));
+    const ruby = glyphs.filter((g) => /[かんじ]/.test(g.text));
+    expect(base.length, 'base glyphs drawn').toBeGreaterThan(0);
+    expect(ruby.length, 'ruby glyphs drawn').toBe(3);
+    // Ruby stands upright (net 0°), like the upright CJK base cells.
+    for (const r of ruby) expect(NEAR(norm(r.angleDeg), 0), `ruby ${r.text}@${r.angleDeg}`).toBe(true);
+    // Physical RIGHT = device +x: every ruby glyph is right of every base glyph.
+    const baseMaxX = Math.max(...base.map((g) => g.devX));
+    const rubyMinX = Math.min(...ruby.map((g) => g.devX));
+    expect(rubyMinX, `ruby minX ${rubyMinX} > base maxX ${baseMaxX}`).toBeGreaterThan(baseMaxX);
+    // Exact cross offset: base fontSize 10 (cell centred on the column baseline),
+    // ruby fontSize 5 ⇒ ruby column centre = baseline − (effSize/2 + rubySize) =
+    // baseline − 10, which maps to device +10 (the physical right). Base and ruby
+    // sit on constant device-x per column, so the mean difference isolates the
+    // cross offset.
+    const meanBaseX = base.reduce((s, g) => s + g.devX, 0) / base.length;
+    const meanRubyX = ruby.reduce((s, g) => s + g.devX, 0) / ruby.length;
+    expect(meanRubyX - meanBaseX, `cross offset ${meanRubyX - meanBaseX} ≈ effSize/2+rubySize=10`)
+      .toBeCloseTo(10, 0);
+  });
+
+  // ── (c) vert + inline image: image stays UPRIGHT ─────────────────────────
+  // GT: the inline raster keeps its physical orientation (a graphic is not text),
+  // even though the surrounding `vert` glyphs rotate 90° CW.
+  it('vert inline image is drawn UPRIGHT (net 0°), not rotated with the text frame', () => {
+    const { ctx, images } = makeMatrixCtx();
+    const imgBlock: ShapeText = {
+      text: '', fontSizePt: 10, alignment: 'left',
+      imagePath: 'word/media/image1.png', imageWidthPt: 24, imageHeightPt: 36,
+    } as unknown as ShapeText;
+    const shape = richTextbox([{ text: CJK, fontSizePt: 10, fontFamily: 'NotInMetrics' }], 'vert');
+    (shape as unknown as { textBlocks: ShapeText[] }).textBlocks.push(imgBlock);
+    const fakeBmp = { width: 24, height: 36 } as unknown as ImageBitmap;
+    const imgs = new Map<string, ImageBitmap>([['word/media/image1.png', fakeBmp]]);
+    renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {}, imgs as never);
+    expect(images.length, 'one image drawn').toBe(1);
+    // Upright: the net rotation cancels the +90° page frame → 0°.
+    expect(NEAR(norm(images[0].angleDeg), 0), `image @${images[0].angleDeg}`).toBe(true);
+    // Portrait aspect preserved (physical 24×36, not swapped to 36×24). The draw
+    // dimensions in the upright local frame are width=physical-width,
+    // height=physical-height (the callback receives dw=cross, dh=along).
+    expect(Math.abs(images[0].w)).toBeCloseTo(24, 3);
+    expect(Math.abs(images[0].h)).toBeCloseTo(36, 3);
+  });
+
+  it('vert270 inline image is ALSO drawn upright (net 0°), not −180° (counter-rotation sign)', () => {
+    // vert270's page frame is −90°, so the image counter-rotation must be +90°
+    // (not the −90° the +90° modes use) — otherwise the raster is flipped 180°.
+    const { ctx, images } = makeMatrixCtx();
+    const imgBlock: ShapeText = {
+      text: '', fontSizePt: 10, alignment: 'left',
+      imagePath: 'word/media/image1.png', imageWidthPt: 24, imageHeightPt: 36,
+    } as unknown as ShapeText;
+    const shape = richTextbox([{ text: CJK, fontSizePt: 10, fontFamily: 'NotInMetrics' }], 'vert270');
+    (shape as unknown as { textBlocks: ShapeText[] }).textBlocks.push(imgBlock);
+    const fakeBmp = { width: 24, height: 36 } as unknown as ImageBitmap;
+    const imgs = new Map<string, ImageBitmap>([['word/media/image1.png', fakeBmp]]);
+    renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {}, imgs as never);
+    expect(images.length).toBe(1);
+    expect(NEAR(norm(images[0].angleDeg), 0), `vert270 image @${images[0].angleDeg}`).toBe(true);
+  });
+
+  it('vertical inline image reserves its physical WIDTH (crossExtent), not its height, along the column stack', () => {
+    // Two CJK text columns sandwich the image column; their cross (device-x)
+    // separation = text-line-box + the image's reserved cross extent. A tall-thin
+    // image (10 wide × 90 tall) reserves its physical WIDTH 10 (crossExtent) — the
+    // fitH-vs-crossExtent bug would instead reserve its 90-tall height, pushing the
+    // trailing column ~80px further, so the separation cleanly distinguishes them.
+    const { ctx, glyphs } = makeMatrixCtx();
+    const imgBlock: ShapeText = {
+      text: '', fontSizePt: 10, alignment: 'left',
+      imagePath: 'word/media/image1.png', imageWidthPt: 10, imageHeightPt: 90,
+    } as unknown as ShapeText;
+    const shape = richTextbox([{ text: CJK, fontSizePt: 10, fontFamily: 'NotInMetrics' }], 'vert');
+    const tb = shape as unknown as { textBlocks: ShapeText[] };
+    tb.textBlocks.push(imgBlock);
+    tb.textBlocks.push({ text: CJK, fontSizePt: 10, alignment: 'left', runs: [run(CJK)] } as ShapeText);
+    const fakeBmp = { width: 10, height: 90 } as unknown as ImageBitmap;
+    const imgs = new Map<string, ImageBitmap>([['word/media/image1.png', fakeBmp]]);
+    renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {}, imgs as never);
+    const cjk = glyphs.filter((g) => g.text.includes(CJK));
+    const firstCol = cjk[0].devX;
+    const lastCol = cjk[cjk.length - 1].devX;
+    const sep = Math.abs(firstCol - lastCol);
+    // Separation ≈ one text line box (~10-14) + image cross 10 ≈ 20-30. With the
+    // bug (reserving the 90 height) it would exceed 90. Assert well below 90.
+    expect(sep, `two-column separation ${sep} reflects image cross 10, not height 90`).toBeLessThan(45);
+    expect(sep, `columns are actually separated ${sep}`).toBeGreaterThan(12);
   });
 });


### PR DESCRIPTION
## Summary

Implements the ground-truth-gated §20.1.10.83 `ST_TextVerticalType` **text-box**
follow-ups carved out in #988 (`<wps:bodyPr vert>`), adjudicated from a Word PDF
export of the batch-3 adjudication fixtures. Horizontal text and the existing
`vert`/`vert270`/`eaVert` text paths stay **byte-identical** — every new branch
gates on the vertical mode, on `ruby`, or on an image block.

## Adjudicated behaviour → implementation

- **(a) `mongolianVert`** — same per-glyph orientation as `eaVert` (East-Asian
  glyphs upright, Latin rotated 90° CW) but columns stack **LEFT→RIGHT** (mirror
  of `eaVert`). It is a reflection of the `eaVert` frame, not a pure rotation, so
  the renderer reuses the +90° CW `eaVert` draw and reflects each line's cross
  (block-stacking) position within the inner box (`mongolianLineFlip` /
  `flipBlockTop`). `verticalTextboxMode` now recognises it.
- **(b) `eaVert` + ruby (§17.3.3.25)** — furigana on the physical **RIGHT** of the
  vertical base column, upright, half-size, distributed over the base span
  (`rubyAlign="distributeSpace"`, monoruby em-cell placement). Cross offset =
  `effSize/2 + rubySize`. Ruby was previously unpainted in a vertical box.
- **(c) vertical box + inline image** — the raster is drawn **UPRIGHT** (a graphic
  keeps its physical orientation, like the section-level tbRl image path),
  reserving its physical **width** as the column-stacking (cross) extent. The
  upright counter-rotation is direction-aware (`-rotSign·90°`) so a `vert270`
  box's image is not left upside-down.
- **(d) `eaVert` + `spAutoFit`** — adjudication recorded in code: the resize axis
  is the **cross axis (physical width)**; the column-length (physical height) is
  the fixed wrap dimension. Word places the columns at the authored `<wp:extent>`
  edges, so vertical boxes keep their declared extent (already reproduces the GT).
  Cross-axis auto-*grow* for an overflowing box stays a documented verify-only
  follow-up.

## Verification

- docx `vitest`: **1317 pass**, including new `mongolianVert` /
  vertical-ruby / upright-image / `vert270`-image tests.
- root `tsc --build`: clean.
- docx VRT: **85/85**, non-regressing (private baseline + committed
  `demo/sample-1`), references untouched.
- The fixture render was compared region-by-region against the Word PDF for all
  four boxes (glyph orientation, column direction, ruby side, image uprighting).
- An independent Codex (gpt-5.6-sol) review caught the `vert270` image
  counter-rotation sign; fixed and covered by a test.

Refs #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
