### PR TITLE
fix(docx): deterministic docGrid cell count for untabled East Asian fonts

### DIFF
--- a/packages/docx/src/docgrid-grid-count-height.test.ts
+++ b/packages/docx/src/docgrid-grid-count-height.test.ts
@@ -5,17 +5,22 @@
  *
  * The rule (see addToLine): the max over segments of each run's Word-faithful
  * single-line height, where a tabled EA run counts from its DESIGN height, an
- * untabled EA run from its measured box, and a Latin run does NOT contribute
+ * untabled EA run from the Word FE 1.3em fallback, and a Latin run does NOT contribute
  * (it is not cell-rounded). This is what keeps a substituted face's over-tall
- * box from inflating the cell count (sample-52) while still letting a genuinely
- * tall untabled East Asian run claim its cells (independent-review mixed case).
+ * or under-tall box from changing the cell count (sample-9/sample-52).
  *
  * A linear stub context makes the metrics analytic: measured box = fontSize
  * (0.8 + 0.2 em); Yu Mincho's tabled EA design height = 1.43267 × em.
  */
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_KINSOKU_RULES } from '@silurus/ooxml-core';
-import { layoutLines, type LayoutSeg, type LayoutTextSeg } from './line-layout.js';
+import {
+  layoutLines,
+  lineBoxHeight,
+  rescaleLayoutLines,
+  type LayoutSeg,
+  type LayoutTextSeg,
+} from './line-layout.js';
 
 function linearCtx(): CanvasRenderingContext2D {
   let font = '10px serif';
@@ -30,6 +35,26 @@ function linearCtx(): CanvasRenderingContext2D {
       fontBoundingBoxDescent: px() * 0.2,
       actualBoundingBoxAscent: px() * 0.8,
       actualBoundingBoxDescent: px() * 0.2,
+    } as TextMetrics),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function integerRoundedCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const px = (): number => Number.parseFloat(/([\d.]+)px/.exec(font)?.[1] ?? '10');
+  return {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (t: string) => ({
+      width: [...t].length * px() * 0.5,
+      // Deliberately reproduce Chrome's integer-rounded font boxes. At 20px
+      // the substituted box lands exactly on the grid-pitch boundary; cell
+      // allocation must come from the run's design count height instead.
+      fontBoundingBoxAscent: Math.round(px() * 0.9),
+      fontBoundingBoxDescent: Math.round(px() * 0.1),
+      actualBoundingBoxAscent: Math.round(px() * 0.9),
+      actualBoundingBoxDescent: Math.round(px() * 0.1),
     } as TextMetrics),
   } as unknown as CanvasRenderingContext2D;
 }
@@ -75,13 +100,78 @@ describe('layoutLines — per-line gridCountSingle (§17.6.5 docGrid cell height
     expect(line.gridCountSingle).toBeLessThan(20); // the 20pt Latin box did NOT count
   });
 
