### PR TITLE
fix(docx): rotate ALL glyphs with the page in a btLr section (§17.6.20)

### DIFF
--- a/packages/docx/src/btlr-rotated-glyphs.test.ts
+++ b/packages/docx/src/btlr-rotated-glyphs.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement, DocParagraph, DocxTextRun, SectionProps, DocxDocumentModel,
+} from './types';
+
+// ECMA-376 §17.6.20 + Part 4 §14.11.7 — section-level `btLr` glyph treatment
+// (issue #988 re-adjudication, correcting adjudication ①). Word GT (raster-
+// proven on asymmetric glyphs — the dakuten of 「び」 lands bottom-right):
+// a `btLr` section is the horizontal layout rotated +90° CW WHOLESALE. It
+// shares the `tbRl` page frame (quarter-turned logical geometry, +90° page
+// paint, columns right→left, advance top→bottom) but — unlike `tbRl` — CJK
+// glyphs are NOT counter-rotated upright, vertical punctuation forms are NOT
+// substituted, and 縦中横 (§17.3.2.10) is NOT grouped: every glyph rotates
+// with the page. These tests pin the glyph mode split with a recording canvas:
+//   - tbRl page: the +π/2 page rotation PLUS per-glyph −π/2 counter-rotations.
+//   - btLr page: ONLY the +π/2 page rotation — runs draw as ordinary whole-run
+//     `fillText` calls (the horizontal draw path inside the rotated frame).
+
+// Deterministic stub canvas that records rotate() and fillText() calls.
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  rotations: number[];
+  fills: string[];
+} {
+  let font = '10px serif';
+  const rotations: number[] = [];
+  const fills: string[] = [];
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    rotate(r: number) { rotations.push(r); },
+    setTransform() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(t: string) { fills.push(t); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, rotations, fills };
+}
+
+// `renderDocumentToCanvas` paginates via `new OffscreenCanvas(...)` when no
+// prebuilt pages are passed — polyfill with the same deterministic stub.
+(globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+  getContext() {
+    return makeRecordingCanvas().canvas.getContext('2d');
+  }
+};
+
+type DocRun = DocParagraph['runs'][number];
+function textRun(text: string, extra: Partial<DocxTextRun> = {}): DocRun {
+  const run: DocxTextRun = {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 20, color: null, fontFamily: 'NotInMetrics', isLink: false, background: null,
+    vertAlign: null, hyperlink: null, ...extra,
+  } as unknown as DocxTextRun;
+  return { type: 'text', ...run } as DocRun;
+}
+function paraOf(runs: DocRun[]): BodyElement {
+  const p: DocParagraph = {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs, defaultFontSize: 20, defaultFontFamily: 'NotInMetrics', widowControl: false,
+  } as unknown as DocParagraph;
+  return { type: 'paragraph', ...p } as BodyElement;
+}
+
+const EMPTY_HF = { default: null, first: null, even: null };
+
+function verticalDoc(textDirection: 'btLr' | 'tbRl', runs: DocRun[]): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 612, pageHeight: 792,
+    marginTop: 72, marginRight: 72, marginBottom: 72, marginLeft: 72,
+    headerDistance: 36, footerDistance: 36, titlePage: false, evenAndOddHeaders: false,
+    textDirection,
+  } as SectionProps;
+  return {
+    section, body: [paraOf(runs)],
+    headers: EMPTY_HF, footers: EMPTY_HF, fontFamilyClasses: {},
+  } as unknown as DocxDocumentModel;
+}
+
+const PAGE_ROT = Math.PI / 2;
+const GLYPH_ROT = -Math.PI / 2;
+const near = (a: number, b: number) => Math.abs(a - b) < 1e-9;
+
+describe('section btLr glyph mode (§17.6.20 + #988 re-adjudication) — all glyphs rotate with the page', () => {
+  it('tbRl control: CJK glyphs are counter-rotated upright (−π/2 per glyph)', async () => {
+    const { canvas, rotations } = makeRecordingCanvas();
+    await renderDocumentToCanvas(verticalDoc('tbRl', [textRun('縦横テスト')]), canvas, 0, { dpr: 1 });
+    // One +π/2 page rotation…
+    expect(rotations.filter((r) => near(r, PAGE_ROT)).length).toBe(1);
+    // …and one −π/2 counter-rotation per upright CJK glyph (5 here).
+    expect(rotations.filter((r) => near(r, GLYPH_ROT)).length).toBe(5);
+  });
+
+  it('btLr: the page rotates +π/2 ONCE and NO glyph is counter-rotated', async () => {
+    const { canvas, rotations, fills } = makeRecordingCanvas();
+    await renderDocumentToCanvas(verticalDoc('btLr', [textRun('縦横テスト')]), canvas, 0, { dpr: 1 });
+    // The page frame is still the rotated vertical one (frame unchanged from
+    // tbRl — #988 ruling ①'s geometry findings stand)…
+    expect(rotations.filter((r) => near(r, PAGE_ROT)).length).toBe(1);
+    // …but the glyphs ride the page rotation: no upright counter-rotation.
+    expect(rotations.filter((r) => near(r, GLYPH_ROT)).length).toBe(0);
+    // The run is drawn as ONE contextual whole-run fillText (the horizontal
+    // draw path), not per-glyph pieces — the raster equals the horizontal
+    // rendering rotated +90°.
+    expect(fills).toContain('縦横テスト');
+  });
+
+  it('btLr: 縦中横 (§17.3.2.10 eastAsianVert) is NOT grouped — the run stays on the horizontal path', async () => {
+    const runs = [textRun('令和'), textRun('２９', { eastAsianVert: true } as Partial<DocxTextRun>)];
+    const { canvas, rotations, fills } = makeRecordingCanvas();
+    await renderDocumentToCanvas(verticalDoc('btLr', runs), canvas, 0, { dpr: 1 });
+    // No counter-rotation at all — neither upright CJK cells nor a 縦中横 cell
+    // (drawTateChuYokoRun would record a −π/2 too).
+    expect(rotations.filter((r) => near(r, GLYPH_ROT)).length).toBe(0);
+    expect(fills).toContain('令和');
+    expect(fills).toContain('２９');
+
+    // tbRl control: the same runs DO counter-rotate (upright cells + 縦中横).
+    const { canvas: c2, rotations: r2 } = makeRecordingCanvas();
+    await renderDocumentToCanvas(verticalDoc('tbRl', runs), c2, 0, { dpr: 1 });
+    expect(r2.filter((r) => near(r, GLYPH_ROT)).length).toBeGreaterThan(0);
+  });
+
+  it('btLr: the numbering marker also rides the page rotation (no upright draw)', async () => {
+    const p: DocParagraph = {
+      alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+      spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+      numbering: { numId: 1, level: 0, format: 'japaneseCounting', text: '一、', indentLeft: 40, tab: 40, suff: 'tab' },
+      tabStops: [],
+      runs: [textRun('項目')], defaultFontSize: 20, defaultFontFamily: 'NotInMetrics', widowControl: false,
+    } as unknown as DocParagraph;
+    const doc = {
+      ...verticalDoc('btLr', [textRun('x')]),
+      body: [{ type: 'paragraph', ...p } as BodyElement],
+    } as DocxDocumentModel;
+    const { canvas, rotations, fills } = makeRecordingCanvas();
+    await renderDocumentToCanvas(doc, canvas, 0, { dpr: 1 });
+    // The marker WAS painted (whole-string fillText — non-vacuity guard)…
+    expect(fills).toContain('一、');
+    // …and rode the page rotation: no upright counter-rotation anywhere.
+    expect(rotations.filter((r) => near(r, GLYPH_ROT)).length).toBe(0);
+  });
+});

