### PR TITLE
fix(xlsx): resolve cacheless chart data and RTL anchors

### DIFF
--- a/packages/core/src/chart/renderer-scatter-legend-key.test.ts
+++ b/packages/core/src/chart/renderer-scatter-legend-key.test.ts
@@ -72,8 +72,10 @@ const LEGEND_Y_MIN = 320; // RECT.h = 360; the bottom legend band starts well be
 function recordingCtx(): {
   ctx: CanvasRenderingContext2D;
   keys: Array<'marker' | 'line'>;
+  plotMarkerYs: number[];
 } {
   const keys: Array<'marker' | 'line'> = [];
+  const plotMarkerYs: number[] = [];
   let pathVerts = 0;
   let lastPathY = 0;   // y of the last moveTo/lineTo/arc vertex (band gating).
   let pendingKey: 'marker' | 'line' | null = null;
@@ -104,7 +106,11 @@ function recordingCtx(): {
         case 'quadraticCurveTo':
           return (_x: number, y: number) => { pathVerts += 1; lastPathY = y; };
         case 'arc':
-          return (_cx: number, cy: number) => { pathVerts += 1; lastPathY = cy; };
+          return (_cx: number, cy: number) => {
+            pathVerts += 1;
+            lastPathY = cy;
+            if (cy < LEGEND_Y_MIN) plotMarkerYs.push(cy);
+          };
         case 'fill':
           // A marker glyph (arc/diamond/triangle/star) fills a closed path.
           return () => { if (inBand()) pendingKey = 'marker'; };
@@ -133,7 +139,11 @@ function recordingCtx(): {
     },
     set(_t, prop: string, value) { state[prop] = value; return true; },
   };
-  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, keys };
+  return {
+    ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D,
+    keys,
+    plotMarkerYs,
+  };
 }
 
 const scatterModel = (over: Partial<ChartModel>, serOver: Partial<ChartSeries> = {}): ChartModel =>
@@ -201,5 +211,40 @@ describe('scatter legend key reflects the plotted mark (#803, §21.2.2.42/.198)'
     );
     expect(rec.keys).toContain('line');
     expect(rec.keys).not.toContain('marker');
