### PR TITLE
fix(core,docx,pptx,xlsx): reflect vertical Tr long-stroke marks (ー 〜 ～) to match Word

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -398,6 +398,7 @@ export {
   verticalFormSubstitute,
   verticalBracketFormSubstitute,
   verticalTrUprightFallback,
+  verticalTrMirrorFallback,
   VO_UNICODE_VERSION,
 } from './text/vertical-orientation';
 export type { VerticalOrientation } from './text/vertical-orientation';

--- a/packages/core/src/text/vertical-orientation.test.ts
+++ b/packages/core/src/text/vertical-orientation.test.ts
@@ -4,6 +4,7 @@ import {
   verticalFormSubstitute,
   verticalBracketFormSubstitute,
   verticalTrUprightFallback,
+  verticalTrMirrorFallback,
 } from './vertical-orientation.js';
 
 const cp = (ch: string): number => ch.codePointAt(0) ?? 0;
@@ -167,6 +168,30 @@ describe('verticalBracketFormSubstitute (UAX #50 Tr code points → U+FE1x/FE3x 
     expect(verticalTrUprightFallback(0x30fc)).toBe(false); // ー
     expect(verticalTrUprightFallback(0x300c)).toBe(false); // 「 (substituted, not fallback)
     expect(verticalTrUprightFallback(cp('漢'))).toBe(false); // ideograph
+  });
+
+  it('verticalTrMirrorFallback: the long-stroke Tr marks reflect; quotes/colon do NOT', () => {
+    // The prolonged sound mark ー and the wave dash / fullwidth tilde 〜／～ are vo=Tr
+    // with NO Unicode vertical form, so they take the ROTATE fallback — but their
+    // font-DESIGNED vertical glyph is the HORIZONTAL REFLECTION of the +90° rotation,
+    // not the rotation (a documented Japanese typographic convention: 起筆/curvature
+    // flip left-right between orientations). Verified against the Word PDF (sample-47,
+    // Yu Mincho) and the font's own `vert` glyph (Hiragino cid07891 for ー): the
+    // rotated horizontal glyph bulges to the OPPOSITE side of the designed vertical.
+    expect(verticalTrMirrorFallback(0x30fc)).toBe(true); // ー prolonged sound mark
+    expect(verticalTrMirrorFallback(0x301c)).toBe(true); // 〜 wave dash
+    expect(verticalTrMirrorFallback(0xff5e)).toBe(true); // ～ fullwidth tilde
+    // The double quotes ARE Tr rotate-fallback too, but their designed vertical form
+    // IS the +90° rotation (font-verified), so they must NOT reflect — reflecting them
+    // would swap the comma-hook direction. The colon ： is symmetric (side-by-side
+    // dots) so it needs no reflection; it stays on the plain rotate path.
+    expect(verticalTrMirrorFallback(0x201c)).toBe(false); // “ left double quote
+    expect(verticalTrMirrorFallback(0x201d)).toBe(false); // ” right double quote
+    expect(verticalTrMirrorFallback(0xff1a)).toBe(false); // ： fullwidth colon
+    expect(verticalTrMirrorFallback(0xff1b)).toBe(false); // ； fullwidth semicolon (upright fallback)
+    expect(verticalTrMirrorFallback(0x300c)).toBe(false); // 「 (substituted bracket, not rotate)
+    expect(verticalTrMirrorFallback(cp('漢'))).toBe(false); // ideograph
+    expect(verticalTrMirrorFallback(cp('A'))).toBe(false); // Latin (sideways)
   });
 
   it('returns null for non-bracket code points (Tu punctuation, ideographs, Latin)', () => {

--- a/packages/core/src/text/vertical-orientation.ts
+++ b/packages/core/src/text/vertical-orientation.ts
@@ -278,3 +278,52 @@ const VERTICAL_TR_UPRIGHT_FALLBACK: ReadonlySet<number> = new Set<number>([
 export function verticalTrUprightFallback(cp: number): boolean {
   return VERTICAL_TR_UPRIGHT_FALLBACK.has(cp);
 }
+
+// The vo=Tr code points whose no-vertical-form ROTATE fallback must additionally be
+// HORIZONTALLY REFLECTED (mirrored) to reproduce Word. These are the long horizontal
+// STROKE marks — the katakana-hiragana prolonged sound mark ー and the wave dash /
+// fullwidth tilde 〜／～ — whose font-DESIGNED vertical form is a reflection of the
+// +90° rotation of the horizontal glyph, NOT the rotation itself. In vertical Japanese
+// typography the 起筆 (brush entry / uroko) and the stroke's curvature flip left↔right
+// between the horizontal and vertical orientations; a type designer draws the vertical
+// glyph accordingly (the horizontal and vertical forms are mirror images across the
+// stroke axis). A Canvas cannot invoke the font's `vert`/`vrt2` feature to reach that
+// designed glyph, so the renderers rotate AND reflect the horizontal glyph to match.
+//
+// Ground truth (font actual-form, not sample-fitting): the designed `vert` glyph in
+// Hiragino Mincho ProN (ー: horizontal cid00660 → vertical cid07891; 〜: cid00665 →
+// cid07894) bulges to the OPPOSITE side of the +90° CW rotation of the horizontal
+// glyph, and the Word PDF (sample-47, Yu Mincho) renders ー with its head at the TOP
+// bulging RIGHT while a plain +90° rotation bulges LEFT — a left-right mirror.
+//
+// Deliberately EXCLUDED (they are vo=Tr rotate-fallback too, but must NOT reflect):
+//   • “ ” U+201C/201D double quotes — their designed vertical form IS the +90° rotation
+//     (font-verified: the comma-hooks match the rotation exactly); reflecting them would
+//     reverse the hook direction. They stay on the plain rotate path.
+//   • ： FF1A fullwidth colon — its vertical form is two dots side by side, symmetric
+//     under a horizontal mirror, so reflection is a visual no-op; kept off this set so
+//     the plain rotate path (which already reproduces FE13, issue #969) is unchanged.
+//   • ゠ U+30A0 double hyphen — two vertical bars, likewise symmetric (no-op).
+// The halfwidth ｰ (FF70) and the em dash / horizontal bar (2014/2015) are vo=R, so they
+// take the SIDEWAYS branch, not this rotate fallback.
+const VERTICAL_TR_MIRROR_FALLBACK: ReadonlySet<number> = new Set<number>([
+  0x30fc, // ー katakana-hiragana prolonged sound mark → vertical form is a reflection
+  0x301c, // 〜 wave dash                              → vertical form is a reflection
+  0xff5e, // ～ fullwidth tilde (same glyph as 〜)      → vertical form is a reflection
+]);
+
+/**
+ * True when a vo=Tr code point with NO substituted vertical form must be
+ * HORIZONTALLY REFLECTED (in addition to the ROTATE fallback) to match Word — the
+ * long-stroke marks ー and 〜／～ whose font-designed vertical glyph is a mirror of
+ * the +90° rotation, not the rotation. The double quotes “ ” and colon ： return
+ * false (their rotate fallback needs no reflection — quotes rotate exactly, the
+ * colon is symmetric). This overrides the informative UAX #50 Tr fallback the way a
+ * layout application may; the renderers implement the reflection geometrically
+ * (a Canvas cannot reach the font's `vert` OpenType glyph).
+ *
+ * @param cp A Unicode scalar value.
+ */
+export function verticalTrMirrorFallback(cp: number): boolean {
+  return VERTICAL_TR_MIRROR_FALLBACK.has(cp);
+}

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -223,15 +223,52 @@ describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin side
     expect(fills.map((f) => f.x)).toEqual([0, 14]);
   });
 
-  it('rotates a Tr glyph WITHOUT a vertical form (ー) with the page — centred, NOT counter-rotated', () => {
+  it('reflects a Tr long-stroke mark (ー) about the column — rotate fallback + horizontal mirror, NOT counter-rotated', () => {
     const { ctx, ops } = mockCtx();
     drawVerticalRun(ctx, 'ー', 100, 200, 12, 0);
-    // ー (U+30FC) has no U+FE3x vertical form, so it keeps the rotate fallback:
-    // the page rotation only (no −90° counter-rotation), centred on the column at
-    // the cell centre (105, 200) with center/middle alignment.
+    // ー (U+30FC) has no U+FE3x vertical form, so it takes the ROTATE fallback — but
+    // its font-designed vertical form is the HORIZONTAL REFLECTION of the +90° page
+    // rotation, not the rotation (verticalTrMirrorFallback; Word/PDF + font `vert`
+    // glyph verified). In the +90° page frame that reflection is `scale(1, -1)` about
+    // the cell centre: translate to (cx, baseline)=(105, 200), scale(1, -1), then a
+    // center/middle fillText at the local origin. No −90° counter-rotation (it is not
+    // upright) and no page-frame rotate op is recorded.
     expect(ops.some((o) => o.op === 'rotate')).toBe(false);
+    const translate = ops.find((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
+    expect(translate).toEqual({ op: 'translate', x: 105, y: 200 });
+    const scale = ops.find((o): o is Extract<Op, { op: 'scale' }> => o.op === 'scale');
+    expect(scale).toEqual({ op: 'scale', sx: 1, sy: -1 });
     const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
-    expect(fill).toMatchObject({ text: 'ー', x: 105, y: 200, align: 'center', baseline: 'middle' });
+    expect(fill).toMatchObject({ text: 'ー', x: 0, y: 0, align: 'center', baseline: 'middle' });
+  });
+
+  it('reflects the wave dash / fullwidth tilde (〜 ～) like ー', () => {
+    // 〜 (U+301C) and ～ (U+FF5E) share ー's reflection (their designed vertical form
+    // is an S-curve = mirror of the +90° rotation's reverse-S). Same scale(1, -1).
+    for (const ch of ['〜', '～']) {
+      const { ctx, ops } = mockCtx();
+      drawVerticalRun(ctx, ch, 0, 0, 12, 0);
+      expect(ops.some((o) => o.op === 'rotate')).toBe(false);
+      const scale = ops.find((o): o is Extract<Op, { op: 'scale' }> => o.op === 'scale');
+      expect(scale).toEqual({ op: 'scale', sx: 1, sy: -1 });
+      const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+      expect(fill).toMatchObject({ text: ch, x: 0, y: 0, align: 'center', baseline: 'middle' });
+    }
+  });
+
+  it('does NOT reflect a Tr rotate glyph whose vertical form is a pure rotation (quotes “ ”)', () => {
+    // The double quotes are vo=Tr rotate-fallback, but their designed vertical form IS
+    // the +90° rotation (font-verified), so they must NOT reflect — they keep the plain
+    // fillText in the page frame at the cell centre, with NO scale and NO translate.
+    for (const ch of ['“', '”']) {
+      const { ctx, ops } = mockCtx();
+      drawVerticalRun(ctx, ch, 100, 200, 12, 0);
+      expect(ops.some((o) => o.op === 'rotate')).toBe(false);
+      expect(ops.some((o) => o.op === 'scale')).toBe(false);
+      expect(ops.some((o) => o.op === 'translate')).toBe(false);
+      const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+      expect(fill).toMatchObject({ text: ch, x: 105, y: 200, align: 'center', baseline: 'middle' });
+    }
   });
 
   it('substitutes a Tr bracket with its vertical form (（→︵, ）→︶) and draws it UPRIGHT', () => {

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -27,13 +27,22 @@
 //     form (core `verticalBracketFormSubstitute`) present in the substitute fonts;
 //     UAX#50 §5 makes Tr "substitute a vertical glyph, ROTATE only as fallback", so
 //     we SUBSTITUTE and draw them upright (Word/PowerPoint-verified, #969). Tr code
-//     points with NO substituted form take a geometric fallback: ROTATE — the ー
-//     prolonged sound mark, the quotes “”, and the fullwidth colon ：(whose FE13
-//     form is absent from most render fonts, so a 90° rotation of the base reproduces
-//     FE13's side-by-side dots) — drawn CENTRED on the column axis via a plain
-//     `fillText` in the +90° page frame; or UPRIGHT — the fullwidth semicolon ；,
-//     whose FE14 form is an upright dot-over-comma, not a rotation (issue #969
-//     follow-up; see core `verticalTrUprightFallback`).
+//     points with NO substituted form take a geometric fallback, one of three:
+//       – ROTATE (plain): the quotes “” and the fullwidth colon ：— drawn CENTRED on
+//         the column via a plain `fillText` in the +90° page frame. The rotation IS
+//         the font's designed vertical form for these (font-verified: the quotes'
+//         comma-hooks match, and the colon's FE13 side-by-side dots fall out of the
+//         base rotation since its FE13 form is absent from most render fonts).
+//       – ROTATE + REFLECT: the long-stroke marks ー (prolonged sound mark) and 〜 ～
+//         (wave dash / tilde) — core `verticalTrMirrorFallback`. Their font-DESIGNED
+//         vertical glyph is the HORIZONTAL REFLECTION of the +90° rotation, not the
+//         rotation (the 起筆/curvature flips left↔right between orientations — a
+//         documented Japanese typographic convention; Word PDF sample-47 + font `vert`
+//         glyph verified). A Canvas cannot reach the `vert` glyph, so we rotate AND
+//         reflect via `scale(1, -1)` about the cell centre (the on-screen horizontal
+//         mirror in the +90° page frame).
+//       – UPRIGHT: the fullwidth semicolon ；, whose FE14 form is an upright dot-over-
+//         comma, not a rotation (issue #969 follow-up; core `verticalTrUprightFallback`).
 //   • vo=R  (rotated): Latin letters, Western digits, Latin punctuation. Stay
 //     SIDEWAYS (rotated with the page) — the conventional "縦中横 not applied"
 //     appearance — drawn as an ordinary contextual `fillText` at the alphabetic
@@ -60,6 +69,7 @@ import {
   verticalFormSubstitute,
   verticalBracketFormSubstitute,
   verticalTrUprightFallback,
+  verticalTrMirrorFallback,
 } from '@silurus/ooxml-core';
 
 /** How a code point is painted inside the +90°-rotated vertical page:
@@ -364,21 +374,37 @@ export function drawVerticalRun(
       ctx.restore();
     } else if (mode === 'rotate') {
       // vo=Tr with NO substituted vertical form and NOT the upright-fallback
-      // semicolon: ー (U+30FC), the double quotes “”, and the fullwidth colon ：
-      // (FF1A). UAX#50's Tr fallback (no vertical glyph reachable on a Canvas) is
-      // to ROTATE the glyph 90° CW. A plain `fillText` in the +90° page frame IS
-      // that rotation; centre it on the column with `center`/`middle` at the cell
-      // centre. For the colon this reproduces FE13's design directly (the two
-      // vertically-stacked dots become side by side), Word-verified (issue #969
-      // follow-up). (The substituted bracket forms never reach here — they were
-      // drawn upright above; a rotated bracket's ink offset is not Canvas-measurable.)
+      // semicolon: ー (U+30FC), the wave dash / tilde 〜 ～, the double quotes “”,
+      // and the fullwidth colon ：(FF1A). UAX#50's Tr fallback (no vertical glyph
+      // reachable on a Canvas) is to ROTATE the glyph 90° CW; a plain `fillText` in
+      // the +90° page frame IS that rotation, centred on the column with
+      // `center`/`middle` at the cell centre. For the colon this reproduces FE13's
+      // design directly (the two vertically-stacked dots become side by side),
+      // Word-verified (issue #969 follow-up); for the quotes the rotation matches the
+      // font's designed vertical form exactly (font-verified).
+      //
+      // The long-stroke marks ー and 〜 ～ (verticalTrMirrorFallback) are the
+      // EXCEPTION: their font-DESIGNED vertical form is the HORIZONTAL REFLECTION of
+      // that +90° rotation, not the rotation — the 起筆/curvature flips left↔right
+      // between orientations (Word PDF sample-47 + font `vert` glyph verified: a plain
+      // rotation of ー bulges LEFT, Word/the designed glyph bulge RIGHT). Since a
+      // Canvas cannot invoke the font's `vert` OpenType glyph, we reproduce it by
+      // reflecting: in the +90° page frame the on-screen horizontal mirror is
+      // `scale(1, -1)` about the cell centre. Advance/measure and the column centring
+      // are unchanged (the em box is symmetric about the cell centre), so only the
+      // glyph's chirality flips. (Substituted bracket forms never reach here — they
+      // were drawn upright above; a rotated bracket's ink offset is not measurable.)
       const cx = x + ax + adv / 2;
+      const mirror = verticalTrMirrorFallback(cp);
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      if (scaled) {
+      if (mirror || scaled) {
         ctx.save();
         ctx.translate(cx, baseline);
-        ctx.scale(charScale, 1);
+        // `scale(1, -1)` is the on-screen horizontal mirror in the +90° page frame
+        // (screen −x ↔ page-frame +y); combine with the §17.3.2.43 `w:w` width
+        // compression on the line axis. Non-mirror glyphs keep sy=+1.
+        ctx.scale(charScale, mirror ? -1 : 1);
         ctx.fillText(ch, 0, 0);
         ctx.restore();
       } else {

--- a/packages/node/src/docx-vertical-prolonged-mark.probe.test.ts
+++ b/packages/node/src/docx-vertical-prolonged-mark.probe.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Vertical (tbRl) prolonged sound mark `ー` reflection probe — ECMA-376 §17.6.20 +
+ * UAX#50 §5 Tr fallback (core `verticalTrMirrorFallback`).
+ *
+ * `ー` (U+30FC) is vo=Tr with NO Unicode vertical presentation form, so it takes the
+ * ROTATE fallback. But its font-DESIGNED vertical glyph is the HORIZONTAL REFLECTION
+ * of the +90° page rotation, NOT the rotation itself — a documented Japanese
+ * typographic convention (the 起筆/uroko and the stroke curvature flip left↔right
+ * between the horizontal and vertical orientations). A plain rotation therefore paints
+ * a LEFT-RIGHT MIRROR of Word.
+ *
+ * Word ground truth (sample-47 PDF, Yu Mincho via macOS Quartz) and the font's own
+ * `vert` glyph (Hiragino Mincho ProN cid07891) agree: the vertical `ー` has its thick
+ * HEAD at the TOP bulging to the RIGHT, tapering to a blunt bottom-left. The
+ * un-reflected +90° rotation bulges LEFT. `drawVerticalRun` reflects the mark via
+ * `scale(1, -1)` (the on-screen horizontal mirror in the +90° page frame) to match.
+ *
+ * This probe renders `話ーー話` through the REAL `drawVerticalRun` and asserts the
+ * mark's HEAD (top band) ink leans to the physical RIGHT of the glyph's own vertical
+ * axis — the Word topology — which a sign regression (dropping the reflection, or
+ * reflecting the wrong axis) would flip. Measured relative to the glyph's OWN ink
+ * bbox so it is font-metric independent; the separation from the mirror is ~0.15 of
+ * the glyph width (robust, not a sub-pixel margin).
+ *
+ * CI-safe: gated on skia (devDependency) + Hiragino (macOS dev host).
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { loadSkiaForTests, importForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, FontLibrary } = (skia ?? {}) as Skia;
+const MINCHO = '/System/Library/Fonts/ヒラギノ明朝 ProN.ttc';
+const haveFont = existsSync(MINCHO);
+const vtMod = await importForTests(
+  () => import('../../docx/src/vertical-text.ts'),
+  'packages/docx/src/vertical-text.ts',
+);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+function ink(d: Uint8ClampedArray, i: number): number {
+  return 255 - (0.299 * d[i] + 0.587 * d[i + 1] + 0.114 * d[i + 2]);
+}
+
+describe.skipIf(!skia || !vtMod || !haveFont)('docx vertical prolonged sound mark ー reflection (§17.6.20 / UAX#50)', () => {
+  const fontPx = 120;
+  const W = 400, H = 700, baseline = 220, logX = 40, cellW = fontPx;
+  const centerline = W - baseline; // column centreline in physical x
+
+  /** Render "話<mid>話" via drawVerticalRun and return the pixel buffer. */
+  function render(mid: string): Uint8ClampedArray {
+    const { drawVerticalRun } = vtMod as { drawVerticalRun: (...a: Any[]) => void };
+    for (const fam of ['Yu Mincho', 'MS Mincho', 'Hiragino Mincho ProN']) FontLibrary.use(fam, [MINCHO]);
+    const canvas = new Canvas(W, H);
+    const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+    ctx.fillStyle = '#fff'; ctx.fillRect(0, 0, W, H);
+    ctx.fillStyle = '#000';
+    ctx.font = `${fontPx}px "MS Mincho", serif`;
+    ctx.save();
+    ctx.translate(W, 0); ctx.rotate(Math.PI / 2);
+    drawVerticalRun(ctx, `話${mid}話`, logX, baseline, fontPx, 0);
+    ctx.restore();
+    return ctx.getImageData(0, 0, W, H).data;
+  }
+
+  /**
+   * The middle cell (2nd glyph) occupies the along-column band physical y in
+   * [logX+cellW, logX+2cellW]. Return the ink bbox there plus the cross-axis (physical
+   * x) centroid of the TOP third of that ink — where the mark's head sits — normalised
+   * to the glyph's own ink-bbox width (0 = left edge, 1 = right edge). Also the whole-
+   * glyph cross centroid for the column-centring sanity check.
+   */
+  function head(data: Uint8ClampedArray): { topNorm: number; wholeCx: number } {
+    const py0 = logX + cellW, py1 = logX + 2 * cellW;
+    let x0 = W, x1 = 0, sxAll = 0, swAll = 0;
+    for (let py = py0; py < py1; py++) for (let px = 0; px < W; px++) {
+      const w = ink(data, (py * W + px) * 4);
+      if (w > 40) { if (px < x0) x0 = px; if (px > x1) x1 = px; sxAll += px * w; swAll += w; }
+    }
+    const topEnd = py0 + (py1 - py0) / 3;
+    let sx = 0, sw = 0;
+    for (let py = py0; py < topEnd; py++) for (let px = 0; px < W; px++) {
+      const w = ink(data, (py * W + px) * 4);
+      if (w > 40) { sx += px * w; sw += w; }
+    }
+    const topCx = sw > 0 ? sx / sw : NaN;
+    return { topNorm: (topCx - x0) / (x1 - x0), wholeCx: swAll > 0 ? sxAll / swAll : NaN };
+  }
+
+  it('ー head leans to the physical RIGHT of its own axis (Word topology), the reflected form', () => {
+    const m = head(render('ー'));
+    // Word / the font `vert` glyph put the head's bulge on the RIGHT: the top-band ink
+    // centroid sits in the RIGHT half of the mark's own width. A dropped/flipped
+    // reflection would land it in the LEFT half (~0.4). Threshold 0.5 with the measured
+    // ~0.57 (vs ~0.43 mirror) leaves a robust, non-sub-pixel margin.
+    expect(m.topNorm).toBeGreaterThan(0.5);
+    // Sanity: the mark still centres on the column (the reflection is about the cell
+    // centre, so the advance/centring is unchanged) — within 0.1em of the centreline.
+    expect(Math.abs(m.wholeCx - centerline)).toBeLessThanOrEqual(0.1 * fontPx);
+  });
+});

--- a/packages/pptx/src/eavert-glyph-orientation.test.ts
+++ b/packages/pptx/src/eavert-glyph-orientation.test.ts
@@ -56,6 +56,9 @@ interface DrawCall {
   /** Accumulated translate-x in effect at draw time — the along-column cell
    *  centre for an upright glyph (translate(cx, …) precedes its fillText). */
   tx: number;
+  /** Net scale-y in effect at draw time. −1 for a reflected Tr long-stroke mark
+   *  (ー 〜 ～ → `scale(1, -1)`); +1 otherwise. */
+  sy: number;
 }
 
 /** Normalise an angle to (−π, π] so 0 (upright) and π/2 (sideways) compare cleanly. */
@@ -75,7 +78,8 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
   let textBaseline: CanvasTextBaseline = 'alphabetic';
   let rotation = 0;
   let tx = 0;
-  const stack: { rotation: number; tx: number }[] = [];
+  let sy = 1;
+  const stack: { rotation: number; tx: number; sy: number }[] = [];
   const px = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
   const calls: DrawCall[] = [];
   const metricsFor = (s: string): TextMetrics => {
@@ -99,13 +103,13 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
     get textAlign() { return textAlign; }, set textAlign(v: CanvasTextAlign) { textAlign = v; },
     get textBaseline() { return textBaseline; }, set textBaseline(v: CanvasTextBaseline) { textBaseline = v; },
     measureText: (s: string) => metricsFor(s),
-    fillText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, tx }),
-    strokeText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, tx }),
-    save: () => { stack.push({ rotation, tx }); },
-    restore: () => { const s = stack.pop(); if (s) { rotation = s.rotation; tx = s.tx; } },
+    fillText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, tx, sy }),
+    strokeText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, tx, sy }),
+    save: () => { stack.push({ rotation, tx, sy }); },
+    restore: () => { const s = stack.pop(); if (s) { rotation = s.rotation; tx = s.tx; sy = s.sy; } },
     translate: (x: number) => { tx += x; },
     rotate: (a: number) => { rotation += a; },