--- a/packages/docx/src/per-section-text-direction.test.ts
+++ b/packages/docx/src/per-section-text-direction.test.ts
@@ -12,7 +12,9 @@ import type {
 } from './types';
 
 // ECMA-376 §17.6.20 — text direction is PER-SECTION (issue #1000, #988 batch-3
-// adjudication ①): a vertical (tbRl ≡ btLr per Word GT) NON-FINAL section can
+// adjudication ①): a vertical (tbRl, or btLr which shares the tbRl page FRAME
+// per the #988 re-adjudication — its GLYPHS all ride the page rotation, see
+// btlr-rotated-glyphs.test.ts) NON-FINAL section can
 // coexist with a horizontal FINAL section in one document. The parser carries
 // the ending section's `<w:textDirection>` on its SectionBreak marker; the
 // paginator lays a vertical section out in its SWAPPED LOGICAL geometry

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -490,15 +490,33 @@ export interface RenderState {
    *  default) or to the continued value for continuous/newSection. Incremented
    *  once per body line drawn (or measured in a dry-run counting pass). */
   lineNumberCounter?: number;
-  /** ECMA-376 §17.6.20 vertical writing (tbRl). When true the page is laid out
-   *  in a SWAPPED logical coordinate space (logical width = physical page height)
-   *  and the whole page paint is rotated +90° into physical space by
-   *  {@link renderDocumentToCanvas}; the glyph-draw path then counter-rotates each
-   *  upright (CJK) glyph −90° about its own centre so ideographs stand upright
-   *  while Latin/digits stay sideways (correct for vertical Japanese). Absent /
-   *  false ⇒ horizontal (lrTb) — the whole layout + paint path is byte-identical
-   *  to the pre-vertical renderer. */
+  /** ECMA-376 §17.6.20 vertical writing — the FRAME-level vertical flag. When
+   *  true the page is laid out in a SWAPPED logical coordinate space (logical
+   *  width = physical page height) and the whole page paint is rotated +90°
+   *  into physical space by {@link renderDocumentToCanvas}. On a tbRl-family
+   *  page (no {@link verticalAllRotated}) the glyph-draw path then counter-
+   *  rotates each upright (CJK) glyph −90° about its own centre so ideographs
+   *  stand upright while Latin/digits stay sideways (correct for vertical
+   *  Japanese); a `btLr` page sets {@link verticalAllRotated} too, which
+   *  SUPPRESSES that counter-rotation (all glyphs ride the page rotation).
+   *  Absent / false ⇒ horizontal (lrTb) — the whole layout + paint path is
+   *  byte-identical to the pre-vertical renderer. */
   verticalCJK?: boolean;
