### PR TITLE
refactor(docx): acquire adjacent logical table grids

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -1486,6 +1486,143 @@ fn parse_body_elements(
     )
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct LogicalTableSequenceContext {
+    /// Parser-owned identity for one §17.4.37 logical table. The source byte
+    /// offset is deterministic within the XML part and survives serde/worker
+    /// boundaries without exposing parser-node objects.
+    sequence_id: usize,
+    /// Zero-based authored-row ordinal within the logical table formed by
+    /// adjacent source `<w:tbl>` elements.
+    ///
+    /// Only the row axis is shared here. §17.4.37 does not define how distinct
+    /// tblGrid, justification, or bidiVisual values on adjacent source tables
+    /// are reconciled, while §17.4.8 defines column membership against the
+    /// parent table's grid. Keep each source grid authoritative rather than
+    /// making a parser-time physical-grid compatibility guess.
+    row_offset: usize,
+    total_rows: usize,
+    /// Whether the logical table's FIRST member activates `w:tblLook@firstRow`.
+    /// §17.7.6.7 horizontal-band parity origins from the logical table's own
+    /// first row, so the band offset is owned by the sequence, not by each
+    /// member's local tblLook. `is_first_row`/`lastRow` and each member's
+    /// `noHBand` gate remain local because those are per-source-table facts.
+    sequence_first_row_flag: bool,
+}
+
+impl LogicalTableSequenceContext {
+    fn standalone(node: roxmltree::Node) -> Self {
+        Self {
+            sequence_id: node.range().start,
+            row_offset: 0,
+            total_rows: table_row_count(node),
+            sequence_first_row_flag: tbl_look_flag(child_w(node, "tblPr"), "firstRow", 0x0020),
+        }
+    }
+}
+
+/// Resolve ECMA-376 Part 1 §17.4.37 logical-table membership before parsing
+/// individual source tables. Conditional table formatting is defined over the
+/// resulting logical row sequence, but authored table/row identity remains
+/// intact in the parser model; consequently this prepass supplies ordinals to
+/// `parse_table` rather than manufacturing a merged table or a runtime stamp.
+fn logical_table_sequence_contexts(
+    children: &[(roxmltree::Node, bool)],
+    style_map: &StyleMap,
+    positioning_context: TablePositioningContext,
+) -> HashMap<roxmltree::NodeId, LogicalTableSequenceContext> {
+    struct TableSequenceFact {
+        node_id: roxmltree::NodeId,
+        source_offset: usize,
+        effective_style_id: String,
+        row_count: usize,
+        first_row_flag: bool,
+    }
+
+    let mut contexts = HashMap::new();
+    let mut group: Vec<TableSequenceFact> = Vec::new();
+    let flush_group =
+        |group: &mut Vec<TableSequenceFact>,
+         contexts: &mut HashMap<roxmltree::NodeId, LogicalTableSequenceContext>| {
+            let total_rows = group
+                .iter()
+                .map(|fact| fact.row_count)
+                .fold(0usize, usize::saturating_add);
+            let sequence_id = group.first().map_or(0, |fact| fact.source_offset);
+            // §17.7.6.7: the band parity origin belongs to the logical table's
+            // first member, so every member shares that member's firstRow flag.
+            let sequence_first_row_flag = group.first().is_some_and(|fact| fact.first_row_flag);
+            let mut row_offset = 0usize;
+            for fact in group.drain(..) {
+                contexts.insert(
+                    fact.node_id,
+                    LogicalTableSequenceContext {
+                        sequence_id,
+                        row_offset,
+                        total_rows,
+                        sequence_first_row_flag,
+                    },
+                );
+                row_offset = row_offset.saturating_add(fact.row_count);
+            }
+        };
+
+    for (node, cover_break_after) in children {
+        match node.tag_name().name() {
+            // §17.4.37 names an intervening paragraph as the separator. Range
+            // markup and other non-paragraph wrapper facts are transparent. A
+            // hidden/vanished paragraph is still a paragraph and still breaks
+            // adjacency.
+            "p" => flush_group(&mut group, &mut contexts),
+            "tbl" => {
+                let tbl_pr = child_w(*node, "tblPr");
+                let ordinary_flow = table_is_ordinary_flow(
+                    tbl_pr.and_then(|properties| child_w(properties, "tblpPr")),
+                    positioning_context,
+                );
+                // A table joins a logical sequence only with a valid effective
+                // table-style identity while it participates in ordinary flow;
+                // an effective float or an unresolved/non-table style is a
+                // standalone §17.4.37 barrier.
+                match effective_table_style_id(*node, style_map) {
+                    Some(effective_style_id) if ordinary_flow => {
+                        if group
+                            .first()
+                            .is_some_and(|first| first.effective_style_id != effective_style_id)
+                        {
+                            flush_group(&mut group, &mut contexts);
+                        }
+                        group.push(TableSequenceFact {
+                            node_id: node.id(),
+                            source_offset: node.range().start,
+                            effective_style_id,
+                            row_count: table_row_count(*node),
+                            first_row_flag: tbl_look_flag(tbl_pr, "firstRow", 0x0020),
+                        });
+                    }
+                    _ => {
+                        flush_group(&mut group, &mut contexts);
+                        contexts.insert(node.id(), LogicalTableSequenceContext::standalone(*node));
+                    }
+                }
+            }
+            // A body-level or mid-body `<w:sectPr>` is a §17.6.1 section
+            // boundary; two tables cannot be one logical table across it.
+            "sectPr" => flush_group(&mut group, &mut contexts),
+            _ => {}
+        }
+
+        // The cover-building-block pass emits a real page break at this
+        // boundary, so conditional table geometry cannot span across it.
+        if *cover_break_after {
+            flush_group(&mut group, &mut contexts);
+        }
+    }
+    flush_group(&mut group, &mut contexts);
+
+    contexts
+}
+
 #[allow(clippy::too_many_arguments)]
 fn parse_body_elements_in_story(
     body_node: roxmltree::Node,
@@ -1521,6 +1658,9 @@ fn parse_body_elements_in_story(
     // building blocks (§17.5.2), so a redundant one can be dropped post-pass (see
     // below) when the cover is already followed by a page-advancing construct.
     let mut cover_break_positions: Vec<usize> = Vec::new();
+
+    let logical_table_sequences =
+        logical_table_sequence_contexts(&body_children, style_map, table_positioning_context);
 
     for (child, cover_break_after) in body_children {
         match child.tag_name().name() {
@@ -1603,6 +1743,10 @@ fn parse_body_elements_in_story(
                     theme,
                     DepthGuard::root(),
                     table_positioning_context,
+                    logical_table_sequences
+                        .get(&child.id())
+                        .copied()
+                        .unwrap_or_else(|| LogicalTableSequenceContext::standalone(child)),
                 );
                 body.push(BodyElement::Table(Box::new(tbl)));
             }
@@ -8788,6 +8932,45 @@ fn table_is_ordinary_flow(
     offset_is_zero("tblpX") && offset_is_zero("tblpY") && horizontal == "text" && vertical != "text"
 }
 
+/// Count authored `<w:tr>` rows, including those nested behind range-markup
+/// wrappers, for §17.4.37 logical-table row totals.
+fn table_row_count(node: roxmltree::Node) -> usize {
+    children_w_flat(node, "tr").len()
+}
+
+/// Effective ECMA-376 §17.7.4 table-style identity of a `<w:tbl>`.
+///
+/// An explicit `<w:tblStyle w:val>` is honored only when it resolves to a real
+/// `<w:style w:type="table">`; an unresolved or non-table reference yields
+/// `None` and cannot form a §17.4.37 grouping identity. When the table omits
+/// `<w:tblStyle>` the implicit default table style applies, preserving the
+/// existing §17.7.4 omitted-style policy owned by `default_table_style_id`.
+fn effective_table_style_id(node: roxmltree::Node, style_map: &StyleMap) -> Option<String> {
+    let authored = child_w(node, "tblPr")
+        .and_then(|properties| child_w(properties, "tblStyle"))
+        .and_then(|style| attr_w(style, "val"));
+    match authored {
+        Some(style_id) if style_map.contains_table_style(&style_id) => Some(style_id),
+        Some(_) => None,
+        None => style_map.default_table_style_id().map(str::to_string),
+    }
+}
+
+/// Resolve one ECMA-376 §17.4.49 `w:tblLook` on/off flag: a named attribute
+/// (`w:firstRow="1"` …) wins, otherwise the legacy combined hex bitmask bit.
+/// Shared so §17.4.37 sequence membership and per-table cnf agree on activation.
+fn tbl_look_flag(tbl_pr: Option<roxmltree::Node>, name: &str, bit: u32) -> bool {
+    let look = tbl_pr.and_then(|p| child_w(p, "tblLook"));
+    let look_val = look
+        .and_then(|l| attr_w(l, "val"))
+        .and_then(|v| u32::from_str_radix(v.trim(), 16).ok());
+    match look.and_then(|l| attr_w(l, name)).as_deref() {
+        Some("1") | Some("true") | Some("on") => true,
+        Some(_) => false, // explicit "0"/"false" disables regardless of hex
+        None => look_val.map(|v| v & bit != 0).unwrap_or(false),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn parse_table(
     node: roxmltree::Node,
@@ -8799,17 +8982,10 @@ fn parse_table(
     theme: &ThemeColors,
     depth: DepthGuard,
     table_positioning_context: TablePositioningContext,
+    logical_sequence: LogicalTableSequenceContext,
 ) -> DocTable {
     let tbl_pr = child_w(node, "tblPr");
     let tbl_grid = child_w(node, "tblGrid");
-
-    // Resolve the table style ID (§17.4.63 w:tblStyle). Cell paragraphs
-    // inherit this style's pPr — e.g. "Table Grid" (style `af3` in this
-    // sample) sets line="240" after="0", which tightens cell line spacing
-    // below the body-text default inherited from docDefault.
-    let table_style_id = tbl_pr
-        .and_then(|p| child_w(p, "tblStyle"))
-        .and_then(|s| attr_w(s, "val"));
 
     let grid_columns = tbl_grid
         .map(|g| {
@@ -8845,10 +9021,9 @@ fn parse_table(
     // `<w:tblCellMar>` (and other tblPr defaults) MUST apply, otherwise a
     // table whose cells rely on TableNormal's 108-twip left/right padding
     // (the Word convention) renders with the wrong column geometry.
-    let effective_table_style_id = table_style_id
-        .as_deref()
-        .or_else(|| style_map.default_table_style_id());
+    let effective_table_style_id = effective_table_style_id(node, style_map);
     let tstyle = effective_table_style_id
+        .as_deref()
         .map(|id| style_map.resolve_table_style(id))
         .unwrap_or_default();
     // ECMA-376 §17.4.49 (w:tblLook). Word writes this either with the modern
@@ -8858,17 +9033,7 @@ fn parse_table(
     // Legacy bit values (§17.4.49 / the older w:tblLook hex form):
     //   0x0020 firstRow   0x0040 lastRow   0x0080 firstColumn
     //   0x0100 lastColumn 0x0200 noHBand   0x0400 noVBand
-    let look = tbl_pr.and_then(|p| child_w(p, "tblLook"));
-    let look_val: Option<u32> = look
-        .and_then(|l| attr_w(l, "val"))
-        .and_then(|v| u32::from_str_radix(v.trim(), 16).ok());
-    let look_flag = |name: &str, bit: u32| {
-        match look.and_then(|l| attr_w(l, name)).as_deref() {
-            Some("1") | Some("true") | Some("on") => true,
-            Some(_) => false, // explicit "0"/"false" disables regardless of hex
-            None => look_val.map(|v| v & bit != 0).unwrap_or(false),
-        }
-    };
+    let look_flag = |name: &str, bit: u32| tbl_look_flag(tbl_pr, name, bit);
     let first_row = look_flag("firstRow", 0x0020);
     let last_row = look_flag("lastRow", 0x0040);
     let first_col = look_flag("firstColumn", 0x0080);
@@ -8961,6 +9126,17 @@ fn parse_table(
             .get("firstRow")
             .map(|c| c.shd.is_some())
             .unwrap_or(false);
+    // The horizontal-band PARITY ORIGIN belongs to the §17.4.37 logical table's
+    // first member, not to each source table's local tblLook. A later member's
+    // own firstRow flag must not re-shift the shared banding, so gate the origin
+    // offset on the sequence-owned firstRow flag combined with the shared style's
+    // firstRow shading (all members share one effective table style).
+    let sequence_first_row_styled = logical_sequence.sequence_first_row_flag
+        && tstyle
+            .cond
+            .get("firstRow")
+            .map(|c| c.shd.is_some())
+            .unwrap_or(false);
     // firstRow rPr/pPr is honored whenever firstRow is enabled and the style
     // defines ANY firstRow run/para formatting (independent of shading).
     let first_row_has_fmt = first_row
@@ -8969,7 +9145,10 @@ fn parse_table(
             .get("firstRow")
             .map(|c| c.run.is_some() || c.para.is_some())
             .unwrap_or(false);
-    let row_count = tr_nodes.len();
+    debug_assert!(
+        logical_sequence.row_offset.saturating_add(tr_nodes.len()) <= logical_sequence.total_rows,
+        "logical table sequence must contain every authored row"
+    );
 
     // Resolve the ROW-LEVEL conditional keys for row `r` (firstRow/lastRow/
     // band*Horz), LOW→HIGH precedence per §17.7.6. The row's explicit
@@ -8987,17 +9166,21 @@ fn parse_table(
                 .collect();
         }
         let mut out: Vec<&'static str> = Vec::new();
-        let is_first_row = r == 0 && (first_row_styled || first_row_has_fmt || first_row);
-        let is_last_row = last_row && r + 1 == row_count;
+        // §17.4.37: firstRow/lastRow and horizontal banding continue across the
+        // whole logical table, so classify by the row's ordinal within the
+        // shared logical sequence, not within this authored source table.
+        let logical_row = logical_sequence.row_offset.saturating_add(r);
+        let is_first_row = logical_row == 0 && (first_row_styled || first_row_has_fmt || first_row);
+        let is_last_row = last_row && logical_row + 1 == logical_sequence.total_rows;
         // Horizontal banding applies to BODY rows — neither the (styled) first row
         // nor the last row. The banding parity offset only shifts when row 0 was
         // consumed as a SHADED first row; a first row that only carries rPr/pPr
         // (no shd) still bands from row 0 like Word.
         if !is_first_row && !is_last_row && h_band {
-            let bi = if first_row_styled {
-                r as i64 - 1
+            let bi = if sequence_first_row_styled {
+                logical_row as i64 - 1
             } else {
-                r as i64
+                logical_row as i64
             };
             // §17.7.6.7: group consecutive `row_band` body rows into one band
             // before alternating band1/band2.
@@ -9200,7 +9383,7 @@ fn parse_table(
             // for tstyle's borders, banding and cell margins. This keeps
             // the inheritance consistent across all tstyle-derived
             // attributes.
-            effective_table_style_id,
+            effective_table_style_id.as_deref(),
             &cell_conds,
             style_cell_spacing,
             style_cell_margins,
@@ -9377,11 +9560,14 @@ fn parse_table(
         .unwrap_or(0)
         .max(grid_columns.len() as u32);
     let table_layout = TableLayoutAcquisitionWire {
-        effective_style_id: effective_table_style_id.map(str::to_string),
+        effective_style_id: effective_table_style_id,
         ordinary_flow: table_is_ordinary_flow(
             tbl_pr.and_then(|p| child_w(p, "tblpPr")),
             table_positioning_context,
         ),
+        logical_sequence_id: format!("table-sequence:{}", logical_sequence.sequence_id),
+        logical_row_offset: logical_sequence.row_offset,
+        logical_total_rows: logical_sequence.total_rows,
         grid: TableGridAcquisitionWire {
             authored: tbl_grid.is_some(),
             columns: grid_columns,
@@ -9618,7 +9804,20 @@ fn parse_table_cell(
     // A complex field cannot cross a cell boundary in well-formed content, so a
     // cell gets its own field scope (paragraphs within the cell still share it).
     let mut field = FieldState::default();
-    for child in element_children_flat(node) {
+    // §17.4.37 applies inside a cell too: nested source tables use the same
+    // parser-owned membership as body-level tables.
+    let cell_children = element_children_flat(node);
+    let logical_table_children: Vec<_> = cell_children
+        .iter()
+        .copied()
+        .map(|child| (child, false))
+        .collect();
+    let logical_table_sequences = logical_table_sequence_contexts(
+        &logical_table_children,
+        style_map,
+        table_positioning_context,
+    );
+    for child in cell_children {
         match child.tag_name().name() {
             "p" => content.push(CellElement::Paragraph(Box::new(parse_paragraph_cond(
                 child,
@@ -9652,6 +9851,10 @@ fn parse_table_cell(
                         theme,
                         child_depth,
                         table_positioning_context,
+                        logical_table_sequences
+                            .get(&child.id())
+                            .copied()
+                            .unwrap_or_else(|| LogicalTableSequenceContext::standalone(child)),
                     ))));
                 }
             }
@@ -10021,6 +10224,28 @@ mod tests {
             &theme,
             DepthGuard::root(),
             table_positioning_context,
+            LogicalTableSequenceContext::standalone(doc.root_element()),
+        )
+    }
+
+    fn parse_tbl_with_style_map(body: &str, style_map: &StyleMap) -> DocTable {
+        let xml = format!(r#"<w:tbl xmlns:w="{ns}">{body}</w:tbl>"#, ns = W_NS);
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let mut num_map = NumberingMap::default();
+        let media: HashMap<String, String> = HashMap::new();
+        let rels: HashMap<String, String> = HashMap::new();
+        let theme = ThemeColors::default();
+        parse_table(
+            doc.root_element(),
+            style_map,
+            &mut num_map,
+            &media,
+            &HashMap::new(),
+            &rels,
+            &theme,
+            DepthGuard::root(),
+            TablePositioningContext::Normal,
+            LogicalTableSequenceContext::standalone(doc.root_element()),
         )
     }
 
@@ -10050,7 +10275,12 @@ mod tests {
 
     #[test]
     fn table_layout_wire_preserves_authored_grid_width_and_style_facts() {
-        let table = parse_tbl(
+        // §17.4.62/§17.7.4: an explicit table style is effective only when it
+        // resolves to a real `<w:style w:type="table">`. Supply that style so
+        // this wire-preservation test exercises the valid-explicit-style path;
+        // the unresolved/non-table case is asserted separately by
+        // `unresolved_or_non_table_style_is_not_an_effective_grouping_identity`.
+        let table = parse_tbl_with_style_map(
             r#"
             <w:tblPr>
               <w:tblStyle w:val="SyntheticTableStyle"/>
@@ -10089,6 +10319,10 @@ mod tests {
               </w:tc>
             </w:tr>
             "#,
+            &StyleMap::parse(&format!(
+                r#"<w:styles xmlns:w="{ns}"><w:style w:type="table" w:styleId="SyntheticTableStyle"/></w:styles>"#,
+                ns = W_NS,
+            )),
         );
 
         let wire = serde_json::to_value(&table).expect("serialize table layout wire");
@@ -11007,6 +11241,7 @@ mod tests {
             &theme,
             DepthGuard::root(),
             TablePositioningContext::Normal,
+            LogicalTableSequenceContext::standalone(doc.root_element()),
         )
     }
 
@@ -19307,6 +19542,7 @@ mod numbering_marker_font_tests {
             &theme,
             DepthGuard::root(),
             TablePositioningContext::Normal,
+            LogicalTableSequenceContext::standalone(doc.root_element()),
         )
     }
 
@@ -19328,6 +19564,349 @@ mod numbering_marker_font_tests {
             }),
             _ => None,
         })
+    }
+
+    // ------------------------------------------------------------------
+    // ECMA-376 Part 1 §17.4.37 parser-owned logical-table membership.
+    // ------------------------------------------------------------------
+
+    fn logical_sequence_styles() -> StyleMap {
+        StyleMap::parse(&format!(
+            r#"<w:styles xmlns:w="{ns}">
+                <w:style w:type="paragraph" w:default="1" w:styleId="Normal"/>
+                <w:style w:type="table" w:default="1" w:styleId="Sequence">
+                    <w:tblStylePr w:type="firstRow"><w:rPr><w:color w:val="AA0000"/></w:rPr></w:tblStylePr>
+                    <w:tblStylePr w:type="lastRow"><w:rPr><w:color w:val="0000BB"/></w:rPr></w:tblStylePr>
+                    <w:tblStylePr w:type="band1Horz"><w:rPr><w:color w:val="11AA11"/></w:rPr></w:tblStylePr>
+                    <w:tblStylePr w:type="band2Horz"><w:rPr><w:color w:val="BB22BB"/></w:rPr></w:tblStylePr>
+                </w:style>
+                <w:style w:type="table" w:styleId="Other">
+                    <w:tblStylePr w:type="firstRow"><w:rPr><w:color w:val="AA0000"/></w:rPr></w:tblStylePr>
+                    <w:tblStylePr w:type="lastRow"><w:rPr><w:color w:val="0000BB"/></w:rPr></w:tblStylePr>
+                </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        ))
+    }
+
+    fn parse_body_tables(body: &str, styles: &StyleMap) -> Vec<DocTable> {
+        let xml = format!(r#"<w:body xmlns:w="{ns}">{body}</w:body>"#, ns = W_NS);
+        let doc = roxmltree::Document::parse(&xml).unwrap();
+        let mut num_map = NumberingMap::default();
+        parse_body_elements(
+            doc.root_element(),
+            styles,
+            &mut num_map,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .into_iter()
+        .filter_map(|element| match element {
+            BodyElement::Table(table) => Some(*table),
+            _ => None,
+        })
+        .collect()
+    }
+
+    fn one_row_table(tbl_pr: &str, text: &str) -> String {
+        format!(
+            r#"<w:tbl><w:tblPr>{tbl_pr}</w:tblPr><w:tr><w:tc><w:p><w:r><w:t>{text}</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#
+        )
+    }
+
+    fn first_cell_color(table: &DocTable) -> Option<String> {
+        cell_text_color(&table.rows[0].cells[0])
+    }
+
+    #[test]
+    fn adjacent_ordinary_tables_share_logical_outer_rows_with_effective_default_style() {
+        // §17.4.37 treats adjacent ordinary-flow tables with the same effective
+        // table style as one logical table. The style is deliberately implicit
+        // here: both source tables inherit the default table style, so lexical
+        // w:tblStyle equality is not sufficient.
+        let look = r#"<w:tblLook w:firstRow="1" w:lastRow="1" w:noHBand="1"/>"#;
+        let tables = parse_body_tables(
+            &format!(
+                "{}{}",
+                one_row_table(look, "first"),
+                one_row_table(&format!(r#"<w:tblStyle w:val="Sequence"/>{look}"#), "last")
+            ),
+            &logical_sequence_styles(),
+        );
+
+        assert_eq!(tables.len(), 2, "authored table identities are preserved");
+        assert_eq!(first_cell_color(&tables[0]).as_deref(), Some("aa0000"));
+        assert_eq!(first_cell_color(&tables[1]).as_deref(), Some("0000bb"));
+        let first = serde_json::to_value(&tables[0].table_layout).unwrap();
+        let second = serde_json::to_value(&tables[1].table_layout).unwrap();
+        assert_eq!(first["logicalSequenceId"], second["logicalSequenceId"]);
+        assert!(first["logicalSequenceId"]
+            .as_str()
+            .is_some_and(|id| !id.is_empty()));
+        assert_eq!(first["logicalRowOffset"], 0);
+        assert_eq!(second["logicalRowOffset"], 1);
+        assert_eq!(first["logicalTotalRows"], 2);
+        assert_eq!(second["logicalTotalRows"], 2);
+    }
+
+    #[test]
+    fn unresolved_or_non_table_style_is_not_an_effective_grouping_identity() {
+        let styles = StyleMap::parse(&format!(
+            r#"<w:styles xmlns:w="{ns}">
+                <w:style w:type="paragraph" w:styleId="WrongType"/>
+                <w:style w:type="table" w:default="1" w:styleId="DefaultTable"/>
+            </w:styles>"#,
+            ns = W_NS,
+        ));
+        for style_id in ["Missing", "WrongType"] {
+            let tables = parse_body_tables(
+                &format!(
+                    "{}{}",
+                    one_row_table(&format!(r#"<w:tblStyle w:val="{style_id}"/>"#), "a"),
+                    one_row_table(&format!(r#"<w:tblStyle w:val="{style_id}"/>"#), "b"),
+                ),
+                &styles,
+            );
+            assert_eq!(tables.len(), 2);
+            for table in tables {
+                assert_eq!(
+                    table.table_layout.effective_style_id, None,
+                    "§17.4.62 requires the referenced style to exist as a table style",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn adjacent_ordinary_tables_continue_horizontal_row_banding() {
+        let look = r#"<w:tblLook w:firstRow="0" w:lastRow="0"/>"#;
+        let tables = parse_body_tables(
+            &format!(
+                "{}{}",
+                one_row_table(look, "band one"),
+                one_row_table(look, "band two")
+            ),
+            &logical_sequence_styles(),
+        );
+
+        assert_eq!(first_cell_color(&tables[0]).as_deref(), Some("11aa11"));
+        assert_eq!(first_cell_color(&tables[1]).as_deref(), Some("bb22bb"));
+    }
+
+    #[test]
+    fn paragraph_different_style_and_effective_float_break_logical_table_sequences() {
+        let look = r#"<w:tblLook w:firstRow="1" w:lastRow="1" w:noHBand="1"/>"#;
+        let cases = [
+            format!(
+                "{}<w:p/>{}",
+                one_row_table(look, "before paragraph"),
+                one_row_table(look, "after paragraph")
+            ),
+            format!(
+                "{}{}",
+                one_row_table(look, "default style"),
+                one_row_table(
+                    &format!(r#"<w:tblStyle w:val="Other"/>{look}"#),
+                    "other style"
+                )
+            ),
+            format!(
+                "{}{}",
+                one_row_table(look, "ordinary"),
+                one_row_table(
+                    &format!(r#"<w:tblpPr w:tblpX="1"/>{look}"#),
+                    "effective float"
+                )
+            ),
+        ];
+
+        for body in cases {
+            let tables = parse_body_tables(&body, &logical_sequence_styles());
+            assert_eq!(first_cell_color(&tables[0]).as_deref(), Some("0000bb"));
+            assert_eq!(first_cell_color(&tables[1]).as_deref(), Some("0000bb"));
+            assert_ne!(
+                tables[0].table_layout.logical_sequence_id,
+                tables[1].table_layout.logical_sequence_id,
+                "parser-owned membership must retain each §17.4.37 barrier",
+            );
+        }
+    }
+
+    #[test]
+    fn ignored_tblppr_remains_ordinary_for_logical_table_sequence() {
+        // [MS-OI29500] 2.1.162(b-c): this authored positioning payload is
+        // ignored by Word after defaults are resolved. It therefore does not
+        // break the §17.4.37 ordinary-flow sequence merely because tblpPr is
+        // present lexically.
+        let look = r#"<w:tblLook w:firstRow="1" w:lastRow="1" w:noHBand="1"/>"#;
+        let tables = parse_body_tables(
+            &format!(
+                "{}{}",
+                one_row_table(look, "first"),
+                one_row_table(
+                    &format!(
+                        r#"<w:tblpPr w:tblpX="0" w:tblpY="0" w:horzAnchor="text" w:vertAnchor="margin"/>{look}"#
+                    ),
+                    "last"
+                )
+            ),
+            &logical_sequence_styles(),
+        );
+
+        assert_eq!(first_cell_color(&tables[0]).as_deref(), Some("aa0000"));
+        assert_eq!(first_cell_color(&tables[1]).as_deref(), Some("0000bb"));
+        assert_eq!(
+            tables[0].table_layout.logical_sequence_id,
+            tables[1].table_layout.logical_sequence_id,
+        );
+    }
+
+    #[test]
+    fn non_paragraph_range_markup_does_not_intervene_in_logical_table_sequence() {
+        // §17.4.37 says specifically that an intervening p separates tables;
+        // range markup between two block elements is not a paragraph and must
+        // not change their logical row ordinals.
+        let look = r#"<w:tblLook w:firstRow="1" w:lastRow="1" w:noHBand="1"/>"#;
+        let tables = parse_body_tables(
+            &format!(
+                r#"{}<w:bookmarkStart w:id="0" w:name="between"/>{}"#,
+                one_row_table(look, "first"),
+                one_row_table(look, "last")
+            ),
+            &logical_sequence_styles(),
+        );
+
+        assert_eq!(first_cell_color(&tables[0]).as_deref(), Some("aa0000"));
+        assert_eq!(first_cell_color(&tables[1]).as_deref(), Some("0000bb"));
+    }
+
+    #[test]
+    fn adjacent_nested_tables_share_logical_outer_rows() {
+        let look = r#"<w:tblLook w:firstRow="1" w:lastRow="1" w:noHBand="1"/>"#;
+        let outer = parse_tbl_styled(
+            &format!(
+                r#"<w:tr><w:tc>{}{}</w:tc></w:tr>"#,
+                one_row_table(look, "nested first"),
+                one_row_table(look, "nested last")
+            ),
+            &logical_sequence_styles(),
+        );
+        let nested: Vec<&DocTable> = outer.rows[0].cells[0]
+            .content
+            .iter()
+            .filter_map(|element| match element {
+                CellElement::Table(table) => Some(table.as_ref()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            nested.len(),
+            2,
+            "authored nested table identities remain distinct"
+        );
+        assert_eq!(first_cell_color(nested[0]).as_deref(), Some("aa0000"));
+        assert_eq!(first_cell_color(nested[1]).as_deref(), Some("0000bb"));
+        let first = serde_json::to_value(&nested[0].table_layout).unwrap();
+        let second = serde_json::to_value(&nested[1].table_layout).unwrap();
+        assert_eq!(first["logicalSequenceId"], second["logicalSequenceId"]);
+        assert_eq!(first["logicalRowOffset"], 0);
+        assert_eq!(second["logicalRowOffset"], 1);
+        assert_eq!(first["logicalTotalRows"], 2);
+        assert_eq!(second["logicalTotalRows"], 2);
+    }
+
+    #[test]
+    fn absent_effective_style_identity_does_not_form_a_logical_table_sequence() {
+        let body = format!(
+            r#"<w:body xmlns:w="{ns}">{}{}</w:body>"#,
+            one_row_table("", "first"),
+            one_row_table("", "second"),
+            ns = W_NS
+        );
+        let doc = roxmltree::Document::parse(&body).unwrap();
+        let children = body_children_with_cover_breaks(doc.root_element());
+        let contexts = logical_table_sequence_contexts(
+            &children,
+            &StyleMap::parse(""),
+            TablePositioningContext::Normal,
+        );
+
+        for (table, _) in children {
+            let context = contexts.get(&table.id()).expect("table context");
+            assert_eq!(*context, LogicalTableSequenceContext::standalone(table));
+        }
+    }
+
+    #[test]
+    fn body_level_sect_pr_breaks_logical_table_sequence() {
+        // §17.6.1: a section boundary between two tables prevents them from
+        // becoming one §17.4.37 logical table even when style and flow match.
+        let look = r#"<w:tblLook w:firstRow="1" w:lastRow="1" w:noHBand="1"/>"#;
+        let tables = parse_body_tables(
+            &format!(
+                r#"{}<w:sectPr><w:type w:val="continuous"/></w:sectPr>{}"#,
+                one_row_table(look, "before section"),
+                one_row_table(look, "after section")
+            ),
+            &logical_sequence_styles(),
+        );
+
+        assert_eq!(tables.len(), 2);
+        assert_ne!(
+            tables[0].table_layout.logical_sequence_id,
+            tables[1].table_layout.logical_sequence_id,
+        );
+    }
+
+    fn phase_styles() -> StyleMap {
+        StyleMap::parse(&format!(
+            r#"<w:styles xmlns:w="{ns}">
+                <w:style w:type="paragraph" w:default="1" w:styleId="Normal"/>
+                <w:style w:type="table" w:default="1" w:styleId="Phase">
+                    <w:tblStylePr w:type="firstRow"><w:tcPr><w:shd w:val="clear" w:fill="FF0000"/></w:tcPr></w:tblStylePr>
+                    <w:tblStylePr w:type="band1Horz"><w:rPr><w:color w:val="11AA11"/></w:rPr></w:tblStylePr>
+                    <w:tblStylePr w:type="band2Horz"><w:rPr><w:color w:val="BB22BB"/></w:rPr></w:tblStylePr>
+                </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        ))
+    }
+
+    fn two_row_table(tbl_pr: &str) -> String {
+        let tr = "<w:tr><w:tc><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr>".repeat(2);
+        format!(r#"<w:tbl><w:tblPr>{tbl_pr}</w:tblPr>{tr}</w:tbl>"#)
+    }
+
+    fn row_color(table: &DocTable, row: usize) -> Option<String> {
+        cell_text_color(&table.rows[row].cells[0])
+    }
+
+    #[test]
+    fn horizontal_band_parity_origin_is_owned_by_the_logical_sequence_first_member() {
+        // The first member activates a shaded firstRow, so the logical table's
+        // horizontal-band parity origins after logical row 0. The second member
+        // turns firstRow OFF via its own tblLook; that LOCAL flag must not
+        // re-phase the shared banding. Logical rows 0(firstRow) 1 2 3 must band
+        // 1,2,1 across the seam — not restart at the second member.
+        let tables = parse_body_tables(
+            &format!(
+                "{}{}",
+                two_row_table(r#"<w:tblLook w:firstRow="1" w:lastRow="0"/>"#),
+                two_row_table(r#"<w:tblLook w:firstRow="0" w:lastRow="0"/>"#)
+            ),
+            &phase_styles(),
+        );
+
+        assert_eq!(tables.len(), 2);
+        // logical row 1 (first member body row): band1.
+        assert_eq!(row_color(&tables[0], 1).as_deref(), Some("11aa11"));
+        // logical rows 2 and 3 (second member) continue the sequence's parity.
+        assert_eq!(row_color(&tables[1], 0).as_deref(), Some("bb22bb"));
+        assert_eq!(row_color(&tables[1], 1).as_deref(), Some("11aa11"));
     }
 
     // A cell carrying an explicit firstCol cnfStyle (`001000000000`) on its tcPr

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -444,6 +444,17 @@ impl StyleMap {
         self.default_table_style_id.as_deref()
     }
 
+    /// Whether `style_id` names an existing `<w:style w:type="table">`. Only
+    /// table-typed styles are indexed in `table_styles`, so this rejects both a
+    /// dangling reference and a reference to a paragraph/character style. Used
+    /// by ECMA-376 Part 1 §17.4.37 logical-table membership: an explicit but
+    /// unresolved or non-table style is not a valid grouping identity. This
+    /// does not alter the omitted-style / default-table-style policy, which
+    /// remains owned by `default_table_style_id`.
+    pub fn contains_table_style(&self, style_id: &str) -> bool {
+        self.table_styles.contains_key(style_id)
+    }
+
     pub fn parse(xml: &str) -> Self {
         let doc = match parse_guarded(xml) {
             Ok(d) => d,

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -2688,6 +2688,14 @@ pub struct TableLayoutAcquisitionWire {
     /// authored positioning payload, whose mere presence is not an effective
     /// floating-status test ([MS-OI29500] 2.1.162(b-c)).
     pub ordinary_flow: bool,
+    /// Parser-owned ECMA-376 Part 1 §17.4.37 logical-table membership. One id is
+    /// assigned per logical table; a standalone table receives its own id, so
+    /// directly adjacent source tables carrying the same id form one logical
+    /// table. `logical_row_offset`/`logical_total_rows` place this source table's
+    /// rows inside that logical table's row sequence.
+    pub logical_sequence_id: String,
+    pub logical_row_offset: usize,
+    pub logical_total_rows: usize,
     pub grid: TableGridAcquisitionWire,
     pub preferred_width: Option<TableWidthAcquisitionWire>,
     pub layout: Option<TableLayoutKindAcquisitionWire>,

--- a/packages/docx/src/layout/adjacent-table-layout-input.test.ts
+++ b/packages/docx/src/layout/adjacent-table-layout-input.test.ts
@@ -1,0 +1,633 @@
+import { describe, expect, it } from 'vitest';
+import { tableColumnLayoutInput } from '../parser-model.js';
+import type { DocTable } from '../types.js';
+import {
+  adjacentTableSymbolNodeCountForTest,
+  combineAdjacentTableLayoutInputs,
+  type AdjacentTableGroupLayoutInput,
+} from './adjacent-table-layout-input.js';
+import { resolveTableColumnLayout } from './table-columns.js';
+import { stableFingerprint } from './fingerprint.js';
+import type {
+  TableBorderInput,
+  TableEdgeInputs,
+  TableLayoutInput,
+  TableRowLayoutInput,
+} from './types.js';
+
+// This suite verifies the transient union-grid BUILDER output only. The builder
+// is a deterministic internal layout policy (§17.4.37 does not define grid
+// reconciliation) and is intentionally decoupled from paint/pagination, so the
+// tests inspect the produced TableLayoutInput directly.
+
+const source = (tableIndex: number, rowIndex?: number) => ({
+  story: 'body' as const,
+  storyInstance: 'body',
+  path: rowIndex == null ? [tableIndex] : [tableIndex, rowIndex],
+});
+
+const border = (widthPt: number, color: string): TableBorderInput => ({
+  widthPt, color, authoredStyle: 'single',
+});
+
+const edges = (overrides: Partial<TableEdgeInputs> = {}): TableEdgeInputs => ({
+  top: null, right: null, bottom: null, left: null, insideH: null, insideV: null,
+  ...overrides,
+});
+
+function row(tableIndex: number, widthCount: number): TableRowLayoutInput {
+  return {
+    id: `table:${tableIndex}:row:0`, source: source(tableIndex, 0), logicalRowIndex: 0,
+    cantSplit: false, heightPt: 10, heightRule: 'exact', cellSpacingPt: 0,
+    exceptionBorders: null, alignment: 'left', indentPt: 0, repeatedHeader: false,
+    cells: [{
+      id: `table:${tableIndex}:cell:0`, source: { ...source(tableIndex, 0), path: [tableIndex, 0, 0] },
+      columnStart: 0, columnSpan: widthCount, verticalMerge: 'none',
+      margins: { topPt: 0, rightPt: 0, bottomPt: 0, leftPt: 0 },
+      vAlign: 'top', borders: edges(), blocks: [],
+    }],
+  };
+}
+
+function tableInput(
+  tableIndex: number,
+  widths: readonly number[],
+  tableEdges: TableEdgeInputs = edges(),
+): TableLayoutInput {
+  return {
+    kind: 'table', id: `table:${tableIndex}`, source: source(tableIndex),
+    flowDomainId: `table:${tableIndex}`, ordinaryFlow: true,
+    alignment: 'left', indentPt: 0, bidiVisual: false,
+    columnWidthsPt: widths, borders: tableEdges,
+    rows: [row(tableIndex, widths.length)],
+  };
+}
+
+/** Build a source TableLayoutInput whose column topology carries the exact
+ * authored grid identity, exercising the exact-length seam of the union. */
+function lexicalGridTableInput(tableIndex: number, widths: readonly string[]): TableLayoutInput {
+  const sourceTable = {
+    colWidths: [],
+    rows: [{
+      cells: [{
+        content: [], colSpan: widths.length, vMerge: null, borders: edges(),
+        background: null, vAlign: 'top', widthPt: null,
+      }],
+      gridBefore: 0, gridAfter: 0, isHeader: false, cantSplit: false,
+    }],
+    borders: edges(),
+    cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+    jc: 'left',
+    __tableLayout: {
+      effectiveStyleId: 'SharedStyle', ordinaryFlow: true,
+      logicalSequenceId: 'table-sequence:0',
+      logicalRowOffset: tableIndex, logicalTotalRows: 2,
+      grid: {
+        authored: true,
+        columns: widths.map((width) => ({ width })),
+        requiredColumnCount: widths.length,
+      },
+      preferredWidth: null, layout: { kind: 'fixed' }, cellSpacing: null,
+    },
+  } as unknown as DocTable;
+  const resolved = resolveTableColumnLayout(tableColumnLayoutInput(
+    sourceTable,
+    1000,
+    () => ({ minWidthPt: 0, maxWidthPt: 0 }),
+  ));
+  return {
+    ...tableInput(tableIndex, resolved.widthsPt),
+    columnWidthKeys: resolved.widthKeys,
+  };
+}
+
+function resolvedLexicalGrid(tableIndex: number, widths: readonly string[]): TableLayoutInput {
+  return lexicalGridTableInput(tableIndex, widths);
+}
+
+/** A source table with one cell per column, for per-cell tiling assertions. */
+function tiledTableInput(
+  tableIndex: number,
+  widths: readonly number[],
+  overrides: Partial<TableLayoutInput> = {},
+): TableLayoutInput {
+  const cells = widths.map((_width, column) => ({
+    id: `table:${tableIndex}:cell:${column}`,
+    source: { ...source(tableIndex, 0), path: [tableIndex, 0, column] },
+    columnStart: column, columnSpan: 1, verticalMerge: 'none' as const,
+    margins: { topPt: 0, rightPt: 0, bottomPt: 0, leftPt: 0 },
+    vAlign: 'top' as const, borders: edges(), blocks: [],
+  }));
+  return {
+    ...tableInput(tableIndex, widths),
+    ...overrides,
+    rows: [{ ...row(tableIndex, widths.length), cells }],
+  };
+}
+
+function cellIntervals(
+  combined: AdjacentTableGroupLayoutInput,
+  rowIndex: number,
+): [number, number][] {
+  return (combined.rows[rowIndex]?.cells ?? []).map((cell) => (
+    [cell.columnStart, cell.columnStart + cell.columnSpan]
+  ));
+}
+
+function rowCellWidths(combined: AdjacentTableGroupLayoutInput, rowIndex: number): number[] {
+  return (combined.rows[rowIndex]?.cells ?? []).map((cell) => {
+    let sum = 0;
+    for (let column = cell.columnStart; column < cell.columnStart + cell.columnSpan; column += 1) {
+      sum += combined.columnWidthsPt[column] ?? 0;
+    }
+    return sum;
+  });
+}
+
+function assertContiguousTiling(combined: AdjacentTableGroupLayoutInput, rowIndex: number): void {
+  const sorted = [...(combined.rows[rowIndex]?.cells ?? [])]
+    .sort((left, right) => left.columnStart - right.columnStart);
+  for (let index = 1; index < sorted.length; index += 1) {
+    expect(sorted[index]!.columnStart)
+      .toBe(sorted[index - 1]!.columnStart + sorted[index - 1]!.columnSpan);
+  }
+}
+
+describe('adjacent-table logical layout input (transient union grid)', () => {
+  it('rejects an empty group or a positioned member', () => {
+    expect(() => combineAdjacentTableLayoutInputs('', [tableInput(0, [80])])).toThrow(/group id/);
+    expect(() => combineAdjacentTableLayoutInputs('group:0', [])).toThrow(/at least one/);
+    const floating: TableLayoutInput = { ...tableInput(0, [80]), ordinaryFlow: false };
+    expect(() => combineAdjacentTableLayoutInputs('group:0', [floating, tableInput(1, [80])]))
+      .toThrow(/absolutely positioned/);
+  });
+
+  it('uses exact grid identity when equivalent boundaries have different addition paths', () => {
+    const split = lexicalGridTableInput(0, ['1', '2']);
+    const whole = lexicalGridTableInput(1, ['3']);
+
+    const combined = combineAdjacentTableLayoutInputs('group:exact', [split, whole]);
+
+    expect(combined.columnWidthsPt).toEqual([0.05, 0.1]);
+    expect(combined.columnWidthKeys).toEqual(['1/20', '1/10']);
+    expect(structuredClone(combined).columnWidthKeys).toEqual(['1/20', '1/10']);
+    expect(stableFingerprint('adjacent-grid', combined)).toBe(
+      stableFingerprint('adjacent-grid', structuredClone(combined)),
+    );
+    expect(combined.rows[0]?.cells[0]).toMatchObject({ columnStart: 0, columnSpan: 2 });
+    expect(combined.rows[1]?.cells[0]).toMatchObject({ columnStart: 0, columnSpan: 2 });
+  });
+
+  it('preserves genuinely distinct exact boundaries even when both round to one paint coordinate', () => {
+    const lower = {
+      ...tableInput(0, [0.15]),
+      columnWidthKeys: ['3/20'],
+    } as TableLayoutInput;
+    const higher = {
+      ...tableInput(1, [0.15]),
+      columnWidthKeys: ['150000000000000001/1000000000000000000'],
+    } as TableLayoutInput;
+
+    const combined = combineAdjacentTableLayoutInputs('group:close', [lower, higher]);
+
+    expect(combined.columnWidthKeys).toEqual([
+      '3/20',
+      '1/1000000000000000000',
+    ]);
+    expect(combined.columnWidthsPt).toHaveLength(2);
+  });
+
+  it('keeps distinct over-budget tracks unknown and prevents false boundary merges', () => {
+    const first = resolvedLexicalGrid(0, [`72.${'0'.repeat(800)}1pt`]);
+    const second = resolvedLexicalGrid(1, [`72.${'0'.repeat(800)}2pt`]);
+
+    expect(first.columnWidthKeys).toEqual([null]);
+    expect(second.columnWidthKeys).toEqual([null]);
+    const combined = combineAdjacentTableLayoutInputs('group:unknown-distinct', [first, second]);
+
+    expect(combined.columnWidthsPt).toEqual([72, 0]);
+    expect(combined.columnWidthKeys).toEqual([null, null]);
+    expect(combined.rows[0]?.cells[0].columnSpan).toBe(1);
+    expect(combined.rows[1]?.cells[0].columnSpan).toBe(2);
+  });
+
+  it('fails closed for identical over-budget tracks from different source tables', () => {
+    const lexical = `72.${'0'.repeat(800)}1pt`;
+    const combined = combineAdjacentTableLayoutInputs('group:unknown-identical', [
+      resolvedLexicalGrid(0, [lexical]),
+      resolvedLexicalGrid(1, [lexical]),
+    ]);
+
+    expect(combined.columnWidthsPt).toEqual([72, 0]);
+    expect(combined.columnWidthKeys).toEqual([null, null]);
+    expect(combined.rows[0]?.cells[0].columnSpan).not.toBe(
+      combined.rows[1]?.cells[0].columnSpan,
+    );
+  });
+
+  it('does not merge an exact boundary with unknown geometry at the same coordinate', () => {
+    const unknown = resolvedLexicalGrid(1, [`72.${'0'.repeat(800)}1pt`]);
+    const combined = combineAdjacentTableLayoutInputs('group:exact-unknown', [
+      lexicalGridTableInput(0, ['72pt']),
+      unknown,
+    ]);
+
+    expect(combined.columnWidthsPt).toEqual([72, 0]);
+    expect(combined.columnWidthKeys).toEqual(['72/1', null]);
+  });
+
+  it('aligns repeated rows from the same unknown source topology', () => {
+    const source = resolvedLexicalGrid(0, [`72.${'0'.repeat(800)}1pt`]);
+    const repeated: TableLayoutInput = { ...source, rows: [source.rows[0]!, source.rows[0]!] };
+    const combined = combineAdjacentTableLayoutInputs('group:unknown-rows', [
+      repeated,
+      lexicalGridTableInput(1, ['72pt']),
+    ]);
+
+    expect(combined.rows[0]?.cells[0]).toMatchObject({ columnStart: 0, columnSpan: 1 });
+    expect(combined.rows[1]?.cells[0]).toMatchObject({
+      columnStart: combined.rows[0]?.cells[0].columnStart,
+      columnSpan: combined.rows[0]?.cells[0].columnSpan,
+    });
+  });
+
+  it('cancels an RTL source unknown symbol when mirrored into its own group frame', () => {
+    const unknown = resolvedLexicalGrid(0, [`72.${'0'.repeat(800)}1pt`]);
+    const rtl: TableLayoutInput = { ...unknown, bidiVisual: true };
+    const combined = combineAdjacentTableLayoutInputs('group:rtl-unknown', [rtl]);
+
+    expect(combined.columnWidthsPt).toEqual([72]);
+    expect(combined.columnWidthKeys).toEqual([null]);
+    expect(combined.rows[0]?.cells[0]).toMatchObject({ columnStart: 0, columnSpan: 1 });
+  });
+
+  it('uses deterministic symbolic half-boundaries for centered unknown rows that tile', () => {
+    const unknown = resolvedLexicalGrid(0, [`72.${'0'.repeat(800)}1pt`]);
+    const centered: TableLayoutInput = {
+      ...unknown,
+      rows: [unknown.rows[0]!, { ...unknown.rows[0]!, alignment: 'center' }],
+    };
+    const combined = combineAdjacentTableLayoutInputs('group:center-unknown', [
+      lexicalGridTableInput(1, ['144pt']),
+      centered,
+    ]);
+
+    expect(combined.columnWidthsPt).toEqual([36, 36, 36, 36]);
+    expect(combined.columnWidthKeys).toEqual([null, null, null, null]);
+    assertContiguousTiling(combined, 1);
+    assertContiguousTiling(combined, 2);
+  });
+
+  it('orders an RTL run of distinct unknown zero boundaries from row constraints', () => {
+    const rtl = tiledTableInput(1, [0, 0], {
+      bidiVisual: true,
+      columnWidthKeys: [null, null],
+    });
+    const combined = combineAdjacentTableLayoutInputs('group:rtl-zero-unknown', [
+      tableInput(0, [80]),
+      rtl,
+    ]);
+
+    expect(combined.columnWidthsPt).toEqual([0, 0, 80]);
+    expect(combined.columnWidthKeys).toEqual([null, null, null]);
+    expect(cellIntervals(combined, 1)).toEqual([[1, 2], [0, 1]]);
+    expect(combined.rows[0]?.cells[0]).toMatchObject({ columnStart: 0, columnSpan: 3 });
+  });
+
+  it('preserves parser-model over-budget underflow zero tracks through RTL ordering', () => {
+    const underflow = `0.${'0'.repeat(1200)}1pt`;
+    const resolved = resolvedLexicalGrid(1, [underflow, underflow]);
+    expect(resolved.columnWidthsPt).toEqual([0, 0]);
+    expect(resolved.columnWidthKeys).toEqual([null, null]);
+    const rtl = tiledTableInput(1, resolved.columnWidthsPt, {
+      bidiVisual: true,
+      columnWidthKeys: resolved.columnWidthKeys,
+    });
+
+    const combined = combineAdjacentTableLayoutInputs('group:rtl-parser-zero', [
+      tableInput(0, [80]),
+      rtl,
+    ]);
+
+    expect(combined.columnWidthsPt).toEqual([0, 0, 80]);
+    expect(combined.columnWidthKeys).toEqual([null, null, null]);
+    expect(cellIntervals(combined, 1)).toEqual([[1, 2], [0, 1]]);
+  });
+
+  it('keeps symbolic node growth linear in unknown tracks and row boundaries', () => {
+    const nodesFor = (count: number): number => {
+      const unknown = tableInput(1, Array.from({ length: count }, () => 0));
+      const input: TableLayoutInput = {
+        ...unknown,
+        columnWidthKeys: Array.from({ length: count }, () => null),
+      };
+      combineAdjacentTableLayoutInputs(`group:complexity:${count}`, [tableInput(0, [80]), input]);
+      return adjacentTableSymbolNodeCountForTest();
+    };
+
+    const small = nodesFor(100);
+    const large = nodesFor(2000);
+    expect(small).toBeLessThanOrEqual(8 * 100 + 64);
+    expect(large).toBeLessThanOrEqual(8 * 2000 + 64);
+    expect(large / small).toBeLessThanOrEqual(25);
+  });
+
+  it('unifies source grids while retaining authored row and cell identity', () => {
+    const combined = combineAdjacentTableLayoutInputs('group:0', [
+      tableInput(0, [80]),
+      tableInput(1, [80, 80]),
+    ]);
+
+    expect(combined.columnWidthsPt).toEqual([80, 80]);
+    expect(combined.id).toBe('group:0');
+    // Authored SourceRef paths and per-row identity are untouched by the union.
+    expect(combined.rows.map((entry) => ({
+      path: entry.source.path,
+      logicalRowIndex: entry.logicalRowIndex,
+      cell: [entry.cells[0]?.columnStart, entry.cells[0]?.columnSpan],
+      outer: [entry.sourceOuterColumnStart, entry.sourceOuterColumnEnd],
+    }))).toEqual([
+      { path: [0, 0], logicalRowIndex: 0, cell: [0, 1], outer: [0, 1] },
+      { path: [1, 0], logicalRowIndex: 1, cell: [0, 2], outer: [0, 2] },
+    ]);
+  });
+
+  it('folds each source seam into row-scoped insideH exception borders', () => {
+    const inside = border(1, '#111111');
+    const combined = combineAdjacentTableLayoutInputs('group:0', [
+      tableInput(0, [80], edges({ bottom: border(4, '#ff0000'), insideH: inside })),
+      tableInput(1, [80], edges({ top: border(5, '#0000ff'), insideH: inside })),
+    ]);
+
+    // The group grid has no whole-table border; each source table's borders are
+    // folded onto its own row in the dedicated sourceTableEdges layer, and the
+    // row's own exceptionBorders slot is fixed null.
+    expect(combined.rows[0]?.exceptionBorders).toBeNull();
+    expect(combined.rows[0]?.sourceTableEdges).toMatchObject({
+      bottom: { color: '#ff0000', widthPt: 4 }, insideH: { color: '#111111', widthPt: 1 },
+    });
+    expect(combined.rows[1]?.sourceTableEdges).toMatchObject({
+      top: { color: '#0000ff', widthPt: 5 }, insideH: { color: '#111111', widthPt: 1 },
+    });
+  });
+
+  it('cascades a row-exception none border through to its source table border, and nil suppresses it', () => {
+    const base = tableInput(0, [80], edges({ right: border(2, '#ff0000') }));
+    const withNone: TableLayoutInput = {
+      ...base,
+      rows: base.rows.map((entry) => ({
+        ...entry,
+        exceptionBorders: edges({ right: { widthPt: 0, color: '#000000', authoredStyle: 'none' } }),
+      })),
+    };
+    const withNil: TableLayoutInput = {
+      ...base,
+      rows: base.rows.map((entry) => ({
+        ...entry,
+        exceptionBorders: edges({ right: { widthPt: 0, color: '#000000', authoredStyle: 'nil' } }),
+      })),
+    };
+
+    const noneCombined = combineAdjacentTableLayoutInputs('group:none', [withNone, tableInput(1, [80])]);
+    // [MS-OI29500] 2.1.169: none falls through to the source table border.
+    expect(noneCombined.rows[0]?.sourceTableEdges.right).toMatchObject({ color: '#ff0000', widthPt: 2 });
+
+    const nilCombined = combineAdjacentTableLayoutInputs('group:nil', [withNil, tableInput(1, [80])]);
+    // nil is an authored suppression: it is retained (not replaced by the
+    // source table border) so downstream border resolution suppresses the edge.
+    expect(nilCombined.rows[0]?.sourceTableEdges.right).toMatchObject({
+      authoredStyle: 'nil', widthPt: 0,
+    });
+  });
+
+  it('maps a narrower centered row into the shared grid without changing its width', () => {
+    const narrow = tableInput(0, [80]);
+    const centered: TableLayoutInput = {
+      ...narrow,
+      rows: narrow.rows.map((entry) => ({ ...entry, alignment: 'center' })),
+    };
+    const combined = combineAdjacentTableLayoutInputs('group:0', [
+      centered,
+      tableInput(1, [80, 80]),
+    ]);
+
+    expect(combined.columnWidthsPt).toEqual([40, 40, 40, 40]);
+    // The centered narrow row occupies the middle physical interval [1,3).
+    expect(combined.rows[0]?.cells[0]).toMatchObject({ columnStart: 1, columnSpan: 2 });
+    expect([combined.rows[0]?.sourceOuterColumnStart, combined.rows[0]?.sourceOuterColumnEnd])
+      .toEqual([1, 3]);
+    expect(combined.rows[1]?.cells[0]).toMatchObject({ columnStart: 0, columnSpan: 4 });
+  });
+
+  it('normalizes a source row indent into the group frame, mirroring it only on a bidi mismatch', () => {
+    const wide = tableInput(0, [80, 80]); // group frame is LTR (first table)
+    const ltrNarrow: TableLayoutInput = {
+      ...tableInput(1, [80]),
+      rows: tableInput(1, [80]).rows.map((entry) => ({ ...entry, indentPt: 6 })),
+    };
+    // Same bidi as the group frame: the indent is already group-oriented.
+    const ltr = combineAdjacentTableLayoutInputs('group:ltr', [wide, ltrNarrow]);
+    expect(ltr.rows[1]?.indentPt).toBe(6);
+    expect('sourcePhysicalIndentPt' in ltr.rows[1]!).toBe(false);
+
+    // Source bidi differs from the group frame: re-orient into the group frame.
+    const rtlNarrow: TableLayoutInput = { ...ltrNarrow, bidiVisual: true };
+    const rtl = combineAdjacentTableLayoutInputs('group:rtl', [wide, rtlNarrow]);
+    expect(rtl.rows[1]?.indentPt).toBe(-6);
+  });
+
+  it('preserves a source table zero-width track through the multiset union', () => {
+    // A set-based union would collapse the two coincident 80pt boundaries and
+    // drop the middle zero-width column; the multiset keeps its multiplicity.
+    const withZeroTrack = tableInput(0, [80, 0, 80]);
+    const plain = tableInput(1, [160]);
+
+    const combined = combineAdjacentTableLayoutInputs('group:zero', [withZeroTrack, plain]);
+
+    expect(combined.columnWidthsPt).toEqual([80, 0, 80]);
+    expect(combined.columnWidthKeys).toEqual(['80/1', '0/1', '80/1']);
+    // Both source rows span the full three-column union including the zero track.
+    expect(combined.rows[0]?.cells[0]).toMatchObject({ columnStart: 0, columnSpan: 3 });
+    expect([combined.rows[0]?.sourceOuterColumnStart, combined.rows[0]?.sourceOuterColumnEnd])
+      .toEqual([0, 3]);
+    expect(combined.rows[1]?.cells[0]).toMatchObject({ columnStart: 0, columnSpan: 3 });
+  });
+
+  it('maps a resolved gridBefore/gridSpan cell to the correct union interval', () => {
+    // Simulate a row whose acquisition already resolved gridBefore=1 and a
+    // gridSpan=2 cell into columnStart=1, columnSpan=2 over a 3-column grid.
+    const spanned: TableLayoutInput = {
+      ...tableInput(0, [40, 40, 40]),
+      rows: [{
+        ...row(0, 3),
+        cells: [{
+          id: 'table:0:cell:0', source: source(0, 0),
+          columnStart: 1, columnSpan: 2, verticalMerge: 'none',
+          margins: { topPt: 0, rightPt: 0, bottomPt: 0, leftPt: 0 },
+          vAlign: 'top', borders: edges(), blocks: [],
+        }],
+      }],
+    };
+    const combined = combineAdjacentTableLayoutInputs('group:span', [spanned, tableInput(1, [120])]);
+
+    expect(combined.columnWidthsPt).toEqual([40, 40, 40]);
+    expect(combined.rows[0]?.cells[0]).toMatchObject({ columnStart: 1, columnSpan: 2 });
+    expect([combined.rows[0]?.sourceOuterColumnStart, combined.rows[0]?.sourceOuterColumnEnd])
+      .toEqual([0, 3]);
+  });
+
+  it('retains physical outer-edge column ownership when the group is bidiVisual', () => {
+    const rtlWide: TableLayoutInput = { ...tableInput(0, [80, 80]), bidiVisual: true };
+    const ltrNarrow = tableInput(1, [80], edges({
+      left: border(2, '#ff0000'),
+      right: border(3, '#0000ff'),
+    }));
+    const rightAligned: TableLayoutInput = {
+      ...ltrNarrow,
+      rows: ltrNarrow.rows.map((entry) => ({ ...entry, alignment: 'right' })),
+    };
+
+    const combined = combineAdjacentTableLayoutInputs('group:0', [rtlWide, rightAligned]);
+    // In the bidiVisual group grid, the right-aligned narrow source table's
+    // outer interval maps to logical columns [0,1) (its physical right edge is
+    // the group's logical start). Its left/right borders were mirrored to stay
+    // physical.
+    expect([combined.rows[1]?.sourceOuterColumnStart, combined.rows[1]?.sourceOuterColumnEnd])
+      .toEqual([0, 1]);
+    expect(combined.rows[1]?.sourceTableEdges).toMatchObject({
+      left: { color: '#0000ff' },
+      right: { color: '#ff0000' },
+    });
+  });
+
+  it('maps a mirrored zero-track source table by orientation, not by coordinate', () => {
+    // [40,0,0,40] has three coincident interior boundaries. The mapping must
+    // depend on bidi orientation (source vs group), never on the coordinates.
+    const ascending = combineAdjacentTableLayoutInputs('group:asc', [
+      tableInput(0, [80]),
+      tiledTableInput(1, [40, 0, 0, 40]),
+    ]);
+    expect(ascending.columnWidthsPt).toEqual([40, 0, 0, 40]);
+    expect(cellIntervals(ascending, 1)).toEqual([[0, 1], [1, 2], [2, 3], [3, 4]]);
+    assertContiguousTiling(ascending, 1);
+
+    // Same source, but bidi-mismatched with the group frame: its source-order
+    // boundaries descend, so it takes the group's HIGH occurrences and its cells
+    // tile the union in reversed physical order.
+    const descending = combineAdjacentTableLayoutInputs('group:desc', [
+      tableInput(0, [80]),
+      tiledTableInput(1, [40, 0, 0, 40], { bidiVisual: true }),
+    ]);
+    expect(descending.columnWidthsPt).toEqual([40, 0, 0, 40]);
+    expect(cellIntervals(descending, 1)).toEqual([[3, 4], [2, 3], [1, 2], [0, 1]]);
+    assertContiguousTiling(descending, 1);
+  });
+
+  it('tiles an all-zero-width source table consistently in both orientations', () => {
+    const ascending = combineAdjacentTableLayoutInputs('group:z-asc', [
+      tableInput(0, [80]),
+      tiledTableInput(1, [0, 0, 0]),
+    ]);
+    const descending = combineAdjacentTableLayoutInputs('group:z-desc', [
+      tableInput(0, [80]),
+      tiledTableInput(1, [0, 0, 0], { bidiVisual: true }),
+    ]);
+    expect(ascending.columnWidthsPt).toEqual([0, 0, 0, 80]);
+    expect(descending.columnWidthsPt).toEqual([0, 0, 0, 80]);
+    expect(cellIntervals(ascending, 1)).toEqual([[0, 1], [1, 2], [2, 3]]);
+    expect(cellIntervals(descending, 1)).toEqual([[2, 3], [1, 2], [0, 1]]);
+    assertContiguousTiling(ascending, 1);
+    assertContiguousTiling(descending, 1);
+  });
+
+  it('preserves each source tiling when adjacent tables have mismatched zero-track multiplicity', () => {
+    // Table A places two boundaries at 40; table B places three. The union keeps
+    // the max (three); each source still tiles its own row without gaps.
+    const combined = combineAdjacentTableLayoutInputs('group:mult', [
+      tiledTableInput(0, [40, 0, 40]),
+      tiledTableInput(1, [40, 0, 0, 40]),
+    ]);
+    expect(combined.columnWidthsPt).toEqual([40, 0, 0, 40]);
+    assertContiguousTiling(combined, 0);
+    assertContiguousTiling(combined, 1);
+    // Each row's cell widths sum to the group width and each authored width
+    // survives (multiplicities differ, geometry does not).
+    expect(rowCellWidths(combined, 0)).toEqual([40, 0, 40]);
+    expect(rowCellWidths(combined, 1)).toEqual([40, 0, 0, 40]);
+  });
+
+  it('carries acquisition-resolved gridBefore/gridAfter zero tracks through the union', () => {
+    // Full path: authored:false grid with an omitted-width gridBefore and a
+    // symmetric gridAfter -> tableColumnLayoutInput -> resolveTableColumnLayout
+    // -> union builder. The empty leading/trailing tracks are zero-width and
+    // must survive; the content cell keeps its offset; both tables share a seam.
+    const contentCell = {
+      content: [], colSpan: 1, vMerge: null, borders: edges(),
+      background: null, vAlign: 'top', widthPt: 40, widthPct: null,
+    };
+    const acquired = {
+      colWidths: [],
+      rows: [{
+        gridBefore: 1, gridAfter: 1,
+        cells: [contentCell], rowHeight: null, rowHeightRule: 'auto', isHeader: false,
+      }],
+      borders: edges(),
+      cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0, jc: 'left',
+      __tableLayout: {
+        effectiveStyleId: 'SharedStyle', ordinaryFlow: true,
+        logicalSequenceId: 'table-sequence:0', logicalRowOffset: 0, logicalTotalRows: 2,
+        grid: { authored: false, columns: [], requiredColumnCount: 0 },
+        preferredWidth: null, layout: null, cellSpacing: null,
+      },
+    } as unknown as DocTable;
+
+    const resolved = resolveTableColumnLayout(tableColumnLayoutInput(
+      acquired, 200, () => ({ minWidthPt: 0, maxWidthPt: 0 }),
+    ));
+    // Solver keys: empty before/content/after tracks around one 40pt cell.
+    expect(resolved.widthsPt).toEqual([0, 40, 0]);
+    expect(resolved.widthKeys).toEqual(['0/1', '40/1', '0/1']);
+
+    // Rebuild the source TableLayoutInput as acquisition would: the content cell
+    // sits after the gridBefore track (columnStart 1), the gridAfter track is
+    // empty.
+    const sourceInput: TableLayoutInput = {
+      ...tableInput(0, resolved.widthsPt),
+      columnWidthKeys: resolved.widthKeys,
+      rows: [{
+        ...row(0, 1),
+        cells: [{
+          id: 'table:0:cell:0', source: { ...source(0, 0), path: [0, 0, 0] },
+          columnStart: 1, columnSpan: 1, verticalMerge: 'none',
+          margins: { topPt: 0, rightPt: 0, bottomPt: 0, leftPt: 0 },
+          vAlign: 'top', borders: edges(), blocks: [],
+        }],
+      }],
+    };
+
+    const combined = combineAdjacentTableLayoutInputs('group:acquired', [sourceInput, tableInput(1, [40])]);
+
+    // Zero tracks survive; the shared seam is the exact 40pt column identity.
+    expect(combined.columnWidthsPt).toEqual([0, 40, 0]);
+    expect(combined.columnWidthKeys).toEqual(['0/1', '40/1', '0/1']);
+    // The content cell keeps its offset over the surviving leading zero track.
+    expect(combined.rows[0]?.cells[0]).toMatchObject({ columnStart: 1, columnSpan: 1 });
+    expect([combined.rows[0]?.sourceOuterColumnStart, combined.rows[0]?.sourceOuterColumnEnd])
+      .toEqual([0, 3]);
+    // The plain [40] table absorbs the leading zero track into its single cell.
+    expect(combined.rows[1]?.cells[0]).toMatchObject({ columnStart: 0, columnSpan: 2 });
+  });
+
+  it('produces a discriminated group grid that is not assignable to TableLayoutInput', () => {
+    const combined = combineAdjacentTableLayoutInputs('group:kind', [
+      tableInput(0, [80]),
+      tableInput(1, [80]),
+    ]);
+    expect(combined.kind).toBe('adjacent-table-group-grid');
+    expect('ordinaryFlow' in combined).toBe(false);
+    expect('borders' in combined).toBe(false);
+    // @ts-expect-error the group grid is a distinct kind, not a TableLayoutInput.
+    const asTable: TableLayoutInput = combined;
+    expect(asTable.kind).toBe('adjacent-table-group-grid');
+  });
+});

--- a/packages/docx/src/layout/adjacent-table-layout-input.ts
+++ b/packages/docx/src/layout/adjacent-table-layout-input.ts
@@ -1,0 +1,530 @@
+import type {
+  SourceRef,
+  TableEdgeInputs,
+  TableLayoutInput,
+  TableRowLayoutInput,
+} from './types.js';
+import { firstAuthoredTableBorder } from './table-border-layer.js';
+import {
+  addExactLengthKeys,
+  compareExactLengthKeys,
+  divideExactLengthKey,
+  exactLengthKeyFromNumber,
+  exactLengthKeyToNumber,
+  subtractExactLengthKeys,
+  type ExactLengthKey,
+} from './exact-length.js';
+
+/** One authored source row inside a §17.4.37 logical group. It extends only
+ * TableRowLayoutInput; the group-specific facts are additive and REQUIRED so a
+ * consumer cannot mistake a group row for a full-grid row. The row's own
+ * `exceptionBorders` is fixed null because the folded source-table border layer
+ * is retained separately (and unambiguously) in `sourceTableEdges`. */
+export interface AdjacentGroupRowFacts extends TableRowLayoutInput {
+  readonly exceptionBorders: null;
+  /** Union-grid interval [start, end) owned by this row's authored source tbl.
+   * Retaining it keeps each source table authoritative for its own outer
+   * border and spacing ownership even after the grids are unioned. */
+  readonly sourceOuterColumnStart: number;
+  readonly sourceOuterColumnEnd: number;
+  /** The source table's tblBorders/tblPrEx layer, folded (and bidi-oriented into
+   * the group frame) for this row: outer edges apply only at the source table's
+   * true edges, every source seam resolves through insideH. */
+  readonly sourceTableEdges: TableEdgeInputs;
+}
+
+/** The transient union grid produced from a §17.4.37 adjacent-table group. This
+ * is a DISCRIMINATED intermediate (`kind: 'adjacent-table-group-grid'`) that is
+ * intentionally NOT assignable to TableLayoutInput: it has no `ordinaryFlow` and
+ * no whole-table `borders`, so a paint/pagination consumer must handle the group
+ * grid explicitly rather than silently treating it as an ordinary table. */
+export interface AdjacentTableGroupLayoutInput {
+  readonly kind: 'adjacent-table-group-grid';
+  readonly id: string;
+  readonly source: SourceRef;
+  readonly flowDomainId: string;
+  readonly alignment: 'left' | 'center' | 'right';
+  readonly indentPt: number;
+  readonly bidiVisual: boolean;
+  readonly columnWidthsPt: readonly number[];
+  readonly columnWidthKeys: readonly (ExactLengthKey | null)[];
+  readonly rows: readonly AdjacentGroupRowFacts[];
+}
+
+function physicalEdges(
+  edges: TableEdgeInputs,
+  sourceBidiVisual: boolean,
+  groupBidiVisual: boolean,
+): TableEdgeInputs {
+  if (sourceBidiVisual === groupBidiVisual) return edges;
+  return Object.freeze({ ...edges, left: edges.right, right: edges.left });
+}
+
+/** Fold a source table's whole-table borders and this row's tblPrEx exception
+ * borders into one edge set oriented to the group frame (none falls through,
+ * nil is retained; [MS-OI29500] 2.1.169). */
+function foldSourceTableEdges(
+  input: TableLayoutInput,
+  row: TableRowLayoutInput,
+  groupBidiVisual: boolean,
+): TableEdgeInputs {
+  const table = physicalEdges(input.borders, input.bidiVisual, groupBidiVisual);
+  const exception = row.exceptionBorders == null
+    ? null
+    : physicalEdges(row.exceptionBorders, input.bidiVisual, groupBidiVisual);
+  if (!exception) return table;
+  return Object.freeze({
+    top: firstAuthoredTableBorder(exception.top, table.top),
+    right: firstAuthoredTableBorder(exception.right, table.right),
+    bottom: firstAuthoredTableBorder(exception.bottom, table.bottom),
+    left: firstAuthoredTableBorder(exception.left, table.left),
+    insideH: firstAuthoredTableBorder(exception.insideH, table.insideH),
+    insideV: firstAuthoredTableBorder(exception.insideV, table.insideV),
+  });
+}
+
+interface GroupBoundary {
+  readonly position: ExactLengthKey;
+  readonly sym: number;
+  readonly identity: string;
+}
+
+type SymbolNode =
+  | Readonly<{ kind: 'zero' }>
+  | Readonly<{ kind: 'token' }>
+  | Readonly<{ kind: 'add' | 'sub'; left: number; right: number }>
+  | Readonly<{ kind: 'div'; value: number; divisor: bigint }>;
+
+/** Combine-call-local symbolic expressions. Nodes are interned by collision-free
+ * structural keys containing only immediate integer child ids. The fixed O(1)
+ * rewrites below are deliberately not an algebraic normalizer: no expression is
+ * expanded, commuted, or reassociated. Consequently the resource bound is
+ * O(unknown tracks + total row boundaries), with O(1) work and storage per
+ * requested symbolic operation. */
+class SymbolDag {
+  readonly nodes: SymbolNode[] = [Object.freeze({ kind: 'zero' })];
+  private readonly interned = new Map<string, number>([['Z', 0]]);
+
+  private intern(key: string, node: SymbolNode): number {
+    const existing = this.interned.get(key);
+    if (existing !== undefined) return existing;
+    const id = this.nodes.length;
+    this.nodes.push(Object.freeze(node));
+    this.interned.set(key, id);
+    return id;
+  }
+
+  token(member: number, track: number): number {
+    return this.intern(`T:${member}:${track}`, { kind: 'token' });
+  }
+
+  add(left: number, right: number): number {
+    if (left === 0) return right;
+    if (right === 0) return left;
+    const leftNode = this.nodes[left]!;
+    const rightNode = this.nodes[right]!;
+    if (leftNode.kind === 'sub' && leftNode.right === right) return leftNode.left;
+    if (rightNode.kind === 'sub' && rightNode.right === left) return rightNode.left;
+    return this.intern(`A:${left}:${right}`, { kind: 'add', left, right });
+  }
+
+  subtract(left: number, right: number): number {
+    if (left === right) return 0;
+    if (right === 0) return left;
+    const rightNode = this.nodes[right]!;
+    if (rightNode.kind === 'sub' && rightNode.left === left) return rightNode.right;
+    return this.intern(`S:${left}:${right}`, { kind: 'sub', left, right });
+  }
+
+  divide(value: number, divisor: bigint): number {
+    if (value === 0) return 0;
+    return this.intern(`D:${value}:${divisor}`, { kind: 'div', value, divisor });
+  }
+}
+
+let lastSymbolNodeCountForTest = 0;
+
+/** Test-only diagnostic. This module is internal and is not re-exported from the
+ * package root, so the counter cannot become public API. */
+export function adjacentTableSymbolNodeCountForTest(): number {
+  return lastSymbolNodeCountForTest;
+}
+
+function boundary(position: ExactLengthKey, sym = 0): GroupBoundary {
+  return Object.freeze({ position, sym, identity: `${position}|${sym}` });
+}
+
+function addBoundaries(
+  dag: SymbolDag,
+  left: GroupBoundary,
+  right: GroupBoundary,
+): GroupBoundary {
+  return boundary(addExactLengthKeys(left.position, right.position), dag.add(left.sym, right.sym));
+}
+
+function subtractBoundaries(
+  dag: SymbolDag,
+  left: GroupBoundary,
+  right: GroupBoundary,
+): GroupBoundary {
+  return boundary(
+    subtractExactLengthKeys(left.position, right.position),
+    dag.subtract(left.sym, right.sym),
+  );
+}
+
+function divideBoundary(dag: SymbolDag, value: GroupBoundary, divisor: bigint): GroupBoundary {
+  return boundary(divideExactLengthKey(value.position, divisor), dag.divide(value.sym, divisor));
+}
+
+function cumulative(
+  dag: SymbolDag,
+  input: TableLayoutInput,
+  memberIndex: number,
+): readonly GroupBoundary[] {
+  const result: GroupBoundary[] = [boundary('0/1')];
+  input.columnWidthsPt.forEach((width, trackIndex) => {
+    const authoredKey = input.columnWidthKeys?.[trackIndex];
+    const numericKey = exactLengthKeyFromNumber(width) ?? '0/1';
+    const track = authoredKey === null
+      ? boundary(numericKey, dag.token(memberIndex, trackIndex))
+      : boundary(authoredKey ?? numericKey);
+    result.push(addBoundaries(dag, result.at(-1)!, track));
+  });
+  return Object.freeze(result);
+}
+
+function rowPhysicalShift(
+  dag: SymbolDag,
+  row: TableRowLayoutInput,
+  sourceWidth: GroupBoundary,
+  groupWidth: GroupBoundary,
+): GroupBoundary {
+  const difference = subtractBoundaries(dag, groupWidth, sourceWidth);
+  if (row.alignment === 'right') return difference;
+  if (row.alignment === 'center') return divideBoundary(dag, difference, 2n);
+  return boundary('0/1');
+}
+
+function physicalBoundary(
+  dag: SymbolDag,
+  logicalBoundary: GroupBoundary,
+  sourceWidth: GroupBoundary,
+  bidiVisual: boolean,
+  shift: GroupBoundary,
+): GroupBoundary {
+  return addBoundaries(
+    dag,
+    shift,
+    bidiVisual ? subtractBoundaries(dag, sourceWidth, logicalBoundary) : logicalBoundary,
+  );
+}
+
+interface RowPlan {
+  readonly input: TableLayoutInput;
+  readonly row: TableRowLayoutInput;
+  /** Group-logical position of every source boundary index (0..source columns),
+   * in SOURCE order (ascending source index). */
+  readonly groupBoundaries: readonly GroupBoundary[];
+  /** True when the source table's bidi differs from the group frame, so its
+   * source-order boundaries descend along the group-logical axis. Derived from
+   * the bidi flags, never inferred from coordinates (which cannot distinguish a
+   * mirrored table from an ordinary one at coincident zero-width tracks). */
+  readonly descending: boolean;
+}
+
+/** ECMA-376 Part 1 §17.4.37 makes adjacent same-style ordinary-flow tbl
+ * siblings one logical table. Build that transient union grid before border
+ * resolution and pagination so source seams receive insideH semantics and one
+ * continuation cursor spans every authored row. SourceRef and node ids remain
+ * untouched.
+ *
+ * WHY (flag for Fable review): §17.4.37 and [MS-OI29500] do not define how
+ * independently authored tblGrid/alignment/bidiVisual payloads are reconciled
+ * into a single physical grid. This union is a deterministic internal layout
+ * policy that builds the transient column topology for seam-border and
+ * pagination geometry, while each source table stays authoritative for its own
+ * first/last-column, vertical banding, and corner membership through the
+ * retained AdjacentGroupRowFacts outer interval. Column boundaries are a MULTISET
+ * union (max multiplicity per exact coordinate) so a source table's zero-width
+ * tracks survive rather than collapsing as they would in a set. */
+export function combineAdjacentTableLayoutInputs(
+  groupId: string,
+  inputs: readonly TableLayoutInput[],
+): AdjacentTableGroupLayoutInput {
+  if (groupId.length === 0) throw new RangeError('Adjacent table group id must not be empty');
+  if (inputs.length === 0) throw new RangeError('Adjacent table group requires at least one table');
+  if (inputs.some((input) => !input.ordinaryFlow)) {
+    throw new Error('An absolutely positioned table cannot join an adjacent table group');
+  }
+  const first = inputs[0]!;
+  const groupBidi = first.bidiVisual;
+  const dag = new SymbolDag();
+  const zeroBoundary = boundary('0/1');
+  const sourceBoundaries = inputs.map((input, member) => cumulative(dag, input, member));
+  const sourceWidths = sourceBoundaries.map((boundaries) => boundaries.at(-1) ?? zeroBoundary);
+  const groupWidth = sourceWidths.reduce((maximum, width) => (
+    compareExactLengthKeys(width.position, maximum.position) > 0 ? width : maximum
+  ), zeroBoundary);
+
+  const groupLogical = (
+    sourceLogicalBoundary: GroupBoundary,
+    sourceWidth: GroupBoundary,
+    sourceBidi: boolean,
+    shift: GroupBoundary,
+  ): GroupBoundary => {
+    const physical = physicalBoundary(dag, sourceLogicalBoundary, sourceWidth, sourceBidi, shift);
+    return groupBidi ? subtractBoundaries(dag, groupWidth, physical) : physical;
+  };
+
+  const rowPlans: RowPlan[] = [];
+  inputs.forEach((input, inputIndex) => {
+    const boundaries = sourceBoundaries[inputIndex]!;
+    const sourceWidth = sourceWidths[inputIndex]!;
+    const descending = input.bidiVisual !== groupBidi;
+    input.rows.forEach((row) => {
+      const shift = rowPhysicalShift(dag, row, sourceWidth, groupWidth);
+      const groupBoundaries = boundaries.map((boundary) => (
+        groupLogical(boundary, sourceWidth, input.bidiVisual, shift)
+      ));
+      rowPlans.push({ input, row, groupBoundaries, descending });
+    });
+  });
+
+  // Multiset union: the max multiplicity of each exact coordinate across rows,
+  // seeded with the group frame [0, groupWidth]. Two boundaries a source row
+  // places at the same coordinate (a zero-width track) survive because their
+  // multiplicity, not just their coordinate, is retained.
+  const maxCount = new Map<string, { boundary: GroupBoundary; count: number }>();
+  for (const frame of [zeroBoundary, groupWidth]) {
+    maxCount.set(frame.identity, { boundary: frame, count: 1 });
+  }
+  for (const plan of rowPlans) {
+    const counts = new Map<string, { boundary: GroupBoundary; count: number }>();
+    for (const position of plan.groupBoundaries) {
+      const current = counts.get(position.identity);
+      counts.set(position.identity, { boundary: position, count: (current?.count ?? 0) + 1 });
+    }
+    for (const [identity, entry] of counts) {
+      const previous = maxCount.get(identity);
+      if (entry.count > (previous?.count ?? 0)) maxCount.set(identity, entry);
+    }
+  }
+
+  interface PositionBucket {
+    readonly position: ExactLengthKey;
+    readonly identities: Map<string, { boundary: GroupBoundary; count: number }>;
+    readonly edges: Map<string, Set<string>>;
+    readonly firstSeen: Map<string, number>;
+  }
+  const buckets = new Map<ExactLengthKey, PositionBucket>();
+  const bucketFor = (position: ExactLengthKey): PositionBucket => {
+    let bucket = buckets.get(position);
+    if (!bucket) {
+      bucket = {
+        position,
+        identities: new Map(),
+        edges: new Map(),
+        firstSeen: new Map(),
+      };
+      buckets.set(position, bucket);
+    }
+    return bucket;
+  };
+  for (const [identity, entry] of maxCount) {
+    bucketFor(entry.boundary.position).identities.set(identity, entry);
+  }
+
+  // Equal numeric positions cannot be ordered by opaque symbolic ids. Each row
+  // instead contributes its directed group-axis order. Consecutive duplicates
+  // are one identity occurrence for ordering, while max multiplicity remains a
+  // separate multiset property. A cycle is unreachable for supported inputs:
+  // every row is a monotone projection onto the same physical group axis, and
+  // the fixed DAG rewrites preserve equal symbolic boundaries across mirror,
+  // right-align, and center transforms. A cycle therefore signals a violated
+  // invariant and must fail rather than be resolved by a heuristic.
+  let firstSeenRank = 0;
+  for (const plan of rowPlans) {
+    const axisOrder = plan.descending ? [...plan.groupBoundaries].reverse() : plan.groupBoundaries;
+    let runPosition: ExactLengthKey | null = null;
+    let previousIdentity: string | null = null;
+    for (const current of axisOrder) {
+      const bucket = bucketFor(current.position);
+      if (!bucket.firstSeen.has(current.identity)) {
+        bucket.firstSeen.set(current.identity, firstSeenRank++);
+      }
+      if (runPosition !== current.position) {
+        runPosition = current.position;
+        previousIdentity = null;
+      }
+      if (previousIdentity !== null && previousIdentity !== current.identity) {
+        let outgoing = bucket.edges.get(previousIdentity);
+        if (!outgoing) {
+          outgoing = new Set();
+          bucket.edges.set(previousIdentity, outgoing);
+        }
+        outgoing.add(current.identity);
+      }
+      previousIdentity = current.identity;
+    }
+  }
+  for (const bucket of buckets.values()) {
+    for (const identity of bucket.identities.keys()) {
+      if (!bucket.firstSeen.has(identity)) bucket.firstSeen.set(identity, firstSeenRank++);
+    }
+  }
+
+  const orderedBuckets = [...buckets.values()].sort((left, right) => (
+    compareExactLengthKeys(left.position, right.position)
+  ));
+  const unionSeq: GroupBoundary[] = [];
+  const unionIndexAt = new Map<string, number>();
+  for (const bucket of orderedBuckets) {
+    const indegree = new Map([...bucket.identities.keys()].map((identity) => [identity, 0]));
+    for (const outgoing of bucket.edges.values()) {
+      for (const target of outgoing) indegree.set(target, (indegree.get(target) ?? 0) + 1);
+    }
+    const ready: string[] = [];
+    const pushReady = (identity: string): void => {
+      ready.push(identity);
+      let child = ready.length - 1;
+      while (child > 0) {
+        const parent = Math.floor((child - 1) / 2);
+        if (bucket.firstSeen.get(ready[parent]!)! <= bucket.firstSeen.get(ready[child]!)!) break;
+        [ready[parent], ready[child]] = [ready[child]!, ready[parent]!];
+        child = parent;
+      }
+    };
+    const popReady = (): string => {
+      const first = ready[0]!;
+      const last = ready.pop()!;
+      if (ready.length > 0) {
+        ready[0] = last;
+        let parent = 0;
+        while (true) {
+          const left = parent * 2 + 1;
+          const right = left + 1;
+          if (left >= ready.length) break;
+          let child = left;
+          if (right < ready.length
+            && bucket.firstSeen.get(ready[right]!)! < bucket.firstSeen.get(ready[left]!)!) {
+            child = right;
+          }
+          if (bucket.firstSeen.get(ready[parent]!)! <= bucket.firstSeen.get(ready[child]!)!) break;
+          [ready[parent], ready[child]] = [ready[child]!, ready[parent]!];
+          parent = child;
+        }
+      }
+      return first;
+    };
+    for (const identity of bucket.identities.keys()) {
+      if (indegree.get(identity) === 0) pushReady(identity);
+    }
+    const ordered: string[] = [];
+    while (ready.length > 0) {
+      const identity = popReady();
+      ordered.push(identity);
+      for (const target of bucket.edges.get(identity) ?? []) {
+        const remaining = indegree.get(target)! - 1;
+        indegree.set(target, remaining);
+        if (remaining === 0) pushReady(target);
+      }
+    }
+    if (ordered.length !== bucket.identities.size) {
+      throw new Error(`Adjacent table symbolic boundary ordering cycle at ${bucket.position}`);
+    }
+    for (const identity of ordered) {
+      const { boundary: position, count } = bucket.identities.get(identity)!;
+      unionIndexAt.set(identity, unionSeq.length);
+      for (let occurrence = 0; occurrence < count; occurrence += 1) unionSeq.push(position);
+    }
+  }
+  const columnWidthKeys = unionSeq.slice(1).map((right, index) => {
+    const left = unionSeq[index]!;
+    return right.sym === left.sym ? subtractExactLengthKeys(right.position, left.position) : null;
+  });
+  const columnWidthsPt = unionSeq.slice(1).map((right, index) => exactLengthKeyToNumber(
+    subtractExactLengthKeys(right.position, unionSeq[index]!.position),
+  ));
+
+  // Map each source boundary index to a union boundary index by occurrence
+  // identity, scanning boundaries in SOURCE order and counting local occurrences
+  // of each coordinate. An ascending source takes the group's low occurrences
+  // (base + local); a descending (bidi-mismatched) source takes the high ones
+  // (base + multiplicity - 1 - local) so its mirrored zero-width tracks tile the
+  // union in the correct physical order.
+  const unionIndicesFor = (
+    groupBoundaries: readonly GroupBoundary[],
+    descending: boolean,
+  ): number[] => {
+    const local = new Map<string, number>();
+    const indices = new Array<number>(groupBoundaries.length);
+    groupBoundaries.forEach((position, sourceIndex) => {
+      const localOrdinal = local.get(position.identity) ?? 0;
+      local.set(position.identity, localOrdinal + 1);
+      const base = unionIndexAt.get(position.identity)!;
+      const multiplicity = maxCount.get(position.identity)!.count;
+      indices[sourceIndex] = descending
+        ? base + (multiplicity - 1 - localOrdinal)
+        : base + localOrdinal;
+    });
+    return indices;
+  };
+
+  let logicalRowIndex = 0;
+  const rows = rowPlans.map((plan): AdjacentGroupRowFacts => {
+    const { input, row, groupBoundaries, descending } = plan;
+    const unionIndexOf = unionIndicesFor(groupBoundaries, descending);
+    const outerStart = unionIndexOf[0]!;
+    const outerEnd = unionIndexOf[groupBoundaries.length - 1]!;
+    const cells = row.cells.map((cell) => {
+      const startIndex = unionIndexOf[cell.columnStart];
+      const endIndex = unionIndexOf[cell.columnStart + cell.columnSpan];
+      if (startIndex == null || endIndex == null) {
+        throw new RangeError(`Table cell ${cell.id} exceeds its authored grid`);
+      }
+      const columnStart = Math.min(startIndex, endIndex);
+      const columnEnd = Math.max(startIndex, endIndex);
+      if (columnEnd <= columnStart) {
+        throw new Error(`Table cell ${cell.id} cannot be mapped into the logical group grid`);
+      }
+      const borders = physicalEdges(cell.borders, input.bidiVisual, groupBidi);
+      return Object.freeze({
+        ...cell,
+        columnStart,
+        columnSpan: columnEnd - columnStart,
+        borders,
+      });
+    });
+    return Object.freeze({
+      ...row,
+      logicalRowIndex: logicalRowIndex++,
+      // The group grid is not a TableLayoutInput; the folded source-table border
+      // layer lives in `sourceTableEdges`, so the row's own exceptionBorders slot
+      // is fixed null to avoid a second, ambiguous border source.
+      exceptionBorders: null,
+      sourceTableEdges: foldSourceTableEdges(input, row, groupBidi),
+      // Re-orient the source's leading-edge indent into the group frame when the
+      // source and group bidi differ; the group frame owns final placement.
+      indentPt: input.bidiVisual === groupBidi ? row.indentPt : -row.indentPt,
+      sourceOuterColumnStart: Math.min(outerStart, outerEnd),
+      sourceOuterColumnEnd: Math.max(outerStart, outerEnd),
+      cells: Object.freeze(cells),
+    });
+  });
+
+  lastSymbolNodeCountForTest = dag.nodes.length;
+
+  return Object.freeze({
+    kind: 'adjacent-table-group-grid',
+    id: groupId,
+    source: first.source,
+    flowDomainId: `${first.flowDomainId}:adjacent-group:${groupId}`,
+    alignment: first.alignment,
+    indentPt: first.indentPt,
+    bidiVisual: groupBidi,
+    columnWidthsPt: Object.freeze(columnWidthsPt),
+    columnWidthKeys: Object.freeze(columnWidthKeys),
+    rows: Object.freeze(rows),
+  });
+}

--- a/packages/docx/src/layout/adjacent-tables.test.ts
+++ b/packages/docx/src/layout/adjacent-tables.test.ts
@@ -5,109 +5,126 @@ import {
 } from './adjacent-tables.js';
 import type { BodyElement } from '../types.js';
 
-function table(
-  effectiveStyleId: string,
-  ordinaryFlow: boolean,
-  computedWidthPt: number,
-): BodyElement {
+function table(rowCount: number): BodyElement {
   return {
     type: 'table',
-    colWidths: [computedWidthPt],
-    rows: [],
+    colWidths: [10],
+    rows: Array.from({ length: rowCount }, () => ({ cells: [] })),
     borders: { top: null, right: null, bottom: null, left: null, insideH: null, insideV: null },
-    cellMarginTop: 0,
-    cellMarginRight: 0,
-    cellMarginBottom: 0,
-    cellMarginLeft: 0,
+    cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
     jc: 'left',
-    __tableLayout: {
-      effectiveStyleId,
-      ordinaryFlow,
-      grid: { authored: true, columns: [{ width: `${computedWidthPt * 20}` }], requiredColumnCount: 1 },
-      preferredWidth: null,
-      layout: null,
-      cellSpacing: null,
-    },
   } as unknown as BodyElement;
 }
 
-function paragraph(hidden = false): BodyElement {
-  return { type: 'paragraph', hidden } as unknown as BodyElement;
+function paragraph(): BodyElement {
+  return { type: 'paragraph' } as unknown as BodyElement;
 }
 
-function publicTable(): BodyElement {
-  const value = table('discarded', true, 42) as BodyElement & Record<string, unknown>;
-  delete value.__tableLayout;
-  return value;
-}
-
+/** Build a body-sequence entry from parser-owned §17.4.37 membership facts.
+ * `sequenceId === null` models a table for which the parser preserved no
+ * logical-table identity (a hand-built public table). */
 function input(
   element: BodyElement,
-  effectiveStyleId: string | null = null,
-  ordinaryFlow = true,
+  sequenceId: string | null,
+  logicalRowOffset = 0,
+  logicalTotalRows = element.type === 'table' ? element.rows.length : 0,
 ): AdjacentTableSequenceInput {
-  return { element, table: element.type === 'table' ? { effectiveStyleId, ordinaryFlow } : null };
+  if (element.type !== 'table' || sequenceId === null) {
+    return { element, table: null };
+  }
+  return {
+    element,
+    table: {
+      logicalSequenceId: sequenceId,
+      logicalRowOffset,
+      logicalTotalRows,
+      rowCount: element.rows.length,
+    },
+  };
 }
 
 describe('adjacent table normalization (ECMA-376 Part 1 §17.4.37)', () => {
-  it('groups directly adjacent in-flow tables by preserved effective style identity', () => {
-    const first = table('SameStyle', true, 36);
-    const second = table('SameStyle', true, 144);
+  it('groups adjacent tables the parser assigned to one logical sequence', () => {
+    const first = table(1);
+    const second = table(2);
 
     expect(normalizeAdjacentTables([
-      input(first, 'SameStyle'), input(second, 'SameStyle'),
+      input(first, 'seq:0', 0, 3),
+      input(second, 'seq:0', 1, 3),
     ])).toEqual([{
       kind: 'adjacent-table-group',
-      effectiveStyleId: 'SameStyle',
+      logicalSequenceId: 'seq:0',
       tables: [first, second],
     }]);
   });
 
-  it('keeps different effective style identities distinct even when public geometry matches', () => {
-    const first = table('StyleA', true, 72);
-    const second = table('StyleB', true, 72);
-
-    expect(normalizeAdjacentTables([input(first, 'StyleA'), input(second, 'StyleB')])).toEqual([
-      { kind: 'body-element', element: first },
-      { kind: 'body-element', element: second },
-    ]);
-  });
-
-  it('treats every intervening paragraph as a barrier, including hidden paragraphs', () => {
-    const first = table('SameStyle', true, 72);
-    const hidden = paragraph(true);
-    const second = table('SameStyle', true, 72);
+  it('keeps parser-distinct logical sequences apart even when adjacent', () => {
+    const first = table(1);
+    const second = table(1);
 
     expect(normalizeAdjacentTables([
-      input(first, 'SameStyle'), input(hidden), input(second, 'SameStyle'),
+      input(first, 'seq:0'),
+      input(second, 'seq:7'),
     ])).toEqual([
       { kind: 'body-element', element: first },
-      { kind: 'body-element', element: hidden },
       { kind: 'body-element', element: second },
     ]);
   });
 
-  it('does not join across an effectively floating table', () => {
-    const first = table('SameStyle', true, 72);
-    const floating = table('SameStyle', false, 72);
-    const second = table('SameStyle', true, 72);
+  it('treats an intervening body element as a barrier', () => {
+    const first = table(1);
+    const between = paragraph();
+    const second = table(1);
 
     expect(normalizeAdjacentTables([
-      input(first, 'SameStyle'), input(floating, 'SameStyle', false), input(second, 'SameStyle'),
+      input(first, 'seq:0'),
+      input(between, null),
+      input(second, 'seq:9'),
     ])).toEqual([
       { kind: 'body-element', element: first },
-      { kind: 'body-element', element: floating },
+      { kind: 'body-element', element: between },
       { kind: 'body-element', element: second },
     ]);
   });
 
-  it('keeps hand-built public tables distinct when no parser style identity was preserved', () => {
-    const first = publicTable();
-    const second = publicTable();
+  it('keeps a table with no preserved parser identity standalone', () => {
+    const first = table(1);
+    const second = table(1);
 
-    expect(normalizeAdjacentTables([input(first), input(second)])).toEqual([
+    expect(normalizeAdjacentTables([
+      input(first, null),
+      input(second, null),
+    ])).toEqual([
       { kind: 'body-element', element: first },
       { kind: 'body-element', element: second },
     ]);
+  });
+
+  it('emits a single-member logical sequence as a plain body element', () => {
+    const only = table(2);
+
+    expect(normalizeAdjacentTables([input(only, 'seq:0', 0, 2)])).toEqual([
+      { kind: 'body-element', element: only },
+    ]);
+  });
+
+  it('rejects a parser sequence whose row offsets are inconsistent', () => {
+    const first = table(1);
+    const second = table(2);
+
+    expect(() => normalizeAdjacentTables([
+      input(first, 'seq:0', 0, 3),
+      input(second, 'seq:0', 2, 3),
+    ])).toThrow(/inconsistent/);
+  });
+
+  it('rejects a parser sequence whose member rows do not total', () => {
+    const first = table(1);
+    const second = table(1);
+
+    expect(() => normalizeAdjacentTables([
+      input(first, 'seq:0', 0, 3),
+      input(second, 'seq:0', 1, 3),
+    ])).toThrow(/incomplete/);
   });
 });

--- a/packages/docx/src/layout/adjacent-tables.ts
+++ b/packages/docx/src/layout/adjacent-tables.ts
@@ -2,11 +2,20 @@ import type { BodyElement } from '../types.js';
 
 export type TableBodyElement = Extract<BodyElement, { type: 'table' }>;
 
+/** Parser-owned ECMA-376 Part 1 §17.4.37 logical-table membership facts for one
+ * body table. `table === null` when the parser preserved no logical-table
+ * identity (e.g. a hand-built public `DocTable` with no acquisition wire); such
+ * a table can never join a logical sequence. Membership, style-identity
+ * validity, and the effective-floating barrier are all decided by the parser
+ * and surface here only as the assigned `logicalSequenceId`; layout does not
+ * re-derive §17.4.37 grouping from style ids or positioning. */
 export interface AdjacentTableSequenceInput {
   readonly element: BodyElement;
   readonly table: Readonly<{
-    readonly effectiveStyleId: string | null;
-    readonly ordinaryFlow: boolean;
+    readonly logicalSequenceId: string;
+    readonly logicalRowOffset: number;
+    readonly logicalTotalRows: number;
+    readonly rowCount: number;
   }> | null;
 }
 
@@ -14,53 +23,86 @@ export type NormalizedBodySequenceEntry =
   | Readonly<{ kind: 'body-element'; element: BodyElement }>
   | Readonly<{
     kind: 'adjacent-table-group';
-    effectiveStyleId: string;
+    logicalSequenceId: string;
     tables: readonly TableBodyElement[];
   }>;
 
-function groupingIdentity(input: AdjacentTableSequenceInput): string | null {
-  if (input.element.type !== 'table' || !input.table?.ordinaryFlow) return null;
-  return input.table.effectiveStyleId;
+type PendingMember = Readonly<{
+  element: TableBodyElement;
+  logicalRowOffset: number;
+  logicalTotalRows: number;
+  rowCount: number;
+}>;
+
+/** Guard the parser-owned row sequence the layer is about to trust: within one
+ * logical table the authored member offsets must be contiguous from zero and
+ * agree on the shared total. Layout never recomputes these; a violation means
+ * the parser boundary is inconsistent, which must fail loudly rather than
+ * silently produce a mismatched union grid. */
+function assertParserOwnedSequence(sequenceId: string, members: readonly PendingMember[]): void {
+  const totalRows = members[0]!.logicalTotalRows;
+  let expectedOffset = 0;
+  for (const member of members) {
+    if (
+      member.logicalTotalRows !== totalRows
+      || !Number.isInteger(member.rowCount)
+      || member.rowCount < 0
+      || member.logicalRowOffset !== expectedOffset
+    ) {
+      throw new Error(`Parser-owned adjacent table sequence ${sequenceId} is inconsistent`);
+    }
+    expectedOffset += member.rowCount;
+  }
+  if (expectedOffset !== totalRows) {
+    throw new Error(`Parser-owned adjacent table sequence ${sequenceId} is incomplete`);
+  }
 }
 
 /**
- * Normalize the body sequence rule from ECMA-376 Part 1 §17.4.37 without
- * comparing derived table geometry. The standard keys adjacency by table style;
- * [MS-OI29500] 2.1.149(a) keeps an effectively positioned table distinct.
- * Parser-private facts are required so a lexical tblpPr that Word ignores is
- * not mistaken for effective floating placement.
+ * Group the body sequence into ECMA-376 Part 1 §17.4.37 logical tables using
+ * only the parser-owned `logicalSequenceId`. The parser has already applied the
+ * standard's adjacency rule together with [MS-OI29500] 2.1.149(a)'s positioned-
+ * table exclusion and table-style-identity validation, so directly adjacent
+ * source tables carry the same id iff they form one logical table. This layer
+ * only coalesces the maximal contiguous run sharing an id and validates the
+ * parser-owned row totals; it does not compare derived geometry or style ids.
  */
 export function normalizeAdjacentTables(
   body: readonly AdjacentTableSequenceInput[],
 ): readonly NormalizedBodySequenceEntry[] {
   const result: NormalizedBodySequenceEntry[] = [];
-  let pendingStyleId: string | null = null;
-  let pendingTables: TableBodyElement[] = [];
+  let pendingSequenceId: string | null = null;
+  let pendingMembers: PendingMember[] = [];
 
   const flush = () => {
-    if (pendingTables.length === 1) {
-      result.push(Object.freeze({ kind: 'body-element', element: pendingTables[0]! }));
-    } else if (pendingTables.length > 1) {
+    if (pendingMembers.length > 0) {
+      assertParserOwnedSequence(pendingSequenceId!, pendingMembers);
+    }
+    if (pendingMembers.length === 1) {
+      result.push(Object.freeze({ kind: 'body-element', element: pendingMembers[0]!.element }));
+    } else if (pendingMembers.length > 1) {
       result.push(Object.freeze({
         kind: 'adjacent-table-group',
-        effectiveStyleId: pendingStyleId!,
-        tables: Object.freeze(pendingTables.slice()),
+        logicalSequenceId: pendingSequenceId!,
+        tables: Object.freeze(pendingMembers.map((member) => member.element)),
       }));
     }
-    pendingStyleId = null;
-    pendingTables = [];
+    pendingSequenceId = null;
+    pendingMembers = [];
   };
 
-  for (const input of body) {
-    const { element } = input;
-    const styleId = groupingIdentity(input);
-    if (styleId !== null && element.type === 'table') {
-      if (pendingTables.length > 0 && pendingStyleId !== styleId) flush();
-      pendingStyleId = styleId;
-      pendingTables.push(element);
+  for (const { element, table } of body) {
+    if (element.type === 'table' && table !== null) {
+      if (pendingMembers.length > 0 && pendingSequenceId !== table.logicalSequenceId) flush();
+      pendingSequenceId = table.logicalSequenceId;
+      pendingMembers.push(Object.freeze({
+        element: element as TableBodyElement,
+        logicalRowOffset: table.logicalRowOffset,
+        logicalTotalRows: table.logicalTotalRows,
+        rowCount: table.rowCount,
+      }));
       continue;
     }
-
     flush();
     result.push(Object.freeze({ kind: 'body-element', element }));
   }

--- a/packages/docx/src/layout/exact-length.test.ts
+++ b/packages/docx/src/layout/exact-length.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  divideExactLengthKey,
+  exactLengthKeyFromDecimal,
+  exactLengthKeyToNumber,
+} from './exact-length.js';
+
+describe('exact layout length', () => {
+  it('converts finite subnormal and large rationals without overflowing either BigInt operand', () => {
+    const smallest = exactLengthKeyFromDecimal('1e-323');
+    const largest = exactLengthKeyFromDecimal('1e308');
+
+    expect(smallest).not.toBeNull();
+    expect(largest).not.toBeNull();
+    expect(exactLengthKeyToNumber(smallest!)).toBe(1e-323);
+    expect(exactLengthKeyToNumber(largest!)).toBe(1e308);
+  });
+
+  it('rounds a schema-valid large unsigned twips measure exactly like the numeric solver input', () => {
+    const lexicalTwips = '2542686831678384';
+    const twips = exactLengthKeyFromDecimal(lexicalTwips);
+
+    expect(twips).not.toBeNull();
+    const points = divideExactLengthKey(twips!, 20n);
+    expect(exactLengthKeyToNumber(points)).toBe(Number(lexicalTwips) / 20);
+  });
+
+  it('rounds normal midpoint ties to the even binary64 significand', () => {
+    const evenLowerMidpoint = '9007199254740993/9007199254740992';
+    const oddLowerMidpoint = '9007199254740995/9007199254740992';
+
+    expect(exactLengthKeyToNumber(evenLowerMidpoint)).toBe(1);
+    expect(exactLengthKeyToNumber(oddLowerMidpoint)).toBe(1.0000000000000004);
+  });
+
+  it('rounds the minimum-subnormal midpoint to even zero and values above it upward', () => {
+    const twiceMinimumSubnormalDenominator = (1n << 1075n).toString();
+    const fourTimesMinimumSubnormalDenominator = (1n << 1076n).toString();
+
+    expect(exactLengthKeyToNumber(`1/${twiceMinimumSubnormalDenominator}`)).toBe(0);
+    expect(exactLengthKeyToNumber(`3/${fourTimesMinimumSubnormalDenominator}`))
+      .toBe(Number.MIN_VALUE);
+  });
+
+  it('changes from the maximum finite binary64 value to Infinity at the overflow midpoint', () => {
+    const overflowMidpoint = (1n << 1024n) - (1n << 970n);
+
+    expect(exactLengthKeyToNumber(`${overflowMidpoint - 1n}/1`)).toBe(Number.MAX_VALUE);
+    expect(exactLengthKeyToNumber(`${overflowMidpoint}/1`)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('canonicalizes millions of redundant zeros without constructing a giant BigInt', () => {
+    // If leading/trailing zeros were folded into a BigInt or power of ten this
+    // would allocate a ~1e6-digit integer and time out; canonicalization first
+    // keeps it O(string length).
+    const leadingZeros = `${'0'.repeat(1_000_000)}5`;
+    const trailingZeros = `5${'0'.repeat(1_000_000)}`;
+
+    expect(exactLengthKeyFromDecimal(leadingZeros)).toBe('5/1');
+    // The trailing-zero magnitude has a normalized exponent of 1e6, over budget.
+    expect(exactLengthKeyFromDecimal(trailingZeros)).toBeNull();
+  });
+
+  it('strips integer leading zeros and maps -0 to 0', () => {
+    expect(exactLengthKeyFromDecimal('007')).toBe('7/1');
+    expect(exactLengthKeyFromDecimal('00.500')).toBe('1/2');
+    expect(exactLengthKeyFromDecimal('-0')).toBe('0/1');
+    expect(exactLengthKeyFromDecimal('-0.000')).toBe('0/1');
+  });
+
+  it('preserves subnormal underflow magnitudes as exact keys rather than rejecting them', () => {
+    const subnormal = exactLengthKeyFromDecimal('1e-323');
+    expect(subnormal).not.toBeNull();
+    expect(exactLengthKeyToNumber(subnormal!)).toBe(1e-323);
+
+    // Below the smallest subnormal but within the decimal budget: kept exact,
+    // and only rounds to 0 at the binary64 boundary rather than being dropped.
+    const belowSubnormal = exactLengthKeyFromDecimal('1e-400');
+    expect(belowSubnormal).not.toBeNull();
+    expect(exactLengthKeyToNumber(belowSubnormal!)).toBe(0);
+  });
+
+  it('accepts values at the significant-digit and exponent budget and rejects beyond it', () => {
+    expect(exactLengthKeyFromDecimal(`1${'0'.repeat(766)}3`)).not.toBeNull(); // 768 sig digits
+    expect(exactLengthKeyFromDecimal(`1${'2'.repeat(768)}`)).toBeNull(); // 769 sig digits
+    expect(exactLengthKeyFromDecimal('1e1100')).not.toBeNull();
+    expect(exactLengthKeyFromDecimal('1e1101')).toBeNull();
+    expect(exactLengthKeyFromDecimal('1e-1100')).not.toBeNull();
+    expect(exactLengthKeyFromDecimal('1e-1101')).toBeNull();
+  });
+});

--- a/packages/docx/src/layout/exact-length.ts
+++ b/packages/docx/src/layout/exact-length.ts
@@ -1,0 +1,191 @@
+/** A reduced rational point value (`numerator/denominator`). BigInt is kept
+ * inside arithmetic only: clone-safe layout inputs retain this canonical text. */
+export type ExactLengthKey = string;
+
+type Rational = Readonly<{ numerator: bigint; denominator: bigint }>;
+
+function gcd(left: bigint, right: bigint): bigint {
+  let a = left < 0n ? -left : left;
+  let b = right < 0n ? -right : right;
+  while (b !== 0n) [a, b] = [b, a % b];
+  return a === 0n ? 1n : a;
+}
+
+function rational(numerator: bigint, denominator: bigint): Rational {
+  if (denominator === 0n) throw new RangeError('Exact length denominator must not be zero');
+  const sign = denominator < 0n ? -1n : 1n;
+  const divisor = gcd(numerator, denominator);
+  return Object.freeze({
+    numerator: sign * numerator / divisor,
+    denominator: sign * denominator / divisor,
+  });
+}
+
+// Resource budget bounding the BigInt work an exact key may cost. These limits
+// are generous supersets of the binary64 finite range (max ~1.8e308, min
+// subnormal ~5e-324, ~17 significant decimal digits), so NO in-range authored
+// measure is ever refused for being merely large or precise — only pathological
+// lexical forms (millions of digits, |exponent| in the thousands) exceed them.
+// Over-budget is therefore "identity unknown", not "out of range": the adapter
+// keeps deterministic binary64 geometry while returning a null exact key.
+const MAX_SIGNIFICANT_DIGITS = 768;
+const MAX_DECIMAL_EXPONENT = 1100;
+
+function parseDecimal(value: string): Rational | null {
+  const match = /^([+-]?)(?:(\d+)(?:\.(\d*))?|\.(\d+))(?:[eE]([+-]?\d+))?$/.exec(value);
+  if (!match) return null;
+  const negative = match[1] === '-';
+  const intDigits = match[2] ?? '';
+  const fractionDigits = match[3] ?? match[4] ?? '';
+  const authoredExponent = Number(match[5] ?? '0');
+  if (!Number.isSafeInteger(authoredExponent)) return null;
+  // The combined digit string with the implied decimal point after intDigits.
+  const digits = `${intDigits}${fractionDigits}`;
+  // Losslessly canonicalize BEFORE constructing any BigInt: strip leading zeros
+  // (value-neutral) and trailing zeros (folded into the decimal scale), and map
+  // -0 to 0. Use two linear index scans rather than a `/0*$/` regex, whose
+  // anchored star backtracks in O(n^2) on a long non-zero-terminated string; a
+  // lexical value carrying millions of redundant zeros must stay O(n) and never
+  // build a giant BigInt or power of ten. `48` is the code point of '0'.
+  let first = 0;
+  while (first < digits.length && digits.charCodeAt(first) === 48) first += 1;
+  if (first === digits.length) return rational(0n, 1n);
+  let last = digits.length - 1;
+  while (last > first && digits.charCodeAt(last) === 48) last -= 1;
+  const mantissa = digits.slice(first, last + 1);
+  const trailingZeros = digits.length - 1 - last;
+  // Decimal scale of the least-significant retained digit.
+  const scale = authoredExponent - fractionDigits.length + trailingZeros;
+  // Normalized scientific exponent (position of the leading significant digit).
+  const normalizedExponent = scale + mantissa.length - 1;
+  if (mantissa.length > MAX_SIGNIFICANT_DIGITS
+    || Math.abs(normalizedExponent) > MAX_DECIMAL_EXPONENT) {
+    return null;
+  }
+  let numerator = BigInt(mantissa);
+  let denominator = 1n;
+  if (scale >= 0) numerator *= 10n ** BigInt(scale);
+  else denominator = 10n ** BigInt(-scale);
+  if (negative) numerator = -numerator;
+  return rational(numerator, denominator);
+}
+
+function parseKey(value: ExactLengthKey): Rational {
+  const match = /^(-?\d+)\/([1-9]\d*)$/.exec(value);
+  if (!match) throw new RangeError(`Invalid exact length key: ${value}`);
+  return rational(BigInt(match[1]!), BigInt(match[2]!));
+}
+
+function key(value: Rational): ExactLengthKey {
+  const reduced = rational(value.numerator, value.denominator);
+  return `${reduced.numerator}/${reduced.denominator}`;
+}
+
+export function exactLengthKeyFromDecimal(value: string): ExactLengthKey | null {
+  const parsed = parseDecimal(value);
+  return parsed ? key(parsed) : null;
+}
+
+export function exactLengthKeyFromNumber(value: number): ExactLengthKey | null {
+  if (!Number.isFinite(value) || value < 0) return null;
+  const parsed = parseDecimal(value.toString());
+  return parsed ? key(parsed) : null;
+}
+
+function binaryExponent(numerator: bigint, denominator: bigint): number {
+  let exponent = numerator.toString(2).length - denominator.toString(2).length;
+  const belowCandidate = exponent >= 0
+    ? numerator < denominator << BigInt(exponent)
+    : numerator << BigInt(-exponent) < denominator;
+  if (belowCandidate) exponent -= 1;
+  return exponent;
+}
+
+function roundedBinaryQuotient(
+  numerator: bigint,
+  denominator: bigint,
+  binaryShift: number,
+): bigint {
+  const scaledNumerator = binaryShift >= 0
+    ? numerator << BigInt(binaryShift)
+    : numerator;
+  const scaledDenominator = binaryShift < 0
+    ? denominator << BigInt(-binaryShift)
+    : denominator;
+  const quotient = scaledNumerator / scaledDenominator;
+  const remainder = scaledNumerator % scaledDenominator;
+  const comparison = remainder * 2n - scaledDenominator;
+  return comparison > 0n || (comparison === 0n && quotient % 2n !== 0n)
+    ? quotient + 1n
+    : quotient;
+}
+
+export function exactLengthKeyToNumber(value: ExactLengthKey): number {
+  const parsed = parseKey(value);
+  if (parsed.numerator === 0n) return 0;
+  const numeratorNegative = parsed.numerator < 0n;
+  const numerator = numeratorNegative ? -parsed.numerator : parsed.numerator;
+  let exponent = binaryExponent(numerator, parsed.denominator);
+  let magnitude: number;
+  if (exponent < -1022) {
+    const significand = roundedBinaryQuotient(numerator, parsed.denominator, 1074);
+    magnitude = Number(significand) * Number.MIN_VALUE;
+  } else {
+    let significand = roundedBinaryQuotient(
+      numerator,
+      parsed.denominator,
+      52 - exponent,
+    );
+    // Rounding can carry a 53-bit significand into the next exponent. Handling
+    // that carry before Number conversion avoids a second, platform-dependent
+    // decimal rounding step at the finite/Infinity boundary as well.
+    if (significand === 1n << 53n) {
+      significand >>= 1n;
+      exponent += 1;
+    }
+    magnitude = exponent > 1023
+      ? Number.POSITIVE_INFINITY
+      : Number(significand) * 2 ** (exponent - 52);
+  }
+  return numeratorNegative ? -magnitude : magnitude;
+}
+
+export function addExactLengthKeys(left: ExactLengthKey, right: ExactLengthKey): ExactLengthKey {
+  const a = parseKey(left);
+  const b = parseKey(right);
+  return key(rational(
+    a.numerator * b.denominator + b.numerator * a.denominator,
+    a.denominator * b.denominator,
+  ));
+}
+
+export function multiplyExactLengthKeys(left: ExactLengthKey, right: ExactLengthKey): ExactLengthKey {
+  const a = parseKey(left);
+  const b = parseKey(right);
+  return key(rational(
+    a.numerator * b.numerator,
+    a.denominator * b.denominator,
+  ));
+}
+
+export function subtractExactLengthKeys(left: ExactLengthKey, right: ExactLengthKey): ExactLengthKey {
+  const a = parseKey(left);
+  const b = parseKey(right);
+  return key(rational(
+    a.numerator * b.denominator - b.numerator * a.denominator,
+    a.denominator * b.denominator,
+  ));
+}
+
+export function divideExactLengthKey(value: ExactLengthKey, divisor: bigint): ExactLengthKey {
+  if (divisor === 0n) throw new RangeError('Exact length divisor must not be zero');
+  const parsed = parseKey(value);
+  return key(rational(parsed.numerator, parsed.denominator * divisor));
+}
+
+export function compareExactLengthKeys(left: ExactLengthKey, right: ExactLengthKey): number {
+  const a = parseKey(left);
+  const b = parseKey(right);
+  const difference = a.numerator * b.denominator - b.numerator * a.denominator;
+  return difference < 0n ? -1 : difference > 0n ? 1 : 0;
+}

--- a/packages/docx/src/layout/table-border-layer.ts
+++ b/packages/docx/src/layout/table-border-layer.ts
@@ -1,0 +1,16 @@
+import type { TableBorderInput } from './types.js';
+
+/** Resolve one authored border layer before shared-edge conflict resolution.
+ * `none` is an omitted layer while `nil` is an authored suppression. Keeping
+ * that distinction here prevents callers that merge tblPrEx/table inputs from
+ * accidentally turning an OOXML suppression into a fallback. */
+export function firstAuthoredTableBorder(
+  ...borders: readonly (TableBorderInput | null)[]
+): TableBorderInput | null {
+  for (const border of borders) {
+    // [MS-OI29500] 2.1.169: nil remains specified and suppresses the edge;
+    // none allows the next applicable border layer to participate.
+    if (border && border.authoredStyle !== 'none') return border;
+  }
+  return null;
+}

--- a/packages/docx/src/layout/table-columns.test.ts
+++ b/packages/docx/src/layout/table-columns.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveTableColumnWidths } from './table-columns.js';
+import { resolveTableColumnLayout, resolveTableColumnWidths } from './table-columns.js';
 import type { TableColumnLayoutInput } from './types.js';
 
 function input(overrides: Partial<TableColumnLayoutInput> = {}): TableColumnLayoutInput {
@@ -59,6 +59,17 @@ describe('ECMA-376 §17.18.87 table column solver', () => {
       availableWidthPt: 75,
       gridWidthsPt: [70, 30],
     }))).toEqual([52.5, 22.5]);
+  });
+
+  it('gives solver-changed tracks exact keys for their final numeric definitions', () => {
+    expect(resolveTableColumnLayout(input({
+      availableWidthPt: 75,
+      gridWidthsPt: [70, 30],
+      gridWidthKeys: [null, '30/1'],
+    }))).toEqual({
+      widthsPt: [52.5, 22.5],
+      widthKeys: ['105/2', '45/2'],
+    });
   });
 
   it('distributes a preferred table width when every declared grid track starts at zero', () => {

--- a/packages/docx/src/layout/table-columns.ts
+++ b/packages/docx/src/layout/table-columns.ts
@@ -4,6 +4,7 @@ import type {
   TableColumnRowConstraint,
   TablePreferredWidthConstraint,
 } from './types.js';
+import { exactLengthKeyFromNumber, type ExactLengthKey } from './exact-length.js';
 
 const EPSILON_PT = 1e-9;
 
@@ -419,7 +420,7 @@ function fitToAvailableWidth(
  * parser-independent constraint solver. `tblGrid` seeds widths; it never
  * suppresses authored row/cell preferences.
  */
-export function resolveTableColumnWidths(input: TableColumnLayoutInput): readonly number[] {
+function solveTableColumnWidths(input: TableColumnLayoutInput): readonly number[] {
   const columnCount = requiredColumnCount(input);
   if (columnCount === 0) return Object.freeze([]);
   const widths = fixedWidths(input, columnCount);
@@ -453,4 +454,34 @@ export function resolveTableColumnWidths(input: TableColumnLayoutInput): readonl
     cells,
     finiteNonNegative(input.availableWidthPt),
   ));
+}
+
+export interface ResolvedTableColumnLayout {
+  readonly widthsPt: readonly number[];
+  readonly widthKeys: readonly (ExactLengthKey | null)[];
+}
+
+/** Preserve an unchanged authored track's identity state exactly. A hand-built
+ * numeric track has no authored key array and therefore receives its numeric
+ * definition; a solver-changed track likewise receives its final numeric
+ * definition. Authored `null` is different: it means the exact identity is
+ * unavailable and must remain unknown while its geometry is unchanged. */
+export function resolveTableColumnLayout(input: TableColumnLayoutInput): ResolvedTableColumnLayout {
+  const widthsPt = solveTableColumnWidths(input);
+  const widthKeys = widthsPt.map((width, column) => {
+    const changed = width !== input.gridWidthsPt[column];
+    if (!changed && input.gridWidthKeys?.[column] === null) return null;
+    if (!changed && input.gridWidthKeys?.[column] !== undefined) {
+      return input.gridWidthKeys[column]!;
+    }
+    return exactLengthKeyFromNumber(width) ?? '0/1';
+  });
+  return Object.freeze({
+    widthsPt: Object.freeze([...widthsPt]),
+    widthKeys: Object.freeze(widthKeys),
+  });
+}
+
+export function resolveTableColumnWidths(input: TableColumnLayoutInput): readonly number[] {
+  return resolveTableColumnLayout(input).widthsPt;
 }

--- a/packages/docx/src/layout/table.ts
+++ b/packages/docx/src/layout/table.ts
@@ -3,6 +3,7 @@ import { retainedBorderTreatment } from './border-treatment.js';
 import { paragraphGapPt } from './paragraph-spacing.js';
 import { snapshotPlainData } from './plain-data.js';
 import { tableCellHorizontalSpacingInsets } from './table-columns.js';
+import { firstAuthoredTableBorder } from './table-border-layer.js';
 import type {
   BlockLayoutResult,
   FlowBlockPlacement,
@@ -287,18 +288,6 @@ function toConflictCandidate(
   };
 }
 
-function firstAuthoredBorder(
-  ...borders: readonly (TableBorderInput | null)[]
-): TableBorderInput | null {
-  for (const border of borders) {
-    // Word treats `none` like omission while resolving cell -> style ->
-    // tblPrEx -> table borders; `nil` remains specified because it suppresses
-    // the final shared edge ([MS-OI29500] 2.1.169).
-    if (border && border.authoredStyle !== 'none') return border;
-  }
-  return null;
-}
-
 function physicalCellEdges(
   cell: TableCellLayoutInput,
   table: TableEdgeInputs,
@@ -323,12 +312,12 @@ function physicalCellEdges(
     tableInside: TableBorderInput | null,
     useInside: boolean,
   ): BorderCandidate | null => {
-    const resolvedCell = firstAuthoredBorder(direct, useInside ? cellInside : null);
+    const resolvedCell = firstAuthoredTableBorder(direct, useInside ? cellInside : null);
     if (resolvedCell) return toConflictCandidate(resolvedCell, 'cell');
     return toConflictCandidate(
       useInside
-        ? firstAuthoredBorder(exceptionInside, tableInside)
-        : firstAuthoredBorder(exceptionOuter, tableOuter),
+        ? firstAuthoredTableBorder(exceptionInside, tableInside)
+        : firstAuthoredTableBorder(exceptionOuter, tableOuter),
       'table',
     );
   };
@@ -632,7 +621,7 @@ function materializeBorders(
         const exceptionBorder = boundary === 0
           ? input.rows[0]?.exceptionBorders?.top ?? null
           : input.rows.at(-1)?.exceptionBorders?.bottom ?? null;
-        const tableBorder = firstAuthoredBorder(
+        const tableBorder = firstAuthoredTableBorder(
           exceptionBorder,
           boundary === 0 ? input.borders.top : input.borders.bottom,
         );
@@ -661,11 +650,11 @@ function materializeBorders(
           if (conditionalInsideOverridesTable) return;
           const startXPt = columnX(gridRow, column);
           const endXPt = columnX(gridRow, column + 1);
-          const aboveTableBorder = firstAuthoredBorder(
+          const aboveTableBorder = firstAuthoredTableBorder(
             input.rows[boundary - 1]?.exceptionBorders?.insideH ?? null,
             input.borders.insideH,
           );
-          const belowTableBorder = firstAuthoredBorder(
+          const belowTableBorder = firstAuthoredTableBorder(
             input.rows[boundary]?.exceptionBorders?.insideH ?? null,
             input.borders.insideH,
           );
@@ -792,11 +781,11 @@ function materializeBorders(
     const rowTopPt = rowY(rowIndex);
     const rowBottomPt = rowY(rowIndex + 1);
     const tableXPt = rowXPt[rowIndex] ?? 0;
-    push(firstAuthoredBorder(row.exceptionBorders?.left ?? null, input.borders.left),
+    push(firstAuthoredTableBorder(row.exceptionBorders?.left ?? null, input.borders.left),
       'left', { xPt: tableXPt, yPt: rowTopPt }, {
       xPt: tableXPt, yPt: rowBottomPt,
     });
-    push(firstAuthoredBorder(row.exceptionBorders?.right ?? null, input.borders.right),
+    push(firstAuthoredTableBorder(row.exceptionBorders?.right ?? null, input.borders.right),
       'right', { xPt: tableXPt + tableWidthPt, yPt: rowTopPt }, {
       xPt: tableXPt + tableWidthPt, yPt: rowBottomPt,
     });
@@ -817,7 +806,7 @@ function materializeBorders(
       if (!separatesOwners) continue;
       const xPt = columnX(rowIndex, boundary);
       if (!conditionalInsideVBoundaries.has(boundary)) {
-        push(firstAuthoredBorder(
+        push(firstAuthoredTableBorder(
           row.exceptionBorders?.insideV ?? null,
           input.borders.insideV,
         ), 'between',

--- a/packages/docx/src/layout/types.ts
+++ b/packages/docx/src/layout/types.ts
@@ -897,6 +897,7 @@ export interface TableColumnLayoutInput {
   readonly layout: 'fixed' | 'autofit';
   readonly availableWidthPt: number;
   readonly gridWidthsPt: readonly number[];
+  readonly gridWidthKeys?: readonly (string | null)[];
   readonly tablePreferredWidthPt: number | null;
   readonly rows: readonly TableColumnRowConstraint[];
 }
@@ -944,6 +945,10 @@ export interface TableRowFormatInput {
 export interface TableFormatInput {
   readonly effectiveStyleId: string | null;
   readonly ordinaryFlow: boolean;
+  /** Parser-owned ECMA-376 §17.4.37 logical table membership. */
+  readonly logicalSequenceId?: string | null;
+  readonly logicalRowOffset?: number;
+  readonly logicalTotalRows?: number;
   readonly positioning: FloatingTablePositionInput | null;
   readonly rows: readonly TableRowFormatInput[];
   readonly firstRowException: TableRowExceptionInput | null;
@@ -995,7 +1000,9 @@ export interface TableRowLayoutInput {
   readonly exceptionBorders: TableEdgeInputs | null;
   /** Effective §17.4.27/.26 row alignment. */
   readonly alignment: 'left' | 'center' | 'right';
-  /** Effective table indent after Word's first-row tblPrEx rule. */
+  /** Effective table indent after Word's first-row tblPrEx rule. In an adjacent
+   * §17.4.37 group this is re-oriented into the group frame by the union
+   * builder, so no separate physical-indent field is retained here. */
   readonly indentPt: number;
   readonly cells: readonly TableCellLayoutInput[];
   readonly repeatedHeader: boolean;
@@ -1011,6 +1018,8 @@ export interface TableLayoutInput {
   readonly indentPt: number;
   readonly bidiVisual: boolean;
   readonly columnWidthsPt: readonly number[];
+  /** Exact grid topology; numeric widths remain the Canvas paint coordinate. */
+  readonly columnWidthKeys?: readonly (string | null)[];
   readonly borders: TableEdgeInputs;
   readonly rows: readonly TableRowLayoutInput[];
 }

--- a/packages/docx/src/parser-model.ts
+++ b/packages/docx/src/parser-model.ts
@@ -45,6 +45,13 @@ import {
 } from './layout/textbox-input.js';
 import { tableCellHorizontalSpacingInsets } from './layout/table-columns.js';
 import {
+  divideExactLengthKey,
+  exactLengthKeyFromDecimal,
+  exactLengthKeyFromNumber,
+  exactLengthKeyToNumber,
+  multiplyExactLengthKeys,
+} from './layout/exact-length.js';
+import {
   sectionGeometry,
   type BodySectionIndexInput,
   type BodySectionOccurrence,
@@ -170,6 +177,12 @@ export interface TableLayoutAcquisitionWire {
   /** Word-effective flow participation after [MS-OI29500] 2.1.162(b-c), not
    * the lexical presence/absence of the public `tblpPr` compatibility field. */
   readonly ordinaryFlow: boolean;
+  /** Parser-owned ECMA-376 Part 1 §17.4.37 logical-table membership. The parser
+   * assigns one id per logical table (a standalone table receives its own id),
+   * so equal ids on directly adjacent source tables mean one logical table. */
+  readonly logicalSequenceId?: string | null;
+  readonly logicalRowOffset?: number;
+  readonly logicalTotalRows?: number;
   readonly grid: {
     readonly authored: boolean;
     readonly columns: readonly { readonly width: string | null }[];
@@ -535,6 +548,10 @@ export function tableFormatInput(table: Readonly<DocTable>): TableFormatInput {
   const input = snapshotPlainData({
     effectiveStyleId: acquisition.table?.effectiveStyleId ?? null,
     ordinaryFlow,
+    // §17.4.37 membership is decided by the parser; carry its facts verbatim.
+    logicalSequenceId: acquisition.table?.logicalSequenceId ?? null,
+    logicalRowOffset: acquisition.table?.logicalRowOffset ?? 0,
+    logicalTotalRows: acquisition.table?.logicalTotalRows ?? 0,
     positioning: ordinaryFlow || table.tblpPr == null
       ? null
       : floatingTablePositionInput(table.tblpPr),
@@ -553,11 +570,16 @@ export function adjacentTableSequenceInput(
   return Object.freeze(body.map((element) => {
     if (element.type !== 'table') return Object.freeze({ element, table: null });
     const format = tableFormatInput(element);
+    // A hand-built public table has no acquisition wire and therefore no
+    // parser-owned logical identity; it can never join a logical sequence.
+    if (format.logicalSequenceId == null) return Object.freeze({ element, table: null });
     return Object.freeze({
       element,
       table: Object.freeze({
-        effectiveStyleId: format.effectiveStyleId,
-        ordinaryFlow: format.ordinaryFlow,
+        logicalSequenceId: format.logicalSequenceId,
+        logicalRowOffset: format.logicalRowOffset ?? 0,
+        logicalTotalRows: format.logicalTotalRows ?? 0,
+        rowCount: element.rows.length,
       }),
     });
   }));
@@ -601,14 +623,129 @@ function tablePreferredWidthPt(
   return null;
 }
 
-function tableGridWidthsPt(table: DocTable, input: TableAcquisitionInput): number[] {
+const tableGridPointFactors: Readonly<Record<string, string>> = Object.freeze({
+  pt: '1/1',
+  in: '72/1',
+  cm: '3600/127',
+  mm: '360/127',
+  pc: '12/1',
+  pi: '12/1',
+});
+
+const xsdUnsignedLongMaximum = '18446744073709551615';
+
+function xsdUnsignedLongLexical(value: string): string | null {
+  const collapsed = value
+    .replace(/[\u0009\u000a\u000d\u0020]+/g, ' ')
+    .replace(/^ | $/g, '');
+  const match = /^([+-]?)([0-9]+)$/.exec(collapsed);
+  if (!match) return null;
+  const [, sign, authoredDigits] = match;
+  if (sign === '-' && /[1-9]/.test(authoredDigits!)) return null;
+  const digits = authoredDigits!.replace(/^0+/, '') || '0';
+  if (digits.length > xsdUnsignedLongMaximum.length
+    || (digits.length === xsdUnsignedLongMaximum.length && digits > xsdUnsignedLongMaximum)) {
+    return null;
+  }
+  return collapsed;
+}
+
+/** One resolved tblGrid column paired with its deterministic binary64 geometry.
+ *
+ * `key` distinguishes three states precisely:
+ *  - a valid exact key: the authored identity is known exactly;
+ *  - `'0/1'`: a DEFINITIONAL zero — the width was missing or lexically invalid,
+ *    so it is repaired to a known-zero identity (not "unknown");
+ *  - `null`: a valid measure whose exact authored identity is UNAVAILABLE
+ *    (over budget). `null` does NOT assert equality between tracks; two distinct
+ *    over-budget widths can share `null` yet carry different `widthPt`, and the
+ *    union must keep them distinct rather than merging on geometry. */
+interface GridTrack {
+  readonly key: string | null;
+  readonly widthPt: number;
+}
+
+/** A valid exact key retains its identity only while it maps to a finite
+ * coordinate; an over-range (infinite) coordinate has no paint geometry, so the
+ * identity is dropped and the width falls back to zero. */
+function exactTrack(key: string): GridTrack {
+  const widthPt = exactLengthKeyToNumber(key);
+  return Number.isFinite(widthPt) ? { key, widthPt } : definitionalZeroTrack;
+}
+
+/** Deterministic geometry for a lexically valid but over-budget universal
+ * measure: convert the magnitude to binary64 FIRST, then apply the exact unit
+ * factor and round once. The exact identity is unknown (`key: null`), but the
+ * authored geometry survives (0.000…001pt -> 0, 72.000…001pt -> 72pt). */
+function degradedTrack(magnitude: string, factor: string): GridTrack {
+  const magnitudeF64 = Number(magnitude);
+  if (!Number.isFinite(magnitudeF64)) return definitionalZeroTrack;
+  const exactMagnitude = exactLengthKeyFromNumber(magnitudeF64);
+  const widthPt = exactMagnitude === null
+    ? 0
+    : exactLengthKeyToNumber(multiplyExactLengthKeys(exactMagnitude, factor));
+  return Number.isFinite(widthPt) ? { key: null, widthPt } : definitionalZeroTrack;
+}
+
+/** Normalize one ST_TwipsMeasure / ST_PositiveUniversalMeasure tblGrid column at
+ * the parser/layout adapter. Layout owns exact topology arithmetic but not OOXML
+ * unit or lexical semantics; this returns the exact authored identity together
+ * with its geometry. */
+/** A missing or lexically invalid width is repaired to a DEFINITIONAL zero: the
+ * identity is known (zero), not unknown. */
+const definitionalZeroTrack: GridTrack = { key: '0/1', widthPt: 0 };
+
+function tableGridTrack(value: string | null | undefined): GridTrack {
+  if (value == null) return definitionalZeroTrack;
+  const unsignedLong = xsdUnsignedLongLexical(value);
+  if (unsignedLong !== null) {
+    // xsd:unsignedLong is bounded (<= 2^64-1), so it is always within the exact
+    // budget and never needs degradation.
+    const twips = exactLengthKeyFromDecimal(unsignedLong);
+    return twips === null ? definitionalZeroTrack : exactTrack(divideExactLengthKey(twips, 20n));
+  }
+  // Union whitespace follows the successful member: xsd:unsignedLong collapses
+  // XML whitespace, while the xsd:string-based universal measure preserves it.
+  // Normalizing the union before member selection would accept unit-bearing
+  // values outside ECMA-376's lexical space.
+  const universal = /^([0-9]+(?:\.[0-9]+)?)(mm|cm|in|pt|pc|pi)$/.exec(value);
+  if (!universal) return definitionalZeroTrack;
+  const factor = tableGridPointFactors[universal[2]!]!;
+  const magnitude = exactLengthKeyFromDecimal(universal[1]!);
+  return magnitude === null
+    ? degradedTrack(universal[1]!, factor)
+    : exactTrack(multiplyExactLengthKeys(magnitude, factor));
+}
+
+interface TableGridLayout {
+  readonly widthsPt: readonly number[];
+  readonly widthKeys: readonly (string | null)[];
+}
+
+/** Resolve the tblGrid column topology once into paired numeric widths and exact
+ * identity keys. A hand-built table keeps the public numeric `Math.max(0, width)`
+ * contract. */
+function tableGridLayout(table: DocTable, input: TableAcquisitionInput): TableGridLayout {
   const grid = input.table?.grid;
-  if (!grid) return table.colWidths.map((width) => Math.max(0, width));
+  if (!grid) {
+    const tracks = table.colWidths.map((width): GridTrack => (
+      Number.isFinite(width) && width >= 0
+        ? { widthPt: width, key: exactLengthKeyFromNumber(width) ?? '0/1' }
+        : definitionalZeroTrack
+    ));
+    return {
+      widthsPt: tracks.map((track) => track.widthPt),
+      widthKeys: tracks.map((track) => track.key),
+    };
+  }
   const count = Math.max(grid.requiredColumnCount, grid.columns.length);
-  return Array.from({ length: count }, (_unused, column) => {
-    const points = tableTwipsValuePt(grid.columns[column]?.width ?? null);
-    return points === null ? 0 : Math.max(0, points);
-  });
+  const tracks = Array.from({ length: count }, (_unused, column) => (
+    tableGridTrack(grid.columns[column]?.width ?? null)
+  ));
+  return {
+    widthsPt: tracks.map((track) => track.widthPt),
+    widthKeys: tracks.map((track) => track.key),
+  };
 }
 
 function skippedTableWidthConstraint(
@@ -629,7 +766,10 @@ export function tableColumnLayoutInput(
 ): TableColumnLayoutInput {
   const acquisition = tableAcquisitionInput(table);
   const format = tableFormatInput(table);
-  const gridWidthsPt = tableGridWidthsPt(table as DocTable, acquisition);
+  const { widthsPt: gridWidthsPt, widthKeys: gridWidthKeys } = tableGridLayout(
+    table as DocTable,
+    acquisition,
+  );
   const layoutKind = format.firstRowException?.layout === 'fixed'
     ? 'fixed'
     : (acquisition.table?.layout?.kind ?? table.layout);
@@ -652,6 +792,7 @@ export function tableColumnLayoutInput(
     layout: layoutKind === 'fixed' ? 'fixed' : 'autofit',
     availableWidthPt: Math.max(0, maximumWidthPt),
     gridWidthsPt,
+    gridWidthKeys,
     tablePreferredWidthPt: tablePreferredWidthPt(
       table as DocTable,
       acquisition,

--- a/packages/docx/src/table-column-input.test.ts
+++ b/packages/docx/src/table-column-input.test.ts
@@ -7,6 +7,298 @@ function emptyBorders() {
 }
 
 describe('table column acquisition boundary', () => {
+  it('repairs invalid hand-built numeric widths to definitional zero', () => {
+    const table = {
+      colWidths: [-1, Number.NaN, Number.POSITIVE_INFINITY], rows: [], borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+      jc: 'left',
+    } as unknown as DocTable;
+
+    const result = tableColumnLayoutInput(table, 200, () => ({ minWidthPt: 0, maxWidthPt: 0 }));
+
+    expect(result.gridWidthsPt).toEqual([0, 0, 0]);
+    expect(result.gridWidthKeys).toEqual(['0/1', '0/1', '0/1']);
+  });
+
+  it('repairs valid exact and over-budget measures with nonfinite geometry to definitional zero', () => {
+    const exactNonfinite = `${'1'}${'0'.repeat(400)}pt`;
+    const overBudgetNonfinite = `${'9'.repeat(800)}pt`;
+    const table = {
+      colWidths: [], rows: [], borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+      jc: 'left',
+      __tableLayout: {
+        effectiveStyleId: null,
+        grid: {
+          authored: true,
+          columns: [{ width: exactNonfinite }, { width: overBudgetNonfinite }],
+          requiredColumnCount: 2,
+        },
+        preferredWidth: null, layout: { kind: 'fixed' }, cellSpacing: null,
+      },
+    } as unknown as DocTable;
+
+    const result = tableColumnLayoutInput(table, Number.MAX_VALUE, () => ({
+      minWidthPt: 0, maxWidthPt: 0,
+    }));
+
+    expect(result.gridWidthsPt).toEqual([0, 0]);
+    expect(result.gridWidthKeys).toEqual(['0/1', '0/1']);
+  });
+  it('preserves the prior finite solver input for a schema-valid large unsigned twips measure', () => {
+    const lexicalTwips = '2542686831678384';
+    const table = {
+      colWidths: [], rows: [], borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+      jc: 'left',
+      __tableLayout: {
+        effectiveStyleId: null,
+        grid: {
+          authored: true,
+          columns: [{ width: lexicalTwips }],
+          requiredColumnCount: 1,
+        },
+        preferredWidth: null, layout: { kind: 'fixed' }, cellSpacing: null,
+      },
+    } as unknown as DocTable;
+
+    const result = tableColumnLayoutInput(table, Number.MAX_VALUE, () => ({
+      minWidthPt: 0, maxWidthPt: 0,
+    }));
+
+    expect(result.gridWidthsPt).toEqual([Number(lexicalTwips) / 20]);
+    expect(result.gridWidthKeys).toEqual(['635671707919596/5']);
+  });
+
+  it('normalizes equivalent Transitional and Strict grid measures to exact point identities', () => {
+    const table = {
+      colWidths: [], rows: [], borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+      jc: 'left',
+      __tableLayout: {
+        effectiveStyleId: null,
+        grid: {
+          authored: true,
+          columns: [
+            { width: '3' },
+            { width: '0.15pt' },
+            { width: '1440' },
+            { width: '72pt' },
+            { width: '1in' },
+            { width: '2.54cm' },
+            { width: '25.4mm' },
+            { width: '6pc' },
+            { width: '6pi' },
+          ],
+          requiredColumnCount: 9,
+        },
+        preferredWidth: null, layout: { kind: 'fixed' }, cellSpacing: null,
+      },
+    } as unknown as DocTable;
+
+    const result = tableColumnLayoutInput(table, 200, () => ({
+      minWidthPt: 0, maxWidthPt: 0,
+    })) as ReturnType<typeof tableColumnLayoutInput> & {
+      readonly gridWidthKeys: readonly (string | null)[];
+    };
+
+    expect(result.gridWidthsPt.slice(0, 2)).toEqual([0.15, 0.15]);
+    expect(result.gridWidthKeys.slice(0, 2)).toEqual(['3/20', '3/20']);
+    expect(result.gridWidthKeys.slice(2)).toEqual([
+      '72/1', '72/1', '72/1', '72/1', '72/1', '72/1', '72/1',
+    ]);
+    expect(JSON.parse(JSON.stringify(result)).gridWidthKeys).toEqual(result.gridWidthKeys);
+    expect(() => structuredClone(result)).not.toThrow();
+  });
+
+  it('accepts the xsd:unsignedLong maximum and rejects unitless overflow before exact arithmetic', () => {
+    const table = {
+      colWidths: [], rows: [], borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+      jc: 'left',
+      __tableLayout: {
+        effectiveStyleId: null,
+        grid: {
+          authored: true,
+          columns: [
+            { width: ' 18446744073709551615\t' },
+            { width: '\n+18446744073709551615\r' },
+            { width: '18446744073709551616' },
+            { width: '+18446744073709551616' },
+            { width: '9'.repeat(10_000) },
+            { width: '-0' },
+            { width: ' \t-00\r\n' },
+          ],
+          requiredColumnCount: 7,
+        },
+        preferredWidth: null, layout: { kind: 'fixed' }, cellSpacing: null,
+      },
+    } as unknown as DocTable;
+
+    const result = tableColumnLayoutInput(table, 200, () => ({
+      minWidthPt: 0, maxWidthPt: 0,
+    }));
+
+    expect(result.gridWidthsPt).toEqual([
+      Number('18446744073709551615') / 20,
+      Number('18446744073709551615') / 20,
+      0,
+      0,
+      0,
+      0,
+      0,
+    ]);
+    expect(result.gridWidthKeys).toEqual([
+      '3689348814741910323/4',
+      '3689348814741910323/4',
+      '0/1',
+      '0/1',
+      '0/1',
+      '0/1',
+      '0/1',
+    ]);
+  });
+
+  it('enforces the ST_PositiveUniversalMeasure lexical grammar for unit-bearing widths', () => {
+    const table = {
+      colWidths: [], rows: [], borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+      jc: 'left',
+      __tableLayout: {
+        effectiveStyleId: null,
+        grid: {
+          authored: true,
+          columns: [
+            { width: '0.5pt' },
+            { width: '1.0pt' },
+            { width: '1e2pt' },
+            { width: '.5pt' },
+            { width: '1.pt' },
+            { width: '+1pt' },
+            { width: '-1pt' },
+            { width: ' 0.5pt' },
+            { width: '0.5pt ' },
+          ],
+          requiredColumnCount: 9,
+        },
+        preferredWidth: null, layout: { kind: 'fixed' }, cellSpacing: null,
+      },
+    } as unknown as DocTable;
+
+    const result = tableColumnLayoutInput(table, 200, () => ({
+      minWidthPt: 0, maxWidthPt: 0,
+    }));
+
+    expect(result.gridWidthsPt).toEqual([0.5, 1, 0, 0, 0, 0, 0, 0, 0]);
+    expect(result.gridWidthKeys).toEqual([
+      '1/2', '1/1', '0/1', '0/1', '0/1', '0/1', '0/1', '0/1', '0/1',
+    ]);
+  });
+
+  it('degrades an over-budget universal magnitude to binary64 geometry with a null identity', () => {
+    const table = {
+      colWidths: [], rows: [], borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+      jc: 'left',
+      __tableLayout: {
+        effectiveStyleId: null,
+        grid: {
+          authored: true,
+          columns: [
+            // Millions of redundant fraction digits: over the exact budget. The
+            // exact identity is unknown (key null) but the binary64 geometry
+            // (72pt) survives.
+            { width: `72.${'0'.repeat(1_000_000)}1pt` },
+            // A sub-underflow universal magnitude degrades to a zero track.
+            { width: `0.${'0'.repeat(1_000_000)}1pt` },
+            // A normal exact universal value keeps its exact identity.
+            { width: '18pt' },
+          ],
+          requiredColumnCount: 3,
+        },
+        preferredWidth: null, layout: { kind: 'fixed' }, cellSpacing: null,
+      },
+    } as unknown as DocTable;
+
+    const result = tableColumnLayoutInput(table, 200, () => ({
+      minWidthPt: 0, maxWidthPt: 0,
+    }));
+
+    expect(result.gridWidthKeys).toEqual([null, null, '18/1']);
+    expect(result.gridWidthsPt).toEqual([72, 0, 18]);
+  });
+
+  it('gives distinct over-budget widths a null identity but their true binary64 width', () => {
+    // Two authored widths that differ only past the exact budget both resolve to
+    // key: null (identity unknown, NOT asserting equality) yet keep width 72.
+    const table = {
+      colWidths: [], rows: [], borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+      jc: 'left',
+      __tableLayout: {
+        effectiveStyleId: null,
+        grid: {
+          authored: true,
+          columns: [
+            { width: `72.${'0'.repeat(800)}1pt` },
+            { width: `72.${'0'.repeat(800)}2pt` },
+          ],
+          requiredColumnCount: 2,
+        },
+        preferredWidth: null, layout: { kind: 'fixed' }, cellSpacing: null,
+      },
+    } as unknown as DocTable;
+
+    const result = tableColumnLayoutInput(table, 200, () => ({ minWidthPt: 0, maxWidthPt: 0 }));
+
+    expect(result.gridWidthKeys).toEqual([null, null]);
+    expect(result.gridWidthsPt).toEqual([72, 72]);
+  });
+
+  it('retains identity at the significant-digit budget and drops it beyond, both keeping geometry', () => {
+    const sig768 = `1.${'2'.repeat(767)}pt`; // 768 significant digits
+    const sig769 = `1.${'2'.repeat(768)}pt`; // 769 significant digits
+    const table = {
+      colWidths: [], rows: [], borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+      jc: 'left',
+      __tableLayout: {
+        effectiveStyleId: null,
+        grid: {
+          authored: true,
+          columns: [{ width: sig768 }, { width: sig769 }],
+          requiredColumnCount: 2,
+        },
+        preferredWidth: null, layout: { kind: 'fixed' }, cellSpacing: null,
+      },
+    } as unknown as DocTable;
+
+    const result = tableColumnLayoutInput(table, 200, () => ({ minWidthPt: 0, maxWidthPt: 0 }));
+
+    expect(result.gridWidthKeys![0]).not.toBeNull(); // 768 retained
+    expect(result.gridWidthKeys![1]).toBeNull(); // 769 over budget
+    expect(result.gridWidthsPt).toEqual([Number('1.' + '2'.repeat(767)), Number('1.' + '2'.repeat(768))]);
+  });
+
+  it('retains an in-budget subnormal underflow magnitude as an exact identity', () => {
+    const underflow = `0.${'0'.repeat(322)}1pt`; // 1e-323, in the decimal budget
+    const table = {
+      colWidths: [], rows: [], borders: emptyBorders(),
+      cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+      jc: 'left',
+      __tableLayout: {
+        effectiveStyleId: null,
+        grid: { authored: true, columns: [{ width: underflow }], requiredColumnCount: 1 },
+        preferredWidth: null, layout: { kind: 'fixed' }, cellSpacing: null,
+      },
+    } as unknown as DocTable;
+
+    const result = tableColumnLayoutInput(table, 200, () => ({ minWidthPt: 0, maxWidthPt: 0 }));
+
+    expect(result.gridWidthKeys![0]).not.toBeNull();
+    expect(result.gridWidthsPt[0]).toBe(1e-323);
+  });
+
   it('normalizes parser-private lexical widths without exposing parser objects to layout', () => {
     const cell = {
       content: [], colSpan: 3, vMerge: null, borders: emptyBorders(),
@@ -51,6 +343,9 @@ describe('table column acquisition boundary', () => {
     expect(result).toEqual({
       layout: 'fixed', availableWidthPt: 200,
       gridWidthsPt: [36, 0, 0, 0, 0],
+      // Exact authored grid identity: the '720' twip column is retained as its
+      // exact point key (720/20), never re-derived from the IEEE-754 width.
+      gridWidthKeys: ['36/1', '0/1', '0/1', '0/1', '0/1'],
       tablePreferredWidthPt: 150,
       rows: [{
         // wBefore/wAfter percentages use the page text extents (§17.4.85–86),

--- a/packages/docx/src/table-format-input.test.ts
+++ b/packages/docx/src/table-format-input.test.ts
@@ -79,9 +79,10 @@ describe('table format acquisition adapter', () => {
     });
   });
 
-  it('projects adjacent body values with cached effective table facts', () => {
-    const source = table([], {
+  it('projects parser-owned logical-sequence facts, not a layout membership decision', () => {
+    const source = table([{ cells: [] }], {
       effectiveStyleId: 'ProjectedStyle', ordinaryFlow: true,
+      logicalSequenceId: 'table-sequence:0', logicalRowOffset: 0, logicalTotalRows: 1,
       grid: { authored: false, columns: [], requiredColumnCount: 0 },
       preferredWidth: null, layout: null, cellSpacing: null,
     }) as DocTable & { type: 'table' };
@@ -93,12 +94,28 @@ describe('table format acquisition adapter', () => {
     expect(projected).toEqual([
       {
         element: source,
-        table: { effectiveStyleId: 'ProjectedStyle', ordinaryFlow: true },
+        table: {
+          logicalSequenceId: 'table-sequence:0',
+          logicalRowOffset: 0,
+          logicalTotalRows: 1,
+          rowCount: 1,
+        },
       },
       { element: paragraph, table: null },
     ]);
     expect(Object.isFrozen(projected)).toBe(true);
     expect(Object.isFrozen(projected[0]?.table)).toBe(true);
+  });
+
+  it('preserves no logical identity for a hand-built public table', () => {
+    const publicTable = {
+      type: 'table', colWidths: [10], rows: [{ cells: [] }], borders: noBorders,
+      cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0, jc: 'left',
+    } as unknown as BodyElement;
+
+    expect(adjacentTableSequenceInput([publicTable])).toEqual([
+      { element: publicTable, table: null },
+    ]);
   });
 
   it('distinguishes omitted hRule from explicit auto and converts twips once', () => {


### PR DESCRIPTION
## Summary

- move ECMA-376 Part 1 §17.4.37 adjacent-table membership and logical row sequencing into the DOCX parser
- preserve exact authored grid identities through acquisition and column solving without deriving topology from IEEE-754 values
- add a transient discriminated union-grid input with source-owned border facts, bidi-safe zero-track ordering, and linearly bounded symbolic unknown-width provenance

## Design

The parser is authoritative for effective style identity, ordinary-flow barriers, section boundaries, and logical row offsets. Layout consumes those facts without re-deriving membership. Exact topology uses reduced rational string keys so values remain structured-clone safe. Schema-valid measures beyond the exact arithmetic budget retain deterministic geometry while unknown identity is propagated fail-closed through an interned symbolic DAG.

The new group-grid type is intentionally not assignable to an ordinary table layout input. Occurrence projection and consumer cutover remain outside this PR.

Relevant behavior follows ECMA-376 Part 1 §§17.4.37 and 17.18.87, with Office-specific table-positioning and border-cascade behavior from MS-OI29500.

## Verification

- DOCX TypeScript: 246 files, 2,128 tests
- focused adjacent-grid and exact-width tests: 75 tests
- DOCX Rust parser: 410 tests
- cargo fmt and clippy with warnings denied
- DOCX typecheck and layout-boundary checker
- root package build and generated DOCX public API declaration comparison
- independent correctness, architecture, resource-safety, and full design reviews

Part of #1037.