### PR TITLE
fix(docx): match Word's SEA justified line fit (issue #991 GT rules)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -382,6 +382,7 @@ export {
   isSeaGraphemeExtend,
   containsSeaScript,
   isGraphemeFillText,
+  isDictionarySeaText,
   seaWordBreakOffsets,
   seaTransitionOffsets,
   seaMixedBreakOffsets,

--- a/packages/core/src/text/sea-break.test.ts
+++ b/packages/core/src/text/sea-break.test.ts
@@ -3,6 +3,7 @@ import {
   containsSeaScript,
   fitSeaWordPrefix,
   graphemeClusterOffsets,
+  isDictionarySeaText,
   isGraphemeFillText,
   isSeaGraphemeExtend,
   isSeaScriptCodePoint,
@@ -474,6 +475,26 @@ describe('isGraphemeFillText (#961)', () => {
     expect(isGraphemeFillText('Hello world')).toBe(false);
     expect(isGraphemeFillText('日本語')).toBe(false);
     expect(isGraphemeFillText('')).toBe(false);
+  });
+});
+
+describe('isDictionarySeaText (#991)', () => {
+  it('true only for pure dictionary-SEA (Thai/Lao/Khmer) content', () => {
+    expect(isDictionarySeaText('ภาษาไทย')).toBe(true);
+    expect(isDictionarySeaText('ພາສາລາວ')).toBe(true);
+    expect(isDictionarySeaText('ភាសាខ្មែរ')).toBe(true);
+    expect(isDictionarySeaText('Hello ไทย 123')).toBe(true); // non-SEA is ignored
+  });
+  it('false for grapheme-fill scripts, mixed SEA families, and non-SEA text', () => {
+    expect(isDictionarySeaText('မြန်မာ')).toBe(false); // Myanmar
+    expect(isDictionarySeaText('བོད་ཡིག')).toBe(false); // Tibetan
+    // A single run mixing both families is excluded REGARDLESS of which span
+    // comes first (isGraphemeFillText would classify by the first span only).
+    expect(isDictionarySeaText('ไทยမြန်မာ')).toBe(false);
+    expect(isDictionarySeaText('မြန်မာไทย')).toBe(false);
+    expect(isDictionarySeaText('Hello world')).toBe(false);
+    expect(isDictionarySeaText('日本語')).toBe(false);
+    expect(isDictionarySeaText('')).toBe(false);
   });
 });
 

--- a/packages/core/src/text/sea-break.ts
+++ b/packages/core/src/text/sea-break.ts
@@ -153,6 +153,30 @@ export function isGraphemeFillText(text: string): boolean {
   return false;
 }
 
