### PR TITLE
docs(docx): correct layout redesign execution gates

### DIFF
--- a/docs/docx-layout-engine-series-a-plan.md
+++ b/docs/docx-layout-engine-series-a-plan.md
@@ -348,7 +348,8 @@ Use the roadmap review gate.
 **Specification evidence:** ECMA-376 §17.3.1.13 (`w:jc`), §17.3.1.38
 (`w:tabs`), §17.3.1.33 (`w:spacing`), §17.3.1.19/§17.9 numbering,
 §17.3.2.41 (`w:vanish`), §17.16 fields, §17.6.20 text direction,
-§20.4.2.7 (`wp:inline`), and §20.4.2.3 (`wp:anchor`). Picture bullets follow
+§20.4.2.8 (`wp:inline`), §20.4.2.7 (`wp:extent`), and §20.4.2.3
+(`wp:anchor`). Picture bullets follow
 §17.9.9/§17.9.20. DrawingML chart paint remains the shared core implementation;
 DOCX owns only inline/anchor flow placement.
 
@@ -476,7 +477,7 @@ Use the roadmap review gate.
 - Consumes: `layoutParagraph` and A1's recursive `layoutFlowBlocks` coordinator.
 - Produces: `TableLayout`, `TableRowLayout`, `TableCellLayout`, `ResolvedBorderSegment`, `layoutTable`, and `paintTableLayout`.
 
-**Specification evidence:** ECMA-376 §17.4.37 (`w:tbl`), §17.4.47
+**Specification evidence:** ECMA-376 §17.4.37 (`w:tbl`), §17.4.48
 (`w:tblGrid`), §17.4.52 (`w:tblLayout`), §17.4.80 (`w:trHeight`),
 §17.4.84 (`w:vMerge`), §17.4.68 (`w:tcMar`), §17.4.71 (`w:tcW`), and
 the table/cell border conflict rules in §17.4 define the retained geometry.

--- a/docs/docx-layout-engine-series-c-plan.md
+++ b/docs/docx-layout-engine-series-c-plan.md
@@ -234,8 +234,8 @@ Use the roadmap review gate.
 - Create: `rule-tests/no-docx-migration-flags-test.yml`
 - Create: `packages/docx/src/layout/architecture.test.ts`
 - Modify: `scripts/check-docx-public-api.mjs`
-- Delete: `scripts/check-docx-layout-boundaries.mjs`
-- Delete: `scripts/check-docx-layout-boundaries.test.mjs`
+- Modify: `scripts/check-docx-layout-boundaries.mjs`
+- Modify: `scripts/check-docx-layout-boundaries.test.mjs`
 - Delete: `scripts/docx-layout-boundary-baseline.json`
 - Create: `.agents/skills/docx-architecture-audit/SKILL.md`
 - Modify: `sgconfig.yml`
@@ -354,14 +354,16 @@ public APIs remain compatible. Run this skill for C3, major DOCX architecture
 changes, and periodic audits rather than pretending semantic review is fully
 enforceable on every CI run.
 
-- [ ] **Step 7: Fix findings, reverify, commit, and merge PR C3**
+- [ ] **Step 7: Clean up, fix findings, reverify the final tree, commit, and merge PR C3**
 
 Commit subject: `refactor(docx): complete immutable layout pipeline`.
-Repeat Steps 4–6 after material fixes, then merge with `gh pr merge <number> --merge`.
-Before committing, delete the migration roadmap and Series A/B/C execution plans;
+Before the final verification, delete the migration roadmap and Series A/B/C execution plans;
 their durable architectural decisions remain in `docx-layout-engine-redesign.md`,
 while Issue #1037 retains the implementation history. Remove the transitional
-boundary checker and baseline. Retain only deterministic static/API/contract
-gates in CI, and retain the semantic architecture audit as a repository skill.
-Close Issue #1037 only after GitHub shows PR C3 merged. Do not create a release
-or tag.
+boundary baseline, which puts `check-docx-layout-boundaries.mjs` into permanent
+final mode; retain that checker and its test for transitive import ownership.
+Retain only deterministic static/API/contract gates in CI, and retain the
+semantic architecture audit as a repository skill. Repeat Steps 4–6 against the
+exact post-cleanup tree after every material fix, then merge with
+`gh pr merge <number> --merge`. Close Issue #1037 only after GitHub shows PR C3
+merged. Do not create a release or tag.


### PR DESCRIPTION
## Summary

- keep the transitive DOCX layout-boundary checker as a permanent final-mode CI gate
- delete only its migration baseline during C3 and verify the exact post-cleanup tree
- correct the ECMA-376 references for inline drawings, extents, and the active table grid

## Rationale

A pre-flight audit of the complete #1037 sequence found that C3 would delete the checker while still requiring its proof, and that two later implementation tasks cited adjacent but different schema elements. These corrections keep the remaining work specification-first and executable through final cleanup.

## Verification

- independent full-plan audit and re-audit: approved
- 

Closes no issue; advances #1037.