### PR TITLE
feat(docx): eaVert spAutoFit cross-axis auto-grow/shrink (#1000)

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -10045,35 +10045,26 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
   if (w < 0 || h < 0) return;
   if (isLineGeom ? w === 0 && h === 0 : w === 0 || h === 0) return;
 
-  if (
-    !isLineGeom &&
-    shape.textAutofit === 'sp' &&
-    shape.textBlocks &&
-    shape.textBlocks.length > 0 &&
-    // §20.1.10.83 vertical text box: `measureShapeTextAutoFitHeight` grows the
-    // PHYSICAL HEIGHT to fit the horizontal line stack, but a vertical box's
-    // block-progression (line-stacking) axis is the CROSS axis (physical WIDTH)
-    // after the ±90° rotation — that is the axis `<a:spAutoFit/>` resizes, NOT the
-    // height (Word-verified: the batch-3 GT / issue #988 shows the column-length
-    // = physical height stays the fixed wrap dimension). Re-measuring height here
-    // would grow the wrong axis. The GT also shows Word placing the columns at the
-    // box's AUTHORED `<wp:extent>` edges (a shrink-to-content cross fit would move
-    // the reading-start edge), so vertical boxes keep their declared extent — this
-    // reproduces the fixture exactly. Cross-axis auto-GROW for a box whose content
-    // overflows its authored cross extent remains a verify-only follow-up (needs a
-    // fixture that overflows AND carries a panel to disambiguate the anchored edge).
-    verticalTextboxMode(shape.textVert) === null
-  ) {
-    const fitH = measureShapeTextAutoFitHeight(
+  if (!isLineGeom) {
+    // §21.1.2.1.1 `<a:spAutoFit/>` — resize the box to its content, keeping the
+    // authored top-left anchor fixed. A HORIZONTAL box grows the physical HEIGHT
+    // (line-stacking axis, top edge fixed); a VERTICAL box (§20.1.10.83, #1000)
+    // grows/shrinks the physical WIDTH (the column-stacking cross axis after the
+    // ±90° rotate-layout, LEFT edge fixed) — Word-verified against the autofit
+    // adjudication fixture. `resolveShapeAutofitBox` picks the axis by `vert`.
+    const fit = resolveShapeAutofitBox(
       shape,
-      w,
+      { x, y, w, h },
       ctx as CanvasRenderingContext2D,
       scale,
       state.fontFamilyClasses,
       state.images,
       state,
     );
-    if (Number.isFinite(fitH) && fitH > 0) h = fitH;
+    x = fit.x;
+    y = fit.y;
+    w = fit.w;
+    h = fit.h;
   }
 
   // ECMA-376 Part 4 §19.1.2.23 `<v:textpath>` — a WordArt text watermark. It
@@ -10404,6 +10395,64 @@ export function measureShapeTextAutoFitHeight(
   } finally {
     ctx.restore();
   }
+}
+
+/** ECMA-376 §21.1.2.1.1 `<a:spAutoFit/>` — resize a text box's bounding box to
+ *  fit its laid-out content, keeping the authored TOP-LEFT anchor (`<a:off>`)
+ *  fixed. Returns the box unchanged for a non-spAutoFit box or one with no text.
+ *
+ *  HORIZONTAL box (`vert` absent): the block-progression (line-stacking) axis is
+ *  the physical HEIGHT, so the height grows/shrinks to the line stack — the TOP
+ *  edge (`off.y`) stays fixed, the BOTTOM edge moves. (Existing behaviour.)
+ *
+ *  VERTICAL box (§20.1.10.83 `vert`/`vert270`/`eaVert`/`mongolianVert`, issue
+ *  #1000): after the ±90° rotate-layout the block-progression (column-stacking)
+ *  axis is the physical WIDTH — the column length (= physical HEIGHT) is the
+ *  FIXED wrap dimension (#988B). spAutoFit resizes THAT cross axis to the column
+ *  stack: GROW on overflow, SHRINK on underflow, keeping the authored LEFT edge
+ *  (`positionH` posOffset / `off.x`) fixed and moving the RIGHT edge — the SAME
+ *  top-left bbox anchor the horizontal branch keeps. Word GT (the autofit
+ *  adjudication fixture, measured from the Word PDF): an overflowing `eaVert` box
+ *  grows +1.37in RIGHTWARD and an underflowing one shrinks −1.45in from the
+ *  right, its authored LEFT edge fixed in both; a `noAutofit` twin keeps the
+ *  authored extent and clips. The cross extent is measured by the SAME line
+ *  engine, but with the wrap width = physical HEIGHT (the swapped column-length
+ *  axis): `measureShapeTextAutoFitHeight` maps lIns/rIns onto the wrap axis and
+ *  tIns/bIns onto the stack axis exactly as the vertical draw does, so its
+ *  returned "height" IS the physical WIDTH the columns require (insets included).
+ *
+ *  A vertical box carrying an inline-image block keeps its authored extent: an
+ *  upright image reserves its cross extent by physical WIDTH, which the
+ *  horizontal line measurement cannot size, so growing/shrinking is skipped
+ *  (pre-#1000 behaviour) rather than sized from a wrong measurement.
+ *
+ *  Exported for unit testing the grow/shrink/anchor contract. */
+export function resolveShapeAutofitBox(
+  shape: ShapeRun,
+  box: { x: number; y: number; w: number; h: number },
+  ctx: CanvasRenderingContext2D,
+  scale: number,
+  fontFamilyClasses: Record<string, string> = {},
+  images: Map<string, DecodedImage> = new Map(),
+  state?: RenderState,
+): { x: number; y: number; w: number; h: number } {
+  const { x, y, w, h } = box;
+  if (shape.textAutofit !== 'sp' || !shape.textBlocks || shape.textBlocks.length === 0) {
+    return { x, y, w, h };
+  }
+  const vmode = verticalTextboxMode(shape.textVert);
+  if (vmode === null) {
+    // HORIZONTAL: grow/shrink the physical HEIGHT (line-stacking axis) to the
+    // laid-out content; the TOP edge (y) stays fixed.
+    const fitH = measureShapeTextAutoFitHeight(shape, w, ctx, scale, fontFamilyClasses, images, state);
+    return Number.isFinite(fitH) && fitH > 0 ? { x, y, w, h: fitH } : { x, y, w, h };
+  }
+  // VERTICAL (§20.1.10.83, #1000): resize the physical WIDTH (cross / column-
+  // stacking axis) to the content, LEFT edge (x) fixed. An upright inline image's
+  // cross extent is not line-measurable ⇒ keep the authored extent.
+  if (shape.textBlocks.some((b) => b.imagePath)) return { x, y, w, h };
+  const fitW = measureShapeTextAutoFitHeight(shape, h, ctx, scale, fontFamilyClasses, images, state);
+  return Number.isFinite(fitW) && fitW > 0 ? { x, y, w: fitW, h } : { x, y, w, h };
 }
 
 /** Render a shape's body text inside its bounding box, honoring lIns/tIns/

--- a/packages/docx/src/textbox-vertical-autofit.test.ts
+++ b/packages/docx/src/textbox-vertical-autofit.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import { resolveShapeAutofitBox } from './renderer';
+import type { ShapeRun, ShapeText, ShapeTextRun } from './types';
+
+// ECMA-376 §20.1.10.83 (`<wps:bodyPr vert>`) + §21.1.2.1.1 (`<a:spAutoFit/>`) —
+// cross-axis auto-grow/shrink for a VERTICAL text box (issue #1000, final
+// remainder of #988).
+//
+// Word ground truth (the autofit adjudication fixture, measured from the Word
+// PDF at 300 dpi):
+//   • OVERFLOW  eaVert spAutoFit box, authored 0.70in wide → rendered 2.070in
+//     (GREW +1.37in) with the authored LEFT edge fixed (grew RIGHTWARD).
+//   • UNDERFLOW eaVert spAutoFit box, authored 2.40in wide → rendered 0.953in
+//     (SHRANK −1.45in) with the authored LEFT edge fixed (shrank from the RIGHT).
+//   • CONTROL   identical content, `noAutofit` → stayed at authored 0.70in and
+//     CLIPPED the overflow.
+// So a vertical spAutoFit box resizes its CROSS axis (physical WIDTH = the
+// column-stacking axis after the ±90° rotate-layout) to the content column
+// stack, keeping the authored TOP-LEFT anchor (`off.x` = LEFT edge) fixed and
+// moving the far (RIGHT) edge — grow on overflow, shrink on underflow. This is
+// the same top-left bbox anchor the horizontal branch keeps (it fixes the TOP
+// edge and moves the BOTTOM).
+
+/** Minimal measuring 2D context: measureShapeTextAutoFitHeight only reads
+ *  font/measureText/save/restore (it never paints). Each code point advances by
+ *  the current font px; symmetric-ish font box (0.8 / 0.2 em). */
+function makeMeasureCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const stack: string[] = [];
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    direction: 'ltr',
+    fontKerning: 'auto',
+    save() { stack.push(font); },
+    restore() { const s = stack.pop(); if (s !== undefined) font = s; },
+    measureText(s: string) {
+      const p = px();
+      return {
+        width: [...s].length * p,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+  };
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+const run = (text: string): ShapeTextRun => ({ text, fontSizePt: 10, fontFamily: 'NotInMetrics' });
+
+/** A single-paragraph text box. Insets 0 keep the arithmetic clean: the vertical
+ *  wrap width (column length) equals the physical HEIGHT and the returned cross
+ *  extent equals the physical WIDTH. */
+function verticalTextbox(
+  text: string,
+  textVert: string | null,
+  autofit: string | null,
+): ShapeRun {
+  const block: ShapeText = { text, fontSizePt: 10, alignment: 'left', runs: [run(text)] };
+  return {
+    type: 'shape', zOrder: 0, subpaths: [], presetGeometry: 'rect', fill: null, stroke: null,
+    textBlocks: [block], textAnchor: 't',
+    textInsetL: 0, textInsetT: 0, textInsetR: 0, textInsetB: 0,
+    textVert,
+    textAutofit: autofit,
+  } as unknown as ShapeRun;
+}
+
+const CJK = '経';
+
+describe('§20.1.10.83 + §21.1.2.1.1 — vertical spAutoFit cross-axis grow/shrink (#1000)', () => {
+  it('GROW: an overflowing eaVert spAutoFit box widens, LEFT edge fixed, RIGHT edge moves', () => {
+    const ctx = makeMeasureCtx();
+    // Box physical 30w × 100h, insets 0 → logical column length 100 → 10 CJK per
+    // column. 60 CJK ⇒ ~6 columns ⇒ required cross width ≫ authored 30.
+    const shape = verticalTextbox(CJK.repeat(60), 'eaVert', 'sp');
+    const box = { x: 100, y: 50, w: 30, h: 100 };
+    const fit = resolveShapeAutofitBox(shape, box, ctx, 1, {});
+    expect(fit.w, `grew past authored 30 (fit.w=${fit.w})`).toBeGreaterThan(45);
+    expect(fit.x, 'authored LEFT edge fixed').toBe(100);
+    expect(fit.y, 'top unchanged').toBe(50);
+    expect(fit.h, 'flow axis (column length = physical height) unchanged').toBe(100);
+    // Right edge moved outward; left edge did not.
+    expect(fit.x + fit.w, 'RIGHT edge moved right').toBeGreaterThan(box.x + box.w);
+  });
+
+  it('SHRINK: an underflowing eaVert spAutoFit box narrows, LEFT edge fixed, RIGHT edge moves in', () => {
+    const ctx = makeMeasureCtx();
+    // Box physical 200w × 100h. 5 CJK ⇒ 1 column ⇒ required cross width ≪ 200.
+    const shape = verticalTextbox(CJK.repeat(5), 'eaVert', 'sp');
+    const box = { x: 100, y: 50, w: 200, h: 100 };
+    const fit = resolveShapeAutofitBox(shape, box, ctx, 1, {});
+    expect(fit.w, `shrank below authored 200 (fit.w=${fit.w})`).toBeLessThan(40);
+    expect(fit.w, 'still positive').toBeGreaterThan(0);
+    expect(fit.x, 'authored LEFT edge fixed').toBe(100);
+    expect(fit.h, 'flow axis unchanged').toBe(100);
+    expect(fit.x + fit.w, 'RIGHT edge moved inward').toBeLessThan(box.x + box.w);
+  });
+
+  it('noAutofit vertical box keeps its authored extent (clips instead of growing)', () => {
+    const ctx = makeMeasureCtx();
+    const shape = verticalTextbox(CJK.repeat(60), 'eaVert', 'none');
+    const box = { x: 100, y: 50, w: 30, h: 100 };
+    const fit = resolveShapeAutofitBox(shape, box, ctx, 1, {});
+    expect(fit).toEqual(box);
+  });
+
+  it('all four vert modes grow the cross (width) axis, never the flow (height) axis', () => {
+    const ctx = makeMeasureCtx();
+    for (const mode of ['vert', 'vert270', 'eaVert', 'mongolianVert']) {
+      const shape = verticalTextbox(CJK.repeat(60), mode, 'sp');
+      const box = { x: 0, y: 0, w: 30, h: 100 };
+      const fit = resolveShapeAutofitBox(shape, box, ctx, 1, {});
+      expect(fit.w, `${mode} grew width`).toBeGreaterThan(45);
+      expect(fit.h, `${mode} kept height`).toBe(100);
+    }
+  });
+
+  it('HORIZONTAL spAutoFit still grows the HEIGHT (flow axis), width untouched — regression', () => {
+    const ctx = makeMeasureCtx();
+    // Horizontal (vert absent): 60 CJK wraps within width 200 → several lines →
+    // height grows well past 20; width stays 200.
+    const shape = verticalTextbox(CJK.repeat(60), null, 'sp');
+    const box = { x: 100, y: 50, w: 200, h: 20 };
+    const fit = resolveShapeAutofitBox(shape, box, ctx, 1, {});
+    expect(fit.w, 'width unchanged for a horizontal box').toBe(200);
+    expect(fit.h, 'height grew to the line stack').toBeGreaterThan(20);
+    expect(fit.x, 'x unchanged').toBe(100);
+    expect(fit.y, 'top edge fixed').toBe(50);
+  });
+
+  it('a vertical box carrying an inline image keeps its authored extent (image cross extent not line-measurable)', () => {
+    const ctx = makeMeasureCtx();
+    const imgBlock: ShapeText = {
+      text: '', fontSizePt: 10, alignment: 'left',
+      imagePath: 'word/media/image1.png', imageWidthPt: 24, imageHeightPt: 36,
+    } as unknown as ShapeText;
+    const shape = verticalTextbox(CJK.repeat(60), 'eaVert', 'sp');
+    (shape as unknown as { textBlocks: ShapeText[] }).textBlocks.push(imgBlock);
+    const box = { x: 10, y: 10, w: 30, h: 100 };
+    const fit = resolveShapeAutofitBox(shape, box, ctx, 1, {});
+    expect(fit).toEqual(box);
+  });
+
+  it('inset-axis mapping: tIns/bIns add to the CROSS (width) extent (not the column length)', () => {
+    // measureShapeTextAutoFitHeight returns `tIns + contentH + bIns` and is called
+    // with the wrap width = physical HEIGHT, so tIns/bIns land on the physical
+    // WIDTH (cross) axis. Two boxes with identical content + identical h differ
+    // only by tIns/bIns ⇒ the grown widths differ by exactly 2·tb.
+    const ctx = makeMeasureCtx();
+    const mk = (tb: number): ShapeRun => {
+      const block: ShapeText = { text: CJK.repeat(30), fontSizePt: 10, alignment: 'left', runs: [run(CJK.repeat(30))] };
+      return {
+        type: 'shape', zOrder: 0, subpaths: [], presetGeometry: 'rect', fill: null, stroke: null,
+        textBlocks: [block], textAnchor: 't',
+        textInsetL: 0, textInsetT: tb, textInsetR: 0, textInsetB: tb,
+        textVert: 'eaVert', textAutofit: 'sp',
+      } as unknown as ShapeRun;
+    };
+    const box = { x: 0, y: 0, w: 30, h: 100 };
+    const w0 = resolveShapeAutofitBox(mk(0), box, ctx, 1, {}).w;
+    const w7 = resolveShapeAutofitBox(mk(7), box, ctx, 1, {}).w;
+    expect(w7 - w0, 'tIns+bIns=2·7 added to the cross width').toBeCloseTo(14, 5);
+  });
+
+  it('inset-axis mapping: lIns/rIns govern the COLUMN LENGTH (wrap) axis — more inset ⇒ shorter columns ⇒ wider box', () => {
+    // lIns/rIns reduce the wrap width (= physical HEIGHT = column length), so a
+    // larger lIns/rIns fits fewer chars per column ⇒ more columns ⇒ a WIDER cross
+    // extent. This distinguishes the wrap axis from the cross axis.
+    const ctx = makeMeasureCtx();
+    const mk = (lr: number): ShapeRun => {
+      const block: ShapeText = { text: CJK.repeat(20), fontSizePt: 10, alignment: 'left', runs: [run(CJK.repeat(20))] };
+      return {
+        type: 'shape', zOrder: 0, subpaths: [], presetGeometry: 'rect', fill: null, stroke: null,
+        textBlocks: [block], textAnchor: 't',
+        textInsetL: lr, textInsetT: 0, textInsetR: lr, textInsetB: 0,
+        textVert: 'eaVert', textAutofit: 'sp',
+      } as unknown as ShapeRun;
+    };
+    const box = { x: 0, y: 0, w: 30, h: 100 };
+    const wNarrowInset = resolveShapeAutofitBox(mk(0), box, ctx, 1, {}).w;
+    const wWideInset = resolveShapeAutofitBox(mk(25), box, ctx, 1, {}).w;
+    expect(wWideInset, 'shorter columns from bigger lIns/rIns pack into more columns ⇒ wider')
+      .toBeGreaterThan(wNarrowInset);
+  });
+
+  it('a shape without spAutoFit or without text blocks is returned unchanged', () => {
+    const ctx = makeMeasureCtx();
+    const noText = { type: 'shape', zOrder: 0, subpaths: [], presetGeometry: 'rect', fill: null, stroke: null, textVert: 'eaVert', textAutofit: 'sp' } as unknown as ShapeRun;
+    const box = { x: 1, y: 2, w: 3, h: 4 };
+    expect(resolveShapeAutofitBox(noText, box, ctx, 1, {})).toEqual(box);
+    const notSp = verticalTextbox(CJK.repeat(60), 'eaVert', null);
+    expect(resolveShapeAutofitBox(notSp, { ...box }, ctx, 1, {})).toEqual(box);
+  });
+});


### PR DESCRIPTION
## Summary

Final remainder of #988 / #1000: **cross-axis auto-grow/shrink for a vertical
`<a:spAutoFit/>` text box** in the DOCX renderer.

A vertical (`eaVert`/`vert`/`vert270`/`mongolianVert`) text box with
`<a:spAutoFit/>` now resizes its physical **WIDTH** — the column-stacking cross
axis after the ±90° rotate-layout — to fit its content, keeping the authored
**LEFT** edge (`off.x`, the `positionH` posOffset anchor) fixed and moving the
right edge: **grow** on overflow, **shrink** on underflow. The column length
(= physical height) stays the fixed wrap dimension (established in #988B).

This is the same top-left bbox anchor the horizontal branch already keeps (it
fixes the top edge and grows/shrinks the bottom). Previously vertical spAutoFit
boxes kept their declared extent and clipped/left slack; that was a documented
verify-only follow-up pending a disambiguating fixture.

## Word adjudication

Ground truth measured from the autofit adjudication fixture (one lrTb US-Letter
page, three page-anchored `eaVert` boxes sharing authored left edge X = 3.4in),
Word PDF rasterised at 300 dpi and each colored frame measured per-hue:

| box | autofit | authored [L,R] / W (in) | Word frame [L,R] / W (in) | Δwidth | anchor |
|---|---|---|---|---|---|
| OVERFLOW | `spAutoFit`, 53 CJK | [3.40, 4.10] / 0.70 | [3.407, 5.473] / 2.070 | **+1.37** | LEFT fixed, grew RIGHT |
| CONTROL | `noAutofit`, same 53 CJK | [3.40, 4.10] / 0.70 | [3.393, 4.103] / 0.713 | ~0 | authored kept, clips |
| UNDERFLOW | `spAutoFit`, 15 CJK | [3.40, 5.80] / 2.40 | [3.407, 4.357] / 0.953 | **−1.45** | LEFT fixed, shrank from RIGHT |

Grow and shrink both keep the authored LEFT edge fixed; `noAutofit` keeps the
authored width and clips the overflowing (leftward) columns at the frame.
Full measurements posted on #1000.

## Implementation

- Extract the autofit decision into `resolveShapeAutofitBox` (renderer.ts). The
  horizontal path is unchanged (height grows to the line stack, top edge fixed).
- Vertical branch measures the cross extent by reusing
  `measureShapeTextAutoFitHeight` with the wrap width = physical **height** (the
  swapped column-length axis); its returned "height" is then the physical
  **width** the columns require, insets included — measured by the same line
  engine the vertical draw uses, so the resized box exactly contains the drawn
  columns (no clip, no slack).
- A vertical box carrying an inline image keeps its authored extent (an upright
  image's cross extent is not line-measurable), preserving the pre-#1000
  behaviour for that case.

## Verification

- New unit tests (`textbox-vertical-autofit.test.ts`, 9 cases) pin grow/shrink,
  the LEFT-edge anchor, the flow-axis (height) staying fixed, all four `vert`
  modes, the `noAutofit`/non-`sp`/no-blocks/image passthroughs, and the
  inset-axis mapping (lIns/rIns → column length, tIns/bIns → cross width).
- Full docx vitest: **1361 passed**. Root `pnpm typecheck`: clean.
- docx demo VRT (`demo/sample-1`): **6/6 pass**, no regression (my change is a
  no-op for non-vertical-spAutoFit content).
- End-to-end: rendering the fixture through this renderer reproduces the
  adjudicated behaviour — LEFT edge fixed at 3.407in on all three boxes, orange
  grows right, green shrinks from the right, blue (`noAutofit`) keeps authored
  width and clips. The absolute grown width is smaller than Word's only because
  Yu Mincho is not installed in headless Chrome (font substitution gives a
  tighter column pitch); the box faithfully fits whatever columns the renderer
  draws.
- Independent Codex review (gpt-5.6-sol, read-only): approved, no correctness
  defect.

Closes #1000.
