### PR TITLE
docx: vertical-section positionV anchors on the physical page + upright table cells (#988 ②/④)

### DIFF
--- a/packages/docx/src/anchor-vertical-shape-physical.test.ts
+++ b/packages/docx/src/anchor-vertical-shape-physical.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import {
+  __test_resolveAnchorBox,
+  __test_resolveShapeBox,
+  __test_verticalLayoutSection,
+  computePages,
+  type RenderState,
+} from './renderer.js';
+import type { BodyElement, DocParagraph, ImageRun, SectionProps, ShapeRun } from './types.js';
+
+// ECMA-376 §17.6.20 (tbRl) + §20.4.3.x — issue #988 batch-3 adjudication ②:
+// `positionH`/`positionV` anchors in a VERTICAL section resolve against the
+// PHYSICAL (un-rotated) page, on the physical vertical axis, increasing
+// downward — independent of the section text direction. `paragraph`-relative
+// vertical anchors resolve from the PHYSICAL TOP of the anchor paragraph's
+// column (the top content margin for a single-column body), NOT from the
+// paragraph's logical flow position.
+//
+// Ground truth = the batch-3 positionV fixture's Word PDF (Letter portrait
+// 612×792 pt, 1 in margins, three identical anchored rectangles):
+//
+//   | relativeFrom | posOffset       | measured physical box top |
+//   |--------------|-----------------|---------------------------|
+//   | page         | 3.0 in (216 pt) | y = 216                   |
+//   | margin       | 1.5 in (108 pt) | y = 72 + 108 = 180        |
+//   | paragraph    | 0.3 in (21.6pt) | y = 72 + 21.6 = 93.6      |
+//
+// positionH is `page`-relative in all three (72 / 230.4 / 388.8 pt), and the
+// physical x equals the raw offset. The shapes are 100.8 × 86.4 pt.
+
+const PHYS_W = 612;
+const PHYS_H = 792;
+const MARGIN = 72;
+
+// Vertical RenderState: LOGICAL (swapped) geometry + `verticalPhys`. The
+// logical frame of a portrait Letter tbRl page: logical width = physical
+// height, margins rotated one quarter-turn (verticalLayoutSection). contentX
+// is the current column band start in LOGICAL x — its physical image is the
+// column's physical TOP (72 = the top content margin), which is what a
+// paragraph-relative positionV anchors from.
+const verticalState = {
+  scale: 1,
+  pageWidth: PHYS_H,
+  marginLeft: MARGIN, // logical left = physical top
+  marginRight: MARGIN, // logical right = physical bottom
+  marginTop: MARGIN, // logical top = physical right
+  marginBottom: MARGIN, // logical bottom = physical left
+  pageH: PHYS_W, // logical height (px) = physical width
+  contentX: MARGIN, // column band start (logical x) ⇒ physical column top
+  contentW: PHYS_H - 2 * MARGIN,
+  verticalCJK: true,
+  verticalPhys: {
+    pageWidth: PHYS_W,
+    pageHeight: PHYS_H,
+    marginLeft: MARGIN,
+    marginRight: MARGIN,
+    marginTop: MARGIN,
+    marginBottom: MARGIN,
+    cssWidthPx: PHYS_W,
+  },
+} as unknown as RenderState;
+
+const SHAPE_W = 100.8;
+const SHAPE_H = 86.4;
+
+function rectShape(
+  xPt: number,
+  yPt: number,
+  yRelativeFrom: string,
+): ShapeRun {
+  return {
+    widthPt: SHAPE_W,
+    heightPt: SHAPE_H,
+    anchorXPt: xPt,
+    anchorYPt: yPt,
+    anchorXFromMargin: false,
+    anchorYFromPara: yRelativeFrom === 'paragraph',
+    anchorXRelativeFrom: 'page',
+    anchorYRelativeFrom: yRelativeFrom,
+    zOrder: 0,
+    subpaths: [],
+    presetGeometry: 'rect',
+    fill: null,
+    stroke: null,
+    wrapMode: 'none',
+  } as unknown as ShapeRun;
+}
+
+/** Invert the logical projection back to the physical frame: the page paint
+ *  transform is `physical = (cssW − logical.y, logical.x)`, so a logical box
+ *  `{x, y, w, h}` images the physical box
+ *  `{x: cssW − (y + h), y: x, w: h, h: w}`. */
+function toPhysical(
+  box: { x: number; y: number; w: number; h: number },
+  cssW: number,
+): { x: number; y: number; w: number; h: number } {
+  return { x: cssW - (box.y + box.h), y: box.x, w: box.h, h: box.w };
+}
+
+// A deliberately WRONG logical flow-Y for the anchor paragraph: the physical
+// resolution must anchor paragraph-relative offsets from the column's PHYSICAL
+// top (state.contentX), never from this logical coordinate.
+const LOGICAL_PARA_TOP = 500;
+
+describe('resolveShapeBox — vertical (tbRl) physical anchor mapping (§20.4.3.x, #988 ②)', () => {
+  it.each([
+    ['page', 388.8, 216, 216],
+    ['margin', 230.4, 108, MARGIN + 108],
+    ['paragraph', 72, 21.6, MARGIN + 21.6],
+  ] as const)(
+    'positionV relativeFrom=%s resolves on the physical vertical axis',
+    (rf, xPt, yPt, expectedPhysTop) => {
+      const box = __test_resolveShapeBox(
+        rectShape(xPt, yPt, rf),
+        verticalState,
+        LOGICAL_PARA_TOP,
+      );
+      const phys = toPhysical(box, PHYS_W);
+      expect(phys.x).toBeCloseTo(xPt, 1);
+      expect(phys.y).toBeCloseTo(expectedPhysTop, 1);
+      expect(phys.w).toBeCloseTo(SHAPE_W, 4);
+      expect(phys.h).toBeCloseTo(SHAPE_H, 4);
+    },
+  );
+
+  it('returns the logical-projected box (w↔h swap) so the flow band matches', () => {
+    const box = __test_resolveShapeBox(
+      rectShape(388.8, 216, 'page'),
+      verticalState,
+      LOGICAL_PARA_TOP,
+    );
+    // logical x = physical y; logical y = cssW − (px + w); w/h swapped.
+    expect(box.x).toBeCloseTo(216, 4);
+    expect(box.y).toBeCloseTo(PHYS_W - (388.8 + SHAPE_W), 4);
+    expect(box.w).toBeCloseTo(SHAPE_H, 4);
+    expect(box.h).toBeCloseTo(SHAPE_W, 4);
+  });
+});
+
+// ── Pagination/paint agreement (Codex review F1) ───────────────────────────
+// The PAGINATOR's float registration must resolve a wrapped anchored shape
+// through the SAME physical projection the paint pass uses — its measure state
+// carries `verticalPhys` — otherwise a `topAndBottom` band is reserved at the
+// raw logical rectangle and page assignment diverges from the painted layout.
+
+function testParagraph(text: string, runs?: unknown[]): DocParagraph {
+  return {
+    alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: runs ?? [{
+      type: 'text', text,
+      bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+      isLink: false, background: null, vertAlign: null, hyperlink: null,
+    }],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman',
+    widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+function makeMeasureCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx: Record<string, unknown> = {
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, rect() {}, clip() {},
+    scale() {}, translate() {}, rotate() {}, setTransform() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left', direction: 'ltr', globalAlpha: 1, lineCap: 'butt', lineJoin: 'miter',
+  };
+  Object.defineProperty(ctx, 'font', { get: () => font, set: (v: string) => { font = v; } });
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+describe('computePages — vertical wrapped-shape band uses the physical projection (#988 ②, F1)', () => {
+  it('a topAndBottom shape displaces the flow by its LOGICAL projection (physical width)', () => {
+    // Physical portrait 200×300, margins T20 R30 B40 L24 ⇒ logical flow starts
+    // at y=30 and ends at 30+146=176 (insets 30/24 on the 200 pt flow axis).
+    const phys = {
+      pageWidth: 200, pageHeight: 300,
+      marginTop: 20, marginRight: 30, marginBottom: 40, marginLeft: 24,
+      headerDistance: 0, footerDistance: 0,
+      titlePage: false, evenAndOddHeaders: false,
+      textDirection: 'tbRl',
+    } as unknown as SectionProps;
+    // Physical box (40, 40)–(155, 60): logical projection y ∈ [45, 160]
+    // (cssW − px − w = 45), a 115 pt-tall topAndBottom band. The RAW logical
+    // rectangle would be y ∈ [40, 60] — only 20 pt tall.
+    const shape = {
+      type: 'shape',
+      widthPt: 115,
+      heightPt: 20,
+      anchorXPt: 40,
+      anchorYPt: 40,
+      anchorXFromMargin: false,
+      anchorYFromPara: false,
+      anchorXRelativeFrom: 'page',
+      anchorYRelativeFrom: 'page',
+      wrapMode: 'topAndBottom',
+      zOrder: 0,
+      subpaths: [],
+      presetGeometry: 'rect',
+      fill: null,
+      stroke: null,
+    };
+    const body = [
+      { type: 'paragraph', ...testParagraph('', [
+        { type: 'text', text: 'zz', bold: false, italic: false, underline: false, strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman', isLink: false, background: null, vertAlign: null, hyperlink: null },
+        shape,
+      ]) },
+      { type: 'paragraph', ...testParagraph('qq') },
+      { type: 'paragraph', ...testParagraph('ww') },
+    ] as unknown as BodyElement[];
+    const pages = computePages(
+      body, __test_verticalLayoutSection(phys), makeMeasureCtx(),
+      { 'Times New Roman': 'roman' },
+    );
+    // With the PHYSICAL projection the band ends at logical y=160: the two
+    // following one-line (~11.5 pt) paragraphs are pushed to ~160–171.5 and
+    // ~171.5–183 — the second crosses the 176 flow bottom onto page 2. With
+    // the raw logical band ([40, 60]) they sit at ~60–83 and fit page 1.
+    expect(pages.length).toBe(2);
+  });
+});
+
+describe('resolveAnchorBox — paragraph-relative positionV under tbRl (§20.4.3.5, #988 ②)', () => {
+  it('anchors from the physical top of the paragraph column, not the logical flow y', () => {
+    const img: ImageRun = {
+      imagePath: 'word/media/image1.png',
+      mimeType: 'image/png',
+      widthPt: SHAPE_W,
+      heightPt: SHAPE_H,
+      anchor: true,
+      wrapMode: 'none',
+      anchorXPt: 72,
+      anchorYPt: 21.6,
+      anchorXRelativeFrom: 'page',
+      anchorYRelativeFrom: 'paragraph',
+      anchorXFromMargin: false,
+      anchorYFromPara: true,
+    } as unknown as ImageRun;
+    const box = __test_resolveAnchorBox(img, verticalState, LOGICAL_PARA_TOP);
+    const phys = toPhysical(box, PHYS_W);
+    expect(phys.x).toBeCloseTo(72, 1);
+    expect(phys.y).toBeCloseTo(MARGIN + 21.6, 1); // 93.6 — Word GT
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2123,6 +2123,10 @@ export function computePages(
     fontFamilyClasses,
     documentSettings,
   );
+  // ECMA-376 §17.6.20 — whether this pagination lays out a vertical (tbRl)
+  // section (`section` here is the SWAPPED logical geometry, textDirection
+  // preserved). Horizontal sections are untouched (`verticalUpright` false).
+  const verticalUpright = isVerticalSection(section);
   const noteById = indexNotes(footnotes);
   const haveFootnotes = noteById.size > 0;
   // Per-page reserved footnote height (pt). Index 0 = first page. Grows as
@@ -2570,6 +2574,13 @@ export function computePages(
   // are pinned regardless of which page the anchor lands on, so they never
   // trigger a break). Measured at scale 1 (pt), matching the paginator's `y`.
   const anchoredFloatBottomOffset = (para: DocParagraph): number => {
+    // §17.6.20 + #988 ② — in a vertical section positionV offsets live on the
+    // PHYSICAL vertical axis (the column-length axis), not the flow axis: a
+    // paragraph-anchored float never extends the logical flow by its offset,
+    // so the horizontal keep-on-page displacement below does not map. (The
+    // physical-axis analogue — a float overflowing the physical bottom — is
+    // un-adjudicated and left to the anchor clamp.)
+    if (verticalUpright) return 0;
     let maxBottom = 0;
     for (const run of para.runs) {
       if (run.type === 'image') {
@@ -4050,6 +4061,31 @@ function buildMeasureState(
     balanceSingleByteDoubleByteWidth:
       layoutSettings.compat.balanceSingleByteDoubleByteWidth,
     showTrackChanges: false,
+    // ECMA-376 §17.6.20 + §20.4.3.x (issue #988 ②, Codex review F1): for a
+    // vertical (tbRl) section — `section` is the SWAPPED logical geometry — the
+    // measure pass must resolve DrawingML anchors against the same PHYSICAL
+    // page the paint pass uses (`resolveAnchorBox`/`resolveShapeBox` key their
+    // physical branch on `verticalPhys`), otherwise a wrapped shape's exclusion
+    // band is reserved at the raw logical rectangle during pagination while the
+    // paint wraps around the physical projection — diverging page assignment.
+    // Mirrors the paint-state seed (renderDocumentToCanvas), un-swapping via
+    // physicalLayoutSection; `cssWidthPx` at the paginator's scale 1 is the
+    // physical page width in pt. `verticalCJK` stays UNSET: the measure pass
+    // keeps its horizontal glyph metrics (only anchor geometry re-frames).
+    verticalPhys: isVerticalSection(section)
+      ? (() => {
+          const phys = physicalLayoutSection(section);
+          return {
+            pageWidth: phys.pageWidth,
+            pageHeight: phys.pageHeight,
+            marginLeft: phys.marginLeft,
+            marginRight: phys.marginRight,
+            marginTop: bodyMarginInsetPt(phys.marginTop),
+            marginBottom: bodyMarginInsetPt(phys.marginBottom),
+            cssWidthPx: phys.pageWidth,
+          };
+        })()
+      : undefined,
   };
 }
 
@@ -9411,6 +9447,28 @@ function resolveShapeBox(
   state: RenderState,
   paragraphTopPx: number,
 ): { x: number; y: number; w: number; h: number } {
+  // ECMA-376 §17.6.20 + §20.4.3.x (issue #988 batch-3 adjudication ②): on a
+  // vertical (tbRl) page an anchored shape's positionH/V resolve against the
+  // PHYSICAL (un-rotated) page — the drawing layer is independent of the
+  // section text direction, exactly like the image path (resolveAnchorBox).
+  // Resolve in the physical frame, then project into the swapped logical
+  // layout frame (w↔h swapped) so the float-exclusion band and the flow all
+  // share one geometry. A `paragraph`/`line`-relative positionV anchors from
+  // the PHYSICAL TOP of the anchor paragraph's COLUMN (Word GT: margin-top +
+  // posOffset for a single-column body) — that physical y is the column
+  // band's logical x start (`state.contentX`, since physical y = logical x
+  // under the +90° page paint), NOT the paragraph's logical flow
+  // `paragraphTopPx`, which lies on the column-progression axis.
+  if (state.verticalPhys) {
+    const phys = resolveShapeBox(
+      shape,
+      verticalPhysicalContentState(state),
+      state.contentX,
+    );
+    return physicalToLogicalAnchorBox(
+      phys.x, phys.y, phys.w, phys.h, state.verticalPhys.cssWidthPx,
+    );
+  }
   const { scale } = state;
   // ECMA-376 §20.4.2.18: when wp14:sizeRelH/sizeRelV is present it overrides
   // the static wp:extent for that axis. The size is `relativeFrom` container
@@ -9531,6 +9589,29 @@ export function drawWatermarkTextPath(
 }
 
 function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: number): void {
+  // ECMA-376 §17.6.20 + §20.4.3.x (issue #988 batch-3 adjudication ②): on a
+  // vertical (tbRl) page an anchored shape stays UPRIGHT at its physical-page
+  // position — the drawing layer does not rotate with the text flow, and a
+  // horizontal (`vert="horz"`) text body keeps horizontal labels. Undo the +90°
+  // page paint (its exact inverse: rotate −90° then translate(−cssW, 0), the
+  // same physical frame the header/footer path re-enters) and re-run this
+  // renderer with the PHYSICAL state view: `resolveShapeBox` then resolves the
+  // physical box directly, text draws horizontally (verticalCJK off), and the
+  // overlay geometry is emitted unrotated at physical coordinates. The physical
+  // paragraph base for a `paragraph`-relative positionV is the column's
+  // physical top = the column band's logical x (`state.contentX`), matching
+  // resolveShapeBox's logical-projection branch so the float band (registered
+  // from the LOGICAL projection) and the painted shape share one geometry.
+  if (state.verticalPhys) {
+    const cssW = state.verticalPhys.cssWidthPx;
+    const { ctx } = state;
+    ctx.save();
+    ctx.rotate(-Math.PI / 2);
+    ctx.translate(-cssW, 0);
+    renderAnchorShape(shape, verticalPhysicalContentState(state), state.contentX);
+    ctx.restore();
+    return;
+  }
   const { ctx, scale } = state;
   let { x, y, w, h } = resolveShapeBox(shape, state, paragraphTopPx);
   // Line/connector presets (ECMA-376 §20.1.9.18) are valid with a degenerate
@@ -10868,6 +10949,16 @@ export const __test_resolveAnchorBox = (
 ): { x: number; y: number; w: number; h: number; dl: number; dr: number; dt: number; db: number } =>
   resolveAnchorBox(img, state, paraBaseY);
 
+/** Exported for the vertical shape-anchor test (ECMA-376 §17.6.20 + §20.4.3.x,
+ *  issue #988 ②): pins the physical-page resolution (and logical projection) of
+ *  an anchored SHAPE's positionH/V on a vertical (tbRl) page. */
+export const __test_resolveShapeBox = (
+  shape: ShapeRun,
+  state: RenderState,
+  paragraphTopPx: number,
+): { x: number; y: number; w: number; h: number } =>
+  resolveShapeBox(shape, state, paragraphTopPx);
+
 /** Exported for the vertical header/footer test (ECMA-376 §17.6.20 + §17.10.1,
  *  issue #988): pins the inverse-of-`verticalLayoutSection` page/margin mapping a
  *  vertical section's HORIZONTAL header/footer are laid out in. */
@@ -10991,6 +11082,32 @@ function physicalAnchorState(state: RenderState): RenderState {
   };
 }
 
+/** ECMA-376 §17.6.20 + §20.4.3.x (issue #988 ②/④) — a RenderState view whose
+ *  geometry AND text flags are PHYSICAL, for content that stays UPRIGHT inside a
+ *  vertical (tbRl) section: anchored shapes and block tables. Word resolves and
+ *  paints these against the un-rotated physical page — cell/label text is
+ *  horizontal — so on top of {@link physicalAnchorState}'s page/margin un-swap
+ *  this view also re-points the content band at the physical margins and clears
+ *  the vertical flags (no per-glyph counter-rotation, no +90° text-layer
+ *  transform, `resolveShapeBox`/`resolveAnchorBox` take their horizontal path).
+ *  `floats` is fresh: the live float set is in LOGICAL flow coordinates and must
+ *  not leak into a physical-frame layout (and vice-versa). `deferFront` is
+ *  cleared so a nested front float paints in place, inside the counter-rotated
+ *  physical frame its geometry was resolved in. */
+function verticalPhysicalContentState(state: RenderState): RenderState {
+  const p = state.verticalPhys;
+  if (!p) return state;
+  return {
+    ...physicalAnchorState(state),
+    contentX: p.marginLeft * state.scale,
+    contentW: (p.pageWidth - p.marginLeft - p.marginRight) * state.scale,
+    verticalCJK: false,
+    verticalPhys: undefined,
+    floats: [],
+    deferFront: null,
+  };
+}
+
 type AnchorBoxSource = Pick<ImageRun,
   | 'widthPt' | 'heightPt'
   | 'anchorXPt' | 'anchorYPt'
@@ -11031,18 +11148,20 @@ function resolveAnchorBox(
     // relative (the drawing layer is not rotated with the text flow). Resolve
     // the box in physical space, then project it into the swapped logical layout
     // frame the body text flows in — so the float-exclusion band and the
-    // (drawUprightBox-un-swapped) painted image share one geometry. paraBaseY is
-    // a LOGICAL flow coordinate and only feeds paragraph-relative positionV; the
-    // vertical samples in scope anchor page/margin-relative, so it is not
-    // physical-mapped here (paragraph-relative vertical anchors in tbRl are a
-    // follow-up — see the vertical-text stage-1 scope note).
+    // (drawUprightBox-un-swapped) painted image share one geometry. A
+    // `paragraph`/`line`-relative positionV anchors from the PHYSICAL TOP of
+    // the anchor paragraph's COLUMN (issue #988 batch-3 adjudication ②: Word GT
+    // = margin-top + posOffset for a single-column body). That physical y is
+    // the column band's logical x start (`state.contentX`; physical y =
+    // logical x under the +90° page paint) — NOT the logical flow `paraBaseY`,
+    // which lies on the column-progression axis and would rotate the offset.
     const phys = physicalAnchorState(state);
     const px = resolveAnchorX(
       img.anchorXAlign, img.anchorXFromMargin ?? false, img.anchorXPt ?? 0, w, phys,
       img.anchorXRelativeFrom ?? null, null, null,
     );
     const py = resolveAnchorY(
-      img.anchorYAlign, img.anchorYFromPara ?? false, img.anchorYPt ?? 0, h, paraBaseY, phys,
+      img.anchorYAlign, img.anchorYFromPara ?? false, img.anchorYPt ?? 0, h, state.contentX, phys,
       img.anchorYRelativeFrom ?? null, null, null,
     );
     const box = physicalToLogicalAnchorBox(px, py, w, h, state.verticalPhys.cssWidthPx);
@@ -11343,10 +11462,20 @@ function registerShapeFloat(
     shape.wrapMode === 'topAndBottom' ? 'topAndBottom' : 'square';
 
   const scale = state.scale;
-  const dl = (shape.distLeft   ?? 0) * scale;
-  const dr = (shape.distRight  ?? 0) * scale;
-  const dt = (shape.distTop    ?? 0) * scale;
-  const db = (shape.distBottom ?? 0) * scale;
+  const pdl = (shape.distLeft   ?? 0) * scale;
+  const pdr = (shape.distRight  ?? 0) * scale;
+  const pdt = (shape.distTop    ?? 0) * scale;
+  const pdb = (shape.distBottom ?? 0) * scale;
+  // §17.6.20 — on a vertical page the box above is the LOGICAL projection of the
+  // physically-resolved shape (resolveShapeBox), so rotate the dist* labels one
+  // quarter-turn with it, exactly like the image path (resolveAnchorBox):
+  // physical top/bottom ↦ logical left/right, physical right/left ↦ logical
+  // top/bottom (logical y runs opposite physical x).
+  const vertical = !!state.verticalPhys;
+  const dl = vertical ? pdt : pdl;
+  const dr = vertical ? pdb : pdr;
+  const dt = vertical ? pdr : pdt;
+  const db = vertical ? pdl : pdb;
 
   // Overlap avoidance, kept consistent with the image path. Shapes carry no
   // parsed allowOverlap field; the spec default is true (§20.4.2.3), so

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1142,12 +1142,15 @@ function verticalLayoutSection(phys: SectionProps): SectionProps {
   };
 }
 
-/** Return a shallow copy of `doc` with its body-level section (and any per-body
- *  sectionBreak geometry) swapped to the vertical LOGICAL geometry, so the
- *  pagination + layout engine — which reads `doc.section` and per-element
- *  `sectionGeom` — organises the page as a rotated horizontal page. Only invoked
- *  when the body section is vertical; horizontal docs are returned untouched
- *  (referential identity), keeping the horizontal path byte-identical. */
+/** Return a shallow copy of `doc` with its BODY-LEVEL section swapped to the
+ *  vertical LOGICAL geometry, so the pagination + layout engine — which reads
+ *  `doc.section` — organises the page as a rotated horizontal page. Per-body
+ *  SectionBreak `geom`s are NOT swapped: per-section geometry/text-direction
+ *  inside a vertical document is the #988 ① per-section follow-up, so vertical
+ *  layout is body-section uniform today and consumers must not mix a mid-body
+ *  section geom into the swapped frame. Only invoked when the body section is
+ *  vertical; horizontal docs are returned untouched (referential identity),
+ *  keeping the horizontal path byte-identical. */
 function verticalLayoutDoc(doc: DocxDocumentModel): DocxDocumentModel {
   if (!isVerticalSection(doc.section)) return doc;
   return { ...doc, section: verticalLayoutSection(doc.section) };
@@ -2128,17 +2131,20 @@ export function computePages(
   // textDirection preserved — a block table is an UPRIGHT block: its cells lay
   // out horizontally at the PHYSICAL content width, and it advances the flow by
   // its PHYSICAL WIDTH (the paint pass's renderTable vertical branch). The
-  // paginator must charge that same footprint. The physical band comes from the
-  // ACTIVE section's geometry (`currentSectionGeom`, reassigned at every break —
-  // TDZ-safe like bodyTopPt above), un-swapped by physicalLayoutSection, so a
-  // vertical section with per-section page geometry stamps the same band the
-  // paint pass derives from its page's `verticalPhys`. Horizontal sections are
-  // untouched (`verticalUpright` false).
+  // paginator must charge that same footprint, so resolve the physical content
+  // band from the BODY-LEVEL swapped section — the one frame-consistent source
+  // today: `verticalLayoutDoc` swaps only `doc.section`, so a mid-body
+  // SectionBreak's `geom` still carries PHYSICAL page geometry and must not be
+  // fed through `physicalLayoutSection` (it would double-invert). Per-section
+  // geometry/text-direction inside a vertical document is the #988 ①
+  // per-section follow-up; until it lands, vertical layout is body-section
+  // uniform (measure `verticalPhys` in buildMeasureState is seeded from the
+  // same body-level section, and the paint pass resolves the same geometry for
+  // every page). Horizontal sections are untouched (`verticalUpright` false).
   const verticalUpright = isVerticalSection(section);
-  const uprightTableBandPt = (): number => {
-    const phys = physicalLayoutSection({ ...section, ...currentSectionGeom });
-    return phys.pageWidth - phys.marginLeft - phys.marginRight;
-  };
+  const uprightPhysSection = verticalUpright ? physicalLayoutSection(section) : section;
+  const uprightTableBandPt = (): number =>
+    uprightPhysSection.pageWidth - uprightPhysSection.marginLeft - uprightPhysSection.marginRight;
   const noteById = indexNotes(footnotes);
   const haveFootnotes = noteById.size > 0;
   // Per-page reserved footnote height (pt). Index 0 = first page. Grows as
@@ -4121,6 +4127,10 @@ function buildMeasureState(
     // physicalLayoutSection; `cssWidthPx` at the paginator's scale 1 is the
     // physical page width in pt. `verticalCJK` stays UNSET: the measure pass
     // keeps its horizontal glyph metrics (only anchor geometry re-frames).
+    // Seeded from the BODY-LEVEL section, the single frame-consistent source —
+    // vertical layout is body-section uniform until the #988 ① per-section
+    // follow-up (see verticalLayoutDoc), and the paint pass resolves the same
+    // geometry for every vertical page.
     verticalPhys: isVerticalSection(section)
       ? (() => {
           const phys = physicalLayoutSection(section);

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2123,10 +2123,22 @@ export function computePages(
     fontFamilyClasses,
     documentSettings,
   );
-  // ECMA-376 §17.6.20 — whether this pagination lays out a vertical (tbRl)
-  // section (`section` here is the SWAPPED logical geometry, textDirection
-  // preserved). Horizontal sections are untouched (`verticalUpright` false).
+  // ECMA-376 §17.6.20 + §17.4.80 (issue #988 batch-3 adjudication ④): in a
+  // vertical (tbRl) section — `section` here is the SWAPPED logical geometry,
+  // textDirection preserved — a block table is an UPRIGHT block: its cells lay
+  // out horizontally at the PHYSICAL content width, and it advances the flow by
+  // its PHYSICAL WIDTH (the paint pass's renderTable vertical branch). The
+  // paginator must charge that same footprint. The physical band comes from the
+  // ACTIVE section's geometry (`currentSectionGeom`, reassigned at every break —
+  // TDZ-safe like bodyTopPt above), un-swapped by physicalLayoutSection, so a
+  // vertical section with per-section page geometry stamps the same band the
+  // paint pass derives from its page's `verticalPhys`. Horizontal sections are
+  // untouched (`verticalUpright` false).
   const verticalUpright = isVerticalSection(section);
+  const uprightTableBandPt = (): number => {
+    const phys = physicalLayoutSection({ ...section, ...currentSectionGeom });
+    return phys.pageWidth - phys.marginLeft - phys.marginRight;
+  };
   const noteById = indexNotes(footnotes);
   const haveFootnotes = noteById.size > 0;
   // Per-page reserved footnote height (pt). Index 0 = first page. Grows as
@@ -2629,6 +2641,13 @@ export function computePages(
       return estimateParagraphHeight(measureState, nxt as unknown as DocParagraph, colW(), false);
     }
     if (nxt.type === 'table') {
+      // §17.6.20 + #988 ④ — an upright vertical-section table's flow footprint
+      // is its PHYSICAL WIDTH, not the sum of its row heights.
+      if (verticalUpright) {
+        return resolveColumnWidths(
+          nxt as unknown as DocTable, uprightTableBandPt(), measureState,
+        ).reduce((s, w) => s + w, 0);
+      }
       return estimateTableHeight(measureState, nxt as unknown as DocTable, colW());
     }
     return 0;
@@ -3521,12 +3540,6 @@ export function computePages(
         continue;
       }
 
-      // Tables in a multi-column section are sized to the column width, not the
-      // full content band. Resolve columns + row heights together (one min-content
-      // scan) so both can be stamped for the paint pass (B2 table stage 1b).
-      const tblContentWPt = colW();
-      const { colWidthsPt: tblColWidthsPt, rowHeightsPt: measuredRowHs } =
-        computeTablePtLayout(measureState, tbl, tblContentWPt);
       // ECMA-376 §17.11.10 — a footnote referenced from inside a table cell is
       // drawn at the bottom of the page holding the table, so the body area must
       // shrink by the note height just as it does for a body-paragraph reference
@@ -3534,7 +3547,8 @@ export function computePages(
       // their height into BOTH the fit decision and the committed page reserve.
       // (A row-split table reserves on the page where it ends — the same
       // approximation a split footnote-bearing paragraph uses above; §17.11.10's
-      // per-row placement across a split is a documented residual.)
+      // per-row placement across a split is a documented residual.) Shared by
+      // the upright-vertical and horizontal block-table paths below.
       let tblNewRefIds: string[] = [];
       let tblReservePt = 0;
       if (haveFootnotes) {
@@ -3546,6 +3560,51 @@ export function computePages(
         }
         tblReservePt = sumReserve(tblNewRefIds);
       }
+      const commitTableReserve = () => {
+        if (!haveFootnotes || tblNewRefIds.length === 0) return;
+        // Re-filter against the landing page (a split may have advanced pages, so
+        // the separator region is charged only if that page had no note yet).
+        tblNewRefIds = tblNewRefIds.filter((id) => !pageNoteIds.has(id));
+        const addPt = sumReserve(tblNewRefIds);
+        const idx = pages.length - 1;
+        footnoteReservePt[idx] = (footnoteReservePt[idx] ?? 0) + addPt;
+        for (const id of tblNewRefIds) pageNoteIds.add(id);
+      };
+
+      // ECMA-376 §17.6.20 + §17.4.80 (issue #988 batch-3 adjudication ④): a
+      // block table in a vertical (tbRl) section is an UPRIGHT block — resolve
+      // its layout at the PHYSICAL content width and charge its PHYSICAL WIDTH
+      // as the flow footprint (the paint pass advances by the same tableW, so
+      // pagination and paint agree). Stamp the physical scale-1 layout so the
+      // paint pass's computeTableLayout reuses it at the same physical band.
+      // Rows stack along the physical vertical axis (the column-length axis),
+      // NOT the flow axis, so the table is atomic: no row-splitting across
+      // columns/pages (a follow-up if a fixture ever adjudicates it) — a table
+      // that does not fit the remaining flow advances to the next column/page
+      // whole, and one wider than a full column overflows like a too-tall
+      // horizontal row.
+      if (verticalUpright) {
+        const bandPt = uprightTableBandPt();
+        const { colWidthsPt, rowHeightsPt } =
+          computeTablePtLayout(measureState, tbl, bandPt);
+        const h = colWidthsPt.reduce((s, w) => s + w, 0);
+        const tableEl = { ...tbl, type: 'table' } as PaginatedBodyElement;
+        stampTableLayout(tableEl, colWidthsPt, rowHeightsPt, bandPt);
+        if (y + h > effContentH() - tblReservePt && y > colTopY) nextColumnOrPage(i);
+        pushTagged(tableEl);
+        y += h;
+        measureState.y += h;
+        commitTableReserve();
+        prevPara = null;
+        continue;
+      }
+
+      // Tables in a multi-column section are sized to the column width, not the
+      // full content band. Resolve columns + row heights together (one min-content
+      // scan) so both can be stamped for the paint pass (B2 table stage 1b).
+      const tblContentWPt = colW();
+      const { colWidthsPt: tblColWidthsPt, rowHeightsPt: measuredRowHs } =
+        computeTablePtLayout(measureState, tbl, tblContentWPt);
       // effContentH() respects any reserve already accumulated on this page; the
       // table's own footnote reserve is subtracted on top so the note clears the
       // table content.
@@ -3562,16 +3621,6 @@ export function computePages(
       const sourceRowIndexByRow = splitRows?.sourceRowIndexByRow;
       const tableEl = { ...pageTable, type: 'table' } as PaginatedBodyElement;
       const h = rowHs.reduce((s, x) => s + x, 0);
-      const commitTableReserve = () => {
-        if (!haveFootnotes || tblNewRefIds.length === 0) return;
-        // Re-filter against the landing page (a split may have advanced pages, so
-        // the separator region is charged only if that page had no note yet).
-        tblNewRefIds = tblNewRefIds.filter((id) => !pageNoteIds.has(id));
-        const addPt = sumReserve(tblNewRefIds);
-        const idx = pages.length - 1;
-        footnoteReservePt[idx] = (footnoteReservePt[idx] ?? 0) + addPt;
-        for (const id of tblNewRefIds) pageNoteIds.add(id);
-      };
       const overflowsCurrentColumn = y + h > tableContentH;
       if (h > tableContentH || (!wantsBalanceBreak(h) && overflowsCurrentColumn)) {
         // Split row-by-row so overflow continues into the next column / page
@@ -12048,6 +12097,42 @@ function renderTable(table: DocTable, state: RenderState): void {
   // path before the normal block layout (which would advance state.y).
   if (table.tblpPr) {
     renderFloatTable(table, state);
+    return;
+  }
+
+  // ECMA-376 §17.6.20 + §17.4.80 (issue #988 batch-3 adjudication ④): a block
+  // table inside a vertical (tbRl) section renders UPRIGHT — its cells do NOT
+  // inherit the section text direction (cell text is horizontal), a fixed
+  // `tcW` is a PHYSICAL width, and `trHeight` exact/auto clip/grow along the
+  // physical vertical axis. Lay the table out with the PHYSICAL state view and
+  // paint it inside the inverse of the +90° page transform (the same physical
+  // frame the header/footer and anchored-shape paths re-enter). Its placement
+  // in the vertical flow: the physical TOP edge sits at the column axis start
+  // (the logical x band start, contentX ⇒ the physical top content margin —
+  // matching Word GT, both fixture tables pinned at the top margin) and the
+  // block advances the flow by its PHYSICAL WIDTH (logical Δy = tableW; the
+  // physical box spans x ∈ [cssW − y − tableW, cssW − y]). `w:jc`/`w:tblInd`
+  // placement along the flow axis and row-splitting across vertical pages are
+  // un-adjudicated follow-ups; the paginator charges the same tableW footprint
+  // (computePages' vertical table branch) so pagination and paint agree.
+  if (state.verticalPhys) {
+    const cssW = state.verticalPhys.cssWidthPx;
+    const physState = verticalPhysicalContentState(state);
+    const { colWidths, tableW, rowHeights } = computeTableLayout(
+      table, physState.contentW, physState,
+    );
+    const physX = cssW - state.y - tableW;
+    // The column axis start: the LOGICAL band start (state.contentX) images the
+    // physical top of the current column (physical y = logical x under the +90°
+    // page paint) — the top content margin for a single-column body.
+    const physY = state.contentX;
+    const { ctx } = state;
+    ctx.save();
+    ctx.rotate(-Math.PI / 2);
+    ctx.translate(-cssW, 0);
+    drawTableRows(table, colWidths, tableW, rowHeights, physX, physY, physState);
+    ctx.restore();
+    state.y += tableW;
     return;
   }
 

--- a/packages/docx/src/vertical-table-upright.test.ts
+++ b/packages/docx/src/vertical-table-upright.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computePages,
+  renderDocumentToCanvas,
+  __test_verticalLayoutSection,
+  type DocxTextRunInfo,
+} from './renderer.js';
+import type {
+  DocxDocumentModel,
+  DocTable,
+  DocTableRow,
+  DocTableCell,
+  DocParagraph,
+  SectionProps,
+  BodyElement,
+} from './types';
+
+// ECMA-376 §17.6.20 + §17.4.80/§17.18.37 — issue #988 batch-3 adjudication ④:
+// a table CELL inside a vertical (tbRl) section renders like a normal
+// HORIZONTAL cell — the section's vertical text direction does NOT propagate
+// into the cell:
+//   - cell text is laid out horizontally (left→right, wrapping downward),
+//   - a fixed `tcW` is the cell's PHYSICAL horizontal width,
+//   - `trHeight hRule="exact"` clips overflow at the physical row height,
+//   - auto row height GROWS to enclose the content.
+// The table block sits upright at the flow position: its physical top edge is
+// the top content margin (the column axis start) and it advances the vertical
+// flow by its PHYSICAL WIDTH (columns progress right→left past it).
+//
+// Word ground truth = the batch-3 vertical-table fixture PDF (two 1-cell
+// 1-in-wide fixed tables, exact 2 in vs auto): both cells lay their long CJK
+// string out horizontally at the physical width; the exact row's border box is
+// exactly 2 in tall with lines 10+ clipped; the auto row grew to fit all lines.
+
+/** Recording 2D context (same skeleton as table-clip-exact.test.ts): captures
+ *  `rect()` calls so the §17.4.80 exact-row clip band can be asserted, with
+ *  deterministic char-count metrics. */
+interface RectCall { x: number; y: number; w: number; h: number; }
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  rectCalls: RectCall[];
+} {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const rectCalls: RectCall[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {},
+    rect(x: number, y: number, w: number, h: number) {
+      rectCalls.push({ x, y, w, h });
+    },
+    clip() {},
+    scale() {}, translate() {}, rotate() {}, setTransform() {},
+    setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0,
+    height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, rectCalls };
+}
+
+function emptyBorders() {
+  return { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null };
+}
+
+function bodyParagraph(text: string): DocParagraph {
+  return {
+    alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: text === '' ? [] : [{
+      type: 'text', text,
+      bold: false, italic: false, underline: false, strikethrough: false,
+      fontSize: 10, color: null, fontFamily: 'Times New Roman', fontFamilyEastAsia: 'Times New Roman',
+      isLink: false, background: null, vertAlign: null, hyperlink: null,
+    }],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman',
+    widowControl: false,
+  } as unknown as DocParagraph;
+}
+
+/** 1×1 fixed-width (50 pt) table. `exactPt` sets `trHeight hRule="exact"`;
+ *  null keeps the row auto. The cell text ('tok tok …') wraps one token per
+ *  line at the 50 pt cell width (each 'tok ' measures 40 pt with the fake
+ *  10 px-per-char metrics), giving 12 lines ≈ 130+ pt of content — far taller
+ *  than an 80 pt exact row. */
+function fixedTable(text: string, exactPt: number | null): DocTable {
+  const cell: DocTableCell = {
+    content: [{ type: 'paragraph', ...bodyParagraph(text) }],
+    colSpan: 1,
+    vMerge: null,
+    borders: emptyBorders(),
+    background: null,
+    vAlign: 'top',
+    widthPt: 50,
+    marginTop: 0, marginBottom: 0, marginLeft: 0, marginRight: 0,
+  } as unknown as DocTableCell;
+  const row: DocTableRow = {
+    cells: [cell],
+    rowHeight: exactPt,
+    rowHeightRule: exactPt == null ? 'auto' : 'exact',
+    isHeader: false,
+  } as unknown as DocTableRow;
+  return {
+    colWidths: [50],
+    rows: [row],
+    borders: emptyBorders(),
+    cellMarginTop: 0,
+    cellMarginBottom: 0,
+    cellMarginLeft: 0,
+    cellMarginRight: 0,
+    jc: 'left',
+  } as unknown as DocTable;
+}
+
+// PHYSICAL portrait page 200×300 pt with DISTINCT margins so the logical
+// (swapped) frame's coordinates can never coincide with the physical ones:
+//   physical top=20 right=30 bottom=40 left=24
+//   ⇒ logical  left=20 top=30   right=40  bottom=24 (verticalLayoutSection)
+// Flow starts at logical y = 30; the column axis starts at logical x = 20
+// (= the physical top margin). Flow budget = 200 − 30 − 24 = 146 pt.
+const PHYS = {
+  pageWidth: 200, pageHeight: 300,
+  marginTop: 20, marginRight: 30, marginBottom: 40, marginLeft: 24,
+  headerDistance: 0, footerDistance: 0,
+  titlePage: false, evenAndOddHeaders: false,
+  textDirection: 'tbRl',
+} as unknown as SectionProps;
+
+const CSS_W = 200; // physical page width == canvas CSS width at scale 1
+const FLOW_TOP = 30; // logical body top (physical right margin)
+const COL_TOP = 20; // physical column top (logical marginLeft)
+const TABLE_W = 50; // fixed tcW ⇒ physical table width
+
+const CELL_TEXT_1 = 'aaa '.repeat(12).trim();
+const CELL_TEXT_2 = 'bbb '.repeat(12).trim();
+
+function verticalTableDoc(): DocxDocumentModel {
+  return {
+    section: PHYS,
+    body: [
+      { type: 'table', ...fixedTable(CELL_TEXT_1, 80) },
+      { type: 'paragraph', ...bodyParagraph('zz') },
+      { type: 'table', ...fixedTable(CELL_TEXT_2, null) },
+      { type: 'paragraph', ...bodyParagraph('qq') },
+    ],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+async function renderRuns(): Promise<{ runs: DocxTextRunInfo[]; rectCalls: RectCall[] }> {
+  const { canvas, rectCalls } = makeRecordingCanvas();
+  const runs: DocxTextRunInfo[] = [];
+  await renderDocumentToCanvas(verticalTableDoc(), canvas, 0, {
+    dpr: 1,
+    width: PHYS.pageWidth,
+    onTextRun: (r) => runs.push(r),
+  });
+  return { runs, rectCalls };
+}
+
+describe('vertical (tbRl) table cells render upright/horizontal (§17.6.20 + §17.4.80, #988 ④)', () => {
+  it('cell text is horizontal at the fixed physical width, from the physical column top', async () => {
+    const { runs } = await renderRuns();
+    const cellRuns = runs.filter((r) => r.text.startsWith('aaa'));
+    expect(cellRuns.length).toBeGreaterThanOrEqual(2);
+    for (const r of cellRuns) {
+      // Horizontal: no +90° overlay rotation.
+      expect(r.transform, `run ${JSON.stringify(r)}`).toBeUndefined();
+      // Fixed tcW ⇒ the physical x band [cssW − flowTop − tableW, +tableW].
+      expect(r.x).toBeGreaterThanOrEqual(CSS_W - FLOW_TOP - TABLE_W - 2);
+      expect(r.x + r.w).toBeLessThanOrEqual(CSS_W - FLOW_TOP + 2);
+    }
+    // Lines share the same x (left-aligned) and stack DOWN the physical page
+    // from the physical column top (top content margin).
+    const ys = cellRuns.map((r) => r.y);
+    expect(new Set(cellRuns.map((r) => Math.round(r.x))).size).toBe(1);
+    expect(Math.min(...ys)).toBeGreaterThanOrEqual(COL_TOP - 1);
+    expect(Math.min(...ys)).toBeLessThanOrEqual(COL_TOP + 15);
+    for (let i = 1; i < ys.length; i++) expect(ys[i]).toBeGreaterThan(ys[i - 1]);
+  });
+
+  it('trHeight exact clips at the physical row height; auto grows past it', async () => {
+    const { runs, rectCalls } = await renderRuns();
+    // §17.4.80 exact ⇒ a Y-only clip band at the row's PHYSICAL box:
+    // top = physical column top (20), height = 80.
+    const clipRect = rectCalls.find(
+      (r) => Math.abs(r.y - COL_TOP) < 1e-6 && Math.abs(r.h - 80) < 1e-6,
+    );
+    expect(clipRect, 'exact row must clip at its physical Y band').toBeDefined();
+    // auto ⇒ the row grows: content extends well past the 80 pt exact height.
+    const autoRuns = runs.filter((r) => r.text.startsWith('bbb'));
+    expect(autoRuns.length).toBeGreaterThanOrEqual(2);
+    for (const r of autoRuns) expect(r.transform).toBeUndefined();
+    expect(Math.max(...autoRuns.map((r) => r.y))).toBeGreaterThan(COL_TOP + 80);
+  });
+
+  it('the table advances the flow by its PHYSICAL WIDTH; body text stays vertical', async () => {
+    const { runs } = await renderRuns();
+    const afterExact = runs.find((r) => r.text === 'zz');
+    expect(afterExact).toBeDefined();
+    // Body text on a vertical page keeps the rotated overlay placement.
+    expect(afterExact!.transform).toBe('rotate(90deg)');
+    // The paragraph after the exact table starts one TABLE-WIDTH (50, the
+    // physical width) past the flow top — NOT one logical-row-height (80) past:
+    // place.left = cssW − (flowTop + tableW) = 200 − 80 = 120.
+    expect(afterExact!.x).toBeCloseTo(CSS_W - (FLOW_TOP + TABLE_W), 1);
+    // And the following auto table + paragraph keep flowing right→left.
+    const afterAuto = runs.find((r) => r.text === 'qq');
+    expect(afterAuto).toBeDefined();
+    expect(afterAuto!.transform).toBe('rotate(90deg)');
+    expect(afterAuto!.x).toBeLessThan(afterExact!.x);
+  });
+
+  it('pagination charges the physical table width as the flow footprint', () => {
+    const { canvas } = makeRecordingCanvas();
+    const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+    // Logical flow budget = physical pageWidth − logical top/bottom insets
+    // (30 + 24) = 146. A leading ~12 pt line + a 140 pt-EXACT-row table:
+    // charging the logical row height (140) overflows onto page 2, while the
+    // upright footprint (tableW = 50) fits page 1 beside it.
+    const body = [
+      { type: 'paragraph', ...bodyParagraph('zz') },
+      { type: 'table', ...fixedTable(CELL_TEXT_1, 140) },
+    ] as unknown as BodyElement[];
+    const logicalSec = __test_verticalLayoutSection(PHYS);
+    const pages = computePages(body, logicalSec, ctx, { 'Times New Roman': 'roman' });
+    expect(pages.length).toBe(1);
+    expect(pages[0].length).toBe(2);
+  });
+});

--- a/packages/node/src/docx-vertical-anchor-shapes.probe.test.ts
+++ b/packages/node/src/docx-vertical-anchor-shapes.probe.test.ts
@@ -1,0 +1,123 @@
+/**
+ * positionV/positionH anchors under a vertical (tbRl) section — ECMA-376
+ * §17.6.20 + §20.4.3.x, issue #988 batch-3 adjudication ②.
+ *
+ * Word ground truth (the batch-3 positionV fixture's PDF, Letter portrait
+ * 612×792 pt, 1 in margins; three identical 100.8×86.4 pt anchored rectangles
+ * differing only in positionV):
+ *
+ *   | fill    | positionH (page) | positionV            | physical box            |
+ *   |---------|------------------|----------------------|-------------------------|
+ *   | #FCE4D6 | 72.0             | paragraph + 21.6     | (72.0, 93.6)–(172.8, 180.0)  |
+ *   | #E2EFDA | 230.4            | margin + 108         | (230.4, 180.0)–(331.2, 266.4)|
+ *   | #DDEBF7 | 388.8            | page + 216           | (388.8, 216.0)–(489.6, 302.4)|
+ *
+ * All three resolve on the PHYSICAL vertical axis, increasing downward,
+ * independent of the tbRl flow; `paragraph` anchors from the PHYSICAL TOP of
+ * the anchor paragraph's column (72 = the top content margin). The rectangles
+ * carry `<wps:bodyPr vert="horz">` labels, so the shape (and its text) stays
+ * upright inside the rotated page.
+ *
+ * This probe renders private/sample-50.docx headlessly at scale 1 (px == pt)
+ * and asserts each rectangle's FILL bounding box against the Word PDF within
+ * ±2.5 pt (the fill sits just inside the 0.75 pt stroke).
+ *
+ * CI-safe: gated on docx WASM + skia-canvas + the PRIVATE sample + a macOS JP
+ * font; skips when any is absent (never hard-fails for the private file).
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, FontLibrary } = (skia ?? {}) as Skia;
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
+const rendererMod = await importForTests(
+  () => import('./../../docx/src/renderer.ts'),
+  'packages/docx/src/renderer.ts',
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+const SAMPLE = fileURLToPath(
+  new URL('../../docx/public/private/sample-50.docx', import.meta.url),
+);
+const MINCHO = '/System/Library/Fonts/ヒラギノ明朝 ProN.ttc';
+const havePrereqs = existsSync(SAMPLE) && existsSync(MINCHO);
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+interface Box { x0: number; y0: number; x1: number; y1: number }
+
+/** Word-PDF physical fill boxes (pt). */
+const GT: Array<{ name: string; rgb: [number, number, number]; box: Box }> = [
+  { name: 'V=paragraph', rgb: [0xfc, 0xe4, 0xd6], box: { x0: 72.0, y0: 93.6, x1: 172.8, y1: 180.0 } },
+  { name: 'V=margin', rgb: [0xe2, 0xef, 0xda], box: { x0: 230.4, y0: 180.0, x1: 331.2, y1: 266.4 } },
+  { name: 'V=page', rgb: [0xdd, 0xeb, 0xf7], box: { x0: 388.8, y0: 216.0, x1: 489.6, y1: 302.4 } },
+];
+
+describe.skipIf(!skia || !docxMod || !rendererMod || !havePrereqs)(
+  'docx vertical anchored shapes resolve physically (§20.4.3.x, #988 ②)',
+  () => {
+    it('lands the three positionV rectangles on the Word PDF physical boxes', async () => {
+      for (const fam of ['Yu Mincho', 'YuMincho', 'Hiragino Mincho ProN', 'MS Mincho', 'Noto Serif JP']) {
+        FontLibrary.use(fam, [MINCHO]);
+      }
+      const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
+      const { renderDocumentToCanvas } = rendererMod as Any;
+      const doc = parseDocx(readFileSync(SAMPLE));
+      const W = Math.round(doc.section.pageWidth);
+      const H = Math.round(doc.section.pageHeight);
+      const canvas = new Canvas(W, H);
+      const rImg = installImageBitmapShim(factory);
+      const rOff = installOffscreenCanvasShim(factory);
+      try {
+        await renderDocumentToCanvas(doc, canvas as Any, 0, {
+          dpr: 1,
+          width: doc.section.pageWidth,
+        });
+      } finally {
+        rOff();
+        rImg();
+      }
+      const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+      const { data } = ctx.getImageData(0, 0, W, H);
+
+      for (const { name, rgb, box } of GT) {
+        let x0 = Infinity, y0 = Infinity, x1 = -Infinity, y1 = -Infinity;
+        for (let y = 0; y < H; y++) {
+          for (let x = 0; x < W; x++) {
+            const i = (y * W + x) * 4;
+            if (
+              Math.abs(data[i] - rgb[0]) <= 4 &&
+              Math.abs(data[i + 1] - rgb[1]) <= 4 &&
+              Math.abs(data[i + 2] - rgb[2]) <= 4
+            ) {
+              if (x < x0) x0 = x;
+              if (x > x1) x1 = x;
+              if (y < y0) y0 = y;
+              if (y > y1) y1 = y;
+            }
+          }
+        }
+        expect(x0, `${name} fill found`).toBeLessThan(Infinity);
+        const TOL = 2.5;
+        expect(Math.abs(x0 - box.x0), `${name} left`).toBeLessThanOrEqual(TOL);
+        expect(Math.abs(y0 - box.y0), `${name} top`).toBeLessThanOrEqual(TOL);
+        expect(Math.abs(x1 - box.x1), `${name} right`).toBeLessThanOrEqual(TOL);
+        expect(Math.abs(y1 - box.y1), `${name} bottom`).toBeLessThanOrEqual(TOL);
+      }
+    }, 120000);
+  },
+);

--- a/packages/node/src/docx-vertical-table-cells.probe.test.ts
+++ b/packages/node/src/docx-vertical-table-cells.probe.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Table cells inside a vertical (tbRl) section — ECMA-376 §17.6.20 +
+ * §17.4.80/§17.18.37, issue #988 batch-3 adjudication ④.
+ *
+ * Word ground truth (the batch-3 vertical-table fixture's PDF, Letter portrait
+ * 612×792 pt, 1 in margins; two 1-cell tables, `tcW` 1440 twips fixed +
+ * `tblLayout` fixed, same long CJK string; TABLE 1 `trHeight hRule="exact"`
+ * 2880 twips, TABLE 2 auto):
+ *
+ *   - cell text lays out HORIZONTALLY (5 chars/line, wrapping downward) — the
+ *     section's vertical direction does not propagate into cells;
+ *   - fixed `tcW` 1 in ⇒ PHYSICAL horizontal width (border box 72.5 pt);
+ *   - TABLE 1 (exact): border box exactly 2 in tall — x [417.1, 489.6],
+ *     y [72, 216.5] — content clipped at the border (line 9 sliced mid-glyph);
+ *   - TABLE 2 (auto): border box grew to enclose all 17 lines (293.8 pt at Yu
+ *     Mincho's 17.2 pt natural line; a substituted face scales the pitch).
+ *
+ * TABLE 1's border box lands at its natural flow position and matches the PDF
+ * on BOTH axes, so it is asserted exactly (±2.5 pt). TABLE 2's physical
+ * placement is Word-IDIOSYNCRATIC (Word pins it before the flow start,
+ * overhanging the right margin at x [504.5, 577] instead of following the
+ * right→left block flow) — the adjudication flags block placement as a partial
+ * won't-fix candidate — so for it only the spec-grounded invariants are
+ * asserted: physical width, top-margin pinning, and auto GROWTH well past the
+ * 144.5 pt exact height.
+ *
+ * CI-safe: gated on docx WASM + skia-canvas + the PRIVATE sample + a macOS JP
+ * font; skips when any is absent.
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, FontLibrary } = (skia ?? {}) as Skia;
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
+const rendererMod = await importForTests(
+  () => import('./../../docx/src/renderer.ts'),
+  'packages/docx/src/renderer.ts',
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+const SAMPLE = fileURLToPath(
+  new URL('../../docx/public/private/sample-52.docx', import.meta.url),
+);
+const MINCHO = '/System/Library/Fonts/ヒラギノ明朝 ProN.ttc';
+const havePrereqs = existsSync(SAMPLE) && existsSync(MINCHO);
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+interface RunInfo { text: string; x: number; y: number; w: number; transform?: string }
+
+describe.skipIf(!skia || !docxMod || !rendererMod || !havePrereqs)(
+  'docx vertical table cells render upright/horizontal (§17.6.20 + §17.4.80, #988 ④)',
+  () => {
+    it('matches the Word PDF: exact clips at 2 in, auto grows, cells horizontal', async () => {
+      for (const fam of ['Yu Mincho', 'YuMincho', 'Hiragino Mincho ProN', 'MS Mincho', 'Noto Serif JP']) {
+        FontLibrary.use(fam, [MINCHO]);
+      }
+      const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
+      const { renderDocumentToCanvas } = rendererMod as Any;
+      const doc = parseDocx(readFileSync(SAMPLE));
+      const W = Math.round(doc.section.pageWidth);
+      const H = Math.round(doc.section.pageHeight);
+      const canvas = new Canvas(W, H);
+      const runs: RunInfo[] = [];
+      const rImg = installImageBitmapShim(factory);
+      const rOff = installOffscreenCanvasShim(factory);
+      try {
+        await renderDocumentToCanvas(doc, canvas as Any, 0, {
+          dpr: 1,
+          width: doc.section.pageWidth,
+          onTextRun: (r: Any) =>
+            runs.push({ text: r.text, x: r.x, y: r.y, w: r.w, transform: r.transform }),
+        });
+      } finally {
+        rOff();
+        rImg();
+      }
+      const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+      const { data } = ctx.getImageData(0, 0, W, H);
+
+      // ── Red (C00000) border boxes ────────────────────────────────────────
+      const isRed = (x: number, y: number): boolean => {
+        const i = (y * W + x) * 4;
+        return data[i] > 120 && data[i + 1] < 80 && data[i + 2] < 80;
+      };
+      // Vertical border lines: columns with a long red span.
+      const vlines: Array<{ x: number; y0: number; y1: number }> = [];
+      for (let x = 0; x < W; x++) {
+        let count = 0, y0 = -1, y1 = -1;
+        for (let y = 0; y < H; y++) {
+          if (isRed(x, y)) {
+            count++;
+            if (y0 < 0) y0 = y;
+            y1 = y;
+          }
+        }
+        if (count > 40) vlines.push({ x, y0, y1 });
+      }
+      // Cluster adjacent columns into border edges.
+      const edges: Array<{ x: number; y0: number; y1: number }> = [];
+      for (const v of vlines) {
+        const last = edges[edges.length - 1];
+        if (last && v.x - last.x <= 2) {
+          last.y0 = Math.min(last.y0, v.y0);
+          last.y1 = Math.max(last.y1, v.y1);
+          continue;
+        }
+        edges.push({ ...v });
+      }
+      expect(edges.length, 'two tables ⇒ four vertical border edges').toBe(4);
+
+      // Pair edges into boxes by matching y extents (left/right of one table
+      // share the same y span).
+      const boxes: Array<{ x0: number; x1: number; y0: number; y1: number }> = [];
+      const used = new Set<number>();
+      for (let a = 0; a < edges.length; a++) {
+        if (used.has(a)) continue;
+        for (let b = a + 1; b < edges.length; b++) {
+          if (used.has(b)) continue;
+          if (Math.abs(edges[a].y1 - edges[b].y1) <= 3 && Math.abs(edges[a].y0 - edges[b].y0) <= 3) {
+            boxes.push({
+              x0: Math.min(edges[a].x, edges[b].x),
+              x1: Math.max(edges[a].x, edges[b].x),
+              y0: Math.min(edges[a].y0, edges[b].y0),
+              y1: Math.max(edges[a].y1, edges[b].y1),
+            });
+            used.add(a).add(b);
+            break;
+          }
+        }
+      }
+      expect(boxes.length, 'two table border boxes').toBe(2);
+      const exactBox = boxes.find((b) => Math.abs(b.y1 - b.y0 - 144.5) < 6);
+      const autoBox = boxes.find((b) => b !== exactBox);
+      expect(exactBox, 'a 2-in-tall exact border box').toBeDefined();
+      expect(autoBox).toBeDefined();
+
+      // TABLE 1 (exact): matches the Word PDF on BOTH axes (±2.5 pt).
+      expect(Math.abs(exactBox!.x0 - 417.1), 'exact left').toBeLessThanOrEqual(2.5);
+      expect(Math.abs(exactBox!.x1 - 489.6), 'exact right').toBeLessThanOrEqual(2.5);
+      expect(Math.abs(exactBox!.y0 - 72), 'exact top').toBeLessThanOrEqual(2.5);
+      expect(Math.abs(exactBox!.y1 - 216.5), 'exact bottom').toBeLessThanOrEqual(2.5);
+
+      // TABLE 2 (auto): spec-grounded invariants only (placement along the
+      // flow axis is the Word-idiosyncratic partial-won't-fix candidate).
+      expect(Math.abs(autoBox!.x1 - autoBox!.x0 - 72.5), 'auto physical width').toBeLessThanOrEqual(2.5);
+      expect(Math.abs(autoBox!.y0 - 72), 'auto pinned at the top margin').toBeLessThanOrEqual(2.5);
+      expect(autoBox!.y1 - autoBox!.y0, 'auto row grew past the exact 144.5').toBeGreaterThan(250);
+
+      // ── Clip: no cell ink below TABLE 1's exact bottom border ───────────
+      let inkBelow = 0;
+      for (let y = Math.round(exactBox!.y1) + 3; y < Math.round(exactBox!.y1) + 90; y++) {
+        for (let x = Math.round(exactBox!.x0) + 2; x < Math.round(exactBox!.x1) - 2; x++) {
+          const i = (y * W + x) * 4;
+          if (data[i] < 200 && data[i + 1] < 200 && data[i + 2] < 200) inkBelow++;
+        }
+      }
+      expect(inkBelow, 'exact row content is clipped at the border').toBe(0);
+
+      // ── Cell text is HORIZONTAL: same x per line, y advancing downward ──
+      const cellLines = runs.filter(
+        (r) => r.transform === undefined && Math.abs(r.w - 60) < 3 && r.x > exactBox!.x0 && r.x < exactBox!.x1,
+      );
+      expect(cellLines.length, 'horizontal cell lines inside TABLE 1').toBeGreaterThanOrEqual(8);
+      expect(new Set(cellLines.map((r) => Math.round(r.x))).size).toBe(1);
+      const ys = cellLines.map((r) => r.y);
+      for (let i = 1; i < ys.length; i++) expect(ys[i]).toBeGreaterThan(ys[i - 1]);
+      // Body text outside the tables keeps the +90° vertical overlay transform.
+      expect(runs.some((r) => r.transform === 'rotate(90deg)')).toBe(true);
+    }, 120000);
+  },
+);


### PR DESCRIPTION
Implements the two remaining adjudicated deferrals from the issue #988 batch-3 ground-truth pack (continuation of #996; rulings in the #988 adjudication comments are authoritative).

## ② `positionV` under tbRl — physical-axis anchor resolution (§20.4.3.x)

Word GT: every `positionH/V` anchor resolves against the **physical un-rotated page**, increasing downward, independent of the section text direction; `paragraph`/`line`-relative `positionV` anchors from the **physical top of the anchor paragraph's column**.

- `resolveShapeBox` now mirrors the image path on vertical pages: resolve physically, project through `physicalToLogicalAnchorBox` (float band and flow share one geometry; `registerShapeFloat` rotates its `dist*` labels a quarter-turn with the projection).
- `renderAnchorShape` paints the shape **upright** by inverting the +90° page transform and re-entering with a physical state view (`verticalPhysicalContentState`) — panels and `vert="horz"` labels stay horizontal, overlay runs emit unrotated physical coordinates.
- `resolveAnchorBox` (images/charts): paragraph-relative `positionV` anchors from the column's physical top (`state.contentX`) instead of the logical flow y.
- `buildMeasureState` carries `verticalPhys` for vertical sections (independent-review finding) so the paginator's wrap-float bands resolve through the same physical projection as paint; the paragraph-anchored keep-on-page displacement is gated off under vertical (the offset lives on the physical axis, not the flow axis).

**Measured vs Word PDF** (headless render, scale 1 ⇒ px = pt; fill bboxes sit just inside the 0.75 pt stroke):

| rectangle | Word PDF box | rendered fill bbox | max Δ |
|---|---|---|---|
| paragraph +0.3 in | (72.0, 93.6)–(172.8, 180.0) | (73, 94)–(171, 178) | ≤ 2.0 pt (stroke inset) |
| margin +1.5 in | (230.4, 180.0)–(331.2, 266.4) | (231, 181)–(329, 265) | ≤ 2.2 pt (stroke inset) |
| page +3.0 in | (388.8, 216.0)–(489.6, 302.4) | (390, 217)–(488, 301) | ≤ 1.6 pt (stroke inset) |

## ④ Table cells inside a vertical section — horizontal cells, exact clip / auto grow (§17.6.20 + §17.4.80)

Word GT: cells render **horizontal** text (the section direction does not propagate into cells); fixed `tcW` ⇒ **physical width**; `trHeight hRule="exact"` ⇒ **clip** (sliced mid-glyph at the border); auto ⇒ **grow**.

- `renderTable`: a block table on a vertical page is an **upright block** — laid out with the physical state view, painted inside the inverse page transform; physical top edge at the column-axis start (the top content margin, matching both fixture tables), flow advanced by its **physical width**.
- `computePages`: charges the same `tableW` footprint (atomic block — no row-splitting along the flow axis), stamps the physical scale-1 layout for the paint-pass reuse, and shares the §17.11.10 table footnote reserve with the horizontal path (independent-review finding).

**Measured vs Word PDF** (red C00000 border boxes):

| table | Word PDF box | rendered | Δ |
|---|---|---|---|
| exact 2 in | x [417.1, 489.6], y [72, 216.5] | x [417, 489.6], y [72, 216.5] | ≤ 0.6 pt both axes |
| auto | width 72.5, top 72, height 293.8 | width 72.5, top 72, height 306 | width/top ≤ 0.5 pt; height +12 pt = substituted-face line pitch (17 lines × Hiragino 18 pt vs Yu Mincho 17.2 pt) |

**Partial won't-fix (proposed on #988, not silently traded off):** the *flow-axis placement* of the **second** table. Word pins it before the flow start, overhanging the right margin (x [504.5, 577.0] — 37 pt into the margin), instead of following the right→left block flow; no ECMA-376 rule or regular flow model reproduces it (the FIRST table's placement at its natural flow position matches Word ≤ 0.6 pt). This renderer keeps the regular block flow for it (rendered x [297, 369]). Also recorded for a future fixture: Word appears to allocate the cell's inline-start margin off the physical left edge (content ink starts at border +0.7 pt with the 2 × 5.4 pt margins stacked on the right), where this renderer insets 5.4 pt from the physical left.

## Deliberately unchanged (follow-ups)

- Per-section geometry/text-direction inside a vertical document (#988 ① — `verticalLayoutDoc` swaps only the body-level section; documented at the new call sites).
- `w:jc`/`w:tblInd` along the vertical flow axis, `w:tblpPr` floating tables, and row-splitting across vertical pages/columns — un-adjudicated, no fixture.

## Verification

- TDD: synthetic-model tests (3 anchor relativeFroms via `resolveShapeBox`/`resolveAnchorBox`, upright-cell orientation/exact-clip/auto-grow/flow-advance via a recording ctx, pagination footprint, wrapped-shape pagination band) — all red on the pre-change code (ablation-verified), green now.
- Private-fixture probes (CI-safe skip) pin the Word-PDF numbers above.
- docx vitest 1327 green; packages/node suite green; root `pnpm typecheck` clean; `ast-grep scan` clean.
- docx VRT: 78 passed — demo non-regressive, private baseline non-regressive, `private/sample-26` (existing tbRl sample) **pixel-identical (0 diff px)**; no reference updated.
- Horizontal path byte-identical by construction: every new branch gates on `isVerticalSection`/`verticalPhys`.
- Independent review: Codex (gpt-5.6-sol, high) — 3 findings addressed in-line (measure-state `verticalPhys`, table footnote reserve, body-level physical band) + follow-up pass confirming F2 and re-scoping the multi-section concerns to the documented ① follow-up.

Refs #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)