### PR TITLE
fix(docx): honor w:rubyPr/w:hpsRaise for ruby reservation and draw offset

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3620,10 +3620,16 @@ fn parse_run_inner(
                     .and_then(|v| v.parse::<f64>().ok())
                     .map(|hp| hp / 2.0) // half-points → points
                     .unwrap_or_else(|| fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE) / 2.0);
+                let hps_raise_pt = child_w(child, "rubyPr")
+                    .and_then(|rp| child_w(rp, "hpsRaise"))
+                    .and_then(|hps_raise| attr_w(hps_raise, "val"))
+                    .and_then(|v| v.parse::<f64>().ok())
+                    .map(|hp| hp / 2.0); // half-points → points (§17.3.3.12)
                 let ruby = if !rt_text.is_empty() {
                     Some(RubyAnnotation {
                         text: rt_text,
                         font_size_pt: rt_size_pt,
+                        hps_raise_pt,
                     })
                 } else {
                     None
@@ -5696,9 +5702,15 @@ fn extract_simple_paragraph_text(
                         .and_then(|v| v.parse::<f64>().ok())
                         .map(|hp| hp / 2.0)
                         .unwrap_or_else(|| fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE) / 2.0);
+                    let hps_raise_pt = child_w(ruby_node, "rubyPr")
+                        .and_then(|rp| child_w(rp, "hpsRaise"))
+                        .and_then(|hps_raise| attr_w(hps_raise, "val"))
+                        .and_then(|v| v.parse::<f64>().ok())
+                        .map(|hp| hp / 2.0);
                     Some(RubyAnnotation {
                         text: rt_text,
                         font_size_pt,
+                        hps_raise_pt,
                     })
                 };
                 // §17.3.3.25 + §17.3.3.32 — split the base at tabs so the shared
@@ -8490,6 +8502,58 @@ mod tests {
                 _ => None,
             })
             .expect("expected a text run")
