### PR TITLE
fix(ooxml): preserve authored layout and grouped drawing geometry

### DIFF
--- a/packages/core/src/draw/dash.test.ts
+++ b/packages/core/src/draw/dash.test.ts
@@ -5,6 +5,7 @@ import {
   xlsxBorderDashArray,
   pptxUnderlineDashArray,
   pptxPresetDashArray,
+  shapeStrokeDashArray,
 } from './dash.js';
 
 describe('dashArray (generic on/off × unit helper)', () => {
@@ -133,5 +134,20 @@ describe('pptxPresetDashArray (§20.1.10.49 ST_PresetLineDashVal, shape borders)
   it('scales with the line width', () => {
     expect(pptxPresetDashArray('sysDash', 3)).toEqual([12, 6]);
     expect(pptxPresetDashArray('dash', 1)).toEqual([6, 3]);
+  });
+});
+
+describe('shapeStrokeDashArray — normalized presets and VML numeric sequences', () => {
+  it('keeps the PPTX preset contract unchanged', () => {
+    expect(shapeStrokeDashArray('sysDashDot', 2)).toEqual([8, 4, 2, 4]);
+  });
+
+  it('discards the final value from an odd VML numeric sequence (Part 4 §19.1.2.21)', () => {
+    expect(shapeStrokeDashArray('1 2 3', 2)).toEqual([2, 4]);
+  });
+
+  it('rejects invalid numeric sequences and preserves a zero-length dot', () => {
+    expect(shapeStrokeDashArray('1 nope', 2)).toEqual([]);
+    expect(shapeStrokeDashArray('0 2', 2)).toEqual([0, 4]);
   });
 });

--- a/packages/core/src/draw/dash.ts
+++ b/packages/core/src/draw/dash.ts
@@ -160,7 +160,23 @@ const PPTX_PRESET_DASH_RELATIVE: Record<string, RelativeDashPattern> = {
  */
 export function pptxPresetDashArray(style: string, lineW: number): number[] {
   const relative = PPTX_PRESET_DASH_RELATIVE[style];
-  return relative ? dashArray(relative, lineW) : [];
+  if (relative) return dashArray(relative, lineW);
+
+  // Legacy VML `<v:stroke dashstyle>` may carry an explicit whitespace/comma-
+  // separated sequence of on/off lengths rather than a DrawingML preset name.
+  // The values are relative to the stroke width, the same unit convention this
+  // shape-stroke helper already uses. Accept only an entirely numeric sequence;
+  // unknown symbolic styles continue to fall back to a solid line.
+  const tokens = style.trim().split(/[\s,]+/);
+  const numeric = tokens.map(Number);
+  if (
+    numeric.length >= 2 &&
+    numeric.every((value) => Number.isFinite(value) && value >= 0) &&
+    numeric.some((value) => value > 0)
+  ) {
+    return dashArray(numeric, lineW);
+  }
+  return [];
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/draw/dash.ts
+++ b/packages/core/src/draw/dash.ts
@@ -160,20 +160,27 @@ const PPTX_PRESET_DASH_RELATIVE: Record<string, RelativeDashPattern> = {
  */
 export function pptxPresetDashArray(style: string, lineW: number): number[] {
   const relative = PPTX_PRESET_DASH_RELATIVE[style];
-  if (relative) return dashArray(relative, lineW);
+  return relative ? dashArray(relative, lineW) : [];
+}
 
-  // Legacy VML `<v:stroke dashstyle>` may carry an explicit whitespace/comma-
-  // separated sequence of on/off lengths rather than a DrawingML preset name.
-  // The values are relative to the stroke width, the same unit convention this
-  // shape-stroke helper already uses. Accept only an entirely numeric sequence;
-  // unknown symbolic styles continue to fall back to a solid line.
-  const tokens = style.trim().split(/[\s,]+/);
-  const numeric = tokens.map(Number);
+/**
+ * Shared shape-stroke dash resolver. Parsers normalize symbolic vocabularies
+ * (DrawingML presets, legacy VML names) to ST_PresetLineDashVal strings before
+ * they reach the shared {@link Stroke} contract. VML additionally permits a
+ * custom whitespace/comma-separated numeric sequence in line-width units
+ * (Part 4 §19.1.2.21); an unmatched final value is explicitly discarded.
+ */
+export function shapeStrokeDashArray(style: string, lineW: number): number[] {
+  const preset = pptxPresetDashArray(style, lineW);
+  if (preset.length > 0) return preset;
+
+  const numeric = style.trim().split(/[\s,]+/).map(Number);
   if (
     numeric.length >= 2 &&
     numeric.every((value) => Number.isFinite(value) && value >= 0) &&
     numeric.some((value) => value > 0)
   ) {
+    if (numeric.length % 2 !== 0) numeric.pop();
     return dashArray(numeric, lineW);
   }
   return [];

--- a/packages/core/src/shape/paint.test.ts
+++ b/packages/core/src/shape/paint.test.ts
@@ -89,18 +89,23 @@ describe('autoContrastColor (impl-defined; §17.3.2.6 w:color auto)', () => {
 function makeStrokeMock(): {
   ctx: CanvasRenderingContext2D;
   lastDash: () => number[];
+  lastCap: () => CanvasLineCap;
 } {
   let dash: number[] = [];
+  let cap: CanvasLineCap = 'butt';
   const ctx = {
     strokeStyle: '',
     lineWidth: 0,
     setLineDash(segments: number[]) {
       dash = segments;
     },
+    get lineCap() { return cap; },
+    set lineCap(value: CanvasLineCap) { cap = value; },
   };
   return {
     ctx: ctx as unknown as CanvasRenderingContext2D,
     lastDash: () => dash,
+    lastCap: () => cap,
   };
 }
 
@@ -167,6 +172,32 @@ describe('applyStroke dash patterns (§20.1.10.49 ST_PresetLineDashVal)', () => 
     const { ctx, lastDash } = makeStrokeMock();
     applyStroke(ctx, strokeWith('sysDash'), 3);
     expect(lastDash()).toEqual([24, 12]);
+  });
+
+  it('carries a round VML endcap so a zero-length dash renders as a dot', () => {
+    const { ctx, lastDash, lastCap } = makeStrokeMock();
+    applyStroke(ctx, { ...strokeWith('0 2'), lineCap: 'round' }, 1);
+    expect(lastDash()).toEqual([0, 4]);
+    expect(lastCap()).toBe('round');
+  });
+
+  it.each([undefined, 'butt' as const])(
+    'renders a zero-length VML dash as a fourfold-symmetric dot with %s endcap',
+    (lineCap) => {
+      const { ctx, lastDash, lastCap } = makeStrokeMock();
+      applyStroke(ctx, { ...strokeWith('0 2'), lineCap }, 1);
+      expect(lastDash()).toEqual([0, 4]);
+      // Canvas paints a zero-length segment with a square cap, but drops it
+      // with its `butt` cap. VML requires the zero token to remain visible.
+      expect(lastCap()).toBe('square');
+    },
+  );
+
+  it('keeps a flat cap when only a VML gap is zero-length', () => {
+    const { ctx, lastDash, lastCap } = makeStrokeMock();
+    applyStroke(ctx, strokeWith('2 0'), 1);
+    expect(lastDash()).toEqual([4, 0]);
+    expect(lastCap()).toBe('butt');
   });
 
   it('renders a VML numeric relative dashstyle without falling back to solid', () => {

--- a/packages/core/src/shape/paint.test.ts
+++ b/packages/core/src/shape/paint.test.ts
@@ -168,4 +168,12 @@ describe('applyStroke dash patterns (§20.1.10.49 ST_PresetLineDashVal)', () => 
     applyStroke(ctx, strokeWith('sysDash'), 3);
     expect(lastDash()).toEqual([24, 12]);
   });
+
+  it('renders a VML numeric relative dashstyle without falling back to solid', () => {
+    const { ctx, lastDash } = makeStrokeMock();
+    // VML dashstyle numbers are relative to the stroke width. With lw=2,
+    // `1 1` becomes one stroke-width on and one stroke-width off.
+    applyStroke(ctx, strokeWith('1 1'), 1);
+    expect(lastDash()).toEqual([2, 2]);
+  });
 });

--- a/packages/core/src/shape/paint.ts
+++ b/packages/core/src/shape/paint.ts
@@ -1,6 +1,6 @@
 import type { Fill, PatternFill, Stroke } from '../types/common';
 import { buildPatternBitmap } from './pattern-bitmaps';
-import { pptxPresetDashArray } from '../draw/dash';
+import { shapeStrokeDashArray } from '../draw/dash';
 
 /**
  * Convert a 6- or 8-char hex colour to a CSS `rgba()` string.
@@ -123,9 +123,9 @@ function resolvePatternFill(
  * Apply a Stroke to ctx. `emuPerPx` converts stroke width from EMU to px
  * (e.g. scale factor from pptx's emuToPx).
  *
- * The dash pattern comes from `pptxPresetDashArray` (§20.1.10.49
- * ST_PresetLineDashVal), which already scales by the pixel line width and
- * returns `[]` for solid / unknown styles.
+ * Parsers normalize symbolic dash vocabularies to DrawingML preset names; the
+ * shared resolver also accepts VML's numeric relative grammar. Both scale by
+ * the pixel line width and return `[]` for solid / unknown styles.
  */
 export function applyStroke(
   ctx: CanvasRenderingContext2D,
@@ -136,10 +136,20 @@ export function applyStroke(
     ctx.strokeStyle = 'transparent';
     ctx.lineWidth = 0;
     ctx.setLineDash([]);
+    ctx.lineCap = 'butt';
     return;
   }
   ctx.strokeStyle = hexToRgba(stroke.color);
   const lw = Math.max(0.5, stroke.width * emuPerPx);
   ctx.lineWidth = lw;
-  ctx.setLineDash(stroke.dashStyle ? pptxPresetDashArray(stroke.dashStyle, lw) : []);
+  const dash = stroke.dashStyle ? shapeStrokeDashArray(stroke.dashStyle, lw) : [];
+  const requestedCap = stroke.lineCap ?? 'butt';
+  // ECMA-376 Part 4 §19.1.2.21: a zero in VML's numeric dash grammar is a
+  // visible fourfold-symmetric dot, even though VML's default endcap is flat.
+  // Canvas drops a zero-length dash under its equivalent `butt` cap. A square
+  // cap is the exact centered, fourfold-symmetric fallback for that one case;
+  // explicit round/square caps keep their authored shape.
+  const hasZeroDash = dash.some((length, index) => index % 2 === 0 && length === 0);
+  ctx.lineCap = requestedCap === 'butt' && hasZeroDash ? 'square' : requestedCap;
+  ctx.setLineDash(dash);
 }

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -184,6 +184,8 @@ export interface Stroke {
   width: number;
   /** OOXML prstDash value: "dash", "dot", "dashDot", "lgDash", "lgDashDot", etc. */
   dashStyle?: string;
+  /** Canvas line cap normalized from DrawingML/VML (`flat` → `butt`). */
+  lineCap?: CanvasLineCap;
   /** Arrow head at the start of the line */
   headEnd?: ArrowEnd;
   /** Arrow head at the end of the line */

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3,6 +3,7 @@ use ooxml_common::blip::{
     svg_blip_rid, Duotone,
 };
 use ooxml_common::depth::{parse_guarded, DepthGuard};
+use ooxml_common::drawing::{DrawingGroupSpec, DrawingGroupTransform};
 use ooxml_common::ns::{attr_ns, is_w_ns, math, relationships, wordprocessingml};
 use ooxml_common::zip::read_zip_string;
 // Production parses go through `ooxml_common::depth::parse_guarded` (depth-guarded
@@ -4124,6 +4125,9 @@ fn parse_inline_drawing(
             src_rect,
             width_pt,
             height_pt,
+            rotation: 0.0,
+            flip_h: false,
+            flip_v: false,
             anchor: false,
             anchor_x_pt: 0.0,
             anchor_y_pt: 0.0,
@@ -4330,11 +4334,7 @@ fn parse_inline_drawing(
             pos_y,
             y_from_para,
             &anchor_meta,
-            1.0,
-            1.0,
-            0.0,
-            0.0,
-            false,
+            None,
             anchor_z_order,
         ) {
             shp.behind_doc = behind_doc;
@@ -4367,6 +4367,9 @@ fn parse_inline_drawing(
         src_rect,
         width_pt,
         height_pt,
+        rotation: 0.0,
+        flip_h: false,
+        flip_v: false,
         anchor: true,
         anchor_x_pt: pos_x,
         anchor_y_pt: pos_y,
@@ -4654,7 +4657,7 @@ fn parse_wgp_images(
     // pic's own offset, ignoring both the group's scale/offset and any nested
     // grpSp transform, mis-placing/mis-sizing grouped pictures.)
     let base = match group_xfrm(wgp) {
-        Some(x) => GroupTransform::IDENTITY.compose_child(x),
+        Some(x) => compose_group_xfrm(GroupTransform::IDENTITY, x),
         None => GroupTransform::IDENTITY,
     };
     let mut results = Vec::new();
@@ -4714,7 +4717,7 @@ fn walk_group_images(
             }
             "grpSp" => {
                 let child_xform = match group_xfrm(child) {
-                    Some(x) => xform.compose_child(x),
+                    Some(x) => compose_group_xfrm(xform, x),
                     None => xform,
                 };
                 walk_group_images(
@@ -4774,6 +4777,14 @@ fn parse_group_pic(
         .attribute("cy")
         .and_then(|v| v.parse::<f64>().ok())
         .unwrap_or(0.0);
+    let leaf_rotation = xfrm
+        .attribute("rot")
+        .and_then(|value| value.parse::<f64>().ok())
+        .unwrap_or(0.0)
+        / 60000.0;
+    let leaf_flip_h = matches!(xfrm.attribute("flipH"), Some("1") | Some("true"));
+    let leaf_flip_v = matches!(xfrm.attribute("flipV"), Some("1") | Some("true"));
+    let mapped = xform.apply_rect(ox, oy, cx, cy, leaf_rotation, leaf_flip_h, leaf_flip_v);
 
     if cx <= 0.0 || cy <= 0.0 {
         return None;
@@ -4810,13 +4821,16 @@ fn parse_group_pic(
         mime_type,
         svg_image_path,
         src_rect,
-        width_pt: cx * xform.scale_x / 12700.0,
-        height_pt: cy * xform.scale_y / 12700.0,
+        width_pt: mapped.width / 12700.0,
+        height_pt: mapped.height / 12700.0,
+        rotation: mapped.rotation_degrees,
+        flip_h: mapped.flip_h,
+        flip_v: mapped.flip_v,
         anchor: true,
         // Map the pic offset through the group chain, then add the page-space
         // anchor offset of the whole group.
-        anchor_x_pt: anchor_pos_x + xform.off_x_emu / 12700.0 + ox * xform.scale_x / 12700.0,
-        anchor_y_pt: anchor_pos_y + xform.off_y_emu / 12700.0 + oy * xform.scale_y / 12700.0,
+        anchor_x_pt: anchor_pos_x + mapped.x / 12700.0,
+        anchor_y_pt: anchor_pos_y + mapped.y / 12700.0,
         anchor_x_from_margin: x_from_margin,
         anchor_y_from_para: y_from_para,
         color_replace_from,
@@ -4854,54 +4868,17 @@ fn parse_group_pic(
 /// transforms have no skew). ECMA-376 §20.1.7.5 (`a:grpSpPr` group transform)
 /// and §20.1.7.6 (`a:xfrm` child offset/extent) define this scale/offset, and
 /// nested groups compose their transforms multiplicatively.
-#[derive(Clone, Copy)]
-struct GroupTransform {
-    scale_x: f64,
-    scale_y: f64,
-    off_x_emu: f64,
-    off_y_emu: f64,
-}
+type GroupTransform = DrawingGroupTransform;
 
-impl GroupTransform {
-    const IDENTITY: GroupTransform = GroupTransform {
-        scale_x: 1.0,
-        scale_y: 1.0,
-        off_x_emu: 0.0,
-        off_y_emu: 0.0,
-    };
-
-    /// Compose with the transform of a child group whose own `grpSpPr/xfrm`
-    /// gives off/ext/chOff/chExt. The child group maps grandchild coordinates
-    /// `g` to this group's child space via `mid = g_off - g_chOff*g_scale +
-    /// g*g_scale`; applying `self` (child→page) on top yields the composite
-    /// `page = self.off + self.scale*(mid)`. Expanding gives:
-    ///   new_scale = self.scale * g_scale
-    ///   new_off   = self.off + self.scale * (g_off - g_chOff * g_scale)
-    fn compose_child(self, xfrm: roxmltree::Node) -> GroupTransform {
-        let (off_x, off_y, ext_cx, ext_cy, ch_off_x, ch_off_y, ch_ext_cx, ch_ext_cy) =
-            read_group_xfrm(xfrm);
-        let g_scale_x = if ch_ext_cx > 0.0 && ext_cx > 0.0 {
-            ext_cx / ch_ext_cx
-        } else {
-            1.0
-        };
-        let g_scale_y = if ch_ext_cy > 0.0 && ext_cy > 0.0 {
-            ext_cy / ch_ext_cy
-        } else {
-            1.0
-        };
-        GroupTransform {
-            scale_x: self.scale_x * g_scale_x,
-            scale_y: self.scale_y * g_scale_y,
-            off_x_emu: self.off_x_emu + self.scale_x * (off_x - ch_off_x * g_scale_x),
-            off_y_emu: self.off_y_emu + self.scale_y * (off_y - ch_off_y * g_scale_y),
-        }
-    }
+/// Parse the host element's `a:xfrm` and delegate the DrawingML composition
+/// contract to `ooxml-common`, shared with the PPTX and XLSX adapters.
+fn compose_group_xfrm(parent: GroupTransform, xfrm: roxmltree::Node) -> GroupTransform {
+    parent.compose_group(read_group_xfrm(xfrm))
 }
 
 /// Read off/ext/chOff/chExt (EMU) from a group `a:xfrm`. Returns
 /// (off_x, off_y, ext_cx, ext_cy, ch_off_x, ch_off_y, ch_ext_cx, ch_ext_cy).
-fn read_group_xfrm(xfrm: roxmltree::Node) -> (f64, f64, f64, f64, f64, f64, f64, f64) {
+fn read_group_xfrm(xfrm: roxmltree::Node) -> DrawingGroupSpec {
     let attr = |node: Option<roxmltree::Node>, name: &str| {
         node.and_then(|n| n.attribute(name).and_then(|v| v.parse::<f64>().ok()))
             .unwrap_or(0.0)
@@ -4918,16 +4895,23 @@ fn read_group_xfrm(xfrm: roxmltree::Node) -> (f64, f64, f64, f64, f64, f64, f64,
     let ch_ext = xfrm
         .children()
         .find(|n| n.is_element() && n.tag_name().name() == "chExt");
-    (
-        attr(off, "x"),
-        attr(off, "y"),
-        attr(ext, "cx"),
-        attr(ext, "cy"),
-        attr(ch_off, "x"),
-        attr(ch_off, "y"),
-        attr(ch_ext, "cx"),
-        attr(ch_ext, "cy"),
-    )
+    DrawingGroupSpec {
+        off_x: attr(off, "x"),
+        off_y: attr(off, "y"),
+        ext_x: attr(ext, "cx"),
+        ext_y: attr(ext, "cy"),
+        child_off_x: attr(ch_off, "x"),
+        child_off_y: attr(ch_off, "y"),
+        child_ext_x: attr(ch_ext, "cx"),
+        child_ext_y: attr(ch_ext, "cy"),
+        rotation_degrees: xfrm
+            .attribute("rot")
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or(0.0)
+            / 60000.0,
+        flip_h: matches!(xfrm.attribute("flipH"), Some("1") | Some("true")),
+        flip_v: matches!(xfrm.attribute("flipV"), Some("1") | Some("true")),
+    }
 }
 
 /// Locate a group's `grpSpPr > xfrm` (the group's own transform), if present.
@@ -4964,7 +4948,7 @@ fn parse_wgp_shapes(
 ) -> Vec<ShapeRun> {
     // Base transform = the outermost wgp grpSpPr/xfrm (chOff/chExt → off/ext).
     let base = match group_xfrm(wgp) {
-        Some(x) => GroupTransform::IDENTITY.compose_child(x),
+        Some(x) => compose_group_xfrm(GroupTransform::IDENTITY, x),
         None => GroupTransform::IDENTITY,
     };
 
@@ -4975,10 +4959,18 @@ fn parse_wgp_shapes(
     // nesting depth.
     let (group_w_pt, group_h_pt) = match group_xfrm(wgp) {
         Some(x) => {
-            let (_, _, ext_cx, ext_cy, _, _, ch_ext_cx, ch_ext_cy) = read_group_xfrm(x);
+            let spec = read_group_xfrm(x);
             (
-                (if ext_cx > 0.0 { ext_cx } else { ch_ext_cx }) / 12700.0,
-                (if ext_cy > 0.0 { ext_cy } else { ch_ext_cy }) / 12700.0,
+                (if spec.ext_x > 0.0 {
+                    spec.ext_x
+                } else {
+                    spec.child_ext_x
+                }) / 12700.0,
+                (if spec.ext_y > 0.0 {
+                    spec.ext_y
+                } else {
+                    spec.child_ext_y
+                }) / 12700.0,
             )
         }
         None => (0.0, 0.0),
@@ -5052,11 +5044,7 @@ fn walk_group_children(
                     anchor_pos_y,
                     y_from_para,
                     anchor_meta,
-                    xform.scale_x,
-                    xform.scale_y,
-                    xform.off_x_emu / 12700.0,
-                    xform.off_y_emu / 12700.0,
-                    true,
+                    Some(xform),
                     anchor_z_order.saturating_add(idx),
                 ) {
                     shape.group_width_pt = Some(group_w_pt);
@@ -5067,7 +5055,7 @@ fn walk_group_children(
             "grpSp" => {
                 // Compose this nested group's transform, then recurse.
                 let child_xform = match group_xfrm(child) {
-                    Some(x) => xform.compose_child(x),
+                    Some(x) => compose_group_xfrm(xform, x),
                     None => xform,
                 };
                 walk_group_children(
@@ -5094,11 +5082,8 @@ fn walk_group_children(
     }
 }
 
-/// Parse a single wps:wsp into ShapeRun. `sx,sy` scale the shape's spPr/xfrm
-/// from group child coord space to page EMU; `group_off_pt_*` are the group origin
-/// on the page (in pt) so the shape's off.x/off.y (in child coord space) can be
-/// translated to page-relative pt. For a standalone wsp (no wgp), pass sx=sy=1,
-/// group_off=0 and `include_xfrm_offset=false`: the enclosing wp:anchor
+/// Parse a single wps:wsp into ShapeRun. `group_transform` is the cumulative
+/// Annex L DrawingML group hierarchy. For a standalone wsp pass `None`: the enclosing wp:anchor
 /// positionH/V already places the DrawingML object, while the shape's
 /// a:xfrm/off is its local DrawingML transform.
 // Carries the accumulated anchor/group coordinate transform (offsets, scale,
@@ -5116,11 +5101,7 @@ fn parse_wsp_shape(
     anchor_pos_y: f64,
     y_from_para: bool,
     anchor_meta: &AnchorMeta,
-    sx: f64,
-    sy: f64,
-    group_off_pt_x: f64,
-    group_off_pt_y: f64,
-    include_xfrm_offset: bool,
+    group_transform: Option<GroupTransform>,
     z_order: u32,
 ) -> Option<ShapeRun> {
     let sp_pr = wsp
@@ -5174,47 +5155,34 @@ fn parse_wsp_shape(
     let flip_h = matches!(xfrm.attribute("flipH"), Some("1") | Some("true"));
     let flip_v = matches!(xfrm.attribute("flipV"), Some("1") | Some("true"));
 
-    // Compose a quarter-turned child with an anisotropically scaled group about
-    // the child's CENTER (§20.1.7.5/.6). After 90°/270°, the local width axis
-    // maps to the parent Y scale and the local height axis maps to X. Applying
-    // sx/sy to width/height before the renderer rotates the box scales the wrong
-    // axes and moves an edge that should stay flush with the group boundary.
-    // ShapeRun cannot represent the shear produced by an arbitrary-angle child
-    // under non-uniform scale; exact quarter turns need no shear and can be
-    // represented by swapping the scale axes while preserving the mapped centre.
-    let normalized_rotation = rotation.rem_euclid(360.0);
-    let quarter_turned = include_xfrm_offset
-        && ((normalized_rotation - 90.0).abs() < 1e-9
-            || (normalized_rotation - 270.0).abs() < 1e-9);
-    let (width_pt, height_pt, local_x_pt, local_y_pt) = if quarter_turned {
-        let width = cx * sy / 12700.0;
-        let height = cy * sx / 12700.0;
-        let center_x = (ox + cx / 2.0) * sx / 12700.0;
-        let center_y = (oy + cy / 2.0) * sy / 12700.0;
-        (
-            width,
-            height,
-            center_x - width / 2.0,
-            center_y - height / 2.0,
-        )
-    } else {
-        (
-            cx * sx / 12700.0,
-            cy * sy / 12700.0,
-            if include_xfrm_offset {
-                ox * sx / 12700.0
-            } else {
-                0.0
-            },
-            if include_xfrm_offset {
-                oy * sy / 12700.0
-            } else {
-                0.0
-            },
-        )
-    };
-    let anchor_x_pt = anchor_pos_x + group_off_pt_x + local_x_pt;
-    let anchor_y_pt = anchor_pos_y + group_off_pt_y + local_y_pt;
+    // Annex L §L.4.7.4–§L.4.7.6: effective scale stays on its authored axis,
+    // rotations/flips compose separately, and the full hierarchy maps the
+    // child's original centre to determine translation.
+    let (width_pt, height_pt, local_x_pt, local_y_pt, rotation, flip_h, flip_v) =
+        if let Some(transform) = group_transform {
+            let mapped = transform.apply_rect(ox, oy, cx, cy, rotation, flip_h, flip_v);
+            (
+                mapped.width / 12700.0,
+                mapped.height / 12700.0,
+                mapped.x / 12700.0,
+                mapped.y / 12700.0,
+                mapped.rotation_degrees,
+                mapped.flip_h,
+                mapped.flip_v,
+            )
+        } else {
+            (
+                cx / 12700.0,
+                cy / 12700.0,
+                0.0,
+                0.0,
+                rotation,
+                flip_h,
+                flip_v,
+            )
+        };
+    let anchor_x_pt = anchor_pos_x + local_x_pt;
+    let anchor_y_pt = anchor_pos_y + local_y_pt;
 
     let cust_geom = sp_pr
         .children()
@@ -6255,70 +6223,11 @@ fn parse_vml_pict(
         return None;
     }
 
-    // VML colors: `fillcolor` / `strokecolor` are "#rrggbb" or a named color; we
-    // keep the 6-hex form the renderer expects (no leading '#').
-    let fill = shape
-        .attribute("fillcolor")
-        .and_then(vml_color_hex6)
-        .map(|color| ShapeFill::Solid { color });
-    // `stroked="f"` (or "false") disables the stroke regardless of strokecolor
-    // (§19.1.2 shape stroked attribute). Otherwise VML enables the stroke by
-    // default; an absent strokecolor resolves to black and the default weight is
-    // 0.75pt (Part 4 §19.1.2.21 strokeweight).
-    let stroked_off = shape
-        .attribute("stroked")
-        .is_some_and(|v| matches!(v.trim(), "f" | "false" | "0"));
-    let stroke = if stroked_off {
-        None
-    } else {
-        Some(
-            shape
-                .attribute("strokecolor")
-                .and_then(vml_color_hex6)
-                .unwrap_or_else(|| "000000".to_string()),
-        )
-    };
-    let stroke_width = if stroke.is_some() {
-        shape
-            .descendants()
-            .find(|n| n.is_element() && n.tag_name().name() == "stroke")
-            .and_then(|n| n.attribute("weight"))
-            .and_then(|w| w.trim_end_matches("pt").trim().parse::<f64>().ok())
-            .or_else(|| {
-                shape
-                    .attribute("strokeweight")
-                    .and_then(|w| w.trim_end_matches("pt").trim().parse::<f64>().ok())
-            })
-            .unwrap_or(0.75)
-    } else {
-        0.0
-    };
-    let stroke_dash = if stroke.is_some() {
-        shape
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "stroke")
-            .and_then(|n| n.attribute("dashstyle"))
-            .map(str::trim)
-            .filter(|v| !v.is_empty() && !v.eq_ignore_ascii_case("solid"))
-            .map(str::to_string)
-    } else {
-        None
-    };
-    let stroke_node = shape
-        .children()
-        .find(|n| n.is_element() && n.tag_name().name() == "stroke");
-    let head_end = stroke_node.and_then(|node| {
-        parse_vml_line_end(node, "startarrow", "startarrowwidth", "startarrowlength")
-    });
-    let tail_end = stroke_node
-        .and_then(|node| parse_vml_line_end(node, "endarrow", "endarrowwidth", "endarrowlength"));
+    let resolved_fill = resolve_vml_fill(shape, shape_type);
+    let resolved_stroke = resolve_vml_stroke(shape, shape_type);
 
     // ECMA-376 Part 4 §19.1.2.5 `<v:fill opacity>` — fill alpha (default opaque).
-    let fill_opacity = shape
-        .children()
-        .find(|n| n.is_element() && n.tag_name().name() == "fill")
-        .and_then(|f| f.attribute("opacity"))
-        .and_then(parse_vml_opacity);
+    let fill_opacity = resolved_fill.opacity;
 
     // §19.1.2.23 `<v:textpath>` — WordArt text (a watermark). When present this
     // shape draws stretched rotated text instead of a fill/stroke panel + body.
@@ -6415,8 +6324,9 @@ fn parse_vml_pict(
         ^ style_flip.split_whitespace().any(|axis| axis == "x");
     let flip_v = line_points.is_some_and(|(from, to)| from.1 > to.1)
         ^ style_flip.split_whitespace().any(|axis| axis == "y");
-    let adj_values = shape_type
-        .and_then(|node| node.attribute("adj"))
+    let adj_values = shape
+        .attribute("adj")
+        .or_else(|| shape_type.and_then(|node| node.attribute("adj")))
         .and_then(|value| value.split(',').next())
         .and_then(|value| value.trim().parse::<f64>().ok())
         .map(|value| vec![Some(value * 100000.0 / 21600.0)])
@@ -6438,13 +6348,14 @@ fn parse_vml_pict(
         subpaths: Vec::new(),
         preset_geometry,
         adj_values,
-        fill,
+        fill: resolved_fill.fill,
         fill_opacity,
-        stroke,
-        stroke_width,
-        stroke_dash,
-        head_end,
-        tail_end,
+        stroke: resolved_stroke.color,
+        stroke_width: resolved_stroke.width_pt,
+        stroke_dash: resolved_stroke.dash,
+        stroke_cap: resolved_stroke.cap,
+        head_end: resolved_stroke.head_end,
+        tail_end: resolved_stroke.tail_end,
         rotation,
         flip_h,
         flip_v,
@@ -6478,6 +6389,235 @@ fn vml_shape_type_preset(spt: u16) -> Option<&'static str> {
         202 => Some("rect"),
         _ => None,
     }
+}
+
+fn vml_direct_child<'a, 'input>(
+    node: roxmltree::Node<'a, 'input>,
+    local_name: &str,
+) -> Option<roxmltree::Node<'a, 'input>> {
+    node.children()
+        .find(|child| child.is_element() && child.tag_name().name() == local_name)
+}
+
+struct ResolvedVmlStroke {
+    color: Option<String>,
+    width_pt: f64,
+    dash: Option<String>,
+    cap: Option<String>,
+    head_end: Option<LineEnd>,
+    tail_end: Option<LineEnd>,
+}
+
+struct ResolvedVmlFill {
+    fill: Option<ShapeFill>,
+    opacity: Option<f64>,
+}
+
+/// Resolve the Part 4 §19.1.2.5/§19.1.2.19 fill cascade. Instance properties
+/// override the referenced shapetype; within either layer `<v:fill>` overrides
+/// the element attributes. An enabled fill defaults to white.
+fn resolve_vml_fill(
+    shape: roxmltree::Node,
+    shape_type: Option<roxmltree::Node>,
+) -> ResolvedVmlFill {
+    let shape_fill = vml_direct_child(shape, "fill");
+    let type_fill = shape_type.and_then(|node| vml_direct_child(node, "fill"));
+    let type_enabled = type_fill
+        .and_then(|node| node.attribute("on"))
+        .and_then(parse_vml_true_false)
+        .or_else(|| {
+            shape_type
+                .and_then(|node| node.attribute("filled"))
+                .and_then(parse_vml_true_false)
+        })
+        .unwrap_or(true);
+    let enabled = shape_fill
+        .and_then(|node| node.attribute("on"))
+        .and_then(parse_vml_true_false)
+        .or_else(|| shape.attribute("filled").and_then(parse_vml_true_false))
+        .unwrap_or(type_enabled);
+    let fill = enabled.then(|| {
+        let color = shape_fill
+            .and_then(|node| node.attribute("color"))
+            .and_then(vml_color_hex6)
+            .or_else(|| shape.attribute("fillcolor").and_then(vml_color_hex6))
+            .or_else(|| {
+                type_fill
+                    .and_then(|node| node.attribute("color"))
+                    .and_then(vml_color_hex6)
+            })
+            .or_else(|| {
+                shape_type
+                    .and_then(|node| node.attribute("fillcolor"))
+                    .and_then(vml_color_hex6)
+            })
+            .unwrap_or_else(|| "FFFFFF".to_string());
+        ShapeFill::Solid { color }
+    });
+    let opacity = enabled
+        .then(|| {
+            shape_fill
+                .and_then(|node| node.attribute("opacity"))
+                .or_else(|| type_fill.and_then(|node| node.attribute("opacity")))
+                .and_then(parse_vml_opacity)
+        })
+        .flatten();
+    ResolvedVmlFill { fill, opacity }
+}
+
+/// Resolve the Part 4 §19.1.2.19/§19.1.2.21 stroke cascade as one cohesive
+/// value. Instance properties override the referenced shapetype; within either
+/// layer a direct `<v:stroke>` child overrides the element attributes.
+fn resolve_vml_stroke(
+    shape: roxmltree::Node,
+    shape_type: Option<roxmltree::Node>,
+) -> ResolvedVmlStroke {
+    let shape_stroke = vml_direct_child(shape, "stroke");
+    let type_stroke = shape_type.and_then(|node| vml_direct_child(node, "stroke"));
+    let type_enabled = type_stroke
+        .and_then(|node| node.attribute("on"))
+        .and_then(parse_vml_true_false)
+        .or_else(|| {
+            shape_type
+                .and_then(|node| node.attribute("stroked"))
+                .and_then(parse_vml_true_false)
+        })
+        .unwrap_or(true);
+    let enabled = shape_stroke
+        .and_then(|node| node.attribute("on"))
+        .and_then(parse_vml_true_false)
+        .or_else(|| shape.attribute("stroked").and_then(parse_vml_true_false))
+        .unwrap_or(type_enabled);
+
+    let color = enabled.then(|| {
+        shape_stroke
+            .and_then(|node| node.attribute("color"))
+            .and_then(vml_color_hex6)
+            .or_else(|| shape.attribute("strokecolor").and_then(vml_color_hex6))
+            .or_else(|| {
+                type_stroke
+                    .and_then(|node| node.attribute("color"))
+                    .and_then(vml_color_hex6)
+            })
+            .or_else(|| {
+                shape_type
+                    .and_then(|node| node.attribute("strokecolor"))
+                    .and_then(vml_color_hex6)
+            })
+            .unwrap_or_else(|| "000000".to_string())
+    });
+    let width_pt = if enabled {
+        shape_stroke
+            .and_then(|node| node.attribute("weight"))
+            .and_then(parse_vml_stroke_weight_pt)
+            .or_else(|| {
+                shape
+                    .attribute("strokeweight")
+                    .and_then(parse_vml_stroke_weight_pt)
+            })
+            .or_else(|| {
+                type_stroke
+                    .and_then(|node| node.attribute("weight"))
+                    .and_then(parse_vml_stroke_weight_pt)
+            })
+            .or_else(|| {
+                shape_type
+                    .and_then(|node| node.attribute("strokeweight"))
+                    .and_then(parse_vml_stroke_weight_pt)
+            })
+            .unwrap_or(1.0)
+    } else {
+        0.0
+    };
+    let dash = enabled
+        .then(|| {
+            shape_stroke
+                .and_then(|node| node.attribute("dashstyle"))
+                .or_else(|| type_stroke.and_then(|node| node.attribute("dashstyle")))
+                .and_then(normalize_vml_dashstyle)
+        })
+        .flatten();
+    let cap = enabled
+        .then(|| {
+            shape_stroke
+                .and_then(|node| node.attribute("endcap"))
+                .or_else(|| type_stroke.and_then(|node| node.attribute("endcap")))
+                .and_then(|value| match value.to_ascii_lowercase().as_str() {
+                    "round" => Some("round".to_string()),
+                    "square" => Some("square".to_string()),
+                    "flat" => Some("butt".to_string()),
+                    _ => None,
+                })
+        })
+        .flatten();
+    let head_end = shape_stroke
+        .filter(|node| node.attribute("startarrow").is_some())
+        .or_else(|| type_stroke.filter(|node| node.attribute("startarrow").is_some()))
+        .and_then(|node| {
+            parse_vml_line_end(node, "startarrow", "startarrowwidth", "startarrowlength")
+        });
+    let tail_end = shape_stroke
+        .filter(|node| node.attribute("endarrow").is_some())
+        .or_else(|| type_stroke.filter(|node| node.attribute("endarrow").is_some()))
+        .and_then(|node| parse_vml_line_end(node, "endarrow", "endarrowwidth", "endarrowlength"));
+
+    ResolvedVmlStroke {
+        color,
+        width_pt,
+        dash,
+        cap,
+        head_end,
+        tail_end,
+    }
+}
+
+/// VML ST_TrueFalse accepts the long, short, and numeric spellings.
+fn parse_vml_true_false(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "t" | "true" | "1" => Some(true),
+        "f" | "false" | "0" => Some(false),
+        _ => None,
+    }
+}
+
+/// Part 4 §19.1.2.19 `strokeweight`: explicit CSS units convert normally, but
+/// a bare number is EMU (not points). The caller supplies the specified 1pt
+/// default when no valid value is present.
+fn parse_vml_stroke_weight_pt(raw: &str) -> Option<f64> {
+    let value = raw.trim().to_ascii_lowercase();
+    let has_unit = ["pt", "in", "cm", "mm", "pc", "px"]
+        .iter()
+        .any(|unit| value.ends_with(unit));
+    if has_unit {
+        parse_vml_length_pt(&value)
+    } else {
+        value.parse::<f64>().ok().map(|emu| emu / 12700.0)
+    }
+}
+
+/// Normalize Part 4 §19.1.2.21 VML symbolic dash names onto the shared
+/// DrawingML preset vocabulary. Numeric custom patterns remain textual and are
+/// interpreted by core's shape-stroke resolver, which applies the Part 4
+/// pair/discard grammar.
+fn normalize_vml_dashstyle(raw: &str) -> Option<String> {
+    let value = raw.trim();
+    if value.is_empty() || value.eq_ignore_ascii_case("solid") {
+        return None;
+    }
+    let preset = match value.to_ascii_lowercase().as_str() {
+        "shortdash" => "sysDash",
+        "shortdot" => "sysDot",
+        "shortdashdot" => "sysDashDot",
+        "shortdashdotdot" => "sysDashDotDot",
+        "dot" => "dot",
+        "dash" => "dash",
+        "longdash" => "lgDash",
+        "dashdot" => "dashDot",
+        "longdashdot" => "lgDashDot",
+        "longdashdotdot" => "lgDashDotDot",
+        _ => return Some(value.to_string()),
+    };
+    Some(preset.to_string())
 }
 
 /// Convert one VML length to points. VML coordinates commonly use points and
@@ -6725,6 +6865,9 @@ fn parse_vml_pict_image(
         src_rect: None,
         width_pt,
         height_pt,
+        rotation: 0.0,
+        flip_h: false,
+        flip_v: false,
         anchor: false,
         anchor_x_pt: 0.0,
         anchor_y_pt: 0.0,
@@ -6813,6 +6956,9 @@ fn parse_object_ole_image(
         src_rect: None,
         width_pt,
         height_pt,
+        rotation: 0.0,
+        flip_h: false,
+        flip_v: false,
         anchor: false,
         anchor_x_pt: 0.0,
         anchor_y_pt: 0.0,
@@ -9395,6 +9541,9 @@ mod tests {
             src_rect: None,
             width_pt: 24.0,
             height_pt: 24.0,
+            rotation: 0.0,
+            flip_h: false,
+            flip_v: false,
             anchor: false,
             anchor_x_pt: 0.0,
             anchor_y_pt: 0.0,
@@ -11709,6 +11858,9 @@ mod svg_blip_tests {
             src_rect: None,
             width_pt: 24.0,
             height_pt: 24.0,
+            rotation: 0.0,
+            flip_h: false,
+            flip_v: false,
             anchor: false,
             anchor_x_pt: 0.0,
             anchor_y_pt: 0.0,
@@ -15827,11 +15979,7 @@ mod shape_preset_geometry_tests {
             0.0,
             true,
             &AnchorMeta::default(),
-            1.0,
-            1.0,
-            0.0,
-            0.0,
-            false,
+            None,
             0,
         )
         .expect("shape parses")
@@ -15963,11 +16111,7 @@ mod shape_fontref_color_tests {
             0.0,
             true,
             &AnchorMeta::default(),
-            1.0,
-            1.0,
-            0.0,
-            0.0,
-            false,
+            None,
             0,
         )
         .expect("shape parses")
@@ -17567,7 +17711,7 @@ mod vml_pict_tests {
                 <v:shape type="#_x0000_t202"
                   style="position:absolute;margin-left:18.25pt;margin-top:-14.25pt;width:444.7pt;height:38.7pt;mso-width-relative:margin"
                   filled="f" strokeweight="1.5pt">
-                  <v:stroke dashstyle="1 1"/>
+                  <v:stroke dashstyle="0 2" endcap="round"/>
                   <v:textbox><w:txbxContent><w:p><w:r><w:t>notice</w:t></w:r></w:p></w:txbxContent></v:textbox>
                 </v:shape>
               </w:pict></w:r></w:p>
@@ -17581,7 +17725,95 @@ mod vml_pict_tests {
         assert!((shape.anchor_y_pt + 14.25).abs() < 1e-6);
         assert_eq!(shape.stroke.as_deref(), Some("000000"));
         assert!((shape.stroke_width - 1.5).abs() < 1e-6);
-        assert_eq!(shape.stroke_dash.as_deref(), Some("1 1"));
+        assert_eq!(shape.stroke_dash.as_deref(), Some("0 2"));
+        assert_eq!(shape.stroke_cap.as_deref(), Some("round"));
+    }
+
+    /// Part 4 §19.1.2.19/§19.1.2.21: the shape instance overrides its
+    /// referenced shapetype, while the instance's child stroke overrides the
+    /// instance attributes. Stroke weight defaults to 1pt and a unitless value
+    /// is expressed in EMU.
+    #[test]
+    fn vml_stroke_cascade_and_units_follow_part4() {
+        let body = format!(
+            r##"<w:document{ns}><w:body>
+              <w:p><w:r><w:pict>
+                <v:shapetype id="base" o:spt="86" stroked="f" strokecolor="#ff0000"
+                  strokeweight="25400" adj="1000">
+                  <v:stroke color="#00ff00" dashstyle="shortdot"/>
+                </v:shapetype>
+                <v:shape type="#base" stroked="t" strokecolor="#0000ff" adj="2000"
+                  style="width:20pt;height:30pt">
+                  <v:stroke on="t" color="#112233" weight="12700" dashstyle="longdashdotdot"/>
+                </v:shape>
+              </w:pict></w:r></w:p>
+              <w:p><w:r><w:pict>
+                <v:rect style="width:20pt;height:30pt" stroked="t">
+                  <v:stroke on="f" color="#abcdef"/>
+                </v:rect>
+              </w:pict></w:r></w:p>
+              <w:p><w:r><w:pict>
+                <v:rect style="width:20pt;height:30pt"/>
+              </w:pict></w:r></w:p>
+            </w:body></w:document>"##,
+            ns = VML_NS,
+        );
+        let shapes = shape_runs(&body, &HashMap::new());
+        assert_eq!(shapes.len(), 3);
+
+        assert_eq!(shapes[0].stroke.as_deref(), Some("112233"));
+        assert!((shapes[0].stroke_width - 1.0).abs() < 1e-6);
+        assert_eq!(shapes[0].stroke_dash.as_deref(), Some("lgDashDotDot"));
+        assert_eq!(
+            shapes[0].adj_values,
+            vec![Some(2000.0 * 100000.0 / 21600.0)]
+        );
+
+        assert_eq!(shapes[1].stroke, None);
+        assert_eq!(shapes[1].stroke_width, 0.0);
+
+        assert_eq!(shapes[2].stroke.as_deref(), Some("000000"));
+        assert!((shapes[2].stroke_width - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn vml_fill_cascade_and_default_follow_part4() {
+        let body = format!(
+            r##"<w:document{ns}><w:body>
+              <w:p><w:r><w:pict>
+                <v:shapetype id="inherited" fillcolor="#ff0000"/>
+                <v:rect type="#inherited" style="width:20pt;height:30pt"/>
+              </w:pict></w:r></w:p>
+              <w:p><w:r><w:pict>
+                <v:shapetype id="typedChild"><v:fill color="#00ff00"/></v:shapetype>
+                <v:rect type="#typedChild" fillcolor="#0000ff" style="width:20pt;height:30pt"/>
+              </w:pict></w:r></w:p>
+              <w:p><w:r><w:pict>
+                <v:rect fillcolor="#0000ff" style="width:20pt;height:30pt">
+                  <v:fill color="#112233" opacity="0.5"/>
+                </v:rect>
+              </w:pict></w:r></w:p>
+              <w:p><w:r><w:pict>
+                <v:rect filled="t" style="width:20pt;height:30pt"><v:fill on="f"/></v:rect>
+              </w:pict></w:r></w:p>
+              <w:p><w:r><w:pict><v:rect style="width:20pt;height:30pt"/></w:pict></w:r></w:p>
+            </w:body></w:document>"##,
+            ns = VML_NS,
+        );
+        let shapes = shape_runs(&body, &HashMap::new());
+        assert_eq!(shapes.len(), 5);
+        fn color(shape: &ShapeRun) -> Option<&str> {
+            match shape.fill.as_ref() {
+                Some(ShapeFill::Solid { color }) => Some(color.as_str()),
+                _ => None,
+            }
+        }
+        assert_eq!(color(&shapes[0]), Some("ff0000"));
+        assert_eq!(color(&shapes[1]), Some("0000ff"));
+        assert_eq!(color(&shapes[2]), Some("112233"));
+        assert!((shapes[2].fill_opacity.unwrap_or(0.0) - 0.5).abs() < 1e-6);
+        assert!(shapes[3].fill.is_none());
+        assert_eq!(color(&shapes[4]), Some("FFFFFF"));
     }
 
     /// VML §19.1.2.12 `<v:line>` stores its geometry in `from` / `to`
@@ -17838,11 +18070,9 @@ mod vml_pict_tests {
 mod wgp_shape_transform_tests {
     use super::*;
 
-    /// ECMA-376 §20.1.7.5/.6: a child shape's rotation is composed with the
-    /// parent group's non-uniform scale. For a quarter-turn, the child's local
-    /// width axis maps to the parent's Y axis and its height axis maps to X.
-    /// Scaling width by X and height by Y before rotating leaves an artificial
-    /// inset at the group edge.
+    /// Annex L §L.4.7.4–§L.4.7.5: horizontal/vertical scales are multiplied on
+    /// their authored axes; child rotation is summed independently. The full
+    /// group transform maps the child's original centre.
     #[test]
     fn quarter_turned_child_composes_non_uniform_group_scale_about_its_center() {
         let xml = r#"
@@ -17881,22 +18111,103 @@ mod wgp_shape_transform_tests {
         let shape = &shapes[0];
         assert!((shape.rotation - 90.0).abs() < 1e-6);
         assert!(
-            (shape.width_pt - 20.0).abs() < 1e-6,
+            (shape.width_pt - 10.0).abs() < 1e-6,
             "width={}",
             shape.width_pt
         );
         assert!(
-            (shape.height_pt - 2.0).abs() < 1e-6,
+            (shape.height_pt - 4.0).abs() < 1e-6,
             "height={}",
             shape.height_pt
         );
         assert!(
-            (shape.anchor_y_pt - 9.0).abs() < 1e-6,
+            (shape.anchor_y_pt - 8.0).abs() < 1e-6,
             "y={}",
             shape.anchor_y_pt
         );
-        let visual_top = shape.anchor_y_pt + shape.height_pt / 2.0 - shape.width_pt / 2.0;
-        assert!(visual_top.abs() < 1e-6, "visual top={visual_top}");
+        assert!(!shape.flip_h);
+        assert!(!shape.flip_v);
+    }
+
+    #[test]
+    fn rotated_flipped_group_composes_shape_per_annex_l() {
+        let xml = r#"
+          <wpg:wgp xmlns:wpg="urn:wpg" xmlns:wps="urn:wps" xmlns:a="urn:a">
+            <wpg:grpSpPr><a:xfrm rot="5400000" flipH="1">
+              <a:off x="0" y="0"/><a:ext cx="2540000" cy="1270000"/>
+              <a:chOff x="0" y="0"/><a:chExt cx="1270000" cy="1270000"/>
+            </a:xfrm></wpg:grpSpPr>
+            <wps:wsp><wps:spPr>
+              <a:xfrm rot="900000" flipV="1">
+                <a:off x="127000" y="254000"/><a:ext cx="254000" cy="127000"/>
+              </a:xfrm>
+              <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+              <a:noFill/><a:ln><a:noFill/></a:ln>
+            </wps:spPr></wps:wsp>
+          </wpg:wgp>
+        "#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let mut num_map = NumberingMap::default();
+        let shapes = parse_wgp_shapes(
+            &StyleMap::default(),
+            &mut num_map,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+            0.0,
+            false,
+            0.0,
+            true,
+            &AnchorMeta::default(),
+            0,
+        );
+        let shape = &shapes[0];
+        assert!((shape.anchor_x_pt - 105.0).abs() < 1e-6);
+        assert!((shape.anchor_y_pt - 105.0).abs() < 1e-6);
+        assert!((shape.width_pt - 40.0).abs() < 1e-6);
+        assert!((shape.height_pt - 10.0).abs() < 1e-6);
+        assert!((shape.rotation - 105.0).abs() < 1e-6);
+        assert!(shape.flip_h);
+        assert!(shape.flip_v);
+    }
+
+    #[test]
+    fn rotated_flipped_group_composes_picture_per_annex_l() {
+        let xml = r#"
+          <wpg:wgp xmlns:wpg="urn:wpg" xmlns:pic="urn:pic" xmlns:a="urn:a"
+                   xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+            <wpg:grpSpPr><a:xfrm rot="5400000" flipH="1">
+              <a:off x="0" y="0"/><a:ext cx="2540000" cy="1270000"/>
+              <a:chOff x="0" y="0"/><a:chExt cx="1270000" cy="1270000"/>
+            </a:xfrm></wpg:grpSpPr>
+            <pic:pic>
+              <pic:blipFill><a:blip r:embed="rId1"/></pic:blipFill>
+              <pic:spPr><a:xfrm rot="900000" flipV="1">
+                <a:off x="127000" y="254000"/><a:ext cx="254000" cy="127000"/>
+              </a:xfrm></pic:spPr>
+            </pic:pic>
+          </wpg:wgp>
+        "#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let media = HashMap::from([("rId1".to_string(), "word/media/image1.png".to_string())]);
+        let images = parse_wgp_images(
+            doc.root_element(),
+            &media,
+            &ThemeColors::default(),
+            0.0,
+            false,
+            0.0,
+            true,
+            &AnchorMeta::default(),
+        );
+        let image = &images[0];
+        assert!((image.anchor_x_pt - 105.0).abs() < 1e-6);
+        assert!((image.anchor_y_pt - 105.0).abs() < 1e-6);
+        assert!((image.width_pt - 40.0).abs() < 1e-6);
+        assert!((image.height_pt - 10.0).abs() < 1e-6);
+        assert!((image.rotation - 105.0).abs() < 1e-6);
+        assert!(image.flip_h);
+        assert!(image.flip_v);
     }
 }
 

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3,7 +3,7 @@ use ooxml_common::blip::{
     svg_blip_rid, Duotone,
 };
 use ooxml_common::depth::{parse_guarded, DepthGuard};
-use ooxml_common::drawing::{DrawingGroupSpec, DrawingGroupTransform};
+use ooxml_common::drawing::{DrawingGroupSpec, DrawingGroupTransform, DrawingRect};
 use ooxml_common::ns::{attr_ns, is_w_ns, math, relationships, wordprocessingml};
 use ooxml_common::zip::read_zip_string;
 // Production parses go through `ooxml_common::depth::parse_guarded` (depth-guarded
@@ -4784,7 +4784,15 @@ fn parse_group_pic(
         / 60000.0;
     let leaf_flip_h = matches!(xfrm.attribute("flipH"), Some("1") | Some("true"));
     let leaf_flip_v = matches!(xfrm.attribute("flipV"), Some("1") | Some("true"));
-    let mapped = xform.apply_rect(ox, oy, cx, cy, leaf_rotation, leaf_flip_h, leaf_flip_v);
+    let mapped = xform.apply_rect(DrawingRect {
+        x: ox,
+        y: oy,
+        width: cx,
+        height: cy,
+        rotation_degrees: leaf_rotation,
+        flip_h: leaf_flip_h,
+        flip_v: leaf_flip_v,
+    });
 
     if cx <= 0.0 || cy <= 0.0 {
         return None;
@@ -5160,7 +5168,15 @@ fn parse_wsp_shape(
     // child's original centre to determine translation.
     let (width_pt, height_pt, local_x_pt, local_y_pt, rotation, flip_h, flip_v) =
         if let Some(transform) = group_transform {
-            let mapped = transform.apply_rect(ox, oy, cx, cy, rotation, flip_h, flip_v);
+            let mapped = transform.apply_rect(DrawingRect {
+                x: ox,
+                y: oy,
+                width: cx,
+                height: cy,
+                rotation_degrees: rotation,
+                flip_h,
+                flip_v,
+            });
             (
                 mapped.width / 12700.0,
                 mapped.height / 12700.0,

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -5174,17 +5174,44 @@ fn parse_wsp_shape(
     let flip_h = matches!(xfrm.attribute("flipH"), Some("1") | Some("true"));
     let flip_v = matches!(xfrm.attribute("flipV"), Some("1") | Some("true"));
 
-    let width_pt = cx * sx / 12700.0;
-    let height_pt = cy * sy / 12700.0;
-    let local_x_pt = if include_xfrm_offset {
-        ox * sx / 12700.0
+    // Compose a quarter-turned child with an anisotropically scaled group about
+    // the child's CENTER (§20.1.7.5/.6). After 90°/270°, the local width axis
+    // maps to the parent Y scale and the local height axis maps to X. Applying
+    // sx/sy to width/height before the renderer rotates the box scales the wrong
+    // axes and moves an edge that should stay flush with the group boundary.
+    // ShapeRun cannot represent the shear produced by an arbitrary-angle child
+    // under non-uniform scale; exact quarter turns need no shear and can be
+    // represented by swapping the scale axes while preserving the mapped centre.
+    let normalized_rotation = rotation.rem_euclid(360.0);
+    let quarter_turned = include_xfrm_offset
+        && ((normalized_rotation - 90.0).abs() < 1e-9
+            || (normalized_rotation - 270.0).abs() < 1e-9);
+    let (width_pt, height_pt, local_x_pt, local_y_pt) = if quarter_turned {
+        let width = cx * sy / 12700.0;
+        let height = cy * sx / 12700.0;
+        let center_x = (ox + cx / 2.0) * sx / 12700.0;
+        let center_y = (oy + cy / 2.0) * sy / 12700.0;
+        (
+            width,
+            height,
+            center_x - width / 2.0,
+            center_y - height / 2.0,
+        )
     } else {
-        0.0
-    };
-    let local_y_pt = if include_xfrm_offset {
-        oy * sy / 12700.0
-    } else {
-        0.0
+        (
+            cx * sx / 12700.0,
+            cy * sy / 12700.0,
+            if include_xfrm_offset {
+                ox * sx / 12700.0
+            } else {
+                0.0
+            },
+            if include_xfrm_offset {
+                oy * sy / 12700.0
+            } else {
+                0.0
+            },
+        )
     };
     let anchor_x_pt = anchor_pos_x + group_off_pt_x + local_x_pt;
     let anchor_y_pt = anchor_pos_y + group_off_pt_y + local_y_pt;
@@ -6150,24 +6177,81 @@ fn parse_vml_pict(
     theme: &ThemeColors,
     media_map: &HashMap<String, String>,
 ) -> Option<ShapeRun> {
-    // v:shape / v:rect / v:roundrect — any VML shape element with geometry. A
+    // v:shape / v:rect / v:roundrect / v:line — any VML shape element with geometry. A
     // shape whose payload is a `<v:imagedata>` is a PICTURE, not a text/fill
     // panel (it is drawn by parse_vml_pict_image, or intentionally skipped when
     // its image can't be resolved); such a shape must not be turned into an
     // empty rectangle here, so it is excluded from the candidate set.
     let shape = pict.descendants().find(|n| {
         n.is_element()
-            && matches!(n.tag_name().name(), "shape" | "rect" | "roundrect" | "oval")
+            && matches!(
+                n.tag_name().name(),
+                "shape" | "rect" | "roundrect" | "oval" | "line"
+            )
             && !n
                 .children()
                 .any(|c| c.is_element() && c.tag_name().name() == "imagedata")
     })?;
 
-    // CSS-like `style`: "position:relative;width:300pt;height:60pt;…"
+    // CSS-like `style`: "position:relative;width:300pt;height:60pt;…".
+    // A referenced shapetype carries the legacy conceptual shape id (`o:spt`);
+    // map the interoperable subset onto the shared DrawingML preset engine.
     let style = shape.attribute("style").unwrap_or("");
-    let width_pt = vml_css_length_pt(style, "width").unwrap_or(0.0);
-    let height_pt = vml_css_length_pt(style, "height").unwrap_or(0.0);
-    if width_pt <= 0.0 || height_pt <= 0.0 {
+    let shape_type = shape
+        .attribute("type")
+        .map(|value| value.trim_start_matches('#'))
+        .and_then(|id| {
+            pict.descendants().find(|node| {
+                node.is_element()
+                    && node.tag_name().name() == "shapetype"
+                    && node.attribute("id") == Some(id)
+            })
+        });
+    let spt = shape
+        .attributes()
+        .find(|attr| attr.name() == "spt")
+        .or_else(|| shape_type.and_then(|node| node.attributes().find(|attr| attr.name() == "spt")))
+        .and_then(|attr| attr.value().parse::<u16>().ok());
+    let preset_geometry = match shape.tag_name().name() {
+        "line" => Some("line".to_string()),
+        "rect" => Some("rect".to_string()),
+        "roundrect" => Some("roundRect".to_string()),
+        "oval" => Some("ellipse".to_string()),
+        _ => Some(
+            spt.and_then(vml_shape_type_preset)
+                .unwrap_or("rect")
+                .to_string(),
+        ),
+    };
+    let is_line_geometry = preset_geometry.as_deref().is_some_and(|preset| {
+        let preset = preset.to_ascii_lowercase();
+        preset == "line" || preset.contains("connector")
+    });
+
+    let line_points = if shape.tag_name().name() == "line" {
+        match (
+            shape.attribute("from").and_then(parse_vml_point_pt),
+            shape.attribute("to").and_then(parse_vml_point_pt),
+        ) {
+            (Some(from), Some(to)) => Some((from, to)),
+            _ => return None,
+        }
+    } else {
+        None
+    };
+    let (width_pt, height_pt) = if let Some((from, to)) = line_points {
+        ((to.0 - from.0).abs(), (to.1 - from.1).abs())
+    } else {
+        (
+            vml_css_length_pt(style, "width").unwrap_or(0.0),
+            vml_css_length_pt(style, "height").unwrap_or(0.0),
+        )
+    };
+    if width_pt < 0.0
+        || height_pt < 0.0
+        || (is_line_geometry && width_pt == 0.0 && height_pt == 0.0)
+        || (!is_line_geometry && (width_pt == 0.0 || height_pt == 0.0))
+    {
         return None;
     }
 
@@ -6178,15 +6262,21 @@ fn parse_vml_pict(
         .and_then(vml_color_hex6)
         .map(|color| ShapeFill::Solid { color });
     // `stroked="f"` (or "false") disables the stroke regardless of strokecolor
-    // (§19.1.2 shape stroked attribute). Otherwise a strokecolor implies a
-    // stroke; VML's default weight is 0.75pt (Part 4 §19.1.2.21 strokeweight).
+    // (§19.1.2 shape stroked attribute). Otherwise VML enables the stroke by
+    // default; an absent strokecolor resolves to black and the default weight is
+    // 0.75pt (Part 4 §19.1.2.21 strokeweight).
     let stroked_off = shape
         .attribute("stroked")
         .is_some_and(|v| matches!(v.trim(), "f" | "false" | "0"));
     let stroke = if stroked_off {
         None
     } else {
-        shape.attribute("strokecolor").and_then(vml_color_hex6)
+        Some(
+            shape
+                .attribute("strokecolor")
+                .and_then(vml_color_hex6)
+                .unwrap_or_else(|| "000000".to_string()),
+        )
     };
     let stroke_width = if stroke.is_some() {
         shape
@@ -6203,6 +6293,25 @@ fn parse_vml_pict(
     } else {
         0.0
     };
+    let stroke_dash = if stroke.is_some() {
+        shape
+            .children()
+            .find(|n| n.is_element() && n.tag_name().name() == "stroke")
+            .and_then(|n| n.attribute("dashstyle"))
+            .map(str::trim)
+            .filter(|v| !v.is_empty() && !v.eq_ignore_ascii_case("solid"))
+            .map(str::to_string)
+    } else {
+        None
+    };
+    let stroke_node = shape
+        .children()
+        .find(|n| n.is_element() && n.tag_name().name() == "stroke");
+    let head_end = stroke_node.and_then(|node| {
+        parse_vml_line_end(node, "startarrow", "startarrowwidth", "startarrowlength")
+    });
+    let tail_end = stroke_node
+        .and_then(|node| parse_vml_line_end(node, "endarrow", "endarrowwidth", "endarrowlength"));
 
     // ECMA-376 Part 4 §19.1.2.5 `<v:fill opacity>` — fill alpha (default opaque).
     let fill_opacity = shape
@@ -6239,17 +6348,27 @@ fn parse_vml_pict(
     };
     let anchor_x_align = vml_css_str(style, "mso-position-horizontal").and_then(map_align);
     let anchor_y_align = vml_css_str(style, "mso-position-vertical").and_then(map_valign);
-    // `text` and `char`/`line` relative-froms map to paragraph-relative flow; we
-    // only forward the page/margin containers the watermark cares about.
-    let map_rel = |v: &str| match v {
+    // VML's `text` base is the containing text column horizontally (including a
+    // table cell's inner text box) and the anchor paragraph vertically. Carry
+    // those explicit containers instead of degrading them to the page margins.
+    let map_x_rel = |v: &str| match v {
         "margin" => Some("margin".to_string()),
         "page" => Some("page".to_string()),
+        "text" => Some("column".to_string()),
+        "char" => Some("character".to_string()),
+        _ => None,
+    };
+    let map_y_rel = |v: &str| match v {
+        "margin" => Some("margin".to_string()),
+        "page" => Some("page".to_string()),
+        "text" => Some("paragraph".to_string()),
+        "line" => Some("line".to_string()),
         _ => None,
     };
     let anchor_x_relative_from =
-        vml_css_str(style, "mso-position-horizontal-relative").and_then(map_rel);
+        vml_css_str(style, "mso-position-horizontal-relative").and_then(map_x_rel);
     let anchor_y_relative_from =
-        vml_css_str(style, "mso-position-vertical-relative").and_then(map_rel);
+        vml_css_str(style, "mso-position-vertical-relative").and_then(map_y_rel);
 
     // §19.1.2.19 style `z-index` — a negative value places the shape BEHIND the
     // document text (a watermark), matching wp:anchor behindDoc semantics.
@@ -6273,11 +6392,41 @@ fn parse_vml_pict(
             .unwrap_or_default()
     };
 
+    // §19.1.2.19: Word's absolute VML text boxes encode their numeric
+    // position in margin-left / margin-top even when `left:0` is also present.
+    // Preserve those authored offsets instead of collapsing every box to the
+    // anchor paragraph's leading corner.
+    let anchor_x_pt = line_points
+        .map(|(from, to)| from.0.min(to.0))
+        .unwrap_or_else(|| {
+            vml_css_length_pt(style, "margin-left")
+                .or_else(|| vml_css_length_pt(style, "left"))
+                .unwrap_or(0.0)
+        });
+    let anchor_y_pt = line_points
+        .map(|(from, to)| from.1.min(to.1))
+        .unwrap_or_else(|| {
+            vml_css_length_pt(style, "margin-top")
+                .or_else(|| vml_css_length_pt(style, "top"))
+                .unwrap_or(0.0)
+        });
+    let style_flip = vml_css_str(style, "flip").unwrap_or_default();
+    let flip_h = line_points.is_some_and(|(from, to)| from.0 > to.0)
+        ^ style_flip.split_whitespace().any(|axis| axis == "x");
+    let flip_v = line_points.is_some_and(|(from, to)| from.1 > to.1)
+        ^ style_flip.split_whitespace().any(|axis| axis == "y");
+    let adj_values = shape_type
+        .and_then(|node| node.attribute("adj"))
+        .and_then(|value| value.split(',').next())
+        .and_then(|value| value.trim().parse::<f64>().ok())
+        .map(|value| vec![Some(value * 100000.0 / 21600.0)])
+        .unwrap_or_default();
+
     Some(ShapeRun {
         width_pt,
         height_pt,
-        anchor_x_pt: 0.0,
-        anchor_y_pt: 0.0,
+        anchor_x_pt,
+        anchor_y_pt,
         anchor_x_from_margin: true,
         anchor_y_from_para: !behind_doc,
         anchor_x_align,
@@ -6287,13 +6436,18 @@ fn parse_vml_pict(
         behind_doc,
         z_order: 0,
         subpaths: Vec::new(),
-        preset_geometry: Some("rect".to_string()),
-        adj_values: Vec::new(),
+        preset_geometry,
+        adj_values,
         fill,
         fill_opacity,
         stroke,
         stroke_width,
+        stroke_dash,
+        head_end,
+        tail_end,
         rotation,
+        flip_h,
+        flip_v,
         text_path,
         // VML t202 text-box default insets are the OOXML defaults (§21.1.2.1.1).
         text_blocks,
@@ -6306,11 +6460,101 @@ fn parse_vml_pict(
     })
 }
 
+/// Map legacy VML conceptual shape ids ([MS-OE376] §3.9.5) onto the equivalent
+/// DrawingML preset names consumed by the shared DOCX/PPTX geometry engine.
+fn vml_shape_type_preset(spt: u16) -> Option<&'static str> {
+    match spt {
+        1 => Some("rect"),
+        2 => Some("roundRect"),
+        3 => Some("ellipse"),
+        20 => Some("line"),
+        32 => Some("straightConnector1"),
+        85 => Some("leftBracket"),
+        86 => Some("rightBracket"),
+        87 => Some("leftBrace"),
+        88 => Some("rightBrace"),
+        185 => Some("bracketPair"),
+        186 => Some("bracePair"),
+        202 => Some("rect"),
+        _ => None,
+    }
+}
+
+/// Convert one VML length to points. VML coordinates commonly use points and
+/// inches in the same document (`from="…pt"`, `to="6in"`), while a bare number
+/// in a WordprocessingML `<w:pict>` is interpreted as points.
+fn parse_vml_length_pt(value: &str) -> Option<f64> {
+    let value = value.trim().to_ascii_lowercase();
+    let (number, scale) = if let Some(number) = value.strip_suffix("pt") {
+        (number, 1.0)
+    } else if let Some(number) = value.strip_suffix("in") {
+        (number, 72.0)
+    } else if let Some(number) = value.strip_suffix("cm") {
+        (number, 72.0 / 2.54)
+    } else if let Some(number) = value.strip_suffix("mm") {
+        (number, 72.0 / 25.4)
+    } else if let Some(number) = value.strip_suffix("pc") {
+        (number, 12.0)
+    } else if let Some(number) = value.strip_suffix("px") {
+        (number, 72.0 / 96.0)
+    } else {
+        (value.as_str(), 1.0)
+    };
+    number.trim().parse::<f64>().ok().map(|n| n * scale)
+}
+
+/// Parse VML's `x,y` point-pair grammar used by `<v:line from/to>`.
+fn parse_vml_point_pt(value: &str) -> Option<(f64, f64)> {
+    let mut parts = value.split(',');
+    let x = parse_vml_length_pt(parts.next()?)?;
+    let y = parse_vml_length_pt(parts.next()?)?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((x, y))
+}
+
+/// Convert VML `<v:stroke startarrow/endarrow>` to the DrawingML-compatible
+/// line-end contract used by the shared renderer.
+fn parse_vml_line_end(
+    stroke: roxmltree::Node,
+    type_attr: &str,
+    width_attr: &str,
+    length_attr: &str,
+) -> Option<LineEnd> {
+    let r#type = match stroke
+        .attribute(type_attr)?
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "none" => return None,
+        "block" => "triangle",
+        "classic" => "stealth",
+        "diamond" => "diamond",
+        "oval" => "oval",
+        "open" => "arrow",
+        _ => return None,
+    };
+    let w = match stroke.attribute(width_attr).unwrap_or("medium").trim() {
+        "narrow" | "sm" => "sm",
+        "wide" | "lg" => "lg",
+        _ => "med",
+    };
+    let len = match stroke.attribute(length_attr).unwrap_or("medium").trim() {
+        "short" | "sm" => "sm",
+        "long" | "lg" => "lg",
+        _ => "med",
+    };
+    Some(LineEnd {
+        r#type: r#type.to_string(),
+        w: w.to_string(),
+        len: len.to_string(),
+    })
+}
+
 /// Read a length from a VML CSS `style` string (ECMA-376 Part 4 §19.1.2.19
-/// "style" — a semicolon-delimited `name:value` list). Returns the numeric value
-/// with a trailing `pt` unit stripped; VML lengths in a `<w:pict>` default to
-/// points, so a bare number is taken as pt. Non-`pt` units (px/cm/…) and
-/// percentages are not converted here (callers that need them handle it).
+/// "style" — a semicolon-delimited `name:value` list) and convert it to points.
 /// Property match is case-insensitive per the CSS2 grammar.
 fn vml_css_length_pt(style: &str, prop: &str) -> Option<f64> {
     for decl in style.split(';') {
@@ -6321,7 +6565,7 @@ fn vml_css_length_pt(style: &str, prop: &str) -> Option<f64> {
             None => continue,
         };
         if k.eq_ignore_ascii_case(prop) {
-            return v.trim_end_matches("pt").trim().parse::<f64>().ok();
+            return parse_vml_length_pt(v);
         }
     }
     None
@@ -7538,6 +7782,21 @@ fn parse_table_row(
     let cant_split = tr_pr
         .and_then(|p| bool_prop(p, "cantSplit"))
         .unwrap_or(false);
+    // ECMA-376 §17.4.15 / §17.4.14 — these are structural offsets into the
+    // shared tblGrid. They determine which grid columns the row's first/last
+    // cells occupy; wBefore/wAfter only supply preferred widths for those
+    // skipped columns and the saved tblGrid already carries their resolved
+    // widths for the renderer's fixed-grid placement.
+    let grid_before = tr_pr
+        .and_then(|p| child_w(p, "gridBefore"))
+        .and_then(|n| attr_w(n, "val"))
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(0);
+    let grid_after = tr_pr
+        .and_then(|p| child_w(p, "gridAfter"))
+        .and_then(|n| attr_w(n, "val"))
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(0);
 
     let mut cells = vec![];
     for (i, tc_node) in children_w_flat(node, "tc").into_iter().enumerate() {
@@ -7559,6 +7818,8 @@ fn parse_table_row(
 
     DocTableRow {
         cells,
+        grid_before,
+        grid_after,
         row_height,
         row_height_rule,
         is_header,
@@ -8055,6 +8316,30 @@ mod tests {
             &theme,
             DepthGuard::root(),
         )
+    }
+
+    #[test]
+    fn table_row_preserves_grid_columns_before_and_after_cells() {
+        // ECMA-376 §17.4.15 / §17.4.14: gridBefore/gridAfter are structural
+        // grid offsets, not ignorable preferred-width hints. A consumer must
+        // skip these columns before/after placing the row's real cells.
+        let table = parse_tbl(
+            r#"
+            <w:tblGrid>
+              <w:gridCol w:w="400"/><w:gridCol w:w="800"/><w:gridCol w:w="1200"/>
+            </w:tblGrid>
+            <w:tr>
+              <w:trPr>
+                <w:gridBefore w:val="1"/><w:wBefore w:w="400" w:type="dxa"/>
+                <w:gridAfter w:val="1"/><w:wAfter w:w="1200" w:type="dxa"/>
+              </w:trPr>
+              <w:tc><w:tcPr><w:tcW w:w="800" w:type="dxa"/></w:tcPr><w:p/></w:tc>
+            </w:tr>
+            "#,
+        );
+        let row = serde_json::to_value(&table.rows[0]).expect("serialize table row");
+        assert_eq!(row["gridBefore"], 1);
+        assert_eq!(row["gridAfter"], 1);
     }
 
     // ── Nested-table recursion depth guard (RB2) ───────────────────────────
@@ -17269,6 +17554,90 @@ mod vml_pict_tests {
             .collect()
     }
 
+    /// VML §19.1.2.19 absolute text boxes carry their authored offsets in the
+    /// CSS-like `margin-left` / `margin-top` declarations. A stroke is enabled
+    /// by default unless `stroked="f"`; when no `strokecolor` is authored VML's
+    /// default is black. Word also emits numeric relative dash patterns on the
+    /// child `<v:stroke>` element.
+    #[test]
+    fn textbox_preserves_offsets_and_default_stroke() {
+        let body = format!(
+            r##"<w:document{ns}><w:body>
+              <w:p><w:r><w:pict>
+                <v:shape type="#_x0000_t202"
+                  style="position:absolute;margin-left:18.25pt;margin-top:-14.25pt;width:444.7pt;height:38.7pt;mso-width-relative:margin"
+                  filled="f" strokeweight="1.5pt">
+                  <v:stroke dashstyle="1 1"/>
+                  <v:textbox><w:txbxContent><w:p><w:r><w:t>notice</w:t></w:r></w:p></w:txbxContent></v:textbox>
+                </v:shape>
+              </w:pict></w:r></w:p>
+            </w:body></w:document>"##,
+            ns = VML_NS,
+        );
+        let shapes = shape_runs(&body, &HashMap::new());
+        assert_eq!(shapes.len(), 1);
+        let shape = &shapes[0];
+        assert!((shape.anchor_x_pt - 18.25).abs() < 1e-6);
+        assert!((shape.anchor_y_pt + 14.25).abs() < 1e-6);
+        assert_eq!(shape.stroke.as_deref(), Some("000000"));
+        assert!((shape.stroke_width - 1.5).abs() < 1e-6);
+        assert_eq!(shape.stroke_dash.as_deref(), Some("1 1"));
+    }
+
+    /// VML §19.1.2.12 `<v:line>` stores its geometry in `from` / `to`
+    /// rather than CSS width/height. Word uses these legacy line elements for
+    /// form connectors; `<v:stroke endarrow="block">` decorates the `to` end.
+    #[test]
+    fn line_preserves_endpoints_and_block_arrow() {
+        let body = format!(
+            r##"<w:document{ns}><w:body>
+              <w:p><w:r><w:pict>
+                <v:line style="position:absolute;mso-position-horizontal-relative:text;mso-position-vertical-relative:text" from="44pt,6.5pt"
+                  to="142pt,6.5pt" strokeweight="1.5pt">
+                  <v:stroke endarrow="block"/>
+                </v:line>
+              </w:pict></w:r></w:p>
+            </w:body></w:document>"##,
+            ns = VML_NS,
+        );
+        let shapes = shape_runs(&body, &HashMap::new());
+        assert_eq!(shapes.len(), 1);
+        let shape = &shapes[0];
+        assert_eq!(shape.preset_geometry.as_deref(), Some("line"));
+        assert!((shape.anchor_x_pt - 44.0).abs() < 1e-6);
+        assert!((shape.anchor_y_pt - 6.5).abs() < 1e-6);
+        assert!((shape.width_pt - 98.0).abs() < 1e-6);
+        assert!(shape.height_pt.abs() < 1e-6);
+        assert_eq!(shape.stroke.as_deref(), Some("000000"));
+        assert!((shape.stroke_width - 1.5).abs() < 1e-6);
+        assert_eq!(shape.anchor_x_relative_from.as_deref(), Some("column"));
+        assert_eq!(shape.anchor_y_relative_from.as_deref(), Some("paragraph"));
+        assert_eq!(
+            shape.tail_end.as_ref().map(|end| end.r#type.as_str()),
+            Some("triangle")
+        );
+    }
+
+    /// [MS-OE376] §3.9.5 maps VML shape type 86 to Right Bracket. Reusing
+    /// the shared DrawingML preset lets DOCX and PPTX render the same geometry.
+    #[test]
+    fn legacy_shape_type_86_maps_to_right_bracket_preset() {
+        let body = format!(
+            r##"<w:document{ns}><w:body>
+              <w:p><w:r><w:pict>
+                <v:shapetype id="_x0000_t86" o:spt="86" filled="f"/>
+                <v:shape type="#_x0000_t86"
+                  style="position:absolute;margin-left:133.5pt;margin-top:10.3pt;width:13.35pt;height:15.1pt"
+                  filled="f"/>
+              </w:pict></w:r></w:p>
+            </w:body></w:document>"##,
+            ns = VML_NS,
+        );
+        let shapes = shape_runs(&body, &HashMap::new());
+        assert_eq!(shapes.len(), 1);
+        assert_eq!(shapes[0].preset_geometry.as_deref(), Some("rightBracket"));
+    }
+
     /// §19.1.2.11 imagedata — a bare `<w:pict>` (no `<w:object>` wrapper) whose
     /// `<v:shape>` carries a `<v:imagedata r:id>` is a non-OLE inline VML image.
     /// It must surface as an inline `ImageRun` sized from the shape's CSS `style`
@@ -17462,6 +17831,72 @@ mod vml_pict_tests {
                 .as_deref(),
             Some("Arial")
         );
+    }
+}
+
+#[cfg(test)]
+mod wgp_shape_transform_tests {
+    use super::*;
+
+    /// ECMA-376 §20.1.7.5/.6: a child shape's rotation is composed with the
+    /// parent group's non-uniform scale. For a quarter-turn, the child's local
+    /// width axis maps to the parent's Y axis and its height axis maps to X.
+    /// Scaling width by X and height by Y before rotating leaves an artificial
+    /// inset at the group edge.
+    #[test]
+    fn quarter_turned_child_composes_non_uniform_group_scale_about_its_center() {
+        let xml = r#"
+          <wpg:wgp xmlns:wpg="urn:wpg" xmlns:wps="urn:wps" xmlns:a="urn:a">
+            <wpg:grpSpPr><a:xfrm>
+              <a:off x="0" y="0"/><a:ext cx="127000" cy="254000"/>
+              <a:chOff x="0" y="0"/><a:chExt cx="127000" cy="127000"/>
+            </a:xfrm></wpg:grpSpPr>
+            <wps:wsp>
+              <wps:spPr>
+                <a:xfrm rot="5400000">
+                  <a:off x="0" y="50800"/><a:ext cx="127000" cy="25400"/>
+                </a:xfrm>
+                <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+                <a:noFill/><a:ln><a:noFill/></a:ln>
+              </wps:spPr>
+            </wps:wsp>
+          </wpg:wgp>
+        "#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let mut num_map = NumberingMap::default();
+        let shapes = parse_wgp_shapes(
+            &StyleMap::default(),
+            &mut num_map,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+            0.0,
+            false,
+            0.0,
+            true,
+            &AnchorMeta::default(),
+            0,
+        );
+        assert_eq!(shapes.len(), 1);
+        let shape = &shapes[0];
+        assert!((shape.rotation - 90.0).abs() < 1e-6);
+        assert!(
+            (shape.width_pt - 20.0).abs() < 1e-6,
+            "width={}",
+            shape.width_pt
+        );
+        assert!(
+            (shape.height_pt - 2.0).abs() < 1e-6,
+            "height={}",
+            shape.height_pt
+        );
+        assert!(
+            (shape.anchor_y_pt - 9.0).abs() < 1e-6,
+            "y={}",
+            shape.anchor_y_pt
+        );
+        let visual_top = shape.anchor_y_pt + shape.height_pt / 2.0 - shape.width_pt / 2.0;
+        assert!(visual_top.abs() < 1e-6, "visual top={visual_top}");
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1048,6 +1048,9 @@ pub struct ShapeRun {
     /// `<a:ln><a:prstDash val>` (ECMA-376 §20.1.8.48). None ⇒ solid.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash: Option<String>,
+    /// VML `<v:stroke endcap>` / DrawingML line cap, normalized for Canvas.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stroke_cap: Option<String>,
     /// `<a:ln><a:headEnd>` decoration (line start). None ⇒ no head.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub head_end: Option<LineEnd>,
@@ -1684,6 +1687,13 @@ pub struct ImageRun {
     pub width_pt: f64,
     /// pt
     pub height_pt: f64,
+    /// Effective DrawingML rotation after composing a picture's parent groups.
+    #[serde(skip_serializing_if = "is_zero_f64")]
+    pub rotation: f64,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub flip_h: bool,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub flip_v: bool,
     /// true = wp:anchor (absolute page position), false = wp:inline (flows with text)
     pub anchor: bool,
     /// X offset in pt (anchor only).  Interpretation depends on anchor_x_from_margin.

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -2010,6 +2010,12 @@ pub struct BorderSpec {
 #[serde(rename_all = "camelCase")]
 pub struct DocTableRow {
     pub cells: Vec<DocTableCell>,
+    /// ECMA-376 §17.4.15: number of table-grid columns skipped before the first
+    /// real cell in this row. Omitted means zero.
+    pub grid_before: u32,
+    /// ECMA-376 §17.4.14: number of table-grid columns skipped after the last
+    /// real cell in this row. Omitted means zero.
+    pub grid_after: u32,
     /// pt, None = auto
     pub row_height: Option<f64>,
     /// ECMA-376 §17.4.80 w:trHeight/@hRule. "auto" (default) = treat row_height

--- a/packages/docx/src/cell-border-conflict-render.test.ts
+++ b/packages/docx/src/cell-border-conflict-render.test.ts
@@ -173,6 +173,55 @@ describe('§17.4.66 — adjacent cell border conflict, end-to-end render', () =>
       expect.objectContaining({ x1: 20, x2: 60 }),
     ]));
     expect(top.some((s) => Math.min(s.x1, s.x2) < 20)).toBe(false);
+    expect(verticalAt(strokes, 20)).toHaveLength(1);
+  });
+
+  it('§17.4.15: ignores gridBefore values larger than the table grid', async () => {
+    const first = cell('first', {
+      top: bs({ width: 1 }),
+      left: bs({ width: 1 }),
+    });
+    const shiftedRow = { ...rowOf([first]), gridBefore: 3 } as unknown as DocTableRow;
+    const t = tableOf([shiftedRow]);
+    t.colWidths = [20, 40];
+    t.layout = 'fixed';
+    t.widthPt = 60;
+
+    const strokes = await render(t);
+
+    expect(horizontalAt(strokes, 0)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ x1: 0, x2: 20 }),
+    ]));
+    expect(verticalAt(strokes, 0)).toHaveLength(1);
+  });
+
+  it('draws a cell top border where the row above omits that grid slot', async () => {
+    const upper = { ...rowOf([cell('upper')]), gridBefore: 1 } as unknown as DocTableRow;
+    const lower = rowOf([cell('lower', { top: bs({ width: 1 }) }), cell('right')]);
+    const t = tableOf([upper, lower]);
+    t.colWidths = [20, 40];
+    t.layout = 'fixed';
+    t.widthPt = 60;
+
+    const strokes = await render(t);
+
+    expect(horizontalAt(strokes, 20)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ x1: 0, x2: 20 }),
+    ]));
+  });
+
+  it('draws the physical-right boundary beside gridBefore in a bidiVisual row', async () => {
+    const shifted = cell('shifted', { left: bs({ width: 1 }) });
+    const shiftedRow = { ...rowOf([shifted]), gridBefore: 1 } as unknown as DocTableRow;
+    const t = tableOf([shiftedRow]);
+    t.colWidths = [20, 40, 60];
+    t.layout = 'fixed';
+    t.widthPt = 120;
+    t.bidiVisual = true;
+
+    const strokes = await render(t);
+
+    expect(verticalAt(strokes, 100)).toHaveLength(1);
   });
 
   it('shared vertical gridline is drawn exactly ONCE (not once per cell)', async () => {

--- a/packages/docx/src/cell-border-conflict-render.test.ts
+++ b/packages/docx/src/cell-border-conflict-render.test.ts
@@ -149,6 +149,32 @@ function horizontalAt(strokes: StrokeSeg[], y: number): StrokeSeg[] {
 }
 
 describe('§17.4.66 — adjacent cell border conflict, end-to-end render', () => {
+  it('§17.4.15: gridBefore starts the first cell after the skipped grid columns', async () => {
+    const middle = cell('middle', {
+      top: bs({ width: 1 }),
+      bottom: bs({ width: 1 }),
+      left: bs({ width: 1 }),
+      right: bs({ width: 1 }),
+    });
+    const shiftedRow = {
+      ...rowOf([middle]),
+      gridBefore: 1,
+      gridAfter: 1,
+    } as unknown as DocTableRow;
+    const t = tableOf([shiftedRow]);
+    t.colWidths = [20, 40, 60];
+    t.layout = 'fixed';
+    t.widthPt = 120;
+
+    const strokes = await render(t);
+    const top = horizontalAt(strokes, 0);
+
+    expect(top).toEqual(expect.arrayContaining([
+      expect.objectContaining({ x1: 20, x2: 60 }),
+    ]));
+    expect(top.some((s) => Math.min(s.x1, s.x2) < 20)).toBe(false);
+  });
+
   it('shared vertical gridline is drawn exactly ONCE (not once per cell)', async () => {
     // Both cells set their facing edge to the SAME single 1pt border. Previously
     // each cell drew it (two strokes at x=60); now it is drawn once.
@@ -326,5 +352,24 @@ describe('§17.4.66 — adjacent cell border conflict, end-to-end render', () =>
     const bot = seg.filter((s) => Math.max(s.y1, s.y2) > 30);
     expect(top.some((s) => s.color.toLowerCase().includes('111111'))).toBe(true);
     expect(bot.some((s) => s.color.toLowerCase().includes('222222'))).toBe(true);
+  });
+
+  it('uses the final continuation cell border at the bottom of a vertical merge', async () => {
+    // A vertical merge is represented by one restart cell followed by continuation
+    // cells. The boundary at the bottom of the merged region is therefore the
+    // continuation cell's bottom edge, not the restart cell's bottom edge. An
+    // explicit nil on that final continuation must suppress the table insideH
+    // fallback at the boundary below the merge.
+    const restart = cell('merged');
+    restart.vMerge = true;
+    const continuation = cell('', { bottom: bs({ style: 'nil' }) });
+    continuation.vMerge = false;
+    const below = cell('below', { top: bs({ style: 'nil' }) });
+    const strokes = await render(tableOf(
+      [rowOf([restart]), rowOf([continuation]), rowOf([below])],
+      { insideH: bs({ style: 'single', width: 1 }) },
+    ));
+
+    expect(horizontalAt(strokes, 40)).toHaveLength(0);
   });
 });

--- a/packages/docx/src/float-table-page-fit.test.ts
+++ b/packages/docx/src/float-table-page-fit.test.ts
@@ -262,6 +262,21 @@ describe('computePages — floating-table page-fit / row-split (§17.4.57, Word 
     expect(pages[2].filter((el) => el.type === 'table' && !isFloatTable(el))).toHaveLength(1);
   });
 
+  it('rechecks the block-table position after each staggered float collision', () => {
+    const body = [
+      floatTableRows(tblp({ vertAnchor: 'text', tblpY: 0 }), 1, 15),
+      // The block table does not initially intersect this second band. Moving it
+      // below the first float creates the second collision.
+      floatTableRows(tblp({ vertAnchor: 'text', tblpY: 20 }), 1, 15),
+      blockTable(10),
+    ];
+    const pages = computePages(body, section({ pageHeight: 80 }), makeCtx());
+
+    expect(pages.length).toBe(2);
+    expect(pages[0].filter((el) => el.type === 'table' && !isFloatTable(el))).toHaveLength(0);
+    expect(pages[1].filter((el) => el.type === 'table' && !isFloatTable(el))).toHaveLength(1);
+  });
+
   it('(b) splits a tall floating table across pages until every row is placed (sample-21 shape)', () => {
     // A single leading 20pt line (anchor at y=20) then an 8-row table (20pt each ⇒
     // 160pt total, > the 100pt content area, so it needs 2 pages). Page 1's band

--- a/packages/docx/src/float-table-page-fit.test.ts
+++ b/packages/docx/src/float-table-page-fit.test.ts
@@ -153,6 +153,17 @@ function floatTable(tp: TblpPr, tableHPt: number): BodyElement {
   return floatTableRows(tp, 1, tableHPt);
 }
 
+/** An ordinary in-flow block table with one exact-height row. */
+function blockTable(tableHPt: number): BodyElement {
+  const table = floatTableRows(tblp(), 1, tableHPt) as unknown as DocTable & { type: 'table' };
+  const { tblpPr: _floating, ...block } = table;
+  return block as unknown as BodyElement;
+}
+
+const continuousBreak = (): BodyElement => ({
+  type: 'sectionBreak', kind: 'nextPage', columns: null,
+} as BodyElement);
+
 /** True when an element is a floating table (identified by its tblpPr). */
 const isFloatTable = (el: PaginatedBodyElement): boolean =>
   el.type === 'table' && (el as unknown as DocTable).tblpPr != null;
@@ -221,6 +232,34 @@ describe('computePages — floating-table page-fit / row-split (§17.4.57, Word 
     expect([...floatRowsOn(pages[0]), ...floatRowsOn(pages[1])]).toEqual([
       'r1', 'r2', 'r3', 'r4', 'r5',
     ]);
+  });
+
+  it('moves a following block table past a page-filling float across a continuous section', () => {
+    const body = [
+      floatTableRows(tblp({ vertAnchor: 'text', tblpY: 0 }), 5, 20),
+      continuousBreak(),
+      blockTable(90),
+    ];
+    const pages = computePages(body, section({ sectionStart: 'continuous' }), makeCtx());
+    expect(pages.length).toBe(2);
+    expect(hasFloatTable(pages[0])).toBe(true);
+    expect(pages[0].filter((el) => el.type === 'table' && !isFloatTable(el))).toHaveLength(0);
+    expect(pages[1].filter((el) => el.type === 'table' && !isFloatTable(el))).toHaveLength(1);
+  });
+
+  it('does not overlap a following block table with a terminal float continuation slice', () => {
+    const body = [
+      // Five rows fill page 1; the sixth occupies y=0..20 on page 2.
+      floatTableRows(tblp({ vertAnchor: 'text', tblpY: 0 }), 6, 20),
+      continuousBreak(),
+      // It fits a clean 100pt page, but not page 2 below the 20pt float slice.
+      blockTable(90),
+    ];
+    const pages = computePages(body, section({ sectionStart: 'continuous' }), makeCtx());
+    expect(pages.length).toBe(3);
+    expect(floatRowsOn(pages[1])).toEqual(['r6']);
+    expect(pages[1].filter((el) => el.type === 'table' && !isFloatTable(el))).toHaveLength(0);
+    expect(pages[2].filter((el) => el.type === 'table' && !isFloatTable(el))).toHaveLength(1);
   });
 
   it('(b) splits a tall floating table across pages until every row is placed (sample-21 shape)', () => {

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -247,6 +247,9 @@ export interface LayoutImageSeg extends LayoutSegSource {
   mimeType: string;
   widthPt: number;
   heightPt: number;
+  rotation?: number;
+  flipH?: boolean;
+  flipV?: boolean;
   /** true = wp:anchor: skip inline flow, draw at absolute page coords */
   anchor: boolean;
   anchorXPt: number;
@@ -2405,6 +2408,9 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
         mimeType: img.mimeType,
         widthPt: img.widthPt,
         heightPt: img.heightPt,
+        rotation: img.rotation,
+        flipH: img.flipH,
+        flipV: img.flipV,
         anchor: img.anchor ?? false,
         anchorXPt: img.anchorXPt ?? 0,
         anchorYPt: img.anchorYPt ?? 0,

--- a/packages/docx/src/line-spacing-baseline.test.ts
+++ b/packages/docx/src/line-spacing-baseline.test.ts
@@ -197,14 +197,15 @@ describe('lineRule=exact / atLeast keep the centred placement (regression guard,
     expect(t!.y).toBeCloseTo(ASCENT, TOL);
   });
 
-  it('sub-single multiplier (0.5×) keeps the baseline pinned at ascent (negative leading)', async () => {
+  it('sub-single auto multiplier (0.5×) centres the glyph in the compressed line box', async () => {
     const calls = await renderAndRead(paragraph('T', auto(0.5)));
     const t = calls.find((c) => c.text === 'T');
     expect(t).toBeDefined();
-    // lineH = 10 × 0.5 = 5 < singleBox 10; the baseline stays at the natural
-    // ascent (8) and the shortfall is negative leading (lines overlap), not a
-    // re-centring inside the shrunken box.
-    expect(t!.y).toBeCloseTo(ASCENT, TOL);
+    // lineH = 10 × 0.5 = 5 < glyph box 10. Word centres the glyph box in the
+    // compressed advance: top + (5 − 10)/2 + ascent 8 = 5.5. The glyph may
+    // extend beyond both line-box edges, but it does not shift wholly downward
+    // into the following row/content.
+    expect(t!.y).toBeCloseTo(5.5, TOL);
   });
 });
 

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3948,22 +3948,32 @@ export function computePages(
           : colX() + indPt;
       }
       const tblRightPt = tblLeftPt + tblWidthPt;
-      const tableTopAbsPt = bodyTopPt() + y;
-      const tableBottomAbsPt = tableTopAbsPt + measuredRowHs.reduce((sum, height) => sum + height, 0);
-      let clearToAbsPt = tableTopAbsPt;
-      for (const float of measureState.floats) {
-        if (float.kind !== 'table') continue;
-        const overlapsX =
-          tblRightPt - float.xLeft > FLOAT_OVERLAP_EPS &&
-          float.xRight - tblLeftPt > FLOAT_OVERLAP_EPS;
-        const overlapsY =
-          tableBottomAbsPt - float.yTop > FLOAT_OVERLAP_EPS &&
-          float.yBottom - tableTopAbsPt > FLOAT_OVERLAP_EPS;
-        if (overlapsX && overlapsY) clearToAbsPt = Math.max(clearToAbsPt, float.yBottom);
+      const tableHeightPt = measuredRowHs.reduce((sum, height) => sum + height, 0);
+      const initialTopAbsPt = bodyTopPt() + y;
+      let candidateTopAbsPt = initialTopAbsPt;
+      // Moving below one exclusion can create a new overlap with a staggered
+      // lower float that did not intersect the original box. Re-evaluate the
+      // translated rectangle until its top is stable. Each iteration advances
+      // to at least one finite float bottom, so the loop is monotonic/bounded.
+      for (;;) {
+        const candidateBottomAbsPt = candidateTopAbsPt + tableHeightPt;
+        let clearToAbsPt = candidateTopAbsPt;
+        for (const float of measureState.floats) {
+          if (float.kind !== 'table') continue;
+          const overlapsX =
+            tblRightPt - float.xLeft > FLOAT_OVERLAP_EPS &&
+            float.xRight - tblLeftPt > FLOAT_OVERLAP_EPS;
+          const overlapsY =
+            candidateBottomAbsPt - float.yTop > FLOAT_OVERLAP_EPS &&
+            float.yBottom - candidateTopAbsPt > FLOAT_OVERLAP_EPS;
+          if (overlapsX && overlapsY) clearToAbsPt = Math.max(clearToAbsPt, float.yBottom);
+        }
+        if (clearToAbsPt <= candidateTopAbsPt + FLOAT_OVERLAP_EPS) break;
+        candidateTopAbsPt = clearToAbsPt;
       }
-      if (clearToAbsPt > tableTopAbsPt + FLOAT_OVERLAP_EPS) {
-        y = clearToAbsPt - bodyTopPt();
-        measureState.y = clearToAbsPt;
+      if (candidateTopAbsPt > initialTopAbsPt + FLOAT_OVERLAP_EPS) {
+        y = candidateTopAbsPt - bodyTopPt();
+        measureState.y = candidateTopAbsPt;
       }
       // effContentH() respects any reserve already accumulated on this page; the
       // table's own footnote reserve is subtracted on top so the note clears the
@@ -5816,8 +5826,12 @@ function tableBreakAllowedBefore(table: DocTable, ri: number): boolean {
 /** The cell whose gridSpan covers logical column `targetCi` in `row`, or `null`.
  *  Pure grid walk (gridSpan-aware), mirroring {@link findMergeEndRow}'s column
  *  scan (ECMA-376 §17.4.85). */
-function cellAtGridColumn(row: DocTableRow, targetCi: number): DocTableCell | null {
-  let ci = rowGridBefore(row, Number.MAX_SAFE_INTEGER);
+function cellAtGridColumn(
+  row: DocTableRow,
+  targetCi: number,
+  columnCount: number,
+): DocTableCell | null {
+  let ci = rowGridBefore(row, columnCount);
   for (const cell of row.cells) {
     if (targetCi >= ci && targetCi < ci + cell.colSpan) return cell;
     ci += cell.colSpan;
@@ -5849,9 +5863,10 @@ function reopenMergedCellsInRow(
   start: number,
   headerCount: number,
   headersPrepended: boolean,
+  columnCount: number,
 ): DocTableRow {
   const row = rows[start];
-  let ci = rowGridBefore(row, Number.MAX_SAFE_INTEGER);
+  let ci = rowGridBefore(row, columnCount);
   const cells = row.cells.map((cell) => {
     const gridCi = ci;
     ci += cell.colSpan;
@@ -5860,7 +5875,7 @@ function reopenMergedCellsInRow(
     let restartRi = -1;
     let restartCell: DocTableCell | null = null;
     for (let r = start - 1; r >= 0; r--) {
-      const above = cellAtGridColumn(rows[r], gridCi);
+      const above = cellAtGridColumn(rows[r], gridCi, columnCount);
       if (!above) break;
       if (above.vMerge === true) { restartRi = r; restartCell = above; break; }
       if (above.vMerge !== false) break; // column left the span — malformed; bail
@@ -6732,7 +6747,16 @@ export function splitTableAcrossPages(
     // column already re-opened by a prepended repeated header is left untouched.
     const reopenedBody =
       start > 0 && bodyRows.length > 0 && bodyRows[0].cells.some((c) => c.vMerge === false)
-        ? [reopenMergedCellsInRow(workRows, start, headerCount, isContinuation), ...bodyRows.slice(1)]
+        ? [
+            reopenMergedCellsInRow(
+              workRows,
+              start,
+              headerCount,
+              isContinuation,
+              workTable.colWidths.length,
+            ),
+            ...bodyRows.slice(1),
+          ]
         : bodyRows;
     const sliceRows = isContinuation ? [...headerRows, ...reopenedBody] : reopenedBody;
     const sliceEl = { ...workTable, type: 'table', rows: sliceRows } as PaginatedBodyElement;
@@ -9864,8 +9888,32 @@ function renderInlineImage(
     ctx.save();
     ctx.globalAlpha *= seg.alpha as number;
   }
-  paint((dx, dy, dw, dh) => drawImageCropped(ctx, bmp, seg.srcRect, dx, dy, dw, dh));
+  paint((dx, dy, dw, dh) => drawImageRunBitmap(ctx, bmp, seg, dx, dy, dw, dh));
   if (hasAlpha) ctx.restore();
+}
+
+/** Paint a picture with the effective DrawingML rotation/reflection composed
+ * by the parser according to Annex L §L.4.7.4–§L.4.7.6. */
+function drawImageRunBitmap(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  bmp: DecodedImage,
+  image: Pick<ImageRun, 'srcRect' | 'rotation' | 'flipH' | 'flipV'>,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): void {
+  const rotation = image.rotation ?? 0;
+  if (rotation === 0 && !image.flipH && !image.flipV) {
+    drawImageCropped(ctx, bmp, image.srcRect ?? undefined, x, y, w, h);
+    return;
+  }
+  ctx.save();
+  ctx.translate(x + w / 2, y + h / 2);
+  ctx.rotate((rotation * Math.PI) / 180);
+  ctx.scale(image.flipH ? -1 : 1, image.flipV ? -1 : 1);
+  drawImageCropped(ctx, bmp, image.srcRect ?? undefined, -w / 2, -h / 2, w, h);
+  ctx.restore();
 }
 
 /** Collect and draw anchor images with wrapMode='none' (or unspecified).
@@ -9983,10 +10031,10 @@ function renderAnchorImages(
       // §17.6.20 (tbRl) — an anchored image is not text: keep it UPRIGHT inside
       // the +90°-rotated page by counter-rotating about its box centre.
       drawUprightBox(state.ctx, pageX, pageY, w, h, (dx, dy, dw, dh) =>
-        drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, dx, dy, dw, dh),
+        drawImageRunBitmap(state.ctx, bmp, img, dx, dy, dw, dh),
       );
     } else {
-      drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, pageX, pageY, w, h);
+      drawImageRunBitmap(state.ctx, bmp, img, pageX, pageY, w, h);
     }
     if (hasAlpha) state.ctx.restore();
   }
@@ -10306,6 +10354,7 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
           color: shape.stroke,
           width: shape.strokeWidth ?? 0,
           dashStyle: shape.strokeDash ?? undefined,
+          lineCap: shape.strokeCap ?? undefined,
           headEnd: lineEndToArrowEnd(shape.headEnd),
           tailEnd: lineEndToArrowEnd(shape.tailEnd),
         }
@@ -12111,10 +12160,10 @@ function registerImageFloat(
       if (state.verticalCJK) {
         // §17.6.20 (tbRl) — keep the floated image UPRIGHT inside the rotated page.
         drawUprightBox(state.ctx, rect.imageX, rect.imageY, rect.imageW, rect.imageH, (dx, dy, dw, dh) =>
-          drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, dx, dy, dw, dh),
+          drawImageRunBitmap(state.ctx, bmp, img, dx, dy, dw, dh),
         );
       } else {
-        drawImageCropped(state.ctx, bmp, img.srcRect ?? undefined, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
+        drawImageRunBitmap(state.ctx, bmp, img, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
       }
       if (hasAlpha) state.ctx.restore();
     }
@@ -12544,7 +12593,7 @@ function drawTableRows(
     // Using only the restart borders incorrectly falls through to table insideH
     // and paints a rule that Word suppresses.
     const terminalCell = j.lastRi > j.ri
-      ? (cellAtGridColumn(table.rows[j.lastRi], j.ci) ?? j.cell)
+      ? (cellAtGridColumn(table.rows[j.lastRi], j.ci, colWidths.length) ?? j.cell)
       : j.cell;
     const ownBottom = terminalCell === j.cell
       ? own.bottom
@@ -12562,19 +12611,75 @@ function drawTableRows(
     // logical `ci + span` in LTR, logical `ci - 1` under mirror.
     const physLeftOuter = mirror ? j.edges.rightCol : j.edges.leftCol;
     const physRightOuter = mirror ? j.edges.leftCol : j.edges.rightCol;
+    const physLeftCi = mirror ? j.ci + j.span : j.ci - 1;
     const physRightCi = mirror ? j.ci - 1 : j.ci + j.span;
 
-    // TOP: only the outer top row draws its own top; interior tops are owned by
-    // the cell above (its bottom). (Vertical direction is unaffected by mirror.)
+    // TOP: the outer top row draws its own top. Interior tops are normally owned
+    // by the cell above (its bottom), but a row omission can leave individual
+    // grid slots empty. No neighbour owns those sub-segments, so this cell must
+    // paint its own resolved top there.
     if (j.edges.topRow) {
       const spec = paintable(own.top?.spec ?? null);
       if (spec) drawBorderLine(ctx, x, y, x + w, y, spec, scale, dpr);
+    } else {
+      const spec = paintable(own.top?.spec ?? null);
+      if (spec) {
+        let cj = j.ci;
+        while (cj < j.ci + j.span) {
+          const idx = occupancy[j.ri - 1]?.[cj] ?? -1;
+          let cEnd = cj + 1;
+          while (
+            cEnd < j.ci + j.span &&
+            (occupancy[j.ri - 1]?.[cEnd] ?? -1) === idx
+          ) cEnd++;
+          if (idx < 0) {
+            drawBorderLine(
+              ctx,
+              colBoundaryX(cj),
+              y,
+              colBoundaryX(cEnd),
+              y,
+              spec,
+              scale,
+              dpr,
+            );
+          }
+          cj = cEnd;
+        }
+      }
     }
-    // PHYSICAL LEFT: only the outer-left column draws its own left; interior lefts
-    // are owned by the physically-left neighbour (its right edge).
+    // PHYSICAL LEFT: outer-left draws its own edge. An interior left is normally
+    // owned by the physically-left neighbour, except where gridBefore/gridAfter
+    // leaves that slot empty for all or part of a vertically merged cell.
     if (physLeftOuter) {
       const spec = paintable(own.left?.spec ?? null);
       if (spec) drawBorderLine(ctx, x, y, x, y + h, spec, scale, dpr);
+    } else {
+      const spec = paintable(own.left?.spec ?? null);
+      if (spec) {
+        let rj = j.ri;
+        while (rj <= j.lastRi) {
+          const idx = occupancy[rj]?.[physLeftCi] ?? -1;
+          let rEnd = rj;
+          while (
+            rEnd + 1 <= j.lastRi &&
+            (occupancy[rEnd + 1]?.[physLeftCi] ?? -1) === idx
+          ) rEnd++;
+          if (idx < 0) {
+            drawBorderLine(
+              ctx,
+              x,
+              rowBoundaryY(rj),
+              x,
+              rowBoundaryY(rEnd + 1),
+              spec,
+              scale,
+              dpr,
+            );
+          }
+          rj = rEnd + 1;
+        }
+      }
     }
     // BOTTOM: outer bottom → own spec; interior → resolve vs each below neighbour's
     // top and draw the winner (this ABOVE cell owns the shared horizontal line).

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -104,6 +104,7 @@ import {
 } from './anchor-geometry.js';
 import {
   findMergeEndRow,
+  rowGridBefore,
   resolveTableRowHeights,
   resolveSingleRowHeight,
 } from './table-geometry.js';
@@ -3923,6 +3924,47 @@ export function computePages(
       const tblContentWPt = colW();
       const { colWidthsPt: tblColWidthsPt, rowHeightsPt: measuredRowHs } =
         computeTablePtLayout(measureState, tbl, tblContentWPt);
+      const tblWidthPt = tblColWidthsPt.reduce((sum, width) => sum + width, 0);
+
+      // §17.4.57: a floating table reserves a page-scoped exclusion band for
+      // following flow content. Paragraphs already consume that band through the
+      // float wrap oracle; an in-flow TABLE is an indivisible block at its own
+      // horizontal origin, so mirror the same avoidance here. If its box would
+      // intersect a floating-table exclusion rectangle, advance the cursor to the
+      // deepest blocking bottom before making the ordinary page-fit/split decision.
+      // This matters especially after splitFloatTableAcrossPages: the terminal
+      // continuation starts at the fresh page top while the flow cursor also resets
+      // to that top, and a following block table must not paint over the slice.
+      const applyInd = tbl.tblInd != null && tbl.jc === 'left';
+      let tblLeftPt = tbl.jc === 'center'
+        ? colX() + Math.max(0, (colW() - tblWidthPt) / 2)
+        : tbl.jc === 'right'
+          ? colX() + Math.max(0, colW() - tblWidthPt)
+          : colX();
+      if (applyInd) {
+        const indPt = tbl.tblInd as number;
+        tblLeftPt = tbl.bidiVisual === true
+          ? colX() + colW() - indPt - tblWidthPt
+          : colX() + indPt;
+      }
+      const tblRightPt = tblLeftPt + tblWidthPt;
+      const tableTopAbsPt = bodyTopPt() + y;
+      const tableBottomAbsPt = tableTopAbsPt + measuredRowHs.reduce((sum, height) => sum + height, 0);
+      let clearToAbsPt = tableTopAbsPt;
+      for (const float of measureState.floats) {
+        if (float.kind !== 'table') continue;
+        const overlapsX =
+          tblRightPt - float.xLeft > FLOAT_OVERLAP_EPS &&
+          float.xRight - tblLeftPt > FLOAT_OVERLAP_EPS;
+        const overlapsY =
+          tableBottomAbsPt - float.yTop > FLOAT_OVERLAP_EPS &&
+          float.yBottom - tableTopAbsPt > FLOAT_OVERLAP_EPS;
+        if (overlapsX && overlapsY) clearToAbsPt = Math.max(clearToAbsPt, float.yBottom);
+      }
+      if (clearToAbsPt > tableTopAbsPt + FLOAT_OVERLAP_EPS) {
+        y = clearToAbsPt - bodyTopPt();
+        measureState.y = clearToAbsPt;
+      }
       // effContentH() respects any reserve already accumulated on this page; the
       // table's own footnote reserve is subtracted on top so the note clears the
       // table content.
@@ -5558,7 +5600,7 @@ export function resolveColumnWidths(table: DocTable, contentWPt: number, state: 
   // tblGrid so a wide spanning cell does not over-inflate any one column.
   const minW: number[] = new Array(n).fill(0);
   for (const row of table.rows) {
-    let ci = 0;
+    let ci = rowGridBefore(row, n);
     for (const cell of row.cells) {
       const span = Math.min(Math.max(cell.colSpan, 1), n - ci);
       const m = cellMinContentPt(cell, table, state);
@@ -5703,7 +5745,7 @@ export function resolveColumnWidths(table: DocTable, contentWPt: number, state: 
 
   // First pass: single-column (non-spanning) cells set a hard per-column floor.
   for (const row of table.rows) {
-    let ci = 0;
+    let ci = rowGridBefore(row, n);
     for (const cell of row.cells) {
       const span = Math.min(Math.max(cell.colSpan, 1), n - ci);
       if (span === 1) {
@@ -5721,7 +5763,7 @@ export function resolveColumnWidths(table: DocTable, contentWPt: number, state: 
   // columns in proportion to the tblGrid widths, but only raise columns that
   // are still below their share (so a single-column floor is never lowered).
   for (const row of table.rows) {
-    let ci = 0;
+    let ci = rowGridBefore(row, n);
     for (const cell of row.cells) {
       const span = Math.min(Math.max(cell.colSpan, 1), n - ci);
       if (span > 1) {
@@ -5775,7 +5817,7 @@ function tableBreakAllowedBefore(table: DocTable, ri: number): boolean {
  *  Pure grid walk (gridSpan-aware), mirroring {@link findMergeEndRow}'s column
  *  scan (ECMA-376 §17.4.85). */
 function cellAtGridColumn(row: DocTableRow, targetCi: number): DocTableCell | null {
-  let ci = 0;
+  let ci = rowGridBefore(row, Number.MAX_SAFE_INTEGER);
   for (const cell of row.cells) {
     if (targetCi >= ci && targetCi < ci + cell.colSpan) return cell;
     ci += cell.colSpan;
@@ -5809,7 +5851,7 @@ function reopenMergedCellsInRow(
   headersPrepended: boolean,
 ): DocTableRow {
   const row = rows[start];
-  let ci = 0;
+  let ci = rowGridBefore(row, Number.MAX_SAFE_INTEGER);
   const cells = row.cells.map((cell) => {
     const gridCi = ci;
     ci += cell.colSpan;
@@ -6263,7 +6305,7 @@ function splitRowByCellLines(
   const restartRemainders = new Map<number, number>();
   let madeProgress = false;
   let hasRemainder = false;
-  let ci = 0;
+  let ci = rowGridBefore(row, colWidthsPt.length);
 
   for (const cell of row.cells) {
     const cellState = withTableCellStory(state);
@@ -6369,8 +6411,9 @@ function repairSpanExtensionAfterRowSplit(
   // impossible: continue cells there would have refused the split).
   let maxEnd = finalPieceIdx;
   const scanRow = (ri: number): void => {
-    let ci = 0;
-    for (const cell of rows[ri].cells) {
+    const row = rows[ri];
+    let ci = rowGridBefore(row, colWidthsPt.length);
+    for (const cell of row.cells) {
       const span = Math.min(cell.colSpan, colWidthsPt.length - ci);
       if (cell.vMerge === true) {
         const e = findMergeEndRow(workTable, ri, ci);
@@ -6388,8 +6431,9 @@ function repairSpanExtensionAfterRowSplit(
   }
   // 2) Re-apply the extension per restart cell, row-major (resolver order).
   for (let ri = finalPieceIdx; ri <= maxEnd && ri < rows.length; ri++) {
-    let ci = 0;
-    for (const cell of rows[ri].cells) {
+    const row = rows[ri];
+    let ci = rowGridBefore(row, colWidthsPt.length);
+    for (const cell of row.cells) {
       const span = Math.min(cell.colSpan, colWidthsPt.length - ci);
       if (cell.vMerge === true) {
         const cellW = colWidthsPt.slice(ci, ci + span).reduce((s, w) => s + w, 0);
@@ -8489,10 +8533,10 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     //     ~22pt when centred.) The substituted-font single-line FLOOR
     //     (intendedSingle) still centres the glyph box within the single design
     //     line (half-leading), so a Meiryo single-spaced line is byte-for-byte
-    //     unchanged. A sub-single multiplier (0 < value < 1) makes lineH <
-    //     singleBox: the baseline stays pinned at the natural ascent and the
-    //     shortfall is NEGATIVE leading (consecutive lines overlap), matching
-    //     Word's compressed sub-single spacing.
+    //     unchanged. A sub-single multiplier (0 < value < 1) compresses the
+    //     entire line box, so the glyph box is centred across that shorter
+    //     advance. This lets the ink protrude equally above and below instead of
+    //     shifting it wholly toward the following row/content.
     //   • exact/atLeast keep the extra space split half above / half below
     //     (centred). docGrid line rules snap to whole cells and ruby paragraphs
     //     use a uniform box — both have their own within-box placement, so they
@@ -8506,10 +8550,14 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     const glyphNatural = line.ascent + line.descent;
     const autoMultiple =
       para.lineSpacing?.rule === 'auto' && !paraHasRuby && !isGridLineRule(grid);
-    // For auto multiple spacing, centre the glyph only within the single design-
-    // line box (= max(glyphNatural, intendedSingle), matching lineBoxHeight's
-    // `natural`); the multiplier's extra (lineH − singleBox) then falls below.
-    const centerBox = autoMultiple ? Math.max(glyphNatural, line.intendedSingle) : lineH;
+    // For auto multiple spacing at or above 1×, centre the glyph only within
+    // the single design-line box (= max(glyphNatural, intendedSingle), matching
+    // lineBoxHeight's `natural`); the multiplier's extra then falls below. Below
+    // 1×, centre against the authored compressed line box itself.
+    const compressedAuto = autoMultiple && (para.lineSpacing?.value ?? 1) < 1;
+    const centerBox = autoMultiple && !compressedAuto
+      ? Math.max(glyphNatural, line.intendedSingle)
+      : lineH;
     const baseline = state.y + (centerBox - glyphNatural) / 2 + line.ascent;
 
     // Per-line X range (may be narrower than paraW when wrapping around floats).
@@ -12385,8 +12433,8 @@ function drawTableRows(
     const row = table.rows[ri];
     const rowFragment = fragment?.rows[ri];
     const rowH = rowHeights[ri];
-    let x = tableX;
-    let ci = 0;
+    let ci = rowGridBefore(row, colWidths.length);
+    let x = tableX + colWidths.slice(0, ci).reduce((sum, width) => sum + width, 0);
     let cellIdx = 0;
 
     for (const cell of row.cells) {
@@ -12489,6 +12537,23 @@ function drawTableRows(
   for (const j of jobs) {
     const { x, y, w, h } = j;
     const own = resolveCellEdges(j.cell.borders, table.borders, j.edges, mirror);
+    // ECMA-376 §17.4.66 / §17.4.85: a vertical merge is serialized as a
+    // restart cell followed by continuation cells. Its bottom boundary belongs
+    // to the LAST continuation cell, whose tcBorders can explicitly differ from
+    // the restart cell (commonly `bottom="nil"` to leave an adjacent area open).
+    // Using only the restart borders incorrectly falls through to table insideH
+    // and paints a rule that Word suppresses.
+    const terminalCell = j.lastRi > j.ri
+      ? (cellAtGridColumn(table.rows[j.lastRi], j.ci) ?? j.cell)
+      : j.cell;
+    const ownBottom = terminalCell === j.cell
+      ? own.bottom
+      : resolveCellEdges(
+          terminalCell.borders,
+          table.borders,
+          { ...j.edges, topRow: false },
+          mirror,
+        ).bottom;
     // `own.left`/`own.right` are already PHYSICAL (resolveCellEdges folded the
     // bidiVisual swap into the spec). The OUTER-vs-interior GATE must be physical
     // too: under mirror a cell's physical-left edge is the logical RIGHT edge, so
@@ -12535,9 +12600,9 @@ function drawTableRows(
           { ...j.edges, topRow: true },
           mirror,
         ).top;
-        spec = resolveSharedEdge(own.bottom, siblingTop);
+        spec = resolveSharedEdge(ownBottom, siblingTop);
       } else {
-        spec = paintable(own.bottom?.spec ?? null);
+        spec = paintable(ownBottom?.spec ?? null);
       }
       if (spec) drawBorderLine(ctx, x, y + h, x + w, y + h, spec, scale, dpr);
     } else if ((table.rows[j.lastRi] as DocTableRow & { pageCutBottom?: boolean })?.pageCutBottom === true) {
@@ -12568,7 +12633,7 @@ function drawTableRows(
         const belowEdges = below
           ? resolveCellEdges(below.cell.borders, table.borders, below.edges, mirror)
           : null;
-        const spec = resolveSharedEdge(own.bottom, belowEdges?.top ?? null);
+        const spec = resolveSharedEdge(ownBottom, belowEdges?.top ?? null);
         if (spec) drawBorderLine(ctx, colBoundaryX(cj), y + h, colBoundaryX(cEnd), y + h, spec, scale, dpr);
         cj = cEnd;
       }

--- a/packages/docx/src/table-fragments.test.ts
+++ b/packages/docx/src/table-fragments.test.ts
@@ -271,6 +271,20 @@ describe('buildTableFragment — pure recursion contract', () => {
     expect(widths).toEqual([40, 30]); // spanned 20+20, then 30
   });
 
+  it('§17.4.15: builds cell blocks from columns after gridBefore', () => {
+    const t = table(
+      [row([textCell('middle')], { gridBefore: 1, gridAfter: 1 } as Partial<DocTableRow>)],
+      [20, 40, 60],
+    );
+    const widths: number[] = [];
+    buildTableFragment({
+      table: t, columnWidthsPt: [20, 40, 60], rowHeightsPt: [12],
+      continuesFromPreviousPage: false, continuesOnNextPage: false, repeatedHeaderRowCount: 0,
+      buildCellBlocks: (_c, w) => { widths.push(w); return []; },
+    });
+    expect(widths).toEqual([40]);
+  });
+
   it('classifies vMerge roles and renders no content for a continue cell', () => {
     const t = table(
       [

--- a/packages/docx/src/table-fragments.ts
+++ b/packages/docx/src/table-fragments.ts
@@ -29,6 +29,7 @@ import type {
   RowFragment,
   TableFragment,
 } from './layout-fragments.js';
+import { rowGridBefore } from './table-geometry.js';
 
 /**
  * Build the recursive content fragments of one cell laid out at `cellTotalWidthPt`
@@ -101,7 +102,7 @@ export function buildTableFragment(input: BuildTableFragmentInput): TableFragmen
   const columns = Object.freeze([...columnWidthsPt]) as readonly number[];
 
   const rows: RowFragment[] = table.rows.map((sourceRow, ri) => {
-    let ci = 0;
+    let ci = rowGridBefore(sourceRow, columns.length);
     const cells: CellFragment[] = sourceRow.cells.map((sourceCell) => {
       const span = Math.min(sourceCell.colSpan, columns.length - ci);
       let cellTotalWidthPt = 0;

--- a/packages/docx/src/table-geometry.ts
+++ b/packages/docx/src/table-geometry.ts
@@ -24,6 +24,15 @@ import type { DocTable, DocTableRow, DocTableCell } from './types.js';
  *  before content (cell margins + measured content) expands it. */
 export const MIN_ROW_HEIGHT_PT = 10;
 
+/** ECMA-376 §17.4.15 — clamp the number of shared table-grid columns skipped
+ * before a row's first cell. Older parsed models omit the property, so zero is
+ * the compatibility default required by the specification. */
+export function rowGridBefore(row: DocTableRow, columnCount: number): number {
+  const raw = row.gridBefore ?? 0;
+  if (!Number.isFinite(raw)) return 0;
+  return Math.min(Math.max(0, Math.trunc(raw)), Math.max(0, columnCount));
+}
+
 /** Last row index covered by the vMerge span that starts at (`startRi`,
  *  `startCi`). A span continues through following rows whose cell anchored in the
  *  same grid column carries `vMerge=continue` (ECMA-376 §17.4.85). Pure
@@ -32,7 +41,7 @@ export function findMergeEndRow(table: DocTable, startRi: number, startCi: numbe
   let endRi = startRi;
   for (let rj = startRi + 1; rj < table.rows.length; rj++) {
     const row = table.rows[rj];
-    let ci = 0;
+    let ci = rowGridBefore(row, table.colWidths.length);
     let matched = false;
     for (const cell of row.cells) {
       if (ci === startCi) {
@@ -129,7 +138,7 @@ export function resolveSingleRowHeight(
       ? row.rowHeight * scale
       : MIN_ROW_HEIGHT_PT * scale;
 
-  let ci = 0;
+  let ci = rowGridBefore(row, colWidths.length);
   for (const cell of row.cells) {
     const span = Math.min(cell.colSpan, colWidths.length - ci);
     // vMerge=restart cells are sized by the span post-pass; vMerge=continue
@@ -157,8 +166,9 @@ export function resolveTableRowHeights(
   // §17.4.85 span extension: for each vMerge=restart cell, grow the span's last
   // row if the restart cell's full content is taller than the summed span rows.
   for (let ri = 0; ri < table.rows.length; ri++) {
-    let ci = 0;
-    for (const cell of table.rows[ri].cells) {
+    const row = table.rows[ri];
+    let ci = rowGridBefore(row, colWidths.length);
+    for (const cell of row.cells) {
       const span = Math.min(cell.colSpan, colWidths.length - ci);
       if (cell.vMerge === true) {
         const cellW = colWidths.slice(ci, ci + span).reduce((s, w) => s + w, 0);

--- a/packages/docx/src/table-geometry.ts
+++ b/packages/docx/src/table-geometry.ts
@@ -30,7 +30,11 @@ export const MIN_ROW_HEIGHT_PT = 10;
 export function rowGridBefore(row: DocTableRow, columnCount: number): number {
   const raw = row.gridBefore ?? 0;
   if (!Number.isFinite(raw)) return 0;
-  return Math.min(Math.max(0, Math.trunc(raw)), Math.max(0, columnCount));
+  const value = Math.max(0, Math.trunc(raw));
+  const size = Math.max(0, Math.trunc(columnCount));
+  // §17.4.15: a value larger than tblGrid is ignored; it is not clamped to
+  // the trailing edge (which would collapse every real cell to zero width).
+  return value > size ? 0 : value;
 }
 
 /** Last row index covered by the vMerge span that starts at (`startRi`,

--- a/packages/docx/src/table-row-height.test.ts
+++ b/packages/docx/src/table-row-height.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { calculateRowHeight } from './renderer.js';
+import { resolveSingleRowHeight } from './table-geometry.js';
 import type { DocTable, DocTableRow, DocTableCell } from './types.js';
 
 // ECMA-376 §17.4.80 (trHeight) + §17.18.37 (ST_HeightRule): the @hRule attribute
@@ -96,5 +97,21 @@ describe('calculateRowHeight — ST_HeightRule (§17.4.80 / §17.18.37)', () => 
   it('atLeast with no @val — falls back to the minimum (val null ⇒ no floor)', () => {
     const h = calculateRowHeight(rowWith(null, 'atLeast'), t, COLS, SCALE, EMPTY_STATE);
     expect(h).toBe(10 * SCALE);
+  });
+
+  it('§17.4.15: measures a cell against columns after gridBefore', () => {
+    const measuredWidths: number[] = [];
+    const row = {
+      ...rowWith(null, 'auto'),
+      gridBefore: 1,
+      gridAfter: 1,
+    } as unknown as DocTableRow;
+
+    resolveSingleRowHeight(row, [20, 40, 60], 1, (_cell, width) => {
+      measuredWidths.push(width);
+      return 10;
+    });
+
+    expect(measuredWidths).toEqual([40]);
   });
 });

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -920,6 +920,8 @@ export interface ShapeRun {
   strokeWidth?: number;
   /** `<a:ln><a:prstDash val>` — ECMA-376 §20.1.8.48. Absent = solid. */
   strokeDash?: string | null;
+  /** Normalized line cap: `butt` | `round` | `square`. */
+  strokeCap?: CanvasLineCap | null;
   /** `<a:ln><a:headEnd>` line-start decoration (ECMA-376 §20.1.8.3). */
   headEnd?: LineEnd | null;
   /** `<a:ln><a:tailEnd>` line-end decoration (ECMA-376 §20.1.8.3). */
@@ -1352,6 +1354,10 @@ export interface ImageRun {
   srcRect?: { l: number; t: number; r: number; b: number } | null;
   widthPt: number;
   heightPt: number;
+  /** Effective DrawingML transform for grouped pictures. */
+  rotation?: number;
+  flipH?: boolean;
+  flipV?: boolean;
   /** true = wp:anchor (absolute positioned), false/undefined = wp:inline (flows with text) */
   anchor?: boolean;
   /** X offset in pt (anchor only) */

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1533,6 +1533,12 @@ export interface BorderSpec {
 
 export interface DocTableRow {
   cells: DocTableCell[];
+  /** ECMA-376 §17.4.15 `<w:gridBefore>` — shared table-grid columns skipped
+   *  before placing this row's first real cell. Omitted/zero means none. */
+  gridBefore?: number;
+  /** ECMA-376 §17.4.14 `<w:gridAfter>` — shared table-grid columns skipped
+   *  after this row's last real cell. Omitted/zero means none. */
+  gridAfter?: number;
   rowHeight: number | null;  // pt
   /** ECMA-376 §17.4.80 hRule. "auto" (default) = informational; "atLeast" =
    *  lower bound; "exact" = fixed clip. */

--- a/packages/node/src/pptx-line-crisp.probe.test.ts
+++ b/packages/node/src/pptx-line-crisp.probe.test.ts
@@ -85,6 +85,9 @@ function buildTableSlide(): Presentation {
     y: TABLE_Y_PX * EMU_PER_PX,
     width: COL_W_PX * EMU_PER_PX,
     height: ROW_H_PX * EMU_PER_PX,
+    rotation: 0,
+    flipH: false,
+    flipV: false,
     cols: [COL_W_PX * EMU_PER_PX],
     rows: [{ height: ROW_H_PX * EMU_PER_PX, cells: [cell] }],
   };

--- a/packages/ooxml-common/src/drawing.rs
+++ b/packages/ooxml-common/src/drawing.rs
@@ -163,27 +163,19 @@ impl DrawingGroupTransform {
 
     /// Apply the Annex L nested-transform rendering procedure to a leaf's
     /// authored bounding box and own rotation/flip.
-    pub fn apply_rect(
-        self,
-        x: f64,
-        y: f64,
-        width: f64,
-        height: f64,
-        rotation_degrees: f64,
-        flip_h: bool,
-        flip_v: bool,
-    ) -> DrawingRect {
-        let (center_x, center_y) = self.map_point(x + width / 2.0, y + height / 2.0);
-        let mapped_width = width * self.scale_x;
-        let mapped_height = height * self.scale_y;
+    pub fn apply_rect(self, rect: DrawingRect) -> DrawingRect {
+        let (center_x, center_y) =
+            self.map_point(rect.x + rect.width / 2.0, rect.y + rect.height / 2.0);
+        let mapped_width = rect.width * self.scale_x;
+        let mapped_height = rect.height * self.scale_y;
         DrawingRect {
             x: center_x - mapped_width / 2.0,
             y: center_y - mapped_height / 2.0,
             width: mapped_width,
             height: mapped_height,
-            rotation_degrees: self.rotation_degrees + rotation_degrees,
-            flip_h: self.flip_h ^ flip_h,
-            flip_v: self.flip_v ^ flip_v,
+            rotation_degrees: self.rotation_degrees + rect.rotation_degrees,
+            flip_h: self.flip_h ^ rect.flip_h,
+            flip_v: self.flip_v ^ rect.flip_v,
         }
     }
 }
@@ -245,7 +237,15 @@ mod tests {
             flip_h: false,
             flip_v: false,
         });
-        let mapped = transform.apply_rect(0.0, 50_800.0, 127_000.0, 25_400.0, 90.0, false, false);
+        let mapped = transform.apply_rect(DrawingRect {
+            x: 0.0,
+            y: 50_800.0,
+            width: 127_000.0,
+            height: 25_400.0,
+            rotation_degrees: 90.0,
+            flip_h: false,
+            flip_v: false,
+        });
 
         assert!((mapped.x - 0.0).abs() < 1e-6);
         assert!((mapped.y - 101_600.0).abs() < 1e-6);
@@ -303,7 +303,15 @@ mod tests {
             flip_h: true,
             flip_v: false,
         });
-        let mapped = transform.apply_rect(10.0, 20.0, 20.0, 10.0, 15.0, false, true);
+        let mapped = transform.apply_rect(DrawingRect {
+            x: 10.0,
+            y: 20.0,
+            width: 20.0,
+            height: 10.0,
+            rotation_degrees: 15.0,
+            flip_h: false,
+            flip_v: true,
+        });
 
         assert!((mapped.x - 105.0).abs() < 1e-6);
         assert!((mapped.y - 105.0).abs() < 1e-6);

--- a/packages/ooxml-common/src/drawing.rs
+++ b/packages/ooxml-common/src/drawing.rs
@@ -32,6 +32,162 @@ pub fn nv_props_hidden(nv_props: Node) -> bool {
         .unwrap_or(false)
 }
 
+/// One DrawingML group-transform step (ECMA-376 §20.1.7.5 and Annex L
+/// §L.4.7.4): child bounding box, parent bounding box, then flip and rotation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DrawingGroupSpec {
+    pub off_x: f64,
+    pub off_y: f64,
+    pub ext_x: f64,
+    pub ext_y: f64,
+    pub child_off_x: f64,
+    pub child_off_y: f64,
+    pub child_ext_x: f64,
+    pub child_ext_y: f64,
+    pub rotation_degrees: f64,
+    pub flip_h: bool,
+    pub flip_v: bool,
+}
+
+/// Cumulative DrawingML group hierarchy. Annex L §L.4.7.4–§L.4.7.6 requires
+/// two related representations: scale/flip/rotation compose independently for
+/// the leaf's effective geometry, while the full per-level matrices are applied
+/// to the leaf's original centre to determine translation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DrawingGroupTransform {
+    pub scale_x: f64,
+    pub scale_y: f64,
+    pub rotation_degrees: f64,
+    pub flip_h: bool,
+    pub flip_v: bool,
+    m11: f64,
+    m12: f64,
+    m21: f64,
+    m22: f64,
+    tx: f64,
+    ty: f64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DrawingRect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub rotation_degrees: f64,
+    pub flip_h: bool,
+    pub flip_v: bool,
+}
+
+impl DrawingGroupTransform {
+    pub const IDENTITY: Self = Self {
+        scale_x: 1.0,
+        scale_y: 1.0,
+        rotation_degrees: 0.0,
+        flip_h: false,
+        flip_v: false,
+        m11: 1.0,
+        m12: 0.0,
+        m21: 0.0,
+        m22: 1.0,
+        tx: 0.0,
+        ty: 0.0,
+    };
+
+    pub fn from_group(spec: DrawingGroupSpec) -> Self {
+        let scale_x = if spec.child_ext_x != 0.0 {
+            spec.ext_x / spec.child_ext_x
+        } else {
+            1.0
+        };
+        let scale_y = if spec.child_ext_y != 0.0 {
+            spec.ext_y / spec.child_ext_y
+        } else {
+            1.0
+        };
+        let radians = spec.rotation_degrees.to_radians();
+        let cos = radians.cos();
+        let sin = radians.sin();
+        let fx = if spec.flip_h { -1.0 } else { 1.0 };
+        let fy = if spec.flip_v { -1.0 } else { 1.0 };
+        let m11 = cos * fx * scale_x;
+        let m12 = -sin * fy * scale_y;
+        let m21 = sin * fx * scale_x;
+        let m22 = cos * fy * scale_y;
+        let center_x = spec.off_x + spec.ext_x / 2.0;
+        let center_y = spec.off_y + spec.ext_y / 2.0;
+        let scaled_origin_x = spec.off_x - spec.child_off_x * scale_x;
+        let scaled_origin_y = spec.off_y - spec.child_off_y * scale_y;
+        let dx = scaled_origin_x - center_x;
+        let dy = scaled_origin_y - center_y;
+        let tx = center_x + cos * fx * dx - sin * fy * dy;
+        let ty = center_y + sin * fx * dx + cos * fy * dy;
+        Self {
+            scale_x,
+            scale_y,
+            rotation_degrees: spec.rotation_degrees,
+            flip_h: spec.flip_h,
+            flip_v: spec.flip_v,
+            m11,
+            m12,
+            m21,
+            m22,
+            tx,
+            ty,
+        }
+    }
+
+    pub fn compose_group(self, spec: DrawingGroupSpec) -> Self {
+        let child = Self::from_group(spec);
+        Self {
+            scale_x: self.scale_x * child.scale_x,
+            scale_y: self.scale_y * child.scale_y,
+            rotation_degrees: self.rotation_degrees + child.rotation_degrees,
+            flip_h: self.flip_h ^ child.flip_h,
+            flip_v: self.flip_v ^ child.flip_v,
+            m11: self.m11 * child.m11 + self.m12 * child.m21,
+            m12: self.m11 * child.m12 + self.m12 * child.m22,
+            m21: self.m21 * child.m11 + self.m22 * child.m21,
+            m22: self.m21 * child.m12 + self.m22 * child.m22,
+            tx: self.m11 * child.tx + self.m12 * child.ty + self.tx,
+            ty: self.m21 * child.tx + self.m22 * child.ty + self.ty,
+        }
+    }
+
+    pub fn map_point(self, x: f64, y: f64) -> (f64, f64) {
+        (
+            self.m11 * x + self.m12 * y + self.tx,
+            self.m21 * x + self.m22 * y + self.ty,
+        )
+    }
+
+    /// Apply the Annex L nested-transform rendering procedure to a leaf's
+    /// authored bounding box and own rotation/flip.
+    pub fn apply_rect(
+        self,
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        rotation_degrees: f64,
+        flip_h: bool,
+        flip_v: bool,
+    ) -> DrawingRect {
+        let (center_x, center_y) = self.map_point(x + width / 2.0, y + height / 2.0);
+        let mapped_width = width * self.scale_x;
+        let mapped_height = height * self.scale_y;
+        DrawingRect {
+            x: center_x - mapped_width / 2.0,
+            y: center_y - mapped_height / 2.0,
+            width: mapped_width,
+            height: mapped_height,
+            rotation_degrees: self.rotation_degrees + rotation_degrees,
+            flip_h: self.flip_h ^ flip_h,
+            flip_v: self.flip_v ^ flip_v,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,5 +228,89 @@ mod tests {
             let doc = node_from(xml);
             assert!(!nv_props_hidden(doc.root_element()), "xml={xml}");
         }
+    }
+
+    #[test]
+    fn group_transform_keeps_scale_axes_independent_of_child_rotation() {
+        let transform = DrawingGroupTransform::from_group(DrawingGroupSpec {
+            off_x: 0.0,
+            off_y: 0.0,
+            ext_x: 127_000.0,
+            ext_y: 254_000.0,
+            child_off_x: 0.0,
+            child_off_y: 0.0,
+            child_ext_x: 127_000.0,
+            child_ext_y: 127_000.0,
+            rotation_degrees: 0.0,
+            flip_h: false,
+            flip_v: false,
+        });
+        let mapped = transform.apply_rect(0.0, 50_800.0, 127_000.0, 25_400.0, 90.0, false, false);
+
+        assert!((mapped.x - 0.0).abs() < 1e-6);
+        assert!((mapped.y - 101_600.0).abs() < 1e-6);
+        assert!((mapped.width - 127_000.0).abs() < 1e-6);
+        assert!((mapped.height - 50_800.0).abs() < 1e-6);
+        assert!((mapped.rotation_degrees - 90.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn nested_group_transform_composes_scale_and_translation() {
+        let outer = DrawingGroupTransform::from_group(DrawingGroupSpec {
+            off_x: 10.0,
+            off_y: 20.0,
+            ext_x: 200.0,
+            ext_y: 300.0,
+            child_off_x: 5.0,
+            child_off_y: 10.0,
+            child_ext_x: 100.0,
+            child_ext_y: 100.0,
+            rotation_degrees: 0.0,
+            flip_h: false,
+            flip_v: false,
+        });
+        let nested = outer.compose_group(DrawingGroupSpec {
+            off_x: 30.0,
+            off_y: 40.0,
+            ext_x: 50.0,
+            ext_y: 80.0,
+            child_off_x: 10.0,
+            child_off_y: 20.0,
+            child_ext_x: 25.0,
+            child_ext_y: 40.0,
+            rotation_degrees: 0.0,
+            flip_h: false,
+            flip_v: false,
+        });
+        let point = nested.map_point(10.0, 20.0);
+
+        assert!((point.0 - 60.0).abs() < 1e-6);
+        assert!((point.1 - 110.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn group_rotation_and_flip_map_center_and_compose_leaf_properties() {
+        let transform = DrawingGroupTransform::from_group(DrawingGroupSpec {
+            off_x: 0.0,
+            off_y: 0.0,
+            ext_x: 200.0,
+            ext_y: 100.0,
+            child_off_x: 0.0,
+            child_off_y: 0.0,
+            child_ext_x: 100.0,
+            child_ext_y: 100.0,
+            rotation_degrees: 90.0,
+            flip_h: true,
+            flip_v: false,
+        });
+        let mapped = transform.apply_rect(10.0, 20.0, 20.0, 10.0, 15.0, false, true);
+
+        assert!((mapped.x - 105.0).abs() < 1e-6);
+        assert!((mapped.y - 105.0).abs() < 1e-6);
+        assert!((mapped.width - 40.0).abs() < 1e-6);
+        assert!((mapped.height - 10.0).abs() < 1e-6);
+        assert!((mapped.rotation_degrees - 105.0).abs() < 1e-6);
+        assert!(mapped.flip_h);
+        assert!(mapped.flip_v);
     }
 }

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -56,6 +56,9 @@ pub(crate) fn parse_legacy_chart(
         y: 0,
         width: 0,
         height: 0,
+        rotation: 0.0,
+        flip_h: false,
+        flip_v: false,
         chart,
     })
 }
@@ -84,6 +87,9 @@ pub(crate) fn parse_chartex(
         y: 0,
         width: 0,
         height: 0,
+        rotation: 0.0,
+        flip_h: false,
+        flip_v: false,
         chart,
     })
 }

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -984,6 +984,9 @@ pub(crate) fn parse_media(
         y: t.y,
         width: t.cx,
         height: t.cy,
+        rotation: t.rot,
+        flip_h: t.flip_h,
+        flip_v: t.flip_v,
         media_kind,
         poster_path,
         poster_mime_type,
@@ -1393,6 +1396,9 @@ pub(crate) fn parse_table(
         y: t.y,
         width: t.cx,
         height: t.cy,
+        rotation: t.rot,
+        flip_h: t.flip_h,
+        flip_v: t.flip_v,
         cols,
         rows,
         rtl,
@@ -1957,6 +1963,9 @@ pub(crate) fn parse_sp_tree_node(
                                 chart.y = t.y;
                                 chart.width = t.cx;
                                 chart.height = t.cy;
+                                chart.rotation = t.rot;
+                                chart.flip_h = t.flip_h;
+                                chart.flip_v = t.flip_v;
                                 out.push(SlideElement::Chart(chart));
                             }
                         }

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -3,6 +3,7 @@
 //! re-exports these via `pub use types::*`.
 
 use ooxml_common::blip::{Duotone, SrcRect};
+use ooxml_common::drawing::{DrawingGroupSpec, DrawingGroupTransform};
 use ooxml_common::math::MathNode;
 use ooxml_common::text::SpaceLine;
 use serde::{Deserialize, Serialize};
@@ -129,6 +130,9 @@ pub(crate) struct ChartElement {
     pub(crate) y: i64,
     pub(crate) width: i64,
     pub(crate) height: i64,
+    pub(crate) rotation: f64,
+    pub(crate) flip_h: bool,
+    pub(crate) flip_v: bool,
     pub(crate) chart: ChartModel,
 }
 
@@ -139,6 +143,9 @@ pub(crate) struct TableElement {
     pub(crate) y: i64,
     pub(crate) width: i64,
     pub(crate) height: i64,
+    pub(crate) rotation: f64,
+    pub(crate) flip_h: bool,
+    pub(crate) flip_v: bool,
     /// Column widths in EMU
     pub(crate) cols: Vec<i64>,
     pub(crate) rows: Vec<TableRow>,
@@ -533,6 +540,9 @@ pub(crate) struct MediaElement {
     pub(crate) y: i64,
     pub(crate) width: i64,
     pub(crate) height: i64,
+    pub(crate) rotation: f64,
+    pub(crate) flip_h: bool,
+    pub(crate) flip_v: bool,
     /// "audio" or "video"
     pub(crate) media_kind: String,
     /// Zip path of the poster image (e.g. "ppt/media/image2.png"). Empty when
@@ -1151,72 +1161,183 @@ pub(crate) struct GroupTransform {
 
 impl GroupTransform {
     fn apply_to_transform(&self, t: Transform) -> Transform {
-        let sx = if self.ch_cx != 0 {
-            self.cx as f64 / self.ch_cx as f64
-        } else {
-            1.0
-        };
-        let sy = if self.ch_cy != 0 {
-            self.cy as f64 / self.ch_cy as f64
-        } else {
-            1.0
-        };
-        // If the group is flipped, mirror child positions in child coordinate space
-        // before applying the normal scale+translate.
-        // Mirror formula: new_left = (ch_x + ch_cx) - (t.x - ch_x) - t.cx
-        //                          = 2*ch_x + ch_cx - t.x - t.cx
-        let child_x = if self.flip_h {
-            2 * self.ch_x + self.ch_cx - t.x - t.cx
-        } else {
-            t.x
-        };
-        let child_y = if self.flip_v {
-            2 * self.ch_y + self.ch_cy - t.y - t.cy
-        } else {
-            t.y
-        };
-
-        // Child position and size in parent space (before group rotation)
-        let new_x = (child_x - self.ch_x) as f64 * sx + self.x as f64;
-        let new_y = (child_y - self.ch_y) as f64 * sy + self.y as f64;
-        let new_cx = (t.cx as f64 * sx).round() as i64;
-        let new_cy = (t.cy as f64 * sy).round() as i64;
-
-        // Apply group rotation: rotate child center around group center (clockwise, screen coords)
-        let (final_x, final_y) = if self.rot != 0.0 {
-            let rot_rad = self.rot.to_radians();
-            let cos_r = rot_rad.cos();
-            let sin_r = rot_rad.sin();
-            let group_cx = self.x as f64 + self.cx as f64 / 2.0;
-            let group_cy = self.y as f64 + self.cy as f64 / 2.0;
-            let child_cx = new_x + new_cx as f64 / 2.0;
-            let child_cy = new_y + new_cy as f64 / 2.0;
-            let dx = child_cx - group_cx;
-            let dy = child_cy - group_cy;
-            // Clockwise rotation in screen coords (y-axis down): x' = x*cos - y*sin, y' = x*sin + y*cos
-            let dx_new = dx * cos_r - dy * sin_r;
-            let dy_new = dx * sin_r + dy * cos_r;
-            (
-                group_cx + dx_new - new_cx as f64 / 2.0,
-                group_cy + dy_new - new_cy as f64 / 2.0,
-            )
-        } else {
-            (new_x, new_y)
-        };
-
-        // When the group has a net flip, the child's own rotation direction is negated
-        // before the group rotation is added (scale→flip→rotate OOXML order).
-        // GF (group net flip) = flip_h XOR flip_v.
-        let gf = self.flip_h ^ self.flip_v;
+        let mapped = DrawingGroupTransform::from_group(DrawingGroupSpec {
+            off_x: self.x as f64,
+            off_y: self.y as f64,
+            ext_x: self.cx as f64,
+            ext_y: self.cy as f64,
+            child_off_x: self.ch_x as f64,
+            child_off_y: self.ch_y as f64,
+            child_ext_x: self.ch_cx as f64,
+            child_ext_y: self.ch_cy as f64,
+            rotation_degrees: self.rot,
+            flip_h: self.flip_h,
+            flip_v: self.flip_v,
+        })
+        .apply_rect(
+            t.x as f64,
+            t.y as f64,
+            t.cx as f64,
+            t.cy as f64,
+            t.rot,
+            t.flip_h,
+            t.flip_v,
+        );
         Transform {
-            x: final_x.round() as i64,
-            y: final_y.round() as i64,
-            cx: new_cx,
-            cy: new_cy,
-            rot: self.rot + if gf { -t.rot } else { t.rot },
-            // Propagate group flip to child element flip flags
-            flip_h: t.flip_h ^ self.flip_h,
-            flip_v: t.flip_v ^ self.flip_v,
+            x: mapped.x.round() as i64,
+            y: mapped.y.round() as i64,
+            cx: mapped.width.round() as i64,
+            cy: mapped.height.round() as i64,
+            rot: mapped.rotation_degrees,
+            flip_h: mapped.flip_h,
+            flip_v: mapped.flip_v,
+        }
+    }
+}
+
+#[cfg(test)]
+mod group_transform_tests {
+    use super::*;
+
+    #[test]
+    fn quarter_turned_child_uses_shared_non_uniform_group_mapping() {
+        let group = GroupTransform {
+            x: 0,
+            y: 0,
+            cx: 127_000,
+            cy: 254_000,
+            ch_x: 0,
+            ch_y: 0,
+            ch_cx: 127_000,
+            ch_cy: 127_000,
+            ..Default::default()
+        };
+        let mapped = group.apply_to_transform(Transform {
+            x: 0,
+            y: 50_800,
+            cx: 127_000,
+            cy: 25_400,
+            rot: 90.0,
+            ..Default::default()
+        });
+
+        assert_eq!((mapped.x, mapped.y), (0, 101_600));
+        assert_eq!((mapped.cx, mapped.cy), (127_000, 50_800));
+        assert_eq!(mapped.rot, 90.0);
+    }
+
+    #[test]
+    fn rotated_flipped_group_uses_shared_annex_l_mapping() {
+        let group = GroupTransform {
+            x: 0,
+            y: 0,
+            cx: 200,
+            cy: 100,
+            ch_x: 0,
+            ch_y: 0,
+            ch_cx: 100,
+            ch_cy: 100,
+            rot: 90.0,
+            flip_h: true,
+            flip_v: false,
+        };
+        let mapped = group.apply_to_transform(Transform {
+            x: 10,
+            y: 20,
+            cx: 20,
+            cy: 10,
+            rot: 15.0,
+            flip_h: false,
+            flip_v: true,
+        });
+
+        assert_eq!(
+            (mapped.x, mapped.y, mapped.cx, mapped.cy),
+            (105, 105, 40, 10)
+        );
+        assert_eq!(mapped.rot, 105.0);
+        assert!(mapped.flip_h);
+        assert!(mapped.flip_v);
+    }
+
+    #[test]
+    fn group_transform_preserves_table_chart_and_media_frame_orientation() {
+        let group = GroupTransform {
+            x: 0,
+            y: 0,
+            cx: 200,
+            cy: 100,
+            ch_x: 0,
+            ch_y: 0,
+            ch_cx: 100,
+            ch_cy: 100,
+            rot: 90.0,
+            flip_h: true,
+            flip_v: false,
+        };
+
+        let xml = r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart><c:plotArea><c:barChart><c:ser><c:cat><c:strLit><c:pt idx="0"><c:v>A</c:v></c:pt></c:strLit></c:cat><c:val><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:val></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>"#;
+        let chart = crate::chart::parse_legacy_chart(xml, &std::collections::HashMap::new())
+            .expect("minimal chart");
+        let mut elements = vec![
+            SlideElement::Table(TableElement {
+                x: 10,
+                y: 20,
+                width: 20,
+                height: 10,
+                rotation: 15.0,
+                flip_h: false,
+                flip_v: true,
+                cols: vec![],
+                rows: vec![],
+                rtl: false,
+            }),
+            SlideElement::Chart(ChartElement {
+                x: 10,
+                y: 20,
+                width: 20,
+                height: 10,
+                rotation: 15.0,
+                flip_h: false,
+                flip_v: true,
+                ..chart
+            }),
+            SlideElement::Media(MediaElement {
+                x: 10,
+                y: 20,
+                width: 20,
+                height: 10,
+                rotation: 15.0,
+                flip_h: false,
+                flip_v: true,
+                media_kind: "video".into(),
+                poster_path: String::new(),
+                poster_mime_type: String::new(),
+                media_path: String::new(),
+                mime_type: "video/mp4".into(),
+            }),
+        ];
+
+        for element in &mut elements {
+            apply_group_transform_to_element(element, &group);
+            match element {
+                SlideElement::Table(frame) => {
+                    assert_eq!(frame.rotation, 105.0);
+                    assert!(frame.flip_h);
+                    assert!(frame.flip_v);
+                }
+                SlideElement::Chart(frame) => {
+                    assert_eq!(frame.rotation, 105.0);
+                    assert!(frame.flip_h);
+                    assert!(frame.flip_v);
+                }
+                SlideElement::Media(frame) => {
+                    assert_eq!(frame.rotation, 105.0);
+                    assert!(frame.flip_h);
+                    assert!(frame.flip_v);
+                }
+                _ => unreachable!(),
+            }
         }
     }
 }
@@ -1292,15 +1413,18 @@ pub(crate) fn apply_group_transform_to_element(el: &mut SlideElement, gt: &Group
                 y: ey,
                 cx: ecx,
                 cy: ecy,
-                rot: 0.0,
-                flip_h: false,
-                flip_v: false,
+                rot: tbl.rotation,
+                flip_h: tbl.flip_h,
+                flip_v: tbl.flip_v,
             };
             let nt = gt.apply_to_transform(t);
             tbl.x = nt.x;
             tbl.y = nt.y;
             tbl.width = nt.cx;
             tbl.height = nt.cy;
+            tbl.rotation = nt.rot;
+            tbl.flip_h = nt.flip_h;
+            tbl.flip_v = nt.flip_v;
         }
         SlideElement::Chart(chart) => {
             // If the chart graphicFrame has no xfrm (zero dimensions), it fills the group's child space.
@@ -1314,15 +1438,18 @@ pub(crate) fn apply_group_transform_to_element(el: &mut SlideElement, gt: &Group
                 y: ey,
                 cx: ecx,
                 cy: ecy,
-                rot: 0.0,
-                flip_h: false,
-                flip_v: false,
+                rot: chart.rotation,
+                flip_h: chart.flip_h,
+                flip_v: chart.flip_v,
             };
             let nt = gt.apply_to_transform(t);
             chart.x = nt.x;
             chart.y = nt.y;
             chart.width = nt.cx;
             chart.height = nt.cy;
+            chart.rotation = nt.rot;
+            chart.flip_h = nt.flip_h;
+            chart.flip_v = nt.flip_v;
         }
         SlideElement::Media(m) => {
             let t = Transform {
@@ -1330,15 +1457,18 @@ pub(crate) fn apply_group_transform_to_element(el: &mut SlideElement, gt: &Group
                 y: m.y,
                 cx: m.width,
                 cy: m.height,
-                rot: 0.0,
-                flip_h: false,
-                flip_v: false,
+                rot: m.rotation,
+                flip_h: m.flip_h,
+                flip_v: m.flip_v,
             };
             let nt = gt.apply_to_transform(t);
             m.x = nt.x;
             m.y = nt.y;
             m.width = nt.cx;
             m.height = nt.cy;
+            m.rotation = nt.rot;
+            m.flip_h = nt.flip_h;
+            m.flip_v = nt.flip_v;
         }
     }
 }

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -3,7 +3,7 @@
 //! re-exports these via `pub use types::*`.
 
 use ooxml_common::blip::{Duotone, SrcRect};
-use ooxml_common::drawing::{DrawingGroupSpec, DrawingGroupTransform};
+use ooxml_common::drawing::{DrawingGroupSpec, DrawingGroupTransform, DrawingRect};
 use ooxml_common::math::MathNode;
 use ooxml_common::text::SpaceLine;
 use serde::{Deserialize, Serialize};
@@ -1174,15 +1174,15 @@ impl GroupTransform {
             flip_h: self.flip_h,
             flip_v: self.flip_v,
         })
-        .apply_rect(
-            t.x as f64,
-            t.y as f64,
-            t.cx as f64,
-            t.cy as f64,
-            t.rot,
-            t.flip_h,
-            t.flip_v,
-        );
+        .apply_rect(DrawingRect {
+            x: t.x as f64,
+            y: t.y as f64,
+            width: t.cx as f64,
+            height: t.cy as f64,
+            rotation_degrees: t.rot,
+            flip_h: t.flip_h,
+            flip_v: t.flip_v,
+        });
         Transform {
             x: mapped.x.round() as i64,
             y: mapped.y.round() as i64,
@@ -1191,6 +1191,137 @@ impl GroupTransform {
             rot: mapped.rotation_degrees,
             flip_h: mapped.flip_h,
             flip_v: mapped.flip_v,
+        }
+    }
+}
+
+pub(crate) fn apply_group_transform_to_element(el: &mut SlideElement, gt: &GroupTransform) {
+    match el {
+        SlideElement::Shape(s) => {
+            let t = Transform {
+                x: s.x,
+                y: s.y,
+                cx: s.width,
+                cy: s.height,
+                rot: s.rotation,
+                flip_h: s.flip_h,
+                flip_v: s.flip_v,
+            };
+            let nt = gt.apply_to_transform(t);
+            s.x = nt.x;
+            s.y = nt.y;
+            s.width = nt.cx;
+            s.height = nt.cy;
+            s.rotation = nt.rot;
+            s.flip_h = nt.flip_h;
+            s.flip_v = nt.flip_v;
+            // Transform the explicit text frame in lock-step. It is axis-aligned
+            // in local coords; pass rot=0/flip=false so it only translates+scales
+            // (SmartArt drawings that carry txXfrm are not nested in rotated groups).
+            if let Some(tr) = &mut s.text_rect {
+                let tt = Transform {
+                    x: tr.x,
+                    y: tr.y,
+                    cx: tr.width,
+                    cy: tr.height,
+                    rot: 0.0,
+                    flip_h: false,
+                    flip_v: false,
+                };
+                let ntt = gt.apply_to_transform(tt);
+                tr.x = ntt.x;
+                tr.y = ntt.y;
+                tr.width = ntt.cx;
+                tr.height = ntt.cy;
+            }
+        }
+        SlideElement::Picture(p) => {
+            let t = Transform {
+                x: p.x,
+                y: p.y,
+                cx: p.width,
+                cy: p.height,
+                rot: p.rotation,
+                flip_h: p.flip_h,
+                flip_v: p.flip_v,
+            };
+            let nt = gt.apply_to_transform(t);
+            p.x = nt.x;
+            p.y = nt.y;
+            p.width = nt.cx;
+            p.height = nt.cy;
+            p.rotation = nt.rot;
+            p.flip_h = nt.flip_h;
+            p.flip_v = nt.flip_v;
+        }
+        SlideElement::Table(tbl) => {
+            // If the table has no xfrm (zero dimensions), it fills the group's child space.
+            let (ex, ey, ecx, ecy) = if tbl.width == 0 && tbl.height == 0 {
+                (gt.ch_x, gt.ch_y, gt.ch_cx, gt.ch_cy)
+            } else {
+                (tbl.x, tbl.y, tbl.width, tbl.height)
+            };
+            let t = Transform {
+                x: ex,
+                y: ey,
+                cx: ecx,
+                cy: ecy,
+                rot: tbl.rotation,
+                flip_h: tbl.flip_h,
+                flip_v: tbl.flip_v,
+            };
+            let nt = gt.apply_to_transform(t);
+            tbl.x = nt.x;
+            tbl.y = nt.y;
+            tbl.width = nt.cx;
+            tbl.height = nt.cy;
+            tbl.rotation = nt.rot;
+            tbl.flip_h = nt.flip_h;
+            tbl.flip_v = nt.flip_v;
+        }
+        SlideElement::Chart(chart) => {
+            // If the chart graphicFrame has no xfrm (zero dimensions), it fills the group's child space.
+            let (ex, ey, ecx, ecy) = if chart.width == 0 && chart.height == 0 {
+                (gt.ch_x, gt.ch_y, gt.ch_cx, gt.ch_cy)
+            } else {
+                (chart.x, chart.y, chart.width, chart.height)
+            };
+            let t = Transform {
+                x: ex,
+                y: ey,
+                cx: ecx,
+                cy: ecy,
+                rot: chart.rotation,
+                flip_h: chart.flip_h,
+                flip_v: chart.flip_v,
+            };
+            let nt = gt.apply_to_transform(t);
+            chart.x = nt.x;
+            chart.y = nt.y;
+            chart.width = nt.cx;
+            chart.height = nt.cy;
+            chart.rotation = nt.rot;
+            chart.flip_h = nt.flip_h;
+            chart.flip_v = nt.flip_v;
+        }
+        SlideElement::Media(m) => {
+            let t = Transform {
+                x: m.x,
+                y: m.y,
+                cx: m.width,
+                cy: m.height,
+                rot: m.rotation,
+                flip_h: m.flip_h,
+                flip_v: m.flip_v,
+            };
+            let nt = gt.apply_to_transform(t);
+            m.x = nt.x;
+            m.y = nt.y;
+            m.width = nt.cx;
+            m.height = nt.cy;
+            m.rotation = nt.rot;
+            m.flip_h = nt.flip_h;
+            m.flip_v = nt.flip_v;
         }
     }
 }
@@ -1338,137 +1469,6 @@ mod group_transform_tests {
                 }
                 _ => unreachable!(),
             }
-        }
-    }
-}
-
-pub(crate) fn apply_group_transform_to_element(el: &mut SlideElement, gt: &GroupTransform) {
-    match el {
-        SlideElement::Shape(s) => {
-            let t = Transform {
-                x: s.x,
-                y: s.y,
-                cx: s.width,
-                cy: s.height,
-                rot: s.rotation,
-                flip_h: s.flip_h,
-                flip_v: s.flip_v,
-            };
-            let nt = gt.apply_to_transform(t);
-            s.x = nt.x;
-            s.y = nt.y;
-            s.width = nt.cx;
-            s.height = nt.cy;
-            s.rotation = nt.rot;
-            s.flip_h = nt.flip_h;
-            s.flip_v = nt.flip_v;
-            // Transform the explicit text frame in lock-step. It is axis-aligned
-            // in local coords; pass rot=0/flip=false so it only translates+scales
-            // (SmartArt drawings that carry txXfrm are not nested in rotated groups).
-            if let Some(tr) = &mut s.text_rect {
-                let tt = Transform {
-                    x: tr.x,
-                    y: tr.y,
-                    cx: tr.width,
-                    cy: tr.height,
-                    rot: 0.0,
-                    flip_h: false,
-                    flip_v: false,
-                };
-                let ntt = gt.apply_to_transform(tt);
-                tr.x = ntt.x;
-                tr.y = ntt.y;
-                tr.width = ntt.cx;
-                tr.height = ntt.cy;
-            }
-        }
-        SlideElement::Picture(p) => {
-            let t = Transform {
-                x: p.x,
-                y: p.y,
-                cx: p.width,
-                cy: p.height,
-                rot: p.rotation,
-                flip_h: p.flip_h,
-                flip_v: p.flip_v,
-            };
-            let nt = gt.apply_to_transform(t);
-            p.x = nt.x;
-            p.y = nt.y;
-            p.width = nt.cx;
-            p.height = nt.cy;
-            p.rotation = nt.rot;
-            p.flip_h = nt.flip_h;
-            p.flip_v = nt.flip_v;
-        }
-        SlideElement::Table(tbl) => {
-            // If the table has no xfrm (zero dimensions), it fills the group's child space.
-            let (ex, ey, ecx, ecy) = if tbl.width == 0 && tbl.height == 0 {
-                (gt.ch_x, gt.ch_y, gt.ch_cx, gt.ch_cy)
-            } else {
-                (tbl.x, tbl.y, tbl.width, tbl.height)
-            };
-            let t = Transform {
-                x: ex,
-                y: ey,
-                cx: ecx,
-                cy: ecy,
-                rot: tbl.rotation,
-                flip_h: tbl.flip_h,
-                flip_v: tbl.flip_v,
-            };
-            let nt = gt.apply_to_transform(t);
-            tbl.x = nt.x;
-            tbl.y = nt.y;
-            tbl.width = nt.cx;
-            tbl.height = nt.cy;
-            tbl.rotation = nt.rot;
-            tbl.flip_h = nt.flip_h;
-            tbl.flip_v = nt.flip_v;
-        }
-        SlideElement::Chart(chart) => {
-            // If the chart graphicFrame has no xfrm (zero dimensions), it fills the group's child space.
-            let (ex, ey, ecx, ecy) = if chart.width == 0 && chart.height == 0 {
-                (gt.ch_x, gt.ch_y, gt.ch_cx, gt.ch_cy)
-            } else {
-                (chart.x, chart.y, chart.width, chart.height)
-            };
-            let t = Transform {
-                x: ex,
-                y: ey,
-                cx: ecx,
-                cy: ecy,
-                rot: chart.rotation,
-                flip_h: chart.flip_h,
-                flip_v: chart.flip_v,
-            };
-            let nt = gt.apply_to_transform(t);
-            chart.x = nt.x;
-            chart.y = nt.y;
-            chart.width = nt.cx;
-            chart.height = nt.cy;
-            chart.rotation = nt.rot;
-            chart.flip_h = nt.flip_h;
-            chart.flip_v = nt.flip_v;
-        }
-        SlideElement::Media(m) => {
-            let t = Transform {
-                x: m.x,
-                y: m.y,
-                cx: m.width,
-                cy: m.height,
-                rot: m.rotation,
-                flip_h: m.flip_h,
-                flip_v: m.flip_v,
-            };
-            let nt = gt.apply_to_transform(t);
-            m.x = nt.x;
-            m.y = nt.y;
-            m.width = nt.cx;
-            m.height = nt.cy;
-            m.rotation = nt.rot;
-            m.flip_h = nt.flip_h;
-            m.flip_v = nt.flip_v;
         }
     }
 }

--- a/packages/pptx/src/frame-transform.test.ts
+++ b/packages/pptx/src/frame-transform.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyFrameTransform } from './renderer.js';
+import type { ChartElement, MediaElement, TableElement } from './types.js';
+
+function contextRecorder() {
+  const translate = vi.fn();
+  const rotate = vi.fn();
+  const scale = vi.fn();
+  return {
+    ctx: { translate, rotate, scale } as unknown as CanvasRenderingContext2D,
+    translate,
+    rotate,
+    scale,
+  };
+}
+
+const frame = {
+  x: 10,
+  y: 20,
+  width: 40,
+  height: 10,
+  rotation: 90,
+  flipH: true,
+  flipV: true,
+};
+
+describe('PPTX frame transforms (ECMA-376 Annex L)', () => {
+  it.each([
+    { type: 'table', cols: [], rows: [] } as unknown as TableElement,
+    { type: 'chart', chart: {} } as unknown as ChartElement,
+    {
+      type: 'media',
+      mediaKind: 'video',
+      posterPath: '',
+      posterMimeType: '',
+      mediaPath: '',
+      mimeType: 'video/mp4',
+    } as unknown as MediaElement,
+  ])('applies rotation and both flips to a $type frame', (element) => {
+    const { ctx, translate, rotate, scale } = contextRecorder();
+    applyFrameTransform(ctx, { ...element, ...frame }, 2);
+
+    expect(translate.mock.calls).toEqual([
+      [60, 50],
+      [-60, -50],
+    ]);
+    expect(rotate).toHaveBeenCalledWith(Math.PI / 2);
+    expect(scale.mock.calls).toEqual([
+      [-1, 1],
+      [1, -1],
+    ]);
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -5,6 +5,7 @@ import type {
   PictureElement,
   MediaElement,
   TableElement,
+  ChartElement,
   TableCell,
   Fill,
   TileInfo,
@@ -4735,26 +4736,30 @@ async function renderMedia(
   const w = emuToPx(el.width, scale);
   const h = emuToPx(el.height, scale);
 
-  let drewPoster = false;
+  let poster: ImageBitmap | undefined;
   if (el.posterPath && fetchMedia) {
     try {
       // Poster is cached (and prefetched by renderSlide); do not close it here —
       // it is reused across renders of the same slide.
-      const bitmap = await getPosterBitmap(el, fetchMedia);
-      ctx.drawImage(bitmap, x, y, w, h);
-      drewPoster = true;
+      poster = await getPosterBitmap(el, fetchMedia);
     } catch {
       // fall through to plain fill
     }
   }
-  if (!drewPoster) {
+
+  // Do not retain a saved canvas state across the asynchronous poster decode:
+  // a newer render may reuse the same context while the promise is pending.
+  ctx.save();
+  applyFrameTransform(ctx, el, scale);
+  if (poster) {
+    ctx.drawImage(poster, x, y, w, h);
+  } else {
     ctx.fillStyle = el.mediaKind === 'video' ? '#111' : '#f0f0f0';
     ctx.fillRect(x, y, w, h);
   }
 
-  if (skipControls) return;
-
-  drawPlayBadge(ctx, x + w / 2, y + h / 2, w, h, 'paused');
+  if (!skipControls) drawPlayBadge(ctx, x + w / 2, y + h / 2, w, h, 'paused');
+  ctx.restore();
 }
 
 // ===== Table renderer =====
@@ -4862,7 +4867,26 @@ function applyStroke(ctx: CanvasRenderingContext2D, stroke: Stroke | null, scale
 
 // ─── Table rendering ─────────────────────────────────────────────────────────
 
+export function applyFrameTransform(
+  ctx: CanvasRenderingContext2D,
+  el: Pick<TableElement | ChartElement | MediaElement, 'x' | 'y' | 'width' | 'height' | 'rotation' | 'flipH' | 'flipV'>,
+  scale: number,
+): void {
+  if (el.rotation === 0 && !el.flipH && !el.flipV) return;
+  const x = emuToPx(el.x, scale);
+  const y = emuToPx(el.y, scale);
+  const w = emuToPx(el.width, scale);
+  const h = emuToPx(el.height, scale);
+  ctx.translate(x + w / 2, y + h / 2);
+  ctx.rotate((el.rotation * Math.PI) / 180);
+  if (el.flipH) ctx.scale(-1, 1);
+  if (el.flipV) ctx.scale(1, -1);
+  ctx.translate(-(x + w / 2), -(y + h / 2));
+}
+
 export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, scale: number, slideNumber?: number, rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 }) {
+  ctx.save();
+  applyFrameTransform(ctx, el, scale);
   const x0 = emuToPx(el.x, scale);
   const y0 = emuToPx(el.y, scale);
 
@@ -5181,6 +5205,7 @@ export function renderTable(ctx: CanvasRenderingContext2D, el: TableElement, sca
     }
     ctx.restore();
   }
+  ctx.restore();
 }
 
 // ===== Public API =====
@@ -5502,6 +5527,8 @@ async function renderSlideLeased(
       const chartPtToPx = PT_TO_EMU * scale;
       // `el.chart` is already the canonical ChartModel emitted by the Rust
       // parser (`ooxml_common::chart::ChartModel`) — no per-field adapter.
+      ctx.save();
+      applyFrameTransform(ctx, el, scale);
       renderChart(
         ctx,
         el.chart,
@@ -5513,6 +5540,7 @@ async function renderSlideLeased(
         },
         chartPtToPx,
       );
+      ctx.restore();
     }
   }
 

--- a/packages/pptx/src/table-border-single-draw.test.ts
+++ b/packages/pptx/src/table-border-single-draw.test.ts
@@ -78,6 +78,7 @@ function tableOf(rows: TableCell[][], cols: number[]): TableElement {
   return {
     type: 'table', x: 0, y: 0,
     width: cols.reduce((a, b) => a + b, 0), height: rowH * rows.length,
+    rotation: 0, flipH: false, flipV: false,
     cols, rows: tableRows,
   };
 }

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -231,6 +231,9 @@ export interface MediaElement {
   y: number;
   width: number;
   height: number;
+  rotation: number;
+  flipH: boolean;
+  flipV: boolean;
   /** "audio" or "video" */
   mediaKind: 'audio' | 'video';
   /** Poster image zip path (e.g. "ppt/media/image2.png"). Empty when no poster. */
@@ -428,6 +431,9 @@ export interface TableElement {
   y: number;
   width: number;
   height: number;
+  rotation: number;
+  flipH: boolean;
+  flipV: boolean;
   /** Column widths in EMU */
   cols: number[];
   rows: TableRow[];
@@ -476,6 +482,9 @@ export interface ChartElement {
   y: number;
   width: number;
   height: number;
+  rotation: number;
+  flipH: boolean;
+  flipV: boolean;
   /**
    * The chart payload, already in the canonical {@link ChartModel} shape emitted
    * by the Rust parser (`ooxml_common::chart::ChartModel`). Passed straight to

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -11,7 +11,7 @@ use ooxml_common::blip::{
     svg_blip_rid,
 };
 use ooxml_common::depth::{parse_guarded, DepthGuard};
-use ooxml_common::drawing::{DrawingGroupSpec, DrawingGroupTransform};
+use ooxml_common::drawing::{DrawingGroupSpec, DrawingGroupTransform, DrawingRect};
 use ooxml_common::ns::{attr_ns, is_a_ns, is_xdr_ns, relationships};
 use ooxml_common::units::EMU_PER_PX_96DPI;
 use std::collections::HashMap;
@@ -987,15 +987,15 @@ pub(crate) fn collect_shapes(
             // Shape rect in root coords. Use the cross-format DrawingML mapper
             // so a quarter-turned leaf under non-uniform group scale keeps its
             // transformed centre and swaps the applicable scale axes.
-            let root_rect = transform.apply_rect(
-                xfrm.off_x,
-                xfrm.off_y,
-                xfrm.ext_x,
-                xfrm.ext_y,
-                xfrm.rot,
-                xfrm.flip_h,
-                xfrm.flip_v,
-            );
+            let root_rect = transform.apply_rect(DrawingRect {
+                x: xfrm.off_x,
+                y: xfrm.off_y,
+                width: xfrm.ext_x,
+                height: xfrm.ext_y,
+                rotation_degrees: xfrm.rot,
+                flip_h: xfrm.flip_h,
+                flip_v: xfrm.flip_v,
+            });
             let root_x = root_rect.x;
             let root_y = root_rect.y;
             let root_w = root_rect.width;
@@ -1225,15 +1225,15 @@ pub(crate) fn collect_shapes(
             };
             let mime_type = mime_from_ext(&image_path).to_string();
 
-            let root_rect = transform.apply_rect(
-                xfrm.off_x,
-                xfrm.off_y,
-                xfrm.ext_x,
-                xfrm.ext_y,
-                xfrm.rot,
-                xfrm.flip_h,
-                xfrm.flip_v,
-            );
+            let root_rect = transform.apply_rect(DrawingRect {
+                x: xfrm.off_x,
+                y: xfrm.off_y,
+                width: xfrm.ext_x,
+                height: xfrm.ext_y,
+                rotation_degrees: xfrm.rot,
+                flip_h: xfrm.flip_h,
+                flip_v: xfrm.flip_v,
+            });
             let root_x = root_rect.x;
             let root_y = root_rect.y;
             let root_w = root_rect.width;
@@ -4226,7 +4226,15 @@ mod group_transform_contract_tests {
             flip_h: group.flip_h,
             flip_v: group.flip_v,
         });
-        let mapped = transform.apply_rect(10.0, 20.0, 20.0, 10.0, 15.0, false, true);
+        let mapped = transform.apply_rect(DrawingRect {
+            x: 10.0,
+            y: 20.0,
+            width: 20.0,
+            height: 10.0,
+            rotation_degrees: 15.0,
+            flip_h: false,
+            flip_v: true,
+        });
 
         assert!((mapped.x - 105.0).abs() < 1e-9);
         assert!((mapped.y - 105.0).abs() < 1e-9);

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -11,6 +11,7 @@ use ooxml_common::blip::{
     svg_blip_rid,
 };
 use ooxml_common::depth::{parse_guarded, DepthGuard};
+use ooxml_common::drawing::{DrawingGroupSpec, DrawingGroupTransform};
 use ooxml_common::ns::{attr_ns, is_a_ns, is_xdr_ns, relationships};
 use ooxml_common::units::EMU_PER_PX_96DPI;
 use std::collections::HashMap;
@@ -269,6 +270,9 @@ pub(crate) struct Xfrm {
     ch_ext_x: f64,
     ch_ext_y: f64,
     has_ch: bool,
+    rot: f64,
+    flip_h: bool,
+    flip_v: bool,
 }
 
 pub(crate) fn parse_xfrm(xfrm_node: &roxmltree::Node) -> Option<Xfrm> {
@@ -327,6 +331,13 @@ pub(crate) fn parse_xfrm(xfrm_node: &roxmltree::Node) -> Option<Xfrm> {
         ch_ext_x: if ch_ext.0 == 0.0 { ext.0 } else { ch_ext.0 },
         ch_ext_y: if ch_ext.1 == 0.0 { ext.1 } else { ch_ext.1 },
         has_ch,
+        rot: xfrm_node
+            .attribute("rot")
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or(0.0)
+            / 60000.0,
+        flip_h: matches!(xfrm_node.attribute("flipH"), Some("1") | Some("true")),
+        flip_v: matches!(xfrm_node.attribute("flipV"), Some("1") | Some("true")),
     })
 }
 
@@ -886,11 +897,8 @@ pub(crate) fn collect_shapes(
     root_off_y: f64,
     root_ext_x: f64,
     root_ext_y: f64,
-    // transform from current local coords into root (top-level grpSp) coords
-    scale_x: f64,
-    scale_y: f64,
-    trans_x: f64,
-    trans_y: f64,
+    // cumulative Annex L transform from current local coords into root coords
+    transform: DrawingGroupTransform,
     theme_colors: &[String],
     theme_ln_widths: &[i64],
     rid_urls: &HashMap<String, String>,
@@ -923,29 +931,29 @@ pub(crate) fn collect_shapes(
                 })
                 .as_ref()
                 .and_then(parse_xfrm);
-            let (sx, sy, tx, ty) = if let Some(x) = xfrm {
-                if x.has_ch && x.ch_ext_x != 0.0 && x.ch_ext_y != 0.0 {
-                    let csx = x.ext_x / x.ch_ext_x;
-                    let csy = x.ext_y / x.ch_ext_y;
-                    // Child point (cx, cy) → (x.off_x + (cx - x.ch_off_x)*csx) in parent coords,
-                    // then apply outer (scale/trans) to reach root coords.
-                    (
-                        scale_x * csx,
-                        scale_y * csy,
-                        trans_x + scale_x * (x.off_x - x.ch_off_x * csx),
-                        trans_y + scale_y * (x.off_y - x.ch_off_y * csy),
-                    )
-                } else {
-                    // No child coord system: treat as identity mapping inside the group.
-                    (
-                        scale_x,
-                        scale_y,
-                        trans_x + scale_x * x.off_x,
-                        trans_y + scale_y * x.off_y,
-                    )
-                }
+            let child_transform = if let Some(x) = xfrm {
+                // Without chOff/chExt, DrawingML defines no distinct child
+                // coordinate system; using ext as chExt keeps scale at 1 while
+                // still applying the group's offset.
+                let child_ext_x = if x.has_ch { x.ch_ext_x } else { x.ext_x };
+                let child_ext_y = if x.has_ch { x.ch_ext_y } else { x.ext_y };
+                let child_off_x = if x.has_ch { x.ch_off_x } else { 0.0 };
+                let child_off_y = if x.has_ch { x.ch_off_y } else { 0.0 };
+                transform.compose_group(DrawingGroupSpec {
+                    off_x: x.off_x,
+                    off_y: x.off_y,
+                    ext_x: x.ext_x,
+                    ext_y: x.ext_y,
+                    child_off_x,
+                    child_off_y,
+                    child_ext_x,
+                    child_ext_y,
+                    rotation_degrees: x.rot,
+                    flip_h: x.flip_h,
+                    flip_v: x.flip_v,
+                })
             } else {
-                (scale_x, scale_y, trans_x, trans_y)
+                transform
             };
             collect_shapes(
                 &child,
@@ -953,10 +961,7 @@ pub(crate) fn collect_shapes(
                 root_off_y,
                 root_ext_x,
                 root_ext_y,
-                sx,
-                sy,
-                tx,
-                ty,
+                child_transform,
                 theme_colors,
                 theme_ln_widths,
                 rid_urls,
@@ -979,16 +984,22 @@ pub(crate) fn collect_shapes(
             let Some(xfrm) = parse_xfrm(&xfrm_n) else {
                 continue;
             };
-            let rot_raw: f64 = xfrm_n
-                .attribute("rot")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0.0);
-
-            // Shape rect in root coords
-            let root_x = trans_x + scale_x * xfrm.off_x;
-            let root_y = trans_y + scale_y * xfrm.off_y;
-            let root_w = scale_x * xfrm.ext_x;
-            let root_h = scale_y * xfrm.ext_y;
+            // Shape rect in root coords. Use the cross-format DrawingML mapper
+            // so a quarter-turned leaf under non-uniform group scale keeps its
+            // transformed centre and swaps the applicable scale axes.
+            let root_rect = transform.apply_rect(
+                xfrm.off_x,
+                xfrm.off_y,
+                xfrm.ext_x,
+                xfrm.ext_y,
+                xfrm.rot,
+                xfrm.flip_h,
+                xfrm.flip_v,
+            );
+            let root_x = root_rect.x;
+            let root_y = root_rect.y;
+            let root_w = root_rect.width;
+            let root_h = root_rect.height;
 
             // Normalize to [0,1] of root ext
             if root_ext_x == 0.0 || root_ext_y == 0.0 {
@@ -1147,7 +1158,9 @@ pub(crate) fn collect_shapes(
                 y: ny,
                 w: nw,
                 h: nh,
-                rot: rot_raw / 60000.0,
+                rot: root_rect.rotation_degrees,
+                flip_h: root_rect.flip_h,
+                flip_v: root_rect.flip_v,
                 fill_color,
                 stroke_color,
                 stroke_width,
@@ -1173,11 +1186,6 @@ pub(crate) fn collect_shapes(
             let Some(xfrm) = parse_xfrm(&xfrm_n) else {
                 continue;
             };
-            let rot_raw: f64 = xfrm_n
-                .attribute("rot")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0.0);
-
             // Resolve `<a:blip>`. The raster fallback rides in `r:embed`; the
             // vector original (Microsoft 2016 svgBlip extension, MS-ODRAWXML) is
             // nested in `<a:blip><a:extLst>`. `rid_urls` maps every media rId
@@ -1217,10 +1225,19 @@ pub(crate) fn collect_shapes(
             };
             let mime_type = mime_from_ext(&image_path).to_string();
 
-            let root_x = trans_x + scale_x * xfrm.off_x;
-            let root_y = trans_y + scale_y * xfrm.off_y;
-            let root_w = scale_x * xfrm.ext_x;
-            let root_h = scale_y * xfrm.ext_y;
+            let root_rect = transform.apply_rect(
+                xfrm.off_x,
+                xfrm.off_y,
+                xfrm.ext_x,
+                xfrm.ext_y,
+                xfrm.rot,
+                xfrm.flip_h,
+                xfrm.flip_v,
+            );
+            let root_x = root_rect.x;
+            let root_y = root_rect.y;
+            let root_w = root_rect.width;
+            let root_h = root_rect.height;
             if root_ext_x == 0.0 || root_ext_y == 0.0 {
                 continue;
             }
@@ -1237,7 +1254,9 @@ pub(crate) fn collect_shapes(
                 y: ny,
                 w: nw,
                 h: nh,
-                rot: rot_raw / 60000.0,
+                rot: root_rect.rotation_degrees,
+                flip_h: root_rect.flip_h,
+                flip_v: root_rect.flip_v,
                 fill_color: None,
                 stroke_color: None,
                 stroke_width: 0,
@@ -1380,11 +1399,21 @@ pub(crate) fn parse_shape_anchors(
             native_ext_cx = root.ext_x as i64;
             native_ext_cy = root.ext_y as i64;
 
-            // Map child coords → root coords with the grpSp's own chOff/chExt.
-            let csx = root.ext_x / root.ch_ext_x;
-            let csy = root.ext_y / root.ch_ext_y;
-            let tx = root.off_x - root.ch_off_x * csx;
-            let ty = root.off_y - root.ch_off_y * csy;
+            // Map child coords → root coords through the same shared DrawingML
+            // transform contract used by DOCX and PPTX.
+            let root_transform = DrawingGroupTransform::from_group(DrawingGroupSpec {
+                off_x: root.off_x,
+                off_y: root.off_y,
+                ext_x: root.ext_x,
+                ext_y: root.ext_y,
+                child_off_x: root.ch_off_x,
+                child_off_y: root.ch_off_y,
+                child_ext_x: root.ch_ext_x,
+                child_ext_y: root.ch_ext_y,
+                rotation_degrees: root.rot,
+                flip_h: root.flip_h,
+                flip_v: root.flip_v,
+            });
 
             collect_shapes(
                 &grp,
@@ -1392,10 +1421,7 @@ pub(crate) fn parse_shape_anchors(
                 root.off_y,
                 root.ext_x,
                 root.ext_y,
-                csx,
-                csy,
-                tx,
-                ty,
+                root_transform,
                 theme_colors,
                 theme_ln_widths,
                 rid_urls,
@@ -1454,10 +1480,7 @@ pub(crate) fn parse_shape_anchors(
                 xfrm.off_y,
                 xfrm.ext_x,
                 xfrm.ext_y,
-                1.0,
-                1.0,
-                0.0,
-                0.0,
+                DrawingGroupTransform::IDENTITY,
                 theme_colors,
                 theme_ln_widths,
                 rid_urls,
@@ -4122,5 +4145,95 @@ mod strict_namespace_tests {
         );
         assert_eq!(anchors[0].image_path, "xl/media/image1.png");
         assert_eq!(anchors[0].mime_type, "image/png");
+    }
+}
+
+#[cfg(test)]
+mod group_transform_contract_tests {
+    use super::*;
+
+    #[test]
+    fn quarter_turned_leaf_uses_shared_non_uniform_group_mapping() {
+        let xml = r#"<xdr:grpSp xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+                                  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <xdr:sp>
+            <xdr:spPr>
+              <a:xfrm rot="5400000">
+                <a:off x="0" y="50800"/>
+                <a:ext cx="127000" cy="25400"/>
+              </a:xfrm>
+              <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+            </xdr:spPr>
+          </xdr:sp>
+        </xdr:grpSp>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let mut shapes = Vec::new();
+        collect_shapes(
+            &doc.root_element(),
+            0.0,
+            0.0,
+            127_000.0,
+            254_000.0,
+            DrawingGroupTransform::from_group(DrawingGroupSpec {
+                off_x: 0.0,
+                off_y: 0.0,
+                ext_x: 127_000.0,
+                ext_y: 254_000.0,
+                child_off_x: 0.0,
+                child_off_y: 0.0,
+                child_ext_x: 127_000.0,
+                child_ext_y: 127_000.0,
+                rotation_degrees: 0.0,
+                flip_h: false,
+                flip_v: false,
+            }),
+            &[],
+            &[],
+            &HashMap::new(),
+            &mut shapes,
+            DepthGuard::root(),
+        );
+
+        assert_eq!(shapes.len(), 1);
+        let shape = &shapes[0];
+        assert!((shape.x - 0.0).abs() < 1e-9);
+        assert!((shape.y - 0.4).abs() < 1e-9);
+        assert!((shape.w - 1.0).abs() < 1e-9);
+        assert!((shape.h - 0.2).abs() < 1e-9);
+        assert_eq!(shape.rot, 90.0);
+    }
+
+    #[test]
+    fn xfrm_preserves_group_rotation_and_flip_for_shared_mapping() {
+        let doc = roxmltree::Document::parse(
+            r#"<a:xfrm xmlns:a="urn:a" rot="5400000" flipH="1">
+                 <a:off x="0" y="0"/><a:ext cx="200" cy="100"/>
+                 <a:chOff x="0" y="0"/><a:chExt cx="100" cy="100"/>
+               </a:xfrm>"#,
+        )
+        .unwrap();
+        let group = parse_xfrm(&doc.root_element()).unwrap();
+        let transform = DrawingGroupTransform::from_group(DrawingGroupSpec {
+            off_x: group.off_x,
+            off_y: group.off_y,
+            ext_x: group.ext_x,
+            ext_y: group.ext_y,
+            child_off_x: group.ch_off_x,
+            child_off_y: group.ch_off_y,
+            child_ext_x: group.ch_ext_x,
+            child_ext_y: group.ch_ext_y,
+            rotation_degrees: group.rot,
+            flip_h: group.flip_h,
+            flip_v: group.flip_v,
+        });
+        let mapped = transform.apply_rect(10.0, 20.0, 20.0, 10.0, 15.0, false, true);
+
+        assert!((mapped.x - 105.0).abs() < 1e-9);
+        assert!((mapped.y - 105.0).abs() < 1e-9);
+        assert!((mapped.width - 40.0).abs() < 1e-9);
+        assert!((mapped.height - 10.0).abs() < 1e-9);
+        assert!((mapped.rotation_degrees - 105.0).abs() < 1e-9);
+        assert!(mapped.flip_h);
+        assert!(mapped.flip_v);
     }
 }

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -524,6 +524,10 @@ pub struct ShapeInfo {
     /// Rotation in degrees (clockwise). DrawingML `a:xfrm/@rot` is in 60000ths
     /// of a degree; the parser converts to degrees here.
     pub rot: f64,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub flip_h: bool,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub flip_v: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_color: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3587,9 +3587,10 @@ function drawShape(
   loadedImages?: Map<string, CanvasImageSource | null>,
 ): void {
   ctx.save();
-  if (shape.rot !== 0) {
+  if (shape.rot !== 0 || shape.flipH || shape.flipV) {
     ctx.translate(sx + sw / 2, sy + sh / 2);
     ctx.rotate((shape.rot * Math.PI) / 180);
+    ctx.scale(shape.flipH ? -1 : 1, shape.flipV ? -1 : 1);
     ctx.translate(-sw / 2, -sh / 2);
   } else {
     ctx.translate(sx, sy);

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -380,6 +380,9 @@ export interface ShapeInfo {
   x: number; y: number; w: number; h: number;
   /** Rotation in degrees, clockwise. */
   rot: number;
+  /** Effective DrawingML reflection after composing parent groups. */
+  flipH?: boolean;
+  flipV?: boolean;
   fillColor?: string;
   strokeColor?: string;
   /** Stroke width in EMU. 0 = no stroke. */


### PR DESCRIPTION
## Summary

- preserve WordprocessingML omitted-grid borders, floating layout constraints, and line metrics across measurement, pagination, and painting
- implement the legacy VML stroke and fill cascade, including default colors, units, dashes, endcaps, arrows, and geometry
- centralize DrawingML group transforms and propagate Annex L scale, rotation, and flip semantics consistently through DOCX, XLSX, and PPTX
- carry PPTX table, chart, and media frame transforms through parser contracts and rendering

## Root cause

Several authored OOXML properties were discarded before rendering, while some layout paths reconstructed geometry from incomplete state. Group transform implementations had also diverged between format packages. These mismatches shifted anchored content, lost legacy form shapes, and introduced pagination or border artifacts.

## Specification basis

The implementation follows ECMA-376 sections 17.4.14, 17.4.15, 17.4.66, and 17.4.85; DrawingML Annex L sections L.4.7.4 through L.4.7.6; and Part 4 VML stroke and fill semantics including section 19.1.2.21. Shared concepts are implemented in the common layer, with no document-path or sample-specific thresholds.

## Independent review

A separate agent critically reviewed the change for specification-first behavior, responsibility boundaries, duplication, and cross-format consistency. Review findings and the CI follow-up refactor were fixed and independently approved with no actionable findings.

## Validation

- all affected Rust parser suites: DOCX, XLSX, PPTX, and ooxml-common
- cargo clippy --workspace --all-targets -- -D warnings
- focused renderer and layout Vitest suites, including VML numeric dash and PPTX frame transforms
- TypeScript typecheck
- ast-grep lint
- git diff check
- local visual comparison against Office-rendered references
- GitHub Actions: rust, audit, typecheck, and smoke

The full JavaScript suite passes 4,377 tests; two local-only fixture assertions remain pre-existing and reproduce unchanged on the base commit.