### PR TITLE
fix(core,docx): docGrid cell count from the Word design line height (#1013)

### DIFF
--- a/packages/core/src/text/line-metrics.test.ts
+++ b/packages/core/src/text/line-metrics.test.ts
@@ -17,6 +17,52 @@ describe('fontWinLineHeightRatio', () => {
     expect(fontWinLineHeightRatio('meiryo ui')).toBeCloseTo(3269 / 2048, 5);
     expect(fontWinLineHeightRatio('MEIRYO')).toBeCloseTo(3269 / 2048, 5);
   });
+  it('returns the Word FE line-height ratio for EA lines in Yu Mincho / Yu Gothic (1.4327 em)', () => {
+    // Word's Far East single-line height for the Yu faces is 1.3 × the hhea
+    // glyph box: (ascent 1802 + |descent| 455) × 1.3 / 2048 = 1.43267 em.
+    // hhea values extracted from the Word-bundled yumin.ttf / YuGoth*.ttc
+    // (identical across Regular/Light/Demibold/Bold weights); the 1.3 Word FE
+    // factor is Word-PDF measured (sample-58 adjudication, issue #1013): the
+    // off-grid single-line pitch is 20.04 pt at 14 pt and 22.94 pt at 16 pt —
+    // 1.432 ± 0.002 em — and the same height reproduces all 15 docGrid cell
+    // counts. Neither the win sum (1.287 em) nor the hhea+lineGap box
+    // (1.602 em) matches Word.
+    const yu = (2257 * 1.3) / 2048;
+    expect(fontWinLineHeightRatio('Yu Mincho', true)).toBeCloseTo(yu, 5);
+    expect(fontWinLineHeightRatio('游明朝', true)).toBeCloseTo(yu, 5);
+    expect(fontWinLineHeightRatio('YuMincho', true)).toBeCloseTo(yu, 5);
+    expect(fontWinLineHeightRatio('Yu Mincho Light', true)).toBeCloseTo(yu, 5);
+    expect(fontWinLineHeightRatio('Yu Gothic', true)).toBeCloseTo(yu, 5);
+    expect(fontWinLineHeightRatio('游ゴシック', true)).toBeCloseTo(yu, 5);
+  });
+  it('hides the Yu FE entry from non-EA (Latin) lines — win-box behavior preserved', () => {
+    // Word gives the FE height to East Asian lines only: a pure-Latin line in
+    // the same Yu Mincho measures 13.44 pt at 10.5 pt (demo/sample-1 page-6
+    // footnote, Word PDF) = the win sum 1.28711 em, NOT 1.43267 em. Latin
+    // callers therefore see the family as untabled (substituted Canvas box).
+    expect(fontWinLineHeightRatio('Yu Mincho')).toBeNull();
+    expect(fontWinLineHeightRatio('游明朝', false)).toBeNull();
+    expect(intendedSingleLinePx('Yu Mincho', 96)).toBe(0);
+    const r = correctLineMetrics('Yu Mincho', 12, 15.38, 3.84);
+    expect(r).toEqual({ ascent: 15.38, descent: 3.84 });
+  });
+  it('does NOT catch Yu Gothic UI (different, unverified metrics)', () => {
+    expect(fontWinLineHeightRatio('Yu Gothic UI', true)).toBeNull();
+  });
+  it('keeps non-eaOnly entries visible to every script (Meiryo)', () => {
+    // Meiryo's usWin sum already encodes the FE height (1.3 × its hhea box),
+    // so the same value serves Latin and EA lines — sample-3 calibration.
+    expect(fontWinLineHeightRatio('Meiryo', true)).toBeCloseTo(3269 / 2048, 5);
+    expect(fontWinLineHeightRatio('Meiryo', false)).toBeCloseTo(3269 / 2048, 5);
+  });
+  it('shrinks an over-large substitute box to the Yu Mincho design box on EA lines', () => {
+    // Canvas reports the win-ish 1.602 em box for 游明朝 (asc 1.2817 + desc
+    // 0.32 em); Word's design box for a CJK line is 1.43267 em, so the
+    // measured metrics are replaced by the design ascent/descent.
+    const r = correctLineMetrics('游明朝', 12, 15.38, 3.84, true);
+    expect(r.ascent).toBeCloseTo(((1802 * 1.3) / 2048) * 12, 5);
+    expect(r.descent).toBeCloseTo(((455 * 1.3) / 2048) * 12, 5);
+  });
   it('returns the hhea single-line ratio for tabled Latin fonts (Times New Roman, Arial)', () => {
     // Word sizes a line from the hhea line height (ascent+|descent|+lineGap), not
     // the win sum Canvas reports. Times New Roman: (1825+443+87)/2048 = 1.1499 em;

--- a/packages/core/src/text/line-metrics.ts
+++ b/packages/core/src/text/line-metrics.ts
@@ -84,6 +84,17 @@ interface WinMetric {
   /** Design ascent ratio (ascent units / unitsPerEm). */ asc: number;
   /** Design descent ratio: `(|descent| + hhea lineGap) / unitsPerEm` so
    *  `asc + desc` is the font's full design single-line height. */ desc: number;
+  /** When true this entry only applies to EAST ASIAN lines (callers pass the
+   *  line/segment script as `eastAsian`). Word's Far East line height
+   *  (1.3 × hhea box) governs CJK lines only; a Latin-only line in the SAME
+   *  font keeps the win-box height. Measured for Yu Mincho: a pure-CJK line is
+   *  1.43267 em (sample-58 sweep, issue #1013) while a pure-Latin footnote
+   *  line in the same document is 13.44 pt at 10.5 pt = the win sum
+   *  1.28711 em (docx demo/sample-1 page-6 footnote, Word PDF). Entries
+   *  without this flag apply to every script — for Meiryo the two heights
+   *  coincide (its usWin sum was designed as 1.3 × its hhea box), which is
+   *  why the sample-3 Latin/mixed calibration matched the win sum. */
+  eaOnly?: boolean;
 }
 
 /** A known font's design line metrics. Keyed by a normalized (lowercased) name test. */
@@ -109,6 +120,43 @@ const WIN_METRICS: ReadonlyArray<readonly [test: (n: string) => boolean, m: WinM
   [
     (n) => n.includes('meiryo') || n.includes('メイリオ'),
     { asc: 2210 / 2048, desc: 1059 / 2048 },
+  ],
+  // Yu Mincho / Yu Gothic (游明朝 / 游ゴシック) — unitsPerEm 2048, hhea ascent
+  // 1802, descent −455 (identical across the Regular/Light/Demibold/Bold faces
+  // of BOTH families; extracted from the Word-bundled yumin*.ttf / YuGoth*.ttc
+  // via fontTools). Word's Far East single-line height for these faces is
+  // 1.3 × the hhea glyph box: (1802 + 455) × 1.3 / 2048 = 1.43267 em. Neither
+  // the OS/2 win sum (2636/2048 = 1.287 em — BELOW the glyph box + leading) nor
+  // the full hhea line height with its 1024 lineGap (3281/2048 = 1.602 em — what
+  // Canvas fontBoundingBox reports) matches what Word renders for CJK text.
+  //
+  // Provenance: the sample-58 adjudication sweep (issue #1013; Word PDF,
+  // pdftotext -bbox) measures Yu Mincho's off-grid single-line pitch at
+  // 20.04 pt for 14 pt and 22.94 pt for 16 pt — 1.432 ± 0.002 em, exactly the
+  // 1.3 × hhea-box value — and the same height reproduces all 15 measured
+  // §17.6.5 docGrid cell counts (see docx docGridLineCells). The 1.3 Word FE
+  // leading factor is corroborated by Meiryo, whose usWin sum (1.596 em) was
+  // designed as 1.3 × its Windows hhea box (2514/2048 = 1.2275 em) so that the
+  // win metric already encodes it. The ascent:descent split scales hhea
+  // proportionally (only the sum is Word-measured; the split keeps the glyph
+  // box centered the way Word's PDF places it inside grid cells).
+  //
+  // eaOnly: Word gives this FE height to EAST ASIAN lines only. A pure-Latin
+  // line set in the same Yu Mincho keeps the win-box height (demo/sample-1
+  // footnote: 13.44 pt at 10.5 pt = the 1.28711 em win sum, Word PDF page 6),
+  // so non-EA callers must not see this entry. A win-sum entry for Latin
+  // Yu-face lines is a possible follow-up; it is NOT included here because the
+  // substituted-canvas behavior for Latin lines predates this entry and
+  // changing it is out of the issue #1013 adjudication's scope.
+  //
+  // "Yu Gothic UI" is EXCLUDED: the UI faces have different (unverified)
+  // metrics, like the Arial Narrow case above.
+  [
+    (n) =>
+      !n.includes('ui')
+      && (n.includes('yu mincho') || n.includes('yumincho') || n.includes('游明朝')
+        || n.includes('yu gothic') || n.includes('yugothic') || n.includes('游ゴシック')),
+    { asc: (1802 * 1.3) / 2048, desc: (455 * 1.3) / 2048, eaOnly: true },
   ],
   // Sakkal Majalla — unitsPerEm 2048, usWinAscent 1810, usWinDescent 1050
   // → asc 0.8838, desc 0.5127, sum = 1.3965. Extracted directly from the
@@ -137,11 +185,14 @@ const WIN_METRICS: ReadonlyArray<readonly [test: (n: string) => boolean, m: WinM
   [(n) => n === 'arial', { asc: 1854 / 2048, desc: 501 / 2048 }],
 ];
 
-function lookupWinMetric(family: string | null | undefined): WinMetric | null {
+function lookupWinMetric(
+  family: string | null | undefined,
+  eastAsian: boolean,
+): WinMetric | null {
   if (!family) return null;
   const n = family.toLowerCase();
   for (const [test, m] of WIN_METRICS) {
-    if (test(n)) return m;
+    if (test(n) && (eastAsian || !m.eaOnly)) return m;
   }
   return null;
 }
@@ -153,9 +204,17 @@ function lookupWinMetric(family: string | null | undefined): WinMetric | null {
  * `(usWinAscent+usWinDescent)/unitsPerEm` for the CJK/Arabic faces and the hhea
  * sum `(ascent+|descent|+lineGap)/unitsPerEm` for the Latin faces (see
  * WIN_METRICS). The legacy name is kept to avoid churn at the call sites.
+ *
+ * `eastAsian` is the SCRIPT of the line/segment being sized (not of the font):
+ * entries flagged `eaOnly` (the Word FE 1.3 × hhea heights, e.g. Yu Mincho)
+ * are visible only to East Asian callers — a Latin-only line in the same font
+ * falls back to the substituted Canvas metrics exactly as if untabled.
  */
-export function fontWinLineHeightRatio(family: string | null | undefined): number | null {
-  const m = lookupWinMetric(family);
+export function fontWinLineHeightRatio(
+  family: string | null | undefined,
+  eastAsian = false,
+): number | null {
+  const m = lookupWinMetric(family, eastAsian);
   return m === null ? null : m.asc + m.desc;
 }
 
@@ -165,8 +224,12 @@ export function fontWinLineHeightRatio(family: string | null | undefined): numbe
  * the table. `0` is a no-op sentinel for the line-box math, which takes the
  * max of this and the substituted font's natural ascent+descent.
  */
-export function intendedSingleLinePx(family: string | null | undefined, emPx: number): number {
-  const ratio = fontWinLineHeightRatio(family);
+export function intendedSingleLinePx(
+  family: string | null | undefined,
+  emPx: number,
+  eastAsian = false,
+): number {
+  const ratio = fontWinLineHeightRatio(family, eastAsian);
   return ratio === null ? 0 : ratio * emPx;
 }
 
@@ -200,8 +263,9 @@ export function correctLineMetrics(
   emPx: number,
   ascentPx: number,
   descentPx: number,
+  eastAsian = false,
 ): { ascent: number; descent: number } {
-  const m = lookupWinMetric(family);
+  const m = lookupWinMetric(family, eastAsian);
   if (m === null) return { ascent: ascentPx, descent: descentPx };
   const targetTotal = (m.asc + m.desc) * emPx;
   if (ascentPx + descentPx <= targetTotal) {

--- a/packages/core/src/text/line-metrics.ts
+++ b/packages/core/src/text/line-metrics.ts
@@ -149,6 +149,15 @@ const WIN_METRICS: ReadonlyArray<readonly [test: (n: string) => boolean, m: WinM
   // substituted-canvas behavior for Latin lines predates this entry and
   // changing it is out of the issue #1013 adjudication's scope.
   //
+  // Yu Gothic scope note: the hhea numbers are verified for BOTH families
+  // (byte-identical tables), but the 1.3 Word FE factor is Word-PDF-measured
+  // on Yu Mincho only — for Yu Gothic it is an EXTRAPOLATION via the identical
+  // metrics and the same vendor pairing. A dedicated Yu Gothic sweep page
+  // (sample-58 style) should confirm it; without this entry a 12pt Yu Gothic
+  // line on an 18pt grid would round by the substitute's ~1.6 em Canvas box to
+  // 2 cells, contradicting the measured Yu Mincho 1 cell, so sharing the value
+  // is the lower-risk reading until measured.
+  //
   // "Yu Gothic UI" is EXCLUDED: the UI faces have different (unverified)
   // metrics, like the Arial Narrow case above.
   [

--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -18,6 +18,15 @@ const atLeast = (value: number): LineSpacing => ({
   explicit: true,
 });
 
+// Yu Mincho design line metrics per pt of font size: 1.3 × the hhea glyph box
+// (asc 1802, |desc| 455, upm 2048) — see core line-metrics and the sample-58
+// adjudication (issue #1013). Sum = 1.43267 em. All call sites feed lineBoxHeight
+// metrics through correctLineMetrics / the intendedSingleLinePx floor, so for a
+// tabled font both ascent+descent and intendedSingle equal this design height.
+const YU_ASC = (1802 * 1.3) / 2048;
+const YU_DESC = (455 * 1.3) / 2048;
+const YU = YU_ASC + YU_DESC;
+
 describe('lineBoxHeight — degenerate zero line spacing', () => {
   // ascent 12 + descent 3 = 15px natural single-line height (no grid).
   it('treats exact line=0 as single spacing (natural), not 0', () => {
@@ -73,99 +82,156 @@ describe('lineBoxHeight — atLeast with an active line grid', () => {
   });
 
   // BEHAVIOUR PIN, not Word-verified ground truth. For an East Asian atLeast
-  // line the grid-minimum term is the em-based single cell (docGridLineCells),
-  // no longer the glyph-box cell rounding: a 12pt line whose substituted glyph
-  // box is 19.22px on an 18pt pitch resolves to its natural 19.22px (max of
-  // natural / authored 18 / em cell 18) — previously 36px (glyph box rounded to
-  // 2 cells). No corpus sample exercises atLeast inside an active line grid and
-  // a Word fixture export could not be captured when this was pinned, so Word's
-  // exact atLeast-on-grid height is UNVERIFIED; the pin makes any future change
-  // to this resolution deliberate rather than accidental. Ruby lines keep the
+  // line the grid-minimum term is the natural-height cell count
+  // (docGridLineCells): a 12pt Yu Mincho line (design box 17.19px) on an 18pt
+  // pitch resolves to max(natural 17.19 / authored 18 / grid cell 18) = 18.
+  // No corpus sample exercises atLeast inside an active line grid and a Word
+  // fixture export could not be captured when this was pinned, so Word's exact
+  // atLeast-on-grid height is UNVERIFIED; the pin makes any future change to
+  // this resolution deliberate rather than accidental. Ruby lines keep the
   // measured-glyph-box minimum (they reserve real furigana height).
-  it('[pin] EA atLeast takes max(natural, authored, em single cell) — unverified vs Word', () => {
-    expect(lineBoxHeight(atLeast(18), 15.38, 3.84, 1, grid18, false, 0, true, 12)).toBeCloseTo(19.22, 6);
+  it('[pin] EA atLeast takes max(natural, authored, grid cells) — unverified vs Word', () => {
+    expect(lineBoxHeight(atLeast(18), 12 * YU_ASC, 12 * YU_DESC, 1, grid18, false, 12 * YU, true)).toBe(18);
   });
-  it('[pin] EA atLeast still snaps to the em cell when it exceeds natural and authored', () => {
-    // em 20 on pitch 18 → 2 cells = 36 > natural 12 and authored 18.
-    expect(lineBoxHeight(atLeast(18), 10, 2, 1, grid18, false, 0, true, 20)).toBe(36);
+  it('[pin] EA atLeast still snaps to the grid cells when they exceed natural and authored', () => {
+    // 20pt design line 28.65px on pitch 18 → 2 cells = 36 > authored 18.
+    expect(lineBoxHeight(atLeast(18), 20 * YU_ASC, 20 * YU_DESC, 1, grid18, false, 20 * YU, true)).toBe(36);
   });
   it('[pin] a RUBY EA atLeast line keeps the measured glyph-box minimum', () => {
     // glyph box 41px (base + furigana reserve) → ceil(41/18) = 3 cells = 54.
-    expect(lineBoxHeight(atLeast(18), 33, 8, 1, grid18, true, 0, true, 13.5)).toBe(54);
+    expect(lineBoxHeight(atLeast(18), 33, 8, 1, grid18, true, 0, true)).toBe(54);
   });
 });
 
 // ECMA-376 §17.6.5 / §17.3.1.32 define the line pitch as the height of ONE
 // single-spaced line; how many whole grid CELLS a single-spaced East Asian line
-// occupies is Word runtime behaviour. That cell count is a function of the run's
-// EM (font size) — NOT the substituted-font glyph box (fontBoundingBox, ~1.6em),
-// which over-counts every EA line whose em is comfortably inside one pitch.
+// occupies is Word runtime behaviour. That cell count is a function of the
+// line's SINGLE-LINE HEIGHT (the document font's design line height): a line
+// occupies ceil(singleLineHeight / pitch) cells — the smallest number of whole
+// cells that CONTAINS it. It is NOT a function of the raw em, and NOT of the
+// substituted-font Canvas glyph box (which can overstate the design height).
 //
 // Word-PDF ground truth (pdftotext -bbox):
-//   • sample-35: docGrid pitch 18pt; a 12pt centred CJK heading is 1 cell (18pt),
-//     and the 10.5pt body lines are 1 cell — even though 12×1.6 = 19.2 > 18.
-//   • sample-9 : docGrid pitch 20pt; a 20pt CJK title is 2 cells (40pt).
-// `ceil(em/pitch)` fits the first two but fails the 20-on-20 boundary (→1, want
-// 2). `floor(em/pitch)+1` fits ALL three: a single-spaced EA line whose em-square
-// exactly fills k pitches still needs its inter-line leading, spilling into the
-// (k+1)-th cell. Latin-only lines are NOT cell-rounded (§17.6.5 leaves them at
-// default spacing); the `eastAsian` flag gates the rule.
-describe('docGridLineCells — em-based East Asian grid cell count (§17.6.5)', () => {
-  it('a sub-pitch em occupies a single cell (12pt heading / 18pt pitch → 1)', () => {
-    expect(docGridLineCells(12, 18)).toBe(1);
+//   • sample-58 adjudication sweep (issue #1013; 19 sections, {10.5,12,14,16,
+//     20}pt × pitch {18,24}pt × {lrTb,tbRl} × {lines,linesAndChars,none}, all
+//     Yu Mincho): with Yu Mincho's design line height 1.43267 em (1.3 × hhea
+//     box — see core line-metrics), EVERY measured point is ceil(design/pitch):
+//     12pt→1 cell, 14pt→2 cells on an 18pt pitch; 16pt→1 cell, 20pt→2 cells on
+//     a 24pt pitch. Horizontal and vertical (tbRl) sections measured IDENTICAL
+//     (36.00pt column pitch = 36.00pt line pitch), and the §17.6.5 grid type
+//     (lines vs linesAndChars) does not change the count.
+//   • sample-35: docGrid pitch 18pt; the 12pt CJK heading (design 17.19pt) and
+//     the 10.5pt body (15.04pt) are 1 cell each.
+//   • sample-9 : docGrid pitch 20pt; a 20pt CJK title (design 28.65pt) is
+//     2 cells (40pt).
+// An earlier em-based rule (floor(em/pitch)+1) fit the sparse pre-sweep data —
+// the sweep's 10.5/12/20pt rows coincide under both rules — but under-counted
+// every 14–16pt line on an 18pt pitch (Word: 2 cells, em rule: 1) in BOTH
+// writing directions. Latin-only lines are NOT cell-rounded (§17.6.5 leaves
+// them at default spacing); the `eastAsian` flag gates the rule.
+describe('docGridLineCells — natural-height East Asian grid cell count (§17.6.5)', () => {
+  it('a sub-pitch line occupies a single cell (12pt Yu Mincho / 18pt pitch → 1)', () => {
+    expect(docGridLineCells(12 * YU, 18)).toBe(1); // 17.19 < 18
   });
-  it('a 13pt em on an 18pt pitch is still a single cell', () => {
-    expect(docGridLineCells(13, 18)).toBe(1);
+  it('a 10.5pt body line on an 18pt pitch is a single cell (sample-58 A1/B1)', () => {
+    expect(docGridLineCells(10.5 * YU, 18)).toBe(1); // 15.04
   });
-  it('a 10.5pt body em on an 18pt pitch is a single cell', () => {
-    expect(docGridLineCells(10.5, 18)).toBe(1);
+  it('a 14pt line on an 18pt pitch spills into TWO cells (sample-58 A3/B3)', () => {
+    expect(docGridLineCells(14 * YU, 18)).toBe(2); // 20.06 > 18
   });
-  it('an em equal to the pitch occupies TWO cells (20pt / 20pt → 2)', () => {
-    expect(docGridLineCells(20, 20)).toBe(2);
+  it('a 16pt line on an 18pt pitch is two cells (sample-58 A4/B4)', () => {
+    expect(docGridLineCells(16 * YU, 18)).toBe(2); // 22.92
   });
-  it('the pitch boundary rounds up (18pt em / 18pt pitch → 2)', () => {
-    expect(docGridLineCells(18, 18)).toBe(2);
+  it('a 16pt line on a 24pt pitch stays a single cell (sample-58 C2)', () => {
+    expect(docGridLineCells(16 * YU, 24)).toBe(1); // 22.92 < 24
   });
-  it('an em between one and two pitches occupies two cells', () => {
-    expect(docGridLineCells(30, 20)).toBe(2);
+  it('a 20pt line on a 24pt pitch is two cells (sample-58 C3)', () => {
+    expect(docGridLineCells(20 * YU, 24)).toBe(2); // 28.65
   });
-  it('an em at exactly two pitches occupies three cells', () => {
-    expect(docGridLineCells(40, 20)).toBe(3);
+  it('a 20pt title on a 20pt pitch is two cells (sample-9)', () => {
+    expect(docGridLineCells(20 * YU, 20)).toBe(2); // 28.65
   });
+  it('a line exactly filling k pitches occupies k cells (ceil; boundary unmeasured)', () => {
+    expect(docGridLineCells(18, 18)).toBe(1);
+    expect(docGridLineCells(36, 18)).toBe(2);
+  });
+  it('a line taller than two pitches occupies three cells (extrapolated)', () => {
+    expect(docGridLineCells(30 * YU, 20)).toBe(3); // 42.98 → ceil = 3
+  });
+  it('returns at least one cell for degenerate heights and pitches', () => {
+    expect(docGridLineCells(0, 18)).toBe(1);
+    expect(docGridLineCells(5, 0)).toBe(1);
+  });
+});
+
+// The sample-58 adjudication matrix as measured (Word PDF, pdftotext -bbox):
+// line pitch (horizontal lrTb sections) = column pitch (vertical tbRl sections)
+// for every {font size × grid pitch} row. Both directions share lineBoxHeight
+// (the tbRl page is laid out by the horizontal engine and rotated), so this
+// table pins the shared rule against the measured matrix.
+describe('lineBoxHeight — sample-58 adjudicated docGrid matrix (Yu Mincho)', () => {
+  const rows: ReadonlyArray<readonly [sizePt: number, pitchPt: number, expectPt: number, sections: string]> = [
+    [10.5, 18, 18, 'A1/B1'],
+    [12, 18, 18, 'A2/B2/D1'],
+    [14, 18, 36, 'A3/B3'],
+    [16, 18, 36, 'A4/B4/D2'],
+    [20, 18, 36, 'A5/B5'],
+    [12, 24, 24, 'C1'],
+    [16, 24, 24, 'C2'],
+    [20, 24, 48, 'C3'],
+  ];
+  for (const [size, pitch, expected, sections] of rows) {
+    it(`${size}pt on a ${pitch}pt pitch → ${expected}pt (${sections})`, () => {
+      expect(lineBoxHeight(
+        null,
+        YU_ASC * size,
+        YU_DESC * size,
+        1,
+        { type: 'lines', linePitchPt: pitch },
+        false,
+        YU * size,
+        true,
+      )).toBe(expected);
+    });
+  }
 });
 
 describe('lineBoxHeight — docGrid line-cell rounding (East Asian vs Latin)', () => {
   const grid18 = { type: 'lines', linePitchPt: 18 } as const;
   const grid20 = { type: 'lines', linePitchPt: 20 } as const;
 
-  // Yu Mincho reports fontBoundingBox ≈ 1.602 em, so a 12pt run's glyph box is
-  // ~19.22px (asc 15.38 + desc 3.84) — over the 18pt pitch. The OLD rule
-  // ceil(19.22/18) = 2 cells over-counted; the em (12pt) → floor(12/18)+1 = 1
-  // cell = 18px is what Word renders (sample-35 heading).
-  it('snaps a sub-pitch EA line to ONE cell by its em, not its inflated glyph box', () => {
-    expect(lineBoxHeight(null, 15.38, 3.84, 1, grid18, false, 0, true, 12)).toBe(18);
+  // A 12pt Yu Mincho line reaches lineBoxHeight with design-corrected metrics
+  // (asc 13.73 + desc 3.47 = 17.19px, the 1.43267em box) — correctLineMetrics
+  // shrinks the substituted ~1.602em Canvas box to it, and intendedSingleLinePx
+  // floors an under-measuring substitute up to it. 17.19 < 18 → one cell
+  // (sample-35 heading, sample-58 A2/B2).
+  it('snaps a sub-pitch EA line to ONE cell of the grid pitch', () => {
+    expect(lineBoxHeight(null, 12 * YU_ASC, 12 * YU_DESC, 1, grid18, false, 12 * YU, true)).toBe(18);
   });
-  it('rounds an EA line whose em equals the pitch UP to two cells (20/20 → 40)', () => {
-    // glyph box 32.04px (25.63 + 6.41); em 20 on pitch 20 → floor(20/20)+1 = 2.
-    expect(lineBoxHeight(null, 25.63, 6.41, 1, grid20, false, 0, true, 20)).toBe(40);
+  it('rounds a 20pt EA line on a 20pt pitch UP to two cells (sample-9)', () => {
+    // design box 28.65px → ceil(28.65/20) = 2 cells = 40.
+    expect(lineBoxHeight(null, 20 * YU_ASC, 20 * YU_DESC, 1, grid20, false, 20 * YU, true)).toBe(40);
   });
-  it('rounds an EA line whose em exceeds the pitch to two cells (30/20 → 40)', () => {
-    expect(lineBoxHeight(null, 24, 6, 1, grid20, false, 0, true, 30)).toBe(40);
+  it('guards the cell count against an UNCORRECTED over-tall glyph box via max()', () => {
+    // A substitute box (24+6=30px) taller than the design floor (20pt design =
+    // 28.65px): natural = max(30, 28.65) = 30 → still 2 cells on a 20pt pitch.
+    expect(lineBoxHeight(null, 24, 6, 1, grid20, false, 20 * YU, true)).toBe(40);
   });
   it('keeps a Latin line at natural height (one-cell floor), NOT cell-rounded', () => {
     // 22px natural, Latin → max(22, 20) = 22px (Word does not cell-round it).
-    expect(lineBoxHeight(null, 17.6, 4.4, 1, grid20, false, 0, false, 22)).toBe(22);
+    expect(lineBoxHeight(null, 17.6, 4.4, 1, grid20, false, 0, false)).toBe(22);
   });
-  it('a RUBY EA line reserves its measured furigana height, NOT the em cell count', () => {
+  it('a RUBY EA line reserves its measured furigana height, NOT the design cell count', () => {
     // sample-5: a 13.5pt ruby base + 8pt rt on an 18pt pitch reserves the base +
     // annotation glyph box (~41px = asc 33 + desc 8), which Word spreads over
-    // whole cells (ceil(41/18) = 3 cells = 54px). The em (13.5pt) would collapse
-    // it to one cell (18px) and clip the furigana, so the em rule must NOT apply
-    // to ruby lines — hasRuby (arg 6) keeps them on the measured glyph box.
-    expect(lineBoxHeight(null, 33, 8, 1, grid18, true, 0, true, 13.5)).toBe(54);
+    // whole cells (ceil(41/18) = 3 cells = 54px). The base design height (13.5pt
+    // → 19.3px → 2 cells) would clip the furigana, so the natural-height rule
+    // must NOT apply to ruby lines — hasRuby (arg 6) keeps them on the measured
+    // glyph box.
+    expect(lineBoxHeight(null, 33, 8, 1, grid18, true, 0, true)).toBe(54);
   });
   it('does not cell-round when no docGrid is active (East Asian, off grid)', () => {
-    expect(lineBoxHeight(null, 17.6, 4.4, 1, undefined, false, 0, true, 22)).toBe(22);
+    expect(lineBoxHeight(null, 17.6, 4.4, 1, undefined, false, 0, true)).toBe(22);
   });
   it('defaults to Latin (no cell rounding) when the flag is omitted', () => {
     expect(lineBoxHeight(null, 17.6, 4.4, 1, grid20)).toBe(22);

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -352,7 +352,7 @@ export interface WrapLayoutCtx {
     maximumWidthPt: number;
   };
   /** Per-line box-height resolver (line natural ascent+descent → total px box height). */
-  lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number, emPx?: number, eastAsian?: boolean) => number;
+  lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number, eastAsian?: boolean) => number;
   /** Hard cap on Y to keep layout from running past the page. */
   pageH: number;
 }
@@ -762,7 +762,7 @@ export function emptyIntendedSinglePx(para: DocParagraph, scale: number): number
 /** Intended single-line height (px) for an empty paragraph in the script axis
  *  used to draw its paragraph mark. */
 function emptyIntendedSingleForScriptPx(para: DocParagraph, scale: number, eastAsian: boolean): number {
-  return intendedSingleLinePx(getDefaultFontFamily(para, eastAsian), getDefaultFontSize(para) * scale);
+  return intendedSingleLinePx(getDefaultFontFamily(para, eastAsian), getDefaultFontSize(para) * scale, eastAsian);
 }
 
 /** Code points whose presence marks a line as East Asian for docGrid line-cell
@@ -914,26 +914,36 @@ export function isGridLineRule(ctx: DocGridCtx | undefined): boolean {
 
 /**
  * ECMA-376 §17.6.5 docGrid line grid — number of whole grid CELLS a
- * single-spaced East Asian line of em `emPx` occupies on a pitch of `pitchPx`.
+ * single-spaced East Asian line occupies on a pitch of `pitchPx`, from the
+ * line's SINGLE-LINE HEIGHT `naturalPx` (the document font's design line
+ * height: max of the corrected glyph box and the intendedSingleLinePx floor).
+ * The count is `ceil(naturalPx / pitchPx)` — the smallest number of whole
+ * cells that CONTAINS the line.
  *
- * Measured in Word PDF output (`pdftotext -bbox`): 10.5pt and 12pt lines on an
- * 18pt pitch occupy one cell (the sub-pitch region), while a 20pt line on a
- * 20pt pitch occupies two (the em == pitch boundary). The k >= 2 region — for
- * example an em of two pitches occupying three cells — extrapolates
- * `floor(em / pitch) + 1` beyond the measured range because the boundary rule
- * is scale-free: an em square that fills k pitches still needs inter-line
- * leading and therefore spills into cell k+1. No Word measurement covers that
- * region yet.
+ * Adjudicated by the sample-58 sweep (issue #1013; Word PDF, pdftotext -bbox;
+ * 19 sections over {10.5,12,14,16,20}pt × pitch {18,24}pt × {lrTb,tbRl} ×
+ * {lines,linesAndChars,none}, all Yu Mincho): with Yu Mincho's design line
+ * height (1.3 × hhea box = 1.43267 em — see core line-metrics) every measured
+ * point is ceil(design/pitch): on an 18pt pitch 10.5/12pt → 1 cell and
+ * 14/16/20pt → 2 cells; on a 24pt pitch 12/16pt → 1 cell and 20pt → 2 cells.
+ * Horizontal (lrTb) and vertical (tbRl) sections measured IDENTICAL pitches,
+ * so the rule is direction-agnostic (the tbRl column pitch is this same cell
+ * height), and the §17.6.5 grid type does not change the count. The pre-sweep
+ * calibration points remain satisfied: sample-35's 12pt heading / 10.5pt body
+ * on 18pt → 1 cell (design 17.19 / 15.04 < 18) and sample-9's 20pt title on a
+ * 20pt pitch → 2 cells (design 28.65). An earlier em-based rule
+ * (floor(em/pitch)+1) fit those sparse points but under-counted every
+ * 14–16pt-class line whose design height exceeds the pitch (Word: 2 cells).
  *
- * For a mixed-size line, callers supply the tallest run's em. This conservative
- * anti-clipping choice follows the tallest-run line-box rule (§17.3.1.33); it is
- * not a Word-measured mixed-size grid behaviour.
- * ECMA-376 defines `linePitch` as one single-spaced line; rounding taller lines
- * to whole cells is Word runtime behaviour. Returns at least 1 for every finite
- * `emPx >= 0`.
+ * A line that fills k pitches exactly occupies k cells (ceil; no measured
+ * point sits on the boundary — the geometric reading is that it still FITS).
+ * For a mixed-size line, callers supply the tallest run's resolved height
+ * (§17.3.1.33 tallest-run line box). ECMA-376 defines `linePitch` as one
+ * single-spaced line; spreading taller lines over whole cells is Word runtime
+ * behaviour. Returns at least 1 for every finite `naturalPx >= 0`.
  */
-export function docGridLineCells(emPx: number, pitchPx: number): number {
-  return pitchPx > 0 ? Math.floor(emPx / pitchPx) + 1 : 1;
+export function docGridLineCells(naturalPx: number, pitchPx: number): number {
+  return pitchPx > 0 ? Math.max(1, Math.ceil(naturalPx / pitchPx)) : 1;
 }
 
 /**
@@ -960,7 +970,6 @@ export function lineBoxHeight(
   hasRuby?: boolean,
   intendedSinglePx = 0,
   eastAsian = false,
-  emPx = 0,
 ): number {
   const glyphNatural = ascentPx + descentPx;
   // For `auto`/single spacing the multiplier applies to the intended font's
@@ -982,20 +991,21 @@ export function lineBoxHeight(
   // body paragraph with line="320" renders at pitch × 1.33 = ~24 pt.
   //
   // A single-spaced line on a docGrid snaps to whole grid CELLS in East Asian
-  // text. The number of cells is derived from the run em rather than the Canvas
-  // glyph bounding box; see docGridLineCells for the boundary rule and Word
-  // observations. A Latin-only line is NOT cell-rounded — it keeps its natural
-  // height above a one-cell floor (demo/sample-1: an 18pt heading on an 18pt
-  // pitch stays ~20.7px, not 36). ECMA-376 Part 1 only defines the natural ≤
-  // pitch case (§17.6.5 / §17.3.1.32); the East-Asian cell rounding for taller
-  // lines is Word runtime behaviour, so it is gated on the line's script.
+  // text. The number of cells is derived from the line's resolved single-line
+  // height (`natural` — the design line height, per the sample-58 adjudication
+  // of issue #1013); see docGridLineCells for the rule and Word measurements.
+  // A Latin-only line is NOT cell-rounded — it keeps its natural height above
+  // a one-cell floor (demo/sample-1: an 18pt heading on an 18pt pitch stays
+  // ~20.7px, not 36). ECMA-376 Part 1 only defines the natural ≤ pitch case
+  // (§17.6.5 / §17.3.1.32); the East-Asian cell rounding for taller lines is
+  // Word runtime behaviour, so it is gated on the line's script.
   const gridSingleCell = (): number => {
     if (!eastAsian) return Math.max(glyphNatural, pitchPx);
     // Ruby lines reserve real furigana height (base + rt); honor the measured
-    // glyph box so the annotation is not clipped. Plain EA lines discount the
-    // substituted font's ~1.6em leading and snap by the run EM.
+    // glyph box so the annotation is not clipped. Plain EA lines snap their
+    // design single-line height to whole cells.
     if (hasRuby) return Math.max(pitchPx, Math.ceil(glyphNatural / pitchPx) * pitchPx);
-    return docGridLineCells(emPx, pitchPx) * pitchPx;
+    return docGridLineCells(natural, pitchPx) * pitchPx;
   };
   const inheritedOnly = ls !== null && ls.explicit !== true;
   if (!ls) {
@@ -1061,10 +1071,11 @@ export function correctedLineMetrics(
   family: string | null | undefined,
   fallbackEmPx: number,
   correctionEmPx: number,
+  eastAsian = false,
 ): { ascent: number; descent: number } {
   const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fallbackEmPx * 0.8;
   const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fallbackEmPx * 0.2;
-  return correctLineMetrics(family, correctionEmPx, rawAsc, rawDesc);
+  return correctLineMetrics(family, correctionEmPx, rawAsc, rawDesc, eastAsian);
 }
 
 /**
@@ -1126,11 +1137,11 @@ export function paragraphMarkLineMetrics(
     const m = ctx.measureText(eastAsian ? 'あ' : 'x');
     ctx.font = prevFont;
     // A mark line carries no smallCaps/vertAlign, so fallback == correction size.
-    ({ ascent: asc, descent: desc } = correctedLineMetrics(m, family, fs * scale, fs * scale));
+    ({ ascent: asc, descent: desc } = correctedLineMetrics(m, family, fs * scale, fs * scale, eastAsian));
   } else {
     ({ asc, desc } = emptyLineNaturalPx(fs, scale));
   }
-  const advancePx = lineBoxHeight(effectiveLineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSingleForScriptPx(para, scale, eastAsian), eastAsian, fs * scale);
+  const advancePx = lineBoxHeight(effectiveLineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSingleForScriptPx(para, scale, eastAsian), eastAsian);
   return { advancePx, ascentPx: asc, descentPx: desc };
 }
 
@@ -2669,7 +2680,7 @@ export function layoutLines(
       consumedEnd: nextStart ?? queue[0]?.src ?? endBoundary,
     });
     if (wrapCtx) {
-      currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle, h * scale, lineEastAsian);
+      currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle, lineEastAsian);
     }
     currentLine = [];
     currentWidth = 0;
@@ -2719,7 +2730,10 @@ export function layoutLines(
       // Small caps (non-super/sub) keep the FULL run size here so the line box
       // follows the run size, not the 2pt-reduced glyphs (§17.3.2.33).
       const intendedEm = ts.smallCaps && !ts.vertAlign ? ts.fontSize * scale : effectiveFontPx(ts);
-      const intended = intendedSingleLinePx(ts.fontFamily, intendedEm);
+      // Script hint: eaOnly design heights (Word FE 1.3 × hhea, e.g. Yu Mincho)
+      // apply to East Asian segments only — a Latin segment in the same font
+      // keeps its Canvas box (issue #1013 / demo sample-1 footnote).
+      const intended = intendedSingleLinePx(ts.fontFamily, intendedEm, EAST_ASIAN_RE.test(ts.text));
       if (intended > lineIntendedSingle) lineIntendedSingle = intended;
     }
   };
@@ -3142,7 +3156,7 @@ export function layoutLines(
       ctx.font = prevFont;
       metricEmPx = fullPx;
     }
-    const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx);
+    const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx, EAST_ASIAN_RE.test(s.text));
     let asc = corrected.ascent;
     const desc = corrected.descent;
     // Ruby annotation: small text rendered above the base. Reserve ascent
@@ -3701,13 +3715,13 @@ export function rescaleLayoutLines(
       metricM = ctx.measureText(s.text || 'X');
       metricEmPx = fullPx;
     }
-    const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx);
+    const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx, EAST_ASIAN_RE.test(s.text));
     // §17.3.3.25 — ruby reserves extra ascent room (rt size × 1.5), same as layoutLines.
     const asc = s.ruby ? corrected.ascent + s.ruby.fontSizePt * scale * 1.5 : corrected.ascent;
     // Intended single-line floor (font-metrics.ts) — small caps keep the FULL run
     // size here too (addToLine's intendedEm).
     const intendedEm = s.smallCaps && !s.vertAlign ? fullPx : effPx;
-    const intended = intendedSingleLinePx(s.fontFamily, intendedEm);
+    const intended = intendedSingleLinePx(s.fontFamily, intendedEm, EAST_ASIAN_RE.test(s.text));
     return { advance, asc, desc: corrected.descent, intended };
   };
 

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -2732,8 +2732,12 @@ export function layoutLines(
       const intendedEm = ts.smallCaps && !ts.vertAlign ? ts.fontSize * scale : effectiveFontPx(ts);
       // Script hint: eaOnly design heights (Word FE 1.3 × hhea, e.g. Yu Mincho)
       // apply to East Asian segments only — a Latin segment in the same font
-      // keeps its Canvas box (issue #1013 / demo sample-1 footnote).
-      const intended = intendedSingleLinePx(ts.fontFamily, intendedEm, EAST_ASIAN_RE.test(ts.text));
+      // keeps its Canvas box (issue #1013 / demo sample-1 footnote). Ruby
+      // segments are excluded too: a ruby line reserves its MEASURED base +
+      // annotation box (sample-5 calibration) and Word's FE height for a
+      // ruby-bearing line is unmeasured, so the pre-#1013 metrics stand.
+      const segScriptHint = EAST_ASIAN_RE.test(ts.text) && !ts.ruby;
+      const intended = intendedSingleLinePx(ts.fontFamily, intendedEm, segScriptHint);
       if (intended > lineIntendedSingle) lineIntendedSingle = intended;
     }
   };
@@ -3156,7 +3160,9 @@ export function layoutLines(
       ctx.font = prevFont;
       metricEmPx = fullPx;
     }
-    const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx, EAST_ASIAN_RE.test(s.text));
+    // FE design correction for EA segments only; ruby keeps its measured box
+    // (see addToLine's segScriptHint note).
+    const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx, EAST_ASIAN_RE.test(s.text) && !s.ruby);
     let asc = corrected.ascent;
     const desc = corrected.descent;
     // Ruby annotation: small text rendered above the base. Reserve ascent
@@ -3715,13 +3721,16 @@ export function rescaleLayoutLines(
       metricM = ctx.measureText(s.text || 'X');
       metricEmPx = fullPx;
     }
-    const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx, EAST_ASIAN_RE.test(s.text));
+    // FE design correction for EA segments only; ruby keeps its measured box
+    // (see addToLine's segScriptHint note).
+    const segScriptHint = EAST_ASIAN_RE.test(s.text) && !s.ruby;
+    const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx, segScriptHint);
     // §17.3.3.25 — ruby reserves extra ascent room (rt size × 1.5), same as layoutLines.
     const asc = s.ruby ? corrected.ascent + s.ruby.fontSizePt * scale * 1.5 : corrected.ascent;
     // Intended single-line floor (font-metrics.ts) — small caps keep the FULL run
     // size here too (addToLine's intendedEm).
     const intendedEm = s.smallCaps && !s.vertAlign ? fullPx : effPx;
-    const intended = intendedSingleLinePx(s.fontFamily, intendedEm, EAST_ASIAN_RE.test(s.text));
+    const intended = intendedSingleLinePx(s.fontFamily, intendedEm, segScriptHint);
     return { advance, asc, desc: corrected.descent, intended };
   };
 

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -252,7 +252,7 @@ export function measureParagraph(
         columnWidthPt: placement.availableWidthPt,
         floats: [],
         lineWindow: (input) => placement.wrap!.lineWindow(input),
-        lineBoxH: (ascent, descent, _hasRuby, intendedSingle, emPx, eastAsian) => lineBoxHeight(
+        lineBoxH: (ascent, descent, _hasRuby, intendedSingle, eastAsian) => lineBoxHeight(
           context.lineSpacing,
           ascent,
           descent,
@@ -263,7 +263,6 @@ export function measureParagraph(
           // §17.6.5 cell rounding follows this line's script, matching text boxes;
           // ruby paragraphs retain their established uniform paragraph resolver.
           context.hasRuby ? context.hasEastAsianText : (eastAsian ?? false),
-          emPx,
         ),
         pageH: placement.maximumYPt,
       }
@@ -302,7 +301,6 @@ export function measureParagraph(
           true,
           line.intendedSingle,
           context.hasEastAsianText,
-          line.height,
         ))),
         grid,
       )
@@ -331,7 +329,6 @@ export function measureParagraph(
           // §17.6.5 cell rounding is gated by the line's script; a Latin-only
           // line in a CJK paragraph keeps its natural height.
           line.eastAsian ?? false,
-          line.height,
         );
     measuredLines.push({ layout: line, topYPt, advancePt });
     cursorPt = topYPt + advancePt;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7678,7 +7678,6 @@ function resolveFrameBox(
         // §17.6.5 cell rounding follows this line's script, matching text boxes;
         // ruby paragraphs retain their established uniform paragraph resolver.
         paraHasRuby ? paragraphContext.hasEastAsianText : (l.eastAsian ?? false),
-        l.height * scale,
       ),
     0,
   );
@@ -8017,7 +8016,7 @@ function renderParagraph(
     columnXPt: contentX,
     columnWidthPt: contentW,
     floats: state.floats,
-    lineBoxH: (a, d, _h, is, emPx, ea) => lineBoxHeight(
+    lineBoxH: (a, d, _h, is, ea) => lineBoxHeight(
       para.lineSpacing,
       a,
       d,
@@ -8028,7 +8027,6 @@ function renderParagraph(
       // §17.6.5 cell rounding follows this line's script, matching text boxes;
       // ruby paragraphs retain their established uniform paragraph resolver.
       paraHasRuby ? paragraphContext.hasEastAsianText : (ea ?? false),
-      emPx,
     ),
     pageH: state.pageH,
   } : undefined;
@@ -8214,7 +8212,7 @@ function renderParagraph(
   // else just the max natural.
   const uniformLineH = paraHasRuby
     ? snapParaLineToGrid(
-        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, paragraphContext.hasEastAsianText, l.height * scale))),
+        Math.max(0, ...lines.map(l => lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, paragraphContext.hasEastAsianText))),
         grid,
         scale,
       )
@@ -8224,7 +8222,7 @@ function renderParagraph(
       ? uniformLineH
       // §17.6.5 cell rounding is gated by the line's script; a Latin-only line
       // in a CJK paragraph keeps its natural height, matching the text-box path.
-      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, l.eastAsian ?? false, l.height * scale);
+      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, l.eastAsian ?? false);
 
   // Slice bounds — when the paginator split this paragraph across pages,
   // only render lines in [sliceStart, sliceEnd). The first line we paint
@@ -10437,18 +10435,22 @@ export function measureShapeTextAutoFitHeight(
       lineText += ts.text;
       if (!tallest || ts.fontSize > tallest.fontSize) tallest = ts;
       const segPx = ts.fontSize * scale;
+      // Script hint: eaOnly design heights (Word FE 1.3 × hhea) apply to East
+      // Asian segments only (issue #1013); Latin segments keep the Canvas box.
+      const segEa = EAST_ASIAN_RE.test(ts.text);
       floorPx = Math.max(
         floorPx,
-        intendedSingleLinePx(ts.fontFamily ?? null, segPx),
-        intendedSingleLinePx(ts.eaFloorFamily ?? null, segPx),
+        intendedSingleLinePx(ts.fontFamily ?? null, segPx, segEa),
+        intendedSingleLinePx(ts.eaFloorFamily ?? null, segPx, segEa),
       );
     }
+    const lineEa = EAST_ASIAN_RE.test(lineText);
     const fontPt = tallest?.fontSize ?? b.fontSizePt;
     const fontPx = fontPt * scale;
     const family = tallest?.fontFamily ?? b.fontFamily ?? null;
     const eaFamily = tallest?.eaFloorFamily ?? b.fontFamily ?? null;
-    const asciiIntended = intendedSingleLinePx(family, fontPx);
-    const eaIntended = intendedSingleLinePx(eaFamily, fontPx);
+    const asciiIntended = intendedSingleLinePx(family, fontPx, lineEa);
+    const eaIntended = intendedSingleLinePx(eaFamily, fontPx, lineEa);
     const measureFamily = eaIntended > asciiIntended ? eaFamily : family;
     ctx.font = buildFont(
       tallest?.bold ?? b.bold ?? false,
@@ -10460,14 +10462,14 @@ export function measureShapeTextAutoFitHeight(
     const m = ctx.measureText('Mg');
     const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fontPx * 0.8;
     const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fontPx * 0.2;
-    const c = correctLineMetrics(measureFamily, fontPx, rawAsc, rawDesc);
+    const c = correctLineMetrics(measureFamily, fontPx, rawAsc, rawDesc, lineEa);
     const ls: LineSpacing | null = b.lineSpacingRule
       ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
       : null;
-    const eastAsian = EAST_ASIAN_RE.test(lineText);
+    const eastAsian = lineEa;
     // Ruby lines reserve real furigana height, so use the measured glyph box,
     // mirroring the body path.
-    return lineBoxHeight(ls, c.ascent, c.descent, scale, effState.docGrid, line.hasRuby ?? false, floorPx, eastAsian, fontPx);
+    return lineBoxHeight(ls, c.ascent, c.descent, scale, effState.docGrid, line.hasRuby ?? false, floorPx, eastAsian);
   };
 
   const spBefore = blocks.map((b) => (b.spaceBefore ?? 0) * scale);
@@ -10793,8 +10795,8 @@ export function renderShapeText(
     // Sakkal text boxes are unchanged. Mirrors the xlsx shape-text floor
     // (PR #646) and the docx BODY per-eastAsia-segment floor. It is NOT per-glyph
     // CJK font switching (a larger change deferred here).
-    const asciiIntended = intendedSingleLinePx(family ?? null, fontPx);
-    const eaIntended = intendedSingleLinePx(familyEa ?? null, fontPx);
+    const asciiIntended = intendedSingleLinePx(family ?? null, fontPx, eastAsian);
+    const eaIntended = intendedSingleLinePx(familyEa ?? null, fontPx, eastAsian);
     // Use the explicit all-runs floor when provided (rich path); else fall back
     // to this run's own faces (single-format path). Both are a floor, so the
     // per-run ascii/eastAsia max is still folded in for the fallback.
@@ -10812,7 +10814,7 @@ export function renderShapeText(
     const m = ctx.measureText('Mg');
     const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fontPx * 0.8;
     const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fontPx * 0.2;
-    const c = correctLineMetrics(measureFamily, fontPx, rawAsc, rawDesc);
+    const c = correctLineMetrics(measureFamily, fontPx, rawAsc, rawDesc, eastAsian);
     // The glyph box (measured, corrected) is kept SEPARATE from the floored line
     // box: `intended` may inflate `lineH` above the glyph box, and Word centers
     // the glyph box within that expanded box (half-leading) rather than pinning
@@ -10824,7 +10826,7 @@ export function renderShapeText(
       : null;
     // Ruby lines reserve real furigana height, so use the measured glyph box,
     // mirroring the body path.
-    const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, grid, hasRuby, intended, eastAsian, fontPx);
+    const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, grid, hasRuby, intended, eastAsian);
     // Baseline placement inside the line box, mirroring the body draw path
     // (~7859). §17.3.1.33 sizes the box; the placement is Word's OBSERVED
     // behaviour (#990), not an ECMA rule:
@@ -10868,10 +10870,12 @@ export function renderShapeText(
       // the run declares it on eastAsia even though the glyphs are Latin. 0 for an
       // all-untabled line ⇒ unchanged (a pure FLOOR, PR #640/#646/#648).
       const segPx = ts.fontSize * scale;
+      // Script hint: eaOnly design heights apply to EA segments only (#1013).
+      const segEa = EAST_ASIAN_RE.test(ts.text);
       floorPx = Math.max(
         floorPx,
-        intendedSingleLinePx(ts.fontFamily ?? null, segPx),
-        intendedSingleLinePx(ts.eaFloorFamily ?? null, segPx),
+        intendedSingleLinePx(ts.fontFamily ?? null, segPx, segEa),
+        intendedSingleLinePx(ts.eaFloorFamily ?? null, segPx, segEa),
       );
     }
     const fontPx = (tallest?.fontSize ?? b.fontSizePt) * scale;
@@ -12855,7 +12859,7 @@ function measureCellParagraphWindow(
     const uniformLineH = paraHasRuby
       ? snapParaLineToGrid(
           Math.max(0, ...paintLines.map((l) => lineBoxHeight(
-            para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, eastAsian, l.height * scale,
+            para.lineSpacing, l.ascent, l.descent, scale, grid, true, l.intendedSingle, eastAsian,
           ))),
           grid,
           scale,
@@ -12866,7 +12870,7 @@ function measureCellParagraphWindow(
         ? uniformLineH
         // §17.6.5 cell rounding is gated by the line's script; a Latin-only line
         // in a CJK paragraph keeps its natural height, matching the text-box path.
-        : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, l.eastAsian ?? false, l.height * scale);
+        : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, l.eastAsian ?? false);
     return {
       heightPx: paintedParagraphHeight(paintLines, windowStart, windowEnd, 0, lineHForLine),
       totalLines,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -10427,17 +10427,23 @@ export function measureShapeTextAutoFitHeight(
 
   const lineHeightFor = (b: ShapeText, line: LayoutLine): number => {
     let tallest: LayoutTextSeg | null = null;
+    let tallestEa = false;
     let floorPx = 0;
     let lineText = '';
     for (const seg of line.segments) {
       if (!('text' in seg)) continue;
       const ts = seg as LayoutTextSeg;
       lineText += ts.text;
-      if (!tallest || ts.fontSize > tallest.fontSize) tallest = ts;
-      const segPx = ts.fontSize * scale;
       // Script hint: eaOnly design heights (Word FE 1.3 × hhea) apply to East
       // Asian segments only (issue #1013); Latin segments keep the Canvas box.
-      const segEa = EAST_ASIAN_RE.test(ts.text);
+      // Ruby segments keep their MEASURED box too (Word's FE height for a
+      // ruby-bearing line is unmeasured — sample-5 calibration stands).
+      const segEa = EAST_ASIAN_RE.test(ts.text) && !ts.ruby;
+      if (!tallest || ts.fontSize > tallest.fontSize) {
+        tallest = ts;
+        tallestEa = segEa;
+      }
+      const segPx = ts.fontSize * scale;
       floorPx = Math.max(
         floorPx,
         intendedSingleLinePx(ts.fontFamily ?? null, segPx, segEa),
@@ -10449,8 +10455,11 @@ export function measureShapeTextAutoFitHeight(
     const fontPx = fontPt * scale;
     const family = tallest?.fontFamily ?? b.fontFamily ?? null;
     const eaFamily = tallest?.eaFloorFamily ?? b.fontFamily ?? null;
-    const asciiIntended = intendedSingleLinePx(family, fontPx, lineEa);
-    const eaIntended = intendedSingleLinePx(eaFamily, fontPx, lineEa);
+    // METRIC hint = the tallest segment's own script (a Latin tallest segment
+    // keeps its Canvas box even on a CJK-bearing line); GRID participation
+    // stays line-wide (any EA content on the line makes it cell-rounded).
+    const asciiIntended = intendedSingleLinePx(family, fontPx, tallestEa);
+    const eaIntended = intendedSingleLinePx(eaFamily, fontPx, tallestEa);
     const measureFamily = eaIntended > asciiIntended ? eaFamily : family;
     ctx.font = buildFont(
       tallest?.bold ?? b.bold ?? false,
@@ -10462,7 +10471,7 @@ export function measureShapeTextAutoFitHeight(
     const m = ctx.measureText('Mg');
     const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fontPx * 0.8;
     const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fontPx * 0.2;
-    const c = correctLineMetrics(measureFamily, fontPx, rawAsc, rawDesc, lineEa);
+    const c = correctLineMetrics(measureFamily, fontPx, rawAsc, rawDesc, tallestEa);
     const ls: LineSpacing | null = b.lineSpacingRule
       ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
       : null;
@@ -10784,6 +10793,11 @@ export function renderShapeText(
     grid?: DocGridCtx,
     eastAsian = false,
     hasRuby = false,
+    // METRIC script hint (issue #1013): the measured/tallest segment's own
+    // script — eaOnly design heights (Word FE 1.3 × hhea) size the glyph box
+    // only when the measured segment is East Asian. `eastAsian` above stays
+    // line-wide (it gates the §17.6.5 grid cell rounding).
+    metricEastAsian = eastAsian,
   ): { lineH: number; baselineOffset: number } => {
     // Floor the single-line box by the TALLEST design line among the run's
     // declared faces (ascii §17.3.2.26 + eastAsia). The common Japanese encoding
@@ -10795,8 +10809,8 @@ export function renderShapeText(
     // Sakkal text boxes are unchanged. Mirrors the xlsx shape-text floor
     // (PR #646) and the docx BODY per-eastAsia-segment floor. It is NOT per-glyph
     // CJK font switching (a larger change deferred here).
-    const asciiIntended = intendedSingleLinePx(family ?? null, fontPx, eastAsian);
-    const eaIntended = intendedSingleLinePx(familyEa ?? null, fontPx, eastAsian);
+    const asciiIntended = intendedSingleLinePx(family ?? null, fontPx, metricEastAsian);
+    const eaIntended = intendedSingleLinePx(familyEa ?? null, fontPx, metricEastAsian);
     // Use the explicit all-runs floor when provided (rich path); else fall back
     // to this run's own faces (single-format path). Both are a floor, so the
     // per-run ascii/eastAsia max is still folded in for the fallback.
@@ -10814,7 +10828,7 @@ export function renderShapeText(
     const m = ctx.measureText('Mg');
     const rawAsc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? fontPx * 0.8;
     const rawDesc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? fontPx * 0.2;
-    const c = correctLineMetrics(measureFamily, fontPx, rawAsc, rawDesc, eastAsian);
+    const c = correctLineMetrics(measureFamily, fontPx, rawAsc, rawDesc, metricEastAsian);
     // The glyph box (measured, corrected) is kept SEPARATE from the floored line
     // box: `intended` may inflate `lineH` above the glyph box, and Word centers
     // the glyph box within that expanded box (half-leading) rather than pinning
@@ -10856,13 +10870,13 @@ export function renderShapeText(
   // back to the block's own font.
   const lineMetricsFor = (b: ShapeText, line: LayoutLine): { lineH: number; baselineOffset: number } => {
     let tallest: LayoutTextSeg | null = null;
+    let tallestEa = false;
     let floorPx = 0;
     let lineText = '';
     for (const seg of line.segments) {
       if (!('text' in seg)) continue;
       const ts = seg as LayoutTextSeg;
       lineText += ts.text;
-      if (!tallest || ts.fontSize > tallest.fontSize) tallest = ts;
       // Design-line FLOOR is the MAX intendedSingleLinePx over EVERY segment's
       // ascii AND declared eastAsia face (§17.3.2.26), at that segment's size —
       // mirrors the body's per-segment max and the pre-refactor per-run floor.
@@ -10870,8 +10884,13 @@ export function renderShapeText(
       // the run declares it on eastAsia even though the glyphs are Latin. 0 for an
       // all-untabled line ⇒ unchanged (a pure FLOOR, PR #640/#646/#648).
       const segPx = ts.fontSize * scale;
-      // Script hint: eaOnly design heights apply to EA segments only (#1013).
-      const segEa = EAST_ASIAN_RE.test(ts.text);
+      // Script hint: eaOnly design heights apply to EA segments only, and ruby
+      // segments keep their measured box (#1013).
+      const segEa = EAST_ASIAN_RE.test(ts.text) && !ts.ruby;
+      if (!tallest || ts.fontSize > tallest.fontSize) {
+        tallest = ts;
+        tallestEa = segEa;
+      }
       floorPx = Math.max(
         floorPx,
         intendedSingleLinePx(ts.fontFamily ?? null, segPx, segEa),
@@ -10895,6 +10914,9 @@ export function renderShapeText(
       effState.docGrid,
       eastAsian,
       line.hasRuby ?? false,
+      // METRIC hint = tallest segment's own script (Latin tallest keeps its
+      // Canvas box on a CJK-bearing line); grid rounding stays line-wide.
+      tallestEa,
     );
   };
 

--- a/packages/docx/src/table-cell-docgrid.test.ts
+++ b/packages/docx/src/table-cell-docgrid.test.ts
@@ -19,6 +19,11 @@ function makeMeasureState(
   docGridType: 'lines' | 'snapToChars' = 'lines',
 ): MeasureState {
   let font = '10px serif';
+  // The mock glyph box is a flat 1.0×em (ascent 0.8 + descent 0.2 of the
+  // CURRENT font size). No run family is in the core metric table, so every
+  // height below is exactly the tallest run's synthetic box — any growth
+  // beyond it must come from the grid cell rounding under test.
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
   const ctx = {
     get font() {
       return font;
@@ -29,10 +34,10 @@ function makeMeasureState(
     letterSpacing: '0px',
     measureText: (text: string) => ({
       width: [...text].length * 10,
-      fontBoundingBoxAscent: 8,
-      fontBoundingBoxDescent: 2,
-      actualBoundingBoxAscent: 8,
-      actualBoundingBoxDescent: 2,
+      fontBoundingBoxAscent: px() * 0.8,
+      fontBoundingBoxDescent: px() * 0.2,
+      actualBoundingBoxAscent: px() * 0.8,
+      actualBoundingBoxDescent: px() * 0.2,
     }) as TextMetrics,
     save() {},
     restore() {},
@@ -222,23 +227,24 @@ describe('table-cell line grid compatibility', () => {
   });
 });
 
-// The docGrid line-cell count (docGridLineCells) is derived from the line's em
-// — the TALLEST run on the line (ECMA-376 §17.6.5; the grid reserves whole
-// cells for the line box, which the tallest run governs). These integration
-// cases pin two call-path properties the pure lineBoxHeight tests cannot see:
-// which em the layout hands over, and which script gate each LINE uses. The
+// The docGrid line-cell count (docGridLineCells) is derived from the line's
+// resolved single-line height — the TALLEST run's box governs the line
+// (ECMA-376 §17.3.1.33; the grid reserves the whole cells that CONTAIN that
+// box, §17.6.5 / issue #1013 sample-58 adjudication). These integration cases
+// pin two call-path properties the pure lineBoxHeight tests cannot see: which
+// line height the layout hands over, and which script gate each LINE uses. The
 // grid is active in a cell via adjustLineHeightInTable (§17.15.3.1); pitch =
-// 20 pt; the mock font box is a fixed 8+2 px, so every height difference below
-// comes from the em / script routing alone.
+// 20 pt; the mock font box is a flat 1.0×em, so every height difference below
+// comes from the line-height / script routing alone.
 describe('docGrid line-cell integration through the cell measure path', () => {
-  it('a manual line break in a SMALLER run does not shrink the line em (tallest governs)', () => {
-    // Line 1: 'あ' at 20 pt + 'い' at 10 pt, terminated by a <w:br> whose
+  it('a manual line break in a SMALLER run does not shrink the line height (tallest governs)', () => {
+    // Line 1: 'あ' at 24 pt + 'い' at 10 pt, terminated by a <w:br> whose
     // nearby size resolves to 10 pt (§17.3.3.1; findNearbyFontSize looks at the
     // preceding run). Line 2: 'う' at 10 pt. The break must NOT overwrite the
-    // line's tallest em (20 pt → floor(20/20)+1 = 2 cells = 40) with its own
-    // 10 pt (1 cell = 20).
+    // line's tallest box (24 px → ceil(24/20) = 2 cells = 40) with its own
+    // 10 pt box (1 cell = 20).
     const para = paragraphWithRuns([
-      { text: 'あ', fontSize: 20 },
+      { text: 'あ', fontSize: 24 },
       { text: 'い', fontSize: 10 },
       { type: 'break', breakType: 'line' },
       { text: 'う', fontSize: 10 },
@@ -250,15 +256,15 @@ describe('docGrid line-cell integration through the cell measure path', () => {
   it('the East Asian cell rounding is gated per LINE, not per paragraph', () => {
     // Line 1: CJK 10 pt → 1 cell (20). Line 2: Latin-only 'Hello' at 22 pt —
     // Word does not cell-round Latin lines; they keep their natural height
-    // above a one-cell floor (mock natural = 10 px → floor = 20), NOT the em
-    // cell count floor(22/20)+1 = 2 cells = 40 that a paragraph-level East
-    // Asian flag would apply.
+    // above a one-cell floor (mock natural = 22 px > floor 20 → 22), NOT the
+    // cell count ceil(22/20) = 2 cells = 40 that a paragraph-level East Asian
+    // flag would apply.
     const para = paragraphWithRuns([
       { text: 'あ', fontSize: 10 },
       { type: 'break', breakType: 'line' },
       { text: 'Hello', fontSize: 22 },
     ]);
     expect(calculateRowHeight(rowWith(para), table(), [100], 1, makeMeasureState(true)))
-      .toBe(40); // 20 (CJK, 1 cell) + 20 (Latin, one-cell floor)
+      .toBe(42); // 20 (CJK, 1 cell) + 22 (Latin, natural above the one-cell floor)
   });
 });

--- a/packages/docx/src/textbox-docgrid-line-pitch.test.ts
+++ b/packages/docx/src/textbox-docgrid-line-pitch.test.ts
@@ -58,14 +58,17 @@ function makeRecordingCanvas(): { ctx: CanvasRenderingContext2D; fillTexts: Fill
 
 /** A no-fill/no-line 10 pt text box whose single EA block wraps into ≥2 lines in
  *  a narrow box (mock measureText is chars × px). The text is CJK so the line is
- *  classified East Asian for docGrid cell rounding (EAST_ASIAN_RE). */
+ *  classified East Asian for docGrid cell rounding (EAST_ASIAN_RE). The family
+ *  is deliberately NOT in the core metric table (游明朝 is, since issue #1013)
+ *  so the natural box stays the mock's flat 1.0×em — the grid snap alone
+ *  accounts for any growth. */
 function eaTextbox(): ShapeRun {
   const text = 'あいうえおかきくけこさしすせそたちつてと';
   const block: ShapeText = {
     text,
     fontSizePt: 10,
     alignment: 'left',
-    runs: [{ text, fontSizePt: 10, fontFamily: '游明朝', fontFamilyEastAsia: '游明朝' }],
+    runs: [{ text, fontSizePt: 10, fontFamily: 'テスト明朝', fontFamilyEastAsia: 'テスト明朝' }],
   } as ShapeText;
   return {
     type: 'shape',
@@ -158,12 +161,13 @@ describe('text-box lines snap to the section docGrid line pitch (ECMA-376 §17.6
 
   // §17.3.3.25 ruby in a text box flows through the SAME shared line engine as
   // body ruby, so a ruby line must take lineBoxHeight's ruby branch (measured
-  // glyph box), NOT the plain-EA em cell count. With the mock's 1.0×em box an
-  // 18 pt ruby base on an 18 pt pitch measures exactly one cell — the em rule
-  // (floor(18/18)+1 = 2 cells = 36 pt) would open a spurious extra cell under
-  // every ruby line. `line.hasRuby` (built by layoutLines from the run's ruby
-  // annotation) must reach lineBoxHeight in BOTH text-box paths.
-  it('renderShapeText keeps a ruby line on its measured glyph box (1 cell), not the em cell count', () => {
+  // glyph box), NOT the plain-EA design-height cell count. The ruby box keeps
+  // 游明朝 (tabled since issue #1013): its 18 pt design line is 25.79 pt, so
+  // the plain-EA rule would round to ceil(25.79/18) = 2 cells = 36 pt — while
+  // the ruby branch keeps the measured 1.0×em glyph box, exactly one 18 pt
+  // cell. `line.hasRuby` (built by layoutLines from the run's ruby annotation)
+  // must reach lineBoxHeight in BOTH text-box paths.
+  it('renderShapeText keeps a ruby line on its measured glyph box (1 cell), not the design cell count', () => {
     const { ctx, fillTexts } = makeRecordingCanvas();
     renderShapeText(rubyTextbox(), 0, 0, 60, 400, ctx, 1, {}, new Map(),
       stateWithGrid(ctx, { type: 'lines', linePitchPt: PITCH }));
@@ -180,13 +184,11 @@ describe('text-box lines snap to the section docGrid line pitch (ECMA-376 §17.6
     const { ctx } = makeRecordingCanvas();
     const shape = rubyTextbox();
     const gridState = stateWithGrid(ctx, { type: 'lines', linePitchPt: PITCH });
-    const flatState = stateWithGrid(ctx, { type: 'default', linePitchPt: null });
     const hGrid = measureShapeTextAutoFitHeight(shape, 60, ctx, 1, {}, new Map(), gridState);
-    const hFlat = measureShapeTextAutoFitHeight(shape, 60, ctx, 1, {}, new Map(), flatState);
-    // Off-grid each 18 pt line is its 18 px natural box, so the line count is
-    // hFlat / 18; on-grid each ruby line is ONE 18 pt cell — identical total.
-    const lineCount = Math.round(hFlat / 18);
-    expect(lineCount).toBeGreaterThanOrEqual(2);
-    expect(hGrid).toBeCloseTo(lineCount * PITCH, 3);
+    // rubyTextbox lands each of its three runs on its own line (3 × 18 pt runs
+    // exactly fill the 60 pt width). Each ruby line is ONE 18 pt cell (its
+    // measured 1.0×em glyph box), not the 2 cells the 游明朝 design height
+    // (25.79 pt) would claim through the plain-EA rule.
+    expect(hGrid).toBeCloseTo(3 * PITCH, 3);
   });
 });

--- a/packages/node/src/docx-docgrid-pitch.probe.test.ts
+++ b/packages/node/src/docx-docgrid-pitch.probe.test.ts
@@ -87,7 +87,7 @@ function storedZip(files: Record<string, string>): Uint8Array {
  *  <w:br/>. Line spacing is single via docDefaults ONLY (inherited-only, the
  *  state that grid-snaps per §17.6.5 — an explicit per-pPr w:line would take
  *  the multiplier path instead, matching Word). */
-function docxWith(sizePt: number, sectPr: string): Uint8Array {
+function docxWith(sizePt: number, sectPr: string, lineText?: string): Uint8Array {
   const contentTypes =
     '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
     '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
@@ -116,7 +116,7 @@ function docxWith(sizePt: number, sectPr: string): Uint8Array {
     '</w:docDefaults></w:styles>';
   const sz = String(Math.round(sizePt * 2));
   const rpr = `<w:rPr><w:rFonts w:ascii="Yu Mincho" w:hAnsi="Yu Mincho" w:eastAsia="游明朝"/><w:sz w:val="${sz}"/><w:szCs w:val="${sz}"/></w:rPr>`;
-  const line = '国境の長いトンネルを抜けると雪国であった';
+  const line = lineText ?? '国境の長いトンネルを抜けると雪国であった';
   const runs = Array.from({ length: 4 }, (_, i) =>
     `<w:r>${rpr}<w:t xml:space="preserve">${line}</w:t></w:r>` +
     (i < 3 ? `<w:r>${rpr}<w:br/></w:r>` : ''),
@@ -137,16 +137,16 @@ function docxWith(sizePt: number, sectPr: string): Uint8Array {
 const A4 = '<w:pgSz w:w="11906" w:h="16838"/>' +
   '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/>';
 
-function sectPr(opts: { vertical?: boolean; pitchTw?: number }): string {
+function sectPr(opts: { vertical?: boolean; pitchTw?: number; gridType?: string }): string {
   return A4 +
     (opts.vertical ? '<w:textDirection w:val="tbRl"/>' : '') +
-    (opts.pitchTw ? `<w:docGrid w:type="lines" w:linePitch="${opts.pitchTw}"/>` : '');
+    (opts.pitchTw ? `<w:docGrid w:type="${opts.gridType ?? 'lines'}" w:linePitch="${opts.pitchTw}"/>` : '');
 }
 
 /** Render page 0 and return the mean gap between consecutive line positions —
  *  physical y for horizontal pages, physical x (column advance, right→left
  *  page rotated to +x order) for vertical ones. */
-async function measurePitch(bytes: Uint8Array, axis: 'y' | 'x'): Promise<number> {
+async function measurePitch(bytes: Uint8Array, axis: 'y' | 'x', marker = '国境'): Promise<number> {
   const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
   const { renderDocumentToCanvas } = rendererMod as Any;
   const doc = parseDocx(bytes);
@@ -159,7 +159,7 @@ async function measurePitch(bytes: Uint8Array, axis: 'y' | 'x'): Promise<number>
       dpr: 1,
       width: doc.section.pageWidth,
       onTextRun: (r: Any) => {
-        if (String(r.text).includes('国境')) pos.push(axis === 'y' ? r.y : r.x);
+        if (String(r.text).includes(marker)) pos.push(axis === 'y' ? r.y : r.x);
       },
     });
   } finally {
@@ -203,6 +203,30 @@ describe.skipIf(!skia || !docxMod || !rendererMod)(
     it('no docGrid: the Yu Mincho design single line (1.43267 em; 16pt → 22.92pt)', async () => {
       const pitch = await measurePitch(docxWith(16, sectPr({})), 'y');
       expect(pitch).toBeCloseTo(16 * ((2257 * 1.3) / 2048), 1);
+    });
+    it('a 20pt line on a 24pt grid takes 2 cells (48pt) — sample-58 C3', async () => {
+      const pitch = await measurePitch(docxWith(20, sectPr({ vertical: true, pitchTw: 480 })), 'x');
+      expect(pitch).toBeCloseTo(48, 1);
+    });
+    it('linesAndChars behaves like lines (grid-type-agnostic; 16pt/18pt → 36pt) — sample-58 D2', async () => {
+      const pitch = await measurePitch(
+        docxWith(16, sectPr({ vertical: true, pitchTw: 360, gridType: 'linesAndChars' })), 'x');
+      expect(pitch).toBeCloseTo(36, 1);
+    });
+    it('a LATIN-only Yu Mincho line keeps its natural box above a one-pitch floor, never FE cells', async () => {
+      // §17.6.5 leaves Latin lines at default spacing above a one-pitch floor
+      // (max(natural, pitch)), and the eaOnly Yu Mincho FE height must NOT
+      // fire for a Latin line (demo/sample-1 footnote adjudication: Word gives
+      // Latin Yu Mincho the win box, not 1.43267 em). The Latin natural is the
+      // SUBSTITUTED font's box (environment-dependent in this headless run),
+      // so calibrate it from the no-grid render and assert the on-grid value
+      // is exactly max(natural, pitch) — an FE regression would instead
+      // cell-round 16pt to 2 cells (36pt).
+      const latin = 'The quick brown fox jumps over the dog';
+      const natural = await measurePitch(docxWith(16, sectPr({}), latin), 'y', 'quick');
+      const pitch = await measurePitch(docxWith(16, sectPr({ pitchTw: 360 }), latin), 'y', 'quick');
+      expect(pitch).toBeCloseTo(Math.max(natural, 18), 1);
+      expect(pitch).toBeLessThan(36);
     });
   },
 );

--- a/packages/node/src/docx-docgrid-pitch.probe.test.ts
+++ b/packages/node/src/docx-docgrid-pitch.probe.test.ts
@@ -1,0 +1,208 @@
+/**
+ * ECMA-376 §17.6.5 docGrid line/column pitch through the REAL parse→render
+ * path — the issue #1013 adjudication (sample-58 sweep, Word PDF ground truth).
+ *
+ * Word measurement (pdftotext -bbox over a 19-section synthetic matrix of
+ * {10.5,12,14,16,20}pt × linePitch {18,24}pt × {lrTb,tbRl} × {lines,
+ * linesAndChars,none}, all Yu Mincho): a single-spaced East Asian line
+ * occupies ceil(designSingleLineHeight / pitch) whole grid cells, where the
+ * design height for Yu Mincho is 1.3 × its hhea box = 1.43267 em (core
+ * line-metrics). The measured matrix:
+ *
+ *   pitch 18pt: 10.5/12pt → 18pt (1 cell);  14/16/20pt → 36pt (2 cells)
+ *   pitch 24pt: 12/16pt   → 24pt (1 cell);  20pt       → 48pt (2 cells)
+ *   no grid   : natural 1.43267 em (e.g. 16pt → 22.92pt)
+ *
+ * HORIZONTAL and VERTICAL (tbRl) sections measured IDENTICAL pitches — the
+ * tbRl column pitch is the same grid cell height (the vertical page is the
+ * horizontal layout rotated), so these probes pin BOTH directions through
+ * renderDocumentToCanvas. The pre-#1013 em-based rule (floor(em/pitch)+1)
+ * rendered every 14–16pt line 1 cell (18pt) — 2× too tight vs Word's 36pt.
+ *
+ * CI-safe: gated on docx WASM + skia-canvas; skips when absent.
+ */
+import { describe, it, expect } from 'vitest';
+import { crc32 } from 'node:zlib';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas } = (skia ?? {}) as Skia;
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
+const rendererMod = await importForTests(
+  () => import('./../../docx/src/renderer.ts'),
+  'packages/docx/src/renderer.ts',
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+const NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+function storedZip(files: Record<string, string>): Uint8Array {
+  const enc = new TextEncoder();
+  const chunks: number[] = [];
+  const central: number[] = [];
+  const u16 = (n: number) => [n & 0xff, (n >> 8) & 0xff];
+  const u32 = (n: number) => [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff];
+  let offset = 0;
+  for (const [name, content] of Object.entries(files)) {
+    const nameBytes = [...enc.encode(name)];
+    const data = [...enc.encode(content)];
+    const crc = crc32(Uint8Array.from(data)) >>> 0;
+    const local = [
+      ...u32(0x04034b50), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...nameBytes, ...data,
+    ];
+    central.push(
+      ...u32(0x02014b50), ...u16(20), ...u16(20), ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+      ...u32(crc), ...u32(data.length), ...u32(data.length),
+      ...u16(nameBytes.length), ...u16(0), ...u16(0), ...u16(0), ...u16(0), ...u32(0), ...u32(offset),
+      ...nameBytes,
+    );
+    chunks.push(...local);
+    offset += local.length;
+  }
+  const centralOffset = offset;
+  const end = [
+    ...u32(0x06054b50), ...u16(0), ...u16(0),
+    ...u16(Object.keys(files).length), ...u16(Object.keys(files).length),
+    ...u32(central.length), ...u32(centralOffset), ...u16(0),
+  ];
+  return Uint8Array.from([...chunks, ...central, ...end]);
+}
+
+/** A one-section docx: a single Yu Mincho paragraph of 4 CJK lines joined by
+ *  <w:br/>. Line spacing is single via docDefaults ONLY (inherited-only, the
+ *  state that grid-snaps per §17.6.5 — an explicit per-pPr w:line would take
+ *  the multiplier path instead, matching Word). */
+function docxWith(sizePt: number, sectPr: string): Uint8Array {
+  const contentTypes =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>' +
+    '</Types>';
+  const rootRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+    '</Relationships>';
+  const docRels =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>' +
+    '</Relationships>';
+  const styles =
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    `<w:styles ${NS}><w:docDefaults>` +
+    '<w:rPrDefault><w:rPr>' +
+    '<w:rFonts w:ascii="Yu Mincho" w:hAnsi="Yu Mincho" w:eastAsia="游明朝"/>' +
+    '<w:sz w:val="21"/><w:szCs w:val="21"/></w:rPr></w:rPrDefault>' +
+    '<w:pPrDefault><w:pPr><w:spacing w:line="240" w:lineRule="auto"/></w:pPr></w:pPrDefault>' +
+    '</w:docDefaults></w:styles>';
+  const sz = String(Math.round(sizePt * 2));
+  const rpr = `<w:rPr><w:rFonts w:ascii="Yu Mincho" w:hAnsi="Yu Mincho" w:eastAsia="游明朝"/><w:sz w:val="${sz}"/><w:szCs w:val="${sz}"/></w:rPr>`;
+  const line = '国境の長いトンネルを抜けると雪国であった';
+  const runs = Array.from({ length: 4 }, (_, i) =>
+    `<w:r>${rpr}<w:t xml:space="preserve">${line}</w:t></w:r>` +
+    (i < 3 ? `<w:r>${rpr}<w:br/></w:r>` : ''),
+  ).join('');
+  const document =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document ${NS}><w:body>` +
+    `<w:p><w:pPr>${rpr}</w:pPr>${runs}</w:p>` +
+    `<w:sectPr>${sectPr}</w:sectPr></w:body></w:document>`;
+  return storedZip({
+    '[Content_Types].xml': contentTypes,
+    '_rels/.rels': rootRels,
+    'word/_rels/document.xml.rels': docRels,
+    'word/document.xml': document,
+    'word/styles.xml': styles,
+  });
+}
+
+const A4 = '<w:pgSz w:w="11906" w:h="16838"/>' +
+  '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/>';
+
+function sectPr(opts: { vertical?: boolean; pitchTw?: number }): string {
+  return A4 +
+    (opts.vertical ? '<w:textDirection w:val="tbRl"/>' : '') +
+    (opts.pitchTw ? `<w:docGrid w:type="lines" w:linePitch="${opts.pitchTw}"/>` : '');
+}
+
+/** Render page 0 and return the mean gap between consecutive line positions —
+ *  physical y for horizontal pages, physical x (column advance, right→left
+ *  page rotated to +x order) for vertical ones. */
+async function measurePitch(bytes: Uint8Array, axis: 'y' | 'x'): Promise<number> {
+  const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
+  const { renderDocumentToCanvas } = rendererMod as Any;
+  const doc = parseDocx(bytes);
+  const canvas = new Canvas(10, 10);
+  const pos: number[] = [];
+  const rImg = installImageBitmapShim(factory);
+  const rOff = installOffscreenCanvasShim(factory);
+  try {
+    await renderDocumentToCanvas(doc, canvas, 0, {
+      dpr: 1,
+      width: doc.section.pageWidth,
+      onTextRun: (r: Any) => {
+        if (String(r.text).includes('国境')) pos.push(axis === 'y' ? r.y : r.x);
+      },
+    });
+  } finally {
+    rOff();
+    rImg();
+  }
+  const uniq = [...new Set(pos.map((v) => Math.round(v * 100) / 100))].sort((a, b) => a - b);
+  // Cluster to line centers (per-glyph runs share the line position ±ε).
+  const centers: number[] = [];
+  for (const v of uniq) {
+    if (centers.length === 0 || v - centers[centers.length - 1] > 2) centers.push(v);
+  }
+  expect(centers.length).toBe(4);
+  const gaps = centers.slice(1).map((v, i) => v - centers[i]);
+  return gaps.reduce((a, b) => a + b, 0) / gaps.length;
+}
+
+describe.skipIf(!skia || !docxMod || !rendererMod)(
+  'docx docGrid line/column pitch (§17.6.5, issue #1013 sample-58 adjudication)',
+  () => {
+    it('HORIZONTAL: a 16pt line on an 18pt grid takes 2 cells (36pt, was 18pt)', async () => {
+      const pitch = await measurePitch(docxWith(16, sectPr({ pitchTw: 360 })), 'y');
+      expect(pitch).toBeCloseTo(36, 1);
+    });
+    it('HORIZONTAL: a 12pt line on an 18pt grid stays 1 cell (18pt)', async () => {
+      const pitch = await measurePitch(docxWith(12, sectPr({ pitchTw: 360 })), 'y');
+      expect(pitch).toBeCloseTo(18, 1);
+    });
+    it('VERTICAL (tbRl): a 16pt column on an 18pt grid takes 2 cells (36pt) — the issue #1013 case', async () => {
+      const pitch = await measurePitch(docxWith(16, sectPr({ vertical: true, pitchTw: 360 })), 'x');
+      expect(pitch).toBeCloseTo(36, 1);
+    });
+    it('VERTICAL (tbRl): a 12pt column on an 18pt grid stays 1 cell (18pt)', async () => {
+      const pitch = await measurePitch(docxWith(12, sectPr({ vertical: true, pitchTw: 360 })), 'x');
+      expect(pitch).toBeCloseTo(18, 1);
+    });
+    it('a 16pt line on a 24pt grid stays 1 cell (24pt) — pitch-scaled, not size-thresholded', async () => {
+      const pitch = await measurePitch(docxWith(16, sectPr({ pitchTw: 480 })), 'y');
+      expect(pitch).toBeCloseTo(24, 1);
+    });
+    it('no docGrid: the Yu Mincho design single line (1.43267 em; 16pt → 22.92pt)', async () => {
+      const pitch = await measurePitch(docxWith(16, sectPr({})), 'y');
+      expect(pitch).toBeCloseTo(16 * ((2257 * 1.3) / 2048), 1);
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Adjudicates and fixes the ECMA-376 §17.6.5 docGrid line/column pitch rule (issue #1013) from a dedicated 19-section Word-PDF sweep (sample-58: {10.5, 12, 14, 16, 20}pt × linePitch {18, 24}pt × {lrTb, tbRl} × {lines, linesAndChars, none}, all Yu Mincho; full measurement table in the [adjudication record](https://github.com/yukiyokotani/office-open-xml-viewer/issues/1013#issuecomment-4950702155)).

### Adjudicated rule

- A single-spaced East Asian line occupies **`ceil(designSingleLineHeight / pitch)` whole grid cells** — the smallest number of cells that contains the line. **Direction-agnostic** (horizontal and tbRl sections measured identical pitches in all 19 sections) and **grid-type-agnostic** (`linesAndChars` == `lines`).
- **Yu Mincho's Word single-line height is 1.3 × its hhea glyph box = 1.43267 em** (hhea verified from the Word-bundled faces; the factor measured off-grid at 14pt/20.04pt and 16pt/22.94pt, and reproducing all 15 grid points). Neither the win sum (1.287 em) nor hhea+lineGap (1.602 em, what Canvas reports) matches.
- **Script-dependent**: a pure-Latin line in the same Yu Mincho keeps the win-box height (Word PDF: demo/sample-1 footnote, 13.44pt @ 10.5pt = 1.28711 em). The new core entry is therefore `eaOnly`, exposed through an optional `eastAsian` hint on `fontWinLineHeightRatio` / `intendedSingleLinePx` / `correctLineMetrics` (default `false`: every existing call site, including the pptx/xlsx design-line floors, is byte-identical).

### What was wrong

The previous `floor(em/pitch)+1` em rule fit the sparse pre-sweep calibration (10.5/12pt on 18pt, 20pt on 20pt — points where both rules coincide) but under-counted every 14–16pt line on an 18pt pitch (Word: 2 cells = 36pt; em rule: 1 cell = 18pt) **in both writing directions** — the reported "vertical column pitch 2× too tight" was the same defect surfacing vertically. Both pre-sweep Word calibration points still hold under the new rule (sample-35 12pt → 1 cell; sample-9 20pt/20pt → 2 cells).

### Before / after (engine, real parse→render, `onTextRun` probe)

| case | Word | before | after |
|---|---|---|---|
| 16pt on 18pt grid, horizontal | 36pt | 18pt | **36pt** |
| 16pt on 18pt grid, vertical tbRl (the #1013 report) | 36pt | 18pt | **36pt** |
| 12pt on 18pt grid (both dirs) | 18pt | 18pt | 18pt |
| 16pt on 24pt grid | 24pt | 24pt | 24pt |
| 20pt on 24pt grid | 48pt | 24pt | **48pt** |
| off-grid 16pt CJK single line | 22.944pt | 25.63pt | **22.92pt** |
| private/sample-47 vertical 16pt columns | 36pt pitch | 18pt | **36pt** (matches Word PDF) |

### Changes

- `packages/docx/src/line-layout.ts` — `docGridLineCells` now takes the line's resolved single-line height (`max(1, ceil(natural/pitch))`); the dead `emPx` parameter removed from `lineBoxHeight` and all call sites. Ruby lines keep the measured-glyph-box reservation (unchanged; verified against sample-53 box (b) that the eaVert ruby cross-axis reservation flows through the line box with no overlap — the folded item needed no code change).
- `packages/core/src/text/line-metrics.ts` — Yu Mincho / Yu Gothic `eaOnly` design entry + the `eastAsian` script hint (default false).
- Script hints threaded per segment/line through the docx body and shape-text paths; the METRIC hint follows the measured/tallest segment's own script while grid-cell participation stays line-wide; ruby segments excluded from the FE correction.
- Tests: `line-box-height.test.ts` rewritten to the adjudicated rule (including the full sample-58 matrix as a table test), core line-metrics tests for the new entry/hint, and a new end-to-end probe `packages/node/src/docx-docgrid-pitch.probe.test.ts` (H+V × {12, 16, 20}pt × {18, 24}pt × {lines, linesAndChars}, off-grid natural, Latin-only guard).

### Independent review

Codex gpt-5.6-sol (high), read-only: no P0; P1 findings (mixed-line metric hint, ruby-metric gating) fixed in the second commit; P2 scope notes recorded (Yu Gothic factor marked as extrapolated pending its own sweep; probe coverage extended).

### Gates

- docx vitest 1400/1400, core+pptx+xlsx suites all green (4171 total), root `pnpm typecheck` clean.
- docx VRT 85/85: private samples byte-identical except sample-5 p1 at 99.9% (0.1%, EA design-height shift, Word-ward); demo pages at their recorded scores (page 5 byte-identical again after the `eaOnly` gating — the Latin footnote is untouched). No reference updated.

### Follow-ups (recorded on #1013)

- Latin lines in Yu faces still use the substituted Canvas box; Word measures the win sum (1.28711 em) — a candidate `eaOnly:false` win entry, kept out of this adjudication's scope.
- Yu Gothic's 1.3 FE factor is extrapolated from Yu Mincho (byte-identical hhea); needs its own sweep page.
- `EAST_ASIAN_RE` misses supplementary-plane Han (e.g. 𠮷) — pre-existing predicate now also gating the metric hint; migrate to Unicode script properties in a dedicated change.
- Per-section `docGrid` (mid-document sectPr grids) is not modeled (single-section model #513); sample-58 itself renders un-snapped, real corpus docs carry the grid on the body-level sectPr.

Closes #1013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