+  /** ECMA-376 §17.6.20 + Part 4 §14.11.7 — set (always together with
+   *  {@link verticalCJK}) on a section-level `btLr` page. Word GT (issue #988
+   *  re-adjudication, raster-proven on asymmetric glyphs — the dakuten of 「び」
+   *  lands bottom-right): `btLr` shares the `tbRl` PAGE FRAME (swapped logical
+   *  layout, +90° page paint, columns right→left) but rotates EVERY glyph with
+   *  the page — CJK is NOT counter-rotated upright, vertical punctuation forms
+   *  (、。（） → U+FE1x/FE3x) are NOT substituted, and 縦中横 (§17.3.2.10) is
+   *  NOT grouped. When set, the glyph-draw sites take the ordinary HORIZONTAL
+   *  branches inside the rotated frame, so the page raster equals the
+   *  horizontal rendering of the swapped frame rotated +90° CW wholesale.
+   *  Frame-level consumers (page rotation, text-layer transform, `verticalPhys`
+   *  anchors, upright images/tables — GT-less for btLr, kept at tbRl parity)
+   *  keep reading {@link verticalCJK}. Absent ⇒ upright-vertical (tbRl family)
+   *  or horizontal. */
+  verticalAllRotated?: boolean;
   /** ECMA-376 §17.6.20 + §20.4.3.x — the PHYSICAL page geometry for a vertical
    *  (tbRl) page, in the SAME units the rest of RenderState uses (margins/page
    *  size in pt; `cssWidthPx` in px). Present only when `verticalCJK` is set.
@@ -1091,13 +1109,20 @@ const renderTokens = new WeakMap<HTMLCanvasElement | OffscreenCanvas, number>();
  *
  *    - `btLr`  (≡ Strict `lr`)  — its NOMINAL semantics are bottom-to-top /
  *                                 left-to-right, but Word ground truth (issue #988
- *                                 batch-3 adjudication ①) shows Word renders a
- *                                 SECTION-level `btLr` IDENTICALLY to `tbRl`:
- *                                 CJK upright stacked top→bottom, Latin/digits
- *                                 rotated 90° CW (sideways), columns right→left —
- *                                 it does NOT honor the literal bottom-to-top /
- *                                 left-to-right flow. So it routes through the
- *                                 same +90° vertical path as `tbRl`. (The per-
+ *                                 re-adjudication, correcting the batch-3
+ *                                 adjudication ① with raster proof on asymmetric
+ *                                 glyphs) shows Word renders a SECTION-level
+ *                                 `btLr` as the HORIZONTAL layout rotated +90° CW
+ *                                 WHOLESALE: same page frame as `tbRl` (columns
+ *                                 right→left, advance top→bottom — neither axis
+ *                                 honors the nominal bottom-to-top/left-to-right),
+ *                                 but EVERY glyph rides the page rotation — CJK is
+ *                                 NOT counter-rotated upright (the dakuten of 「び」
+ *                                 lands bottom-right) and vertical punctuation
+ *                                 forms are NOT substituted. So `btLr` routes
+ *                                 through the same +90° FRAME as `tbRl` while
+ *                                 `RenderState.verticalAllRotated` switches the
+ *                                 glyph draw to the horizontal branches. (The per-
  *                                 SECTION mixing that fixture also exercises —
  *                                 a `btLr` non-final section beside a horizontal
  *                                 final section — is surfaced per-section: the
@@ -1119,6 +1144,16 @@ function isVerticalSection(s: SectionProps): boolean {
  *  full SectionProps (issue #1000). `null`/`undefined`/unknown ⇒ horizontal. */
 function isVerticalTextDirection(td: string | null | undefined): boolean {
   return td === 'tbRl' || td === 'tbRlV' || td === 'tbLrV' || td === 'btLr';
+}
+
+/** True for a VERTICAL direction whose glyphs ALL ride the +90° page rotation
+ *  (no CJK upright counter-rotation, no vertical punctuation forms, no 縦中横):
+ *  section-level `btLr` per the issue #988 re-adjudication (Word GT, raster-
+ *  proven — see {@link RenderState.verticalAllRotated}). The tbRl family keeps
+ *  the upright-CJK glyph path. Only meaningful when
+ *  {@link isVerticalTextDirection} is already true. */
+function isAllRotatedVerticalTextDirection(td: string | null | undefined): boolean {
+  return td === 'btLr';
 }
 
 /** Map a vertical (tbRl) section's PHYSICAL page geometry to the SWAPPED LOGICAL
@@ -1241,8 +1276,8 @@ interface PageFrameMeta {
 const pageFrameMeta = new WeakMap<object, PageFrameMeta>();
 
 /** A section resolved to the LOGICAL frame the paginator lays it out in (issue
- *  #1000 per-section text direction): a vertical (tbRl ≡ btLr, §17.6.20 + the
- *  #988 batch-3 adjudication ①) section's `geom` is its PHYSICAL page geometry
+ *  #1000 per-section text direction): a vertical (tbRl, or btLr which shares the
+ *  tbRl FRAME per the #988 re-adjudication) section's `geom` is its PHYSICAL page geometry
  *  quarter-turned by {@link logicalGeomOf}; a horizontal section's `geom` is
  *  physical verbatim. `textDirection` is the owning section's raw token
  *  (`null` ⇒ horizontal) and `vertical` its {@link isVerticalTextDirection}
@@ -1521,8 +1556,10 @@ async function renderDocumentToCanvasLeased(
   // (`translate(cssWidth, 0)` then `rotate(+90°)`): logical +x (character flow)
   // → physical +y (down the column), logical +y (line stacking) → physical −x
   // (columns advance right→left). The white background above stays in physical
-  // space (drawn before the rotate). Glyphs are counter-rotated per-glyph in the
-  // draw path (`state.verticalCJK`) so CJK ideographs stand upright.
+  // space (drawn before the rotate). On a tbRl-family page, glyphs are counter-
+  // rotated per-glyph in the draw path (`state.verticalCJK`) so CJK ideographs
+  // stand upright; on a btLr page (`state.verticalAllRotated`) NO glyph is
+  // counter-rotated — everything rides this page rotation (#988 re-adjudication).
   if (vertical) {
     ctx.translate(cssWidth, 0);
     ctx.rotate(Math.PI / 2);
@@ -1602,10 +1639,15 @@ async function renderDocumentToCanvasLeased(
     // §17.16.4.1 — the instant DATE/TIME fields format against (default real time).
     currentDateMs: resolveCurrentDateMs(opts.currentDate),
     noteNumbers,
-    // ECMA-376 §17.6.20 — when set, the glyph-draw path counter-rotates upright
-    // (CJK) glyphs so they stand up inside the +90°-rotated page (see the page
-    // transform above and `drawVerticalRun`).
+    // ECMA-376 §17.6.20 — the frame-level vertical flag. On a tbRl-family page
+    // the glyph-draw path counter-rotates upright (CJK) glyphs so they stand up
+    // inside the +90°-rotated page (see the page transform above and
+    // `drawVerticalRun`); `verticalAllRotated` below suppresses that for btLr.
     verticalCJK: vertical,
+    // §17.6.20 btLr (#988 re-adjudication): every glyph rides the +90° page
+    // rotation — the glyph-draw sites take the HORIZONTAL branches instead of
+    // the upright-CJK vertical ones (see RenderState.verticalAllRotated).
+    verticalAllRotated: vertical && isAllRotatedVerticalTextDirection(pageTd),
     // ECMA-376 §20.4.3.x — physical page geometry for resolving DrawingML anchors
     // against the un-rotated physical page (see `verticalPhys` docs and
     // `resolveAnchorBox`). `sec` here is the LOGICAL (swapped) section, so un-swap
@@ -1673,6 +1715,7 @@ async function renderDocumentToCanvasLeased(
         docGrid: toLegacyDocGridContext(physSectionLayout),
         sectionLayout: physSectionLayout,
         verticalCJK: false,
+        verticalAllRotated: false,
         verticalPhys: undefined,
       };
       ctx.save();
@@ -4480,6 +4523,7 @@ function paragraphMeasurementEnvironment(
     | 'noteNumbers'
     | 'currentNoteNumber'
     | 'verticalCJK'
+    | 'verticalAllRotated'
     | 'docEastAsian'
   >,
 ): ParagraphMeasurementEnvironment {
@@ -4491,9 +4535,25 @@ function paragraphMeasurementEnvironment(
     currentDateMs: state.currentDateMs,
     noteNumbers: state.noteNumbers,
     currentNoteNumber: state.currentNoteNumber,
-    verticalCJK: state.verticalCJK,
+    // §17.6.20 btLr (#988 re-adjudication): an all-rotated page lays its lines
+    // out with the HORIZONTAL semantics (no 縦中横 grouping — the whole layout
+    // rotates wholesale), so the environment's vertical flag is the effective
+    // "upright vertical" one. tbRl (no verticalAllRotated) is unchanged.
+    verticalCJK: state.verticalCJK && !state.verticalAllRotated,
     documentHasEastAsianText: state.docEastAsian,
   };
+}
+
+/** The `LineLayoutEnvironment` for building a paragraph's segments straight
+ *  from a paint state. Identity (the state itself — byte-identical) for
+ *  horizontal and upright-vertical (tbRl family) states; an all-rotated
+ *  (§17.6.20 btLr, #988 re-adjudication) page builds its segments with
+ *  `verticalCJK` CLEARED so no 縦中横 grouping (§17.3.2.10) engages — the btLr
+ *  page is the horizontal layout rotated wholesale, so its segments are the
+ *  horizontal ones (measure == paint: the paginator's measure state never sets
+ *  `verticalCJK` either). */
+function segmentEnvironmentOf(state: RenderState): RenderState {
+  return state.verticalAllRotated ? { ...state, verticalCJK: false } : state;
 }
 
 // ===== Body layout fragments (PR 5) =====
