### PR TITLE
fix(docx): count docGrid cells from the design height, not the substituted box (§17.6.5)

### DIFF
--- a/packages/docx/src/docgrid-grid-count-height.test.ts
+++ b/packages/docx/src/docgrid-grid-count-height.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Producer-level pins for the per-line docGrid grid-count height
+ * (`LayoutLine.gridCountSingle`) computed by {@link layoutLines} — the value
+ * that feeds §17.6.5 East Asian cell counting in {@link lineBoxHeight}.
+ *
+ * The rule (see addToLine): the max over segments of each run's Word-faithful
+ * single-line height, where a tabled EA run counts from its DESIGN height, an
+ * untabled EA run from its measured box, and a Latin run does NOT contribute
+ * (it is not cell-rounded). This is what keeps a substituted face's over-tall
+ * box from inflating the cell count (sample-52) while still letting a genuinely
+ * tall untabled East Asian run claim its cells (independent-review mixed case).
+ *
+ * A linear stub context makes the metrics analytic: measured box = fontSize
+ * (0.8 + 0.2 em); Yu Mincho's tabled EA design height = 1.43267 × em.
+ */
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_KINSOKU_RULES } from '@silurus/ooxml-core';
+import { layoutLines, type LayoutSeg, type LayoutTextSeg } from './line-layout.js';
+
+function linearCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const px = (): number => Number.parseFloat(/([\d.]+)px/.exec(font)?.[1] ?? '10');
+  return {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (t: string) => ({
+      width: [...t].length * px() * 0.5,
+      fontBoundingBoxAscent: px() * 0.8,
+      fontBoundingBoxDescent: px() * 0.2,
+      actualBoundingBoxAscent: px() * 0.8,
+      actualBoundingBoxDescent: px() * 0.2,
+    } as TextMetrics),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function seg(text: string, fontFamily: string, fontSize: number): LayoutTextSeg {
+  return {
+    text, bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize, color: null, fontFamily, vertAlign: null, measuredWidth: 0,
+  };
+}
+
+function layout(segs: LayoutTextSeg[], width = 400) {
+  return layoutLines(
+    linearCtx(), segs.map((s) => ({ ...s })) as LayoutSeg[], width, 0, 1,
+    undefined, undefined, {}, 0, DEFAULT_KINSOKU_RULES, 0, 36, width, false, false, false,
+  );
+}
+
+// Yu Mincho tabled EA design single-line height per pt: 1.3 × hhea box = 1.43267 em.
+const YU = (2257 * 1.3) / 2048;
+
+describe('layoutLines — per-line gridCountSingle (§17.6.5 docGrid cell height)', () => {
+  it('a tabled EA line counts from its DESIGN height, not the (larger) measured box', () => {
+    // 12pt Yu Mincho CJK: measured box 12px (linear stub) but design 17.19px.
+    const [line] = layout([seg('あいうえお', 'Yu Mincho', 12)]);
+    expect(line.gridCountSingle).toBeCloseTo(12 * YU, 4);
+    expect(line.gridCountSingle).toBeGreaterThan(12); // above the raw box
+  });
+
+  it('EXCLUDES a Latin run on a mixed CJK+Latin line (sample-52 shape)', () => {
+    // sample-52's lines mix ASCII and CJK ("TABLE 1 = …（…）"). The ASCII run in
+    // Yu Mincho has no design height (eaOnly ⇒ intendedSingle 0), and its
+    // SUBSTITUTED Canvas box overshoots the real Latin height — Word measured
+    // sample-52's exact table at x0=417 == the CJK-design (1-cell) layout, so
+    // the ASCII box must NOT drive the count. This test uses a deliberately
+    // TALL 20pt Latin run (box 20px > the 12pt CJK design 17.19px) to
+    // DISCRIMINATE the exclusion: were it counted the result would be 20; the
+    // §17.6.5 "Latin is not cell-rounded" rule yields the CJK design alone.
+    // (The tall-Latin mixed line has no Word ground truth of its own — this
+    // characterizes the deliberate rule, consistent with the Latin-only case.)
+    const [line] = layout([seg('TABLE 1 = ', 'Yu Mincho', 20), seg('固定幅（両軸拘束）。', 'Yu Mincho', 12)]);
+    expect(line.gridCountSingle).toBeCloseTo(12 * YU, 4);
+    expect(line.gridCountSingle).toBeLessThan(20); // the 20pt Latin box did NOT count
+  });
+
+  it('counts a genuinely TALL untabled EA run over a small tabled run (mixed case)', () => {
+    // Small 12pt Yu Mincho (design 17.19) + a large 24pt untabled CJK face
+    // (measured box 24). The untabled run is taller and East Asian, so it must
+    // claim its extent: max(17.19, 24) = 24. Guards the design-height rule from
+    // under-counting a tall untabled run (independent review, Codex gpt-5.6-sol).
+    const [line] = layout([seg('小', 'Yu Mincho', 12), seg('大きい', 'PMingLiU', 24)]);
+    expect(line.gridCountSingle).toBeCloseTo(24, 4);
+  });
+
+  it('a pure-Latin line is NOT cell-rounded — falls back to the box (unused off the EA path)', () => {
+    // No EA segment contributes, so gridCountSingle falls back to the line box
+    // (== old `natural`). The line is non-EA, so lineBoxHeight never consults it.
+    const [line] = layout([seg('hello world', 'Times New Roman', 12)]);
+    expect(line.eastAsian ?? false).toBe(false);
+    expect(line.gridCountSingle).toBeCloseTo(line.ascent + line.descent, 4);
+  });
+});

--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -208,13 +208,39 @@ describe('lineBoxHeight — docGrid line-cell rounding (East Asian vs Latin)', (
   it('snaps a sub-pitch EA line to ONE cell of the grid pitch', () => {
     expect(lineBoxHeight(null, 12 * YU_ASC, 12 * YU_DESC, 1, grid18, false, 12 * YU, true)).toBe(18);
   });
+  it('does NOT let a substitute box a hair over the pitch add a cell — grid-count height governs (sample-52)', () => {
+    // Font-substitution artifact: Hiragino Mincho ProN stands in for Yu Mincho
+    // and its 12pt Canvas box measures 18.0+px — a HAIR OVER the 18pt pitch —
+    // while Yu Mincho's design single-line height is 17.19px, UNDER the pitch.
+    // Word counts grid cells from the REAL font's design height (1 cell here),
+    // never from the substituted Canvas box, so when the caller supplies the
+    // line's design grid-count height (arg 9 = 12*YU) the over-tall box must not
+    // inflate the count to two cells. Counting from the box mis-widths every
+    // tbRl column and shifts vertical-section block tables 36pt (issue:
+    // sample-52 vertical-table probe, exact table left 417→381pt).
+    const boxAsc = 18.02 * 0.8; // substitute box 18.02px > the 18pt pitch
+    const boxDesc = 18.02 * 0.2;
+    expect(lineBoxHeight(null, boxAsc, boxDesc, 1, grid18, false, 12 * YU, true, 12 * YU)).toBe(18);
+  });
+  it('still counts a tall UNTABLED run on a mixed line — grid-count height keeps its box', () => {
+    // A mixed docGrid line: a small 12pt tabled Yu Mincho run (design 17.19px,
+    // the intendedSingle floor) plus a larger untabled CJK run whose measured
+    // box is 30px. The line's grid-count height (arg 9) is the max over runs of
+    // (tabled design | untabled box) = max(17.19, 30) = 30, so the untabled run
+    // still claims its two cells — the design-height rule must not UNDER-count
+    // a genuinely tall untabled run (independent review, Codex gpt-5.6-sol).
+    expect(lineBoxHeight(null, 24, 6, 1, grid18, false, 12 * YU, true, 30)).toBe(36);
+  });
   it('rounds a 20pt EA line on a 20pt pitch UP to two cells (sample-9)', () => {
     // design box 28.65px → ceil(28.65/20) = 2 cells = 40.
     expect(lineBoxHeight(null, 20 * YU_ASC, 20 * YU_DESC, 1, grid20, false, 20 * YU, true)).toBe(40);
   });
-  it('guards the cell count against an UNCORRECTED over-tall glyph box via max()', () => {
-    // A substitute box (24+6=30px) taller than the design floor (20pt design =
-    // 28.65px): natural = max(30, 28.65) = 30 → still 2 cells on a 20pt pitch.
+  it('falls back to natural when no grid-count height is supplied (box 30 → 2 cells)', () => {
+    // With no arg-9 grid-count height, the count falls back to `natural` =
+    // max(box 24+6=30, design floor 20*YU=28.65) = 30 → ceil(30/20) = 2 cells =
+    // 40 on a 20pt pitch. Both the box and the design floor land in the same
+    // cell here, so the pre-existing callers (which supply no arg 9) are
+    // unaffected. Callers that need the substitution-robust count pass arg 9.
     expect(lineBoxHeight(null, 24, 6, 1, grid20, false, 20 * YU, true)).toBe(40);
   });
   it('keeps a Latin line at natural height (one-cell floor), NOT cell-rounded', () => {

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -316,6 +316,12 @@ export interface LayoutLine {
    *  font's win line-height ratio × em), for fonts whose substituted Canvas
    *  metrics understate Word's line spacing. 0 when no segment needs it. */
   intendedSingle: number;
+  /** px — DESIGN grid-count height: the max over segments of each run's
+   *  Word-faithful single-line height (a tabled run's design height, an
+   *  untabled run's measured box). Feeds docGrid cell counting so a substituted
+   *  face's over-tall box does not inflate the cell count while a genuinely tall
+   *  untabled run still counts its real extent (§17.6.5; sample-52). */
+  gridCountSingle: number;
   /** Additional horizontal offset (px) from paraX, caused by wrap-around floats. */
   xOffset: number;
   /** Effective available width (px) for this line after float exclusion. */
@@ -372,8 +378,10 @@ export interface WrapLayoutCtx {
     xOffsetPt: number;
     maximumWidthPt: number;
   };
-  /** Per-line box-height resolver (line natural ascent+descent → total px box height). */
-  lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number, eastAsian?: boolean) => number;
+  /** Per-line box-height resolver (line natural ascent+descent → total px box height).
+   *  `gridCountSinglePx` (the line's design grid-count height) keeps the
+   *  float-wrap advance consistent with the final render's docGrid cell count. */
+  lineBoxH: (ascentPx: number, descentPx: number, hasRuby?: boolean, intendedSinglePx?: number, eastAsian?: boolean, gridCountSinglePx?: number) => number;
   /** Hard cap on Y to keep layout from running past the page. */
   pageH: number;
 }
@@ -991,6 +999,16 @@ export function lineBoxHeight(
   hasRuby?: boolean,
   intendedSinglePx = 0,
   eastAsian = false,
+  // px — the line's DESIGN grid-count height: the max over segments of each
+  // run's Word-faithful single-line height (a tabled run's design height, an
+  // untabled run's measured box). Used ONLY to count docGrid cells for East
+  // Asian lines, so a substituted face whose Canvas box overshoots the real
+  // font's design height does not add a spurious cell (see gridSingleCell).
+  // When omitted, the count falls back to `natural` (the substituted glyph
+  // box floored by the design height) — the pre-existing behaviour, which the
+  // callers that pre-correct their metrics (correctLineMetrics) already resolve
+  // correctly.
+  gridCountSinglePx?: number,
 ): number {
   const glyphNatural = ascentPx + descentPx;
   // For `auto`/single spacing the multiplier applies to the intended font's
@@ -1012,9 +1030,12 @@ export function lineBoxHeight(
   // body paragraph with line="320" renders at pitch × 1.33 = ~24 pt.
   //
   // A single-spaced line on a docGrid snaps to whole grid CELLS in East Asian
-  // text. The number of cells is derived from the line's resolved single-line
-  // height (`natural` — the design line height, per the sample-58 adjudication
-  // of issue #1013); see docGridLineCells for the rule and Word measurements.
+  // text. The number of cells is derived from the line's DESIGN single-line
+  // height (`gridCountSinglePx` — what Word measures: each run's real-font
+  // single-line height), per the sample-58 adjudication of issue #1013; the
+  // substituted Canvas glyph box is NOT used for the count (it can overstate a
+  // tabled font's design height and add a spurious cell). See gridSingleCell and
+  // docGridLineCells for the rule and measurements.
   // A Latin-only line is NOT cell-rounded — it keeps its natural height above
   // a one-cell floor (demo/sample-1: an 18pt heading on an 18pt pitch stays
   // ~20.7px, not 36). ECMA-376 Part 1 only defines the natural ≤ pitch case
@@ -1026,7 +1047,21 @@ export function lineBoxHeight(
     // glyph box so the annotation is not clipped. Plain EA lines snap their
     // design single-line height to whole cells.
     if (hasRuby) return Math.max(pitchPx, Math.ceil(glyphNatural / pitchPx) * pitchPx);
-    return docGridLineCells(natural, pitchPx) * pitchPx;
+    // Word counts grid cells from the run's DESIGN single-line height (the real
+    // font's metrics — §17.6.5), NOT the substituted Canvas glyph box, which can
+    // overstate that height. A substitute face whose box lands a hair over the
+    // pitch (e.g. Hiragino Mincho ProN standing in for Yu Mincho: an 18.17px box
+    // vs Yu's 17.19px design height at 12pt on an 18pt pitch) must not push the
+    // line into an extra cell — that mis-widths every tbRl column and shifts
+    // vertical-section block tables by whole cells (sample-52). Prefer the
+    // per-line design grid-count height when the caller supplies it — it is the
+    // max over runs of each run's Word-faithful single-line height (design for a
+    // tabled run, measured box for an untabled one), so a mixed tabled+untabled
+    // line still counts the untabled run's real extent. Callers that pre-correct
+    // their metrics (correctLineMetrics) omit it and fall back to `natural`,
+    // which is already the design height for them.
+    const cellCountHeight = gridCountSinglePx ?? natural;
+    return docGridLineCells(cellCountHeight, pitchPx) * pitchPx;
   };
   const inheritedOnly = ls !== null && ls.explicit !== true;
   if (!ls) {
@@ -2552,6 +2587,7 @@ export function layoutLines(
   let lineAscent = 0;   // px
   let lineDescent = 0;  // px
   let lineIntendedSingle = 0; // px — max intended single-line height on the line
+  let lineGridCountSingle = 0; // px — max over segments of (tabled design height | untabled box)
   let isFirst = true;
   // Effective width/offset for the current line after float exclusion.
   let lineMaxWidth = maxWidth;
@@ -2707,6 +2743,9 @@ export function layoutLines(
       ascent: asc,
       descent: desc,
       intendedSingle: lineIntendedSingle,
+      // Empty/synthetic lines carry no per-segment count, so fall back to the
+      // synthesized box (== the old `natural` for an untabled line).
+      gridCountSingle: lineGridCountSingle || (asc + desc),
       xOffset: lineXOffset,
       availWidth: lineMaxWidth,
       topY: wrapCtx ? currentLineTopY : undefined,
@@ -2716,7 +2755,7 @@ export function layoutLines(
       consumedEnd: nextStart ?? queue[0]?.src ?? endBoundary,
     });
     if (wrapCtx) {
-      currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle, lineEastAsian);
+      currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle, lineEastAsian, lineGridCountSingle || (asc + desc));
     }
     currentLine = [];
     currentWidth = 0;
@@ -2726,6 +2765,7 @@ export function layoutLines(
     lineAscent = 0;
     lineDescent = 0;
     lineIntendedSingle = 0;
+    lineGridCountSingle = 0;
     lineHasRuby = false;
     lineEastAsian = false;
     lineHasSea = false;
@@ -2756,6 +2796,13 @@ export function layoutLines(
     if (h > lineHeight) lineHeight = h;
     if (asc > lineAscent) lineAscent = asc;
     if (desc > lineDescent) lineDescent = desc;
+    // Grid-count height for docGrid cell allocation (§17.6.5). Only East Asian
+    // TEXT (and tall inline objects) drives the count — a Latin run keeps its
+    // natural height and is NOT cell-rounded, so it must not contribute (its
+    // substituted Canvas box would otherwise inflate the count). An EA text run
+    // counts from its DESIGN height when tabled, else its measured box; an
+    // image/math object counts its measured box. The line's value is the max.
+    let segGridCount = 0;
     if (!('isTab' in s) && !('imagePath' in s) && !('mathNodes' in s)) {
       const ts = s as LayoutTextSeg;
       if (ts.ruby) lineHasRuby = true;
@@ -2775,7 +2822,14 @@ export function layoutLines(
       const segScriptHint = EAST_ASIAN_RE.test(ts.text) && !ts.ruby;
       const intended = intendedSingleLinePx(ts.fontFamily, intendedEm, segScriptHint);
       if (intended > lineIntendedSingle) lineIntendedSingle = intended;
+      // Only East Asian text is cell-rounded; a tabled EA run counts from its
+      // design height, an untabled EA run from its measured box.
+      if (segScriptHint) segGridCount = intended > 0 ? intended : asc + desc;
+    } else if (!('isTab' in s)) {
+      // Image/math object: a tall inline object sizes the line's cells too.
+      segGridCount = asc + desc;
     }
+    if (segGridCount > lineGridCountSingle) lineGridCountSingle = segGridCount;
   };
 
   const effectiveFontPx = (s: LayoutTextSeg): number => calcEffectiveFontPx(s, scale);
@@ -3803,6 +3857,7 @@ export function rescaleLayoutLines(
     let asc = 0;
     let desc = 0;
     let intended = 0;
+    let gridCount = 0; // px — max over segments of (tabled design | measured box)
     let hasText = false;
     const scaledSource = l.segments.map((segment) => ({ ...segment })) as LayoutSeg[];
     // Recompute the region gap from paint-scale natural metrics. Reusing the
@@ -3843,6 +3898,7 @@ export function rescaleLayoutLines(
         copy.mathDescent *= scale;
         asc = Math.max(asc, copy.mathAscent, s.fontSize * scale * 0.8);
         desc = Math.max(desc, copy.mathDescent, s.fontSize * scale * 0.2);
+        gridCount = Math.max(gridCount, copy.mathAscent + copy.mathDescent);
         return copy;
       }
       const t = s as LayoutTextSeg;
@@ -3851,6 +3907,13 @@ export function rescaleLayoutLines(
       if (mm.asc > asc) asc = mm.asc;
       if (mm.desc > desc) desc = mm.desc;
       if (mm.intended > intended) intended = mm.intended;
+      // Only East Asian text is cell-rounded (§17.6.5); a Latin run keeps its
+      // natural height and must not contribute its (substituted) box to the
+      // grid-count height. A tabled EA run counts from its design height, an
+      // untabled EA run from its measured box.
+      if (EAST_ASIAN_RE.test(t.text) && !t.ruby) {
+        gridCount = Math.max(gridCount, mm.intended > 0 ? mm.intended : mm.asc + mm.desc);
+      }
       return { ...t, measuredWidth: mm.advance };
     });
     // Empty/synthetic line (no text/math contributing metrics): fall back to the
@@ -3859,6 +3922,7 @@ export function rescaleLayoutLines(
       asc = l.ascent * scale;
       desc = l.descent * scale;
       intended = l.intendedSingle * scale;
+      gridCount = l.gridCountSingle * scale;
     }
     return {
       ...l,
@@ -3866,6 +3930,7 @@ export function rescaleLayoutLines(
       ascent: asc,
       descent: desc,
       intendedSingle: intended,
+      gridCountSingle: gridCount || (asc + desc),
       // Pure page geometry — scale-linear (no glyph hinting).
       xOffset: l.xOffset * scale,
       availWidth: l.availWidth * scale,

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -252,7 +252,7 @@ export function measureParagraph(
         columnWidthPt: placement.availableWidthPt,
         floats: [],
         lineWindow: (input) => placement.wrap!.lineWindow(input),
-        lineBoxH: (ascent, descent, _hasRuby, intendedSingle, eastAsian) => lineBoxHeight(
+        lineBoxH: (ascent, descent, _hasRuby, intendedSingle, eastAsian, gridCountSingle) => lineBoxHeight(
           context.lineSpacing,
           ascent,
           descent,
@@ -263,6 +263,7 @@ export function measureParagraph(
           // §17.6.5 cell rounding follows this line's script, matching text boxes;
           // ruby paragraphs retain their established uniform paragraph resolver.
           context.hasRuby ? context.hasEastAsianText : (eastAsian ?? false),
+          gridCountSingle,
         ),
         pageH: placement.maximumYPt,
       }
@@ -329,6 +330,7 @@ export function measureParagraph(
           // §17.6.5 cell rounding is gated by the line's script; a Latin-only
           // line in a CJK paragraph keeps its natural height.
           line.eastAsian ?? false,
+          line.gridCountSingle,
         );
     measuredLines.push({ layout: line, topYPt, advancePt });
     cursorPt = topYPt + advancePt;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -7679,6 +7679,7 @@ function resolveFrameBox(
         // §17.6.5 cell rounding follows this line's script, matching text boxes;
         // ruby paragraphs retain their established uniform paragraph resolver.
         paraHasRuby ? paragraphContext.hasEastAsianText : (l.eastAsian ?? false),
+        l.gridCountSingle,
       ),
     0,
   );
@@ -8017,7 +8018,7 @@ function renderParagraph(
     columnXPt: contentX,
     columnWidthPt: contentW,
     floats: state.floats,
-    lineBoxH: (a, d, _h, is, ea) => lineBoxHeight(
+    lineBoxH: (a, d, _h, is, ea, gc) => lineBoxHeight(
       para.lineSpacing,
       a,
       d,
@@ -8028,6 +8029,7 @@ function renderParagraph(
       // §17.6.5 cell rounding follows this line's script, matching text boxes;
       // ruby paragraphs retain their established uniform paragraph resolver.
       paraHasRuby ? paragraphContext.hasEastAsianText : (ea ?? false),
+      gc,
     ),
     pageH: state.pageH,
   } : undefined;
@@ -8223,7 +8225,7 @@ function renderParagraph(
       ? uniformLineH
       // §17.6.5 cell rounding is gated by the line's script; a Latin-only line
       // in a CJK paragraph keeps its natural height, matching the text-box path.
-      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, l.eastAsian ?? false);
+      : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, l.eastAsian ?? false, l.gridCountSingle);
 
   // Slice bounds — when the paginator split this paragraph across pages,
   // only render lines in [sliceStart, sliceEnd). The first line we paint
@@ -12955,7 +12957,7 @@ function measureCellParagraphWindow(
         ? uniformLineH
         // §17.6.5 cell rounding is gated by the line's script; a Latin-only line
         // in a CJK paragraph keeps its natural height, matching the text-box path.
-        : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, l.eastAsian ?? false);
+        : lineBoxHeight(para.lineSpacing, l.ascent, l.descent, scale, grid, false, l.intendedSingle, l.eastAsian ?? false, l.gridCountSingle);
     return {
       heightPx: paintedParagraphHeight(paintLines, windowStart, windowEnd, 0, lineHForLine),
       totalLines,


### PR DESCRIPTION
## Problem

In a vertical (`tbRl`) section with a `<w:docGrid>` line grid, block tables were positioned whole grid cells away from where Word places them. The exact-height table in the vertical-table fixture landed 36.1 pt (two 18 pt cells) to the left of its Word-PDF x-position, and the preceding text columns were correspondingly over-wide.

A bisect pinned the regression to the change that moved the East Asian docGrid cell count to a natural-height rule (#1013): it is not #1022-related.

## Root cause

Per ECMA-376 §17.6.5, an East Asian line on a docGrid occupies `ceil(single-line height / linePitch)` whole cells; in a `tbRl` section that cell height is the physical **column width**, so it directly drives where downstream content — including block tables — is placed.

`lineBoxHeight` derived that count from `natural = max(substituted Canvas glyph box, design-height floor)`. When the document font is **substituted**, the substitute's box can overshoot the real font's design height by a hair: a 12 pt East Asian line whose design height is ~17.2 pt (**under** an 18 pt pitch) renders through a substitute whose box measures ~18.2 pt (**over** the pitch), so the line claimed 2 cells (36 pt) where Word takes 1 (18 pt). That widened every preceding `tbRl` column and pushed the section's block tables left by whole cells.

Word measures grid cells from the **real font's design height**, so a substitution artifact must not change the count. (The Word PDF was re-measured from the rendered page bitmap to confirm the fixture's ground-truth table positions are correct, not stale.)

## Fix

Derive the cell count from a per-line **design grid-count height** — the max over the line's segments of each run's Word-faithful single-line height:

- a **tabled** East Asian run counts from its design height;
- a genuinely **untabled** East Asian run counts from its measured box;
- an image / math object counts its box;
- **Latin runs are excluded** — §17.6.5 does not cell-round Latin text, and their substitute box would otherwise inflate the count on a mixed CJK+Latin line (the direct cause here, since the design-height table entry is East-Asian-only).

The value is computed once in `layoutLines` (and `rescaleLayoutLines`), carried on `LayoutLine` as `gridCountSingle`, and passed to `lineBoxHeight` — including through the float-wrap `WrapLayoutCtx.lineBoxH` callback so the wrap advance matches the final render. `lineBoxHeight` falls back to the previous `natural` when no grid-count height is supplied, so callers that already pre-correct their metrics are unchanged.

## Verification

- Vertical-table probe: exact table now matches its Word-PDF x-position on both axes; auto table invariants hold.
- docGrid line/column-pitch adjudication matrix (both writing directions, 10.5/12/14/16/20 pt × 18/24 pt pitch) unchanged.
- New producer-level tests pin `gridCountSingle`: tabled EA → design height; Latin excluded on a mixed line; a tall untabled EA run still counts its box; pure-Latin falls back.
- Full docx unit + probe suites, node suite, and root typecheck pass; the demo visual-regression baseline is pixel-identical.
- Independently reviewed (read-only) by Codex gpt-5.6-sol across two rounds; the mixed tabled/untabled handling and the float-wrap threading are the result of that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)