+  });
+
+  it('does not reuse chart-level X values for an explicitly empty later series', () => {
+    const resolved = series({ name: 'resolved', values: [10], categories: null, showMarker: true });
+    const baseline = recordingCtx();
+    renderChart(
+      baseline.ctx,
+      scatterModel({ showLegend: false, scatterStyle: 'marker', series: [resolved] }),
+      RECT,
+      1,
+    );
+
+    const rec = recordingCtx();
+    renderChart(
+      rec.ctx,
+      scatterModel({
+        showLegend: false,
+        scatterStyle: 'marker',
+        series: [
+          resolved,
+          series({
+            name: 'unresolved',
+            values: [1_000_000],
+            categories: [],
+            showMarker: true,
+          }),
+        ],
+      }),
+      RECT,
+      1,
+    );
+
+    expect(baseline.plotMarkerYs).toHaveLength(1);
+    expect(rec.plotMarkerYs).toHaveLength(1);
+    expect(rec.plotMarkerYs[0]).toBeCloseTo(baseline.plotMarkerYs[0]);
   });
 });

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -348,6 +348,7 @@ function buildLegendEntries(
   chartType: string | undefined,
   scatterStyle?: string | null,
   varyByPoint = false,
+  chartCategories: string[] = [],
 ): LegendEntry[] {
   if (varyByPoint || legendIsCategoryDriven(chartType)) {
     // Category-driven: one entry per data point of the first series, labeled by
@@ -355,7 +356,7 @@ function buildLegendEntries(
     // point (pie slice, or a varyColors bar). §21.2.2.227.
     const first = series[0];
     const n = first ? first.values.length : 0;
-    const cats = first?.categories ?? [];
+    const cats = first?.categories ?? chartCategories;
     return Array.from({ length: n }, (_, i) => ({
       label: (cats[i] ?? `Item ${i + 1}`).toString(),
       color: legendEntryColor(chartType, series, i, varyByPoint),
@@ -396,10 +397,11 @@ function drawLegend(
   style: LegendTextStyle = DEFAULT_LEGEND_STYLE,
   scatterStyle?: string | null,
   varyByPoint = false,
+  chartCategories: string[] = [],
 ): void {
   const sw = 10; const gap = 4;
   const swatchStyle = legendSwatchStyle(chartType);
-  const entries = buildLegendEntries(series, chartType, scatterStyle, varyByPoint);
+  const entries = buildLegendEntries(series, chartType, scatterStyle, varyByPoint, chartCategories);
   const boldPrefix = style.bold ? 'bold ' : '';
   if (orient === 'horizontal') {
     // Excel lays a bottom/top legend as a single horizontal row, centered.
@@ -492,21 +494,21 @@ function drawLegendForLayout(
     // when on left/right. A manual box wider than tall implies horizontal —
     // matches Excel's one-row legend rendering for top/bottom manual layouts.
     const orient = lw >= lh ? 'horizontal' : 'vertical';
-    drawLegend(ctx, chart.series, lx, ly, lw, lh, orient, chart.chartType, legStyle, chart.scatterStyle, varyByPoint);
+    drawLegend(ctx, chart.series, lx, ly, lw, lh, orient, chart.chartType, legStyle, chart.scatterStyle, varyByPoint, chart.categories);
     return;
   }
   switch (leg.side) {
     case 'r':
-      drawLegend(ctx, chart.series, x + w - leg.reserveW + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle, chart.scatterStyle, varyByPoint);
+      drawLegend(ctx, chart.series, x + w - leg.reserveW + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle, chart.scatterStyle, varyByPoint, chart.categories);
       break;
     case 'l':
-      drawLegend(ctx, chart.series, x + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle, chart.scatterStyle, varyByPoint);
+      drawLegend(ctx, chart.series, x + 4, py0, leg.reserveW - 8, ph, 'vertical', chart.chartType, legStyle, chart.scatterStyle, varyByPoint, chart.categories);
       break;
     case 't':
-      drawLegend(ctx, chart.series, px0, y + topBand, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle, chart.scatterStyle, varyByPoint);
+      drawLegend(ctx, chart.series, px0, y + topBand, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle, chart.scatterStyle, varyByPoint, chart.categories);
       break;
     case 'b':
-      drawLegend(ctx, chart.series, px0, y + h - leg.reserveH, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle, chart.scatterStyle, varyByPoint);
+      drawLegend(ctx, chart.series, px0, y + h - leg.reserveH, pw, leg.reserveH, 'horizontal', chart.chartType, legStyle, chart.scatterStyle, varyByPoint, chart.categories);
       break;
   }
 }
@@ -3483,6 +3485,14 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
 // (`useSecondaryAxis` / a right-hand `<c:valAx>` pairs with a category-based
 // family). So `computeSecondaryAxis` is never called here — the CH7 helper is
 // wired only into the category-axis families (bar already; line + area now).
+function scatterXValue(cats: string[], index: number, useIndexX: boolean): number | null {
+  if (useIndexX) return index;
+  const raw = cats[index];
+  if (raw == null) return null;
+  const value = parseFloat(raw);
+  return Number.isNaN(value) ? null : value;
+}
+
 function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: ChartRect, ptToPx: number): void {
   const { x, y, w, h } = r;
   // Shared frame bands. Title + bottom axis-label bands follow PowerPoint's
@@ -3543,14 +3553,32 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   // X / Y data extents.
   const allX: number[] = []; const allY: number[] = [];
   for (const s of chart.series) {
-    const cats = s.categories ?? [];
+    const cats = s.categories ?? chart.categories;
     for (const c of cats) { const v = parseFloat(c); if (!isNaN(v)) allX.push(v); }
-    for (const v of s.values) if (v != null) allY.push(v);
   }
   const useIndexX = allX.length === 0;
   if (useIndexX) {
     const maxLen = Math.max(...chart.series.map(s => s.values.length));
     for (let i = 0; i < maxLen; i++) allX.push(i);
+    for (const s of chart.series) {
+      for (const value of s.values) if (value != null) allY.push(value);
+    }
+  } else {
+    // Numeric scatter/bubble axes are derived only from paintable X/Y pairs.
+    // A distinct unresolved X source is represented by `categories: []`; its
+    // Y values must not stretch the value axis when none of its points render.
+    allX.length = 0;
+    for (const s of chart.series) {
+      const cats = s.categories ?? chart.categories;
+      for (let i = 0; i < s.values.length; i++) {
+        const y = s.values[i];
+        if (y == null) continue;
+        const x = scatterXValue(cats, i, false);
+        if (x == null) continue;
+        allX.push(x);
+        allY.push(y);
+      }
+    }
   }
 
   let xMin = Math.min(...allX); let xMax = Math.max(...allX);
@@ -3702,7 +3730,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   for (let si = 0; si < chart.series.length; si++) {
     const s = chart.series[si];
     const fallbackColor = chartColor(si, s);
-    const cats = s.categories ?? [];
+    const cats = s.categories ?? chart.categories;
 
     // Error bars (drawn first so markers overlay the bar tip).
     for (const eb of s.errBars ?? []) {
@@ -3718,8 +3746,8 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       const pts: Array<{ x: number; y: number }> = [];
       for (let ci = 0; ci < s.values.length; ci++) {
         const yv = s.values[ci]; if (yv == null) continue;
-        const xv = useIndexX ? ci : parseFloat(cats[ci] ?? '0');
-        if (isNaN(xv)) continue;
+        const xv = scatterXValue(cats, ci, useIndexX);
+        if (xv == null) continue;
         pts.push({ x: toX(xv), y: toY(yv) });
       }
       if (pts.length >= 2) {
@@ -3772,8 +3800,8 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
 
       for (let ci = 0; ci < s.values.length; ci++) {
         const yv = s.values[ci]; if (yv == null) continue;
-        const xv = useIndexX ? ci : parseFloat(cats[ci] ?? '0');
-        if (isNaN(xv)) continue;
+        const xv = scatterXValue(cats, ci, useIndexX);
+        if (xv == null) continue;
         const dpt = (s.dataPointOverrides ?? []).find(d => d.idx === ci);
         const symbol = (dpt?.markerSymbol ?? s.markerSymbol ?? 'circle') as string;
         let sizePt = dpt?.markerSize ?? s.markerSize ?? 5;
@@ -3940,8 +3968,8 @@ function drawSeriesErrorBars(
   const capHalf = ctx.lineWidth * 1.5;
   for (let i = 0; i < s.values.length; i++) {
     const yv = s.values[i]; if (yv == null) continue;
-    const xv = useIndexX ? i : parseFloat(cats[i] ?? '0');
-    if (isNaN(xv)) continue;
+    const xv = scatterXValue(cats, i, useIndexX);
+    if (xv == null) continue;
     const px = toX(xv); const py = toY(yv);
     const drawSeg = (dataDelta: number) => {
       let x2 = px, y2 = py;
@@ -4009,8 +4037,8 @@ function drawSeriesDataLabels(
   const seriesDef = s.seriesDataLabels;
   for (let i = 0; i < s.values.length; i++) {
     const yv = s.values[i]; if (yv == null) continue;
-    const xv = useIndexX ? i : parseFloat(cats[i] ?? '0');
-    if (isNaN(xv)) continue;
+    const xv = scatterXValue(cats, i, useIndexX);
+    if (xv == null) continue;
     const ovr = overrides.find(o => o.idx === i);
     // A genuine `<c:delete val="1"/>` (§21.2.2.43) skips the point; a per-point
     // `<c:dLbl>` that only carries style / flag overrides (empty `<c:tx>`) is NOT

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -3195,6 +3195,89 @@ pub fn collect_num_cache_positional(ser_node: Node, child_tag: &str) -> Vec<Opti
     result
 }
 
+/// Package-specific resolver for legacy chart formulas whose authored cache or
+/// literal is absent. DrawingML owns the series-field walk; a host package such
+/// as XLSX supplies only the external data lookup. DOCX and PPTX use the
+/// no-op resolver through [`parse_chart_part`].
+pub trait ChartReferenceResolver {
+    /// `None` means the host could not resolve the formula. `Some` with an
+    /// empty or all-gap vector is a successfully resolved empty range.
+    fn resolve_strings(&mut self, formula: &str) -> Option<Vec<String>>;
+    fn resolve_numbers(&mut self, formula: &str) -> Option<Vec<Option<f64>>>;
+}
+
+struct EmptyChartReferenceResolver;
+
+impl ChartReferenceResolver for EmptyChartReferenceResolver {
+    fn resolve_strings(&mut self, _formula: &str) -> Option<Vec<String>> {
+        None
+    }
+
+    fn resolve_numbers(&mut self, _formula: &str) -> Option<Vec<Option<f64>>> {
+        None
+    }
+}
+
+fn has_authored_reference_data(container: Node<'_, '_>) -> bool {
+    container.descendants().any(|node| {
+        node.is_element()
+            && matches!(
+                node.tag_name().name(),
+                "strCache" | "numCache" | "multiLvlStrCache" | "strLit" | "numLit"
+            )
+    })
+}
+
+fn reference_formula(container: Node<'_, '_>) -> Option<String> {
+    container
+        .descendants()
+        .find(|node| node.is_element() && node.tag_name().name() == "f")
+        .and_then(|node| node.text())
+        .map(str::trim)
+        .filter(|formula| !formula.is_empty())
+        .map(str::to_owned)
+}
+
+fn collect_string_source(
+    ser_node: Node<'_, '_>,
+    child_tag: &str,
+    references: &mut dyn ChartReferenceResolver,
+) -> Option<Vec<String>> {
+    let container = ser_node
+        .children()
+        .find(|node| node.is_element() && node.tag_name().name() == child_tag)?;
+    if has_authored_reference_data(container) {
+        return Some(collect_str_cache_positional(ser_node, child_tag));
+    }
+    reference_formula(container).and_then(|formula| references.resolve_strings(&formula))
+}
+
+fn collect_number_source(
+    ser_node: Node<'_, '_>,
+    child_tag: &str,
+    references: &mut dyn ChartReferenceResolver,
+) -> Option<Vec<Option<f64>>> {
+    let container = ser_node
+        .children()
+        .find(|node| node.is_element() && node.tag_name().name() == child_tag)?;
+    if has_authored_reference_data(container) {
+        return Some(collect_num_cache_positional(ser_node, child_tag));
+    }
+    reference_formula(container).and_then(|formula| references.resolve_numbers(&formula))
+}
+
+/// Formula identity for a source that genuinely needs the host resolver.
+/// Authored caches/literals deliberately return `None`: even when their `<f>`
+/// text matches another series, their authored point data remains authoritative.
+fn external_reference_formula(ser_node: Node<'_, '_>, child_tag: &str) -> Option<String> {
+    let container = ser_node
+        .children()
+        .find(|node| node.is_element() && node.tag_name().name() == child_tag)?;
+    (!has_authored_reference_data(container))
+        .then(|| reference_formula(container))
+        .flatten()
+}
+
 /// Parse the shared body of a legacy DrawingML chart (`c:` namespace) into a
 /// [`ChartModel`]. `chart_root` is the `<c:chartSpace>` root element; the
 /// crate-specific `<a:solidFill>` resolution (pptx theme map vs. xlsx theme
@@ -3218,6 +3301,19 @@ pub fn collect_num_cache_positional(ser_node: Node, child_tag: &str) -> Vec<Opti
 pub fn parse_chart_part(
     chart_root: Node,
     color_resolver: &dyn ColorResolver,
+) -> Option<ChartModel> {
+    let mut references = EmptyChartReferenceResolver;
+    parse_chart_part_with_references(chart_root, color_resolver, &mut references)
+}
+
+/// Parse a legacy chart with an optional package-supplied formula resolver.
+/// Authored caches and literals always win; the resolver is called only for a
+/// formula-only reference. This keeps series identity and field dispatch in the
+/// shared DrawingML parser while leaving workbook lookup to the host package.
+pub fn parse_chart_part_with_references(
+    chart_root: Node,
+    color_resolver: &dyn ColorResolver,
+    references: &mut dyn ChartReferenceResolver,
 ) -> Option<ChartModel> {
     let root = chart_root;
 
@@ -3471,13 +3567,6 @@ pub fn parse_chart_part(
         return None;
     }
 
-    // ECMA-376 §21.2.2: category data may be in a *Cache (backing a *Ref) or a *Lit (inline literal).
-    // Accept strCache/numCache (external refs with cached values) AND strLit/numLit (inline literals).
-    // Still used for the series-name lookup below; category/value data now flows
-    // through the positional collectors.
-    let is_pt_container =
-        |name: &str| matches!(name, "strCache" | "numCache" | "strLit" | "numLit");
-
     // Chart-level category labels from the first series, using the POSITIONAL
     // collector so a sparse cache (labels that start at `idx=1`, or a hole in
     // the middle) keeps its true length and per-index alignment. The old
@@ -3487,11 +3576,10 @@ pub fn parse_chart_part(
     // so read that instead — the shared category list mirrors the first series'
     // X data, matching how Excel drives the horizontal-axis labels.
     let chart_uses_xval = chart_type == "scatter" || chart_type == "bubble";
-    let categories: Vec<String> = if chart_uses_xval {
-        collect_str_cache_positional(ser_nodes[0], "xVal")
-    } else {
-        collect_str_cache_positional(ser_nodes[0], "cat")
-    };
+    let category_tag = if chart_uses_xval { "xVal" } else { "cat" };
+    let shared_category_formula = external_reference_formula(ser_nodes[0], category_tag);
+    let categories: Vec<String> =
+        collect_string_source(ser_nodes[0], category_tag, references).unwrap_or_default();
 
     let is_scatter_like = chart_type == "scatter" || chart_type == "bubble";
 
@@ -3525,7 +3613,8 @@ pub fn parse_chart_part(
 
     let series: Vec<ChartSeries> = ser_nodes
         .iter()
-        .map(|ser| {
+        .enumerate()
+        .map(|(series_position, ser)| {
             // Each `<c:ser>` is a direct child of its chart-group element
             // (`<c:barChart>`/`<c:lineChart>`/…). `series_type` carries that
             // group's type so the renderer can draw line-group series as a line
@@ -3545,25 +3634,12 @@ pub fn parse_chart_part(
             };
 
             // Series name from <c:tx>  (can be strRef/strCache, strLit, or a bare <c:v>)
-            let name = ser
-                .children()
-                .find(|n| n.is_element() && n.tag_name().name() == "tx")
-                .and_then(|tx| {
-                    // Preferred: first pt > v inside any cache/lit container
-                    tx.descendants()
-                        .find(|n| n.is_element() && is_pt_container(n.tag_name().name()))
-                        .and_then(|cache| {
-                            cache
-                                .children()
-                                .find(|n| n.is_element() && n.tag_name().name() == "pt")
-                                .and_then(|pt| {
-                                    pt.children()
-                                        .find(|n| n.is_element() && n.tag_name().name() == "v")
-                                })
-                                .and_then(|v| v.text().map(|t| t.to_string()))
-                        })
-                        // Fallback: <c:tx><c:v>Name</c:v></c:tx>
-                        .or_else(|| {
+            let name = collect_string_source(*ser, "tx", references)
+                .and_then(|values| values.into_iter().next())
+                .or_else(|| {
+                    ser.children()
+                        .find(|n| n.is_element() && n.tag_name().name() == "tx")
+                        .and_then(|tx| {
                             tx.children()
                                 .find(|n| n.is_element() && n.tag_name().name() == "v")
                                 .and_then(|v| v.text().map(|t| t.to_string()))
@@ -3581,26 +3657,31 @@ pub fn parse_chart_part(
 
             // Per-series category labels. Scatter/bubble put numeric X data in
             // `<c:xVal>` (ECMA-376 §21.2.2.43); every other type reads the
-            // series' own `<c:cat>`, falling back to the shared chart-level
-            // `categories` when this series carries none (mixed / combo charts
-            // share one category axis). Emitted as `None` only when the resulting
-            // list is empty, matching the historical xlsx wire shape (every
-            // series carried its resolved `categories`).
+            // series' own `<c:cat>`. The first series is already represented by
+            // chart-level `categories`; repeated live formulas also use that
+            // canonical vector instead of resolving and retaining duplicate
+            // copies. `ChartSeries.categories = None` explicitly means to fall
+            // back to `ChartModel.categories` (the shared TS contract). Authored
+            // caches/literals and genuinely distinct formulas remain per-series.
             let series_categories: Option<Vec<String>> = {
-                let cats = if is_scatter_like {
-                    collect_str_cache_positional(*ser, "xVal")
-                } else {
-                    let own = collect_str_cache_positional(*ser, "cat");
-                    if own.is_empty() {
-                        categories.clone()
-                    } else {
-                        own
-                    }
-                };
-                if cats.is_empty() {
+                let own_formula = external_reference_formula(*ser, category_tag);
+                let shares_chart_categories = series_position == 0
+                    || (own_formula.is_some()
+                        && own_formula.as_deref() == shared_category_formula.as_deref());
+                if shares_chart_categories {
                     None
                 } else {
-                    Some(cats)
+                    let has_own_source = ser
+                        .children()
+                        .any(|node| node.is_element() && node.tag_name().name() == category_tag);
+                    match collect_string_source(*ser, category_tag, references) {
+                        Some(own) if is_scatter_like || !own.is_empty() => Some(own),
+                        // A distinct scatter/bubble X source that cannot be
+                        // resolved must not inherit the first series' X values.
+                        // `Some([])` explicitly suppresses that fallback.
+                        None if is_scatter_like && has_own_source => Some(Vec::new()),
+                        _ => None,
+                    }
                 }
             };
 
@@ -3611,7 +3692,8 @@ pub fn parse_chart_part(
             // than there are cat labels (cat-less line, sparse radar) keeps all
             // of its data.
             let val_tag = if is_scatter_like { "yVal" } else { "val" };
-            let values: Vec<Option<f64>> = collect_num_cache_positional(*ser, val_tag);
+            let values: Vec<Option<f64>> =
+                collect_number_source(*ser, val_tag, references).unwrap_or_default();
             let series_pt_count = values.len().max(1);
             // Value-cache node for the series-value number format (`<c:formatCode>`).
             let val_cache = ser
@@ -3628,32 +3710,8 @@ pub fn parse_chart_part(
             // Bubble per-point sizes (ECMA-376 §21.2.2.4 `<c:bubbleSize>`).
             // Only meaningful for bubble charts; scatter / others ignore.
             let bubble_sizes: Option<Vec<Option<f64>>> = if chart_type == "bubble" {
-                let bub_cache = ser
-                    .children()
-                    .find(|n| n.is_element() && n.tag_name().name() == "bubbleSize")
-                    .and_then(|b| {
-                        b.descendants().find(|n| {
-                            n.is_element()
-                                && (n.tag_name().name() == "numCache"
-                                    || n.tag_name().name() == "numLit")
-                        })
-                    });
-                bub_cache.map(|cache| {
-                    let mut sizes: Vec<Option<f64>> = vec![None; series_pt_count];
-                    for pt in cache
-                        .children()
-                        .filter(|n| n.is_element() && n.tag_name().name() == "pt")
-                    {
-                        let idx: usize = attr(&pt, "idx").and_then(|v| v.parse().ok()).unwrap_or(0);
-                        let val: Option<f64> = pt
-                            .children()
-                            .find(|n| n.is_element() && n.tag_name().name() == "v")
-                            .and_then(|v| v.text())
-                            .and_then(|t| t.parse().ok());
-                        if idx < sizes.len() {
-                            sizes[idx] = val;
-                        }
-                    }
+                collect_number_source(*ser, "bubbleSize", references).map(|mut sizes| {
+                    sizes.resize(sizes.len().max(series_pt_count), None);
                     sizes
                 })
             } else {
@@ -7442,5 +7500,158 @@ mod tests {
         let m = parse_chart_part(d.root_element(), &FixtureResolver).expect("parses");
         assert_eq!(m.series.len(), 2);
         assert_eq!(m.title, None);
+    }
+
+    struct FormulaResolver;
+
+    impl ChartReferenceResolver for FormulaResolver {
+        fn resolve_strings(&mut self, formula: &str) -> Option<Vec<String>> {
+            Some(match formula {
+                "Name" => vec!["Resolved series".into()],
+                "X" => vec!["1".into(), "2".into()],
+                "CachedCats" => vec!["live value must not win".into()],
+                _ => return None,
+            })
+        }
+
+        fn resolve_numbers(&mut self, formula: &str) -> Option<Vec<Option<f64>>> {
+            Some(match formula {
+                "Y" => vec![Some(10.0), Some(20.0)],
+                "Size" => vec![Some(3.0), Some(5.0)],
+                _ => return None,
+            })
+        }
+    }
+
+    #[test]
+    fn parse_chart_part_resolves_cacheless_bubble_fields() {
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}"><c:chart><c:plotArea><c:bubbleChart>
+              <c:ser><c:idx val="0"/><c:order val="0"/>
+                <c:tx><c:strRef><c:f>Name</c:f></c:strRef></c:tx>
+                <c:xVal><c:numRef><c:f>X</c:f></c:numRef></c:xVal>
+                <c:yVal><c:numRef><c:f>Y</c:f></c:numRef></c:yVal>
+                <c:bubbleSize><c:numRef><c:f>Size</c:f></c:numRef></c:bubbleSize>
+              </c:ser>
+            </c:bubbleChart></c:plotArea></c:chart></c:chartSpace>"#
+        );
+        let doc = root_of(&xml);
+        let mut references = FormulaResolver;
+        let chart =
+            parse_chart_part_with_references(doc.root_element(), &FixtureResolver, &mut references)
+                .expect("bubble chart parses");
+
+        assert_eq!(chart.categories, vec!["1", "2"]);
+        assert_eq!(chart.series[0].name, "Resolved series");
+        assert_eq!(chart.series[0].categories, None);
+        assert_eq!(chart.series[0].values, vec![Some(10.0), Some(20.0)]);
+        assert_eq!(
+            chart.series[0].bubble_sizes,
+            Some(vec![Some(3.0), Some(5.0)])
+        );
+    }
+
+    #[test]
+    fn parse_chart_part_keeps_unresolved_cacheless_bubble_sizes_absent() {
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}"><c:chart><c:plotArea><c:bubbleChart>
+              <c:ser><c:idx val="0"/><c:order val="0"/>
+                <c:xVal><c:numRef><c:f>X</c:f></c:numRef></c:xVal>
+                <c:yVal><c:numRef><c:f>Y</c:f></c:numRef></c:yVal>
+                <c:bubbleSize><c:numRef><c:f>Size</c:f></c:numRef></c:bubbleSize>
+              </c:ser>
+            </c:bubbleChart></c:plotArea></c:chart></c:chartSpace>"#
+        );
+        let doc = root_of(&xml);
+        let chart = parse_chart_part(doc.root_element(), &FixtureResolver)
+            .expect("cacheless bubble chart still parses");
+
+        assert_eq!(chart.categories, Vec::<String>::new());
+        assert_eq!(chart.series[0].categories, None);
+        assert_eq!(chart.series[0].values, Vec::<Option<f64>>::new());
+        assert_eq!(chart.series[0].bubble_sizes, None);
+    }
+
+    struct CountingCategoryResolver {
+        string_calls: usize,
+    }
+
+    impl ChartReferenceResolver for CountingCategoryResolver {
+        fn resolve_strings(&mut self, formula: &str) -> Option<Vec<String>> {
+            self.string_calls += 1;
+            (formula == "Cats").then(|| vec!["A".into(), "B".into(), "C".into()])
+        }
+
+        fn resolve_numbers(&mut self, _formula: &str) -> Option<Vec<Option<f64>>> {
+            None
+        }
+    }
+
+    #[test]
+    fn parse_chart_part_resolves_shared_categories_once_without_series_clones() {
+        let first = r#"<c:ser><c:idx val="0"/><c:order val="0"/><c:cat><c:strRef><c:f>Cats</c:f></c:strRef></c:cat><c:val><c:numLit><c:ptCount val="1"/><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:val></c:ser>"#;
+        let repeated = r#"<c:ser><c:idx val="1"/><c:order val="1"/><c:cat><c:strRef><c:f>Cats</c:f></c:strRef></c:cat><c:val><c:numLit><c:ptCount val="1"/><c:pt idx="0"><c:v>2</c:v></c:pt></c:numLit></c:val></c:ser>"#;
+        let category_less: String = (2..12)
+            .map(|idx| format!(r#"<c:ser><c:idx val="{idx}"/><c:order val="{idx}"/><c:val><c:numLit><c:ptCount val="1"/><c:pt idx="0"><c:v>{idx}</c:v></c:pt></c:numLit></c:val></c:ser>"#))
+            .collect();
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}"><c:chart><c:plotArea><c:lineChart>{first}{repeated}{category_less}</c:lineChart></c:plotArea></c:chart></c:chartSpace>"#
+        );
+        let doc = root_of(&xml);
+        let mut references = CountingCategoryResolver { string_calls: 0 };
+        let chart =
+            parse_chart_part_with_references(doc.root_element(), &FixtureResolver, &mut references)
+                .expect("multi-series chart parses");
+
+        assert_eq!(references.string_calls, 1);
+        assert_eq!(chart.categories, vec!["A", "B", "C"]);
+        assert_eq!(chart.series.len(), 12);
+        assert!(chart
+            .series
+            .iter()
+            .all(|series| series.categories.is_none()));
+    }
+
+    #[test]
+    fn parse_chart_part_does_not_reuse_first_x_for_unresolved_distinct_scatter_x() {
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}"><c:chart><c:plotArea><c:scatterChart>
+              <c:ser><c:idx val="0"/><c:order val="0"/><c:xVal><c:numRef><c:f>X</c:f></c:numRef></c:xVal><c:yVal><c:numLit><c:ptCount val="2"/><c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt></c:numLit></c:yVal></c:ser>
+              <c:ser><c:idx val="1"/><c:order val="1"/><c:xVal><c:numRef><c:f>UnavailableX</c:f></c:numRef></c:xVal><c:yVal><c:numLit><c:ptCount val="2"/><c:pt idx="0"><c:v>3</c:v></c:pt><c:pt idx="1"><c:v>4</c:v></c:pt></c:numLit></c:yVal></c:ser>
+              <c:ser><c:idx val="2"/><c:order val="2"/><c:xVal><c:numRef><c:f>X</c:f><c:numCache><c:ptCount val="0"/></c:numCache></c:numRef></c:xVal><c:yVal><c:numLit><c:ptCount val="1"/><c:pt idx="0"><c:v>5</c:v></c:pt></c:numLit></c:yVal></c:ser>
+            </c:scatterChart></c:plotArea></c:chart></c:chartSpace>"#
+        );
+        let doc = root_of(&xml);
+        let mut references = FormulaResolver;
+        let chart =
+            parse_chart_part_with_references(doc.root_element(), &FixtureResolver, &mut references)
+                .expect("two-series scatter parses");
+
+        assert_eq!(chart.categories, vec!["1", "2"]);
+        assert_eq!(chart.series[0].categories, None);
+        assert_eq!(chart.series[1].categories, Some(Vec::new()));
+        assert_eq!(chart.series[2].categories, Some(Vec::new()));
+    }
+
+    #[test]
+    fn parse_chart_part_preserves_authored_multilevel_cache() {
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}"><c:chart><c:plotArea><c:barChart>
+              <c:barDir val="col"/><c:ser><c:idx val="0"/><c:order val="0"/>
+                <c:cat><c:multiLvlStrRef><c:f>CachedCats</c:f><c:multiLvlStrCache>
+                  <c:ptCount val="2"/><c:lvl><c:pt idx="0"><c:v>Authored A</c:v></c:pt><c:pt idx="1"><c:v>Authored B</c:v></c:pt></c:lvl>
+                </c:multiLvlStrCache></c:multiLvlStrRef></c:cat>
+                <c:val><c:numLit><c:ptCount val="2"/><c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt></c:numLit></c:val>
+              </c:ser>
+            </c:barChart></c:plotArea></c:chart></c:chartSpace>"#
+        );
+        let doc = root_of(&xml);
+        let mut references = FormulaResolver;
+        let chart =
+            parse_chart_part_with_references(doc.root_element(), &FixtureResolver, &mut references)
+                .expect("bar chart parses");
+
+        assert_eq!(chart.categories, vec!["Authored A", "Authored B"]);
+        assert_eq!(chart.series[0].categories, None);
     }
 }

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -1,144 +1,75 @@
 use crate::types::*;
-use crate::worksheet_reference::{resolve_worksheet_reference, ReferencedCellValue};
+use crate::worksheet_reference::{
+    resolve_worksheet_reference, ReferencedCellValue, WorksheetReferenceSession,
+};
 use crate::{find_rel_target_by_type, parse_rels_map, resolve_fill_color, resolve_zip_path};
 use ooxml_common::depth::parse_guarded;
 use ooxml_common::ns::{is_c_ns, is_r_ns, is_xdr_ns};
 use ooxml_common::zip::read_zip_string;
-use std::collections::HashMap;
 
-#[derive(Clone, Copy)]
-pub(crate) struct ChartReferenceContext<'a, 'input> {
+pub(crate) struct ChartReferenceContext<'a, 'input, 'session> {
     pub(crate) sheet_xml: &'a str,
     pub(crate) sheet_name: &'a str,
     pub(crate) sheets: &'a [SheetMeta],
     pub(crate) workbook_rels: &'a roxmltree::Document<'input>,
     pub(crate) shared_strings: &'a [SharedString],
+    pub(crate) session: &'session mut WorksheetReferenceSession,
 }
 
-fn reference_formula_without_authored_data(
-    series: roxmltree::Node<'_, '_>,
-    field_name: &str,
-) -> Option<String> {
-    let field = series
-        .children()
-        .find(|node| node.is_element() && node.tag_name().name() == field_name)?;
-    if field.descendants().any(|node| {
-        node.is_element()
-            && matches!(
-                node.tag_name().name(),
-                "strCache" | "numCache" | "strLit" | "numLit"
-            )
-    }) {
-        return None;
+struct XlsxChartReferenceResolver<'archive, 'data, 'input, 'session> {
+    archive: &'archive mut crate::XlsxZip,
+    sheet_xml: &'data str,
+    sheet_name: &'data str,
+    sheets: &'data [SheetMeta],
+    workbook_rels: &'data roxmltree::Document<'input>,
+    shared_strings: &'data [SharedString],
+    session: &'session mut WorksheetReferenceSession,
+}
+
+impl ooxml_common::chart::ChartReferenceResolver for XlsxChartReferenceResolver<'_, '_, '_, '_> {
+    fn resolve_strings(&mut self, formula: &str) -> Option<Vec<String>> {
+        resolve_worksheet_reference(
+            self.archive,
+            formula,
+            self.sheet_xml,
+            self.sheet_name,
+            self.sheets,
+            self.workbook_rels,
+            self.shared_strings,
+            self.session,
+        )
+        .map(|values| {
+            values
+                .into_iter()
+                .map(|value| match value {
+                    ReferencedCellValue::Text(text) => text,
+                    ReferencedCellValue::Number(number) => number.to_string(),
+                    ReferencedCellValue::Empty => String::new(),
+                })
+                .collect()
+        })
     }
-    field
-        .descendants()
-        .find(|node| node.is_element() && node.tag_name().name() == "f")
-        .and_then(|node| node.text())
-        .map(str::trim)
-        .filter(|formula| !formula.is_empty())
-        .map(str::to_owned)
-}
 
-fn text_values(values: Vec<ReferencedCellValue>) -> Vec<String> {
-    values
-        .into_iter()
-        .map(|value| match value {
-            ReferencedCellValue::Text(text) => text,
-            ReferencedCellValue::Number(number) => number.to_string(),
-            ReferencedCellValue::Empty => String::new(),
+    fn resolve_numbers(&mut self, formula: &str) -> Option<Vec<Option<f64>>> {
+        resolve_worksheet_reference(
+            self.archive,
+            formula,
+            self.sheet_xml,
+            self.sheet_name,
+            self.sheets,
+            self.workbook_rels,
+            self.shared_strings,
+            self.session,
+        )
+        .map(|values| {
+            values
+                .into_iter()
+                .map(|value| match value {
+                    ReferencedCellValue::Number(number) => Some(number),
+                    _ => None,
+                })
+                .collect()
         })
-        .collect()
-}
-
-fn numeric_values(values: Vec<ReferencedCellValue>) -> Vec<Option<f64>> {
-    values
-        .into_iter()
-        .map(|value| match value {
-            ReferencedCellValue::Number(number) => Some(number),
-            _ => None,
-        })
-        .collect()
-}
-
-#[allow(clippy::too_many_arguments)]
-fn hydrate_legacy_chart_references(
-    archive: &mut crate::XlsxZip,
-    chart_root: roxmltree::Node<'_, '_>,
-    chart: &mut ooxml_common::chart::ChartModel,
-    sheet_xml: &str,
-    sheet_name: &str,
-    sheets: &[SheetMeta],
-    workbook_rels: &roxmltree::Document<'_>,
-    shared_strings: &[SharedString],
-) {
-    // ECMA-376 chart schemas make CT_StrRef.strCache and CT_NumRef.numCache
-    // optional. XLSX can therefore carry only worksheet formulas; resolve those
-    // here, where workbook sheets are available, without teaching the shared
-    // chart parser about SpreadsheetML packages.
-    let Some(plot_area) = chart_root
-        .descendants()
-        .find(|node| node.is_element() && node.tag_name().name() == "plotArea")
-    else {
-        return;
-    };
-    let source_series: Vec<_> = plot_area
-        .descendants()
-        .filter(|node| node.is_element() && node.tag_name().name() == "ser")
-        .collect();
-    let mut xml_cache: HashMap<String, Option<String>> = HashMap::new();
-
-    for (source, target) in source_series.into_iter().zip(chart.series.iter_mut()) {
-        if let Some(formula) = reference_formula_without_authored_data(source, "tx") {
-            let values = resolve_worksheet_reference(
-                archive,
-                &formula,
-                sheet_xml,
-                sheet_name,
-                sheets,
-                workbook_rels,
-                shared_strings,
-                &mut xml_cache,
-            );
-            if let Some(name) = text_values(values).into_iter().next() {
-                target.name = name;
-            }
-        }
-
-        if let Some(formula) = reference_formula_without_authored_data(source, "cat") {
-            let categories = text_values(resolve_worksheet_reference(
-                archive,
-                &formula,
-                sheet_xml,
-                sheet_name,
-                sheets,
-                workbook_rels,
-                shared_strings,
-                &mut xml_cache,
-            ));
-            if !categories.is_empty() {
-                if chart.categories.is_empty() {
-                    chart.categories = categories.clone();
-                }
-                target.categories = Some(categories);
-            }
-        }
-
-        if let Some(formula) = reference_formula_without_authored_data(source, "val") {
-            let values = numeric_values(resolve_worksheet_reference(
-                archive,
-                &formula,
-                sheet_xml,
-                sheet_name,
-                sheets,
-                workbook_rels,
-                shared_strings,
-                &mut xml_cache,
-            ));
-            if !values.is_empty() {
-                target.values = values;
-            }
-        }
     }
 }
 
@@ -163,7 +94,7 @@ fn load_chart_style_xml(archive: &mut crate::XlsxZip, chart_path: &str) -> Optio
 pub(crate) fn load_sheet_charts(
     archive: &mut crate::XlsxZip,
     sheet_path: &str,
-    reference_context: Option<ChartReferenceContext<'_, '_>>,
+    mut reference_context: Option<ChartReferenceContext<'_, '_, '_>>,
     theme_colors: &[String],
     theme_fonts: (Option<&str>, Option<&str>),
 ) -> Vec<ChartAnchor> {
@@ -220,7 +151,7 @@ pub(crate) fn load_sheet_charts(
         // Iterate over chart anchors. Charts may be saved either as a
         // `<xdr:twoCellAnchor>` (from + to cells — Excel's default) or a
         // `<xdr:oneCellAnchor>` (from cell + a saved `<xdr:ext cx cy>` EMU
-        // size, ECMA-376 §20.5.2.16). openpyxl and some other writers emit
+        // size, ECMA-376 §20.5.2.24). openpyxl and some other writers emit
         // oneCellAnchor; both must produce a chart.
         for anchor in draw_doc
             .root_element()
@@ -337,7 +268,7 @@ pub(crate) fn load_sheet_charts(
             }
 
             // For a oneCellAnchor the `<to>` corner is absent; the chart's
-            // size is the saved EMU extent (ECMA-376 §20.5.2.16). Encode it as
+            // size is the saved EMU extent (ECMA-376 §20.5.2.24). Encode it as
             // a `to` corner pinned to the `from` cell plus the extent offset so
             // the renderer's from/to → pixel math yields exactly `ext` px.
             if is_one_cell {
@@ -388,26 +319,27 @@ pub(crate) fn load_sheet_charts(
                     &resolver,
                     style_xml.as_deref(),
                 )
+            } else if let Some(context) = reference_context.as_mut() {
+                let mut references = XlsxChartReferenceResolver {
+                    archive,
+                    sheet_xml: context.sheet_xml,
+                    sheet_name: context.sheet_name,
+                    sheets: context.sheets,
+                    workbook_rels: context.workbook_rels,
+                    shared_strings: context.shared_strings,
+                    session: context.session,
+                };
+                ooxml_common::chart::parse_chart_part_with_references(
+                    chart_doc.root_element(),
+                    &resolver,
+                    &mut references,
+                )
             } else {
                 ooxml_common::chart::parse_chart_part(chart_doc.root_element(), &resolver)
             };
-            let Some(mut chart) = chart_opt else {
+            let Some(chart) = chart_opt else {
                 continue;
             };
-            if !is_chartex {
-                if let Some(context) = reference_context {
-                    hydrate_legacy_chart_references(
-                        archive,
-                        chart_doc.root_element(),
-                        &mut chart,
-                        context.sheet_xml,
-                        context.sheet_name,
-                        context.sheets,
-                        context.workbook_rels,
-                        context.shared_strings,
-                    );
-                }
-            }
 
             all_charts.push(ChartAnchor {
                 from_col,
@@ -721,7 +653,7 @@ mod worksheet_reference_tests {
     use zip::write::SimpleFileOptions;
 
     const DASHBOARD_XML: &str = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>"#;
-    const DATA_XML: &str = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="C1" t="inlineStr"><is><t>المبيعات</t></is></c></row><row r="2"><c r="A2" t="inlineStr"><is><t>أحمد</t></is></c><c r="C2"><v>5000</v></c></row><row r="3"><c r="A3" t="inlineStr"><is><t>سارة</t></is></c><c r="C3"><v>6200</v></c></row><row r="4"><c r="A4" t="inlineStr"><is><t>خالد</t></is></c><c r="C4"><v>7500</v></c></row></sheetData></worksheet>"#;
+    const DATA_XML: &str = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="C1" t="inlineStr"><is><t>المبيعات</t></is></c></row><row r="2"><c r="A2" t="inlineStr"><is><t>أحمد</t></is></c><c r="C2"><v>5000</v></c><c r="D2"><v>10</v></c><c r="E2"><v>3</v></c></row><row r="3"><c r="A3" t="inlineStr"><is><t>سارة</t></is></c><c r="C3"><v>6200</v></c><c r="D3"><v>20</v></c><c r="E3"><v>5</v></c></row><row r="4"><c r="A4" t="inlineStr"><is><t>خالد</t></is></c><c r="C4"><v>7500</v></c><c r="D4"><v>30</v></c><c r="E4"><v>7</v></c></row></sheetData></worksheet>"#;
 
     fn chart_xml(with_cache: bool) -> String {
         let name_cache = if with_cache {
@@ -744,12 +676,31 @@ mod worksheet_reference_tests {
         )
     }
 
-    fn archive_with_data_sheet() -> crate::XlsxZip {
+    fn cacheless_bubble_chart_xml() -> String {
+        r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart><c:plotArea><c:bubbleChart><c:ser><c:idx val="0"/><c:order val="0"/><c:tx><c:strRef><c:f>'التقرير'!C1</c:f></c:strRef></c:tx><c:xVal><c:numRef><c:f>'التقرير'!C2:C4</c:f></c:numRef></c:xVal><c:yVal><c:numRef><c:f>'التقرير'!D2:D4</c:f></c:numRef></c:yVal><c:bubbleSize><c:numRef><c:f>'التقرير'!E2:E4</c:f></c:numRef></c:bubbleSize></c:ser></c:bubbleChart></c:plotArea></c:chart></c:chartSpace>"#.into()
+    }
+
+    fn archive_with_chart_and_data(chart_xml: &str) -> crate::XlsxZip {
         let mut bytes = Vec::new();
         {
             let mut writer = zip::ZipWriter::new(Cursor::new(&mut bytes));
+            let options = SimpleFileOptions::default();
             writer
-                .start_file("xl/worksheets/sheet2.xml", SimpleFileOptions::default())
+                .start_file("xl/worksheets/_rels/sheet1.xml.rels", options)
+                .unwrap();
+            writer.write_all(br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rDrawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#).unwrap();
+            writer
+                .start_file("xl/drawings/drawing1.xml", options)
+                .unwrap();
+            writer.write_all(br#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:twoCellAnchor><xdr:from><xdr:col>6</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>1</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from><xdr:to><xdr:col>12</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>15</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to><xdr:graphicFrame><xdr:nvGraphicFramePr><xdr:cNvPr id="1" name="Chart 1"/></xdr:nvGraphicFramePr><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart r:id="rChart"/></a:graphicData></a:graphic></xdr:graphicFrame><xdr:clientData/></xdr:twoCellAnchor></xdr:wsDr>"#).unwrap();
+            writer
+                .start_file("xl/drawings/_rels/drawing1.xml.rels", options)
+                .unwrap();
+            writer.write_all(br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rChart" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/></Relationships>"#).unwrap();
+            writer.start_file("xl/charts/chart1.xml", options).unwrap();
+            writer.write_all(chart_xml.as_bytes()).unwrap();
+            writer
+                .start_file("xl/worksheets/sheet2.xml", options)
                 .unwrap();
             writer.write_all(DATA_XML.as_bytes()).unwrap();
             writer.finish().unwrap();
@@ -780,43 +731,38 @@ mod worksheet_reference_tests {
         r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rDashboard" Target="worksheets/sheet1.xml"/><Relationship Id="rData" Target="worksheets/sheet2.xml"/></Relationships>"#
     }
 
-    fn parse_model(xml: &str) -> (roxmltree::Document<'_>, ooxml_common::chart::ChartModel) {
-        let document = parse_guarded(xml).unwrap();
+    fn load_model(xml: &str) -> ooxml_common::chart::ChartModel {
+        let mut archive = archive_with_chart_and_data(xml);
+        let rels = parse_guarded(workbook_rels_xml()).unwrap();
+        let sheet_metas = sheets();
         let theme = vec!["#4472C4".into(); 12];
-        let resolver = XlsxColorResolver {
-            theme_colors: &theme,
-            theme_major_font_latin: None,
-            theme_minor_font_latin: None,
-        };
-        let chart = ooxml_common::chart::parse_chart_part(document.root_element(), &resolver)
-            .expect("chart parses");
-        (document, chart)
+        let mut session = WorksheetReferenceSession::default();
+        let charts = load_sheet_charts(
+            &mut archive,
+            "worksheets/sheet1.xml",
+            Some(ChartReferenceContext {
+                sheet_xml: DASHBOARD_XML,
+                sheet_name: "Dashboard",
+                sheets: &sheet_metas,
+                workbook_rels: &rels,
+                shared_strings: &[],
+                session: &mut session,
+            }),
+            &theme,
+            (None, None),
+        );
+        assert_eq!(charts.len(), 1);
+        charts.into_iter().next().unwrap().chart
     }
 
     #[test]
     fn cacheless_unicode_chart_resolves_cross_sheet_series() {
         let xml = chart_xml(false);
-        let (document, mut chart) = parse_model(&xml);
-        let mut archive = archive_with_data_sheet();
-        let rels = parse_guarded(workbook_rels_xml()).unwrap();
-
-        hydrate_legacy_chart_references(
-            &mut archive,
-            document.root_element(),
-            &mut chart,
-            DASHBOARD_XML,
-            "Dashboard",
-            &sheets(),
-            &rels,
-            &[],
-        );
+        let chart = load_model(&xml);
 
         assert_eq!(chart.series[0].name, "المبيعات");
         assert_eq!(chart.categories, vec!["أحمد", "سارة", "خالد"]);
-        assert_eq!(
-            chart.series[0].categories,
-            Some(vec!["أحمد".into(), "سارة".into(), "خالد".into()]),
-        );
+        assert_eq!(chart.series[0].categories, None);
         assert_eq!(
             chart.series[0].values,
             vec![Some(5000.0), Some(6200.0), Some(7500.0)],
@@ -826,24 +772,27 @@ mod worksheet_reference_tests {
     #[test]
     fn authored_chart_caches_take_precedence_over_live_cells() {
         let xml = chart_xml(true);
-        let (document, mut chart) = parse_model(&xml);
-        let mut archive = archive_with_data_sheet();
-        let rels = parse_guarded(workbook_rels_xml()).unwrap();
-
-        hydrate_legacy_chart_references(
-            &mut archive,
-            document.root_element(),
-            &mut chart,
-            DASHBOARD_XML,
-            "Dashboard",
-            &sheets(),
-            &rels,
-            &[],
-        );
+        let chart = load_model(&xml);
 
         assert_eq!(chart.series[0].name, "Cached");
         assert_eq!(chart.categories, vec!["Cached category"]);
         assert_eq!(chart.series[0].values, vec![Some(99.0)]);
+    }
+
+    #[test]
+    fn cacheless_bubble_chart_resolves_all_series_fields_through_loader() {
+        let chart = load_model(&cacheless_bubble_chart_xml());
+
+        assert_eq!(chart.categories, vec!["5000", "6200", "7500"]);
+        assert_eq!(chart.series[0].name, "المبيعات");
+        assert_eq!(
+            chart.series[0].values,
+            vec![Some(10.0), Some(20.0), Some(30.0)]
+        );
+        assert_eq!(
+            chart.series[0].bubble_sizes,
+            Some(vec![Some(3.0), Some(5.0), Some(7.0)])
+        );
     }
 }
 

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -1,8 +1,146 @@
 use crate::types::*;
+use crate::worksheet_reference::{resolve_worksheet_reference, ReferencedCellValue};
 use crate::{find_rel_target_by_type, parse_rels_map, resolve_fill_color, resolve_zip_path};
 use ooxml_common::depth::parse_guarded;
 use ooxml_common::ns::{is_c_ns, is_r_ns, is_xdr_ns};
 use ooxml_common::zip::read_zip_string;
+use std::collections::HashMap;
+
+#[derive(Clone, Copy)]
+pub(crate) struct ChartReferenceContext<'a, 'input> {
+    pub(crate) sheet_xml: &'a str,
+    pub(crate) sheet_name: &'a str,
+    pub(crate) sheets: &'a [SheetMeta],
+    pub(crate) workbook_rels: &'a roxmltree::Document<'input>,
+    pub(crate) shared_strings: &'a [SharedString],
+}
+
+fn reference_formula_without_authored_data(
+    series: roxmltree::Node<'_, '_>,
+    field_name: &str,
+) -> Option<String> {
+    let field = series
+        .children()
+        .find(|node| node.is_element() && node.tag_name().name() == field_name)?;
+    if field.descendants().any(|node| {
+        node.is_element()
+            && matches!(
+                node.tag_name().name(),
+                "strCache" | "numCache" | "strLit" | "numLit"
+            )
+    }) {
+        return None;
+    }
+    field
+        .descendants()
+        .find(|node| node.is_element() && node.tag_name().name() == "f")
+        .and_then(|node| node.text())
+        .map(str::trim)
+        .filter(|formula| !formula.is_empty())
+        .map(str::to_owned)
+}
+
+fn text_values(values: Vec<ReferencedCellValue>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|value| match value {
+            ReferencedCellValue::Text(text) => text,
+            ReferencedCellValue::Number(number) => number.to_string(),
+            ReferencedCellValue::Empty => String::new(),
+        })
+        .collect()
+}
+
+fn numeric_values(values: Vec<ReferencedCellValue>) -> Vec<Option<f64>> {
+    values
+        .into_iter()
+        .map(|value| match value {
+            ReferencedCellValue::Number(number) => Some(number),
+            _ => None,
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn hydrate_legacy_chart_references(
+    archive: &mut crate::XlsxZip,
+    chart_root: roxmltree::Node<'_, '_>,
+    chart: &mut ooxml_common::chart::ChartModel,
+    sheet_xml: &str,
+    sheet_name: &str,
+    sheets: &[SheetMeta],
+    workbook_rels: &roxmltree::Document<'_>,
+    shared_strings: &[SharedString],
+) {
+    // ECMA-376 chart schemas make CT_StrRef.strCache and CT_NumRef.numCache
+    // optional. XLSX can therefore carry only worksheet formulas; resolve those
+    // here, where workbook sheets are available, without teaching the shared
+    // chart parser about SpreadsheetML packages.
+    let Some(plot_area) = chart_root
+        .descendants()
+        .find(|node| node.is_element() && node.tag_name().name() == "plotArea")
+    else {
+        return;
+    };
+    let source_series: Vec<_> = plot_area
+        .descendants()
+        .filter(|node| node.is_element() && node.tag_name().name() == "ser")
+        .collect();
+    let mut xml_cache: HashMap<String, Option<String>> = HashMap::new();
+
+    for (source, target) in source_series.into_iter().zip(chart.series.iter_mut()) {
+        if let Some(formula) = reference_formula_without_authored_data(source, "tx") {
+            let values = resolve_worksheet_reference(
+                archive,
+                &formula,
+                sheet_xml,
+                sheet_name,
+                sheets,
+                workbook_rels,
+                shared_strings,
+                &mut xml_cache,
+            );
+            if let Some(name) = text_values(values).into_iter().next() {
+                target.name = name;
+            }
+        }
+
+        if let Some(formula) = reference_formula_without_authored_data(source, "cat") {
+            let categories = text_values(resolve_worksheet_reference(
+                archive,
+                &formula,
+                sheet_xml,
+                sheet_name,
+                sheets,
+                workbook_rels,
+                shared_strings,
+                &mut xml_cache,
+            ));
+            if !categories.is_empty() {
+                if chart.categories.is_empty() {
+                    chart.categories = categories.clone();
+                }
+                target.categories = Some(categories);
+            }
+        }
+
+        if let Some(formula) = reference_formula_without_authored_data(source, "val") {
+            let values = numeric_values(resolve_worksheet_reference(
+                archive,
+                &formula,
+                sheet_xml,
+                sheet_name,
+                sheets,
+                workbook_rels,
+                shared_strings,
+                &mut xml_cache,
+            ));
+            if !values.is_empty() {
+                target.values = values;
+            }
+        }
+    }
+}
 
 /// Read the chartStyle part (`styleN.xml`) associated with a chart part at
 /// `chart_path` (e.g. `xl/charts/chart1.xml`), following that part's own
@@ -25,6 +163,7 @@ fn load_chart_style_xml(archive: &mut crate::XlsxZip, chart_path: &str) -> Optio
 pub(crate) fn load_sheet_charts(
     archive: &mut crate::XlsxZip,
     sheet_path: &str,
+    reference_context: Option<ChartReferenceContext<'_, '_>>,
     theme_colors: &[String],
     theme_fonts: (Option<&str>, Option<&str>),
 ) -> Vec<ChartAnchor> {
@@ -252,9 +391,23 @@ pub(crate) fn load_sheet_charts(
             } else {
                 ooxml_common::chart::parse_chart_part(chart_doc.root_element(), &resolver)
             };
-            let Some(chart) = chart_opt else {
+            let Some(mut chart) = chart_opt else {
                 continue;
             };
+            if !is_chartex {
+                if let Some(context) = reference_context {
+                    hydrate_legacy_chart_references(
+                        archive,
+                        chart_doc.root_element(),
+                        &mut chart,
+                        context.sheet_xml,
+                        context.sheet_name,
+                        context.sheets,
+                        context.workbook_rels,
+                        context.shared_strings,
+                    );
+                }
+            }
 
             all_charts.push(ChartAnchor {
                 from_col,
@@ -537,6 +690,7 @@ mod hidden_tests {
             let charts = load_sheet_charts(
                 &mut archive,
                 "worksheets/sheet1.xml",
+                None,
                 &theme(),
                 (None, None),
             );
@@ -551,11 +705,145 @@ mod hidden_tests {
             let charts = load_sheet_charts(
                 &mut archive,
                 "worksheets/sheet1.xml",
+                None,
                 &theme(),
                 (None, None),
             );
             assert_eq!(charts.len(), 1, "visible chart dropped (attr={attr})");
         }
+    }
+}
+
+#[cfg(test)]
+mod worksheet_reference_tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+    use zip::write::SimpleFileOptions;
+
+    const DASHBOARD_XML: &str = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>"#;
+    const DATA_XML: &str = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="C1" t="inlineStr"><is><t>المبيعات</t></is></c></row><row r="2"><c r="A2" t="inlineStr"><is><t>أحمد</t></is></c><c r="C2"><v>5000</v></c></row><row r="3"><c r="A3" t="inlineStr"><is><t>سارة</t></is></c><c r="C3"><v>6200</v></c></row><row r="4"><c r="A4" t="inlineStr"><is><t>خالد</t></is></c><c r="C4"><v>7500</v></c></row></sheetData></worksheet>"#;
+
+    fn chart_xml(with_cache: bool) -> String {
+        let name_cache = if with_cache {
+            r#"<c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Cached</c:v></c:pt></c:strCache>"#
+        } else {
+            ""
+        };
+        let category_cache = if with_cache {
+            r#"<c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Cached category</c:v></c:pt></c:strCache>"#
+        } else {
+            ""
+        };
+        let value_cache = if with_cache {
+            r#"<c:numCache><c:ptCount val="1"/><c:pt idx="0"><c:v>99</c:v></c:pt></c:numCache>"#
+        } else {
+            ""
+        };
+        format!(
+            r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart><c:plotArea><c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/><c:order val="0"/><c:tx><c:strRef><c:f>'التقرير'!C1</c:f>{name_cache}</c:strRef></c:tx><c:cat><c:strRef><c:f>'التقرير'!$A$2:$A$4</c:f>{category_cache}</c:strRef></c:cat><c:val><c:numRef><c:f>'التقرير'!$C$2:$C$4</c:f>{value_cache}</c:numRef></c:val></c:ser><c:axId val="10"/><c:axId val="100"/></c:barChart><c:catAx><c:axId val="10"/><c:axPos val="b"/></c:catAx><c:valAx><c:axId val="100"/><c:axPos val="l"/></c:valAx></c:plotArea></c:chart></c:chartSpace>"#,
+        )
+    }
+
+    fn archive_with_data_sheet() -> crate::XlsxZip {
+        let mut bytes = Vec::new();
+        {
+            let mut writer = zip::ZipWriter::new(Cursor::new(&mut bytes));
+            writer
+                .start_file("xl/worksheets/sheet2.xml", SimpleFileOptions::default())
+                .unwrap();
+            writer.write_all(DATA_XML.as_bytes()).unwrap();
+            writer.finish().unwrap();
+        }
+        zip::ZipArchive::new(Cursor::new(bytes)).unwrap()
+    }
+
+    fn sheets() -> Vec<SheetMeta> {
+        vec![
+            SheetMeta {
+                name: "Dashboard".into(),
+                sheet_id: 1,
+                r_id: "rDashboard".into(),
+                tab_color: None,
+                visibility: SheetVisibility::Visible,
+            },
+            SheetMeta {
+                name: "التقرير".into(),
+                sheet_id: 2,
+                r_id: "rData".into(),
+                tab_color: None,
+                visibility: SheetVisibility::Visible,
+            },
+        ]
+    }
+
+    fn workbook_rels_xml() -> &'static str {
+        r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rDashboard" Target="worksheets/sheet1.xml"/><Relationship Id="rData" Target="worksheets/sheet2.xml"/></Relationships>"#
+    }
+
+    fn parse_model(xml: &str) -> (roxmltree::Document<'_>, ooxml_common::chart::ChartModel) {
+        let document = parse_guarded(xml).unwrap();
+        let theme = vec!["#4472C4".into(); 12];
+        let resolver = XlsxColorResolver {
+            theme_colors: &theme,
+            theme_major_font_latin: None,
+            theme_minor_font_latin: None,
+        };
+        let chart = ooxml_common::chart::parse_chart_part(document.root_element(), &resolver)
+            .expect("chart parses");
+        (document, chart)
+    }
+
+    #[test]
+    fn cacheless_unicode_chart_resolves_cross_sheet_series() {
+        let xml = chart_xml(false);
+        let (document, mut chart) = parse_model(&xml);
+        let mut archive = archive_with_data_sheet();
+        let rels = parse_guarded(workbook_rels_xml()).unwrap();
+
+        hydrate_legacy_chart_references(
+            &mut archive,
+            document.root_element(),
+            &mut chart,
+            DASHBOARD_XML,
+            "Dashboard",
+            &sheets(),
+            &rels,
+            &[],
+        );
+
+        assert_eq!(chart.series[0].name, "المبيعات");
+        assert_eq!(chart.categories, vec!["أحمد", "سارة", "خالد"]);
+        assert_eq!(
+            chart.series[0].categories,
+            Some(vec!["أحمد".into(), "سارة".into(), "خالد".into()]),
+        );
+        assert_eq!(
+            chart.series[0].values,
+            vec![Some(5000.0), Some(6200.0), Some(7500.0)],
+        );
+    }
+
+    #[test]
+    fn authored_chart_caches_take_precedence_over_live_cells() {
+        let xml = chart_xml(true);
+        let (document, mut chart) = parse_model(&xml);
+        let mut archive = archive_with_data_sheet();
+        let rels = parse_guarded(workbook_rels_xml()).unwrap();
+
+        hydrate_legacy_chart_references(
+            &mut archive,
+            document.root_element(),
+            &mut chart,
+            DASHBOARD_XML,
+            "Dashboard",
+            &sheets(),
+            &rels,
+            &[],
+        );
+
+        assert_eq!(chart.series[0].name, "Cached");
+        assert_eq!(chart.categories, vec!["Cached category"]);
+        assert_eq!(chart.series[0].values, vec![Some(99.0)]);
     }
 }
 
@@ -679,6 +967,7 @@ mod chartex_tests {
         let charts = load_sheet_charts(
             &mut archive,
             "worksheets/sheet1.xml",
+            None,
             &theme(),
             (None, None),
         );

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -8,6 +8,11 @@ use ooxml_common::zip::read_zip_string;
 
 mod markdown;
 
+mod worksheet_reference;
+use worksheet_reference::{
+    extract_reference_cells, resolve_worksheet_reference, ReferencedCellValue, MAX_REFERENCE_CELLS,
+};
+
 mod types;
 pub use types::*;
 mod styles;
@@ -274,8 +279,15 @@ fn parse_sheet_with(
     ws.defined_names = parse_defined_names_for_sheet(&wb_doc, sheet_index);
     ws.tables = load_sheet_tables(archive, &sheet_path, theme_colors);
     ws.slicers = load_sheet_slicers(archive, &sheet_path);
-    ws.sparkline_groups =
-        load_sheet_sparklines(archive, &sheet_xml, &shared.sheets, &rels_doc, theme_colors);
+    ws.sparkline_groups = load_sheet_sparklines(
+        archive,
+        &sheet_xml,
+        name,
+        &shared.sheets,
+        &rels_doc,
+        theme_colors,
+        &shared.shared_strings,
+    );
     let (df_family, df_size) = parse_default_font(archive);
     ws.default_font_family = df_family;
     ws.default_font_size = df_size;
@@ -692,7 +704,7 @@ fn parse_defined_names_for_sheet(doc: &roxmltree::Document, sheet_index: u32) ->
     names
 }
 
-fn resolve_sheet_path(doc: &roxmltree::Document, r_id: &str) -> Option<String> {
+pub(crate) fn resolve_sheet_path(doc: &roxmltree::Document, r_id: &str) -> Option<String> {
     let ns = "http://schemas.openxmlformats.org/package/2006/relationships";
     for node in doc.descendants() {
         if node.tag_name().name() == "Relationship"
@@ -2077,25 +2089,6 @@ fn parse_sqref(s: &str) -> Vec<CellRange> {
         .collect()
 }
 
-/// Split an `<xm:f>` reference like `Sheet1!A1:A10` or `'My Sheet'!$B$3:$B$8`
-/// into `(sheet_name, range)`. Returns `None` if the reference has no sheet
-/// qualifier — sparkline data refs always do, so unqualified is treated as
-/// "same sheet" by callers.
-fn split_sheet_ref(s: &str) -> (Option<String>, String) {
-    let s = s.trim();
-    let Some(bang) = s.rfind('!') else {
-        return (None, s.to_string());
-    };
-    let mut sheet = s[..bang].to_string();
-    // Strip absolute-ref dollars from the range part.
-    let range = s[bang + 1..].replace('$', "");
-    // Quoted sheet names ('foo''s sheet' uses doubled quotes for inner ').
-    if sheet.starts_with('\'') && sheet.ends_with('\'') {
-        sheet = sheet[1..sheet.len() - 1].replace("''", "'");
-    }
-    (Some(sheet), range)
-}
-
 /// Read a worksheet XML and extract numeric `<v>` values for the cells in
 /// `range`. Returns one value per cell in row-major order across the range.
 /// Empty cells, non-numeric values, and cells outside the range yield `None`.
@@ -2119,86 +2112,16 @@ fn split_sheet_ref(s: &str) -> (Option<String>, String) {
 /// `Vec` and the sparkline is simply not drawn (the renderer iterates the value
 /// slice by index, so an empty slice draws nothing — graceful degradation, not
 /// a hard error).
-const MAX_SPARKLINE_CELLS: usize = 1_000_000;
+const MAX_SPARKLINE_CELLS: usize = MAX_REFERENCE_CELLS;
 
 fn extract_range_values(sheet_xml: &str, range: &CellRange) -> Vec<Option<f64>> {
-    let total = ((range.bottom - range.top + 1) as usize)
-        .saturating_mul((range.right - range.left + 1) as usize);
-    // Guard the dense allocation: refuse pathological ranges (e.g. a full-sheet
-    // `<xm:f>`) that would demand a multi-hundred-GB buffer. Returning empty
-    // fails safe — no sparkline rather than OOM. See MAX_SPARKLINE_CELLS.
-    if total > MAX_SPARKLINE_CELLS {
-        return Vec::new();
-    }
-    let mut values: Vec<Option<f64>> = vec![None; total];
-    let Ok(doc) = parse_guarded(sheet_xml) else {
-        return values;
-    };
-    let row_span = (range.right - range.left + 1) as usize;
-
-    // Walk `<row>` elements first so we can reconstruct implicit positions the
-    // same way the main cell path does (PR #851): `@r` is `use="optional"` on
-    // both `CT_Row` (§18.3.1.73) and `CT_Cell` (§18.3.1.4). A flat
-    // `doc.descendants()` scan over `<c>` cannot recover an omitted position
-    // because it has no row grouping and no running column, so an r-less cell
-    // would be silently dropped and the sparkline would render blank. Track an
-    // implicit row counter across rows and, within each row, an implicit column
-    // counter — both resolved through `resolve_implicit_ordinal` so this path
-    // stays in lockstep with `parse_worksheet` / `parse_row_cells`.
-    let mut prev_row: u32 = 0;
-    for row_node in doc
-        .descendants()
-        .filter(|n| n.tag_name().name() == "row" && is_x_ns(n.tag_name().namespace()))
-    {
-        let row = resolve_implicit_ordinal(
-            row_node.attribute("r").and_then(|s| s.parse::<u32>().ok()),
-            &mut prev_row,
-        );
-
-        let mut prev_col: u32 = 0;
-        for c in row_node
-            .children()
-            .filter(|n| n.tag_name().name() == "c" && is_x_ns(n.tag_name().namespace()))
-        {
-            // An explicit `@r` re-anchors both the column and (authoritatively)
-            // the row; an omitted `@r` takes the previous cell's column + 1 and
-            // the running row.
-            let (col, cell_row) = match c.attribute("r") {
-                Some(r_attr) => {
-                    let (col, row) = parse_cell_ref(r_attr);
-                    prev_col = col;
-                    (col, row)
-                }
-                None => (resolve_implicit_ordinal(None, &mut prev_col), row),
-            };
-
-            if cell_row < range.top
-                || cell_row > range.bottom
-                || col < range.left
-                || col > range.right
-            {
-                continue;
-            }
-            // Only honor numeric / formula-numeric cells. `t` of "s" / "str" /
-            // "inlineStr" / "b" / "e" all map to None for sparkline values.
-            let t = c.attribute("t").unwrap_or("");
-            if matches!(t, "s" | "str" | "inlineStr" | "b" | "e") {
-                continue;
-            }
-            let v = c
-                .children()
-                .find(|n| n.tag_name().name() == "v" && is_x_ns(n.tag_name().namespace()))
-                .and_then(|n| n.text())
-                .and_then(|s| s.trim().parse::<f64>().ok());
-            if let Some(num) = v {
-                let idx = (cell_row - range.top) as usize * row_span + (col - range.left) as usize;
-                if idx < values.len() {
-                    values[idx] = Some(num);
-                }
-            }
-        }
-    }
-    values
+    extract_reference_cells(sheet_xml, range, &[])
+        .into_iter()
+        .map(|value| match value {
+            ReferencedCellValue::Number(number) => Some(number),
+            _ => None,
+        })
+        .collect()
 }
 
 /// Walk the worksheet XML's `<extLst>` and produce one `SparklineGroup` per
@@ -2208,9 +2131,11 @@ fn extract_range_values(sheet_xml: &str, range: &CellRange) -> Vec<Option<f64>> 
 fn load_sheet_sparklines(
     archive: &mut XlsxZip,
     sheet_xml: &str,
+    current_sheet_name: &str,
     sheets: &[SheetMeta],
     rels_doc: &roxmltree::Document,
     theme_colors: &[String],
+    shared_strings: &[SharedString],
 ) -> Vec<SparklineGroup> {
     let Ok(doc) = parse_guarded(sheet_xml) else {
         return Vec::new();
@@ -2275,33 +2200,22 @@ fn load_sheet_sparklines(
                     continue;
                 }
                 let (col, row) = parse_cell_ref(sqref_text.trim());
-                let (source_sheet, range_str) = split_sheet_ref(f_text);
-                let ranges = parse_sqref(&range_str);
-                let Some(range) = ranges.into_iter().next() else {
-                    continue;
-                };
-
-                // Look up source sheet XML (cross-sheet ref). When the ref
-                // has no sheet qualifier, fall back to the *current* sheet
-                // XML.
-                let source_xml: Option<&str> = match source_sheet {
-                    Some(name) => {
-                        if !xml_cache.contains_key(&name) {
-                            let path = sheets
-                                .iter()
-                                .find(|s| s.name == name)
-                                .and_then(|s| resolve_sheet_path(rels_doc, &s.r_id))
-                                .map(|p| format!("xl/{}", p));
-                            let xml = path.and_then(|p| read_zip_string(archive, &p).ok());
-                            xml_cache.insert(name.clone(), xml);
-                        }
-                        xml_cache.get(&name).and_then(|o| o.as_deref())
-                    }
-                    None => Some(sheet_xml),
-                };
-                let values = source_xml
-                    .map(|xml| extract_range_values(xml, &range))
-                    .unwrap_or_default();
+                let values = resolve_worksheet_reference(
+                    archive,
+                    f_text,
+                    sheet_xml,
+                    current_sheet_name,
+                    sheets,
+                    rels_doc,
+                    shared_strings,
+                    &mut xml_cache,
+                )
+                .into_iter()
+                .map(|value| match value {
+                    ReferencedCellValue::Number(number) => Some(number),
+                    _ => None,
+                })
+                .collect();
 
                 sparklines.push(Sparkline { row, col, values });
             }
@@ -2516,7 +2430,7 @@ pub(crate) fn parse_cell_ref(r: &str) -> (u32, u32) {
 /// `<row>`/`<c>` sequences — `parse_worksheet` (row numbers), `parse_row_cells`
 /// (cell columns), and `extract_range_values` (sparkline data cells) — so their
 /// implicit-reference handling cannot drift apart.
-fn resolve_implicit_ordinal(explicit: Option<u32>, prev: &mut u32) -> u32 {
+pub(crate) fn resolve_implicit_ordinal(explicit: Option<u32>, prev: &mut u32) -> u32 {
     let resolved = explicit.unwrap_or(*prev + 1);
     *prev = resolved;
     resolved

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -11,7 +11,9 @@ mod markdown;
 mod worksheet_reference;
 #[cfg(test)]
 use worksheet_reference::{extract_reference_cells, MAX_REFERENCE_CELLS};
-use worksheet_reference::{resolve_worksheet_reference, ReferencedCellValue};
+use worksheet_reference::{
+    resolve_worksheet_reference, ReferencedCellValue, WorksheetReferenceSession,
+};
 
 mod types;
 pub use types::*;
@@ -263,6 +265,7 @@ fn parse_sheet_with(
     // list; their preview parts are referenced from the worksheet XML + rels.
     ws.images
         .extend(load_sheet_ole_images(archive, &sheet_path, &sheet_xml));
+    let mut reference_session = WorksheetReferenceSession::default();
     ws.charts = load_sheet_charts(
         archive,
         &sheet_path,
@@ -272,6 +275,7 @@ fn parse_sheet_with(
             sheets: &shared.sheets,
             workbook_rels: &rels_doc,
             shared_strings: &shared.shared_strings,
+            session: &mut reference_session,
         }),
         theme_colors,
         (
@@ -294,6 +298,7 @@ fn parse_sheet_with(
         &rels_doc,
         theme_colors,
         &shared.shared_strings,
+        &mut reference_session,
     );
     let (df_family, df_size) = parse_default_font(archive);
     ws.default_font_family = df_family;
@@ -2137,6 +2142,7 @@ fn extract_range_values(sheet_xml: &str, range: &CellRange) -> Vec<Option<f64>> 
 /// `<x14:sparklineGroup>`. Resolves cross-sheet `<xm:f>` data references by
 /// reading the referenced sheet from the archive (cached per call to avoid
 /// re-reads). Theme colors are flattened to `#RRGGBB` via `parse_color`.
+#[allow(clippy::too_many_arguments)]
 fn load_sheet_sparklines(
     archive: &mut XlsxZip,
     sheet_xml: &str,
@@ -2145,16 +2151,12 @@ fn load_sheet_sparklines(
     rels_doc: &roxmltree::Document,
     theme_colors: &[String],
     shared_strings: &[SharedString],
+    reference_session: &mut WorksheetReferenceSession,
 ) -> Vec<SparklineGroup> {
     let Ok(doc) = parse_guarded(sheet_xml) else {
         return Vec::new();
     };
     let mut groups: Vec<SparklineGroup> = Vec::new();
-    // Cache: sheet name → loaded XML. Saves re-reading when many sparklines
-    // reference the same source sheet (typical: one "data" sheet feeds many
-    // dashboard sparklines).
-    let mut xml_cache: HashMap<String, Option<String>> = HashMap::new();
-
     let parse_bool_attr = |n: &roxmltree::Node, key: &str, default: bool| -> bool {
         match n.attribute(key) {
             Some(v) => v == "1" || v.eq_ignore_ascii_case("true"),
@@ -2217,8 +2219,9 @@ fn load_sheet_sparklines(
                     sheets,
                     rels_doc,
                     shared_strings,
-                    &mut xml_cache,
+                    reference_session,
                 )
+                .unwrap_or_default()
                 .into_iter()
                 .map(|value| match value {
                     ReferencedCellValue::Number(number) => Some(number),

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -9,9 +9,9 @@ use ooxml_common::zip::read_zip_string;
 mod markdown;
 
 mod worksheet_reference;
-use worksheet_reference::{
-    extract_reference_cells, resolve_worksheet_reference, ReferencedCellValue, MAX_REFERENCE_CELLS,
-};
+#[cfg(test)]
+use worksheet_reference::{extract_reference_cells, MAX_REFERENCE_CELLS};
+use worksheet_reference::{resolve_worksheet_reference, ReferencedCellValue};
 
 mod types;
 pub use types::*;
@@ -2119,8 +2119,10 @@ fn parse_sqref(s: &str) -> Vec<CellRange> {
 /// `Vec` and the sparkline is simply not drawn (the renderer iterates the value
 /// slice by index, so an empty slice draws nothing — graceful degradation, not
 /// a hard error).
+#[cfg(test)]
 const MAX_SPARKLINE_CELLS: usize = MAX_REFERENCE_CELLS;
 
+#[cfg(test)]
 fn extract_range_values(sheet_xml: &str, range: &CellRange) -> Vec<Option<f64>> {
     extract_reference_cells(sheet_xml, range, &[])
         .into_iter()

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -266,6 +266,13 @@ fn parse_sheet_with(
     ws.charts = load_sheet_charts(
         archive,
         &sheet_path,
+        Some(ChartReferenceContext {
+            sheet_xml: &sheet_xml,
+            sheet_name: name,
+            sheets: &shared.sheets,
+            workbook_rels: &rels_doc,
+            shared_strings: &shared.shared_strings,
+        }),
         theme_colors,
         (
             shared.theme_fonts.0.as_deref(),

--- a/packages/xlsx/parser/src/worksheet_reference.rs
+++ b/packages/xlsx/parser/src/worksheet_reference.rs
@@ -1,0 +1,308 @@
+use crate::{parse_cell_ref, resolve_implicit_ordinal, resolve_sheet_path};
+use crate::{CellRange, SharedString, SheetMeta, XlsxZip};
+use ooxml_common::depth::parse_guarded;
+use ooxml_common::ns::is_x_ns;
+use ooxml_common::zip::read_zip_string;
+use std::collections::HashMap;
+
+pub(crate) const MAX_REFERENCE_CELLS: usize = 1_000_000;
+const MAX_COL: u32 = 16_384;
+const MAX_ROW: u32 = 1_048_576;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ReferencedCellValue {
+    Empty,
+    Text(String),
+    Number(f64),
+}
+
+pub(crate) fn split_sheet_ref(formula: &str) -> Option<(Option<String>, String)> {
+    let formula = formula.trim();
+    if formula.is_empty() {
+        return None;
+    }
+
+    let (sheet_name, reference) = match formula.rfind('!') {
+        Some(bang) => {
+            let raw_sheet = formula[..bang].trim();
+            let reference = formula[bang + 1..].trim();
+            if raw_sheet.is_empty() || reference.is_empty() {
+                return None;
+            }
+            let sheet = if raw_sheet.starts_with('\'') && raw_sheet.ends_with('\'') {
+                if raw_sheet.len() < 2 {
+                    return None;
+                }
+                raw_sheet[1..raw_sheet.len() - 1].replace("''", "'")
+            } else {
+                if raw_sheet.contains(['\'', '!', '[', ']']) {
+                    return None;
+                }
+                raw_sheet.to_string()
+            };
+            (Some(sheet), reference)
+        }
+        None => (None, formula),
+    };
+
+    Some((sheet_name, reference.replace('$', "")))
+}
+
+fn parse_a1_cell(reference: &str) -> Option<(u32, u32)> {
+    let split = reference
+        .find(|c: char| !c.is_ascii_alphabetic())
+        .unwrap_or(reference.len());
+    let (col_text, row_text) = reference.split_at(split);
+    if col_text.is_empty() || row_text.is_empty() || !row_text.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+
+    let col = col_text.chars().try_fold(0u32, |value, c| {
+        value
+            .checked_mul(26)?
+            .checked_add(c.to_ascii_uppercase() as u32 - 'A' as u32 + 1)
+    })?;
+    let row = row_text.parse::<u32>().ok()?;
+    if !(1..=MAX_COL).contains(&col) || !(1..=MAX_ROW).contains(&row) {
+        return None;
+    }
+    Some((col, row))
+}
+
+pub(crate) fn parse_a1_range(reference: &str) -> Option<CellRange> {
+    let mut parts = reference.trim().split(':');
+    let first = parts.next()?;
+    let second = parts.next();
+    if parts.next().is_some() {
+        return None;
+    }
+    let (col_a, row_a) = parse_a1_cell(first)?;
+    let (col_b, row_b) = match second {
+        Some(cell) => parse_a1_cell(cell)?,
+        None => (col_a, row_a),
+    };
+    Some(CellRange {
+        top: row_a.min(row_b),
+        left: col_a.min(col_b),
+        bottom: row_a.max(row_b),
+        right: col_a.max(col_b),
+    })
+}
+
+fn inline_string_text(cell: roxmltree::Node<'_, '_>) -> String {
+    cell.descendants()
+        .filter(|node| {
+            node.is_element()
+                && node.tag_name().name() == "t"
+                && is_x_ns(node.tag_name().namespace())
+        })
+        .filter_map(|node| node.text())
+        .collect()
+}
+
+fn cell_value(
+    cell: roxmltree::Node<'_, '_>,
+    shared_strings: &[SharedString],
+) -> ReferencedCellValue {
+    let cell_type = cell.attribute("t").unwrap_or("");
+    if cell_type == "inlineStr" {
+        return ReferencedCellValue::Text(inline_string_text(cell));
+    }
+    let value = cell
+        .children()
+        .find(|node| {
+            node.is_element()
+                && node.tag_name().name() == "v"
+                && is_x_ns(node.tag_name().namespace())
+        })
+        .and_then(|node| node.text())
+        .unwrap_or("");
+
+    match cell_type {
+        "s" => value
+            .parse::<usize>()
+            .ok()
+            .and_then(|index| shared_strings.get(index))
+            .map(|string| ReferencedCellValue::Text(string.text.clone()))
+            .unwrap_or(ReferencedCellValue::Empty),
+        "str" => ReferencedCellValue::Text(value.to_string()),
+        "" | "n" => value
+            .parse::<f64>()
+            .ok()
+            .filter(|number| number.is_finite())
+            .map(ReferencedCellValue::Number)
+            .unwrap_or(ReferencedCellValue::Empty),
+        _ => ReferencedCellValue::Empty,
+    }
+}
+
+pub(crate) fn extract_reference_cells(
+    sheet_xml: &str,
+    range: &CellRange,
+    shared_strings: &[SharedString],
+) -> Vec<ReferencedCellValue> {
+    let Some(row_count) = range
+        .bottom
+        .checked_sub(range.top)
+        .and_then(|value| value.checked_add(1))
+    else {
+        return Vec::new();
+    };
+    let Some(col_count) = range
+        .right
+        .checked_sub(range.left)
+        .and_then(|value| value.checked_add(1))
+    else {
+        return Vec::new();
+    };
+    let Some(total) = (row_count as usize).checked_mul(col_count as usize) else {
+        return Vec::new();
+    };
+    if total > MAX_REFERENCE_CELLS {
+        return Vec::new();
+    }
+
+    let Ok(document) = parse_guarded(sheet_xml) else {
+        return Vec::new();
+    };
+    let mut values = vec![ReferencedCellValue::Empty; total];
+    let mut previous_row = 0;
+    for row_node in document.descendants().filter(|node| {
+        node.is_element() && node.tag_name().name() == "row" && is_x_ns(node.tag_name().namespace())
+    }) {
+        let row = resolve_implicit_ordinal(
+            row_node
+                .attribute("r")
+                .and_then(|value| value.parse::<u32>().ok()),
+            &mut previous_row,
+        );
+        let mut previous_col = 0;
+        for cell in row_node.children().filter(|node| {
+            node.is_element()
+                && node.tag_name().name() == "c"
+                && is_x_ns(node.tag_name().namespace())
+        }) {
+            let (col, cell_row) = match cell.attribute("r") {
+                Some(reference) => {
+                    let (col, row) = parse_cell_ref(reference);
+                    previous_col = col;
+                    (col, row)
+                }
+                None => (resolve_implicit_ordinal(None, &mut previous_col), row),
+            };
+            if cell_row < range.top
+                || cell_row > range.bottom
+                || col < range.left
+                || col > range.right
+            {
+                continue;
+            }
+            let index =
+                (cell_row - range.top) as usize * col_count as usize + (col - range.left) as usize;
+            values[index] = cell_value(cell, shared_strings);
+        }
+    }
+    values
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn resolve_worksheet_reference(
+    archive: &mut XlsxZip,
+    formula: &str,
+    current_sheet_xml: &str,
+    current_sheet_name: &str,
+    sheets: &[SheetMeta],
+    workbook_rels: &roxmltree::Document<'_>,
+    shared_strings: &[SharedString],
+    xml_cache: &mut HashMap<String, Option<String>>,
+) -> Vec<ReferencedCellValue> {
+    let Some((source_sheet, reference)) = split_sheet_ref(formula) else {
+        return Vec::new();
+    };
+    let Some(range) = parse_a1_range(&reference) else {
+        return Vec::new();
+    };
+    let sheet_name = source_sheet.as_deref().unwrap_or(current_sheet_name);
+    if sheet_name == current_sheet_name {
+        return extract_reference_cells(current_sheet_xml, &range, shared_strings);
+    }
+
+    if !xml_cache.contains_key(sheet_name) {
+        let xml = sheets
+            .iter()
+            .find(|sheet| sheet.name == sheet_name)
+            .and_then(|sheet| resolve_sheet_path(workbook_rels, &sheet.r_id))
+            .and_then(|path| read_zip_string(archive, &format!("xl/{path}")).ok());
+        xml_cache.insert(sheet_name.to_string(), xml);
+    }
+    xml_cache
+        .get(sheet_name)
+        .and_then(Option::as_deref)
+        .map(|xml| extract_reference_cells(xml, &range, shared_strings))
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CellRange, SharedString};
+
+    #[test]
+    fn quoted_unicode_sheet_reference_is_split_and_unescaped() {
+        assert_eq!(
+            split_sheet_ref("'التقرير'!$A$2:$A$5"),
+            Some((Some("التقرير".into()), "A2:A5".into())),
+        );
+        assert_eq!(
+            split_sheet_ref("'Bob''s data'!C1"),
+            Some((Some("Bob's data".into()), "C1".into())),
+        );
+        assert_eq!(split_sheet_ref("A1:A3"), Some((None, "A1:A3".into())));
+    }
+
+    #[test]
+    fn direct_a1_range_is_normalized() {
+        let range = parse_a1_range("C5:A2").expect("direct A1 range parses");
+        assert_eq!(
+            (range.top, range.left, range.bottom, range.right),
+            (2, 1, 5, 3),
+        );
+        assert!(parse_a1_range("Sales").is_none());
+        assert!(parse_a1_range("A1+1").is_none());
+    }
+
+    #[test]
+    fn worksheet_cells_resolve_inline_shared_formula_string_and_numbers() {
+        let xml = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>Inline</t></is></c><c r="B1" t="s"><v>0</v></c><c r="C1" t="str"><f>UPPER(&quot;x&quot;)</f><v>X</v></c><c r="D1"><v>42</v></c></row></sheetData></worksheet>"#;
+        let shared = vec![SharedString {
+            text: "Shared".into(),
+            ..Default::default()
+        }];
+        let range = CellRange {
+            top: 1,
+            left: 1,
+            bottom: 1,
+            right: 4,
+        };
+        assert_eq!(
+            extract_reference_cells(xml, &range, &shared),
+            vec![
+                ReferencedCellValue::Text("Inline".into()),
+                ReferencedCellValue::Text("Shared".into()),
+                ReferencedCellValue::Text("X".into()),
+                ReferencedCellValue::Number(42.0),
+            ],
+        );
+    }
+
+    #[test]
+    fn oversized_range_is_rejected_before_allocation() {
+        let range = CellRange {
+            top: 1,
+            left: 1,
+            bottom: 1_048_576,
+            right: 16_384,
+        };
+        assert!(extract_reference_cells("<worksheet/>", &range, &[]).is_empty());
+    }
+}

--- a/packages/xlsx/parser/src/worksheet_reference.rs
+++ b/packages/xlsx/parser/src/worksheet_reference.rs
@@ -6,6 +6,10 @@ use ooxml_common::zip::read_zip_string;
 use std::collections::HashMap;
 
 pub(crate) const MAX_REFERENCE_CELLS: usize = 1_000_000;
+pub(crate) const MAX_TOTAL_REFERENCE_CELLS: usize = 1_000_000;
+const MAX_TOTAL_REFERENCE_STRING_BYTES: usize = 64 * 1024 * 1024;
+const MAX_TOTAL_INDEXED_CELLS: usize = MAX_TOTAL_REFERENCE_CELLS;
+const MAX_TOTAL_INDEXED_STRING_BYTES: usize = MAX_TOTAL_REFERENCE_STRING_BYTES;
 const MAX_COL: u32 = 16_384;
 const MAX_ROW: u32 = 1_048_576;
 
@@ -14,6 +18,64 @@ pub(crate) enum ReferencedCellValue {
     Empty,
     Text(String),
     Number(f64),
+}
+
+impl ReferencedCellValue {
+    fn string_bytes(&self) -> usize {
+        match self {
+            Self::Text(text) => text.len(),
+            _ => 0,
+        }
+    }
+}
+
+struct IndexedWorksheet {
+    cells: HashMap<(u32, u32), ReferencedCellValue>,
+    string_bytes: usize,
+}
+
+/// Per-worksheet-parse state shared by charts and sparklines. Source sheets
+/// are parsed once into sparse non-empty-cell maps. Independent cumulative
+/// cell and UTF-8 byte budgets bound both those indexes and the dense reference
+/// vectors retained by the resulting model.
+pub(crate) struct WorksheetReferenceSession {
+    sheets: HashMap<String, Option<IndexedWorksheet>>,
+    remaining_cells: usize,
+    remaining_string_bytes: usize,
+    remaining_indexed_cells: usize,
+    remaining_indexed_string_bytes: usize,
+}
+
+impl Default for WorksheetReferenceSession {
+    fn default() -> Self {
+        Self {
+            sheets: HashMap::new(),
+            remaining_cells: MAX_TOTAL_REFERENCE_CELLS,
+            remaining_string_bytes: MAX_TOTAL_REFERENCE_STRING_BYTES,
+            remaining_indexed_cells: MAX_TOTAL_INDEXED_CELLS,
+            remaining_indexed_string_bytes: MAX_TOTAL_INDEXED_STRING_BYTES,
+        }
+    }
+}
+
+impl WorksheetReferenceSession {
+    fn reservable_cell_count(&self, range: &CellRange) -> Option<usize> {
+        let total = reference_cell_count(range)?;
+        if total > MAX_REFERENCE_CELLS || total > self.remaining_cells {
+            return None;
+        }
+        Some(total)
+    }
+
+    fn consume_result(&mut self, cell_count: usize, string_bytes: usize) {
+        self.remaining_cells -= cell_count;
+        self.remaining_string_bytes -= string_bytes;
+    }
+
+    fn consume_index(&mut self, worksheet: &IndexedWorksheet) {
+        self.remaining_indexed_cells -= worksheet.cells.len();
+        self.remaining_indexed_string_bytes -= worksheet.string_bytes;
+    }
 }
 
 pub(crate) fn split_sheet_ref(formula: &str) -> Option<(Option<String>, String)> {
@@ -90,14 +152,32 @@ pub(crate) fn parse_a1_range(reference: &str) -> Option<CellRange> {
 }
 
 fn inline_string_text(cell: roxmltree::Node<'_, '_>) -> String {
-    cell.descendants()
-        .filter(|node| {
-            node.is_element()
-                && node.tag_name().name() == "t"
-                && is_x_ns(node.tag_name().namespace())
-        })
-        .filter_map(|node| node.text())
-        .collect()
+    let Some(inline) = cell.children().find(|node| {
+        node.is_element() && node.tag_name().name() == "is" && is_x_ns(node.tag_name().namespace())
+    }) else {
+        return String::new();
+    };
+    let mut text = String::new();
+    for child in inline.children().filter(|node| node.is_element()) {
+        match child.tag_name().name() {
+            "t" if is_x_ns(child.tag_name().namespace()) => {
+                text.push_str(child.text().unwrap_or(""));
+            }
+            "r" if is_x_ns(child.tag_name().namespace()) => {
+                for run_text in child.children().filter(|node| {
+                    node.is_element()
+                        && node.tag_name().name() == "t"
+                        && is_x_ns(node.tag_name().namespace())
+                }) {
+                    text.push_str(run_text.text().unwrap_or(""));
+                }
+            }
+            // `<rPh>` is phonetic guidance for the base text, not part of the
+            // cell's displayed value (ECMA-376 §18.4.6).
+            _ => {}
+        }
+    }
+    text
 }
 
 fn cell_value(
@@ -136,36 +216,15 @@ fn cell_value(
     }
 }
 
-pub(crate) fn extract_reference_cells(
+fn parse_worksheet_cells(
     sheet_xml: &str,
-    range: &CellRange,
     shared_strings: &[SharedString],
-) -> Vec<ReferencedCellValue> {
-    let Some(row_count) = range
-        .bottom
-        .checked_sub(range.top)
-        .and_then(|value| value.checked_add(1))
-    else {
-        return Vec::new();
-    };
-    let Some(col_count) = range
-        .right
-        .checked_sub(range.left)
-        .and_then(|value| value.checked_add(1))
-    else {
-        return Vec::new();
-    };
-    let Some(total) = (row_count as usize).checked_mul(col_count as usize) else {
-        return Vec::new();
-    };
-    if total > MAX_REFERENCE_CELLS {
-        return Vec::new();
-    }
-
-    let Ok(document) = parse_guarded(sheet_xml) else {
-        return Vec::new();
-    };
-    let mut values = vec![ReferencedCellValue::Empty; total];
+    max_cells: usize,
+    max_string_bytes: usize,
+) -> Option<IndexedWorksheet> {
+    let document = parse_guarded(sheet_xml).ok()?;
+    let mut values = HashMap::new();
+    let mut string_bytes = 0usize;
     let mut previous_row = 0;
     for row_node in document.descendants().filter(|node| {
         node.is_element() && node.tag_name().name() == "row" && is_x_ns(node.tag_name().namespace())
@@ -190,19 +249,91 @@ pub(crate) fn extract_reference_cells(
                 }
                 None => (resolve_implicit_ordinal(None, &mut previous_col), row),
             };
-            if cell_row < range.top
-                || cell_row > range.bottom
-                || col < range.left
-                || col > range.right
-            {
+            if !(1..=MAX_COL).contains(&col) || !(1..=MAX_ROW).contains(&cell_row) {
                 continue;
             }
-            let index =
-                (cell_row - range.top) as usize * col_count as usize + (col - range.left) as usize;
-            values[index] = cell_value(cell, shared_strings);
+            let value = cell_value(cell, shared_strings);
+            if value == ReferencedCellValue::Empty {
+                continue;
+            }
+            let key = (cell_row, col);
+            let old_string_bytes = values
+                .get(&key)
+                .map(ReferencedCellValue::string_bytes)
+                .unwrap_or(0);
+            let next_cell_count = values.len() + usize::from(!values.contains_key(&key));
+            let next_string_bytes = string_bytes
+                .checked_sub(old_string_bytes)?
+                .checked_add(value.string_bytes())?;
+            if next_cell_count > max_cells || next_string_bytes > max_string_bytes {
+                return None;
+            }
+            values.insert(key, value);
+            string_bytes = next_string_bytes;
         }
     }
-    values
+    Some(IndexedWorksheet {
+        cells: values,
+        string_bytes,
+    })
+}
+
+fn reference_cell_count(range: &CellRange) -> Option<usize> {
+    let row_count = range
+        .bottom
+        .checked_sub(range.top)
+        .and_then(|value| value.checked_add(1))?;
+    let col_count = range
+        .right
+        .checked_sub(range.left)
+        .and_then(|value| value.checked_add(1))?;
+    let total = (row_count as usize).checked_mul(col_count as usize)?;
+    Some(total)
+}
+
+fn extract_from_sparse_cells(
+    cells: &HashMap<(u32, u32), ReferencedCellValue>,
+    range: &CellRange,
+) -> Option<(Vec<ReferencedCellValue>, usize)> {
+    let total = reference_cell_count(range)?;
+    if total > MAX_REFERENCE_CELLS {
+        return None;
+    }
+    let col_count = (range.right - range.left + 1) as usize;
+    let mut values = vec![ReferencedCellValue::Empty; total];
+    let mut string_bytes = 0usize;
+    for row in range.top..=range.bottom {
+        for col in range.left..=range.right {
+            let Some(value) = cells.get(&(row, col)) else {
+                continue;
+            };
+            string_bytes = string_bytes.checked_add(value.string_bytes())?;
+            let index = (row - range.top) as usize * col_count + (col - range.left) as usize;
+            values[index] = value.clone();
+        }
+    }
+    Some((values, string_bytes))
+}
+
+#[cfg(test)]
+pub(crate) fn extract_reference_cells(
+    sheet_xml: &str,
+    range: &CellRange,
+    shared_strings: &[SharedString],
+) -> Vec<ReferencedCellValue> {
+    if reference_cell_count(range).is_none_or(|total| total > MAX_REFERENCE_CELLS) {
+        return Vec::new();
+    }
+    parse_worksheet_cells(
+        sheet_xml,
+        shared_strings,
+        MAX_TOTAL_INDEXED_CELLS,
+        MAX_TOTAL_INDEXED_STRING_BYTES,
+    )
+    .as_ref()
+    .and_then(|worksheet| extract_from_sparse_cells(&worksheet.cells, range))
+    .map(|(values, _)| values)
+    .unwrap_or_default()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -214,32 +345,54 @@ pub(crate) fn resolve_worksheet_reference(
     sheets: &[SheetMeta],
     workbook_rels: &roxmltree::Document<'_>,
     shared_strings: &[SharedString],
-    xml_cache: &mut HashMap<String, Option<String>>,
-) -> Vec<ReferencedCellValue> {
-    let Some((source_sheet, reference)) = split_sheet_ref(formula) else {
-        return Vec::new();
-    };
-    let Some(range) = parse_a1_range(&reference) else {
-        return Vec::new();
-    };
+    session: &mut WorksheetReferenceSession,
+) -> Option<Vec<ReferencedCellValue>> {
+    let (source_sheet, reference) = split_sheet_ref(formula)?;
+    let range = parse_a1_range(&reference)?;
+    let cell_count = session.reservable_cell_count(&range)?;
     let sheet_name = source_sheet.as_deref().unwrap_or(current_sheet_name);
-    if sheet_name == current_sheet_name {
-        return extract_reference_cells(current_sheet_xml, &range, shared_strings);
+    if !session.sheets.contains_key(sheet_name) {
+        let worksheet = if sheet_name == current_sheet_name {
+            parse_worksheet_cells(
+                current_sheet_xml,
+                shared_strings,
+                session.remaining_indexed_cells,
+                session.remaining_indexed_string_bytes,
+            )
+        } else {
+            sheets
+                .iter()
+                .find(|sheet| sheet.name == sheet_name)
+                .and_then(|sheet| resolve_sheet_path(workbook_rels, &sheet.r_id))
+                .and_then(|path| read_zip_string(archive, &format!("xl/{path}")).ok())
+                .and_then(|xml| {
+                    parse_worksheet_cells(
+                        &xml,
+                        shared_strings,
+                        session.remaining_indexed_cells,
+                        session.remaining_indexed_string_bytes,
+                    )
+                })
+        };
+        if let Some(worksheet) = worksheet.as_ref() {
+            session.consume_index(worksheet);
+        }
+        session.sheets.insert(sheet_name.to_string(), worksheet);
     }
-
-    if !xml_cache.contains_key(sheet_name) {
-        let xml = sheets
-            .iter()
-            .find(|sheet| sheet.name == sheet_name)
-            .and_then(|sheet| resolve_sheet_path(workbook_rels, &sheet.r_id))
-            .and_then(|path| read_zip_string(archive, &format!("xl/{path}")).ok());
-        xml_cache.insert(sheet_name.to_string(), xml);
-    }
-    xml_cache
+    session.sheets.get(sheet_name).and_then(Option::as_ref)?;
+    // Only successful source resolution consumes the cumulative dense-output
+    // budget. Broken sheet names and unreadable parts must not starve later,
+    // valid references in the same worksheet parse.
+    let (values, string_bytes) = session
+        .sheets
         .get(sheet_name)
-        .and_then(Option::as_deref)
-        .map(|xml| extract_reference_cells(xml, &range, shared_strings))
-        .unwrap_or_default()
+        .and_then(Option::as_ref)
+        .and_then(|worksheet| extract_from_sparse_cells(&worksheet.cells, &range))?;
+    if string_bytes > session.remaining_string_bytes {
+        return None;
+    }
+    session.consume_result(cell_count, string_bytes);
+    Some(values)
 }
 
 #[cfg(test)]
@@ -304,5 +457,58 @@ mod tests {
             right: 16_384,
         };
         assert!(extract_reference_cells("<worksheet/>", &range, &[]).is_empty());
+    }
+
+    #[test]
+    fn cumulative_budget_rejects_individually_valid_ranges() {
+        let mut session = WorksheetReferenceSession {
+            remaining_cells: 4,
+            ..Default::default()
+        };
+        let two_cells = CellRange {
+            top: 1,
+            left: 1,
+            bottom: 1,
+            right: 2,
+        };
+        let three_cells = CellRange {
+            top: 1,
+            left: 1,
+            bottom: 1,
+            right: 3,
+        };
+
+        let first_count = session.reservable_cell_count(&two_cells).unwrap();
+        session.consume_result(first_count, 0);
+        assert!(session.reservable_cell_count(&three_cells).is_none());
+        assert_eq!(session.remaining_cells, 2);
+    }
+
+    #[test]
+    fn sparse_index_has_cell_and_string_budgets() {
+        let xml = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1" s="1"/><c r="B1" t="inlineStr"><is><t>alpha</t></is></c><c r="C1"><v>42</v></c></row></sheetData></worksheet>"#;
+
+        let indexed = parse_worksheet_cells(xml, &[], 2, 5).expect("two non-empty cells fit");
+        assert_eq!(indexed.cells.len(), 2);
+        assert_eq!(indexed.string_bytes, 5);
+        assert!(!indexed.cells.contains_key(&(1, 1)));
+        assert!(parse_worksheet_cells(xml, &[], 1, 5).is_none());
+        assert!(parse_worksheet_cells(xml, &[], 2, 4).is_none());
+    }
+
+    #[test]
+    fn inline_string_excludes_phonetic_guidance() {
+        let xml = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>漢字</t><rPh sb="0" eb="2"><t>かんじ</t></rPh></is></c></row></sheetData></worksheet>"#;
+        let range = CellRange {
+            top: 1,
+            left: 1,
+            bottom: 1,
+            right: 1,
+        };
+
+        assert_eq!(
+            extract_reference_cells(xml, &range, &[]),
+            vec![ReferencedCellValue::Text("漢字".into())]
+        );
     }
 }

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -138,6 +138,17 @@ export function rtlMirrorX(x: number, w: number, canvasW: number): number {
   return canvasW - x - w;
 }
 
+/** Map a logical-LTR anchored-object rectangle into sheet display space.
+ * Sheet RTL mirrors placement only; the object contents and width stay intact. */
+export function sheetAnchoredRectX(
+  x: number,
+  width: number,
+  canvasWidth: number,
+  rtl: boolean,
+): number {
+  return rtl ? rtlMirrorX(x, width, canvasWidth) : x;
+}
+
 // Thin line drawn between frozen and scrollable areas
 const FREEZE_LINE_COLOR = '#7a7a7a';
 
@@ -3103,6 +3114,7 @@ export function renderViewport(
       scrollOffsetX, scrollOffsetY,
       scrollAreaX, scrollAreaY,
       scrollAreaW, scrollAreaH,
+      worksheet.rightToLeft === true, canvasW,
     );
   }
 
@@ -3115,6 +3127,7 @@ export function renderViewport(
       scrollAreaX, scrollAreaY,
       scrollAreaW, scrollAreaH,
       opts.loadedImages,
+      worksheet.rightToLeft === true, canvasW,
     );
   }
 
@@ -3126,6 +3139,7 @@ export function renderViewport(
       scrollOffsetX, scrollOffsetY,
       scrollAreaX, scrollAreaY,
       scrollAreaW, scrollAreaH,
+      worksheet.rightToLeft === true, canvasW,
     );
   }
 
@@ -3137,6 +3151,7 @@ export function renderViewport(
       scrollOffsetX, scrollOffsetY,
       scrollAreaX, scrollAreaY,
       scrollAreaW, scrollAreaH,
+      worksheet.rightToLeft === true, canvasW,
     );
   }
 
@@ -3436,6 +3451,8 @@ function renderImages(
   scrollAreaY: number,
   scrollAreaW: number,
   scrollAreaH: number,
+  rtl: boolean,
+  canvasW: number,
 ): void {
   if (scrollAreaW <= 0 || scrollAreaH <= 0) return;
 
@@ -3445,7 +3462,8 @@ function renderImages(
 
   ctx.save();
   ctx.beginPath();
-  ctx.rect(scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH);
+  const clipX = sheetAnchoredRectX(scrollAreaX, scrollAreaW, canvasW, rtl);
+  ctx.rect(clipX, scrollAreaY, scrollAreaW, scrollAreaH);
   ctx.clip();
 
   for (const anchor of ws.images) {
@@ -3487,11 +3505,12 @@ function renderImages(
     if (imgW <= 0 || imgH <= 0) continue;
 
     // Translate to canvas coordinates of the scrollable viewport
-    const canvasX = scrollAreaX + (imgSheetX1 - scrollOriginSheetX) - scrollOffsetX;
+    const logicalCanvasX = scrollAreaX + (imgSheetX1 - scrollOriginSheetX) - scrollOffsetX;
+    const canvasX = sheetAnchoredRectX(logicalCanvasX, imgW, canvasW, rtl);
     const canvasY = scrollAreaY + (imgSheetY1 - scrollOriginSheetY) - scrollOffsetY;
 
     // Early out when entirely off-screen
-    if (canvasX + imgW < scrollAreaX || canvasX > scrollAreaX + scrollAreaW) continue;
+    if (canvasX + imgW < clipX || canvasX > clipX + scrollAreaW) continue;
     if (canvasY + imgH < scrollAreaY || canvasY > scrollAreaY + scrollAreaH) continue;
 
     // ECMA-376 §20.1.8.6 `<a:alphaModFix>`: scale the picture's opacity so it
@@ -3522,7 +3541,9 @@ function renderShapeGroups(
   scrollAreaY: number,
   scrollAreaW: number,
   scrollAreaH: number,
-  loadedImages?: Map<string, CanvasImageSource | null>,
+  loadedImages: Map<string, CanvasImageSource | null> | undefined,
+  rtl: boolean,
+  canvasW: number,
 ): void {
   if (scrollAreaW <= 0 || scrollAreaH <= 0) return;
   const anchors = ws.shapeGroups;
@@ -3533,7 +3554,8 @@ function renderShapeGroups(
 
   ctx.save();
   ctx.beginPath();
-  ctx.rect(scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH);
+  const clipX = sheetAnchoredRectX(scrollAreaX, scrollAreaW, canvasW, rtl);
+  ctx.rect(clipX, scrollAreaY, scrollAreaW, scrollAreaH);
   ctx.clip();
 
   for (const anchor of anchors) {
@@ -3560,10 +3582,11 @@ function renderShapeGroups(
     }
     if (w <= 0 || h <= 0) continue;
 
-    const canvasX = scrollAreaX + (x1 - scrollOriginSheetX) - scrollOffsetX;
+    const logicalCanvasX = scrollAreaX + (x1 - scrollOriginSheetX) - scrollOffsetX;
+    const canvasX = sheetAnchoredRectX(logicalCanvasX, w, canvasW, rtl);
     const canvasY = scrollAreaY + (y1 - scrollOriginSheetY) - scrollOffsetY;
 
-    if (canvasX + w < scrollAreaX || canvasX > scrollAreaX + scrollAreaW) continue;
+    if (canvasX + w < clipX || canvasX > clipX + scrollAreaW) continue;
     if (canvasY + h < scrollAreaY || canvasY > scrollAreaY + scrollAreaH) continue;
 
     for (const shape of anchor.shapes) {
@@ -4460,11 +4483,14 @@ function renderCharts(
   scrollAreaY: number,
   scrollAreaW: number,
   scrollAreaH: number,
+  rtl: boolean,
+  canvasW: number,
 ): void {
   if (scrollAreaW <= 0 || scrollAreaH <= 0) return;
 
   const scrollOriginSheetX = sheetXForCol(ws, startCol, cs);
   const scrollOriginSheetY = sheetYForRow(ws, startRow, cs);
+  const clipX = sheetAnchoredRectX(scrollAreaX, scrollAreaW, canvasW, rtl);
 
   for (const anchor of ws.charts) {
     const fromCol1 = anchor.fromCol + 1;
@@ -4481,15 +4507,16 @@ function renderCharts(
     const ch = shY2 - shY1;
     if (cw <= 0 || ch <= 0) continue;
 
-    const cx = scrollAreaX + (shX1 - scrollOriginSheetX) - scrollOffsetX;
+    const logicalCx = scrollAreaX + (shX1 - scrollOriginSheetX) - scrollOffsetX;
+    const cx = sheetAnchoredRectX(logicalCx, cw, canvasW, rtl);
     const cy = scrollAreaY + (shY1 - scrollOriginSheetY) - scrollOffsetY;
 
-    if (cx + cw < scrollAreaX || cx > scrollAreaX + scrollAreaW) continue;
+    if (cx + cw < clipX || cx > clipX + scrollAreaW) continue;
     if (cy + ch < scrollAreaY || cy > scrollAreaY + scrollAreaH) continue;
 
     ctx.save();
     ctx.beginPath();
-    ctx.rect(scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH);
+    ctx.rect(clipX, scrollAreaY, scrollAreaW, scrollAreaH);
     ctx.clip();
 
     // XLSX natural rendering is device-px at 96 DPI where 1pt = 4/3 px. Scale
@@ -4538,6 +4565,8 @@ function renderSlicers(
   scrollAreaY: number,
   scrollAreaW: number,
   scrollAreaH: number,
+  rtl: boolean,
+  canvasW: number,
 ): void {
   if (scrollAreaW <= 0 || scrollAreaH <= 0) return;
   const slicers = ws.slicers;
@@ -4545,6 +4574,7 @@ function renderSlicers(
 
   const scrollOriginSheetX = sheetXForCol(ws, startCol, cs);
   const scrollOriginSheetY = sheetYForRow(ws, startRow, cs);
+  const clipX = sheetAnchoredRectX(scrollAreaX, scrollAreaW, canvasW, rtl);
 
   for (const anchor of slicers) {
     const fromCol1 = anchor.fromCol + 1;
@@ -4561,15 +4591,16 @@ function renderSlicers(
     const h = shY2 - shY1;
     if (w <= 0 || h <= 0) continue;
 
-    const x = scrollAreaX + (shX1 - scrollOriginSheetX) - scrollOffsetX;
+    const logicalX = scrollAreaX + (shX1 - scrollOriginSheetX) - scrollOffsetX;
+    const x = sheetAnchoredRectX(logicalX, w, canvasW, rtl);
     const y = scrollAreaY + (shY1 - scrollOriginSheetY) - scrollOffsetY;
 
-    if (x + w < scrollAreaX || x > scrollAreaX + scrollAreaW) continue;
+    if (x + w < clipX || x > clipX + scrollAreaW) continue;
     if (y + h < scrollAreaY || y > scrollAreaY + scrollAreaH) continue;
 
     ctx.save();
     ctx.beginPath();
-    ctx.rect(scrollAreaX, scrollAreaY, scrollAreaW, scrollAreaH);
+    ctx.rect(clipX, scrollAreaY, scrollAreaW, scrollAreaH);
     ctx.clip();
 
     drawSlicerFrame(ctx, anchor.caption, anchor.items, x, y, w, h, cs);

--- a/packages/xlsx/src/rtl-anchored-chart-render.test.ts
+++ b/packages/xlsx/src/rtl-anchored-chart-render.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import type { ChartModel } from '@silurus/ooxml-core';
+import { renderViewport } from './renderer.js';
+import type { Styles, Worksheet } from './types.js';
+
+type FillRectCall = { x: number; y: number; w: number; h: number; color: string };
+
+function recordingContext(width = 800, height = 400): {
+  ctx: CanvasRenderingContext2D;
+  fills: FillRectCall[];
+  scales: Array<[number, number]>;
+} {
+  const fills: FillRectCall[] = [];
+  const scales: Array<[number, number]> = [];
+  const state: Record<string, unknown> = {
+    canvas: { width, height },
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    lineWidth: 1,
+    font: '11px sans-serif',
+    textAlign: 'left',
+    textBaseline: 'alphabetic',
+    direction: 'ltr',
+    globalAlpha: 1,
+    measureText: (text: string) => ({ width: [...text].length * 7 }),
+    fillRect(x: number, y: number, w: number, h: number) {
+      fills.push({ x, y, w, h, color: String(state.fillStyle) });
+    },
+    scale(x: number, y: number) {
+      scales.push([x, y]);
+    },
+    createLinearGradient: () => ({ addColorStop: () => {} }),
+  };
+  const noOp = () => {};
+  const ctx = new Proxy(state, {
+    get(target, property) {
+      return property in target ? target[property as string] : noOp;
+    },
+    set(target, property, value) {
+      target[property as string] = value;
+      return true;
+    },
+  });
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fills, scales };
+}
+
+const STYLES: Styles = {
+  fonts: [
+    {
+      bold: false,
+      italic: false,
+      underline: false,
+      strike: false,
+      size: 11,
+      color: null,
+      name: null,
+    },
+  ],
+  fills: [],
+  borders: [],
+  cellXfs: [{ fontId: 0, fillId: 0, borderId: 0, numFmtId: 0 } as Styles['cellXfs'][number]],
+  numFmts: [],
+  dxfs: [],
+};
+
+const CHART: ChartModel = {
+  chartType: 'clusteredBar',
+  title: null,
+  categories: [],
+  series: [],
+  showDataLabels: false,
+  valMin: null,
+  valMax: null,
+  catAxisTitle: null,
+  valAxisTitle: null,
+  catAxisHidden: false,
+  valAxisHidden: false,
+  catAxisLineHidden: false,
+  valAxisLineHidden: false,
+  plotAreaBg: null,
+  chartBg: 'ABCDEF',
+  showLegend: false,
+  legendPos: null,
+  catAxisCrossBetween: 'between',
+  valAxisMajorTickMark: 'out',
+  catAxisMajorTickMark: 'out',
+  titleFontSizeHpt: null,
+  titleFontColor: null,
+  titleFontFace: null,
+  catAxisFontSizeHpt: null,
+  valAxisFontSizeHpt: null,
+  dataLabelFontSizeHpt: null,
+  subtotalIndices: [],
+};
+
+function worksheet(rightToLeft: boolean): Worksheet {
+  return {
+    name: 'Sheet1',
+    rows: [],
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 1,
+    conditionalFormats: [],
+    images: [],
+    rightToLeft,
+    charts: [
+      {
+        fromCol: 6,
+        fromColOff: 0,
+        fromRow: 1,
+        fromRowOff: 0,
+        toCol: 10,
+        toColOff: 0,
+        toRow: 10,
+        toRowOff: 0,
+        chart: CHART,
+      },
+    ],
+    defaultFontFamily: 'Calibri',
+    defaultFontSize: 11,
+  } as Worksheet;
+}
+
+function chartBackground(rightToLeft: boolean) {
+  const recording = recordingContext();
+  renderViewport(
+    recording.ctx,
+    worksheet(rightToLeft),
+    STYLES,
+    { row: 1, col: 2, rows: 20, cols: 20 },
+    { freezeCols: 1, scrollOffsetX: 17 },
+  );
+  const fills = recording.fills.filter((call) => call.color === '#ABCDEF');
+  expect(fills).toHaveLength(1);
+  return { background: fills[0], scales: recording.scales };
+}
+
+describe('RTL anchored chart rendering', () => {
+  it('mirrors the chart rectangle with scrolling and frozen columns', () => {
+    const ltr = chartBackground(false);
+    const rtl = chartBackground(true);
+
+    expect(rtl.background.w).toBe(ltr.background.w);
+    expect(rtl.background.h).toBe(ltr.background.h);
+    expect(rtl.background.x).toBeCloseTo(800 - ltr.background.x - ltr.background.w);
+  });
+
+  it('does not flip the chart contents', () => {
+    const rtl = chartBackground(true);
+    expect(rtl.scales.some(([x, y]) => x < 0 || y < 0)).toBe(false);
+  });
+});

--- a/packages/xlsx/src/rtl-mirror.test.ts
+++ b/packages/xlsx/src/rtl-mirror.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { rtlMirrorX, HEADER_W } from './renderer.js';
+import { rtlMirrorX, sheetAnchoredRectX, HEADER_W } from './renderer.js';
 
 /**
  * Regression tests for the RTL selection / hit-testing bug (ECMA-376
@@ -92,5 +92,21 @@ describe('rtlMirrorX', () => {
     const xA = rtlMirrorX(HEADER_W + 100, colW, canvasW);
     const xB = rtlMirrorX(HEADER_W + 200, colW, canvasW);
     expect(xB).toBeLessThan(xA);
+  });
+});
+
+describe('sheetAnchoredRectX', () => {
+  it('preserves an anchored rectangle in LTR', () => {
+    expect(sheetAnchoredRectX(420, 180, 800, false)).toBe(420);
+  });
+
+  it('mirrors the full rectangle in RTL without changing its width', () => {
+    const x = sheetAnchoredRectX(420, 180, 800, true);
+    expect(x).toBe(200);
+    expect(x + 180).toBe(380);
+  });
+
+  it('mirrors the scroll-area clipping rectangle through the same transform', () => {
+    expect(sheetAnchoredRectX(HEADER_W, 750, 800, true)).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- resolve cacheless legacy chart formulas through a shared DrawingML resolver contract while keeping worksheet access XLSX-specific
- preserve authored caches and literals, including multi-level categories, and cover category, value, series-name, scatter, and bubble sources
- share a bounded sparse worksheet-reference session across charts and sparklines
- mirror anchored objects and clipping rectangles on right-to-left worksheets without flipping object contents

## Design

The shared chart parser owns OOXML series-field semantics and accepts an optional host reference resolver. DOCX and PPTX retain the existing no-op entry point; XLSX supplies direct A1 worksheet lookup. Unresolved formulas remain distinct from successfully resolved empty ranges.

The XLSX session parses each referenced worksheet once, indexes non-empty cells, and applies cumulative cell and UTF-8 byte budgets to both indexes and retained dense results. Shared categories are canonicalized in ChartModel.categories to avoid duplicate model data. Scatter and bubble axes use only paintable X/Y pairs.

RTL handling mirrors the full anchored-object rectangle in viewport space, including scrolling and frozen columns, while preserving content direction.

## Verification

- shared OOXML Rust tests: 238 passed
- XLSX parser Rust tests: 165 passed
- DOCX parser Rust tests: 360 passed
- PPTX parser Rust tests: 183 passed
- core chart and XLSX Vitest: 838 passed
- core and XLSX TypeScript typechecks
- repository lint
- XLSX WASM rebuild
- local-only parser-backed and Storybook comparison against representative cacheless LTR and RTL workbooks
- two independent critical review passes covering OOXML specification alignment, responsibilities, duplication, resource bounds, and cross-format consistency
