### PR TITLE
fix(core,docx,pptx,xlsx): geometric fallback for vertical colon/semicolon (#969)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -397,6 +397,7 @@ export {
   verticalOrientation,
   verticalFormSubstitute,
   verticalBracketFormSubstitute,
+  verticalTrUprightFallback,
   VO_UNICODE_VERSION,
 } from './text/vertical-orientation';
 export type { VerticalOrientation } from './text/vertical-orientation';

--- a/packages/core/src/text/vertical-orientation.test.ts
+++ b/packages/core/src/text/vertical-orientation.test.ts
@@ -3,6 +3,7 @@ import {
   verticalOrientation,
   verticalFormSubstitute,
   verticalBracketFormSubstitute,
+  verticalTrUprightFallback,
 } from './vertical-orientation.js';
 
 const cp = (ch: string): number => ch.codePointAt(0) ?? 0;
@@ -132,25 +133,40 @@ describe('verticalBracketFormSubstitute (UAX #50 Tr code points → U+FE1x/FE3x 
     expect(verticalBracketFormSubstitute(0x300f)).toBe(0xfe44); // 』 → ﹄
   });
 
-  it('maps the vo=Tr fullwidth colon/semicolon and white lenticular brackets to their U+FE1x form (issue #969)', () => {
-    // Word/PowerPoint ground truth (Yu Mincho tbRl + eaVert, PDF-adjudicated):
-    // these vo=Tr code points SUBSTITUTE their U+FE1x vertical presentation form
-    // and draw UPRIGHT — NOT the rotate fallback. The fullwidth colon/semicolon are
-    // vo=Tr punctuation (not brackets) but share the same substitute-first behaviour,
-    // so they live in this Tr map. FE13/FE14 decompose (UnicodeData `<vertical>`) to
-    // the ASCII 003A/003B; vertical Japanese carries the FULLWIDTH forms, so — like
-    // FE10 ← FF0C — the map keys on FF1A/FF1B. FE17/FE18 are the exact `<vertical>`
-    // inverses of the white lenticular brackets 3016/3017.
-    expect(verticalBracketFormSubstitute(0xff1a)).toBe(0xfe13); // ： → ︓ vertical colon
-    expect(verticalBracketFormSubstitute(0xff1b)).toBe(0xfe14); // ； → ︔ vertical semicolon
+  it('maps the vo=Tr white lenticular brackets to their U+FE1x form (issue #969)', () => {
+    // FE17/FE18 are the exact UnicodeData `<vertical>` inverses of the white
+    // lenticular brackets 3016/3017 and ARE present in the common substitute fonts,
+    // so they stay substituted and draw UPRIGHT.
     expect(verticalBracketFormSubstitute(0x3016)).toBe(0xfe17); // 〖 → ︗ vertical left white lenticular
     expect(verticalBracketFormSubstitute(0x3017)).toBe(0xfe18); // 〗 → ︘ vertical right white lenticular
+  });
+
+  it('does NOT substitute the fullwidth colon/semicolon (FE13/FE14 dropped, issue #969 follow-up)', () => {
+    // FE13/FE14 are absent from most render fonts (Hiragino Mincho ProN, macOS's Yu
+    // Mincho substitute) and a Canvas cannot invoke the font's `vert` feature, so
+    // substituting reached a mispositioned system-fallback glyph. The colon/semicolon
+    // now take a GEOMETRIC fallback in the renderers instead (see
+    // verticalTrUprightFallback): colon rotates (→ FE13's side-by-side dots),
+    // semicolon draws upright (→ FE14's dot-over-comma).
+    expect(verticalBracketFormSubstitute(0xff1a)).toBeNull(); // ： fullwidth colon
+    expect(verticalBracketFormSubstitute(0xff1b)).toBeNull(); // ； fullwidth semicolon
   });
 
   it('returns null for Tr code points with no U+FE30 vertical form (ー, quotes)', () => {
     expect(verticalBracketFormSubstitute(0x30fc)).toBeNull(); // ー prolonged sound mark
     expect(verticalBracketFormSubstitute(0x201c)).toBeNull(); // “ left double quote
     expect(verticalBracketFormSubstitute(0x201d)).toBeNull(); // ” right double quote
+  });
+
+  it('verticalTrUprightFallback: only the fullwidth semicolon takes the UPRIGHT Tr fallback', () => {
+    // ；(FF1B) → FE14 is an upright dot-over-comma, NOT a rotation of the base, so its
+    // no-vertical-form fallback is UPRIGHT (Word/JIS-verified). Everything else that
+    // rotates — colon ：, ー, quotes, un-substituted brackets — returns false.
+    expect(verticalTrUprightFallback(0xff1b)).toBe(true); // ；
+    expect(verticalTrUprightFallback(0xff1a)).toBe(false); // ： (rotates → FE13 dots)
+    expect(verticalTrUprightFallback(0x30fc)).toBe(false); // ー
+    expect(verticalTrUprightFallback(0x300c)).toBe(false); // 「 (substituted, not fallback)
+    expect(verticalTrUprightFallback(cp('漢'))).toBe(false); // ideograph
   });
 
   it('returns null for non-bracket code points (Tu punctuation, ideographs, Latin)', () => {

--- a/packages/core/src/text/vertical-orientation.ts
+++ b/packages/core/src/text/vertical-orientation.ts
@@ -91,10 +91,12 @@ export function verticalOrientation(cp: number): VerticalOrientation {
  *     (Hiragino ink at +0.31em cross-axis), so substituting them pushed ！／？ to
  *     the right of the column — the sample-26 "！ shifted right" defect (#771).
  *     PDF ground truth: Word centres ！ (+0.03em), matching the upright original.
- *   • ：FF1A / ；FF1B and 〖3016 / 〗3017 are vo=Tr, so their vertical forms
- *     (FE13/FE14/FE17/FE18) live in {@link verticalBracketFormSubstitute} (the Tr
- *     map), NOT here — the Tr draw branch consults that map, and this Tu-only map
- *     stays null for them (issue #969, following #790 / #771).
+ *   • ：FF1A / ；FF1B and 〖3016 / 〗3017 are vo=Tr, not Tu, so this Tu-only map
+ *     stays null for them. The white lenticular brackets 〖〗 (→ FE17/FE18) are
+ *     substituted via {@link verticalBracketFormSubstitute}; the fullwidth colon /
+ *     semicolon take a GEOMETRIC fallback in the renderers (their FE13/FE14 forms
+ *     are absent from most render fonts — see {@link verticalTrUprightFallback}),
+ *     issue #969, following #790 / #771.
  *   • … U+2026 is vo=R — the sideways branch rotates it 90° with the page, so
  *     its three dots already stack vertically, visually equivalent to Word's
  *     vertical ellipsis; no substitution is needed.
@@ -141,18 +143,22 @@ const VERTICAL_FORM_MAP: ReadonlyMap<number, number> = new Map<number, number>([
  * Covers, keyed by their horizontal form:
  *   • the fullwidth parens / corner / angle / brace / tortoise-shell / black-
  *     lenticular brackets → U+FE35–U+FE44 ("Presentation Forms For Vertical");
- *   • the fullwidth colon ： / semicolon ； and the WHITE lenticular brackets 〖〗
- *     → U+FE13/FE14/FE17/FE18 (the U+FE1x "Vertical Forms" block, issue #969).
- *     The colon/semicolon are vo=Tr PUNCTUATION, not brackets, but they share the
- *     substitute-first / rotate-fallback behaviour this map encodes, so they live
- *     here. Word and PowerPoint substitute all four upright (PDF-adjudicated).
+ *   • the WHITE lenticular brackets 〖〗 → U+FE17/FE18 (the U+FE1x "Vertical Forms"
+ *     block, issue #969), which the common substitute fonts DO contain.
+ *
+ * NOTE: the fullwidth colon ： / semicolon ； (→ FE13/FE14) were REMOVED from this
+ * map (issue #969 follow-up). Those forms are absent from most render fonts and a
+ * Canvas cannot invoke the font's `vert` feature, so substituting reached a
+ * mispositioned system-fallback glyph. They now take a GEOMETRIC fallback in the
+ * renderers (colon rotate, semicolon upright per {@link verticalTrUprightFallback}).
  *
  * WHY this is separate from {@link verticalFormSubstitute} (the Tu map): the two
  * fallbacks differ. A Tu code point with no vertical form draws UPRIGHT; a Tr
  * one ROTATES. Keeping the maps distinct lets each draw branch pick the right
  * fallback (see the docx renderer's `drawVerticalRun`) without conflating the
  * two UAX #50 transform classes. (The name says "Bracket" for its original scope;
- * it is really "the vo=Tr vertical-form map" — brackets plus ：；.)
+ * it is really "the vo=Tr vertical-form map" — brackets plus the white lenticular
+ * 〖〗. The fullwidth colon/semicolon were removed — see the NOTE above.)
  *
  * WHY substitute a Tr bracket at all: UAX #50 §5 defines the Tr transform as
  * "substitute a vertical glyph variant; ROTATE only as the fallback when none is
@@ -175,9 +181,7 @@ const VERTICAL_FORM_MAP: ReadonlyMap<number, number> = new Map<number, number>([
  *
  * Mapping source: the UnicodeData.txt `<vertical>` compatibility decompositions
  * of the U+FE10 and U+FE30 blocks (each vertical form decomposes to its horizontal
- * source). FE17/FE18 decompose exactly to 〖/〗; FE13/FE14 decompose to the ASCII
- * colon/semicolon, but vertical Japanese carries the fullwidth forms, so the map
- * keys on FF1A/FF1B (as verticalFormSubstitute keys FE10 on FF0C).
+ * source). FE17/FE18 decompose exactly to 〖/〗.
  *
  * Renderers apply this ONLY at glyph-draw time (glyph selection): the advance/
  * width, text model, selection, and find/highlight all keep the ORIGINAL code
@@ -199,19 +203,19 @@ export function verticalBracketFormSubstitute(cp: number): number | null {
 // group is punctuation, not brackets:
 //   1. Fullwidth brackets / parens / braces → U+FE35–FE44 ("Presentation Forms For
 //      Vertical" block). Keyed on the horizontal bracket.
-//   2. The fullwidth colon / semicolon ：； and the white lenticular brackets 〖〗
-//      → the U+FE13/FE14/FE17/FE18 forms in the U+FE1x "Vertical Forms" block
-//      (issue #969). Word and PowerPoint substitute these upright too (Yu Mincho
-//      tbRl + eaVert, PDF-adjudicated): the colon becomes two side-by-side dots
-//      (FE13 — which *looks* rotated but is the vertical form), the semicolon stays
-//      an upright dot-over-comma (FE14 — a 90° rotation could never produce that,
-//      proving substitution), and the lenticular brackets become horizontal bracket
-//      forms (FE17/FE18). FE13/FE14 decompose to the ASCII colon/semicolon
-//      (003A/003B); vertical Japanese carries the FULLWIDTH forms, so — exactly like
-//      FE10 ← FF0C in verticalFormSubstitute — the map keys on FF1A/FF1B.
+//   2. The white lenticular brackets 〖〗 → the U+FE17/FE18 forms in the U+FE1x
+//      "Vertical Forms" block (issue #969), which the common substitute fonts DO
+//      contain, so they stay substituted upright (PDF-adjudicated). The fullwidth
+//      colon / semicolon ：；(→ FE13/FE14) were REMOVED — those forms are absent
+//      from most render fonts, so they take a geometric fallback in the renderers
+//      instead (colon rotate → FE13's side-by-side dots, semicolon upright → FE14's
+//      dot-over-comma; see verticalTrUprightFallback). FE17/FE18 decompose to
+//      the white lenticular brackets 3016/3017 exactly.
 //
 // ー (30FC) and the double quotes (201C/201D) are vo=Tr with NO vertical form and are
-// absent, so the renderer rotates them.
+// absent, so the renderer rotates them. The fullwidth colon ：(FF1A) rotates too
+// (→ FE13's side-by-side dots); the semicolon ；(FF1B) is upright (→ FE14) — see
+// verticalTrUprightFallback.
 const VERTICAL_BRACKET_FORM_MAP: ReadonlyMap<number, number> = new Map<number, number>([
   [0xff08, 0xfe35], // （ fullwidth left parenthesis  → ︵
   [0xff09, 0xfe36], // ） fullwidth right parenthesis → ︶
@@ -229,9 +233,48 @@ const VERTICAL_BRACKET_FORM_MAP: ReadonlyMap<number, number> = new Map<number, n
   [0x300d, 0xfe42], // 」 right corner bracket         → ﹂
   [0x300e, 0xfe43], // 『 left white corner bracket    → ﹃
   [0x300f, 0xfe44], // 』 right white corner bracket   → ﹄
-  // vo=Tr punctuation + white lenticular brackets in the U+FE1x block (issue #969).
-  [0xff1a, 0xfe13], // ： fullwidth colon              → ︓ vertical colon
-  [0xff1b, 0xfe14], // ； fullwidth semicolon          → ︔ vertical semicolon
+  // vo=Tr white lenticular brackets in the U+FE1x block (issue #969). The
+  // fullwidth colon ： / semicolon ； (→ FE13/FE14) were REMOVED here (issue #969
+  // follow-up): their U+FE13/FE14 forms are absent from most render fonts
+  // (e.g. Hiragino Mincho ProN, macOS's Yu Mincho substitute) and a Canvas
+  // cannot reach the font's `vert` OpenType feature, so substituting the code
+  // point reaches the system fallback cascade and paints a DIFFERENT font's glyph
+  // positioned wrong (measured: FE13/FE14 ink lands ~0.25em RIGHT of the column
+  // centre in both skia AND Chrome). They now take a GEOMETRIC fallback that
+  // reproduces each vertical form's design directly — colon rotates (→ FE13's
+  // side-by-side dots), semicolon stays upright (→ FE14's dot-over-comma). See
+  // {@link verticalTrUprightFallback}. The white lenticular brackets FE17/FE18
+  // ARE present in the substitute font, so they stay substituted.
   [0x3016, 0xfe17], // 〖 left white lenticular        → ︗ vertical left white lenticular
   [0x3017, 0xfe18], // 〗 right white lenticular       → ︘ vertical right white lenticular
 ]);
+
+// The vo=Tr code points whose no-vertical-form rotate fallback must be OVERRIDDEN
+// to UPRIGHT. This is an APPLICATION-LEVEL layout override, not the normative UAX
+// #50 Tr fallback (which is rotation): Vertical_Orientation is an informative
+// property that a layout application may override, and Word does here. The fullwidth
+// semicolon ；(FF1B) is the sole member: its Unicode vertical form FE14 (︔) is a
+// dot-over-comma drawn UPRIGHT, NOT a rotation of the base — Word/JIS X 4051 verified
+// (sample-47 PDF: ；renders as a vertical dot+comma centred on the column, whereas a
+// 90° rotation would put the comma and dot side by side). The colon ：(FF1A) is NOT
+// here: FE13 (︓) IS a 90° rotation of the base (two dots that go from vertically
+// stacked to side by side), so the generic Tr rotate fallback reproduces it. ASCII
+// `;` (003B) is vo=R (Latin), so only the fullwidth form participates.
+const VERTICAL_TR_UPRIGHT_FALLBACK: ReadonlySet<number> = new Set<number>([
+  0xff1b, // ； fullwidth semicolon → FE14 design is upright dot-over-comma
+]);
+
+/**
+ * True when a vo=Tr code point with NO substituted vertical form should take an
+ * UPRIGHT fallback rather than the generic ROTATE fallback. Only the fullwidth
+ * semicolon ；(FF1B) qualifies (its FE14 vertical form is upright dot-over-comma,
+ * not a rotation). All other rotate-fallback Tr code points — the colon ：, ー,
+ * quotes, un-substituted brackets — return false and rotate. This is an
+ * application-level override of the informative UAX #50 property (Word behaviour),
+ * not the normative Tr fallback (rotation).
+ *
+ * @param cp A Unicode scalar value.
+ */
+export function verticalTrUprightFallback(cp: number): boolean {
+  return VERTICAL_TR_UPRIGHT_FALLBACK.has(cp);
+}

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -268,18 +268,25 @@ describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin side
     expect(fills.every((f) => f.x === 0 && f.y === 0)).toBe(true);
   });
 
-  it('substitutes the vo=Tr colon/semicolon and white lenticular brackets, drawn UPRIGHT (issue #969)', () => {
-    // Word/PowerPoint ground truth (PDF-adjudicated): ：；〖〗 are vo=Tr with a
-    // U+FE1x vertical form, so they substitute-first and draw upright like the other
-    // brackets — NOT the rotate fallback (the semicolon staying an upright dot-over-
-    // comma is the proof; a rotation could not produce that).
+  it('gives the colon/semicolon a geometric fallback and substitutes the lenticular brackets (issue #969)', () => {
+    // FE13/FE14 (vertical colon/semicolon) are absent from most render fonts and a
+    // Canvas cannot invoke the font's `vert` feature, so unconditional substitution
+    // reached a mispositioned system-fallback glyph. They now take a GEOMETRIC
+    // fallback that reproduces each vertical form's design directly (Word-verified):
+    //   • colon ： → ROTATE (drawn as-is in the +90° page frame → FE13's side-by-side
+    //     dots); no local counter-rotation.
+    //   • semicolon ； → UPRIGHT (counter-rotated −90° → FE14's dot-over-comma; a
+    //     rotation could not produce that).
+    // The white lenticular brackets 〖〗 keep their FE17/FE18 substitute (present in
+    // the substitute fonts), drawn upright.
     const { ctx, ops } = mockCtx();
     drawVerticalRun(ctx, '：；〖〗', 0, 0, 12, 0);
     const fills = ops.filter((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
-    expect(fills.map((f) => f.text)).toEqual(['︓', '︔', '︗', '︘']); // FE13/FE14/FE17/FE18
-    // All four are counter-rotated −90° (upright), centred on the column.
+    expect(fills.map((f) => f.text)).toEqual(['：', '；', '︗', '︘']); // colon/semicolon base; FE17/FE18
+    // Counter-rotations (−90°, upright): semicolon + both lenticular brackets = 3;
+    // the colon is NOT counter-rotated (it rides the +90° page rotation).
     const rotates = ops.filter((o): o is Extract<Op, { op: 'rotate' }> => o.op === 'rotate');
-    expect(rotates).toHaveLength(4);
+    expect(rotates).toHaveLength(3);
     expect(rotates.every((r) => Math.abs(r.a - -Math.PI / 2) < 1e-9)).toBe(true);
     expect(fills.every((f) => f.align === 'center' && f.baseline === 'middle')).toBe(true);
   });

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -22,15 +22,18 @@
 //     corner-designed in many fonts and would shift ！？ off-column). Where no
 //     form exists (．, small kana) we draw the original upright unchanged (．
 //     keeps a corner-nudge fallback).
-//   • vo=Tr (transform, fallback rotate): the fullwidth brackets （「」〈〉【】…, the
-//     white lenticular brackets 〖〗, and the fullwidth colon/semicolon ：； have a
-//     U+FE1x/FE3x vertical presentation form (core `verticalBracketFormSubstitute`);
+//   • vo=Tr (transform, fallback rotate): the fullwidth brackets （「」〈〉【】… and
+//     the white lenticular brackets 〖〗 have a U+FE1x/FE3x vertical presentation
+//     form (core `verticalBracketFormSubstitute`) present in the substitute fonts;
 //     UAX#50 §5 makes Tr "substitute a vertical glyph, ROTATE only as fallback", so
-//     we SUBSTITUTE and draw them upright (Word/PowerPoint-verified, #969). Only Tr
-//     code points with NO vertical form — the ー prolonged sound mark and the quotes
-//     “” — take the ROTATE fallback: a plain `fillText` in the +90° page frame is
-//     already that 90° CW rotation, drawn CENTRED on the column axis so ー sits
-//     mid-column.
+//     we SUBSTITUTE and draw them upright (Word/PowerPoint-verified, #969). Tr code
+//     points with NO substituted form take a geometric fallback: ROTATE — the ー
+//     prolonged sound mark, the quotes “”, and the fullwidth colon ：(whose FE13
+//     form is absent from most render fonts, so a 90° rotation of the base reproduces
+//     FE13's side-by-side dots) — drawn CENTRED on the column axis via a plain
+//     `fillText` in the +90° page frame; or UPRIGHT — the fullwidth semicolon ；,
+//     whose FE14 form is an upright dot-over-comma, not a rotation (issue #969
+//     follow-up; see core `verticalTrUprightFallback`).
 //   • vo=R  (rotated): Latin letters, Western digits, Latin punctuation. Stay
 //     SIDEWAYS (rotated with the page) — the conventional "縦中横 not applied"
 //     appearance — drawn as an ordinary contextual `fillText` at the alphabetic
@@ -56,6 +59,7 @@ import {
   verticalOrientation,
   verticalFormSubstitute,
   verticalBracketFormSubstitute,
+  verticalTrUprightFallback,
 } from '@silurus/ooxml-core';
 
 /** How a code point is painted inside the +90°-rotated vertical page:
@@ -290,13 +294,22 @@ export function drawVerticalRun(
     // Advance/width uses the ORIGINAL code point (measure == draw, and the text
     // model / selection / find keep the original character — see the module doc).
     const adv = ctx.measureText(ch).width * charScale + letterSpacingPx;
-    // A vo=Tr code point with a Unicode vertical presentation form — the brackets
-    // （）「」〈〉… and the colon/semicolon/white-lenticular ：；〖〗 (#969) — is
-    // SUBSTITUTED and drawn upright, exactly like the upright cells — UAX#50 §5
-    // Tr means "substitute a vertical glyph; rotate only as fallback". Only Tr
-    // code points with NO vertical form (ー, quotes “”) keep the rotate fallback.
+    // A vo=Tr code point with a substituted Unicode vertical presentation form — the
+    // brackets （）「」〈〉… and the white lenticular 〖〗 (#969) — is SUBSTITUTED and
+    // drawn upright, exactly like the upright cells — UAX#50 §5 Tr means "substitute a
+    // vertical glyph; rotate only as fallback". Tr code points with NO substituted form
+    // (ー, quotes “”, and the colon ：/ semicolon ；whose FE13/FE14 forms are absent
+    // from most render fonts) take a geometric fallback below (rotate, or — for ；—
+    // upright).
     const bracketCp = mode === 'rotate' ? verticalBracketFormSubstitute(cp) : null;
-    if (mode === 'upright' || bracketCp !== null) {
+    // A vo=Tr code point with NO substituted vertical form whose fallback is
+    // UPRIGHT rather than the generic UAX#50 §5 ROTATE — the fullwidth semicolon
+    // ；(FF1B), whose FE14 vertical form is an upright dot-over-comma, not a
+    // rotation (Word-verified, issue #969 follow-up). It draws upright exactly
+    // like the vo=U / vo=Tu cells; the colon ：is NOT here (its FE13 form IS a 90°
+    // rotation, so it takes the rotate branch below → side-by-side dots).
+    const uprightFallback = mode === 'rotate' && bracketCp === null && verticalTrUprightFallback(cp);
+    if (mode === 'upright' || bracketCp !== null || uprightFallback) {
       // vo=U / Tu, or a substituted Tr bracket. Counter-rotate −90° about the
       // cell centre so the glyph (which the page rotation would otherwise lay on
       // its side) stands upright. For corner-hanging Tu punctuation with a Unicode
@@ -350,12 +363,15 @@ export function drawVerticalRun(
       ctx.fillText(drawStr, off.dx * fontPx, (alongEm + off.dy) * fontPx);
       ctx.restore();
     } else if (mode === 'rotate') {
-      // vo=Tr with NO vertical form: ー (U+30FC) and the double quotes “”. UAX#50's
-      // Tr fallback (no vertical glyph reachable on a Canvas) is to ROTATE the
-      // glyph 90° CW. A plain `fillText` in the +90° page frame IS that rotation;
-      // centre it on the column with `center`/`middle` at the cell centre. (The
-      // bracket forms never reach here — they were substituted and drawn upright
-      // above; a rotated bracket's ink offset is not measurable from a Canvas.)
+      // vo=Tr with NO substituted vertical form and NOT the upright-fallback
+      // semicolon: ー (U+30FC), the double quotes “”, and the fullwidth colon ：
+      // (FF1A). UAX#50's Tr fallback (no vertical glyph reachable on a Canvas) is
+      // to ROTATE the glyph 90° CW. A plain `fillText` in the +90° page frame IS
+      // that rotation; centre it on the column with `center`/`middle` at the cell
+      // centre. For the colon this reproduces FE13's design directly (the two
+      // vertically-stacked dots become side by side), Word-verified (issue #969
+      // follow-up). (The substituted bracket forms never reach here — they were
+      // drawn upright above; a rotated bracket's ink offset is not Canvas-measurable.)
       const cx = x + ax + adv / 2;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';

--- a/packages/node/src/docx-vertical-punct-forms.probe.test.ts
+++ b/packages/node/src/docx-vertical-punct-forms.probe.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Vertical (tbRl) colon `：` / semicolon `；` form probe — ECMA-376 §17.6.20 +
+ * UAX#50 §5, issue #969 follow-up.
+ *
+ * Both `：`(FF1A) and `；`(FF1B) are vo=Tr. The Unicode vertical presentation
+ * forms are FE13 (︓) and FE14 (︔), but MOST render fonts (Hiragino Mincho ProN,
+ * which macOS substitutes for the sample's Yu Mincho) do NOT contain FE13/FE14,
+ * and a Canvas cannot reach the font's `vert` OpenType feature. Unconditionally
+ * substituting the FE code point therefore reaches the system fallback cascade,
+ * which supplies a DIFFERENT font's glyph positioned wrong (measured: FE13/FE14
+ * ink lands ~0.25em to the RIGHT of the column centre in both skia AND Chrome).
+ *
+ * Word ground truth (sample-47 PDF, macOS Quartz):
+ *   • `：` renders as two dots SIDE BY SIDE (horizontal), centred on the column —
+ *     which is the base `：` (two vertically-stacked dots) ROTATED 90°, and is
+ *     FE13's intrinsic design.
+ *   • `；` renders as dot-over-comma VERTICAL (upright), centred — which is the
+ *     base `；` drawn UPRIGHT, and is FE14's intrinsic design (NOT a rotation).
+ *
+ * So the correct, font-robust rendering is a GEOMETRIC fallback that reproduces
+ * each vertical form's design directly: colon → rotate, semicolon → upright.
+ * This probe measures the rendered ink through the REAL `drawVerticalRun` and
+ * asserts each mark is (a) centred on the column centreline (cross-axis) and
+ * (b) has the right orientation (colon wider-than-tall, semicolon taller-than-wide).
+ *
+ * CI-safe: gated on skia (devDependency) + Hiragino (macOS dev host).
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { loadSkiaForTests, importForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, FontLibrary } = (skia ?? {}) as Skia;
+const MINCHO = '/System/Library/Fonts/ヒラギノ明朝 ProN.ttc';
+const haveFont = existsSync(MINCHO);
+const vtMod = await importForTests(
+  () => import('../../docx/src/vertical-text.ts'),
+  'packages/docx/src/vertical-text.ts',
+);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+function ink(data: Uint8ClampedArray, i: number): number {
+  return 255 - (0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2]);
+}
+
+describe.skipIf(!skia || !vtMod || !haveFont)('docx vertical colon/semicolon forms (§17.6.20 / UAX#50)', () => {
+  const fontPx = 48;
+  const W = 300, H = 300, baseline = 150, logX = 40, cellW = fontPx;
+  const centerline = W - baseline; // column centreline in physical x
+
+  /** Render "話X話" via drawVerticalRun and return the pixel buffer. */
+  function render(mid: string): Uint8ClampedArray {
+    const { drawVerticalRun } = vtMod as { drawVerticalRun: (...a: Any[]) => void };
+    for (const fam of ['Yu Mincho', 'MS Mincho', 'Hiragino Mincho ProN']) FontLibrary.use(fam, [MINCHO]);
+    const canvas = new Canvas(W, H);
+    const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+    ctx.fillStyle = '#fff'; ctx.fillRect(0, 0, W, H);
+    ctx.fillStyle = '#000';
+    ctx.font = `${fontPx}px "MS Mincho", serif`;
+    ctx.save();
+    ctx.translate(W, 0); ctx.rotate(Math.PI / 2);
+    drawVerticalRun(ctx, `話${mid}話`, logX, baseline, fontPx, 0);
+    ctx.restore();
+    return ctx.getImageData(0, 0, W, H).data;
+  }
+
+  /** Ink bbox + cross-axis centroid of the middle cell (2nd glyph, physical y band). */
+  function midCell(data: Uint8ClampedArray): { cx: number; bw: number; bh: number } {
+    const py0 = logX + cellW, py1 = logX + 2 * cellW; // 2nd cell along the column
+    let sx = 0, sw = 0, x0 = W, x1 = 0, y0 = H, y1 = 0;
+    for (let py = py0; py < py1; py++) for (let px = 0; px < W; px++) {
+      const w = ink(data, (py * W + px) * 4);
+      if (w > 40) { sx += px * w; sw += w; if (px < x0) x0 = px; if (px > x1) x1 = px; if (py < y0) y0 = py; if (py > y1) y1 = py; }
+    }
+    return { cx: sw > 0 ? sx / sw : NaN, bw: x1 - x0, bh: y1 - y0 };
+  }
+
+  it('colon ： is centred on the column and renders horizontal (wider than tall)', () => {
+    const m = midCell(render('：'));
+    // Centred on the column centreline (cross-axis), within 0.1em.
+    expect(Math.abs(m.cx - centerline)).toBeLessThanOrEqual(0.1 * fontPx);
+    // Two dots SIDE BY SIDE ⇒ cross-axis extent (bw) > along-column extent (bh).
+    expect(m.bw).toBeGreaterThan(m.bh);
+  });
+
+  it('semicolon ； is centred on the column and renders upright (taller than wide)', () => {
+    const m = midCell(render('；'));
+    expect(Math.abs(m.cx - centerline)).toBeLessThanOrEqual(0.1 * fontPx);
+    // Dot-over-comma stacked VERTICALLY ⇒ along-column extent (bh) > cross (bw).
+    expect(m.bh).toBeGreaterThan(m.bw);
+  });
+});

--- a/packages/pptx/src/eavert-glyph-orientation.test.ts
+++ b/packages/pptx/src/eavert-glyph-orientation.test.ts
@@ -38,10 +38,11 @@ const TR_BRACKET_FE = String.fromCodePoint(0xfe35); // ︵
 const TU_COMMA = '、'; // vo=Tu → substitute U+FE11, upright
 const TU_COMMA_FE = String.fromCodePoint(0xfe11);
 const TR_ROTATE = 'ー'; // vo=Tr, no vertical form → rotate 90°
-// vo=Tr punctuation / white lenticular brackets with a U+FE1x form (issue #969).
+// vo=Tr white lenticular brackets with a U+FE1x form present in the substitute
+// fonts (issue #969) — still substituted upright. The fullwidth colon ： /
+// semicolon ； (FE13/FE14) were dropped from the substitute map (absent in most
+// render fonts) and take a geometric fallback instead — see their own tests below.
 const TR_VFORMS: Array<[string, string]> = [
-  ['：', String.fromCodePoint(0xfe13)], // fullwidth colon → ︓
-  ['；', String.fromCodePoint(0xfe14)], // fullwidth semicolon → ︔
   ['〖', String.fromCodePoint(0xfe17)], // left white lenticular → ︗
   ['〗', String.fromCodePoint(0xfe18)], // right white lenticular → ︘
 ];
@@ -186,7 +187,7 @@ describe('pptx eaVert — UAX#50 per-glyph orientation (§20.1.10.83, issue #790
   });
 
   it.each(TR_VFORMS)(
-    'SUBSTITUTES the vo=Tr colon/semicolon/lenticular %s with its U+FE1x vertical form, drawn upright (issue #969)',
+    'SUBSTITUTES the vo=Tr white lenticular %s with its U+FE1x vertical form, drawn upright (issue #969)',
     (orig, fe) => {
       const calls = renderEaVert(orig);
       expect(calls.some((c) => c.text === orig), `original ${orig} is not painted`).toBe(false);
@@ -195,6 +196,25 @@ describe('pptx eaVert — UAX#50 per-glyph orientation (§20.1.10.83, issue #790
       expect(norm(sub[0].rot), 'substituted form is upright').toBeCloseTo(UPRIGHT, 5);
     },
   );
+
+  it('ROTATES the vo=Tr colon ： (geometric fallback → FE13 side-by-side dots) (issue #969)', () => {
+    // FE13 is absent from most render fonts, so the colon is NOT substituted; it
+    // rotates with the page like ー — a 90° rotation turns the base ：'s two
+    // vertically-stacked dots into FE13's side-by-side dots (Word-verified).
+    const calls = renderEaVert('：');
+    const mark = calls.filter((c) => c.text === '：');
+    expect(mark.length, '： is painted as its own glyph (not substituted)').toBe(1);
+    expect(norm(mark[0].rot), '： rotates 90° (the Tr fallback)').toBeCloseTo(SIDEWAYS, 5);
+  });
+
+  it('draws the vo=Tr semicolon ； UPRIGHT (geometric fallback → FE14 dot-over-comma) (issue #969)', () => {
+    // FE14 is an upright dot-over-comma, NOT a rotation, so the semicolon's fallback
+    // is UPRIGHT (Word/JIS-verified) rather than the generic Tr rotate.
+    const calls = renderEaVert('；');
+    const mark = calls.filter((c) => c.text === '；');
+    expect(mark.length, '； is painted as its own glyph (not substituted)').toBe(1);
+    expect(norm(mark[0].rot), '； stays upright (the FE14 fallback)').toBeCloseTo(UPRIGHT, 5);
+  });
 
   it('ROTATES a vo=Tr glyph with no vertical form (ー U+30FC) with the page (+90°)', () => {
     const calls = renderEaVert(TR_ROTATE);

--- a/packages/pptx/src/vertical-text.ts
+++ b/packages/pptx/src/vertical-text.ts
@@ -17,13 +17,16 @@
 //     `verticalFormSubstitute`) and drawn upright, so the font supplies the
 //     designed upper-right placement; ！？ and small kana have no form and draw
 //     upright unchanged.
-//   • vo=Tr (transform, fallback rotate): the fullwidth brackets （「」〈〉【】…, the
-//     white lenticular brackets 〖〗, and the fullwidth colon/semicolon ：； have a
-//     U+FE1x/FE3x vertical presentation form (core `verticalBracketFormSubstitute`);
+//   • vo=Tr (transform, fallback rotate): the fullwidth brackets （「」〈〉【】… and
+//     the white lenticular brackets 〖〗 have a U+FE1x/FE3x vertical presentation
+//     form (core `verticalBracketFormSubstitute`) present in the substitute fonts;
 //     UAX#50 §5 makes Tr "substitute a vertical glyph, ROTATE only as fallback", so
-//     we substitute and draw them upright (Word/PowerPoint-verified, #969). The
-//     prolonged sound mark ー (U+30FC) and the quotation marks “” have no vertical
-//     form, so they take the rotate fallback (drawn with the page).
+//     we substitute and draw them upright (Word/PowerPoint-verified, #969). Tr code
+//     points with no substituted form take a geometric fallback: ROTATE (the ー
+//     prolonged sound mark, the quotes “”, and the colon ：→ FE13's side-by-side
+//     dots) or UPRIGHT (the semicolon ；→ FE14's dot-over-comma; issue #969
+//     follow-up, core `verticalTrUprightFallback`) — FE13/FE14 are absent from most
+//     render fonts, so those two take the geometric path.
 //   • vo=R  (rotated): Latin letters, Western digits, Latin punctuation stay
 //     SIDEWAYS (rotated with the page) — the conventional "縦中横 not applied" look.
 //
@@ -37,6 +40,7 @@ import {
   verticalOrientation,
   verticalFormSubstitute,
   verticalBracketFormSubstitute,
+  verticalTrUprightFallback,
 } from '@silurus/ooxml-core';
 
 type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
@@ -143,11 +147,15 @@ export function drawEaVertRun(
     // selection and find keep the original character — substitution is glyph-only).
     const adv = ctx.measureText(ch).width + letterSpacingPx;
     // A vo=Tr code point with a Unicode vertical presentation form — brackets （「」…
-    // and the colon/semicolon/white-lenticular ：；〖〗 (#969) — is substituted and
-    // drawn UPRIGHT (UAX#50 §5 substitute-first); only Tr code points with NO form
-    // (ー, quotes) take the rotate fallback.
+    // and the white-lenticular 〖〗 (#969) — is substituted and drawn UPRIGHT
+    // (UAX#50 §5 substitute-first). Tr code points with NO substituted form take a
+    // fallback: ROTATE (ー, quotes, colon ： → FE13's side-by-side dots) or, for the
+    // semicolon ；(FF1B), UPRIGHT (its FE14 form is upright dot-over-comma, not a
+    // rotation). The colon/semicolon FE13/FE14 substitution was dropped in core —
+    // those forms are absent from most render fonts (issue #969 follow-up).
     const bracketCp = vo === 'Tr' ? verticalBracketFormSubstitute(cp) : null;
-    const upright = vo === 'U' || vo === 'Tu' || bracketCp !== null;
+    const uprightFallback = vo === 'Tr' && bracketCp === null && verticalTrUprightFallback(cp);
+    const upright = vo === 'U' || vo === 'Tu' || bracketCp !== null || uprightFallback;
     if (upright) {
       // vo=U / vo=Tu, or a substituted Tr bracket. Counter-rotate −90° about the
       // cell centre so the glyph (which the page rotation would lay on its side)
@@ -173,9 +181,11 @@ export function drawEaVertRun(
       draw(drawStr, 0, alongEm * fontPx);
       ctx.restore();
     } else if (vo === 'Tr') {
-      // vo=Tr with NO vertical form (ー U+30FC, quotes “”). The Tr fallback is to
-      // ROTATE 90° CW — a plain draw in the +90° page frame IS that rotation; centre
-      // it on the column with `center`/`middle` at the cell centre.
+      // vo=Tr with NO substituted vertical form and NOT the upright-fallback
+      // semicolon: ー (U+30FC), quotes “”, and the colon ：(FF1A). The Tr fallback is
+      // to ROTATE 90° CW — a plain draw in the +90° page frame IS that rotation;
+      // centre it on the column. For the colon this reproduces FE13's design (the
+      // vertically-stacked dots become side by side), Word-verified (issue #969).
       const cx = x + ax + adv / 2;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';

--- a/packages/xlsx/src/stacked-glyph-orientation.test.ts
+++ b/packages/xlsx/src/stacked-glyph-orientation.test.ts
@@ -32,12 +32,12 @@ const TR_BRACKET_FE = String.fromCodePoint(0xfe35); // ︵
 const TU_COMMA = '、';
 const TU_COMMA_FE = String.fromCodePoint(0xfe11);
 const TR_ROTATE = 'ー'; // U+30FC — no vertical form → rotate
-// vo=Tr punctuation / white lenticular brackets with a U+FE1x form (issue #969).
-// XLSX has no Excel ground-truth image; it follows the Word/PowerPoint verdict
-// (docx tbRl + pptx eaVert, PDF-adjudicated) since the classifier is shared.
+// vo=Tr white lenticular brackets with a U+FE1x form present in the substitute
+// fonts (issue #969) — still substituted upright. XLSX has no Excel ground-truth
+// image; it follows the Word/PowerPoint verdict since the classifier is shared.
+// The fullwidth colon ： / semicolon ； (FE13/FE14) were dropped from the substitute
+// map (absent in most render fonts) and take a geometric fallback — see below.
 const TR_VFORMS: Array<[string, string]> = [
-  ['：', String.fromCodePoint(0xfe13)], // fullwidth colon → ︓
-  ['；', String.fromCodePoint(0xfe14)], // fullwidth semicolon → ︔
   ['〖', String.fromCodePoint(0xfe17)], // left white lenticular → ︗
   ['〗', String.fromCodePoint(0xfe18)], // right white lenticular → ︘
 ];
@@ -117,7 +117,7 @@ describe('xlsx stacked text — UAX#50 per-glyph orientation (textRotation=255, 
   });
 
   it.each(TR_VFORMS)(
-    'SUBSTITUTES the vo=Tr colon/semicolon/lenticular %s with its U+FE1x vertical form, upright (issue #969)',
+    'SUBSTITUTES the vo=Tr white lenticular %s with its U+FE1x vertical form, upright (issue #969)',
     (orig, fe) => {
       const calls = draw(orig);
       expect(calls.length).toBe(1);
@@ -125,6 +125,24 @@ describe('xlsx stacked text — UAX#50 per-glyph orientation (textRotation=255, 
       expect(norm(calls[0].rot)).toBeCloseTo(UPRIGHT, 5);
     },
   );
+
+  it('ROTATES the vo=Tr colon ： (geometric fallback → FE13 side-by-side dots) (issue #969)', () => {
+    // FE13 is absent from most render fonts, so ：is not substituted; a 90° rotation
+    // turns its two vertically-stacked dots into FE13's side-by-side dots.
+    const calls = draw('：');
+    expect(calls.length).toBe(1);
+    expect(calls[0].text, '： is painted as its own glyph').toBe('：');
+    expect(norm(calls[0].rot), '： rotates 90°').toBeCloseTo(ROTATED, 5);
+  });
+
+  it('draws the vo=Tr semicolon ； UPRIGHT (geometric fallback → FE14 dot-over-comma) (issue #969)', () => {
+    // FE14 is an upright dot-over-comma (not a rotation), so ；draws upright like an
+    // ideograph rather than rotating.
+    const calls = draw('；');
+    expect(calls.length).toBe(1);
+    expect(calls[0].text, '； is painted as its own glyph').toBe('；');
+    expect(norm(calls[0].rot), '； stays upright').toBeCloseTo(UPRIGHT, 5);
+  });
 
   it('ROTATES a vo=Tr glyph with no vertical form (ー) by 90°', () => {
     const calls = draw(TR_ROTATE);

--- a/packages/xlsx/src/vertical-text.ts
+++ b/packages/xlsx/src/vertical-text.ts
@@ -13,18 +13,23 @@
 //   • vo=Tu with a U+FE10–FE12 vertical form (、。，) → SUBSTITUTE that form
 //     (core `verticalFormSubstitute`), drawn upright so the font hangs it in the
 //     cell's upper-right corner; ！？ and small kana have no form and draw upright.
-//   • vo=Tr with a U+FE1x/FE3x vertical form — the brackets （）「」〈〉【】…, the white
-//     lenticular brackets 〖〗, and the fullwidth colon/semicolon ：； (#969) →
+//   • vo=Tr with a U+FE1x/FE3x vertical form present in the substitute fonts — the
+//     brackets （）「」〈〉【】… and the white lenticular brackets 〖〗 (#969) →
 //     SUBSTITUTE that form (core `verticalBracketFormSubstitute`), drawn upright
 //     (UAX#50 §5 "substitute a vertical glyph, rotate only as fallback"). XLSX has
-//     no Excel ground-truth image, so ：；〖〗 follow the Word/PowerPoint verdict.
-//   • vo=Tr with NO vertical form (ー U+30FC, quotes “”) → ROTATE the glyph 90° CW
-//     (the Tr fallback) so ー becomes the vertical bar Excel draws.
+//     no Excel ground-truth image, so 〖〗 follow the Word/PowerPoint verdict.
+//   • vo=Tr with NO substituted form → a geometric fallback: ROTATE 90° CW (ー U+30FC,
+//     quotes “”, and the colon ： — a rotation turns the base ：'s stacked dots into
+//     FE13's side-by-side dots) or UPRIGHT (the semicolon ；, whose FE14 form is an
+//     upright dot-over-comma, not a rotation; core `verticalTrUprightFallback`).
+//     FE13/FE14 are absent from most render fonts, so ：；take this geometric path
+//     rather than substitution (issue #969 follow-up).
 
 import {
   verticalOrientation,
   verticalFormSubstitute,
   verticalBracketFormSubstitute,
+  verticalTrUprightFallback,
 } from '@silurus/ooxml-core';
 
 type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
@@ -59,17 +64,25 @@ export function drawStackedVerticalChar(
   const vo = verticalOrientation(cp);
 
   if (vo === 'Tr') {
-    // Substitute-first: a fullwidth bracket, white lenticular bracket, or the
-    // colon/semicolon ：；〖〗 (#969) has a U+FE1x/FE3x vertical form drawn UPRIGHT
-    // (UAX#50 §5). It fills the cell like an ideograph, so the caller's center/top
-    // placement lands it correctly.
+    // Substitute-first: a fullwidth bracket or white lenticular bracket 〖〗 (#969)
+    // has a U+FE3x/FE1x vertical form drawn UPRIGHT (UAX#50 §5). It fills the cell
+    // like an ideograph, so the caller's center/top placement lands it correctly.
     const bracket = verticalBracketFormSubstitute(cp);
     if (bracket !== null) {
       ctx.fillText(String.fromCodePoint(bracket), centerX, cellTopY);
       return;
     }
-    // Fallback: no vertical form (ー U+30FC, quotes) → rotate 90° CW, centred in the
-    // cell slot. save/restore also restores the caller's textAlign/textBaseline.
+    // Semicolon ；(FF1B): its FE14 vertical form is an upright dot-over-comma (not a
+    // rotation), so draw it UPRIGHT like an ideograph — NOT rotated (issue #969
+    // follow-up; FE13/FE14 were dropped from the core substitute map because those
+    // forms are absent from most render fonts). The colon ：falls through to rotate,
+    // reproducing FE13's side-by-side dots.
+    if (verticalTrUprightFallback(cp)) {
+      ctx.fillText(ch, centerX, cellTopY);
+      return;
+    }
+    // Fallback: no vertical form (ー U+30FC, quotes, colon ：) → rotate 90° CW, centred
+    // in the cell slot. save/restore also restores the caller's textAlign/textBaseline.
     ctx.save();
     ctx.translate(centerX, cellTopY + charH / 2);
     ctx.rotate(Math.PI / 2);


### PR DESCRIPTION
## Problem

The fullwidth colon `：`(U+FF1A) and semicolon `；`(U+FF1B) are UAX #50 `Vertical_Orientation = Tr`. Issue #969 substituted their Unicode vertical presentation forms **FE13/FE14** unconditionally and drew them upright. But FE13/FE14 are **absent from most render fonts** (e.g. the Mincho face macOS substitutes for a document that requests Yu Mincho), and a Canvas cannot invoke the font's `vert` OpenType feature. Substituting the FE code point therefore reached the system fallback cascade and painted a *different* font's glyph positioned wrong — measured at **~0.25em to the right of the column centre in both skia-canvas and Chrome**. The colon rendered as vertically-stacked dots shoved right; the semicolon shoved right — neither matching Word.

## Root cause

The FE13/FE14 substitution is an unreliable proxy for the font's `vert` feature: those code points are not mapped in common render fonts, and a mispositioned system-fallback glyph is not detectable/correctable from a Canvas (Canvas always substitutes, so a `.notdef`/tofu probe cannot distinguish a native glyph from a foreign-fallback one).

## Fix

Drop FE13/FE14 from the shared `verticalBracketFormSubstitute` map and give the two marks a **geometric fallback** that reproduces each vertical form's design directly and font-robustly (Word ground truth, PDF-adjudicated):

- **colon `：` → rotate 90°** (the generic Tr fallback): the base's two vertically-stacked dots become the side-by-side dots of FE13.
- **semicolon `；` → upright** (an application-level override of the informative `Vertical_Orientation`; new core `verticalTrUprightFallback`): FE14 is a dot-over-comma drawn upright, not a rotation.

The white lenticular brackets `〖〗` (FE17/FE18, present in the substitute fonts) keep substituting. Applied across all three renderers — docx tbRl (§17.6.20), pptx eaVert (§20.1.10.83), xlsx stacked — since the UAX #50 classifier and substitute map are shared; XLSX follows the shared verdict (no Excel ground truth).

## Verification

- New skia probe asserts each mark is centred on the column and correctly oriented (colon wider-than-tall, semicolon taller-than-wide).
- Updated core/docx/pptx/xlsx unit tests.
- Re-rendered the affected tbRl document in **real Chrome**: both marks now render centred and correct.
- docx demo VRT non-regression holds; the only vertical VRT reference sample contains no `：；〖〗`, so the change is orthogonal to every reference.
- Independent read-only Codex review approved the rendering logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)