### PR TITLE
docx: per-section text direction — vertical non-final beside horizontal final section (§17.6.20)

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1593,6 +1593,25 @@ fn read_section_break_type(sect_pr: roxmltree::Node) -> Option<String> {
         .find_map(|n| attr_w(n, "val"))
 }
 
+/// ECMA-376 §17.6.20 `<w:textDirection w:val>` — read a sectPr's flow direction.
+/// Word writes the TRANSITIONAL ST_TextDirection enum (Part 4 §14.11.7):
+/// `lrTb`|`tbRl`|`btLr`|`lrTbV`|`tbLrV`|`tbRlV` — NOT the Part 1 §17.18.93
+/// Strict set (`tb`|`rl`|`lr`|…). The default "lrTb" (horizontal, left→right /
+/// top→bottom) is dropped to `None` so horizontal documents serialize exactly
+/// as before (both carriers are `skip_serializing_if = "Option::is_none"`);
+/// any other value (most commonly "tbRl" for vertical Japanese) is carried
+/// through verbatim so the renderer decides which are vertical (see
+/// `isVerticalSection`). The parser does not validate the enum — an unknown
+/// value is carried and the renderer treats it as horizontal, the safe
+/// default. Single extraction source for BOTH the body-level
+/// `SectionProps.text_direction` and the per-terminating-section
+/// `SectionBreak.text_direction` (issue #1000).
+fn read_text_direction(sect_pr: roxmltree::Node) -> Option<String> {
+    child_w(sect_pr, "textDirection")
+        .and_then(|n| attr_w(n, "val"))
+        .filter(|td| td != "lrTb")
+}
+
 /// ECMA-376 §17.6.12 `<w:pgNumType>` — parse a section's page-numbering settings.
 /// Returns `None` when the sectPr has no `<w:pgNumType>` OR the element carries
 /// neither `@w:start` nor `@w:fmt` (only chapter attributes, which are out of
@@ -1794,6 +1813,9 @@ fn section_break_element(
         geom: section_geom(sect_pr),
         // ECMA-376 §17.6.12 — this ending section's page-numbering restart/format.
         page_num_type: parse_pgnum_type(sect_pr),
+        // ECMA-376 §17.6.20 — this ending section's flow direction (issue #1000
+        // per-section mixing); lrTb/absent ⇒ None, others verbatim.
+        text_direction: read_text_direction(sect_pr),
     }
 }
 
