### PR TITLE
fix: render vertical ー 〜 ～ with real 'vert' glyphs; de-slant the geometric fallback

### DIFF
--- a/packages/core/src/canvas/aux-canvas.ts
+++ b/packages/core/src/canvas/aux-canvas.ts
@@ -13,6 +13,11 @@
 export type AuxCanvas = HTMLCanvasElement | OffscreenCanvas;
 /** The 2D context type of an {@link AuxCanvas}. */
 export type AuxContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+type SourceContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+function dimensions(w: number, h: number): [number, number] {
+  return [Math.max(1, Math.ceil(w)), Math.max(1, Math.ceil(h))];
+}
 
 /**
  * Allocate an auxiliary canvas. Prefers OffscreenCanvas (no DOM pollution, works
@@ -21,8 +26,7 @@ export type AuxContext = CanvasRenderingContext2D | OffscreenCanvasRenderingCont
  * Dimensions are clamped to >=1 to avoid zero-size canvas errors.
  */
 export function createAuxCanvas(w: number, h: number): AuxCanvas | null {
-  const cw = Math.max(1, Math.ceil(w));
-  const ch = Math.max(1, Math.ceil(h));
+  const [cw, ch] = dimensions(w, h);
   if (typeof OffscreenCanvas !== 'undefined') {
     return new OffscreenCanvas(cw, ch);
   }
@@ -33,4 +37,44 @@ export function createAuxCanvas(w: number, h: number): AuxCanvas | null {
     return c;
   }
   return null;
+}
+
+/**
+ * Allocate a scratch canvas for a specific live context. The final constructor
+ * fallback supports Canvas-compatible node implementations such as skia-canvas;
+ * it intentionally runs after browser/worker strategies because constructing an
+ * HTMLCanvasElement directly throws. Every strategy is isolated so draw callers
+ * can safely degrade when allocation is unavailable.
+ */
+export function createAuxCanvasForContext(
+  ctx: SourceContext,
+  w: number,
+  h: number,
+): AuxCanvas | null {
+  const [cw, ch] = dimensions(w, h);
+  if (typeof OffscreenCanvas !== 'undefined') {
+    try {
+      return new OffscreenCanvas(cw, ch);
+    } catch {
+      // Continue to the DOM canvas strategy.
+    }
+  }
+  if (typeof document !== 'undefined') {
+    try {
+      const canvas = document.createElement('canvas');
+      canvas.width = cw;
+      canvas.height = ch;
+      return canvas;
+    } catch {
+      // Continue to the context-compatible constructor strategy.
+    }
+  }
+  try {
+    const constructor = ctx.canvas?.constructor;
+    if (typeof constructor !== 'function') return null;
+    const CanvasConstructor = constructor as new (width: number, height: number) => AuxCanvas;
+    return new CanvasConstructor(cw, ch);
+  } catch {
+    return null;
+  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -402,6 +402,10 @@ export {
   VO_UNICODE_VERSION,
 } from './text/vertical-orientation';
 export type { VerticalOrientation } from './text/vertical-orientation';
+export {
+  verticalVertFeatureSupported,
+  withVertFeature,
+} from './text/vertical-vert-feature';
 // Shared Excel serial-date → UTC `Date` conversion (ECMA-376 §18.17.4.1),
 // with the 1900 Lotus leap-year-bug compat and 1900/1904 date-system select.
 // Used by the xlsx cell formatter and the core chart date formatter.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -406,6 +406,10 @@ export {
   verticalVertFeatureSupported,
   withVertFeature,
 } from './text/vertical-vert-feature';
+export {
+  verticalFallbackShearCoefficient,
+  verticalFallbackShearEnabled,
+} from './text/vertical-fallback-shear';
 // Shared Excel serial-date → UTC `Date` conversion (ECMA-376 §18.17.4.1),
 // with the 1900 Lotus leap-year-bug compat and 1900/1904 date-system select.
 // Used by the xlsx cell formatter and the core chart date formatter.

--- a/packages/core/src/shape/effects.test.ts
+++ b/packages/core/src/shape/effects.test.ts
@@ -5,6 +5,7 @@ import {
   applyReflection,
   createAuxCanvas,
 } from './effects';
+import { createAuxCanvasForContext } from '../canvas/aux-canvas';
 import type { Shadow, SoftEdge, Reflection } from '../types/common';
 
 /**
@@ -95,6 +96,29 @@ describe('createAuxCanvas', () => {
     vi.stubGlobal('OffscreenCanvas', undefined);
     vi.stubGlobal('document', undefined);
     expect(createAuxCanvas(10, 10)).toBeNull();
+  });
+
+  it('uses the live context canvas constructor last in a headless skia-like environment', () => {
+    vi.stubGlobal('OffscreenCanvas', undefined);
+    vi.stubGlobal('document', undefined);
+    class SkiaLikeCanvas {
+      constructor(public width: number, public height: number) {}
+    }
+    const ctx = { canvas: new SkiaLikeCanvas(20, 20) } as unknown as CanvasRenderingContext2D;
+
+    const aux = createAuxCanvasForContext(ctx, 10.1, 0) as unknown as SkiaLikeCanvas;
+
+    expect(aux).toBeInstanceOf(SkiaLikeCanvas);
+    expect([aux.width, aux.height]).toEqual([11, 1]);
+  });
+
+  it('returns null when every ctx-aware allocation strategy throws', () => {
+    vi.stubGlobal('OffscreenCanvas', class { constructor() { throw new Error('offscreen'); } });
+    vi.stubGlobal('document', { createElement: () => { throw new Error('dom'); } });
+    class BrokenCanvas { constructor() { throw new Error('constructor'); } }
+    const ctx = { canvas: Object.create(BrokenCanvas.prototype) } as unknown as CanvasRenderingContext2D;
+
+    expect(createAuxCanvasForContext(ctx, 10, 10)).toBeNull();
   });
 });
 

--- a/packages/core/src/text/vertical-fallback-shear.test.ts
+++ b/packages/core/src/text/vertical-fallback-shear.test.ts
@@ -139,4 +139,25 @@ describe('non-vert prolonged-mark fallback shear', () => {
     expect(verticalFallbackShearCoefficient(ctx, 0x30fc)).toBeCloseTo(0.125, 2);
     expect(reads).toBe(2);
   });
+
+  it('scopes non-DOM cache reuse to the source canvas surface', () => {
+    vi.stubGlobal('OffscreenCanvas', undefined);
+    vi.stubGlobal('document', undefined);
+    let reads = 0;
+    const Canvas = rasterCanvas(0.125, () => { reads += 1; });
+    const first = {
+      canvas: new Canvas(10, 10),
+      font: '16px "Surface Mincho", serif',
+    } as unknown as CanvasRenderingContext2D;
+    const second = {
+      canvas: new Canvas(10, 10),
+      font: '16px "Surface Mincho", serif',
+    } as unknown as CanvasRenderingContext2D;
+
+    expect(verticalFallbackShearCoefficient(first, 0x30fc)).toBeCloseTo(0.125, 2);
+    expect(verticalFallbackShearCoefficient(first, 0x30fc)).toBeCloseTo(0.125, 2);
+    expect(reads).toBe(1);
+    expect(verticalFallbackShearCoefficient(second, 0x30fc)).toBeCloseTo(0.125, 2);
+    expect(reads).toBe(2);
+  });
 });

--- a/packages/core/src/text/vertical-fallback-shear.test.ts
+++ b/packages/core/src/text/vertical-fallback-shear.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  verticalFallbackShearCoefficient,
+  verticalFallbackShearEnabled,
+} from './vertical-fallback-shear.js';
+
+type Listener = () => void;
+
+function rasterCanvas(slope: number, onRead?: () => void) {
+  return class RasterCanvas {
+    width: number;
+    height: number;
+    constructor(width: number, height: number) {
+      this.width = width;
+      this.height = height;
+    }
+    getContext(): CanvasRenderingContext2D {
+      const canvas = this;
+      return {
+        canvas,
+        font: '',
+        fillStyle: '#000',
+        textAlign: 'center',
+        textBaseline: 'middle',
+        clearRect() {},
+        fillText() {},
+        getImageData() {
+          onRead?.();
+          const data = new Uint8ClampedArray(canvas.width * canvas.height * 4);
+          const x0 = Math.floor(canvas.width / 4);
+          const x1 = Math.floor(canvas.width * 3 / 4);
+          for (let x = x0; x <= x1; x++) {
+            const center = canvas.height / 2 + slope * (x - canvas.width / 2);
+            const y = Math.floor(center);
+            const fraction = center - y;
+            data[(y * canvas.width + x) * 4 + 3] = Math.round(255 * (1 - fraction));
+            data[((y + 1) * canvas.width + x) * 4 + 3] = Math.round(255 * fraction);
+          }
+          // A damaged terminal column must not steer the robust all-column fit.
+          data[((canvas.height - 2) * canvas.width + x0) * 4 + 3] = 255;
+          return { data } as ImageData;
+        },
+      } as unknown as CanvasRenderingContext2D;
+    }
+  };
+}
+
+describe('non-vert prolonged-mark fallback shear', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('classifies U+30FC only, leaving both wave marks unchanged', () => {
+    expect(verticalFallbackShearEnabled(0x30fc)).toBe(true);
+    expect(verticalFallbackShearEnabled(0x301c)).toBe(false);
+    expect(verticalFallbackShearEnabled(0xff5e)).toBe(false);
+    expect(verticalFallbackShearEnabled(0x3030)).toBe(false);
+  });
+
+  it('measures an all-column alpha-centroid slope with robust Theil-Sen regression', () => {
+    vi.stubGlobal('OffscreenCanvas', undefined);
+    vi.stubGlobal('document', undefined);
+    const Canvas = rasterCanvas(0.25);
+    const ctx = {
+      canvas: new Canvas(10, 10),
+      font: 'italic 600 17px "Probe Mincho", serif',
+    } as unknown as CanvasRenderingContext2D;
+
+    expect(verticalFallbackShearCoefficient(ctx, 0x30fc)).toBeCloseTo(0.25, 2);
+  });
+
+  it('returns zero without allocating for wave marks and on readback failure', () => {
+    vi.stubGlobal('OffscreenCanvas', undefined);
+    vi.stubGlobal('document', undefined);
+    let constructions = 0;
+    class BrokenCanvas {
+      constructor(_width: number, _height: number) { constructions += 1; }
+      getContext() { throw new Error('readback unavailable'); }
+    }
+    const ctx = {
+      canvas: Object.create(BrokenCanvas.prototype),
+      font: '16px Failure Mincho',
+    } as unknown as CanvasRenderingContext2D;
+
+    expect(verticalFallbackShearCoefficient(ctx, 0x301c)).toBe(0);
+    expect(constructions).toBe(0);
+    expect(verticalFallbackShearCoefficient(ctx, 0x30fc)).toBe(0);
+    expect(constructions).toBe(1);
+  });
+
+  it('returns zero when the raster has no ink or fewer than two ink columns', () => {
+    vi.stubGlobal('OffscreenCanvas', undefined);
+    vi.stubGlobal('document', undefined);
+    function coefficient(columns: number): number {
+      class SparseCanvas {
+        constructor(public width: number, public height: number) {}
+        getContext() {
+          const canvas = this;
+          return {
+            canvas, font: '', fillStyle: '#000', textAlign: 'center', textBaseline: 'middle',
+            clearRect() {}, fillText() {},
+            getImageData() {
+              const data = new Uint8ClampedArray(canvas.width * canvas.height * 4);
+              for (let x = 0; x < columns; x++) data[((256 * canvas.width + x) * 4) + 3] = 255;
+              return { data };
+            },
+          };
+        }
+      }
+      const ctx = { canvas: new SparseCanvas(1, 1), font: `16px Sparse${columns}` } as unknown as CanvasRenderingContext2D;
+      return verticalFallbackShearCoefficient(ctx, 0x30fc);
+    }
+
+    expect(coefficient(0)).toBe(0);
+    expect(coefficient(1)).toBe(0);
+  });
+
+  it('caches by size-independent font identity and remeasures after a FontFace epoch', () => {
+    vi.stubGlobal('OffscreenCanvas', undefined);
+    const listeners = new Map<string, Listener>();
+    let reads = 0;
+    const Canvas = rasterCanvas(0.125, () => { reads += 1; });
+    const fonts = {
+      addEventListener: (name: string, listener: Listener) => listeners.set(name, listener),
+    };
+    const document = {
+      fonts,
+      createElement: () => new Canvas(1, 1),
+    };
+    vi.stubGlobal('document', document);
+    const ctx = {
+      canvas: { ownerDocument: document },
+      font: 'normal 400 16px "Epoch Mincho", serif',
+    } as unknown as CanvasRenderingContext2D;
+
+    expect(verticalFallbackShearCoefficient(ctx, 0x30fc)).toBeCloseTo(0.125, 2);
+    ctx.font = 'normal 400 48px "Epoch Mincho", serif';
+    expect(verticalFallbackShearCoefficient(ctx, 0x30fc)).toBeCloseTo(0.125, 2);
+    expect(reads).toBe(1);
+    listeners.get('loadingdone')?.();
+    expect(verticalFallbackShearCoefficient(ctx, 0x30fc)).toBeCloseTo(0.125, 2);
+    expect(reads).toBe(2);
+  });
+});

--- a/packages/core/src/text/vertical-fallback-shear.ts
+++ b/packages/core/src/text/vertical-fallback-shear.ts
@@ -19,7 +19,7 @@ const PROLONGED_SOUND_MARK = 0x30fc;
 const RASTER_SIZE_PX = 512;
 const RASTER_FONT_PX = 384;
 const documentStates = new WeakMap<object, CacheState>();
-const constructorStates = new WeakMap<object, CacheState>();
+const surfaceStates = new WeakMap<object, CacheState>();
 const fallbackState: CacheState = { cache: new Map(), epoch: 0 };
 
 function replaceFontSize(font: string, replacement: string): string {
@@ -51,12 +51,12 @@ function cacheState(ctx: Ctx2D): CacheState {
     return state;
   }
 
-  const constructor = ctx.canvas?.constructor;
-  if (typeof constructor === 'function') {
-    const existing = constructorStates.get(constructor);
+  const surface = ctx.canvas;
+  if (surface !== null && (typeof surface === 'object' || typeof surface === 'function')) {
+    const existing = surfaceStates.get(surface);
     if (existing) return existing;
     const state: CacheState = { cache: new Map(), epoch: 0 };
-    constructorStates.set(constructor, state);
+    surfaceStates.set(surface, state);
     return state;
   }
   return fallbackState;
@@ -115,8 +115,10 @@ export function verticalFallbackShearEnabled(cp: number): boolean {
 
 /**
  * Runtime-measured horizontal-glyph slope used by the non-`vert` mirror fallback.
- * A FontFace completion advances the cache epoch. Any allocation, paint, or
- * readback failure returns and caches zero, preserving the prior fallback.
+ * DOM results follow the document FontFace epoch; worker/Node results are cached
+ * only on the source canvas surface, so a new surface remeasures after host-side
+ * font registration. Any allocation, paint, or readback failure returns and
+ * caches zero, preserving the prior fallback.
  */
 export function verticalFallbackShearCoefficient(ctx: Ctx2D, cp: number): number {
   if (!verticalFallbackShearEnabled(cp)) return 0;

--- a/packages/core/src/text/vertical-fallback-shear.ts
+++ b/packages/core/src/text/vertical-fallback-shear.ts
@@ -1,0 +1,136 @@
+import { createAuxCanvasForContext } from '../canvas/aux-canvas.js';
+
+type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+interface CacheState {
+  cache: Map<string, number>;
+  epoch: number;
+}
+
+interface FontSetLike {
+  addEventListener?: (name: string, listener: () => void) => void;
+}
+
+interface DocumentLike {
+  fonts?: FontSetLike;
+}
+
+const PROLONGED_SOUND_MARK = 0x30fc;
+const RASTER_SIZE_PX = 512;
+const RASTER_FONT_PX = 384;
+const documentStates = new WeakMap<object, CacheState>();
+const constructorStates = new WeakMap<object, CacheState>();
+const fallbackState: CacheState = { cache: new Map(), epoch: 0 };
+
+function replaceFontSize(font: string, replacement: string): string {
+  return font.replace(
+    /(^|\s)\d*\.?\d+(?:px|pt|pc|in|cm|mm|q|em|rem|%)(?:\/[^\s]+)?(?=\s)/i,
+    `$1${replacement}`,
+  );
+}
+
+function sourceDocument(ctx: Ctx2D): DocumentLike | null {
+  const canvas = ctx.canvas as { ownerDocument?: DocumentLike };
+  if (canvas.ownerDocument) return canvas.ownerDocument;
+  return typeof document !== 'undefined' ? document : null;
+}
+
+function cacheState(ctx: Ctx2D): CacheState {
+  const doc = sourceDocument(ctx);
+  if (doc !== null && typeof doc === 'object') {
+    const existing = documentStates.get(doc);
+    if (existing) return existing;
+    const state: CacheState = { cache: new Map(), epoch: 0 };
+    const invalidate = () => {
+      state.epoch += 1;
+      state.cache.clear();
+    };
+    doc.fonts?.addEventListener?.('loadingdone', invalidate);
+    doc.fonts?.addEventListener?.('loadingerror', invalidate);
+    documentStates.set(doc, state);
+    return state;
+  }
+
+  const constructor = ctx.canvas?.constructor;
+  if (typeof constructor === 'function') {
+    const existing = constructorStates.get(constructor);
+    if (existing) return existing;
+    const state: CacheState = { cache: new Map(), epoch: 0 };
+    constructorStates.set(constructor, state);
+    return state;
+  }
+  return fallbackState;
+}
+
+function median(values: number[]): number {
+  values.sort((a, b) => a - b);
+  const middle = Math.floor(values.length / 2);
+  return values.length % 2 === 0
+    ? (values[middle - 1] + values[middle]) / 2
+    : values[middle];
+}
+
+function measureSlope(ctx: Ctx2D): number {
+  const canvas = createAuxCanvasForContext(ctx, RASTER_SIZE_PX, RASTER_SIZE_PX);
+  if (canvas === null) return 0;
+  const scratch = canvas.getContext('2d', { willReadFrequently: true }) as
+    | CanvasRenderingContext2D
+    | OffscreenCanvasRenderingContext2D
+    | null;
+  if (scratch === null) return 0;
+
+  scratch.clearRect(0, 0, RASTER_SIZE_PX, RASTER_SIZE_PX);
+  scratch.font = replaceFontSize(ctx.font, `${RASTER_FONT_PX}px`);
+  scratch.fillStyle = '#000';
+  scratch.textAlign = 'center';
+  scratch.textBaseline = 'middle';
+  scratch.fillText('ー', RASTER_SIZE_PX / 2, RASTER_SIZE_PX / 2);
+  const data = scratch.getImageData(0, 0, RASTER_SIZE_PX, RASTER_SIZE_PX).data;
+  const centroids: Array<{ x: number; y: number }> = [];
+  for (let x = 0; x < RASTER_SIZE_PX; x += 1) {
+    let alphaSum = 0;
+    let weightedY = 0;
+    for (let y = 0; y < RASTER_SIZE_PX; y += 1) {
+      const alpha = data[(y * RASTER_SIZE_PX + x) * 4 + 3];
+      alphaSum += alpha;
+      weightedY += y * alpha;
+    }
+    if (alphaSum > 0) centroids.push({ x, y: weightedY / alphaSum });
+  }
+  if (centroids.length < 2) return 0;
+
+  const slopes: number[] = [];
+  for (let i = 0; i < centroids.length; i += 1) {
+    for (let j = i + 1; j < centroids.length; j += 1) {
+      slopes.push((centroids[j].y - centroids[i].y) / (centroids[j].x - centroids[i].x));
+    }
+  }
+  return slopes.length > 0 ? median(slopes) : 0;
+}
+
+/** Only U+30FC is straightened; the two wave marks retain their designed drift. */
+export function verticalFallbackShearEnabled(cp: number): boolean {
+  return cp === PROLONGED_SOUND_MARK;
+}
+
+/**
+ * Runtime-measured horizontal-glyph slope used by the non-`vert` mirror fallback.
+ * A FontFace completion advances the cache epoch. Any allocation, paint, or
+ * readback failure returns and caches zero, preserving the prior fallback.
+ */
+export function verticalFallbackShearCoefficient(ctx: Ctx2D, cp: number): number {
+  if (!verticalFallbackShearEnabled(cp)) return 0;
+  const state = cacheState(ctx);
+  const key = `${state.epoch}:${replaceFontSize(ctx.font, '<size>')}:${cp}`;
+  const cached = state.cache.get(key);
+  if (cached !== undefined) return cached;
+  let coefficient = 0;
+  try {
+    coefficient = measureSlope(ctx);
+    if (!Number.isFinite(coefficient)) coefficient = 0;
+  } catch {
+    coefficient = 0;
+  }
+  state.cache.set(key, coefficient);
+  return coefficient;
+}

--- a/packages/core/src/text/vertical-vert-feature.test.ts
+++ b/packages/core/src/text/vertical-vert-feature.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  verticalVertFeatureSupported,
+  withVertFeature,
+} from './vertical-vert-feature.js';
+
+describe('vertical OpenType vert feature', () => {
+  it('reports unsupported for a context whose canvas has no element style', () => {
+    const ctx = {
+      canvas: { width: 1, height: 1 },
+      font: '16px serif',
+    } as unknown as OffscreenCanvasRenderingContext2D;
+
+    expect(verticalVertFeatureSupported(ctx)).toBe(false);
+  });
+
+  it('sets the canvas feature before refonting and restores both after drawing', () => {
+    const events: string[] = [];
+    let font = 'italic 700 16px "Hiragino Mincho ProN"';
+    let feature = '"kern" 1';
+    const style = {
+      get fontFeatureSettings() {
+        return feature;
+      },
+      set fontFeatureSettings(value: string) {
+        feature = value;
+        events.push(`feature:${value}`);
+      },
+    };
+    const ctx = {
+      canvas: { style },
+      get font() {
+        return font;
+      },
+      set font(value: string) {
+        font = value;
+        events.push(`font:${value}`);
+      },
+    } as unknown as CanvasRenderingContext2D;
+
+    const result = withVertFeature(ctx, () => {
+      events.push(`draw:${style.fontFeatureSettings}`);
+      return 47;
+    });
+
+    expect(result).toBe(47);
+    expect(events).toEqual([
+      'feature:"vert" 1',
+      'font:italic 700 16px "Hiragino Mincho ProN"',
+      'draw:"vert" 1',
+      'feature:"kern" 1',
+      'font:italic 700 16px "Hiragino Mincho ProN"',
+    ]);
+  });
+
+  it('restores the prior feature and refonts when drawing throws', () => {
+    let fontAssignments = 0;
+    let font = '16px serif';
+    const style = { fontFeatureSettings: '' };
+    const ctx = {
+      canvas: { style },
+      get font() {
+        return font;
+      },
+      set font(value: string) {
+        font = value;
+        fontAssignments += 1;
+      },
+    } as unknown as CanvasRenderingContext2D;
+
+    expect(() =>
+      withVertFeature(ctx, () => {
+        throw new Error('paint failed');
+      }),
+    ).toThrow('paint failed');
+    expect(style.fontFeatureSettings).toBe('');
+    expect(fontAssignments).toBe(2);
+  });
+});

--- a/packages/core/src/text/vertical-vert-feature.test.ts
+++ b/packages/core/src/text/vertical-vert-feature.test.ts
@@ -1,17 +1,153 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   verticalVertFeatureSupported,
   withVertFeature,
 } from './vertical-vert-feature.js';
 
