### PR TITLE
docs(docx): re-adjudicate vertical-section table block placement (#988)

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -12582,6 +12582,17 @@ function renderTable(table: DocTable, state: RenderState): void {
   // placement along the flow axis and row-splitting across vertical pages are
   // un-adjudicated follow-ups; the paginator charges the same tableW footprint
   // (computePages' vertical table branch) so pagination and paint agree.
+  //
+  // WON'T-FIX (narrowed, issue #988 re-adjudication 2026-07-12; measurements in
+  // docx-vertical-table-cells.probe.test.ts): Word additionally flows the
+  // vertical text BELOW each top-anchored table and places a MULTI-table run in
+  // a page-level order that is NON-CAUSAL for a single forward pass — a later
+  // table displaces earlier text, tables progress left→right (reverse of the RTL
+  // text), and an auto table can overhang the right margin. §17.6.20/§17.4.80 do
+  // not define this and a plain block table has no wrapTopAndBottom, so we keep
+  // the causal RTL block-flow placement here rather than sample-fit a Word quirk
+  // (independently reviewed). Reproducing it would need a place-all-tables →
+  // register-exclusions → reflow pass, gated on a purpose-built fixture matrix.
   if (state.verticalPhys) {
     const cssW = state.verticalPhys.cssWidthPx;
     const physState = verticalPhysicalContentState(state);

--- a/packages/node/src/docx-vertical-table-cells.probe.test.ts
+++ b/packages/node/src/docx-vertical-table-cells.probe.test.ts
@@ -17,12 +17,47 @@
  *
  * TABLE 1's border box lands at its natural flow position and matches the PDF
  * on BOTH axes, so it is asserted exactly (±2.5 pt). TABLE 2's physical
- * placement is Word-IDIOSYNCRATIC (Word pins it before the flow start,
- * overhanging the right margin at x [504.5, 577] instead of following the
- * right→left block flow) — the adjudication flags block placement as a partial
- * won't-fix candidate — so for it only the spec-grounded invariants are
- * asserted: physical width, top-margin pinning, and auto GROWTH well past the
- * 144.5 pt exact height.
+ * placement is Word-IDIOSYNCRATIC (see the RE-ADJUDICATION below) — so for it
+ * only the spec-grounded invariants are asserted: physical width, top-margin
+ * pinning, and auto GROWTH well past the 144.5 pt exact height.
+ *
+ * ── RE-ADJUDICATION (2026-07-12, issue #988 follow-up) ──────────────────────
+ * The user re-observed sample-52 and reported (1) "cells still vertical / cut
+ * off" and (2) "Word keeps vertical text BELOW the table, we put it beside it".
+ *
+ * (1) does NOT reproduce. Cell text renders HORIZONTAL/upright in BOTH the node
+ * (skia-canvas) render AND the browser (Chromium via Storybook) — verified with
+ * onTextRun (transform:undefined, 5-char w≈60 runs advancing downward), the
+ * cell-glyph ctm (identity — the +90° page rotation is un-done), and a pixel
+ * band analysis. The earlier report was a STALE Storybook build predating #999
+ * (merge 6e2a2cc); the low line-pitch of a substituted CJK face makes stacked
+ * horizontal lines LOOK like vertical columns until magnified. So #999's
+ * horizontal-cell behaviour is CORRECT and is regression-guarded below.
+ *
+ * (2) is real but NON-CAUSAL, so it stays a won't-fix (narrowed & measured).
+ * Word GT (red-border boxes + pdftotext -bbox), physical page x[72,540] y[72,720]:
+ *   • T1 (exact) box x[417,489] y[72,216]  — top-anchored, LEFT.
+ *   • T2 (auto)  box x[504,576] y[72,365]  — top-anchored, RIGHT, OVERHANGS the
+ *     right content margin (576 > 540).
+ *   • p0 heading col x[519,531] y[366,563] and p1 col x[497,510] y[366,621]
+ *     resume BELOW T2 (start at T2's bottom, in T2's x-band).
+ *   • p4 col x[449,462] y[217,516] and p6 col x[425,438] y[217,620] resume
+ *     BELOW T1 (start at T1's bottom, in T1's x-band).
+ * So Word DOES flow vertical text below each top-anchored table. BUT the pairing
+ * is non-causal: text BEFORE T1 (p0,p1) sits under the LATER table T2, and text
+ * after T1 (p4,p6) sits under the EARLIER table T1 — text-segment i is capped by
+ * table (n+1−i), the tables progress LEFT→RIGHT (reverse of the RTL text), and
+ * T2 overhangs the margin. A later table displacing earlier text cannot arise in
+ * a single forward layout pass; reproducing it needs a page-level place-all-
+ * tables → register-exclusions → reflow model, and even that leaves the reversed
+ * pairing + overhang undocumented. §17.6.20/§17.4.80 say nothing about it and a
+ * plain block table has no wrapTopAndBottom, so a forward-only "text-below-table"
+ * approximation would be sample-fitting (spec-first violation) AND a *different*
+ * wrong layout (it would put p6 under T2, not T1). Independent review (Codex
+ * gpt-5.6-sol) concurred. Decision: keep the renderer's RTL block-flow placement,
+ * assert only the spec-grounded invariants, and CHARACTERIZE the residual (our
+ * T2 lands LEFT of T1, the reverse of Word) so a future adjudication sweep on a
+ * purpose-built fixture matrix notices any change.
  *
  * CI-safe: gated on docx WASM + skia-canvas + the PRIVATE sample + a macOS JP
  * font; skips when any is absent.
@@ -160,6 +195,16 @@ describe.skipIf(!skia || !docxMod || !rendererMod || !havePrereqs)(
       expect(Math.abs(autoBox!.x1 - autoBox!.x0 - 72.5), 'auto physical width').toBeLessThanOrEqual(2.5);
       expect(Math.abs(autoBox!.y0 - 72), 'auto pinned at the top margin').toBeLessThanOrEqual(2.5);
       expect(autoBox!.y1 - autoBox!.y0, 'auto row grew past the exact 144.5').toBeGreaterThan(250);
+      // Both tables share the SAME physical top edge (top content margin) — the
+      // top-anchoring the RE-ADJUDICATION confirms matches Word for BOTH tables.
+      expect(Math.abs(exactBox!.y0 - autoBox!.y0), 'both tables top-anchored together').toBeLessThanOrEqual(2.5);
+      // CHARACTERIZATION of the documented won't-fix residual (see the header
+      // RE-ADJUDICATION): our RTL block flow lays the LATER auto table entirely
+      // to the LEFT of the earlier exact table. Word GT is the REVERSE (auto at
+      // x[504,576], right of exact at x[417,489], overhanging the margin). If a
+      // future change reproduces Word's page-level exclusion/reflow model this
+      // flips and must be re-adjudicated on a purpose-built fixture matrix.
+      expect(autoBox!.x1, 'residual: auto table lands LEFT of exact (reverse of Word)').toBeLessThan(exactBox!.x0);
 
       // ── Clip: no cell ink below TABLE 1's exact bottom border ───────────
       let inkBelow = 0;


### PR DESCRIPTION
## Summary

Re-adjudication of the vertical (tbRl §17.6.20) block-table layout for the private
`sample-52` fixture (issue #988 follow-up). **No renderer behaviour change** —
`renderer.ts` is comment-only; the substance is in the probe + measured evidence.

> ⚠️ **This overturns the task's premise, not with a code fix but with evidence.**
> Both reported symptoms were investigated end-to-end (headless node **and**
> browser Chromium). Symptom 1 does not reproduce; symptom 2 is a non-causal Word
> quirk that a spec-faithful renderer should not chase. See below before merging.

## Symptom 1 — "cells still vertical / cut off": NOT a regression, does not reproduce

Cell text renders **horizontal/upright** in both paths. Evidence:
- `onTextRun`: cell runs are `transform: undefined`, `w≈60` (5 CJK chars), `x` fixed,
  `y` advancing — a horizontal paragraph. Identical structure node vs browser.
- Cell-glyph **ctm = identity** at draw time (the +90° page rotation is un-done by
  the upright branch) in both skia-canvas and Chromium.
- Pixel band analysis + magnified crop read cleanly as rows
  ("縦書きの表 / セルに固定 / 幅で入りき / …").

The earlier "vertical" report was a **stale Storybook build predating #999**
(merge `6e2a2cc`). A substituted CJK face's tight line pitch makes stacked
horizontal lines *look* like vertical columns until magnified. #999's horizontal-
cell behaviour is correct and is now regression-guarded by the probe.

## Symptom 2 — "Word puts vertical text below the table; we put it beside": real, but NON-CAUSAL → narrowed won't-fix

Measured Word GT (`sample-52.pdf`; red-border boxes + `pdftotext -bbox`; physical
page content band x[72,540] y[72,720]):

| element | box / column | note |
|---|---|---|
| T1 (exact) | x[417,489] y[72,216] | top-anchored, LEFT |
| T2 (auto)  | x[504,576] y[72,365] | top-anchored, RIGHT, **overhangs** right margin |
| p0 heading | x[519,531] y[366,563] | resumes **below T2** |
| p1         | x[497,510] y[366,621] | below T2 |
| p4         | x[449,462] y[217,516] | resumes **below T1** |
| p6         | x[425,438] y[217,620] | below T1 |

So Word *does* flow vertical text **below** each top-anchored table. **But** the
pairing is non-causal: text **before** the first table (p0, p1) sits under the
**later** table T2; the tables progress **left→right** (reverse of the RTL text);
T2 overhangs the margin. A later table displacing earlier text cannot arise in a
single forward layout pass. §17.6.20/§17.4.80 do not define table layout inside a
vertical section, and a plain block table has no `wrapTopAndBottom`, so a forward-
only "text-below-table" rule would be **sample-fitting (spec-first violation)** and
would produce a **different** wrong layout (p6 ends up under T2, not T1).
**Independent review (Codex gpt-5.6-sol, high) concurred**: keep the causal RTL
block-flow placement; reproducing Word here would require a page-level
place-all-tables → register-exclusions → reflow pass, gated on a purpose-built
fixture matrix — out of scope for a single fixture.

## Changes
- `renderer.ts` — sharpened the `renderTable` upright-branch WON'T-FIX comment with
  the narrowed, measured limitation. **No code/behaviour change.**
- `docx-vertical-table-cells.probe.test.ts` — recorded the re-adjudication
  (measured boxes + non-causal finding + node↔browser cell-horizontal parity),
  added a **both-tables-top-anchored** assertion, and a **characterization** of the
  residual (our auto table lands left of the exact table — the reverse of Word), so
  a future exclusion/reflow implementation trips this test and re-adjudicates.

## Verification
- docx package: **1361 tests pass**. Vertical node probes: **9 pass**
  (incl. the enhanced `docx-vertical-table-cells` probe).
- Root `pnpm typecheck`: **pass** (after building all three WASM parsers).
- docx demo VRT (`demo/sample-1`, isolated port to avoid the peer worktree on
  5180): **6/6 pass, non-regressive** (pages 4–6 exactly 0.0%). Private references
  (sample-26 0px, etc.) are gitignored/absent in this fresh worktree; the renderer
  change is comment-only so those pixels are byte-identical by construction.
- Browser (playwright Chromium, DocxViewer main + worker) confirmed cells horizontal.

Refs #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
