### PR TITLE
fix(pptx): wrap tab-led lines; continuation re-anchors at text-left (#1006)

### DIFF
--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -4360,6 +4360,76 @@ mod tests {
         );
     }
 
+    /// ECMA-376 §21.1.2.2.7 (`a:pPr@defTabSz`) — the default tab interval used by
+    /// the renderer's wrap-aware tab grid (issue #1006). An explicit value is
+    /// carried through as `def_tab_sz` (EMU); absent yields None (the renderer
+    /// then applies the 1-inch default).
+    #[test]
+    fn test_parse_paragraph_def_tab_sz() {
+        let theme = HashMap::new();
+        let rels = HashMap::new();
+        let bytes = empty_zip_bytes();
+        let cursor = Cursor::new(bytes.clone());
+        let mut zip = zip::ZipArchive::new(cursor).unwrap();
+        let mut parse_para = |p_pr: &str| -> Paragraph {
+            let xml = format!(
+                r#"<txBody xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><p>{p_pr}<r><t>a</t></r></p></txBody>"#
+            );
+            let doc = roxmltree::Document::parse(&xml).unwrap();
+            let mut tb = parse_text_body(
+                doc.root_element(),
+                &theme,
+                &rels,
+                None,
+                [None; 9],
+                Default::default(),
+                &empty_level_bullets(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                ShapeKind::Sp,
+                &mut zip,
+            );
+            tb.paragraphs.remove(0)
+        };
+
+        // Explicit defTabSz="914400" (1 inch) → Some(914400).
+        assert_eq!(
+            parse_para(r#"<pPr algn="l" defTabSz="914400"/>"#).def_tab_sz,
+            Some(914400),
+            "defTabSz=\"914400\" should parse to Some(914400)"
+        );
+        // Absent → None (renderer supplies the 1-inch default).
+        assert_eq!(
+            parse_para("").def_tab_sz,
+            None,
+            "omitted defTabSz should yield None"
+        );
+        // A non-positive value is ignored (treated as absent).
+        assert_eq!(
+            parse_para(r#"<pPr defTabSz="0"/>"#).def_tab_sz,
+            None,
+            "defTabSz=\"0\" should be ignored"
+        );
+        // Serialized under the camelCase key "defTabSz"; omitted when None.
+        let json = serde_json::to_string(&parse_para(r#"<pPr defTabSz="457200"/>"#)).unwrap();
+        assert!(
+            json.contains("\"defTabSz\":457200"),
+            "expected defTabSz:457200 in JSON; got {json}"
+        );
+        let json_absent = serde_json::to_string(&parse_para("")).unwrap();
+        assert!(
+            !json_absent.contains("defTabSz"),
+            "absent defTabSz must be omitted from JSON; got {json_absent}"
+        );
+    }
+
     /// ECMA-376 §21.1.3.13 (`a:tblPr@rtl`): a right-to-left table sets `rtl=true`
     /// so the renderer can place column 0 at the right edge. Absent/false must be
     /// omitted from the serialized JSON (TableElement.rtl is optional in TS).

--- a/packages/pptx/parser/src/smartart_fallback.rs
+++ b/packages/pptx/parser/src/smartart_fallback.rs
@@ -446,6 +446,7 @@ fn default_paragraph() -> Paragraph {
         def_italic: None,
         def_font_family: None,
         tab_stops: Vec::new(),
+        def_tab_sz: None,
         rtl: false,
         ea_ln_brk: true,
         runs: Vec::new(),

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -883,6 +883,16 @@ pub(crate) fn parse_paragraph(
         })
         .unwrap_or_default();
 
+    // §21.1.2.2.7 defTabSz — the paragraph's default tab interval (EMU). When a
+    // `\t` has no reachable explicit stop it snaps to this grid (issue #1006).
+    // Read only from the paragraph's own pPr; a value inherited through
+    // lstStyle/lvlNpPr/layout/master is not resolved here. Acceptable because the
+    // renderer falls back to PowerPoint's universal 1-inch default (914400 EMU) —
+    // the value every real deck's defaultTextStyle carries.
+    let def_tab_sz = p_pr
+        .and_then(|n| attr_i64(&n, "defTabSz"))
+        .filter(|&v| v > 0);
+
     // Paragraph-level default run properties (pPr > defRPr)
     let def_rpr = p_pr.and_then(|n| child(n, "defRPr"));
     let def_font_size = def_rpr.and_then(|n| attr_f64(&n, "sz")).map(|v| v / 100.0);
@@ -1011,6 +1021,7 @@ pub(crate) fn parse_paragraph(
         def_italic,
         def_font_family,
         tab_stops,
+        def_tab_sz,
         rtl,
         ea_ln_brk,
         runs,

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -975,6 +975,13 @@ pub(crate) struct Paragraph {
     pub(crate) def_font_family: Option<String>,
     /// Tab stops from pPr > tabLst
     pub(crate) tab_stops: Vec<TabStop>,
+    /// `<a:pPr defTabSz>` (ECMA-376 §21.1.2.2.7) — default tab interval in EMU.
+    /// A `\t` with no reachable explicit stop advances to the next multiple of
+    /// this grid (issue #1006). None when the paragraph carried no explicit
+    /// value; the renderer then applies PowerPoint's 1-inch (914400 EMU) default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub(crate) def_tab_sz: Option<i64>,
     /// ECMA-376 §21.1.2.2.7 `<a:pPr rtl="1">` — right-to-left paragraph.
     /// When true and no explicit `algn`, the default alignment flips from
     /// "l" to "r". Carried through so the renderer can also flow runs RTL

--- a/packages/pptx/src/pptx-tab-wrap.test.ts
+++ b/packages/pptx/src/pptx-tab-wrap.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'vitest';
+import { renderTextBody } from './renderer.js';
+import type { TextBody, Paragraph } from './types';
+import type { TextRunData, TabStop } from '@silurus/ooxml-core';
+
+// issue #1006 — a tab-led line MUST wrap (PowerPoint wraps tab-led paragraphs in
+// every script and alignment). Adjudicated against the PowerPoint ground-truth
+// PDF (sample-21, 6 slides): a tab is a horizontal pen JUMP to its stop within
+// the visual line where the tab occurs; content overflowing the line's right
+// edge wraps at a normal break opportunity; and every CONTINUATION line
+// re-anchors at the leading text-inset edge (text-left) — identical to a no-tab
+// paragraph. The tab-stop ORIGIN (explicit a:tabLst vs default defTabSz grid)
+// does not change the continuation anchor. Latin and Thai behave identically.
+//
+// Deterministic linear metrics (like pptx-multi-tab.test.ts): every glyph is a
+// fixed `FONT_PX`-wide cell, so "t01" = 60px, a space = 20px. Box widths are
+// chosen so the wrap point PROVES tab-awareness (line 1 fits FEWER tokens than a
+// tab-blind budget would, because the tab jump consumes the leading space).
+
+const FONT_PX = 20;
+const SCALE = 1 / 12700; // emuToPx(emu, SCALE) = emu·SCALE; 1pt → 1px
+const px = (n: number): number => n * 12700; // px → EMU at SCALE
+
+function mockCtx(): {
+  ctx: CanvasRenderingContext2D;
+} {
+  let font = `${FONT_PX}px serif`;
+  let letterSpacing = '0px';
+  let fillStyle = '';
+  let direction: CanvasDirection = 'ltr';
+  const pxOf = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
+  const ctx = {
+    get font() { return font; }, set font(v: string) { font = v; },
+    get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
+    get direction() { return direction; }, set direction(v: CanvasDirection) { direction = v; },
+    get letterSpacing() { return letterSpacing; }, set letterSpacing(v: string) { letterSpacing = v; },
+    measureText: (s: string) => {
+      const p = pxOf();
+      return {
+        width: [...s].length * p,
+        actualBoundingBoxAscent: p * 0.8,
+        actualBoundingBoxDescent: p * 0.2,
+        fontBoundingBoxAscent: p * 0.8,
+        fontBoundingBoxDescent: p * 0.2,
+      } as TextMetrics;
+    },
+    fillText: () => {},
+    strokeText: () => {},
+    fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
+    translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
+    moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
+    setLineDash: () => {}, closePath: () => {}, arc: () => {},
+    strokeStyle: '#000', lineWidth: 1, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D };
+}
+
+function run(text: string): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: FONT_PX, color: '000000', fontFamily: 'Serif',
+  } as TextRunData;
+}
+
+function body(
+  runs: TextRunData[],
+  opts: {
+    tabStops?: TabStop[];
+    defTabSz?: number;
+    rtl?: boolean;
+    algn?: string;
+    marL?: number;
+    indent?: number;
+  } = {},
+): TextBody {
+  const rtl = opts.rtl ?? false;
+  const para: Paragraph = {
+    alignment: opts.algn ?? (rtl ? 'r' : 'l'),
+    marL: opts.marL ?? 0, marR: 0, indent: opts.indent ?? 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null, defBold: null, defItalic: null,
+    defFontFamily: null, tabStops: opts.tabStops ?? [], defTabSz: opts.defTabSz, rtl, runs,
+  } as unknown as Paragraph;
+  return {
+    verticalAnchor: 't', paragraphs: [para], defaultFontSize: FONT_PX,
+    defaultBold: null, defaultItalic: null,
+    lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'square', vert: 'horz', autoFit: 'none',
+  } as unknown as TextBody;
+}
+
+type RunInfo = { text: string; x: number; y: number; w: number };
+
+/** Render and return drawn runs grouped into visual lines (by inShapeY). Each
+ *  line lists its runs left-to-right; `startX` is the first run's inShapeX. */
+function renderLines(tb: TextBody, boxW: number): {
+  runs: RunInfo[];
+  lines: { y: number; startX: number; text: string; runs: RunInfo[] }[];
+} {
+  const { ctx } = mockCtx();
+  const runs: RunInfo[] = [];
+  renderTextBody(
+    ctx, tb, 0, 0, boxW, 400, SCALE,
+    null, 0, false, false, '#000000', undefined,
+    { themeMajorFont: null, themeMinorFont: null, dpr: 1 },
+    (r) => runs.push({ text: r.text, x: r.inShapeX, y: r.inShapeY, w: r.w }),
+  );
+  const byY = new Map<number, RunInfo[]>();
+  for (const r of runs) {
+    const key = Math.round(r.y);
+    (byY.get(key) ?? byY.set(key, []).get(key)!).push(r);
+  }
+  const lines = [...byY.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([y, rs]) => {
+      const sorted = [...rs].sort((a, b) => a.x - b.x);
+      // Consecutive same-format tokens in a cell merge into ONE drawn run, so a
+      // line's text is the concatenation of its runs (e.g. "t01 t02 ").
+      return {
+        y,
+        startX: sorted[0].x,
+        text: sorted.map((r) => r.text).join('').trim(),
+        runs: sorted,
+      };
+    });
+  return { runs, lines };
+}
+
+const LATIN = '\tt01 t02 t03 t04 t05 t06 t07 t08 t09 t10 t11 t12';
+
+describe('issue #1006 — tab-led lines wrap; continuation re-anchors at text-left', () => {
+  it('Latin leading tab wraps (tab-aware budget) and continuation starts at text-left', () => {
+    // Left stop @100. Budget 280. Tab jumps to 100, leaving 180px on line 1:
+    // "t01"(60)+" "(20)+"t02"(60) = 140 fits, +" "(20)=160, "t03" overflows.
+    // A TAB-BLIND budget would fit t01,t02,t03 (60/140/220) — so exactly TWO
+    // content tokens on line 1 proves the jump is charged to the wrap budget.
+    const { lines } = renderLines(
+      body([run(LATIN)], { tabStops: [{ pos: px(100), algn: 'l' }] }),
+      280,
+    );
+    expect(lines.length, 'tab-led paragraph must wrap into multiple lines').toBeGreaterThan(1);
+    // Line 1 begins at the tab stop; holds exactly t01, t02 (a tab-blind budget
+    // of 280 would have fit t01 t02 t03 — proving the jump is charged).
+    expect(lines[0].startX).toBeCloseTo(100, 3);
+    expect(lines[0].text).toBe('t01 t02');
+    // Continuation re-anchors at text-left (x≈0) and leads with t03.
+    expect(lines[1].startX).toBeCloseTo(0, 3);
+    expect(lines[1].text.startsWith('t03')).toBe(true);
+  });
+
+  it('wide box fits more line-1 tokens but still re-anchors continuation at text-left', () => {
+    // Same stop @100, budget 520. Natural extent = 100 (jump) + content: five
+    // tokens "t01…t05" = 5·60+4·20 = 380 (+jump 480 ≤520); the trailing space →
+    // 500 ≤520; "t06" → 560 > 520 wraps. So exactly five tokens on line 1.
+    const { lines } = renderLines(
+      body([run(LATIN)], { tabStops: [{ pos: px(100), algn: 'l' }] }),
+      520,
+    );
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[0].startX).toBeCloseTo(100, 3);
+    expect(lines[0].text).toBe('t01 t02 t03 t04 t05');
+    expect(lines[1].startX).toBeCloseTo(0, 3);
+    expect(lines[1].text.startsWith('t06')).toBe(true);
+  });
+
+  it('Thai no-space leading tab reaches SEA fill: wraps and continuation at text-left', () => {
+    // A long no-space Thai run after a leading tab. Before the fix this stayed on
+    // ONE line forever (never reached the SEA branch); now it wraps and every
+    // continuation line starts at text-left.
+    const thai = '\tการเขียนภาษาไทยไม่ใช้ช่องว่างระหว่างคำแต่ใช้ช่องว่างเฉพาะเมื่อจบประโยคหรือวลี';
+    const { lines } = renderLines(
+      body([run(thai)], { tabStops: [{ pos: px(100), algn: 'l' }] }),
+      280,
+    );
+    expect(lines.length, 'tab-led Thai must reach SEA fill and wrap').toBeGreaterThan(1);
+    expect(lines[0].startX).toBeCloseTo(100, 3); // line 1 at the tab stop
+    for (let i = 1; i < lines.length; i++) {
+      expect(lines[i].startX, `Thai continuation line ${i} at text-left`).toBeCloseTo(0, 3);
+    }
+  });
+
+  it('multi-tab: cells sit on their stops; the overflowing cell tail re-anchors at text-left', () => {
+    // A1<tab>B2<tab>{t01…} with left stops @100 and @200, budget 260.
+    // A1@0, B2@100, t01@200 (ends 260); the tail wraps to text-left.
+    const r = run('A1\tB2\tt01 t02 t03 t04 t05 t06 t07 t08 t09 t10');
+    const { lines } = renderLines(
+      body([r], { tabStops: [{ pos: px(100), algn: 'l' }, { pos: px(200), algn: 'l' }] }),
+      260,
+    );
+    expect(lines.length).toBeGreaterThan(1);
+    const first = lines[0];
+    const a1 = first.runs.find((x) => x.text === 'A1')!;
+    const b2 = first.runs.find((x) => x.text === 'B2')!;
+    const t01 = first.runs.find((x) => x.text === 't01')!;
+    expect(a1.x).toBeCloseTo(0, 3);
+    expect(b2.x).toBeCloseTo(100, 3);
+    expect(t01.x).toBeCloseTo(200, 3);
+    // The overflowing 3rd cell's tail continues at text-left.
+    expect(lines[1].startX).toBeCloseTo(0, 3);
+    expect(lines[1].text.startsWith('t02')).toBe(true);
+  });
+
+  it('default tab grid (defTabSz, no a:tabLst): leading tab lands on the 1-grid stop', () => {
+    // No explicit stops. defTabSz = 100px grid → the leading tab jumps to 100
+    // (NOT to a single space width). Continuation re-anchors at text-left.
+    const { lines } = renderLines(
+      body([run(LATIN)], { defTabSz: px(100) }),
+      280,
+    );
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[0].startX, 'leading tab lands on the default 1-inch grid stop').toBeCloseTo(100, 3);
+    expect(lines[0].text).toBe('t01 t02');
+    expect(lines[1].startX).toBeCloseTo(0, 3);
+  });
+
+  it('a right-aligned tab cell that FITS never wraps (preserves the demo "22%" invariant)', () => {
+    // "ab"<tab>"value", right stop @200, tight budget 220. The cell ends AT 200,
+    // so it fits; a tab-blind "jump-then-add" budget would compute 300 and wrongly
+    // wrap. Exactly one line; value ends on the stop.
+    const { lines } = renderLines(
+      body([run('ab\tvalue')], { tabStops: [{ pos: px(200), algn: 'r' }] }),
+      220,
+    );
+    expect(lines.length).toBe(1);
+    const value = lines[0].runs.find((x) => x.text === 'value')!;
+    expect(value.x + value.w).toBeCloseTo(200, 3);
+  });
+
+  it('a right-tab CJK cell that fits by shrinking its gap does NOT wrap early', () => {
+    // Leading right tab @200, then a 9-glyph CJK run (180px). The cell ends AT
+    // 200 (occupying [20,200]) and fits the 220 box. The CJK branch must use the
+    // tab-aware available width (200px absorbable via the shrinking gap), not the
+    // additive 20px remainder — otherwise it would falsely wrap after one glyph.
+    const { lines } = renderLines(
+      body([run('\t日本語日本語日本語')], { tabStops: [{ pos: px(200), algn: 'r' }] }),
+      220,
+    );
+    expect(lines.length, 'fitting right-tab CJK cell stays on one line').toBe(1);
+    const cjk = lines[0].runs[lines[0].runs.length - 1];
+    expect(cjk.x + cjk.w).toBeCloseTo(200, 1); // right-aligned to the stop
+  });
+
+  it('a leading tab whose jump exceeds the box does not emit a tab-only CJK line', () => {
+    // Left stop @300 in a 260 box: the jump alone overflows, so no CJK glyph fits
+    // past it. The tab-led line must still carry a glyph (overflow) rather than be
+    // finalised empty, and the remaining glyphs wrap to text-left.
+    const { lines } = renderLines(
+      body([run('\t日本語日本語日本語日本語')], { tabStops: [{ pos: px(300), algn: 'l' }] }),
+      260,
+    );
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[0].text.length, 'the tab-led line carries a glyph, not tab-only').toBeGreaterThan(0);
+    expect(lines[1].startX).toBeCloseTo(0, 3); // continuation at text-left
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -103,7 +103,7 @@ import { justifyLine, type Justified } from './text-justify';
 import { justifiedPiecePositions } from '@silurus/ooxml-core';
 import { resolveTableBorderConflict } from './table-border-conflict.js';
 import { isSmartArtFallbackShape, smartArtFallbackTextColor } from './smartart-fallback-contrast';
-import { resolveTabWidths } from './tab-layout.js';
+import { resolveTabWidths, type TabItem, type TabStopPx } from './tab-layout.js';
 import { drawEaVertRun } from './vertical-text.js';
 
 /** Theme font context threaded through the render call chain. */
@@ -618,6 +618,12 @@ function firstLineIndentPxFor(hasBullet: boolean, indentPx: number): number {
  * `\t` runs. That matches what PowerPoint compares — "one continuous line
  * of glyphs" — and avoids over-eager wrap when a paragraph is barely wider
  * than the bbox due to font-measurement drift.
+ *
+ * Known limitation (issue #1006): because tab jumps are ignored here, a tab-led
+ * paragraph inside a `spAutoFit` shape whose raw glyph sum fits the box will
+ * take the grow-not-wrap path even if its tab-jumped extent would overflow. The
+ * adjudicated fixtures use `noAutofit`; spAutoFit + tab is unadjudicated and left
+ * as documented behaviour rather than guessed.
  */
 export function naturalWidthExceedsBbox(
   ctx: CanvasRenderingContext2D,
@@ -709,15 +715,89 @@ export function layoutParagraph(
   // sample-2 slide-7 stay on one line even though the bbox is tight).
   let hasWhitespaceOnLine = false;
 
-  // Once a line contains a tab, its cells remain unwrapped on that line.
-  let tabSeen = false;
+  // ── Wrap-aware tab context (issue #1006) ──────────────────────────────────
+  // A tab is a horizontal pen JUMP to its stop within the visual line where it
+  // occurs; content overflowing the line's right edge wraps normally and every
+  // CONTINUATION line re-anchors at the leading text-inset edge (text-left).
+  // The wrap budget must ACCOUNT for the tab jump, so a tabbed line measures its
+  // NATURAL extent with the SAME resolver the paint pass uses (`resolveTabWidths`
+  // with an infinite limit — the #835 clamp must not hide overflow). Tab-free
+  // lines keep the fast additive `lineW` path unchanged (byte-identical).
+  const baseRtl = para.rtl === true;
+  const marRPxL = emuToPx(para.marR, scale);
+  const stopsPxL: TabStopPx[] = (para.tabStops ?? []).map((s) => ({
+    pos: emuToPx(s.pos, scale),
+    algn: s.algn,
+  }));
+  // Effective default tab grid (§21.1.2.2.7): explicit pPr value, else the
+  // PowerPoint universal 1-inch default so a `\t` never collapses to a space.
+  const defTabSzPxL = emuToPx(para.defTabSz ?? 914400, scale);
+  // A tab contributes nothing to the additive `lineW` (its gap is resolved), so
+  // track "the line carries a tab" explicitly rather than via lineW.
+  let lineHasTab = false;
+  // Logical-order items for the current line (content advances + tab markers),
+  // mirroring the paint-side items so layout and paint resolve identically.
+  let lineItems: TabItem[] = [];
+  // Space width for the (now unused when defTabSz>0) no-stop fallback; captured
+  // from the first tab's font, matching the paint pass.
+  let tabSpaceW = 0;
+
+  /** Leading pen for the current line in the reading frame, matching the paint
+   *  pass's `leadingIndentPx`: RTL right-anchors at marR (no first-line indent);
+   *  LTR starts at marL plus the first line's positive indent. */
+  const lineStartPen = (): number =>
+    baseRtl ? marRPxL : marLPx + (lines.length === 0 ? firstLineIndentPx : 0);
+
+  /** Natural extent (px advance from the line's leading pen) of the current
+   *  line's committed items plus an optional trailing content advance, resolved
+   *  against the tab grid with NO trailing clamp. */
+  const tabAwareExtent = (extraW = 0): number => {
+    const items = extraW > 0 ? [...lineItems, { isTab: false, width: extraW }] : lineItems;
+    const widths = resolveTabWidths(items, stopsPxL, lineStartPen(), Infinity, tabSpaceW, defTabSzPxL);
+    let sum = 0;
+    for (const w of widths) sum += w;
+    return sum;
+  };
+
+  /** Whether a content advance of `w` still fits the current line's budget.
+   *  Tab-free lines use the fast additive path (byte-identical); a tabbed line
+   *  resolves the WHOLE hypothetical line (candidate-aware) so a right/centre
+   *  tab — whose gap SHRINKS as its cell grows — is placed correctly rather than
+   *  via `lineW + w`. An infinite budget (wrap="none" / spAutoFit measured on
+   *  one line) never wraps, so short-circuit before the O(items) resolve. */
+  const fitsW = (w: number): boolean => {
+    const budget = lineMaxW();
+    if (!Number.isFinite(budget)) return true;
+    return lineHasTab ? tabAwareExtent(w) <= budget : lineW + w <= budget;
+  };
+
+  /** Max additional content advance the current line can accept before its
+   *  natural extent exceeds the budget. Tab-free ⇒ the additive remainder; a
+   *  tabbed line ⇒ the exact monotone threshold of `tabAwareExtent` (correct for
+   *  left / right / centre tabs, so a fitting right-tab cell is never wrapped
+   *  early). Used by the CJK / SEA prefix-fit, which take a scalar budget. */
+  const availW = (): number => {
+    const budget = lineMaxW();
+    if (!lineHasTab) return budget - lineW;
+    if (!Number.isFinite(budget)) return Infinity;
+    if (tabAwareExtent(0) >= budget) return 0;
+    let lo = 0;
+    let hi = budget;
+    for (let i = 0; i < 40; i++) {
+      const mid = (lo + hi) / 2;
+      if (tabAwareExtent(mid) <= budget) lo = mid;
+      else hi = mid;
+    }
+    return lo;
+  };
 
   const newLine = (endsWithBreak = false) => {
     if (endsWithBreak) currentLine.endsWithBreak = true;
     lines.push(currentLine);
     currentLine = { segments: [] };
     lineW = 0;
-    tabSeen = false;
+    lineHasTab = false;
+    lineItems = [];
     hasWhitespaceOnLine = false;
   };
 
@@ -781,6 +861,10 @@ export function layoutParagraph(
       (a.fontFamily ?? '') === (fontFamily ?? '') &&
       hyperlinkKey(a.hyperlink) === hyperlinkKey(hyperlink);
     lineW += w;
+    // Mirror the paint-side item sequence so a tabbed line's wrap budget resolves
+    // identically (issue #1006). One item per push call; consecutive content
+    // items simply sum inside resolveTabWidths.
+    lineItems.push({ isTab: false, width: w });
     const last = currentLine.segments.at(-1);
     if (last && sameMeta(last)) {
       last.text += text;
@@ -851,7 +935,8 @@ export function layoutParagraph(
       const descent = render ? render.descentEm * emPx : 0;
       // Block (display) math gets its own line; the draw pass centres it.
       if (run.display && lineW > 0) newLine();
-      else if (lineW + width > lineMaxW() && lineW > 0) newLine();
+      else if (!fitsW(width) && lineW > 0) newLine();
+      lineItems.push({ isTab: false, width });
       currentLine.segments.push({
         text: '',
         font: `${emPx}px sans-serif`,
@@ -954,6 +1039,13 @@ export function layoutParagraph(
       if (/^\t+$/.test(token)) {
         // §21.1.2.1.x: retain every tab inline. Gap resolution is deferred until
         // paint, when every cell width is known; UAX#9 S then reorders cells.
+        // The wrap pass measures the tab jump via `tabAwareExtent` (#1006) so the
+        // line breaks at the correct point, and a continuation line (which never
+        // carries the tab) re-anchors at text-left.
+        if (!lineHasTab) {
+          ctx.font = font;
+          tabSpaceW = ctx.measureText(' ').width;
+        }
         for (const _ of token) {
           currentLine.segments.push({
             text: '',
@@ -965,20 +1057,15 @@ export function layoutParagraph(
             underline: false,
             strikethrough: false,
           });
+          lineItems.push({ isTab: true, width: 0 });
         }
-        tabSeen = true;
+        lineHasTab = true;
         continue;
       }
 
       ctx.font = font;
       const tokW = ctx.measureText(token).width;
       const isWhitespace = /^\s+$/.test(token);
-
-      // Tab-delimited cells stay on one line; tab gaps are resolved as a unit.
-      if (tabSeen) {
-        push(token, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
-        continue;
-      }
 
       // ── Symbol-font characters (Wingdings/Webdings/Symbol) ───────────────
       // PowerPoint stores symbol glyphs as Private-Use codepoints U+F020–U+F0FF
@@ -1009,7 +1096,7 @@ export function layoutParagraph(
           }
           ctx.font = chFont;
           const chW = ctx.measureText(drawCh).width;
-          if (lineW + chW > lineMaxW() && lineW > 0) newLine();
+          if (!fitsW(chW) && lineW > 0) newLine();
           push(drawCh, chFont, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         }
         continue;
@@ -1063,7 +1150,7 @@ export function layoutParagraph(
           // content and the token would overflow, wrap once before placing it;
           // never break mid-token (an over-wide token simply overflows).
           const tokenW = measured.reduce((acc, m) => acc + m.w, 0);
-          if (lineW > 0 && lineW + tokenW > lineMaxW()) newLine();
+          if (lineW > 0 && !fitsW(tokenW)) newLine();
           for (const m of measured) {
             push(m.ch, m.font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, { ...segExtras, fontFamily: m.family });
           }
@@ -1071,10 +1158,19 @@ export function layoutParagraph(
         }
         let rest = measured;
         while (rest.length > 0) {
-          const n = fitCjkLine(rest, lineW, lineMaxW(), DEFAULT_KINSOKU_RULES);
+          // Effective start pen so the fit sees the line's true remaining width:
+          // budget − availW = the additive pen (tab-free / left tab) or the
+          // slack-adjusted pen (right / centre tab). Equivalent to lineW when no
+          // tab, so tab-free CJK is byte-identical.
+          const cjkPen = Number.isFinite(lineMaxW()) ? lineMaxW() - availW() : lineW;
+          let n = fitCjkLine(rest, cjkPen, lineMaxW(), DEFAULT_KINSOKU_RULES);
           if (n === 0) {
-            newLine(); // non-empty line can't take the run head → break, retry empty
-            continue;
+            // A non-empty line can't take the run head → break and retry empty.
+            // But a line holding ONLY a tab (lineW===0, tab jump consumed the
+            // width) must NOT be finalised as a tab-only line — place one glyph
+            // so it overflows, mirroring the Latin "no break opportunity" rule.
+            if (lineW > 0) { newLine(); continue; }
+            n = 1;
           }
           for (let i = 0; i < n; i++) {
             const m = rest[i];
@@ -1148,7 +1244,7 @@ export function layoutParagraph(
         const N = token.length;
         let start = 0;
         while (start < N) {
-          const avail = lineMaxW() - lineW;
+          const avail = availW();
           let end = fitSeaWordPrefix(token, seaBreaks, start, avail, measureSub, monotone);
           if (end <= start) {
             if (lineW > 0) { newLine(); continue; } // wrap first, retry empty line
@@ -1167,7 +1263,7 @@ export function layoutParagraph(
         continue;
       }
 
-      if (lineW + tokW <= lineMaxW()) {
+      if (fitsW(tokW)) {
         push(token, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         if (isWhitespace) hasWhitespaceOnLine = true;
       } else if (isWhitespace) {
@@ -1177,7 +1273,7 @@ export function layoutParagraph(
         for (const ch of token) {
           ctx.font = font;
           const chW = ctx.measureText(ch).width;
-          if (lineW + chW > lineMaxW() && lineW > 0) newLine();
+          if (!fitsW(chW) && lineW > 0) newLine();
           push(ch, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         }
       } else if (!hasWhitespaceOnLine) {
@@ -3358,7 +3454,11 @@ export function renderTextBody(
         pos: emuToPx(stop.pos, scale),
         algn: stop.algn,
       }));
-      const widths = resolveTabWidths(items, stops, leadingIndentPx, limitPx, spaceW);
+      // Default tab grid (§21.1.2.2.7): explicit pPr value, else PowerPoint's
+      // universal 1-inch default so an unreached tab snaps to the grid (matching
+      // the wrap pass) rather than collapsing to a space (issue #1006).
+      const defTabSzPx = emuToPx(entry.para.defTabSz ?? 914400, scale);
+      const widths = resolveTabWidths(items, stops, leadingIndentPx, limitPx, spaceW, defTabSzPx);
       for (let i = 0; i < line.segments.length; i++) {
         if (line.segments[i].isTab) line.segments[i].tabWidthPx = widths[i];
       }

--- a/packages/pptx/src/tab-layout.test.ts
+++ b/packages/pptx/src/tab-layout.test.ts
@@ -77,4 +77,31 @@ describe('resolveTabWidths — inline tab gap resolution (§21.1.2.1.x)', () => 
     const out = resolveTabWidths(items, [S(400, 'l'), S(200, 'l')], 0, 600, 0);
     expect(out).toEqual([200, 10, 190, 10]);
   });
+
+  // §21.1.2.1.1 / §21.1.2.2.7 default tab grid (defTabSz) — issue #1006.
+  it('defTabSz grid: a tab with no explicit stops jumps to the next grid line', () => {
+    // Grid 100; pen 0 → first grid stop 100 (LEFT). Cell keeps its width.
+    const out = resolveTabWidths([tab(), text(30)], [], 0, 600, 0, 100);
+    expect(out).toEqual([100, 30]);
+  });
+
+  it('defTabSz grid resumes past the last explicit stop', () => {
+    // Explicit l@120 lands cell 1; the SECOND tab (pen 150) has no explicit stop
+    // past it → default grid 100 gives the next line at 200.
+    const items = [tab(), text(30), tab(), text(20)];
+    const out = resolveTabWidths(items, [S(120, 'l')], 0, 600, 0, 100);
+    // gap1 = 120, then text 30 → pen 150; gap2 to grid 200 = 50.
+    expect(out).toEqual([120, 30, 50, 20]);
+  });
+
+  it('defTabSz grid picks the NEXT line when the pen sits exactly on a grid line', () => {
+    // pen starts at 100 (on the grid); the tab must advance to 200, not stay.
+    const out = resolveTabWidths([tab(), text(10)], [], 100, 600, 0, 100);
+    expect(out).toEqual([100, 10]); // gap 100 → pen 200
+  });
+
+  it('defTabSz = 0 keeps the legacy space-degradation for an unreachable tab', () => {
+    const out = resolveTabWidths([tab(), text(30)], [], 0, 600, 20, 0);
+    expect(out).toEqual([20, 30]);
+  });
 });

--- a/packages/pptx/src/tab-layout.ts
+++ b/packages/pptx/src/tab-layout.ts
@@ -30,13 +30,20 @@ export interface TabStopPx {
  * visual gap and the cumulative draw reproduces the mirrored stops.
  *
  * `dec` aligns like `r` (frac 1): true decimal-point splitting is not
- * implemented — the same approximation docx uses. DrawingML defines no
- * automatic tab grid (there is no `defTabSz` support in this parser), so a
- * tab with no reachable stop degrades to `noStopGap` (a space width,
- * preserving the pre-#916 behaviour). Two clamps mirror docx: a cell whose
- * far edge would cross `limit` (the trailing text-inset edge) is pinned to it
- * (#835 — Word never pushes a cell off the text area), and a tab never moves
- * the pen backwards.
+ * implemented — the same approximation docx uses. When a tab has no reachable
+ * explicit stop, the DrawingML default tab grid applies (§21.1.2.1.1 /
+ * §21.1.2.2.7 `defTabSz`, PowerPoint default 1 inch): `defTabSz > 0` synthesises
+ * a LEFT stop at the next grid multiple strictly past the pen. With `defTabSz`
+ * 0 (the pure default, e.g. the unit tests) the tab instead degrades to
+ * `noStopGap` (a space width, the pre-#916 behaviour). Two clamps mirror docx:
+ * a cell whose far edge would cross `limit` (the trailing text-inset edge) is
+ * pinned to it (#835 — Word never pushes a cell off the text area), and a tab
+ * never moves the pen backwards.
+ *
+ * `limit` is `+Infinity` when the caller wants the line's NATURAL extent (the
+ * wrap pass, issue #1006): the #835 clamp must not hide overflow from line
+ * breaking, so the layout measures the unclamped extent and the paint pass keeps
+ * the finite clamp.
  *
  * @returns one width per LOGICAL index (non-tabs keep their input width).
  */
@@ -46,6 +53,7 @@ export function resolveTabWidths(
   startPen: number,
   limit: number,
   noStopGap: number,
+  defTabSz = 0,
 ): number[] {
   const widths = items.map((item) => item.width);
   const followW = (from: number): number => {
@@ -70,9 +78,15 @@ export function resolveTabWidths(
       }
     }
     if (stop === null) {
-      widths[i] = noStopGap;
-      pen += noStopGap;
-      continue;
+      if (defTabSz > 0) {
+        // §21.1.2.1.1 default tab grid: jump to the next grid line strictly past
+        // the pen (a LEFT stop). Beyond the last explicit stop the grid resumes.
+        stop = { pos: (Math.floor(pen / defTabSz) + 1) * defTabSz, algn: 'l' };
+      } else {
+        widths[i] = noStopGap;
+        pen += noStopGap;
+        continue;
+      }
     }
 
     const followingWidth = followW(i + 1);

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -80,6 +80,14 @@ export interface Paragraph extends CoreParagraph {
    * emits an effective boolean.
    */
   eaLnBrk: boolean;
+  /**
+   * `<a:pPr defTabSz>` (ECMA-376 §21.1.2.2.7) — the default tab-stop interval in
+   * EMU. When a `\t` has no reachable explicit `a:tabLst` stop, it advances to
+   * the next multiple of this grid (issue #1006). Absent ⇒ the renderer uses the
+   * PowerPoint universal default of 914400 EMU (1 inch). Omitted from JSON when
+   * the parser found no explicit value.
+   */
+  defTabSz?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

`layoutParagraph` set a `tabSeen` flag once a line contained a `\t` and then pushed every following token unconditionally, so a **tab-led line never wrapped** — for any script or alignment — and tab-led Thai never even reached the SEA dictionary-fill branch. PowerPoint wraps tab-led paragraphs normally.

## Adjudication (PowerPoint ground truth)

Measured the PowerPoint GT PDF of a purpose-built 6-slide fixture (2 boxes/slide, Latin `t01…t12` + no-space Thai, `a:tabLst` vs default `defTabSz`, single vs 2-cell tabs). Full record on the issue. Verdict:

| Q | Finding |
|---|---------|
| Continuation anchor | **(A) leading text-left.** Line 1 (tab-led) begins at the tab stop; every wrapped continuation line begins at text-left — like a no-tab paragraph. |
| a:tabLst vs default `defTabSz` | **No difference** — both land line 1 at the stop and re-anchor continuation at text-left. |
| Multiple tabs (2 cells) | All cells on line 1; the overflowing cell's tail wraps to text-left. |
| Script (Latin vs Thai) | **Identical**; Thai reaches SEA dictionary fill. |

Rule: a tab is a horizontal pen JUMP to its stop within the visual line where it occurs; overflow wraps at a normal break opportunity; continuation lines re-anchor at the leading text-inset edge.

## Change

- **`resolveTabWidths`** gains a `defTabSz` param: a tab with no reachable explicit stop snaps to the next default-grid multiple (§21.1.2.2.7) instead of degrading to a space. `defTabSz = 0` preserves the pure-resolver behaviour. Callers pass `Infinity` as the limit to measure the unclamped natural extent (the #835 clamp must not hide overflow from wrapping).
- **`layoutParagraph`** drops `tabSeen`. A tabbed line measures its natural extent with the *same* resolver the paint pass uses, so layout and paint agree; tab-free lines keep the fast additive path (byte-identical). The Latin fit is candidate-aware (a right/centre tab whose gap shrinks as its cell grows is placed correctly — a fitting cell like the demo "22%" is never wrapped early); the CJK/SEA prefix fit uses the exact monotone available width; and a leading tab that overflows the box places a glyph rather than emitting a tab-only line. A wrapped continuation carries no tab segment, so paint draws it at text-left with no extra code.
- **Parser** reads `a:pPr@defTabSz` into `Paragraph.defTabSz`; the renderer defaults an absent value to PowerPoint's universal 1-inch (914400 EMU) grid at both layout and paint.

## Verification

- New `pptx-tab-wrap.test.ts` (8 cases) locks the adjudicated token counts, the text-left continuation anchor, Thai SEA fill, multi-tab cells, the `defTabSz` grid, the right-tab non-wrap invariant, and the two CJK edge cases from review.
- `resolveTabWidths` `defTabSz` unit tests; a Rust `defTabSz` parse test.
- The **public VRT demo deck has no tabs**, so the demo VRT is unaffected (verified non-regressing, all 9 slides). Existing tab invariants stay covered by `tab-layout` / `pptx-multi-tab` / `rtl-tab-stops` / `tab-stop-spc`.
- A real-WASM render of the adjudication fixture reproduces the GT token counts (narrow t01–t04, wide t01–t08) and continuation anchors exactly.
- Gates green: pptx vitest, root typecheck, Rust fmt/clippy/test, ast-grep (0 errors). Design and an independent read-only review were done with Codex gpt-5.6-sol; the review's findings were addressed (candidate-aware CJK/SEA width, tab-only-line guard, infinite-budget short-circuit) or documented (spAutoFit tab-blindness, `defTabSz` cascade — both fall back to the 1-inch default).

Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)