### PR TITLE
fix(docx): improve Word-compatible layout geometry

### DIFF
--- a/packages/core/src/fonts/local-metrics.test.ts
+++ b/packages/core/src/fonts/local-metrics.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  loadLocalFontMetrics,
+  unloadLocalFontMetrics,
+} from './local-metrics.js';
+import { _resetFontRegistryForTests } from './font-registry.js';
+
+const G = globalThis as unknown as Record<string, unknown>;
+const ORIGINALS = {
+  document: G.document,
+  self: G.self,
+  FontFace: G.FontFace,
+  OffscreenCanvas: G.OffscreenCanvas,
+};
+
+beforeEach(() => {
+  _resetFontRegistryForTests();
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(ORIGINALS)) {
+    if (value === undefined) delete G[key];
+    else G[key] = value;
+  }
+  _resetFontRegistryForTests();
+});
+
+function installFontEnvironment() {
+  const added: FakeFontFace[] = [];
+  const deleted: FakeFontFace[] = [];
+  class FakeFontFace {
+    status: FontFaceLoadStatus = 'unloaded';
+    constructor(
+      readonly family: string,
+      readonly source: string,
+    ) {}
+    async load(): Promise<this> {
+      if (this.source.includes('Missing Face')) {
+        this.status = 'error';
+        throw new DOMException('missing', 'NetworkError');
+      }
+      this.status = 'loaded';
+      return this;
+    }
+  }
+  const fonts = {
+    add(face: FakeFontFace) { added.push(face); },
+    delete(face: FakeFontFace) { deleted.push(face); return true; },
+  } as unknown as FontFaceSet;
+  class FakeOffscreenCanvas {
+    constructor(_width: number, _height: number) {}
+    getContext() {
+      return {
+        font: '',
+        measureText: () => ({
+          fontBoundingBoxAscent: 106,
+          fontBoundingBoxDescent: 44,
+        }),
+      };
+    }
+  }
+  G.document = { fonts };
+  G.FontFace = FakeFontFace;
+  G.OffscreenCanvas = FakeOffscreenCanvas;
+  return { added, deleted };
+}
+
+describe('loadLocalFontMetrics', () => {
+  it('loads an exact local face under an isolated alias and derives its line ratio', async () => {
+    const { added, deleted } = installFontEnvironment();
+
+    const loaded = await loadLocalFontMetrics([{
+      family: 'メイリオ',
+      localNames: ['Meiryo'],
+      lineHeightMultiplier: 1.3,
+    }]);
+
+    expect(loaded.faces).toHaveLength(1);
+    expect(added).toHaveLength(1);
+    expect(added[0].source).toBe('local("Meiryo")');
+    expect(loaded.metrics['メイリオ'].family).toBe(added[0].family);
+    expect(loaded.metrics['メイリオ'].lineHeightRatio).toBeCloseTo(1.95, 8);
+
+    unloadLocalFontMetrics(loaded.faces);
+    expect(deleted).toEqual([added[0]]);
+  });
+
+  it('does not mistake a missing local font for a fallback face', async () => {
+    const { added, deleted } = installFontEnvironment();
+
+    const loaded = await loadLocalFontMetrics([{
+      family: 'Missing',
+      localNames: ['Missing Face'],
+      lineHeightMultiplier: 1.3,
+    }]);
+
+    expect(loaded.faces).toEqual([]);
+    expect(loaded.metrics).toEqual({});
+    expect(added).toHaveLength(1);
+    expect(deleted).toEqual(added);
+  });
+
+  it('waits for a shared face that another document is still loading', async () => {
+    const added: Array<{ family: string; source: string; status: FontFaceLoadStatus }> = [];
+    let finishLoad!: () => void;
+    const loaded = new Promise<void>((resolve) => { finishLoad = resolve; });
+    class DeferredFontFace {
+      status: FontFaceLoadStatus = 'unloaded';
+      constructor(readonly family: string, readonly source: string) {}
+      async load(): Promise<this> {
+        if (this.status === 'loaded') return this;
+        this.status = 'loading';
+        await loaded;
+        this.status = 'loaded';
+        return this;
+      }
+    }
+    const fonts = {
+      add(face: DeferredFontFace) { added.push(face); },
+      delete() { return true; },
+    } as unknown as FontFaceSet;
+    class DeferredCanvas {
+      getContext() {
+        return {
+          font: '',
+          measureText: () => added[0]?.status === 'loaded'
+            ? { fontBoundingBoxAscent: 106, fontBoundingBoxDescent: 44 }
+            : { fontBoundingBoxAscent: Number.NaN, fontBoundingBoxDescent: Number.NaN },
+        };
+      }
+    }
+    G.document = { fonts };
+    G.FontFace = DeferredFontFace;
+    G.OffscreenCanvas = DeferredCanvas;
+    const request = [{
+      family: 'Meiryo',
+      localNames: ['Meiryo'],
+      lineHeightMultiplier: 1.3,
+    }];
+
+    const first = loadLocalFontMetrics(request);
+    await Promise.resolve();
+    const second = loadLocalFontMetrics(request);
+    await Promise.resolve();
+    finishLoad();
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(added).toHaveLength(1);
+    expect(a.metrics.meiryo.lineHeightRatio).toBeCloseTo(1.95, 8);
+    expect(b.metrics.meiryo.lineHeightRatio).toBeCloseTo(1.95, 8);
+  });
+
+  it('is a no-op when the current context has no FontFaceSet', async () => {
+    delete G.document;
+    delete G.self;
+    const loaded = await loadLocalFontMetrics([{
+      family: 'Meiryo',
+      localNames: ['Meiryo'],
+      lineHeightMultiplier: 1.3,
+    }]);
+    expect(loaded).toEqual({ faces: [], metrics: {} });
+  });
+});

--- a/packages/core/src/fonts/local-metrics.ts
+++ b/packages/core/src/fonts/local-metrics.ts
@@ -1,0 +1,113 @@
+import { retainFace, releaseFaces } from './font-registry.js';
+import { activeFontSet, withFontCeiling } from './preload.js';
+
+/** A family-level local-font measurement request. This API is shared by all
+ * OOXML formats; each format decides which Office behavior requires a measured
+ * multiplier and supplies the evidence-backed value. */
+export interface LocalFontMetricRequest {
+  /** Authored OOXML family name used as the lookup key. */
+  family: string;
+  /** Exact local() names, in preference order. No generic fallback is allowed. */
+  localNames: readonly string[];
+  /** Office single-line multiplier applied to the local face's design box. */
+  lineHeightMultiplier: number;
+}
+
+export interface ResolvedLocalFontMetric {
+  /** Isolated FontFace family registered for Canvas measure and paint. */
+  family: string;
+  /** Office single-line height divided by em. */
+  lineHeightRatio: number;
+}
+
+export interface LoadedLocalFontMetrics {
+  /** Refcounted faces retained by this caller; release on document destroy. */
+  faces: FontFace[];
+  /** Normalized authored family → exact local face and measured line ratio. */
+  metrics: Record<string, ResolvedLocalFontMetric>;
+}
+
+export function normalizeLocalFontMetricFamily(family: string): string {
+  return family.trim().toLowerCase();
+}
+
+function quoteLocalName(name: string): string {
+  return `local("${name.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}")`;
+}
+
+function stableHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function measureContext():
+  | CanvasRenderingContext2D
+  | OffscreenCanvasRenderingContext2D
+  | null {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    return new OffscreenCanvas(1, 1).getContext('2d');
+  }
+  if (typeof document !== 'undefined' && document?.createElement) {
+    return document.createElement('canvas').getContext('2d');
+  }
+  return null;
+}
+
+/** Load exact local faces and measure their design line boxes without accepting
+ * CSS fallback substitution. A missing local() source rejects FontFace.load(),
+ * so no metric is returned and the renderer keeps its static OOXML/Office
+ * profile. The isolated alias makes the measured and painted face identical.
+ */
+export async function loadLocalFontMetrics(
+  requests: readonly LocalFontMetricRequest[],
+): Promise<LoadedLocalFontMetrics> {
+  const set = activeFontSet();
+  const ctx = measureContext();
+  if (!set || !ctx || typeof FontFace === 'undefined') return { faces: [], metrics: {} };
+
+  const faces: FontFace[] = [];
+  const metrics: Record<string, ResolvedLocalFontMetric> = {};
+  for (const request of requests) {
+    const family = request.family.trim();
+    const localNames = request.localNames.map((name) => name.trim()).filter(Boolean);
+    if (!family || localNames.length === 0 || !(request.lineHeightMultiplier > 0)) continue;
+    const source = localNames.map(quoteLocalName).join(', ');
+    const signature = `local-metric:${normalizeLocalFontMetricFamily(family)}:${source}`;
+    const alias = `__ooxml_local_${stableHash(signature)}`;
+    const { face } = retainFace(signature, set, () => {
+      const created = new FontFace(alias, source);
+      set.add(created);
+      return created;
+    });
+
+    try {
+      // A second document can retain the shared face while the first holder's
+      // load is still in flight. FontFace.load() is idempotent and joins that
+      // pending load, so await it for every holder before measuring; `isNew`
+      // alone is not a sufficient loaded-state guarantee under concurrent opens.
+      const loaded = await withFontCeiling(face.load());
+      if (!loaded || face.status !== 'loaded') throw new Error('local font load timed out');
+      ctx.font = `100px "${alias}"`;
+      const measured = ctx.measureText('Hg国');
+      const ascent = measured.fontBoundingBoxAscent;
+      const descent = measured.fontBoundingBoxDescent;
+      if (!(Number.isFinite(ascent) && Number.isFinite(descent) && ascent + descent > 0)) {
+        throw new Error('font design metrics unavailable');
+      }
+      const lineHeightRatio = ((ascent + descent) / 100) * request.lineHeightMultiplier;
+      faces.push(face);
+      metrics[normalizeLocalFontMetricFamily(family)] = { family: alias, lineHeightRatio };
+    } catch {
+      releaseFaces([face]);
+    }
+  }
+  return { faces, metrics };
+}
+
+export function unloadLocalFontMetrics(faces: Iterable<FontFace>): void {
+  releaseFaces(faces);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -489,6 +489,16 @@ export {
   intendedSingleLinePx,
   correctLineMetrics,
 } from './text/line-metrics';
+// Exact local-font metric probing. Shared contract for docx/xlsx/pptx; format
+// packages supply only their evidence-backed Office line-height policy.
+export {
+  loadLocalFontMetrics,
+  unloadLocalFontMetrics,
+  normalizeLocalFontMetricFamily,
+  type LocalFontMetricRequest,
+  type ResolvedLocalFontMetric,
+  type LoadedLocalFontMetrics,
+} from './fonts/local-metrics';
 // Format-agnostic same-font Canvas-vs-Word line-fit bias. Consumers keep their
 // layout/paint wiring local, while the metric provenance and normalized family
 // matching remain shared data.

--- a/packages/docx/parser/src/markdown.rs
+++ b/packages/docx/parser/src/markdown.rs
@@ -129,7 +129,7 @@ fn render_runs(runs: &[DocRun]) -> String {
                     BreakType::Page | BreakType::Column => out.push_str("\n\n"),
                 }
             }
-            DocRun::Image(_) | DocRun::Shape(_) | DocRun::Chart(_) => {
+            DocRun::AnchorHost(_) | DocRun::Image(_) | DocRun::Shape(_) | DocRun::Chart(_) => {
                 // No readable text; intentionally dropped. Use docx_get_images
                 // / docx_get_shapes when you need metadata.
             }

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3096,8 +3096,6 @@ fn text_runs_mergeable(a: &TextRun, b: &TextRun) -> bool {
         && a.east_asian_vert_compress == b.east_asian_vert_compress
 }
 
-// Same parse-context threading as handle_run_in_para.
-#[allow(clippy::too_many_arguments)]
 /// Prepend the zero-advance host-character metrics for a floating DrawingML
 /// payload. The metrics belong to the enclosing WordprocessingML `<w:r>`, so a
 /// group expanded into multiple drawing runs must still receive exactly one.
@@ -3116,6 +3114,8 @@ fn prepend_anchor_host_metrics(
     }
 }
 
