### PR TITLE
chore(pptx): ignore the private fixture directory like docx/xlsx

### DIFF
--- a/packages/pptx/.gitignore
+++ b/packages/pptx/.gitignore
@@ -1,0 +1,5 @@
+# Local-only sample fixtures and adjudication documents (never committed)
+public/private/
+tests/visual/references/private/
+# Local-only Storybook stories that load sample PPTX files
+src/*.privateDemo.stories.ts


### PR DESCRIPTION
The pptx package had no package-level \`.gitignore\` — only binary sample extensions were ignored via root rules, so adjudication manifests/generator scripts under \`public/private/\` were untracked-but-not-ignored (a broad \`git add\` could sweep them in). docx and xlsx already ignore the whole directory; this adds the same three private-protection rules to pptx. Already-tracked files under the directory remain tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)