### PR TITLE
fix(docx): size vertical Tr rotate-fallback cells to their ink extent (#1014)

### DIFF
--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -54,6 +54,7 @@ import {
   resolveLineFloatWindow,
   wordMinLineStartPx,
 } from './float-layout.js';
+import { verticalRunInkExtraPx } from './vertical-text.js';
 
 export interface LineBoundary {
   segIndex: number;
@@ -184,6 +185,14 @@ export interface LayoutTextSeg extends LayoutSegSource {
    *  the horizontally-laid-out run so it fits the line height. Only meaningful
    *  when {@link tateChuYoko} is set. */
   tateChuYokoCompress?: boolean;
+  /** issue #1014 — set by {@link buildSegments} when this segment is drawn by the
+   *  per-glyph upright-vertical (tbRl) path (`environment.verticalCJK`, and NOT a
+   *  縦中横 cell). It gates the vo=Tr rotate-fallback INK-extent advance correction
+   *  (`verticalRunInkExtraPx`) in the measure passes so the layout advance matches
+   *  the ink-sized cell `drawVerticalRun` paints — measure == draw. Inert (0
+   *  correction) for every font that does not under-report a rotate mark's advance,
+   *  which is all of them except a Chrome substitute; absent on horizontal pages. */
+  verticalRun?: boolean;
   /** Issue #797 — dictionary word-break offsets (seg-local UTF-16 indices, from
    *  core `seaWordBreakOffsets`) for a Thai/Lao/Khmer segment, which has no
    *  inter-word spaces. Populated by {@link layoutLines} for SEA text; the wrap
@@ -1409,6 +1418,12 @@ export function fitCJKPrefix(
   // model uses (measure==paint). Default (1, 0) reproduces the prior behaviour.
   charScale = 1,
   charSpacingPx = 0,
+  // issue #1014 — a vertical (tbRl) run whose segment is flagged `verticalRun`:
+  // fold the vo=Tr rotate-fallback ink deficit into the fit predicate too, so the
+  // wrap chooses a prefix whose CORRECTED advance (the same the line box measures)
+  // fits — not one that only fits by the under-reported raw width. 0 for horizontal
+  // / non-under-reporting runs, so the split is byte-identical there.
+  verticalRun = false,
 ): string {
   const chars = [...text]; // spread handles surrogate pairs
   // Trailing IDEOGRAPHIC SPACE (U+3000) line-end allowance: a candidate that
@@ -1429,7 +1444,7 @@ export function fitCJKPrefix(
     const prefix = chars.slice(0, visibleEnd).join('');
     if (prefix.length === 0) return true;
     const advance = textAdvanceWidth(
-      ctx.measureText(prefix).width,
+      ctx.measureText(prefix).width + (verticalRun ? verticalRunInkExtraPx(ctx, prefix) : 0),
       prefix,
       gridDeltaPx,
       charScale,
@@ -2176,6 +2191,11 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
           environment.verticalCJK && r.eastAsianVert === true && r.eastAsianVertCompress === true
             ? true
             : undefined,
+        // #1014 — an upright-vertical (tbRl) per-glyph segment (NOT a 縦中横 cell,
+        // which is one drawTateChuYokoRun cell). Marks the segment for the vo=Tr
+        // rotate-fallback ink-extent advance correction in the measure passes.
+        verticalRun:
+          environment.verticalCJK && r.eastAsianVert !== true ? true : undefined,
       });
       firstSeg = false;
       gluePending = false; // glue applies only to a piece's FIRST segment
@@ -2790,6 +2810,18 @@ export function layoutLines(
     restoreKerning(prevKern);
     return m;
   };
+  // #1014 — extra along-column advance a vertical (tbRl) run needs so a vo=Tr
+  // rotate-fallback mark (ー 〜 “” ：) whose substitute font UNDER-REPORTS its
+  // advance via measureText keeps its ink inside the ink-sized cell
+  // `drawVerticalRun` paints. Added to the natural advance at EVERY site that
+  // measures a vertical text seg's advance (the main commit, the tab forced-commit
+  // paths, the fitText gap resolver, and the wrap/split look-ahead) so the measured
+  // box tracks the drawn cell (measure == draw). 0 for horizontal runs, 縦中横 cells
+  // (`!verticalRun`), and every font that does not under-report — byte-identical
+  // common path. The run's font must already be selected on `ctx` (the callers
+  // select it via measureText / setMeasureFont immediately before).
+  const verticalInkExtra = (s: LayoutTextSeg, text: string): number =>
+    s.verticalRun ? verticalRunInkExtraPx(ctx, text) : 0;
 
   const endBoundary: LineBoundary = { segIndex: segs.length, charOffset: 0 };
   const sourcedSegs = segs.map((seg, segIndex) => {
@@ -2843,10 +2875,13 @@ export function layoutLines(
   // Resolve §17.3.2.14 from RAW natural advances at this exact layout scale.
   // The resulting per-gap is folded into segAdvanceWidth below, so the line
   // breaker and paint pen use one width authority. Cached w:spacing is ignored.
+  // #1014 — the natural width includes the vo=Tr ink deficit so the resolved gap
+  // (target − natural)/n, plus the ink-grown cell the paint draws, still sums to
+  // the fitText target (measure == paint); 0 for non-under-reporting runs.
   resolveFitTextSegments(
     queue.filter((seg): seg is LayoutTextSeg => 'text' in seg),
     scale,
-    (segment) => measureText(segment).width,
+    (segment) => measureText(segment).width + verticalInkExtra(segment, segment.text),
   );
 
   // The segment's laid-out ADVANCE (= its measuredWidth): natural width plus the
@@ -2856,8 +2891,10 @@ export function layoutLines(
   // tab measurement uses it so line wrapping packs the grid's char count and the
   // box matches what is drawn (measure==paint). `kerning` (§17.3.2.19) is applied
   // via `ctx.fontKerning` inside `withSegKerning`, wrapping the measureText call.
+  // The #1014 vo=Tr ink deficit (`verticalInkExtra`, defined above) is folded into
+  // the natural width so measure == paint on an under-reporting vertical run.
   const segAdvance = (s: LayoutTextSeg): number =>
-    segAdvanceWidth(s, measureText(s).width, gridDeltaPx, scale);
+    segAdvanceWidth(s, measureText(s).width + verticalInkExtra(s, s.text), gridDeltaPx, scale);
   // Grid advance of an arbitrary substring under a segment's font (for split
   // prefixes/tails). Selects the font (and the run's kerning state), then applies
   // the same width model as a whole segment BUT with the substring's own
@@ -2868,7 +2905,7 @@ export function layoutLines(
     const prevKern = setSegKerning(s);
     const natural = ctx.measureText(text).width;
     restoreKerning(prevKern);
-    return segAdvanceWidth({ ...s, text }, natural, gridDeltaPx, scale);
+    return segAdvanceWidth({ ...s, text }, natural + verticalInkExtra(s, text), gridDeltaPx, scale);
   };
 
   // Width of a queued segment, for right/center tab look-ahead.
@@ -2988,7 +3025,8 @@ export function layoutLines(
               addToLine(q, q.measuredWidth || 0, q.fontSize, q.mathAscent || 0, q.mathDescent || 0);
             } else {
               const m = measureText(q);
-              const w = segAdvanceWidth(q, m.width, gridDeltaPx, scale);
+              // #1014 — fold the vo=Tr ink deficit into the committed advance too.
+              const w = segAdvanceWidth(q, m.width + verticalInkExtra(q, q.text), gridDeltaPx, scale);
               q.measuredWidth = w;
               const asc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? q.fontSize * scale * 0.8;
               const desc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? q.fontSize * scale * 0.2;
@@ -3041,7 +3079,8 @@ export function layoutLines(
             addToLine(q, q.measuredWidth || 0, q.fontSize, q.mathAscent || 0, q.mathDescent || 0);
           } else {
             const m = measureText(q);
-            const w = segAdvanceWidth(q, m.width, gridDeltaPx, scale);
+            // #1014 — fold the vo=Tr ink deficit into the committed advance too.
+            const w = segAdvanceWidth(q, m.width + verticalInkExtra(q, q.text), gridDeltaPx, scale);
             q.measuredWidth = w;
             const asc = m.fontBoundingBoxAscent ?? m.actualBoundingBoxAscent ?? q.fontSize * scale * 0.8;
             const desc = m.fontBoundingBoxDescent ?? m.actualBoundingBoxDescent ?? q.fontSize * scale * 0.2;
@@ -3134,7 +3173,11 @@ export function layoutLines(
     const m = measureText(s);
     // Advance = natural width + character-grid delta (the SINGLE model shared
     // with the draw paths; 0 unless an active grid AND a pure-EA segment).
-    const w = segAdvanceWidth(s, m.width, gridDeltaPx, scale);
+    // #1014 — plus the vo=Tr rotate-fallback ink deficit for a vertical run, so
+    // this MAIN commit path (the segment's stored measuredWidth and the pen advance
+    // to the next segment) matches the ink-sized cell `drawVerticalRun` paints
+    // (measure == paint); 0 for horizontal / non-under-reporting runs.
+    const w = segAdvanceWidth(s, m.width + verticalInkExtra(s, s.text), gridDeltaPx, scale);
     // Line-height tracks the un-scaled pt font so super/sub don't shrink the line.
     const h = s.fontSize;
     // Prefer font-metric ascent/descent (stable per font+size) so baselines and
@@ -3406,7 +3449,7 @@ export function layoutLines(
       //  binary-search + the cross-run 追い出し below. Don't naively unify them.)
       const available = availW() - currentWidth;
       ctx.font = buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses);
-      const rawPrefix = available > 0 ? fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), charScaleFactor(s), charSpacingDeltaPx(s, scale)) : '';
+      const rawPrefix = available > 0 ? fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), charScaleFactor(s), charSpacingDeltaPx(s, scale), s.verticalRun === true) : '';
       // Apply kinsoku to the break position: retract leftwards so the tail
       // never begins with a 行頭禁則 char and the head never ends with a
       // 行末禁則 char (ECMA-376 §17.15.1.58–.60). When the current line
@@ -3620,7 +3663,7 @@ export function layoutLines(
       const available = availW();
       ctx.font = buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses);
       const allChars = [...s.text];
-      let split = available > 0 ? [...fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), charScaleFactor(s), charSpacingDeltaPx(s, scale))].length : 0;
+      let split = available > 0 ? [...fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), charScaleFactor(s), charSpacingDeltaPx(s, scale), s.verticalRun === true)].length : 0;
       if (split < 1) split = 1;
       split = extendThroughTrailingIdeographicSpaces(allChars, split);
       if (split >= allChars.length) {
@@ -3709,7 +3752,11 @@ export function rescaleLayoutLines(
     const effPx = calcEffectiveFontPx(s, scale);
     ctx.font = buildFont(s.bold, s.italic, effPx, s.fontFamily, fontFamilyClasses);
     const m = ctx.measureText(s.text);
-    const advance = segAdvanceWidth(s, m.width, gridDeltaPx, scale);
+    // #1014 — fold in the vo=Tr rotate-fallback ink-extent deficit for a vertical
+    // run so the rescaled box matches the ink-sized cell (measure == draw); 0 on
+    // horizontal pages and non-under-reporting fonts. `ctx.font` is set above.
+    const natural = m.width + (s.verticalRun ? verticalRunInkExtraPx(ctx, s.text) : 0);
+    const advance = segAdvanceWidth(s, natural, gridDeltaPx, scale);
     // §17.3.2.33 — a small-caps run's LINE BOX follows the FULL run size (measure
     // the box at fullPx, not the 2pt-reduced glyphs); super/subscript keeps its
     // shrunk contribution. Mirrors layoutLines' fullPx / metricEmPx split.
@@ -3749,7 +3796,12 @@ export function rescaleLayoutLines(
       (segment) => {
         const effPx = calcEffectiveFontPx(segment, scale);
         ctx.font = buildFont(segment.bold, segment.italic, effPx, segment.fontFamily, fontFamilyClasses);
-        return ctx.measureText(segment.text).width;
+        // #1014 — include the vo=Tr ink deficit so the rescaled fitText gap stays
+        // measure==paint against the ink-grown cell; 0 for non-under-reporting runs.
+        return (
+          ctx.measureText(segment.text).width +
+          (segment.verticalRun ? verticalRunInkExtraPx(ctx, segment.text) : 0)
+        );
       },
     );
     const segments = scaledSource.map((s) => {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -9160,6 +9160,9 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             effSizePx,
             segLetterSpacingPx(s, drawGridDeltaPx, scale),
             segCharScale,
+            // #1014 — grow a vo=Tr rotate mark's cell to its ink ONLY when the layout
+            // advance was grown by the same deficit (`s.verticalRun`), so paint==measure.
+            s.verticalRun === true,
           );
         } else if (s.fitTextPerGapPx !== undefined) {
           // ECMA-376 §17.3.2.14 Manual Run Width. Same draw model as the
@@ -11348,6 +11351,12 @@ export function renderShapeText(
               effSizePx,
               segLetterSpacingPx(s, 0, scale),
               s.charScale ?? 1,
+              // #1014 — couple the ink-grow to the measure exactly as the body path:
+              // `s.verticalRun` is unset here (the eaVert text box builds segments with
+              // a non-tbRl-page `verticalCJK`), so paint stays advance-sized and matches
+              // its (un-grown) measured advance. A follow-up that wires the text box's
+              // vertical measure would flip this on automatically.
+              s.verticalRun === true,
             );
             // ECMA-376 §17.3.3.25 ruby (furigana) on a vertical text-box run. Word
             // sets the annotation on the RIGHT side of the vertical base column

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -9,6 +9,7 @@ import {
   drawUprightBox,
   physicalToLogicalAnchorBox,
   verticalTextLayerPlacement,
+  verticalRunInkExtraPx,
 } from './vertical-text.js';
 
 // ECMA-376 §17.6.20 vertical writing (tbRl). These are the pure classification
@@ -129,6 +130,14 @@ interface MockMetrics {
   fontBoundingBoxDescent?: number;
   // Per-glyph tight ink extent under a `middle` textBaseline, by draw glyph.
   inkMiddle?: Record<string, { asc: number; desc: number }>;
+  // Per-glyph HORIZONTAL tight ink bounds relative to the advance CENTRE (the
+  // values a `textAlign='center'` measureText reports as
+  // actualBoundingBoxLeft/Right), by glyph. Used by the vo=Tr rotate-fallback
+  // ink-overrun path (#1014): after the +90° page rotation the glyph's HORIZONTAL
+  // ink maps onto the along-column axis, so left+right is the along-column ink
+  // extent. Returned regardless of the current textAlign (the values are already
+  // centre-relative).
+  inkLR?: Record<string, { left: number; right: number }>;
 }
 
 function mockCtx(metrics: MockMetrics = {}): { ctx: any; ops: Op[] } {
@@ -163,6 +172,11 @@ function mockCtx(metrics: MockMetrics = {}): { ctx: any; ops: Op[] } {
       if (ink && this.textBaseline === 'middle') {
         m.actualBoundingBoxAscent = ink.asc;
         m.actualBoundingBoxDescent = ink.desc;
+      }
+      const lr = metrics.inkLR?.[s];
+      if (lr) {
+        m.actualBoundingBoxLeft = lr.left;
+        m.actualBoundingBoxRight = lr.right;
       }
       return m;
     },
@@ -377,6 +391,88 @@ describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin side
     expect(rotates).toHaveLength(2);
     expect(fills.every((f) => f.align === 'center' && f.baseline === 'middle')).toBe(true);
     expect(fills.every((f) => f.x === 0 && f.y === 0)).toBe(true);
+  });
+});
+
+// issue #1014 — a vo=Tr rotate-fallback mark (ー, 〜, quotes, colon) whose
+// substitute font UNDER-REPORTS its advance via measureText draws with ink that
+// spills PAST the advance-sized cell into the following sideways run (Chrome).
+// The fix sizes the rotate cell to the along-column INK extent (a NO-OP unless
+// the ink exceeds the advance) and ink-centres the glyph in the grown cell, so
+// the mark stays inside its own cell and the next run clears it. measure==paint:
+// the SAME per-glyph deficit is added to the layout advance via
+// verticalRunInkExtraPx.
+describe('vo=Tr rotate-fallback ink overrun (#1014 — ink-sized cell + ink-centring)', () => {
+  // A `middle`/`center` measureText for ー reports advance 10 (mock: 1 cp × 10)
+  // but a HORIZONTAL ink of left+right = 5+24 = 29 > 10 — the under-report.
+  const underReport = { inkLR: { ー: { left: 5, right: 24 } } };
+
+  it('verticalRunInkExtraPx sums the per-glyph ink deficit over Tr rotate glyphs only', () => {
+    const { ctx } = mockCtx(underReport);
+    // ー: max(0, 29 − 10) = 19. Upright 話 and sideways A/space contribute 0.
+    expect(verticalRunInkExtraPx(ctx, 'ー')).toBeCloseTo(19, 6);
+    expect(verticalRunInkExtraPx(ctx, '話ー')).toBeCloseTo(19, 6);
+    expect(verticalRunInkExtraPx(ctx, '話A ')).toBe(0);
+  });
+
+  it('verticalRunInkExtraPx is 0 when the ink fits the advance (all real fonts) or metrics are absent', () => {
+    const fits = mockCtx({ inkLR: { ー: { left: 3, right: 4 } } }); // extent 7 ≤ 10
+    expect(verticalRunInkExtraPx(fits.ctx, 'ー')).toBe(0);
+    const noMetrics = mockCtx(); // no actualBoundingBox* → graceful 0
+    expect(verticalRunInkExtraPx(noMetrics.ctx, 'ー')).toBe(0);
+  });
+
+  it('grows the ー cell to its ink extent so the FOLLOWING glyph clears the ink', () => {
+    const { ctx, ops } = mockCtx(underReport);
+    // ー (grown cell 29) then upright 話 (advance 10). Without the fix 話 would
+    // centre at 10 + 5 = 15 (inside the ー ink); with the ink-sized cell it
+    // centres at 29 + 5 = 34. `growTrRotateInk=true` = the body path (whose layout
+    // advance was grown by the same deficit — measure==paint).
+    drawVerticalRun(ctx, 'ー話', 0, 0, 12, 0, 1, true);
+    const translates = ops.filter((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
+    // First translate = ー cell centre (29/2 = 14.5); second = 話 cell centre 34.
+    expect(translates[0].x).toBeCloseTo(14.5, 6);
+    expect(translates[1].x).toBeCloseTo(34, 6);
+  });
+
+  it('ink-centres the grown ー (shift by (left − right)/2) so its ink fills the grown cell', () => {
+    const { ctx, ops } = mockCtx(underReport);
+    drawVerticalRun(ctx, 'ー', 0, 0, 12, 0, 1, true);
+    // Mirror path (ー reflects): translate to cell centre 14.5, scale(1,-1), then a
+    // center/middle fillText shifted by (5 − 24)/2 = −9.5 so the ink centres on the
+    // cell. Ink then spans [14.5 − 9.5 − 5, 14.5 − 9.5 + 24] = [0, 29] = the cell.
+    const translate = ops.find((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
+    expect(translate?.x).toBeCloseTo(14.5, 6);
+    const scale = ops.find((o): o is Extract<Op, { op: 'scale' }> => o.op === 'scale');
+    expect(scale).toEqual({ op: 'scale', sx: 1, sy: -1 });
+    const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fill).toMatchObject({ text: 'ー', y: 0, align: 'center', baseline: 'middle' });
+    expect(fill?.x).toBeCloseTo(-9.5, 6);
+  });
+
+  it('is a NO-OP (byte-identical) when the ink fits the advance — no growth, no shift', () => {
+    // extent 7 ≤ advance 10 → the ー draws exactly as today even with grow enabled:
+    // cell 10, centre 5, mirror scale(1,-1), fillText at the local origin.
+    const { ctx, ops } = mockCtx({ inkLR: { ー: { left: 3, right: 4 } } });
+    drawVerticalRun(ctx, 'ー', 100, 200, 12, 0, 1, true);
+    const translate = ops.find((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
+    expect(translate).toEqual({ op: 'translate', x: 105, y: 200 });
+    const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fill).toMatchObject({ text: 'ー', x: 0, y: 0 });
+  });
+
+  it('does NOT grow when growTrRotateInk is false (marker / unwired text box) — paint stays coupled to the measure', () => {
+    // The same under-reporting ー, but growTrRotateInk defaults to false: the cell
+    // stays advance-sized (10) and advance-centred (cx=5), byte-identical to the
+    // pre-#1014 draw. Callers whose LAYOUT advance was NOT grown (no s.verticalRun —
+    // list markers, eaVert text boxes) pass false so paint never exceeds measure.
+    const { ctx, ops } = mockCtx(underReport);
+    drawVerticalRun(ctx, 'ー話', 0, 0, 12, 0); // 7 args → growTrRotateInk = false
+    const translates = ops.filter((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
+    expect(translates[0].x).toBeCloseTo(5, 6);  // ー cell centre at advance/2, NOT ink/2
+    expect(translates[1].x).toBeCloseTo(15, 6); // 話 at 10 + 5, NOT 29 + 5
+    const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fill?.x).toBe(0); // no ink-centre shift
   });
 });
 

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -249,6 +249,98 @@ function inkCenterAboveMiddlePx(ctx: Ctx2D, drawStr: string): number {
 }
 
 /**
+ * True for a vo=Tr code point that takes the GEOMETRIC ROTATE fallback in
+ * {@link drawVerticalRun} — i.e. `mode==='rotate'` with NO substituted vertical
+ * bracket form and NOT the upright-fallback semicolon. These are the marks drawn
+ * by a plain (optionally reflected) `fillText` in the +90° page frame: ー 〜 ～,
+ * the quotes “”, and the colon ：. This is the SINGLE predicate shared by the
+ * paint path and the {@link verticalRunInkExtraPx} measure path (issue #1014), so
+ * the two agree on which glyphs get the ink-sized cell.
+ *
+ * @param cp A Unicode scalar value.
+ */
+function isVerticalRotateFallback(cp: number): boolean {
+  return (
+    verticalDrawMode(cp) === 'rotate' &&
+    verticalBracketFormSubstitute(cp) === null &&
+    !verticalTrUprightFallback(cp)
+  );
+}
+
+/**
+ * Along-column ink geometry of a vo=Tr rotate-fallback glyph (issue #1014). The
+ * glyph is painted by a plain `fillText` in the +90°-rotated page frame, so its
+ * HORIZONTAL ink extent maps onto the ALONG-COLUMN axis (the advance axis). Read
+ * the tight horizontal ink box with a `center`/`middle` alignment:
+ *   - `extentPx` = actualBoundingBoxLeft + actualBoundingBoxRight — the ink width
+ *     along the column (used to size the cell so the ink cannot spill past it).
+ *   - `shiftPx`  = (actualBoundingBoxLeft − actualBoundingBoxRight)/2 — the local
+ *     along-column shift that re-centres the ink on the (grown) cell, since a
+ *     `center` draw centres the glyph's ADVANCE and an under-reported advance is
+ *     off-centre from the ink.
+ * Returns `null` when the Canvas does not report `actualBoundingBox*` (older
+ * engines / node mocks) so callers degrade to the advance-sized, advance-centred
+ * draw exactly as before this metric existed.
+ */
+function verticalRotateInkGeometry(
+  ctx: Ctx2D,
+  ch: string,
+): { extentPx: number; shiftPx: number } | null {
+  const prevAlign = ctx.textAlign;
+  const prevBaseline = ctx.textBaseline;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  const m = ctx.measureText(ch);
+  ctx.textAlign = prevAlign;
+  ctx.textBaseline = prevBaseline;
+  const l = m.actualBoundingBoxLeft;
+  const r = m.actualBoundingBoxRight;
+  if (
+    typeof l !== 'number' ||
+    typeof r !== 'number' ||
+    !Number.isFinite(l) ||
+    !Number.isFinite(r)
+  ) {
+    return null;
+  }
+  return { extentPx: l + r, shiftPx: (l - r) / 2 };
+}
+
+/**
+ * ECMA-376 §17.6.20 (tbRl) + issue #1014 — the EXTRA along-column advance (px, at
+ * the run's current font, BEFORE the §17.3.2.43 `w:w` scale and §17.3.2.35 pitch)
+ * that a vertical run needs so its vo=Tr rotate-fallback glyphs' INK fits inside
+ * their cells. For each rotate-fallback glyph whose along-column ink extent
+ * exceeds its `measureText` advance (a substitute font UNDER-REPORTING the
+ * advance — Chrome-only; skia and normal fonts report ink ≤ advance), this adds
+ * the deficit `max(0, inkExtent − advance)`. The layout folds this into the
+ * segment's natural advance (`segAdvanceWidth`'s `naturalWidthPx`) so the grown
+ * cell {@link drawVerticalRun} paints is matched by the measured box — measure ==
+ * paint (wrapping, the next run's position, and the selection overlay all track
+ * the drawn cell). Returns 0 for a run with no such glyph, for every font that
+ * does not under-report (the common path — byte-identical), and when ink metrics
+ * are unavailable.
+ *
+ * The caller must set `ctx.font` (and any kerning state) for the run before
+ * calling, exactly as it does for the `measureText` that produces `naturalWidthPx`.
+ *
+ * @param ctx  2D context with the run's font selected.
+ * @param text The run's text.
+ */
+export function verticalRunInkExtraPx(ctx: Ctx2D, text: string): number {
+  let extra = 0;
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) ?? 0;
+    if (!isVerticalRotateFallback(cp)) continue;
+    const geom = verticalRotateInkGeometry(ctx, ch);
+    if (geom === null) continue;
+    const advance = ctx.measureText(ch).width;
+    if (geom.extentPx > advance) extra += geom.extentPx - advance;
+  }
+  return extra;
+}
+
+/**
  * Draw one run's glyphs in vertical mode. The context is assumed to already be
  * in the page's SWAPPED logical frame (the +90° page rotation is installed by
  * `renderDocumentToCanvas`), so an ordinary `fillText` advances DOWN the line.
@@ -271,6 +363,16 @@ function inkCenterAboveMiddlePx(ctx: Ctx2D, drawStr: string): number {
  *                         delta + §17.3.2.35 `w:spacing` pitch (the layout's
  *                         `segLetterSpacingPx`); 0 for the common path.
  * @param charScale        ECMA-376 §17.3.2.43 `w:w` fraction; 1 by default.
+ * @param growTrRotateInk  issue #1014 — when true, a vo=Tr GEOMETRIC rotate-fallback
+ *                         glyph (ー 〜 ～ “” ：) whose substitute font under-reports
+ *                         its advance is sized to its along-column INK extent (and
+ *                         ink-centred) so its ink cannot spill past the cell into the
+ *                         next run. MUST be set ONLY where the layout advance was
+ *                         grown by the SAME deficit ({@link verticalRunInkExtraPx},
+ *                         gated on `LayoutTextSeg.verticalRun`) so paint == measure;
+ *                         the caller passes `s.verticalRun === true`. Default false
+ *                         keeps the advance-sized, advance-centred draw byte-identical
+ *                         (markers and unwired vertical text boxes).
  */
 export function drawVerticalRun(
   ctx: Ctx2D,
@@ -280,6 +382,7 @@ export function drawVerticalRun(
   fontPx: number,
   letterSpacingPx: number,
   charScale = 1,
+  growTrRotateInk = false,
 ): void {
   const prevAlign = ctx.textAlign;
   const prevBaseline = ctx.textBaseline;
@@ -301,9 +404,6 @@ export function drawVerticalRun(
   for (const ch of text) {
     const cp = ch.codePointAt(0) ?? 0;
     const mode = verticalDrawMode(cp);
-    // Advance/width uses the ORIGINAL code point (measure == draw, and the text
-    // model / selection / find keep the original character — see the module doc).
-    const adv = ctx.measureText(ch).width * charScale + letterSpacingPx;
     // A vo=Tr code point with a substituted Unicode vertical presentation form — the
     // brackets （）「」〈〉… and the white lenticular 〖〗 (#969) — is SUBSTITUTED and
     // drawn upright, exactly like the upright cells — UAX#50 §5 Tr means "substitute a
@@ -319,6 +419,27 @@ export function drawVerticalRun(
     // like the vo=U / vo=Tu cells; the colon ：is NOT here (its FE13 form IS a 90°
     // rotation, so it takes the rotate branch below → side-by-side dots).
     const uprightFallback = mode === 'rotate' && bracketCp === null && verticalTrUprightFallback(cp);
+    // Advance/width uses the ORIGINAL code point (measure == draw, and the text
+    // model / selection / find keep the original character — see the module doc).
+    // #1014: a vo=Tr GEOMETRIC rotate-fallback glyph (ー 〜 ～ “” ：) is painted by a
+    // plain `fillText` in the +90° page frame, so its HORIZONTAL ink maps onto the
+    // along-column (advance) axis. When a substitute font UNDER-REPORTS the advance
+    // (Chrome), that ink spills PAST the advance-sized cell into the next run. Size
+    // the cell to the along-column INK extent instead so the ink is contained; the
+    // SAME per-glyph deficit is folded into the layout advance by
+    // `verticalRunInkExtraPx` (measure == draw). NO-OP unless the ink exceeds the
+    // advance (every real font here reports ink ≤ advance ⇒ byte-identical), and only
+    // for the geometric rotate branch (substituted/upright Tr glyphs keep their path).
+    let cellNaturalPx = ctx.measureText(ch).width;
+    let rotateInkShiftPx = 0;
+    if (growTrRotateInk && mode === 'rotate' && bracketCp === null && !uprightFallback) {
+      const geom = verticalRotateInkGeometry(ctx, ch);
+      if (geom !== null && geom.extentPx > cellNaturalPx) {
+        cellNaturalPx = geom.extentPx;
+        rotateInkShiftPx = geom.shiftPx;
+      }
+    }
+    const adv = cellNaturalPx * charScale + letterSpacingPx;
     if (mode === 'upright' || bracketCp !== null || uprightFallback) {
       // vo=U / Tu, or a substituted Tr bracket. Counter-rotate −90° about the
       // cell centre so the glyph (which the page rotation would otherwise lay on
@@ -398,14 +519,20 @@ export function drawVerticalRun(
       const mirror = verticalTrMirrorFallback(cp);
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      if (mirror || scaled) {
+      // #1014: `rotateInkShiftPx` (glyph-space, non-zero ONLY when the cell was grown
+      // to the ink extent above) re-centres the ink on the grown cell — a `center`
+      // draw centres the glyph's ADVANCE, and an under-reported advance is off-centre
+      // from the ink. It rides the local frame so it composes with the §17.3.2.43
+      // `w:w` scale and the reflection; 0 (the common path) leaves today's advance-
+      // centred draw byte-identical.
+      if (mirror || scaled || rotateInkShiftPx !== 0) {
         ctx.save();
         ctx.translate(cx, baseline);
         // `scale(1, -1)` is the on-screen horizontal mirror in the +90° page frame
         // (screen −x ↔ page-frame +y); combine with the §17.3.2.43 `w:w` width
         // compression on the line axis. Non-mirror glyphs keep sy=+1.
         ctx.scale(charScale, mirror ? -1 : 1);
-        ctx.fillText(ch, 0, 0);
+        ctx.fillText(ch, rotateInkShiftPx, 0);
         ctx.restore();
       } else {
         ctx.fillText(ch, cx, baseline);

--- a/packages/node/src/docx-vertical-tr-ink-overlap.probe.test.ts
+++ b/packages/node/src/docx-vertical-tr-ink-overlap.probe.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Browser (Chromium) regression for issue #1014 — a vo=Tr rotate-fallback mark
+ * (ー prolonged sound mark) whose SUBSTITUTE font under-reports its advance via
+ * `measureText` draws ink that overruns its advance-sized cell and overlaps the
+ * following sideways run. Reproduces in Chrome but NOT in headless skia (skia
+ * reports a full-em advance for ー), so the skia/Chrome parity gap is itself part
+ * of the bug and the guard must run in a real Chromium — via Playwright here.
+ *
+ * No installed font on a dev host under-reports ー (every one reports advance ≥
+ * ink), so the trigger is a MINIMAL synthetic font (FONT_B64 below): U+30FC has
+ * an hmtx advance of 500 units (0.5em) but a glyf outline spanning x∈[40,960]
+ * (~0.96em) — exactly the "advance under-reports the ink" condition the issue
+ * names. The Latin letters of "controls" advance 560 with ink inside, and 話 is a
+ * full-em kanji, so the run geometry mirrors the reported "…ー controls" case.
+ *
+ * The test drives the REAL packages/docx `drawVerticalRun` and
+ * `verticalRunInkExtraPx` (esbuild-bundled to browser ESM) inside the +90° page
+ * frame the renderer installs, and asserts:
+ *   1. the synthetic font really under-reports (measureText advance < ink extent);
+ *   2. single run: the ー ink is sized into its own (ink-extent) cell and does NOT
+ *      overlap the following sideways Latin run;
+ *   3. two segments (measure==paint): when the next segment is positioned by the
+ *      MEASURED advance — which folds in `verticalRunInkExtraPx` — the marks clear,
+ *      and WITHOUT that extra they would still overlap (the fix is load-bearing).
+ *
+ * Gated on Playwright Chromium being present; skips cleanly otherwise.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../../..');
+const verticalTextEntry = resolve(repoRoot, 'packages/docx/src/vertical-text.ts');
+
+// Synthetic under-reporting font (family "IQ1014Test"). See the file header.
+const FONT_B64 = 'AAEAAAAKAIAAAwAgT1MvMkUA1kYAAAEoAAAAYGNtYXAyioyWAAABtAAAAG5nbHlmh2Y1lwAAAjwAAADqaGVhZC/wfuYAAACsAAAANmhoZWEHCwFgAAAA5AAAACRobXR4GEwCHAAAAYgAAAAsbG9jYQEEAUUAAAIkAAAAGG1heHAADQAGAAABCAAAACBuYW1lu6hWtwAAAygAAAC3cG9zdIcOa74AAAPgAAAAgAABAAAAAQAAgZbZ8F8PPPUAAwPoAAAAAOZ5HXMAAAAA5nkdcwAoAAADwAMgAAAAAwACAAAAAAAAAAEAAAMg/zgAAAPoACj+NAPAAAEAAAAAAAAAAAAAAAAAAAALAAEAAAALAAQAAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAwI1AZAABQAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCAQAAAAAAAAAAAAAPz8/PwAAACCKcQMg/zgAAAMgAMgAAAAAAAAAAAAAAAAAAAAgAAAB9AAAASwAAAH0ACgCMAA8AjAAPAIwADwCMAA8AjAAPAIwADwCMAA8A+gAUAAAAAIAAAADAAAAFAADAAEAAAAUAAQAWgAAABAAEAADAAAAIABjAGwAbwB0MPyKcf//AAAAIABjAGwAbgByMPyKcf///+H/oP+cAAAAAM8GdZkAAQAAAAAAAAAKAAwAAAAAAAAABQAEAAcACQAGAAAAAAAAAAAADQAaACcANABBAE4AWwBoAHUAAQAoAbgDwAIIAAMAABMhNSEoA5j8aAG4UAABADwAAAH0ArwAAwAAMyERITwBuP5IArwAAAEAPAAAAfQCvAADAAAzIREhPAG4/kgCvAAAAQA8AAAB9AK8AAMAADMhESE8Abj+SAK8AAABADwAAAH0ArwAAwAAMyERITwBuP5IArwAAAEAPAAAAfQCvAADAAAzIREhPAG4/kgCvAAAAQA8AAAB9AK8AAMAADMhESE8Abj+SAK8AAABADwAAAH0ArwAAwAAMyERITwBuP5IArwAAAEAUAAAA5gDIAADAAAzIREhUANI/LgDIAAAAAAAAAYATgABAAAAAAABAAoAAAABAAAAAAACAAcACgABAAAAAAAGABIAEQADAAEECQABABQAIwADAAEECQACAA4ANwADAAEECQAGACQARUlRMTAxNFRlc3RSZWd1bGFySVExMDE0VGVzdC1SZWd1bGFyAEkAUQAxADAAMQA0AFQAZQBzAHQAUgBlAGcAdQBsAGEAcgBJAFEAMQAwADEANABUAGUAcwB0AC0AUgBlAGcAdQBsAGEAcgAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALAAAAAwECAQMBBAEFAQYBBwEIAQkBCglwcm9sb25nZWQHbGF0aW5fYwdsYXRpbl9vB2xhdGluX24HbGF0aW5fdAdsYXRpbl9yB2xhdGluX2wHbGF0aW5fcwVrYW5qaQ==';
+
+// `playwright` and `esbuild` are ROOT devDependencies (used only by this optional,
+// Chromium-gated probe), NOT declared deps of @silurus/ooxml-node, so a static
+// import specifier trips `tsc --noEmit` with TS2307 in the per-package typecheck.
+// Import them through a runtime variable specifier: TS then types the result as
+// `Promise<any>` and does not resolve the path, while Node resolves the real module
+// at runtime (from the hoisted root node_modules). The suite skips when absent.
+const PLAYWRIGHT = 'playwright';
+const ESBUILD = 'esbuild';
+
+/** Resolve Playwright chromium; return null (→ skip) when it or its browser is absent. */
+async function loadChromium(): Promise<Any | null> {
+  try {
+    const pw = (await import(PLAYWRIGHT)) as Any;
+    const exe = pw.chromium?.executablePath?.();
+    if (typeof exe === 'string' && existsSync(exe)) return pw.chromium;
+  } catch {
+    /* playwright not installed */
+  }
+  return null;
+}
+
+/** esbuild-bundle the real drawVerticalRun + verticalRunInkExtraPx into a browser
+ *  IIFE that assigns the module's exports to `window.__vt` (a classic <script>, so
+ *  no dynamic `import()` — which vitest's SSR transform would rewrite). */
+async function bundleVerticalText(): Promise<string> {
+  const esbuild = (await import(ESBUILD)) as Any;
+  const out = await esbuild.build({
+    entryPoints: [verticalTextEntry],
+    bundle: true,
+    format: 'iife',
+    globalName: '__vt',
+    platform: 'browser',
+    target: 'es2020',
+    write: false,
+    absWorkingDir: repoRoot,
+  });
+  return out.outputFiles[0].text as string;
+}
+
+const chromium = await loadChromium();
+
+describe.skipIf(!chromium)('docx vertical Tr rotate-fallback ink overrun (#1014, Chromium)', () => {
+  const fontPx = 100;
+  let browser: Any;
+  let page: Any;
+
+  beforeAll(async () => {
+    const bundle = await bundleVerticalText();
+    browser = await chromium.launch();
+    page = await browser.newPage();
+    await page.setContent('<!doctype html><canvas id="c" width="600" height="1400"></canvas>');
+    await page.evaluate(async (b64: string) => {
+      const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+      const ff = new (window as Any).FontFace('IQ1014Test', bytes.buffer);
+      await ff.load();
+      (document as Any).fonts.add(ff);
+    }, FONT_B64);
+    // Classic script — the IIFE assigns the exports to `window.__vt`.
+    await page.addScriptTag({ content: bundle });
+  }, 60_000);
+
+  afterAll(async () => {
+    await browser?.close();
+  });
+
+  it('the synthetic font under-reports the ー advance (the Chrome-only trigger)', async () => {
+    const m = await page.evaluate((px: number) => {
+      const ctx = (document.getElementById('c') as HTMLCanvasElement).getContext('2d')!;
+      ctx.font = px + 'px IQ1014Test';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      const tm = ctx.measureText('ー');
+      return {
+        advance: tm.width,
+        inkExtent: tm.actualBoundingBoxLeft + tm.actualBoundingBoxRight,
+      };
+    }, fontPx);
+    // The along-column ink extent (left+right) exceeds the advance — the report's
+    // under-report. A real font gives ink ≤ advance, making the fix a no-op there.
+    expect(m.inkExtent).toBeGreaterThan(m.advance);
+    expect(m.advance).toBeCloseTo(fontPx * 0.5, 0);
+  });
+
+  it('single run: the ー ink stays in its ink-sized cell and does not overlap the next sideways run', async () => {
+    const r = await page.evaluate((px: number) => {
+      const W = 600, H = 1400, logX = 60, baseline = 300;
+      const { drawVerticalRun } = (window as Any).__vt;
+      const render = (text: string) => {
+        const cv = document.createElement('canvas'); cv.width = W; cv.height = H;
+        const ctx = cv.getContext('2d')!;
+        ctx.fillStyle = '#fff'; ctx.fillRect(0, 0, W, H);
+        ctx.fillStyle = '#000'; ctx.font = px + 'px IQ1014Test';
+        ctx.save(); ctx.translate(W, 0); ctx.rotate(Math.PI / 2);
+        drawVerticalRun(ctx, text, logX, baseline, px, 0, 1, true);
+        ctx.restore();
+        return ctx.getImageData(0, 0, W, H).data;
+      };
+      const dark = (d: Uint8ClampedArray, i: number) =>
+        0.299 * d[i] + 0.587 * d[i + 1] + 0.114 * d[i + 2] < 128;
+      // Physical-y range of ink present in `more` but not `base` (isolates the extra glyphs).
+      const diffY = (base: Uint8ClampedArray, more: Uint8ClampedArray) => {
+        let y0 = H, y1 = -1;
+        for (let y = 0; y < H; y++) for (let x = 0; x < W; x++) {
+          const i = (y * W + x) * 4;
+          if (dark(more, i) && !dark(base, i)) { if (y < y0) y0 = y; if (y > y1) y1 = y; break; }
+        }
+        return { y0, y1 };
+      };
+      const dashInk = diffY(render('話'), render('話ー'));                 // ー's along-column ink
+      const controlsInk = diffY(render('話ー '), render('話ー controls')); // controls' ink (c first)
+      return { dashMaxY: dashInk.y1, controlsMinY: controlsInk.y0 };
+    }, fontPx);
+    // The ー ink must end (max physical-y) strictly BEFORE the following run's ink begins.
+    expect(r.dashMaxY).toBeLessThan(r.controlsMinY);
+  });
+
+  it('two segments (measure==paint): the next segment positioned by the measured advance clears the ー ink', async () => {
+    const r = await page.evaluate((px: number) => {
+      const W = 600, H = 1400, logX = 60, baseline = 300;
+      const { drawVerticalRun, verticalRunInkExtraPx } = (window as Any).__vt;
+      const ctx0 = (document.getElementById('c') as HTMLCanvasElement).getContext('2d')!;
+      ctx0.font = px + 'px IQ1014Test';
+      const seg1 = '話ー';
+      const extra = verticalRunInkExtraPx(ctx0, seg1);
+      const seg1NaturalW = ctx0.measureText(seg1).width; // whole-string advance (under-reports)
+      const seg2OriginNoFix = logX + seg1NaturalW;        // where controls would start WITHOUT the fix
+      const seg2Origin = logX + seg1NaturalW + extra;     // WITH the fix (measure folds in the deficit)
+
+      const render = (draw: (ctx: CanvasRenderingContext2D) => void) => {
+        const cv = document.createElement('canvas'); cv.width = W; cv.height = H;
+        const ctx = cv.getContext('2d')!;
+        ctx.fillStyle = '#fff'; ctx.fillRect(0, 0, W, H);
+        ctx.fillStyle = '#000'; ctx.font = px + 'px IQ1014Test';
+        ctx.save(); ctx.translate(W, 0); ctx.rotate(Math.PI / 2); draw(ctx); ctx.restore();
+        return ctx.getImageData(0, 0, W, H).data;
+      };
+      const dark = (d: Uint8ClampedArray, i: number) =>
+        0.299 * d[i] + 0.587 * d[i + 1] + 0.114 * d[i + 2] < 128;
+      const maxDarkY = (d: Uint8ClampedArray) => {
+        let y1 = -1;
+        for (let y = 0; y < H; y++) for (let x = 0; x < W; x++) { if (dark(d, (y * W + x) * 4)) { if (y > y1) y1 = y; break; } }
+        return y1;
+      };
+      const minDarkY = (d: Uint8ClampedArray) => {
+        for (let y = 0; y < H; y++) for (let x = 0; x < W; x++) { if (dark(d, (y * W + x) * 4)) return y; }
+        return H;
+      };
+
+      const dashMaxY = maxDarkY(render((ctx) => drawVerticalRun(ctx, seg1, logX, baseline, px, 0, 1, true)));
+      const controlsMinYFix = minDarkY(render((ctx) => drawVerticalRun(ctx, 'controls', seg2Origin, baseline, px, 0, 1, true)));
+      const controlsMinYNoFix = minDarkY(render((ctx) => drawVerticalRun(ctx, 'controls', seg2OriginNoFix, baseline, px, 0, 1, true)));
+      return { extra, dashMaxY, controlsMinYFix, controlsMinYNoFix };
+    }, fontPx);
+    // The fix folds a positive deficit into the layout advance…
+    expect(r.extra).toBeGreaterThan(0);
+    // …so the second segment's ink clears the ー ink (no overlap)…
+    expect(r.dashMaxY).toBeLessThan(r.controlsMinYFix);
+    // …and WITHOUT that extra the second segment would still be overlapped by the ー
+    // ink (proving the measure-side correction is load-bearing, not cosmetic).
+    expect(r.dashMaxY).toBeGreaterThan(r.controlsMinYNoFix);
+  });
+});


### PR DESCRIPTION
## Problem (#1014)

In a tbRl vertical line, a vo=Tr rotate-fallback mark (`ー` prolonged sound mark; also `〜 ～ “” ：`) whose **substitute font under-reports its advance** via `measureText` draws ink that overruns its advance-sized cell and overlaps the following sideways (Latin) run — e.g. `…「」ー controls…` in sample-47. Reproduces in Chrome but **not** in headless skia (skia reports a full-em advance for `ー`), so the skia/Chrome advance-metric parity gap is itself part of the bug.

## Fix

- Size a vo=Tr **geometric rotate-fallback** glyph's cell to its along-column **ink extent** (`actualBoundingBoxLeft + actualBoundingBoxRight`) and ink-centre it, so the ink cannot spill past the cell.
- Fold the **same per-glyph deficit** (`verticalRunInkExtraPx`) into the layout advance at **every** vertical measure site so the grown cell is matched by the measured box (**measure == paint**): the main segment commit, both tab forced-commit paths, `segAdvance`/`strAdvance`, the `fitText` gap resolver, the CJK-prefix wrap fitter, and `rescaleLayoutLines`.
- Couple paint↔measure via a new `drawVerticalRun` `growTrRotateInk` parameter that every caller passes `s.verticalRun === true` (stamped in `buildSegments` from `environment.verticalCJK`); list markers and unwired eaVert text boxes pass the default `false` and stay byte-identical.

The correction is a **no-op for every font that reports `ink ≤ advance`** (all real/skia fonts), so the change is byte-identical on real fonts and engages only for a genuinely under-reporting substitute font.

## Verification

- **Real-Chromium regression probe** (`packages/node/src/docx-vertical-tr-ink-overlap.probe.test.ts`) driving the actual `drawVerticalRun` + `verticalRunInkExtraPx` with a minimal synthetic under-reporting font (U+30FC advance 0.5em / ink ~0.96em): single-run **and** two-segment (measure==paint) overlap resolved; without the measure deficit it still overlaps (the correction is load-bearing).
- **Mock-ctx unit tests** for the cell growth, ink-centring, the no-op-when-`ink ≤ advance` case, the paint/measure coupling, and the measure helper.
- **Byte-identity**: sample-26 + sample-47 `onTextRun` stream hash **unchanged** vs. pristine (via the exact prebuilt-pages viewer path); every vertical draw engages the fix and zero rotate glyphs draw un-grown.
- docx `vitest` 1398 pass · root `typecheck` clean · demo VRT 6 pages within threshold · `ast-grep` 0 errors.

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)