-  it('counts a genuinely TALL untabled EA run over a small tabled run (mixed case)', () => {
-    // Small 12pt Yu Mincho (design 17.19) + a large 24pt untabled CJK face
-    // (measured box 24). The untabled run is taller and East Asian, so it must
-    // claim its extent: max(17.19, 24) = 24. Guards the design-height rule from
-    // under-counting a tall untabled run (independent review, Codex gpt-5.6-sol).
+  it('counts a genuinely TALL untabled EA run from the Word FE design fallback', () => {
+    // Small 12pt Yu Mincho (design 17.19) + a large 24pt untabled CJK face.
+    // Word's untabled FE fallback is 1.3em, so the latter contributes 31.2px;
+    // its substituted Canvas box (24px in this stub) is irrelevant.
     const [line] = layout([seg('小', 'Yu Mincho', 12), seg('大きい', 'PMingLiU', 24)]);
-    expect(line.gridCountSingle).toBeCloseTo(24, 4);
+    expect(line.gridCountSingle).toBeCloseTo(24 * 1.3, 4);
+  });
+
+  it('uses 1.3em for an untabled 20pt EA run whose measured box is exactly one em', () => {
+    const run = seg('物理', 'ＭＳ 明朝', 20);
+    const [line] = layoutLines(
+      integerRoundedCtx(), [{ ...run }] as LayoutSeg[], 400, 0, 1,
+      undefined, undefined, {}, 0, DEFAULT_KINSOKU_RULES, 0, 36, 400,
+      false, false, false,
+    );
+
+    expect(line.ascent + line.descent).toBe(20);
+    expect(line.gridCountSingle).toBeCloseTo(26, 8);
+  });
+
+  it('keeps the untabled EA grid count scale-linear through paint-side rescaling', () => {
+    const paintScale = 2.3529;
+    const run = seg('物理', 'ＭＳ 明朝', 20);
+    const ctx = integerRoundedCtx();
+    const measured = layoutLines(
+      ctx, [{ ...run }] as LayoutSeg[], 400, 0, 1,
+      undefined, undefined, {}, 0, DEFAULT_KINSOKU_RULES, 0, 36, 400,
+      false, false, false,
+    );
+    const [painted] = rescaleLayoutLines(measured, paintScale, ctx, {}, 0);
+
+    expect(measured[0].ascent + measured[0].descent).toBe(20);
+    expect(painted.ascent + painted.descent).toBe(47);
+    expect(measured[0].gridCountSingle).toBeCloseTo(26, 8);
+    expect(painted.gridCountSingle).toBeCloseTo(26 * paintScale, 8);
+  });
+
+  it('keeps paginator and paint advances equal across integer-rounded docGrid boundaries', () => {
+    const paintScale = 2.3529;
+    const cases = [
+      { fontSize: 20, linePitchPt: 20, expectedAdvance: 40 },
+      { fontSize: 16, linePitchPt: 18, expectedAdvance: 36 },
+    ];
+
+    for (const { fontSize, linePitchPt, expectedAdvance } of cases) {
+      const ctx = integerRoundedCtx();
+      const measured = layoutLines(
+        ctx, [seg('物理', 'ＭＳ 明朝', fontSize)] as LayoutSeg[], 400, 0, 1,
+        undefined, undefined, {}, 0, DEFAULT_KINSOKU_RULES, 0, 36, 400,
+        false, false, false,
+      );
+      const painted = rescaleLayoutLines(measured, paintScale, ctx, {}, 0);
+      const grid = { type: 'lines' as const, linePitchPt };
+
+      expect(painted).toHaveLength(measured.length);
+      for (const [index, measuredLine] of measured.entries()) {
+        const paintedLine = painted[index];
+        const measureAdvance = lineBoxHeight(
+          null, measuredLine.ascent, measuredLine.descent, 1, grid, false,
+          measuredLine.intendedSingle, measuredLine.eastAsian ?? false,
+          measuredLine.gridCountSingle,
+        );
+        const paintAdvance = lineBoxHeight(
+          null, paintedLine.ascent, paintedLine.descent, paintScale, grid, false,
+          paintedLine.intendedSingle, paintedLine.eastAsian ?? false,
+          paintedLine.gridCountSingle,
+        );
+
+        expect(measureAdvance).toBe(expectedAdvance);
+        expect(paintAdvance).toBeCloseTo(measureAdvance * paintScale, 8);
+      }
+    }
   });
 
   it('a pure-Latin line is NOT cell-rounded — falls back to the box (unused off the EA path)', () => {

--- a/packages/docx/src/empty-paragraph-mark-height.test.ts
+++ b/packages/docx/src/empty-paragraph-mark-height.test.ts
@@ -160,4 +160,34 @@ describe('empty paragraph mark line height (§17.3.1.29 / §17.3.1.33)', () => {
     expect(paragraphMarkLineHeight(p, 1, { type: null, linePitchPt: null }, false, false, ctx, {})).toBe(10);
     expect(paragraphMarkLineHeight(p, 1, { type: null, linePitchPt: null }, false, true, ctx, {})).toBe(30);
   });
+
+  it('counts an untabled 20pt East Asian mark as two cells on a 20pt grid', () => {
+    const p = {
+      ...para(''),
+      defaultFontSize: 20,
+      defaultFontFamilyEastAsia: 'ＭＳ 明朝',
+    } as DocParagraph;
+    let font = '';
+    const ctx = {
+      get font() { return font; },
+      set font(v: string) { font = v; },
+      measureText: () => ({
+        width: 0,
+        fontBoundingBoxAscent: 18,
+        fontBoundingBoxDescent: 2,
+        actualBoundingBoxAscent: 18,
+        actualBoundingBoxDescent: 2,
+      } as TextMetrics),
+    } as unknown as CanvasRenderingContext2D;
+
+    expect(paragraphMarkLineHeight(
+      p,
+      1,
+      { type: 'lines', linePitchPt: 20 },
+      false,
+      true,
+      ctx,
+      {},
+    )).toBe(40);
+  });
 });

--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { docGridLineCells, isGridLineRule, lineBoxHeight } from './line-layout.js';
+import {
+  docGridLineCells,
+  eastAsianGridCountSinglePx,
+  isGridLineRule,
+  lineBoxHeight,
+} from './line-layout.js';
 import type { LineSpacing } from './types.js';
 
 // Regression: some generators emit <w:spacing w:line="0" w:lineRule="exact"/> on
@@ -222,25 +227,28 @@ describe('lineBoxHeight — docGrid line-cell rounding (East Asian vs Latin)', (
     const boxDesc = 18.02 * 0.2;
     expect(lineBoxHeight(null, boxAsc, boxDesc, 1, grid18, false, 12 * YU, true, 12 * YU)).toBe(18);
   });
-  it('still counts a tall UNTABLED run on a mixed line — grid-count height keeps its box', () => {
-    // A mixed docGrid line: a small 12pt tabled Yu Mincho run (design 17.19px,
-    // the intendedSingle floor) plus a larger untabled CJK run whose measured
-    // box is 30px. The line's grid-count height (arg 9) is the max over runs of
-    // (tabled design | untabled box) = max(17.19, 30) = 30, so the untabled run
-    // still claims its two cells — the design-height rule must not UNDER-count
-    // a genuinely tall untabled run (independent review, Codex gpt-5.6-sol).
-    expect(lineBoxHeight(null, 24, 6, 1, grid18, false, 12 * YU, true, 30)).toBe(36);
+  it('counts a tall UNTABLED run on a mixed line from its 1.3em FE height', () => {
+    // A mixed docGrid line: a small 12pt tabled Yu Mincho run (design 17.19px)
+    // plus a 24pt untabled CJK run. The latter contributes 31.2px regardless of
+    // its substituted 30px Canvas box, so the line still claims two cells.
+    const untabledDesign = eastAsianGridCountSinglePx(0, 24);
+    expect(lineBoxHeight(null, 24, 6, 1, grid18, false, 12 * YU, true, untabledDesign)).toBe(36);
   });
   it('rounds a 20pt EA line on a 20pt pitch UP to two cells (sample-9)', () => {
     // design box 28.65px → ceil(28.65/20) = 2 cells = 40.
     expect(lineBoxHeight(null, 20 * YU_ASC, 20 * YU_DESC, 1, grid20, false, 20 * YU, true)).toBe(40);
   });
-  it('falls back to natural when no grid-count height is supplied (box 30 → 2 cells)', () => {
-    // With no arg-9 grid-count height, the count falls back to `natural` =
-    // max(box 24+6=30, design floor 20*YU=28.65) = 30 → ceil(30/20) = 2 cells =
-    // 40 on a 20pt pitch. Both the box and the design floor land in the same
-    // cell here, so the pre-existing callers (which supply no arg 9) are
-    // unaffected. Callers that need the substitution-robust count pass arg 9.
+  it('uses a scale-linear 1.3em fallback for an untabled EA line', () => {
+    // MS Mincho's hhea box is 1.0em and Word's FE single-line height is 1.3 ×
+    // hhea. The substituted Canvas box is exactly 1.0em here, but a 20pt line
+    // on a 20pt grid still occupies two cells in the sample-9 Word PDF.
+    expect(lineBoxHeight(null, 18, 2, 1, grid20, false, 0, true, undefined, 20)).toBe(40);
+    expect(lineBoxHeight(null, 43, 5, 2.3529, grid20, false, 0, true, undefined, 20 * 2.3529)).toBeCloseTo(40 * 2.3529, 8);
+  });
+  it('uses the tabled design floor when no per-line grid-count height is supplied', () => {
+    // A direct caller without arg 9 still has a deterministic tabled-font input
+    // in intendedSinglePx. The substituted 30px box is not consulted for the
+    // cell count; Yu Mincho's 28.65px design height takes two 20px cells.
     expect(lineBoxHeight(null, 24, 6, 1, grid20, false, 20 * YU, true)).toBe(40);
   });
   it('keeps a Latin line at natural height (one-cell floor), NOT cell-rounded', () => {

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -318,9 +318,9 @@ export interface LayoutLine {
   intendedSingle: number;
   /** px — DESIGN grid-count height: the max over segments of each run's
    *  Word-faithful single-line height (a tabled run's design height, an
-   *  untabled run's measured box). Feeds docGrid cell counting so a substituted
-   *  face's over-tall box does not inflate the cell count while a genuinely tall
-   *  untabled run still counts its real extent (§17.6.5; sample-52). */
+   *  untabled East Asian run's 1.3em Word FE fallback). Feeds docGrid cell
+   *  counting without depending on a substituted face's Canvas box
+   *  (§17.6.5; sample-9/sample-52). */
   gridCountSingle: number;
   /** Additional horizontal offset (px) from paraX, caused by wrap-around floats. */
   xOffset: number;
@@ -975,6 +975,32 @@ export function docGridLineCells(naturalPx: number, pitchPx: number): number {
   return pitchPx > 0 ? Math.max(1, Math.ceil(naturalPx / pitchPx)) : 1;
 }
 
+/** Deterministic single-line height used to count docGrid cells for one East
+ * Asian text run. Tabled fonts contribute their recorded design height.
+ *
+ * Word's Far-East single-line height is 1.3 × the font's hhea box: measured for
+ * Yu Mincho in the issue #1013 sample-58 sweep and corroborated by Meiryo, whose
+ * usWin sum is designed as 1.3 × its hhea box. The factor is font-independent
+ * Word runtime behaviour, not an ECMA-376 rule (§17.6.5 does not define it).
+ *
+ * An untabled font's hhea box is unknown, so the fallback assumes 1.0em. That is
+ * exact for the legacy full-frame Japanese fonts that dominate the untabled
+ * corpus (MS Mincho / MS Gothic), and ceil-to-whole-cell allocation bounds the
+ * assumption's effect. The resulting counts match the previous Word-measured
+ * em rule (floor(em/pitch) + 1, before #1018) at every recorded untabled point:
+ * 10.5pt and 12pt on 18pt → 1 cell (sample-35), 20pt on 20pt → 2 cells
+ * (sample-9), and 11pt on 16.4pt → 1 cell. The rules diverge only in the
+ * never-measured em/pitch ∈ (0.77, 1) band; here this fallback follows the
+ * #1013 sweep direction (14–16pt on 18pt → 2 cells).
+ *
+ * Never use a substituted Canvas box here: its integer-rounded metrics are
+ * font- and scale-dependent. Follow-up: replace the 1.0em assumption with
+ * fontTools-extracted MS Mincho/MS Gothic hhea metrics in core WIN_METRICS when
+ * those font binaries are available. */
+export function eastAsianGridCountSinglePx(intendedSinglePx: number, emPx: number): number {
+  return intendedSinglePx > 0 ? intendedSinglePx : emPx * 1.3;
+}
+
 /**
  * Compute the total line-box height in px from a line's natural font metrics
  * (fontBoundingBoxAscent + fontBoundingBoxDescent) per ECMA-376 §17.3.1.33.
@@ -1001,14 +1027,13 @@ export function lineBoxHeight(
   eastAsian = false,
   // px — the line's DESIGN grid-count height: the max over segments of each
   // run's Word-faithful single-line height (a tabled run's design height, an
-  // untabled run's measured box). Used ONLY to count docGrid cells for East
-  // Asian lines, so a substituted face whose Canvas box overshoots the real
-  // font's design height does not add a spurious cell (see gridSingleCell).
-  // When omitted, the count falls back to `natural` (the substituted glyph
-  // box floored by the design height) — the pre-existing behaviour, which the
-  // callers that pre-correct their metrics (correctLineMetrics) already resolve
-  // correctly.
+  // untabled East Asian run's 1.3em Word FE fallback). Used ONLY to count
+  // docGrid cells for East Asian lines, so a substituted face's Canvas box
+  // cannot change pagination or paint-scale cell allocation.
   gridCountSinglePx?: number,
+  // px — untabled East Asian run em used only by direct/synthetic callers that
+  // cannot provide the producer-computed per-line gridCountSinglePx.
+  untabledEastAsianEmPx?: number,
 ): number {
   const glyphNatural = ascentPx + descentPx;
   // For `auto`/single spacing the multiplier applies to the intended font's
@@ -1055,12 +1080,16 @@ export function lineBoxHeight(
     // line into an extra cell — that mis-widths every tbRl column and shifts
     // vertical-section block tables by whole cells (sample-52). Prefer the
     // per-line design grid-count height when the caller supplies it — it is the
-    // max over runs of each run's Word-faithful single-line height (design for a
-    // tabled run, measured box for an untabled one), so a mixed tabled+untabled
-    // line still counts the untabled run's real extent. Callers that pre-correct
-    // their metrics (correctLineMetrics) omit it and fall back to `natural`,
-    // which is already the design height for them.
-    const cellCountHeight = gridCountSinglePx ?? natural;
+    // max over runs of each run's Word-faithful design height. Direct callers
+    // may instead provide the untabled run em; tabled direct callers already
+    // expose their design height through intendedSinglePx. A legacy caller with
+    // neither design input gets one pitch, never the substituted Canvas box.
+    const cellCountHeight = gridCountSinglePx
+      ?? (intendedSinglePx > 0
+        ? intendedSinglePx
+        : untabledEastAsianEmPx === undefined
+          ? pitchPx
+          : eastAsianGridCountSinglePx(0, untabledEastAsianEmPx));
     return docGridLineCells(cellCountHeight, pitchPx) * pitchPx;
   };
   const inheritedOnly = ls !== null && ls.explicit !== true;
@@ -1197,7 +1226,21 @@ export function paragraphMarkLineMetrics(
   } else {
     ({ asc, desc } = emptyLineNaturalPx(fs, scale));
   }
-  const advancePx = lineBoxHeight(effectiveLineSpacing, asc, desc, scale, grid, paraHasRuby, emptyIntendedSingleForScriptPx(para, scale, eastAsian), eastAsian);
+  const intendedSingle = emptyIntendedSingleForScriptPx(para, scale, eastAsian);
+  const gridCountSingle = eastAsian
+    ? eastAsianGridCountSinglePx(intendedSingle, fs * scale)
+    : undefined;
+  const advancePx = lineBoxHeight(
+    effectiveLineSpacing,
+    asc,
+    desc,
+    scale,
+    grid,
+    paraHasRuby,
+    intendedSingle,
+    eastAsian,
+    gridCountSingle,
+  );
   return { advancePx, ascentPx: asc, descentPx: desc };
 }
 
@@ -2737,15 +2780,18 @@ export function layoutLines(
     const hasContent = lineAscent > 0 || lineDescent > 0;
     const asc = hasContent ? lineAscent : h * scale * 0.8;
     const desc = hasContent ? lineDescent : h * scale * 0.2;
+    const gridCountSingle = lineGridCountSingle
+      || (lineEastAsian ? eastAsianGridCountSinglePx(lineIntendedSingle, h * scale) : asc + desc);
     lines.push({
       segments: currentLine,
       height: h,
       ascent: asc,
       descent: desc,
       intendedSingle: lineIntendedSingle,
-      // Empty/synthetic lines carry no per-segment count, so fall back to the
-      // synthesized box (== the old `natural` for an untabled line).
-      gridCountSingle: lineGridCountSingle || (asc + desc),
+      // Empty/synthetic East Asian lines use the same design-height rule as a
+      // text run; their synthesized Canvas box must not reintroduce a
+      // scale-dependent cell count.
+      gridCountSingle,
       xOffset: lineXOffset,
       availWidth: lineMaxWidth,
       topY: wrapCtx ? currentLineTopY : undefined,
@@ -2755,7 +2801,14 @@ export function layoutLines(
       consumedEnd: nextStart ?? queue[0]?.src ?? endBoundary,
     });
     if (wrapCtx) {
-      currentLineTopY += wrapCtx.lineBoxH(asc, desc, lineHasRuby, lineIntendedSingle, lineEastAsian, lineGridCountSingle || (asc + desc));
+      currentLineTopY += wrapCtx.lineBoxH(
+        asc,
+        desc,
+        lineHasRuby,
+        lineIntendedSingle,
+        lineEastAsian,
+        gridCountSingle,
+      );
     }
     currentLine = [];
     currentWidth = 0;
@@ -2800,8 +2853,9 @@ export function layoutLines(
     // TEXT (and tall inline objects) drives the count — a Latin run keeps its
     // natural height and is NOT cell-rounded, so it must not contribute (its
     // substituted Canvas box would otherwise inflate the count). An EA text run
-    // counts from its DESIGN height when tabled, else its measured box; an
-    // image/math object counts its measured box. The line's value is the max.
+    // counts from its DESIGN height when tabled, else the deterministic Word FE
+    // 1.3em fallback; an image/math object counts its measured box. The line's
+    // value is the max.
     let segGridCount = 0;
     if (!('isTab' in s) && !('imagePath' in s) && !('mathNodes' in s)) {
       const ts = s as LayoutTextSeg;
@@ -2822,9 +2876,9 @@ export function layoutLines(
       const segScriptHint = EAST_ASIAN_RE.test(ts.text) && !ts.ruby;
       const intended = intendedSingleLinePx(ts.fontFamily, intendedEm, segScriptHint);
       if (intended > lineIntendedSingle) lineIntendedSingle = intended;
-      // Only East Asian text is cell-rounded; a tabled EA run counts from its
-      // design height, an untabled EA run from its measured box.
-      if (segScriptHint) segGridCount = intended > 0 ? intended : asc + desc;
+      // Only East Asian text is cell-rounded. Both branches are scale-linear:
+      // tabled fonts use recorded design metrics; untabled fonts use 1.3em.
+      if (segScriptHint) segGridCount = eastAsianGridCountSinglePx(intended, intendedEm);
     } else if (!('isTab' in s)) {
       // Image/math object: a tall inline object sizes the line's cells too.
       segGridCount = asc + desc;
@@ -3852,7 +3906,13 @@ export function rescaleLayoutLines(
 
   // Per-text-segment measurement at the PAINT scale — the SAME model layoutLines
   // uses (segAdvance + the text-segment metric block), so measure == draw.
-  const measureTextSeg = (s: LayoutTextSeg): { advance: number; asc: number; desc: number; intended: number } => {
+  const measureTextSeg = (s: LayoutTextSeg): {
+    advance: number;
+    asc: number;
+    desc: number;
+    intended: number;
+    gridCount: number;
+  } => {
     const effPx = calcEffectiveFontPx(s, scale);
     ctx.font = buildFont(s.bold, s.italic, effPx, s.fontFamily, fontFamilyClasses);
     const m = withSegKerning(s, () => ctx.measureText(s.text));
@@ -3883,14 +3943,20 @@ export function rescaleLayoutLines(
     // size here too (addToLine's intendedEm).
     const intendedEm = s.smallCaps && !s.vertAlign ? fullPx : effPx;
     const intended = intendedSingleLinePx(s.fontFamily, intendedEm, segScriptHint);
-    return { advance, asc, desc: corrected.descent, intended };
+    return {
+      advance,
+      asc,
+      desc: corrected.descent,
+      intended,
+      gridCount: segScriptHint ? eastAsianGridCountSinglePx(intended, intendedEm) : 0,
+    };
   };
 
   return lines.map((l) => {
     let asc = 0;
     let desc = 0;
     let intended = 0;
-    let gridCount = 0; // px — max over segments of (tabled design | measured box)
+    let gridCount = 0; // px — max over segments of (tabled design | untabled 1.3em)
     let hasText = false;
     const scaledSource = l.segments.map((segment) => ({ ...segment })) as LayoutSeg[];
     // Recompute the region gap from paint-scale natural metrics. Reusing the
@@ -3939,11 +4005,9 @@ export function rescaleLayoutLines(
       if (mm.intended > intended) intended = mm.intended;
       // Only East Asian text is cell-rounded (§17.6.5); a Latin run keeps its
       // natural height and must not contribute its (substituted) box to the
-      // grid-count height. A tabled EA run counts from its design height, an
-      // untabled EA run from its measured box.
-      if (EAST_ASIAN_RE.test(t.text) && !t.ruby) {
-        gridCount = Math.max(gridCount, mm.intended > 0 ? mm.intended : mm.asc + mm.desc);
-      }
+      // grid-count height. measureTextSeg derives both tabled and untabled
+      // contributions from deterministic design quantities.
+      gridCount = Math.max(gridCount, mm.gridCount);
       return { ...t, measuredWidth: mm.advance };
     });
     // Empty/synthetic line (no text/math contributing metrics): fall back to the

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -10516,7 +10516,17 @@ export function measureShapeTextAutoFitHeight(
     const eastAsian = lineEa;
     // Ruby lines reserve real furigana height, so use the measured glyph box,
     // mirroring the body path.
-    return lineBoxHeight(ls, c.ascent, c.descent, scale, effState.docGrid, line.hasRuby ?? false, floorPx, eastAsian);
+    return lineBoxHeight(
+      ls,
+      c.ascent,
+      c.descent,
+      scale,
+      effState.docGrid,
+      line.hasRuby ?? false,
+      floorPx,
+      eastAsian,
+      line.gridCountSingle,
+    );
   };
 
   const spBefore = blocks.map((b) => (b.spaceBefore ?? 0) * scale);
@@ -10828,6 +10838,8 @@ export function renderShapeText(
     // floor falls back to this run's own ascii+eastAsia faces. Either way it is a
     // FLOOR (0 for all-untabled lines ⇒ unchanged).
     lineFloorPx?: number,
+    // Deterministic per-line docGrid count height produced by layoutLines.
+    gridCountSinglePx?: number,
     grid?: DocGridCtx,
     eastAsian = false,
     hasRuby = false,
@@ -10878,7 +10890,17 @@ export function renderShapeText(
       : null;
     // Ruby lines reserve real furigana height, so use the measured glyph box,
     // mirroring the body path.
-    const lineH = lineBoxHeight(ls, c.ascent, c.descent, scale, grid, hasRuby, intended, eastAsian);
+    const lineH = lineBoxHeight(
+      ls,
+      c.ascent,
+      c.descent,
+      scale,
+      grid,
+      hasRuby,
+      intended,
+      eastAsian,
+      gridCountSinglePx,
+    );
     // Baseline placement inside the line box, mirroring the body draw path
     // (~7859). §17.3.1.33 sizes the box; the placement is Word's OBSERVED
     // behaviour (#990), not an ECMA rule:
@@ -10952,6 +10974,7 @@ export function renderShapeText(
       // passed explicitly, so a shorter tabled segment still raises the box.
       tallest?.eaFloorFamily ?? b.fontFamily,
       floorPx,
+      line.gridCountSingle,
       effState.docGrid,
       eastAsian,
       line.hasRuby ?? false,

--- a/packages/docx/tests/visual/visual.spec.ts
+++ b/packages/docx/tests/visual/visual.spec.ts
@@ -22,7 +22,11 @@ const DOCX_FILES: { name: string; pageCount: number; width: number }[] = [
   // XF9 vertical writing (§17.6.20 tbRl): a landscape vertical-Japanese
   // newspaper. width = physical page width (842pt, A4 landscape). Reference is
   // private (gitignored) and generated locally with UPDATE_REFS=1.
-  { name: 'private/sample-26', pageCount: 1, width: 842 },
+  // 2 pages per the Word PDF (page 2 carries only the spill of the final
+  // column): the deterministic untabled EA docGrid cell height (1.3 em — the
+  // sample-9 regression fix) restores the Word page count from the crammed
+  // 1-page state the 2026-07-13a baseline captured.
+  { name: 'private/sample-26', pageCount: 2, width: 842 },
   // Multilingual / section coverage (references private + gitignored, generated
   // locally with UPDATE_REFS=1):
   // sample-27 = continuous section-break page-number restart fixture (US Letter, 612pt).


### PR DESCRIPTION
## Summary

Fixes the user-reported docx pagination regression: on a `docGrid` section, page 1 of a private JP report sample absorbed the following section's heading/body and the painted text ran past the bottom margin to the physical page edge (clipped mid-line) in the browser. The Word PDF ground truth keeps that content on page 2.

## Bisect

- GOOD `8503538` (merge #1017) → FIRST BAD `3791244` (merge #1018, `aa3b9cf` "docGrid cell count from the design line height"). #1026 later moved tabled fonts to design heights but kept the untabled measured-box fallback, so HEAD stayed bad.

## Root cause

#1018 changed the ECMA-376 §17.6.5 cell count from the em-based `floor(em/pitch)+1` to `ceil(box/pitch)`, where an **untabled** East Asian run feeds the **substituted** font's Canvas `fontBoundingBox`. That box is:

1. **Environment-dependent** — in Chrome the substitution chain for ＭＳ 明朝 resolves to a face with a 1.0 em box, so a 20 pt line on a 20 pt pitch counted **1 cell** where the Word PDF shows **2** (Word FE line height = 1.3 × hhea box; the legacy full-frame JP faces have a 1.0 em hhea box → 26 pt > pitch). Page 1 therefore charged half the Word height for every title-page line and absorbed the next section.
2. **Scale-unstable** — the paint pass re-measures at the canvas scale, where Chrome's integer-rounded metrics flip `ceil()` at the box == pitch boundary (measure: 20.0/20 → 1 cell; paint: 24/23.53 → 2 cells). Instrumentation on page 1 showed 15 lines flipping to 2 cells at paint → the painter drew ~15 × 20 pt more than the paginator charged → visible bottom-edge clipping.

## Fix

`eastAsianGridCountSinglePx()`: an EA run's docGrid cell height is its tabled design height when recorded, else the Word FE height **1.3 × em** — deterministic and scale-linear. All EA cell-count feeds route through it (segment accumulation, empty/synthetic line flush, paragraph-mark metrics, paint-side rescale, shape-text paths). The substituted Canvas box no longer reaches `docGridLineCells` for EA text. Ruby lines and inline images/math keep measured extents; Latin lines stay un-rounded; tabled fonts (#1013 sweep) are unchanged.

The 1.3 factor is Word runtime behaviour measured in the #1013 sweep (Yu Mincho) and corroborated by Meiryo's win-sum design; the 1.0 em hhea assumption for untabled faces is exact for MS Mincho / MS Gothic and reproduces the pre-#1018 Word-measured em-rule counts at every recorded point (see the doc comment). Follow-up noted in-code: replace the assumption with fontTools-extracted MS Mincho/MS Gothic metrics in core WIN_METRICS when the binaries are available.

## Verification

- Browser (Storybook, Chrome): the regressed sample restores the Word page-1/page-2 split; ink-scan below the bottom margin = 0 rows at story scale (was 89 rows); the pagination probe and the story canvas agree.
- Browser corpus sweep (59 private samples): only one other sample changes page count (1 → 2, matching its Word PDF — its 2 pages split one line earlier than Word; noted as a residual nuance).
- Headless (skia) sweep: two samples converge to the browser's counts (environment determinism); both were already Word-divergent for unrelated, pre-existing reasons (explicit line spacing).
- docx vitest 1436 passed / node suite 109 passed / root typecheck clean / ast-grep lint clean (pre-existing warnings only).
- docx demo VRT: byte-identical match values vs the baseline code (non-regression).
- Private VRT: the only diff vs the 2026-07-13a baseline is the vertical newspaper sample's page 1 — that baseline was captured on the regressed code. **Private references need regeneration after merge** (`UPDATE_REFS=1`, owner-run); the VRT spec's declared page count for that sample is updated to the Word-true 2.
- Independent review (Codex gpt-5.6-sol, read-only): no blockers; both should-fix items addressed (documentation of the untabled fallback's grounding + a cross-scale measure==paint invariance test). A pre-existing, unrelated gap was noted: mixed text+inline-image lines lose the image height in `rescaleLayoutLines` — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