+// Same parse-context threading as handle_run_in_para.
+#[allow(clippy::too_many_arguments)]
 fn parse_run_inner(
     node: roxmltree::Node,
     base_run: &RunFmt,

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3193,6 +3193,29 @@ fn parse_run_inner(
     // renderer can pick per character (CJK glyphs → eastAsia face). `font_family`
     // above keeps the conflated single-font fallback for non-per-char paths.
     let font_family_east_asia = theme.resolve_font_ref(fmt.font_family_east_asia.clone());
+    // A floating drawing remains attached to an anchor character in this run.
+    // ECMA-376 §20.4.2.3 defines the floating placement; Word's line formatter
+    // still sizes that anchor character from the resolved §17.3.2 run
+    // properties. Preserve those metrics on emitted shapes instead of dropping
+    // them at the parser/model boundary.
+    let anchor_host_metrics = AnchorHostMetrics {
+        font_size,
+        font_family: font_family.clone(),
+        font_family_east_asia: font_family_east_asia.clone(),
+        bold,
+        italic,
+    };
+    let attach_anchor_host_metrics = |drawing_runs: &mut [DocRun]| {
+        // A grouped drawing expands into several ShapeRuns, but its containing
+        // `<w:r>` still has one anchor character. Attach the zero-width metric
+        // contribution once, to the first emitted shape.
+        if let Some(shape) = drawing_runs.iter_mut().find_map(|run| match run {
+            DocRun::Shape(shape) => Some(shape),
+            _ => None,
+        }) {
+            shape.anchor_host_metrics = Some(anchor_host_metrics.clone());
+        }
+    };
     let vert_align = fmt.vert_align.clone();
     let all_caps = fmt.all_caps.unwrap_or(false);
     let small_caps = fmt.small_caps.unwrap_or(false);
@@ -3671,11 +3694,10 @@ fn parse_run_inner(
                 }
             }
             "drawing" => {
-                for r in
-                    parse_inline_drawing(style_map, num_map, child, media_map, chart_map, theme)
-                {
-                    runs.push(r);
-                }
+                let mut drawing_runs =
+                    parse_inline_drawing(style_map, num_map, child, media_map, chart_map, theme);
+                attach_anchor_host_metrics(&mut drawing_runs);
+                runs.extend(drawing_runs);
             }
             "footnoteReference" | "endnoteReference" | "footnoteRef" | "endnoteRef" => {
                 // ECMA-376 §17.11.6 / §17.11.7 / §17.11.16 / §17.11.17.
@@ -3763,11 +3785,11 @@ fn parse_run_inner(
                 {
                     for inner in selected.children().filter(|n| n.is_element()) {
                         if inner.tag_name().name() == "drawing" {
-                            for r in parse_inline_drawing(
+                            let mut drawing_runs = parse_inline_drawing(
                                 style_map, num_map, inner, media_map, chart_map, theme,
-                            ) {
-                                runs.push(r);
-                            }
+                            );
+                            attach_anchor_host_metrics(&mut drawing_runs);
+                            runs.extend(drawing_runs);
                         }
                     }
                 }
@@ -3811,11 +3833,11 @@ fn parse_run_inner(
                     .children()
                     .find(|n| n.is_element() && n.tag_name().name() == "drawing");
                 if let Some(drawing) = drawing {
-                    for r in parse_inline_drawing(
+                    let mut drawing_runs = parse_inline_drawing(
                         style_map, num_map, drawing, media_map, chart_map, theme,
-                    ) {
-                        runs.push(r);
-                    }
+                    );
+                    attach_anchor_host_metrics(&mut drawing_runs);
+                    runs.extend(drawing_runs);
                 } else if let Some(img) = parse_object_ole_image(child, media_map) {
                     runs.push(DocRun::Image(img));
                 }
@@ -12625,6 +12647,41 @@ mod anchor_image_relative_from_tests {
         let data = build_docx(body);
         let doc = parse_from_bytes(&data).expect("parse must succeed");
         assert_eq!(first_shape(&doc).z_order, 251651072);
+    }
+
+    #[test]
+    fn anchored_shape_serializes_its_host_run_metrics() {
+        let body = r#"<w:p><w:r>
+  <w:rPr>
+    <w:rFonts w:ascii="Arial" w:eastAsia="Yu Mincho"/>
+    <w:b/><w:i/><w:sz w:val="40"/>
+  </w:rPr>
+  <w:drawing>
+    <wp:anchor xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+               xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+               xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+               behindDoc="0" relativeHeight="1">
+      <wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>
+      <wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>
+      <wp:extent cx="127000" cy="127000"/>
+      <wp:wrapNone/>
+      <wp:docPr id="1" name="shape"/>
+      <a:graphic><a:graphicData><wps:wsp><wps:spPr>
+        <a:xfrm><a:off x="0" y="0"/><a:ext cx="127000" cy="127000"/></a:xfrm>
+        <a:prstGeom prst="rect"/>
+      </wps:spPr></wps:wsp></a:graphicData></a:graphic>
+    </wp:anchor>
+  </w:drawing>
+</w:r></w:p>"#;
+        let data = build_docx(body);
+        let doc = parse_from_bytes(&data).expect("parse must succeed");
+        let json = serde_json::to_value(first_shape(&doc)).expect("shape serializes");
+
+        assert_eq!(json["anchorHostMetrics"]["fontSize"], 20.0);
+        assert_eq!(json["anchorHostMetrics"]["fontFamily"], "Arial");
+        assert_eq!(json["anchorHostMetrics"]["fontFamilyEastAsia"], "Yu Mincho");
+        assert_eq!(json["anchorHostMetrics"]["bold"], true);
+        assert_eq!(json["anchorHostMetrics"]["italic"], true);
     }
 
     /// ECMA-376 §20.4.2.3/§20.4.3.5 — a standalone `wps:wsp` inside

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1513,7 +1513,10 @@ fn split_para_on_page_breaks(para: DocParagraph) -> Vec<ParaPiece> {
         runs.iter().any(|r| {
             matches!(r,
             DocRun::Text(t) if !t.text.trim().is_empty())
-                || matches!(r, DocRun::Field(_) | DocRun::Image(_) | DocRun::Shape(_))
+                || matches!(
+                    r,
+                    DocRun::Field(_) | DocRun::Image(_) | DocRun::Chart(_) | DocRun::Shape(_)
+                )
         })
     };
 
@@ -3095,6 +3098,24 @@ fn text_runs_mergeable(a: &TextRun, b: &TextRun) -> bool {
 
 // Same parse-context threading as handle_run_in_para.
 #[allow(clippy::too_many_arguments)]
+/// Prepend the zero-advance host-character metrics for a floating DrawingML
+/// payload. The metrics belong to the enclosing WordprocessingML `<w:r>`, so a
+/// group expanded into multiple drawing runs must still receive exactly one.
+fn prepend_anchor_host_metrics(
+    drawing_runs: &mut Vec<DocRun>,
+    anchor_host_metrics: &AnchorHostMetrics,
+) {
+    let has_floating_drawing = drawing_runs.iter().any(|run| match run {
+        DocRun::Image(image) => image.anchor,
+        DocRun::Chart(chart) => chart.anchor,
+        DocRun::Shape(_) => true,
+        _ => false,
+    });
+    if has_floating_drawing {
+        drawing_runs.insert(0, DocRun::AnchorHost(anchor_host_metrics.clone()));
+    }
+}
+
 fn parse_run_inner(
     node: roxmltree::Node,
     base_run: &RunFmt,
@@ -3205,16 +3226,8 @@ fn parse_run_inner(
         bold,
         italic,
     };
-    let attach_anchor_host_metrics = |drawing_runs: &mut [DocRun]| {
-        // A grouped drawing expands into several ShapeRuns, but its containing
-        // `<w:r>` still has one anchor character. Attach the zero-width metric
-        // contribution once, to the first emitted shape.
-        if let Some(shape) = drawing_runs.iter_mut().find_map(|run| match run {
-            DocRun::Shape(shape) => Some(shape),
-            _ => None,
-        }) {
-            shape.anchor_host_metrics = Some(anchor_host_metrics.clone());
-        }
+    let attach_anchor_host_metrics = |drawing_runs: &mut Vec<DocRun>| {
+        prepend_anchor_host_metrics(drawing_runs, &anchor_host_metrics);
     };
     let vert_align = fmt.vert_align.clone();
     let all_caps = fmt.all_caps.unwrap_or(false);
@@ -9604,6 +9617,16 @@ mod tests {
         };
         let cases: Vec<(DocRun, &str)> = vec![
             (DocRun::Text(Box::default()), "text"),
+            (
+                DocRun::AnchorHost(AnchorHostMetrics {
+                    font_size: 11.0,
+                    font_family: None,
+                    font_family_east_asia: None,
+                    bold: false,
+                    italic: false,
+                }),
+                "anchorHost",
+            ),
             (DocRun::Image(image), "image"),
             (
                 DocRun::Break {
@@ -12540,6 +12563,19 @@ mod anchor_image_relative_from_tests {
             .expect("expected one anchor shape")
     }
 
+    fn first_anchor_host(doc: &Document) -> &AnchorHostMetrics {
+        doc.body
+            .iter()
+            .find_map(|el| match el {
+                BodyElement::Paragraph(p) => p.runs.iter().find_map(|r| match r {
+                    DocRun::AnchorHost(host) => Some(host),
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .expect("expected one anchor host")
+    }
+
     /// Body XML for an anchor image with the given `<wp:positionH>` and
     /// `<wp:positionV>` children (relativeFrom + align). Mirrors the shape
     /// produced by Word for the sample-11 left/right page arrows: `wrap=none`,
@@ -12650,7 +12686,7 @@ mod anchor_image_relative_from_tests {
     }
 
     #[test]
-    fn anchored_shape_serializes_its_host_run_metrics() {
+    fn anchored_shape_serializes_independent_host_run_metrics() {
         let body = r#"<w:p><w:r>
   <w:rPr>
     <w:rFonts w:ascii="Arial" w:eastAsia="Yu Mincho"/>
@@ -12675,13 +12711,75 @@ mod anchor_image_relative_from_tests {
 </w:r></w:p>"#;
         let data = build_docx(body);
         let doc = parse_from_bytes(&data).expect("parse must succeed");
-        let json = serde_json::to_value(first_shape(&doc)).expect("shape serializes");
+        let json = serde_json::to_value(first_anchor_host(&doc)).expect("host serializes");
 
-        assert_eq!(json["anchorHostMetrics"]["fontSize"], 20.0);
-        assert_eq!(json["anchorHostMetrics"]["fontFamily"], "Arial");
-        assert_eq!(json["anchorHostMetrics"]["fontFamilyEastAsia"], "Yu Mincho");
-        assert_eq!(json["anchorHostMetrics"]["bold"], true);
-        assert_eq!(json["anchorHostMetrics"]["italic"], true);
+        assert_eq!(json["fontSize"], 20.0);
+        assert_eq!(json["fontFamily"], "Arial");
+        assert_eq!(json["fontFamilyEastAsia"], "Yu Mincho");
+        assert_eq!(json["bold"], true);
+        assert_eq!(json["italic"], true);
+    }
+
+    #[test]
+    fn anchored_picture_gets_one_independent_host_run() {
+        let body = anchor_body(
+            r#"<wp:positionH relativeFrom="page"><wp:posOffset>0</wp:posOffset></wp:positionH>"#,
+            r#"<wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>"#,
+        );
+        let doc = parse_from_bytes(&build_docx(&body)).expect("parse must succeed");
+        let paragraph = doc
+            .body
+            .iter()
+            .find_map(|el| match el {
+                BodyElement::Paragraph(p) => Some(p),
+                _ => None,
+            })
+            .expect("paragraph");
+
+        assert_eq!(
+            paragraph
+                .runs
+                .iter()
+                .filter(|r| matches!(r, DocRun::AnchorHost(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            paragraph
+                .runs
+                .iter()
+                .filter(|r| matches!(r, DocRun::Image(_)))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn grouped_shapes_share_one_independent_host_run() {
+        let metrics = AnchorHostMetrics {
+            font_size: 12.0,
+            font_family: Some("Arial".to_string()),
+            font_family_east_asia: None,
+            bold: false,
+            italic: false,
+        };
+        // A parsed wpg group expands into multiple Shape runs before the host
+        // character is attached. The enclosing w:r contributes only once.
+        let mut runs = vec![DocRun::Shape(Box::default()), DocRun::Shape(Box::default())];
+        prepend_anchor_host_metrics(&mut runs, &metrics);
+
+        assert_eq!(
+            runs.iter()
+                .filter(|r| matches!(r, DocRun::AnchorHost(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            runs.iter()
+                .filter(|r| matches!(r, DocRun::Shape(_)))
+                .count(),
+            2
+        );
     }
 
     /// ECMA-376 §20.4.2.3/§20.4.3.5 — a standalone `wps:wsp` inside
@@ -13129,9 +13227,20 @@ mod anchor_image_relative_from_tests {
         let mut chart_map: HashMap<String, ooxml_common::chart::ChartModel> = HashMap::new();
         chart_map.insert("rIdChart".to_string(), model);
 
-        let runs = parse_inline_drawing(&style_map, drawing, &media, &chart_map, &theme);
-        assert_eq!(runs.len(), 1, "one anchored chart run expected");
-        match &runs[0] {
+        let mut runs = parse_inline_drawing(&style_map, drawing, &media, &chart_map, &theme);
+        prepend_anchor_host_metrics(
+            &mut runs,
+            &AnchorHostMetrics {
+                font_size: 11.0,
+                font_family: Some("Arial".to_string()),
+                font_family_east_asia: None,
+                bold: false,
+                italic: false,
+            },
+        );
+        assert_eq!(runs.len(), 2, "one host plus one anchored chart expected");
+        assert!(matches!(&runs[0], DocRun::AnchorHost(host) if host.font_size == 11.0));
+        match &runs[1] {
             DocRun::Chart(c) => {
                 assert!(c.anchor, "anchored chart must carry anchor == true");
                 assert_eq!(c.chart.chart_type, "clusteredBar");
@@ -13157,7 +13266,17 @@ mod anchor_image_relative_from_tests {
 
         // Unresolvable rId (empty map) → no run (chart fell through, no blip).
         let empty: HashMap<String, ooxml_common::chart::ChartModel> = HashMap::new();
-        let none = parse_inline_drawing(&style_map, drawing, &media, &empty, &theme);
+        let mut none = parse_inline_drawing(&style_map, drawing, &media, &empty, &theme);
+        prepend_anchor_host_metrics(
+            &mut none,
+            &AnchorHostMetrics {
+                font_size: 11.0,
+                font_family: None,
+                font_family_east_asia: None,
+                bold: false,
+                italic: false,
+            },
+        );
         assert!(
             none.is_empty(),
             "unresolvable anchored chart rId must emit nothing"

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -949,11 +949,36 @@ pub struct LineEnd {
     pub len: String,
 }
 
+/// Resolved character formatting of the WordprocessingML run that hosts a
+/// floating drawing. The drawing is out of inline flow, but Word still uses its
+/// anchor character's run metrics when sizing the containing text line.
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AnchorHostMetrics {
+    /// Effective run size in points (§17.3.2.38 `<w:sz>`).
+    pub font_size: f64,
+    /// Resolved ascii/hAnsi font face (§17.3.2.26 `<w:rFonts>`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub font_family: Option<String>,
+    /// Resolved East Asian font face, kept separately so document-grid line
+    /// allocation can use the Far East design metrics.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub font_family_east_asia: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub bold: bool,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub italic: bool,
+}
+
 /// A drawn shape (wps:wsp inside wp:anchor). Positioned like an anchor image
 /// and rendered via core's buildCustomPath + paint primitives.
 #[derive(Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ShapeRun {
+    /// Formatting of the `<w:r>` anchor character that contains this floating
+    /// drawing. Absent on legacy/parser-created shapes that predate this field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_host_metrics: Option<AnchorHostMetrics>,
     /// pt
     pub width_pt: f64,
     /// pt

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -871,6 +871,11 @@ pub enum DocRun {
     // keeps the enum compact (clippy::large_enum_variant). Serde flattens the
     // Box, so the JSON tag/shape is unchanged.
     Text(Box<TextRun>),
+    /// Zero-advance formatting contribution of the WordprocessingML run that
+    /// hosts a floating DrawingML object. Kept independent of the drawing kind
+    /// because the same `<wp:anchor>` can contain a picture, chart, shape, or
+    /// group, while the host character participates in line sizing exactly once.
+    AnchorHost(AnchorHostMetrics),
     Image(ImageRun),
     /// ECMA-376 §21.2 DrawingML chart embedded in a `<w:drawing>` whose
     /// `<a:graphicData uri=".../chart">` carries a `<c:chart r:id>`. The chart
@@ -975,10 +980,6 @@ pub struct AnchorHostMetrics {
 #[derive(Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ShapeRun {
-    /// Formatting of the `<w:r>` anchor character that contains this floating
-    /// drawing. Absent on legacy/parser-created shapes that predate this field.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub anchor_host_metrics: Option<AnchorHostMetrics>,
     /// pt
     pub width_pt: f64,
     /// pt

--- a/packages/docx/src/anchor-host-metrics.test.ts
+++ b/packages/docx/src/anchor-host-metrics.test.ts
@@ -1,0 +1,103 @@
+import { DEFAULT_KINSOKU_RULES } from '@silurus/ooxml-core';
+import { describe, expect, it } from 'vitest';
+import {
+  buildSegments,
+  layoutLines,
+  lineBoxHeight,
+  type LayoutSeg,
+  type LayoutTextSeg,
+} from './line-layout.js';
+import type { DocRun } from './types.js';
+
+function linearCtx(): CanvasRenderingContext2D {
+  let font = '10px serif';
+  const px = (): number => Number.parseFloat(/([\d.]+)px/.exec(font)?.[1] ?? '10');
+  return {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    letterSpacing: '0px',
+    measureText: (text: string) => ({
+      width: [...text].length * px() * 0.5,
+      fontBoundingBoxAscent: px() * 0.8,
+      fontBoundingBoxDescent: px() * 0.2,
+      actualBoundingBoxAscent: px() * 0.8,
+      actualBoundingBoxDescent: px() * 0.2,
+    } as TextMetrics),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function anchoredShape(): DocRun {
+  return {
+    type: 'shape',
+    widthPt: 100,
+    heightPt: 1,
+    anchorXPt: 0,
+    anchorYPt: 0,
+    anchorXFromMargin: false,
+    anchorYFromPara: true,
+    zOrder: 0,
+    subpaths: [],
+    presetGeometry: 'line',
+    fill: null,
+    stroke: '000000',
+    anchorHostMetrics: {
+      fontSize: 20,
+      fontFamily: 'Arial',
+      fontFamilyEastAsia: 'Yu Mincho',
+      bold: false,
+      italic: false,
+    },
+  } as DocRun;
+}
+
+describe('floating drawing anchor-host metrics', () => {
+  it('emits a zero-width metric segment using the anchor character formatting', () => {
+    const segments = buildSegments([anchoredShape()], { pageIndex: 0, totalPages: 1 });
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      text: '',
+      measuredWidth: 0,
+      fontSize: 20,
+      fontFamily: 'Yu Mincho',
+      metricOnly: true,
+      metricEastAsian: true,
+    });
+  });
+
+  it('uses the zero-width metric segment to allocate East Asian document-grid cells', () => {
+    const segments = buildSegments([anchoredShape()], { pageIndex: 0, totalPages: 1 });
+    const [line] = layoutLines(
+      linearCtx(),
+      segments.map((segment) => ({ ...segment })) as LayoutSeg[],
+      400,
+      0,
+      1,
+      undefined,
+      undefined,
+      {},
+      0,
+      DEFAULT_KINSOKU_RULES,
+      0,
+      36,
+      400,
+      false,
+      false,
+      false,
+    );
+
+    expect((line.segments[0] as LayoutTextSeg).measuredWidth).toBe(0);
+    expect(line.eastAsian).toBe(true);
+    expect(lineBoxHeight(
+      null,
+      line.ascent,
+      line.descent,
+      1,
+      { type: 'lines', linePitchPt: 18 },
+      false,
+      line.intendedSingle,
+      line.eastAsian,
+      line.gridCountSingle,
+    )).toBe(36);
+  });
+});

--- a/packages/docx/src/anchor-host-metrics.test.ts
+++ b/packages/docx/src/anchor-host-metrics.test.ts
@@ -50,6 +50,46 @@ function anchoredShape(): DocRun {
   } as DocRun;
 }
 
+function textRun(text: string, fontSize = 11): DocRun {
+  return {
+    type: 'text',
+    text,
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    fontSize,
+    color: null,
+    fontFamily: 'Yu Mincho',
+    fontFamilyEastAsia: 'Yu Mincho',
+    isLink: false,
+    background: null,
+    vertAlign: null,
+  } as DocRun;
+}
+
+function layOut(runs: DocRun[]) {
+  return layoutLines(
+    linearCtx(),
+    buildSegments(runs, { pageIndex: 0, totalPages: 1 })
+      .map((segment) => ({ ...segment })) as LayoutSeg[],
+    400,
+    0,
+    1,
+    undefined,
+    undefined,
+    {},
+    0,
+    DEFAULT_KINSOKU_RULES,
+    0,
+    36,
+    400,
+    false,
+    false,
+    false,
+  );
+}
+
 describe('floating drawing anchor-host metrics', () => {
   it('emits a zero-width metric segment using the anchor character formatting', () => {
     const segments = buildSegments([anchoredShape()], { pageIndex: 0, totalPages: 1 });
@@ -99,5 +139,23 @@ describe('floating drawing anchor-host metrics', () => {
       line.eastAsian,
       line.gridCountSingle,
     )).toBe(36);
+  });
+
+  it('reserves host line height without using its zero-ink box for a visible run baseline', () => {
+    const [hostOnly] = layOut([anchoredShape()]);
+    const [visibleOnly] = layOut([textRun('Caption')]);
+    const [mixed] = layOut([anchoredShape(), textRun('Caption')]);
+
+    // The host formatting still reserves the same two-cell line advance used by
+    // anchor-only rows; only the visible glyph baseline comes from visible ink.
+    expect(mixed.height).toBe(hostOnly.height);
+    expect(mixed.ascent).toBe(hostOnly.ascent);
+    expect(mixed.descent).toBe(hostOnly.descent);
+    expect(mixed.intendedSingle).toBe(hostOnly.intendedSingle);
+    expect(mixed.gridCountSingle).toBe(hostOnly.gridCountSingle);
+    expect(mixed.visibleAscent).toBe(visibleOnly.ascent);
+    expect(mixed.visibleDescent).toBe(visibleOnly.descent);
+    expect(hostOnly.visibleAscent).toBe(hostOnly.ascent);
+    expect(hostOnly.visibleDescent).toBe(hostOnly.descent);
   });
 });

--- a/packages/docx/src/anchor-host-metrics.test.ts
+++ b/packages/docx/src/anchor-host-metrics.test.ts
@@ -26,27 +26,14 @@ function linearCtx(): CanvasRenderingContext2D {
   } as unknown as CanvasRenderingContext2D;
 }
 
-function anchoredShape(): DocRun {
+function anchorHost(): DocRun {
   return {
-    type: 'shape',
-    widthPt: 100,
-    heightPt: 1,
-    anchorXPt: 0,
-    anchorYPt: 0,
-    anchorXFromMargin: false,
-    anchorYFromPara: true,
-    zOrder: 0,
-    subpaths: [],
-    presetGeometry: 'line',
-    fill: null,
-    stroke: '000000',
-    anchorHostMetrics: {
-      fontSize: 20,
-      fontFamily: 'Arial',
-      fontFamilyEastAsia: 'Yu Mincho',
-      bold: false,
-      italic: false,
-    },
+    type: 'anchorHost',
+    fontSize: 20,
+    fontFamily: 'Arial',
+    fontFamilyEastAsia: 'Yu Mincho',
+    bold: false,
+    italic: false,
   } as DocRun;
 }
 
@@ -92,7 +79,7 @@ function layOut(runs: DocRun[]) {
 
 describe('floating drawing anchor-host metrics', () => {
   it('emits a zero-width metric segment using the anchor character formatting', () => {
-    const segments = buildSegments([anchoredShape()], { pageIndex: 0, totalPages: 1 });
+    const segments = buildSegments([anchorHost()], { pageIndex: 0, totalPages: 1 });
 
     expect(segments).toHaveLength(1);
     expect(segments[0]).toMatchObject({
@@ -106,7 +93,7 @@ describe('floating drawing anchor-host metrics', () => {
   });
 
   it('uses the zero-width metric segment to allocate East Asian document-grid cells', () => {
-    const segments = buildSegments([anchoredShape()], { pageIndex: 0, totalPages: 1 });
+    const segments = buildSegments([anchorHost()], { pageIndex: 0, totalPages: 1 });
     const [line] = layoutLines(
       linearCtx(),
       segments.map((segment) => ({ ...segment })) as LayoutSeg[],
@@ -142,9 +129,9 @@ describe('floating drawing anchor-host metrics', () => {
   });
 
   it('reserves host line height without using its zero-ink box for a visible run baseline', () => {
-    const [hostOnly] = layOut([anchoredShape()]);
+    const [hostOnly] = layOut([anchorHost()]);
     const [visibleOnly] = layOut([textRun('Caption')]);
-    const [mixed] = layOut([anchoredShape(), textRun('Caption')]);
+    const [mixed] = layOut([anchorHost(), textRun('Caption')]);
 
     // The host formatting still reserves the same two-cell line advance used by
     // anchor-only rows; only the visible glyph baseline comes from visible ink.

--- a/packages/docx/src/callout-arrowhead-render.test.ts
+++ b/packages/docx/src/callout-arrowhead-render.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { renderDocumentToCanvas } from './renderer.js';
 import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps, ShapeRun } from './types';
 
-function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: number } {
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: number; strokes: number } {
   let fills = 0;
+  let strokes = 0;
   let font = '11px serif';
   const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '11');
   const ctx = {
@@ -25,7 +26,7 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: number } {
     arc() {}, ellipse() {}, rect() {}, clip() {},
     translate() {}, rotate() {}, scale() {}, setLineDash() {},
     clearRect() {}, fillRect() {}, strokeRect() {}, drawImage() {},
-    stroke() {},
+    stroke() { strokes += 1; },
     fill() { fills += 1; },
     fillText() {}, strokeText() {},
     fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
@@ -40,6 +41,7 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: number } {
   return {
     canvas: canvas as unknown as HTMLCanvasElement,
     get fills() { return fills; },
+    get strokes() { return strokes; },
   };
 }
 
@@ -86,6 +88,28 @@ function calloutWithTailArrow(): ShapeRun & { type: 'shape' } {
   } as unknown as ShapeRun & { type: 'shape' };
 }
 
+function plainLine(): ShapeRun & { type: 'shape' } {
+  return {
+    type: 'shape',
+    zOrder: 0,
+    subpaths: [],
+    presetGeometry: 'line',
+    fill: null,
+    stroke: '000000',
+    strokeWidth: 0.5,
+    widthPt: 120,
+    heightPt: 0.75,
+    anchorXPt: 40,
+    anchorYPt: 40,
+    anchorXFromMargin: false,
+    anchorYFromPara: true,
+    anchorXRelativeFrom: 'column',
+    anchorYRelativeFrom: 'paragraph',
+    wrapMode: 'none',
+    behindDoc: false,
+  } as unknown as ShapeRun & { type: 'shape' };
+}
+
 function docWith(body: BodyElement[]): DocxDocumentModel {
   return {
     section: {
@@ -108,6 +132,19 @@ function docWith(body: BodyElement[]): DocxDocumentModel {
 }
 
 describe('callout line-end rendering', () => {
+  it('strokes an undecorated line exactly once', async () => {
+    const rec = makeRecordingCanvas();
+
+    await renderDocumentToCanvas(
+      docWith([para([plainLine()])]),
+      rec.canvas,
+      0,
+      { dpr: 1, width: 300 },
+    );
+
+    expect(rec.strokes).toBe(1);
+  });
+
   it('draws a triangle tailEnd on the callout leader tip', async () => {
     const rec = makeRecordingCanvas();
 
@@ -119,5 +156,7 @@ describe('callout line-end rendering', () => {
     );
 
     expect(rec.fills).toBeGreaterThan(0);
+    // accentBorderCallout2: text-box border + accent bar + retracted leader.
+    expect(rec.strokes).toBe(3);
   });
 });

--- a/packages/docx/src/cell-border-conflict-render.test.ts
+++ b/packages/docx/src/cell-border-conflict-render.test.ts
@@ -31,6 +31,7 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; strokes: StrokeSeg[
   let strokeStyle = '#000000';
   let fillStyle = '#000000';
   const ctx = {
+    canvas: { width: 1000, height: 1000 },
     get font() { return font; },
     set font(v: string) { font = v; },
     get lineWidth() { return lineWidth; },
@@ -110,7 +111,10 @@ function tableOf(rows: DocTableRow[], tableBorders: Partial<Edges> = {}): DocTab
 }
 
 function rowOf(cells: DocTableCell[]): DocTableRow {
-  return { cells, rowHeight: 20, rowHeightRule: 'atLeast', isHeader: false } as unknown as DocTableRow;
+  // Exact rows keep the border-conflict assertions pinned to y=20; non-exact
+  // rows intentionally reserve resolved border width and are covered by the
+  // table-row-height geometry tests.
+  return { cells, rowHeight: 20, rowHeightRule: 'exact', isHeader: false } as unknown as DocTableRow;
 }
 
 function docOf(t: DocTable): DocxDocumentModel {

--- a/packages/docx/src/cell-border-conflict.ts
+++ b/packages/docx/src/cell-border-conflict.ts
@@ -1,4 +1,4 @@
-import type { BorderSpec } from './types';
+import type { BorderSpec, CellBorders, TableBorders } from './types';
 
 /**
  * ECMA-376 §17.4.66 (tcBorders) — adjacent table cell border conflict resolution.
@@ -28,6 +28,62 @@ import type { BorderSpec } from './types';
 export interface BorderCandidate {
   spec: BorderSpec;
   source: 'cell' | 'table';
+}
+
+/** Structural location of a cell in the table grid. The same edge cascade is
+ * consumed by both border paint and row-footprint measurement. */
+export interface CellEdgeFlags {
+  topRow: boolean;
+  bottomRow: boolean;
+  leftCol: boolean;
+  rightCol: boolean;
+}
+
+/** Cell/table cascade result before an adjacent-cell conflict is resolved. */
+export interface ResolvedCellEdges {
+  top: BorderCandidate | null;
+  bottom: BorderCandidate | null;
+  left: BorderCandidate | null;
+  right: BorderCandidate | null;
+}
+
+/** ECMA-376 §17.4.38/§17.4.39/§17.4.66 — resolve one cell's own, inside,
+ * and outer table border cascade. `mirror` maps logical left/right to physical
+ * sides for `bidiVisual`; horizontal edges are unchanged. */
+export function resolveCellEdges(
+  cell: CellBorders,
+  table: TableBorders,
+  edges: CellEdgeFlags,
+  mirror: boolean,
+): ResolvedCellEdges {
+  const horizontal = (
+    own: BorderSpec | null,
+    outer: boolean,
+    tableOuter: BorderSpec | null,
+  ): BorderCandidate | null => {
+    if (own) return { spec: own, source: 'cell' };
+    const inherited = outer ? tableOuter : (cell.insideH ?? table.insideH);
+    return inherited ? { spec: inherited, source: 'table' } : null;
+  };
+  const vertical = (
+    own: BorderSpec | null,
+    outer: boolean,
+    tableOuter: BorderSpec | null,
+  ): BorderCandidate | null => {
+    if (own) return { spec: own, source: 'cell' };
+    const inherited = outer ? tableOuter : (cell.insideV ?? table.insideV);
+    return inherited ? { spec: inherited, source: 'table' } : null;
+  };
+
+  const top = horizontal(cell.top, edges.topRow, table.top);
+  const bottom = horizontal(cell.bottom, edges.bottomRow, table.bottom);
+  const left = mirror
+    ? vertical(cell.right, edges.rightCol, table.right)
+    : vertical(cell.left, edges.leftCol, table.left);
+  const right = mirror
+    ? vertical(cell.left, edges.leftCol, table.left)
+    : vertical(cell.right, edges.rightCol, table.right);
+  return { top, bottom, left, right };
 }
 
 /** ECMA-376 §17.4.66 — the "border number" rank of each ST_Border style. The

--- a/packages/docx/src/cell-height-scale-metrics.test.ts
+++ b/packages/docx/src/cell-height-scale-metrics.test.ts
@@ -17,38 +17,32 @@ import type {
 } from './types';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Finding 1 — cell height measurement must use REAL-SCALE Canvas metrics.
+// Cell height measurement and glyph paint share canonical scale-1 geometry.
 //
-// The cell-height path (measureCellParagraphHeight → measureCellElementHeight →
-// measureCellContentHeightPx) measures a cell paragraph at scale 1 and then does
-// a geometric `× scale` on the scale-1 point height. That is the exact anti-
-// pattern `rescaleLayoutLines` exists to avoid: a real (hinted) font's Canvas
-// metrics are NOT scale-linear, so `metric(pt · s) ≠ s · metric(pt)`. The paint
-// path (renderParagraph) rehydrates the scale-1 line PARTITION to the paint scale
-// by RE-MEASURING every line at that scale (rescaleLayoutLines), so the painted
-// content occupies a height the naive `× scale` cannot reproduce. When the two
-// disagree, a vAlign=center/bottom cell centres its content off the true middle,
-// and the content-driven row-height fallback reserves the wrong height.
+// Pagination resolves ordinary body-table text in document coordinates. Paint
+// must preserve that scale-1 line geometry and map its glyphs through a Canvas
+// viewport transform; cell measurement must scale the same canonical line boxes.
+// If either side instead asks Canvas for fresh paint-size metrics, hinted fonts
+// can make row height / vAlign disagree with the glyph box actually drawn.
 //
 // These tests mock a NON-LINEAR `measureText` — a sub-linear ascent/descent, the
 // direction real font hinting bends (glyphs proportionally shorter at larger
 // sizes) — so `metric(12·s) ≠ s·metric(12)`. They then render at scale = 4/3
 // (≈1.333, the renderer's default cssWidth/physWidth ratio) and assert the cell
-// content height that vAlign / row layout USES equals the height the paint side
-// actually PRODUCES, read back through the public render seam.
+// content height that vAlign / row layout USES equals the transformed glyph box
+// the paint side actually PRODUCES, read back through the public render seam.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** Sub-linear single-glyph vertical metrics in px at font size `p` px. The
  *  ascent/descent shrink proportionally as `p` grows, so `metric(p·s) ≠ s·metric(p)`
- *  — the hinting-like non-linearity `rescaleLayoutLines` re-measures for. Width is
+ *  — a hinting-like non-linearity that would expose a paint-size remeasurement. Width is
  *  kept linear (charCount · p · 0.5) so the line PARTITION never changes with
- *  scale; only the per-line BOX height is scale-non-linear, which is exactly the
- *  quantity that drives a cell's measured height. */
+ *  scale; only the native paint-size BOX height is scale-non-linear. */
 function glyphMetrics(p: number): { asc: number; desc: number } {
   return { asc: p * (0.8 - 0.01 * p), desc: p * (0.2 - 0.005 * p) };
 }
 
-interface FillTextCall { text: string; x: number; y: number; font: string; }
+interface FillTextCall { text: string; x: number; y: number; font: string; scaleY: number; }
 interface FillRectCall { x: number; y: number; w: number; h: number; fillStyle: string; }
 
 function makeRecordingCanvas(): {
@@ -58,6 +52,8 @@ function makeRecordingCanvas(): {
 } {
   let font = '10px serif';
   let fillStyle = '#000';
+  let transform = { scaleX: 1, scaleY: 1, translateX: 0, translateY: 0 };
+  const stack: typeof transform[] = [];
   const px = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
   const fillTextCalls: FillTextCall[] = [];
   const fillRectCalls: FillRectCall[] = [];
@@ -78,16 +74,38 @@ function makeRecordingCanvas(): {
         actualBoundingBoxDescent: desc,
       } as TextMetrics;
     },
-    save() {}, restore() {}, beginPath() {}, closePath() {},
+    save() { stack.push({ ...transform }); },
+    restore() { transform = stack.pop() ?? transform; },
+    beginPath() {}, closePath() {},
     moveTo() {}, lineTo() {}, stroke() {}, fill() {},
     fillRect(x: number, y: number, w: number, h: number) {
-      fillRectCalls.push({ x, y, w, h, fillStyle });
+      fillRectCalls.push({
+        x: transform.translateX + transform.scaleX * x,
+        y: transform.translateY + transform.scaleY * y,
+        w: transform.scaleX * w,
+        h: transform.scaleY * h,
+        fillStyle,
+      });
     },
-    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {},
+    strokeRect() {}, clip() {}, rect() {},
+    scale(x: number, y: number) {
+      transform.scaleX *= x;
+      transform.scaleY *= y;
+    },
+    translate(x: number, y: number) {
+      transform.translateX += transform.scaleX * x;
+      transform.translateY += transform.scaleY * y;
+    },
     setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
     bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
     fillText(text: string, x: number, y: number) {
-      fillTextCalls.push({ text, x, y, font });
+      fillTextCalls.push({
+        text,
+        x: transform.translateX + transform.scaleX * x,
+        y: transform.translateY + transform.scaleY * y,
+        font,
+        scaleY: transform.scaleY,
+      });
     },
     strokeText() {},
     strokeStyle: '#000', lineWidth: 1,
@@ -107,7 +125,7 @@ function makeRecordingCanvas(): {
 
 // An untabled synthetic font so the font-metrics single-line FLOOR
 // (intendedSingleLinePx) is 0 and the line box is exactly the mock's ascent +
-// descent — isolating the scale non-linearity under test.
+// descent — isolating the metric non-linearity that the canonical path must avoid.
 const TEST_FONT = 'Synthetic Untabled Serif';
 
 function textRun(text: string): DocxTextRun {
@@ -164,6 +182,9 @@ function tableOf(r: DocTableRow): DocTable {
     borders: { top: null, bottom: null, left: null, right: null, insideH: null, insideV: null },
     cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
     jc: 'left',
+    // A negative leading indent forces the legacy table paint path, matching the
+    // negative-indent table class whose cell measurement must still match glyph paint.
+    tblInd: -10,
   } as DocTable;
 }
 
@@ -185,7 +206,6 @@ function docWithTable(t: DocTable): DocxDocumentModel {
 const CSS_WIDTH = 400;
 const PAGE_WIDTH = 300;
 const SCALE = CSS_WIDTH / PAGE_WIDTH;
-const FONT_PX = 12 * SCALE; // 16 exactly
 
 async function renderAndRead(t: DocTable) {
   const rec = makeRecordingCanvas();
@@ -197,26 +217,30 @@ async function renderAndRead(t: DocTable) {
 }
 
 /** Painted inked-block extent (px) of a set of one-line paragraphs, read from the
- *  fillText baselines and the mock's paint-scale glyph box. This is the height the
- *  paint side actually PRODUCES — the reference every measured height is compared
- *  against. */
+ *  transformed fillText baselines and the scale-1 glyph box mapped by its CTM. */
 function paintedExtent(calls: FillTextCall[], firstText: string, lastText: string): { top: number; bottom: number } {
   const first = calls.find((c) => c.text === firstText);
   const last = calls.find((c) => c.text === lastText);
   expect(first).toBeDefined();
   expect(last).toBeDefined();
-  const { asc, desc } = glyphMetrics(FONT_PX);
-  return { top: first!.y - asc, bottom: last!.y + desc };
+  const firstPx = parseFloat(/(\d+(?:\.\d+)?)px/.exec(first!.font)?.[1] ?? '12');
+  const lastPx = parseFloat(/(\d+(?:\.\d+)?)px/.exec(last!.font)?.[1] ?? '12');
+  const firstMetrics = glyphMetrics(firstPx);
+  const lastMetrics = glyphMetrics(lastPx);
+  return {
+    top: first!.y - firstMetrics.asc * first!.scaleY,
+    bottom: last!.y + lastMetrics.desc * last!.scaleY,
+  };
 }
 
-describe('Finding 1 — cell content height uses real-scale (rescaled) Canvas metrics', () => {
+describe('cell content height matches canonical transformed Canvas metrics', () => {
   it('sanity: the mock ascent/descent is scale-NON-linear (else the test is vacuous)', () => {
     const one = glyphMetrics(12);
     const s = glyphMetrics(12 * SCALE);
     const oneH = one.asc + one.desc;
     const scaledH = s.asc + s.desc;
-    // A geometric ×scale of the scale-1 box must MISS the real paint-scale box by
-    // a clearly observable margin — this is the divergence Finding 1 is about.
+    // Native paint-size metrics must differ clearly from the canonical scale-1
+    // box × viewport scale, or an accidental paint-size remeasurement could pass.
     expect(Math.abs(oneH * SCALE - scaledH)).toBeGreaterThan(0.5);
   });
 
@@ -237,9 +261,8 @@ describe('Finding 1 — cell content height uses real-scale (rescaled) Canvas me
     const { top, bottom } = paintedExtent(fillTextCalls, 'aa', 'cc');
     const inkedMid = (top + bottom) / 2;
     const cellMid = (120 * SCALE) / 2; // row at y=0, exact height 120·scale.
-    // measure == paint: the vAlign offset used the true painted content height, so
-    // the painted block's midpoint lands on the cell midpoint. With the geometric
-    // ×scale bug the block is off-centre by ~1.4 px here.
+    // measure == paint: vAlign used the same canonical transformed content height,
+    // so the painted block's midpoint lands on the cell midpoint.
     expect(inkedMid).toBeCloseTo(cellMid, 1);
   });
 
@@ -251,18 +274,14 @@ describe('Finding 1 — cell content height uses real-scale (rescaled) Canvas me
     ));
     const { fillTextCalls } = await renderAndRead(t);
     const { bottom } = paintedExtent(fillTextCalls, 'aa', 'cc');
-    // mb = 0 → the inked bottom sits on the cell bottom (120·scale). A geometric
-    // ×scale measured height would seat it short of / past the true bottom.
+    // mb = 0 → the transformed inked bottom sits on the cell bottom (120·scale).
     expect(bottom).toBeCloseTo(120 * SCALE, 1);
   });
 
   it('auto row height fallback: reserved row height equals the painted content height', async () => {
     // Auto height → the row height IS the measured cell content height. Disable the
-    // stamped-layout reuse so computeTableLayout runs the fresh real-scale fallback
-    // (the exact path Finding 1 flags), not the paginator's scale-1 stamp × scale.
-    // PR 6 — also disable the fragment paint path (which, like the reuse, draws the
-    // paginator's scale-1 row height × scale); the legacy `renderTable` recompute is
-    // the path this Finding characterizes.
+    // stamped-layout and fragment-paint paths so the legacy `renderTable` fallback
+    // must independently honor the same canonical measurement/paint contract.
     const prevFrag = __test_setFragmentPaintEnabled(false);
     const prev = __test_setTableReuseEnabled(false);
     try {
@@ -275,9 +294,8 @@ describe('Finding 1 — cell content height uses real-scale (rescaled) Canvas me
       const bg = fillRectCalls.find((r) => r.fillStyle === '#abcdef');
       expect(bg).toBeDefined();
       const { top, bottom } = paintedExtent(fillTextCalls, 'aa', 'cc');
-      // Zero cell margins → the reserved (drawn) row height must equal the painted
-      // content extent. The geometric ×scale fallback reserves the scale-1 height
-      // × scale, which misses the painted height under non-linear metrics.
+      // Zero cell margins → the reserved row height equals the transformed glyph
+      // extent, even through the legacy table fallback.
       expect(bg!.h).toBeCloseTo(bottom - top, 1);
     } finally {
       __test_setTableReuseEnabled(prev);
@@ -285,14 +303,14 @@ describe('Finding 1 — cell content height uses real-scale (rescaled) Canvas me
     }
   });
 
-  it('PR 6 — a vAlign table (fragment-paint gate-excluded) still reuses the paginator scale-1 geometry in production', async () => {
-    // A vAlign=center cell excludes its table from fragment paint (the §17.4.84
-    // centring re-measures content), so it takes the LEGACY renderTable path — which,
+  it('PR 6 — a negative-indent vAlign table still reuses paginator scale-1 geometry in production', async () => {
+    // Negative tblInd excludes the table from fragment paint, so the §17.4.84
+    // centring measurement takes the LEGACY renderTable path — which,
     // in production (table reuse ON), must draw the PAGINATOR's scale-1 row height
     // × scale exactly as the pre-PR6 stamp reuse did. PR 6 removed the stamp from the
     // non-split parsed table (model-mutation removal), so computeTableLayout must
     // source the same geometry from the attached TableFragment instead; without that,
-    // the fallback recomputes at paint-scale metrics and the drawn row height shifts
+    // the fallback can diverge from the canonical row geometry and the drawn height shifts
     // under non-linear metrics (observed as a raw-pixel VRT delta on a private
     // multi-table document). Defaults untouched: fragment paint ON, table reuse ON.
     const t = tableOf(row(
@@ -305,8 +323,7 @@ describe('Finding 1 — cell content height uses real-scale (rescaled) Canvas me
     expect(bg).toBeDefined();
     // The paginator resolved the row at scale 1: 3 one-line paragraphs at 12pt with
     // the mock's scale-1 glyph box (asc+desc at p=12), so the production-drawn row
-    // height is that scale-1 height × SCALE — NOT the paint-scale recompute (which
-    // under the non-linear mock is measurably shorter).
+    // height is that scale-1 height × SCALE, matching the canonical glyph transform.
     const { asc, desc } = glyphMetrics(12);
     const scale1RowHeightPt = 3 * (asc + desc);
     expect(bg!.h).toBeCloseTo(scale1RowHeightPt * SCALE, 1);

--- a/packages/docx/src/cell-paragraph-line-reuse.test.ts
+++ b/packages/docx/src/cell-paragraph-line-reuse.test.ts
@@ -74,6 +74,8 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[]; meas
   let font = '10px serif';
   const calls: Call[] = [];
   let measures = 0;
+  let transform = { scaleX: 1, scaleY: 1, translateX: 0, translateY: 0 };
+  const stack: typeof transform[] = [];
   const ctx = {
     get font() { return font; },
     set font(v: string) { font = v; },
@@ -88,14 +90,46 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[]; meas
         actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
       } as TextMetrics;
     },
-    save() {}, restore() {}, beginPath() {}, closePath() {},
+    save() { stack.push({ ...transform }); },
+    restore() { transform = stack.pop() ?? transform; },
+    beginPath() {}, closePath() {},
     moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
-    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    strokeRect() {}, clip() {}, rect() {},
+    scale(x: number, y: number) {
+      transform.scaleX *= x;
+      transform.scaleY *= y;
+    },
+    translate(x: number, y: number) {
+      transform.translateX += transform.scaleX * x;
+      transform.translateY += transform.scaleY * y;
+    },
+    rotate() {},
     setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
     bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
-    drawImage(_img: unknown, x: number, y: number) { calls.push({ op: 'img', text: '', x, y, font }); },
-    fillText(s: string, x: number, y: number) { calls.push({ op: 'fill', text: s, x, y, font }); },
-    strokeText(s: string, x: number, y: number) { calls.push({ op: 'stroke', text: s, x, y, font }); },
+    drawImage(_img: unknown, x: number, y: number) {
+      calls.push({
+        op: 'img', text: '',
+        x: transform.translateX + transform.scaleX * x,
+        y: transform.translateY + transform.scaleY * y,
+        font,
+      });
+    },
+    fillText(s: string, x: number, y: number) {
+      calls.push({
+        op: 'fill', text: s,
+        x: transform.translateX + transform.scaleX * x,
+        y: transform.translateY + transform.scaleY * y,
+        font,
+      });
+    },
+    strokeText(s: string, x: number, y: number) {
+      calls.push({
+        op: 'stroke', text: s,
+        x: transform.translateX + transform.scaleX * x,
+        y: transform.translateY + transform.scaleY * y,
+        font,
+      });
+    },
     fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
     textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
     globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,

--- a/packages/docx/src/document-content.ts
+++ b/packages/docx/src/document-content.ts
@@ -1,0 +1,146 @@
+import type {
+  BodyElement,
+  DocParagraph,
+  DocRun,
+  DocTable,
+  DocxDocumentModel,
+  HeadersFooters,
+  ShapeRun,
+  ShapeText,
+} from './types.js';
+
+/** One rendered string and every authored font family that can supply it.
+ * Empty text records are intentional: paragraph marks and drawing anchors can
+ * affect line metrics even when they paint no glyphs. */
+export interface DocxRenderedTextUsage {
+  text: string;
+  fontFamilies: readonly (string | null | undefined)[];
+}
+
+function* shapeTextUsages(shape: ShapeRun): Generator<DocxRenderedTextUsage> {
+  if (shape.textPath) {
+    yield { text: shape.textPath.string, fontFamilies: [shape.textPath.fontFamily] };
+  }
+  for (const block of shape.textBlocks ?? []) {
+    yield* shapeBlockUsages(block);
+  }
+}
+
+function* shapeBlockUsages(block: ShapeText): Generator<DocxRenderedTextUsage> {
+  if (block.numbering) {
+    yield {
+      text: block.numbering.text,
+      fontFamilies: [block.numbering.fontFamily, block.numbering.fontFamilyEastAsia],
+    };
+  }
+  if (block.runs?.length) {
+    for (const run of block.runs) {
+      yield {
+        text: run.text,
+        // A run without an explicit axis inherits the block-level face.
+        fontFamilies: [
+          run.fontFamily,
+          run.fontFamilyEastAsia,
+          block.fontFamily,
+        ],
+      };
+    }
+  } else {
+    yield { text: block.text, fontFamilies: [block.fontFamily] };
+  }
+}
+
+function* runUsages(run: DocRun): Generator<DocxRenderedTextUsage> {
+  if (run.type === 'text') {
+    yield {
+      text: run.text,
+      fontFamilies: [run.fontFamily, run.fontFamilyEastAsia, run.fontFamilyCs],
+    };
+  } else if (run.type === 'field') {
+    yield { text: run.fallbackText, fontFamilies: [run.fontFamily] };
+  } else if (run.type === 'shape') {
+    yield* shapeTextUsages(run);
+  } else if (run.type === 'anchorHost') {
+    yield {
+      text: '',
+      fontFamilies: [run.fontFamily, run.fontFamilyEastAsia],
+    };
+  }
+}
+
+function* paragraphUsages(paragraph: DocParagraph): Generator<DocxRenderedTextUsage> {
+  // Empty paragraphs still reserve the resolved paragraph-mark line box.
+  yield {
+    text: '',
+    fontFamilies: [paragraph.defaultFontFamily, paragraph.defaultFontFamilyEastAsia],
+  };
+  if (paragraph.numbering) {
+    yield {
+      text: paragraph.numbering.text,
+      fontFamilies: [
+        paragraph.numbering.fontFamily,
+        paragraph.numbering.fontFamilyEastAsia,
+      ],
+    };
+  }
+  for (const run of paragraph.runs) yield* runUsages(run);
+}
+
+function* tableUsages(table: DocTable): Generator<DocxRenderedTextUsage> {
+  for (const row of table.rows) {
+    for (const cell of row.cells) {
+      yield* bodyUsages(cell.content as BodyElement[]);
+    }
+  }
+}
+
+function* headerFooterUsages(
+  stories: HeadersFooters | null | undefined,
+): Generator<DocxRenderedTextUsage> {
+  if (!stories) return;
+  for (const story of [stories.default, stories.first, stories.even]) {
+    if (story) yield* bodyUsages(story.body);
+  }
+}
+
+function* bodyUsages(body: readonly BodyElement[]): Generator<DocxRenderedTextUsage> {
+  for (const element of body) {
+    if (element.type === 'paragraph') {
+      yield* paragraphUsages(element);
+    } else if (element.type === 'table') {
+      yield* tableUsages(element);
+    } else if (element.type === 'sectionBreak') {
+      // Non-final sections keep their resolved header/footer stories on the
+      // marker; the top-level sets represent only the final section.
+      yield* headerFooterUsages(element.headers);
+      yield* headerFooterUsages(element.footers);
+    }
+  }
+}
+
+/** Traverse every rendered DOCX story once. This is shared by script-aware web
+ * font preloading and exact-local metric discovery so those paths cannot drift
+ * on nested tables, section headers/footers, notes, or drawing text. Comments
+ * are excluded because the page renderer does not paint comment bodies. */
+export function* docxRenderedTextUsages(
+  doc: DocxDocumentModel,
+): Generator<DocxRenderedTextUsage> {
+  yield* bodyUsages(doc.body ?? []);
+  yield* headerFooterUsages(doc.headers);
+  yield* headerFooterUsages(doc.footers);
+  for (const note of [...(doc.footnotes ?? []), ...(doc.endnotes ?? [])]) {
+    yield* bodyUsages(note.content);
+  }
+}
+
+/** Unique authored families in first-rendered-use order. */
+export function docxRenderedFontFamilies(doc: DocxDocumentModel): string[] {
+  const families = new Set<string>();
+  for (const usage of docxRenderedTextUsages(doc)) {
+    for (const family of usage.fontFamilies) {
+      const trimmed = family?.trim();
+      if (trimmed) families.add(trimmed);
+    }
+  }
+  return [...families];
+}

--- a/packages/docx/src/document-destroy.test.ts
+++ b/packages/docx/src/document-destroy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import {
   WorkerBridge,
+  loadLocalFontMetrics,
   registerEmbeddedFonts,
   preloadGoogleFonts,
   type WorkerLike,
@@ -33,12 +34,19 @@ class SilentWorker implements WorkerLike {
 // ── Fake FontFaceSet so destroy()'s embedded-font / Google-Fonts release is
 // observable ──────────────────────────────────────────────────────────────
 const G = globalThis as Record<string, unknown>;
-const ORIG_FONTS = { document: G.document, self: G.self, fetch: G.fetch, FontFace: G.FontFace };
+const ORIG_FONTS = {
+  document: G.document,
+  self: G.self,
+  fetch: G.fetch,
+  FontFace: G.FontFace,
+  OffscreenCanvas: G.OffscreenCanvas,
+};
 afterEach(() => {
   G.document = ORIG_FONTS.document;
   G.self = ORIG_FONTS.self;
   G.fetch = ORIG_FONTS.fetch;
   G.FontFace = ORIG_FONTS.FontFace;
+  G.OffscreenCanvas = ORIG_FONTS.OffscreenCanvas;
 });
 
 interface FakeFace { family: string }
@@ -84,6 +92,39 @@ function installGoogleFontFaceSet(): { added: FakeFace[] } {
   delete G.self;
   return { added };
 }
+
+function installLocalMetricFontEnvironment(): { added: FakeFace[] } {
+  const added: FakeFace[] = [];
+  class FakeFontFace {
+    status: FontFaceLoadStatus = 'unloaded';
+    constructor(public family: string, public source: string) {}
+    load(): Promise<this> {
+      this.status = 'loaded';
+      return Promise.resolve(this);
+    }
+  }
+  const set = {
+    add: (face: FakeFace) => { added.push(face); },
+    delete: (face: FakeFace) => {
+      const index = added.indexOf(face);
+      if (index >= 0) added.splice(index, 1);
+      return index >= 0;
+    },
+  };
+  class FakeOffscreenCanvas {
+    getContext() {
+      return {
+        font: '',
+        measureText: () => ({ fontBoundingBoxAscent: 106, fontBoundingBoxDescent: 44 }),
+      };
+    }
+  }
+  G.FontFace = FakeFontFace;
+  G.document = { fonts: set };
+  G.OffscreenCanvas = FakeOffscreenCanvas;
+  delete G.self;
+  return { added };
+}
 const GOOGLE_FONT_MAP: Record<string, FontPreloadEntry> = {
   calibri: { url: 'https://fonts.googleapis.com/css2?family=Carlito', loadFamily: 'Carlito' },
 };
@@ -112,6 +153,7 @@ describe('DocxDocument.destroy() — rejects in-flight worker requests', () => {
     instance._imageCache = new Map();
     instance._embeddedFontFaces = [];
     instance._googleFontFaces = [];
+    instance._localMetricFontFaces = [];
     instance._fetchImage = () => Promise.resolve(new Blob());
     return { doc: instance as unknown as DestroyProbe, bridge, worker };
   }
@@ -175,5 +217,22 @@ describe('DocxDocument.destroy() — rejects in-flight worker requests', () => {
     // left the FontFaceSet, and the held array was cleared.
     expect(added).toHaveLength(0);
     expect((doc as unknown as { _googleFontFaces: FontFace[] })._googleFontFaces).toHaveLength(0);
+  });
+
+  it('destroy() releases exact local metric faces from the FontFaceSet', async () => {
+    const { added } = installLocalMetricFontEnvironment();
+    const held = await loadLocalFontMetrics([{
+      family: 'Metric Face',
+      localNames: ['Metric Face'],
+      lineHeightMultiplier: 1.3,
+    }]);
+    expect(added).toHaveLength(1);
+
+    const { doc } = makeDocument();
+    (doc as unknown as { _localMetricFontFaces: FontFace[] })._localMetricFontFaces = held.faces;
+    doc.destroy();
+
+    expect(added).toHaveLength(0);
+    expect((doc as unknown as { _localMetricFontFaces: FontFace[] })._localMetricFontFaces).toHaveLength(0);
   });
 });

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -3,6 +3,7 @@ import wasmAssetUrl from './wasm/docx_parser_bg.wasm?url';
 import {
   preloadGoogleFonts,
   unloadGoogleFonts,
+  unloadLocalFontMetrics,
   unregisterEmbeddedFonts,
   WorkerBridge,
   defaultDpr,
@@ -14,10 +15,11 @@ import {
   type MathRenderer,
 } from '@silurus/ooxml-core';
 import type { PaginatedBodyElement, DocxDocumentModel, RenderPageOptions, WorkerRequest, WorkerResponse, DocComment, DocNote } from './types';
-import { renderDocumentToCanvas, documentHasMath, prepareMathRuns, paginateDocument, dropColorReplacedCache, physicalPageSizeForPage, type DocxTextRunInfo } from './renderer';
+import { renderDocumentToCanvas, documentHasMath, prepareMathRuns, paginateDocument, dropColorReplacedCache, physicalPageSizeForPage, setResolvedLocalFonts, clearResolvedLocalFonts, type DocxTextRunInfo } from './renderer';
 import { buildBookmarkPageMap } from './bookmark-nav';
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
 import { loadEmbeddedFonts } from './embedded-fonts';
+import { loadDocxLocalFontMetrics } from './local-font-metrics';
 import type {
   DocumentMeta,
   RenderWorkerRequest,
@@ -79,6 +81,8 @@ export class DocxDocument {
    *  shared FontFaceSet for the lifetime of the SPA (deduped + refcounted in core,
    *  so a web font shared with another open document survives until both go). */
   private _googleFontFaces: FontFace[] = [];
+  /** Exact local faces used for version-adaptive Office line metrics. */
+  private _localMetricFontFaces: FontFace[] = [];
   /** One stable closure per instance: core's path-keyed SVG cache namespaces on
    *  this identity, so two open documents never swap a shared zip path (e.g.
    *  word/media/image1.svg). Reusing one reference also lets the SVG cache hit
@@ -154,6 +158,11 @@ export class DocxDocument {
     if (mode === 'main' && doc._document?.embeddedFonts?.length) {
       doc._embeddedFontFaces = await loadEmbeddedFonts(doc._document, (p) => doc.getFontBytes(p));
     }
+    if (mode === 'main' && doc._document) {
+      const localMetrics = await loadDocxLocalFontMetrics(doc._document);
+      doc._localMetricFontFaces = localMetrics.faces;
+      setResolvedLocalFonts(doc._document, localMetrics.metrics);
+    }
     // Equations are converted + rasterized before pagination (which reads their
     // extents synchronously). Requires the opt-in `math` engine; without it,
     // equations are skipped (and the engine asset is never bundled). Math is
@@ -192,6 +201,7 @@ export class DocxDocument {
 
   destroy(): void {
     this._bridge.terminate();
+    if (this._document) clearResolvedLocalFonts(this._document);
     this._document = null;
     this._meta = null;
     this._pages = null;
@@ -213,6 +223,10 @@ export class DocxDocument {
     if (this._googleFontFaces.length > 0) {
       unloadGoogleFonts(this._googleFontFaces);
       this._googleFontFaces = [];
+    }
+    if (this._localMetricFontFaces.length > 0) {
+      unloadLocalFontMetrics(this._localMetricFontFaces);
+      this._localMetricFontFaces = [];
     }
     // Release this document's three per-fetchImage image caches: the decoded
     // base raster bitmaps (GPU-backed, shared with pptx/xlsx), the a:clrChange

--- a/packages/docx/src/empty-paragraph-mark-height.test.ts
+++ b/packages/docx/src/empty-paragraph-mark-height.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { renderDocumentToCanvas } from './renderer.js';
-import { paragraphMarkLineHeight } from './line-layout.js';
+import {
+  clearResolvedLocalFonts,
+  paginateDocument,
+  renderDocumentToCanvas,
+  setResolvedLocalFonts,
+} from './renderer.js';
+import { paragraphMarkBelowBaselinePt, paragraphMarkLineHeight } from './line-layout.js';
 import type {
   BodyElement,
   DocParagraph,
@@ -26,6 +31,7 @@ import type {
 // two code paths would coincide and the regression would be invisible.
 
 interface FillTextCall { text: string; x: number; y: number; }
+interface FillRectCall { x: number; y: number; width: number; height: number; }
 
 const ASC_RATIO = 0.95;
 const DESC_RATIO = 0.2; // sum = 1.15 em ≠ the old synthetic 0.8 + 0.2 = 1.0 em
@@ -65,6 +71,54 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: FillTextCall
     getContext: () => ctx,
   };
   return { canvas: canvas as unknown as HTMLCanvasElement, calls };
+}
+
+function makeResolvedMetricCanvas(): {
+  canvas: HTMLCanvasElement;
+  textCalls: FillTextCall[];
+  rectCalls: FillRectCall[];
+} {
+  let font = '10px serif';
+  const textCalls: FillTextCall[] = [];
+  const rectCalls: FillRectCall[] = [];
+  const fontPx = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    letterSpacing: '0px',
+    measureText: (s: string) => {
+      const px = fontPx();
+      const local = font.includes('__ooxml_local_exact');
+      const ascent = px * (local ? 1.2 : 0.8);
+      const descent = px * (local ? 0.3 : 0.2);
+      return {
+        width: [...s].length * px * 0.5,
+        fontBoundingBoxAscent: ascent,
+        fontBoundingBoxDescent: descent,
+        actualBoundingBoxAscent: ascent,
+        actualBoundingBoxDescent: descent,
+      } as TextMetrics;
+    },
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, stroke() {}, fill() {}, strokeRect() {},
+    clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    setLineDash() {}, drawImage() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
+    bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
+    fillRect(x: number, y: number, width: number, height: number) {
+      rectCalls.push({ x, y, width, height });
+    },
+    fillText(text: string, x: number, y: number) { textCalls.push({ text, x, y }); },
+    strokeText() {},
+    fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0, height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  return { canvas: canvas as unknown as HTMLCanvasElement, textCalls, rectCalls };
 }
 
 function textRun(text: string): DocxTextRun {
@@ -189,5 +243,99 @@ describe('empty paragraph mark line height (§17.3.1.29 / §17.3.1.33)', () => {
       ctx,
       {},
     )).toBe(40);
+  });
+
+  it('uses the resolved local alias and line ratio for the mark advance and baseline split', () => {
+    const p = {
+      ...para(''),
+      defaultFontSize: 10,
+      defaultFontFamily: 'Authored Family',
+    } as DocParagraph;
+    let font = '';
+    const ctx = {
+      get font() { return font; },
+      set font(v: string) { font = v; },
+      measureText: () => {
+        const local = font.includes('__ooxml_local_exact');
+        return {
+          width: 0,
+          fontBoundingBoxAscent: local ? 12 : 8,
+          fontBoundingBoxDescent: local ? 3 : 2,
+          actualBoundingBoxAscent: local ? 12 : 8,
+          actualBoundingBoxDescent: local ? 3 : 2,
+        } as TextMetrics;
+      },
+    } as unknown as CanvasRenderingContext2D;
+    const resolved = {
+      'authored family': { family: '__ooxml_local_exact', lineHeightRatio: 1.5 },
+    };
+
+    expect(paragraphMarkLineHeight(
+      p, 1, { type: null, linePitchPt: null }, false, false, ctx, {}, null, resolved,
+    )).toBe(15);
+    expect(paragraphMarkBelowBaselinePt(
+      p, { type: null, linePitchPt: null }, false, false, ctx, {}, null, resolved,
+    )).toBe(3);
+    expect(font).toBe('');
+  });
+
+  it('uses the same resolved local mark metrics for pagination and paint', async () => {
+    const authoredFamily = 'Authored Family';
+    const localPara = (text: string, shading?: string): DocParagraph => ({
+      ...para(text),
+      runs: text === ''
+        ? []
+        : [{ type: 'text', ...textRun(text), fontSize: 10, fontFamily: authoredFamily } as DocParagraph['runs'][number]],
+      defaultFontSize: 10,
+      defaultFontFamily: authoredFamily,
+      shading,
+    } as DocParagraph);
+    const model = docOf([
+      localPara('A'),
+      localPara('', 'c0ffee'),
+      localPara('B'),
+    ]);
+    model.section.pageWidth = 200;
+    model.section.pageHeight = 40;
+    model.fontFamilyClasses = {};
+    const resolved = {
+      'authored family': { family: '__ooxml_local_exact', lineHeightRatio: 1.5 },
+    };
+    const globalWithCanvas = globalThis as unknown as { OffscreenCanvas?: unknown };
+    const previousOffscreenCanvas = globalWithCanvas.OffscreenCanvas;
+    globalWithCanvas.OffscreenCanvas = class {
+      getContext() { return makeResolvedMetricCanvas().canvas.getContext('2d'); }
+    };
+    setResolvedLocalFonts(model, resolved);
+
+    try {
+      // Three 15pt local-face line boxes do not fit in the 40pt content band.
+      // Before the fix the empty mark used the authored fallback's 10pt box, so
+      // all three paragraphs were incorrectly packed onto one page.
+      const pages = paginateDocument(model);
+      expect(pages).toHaveLength(2);
+      expect(pages[0]).toHaveLength(2);
+      expect(pages[1]).toHaveLength(1);
+
+      const painted = [] as ReturnType<typeof makeResolvedMetricCanvas>[];
+      for (let pageIndex = 0; pageIndex < pages.length; pageIndex++) {
+        const recording = makeResolvedMetricCanvas();
+        painted.push(recording);
+        await renderDocumentToCanvas(model, recording.canvas, pageIndex, {
+          dpr: 1,
+          width: 200,
+          prebuiltPages: pages,
+        });
+      }
+
+      expect(painted[0].textCalls.map((call) => call.text)).toContain('A');
+      expect(painted[0].textCalls.map((call) => call.text)).not.toContain('B');
+      expect(painted[1].textCalls.map((call) => call.text)).toContain('B');
+      expect(painted[0].rectCalls.some((call) => Math.abs(call.height - 15) < 1e-6)).toBe(true);
+    } finally {
+      clearResolvedLocalFonts(model);
+      if (previousOffscreenCanvas === undefined) delete globalWithCanvas.OffscreenCanvas;
+      else globalWithCanvas.OffscreenCanvas = previousOffscreenCanvas;
+    }
   });
 });

--- a/packages/docx/src/float-layout.ts
+++ b/packages/docx/src/float-layout.ts
@@ -94,12 +94,11 @@ export const FLOAT_PAGE_RIGHT_SLACK = 0.5;
  *  (a ~62pt side-gap, below 1 inch, where the nine authoring blank-line marks
  *  after the figure stay BESIDE the float — flowing them below at 1 inch (the
  *  regression #676 introduced) pushed the caption + CONCLUSION onto the next
- *  page). The empty-mark
- *  threshold is `paragraphMarkEmPx` (renderer.ts); it governs the literally-empty
- *  / anchor-only paragraph paths — the paint pass `resolveEmptyMarkTop` and the
- *  paginator's mirror `flowMarkLine` — while every CONTENT line (including a
- *  content paragraph's trailing-break empty final line inside `layoutLines`)
- *  passes `wordMinLineStartPx` below. */
+ *  page). The narrow threshold is the paragraph-mark em; it governs the
+ *  literally-empty paths — the paint pass `resolveEmptyMarkTop` and paginator
+ *  mirror `flowMarkLine` — plus the anchorHost-only metric line inside
+ *  `layoutLines`. Every CONTENT line (including a content paragraph's
+ *  trailing-break empty final line) passes `wordMinLineStartPx` below. */
 export const WORD_MIN_LINE_START_PT = 72;
 
 /** Tolerance (pt) subtracted from the 1-inch requirement when testing a side

--- a/packages/docx/src/float-line-start-one-inch.test.ts
+++ b/packages/docx/src/float-line-start-one-inch.test.ts
@@ -239,6 +239,31 @@ describe('layoutLines — 1-inch line-start rule end to end (issue #676)', () =>
     expect(firstLinePlacement(emptyBeside)).toBe('beside');
   });
 
+  it('keeps an anchor-host metric-only line on the paragraph-mark threshold', () => {
+    const markWrap = {
+      ...wrapCtx(bandFor(62)),
+      paragraphMarkLineStartWidth: 10,
+    };
+    const lines = layoutLines(
+      makeLinearCtx(),
+      [textSeg('', 10, { metricOnly: true })],
+      colW,
+      0,
+      scale,
+      [],
+      markWrap,
+      {},
+      0,
+    );
+
+    // A zero-advance anchor-character placeholder preserves the run's line
+    // metrics, but it does not turn the pilcrow into inline content. The 62pt
+    // side gap holds the 10pt mark even though it is below the 1-inch content
+    // threshold, so the host line stays beside the float.
+    expect(firstLinePlacement(lines)).toBe('beside');
+    expect(lines[0].ascent + lines[0].descent).toBe(10);
+  });
+
   it('(c) a text line makes the SAME below/beside decision as the empty line', () => {
     const textBelow = layoutLines(makeLinearCtx(), [textSeg('hi', 10)], colW, 0, scale, [], wrapCtx(bandFor(70)), {}, 0);
     const textBeside = layoutLines(makeLinearCtx(), [textSeg('hi', 10)], colW, 0, scale, [], wrapCtx(bandFor(72)), {}, 0);

--- a/packages/docx/src/float-table-page-fit.test.ts
+++ b/packages/docx/src/float-table-page-fit.test.ts
@@ -147,6 +147,38 @@ function floatTableRows(tp: TblpPr, n: number, rowHPt: number): BodyElement {
   return { type: 'table', ...t } as unknown as BodyElement;
 }
 
+function borderedFloatTableRows(
+  tp: TblpPr,
+  n: number,
+  rule: 'auto' | 'atLeast',
+): BodyElement {
+  const rows = Array.from({ length: n }, (_value, index) => ({
+    ...row(20, `r${index + 1}`),
+    rowHeightRule: rule,
+  } as DocTableRow));
+  const outer = { style: 'single', width: 4, color: '#000000' } as const;
+  const inside = { style: 'single', width: 1, color: '#000000' } as const;
+  const table: DocTable = {
+    colWidths: [80],
+    rows,
+    borders: {
+      top: outer,
+      bottom: outer,
+      left: null,
+      right: null,
+      insideH: inside,
+      insideV: null,
+    },
+    cellMarginTop: 0,
+    cellMarginBottom: 0,
+    cellMarginLeft: 0,
+    cellMarginRight: 0,
+    jc: 'left',
+    tblpPr: tp,
+  };
+  return { type: 'table', ...table } as unknown as BodyElement;
+}
+
 /** A floating table (`w:tblpPr`) of total height `tableHPt`, laid out as one
  *  exact-height row so its measured extent is deterministic. */
 function floatTable(tp: TblpPr, tableHPt: number): BodyElement {
@@ -233,6 +265,30 @@ describe('computePages — floating-table page-fit / row-split (§17.4.57, Word 
       'r1', 'r2', 'r3', 'r4', 'r5',
     ]);
   });
+
+  it.each(['auto', 'atLeast'] as const)(
+    're-resolves outer border footprints for every %s floating-table slice',
+    (rule) => {
+      const body = [
+        borderedFloatTableRows(tblp({ vertAnchor: 'text', tblpY: 0 }), 3, rule),
+        para({ text: 'anchor' }),
+      ];
+
+      // The body band is 44pt. In the unsliced table, the first two rows appear
+      // to total 43.5pt (outer/2 + inside + content). Once emitted as a page
+      // slice, however, their last edge is the 4pt outer bottom and the pair is
+      // 45pt, so only one row fits. Each one-row slice is 20 + 4/2 + 4/2 = 24pt.
+      const pages = computePages(body, section({ pageHeight: 84 }), makeCtx());
+      const slices = pages
+        .flatMap((page) => page.filter(isFloatTable));
+
+      expect(slices).toHaveLength(3);
+      expect(pages.map(floatRowsOn).filter((labels) => labels.length > 0))
+        .toEqual([['r1'], ['r2'], ['r3']]);
+      expect(slices.map((slice) => slice.tableRowHeightsPt))
+        .toEqual([[24], [24], [24]]);
+    },
+  );
 
   it('moves a following block table past a page-filling float across a continuous section', () => {
     const body = [

--- a/packages/docx/src/float-table-page-fit.test.ts
+++ b/packages/docx/src/float-table-page-fit.test.ts
@@ -179,6 +179,40 @@ function borderedFloatTableRows(
   return { type: 'table', ...table } as unknown as BodyElement;
 }
 
+function mixedBoundaryFloatTable(tp: TblpPr): BodyElement {
+  const rules = [
+    { height: 10, rule: 'auto' },
+    { height: 1, rule: 'exact' },
+    { height: 10, rule: 'auto' },
+    { height: 1, rule: 'exact' },
+    { height: 10, rule: 'auto' },
+  ] as const;
+  const rows = rules.map(({ height, rule }) => ({
+    ...row(height),
+    rowHeightRule: rule,
+  } as DocTableRow));
+  const outer = { style: 'single', width: 12, color: '#000000' } as const;
+  const table: DocTable = {
+    colWidths: [80],
+    rows,
+    borders: {
+      top: outer,
+      bottom: outer,
+      left: null,
+      right: null,
+      insideH: null,
+      insideV: null,
+    },
+    cellMarginTop: 0,
+    cellMarginBottom: 0,
+    cellMarginLeft: 0,
+    cellMarginRight: 0,
+    jc: 'left',
+    tblpPr: tp,
+  };
+  return { type: 'table', ...table } as unknown as BodyElement;
+}
+
 /** A floating table (`w:tblpPr`) of total height `tableHPt`, laid out as one
  *  exact-height row so its measured extent is deterministic. */
 function floatTable(tp: TblpPr, tableHPt: number): BodyElement {
@@ -289,6 +323,25 @@ describe('computePages — floating-table page-fit / row-split (§17.4.57, Word 
         .toEqual([[24], [24], [24]]);
     },
   );
+
+  it('chooses the largest fitting mixed exact/auto floating-slice endpoint', () => {
+    const body = [
+      mixedBoundaryFloatTable(tblp({ vertAnchor: 'text', tblpY: 0 })),
+      para({ text: 'anchor' }),
+    ];
+
+    // The candidate prefix heights are [22, 17, 33, 28, 44]. They are not
+    // monotonic because appending an exact row removes the preceding auto row's
+    // outer-bottom footprint. The 32pt band must select four rows at 28pt.
+    const pages = computePages(body, section({ pageHeight: 72 }), makeCtx());
+    const slices = pages.flatMap((page) => page.filter(isFloatTable));
+
+    expect(slices.map((slice) => (slice as unknown as DocTable).rows.length))
+      .toEqual([4, 1]);
+    expect(slices.map((slice) =>
+      slice.tableRowHeightsPt?.reduce((sum, height) => sum + height, 0)))
+      .toEqual([28, 22]);
+  });
 
   it('moves a following block table past a page-filling float across a continuous section', () => {
     const body = [

--- a/packages/docx/src/google-fonts.ts
+++ b/packages/docx/src/google-fonts.ts
@@ -6,11 +6,9 @@ import {
   type FontPreloadEntry,
 } from '@silurus/ooxml-core';
 import type {
-  BodyElement,
-  DocParagraph,
-  DocTable,
   DocxDocumentModel,
 } from './types.js';
+import { docxRenderedTextUsages } from './document-content.js';
 
 /** Theme-referenced typefaces commonly used by DOCX templates.
  *
@@ -26,43 +24,8 @@ export const DOCX_GOOGLE_FONTS: Record<string, FontPreloadEntry> = {
   ...SCRIPT_GOOGLE_FONTS,
 };
 
-/** Yield every rendered text string in the document model so the preload step
- *  can detect which scripts are actually present. Walks the body, headers /
- *  footers, footnotes / endnotes and nested tables (text-only). Comments are
- *  not painted on the page, so they are excluded. */
 function* docxTextRuns(doc: DocxDocumentModel): Generator<string> {
-  const fromRuns = function* (runs: DocParagraph['runs']): Generator<string> {
-    for (const r of runs) {
-      if (r.type === 'text') yield r.text;
-      else if (r.type === 'field') yield r.fallbackText;
-      else if (r.type === 'shape') {
-        for (const t of r.textBlocks ?? []) yield t.text;
-      }
-    }
-  };
-  const walk = function* (el: BodyElement): Generator<string> {
-    if ('runs' in el) yield* fromRuns((el as DocParagraph).runs);
-    if ('rows' in el) {
-      for (const row of (el as DocTable).rows) {
-        for (const cell of row.cells) {
-          for (const child of cell.content) yield* walk(child as BodyElement);
-        }
-      }
-    }
-  };
-  const walkBody = function* (body: BodyElement[] | undefined): Generator<string> {
-    for (const el of body ?? []) yield* walk(el);
-  };
-
-  yield* walkBody(doc.body);
-  for (const hf of [doc.headers, doc.footers]) {
-    for (const which of [hf?.default, hf?.first, hf?.even]) {
-      yield* walkBody(which?.body);
-    }
-  }
-  for (const note of [...(doc.footnotes ?? []), ...(doc.endnotes ?? [])]) {
-    yield* walkBody(note.content);
-  }
+  for (const usage of docxRenderedTextUsages(doc)) yield usage.text;
 }
 
 /**

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -58,6 +58,7 @@ export type {
   // DrawingML chart run (reachable via the DocRun union's `chart` arm,
   // ECMA-376 §21.2).
   ChartRun,
+  AnchorHostMetrics,
   ShapeRun,
   // VML `<v:textpath>` watermark text (reachable via ShapeRun.textPath).
   TextPath,

--- a/packages/docx/src/layout-lines-reuse-identity.test.ts
+++ b/packages/docx/src/layout-lines-reuse-identity.test.ts
@@ -46,7 +46,15 @@ import type {
 // migrated paragraph paints with zero measureText calls).
 // ─────────────────────────────────────────────────────────────────────────────
 
-interface Call { op: 'fill' | 'stroke' | 'img'; text: string; x: number; y: number; font: string; }
+interface Call {
+  op: 'fill' | 'stroke' | 'img';
+  text: string;
+  x: number;
+  y: number;
+  font: string;
+  scaleX: number;
+  scaleY: number;
+}
 
 /** `paginateDocument` builds its measure ctx from `new OffscreenCanvas(1,1)`,
  *  which the node test env lacks. Polyfill it with the SAME linear metric the
@@ -91,6 +99,19 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[]; meas
   let font = '10px serif';
   const calls: Call[] = [];
   let measures = 0;
+  let transform = { scaleX: 1, scaleY: 1, translateX: 0, translateY: 0 };
+  const transformStack: typeof transform[] = [];
+  const record = (op: Call['op'], text: string, x: number, y: number): void => {
+    calls.push({
+      op,
+      text,
+      x: transform.translateX + transform.scaleX * x,
+      y: transform.translateY + transform.scaleY * y,
+      font,
+      scaleX: transform.scaleX,
+      scaleY: transform.scaleY,
+    });
+  };
   const ctx = {
     get font() { return font; },
     set font(v: string) { font = v; },
@@ -105,14 +126,29 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; calls: Call[]; meas
         actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
       } as TextMetrics;
     },
-    save() {}, restore() {}, beginPath() {}, closePath() {},
+    save() { transformStack.push({ ...transform }); },
+    restore() { transform = transformStack.pop() ?? transform; },
+    beginPath() {}, closePath() {},
     moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
-    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    strokeRect() {}, clip() {}, rect() {},
+    scale(sx: number, sy: number) {
+      transform.scaleX *= sx;
+      transform.scaleY *= sy;
+    },
+    translate(x: number, y: number) {
+      transform.translateX += transform.scaleX * x;
+      transform.translateY += transform.scaleY * y;
+    },
+    rotate() {},
     setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
     bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
-    drawImage(_img: unknown, x: number, y: number) { calls.push({ op: 'img', text: '', x, y, font }); },
-    fillText(s: string, x: number, y: number) { calls.push({ op: 'fill', text: s, x, y, font }); },
-    strokeText(s: string, x: number, y: number) { calls.push({ op: 'stroke', text: s, x, y, font }); },
+    drawImage(_img: unknown, ...args: number[]) {
+      const x = args.length >= 8 ? args[4] : args[0];
+      const y = args.length >= 8 ? args[5] : args[1];
+      record('img', '', x ?? 0, y ?? 0);
+    },
+    fillText(s: string, x: number, y: number) { record('fill', s, x, y); },
+    strokeText(s: string, x: number, y: number) { record('stroke', s, x, y); },
     fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
     textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
     globalAlpha: 1, lineCap: 'butt' as CanvasLineCap, lineJoin: 'miter' as CanvasLineJoin,
@@ -188,8 +224,8 @@ async function renderVariant(
 /** Render every page at the DEFAULT CSS scale (PT_TO_PX = 4/3, `width` OMITTED so
  *  scale = 4/3 ≠ 1) under an explicit (fragmentPaint, reuse) configuration; restore
  *  the flags after. At this scale the fragment path and the legacy reuse path both
- *  RESCALE their stored scale-1 partition (rescaleLayoutLines re-measures each line at
- *  the paint scale), so their streams must be byte-identical. */
+ *  map their stored scale-1 partition through the canonical viewport transform,
+ *  so their streams must be byte-identical. */
 async function renderVariantScaled(
   model: DocxDocumentModel,
   pages: PaginatedBodyElement[][],
@@ -352,10 +388,10 @@ describe('body paint byte-identity — fragment paint and compute-once line reus
     for (let p = 0; p < production.length; p++) {
       expect(production[p]).toEqual(reuse[p]);
     }
-    // Non-vacuity: the paint really ran at scale 4/3 — a fractional glyph px size in
-    // the recorded font proves the geometry was rescaled off scale 1 (a scale-1 paint
-    // would only ever show the integer '10px').
-    const scaled = production.flat().some((c) => c.op !== 'img' && /\d+\.\d+px/.test(c.font));
+    // Non-vacuity: the glyphs retain their canonical 10px shaping font and are
+    // mapped to the default 4/3 paint scale by the local Canvas transform.
+    const scaled = production.flat().some((c) =>
+      c.op !== 'img' && c.font.includes('10px') && Math.abs(c.scaleX - 4 / 3) < 1e-9);
     expect(scaled).toBe(true);
     expect(production.some((pg) => pg.length > 0)).toBe(true);
   });

--- a/packages/docx/src/layout-lines-zoom-invariant.test.ts
+++ b/packages/docx/src/layout-lines-zoom-invariant.test.ts
@@ -5,7 +5,17 @@ import {
   __test_setLineReuseEnabled,
 } from './renderer.js';
 import { layoutLines, type LayoutSeg } from './line-layout.js';
-import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps, PaginatedBodyElement } from './types';
+import type {
+  BodyElement,
+  CellElement,
+  DocParagraph,
+  DocTable,
+  DocTableCell,
+  DocTableRow,
+  DocxDocumentModel,
+  SectionProps,
+  PaginatedBodyElement,
+} from './types';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Phase 4-1 B2 Stage 2 — ZOOM-INVARIANT line breaking.
@@ -13,9 +23,9 @@ import type { BodyElement, DocParagraph, DocxDocumentModel, SectionProps, Pagina
 // Word lays text out in the document's own coordinate space and treats the
 // display scale as a viewport transform: the line PARTITION (which glyphs land
 // on which line) is the same at every zoom. Stage 2 realises this by reusing the
-// paginator's scale-1 line PARTITION at ANY paint scale — re-measuring the glyph
-// geometry at the paint scale (so the pen tracks the glyphs) but never
-// re-deciding the wrap points — instead of re-running layoutLines' break
+// paginator's scale-1 line PARTITION at ANY paint scale — mapping ordinary body
+// glyph geometry through a viewport transform without re-deciding wrap points —
+// instead of re-running layoutLines' break
 // decisions at the paint scale, which under a real (hinted) font whose glyph
 // advance is NOT proportional to the font px size would shift wrap points as the
 // zoom changes (documented in layout-lines-scale-invariance.test.ts).
@@ -66,18 +76,22 @@ function makeMeasureStubCtx(): CanvasRenderingContext2D {
   getContext() { return makeMeasureStubCtx(); }
 };
 
-interface Draw { text: string; x: number; y: number; }
+interface Draw { text: string; x: number; y: number; right: number; font: string; scaleX: number; }
 
 /** A recording canvas backed by the SAME sub-linear metric. Records every text
  *  draw with its baseline y so the caller can reconstruct the per-line partition
  *  (glyphs sharing a baseline belong to one line). */
 function makeRecordingCanvas(): { canvas: HTMLCanvasElement; draws: Draw[] } {
   let font = '10px serif';
+  let letterSpacing = '0px';
+  let transform = { scaleX: 1, scaleY: 1, translateX: 0, translateY: 0 };
+  const stack: typeof transform[] = [];
   const draws: Draw[] = [];
   const ctx = {
     get font() { return font; },
     set font(v: string) { font = v; },
-    letterSpacing: '0px',
+    get letterSpacing() { return letterSpacing; },
+    set letterSpacing(v: string) { letterSpacing = v; },
     measureText: (s: string) => {
       const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
       return {
@@ -86,13 +100,40 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; draws: Draw[] } {
         actualBoundingBoxAscent: p * 0.8, actualBoundingBoxDescent: p * 0.2,
       } as TextMetrics;
     },
-    save() {}, restore() {}, beginPath() {}, closePath() {},
+    save() { stack.push({ ...transform }); },
+    restore() { transform = stack.pop() ?? transform; },
+    beginPath() {}, closePath() {},
     moveTo() {}, lineTo() {}, stroke() {}, fill() {}, fillRect() {},
-    strokeRect() {}, clip() {}, rect() {}, scale() {}, translate() {}, rotate() {},
+    strokeRect() {}, clip() {}, rect() {},
+    scale(x: number, y: number) {
+      transform.scaleX *= x;
+      transform.scaleY *= y;
+    },
+    translate(x: number, y: number) {
+      transform.translateX += transform.scaleX * x;
+      transform.translateY += transform.scaleY * y;
+    },
+    rotate() {},
     setLineDash() {}, clearRect() {}, arc() {}, quadraticCurveTo() {},
     bezierCurveTo() {}, createLinearGradient() { return { addColorStop() {} }; },
     drawImage() {},
-    fillText(s: string, x: number, y: number) { if (s) draws.push({ text: s, x, y }); },
+    fillText(s: string, x: number, y: number) {
+      if (!s) return;
+      const p = parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+      const worldX = transform.translateX + transform.scaleX * x;
+      const worldY = transform.translateY + transform.scaleY * y;
+      const spacing = parseFloat(letterSpacing) || 0;
+      const localAdvance =
+        subLinearWidth(s, p) + Math.max(0, [...s].length - 1) * spacing;
+      draws.push({
+        text: s,
+        x: worldX,
+        y: worldY,
+        right: worldX + transform.scaleX * localAdvance,
+        font,
+        scaleX: transform.scaleX,
+      });
+    },
     strokeText() {},
     fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
     textAlign: 'left' as CanvasTextAlign, direction: 'ltr' as CanvasDirection,
@@ -135,6 +176,41 @@ function doc(body: BodyElement[], pageHeight = 60): DocxDocumentModel {
     fontFamilyClasses: { 'Times New Roman': 'roman' },
     footnotes: [],
   } as unknown as DocxDocumentModel;
+}
+
+function oneCellTable(paragraph: DocParagraph): BodyElement {
+  const border = { style: 'single', color: '000000', width: 0.5 };
+  const cell: DocTableCell = {
+    content: [{ type: 'paragraph', ...paragraph } as CellElement],
+    colSpan: 1,
+    vMerge: null,
+    borders: { top: border, bottom: border, left: border, right: border, insideH: null, insideV: null },
+    background: null,
+    vAlign: 'top',
+    widthPt: 180,
+  } as DocTableCell;
+  const row: DocTableRow = {
+    cells: [cell],
+    rowHeight: null,
+    rowHeightRule: 'auto',
+    isHeader: false,
+  } as DocTableRow;
+  const table: DocTable = {
+    type: 'table',
+    colWidths: [180],
+    rows: [row],
+    borders: { top: border, bottom: border, left: border, right: border, insideH: null, insideV: null },
+    cellMarginTop: 0,
+    cellMarginBottom: 0,
+    cellMarginLeft: 0,
+    cellMarginRight: 0,
+    jc: 'left',
+    // A negative leading indent gate-excludes fragment paint, so the legacy
+    // table layout must share the canonical paragraph contract.
+    tblInd: -5,
+    layout: 'fixed',
+  } as DocTable;
+  return table as unknown as BodyElement;
 }
 
 /** Reconstruct the per-line TEXT partition from a paint stream: group draws by
@@ -190,6 +266,109 @@ describe('zoom-invariant line breaking (Phase 4-1 B2 Stage 2)', () => {
     const at1 = await partitionAtWidth(model, pages, 200);   // scale 1.0
     const at05 = await partitionAtWidth(model, pages, 100);  // scale 0.5
     expect(at05).toEqual(at1);
+  });
+
+  it('keeps a justified CJK line inside its right paragraph border at every scale', async () => {
+    const borderSpacePt = 4;
+    const p = para('あ'.repeat(240), {
+      alignment: 'justify',
+      borders: {
+        top: null,
+        bottom: null,
+        left: null,
+        right: { style: 'single', color: '000000', width: 0.5, space: borderSpacePt },
+        between: null,
+      },
+    });
+    const model = doc([p as unknown as BodyElement]);
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(1);
+
+    const paintScale = 0.5;
+    const runBoxes: { x: number; w: number; font: string; fontSize: number }[] = [];
+    const glyphDraws: Draw[] = [];
+    for (let pageIndex = 0; pageIndex < pages.length; pageIndex++) {
+      const rec = makeRecordingCanvas();
+      await renderDocumentToCanvas(model, rec.canvas, pageIndex, {
+        dpr: 1,
+        width: model.section.pageWidth * paintScale,
+        prebuiltPages: pages,
+        onTextRun: ({ x, w, font, fontSize }) => runBoxes.push({ x, w, font, fontSize }),
+      });
+      glyphDraws.push(...rec.draws);
+    }
+
+    expect(runBoxes.length).toBeGreaterThan(0);
+    const rightBorderX =
+      (model.section.pageWidth - model.section.marginRight + borderSpacePt) * paintScale;
+    const rightmostRunX = Math.max(...runBoxes.map(({ x, w }) => x + w));
+    expect(rightmostRunX).toBeLessThanOrEqual(rightBorderX + 1e-6);
+    expect(Math.max(...glyphDraws.map(({ right }) => right))).toBeLessThanOrEqual(rightBorderX + 1e-6);
+    expect(runBoxes.every(({ font, fontSize }) => font.includes('5px') && fontSize === 5)).toBe(true);
+  });
+
+  it('keeps justified CJK inside a negative-indent legacy body table cell at every scale', async () => {
+    const model = doc([
+      oneCellTable(para('あ'.repeat(240), { alignment: 'justify' })),
+    ], 600);
+    const pages = paginateDocument(model);
+    expect(pages.length).toBeGreaterThan(0);
+
+    const paintScale = 0.5;
+    const glyphDraws: Draw[] = [];
+    const runRights: number[] = [];
+    for (let pageIndex = 0; pageIndex < pages.length; pageIndex++) {
+      const rec = makeRecordingCanvas();
+      await renderDocumentToCanvas(model, rec.canvas, pageIndex, {
+        dpr: 1,
+        width: model.section.pageWidth * paintScale,
+        prebuiltPages: pages,
+        onTextRun: ({ x, w }) => runRights.push(x + w),
+      });
+      glyphDraws.push(...rec.draws);
+    }
+
+    expect(glyphDraws.length).toBeGreaterThan(0);
+    const tableRightX =
+      (model.section.marginLeft - 5 + 180) * paintScale;
+    expect(Math.max(...runRights)).toBeLessThanOrEqual(tableRightX + 1e-6);
+    expect(Math.max(...glyphDraws.map(({ right }) => right))).toBeLessThanOrEqual(tableRightX + 1e-6);
+    expect(glyphDraws.some(({ font, scaleX }) =>
+      font.includes('10px') && Math.abs(scaleX - paintScale) < 1e-9)).toBe(true);
+  });
+
+  it.each([
+    ['numbering marker', () => para('body', {
+      numbering: {
+        numId: 1, level: 0, format: 'decimal', text: '1.', indentLeft: 18,
+        tab: 18, suff: 'tab', jc: 'left',
+      },
+    })],
+    ['tab segment', () => para('body\ttail', {
+      tabStops: [{ pos: 60, alignment: 'left', leader: 'dot' }],
+    })],
+    ['math segment', () => {
+      const paragraph = para('body');
+      paragraph.runs.push({
+        type: 'math', display: false, fontSize: 10,
+        nodes: [{ kind: 'run', text: 'x+1', style: 'italic' }],
+      } as DocParagraph['runs'][number]);
+      return paragraph;
+    }],
+  ])('keeps %s on the established paint-scale path', async (_name, makeParagraph) => {
+    const model = doc([makeParagraph() as unknown as BodyElement], 600);
+    const pages = paginateDocument(model);
+    const rec = makeRecordingCanvas();
+    await renderDocumentToCanvas(model, rec.canvas, 0, {
+      dpr: 1,
+      width: model.section.pageWidth * 0.5,
+      prebuiltPages: pages,
+    });
+
+    const body = rec.draws.find((draw) => draw.text === 'body');
+    expect(body).toBeDefined();
+    expect(body!.font).toContain('5px');
+    expect(body!.scaleX).toBe(1);
   });
 
   it('CONTROL: the mock font is genuinely NON-linear — a paint-scale re-layout WOULD wrap differently', () => {

--- a/packages/docx/src/layout-lines-zoom-invariant.test.ts
+++ b/packages/docx/src/layout-lines-zoom-invariant.test.ts
@@ -304,6 +304,10 @@ describe('zoom-invariant line breaking (Phase 4-1 B2 Stage 2)', () => {
     const rightmostRunX = Math.max(...runBoxes.map(({ x, w }) => x + w));
     expect(rightmostRunX).toBeLessThanOrEqual(rightBorderX + 1e-6);
     expect(Math.max(...glyphDraws.map(({ right }) => right))).toBeLessThanOrEqual(rightBorderX + 1e-6);
+    // Top-level body paragraphs intentionally have an empty story-container
+    // chain and still use the canonical document-space glyph transform.
+    expect(glyphDraws.some(({ font, scaleX }) =>
+      font.includes('10px') && Math.abs(scaleX - paintScale) < 1e-9)).toBe(true);
     expect(runBoxes.every(({ font, fontSize }) => font.includes('5px') && fontSize === 5)).toBe(true);
   });
 

--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -86,23 +86,26 @@ describe('lineBoxHeight — atLeast with an active line grid', () => {
     expect(lineBoxHeight(atLeast(24), 10, 2, 1, grid20)).toBe(24);
   });
 
-  // BEHAVIOUR PIN, not Word-verified ground truth. For an East Asian atLeast
-  // line the grid-minimum term is the natural-height cell count
-  // (docGridLineCells): a 12pt Yu Mincho line (design box 17.19px) on an 18pt
-  // pitch resolves to max(natural 17.19 / authored 18 / grid cell 18) = 18.
-  // No corpus sample exercises atLeast inside an active line grid and a Word
-  // fixture export could not be captured when this was pinned, so Word's exact
-  // atLeast-on-grid height is UNVERIFIED; the pin makes any future change to
-  // this resolution deliberate rather than accidental. Ruby lines keep the
-  // measured-glyph-box minimum (they reserve real furigana height).
-  it('[pin] EA atLeast takes max(natural, authored, grid cells) — unverified vs Word', () => {
+  // ECMA-376 §17.18.48 defines atLeast as an authored minimum that expands only
+  // as needed to fit its content. §17.6.5 contributes the active line pitch as
+  // another minimum (unless exact spacing or snapToGrid=false overrides it),
+  // but does not require an explicit atLeast line to occupy an integer number
+  // of grid cells. Whole-cell rounding belongs to automatic/null grid layout.
+  it('takes the maximum of content, authored minimum, and one grid pitch', () => {
     expect(lineBoxHeight(atLeast(18), 12 * YU_ASC, 12 * YU_DESC, 1, grid18, false, 12 * YU, true)).toBe(18);
   });
-  it('[pin] EA atLeast still snaps to the grid cells when they exceed natural and authored', () => {
-    // 20pt design line 28.65px on pitch 18 → 2 cells = 36 > authored 18.
-    expect(lineBoxHeight(atLeast(18), 20 * YU_ASC, 20 * YU_DESC, 1, grid18, false, 20 * YU, true)).toBe(36);
+  it('does not round tall East Asian content up to an additional grid cell', () => {
+    // 20pt design line 28.65px on pitch 18: content exceeds both minima, so
+    // atLeast keeps 28.65px rather than automatic grid rounding it to 36px.
+    expect(lineBoxHeight(atLeast(18), 20 * YU_ASC, 20 * YU_DESC, 1, grid18, false, 20 * YU, true))
+      .toBeCloseTo(20 * YU, 12);
   });
-  it('[pin] a RUBY EA atLeast line keeps the measured glyph-box minimum', () => {
+  it('preserves automatic whole-cell rounding for inherited-only spacing', () => {
+    const inherited = { ...atLeast(18), explicit: false };
+    expect(lineBoxHeight(inherited, 20 * YU_ASC, 20 * YU_DESC, 1, grid18, false, 20 * YU, true))
+      .toBe(36);
+  });
+  it('keeps ruby atLeast lines rounded to cells that contain the annotation', () => {
     // glyph box 41px (base + furigana reserve) → ceil(41/18) = 3 cells = 54.
     expect(lineBoxHeight(atLeast(18), 33, 8, 1, grid18, true, 0, true)).toBe(54);
   });

--- a/packages/docx/src/line-box-height.test.ts
+++ b/packages/docx/src/line-box-height.test.ts
@@ -86,17 +86,15 @@ describe('lineBoxHeight — atLeast with an active line grid', () => {
     expect(lineBoxHeight(atLeast(24), 10, 2, 1, grid20)).toBe(24);
   });
 
-  // ECMA-376 §17.18.48 defines atLeast as an authored minimum that expands only
-  // as needed to fit its content. §17.6.5 contributes the active line pitch as
-  // another minimum (unless exact spacing or snapToGrid=false overrides it),
-  // but does not require an explicit atLeast line to occupy an integer number
-  // of grid cells. Whole-cell rounding belongs to automatic/null grid layout.
+  // ECMA-376 defines the authored atLeast minimum and the active grid pitch,
+  // but not this precise tall-line interaction. The unsnapped result below is
+  // retained as observed Windows Word compatibility behavior.
   it('takes the maximum of content, authored minimum, and one grid pitch', () => {
     expect(lineBoxHeight(atLeast(18), 12 * YU_ASC, 12 * YU_DESC, 1, grid18, false, 12 * YU, true)).toBe(18);
   });
   it('does not round tall East Asian content up to an additional grid cell', () => {
-    // 20pt design line 28.65px on pitch 18: content exceeds both minima, so
-    // atLeast keeps 28.65px rather than automatic grid rounding it to 36px.
+    // Observed output keeps a 20pt design line at 28.65px on an 18px pitch,
+    // rather than applying automatic grid rounding to 36px.
     expect(lineBoxHeight(atLeast(18), 20 * YU_ASC, 20 * YU_DESC, 1, grid18, false, 20 * YU, true))
       .toBeCloseTo(20 * YU, 12);
   });

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -19,7 +19,7 @@ import type {
   DocParagraph, DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeTextRun, FieldRun,
   LineSpacing, TabStop, DocxRunBorder, DocSettings, EmphasisMark,
 } from './types';
-import type { MathNode, KinsokuRules, ChartModel, HyperlinkTarget, NumberFormat, Duotone } from '@silurus/ooxml-core';
+import type { MathNode, KinsokuRules, ChartModel, HyperlinkTarget, NumberFormat, Duotone, ResolvedLocalFontMetric } from '@silurus/ooxml-core';
 import type { RenderState, DecodedImage } from './renderer.js';
 import {
   classifyCjkFont,
@@ -46,6 +46,7 @@ import {
   formatDateTimePicture,
   parseDateTimePictureSwitch,
   fontAdvanceBiasEm,
+  normalizeLocalFontMetricFamily,
 } from '@silurus/ooxml-core';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
 import { groupFitTextRegions, type FitTextRun } from './fit-text.js';
@@ -87,6 +88,10 @@ export interface LayoutTextSeg extends LayoutSegSource {
   fontSize: number;  // pt
   color: string | null;
   fontFamily: string | null;
+  /** Exact local face selected during async document loading. The family above
+   * is its isolated alias; this measured ratio supplies Word's design-line floor
+   * without a version-specific font constant. */
+  resolvedLineHeightRatio?: number;
   vertAlign: 'super' | 'sub' | null;
   measuredWidth: number;  // px (set during layout)
   smallCaps?: boolean;
@@ -134,6 +139,7 @@ export interface LayoutTextSeg extends LayoutSegSource {
    *  per segment, so body behaviour is unchanged); the TEXT-BOX metrics
    *  (`lineMetricsFor`) floor on it so a text box matches PR #640/#646/#648. */
   eaFloorFamily?: string | null;
+  resolvedEaFloorLineHeightRatio?: number;
   /** IX1 — the resolved hyperlink target of the originating run (ECMA-376
    *  §17.16.22 external `r:id` URL / §17.16.23 internal `w:anchor` bookmark),
    *  computed once per run in `buildSegments`. Carried purely so the text-layer
@@ -321,6 +327,12 @@ export interface LayoutLine {
   height: number;  // pt — max fontSize on line (for empty-line sizing fallback)
   ascent: number;  // px — fontBoundingBoxAscent (font-metric, stable per font+size)
   descent: number; // px — fontBoundingBoxDescent
+  /** Baseline box contributed by segments that paint inline ink. A floating
+   *  anchor host can reserve the line's ascent/descent while contributing no
+   *  glyph; in that mixed case these exclude the metric-only placeholder. */
+  visibleAscent?: number;
+  visibleDescent?: number;
+  visibleIntendedSingle?: number;
   /** px — intended single-line height (max over segments of the requested
    *  font's win line-height ratio × em), for fonts whose substituted Canvas
    *  metrics understate Word's line spacing. 0 when no segment needs it. */
@@ -429,6 +441,7 @@ export interface LineLayoutEnvironment {
   readonly noteNumbers?: ReadonlyMap<string, number>;
   readonly currentNoteNumber?: number;
   readonly verticalCJK?: boolean;
+  readonly resolvedLocalFonts?: Readonly<Record<string, ResolvedLocalFontMetric>>;
 }
 
 // ── Math (OMML) rendering via MathJax ───────────────────────────────────────
@@ -762,6 +775,31 @@ export function calcEffectiveFontPx(s: LayoutTextSeg, scale: number): number {
   let size = pt * scale;
   if (s.vertAlign) size *= 0.65;
   return size;
+}
+
+/** Design single-line floor for a measured segment. An exact local face, when
+ * resolved during document loading, supersedes the static family profile; the
+ * latter remains the fallback when local() is unavailable or rejected. */
+export function segmentIntendedSingleLinePx(
+  segment: LayoutTextSeg,
+  emPx: number,
+  eastAsian = false,
+): number {
+  return Math.max(
+    intendedSingleLinePx(segment.fontFamily, emPx, eastAsian),
+    (segment.resolvedLineHeightRatio ?? 0) * emPx,
+  );
+}
+
+export function segmentEastAsiaFloorSingleLinePx(
+  segment: LayoutTextSeg,
+  emPx: number,
+  eastAsian = false,
+): number {
+  return Math.max(
+    intendedSingleLinePx(segment.eaFloorFamily, emPx, eastAsian),
+    (segment.resolvedEaFloorLineHeightRatio ?? 0) * emPx,
+  );
 }
 
 export function getDefaultFontSize(para: DocParagraph): number {
@@ -2111,6 +2149,8 @@ function resolveFitTextSegments(
 
 export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment): LayoutSeg[] {
   const segs: LayoutSeg[] = [];
+  const resolvedFont = (family: string | null | undefined): ResolvedLocalFontMetric | undefined =>
+    family ? environment.resolvedLocalFonts?.[normalizeLocalFontMetricFamily(family)] : undefined;
   // Group §17.3.2.14 adjacency over SOURCE RUNS before script/font, word, or
   // small-caps segmentation, but model each tab-delimited fragment as its own
   // source unit. A tab is a position-dependent advance rather than a glyph, so a
@@ -2240,6 +2280,8 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
     // family for its whole `.text` — so the measure==draw / docGrid char-grid
     // invariant holds and the draw loop needs no per-segment font switching.
     const pushSeg = (text: string, cs: boolean, fontFamily: string | null) => {
+      const localFont = resolvedFont(fontFamily);
+      const localEaFloor = resolvedFont(eaFontFamily);
       segs.push({
         text,
         bold: cs ? csBold : base.bold,
@@ -2253,7 +2295,8 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
         strikethrough: base.strikethrough,
         fontSize: cs ? csFontSize : base.fontSize,
         color: base.color,
-        fontFamily,
+        fontFamily: localFont?.family ?? fontFamily,
+        resolvedLineHeightRatio: localFont?.lineHeightRatio,
         vertAlign,
         measuredWidth: 0,
         smallCaps: reduced,
@@ -2272,7 +2315,8 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
         digitsAsAN: digitsAsAN ? true : undefined,
         // §17.3.2.26 declared eastAsia axis — recorded for the text-box line-box
         // floor only (see LayoutTextSeg.eaFloorFamily). Inert for the body path.
-        eaFloorFamily: eaFontFamily,
+        eaFloorFamily: localEaFloor?.family ?? eaFontFamily,
+        resolvedEaFloorLineHeightRatio: localEaFloor?.lineHeightRatio,
         // IX1 — resolved hyperlink target of the originating run, for the
         // text-layer clickable overlay. Does not affect layout or drawing.
         hyperlink,
@@ -2669,6 +2713,10 @@ export function layoutLines(
   let lineDescent = 0;  // px
   let lineIntendedSingle = 0; // px — max intended single-line height on the line
   let lineGridCountSingle = 0; // px — max over segments of (tabled design height | untabled box)
+  let lineVisibleAscent = 0;
+  let lineVisibleDescent = 0;
+  let lineVisibleIntendedSingle = 0;
+  let lineHasVisibleMetrics = false;
   let isFirst = true;
   // Effective width/offset for the current line after float exclusion.
   let lineMaxWidth = maxWidth;
@@ -2818,6 +2866,11 @@ export function layoutLines(
     const hasContent = lineAscent > 0 || lineDescent > 0;
     const asc = hasContent ? lineAscent : h * scale * 0.8;
     const desc = hasContent ? lineDescent : h * scale * 0.2;
+    const visibleAscent = lineHasVisibleMetrics ? lineVisibleAscent : asc;
+    const visibleDescent = lineHasVisibleMetrics ? lineVisibleDescent : desc;
+    const visibleIntendedSingle = lineHasVisibleMetrics
+      ? lineVisibleIntendedSingle
+      : lineIntendedSingle;
     const gridCountSingle = lineGridCountSingle
       || (lineEastAsian ? eastAsianGridCountSinglePx(lineIntendedSingle, h * scale) : asc + desc);
     lines.push({
@@ -2825,6 +2878,9 @@ export function layoutLines(
       height: h,
       ascent: asc,
       descent: desc,
+      visibleAscent,
+      visibleDescent,
+      visibleIntendedSingle,
       intendedSingle: lineIntendedSingle,
       // Empty/synthetic East Asian lines use the same design-height rule as a
       // text run; their synthesized Canvas box must not reintroduce a
@@ -2857,6 +2913,10 @@ export function layoutLines(
     lineDescent = 0;
     lineIntendedSingle = 0;
     lineGridCountSingle = 0;
+    lineVisibleAscent = 0;
+    lineVisibleDescent = 0;
+    lineVisibleIntendedSingle = 0;
+    lineHasVisibleMetrics = false;
     lineHasRuby = false;
     lineEastAsian = false;
     lineHasSea = false;
@@ -2887,6 +2947,12 @@ export function layoutLines(
     if (h > lineHeight) lineHeight = h;
     if (asc > lineAscent) lineAscent = asc;
     if (desc > lineDescent) lineDescent = desc;
+    const paintsInlineInk = !('text' in s) || s.metricOnly !== true;
+    if (paintsInlineInk) {
+      lineHasVisibleMetrics = true;
+      if (asc > lineVisibleAscent) lineVisibleAscent = asc;
+      if (desc > lineVisibleDescent) lineVisibleDescent = desc;
+    }
     // Grid-count height for docGrid cell allocation (§17.6.5). Only East Asian
     // TEXT (and tall inline objects) drives the count — a Latin run keeps its
     // natural height and is NOT cell-rounded, so it must not contribute (its
@@ -2913,8 +2979,11 @@ export function layoutLines(
       // annotation box (sample-5 calibration) and Word's FE height for a
       // ruby-bearing line is unmeasured, so the pre-#1013 metrics stand.
       const segScriptHint = metricEastAsian && !ts.ruby;
-      const intended = intendedSingleLinePx(ts.fontFamily, intendedEm, segScriptHint);
+      const intended = segmentIntendedSingleLinePx(ts, intendedEm, segScriptHint);
       if (intended > lineIntendedSingle) lineIntendedSingle = intended;
+      if (paintsInlineInk && intended > lineVisibleIntendedSingle) {
+        lineVisibleIntendedSingle = intended;
+      }
       // Only East Asian text is cell-rounded. Both branches are scale-linear:
       // tabled fonts use recorded design metrics; untabled fonts use 1.3em.
       if (segScriptHint) segGridCount = eastAsianGridCountSinglePx(intended, intendedEm);
@@ -3892,8 +3961,9 @@ export function layoutLines(
 }
 
 /** Phase 4-1 B2 Stage 2 — rehydrate the paginator's scale-1 stamped lines into
- *  the paint scale, keeping the scale-1 line PARTITION but re-deriving all
- *  hinting-sensitive geometry at the paint scale.
+ *  the paint scale while keeping the scale-1 line PARTITION. The default legacy
+ *  bridge re-derives hinting-sensitive geometry at the paint scale; the optional
+ *  canonical bridge scales the complete stored geometry for viewport paint.
  *
  *  Why not a pure ×scale of the scale-1 fields: a real (hinted) font's Canvas
  *  metrics are NOT scale-linear — `measureText(pt·s).width ≠ s · measureText(pt)`
@@ -3924,15 +3994,65 @@ export function layoutLines(
  *  draw path and repeated renderPage calls read the same immutable array; see
  *  layout-lines-reuse-identity.test.ts). `scale === 1` returns the stamp
  *  unchanged (identity — no copy, no re-measure), so the scale-1 reuse path stays
- *  byte-for-byte as in Stage 1. */
+ *  byte-for-byte as in Stage 1.
+ *
+ *  When `canonicalGeometry` is true, text and line geometry are also mapped by
+ *  a pure ×scale from the stamp. The caller must then paint scale-1 glyphs under
+ *  the matching Canvas transform; this is the document-space body-text path that
+ *  preserves both the frozen partition and its width contract. */
 export function rescaleLayoutLines(
   lines: LayoutLine[],
   scale: number,
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   fontFamilyClasses: Record<string, string>,
   gridDeltaPx: number,
+  canonicalGeometry = false,
 ): LayoutLine[] {
   if (scale === 1) return lines;
+
+  if (canonicalGeometry) {
+    return lines.map((line) => ({
+      ...line,
+      segments: line.segments.map((segment) => {
+        if ('imagePath' in segment) {
+          return segment.anchor
+            ? { ...segment, measuredWidth: 0 }
+            : { ...segment, measuredWidth: segment.widthPt * scale };
+        }
+        if ('mathNodes' in segment) {
+          return {
+            ...segment,
+            measuredWidth: segment.measuredWidth * scale,
+            mathAscent: segment.mathAscent * scale,
+            mathDescent: segment.mathDescent * scale,
+          };
+        }
+        if ('text' in segment) {
+          return {
+            ...segment,
+            measuredWidth: segment.measuredWidth * scale,
+            fitTextPerGapPx: segment.fitTextPerGapPx === undefined
+              ? undefined
+              : segment.fitTextPerGapPx * scale,
+            fitTextTrailingPadPx: segment.fitTextTrailingPadPx === undefined
+              ? undefined
+              : segment.fitTextTrailingPadPx * scale,
+          };
+        }
+        return { ...segment, measuredWidth: segment.measuredWidth * scale };
+      }),
+      ascent: line.ascent * scale,
+      descent: line.descent * scale,
+      visibleAscent: (line.visibleAscent ?? line.ascent) * scale,
+      visibleDescent: (line.visibleDescent ?? line.descent) * scale,
+      visibleIntendedSingle: (line.visibleIntendedSingle ?? line.intendedSingle) * scale,
+      intendedSingle: line.intendedSingle * scale,
+      gridCountSingle: line.gridCountSingle * scale,
+      xOffset: line.xOffset * scale,
+      availWidth: line.availWidth * scale,
+      topY: line.topY === undefined ? undefined : line.topY * scale,
+    }));
+  }
 
   const withSegKerning = <T>(s: LayoutTextSeg, measure: () => T): T => {
     if (s.kerning == null) return measure();
@@ -3987,7 +4107,7 @@ export function rescaleLayoutLines(
     // Intended single-line floor (font-metrics.ts) — small caps keep the FULL run
     // size here too (addToLine's intendedEm).
     const intendedEm = s.smallCaps && !s.vertAlign ? fullPx : effPx;
-    const intended = intendedSingleLinePx(s.fontFamily, intendedEm, segScriptHint);
+    const intended = segmentIntendedSingleLinePx(s, intendedEm, segScriptHint);
     return {
       advance,
       asc,
@@ -4003,6 +4123,10 @@ export function rescaleLayoutLines(
     let intended = 0;
     let gridCount = 0; // px — max over segments of (tabled design | untabled 1.3em)
     let hasText = false;
+    let visibleAsc = 0;
+    let visibleDesc = 0;
+    let visibleIntended = 0;
+    let hasVisibleMetrics = false;
     const scaledSource = l.segments.map((segment) => ({ ...segment })) as LayoutSeg[];
     // Recompute the region gap from paint-scale natural metrics. Reusing the
     // scale-1 gap would break measure==paint because targetPx and font advances
@@ -4036,6 +4160,8 @@ export function rescaleLayoutLines(
         // size docGrid cells, mirroring layoutLines' addToLine contribution.
         asc = Math.max(asc, h);
         gridCount = Math.max(gridCount, h);
+        visibleAsc = Math.max(visibleAsc, h);
+        hasVisibleMetrics = true;
         return { ...s, measuredWidth: s.widthPt * scale };
       }
       if ('mathNodes' in s) {
@@ -4045,6 +4171,9 @@ export function rescaleLayoutLines(
         asc = Math.max(asc, copy.mathAscent, s.fontSize * scale * 0.8);
         desc = Math.max(desc, copy.mathDescent, s.fontSize * scale * 0.2);
         gridCount = Math.max(gridCount, copy.mathAscent + copy.mathDescent);
+        visibleAsc = Math.max(visibleAsc, copy.mathAscent, s.fontSize * scale * 0.8);
+        visibleDesc = Math.max(visibleDesc, copy.mathDescent, s.fontSize * scale * 0.2);
+        hasVisibleMetrics = true;
         return copy;
       }
       const t = s as LayoutTextSeg;
@@ -4053,6 +4182,12 @@ export function rescaleLayoutLines(
       if (mm.asc > asc) asc = mm.asc;
       if (mm.desc > desc) desc = mm.desc;
       if (mm.intended > intended) intended = mm.intended;
+      if (t.metricOnly !== true) {
+        visibleAsc = Math.max(visibleAsc, mm.asc);
+        visibleDesc = Math.max(visibleDesc, mm.desc);
+        visibleIntended = Math.max(visibleIntended, mm.intended);
+        hasVisibleMetrics = true;
+      }
       // Only East Asian text is cell-rounded (§17.6.5); a Latin run keeps its
       // natural height and must not contribute its (substituted) box to the
       // grid-count height. measureTextSeg derives both tabled and untabled
@@ -4073,6 +4208,15 @@ export function rescaleLayoutLines(
       segments,
       ascent: asc,
       descent: desc,
+      visibleAscent: hasVisibleMetrics
+        ? visibleAsc
+        : (l.visibleAscent ?? l.ascent) * scale,
+      visibleDescent: hasVisibleMetrics
+        ? visibleDesc
+        : (l.visibleDescent ?? l.descent) * scale,
+      visibleIntendedSingle: hasVisibleMetrics
+        ? visibleIntended
+        : (l.visibleIntendedSingle ?? l.intendedSingle) * scale,
       intendedSingle: intended,
       gridCountSingle: gridCount || (asc + desc),
       // Pure page geometry — scale-linear (no glyph hinting).

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -2781,7 +2781,7 @@ export function layoutLines(
   // mark line, but `isParagraphMarkOnlyFlow` selects the same narrow threshold
   // for its first line. Word keeps either mark beside a float down to a sub-inch
   // gap and drops it below only for a full-width band. #676 over-generalized 1
-  // inch onto marks and pushed sample-12's caption to the next page. Inline
+  // inch onto marks and pushed following content to the next page. Inline
   // content (including a content paragraph's trailing-break final line) keeps
   // the 1-inch rule.
   const minLineStartWidth = (): number => wordMinLineStartPx(scale);

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -16,7 +16,7 @@
 // is documented inline (as before the move) — see packages/docx/CLAUDE.md.
 
 import type {
-  DocParagraph, DocRun, DocxTextRun, ImageRun, ShapeTextRun, FieldRun,
+  DocParagraph, DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeTextRun, FieldRun,
   LineSpacing, TabStop, DocxRunBorder, DocSettings, EmphasisMark,
 } from './types';
 import type { MathNode, KinsokuRules, ChartModel, HyperlinkTarget, NumberFormat, Duotone } from '@silurus/ooxml-core';
@@ -67,6 +67,12 @@ interface LayoutSegSource {
 
 export interface LayoutTextSeg extends LayoutSegSource {
   text: string;
+  /** Zero-advance anchor-character placeholder: contributes run metrics to the
+   * line box but paints no glyph. */
+  metricOnly?: true;
+  /** The anchor character uses the run's East Asian font axis, so §17.6.5 grid
+   * allocation must use Far East design metrics despite `text` being empty. */
+  metricEastAsian?: true;
   bold: boolean;
   italic: boolean;
   underline: boolean;
@@ -2484,6 +2490,27 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
         leader: run.leader,
         ptab: { alignment: run.alignment, relativeTo: run.relativeTo },
       });
+    } else if (run.type === 'shape') {
+      const host = (run as unknown as ShapeRun).anchorHostMetrics;
+      if (host) {
+        const eastAsian = host.fontFamilyEastAsia != null;
+        segs.push({
+          text: '',
+          metricOnly: true,
+          ...(eastAsian ? { metricEastAsian: true as const } : {}),
+          bold: host.bold ?? false,
+          italic: host.italic ?? false,
+          underline: false,
+          strikethrough: false,
+          fontSize: host.fontSize,
+          color: null,
+          fontFamily: host.fontFamilyEastAsia ?? host.fontFamily ?? null,
+          vertAlign: null,
+          measuredWidth: 0,
+          eaFloorFamily: host.fontFamilyEastAsia ?? null,
+          snapToCharacterGrid: false,
+        });
+      }
     }
   }
 
@@ -2867,7 +2894,8 @@ export function layoutLines(
       const ts = s as LayoutTextSeg;
       if (ts.ruby) lineHasRuby = true;
       if (ts.seaBreaks !== undefined && isDictionarySeaText(ts.text)) lineHasSea = true;
-      if (!lineEastAsian && EAST_ASIAN_RE.test(ts.text)) lineEastAsian = true;
+      const metricEastAsian = ts.metricEastAsian === true || EAST_ASIAN_RE.test(ts.text);
+      if (!lineEastAsian && metricEastAsian) lineEastAsian = true;
       // Intended single-line height for fonts whose substituted Canvas metrics
       // understate Word's line spacing (font-metrics.ts). 0 for untabled fonts.
       // Small caps (non-super/sub) keep the FULL run size here so the line box
@@ -2879,7 +2907,7 @@ export function layoutLines(
       // segments are excluded too: a ruby line reserves its MEASURED base +
       // annotation box (sample-5 calibration) and Word's FE height for a
       // ruby-bearing line is unmeasured, so the pre-#1013 metrics stand.
-      const segScriptHint = EAST_ASIAN_RE.test(ts.text) && !ts.ruby;
+      const segScriptHint = metricEastAsian && !ts.ruby;
       const intended = intendedSingleLinePx(ts.fontFamily, intendedEm, segScriptHint);
       if (intended > lineIntendedSingle) lineIntendedSingle = intended;
       // Only East Asian text is cell-rounded. Both branches are scale-linear:
@@ -3342,7 +3370,13 @@ export function layoutLines(
     }
     // FE design correction for EA segments only; ruby keeps its measured box
     // (see addToLine's segScriptHint note).
-    const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx, EAST_ASIAN_RE.test(s.text) && !s.ruby);
+    const corrected = correctedLineMetrics(
+      metricM,
+      s.fontFamily,
+      fullPx,
+      metricEmPx,
+      (s.metricEastAsian === true || EAST_ASIAN_RE.test(s.text)) && !s.ruby,
+    );
     let asc = corrected.ascent;
     const desc = corrected.descent;
     // Ruby annotation: small text rendered above the base. Reserve ascent
@@ -3939,7 +3973,7 @@ export function rescaleLayoutLines(
     }
     // FE design correction for EA segments only; ruby keeps its measured box
     // (see addToLine's segScriptHint note).
-    const segScriptHint = EAST_ASIAN_RE.test(s.text) && !s.ruby;
+    const segScriptHint = (s.metricEastAsian === true || EAST_ASIAN_RE.test(s.text)) && !s.ruby;
     const corrected = correctedLineMetrics(metricM, s.fontFamily, fullPx, metricEmPx, segScriptHint);
     // §17.3.3.12 — ruby reserves hpsRaise when present, same as layoutLines.
     const asc = s.ruby

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -382,6 +382,11 @@ export interface WrapLayoutCtx {
   /** Absolute px width of the paragraph's raw COLUMN band. See columnXPt. */
   columnWidthPt: number;
   floats: FloatRect[];  // legacy float geometry supplied directly by renderer paths
+  /** Minimum clear side-gap for an anchor-host-only paragraph mark. Such a
+   *  zero-advance metric placeholder preserves the anchor character's line box,
+   *  but is not inline content and therefore keeps the pilcrow-em threshold
+   *  instead of the 1-inch content-line threshold (issue #676). */
+  paragraphMarkLineStartWidth?: number;
   /** Placement-aware wrap boundary used by paragraph measurement. */
   lineWindow?: (input: {
     topYPt: number;
@@ -1250,9 +1255,14 @@ export function paragraphMarkLineMetrics(
   ctx?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   fontFamilyClasses: Record<string, string> = {},
   effectiveLineSpacing: LineSpacing | null = para.lineSpacing,
+  resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>> = {},
 ): MarkLineMetrics {
   const fs = getDefaultFontSize(para);
-  const family = getDefaultFontFamily(para, eastAsian);
+  const authoredFamily = getDefaultFontFamily(para, eastAsian);
+  const resolvedLocalFont = authoredFamily
+    ? resolvedLocalFonts[normalizeLocalFontMetricFamily(authoredFamily)]
+    : undefined;
+  const measuredFamily = resolvedLocalFont?.family ?? authoredFamily;
   let asc: number;
   let desc: number;
   if (ctx) {
@@ -1275,15 +1285,19 @@ export function paragraphMarkLineMetrics(
     // (intendedSingleLinePx, via emptyIntendedSinglePx below) then raises tabled
     // fonts — Latin included — to Word's line height.
     const prevFont = ctx.font;
-    ctx.font = buildFont(false, false, fs * scale, family, fontFamilyClasses);
+    ctx.font = buildFont(false, false, fs * scale, measuredFamily, fontFamilyClasses);
     const m = ctx.measureText(eastAsian ? 'あ' : 'x');
     ctx.font = prevFont;
     // A mark line carries no smallCaps/vertAlign, so fallback == correction size.
-    ({ ascent: asc, descent: desc } = correctedLineMetrics(m, family, fs * scale, fs * scale, eastAsian));
+    ({ ascent: asc, descent: desc } = correctedLineMetrics(
+      m, measuredFamily, fs * scale, fs * scale, eastAsian,
+    ));
   } else {
     ({ asc, desc } = emptyLineNaturalPx(fs, scale));
   }
-  const intendedSingle = emptyIntendedSingleForScriptPx(para, scale, eastAsian);
+  const intendedSingle = resolvedLocalFont
+    ? fs * scale * resolvedLocalFont.lineHeightRatio
+    : emptyIntendedSingleForScriptPx(para, scale, eastAsian);
   const gridCountSingle = eastAsian
     ? eastAsianGridCountSinglePx(intendedSingle, fs * scale)
     : undefined;
@@ -1310,9 +1324,11 @@ export function paragraphMarkLineHeight(
   ctx?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   fontFamilyClasses: Record<string, string> = {},
   effectiveLineSpacing: LineSpacing | null = para.lineSpacing,
+  resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>> = {},
 ): number {
   return paragraphMarkLineMetrics(
     para, scale, grid, paraHasRuby, eastAsian, ctx, fontFamilyClasses, effectiveLineSpacing,
+    resolvedLocalFonts,
   ).advancePx;
 }
 
@@ -1348,10 +1364,12 @@ export function paragraphMarkBelowBaselinePt(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | undefined,
   fontFamilyClasses: Record<string, string>,
   effectiveLineSpacing: LineSpacing | null,
+  resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>> = {},
 ): number {
   // Measured at scale 1 so the returned px value is already in points.
   const m = paragraphMarkLineMetrics(
     para, 1, grid, paraHasRuby, eastAsian, ctx, fontFamilyClasses, effectiveLineSpacing,
+    resolvedLocalFonts,
   );
   return lineBelowBaselinePx(m.advancePx, m.ascentPx, m.descentPx);
 }
@@ -2756,16 +2774,21 @@ export function layoutLines(
   // paginator's two mirror layouts (they call layoutLines with scale 1), so the
   // flow/beside decision agrees across passes.
   //
-  // NOTE — this 1-inch rule is the CONTENT-line threshold. A literally-empty /
-  // anchor-only paragraph's pilcrow is placed by resolveEmptyMarkTop /
-  // flowMarkLine (renderer.ts) against the NARROWER pilcrow-em threshold
-  // (paragraphMarkEmPx): Word keeps such a mark beside a float down to a
-  // sub-inch gap and drops it below only for a full-width band. #676
-  // over-generalized 1 inch onto empty marks and pushed sample-12's caption
-  // to the next page. Lines routed through layoutLines carry inline content
-  // (or a content paragraph's trailing-break final line) and keep the 1-inch
-  // rule.
+  // NOTE — this 1-inch rule is the CONTENT-line threshold. A literally-empty
+  // paragraph's pilcrow is placed by resolveEmptyMarkTop / flowMarkLine
+  // (renderer.ts) against the NARROWER pilcrow-em threshold. An anchorHost-only
+  // paragraph still enters layoutLines so its anchor-character metrics size the
+  // mark line, but `isParagraphMarkOnlyFlow` selects the same narrow threshold
+  // for its first line. Word keeps either mark beside a float down to a sub-inch
+  // gap and drops it below only for a full-width band. #676 over-generalized 1
+  // inch onto marks and pushed sample-12's caption to the next page. Inline
+  // content (including a content paragraph's trailing-break final line) keeps
+  // the 1-inch rule.
   const minLineStartWidth = (): number => wordMinLineStartPx(scale);
+  const isParagraphMarkOnlyFlow = segs.length > 0 && segs.every((segment) =>
+    ('text' in segment && segment.metricOnly === true)
+    || ('imagePath' in segment && Boolean(segment.anchor)),
+  );
 
   // Compute wrap constraints for a new line about to start. Mutates
   // lineXOffset/lineMaxWidth/currentLineTopY. `minWidth` is the smallest clear
@@ -3183,7 +3206,11 @@ export function layoutLines(
   let trailingBreakFontSize: number | null = null;
 
   // Establish the first line's wrap window now that the content queue exists.
-  startLine(minLineStartWidth());
+  startLine(
+    isParagraphMarkOnlyFlow
+      ? (wrapCtx?.paragraphMarkLineStartWidth ?? minLineStartWidth())
+      : minLineStartWidth(),
+  );
 
   while (queue.length > 0) {
     const seg = queue.shift()!;

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1133,10 +1133,15 @@ export function lineBoxHeight(
   }
   if (ls.rule === 'exact') return ls.value * scale;
   if (ls.rule === 'atLeast') {
+    // §17.18.48 makes the authored value a minimum that expands to fit content;
+    // §17.6.5 contributes one active line pitch as another minimum. Unlike the
+    // automatic/null rule, explicit atLeast does not snap a tall plain line to
+    // an integer cell count. Ruby keeps the established whole-cell reservation
+    // because its measured base + annotation box must fit without clipping.
     return Math.max(
       natural,
       ls.value * scale,
-      hasGrid ? gridSingleCell() : 0,
+      hasGrid ? (hasRuby || inheritedOnly ? gridSingleCell() : pitchPx) : 0,
     );
   }
   return natural;

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -16,7 +16,7 @@
 // is documented inline (as before the move) — see packages/docx/CLAUDE.md.
 
 import type {
-  DocParagraph, DocRun, DocxTextRun, ImageRun, ShapeRun, ShapeTextRun, FieldRun,
+  DocParagraph, DocRun, DocxTextRun, ImageRun, ShapeTextRun, FieldRun,
   LineSpacing, TabStop, DocxRunBorder, DocSettings, EmphasisMark,
 } from './types';
 import type { MathNode, KinsokuRules, ChartModel, HyperlinkTarget, NumberFormat, Duotone, ResolvedLocalFontMetric } from '@silurus/ooxml-core';
@@ -1057,7 +1057,10 @@ export function eastAsianGridCountSinglePx(intendedSinglePx: number, emPx: numbe
  *             multiplier applies against the grid pitch instead, with a
  *             floor of the natural line height.
  *   exact   → value in pt, converted to px (ignores font and grid).
- *   atLeast → max(natural, authored minimum, active grid minimum).
+ *   atLeast → max(natural, authored minimum, active grid minimum). For an
+ *             explicitly authored value, the unsnapped tall-line result is an
+ *             observed Windows Word compatibility behavior; it is not stated
+ *             normatively by the line-grid clauses.
  *   null    → natural, or grid pitch if the section defines one.
  *
  * Exported for unit tests only — not part of the package API (not
@@ -1171,11 +1174,13 @@ export function lineBoxHeight(
   }
   if (ls.rule === 'exact') return ls.value * scale;
   if (ls.rule === 'atLeast') {
-    // §17.18.48 makes the authored value a minimum that expands to fit content;
-    // §17.6.5 contributes one active line pitch as another minimum. Unlike the
-    // automatic/null rule, explicit atLeast does not snap a tall plain line to
-    // an integer cell count. Ruby keeps the established whole-cell reservation
-    // because its measured base + annotation box must fit without clipping.
+    // §17.18.48 establishes the authored minimum and §17.6.5 establishes the
+    // grid pitch, but neither clause specifies how a tall, plain line with an
+    // explicit atLeast value combines with whole-cell grid allocation. Windows
+    // Word output leaves that line at its raw content height while later
+    // ordinary lines remain on one pitch. Preserve that observed compatibility
+    // behavior here. Ruby and inherited-only spacing retain the established
+    // whole-cell path because their separate fixtures require it.
     return Math.max(
       natural,
       ls.value * scale,
@@ -2280,12 +2285,21 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
     // family for its whole `.text` — so the measure==draw / docGrid char-grid
     // invariant holds and the draw loop needs no per-segment font switching.
     const pushSeg = (text: string, cs: boolean, fontFamily: string | null) => {
+      const bold = cs ? csBold : base.bold;
+      const italic = cs ? csItalic : base.italic;
       const localFont = resolvedFont(fontFamily);
       const localEaFloor = resolvedFont(eaFontFamily);
+      // Local-metric aliases intentionally register the normal face only. A
+      // bold/italic Canvas request against that alias would synthesize the
+      // style instead of resolving the installed family's real styled face.
+      // Keep the authored family for styled paint/measurement, while retaining
+      // the family-level design line ratio used by Word's line-box calculation.
+      const localPaintFamily = !bold && !italic ? localFont?.family : undefined;
+      const localEaFloorFamily = !bold && !italic ? localEaFloor?.family : undefined;
       segs.push({
         text,
-        bold: cs ? csBold : base.bold,
-        italic: cs ? csItalic : base.italic,
+        bold,
+        italic,
         underline: base.underline,
         // §17.3.2.40 underline style / colour — carried only on DocxTextRun (a
         // FieldRun draws single). Kept raw ST_Underline; the renderer normalizes
@@ -2295,7 +2309,7 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
         strikethrough: base.strikethrough,
         fontSize: cs ? csFontSize : base.fontSize,
         color: base.color,
-        fontFamily: localFont?.family ?? fontFamily,
+        fontFamily: localPaintFamily ?? fontFamily,
         resolvedLineHeightRatio: localFont?.lineHeightRatio,
         vertAlign,
         measuredWidth: 0,
@@ -2315,7 +2329,7 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
         digitsAsAN: digitsAsAN ? true : undefined,
         // §17.3.2.26 declared eastAsia axis — recorded for the text-box line-box
         // floor only (see LayoutTextSeg.eaFloorFamily). Inert for the body path.
-        eaFloorFamily: localEaFloor?.family ?? eaFontFamily,
+        eaFloorFamily: localEaFloorFamily ?? eaFontFamily,
         resolvedEaFloorLineHeightRatio: localEaFloor?.lineHeightRatio,
         // IX1 — resolved hyperlink target of the originating run, for the
         // text-layer clickable overlay. Does not affect layout or drawing.
@@ -2539,27 +2553,33 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
         leader: run.leader,
         ptab: { alignment: run.alignment, relativeTo: run.relativeTo },
       });
-    } else if (run.type === 'shape') {
-      const host = (run as unknown as ShapeRun).anchorHostMetrics;
-      if (host) {
-        const eastAsian = host.fontFamilyEastAsia != null;
-        segs.push({
-          text: '',
-          metricOnly: true,
-          ...(eastAsian ? { metricEastAsian: true as const } : {}),
-          bold: host.bold ?? false,
-          italic: host.italic ?? false,
-          underline: false,
-          strikethrough: false,
-          fontSize: host.fontSize,
-          color: null,
-          fontFamily: host.fontFamilyEastAsia ?? host.fontFamily ?? null,
-          vertAlign: null,
-          measuredWidth: 0,
-          eaFloorFamily: host.fontFamilyEastAsia ?? null,
-          snapToCharacterGrid: false,
-        });
-      }
+    } else if (run.type === 'anchorHost') {
+      const eastAsian = run.fontFamilyEastAsia != null;
+      const bold = run.bold ?? false;
+      const italic = run.italic ?? false;
+      const authoredFamily = run.fontFamilyEastAsia ?? run.fontFamily ?? null;
+      const localFont = resolvedFont(authoredFamily);
+      const localEaFloor = resolvedFont(run.fontFamilyEastAsia ?? null);
+      const normalFace = !bold && !italic;
+      segs.push({
+        text: '',
+        metricOnly: true,
+        ...(eastAsian ? { metricEastAsian: true as const } : {}),
+        bold,
+        italic,
+        underline: false,
+        strikethrough: false,
+        fontSize: run.fontSize,
+        color: null,
+        fontFamily: (normalFace ? localFont?.family : undefined) ?? authoredFamily,
+        resolvedLineHeightRatio: localFont?.lineHeightRatio,
+        vertAlign: null,
+        measuredWidth: 0,
+        eaFloorFamily:
+          (normalFace ? localEaFloor?.family : undefined) ?? run.fontFamilyEastAsia ?? null,
+        resolvedEaFloorLineHeightRatio: localEaFloor?.lineHeightRatio,
+        snapToCharacterGrid: false,
+      });
     }
   }
 

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1273,11 +1273,11 @@ export function paragraphMarkLineMetrics(
     // The synthetic 0.8/0.2 ≈ 1em box under-measured every empty paragraph
     // whenever the (often substituted) font's real box exceeds 1em — a Latin
     // fallback reports ~1.15em — so a run of empty "spacer" paragraphs fell
-    // short and the following content rose into a preceding float's wrap band
-    // (sample-12: the figure caption wrapped beside the image instead of below
-    // it). East Asian documents probe an EA glyph so docGrid cell rounding
-    // (lineBoxHeight) reserves whole cells (a 20pt mark on a 20pt pitch → 2
-    // cells); others probe a Latin glyph. fontBoundingBox is reported per
+    // short and following content rose into a preceding float's wrap band
+    // instead of clearing the float. East Asian documents probe an EA glyph so
+    // docGrid cell rounding (lineBoxHeight) reserves whole cells (a 20pt mark
+    // on a 20pt pitch occupies two cells); others probe a Latin glyph.
+    // fontBoundingBox is reported per
     // resolved face (not per glyph), so the probe choice does not change the box
     // for a face that contains it — and the probe is script-matched, so the mark
     // font does. correctedLineMetrics rescales a substituted font to the document

--- a/packages/docx/src/local-font-metrics.test.ts
+++ b/packages/docx/src/local-font-metrics.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { docxLocalMetricRequests } from './local-font-metrics.js';
+import { buildSegments, segmentIntendedSingleLinePx } from './line-layout.js';
+import type { DocRun, DocxDocumentModel, DocxTextRun } from './types.js';
+
+function model(fonts: string[]): DocxDocumentModel {
+  return {
+    fontFamilyClasses: Object.fromEntries(fonts.map((font) => [font, 'modern'])),
+  } as unknown as DocxDocumentModel;
+}
+
+describe('docxLocalMetricRequests', () => {
+  it('maps Japanese and English Meiryo names to the exact local family', () => {
+    expect(docxLocalMetricRequests(model(['メイリオ', 'Meiryo']))).toEqual([
+      { family: 'メイリオ', localNames: ['Meiryo'], lineHeightMultiplier: 1.3 },
+      { family: 'Meiryo', localNames: ['Meiryo'], lineHeightMultiplier: 1.3 },
+    ]);
+  });
+
+  it('does not merge Meiryo UI into Meiryo because their design metrics differ', () => {
+    expect(docxLocalMetricRequests(model(['Meiryo UI']))).toEqual([]);
+  });
+
+  it('routes layout through the exact local alias and its measured Word line height', () => {
+    const run = {
+      type: 'text', text: '平成', bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'メイリオ',
+      fontFamilyEastAsia: 'メイリオ', vertAlign: null,
+    } as unknown as DocxTextRun;
+    const segments = buildSegments([run as unknown as DocRun], {
+      pageIndex: 0,
+      totalPages: 1,
+      resolvedLocalFonts: {
+        'メイリオ': { family: '__ooxml_local_meiryo', lineHeightRatio: 1.95 },
+      },
+    });
+    const segment = segments[0];
+    expect('text' in segment && segment.fontFamily).toBe('__ooxml_local_meiryo');
+    expect('text' in segment && segmentIntendedSingleLinePx(segment, 10, true)).toBeCloseTo(19.5, 8);
+  });
+});

--- a/packages/docx/src/local-font-metrics.test.ts
+++ b/packages/docx/src/local-font-metrics.test.ts
@@ -28,6 +28,46 @@ describe('docxLocalMetricRequests', () => {
     expect(docxLocalMetricRequests(model(['Meiryo UI']))).toEqual([]);
   });
 
+  it('keeps an embedded regular face authoritative over terminal-local probing and aliases', () => {
+    const doc = {
+      ...model(['メイリオ']),
+      embeddedFonts: [{
+        fontName: 'メイリオ', style: 'regular',
+        partPath: 'word/fonts/font1.odttf', fontKey: '{00000000-0000-0000-0000-000000000000}',
+      }],
+      body: [paragraphWithFamily('メイリオ')],
+    } as unknown as DocxDocumentModel;
+
+    const requests = docxLocalMetricRequests(doc);
+    expect(requests).toEqual([]);
+    // Model the runtime hand-off from selected local-metric requests to the
+    // segment resolver. If the embedded family leaked into `requests`, its
+    // terminal alias would replace the embedded face during normal-run layout.
+    const resolvedLocalFonts = Object.fromEntries(requests.map(({ family }) => [
+      family.trim().toLowerCase(),
+      { family: '__terminal_local_alias', lineHeightRatio: 1.5 },
+    ]));
+    const [segment] = buildSegments(
+      (doc.body[0] as { runs: DocRun[] }).runs,
+      { pageIndex: 0, totalPages: 1, resolvedLocalFonts },
+    );
+    expect('text' in segment && segment.fontFamily).toBe('メイリオ');
+  });
+
+  it('still probes a normal face when only a non-regular embedded face exists', () => {
+    const doc = {
+      ...model(['メイリオ']),
+      embeddedFonts: [{
+        fontName: 'メイリオ', style: 'bold',
+        partPath: 'word/fonts/font1.odttf', fontKey: '{00000000-0000-0000-0000-000000000000}',
+      }],
+    } as unknown as DocxDocumentModel;
+
+    expect(docxLocalMetricRequests(doc)).toEqual([
+      { family: 'メイリオ', localNames: ['Meiryo'], lineHeightMultiplier: 1.3 },
+    ]);
+  });
+
   it('discovers a directly-authored run family absent from fontTable and the theme', () => {
     const doc = {
       body: [paragraphWithFamily('メイリオ')],

--- a/packages/docx/src/local-font-metrics.test.ts
+++ b/packages/docx/src/local-font-metrics.test.ts
@@ -9,6 +9,13 @@ function model(fonts: string[]): DocxDocumentModel {
   } as unknown as DocxDocumentModel;
 }
 
+function paragraphWithFamily(family: string): unknown {
+  return {
+    type: 'paragraph',
+    runs: [{ type: 'text', text: '平成', fontFamily: family }],
+  };
+}
+
 describe('docxLocalMetricRequests', () => {
   it('maps Japanese and English Meiryo names to the exact local family', () => {
     expect(docxLocalMetricRequests(model(['メイリオ', 'Meiryo']))).toEqual([
@@ -19,6 +26,78 @@ describe('docxLocalMetricRequests', () => {
 
   it('does not merge Meiryo UI into Meiryo because their design metrics differ', () => {
     expect(docxLocalMetricRequests(model(['Meiryo UI']))).toEqual([]);
+  });
+
+  it('discovers a directly-authored run family absent from fontTable and the theme', () => {
+    const doc = {
+      body: [paragraphWithFamily('メイリオ')],
+    } as unknown as DocxDocumentModel;
+
+    expect(docxLocalMetricRequests(doc)).toEqual([
+      { family: 'メイリオ', localNames: ['Meiryo'], lineHeightMultiplier: 1.3 },
+    ]);
+  });
+
+  it('discovers the direct complex-script rFonts axis', () => {
+    const doc = {
+      body: [{
+        type: 'paragraph',
+        runs: [{
+          type: 'text', text: 'العربية', fontFamily: 'Arial',
+          fontFamilyEastAsia: 'Arial', fontFamilyCs: 'Meiryo',
+        }],
+      }],
+    } as unknown as DocxDocumentModel;
+
+    expect(docxLocalMetricRequests(doc)).toEqual([
+      { family: 'Meiryo', localNames: ['Meiryo'], lineHeightMultiplier: 1.3 },
+    ]);
+  });
+
+  it.each([
+    {
+      story: 'header',
+      document: { headers: { default: { body: [paragraphWithFamily('Meiryo')] }, first: null, even: null } },
+    },
+    {
+      story: 'footer',
+      document: { footers: { default: { body: [paragraphWithFamily('Meiryo')] }, first: null, even: null } },
+    },
+    {
+      story: 'earlier-section header',
+      document: {
+        body: [{
+          type: 'sectionBreak',
+          headers: { default: { body: [paragraphWithFamily('Meiryo')] }, first: null, even: null },
+        }],
+      },
+    },
+    {
+      story: 'footnote',
+      document: { footnotes: [{ id: '1', content: [paragraphWithFamily('Meiryo')] }] },
+    },
+    {
+      story: 'endnote',
+      document: { endnotes: [{ id: '1', content: [paragraphWithFamily('Meiryo')] }] },
+    },
+    {
+      story: 'shape text',
+      document: {
+        body: [{
+          type: 'paragraph',
+          runs: [{
+            type: 'shape',
+            textBlocks: [{
+              text: '平成', fontSizePt: 10, alignment: 'left', fontFamily: 'Meiryo',
+            }],
+          }],
+        }],
+      },
+    },
+  ])('discovers a family used only in $story', ({ document }) => {
+    expect(docxLocalMetricRequests(document as unknown as DocxDocumentModel)).toEqual([
+      { family: 'Meiryo', localNames: ['Meiryo'], lineHeightMultiplier: 1.3 },
+    ]);
   });
 
   it('routes layout through the exact local alias and its measured Word line height', () => {
@@ -36,6 +115,88 @@ describe('docxLocalMetricRequests', () => {
     });
     const segment = segments[0];
     expect('text' in segment && segment.fontFamily).toBe('__ooxml_local_meiryo');
+    expect('text' in segment && segmentIntendedSingleLinePx(segment, 10, true)).toBeCloseTo(19.5, 8);
+  });
+
+  it.each([
+    { bold: true, italic: false },
+    { bold: false, italic: true },
+    { bold: true, italic: true },
+  ])('keeps the authored family for styled faces while retaining measured line height (%o)', (style) => {
+    const run = {
+      type: 'text', text: '平成', ...style, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'メイリオ',
+      fontFamilyEastAsia: 'メイリオ', vertAlign: null,
+    } as unknown as DocxTextRun;
+    const [segment] = buildSegments([run as unknown as DocRun], {
+      pageIndex: 0,
+      totalPages: 1,
+      resolvedLocalFonts: {
+        'メイリオ': { family: '__ooxml_local_meiryo', lineHeightRatio: 1.95 },
+      },
+    });
+
+    expect('text' in segment && segment.fontFamily).toBe('メイリオ');
+    expect('text' in segment && segmentIntendedSingleLinePx(segment, 10, true)).toBeCloseTo(19.5, 8);
+  });
+
+  it.each([
+    { boldCs: true, italicCs: false },
+    { boldCs: false, italicCs: true },
+  ])('keeps the authored complex-script family for styled faces (%o)', (style) => {
+    const run = {
+      type: 'text', text: 'العربية', bold: false, italic: false, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'Arial',
+      fontFamilyEastAsia: 'Arial', fontFamilyCs: 'メイリオ', fontSizeCs: 10,
+      cs: true, ...style, vertAlign: null,
+    } as unknown as DocxTextRun;
+    const [segment] = buildSegments([run as unknown as DocRun], {
+      pageIndex: 0,
+      totalPages: 1,
+      resolvedLocalFonts: {
+        'メイリオ': { family: '__ooxml_local_meiryo', lineHeightRatio: 1.95 },
+      },
+    });
+
+    expect('text' in segment && segment.fontFamily).toBe('メイリオ');
+    expect('text' in segment && segmentIntendedSingleLinePx(segment, 10, true)).toBeCloseTo(19.5, 8);
+  });
+
+  it('uses the exact normal alias when complex-script styling is explicitly off', () => {
+    const run = {
+      type: 'text', text: 'العربية', bold: true, italic: true, underline: false,
+      strikethrough: false, fontSize: 10, color: null, fontFamily: 'Arial',
+      fontFamilyEastAsia: 'Arial', fontFamilyCs: 'メイリオ', fontSizeCs: 10,
+      cs: true, boldCs: false, italicCs: false, vertAlign: null,
+    } as unknown as DocxTextRun;
+    const [segment] = buildSegments([run as unknown as DocRun], {
+      pageIndex: 0,
+      totalPages: 1,
+      resolvedLocalFonts: {
+        'メイリオ': { family: '__ooxml_local_meiryo', lineHeightRatio: 1.95 },
+      },
+    });
+
+    expect('text' in segment && segment.fontFamily).toBe('__ooxml_local_meiryo');
+  });
+
+  it.each([
+    { bold: false, italic: false, expectedFamily: '__ooxml_local_meiryo' },
+    { bold: true, italic: false, expectedFamily: 'メイリオ' },
+    { bold: false, italic: true, expectedFamily: 'メイリオ' },
+  ])('applies the normal-vs-styled alias policy to anchor-host metrics (%o)', (style) => {
+    const [segment] = buildSegments([{
+      type: 'anchorHost', fontSize: 10, fontFamily: 'メイリオ',
+      fontFamilyEastAsia: 'メイリオ', bold: style.bold, italic: style.italic,
+    }], {
+      pageIndex: 0,
+      totalPages: 1,
+      resolvedLocalFonts: {
+        'メイリオ': { family: '__ooxml_local_meiryo', lineHeightRatio: 1.95 },
+      },
+    });
+
+    expect('text' in segment && segment.fontFamily).toBe(style.expectedFamily);
     expect('text' in segment && segmentIntendedSingleLinePx(segment, 10, true)).toBeCloseTo(19.5, 8);
   });
 });

--- a/packages/docx/src/local-font-metrics.ts
+++ b/packages/docx/src/local-font-metrics.ts
@@ -1,0 +1,39 @@
+import {
+  loadLocalFontMetrics,
+  type LoadedLocalFontMetrics,
+  type LocalFontMetricRequest,
+} from '@silurus/ooxml-core';
+import type { DocxDocumentModel } from './types.js';
+
+/** Word's Far-East single-line height for Meiryo is 1.3 × the selected face's
+ * hhea design box. This is Office compatibility behavior, not an ECMA-376
+ * formula: it is measured from Word output and already underpins the static
+ * fallback in core. Resolving the exact local face makes the rule version-safe
+ * (Meiryo 6.30 has a different hhea box from older builds) without encoding a
+ * version-specific number. Meiryo UI is deliberately excluded: it is a distinct
+ * family with different metrics and has no equivalent Word measurement here. */
+export function docxLocalMetricRequests(doc: DocxDocumentModel): LocalFontMetricRequest[] {
+  const names = new Set<string>([
+    ...Object.keys(doc.fontFamilyClasses ?? {}),
+    ...(doc.majorFont ? [doc.majorFont] : []),
+    ...(doc.minorFont ? [doc.minorFont] : []),
+  ]);
+  const requests: LocalFontMetricRequest[] = [];
+  for (const family of names) {
+    const normalized = family.trim().toLowerCase();
+    const isMeiryo = normalized === 'meiryo' || family.trim() === 'メイリオ';
+    if (!isMeiryo) continue;
+    requests.push({
+      family,
+      localNames: ['Meiryo'],
+      lineHeightMultiplier: 1.3,
+    });
+  }
+  return requests;
+}
+
+export function loadDocxLocalFontMetrics(
+  doc: DocxDocumentModel,
+): Promise<LoadedLocalFontMetrics> {
+  return loadLocalFontMetrics(docxLocalMetricRequests(doc));
+}

--- a/packages/docx/src/local-font-metrics.ts
+++ b/packages/docx/src/local-font-metrics.ts
@@ -1,5 +1,6 @@
 import {
   loadLocalFontMetrics,
+  normalizeLocalFontMetricFamily,
   type LoadedLocalFontMetrics,
   type LocalFontMetricRequest,
 } from '@silurus/ooxml-core';
@@ -14,6 +15,16 @@ import { docxRenderedFontFamilies } from './document-content.js';
  * version-specific number. Meiryo UI is deliberately excluded: it is a distinct
  * family with different metrics and has no equivalent Word measurement here. */
 export function docxLocalMetricRequests(doc: DocxDocumentModel): LocalFontMetricRequest[] {
+  // ECMA-376 §17.8.3.3: an embedded regular face is the document's authored
+  // normal face for that family. Registering a terminal-local alias afterwards
+  // would replace it during normal-run layout, so embedded families never enter
+  // local probing. Bold/italic-only embeddings do not suppress a missing normal
+  // face because they cannot satisfy the normal style slot.
+  const embeddedRegularFamilies = new Set(
+    (doc.embeddedFonts ?? [])
+      .filter((font) => font.style === 'regular')
+      .map((font) => normalizeLocalFontMetricFamily(font.fontName)),
+  );
   const names = new Set<string>([
     ...Object.keys(doc.fontFamilyClasses ?? {}),
     ...(doc.majorFont ? [doc.majorFont] : []),
@@ -22,7 +33,8 @@ export function docxLocalMetricRequests(doc: DocxDocumentModel): LocalFontMetric
   ]);
   const requests: LocalFontMetricRequest[] = [];
   for (const family of names) {
-    const normalized = family.trim().toLowerCase();
+    const normalized = normalizeLocalFontMetricFamily(family);
+    if (embeddedRegularFamilies.has(normalized)) continue;
     const isMeiryo = normalized === 'meiryo' || family.trim() === 'メイリオ';
     if (!isMeiryo) continue;
     requests.push({

--- a/packages/docx/src/local-font-metrics.ts
+++ b/packages/docx/src/local-font-metrics.ts
@@ -4,6 +4,7 @@ import {
   type LocalFontMetricRequest,
 } from '@silurus/ooxml-core';
 import type { DocxDocumentModel } from './types.js';
+import { docxRenderedFontFamilies } from './document-content.js';
 
 /** Word's Far-East single-line height for Meiryo is 1.3 × the selected face's
  * hhea design box. This is Office compatibility behavior, not an ECMA-376
@@ -17,6 +18,7 @@ export function docxLocalMetricRequests(doc: DocxDocumentModel): LocalFontMetric
     ...Object.keys(doc.fontFamilyClasses ?? {}),
     ...(doc.majorFont ? [doc.majorFont] : []),
     ...(doc.minorFont ? [doc.minorFont] : []),
+    ...docxRenderedFontFamilies(doc),
   ]);
   const requests: LocalFontMetricRequest[] = [];
   for (const family of names) {

--- a/packages/docx/src/para-shading-border.test.ts
+++ b/packages/docx/src/para-shading-border.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { paraShadingRect, paintedParagraphHeight } from './renderer.js';
+import {
+  paragraphBorderContentBox,
+  paraBorderSegments,
+  paraShadingRect,
+  paintedParagraphHeight,
+} from './renderer.js';
 import type { ParagraphBorders } from './types';
 
 // ECMA-376 §17.3.1.31 — paragraph shading fills the border BOX: it extends to
@@ -48,6 +53,50 @@ describe('paraShadingRect (§17.3.1.31 shading fills the border box)', () => {
     const r = paraShadingRect(0, 0, 100, 10, b, { suppressTop: true, suppressBottom: true }, 1);
     expect(r.y).toBe(-2);            // between space 2 (not top's 9)
     expect(r.h).toBe(10 + 2 + 0);    // top(between) 2 + bottom 0 (suppressed)
+  });
+});
+
+describe('paragraph border joins (§17.3.1.17)', () => {
+  it('includes a hanging first-line/list marker on the paragraph start side', () => {
+    expect(paragraphBorderContentBox(100, 500, 36, 0, -36, false)).toEqual({ x: 100, w: 500 });
+    expect(paragraphBorderContentBox(100, 500, 0, 36, -36, true)).toEqual({ x: 100, w: 500 });
+  });
+
+  it('does not expand toward a positive first-line indent', () => {
+    expect(paragraphBorderContentBox(100, 500, 36, 18, 12, false)).toEqual({ x: 136, w: 446 });
+  });
+
+  it('spans horizontal edges to the vertical border positions and vertical edges between them', () => {
+    const borders: ParagraphBorders = {
+      ...noEdges,
+      top: edge(1),
+      bottom: edge(2),
+      left: edge(4),
+      right: edge(5),
+    };
+
+    const segments = paraBorderSegments(10, 20, 100, 30, borders, undefined, 1);
+    expect(segments.map(({ side, x1, y1, x2, y2 }) => ({ side, x1, y1, x2, y2 }))).toEqual([
+      { side: 'top', x1: 6, y1: 19, x2: 115, y2: 19 },
+      { side: 'bottom', x1: 6, y1: 52, x2: 115, y2: 52 },
+      { side: 'left', x1: 6, y1: 19, x2: 6, y2: 52 },
+      { side: 'right', x1: 115, y1: 19, x2: 115, y2: 52 },
+    ]);
+  });
+
+  it('keeps a merged run open at an inner join when no between edge exists', () => {
+    const borders: ParagraphBorders = {
+      ...noEdges,
+      top: edge(1),
+      bottom: edge(2),
+      left: edge(4),
+      right: edge(5),
+    };
+
+    const segments = paraBorderSegments(10, 20, 100, 30, borders, { suppressBottom: true }, 1);
+    expect(segments.find((segment) => segment.side === 'bottom')).toBeUndefined();
+    expect(segments.find((segment) => segment.side === 'left')).toMatchObject({ y1: 19, y2: 50 });
+    expect(segments.find((segment) => segment.side === 'right')).toMatchObject({ y1: 19, y2: 50 });
   });
 });
 

--- a/packages/docx/src/para-shading-border.test.ts
+++ b/packages/docx/src/para-shading-border.test.ts
@@ -56,7 +56,7 @@ describe('paraShadingRect (§17.3.1.31 shading fills the border box)', () => {
   });
 });
 
-describe('paragraph border joins (§17.3.1.17)', () => {
+describe('paragraph border joins (§17.3.1.24)', () => {
   it('includes a hanging first-line/list marker on the paragraph start side', () => {
     expect(paragraphBorderContentBox(100, 500, 36, 0, -36, false)).toEqual({ x: 100, w: 500 });
     expect(paragraphBorderContentBox(100, 500, 0, 36, -36, true)).toEqual({ x: 100, w: 500 });
@@ -64,6 +64,18 @@ describe('paragraph border joins (§17.3.1.17)', () => {
 
   it('does not expand toward a positive first-line indent', () => {
     expect(paragraphBorderContentBox(100, 500, 36, 18, 12, false)).toEqual({ x: 136, w: 446 });
+  });
+
+  it('unions resolved marker bounds on either physical side', () => {
+    expect(paragraphBorderContentBox(
+      100,
+      500,
+      36,
+      18,
+      -18,
+      false,
+      { left: 90, right: 610 },
+    )).toEqual({ x: 90, w: 520 });
   });
 
   it('spans horizontal edges to the vertical border positions and vertical edges between them', () => {

--- a/packages/docx/src/paragraph-border-numbering-marker.test.ts
+++ b/packages/docx/src/paragraph-border-numbering-marker.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderDocumentToCanvas } from './renderer.js';
+import type {
+  BodyElement,
+  DocParagraph,
+  DocxDocumentModel,
+  NumberingInfo,
+  ParagraphBorders,
+  SectionProps,
+} from './types.js';
+
+// ECMA-376 Part 1 §17.9.7: lvlJc positions numbering text relative to the
+// paragraph text margin; numbering text includes numerals, symbols and graphics.
+// §17.3.1.24: pBdr applies to the paragraph. Therefore the resolved marker ink
+// must remain inside the paragraph border even when right/center lvlJc shifts the
+// marker left of the raw hanging-indent reference.
+
+interface FillCall { text: string; x: number; }
+interface VerticalStroke { x: number; width: number; color: string; }
+interface ImageCall { x: number; w: number; }
+
+function makeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fills: FillCall[];
+  verticalStrokes: VerticalStroke[];
+  images: ImageCall[];
+} {
+  let font = '10px serif';
+  let strokeStyle = '#000';
+  let lineWidth = 1;
+  let path: { x: number; y: number }[] = [];
+  const fills: FillCall[] = [];
+  const verticalStrokes: VerticalStroke[] = [];
+  const images: ImageCall[] = [];
+  const fontPx = () => parseFloat(/(\d+(?:\.\d+)?)px/.exec(font)?.[1] ?? '10');
+  const ctx = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    get strokeStyle() { return strokeStyle; },
+    set strokeStyle(value: string) { strokeStyle = value; },
+    get lineWidth() { return lineWidth; },
+    set lineWidth(value: number) { lineWidth = value; },
+    letterSpacing: '0px',
+    measureText(text: string) {
+      const px = fontPx();
+      return {
+        width: [...text].length * px,
+        fontBoundingBoxAscent: px * 0.8,
+        fontBoundingBoxDescent: px * 0.2,
+        actualBoundingBoxAscent: px * 0.8,
+        actualBoundingBoxDescent: px * 0.2,
+      } as TextMetrics;
+    },
+    save() {}, restore() {},
+    beginPath() { path = []; }, closePath() {},
+    moveTo(x: number, y: number) { path.push({ x, y }); },
+    lineTo(x: number, y: number) { path.push({ x, y }); },
+    stroke() {
+      for (let i = 1; i < path.length; i++) {
+        if (path[i - 1].x === path[i].x) {
+          verticalStrokes.push({ x: path[i].x, width: lineWidth, color: strokeStyle });
+        }
+      }
+    },
+    fill() {}, fillRect() {}, strokeRect() {}, clip() {}, rect() {},
+    scale() {}, translate() {}, rotate() {}, setLineDash() {}, clearRect() {}, arc() {},
+    quadraticCurveTo() {}, bezierCurveTo() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+    drawImage(_image: unknown, x: number, _y: number, w: number) { images.push({ x, w }); },
+    fillText(text: string, x: number) { fills.push({ text, x }); },
+    strokeText() {},
+    fillStyle: '#000',
+    textAlign: 'left' as CanvasTextAlign,
+    direction: 'ltr' as CanvasDirection,
+    globalAlpha: 1,
+    lineCap: 'butt' as CanvasLineCap,
+    lineJoin: 'miter' as CanvasLineJoin,
+  };
+  const canvas = {
+    width: 0,
+    height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+  };
+  (ctx as unknown as { canvas: unknown }).canvas = canvas;
+  return { canvas: canvas as unknown as HTMLCanvasElement, fills, verticalStrokes, images };
+}
+
+const ONE_BY_ONE_GIF = new Uint8Array([
+  0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00,
+  0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x21, 0xf9, 0x04, 0x01, 0x00, 0x00, 0x00,
+  0x00, 0x2c, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x02,
+  0x44, 0x01, 0x00, 0x3b,
+]);
+
+const BORDER_COLOR = '123456';
+const borderEdge = () => ({ style: 'single', color: BORDER_COLOR, width: 1, space: 0 });
+const borders = (): ParagraphBorders => ({
+  top: borderEdge(),
+  bottom: borderEdge(),
+  left: borderEdge(),
+  right: borderEdge(),
+  between: null,
+});
+
+function numberedParagraph(jc: 'right' | 'center'): DocParagraph {
+  const numbering: NumberingInfo = {
+    numId: 1,
+    level: 0,
+    format: 'decimal',
+    text: '1.',
+    indentLeft: 72,
+    tab: 18,
+    suff: 'tab',
+    jc,
+    fontFamily: 'Times New Roman',
+  };
+  return {
+    type: 'paragraph',
+    alignment: 'left',
+    indentLeft: 72,
+    indentRight: 0,
+    indentFirst: -18,
+    spaceBefore: 0,
+    spaceAfter: 0,
+    lineSpacing: null,
+    numbering,
+    tabStops: [],
+    borders: borders(),
+    runs: [{
+      type: 'text',
+      text: 'Body',
+      bold: false,
+      italic: false,
+      underline: false,
+      strikethrough: false,
+      fontSize: 10,
+      color: null,
+      fontFamily: 'Times New Roman',
+      fontFamilyEastAsia: '',
+      isLink: false,
+      background: null,
+      vertAlign: null,
+      hyperlink: null,
+    }],
+    defaultFontSize: 10,
+    defaultFontFamily: 'Times New Roman',
+    widowControl: false,
+  } as DocParagraph;
+}
+
+function rtlNumberedParagraph(jc: 'right' | 'center'): DocParagraph {
+  const paragraph = numberedParagraph(jc);
+  paragraph.bidi = true;
+  paragraph.numbering!.tab = 36;
+  (paragraph.runs[0] as { text: string }).text = 'سلام';
+  return paragraph;
+}
+
+function documentOf(paragraph: DocParagraph): DocxDocumentModel {
+  return {
+    section: {
+      pageWidth: 400,
+      pageHeight: 400,
+      marginTop: 0,
+      marginRight: 0,
+      marginBottom: 0,
+      marginLeft: 0,
+      headerDistance: 0,
+      footerDistance: 0,
+      titlePage: false,
+      evenAndOddHeaders: false,
+    } as SectionProps,
+    body: [paragraph as unknown as BodyElement],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+    fontFamilyClasses: { 'Times New Roman': 'roman' },
+  } as unknown as DocxDocumentModel;
+}
+
+describe('paragraph border contains justified numbering marker', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 1, height: 1, close() {} }) as unknown as ImageBitmap),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it.each(['right', 'center'] as const)('contains an LTR %s-justified marker', async (jc) => {
+    const { canvas, fills, verticalStrokes } = makeRecordingCanvas();
+    await renderDocumentToCanvas(documentOf(numberedParagraph(jc)), canvas, 0, {
+      dpr: 1,
+      width: 400,
+    });
+
+    const marker = fills.find(({ text }) => text === '1.');
+    expect(marker).toBeDefined();
+    const borderSides = verticalStrokes.filter(({ color }) => color === `#${BORDER_COLOR}`);
+    expect(borderSides).toHaveLength(2);
+    const leftBorder = borderSides.reduce((left, stroke) => stroke.x < left.x ? stroke : left);
+    const borderOuterLeft = leftBorder.x - leftBorder.width / 2;
+
+    expect(marker!.x).toBeGreaterThanOrEqual(borderOuterLeft - 1e-9);
+  });
+
+  it.each(['right', 'center'] as const)('contains a mirrored RTL %s-justified marker', async (jc) => {
+    const { canvas, fills, verticalStrokes } = makeRecordingCanvas();
+    await renderDocumentToCanvas(documentOf(rtlNumberedParagraph(jc)), canvas, 0, {
+      dpr: 1,
+      width: 400,
+    });
+
+    const marker = fills.find(({ text }) => text === '1.');
+    expect(marker).toBeDefined();
+    const borderSides = verticalStrokes.filter(({ color }) => color === `#${BORDER_COLOR}`);
+    expect(borderSides).toHaveLength(2);
+    const rightBorder = borderSides.reduce((right, stroke) => stroke.x > right.x ? stroke : right);
+    const borderOuterRight = rightBorder.x + rightBorder.width / 2;
+    const markerRight = marker!.x + 20;
+
+    expect(markerRight).toBeLessThanOrEqual(borderOuterRight + 1e-9);
+  });
+
+  it('contains the actual decoded picture-bullet draw box', async () => {
+    const paragraph = numberedParagraph('right');
+    paragraph.numbering = {
+      ...paragraph.numbering!,
+      text: '',
+      picBulletImagePath: 'word/media/border-picture-bullet.gif',
+      picBulletMimeType: 'image/gif',
+      picBulletWidthPt: 24,
+      picBulletHeightPt: 12,
+    };
+    const { canvas, images, verticalStrokes } = makeRecordingCanvas();
+    await renderDocumentToCanvas(documentOf(paragraph), canvas, 0, {
+      dpr: 1,
+      width: 400,
+      fetchImage: async (_path, mime) => new Blob([ONE_BY_ONE_GIF], { type: mime }),
+    });
+
+    expect(images).toHaveLength(1);
+    const borderSides = verticalStrokes.filter(({ color }) => color === `#${BORDER_COLOR}`);
+    expect(borderSides).toHaveLength(2);
+    const leftBorder = borderSides.reduce((left, stroke) => stroke.x < left.x ? stroke : left);
+    const rightBorder = borderSides.reduce((right, stroke) => stroke.x > right.x ? stroke : right);
+    const borderOuterLeft = leftBorder.x - leftBorder.width / 2;
+    const borderOuterRight = rightBorder.x + rightBorder.width / 2;
+
+    expect(images[0].x).toBeGreaterThanOrEqual(borderOuterLeft - 1e-9);
+    expect(images[0].x + images[0].w).toBeLessThanOrEqual(borderOuterRight + 1e-9);
+  });
+});

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -215,6 +215,44 @@ describe('measureParagraph', () => {
     expect(paragraphOnlyMetrics.contentEndYPt).toBe(22);
   });
 
+  it('matches observed Word spacing for an explicit atLeast line on a body grid', () => {
+    const designRatio = 3269 / 2048;
+    const designMeasurer: TextMeasurer = {
+      context: makeContext(designRatio * 0.8, designRatio * 0.2),
+      fontFamilyClasses: {},
+    };
+    const explicitAtLeast = { value: 0, rule: 'atLeast' as const, explicit: true };
+    const result = measureParagraph(
+      paragraph({
+        spaceBefore: 0,
+        spaceAfter: 0,
+        lineSpacing: explicitAtLeast,
+        runs: [
+          { type: 'text', ...textRun('あ', { fontSize: 14, fontFamilyEastAsia: 'Test CJK' }) },
+          { type: 'break', breakType: 'line' },
+          { type: 'text', ...textRun('い', { fontSize: 10, fontFamilyEastAsia: 'Test CJK' }) },
+        ],
+      }),
+      layoutContext({
+        lineGrid: { active: true, pitchPt: 20 },
+        lineSpacing: explicitAtLeast,
+        spaceBeforePt: 0,
+        spaceAfterPt: 0,
+        hasEastAsianText: true,
+      }),
+      placement({ startYPt: 0 }),
+      designMeasurer,
+      environment({ documentHasEastAsianText: true }),
+    );
+
+    // Windows Word leaves the first explicit-atLeast line at its raw 14pt
+    // design height (slightly over one pitch), then keeps the ordinary line at
+    // one 20pt pitch. This is a compatibility fixture, not a normative claim
+    // that §17.3.1.33 or §17.6.5 defines this exception.
+    expect(result.lines.map((line) => line.advancePt))
+      .toEqual([14 * designRatio, 20]);
+  });
+
   it('treats an anchor-only paragraph as a paragraph mark', () => {
     const anchor: ImageRun = {
       imagePath: 'word/media/anchor.png', mimeType: 'image/png',

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -216,6 +216,7 @@ export function measureParagraph(
       measurer.context,
       fontFamilyClasses,
       context.lineSpacing,
+      environment.resolvedLocalFonts,
     );
     return {
       lines: [],
@@ -233,6 +234,7 @@ export function measureParagraph(
         measurer.context,
         fontFamilyClasses,
         context.lineSpacing,
+        environment.resolvedLocalFonts,
       ),
       placement: recordedPlacement,
     };
@@ -251,6 +253,7 @@ export function measureParagraph(
         columnXPt: placement.paragraphXPt,
         columnWidthPt: placement.availableWidthPt,
         floats: [],
+        paragraphMarkLineStartWidth: getDefaultFontSize(paragraph),
         lineWindow: (input) => placement.wrap!.lineWindow(input),
         lineBoxH: (ascent, descent, _hasRuby, intendedSingle, eastAsian, gridCountSingle) => lineBoxHeight(
           context.lineSpacing,

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -11,15 +11,17 @@ import init, { DocxArchive, reinit } from './wasm/docx_parser.js';
 import {
   decodeDataUrl,
   preloadGoogleFonts,
+  unloadLocalFontMetrics,
   WasmParserHost,
   dropBitmapCacheByPath,
   dropSvgImageCache,
 } from '@silurus/ooxml-core';
 import type { DocxDocumentModel, PaginatedBodyElement } from './types';
-import { paginateDocument, renderDocumentToCanvas, physicalPageSizeForPage, dropColorReplacedCache, type DocxTextRunInfo } from './renderer';
+import { paginateDocument, renderDocumentToCanvas, physicalPageSizeForPage, dropColorReplacedCache, setResolvedLocalFonts, clearResolvedLocalFonts, type DocxTextRunInfo } from './renderer';
 import { buildBookmarkPageMap } from './bookmark-nav';
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts';
 import { loadEmbeddedFonts } from './embedded-fonts';
+import { loadDocxLocalFontMetrics } from './local-font-metrics';
 import type { RenderWorkerRequest, RenderWorkerResponse, DocumentMeta } from './worker-protocol';
 
 // RB6: self-poison + auto-respawn. A trap during parse (or an in-worker image /
@@ -33,6 +35,7 @@ const host = new WasmParserHost<DocxArchive>(init, {
 });
 let doc: DocxDocumentModel | null = null;
 let pages: PaginatedBodyElement[][] | null = null;
+let localMetricFontFaces: FontFace[] = [];
 const imageCache = new Map<string, Promise<Blob>>();
 
 const post = (msg: RenderWorkerResponse, transfer?: Transferable[]) =>
@@ -65,6 +68,11 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
   try {
     await host.ensureReady();
     if (req.type === 'parse') {
+      if (doc) clearResolvedLocalFonts(doc);
+      if (localMetricFontFaces.length > 0) {
+        unloadLocalFontMetrics(localMetricFontFaces);
+        localMetricFontFaces = [];
+      }
       // Cached blobs belong to the previous document; serving them after a
       // re-parse would silently return the wrong file's image.
       imageCache.clear();
@@ -113,6 +121,9 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
           return new Uint8Array(host.run(() => loaded.extract_image(p))).slice();
         });
       }
+      const localMetrics = await loadDocxLocalFontMetrics(doc);
+      localMetricFontFaces = localMetrics.faces;
+      setResolvedLocalFonts(doc, localMetrics.metrics);
       pages = paginateDocument(doc);
       // ECMA-376 §17.6.13 / §17.6.11 / §17.6.20 — per-page size from each page's
       // stamped frame (its page-meta for an empty parity page). A vertical

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -53,11 +53,16 @@ import {
   drawUnderline,
   renderChart,
 } from '@silurus/ooxml-core';
-import type { MathNode, MathRenderer, KinsokuRules, HyperlinkTarget, NumberFormat, Duotone } from '@silurus/ooxml-core';
+import type { MathNode, MathRenderer, KinsokuRules, HyperlinkTarget, NumberFormat, Duotone, ResolvedLocalFontMetric } from '@silurus/ooxml-core';
 import { computePageNumbering } from './page-numbering.js';
 import { docxUnderlineToDrawingML } from './underline-map.js';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
-import { resolveBorderConflict } from './cell-border-conflict.js';
+import {
+  resolveBorderConflict,
+  resolveCellEdges,
+  type CellEdgeFlags,
+  type ResolvedCellEdges,
+} from './cell-border-conflict.js';
 import {
   segmentsHaveRtl,
   computeLineVisualOrder,
@@ -156,6 +161,8 @@ import {
   shapeRenderState,
   shapeRunToDocRun,
   segmentCharacterGridDeltaPx,
+  segmentEastAsiaFloorSingleLinePx,
+  segmentIntendedSingleLinePx,
   splitTextForLayout,
 } from './line-layout.js';
 import type {
@@ -407,6 +414,9 @@ export interface RenderState {
   /** ECMA-376 §17.8.3.10 — font→family map from word/fontTable.xml. Used by
    *  resolveFontFamily as the authoritative source of serif/sans-serif classification. */
   fontFamilyClasses: Record<string, string>;
+  /** Exact local faces and version-adaptive Word line metrics resolved before
+   * pagination. Keyed by normalized authored family. */
+  resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>>;
   /** ECMA-376 §17.15.1.58–.60 — resolved Japanese line-breaking rules
    *  (kinsoku enabled flag + line-start/line-end forbidden character sets).
    *  Default is the application's Japanese kinsoku table with kinsoku ON. */
@@ -588,6 +598,39 @@ function withTableCellStory(state: RenderState): RenderState {
       state.storyContext ?? BODY_STORY_CONTEXT,
     ),
   };
+}
+
+/** Whether a paragraph may use scale-1 glyph geometry as the single layout
+ * authority and map it to the paint viewport with a Canvas transform.
+ *
+ * Keep this predicate shared by paint and table-cell height measurement: row
+ * height / vAlign must reserve the exact line boxes that the glyph path draws.
+ * The excluded paths still have scale-aware layout or decoration behavior —
+ * including marker/tab-leader paint and math fallback — that has not yet been
+ * expressed entirely in canonical document coordinates. */
+function canonicalParagraphTextScaleEligible(
+  storyContext: StoryContext,
+  verticalCJK: boolean | undefined,
+  inFrame: boolean,
+  hasWrapContext: boolean,
+  paragraphContext: Pick<ParagraphLayoutContext, 'hasRuby' | 'baseRtl'>,
+  paragraph: Pick<DocParagraph, 'alignment' | 'numbering'>,
+  segments: readonly LayoutSeg[],
+): boolean {
+  return !hasWrapContext
+    && !inFrame
+    && storyContext.story === 'body'
+    && storyContext.containers.every((container) => container.kind === 'tableCell')
+    && !verticalCJK
+    && !paragraphContext.hasRuby
+    && !paragraphContext.baseRtl
+    && paragraph.numbering == null
+    && !segmentsHaveRtl(segments)
+    && kashidaLevelOf(paragraph.alignment) === null
+    && segments.every((segment) =>
+      !('isTab' in segment)
+      && !('mathNodes' in segment)
+      && (!('text' in segment) || segment.emphasisMark == null));
 }
 
 /** Information about a rendered text segment for building a transparent selection overlay. */
@@ -1097,6 +1140,31 @@ export async function preloadImages(
  */
 const renderTokens = new WeakMap<HTMLCanvasElement | OffscreenCanvas, number>();
 
+/** Async font resolution is document-scoped runtime state, not parser output.
+ * Keeping it in a WeakMap avoids mutating the public parsed model while both
+ * main-thread and worker renderers consume the same explicit document key. */
+const resolvedLocalFontsByDocument = new WeakMap<
+  DocxDocumentModel,
+  Readonly<Record<string, ResolvedLocalFontMetric>>
+>();
+
+export function setResolvedLocalFonts(
+  doc: DocxDocumentModel,
+  metrics: Readonly<Record<string, ResolvedLocalFontMetric>>,
+): void {
+  resolvedLocalFontsByDocument.set(doc, metrics);
+}
+
+export function clearResolvedLocalFonts(doc: DocxDocumentModel): void {
+  resolvedLocalFontsByDocument.delete(doc);
+}
+
+function resolvedLocalFontsFor(
+  doc: DocxDocumentModel,
+): Readonly<Record<string, ResolvedLocalFontMetric>> {
+  return resolvedLocalFontsByDocument.get(doc) ?? {};
+}
+
 /** True when a section flows VERTICALLY (glyphs stack top→bottom, lines advance
  *  across the page). `<w:sectPr><w:textDirection>` uses the TRANSITIONAL
  *  ST_TextDirection enum (ECMA-376 Part 4 §14.11.7; Word writes these, not the
@@ -1454,6 +1522,7 @@ async function renderDocumentToCanvasLeased(
   // get `doc` unchanged (referential identity ⇒ byte-identical). Text direction
   // is PER-SECTION (issue #1000), so the `vertical` flag is resolved per PAGE
   // below, after the stamped page frame is merged.
+  const resolvedLocalFonts = resolvedLocalFontsFor(doc);
   const layoutDoc = verticalLayoutDoc(doc);
   const layoutSettings = resolveDocumentLayoutSettings(layoutDoc);
   const kinsoku = layoutSettings.kinsoku;
@@ -1463,6 +1532,7 @@ async function renderDocumentToCanvasLeased(
     fontClassesWithPitches(layoutDoc.fontFamilyClasses, layoutDoc.fontFamilyPitches),
     layoutSettings,
     layoutDoc.footnotes ?? [],
+    resolvedLocalFonts,
   );
   const totalPages = Math.max(opts.totalPages ?? pages.length, pages.length);
   const elements = pages[pageIndex] ?? pages[0] ?? [];
@@ -1627,6 +1697,7 @@ async function renderDocumentToCanvasLeased(
     storyContext: BODY_STORY_CONTEXT,
     docEastAsian: layoutSettings.documentHasEastAsianText,
     fontFamilyClasses: fontClassesWithPitches(doc.fontFamilyClasses, doc.fontFamilyPitches),
+    resolvedLocalFonts,
     kinsoku,
     // §17.15.1.25 — automatic tab interval, resolved once and threaded like
     // `kinsoku` so the measure and draw passes agree.
@@ -2256,6 +2327,8 @@ export function computePages(
   settings?: DocSettings,
   /** Pre-resolved policy supplied by production entry points. */
   resolvedLayoutSettings?: DocumentLayoutSettings,
+  /** Exact local faces resolved before pagination; absent in pure unit callers. */
+  resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>> = {},
 ): PaginatedBodyElement[][] {
   // ECMA-376 §17.6.11: the body is inset from each page edge by the margin's MAGNITUDE
   // (a negative margin measures the body |margin| from the edge and overlaps the
@@ -2286,6 +2359,7 @@ export function computePages(
     section,
     fontFamilyClasses,
     documentSettings,
+    resolvedLocalFonts,
   );
   // ECMA-376 §17.6.20 + §17.4.80 (issue #988 batch-3 adjudication ④): in a
   // vertical (tbRl) section a block table is an UPRIGHT block: its cells lay
@@ -4280,6 +4354,7 @@ function paginateWithHeaderFooterReserve(
   fontFamilyClasses: Record<string, string>,
   layoutSettings: DocumentLayoutSettings,
   footnotes: DocNote[],
+  resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>> = {},
 ): PaginatedBodyElement[][] {
   // §17.15.1.25 — resolve once here so both pagination passes and the
   // reserve-measure state share the document's automatic tab interval.
@@ -4294,6 +4369,7 @@ function paginateWithHeaderFooterReserve(
     layoutSettings.defaultTabPt,
     doc.settings,
     layoutSettings,
+    resolvedLocalFonts,
   );
   // ECMA-376 §17.6.20 + §17.10.1 (issue #988): a vertical (tbRl) section lays its
   // header/footer out HORIZONTALLY in physical space with NO body reserve (see the
@@ -4314,7 +4390,13 @@ function paginateWithHeaderFooterReserve(
       (e) => e.type === 'sectionBreak' && !isVerticalTextDirection(e.textDirection ?? null),
     );
   if (!anyHorizontalSection) return pass1;
-  const measure = buildMeasureState(ctx, doc.section, fontFamilyClasses, layoutSettings);
+  const measure = buildMeasureState(
+    ctx,
+    doc.section,
+    fontFamilyClasses,
+    layoutSettings,
+    resolvedLocalFonts,
+  );
   // Issue #1000 — a horizontal page's header/footer must be measured against its
   // OWN frame: in a vertical-body mixed document the body-level `measure` is the
   // SWAPPED logical frame, which would wrap header/footer content at the wrong
@@ -4328,6 +4410,7 @@ function paginateWithHeaderFooterReserve(
           { ...doc.section, ...(g ?? {}), textDirection: null },
           fontFamilyClasses,
           layoutSettings,
+          resolvedLocalFonts,
         );
       }
     : (): RenderState => measure;
@@ -4350,6 +4433,7 @@ function paginateWithHeaderFooterReserve(
     layoutSettings.defaultTabPt,
     doc.settings,
     layoutSettings,
+    resolvedLocalFonts,
   );
 }
 
@@ -4381,6 +4465,7 @@ export function paginateDocument(doc: DocxDocumentModel): PaginatedBodyElement[]
   // the swapped doc here keeps the two passes consistent whether the pages are
   // prebuilt (this path) or paginated inline. Horizontal docs are unchanged
   // (referential identity).
+  const resolvedLocalFonts = resolvedLocalFontsFor(doc);
   const layoutDoc = verticalLayoutDoc(doc);
   const layoutSettings = resolveDocumentLayoutSettings(layoutDoc);
   return paginateWithHeaderFooterReserve(
@@ -4389,6 +4474,7 @@ export function paginateDocument(doc: DocxDocumentModel): PaginatedBodyElement[]
     fontClassesWithPitches(layoutDoc.fontFamilyClasses, layoutDoc.fontFamilyPitches),
     layoutSettings,
     layoutDoc.footnotes ?? [],
+    resolvedLocalFonts,
   );
 }
 
@@ -4414,6 +4500,7 @@ export function paginateDocument(doc: DocxDocumentModel): PaginatedBodyElement[]
 export function layoutDocument(doc: DocxDocumentModel): DocumentLayout {
   const ctx = new OffscreenCanvas(1, 1).getContext('2d');
   if (!ctx) return Object.freeze({ pages: Object.freeze([]) });
+  const resolvedLocalFonts = resolvedLocalFontsFor(doc);
   const layoutDoc = verticalLayoutDoc(doc);
   const layoutSettings = resolveDocumentLayoutSettings(layoutDoc);
   const pages = paginateWithHeaderFooterReserve(
@@ -4422,6 +4509,7 @@ export function layoutDocument(doc: DocxDocumentModel): DocumentLayout {
     fontClassesWithPitches(layoutDoc.fontFamilyClasses, layoutDoc.fontFamilyPitches),
     layoutSettings,
     layoutDoc.footnotes ?? [],
+    resolvedLocalFonts,
   );
   const layoutPages: LayoutPage[] = pages.map((elements, pageIndex) => {
     const firstEl = elements[0] as PaginatedBodyElement | undefined;
@@ -4482,6 +4570,7 @@ function buildMeasureState(
   section: SectionProps,
   fontFamilyClasses: Record<string, string> = {},
   layoutSettings: DocumentLayoutSettings,
+  resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>> = {},
 ): RenderState {
   const sectionLayout = resolveSectionLayoutContext(layoutSettings, section);
   return {
@@ -4525,6 +4614,7 @@ function buildMeasureState(
     storyContext: BODY_STORY_CONTEXT,
     docEastAsian: layoutSettings.documentHasEastAsianText,
     fontFamilyClasses,
+    resolvedLocalFonts,
     kinsoku: layoutSettings.kinsoku,
     defaultTabPt: layoutSettings.defaultTabPt,
     characterSpacingControl: layoutSettings.characterSpacingControl,
@@ -4577,6 +4667,7 @@ function paragraphMeasurementEnvironment(
     | 'verticalCJK'
     | 'verticalAllRotated'
     | 'docEastAsian'
+    | 'resolvedLocalFonts'
   >,
 ): ParagraphMeasurementEnvironment {
   return {
@@ -4593,6 +4684,7 @@ function paragraphMeasurementEnvironment(
     // "upright vertical" one. tbRl (no verticalAllRotated) is unchanged.
     verticalCJK: state.verticalCJK && !state.verticalAllRotated,
     documentHasEastAsianText: state.docEastAsian,
+    resolvedLocalFonts: state.resolvedLocalFonts,
   };
 }
 
@@ -7577,6 +7669,8 @@ function renderEmptyMarkParagraph(
     contentX: number;
     indLeft: number;
     paraW: number;
+    borderX: number;
+    borderW: number;
     textAreaTopY: number;
     paragraphStartY: number;
     /** Flowed top of the mark line (output of resolveEmptyMarkTop). */
@@ -7589,7 +7683,7 @@ function renderEmptyMarkParagraph(
   },
 ): void {
   const { ctx, scale, dryRun } = state;
-  const { grid, paraHasRuby, contentX, indLeft, paraW, textAreaTopY,
+  const { grid, paraHasRuby, contentX, indLeft, paraW, borderX, borderW, textAreaTopY,
     paragraphStartY, markTop, totalLines, lineSlice, borderMerge } = markCtx;
   // Displacement applied by the float-flow (0 when the mark fits where it is).
   const flowShift = Math.max(0, markTop - textAreaTopY);
@@ -7598,12 +7692,12 @@ function renderEmptyMarkParagraph(
   const emptyH = paragraphMarkLineHeight(para, scale, grid, paraHasRuby, state.docEastAsian, ctx, state.fontFamilyClasses);
   if (para.shading && !dryRun) {
     ctx.fillStyle = `#${para.shading}`;
-    const sb = paraShadingRect(contentX + indLeft, markRectTop, paraW, emptyH, para.borders, borderMerge, scale);
+    const sb = paraShadingRect(borderX, markRectTop, borderW, emptyH, para.borders, borderMerge, scale);
     ctx.fillRect(sb.x, sb.y, sb.w, sb.h);
   }
   state.y += emptyH;
   if (para.borders && !dryRun) {
-    drawParaBorders(ctx, contentX + indLeft, markRectTop, paraW, emptyH, para.borders, scale, state.dpr, borderMerge);
+    drawParaBorders(ctx, borderX, markRectTop, borderW, emptyH, para.borders, scale, state.dpr, borderMerge);
   }
   // Only the slice covering the FINAL line emits spaceAfter. With no inline
   // lines there is a single slice, so this is the whole paragraph. §17.3.1.7: a
@@ -7999,6 +8093,14 @@ function renderParagraph(
   const paraX = contentX + indLeft;
   const firstLineX = paraX + indFirst;
   const paraW = contentW - indLeft - indRight;
+  const borderBox = paragraphBorderContentBox(
+    contentX,
+    contentW,
+    indLeft,
+    indRight,
+    indFirst,
+    baseRtl,
+  );
 
   // ECMA-376 §17.9.28 (`<w:suff>`) governs where a numbering marker's first-line
   // body starts. With suff=tab (default) the body advances to the indentLeft tab
@@ -8069,7 +8171,9 @@ function renderParagraph(
     // Literally-empty paragraph: one paragraph-mark line box, no inline content
     // and (by construction in the paginator) never sliced.
     renderEmptyMarkParagraph(para, state, {
-      grid, paraHasRuby, contentX, indLeft, paraW, textAreaTopY, paragraphStartY,
+      grid, paraHasRuby, contentX, indLeft, paraW,
+      borderX: borderBox.x, borderW: borderBox.w,
+      textAreaTopY, paragraphStartY,
       markTop: resolveEmptyMarkTop(), totalLines: 0, lineSlice: undefined, borderMerge,
     });
     return;
@@ -8101,6 +8205,21 @@ function renderParagraph(
     ),
     pageH: state.pageH,
   } : undefined;
+  // The canonical scale-1 paint bridge is intentionally limited to ordinary
+  // horizontal paragraphs in the body story, including body-table cells (and
+  // nested body tables). Float wrapping still lays out directly in paint-space;
+  // non-body stories, frames, bidi/kashida, ruby, emphasis marks, and vertical
+  // text retain their established scale-aware draw paths until each has dedicated
+  // canonical-transform coverage.
+  const canonicalTextScale = canonicalParagraphTextScaleEligible(
+    state.storyContext ?? BODY_STORY_CONTEXT,
+    state.verticalCJK,
+    inFrame,
+    wrapCtx !== undefined,
+    paragraphContext,
+    para,
+    segments,
+  );
 
   // ECMA-376 §17.3.1.12 (hanging) + §17.3.1.38 (a hanging indent implicitly
   // creates a tab stop at indentLeft) + §17.9.28 (`<w:suff>`, default "tab"):
@@ -8126,10 +8245,10 @@ function renderParagraph(
   // Phase 4-1 B2 Stage 2 — compute-once, ZOOM-INVARIANT reuse. When the paginator
   // split this paragraph it stamped the scale-1 lines it laid out
   // (splitParagraphAcrossPages). Reuse the scale-1 line PARTITION at ANY paint
-  // scale — skipping this scale's line-BREAK decisions — and rehydrate to the
-  // paint scale by RE-MEASURING each line's glyph geometry at the paint scale
-  // (rescaleLayoutLines: advance + box + tabs, so measure == draw with no hinting
-  // drift; scale 1 returns the stamp unchanged). This is a deliberate BEHAVIOUR
+  // scale — skipping this scale's line-BREAK decisions. Ordinary horizontal body
+  // paragraphs map their complete scale-1 geometry through a Canvas viewport
+  // transform; excluded legacy paths re-measure at paint scale. Scale 1 returns
+  // the stamp unchanged. This is a deliberate BEHAVIOUR
   // CHANGE from Stage 1, which reused only at scale 1 and otherwise re-ran the
   // break decisions at the paint scale: with a real (hinted) font those decisions
   // could move wrap points as the zoom changes, whereas Word lays text out in the
@@ -8188,8 +8307,8 @@ function renderParagraph(
     // references legitimately differ while the rules are identical.
     kinsokuRulesEquivalent(stamped.layoutLinesInputs.kinsoku, state.kinsoku);
   // Zoom-invariant line breaking (Phase 4-1 B2 Stage 2). Three cases, all feeding
-  // the SAME draw loop below; rescaleLayoutLines re-measures the geometry at the
-  // paint scale off the scale-1 PARTITION (so measure == draw, no hinting drift):
+  // the SAME draw loop below; rescaleLayoutLines bridges the scale-1 PARTITION to
+  // paint using canonical geometry when eligible, or legacy paint-scale metrics:
   //  1. reuse — the paginator's scale-1 stamp.
   //  2. no float context — recompute the partition in the paginator's SAME scale-1
   //     space (paraW1 / firstIndent1 / indLeft1 / gridDelta1). A paragraph that
@@ -8216,14 +8335,14 @@ function renderParagraph(
     // paint scale via the same bridge the reuse gate uses. No re-layout, so paint
     // scales stored geometry only (scale 1 returns the partition unchanged, so a
     // scale-1 paint invokes no measureText).
-    ? rescaleLayoutLines([...suppliedScale1Lines], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx)
+    ? rescaleLayoutLines([...suppliedScale1Lines], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx, canonicalTextScale)
     : reuse
-    ? rescaleLayoutLines(stamped.layoutLines as LayoutLine[], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx)
+    ? rescaleLayoutLines(stamped.layoutLines as LayoutLine[], scale, ctx, state.fontFamilyClasses, paintGridDeltaPx, canonicalTextScale)
     : wrapCtx
       ? layoutLines(ctx, segments, paraW, firstLineIndent, scale, para.tabStops, wrapCtx, state.fontFamilyClasses, indLeft, state.kinsoku, paintGridDeltaPx, state.defaultTabPt, marginRightPx, baseRtl, jcIsFullyJustified(para.alignment), jcStretchesLastLine(para.alignment))
       : rescaleLayoutLines(
           layoutLines(ctx, segments, paraW1, firstIndent1, 1, para.tabStops, undefined, state.fontFamilyClasses, indLeft1, state.kinsoku, gridDelta1, state.defaultTabPt, marginRightPx1, baseRtl, jcIsFullyJustified(para.alignment), jcStretchesLastLine(para.alignment)),
-          scale, ctx, state.fontFamilyClasses, paintGridDeltaPx,
+          scale, ctx, state.fontFamilyClasses, paintGridDeltaPx, canonicalTextScale,
         );
 
   // Decimal-tab auto-alignment. ECMA-376 (§17.3.1.37 tabs / §17.18.84 ST_TabJc
@@ -8267,7 +8386,9 @@ function renderParagraph(
     // honor a paginator-split slice (spaceAfter on the final slice, anchor
     // images on the first).
     renderEmptyMarkParagraph(para, state, {
-      grid, paraHasRuby, contentX, indLeft, paraW, textAreaTopY, paragraphStartY,
+      grid, paraHasRuby, contentX, indLeft, paraW,
+      borderX: borderBox.x, borderW: borderBox.w,
+      textAreaTopY, paragraphStartY,
       markTop: resolveEmptyMarkTop(), totalLines: lines.length, lineSlice, borderMerge,
     });
     return;
@@ -8303,16 +8424,11 @@ function renderParagraph(
   // must not fill to the full-paragraph height past the slice's bottom border.
   const sliceStart = lineSlice ? lineSlice.start : 0;
   const sliceEnd = lineSlice ? lineSlice.end : lines.length;
-  // The slice is authoritative for WHICH lines land on this page, but THIS
-  // pass's `lines` array is authoritative for how many lines the text actually
-  // occupies at this scale (pagination lays out at scale 1; ctx.measureText is
-  // not perfectly scale-invariant, so a long narrow paragraph can wrap to a
-  // slightly different line count here than the scale-1 slice assumed). Cap the
-  // iteration at lines.length so we paint every real line and never index a
-  // phantom line that only existed in the scale-1 measurement (lines[i] would be
-  // undefined → "Cannot read properties of undefined"). The overflow is bounded
-  // (at most a line or two), so all the paragraph's text is still painted across
-  // its slices. `paintEnd` also bounds the shading height below.
+  // The slice is authoritative for WHICH lines land on this page. Canonically
+  // scaled body paragraphs retain the exact scale-1 count; excluded float/legacy
+  // paths may still lay out at paint scale, so cap against their actual line array
+  // and never index a phantom slice line. `paintEnd` also bounds the shading
+  // height below.
   const paintEnd = Math.min(sliceEnd, lines.length);
 
   if (para.shading && !dryRun) {
@@ -8323,7 +8439,7 @@ function renderParagraph(
     // in the float-clearance and page-slice cases too, not just top/left/right.
     const paintedH = paintedParagraphHeight(lines, sliceStart, paintEnd, textAreaTopY, lineHForLine);
     ctx.fillStyle = `#${para.shading}`;
-    const sb = paraShadingRect(contentX + indLeft, textAreaTopY, paraW, paintedH, para.borders, borderMerge, scale);
+    const sb = paraShadingRect(borderBox.x, textAreaTopY, borderBox.w, paintedH, para.borders, borderMerge, scale);
     ctx.fillRect(sb.x, sb.y, sb.w, sb.h);
   }
 
@@ -8354,7 +8470,7 @@ function renderParagraph(
   // glyph lands on the box edge, so the painted advance equals measuredWidth by
   // construction. See the gridCharDeltaPx / gridSegDeltaPx header.
   const drawGridDeltaPx = gridCharDeltaPx(grid, scale);
-  const drawCtx: ParagraphLineDrawCtx = { ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses, contentX, contentW, lines, grid, paraHasRuby, paraX, firstLineX, paraW, indLeft, indFirst, continuesParagraph: lineSlice?.continues === true, baseRtl, hasMarker, markerUsesBodyOffset, numTab, numBodyOffset, markerJcShiftPx, picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi, decimalAutoTabPx, drawGridDeltaPx, lineHForLine };
+  const drawCtx: ParagraphLineDrawCtx = { ctx, scale, state, para, dryRun, defaultColor, fontFamilyClasses, contentX, contentW, lines, grid, paraHasRuby, paraX, firstLineX, paraW, indLeft, indFirst, continuesParagraph: lineSlice?.continues === true, baseRtl, hasMarker, markerUsesBodyOffset, numTab, numBodyOffset, markerJcShiftPx, picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi, decimalAutoTabPx, drawGridDeltaPx, canonicalTextScale, lineHForLine };
   for (let li = sliceStart; li < paintEnd; li++) {
     drawParagraphLine(li, drawCtx);
   }
@@ -8367,7 +8483,7 @@ function renderParagraph(
     // used above — the fill meets this bottom border by construction, in the
     // normal, float-clearance and page-slice cases alike.
     const textH = state.y - textAreaTopY;
-    drawParaBorders(ctx, contentX + indLeft, textAreaTopY, paraW, textH, para.borders, scale, state.dpr, borderMerge);
+    drawParaBorders(ctx, borderBox.x, textAreaTopY, borderBox.w, textH, para.borders, scale, state.dpr, borderMerge);
   }
 
   // spaceAfter is paragraph-level; only emit it on the slice that covers
@@ -8514,6 +8630,7 @@ interface ParagraphLineDrawCtx {
   paraNeedsBidi: boolean;
   decimalAutoTabPx: number | null;
   drawGridDeltaPx: number;
+  canonicalTextScale: boolean;
   lineHForLine: (l: LayoutLine) => number;
 }
 
@@ -8526,7 +8643,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     contentX, contentW, lines, grid, paraHasRuby, paraX, firstLineX, paraW, indLeft,
     indFirst, continuesParagraph, baseRtl, hasMarker, markerUsesBodyOffset, numTab, numBodyOffset, markerJcShiftPx,
     picBullet, isJustified, stretchLastLine, alignEdge, paraNeedsBidi,
-    decimalAutoTabPx, drawGridDeltaPx, lineHForLine,
+    decimalAutoTabPx, drawGridDeltaPx, canonicalTextScale, lineHForLine,
   } = c;
     const line = lines[li];
     // ECMA-376 §17.6.20 + Part 4 §14.11.7 (#988 re-adjudication): only an
@@ -8571,7 +8688,15 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     // centred below-baseline extent that is deliberately left unchanged; see
     // lineBelowBaselinePx in line-layout.ts.)
     const lineH = lineHForLine(line);
-    const glyphNatural = line.ascent + line.descent;
+    // A floating-anchor host can reserve line/grid height while painting no
+    // glyph. Keep that reservation in `lineH`, but position visible ink from
+    // the segments that actually draw. This preserves the host paragraph's
+    // advance without letting a differently-sized zero-ink run lower adjacent
+    // caption text (Word-compatible mixed-anchor behavior).
+    const visibleAscent = line.visibleAscent ?? line.ascent;
+    const visibleDescent = line.visibleDescent ?? line.descent;
+    const visibleIntendedSingle = line.visibleIntendedSingle ?? line.intendedSingle;
+    const glyphNatural = visibleAscent + visibleDescent;
     const autoMultiple =
       para.lineSpacing?.rule === 'auto' && !paraHasRuby && !isGridLineRule(grid);
     // For auto multiple spacing at or above 1×, centre the glyph only within
@@ -8580,9 +8705,9 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
     // 1×, centre against the authored compressed line box itself.
     const compressedAuto = autoMultiple && (para.lineSpacing?.value ?? 1) < 1;
     const centerBox = autoMultiple && !compressedAuto
-      ? Math.max(glyphNatural, line.intendedSingle)
+      ? Math.max(glyphNatural, visibleIntendedSingle)
       : lineH;
-    const baseline = state.y + (centerBox - glyphNatural) / 2 + line.ascent;
+    const baseline = state.y + (centerBox - glyphNatural) / 2 + visibleAscent;
 
     // Per-line X range (may be narrower than paraW when wrapping around floats).
     const lineLeft = paraX + line.xOffset;
@@ -8970,7 +9095,9 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
       const trailingDistributionGap = distributedStretch?.trailingGap ?? false;
       const internalStretch = (stretch?.internalStretch ?? 0) + (kashida?.advanceDeltaPx ?? 0);
       if (!dryRun) {
+        const useCanonicalTransform = canonicalTextScale && scale !== 1;
         const effSizePx = calcEffectiveFontPx(s, scale);
+        const glyphSizePx = calcEffectiveFontPx(s, useCanonicalTransform ? 1 : scale);
         // ECMA-376 §17.3.2.24 `<w:position>` — baseline raise(+)/lower(−) in pt.
         // Canvas y grows DOWNWARD, so a positive (raised) position subtracts from
         // y. It layers ON TOP of the super/sub offset (a positioned superscript
@@ -8982,7 +9109,7 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             : s.vertAlign === 'sub'
               ? s.fontSize * scale * 0.15
               : 0) + positionOffset;
-        ctx.font = buildFont(s.bold, s.italic, effSizePx, s.fontFamily, fontFamilyClasses);
+        ctx.font = buildFont(s.bold, s.italic, glyphSizePx, s.fontFamily, fontFamilyClasses);
 
         // ECMA-376 §17.3.2.43 `<w:w>` horizontal glyph scale (1 = 100%) and
         // §17.3.2.35 `<w:spacing>` per-code-point character pitch in px. Both were
@@ -9199,6 +9326,15 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             glyphDrawX = x + rtlWsShiftPx;
           }
         }
+        const glyphUnitScale = useCanonicalTransform ? scale : 1;
+        const glyphBaseline = useCanonicalTransform ? 0 : baseline + yOffset;
+        const glyphLocalX = (absolutePaintX: number): number =>
+          useCanonicalTransform ? (absolutePaintX - x) / scale : absolutePaintX;
+        if (useCanonicalTransform) {
+          ctx.save();
+          ctx.translate(x, baseline + yOffset);
+          ctx.scale(scale, scale);
+        }
         if (verticalUpright && s.tateChuYoko) {
           // ECMA-376 §17.3.2.10 縦中横 (horizontal-in-vertical): draw the whole run
           // horizontally, side by side, inside ONE cell of the vertical column.
@@ -9278,9 +9414,10 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           const fitDrawX = x + (fitRtl ? fitPad : 0) + rtlWsShiftPx;
           const scaled = segCharScale !== 1;
           const prevLetterSpacing = ctx.letterSpacing;
-          if (scaled) { ctx.save(); ctx.translate(fitDrawX, 0); ctx.scale(segCharScale, 1); }
-          ctx.letterSpacing = `${s.fitTextPerGapPx / segCharScale}px`;
-          ctx.fillText(glyphText, scaled ? 0 : fitDrawX, baseline + yOffset);
+          const fitLocalX = glyphLocalX(fitDrawX);
+          if (scaled) { ctx.save(); ctx.translate(fitLocalX, 0); ctx.scale(segCharScale, 1); }
+          ctx.letterSpacing = `${s.fitTextPerGapPx / glyphUnitScale / segCharScale}px`;
+          ctx.fillText(glyphText, scaled ? 0 : fitLocalX, glyphBaseline);
           ctx.letterSpacing = prevLetterSpacing;
           if (scaled) ctx.restore();
         } else if (segGridDelta !== 0) {
@@ -9328,16 +9465,17 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           const pieces = justifiedPiecePositions(
             cps,
             stretch?.splitBefore ?? [],
-            distPerGap / segCharScale,
+            distPerGap / glyphUnitScale / segCharScale,
             measure,
-            gridPlusSpacing / segCharScale,
+            gridPlusSpacing / glyphUnitScale / segCharScale,
           );
           const prevLetterSpacing = ctx.letterSpacing;
-          if (scaled) { ctx.save(); ctx.translate(x, 0); ctx.scale(segCharScale, 1); }
-          const originX = scaled ? 0 : x;
-          ctx.letterSpacing = `${gridPlusSpacing / segCharScale}px`;
+          const lineLocalX = glyphLocalX(x);
+          if (scaled) { ctx.save(); ctx.translate(lineLocalX, 0); ctx.scale(segCharScale, 1); }
+          const originX = scaled ? 0 : lineLocalX;
+          ctx.letterSpacing = `${gridPlusSpacing / glyphUnitScale / segCharScale}px`;
           for (const { text: piece, dx } of pieces) {
-            ctx.fillText(piece, originX + dx, baseline + yOffset);
+            ctx.fillText(piece, originX + dx, glyphBaseline);
           }
           ctx.letterSpacing = prevLetterSpacing;
           if (scaled) ctx.restore();
@@ -9362,9 +9500,10 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           // exactly: no transform, pieces at `x + dx`, pitch un-divided.
           const cps = [...drawText]; // code points (handles surrogate pairs)
           const scaled = segCharScale !== 1;
-          const originX = scaled ? 0 : x;
+          const lineLocalX = glyphLocalX(x);
+          const originX = scaled ? 0 : lineLocalX;
           const prevLetterSpacing = ctx.letterSpacing;
-          if (scaled) { ctx.save(); ctx.translate(x, 0); ctx.scale(segCharScale, 1); }
+          if (scaled) { ctx.save(); ctx.translate(lineLocalX, 0); ctx.scale(segCharScale, 1); }
           if (stretch.splitBefore.length === cps.length - 1) {
             // FULLY distributed: a gap was opened at EVERY inter-glyph boundary
             // (pure-CJK justify), so the pitch is UNIFORM. Drawing one glyph per
@@ -9387,8 +9526,8 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             // Both fixed pitches are divided by `segCharScale` (see the arm header)
             // so the ×scale frame reproduces their un-scaled magnitude (a no-op
             // divide by 1 on the common non-w:w path).
-            ctx.letterSpacing = `${(distPerGap + segCharSpacingPx) / segCharScale}px`;
-            ctx.fillText(drawText, originX, baseline + yOffset);
+            ctx.letterSpacing = `${(distPerGap + segCharSpacingPx) / glyphUnitScale / segCharScale}px`;
+            ctx.fillText(drawText, originX, glyphBaseline);
           } else {
             const measure = (str: string): number => ctx.measureText(str).width;
             // Partial justify split: pass the char-spacing pitch both as the
@@ -9400,12 +9539,12 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
             for (const { text: piece, dx } of justifiedPiecePositions(
               cps,
               stretch.splitBefore,
-              distPerGap / segCharScale,
+              distPerGap / glyphUnitScale / segCharScale,
               measure,
-              segCharSpacingPx / segCharScale,
+              segCharSpacingPx / glyphUnitScale / segCharScale,
             )) {
-              ctx.letterSpacing = `${segCharSpacingPx / segCharScale}px`;
-              ctx.fillText(piece, originX + dx, baseline + yOffset);
+              ctx.letterSpacing = `${segCharSpacingPx / glyphUnitScale / segCharScale}px`;
+              ctx.fillText(piece, originX + dx, glyphBaseline);
             }
           }
           ctx.letterSpacing = prevLetterSpacing;
@@ -9420,13 +9559,13 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           // (The docGrid and justify arms above compose the SAME transform when a
           // grid / distributed run also carries w:w — issue #816.)
           ctx.save();
-          ctx.translate(glyphDrawX, 0);
+          ctx.translate(glyphLocalX(glyphDrawX), 0);
           ctx.scale(segCharScale, 1);
           const prevLetterSpacing = ctx.letterSpacing;
           if (segCharSpacingPx !== 0) {
-            ctx.letterSpacing = `${segCharSpacingPx / segCharScale}px`;
+            ctx.letterSpacing = `${segCharSpacingPx / glyphUnitScale / segCharScale}px`;
           }
-          ctx.fillText(glyphText, 0, baseline + yOffset);
+          ctx.fillText(glyphText, 0, glyphBaseline);
           ctx.letterSpacing = prevLetterSpacing;
           ctx.restore();
         } else if (segCharSpacingPx !== 0) {
@@ -9434,11 +9573,18 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           // whole run draws with a uniform per-glyph letter-spacing pitch that the
           // layout already folded into `s.measuredWidth` (measure==paint).
           const prevLetterSpacing = ctx.letterSpacing;
-          ctx.letterSpacing = `${segCharSpacingPx}px`;
-          ctx.fillText(glyphText, glyphDrawX, baseline + yOffset);
+          ctx.letterSpacing = `${segCharSpacingPx / glyphUnitScale}px`;
+          ctx.fillText(glyphText, glyphLocalX(glyphDrawX), glyphBaseline);
           ctx.letterSpacing = prevLetterSpacing;
         } else {
-          ctx.fillText(glyphText, glyphDrawX, baseline + yOffset);
+          ctx.fillText(glyphText, glyphLocalX(glyphDrawX), glyphBaseline);
+        }
+        if (useCanonicalTransform) {
+          ctx.restore();
+          // Overlay consumers receive paint-space geometry and must see the
+          // corresponding paint-size font even though the glyphs themselves were
+          // shaped at scale 1 and mapped through the local viewport transform.
+          ctx.font = buildFont(s.bold, s.italic, effSizePx, s.fontFamily, fontFamilyClasses);
         }
         // §17.3.2.19 — restore the inherited font-kerning now the run's glyphs are
         // painted (the following ruby / emphasis-mark draws are separate glyphs at
@@ -10583,8 +10729,8 @@ export function measureShapeTextAutoFitHeight(
       const segPx = ts.fontSize * scale;
       floorPx = Math.max(
         floorPx,
-        intendedSingleLinePx(ts.fontFamily ?? null, segPx, segEa),
-        intendedSingleLinePx(ts.eaFloorFamily ?? null, segPx, segEa),
+        segmentIntendedSingleLinePx(ts, segPx, segEa),
+        segmentEastAsiaFloorSingleLinePx(ts, segPx, segEa),
       );
     }
     const lineEa = EAST_ASIAN_RE.test(lineText);
@@ -10595,8 +10741,12 @@ export function measureShapeTextAutoFitHeight(
     // METRIC hint = the tallest segment's own script (a Latin tallest segment
     // keeps its Canvas box even on a CJK-bearing line); GRID participation
     // stays line-wide (any EA content on the line makes it cell-rounded).
-    const asciiIntended = intendedSingleLinePx(family, fontPx, tallestEa);
-    const eaIntended = intendedSingleLinePx(eaFamily, fontPx, tallestEa);
+    const asciiIntended = tallest
+      ? segmentIntendedSingleLinePx(tallest, fontPx, tallestEa)
+      : intendedSingleLinePx(family, fontPx, tallestEa);
+    const eaIntended = tallest
+      ? segmentEastAsiaFloorSingleLinePx(tallest, fontPx, tallestEa)
+      : intendedSingleLinePx(eaFamily, fontPx, tallestEa);
     const measureFamily = eaIntended > asciiIntended ? eaFamily : family;
     ctx.font = buildFont(
       tallest?.bold ?? b.bold ?? false,
@@ -11055,8 +11205,8 @@ export function renderShapeText(
       }
       floorPx = Math.max(
         floorPx,
-        intendedSingleLinePx(ts.fontFamily ?? null, segPx, segEa),
-        intendedSingleLinePx(ts.eaFloorFamily ?? null, segPx, segEa),
+        segmentIntendedSingleLinePx(ts, segPx, segEa),
+        segmentEastAsiaFloorSingleLinePx(ts, segPx, segEa),
       );
     }
     const fontPx = (tallest?.fontSize ?? b.fontSizePt) * scale;
@@ -12771,50 +12921,6 @@ function drawTableRows(
   return y;
 }
 
-/** ECMA-376 §17.4.66 — the resolved physical edge specs of one cell (top / bottom
- *  / left / right), each folding the cell's own edge → cell inside → table
- *  inside/outer precedence (§17.4.38/§17.4.39), with `mirror` swapping the logical
- *  left/right onto physical sides for a bidiVisual table. `null` = the edge paints
- *  nothing at the cell level (before the neighbour conflict is considered).
- *  A `source` tag ('cell' | 'table') travels with each spec for §17.4.66 rule #1. */
-interface ResolvedCellEdges {
-  top: { spec: BorderSpec; source: 'cell' | 'table' } | null;
-  bottom: { spec: BorderSpec; source: 'cell' | 'table' } | null;
-  left: { spec: BorderSpec; source: 'cell' | 'table' } | null;
-  right: { spec: BorderSpec; source: 'cell' | 'table' } | null;
-}
-
-function resolveCellEdges(
-  cell: CellBorders,
-  table: TableBorders,
-  edges: CellEdgeFlags,
-  mirror: boolean,
-): ResolvedCellEdges {
-  // Per-edge cascade: the cell's own explicit edge (source 'cell') wins; else an
-  // interior edge falls to the cell's insideH/insideV then the table inside spec;
-  // an outer edge falls to the table outer spec (all source 'table').
-  const horiz = (own: BorderSpec | null, outer: boolean, tableOuter: BorderSpec | null) => {
-    if (own) return { spec: own, source: 'cell' as const };
-    const t = outer ? tableOuter : (cell.insideH ?? table.insideH);
-    return t ? { spec: t, source: 'table' as const } : null;
-  };
-  const vert = (own: BorderSpec | null, outer: boolean, tableOuter: BorderSpec | null) => {
-    if (own) return { spec: own, source: 'cell' as const };
-    const t = outer ? tableOuter : (cell.insideV ?? table.insideV);
-    return t ? { spec: t, source: 'table' as const } : null;
-  };
-  const top = horiz(cell.top, edges.topRow, table.top);
-  const bottom = horiz(cell.bottom, edges.bottomRow, table.bottom);
-  // bidiVisual mirrors which logical edge maps to each physical side (§17.4.1).
-  const left = mirror
-    ? vert(cell.right, edges.rightCol, table.right)
-    : vert(cell.left, edges.leftCol, table.left);
-  const right = mirror
-    ? vert(cell.left, edges.leftCol, table.left)
-    : vert(cell.right, edges.rightCol, table.right);
-  return { top, bottom, left, right };
-}
-
 /** Resolve the neighbour cell at grid slot (ri, ci) and return its resolved
  *  edges, or `null` when the slot is empty/out of range. */
 function neighbourEdges(
@@ -13028,12 +13134,11 @@ function measureCellParagraphHeight(
 
 /** Slice-aware twin of {@link measureCellParagraphHeight}: measures only the
  *  `[range.start, range.end)` line window (a mid-row split piece's slice) with
- *  the SAME real-scale rescale machinery, and reports the paragraph's total
+ *  the SAME canonical/legacy scale bridge as paint, and reports the paragraph's total
  *  line count so the caller can tell whether the window covers the paragraph
  *  end (trailing-spacing ownership). No range ⇒ the full paragraph — byte-
- *  identical to the historical behavior. The rescale (not a geometric ×scale)
- *  is the Finding-1 invariant: the vAlign centring height must equal what
- *  paint actually draws at this scale. */
+ *  identical to the historical behavior. The invariant is that vAlign and row
+ *  sizing consume the same line boxes that paint actually draws. */
 function measureCellParagraphWindow(
   state: RenderState,
   para: DocParagraph,
@@ -13077,16 +13182,11 @@ function measureCellParagraphWindow(
         },
       );
     }
-    // measureParagraph works in scale-1 points (its contract). A geometric
-    // `× scale` of that height is the exact anti-pattern rescaleLayoutLines
-    // exists to avoid: a real (hinted) font's Canvas metrics are NOT scale-linear
-    // (`metric(pt·s) ≠ s·metric(pt)`; see rescaleLayoutLines' header and
-    // layout-lines-scale-invariance.test.ts), so `scale1Height × scale` drifts
-    // from the height the paint pass (renderParagraph) actually draws. Reproduce
-    // the SAME scale-1-partition → paint-scale bridge paint uses, so the measured
-    // cell height equals the painted height at `scale` — the height that feeds
-    // vAlign centring (renderCell) and the content-driven row-height fallback
-    // (computeTableLayout → resolveTableRowHeights).
+    // measureParagraph works in scale-1 points (its contract). Reproduce the
+    // SAME scale bridge as renderParagraph: ordinary body-table text keeps these
+    // canonical line boxes and paint maps them through the Canvas viewport;
+    // excluded legacy paths re-measure their line geometry at paint scale. This
+    // keeps vAlign and content-driven row sizing equal to the painted glyph box.
     const scale1ContentHeight = measured.contentEndYPt - measured.placement.startYPt;
     const totalLines = measured.markOnly ? 0 : measured.lines.length;
     const windowStart = range ? Math.max(0, range.start) : 0;
@@ -13125,9 +13225,20 @@ function measureCellParagraphWindow(
         totalLines,
       };
     }
-    // Rehydrate the scale-1 line PARTITION to the paint scale exactly as
-    // renderParagraph does (re-measure every line's glyph geometry), then advance
-    // by the per-line box height with the SAME ruby/docGrid/lineSpacing resolver
+    const segments = buildSegments(para.runs, segmentEnvironmentOf(state));
+    const canonicalTextScale = canonicalParagraphTextScaleEligible(
+      state.storyContext ?? BODY_STORY_CONTEXT,
+      state.verticalCJK,
+      false,
+      false,
+      paragraphContext,
+      para,
+      segments,
+    );
+    // Rehydrate the scale-1 line PARTITION exactly as renderParagraph does:
+    // canonical body-table text scales stored geometry, while excluded legacy
+    // paths re-measure it. Then advance by the per-line box height with the SAME
+    // ruby/docGrid/lineSpacing resolver
     // (§17.3.1.33). A table cell carries no page-level float wrap oracle, so no
     // line has a topY jump; the painted content height is Σ lineHForLine over the
     // whole, unsliced paragraph.
@@ -13137,6 +13248,7 @@ function measureCellParagraphWindow(
       state.ctx,
       state.fontFamilyClasses,
       gridCharDeltaPx(grid, scale),
+      canonicalTextScale,
     );
     const uniformLineH = paraHasRuby
       ? snapParaLineToGrid(
@@ -13578,16 +13690,6 @@ export function renderTableFragment(fragment: TableFragment, state: RenderState)
   state.y = drawTableRows(table, colWidths, tableW, rowHeights, tableX, state.y, state, fragment);
 }
 
-/** Which grid edges of the table this cell touches, so {@link resolveCellEdges}
- *  can pick the OUTER (table.top/bottom/left/right) vs the INNER
- *  (table.insideH/insideV) spec per physical edge (ECMA-376 §17.4.38/§17.4.39). */
-interface CellEdgeFlags {
-  topRow: boolean;     // cell sits in the table's first row → its top is the table outer top
-  bottomRow: boolean;  // cell's bottom edge is the table outer bottom (vMerge-span aware)
-  leftCol: boolean;    // cell's left edge is the table outer left
-  rightCol: boolean;   // cell's right edge is the table outer right
-}
-
 /** Resolve a `nil`/`none` border to "no ink". A `null` means "not set" — the
  *  caller already substituted a fallback before reaching here. */
 function paintable(b: BorderSpec | null): BorderSpec | null {
@@ -13754,6 +13856,91 @@ export function paraShadingRect(
   return { x: x - l, y: y - t, w: w + l + r, h: h + t + b };
 }
 
+export interface ParaBorderSegment {
+  side: 'top' | 'bottom' | 'left' | 'right';
+  edge: ParaBorderEdge;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+/**
+ * Horizontal paragraph content extent used by shading and `w:pBdr`.
+ *
+ * ECMA-376 §17.3.1.17 describes the border as surrounding the paragraph. A
+ * hanging first line (including a list marker from §17.9) is part of that
+ * paragraph, so its start position must be inside the box. The normal body edge
+ * remains authoritative for a positive first-line indent because later lines
+ * still begin at the body edge. `physicalIndentLeft/Right` have already been
+ * mirrored for bidi; `firstIndent` remains logical, so the expansion is applied
+ * to the physical left for LTR and physical right for RTL.
+ */
+export function paragraphBorderContentBox(
+  contentX: number,
+  contentW: number,
+  physicalIndentLeft: number,
+  physicalIndentRight: number,
+  firstIndent: number,
+  baseRtl: boolean,
+): { x: number; w: number } {
+  let left = contentX + physicalIndentLeft;
+  let right = contentX + contentW - physicalIndentRight;
+  if (firstIndent < 0) {
+    if (baseRtl) right -= firstIndent;
+    else left += firstIndent;
+  }
+  return { x: left, w: Math.max(0, right - left) };
+}
+
+/**
+ * Resolve paragraph-border strokes into one connected box.
+ *
+ * ECMA-376 §17.3.1.17 requires a left paragraph border to run between the
+ * top/between border above and the bottom/between border below. The same
+ * geometry applies symmetrically to the right side: horizontal strokes reach
+ * the vertical-border positions, and vertical strokes use the horizontal
+ * strokes as their endpoints. Computing the four segments together prevents
+ * the independent `w:space` offsets from leaving open corners.
+ */
+export function paraBorderSegments(
+  x: number, y: number, w: number, h: number,
+  borders: ParagraphBorders,
+  merge?: ParaBorderMerge,
+  scale = 1,
+): ParaBorderSegment[] {
+  const visible = (edge: ParaBorderEdge | null): edge is ParaBorderEdge =>
+    edge != null && edge.style !== 'none';
+  const sp = (edge: ParaBorderEdge | null): number =>
+    visible(edge) ? (edge.space ?? 0) * scale : 0;
+  // §17.3.1.7 top edge: on a non-first paragraph of a shared run, the `top` edge
+  // gives way to the `between` edge drawn at the join (nothing when `between` is
+  // absent — the box has no internal rules).
+  const topEdge = merge?.suppressTop ? borders.between : borders.top;
+  const bottomEdge = merge?.suppressBottom ? null : borders.bottom;
+  const leftX = x - sp(borders.left);
+  const rightX = x + w + sp(borders.right);
+  const topY = y - sp(topEdge);
+  const bottomY = y + h + sp(bottomEdge);
+  const segments: ParaBorderSegment[] = [];
+  if (visible(topEdge)) {
+    segments.push({ side: 'top', edge: topEdge, x1: leftX, y1: topY, x2: rightX, y2: topY });
+  }
+  // The `bottom` edge is skipped entirely when a same-border paragraph follows
+  // (the box continues into it; its own join is handled by that paragraph's
+  // suppressed-top `between`).
+  if (visible(bottomEdge)) {
+    segments.push({ side: 'bottom', edge: bottomEdge, x1: leftX, y1: bottomY, x2: rightX, y2: bottomY });
+  }
+  if (visible(borders.left)) {
+    segments.push({ side: 'left', edge: borders.left, x1: leftX, y1: topY, x2: leftX, y2: bottomY });
+  }
+  if (visible(borders.right)) {
+    segments.push({ side: 'right', edge: borders.right, x1: rightX, y1: topY, x2: rightX, y2: bottomY });
+  }
+  return segments;
+}
+
 function drawParaBorders(
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   x: number, y: number, w: number, h: number,
@@ -13762,25 +13949,11 @@ function drawParaBorders(
   dpr = 1,
   merge?: ParaBorderMerge,
 ): void {
-  const drawEdge = (edge: ParaBorderEdge | null, x1: number, y1: number, x2: number, y2: number) => {
-    if (!edge || edge.style === 'none') return;
+  for (const segment of paraBorderSegments(x, y, w, h, borders, merge, scale)) {
+    const { edge } = segment;
     const spec: BorderSpec = { width: edge.width, color: edge.color, style: edge.style };
-    drawBorderLine(ctx, x1, y1, x2, y2, spec, scale, dpr);
-  };
-  const sp = (edge: ParaBorderEdge | null) => (edge?.space ?? 0) * scale;
-  // §17.3.1.7 top edge: on a non-first paragraph of a shared run, the `top` edge
-  // gives way to the `between` edge drawn at the join (nothing when `between` is
-  // absent — the box has no internal rules).
-  const topEdge = merge?.suppressTop ? borders.between : borders.top;
-  drawEdge(topEdge, x, y - sp(topEdge), x + w, y - sp(topEdge));
-  // The `bottom` edge is skipped entirely when a same-border paragraph follows
-  // (the box continues into it; its own join is handled by that paragraph's
-  // suppressed-top `between`).
-  if (!merge?.suppressBottom) {
-    drawEdge(borders.bottom, x, y + h + sp(borders.bottom), x + w, y + h + sp(borders.bottom));
+    drawBorderLine(ctx, segment.x1, segment.y1, segment.x2, segment.y2, spec, scale, dpr);
   }
-  drawEdge(borders.left,   x - sp(borders.left), y,        x - sp(borders.left), y + h);
-  drawEdge(borders.right,  x + w + sp(borders.right), y,   x + w + sp(borders.right), y + h);
 }
 
 /** ECMA-376 §17.3.1.7 — the vertical extent (in scale-1 points) a paragraph's

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -10380,7 +10380,9 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
       // A retractable connector leader is re-stroked retracted below; suppress
       // the preset engine's full-length leader stroke to avoid a double line /
       // a cap poking through the arrow tip.
-      isRetractableLeader ? { skipTrailingStroke: true } : undefined,
+      isRetractableLeader && (coreStroke?.headEnd || coreStroke?.tailEnd)
+        ? { skipTrailingStroke: true }
+        : undefined,
     );
   } else {
     ctx.beginPath();

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3747,8 +3747,9 @@ export function computePages(
         //
         // Lay the table out against the CURRENT column band and resolve its box +
         // per-row heights (B2 stage 1b: computeTableLayout is the ONE heavy
-        // measurement — its rowHeights drive the overflow test, the row-split
-        // greedy fit, and the paint-reuse stamp below; never re-measured). `tp` is
+        // measurement — whole-table rowHeights drive the overflow test, while
+        // rowContentHeights let each emitted slice resolve its own boundaries for
+        // fit, paint-reuse stamp, and FloatRect; cell content is never re-measured). `tp` is
         // the tblpPr under which the FIRST slice is placed (at the in-flow anchor);
         // continuation slices clone it with tblpY=0 so their box sits at body top.
         const tp = tbl.tblpPr;
@@ -3874,7 +3875,7 @@ export function computePages(
             tbl,
             tp,
             first.layout.colWidths, // scale-1 (px==pt) column grid, constant across slices
-            first.layout.rowHeights,
+            first.layout.rowContentHeights,
             slice1TopOffset,
             first.contentWPt,
             () => y,
@@ -7047,7 +7048,8 @@ export function splitFloatTableAcrossPages(
   table: DocTable,
   tp: TblpPr,
   colWidthsPt: number[],
-  rowHs: number[],
+  /** Per-row content boxes without horizontal boundary footprints. */
+  rowContentHs: number[],
   /** pt offset of slice 1's top below the flow cursor (`tp.tblpY × scale`; ~0 for
    *  a tblpY=1twip auto-converted float). Continuation slices ignore it (tblpY=0). */
   slice1TopOffset: number,
@@ -7068,9 +7070,39 @@ export function splitFloatTableAcrossPages(
    *  unit tests) ⇒ the slice is dropped (the test asserts geometry via a stub). */
   emitSlice?: (sliceEl: PaginatedBodyElement) => void,
 ): number {
-  const n = rowHs.length;
+  const n = rowContentHs.length;
   let start = 0;
   let firstSlice = true;
+
+  const materializeSlice = (
+    windowStart: number,
+    windowEnd: number,
+    isFirstSlice: boolean,
+  ): { element: PaginatedBodyElement; heightsPt: number[]; usedPt: number } => {
+    const sliceTp: TblpPr = isFirstSlice
+      ? tp
+      : { ...tp, vertAnchor: 'text', tblpY: 0, tblpYSpec: undefined };
+    const sliceTable = {
+      ...table,
+      type: 'table',
+      rows: table.rows.slice(windowStart, windowEnd),
+      tblpPr: sliceTp,
+    } as unknown as PaginatedBodyElement;
+    const contentHeights = rowContentHs.slice(windowStart, windowEnd);
+    // §17.4.66: resolve conflicts against this emitted slice, whose first/last
+    // rows now own outer edges. §17.4.80 exact rows remain complete boxes while
+    // auto/atLeast rows receive the resolved half-boundary footprints.
+    const heightsPt = applyTableRowBoundaryFootprints(
+      sliceTable as unknown as DocTable,
+      contentHeights,
+      1,
+    );
+    return {
+      element: sliceTable,
+      heightsPt,
+      usedPt: heightsPt.reduce((sum, height) => sum + height, 0),
+    };
+  };
 
   while (start < n) {
     // Slice top (content-relative pt): the in-flow anchor for slice 1, else the
@@ -7084,20 +7116,47 @@ export function splitFloatTableAcrossPages(
     // (i.e. slice 1 low on the page); a fresh page's `avail` already equals the max
     // band, so this never loops. (A row taller than a full page still gets placed
     // below, since then `avail == the max band` and the guard is false.)
-    if (rowHs[start] > avail && sliceTopRel > regionTopY()) {
+    const firstRowHeight = materializeSlice(start, start + 1, firstSlice).usedPt;
+    if (firstRowHeight > avail && sliceTopRel > regionTopY()) {
       advancePage();
       firstSlice = false;
       continue;
     }
 
-    // Greedy-fit rows [start, end); always take the first row (forward progress).
+    // Scan content boxes linearly. The selected safe endpoints are materialized
+    // below with their own outer/interior boundaries, avoiding both stale
+    // original-table footprints and per-candidate quadratic resolution.
     let used = 0;
     let end = start;
+    const safeEnds: number[] = [];
     while (end < n) {
-      const h = rowHs[end];
+      const h = rowContentHs[end];
       if (end > start && used + h > avail && tableBreakAllowedBefore(table, end)) break;
       used += h;
       end++;
+      if (end === n || tableBreakAllowedBefore(table, end)) safeEnds.push(end);
+    }
+
+    let materialized = materializeSlice(start, end, firstSlice);
+    if (materialized.usedPt > avail && safeEnds.length > 1) {
+      let low = 0;
+      let high = safeEnds.length - 1;
+      let best = materializeSlice(start, safeEnds[0], firstSlice);
+      let bestEnd = safeEnds[0];
+      while (low <= high) {
+        const mid = Math.floor((low + high) / 2);
+        const candidateEnd = safeEnds[mid];
+        const candidate = materializeSlice(start, candidateEnd, firstSlice);
+        if (candidate.usedPt <= avail || mid === 0) {
+          best = candidate;
+          bestEnd = candidateEnd;
+          low = mid + 1;
+        } else {
+          high = mid - 1;
+        }
+      }
+      materialized = best;
+      end = bestEnd;
     }
 
     // Build the slice element: a subset of rows, its own tblpPr (slice 1 keeps the
@@ -7115,20 +7174,12 @@ export function splitFloatTableAcrossPages(
     // table), and sample-18/21 have no header rows — so the safe, observed behaviour
     // is to carry each row exactly once (UNOBSERVED for headers; revisit with a
     // header fixture if one surfaces).
-    const sliceTp: TblpPr = firstSlice
-      ? tp
-      : { ...tp, vertAnchor: 'text', tblpY: 0, tblpYSpec: undefined };
-    const sliceEl = {
-      ...table,
-      type: 'table',
-      rows: table.rows.slice(start, end),
-      tblpPr: sliceTp,
-    } as unknown as PaginatedBodyElement;
+    const sliceEl = materialized.element;
     // B2 stage 1b — stamp the full column grid (constant across slices) + this
     // slice's own rows so the paint pass (renderFloatTable → computeTableLayout)
     // reuses them 1:1 instead of re-measuring, and emitSlice's box math below reuses
     // the same stamp.
-    stampTableLayout(sliceEl, colWidthsPt, rowHs.slice(start, end), contentWPt);
+    stampTableLayout(sliceEl, colWidthsPt, materialized.heightsPt, contentWPt);
 
     emitSlice?.(sliceEl);
 
@@ -7793,7 +7844,10 @@ function renderEmptyMarkParagraph(
   const flowShift = Math.max(0, markTop - textAreaTopY);
   if (markTop > state.y) state.y = markTop;
   const markRectTop = state.y;
-  const emptyH = paragraphMarkLineHeight(para, scale, grid, paraHasRuby, state.docEastAsian, ctx, state.fontFamilyClasses);
+  const emptyH = paragraphMarkLineHeight(
+    para, scale, grid, paraHasRuby, state.docEastAsian, ctx, state.fontFamilyClasses,
+    para.lineSpacing, state.resolvedLocalFonts,
+  );
   if (para.shading && !dryRun) {
     ctx.fillStyle = `#${para.shading}`;
     const sb = paraShadingRect(borderX, markRectTop, borderW, emptyH, para.borders, borderMerge, scale);
@@ -7852,6 +7906,8 @@ function frameAnchorLineHeightPx(
       state.docEastAsian,
       state.ctx,
       state.fontFamilyClasses,
+      p.lineSpacing,
+      state.resolvedLocalFonts,
     );
   }
   const fp = frameEl as unknown as DocParagraph;
@@ -7863,6 +7919,8 @@ function frameAnchorLineHeightPx(
     state.docEastAsian,
     state.ctx,
     state.fontFamilyClasses,
+    fp.lineSpacing,
+    state.resolvedLocalFonts,
   );
 }
 
@@ -8346,6 +8404,7 @@ function renderParagraph(
     columnXPt: contentX,
     columnWidthPt: contentW,
     floats: state.floats,
+    paragraphMarkLineStartWidth: paragraphMarkEmPx(para, scale),
     lineBoxH: (a, d, _h, is, ea, gc) => lineBoxHeight(
       para.lineSpacing,
       a,
@@ -12595,8 +12654,21 @@ function computeTableLayout(
   table: DocTable,
   contentWPx: number,
   state: RenderState,
-): { colWidths: number[]; tableW: number; rowHeights: number[] } {
+): {
+  colWidths: number[];
+  tableW: number;
+  rowContentHeights: number[];
+  rowHeights: number[];
+} {
   const { scale } = state;
+  const contentHeightsFromResolved = (rowHeights: number[]): number[] => {
+    const footprints = applyTableRowBoundaryFootprints(
+      table,
+      new Array<number>(table.rows.length).fill(0),
+      scale,
+    );
+    return rowHeights.map((height, index) => height - (footprints[index] ?? 0));
+  };
 
   // B2 table stage 1b — compute-once reuse. When the paginator laid this table
   // out it stamped the scale-1 pt column widths and per-row heights it resolved
@@ -12640,7 +12712,12 @@ function computeTableLayout(
     const fragment = placedFragment.fragment;
     const colWidths = fragment.columnWidthsPt.map((w) => w * scale);
     const rowHeights = fragment.rows.map((r) => r.heightPt * scale);
-    return { colWidths, tableW: colWidths.reduce((s, w) => s + w, 0), rowHeights };
+    return {
+      colWidths,
+      tableW: colWidths.reduce((s, w) => s + w, 0),
+      rowContentHeights: contentHeightsFromResolved(rowHeights),
+      rowHeights,
+    };
   }
   const reuseInputs = stamped.tableLayoutInputs;
   const reuse =
@@ -12654,7 +12731,12 @@ function computeTableLayout(
   if (reuse) {
     const colWidths = (stamped.tableColWidthsPt as number[]).map((w) => w * scale);
     const rowHeights = (stamped.tableRowHeightsPt as number[]).map((h) => h * scale);
-    return { colWidths, tableW: colWidths.reduce((s, w) => s + w, 0), rowHeights };
+    return {
+      colWidths,
+      tableW: colWidths.reduce((s, w) => s + w, 0),
+      rowContentHeights: contentHeightsFromResolved(rowHeights),
+      rowHeights,
+    };
   }
 
   // Resolve column widths in pt (autofit by preferred widths, or fixed grid),
@@ -12666,11 +12748,12 @@ function computeTableLayout(
   // with the paint pass's px cell measurer. The restart-span extension is part of
   // the skeleton now — calculateRowHeight already excludes restart cells per-row,
   // and the resolver re-measures them via the same callback to grow the last row.
-  const rowHeights = resolveTableRowHeights(table, colWidths, scale, (cell, cellW) =>
+  const rowContentHeights = resolveTableRowContentHeights(table, colWidths, scale, (cell, cellW) =>
     measureCellContentHeightPx(cell, table, cellW, scale, state),
   );
+  const rowHeights = applyTableRowBoundaryFootprints(table, rowContentHeights, scale);
 
-  return { colWidths, tableW, rowHeights };
+  return { colWidths, tableW, rowContentHeights, rowHeights };
 }
 
 /** Content height of a table cell laid out at total width `cellW`, in the target
@@ -13377,6 +13460,8 @@ function measureCellParagraphWindow(
           state.docEastAsian,
           state.ctx,
           state.fontFamilyClasses,
+          paragraphContext.lineSpacing,
+          state.resolvedLocalFonts,
         ),
         totalLines,
       };

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -110,6 +110,8 @@ import {
 import {
   findMergeEndRow,
   rowGridBefore,
+  applyTableRowBoundaryFootprints,
+  resolveTableRowContentHeights,
   resolveTableRowHeights,
   resolveSingleRowHeight,
 } from './table-geometry.js';
@@ -617,10 +619,16 @@ function canonicalParagraphTextScaleEligible(
   paragraph: Pick<DocParagraph, 'alignment' | 'numbering'>,
   segments: readonly LayoutSeg[],
 ): boolean {
+  // `containers=[]` is the deliberate top-level body case. Nested body text is
+  // accepted only while every enclosing story container is a table cell; other
+  // stories/containers keep their established paint-space paths.
+  const isSupportedBodyContainerChain =
+    storyContext.story === 'body'
+    && (storyContext.containers.length === 0
+      || storyContext.containers.every((container) => container.kind === 'tableCell'));
   return !hasWrapContext
     && !inFrame
-    && storyContext.story === 'body'
-    && storyContext.containers.every((container) => container.kind === 'tableCell')
+    && isSupportedBodyContainerChain
     && !verticalCJK
     && !paragraphContext.hasRuby
     && !paragraphContext.baseRtl
@@ -3996,7 +4004,11 @@ export function computePages(
       // full content band. Resolve columns + row heights together (one min-content
       // scan) so both can be stamped for the paint pass (B2 table stage 1b).
       const tblContentWPt = colW();
-      const { colWidthsPt: tblColWidthsPt, rowHeightsPt: measuredRowHs } =
+      const {
+        colWidthsPt: tblColWidthsPt,
+        rowContentHeightsPt: measuredRowContentHs,
+        rowHeightsPt: measuredRowHs,
+      } =
         computeTablePtLayout(measureState, tbl, tblContentWPt);
       const tblWidthPt = tblColWidthsPt.reduce((sum, width) => sum + width, 0);
 
@@ -4055,13 +4067,17 @@ export function computePages(
       const tableContentH = effContentH() - tblReservePt;
       const splitRows = splitRowsTallerThanPage(
         tbl,
-        measuredRowHs,
+        measuredRowContentHs,
         tblColWidthsPt,
         tableContentH,
         measureState,
+        true,
       );
       const pageTable = splitRows?.table ?? tbl;
-      const rowHs = splitRows?.rowHs ?? measuredRowHs;
+      const rowContentHs = splitRows?.rowHs ?? measuredRowContentHs;
+      const rowHs = splitRows
+        ? applyTableRowBoundaryFootprints(pageTable, rowContentHs, 1)
+        : measuredRowHs;
       const sourceRowIndexByRow = splitRows?.sourceRowIndexByRow;
       const tableEl = { ...pageTable, type: 'table' } as PaginatedBodyElement;
       const h = rowHs.reduce((s, x) => s + x, 0);
@@ -4073,7 +4089,7 @@ export function computePages(
         // splitter may also divide that row by cell block boundaries, matching
         // Word's default table-row pagination.
         const endY = splitTableAcrossPages(
-          pageTable, rowHs, y, tableContentH, pages,
+          pageTable, rowContentHs, y, tableContentH, pages,
           // Table slices belong to THIS table element, so the new page's
           // pre-scan starts at `i` (this table's body index). The just-filled
           // column bottom folds into `maxColBottomY` so a following continuous
@@ -4089,7 +4105,11 @@ export function computePages(
           // B2 table stage 1b — stamp the scale-1 layout onto each slice so the
           // paint pass reuses it. Each slice records ITS rows' heights; the column
           // widths + contentWPt are constant across the split.
-          { colWidthsPt: tblColWidthsPt, contentWPt: tblContentWPt },
+          {
+            colWidthsPt: tblColWidthsPt,
+            contentWPt: tblContentWPt,
+            rowHeightsAreContent: true,
+          },
           { colWidthsPt: tblColWidthsPt, state: measureState },
           sourceRowIndexByRow,
           // PR 6 — attach each slice's table fragment (byte-identical additive step:
@@ -5581,12 +5601,13 @@ function computeTablePtLayout(
   state: RenderState,
   table: DocTable,
   contentWPt: number,
-): { colWidthsPt: number[]; rowHeightsPt: number[] } {
+): { colWidthsPt: number[]; rowContentHeightsPt: number[]; rowHeightsPt: number[] } {
   const colWidthsPt = resolveColumnWidths(table, contentWPt, state);
-  const rowHeightsPt = resolveTableRowHeights(table, colWidthsPt, 1, (cell, cellW) =>
+  const rowContentHeightsPt = resolveTableRowContentHeights(table, colWidthsPt, 1, (cell, cellW) =>
     measureCellContentHeightPx(cell, table, cellW, 1, state),
   );
-  return { colWidthsPt, rowHeightsPt };
+  const rowHeightsPt = applyTableRowBoundaryFootprints(table, rowContentHeightsPt, 1);
+  return { colWidthsPt, rowContentHeightsPt, rowHeightsPt };
 }
 
 function estimateTableHeight(state: RenderState, table: DocTable, contentWPt: number): number {
@@ -6566,6 +6587,7 @@ function splitRowsTallerThanPage(
   colWidthsPt: number[],
   pageContentHeightPt: number,
   state: RenderState,
+  rowHeightsAreContent = false,
 ): { table: DocTable; rowHs: number[]; sourceRowIndexByRow: number[] } | null {
   let changed = false;
   const rows: DocTableRow[] = [];
@@ -6575,8 +6597,18 @@ function splitRowsTallerThanPage(
   for (let ri = 0; ri < table.rows.length; ri++) {
     const row = table.rows[ri];
     const rowH = rowHeightsPt[ri];
-    if (rowH > pageContentHeightPt) {
-      const split = splitRowForHeight(table, row, colWidthsPt, pageContentHeightPt, state);
+    const singleRowHeight = rowHeightsAreContent
+      ? applyTableRowBoundaryFootprints({ ...table, rows: [row] }, [rowH], 1)[0]
+      : rowH;
+    if (singleRowHeight > pageContentHeightPt) {
+      const boundaryFootprint = Math.max(0, singleRowHeight - rowH);
+      const split = splitRowForHeight(
+        table,
+        row,
+        colWidthsPt,
+        Math.max(0, pageContentHeightPt - boundaryFootprint),
+        state,
+      );
       if (split) {
         rows.push(...split.rows);
         heights.push(...split.heights);
@@ -6654,7 +6686,13 @@ export function splitTableAcrossPages(
    *  gets ITS rows' heights (sliced from `rowHs`, with the repeated header rows
    *  prepended on continuations so the stamp aligns 1:1 with the slice's rows).
    *  Omitted (direct unit tests) ⇒ slices carry no table stamp and paint recomputes. */
-  tableStamp?: { colWidthsPt: number[]; contentWPt: number },
+  tableStamp?: {
+    colWidthsPt: number[];
+    contentWPt: number;
+    /** Incoming row heights exclude horizontal rule footprints. Each emitted
+     * slice must resolve those footprints from its own first/last boundaries. */
+    rowHeightsAreContent?: boolean;
+  },
   /** Optional row-block splitter used by computePages. Direct unit tests can omit
    *  this and exercise only row-boundary splitting. */
   rowSplit?: { colWidthsPt: number[]; state: RenderState },
@@ -6693,8 +6731,44 @@ export function splitTableAcrossPages(
   while (headerCount < n && workRows[headerCount].isHeader) headerCount++;
   const headerRows = workRows.slice(0, headerCount);
   const headerSourceRowIndices = workSourceRowIndices.slice(0, headerCount);
-  const headerH = workRowHs.slice(0, headerCount).reduce((s, h) => s + h, 0);
   const headerHeightsPt = workRowHs.slice(0, headerCount);
+  const headerContentHeightPt = headerHeightsPt.reduce((sum, height) => sum + height, 0);
+
+  const materializeSlice = (
+    windowStart: number,
+    windowEnd: number,
+    isContinuation: boolean,
+  ): { rows: DocTableRow[]; heightsPt: number[]; usedPt: number } => {
+    const bodyRows = workRows.slice(windowStart, windowEnd);
+    // §17.4.85 — a slice that starts inside a vMerge span re-opens the merged
+    // cell so both paint and page-local boundary resolution see the same row.
+    const reopenedBody =
+      windowStart > 0 && bodyRows.length > 0 && bodyRows[0].cells.some((c) => c.vMerge === false)
+        ? [
+            reopenMergedCellsInRow(
+              workRows,
+              windowStart,
+              headerCount,
+              isContinuation,
+              workTable.colWidths.length,
+            ),
+            ...bodyRows.slice(1),
+          ]
+        : bodyRows;
+    const rows = isContinuation ? [...headerRows, ...reopenedBody] : reopenedBody;
+    const baseHeights = isContinuation
+      ? [...headerHeightsPt, ...workRowHs.slice(windowStart, windowEnd)]
+      : workRowHs.slice(windowStart, windowEnd);
+    const sliceTable = { ...workTable, rows };
+    const heightsPt = tableStamp?.rowHeightsAreContent
+      ? applyTableRowBoundaryFootprints(sliceTable, baseHeights, 1)
+      : baseHeights;
+    return {
+      rows,
+      heightsPt,
+      usedPt: heightsPt.reduce((sum, height) => sum + height, 0),
+    };
+  };
 
   let y = startY;
   let start = 0;
@@ -6703,9 +6777,9 @@ export function splitTableAcrossPages(
   while (start < n) {
     const isContinuation = !firstSlice && headerCount > 0 && start >= headerCount;
     const avail = contentH - y;
-    const firstRowH = (isContinuation ? headerH : 0) + workRowHs[start];
+    const firstRowH = materializeSlice(start, start + 1, isContinuation).usedPt;
     const freshAvail = contentH - colTop();
-    const rowAvail = avail - (isContinuation ? headerH : 0);
+    const rowAvail = Math.max(0, workRowHs[start] + avail - firstRowH);
     // The vMerge group starting at `start`: a restart row chained to its continue
     // rows. This renderer keeps such a group together across page breaks (Word's
     // observed behavior; ECMA-376 §17.4.85 defines the merge STRUCTURE but does not
@@ -6728,8 +6802,7 @@ export function splitTableAcrossPages(
     //     full page rather than splitting inside the region.
     let groupEnd = start;
     while (groupEnd + 1 < n && !tableBreakAllowedBefore(workTable, groupEnd + 1)) groupEnd++;
-    let groupH = isContinuation ? headerH : 0;
-    for (let r = start; r <= groupEnd; r++) groupH += workRowHs[r];
+    const groupH = materializeSlice(start, groupEnd + 1, isContinuation).usedPt;
     const relaxSpanBreak = groupH > contentH;
     const breakAllowedBefore = (ri: number): boolean =>
       tableBreakAllowedBefore(workTable, ri) ||
@@ -6770,16 +6843,34 @@ export function splitTableAcrossPages(
       firstSlice = false;
       continue;
     }
-    let used = isContinuation ? headerH : 0;
+    // In content-height mode the repeated header's bottom is not an outer edge
+    // once a body row is appended. Start from header CONTENT only; the exact
+    // endpoint materialization below supplies the header/body insideH and final
+    // outer-bottom footprints. Using a header-only materialization here can
+    // overestimate mixed atLeast/exact slices and stop one row early.
+    let used = tableStamp?.rowHeightsAreContent
+      ? (isContinuation ? headerContentHeightPt : 0)
+      : materializeSlice(start, start, isContinuation).usedPt;
     let end = start;
     let lastSafeEnd = start;
     let lastSafeUsed = used;
+    const safeEnds: number[] = [];
     // Always place at least one row to guarantee forward progress.
     while (end < n) {
-      const h = workRowHs[end];
-      if (end > start && used + h > avail) {
+      // Scan content heights linearly. Page-local boundary footprints are
+      // resolved only for the selected safe endpoints below; resolving the
+      // whole candidate slice for every row would make long-table pagination
+      // quadratic.
+      const candidateUsed = used + workRowHs[end];
+      if (end > start && candidateUsed > avail) {
         if (breakAllowedBefore(end)) {
-          const remainingForNextRow = avail - used;
+          const candidateWithBoundaries = tableStamp?.rowHeightsAreContent
+            ? materializeSlice(start, end + 1, isContinuation).usedPt
+            : candidateUsed;
+          const remainingForNextRow = Math.max(
+            0,
+            workRowHs[end] + avail - candidateWithBoundaries,
+          );
           if (rowSplit && remainingForNextRow > 0 && end >= headerCount) {
             const split = splitRowForHeight(
               workTable,
@@ -6826,31 +6917,45 @@ export function splitTableAcrossPages(
       if (end > start && breakAllowedBefore(end)) {
         lastSafeEnd = end;
         lastSafeUsed = used;
+        safeEnds.push(end);
       }
-      used += h;
+      used = candidateUsed;
       end++;
     }
 
-    const bodyRows = workRows.slice(start, end);
-    // §17.4.85 — a slice that STARTS inside a vMerge span (its first body row is a
-    // `vMerge=continue` row, because an over-tall span was broken at an interior
-    // boundary above) re-opens the merged cell so the paint pass draws its box on
-    // this page. Runtime-only clone; only the leading body row is rewritten, and a
-    // column already re-opened by a prepended repeated header is left untouched.
-    const reopenedBody =
-      start > 0 && bodyRows.length > 0 && bodyRows[0].cells.some((c) => c.vMerge === false)
-        ? [
-            reopenMergedCellsInRow(
-              workRows,
-              start,
-              headerCount,
-              isContinuation,
-              workTable.colWidths.length,
-            ),
-            ...bodyRows.slice(1),
-          ]
-        : bodyRows;
-    const sliceRows = isContinuation ? [...headerRows, ...reopenedBody] : reopenedBody;
+    // Content-only scanning can tentatively include a row whose page-local
+    // outer/inside rule footprint crosses the available band. Find the largest
+    // safe endpoint whose exact slice geometry fits. Binary search keeps exact
+    // boundary resolution to O(log rows) candidates instead of once per row.
+    let materialized = materializeSlice(start, end, isContinuation);
+    if (materialized.usedPt > avail && end > start + 1) {
+      const candidates = [
+        start + 1,
+        ...safeEnds.filter(
+          (candidateEnd) => candidateEnd > start + 1 && candidateEnd < end,
+        ),
+        ...(end > start + 1 ? [end] : []),
+      ];
+      let low = 0;
+      let high = candidates.length - 1;
+      let bestEnd = start + 1;
+      let bestSlice = materializeSlice(start, bestEnd, isContinuation);
+      while (low <= high) {
+        const mid = Math.floor((low + high) / 2);
+        const candidateEnd = candidates[mid];
+        const candidateSlice = materializeSlice(start, candidateEnd, isContinuation);
+        if (candidateSlice.usedPt <= avail || candidateEnd === start + 1) {
+          bestEnd = candidateEnd;
+          bestSlice = candidateSlice;
+          low = mid + 1;
+        } else {
+          high = mid - 1;
+        }
+      }
+      end = bestEnd;
+      materialized = bestSlice;
+    }
+    const sliceRows = materialized.rows;
     const sliceEl = { ...workTable, type: 'table', rows: sliceRows } as PaginatedBodyElement;
     if (tagColIndex) sliceEl.colIndex = tagColIndex();
     if (colGeom) sliceEl.colGeom = colGeom;
@@ -6864,9 +6969,7 @@ export function splitTableAcrossPages(
     // B2 table stage 1b — stamp this slice's own row heights (repeated header rows
     // prepended on continuations, matching `sliceRows`) so the paint pass reuses
     // them 1:1 instead of re-measuring the slice.
-    const sliceHeightsPt = isContinuation
-      ? [...headerHeightsPt, ...workRowHs.slice(start, end)]
-      : workRowHs.slice(start, end);
+    const sliceHeightsPt = materialized.heightsPt;
     if (tableStamp) {
       stampTableLayout(sliceEl, tableStamp.colWidthsPt, sliceHeightsPt, tableStamp.contentWPt);
     }
@@ -6892,6 +6995,7 @@ export function splitTableAcrossPages(
     }
     pages[pages.length - 1].push(sliceEl);
 
+    used = materialized.usedPt;
     y += used;
     start = end;
     firstSlice = false;
@@ -7905,6 +8009,9 @@ interface NumberingMarkerLayout {
   picBullet: { bmp: DecodedImage; w: number; h: number } | null;
   numBodyOffset: number;
   markerJcShiftPx: number;
+  /** Resolved marker ink width in px. Uses the decoded picture-bullet width when
+   *  present, otherwise the marker glyph measurement in its resolved font. */
+  markerWidthPx: number;
   hasMarker: boolean;
 }
 
@@ -7933,6 +8040,7 @@ function resolveNumberingMarker(
   // 0 = left (default); −markerW = right (period-aligned numerals: right edge at
   // firstLineX); −markerW/2 = centre. Set in the numbering block below.
   let markerJcShiftPx = 0;
+  let markerWidthPx = 0;
   if (para.numbering) {
     numMarker = para.numbering.text;
     numTab = para.numbering.tab * scale;
@@ -7958,6 +8066,7 @@ function resolveNumberingMarker(
       ctx.font = buildFont(false, false, getDefaultFontSize(para) * scale, markerFontFamily(para.numbering), fontFamilyClasses);
       markerW = ctx.measureText(markerDisplayText(para.numbering)).width;
     }
+    markerWidthPx = markerW;
     // §17.9.8 lvlJc: shift the marker so its left/right/centre aligns at
     // firstLineX (the hanging-indent reference). The marker's RIGHT edge measured
     // from paraX (the indentLeft tab) is then `indFirst + shift + markerW`.
@@ -7999,7 +8108,40 @@ function resolveNumberingMarker(
   }
   // True when the paragraph has any marker to draw (text glyph OR picture bullet).
   const hasMarker = numMarker !== '' || picBullet !== null;
-  return { numTab, picBullet, numBodyOffset, markerJcShiftPx, hasMarker };
+  return { numTab, picBullet, numBodyOffset, markerJcShiftPx, markerWidthPx, hasMarker };
+}
+
+/** Resolved numbering-marker bounds in the paragraph's physical coordinate
+ * space. §17.9.7 applies lvlJc at the logical first-line margin; the RTL result
+ * is therefore the physical mirror of LTR. `markerWidthPx` already represents
+ * either measured text ink or the resolved picture-bullet width. */
+function numberingMarkerBorderBounds(
+  contentX: number,
+  contentW: number,
+  physicalIndentLeft: number,
+  physicalIndentRight: number,
+  firstIndent: number,
+  markerJcShiftPx: number,
+  markerWidthPx: number,
+  numTab: number,
+  baseRtl: boolean,
+): { left: number; right: number } {
+  if (!baseRtl) {
+    const left = contentX + physicalIndentLeft + firstIndent + markerJcShiftPx;
+    return { left, right: left + markerWidthPx };
+  }
+  const anchor = contentX + contentW - physicalIndentRight - firstIndent;
+  const mirroredRight = anchor - markerJcShiftPx;
+  const mirroredLeft = mirroredRight - markerWidthPx;
+  // The established RTL draw path anchors the marker's right edge `numTab`
+  // beyond the aligned body start. Its maximum physical-right position is the
+  // paragraph start edge plus numTab (other text alignments can only move it
+  // inward). Union that actual paint envelope with the mirrored lvlJc bounds.
+  const paintedRight = contentX + contentW - physicalIndentRight + numTab;
+  return {
+    left: Math.min(mirroredLeft, paintedRight - markerWidthPx),
+    right: Math.max(mirroredRight, paintedRight),
+  };
 }
 
 function renderParagraph(
@@ -8087,12 +8229,25 @@ function renderParagraph(
   const indFirst = inFrame ? 0 : para.indentFirst * scale;
 
   // Numbering marker layout (§17.9.x): see resolveNumberingMarker.
-  const { numTab, picBullet, numBodyOffset, markerJcShiftPx, hasMarker } =
+  const { numTab, picBullet, numBodyOffset, markerJcShiftPx, markerWidthPx, hasMarker } =
     resolveNumberingMarker(para, state, indLeft, indFirst);
 
   const paraX = contentX + indLeft;
   const firstLineX = paraX + indFirst;
   const paraW = contentW - indLeft - indRight;
+  const markerBounds = hasMarker
+    ? numberingMarkerBorderBounds(
+        contentX,
+        contentW,
+        indLeft,
+        indRight,
+        indFirst,
+        markerJcShiftPx,
+        markerWidthPx,
+        numTab,
+        baseRtl,
+      )
+    : undefined;
   const borderBox = paragraphBorderContentBox(
     contentX,
     contentW,
@@ -8100,6 +8255,7 @@ function renderParagraph(
     indRight,
     indFirst,
     baseRtl,
+    markerBounds,
   );
 
   // ECMA-376 §17.9.28 (`<w:suff>`) governs where a numbering marker's first-line
@@ -13868,13 +14024,14 @@ export interface ParaBorderSegment {
 /**
  * Horizontal paragraph content extent used by shading and `w:pBdr`.
  *
- * ECMA-376 §17.3.1.17 describes the border as surrounding the paragraph. A
+ * ECMA-376 §17.3.1.24 applies pBdr to the paragraph. A
  * hanging first line (including a list marker from §17.9) is part of that
  * paragraph, so its start position must be inside the box. The normal body edge
  * remains authoritative for a positive first-line indent because later lines
  * still begin at the body edge. `physicalIndentLeft/Right` have already been
  * mirrored for bidi; `firstIndent` remains logical, so the expansion is applied
- * to the physical left for LTR and physical right for RTL.
+ * to the physical left for LTR and physical right for RTL. Resolved marker bounds
+ * are then unioned so lvlJc-shifted text and picture markers remain inside the box.
  */
 export function paragraphBorderContentBox(
   contentX: number,
@@ -13883,12 +14040,17 @@ export function paragraphBorderContentBox(
   physicalIndentRight: number,
   firstIndent: number,
   baseRtl: boolean,
+  markerBounds?: { left: number; right: number },
 ): { x: number; w: number } {
   let left = contentX + physicalIndentLeft;
   let right = contentX + contentW - physicalIndentRight;
   if (firstIndent < 0) {
     if (baseRtl) right -= firstIndent;
     else left += firstIndent;
+  }
+  if (markerBounds) {
+    left = Math.min(left, markerBounds.left);
+    right = Math.max(right, markerBounds.right);
   }
   return { x: left, w: Math.max(0, right - left) };
 }

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -6635,6 +6635,32 @@ function splitRowsTallerThanPage(
   return { table: outTable, rowHs: heights, sourceRowIndexByRow };
 }
 
+/** Pick the greatest safe slice endpoint whose fully materialized height fits.
+ * Endpoint heights are not monotonic: appending an exact §17.4.80 row can
+ * replace the preceding auto row's wide outer-bottom footprint with a narrow
+ * insideH boundary and make the longer slice shorter. The content-height scan
+ * performed by each paginator already limits `endpoints` to the tentative tail;
+ * walking that tail backwards therefore preserves the largest-fit contract and
+ * normally resolves only the already-known last candidate. The first safe
+ * endpoint is the forward-progress fallback even when one atomic row/span is
+ * taller than the page. */
+function selectLastFittingSliceEndpoint<T extends { usedPt: number }>(
+  endpoints: readonly number[],
+  availablePt: number,
+  materialize: (endpoint: number) => T,
+  knownLast?: { endpoint: number; value: T },
+): { endpoint: number; value: T } {
+  if (endpoints.length === 0) throw new Error('expected at least one safe table endpoint');
+  for (let index = endpoints.length - 1; index >= 0; index--) {
+    const endpoint = endpoints[index];
+    const value = knownLast?.endpoint === endpoint
+      ? knownLast.value
+      : materialize(endpoint);
+    if (value.usedPt <= availablePt || index === 0) return { endpoint, value };
+  }
+  throw new Error('unreachable table endpoint selection');
+}
+
 /**
  * Split a table that is taller than one page across page boundaries, row by
  * row (ECMA-376 table pagination). Each page receives a {@link DocTable} slice
@@ -6926,8 +6952,7 @@ export function splitTableAcrossPages(
 
     // Content-only scanning can tentatively include a row whose page-local
     // outer/inside rule footprint crosses the available band. Find the largest
-    // safe endpoint whose exact slice geometry fits. Binary search keeps exact
-    // boundary resolution to O(log rows) candidates instead of once per row.
+    // safe endpoint whose exact slice geometry fits.
     let materialized = materializeSlice(start, end, isContinuation);
     if (materialized.usedPt > avail && end > start + 1) {
       const candidates = [
@@ -6937,24 +6962,14 @@ export function splitTableAcrossPages(
         ),
         ...(end > start + 1 ? [end] : []),
       ];
-      let low = 0;
-      let high = candidates.length - 1;
-      let bestEnd = start + 1;
-      let bestSlice = materializeSlice(start, bestEnd, isContinuation);
-      while (low <= high) {
-        const mid = Math.floor((low + high) / 2);
-        const candidateEnd = candidates[mid];
-        const candidateSlice = materializeSlice(start, candidateEnd, isContinuation);
-        if (candidateSlice.usedPt <= avail || candidateEnd === start + 1) {
-          bestEnd = candidateEnd;
-          bestSlice = candidateSlice;
-          low = mid + 1;
-        } else {
-          high = mid - 1;
-        }
-      }
-      end = bestEnd;
-      materialized = bestSlice;
+      const selected = selectLastFittingSliceEndpoint(
+        candidates,
+        avail,
+        (candidateEnd) => materializeSlice(start, candidateEnd, isContinuation),
+        { endpoint: end, value: materialized },
+      );
+      end = selected.endpoint;
+      materialized = selected.value;
     }
     const sliceRows = materialized.rows;
     const sliceEl = { ...workTable, type: 'table', rows: sliceRows } as PaginatedBodyElement;
@@ -7139,24 +7154,14 @@ export function splitFloatTableAcrossPages(
 
     let materialized = materializeSlice(start, end, firstSlice);
     if (materialized.usedPt > avail && safeEnds.length > 1) {
-      let low = 0;
-      let high = safeEnds.length - 1;
-      let best = materializeSlice(start, safeEnds[0], firstSlice);
-      let bestEnd = safeEnds[0];
-      while (low <= high) {
-        const mid = Math.floor((low + high) / 2);
-        const candidateEnd = safeEnds[mid];
-        const candidate = materializeSlice(start, candidateEnd, firstSlice);
-        if (candidate.usedPt <= avail || mid === 0) {
-          best = candidate;
-          bestEnd = candidateEnd;
-          low = mid + 1;
-        } else {
-          high = mid - 1;
-        }
-      }
-      materialized = best;
-      end = bestEnd;
+      const selected = selectLastFittingSliceEndpoint(
+        safeEnds,
+        avail,
+        (candidateEnd) => materializeSlice(start, candidateEnd, firstSlice),
+        { endpoint: end, value: materialized },
+      );
+      materialized = selected.value;
+      end = selected.endpoint;
     }
 
     // Build the slice element: a subset of rows, its own tblpPr (slice 1 keeps the

--- a/packages/docx/src/table-cell-docgrid.test.ts
+++ b/packages/docx/src/table-cell-docgrid.test.ts
@@ -237,6 +237,22 @@ describe('table-cell line grid compatibility', () => {
 // 20 pt; the mock font box is a flat 1.0×em, so every height difference below
 // comes from the line-height / script routing alone.
 describe('docGrid line-cell integration through the cell measure path', () => {
+  it('does not whole-cell round tall East Asian design metrics for explicit atLeast', () => {
+    const para = paragraphWithRuns([{
+      text: 'あ',
+      fontSize: 14,
+      fontFamily: 'Meiryo',
+      fontFamilyEastAsia: 'Meiryo',
+    }]);
+    para.lineSpacing = { value: 0, rule: 'atLeast', explicit: true };
+
+    // Meiryo's established design line is 3269/2048 em. At 14pt it is
+    // 22.35pt, taller than the 20pt table grid pitch. Explicit atLeast expands
+    // to that content height; automatic grid layout would round it to 40pt.
+    expect(calculateRowHeight(rowWith(para), table(), [100], 1, makeMeasureState(true)))
+      .toBeCloseTo(14 * 3269 / 2048, 12);
+  });
+
   it('a manual line break in a SMALLER run does not shrink the line height (tallest governs)', () => {
     // Line 1: 'あ' at 24 pt + 'い' at 10 pt, terminated by a <w:br> whose
     // nearby size resolves to 10 pt (§17.3.3.1; findNearbyFontSize looks at the

--- a/packages/docx/src/table-cell-docgrid.test.ts
+++ b/packages/docx/src/table-cell-docgrid.test.ts
@@ -237,20 +237,31 @@ describe('table-cell line grid compatibility', () => {
 // 20 pt; the mock font box is a flat 1.0×em, so every height difference below
 // comes from the line-height / script routing alone.
 describe('docGrid line-cell integration through the cell measure path', () => {
-  it('does not whole-cell round tall East Asian design metrics for explicit atLeast', () => {
-    const para = paragraphWithRuns([{
-      text: 'あ',
-      fontSize: 14,
-      fontFamily: 'Meiryo',
-      fontFamilyEastAsia: 'Meiryo',
-    }]);
+  it('matches observed Word spacing for explicit atLeast lines in a table cell', () => {
+    const para = paragraphWithRuns([
+      {
+        text: 'あ',
+        fontSize: 14,
+        fontFamily: 'Meiryo',
+        fontFamilyEastAsia: 'Meiryo',
+      },
+      { type: 'break', breakType: 'line' },
+      {
+        text: 'い',
+        fontSize: 10,
+        fontFamily: 'Meiryo',
+        fontFamilyEastAsia: 'Meiryo',
+      },
+    ]);
     para.lineSpacing = { value: 0, rule: 'atLeast', explicit: true };
 
-    // Meiryo's established design line is 3269/2048 em. At 14pt it is
-    // 22.35pt, taller than the 20pt table grid pitch. Explicit atLeast expands
-    // to that content height; automatic grid layout would round it to 40pt.
+    // Observed Windows Word output keeps the first explicit-atLeast line at
+    // Meiryo's raw 14pt design height (3269/2048 em, slightly over the 20pt
+    // pitch), then keeps the ordinary 10pt line at one pitch. This fixture
+    // records Office compatibility; the standards do not define this precise
+    // tall-line exception.
     expect(calculateRowHeight(rowWith(para), table(), [100], 1, makeMeasureState(true)))
-      .toBeCloseTo(14 * 3269 / 2048, 12);
+      .toBeCloseTo(14 * 3269 / 2048 + 20, 12);
   });
 
   it('a manual line break in a SMALLER run does not shrink the line height (tallest governs)', () => {

--- a/packages/docx/src/table-fragments.test.ts
+++ b/packages/docx/src/table-fragments.test.ts
@@ -454,6 +454,37 @@ describe('layoutDocument — table fragments', () => {
       .toEqual([24, 24, 24]);
   });
 
+  it('chooses the largest fitting mixed exact/auto slice endpoint', () => {
+    const outer = singleBorder(12);
+    const rows = [
+      row([cell([])], { rowHeight: 10, rowHeightRule: 'auto' }),
+      row([cell([])], { rowHeight: 1, rowHeightRule: 'exact' }),
+      row([cell([])], { rowHeight: 10, rowHeightRule: 'auto' }),
+      row([cell([])], { rowHeight: 1, rowHeightRule: 'exact' }),
+      row([cell([])], { rowHeight: 10, rowHeightRule: 'auto' }),
+    ];
+    const t = table(rows, [120], {
+      borders: {
+        top: outer,
+        bottom: outer,
+        left: null,
+        right: null,
+        insideH: null,
+        insideV: null,
+      },
+    });
+
+    // Prefix slice heights are non-monotonic because exact rows already contain
+    // their complete §17.4.80 boxes: [22, 17, 33, 28, 44]. The 32pt band must
+    // therefore select the four-row endpoint (28pt), not the two-row endpoint.
+    const tables = allTables(doc([t as unknown as BodyElement], 52));
+
+    expect(tables.map(({ table: fragment }) => fragment.rows.length))
+      .toEqual([4, 1]);
+    expect(tables.map(({ table: fragment }) => tableFragmentHeightPt(fragment)))
+      .toEqual([28, 22]);
+  });
+
   it('re-resolves repeated-header boundaries for each atLeast page slice', () => {
     const rows = [
       row([textCell('header')], {

--- a/packages/docx/src/table-fragments.test.ts
+++ b/packages/docx/src/table-fragments.test.ts
@@ -3,6 +3,7 @@ import { layoutDocument } from './document-layout.js';
 import { bodyFragmentFor, computePages } from './renderer.js';
 import { buildTableFragment } from './table-fragments.js';
 import * as layoutFragments from './layout-fragments.js';
+import { resolvedHorizontalBoundaryWidths } from './table-geometry.js';
 import {
   paragraphFragmentAdvancePt,
   tableFragmentHeightPt,
@@ -125,6 +126,10 @@ function table(rows: DocTableRow[], colWidths: number[], over: Partial<DocTable>
     jc: 'left', layout: 'fixed',
     ...over,
   } as unknown as DocTable;
+}
+
+function singleBorder(width: number) {
+  return { style: 'single', width, color: '#000000' } as const;
 }
 
 function doc(body: BodyElement[], pageHeight = 400): DocxDocumentModel {
@@ -423,6 +428,103 @@ describe('layoutDocument — table fragments', () => {
     expect(seen).toEqual(rows.map((_v, i) => i));
   });
 
+  it('re-resolves outer border footprints for each auto-height page slice', () => {
+    const rows = Array.from({ length: 3 }, (_value, index) =>
+      row([textCell(`row ${index}`)], { rowHeight: 20, rowHeightRule: 'auto' }));
+    const outer = singleBorder(4);
+    const inside = singleBorder(1);
+    const t = table(rows, [120], {
+      borders: {
+        top: outer,
+        bottom: outer,
+        left: null,
+        right: null,
+        insideH: inside,
+        insideV: null,
+      },
+    });
+
+    // The 30pt body band admits one row per page. Every emitted one-row table
+    // paints both horizontal edges as 4pt outer rules, so its 20pt content box
+    // reserves half of each rule: 20 + 2 + 2 = 24pt.
+    const tables = allTables(doc([t as unknown as BodyElement], 50));
+
+    expect(tables).toHaveLength(3);
+    expect(tables.map(({ table: fragment }) => fragment.rows[0].heightPt))
+      .toEqual([24, 24, 24]);
+  });
+
+  it('re-resolves repeated-header boundaries for each atLeast page slice', () => {
+    const rows = [
+      row([textCell('header')], {
+        isHeader: true,
+        rowHeight: 20,
+        rowHeightRule: 'atLeast',
+      }),
+      ...Array.from({ length: 3 }, (_value, index) =>
+        row([textCell(`body ${index}`)], { rowHeight: 20, rowHeightRule: 'atLeast' })),
+    ];
+    const outer = singleBorder(4);
+    const inside = singleBorder(1);
+    const t = table(rows, [120], {
+      borders: {
+        top: outer,
+        bottom: outer,
+        left: null,
+        right: null,
+        insideH: inside,
+        insideV: null,
+      },
+    });
+
+    // A header + one body row occupies 45pt in every slice:
+    //   header 20 + outer-top/2 2 + inside/2 0.5 = 22.5
+    //   body   20 + inside/2 0.5 + outer-bottom/2 2 = 22.5
+    const tables = allTables(doc([t as unknown as BodyElement], 70));
+
+    expect(tables).toHaveLength(3);
+    for (const { table: fragment } of tables) {
+      expect(fragment.rows.map((fragmentRow) => fragmentRow.heightPt))
+        .toEqual([22.5, 22.5]);
+    }
+  });
+
+  it('does not charge a repeated header outer-bottom while scanning body rows', () => {
+    const rows = [
+      row([textCell('header')], {
+        isHeader: true,
+        rowHeight: 20,
+        rowHeightRule: 'atLeast',
+      }),
+      ...Array.from({ length: 4 }, (_value, index) =>
+        row([textCell(`body ${index}`)], { rowHeight: 20, rowHeightRule: 'exact' })),
+    ];
+    const outer = singleBorder(4);
+    const inside = singleBorder(1);
+    const t = table(rows, [120], {
+      borders: {
+        top: outer,
+        bottom: outer,
+        left: null,
+        right: null,
+        insideH: inside,
+        insideV: null,
+      },
+    });
+
+    // The 63pt band fits header + two exact body rows: the non-exact header
+    // contributes outer-top/2 + insideH/2, while exact rows already contain
+    // their complete boxes. Treating the header alone during the scan would
+    // incorrectly charge outer-bottom/2 and stop after one body row.
+    const tables = allTables(doc([t as unknown as BodyElement], 83));
+
+    expect(tables).toHaveLength(2);
+    expect(tables.map(({ table: fragment }) => fragment.rows.length))
+      .toEqual([3, 3]);
+    expect(tables.map(({ table: fragment }) => tableFragmentHeightPt(fragment)))
+      .toEqual([62.5, 62.5]);
+  });
+
   it('keeps original row indices when a row taller than the page is split into pieces', () => {
     const tallCell = cell([
       { type: 'paragraph', ...para('あ'.repeat(400)) } as unknown as CellElement,
@@ -440,6 +542,45 @@ describe('layoutDocument — table fragments', () => {
     expect(fragmentRows.slice(0, -1).map((fragment) => fragment.sourceRowIndex))
       .toEqual(Array.from({ length: fragmentRows.length - 1 }, () => 0));
     expect(fragmentRows.at(-1)?.sourceRowIndex).toBe(1);
+  });
+
+  it('uses each split-row slice boundary when sizing its auto-height pieces', () => {
+    const outer = singleBorder(4);
+    const inside = singleBorder(1);
+    const tallCell = cell([
+      { type: 'paragraph', ...para('あ'.repeat(400)) } as unknown as CellElement,
+    ]);
+    const t = table([row([tallCell])], [120], {
+      borders: {
+        top: outer,
+        bottom: outer,
+        left: null,
+        right: null,
+        insideH: inside,
+        insideV: null,
+      },
+    });
+    const tables = allTables(doc([t as unknown as BodyElement], 120));
+    const cellContentHeight = (
+      layoutFragments as unknown as {
+        cellFragmentContentHeightPt: (fragment: CellFragment) => number;
+      }
+    ).cellFragmentContentHeightPt;
+
+    expect(tables.length).toBeGreaterThan(1);
+    for (const { table: fragment } of tables) {
+      const boundaries = resolvedHorizontalBoundaryWidths(fragment.source);
+      fragment.rows.forEach((fragmentRow, rowIndex) => {
+        const contentHeight = Math.max(
+          10,
+          ...fragmentRow.cells.map((fragmentCell) => cellContentHeight(fragmentCell)),
+        );
+        expect(fragmentRow.heightPt).toBeCloseTo(
+          contentHeight + (boundaries[rowIndex] + boundaries[rowIndex + 1]) / 2,
+          8,
+        );
+      });
+    }
   });
 
   it('repeats a leading header row on every continuation slice (§17.4.78)', () => {

--- a/packages/docx/src/table-geometry.ts
+++ b/packages/docx/src/table-geometry.ts
@@ -17,6 +17,7 @@
 // so there is no import cycle with renderer.ts.
 
 import type { DocTable, DocTableRow, DocTableCell } from './types.js';
+import { resolveBorderConflict, resolveCellEdges } from './cell-border-conflict.js';
 
 /** Minimum table-row height (pt) when no `w:trHeight` floor applies — i.e. an
  *  `auto` row, or `atLeast`/`exact` with no `@val`. ECMA-376 leaves the auto
@@ -71,6 +72,113 @@ export function findMergeEndRow(table: DocTable, startRi: number, startCi: numbe
  *  Asian paragraph mark on a docGrid rounds to a different cell count), so this
  *  skeleton keeps each caller's measurer intact rather than choosing one. */
 export type MeasureCellContentHeight = (cell: DocTableCell, cellWidth: number) => number;
+
+interface TableGridOwner {
+  cell: DocTableCell;
+  ri: number;
+  lastRi: number;
+  ci: number;
+  span: number;
+}
+
+function cellAtGridColumn(
+  row: DocTableRow,
+  targetCi: number,
+  columnCount: number,
+): DocTableCell | null {
+  let ci = rowGridBefore(row, columnCount);
+  for (const cell of row.cells) {
+    if (targetCi >= ci && targetCi < ci + cell.colSpan) return cell;
+    ci += cell.colSpan;
+  }
+  return null;
+}
+
+function paintWidth(candidate: ReturnType<typeof resolveBorderConflict>): number {
+  const spec = candidate?.spec;
+  if (!spec || spec.style === 'none' || spec.style === 'nil') return 0;
+  return spec.width;
+}
+
+/** Width of each resolved horizontal table-grid boundary, from the outer top
+ * through every shared row boundary to the outer bottom. Adjacent-cell
+ * conflicts use the same §17.4.66 cascade as paint; a boundary inside one
+ * vertically merged owner contributes no rule. */
+export function resolvedHorizontalBoundaryWidths(table: DocTable): number[] {
+  const rowCount = table.rows.length;
+  const columnCount = table.colWidths.length;
+  const widths = new Array<number>(rowCount + 1).fill(0);
+  if (rowCount === 0 || columnCount === 0) return widths;
+
+  const owners: Array<Array<TableGridOwner | null>> = Array.from(
+    { length: rowCount },
+    () => new Array<TableGridOwner | null>(columnCount).fill(null),
+  );
+  for (let ri = 0; ri < rowCount; ri++) {
+    const row = table.rows[ri];
+    let ci = rowGridBefore(row, columnCount);
+    for (const cell of row.cells) {
+      const span = Math.min(cell.colSpan, columnCount - ci);
+      if (cell.vMerge !== false && span > 0) {
+        const lastRi = cell.vMerge === true ? findMergeEndRow(table, ri, ci) : ri;
+        const owner: TableGridOwner = { cell, ri, lastRi, ci, span };
+        for (let rj = ri; rj <= lastRi; rj++) {
+          for (let cj = ci; cj < ci + span; cj++) owners[rj][cj] = owner;
+        }
+      }
+      ci += span;
+    }
+  }
+
+  const edgesFor = (owner: TableGridOwner) => ({
+    topRow: owner.ri === 0,
+    bottomRow: owner.lastRi === rowCount - 1,
+    leftCol: owner.ci === 0,
+    rightCol: owner.ci + owner.span === columnCount,
+  });
+  const bottomCandidate = (owner: TableGridOwner) => {
+    const terminal = owner.lastRi > owner.ri
+      ? (cellAtGridColumn(table.rows[owner.lastRi], owner.ci, columnCount) ?? owner.cell)
+      : owner.cell;
+    return resolveCellEdges(terminal.borders, table.borders, edgesFor(owner), false).bottom;
+  };
+
+  for (let ci = 0; ci < columnCount; ci++) {
+    const topOwner = owners[0][ci];
+    if (topOwner) {
+      const top = resolveCellEdges(
+        topOwner.cell.borders,
+        table.borders,
+        edgesFor(topOwner),
+        false,
+      ).top;
+      widths[0] = Math.max(widths[0], paintWidth(resolveBorderConflict(top, null)));
+    }
+
+    for (let boundary = 1; boundary < rowCount; boundary++) {
+      const above = owners[boundary - 1][ci];
+      const below = owners[boundary][ci];
+      if (above && above === below) continue;
+      const aboveBottom = above ? bottomCandidate(above) : null;
+      const belowTop = below
+        ? resolveCellEdges(below.cell.borders, table.borders, edgesFor(below), false).top
+        : null;
+      widths[boundary] = Math.max(
+        widths[boundary],
+        paintWidth(resolveBorderConflict(aboveBottom, belowTop)),
+      );
+    }
+
+    const bottomOwner = owners[rowCount - 1][ci];
+    if (bottomOwner) {
+      widths[rowCount] = Math.max(
+        widths[rowCount],
+        paintWidth(resolveBorderConflict(bottomCandidate(bottomOwner), null)),
+      );
+    }
+  }
+  return widths;
+}
 
 /**
  * Resolve per-row heights for a table whose grid columns have widths
@@ -166,6 +274,18 @@ export function resolveTableRowHeights(
   const rowHeights = table.rows.map((row) =>
     resolveSingleRowHeight(row, colWidths, scale, measureCellContentHeight),
   );
+
+  // Word's auto/atLeast row footprint runs between the centres of the resolved
+  // horizontal rules. Therefore each non-exact row reserves half of the rule
+  // above and half below. Exact `trHeight` already defines the complete row box
+  // and is not expanded (§17.4.80).
+  const horizontalBoundaries = resolvedHorizontalBoundaryWidths(table);
+  for (let ri = 0; ri < rowHeights.length; ri++) {
+    if (table.rows[ri].rowHeightRule === 'exact') continue;
+    rowHeights[ri] += (
+      (horizontalBoundaries[ri] ?? 0) + (horizontalBoundaries[ri + 1] ?? 0)
+    ) * scale / 2;
+  }
 
   // §17.4.85 span extension: for each vMerge=restart cell, grow the span's last
   // row if the restart cell's full content is taller than the summed span rows.

--- a/packages/docx/src/table-geometry.ts
+++ b/packages/docx/src/table-geometry.ts
@@ -156,6 +156,11 @@ export function resolvedHorizontalBoundaryWidths(table: DocTable): number[] {
     }
 
     for (let boundary = 1; boundary < rowCount; boundary++) {
+      // Runtime row pieces separated inside one emitted slice are one
+      // continuous source row. Paint deliberately leaves that internal cut
+      // open, so it has no footprint in either adjacent row box.
+      if ((table.rows[boundary - 1] as DocTableRow & { pageCutBottom?: boolean })
+        .pageCutBottom === true) continue;
       const above = owners[boundary - 1][ci];
       const below = owners[boundary][ci];
       if (above && above === below) continue;
@@ -265,7 +270,11 @@ export function resolveSingleRowHeight(
   return rowH;
 }
 
-export function resolveTableRowHeights(
+/** Resolve row content boxes, before page-local horizontal rule footprints are
+ * added. Keeping this geometry separate is essential for pagination: once a
+ * table is sliced, the first/last rows resolve against that slice's outer
+ * borders rather than the original table's interior boundaries. */
+export function resolveTableRowContentHeights(
   table: DocTable,
   colWidths: number[],
   scale: number,
@@ -274,18 +283,6 @@ export function resolveTableRowHeights(
   const rowHeights = table.rows.map((row) =>
     resolveSingleRowHeight(row, colWidths, scale, measureCellContentHeight),
   );
-
-  // Word's auto/atLeast row footprint runs between the centres of the resolved
-  // horizontal rules. Therefore each non-exact row reserves half of the rule
-  // above and half below. Exact `trHeight` already defines the complete row box
-  // and is not expanded (§17.4.80).
-  const horizontalBoundaries = resolvedHorizontalBoundaryWidths(table);
-  for (let ri = 0; ri < rowHeights.length; ri++) {
-    if (table.rows[ri].rowHeightRule === 'exact') continue;
-    rowHeights[ri] += (
-      (horizontalBoundaries[ri] ?? 0) + (horizontalBoundaries[ri + 1] ?? 0)
-    ) * scale / 2;
-  }
 
   // §17.4.85 span extension: for each vMerge=restart cell, grow the span's last
   // row if the restart cell's full content is taller than the summed span rows.
@@ -309,4 +306,34 @@ export function resolveTableRowHeights(
   }
 
   return rowHeights;
+}
+
+/** Add the horizontal rule footprint painted by this concrete table or page
+ * slice. Auto/atLeast row boxes run between rule centres; exact trHeight already
+ * defines the complete row box and is not expanded (§17.4.80). */
+export function applyTableRowBoundaryFootprints(
+  table: DocTable,
+  contentHeights: readonly number[],
+  scale: number,
+): number[] {
+  const horizontalBoundaries = resolvedHorizontalBoundaryWidths(table);
+  return contentHeights.map((contentHeight, ri) => {
+    if (table.rows[ri]?.rowHeightRule === 'exact') return contentHeight;
+    return contentHeight + (
+      (horizontalBoundaries[ri] ?? 0) + (horizontalBoundaries[ri + 1] ?? 0)
+    ) * scale / 2;
+  });
+}
+
+export function resolveTableRowHeights(
+  table: DocTable,
+  colWidths: number[],
+  scale: number,
+  measureCellContentHeight: MeasureCellContentHeight,
+): number[] {
+  return applyTableRowBoundaryFootprints(
+    table,
+    resolveTableRowContentHeights(table, colWidths, scale, measureCellContentHeight),
+    scale,
+  );
 }

--- a/packages/docx/src/table-row-height.test.ts
+++ b/packages/docx/src/table-row-height.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { calculateRowHeight } from './renderer.js';
-import { resolveSingleRowHeight } from './table-geometry.js';
+import { resolveSingleRowHeight, resolveTableRowHeights } from './table-geometry.js';
 import type { DocTable, DocTableRow, DocTableCell } from './types.js';
 
 // ECMA-376 §17.4.80 (trHeight) + §17.18.37 (ST_HeightRule): the @hRule attribute
@@ -113,5 +113,27 @@ describe('calculateRowHeight — ST_HeightRule (§17.4.80 / §17.18.37)', () => 
     });
 
     expect(measuredWidths).toEqual([40]);
+  });
+
+  it('includes half of each resolved horizontal border in adjacent non-exact row boxes', () => {
+    const single = { style: 'single', width: 0.5, color: '#000000' };
+    const rows = Array.from({ length: 4 }, () => ({
+      ...rowWith(20.4, 'auto'),
+      cells: [{
+        ...emptyCell(),
+        borders: { top: single, bottom: single, left: null, right: null, insideH: null, insideV: null },
+      }],
+    } as unknown as DocTableRow));
+    const bordered = {
+      ...table(),
+      rows,
+    } as DocTable;
+
+    const heights = resolveTableRowHeights(bordered, [100], 1, () => 0);
+
+    // Five 0.5pt boundary rules contribute half at the two outer edges and a
+    // full rule across each of the three shared boundaries: 4 × 20.4 + 2.0.
+    expect(heights).toEqual([20.9, 20.9, 20.9, 20.9]);
+    expect(heights.reduce((sum, height) => sum + height, 0)).toBeCloseTo(83.6, 8);
   });
 });

--- a/packages/docx/src/table-row-split-fidelity.test.ts
+++ b/packages/docx/src/table-row-split-fidelity.test.ts
@@ -213,22 +213,21 @@ describe('table row split fidelity — fragment-owned paint geometry', () => {
     const model = documentWithRow(row(splitText, 'top'), 60);
     const pages = paginateDocument(model);
     expect(pages).toHaveLength(2);
-    expect(firstSliceOnPage(pages, 0)).toEqual({ start: 0, end: 3 });
-    expect(firstSliceOnPage(pages, 1)).toEqual({ start: 3, end: 4 });
+    expect(firstSliceOnPage(pages, 0)).toEqual({ start: 0, end: 2 });
+    expect(firstSliceOnPage(pages, 1)).toEqual({ start: 2, end: 4 });
 
     const page2 = await renderPage(model, pages, 1, fragmentPaint);
     const paintedText = page2.texts.map((call) => call.text).join('');
-    expect(paintedText).toBe('丁'.repeat(16));
+    expect(paintedText).toBe('丙'.repeat(16) + '丁'.repeat(16));
     expect(paintedText).not.toContain('甲');
     expect(paintedText).not.toContain('乙');
-    expect(paintedText).not.toContain('丙');
   });
 
   it('keeps every centered continuation baseline at or below its row-top rule', async () => {
     const model = documentWithRow(row(splitText, 'center'), 60);
     const pages = paginateDocument(model);
     expect(pages).toHaveLength(2);
-    expect(firstSliceOnPage(pages, 1)).toEqual({ start: 3, end: 4 });
+    expect(firstSliceOnPage(pages, 1)).toEqual({ start: 2, end: 4 });
 
     const page2 = await renderPage(model, pages, 1, true);
     const topRule = page2.strokes.find(

--- a/packages/docx/src/table-samepage-cut-border.test.ts
+++ b/packages/docx/src/table-samepage-cut-border.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { renderDocumentToCanvas, paginateDocument } from './renderer.js';
+import { renderDocumentToCanvas } from './renderer.js';
 import type {
   BodyElement,
   CellElement,
@@ -176,11 +176,24 @@ const nearFullWidth = (h: StrokeSeg[], y: number, pageW: number, tol = 1.2) =>
 
 describe('#986 same-page intra-row cut border', () => {
   it('draws NO rule at an intra-row cut whose continuation piece shares the page', async () => {
-    // Two tall rows into a 120pt body: the paginator splits both and packs a
-    // continuation piece of each onto one interior page — page 2 carries a
-    // 2-row table with BOTH pieces marked pageCutBottom (mirrors sample-33 p.3).
+    // Build the renderer-facing page slice directly. Pagination geometry is
+    // covered separately; this regression is specifically the paint contract
+    // for two row pieces sharing a page, with the leading piece ending at an
+    // intra-source-row cut.
     const model = twoTallRowsDoc(120);
-    const pages = paginateDocument(model);
+    const sourceTable = model.body[0] as unknown as DocTable;
+    const leading = tallBlockRow(2) as DocTableRow & { pageCutBottom?: boolean };
+    leading.pageCutBottom = true;
+    const slice = {
+      ...sourceTable,
+      type: 'table',
+      rows: [leading, tallBlockRow(2)],
+      colTopPt: 0,
+      tableColWidthsPt: [160],
+      tableRowHeightsPt: [41, 41],
+      tableContentWPt: 160,
+    } as unknown as PaginatedBodyElement;
+    const pages: PaginatedBodyElement[][] = [[slice]];
     const hit = findSamePageCutPage(pages);
 
     // Fixture sanity: the same-page two-piece condition really exists and the

--- a/packages/docx/src/table-split-borders.test.ts
+++ b/packages/docx/src/table-split-borders.test.ts
@@ -131,7 +131,10 @@ const shortRow = (text: string): DocTableRow => ({
     content: [{ type: 'paragraph', ...para(text) } as unknown as CellElement],
     colSpan: 1, vMerge: null, borders: allEdges(), background: null, vAlign: 'top', widthPt: null,
   }],
-  rowHeight: null, rowHeightRule: 'auto', isHeader: false,
+  // This fixture isolates a page cut that lands exactly on a row boundary.
+  // `exact` makes 20pt the complete §17.4.80 row box; an auto row also reserves
+  // the resolved border footprint and therefore would not be a 20pt row.
+  rowHeight: 20, rowHeightRule: 'exact', isHeader: false,
 } as unknown as DocTableRow);
 
 async function renderPage(model: DocxDocumentModel, pages: PaginatedBodyElement[][], pageIndex: number): Promise<StrokeSeg[]> {

--- a/packages/docx/src/table-split-borders.test.ts
+++ b/packages/docx/src/table-split-borders.test.ts
@@ -148,7 +148,9 @@ const horizontals = (strokes: StrokeSeg[]) =>
 
 describe('mid-row page-cut border semantics (§17.4.66 conflict at the cut)', () => {
   it('draws the §17.4.66 winner at the page-1 cut and the continuation top on page 2', async () => {
-    // 4-line cell (80pt) into a 60pt page body: p.1 piece = 3 lines, cut at y=60.
+    // A 4-line cell (80pt) in a 60pt body also needs the page-local top/cut
+    // footprint. Two 20pt lines fit with the two half-rules; a third would make
+    // the complete slice overflow.
     const model = splitDoc([wrappingRow()], 60);
     const pages = paginateDocument(model);
     expect(pages.length).toBeGreaterThan(1);
@@ -163,8 +165,9 @@ describe('mid-row page-cut border semantics (§17.4.66 conflict at the cut)', ()
     const p1H = horizontals(p1);
     // Top frame at y=0 present…
     expect(p1H.some((s) => Math.abs(s.y1 - 0) <= 1)).toBe(true);
-    // …and the cut draws the conflict winner (single ∨ single) at y=60, full width.
-    const cut = p1H.filter((s) => Math.abs(s.y1 - 60) <= 1);
+    // …and the cut draws the conflict winner (single ∨ single) at y=41.5 after
+    // the canvas hairline offset, full width.
+    const cut = p1H.filter((s) => Math.abs(s.y1 - 41.5) <= 0.1);
     expect(cut.length).toBe(1);
     expect(Math.min(cut[0].x1, cut[0].x2)).toBeLessThanOrEqual(1);
     expect(Math.max(cut[0].x1, cut[0].x2)).toBeGreaterThanOrEqual(159);
@@ -184,7 +187,7 @@ describe('mid-row page-cut border semantics (§17.4.66 conflict at the cut)', ()
     const pages = paginateDocument(model);
     expect(pages.length).toBeGreaterThan(1);
     const p1H = horizontals(await renderPage(model, pages, 0));
-    expect(p1H.filter((s) => Math.abs(s.y1 - 60) <= 1)).toHaveLength(1);
+    expect(p1H.filter((s) => Math.abs(s.y1 - 41.5) <= 0.1)).toHaveLength(1);
   });
 
   it('draws NOTHING at the cut of a borderless table', async () => {

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -861,7 +861,23 @@ export type PathCmd =
   | { cmd: 'arcTo'; wr: number; hr: number; stAng: number; swAng: number }
   | { cmd: 'close' };
 
+/** Resolved formatting of the WordprocessingML anchor character that hosts a
+ * floating drawing. The drawing has zero inline advance, but these metrics still
+ * participate in the containing line's height and document-grid allocation. */
+export interface AnchorHostMetrics {
+  /** Effective `<w:sz>` in points. */
+  fontSize: number;
+  /** Resolved ascii/hAnsi font face. */
+  fontFamily?: string | null;
+  /** Resolved East Asian font face, retained for Far East line metrics. */
+  fontFamilyEastAsia?: string | null;
+  bold?: boolean;
+  italic?: boolean;
+}
+
 export interface ShapeRun {
+  /** Formatting of the `<w:r>` anchor character containing this floating shape. */
+  anchorHostMetrics?: AnchorHostMetrics | null;
   widthPt: number;
   heightPt: number;
   /** X offset in pt */

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -775,6 +775,7 @@ export interface NumberingInfo {
 
 export type DocRun =
   | { type: 'text' } & DocxTextRun
+  | { type: 'anchorHost' } & AnchorHostMetrics
   | { type: 'image' } & ImageRun
   | { type: 'chart' } & ChartRun
   | { type: 'break'; breakType: 'line' | 'page' | 'column' }
@@ -876,8 +877,6 @@ export interface AnchorHostMetrics {
 }
 
 export interface ShapeRun {
-  /** Formatting of the `<w:r>` anchor character containing this floating shape. */
-  anchorHostMetrics?: AnchorHostMetrics | null;
   widthPt: number;
   heightPt: number;
   /** X offset in pt */


### PR DESCRIPTION
## Summary

- preserve floating-anchor host line metrics independently of picture, chart, shape, or grouped-shape payloads
- use exact installed normal faces for eligible local metrics while retaining authored styled faces and prioritizing embedded regular faces, with one shared rendered-content font discovery traversal
- apply resolved font metrics consistently to text, floating-anchor hosts, and empty paragraph marks
- keep eligible body and table text in canonical document-space geometry, include justified text and picture list markers in paragraph border bounds, and resolve table boundary footprints per emitted page slice without assuming mixed row heights are monotonic

## Design basis

- ECMA-376 sections 20.4.2.3 and 17.3.2: drawing anchors retain hosting run formatting independently of the drawing payload kind
- ECMA-376 sections 17.9.7 and 17.3.1.24: resolved numbering marker geometry participates in paragraph border and shading bounds
- ECMA-376 sections 17.4.66 and 17.4.80: border conflict resolution and non-exact row sizing are separated so each page slice uses the edges it actually paints
- ECMA-376 section 17.8.3.3: an embedded regular face remains authoritative over a terminal-local face of the same family
- explicit `atLeast` plus line-grid behavior for a tall first line is documented and tested as observed Windows Word compatibility, not as a normative ECMA rule
- exact local aliases are limited to the normal face; styled runs retain the authored family so the browser can select the installed bold or italic face
- metric-only anchor-host lines retain their run line box while using the existing paragraph-mark float-clearance contract; visible content retains the one-inch line-start rule
- no document-path branches, sample-name branches, or sample-specific thresholds

## Independent review

- reviewed specification grounding, single responsibility, duplicate traversal, font lifecycle, pagination, and consistency with shared OOXML rendering contracts
- all findings were addressed with focused regression coverage and re-reviewed by the same independent reviewer
- final independent assessment: ready to merge, with no unresolved Critical, Important, or Minor findings

## Verification

- 444 TypeScript test files passed; 2 skipped (4,433 tests passed; 9 skipped)
- DOCX parser: 360 tests passed
- `ooxml-common`, DOCX, XLSX, and PPTX Rust package tests passed
- TypeScript project type checking passed
- all DOCX, XLSX, and PPTX WASM packages rebuilt successfully
- Rust formatting, workspace Clippy with warnings denied, and Git diff checks passed
- local Storybook smoke checks confirmed the affected documents load with the expected page counts

This PR is intentionally left unmerged for visual approval.