-    scale: () => {},
+    scale: (_sx: number, syArg: number) => { sy *= syArg; },
     beginPath: () => {}, moveTo: () => {}, lineTo: () => {}, stroke: () => {},
     clip: () => {}, rect: () => {}, fillRect: () => {}, drawImage: () => {},
     setLineDash: () => {}, closePath: () => {}, arc: () => {},
@@ -216,11 +220,28 @@ describe('pptx eaVert — UAX#50 per-glyph orientation (§20.1.10.83, issue #790
     expect(norm(mark[0].rot), '； stays upright (the FE14 fallback)').toBeCloseTo(UPRIGHT, 5);
   });
 
-  it('ROTATES a vo=Tr glyph with no vertical form (ー U+30FC) with the page (+90°)', () => {
-    const calls = renderEaVert(TR_ROTATE);
-    const mark = calls.filter((c) => c.text === TR_ROTATE);
-    expect(mark.length, 'ー is painted as its own glyph').toBe(1);
-    expect(norm(mark[0].rot), 'ー rotates 90° (the Tr fallback)').toBeCloseTo(SIDEWAYS, 5);
+  // The long-stroke Tr marks whose designed vertical form is the horizontal MIRROR of
+  // the +90° rotation (core verticalTrMirrorFallback): ー and the wave dash / tilde.
+  it.each(['ー', '〜', '～'])(
+    'ROTATES + REFLECTS the vo=Tr long-stroke mark %s — page +90° plus scale(1,-1)',
+    (mk) => {
+      // These ride the page +90° rotation like the colon, but their font-designed
+      // vertical form is the HORIZONTAL MIRROR of that rotation (Word/PowerPoint +
+      // font `vert` glyph verified — a plain rotation of ー bulges LEFT, the designed
+      // form bulges RIGHT). So they also reflect via `scale(1, -1)`.
+      const mark = renderEaVert(mk).filter((c) => c.text === mk);
+      expect(mark.length, `${mk} is painted as its own glyph`).toBe(1);
+      expect(norm(mark[0].rot), `${mk} rotates 90° (the Tr fallback)`).toBeCloseTo(SIDEWAYS, 5);
+      expect(mark[0].sy, `${mk} is reflected (scale-y = −1)`).toBe(-1);
+    },
+  );
+
+  it('does NOT reflect the vo=Tr colon ： (rotation matches its designed vertical form)', () => {
+    // The colon's FE13 side-by-side dots fall out of the plain rotation (symmetric
+    // under the mirror), so it must NOT get the scale(1,-1) reflection.
+    const mark = renderEaVert('：').filter((c) => c.text === '：');
+    expect(mark.length).toBe(1);
+    expect(mark[0].sy, '： is not reflected (scale-y = +1)').toBe(1);
   });
 
   it('orients a mixed column: CJK upright, Latin sideways, bracket substituted, comma substituted, ー rotated', () => {
@@ -233,6 +254,7 @@ describe('pptx eaVert — UAX#50 per-glyph orientation (§20.1.10.83, issue #790
     expect(at(TU_COMMA_FE), 'comma substituted').toBeTruthy();
     expect(norm(at(TU_COMMA_FE)!.rot)).toBeCloseTo(UPRIGHT, 5);
     expect(norm(at(TR_ROTATE)!.rot)).toBeCloseTo(SIDEWAYS, 5);
+    expect(at(TR_ROTATE)!.sy, 'ー is reflected in the mixed column too').toBe(-1);
   });
 });
 
@@ -281,10 +303,14 @@ describe('drawEaVertRun — per-glyph orientation helper', () => {
     expect(runHelper(TU_COMMA)[0].text).toBe(TU_COMMA_FE);
     expect(norm(runHelper(TU_COMMA)[0].rot)).toBeCloseTo(-Math.PI / 2, 5);
   });
-  it('leaves vo=Tr ー rotated with the page (no counter-rotation, no substitution)', () => {
+  it('leaves vo=Tr ー rotated with the page but REFLECTS it (scale-y −1, no counter-rotation, no substitution)', () => {
     const calls = runHelper(TR_ROTATE);
     expect(calls[0].text).toBe(TR_ROTATE);
     expect(norm(calls[0].rot)).toBeCloseTo(0, 5);
+    // The reflection (core verticalTrMirrorFallback) is the helper's own scale(1,-1);
+    // the +90° page rotation is added by renderTextBody (not installed in this helper
+    // test), so here only the reflection is observable.
+    expect(calls[0].sy, 'ー is reflected').toBe(-1);
   });
   it('advances each cell by measure + letterSpacingPx (the justification pitch)', () => {
     const { ctx: c0, calls: k0 } = mockCtx();

--- a/packages/pptx/src/vertical-text.ts
+++ b/packages/pptx/src/vertical-text.ts
@@ -22,11 +22,13 @@
 //     form (core `verticalBracketFormSubstitute`) present in the substitute fonts;
 //     UAX#50 §5 makes Tr "substitute a vertical glyph, ROTATE only as fallback", so
 //     we substitute and draw them upright (Word/PowerPoint-verified, #969). Tr code
-//     points with no substituted form take a geometric fallback: ROTATE (the ー
-//     prolonged sound mark, the quotes “”, and the colon ：→ FE13's side-by-side
-//     dots) or UPRIGHT (the semicolon ；→ FE14's dot-over-comma; issue #969
-//     follow-up, core `verticalTrUprightFallback`) — FE13/FE14 are absent from most
-//     render fonts, so those two take the geometric path.
+//     points with no substituted form take a geometric fallback: ROTATE (the quotes
+//     “” and the colon ：→ FE13's side-by-side dots), ROTATE + REFLECT (the long-
+//     stroke marks ー 〜 ～ whose designed vertical form is a horizontal mirror of the
+//     rotation, not the rotation — core `verticalTrMirrorFallback`; `scale(1, -1)`),
+//     or UPRIGHT (the semicolon ；→ FE14's dot-over-comma; issue #969 follow-up, core
+//     `verticalTrUprightFallback`) — FE13/FE14 are absent from most render fonts, so
+//     those take the geometric path.
 //   • vo=R  (rotated): Latin letters, Western digits, Latin punctuation stay
 //     SIDEWAYS (rotated with the page) — the conventional "縦中横 not applied" look.
 //
@@ -41,6 +43,7 @@ import {
   verticalFormSubstitute,
   verticalBracketFormSubstitute,
   verticalTrUprightFallback,
+  verticalTrMirrorFallback,
 } from '@silurus/ooxml-core';
 
 type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
@@ -182,14 +185,30 @@ export function drawEaVertRun(
       ctx.restore();
     } else if (vo === 'Tr') {
       // vo=Tr with NO substituted vertical form and NOT the upright-fallback
-      // semicolon: ー (U+30FC), quotes “”, and the colon ：(FF1A). The Tr fallback is
-      // to ROTATE 90° CW — a plain draw in the +90° page frame IS that rotation;
-      // centre it on the column. For the colon this reproduces FE13's design (the
-      // vertically-stacked dots become side by side), Word-verified (issue #969).
+      // semicolon: ー (U+30FC), the wave dash / tilde 〜 ～, quotes “”, and the colon
+      // ：(FF1A). The Tr fallback is to ROTATE 90° CW — a plain draw in the +90° page
+      // frame IS that rotation; centre it on the column. For the colon this reproduces
+      // FE13's design (the vertically-stacked dots become side by side) and for the
+      // quotes it matches the font's designed vertical form, both Word-verified (#969).
+      //
+      // The long-stroke marks ー and 〜 ～ (core `verticalTrMirrorFallback`) are the
+      // EXCEPTION: their font-designed vertical form is the HORIZONTAL REFLECTION of
+      // the +90° rotation, not the rotation (Word PDF + font `vert` glyph verified — a
+      // plain rotation of ー bulges LEFT, Word bulges RIGHT). A Canvas cannot reach the
+      // `vert` glyph, so reflect via `scale(1, -1)` about the cell centre (the on-screen
+      // horizontal mirror in the +90° page frame). Same fix as docx `drawVerticalRun`.
       const cx = x + ax + adv / 2;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      draw(ch, cx, crossCenterY);
+      if (verticalTrMirrorFallback(cp)) {
+        ctx.save();
+        ctx.translate(cx, crossCenterY);
+        ctx.scale(1, -1);
+        draw(ch, 0, 0);
+        ctx.restore();
+      } else {
+        draw(ch, cx, crossCenterY);
+      }
     } else {
       // vo=R (Latin/digits): stay SIDEWAYS (rotated with the page). Draw at the
       // alphabetic baseline; its ink already centres on the column centreline the

--- a/packages/xlsx/src/stacked-glyph-orientation.test.ts
+++ b/packages/xlsx/src/stacked-glyph-orientation.test.ts
@@ -48,6 +48,9 @@ interface DrawCall {
   y: number;
   /** Net canvas rotation in effect at draw time, normalised to (−π, π]. */
   rot: number;
+  /** Net scale-y in effect at draw time. −1 for a reflected Tr long-stroke mark
+   *  (ー 〜 ～ → `scale(1, -1)`); +1 otherwise. */
+  sy: number;
 }
 
 function norm(a: number): number {
@@ -59,18 +62,20 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
   let textAlign: CanvasTextAlign = 'center';
   let textBaseline: CanvasTextBaseline = 'top';
   let rotation = 0;
-  const stack: number[] = [];
+  let sy = 1;
+  const stack: Array<{ rotation: number; sy: number }> = [];
   const calls: DrawCall[] = [];
   const ctx = {
     get font() { return font; }, set font(v: string) { font = v; },
     get textAlign() { return textAlign; }, set textAlign(v: CanvasTextAlign) { textAlign = v; },
     get textBaseline() { return textBaseline; }, set textBaseline(v: CanvasTextBaseline) { textBaseline = v; },
     measureText: (s: string) => ({ width: [...s].length * 20 }) as TextMetrics,
-    fillText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation }),
-    save: () => { stack.push(rotation); },
-    restore: () => { rotation = stack.pop() ?? rotation; },
+    fillText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, sy }),
+    save: () => { stack.push({ rotation, sy }); },
+    restore: () => { const s = stack.pop(); if (s) { rotation = s.rotation; sy = s.sy; } },
     translate: () => {},
     rotate: (a: number) => { rotation += a; },
+    scale: (_sx: number, syArg: number) => { sy *= syArg; },
     fillStyle: '#000',
   };
   return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
@@ -144,10 +149,27 @@ describe('xlsx stacked text — UAX#50 per-glyph orientation (textRotation=255, 
     expect(norm(calls[0].rot), '； stays upright').toBeCloseTo(UPRIGHT, 5);
   });
 
-  it('ROTATES a vo=Tr glyph with no vertical form (ー) by 90°', () => {
-    const calls = draw(TR_ROTATE);
-    expect(calls.length).toBe(1);
-    expect(calls[0].text).toBe(TR_ROTATE);
-    expect(norm(calls[0].rot), 'ー is rotated to a vertical bar').toBeCloseTo(ROTATED, 5);
+  // The long-stroke Tr marks whose designed vertical form is the horizontal MIRROR of
+  // the rotation (core verticalTrMirrorFallback): ー and the wave dash / tilde.
+  it.each(['ー', '〜', '～'])(
+    'ROTATES + REFLECTS the vo=Tr long-stroke mark %s by 90° plus scale(1,-1)',
+    (mk) => {
+      // These rotate 90° like the colon, but their font-designed vertical form is the
+      // HORIZONTAL MIRROR of that rotation (Word/PowerPoint + font `vert` glyph
+      // verified — a plain rotation of ー bulges LEFT, the designed form bulges RIGHT).
+      // So they also reflect via `scale(1, -1)`.
+      const calls = draw(mk);
+      expect(calls.length).toBe(1);
+      expect(calls[0].text).toBe(mk);
+      expect(norm(calls[0].rot), `${mk} is rotated to a vertical bar`).toBeCloseTo(ROTATED, 5);
+      expect(calls[0].sy, `${mk} is reflected (scale-y = −1)`).toBe(-1);
+    },
+  );
+
+  it('does NOT reflect the vo=Tr colon ： (rotation already matches its designed form)', () => {
+    // The colon's FE13 side-by-side dots fall out of the plain rotation (symmetric
+    // under the mirror), so it must NOT get the scale(1,-1) reflection.
+    const calls = draw('：');
+    expect(calls[0].sy, '： is not reflected (scale-y = +1)').toBe(1);
   });
 });

--- a/packages/xlsx/src/vertical-text.ts
+++ b/packages/xlsx/src/vertical-text.ts
@@ -18,18 +18,21 @@
 //     SUBSTITUTE that form (core `verticalBracketFormSubstitute`), drawn upright
 //     (UAX#50 §5 "substitute a vertical glyph, rotate only as fallback"). XLSX has
 //     no Excel ground-truth image, so 〖〗 follow the Word/PowerPoint verdict.
-//   • vo=Tr with NO substituted form → a geometric fallback: ROTATE 90° CW (ー U+30FC,
-//     quotes “”, and the colon ： — a rotation turns the base ：'s stacked dots into
-//     FE13's side-by-side dots) or UPRIGHT (the semicolon ；, whose FE14 form is an
-//     upright dot-over-comma, not a rotation; core `verticalTrUprightFallback`).
-//     FE13/FE14 are absent from most render fonts, so ：；take this geometric path
-//     rather than substitution (issue #969 follow-up).
+//   • vo=Tr with NO substituted form → a geometric fallback: ROTATE 90° CW (the
+//     quotes “” and the colon ： — a rotation turns the base ：'s stacked dots into
+//     FE13's side-by-side dots), ROTATE + REFLECT (the long-stroke marks ー 〜 ～,
+//     whose font-designed vertical form is a horizontal mirror of the rotation, not
+//     the rotation — core `verticalTrMirrorFallback`; add `scale(1, -1)`), or UPRIGHT
+//     (the semicolon ；, whose FE14 form is an upright dot-over-comma, not a rotation;
+//     core `verticalTrUprightFallback`). FE13/FE14 are absent from most render fonts,
+//     so ：；take this geometric path rather than substitution (issue #969 follow-up).
 
 import {
   verticalOrientation,
   verticalFormSubstitute,
   verticalBracketFormSubstitute,
   verticalTrUprightFallback,
+  verticalTrMirrorFallback,
 } from '@silurus/ooxml-core';
 
 type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
@@ -81,11 +84,21 @@ export function drawStackedVerticalChar(
       ctx.fillText(ch, centerX, cellTopY);
       return;
     }
-    // Fallback: no vertical form (ー U+30FC, quotes, colon ：) → rotate 90° CW, centred
-    // in the cell slot. save/restore also restores the caller's textAlign/textBaseline.
+    // Fallback: no vertical form (ー U+30FC, wave dash / tilde 〜 ～, quotes, colon ：)
+    // → rotate 90° CW, centred in the cell slot. save/restore also restores the
+    // caller's textAlign/textBaseline.
+    //
+    // The long-stroke marks ー and 〜 ～ (core `verticalTrMirrorFallback`) additionally
+    // REFLECT: their font-designed vertical form is the HORIZONTAL MIRROR of the +90°
+    // rotation, not the rotation (Word/PowerPoint + font `vert` glyph verified — a plain
+    // rotation of ー bulges LEFT, the designed form bulges RIGHT). After the +90° rotate,
+    // `scale(1, -1)` is the on-screen horizontal mirror. The quotes and colon do NOT
+    // reflect (their rotation matches the designed form; the colon is symmetric). Same
+    // fix as docx `drawVerticalRun` / pptx `drawEaVertRun`.
     ctx.save();
     ctx.translate(centerX, cellTopY + charH / 2);
     ctx.rotate(Math.PI / 2);
+    if (verticalTrMirrorFallback(cp)) ctx.scale(1, -1);
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillText(ch, 0, 0);


### PR DESCRIPTION
## Problem

The katakana-hiragana prolonged sound mark **ー (U+30FC)** rendered as a **left-right mirror** of Word/PowerPoint in vertical text — across docx `tbRl`, pptx `eaVert`, and xlsx stacked. Confirmed by a user's zoomed comparison of sample-47.

## Root cause

All three renderers fall back to **ROTATE** a `vo=Tr` glyph 90° CW when it has no Unicode vertical presentation form. But the prolonged sound mark's font-**designed** vertical glyph is the **horizontal reflection** of that rotation, not the rotation itself — a documented Japanese typographic convention (the 起筆/uroko and stroke curvature flip left↔right between orientations). A plain rotation therefore paints the mirror image.

## Evidence (empirical adjudication)

- **Word GT** (sample-47.pdf, Yu Mincho via Quartz): ー has its head at the **top bulging RIGHT**.
- **Font `vert` glyph** (Hiragino ProN cid07891, the designed vertical form): also **head-top, bulge RIGHT**.
- **A plain +90° rotation** of the horizontal glyph: **bulge LEFT** — the mirror.
- Rendering sample-47's ー through the real `drawVerticalRun` with the fix reproduces Word's topology: per-segment ink-centroid profile matches Word (0.56–0.60), the mirror of the old (0.37–0.44).

The double quotes `“ ”` and the colon `：` are **NOT** reflected — their designed vertical form *is* the rotation (font-verified); the colon is symmetric under the mirror.

## Fix

- **core**: new `verticalTrMirrorFallback(cp)` classifier (a `ReadonlySet`, same shape as `verticalTrUprightFallback`) for the long-stroke `Tr` marks whose vertical form reflects: **ー (U+30FC), 〜 (U+301C), ～ (U+FF5E)**. The wave dash / fullwidth tilde reflect too (verified: same `vert` glyph cid07894). The wavy dash U+3030 reaches the Tr fallback but has no `vert` substitute, so it stays a plain rotate — excluded.
- **docx / pptx / xlsx**: in the `Tr` rotate fallback, apply `scale(1, -1)` (the on-screen horizontal mirror in the +90° page frame) for those marks. Advance, letter spacing, and column centring are unchanged (the reflection is about the already-centred cell centre; docx composes it with `w:w` as `scale(charScale, -1)`).

## Tests

- core classifier test (`ー/〜/～` reflect; quotes/colon/semicolon/brackets do not).
- deterministic transform assertions in each renderer: `scale-y = −1` for ー/〜/～ (table-driven), `+1` for quotes/colon. The docx unit test also pins the reflection geometry (translate to cell centre, `scale(1,-1)`, centred `fillText`).
- a skia + Hiragino pixel probe (`packages/node/docx-vertical-prolonged-mark.probe.test.ts`) that pins the head's right-lean against a sign regression.

## Cross-package rationale

Same bug, same code path, shared core classifier — the coherent unit of work per AGENTS.md §Cross-Package Integration.

## Review

Codex `gpt-5.6-sol` independently reviewed (read-only) and **approved**: the reflection axis is correct (`R·scale(1,-1) = Hx·R`; `scale(-1,1)` would be an up-down flip), the three renderers are consistent, and advance/centring are preserved.

## VRT

Horizontal rendering is byte-identical (change is inside the vertical rotate branch). sample-26 (tbRl VRT fixture, contains ー ×13) renders without error and now matches Word's ー orientation — a non-regression toward the Word-export reference. No reference images updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)