+    }
+
+    #[test]
+    fn body_ruby_surfaces_hps_raise_and_omits_it_when_absent() {
+        let base = RunFmt::default();
+        let styles = StyleMap::parse("");
+        let ruby = |ruby_pr: &str| {
+            format!(
+                r#"<w:r><w:ruby>
+                    <w:rubyPr><w:hps w:val="15"/>{ruby_pr}</w:rubyPr>
+                    <w:rt><w:r><w:t>かん</w:t></w:r></w:rt>
+                    <w:rubyBase><w:r><w:t>漢</w:t></w:r></w:rubyBase>
+                  </w:ruby></w:r>"#
+            )
+        };
+
+        let with_raise = parse_para(&ruby(r#"<w:hpsRaise w:val="30"/>"#), &base, &styles);
+        let annotation = first_text(&with_raise)
+            .ruby
+            .as_ref()
+            .expect("ruby annotation");
+        assert_eq!(
+            annotation.font_size_pt, 7.5,
+            "w:hps is stored in half-points"
+        );
+        assert_eq!(annotation.hps_raise_pt, Some(15.0));
+        assert_eq!(
+            serde_json::to_value(annotation).unwrap()["hpsRaisePt"],
+            serde_json::json!(15.0),
+        );
+
+        let without_raise = parse_para(&ruby(""), &base, &styles);
+        let annotation = first_text(&without_raise)
+            .ruby
+            .as_ref()
+            .expect("ruby annotation");
+        assert_eq!(annotation.hps_raise_pt, None);
+        assert!(
+            serde_json::to_value(annotation)
+                .unwrap()
+                .get("hpsRaisePt")
+                .is_none(),
+            "absent w:hpsRaise must remain distinguishable from zero",
+        );
+
+        let zero = parse_para(&ruby(r#"<w:hpsRaise w:val="0"/>"#), &base, &styles);
+        let annotation = first_text(&zero).ruby.as_ref().expect("ruby annotation");
+        assert_eq!(annotation.hps_raise_pt, Some(0.0));
+        assert_eq!(
+            serde_json::to_value(annotation).unwrap()["hpsRaisePt"],
+            serde_json::json!(0.0),
+        );
     }
 
     // §17.16.5.69 — Word generates each TOC entry as a navigation hyperlink
@@ -18150,6 +18214,46 @@ mod ruby_tab_tests {
         let media: HashMap<String, String> = HashMap::new();
         let theme = ThemeColors::default();
         extract_simple_paragraph_text(&style_map, &mut num_map, doc.root_element(), &theme, &media)
+    }
+
+    #[test]
+    fn shape_ruby_surfaces_hps_raise_and_omits_it_when_absent() {
+        let parse = |ruby_pr: &str| {
+            parse_shape_para(&format!(
+                r#"<w:r><w:ruby>
+                    <w:rubyPr><w:hps w:val="15"/>{ruby_pr}</w:rubyPr>
+                    <w:rt><w:r><w:t>かん</w:t></w:r></w:rt>
+                    <w:rubyBase><w:r><w:t>漢</w:t></w:r></w:rubyBase>
+                  </w:ruby></w:r>"#
+            ))
+            .expect("text-box paragraph yields a ShapeText block")
+        };
+
+        let with_raise = parse(r#"<w:hpsRaise w:val="30"/>"#);
+        let annotation = with_raise.runs[0].ruby.as_ref().expect("ruby annotation");
+        assert_eq!(
+            annotation.font_size_pt, 7.5,
+            "w:hps is stored in half-points"
+        );
+        assert_eq!(annotation.hps_raise_pt, Some(15.0));
+        assert_eq!(
+            serde_json::to_value(annotation).unwrap()["hpsRaisePt"],
+            serde_json::json!(15.0),
+        );
+
+        let without_raise = parse("");
+        let annotation = without_raise.runs[0]
+            .ruby
+            .as_ref()
+            .expect("ruby annotation");
+        assert_eq!(annotation.hps_raise_pt, None);
+        assert!(
+            serde_json::to_value(annotation)
+                .unwrap()
+                .get("hpsRaisePt")
+                .is_none(),
+            "absent w:hpsRaise must remain distinguishable from zero",
+        );
     }
 
     /// ECMA-376 §17.3.3.25 (`w:ruby`) + §17.3.3.32 (`w:tab`) — a `<w:tab/>` inside

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1491,6 +1491,10 @@ pub struct RubyAnnotation {
     pub text: String,
     /// pt
     pub font_size_pt: f64,
+    /// Distance “between the phonetic guide base text and the phonetic guide text”
+    /// in pt (ECMA-376 §17.3.3.12).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hps_raise_pt: Option<f64>,
 }
 
 /// One formatting run (`<w:r>`) inside a shape-text paragraph. Mirrors the

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -107,7 +107,7 @@ export interface LayoutTextSeg extends LayoutSegSource {
   /** ECMA-376 §17.3.2.4 `<w:bdr>` — a run-level border (box) around the text. */
   border?: DocxRunBorder | null;
   /** Ruby annotation rendered in a small font directly above this segment. */
-  ruby?: { text: string; fontSizePt: number };
+  ruby?: { text: string; fontSizePt: number; hpsRaisePt?: number };
   /** Track-changes revision attached to this run (insertion / deletion). */
   revision?: { kind: 'insertion' | 'deletion' | string; author?: string };
   /** ECMA-376 §17.3.2.30 `<w:rtl>` — run carries right-to-left characteristics.
@@ -202,9 +202,16 @@ export interface LayoutTextSeg extends LayoutSegSource {
   seaBreaks?: readonly number[];
 }
 
-/** ECMA-376 §17.3.3.25 ruby annotation ascent reserved above its base text. */
-export function rubyAscentReservePx(rubySizePt: number, scale: number): number {
-  return rubySizePt * scale * 1.5;
+/** ECMA-376 §17.3.3.12 defines `hpsRaise` as the “distance [...] between the
+ *  phonetic guide base text and the phonetic guide text.” Use that distance as
+ *  the ruby ascent reservation when present; preserve the existing 1.5×
+ *  ruby-size fallback when it is absent because the property has no default. */
+export function rubyAscentReservePx(
+  rubySizePt: number,
+  hpsRaisePt: number | undefined,
+  scale: number,
+): number {
+  return hpsRaisePt != null ? hpsRaisePt * scale : rubySizePt * scale * 1.5;
 }
 
 /**
@@ -2064,7 +2071,11 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
     // the annotation only to the first emitted segment.
     const baseRuby = (base as DocxTextRun).ruby;
     const ruby = baseRuby
-      ? { text: baseRuby.text, fontSizePt: baseRuby.fontSizePt }
+      ? {
+          text: baseRuby.text,
+          fontSizePt: baseRuby.fontSizePt,
+          ...(baseRuby.hpsRaisePt != null ? { hpsRaisePt: baseRuby.hpsRaisePt } : {}),
+        }
       : undefined;
     const revision = (base as DocxTextRun).revision;
     const r = base as DocxTextRun;
@@ -3223,7 +3234,7 @@ export function layoutLines(
     // snap actually picks the next pitch slot. 1.5× rt-size is enough for
     // any rt size that fits in one extra pitch above the base.
     if (s.ruby) {
-      asc = asc + rubyAscentReservePx(s.ruby.fontSizePt, scale);
+      asc = asc + rubyAscentReservePx(s.ruby.fontSizePt, s.ruby.hpsRaisePt, scale);
     }
 
     // ECMA-376 §17.3.2.14: a fit region is an atomic fixed-width cell. The
@@ -3777,9 +3788,9 @@ export function rescaleLayoutLines(
     // (see addToLine's segScriptHint note).
     const segScriptHint = EAST_ASIAN_RE.test(s.text) && !s.ruby;
     const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx, segScriptHint);
-    // §17.3.3.25 — ruby reserves extra ascent room (rt size × 1.5), same as layoutLines.
+    // §17.3.3.12 — ruby reserves hpsRaise when present, same as layoutLines.
     const asc = s.ruby
-      ? corrected.ascent + rubyAscentReservePx(s.ruby.fontSizePt, scale)
+      ? corrected.ascent + rubyAscentReservePx(s.ruby.fontSizePt, s.ruby.hpsRaisePt, scale)
       : corrected.ascent;
     // Intended single-line floor (font-metrics.ts) — small caps keep the FULL run
     // size here too (addToLine's intendedEm).

--- a/packages/docx/src/renderer.textbox-image.test.ts
+++ b/packages/docx/src/renderer.textbox-image.test.ts
@@ -325,6 +325,25 @@ describe('textbox rich text — per-run formatting', () => {
     expect(fillTextCalls.map((c) => c.text).join('')).toBe('根号こんごうを含む式の加か減げん');
   });
 
+  it('uses hpsRaise for the horizontal text-box ruby baseline and preserves zero', () => {
+    const distance = (hpsRaisePt: number): number => {
+      const { ctx, fillTextCalls } = makeRecordingCtx();
+      const shape = richTextbox([{
+        text: '漢', fontSizePt: 12, fontFamily: 'NotInMetrics',
+        ruby: { text: 'かん', fontSizePt: 8, hpsRaisePt },
+      }]);
+      renderShapeText(shape, 0, 0, 200, 100, ctx, 2, {}, new Map());
+      const base = fillTextCalls.find((call) => call.text === '漢');
+      const ruby = fillTextCalls.find((call) => call.text === 'かん');
+      expect(base, 'base glyph drawn').toBeDefined();
+      expect(ruby, 'ruby glyph drawn').toBeDefined();
+      return base!.y - ruby!.y;
+    };
+
+    expect(distance(14)).toBeCloseTo(28, 8);
+    expect(distance(0)).toBe(0);
+  });
+
   it('draws a numbered marker for text-box paragraphs', () => {
     const { ctx, fillTextCalls } = makeRecordingCtx();
     const shape = richTextbox([{ text: '加法、減法の言葉に合った数式を生徒に考えさせる。', fontSizePt: 10, color: '000000' }]);

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -9383,7 +9383,9 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           // characters don't touch. fillText baseline is at the line of the
           // characters, so subtract the ruby descent + small gap from the
           // base's ascent line to position correctly.
-          const rubyBaseline = baseline + yOffset - effSizePx * 0.85 - rubySizePx * 0.1;
+          const rubyBaseline = s.ruby.hpsRaisePt != null
+            ? baseline + yOffset - s.ruby.hpsRaisePt * scale
+            : baseline + yOffset - effSizePx * 0.85 - rubySizePx * 0.1;
           // Ruby shares glyphColor, so a track-changes run's ruby inherits the
           // author revision color (a behavior change from previously ignoring
           // revColor for ruby).
@@ -11184,7 +11186,10 @@ export function renderShapeText(
         const rubyReserve = mongolianLineFlip
           ? line.segments.reduce((reserve, seg) => {
               if (!('text' in seg) || !seg.ruby) return reserve;
-              return Math.max(reserve, rubyAscentReservePx(seg.ruby.fontSizePt, scale));
+              return Math.max(
+                reserve,
+                rubyAscentReservePx(seg.ruby.fontSizePt, seg.ruby.hpsRaisePt, scale),
+              );
             }, 0)
           : 0;
         const baseline =
@@ -11424,7 +11429,9 @@ export function renderShapeText(
               const rubyPx = s.ruby.fontSizePt * scale;
               const rubyChars = [...s.ruby.text];
               const spanAlong = s.measuredWidth;
-              const rubyCross = baseline + yOffset - (effSizePx / 2 + rubyPx);
+              const rubyCross = s.ruby.hpsRaisePt != null
+                ? baseline + yOffset - s.ruby.hpsRaisePt * scale
+                : baseline + yOffset - (effSizePx / 2 + rubyPx);
               const natural = rubyChars.length * rubyPx;
               const along0 = natural <= spanAlong ? x : x + (spanAlong - natural) / 2;
               const step = natural <= spanAlong ? spanAlong / rubyChars.length : rubyPx;
@@ -11551,7 +11558,9 @@ export function renderShapeText(
             ctx.font = rubyFont;
             const rubyW = ctx.measureText(s.ruby.text).width;
             const rubyX = x + (spanW - rubyW) / 2;
-            const rubyBaseline = baseline + yOffset - effSizePx * 0.85 - rubySizePx * 0.1;
+            const rubyBaseline = s.ruby.hpsRaisePt != null
+              ? baseline + yOffset - s.ruby.hpsRaisePt * scale
+              : baseline + yOffset - effSizePx * 0.85 - rubySizePx * 0.1;
             ctx.fillText(s.ruby.text, rubyX, rubyBaseline);
             ctx.restore();
           }

--- a/packages/docx/src/ruby-hpsraise-render.test.ts
+++ b/packages/docx/src/ruby-hpsraise-render.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { buildSegments, rubyAscentReservePx } from './line-layout.js';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxDocumentModel,
+  DocxTextRun,
+  SectionProps,
+} from './types';
+
+interface GlyphCall {
+  text: string;
+  x: number;
+  y: number;
+  font: string;
+}
+
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  glyphs: GlyphCall[];
+} {
+  let font = '10px serif';
+  let letterSpacing = '0px';
+  const glyphs: GlyphCall[] = [];
+  const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(value: string) { letterSpacing = value; },
+    measureText(text: string) {
+      const size = px();
+      return {
+        width: [...text].length * size,
+        fontBoundingBoxAscent: size * 0.8,
+        fontBoundingBoxDescent: size * 0.2,
+        actualBoundingBoxAscent: size * 0.8,
+        actualBoundingBoxDescent: size * 0.2,
+      } as TextMetrics;
+    },
+    fillText(text: string, x: number, y: number) { glyphs.push({ text, x, y, font }); },
+    save() {}, restore() {}, beginPath() {}, closePath() {}, moveTo() {}, lineTo() {},
+    stroke() {}, fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, setLineDash() {}, drawImage() {}, clearRect() {},
+    arc() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, textBaseline: 'alphabetic' as CanvasTextBaseline,
+    direction: 'ltr' as CanvasDirection, globalAlpha: 1,
+    lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0,
+    height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, glyphs };
+}
+
+function textRun(hpsRaisePt?: number): DocxTextRun {
+  return {
+    text: '漢', bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize: 12, color: null, fontFamily: 'NotInMetrics', isLink: false,
+    background: null, vertAlign: null, hyperlink: null,
+    ruby: {
+      text: 'かん',
+      fontSizePt: 8,
+      ...(hpsRaisePt != null ? { hpsRaisePt } : {}),
+    },
+  };
+}
+
+function documentWithRuby(hpsRaisePt?: number): DocxDocumentModel {
+  const paragraph: DocParagraph = {
+    alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+    spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+    runs: [{ type: 'text', ...textRun(hpsRaisePt) }],
+    defaultFontSize: 12, defaultFontFamily: 'NotInMetrics', widowControl: false,
+  };
+  const section: SectionProps = {
+    pageWidth: 200, pageHeight: 200,
+    marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
+    headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
+  };
+  return {
+    section,
+    body: [{ type: 'paragraph', ...paragraph } as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+async function bodyRubyBaselineDistance(hpsRaisePt?: number, scale = 2): Promise<number> {
+  const { canvas, glyphs } = makeRecordingCanvas();
+  await renderDocumentToCanvas(documentWithRuby(hpsRaisePt), canvas, 0, {
+    dpr: 1,
+    width: 200 * scale,
+  });
+  const base = glyphs.find((glyph) => glyph.text === '漢');
+  const ruby = glyphs.find((glyph) => glyph.text === 'かん');
+  expect(base, 'base glyph drawn').toBeDefined();
+  expect(ruby, 'ruby glyph drawn').toBeDefined();
+  return base!.y - ruby!.y;
+}
+
+describe('§17.3.3.12 w:hpsRaise ruby geometry', () => {
+  it('draws horizontal body ruby hpsRaise above the base baseline', async () => {
+    expect(await bodyRubyBaselineDistance(14)).toBeCloseTo(14 * 2, 8);
+  });
+
+  it('keeps the exact size-based horizontal body fallback when hpsRaise is absent', async () => {
+    const scale = 2;
+    expect(await bodyRubyBaselineDistance(undefined, scale))
+      .toBeCloseTo(12 * scale * 0.85 + 8 * scale * 0.1, 8);
+  });
+
+  it('treats explicit hpsRaise zero as a zero reservation and zero draw offset', async () => {
+    expect(rubyAscentReservePx(8, 0, 2)).toBe(0);
+    expect(await bodyRubyBaselineDistance(0)).toBe(0);
+  });
+
+  it('keeps absent hpsRaise off the emitted segment own-property set', () => {
+    const environment = {
+      defaultFontSize: 12,
+      defaultFontFamily: 'NotInMetrics',
+      fontFamilyClasses: {},
+      pageIndex: 0,
+      totalPages: 1,
+    };
+    const [absent] = buildSegments(
+      [{ type: 'text', ...textRun() }],
+      environment,
+    );
+    const [zero] = buildSegments(
+      [{ type: 'text', ...textRun(0) }],
+      environment,
+    );
+    expect(absent && 'ruby' in absent && absent.ruby).toBeDefined();
+    expect(zero && 'ruby' in zero && zero.ruby).toBeDefined();
+    if (!absent || !('ruby' in absent) || !zero || !('ruby' in zero)) {
+      throw new Error('expected text segments');
+    }
+    expect(Object.hasOwn(absent.ruby!, 'hpsRaisePt')).toBe(false);
+    expect(Object.hasOwn(zero.ruby!, 'hpsRaisePt')).toBe(true);
+    expect(zero.ruby!.hpsRaisePt).toBe(0);
+  });
+});

--- a/packages/docx/src/textbox-vertical-render.test.ts
+++ b/packages/docx/src/textbox-vertical-render.test.ts
@@ -502,6 +502,89 @@ describe('§20.1.10.83 textbox <wps:bodyPr vert> — vertical text-box rendering
     }
   });
 
+  it('mongolianVert hpsRaise increases the ruby-bearing column advance by the reservation delta', () => {
+    const render = (ruby: false | { hpsRaisePt?: number }) => {
+      const { ctx, glyphs } = makeMatrixCtx();
+      const baseSizePt = 15;
+      const rubySizePt = 7.5;
+      const baseRun: ShapeTextRun = {
+        text: '漢', fontSizePt: baseSizePt, fontFamily: 'NotInMetrics',
+        ...(ruby ? { ruby: { text: 'かん', fontSizePt: rubySizePt, ...ruby } } : {}),
+      };
+      const rubyBlock: ShapeText = {
+        text: '漢', fontSizePt: baseSizePt, alignment: 'left',
+        runs: [baseRun],
+      };
+      const nextBlock: ShapeText = {
+        text: CJK, fontSizePt: baseSizePt, alignment: 'left',
+        runs: [{ text: CJK, fontSizePt: baseSizePt, fontFamily: 'NotInMetrics' }],
+      };
+      const shape = richTextbox([baseRun], 'mongolianVert');
+      (shape as unknown as { textBlocks: ShapeText[] }).textBlocks = [rubyBlock, nextBlock];
+      renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {});
+      const base = glyphs.find((g) => g.text.includes('漢'));
+      const next = glyphs.find((g) => g.text.includes(CJK));
+      const rubyGlyphs = glyphs.filter((g) => /[かん]/.test(g.text));
+      expect(base, 'base glyph drawn').toBeDefined();
+      expect(next, 'next-column glyph drawn').toBeDefined();
+      if (ruby) expect(rubyGlyphs.length, 'ruby glyphs drawn').toBe(2);
+      return {
+        columnAdvance: next!.devX - base!.devX,
+        rubyCrossOffset: rubyGlyphs.length > 0
+          ? Math.max(...rubyGlyphs.map((g) => g.devX)) - base!.devX
+          : NaN,
+      };
+    };
+
+    const plain = render(false);
+    const fallback = render({});
+    const zero = render({ hpsRaisePt: 0 });
+    const raised = render({ hpsRaisePt: 15 });
+    expect(
+      fallback.columnAdvance - plain.columnAdvance,
+      'the absent-hpsRaise column reserves 1.5 × 7.5pt',
+    ).toBeCloseTo(11.25, 5);
+    expect(
+      raised.columnAdvance - fallback.columnAdvance,
+      'the explicit reservation grows from 11.25pt to 15pt',
+    ).toBeCloseTo(3.75, 5);
+    expect(zero.columnAdvance, 'zero hpsRaise adds no column reservation')
+      .toBeCloseTo(plain.columnAdvance, 5);
+    expect(zero.rubyCrossOffset, 'zero hpsRaise draws ruby on the base centerline').toBeCloseTo(0, 5);
+    expect(
+      raised.rubyCrossOffset,
+      '15pt hpsRaise equals the established effSize/2 + rubySize draw offset',
+    ).toBeCloseTo(fallback.rubyCrossOffset, 5);
+  });
+
+  it('mongolianVert without hpsRaise keeps the ruby-size-times-1.5 column reservation', () => {
+    const columnAdvance = (withRuby: boolean): number => {
+      const { ctx, glyphs } = makeMatrixCtx();
+      const baseRun: ShapeTextRun = {
+        text: '漢', fontSizePt: 15, fontFamily: 'NotInMetrics',
+        ...(withRuby ? { ruby: { text: 'かん', fontSizePt: 7.5 } } : {}),
+      };
+      const rubyBlock: ShapeText = {
+        text: '漢', fontSizePt: 15, alignment: 'left',
+        runs: [baseRun],
+      };
+      const nextBlock: ShapeText = {
+        text: CJK, fontSizePt: 15, alignment: 'left',
+        runs: [{ text: CJK, fontSizePt: 15, fontFamily: 'NotInMetrics' }],
+      };
+      const shape = richTextbox([baseRun], 'mongolianVert');
+      (shape as unknown as { textBlocks: ShapeText[] }).textBlocks = [rubyBlock, nextBlock];
+      renderShapeText(shape, 0, 0, 200, 100, ctx, 1, {});
+      const base = glyphs.find((g) => g.text.includes('漢'));
+      const next = glyphs.find((g) => g.text.includes(CJK));
+      expect(base, 'base glyph drawn').toBeDefined();
+      expect(next, 'next-column glyph drawn').toBeDefined();
+      return next!.devX - base!.devX;
+    };
+
+    expect(columnAdvance(true) - columnAdvance(false)).toBeCloseTo(11.25, 5);
+  });
+
   // Autofit (spAutoFit) shares the same line resolver: a ruby-bearing vertical
   // line must widen the fitted cross extent by the same reservation, or the
   // grown box would clip the furigana (sample-53 box (d) class).

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1310,6 +1310,10 @@ export interface RubyAnnotation {
   text: string;
   /** Annotation font size in pt. Word stores this as half-points in `<w:hps>`. */
   fontSizePt: number;
+  /** Distance “between the phonetic guide base text and the phonetic guide
+   *  text” in pt. Word stores this as half-points in `<w:hpsRaise>`
+   *  (ECMA-376 §17.3.3.12). */
+  hpsRaisePt?: number;
 }
 
 /** ECMA-376 §17.18.24 ST_Em — the emphasis-mark styles a run may carry via


### PR DESCRIPTION
## Summary

ECMA-376 §17.3.3.12 defines `w:rubyPr/w:hpsRaise` (half-points) as the distance left between the phonetic guide base text and the phonetic guide text. We previously ignored it everywhere: the ruby line/column reservation used a flat `1.5 × rt-size` heuristic and the ruby draw offsets used size-based fallbacks. Known follow-up from PR #1022.

### Parser (Rust, both paths)

`hpsRaise` is now surfaced as `RubyAnnotation.hpsRaisePt` (pt) from both the body `w:ruby` path and the shape/`txbxContent` path. `Option<f64>` with serde omission keeps an absent element distinguishable from an explicit `0`; the TS `RubyAnnotation` mirrors it as an optional field.

### Reservation

`rubyAscentReservePx` (the single chokepoint feeding body line height and vertical text-box column advance) reserves `hpsRaisePt` when present. When absent it keeps the byte-identical `rt-size × 1.5` fallback — the property has no spec default.

### Draw offsets

All three renderer ruby draw sites (horizontal body, horizontal text-box, vertical text-box cross axis) place the ruby `hpsRaisePt` above the base baseline when present; the size-based fallback expressions are byte-identical when absent.

## Ground truth (Word PDFs, measured with pdfplumber)

- Horizontal body ruby (base 12pt / rt 8pt / hpsRaise 14pt): Word lifts the ruby baseline ~14pt above the base baseline. Before: 11.0pt (`0.85×base + 0.1×rt`); after: 14.0pt.
- Vertical eaVert text box (base 15pt / rt 7.5pt / hpsRaise 15pt): Word leaves ~8pt between the furigana column and the next column. Before: ~4pt (reservation 11.25pt); after: ~8pt (reservation 15pt = hpsRaise). The vertical draw offset is invariant there because the `eff/2 + rt` fallback coincides with hpsRaise at those sizes.

## Tests

- Rust: presence + omission of `hpsRaisePt` for both parse paths (348 pass).
- TS: horizontal draw-offset geometry (hpsRaise / fallback / explicit zero), vertical column-advance reservation delta (+3.75pt for the GT sizes), absent-vs-zero own-property distinction, horizontal text-box path (1415 pass).

## Gates

- `cargo fmt` / `clippy -D warnings` / `cargo test` — clean, 348 pass
- WASM rebuilt via package script; real-file probe confirms `hpsRaisePt` surfaces end to end
- docx vitest 180 files / 1415 tests pass; root `pnpm typecheck` clean
- demo VRT 6/6 non-regression (byte-identical diffs to pre-change baseline; the demo sample carries no ruby)

Private ruby-bearing samples will shift toward Word (horizontal ruby sits 1–3pt higher; reviewer to regenerate local references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)