### PR TITLE
chore(release): 0.72.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.72.1 — 2026-07-13
+
+Patch (fix on v0.72.0). Preserves authored OOXML layout and grouped-drawing
+geometry that had been discarded or reconstructed from incomplete state before
+rendering, which shifted anchored content, lost legacy VML form shapes, and
+introduced pagination/border artifacts.
+
+- **docx:** preserve omitted-grid table borders, floating-layout constraints,
+  and line metrics consistently across measurement, pagination, and painting;
+  implement the legacy VML stroke/fill cascade (default colors, units, dashes,
+  endcaps, arrows, geometry) so authored form shapes render (ECMA-376 §17.4.14,
+  §17.4.15, §17.4.66, §17.4.85; Part 4 VML §19.1.2.21).
+- **DrawingML (docx / xlsx / pptx):** centralize group transforms in the shared
+  layer and propagate Annex L scale / rotation / flip semantics consistently
+  across all three formats (Annex L §L.4.7.4–L.4.7.6); carry pptx table, chart,
+  and media frame transforms through the parser contracts into rendering. No
+  document-path or sample-specific thresholds. (#1032)
+
 ## 0.72.0 — 2026-07-13
 
 Minor. A large docx fidelity cycle centered on **vertical writing (縦書き)** and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-markdown",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.72.0"
+version = "0.72.1"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",


### PR DESCRIPTION
Patch release **0.72.1** on v0.72.0.

## Version bump
All npm packages (root `@silurus/ooxml` + core/docx/pptx/xlsx/markdown/node/vscode-extension), the site, and the `ooxml-mcp-server` crate → **0.72.1**. `Cargo.lock` refreshed via `cargo check -p ooxml-mcp-server`.

## Fix included
- **#1032 — preserve authored layout and grouped drawing geometry**: omitted-grid table borders, floating-layout constraints, and line metrics across measurement/pagination/painting; legacy VML stroke/fill cascade so authored form shapes render; centralized DrawingML group transforms with Annex L scale/rotation/flip propagated consistently across docx/xlsx/pptx; pptx table/chart/media frame transforms carried through the parser contracts. ECMA-376 §17.4.14/15/66/85, Annex L §L.4.7.4–6, Part 4 VML §19.1.2.21. No sample-specific thresholds.

(#1031, a CI-only change running artifact actions on Node.js 24, is also on main since v0.72.0 but is not user-facing.)

## Release mechanism
Merge → push `v0.72.1` tag → `publish.yml` publishes to npm; `gh release create v0.72.1` then triggers the MCP-binary build.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>