+type Listener = () => void;
+
+interface ProbeFixture {
+  ctx: CanvasRenderingContext2D;
+  featuresAtPaint: string[];
+  fontAssignments: () => number;
+  paints: () => number;
+  listeners: Map<string, Listener>;
+  supported: Set<number>;
+}
+
+function fakeHtmlCanvasProbe(initialFeature = 'normal'): ProbeFixture {
+  const listeners = new Map<string, Listener>();
+  const supported = new Set<number>();
+  const featuresAtPaint: string[] = [];
+  let paints = 0;
+  let fontAssignments = 0;
+
+  class FakeCanvas {
+    width = 1;
+    height = 1;
+    isConnected = false;
+    ownerDocument: typeof document;
+    style = { fontFeatureSettings: initialFeature };
+    private context: CanvasRenderingContext2D | null = null;
+
+    constructor(ownerDocument: typeof document) {
+      this.ownerDocument = ownerDocument;
+    }
+
+    setAttribute() {}
+    remove() { this.isConnected = false; }
+
+    getContext(): CanvasRenderingContext2D {
+      if (this.context !== null) return this.context;
+      const canvas = this;
+      let font = '';
+      let resolvedFeature = canvas.style.fontFeatureSettings;
+      let drawnCp = 0;
+      this.context = {
+        canvas,
+        get font() { return font; },
+        set font(value: string) {
+          font = value;
+          resolvedFeature = canvas.style.fontFeatureSettings;
+          fontAssignments += 1;
+        },
+        fillStyle: '#000',
+        textAlign: 'center',
+        textBaseline: 'middle',
+        clearRect() {},
+        fillText(text: string) {
+          drawnCp = text.codePointAt(0) ?? 0;
+          featuresAtPaint.push(resolvedFeature);
+          paints += 1;
+        },
+        getImageData() {
+          const data = new Uint8ClampedArray(canvas.width * canvas.height * 4);
+          const vert = resolvedFeature.includes('"vert" 1') && supported.has(drawnCp);
+          const inkWidth = vert ? 3 : 9;
+          const inkHeight = vert ? 9 : 3;
+          for (let y = 0; y < inkHeight; y += 1) {
+            for (let x = 0; x < inkWidth; x += 1) {
+              data[(y * canvas.width + x) * 4 + 3] = 255;
+            }
+          }
+          return { data } as ImageData;
+        },
+      } as unknown as CanvasRenderingContext2D;
+      return this.context;
+    }
+  }
+
+  const parent = {
+    appendChild(canvas: FakeCanvas) { canvas.isConnected = true; },
+  };
+  const fakeDocument = {
+    body: parent,
+    documentElement: parent,
+    fonts: {
+      addEventListener(name: string, listener: Listener) { listeners.set(name, listener); },
+    },
+    createElement: () => new FakeCanvas(fakeDocument as unknown as Document),
+  } as unknown as Document;
+  vi.stubGlobal('HTMLCanvasElement', FakeCanvas);
+  vi.stubGlobal('document', fakeDocument);
+
+  const canvas = new FakeCanvas(fakeDocument);
+  let sourceFont = '16px "Probe Mincho", serif';
+  const ctx = {
+    canvas,
+    get font() { return sourceFont; },
+    set font(value: string) { sourceFont = value; },
+  } as unknown as CanvasRenderingContext2D;
+  return {
+    ctx,
+    featuresAtPaint,
+    fontAssignments: () => fontAssignments,
+    paints: () => paints,
+    listeners,
+    supported,
+  };
+}
+
 describe('vertical OpenType vert feature', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
   it('reports unsupported for a context whose canvas has no element style', () => {
     const ctx = {
       canvas: { width: 1, height: 1 },
       font: '16px serif',
     } as unknown as OffscreenCanvasRenderingContext2D;
 
-    expect(verticalVertFeatureSupported(ctx)).toBe(false);
+    expect(verticalVertFeatureSupported(ctx, 0x30fc)).toBe(false);
+  });
+
+  it('probes the requested glyph, refonts after each feature change, and caches per code point', () => {
+    const fixture = fakeHtmlCanvasProbe('"kern" 1, "ss01" 1');
+    fixture.supported.add(0x30fc);
+
+    expect(verticalVertFeatureSupported(fixture.ctx, 0x30fc)).toBe(true);
+    expect(fixture.featuresAtPaint).toEqual([
+      '"kern" 1, "ss01" 1',
+      '"kern" 1, "ss01" 1, "vert" 1',
+    ]);
+    expect(fixture.fontAssignments()).toBeGreaterThanOrEqual(3);
+    expect(verticalVertFeatureSupported(fixture.ctx, 0x30fc)).toBe(true);
+    expect(fixture.paints()).toBe(2);
+
+    expect(verticalVertFeatureSupported(fixture.ctx, 0x301c)).toBe(false);
+    expect(fixture.paints()).toBe(4);
+  });
+
+  it('invalidates each glyph result after the FontFace epoch changes', () => {
+    const fixture = fakeHtmlCanvasProbe();
+
+    expect(verticalVertFeatureSupported(fixture.ctx, 0xff5e)).toBe(false);
+    fixture.supported.add(0xff5e);
+    expect(verticalVertFeatureSupported(fixture.ctx, 0xff5e)).toBe(false);
+    expect(fixture.paints()).toBe(2);
+
+    fixture.listeners.get('loadingdone')?.();
+    expect(verticalVertFeatureSupported(fixture.ctx, 0xff5e)).toBe(true);
+    expect(fixture.paints()).toBe(4);
   });
 
   it('sets the canvas feature before refonting and restores both after drawing', () => {
@@ -45,9 +181,9 @@ describe('vertical OpenType vert feature', () => {
 
     expect(result).toBe(47);
     expect(events).toEqual([
-      'feature:"vert" 1',
+      'feature:"kern" 1, "vert" 1',
       'font:italic 700 16px "Hiragino Mincho ProN"',
-      'draw:"vert" 1',
+      'draw:"kern" 1, "vert" 1',
       'feature:"kern" 1',
       'font:italic 700 16px "Hiragino Mincho ProN"',
     ]);

--- a/packages/core/src/text/vertical-vert-feature.ts
+++ b/packages/core/src/text/vertical-vert-feature.ts
@@ -1,0 +1,147 @@
+type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+interface ProbeState {
+  canvas: HTMLCanvasElement;
+  cache: Map<string, boolean>;
+  epoch: number;
+}
+
+const PROBE_SIZE_PX = 256;
+const PROBE_FONT_PX = 200;
+const probeStates = new WeakMap<Document, ProbeState>();
+
+function canvasElementFor(ctx: Ctx2D): HTMLCanvasElement | null {
+  if (typeof HTMLCanvasElement === 'undefined') return null;
+  return ctx.canvas instanceof HTMLCanvasElement ? ctx.canvas : null;
+}
+
+function replaceFontSize(font: string, replacement: string): string {
+  return font.replace(
+    /(^|\s)\d*\.?\d+(?:px|pt|pc|in|cm|mm|q|em|rem|%)(?:\/[^\s]+)?(?=\s)/i,
+    `$1${replacement}`,
+  );
+}
+
+function probeState(doc: Document): ProbeState {
+  const existing = probeStates.get(doc);
+  if (existing) return existing;
+
+  const canvas = doc.createElement('canvas');
+  canvas.width = PROBE_SIZE_PX;
+  canvas.height = PROBE_SIZE_PX;
+  canvas.setAttribute('aria-hidden', 'true');
+  Object.assign(canvas.style, {
+    position: 'fixed',
+    left: '-99999px',
+    top: '0',
+    opacity: '0',
+    pointerEvents: 'none',
+  });
+  const state: ProbeState = { canvas, cache: new Map(), epoch: 0 };
+  const invalidate = () => {
+    state.epoch += 1;
+    state.cache.clear();
+  };
+  doc.fonts?.addEventListener?.('loadingdone', invalidate);
+  doc.fonts?.addEventListener?.('loadingerror', invalidate);
+  probeStates.set(doc, state);
+  return state;
+}
+
+function inkBounds(ctx: CanvasRenderingContext2D): { width: number; height: number } | null {
+  const { width, height } = ctx.canvas;
+  const data = ctx.getImageData(0, 0, width, height).data;
+  let minX = width;
+  let minY = height;
+  let maxX = -1;
+  let maxY = -1;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (data[(y * width + x) * 4 + 3] === 0) continue;
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    }
+  }
+  return maxX >= minX && maxY >= minY
+    ? { width: maxX - minX + 1, height: maxY - minY + 1 }
+    : null;
+}
+
+function rasterizeProbe(
+  ctx: CanvasRenderingContext2D,
+  featureSettings: string,
+): { width: number; height: number } | null {
+  const canvas = ctx.canvas;
+  canvas.style.fontFeatureSettings = featureSettings;
+  ctx.font = ctx.font;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillText('ー', canvas.width / 2, canvas.height / 2);
+  return inkBounds(ctx);
+}
+
+/**
+ * Whether this main-thread canvas/font can paint the font's OpenType `vert`
+ * glyphs. Results are cached by family/weight/style shorthand and invalidated
+ * whenever the document FontFaceSet completes or fails a load.
+ */
+export function verticalVertFeatureSupported(ctx: Ctx2D): boolean {
+  const target = canvasElementFor(ctx);
+  if (target === null || typeof document === 'undefined') return false;
+
+  const doc = target.ownerDocument ?? document;
+  const state = probeState(doc);
+  const key = `${state.epoch}:${replaceFontSize(ctx.font, '<size>')}`;
+  const cached = state.cache.get(key);
+  if (cached !== undefined) return cached;
+
+  let supported = false;
+  const parent = doc.body ?? doc.documentElement;
+  if (!parent) return false;
+  const wasAttached = state.canvas.isConnected;
+  if (!wasAttached) parent.appendChild(state.canvas);
+  const probe = state.canvas.getContext('2d', { willReadFrequently: true });
+  if (probe !== null) {
+    const previousFeature = state.canvas.style.fontFeatureSettings;
+    try {
+      probe.font = replaceFontSize(ctx.font, `${PROBE_FONT_PX}px`);
+      probe.fillStyle = '#000';
+      probe.textAlign = 'center';
+      probe.textBaseline = 'middle';
+      const plain = rasterizeProbe(probe, 'normal');
+      const vert = rasterizeProbe(probe, '"vert" 1');
+      supported =
+        plain !== null &&
+        vert !== null &&
+        plain.width > plain.height &&
+        vert.height > vert.width;
+    } catch {
+      supported = false;
+    } finally {
+      state.canvas.style.fontFeatureSettings = previousFeature;
+      probe.font = probe.font;
+      probe.clearRect(0, 0, state.canvas.width, state.canvas.height);
+      if (!wasAttached) state.canvas.remove();
+    }
+  }
+  state.cache.set(key, supported);
+  return supported;
+}
+
+/** Enable the element's `vert` feature, refont, draw, then restore and refont. */
+export function withVertFeature<T>(ctx: Ctx2D, draw: () => T): T {
+  const canvas = ctx.canvas as HTMLCanvasElement;
+  const style = canvas?.style;
+  if (!style) return draw();
+
+  const previous = style.fontFeatureSettings;
+  style.fontFeatureSettings = '"vert" 1';
+  ctx.font = ctx.font;
+  try {
+    return draw();
+  } finally {
+    style.fontFeatureSettings = previous;
+    ctx.font = ctx.font;
+  }
+}

--- a/packages/core/src/text/vertical-vert-feature.ts
+++ b/packages/core/src/text/vertical-vert-feature.ts
@@ -22,6 +22,13 @@ function replaceFontSize(font: string, replacement: string): string {
   );
 }
 
+function composeVertFeature(featureSettings: string): string {
+  const normalized = featureSettings.trim();
+  return normalized === '' || normalized.toLowerCase() === 'normal'
+    ? '"vert" 1'
+    : `${featureSettings}, "vert" 1`;
+}
+
 function probeState(doc: Document): ProbeState {
   const existing = probeStates.get(doc);
   if (existing) return existing;
@@ -71,28 +78,31 @@ function inkBounds(ctx: CanvasRenderingContext2D): { width: number; height: numb
 
 function rasterizeProbe(
   ctx: CanvasRenderingContext2D,
+  cp: number,
   featureSettings: string,
 ): { width: number; height: number } | null {
   const canvas = ctx.canvas;
   canvas.style.fontFeatureSettings = featureSettings;
   ctx.font = ctx.font;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  ctx.fillText('ー', canvas.width / 2, canvas.height / 2);
+  ctx.fillText(String.fromCodePoint(cp), canvas.width / 2, canvas.height / 2);
   return inkBounds(ctx);
 }
 
 /**
- * Whether this main-thread canvas/font can paint the font's OpenType `vert`
- * glyphs. Results are cached by family/weight/style shorthand and invalidated
- * whenever the document FontFaceSet completes or fails a load.
+ * Whether this main-thread canvas/font can paint the requested code point with
+ * a wide-to-tall OpenType `vert` substitution. Results are cached by code point,
+ * feature settings, and family/weight/style shorthand, and invalidated whenever
+ * the document FontFaceSet completes or fails a load.
  */
-export function verticalVertFeatureSupported(ctx: Ctx2D): boolean {
+export function verticalVertFeatureSupported(ctx: Ctx2D, cp: number): boolean {
   const target = canvasElementFor(ctx);
   if (target === null || typeof document === 'undefined') return false;
 
   const doc = target.ownerDocument ?? document;
   const state = probeState(doc);
-  const key = `${state.epoch}:${replaceFontSize(ctx.font, '<size>')}`;
+  const sourceFeature = target.style.fontFeatureSettings;
+  const key = `${state.epoch}:${replaceFontSize(ctx.font, '<size>')}:${sourceFeature}:${cp}`;
   const cached = state.cache.get(key);
   if (cached !== undefined) return cached;
 
@@ -109,8 +119,8 @@ export function verticalVertFeatureSupported(ctx: Ctx2D): boolean {
       probe.fillStyle = '#000';
       probe.textAlign = 'center';
       probe.textBaseline = 'middle';
-      const plain = rasterizeProbe(probe, 'normal');
-      const vert = rasterizeProbe(probe, '"vert" 1');
+      const plain = rasterizeProbe(probe, cp, sourceFeature);
+      const vert = rasterizeProbe(probe, cp, composeVertFeature(sourceFeature));
       supported =
         plain !== null &&
         vert !== null &&
@@ -129,14 +139,14 @@ export function verticalVertFeatureSupported(ctx: Ctx2D): boolean {
   return supported;
 }
 
-/** Enable the element's `vert` feature, refont, draw, then restore and refont. */
+/** Compose `vert` onto the element features, refont, draw, then restore exactly. */
 export function withVertFeature<T>(ctx: Ctx2D, draw: () => T): T {
   const canvas = ctx.canvas as HTMLCanvasElement;
   const style = canvas?.style;
   if (!style) return draw();
 
   const previous = style.fontFeatureSettings;
-  style.fontFeatureSettings = '"vert" 1';
+  style.fontFeatureSettings = composeVertFeature(previous);
   ctx.font = ctx.font;
   try {
     return draw();

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -5,11 +5,13 @@ import {
   verticalGlyphOffset,
   splitVerticalOrientationRuns,
   drawVerticalRun,
+  drawVerticalRunWithCapability,
   drawTateChuYokoRun,
   drawUprightBox,
   physicalToLogicalAnchorBox,
   verticalTextLayerPlacement,
   verticalRunInkExtraPx,
+  verticalRunInkExtraPxWithCapability,
 } from './vertical-text.js';
 
 // ECMA-376 §17.6.20 vertical writing (tbRl). These are the pure classification
@@ -116,7 +118,7 @@ type Op =
   | { op: 'translate'; x: number; y: number }
   | { op: 'rotate'; a: number }
   | { op: 'scale'; sx: number; sy: number }
-  | { op: 'fillText'; text: string; x: number; y: number; align: string; baseline: string }
+  | { op: 'fillText'; text: string; x: number; y: number; align: string; baseline: string; feature: string }
   | { op: 'draw'; dx: number; dy: number; dw: number; dh: number };
 
 // Optional metrics the mock returns from `measureText`, keyed by the metric it
@@ -142,7 +144,10 @@ interface MockMetrics {
 
 function mockCtx(metrics: MockMetrics = {}): { ctx: any; ops: Op[] } {
   const ops: Op[] = [];
+  const style = { fontFeatureSettings: 'normal' };
   const ctx: any = {
+    canvas: { style },
+    font: '12px serif',
     textAlign: 'start',
     textBaseline: 'alphabetic',
     letterSpacing: '0px',
@@ -181,13 +186,33 @@ function mockCtx(metrics: MockMetrics = {}): { ctx: any; ops: Op[] } {
       return m;
     },
     fillText(text: string, x: number, y: number) {
-      ops.push({ op: 'fillText', text, x, y, align: this.textAlign, baseline: this.textBaseline });
+      ops.push({
+        op: 'fillText', text, x, y, align: this.textAlign,
+        baseline: this.textBaseline, feature: style.fontFeatureSettings,
+      });
     },
   };
   return { ctx, ops };
 }
 
 describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin sideways)', () => {
+  it('uses vert only for mirror-fallback marks and keeps other glyphs on manual paths', () => {
+    const { ctx, ops } = mockCtx();
+    drawVerticalRunWithCapability(ctx, 'ー〜～、。：；「」“”A', 0, 0, 12, 0, 1, true, true);
+    const fills = ops.filter((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fills.map((fill) => fill.text)).toEqual([
+      'ー', '〜', '～', '︑', '︒', '：', '；', '﹁', '﹂', '“', '”', 'A',
+    ]);
+    expect(fills.map((fill) => fill.feature)).toEqual([
+      '"vert" 1', '"vert" 1', '"vert" 1',
+      'normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal',
+    ]);
+    const rotates = ops.filter((o): o is Extract<Op, { op: 'rotate' }> => o.op === 'rotate');
+    expect(rotates).toHaveLength(8);
+    expect(rotates.every((rotate) => rotate.a === -Math.PI / 2)).toBe(true);
+    expect(ops.some((op) => op.op === 'scale' && op.sy === -1)).toBe(false);
+  });
+
   it('counter-rotates every upright glyph −90° about its cell centre', () => {
     const { ctx, ops } = mockCtx();
     drawVerticalRun(ctx, '富士', 100, 200, 12, 0);
@@ -413,6 +438,30 @@ describe('vo=Tr rotate-fallback ink overrun (#1014 — ink-sized cell + ink-cent
     expect(verticalRunInkExtraPx(ctx, 'ー')).toBeCloseTo(19, 6);
     expect(verticalRunInkExtraPx(ctx, '話ー')).toBeCloseTo(19, 6);
     expect(verticalRunInkExtraPx(ctx, '話A ')).toBe(0);
+  });
+
+  it('skips growth only for vert-rendered mirror marks and keeps quote/colon growth', () => {
+    const { ctx } = mockCtx({
+      inkLR: {
+        'ー': { left: 5, right: 24 },
+        '“': { left: 5, right: 24 },
+        '：': { left: 5, right: 24 },
+      },
+    });
+    expect(verticalRunInkExtraPxWithCapability(ctx, 'ー“：', true)).toBeCloseTo(38, 6);
+  });
+
+  it('applies the same per-glyph growth gate while painting', () => {
+    const { ctx, ops } = mockCtx({
+      inkLR: {
+        'ー': { left: 5, right: 24 },
+        '“': { left: 5, right: 24 },
+        '：': { left: 5, right: 24 },
+      },
+    });
+    drawVerticalRunWithCapability(ctx, 'ー“：話', 0, 0, 12, 0, 1, true, true);
+    const translates = ops.filter((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
+    expect(translates.map((op) => op.x)).toEqual([5, 24.5, 53.5, 73]);
   });
 
   it('verticalRunInkExtraPx is 0 when the ink fits the advance (all real fonts) or metrics are absent', () => {

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -226,7 +226,17 @@ function mockCtx(metrics: MockMetrics = {}): { ctx: any; ops: Op[] } {
 describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin sideways)', () => {
   it('uses vert only for mirror-fallback marks and keeps other glyphs on manual paths', () => {
     const { ctx, ops } = mockCtx();
-    drawVerticalRunWithCapability(ctx, 'ー〜～、。：；「」“”A', 0, 0, 12, 0, 1, true, true);
+    drawVerticalRunWithCapability(
+      ctx,
+      'ー〜～、。：；「」“”A',
+      0,
+      0,
+      12,
+      0,
+      1,
+      true,
+      () => true,
+    );
     const fills = ops.filter((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
     expect(fills.map((fill) => fill.text)).toEqual([
       'ー', '〜', '～', '︑', '︒', '：', '；', '﹁', '﹂', '“', '”', 'A',
@@ -476,7 +486,29 @@ describe('vo=Tr rotate-fallback ink overrun (#1014 — ink-sized cell + ink-cent
         '：': { left: 5, right: 24 },
       },
     });
-    expect(verticalRunInkExtraPxWithCapability(ctx, 'ー“：', true)).toBeCloseTo(38, 6);
+    expect(verticalRunInkExtraPxWithCapability(ctx, 'ー“：', () => true)).toBeCloseTo(38, 6);
+  });
+
+  it('uses the same per-code-point vert gate for measurement and painting', () => {
+    const metrics = {
+      inkLR: {
+        'ー': { left: 5, right: 24 },
+        '〜': { left: 5, right: 24 },
+      },
+    };
+    const supported = (cp: number) => cp === 0x30fc;
+    const { ctx } = mockCtx(metrics);
+    expect(verticalRunInkExtraPxWithCapability(ctx, 'ー〜', supported)).toBeCloseTo(19, 6);
+
+    const painted = mockCtx(metrics);
+    drawVerticalRunWithCapability(painted.ctx, 'ー〜', 0, 0, 12, 0, 1, true, supported);
+    const fills = painted.ops.filter((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fills.map((fill) => fill.feature)).toEqual(['"vert" 1', 'normal']);
+    const transforms = painted.ops.filter(
+      (o): o is Extract<Op, { op: 'transform' }> => o.op === 'transform',
+    );
+    expect(transforms).toHaveLength(1);
+    expect(transforms[0].d).toBe(-1);
   });
 
   it('applies the same per-glyph growth gate while painting', () => {
@@ -487,7 +519,7 @@ describe('vo=Tr rotate-fallback ink overrun (#1014 — ink-sized cell + ink-cent
         '：': { left: 5, right: 24 },
       },
     });
-    drawVerticalRunWithCapability(ctx, 'ー“：話', 0, 0, 12, 0, 1, true, true);
+    drawVerticalRunWithCapability(ctx, 'ー“：話', 0, 0, 12, 0, 1, true, () => true);
     const translates = ops.filter((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
     expect(translates.map((op) => op.x)).toEqual([5, 24.5, -9.5, 53.5, -9.5, 73]);
   });

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -118,6 +118,7 @@ type Op =
   | { op: 'translate'; x: number; y: number }
   | { op: 'rotate'; a: number }
   | { op: 'scale'; sx: number; sy: number }
+  | { op: 'transform'; a: number; b: number; c: number; d: number; e: number; f: number }
   | { op: 'fillText'; text: string; x: number; y: number; align: string; baseline: string; feature: string }
   | { op: 'draw'; dx: number; dy: number; dw: number; dh: number };
 
@@ -140,13 +141,37 @@ interface MockMetrics {
   // extent. Returned regardless of the current textAlign (the values are already
   // centre-relative).
   inkLR?: Record<string, { left: number; right: number }>;
+  shearSlope?: number;
 }
 
 function mockCtx(metrics: MockMetrics = {}): { ctx: any; ops: Op[] } {
   const ops: Op[] = [];
   const style = { fontFeatureSettings: 'normal' };
+  class ScratchCanvas {
+    width: number;
+    height: number;
+    style = style;
+    constructor(width: number, height: number) { this.width = width; this.height = height; }
+    getContext() {
+      const canvas = this;
+      return {
+        canvas,
+        font: '', fillStyle: '#000', textAlign: 'center', textBaseline: 'middle',
+        clearRect() {}, fillText() {},
+        getImageData() {
+          const data = new Uint8ClampedArray(canvas.width * canvas.height * 4);
+          const slope = metrics.shearSlope ?? 0;
+          for (let x = 128; x <= 384; x++) {
+            const y = Math.round(256 + slope * (x - 256));
+            data[(y * canvas.width + x) * 4 + 3] = 255;
+          }
+          return { data };
+        },
+      };
+    }
+  }
   const ctx: any = {
-    canvas: { style },
+    canvas: metrics.shearSlope === undefined ? { style } : new ScratchCanvas(1, 1),
     font: '12px serif',
     textAlign: 'start',
     textBaseline: 'alphabetic',
@@ -165,6 +190,9 @@ function mockCtx(metrics: MockMetrics = {}): { ctx: any; ops: Op[] } {
     },
     scale(sx: number, sy: number) {
       ops.push({ op: 'scale', sx, sy });
+    },
+    transform(a: number, b: number, c: number, d: number, e: number, f: number) {
+      ops.push({ op: 'transform', a, b, c, d, e, f });
     },
     measureText(s: string) {
       // Every code point is 10px wide.
@@ -275,8 +303,8 @@ describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin side
     expect(ops.some((o) => o.op === 'rotate')).toBe(false);
     const translate = ops.find((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
     expect(translate).toEqual({ op: 'translate', x: 105, y: 200 });
-    const scale = ops.find((o): o is Extract<Op, { op: 'scale' }> => o.op === 'scale');
-    expect(scale).toEqual({ op: 'scale', sx: 1, sy: -1 });
+    const transform = ops.find((o): o is Extract<Op, { op: 'transform' }> => o.op === 'transform');
+    expect(transform).toEqual({ op: 'transform', a: 1, b: 0, c: 0, d: -1, e: 0, f: 0 });
     const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
     expect(fill).toMatchObject({ text: 'ー', x: 0, y: 0, align: 'center', baseline: 'middle' });
   });
@@ -288,8 +316,8 @@ describe('drawVerticalRun (§17.6.20 — upright CJK counter-rotated, Latin side
       const { ctx, ops } = mockCtx();
       drawVerticalRun(ctx, ch, 0, 0, 12, 0);
       expect(ops.some((o) => o.op === 'rotate')).toBe(false);
-      const scale = ops.find((o): o is Extract<Op, { op: 'scale' }> => o.op === 'scale');
-      expect(scale).toEqual({ op: 'scale', sx: 1, sy: -1 });
+      const transform = ops.find((o): o is Extract<Op, { op: 'transform' }> => o.op === 'transform');
+      expect(transform).toEqual({ op: 'transform', a: 1, b: 0, c: 0, d: -1, e: 0, f: 0 });
       const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
       expect(fill).toMatchObject({ text: ch, x: 0, y: 0, align: 'center', baseline: 'middle' });
     }
@@ -461,7 +489,7 @@ describe('vo=Tr rotate-fallback ink overrun (#1014 — ink-sized cell + ink-cent
     });
     drawVerticalRunWithCapability(ctx, 'ー“：話', 0, 0, 12, 0, 1, true, true);
     const translates = ops.filter((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
-    expect(translates.map((op) => op.x)).toEqual([5, 24.5, 53.5, 73]);
+    expect(translates.map((op) => op.x)).toEqual([5, 24.5, -9.5, 53.5, -9.5, 73]);
   });
 
   it('verticalRunInkExtraPx is 0 when the ink fits the advance (all real fonts) or metrics are absent', () => {
@@ -479,24 +507,43 @@ describe('vo=Tr rotate-fallback ink overrun (#1014 — ink-sized cell + ink-cent
     // advance was grown by the same deficit — measure==paint).
     drawVerticalRun(ctx, 'ー話', 0, 0, 12, 0, 1, true);
     const translates = ops.filter((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
-    // First translate = ー cell centre (29/2 = 14.5); second = 話 cell centre 34.
+    // First translate = ー cell centre (29/2 = 14.5); second is its separate
+    // output-axis ink shift; third = 話 cell centre 34.
     expect(translates[0].x).toBeCloseTo(14.5, 6);
-    expect(translates[1].x).toBeCloseTo(34, 6);
+    expect(translates[1].x).toBeCloseTo(-9.5, 6);
+    expect(translates[2].x).toBeCloseTo(34, 6);
   });
 
   it('ink-centres the grown ー (shift by (left − right)/2) so its ink fills the grown cell', () => {
     const { ctx, ops } = mockCtx(underReport);
     drawVerticalRun(ctx, 'ー', 0, 0, 12, 0, 1, true);
-    // Mirror path (ー reflects): translate to cell centre 14.5, scale(1,-1), then a
-    // center/middle fillText shifted by (5 − 24)/2 = −9.5 so the ink centres on the
+    // Mirror path (ー reflects): translate to cell centre 14.5, then translate the
+    // output advance axis by (5 − 24)/2 = −9.5 before the mirror/shear matrix so
+    // the ink centres on the
     // cell. Ink then spans [14.5 − 9.5 − 5, 14.5 − 9.5 + 24] = [0, 29] = the cell.
     const translate = ops.find((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
     expect(translate?.x).toBeCloseTo(14.5, 6);
-    const scale = ops.find((o): o is Extract<Op, { op: 'scale' }> => o.op === 'scale');
-    expect(scale).toEqual({ op: 'scale', sx: 1, sy: -1 });
+    const translates = ops.filter((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
+    expect(translates[1]?.x).toBeCloseTo(-9.5, 6);
+    const transform = ops.find((o): o is Extract<Op, { op: 'transform' }> => o.op === 'transform');
+    expect(transform).toEqual({ op: 'transform', a: 1, b: 0, c: 0, d: -1, e: 0, f: 0 });
     const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
     expect(fill).toMatchObject({ text: 'ー', y: 0, align: 'center', baseline: 'middle' });
-    expect(fill?.x).toBeCloseTo(-9.5, 6);
+    expect(fill?.x).toBe(0);
+  });
+
+  it('separates charScale and rotateInkShiftPx from the measured shear matrix', () => {
+    const { ctx, ops } = mockCtx({ ...underReport, shearSlope: 0.125 });
+    drawVerticalRun(ctx, 'ー', 0, 0, 12, 0, 0.5, true);
+    const translates = ops.filter((o): o is Extract<Op, { op: 'translate' }> => o.op === 'translate');
+    expect(translates).toEqual([
+      { op: 'translate', x: 7.25, y: 0 },
+      { op: 'translate', x: -4.75, y: 0 },
+    ]);
+    const transform = ops.find((o): o is Extract<Op, { op: 'transform' }> => o.op === 'transform');
+    expect(transform).toMatchObject({ a: 0.5, b: 0.125, c: 0, d: -1, e: 0, f: 0 });
+    const fill = ops.find((o): o is Extract<Op, { op: 'fillText' }> => o.op === 'fillText');
+    expect(fill).toMatchObject({ text: 'ー', x: 0, y: 0 });
   });
 
   it('is a NO-OP (byte-identical) when the ink fits the advance — no growth, no shift', () => {

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -70,6 +70,8 @@ import {
   verticalBracketFormSubstitute,
   verticalTrUprightFallback,
   verticalTrMirrorFallback,
+  verticalVertFeatureSupported,
+  withVertFeature,
 } from '@silurus/ooxml-core';
 
 /** How a code point is painted inside the +90°-rotated vertical page:
@@ -327,17 +329,29 @@ function verticalRotateInkGeometry(
  * @param ctx  2D context with the run's font selected.
  * @param text The run's text.
  */
-export function verticalRunInkExtraPx(ctx: Ctx2D, text: string): number {
+export function verticalRunInkExtraPxWithCapability(
+  ctx: Ctx2D,
+  text: string,
+  vertCapable: boolean,
+): number {
   let extra = 0;
   for (const ch of text) {
     const cp = ch.codePointAt(0) ?? 0;
     if (!isVerticalRotateFallback(cp)) continue;
+    // A real vert long-stroke glyph is upright in its ordinary one-em cell. All
+    // other rotate-fallback glyphs (notably quotes and the colon) still use the
+    // geometric path and therefore retain #1014/#1019 ink growth.
+    if (vertCapable && verticalTrMirrorFallback(cp)) continue;
     const geom = verticalRotateInkGeometry(ctx, ch);
     if (geom === null) continue;
     const advance = ctx.measureText(ch).width;
     if (geom.extentPx > advance) extra += geom.extentPx - advance;
   }
   return extra;
+}
+
+export function verticalRunInkExtraPx(ctx: Ctx2D, text: string): number {
+  return verticalRunInkExtraPxWithCapability(ctx, text, verticalVertFeatureSupported(ctx));
 }
 
 /**
@@ -374,7 +388,7 @@ export function verticalRunInkExtraPx(ctx: Ctx2D, text: string): number {
  *                         keeps the advance-sized, advance-centred draw byte-identical
  *                         (markers and unwired vertical text boxes).
  */
-export function drawVerticalRun(
+export function drawVerticalRunWithCapability(
   ctx: Ctx2D,
   text: string,
   x: number,
@@ -383,6 +397,7 @@ export function drawVerticalRun(
   letterSpacingPx: number,
   charScale = 1,
   growTrRotateInk = false,
+  vertCapable = false,
 ): void {
   const prevAlign = ctx.textAlign;
   const prevBaseline = ctx.textBaseline;
@@ -432,7 +447,13 @@ export function drawVerticalRun(
     // for the geometric rotate branch (substituted/upright Tr glyphs keep their path).
     let cellNaturalPx = ctx.measureText(ch).width;
     let rotateInkShiftPx = 0;
-    if (growTrRotateInk && mode === 'rotate' && bracketCp === null && !uprightFallback) {
+    if (
+      !(vertCapable && verticalTrMirrorFallback(cp)) &&
+      growTrRotateInk &&
+      mode === 'rotate' &&
+      bracketCp === null &&
+      !uprightFallback
+    ) {
       const geom = verticalRotateInkGeometry(ctx, ch);
       if (geom !== null && geom.extentPx > cellNaturalPx) {
         cellNaturalPx = geom.extentPx;
@@ -440,7 +461,20 @@ export function drawVerticalRun(
       }
     }
     const adv = cellNaturalPx * charScale + letterSpacingPx;
-    if (mode === 'upright' || bracketCp !== null || uprightFallback) {
+    if (vertCapable && verticalTrMirrorFallback(cp)) {
+      // The font's `vert` table supplies the designed upright form for the three
+      // long-stroke marks whose geometric fallback otherwise needs reflection.
+      // Keep every other glyph on its Word-adjudicated manual path below.
+      const cx = x + ax + adv / 2;
+      ctx.save();
+      ctx.translate(cx, baseline);
+      ctx.rotate(-Math.PI / 2);
+      if (scaled) ctx.scale(1, charScale);
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      withVertFeature(ctx, () => ctx.fillText(ch, 0, 0));
+      ctx.restore();
+    } else if (mode === 'upright' || bracketCp !== null || uprightFallback) {
       // vo=U / Tu, or a substituted Tr bracket. Counter-rotate −90° about the
       // cell centre so the glyph (which the page rotation would otherwise lay on
       // its side) stands upright. For corner-hanging Tu punctuation with a Unicode
@@ -565,6 +599,30 @@ export function drawVerticalRun(
   }
   ctx.textAlign = prevAlign;
   ctx.textBaseline = prevBaseline;
+}
+
+export function drawVerticalRun(
+  ctx: Ctx2D,
+  text: string,
+  x: number,
+  baseline: number,
+  fontPx: number,
+  letterSpacingPx: number,
+  charScale = 1,
+  growTrRotateInk = false,
+): void {
+  const vertCapable = verticalVertFeatureSupported(ctx);
+  drawVerticalRunWithCapability(
+    ctx,
+    text,
+    x,
+    baseline,
+    fontPx,
+    letterSpacingPx,
+    charScale,
+    growTrRotateInk,
+    vertCapable,
+  );
 }
 
 /**

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -38,9 +38,9 @@
 //         vertical glyph is the HORIZONTAL REFLECTION of the +90° rotation, not the
 //         rotation (the 起筆/curvature flips left↔right between orientations — a
 //         documented Japanese typographic convention; Word PDF sample-47 + font `vert`
-//         glyph verified). A Canvas cannot reach the `vert` glyph, so we rotate AND
-//         reflect via `scale(1, -1)` about the cell centre (the on-screen horizontal
-//         mirror in the +90° page frame).
+//         glyph verified). When the element/CSS route or this glyph's `vert` coverage
+//         is unavailable, we rotate AND reflect via `scale(1, -1)` about the cell
+//         centre (the on-screen horizontal mirror in the +90° page frame).
 //       – UPRIGHT: the fullwidth semicolon ；, whose FE14 form is an upright dot-over-
 //         comma, not a rotation (issue #969 follow-up; core `verticalTrUprightFallback`).
 //   • vo=R  (rotated): Latin letters, Western digits, Latin punctuation. Stay
@@ -91,8 +91,8 @@ export type VerticalDrawMode = 'upright' | 'rotate' | 'sideways';
  *   Tu → upright   (draw upright; the caller substitutes a vertical form glyph
  *                   via {@link verticalFormSubstitute} when one exists so the
  *                   comma/full stop land in the upper-right of the cell)
- *   Tr → rotate    (rotate 90° CW — the fallback when no vertical glyph is
- *                   reachable on a Canvas — centred on the column)
+ *   Tr → rotate    (rotate 90° CW — the fallback when the element/CSS route or
+ *                   that glyph's vertical coverage is unavailable — centred)
  *   R  → sideways  (leave rotated with the page: Latin/digits)
  *
  * @param cp A Unicode scalar value (e.g. from `String.prototype.codePointAt`).
@@ -187,6 +187,8 @@ export function splitVerticalOrientationRuns(
 }
 
 type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+type VertCapability = (cp: number) => boolean;
+const NO_VERT_CAPABILITY: VertCapability = () => false;
 
 /**
  * Cross-axis (column-thickness) offset, in px, from the alphabetic baseline to
@@ -333,7 +335,7 @@ function verticalRotateInkGeometry(
 export function verticalRunInkExtraPxWithCapability(
   ctx: Ctx2D,
   text: string,
-  vertCapable: boolean,
+  vertCapability: VertCapability,
 ): number {
   let extra = 0;
   for (const ch of text) {
@@ -342,7 +344,7 @@ export function verticalRunInkExtraPxWithCapability(
     // A real vert long-stroke glyph is upright in its ordinary one-em cell. All
     // other rotate-fallback glyphs (notably quotes and the colon) still use the
     // geometric path and therefore retain #1014/#1019 ink growth.
-    if (vertCapable && verticalTrMirrorFallback(cp)) continue;
+    if (verticalTrMirrorFallback(cp) && vertCapability(cp)) continue;
     const geom = verticalRotateInkGeometry(ctx, ch);
     if (geom === null) continue;
     const advance = ctx.measureText(ch).width;
@@ -352,7 +354,11 @@ export function verticalRunInkExtraPxWithCapability(
 }
 
 export function verticalRunInkExtraPx(ctx: Ctx2D, text: string): number {
-  return verticalRunInkExtraPxWithCapability(ctx, text, verticalVertFeatureSupported(ctx));
+  return verticalRunInkExtraPxWithCapability(
+    ctx,
+    text,
+    (cp) => verticalVertFeatureSupported(ctx, cp),
+  );
 }
 
 /**
@@ -398,7 +404,7 @@ export function drawVerticalRunWithCapability(
   letterSpacingPx: number,
   charScale = 1,
   growTrRotateInk = false,
-  vertCapable = false,
+  vertCapability: VertCapability = NO_VERT_CAPABILITY,
 ): void {
   const prevAlign = ctx.textAlign;
   const prevBaseline = ctx.textBaseline;
@@ -435,6 +441,7 @@ export function drawVerticalRunWithCapability(
     // like the vo=U / vo=Tu cells; the colon ：is NOT here (its FE13 form IS a 90°
     // rotation, so it takes the rotate branch below → side-by-side dots).
     const uprightFallback = mode === 'rotate' && bracketCp === null && verticalTrUprightFallback(cp);
+    const vertGlyphSupported = verticalTrMirrorFallback(cp) && vertCapability(cp);
     // Advance/width uses the ORIGINAL code point (measure == draw, and the text
     // model / selection / find keep the original character — see the module doc).
     // #1014: a vo=Tr GEOMETRIC rotate-fallback glyph (ー 〜 ～ “” ：) is painted by a
@@ -449,7 +456,7 @@ export function drawVerticalRunWithCapability(
     let cellNaturalPx = ctx.measureText(ch).width;
     let rotateInkShiftPx = 0;
     if (
-      !(vertCapable && verticalTrMirrorFallback(cp)) &&
+      !vertGlyphSupported &&
       growTrRotateInk &&
       mode === 'rotate' &&
       bracketCp === null &&
@@ -462,7 +469,7 @@ export function drawVerticalRunWithCapability(
       }
     }
     const adv = cellNaturalPx * charScale + letterSpacingPx;
-    if (vertCapable && verticalTrMirrorFallback(cp)) {
+    if (vertGlyphSupported) {
       // The font's `vert` table supplies the designed upright form for the three
       // long-stroke marks whose geometric fallback otherwise needs reflection.
       // Keep every other glyph on its Word-adjudicated manual path below.
@@ -532,8 +539,8 @@ export function drawVerticalRunWithCapability(
       // vo=Tr with NO substituted vertical form and NOT the upright-fallback
       // semicolon: ー (U+30FC), the wave dash / tilde 〜 ～, the double quotes “”,
       // and the fullwidth colon ：(FF1A). UAX#50's Tr fallback (no vertical glyph
-      // reachable on a Canvas) is to ROTATE the glyph 90° CW; a plain `fillText` in
-      // the +90° page frame IS that rotation, centred on the column with
+      // available through the element/CSS route) is to ROTATE the glyph 90° CW;
+      // a plain `fillText` in the +90° page frame IS that rotation, centred with
       // `center`/`middle` at the cell centre. For the colon this reproduces FE13's
       // design directly (the two vertically-stacked dots become side by side),
       // Word-verified (issue #969 follow-up); for the quotes the rotation matches the
@@ -543,9 +550,9 @@ export function drawVerticalRunWithCapability(
       // EXCEPTION: their font-DESIGNED vertical form is the HORIZONTAL REFLECTION of
       // that +90° rotation, not the rotation — the 起筆/curvature flips left↔right
       // between orientations (Word PDF sample-47 + font `vert` glyph verified: a plain
-      // rotation of ー bulges LEFT, Word/the designed glyph bulge RIGHT). Since a
-      // Canvas cannot invoke the font's `vert` OpenType glyph, we reproduce it by
-      // reflecting about the cell centre. For U+30FC only, the shared runtime
+      // rotation of ー bulges LEFT, Word/the designed glyph bulge RIGHT). Since
+      // this glyph lacks verified `vert` coverage, we reproduce it by reflecting
+      // about the cell centre. For U+30FC only, the shared runtime
       // coefficient adds y'=m·x−y to cancel the horizontal glyph's measured drift;
       // the designed wave-mark drift remains untouched. Because x'=s·x is independent
       // of y, advance/measure and along-column centring are unchanged.
@@ -614,7 +621,6 @@ export function drawVerticalRun(
   charScale = 1,
   growTrRotateInk = false,
 ): void {
-  const vertCapable = verticalVertFeatureSupported(ctx);
   drawVerticalRunWithCapability(
     ctx,
     text,
@@ -624,7 +630,7 @@ export function drawVerticalRun(
     letterSpacingPx,
     charScale,
     growTrRotateInk,
-    vertCapable,
+    (cp) => verticalVertFeatureSupported(ctx, cp),
   );
 }
 

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -72,6 +72,7 @@ import {
   verticalTrMirrorFallback,
   verticalVertFeatureSupported,
   withVertFeature,
+  verticalFallbackShearCoefficient,
 } from '@silurus/ooxml-core';
 
 /** How a code point is painted inside the +90°-rotated vertical page:
@@ -544,11 +545,10 @@ export function drawVerticalRunWithCapability(
       // between orientations (Word PDF sample-47 + font `vert` glyph verified: a plain
       // rotation of ー bulges LEFT, Word/the designed glyph bulge RIGHT). Since a
       // Canvas cannot invoke the font's `vert` OpenType glyph, we reproduce it by
-      // reflecting: in the +90° page frame the on-screen horizontal mirror is
-      // `scale(1, -1)` about the cell centre. Advance/measure and the column centring
-      // are unchanged (the em box is symmetric about the cell centre), so only the
-      // glyph's chirality flips. (Substituted bracket forms never reach here — they
-      // were drawn upright above; a rotated bracket's ink offset is not measurable.)
+      // reflecting about the cell centre. For U+30FC only, the shared runtime
+      // coefficient adds y'=m·x−y to cancel the horizontal glyph's measured drift;
+      // the designed wave-mark drift remains untouched. Because x'=s·x is independent
+      // of y, advance/measure and along-column centring are unchanged.
       const cx = x + ax + adv / 2;
       const mirror = verticalTrMirrorFallback(cp);
       ctx.textAlign = 'center';
@@ -556,17 +556,20 @@ export function drawVerticalRunWithCapability(
       // #1014: `rotateInkShiftPx` (glyph-space, non-zero ONLY when the cell was grown
       // to the ink extent above) re-centres the ink on the grown cell — a `center`
       // draw centres the glyph's ADVANCE, and an under-reported advance is off-centre
-      // from the ink. It rides the local frame so it composes with the §17.3.2.43
-      // `w:w` scale and the reflection; 0 (the common path) leaves today's advance-
-      // centred draw byte-identical.
+      // from the ink. It is applied separately on the advance OUTPUT axis before
+      // the §17.3.2.43 `w:w` + mirror/shear matrix, avoiding an m·shift cross-axis
+      // displacement. Zero (the common path) leaves advance centring unchanged.
       if (mirror || scaled || rotateInkShiftPx !== 0) {
         ctx.save();
         ctx.translate(cx, baseline);
-        // `scale(1, -1)` is the on-screen horizontal mirror in the +90° page frame
-        // (screen −x ↔ page-frame +y); combine with the §17.3.2.43 `w:w` width
-        // compression on the line axis. Non-mirror glyphs keep sy=+1.
-        ctx.scale(charScale, mirror ? -1 : 1);
-        ctx.fillText(ch, rotateInkShiftPx, 0);
+        // Keep the #1014 ink shift on the advance OUTPUT axis. Folding it into
+        // the shear matrix would introduce an m·shift cross-axis displacement.
+        if (rotateInkShiftPx !== 0) ctx.translate(charScale * rotateInkShiftPx, 0);
+        const shear = verticalFallbackShearCoefficient(ctx, cp);
+        // x'=charScale·x preserves along-column extent; y'=shear·x−y mirrors
+        // chirality and cancels the horizontal glyph's measured stroke drift.
+        ctx.transform(charScale, shear, 0, mirror ? -1 : 1, 0, 0);
+        ctx.fillText(ch, 0, 0);
         ctx.restore();
       } else {
         ctx.fillText(ch, cx, baseline);

--- a/packages/docx/tests/visual/vertical-vert-feature.html
+++ b/packages/docx/tests/visual/vertical-vert-feature.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Vertical OpenType feature fixture</title>
+  </head>
+  <body>
+    <canvas></canvas>
+  </body>
+</html>

--- a/packages/docx/tests/visual/vertical-vert-feature.spec.ts
+++ b/packages/docx/tests/visual/vertical-vert-feature.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from '@playwright/test';
+
+interface StrokeMeasurement {
+  angleDeg: number;
+  headMinusTailPx: number;
+  topQuarterInkWeight: number;
+  bottomQuarterInkWeight: number;
+  inkWidth: number;
+  inkHeight: number;
+  centroidRangePx: number;
+}
+
+test('tbRl uses the font vert glyph for prolonged and wave marks', async ({ page }) => {
+  await page.goto('/tests/visual/vertical-vert-feature.html');
+
+  const result = await page.evaluate(async () => {
+    const family = 'Hiragino Mincho ProN';
+    await document.fonts.ready;
+    if (!document.fonts.check(`200px "${family}"`)) return null;
+
+    const { drawVerticalRun } = await import('/src/vertical-text.ts');
+    const canvas = document.querySelector('canvas') as HTMLCanvasElement;
+    canvas.width = 900;
+    canvas.height = 1100;
+    canvas.style.width = '900px';
+    canvas.style.height = '1100px';
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    if (!ctx) throw new Error('2D context unavailable');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = '#000';
+    ctx.font = `200px "${family}"`;
+    ctx.translate(500, 50);
+    ctx.rotate(Math.PI / 2);
+    drawVerticalRun(ctx, '話ーー話〜～', 0, 0, 200, 0);
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+
+    const measureCell = (index: number): StrokeMeasurement => {
+      const x0 = 350;
+      const y0 = 50 + index * 200;
+      const width = 300;
+      const height = 200;
+      const data = ctx.getImageData(x0, y0, width, height).data;
+      const rows: Array<{ y: number; x: number; weight: number }> = [];
+      let minX = width;
+      let maxX = -1;
+      let minY = height;
+      let maxY = -1;
+      for (let y = 0; y < height; y += 1) {
+        let weightedX = 0;
+        let weight = 0;
+        for (let x = 0; x < width; x += 1) {
+          const alpha = data[(y * width + x) * 4 + 3];
+          if (alpha === 0) continue;
+          weightedX += x * alpha;
+          weight += alpha;
+          minX = Math.min(minX, x);
+          maxX = Math.max(maxX, x);
+          minY = Math.min(minY, y);
+          maxY = Math.max(maxY, y);
+        }
+        if (weight > 0) rows.push({ y, x: weightedX / weight, weight });
+      }
+      if (rows.length < 2) throw new Error(`no measurable ink in cell ${index}`);
+
+      // Theil-Sen over every occupied scanline: endpoint bulges remain evidence
+      // instead of being removed by a fixed end trim.
+      const slopes: number[] = [];
+      for (let i = 0; i < rows.length; i += 1) {
+        for (let j = i + 1; j < rows.length; j += 1) {
+          slopes.push((rows[j].x - rows[i].x) / (rows[j].y - rows[i].y));
+        }
+      }
+      slopes.sort((a, b) => a - b);
+      const slope = slopes[Math.floor(slopes.length / 2)];
+      const quarter = Math.max(1, Math.floor(rows.length / 4));
+      const average = (values: Array<{ x: number }>) =>
+        values.reduce((sum, value) => sum + value.x, 0) / values.length;
+      const totalWeight = (values: Array<{ weight: number }>) =>
+        values.reduce((sum, value) => sum + value.weight, 0);
+      const topQuarter = rows.slice(0, quarter);
+      const bottomQuarter = rows.slice(-quarter);
+      return {
+        angleDeg: (Math.atan(slope) * 180) / Math.PI,
+        headMinusTailPx: average(topQuarter) - average(bottomQuarter),
+        topQuarterInkWeight: totalWeight(topQuarter),
+        bottomQuarterInkWeight: totalWeight(bottomQuarter),
+        inkWidth: maxX - minX + 1,
+        inkHeight: maxY - minY + 1,
+        centroidRangePx:
+          Math.max(...rows.map((row) => row.x)) - Math.min(...rows.map((row) => row.x)),
+      };
+    };
+
+    return {
+      prolonged: [measureCell(1), measureCell(2)],
+      waveDash: measureCell(4),
+      fullwidthTilde: measureCell(5),
+    };
+  });
+
+  test.skip(result === null, 'Hiragino Mincho ProN is required for Word-PDF adjudication');
+  if (result === null) return;
+
+  for (const stroke of result.prolonged) {
+    console.log(
+      `vert prolonged angle=${stroke.angleDeg.toFixed(3)}deg head-tail=${stroke.headMinusTailPx.toFixed(2)}px (${((stroke.headMinusTailPx / stroke.inkHeight) * 100).toFixed(2)}%) top-bottom-weight=${(stroke.topQuarterInkWeight / stroke.bottomQuarterInkWeight).toFixed(2)}x`,
+    );
+    expect(Math.abs(stroke.angleDeg)).toBeLessThanOrEqual(0.8);
+    // Word ground truth (word47-chouonpu-zoom-only.png) is -1.02% over the
+    // measured ink height, so the signed quarter-centroid offset is a taper
+    // check rather than evidence that the head must lie to the right.
+    expect(Math.abs(stroke.headMinusTailPx)).toBeLessThanOrEqual(stroke.inkHeight * 0.025);
+    // The same Word crop has 1.30x as much top-quarter ink weight. A 180-degree
+    // inversion reverses this relationship even though its stroke stays vertical.
+    expect(stroke.topQuarterInkWeight).toBeGreaterThan(stroke.bottomQuarterInkWeight);
+    expect(stroke.inkHeight).toBeGreaterThan(stroke.inkWidth * 2);
+  }
+  for (const [name, wave] of [
+    ['wave dash', result.waveDash],
+    ['fullwidth tilde', result.fullwidthTilde],
+  ] as const) {
+    expect(wave.inkHeight, `${name} is the real tall vert glyph`).toBeGreaterThan(wave.inkWidth);
+    expect(wave.centroidRangePx, `${name} preserves its designed waveform`).toBeGreaterThan(8);
+  }
+});

--- a/packages/node/src/docx-vertical-prolonged-mark.probe.test.ts
+++ b/packages/node/src/docx-vertical-prolonged-mark.probe.test.ts
@@ -26,6 +26,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { loadSkiaForTests, importForTests } from './test-imports';
 
 const skia = await loadSkiaForTests();
@@ -72,7 +73,7 @@ describe.skipIf(!skia || !vtMod || !haveFont)('docx vertical prolonged sound mar
    * to the glyph's own ink-bbox width (0 = left edge, 1 = right edge). Also the whole-
    * glyph cross centroid for the column-centring sanity check.
    */
-  function head(data: Uint8ClampedArray): { topNorm: number; wholeCx: number } {
+  function head(data: Uint8ClampedArray): { topNorm: number; wholeCx: number; x0: number; x1: number } {
     const py0 = logX + cellW, py1 = logX + 2 * cellW;
     let x0 = W, x1 = 0, sxAll = 0, swAll = 0;
     for (let py = py0; py < py1; py++) for (let px = 0; px < W; px++) {
@@ -86,8 +87,47 @@ describe.skipIf(!skia || !vtMod || !haveFont)('docx vertical prolonged sound mar
       if (w > 40) { sx += px * w; sw += w; }
     }
     const topCx = sw > 0 ? sx / sw : NaN;
-    return { topNorm: (topCx - x0) / (x1 - x0), wholeCx: swAll > 0 ? sxAll / swAll : NaN };
+    return { topNorm: (topCx - x0) / (x1 - x0), wholeCx: swAll > 0 ? sxAll / swAll : NaN, x0, x1 };
   }
+
+  /** Robust physical cross-axis drift over every ink-bearing along-column row. */
+  function strokeAngleDeg(data: Uint8ClampedArray): number {
+    const py0 = logX + cellW, py1 = logX + 2 * cellW;
+    const centroids: Array<{ along: number; cross: number }> = [];
+    for (let py = py0; py < py1; py++) {
+      let sx = 0, sw = 0;
+      for (let px = 0; px < W; px++) {
+        const w = ink(data, (py * W + px) * 4);
+        if (w > 0) { sx += px * w; sw += w; }
+      }
+      if (sw > 0) centroids.push({ along: py, cross: sx / sw });
+    }
+    const slopes: number[] = [];
+    for (let i = 0; i < centroids.length; i++) {
+      for (let j = i + 1; j < centroids.length; j++) {
+        slopes.push(
+          (centroids[j].cross - centroids[i].cross) /
+          (centroids[j].along - centroids[i].along),
+        );
+      }
+    }
+    slopes.sort((a, b) => a - b);
+    const middle = Math.floor(slopes.length / 2);
+    const slope = slopes.length % 2 === 0
+      ? (slopes[middle - 1] + slopes[middle]) / 2
+      : slopes[middle];
+    return Math.atan(slope) * 180 / Math.PI;
+  }
+
+  it('straightens the non-vert fallback ー stroke to within 0.8 degrees', () => {
+    const angle = strokeAngleDeg(render('ー'));
+    expect(Math.abs(angle)).toBeLessThanOrEqual(0.8);
+  });
+
+  it.each(['〜', '～'])('keeps the fallback %s waveform byte-identical', (mark) => {
+    const digest = createHash('sha256').update(render(mark)).digest('hex');
+    expect(digest).toBe('c3c484be6ea34f4283a70bf4aef9b07e62efdd0c2141772074f581e16842c60b');
+  });
 
   it('ー head leans to the physical RIGHT of its own axis (Word topology), the reflected form', () => {
     const m = head(render('ー'));
@@ -99,5 +139,9 @@ describe.skipIf(!skia || !vtMod || !haveFont)('docx vertical prolonged sound mar
     // Sanity: the mark still centres on the column (the reflection is about the cell
     // centre, so the advance/centring is unchanged) — within 0.1em of the centreline.
     expect(Math.abs(m.wholeCx - centerline)).toBeLessThanOrEqual(0.1 * fontPx);
+    // The shear grows only the cross-axis bbox and the result remains inside its
+    // one-em column band, so an authored textbox clip does not cut the stroke.
+    expect(m.x0).toBeGreaterThan(centerline - fontPx / 2);
+    expect(m.x1).toBeLessThan(centerline + fontPx / 2);
   });
 });

--- a/packages/pptx/src/eavert-glyph-orientation.test.ts
+++ b/packages/pptx/src/eavert-glyph-orientation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { renderTextBody } from './renderer.js';
-import { drawEaVertRun } from './vertical-text.js';
+import { drawEaVertRun, drawEaVertRunWithCapability } from './vertical-text.js';
 import type { TextBody, Paragraph } from './types';
 import type { TextRunData } from '@silurus/ooxml-core';
 
@@ -59,6 +59,7 @@ interface DrawCall {
   /** Net scale-y in effect at draw time. −1 for a reflected Tr long-stroke mark
    *  (ー 〜 ～ → `scale(1, -1)`); +1 otherwise. */
   sy: number;
+  feature: string;
 }
 
 /** Normalise an angle to (−π, π] so 0 (upright) and π/2 (sideways) compare cleanly. */
@@ -82,6 +83,7 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
   const stack: { rotation: number; tx: number; sy: number }[] = [];
   const px = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
   const calls: DrawCall[] = [];
+  const style = { fontFeatureSettings: 'normal' };
   const metricsFor = (s: string): TextMetrics => {
     const p = px();
     // Full-width EA glyphs advance one em; ASCII ~half em.
@@ -96,6 +98,7 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
     } as TextMetrics;
   };
   const ctx = {
+    canvas: { style },
     get font() { return font; }, set font(v: string) { font = v; },
     get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
     get letterSpacing() { return letterSpacing; }, set letterSpacing(v: string) { letterSpacing = v; },
@@ -103,8 +106,8 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
     get textAlign() { return textAlign; }, set textAlign(v: CanvasTextAlign) { textAlign = v; },
     get textBaseline() { return textBaseline; }, set textBaseline(v: CanvasTextBaseline) { textBaseline = v; },
     measureText: (s: string) => metricsFor(s),
-    fillText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, tx, sy }),
-    strokeText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, tx, sy }),
+    fillText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, tx, sy, feature: style.fontFeatureSettings }),
+    strokeText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, tx, sy, feature: style.fontFeatureSettings }),
     save: () => { stack.push({ rotation, tx, sy }); },
     restore: () => { const s = stack.pop(); if (s) { rotation = s.rotation; tx = s.tx; sy = s.sy; } },
     translate: (x: number) => { tx += x; },
@@ -287,6 +290,22 @@ describe('drawEaVertRun — per-glyph orientation helper', () => {
     drawEaVertRun(ctx, text, 0, 100, FONT_PX, 0, 'fill');
     return calls;
   }
+  it('uses vert only for mirror-fallback marks and keeps other glyphs on manual paths', () => {
+    const { ctx, calls } = mockCtx();
+    drawEaVertRunWithCapability(ctx, 'ー〜～、。：；「」“”A', 0, 100, FONT_PX, 0, 'fill', true);
+    expect(calls.map((call) => call.text)).toEqual([
+      'ー', '〜', '～', '︑', '︒', '：', '；', '﹁', '﹂', '“', '”', 'A',
+    ]);
+    expect(calls.map((call) => call.feature)).toEqual([
+      '"vert" 1', '"vert" 1', '"vert" 1',
+      'normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal',
+    ]);
+    expect(calls.slice(0, 5).every((call) => norm(call.rot) === -Math.PI / 2)).toBe(true);
+    expect(norm(calls[5].rot)).toBe(0);
+    expect(calls.slice(6, 9).every((call) => norm(call.rot) === -Math.PI / 2)).toBe(true);
+    expect(calls.slice(9).every((call) => norm(call.rot) === 0)).toBe(true);
+    expect(calls.every((call) => call.sy === 1)).toBe(true);
+  });
   it('counter-rotates vo=U glyphs by −90° (upright in the +90° page frame)', () => {
     const calls = runHelper(U_CJK);
     expect(norm(calls[0].rot)).toBeCloseTo(-Math.PI / 2, 5);

--- a/packages/pptx/src/eavert-glyph-orientation.test.ts
+++ b/packages/pptx/src/eavert-glyph-orientation.test.ts
@@ -113,6 +113,7 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
     translate: (x: number) => { tx += x; },
     rotate: (a: number) => { rotation += a; },
     scale: (_sx: number, syArg: number) => { sy *= syArg; },
+    transform: (_a: number, _b: number, _c: number, d: number) => { sy *= d; },
     beginPath: () => {}, moveTo: () => {}, lineTo: () => {}, stroke: () => {},
     clip: () => {}, rect: () => {}, fillRect: () => {}, drawImage: () => {},
     setLineDash: () => {}, closePath: () => {}, arc: () => {},

--- a/packages/pptx/src/eavert-glyph-orientation.test.ts
+++ b/packages/pptx/src/eavert-glyph-orientation.test.ts
@@ -62,6 +62,15 @@ interface DrawCall {
   feature: string;
 }
 
+interface TransformMatrix {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+  e: number;
+  f: number;
+}
+
 /** Normalise an angle to (−π, π] so 0 (upright) and π/2 (sideways) compare cleanly. */
 function norm(a: number): number {
   return Math.atan2(Math.sin(a), Math.cos(a));
@@ -70,7 +79,11 @@ function norm(a: number): number {
 /** Recording 2D context that tracks the accumulated rotation through a
  *  save/restore stack, so each fillText records the NET rotation the glyph is
  *  painted under — 0 ≈ upright, +π/2 ≈ sideways/rotated. */
-function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
+function mockCtx(shearSlope?: number): {
+  ctx: CanvasRenderingContext2D;
+  calls: DrawCall[];
+  transforms: TransformMatrix[];
+} {
   let font = `${FONT_PX}px serif`;
   let fillStyle = '';
   let letterSpacing = '0px';
@@ -83,7 +96,29 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
   const stack: { rotation: number; tx: number; sy: number }[] = [];
   const px = (): number => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? String(FONT_PX));
   const calls: DrawCall[] = [];
+  const transforms: TransformMatrix[] = [];
   const style = { fontFeatureSettings: 'normal' };
+  class ScratchCanvas {
+    width: number;
+    height: number;
+    style = style;
+    constructor(width: number, height: number) { this.width = width; this.height = height; }
+    getContext() {
+      const canvas = this;
+      return {
+        canvas, font: '', fillStyle: '#000', textAlign: 'center', textBaseline: 'middle',
+        clearRect() {}, fillText() {},
+        getImageData() {
+          const data = new Uint8ClampedArray(canvas.width * canvas.height * 4);
+          for (let x = 128; x <= 384; x += 1) {
+            const y = Math.round(256 + (shearSlope ?? 0) * (x - 256));
+            data[(y * canvas.width + x) * 4 + 3] = 255;
+          }
+          return { data };
+        },
+      };
+    }
+  }
   const metricsFor = (s: string): TextMetrics => {
     const p = px();
     // Full-width EA glyphs advance one em; ASCII ~half em.
@@ -98,7 +133,7 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
     } as TextMetrics;
   };
   const ctx = {
-    canvas: { style },
+    canvas: shearSlope === undefined ? { style } : new ScratchCanvas(1, 1),
     get font() { return font; }, set font(v: string) { font = v; },
     get fillStyle() { return fillStyle; }, set fillStyle(v: string) { fillStyle = v; },
     get letterSpacing() { return letterSpacing; }, set letterSpacing(v: string) { letterSpacing = v; },
@@ -113,13 +148,16 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
     translate: (x: number) => { tx += x; },
     rotate: (a: number) => { rotation += a; },
     scale: (_sx: number, syArg: number) => { sy *= syArg; },
-    transform: (_a: number, _b: number, _c: number, d: number) => { sy *= d; },
+    transform: (a: number, b: number, c: number, d: number, e: number, f: number) => {
+      transforms.push({ a, b, c, d, e, f });
+      sy *= d;
+    },
     beginPath: () => {}, moveTo: () => {}, lineTo: () => {}, stroke: () => {},
     clip: () => {}, rect: () => {}, fillRect: () => {}, drawImage: () => {},
     setLineDash: () => {}, closePath: () => {}, arc: () => {},
     strokeStyle: '#000', lineWidth: 1, lineJoin: 'miter' as CanvasLineJoin,
   };
-  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls, transforms };
 }
 
 function run(text: string): TextRunData {
@@ -293,7 +331,16 @@ describe('drawEaVertRun — per-glyph orientation helper', () => {
   }
   it('uses vert only for mirror-fallback marks and keeps other glyphs on manual paths', () => {
     const { ctx, calls } = mockCtx();
-    drawEaVertRunWithCapability(ctx, 'ー〜～、。：；「」“”A', 0, 100, FONT_PX, 0, 'fill', true);
+    drawEaVertRunWithCapability(
+      ctx,
+      'ー〜～、。：；「」“”A',
+      0,
+      100,
+      FONT_PX,
+      0,
+      'fill',
+      () => true,
+    );
     expect(calls.map((call) => call.text)).toEqual([
       'ー', '〜', '～', '︑', '︒', '：', '；', '﹁', '﹂', '“', '”', 'A',
     ]);
@@ -306,6 +353,27 @@ describe('drawEaVertRun — per-glyph orientation helper', () => {
     expect(calls.slice(6, 9).every((call) => norm(call.rot) === -Math.PI / 2)).toBe(true);
     expect(calls.slice(9).every((call) => norm(call.rot) === 0)).toBe(true);
     expect(calls.every((call) => call.sy === 1)).toBe(true);
+  });
+  it('keeps a glyph without vert coverage on the reflected geometric fallback', () => {
+    const { ctx, calls } = mockCtx();
+    drawEaVertRunWithCapability(
+      ctx,
+      'ー〜',
+      0,
+      100,
+      FONT_PX,
+      0,
+      'fill',
+      (cp) => cp === 0x30fc,
+    );
+    expect(calls.map((call) => call.feature)).toEqual(['"vert" 1', 'normal']);
+    expect(calls.map((call) => call.sy)).toEqual([1, -1]);
+  });
+  it('records the complete fallback shear matrix with a positive b component', () => {
+    const { ctx, transforms } = mockCtx(0.125);
+    drawEaVertRun(ctx, 'ー', 0, 100, FONT_PX, 0, 'fill');
+    expect(transforms).toEqual([{ a: 1, b: 0.125, c: 0, d: -1, e: 0, f: 0 }]);
+    expect(transforms[0].b).toBeGreaterThan(0);
   });
   it('counter-rotates vo=U glyphs by −90° (upright in the +90° page frame)', () => {
     const calls = runHelper(U_CJK);

--- a/packages/pptx/src/vertical-text.ts
+++ b/packages/pptx/src/vertical-text.ts
@@ -44,6 +44,8 @@ import {
   verticalBracketFormSubstitute,
   verticalTrUprightFallback,
   verticalTrMirrorFallback,
+  verticalVertFeatureSupported,
+  withVertFeature,
 } from '@silurus/ooxml-core';
 
 type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
@@ -124,7 +126,7 @@ function inkCenterAboveMiddlePx(ctx: Ctx2D, drawStr: string): number {
  *                         common path.
  * @param paint            `'fill'` or `'stroke'` (run outline, rPr > a:ln).
  */
-export function drawEaVertRun(
+export function drawEaVertRunWithCapability(
   ctx: Ctx2D,
   text: string,
   x: number,
@@ -132,6 +134,7 @@ export function drawEaVertRun(
   fontPx: number,
   letterSpacingPx: number,
   paint: 'fill' | 'stroke' = 'fill',
+  vertCapable = false,
 ): void {
   const prevAlign = ctx.textAlign;
   const prevBaseline = ctx.textBaseline;
@@ -159,7 +162,16 @@ export function drawEaVertRun(
     const bracketCp = vo === 'Tr' ? verticalBracketFormSubstitute(cp) : null;
     const uprightFallback = vo === 'Tr' && bracketCp === null && verticalTrUprightFallback(cp);
     const upright = vo === 'U' || vo === 'Tu' || bracketCp !== null || uprightFallback;
-    if (upright) {
+    if (vertCapable && verticalTrMirrorFallback(cp)) {
+      const cx = x + ax + adv / 2;
+      ctx.save();
+      ctx.translate(cx, crossCenterY);
+      ctx.rotate(-Math.PI / 2);
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      withVertFeature(ctx, () => draw(ch, 0, 0));
+      ctx.restore();
+    } else if (upright) {
       // vo=U / vo=Tu, or a substituted Tr bracket. Counter-rotate −90° about the
       // cell centre so the glyph (which the page rotation would lay on its side)
       // stands upright. Corner-hanging Tu punctuation (、。， → U+FE10–FE12) and Tr
@@ -222,4 +234,26 @@ export function drawEaVertRun(
   }
   ctx.textAlign = prevAlign;
   ctx.textBaseline = prevBaseline;
+}
+
+export function drawEaVertRun(
+  ctx: Ctx2D,
+  text: string,
+  x: number,
+  baseline: number,
+  fontPx: number,
+  letterSpacingPx: number,
+  paint: 'fill' | 'stroke' = 'fill',
+): void {
+  const vertCapable = verticalVertFeatureSupported(ctx);
+  drawEaVertRunWithCapability(
+    ctx,
+    text,
+    x,
+    baseline,
+    fontPx,
+    letterSpacingPx,
+    paint,
+    vertCapable,
+  );
 }

--- a/packages/pptx/src/vertical-text.ts
+++ b/packages/pptx/src/vertical-text.ts
@@ -50,6 +50,8 @@ import {
 } from '@silurus/ooxml-core';
 
 type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+type VertCapability = (cp: number) => boolean;
+const NO_VERT_CAPABILITY: VertCapability = () => false;
 
 /**
  * Cross-axis (column-thickness) offset, in px, from the alphabetic baseline to
@@ -135,7 +137,7 @@ export function drawEaVertRunWithCapability(
   fontPx: number,
   letterSpacingPx: number,
   paint: 'fill' | 'stroke' = 'fill',
-  vertCapable = false,
+  vertCapability: VertCapability = NO_VERT_CAPABILITY,
 ): void {
   const prevAlign = ctx.textAlign;
   const prevBaseline = ctx.textBaseline;
@@ -163,7 +165,8 @@ export function drawEaVertRunWithCapability(
     const bracketCp = vo === 'Tr' ? verticalBracketFormSubstitute(cp) : null;
     const uprightFallback = vo === 'Tr' && bracketCp === null && verticalTrUprightFallback(cp);
     const upright = vo === 'U' || vo === 'Tu' || bracketCp !== null || uprightFallback;
-    if (vertCapable && verticalTrMirrorFallback(cp)) {
+    const vertGlyphSupported = verticalTrMirrorFallback(cp) && vertCapability(cp);
+    if (vertGlyphSupported) {
       const cx = x + ax + adv / 2;
       ctx.save();
       ctx.translate(cx, crossCenterY);
@@ -207,9 +210,10 @@ export function drawEaVertRunWithCapability(
       // The long-stroke marks ー and 〜 ～ (core `verticalTrMirrorFallback`) are the
       // EXCEPTION: their font-designed vertical form is the HORIZONTAL REFLECTION of
       // the +90° rotation, not the rotation (Word PDF + font `vert` glyph verified — a
-      // plain rotation of ー bulges LEFT, Word bulges RIGHT). A Canvas cannot reach the
-      // `vert` glyph, so reflect about the cell centre (the on-screen horizontal
-      // mirror in the +90° page frame). For U+30FC only, the shared runtime
+      // plain rotation of ー bulges LEFT, Word bulges RIGHT). When the element/CSS
+      // route or this glyph's `vert` coverage is unavailable, reflect about the cell
+      // centre (the on-screen horizontal mirror in the +90° page frame). For U+30FC
+      // only, the shared runtime
       // coefficient adds y'=m·x−y to cancel the horizontal glyph's measured drift;
       // the designed wave-mark drift remains untouched. Same fix as docx.
       const cx = x + ax + adv / 2;
@@ -248,7 +252,6 @@ export function drawEaVertRun(
   letterSpacingPx: number,
   paint: 'fill' | 'stroke' = 'fill',
 ): void {
-  const vertCapable = verticalVertFeatureSupported(ctx);
   drawEaVertRunWithCapability(
     ctx,
     text,
@@ -257,6 +260,6 @@ export function drawEaVertRun(
     fontPx,
     letterSpacingPx,
     paint,
-    vertCapable,
+    (cp) => verticalVertFeatureSupported(ctx, cp),
   );
 }

--- a/packages/pptx/src/vertical-text.ts
+++ b/packages/pptx/src/vertical-text.ts
@@ -46,6 +46,7 @@ import {
   verticalTrMirrorFallback,
   verticalVertFeatureSupported,
   withVertFeature,
+  verticalFallbackShearCoefficient,
 } from '@silurus/ooxml-core';
 
 type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
@@ -207,15 +208,17 @@ export function drawEaVertRunWithCapability(
       // EXCEPTION: their font-designed vertical form is the HORIZONTAL REFLECTION of
       // the +90° rotation, not the rotation (Word PDF + font `vert` glyph verified — a
       // plain rotation of ー bulges LEFT, Word bulges RIGHT). A Canvas cannot reach the
-      // `vert` glyph, so reflect via `scale(1, -1)` about the cell centre (the on-screen
-      // horizontal mirror in the +90° page frame). Same fix as docx `drawVerticalRun`.
+      // `vert` glyph, so reflect about the cell centre (the on-screen horizontal
+      // mirror in the +90° page frame). For U+30FC only, the shared runtime
+      // coefficient adds y'=m·x−y to cancel the horizontal glyph's measured drift;
+      // the designed wave-mark drift remains untouched. Same fix as docx.
       const cx = x + ax + adv / 2;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
       if (verticalTrMirrorFallback(cp)) {
         ctx.save();
         ctx.translate(cx, crossCenterY);
-        ctx.scale(1, -1);
+        ctx.transform(1, verticalFallbackShearCoefficient(ctx, cp), 0, -1, 0, 0);
         draw(ch, 0, 0);
         ctx.restore();
       } else {

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -6,7 +6,7 @@ import type {
   PhoneticRun, PhoneticProperties, PhoneticAlignment, Duotone,
 } from './types.js';
 import { placePhoneticRuns } from './phonetic.js';
-import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, isGraphemeFillText, seaMixedBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
+import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, isGraphemeFillText, seaMixedBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, verticalVertFeatureSupported, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValueWithColor } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -2654,11 +2654,12 @@ function renderQuadrant(
           : cy + cellH - totalH - paddingY;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
+        const vertCapable = verticalVertFeatureSupported(ctx);
         for (const ch of text) {
           // UAX#50 per-glyph orientation (issue #790): CJK/Latin stay upright,
           // 、。 substitute their vertical form, fullwidth brackets substitute
           // their U+FE3x form, and ー rotates 90° to a vertical bar.
-          drawStackedVerticalChar(ctx, ch, cx + cellW / 2, charY, charH);
+          drawStackedVerticalChar(ctx, ch, cx + cellW / 2, charY, charH, vertCapable);
           charY += charH;
         }
         ctx.restore();

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -6,7 +6,7 @@ import type {
   PhoneticRun, PhoneticProperties, PhoneticAlignment, Duotone,
 } from './types.js';
 import { placePhoneticRuns } from './phonetic.js';
-import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, isGraphemeFillText, seaMixedBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, verticalVertFeatureSupported, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
+import { crispOffset, renderChart, renderSparkline, renderPresetShape, createAuxCanvas, PT_TO_PX, EMU_PER_PX, mathToMathML, recolorSvg, classifyCjkFont, classifyFontGeneric, cjkFallbackChain, NON_CJK_SANS_FALLBACKS, NON_CJK_SERIF_FALLBACKS, kinsokuAdjustedSplit, DEFAULT_KINSOKU_RULES, isCjkBreakChar, isLatinWordCodePoint, isUax14NoBreakPair, containsSeaScript, isGraphemeFillText, seaMixedBreakOffsets, fitSeaWordPrefix, graphemeClusterOffsets, xlsxBorderDashArray, drawImageCropped, hexToRgba, intendedSingleLinePx, verticalTrMirrorFallback, verticalVertFeatureSupported, type SparklineModel, type MathNode, type MathRenderer } from '@silurus/ooxml-core';
 import { evalFormulaToBool, todaySerial, nowSerial } from './formula.js';
 import { formatCellValueWithColor } from './number-format.js';
 import { type CfContext, compileCf, evaluateCf } from './conditional-format.js';
@@ -2654,11 +2654,13 @@ function renderQuadrant(
           : cy + cellH - totalH - paddingY;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
-        const vertCapable = verticalVertFeatureSupported(ctx);
         for (const ch of text) {
           // UAX#50 per-glyph orientation (issue #790): CJK/Latin stay upright,
           // 、。 substitute their vertical form, fullwidth brackets substitute
           // their U+FE3x form, and ー rotates 90° to a vertical bar.
+          const cp = ch.codePointAt(0) ?? 0;
+          const vertCapable =
+            verticalTrMirrorFallback(cp) && verticalVertFeatureSupported(ctx, cp);
           drawStackedVerticalChar(ctx, ch, cx + cellW / 2, charY, charH, vertCapable);
           charY += charH;
         }

--- a/packages/xlsx/src/stacked-glyph-orientation.test.ts
+++ b/packages/xlsx/src/stacked-glyph-orientation.test.ts
@@ -51,6 +51,7 @@ interface DrawCall {
   /** Net scale-y in effect at draw time. −1 for a reflected Tr long-stroke mark
    *  (ー 〜 ～ → `scale(1, -1)`); +1 otherwise. */
   sy: number;
+  feature: string;
 }
 
 function norm(a: number): number {
@@ -65,12 +66,14 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
   let sy = 1;
   const stack: Array<{ rotation: number; sy: number }> = [];
   const calls: DrawCall[] = [];
+  const style = { fontFeatureSettings: 'normal' };
   const ctx = {
+    canvas: { style },
     get font() { return font; }, set font(v: string) { font = v; },
     get textAlign() { return textAlign; }, set textAlign(v: CanvasTextAlign) { textAlign = v; },
     get textBaseline() { return textBaseline; }, set textBaseline(v: CanvasTextBaseline) { textBaseline = v; },
     measureText: (s: string) => ({ width: [...s].length * 20 }) as TextMetrics,
-    fillText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, sy }),
+    fillText: (t: string, x: number, y: number) => calls.push({ text: t, x, y, rot: rotation, sy, feature: style.fontFeatureSettings }),
     save: () => { stack.push({ rotation, sy }); },
     restore: () => { const s = stack.pop(); if (s) { rotation = s.rotation; sy = s.sy; } },
     translate: () => {},
@@ -93,6 +96,35 @@ const UPRIGHT = 0;
 const ROTATED = Math.PI / 2;
 
 describe('xlsx stacked text — UAX#50 per-glyph orientation (textRotation=255, issue #790)', () => {
+  it('draws mirror-fallback marks upright with a per-glyph vert feature', () => {
+    for (const ch of ['ー', '〜', '～']) {
+      const { ctx, calls } = mockCtx();
+      drawStackedVerticalChar(ctx, ch, CENTER_X, CELL_TOP, CHAR_H, true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].text).toBe(ch);
+      expect(norm(calls[0].rot)).toBe(UPRIGHT);
+      expect(calls[0].sy).toBe(1);
+      expect(calls[0].feature).toBe('"vert" 1');
+    }
+  });
+
+  it('keeps punctuation and brackets on their manual paths when vert is supported', () => {
+    const expected: Array<[string, string, number]> = [
+      ['、', '︑', UPRIGHT], ['。', '︒', UPRIGHT],
+      ['：', '：', ROTATED], ['；', '；', UPRIGHT],
+      ['「', '﹁', UPRIGHT], ['」', '﹂', UPRIGHT],
+      ['“', '“', ROTATED], ['”', '”', ROTATED],
+    ];
+    for (const [ch, text, rotation] of expected) {
+      const { ctx, calls } = mockCtx();
+      drawStackedVerticalChar(ctx, ch, CENTER_X, CELL_TOP, CHAR_H, true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].text).toBe(text);
+      expect(norm(calls[0].rot)).toBeCloseTo(rotation, 5);
+      expect(calls[0].feature).toBe('normal');
+    }
+  });
+
   it('keeps vo=U CJK upright (unchanged)', () => {
     const calls = draw(U_CJK);
     expect(calls.length).toBe(1);

--- a/packages/xlsx/src/stacked-glyph-orientation.test.ts
+++ b/packages/xlsx/src/stacked-glyph-orientation.test.ts
@@ -54,11 +54,24 @@ interface DrawCall {
   feature: string;
 }
 
+interface TransformMatrix {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+  e: number;
+  f: number;
+}
+
 function norm(a: number): number {
   return Math.atan2(Math.sin(a), Math.cos(a));
 }
 
-function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
+function mockCtx(shearSlope?: number): {
+  ctx: CanvasRenderingContext2D;
+  calls: DrawCall[];
+  transforms: TransformMatrix[];
+} {
   let font = '20px serif';
   let textAlign: CanvasTextAlign = 'center';
   let textBaseline: CanvasTextBaseline = 'top';
@@ -66,9 +79,31 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
   let sy = 1;
   const stack: Array<{ rotation: number; sy: number }> = [];
   const calls: DrawCall[] = [];
+  const transforms: TransformMatrix[] = [];
   const style = { fontFeatureSettings: 'normal' };
+  class ScratchCanvas {
+    width: number;
+    height: number;
+    style = style;
+    constructor(width: number, height: number) { this.width = width; this.height = height; }
+    getContext() {
+      const canvas = this;
+      return {
+        canvas, font: '', fillStyle: '#000', textAlign: 'center', textBaseline: 'middle',
+        clearRect() {}, fillText() {},
+        getImageData() {
+          const data = new Uint8ClampedArray(canvas.width * canvas.height * 4);
+          for (let x = 128; x <= 384; x += 1) {
+            const y = Math.round(256 + (shearSlope ?? 0) * (x - 256));
+            data[(y * canvas.width + x) * 4 + 3] = 255;
+          }
+          return { data };
+        },
+      };
+    }
+  }
   const ctx = {
-    canvas: { style },
+    canvas: shearSlope === undefined ? { style } : new ScratchCanvas(1, 1),
     get font() { return font; }, set font(v: string) { font = v; },
     get textAlign() { return textAlign; }, set textAlign(v: CanvasTextAlign) { textAlign = v; },
     get textBaseline() { return textBaseline; }, set textBaseline(v: CanvasTextBaseline) { textBaseline = v; },
@@ -79,10 +114,13 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
     translate: () => {},
     rotate: (a: number) => { rotation += a; },
     scale: (_sx: number, syArg: number) => { sy *= syArg; },
-    transform: (_a: number, _b: number, _c: number, d: number) => { sy *= d; },
+    transform: (a: number, b: number, c: number, d: number, e: number, f: number) => {
+      transforms.push({ a, b, c, d, e, f });
+      sy *= d;
+    },
     fillStyle: '#000',
   };
-  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls, transforms };
 }
 
 function draw(ch: string): DrawCall[] {
@@ -107,6 +145,13 @@ describe('xlsx stacked text — UAX#50 per-glyph orientation (textRotation=255, 
       expect(calls[0].sy).toBe(1);
       expect(calls[0].feature).toBe('"vert" 1');
     }
+  });
+
+  it('records the complete fallback shear matrix with a positive b component', () => {
+    const { ctx, transforms } = mockCtx(0.125);
+    drawStackedVerticalChar(ctx, 'ー', CENTER_X, CELL_TOP, CHAR_H);
+    expect(transforms).toEqual([{ a: 1, b: 0.125, c: 0, d: -1, e: 0, f: 0 }]);
+    expect(transforms[0].b).toBeGreaterThan(0);
   });
 
   it('keeps punctuation and brackets on their manual paths when vert is supported', () => {

--- a/packages/xlsx/src/stacked-glyph-orientation.test.ts
+++ b/packages/xlsx/src/stacked-glyph-orientation.test.ts
@@ -79,6 +79,7 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
     translate: () => {},
     rotate: (a: number) => { rotation += a; },
     scale: (_sx: number, syArg: number) => { sy *= syArg; },
+    transform: (_a: number, _b: number, _c: number, d: number) => { sy *= d; },
     fillStyle: '#000',
   };
   return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };

--- a/packages/xlsx/src/vertical-text.ts
+++ b/packages/xlsx/src/vertical-text.ts
@@ -33,6 +33,7 @@ import {
   verticalBracketFormSubstitute,
   verticalTrUprightFallback,
   verticalTrMirrorFallback,
+  withVertFeature,
 } from '@silurus/ooxml-core';
 
 type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
@@ -62,9 +63,20 @@ export function drawStackedVerticalChar(
   centerX: number,
   cellTopY: number,
   charH: number,
+  vertCapable = false,
 ): void {
   const cp = ch.codePointAt(0) ?? 0;
   const vo = verticalOrientation(cp);
+
+  if (vertCapable && verticalTrMirrorFallback(cp)) {
+    ctx.save();
+    ctx.translate(centerX, cellTopY + charH / 2);
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    withVertFeature(ctx, () => ctx.fillText(ch, 0, 0));
+    ctx.restore();
+    return;
+  }
 
   if (vo === 'Tr') {
     // Substitute-first: a fullwidth bracket or white lenticular bracket 〖〗 (#969)

--- a/packages/xlsx/src/vertical-text.ts
+++ b/packages/xlsx/src/vertical-text.ts
@@ -34,6 +34,7 @@ import {
   verticalTrUprightFallback,
   verticalTrMirrorFallback,
   withVertFeature,
+  verticalFallbackShearCoefficient,
 } from '@silurus/ooxml-core';
 
 type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
@@ -104,13 +105,16 @@ export function drawStackedVerticalChar(
     // REFLECT: their font-designed vertical form is the HORIZONTAL MIRROR of the +90°
     // rotation, not the rotation (Word/PowerPoint + font `vert` glyph verified — a plain
     // rotation of ー bulges LEFT, the designed form bulges RIGHT). After the +90° rotate,
-    // `scale(1, -1)` is the on-screen horizontal mirror. The quotes and colon do NOT
-    // reflect (their rotation matches the designed form; the colon is symmetric). Same
-    // fix as docx `drawVerticalRun` / pptx `drawEaVertRun`.
+    // y'=−y is the on-screen horizontal mirror. For U+30FC only, the shared
+    // runtime coefficient adds y'=m·x−y to cancel the horizontal glyph's measured
+    // drift. The wave marks keep their designed drift; quotes and colon do not
+    // reflect. Same fix as docx `drawVerticalRun` / pptx `drawEaVertRun`.
     ctx.save();
     ctx.translate(centerX, cellTopY + charH / 2);
     ctx.rotate(Math.PI / 2);
-    if (verticalTrMirrorFallback(cp)) ctx.scale(1, -1);
+    if (verticalTrMirrorFallback(cp)) {
+      ctx.transform(1, verticalFallbackShearCoefficient(ctx, cp), 0, -1, 0, 0);
+    }
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillText(ch, 0, 0);


### PR DESCRIPTION
## Summary

Follow-up to #1017 (vertical Tr mirror fallback). The prolonged sound mark ー (U+30FC) and wave marks 〜/～ have no Unicode vertical presentation form, so vertical (tbRl/eaVert) text painted them by rotating +90° and mirroring. That fixed the chirality but carried the horizontal glyph's right-rising stroke drift through the transform: the vertical ー rendered as a visibly diagonal stroke (≈ −2.8°), while the font's designed vertical glyph and Word are near-straight (Word PDF: −0.48°).

Three commits:

1. **Real OpenType `vert` glyphs (main line).** A canvas ELEMENT's CSS `font-feature-settings: "vert" 1` does reach the font's vert lookup, provided `ctx.font` is re-assigned after the style change (the 2D context caches the resolved font). New core helpers probe per-glyph capability (hidden per-document canvas, wide→tall ink-aspect flip, cached per font/features/code point, invalidated on FontFaceSet events) and scope-toggle the feature per glyph. docx/pptx/xlsx draw ー 〜 ～ with the real designed glyph when reachable. Scope is deliberately narrow: a broad-class prototype measurably regressed ordinary upright glyphs vs the Word PDF (title glyph ink centroids 0.94 pt → 2.24 pt mean deviation), so every other class stays on its Word-adjudicated manual path byte-identical.
2. **Measured-shear de-slant for the geometric fallback.** Workers (OffscreenCanvas), skia/node, and fonts without per-glyph vert coverage keep the rotate+mirror fallback — now composed with a runtime-measured shear for U+30FC only: the horizontal glyph's ink-centroid slope (alpha-weighted per-column centroids, Theil–Sen median over ALL ink columns — no endpoint-trim heuristics, no per-font constants) is cancelled by `transform(charScale, m, 0, −1, 0, 0)`. x′ is independent of y, so advance/measure and the #1014/#1019 ink growth are unchanged. The wave marks keep their designed drift (Yu Mincho outline evidence: vert forms retain ~8–9.5° net drift by design; skia render digests pinned byte-identical).
3. **Independent-review fixes.** Per-glyph capability probing (a font chain with vert for ー but not 〜 keeps 〜 on the fallback), feature-settings composition (kern/ssXX preserved while painting), per-surface shear cache in non-DOM environments, deterministic probe/refont/cache/sign coverage, comment updates.

## Stroke angle evidence (ー)

| Path | Before | After | Ground truth |
|---|---:|---:|---:|
| Browser (Chrome, vert path, 200px em) | ≈ −2.8° | **−0.386°** | Word PDF −0.48° |
| skia fallback (all-column Theil–Sen) | +1.04° | **−0.02°** | ≈0° designed |

Browser acceptance additionally matches Word on head/tail ink centroid (−0.59% of ink height vs GT −1.02%) and top/bottom stroke thickness ratio (1.31× vs GT 1.30×). The new VRT spec (`vertical-vert-feature.spec.ts`) measures the painted stroke through the real `drawVerticalRun` and gates |angle| ≤ 0.8°, plus orientation and waveform checks.

## Verification

- Root vitest: 4328 passed; the single failure is the known pre-existing `docx-vertical-table-cells` Word-baseline mismatch (fails identically on clean main).
- docx playwright: 86/86 — VRT demo + private references non-regressed (the vertical sample's page moved only its 13 ー glyphs, in the Word direction, staying at 100.0% match), worker-equivalence, and the new acceptance spec.
- Root typecheck, ast-grep lint clean.
- Independent read-only review (5 findings) fully addressed in commit 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)