### PR TITLE
fix(docx): include inline images in rescaled line metrics

### DIFF
--- a/packages/docx/src/layout-lines-scale-invariance.test.ts
+++ b/packages/docx/src/layout-lines-scale-invariance.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
   layoutLines,
+  lineBoxHeight,
   rescaleLayoutLines,
   type LayoutSeg,
+  type LayoutImageSeg,
   type LayoutLine,
   type LayoutTextSeg,
   type WrapLayoutCtx,
@@ -88,6 +90,25 @@ function textSeg(text: string, fontSize = 10, extra: Partial<LayoutTextSeg> = {}
     fontSize, color: null, fontFamily: 'Times New Roman', vertAlign: null,
     measuredWidth: 0, ...extra,
   } as LayoutSeg;
+}
+
+function inlineImageSeg(
+  heightPt: number,
+  imagePath = 'word/media/image1.png',
+  anchor = false,
+): LayoutImageSeg {
+  return {
+    imagePath,
+    mimeType: imagePath ? 'image/png' : '',
+    widthPt: 12,
+    heightPt,
+    anchor,
+    anchorXPt: 0,
+    anchorYPt: 0,
+    anchorXFromMargin: false,
+    anchorYFromPara: false,
+    measuredWidth: 0,
+  };
 }
 
 /** Deep-clone segs so a scale=1 call and a scale=s call never share the mutable
@@ -391,5 +412,104 @@ describe('layoutLines scale-dependence under a NON-linear (real-font-like) advan
     // Fewer lines at the larger scale — the exact paginate/paint mismatch the
     // paint loop already guards (paintEnd = min(sliceEnd, lines.length)).
     expect(b.length).toBeLessThan(a.length);
+  });
+});
+
+describe('rescaleLayoutLines inline-image line-box parity', () => {
+  it('includes a tall inline image in mixed-line ascent and grid-count metrics', () => {
+    const imageHeightPt = 30;
+    const scale = 2;
+    const { ctx } = makeLinearCtx();
+    const measured = layoutLines(
+      ctx,
+      [textSeg('body', 10), inlineImageSeg(imageHeightPt)],
+      200,
+      0,
+      1,
+    );
+
+    const [painted] = rescaleLayoutLines(measured, scale, ctx, {}, 0);
+
+    expect(painted.ascent).toBeCloseTo(imageHeightPt * scale, 8);
+    expect(painted.descent).toBeCloseTo(10 * 0.2 * scale, 8);
+    expect(painted.gridCountSingle).toBeCloseTo(imageHeightPt * scale, 8);
+  });
+
+  it('keeps a mixed text/chart-sentinel line box measure==paint on docGrid', () => {
+    const scale = 2;
+    const grid = { type: 'lines', linePitchPt: 10 };
+    const makeSegs = (): LayoutSeg[] => [textSeg('物', 10), inlineImageSeg(30, '')];
+    const { ctx } = makeLinearCtx();
+    const [measured] = layoutLines(
+      ctx,
+      makeSegs(),
+      200,
+      0,
+      1,
+    );
+    const [painted] = rescaleLayoutLines([measured], scale, ctx, {}, 0);
+    const { ctx: freshCtx } = makeLinearCtx();
+    const [freshPainted] = layoutLines(freshCtx, makeSegs(), 200 * scale, 0, scale);
+
+    expect(painted.ascent).toBeCloseTo(freshPainted.ascent, 8);
+    expect(painted.descent).toBeCloseTo(freshPainted.descent, 8);
+    expect(painted.gridCountSingle).toBeCloseTo(freshPainted.gridCountSingle, 8);
+    expect(painted.segments.map((segment) => segment.measuredWidth))
+      .toEqual(freshPainted.segments.map((segment) => segment.measuredWidth));
+
+    const measuredLineBox = lineBoxHeight(
+      null,
+      measured.ascent,
+      measured.descent,
+      1,
+      grid,
+      measured.hasRuby,
+      measured.intendedSingle,
+      measured.eastAsian,
+      measured.gridCountSingle,
+    );
+    const paintedLineBox = lineBoxHeight(
+      null,
+      painted.ascent,
+      painted.descent,
+      scale,
+      grid,
+      painted.hasRuby,
+      painted.intendedSingle,
+      painted.eastAsian,
+      painted.gridCountSingle,
+    );
+
+    expect(paintedLineBox).toBeCloseTo(measuredLineBox * scale, 8);
+  });
+
+  it('preserves the former fallback metrics for an image-only line', () => {
+    const scale = 2;
+    const { ctx } = makeLinearCtx();
+    const [measured] = layoutLines(ctx, [inlineImageSeg(30)], 200, 0, 1);
+
+    const [painted] = rescaleLayoutLines([measured], scale, ctx, {}, 0);
+
+    expect(painted.ascent).toBeCloseTo(measured.ascent * scale, 8);
+    expect(painted.descent).toBeCloseTo(measured.descent * scale, 8);
+    expect(painted.gridCountSingle).toBeCloseTo(measured.gridCountSingle * scale, 8);
+  });
+
+  it('keeps an anchored image out of rescaled inline metrics', () => {
+    const scale = 2;
+    const { ctx } = makeLinearCtx();
+    const [measured] = layoutLines(ctx, [textSeg('body', 10)], 200, 0, 1);
+    const withAnchor: LayoutLine = {
+      ...measured,
+      segments: [...measured.segments, inlineImageSeg(100, 'word/media/anchor.png', true)],
+    };
+
+    const [textOnlyPainted] = rescaleLayoutLines([measured], scale, ctx, {}, 0);
+    const [anchoredPainted] = rescaleLayoutLines([withAnchor], scale, ctx, {}, 0);
+
+    expect(anchoredPainted.ascent).toBeCloseTo(textOnlyPainted.ascent, 8);
+    expect(anchoredPainted.descent).toBeCloseTo(textOnlyPainted.descent, 8);
+    expect(anchoredPainted.gridCountSingle).toBeCloseTo(textOnlyPainted.gridCountSingle, 8);
+    expect(anchoredPainted.segments.at(-1)?.measuredWidth).toBe(0);
   });
 });

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -3986,6 +3986,11 @@ export function rescaleLayoutLines(
         // measuredWidth to 0 (they add no pen advance) and their anchor*Pt
         // fields stay in pt space for the draw-time position resolver.
         if (s.anchor) return { ...s, measuredWidth: 0 };
+        const h = s.heightPt * scale;
+        // Inline images stand fully above the baseline (descent 0) and always
+        // size docGrid cells, mirroring layoutLines' addToLine contribution.
+        asc = Math.max(asc, h);
+        gridCount = Math.max(gridCount, h);
         return { ...s, measuredWidth: s.widthPt * scale };
       }
       if ('mathNodes' in s) {


### PR DESCRIPTION
## Summary

- include non-anchored inline-image height in paint-scale ascent and docGrid cell metrics
- preserve zero descent, anchored-image neutrality, and chart-sentinel behavior
- add regression coverage for mixed lines, fresh paint-layout parity, image-only fallback equivalence, and anchors

## Root cause

`rescaleLayoutLines` scaled an inline image's horizontal advance but did not fold its height into the line metrics. On a mixed text/image line at a paint scale other than 1, the remeasured line box could therefore be shorter than the image even though the scale-1 `layoutLines` path correctly sized the line from the image.

The fix mirrors `layoutLines` / `addToLine`: a non-anchored image contributes `heightPt * scale` to ascent and `gridCountSingle`, with zero descent. This also covers chart runs represented by the empty-`imagePath` `LayoutImageSeg` sentinel.

## TDD evidence

Before the implementation, the focused regression suite failed with:

- mixed-line ascent: expected at least 60, received 16
- chart-sentinel docGrid line box: expected 60, received 40

After the implementation and review-driven test strengthening, the focused suite passes 17/17.

## Verification

- `pnpm vitest run packages/docx/src/layout-lines-scale-invariance.test.ts` — 17 passed
- `cd packages/docx && npx vitest run --exclude 'tests/visual/**'` — 181 files, 1440 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed with pre-existing warnings only; no new warning from this diff
- `pnpm --filter @silurus/ooxml-docx vrt` — 90 passed; all available private references had 0 changed pixels
- demo VRT actual output after this change is byte-identical to the output from base commit `41251cc` for all six pages (per-file SHA-256 equality); no references were updated
- `git diff --check` — passed
- independent Codex `gpt-5.6-sol` / high review — approve, no blocker or should-fix

## Existing test-runner note

The requested bare `cd packages/docx && npx vitest run` invocation passes all 1440 unit assertions but also mis-discovers six Playwright files under `tests/visual/`, which then fail at collection because Playwright's `test()` is running inside Vitest. The unit suite is green with the visual directory excluded, and those Playwright suites are separately green through the VRT command above.

In the current environment, committed demo references differ from both base and this branch on pages 1–3. A same-environment base-vs-branch render proved that this change introduces no demo-byte difference.

## Out of scope review note

The independent review also noticed a pre-existing scale-1 `layoutLines` issue where an anchored image after an aligned tab may enter tab look-ahead/commit metrics. It is independent of this paint-side non-anchored-image fix and is intentionally not bundled into this single-purpose PR. The changed `rescaleLayoutLines` anchor branch itself is covered and remains metric-neutral.
