### PR TITLE
chore(release): 0.72.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.72.2 — 2026-07-13
+
+Patch (fixes on v0.72.1). Word-compatible docx layout geometry plus xlsx
+cacheless chart and RTL-anchor correctness.
+
+- **docx:** preserve floating-anchor host line metrics independently of the
+  drawing payload (picture / chart / shape / group); resolve installed normal
+  faces for eligible local metrics while keeping authored styled faces and
+  prioritizing embedded regular faces (§17.8.3.3), applied consistently to text,
+  floating-anchor hosts, and empty paragraph marks; include justified text and
+  picture list markers in paragraph border bounds (§17.9.7, §17.3.1.24); resolve
+  each emitted table page slice by the borders it actually paints without
+  assuming monotonic row heights (§17.4.66, §17.4.80); honor an explicit
+  `atLeast` grid minimum for a tall first line (observed Word behavior). No
+  sample-specific thresholds. (#1035)
+- **xlsx:** resolve cacheless legacy chart formulas through a shared DrawingML
+  resolver contract (category / value / series-name / scatter / bubble sources,
+  multi-level categories), with a bounded sparse worksheet-reference session
+  shared across charts and sparklines; mirror anchored objects and clipping
+  rectangles on right-to-left sheets without flipping content. (#1034)
+
 ## 0.72.1 — 2026-07-13
 
 Patch (fix on v0.72.0). Preserves authored OOXML layout and grouped-drawing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.72.1"
+version = "0.72.2"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.72.1",
+  "version": "0.72.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.72.1",
+  "version": "0.72.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.72.1",
+  "version": "0.72.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-markdown",
-  "version": "0.72.1",
+  "version": "0.72.2",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.72.1"
+version = "0.72.2"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.72.1",
+  "version": "0.72.2",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.72.1",
+  "version": "0.72.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.72.1",
+  "version": "0.72.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.72.1",
+  "version": "0.72.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.72.1",
+  "version": "0.72.2",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",


### PR DESCRIPTION
Patch release **0.72.2** on v0.72.1.

## Version bump
All npm packages (root `@silurus/ooxml` + core/docx/pptx/xlsx/markdown/node/vscode-extension), the site, and the `ooxml-mcp-server` crate → **0.72.2**. `Cargo.lock` refreshed via `cargo check -p ooxml-mcp-server`.

## Fixes included
- **#1035 — docx Word-compatible layout geometry**: floating-anchor host line metrics preserved independently of the drawing payload; installed normal-face metric resolution with embedded-regular priority (§17.8.3.3); justified text + picture list markers in paragraph border bounds (§17.9.7, §17.3.1.24); per-slice table boundary resolution without assuming monotonic row heights (§17.4.66, §17.4.80); explicit `atLeast` grid minimum. No sample-specific thresholds.
- **#1034 — xlsx cacheless chart data + RTL anchors**: cacheless legacy chart formulas resolved via a shared DrawingML resolver contract (category/value/series-name/scatter/bubble, multi-level categories) with a bounded shared worksheet-reference session; anchored objects + clipping rectangles mirrored on RTL sheets without flipping content.

## Release mechanism
Merge → push `v0.72.2` tag → `publish.yml` publishes to npm; `gh release create v0.72.2` then triggers the MCP-binary build.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>