### PR TITLE
ci: run artifact actions on Node.js 24

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -131,7 +131,7 @@ jobs:
       # run, not just a successful one.
       - name: Upload crash artifacts
         if: always() && steps.gate.outputs.run == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fuzz-artifacts-${{ matrix.target }}
           path: |

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -71,7 +71,7 @@ jobs:
         run: pnpm exec vsce package --no-dependencies --out ooxml-viewer.vsix
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ooxml-viewer-vsix
           path: packages/vscode-extension/ooxml-viewer.vsix

--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -109,7 +109,7 @@ jobs:
           cat "${{ matrix.asset }}.sha256"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset }}
           path: staging/*
@@ -132,7 +132,7 @@ jobs:
             echo "name=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Summary

- update all `actions/upload-artifact` usages to v7
- update the matching `actions/download-artifact` usage to v8
- preserve existing artifact names, paths, retention, and workflow control flow

## Why

Older artifact action releases target Node.js 20 and now emit deprecation warnings on GitHub Actions runners. The updated upload/download versions run on Node.js 24.

## Verification

- `pnpm test` (441 test files passed, 1 skipped; 4,359 tests passed, 4 skipped)
- parsed all workflow YAML files successfully
- confirmed no legacy artifact action versions remain
- `git diff --check`