@@ -7517,7 +7577,7 @@ function resolveFrameBox(
   const grid = paraGrid(para, state);
   const paragraphContext = resolveBodyParagraphLayoutContext(state, para);
   const paraHasRuby = paragraphContext.hasRuby;
-  const segments = buildSegments(para.runs, state);
+  const segments = buildSegments(para.runs, segmentEnvironmentOf(state));
 
   // Measure the frame's natural content size at a wide width (single-line frame
   // content stays one line). No floats apply INSIDE the frame; the cap glyph's
@@ -7834,7 +7894,7 @@ function renderParagraph(
     && (!baseRtl || ((para.numbering?.suff || 'tab') === 'tab' && indFirst < 0));
 
   // Collect all text segments with formatting (resolving field runs against page context)
-  const segments = buildSegments(para.runs, state);
+  const segments = buildSegments(para.runs, segmentEnvironmentOf(state));
   // Word renders ruby paragraphs with consistent line spacing — every line
   // in a paragraph that carries ANY furigana snaps to the same pitch
   // multiple. Compute once at paragraph scope and share with the line loop.
@@ -8344,6 +8404,13 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     decimalAutoTabPx, drawGridDeltaPx, lineHForLine,
   } = c;
     const line = lines[li];
+    // ECMA-376 §17.6.20 + Part 4 §14.11.7 (#988 re-adjudication): only an
+    // UPRIGHT-vertical page (tbRl family) takes the per-glyph vertical draw
+    // paths below. A `btLr` page (`state.verticalAllRotated`) is the horizontal
+    // layout rotated wholesale — its glyphs draw through the ordinary
+    // HORIZONTAL branches and ride the +90° page rotation, so CJK lies rotated
+    // 90° CW exactly like Word's GT. Horizontal pages: false, byte-identical.
+    const verticalUpright = !!state.verticalCJK && !state.verticalAllRotated;
     // First-line indent and numbering prefix only apply to the paragraph's
     // ORIGINAL first line, not the first line of a continuation slice.
     const firstLine = li === 0 && !continuesParagraph;
@@ -8593,9 +8660,10 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           // (numBodyOffset).
           const markerText = markerDisplayText(para.numbering!);
           const markerX = lineLeft + indFirst + markerJcShiftPx;
-          if (state.verticalCJK) {
+          if (verticalUpright) {
             // §17.6.20 (tbRl) — draw the bullet/number upright inside the rotated
-            // page, same per-glyph counter-rotation as body glyphs.
+            // page, same per-glyph counter-rotation as body glyphs. A btLr page
+            // takes the plain branch: the marker rides the page rotation too.
             drawVerticalRun(ctx, markerText, markerX, baseline, numFontSize, 0);
           } else {
             ctx.fillText(markerText, markerX, baseline);
@@ -8639,8 +8707,10 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
       // ECMA-376 §17.18.44 low/medium/highKashida first elongate valid
       // Arabic joins. Only the residual goes through the ordinary space/CJK
       // distributor; a line with no eligible join falls back to the full-slack
-      // `both` behaviour. Vertical text keeps the established stage-1 path.
-      const kashidaLevel = !state.verticalCJK
+      // `both` behaviour. Upright-vertical (tbRl) text keeps the established
+      // stage-1 path; an all-rotated (btLr) page follows the horizontal rules
+      // like every other horizontal-branch behavior (measure == paint).
+      const kashidaLevel = !verticalUpright
         ? kashidaLevelOf(para.alignment)
         : null;
       const kashidaDist = kashidaLevel
@@ -8981,7 +9051,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
         if (
           visual &&
           visual.rtl[si] === true &&
-          !state.verticalCJK &&
+          !verticalUpright &&
           /\s$/u.test(drawText)
         ) {
           const trimmed = drawText.replace(/\s+$/u, '');
@@ -9000,7 +9070,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             glyphDrawX = x + rtlWsShiftPx;
           }
         }
-        if (state.verticalCJK && s.tateChuYoko) {
+        if (verticalUpright && s.tateChuYoko) {
           // ECMA-376 §17.3.2.10 縦中横 (horizontal-in-vertical): draw the whole run
           // horizontally, side by side, inside ONE cell of the vertical column.
           // The cell's along-column advance is `spanW` (= s.measuredWidth, which
@@ -9017,7 +9087,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             segCharScale,
             !!s.tateChuYokoCompress,
           );
-        } else if (state.verticalCJK) {
+        } else if (verticalUpright) {
           // ECMA-376 §17.6.20 (tbRl) — the run flows DOWN the column (logical
           // +x). Draw each glyph advancing by its measured horizontal width
           // (× the §17.3.2.43 `w:w` scale) plus the combined per-glyph pitch —
@@ -9342,8 +9412,10 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           );
           // Reuse the paint path's single pitch authority so selection and find
           // overlays reproduce §17.3.2.14 fitText or docGrid + §17.3.2.35 spacing.
-          // Vertical / 縦中横 runs retain their existing payload and geometry.
-          const letterSpacingPx = !state.verticalCJK && !s.tateChuYoko
+          // Upright-vertical / 縦中横 runs retain their existing payload and
+          // geometry; an all-rotated (btLr) run drew through the horizontal
+          // branch WITH the pitch, so its overlay reports it like horizontal.
+          const letterSpacingPx = !verticalUpright && !s.tateChuYoko
             ? segLetterSpacingPx(s, drawGridDeltaPx, scale)
             : 0;
           state.onTextRun({
@@ -9365,7 +9437,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             // natural glyph width (#836). Only set on a vertical page, where the
             // 縦中横 draw path (above) actually fires; `undefined` otherwise so a
             // non-縦中横 run's payload is byte-identical.
-            eastAsianVert: state.verticalCJK && s.tateChuYoko ? true : undefined,
+            eastAsianVert: verticalUpright && s.tateChuYoko ? true : undefined,
           });
         }
 
@@ -11545,6 +11617,7 @@ function verticalPhysicalContentState(state: RenderState): RenderState {
     contentX: p.marginLeft * state.scale,
     contentW: (p.pageWidth - p.marginLeft - p.marginRight) * state.scale,
     verticalCJK: false,
+    verticalAllRotated: false,
     verticalPhys: undefined,
     floats: [],
     deferFront: null,

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -47,9 +47,10 @@
 // (PDF-verified centroid); inline/anchored/float image uprighting; and the
 // vertical text-layer transform. Still approximated / deferred (flagged inline):
 // the `0.12em` upright-centring nudge and the Tu upper-right corner nudge are
-// font-dependent stage-1 heuristics; 縦中横 (tate-chū-yoko), `btLr` flow,
-// header/footer + tables in tbRl, and paragraph-relative vertical anchors are
-// follow-ups.
+// font-dependent stage-1 heuristics; paragraph-relative vertical anchors are a
+// follow-up. `btLr` shares the +90° page FRAME but bypasses this module's
+// upright/substitute glyph handling entirely (issue #988 re-adjudication: every
+// glyph rides the page rotation — see RenderState.verticalAllRotated).
 
 import {
   verticalOrientation,

--- a/packages/node/src/docx-btlr-vertical.probe.test.ts
+++ b/packages/node/src/docx-btlr-vertical.probe.test.ts
@@ -1,14 +1,25 @@
 /**
- * Section-level `btLr` renders identically to `tbRl` — ECMA-376 §17.6.20,
- * issue #988 batch-3 adjudication ①.
+ * Section-level `btLr` — the horizontal layout rotated +90° CW wholesale.
+ * ECMA-376 §17.6.20 + Part 4 §14.11.7; issue #988 re-adjudication (correcting
+ * batch-3 adjudication ①).
  *
- * Word ground truth: a section whose `<w:textDirection w:val="btLr"/>` is applied
- * at SECTION level is laid out the same as `tbRl` (CJK upright stacked top→bottom,
- * Latin/digits sideways 90° CW, columns right→left) — Word does NOT honor btLr's
- * nominal bottom-to-top / left-to-right flow. This probe renders the SAME body
- * once as `btLr` and once as `tbRl` and asserts the two produce byte-identical
- * text-run layouts (position + rotation), pinning that `btLr` routes through the
- * vertical path.
+ * Word ground truth (raster-proven on asymmetric glyphs — the dakuten of 「び」
+ * lands bottom-right, readable only after rotating the page 90° CCW): a section
+ * whose `<w:textDirection w:val="btLr"/>` shares the `tbRl` PAGE FRAME (physical
+ * portrait page, quarter-turned logical layout, columns right→left, character
+ * advance top→bottom) but rotates EVERY glyph with the page — CJK is NOT
+ * counter-rotated upright and vertical punctuation forms are NOT substituted
+ * (（） stay the horizontal forms, rotated). Equivalently: the btLr page raster
+ * IS the horizontal rendering of the quarter-turned frame, rotated +90° CW.
+ *
+ * Three probes pin that:
+ *   1. FRAME — btLr text-run layout (position + rotation transform) is
+ *      identical to tbRl (adjudication ①'s geometry findings stand).
+ *   2. GLYPHS — the btLr page raster equals the HORIZONTAL rendering of the
+ *      same content in the quarter-turned (swapped pgSz, rotated pgMar) frame,
+ *      rotated +90° CW as a bitmap (small anti-aliasing tolerance).
+ *   3. TRIPWIRE — the btLr raster differs from the tbRl raster of the same CJK
+ *      body (a regression to "btLr ≡ tbRl upright CJK" trips this).
  *
  * CI-safe: gated on docx WASM + skia-canvas; skips when absent, hard-fails under
  * OOXML_REQUIRE_SKIA=1.
@@ -75,7 +86,10 @@ function storedZip(files: Record<string, string>): Uint8Array {
   return Uint8Array.from([...chunks, ...central, ...end]);
 }
 
-function verticalDocx(dir: 'btLr' | 'tbRl'): Uint8Array {
+const PARAS = ['縦横ABC混在123テスト', '日本語Wordと英語Englishの並び（対照）'];
+
+/** A one-section docx. `sectPr` supplies the raw pgSz/pgMar/textDirection XML. */
+function docxWith(sectPr: string): Uint8Array {
   const contentTypes =
     '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
     '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
@@ -92,13 +106,8 @@ function verticalDocx(dir: 'btLr' | 'tbRl'): Uint8Array {
     `<w:p><w:r><w:rPr><w:sz w:val="28"/></w:rPr><w:t>${t}</w:t></w:r></w:p>`;
   const document =
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document ${NS}><w:body>` +
-    para('縦横ABC混在123テスト') +
-    para('日本語Wordと英語Englishの並び') +
-    '<w:sectPr>' +
-    '<w:pgSz w:w="12240" w:h="15840"/>' +
-    '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/>' +
-    `<w:textDirection w:val="${dir}"/>` +
-    '</w:sectPr></w:body></w:document>';
+    PARAS.map(para).join('') +
+    `<w:sectPr>${sectPr}</w:sectPr></w:body></w:document>`;
   return storedZip({
     '[Content_Types].xml': contentTypes,
     '_rels/.rels': rootRels,
@@ -106,20 +115,39 @@ function verticalDocx(dir: 'btLr' | 'tbRl'): Uint8Array {
   });
 }
 
+// ASYMMETRIC margins so any frame-rotation slip shifts the raster and fails the
+// pixel comparison. Physical (btLr / tbRl) frame: portrait Letter.
+const VERT_SECTPR = (dir: 'btLr' | 'tbRl') =>
+  '<w:pgSz w:w="12240" w:h="15840"/>' +
+  '<w:pgMar w:top="1440" w:right="720" w:bottom="480" w:left="240" w:header="720" w:footer="720" w:gutter="0"/>' +
+  `<w:textDirection w:val="${dir}"/>`;
+
+// The QUARTER-TURNED logical frame rendered as a plain horizontal document:
+// swapped pgSz, margins rotated logical{L,T,R,B} = physical{T,R,B,L}
+// (verticalLayoutSection, §17.6.11). No textDirection.
+const HORIZ_CONTROL_SECTPR =
+  '<w:pgSz w:w="15840" w:h="12240"/>' +
+  '<w:pgMar w:top="720" w:right="480" w:bottom="240" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/>';
+
 interface Run { t: string; x: number; y: number; w: number; h: number; tr: string }
 
-async function renderRuns(dir: 'btLr' | 'tbRl'): Promise<Run[]> {
+async function renderDoc(
+  bytes: Uint8Array,
+): Promise<{ runs: Run[]; pixels: Uint8ClampedArray; w: number; h: number }> {
   const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
   const { renderDocumentToCanvas } = rendererMod as Any;
-  const doc = parseDocx(verticalDocx(dir));
-  const canvas = new Canvas(Math.round(doc.section.pageWidth), Math.round(doc.section.pageHeight));
+  const doc = parseDocx(bytes);
+  // Single-section docs: `doc.section` is the sectPr's verbatim PHYSICAL page
+  // box (the vertical swap happens inside renderDocumentToCanvas).
+  const physWidthPt = doc.section.pageWidth;
+  const canvas = new Canvas(10, 10);
   const runs: Run[] = [];
   const rImg = installImageBitmapShim(factory);
   const rOff = installOffscreenCanvasShim(factory);
   try {
     await renderDocumentToCanvas(doc, canvas, 0, {
       dpr: 1,
-      width: doc.section.pageWidth,
+      width: physWidthPt,
       onTextRun: (r: Any) =>
         runs.push({
           t: r.text,
@@ -134,20 +162,70 @@ async function renderRuns(dir: 'btLr' | 'tbRl'): Promise<Run[]> {
     rOff();
     rImg();
   }
-  return runs;
+  const ctx = (canvas as Any).getContext('2d');
+  const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  return { runs, pixels: img.data, w: canvas.width, h: canvas.height };
 }
 
-describe.skipIf(!skia || !docxMod || !rendererMod)('docx section btLr ≡ tbRl (§17.6.20)', () => {
-  it('renders a btLr section identically to tbRl (vertical, same run layout)', async () => {
-    // Sequential — each render installs/restores global OffscreenCanvas +
-    // createImageBitmap shims; running them concurrently could restore out of order.
-    const btlr = await renderRuns('btLr');
-    const tbrl = await renderRuns('tbRl');
-    // Both must actually be vertical (rotate transform present).
-    expect(btlr.length, 'btLr produced runs').toBeGreaterThan(0);
-    expect(btlr.every((r) => /rotate/.test(r.tr)), 'btLr runs are vertical').toBe(true);
-    expect(tbrl.every((r) => /rotate/.test(r.tr)), 'tbRl runs are vertical').toBe(true);
-    // And identical layout: same texts, positions, and rotation.
-    expect(btlr).toEqual(tbrl);
-  });
-});
+describe.skipIf(!skia || !docxMod || !rendererMod)(
+  'docx section btLr = rotated horizontal (§17.6.20, #988 re-adjudication)',
+  () => {
+    it('FRAME: btLr text-run layout (position + transform) equals tbRl', async () => {
+      // Sequential — each render installs/restores global OffscreenCanvas +
+      // createImageBitmap shims; concurrent runs could restore out of order.
+      const btlr = await renderDoc(docxWith(VERT_SECTPR('btLr')));
+      const tbrl = await renderDoc(docxWith(VERT_SECTPR('tbRl')));
+      expect(btlr.runs.length, 'btLr produced runs').toBeGreaterThan(0);
+      expect(btlr.runs.every((r) => /rotate/.test(r.tr)), 'btLr runs are on the rotated page').toBe(true);
+      expect(btlr.runs).toEqual(tbrl.runs);
+    });
+
+    it('GLYPHS: the btLr raster equals the quarter-turned horizontal render rotated +90° CW', async () => {
+      const btlr = await renderDoc(docxWith(VERT_SECTPR('btLr')));
+      const horiz = await renderDoc(docxWith(HORIZ_CONTROL_SECTPR));
+      // Physical portrait page vs its logical landscape frame.
+      expect([btlr.w, btlr.h]).toEqual([612, 792]);
+      expect([horiz.w, horiz.h]).toEqual([792, 612]);
+      // Page paint transform: physical = (cssWidth − logical.y, logical.x) —
+      // control pixel (cx, cy) lands on btLr pixel (611 − cy, cx). Count
+      // channel mismatches with a small AA tolerance: the two rasters are the
+      // same layout drawn under a ±90° coordinate change, so glyph coverage may
+      // differ by a hair at edges, but any orientation/position error moves
+      // whole glyphs (thousands of pixels).
+      let mismatched = 0;
+      const TOL = 32;
+      for (let cy = 0; cy < 612; cy++) {
+        for (let cx = 0; cx < 792; cx++) {
+          const hIdx = (cy * 792 + cx) * 4;
+          const bIdx = (cx * 612 + (611 - cy)) * 4;
+          if (
+            Math.abs(btlr.pixels[bIdx] - horiz.pixels[hIdx]) > TOL ||
+            Math.abs(btlr.pixels[bIdx + 1] - horiz.pixels[hIdx + 1]) > TOL ||
+            Math.abs(btlr.pixels[bIdx + 2] - horiz.pixels[hIdx + 2]) > TOL
+          ) {
+            mismatched++;
+          }
+        }
+      }
+      const total = 612 * 792;
+      // Anti-aliasing may differ between drawing under a rotated CTM and
+      // rotating the raster: measured 0.10% on macOS skia. The wrong glyph
+      // mode (upright CJK, the pre-#988-re-adjudication behavior) measures
+      // 0.69%. Gate at 0.3% — 3× the correct output (portability headroom for
+      // other skia/font stacks) while keeping a 2.3× margin below the broken
+      // state.
+      expect(mismatched / total, `mismatched ${mismatched}/${total}`).toBeLessThan(0.003);
+    });
+
+    it('TRIPWIRE: the btLr raster differs from tbRl (CJK rides the page rotation)', async () => {
+      const btlr = await renderDoc(docxWith(VERT_SECTPR('btLr')));
+      const tbrl = await renderDoc(docxWith(VERT_SECTPR('tbRl')));
+      let differing = 0;
+      for (let i = 0; i < btlr.pixels.length; i += 4) {
+        if (Math.abs(btlr.pixels[i] - tbrl.pixels[i]) > 32) differing++;
+      }
+      // Upright CJK vs rotated CJK moves nearly every ideograph's ink.
+      expect(differing, 'btLr must not render CJK upright like tbRl').toBeGreaterThan(1000);
+    });
+  },
+);

--- a/packages/node/src/docx-per-section-mixed-direction.probe.test.ts
+++ b/packages/node/src/docx-per-section-mixed-direction.probe.test.ts
@@ -1,12 +1,14 @@
 /**
  * Per-section text-direction mixing — ECMA-376 §17.6.20, issue #1000 (the
  * carve-out of #988 batch-3 adjudication ①): a document whose NON-FINAL
- * section is vertical (`btLr` ≡ `tbRl` per Word ground truth) while the FINAL
+ * section is vertical (`btLr`, which shares the `tbRl` page FRAME per the #988
+ * re-adjudication; its GLYPHS all ride the page rotation — pinned by
+ * docx-btlr-vertical.probe.test.ts, not here) while the FINAL
  * section is horizontal renders page 1 vertical and page 2 horizontal.
  *
  * Word ground truth (the batch-3 btLr fixture's PDF, `pdftotext -bbox` +
- * `pdfinfo`): 2 pages, BOTH physical Letter portrait 612×792 pt; page 1 lays
- * the btLr section out exactly like tbRl — the heading column hugs the RIGHT
+ * `pdfinfo`): 2 pages, BOTH physical Letter portrait 612×792 pt; page 1 frames
+ * the btLr section exactly like tbRl — the heading column hugs the RIGHT
  * content margin (x ≈ 519.1–532.0), glyphs advance top→bottom from y = 72, and
  * successive paragraphs stack as columns progressing right→left (x ≈ 519 →
  * 496 → 470 → 444 → 418); page 2 draws the same text horizontally from the
@@ -97,7 +99,7 @@ describe.skipIf(!skia || !docxMod || !rendererMod || !havePrereqs)(
           return { runs, canvas };
         };
 
-        // Page 1 — vertical (btLr ≡ tbRl): physical portrait canvas, every text
+        // Page 1 — vertical (btLr, tbRl-framed): physical portrait canvas, every text
         // run projected through the +90° page rotation (transform set), heading
         // column hugging the right content margin, columns advancing right→left.
         const p0 = await renderPage(0);


### PR DESCRIPTION
## Summary

A section-level `<w:textDirection w:val="btLr"/>` (ECMA-376 §17.6.20, Part 4 §14.11.7) now renders as Word does: the **horizontal layout rotated +90° clockwise wholesale** — every glyph rides the page rotation. Previously (#996/#1002) `btLr` reused the `tbRl` glyph path, drawing CJK upright, which a user observing Word's actual output flagged as wrong.

## Adjudication correction (issue #988 ruling ①)

The original batch-3 ruling ("btLr renders identically to tbRl, CJK upright") was measured with `pdftotext -bbox`. That measurement is **degenerate for CJK**: a near-square ideograph cell has the same bounding box whether the glyph stands upright or lies rotated 90°, so bbox transposition proved the column geometry but silently got the glyph orientation wrong. The user's observation of Word prompted a re-adjudication of the same Word PDF at 300 dpi using **raster inspection of asymmetric glyphs**:

- 「び」— its dakuten (゛), designed at the glyph's top-right, sits at the **bottom-right** on the btLr page ⇒ rotated 90° **clockwise**.
- The bold title strip, cut out and rotated 90° CCW as a raster, reads perfectly left→right with every glyph upright (kana, kanji, Latin, digits, parentheses alike); rotated CW it is upside down.
- The fullwidth parentheses render as the ordinary horizontal forms rotated with the text — **no** vertical presentation forms (U+FE35/36).

| Aspect | Old ruling ① (#996) | Corrected (raster-proven) |
|---|---|---|
| Page frame / canvas | tbRl frame (quarter-turned logical layout, +90° paint) | **unchanged — confirmed** |
| Column progression | right→left | **unchanged — confirmed** |
| Character advance | physical top→bottom | **unchanged — confirmed** |
| Latin / digits | rotated 90° CW (sideways) | **unchanged — confirmed** |
| **CJK glyphs** | **upright** | **rotated 90° CW with the page** |
| Vertical punctuation forms | as tbRl (︑︒︵︶ substituted) | **not substituted** — horizontal forms rotate with the text |
| 縦中横 (§17.3.2.10) | grouped as tbRl | **not grouped** — plain horizontal run |

Full correction posted on the issue: https://github.com/yukiyokotani/office-open-xml-viewer/issues/988#issuecomment-4950296007

## Implementation

- New `RenderState.verticalAllRotated` (true only on a `btLr` page; `isAllRotatedVerticalTextDirection`). It switches ONLY the **glyph-level** sites to the ordinary horizontal branches inside the rotated frame:
  - `drawParagraphLine`: numbering-marker draw, 縦中横 / `drawVerticalRun` branches (→ whole-run contextual `fillText`), kashida gate, RTL trailing-space trim, overlay `letterSpacingPx` / `eastAsianVert` reporting.
  - `paragraphMeasurementEnvironment` + new `segmentEnvironmentOf` for the two direct `buildSegments(para.runs, ·)` sites: no 縦中横 grouping, so paint layout equals the paginator's measure layout (which never set `verticalCJK`).
- **Frame-level machinery is untouched** and keeps reading `verticalCJK`: geometry quarter-turn, +90° page paint, per-section mixing (#1002), text-layer transform, `verticalPhys` anchor resolution, upright images/tables (GT-less for btLr — deliberately kept at tbRl parity, documented in `RenderState.verticalAllRotated`'s docs).
- `tbRl`/`tbRlV`/`tbLrV` and horizontal paths are byte-identical: every changed expression reduces to its previous value when `verticalAllRotated` is undefined.

## Tests

- `packages/docx/src/btlr-rotated-glyphs.test.ts` (new): recording-canvas pins — btLr page has exactly one +π/2 page rotation and **zero** −π/2 glyph counter-rotations, runs and numbering markers draw as whole-run `fillText`, 縦中横 is not grouped; tbRl control keeps its per-glyph counter-rotations.
- `packages/node/src/docx-btlr-vertical.probe.test.ts` (rewritten): ① FRAME — btLr run layout (positions + transform) equals tbRl; ② GLYPHS — the btLr page raster equals the **quarter-turned horizontal render rotated +90° CW** (asymmetric margins; 0.10% AA mismatch measured vs 0.69% for the old upright-CJK behavior; gate 0.3%); ③ TRIPWIRE — btLr raster differs from tbRl.
- Existing per-section frame tests (#1002) unchanged and green — the frame behavior of btLr is exactly what they pinned.

## Verification

- Headless render of the private btLr fixture vs its Word PDF: glyph orientation now matches exactly; ink top at 72.0 pt (1 in margin, exact); five columns right→left with centers within 1.3–4.6 pt of Word (the known cumulative font-metric pitch residual); horizontal control page unchanged.
- docx vitest 177 files / 1365 tests green; node suite green; root `pnpm typecheck` clean; `ast-grep scan` clean.
- docx VRT (demo + private, 2026-07-12b baseline): **all 85 items pass; the private tbRl vertical sample is 0 px**; all horizontal private samples 0 px; demo within the fidelity ratchet.
- Codex (gpt-5.6-sol, high) independent review: no blocker/major; both minors (marker-test vacuity guard, raster-gate headroom) and the doc nit addressed.

Refs #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
