### PR TITLE
fix(docx): per-side contextualSpacing subtraction semantics (§17.3.1.9)

### DIFF
--- a/packages/docx/src/contextual-spacing-body-paint.test.ts
+++ b/packages/docx/src/contextual-spacing-body-paint.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { paginateDocument, renderDocumentToCanvas } from './renderer.js';
+import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps } from './types';
+
+// ECMA-376 §17.3.1.9 contextualSpacing — BODY paginator + paint integration pin
+// for the Word-adjudicated per-side semantics (issue #1015, sample-57 ground
+// truth). The unit tests cover the shared kernel through the cell/text-box
+// helpers; this test drives the real body path end-to-end (paginateDocument →
+// prebuiltPages → renderDocumentToCanvas) so a regression in EITHER the
+// paginator's gap arithmetic or the paint pass's mirrored recompute (they must
+// stay in lockstep) moves a painted baseline and fails here.
+//
+// Measurement is differential, like the sample-57 fixture: a control document
+// whose two paragraphs carry zero spacing yields the pure single-line pitch L;
+// each case document's baseline delta minus L is the inter-paragraph gap in pt
+// (scale 1: canvas width == page width).
+//
+// Adjudicated table (a = prev.spaceAfter, b = curr.spaceBefore):
+//   no toggle             → max(a, b)
+//   prev-only toggle      → max(b − a, 0)
+//   curr-only toggle      → a
+//   both toggle           → 0
+//   different styles      → max(a, b) (no suppression)
+
+interface Call { text: string; y: number; }
+
+/** Minimal recording canvas with LINEAR, scale-proportional metrics. */
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[] } {
+  let font = '10px serif';
+  const calls: Call[] = [];
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      return {
+        width: [...s].length * p * 0.5,
+        fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
+        actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
+    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    drawImage() {},
+    fillText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
+    strokeText(s: string, _x: number, y: number) { calls.push({ text: s, y }); },
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = { width: 0, height: 0, style: {} as Record<string, string>, getContext: () => ctx };
+  return { canvas: canvas as unknown as HTMLCanvasElement, calls };
+}
+
+(globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+  getContext() { return makeRecordingCanvas().canvas.getContext('2d'); }
+};
+
+function para(
+  text: string,
+  over: Partial<DocParagraph> & { styleId?: string | null },
+): DocParagraph {
+  return {
+    type: 'paragraph', alignment: 'left',
+    indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+    numbering: null, tabStops: [],
+    runs: [{
+      type: 'text', text, bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '', isLink: false, background: null, vertAlign: null, hyperlink: null,
+    } as DocParagraph['runs'][number]],
+    defaultFontSize: 10, defaultFontFamily: 'Times New Roman', widowControl: false,
+    ...over,
+  } as unknown as DocParagraph;
+}
+
+function doc(body: BodyElement[]): DocxDocumentModel {
+  const section: SectionProps = {
+    pageWidth: 400, pageHeight: 400,
+    marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+    headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
+    sectionStart: 'nextPage', columns: null,
+  } as SectionProps;
+  return {
+    section,
+    body,
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+    footnotes: [],
+  } as unknown as DocxDocumentModel;
+}
+
+/** Paint a two-paragraph body at scale 1 and return yCURR − yPREV (baseline pt). */
+async function baselineDelta(prev: DocParagraph, curr: DocParagraph): Promise<number> {
+  const model = doc([prev, curr] as unknown as BodyElement[]);
+  const pages = paginateDocument(model);
+  expect(pages.length).toBe(1);
+  const { canvas, calls } = makeRecordingCanvas();
+  await renderDocumentToCanvas(model, canvas, 0, { dpr: 1, width: 400, prebuiltPages: pages });
+  const yPrev = calls.find((c) => c.text.includes('PREV'))?.y;
+  const yCurr = calls.find((c) => c.text.includes('CURR'))?.y;
+  expect(yPrev).toBeTypeOf('number');
+  expect(yCurr).toBeTypeOf('number');
+  return (yCurr as number) - (yPrev as number);
+}
+
+describe('§17.3.1.9 contextualSpacing — body paginate+paint per-side gaps (issue #1015)', () => {
+  it('paints the adjudicated six-case gap table', async () => {
+    // Control: zero spacing everywhere → pure single-line pitch L (gap 0).
+    const L = await baselineDelta(
+      para('PREV', { styleId: 'CtxPair' }),
+      para('CURR', { styleId: 'CtxPair' }),
+    );
+    expect(L).toBeGreaterThan(0);
+
+    const gap = async (
+      prevOver: Partial<DocParagraph> & { styleId?: string | null },
+      currOver: Partial<DocParagraph> & { styleId?: string | null },
+    ): Promise<number> =>
+      (await baselineDelta(para('PREV', prevOver), para('CURR', currOver))) - L;
+
+    // Case 5 — no toggle: gap = max(10, 12) = 12.
+    expect(await gap(
+      { styleId: 'CtxPair', spaceAfter: 10 },
+      { styleId: 'CtxPair', spaceBefore: 12 },
+    )).toBeCloseTo(12, 5);
+
+    // Case 1 — PREV-only toggle: gap = max(12 − 10, 0) = 2 (spec worked example).
+    expect(await gap(
+      { styleId: 'CtxPair', spaceAfter: 10, contextualSpacing: true },
+      { styleId: 'CtxPair', spaceBefore: 12 },
+    )).toBeCloseTo(2, 5);
+
+    // Case 2 — CURR-only toggle: gap = prev.spaceAfter = 10 (Word-measured).
+    expect(await gap(
+      { styleId: 'CtxPair', spaceAfter: 10 },
+      { styleId: 'CtxPair', spaceBefore: 12, contextualSpacing: true },
+    )).toBeCloseTo(10, 5);
+
+    // Case 3a — both toggle: gap = 0.
+    expect(await gap(
+      { styleId: 'CtxPair', spaceAfter: 10, contextualSpacing: true },
+      { styleId: 'CtxPair', spaceBefore: 12, contextualSpacing: true },
+    )).toBeCloseTo(0, 5);
+
+    // Case 3b — both toggle, asymmetric 4/12: still 0.
+    expect(await gap(
+      { styleId: 'CtxPair', spaceAfter: 4, contextualSpacing: true },
+      { styleId: 'CtxPair', spaceBefore: 12, contextualSpacing: true },
+    )).toBeCloseTo(0, 5);
+
+    // Case 4 — both toggle, DIFFERENT styles: no suppression, gap = 12.
+    expect(await gap(
+      { styleId: 'CtxPair', spaceAfter: 10, contextualSpacing: true },
+      { styleId: 'CtxOther', spaceBefore: 12, contextualSpacing: true },
+    )).toBeCloseTo(12, 5);
+  });
+});

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -2805,9 +2805,10 @@ export function computePages(
         const p = e as unknown as DocParagraph;
         if (p.pageBreakBefore) return { height: Infinity, terminated: false };
         if (p.framePr) continue; // frame is out of flow (adds no column height)
-        const suppress = contextualSuppressed(prevP, p) || isContinuousSectionSpacer(j);
-        const before = suppress ? 0 : p.spaceBefore;
-        total += estimateParagraphHeight(ms, p, colWPt, suppress, 0) - Math.min(prevAfter, before);
+        const spacer = isContinuousSectionSpacer(j);
+        const adjust = contextualSpacingAdjust(prevP, p, prevAfter, spacer ? 0 : p.spaceBefore);
+        const suppress = adjust.suppressBefore || spacer;
+        total += estimateParagraphHeight(ms, p, colWPt, suppress, 0) - adjust.overlap;
         prevAfter = p.spaceAfter;
         prevP = p;
       } else if (e.type === 'table') {
@@ -3243,13 +3244,12 @@ export function computePages(
         pushTagged(el as PaginatedBodyElement);
         continue;
       }
-      const contextual = contextualSuppressed(prevPara, para);
       // An empty CONTINUOUS-section-break spacer drops only ITS OWN before (gap
       // collapses to prev.after, normally 0) — NOT the previous paragraph's after
-      // (see isSectionBreakSpacerAt). contextualSpacing drops both. Stamp the
-      // element so the paint pass (which gets per-page lists with the sectionBreak
-      // already consumed, so it cannot re-detect the adjacency) applies the same
-      // drop.
+      // (see isSectionBreakSpacerAt). contextualSpacing drops per-side
+      // contributions (contextualSpacingAdjust). Stamp the element so the paint
+      // pass (which gets per-page lists with the sectionBreak already consumed,
+      // so it cannot re-detect the adjacency) applies the same drop.
       const spacer = isContinuousSectionSpacer(i);
       if (spacer) (el as PaginatedBodyElement).sectionBreakSpacer = true;
       // A zero-before continuous-section spacer renders NO mark line box (Word's
@@ -3279,28 +3279,27 @@ export function computePages(
         pushTagged(el as PaginatedBodyElement);
         continue;
       }
-      const suppressBefore = contextual || spacer;
+      // §17.3.1.9 per-side contextualSpacing (contextualSpacingAdjust) over the
+      // §17.3.1.33 max-collapse — a spacer contributes no before of its own, so
+      // the adjustment is computed against 0. Keeps the paginator's fill in
+      // lockstep with the paint pass, which recomputes the same pair.
+      const adjust = contextualSpacingAdjust(prevPara, para, prevSpaceAfter, spacer ? 0 : para.spaceBefore);
+      const suppressBefore = adjust.suppressBefore || spacer;
 
       // An empty paragraph that immediately precedes a COLLAPSED continuous spacer
       // begins the section-break empty run, which Word renders FLUSH below the
       // preceding content (the section transition collapses upward): the previous
       // paragraph's spaceAfter is dropped too (sample-12: "[Format…]"'s 6pt after
       // vanishes, so "1. INTRODUCTION" sits at Word's 446pt rather than ~452pt).
-      // Mirrors contextualSpacing's full drop of the previous after; no-op when the
-      // spacer is NOT collapsed (sample-13, before=22 keeps normal flow).
+      // No-op when the spacer is NOT collapsed (sample-13, before=22 keeps normal
+      // flow).
       const leadsCollapsedRun = isInklessParagraph(para) && isCollapsedContinuousSpacer(i + 1);
       // Stamp it so the paint pass reads the decision here rather than re-deriving it
       // from per-page adjacency: the collapsed spacer this looks ahead to can fall on
       // the NEXT page's element list, where paint could not see it (lockstep).
       if (leadsCollapsedRun) (el as PaginatedBodyElement).leadsCollapsedRun = true;
 
-      // Collapse with the previous paragraph's spaceAfter — Word takes
-      // max(prev.after, this.before) between paragraphs, not the sum.
-      const effectiveBefore = suppressBefore ? 0 : para.spaceBefore;
-      // §17.3.1.9 contextualSpacing: same-style adjacent paragraphs drop BOTH the
-      // previous after and this before (gap = 0), keeping the paginator's fill in
-      // lockstep with the paint pass.
-      const overlap = (contextual || leadsCollapsedRun) ? prevSpaceAfter : Math.min(prevSpaceAfter, effectiveBefore);
+      const overlap = leadsCollapsedRun ? prevSpaceAfter : adjust.overlap;
       y -= overlap;
       measureState.y -= overlap;
 
@@ -6071,12 +6070,13 @@ function splitCellContentByHeight(
     const para = ce as unknown as DocParagraph;
     const continuationSlice = !!slice && slice.start > 0;
     const rawBefore = continuationSlice ? 0 : para.spaceBefore;
-    const suppress = !continuationSlice && contextualSuppressed(prevPara, para);
-    const effBefore = suppress ? 0 : rawBefore;
-    const overlap = suppress ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
+    // §17.3.1.9 per-side suppression (a continuation slice already consumed its
+    // spacing boundary on the previous slice — no adjacency, prev = null).
+    const adjust = contextualSpacingAdjust(
+      continuationSlice ? null : prevPara, para, prevSpaceAfter, rawBefore);
     return rawHeight
-      - (suppress ? rawBefore : 0)
-      - overlap;
+      - (adjust.suppressBefore ? rawBefore : 0)
+      - adjust.overlap;
   };
   const appendBefore = (ce: CellElement, rawHeight: number, slice = cellLineSlice(ce), totalLines?: number): void => {
     before.push(ce);
@@ -6125,10 +6125,9 @@ function splitCellContentByHeight(
       const para = item as unknown as DocParagraph;
       const continuationSlice = !!measured.slice && measured.slice.start > 0;
       const rawBefore = continuationSlice ? 0 : para.spaceBefore;
-      const suppress = !continuationSlice && contextualSuppressed(localPrevPara, para);
-      const effBefore = suppress ? 0 : rawBefore;
-      const overlap = suppress ? localPrevSpaceAfter : Math.min(localPrevSpaceAfter, effBefore);
-      h += measured.rawHeight - (suppress ? rawBefore : 0) - overlap;
+      const adjust = contextualSpacingAdjust(
+        continuationSlice ? null : localPrevPara, para, localPrevSpaceAfter, rawBefore);
+      h += measured.rawHeight - (adjust.suppressBefore ? rawBefore : 0) - adjust.overlap;
       localPrevPara = para;
       localPrevSpaceAfter = !measured.slice || measured.totalLines == null || measured.slice.end >= measured.totalLines
         ? para.spaceAfter
@@ -6958,30 +6957,59 @@ function renderBodyElement(el: BodyElement, state: RenderState): void {
 }
 
 /**
- * ECMA-376 §17.3.1.9 — two ADJACENT paragraphs that share a style id and BOTH set
- * `<w:contextualSpacing>` suppress the spaceBefore/spaceAfter between them. Kept
- * structural (not `DocParagraph`) so the SAME rule drives both the body paragraph
- * path and the text-box path ({@link ShapeText}), which carry the identical
+ * ECMA-376 §17.3.1.9 `<w:contextualSpacing>` — Word-adjudicated PER-SIDE
+ * semantics (issue #1015, fixture sample-57 ground truth; identical in body,
+ * table cell, and text box).
+ *
+ * The §17.3.1.33 collapsed inter-paragraph gap decomposes as
+ *   gap = prevContrib + currContrib
+ *   prevContrib = prev.spaceAfter                          (the collapse base)
+ *   currContrib = max(curr.spaceBefore − prev.spaceAfter, 0)   (the excess)
+ * summing to max(after, before). A paragraph whose toggle is set AND whose
+ * neighbour shares its paragraph style drops ITS OWN contribution only:
+ *   - prev toggles → gap = max(before − after, 0)  — matches the spec's worked
+ *     example (after=10pt, before=12pt → 2pt);
+ *   - curr toggles → gap = after — Word renders prev's spaceAfter intact (the
+ *     spec-literal "subtract this paragraph's before from the net" would give
+ *     0; Word measured 10pt on sample-57 case 2);
+ *   - both toggle  → gap = 0 (each side's contribution dropped; the
+ *     decomposition is non-negative so no explicit floor is needed).
+ *
+ * Every gap site uses the effBefore/overlap form
+ *   gap = prevAfter + (suppressBefore ? 0 : spaceBefore) − overlap
+ * so this helper returns that pair. Kept structural (not `DocParagraph`) so the
+ * SAME rule drives the body paragraph path, the cell paths, and the text-box
+ * path ({@link ShapeText}), which carry the identical
  * `contextualSpacing`/`styleId` pair.
  */
-function contextualSuppressed(
+function contextualSpacingAdjust(
   prev: { contextualSpacing?: boolean; styleId?: string | null } | null,
   curr: { contextualSpacing?: boolean; styleId?: string | null },
-): boolean {
-  return !!(prev?.contextualSpacing && curr.contextualSpacing && prev.styleId && prev.styleId === curr.styleId);
+  prevAfter: number,
+  spaceBefore: number,
+): { suppressBefore: boolean; overlap: number } {
+  const sameStyle = !!(prev?.styleId && prev.styleId === curr.styleId);
+  const dropPrev = !!(sameStyle && prev?.contextualSpacing);
+  const dropCurr = !!(sameStyle && curr.contextualSpacing);
+  if (dropPrev && dropCurr) return { suppressBefore: true, overlap: prevAfter };
+  // gap = prevAfter: curr's before-excess contribution is dropped whole.
+  if (dropCurr) return { suppressBefore: true, overlap: 0 };
+  // gap = max(before − after, 0): prev's spaceAfter contribution is dropped.
+  if (dropPrev) return { suppressBefore: false, overlap: prevAfter + Math.min(prevAfter, spaceBefore) };
+  // No suppression — the plain §17.3.1.33 max-collapse.
+  return { suppressBefore: false, overlap: Math.min(prevAfter, spaceBefore) };
 }
 
 /**
  * ECMA-376 §17.3.1.33 + §17.3.1.9 — the vertical gap reserved ABOVE text-box
  * paragraph `i`. The first paragraph reserves only its own spaceBefore; between
  * two paragraphs the gap collapses to max(prev.spaceAfter, this.spaceBefore) — NOT
- * their sum — UNLESS the two are the same style and BOTH set contextualSpacing, in
- * which case Word drops the whole gap (the identical rule the body path applies via
- * {@link contextualSuppressed}). Without the suppression a `<w:contextualSpacing/>`
- * ListParagraph list inside a fixed box kept inheriting the docDefault `after=160`
- * (8 pt) gap, which inflated its line pitch and clipped the trailing line
- * (sample-32). Shared by the render pass and the auto-fit height measurement so the
- * two never disagree.
+ * their sum — minus any {@link contextualSpacingAdjust} per-side suppression
+ * (the identical rule the body path applies). Without the suppression a
+ * `<w:contextualSpacing/>` ListParagraph list inside a fixed box kept inheriting
+ * the docDefault `after=160` (8 pt) gap, which inflated its line pitch and
+ * clipped the trailing line (sample-32). Shared by the render pass and the
+ * auto-fit height measurement so the two never disagree.
  */
 export function shapeParagraphGapBefore(
   blocks: ReadonlyArray<{ contextualSpacing?: boolean; styleId?: string | null }>,
@@ -6990,8 +7018,8 @@ export function shapeParagraphGapBefore(
   spAfter: readonly number[],
 ): number {
   if (i <= 0) return spBefore[i];
-  if (contextualSuppressed(blocks[i - 1], blocks[i])) return 0;
-  return Math.max(spBefore[i], spAfter[i - 1]);
+  const adjust = contextualSpacingAdjust(blocks[i - 1], blocks[i], spAfter[i - 1], spBefore[i]);
+  return spAfter[i - 1] + (adjust.suppressBefore ? 0 : spBefore[i]) - adjust.overlap;
 }
 
 /**
@@ -7095,10 +7123,9 @@ function isSectionBreakSpacerAt(body: ArrayLike<{ type?: string }>, i: number): 
  * sizing equals the height it actually paints. Two collapse rules apply
  * (mirroring the paint pass):
  *
- *   - ECMA-376 §17.3.1.33 `<w:contextualSpacing>`: a paragraph whose
- *     contextualSpacing toggle matches the previous paragraph's AND shares its
- *     styleId emits zero spaceBefore (the toggle suppresses spacing between
- *     same-style siblings).
+ *   - ECMA-376 §17.3.1.9 `<w:contextualSpacing>`: a same-style toggling
+ *     paragraph drops its OWN contribution to the inter-paragraph gap
+ *     ({@link contextualSpacingAdjust} — per-side, Word-adjudicated).
  *   - Adjacent-paragraph spacing OVERLAP: the gap between two paragraphs is
  *     `max(prevSpaceAfter, currSpaceBefore)`, not their sum. We subtract the
  *     overlap `min(prevSpaceAfter, effBefore)` so a 12pt space-after followed
@@ -7128,15 +7155,13 @@ export function sumCellContentHeight(
   for (const ce of content) {
     if (ce.type === 'paragraph') {
       const para = ce as unknown as DocParagraph;
-      const suppress = contextualSuppressed(prevPara, para);
-      const effBefore = suppress ? 0 : para.spaceBefore;
-      // §17.3.1.9 contextualSpacing: between two same-style paragraphs that both
-      // set it, BOTH the previous after and this before are dropped (gap = 0), not
-      // just collapsed — so e.g. a code listing's lines sit tight.
-      const overlap = suppress ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
+      // §17.3.1.9 per-side contextualSpacing (contextualSpacingAdjust) over the
+      // §17.3.1.33 max-collapse — a same-style toggle drops the toggling
+      // paragraph's own contribution to the gap.
+      const adjust = contextualSpacingAdjust(prevPara, para, prevSpaceAfter, para.spaceBefore);
       h += perElementHeight(ce)
-        - (suppress ? para.spaceBefore : 0) * spaceScale
-        - overlap * spaceScale;
+        - (adjust.suppressBefore ? para.spaceBefore : 0) * spaceScale
+        - adjust.overlap * spaceScale;
       prevPara = para;
       prevSpaceAfter = para.spaceAfter;
     } else {
@@ -7322,25 +7347,22 @@ function renderBodyElements(
       // advances y by nothing, leaving prevPara/prevSpaceAfter as the paragraph
       // BEFORE it — the paint mirror of the paginator's identical skip.
       if ((el as PaginatedBodyElement).hiddenCollapsed) continue;
-      const contextual = contextualSuppressed(prevPara, para);
       // Empty section-break spacer: drop only its own before (see
-      // isSectionBreakSpacerAt); contextualSpacing drops the previous after too.
+      // isSectionBreakSpacerAt); §17.3.1.9 per-side contextualSpacing
+      // (contextualSpacingAdjust) drops each toggling side's own contribution.
       // The adjacency was detected during pagination and stamped (the sectionBreak
-      // marker is gone from this per-page list), so read the tag here.
+      // marker is gone from this per-page list), so read the tag here. Mirrors the
+      // paginator's identical computation (lockstep).
       const spacer = !!(el as PaginatedBodyElement).sectionBreakSpacer;
-      const suppress = contextual || spacer;
+      const adjust = contextualSpacingAdjust(prevPara, para, prevSpaceAfter, spacer ? 0 : para.spaceBefore);
+      const suppress = adjust.suppressBefore || spacer;
       // An empty paragraph immediately before a COLLAPSED continuous spacer begins the
       // section-break empty run; Word renders it FLUSH below the preceding content,
       // dropping the previous paragraph's spaceAfter too. Read the paginator-stamped
       // flag rather than looking ahead in this per-page slice: the collapsed spacer can
       // sit on the next page, where `elements[elIdx + 1]` would be undefined.
       const leadsCollapsedRun = !!(el as PaginatedBodyElement).leadsCollapsedRun;
-      // Collapse spaceAfter+spaceBefore like Word: use max, not sum.
-      const effBefore = suppress ? 0 : para.spaceBefore;
-      // §17.3.1.9 contextualSpacing: between two same-style paragraphs that both
-      // set it, BOTH the previous after and this before are dropped (gap = 0), not
-      // just collapsed — so e.g. a code listing's lines sit tight.
-      const overlap = (contextual || leadsCollapsedRun) ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
+      const overlap = leadsCollapsedRun ? prevSpaceAfter : adjust.overlap;
       state.y -= overlap * state.scale;
       // Continuation slices (slice.start > 0) suppress spaceBefore: the
       // earlier slice already consumed it on the previous page. Likewise
@@ -7415,10 +7437,11 @@ function renderParaList(paras: DocParagraph[], state: RenderState): void {
   let prevSpaceAfter = 0;
   for (let i = 0; i < paras.length; i++) {
     const para = paras[i];
-    const suppress = contextualSuppressed(prevPara, para);
-    const effBefore = suppress ? 0 : para.spaceBefore;
-    const overlap = Math.min(prevSpaceAfter, effBefore);
-    state.y -= overlap * state.scale;
+    // §17.3.1.9 per-side contextualSpacing over the §17.3.1.33 max-collapse —
+    // the same contextualSpacingAdjust pair every other flow applies.
+    const adjust = contextualSpacingAdjust(prevPara, para, prevSpaceAfter, para.spaceBefore);
+    const suppress = adjust.suppressBefore;
+    state.y -= adjust.overlap * state.scale;
     // ECMA-376 §17.3.1.7 paragraph-border merge. This list is a single flow (a
     // note or a table cell), so adjacency is just consecutive list members; a
     // frame paragraph (§17.3.1.11) is out of flow and breaks the run. `framePr`
@@ -12168,8 +12191,8 @@ function measureCellContentHeightPx(
   const measured = trimTrailingStructuralMarker(cell.content);
   // measureCellElementHeight always includes paragraph spaceBefore plus
   // max(spaceAfter, bottom-border extent) — the same trailing advance the paint
-  // pass emits (§17.3.1.7); sumCellContentHeight folds in contextualSuppressed
-  // (§17.3.1.33) and the prevSpaceAfter/spaceBefore overlap collapse to match the
+  // pass emits (§17.3.1.7); sumCellContentHeight folds in contextualSpacingAdjust
+  // (§17.3.1.9) and the prevSpaceAfter/spaceBefore overlap collapse to match the
   // paint pass's renderCellContent. Spacing is converted from pt to px with `scale`.
   return (cm.top + cm.bottom) * scale + sumCellContentHeight(
     measured,
@@ -13120,14 +13143,13 @@ function renderCellContent(content: CellElement[], state: RenderState): void {
       const lineSlice = slice
         ? { ...slice, ...(continues ? { continues: true as const } : {}) }
         : undefined;
-      const suppress = !continues && contextualSuppressed(prevPara, para);
-      const effBefore = suppress || continues ? 0 : para.spaceBefore;
-      // §17.3.1.9 contextualSpacing: between two same-style paragraphs that both
-      // set it, BOTH the previous after and this before are dropped (gap = 0), not
-      // just collapsed — so e.g. a code listing's lines sit tight.
-      const overlap = suppress ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
-      state.y -= overlap * state.scale;
-      renderParagraph(para, state, suppress || continues, lineSlice);
+      // §17.3.1.9 per-side contextualSpacing (contextualSpacingAdjust) over the
+      // §17.3.1.33 max-collapse — a continuation slice consumed its spacing
+      // boundary on the previous slice (no adjacency, prev = null).
+      const adjust = contextualSpacingAdjust(
+        continues ? null : prevPara, para, prevSpaceAfter, continues ? 0 : para.spaceBefore);
+      state.y -= adjust.overlap * state.scale;
+      renderParagraph(para, state, adjust.suppressBefore || continues, lineSlice);
       prevPara = para;
       prevSpaceAfter = para.spaceAfter;
     } else if (ce.type === 'table') {
@@ -13210,21 +13232,21 @@ function renderCellContentFragment(cellFragment: CellFragment, state: RenderStat
             end: block.lineEnd,
             ...(continues ? { continues: true as const } : {}),
           };
-      const suppress = !continues && contextualSuppressed(prevPara, para);
-      const effBefore = suppress || continues ? 0 : para.spaceBefore;
-      const overlap = suppress ? prevSpaceAfter : Math.min(prevSpaceAfter, effBefore);
-      state.y -= overlap * state.scale;
+      // Mirror renderCellContent's §17.3.1.9 per-side adjustment EXACTLY.
+      const adjust = contextualSpacingAdjust(
+        continues ? null : prevPara, para, prevSpaceAfter, continues ? 0 : para.spaceBefore);
+      state.y -= adjust.overlap * state.scale;
       if (isFragmentPaintableCellBlock(block, state)) {
         renderBodyParagraphLines(
           para,
           state,
           block.measured.lines.map((line) => line.layout),
-          suppress || continues,
+          adjust.suppressBefore || continues,
           lineSlice,
           undefined,
         );
       } else {
-        renderParagraph(para, state, suppress || continues, lineSlice);
+        renderParagraph(para, state, adjust.suppressBefore || continues, lineSlice);
       }
       prevPara = para;
       prevSpaceAfter = para.spaceAfter;

--- a/packages/docx/src/shape-contextual-spacing.test.ts
+++ b/packages/docx/src/shape-contextual-spacing.test.ts
@@ -4,59 +4,131 @@ import { shapeParagraphGapBefore } from './renderer';
 import type { ShapeText } from './types';
 
 /**
- * ECMA-376 §17.3.1.9 `<w:contextualSpacing>` inside a text box (`<wps:txbx>`).
+ * ECMA-376 §17.3.1.9 `<w:contextualSpacing>` — Word-adjudicated PER-SIDE
+ * semantics (issue #1015, fixture sample-57 ground truth).
  *
- * The vertical gap reserved ABOVE text-box paragraph `i` is normally
- * max(prev.spaceAfter, this.spaceBefore) (collapse, not sum). When two ADJACENT
- * paragraphs share a style id and BOTH set contextualSpacing, Word drops the
- * whole gap — the same rule the body renderer applies via `contextualSuppressed`.
- * Before the fix the text-box path lacked this, so a `<w:contextualSpacing/>`
- * ListParagraph list inherited the docDefault `after=160` (8 pt) gap that
- * inflated its line pitch and clipped the trailing line (sample-32).
+ * The inter-paragraph gap decomposes as
+ *   gap = prevContrib + currContrib
+ *   prevContrib = prev.spaceAfter
+ *   currContrib = max(curr.spaceBefore − prev.spaceAfter, 0)
+ * (summing to max(after, before) — the §17.3.1.33 collapse). A paragraph whose
+ * toggle matches a same-style neighbour drops ITS OWN contribution only:
+ *   - prev toggles → gap = max(before − after, 0)   (spec's worked example: 10/12 → 2)
+ *   - curr toggles → gap = after                    (Word measured 10, NOT the
+ *     spec-literal "subtract own before from net" which would give 0)
+ *   - both toggle  → gap = 0
+ * Word applies this identically in body, table cell, and text box (sample-57
+ * measured parity), so this text-box helper carries the same table as the body
+ * and cell paths.
  */
-describe('shapeParagraphGapBefore — §17.3.1.9 contextualSpacing in a text box', () => {
+describe('shapeParagraphGapBefore — §17.3.1.9 contextualSpacing per-side semantics', () => {
   const block = (over: Partial<ShapeText>): ShapeText =>
     ({ text: 'x', fontSizePt: 12, alignment: 'left', ...over }) as ShapeText;
 
-  // 8 pt after / 4 pt before, both scaled ×1 for the table.
-  const spBefore = [0, 4];
-  const spAfter = [8, 0];
+  const pair = (
+    prev: Partial<ShapeText>,
+    curr: Partial<ShapeText>,
+    afterPt: number,
+    beforePt: number,
+  ): number =>
+    shapeParagraphGapBefore(
+      [block(prev), block(curr)],
+      1,
+      [0, beforePt],
+      [afterPt, 0],
+    );
 
   it('reserves only the first block own spaceBefore at i=0 (no previous block)', () => {
     const blocks = [block({ spaceBefore: 6 }), block({})];
     expect(shapeParagraphGapBefore(blocks, 0, [6, 4], [0, 0])).toBe(6);
   });
 
-  it('drops the gap when both blocks share a style id AND both set contextualSpacing', () => {
-    const blocks = [
-      block({ styleId: 'ListParagraph', contextualSpacing: true }),
-      block({ styleId: 'ListParagraph', contextualSpacing: true }),
-    ];
-    expect(shapeParagraphGapBefore(blocks, 1, spBefore, spAfter)).toBe(0);
+  // ── sample-57 adjudication table (after=10 / before=12 unless noted) ──────
+  it('case 1 — PREV-only toggle: gap = max(before − after, 0) = 2 (spec worked example)', () => {
+    expect(
+      pair(
+        { styleId: 'CtxPair', contextualSpacing: true },
+        { styleId: 'CtxPair' },
+        10,
+        12,
+      ),
+    ).toBe(2);
   });
 
-  it('keeps the collapsed gap when the two blocks have DIFFERENT style ids', () => {
-    const blocks = [
-      block({ styleId: 'ListParagraph', contextualSpacing: true }),
-      block({ styleId: 'Body', contextualSpacing: true }),
-    ];
-    // max(spBefore[1]=4, spAfter[0]=8) = 8.
-    expect(shapeParagraphGapBefore(blocks, 1, spBefore, spAfter)).toBe(8);
+  it('case 2 — CURR-only toggle: gap = prev.spaceAfter = 10 (Word; not the literal net-minus-before 0)', () => {
+    expect(
+      pair(
+        { styleId: 'CtxPair' },
+        { styleId: 'CtxPair', contextualSpacing: true },
+        10,
+        12,
+      ),
+    ).toBe(10);
   });
 
-  it('keeps the gap when only ONE of the two same-style blocks sets contextualSpacing', () => {
-    const blocks = [
-      block({ styleId: 'ListParagraph', contextualSpacing: true }),
-      block({ styleId: 'ListParagraph', contextualSpacing: false }),
-    ];
-    expect(shapeParagraphGapBefore(blocks, 1, spBefore, spAfter)).toBe(8);
+  it('case 3a — both toggle: gap = 0', () => {
+    expect(
+      pair(
+        { styleId: 'CtxPair', contextualSpacing: true },
+        { styleId: 'CtxPair', contextualSpacing: true },
+        10,
+        12,
+      ),
+    ).toBe(0);
   });
 
-  it('keeps the gap when the shared style id is missing on either block', () => {
-    const blocks = [
-      block({ contextualSpacing: true }),
-      block({ contextualSpacing: true }),
-    ];
-    expect(shapeParagraphGapBefore(blocks, 1, spBefore, spAfter)).toBe(8);
+  it('case 3b — both toggle, asymmetric 4/12: still 0 (no negative residue)', () => {
+    expect(
+      pair(
+        { styleId: 'CtxPair', contextualSpacing: true },
+        { styleId: 'CtxPair', contextualSpacing: true },
+        4,
+        12,
+      ),
+    ).toBe(0);
+  });
+
+  it('case 4 — both toggle but DIFFERENT styles: no suppression, gap = max = 12', () => {
+    expect(
+      pair(
+        { styleId: 'CtxPair', contextualSpacing: true },
+        { styleId: 'CtxOther', contextualSpacing: true },
+        10,
+        12,
+      ),
+    ).toBe(12);
+  });
+
+  it('case 5 — no toggle: gap collapses to max(after, before) = 12', () => {
+    expect(pair({ styleId: 'CtxPair' }, { styleId: 'CtxPair' }, 10, 12)).toBe(12);
+  });
+
+  // ── direction corners beyond the fixture values ───────────────────────────
+  it('PREV-only toggle with after ≥ before floors at 0 (8/4 → max(4−8,0))', () => {
+    expect(
+      pair(
+        { styleId: 'ListParagraph', contextualSpacing: true },
+        { styleId: 'ListParagraph' },
+        8,
+        4,
+      ),
+    ).toBe(0);
+  });
+
+  it('CURR-only toggle with after ≥ before keeps prev.spaceAfter (8/4 → 8)', () => {
+    expect(
+      pair(
+        { styleId: 'ListParagraph' },
+        { styleId: 'ListParagraph', contextualSpacing: true },
+        8,
+        4,
+      ),
+    ).toBe(8);
+  });
+
+  it('keeps the collapsed gap when the shared style id is missing on either block', () => {
+    expect(
+      pair({ contextualSpacing: true }, { contextualSpacing: true }, 8, 4),
+    ).toBe(8);
   });
 });

--- a/packages/docx/src/table-spacing-collapse.test.ts
+++ b/packages/docx/src/table-spacing-collapse.test.ts
@@ -4,8 +4,9 @@ import type { CellElement, DocParagraph } from './types.js';
 
 // `sumCellContentHeight` is the shared measure-side spacing-collapse helper
 // that mirrors `renderCellContent`'s paint-side spacing rules:
-//   * ECMA-376 §17.3.1.33 contextualSpacing (same styleId siblings suppress
-//     spaceBefore between them).
+//   * ECMA-376 §17.3.1.9 contextualSpacing — a same-style toggling paragraph
+//     drops its OWN contribution to the collapsed gap (per-side, Word-
+//     adjudicated: issue #1015 / sample-57).
 //   * Adjacent-paragraph spacing OVERLAP: the gap between two paragraphs is
 //     max(prevSpaceAfter, currSpaceBefore), not their sum.
 // Both rules were applied in the paint loop (`renderCellContent`) but the
@@ -74,6 +75,35 @@ describe('sumCellContentHeight — spacing collapse mirrors renderCellContent', 
     ];
     // 2nd paragraph's spaceBefore is suppressed: 20 + 0 + 20 + 0 = 40
     // (no spaceBefore for the suppressed paragraph, no overlap to subtract).
+    expect(sumCellContentHeight(content, fullHeight(20), 1)).toBe(40);
+  });
+
+  // §17.3.1.9 per-side semantics (issue #1015, sample-57 ground truth): a
+  // same-style toggle drops the TOGGLING paragraph's own contribution to the
+  // collapsed gap — prev's spaceAfter, or curr's before-excess max(before−after,0).
+  it('PREV-only contextualSpacing leaves gap = max(before − after, 0) (sample-57 case 1: 10/12 → 2)', () => {
+    const content = [
+      para({ styleId: 'CtxPair', contextualSpacing: true, spaceAfter: 10 }),
+      para({ styleId: 'CtxPair', spaceBefore: 12 }),
+    ];
+    // gap = max(12 − 10, 0) = 2 → total = 20 + 2 + 20 = 42.
+    expect(sumCellContentHeight(content, fullHeight(20), 1)).toBe(42);
+  });
+
+  it('CURR-only contextualSpacing leaves gap = prev.spaceAfter (sample-57 case 2: 10/12 → 10)', () => {
+    const content = [
+      para({ styleId: 'CtxPair', spaceAfter: 10 }),
+      para({ styleId: 'CtxPair', contextualSpacing: true, spaceBefore: 12 }),
+    ];
+    // gap = prev.spaceAfter = 10 → total = 20 + 10 + 20 = 50.
+    expect(sumCellContentHeight(content, fullHeight(20), 1)).toBe(50);
+  });
+
+  it('both-toggle asymmetric spacing still drops the whole gap (sample-57 case 3b: 4/12 → 0)', () => {
+    const content = [
+      para({ styleId: 'CtxPair', contextualSpacing: true, spaceAfter: 4 }),
+      para({ styleId: 'CtxPair', contextualSpacing: true, spaceBefore: 12 }),
+    ];
     expect(sumCellContentHeight(content, fullHeight(20), 1)).toBe(40);
   });
 

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -573,7 +573,10 @@ export interface DocParagraph {
   shading?: string | null;
   /** Force a page break before this paragraph (w:pageBreakBefore) */
   pageBreakBefore?: boolean;
-  /** Suppress spacing between adjacent same-style paragraphs (w:contextualSpacing) */
+  /** ECMA-376 §17.3.1.9 `<w:contextualSpacing>` — between adjacent SAME-style
+   *  paragraphs, a toggling paragraph drops its OWN contribution to the
+   *  collapsed inter-paragraph gap (per-side, Word-adjudicated — issue #1015;
+   *  see the renderer's `contextualSpacingAdjust`). */
   contextualSpacing?: boolean;
   /** Keep paragraph on same page as the next paragraph (w:keepNext) */
   keepNext?: boolean;
@@ -1080,11 +1083,11 @@ export interface ShapeText {
    *  identical field). */
   bidi?: boolean;
   /** ECMA-376 §17.3.1.9 `<w:contextualSpacing>` — resolved through the style
-   *  chain in the parser. When set, the renderer suppresses the spaceBefore/
-   *  spaceAfter gap between this text-box paragraph and an ADJACENT paragraph
-   *  that shares its {@link ShapeText.styleId} and also sets the toggle
-   *  (identical to {@link DocParagraph.contextualSpacing} / `contextualSuppressed`).
-   *  Absent ⇒ no suppression. */
+   *  chain in the parser. When set, this text-box paragraph drops its OWN
+   *  contribution to the collapsed gap against an ADJACENT paragraph that
+   *  shares its {@link ShapeText.styleId} (per-side, Word-adjudicated — issue
+   *  #1015; identical to {@link DocParagraph.contextualSpacing} via the
+   *  renderer's `contextualSpacingAdjust`). Absent ⇒ no suppression. */
   contextualSpacing?: boolean;
   /** Resolved paragraph style id of this text-box paragraph — the explicit
    *  `<w:pStyle>`, else the document default paragraph style, else "Normal" (the


### PR DESCRIPTION
## Summary

Fixes #1015 — ECMA-376 §17.3.1.9 `contextualSpacing` one-sided semantics, adjudicated against Word (macOS) output with a synthetic fixture (sample-57, private corpus).

The previous implementation (`contextualSuppressed`) dropped the whole inter-paragraph gap to 0 **only when both neighbours carried the toggle and shared a styleId**, ignoring one-sided toggles entirely. Word's measured behaviour (see the adjudication table in #1015) is a **per-side contribution drop** over the §17.3.1.33 max-collapse:

```
gap = prevContrib + currContrib
prevContrib = prev.spaceAfter                              (dropped if prev toggles & same style)
currContrib = max(curr.spaceBefore − prev.spaceAfter, 0)   (dropped if curr toggles & same style)
```

Closed forms (a = prev.after, b = curr.before): none → `max(a,b)`; prev-only → `max(b−a,0)`; curr-only → `a`; both → `0`. This matches the spec's own worked example (prev-only, 10pt/12pt → 2pt) and Word's measured 10pt for the curr-only case (where the spec-literal "subtract own value from net" reading would give 0).

## Changes

- Replace `contextualSuppressed` (boolean both-toggle gate) with `contextualSpacingAdjust` returning the `{suppressBefore, overlap}` pair every gap site already uses (`gap = prevAfter + effBefore − overlap`).
- Migrate all gap computations: paginator, body paint pass, column-balance estimate, `sumCellContentHeight`, `splitCellContentByHeight` (measure + split sums), `renderParaList`, `renderCellContent`, `renderCellContentFragment`, and the text-box path `shapeParagraphGapBefore` — body, table cell, and text box share one kernel (Word measured perfect parity across the three).
- `renderParaList` (notes flow) previously left `gap = prevAfter` even for both-toggle pairs — now aligned with every other path (0), per the adjudication.

## Verification

- TDD: the adjudicated 6-case table pinned at three levels — `shape-contextual-spacing.test.ts` (text-box helper), `table-spacing-collapse.test.ts` (cell measure path), and `contextual-spacing-body-paint.test.ts` (body paginate+paint integration: painted baselines, fails if paginator and paint fall out of lockstep; added per independent review). Red on the old gate, Green after.
- Full docx unit suite: 1379 tests pass.
- Root `pnpm typecheck` passes.
- docx VRT: all 78 checks pass; demo/sample-1 pixel-diff counts are byte-identical with and without the change (pre-existing baseline noise), private samples 100% — no VRT sample exercises one-sided toggles.
- Independent review (Codex gpt-5.6-sol, read-only): approve; findings (stale doc comments, body-path test coverage) addressed in this PR.
- End-to-end: sample-57 rendered through the fixed renderer measures 2 / 10 / 0 / 0 / 12 / 12 pt in body, cell, and text box (±0.5pt ink-band quantisation) — all 18 match the Word PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)