### PR TITLE
fix(docx): honor contextualSpacing and tabs in text-box paragraphs

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -5692,12 +5692,29 @@ fn extract_simple_paragraph_text(
         }
 
         let mut run_text = String::new();
-        for t in r
+        // Walk the run's descendants IN DOCUMENT ORDER, emitting `<w:t>` text and a
+        // horizontal tab for each `<w:tab>` (§17.3.3.32). The body path emits the
+        // same `\t` for its run-content `w:tab` (~parser.rs:3401); the shape path
+        // previously scanned only `<w:t>`, so a text-box `<w:tab/>` collapsed to
+        // nothing and tabbed layouts (sample-32's course grid:
+        // "Course<tab><tab>(0.5)<tab>□") lost their column alignment. The `\t`
+        // reaches the SAME line engine, which resolves it against the paragraph's
+        // tab stops + the default-tab grid (`effState.defaultTabPt`, §17.15.1.25).
+        // Match by WordprocessingML NAMESPACE, not bare local name: an embedded
+        // graphic under the same `<w:r>` can carry DrawingML `<a:tab>`/`<a:t>`,
+        // which are NOT run content and must not leak into the paragraph text.
+        for n in r
             .descendants()
-            .filter(|n| n.is_element() && n.tag_name().name() == "t")
+            .filter(|n| n.is_element() && is_w_ns(n.tag_name().namespace()))
         {
-            if let Some(text_node) = t.text() {
-                run_text.push_str(text_node);
+            match n.tag_name().name() {
+                "t" => {
+                    if let Some(text_node) = n.text() {
+                        run_text.push_str(text_node);
+                    }
+                }
+                "tab" => run_text.push('\t'),
+                _ => {}
             }
         }
         let fmt = resolve_run_fmt(child_w(r, "rPr"));
@@ -15233,6 +15250,67 @@ mod txbx_inline_image_tests {
                   <w:r><w:t>x</w:t></w:r></w:p>"#,
         );
         assert!(none.tab_stops.is_empty());
+    }
+
+    /// ECMA-376 §17.3.3.32 — a `<w:tab/>` inside a text-box run must surface as a
+    /// literal `\t` in the block/run text so the line engine can advance to the
+    /// next tab stop (or the default-tab grid). The parser previously scanned only
+    /// `<w:t>`, so a tab-only run collapsed to nothing and a tabbed course grid
+    /// (sample-32: "Course<tab><tab>(0.5)<tab>□") lost its column alignment. The
+    /// `\t` must sit in DOCUMENT ORDER between the surrounding text runs.
+    #[test]
+    fn extract_simple_paragraph_text_surfaces_tab_characters() {
+        let doc = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:r><w:t>Arabic 2250</w:t></w:r>
+                 <w:r><w:tab/></w:r>
+                 <w:r><w:tab/><w:t>(1.0)</w:t></w:r>
+               </w:p>"#,
+        )
+        .unwrap();
+        let block = extract_simple_paragraph_text(
+            &StyleMap::default(),
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+        // Two tabs surface; the mid run interleaves its tab BEFORE its text.
+        assert_eq!(block.text, "Arabic 2250\t\t(1.0)");
+        // The tab-only run is preserved as its own rich run carrying just "\t"
+        // (not dropped as empty), so per-run layout keeps the advance.
+        let run_texts: Vec<&str> = block.runs.iter().map(|r| r.text.as_str()).collect();
+        assert_eq!(run_texts, vec!["Arabic 2250", "\t", "\t(1.0)"]);
+    }
+
+    /// The run-content walk matches `t`/`tab` by WordprocessingML NAMESPACE, not
+    /// bare local name: a DrawingML `<a:tab>` (e.g. in an embedded graphic's
+    /// `<a:tabLst>`) or `<a:t>` living under the same `<w:r>` must NOT leak into
+    /// the paragraph text as a `\t` / text fragment — only §17.3.3.32 `<w:tab/>`
+    /// and §17.3.3.31 `<w:t>` are WordprocessingML run content.
+    #[test]
+    fn extract_simple_paragraph_text_ignores_foreign_namespace_tab_and_t() {
+        let doc = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                    xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                 <w:r>
+                   <w:t>A</w:t>
+                   <a:tabLst><a:tab/></a:tabLst>
+                   <a:t>ignored</a:t>
+                   <w:tab/>
+                   <w:t>B</w:t>
+                 </w:r>
+               </w:p>"#,
+        )
+        .unwrap();
+        let block = extract_simple_paragraph_text(
+            &StyleMap::default(),
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert_eq!(block.text, "A\tB");
     }
 
     /// ECMA-376 §17.3.1.37 — a text-box paragraph's tab stops resolve through the

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -5922,6 +5922,29 @@ fn extract_simple_paragraph_text(
         .clone()
         .or_else(|| style_para.line_spacing_rule.clone());
 
+    // ECMA-376 §17.3.1.9 `<w:contextualSpacing>` — resolved with the SAME
+    // §17.7.2 precedence as the spacing above (direct `<w:pPr>` via `direct_ind`
+    // wins, else the style-chain-resolved `style_para`, which folds in the
+    // paragraph style + docDefaults). Paired with the resolved paragraph style id
+    // so the renderer can drop the inter-paragraph gap between two adjacent
+    // same-style paragraphs that both set the toggle — the identical rule the body
+    // path applies (`contextual_spacing`/`style_id`; renderer `contextualSuppressed`).
+    // Without this a `<w:contextualSpacing/>` ListParagraph list inside a fixed box
+    // kept the docDefault `after=160` (8 pt) gap that inflated its line pitch and
+    // clipped the trailing line (sample-32).
+    let contextual_spacing = direct_ind
+        .contextual_spacing
+        .or(style_para.contextual_spacing)
+        .unwrap_or(false);
+    // Expose the SAME stable style id the body path stamps (parser.rs ~2578):
+    // the explicit `<w:pStyle>`, else the document default paragraph style
+    // (locale ids like "a"/"標準"), else "Normal", so grouping survives templates
+    // that never name the default style explicitly.
+    let resolved_style_id = style_id
+        .clone()
+        .or_else(|| style_map.default_para_style_id().map(str::to_string))
+        .or_else(|| Some("Normal".to_string()));
+
     // ECMA-376 §17.3.1.37 tab stops and §17.3.1.6 bidi — resolved with the SAME
     // §17.7.2 precedence as the indent/spacing above (direct `<w:pPr>` via
     // `direct_ind` = `parse_para_fmt`, else the style-chain-resolved `style_para`).
@@ -5994,6 +6017,8 @@ fn extract_simple_paragraph_text(
         indent_first,
         tab_stops,
         bidi,
+        contextual_spacing,
+        style_id: resolved_style_id,
         image_path,
         mime_type,
         svg_image_path,
@@ -14666,6 +14691,77 @@ mod txbx_inline_image_tests {
         .unwrap();
         assert!((block2.space_before - 12.0).abs() < 1e-6);
         assert!((block2.space_after - 18.0).abs() < 1e-6);
+    }
+
+    /// ECMA-376 §17.3.1.9 — a text-box paragraph surfaces its resolved
+    /// `contextualSpacing` toggle AND its style id so the renderer can group
+    /// adjacent same-style paragraphs and drop the inter-paragraph gap (the body
+    /// path already does this via `contextual_spacing`/`style_id`; the text-box
+    /// path previously dropped both, so a `<w:contextualSpacing/>` ListParagraph
+    /// list kept the docDefault `after=160` gap that clipped its trailing line —
+    /// sample-32). Direct `<w:contextualSpacing/>` wins; an absent one inherits
+    /// from the paragraph style; a style id is exposed for grouping.
+    #[test]
+    fn extract_simple_paragraph_text_surfaces_contextual_spacing_and_style_id() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="paragraph" w:styleId="ListParagraph">
+                <w:name w:val="List Paragraph"/>
+                <w:pPr><w:contextualSpacing/><w:spacing w:after="160"/></w:pPr>
+              </w:style>
+              <w:style w:type="paragraph" w:styleId="Plain">
+                <w:name w:val="Plain"/>
+                <w:pPr><w:spacing w:after="160"/></w:pPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        let parse_block = |xml: &str| {
+            let doc = roxmltree::Document::parse(xml).unwrap();
+            extract_simple_paragraph_text(
+                &styles,
+                doc.root_element(),
+                &ThemeColors::default(),
+                &HashMap::new(),
+            )
+            .unwrap()
+        };
+
+        // (a) The toggle is INHERITED from the paragraph style (no direct one),
+        // and the explicit pStyle is exposed as the block's style id.
+        let inherited = parse_block(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:pPr><w:pStyle w:val="ListParagraph"/></w:pPr>
+                 <w:r><w:t>item</w:t></w:r></w:p>"#,
+        );
+        assert!(
+            inherited.contextual_spacing,
+            "contextualSpacing must inherit from the paragraph style"
+        );
+        assert_eq!(inherited.style_id.as_deref(), Some("ListParagraph"));
+
+        // (b) A style WITHOUT contextualSpacing ⇒ false; its id is still exposed.
+        let plain = parse_block(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:pPr><w:pStyle w:val="Plain"/></w:pPr>
+                 <w:r><w:t>item</w:t></w:r></w:p>"#,
+        );
+        assert!(
+            !plain.contextual_spacing,
+            "a style without contextualSpacing ⇒ false"
+        );
+        assert_eq!(plain.style_id.as_deref(), Some("Plain"));
+
+        // (c) A DIRECT `<w:contextualSpacing/>` sets the toggle even over a style
+        // that lacks it.
+        let direct = parse_block(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                 <w:pPr><w:pStyle w:val="Plain"/><w:contextualSpacing/></w:pPr>
+                 <w:r><w:t>item</w:t></w:r></w:p>"#,
+        );
+        assert!(
+            direct.contextual_spacing,
+            "direct contextualSpacing must win over a style that lacks it"
+        );
     }
 
     /// ECMA-376 §17.3.1.12 — a text-box paragraph surfaces its own `<w:ind>`

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1608,6 +1608,24 @@ pub struct ShapeText {
     /// reordering pass (the body renderer reads the identical field).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bidi: Option<bool>,
+    /// ECMA-376 §17.3.1.9 `<w:contextualSpacing>` — resolved through the style
+    /// chain (direct `<w:pPr>` wins, else the paragraph style incl. docDefaults).
+    /// When set, Word suppresses `space_before`/`space_after` between this
+    /// text-box paragraph and an ADJACENT paragraph that shares its `style_id`
+    /// and also sets the toggle — identical to the body paragraph's
+    /// `contextual_spacing` (parser.rs `resolve_para` / renderer `contextualSuppressed`).
+    /// Without it a `<w:contextualSpacing/>` ListParagraph list inside a fixed
+    /// text box kept inheriting the docDefault `after=160` (8 pt) gap, which
+    /// inflated its line pitch and clipped the trailing line (sample-32).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub contextual_spacing: bool,
+    /// Resolved paragraph style id of this text-box paragraph: the explicit
+    /// `<w:pStyle w:val>` when present, else the document default paragraph style
+    /// (`w:default="1"`), else "Normal" — the SAME stable id the body path stamps
+    /// (parser.rs ~2578) so §17.3.1.9 `contextual_spacing` can group adjacent
+    /// same-style paragraphs even under locale-specific default style ids.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub style_id: Option<String>,
     /// Embedded zip path of an inline image living inside this text-box
     /// paragraph (`<w:drawing><wp:inline>…<a:blip r:embed>`), e.g.
     /// `word/media/image1.emf`. `None` for a text-only paragraph. Resolved

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6957,8 +6957,41 @@ function renderBodyElement(el: BodyElement, state: RenderState): void {
   }
 }
 
-function contextualSuppressed(prev: DocParagraph | null, curr: DocParagraph): boolean {
+/**
+ * ECMA-376 §17.3.1.9 — two ADJACENT paragraphs that share a style id and BOTH set
+ * `<w:contextualSpacing>` suppress the spaceBefore/spaceAfter between them. Kept
+ * structural (not `DocParagraph`) so the SAME rule drives both the body paragraph
+ * path and the text-box path ({@link ShapeText}), which carry the identical
+ * `contextualSpacing`/`styleId` pair.
+ */
+function contextualSuppressed(
+  prev: { contextualSpacing?: boolean; styleId?: string | null } | null,
+  curr: { contextualSpacing?: boolean; styleId?: string | null },
+): boolean {
   return !!(prev?.contextualSpacing && curr.contextualSpacing && prev.styleId && prev.styleId === curr.styleId);
+}
+
+/**
+ * ECMA-376 §17.3.1.33 + §17.3.1.9 — the vertical gap reserved ABOVE text-box
+ * paragraph `i`. The first paragraph reserves only its own spaceBefore; between
+ * two paragraphs the gap collapses to max(prev.spaceAfter, this.spaceBefore) — NOT
+ * their sum — UNLESS the two are the same style and BOTH set contextualSpacing, in
+ * which case Word drops the whole gap (the identical rule the body path applies via
+ * {@link contextualSuppressed}). Without the suppression a `<w:contextualSpacing/>`
+ * ListParagraph list inside a fixed box kept inheriting the docDefault `after=160`
+ * (8 pt) gap, which inflated its line pitch and clipped the trailing line
+ * (sample-32). Shared by the render pass and the auto-fit height measurement so the
+ * two never disagree.
+ */
+export function shapeParagraphGapBefore(
+  blocks: ReadonlyArray<{ contextualSpacing?: boolean; styleId?: string | null }>,
+  i: number,
+  spBefore: readonly number[],
+  spAfter: readonly number[],
+): number {
+  if (i <= 0) return spBefore[i];
+  if (contextualSuppressed(blocks[i - 1], blocks[i])) return 0;
+  return Math.max(spBefore[i], spAfter[i - 1]);
 }
 
 /**
@@ -10416,8 +10449,7 @@ export function measureShapeTextAutoFitHeight(
 
   const spBefore = blocks.map((b) => (b.spaceBefore ?? 0) * scale);
   const spAfter = blocks.map((b) => (b.spaceAfter ?? 0) * scale);
-  const gapBefore = (i: number): number =>
-    i > 0 ? Math.max(spBefore[i], spAfter[i - 1]) : spBefore[i];
+  const gapBefore = (i: number): number => shapeParagraphGapBefore(blocks, i, spBefore, spAfter);
 
   ctx.save();
   try {
@@ -10931,8 +10963,7 @@ export function renderShapeText(
   // totalH used for ctr/bottom anchoring).
   const spBefore = blocks.map((b) => (b.spaceBefore ?? 0) * scale);
   const spAfter = blocks.map((b) => (b.spaceAfter ?? 0) * scale);
-  const gapBefore = (i: number): number =>
-    i > 0 ? Math.max(spBefore[i], spAfter[i - 1]) : spBefore[i];
+  const gapBefore = (i: number): number => shapeParagraphGapBefore(blocks, i, spBefore, spAfter);
   const totalH = layouts.reduce((s, l, i) => s + gapBefore(i) + blockHeight(l), 0);
 
   const anchor = shape.textAnchor ?? 't';

--- a/packages/docx/src/shape-contextual-spacing.test.ts
+++ b/packages/docx/src/shape-contextual-spacing.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { shapeParagraphGapBefore } from './renderer';
+import type { ShapeText } from './types';
+
+/**
+ * ECMA-376 §17.3.1.9 `<w:contextualSpacing>` inside a text box (`<wps:txbx>`).
+ *
+ * The vertical gap reserved ABOVE text-box paragraph `i` is normally
+ * max(prev.spaceAfter, this.spaceBefore) (collapse, not sum). When two ADJACENT
+ * paragraphs share a style id and BOTH set contextualSpacing, Word drops the
+ * whole gap — the same rule the body renderer applies via `contextualSuppressed`.
+ * Before the fix the text-box path lacked this, so a `<w:contextualSpacing/>`
+ * ListParagraph list inherited the docDefault `after=160` (8 pt) gap that
+ * inflated its line pitch and clipped the trailing line (sample-32).
+ */
+describe('shapeParagraphGapBefore — §17.3.1.9 contextualSpacing in a text box', () => {
+  const block = (over: Partial<ShapeText>): ShapeText =>
+    ({ text: 'x', fontSizePt: 12, alignment: 'left', ...over }) as ShapeText;
+
+  // 8 pt after / 4 pt before, both scaled ×1 for the table.
+  const spBefore = [0, 4];
+  const spAfter = [8, 0];
+
+  it('reserves only the first block own spaceBefore at i=0 (no previous block)', () => {
+    const blocks = [block({ spaceBefore: 6 }), block({})];
+    expect(shapeParagraphGapBefore(blocks, 0, [6, 4], [0, 0])).toBe(6);
+  });
+
+  it('drops the gap when both blocks share a style id AND both set contextualSpacing', () => {
+    const blocks = [
+      block({ styleId: 'ListParagraph', contextualSpacing: true }),
+      block({ styleId: 'ListParagraph', contextualSpacing: true }),
+    ];
+    expect(shapeParagraphGapBefore(blocks, 1, spBefore, spAfter)).toBe(0);
+  });
+
+  it('keeps the collapsed gap when the two blocks have DIFFERENT style ids', () => {
+    const blocks = [
+      block({ styleId: 'ListParagraph', contextualSpacing: true }),
+      block({ styleId: 'Body', contextualSpacing: true }),
+    ];
+    // max(spBefore[1]=4, spAfter[0]=8) = 8.
+    expect(shapeParagraphGapBefore(blocks, 1, spBefore, spAfter)).toBe(8);
+  });
+
+  it('keeps the gap when only ONE of the two same-style blocks sets contextualSpacing', () => {
+    const blocks = [
+      block({ styleId: 'ListParagraph', contextualSpacing: true }),
+      block({ styleId: 'ListParagraph', contextualSpacing: false }),
+    ];
+    expect(shapeParagraphGapBefore(blocks, 1, spBefore, spAfter)).toBe(8);
+  });
+
+  it('keeps the gap when the shared style id is missing on either block', () => {
+    const blocks = [
+      block({ contextualSpacing: true }),
+      block({ contextualSpacing: true }),
+    ];
+    expect(shapeParagraphGapBefore(blocks, 1, spBefore, spAfter)).toBe(8);
+  });
+});

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1079,6 +1079,19 @@ export interface ShapeText {
    *  base direction for the UAX#9 reordering pass (the body renderer reads the
    *  identical field). */
   bidi?: boolean;
+  /** ECMA-376 §17.3.1.9 `<w:contextualSpacing>` — resolved through the style
+   *  chain in the parser. When set, the renderer suppresses the spaceBefore/
+   *  spaceAfter gap between this text-box paragraph and an ADJACENT paragraph
+   *  that shares its {@link ShapeText.styleId} and also sets the toggle
+   *  (identical to {@link DocParagraph.contextualSpacing} / `contextualSuppressed`).
+   *  Absent ⇒ no suppression. */
+  contextualSpacing?: boolean;
+  /** Resolved paragraph style id of this text-box paragraph — the explicit
+   *  `<w:pStyle>`, else the document default paragraph style, else "Normal" (the
+   *  same stable id {@link DocParagraph.styleId} carries). Paired with
+   *  {@link ShapeText.contextualSpacing} to group adjacent same-style paragraphs
+   *  for §17.3.1.9. */
+  styleId?: string | null;
   /** Zip path of an inline image inside this text-box paragraph
    *  (`<w:drawing><wp:inline><a:blip r:embed>`), e.g. `word/media/image1.emf`.
    *  Absent for a text-only paragraph. */


### PR DESCRIPTION
## Summary

Two ECMA-376 fidelity fixes for text-box (`<wps:txbx>`) paragraphs, both surfacing on a course-grid checklist fixture whose Word PDF is the ground truth. Commits are split by concern.

### 1. `contextualSpacing` in text boxes (§17.3.1.9) — `fix(docx): honor contextualSpacing…`

A text-box paragraph inherited the docDefault `after=160` (8 pt) inter-paragraph spacing even when two adjacent same-style paragraphs both set `<w:contextualSpacing/>`. Because a `<a:noAutofit/>` box is a fixed size that clips, the inflated line pitch pushed the trailing rows out of the box and they disappeared. The body and table-cell paths already suppressed this via `contextualSuppressed()`; only the text-box path was missing it.

- Rust: `ShapeText` gains `contextual_spacing` + `style_id`, populated in `extract_simple_paragraph_text` with the same style-chain precedence as the body path (direct `<w:pPr>` wins, else the paragraph style incl. docDefaults; `style_id` = explicit `<w:pStyle>`, else the default paragraph style, else `"Normal"`).
- TS: `contextualSuppressed` widened to a structural type so the body and text-box paths share one rule; a new pure `shapeParagraphGapBefore` helper unifies the `gapBefore` logic used by both `renderShapeText` and `measureShapeTextAutoFitHeight`, dropping the gap between adjacent same-style contextualSpacing paragraphs.

### 2. `<w:tab/>` in text-box runs (§17.3.3.32) — `fix(docx): emit tab characters…`

`collect_run_node` built text-box run text from `<w:t>` descendants only, so a `<w:tab/>` collapsed to nothing and tabbed grids ("Course⇥⇥(credits)⇥☐") lost their column alignment. It now walks the run's descendants in document order and emits `\t` for each `<w:tab>`, mirroring the body path. The tab reaches the shared line engine, which resolves it against the paragraph tab stops and the default-tab grid (§17.15.1.25).

## Verification

Rendered the fixture in a browser and measured pixels against the Word PDF (1 pt tolerance):

- **Box width**: borders at 44.8 → 573.9 pt (529.1 pt) vs Word 44.9 → 573.8 pt (528.9 pt) — match. *(A reported "box too wide" symptom turned out not to be a bug: the box already renders at the exact `<wp:extent>` width, which bleeds into both margins in Word too. No code change.)*
- **Tab columns**: the default-tab grid (origin = box content-left, 36 pt steps) lands credits at 196.9 pt and checkboxes at 268.9 pt vs Word 196.6 / 268.6 — match. Two short-name rows land one 36 pt stop later than Word because the substitute font renders those names ~4 pt wider (crossing a grid line) — a font-substitution residual, not a tab-logic difference.
- **contextualSpacing**: row pitch collapses from the broken ~21 pt to the box line height; previously clipped trailing rows reappear; no box overflow.

Non-regression: the sole demo VRT sample has no text-box/tab/contextualSpacing, so demo VRT is unaffected by construction. Other text-box samples (e.g. the journal-template masthead with a tabbed "homepage" line) re-rendered cleanly. *(The private VRT baseline could not run in this worktree — no reference images present — so no reference images were touched.)*

## Cross-package note

docx-specific. PowerPoint's `<a:p>` uses `spcBef`/`spcAft` and has no `contextualSpacing` equivalent (deliberately unclipped shape text), and Excel likewise; neither shares this text-box gap/tab path.

## Independent review (codex gpt-5.6-sol, read-only)

Verdict was "request changes" with four findings; each was verified against the local ECMA-376 Part 1 5th-edition text:

1. **§17.3.1.9 is per-side subtraction, not a both-sides gate** — confirmed in the spec text ("the spacing above or below on this paragraph is subtracted…, never going below zero"; the neighbor needs only the *same style*, not the toggle). However, the both-toggles+same-style rule is the codebase's long-standing, Word-adjudicated `contextualSuppressed` semantics used by every body/table call site, and this PR deliberately gives text boxes *parity with the body* rather than changing the document-wide rule blind. The spec's one-sided case needs a Word-behavior adjudication fixture before touching all paths at once → follow-up filed.
2. **Namespace check on the run-content walk** — fixed in this PR: the walk now matches `t`/`tab` by WordprocessingML namespace so DrawingML `<a:tab>`/`<a:t>` under an embedded graphic cannot leak into paragraph text (+ regression test).
3. **Ruby-base runs still drop `<w:tab/>`** — pre-existing limitation of the ruby branch (untouched by this PR); a tab inside a ruby base also has no layout representation in the ruby model today, so it is left for the ruby path rather than half-fixed here.
4. **`tab` is §17.3.3.32 (not §17.3.3.29, which is softHyphen)** — fixed in code comments, the commit message, and this description.

## Tests

- Rust: `extract_simple_paragraph_text_surfaces_contextual_spacing_and_style_id`, `…surfaces_tab_characters`.
- TS: `shape-contextual-spacing.test.ts` — the `shapeParagraphGapBefore` suppression table (same-style+both = 0 / different style / one-sided / missing style-id = collapse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)