+/**
+ * True when `text` carries dictionary-SEA (Thai/Lao/Khmer) content and NO
+ * grapheme-fill (Myanmar/Tibetan) content. Unlike {@link isGraphemeFillText}
+ * this scans EVERY code point, so a rare single run mixing both SEA families
+ * is excluded rather than classified by its first span.
+ *
+ * Introduced for the issue #991 Word-verified fit rules (zero trailing-space
+ * shrink on Thai lines; whole-chunk movement of a full-line-fitting no-space
+ * run): they apply exactly to pure dictionary-SEA segments. Grapheme-fill
+ * scripts keep the per-cluster greedy fill (#961), and a mixed-family segment
+ * falls back to the pre-#991 greedy path so a grapheme-fill span is never
+ * moved as part of an atomic chunk.
+ */
+export function isDictionarySeaText(text: string): boolean {
+  let hasDict = false;
+  for (const ch of text) {
+    const cp = ch.codePointAt(0)!;
+    if (!isSeaScriptCodePoint(cp)) continue;
+    if (isGraphemeFillScript(seaScriptOf(cp))) return false;
+    hasDict = true;
+  }
+  return hasDict;
+}
+
 // ── Segmenter plumbing (cached + test-injectable) ────────────────────────────
 
 /** Minimal shape of one `Intl.Segments` entry we rely on. */

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -33,6 +33,7 @@ import {
   isUax14NoBreakPair,
   containsSeaScript,
   isGraphemeFillText,
+  isDictionarySeaText,
   seaMixedBreakOffsets,
   fitSeaWordPrefix,
   graphemeClusterOffsets,
@@ -2626,6 +2627,18 @@ export function layoutLines(
 
   let lineHasRuby = false;
   let lineEastAsian = false;
+  // Whether any committed token on the current line carries DICTIONARY-SEA
+  // (Thai/Lao/Khmer) text — `seaBreaks` marks all SEA segments; the
+  // grapheme-fill scripts (Myanmar/Tibetan, #961) are excluded because the
+  // issue #991 ground truth covers only the dictionary scripts and their
+  // Word-verified wrap is per-cluster greedy. Gates the trailing-space shrink
+  // budget: Word-observed (issue #991 — the calibration fixture's
+  // 21-paragraph overflow sweep at 5/9/13 inter-phrase spaces) shows Word
+  // wraps such a line's final word at natural fit for EVERY overflow > 0,
+  // i.e. it never compresses inter-word spaces on Thai lines, while the Latin
+  // demo evidence for SPACE_SHRINK_RATIO (sample-1 p3/p6) and the CJK centred
+  // title (sample-10) keep the 25% drawable budget.
+  let lineHasSea = false;
   const flush = (
     forceHeight?: number,
     brTerminated = false,
@@ -2668,6 +2681,7 @@ export function layoutLines(
     lineIntendedSingle = 0;
     lineHasRuby = false;
     lineEastAsian = false;
+    lineHasSea = false;
     isFirst = false;
     startLine(minLineStartWidth());
   };
@@ -2698,6 +2712,7 @@ export function layoutLines(
     if (!('isTab' in s) && !('imagePath' in s) && !('mathNodes' in s)) {
       const ts = s as LayoutTextSeg;
       if (ts.ruby) lineHasRuby = true;
+      if (ts.seaBreaks !== undefined && isDictionarySeaText(ts.text)) lineHasSea = true;
       if (!lineEastAsian && EAST_ASIAN_RE.test(ts.text)) lineEastAsian = true;
       // Intended single-line height for fonts whose substituted Canvas metrics
       // understate Word's line spacing (font-metrics.ts). 0 for untabled fonts.
@@ -3190,10 +3205,26 @@ export function layoutLines(
     //    (`shrinkFitCompression`). Demo/sample-1 p3/p6 space-collapse evidence
     //    shows that ADDING the bias double-counts tolerance and admits words the
     //    non-justified paint path cannot fit.
+    // Dictionary-SEA candidate (Thai/Lao/Khmer; grapheme-fill Myanmar/Tibetan
+    // excluded — their Word-verified wrap is per-cluster greedy, #961, and the
+    // #991 ground truth covers only the dictionary scripts). Per-codepoint
+    // scan: a rare segment mixing both SEA families is NOT dictionary-SEA, so
+    // it keeps the pre-#991 greedy path instead of moving a grapheme-fill span
+    // inside an atomic chunk.
+    const sDictSea = s.seaBreaks !== undefined && isDictionarySeaText(s.text);
     const shrinkBudgetFor = (next: LayoutSeg | undefined, biasBudget: number): number => {
       const closesLogicalLine = next === undefined || 'lineBreak' in next;
       const lineWillJustify = isJustified && (!closesLogicalLine || stretchLastLine);
-      return lineWillJustify ? biasBudget : lineTotalTrailingW * SPACE_SHRINK_RATIO;
+      if (lineWillJustify) return biasBudget;
+      // Word-observed (issue #991 calibration sweep): a line carrying
+      // dictionary-SEA text never compresses its inter-word spaces — Word
+      // wraps at natural fit for every overflow > 0 regardless of how many
+      // spaces the line holds. The candidate counts too: admitting it would
+      // make the line SEA, so the same zero-shrink fit applies (the sweep's
+      // committed tokens were all Thai; mixed-script GT is uncollected — this
+      // takes the wrap conservatively). The 25% drawable budget below is the
+      // Latin/CJK-verified behavior.
+      return lineHasSea || sDictSea ? 0 : lineTotalTrailingW * SPACE_SHRINK_RATIO;
     };
     const shrinkBudget = shrinkBudgetFor(
       queue[0],
@@ -3281,6 +3312,60 @@ export function layoutLines(
       if (
         currentWidth + (groupW - groupTrail)
         > availW() + shrinkBudgetFor(queue[groupEnd], groupBiasBudget)
+      ) {
+        flush(undefined, false, s.src);
+      }
+    }
+
+    // No-space SEA chunk placement — ECMA-376 prescribes no SEA line-breaking
+    // algorithm; Word-observed (issue #991, calibration fixture parts II/II-D):
+    // the dictionary boundaries inside a no-space Thai/Lao/Khmer chunk are
+    // SECONDARY break opportunities. A chunk that does not fit the remaining
+    // width of a non-empty line moves to the next line WHOLE when it fits a
+    // full line by itself — Word never splits it mid-chunk to fill the current
+    // line (invariant across remaining widths, across the chunk being authored
+    // as several glued `w:r`, and with/without a leading tab). Only a chunk
+    // wider than a full line breaks at the dictionary boundaries (part II-D;
+    // ordinary spaceless Thai paragraphs wrap this way on every line), which
+    // is the greedy SEA branch below, kept unchanged.
+    //
+    // Judged only at chunk START: if the previously committed token is a text
+    // segment glued to `s` (no trailing space), the whole chunk already passed
+    // this judgment when its head was placed, so a mid-chunk segment never
+    // needs it. The chunk spans `s` plus following queue segments while they
+    // stay dictionary-SEA text glued without intervening spaces. Grapheme-fill
+    // scripts (Myanmar/Tibetan) are excluded: their Word-verified wrap fills
+    // per cluster (#961), so a fitting chunk must NOT move whole.
+    if (
+      sDictSea &&
+      currentLine.length > 0 &&
+      (() => {
+        const last = currentLine[currentLine.length - 1];
+        return !('text' in last) || (last as LayoutTextSeg).text.endsWith(' ');
+      })()
+    ) {
+      let chunkW = w;
+      let chunkTrail = trailingSpaceW;
+      let chunkEnd = 0;
+      let chunkBias = lineBiasBudget + biasBudgetContribution(s, trimmed);
+      if (!s.text.endsWith(' ')) {
+        for (; chunkEnd < queue.length; chunkEnd++) {
+          const f = queue[chunkEnd];
+          if (!('text' in f) || (f as LayoutTextSeg).seaBreaks === undefined) break;
+          if (!isDictionarySeaText((f as LayoutTextSeg).text)) break;
+          const ft = f as LayoutTextSeg;
+          const fw = segAdvance(ft);
+          const fTrim = ft.text.replace(/ +$/, '');
+          chunkW += fw;
+          chunkTrail = ft.text.endsWith(' ') ? fw - strAdvance(ft, fTrim) : 0;
+          chunkBias += biasBudgetContribution(ft, fTrim);
+          if (ft.text.endsWith(' ')) { chunkEnd++; break; } // a space ends the chunk
+        }
+      }
+      const chunkWForFit = chunkW - chunkTrail;
+      if (
+        currentWidth + chunkWForFit > availW() + shrinkBudgetFor(queue[chunkEnd], chunkBias) &&
+        chunkWForFit <= lineMaxWidth
       ) {
         flush(undefined, false, s.src);
       }

--- a/packages/docx/src/sea-justified-fit.test.ts
+++ b/packages/docx/src/sea-justified-fit.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas, type DocxTextRunInfo } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxTextRun,
+  DocxDocumentModel,
+  SectionProps,
+} from './types';
+
+// Word-observed SEA (Thai/Lao/Khmer) line-fit behavior — issue #991, adjudicated
+// against the Word PDF of the purpose-built calibration fixture (21-paragraph
+// overflow sweep + 8 no-space-run placements; record on the issue):
+//
+// 1. ZERO trailing-space shrink on SEA lines. Word admits a paragraph-final
+//    word past the column edge on a non-justified-painted line only for Latin
+//    (the SPACE_SHRINK_RATIO budget, demo-verified); on lines carrying SEA
+//    script Word wraps at natural fit for EVERY overflow ≥ +1pt across 5/9/13
+//    inter-phrase spaces (admits only the negative-overflow controls). The
+//    allowance is therefore suppressed per line when the line contains SEA
+//    text. Latin/CJK lines keep the 25% drawable budget (sample-1 p3/p6,
+//    sample-10 title).
+//
+// 2. Dictionary boundaries are SECONDARY break opportunities. A no-space SEA
+//    chunk that does not fit the remaining width of a non-empty line moves to
+//    the next line WHOLE when it fits a full line by itself — Word never
+//    splits it mid-chunk to fill the current line (invariant across remaining
+//    widths 305–348pt, across run splits into multiple w:r, and with/without a
+//    leading tab). Only a chunk wider than a full line breaks at dictionary
+//    boundaries (calibration part II-D; both controls broke at exactly our
+//    boundaries, so the dictionaries agree).
+//
+// The linear stub advances FONT_PX per code point, making the arithmetic
+// explicit. Thai combining marks count as full advances here — irrelevant, as
+// every expected number below is computed in the same model.
+
+const FONT_PX = 12;
+
+function makeLinearCanvas(): HTMLCanvasElement {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  const px = () => Number(/([\d.]+)px/.exec(font)?.[1] ?? FONT_PX);
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(v: string) { letterSpacing = v; },
+    fontKerning: 'auto',
+    measureText: (s: string) => {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillText() {}, strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0, style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return canvas as unknown as HTMLCanvasElement;
+}
+
+function textRun(text: string, extra: Partial<DocxTextRun> = {}): DocxTextRun {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: FONT_PX, color: null, fontFamily: 'serif', isLink: false, background: null,
+    vertAlign: null, hyperlink: null, ...extra,
+  };
+}
+
+type DocRun = DocParagraph['runs'][number];
+
+function para(runs: DocRun[], alignment: DocParagraph['alignment']): BodyElement {
+  const p: DocParagraph = {
+    alignment,
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs,
+    defaultFontSize: FONT_PX, defaultFontFamily: 'serif',
+    widowControl: false,
+  };
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+function textPara(text: string, alignment: DocParagraph['alignment']): BodyElement {
+  return para([{ type: 'text', ...textRun(text) } as DocRun], alignment);
+}
+
+function section(pageWidth: number): SectionProps {
+  return {
+    pageWidth, pageHeight: 400,
+    marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+    docGridCharSpace: undefined,
+  } as SectionProps;
+}
+
+function doc(el: BodyElement, sec: SectionProps): DocxDocumentModel {
+  return {
+    section: sec, body: [el],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+async function renderLines(el: BodyElement, pageWidth: number): Promise<string[]> {
+  const runs: DocxTextRunInfo[] = [];
+  await renderDocumentToCanvas(doc(el, section(pageWidth)), makeLinearCanvas(), 0, {
+    dpr: 1,
+    width: pageWidth,
+    onTextRun: (r) => { if (r.text && r.text.trim()) runs.push(r); },
+  });
+  const byY = new Map<number, DocxTextRunInfo[]>();
+  for (const r of runs) {
+    const key = Math.round(r.y);
+    let arr = byY.get(key);
+    if (!arr) { arr = []; byY.set(key, arr); }
+    arr.push(r);
+  }
+  return [...byY.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, rs]) => rs.slice().sort((p, q) => p.x - q.x).map((r) => r.text).join(''));
+}
+
+const norm = (l: string) => l.replace(/\s+/g, '');
+
+// ── Rule 1 arithmetic ────────────────────────────────────────────────────────
+// 'มาก ' token = 4 cp = 48px (word 36 + trailing space 12); three tokens = 144.
+// Final word 'ดังนี้' = 6 cp = 72 (no interior dictionary boundary). Natural end
+// = 216. Column 210 ⇒ overflow 6px, under the Latin-style 25% budget
+// (0.25 × 36 = 9px) — a Latin line would ADMIT; the SEA line must WRAP.
+const THAI_FINAL = 'มาก มาก มาก ดังนี้';
+
+// ── Rule 2 arithmetic ────────────────────────────────────────────────────────
+// Lead token 'มาก ' = 48. Chunk 'น้อยน้อยน้อยน้อย' = 16 cp = 192, dictionary
+// boundaries at 4/8/12 (48px words). Column 200: 48+192 = 240 overflows; the
+// old greedy fill split the chunk at offset 12 (144 ≤ 152 remaining). The
+// chunk alone fits a full line (192 ≤ 200) ⇒ Word moves it WHOLE.
+const THAI_CHUNK = 'มาก น้อยน้อยน้อยน้อย';
+
+describe('issue #991 — SEA justified fit (Word calibration-fixture rules)', () => {
+  it('Rule 1: wraps the paragraph-final Thai word on a thaiDistribute closing line (zero space-shrink)', async () => {
+    const lines = await renderLines(textPara(THAI_FINAL, 'thaiDistribute'), 210);
+    expect(lines.length).toBe(2);
+    expect(norm(lines[0])).toBe('มากมากมาก');
+    expect(norm(lines[1])).toBe('ดังนี้');
+  });
+
+  it('Rule 1: the suppression is script-scoped, not jc-scoped (left-aligned Thai wraps too)', async () => {
+    const lines = await renderLines(textPara(THAI_FINAL, 'left'), 210);
+    expect(lines.length).toBe(2);
+    expect(norm(lines[1])).toBe('ดังนี้');
+  });
+
+  it('Rule 1 control: content that genuinely fits stays on one line', async () => {
+    const lines = await renderLines(textPara(THAI_FINAL, 'thaiDistribute'), 216);
+    expect(lines.length).toBe(1);
+  });
+
+  it('Rule 1: a SEA candidate on a Latin line also gets zero shrink (candidate-inclusive)', async () => {
+    // 'AAAA ' ×3 = 180, Thai final word 'ดังนี้' = 72 ⇒ natural end 252; column
+    // 246 ⇒ overflow 6 ≤ 0.25×36 — a Latin candidate would be admitted, but
+    // admitting the Thai word makes the line SEA, so the same zero-shrink fit
+    // applies and it wraps (mixed-script GT uncollected; conservative wrap).
+    const lines = await renderLines(textPara('AAAA AAAA AAAA ดังนี้', 'left'), 246);
+    expect(lines.length).toBe(2);
+    expect(norm(lines[1])).toBe('ดังนี้');
+  });
+
+  it('Rule 1/2 guard: grapheme-fill scripts (Myanmar) keep the per-cluster greedy fill', async () => {
+    // Myanmar is SEA-marked but grapheme-fill (#961): both #991 rules must NOT
+    // apply. Lead 'မာ ' = 3 cp = 36; run 'စု'×7 = 14 cp = 168 ('စ' U+1005 +
+    // nonspacing 'ု' U+102F = ONE grapheme cluster; boundaries every 2 cp —
+    // unlike U+102C, a UAX#29 SpacingMark exception that clusters alone).
+    // Column 200: the run fits a full line (168 ≤ 200) but not the remainder
+    // (164) — a dictionary chunk would move whole; the grapheme-fill run must
+    // instead fill the line cluster-by-cluster (6 clusters = 144 ≤ 164 < 168).
+    const lines = await renderLines(textPara('မာ စုစုစုစုစုစုစု', 'left'), 200);
+    expect(lines.length).toBe(2);
+    expect(norm(lines[0])).toBe('မာစုစုစုစုစုစု');
+    expect(norm(lines[1])).toBe('စု');
+  });
+
+  it('Rule 2 guard: a segment mixing dictionary and grapheme-fill SEA is not moved whole', async () => {
+    // 'น้อยน้อยစုစုစုစุ'-style mixed runs are NOT dictionary-SEA (per-codepoint
+    // scan), so the chunk pre-flush must not fire even though the run fits a
+    // full line: the greedy SEA fill splits it at the merged offset set.
+    // Lead 'มาก ' = 48; mixed run 'น้อยน้อย' + 'စုစုစုစု' = 16 cp = 192 ≤ 200,
+    // remaining = 152 ⇒ greedy split keeps a prefix on line 1.
+    const lines = await renderLines(textPara('มาก น้อยน้อยစုစုစုစု', 'left'), 200);
+    expect(lines.length).toBe(2);
+    expect(norm(lines[0]).length, 'a prefix of the mixed run stays on line 1 (greedy)').toBeGreaterThan(3);
+    expect(norm(lines.join(''))).toBe('มากน้อยน้อยစုစုစုစု');
+  });
+
+  it('Rule 1 guard: a Latin line keeps the 25% drawable trailing-space budget', async () => {
+    // 'AAAA ' ×3 = 180, final 'AAAA' = 48 ⇒ natural end 228, column 225 ⇒
+    // overflow 3 ≤ 0.25×36 — the Latin closing line still admits (issue #698
+    // behavior; full matrix in justify-shrink-overshoot.test.ts).
+    const lines = await renderLines(textPara('AAAA AAAA AAAA AAAA', 'left'), 225);
+    expect(lines.length).toBe(1);
+  });
+
+  it('Rule 2: a no-space chunk that fits a full line moves whole instead of splitting', async () => {
+    const lines = await renderLines(textPara(THAI_CHUNK, 'thaiDistribute'), 200);
+    expect(lines.length).toBe(2);
+    expect(norm(lines[0])).toBe('มาก');
+    expect(norm(lines[1])).toBe('น้อยน้อยน้อยน้อย');
+  });
+
+  it('Rule 2: same movement under a non-justified alignment', async () => {
+    const lines = await renderLines(textPara(THAI_CHUNK, 'left'), 200);
+    expect(lines.length).toBe(2);
+    expect(norm(lines[0])).toBe('มาก');
+    expect(norm(lines[1])).toBe('น้อยน้อยน้อยน้อย');
+  });
+
+  it('Rule 2: the chunk spans w:r boundaries (a run split is not a break opportunity)', async () => {
+    const el = para(
+      [
+        { type: 'text', ...textRun('มาก ') } as DocRun,
+        { type: 'text', ...textRun('น้อยน้อย') } as DocRun,
+        { type: 'text', ...textRun('น้อยน้อย') } as DocRun,
+      ],
+      'thaiDistribute',
+    );
+    const lines = await renderLines(el, 200);
+    expect(lines.length).toBe(2);
+    expect(norm(lines[0])).toBe('มาก');
+    expect(norm(lines[1])).toBe('น้อยน้อยน้อยน้อย');
+  });
+
+  it('Rule 2 guard: an over-full chunk still fills the line greedily at dictionary boundaries', async () => {
+    // Column 180 < chunk 192 ⇒ the chunk cannot fit any line whole; Word breaks
+    // it at dictionary boundaries (calibration part II-D), which is the greedy
+    // fill: remaining after the lead = 132 ⇒ split at offset 8 (96 ≤ 132 < 144).
+    const lines = await renderLines(textPara(THAI_CHUNK, 'thaiDistribute'), 180);
+    expect(lines.length).toBe(2);
+    expect(norm(lines[0])).toBe('มากน้อยน้อย');
+    expect(norm(lines[1])).toBe('น้อยน้อย');
+  });
+
+  it('Rule 2 control: a chunk that fits the remaining width stays on the line', async () => {
+    const lines = await renderLines(textPara('มาก น้อยน้อย', 'thaiDistribute'), 200);
+    expect(lines.length).toBe(1);
+  });
+});

--- a/packages/node/src/docx-sea-justified-fit.probe.test.ts
+++ b/packages/node/src/docx-sea-justified-fit.probe.test.ts
@@ -176,8 +176,11 @@ const macos = process.platform === 'darwin';
 const havePdftotext = (() => {
   try { execFileSync('pdftotext', ['-v'], { stdio: 'ignore' }); return true; } catch { return false; }
 })();
-const gate = !!skia && !!docxMod && !!rendererMod && macos && havePdftotext
-  && !!SAMPLE && !!PDF && existsSync(SAMPLE!) && existsSync(PDF!);
+const havePdfinfo = (() => {
+  try { execFileSync('pdfinfo', ['-v'], { stdio: 'ignore' }); return true; } catch { return false; }
+})();
+const baseGate = !!skia && !!docxMod && !!rendererMod && macos && havePdftotext;
+const gate = baseGate && !!SAMPLE && !!PDF && existsSync(SAMPLE!) && existsSync(PDF!);
 
 describe.skipIf(!gate)('issue #991 — SEA justified line-fit adjudication', () => {
   it('per-page line-break divergence report', async () => {
@@ -260,4 +263,61 @@ describe.skipIf(!gate)('issue #991 — SEA justified line-fit adjudication', () 
     if (process.env.DOCX_FIT_OUT) writeFileSync(process.env.DOCX_FIT_OUT, summary);
     expect(ourTotal).toBeGreaterThan(0);
   });
+});
+
+// ── Fixture pins (private corpus, local-only — CI has no private fixtures) ────
+// Word-parity ACCEPTANCE for the issue #991 fix: on a host that has the private
+// fixtures AND their real fonts installed, our per-page visible-line counts must
+// equal the Word reference PDF's. sample-29 is the Thai corpus document (Word
+// emits 221 lines; the pre-fix engine emitted 219) and sample-55 is the #991
+// calibration fixture (21-paragraph overflow sweep + 8 no-space-run placements,
+// adjudication-manifest-4.md). Line-content divergences inside an equal-count
+// page (e.g. interleaved narrow table-cell headers that pdftotext flattens in a
+// different order) are reconstruction artifacts, so the pin is count-based.
+const privatePair = (name: string): { docx: string; pdf: string } | null => {
+  const dir = resolve(ROOT, 'packages/docx/public/private');
+  const docx = resolve(dir, `${name}.docx`);
+  const pdf = resolve(dir, `${name}.pdf`);
+  return existsSync(docx) && existsSync(pdf) ? { docx, pdf } : null;
+};
+
+// Requires `pdfinfo` (poppler, alongside pdftotext) for the trailing-page
+// emptiness check below.
+describe.skipIf(!baseGate || !havePdfinfo)('issue #991 — private fixture line-count pins', () => {
+  for (const name of ['sample-29', 'sample-55']) {
+    const pair = privatePair(name);
+    it.skipIf(!pair)(`${name}: per-page visible-line counts match the Word PDF`, async () => {
+      const doc = parse(pair!.docx);
+      const restore = [installOffscreenCanvasShim(factory), installImageBitmapShim(factory)];
+      let pages: unknown[][];
+      try { pages = (rendererMod as unknown as RendererMod).paginateDocument(doc); }
+      finally { restore.forEach((r) => r()); }
+      let ourTotal = 0;
+      let wordTotal = 0;
+      for (let p = 0; p < pages.length; p++) {
+        const our = await ourPageLines(doc, pages, p, 595);
+        const word = wordPageLines(pair!.pdf, p);
+        ourTotal += our.length;
+        wordTotal += word.length;
+        expect(our.length, `${name} page ${p + 1} visible-line count`).toBe(word.length);
+      }
+      // Word may paginate onto MORE pages than we do (e.g. the Thai corpus
+      // document renders 11 pages under the #989-adjudicated grazing fit while
+      // Word emits a 12th, empty, page). Any PDF page beyond our page count
+      // must then carry NO text — otherwise the per-page loop above silently
+      // skipped real Word content and the equal totals would be a lie.
+      const pdfInfo = execFileSync('pdfinfo', [pair!.pdf], { encoding: 'utf8' });
+      const pdfPages = Number(/^Pages:\s+(\d+)$/m.exec(pdfInfo)?.[1] ?? '0');
+      expect(pdfPages, `${name} pdfinfo page count`).toBeGreaterThan(0);
+      for (let p = pages.length; p < pdfPages; p++) {
+        expect(
+          wordPageLines(pair!.pdf, p).length,
+          `${name} Word PDF page ${p + 1} exceeds our pagination and must be empty`,
+        ).toBe(0);
+      }
+      // eslint-disable-next-line no-console
+      console.log(`[#991 pin] ${name}: ${ourTotal} lines == Word ${wordTotal} (our ${pages.length} pages, PDF ${pdfPages})`);
+      expect(ourTotal).toBe(wordTotal);
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Implements the two Word-PDF-adjudicated rules from the issue #991 ground-truth sweep (calibration fixture: 21-paragraph final-word overflow sweep at 5/9/13 inter-phrase spaces + 8 no-space-run placements, printed to PDF by Word with the real Thai face; full adjudication tables on the issue):

1. **Zero trailing-space shrink on dictionary-SEA lines.** Word wraps a paragraph-final word at natural fit for every overflow > 0, independent of the space count. `shrinkBudgetFor` now returns 0 when the line (or the candidate) carries dictionary-SEA text. Latin (demo sample-1 p3/p6) and CJK (sample-10 title) keep the verified 25% budget.
2. **A no-space SEA chunk that fits a full line moves whole.** Dictionary boundaries are secondary break opportunities: a Thai/Lao/Khmer chunk (spanning glued `w:r`) that no longer fits a non-empty line's remainder is moved intact to the next line when it fits a line by itself — invariant in the GT across remaining widths (305–348pt), multi-run authoring, and leading tabs. Chunks wider than a full line keep the greedy dictionary fill (GT part II-D, where Word's break positions equal ours exactly).

Both rules key on a new core predicate `isDictionarySeaText` (per-codepoint scan), so grapheme-fill scripts (Myanmar/Tibetan — #961 per-cluster greedy) and mixed-family segments keep their existing paths, and non-SEA documents are byte-identical.

## Before / after

| measurement | before | after |
|---|---|---|
| Thai corpus fixture visible lines vs Word 221 | 219 (2 divergent wraps) | **221 (Δ=0, no divergences)** |
| calibration fixture (29 adjudication paragraphs) | 2 rule families divergent | **94/94 lines, zero divergences** |
| pagination | 11 pages | 11 pages (unchanged) |
| demo (Georgia) VRT ratchet | pass | pass — byte-identical (A/B against pristine HEAD: same diff-pixel counts) |
| non-Thai private VRT samples | 100% self-match | 100% (pixel-identical) |
| Thai corpus pages p1/2/3/4/8 vs Word raster | 94.33/89.04/91.72/94.15/95.28% | **96.13/89.57/94.93/96.49/95.31%** (all toward Word) |

The 5 re-wrapped Thai pages intentionally differ from the local private VRT baseline (2026-07-12a); reference update is deferred to the user per policy.

## Tests

- `packages/docx/src/sea-justified-fit.test.ts` — 12 Word-verified synthetic gates (linear-stub arithmetic): both rules, candidate-inclusive SEA gate, Latin 25% guard, Myanmar per-cluster guard, mixed-family guard, over-full greedy guard, fit controls.
- `packages/core/src/text/sea-break.test.ts` — `isDictionarySeaText` cases incl. both mixed-family orders.
- `packages/node/src/docx-sea-justified-fit.probe.test.ts` — private fixture line-count pins (per-page equality vs the Word PDFs + trailing-PDF-page emptiness guard; local-only, CI skips).

## Verification

- docx 174 files / core / node suites: all green (3196 tests); root `pnpm typecheck` green.
- Independent Codex review (gpt-5.6-sol, high): two rounds of findings addressed (candidate-inclusive gate, Myanmar/Tibetan + mixed-segment exclusion via the per-codepoint core predicate, pdfinfo gating); final VERDICT: LGTM.
- Rebased on latest main; the #1002 per-section direction probe passes after a WASM rebuild.

Follow-up (separate): pptx/xlsx share the SEA break kernel but keep their own greedy fill policies — cross-package parity check.

Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)