### PR TITLE
fix(docx): textbox vertical cross-axis spacing — ruby column reservation and mongolianVert inset/mirror

### DIFF
--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -202,6 +202,11 @@ export interface LayoutTextSeg extends LayoutSegSource {
   seaBreaks?: readonly number[];
 }
 
+/** ECMA-376 §17.3.3.25 ruby annotation ascent reserved above its base text. */
+export function rubyAscentReservePx(rubySizePt: number, scale: number): number {
+  return rubySizePt * scale * 1.5;
+}
+
 /**
  * Horizontal tab. Width is resolved during layout against paragraph tab stops
  * (or the default 36pt interval if no explicit stop is configured).
@@ -3218,7 +3223,7 @@ export function layoutLines(
     // snap actually picks the next pitch slot. 1.5× rt-size is enough for
     // any rt size that fits in one extra pitch above the base.
     if (s.ruby) {
-      asc = asc + s.ruby.fontSizePt * scale * 1.5;
+      asc = asc + rubyAscentReservePx(s.ruby.fontSizePt, scale);
     }
 
     // ECMA-376 §17.3.2.14: a fit region is an atomic fixed-width cell. The
@@ -3773,7 +3778,9 @@ export function rescaleLayoutLines(
     const segScriptHint = EAST_ASIAN_RE.test(s.text) && !s.ruby;
     const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx, segScriptHint);
     // §17.3.3.25 — ruby reserves extra ascent room (rt size × 1.5), same as layoutLines.
-    const asc = s.ruby ? corrected.ascent + s.ruby.fontSizePt * scale * 1.5 : corrected.ascent;
+    const asc = s.ruby
+      ? corrected.ascent + rubyAscentReservePx(s.ruby.fontSizePt, scale)
+      : corrected.ascent;
     // Intended single-line floor (font-metrics.ts) — small caps keep the FULL run
     // size here too (addToLine's intendedEm).
     const intendedEm = s.smallCaps && !s.vertAlign ? fullPx : effPx;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -149,6 +149,7 @@ import {
   paragraphMarkLineHeight,
   paragraphSegsStateSensitive,
   rescaleLayoutLines,
+  rubyAscentReservePx,
   segAdvanceWidth,
   segLetterSpacingPx,
   shapeRenderState,
@@ -10382,6 +10383,12 @@ function shapeTextHorizontalInsetsPx(shape: ShapeRun, scale: number): { lIns: nu
   };
 }
 
+function shapeLineSpacingOf(b: ShapeText): LineSpacing | null {
+  return b.lineSpacingRule
+    ? { value: b.lineSpacingVal ?? 0, rule: b.lineSpacingRule as 'auto' | 'exact' | 'atLeast' }
+    : null;
+}
+
 /** ECMA-376 §20.1.10.83 ST_TextVerticalType — the IMPLEMENTED vertical text-box
  *  directions (`<wps:bodyPr vert>`), or `null` for horizontal / not-yet-handled
  *  values. `eaVert` keeps East-Asian glyphs upright (per-glyph UAX#50); `vert`
@@ -10400,6 +10407,26 @@ function verticalTextboxMode(
     : null;
 }
 
+function verticalRubyLineMetrics(
+  line: LayoutLine,
+  lineSpacing: LineSpacing | null,
+  scale: number,
+  grid?: DocGridCtx,
+): { lineH: number; baselineOffset: number } {
+  const glyphNatural = line.ascent + line.descent;
+  const lineH = lineBoxHeight(
+    lineSpacing,
+    line.ascent,
+    line.descent,
+    scale,
+    grid,
+    true,
+    line.intendedSingle,
+    line.eastAsian ?? false,
+  );
+  return { lineH, baselineOffset: (lineH - glyphNatural) / 2 + line.ascent };
+}
+
 /** Measure a shape text body's fitted height for `<a:spAutoFit/>`.
  *  Returns px, including bodyPr top/bottom insets and paragraph spacing. */
 export function measureShapeTextAutoFitHeight(
@@ -10413,6 +10440,7 @@ export function measureShapeTextAutoFitHeight(
 ): number {
   const effState = state ?? shapeRenderState(ctx, scale, fontFamilyClasses, images);
   const blocks = shape.textBlocks ?? [];
+  const vmode = verticalTextboxMode(shape.textVert);
   const { lIns, rIns } = shapeTextHorizontalInsetsPx(shape, scale);
   const tIns = (shape.textInsetT ?? 0) * scale;
   const bIns = (shape.textInsetB ?? 0) * scale;
@@ -10429,6 +10457,9 @@ export function measureShapeTextAutoFitHeight(
   };
 
   const lineHeightFor = (b: ShapeText, line: LayoutLine): number => {
+    if (vmode && line.hasRuby) {
+      return verticalRubyLineMetrics(line, shapeLineSpacingOf(b), scale, effState.docGrid).lineH;
+    }
     let tallest: LayoutTextSeg | null = null;
     let tallestEa = false;
     let floorPx = 0;
@@ -10710,16 +10741,16 @@ export function renderShapeText(
   const innerY = y + tIns;
   const innerH = Math.max(0, h - tIns - bIns);
 
-  // §20.1.10.83 `mongolianVert` — reflect a block that occupies the cross-axis
-  // (line-stacking) interval `[top, top + extent]` about the inner box's cross
-  // centre, so its columns stack LEFT→RIGHT (device) instead of the eaVert R→L.
-  // The reflection moves ONLY the cross position; each line's own glyphs (drawn
-  // upright/sideways by drawVerticalRun, inline axis = local +x) are untouched, so
-  // the reading order within a column and the glyph orientation stay identical to
-  // eaVert — the batch-3 GT shows the label column at the box's physical LEFT and
-  // later columns to its right. Identity for every non-mongolian mode.
+  // §20.1.10.83 `mongolianVert` — `flipBlockTop` keeps its historical name, but
+  // this mapping is not a pure reflection about the inner-box centre. It first
+  // reflects the cross-axis interval `[top, top + extent]`, then `+ bIns - lIns`
+  // re-homes the reflected stack so the FIRST column starts at the physical LEFT
+  // inset `lIns` (§21.1.2.1.1 names insets by physical bounding-rectangle edge).
+  // This helper positions the line band only; the draw site mirrors each line's
+  // centerline within that band and keeps ruby reservation on the band-interior /
+  // physical-right side. Identity for every non-mongolian mode.
   const flipBlockTop = (top: number, extent: number): number =>
-    mongolianLineFlip ? 2 * innerY + innerH - top - extent : top;
+    mongolianLineFlip ? 2 * innerY + innerH - top - extent + bIns - lIns : top;
 
   // ECMA-376 §17.3.1.12 — per-paragraph indent (px). `leftPx`/`rightPx` shrink
   // the text column from the inner box edges; `firstPx` is the SIGNED first-line
@@ -10872,6 +10903,9 @@ export function renderShapeText(
   // TALLEST text segment. A line with no text segment (e.g. only a tab) falls
   // back to the block's own font.
   const lineMetricsFor = (b: ShapeText, line: LayoutLine): { lineH: number; baselineOffset: number } => {
+    if (vmode && line.hasRuby) {
+      return verticalRubyLineMetrics(line, shapeLineSpacingOf(b), scale, effState.docGrid);
+    }
     let tallest: LayoutTextSeg | null = null;
     let tallestEa = false;
     let floorPx = 0;
@@ -11142,9 +11176,20 @@ export function renderShapeText(
         const lineH = layout.lineHeights[li];
         // §20.1.10.83 mongolianVert reflects the line's cross (stacking) position
         // within the inner box (L→R columns); no-op for every other mode. The
-        // baseline keeps its offset from the (reflected) line top, so the glyphs
-        // sit inside the line box exactly as eaVert draws them.
-        const baseline = flipBlockTop(cursorY, lineH) + layout.baselineOffsets[li];
+        // reflection mirrors the line CENTERLINE within its band too. Ruby grows
+        // `baselineOffset` on its ascent side, so add that same reservation back
+        // only in the mongolian arm: the base keeps its non-ruby centerline and
+        // the furigana occupies the band-interior / physical-right side.
+        const baselineOffset = layout.baselineOffsets[li];
+        const rubyReserve = mongolianLineFlip
+          ? line.segments.reduce((reserve, seg) => {
+              if (!('text' in seg) || !seg.ruby) return reserve;
+              return Math.max(reserve, rubyAscentReservePx(seg.ruby.fontSizePt, scale));
+            }, 0)
+          : 0;
+        const baseline =
+          flipBlockTop(cursorY, lineH) +
+          (mongolianLineFlip ? lineH - baselineOffset + rubyReserve : baselineOffset);
         // Per-line indented region (§17.3.1.12): content-left = innerX + leftPx,
         // shifted by the signed first-line indent on the first line; width =
         // firstLineW (first) / paraW (continuation).

--- a/packages/docx/src/textbox-vertical-render.test.ts
+++ b/packages/docx/src/textbox-vertical-render.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renderShapeText } from './renderer';
+import { measureShapeTextAutoFitHeight, renderShapeText } from './renderer';
 import type { ShapeRun, ShapeText, ShapeTextRun } from './types';
 
 // ECMA-376 §20.1.10.83 ST_TextVerticalType — a DrawingML text-box body direction
@@ -391,5 +391,155 @@ describe('§20.1.10.83 textbox <wps:bodyPr vert> — vertical text-box rendering
     // bug (reserving the 90 height) it would exceed 90. Assert well below 90.
     expect(sep, `two-column separation ${sep} reflects image cross 10, not height 90`).toBeLessThan(45);
     expect(sep, `columns are actually separated ${sep}`).toBeGreaterThan(12);
+  });
+
+  // ── cross-axis spacing (sample-53 class regressions) ─────────────────────
+  // GT (Word PDF): a ruby-bearing line's COLUMN is widened by the ruby
+  // reservation (the same `ruby.fontSizePt × 1.5` ascent bump layoutLines()
+  // already computes for the section body), so the base column clears the
+  // previous column instead of the furigana overprinting it.
+  it('eaVert ruby line widens its column advance by the ruby reservation (§17.3.3.25)', () => {
+    const advance = (withRuby: boolean): number => {
+      const { ctx, glyphs } = makeMatrixCtx();
+      const labelBlock: ShapeText = {
+        text: CJK, fontSizePt: 10, alignment: 'left',
+        runs: [{ text: CJK, fontSizePt: 10, fontFamily: 'NotInMetrics' }],
+      };
+      const baseRun: ShapeTextRun = {
+        text: '漢', fontSizePt: 10, fontFamily: 'NotInMetrics',
+        ...(withRuby ? { ruby: { text: 'かん', fontSizePt: 5 } } : {}),
+      };
+      const baseBlock: ShapeText = { text: '漢', fontSizePt: 10, alignment: 'left', runs: [baseRun] };
+      const shape = richTextbox([{ text: CJK, fontSizePt: 10, fontFamily: 'NotInMetrics' }], 'eaVert');
+      (shape as unknown as { textBlocks: ShapeText[] }).textBlocks = [labelBlock, baseBlock];
+      renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {});
+      const label = glyphs.find((g) => g.text.includes(CJK));
+      const base = glyphs.find((g) => g.text.includes('漢'));
+      expect(label, 'label glyph drawn').toBeDefined();
+      expect(base, 'base glyph drawn').toBeDefined();
+      // eaVert stacks columns R→L: the base column sits LEFT of the label column.
+      return label!.devX - base!.devX;
+    };
+    const plain = advance(false);
+    const withRuby = advance(true);
+    // layoutLines() reserves ruby.fontSizePt × 1.5 = 7.5 of extra ascent; the
+    // ruby-bearing column must advance by exactly that much more.
+    expect(withRuby - plain, `ruby advance ${withRuby} vs plain ${plain}`).toBeCloseTo(7.5, 5);
+  });
+
+  // GT (Word PDF): mongolianVert's first column is the exact MIRROR of the
+  // eaVert first column (sample-53: flow-start-edge → label glyph-box gap is
+  // preserved within 0.5pt). Reflecting only the band ORIGIN keeps the baseline
+  // measured from the band's physical RIGHT edge, so asymmetric leading (line
+  // box taller than the glyph em box) shoves the mongolian line toward the
+  // physical left — the centerline inside the band must be reflected too.
+  it('mongolianVert mirrors the line centerline within its cross-axis band', () => {
+    const firstColumnCenterX = (mode: 'eaVert' | 'mongolianVert'): number => {
+      const { ctx, glyphs } = makeMatrixCtx();
+      const shape = richTextbox([{ text: CJK, fontSizePt: 11, fontFamily: 'NotInMetrics' }], mode);
+      const [block] = (shape as unknown as { textBlocks: ShapeText[] }).textBlocks;
+      // Exact 20pt line box > the 11pt glyph box → asymmetric leading exposes a
+      // non-mirrored centerline (natural == lineH would accidentally pass).
+      (block as unknown as { lineSpacingRule: string; lineSpacingVal: number }).lineSpacingRule = 'exact';
+      (block as unknown as { lineSpacingRule: string; lineSpacingVal: number }).lineSpacingVal = 20;
+      renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {});
+      const glyph = glyphs.find((g) => g.text.includes(CJK));
+      expect(glyph, 'first-column glyph drawn').toBeDefined();
+      // Upright CJK cells draw centred on the column centerline, so devX IS the
+      // centerline's cross position.
+      return glyph!.devX;
+    };
+    const eaX = firstColumnCenterX('eaVert');
+    const mongolianX = firstColumnCenterX('mongolianVert');
+    // Equal glyphs have equal cross extents, so mirrored centerlines imply equal
+    // flow-start-edge → glyph-box gaps (box spans x ∈ [0, 200], insets 0).
+    expect(mongolianX, `mongolian centerline ${mongolianX} mirrors eaVert ${eaX}`).toBeCloseTo(200 - eaX, 5);
+  });
+
+  // mongolianVert + ruby: the furigana keeps its orientation side (physical
+  // RIGHT of the base column, like eaVert) — so the mirror must keep the BASE
+  // cell at its non-ruby mirrored position and spend the ruby reservation on
+  // the band's interior (right) side. Mirroring the ruby-inflated baseline
+  // offset naively would shove the base toward the band's right edge and paint
+  // the furigana on top of the NEXT column.
+  it('mongolianVert ruby line keeps its base column mirrored and reserves toward the next column', () => {
+    const render = (withRuby: boolean) => {
+      const { ctx, glyphs } = makeMatrixCtx();
+      const rubyBlock: ShapeText = {
+        text: '漢', fontSizePt: 10, alignment: 'left',
+        runs: [{
+          text: '漢', fontSizePt: 10, fontFamily: 'NotInMetrics',
+          ...(withRuby ? { ruby: { text: 'かん', fontSizePt: 5 } } : {}),
+        }],
+      };
+      const nextBlock: ShapeText = {
+        text: CJK, fontSizePt: 10, alignment: 'left',
+        runs: [{ text: CJK, fontSizePt: 10, fontFamily: 'NotInMetrics' }],
+      };
+      const shape = richTextbox([{ text: '漢', fontSizePt: 10, fontFamily: 'NotInMetrics' }], 'mongolianVert');
+      (shape as unknown as { textBlocks: ShapeText[] }).textBlocks = [rubyBlock, nextBlock];
+      renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {});
+      const base = glyphs.find((g) => g.text.includes('漢'));
+      const next = glyphs.find((g) => g.text.includes(CJK));
+      const ruby = glyphs.filter((g) => /[かん]/.test(g.text));
+      expect(base, 'base glyph drawn').toBeDefined();
+      expect(next, 'next-column glyph drawn').toBeDefined();
+      if (withRuby) expect(ruby.length, 'ruby glyphs drawn').toBe(2);
+      return { baseX: base!.devX, nextX: next!.devX, rubyXs: ruby.map((g) => g.devX) };
+    };
+    const plain = render(false);
+    const withRuby = render(true);
+    // The base column does NOT move: the reservation goes to the ruby side
+    // (band interior), not the flow-start edge.
+    expect(withRuby.baseX, `base ${withRuby.baseX} unmoved from ${plain.baseX}`).toBeCloseTo(plain.baseX, 5);
+    // The NEXT column (to the right, L→R) advances by the ruby reservation.
+    expect(withRuby.nextX - plain.nextX, 'next column pushed by the reservation').toBeCloseTo(7.5, 5);
+    // The furigana sits BETWEEN its base column and the next column — physical
+    // right of the base (orientation preserved), clear of the next column.
+    for (const rx of withRuby.rubyXs) {
+      expect(rx, `ruby ${rx} right of base ${withRuby.baseX}`).toBeGreaterThan(withRuby.baseX);
+      expect(rx, `ruby ${rx} clears next column ${withRuby.nextX}`).toBeLessThan(withRuby.nextX - 5);
+    }
+  });
+
+  // Autofit (spAutoFit) shares the same line resolver: a ruby-bearing vertical
+  // line must widen the fitted cross extent by the same reservation, or the
+  // grown box would clip the furigana (sample-53 box (d) class).
+  it('eaVert spAutoFit measurement grows by the ruby reservation', () => {
+    const measure = (withRuby: boolean): number => {
+      const { ctx } = makeMatrixCtx();
+      const shape = richTextbox([{
+        text: '漢', fontSizePt: 10, fontFamily: 'NotInMetrics',
+        ...(withRuby ? { ruby: { text: 'かん', fontSizePt: 5 } } : {}),
+      }], 'eaVert');
+      return measureShapeTextAutoFitHeight(shape, 200, ctx, 1, {});
+    };
+    expect(measure(true) - measure(false), 'fitted extent grows by ruby.fontSizePt × 1.5').toBeCloseTo(7.5, 5);
+  });
+
+  // GT (Word PDF): §21.1.2.1.1 names the insets by PHYSICAL bounding-box edge
+  // (lIns = left inset, default 91440 EMU = 7.2pt; bIns = bottom, 45720 EMU) —
+  // reflecting the column stack for mongolianVert's L→R flow must not hand the
+  // physical LEFT edge to bIns.
+  it('mongolianVert first column origin honors lIns (physical left), not bIns (§21.1.2.1.1)', () => {
+    const firstColX = (lIns: number, bIns: number): number => {
+      const { ctx, glyphs } = makeMatrixCtx();
+      const shape = richTextbox([{ text: CJK, fontSizePt: 10, fontFamily: 'NotInMetrics' }], 'mongolianVert');
+      const s = shape as unknown as {
+        textInsetL: number; textInsetT: number; textInsetR: number; textInsetB: number;
+      };
+      s.textInsetL = lIns;
+      s.textInsetT = 3;
+      s.textInsetR = 7;
+      s.textInsetB = bIns;
+      renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {});
+      const g = glyphs.find((gl) => gl.text.includes(CJK));
+      expect(g, 'glyph drawn').toBeDefined();
+      return g!.devX;
+    };
+    // +12pt of lIns moves the first (leftmost) column +12pt right.
+    expect(firstColX(17, 3) - firstColX(5, 3), 'lIns owns the physical-left origin').toBeCloseTo(12, 5);
+    // bIns must NOT move the physical-left first column.
+    expect(firstColX(7, 20), 'bIns does not own the physical-left origin').toBeCloseTo(firstColX(7, 3), 5);
   });
 });