@@ -2085,21 +2107,10 @@ fn parse_section(
     // paginator needs the final section's here to resolve the boundary INTO it.
     props.section_start = read_section_break_type(sp);
 
-    // ECMA-376 §17.6.20 `<w:textDirection w:val>`. Word writes the TRANSITIONAL
-    // ST_TextDirection enum (Part 4 §14.11.7): `lrTb`|`tbRl`|`btLr`|`lrTbV`|
-    // `tbLrV`|`tbRlV` — NOT the Part 1 §17.18.93 Strict set (`tb`|`rl`|`lr`|…).
-    // The default "lrTb" (horizontal, left→right / top→bottom) is dropped to
-    // `None` so horizontal documents serialize exactly as before (the field is
-    // `skip_serializing_if = "Option::is_none"`); any other value (most commonly
-    // "tbRl" for vertical Japanese) is carried through verbatim so the renderer
-    // decides which are vertical (see `isVerticalSection`). The parser does not
-    // validate the enum — an unknown value is carried and the renderer treats it
-    // as horizontal, which is the safe default.
-    if let Some(td) = child_w(sp, "textDirection").and_then(|n| attr_w(n, "val")) {
-        if td != "lrTb" {
-            props.text_direction = Some(td);
-        }
-    }
+    // ECMA-376 §17.6.20 `<w:textDirection w:val>` — shared extraction (see
+    // `read_text_direction`); also carried per-terminating-section on the
+    // `SectionBreak` marker (issue #1000 per-section mixing).
+    props.text_direction = read_text_direction(sp);
 
     // ECMA-376 §17.6.5 w:docGrid. When @type=lines|linesAndChars with a
     // linePitch, Word renders each line of text at intervals of linePitch
@@ -13872,6 +13883,73 @@ mod column_tests {
         assert_eq!(g.margin_left, 72.0);
         assert_eq!(g.header_distance, 36.0);
         assert_eq!(g.footer_distance, 36.0);
+    }
+
+    /// ECMA-376 §17.6.20 `<w:textDirection w:val>` — a mid-body section break
+    /// carries its ENDING section's text direction on `text_direction`, exactly
+    /// like `columns`/`page_num_type` (issue #1000 per-section mixing: a
+    /// vertical non-final section beside a horizontal final section). Same
+    /// TRANSITIONAL ST_TextDirection handling as the body-level SectionProps
+    /// parse: the default "lrTb" (and an absent element) collapse to `None`;
+    /// any other token is carried verbatim so the renderer decides which flow
+    /// vertically.
+    #[test]
+    fn section_break_carries_text_direction() {
+        // Extract the SectionBreak's text_direction from a body whose FIRST
+        // section ends with `sect_pr_xml` inside a pPr-owned sectPr.
+        let td_of = |sect_pr_xml: &str| -> Option<String> {
+            let body = body_from(&format!(
+                r#"
+                <w:p>
+                  <w:pPr>
+                    <w:sectPr>
+                      <w:type w:val="nextPage"/>
+                      {sect_pr_xml}
+                    </w:sectPr>
+                  </w:pPr>
+                </w:p>
+                <w:p><w:r><w:t>body</w:t></w:r></w:p>
+                "#,
+            ));
+            body.iter()
+                .find_map(|e| match e {
+                    BodyElement::SectionBreak { text_direction, .. } => {
+                        Some(text_direction.clone())
+                    }
+                    _ => None,
+                })
+                .expect("a SectionBreak marker")
+        };
+        // Vertical tokens are carried verbatim (§17.6.20 / Part 4 §14.11.7).
+        assert_eq!(
+            td_of(r#"<w:textDirection w:val="tbRl"/>"#).as_deref(),
+            Some("tbRl"),
+        );
+        assert_eq!(
+            td_of(r#"<w:textDirection w:val="btLr"/>"#).as_deref(),
+            Some("btLr"),
+        );
+        // The default "lrTb" collapses to None (horizontal serialization
+        // unchanged), as does an absent <w:textDirection>.
+        assert_eq!(td_of(r#"<w:textDirection w:val="lrTb"/>"#), None);
+        assert_eq!(td_of(""), None);
+
+        // A LOOSE mid-body sectPr (not pPr-owned) carries it too.
+        let body = body_from(
+            r#"
+            <w:p><w:r><w:t>sec1</w:t></w:r></w:p>
+            <w:sectPr><w:type w:val="nextPage"/><w:textDirection w:val="tbRl"/></w:sectPr>
+            <w:p><w:r><w:t>body</w:t></w:r></w:p>
+            "#,
+        );
+        let td = body
+            .iter()
+            .find_map(|e| match e {
+                BodyElement::SectionBreak { text_direction, .. } => Some(text_direction.clone()),
+                _ => None,
+            })
+            .expect("a SectionBreak marker");
+        assert_eq!(td.as_deref(), Some("tbRl"));
     }
 
     /// ECMA-376 §17.6.11 — `w:top` / `w:bottom` are ST_SignedTwipsMeasure and MAY

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -537,6 +537,17 @@ pub enum BodyElement {
         /// `headers` are carried per-terminating-section.
         #[serde(skip_serializing_if = "Option::is_none")]
         page_num_type: Option<PageNumType>,
+        /// ECMA-376 §17.6.20 `<w:textDirection w:val>` — this ENDING section's
+        /// flow direction (TRANSITIONAL ST_TextDirection, Part 4 §14.11.7), so a
+        /// vertical (tbRl/btLr) non-final section can coexist with a horizontal
+        /// final section (issue #1000 per-section mixing). Same handling as
+        /// `SectionProps.text_direction`: the default "lrTb" (and an absent
+        /// element) collapse to `None`; other tokens are carried verbatim.
+        /// Carried SEPARATELY from `geom` (like `page_num_type`) because a
+        /// section may inherit its page geometry yet still set its own flow
+        /// direction. `None` ⇒ horizontal (lrTb).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        text_direction: Option<String>,
     },
 }
 

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -14,7 +14,7 @@ import {
   type MathRenderer,
 } from '@silurus/ooxml-core';
 import type { PaginatedBodyElement, DocxDocumentModel, RenderPageOptions, WorkerRequest, WorkerResponse, DocComment, DocNote } from './types';
-import { renderDocumentToCanvas, documentHasMath, prepareMathRuns, paginateDocument, dropColorReplacedCache, physicalPageSizePt, type DocxTextRunInfo } from './renderer';
+import { renderDocumentToCanvas, documentHasMath, prepareMathRuns, paginateDocument, dropColorReplacedCache, physicalPageSizeForPage, type DocxTextRunInfo } from './renderer';
 import { buildBookmarkPageMap } from './bookmark-nav';
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
 import { loadEmbeddedFonts } from './embedded-fonts';
@@ -401,15 +401,13 @@ export class DocxDocument {
     if (!this._document) return { widthPt: 0, heightPt: 0 };
     const pages = this._getPages();
     const clamped = Math.max(0, Math.min(pageIndex, pages.length - 1));
-    const g = pages[clamped]?.[0]?.sectionGeom;
-    // The stamped `sectionGeom` is in LOGICAL dims for a vertical (tbRl) section
-    // (pagination runs on the swapped page); `physicalPageSizePt` un-swaps it so
-    // this reports the visible PHYSICAL page box (identity for horizontal docs).
-    return physicalPageSizePt(
-      this._document.section,
-      g?.pageWidth ?? this._document.section.pageWidth,
-      g?.pageHeight ?? this._document.section.pageHeight,
-    );
+    // The stamped `sectionGeom` is in LOGICAL dims for a vertical section
+    // (pagination runs on the swapped frame); `physicalPageSizeForPage` — the
+    // resolver shared with the render worker's `pageSizes` meta — un-swaps it
+    // by the PAGE's OWN stamped direction (§17.6.20 is per-section, issue
+    // #1000), so this reports the visible PHYSICAL page box (identity for
+    // horizontal pages).
+    return physicalPageSizeForPage(pages, clamped, this._document.section);
   }
 
   renderPage(

--- a/packages/docx/src/per-section-text-direction.test.ts
+++ b/packages/docx/src/per-section-text-direction.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computePages,
+  paginateDocument,
+  renderDocumentToCanvas,
+  physicalPageSizeForPage,
+  type DocxTextRunInfo,
+} from './renderer.js';
+import type {
+  BodyElement, DocParagraph, DocxTextRun, SectionProps, DocxDocumentModel,
+  SectionGeom, PaginatedBodyElement,
+} from './types';
+
+// ECMA-376 §17.6.20 — text direction is PER-SECTION (issue #1000, #988 batch-3
+// adjudication ①): a vertical (tbRl ≡ btLr per Word GT) NON-FINAL section can
+// coexist with a horizontal FINAL section in one document. The parser carries
+// the ending section's `<w:textDirection>` on its SectionBreak marker; the
+// paginator lays a vertical section out in its SWAPPED LOGICAL geometry
+// (`verticalLayoutSection`'s quarter-turn: logical width = physical height,
+// margins rotated) and stamps `sectionGeom` (logical) + `sectionTextDirection`
+// in lockstep; the renderer rotates each page +90° per ITS OWN direction.
+
+// Deterministic stub canvas: glyph advance = charCount × fontPx, font box =
+// 0.8/0.2 em (a single line is exactly fontPx tall). Copied from
+// per-section-page-geometry.test.ts.
+function makeCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, fillText() {}, strokeText() {}, beginPath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fillRect() {}, drawImage() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    letterSpacing: '0px',
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+// `paginateDocument` builds its measure ctx from `new OffscreenCanvas(...)`,
+// which the node test env lacks — polyfill with the same deterministic stub.
+(globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+  getContext() { return makeCtx(); }
+};
+
+type DocRun = DocParagraph['runs'][number];
+function textRun(text: string, fontSize: number): DocRun {
+  const run: DocxTextRun = {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize, color: null, fontFamily: 'NotInMetrics', isLink: false, background: null,
+    vertAlign: null, hyperlink: null,
+  } as unknown as DocxTextRun;
+  return { type: 'text', ...run } as DocRun;
+}
+function para(text: string, fontSize = 20): BodyElement {
+  const p: DocParagraph = {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: [textRun(text, fontSize)],
+    defaultFontSize: fontSize, defaultFontFamily: 'NotInMetrics', widowControl: false,
+  } as unknown as DocParagraph;
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+const EMPTY_HF = { default: null, first: null, even: null };
+
+// Horizontal FINAL (body) section with fully asymmetric margins so any margin
+// rotation slip is caught.
+function horizontalBodySection(): SectionProps {
+  return {
+    pageWidth: 400, pageHeight: 500,
+    marginTop: 12, marginRight: 24, marginBottom: 36, marginLeft: 48,
+    headerDistance: 5, footerDistance: 6, titlePage: false, evenAndOddHeaders: false,
+  } as SectionProps;
+}
+
+// A vertical section's PHYSICAL page geometry (as the parser emits it — the
+// sectPr's verbatim pgSz/pgMar), asymmetric margins.
+const VERT_PHYS: SectionGeom = {
+  pageWidth: 612, pageHeight: 792,
+  marginTop: 10, marginRight: 20, marginBottom: 30, marginLeft: 40,
+  headerDistance: 7, footerDistance: 8,
+};
+
+// body: [V1] <break: vertical btLr, explicit geom> [H1] (horizontal body section).
+function mixedDoc(): DocxDocumentModel {
+  const body: BodyElement[] = [
+    para('V1'),
+    { type: 'sectionBreak', kind: 'nextPage', geom: VERT_PHYS, textDirection: 'btLr' } as BodyElement,
+    para('H1'),
+  ];
+  return {
+    section: horizontalBodySection(), body,
+    headers: EMPTY_HF, footers: EMPTY_HF,
+    fontFamilyClasses: {},
+  } as unknown as DocxDocumentModel;
+}
+
+describe('per-section text direction (§17.6.20, issue #1000) — paginator stamps', () => {
+  it('stamps a vertical mid-section with its SWAPPED logical geometry + direction', () => {
+    const doc = mixedDoc();
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    // Page 0 = the btLr section. Its stamped geometry is the LOGICAL quarter-turn
+    // of the marker's physical geom: logical width = physical height, and
+    // logical margin{Left,Top,Right,Bottom} = physical margin{Top,Right,Bottom,Left}
+    // (verticalLayoutSection). header/footer distances are preserved.
+    const v1 = pages[0].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    expect(v1.sectionTextDirection).toBe('btLr');
+    expect(v1.sectionGeom).toEqual({
+      pageWidth: 792, pageHeight: 612,
+      marginLeft: 10, marginTop: 20, marginRight: 30, marginBottom: 40,
+      headerDistance: 7, footerDistance: 8,
+    });
+    // Page 1 = horizontal final section: body-level geometry, direction null.
+    const h1 = pages[1].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    expect(h1.sectionTextDirection).toBeNull();
+    expect(h1.sectionGeom?.pageWidth).toBe(400);
+    expect(h1.sectionGeom?.pageHeight).toBe(500);
+    expect(h1.sectionGeom?.marginLeft).toBe(48);
+  });
+
+  it('a geom-less vertical break swaps the BODY geometry (§17.18.77 inheritance)', () => {
+    const doc = mixedDoc();
+    doc.body[1] = { type: 'sectionBreak', kind: 'nextPage', textDirection: 'tbRl' } as BodyElement;
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    const v1 = pages[0].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    expect(v1.sectionTextDirection).toBe('tbRl');
+    // swap of body 400×500 / margins T12 R24 B36 L48 → logical
+    // 500×400 / L12 T24 R36 B48.
+    expect(v1.sectionGeom).toEqual({
+      pageWidth: 500, pageHeight: 400,
+      marginLeft: 12, marginTop: 24, marginRight: 36, marginBottom: 48,
+      headerDistance: 5, footerDistance: 6,
+    });
+  });
+
+  it('all-vertical single-section document keeps the legacy swapped stamps', () => {
+    const section: SectionProps = {
+      ...horizontalBodySection(),
+      pageWidth: 612, pageHeight: 792,
+      marginTop: 10, marginRight: 20, marginBottom: 30, marginLeft: 40,
+      headerDistance: 7, footerDistance: 8,
+      textDirection: 'tbRl',
+    } as SectionProps;
+    const doc = {
+      section, body: [para('V1'), para('V2')],
+      headers: EMPTY_HF, footers: EMPTY_HF, fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    // paginateDocument applies verticalLayoutDoc (the body-level swap) itself.
+    const pages = paginateDocument(doc);
+    for (const page of pages) {
+      for (const el of page) {
+        const p = el as PaginatedBodyElement;
+        expect(p.sectionTextDirection).toBe('tbRl');
+        expect(p.sectionGeom?.pageWidth).toBe(792);
+        expect(p.sectionGeom?.pageHeight).toBe(612);
+        expect(p.sectionGeom?.marginLeft).toBe(10);
+      }
+    }
+  });
+
+  // Height- AND width-sensitive: the vertical section must paginate against its
+  // SWAPPED frame. Physical 200(w)×300(h), margins all 20 ⇒ logical page 300×200,
+  // content height 160 (8 × 20pt one-line paras), wrap width 260 (a 10-char 20pt
+  // para = 200pt fits on ONE line). If the frame were left physical: content
+  // height 260 and wrap width 160 (two lines per para) — a totally different
+  // distribution — so this fails the moment the swap is dropped.
+  it('paginates a vertical mid-section against its SWAPPED logical frame', () => {
+    const vertPhys: SectionGeom = {
+      pageWidth: 200, pageHeight: 300,
+      marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+      headerDistance: 0, footerDistance: 0,
+    };
+    const body: BodyElement[] = [
+      ...Array.from({ length: 10 }, (_v, i) => para(`A${i + 1}______A${i + 1}`.slice(0, 10))),
+      { type: 'sectionBreak', kind: 'nextPage', geom: vertPhys, textDirection: 'tbRl' } as BodyElement,
+      para('B1'),
+    ];
+    const doc = {
+      section: horizontalBodySection(), body,
+      headers: EMPTY_HF, footers: EMPTY_HF, fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    const counts = pages.map((page) => page.filter((e) => e.type === 'paragraph').length);
+    // 8 one-line paras on page 0, the remaining 2 on page 1, B1 on page 2.
+    expect(counts).toEqual([8, 2, 1]);
+  });
+
+  it('promotes a CONTINUOUS boundary to a page break when the direction changes', () => {
+    // The paint model rotates a whole page: one direction per physical page is a
+    // documented renderer constraint, so a continuous break whose flow direction
+    // changes must open a fresh page. (Word GT for this boundary is unverified —
+    // this pins the model constraint, not a Word behavior claim.)
+    const section: SectionProps = { ...horizontalBodySection(), sectionStart: 'continuous' } as SectionProps;
+    const body: BodyElement[] = [
+      para('V1'),
+      { type: 'sectionBreak', kind: 'nextPage', geom: VERT_PHYS, textDirection: 'btLr' } as BodyElement,
+      para('H1'),
+    ];
+    const doc = {
+      section, body, headers: EMPTY_HF, footers: EMPTY_HF, fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    expect(pages.length).toBe(2);
+
+    // Control: the same continuous boundary WITHOUT a direction change stays on
+    // one page (the existing §17.18.77 continuous behavior is untouched).
+    const flatBody: BodyElement[] = [
+      para('S1'),
+      { type: 'sectionBreak', kind: 'nextPage', geom: VERT_PHYS } as BodyElement,
+      para('S2'),
+    ];
+    const flatDoc = {
+      section, body: flatBody, headers: EMPTY_HF, footers: EMPTY_HF, fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const flatPages = computePages(flatDoc.body, flatDoc.section, makeCtx());
+    expect(flatPages.length).toBe(1);
+  });
+});
+
+// A recording canvas that captures ctx.rotate + canvas dims + text-run overlay
+// payloads, so a test can assert the per-page +90° rotation.
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; rotations: number[] } {
+  let font = '10px serif';
+  const rotations: number[] = [];
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    rotate(r: number) { rotations.push(r); },
+    setTransform() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {}, fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, rotations };
+}
+
+describe('per-section text direction (§17.6.20, issue #1000) — renderer', () => {
+  it('rotates ONLY the vertical page +90°; the horizontal page stays unrotated', async () => {
+    const doc = mixedDoc();
+    const runs0: DocxTextRunInfo[] = [];
+    const { canvas: c0, rotations: r0 } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, c0, 0, { dpr: 1, onTextRun: (r) => runs0.push(r) });
+    const runs1: DocxTextRunInfo[] = [];
+    const { canvas: c1, rotations: r1 } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, c1, 1, { dpr: 1, onTextRun: (r) => runs1.push(r) });
+
+    // Page 0 (btLr): the whole-page +90° paint rotation fires (one +π/2 among the
+    // rotations; per-glyph counter-rotations may add more entries).
+    expect(r0.some((r) => Math.abs(r - Math.PI / 2) < 1e-9)).toBe(true);
+    // Its canvas is the PHYSICAL page box (612×792 portrait).
+    expect(c0.width / c0.height).toBeCloseTo(612 / 792, 2);
+    // The overlay run is handed the vertical placement transform.
+    expect(runs0.length).toBeGreaterThan(0);
+    expect(runs0[0].transform).toBeDefined();
+
+    // Page 1 (horizontal body): no page rotation, no overlay transform, its own
+    // 400×500 box.
+    expect(r1.some((r) => Math.abs(r - Math.PI / 2) < 1e-9)).toBe(false);
+    expect(c1.width / c1.height).toBeCloseTo(400 / 500, 2);
+    expect(runs1.length).toBeGreaterThan(0);
+    expect(runs1[0].transform).toBeUndefined();
+  });
+});
+
+describe('per-section text direction (§17.6.20, issue #1000) — physical page size', () => {
+  it('un-swaps each page by ITS OWN stamped direction', () => {
+    const doc = mixedDoc();
+    const pages = paginateDocument(doc);
+    // Page 0 (vertical): stamped LOGICAL 792×612 → physical 612×792.
+    expect(physicalPageSizeForPage(pages, 0, doc.section)).toEqual({ widthPt: 612, heightPt: 792 });
+    // Page 1 (horizontal): stamped physical box verbatim.
+    expect(physicalPageSizeForPage(pages, 1, doc.section)).toEqual({ widthPt: 400, heightPt: 500 });
+  });
+
+  it('resolves an EMPTY parity page from its page metadata, not the body fallback', () => {
+    // Mid VERTICAL section whose start type is oddPage: the parity padding leaves
+    // a BLANK page owned by the incoming vertical section (pages: [H1][blank][V1]
+    // [H2]). Element-stamp fallback would report the body-level 400×500 box for
+    // the blank page; the paginator's page metadata reports the vertical
+    // section's physical 612×792.
+    const body: BodyElement[] = [
+      para('H1'),
+      // marker ending section 1 (horizontal, geom-less). The UPCOMING section's
+      // start type is the NEXT marker's kind (§17.6.22): oddPage.
+      { type: 'sectionBreak', kind: 'nextPage' } as BodyElement,
+      para('V1'),
+      { type: 'sectionBreak', kind: 'oddPage', geom: VERT_PHYS, textDirection: 'tbRl' } as BodyElement,
+      para('H2'),
+    ];
+    const doc = {
+      section: horizontalBodySection(), body,
+      headers: EMPTY_HF, footers: EMPTY_HF, fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const pages = paginateDocument(doc);
+    // Page 0: H1. Page 1: parity blank (the oddPage section pads past the even
+    // slot). Page 2: V1 (vertical). Page 3: H2.
+    expect(pages.length).toBe(4);
+    expect(pages[1]).toHaveLength(0);
+    expect(physicalPageSizeForPage(pages, 2, doc.section)).toEqual({ widthPt: 612, heightPt: 792 });
+    // The blank parity page belongs to the INCOMING vertical section (the
+    // paginator's transition model): physical 612×792, not the body 400×500.
+    expect(physicalPageSizeForPage(pages, 1, doc.section)).toEqual({ widthPt: 612, heightPt: 792 });
+  });
+});
+
+describe('per-section text direction (§17.6.20, issue #1000) — HF reserve', () => {
+  it('reserves NOTHING on a vertical page (paint draws its HF physically, reserve-free)', () => {
+    // Vertical mid-section: physical 200×300, margins 20 ⇒ logical content height
+    // 160 ⇒ exactly 8 one-line 20pt paras. A 40pt footer whose extent (10+40)
+    // overflows the 20pt logical bottom margin would phantom-reserve 30pt and
+    // push A7/A8 off the page — the paint pass never reserves on vertical pages
+    // (issue #988: vertical HF draw horizontally at the physical margins), so
+    // pagination must not either.
+    const vertPhys: SectionGeom = {
+      pageWidth: 200, pageHeight: 300,
+      marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+      headerDistance: 0, footerDistance: 10,
+    };
+    const footer40 = { body: [para('F', 40)] };
+    const body: BodyElement[] = [
+      ...Array.from({ length: 8 }, (_v, i) => para(`A${i + 1}`)),
+      {
+        type: 'sectionBreak', kind: 'nextPage', geom: vertPhys, textDirection: 'tbRl',
+        headers: EMPTY_HF, footers: { default: footer40, first: null, even: null },
+        titlePage: false,
+      } as BodyElement,
+      para('B1'),
+    ];
+    const doc = {
+      section: { ...horizontalBodySection(), footerDistance: 10 },
+      body,
+      headers: EMPTY_HF, footers: { default: footer40, first: null, even: null },
+      fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const pages = paginateDocument(doc);
+    const textsOn = (i: number) =>
+      (pages[i] ?? []).filter((e) => e.type === 'paragraph')
+        .map((e) => ((e as { runs?: { text?: string }[] }).runs ?? []).map((r) => r.text).join(''));
+    expect(textsOn(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8']);
+    expect(textsOn(1)).toEqual(['B1']);
+  });
+});

--- a/packages/docx/src/per-section-text-direction.test.ts
+++ b/packages/docx/src/per-section-text-direction.test.ts
@@ -297,19 +297,21 @@ describe('per-section text direction (§17.6.20, issue #1000) — physical page 
     expect(physicalPageSizeForPage(pages, 1, doc.section)).toEqual({ widthPt: 400, heightPt: 500 });
   });
 
-  it('resolves an EMPTY parity page from its page metadata, not the body fallback', () => {
-    // Mid VERTICAL section whose start type is oddPage: the parity padding leaves
-    // a BLANK page owned by the incoming vertical section (pages: [H1][blank][V1]
-    // [H2]). Element-stamp fallback would report the body-level 400×500 box for
-    // the blank page; the paginator's page metadata reports the vertical
-    // section's physical 612×792.
+  it('resolves an EMPTY parity page from its page metadata: the blank belongs to the OUTGOING section', () => {
+    // A VERTICAL first section followed by an oddPage-starting horizontal
+    // section: the parity padding leaves a BLANK page (pages: [V1][blank][H1]
+    // [H2]). §17.18.77 — the new section "begins on the next odd-numbered page,
+    // LEAVING the next even page blank": the blank precedes the incoming
+    // section's start, so it carries the OUTGOING (vertical) section's frame —
+    // physical 612×792 — not the body-level 400×500 the element-stamp fallback
+    // would report (the blank has no elements).
     const body: BodyElement[] = [
-      para('H1'),
-      // marker ending section 1 (horizontal, geom-less). The UPCOMING section's
-      // start type is the NEXT marker's kind (§17.6.22): oddPage.
-      { type: 'sectionBreak', kind: 'nextPage' } as BodyElement,
       para('V1'),
-      { type: 'sectionBreak', kind: 'oddPage', geom: VERT_PHYS, textDirection: 'tbRl' } as BodyElement,
+      // marker ending section 1 (vertical). The UPCOMING section's start type
+      // is the NEXT marker's kind (§17.6.22): oddPage.
+      { type: 'sectionBreak', kind: 'nextPage', geom: VERT_PHYS, textDirection: 'tbRl' } as BodyElement,
+      para('H1'),
+      { type: 'sectionBreak', kind: 'oddPage' } as BodyElement,
       para('H2'),
     ];
     const doc = {
@@ -317,14 +319,137 @@ describe('per-section text direction (§17.6.20, issue #1000) — physical page 
       headers: EMPTY_HF, footers: EMPTY_HF, fontFamilyClasses: {},
     } as unknown as DocxDocumentModel;
     const pages = paginateDocument(doc);
-    // Page 0: H1. Page 1: parity blank (the oddPage section pads past the even
-    // slot). Page 2: V1 (vertical). Page 3: H2.
+    // Page 0: V1 (vertical). Page 1: parity blank (the oddPage section pads
+    // past the even slot). Page 2: H1. Page 3: H2 (nextPage default into the
+    // final section).
     expect(pages.length).toBe(4);
     expect(pages[1]).toHaveLength(0);
-    expect(physicalPageSizeForPage(pages, 2, doc.section)).toEqual({ widthPt: 612, heightPt: 792 });
-    // The blank parity page belongs to the INCOMING vertical section (the
-    // paginator's transition model): physical 612×792, not the body 400×500.
+    expect(physicalPageSizeForPage(pages, 0, doc.section)).toEqual({ widthPt: 612, heightPt: 792 });
+    // The blank parity page belongs to the OUTGOING vertical section
+    // (§17.18.77): physical 612×792, not the body 400×500.
     expect(physicalPageSizeForPage(pages, 1, doc.section)).toEqual({ widthPt: 612, heightPt: 792 });
+    // The incoming oddPage section itself is horizontal at the body box.
+    expect(physicalPageSizeForPage(pages, 2, doc.section)).toEqual({ widthPt: 400, heightPt: 500 });
+  });
+});
+
+describe('per-section text direction (§17.6.20, issue #1000) — vertical BODY + horizontal mid', () => {
+  // The reverse mix: the FINAL (body) section is vertical, a NON-final section
+  // horizontal. The body-level swap (verticalLayoutDoc) still runs, so the
+  // geom-less horizontal marker must inherit the body's PHYSICAL geometry
+  // (physicalGeomOf un-swaps the already-swapped body frame — the double-swap
+  // trap), and the horizontal page must paint unrotated while the vertical
+  // final page rotates.
+  it('a geom-less horizontal mid-section inherits the PHYSICAL body geometry', () => {
+    const section: SectionProps = {
+      ...horizontalBodySection(),
+      pageWidth: 612, pageHeight: 792,
+      marginTop: 10, marginRight: 20, marginBottom: 30, marginLeft: 40,
+      headerDistance: 7, footerDistance: 8,
+      textDirection: 'tbRl',
+    } as SectionProps;
+    const body: BodyElement[] = [
+      para('H1'),
+      { type: 'sectionBreak', kind: 'nextPage' } as BodyElement, // horizontal, geom-less
+      para('V1'),
+    ];
+    const doc = {
+      section, body, headers: EMPTY_HF, footers: EMPTY_HF, fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const pages = paginateDocument(doc);
+    const h1 = pages[0].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    // The horizontal mid-section's frame is the body's verbatim PHYSICAL box —
+    // NOT the swapped logical one, and NOT a double-swap of it.
+    expect(h1.sectionTextDirection).toBeNull();
+    expect(h1.sectionGeom).toEqual({
+      pageWidth: 612, pageHeight: 792,
+      marginTop: 10, marginRight: 20, marginBottom: 30, marginLeft: 40,
+      headerDistance: 7, footerDistance: 8,
+    });
+    // The vertical final section keeps the swapped logical frame.
+    const v1 = pages[1].find((e) => e.type === 'paragraph') as PaginatedBodyElement;
+    expect(v1.sectionTextDirection).toBe('tbRl');
+    expect(v1.sectionGeom).toEqual({
+      pageWidth: 792, pageHeight: 612,
+      marginLeft: 10, marginTop: 20, marginRight: 30, marginBottom: 40,
+      headerDistance: 7, footerDistance: 8,
+    });
+    // Physical page boxes agree per page.
+    expect(physicalPageSizeForPage(pages, 0, doc.section)).toEqual({ widthPt: 612, heightPt: 792 });
+    expect(physicalPageSizeForPage(pages, 1, doc.section)).toEqual({ widthPt: 612, heightPt: 792 });
+  });
+
+  it('paints the horizontal mid page unrotated and the vertical final page rotated', async () => {
+    const section: SectionProps = {
+      ...horizontalBodySection(),
+      pageWidth: 612, pageHeight: 792,
+      marginTop: 10, marginRight: 20, marginBottom: 30, marginLeft: 40,
+      textDirection: 'tbRl',
+    } as SectionProps;
+    const body: BodyElement[] = [
+      para('H1'),
+      { type: 'sectionBreak', kind: 'nextPage' } as BodyElement,
+      para('V1'),
+    ];
+    const doc = {
+      section, body, headers: EMPTY_HF, footers: EMPTY_HF, fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const { canvas: c0, rotations: r0 } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, c0, 0, { dpr: 1 });
+    const { canvas: c1, rotations: r1 } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, c1, 1, { dpr: 1 });
+    expect(r0.some((r) => Math.abs(r - Math.PI / 2) < 1e-9)).toBe(false);
+    expect(r1.some((r) => Math.abs(r - Math.PI / 2) < 1e-9)).toBe(true);
+    // Both pages share the same physical portrait box here.
+    expect(c0.width / c0.height).toBeCloseTo(612 / 792, 2);
+    expect(c1.width / c1.height).toBeCloseTo(612 / 792, 2);
+  });
+});
+
+describe('per-section text direction (§17.6.20, issue #1000) — split slices and layoutDocument', () => {
+  it('stamps the direction on every slice of a split paragraph in a vertical mid-section', () => {
+    // Physical 200×300, margins 20 ⇒ logical frame 300×200: wrap width 260
+    // (13 chars × 20 pt), content height 160 (8 lines/page). One 40-char
+    // paragraph wraps to 4 lines; 26 of them (104 lines) force paragraph
+    // SPLITS across pages, so the split-slice stamping path (tagSection…
+    // thunks) is exercised, not just pushTagged.
+    const vertPhys: SectionGeom = {
+      pageWidth: 200, pageHeight: 300,
+      marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20,
+      headerDistance: 0, footerDistance: 0,
+    };
+    const body: BodyElement[] = [
+      para('X'.repeat(13 * 12)), // 12 lines > 8 per page ⇒ must split
+      { type: 'sectionBreak', kind: 'nextPage', geom: vertPhys, textDirection: 'tbRl' } as BodyElement,
+      para('B1'),
+    ];
+    const doc = {
+      section: horizontalBodySection(), body,
+      headers: EMPTY_HF, footers: EMPTY_HF, fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const pages = computePages(doc.body, doc.section, makeCtx());
+    // The paragraph split across ≥ 2 pages inside the vertical section.
+    expect(pages.length).toBeGreaterThanOrEqual(3);
+    for (let i = 0; i < pages.length - 1; i++) {
+      const slices = pages[i].filter((e) => e.type === 'paragraph') as PaginatedBodyElement[];
+      expect(slices.length).toBeGreaterThan(0);
+      for (const s of slices) {
+        expect(s.sectionTextDirection).toBe('tbRl');
+        expect(s.sectionGeom?.pageWidth).toBe(300);
+        expect(s.sectionGeom?.pageHeight).toBe(200);
+      }
+    }
+  });
+
+  it('layoutDocument reports each page own textDirection', async () => {
+    const { layoutDocument } = await import('./renderer.js');
+    const layout = layoutDocument(mixedDoc());
+    expect(layout.pages.length).toBe(2);
+    expect(layout.pages[0].section.textDirection).toBe('btLr');
+    // The vertical page's LayoutPage geometry is the swapped logical frame.
+    expect(layout.pages[0].geometry.pageWidth).toBe(792);
+    expect(layout.pages[1].section.textDirection).toBe('lrTb');
+    expect(layout.pages[1].geometry.pageWidth).toBe(400);
   });
 });
 

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -16,7 +16,7 @@ import {
   dropSvgImageCache,
 } from '@silurus/ooxml-core';
 import type { DocxDocumentModel, PaginatedBodyElement } from './types';
-import { paginateDocument, renderDocumentToCanvas, physicalPageSizePt, dropColorReplacedCache, type DocxTextRunInfo } from './renderer';
+import { paginateDocument, renderDocumentToCanvas, physicalPageSizeForPage, dropColorReplacedCache, type DocxTextRunInfo } from './renderer';
 import { buildBookmarkPageMap } from './bookmark-nav';
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
 import { loadEmbeddedFonts } from './embedded-fonts';
@@ -114,20 +114,16 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         });
       }
       pages = paginateDocument(doc);
-      // ECMA-376 §17.6.13 / §17.6.11 — per-page size from each page's first
-      // element's stamped `sectionGeom` (body-level fallback for an empty page).
+      // ECMA-376 §17.6.13 / §17.6.11 / §17.6.20 — per-page size from each page's
+      // stamped frame (its page-meta for an empty parity page). A vertical
+      // section paginates on the SWAPPED logical geometry, so
+      // `physicalPageSizeForPage` — the resolver shared with
+      // `DocxDocument.pageSize` — un-swaps the stamped dims by the PAGE's OWN
+      // direction (per-section, issue #1000) back to the PHYSICAL page box the
+      // meta reports (identity for horizontal pages).
       const model = doc;
-      const pageSizes = pages.map((els) => {
-        const g = els[0]?.sectionGeom;
-        // A vertical (tbRl) section paginates on the SWAPPED logical geometry, so
-        // un-swap the stamped dims back to the PHYSICAL page box the meta reports
-        // (identity for horizontal docs).
-        return physicalPageSizePt(
-          model.section,
-          g?.pageWidth ?? model.section.pageWidth,
-          g?.pageHeight ?? model.section.pageHeight,
-        );
-      });
+      const paginated = pages;
+      const pageSizes = paginated.map((_els, i) => physicalPageSizeForPage(paginated, i, model.section));
       const meta: DocumentMeta = {
         pageCount: pages.length,
         comments: doc.comments ?? [],

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1,7 +1,7 @@
 import type {
   DocxDocumentModel, BodyElement, PaginatedBodyElement, DocParagraph, DocTable, DocTableRow, DocTableCell, CellElement,
   DocRun, DocxTextRun, ImageRun, ChartRun, ShapeRun, ShapeFill, TextPath, ShapeText, ShapeTextRun, FieldRun, HeaderFooter, HeadersFooters, LineSpacing, BorderSpec, TableBorders, CellBorders,
-  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, SectionGeom, PageNumType, PageBorders, PageBorderEdge, DocNote, NumberingInfo, ColumnGeom, FramePr, TblpPr, DocSettings,
+  TabStop, ParagraphBorders, ParaBorderEdge, DocxRunBorder, SectionProps, SectionGeom, PageNumType, PageBorders, PageBorderEdge, DocNote, NumberingInfo, ColumnGeom, ColumnsSpec, FramePr, TblpPr, DocSettings,
 } from './types';
 import type { ArrowEnd, Stroke } from '@silurus/ooxml-core';
 import {
@@ -1100,16 +1100,24 @@ const renderTokens = new WeakMap<HTMLCanvasElement | OffscreenCanvas, number>();
  *                                 same +90° vertical path as `tbRl`. (The per-
  *                                 SECTION mixing that fixture also exercises —
  *                                 a `btLr` non-final section beside a horizontal
- *                                 final section — needs per-section text-direction
- *                                 surfacing and remains a follow-up; a document
- *                                 whose body section is `btLr` renders vertically
- *                                 here already.)
+ *                                 final section — is surfaced per-section: the
+ *                                 SectionBreak marker carries `textDirection`,
+ *                                 the paginator stamps it in lockstep with the
+ *                                 section geometry, and each page rotates by its
+ *                                 OWN direction. Issue #1000.)
  *  Two are HORIZONTAL (glyphs upright, lines top→bottom) ⇒ false:
  *    - `lrTb`  (≡ Strict `tb`, the default) — dropped to null by the parser.
  *    - `lrTbV` (≡ Strict `tbV`) — horizontal, EA glyphs rotated 270°; still a
  *                                 horizontal flow, so not this vertical path. */
 function isVerticalSection(s: SectionProps): boolean {
-  const td = s.textDirection;
+  return isVerticalTextDirection(s.textDirection);
+}
+
+/** The raw-token predicate behind {@link isVerticalSection}, for the PER-SECTION
+ *  carriers that hold a bare `textDirection` value (a SectionBreak marker's
+ *  `textDirection`, an element's stamped `sectionTextDirection`) rather than a
+ *  full SectionProps (issue #1000). `null`/`undefined`/unknown ⇒ horizontal. */
+function isVerticalTextDirection(td: string | null | undefined): boolean {
   return td === 'tbRl' || td === 'tbRlV' || td === 'tbLrV' || td === 'btLr';
 }
 
@@ -1145,12 +1153,12 @@ function verticalLayoutSection(phys: SectionProps): SectionProps {
 /** Return a shallow copy of `doc` with its BODY-LEVEL section swapped to the
  *  vertical LOGICAL geometry, so the pagination + layout engine — which reads
  *  `doc.section` — organises the page as a rotated horizontal page. Per-body
- *  SectionBreak `geom`s are NOT swapped: per-section geometry/text-direction
- *  inside a vertical document is the #988 ① per-section follow-up, so vertical
- *  layout is body-section uniform today and consumers must not mix a mid-body
- *  section geom into the swapped frame. Only invoked when the body section is
- *  vertical; horizontal docs are returned untouched (referential identity),
- *  keeping the horizontal path byte-identical. */
+ *  SectionBreak `geom`s are NOT swapped here: the paginator resolves each
+ *  mid-body section's own logical frame (swapped iff THAT section is vertical)
+ *  through `sectionFrameFrom` (issue #1000 per-section text direction), so a
+ *  marker's `geom` stays the PHYSICAL geometry the parser emitted. Only invoked
+ *  when the body section is vertical; horizontal docs are returned untouched
+ *  (referential identity), keeping the horizontal path byte-identical. */
 function verticalLayoutDoc(doc: DocxDocumentModel): DocxDocumentModel {
   if (!isVerticalSection(doc.section)) return doc;
   return { ...doc, section: verticalLayoutSection(doc.section) };
@@ -1175,22 +1183,115 @@ function physicalLayoutSection(logical: SectionProps): SectionProps {
   };
 }
 
-/** Map a page's stamped `sectionGeom` width/height back to PHYSICAL page size.
- *  Pagination for a vertical (tbRl) section runs on the SWAPPED logical geometry
- *  (`verticalLayoutDoc`), so a page's stamped `pageWidth`/`pageHeight` are the
- *  LOGICAL dims (width = physical height). Callers that report the visible page
- *  box (e.g. `DocxDocument.pageSize`, the worker's `pageSizes` meta, a scroll
- *  viewer's spacer) want the PHYSICAL size, so this un-swaps for vertical sections
- *  and is identity for horizontal ones. `section` is the body-level section (its
- *  `textDirection` decides the flow); `w`/`h` are the page's stamped dims. */
-export function physicalPageSizePt(
+/** The geometry projection of {@link verticalLayoutSection} on a bare
+ *  {@link SectionGeom}: physical → SWAPPED LOGICAL (quarter-turn; margins rotate
+ *  L←T, T←R, R←B, B←L; header/footer distances preserved). Used by the paginator
+ *  to lay a vertical MID-BODY section out in its own logical frame (issue #1000)
+ *  — the body-level section keeps going through `verticalLayoutDoc`. */
+function logicalGeomOf(phys: SectionGeom): SectionGeom {
+  return {
+    pageWidth: phys.pageHeight,
+    pageHeight: phys.pageWidth,
+    marginLeft: phys.marginTop,
+    marginTop: phys.marginRight,
+    marginRight: phys.marginBottom,
+    marginBottom: phys.marginLeft,
+    headerDistance: phys.headerDistance,
+    footerDistance: phys.footerDistance,
+  };
+}
+
+/** Inverse of {@link logicalGeomOf} — the geometry projection of
+ *  {@link physicalLayoutSection}: SWAPPED LOGICAL → physical (margins rotate
+ *  T←L, R←T, B←R, L←B). `physicalGeomOf(logicalGeomOf(g)) === g`. */
+function physicalGeomOf(logical: SectionGeom): SectionGeom {
+  return {
+    pageWidth: logical.pageHeight,
+    pageHeight: logical.pageWidth,
+    marginTop: logical.marginLeft,
+    marginRight: logical.marginTop,
+    marginBottom: logical.marginRight,
+    marginLeft: logical.marginBottom,
+    headerDistance: logical.headerDistance,
+    footerDistance: logical.footerDistance,
+  };
+}
+
+/** Per-PAGE frame metadata the paginator records for every physical page it
+ *  opens (keyed by the page's element-array identity, so prebuilt pages carry it
+ *  into the paint pass without any API change — mirrors the `bodyFlowFragments`
+ *  WeakMap pattern). It duplicates the first element's `sectionGeom` /
+ *  `sectionTextDirection` stamps, and is the ONLY carrier for an EMPTY page
+ *  (§17.18.79 oddPage/evenPage parity padding), whose direction and physical
+ *  size are observable even though it has no elements — the incoming section
+ *  (the paginator's transition model) owns it. Scope note (issue #1000): the
+ *  metadata carries the page FRAME only (geometry + direction); header/footer
+ *  and page-number resolution for empty pages keep their existing body-level
+ *  fallback (documented residual). */
+interface PageFrameMeta {
+  /** The owning section's LOGICAL page geometry (swapped for a vertical section). */
+  geom: SectionGeom;
+  /** The owning section's `textDirection` (`null` ⇒ horizontal). */
+  textDirection: string | null;
+}
+const pageFrameMeta = new WeakMap<object, PageFrameMeta>();
+
+/** A section resolved to the LOGICAL frame the paginator lays it out in (issue
+ *  #1000 per-section text direction): a vertical (tbRl ≡ btLr, §17.6.20 + the
+ *  #988 batch-3 adjudication ①) section's `geom` is its PHYSICAL page geometry
+ *  quarter-turned by {@link logicalGeomOf}; a horizontal section's `geom` is
+ *  physical verbatim. `textDirection` is the owning section's raw token
+ *  (`null` ⇒ horizontal) and `vertical` its {@link isVerticalTextDirection}
+ *  projection — carried separately so consumers never re-derive it against the
+ *  wrong section. `columnsSpec` is the owning section's `<w:cols>` (§17.6.4). */
+interface ResolvedSectionFrame {
+  geom: SectionGeom;
+  textDirection: string | null;
+  vertical: boolean;
+  columnsSpec: ColumnsSpec | null;
+}
+
+/** Resolve a page's `textDirection` (issue #1000 per-section mixing): the first
+ *  element's stamped `sectionTextDirection`, else the page's {@link PageFrameMeta}
+ *  (empty pages), else the body-level `section.textDirection` (legacy / manually
+ *  constructed test pages — the pre-per-section behaviour). `null` ⇒ horizontal.
+ *  NOTE: `sectionTextDirection` stamps `null` explicitly for horizontal sections,
+ *  so only `undefined` (no stamp) falls through. */
+function pageTextDirection(
+  pages: PaginatedBodyElement[][],
+  pageIndex: number,
   section: SectionProps,
-  w: number,
-  h: number,
+): string | null {
+  const page = pages[pageIndex];
+  const stamped = page?.[0]?.sectionTextDirection;
+  if (stamped !== undefined) return stamped;
+  const meta = page ? pageFrameMeta.get(page) : undefined;
+  if (meta) return meta.textDirection;
+  return section.textDirection ?? null;
+}
+
+/** The PHYSICAL page box of page `pageIndex` — the single page-size resolver
+ *  shared by `DocxDocument.pageSize` (main mode) and the render worker's
+ *  `pageSizes` meta, so the two can never drift (issue #1000). The stamped
+ *  `sectionGeom` is the owning section's LOGICAL geometry (swapped for a
+ *  vertical section), so it is un-swapped by the PAGE's OWN direction — not the
+ *  body-level one, which a per-section mixed document would misreport. An empty
+ *  (parity-padding) page resolves through its {@link PageFrameMeta}; a page with
+ *  no stamp at all (legacy callers) reports the body-level section's verbatim —
+ *  PHYSICAL — pgSz box. `section` is the body-level section as parsed
+ *  (physical, unswapped). */
+export function physicalPageSizeForPage(
+  pages: PaginatedBodyElement[][],
+  pageIndex: number,
+  section: SectionProps,
 ): { widthPt: number; heightPt: number } {
-  return isVerticalSection(section)
-    ? { widthPt: h, heightPt: w }
-    : { widthPt: w, heightPt: h };
+  const page = pages[pageIndex];
+  const meta = page ? pageFrameMeta.get(page) : undefined;
+  const g = page?.[0]?.sectionGeom ?? meta?.geom;
+  if (g == null) return { widthPt: section.pageWidth, heightPt: section.pageHeight };
+  return isVerticalTextDirection(pageTextDirection(pages, pageIndex, section))
+    ? { widthPt: g.pageHeight, heightPt: g.pageWidth }
+    : { widthPt: g.pageWidth, heightPt: g.pageHeight };
 }
 
 /**
@@ -1307,11 +1408,11 @@ async function renderDocumentToCanvasLeased(
   const ctx = canvas.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
   // ECMA-376 §17.6.20 — for a vertical (tbRl) section the page is laid out in a
   // SWAPPED logical space (logical width = physical page height) and rotated +90°
-  // into physical space at paint. `layoutDoc` carries the swapped geometry through
-  // pagination + per-page section resolution; horizontal docs get `doc` unchanged
-  // (referential identity ⇒ byte-identical). The vertical flag is read from the
-  // ORIGINAL section (the swap preserves textDirection).
-  const vertical = isVerticalSection(doc.section);
+  // into physical space at paint. `layoutDoc` carries the swapped BODY-level
+  // geometry through pagination + per-page section resolution; horizontal docs
+  // get `doc` unchanged (referential identity ⇒ byte-identical). Text direction
+  // is PER-SECTION (issue #1000), so the `vertical` flag is resolved per PAGE
+  // below, after the stamped page frame is merged.
   const layoutDoc = verticalLayoutDoc(doc);
   const layoutSettings = resolveDocumentLayoutSettings(layoutDoc);
   const kinsoku = layoutSettings.kinsoku;
@@ -1343,12 +1444,23 @@ async function renderDocumentToCanvasLeased(
   // single-section document `geom` equals `doc.section`, so `sec === doc.section` in
   // value — byte-identical output.
   // `sec` is the LOGICAL section the body/header/footer are laid out in: for a
-  // vertical page that is the swapped geometry (from `layoutDoc`), for horizontal
-  // it equals the physical section. All RenderState geometry below (contentX/W,
-  // margins, pageWidth, docGrid) reads `sec`, so the entire layout is expressed
-  // in logical coordinates and the page transform maps it to physical space.
+  // vertical page that is the swapped geometry (the paginator stamps a vertical
+  // section's SWAPPED logical geom), for horizontal it equals the physical
+  // section. All RenderState geometry below (contentX/W, margins, pageWidth,
+  // docGrid) reads `sec`, so the entire layout is expressed in logical
+  // coordinates and the page transform maps it to physical space.
+  //
+  // Issue #1000 — `textDirection` is merged per PAGE too (the stamped
+  // `sectionTextDirection`, in lockstep with the stamped geom; body-level
+  // fallback for unstamped legacy pages), and `vertical` — which keys the
+  // physical canvas box, the +90° page rotation, `verticalCJK`, `verticalPhys`
+  // and the horizontal header/footer branch below — is derived from the MERGED
+  // section, so a vertical non-final section and a horizontal final section
+  // each paint in their own orientation.
   const pageGeom = resolvePageSection(pages, pageIndex, layoutDoc).geom;
-  const sec: SectionProps = { ...layoutDoc.section, ...pageGeom };
+  const pageTd = pageTextDirection(pages, pageIndex, layoutDoc.section);
+  const sec: SectionProps = { ...layoutDoc.section, ...pageGeom, textDirection: pageTd };
+  const vertical = isVerticalSection(sec);
   const sectionLayout = resolveSectionLayoutContext(layoutSettings, sec);
 
   // The CANVAS is sized to the PHYSICAL page (visible landscape page for tbRl):
@@ -2127,24 +2239,25 @@ export function computePages(
     documentSettings,
   );
   // ECMA-376 §17.6.20 + §17.4.80 (issue #988 batch-3 adjudication ④): in a
-  // vertical (tbRl) section — `section` here is the SWAPPED logical geometry,
-  // textDirection preserved — a block table is an UPRIGHT block: its cells lay
+  // vertical (tbRl) section a block table is an UPRIGHT block: its cells lay
   // out horizontally at the PHYSICAL content width, and it advances the flow by
   // its PHYSICAL WIDTH (the paint pass's renderTable vertical branch). The
-  // paginator must charge that same footprint, so resolve the physical content
-  // band from the BODY-LEVEL swapped section — the one frame-consistent source
-  // today: `verticalLayoutDoc` swaps only `doc.section`, so a mid-body
-  // SectionBreak's `geom` still carries PHYSICAL page geometry and must not be
-  // fed through `physicalLayoutSection` (it would double-invert). Per-section
-  // geometry/text-direction inside a vertical document is the #988 ①
-  // per-section follow-up; until it lands, vertical layout is body-section
-  // uniform (measure `verticalPhys` in buildMeasureState is seeded from the
-  // same body-level section, and the paint pass resolves the same geometry for
-  // every page). Horizontal sections are untouched (`verticalUpright` false).
-  const verticalUpright = isVerticalSection(section);
-  const uprightPhysSection = verticalUpright ? physicalLayoutSection(section) : section;
-  const uprightTableBandPt = (): number =>
-    uprightPhysSection.pageWidth - uprightPhysSection.marginLeft - uprightPhysSection.marginRight;
+  // paginator must charge that same footprint. Text direction is PER-SECTION
+  // (issue #1000), so these are closures over the ACTIVE section's resolved
+  // frame (`currentSectionFrame`, reassigned at every SectionBreak): the
+  // physical band is the quarter-turn un-swap of the current LOGICAL geometry.
+  // For a single-section vertical document the frame is the body-level swapped
+  // section throughout — value-identical to the previous body-pinned band.
+  // Horizontal sections are untouched (`verticalUpright()` false).
+  // (TDZ note: `currentSectionFrame` is declared below; these arrows only close
+  // over it and first run during the element loop, after its `let` init.)
+  const verticalUpright = (): boolean => currentSectionFrame.vertical;
+  const uprightTableBandPt = (): number => {
+    const g = currentSectionFrame.vertical
+      ? physicalGeomOf(currentSectionFrame.geom)
+      : currentSectionFrame.geom;
+    return g.pageWidth - g.marginLeft - g.marginRight;
+  };
   const noteById = indexNotes(footnotes);
   const haveFootnotes = noteById.size > 0;
   // Per-page reserved footnote height (pt). Index 0 = first page. Grows as
@@ -2163,18 +2276,19 @@ export function computePages(
     for (let j = startIdx; j < body.length; j++) {
       const e = body[j];
       if (e.type === 'sectionBreak') {
-        // Resolve this section's cols by swapping in its ColumnsSpec AND its page
-        // GEOMETRY. `computeColumns` derives the text band from
-        // pageWidth/marginLeft/marginRight (ECMA-376 §17.6.13 pgSz + §17.6.11
-        // pgMar), which are PER-SECTION — the ending section's geometry lives on
-        // this same SectionBreak marker (`e.geom`, from `sectionGeomFrom`). Spread
-        // it over the body-level `section` so the band width and x-origin come from
-        // the owning section, not the body-level one. `SectionGeom`'s field names
-        // and semantics match `SectionProps` (see the SectionGeom warning comment),
-        // so this only overrides the page-box fields. A `geom`-less marker (an
-        // inheriting section) falls back to the body-level geometry, matching
-        // `sectionGeomFrom`'s `?? bodySectionGeom`.
-        return computeColumns({ ...section, ...(e.geom ?? {}), columns: e.columns ?? null });
+        // Resolve this section's cols by swapping in its ColumnsSpec AND its
+        // resolved LOGICAL page geometry. `computeColumns` derives the text band
+        // from pageWidth/marginLeft/marginRight (ECMA-376 §17.6.13 pgSz +
+        // §17.6.11 pgMar), which are PER-SECTION — and for a VERTICAL section
+        // (issue #1000) the band lives in the SWAPPED logical frame, so this
+        // consumes the same `markerFrame` the geometry rail stamps (never the
+        // raw physical `e.geom`). Spread over the body-level `section` so only
+        // the page-box fields are overridden (`SectionGeom`'s names/semantics
+        // match `SectionProps` — see the SectionGeom warning comment). For a
+        // horizontal marker `markerFrame(e).geom` is `e.geom` verbatim (or the
+        // body-level physical geometry for a `geom`-less inheriting marker,
+        // §17.18.77) — value-identical to the pre-#1000 spread.
+        return computeColumns({ ...section, ...markerFrame(e).geom, columns: e.columns ?? null });
       }
     }
     return computeColumns(section);
@@ -2266,22 +2380,52 @@ export function computePages(
     return undefined;
   };
 
-  // ECMA-376 §17.6.13 / §17.6.11 — the page geometry (size + margins) of the
-  // section that OWNS the content starting at body index `startIdx`. Mirrors
-  // `sectionColumnsFrom` / `sectionHFFrom`: the owning section's geometry is on the
-  // NEXT `SectionBreak` marker's `geom` at/after `startIdx` (the marker ENDS that
-  // section); if there is none, the content belongs to the FINAL (body-level)
-  // section whose geometry lives on `section`. A `geom`-less marker (a section that
-  // inherits pgSz/pgMar) also falls back to the body-level geometry. For a
-  // single-section document there are no markers, so every element gets the
-  // body-level geometry — behaviour-neutral.
+  // ECMA-376 §17.6.13 / §17.6.11 / §17.6.20 — the resolved LOGICAL frame of the
+  // section that OWNS the content starting at body index `startIdx`: its page
+  // geometry (size + margins), its `textDirection`, and the derived vertical
+  // flag (issue #1000 per-section mixing). Mirrors `sectionColumnsFrom` /
+  // `sectionHFFrom`: the owning section is on the NEXT `SectionBreak` marker
+  // at/after `startIdx` (the marker ENDS that section); if there is none, the
+  // content belongs to the FINAL (body-level) section.
+  //
+  // Frame convention: `section` (the computePages parameter) is the LOGICAL
+  // body-level section — `verticalLayoutDoc` already swapped it when the BODY
+  // section is vertical — while a mid-body marker's `e.geom` is the PHYSICAL
+  // geometry the parser emitted. So a marker section's logical geometry is its
+  // physical geometry quarter-turned (`logicalGeomOf`) when THAT section is
+  // vertical, verbatim otherwise; a `geom`-less marker (a section inheriting
+  // pgSz/pgMar, §17.18.77) inherits the body-level PHYSICAL geometry — un-swap
+  // the logical body geometry first when the body is vertical, else the
+  // quarter-turn would double-apply. For a single-section document there are no
+  // markers, so every element gets the body-level frame — behaviour-neutral
+  // (the geom object is `bodySectionGeom` itself, identical to the pre-#1000
+  // stamps).
   const bodySectionGeom: SectionGeom = sectionGeomOf(section);
-  const sectionGeomFrom = (startIdx: number): SectionGeom => {
+  const bodyVertical = isVerticalSection(section);
+  const bodyPhysGeom: SectionGeom = bodyVertical ? physicalGeomOf(bodySectionGeom) : bodySectionGeom;
+  const bodyFrame: ResolvedSectionFrame = {
+    geom: bodySectionGeom,
+    textDirection: section.textDirection ?? null,
+    vertical: bodyVertical,
+    columnsSpec: section.columns ?? null,
+  };
+  const markerFrame = (e: Extract<BodyElement, { type: 'sectionBreak' }>): ResolvedSectionFrame => {
+    const textDirection = e.textDirection ?? null;
+    const vertical = isVerticalTextDirection(textDirection);
+    const phys = e.geom ?? bodyPhysGeom;
+    return {
+      geom: vertical ? logicalGeomOf(phys) : phys,
+      textDirection,
+      vertical,
+      columnsSpec: e.columns ?? null,
+    };
+  };
+  const sectionFrameFrom = (startIdx: number): ResolvedSectionFrame => {
     for (let j = startIdx; j < body.length; j++) {
       const e = body[j];
-      if (e.type === 'sectionBreak') return e.geom ?? bodySectionGeom;
+      if (e.type === 'sectionBreak') return markerFrame(e);
     }
-    return bodySectionGeom;
+    return bodyFrame;
   };
 
   // ECMA-376 §17.6.12 `<w:pgNumType>` — the page-numbering settings (start / fmt)
@@ -2317,16 +2461,76 @@ export function computePages(
   // on each element so the renderer picks the active section's header/footer per
   // page. `undefined` for the final section ⇒ the renderer's body-level fallback.
   let currentSectionHF = sectionHFFrom(0);
-  // ECMA-376 §17.6.13 / §17.6.11 — the active section's page geometry, tracked in
-  // lockstep with `columns`/`currentSectionHF` (reassigned at every SectionBreak).
-  // Stamped on each element so the renderer sizes each page from its own section.
-  // For a single-section document this stays the body-level geometry throughout.
-  let currentSectionGeom = sectionGeomFrom(0);
+  // ECMA-376 §17.6.13 / §17.6.11 / §17.6.20 — the active section's resolved
+  // LOGICAL frame (geometry + text direction + vertical flag; issue #1000),
+  // tracked in lockstep with `columns`/`currentSectionHF` (reassigned at every
+  // SectionBreak). `currentSectionGeom` aliases `currentSectionFrame.geom` (the
+  // many geometry readers keep their name); both are stamped on each element so
+  // the renderer sizes AND orients each page from its own section. For a
+  // single-section document this stays the body-level frame throughout.
+  let currentSectionFrame = sectionFrameFrom(0);
+  let currentSectionGeom = currentSectionFrame.geom;
   // ECMA-376 §17.6.12 — the active section's page-numbering settings, tracked in
   // lockstep with `currentSectionGeom` (reassigned at every SectionBreak). Stamped
   // on each element so `computePageNumbering` resolves each physical page's owning
   // section's restart/format. `null` for a section with no `<w:pgNumType>`.
   let currentSectionPageNumType = sectionPageNumTypeFrom(0);
+  // Issue #1000 — is this document DIRECTION-MIXED (some section's rendered
+  // orientation differs from the body's)? Only then does the measure state's
+  // logical frame need per-section re-seeding: a NON-mixed document keeps the
+  // exact pre-#1000 body-level measure seed (byte-identical for every
+  // horizontal document and for the all-vertical single-frame path), including
+  // its documented residual — per-section page SIZE differences measure
+  // header/footer/anchor content at the body-level width.
+  const directionMixed = body.some(
+    (e) =>
+      e.type === 'sectionBreak' &&
+      isVerticalTextDirection(e.textDirection ?? null) !== bodyVertical,
+  );
+  // Issue #1000 — re-seed the measure state's LOGICAL frame from the ACTIVE
+  // section's resolved frame (called at init and at every SectionBreak): page
+  // box, margins, base content band, the per-section `verticalPhys` physical
+  // frame DrawingML anchors resolve against (§20.4.3.x — a vertical section's
+  // anchors key their physical branch on it; a horizontal section must CLEAR
+  // it), and the frame-derived SectionLayoutContext (its geometry / columns /
+  // textDirection; docGrid, line numbering and vAlign stay body-level — the
+  // existing single-section residual, documented in the PR). No-op for a
+  // non-direction-mixed document (see `directionMixed`).
+  const syncMeasureFrame = (): void => {
+    if (!directionMixed) return;
+    const g = currentSectionGeom;
+    measureState.pageWidth = g.pageWidth;
+    measureState.pageH = g.pageHeight; // scale 1 (pt)
+    measureState.marginLeft = g.marginLeft;
+    measureState.marginRight = g.marginRight;
+    measureState.marginTop = bodyMarginInsetPt(g.marginTop);
+    measureState.marginBottom = bodyMarginInsetPt(g.marginBottom);
+    measureState.contentX = g.marginLeft;
+    measureState.contentW = g.pageWidth - g.marginLeft - g.marginRight;
+    if (currentSectionFrame.vertical) {
+      const phys = physicalGeomOf(g);
+      measureState.verticalPhys = {
+        pageWidth: phys.pageWidth,
+        pageHeight: phys.pageHeight,
+        marginLeft: phys.marginLeft,
+        marginRight: phys.marginRight,
+        marginTop: bodyMarginInsetPt(phys.marginTop),
+        marginBottom: bodyMarginInsetPt(phys.marginBottom),
+        cssWidthPx: phys.pageWidth,
+      };
+    } else {
+      measureState.verticalPhys = undefined;
+    }
+    const frameSection: SectionProps = {
+      ...section,
+      ...g,
+      textDirection: currentSectionFrame.textDirection,
+      columns: currentSectionFrame.columnsSpec,
+    };
+    measureState.sectionLayout = resolveSectionLayoutContext(documentSettings, frameSection);
+    measureState.docGrid = toLegacyDocGridContext(measureState.sectionLayout);
+  };
+  syncMeasureFrame();
   // ECMA-376 §17.6.4 / §17.18.79 — the CURRENT multi-column region's vertical
   // extent on the current page, in content-relative pt (0 = page content top,
   // i.e. the same frame as `y`). A region tiled into N newspaper columns is a
@@ -2381,6 +2585,20 @@ export function computePages(
   };
 
   const pages: PaginatedBodyElement[][] = [[]];
+  // Issue #1000 — record the CURRENT (incoming) section's frame as the page's
+  // {@link PageFrameMeta} whenever a page opens. It duplicates the per-element
+  // stamps for content pages and is the only frame carrier for an EMPTY page
+  // (§17.18.79 parity padding): the incoming section — the paginator's
+  // transition model — owns it, so its physical size and direction resolve
+  // consistently (Word GT for parity-blank ownership is unverified; this pins
+  // the model's deterministic choice).
+  const stampPageMeta = (): void => {
+    pageFrameMeta.set(pages[pages.length - 1], {
+      geom: currentSectionGeom,
+      textDirection: currentSectionFrame.textDirection,
+    });
+  };
+  stampPageMeta();
   let y = 0;
   let prevPara: DocParagraph | null = null;
   // Word collapses the gap between two paragraphs to max(prev.spaceAfter,
@@ -2453,6 +2671,9 @@ export function computePages(
   const startPageBookkeeping = () => {
     footnoteReservePt[pages.length - 1] = 0;
     pageNoteIds = new Set<string>();
+    // Issue #1000 — every page open records its owning section's frame (see
+    // stampPageMeta; called after every pages.push, including parity blanks).
+    stampPageMeta();
   };
   /** Open a new page (no-op when the current one is empty). `pageStartIdx`
    *  is the body index that becomes the new page's first laid-out item — the
@@ -2598,7 +2819,7 @@ export function computePages(
     // so the horizontal keep-on-page displacement below does not map. (The
     // physical-axis analogue — a float overflowing the physical bottom — is
     // un-adjudicated and left to the anchor clamp.)
-    if (verticalUpright) return 0;
+    if (verticalUpright()) return 0;
     let maxBottom = 0;
     for (const run of para.runs) {
       if (run.type === 'image') {
@@ -2649,7 +2870,7 @@ export function computePages(
     if (nxt.type === 'table') {
       // §17.6.20 + #988 ④ — an upright vertical-section table's flow footprint
       // is its PHYSICAL WIDTH, not the sum of its row heights.
-      if (verticalUpright) {
+      if (verticalUpright()) {
         return resolveColumnWidths(
           nxt as unknown as DocTable, uprightTableBandPt(), measureState,
         ).reduce((s, w) => s + w, 0);
@@ -2691,6 +2912,11 @@ export function computePages(
     el.sectionHF = currentSectionHF;
     el.sectionGeom = currentSectionGeom;
     el.sectionPageNumType = currentSectionPageNumType;
+    // Issue #1000 — the owning section's text direction, in lockstep with
+    // `sectionGeom` (which is that section's SWAPPED logical geometry when this
+    // is a vertical value). Explicitly `null` for horizontal sections so
+    // consumers can distinguish "stamped horizontal" from "no stamp".
+    el.sectionTextDirection = currentSectionFrame.textDirection;
     pages[pages.length - 1].push(el);
   };
 
@@ -2782,17 +3008,36 @@ export function computePages(
       // ECMA-376 §17.10.1 — the section starting at i+1 owns the following pages'
       // headers/footers (resolved from the NEXT marker, or the body-level set).
       currentSectionHF = sectionHFFrom(i + 1);
-      // ECMA-376 §17.6.13 / §17.6.11 — and its page geometry (size + margins).
-      currentSectionGeom = sectionGeomFrom(i + 1);
+      // ECMA-376 §17.6.13 / §17.6.11 / §17.6.20 — and its resolved LOGICAL frame
+      // (geometry + text direction; issue #1000). The outgoing frame is kept for
+      // the direction-change promotion below.
+      const prevFrame = currentSectionFrame;
+      currentSectionFrame = sectionFrameFrom(i + 1);
+      currentSectionGeom = currentSectionFrame.geom;
       // ECMA-376 §17.6.12 — and its page-numbering settings (start / fmt).
       currentSectionPageNumType = sectionPageNumTypeFrom(i + 1);
+      // Issue #1000 — keep the measure state's logical frame in lockstep for a
+      // direction-mixed document (no-op otherwise; see syncMeasureFrame).
+      syncMeasureFrame();
       // The break is governed by the UPCOMING section's start type (§17.6.22),
       // not this marker's own kind (the section it closes). See sectionKindFrom.
       // The sample-5 cover overprint that prompted the 0.66.1 hotfix is now fixed
       // at its real root: the parser emits a PageBreak after a "Cover Pages"
       // building block, so the continuous body after the cover lands on page 2
       // without forcing every nextPage→continuous boundary to break a page.
-      const upcomingKind = sectionKindFrom(i + 1);
+      //
+      // Issue #1000 — a CONTINUOUS boundary whose RENDERED ORIENTATION changes
+      // (vertical ⇄ horizontal, compared via the frames' `vertical` flags — NOT
+      // raw tokens, so tbRl→btLr stays continuous) is promoted to a page break:
+      // the paint model rotates a whole physical page, so one direction per page
+      // is a hard renderer constraint (a documented model constraint — Word's
+      // behaviour at such a boundary has no fixture yet, so this pins the
+      // constraint, not a Word claim). Horizontal-only documents never differ.
+      const upcomingKindRaw = sectionKindFrom(i + 1);
+      const upcomingKind =
+        upcomingKindRaw === 'continuous' && currentSectionFrame.vertical !== prevFrame.vertical
+          ? 'nextPage'
+          : upcomingKindRaw;
       if (upcomingKind === 'continuous') {
         // ECMA-376 §17.18.77 (ST_SectionMark) / §17.6.22 (type) — geometry residual:
         // reassigning `currentSectionGeom` above activates the incoming section's
@@ -3267,6 +3512,7 @@ export function computePages(
           () => currentSectionHF,
           () => currentSectionGeom,
           () => currentSectionPageNumType,
+          () => currentSectionFrame.textDirection,
         );
         // After splitting, `y` is the bottom of the last slice in the
         // current column (continues for the LAST slice; intermediate slices
@@ -3589,7 +3835,7 @@ export function computePages(
       // that does not fit the remaining flow advances to the next column/page
       // whole, and one wider than a full column overflows like a too-tall
       // horizontal row.
-      if (verticalUpright) {
+      if (verticalUpright()) {
         const bandPt = uprightTableBandPt();
         const { colWidthsPt, rowHeightsPt } =
           computeTablePtLayout(measureState, tbl, bandPt);
@@ -3675,6 +3921,7 @@ export function computePages(
                 sourceRowIndexOf: meta.sourceRowIndexOf,
               },
             ),
+          () => currentSectionFrame.textDirection,
         );
         y = endY;
         measureState.y = bodyTopPt() + endY;
@@ -3823,17 +4070,22 @@ const MIN_MARGIN_OVERFLOW_PT = 0.5;
 function computeFooterReserves(
   pages: PaginatedBodyElement[][],
   doc: DocxDocumentModel,
-  measure: RenderState,
+  measureFor: (pageIdx: number) => RenderState,
 ): number[] {
   return pages.map((_unused, pageIdx) => {
+    // Issue #1000 (§17.6.20 + §17.10.1, #988): a VERTICAL page's footer draws
+    // horizontally at the physical bottom margin with NO body reserve (the paint
+    // branch never reserves there) — reserve 0 so pagination and paint agree.
+    if (isVerticalTextDirection(pageTextDirection(pages, pageIdx, doc.section))) return 0;
     const footer = resolvePageFooter(pages, pageIdx, doc);
     if (!footer) return 0;
-    const footerH = measureHeaderFooterHeight(footer, measure); // pt (measure is scale 1)
+    const footerH = measureHeaderFooterHeight(footer, measureFor(pageIdx)); // pt (measure is scale 1)
     // ECMA-376 §17.6.11 — margins/distances are PER-SECTION: read this page's stamped
-    // geometry (body-level fallback only for a truly empty page). Residual: footer
-    // CONTENT is still measured at the body-level width (`measure` is built once from
-    // doc.section); per-section measure width is a follow-up — it matters only when
-    // mixed page WIDTHS meet a wrapping footer.
+    // geometry (body-level fallback only for a truly empty page). Residual: in a
+    // horizontal-body document footer CONTENT is still measured at the body-level
+    // width (`measureFor` returns the one shared measure); per-section measure
+    // width is a follow-up — it matters only when mixed page WIDTHS meet a
+    // wrapping footer.
     const g = pages[pageIdx]?.[0]?.sectionGeom;
     return footerOverflowPt(
       footerH,
@@ -3855,17 +4107,22 @@ function computeFooterReserves(
 function computeHeaderReserves(
   pages: PaginatedBodyElement[][],
   doc: DocxDocumentModel,
-  measure: RenderState,
+  measureFor: (pageIdx: number) => RenderState,
 ): number[] {
   return pages.map((_unused, pageIdx) => {
+    // Issue #1000 (§17.6.20 + §17.10.1, #988): a VERTICAL page's header draws
+    // horizontally at the physical top margin with NO body reserve (the paint
+    // branch never reserves there) — reserve 0 so pagination and paint agree.
+    if (isVerticalTextDirection(pageTextDirection(pages, pageIdx, doc.section))) return 0;
     const header = resolvePageHeader(pages, pageIdx, doc);
     if (!header) return 0;
-    const headerH = measureHeaderFooterHeight(header, measure); // pt (measure is scale 1)
+    const headerH = measureHeaderFooterHeight(header, measureFor(pageIdx)); // pt (measure is scale 1)
     // ECMA-376 §17.6.11 — margins/distances are PER-SECTION: read this page's stamped
-    // geometry (body-level fallback only for a truly empty page). Residual: header
-    // CONTENT is still measured at the body-level width (`measure` is built once from
-    // doc.section); per-section measure width is a follow-up — it matters only when
-    // mixed page WIDTHS meet a wrapping header.
+    // geometry (body-level fallback only for a truly empty page). Residual: in a
+    // horizontal-body document header CONTENT is still measured at the body-level
+    // width (`measureFor` returns the one shared measure); per-section measure
+    // width is a follow-up — it matters only when mixed page WIDTHS meet a
+    // wrapping header.
     const g = pages[pageIdx]?.[0]?.sectionGeom;
     return headerOverflowPt(
       headerH,
@@ -3922,16 +4179,42 @@ function paginateWithHeaderFooterReserve(
   );
   // ECMA-376 §17.6.20 + §17.10.1 (issue #988): a vertical (tbRl) section lays its
   // header/footer out HORIZONTALLY in physical space with NO body reserve (see the
-  // paint path, which sets headerReservePx/footerReservePx = 0). `doc` here is the
-  // SWAPPED logical doc, so measuring a header against its logical marginTop/Bottom
-  // (physical right/left) and reserving on the logical `y` axis would mismatch the
-  // paint. Skip the reserve entirely for vertical sections so pagination and paint
-  // agree. (Physical-axis body-push for an over-margin vertical header/footer is a
-  // documented follow-up, matching the paint path's TODO.)
-  if (isVerticalSection(doc.section)) return pass1;
+  // paint path, which sets headerReservePx/footerReservePx = 0). For a vertical
+  // page the stamped section is the SWAPPED logical frame, so measuring a header
+  // against its logical marginTop/Bottom (physical right/left) and reserving on
+  // the logical `y` axis would mismatch the paint — the reserve is skipped for
+  // vertical PAGES (per-section text direction, issue #1000; the per-page skip
+  // lives in computeHeader/FooterReserves). When EVERY section is vertical there
+  // is nothing to reserve at all — the pre-#1000 early return, byte-identical
+  // for the existing all-vertical documents. (Physical-axis body-push for an
+  // over-margin vertical header/footer is a documented follow-up, matching the
+  // paint path's TODO.)
+  const bodyVertical = isVerticalSection(doc.section);
+  const anyHorizontalSection =
+    !bodyVertical ||
+    doc.body.some(
+      (e) => e.type === 'sectionBreak' && !isVerticalTextDirection(e.textDirection ?? null),
+    );
+  if (!anyHorizontalSection) return pass1;
   const measure = buildMeasureState(ctx, doc.section, fontFamilyClasses, layoutSettings);
-  const footerReserves = computeFooterReserves(pass1, doc, measure);
-  const headerReserves = computeHeaderReserves(pass1, doc, measure);
+  // Issue #1000 — a horizontal page's header/footer must be measured against its
+  // OWN frame: in a vertical-body mixed document the body-level `measure` is the
+  // SWAPPED logical frame, which would wrap header/footer content at the wrong
+  // width. Horizontal-body documents keep the single shared `measure` verbatim
+  // (byte-identical, including the documented per-section-width residual).
+  const measureFor = bodyVertical
+    ? (pageIdx: number): RenderState => {
+        const g = pass1[pageIdx]?.[0]?.sectionGeom;
+        return buildMeasureState(
+          ctx,
+          { ...doc.section, ...(g ?? {}), textDirection: null },
+          fontFamilyClasses,
+          layoutSettings,
+        );
+      }
+    : (): RenderState => measure;
+  const footerReserves = computeFooterReserves(pass1, doc, measureFor);
+  const headerReserves = computeHeaderReserves(pass1, doc, measureFor);
   const overflows = (rs: number[]): boolean => rs.some((r) => r > MIN_MARGIN_OVERFLOW_PT);
   if (!overflows(footerReserves) && !overflows(headerReserves)) return pass1;
   const pageReserves = pass1.map((_unused, i): PageReserve => ({
@@ -4025,8 +4308,17 @@ export function layoutDocument(doc: DocxDocumentModel): DocumentLayout {
   const layoutPages: LayoutPage[] = pages.map((elements, pageIndex) => {
     const firstEl = elements[0] as PaginatedBodyElement | undefined;
     const geomOverride = firstEl?.sectionGeom;
+    // Issue #1000 — merge the page's OWN text direction alongside its geometry
+    // (stamped in lockstep), so `LayoutPage.section.textDirection` reports the
+    // page's direction, not the body's, in a per-section mixed document.
+    // Undefined (unstamped legacy pages) keeps the body-level value.
+    const tdOverride = firstEl?.sectionTextDirection;
     const sectionProps: SectionProps = geomOverride
-      ? { ...layoutDoc.section, ...geomOverride }
+      ? {
+          ...layoutDoc.section,
+          ...geomOverride,
+          ...(tdOverride !== undefined ? { textDirection: tdOverride } : {}),
+        }
       : layoutDoc.section;
     const resolvedSection = resolveSectionLayoutContext(layoutSettings, sectionProps);
     // M-2 — the paginator stamped the resolved §17.6.4 column geometry active at this
@@ -4127,10 +4419,10 @@ function buildMeasureState(
     // physicalLayoutSection; `cssWidthPx` at the paginator's scale 1 is the
     // physical page width in pt. `verticalCJK` stays UNSET: the measure pass
     // keeps its horizontal glyph metrics (only anchor geometry re-frames).
-    // Seeded from the BODY-LEVEL section, the single frame-consistent source —
-    // vertical layout is body-section uniform until the #988 ① per-section
-    // follow-up (see verticalLayoutDoc), and the paint pass resolves the same
-    // geometry for every vertical page.
+    // Seeded from the section this measure state is BUILT from (the body-level
+    // one in computePages); a direction-MIXED document then re-seeds it per
+    // section via computePages' `syncMeasureFrame` rail (issue #1000), so a
+    // mid-body section's anchors resolve against ITS OWN physical frame.
     verticalPhys: isVerticalSection(section)
       ? (() => {
           const phys = physicalLayoutSection(section);
@@ -4735,6 +5027,10 @@ function splitParagraphAcrossPages(
    *  sees the section's restart/format on EVERY physical page a spilled paragraph
    *  lands on (not only the section's first page). Omitted ⇒ `null` (continue). */
   tagSectionPageNumType?: () => PageNumType | null,
+  /** ECMA-376 §17.6.20 — the active SECTION's text direction (issue #1000),
+   *  stamped in lockstep with `tagSectionGeom` (constant across a paragraph's
+   *  slices). Omitted ⇒ no stamp (the renderer's body-level fallback). */
+  tagSectionTextDirection?: () => string | null,
 ): { endY: number } {
   const colTop = columnTop ?? (() => 0);
   const colBot = columnBottom ?? (() => contentH);
@@ -4760,6 +5056,7 @@ function splitParagraphAcrossPages(
     if (tagSectionHF) el.sectionHF = tagSectionHF();
     if (tagSectionGeom) el.sectionGeom = tagSectionGeom();
     if (tagSectionPageNumType) el.sectionPageNumType = tagSectionPageNumType();
+    if (tagSectionTextDirection) el.sectionTextDirection = tagSectionTextDirection();
     return el;
   };
   {
@@ -6139,6 +6436,10 @@ export function splitTableAcrossPages(
       sourceRowIndexOf: (fragmentRowIndex: number) => number;
     },
   ) => void,
+  /** ECMA-376 §17.6.20 — the active SECTION's text direction (issue #1000),
+   *  stamped in lockstep with `tagSectionGeom` (constant across the split).
+   *  Omitted ⇒ no stamp (the renderer's body-level fallback). */
+  tagSectionTextDirection?: () => string | null,
 ): number {
   const colTop = columnTop ?? (() => 0);
   let workTable = table;
@@ -6310,6 +6611,7 @@ export function splitTableAcrossPages(
     if (tagSectionHF) sliceEl.sectionHF = tagSectionHF();
     if (tagSectionGeom) sliceEl.sectionGeom = tagSectionGeom();
     if (tagSectionPageNumType) sliceEl.sectionPageNumType = tagSectionPageNumType();
+    if (tagSectionTextDirection) sliceEl.sectionTextDirection = tagSectionTextDirection();
     // B2 table stage 1b — stamp this slice's own row heights (repeated header rows
     // prepended on continuations, matching `sliceRows`) so the paint pass reuses
     // them 1:1 instead of re-measuring the slice.

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1222,12 +1222,16 @@ function physicalGeomOf(logical: SectionGeom): SectionGeom {
  *  into the paint pass without any API change — mirrors the `bodyFlowFragments`
  *  WeakMap pattern). It duplicates the first element's `sectionGeom` /
  *  `sectionTextDirection` stamps, and is the ONLY carrier for an EMPTY page
- *  (§17.18.79 oddPage/evenPage parity padding), whose direction and physical
- *  size are observable even though it has no elements — the incoming section
- *  (the paginator's transition model) owns it. Scope note (issue #1000): the
- *  metadata carries the page FRAME only (geometry + direction); header/footer
- *  and page-number resolution for empty pages keep their existing body-level
- *  fallback (documented residual). */
+ *  (§17.18.77 oddPage/evenPage parity padding), whose direction and physical
+ *  size are observable even though it has no elements. An oddPage/evenPage
+ *  parity BLANK belongs to the OUTGOING section (§17.18.77: the new section
+ *  "begins on the next odd/even-numbered page, LEAVING the next page blank" —
+ *  the blank precedes the incoming section's start); every other page open
+ *  records the incoming frame. Consumed by `resolvePageSection` (paint frame),
+ *  `layoutDocument`, `pageTextDirection` and `physicalPageSizeForPage`. Scope
+ *  note (issue #1000): the metadata carries the page FRAME only (geometry +
+ *  direction); header/footer and page-number resolution for empty pages keep
+ *  their existing body-level fallback (documented residual). */
 interface PageFrameMeta {
   /** The owning section's LOGICAL page geometry (swapped for a vertical section). */
   geom: SectionGeom;
@@ -2585,13 +2589,13 @@ export function computePages(
   };
 
   const pages: PaginatedBodyElement[][] = [[]];
-  // Issue #1000 — record the CURRENT (incoming) section's frame as the page's
+  // Issue #1000 — record the CURRENT section's frame as the page's
   // {@link PageFrameMeta} whenever a page opens. It duplicates the per-element
-  // stamps for content pages and is the only frame carrier for an EMPTY page
-  // (§17.18.79 parity padding): the incoming section — the paginator's
-  // transition model — owns it, so its physical size and direction resolve
-  // consistently (Word GT for parity-blank ownership is unverified; this pins
-  // the model's deterministic choice).
+  // stamps for content pages and is the only frame carrier for an EMPTY page.
+  // An oddPage/evenPage parity BLANK is re-stamped with the OUTGOING frame at
+  // the section-break parity push (§17.18.77: the new section "begins on the
+  // next odd/even-numbered page, leaving the next page blank" — the blank
+  // precedes the incoming section's start).
   const stampPageMeta = (): void => {
     pageFrameMeta.set(pages[pages.length - 1], {
       geom: currentSectionGeom,
@@ -3028,11 +3032,15 @@ export function computePages(
       //
       // Issue #1000 — a CONTINUOUS boundary whose RENDERED ORIENTATION changes
       // (vertical ⇄ horizontal, compared via the frames' `vertical` flags — NOT
-      // raw tokens, so tbRl→btLr stays continuous) is promoted to a page break:
-      // the paint model rotates a whole physical page, so one direction per page
-      // is a hard renderer constraint (a documented model constraint — Word's
-      // behaviour at such a boundary has no fixture yet, so this pins the
-      // constraint, not a Word claim). Horizontal-only documents never differ.
+      // raw tokens, so tbRl→btLr stays continuous) is promoted to a page break.
+      // ⚠ DOCUMENTED SPEC DEVIATION: §17.18.77 "continuous" begins the new
+      // section on the following paragraph (its only stated exception is a
+      // same-page footnote reference); this renderer's paint model rotates ONE
+      // whole physical page, so a same-page orientation mix is unrepresentable
+      // and the promotion is the deliberate, pinned fallback (the alternative
+      // is an incoherent page). No Word ground-truth fixture for this boundary
+      // exists yet; revisit against Word output if one is adjudicated.
+      // Horizontal-only documents never differ (both flags false).
       const upcomingKindRaw = sectionKindFrom(i + 1);
       const upcomingKind =
         upcomingKindRaw === 'continuous' && currentSectionFrame.vertical !== prevFrame.vertical
@@ -3095,10 +3103,25 @@ export function computePages(
         startPageBookkeeping();
         // Balance the new section's columns if it fits on its fresh page (§17.6.4).
         setupBalancing(i + 1);
+        // ECMA-376 §17.6.22 / §17.18.77 — oddPage/evenPage "begins the new
+        // section on the next odd/even-numbered page, leaving the next
+        // even/odd page blank if necessary": the intervening BLANK precedes the
+        // incoming section's start, so its frame metadata belongs to the
+        // OUTGOING section (`prevFrame`) — re-stamp the just-opened page (which
+        // becomes the blank once the padding page is pushed) before opening the
+        // section's real start page (issue #1000; Codex review).
         if (upcomingKind === 'oddPage' && pages.length % 2 === 0) {
+          pageFrameMeta.set(pages[pages.length - 1], {
+            geom: prevFrame.geom,
+            textDirection: prevFrame.textDirection,
+          });
           pages.push([]);
           startPageBookkeeping();
         } else if (upcomingKind === 'evenPage' && pages.length % 2 === 1) {
+          pageFrameMeta.set(pages[pages.length - 1], {
+            geom: prevFrame.geom,
+            textDirection: prevFrame.textDirection,
+          });
           pages.push([]);
           startPageBookkeeping();
         }
@@ -4307,12 +4330,18 @@ export function layoutDocument(doc: DocxDocumentModel): DocumentLayout {
   );
   const layoutPages: LayoutPage[] = pages.map((elements, pageIndex) => {
     const firstEl = elements[0] as PaginatedBodyElement | undefined;
-    const geomOverride = firstEl?.sectionGeom;
-    // Issue #1000 — merge the page's OWN text direction alongside its geometry
-    // (stamped in lockstep), so `LayoutPage.section.textDirection` reports the
-    // page's direction, not the body's, in a per-section mixed document.
-    // Undefined (unstamped legacy pages) keeps the body-level value.
-    const tdOverride = firstEl?.sectionTextDirection;
+    // Issue #1000 — merge the page's OWN frame: geometry + text direction
+    // (stamped in lockstep on the first element; an EMPTY parity page resolves
+    // through its PageFrameMeta), so `LayoutPage.section.textDirection` and
+    // `.geometry` report the page's frame, not the body's, in a per-section
+    // mixed document. Undefined (unstamped legacy pages) keeps the body-level
+    // value.
+    const meta = pageFrameMeta.get(elements);
+    const geomOverride = firstEl?.sectionGeom ?? meta?.geom;
+    const tdOverride =
+      firstEl?.sectionTextDirection !== undefined
+        ? firstEl.sectionTextDirection
+        : meta?.textDirection;
     const sectionProps: SectionProps = geomOverride
       ? {
           ...layoutDoc.section,
@@ -6836,10 +6865,14 @@ function resolvePageSection(
   const titlePage = active?.titlePage ?? doc.section.titlePage;
   const isFirstPageOfSection = pageIndex === 0 || sectionOf(pageIndex - 1) !== active;
   // ECMA-376 §17.6.13 / §17.6.11 — the page's geometry, from the paginator's stamp
-  // on this page's first element, falling back to the body-level section (the value
-  // the paginator itself stamps for the final/single section, so this fallback only
-  // fires for a truly empty page). Sizes the canvas + margins per page.
-  const geom: SectionGeom = pages[pageIndex]?.[0]?.sectionGeom ?? sectionGeomOf(doc.section);
+  // on this page's first element; an EMPTY page (§17.18.77 parity padding)
+  // resolves through its {@link PageFrameMeta} (issue #1000) so the blank paints
+  // in its owning section's frame, consistent with `physicalPageSizeForPage`.
+  // The body-level fallback only fires for pages with neither (legacy / manually
+  // constructed test pages). Sizes the canvas + margins per page.
+  const page = pages[pageIndex];
+  const meta = page ? pageFrameMeta.get(page) : undefined;
+  const geom: SectionGeom = page?.[0]?.sectionGeom ?? meta?.geom ?? sectionGeomOf(doc.section);
   return { headers, footers, titlePage, isFirstPageOfSection, geom };
 }
 

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -494,6 +494,17 @@ export type PaginatedBodyElement = BodyElement & {
    *  format. `null` ⇒ the section has no `<w:pgNumType>` (numbering continues;
    *  decimal). Runtime-only — never emitted by the parser. */
   sectionPageNumType?: PageNumType | null;
+  /** ECMA-376 §17.6.20 — the flow direction of the SECTION this element belongs
+   *  to (same enum as {@link SectionProps.textDirection}; `null` ⇒ horizontal).
+   *  Stamped by the paginator (from the upcoming `SectionBreak`'s
+   *  `textDirection`, or the body-level section) IN LOCKSTEP with `sectionGeom`:
+   *  when this is a vertical value the stamped `sectionGeom` is that section's
+   *  SWAPPED LOGICAL geometry (see `verticalLayoutSection`), and the renderer
+   *  rotates the page +90° at paint (issue #1000 per-section mixing). Kept as a
+   *  SIBLING of `sectionGeom` — `SectionGeom` stays pure page-box geometry
+   *  mirroring the Rust struct. Absent (undefined) ⇒ legacy pages fall back to
+   *  the body-level `doc.section.textDirection`. Runtime-only. */
+  sectionTextDirection?: string | null;
   /** B2 table stage 1b — compute-once table layout for the LEGACY paint path
    *  (floating tables, and the fallback for a block table the fragment-paint gate does
    *  not cover). When this element is a table, the paginator stamps the per-grid-column

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -396,6 +396,14 @@ export type BodyElement =
        *  separately from `geom` because a section may inherit its geometry yet
        *  still restart / re-format its page numbers. */
       pageNumType?: PageNumType | null;
+      /** ECMA-376 §17.6.20 `<w:textDirection w:val>` — this ENDING section's
+       *  flow direction (TRANSITIONAL ST_TextDirection, same enum and semantics
+       *  as {@link SectionProps.textDirection}), so a vertical (tbRl/btLr)
+       *  non-final section can coexist with a horizontal final section (issue
+       *  #1000). Absent ⇒ horizontal ("lrTb" is collapsed by the parser).
+       *  Carried separately from `geom` (like `pageNumType`) because a section
+       *  may inherit its page geometry yet still set its own flow direction. */
+      textDirection?: string | null;
     };
 
 /** A BodyElement annotated with a line range to render. Set when the

--- a/packages/node/src/docx-per-section-mixed-direction.probe.test.ts
+++ b/packages/node/src/docx-per-section-mixed-direction.probe.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-section text-direction mixing — ECMA-376 §17.6.20, issue #1000 (the
+ * carve-out of #988 batch-3 adjudication ①): a document whose NON-FINAL
+ * section is vertical (`btLr` ≡ `tbRl` per Word ground truth) while the FINAL
+ * section is horizontal renders page 1 vertical and page 2 horizontal.
+ *
+ * Word ground truth (the batch-3 btLr fixture's PDF, `pdftotext -bbox` +
+ * `pdfinfo`): 2 pages, BOTH physical Letter portrait 612×792 pt; page 1 lays
+ * the btLr section out exactly like tbRl — the heading column hugs the RIGHT
+ * content margin (x ≈ 519.1–532.0), glyphs advance top→bottom from y = 72, and
+ * successive paragraphs stack as columns progressing right→left (x ≈ 519 →
+ * 496 → 470 → 444 → 418); page 2 draws the same text horizontally from the
+ * top-left content corner (x = 72, first line y ≈ 80.0–92.9).
+ *
+ * This probe parses private/sample-49.docx through the real WASM parser,
+ * paginates, and renders both pages headlessly at scale 1 (px == pt),
+ * asserting: the per-page PHYSICAL page box, the per-page orientation via the
+ * text-layer `transform` (set only under the vertical +90° paint), the first
+ * column's physical x against the PDF, the right→left column progression, and
+ * the horizontal page's top-left flow start.
+ *
+ * Substitute-font note: Hiragino Mincho ProN stands in for Yu Mincho; glyph
+ * ADVANCES differ slightly, but the assertions here are frame-level (column x
+ * positions come from line stacking at the section's line pitch, flow origins
+ * from the page margins), so ±3 pt tolerances hold.
+ *
+ * CI-safe: gated on docx WASM + skia-canvas + the PRIVATE sample + a macOS JP
+ * font; skips when any is absent (never hard-fails for the private file).
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, FontLibrary } = (skia ?? {}) as Skia;
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
+const rendererMod = await importForTests(
+  () => import('./../../docx/src/renderer.ts'),
+  'packages/docx/src/renderer.ts',
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+const SAMPLE = fileURLToPath(
+  new URL('../../docx/public/private/sample-49.docx', import.meta.url),
+);
+const MINCHO = '/System/Library/Fonts/ヒラギノ明朝 ProN.ttc';
+const havePrereqs = existsSync(SAMPLE) && existsSync(MINCHO);
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+interface RunInfo { text: string; x: number; y: number; transform?: unknown }
+
+describe.skipIf(!skia || !docxMod || !rendererMod || !havePrereqs)(
+  'docx per-section text-direction mixing (§17.6.20, issue #1000)',
+  () => {
+    it('renders the btLr section vertical on page 1 and the lrTb section horizontal on page 2', async () => {
+      for (const fam of ['Yu Mincho', 'YuMincho', 'Hiragino Mincho ProN', 'MS Mincho', 'Noto Serif JP']) {
+        FontLibrary.use(fam, [MINCHO]);
+      }
+      const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
+      const { renderDocumentToCanvas, paginateDocument, physicalPageSizeForPage } =
+        rendererMod as Any;
+      const doc = parseDocx(readFileSync(SAMPLE));
+
+      const rImg = installImageBitmapShim(factory);
+      const rOff = installOffscreenCanvasShim(factory);
+      try {
+        // Word PDF: 2 pages, both physical Letter portrait 612×792 pt — the
+        // vertical page's stamped LOGICAL frame (792×612) must un-swap by its
+        // OWN direction, the horizontal page by its own.
+        const pages = paginateDocument(doc);
+        expect(pages.length).toBe(2);
+        expect(physicalPageSizeForPage(pages, 0, doc.section)).toEqual({ widthPt: 612, heightPt: 792 });
+        expect(physicalPageSizeForPage(pages, 1, doc.section)).toEqual({ widthPt: 612, heightPt: 792 });
+
+        const renderPage = async (pageIndex: number) => {
+          const runs: RunInfo[] = [];
+          const canvas = new Canvas(10, 10);
+          await renderDocumentToCanvas(doc, canvas as Any, pageIndex, {
+            dpr: 1,
+            width: 612,
+            prebuiltPages: pages,
+            onTextRun: (r: RunInfo) => runs.push(r),
+          });
+          return { runs, canvas };
+        };
+
+        // Page 1 — vertical (btLr ≡ tbRl): physical portrait canvas, every text
+        // run projected through the +90° page rotation (transform set), heading
+        // column hugging the right content margin, columns advancing right→left.
+        const p0 = await renderPage(0);
+        expect(p0.canvas.width).toBe(612);
+        expect(p0.canvas.height).toBe(792);
+        expect(p0.runs.length).toBeGreaterThan(0);
+        expect(p0.runs.every((r) => r.transform !== undefined)).toBe(true);
+        // Word PDF: heading column at x ≈ 519.1 (right content margin 540 minus
+        // the line box); glyphs start at the physical top margin y = 72.
+        const xs = p0.runs.map((r) => r.x);
+        expect(Math.max(...xs)).toBeGreaterThan(515);
+        expect(Math.max(...xs)).toBeLessThan(541);
+        expect(Math.min(...p0.runs.map((r) => r.y))).toBeCloseTo(72, 0);
+        // Columns progress right→left: the last paragraph's column sits well
+        // left of the heading's (Word PDF: 417.9 vs 519.1).
+        expect(Math.min(...xs)).toBeLessThan(460);
+
+        // Page 2 — horizontal control: same physical box, NO vertical transform,
+        // text flowing from the top-left content corner (x = 72, first line
+        // baseline band y ≈ 80–93 in the Word PDF).
+        const p1 = await renderPage(1);
+        expect(p1.canvas.width).toBe(612);
+        expect(p1.canvas.height).toBe(792);
+        expect(p1.runs.length).toBeGreaterThan(0);
+        expect(p1.runs.every((r) => r.transform === undefined)).toBe(true);
+        expect(Math.min(...p1.runs.map((r) => r.x))).toBeCloseTo(72, 0);
+        const minY1 = Math.min(...p1.runs.map((r) => r.y));
+        expect(minY1).toBeGreaterThan(70);
+        expect(minY1).toBeLessThan(95);
+      } finally {
+        rOff();
+        rImg();
+      }
+    });
+  },
+);

--- a/packages/node/src/docx-vertical-header-footer.probe.test.ts
+++ b/packages/node/src/docx-vertical-header-footer.probe.test.ts
@@ -164,11 +164,10 @@ function verticalHeaderFooterDocx(opts: DocxOpts): Uint8Array {
 
 interface Run { t: string; x: number; y: number; w: number; h: number; tr?: string }
 
-async function renderRuns(): Promise<{ runs: Run[]; physW: number; physH: number }> {
+async function renderRuns(): Promise<{ runs: Run[] }> {
   const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
-  const { renderDocumentToCanvas, physicalPageSizePt } = rendererMod as Any;
+  const { renderDocumentToCanvas } = rendererMod as Any;
   const doc = parseDocx(verticalHeaderFooterDocx({ hf: true }));
-  const phys = physicalPageSizePt(doc.section, doc.section.pageWidth, doc.section.pageHeight);
   // Physical letter portrait: width 612 (=pageWidth), height 792 (=pageHeight).
   const canvas = new Canvas(Math.round(doc.section.pageWidth), Math.round(doc.section.pageHeight));
   const runs: Run[] = [];
@@ -185,7 +184,7 @@ async function renderRuns(): Promise<{ runs: Run[]; physW: number; physH: number
     restoreOff();
     restoreImg();
   }
-  return { runs, physW: phys.widthPt, physH: phys.heightPt };
+  return { runs };
 }
 
 describe.skipIf(!skia || !docxMod || !rendererMod)(


### PR DESCRIPTION
Refs #1000 (the folded-in textbox cross-axis auto-grow item stays verify-only pending a disambiguating fixture, so this does not close the issue).

## What

A document whose NON-final section is vertical (`btLr` ≡ `tbRl` per the #988 batch-3 Word adjudication ①) while the final section is horizontal now renders each page in its own orientation. The single-section model (#513) surfaced only the body-level sectPr's `textDirection`; this generalizes the #996/#999 rotate-layout model to per-section frames — the `columns` per-section precedent applied to text direction.

- **parser (Rust)**: the ENDING section's `<w:textDirection>` is carried on its `SectionBreak` marker (sibling of `geom`/`pageNumType`, shared extraction with the body-level parse; `lrTb`/absent collapse to `None` so horizontal documents serialize byte-identically).
- **pagination**: each owning section resolves to a `ResolvedSectionFrame` — LOGICAL geometry (quarter-turn of the marker's physical `geom` iff that section is vertical; geom-less markers inherit the body-level PHYSICAL geometry) + direction + vertical flag — tracked on the section rails and stamped per element (`sectionTextDirection` in lockstep with `sectionGeom`, split slices included). Direction-MIXED documents re-seed the measure frame (page box, margins, content band, per-section `verticalPhys` for §20.4.3.x anchors, frame-derived section layout) at each transition; non-mixed documents keep the exact pre-existing body-level seed. The #999 upright-table band is a current-frame closure.
- **paint**: `renderDocumentToCanvas` derives `vertical` from the MERGED per-page section, so the physical canvas box, +90° rotation, `verticalCJK`, `verticalPhys` and the horizontal header/footer branch are per-page.
- **reserves (§17.6.11)**: vertical PAGES reserve 0 (matching the paint branch); the all-vertical early return is preserved; horizontal pages in a vertical-body mixed document measure their header/footer against their own frame.
- **page size**: `physicalPageSizeForPage` (shared by `DocxDocument.pageSize` and the worker `pageSizes` meta) un-swaps each page by its OWN direction; empty §17.18.77 parity pages resolve through per-page frame metadata (WeakMap, stamped at every page open; a parity BLANK carries the OUTGOING section's frame — §17.18.77: the new section "begins on the next odd/even-numbered page, leaving the next page blank"). Replaces the body-level `physicalPageSizePt`.

## Documented deviation (explicit, pinned in test)

A CONTINUOUS boundary whose rendered orientation changes is promoted to a page break. §17.18.77 wants the new section on the following paragraph; this renderer paints ONE rotation frame per physical page, so a same-page orientation mix is unrepresentable — the promotion is the deliberate fallback (compared via orientation flags, so `tbRl`→`btLr` stays continuous; horizontal-only documents never differ). No Word GT fixture exists for this boundary yet; revisit if one is adjudicated.

## Residuals (unchanged behavior, documented in code)

- per-section `docGrid` / line numbering / `vAlign` / page borders stay body-level (single-section model residual).
- empty-page header/footer + page-number resolution keep the body-level fallback (frame metadata carries geometry + direction only).
- non-mixed documents keep the body-level measure width for header/footer content (pre-existing residual).
- Strict ST_TextDirection tokens (`rl`/`lr`/`rlV`/`lrV`) remain classified horizontal — pre-existing, GT-gated (§17.18.93 `lr` glyph-orientation semantics were exactly the #988 adjudication question).

## Verification

- **Mixed fixture (private batch-3 ①, Word PDF GT via `pdfinfo` + `pdftotext -bbox`)**: 2 pages, both physical Letter portrait 612×792; p.1 vertical — heading column at the right content margin (GT x ≈ 519.1–532.0), flow from the physical top margin y = 72, columns right→left (519 → 496 → 470 → 444 → 418); p.2 horizontal from (72, ~80). Headless render matches (gated node probe pins page boxes, per-run +90° transforms, column x, and flow origins); `pdftoppm` side-by-side confirms the composition.
- **All-vertical sample (tbRl)**: VRT `match=100.0% diff=0.0%`, and the headless PNG is **byte-identical** to a pristine merge-base render; the horizontal page of the mixed fixture is also byte-identical to its merge-base render.
- **Horizontal path**: full VRT 85/85 (demo + private, fidelity ratchet intact), worker-equivalence VRT 0.000%.
- **Suites**: docx vitest 1349 + node 90 green (13 new unit tests + 1 gated GT probe), root `pnpm typecheck` clean, `cargo fmt`/`clippy -D warnings`/`cargo test` (339) clean, `ast-grep scan` clean, WASM rebuilt via package scripts.
- **Design + review**: architecture fixed with Codex gpt-5.6-sol (xhigh) before implementation; independent Codex gpt-5.6-sol (xhigh) review afterwards — parity-blank ownership, empty-page paint frame, citation fixes and the added reverse-mix/split-slice/layoutDocument tests are the review follow-ups (last commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)