### PR TITLE
feat(core): add stable text source references

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,10 +22,13 @@ export type {
   TabStop,
   TextBody,
   TextOutline,
+  TextSourcePathStep,
+  TextSourceRef,
   TextRun,
   TextRunData,
   TileInfo,
 } from './types/common';
+export { offsetTextSourceRefs, sliceTextSourceRefs } from './text/source-ref';
 export type {
   ChartDataLabelOverride,
   ChartDataPointOverride,

--- a/packages/core/src/text/source-ref.test.ts
+++ b/packages/core/src/text/source-ref.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import type { TextSourceRef } from '../types/common';
+import { offsetTextSourceRefs, sliceTextSourceRefs } from './source-ref';
+
+const source: TextSourceRef = {
+  partName: 'word/document.xml',
+  path: [{ namespaceUri: 'urn:w', localName: 't', index: 0 }],
+  textStart: 2,
+  textEnd: 8,
+  sourceStart: 10,
+  sourceEnd: 16,
+};
+
+describe('text source references', () => {
+  it('clips and rebases UTF-16 source intervals', () => {
+    expect(sliceTextSourceRefs([source], 4, 7)).toEqual([{
+      ...source,
+      textStart: 0,
+      textEnd: 3,
+      sourceStart: 12,
+      sourceEnd: 15,
+    }]);
+  });
+
+  it('rebases mappings when text is appended', () => {
+    expect(offsetTextSourceRefs([source], 5)).toEqual([{
+      ...source,
+      textStart: 7,
+      textEnd: 13,
+    }]);
+  });
+});

--- a/packages/core/src/text/source-ref.ts
+++ b/packages/core/src/text/source-ref.ts
@@ -1,0 +1,46 @@
+import type { TextSourceRef } from '../types/common';
+
+/**
+ * Clip source mappings to `[start, end)` in their containing UTF-16 string and
+ * rebase the returned `textStart` / `textEnd` offsets to the clipped string.
+ */
+export function sliceTextSourceRefs(
+  refs: readonly TextSourceRef[] | undefined,
+  start: number,
+  end: number,
+): TextSourceRef[] {
+  if (!refs || end <= start) return [];
+
+  const result: TextSourceRef[] = [];
+  for (const ref of refs) {
+    const overlapStart = Math.max(start, ref.textStart);
+    const overlapEnd = Math.min(end, ref.textEnd);
+    if (overlapEnd <= overlapStart) continue;
+
+    const textLength = ref.textEnd - ref.textStart;
+    const sourceLength = ref.sourceEnd - ref.sourceStart;
+    if (textLength !== sourceLength) continue;
+
+    result.push({
+      ...ref,
+      textStart: overlapStart - start,
+      textEnd: overlapEnd - start,
+      sourceStart: ref.sourceStart + overlapStart - ref.textStart,
+      sourceEnd: ref.sourceStart + overlapEnd - ref.textStart,
+    });
+  }
+  return result;
+}
+
+/** Rebase mappings when their containing text is appended after `offset` UTF-16 units. */
+export function offsetTextSourceRefs(
+  refs: readonly TextSourceRef[] | undefined,
+  offset: number,
+): TextSourceRef[] {
+  if (!refs || refs.length === 0) return [];
+  return refs.map((ref) => ({
+    ...ref,
+    textStart: ref.textStart + offset,
+    textEnd: ref.textEnd + offset,
+  }));
+}

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -197,6 +197,32 @@ export interface Stroke {
   cmpd?: string;
 }
 
+/** One namespace-aware step from an OOXML part root to a source element. */
+export interface TextSourcePathStep {
+  /** Namespace URI, rather than an author-chosen XML prefix. */
+  namespaceUri?: string;
+  localName: string;
+  /** Zero-based ordinal among element siblings with the same expanded name. */
+  index: number;
+}
+
+/**
+ * Identity mapping from a UTF-16 interval in parsed/rendered text to one XML
+ * text node. `partName + path` identifies the node; both interval pairs are
+ * half-open.
+ */
+export interface TextSourceRef {
+  /** Normalized OPC part name, e.g. `word/document.xml`. */
+  partName?: string;
+  path: TextSourcePathStep[];
+  /** UTF-16 interval in the containing text value. */
+  textStart: number;
+  textEnd: number;
+  /** UTF-16 interval in the XML text node. */
+  sourceStart: number;
+  sourceEnd: number;
+}
+
 export interface TextBody {
   /** Vertical anchor: "t" | "ctr" | "b" */
   verticalAnchor: string;
@@ -319,6 +345,8 @@ export interface EquationRun {
 export interface TextRunData {
   type: 'text';
   text: string;
+  /** Stable source mappings for file-authored text. Absent for generated text. */
+  sourceRefs?: TextSourceRef[];
   /** null = not set, inherit from paragraph/body defaults */
   bold: boolean | null;
   /** null = not set, inherit from paragraph/body defaults */

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3096,6 +3096,33 @@ fn text_runs_mergeable(a: &TextRun, b: &TextRun) -> bool {
         && a.east_asian_vert_compress == b.east_asian_vert_compress
 }
 
+fn append_text_run(target: &mut TextRun, mut appended: TextRun) {
+    let text_offset = target.text.encode_utf16().count() as u32;
+    for source in &mut appended.source_refs {
+        source.text_start += text_offset;
+        source.text_end += text_offset;
+    }
+    target.text.push_str(&appended.text);
+    target.source_refs.append(&mut appended.source_refs);
+}
+
+fn docx_text_source_refs(
+    node: roxmltree::Node<'_, '_>,
+) -> Vec<ooxml_common::source::TextSourceRef> {
+    let root_name = node
+        .ancestors()
+        .filter(|ancestor| ancestor.is_element())
+        .last()
+        .map(|root| root.tag_name().name());
+    if root_name != Some("document") {
+        return Vec::new();
+    }
+    vec![ooxml_common::source::text_source_ref(
+        node,
+        Some("word/document.xml"),
+    )]
+}
+
 /// Prepend the zero-advance host-character metrics for a floating DrawingML
 /// payload. The metrics belong to the enclosing WordprocessingML `<w:r>`, so a
 /// group expanded into multiple drawing runs must still receive exactly one.
@@ -3309,6 +3336,7 @@ fn parse_run_inner(
                 if !text.is_empty() {
                     let this = TextRun {
                         text,
+                        source_refs: docx_text_source_refs(child),
                         bold,
                         italic,
                         underline,
@@ -3357,7 +3385,7 @@ fn parse_run_inner(
                         Some(DocRun::Text(prev))
                             if merge_here && text_runs_mergeable(prev, &this) =>
                         {
-                            prev.text.push_str(&this.text);
+                            append_text_run(prev, this);
                         }
                         _ => runs.push(DocRun::Text(Box::new(this))),
                     }
@@ -3384,6 +3412,7 @@ fn parse_run_inner(
                         .or_else(|| font_family.clone());
                     runs.push(DocRun::Text(Box::new(TextRun {
                         text: c.to_string(),
+                        source_refs: Vec::new(),
                         bold,
                         italic,
                         underline,
@@ -3439,6 +3468,7 @@ fn parse_run_inner(
                 // w:tab emits a horizontal tab character; layout handles tab stop alignment.
                 runs.push(DocRun::Text(Box::new(TextRun {
                     text: "\t".to_string(),
+                    source_refs: Vec::new(),
                     bold,
                     italic,
                     underline,
@@ -3534,6 +3564,7 @@ fn parse_run_inner(
                 // collapses to one run and the boundary vanishes entirely.
                 let this = TextRun {
                     text: "-".to_string(),
+                    source_refs: Vec::new(),
                     bold,
                     italic,
                     underline,
@@ -3580,7 +3611,7 @@ fn parse_run_inner(
                 };
                 match runs.last_mut() {
                     Some(DocRun::Text(prev)) if text_runs_mergeable(prev, &this) => {
-                        prev.text.push_str(&this.text);
+                        append_text_run(prev, this);
                     }
                     _ => runs.push(DocRun::Text(Box::new(this))),
                 }
@@ -3731,6 +3762,7 @@ fn parse_run_inner(
                 let id_str = attr_w(child, "id").unwrap_or_default();
                 runs.push(DocRun::Text(Box::new(TextRun {
                     text: id_str.clone(),
+                    source_refs: Vec::new(),
                     bold,
                     italic,
                     underline,
@@ -10299,6 +10331,23 @@ mod cs_toggle_tests {
         // §17.3.2.7 <w:cs/> — the complex-script run toggle.
         let run = run_of(r#"<w:p><w:r><w:rPr><w:cs/></w:rPr><w:t>x</w:t></w:r></w:p>"#);
         assert_eq!(run.cs, Some(true));
+    }
+
+    #[test]
+    fn merged_text_nodes_keep_independent_utf16_source_ranges() {
+        let run = run_of(
+            r#"<w:p><w:r><w:t>A😀</w:t><w:t>B</w:t></w:r></w:p>"#,
+        );
+
+        assert_eq!(run.text, "A😀B");
+        assert_eq!(run.source_refs.len(), 2);
+        assert_eq!(run.source_refs[0].text_start, 0);
+        assert_eq!(run.source_refs[0].text_end, 3);
+        assert_eq!(run.source_refs[1].text_start, 3);
+        assert_eq!(run.source_refs[1].text_end, 4);
+        assert_eq!(run.source_refs[0].part_name.as_deref(), Some("word/document.xml"));
+        assert_eq!(run.source_refs[0].path.last().unwrap().index, 0);
+        assert_eq!(run.source_refs[1].path.last().unwrap().index, 1);
     }
 
     #[test]

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -10336,15 +10336,17 @@ mod cs_toggle_tests {
     #[test]
     fn merged_text_nodes_keep_independent_utf16_source_ranges() {
         let run = run_of(
-            r#"<w:p><w:r><w:t>A😀</w:t><w:t>B</w:t></w:r></w:p>"#,
+            r#"<w:p><w:r><w:t>A😀</w:t><w:noBreakHyphen/><w:t>B</w:t></w:r></w:p>"#,
         );
 
-        assert_eq!(run.text, "A😀B");
+        assert_eq!(run.text, "A😀-B");
         assert_eq!(run.source_refs.len(), 2);
         assert_eq!(run.source_refs[0].text_start, 0);
         assert_eq!(run.source_refs[0].text_end, 3);
-        assert_eq!(run.source_refs[1].text_start, 3);
-        assert_eq!(run.source_refs[1].text_end, 4);
+        // The generated no-break hyphen occupies [3, 4) in the merged run but
+        // intentionally has no source reference of its own.
+        assert_eq!(run.source_refs[1].text_start, 4);
+        assert_eq!(run.source_refs[1].text_end, 5);
         assert_eq!(run.source_refs[0].part_name.as_deref(), Some("word/document.xml"));
         assert_eq!(run.source_refs[0].path.last().unwrap().index, 0);
         assert_eq!(run.source_refs[1].path.last().unwrap().index, 1);

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1,6 +1,8 @@
 use serde::Serialize;
 use std::collections::BTreeMap;
 
+use ooxml_common::source::TextSourceRef;
+
 #[derive(Serialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Document {
@@ -1304,6 +1306,10 @@ pub struct FieldRun {
 #[serde(rename_all = "camelCase")]
 pub struct TextRun {
     pub text: String,
+    /// Identity mappings from this run's UTF-16 text to source XML text nodes.
+    /// Empty for generated or otherwise non-editable text.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub source_refs: Vec<TextSourceRef>,
     pub bold: bool,
     pub italic: bool,
     pub underline: bool,

--- a/packages/docx/src/DocxViewer.stories.ts
+++ b/packages/docx/src/DocxViewer.stories.ts
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/html';
 import { DocxDocument } from './document';
 import { DocxViewer } from './viewer';
+// Published-package equivalent:
+// import { getDocxTextRunAtNode, sliceTextSourceRefs } from '@silurus/ooxml/docx';
+import { getDocxTextRunAtNode, sliceTextSourceRefs } from './index';
 import init, { parse_docx } from './wasm/docx_parser.js';
 import wasmUrl from './wasm/docx_parser_bg.wasm?url';
 // Opt-in math engine. In published usage: `import { math } from '@silurus/ooxml/math'`.
@@ -25,6 +28,49 @@ const meta: Meta<Args> = {
 };
 export default meta;
 type Story = StoryObj<Args>;
+
+let removeSelectionSourceDebug: (() => void) | null = null;
+
+/** Log a same-segment selection and its OOXML source ranges in the browser console. */
+function installSelectionSourceDebug(root: HTMLElement): void {
+  // Storybook can re-render a story after args changes or HMR. Keep exactly one
+  // document-level listener so each selection produces one console entry.
+  removeSelectionSourceDebug?.();
+
+  const onSelectionChange = () => {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+
+    const range = selection.getRangeAt(0);
+    if (!root.contains(range.commonAncestorContainer)) return;
+
+    const startRun = getDocxTextRunAtNode(range.startContainer);
+    const endRun = getDocxTextRunAtNode(range.endContainer);
+
+    if (startRun && startRun === endRun) {
+      console.log('[docx source selection]', {
+        text: range.toString(),
+        visual: startRun,
+        sourceRefs: sliceTextSourceRefs(
+          startRun.sourceRefs,
+          range.startOffset,
+          range.endOffset,
+        ),
+      });
+    } else {
+      console.log('[docx source selection] multiple rendered segments', {
+        text: range.toString(),
+        startRun,
+        endRun,
+      });
+    }
+  };
+
+  document.addEventListener('selectionchange', onSelectionChange);
+  removeSelectionSourceDebug = () => {
+    document.removeEventListener('selectionchange', onSelectionChange);
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Helper: build nav bar + viewer (exported for use in local-only sample stories)
@@ -103,6 +149,8 @@ export function buildViewerUI(
   } else {
     spinner.remove();
   }
+
+  installSelectionSourceDebug(root);
 
   return { root, doc: null };
 }

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -2,7 +2,7 @@ export { DocxDocument, type LoadOptions, type RenderPageToBitmapOptions } from '
 export type { WireRenderPageOptions } from './worker-protocol';
 export { DocxViewer, type DocxViewerOptions } from './viewer';
 export { DocxScrollViewer, type DocxScrollViewerOptions } from './scroll-viewer';
-export { buildDocxTextLayer } from './text-layer';
+export { buildDocxTextLayer, getDocxTextRunAtNode } from './text-layer';
 // IX2 find-in-document: the highlight overlay builder + the docx match-location
 // shape. `FindMatch` / `FindMatchesOptions` come from core (shared across formats).
 export {
@@ -17,6 +17,8 @@ export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 // onHyperlinkClick`, `DocxTextRunInfo.hyperlink`, and the 5th arg of
 // `buildDocxTextLayer`, plus the default "open in a new tab, sanitised" helper.
 export { type HyperlinkTarget, openExternalHyperlink } from '@silurus/ooxml-core';
+export type { TextSourcePathStep, TextSourceRef } from '@silurus/ooxml-core';
+export { sliceTextSourceRefs } from '@silurus/ooxml-core';
 // Typed load-time error surfaced by DocxDocument.load (e.g. a password-protected
 // or legacy-binary .doc file). Re-exported so `@silurus/ooxml/docx` consumers can
 // narrow on `err.code`.

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -19,7 +19,7 @@ import type {
   DocParagraph, DocRun, DocxTextRun, ImageRun, ShapeTextRun, FieldRun,
   LineSpacing, TabStop, DocxRunBorder, DocSettings, EmphasisMark,
 } from './types';
-import type { MathNode, KinsokuRules, ChartModel, HyperlinkTarget, NumberFormat, Duotone, ResolvedLocalFontMetric } from '@silurus/ooxml-core';
+import type { MathNode, KinsokuRules, ChartModel, HyperlinkTarget, NumberFormat, Duotone, ResolvedLocalFontMetric, TextSourceRef } from '@silurus/ooxml-core';
 import type { RenderState, DecodedImage } from './renderer.js';
 import {
   classifyCjkFont,
@@ -47,6 +47,7 @@ import {
   parseDateTimePictureSwitch,
   fontAdvanceBiasEm,
   normalizeLocalFontMetricFamily,
+  sliceTextSourceRefs,
 } from '@silurus/ooxml-core';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
 import { groupFitTextRegions, type FitTextRun } from './fit-text.js';
@@ -68,6 +69,8 @@ interface LayoutSegSource {
 
 export interface LayoutTextSeg extends LayoutSegSource {
   text: string;
+  /** Full source mapping for the unsplit layout segment. */
+  sourceRefs?: TextSourceRef[];
   /** Zero-advance anchor-character placeholder: contributes run metrics to the
    * line box but paints no glyph. */
   metricOnly?: true;
@@ -2214,7 +2217,9 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
     vertAlign: 'super' | 'sub' | null,
     sourceRunIndex: number,
     sourceFragmentIndex?: number,
+    sourceTextStart?: number,
   ) => {
+    const firstOutputIndex = segs.length;
     // §17.3.2.33 small caps are sized per character: lowercase LETTERS render two
     // points smaller, uppercase letters and non-alphabetic characters at the full
     // run size. `reduced` (set per case-piece in the loop below) carries that onto
@@ -2456,6 +2461,22 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
         }
       }
     }
+
+    const emitted = segs
+      .slice(firstOutputIndex)
+      .filter((segment): segment is LayoutTextSeg => 'text' in segment);
+    if (
+      sourceTextStart !== undefined
+      && emitted.map((segment) => segment.text).join('') === text
+    ) {
+      let offset = sourceTextStart;
+      const refs = (base as DocxTextRun).sourceRefs;
+      for (const segment of emitted) {
+        const sourceRefs = sliceTextSourceRefs(refs, offset, offset + segment.text.length);
+        if (sourceRefs.length > 0) segment.sourceRefs = sourceRefs;
+        offset += segment.text.length;
+      }
+    }
   };
 
   for (const [runIndex, run] of runs.entries()) {
@@ -2480,12 +2501,15 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
       }
       // Split on tab chars so tab alignment can be resolved during layout.
       const parts = t.text.split('\t');
+      let sourceTextStart = 0;
       for (let i = 0; i < parts.length; i++) {
         if (parts[i].length > 0) {
-          pushTextPiece(parts[i], t, t.vertAlign, runIndex, i);
+          pushTextPiece(parts[i], t, t.vertAlign, runIndex, i, sourceTextStart);
         }
+        sourceTextStart += parts[i].length;
         if (i < parts.length - 1) {
           segs.push({ isTab: true, fontSize: t.fontSize, measuredWidth: 0, bold: t.bold, italic: t.italic });
+          sourceTextStart += 1;
         }
       }
     } else if (run.type === 'image') {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -52,8 +52,9 @@ import {
   fillDoubleBorder,
   drawUnderline,
   renderChart,
+  sliceTextSourceRefs,
 } from '@silurus/ooxml-core';
-import type { MathNode, MathRenderer, KinsokuRules, HyperlinkTarget, NumberFormat, Duotone, ResolvedLocalFontMetric } from '@silurus/ooxml-core';
+import type { MathNode, MathRenderer, KinsokuRules, HyperlinkTarget, NumberFormat, Duotone, ResolvedLocalFontMetric, TextSourceRef } from '@silurus/ooxml-core';
 import { computePageNumbering } from './page-numbering.js';
 import { docxUnderlineToDrawingML } from './underline-map.js';
 import { intendedSingleLinePx, correctLineMetrics } from './font-metrics.js';
@@ -644,6 +645,8 @@ function canonicalParagraphTextScaleEligible(
 /** Information about a rendered text segment for building a transparent selection overlay. */
 export interface DocxTextRunInfo {
   text: string;
+  /** Source mappings rebased to this callback segment's UTF-16 text. */
+  sourceRefs?: TextSourceRef[];
   /** Left edge in canvas CSS px. */
   x: number;
   /** Top of line box in canvas CSS px. */
@@ -9918,8 +9921,15 @@ function drawParagraphLine(li: number, c: ParagraphLineDrawCtx): void {
           const letterSpacingPx = !verticalUpright && !s.tateChuYoko
             ? segLetterSpacingPx(s, drawGridDeltaPx, scale)
             : 0;
+          const sourceOffset = s.src?.charOffset ?? 0;
+          const sourceRefs = sliceTextSourceRefs(
+            s.sourceRefs,
+            sourceOffset,
+            sourceOffset + s.text.length,
+          );
           state.onTextRun({
             text: s.text,
+            ...(sourceRefs.length > 0 ? { sourceRefs } : {}),
             x: place ? place.left : x,
             y: place ? place.top : state.y,
             w: spanW,

--- a/packages/docx/src/source-ref.test.ts
+++ b/packages/docx/src/source-ref.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { buildSegments, type LayoutTextSeg } from './line-layout.js';
+import type { DocRun, DocxTextRun } from './types.js';
+
+const ENV = { pageIndex: 0, totalPages: 1 };
+
+function textRun(text: string, extra: Partial<DocxTextRun> = {}): DocRun {
+  return {
+    type: 'text',
+    text,
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    fontSize: 12,
+    color: null,
+    fontFamily: 'serif',
+    isLink: false,
+    background: null,
+    vertAlign: null,
+    allCaps: false,
+    smallCaps: false,
+    doubleStrikethrough: false,
+    ...extra,
+  } as unknown as DocRun;
+}
+
+describe('DOCX text source references', () => {
+  it('clips one XML text-node range across visual script segments', () => {
+    const sourceRefs = [{
+      partName: 'word/document.xml',
+      path: [{ namespaceUri: 'urn:w', localName: 't', index: 0 }],
+      textStart: 0,
+      textEnd: 4,
+      sourceStart: 0,
+      sourceEnd: 4,
+    }];
+    const segments = buildSegments(
+      [textRun('A😀中', { sourceRefs })],
+      ENV,
+    ).filter((segment): segment is LayoutTextSeg => 'text' in segment);
+
+    expect(segments.map((segment) => segment.text).join('')).toBe('A😀中');
+    expect(segments.flatMap((segment) => segment.sourceRefs ?? []).map((ref) => [
+      ref.sourceStart,
+      ref.sourceEnd,
+    ])).toEqual([[0, 3], [3, 4]]);
+    for (const segment of segments) {
+      expect(segment.sourceRefs).toEqual([expect.objectContaining({
+        textStart: 0,
+        textEnd: segment.text.length,
+      })]);
+    }
+  });
+});

--- a/packages/docx/src/text-layer.test.ts
+++ b/packages/docx/src/text-layer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { buildDocxTextLayer } from './text-layer.js';
+import { buildDocxTextLayer, getDocxTextRunAtNode } from './text-layer.js';
 import type { DocxTextRunInfo } from './renderer';
 
 // The vitest env is `node` (no document). Following renderer.textbox-image.test.ts's
@@ -111,6 +111,24 @@ describe('buildDocxTextLayer (extracted from DocxViewer._buildTextLayer)', () =>
     expect(a.style.cssText).toMatch(/font:[^;]+;line-height:/);
     expect(b.textContent).toBe('World');
     expect(b.style.left).toBe(`${(50 / 700) * 100}%`);
+  });
+
+  it('maps a selection-layer span back to its rendered source run', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const sourceRefs = [{
+      partName: 'word/document.xml',
+      path: [{ localName: 't', index: 0 }],
+      textStart: 0,
+      textEnd: 1,
+      sourceStart: 0,
+      sourceEnd: 1,
+    }];
+    const sourceRun = run({ sourceRefs });
+
+    buildDocxTextLayer(layer as unknown as HTMLDivElement, [sourceRun], 100, 100);
+
+    expect(getDocxTextRunAtNode(layer.children[0] as unknown as Node)).toBe(sourceRun);
   });
 
   // ECMA-376 §17.3.2.10 縦中横 (#836): a tate-chu-yoko run is drawn compressed into

--- a/packages/docx/src/text-layer.ts
+++ b/packages/docx/src/text-layer.ts
@@ -2,6 +2,19 @@ import type { DocxTextRunInfo } from './renderer';
 import { overlayPercent, type HyperlinkTarget } from '@silurus/ooxml-core';
 import { tateChuYokoOverlayScale } from './tate-chu-yoko-overlay';
 
+const textRunByNode = new WeakMap<Node, DocxTextRunInfo>();
+
+/** Return the rendered run associated with a text-layer node or its ancestors. */
+export function getDocxTextRunAtNode(node: Node | null): DocxTextRunInfo | undefined {
+  let current = node;
+  while (current) {
+    const run = textRunByNode.get(current);
+    if (run) return run;
+    current = current.parentNode;
+  }
+  return undefined;
+}
+
 /**
  * Build the transparent text-selection overlay for a rendered docx page: one
  * absolutely-positioned, color-transparent `<span>` per {@link DocxTextRunInfo}
@@ -60,6 +73,7 @@ export function buildDocxTextLayer(
   for (const run of runs) {
     const span = document.createElement('span');
     span.textContent = run.text;
+    textRunByNode.set(span, run);
     // The `font` shorthand must precede `line-height` because the shorthand
     // resets `line-height` to `normal`. Reset `letter-spacing` so a parent
     // CSS rule cannot drift the trailing edge of the selection. Kerning /

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1,6 +1,6 @@
 // ===== Output JSON model (mirrors Rust types) =====
 
-import type { MathNode, ChartModel, Duotone } from '@silurus/ooxml-core';
+import type { MathNode, ChartModel, Duotone, TextSourceRef } from '@silurus/ooxml-core';
 
 export interface DocxDocumentModel {
   section: SectionProps;
@@ -1164,6 +1164,8 @@ export interface FieldRun {
 
 export interface DocxTextRun {
   text: string;
+  /** Stable source mappings for ordinary text in `word/document.xml`. */
+  sourceRefs?: TextSourceRef[];
   bold: boolean;
   italic: boolean;
   underline: boolean;
@@ -1651,7 +1653,17 @@ export interface RenderPageOptions {
    *  selection overlay. On a vertical (§17.6.20 tbRl) page `x`/`y` are the
    *  PHYSICAL top-left and `transform` is the CSS rotation the overlay span
    *  applies about its top-left; absent for horizontal pages. */
-  onTextRun?: (run: { text: string; x: number; y: number; w: number; h: number; fontSize: number; font: string; transform?: string }) => void;
+  onTextRun?: (run: {
+    text: string;
+    sourceRefs?: TextSourceRef[];
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    fontSize: number;
+    font: string;
+    transform?: string;
+  }) => void;
   /** Default `true`. When false, ECMA-376 §17.13.5 track-changes runs render
    *  in their normal style (no author colour, no underline / strikethrough)
    *  — equivalent to Word's "Final / No Markup" view. */

--- a/packages/ooxml-common/src/lib.rs
+++ b/packages/ooxml-common/src/lib.rs
@@ -16,6 +16,7 @@ pub mod math;
 pub mod mce;
 pub mod ns;
 pub mod rels;
+pub mod source;
 pub mod text;
 pub mod theme;
 pub mod units;

--- a/packages/ooxml-common/src/source.rs
+++ b/packages/ooxml-common/src/source.rs
@@ -57,6 +57,8 @@ pub fn element_path(node: Node<'_, '_>) -> Vec<SourcePathStep> {
             let tag = element.tag_name();
             let index = element
                 .prev_siblings()
+                // roxmltree includes the node itself as the first item.
+                .skip(1)
                 .filter(|sibling| {
                     sibling.is_element()
                         && sibling.tag_name().name() == tag.name()

--- a/packages/ooxml-common/src/source.rs
+++ b/packages/ooxml-common/src/source.rs
@@ -1,0 +1,133 @@
+//! Stable source references for text parsed from OOXML XML parts.
+//!
+//! Renderers are free to split and reorder text for layout, so a source reference
+//! maps a UTF-16 range in the parsed text back to a UTF-16 range in one XML text
+//! node. The node itself is addressed by a namespace-aware element path.
+
+use roxmltree::Node;
+use serde::{Deserialize, Serialize};
+
+/// One namespace-aware step in an OOXML element path.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SourcePathStep {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace_uri: Option<String>,
+    pub local_name: String,
+    /// Zero-based ordinal among element siblings with the same expanded name.
+    pub index: u32,
+}
+
+/// Maps a UTF-16 interval in parsed/rendered text to one XML text node.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TextSourceRef {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub part_name: Option<String>,
+    pub path: Vec<SourcePathStep>,
+    /// UTF-16 interval in the containing parsed text run.
+    pub text_start: u32,
+    pub text_end: u32,
+    /// UTF-16 interval in the source XML text node.
+    pub source_start: u32,
+    pub source_end: u32,
+}
+
+/// Build a reference for the full text of an XML element such as `w:t` or `a:t`.
+pub fn text_source_ref(node: Node<'_, '_>, part_name: Option<&str>) -> TextSourceRef {
+    let text_len = node.text().unwrap_or("").encode_utf16().count() as u32;
+    TextSourceRef {
+        part_name: part_name.map(str::to_owned),
+        path: element_path(node),
+        text_start: 0,
+        text_end: text_len,
+        source_start: 0,
+        source_end: text_len,
+    }
+}
+
+/// Return the namespace-aware path from the XML root element to `node`.
+pub fn element_path(node: Node<'_, '_>) -> Vec<SourcePathStep> {
+    node.ancestors()
+        .filter(|ancestor| ancestor.is_element())
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .map(|element| {
+            let tag = element.tag_name();
+            let index = element
+                .prev_siblings()
+                .filter(|sibling| {
+                    sibling.is_element()
+                        && sibling.tag_name().name() == tag.name()
+                        && sibling.tag_name().namespace() == tag.namespace()
+                })
+                .count() as u32;
+            SourcePathStep {
+                namespace_uri: tag.namespace().map(str::to_owned),
+                local_name: tag.name().to_owned(),
+                index,
+            }
+        })
+        .collect()
+}
+
+/// Resolve a path produced by [`element_path`] against an OOXML part root.
+pub fn resolve_element_path<'a, 'input>(
+    root: Node<'a, 'input>,
+    path: &[SourcePathStep],
+) -> Option<Node<'a, 'input>> {
+    let first = path.first()?;
+    if !matches_step(root, first) || first.index != 0 {
+        return None;
+    }
+
+    let mut current = root;
+    for step in &path[1..] {
+        current = current
+            .children()
+            .filter(|child| child.is_element() && matches_step(*child, step))
+            .nth(step.index as usize)?;
+    }
+    Some(current)
+}
+
+fn matches_step(node: Node<'_, '_>, step: &SourcePathStep) -> bool {
+    node.tag_name().name() == step.local_name
+        && node.tag_name().namespace() == step.namespace_uri.as_deref()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_ref_uses_expanded_name_sibling_ordinals_and_utf16_offsets() {
+        let doc = roxmltree::Document::parse(
+            r#"<w:document xmlns:w="urn:w"><w:body><w:p/><w:p><w:r><w:t>A😀B</w:t></w:r></w:p></w:body></w:document>"#,
+        )
+        .unwrap();
+        let text = doc
+            .descendants()
+            .find(|node| node.is_element() && node.tag_name().name() == "t")
+            .unwrap();
+
+        let source = text_source_ref(text, Some("word/document.xml"));
+
+        assert_eq!(source.source_end, 4);
+        assert_eq!(source.text_end, 4);
+        assert_eq!(source.part_name.as_deref(), Some("word/document.xml"));
+        assert_eq!(
+            source
+                .path
+                .iter()
+                .map(|step| (step.local_name.as_str(), step.index))
+                .collect::<Vec<_>>(),
+            vec![("document", 0), ("body", 0), ("p", 1), ("r", 0), ("t", 0)]
+        );
+        assert_eq!(
+            resolve_element_path(doc.root_element(), &source.path),
+            Some(text)
+        );
+    }
+}

--- a/packages/pptx/parser/src/smartart_fallback.rs
+++ b/packages/pptx/parser/src/smartart_fallback.rs
@@ -456,6 +456,7 @@ fn default_paragraph() -> Paragraph {
 fn default_run() -> TextRunData {
     TextRunData {
         text: String::new(),
+        source_refs: Vec::new(),
         bold: None,
         italic: None,
         underline: false,

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -956,6 +956,7 @@ pub(crate) fn parse_paragraph(
                     .and_then(|n| parse_color_node(n, theme));
                 runs.push(TextRun::Text(TextRunData {
                     text,
+                    source_refs: Vec::new(),
                     bold,
                     italic,
                     underline: false,
@@ -1190,6 +1191,7 @@ pub(crate) fn parse_run(
 ) -> Option<TextRunData> {
     let t_node = child(r_node, "t")?;
     let text = t_node.text().unwrap_or("").to_owned();
+    let source_refs = pptx_text_source_refs(t_node);
     let r_pr = child(r_node, "rPr");
 
     // Attribute with rPr → defRPr fallback; None means "not set" (inherit from body/layout defaults)
@@ -1357,6 +1359,7 @@ pub(crate) fn parse_run(
 
     Some(TextRunData {
         text,
+        source_refs,
         bold,
         italic,
         underline,
@@ -1379,4 +1382,46 @@ pub(crate) fn parse_run(
         outline,
         highlight,
     })
+}
+
+/// Return source metadata only for text physically stored in a slide part.
+/// Layout/master text can be rendered into the slide but belongs to another
+/// package part whose name is not available in this parser call.
+fn pptx_text_source_refs(
+    t_node: roxmltree::Node<'_, '_>,
+) -> Vec<ooxml_common::source::TextSourceRef> {
+    let root = t_node.document().root_element();
+    if root.tag_name().name() != "sld" {
+        return Vec::new();
+    }
+
+    ooxml_common::source::text_source_ref(t_node, None)
+        .into_iter()
+        .collect()
+}
+
+#[cfg(test)]
+mod source_ref_tests {
+    use super::*;
+
+    #[test]
+    fn slide_run_keeps_namespace_path_and_utf16_source_range() {
+        let doc = roxmltree::Document::parse(
+            r#"<p:sld xmlns:p="urn:p" xmlns:a="urn:a"><p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>A😀B</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>"#,
+        )
+        .unwrap();
+        let run_node = doc
+            .descendants()
+            .find(|node| node.is_element() && node.tag_name().name() == "r")
+            .unwrap();
+        let run = parse_run(run_node, None, &HashMap::new(), &HashMap::new()).unwrap();
+
+        assert_eq!(run.source_refs.len(), 1);
+        let source = &run.source_refs[0];
+        assert_eq!(source.text_end, 4);
+        assert_eq!(source.source_end, 4);
+        assert_eq!(source.path.first().unwrap().local_name, "sld");
+        assert_eq!(source.path.last().unwrap().local_name, "t");
+        assert!(source.part_name.is_none());
+    }
 }

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -1395,9 +1395,7 @@ fn pptx_text_source_refs(
         return Vec::new();
     }
 
-    ooxml_common::source::text_source_ref(t_node, None)
-        .into_iter()
-        .collect()
+    vec![ooxml_common::source::text_source_ref(t_node, None)]
 }
 
 #[cfg(test)]

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -1038,6 +1038,10 @@ pub(crate) enum TextRun {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TextRunData {
     pub(crate) text: String,
+    /// Stable source ranges for ordinary slide-owned DrawingML text. Empty for
+    /// generated fields and inherited layout/master content.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) source_refs: Vec<ooxml_common::source::TextSourceRef>,
     /// None = not set (inherit from paragraph/body/layout defaults); Some(true/false) = explicit
     pub(crate) bold: Option<bool>,
     /// None = not set; Some(true/false) = explicit

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -7,7 +7,7 @@ export {
   type RenderSlideToBitmapOptions,
 } from './presentation';
 export { renderSlide, type RenderOptions, type PptxTextRunInfo, type TextRunCallback } from './renderer';
-export { buildPptxTextLayer } from './text-layer';
+export { buildPptxTextLayer, getPptxTextRunAtNode } from './text-layer';
 // IX2 find-in-document: the highlight overlay builder + the pptx match-location
 // shape. `FindMatch` / `FindMatchesOptions` come from core (shared across formats).
 export {
@@ -27,6 +27,8 @@ export { type HyperlinkTarget, openExternalHyperlink } from '@silurus/ooxml-core
 // password-protected or legacy-binary .ppt file). Re-exported so
 // `@silurus/ooxml/pptx` consumers can narrow on `err.code`.
 export { OoxmlError, type OoxmlErrorCode } from '@silurus/ooxml-core';
+export type { TextSourcePathStep, TextSourceRef } from '@silurus/ooxml-core';
+export { sliceTextSourceRefs } from '@silurus/ooxml-core';
 export type {
   Presentation,
   Slide,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -87,6 +87,9 @@ import {
   buildWarpEnvelope,
   warpGlyphTransform,
   followPathUScale,
+  offsetTextSourceRefs,
+  sliceTextSourceRefs,
+  type TextSourceRef,
 } from '@silurus/ooxml-core';
 import type { WarpEnvelope, WarpGlyphTransform } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput, BevelRegion } from '@silurus/ooxml-core';
@@ -137,6 +140,8 @@ export interface RenderContext {
 /** Information about a rendered text segment for building a transparent selection overlay. */
 export interface PptxTextRunInfo {
   text: string;
+  /** Stable OOXML source ranges covered by this rendered segment. */
+  sourceRefs?: TextSourceRef[];
   /** X position in CSS px, relative to the shape's top-left corner. */
   inShapeX: number;
   /** Y position (top of line box) in CSS px, relative to the shape's top-left corner. */
@@ -362,6 +367,8 @@ export async function prepareSlideMath(slide: Slide, math: MathRenderer): Promis
 
 type LayoutSegment = {
   text: string;
+  /** Stable OOXML source ranges rebased to this segment's UTF-16 text. */
+  sourceRefs?: TextSourceRef[];
   font: string;
   /** Inline DrawingML TAB, classified UAX#9 S during visual ordering (#916). */
   isTab?: true;
@@ -1326,7 +1333,36 @@ export function layoutParagraph(
   // Always emit the last (possibly empty) line
   lines.push(currentLine);
 
+  attachParagraphSourceRefs(lines, para);
   return lines;
+}
+
+/**
+ * Project parser-level run mappings onto the final visual segments. The
+ * all-text equality guard intentionally drops metadata when the renderer has
+ * transformed content (fields, caps, symbols, tabs, or generated text), since
+ * claiming a source offset there would be less useful than omitting it.
+ */
+function attachParagraphSourceRefs(lines: LayoutLine[], para: Paragraph): void {
+  let sourceText = '';
+  const sourceRefs: TextSourceRef[] = [];
+
+  for (const run of para.runs) {
+    if (run.type !== 'text') continue;
+    sourceRefs.push(...offsetTextSourceRefs(run.sourceRefs, sourceText.length));
+    sourceText += run.text;
+  }
+
+  if (sourceRefs.length === 0) return;
+  const segments = lines.flatMap((line) => line.segments.filter((segment) => !segment.math && !segment.isTab));
+  if (segments.map((segment) => segment.text).join('') !== sourceText) return;
+
+  let textOffset = 0;
+  for (const segment of segments) {
+    const refs = sliceTextSourceRefs(sourceRefs, textOffset, textOffset + segment.text.length);
+    if (refs.length > 0) segment.sourceRefs = refs;
+    textOffset += segment.text.length;
+  }
 }
 
 // ===== Element renderers =====
@@ -3805,6 +3841,7 @@ export function renderTextBody(
       if (onTextRun && seg.text) {
         onTextRun({
           text: seg.text,
+          sourceRefs: seg.sourceRefs,
           inShapeX: penX - bx,
           inShapeY: cursorY - by,
           w: segW + jext,
@@ -5434,6 +5471,15 @@ async function renderSlideLeased(
   if (superseded()) return canvas;
 
   const slideNumber = slide.slideNumber;
+  const sourceOnTextRun: TextRunCallback | undefined = onTextRun
+    ? (run) => onTextRun({
+        ...run,
+        sourceRefs: run.sourceRefs?.map((ref) => ({
+          ...ref,
+          partName: ref.partName ?? slide.partName,
+        })),
+      })
+    : undefined;
 
   // Warm the bitmap caches for every image-bearing element concurrently.
   // The draw loop below still awaits in element order (z-order), but each
@@ -5514,7 +5560,7 @@ async function renderSlideLeased(
     // stop so we don't paint this (now stale) slide over the newer one.
     if (superseded()) return canvas;
     if (el.type === 'shape') {
-      renderShape(ctx, el, scale, themeDefaultColor, slideNumber, rc, onTextRun, opts.fetchImage);
+      renderShape(ctx, el, scale, themeDefaultColor, slideNumber, rc, sourceOnTextRun, opts.fetchImage);
     } else if (el.type === 'picture') {
       await renderPicture(ctx, el, scale, opts.fetchImage);
     } else if (el.type === 'table') {

--- a/packages/pptx/src/source-ref.test.ts
+++ b/packages/pptx/src/source-ref.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import type { TextRunData, TextSourceRef } from '@silurus/ooxml-core';
+import { layoutParagraph } from './renderer.js';
+import type { Paragraph } from './types.js';
+
+function mockCtx(): CanvasRenderingContext2D {
+  let font = '';
+  return {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    measureText: (text: string) => ({ width: [...text].length * 10 }) as TextMetrics,
+    fillRect() {},
+    fillText() {},
+    fillStyle: '',
+    strokeStyle: '',
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function run(text: string, sourceRefs: TextSourceRef[]): TextRunData {
+  return {
+    type: 'text',
+    text,
+    sourceRefs,
+    bold: null,
+    italic: null,
+    underline: false,
+    strikethrough: false,
+    fontSize: 20,
+    color: '000000',
+    fontFamily: 'Arial',
+  };
+}
+
+function paragraph(runs: TextRunData[]): Paragraph {
+  return {
+    alignment: 'l',
+    marL: 0,
+    marR: 0,
+    indent: 0,
+    spaceBefore: null,
+    spaceAfter: null,
+    spaceLine: null,
+    lvl: 0,
+    bullet: { type: 'none' },
+    defFontSize: null,
+    defColor: null,
+    defBold: null,
+    defItalic: null,
+    defFontFamily: null,
+    tabStops: [],
+    eaLnBrk: true,
+    runs,
+  } as Paragraph;
+}
+
+describe('PPTX text source references', () => {
+  it('rebases source intervals onto automatically wrapped visual segments', () => {
+    const sourceRefs: TextSourceRef[] = [{
+      path: [{ namespaceUri: 'urn:a', localName: 't', index: 0 }],
+      textStart: 0,
+      textEnd: 10,
+      sourceStart: 0,
+      sourceEnd: 10,
+    }];
+    const lines = layoutParagraph(
+      mockCtx(),
+      paragraph([run('Alpha Beta', sourceRefs)]),
+      60,
+      20,
+      '000000',
+      1,
+      0,
+    );
+    const segments = lines.flatMap((line) => line.segments.filter((segment) => segment.text));
+
+    expect(segments.map((segment) => segment.text)).toEqual(['Alpha ', 'Beta']);
+    expect(segments.map((segment) => segment.sourceRefs)).toEqual([
+      [expect.objectContaining({ textStart: 0, textEnd: 6, sourceStart: 0, sourceEnd: 6 })],
+      [expect.objectContaining({ textStart: 0, textEnd: 4, sourceStart: 6, sourceEnd: 10 })],
+    ]);
+  });
+
+  it('keeps separate XML nodes when same-style runs merge visually', () => {
+    const lines = layoutParagraph(
+      mockCtx(),
+      paragraph([
+        run('Hello', [{
+          path: [{ localName: 't', index: 0 }],
+          textStart: 0,
+          textEnd: 5,
+          sourceStart: 0,
+          sourceEnd: 5,
+        }]),
+        run('世界', [{
+          path: [{ localName: 't', index: 1 }],
+          textStart: 0,
+          textEnd: 2,
+          sourceStart: 0,
+          sourceEnd: 2,
+        }]),
+      ]),
+      200,
+      20,
+      '000000',
+      1,
+      0,
+    );
+    const refs = lines.flatMap((line) => line.segments).flatMap((segment) => segment.sourceRefs ?? []);
+
+    expect(refs.map((ref) => [ref.path[0].index, ref.textStart, ref.textEnd])).toEqual([
+      [0, 0, 5],
+      [1, 5, 7],
+    ]);
+  });
+});

--- a/packages/pptx/src/text-layer.test.ts
+++ b/packages/pptx/src/text-layer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { buildPptxTextLayer } from './text-layer.js';
+import { buildPptxTextLayer, getPptxTextRunAtNode } from './text-layer.js';
 import type { PptxTextRunInfo } from './renderer';
 
 // node env: no document. Recording DOM stub (see docx text-layer.test.ts). pptx
@@ -104,6 +104,26 @@ describe('buildPptxTextLayer (extracted from PptxViewer._buildTextLayer)', () =>
     expect(spanA.style['line-height']).toBe('12px');
     expect(spanA.style['letter-spacing']).toBe('0');
     expect(spanA.style.color).toBe('transparent');
+  });
+
+  it('maps a selection-layer span back to its rendered source run', () => {
+    vi.stubGlobal('document', { createElement: (t: string) => makeEl(t) });
+    const layer = makeEl('div');
+    const sourceRun = run({
+      sourceRefs: [{
+        partName: 'ppt/slides/slide1.xml',
+        path: [{ localName: 't', index: 0 }],
+        textStart: 0,
+        textEnd: 1,
+        sourceStart: 0,
+        sourceEnd: 1,
+      }],
+    });
+
+    buildPptxTextLayer(layer as unknown as HTMLDivElement, [sourceRun], 100, 100);
+
+    const span = layer.children[0].children[0];
+    expect(getPptxTextRunAtNode(span as unknown as Node)).toBe(sourceRun);
   });
 
   it('splits runs of different shapes into separate group divs', () => {

--- a/packages/pptx/src/text-layer.ts
+++ b/packages/pptx/src/text-layer.ts
@@ -1,6 +1,19 @@
 import { overlayPercent, type HyperlinkTarget } from '@silurus/ooxml-core';
 import type { PptxTextRunInfo } from './renderer';
 
+const textRunByNode = new WeakMap<Node, PptxTextRunInfo>();
+
+/** Return the rendered run associated with a text-layer node or its ancestors. */
+export function getPptxTextRunAtNode(node: Node | null): PptxTextRunInfo | undefined {
+  let current = node;
+  while (current) {
+    const run = textRunByNode.get(current);
+    if (run) return run;
+    current = current.parentNode;
+  }
+  return undefined;
+}
+
 /**
  * Build the transparent text-selection overlay for a rendered pptx slide. Unlike
  * docx (flat spans), pptx groups runs into one positioned `<div>` per shape frame
@@ -76,6 +89,7 @@ export function buildPptxTextLayer(
     const shape = shapeMap.get(key)!;
     const span = document.createElement('span');
     span.textContent = run.text;
+    textRunByNode.set(span, run);
     // The `font` shorthand must precede `line-height` because the shorthand
     // resets `line-height` to `normal`. Reset `letter-spacing` so a parent
     // CSS rule cannot drift the trailing edge of the selection. Kerning /


### PR DESCRIPTION
Rendered text had no format-independent identity linking it back to its OOXML XML node and UTF-16 interval.

Add namespace-aware source paths, shared Rust and TypeScript source-reference models, and helpers for slicing and offsetting mappings as text is transformed.

Verified with focused Vitest coverage and git diff --check. Rust tests were not run because cargo is unavailable in this environment.

Co-Authored-By: Codex GPT-5 <noreply@openai.com>