--- a/packages/node/src/docx-vertical-textbox-crossaxis.probe.test.ts
+++ b/packages/node/src/docx-vertical-textbox-crossaxis.probe.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Vertical text-box cross-axis spacing on the REAL private sample-53 —
+ * ECMA-376 §20.1.10.83 (bodyPr vert) + §21.1.2.1.1 (insets) + §17.3.3.25 (ruby).
+ *
+ * Word PDF ground truth (Letter 612×792 pt; all boxes lIns/rIns = 7.2 pt,
+ * tIns/bIns = 3.6 pt; label runs 11 pt, body/base runs 15 pt, ruby 7.5 pt):
+ *
+ *   box (a) `vert="mongolianVert"` at x ∈ [28.8, 144.0] — columns flow L→R.
+ *     Word puts the first (label) column's glyph box at x = 38.56..50.49, i.e.
+ *     the flow-start gap MIRRORS the eaVert twin (box b: right gap 9.27 pt vs
+ *     a: left gap 9.76 pt). The two historical bugs pulled the label ~7 pt left:
+ *     (1) the reflected column stack started at physical bIns (3.6) instead of
+ *     lIns (7.2), and (2) the line CENTERLINE was not mirrored within its band,
+ *     so Yu-Mincho-style asc-heavy leading pushed ink LEFT of the lIns content
+ *     edge (x < 36).
+ *
+ *   box (b) `vert="eaVert"` at x ∈ [172.8, 288.0] — columns flow R→L; a label
+ *     line then a ruby-bearing base line. Word renders THREE distinct ink
+ *     bands: base column 235..247, ruby band 254..259, label column 267..277.
+ *     The historical bug dropped the layoutLines() ruby ascent reservation in
+ *     the textbox re-measure, so the base column advanced by the plain line
+ *     pitch and the furigana overprinted the label column (two merged bands).
+ *
+ * Assertions are font-robust invariants of those two fixes (the harness aliases
+ * Hiragino for Yu Mincho, so exact Word ink positions shift by a few pt):
+ *   a-1. box (a) first-column ink starts at/after the lIns content edge (36.0).
+ *   a-2. …and not absurdly far in (< 48; Word ink starts at 39).
+ *   b-1. box (b) has THREE separated ink bands (base / ruby / label).
+ *   b-2. the ruby band clears the label band by ≥ 2 pt (no overprint).
+ *
+ * CI-safe: gated on docx WASM + skia-canvas + the PRIVATE sample + a macOS JP
+ * font; skips when any is absent (never hard-fails for the private file).
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { installImageBitmapShim, installOffscreenCanvasShim } from './render.ts';
+import type { NodeCanvasFactory } from './render.ts';
+import { importForTests, loadSkiaForTests } from './test-imports';
+
+const skia = await loadSkiaForTests();
+type Skia = typeof import('skia-canvas');
+const { Canvas, FontLibrary } = (skia ?? {}) as Skia;
+const docxMod = await importForTests(() => import('./docx.ts'), './docx.ts (docx WASM)');
+const rendererMod = await importForTests(
+  () => import('./../../docx/src/renderer.ts'),
+  'packages/docx/src/renderer.ts',
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+const SAMPLE = fileURLToPath(
+  new URL('../../docx/public/private/sample-53.docx', import.meta.url),
+);
+const MINCHO = '/System/Library/Fonts/ヒラギノ明朝 ProN.ttc';
+const havePrereqs = existsSync(SAMPLE) && existsSync(MINCHO);
+
+const factory: NodeCanvasFactory = {
+  createCanvas: (w, h) =>
+    new Canvas(w, h) as unknown as ReturnType<NodeCanvasFactory['createCanvas']>,
+  loadImage: (() => {
+    throw new Error('loadImage not needed');
+  }) as unknown as NodeCanvasFactory['loadImage'],
+};
+
+/** Contiguous x-ranges holding dark text ink inside [x0,x1) × [y0,y1). */
+function inkBands(
+  data: Uint8ClampedArray,
+  W: number,
+  x0: number,
+  x1: number,
+  y0: number,
+  y1: number,
+): Array<{ start: number; end: number }> {
+  const bands: Array<{ start: number; end: number }> = [];
+  let cur: { start: number; end: number } | null = null;
+  for (let x = x0; x < x1; x++) {
+    let ink = 0;
+    for (let y = y0; y < y1; y++) {
+      const i = (y * W + x) * 4;
+      const lum = 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+      if (lum < 150) ink++;
+    }
+    if (ink > 0) {
+      if (cur && x - cur.end <= 3) cur.end = x;
+      else bands.push((cur = { start: x, end: x }));
+    }
+  }
+  return bands;
+}
+
+describe.skipIf(!skia || !docxMod || !rendererMod || !havePrereqs)(
+  'docx vertical textbox cross-axis spacing (sample-53: mongolianVert inset+mirror, eaVert ruby reservation)',
+  () => {
+    it('places the mongolian first column inside lIns and separates base/ruby/label bands', async () => {
+      for (const fam of ['Yu Mincho', 'YuMincho', 'Hiragino Mincho ProN', 'MS Mincho', 'Noto Serif JP']) {
+        FontLibrary.use(fam, [MINCHO]);
+      }
+      const { parseDocx } = docxMod as { parseDocx: (b: Uint8Array) => Any };
+      const { renderDocumentToCanvas } = rendererMod as Any;
+      const doc = parseDocx(readFileSync(SAMPLE));
+      const W = Math.round(doc.section.pageWidth);
+      const H = Math.round(doc.section.pageHeight);
+      const canvas = new Canvas(W, H);
+      const rImg = installImageBitmapShim(factory);
+      const rOff = installOffscreenCanvasShim(factory);
+      try {
+        await renderDocumentToCanvas(doc, canvas as Any, 0, {
+          dpr: 1,
+          width: doc.section.pageWidth,
+        });
+      } finally {
+        rOff();
+        rImg();
+      }
+      const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
+      const { data } = ctx.getImageData(0, 0, W, H);
+
+      // box (a) mongolianVert x ∈ [28.8, 144]: interior scan (skip the border).
+      const a = inkBands(data, W, 30, 143, 80, 550);
+      expect(a.length, `box(a) ink bands ${JSON.stringify(a)}`).toBeGreaterThanOrEqual(2);
+      // a-1: no trespass over the lIns content edge (28.8 + 7.2 = 36; −1 for AA fringe).
+      expect(a[0].start, `box(a) first ink ${a[0].start} respects lIns edge 36`).toBeGreaterThanOrEqual(35);
+      // a-2: still starts near the edge (Word ink @39; Hiragino metrics shift a few pt).
+      expect(a[0].start, `box(a) first ink ${a[0].start} stays near the edge`).toBeLessThan(48);
+
+      // box (b) eaVert + ruby x ∈ [172.8, 288]: THREE separated bands.
+      const b = inkBands(data, W, 174, 287, 80, 550);
+      expect(b.length, `box(b) ink bands ${JSON.stringify(b)}`).toBe(3);
+      const [, ruby, label] = b;
+      // b-2: furigana clears the label column (the bug overprinted it).
+      expect(label.start - ruby.end, `ruby→label gap ${label.start - ruby.end}`).toBeGreaterThanOrEqual(2);
+    }, 120000);
+  },
+);


### PR DESCRIPTION
## Problem

Two cross-axis (column-stacking) spacing bugs in vertical text boxes (`<wps:bodyPr vert>`), found against Word PDF ground truth on a local vertical-textbox fixture:

1. **eaVert + ruby overprint** — `layoutLines()` reserves extra ascent for a ruby-bearing line (rt size × 1.5), but the textbox line resolvers (`renderShapeText` `lineMetricsFor` and `measureShapeTextAutoFitHeight`) re-measured `'Mg'` and discarded it. `lineBoxHeight()` only honors `hasRuby` inside the docGrid branch, so off-grid textbox columns never widened and the furigana — painted on the physical right of its base column per §17.3.3.25 — overprinted the previous column.
2. **mongolianVert left inset + mirror** (§20.1.10.83, columns L→R) — the cross-stack reflection (`flipBlockTop`) landed the first column at the physical `bIns` instead of `lIns` (§21.1.2.1.1 names insets by physical bounding-rectangle edge; `lIns` default 91440 EMU = 7.2 pt), and the line centerline was not mirrored within its band, so ascent-heavy fonts pushed ink left of the `lIns` content edge. Word's mongolianVert first column mirrors the eaVert twin exactly (flow-start-edge → glyph-box gap preserved within 0.5 pt in the PDF ground truth).

## Fix

- `verticalRubyLineMetrics()` — vertical ruby lines take their column extent and centerline from the `LayoutLine` ascent/descent (which already carry the layout-time reservation), gated on `vmode && line.hasRuby`, in both draw and autofit. No new constants; the existing rt × 1.5 reservation moved behind `rubyAscentReservePx()` in line-layout and is now shared.
- `flipBlockTop` re-homes the reflected stack by `+ bIns − lIns` so the first column starts at the physical LEFT inset, and the draw site mirrors the per-line centerline (`lineH − baselineOffset`), keeping the ruby reservation on the band-interior side so a mongolian ruby line neither moves its base column nor overprints the next one.

## Verification

- Real-Chromium fixture render vs the Word PDF (pt = px at 72 dpi): mongolianVert label column ink within 1 pt of Word and the 15 pt body column ink exactly matching; the eaVert ruby box renders three separated bands (base / ruby / label) like Word instead of the furigana merging into the label column. All other text boxes and the rest of the page byte-identical before/after (pixel diff).
- New font-independent unit tests (5) pin: ruby column advance widening, autofit widening, `lIns` ownership of the mongolian first-column origin, the mirrored centerline, and the mongolian ruby geometry. A skip-gated headless probe covers the private fixture end to end.
- `packages/docx` vitest 1403/1403, root `pnpm typecheck`, docx VRT 85/85 (demo non-regressed; private baselines matched, references untouched).
- Independent read-only review (separate Codex session) — its blocker (mongolianVert × ruby mirroring the reservation away from the painted ruby) and nits (comment accuracy, duplicated LineSpacing construction) are addressed in this diff.

## Known follow-up

Word spaces the ruby-bearing column by `w:hpsRaise` (§17.3.3) while the shared reservation is a flat rt × 1.5; on the fixture this leaves the base/ruby cluster ~3.75 pt right of Word (gap 4 pt vs 8 pt), with no overlap. Honoring `hpsRaise` needs parser/model plumbing across the body and textbox ruby paths and re-validation of the body-path samples, so it is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)