### PR TITLE
refactor(docx): project retained body occurrences

### DIFF
--- a/packages/docx/src/layout/floating-table-transaction.ts
+++ b/packages/docx/src/layout/floating-table-transaction.ts
@@ -1,4 +1,5 @@
 import { resolveFloatOverlap } from '../float-layout.js';
+import { floatingTableAxesFollowHostFlow } from './retained-geometry-translation.js';
 import type {
   FloatRegistryEntryPt,
   FloatRegistryDeltaPt,
@@ -112,16 +113,12 @@ export function resolveFloatingTablePlacement(
   const widthPt = placement.child.columnWidthsPt.reduce((sum, width) => sum + width, 0);
   const heightPt = placement.child.advancePt;
   const raw = resolveFloatingTableBoxPt(placement.positioning, frames, widthPt, heightPt);
-  const usesTextX = !placement.positioning.horzSpecified
-    || (placement.positioning.horzAnchor !== 'page'
-      && placement.positioning.horzAnchor !== 'margin');
-  const usesTextY = placement.positioning.vertAnchor !== 'page'
-    && placement.positioning.vertAnchor !== 'margin';
+  const followsHost = floatingTableAxesFollowHostFlow(placement.positioning);
   return resolvedPlacement(
     placement,
-    usesTextX && placement.acquiredTextOffsetPt
+    followsHost.x && placement.acquiredTextOffsetPt
       ? frames.text.xPt + placement.acquiredTextOffsetPt.xPt : raw.x,
-    usesTextY && placement.acquiredTextOffsetPt
+    followsHost.y && placement.acquiredTextOffsetPt
       ? frames.text.yPt + placement.acquiredTextOffsetPt.yPt : raw.y,
   );
 }

--- a/packages/docx/src/layout/occurrence-projection.test.ts
+++ b/packages/docx/src/layout/occurrence-projection.test.ts
@@ -1,0 +1,645 @@
+import { describe, expect, it } from 'vitest';
+import { projectBodyOccurrence, translateBodyOccurrence } from './occurrence-projection.js';
+import type {
+  FloatingTablePlacementLayout, FloatingTablePositionInput, ParagraphLayout,
+  ResolvedFloatingTablePlacementLayout, TableLayout, TextBoxLayout, TextPlacement,
+} from './types.js';
+import type { TableFragmentLayout, TableRowFragmentLayout } from './table-pagination.js';
+import type { AnchorFrameResult } from './anchor-frame.js';
+import { floatingTableAxesFollowHostFlow } from './retained-geometry-translation.js';
+
+const source = (path: readonly number[]) => ({ story: 'body' as const, storyInstance: 'body', path });
+const rect = (xPt: number, yPt: number, widthPt = 10, heightPt = 10) => ({ xPt, yPt, widthPt, heightPt });
+
+function paragraph(id = 'paragraph'): ParagraphLayout {
+  return {
+    kind: 'paragraph', id, source: source([0]), flowDomainId: 'body', ordinaryFlow: true,
+    flowBounds: rect(1, 2, 40, 12), inkBounds: rect(1, 2, 30, 10), advancePt: 12,
+    spacing: { beforePt: 0, afterPt: 0 }, contextualSpacing: false,
+    lines: [{
+      range: { start: 0, end: 4 }, bounds: rect(1, 2, 20, 10), baselinePt: 10, advancePt: 12,
+      placements: [{
+        kind: 'text', text: 'PAGE', range: { start: 0, end: 4 }, origin: { xPt: 1, yPt: 10 },
+        bounds: rect(1, 2, 20, 10), advancePt: 20, clusters: [], paintOps: [],
+        color: { kind: 'explicit', color: '#000000' },
+        fontRoute: { familyList: 'serif', scope: 'native', fingerprint: 'serif' },
+        fontSizePt: 10, fontWeight: 400, fontStyle: 'normal', direction: 'ltr',
+        decorations: [], dependency: 'page', sourceRunIndex: 7,
+      } satisfies TextPlacement],
+    }],
+    borders: [], resources: [], drawings: [], textBoxes: [], events: [], exclusions: [],
+  };
+}
+
+function table(id = 'table'): TableLayout {
+  const child = paragraph(`${id}-cell-paragraph`);
+  return {
+    kind: 'table', id, source: source([1]), flowDomainId: 'body', ordinaryFlow: true,
+    flowBounds: rect(5, 6, 100, 20), inkBounds: rect(5, 6, 100, 20), advancePt: 20,
+    columnWidthsPt: [100], borders: [], rows: [{
+      kind: 'table-row', id: `${id}-row`, source: source([1, 0]), flowDomainId: 'body', ordinaryFlow: true,
+      flowBounds: rect(5, 6, 100, 20), inkBounds: rect(5, 6, 100, 20), advancePt: 20,
+      heightPt: 20, contentHeightPt: 12, cells: [{
+        kind: 'table-cell', id: `${id}-cell`, source: source([1, 0, 0]), flowDomainId: 'cell-source', ordinaryFlow: true,
+        flowBounds: rect(5, 6, 100, 20), inkBounds: rect(5, 6, 100, 20), advancePt: 20,
+        contentBounds: rect(7, 8, 96, 16), verticalMerge: 'none', vAlign: 'top',
+        blocks: [{ layout: child, offsetPt: 2, advancePt: 12 }],
+      }],
+    }],
+  };
+}
+
+const options = {
+  occurrenceId: 'page 2/header',
+  destination: {
+    coordinateSpace: 'logical-body-points' as const,
+    flowDomainId: 'body/page-2', translation: { xPt: 20, yPt: 30 },
+  },
+};
+
+const floatingPosition = (overrides: Partial<FloatingTablePositionInput> = {}): FloatingTablePositionInput => ({
+  leftFromTextPt: 1, rightFromTextPt: 1, topFromTextPt: 1, bottomFromTextPt: 1,
+  horzAnchor: 'page', horzSpecified: true, vertAnchor: 'text', xPt: 0, yPt: 0,
+  ...overrides,
+});
+
+type ProjectedTableGraph = TableLayout & Readonly<{
+  floatingTables?: readonly FloatingTablePlacementLayout[];
+  resolvedFloatingTables?: readonly ResolvedFloatingTablePlacementLayout[];
+}>;
+
+interface ProjectedGraphFacts {
+  readonly nodeIds: ReadonlySet<string>;
+  readonly anchorIds: ReadonlySet<string>;
+  readonly occurrenceIds: ReadonlySet<string>;
+}
+
+function validateProjectedGraph(
+  root: ParagraphLayout | TableLayout,
+  outerOccurrenceId: string,
+  externalAnchorRefs: ReadonlySet<string> = new Set(),
+): ProjectedGraphFacts {
+  const nodeOwners = new Map<string, Readonly<{ owner: object; kind: string }>>();
+  const anchorOwners = new Map<string, object>();
+  const nodeRefs: Array<Readonly<{ id: string; kind: 'drawing' | 'textbox' | 'table-cell' | 'table' }>> = [];
+  const anchorRefs = new Set<string>();
+  const floatOccurrenceIds = new Set<string>();
+  const rowStamps = new Set<string>();
+  const visited = new WeakSet<object>();
+  const ownNode = (id: string, owner: object, kind: string) => {
+    expect(id.startsWith(`${outerOccurrenceId}/node/`)).toBe(true);
+    const prior = nodeOwners.get(id);
+    expect(prior === undefined || prior.owner === owner).toBe(true);
+    nodeOwners.set(id, { owner, kind });
+  };
+  const visit = (layout: ParagraphLayout | TableLayout): void => {
+    if (visited.has(layout)) return;
+    visited.add(layout);
+    ownNode(layout.id, layout, layout.kind);
+    if (layout.kind === 'paragraph') {
+      for (const line of layout.lines) for (const placement of line.placements) {
+        if (placement.kind === 'drawing') nodeRefs.push({ id: placement.drawingId, kind: 'drawing' });
+        if (placement.kind === 'anchor-host' && placement.anchorOccurrenceId) {
+          anchorRefs.add(placement.anchorOccurrenceId);
+        }
+      }
+      for (const drawing of layout.drawings) {
+        ownNode(drawing.id, drawing, 'drawing');
+        drawing.textBoxIds?.forEach((id) => nodeRefs.push({ id, kind: 'textbox' }));
+        if (drawing.anchorLayer) {
+          const id = drawing.anchorLayer.occurrenceId;
+          expect(id.startsWith(`${outerOccurrenceId}/anchor/`)).toBe(true);
+          const prior = anchorOwners.get(id);
+          expect(prior === undefined || prior === drawing).toBe(true);
+          anchorOwners.set(id, drawing);
+        }
+      }
+      for (const textBox of layout.textBoxes) {
+        ownNode(textBox.id, textBox, 'textbox');
+        textBox.paragraphs.forEach(visit);
+      }
+      for (const exclusion of layout.exclusions) {
+        ownNode(exclusion.id, exclusion, 'exclusion');
+        if (exclusion.anchorOccurrenceId) anchorRefs.add(exclusion.anchorOccurrenceId);
+      }
+      layout.anchorFrames?.forEach((frame) => anchorRefs.add(frame.occurrenceId));
+      return;
+    }
+    const tableGraph = layout as ProjectedTableGraph;
+    for (const row of layout.rows) {
+      ownNode(row.id, row, 'table-row');
+      if ('occurrenceId' in row && typeof row.occurrenceId === 'string') {
+        expect(row.occurrenceId.startsWith(`${outerOccurrenceId}/occurrence/`)).toBe(true);
+        rowStamps.add(row.occurrenceId);
+      }
+      for (const cell of row.cells) {
+        ownNode(cell.id, cell, 'table-cell');
+        cell.blocks.forEach((block) => visit(block.layout));
+      }
+    }
+    const validateSource = (placement: FloatingTablePlacementLayout) => {
+      expect(placement.occurrenceId.startsWith(`${outerOccurrenceId}/occurrence/`)).toBe(true);
+      floatOccurrenceIds.add(placement.occurrenceId);
+      nodeRefs.push({ id: placement.hostCellId, kind: 'table-cell' });
+      nodeRefs.push({ id: placement.tableId, kind: 'table' });
+      expect(placement.tableId).toBe(placement.child.id);
+      visit(placement.child);
+    };
+    tableGraph.floatingTables?.forEach(validateSource);
+    tableGraph.resolvedFloatingTables?.forEach((resolved) => {
+      validateSource(resolved.source);
+      floatOccurrenceIds.add(resolved.occurrenceId);
+      expect(resolved.occurrenceId).toBe(resolved.source.occurrenceId);
+      expect(resolved.child).toBe(resolved.source.child);
+    });
+  };
+  visit(root);
+  for (const reference of nodeRefs) expect(nodeOwners.get(reference.id)?.kind).toBe(reference.kind);
+  for (const reference of anchorRefs) {
+    expect(anchorOwners.has(reference) || externalAnchorRefs.has(reference)).toBe(true);
+  }
+  return {
+    nodeIds: new Set(nodeOwners.keys()),
+    anchorIds: new Set(anchorOwners.keys()),
+    occurrenceIds: new Set([...floatOccurrenceIds, ...rowStamps]),
+  };
+}
+
+function expectDisjoint(left: ReadonlySet<string>, right: ReadonlySet<string>): void {
+  for (const value of left) expect(right.has(value)).toBe(false);
+}
+
+it('uses one tblpPr predicate for mixed-axis host ownership', () => {
+  expect(floatingTableAxesFollowHostFlow(floatingPosition({
+    horzAnchor: 'page', horzSpecified: true, vertAnchor: 'text',
+  }))).toEqual({ x: false, y: true });
+  expect(floatingTableAxesFollowHostFlow(floatingPosition({
+    horzAnchor: 'text', horzSpecified: true, vertAnchor: 'page',
+  }))).toEqual({ x: true, y: false });
+});
+
+describe('translateBodyOccurrence', () => {
+  it('translates geometry while preserving the complete identity graph', () => {
+    const retained = paragraph();
+    const translated = translateBodyOccurrence(retained, { xPt: 20, yPt: 30 });
+
+    expect(translated).toMatchObject({
+      id: retained.id, flowDomainId: retained.flowDomainId,
+      flowBounds: { xPt: 21, yPt: 32 },
+      lines: [{ baselinePt: 40, placements: [{ text: 'PAGE', origin: { xPt: 21, yPt: 40 } }] }],
+    });
+    expect(retained.flowBounds).toEqual(rect(1, 2, 40, 12));
+  });
+
+  it('rejects non-finite translations', () => {
+    expect(() => translateBodyOccurrence(paragraph(), { xPt: Number.NaN, yPt: 0 })).toThrow(RangeError);
+  });
+});
+
+describe('projectBodyOccurrence', () => {
+  it('rejects two distinct drawing owners claiming one raw anchor occurrence ID', () => {
+    const retained = paragraph();
+    const drawing = (id: string) => ({
+      kind: 'drawing' as const, id, source: source([0, id.length]), flowDomainId: 'body', ordinaryFlow: false,
+      flowBounds: rect(1, 2), inkBounds: rect(1, 2), advancePt: 0, commands: [],
+      anchorLayer: { occurrenceId: 'same-anchor', behindDoc: false, relativeHeight: 0, sourceOrder: 0,
+        horizontalOwnership: 'host' as const, verticalOwnership: 'host' as const },
+    });
+
+    expect(() => projectBodyOccurrence({ ...retained, drawings: [drawing('one'), drawing('two')] }, options))
+      .toThrow('duplicate anchor occurrence owner');
+  });
+
+  it('allows repeated references to one drawing anchor owner', () => {
+    const retained = paragraph();
+    const drawing = {
+      kind: 'drawing' as const, id: 'shared-drawing', source: source([0, 1]), flowDomainId: 'body',
+      ordinaryFlow: false, flowBounds: rect(1, 2), inkBounds: rect(1, 2), advancePt: 0, commands: [],
+      anchorLayer: { occurrenceId: 'shared-anchor', behindDoc: false, relativeHeight: 0, sourceOrder: 0,
+        horizontalOwnership: 'host' as const, verticalOwnership: 'host' as const },
+    };
+
+    const projected = projectBodyOccurrence({ ...retained, drawings: [drawing, drawing] }, options);
+
+    expect(projected.drawings[0]).toBe(projected.drawings[1]);
+    validateProjectedGraph(projected, options.occurrenceId);
+  });
+
+  it('rejects two distinct floating source owners claiming one raw occurrence ID', () => {
+    const firstChild = table('float-child-one');
+    const secondChild = table('float-child-two');
+    const placement = (child: TableLayout): FloatingTablePlacementLayout => ({
+      kind: 'floating-table-placement', occurrenceId: 'same-float', ownership: 'source',
+      physicalPageIndex: 0, displayPageNumber: 1, hostCellId: 'table-cell', sourceBlockIndex: 0,
+      anchorBlockIndex: 0, tableId: child.id, overlap: 'overlap', positioning: floatingPosition(),
+      anchorBounds: rect(1, 2), child,
+    });
+    const retained = Object.assign(table(), {
+      floatingTables: [placement(firstChild), placement(secondChild)],
+      resolvedFloatingTables: [] as ResolvedFloatingTablePlacementLayout[],
+    });
+
+    expect(() => projectBodyOccurrence(retained, options))
+      .toThrow('duplicate floating placement occurrence owner');
+  });
+
+  it('re-keys a paragraph graph deterministically and preserves acquisition occurrence identity', () => {
+    const retained = paragraph();
+    const drawing = {
+      kind: 'drawing' as const, id: 'drawing/a', source: source([0, 0]), flowDomainId: 'body', ordinaryFlow: false,
+      flowBounds: rect(3, 4), inkBounds: rect(3, 4), advancePt: 0, commands: [],
+      anchorLayer: {
+        occurrenceId: 'anchor/a', behindDoc: false, relativeHeight: 1, sourceOrder: 0,
+        horizontalOwnership: 'host' as const, verticalOwnership: 'host' as const,
+      },
+    };
+    const withDrawing = {
+      ...retained,
+      drawings: [drawing],
+      lines: [{ ...retained.lines[0]!, placements: [{
+        kind: 'drawing' as const, range: { start: 0, end: 0 }, drawingId: drawing.id,
+        bounds: drawing.flowBounds, advancePt: 0,
+      }] }],
+      exclusions: [{
+        id: 'exclusion', wrap: 'square' as const, bounds: drawing.flowBounds,
+        polygon: [{ xPt: 3, yPt: 4 }], anchorOccurrenceId: 'anchor/a',
+      }],
+    };
+
+    const first = projectBodyOccurrence(withDrawing, options);
+    const again = projectBodyOccurrence(withDrawing, options);
+    const anchor = first.drawings[0]!.anchorLayer!;
+
+    expect(first).toEqual(again);
+    expect(first.id).toBe('page 2/header/node/paragraph');
+    expect(first.drawings[0]!.id).toBe('page 2/header/node/drawing%2Fa');
+    expect(first.lines[0]!.placements[0]).toMatchObject({ drawingId: first.drawings[0]!.id });
+    expect(anchor).toMatchObject({
+      occurrenceId: 'page 2/header/anchor/anchor%2Fa', acquisitionOccurrenceId: 'anchor/a',
+    });
+    expect(first.exclusions[0]!.anchorOccurrenceId).toBe(anchor.occurrenceId);
+    validateProjectedGraph(first, options.occurrenceId);
+  });
+
+  it('makes repeated occurrences disjoint while preserving source and shaped field metadata', () => {
+    const retained = paragraph();
+    const first = projectBodyOccurrence(retained, options);
+    const second = projectBodyOccurrence(retained, { ...options, occurrenceId: 'page-3' });
+
+    expect(first.id).not.toBe(second.id);
+    expect(first.source).toEqual(retained.source);
+    expect(first.lines[0]!.placements[0]).toEqual(expect.objectContaining({ text: 'PAGE' }));
+    expect(first.lines[0]!.placements[0]).toEqual(expect.objectContaining({
+      text: 'PAGE', dependency: 'page', sourceRunIndex: 7,
+    }));
+    const firstFacts = validateProjectedGraph(first, options.occurrenceId);
+    const secondFacts = validateProjectedGraph(second, 'page-3');
+    expectDisjoint(firstFacts.nodeIds, secondFacts.nodeIds);
+    expectDisjoint(firstFacts.anchorIds, secondFacts.anchorIds);
+    expectDisjoint(firstFacts.occurrenceIds, secondFacts.occurrenceIds);
+  });
+
+  it('projects table, row and cell identity without double-translating cell-local blocks', () => {
+    const retained = table();
+    const projected = projectBodyOccurrence(retained, options);
+    const cell = projected.rows[0]!.cells[0]!;
+
+    expect(projected.flowBounds).toMatchObject({ xPt: 25, yPt: 36 });
+    expect(projected.rows[0]!.id).toBe('page 2/header/node/table-row');
+    expect(cell.id).toBe('page 2/header/node/table-cell');
+    expect(cell.flowDomainId).toBe('body/page-2/occurrence/page%202%2Fheader/cell/table-cell');
+    expect(cell.blocks[0]!.layout.flowBounds).toEqual(retained.rows[0]!.cells[0]!.blocks[0]!.layout.flowBounds);
+    expect(cell.blocks[0]!.layout.id).toBe('page 2/header/node/table-cell-paragraph');
+  });
+
+  it('preserves resolved floating table aliases through snapshotting and keeps page-owned axes fixed', () => {
+    const nested = table('nested');
+    const sourcePlacement: FloatingTablePlacementLayout = {
+      kind: 'floating-table-placement' as const, occurrenceId: 'float-source', ownership: 'source' as const,
+      physicalPageIndex: 4, displayPageNumber: 9, hostCellId: 'table-cell', sourceBlockIndex: 2,
+      anchorBlockIndex: 2, tableId: 'nested', overlap: 'overlap' as const,
+      positioning: floatingPosition({ horzAnchor: 'page', horzSpecified: true, vertAnchor: 'margin' }),
+      columnBounds: rect(60, 70), anchorBounds: rect(70, 80), child: nested,
+    };
+    const resolved: ResolvedFloatingTablePlacementLayout = {
+      kind: 'resolved-floating-table-placement' as const, occurrenceId: 'float-source',
+      xPt: 70, yPt: 80, bounds: rect(70, 80), exclusionBounds: rect(69, 79, 12, 12),
+      overlap: 'overlap' as const, child: nested, source: sourcePlacement,
+    };
+    const retained = Object.assign(table(), {
+      floatingTables: [] as FloatingTablePlacementLayout[], resolvedFloatingTables: [resolved],
+    });
+
+    const projected = projectBodyOccurrence(retained, options) as typeof retained;
+    const projectedResolved = projected.resolvedFloatingTables[0]!;
+
+    expect(projectedResolved.bounds).toEqual(rect(70, 80));
+    expect(projectedResolved.source.anchorBounds).toEqual(rect(90, 110));
+    expect(projectedResolved.source.columnBounds).toEqual(rect(80, 100));
+    expect(projectedResolved.source.child.flowDomainId)
+      .toBe('body/page-2/occurrence/page%202%2Fheader/cell/table-cell');
+    expect(projectedResolved.child).toBe(projectedResolved.source.child);
+    const clone = structuredClone(projectedResolved);
+    expect(clone.child).toBe(clone.source.child);
+    expect(projectedResolved.occurrenceId).toBe('page 2/header/occurrence/float-source');
+    expect(projectedResolved.source.occurrenceId).toBe('page 2/header/occurrence/float-source');
+    validateProjectedGraph(projected, options.occurrenceId);
+  });
+
+  it('translates an unresolved-only float anchor and column with host flow', () => {
+    const child = table('unresolved-child');
+    const unresolved: FloatingTablePlacementLayout = {
+      kind: 'floating-table-placement', occurrenceId: 'unresolved', ownership: 'source',
+      physicalPageIndex: 0, displayPageNumber: 1, hostCellId: 'table-cell', sourceBlockIndex: 0,
+      anchorBlockIndex: 0, tableId: child.id, overlap: 'overlap',
+      positioning: floatingPosition({ horzAnchor: 'page', horzSpecified: true, vertAnchor: 'page' }),
+      anchorBounds: rect(5, 6), columnBounds: rect(7, 8), child,
+    };
+    const retained = Object.assign(table(), {
+      floatingTables: [unresolved], resolvedFloatingTables: [] as ResolvedFloatingTablePlacementLayout[],
+    });
+
+    const translated = translateBodyOccurrence(retained, { xPt: 20, yPt: 30 });
+
+    expect(translated.floatingTables[0]).toMatchObject({
+      anchorBounds: { xPt: 25, yPt: 36 }, columnBounds: { xPt: 27, yPt: 38 },
+      child: { flowBounds: { xPt: 25, yPt: 36 } },
+    });
+    validateProjectedGraph(projectBodyOccurrence(retained, options), options.occurrenceId);
+  });
+
+  it.each([
+    {
+      name: 'x-page/y-host', positioning: { horzAnchor: 'page', horzSpecified: true, vertAnchor: 'text' },
+      expected: { xPt: 10, yPt: 50 }, child: { xPt: 5, yPt: 36 }, exclusion: { xPt: 9, yPt: 49 },
+    },
+    {
+      name: 'x-host/y-page', positioning: { horzAnchor: 'text', horzSpecified: true, vertAnchor: 'page' },
+      expected: { xPt: 30, yPt: 20 }, child: { xPt: 25, yPt: 6 }, exclusion: { xPt: 29, yPt: 19 },
+    },
+  ])('translates successful mixed-axis resolved float geometry: $name', ({ positioning, expected, child, exclusion }) => {
+    const nested = table(`mixed-${positioning.horzAnchor}-${positioning.vertAnchor}`);
+    const sourcePlacement: FloatingTablePlacementLayout = {
+      kind: 'floating-table-placement', occurrenceId: `mixed-${positioning.horzAnchor}`, ownership: 'source',
+      physicalPageIndex: 0, displayPageNumber: 1, hostCellId: 'table-cell', sourceBlockIndex: 0,
+      anchorBlockIndex: 0, tableId: nested.id, overlap: 'overlap',
+      positioning: floatingPosition(positioning), anchorBounds: rect(3, 4), child: nested,
+    };
+    const resolved: ResolvedFloatingTablePlacementLayout = {
+      kind: 'resolved-floating-table-placement', occurrenceId: sourcePlacement.occurrenceId,
+      xPt: 10, yPt: 20, bounds: rect(10, 20), exclusionBounds: rect(9, 19, 12, 12),
+      overlap: 'overlap', child: nested, source: sourcePlacement,
+    };
+    const retained = Object.assign(table(), {
+      floatingTables: [] as FloatingTablePlacementLayout[], resolvedFloatingTables: [resolved],
+    });
+
+    const translated = translateBodyOccurrence(retained, { xPt: 20, yPt: 30 });
+    const result = translated.resolvedFloatingTables[0]!;
+
+    expect(result).toMatchObject({ xPt: expected.xPt, yPt: expected.yPt,
+      bounds: expected, exclusionBounds: exclusion, child: { flowBounds: child } });
+    expect(result.child).toBe(result.source.child);
+  });
+
+  it('preserves PAGE and NUMPAGES dependency/source-run metadata verbatim', () => {
+    const retained = paragraph();
+    const page = retained.lines[0]!.placements[0] as TextPlacement;
+    const totalPages: TextPlacement = {
+      ...page, text: 'NUMPAGES', dependency: 'total-pages', sourceRunIndex: 8,
+      range: { start: 4, end: 12 },
+    };
+    const graph = { ...retained, lines: [{ ...retained.lines[0]!, placements: [page, totalPages] }] };
+
+    const projected = projectBodyOccurrence(graph, options);
+
+    expect(projected.lines[0]!.placements).toEqual([
+      expect.objectContaining({ text: 'PAGE', dependency: 'page', sourceRunIndex: 7 }),
+      expect.objectContaining({ text: 'NUMPAGES', dependency: 'total-pages', sourceRunIndex: 8 }),
+    ]);
+  });
+
+  it('returns a structured-clone-safe deep-frozen snapshot without changing input', () => {
+    const retained = table();
+    const before = structuredClone(retained);
+    const projected = projectBodyOccurrence(retained, options);
+
+    expect(structuredClone(projected)).toEqual(projected);
+    expect(Object.isFrozen(projected)).toBe(true);
+    expect(Object.isFrozen(projected.rows[0]!.cells[0]!.blocks[0]!.layout)).toBe(true);
+    expect(retained).toEqual(before);
+  });
+
+  it('rejects empty identities and conflicting ownership of one table object', () => {
+    expect(() => projectBodyOccurrence(paragraph(), { ...options, occurrenceId: '' })).toThrow(RangeError);
+    expect(() => projectBodyOccurrence(paragraph(), {
+      ...options, destination: { ...options.destination, flowDomainId: '' },
+    })).toThrow(RangeError);
+    const shared = table('shared');
+    const retained = table();
+    const conflicting = {
+      ...retained,
+      rows: [{ ...retained.rows[0]!, cells: [
+        { ...retained.rows[0]!.cells[0]!, id: 'cell-a', blocks: [{ layout: shared, offsetPt: 0, advancePt: 20 }] },
+        { ...retained.rows[0]!.cells[0]!, id: 'cell-b', blocks: [{ layout: shared, offsetPt: 0, advancePt: 20 }] },
+      ] }],
+    };
+
+    expect(() => projectBodyOccurrence(conflicting, options)).toThrow('incompatible projection ownership');
+  });
+
+  it('allows fragment descendants to share their semantic page occurrence identity', () => {
+    const retained = table();
+    const drawing = {
+      kind: 'drawing' as const, id: 'anchor-drawing', source: source([1, 0, 0, 0]),
+      flowDomainId: 'cell-source', ordinaryFlow: false, flowBounds: rect(0, 0),
+      inkBounds: rect(0, 0), advancePt: 0, commands: [],
+      anchorLayer: {
+        occurrenceId: 'duplicate-owner', behindDoc: false, relativeHeight: 0, sourceOrder: 0,
+        horizontalOwnership: 'host' as const, verticalOwnership: 'host' as const,
+      },
+    };
+    const child = { ...paragraph('owned-child'), drawings: [drawing] };
+    const conflicting = {
+      ...retained,
+      rows: [{
+        ...retained.rows[0]!, occurrenceId: 'duplicate-owner',
+        cells: [{ ...retained.rows[0]!.cells[0]!, blocks: [{ layout: child, offsetPt: 0, advancePt: 12 }] }],
+      }],
+    };
+
+    const first = projectBodyOccurrence(conflicting, options);
+    const secondOccurrence = { ...options, occurrenceId: 'page-3/cross-category' };
+    const second = projectBodyOccurrence(conflicting, secondOccurrence);
+    const firstFacts = validateProjectedGraph(first, options.occurrenceId);
+    const secondFacts = validateProjectedGraph(second, secondOccurrence.occurrenceId);
+    expectDisjoint(firstFacts.nodeIds, secondFacts.nodeIds);
+    expectDisjoint(firstFacts.anchorIds, secondFacts.anchorIds);
+    expectDisjoint(firstFacts.occurrenceIds, secondFacts.occurrenceIds);
+  });
+
+  it('preserves repeated-header and split fragment metadata while re-keying shared row occurrences', () => {
+    const base = table();
+    const fragmentRow = (
+      id: string,
+      logicalRowIndex: number,
+      fragmentIndex: number,
+      ownership: 'source' | 'repeated-header',
+    ): TableRowFragmentLayout => ({
+      ...base.rows[0]!, id, logicalRowIndex, fragmentIndex, ownership,
+      occurrenceId: 'page-9', physicalPageIndex: 4, displayPageNumber: 9,
+      repeatedHeader: ownership === 'repeated-header',
+      cells: base.rows[0]!.cells.map((cell) => ({
+        ...cell, id: `${id}-cell`, source: source([1, logicalRowIndex, 0]),
+        blocks: cell.blocks.map((block) => ({
+          ...block,
+          layout: { ...block.layout, id: `${id}-paragraph`, source: source([1, logicalRowIndex, 0, 0]) },
+        })),
+        contentRanges: [{ kind: 'paragraph', blockIndex: 0, lineStart: 1, lineEnd: 2 }],
+        ...(fragmentIndex > 0 ? { visualMergeOwnership: 'continuation' as const } : {}),
+      })),
+    });
+    const fragment: TableFragmentLayout = {
+      ...base,
+      rows: [fragmentRow('header-row', 0, 0, 'repeated-header'), fragmentRow('split-row', 3, 2, 'source')],
+      floatingTables: [], resolvedFloatingTables: [], floatingTableCoordinateSpace: 'logical-page-points',
+    };
+
+    const projected = projectBodyOccurrence(fragment, options) as TableFragmentLayout;
+
+    expect(projected.rows.map((row) => row.occurrenceId)).toEqual([
+      'page 2/header/occurrence/page-9', 'page 2/header/occurrence/page-9',
+    ]);
+    expect(projected.rows.map((row) => ({
+      logicalRowIndex: row.logicalRowIndex, fragmentIndex: row.fragmentIndex,
+      ownership: row.ownership, physicalPageIndex: row.physicalPageIndex,
+      displayPageNumber: row.displayPageNumber, ranges: row.cells[0]!.contentRanges,
+      merge: row.cells[0]!.visualMergeOwnership,
+    }))).toEqual([
+      { logicalRowIndex: 0, fragmentIndex: 0, ownership: 'repeated-header', physicalPageIndex: 4,
+        displayPageNumber: 9, ranges: [{ kind: 'paragraph', blockIndex: 0, lineStart: 1, lineEnd: 2 }], merge: undefined },
+      { logicalRowIndex: 3, fragmentIndex: 2, ownership: 'source', physicalPageIndex: 4,
+        displayPageNumber: 9, ranges: [{ kind: 'paragraph', blockIndex: 0, lineStart: 1, lineEnd: 2 }], merge: 'continuation' },
+    ]);
+    validateProjectedGraph(projected, options.occurrenceId);
+  });
+
+  it('preserves shared textbox paragraph aliases and rejects textbox cycles before recursion', () => {
+    const child = paragraph('textbox-child');
+    const textBox = (id: string, paragraphs: readonly ParagraphLayout[]): TextBoxLayout => ({
+      kind: 'textbox', id, source: source([0, 1]), flowDomainId: 'textbox', ordinaryFlow: false,
+      flowBounds: rect(5, 6), inkBounds: rect(5, 6), advancePt: 0, paragraphs,
+      writingMode: 'horizontal-tb', insets: { topPt: 0, rightPt: 0, bottomPt: 0, leftPt: 0 },
+    });
+    const aliased = { ...paragraph(), textBoxes: [textBox('box-a', [child, child])] };
+
+    const projected = projectBodyOccurrence(aliased, options);
+
+    expect(projected.textBoxes[0]!.paragraphs[0]).toBe(projected.textBoxes[0]!.paragraphs[1]);
+    const cyclicChildren: ParagraphLayout[] = [];
+    const cyclic = { ...paragraph('cyclic'), textBoxes: [textBox('cycle-box', cyclicChildren)] };
+    cyclicChildren.push(cyclic);
+    expect(() => projectBodyOccurrence(cyclic, options)).toThrow(/acyclic/);
+  });
+
+  it('rejects one table translated under incompatible mixed-axis ownership', () => {
+    const shared = table('shared-float-child');
+    const hostSource: FloatingTablePlacementLayout = {
+      kind: 'floating-table-placement', occurrenceId: 'host-float', ownership: 'source',
+      physicalPageIndex: 0, displayPageNumber: 1, hostCellId: 'cell', sourceBlockIndex: 0,
+      anchorBlockIndex: 0, tableId: shared.id, overlap: 'overlap',
+      positioning: floatingPosition({ horzAnchor: 'text', horzSpecified: true, vertAnchor: 'text' }),
+      anchorBounds: rect(1, 2), child: shared,
+    };
+    const pageSource: FloatingTablePlacementLayout = {
+      ...hostSource, occurrenceId: 'page-float', positioning: floatingPosition({
+        horzAnchor: 'page', horzSpecified: true, vertAnchor: 'text',
+      }),
+    };
+    const resolved: ResolvedFloatingTablePlacementLayout = {
+      kind: 'resolved-floating-table-placement', occurrenceId: pageSource.occurrenceId,
+      xPt: 1, yPt: 2, bounds: rect(1, 2), exclusionBounds: rect(0, 1, 12, 12),
+      overlap: 'overlap', child: shared, source: pageSource,
+    };
+    const retained = Object.assign(table(), {
+      floatingTables: [hostSource, pageSource], resolvedFloatingTables: [resolved],
+    });
+
+    expect(() => translateBodyOccurrence(retained, { xPt: 20, yPt: 30 }))
+      .toThrow('incompatible projection ownership');
+  });
+
+  it('validates every retained ID reference against its live occurrence-local owner', () => {
+    const retained = paragraph();
+    const drawing = {
+      kind: 'drawing' as const, id: 'drawing-live', source: source([0, 2]), flowDomainId: 'body',
+      ordinaryFlow: false, flowBounds: rect(1, 2), inkBounds: rect(1, 2), advancePt: 0, commands: [],
+      anchorLayer: { occurrenceId: 'anchor-live', behindDoc: false, relativeHeight: 0, sourceOrder: 0,
+        horizontalOwnership: 'host' as const, verticalOwnership: 'host' as const },
+    };
+    const graph = {
+      ...retained, drawings: [drawing],
+      lines: [{ ...retained.lines[0]!, placements: [{ kind: 'drawing' as const,
+        range: { start: 0, end: 0 }, drawingId: drawing.id, bounds: drawing.flowBounds, advancePt: 0 }] }],
+      exclusions: [{ id: 'wrap-live', wrap: 'square' as const, bounds: rect(1, 2), polygon: [],
+        anchorOccurrenceId: drawing.anchorLayer.occurrenceId }],
+    };
+    const projected = projectBodyOccurrence(graph, options);
+    validateProjectedGraph(projected, options.occurrenceId);
+  });
+
+  it('translates anchor frames and line numbers while keeping vertical textbox children local', () => {
+    const axis = (axisName: 'horizontal' | 'vertical', origin: number) => ({
+      axis: axisName, status: 'resolved' as const, relativeFrom: axisName === 'horizontal' ? 'paragraph' : 'line',
+      referenceFrame: axisName === 'horizontal' ? 'paragraph' as const : 'line' as const,
+      choiceKind: 'offset' as const, choiceValue: 0, baseStartPt: origin, baseEndPt: origin + 100,
+      resolvedOriginPt: origin, pageParity: null,
+    });
+    const anchorFrame: AnchorFrameResult = {
+      status: 'resolved', occurrenceId: 'frame-occurrence',
+      axes: { horizontal: axis('horizontal', 4), vertical: axis('vertical', 5) }, issues: [],
+      geometry: {
+        objectFrame: rect(4, 5), inkBounds: rect(4, 5), wrapBounds: rect(3, 4, 12, 12),
+        size: {
+          horizontal: { source: 'extent', valuePt: 10, relativeFrom: null, referenceFrame: null, fraction: null },
+          vertical: { source: 'extent', valuePt: 10, relativeFrom: null, referenceFrame: null, fraction: null },
+        },
+        parentEffectExtent: { topPt: 0, rightPt: 0, bottomPt: 0, leftPt: 0 },
+        wrap: {
+          kind: 'square', side: 'bothSides',
+          distances: { topPt: 0, rightPt: 0, bottomPt: 0, leftPt: 0 },
+          distanceSources: { top: 'implicit-zero', right: 'implicit-zero', bottom: 'implicit-zero', left: 'implicit-zero' },
+          effectExtent: { topPt: 0, rightPt: 0, bottomPt: 0, leftPt: 0 }, effectExtentSource: 'none',
+          coordinateSpace: null, polygon: { edited: false, points: [{ xPt: 4, yPt: 5 }] },
+        },
+        transform: { coordinateSpace: 'anchor-frame', groupApplication: 'parser-resolved-child-frame', group: null },
+      },
+    };
+    const localChild = paragraph('vertical-local-child');
+    const verticalBox: TextBoxLayout = {
+      kind: 'textbox', id: 'vertical-box', source: source([0, 4]), flowDomainId: 'textbox', ordinaryFlow: false,
+      flowBounds: rect(8, 9), inkBounds: rect(8, 9), contentBounds: rect(9, 10), advancePt: 0,
+      paragraphs: [localChild], writingMode: 'vertical-rl', verticalMode: 'vert',
+      insets: { topPt: 0, rightPt: 0, bottomPt: 0, leftPt: 0 },
+    };
+    const retained = {
+      ...paragraph(), anchorFrames: [anchorFrame], textBoxes: [verticalBox],
+      lineNumbers: [{ lineIndex: 0, counterValue: 12, bounds: rect(0, 2),
+        paintOps: [{ kind: 'text' as const, text: '12', origin: { xPt: 0, yPt: 10 },
+          font: '10pt serif', color: '#000000', textAlign: 'right' as const }] }],
+    };
+
+    const projected = projectBodyOccurrence(retained, options);
+
+    expect(projected.anchorFrames![0]).toMatchObject({
+      occurrenceId: 'page 2/header/anchor/frame-occurrence',
+      axes: { horizontal: { resolvedOriginPt: 24 }, vertical: { resolvedOriginPt: 35 } },
+      geometry: { objectFrame: { xPt: 24, yPt: 35 } },
+    });
+    expect(projected.lineNumbers![0]).toMatchObject({ bounds: { xPt: 20, yPt: 32 },
+      paintOps: [{ origin: { xPt: 20, yPt: 40 } }] });
+    expect(projected.textBoxes[0]!.flowDomainId)
+      .toBe('body/page-2/occurrence/page%202%2Fheader/textbox/vertical-box');
+    expect(projected.textBoxes[0]!.paragraphs[0]!.flowBounds).toEqual(localChild.flowBounds);
+  });
+});

--- a/packages/docx/src/layout/occurrence-projection.ts
+++ b/packages/docx/src/layout/occurrence-projection.ts
@@ -1,0 +1,317 @@
+import { snapshotPlainData } from './plain-data.js';
+import {
+  floatingTableAxesFollowHostFlow,
+  translateCompleteParagraphLayout,
+  translateRect,
+  translateTableLayout,
+  type LayoutTranslation,
+} from './retained-geometry-translation.js';
+import type {
+  DrawingLayout,
+  FloatingTablePlacementLayout,
+  ParagraphLayout,
+  ParagraphPlacement,
+  ResolvedFloatingTablePlacementLayout,
+  TableCellLayout,
+  TableLayout,
+  TableRowLayout,
+  TextBoxLayout,
+} from './types.js';
+
+export interface BodyOccurrenceDestination {
+  readonly coordinateSpace: 'logical-body-points';
+  readonly flowDomainId: string;
+  readonly translation: Readonly<{ xPt: number; yPt: number }>;
+}
+
+export interface BodyOccurrenceProjectionOptions {
+  readonly occurrenceId: string;
+  readonly destination: BodyOccurrenceDestination;
+}
+
+type OccurrenceTableLayout = TableLayout & Readonly<{
+  floatingTables?: readonly FloatingTablePlacementLayout[];
+  resolvedFloatingTables?: readonly ResolvedFloatingTablePlacementLayout[];
+}>;
+
+function validateTranslation(translation: LayoutTranslation): void {
+  if (!Number.isFinite(translation.xPt) || !Number.isFinite(translation.yPt)) {
+    throw new RangeError('body occurrence translation must be finite');
+  }
+}
+
+function validateProjectionOptions(options: BodyOccurrenceProjectionOptions): void {
+  if (options.occurrenceId.length === 0) throw new RangeError('occurrenceId must not be empty');
+  if (options.destination.flowDomainId.length === 0) throw new RangeError('flowDomainId must not be empty');
+  validateTranslation(options.destination.translation);
+}
+
+function resolvedFloatingDelta(
+  placement: FloatingTablePlacementLayout,
+  hostDelta: LayoutTranslation,
+): LayoutTranslation {
+  const followsHost = floatingTableAxesFollowHostFlow(placement.positioning);
+  return {
+    xPt: followsHost.x ? hostDelta.xPt : 0,
+    yPt: followsHost.y ? hostDelta.yPt : 0,
+  };
+}
+
+function assertAcyclicLayoutGraph(root: ParagraphLayout | TableLayout): void {
+  const visiting = new WeakSet<object>();
+  const completed = new WeakSet<object>();
+  const visit = (layout: ParagraphLayout | TableLayout): void => {
+    if (visiting.has(layout)) throw new TypeError('body occurrence layout graph must be acyclic');
+    if (completed.has(layout)) return;
+    visiting.add(layout);
+    if (layout.kind === 'paragraph') {
+      for (const textBox of layout.textBoxes) for (const paragraph of textBox.paragraphs) visit(paragraph);
+    } else {
+      for (const row of layout.rows) for (const cell of row.cells) {
+        for (const block of cell.blocks) visit(block.layout);
+      }
+      const table = layout as OccurrenceTableLayout;
+      for (const placement of table.floatingTables ?? []) visit(placement.child);
+      for (const placement of table.resolvedFloatingTables ?? []) {
+        visit(placement.source.child);
+        visit(placement.child);
+      }
+    }
+    visiting.delete(layout);
+    completed.add(layout);
+  };
+  visit(root);
+}
+
+function translateOccurrenceGeometry<T extends ParagraphLayout | TableLayout>(
+  retained: T,
+  translation: LayoutTranslation,
+): T {
+  assertAcyclicLayoutGraph(retained);
+  const tableMemo = new WeakMap<TableLayout, { key: string; value: TableLayout }>();
+  const paragraphMemo = new WeakMap<ParagraphLayout, { key: string; value: ParagraphLayout }>();
+  const keyFor = (delta: LayoutTranslation) => `${delta.xPt}\u0000${delta.yPt}`;
+
+  const translateParagraph = (paragraph: ParagraphLayout, delta: LayoutTranslation): ParagraphLayout => {
+    const key = keyFor(delta);
+    const prior = paragraphMemo.get(paragraph);
+    if (prior) {
+      if (prior.key !== key) throw new Error('incompatible projection ownership');
+      return prior.value;
+    }
+    const translated = translateCompleteParagraphLayout(paragraph, delta);
+    paragraphMemo.set(paragraph, { key, value: translated });
+    return translated;
+  };
+
+  const translateTable = (retainedTable: OccurrenceTableLayout, delta: LayoutTranslation): TableLayout => {
+    const key = keyFor(delta);
+    const prior = tableMemo.get(retainedTable);
+    if (prior) {
+      if (prior.key !== key) throw new Error('incompatible projection ownership');
+      return prior.value;
+    }
+    const translated: OccurrenceTableLayout = translateTableLayout(retainedTable, delta);
+    tableMemo.set(retainedTable, { key, value: translated });
+
+    const resolvedDeltaBySource = new Map<FloatingTablePlacementLayout, LayoutTranslation>();
+    for (const resolved of retainedTable.resolvedFloatingTables ?? []) {
+      resolvedDeltaBySource.set(resolved.source, resolvedFloatingDelta(resolved.source, delta));
+    }
+    const sourceMemo = new Map<FloatingTablePlacementLayout, FloatingTablePlacementLayout>();
+    const translateSource = (source: FloatingTablePlacementLayout): FloatingTablePlacementLayout => {
+      const priorSource = sourceMemo.get(source);
+      if (priorSource) return priorSource;
+      const childDelta = resolvedDeltaBySource.get(source) ?? delta;
+      const result: FloatingTablePlacementLayout = {
+        ...source,
+        anchorBounds: translateRect(source.anchorBounds, delta),
+        ...(source.columnBounds ? { columnBounds: translateRect(source.columnBounds, delta) } : {}),
+        child: translateTable(source.child, childDelta),
+      };
+      sourceMemo.set(source, result);
+      return result;
+    };
+    const floatingTables = (retainedTable.floatingTables ?? []).map(translateSource);
+    const resolvedFloatingTables = (retainedTable.resolvedFloatingTables ?? []).map((resolved) => {
+      const source = translateSource(resolved.source);
+      const ownedDelta = resolvedFloatingDelta(resolved.source, delta);
+      return {
+        ...resolved,
+        xPt: resolved.xPt + ownedDelta.xPt,
+        yPt: resolved.yPt + ownedDelta.yPt,
+        bounds: translateRect(resolved.bounds, ownedDelta),
+        exclusionBounds: translateRect(resolved.exclusionBounds, ownedDelta),
+        child: source.child,
+        source,
+      } satisfies ResolvedFloatingTablePlacementLayout;
+    });
+    if (retainedTable.floatingTables || retainedTable.resolvedFloatingTables) {
+      Object.assign(translated, { floatingTables, resolvedFloatingTables });
+    }
+    return translated;
+  };
+
+  return (retained.kind === 'paragraph'
+    ? translateParagraph(retained, translation)
+    : translateTable(retained, translation)) as T;
+}
+
+export function translateBodyOccurrence<T extends ParagraphLayout | TableLayout>(
+  retained: T,
+  translation: Readonly<{ xPt: number; yPt: number }>,
+): T {
+  validateTranslation(translation);
+  return translateOccurrenceGeometry(retained, translation);
+}
+
+/** Deterministic ID/domain/freezing policy; these are engine rules, not OOXML rules. */
+export function projectBodyOccurrence<T extends ParagraphLayout | TableLayout>(
+  retained: T,
+  options: BodyOccurrenceProjectionOptions,
+): T {
+  validateProjectionOptions(options);
+  const translated = translateOccurrenceGeometry(retained, options.destination.translation);
+  const encodedOccurrence = encodeURIComponent(options.occurrenceId);
+  const tableMemo = new WeakMap<TableLayout, { domain: string; value: TableLayout }>();
+  const paragraphMemo = new WeakMap<ParagraphLayout, { domain: string; value: ParagraphLayout }>();
+  const drawingMemo = new WeakMap<DrawingLayout, { domain: string; value: DrawingLayout }>();
+  const anchorOwners = new Map<string, DrawingLayout>();
+  const floatingOwners = new Map<string, FloatingTablePlacementLayout>();
+  const nodeId = (sourceId: string) => `${options.occurrenceId}/node/${encodeURIComponent(sourceId)}`;
+  const anchorId = (sourceId: string) => `${options.occurrenceId}/anchor/${encodeURIComponent(sourceId)}`;
+  const occurrenceId = (sourceId: string) =>
+    `${options.occurrenceId}/occurrence/${encodeURIComponent(sourceId)}`;
+  const nestedDomain = (kind: 'cell' | 'textbox', sourceId: string) =>
+    `${options.destination.flowDomainId}/occurrence/${encodedOccurrence}/${kind}/${encodeURIComponent(sourceId)}`;
+
+  const projectPlacement = (placement: ParagraphPlacement): ParagraphPlacement => {
+    if (placement.kind === 'drawing') return { ...placement, drawingId: nodeId(placement.drawingId) };
+    if (placement.kind === 'anchor-host' && placement.anchorOccurrenceId) return {
+      ...placement, anchorOccurrenceId: anchorId(placement.anchorOccurrenceId),
+    };
+    return placement;
+  };
+  const projectDrawing = (drawing: DrawingLayout, domain: string): DrawingLayout => {
+    const memoized = drawingMemo.get(drawing);
+    if (memoized) {
+      if (memoized.domain !== domain) throw new Error('incompatible projection ownership');
+      return memoized.value;
+    }
+    if (drawing.anchorLayer) {
+      const prior = anchorOwners.get(drawing.anchorLayer.occurrenceId);
+      if (prior && prior !== drawing) throw new Error('duplicate anchor occurrence owner');
+      anchorOwners.set(drawing.anchorLayer.occurrenceId, drawing);
+    }
+    const projected: DrawingLayout = {
+      ...drawing, id: nodeId(drawing.id), flowDomainId: domain,
+      ...(drawing.textBoxIds ? { textBoxIds: drawing.textBoxIds.map(nodeId) } : {}),
+      ...(drawing.anchorLayer ? { anchorLayer: {
+        ...drawing.anchorLayer,
+        occurrenceId: anchorId(drawing.anchorLayer.occurrenceId),
+        acquisitionOccurrenceId: drawing.anchorLayer.acquisitionOccurrenceId ?? drawing.anchorLayer.occurrenceId,
+      } } : {}),
+    };
+    drawingMemo.set(drawing, { domain, value: projected });
+    return projected;
+  };
+  const projectTextBox = (textBox: TextBoxLayout): TextBoxLayout => {
+    const domain = nestedDomain('textbox', textBox.id);
+    return {
+      ...textBox, id: nodeId(textBox.id), flowDomainId: domain,
+      paragraphs: textBox.paragraphs.map((paragraph) => projectParagraph(paragraph, domain)),
+    };
+  };
+  const projectParagraph = (paragraph: ParagraphLayout, domain: string): ParagraphLayout => {
+    const prior = paragraphMemo.get(paragraph);
+    if (prior) {
+      if (prior.domain !== domain) throw new Error('incompatible projection ownership');
+      return prior.value;
+    }
+    const projected: ParagraphLayout = {
+      ...paragraph, id: nodeId(paragraph.id), flowDomainId: domain,
+      lines: paragraph.lines.map((line) => ({
+        ...line, placements: line.placements.map(projectPlacement),
+      })),
+      drawings: paragraph.drawings.map((drawing) => projectDrawing(drawing, domain)),
+      textBoxes: paragraph.textBoxes.map(projectTextBox),
+      exclusions: paragraph.exclusions.map((exclusion) => ({
+        ...exclusion, id: nodeId(exclusion.id),
+        ...(exclusion.anchorOccurrenceId
+          ? { anchorOccurrenceId: anchorId(exclusion.anchorOccurrenceId) } : {}),
+      })),
+      ...(paragraph.anchorFrames ? { anchorFrames: paragraph.anchorFrames.map((frame) => ({
+        ...frame, occurrenceId: anchorId(frame.occurrenceId),
+      })) } : {}),
+    };
+    paragraphMemo.set(paragraph, { domain, value: projected });
+    return projected;
+  };
+  const projectCell = (cell: TableCellLayout): TableCellLayout => {
+    const domain = nestedDomain('cell', cell.id);
+    return {
+      ...cell, id: nodeId(cell.id), flowDomainId: domain,
+      blocks: cell.blocks.map((block) => ({ ...block, layout: projectBlock(block.layout, domain) })),
+    };
+  };
+  const projectRow = (row: TableRowLayout, domain: string): TableRowLayout => ({
+    ...row, id: nodeId(row.id), flowDomainId: domain,
+    ...('occurrenceId' in row && typeof row.occurrenceId === 'string'
+      ? { occurrenceId: occurrenceId(row.occurrenceId) } : {}),
+    cells: row.cells.map(projectCell),
+  });
+  const projectSource = (source: FloatingTablePlacementLayout): FloatingTablePlacementLayout => {
+    const childDomain = nestedDomain('cell', source.hostCellId);
+    return {
+      ...source,
+      occurrenceId: occurrenceId(source.occurrenceId),
+      hostCellId: nodeId(source.hostCellId),
+      tableId: nodeId(source.tableId),
+      child: projectTable(source.child as OccurrenceTableLayout, childDomain),
+    };
+  };
+  const projectTable = (table: OccurrenceTableLayout, domain: string): TableLayout => {
+    const prior = tableMemo.get(table);
+    if (prior) {
+      if (prior.domain !== domain) throw new Error('incompatible projection ownership');
+      return prior.value;
+    }
+    const projected: OccurrenceTableLayout = {
+      ...table, id: nodeId(table.id), flowDomainId: domain,
+      rows: table.rows.map((row) => projectRow(row, domain)),
+    };
+    tableMemo.set(table, { domain, value: projected });
+    const sourceMemo = new Map<FloatingTablePlacementLayout, FloatingTablePlacementLayout>();
+    const sourceFor = (source: FloatingTablePlacementLayout) => {
+      const priorSource = sourceMemo.get(source);
+      if (priorSource) return priorSource;
+      const priorOwner = floatingOwners.get(source.occurrenceId);
+      if (priorOwner && priorOwner !== source) {
+        throw new Error('duplicate floating placement occurrence owner');
+      }
+      floatingOwners.set(source.occurrenceId, source);
+      const result = projectSource(source);
+      sourceMemo.set(source, result);
+      return result;
+    };
+    const floatingTables = (table.floatingTables ?? []).map(sourceFor);
+    const resolvedFloatingTables = (table.resolvedFloatingTables ?? []).map((resolved) => {
+      const source = sourceFor(resolved.source);
+      return {
+        ...resolved, occurrenceId: occurrenceId(resolved.occurrenceId), child: source.child, source,
+      } satisfies ResolvedFloatingTablePlacementLayout;
+    });
+    if (table.floatingTables || table.resolvedFloatingTables) {
+      Object.assign(projected, { floatingTables, resolvedFloatingTables });
+    }
+    return projected;
+  };
+  function projectBlock(layout: ParagraphLayout | TableLayout, domain: string): ParagraphLayout | TableLayout {
+    return layout.kind === 'paragraph'
+      ? projectParagraph(layout, domain)
+      : projectTable(layout, domain);
+  }
+
+  const projected = projectBlock(translated, options.destination.flowDomainId);
+  return snapshotPlainData(projected, 'DOCX body occurrence projection') as T;
+}

--- a/packages/docx/src/layout/paragraph.test.ts
+++ b/packages/docx/src/layout/paragraph.test.ts
@@ -326,6 +326,19 @@ describe('layoutParagraph', () => {
     expect(continuation.borders[0]).toMatchObject({ from: { yPt: 15 }, to: { yPt: 15 } });
   });
 
+  it('characterizes continuation Y translation as the general translation with zero X delta', () => {
+    const whole = layoutParagraph(input());
+    const deltaYPt = whole.flowBounds.yPt - whole.lines[1]!.bounds.yPt;
+
+    const continuation = sliceParagraphLayout(whole, {
+      lineStart: 1, lineEnd: 2, continuesFromPrevious: true, continuesOnNext: false,
+    });
+    const generallyTranslated = translateParagraphLayout(whole, { xPt: 0, yPt: deltaYPt });
+
+    expect(continuation.lines[0]).toEqual(generallyTranslated.lines[1]);
+    expect(continuation.lines[0]!.bounds.xPt).toBe(whole.lines[1]!.bounds.xPt);
+  });
+
   it('keeps page-owned anchor geometry fixed when its host line is rebased on a continuation', () => {
     const base = input();
     const drawing = {

--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -58,6 +58,16 @@ import {
 import type { RunTypographyAcquisitionInput } from './typography-input.js';
 import { resolveAnchorFrame, type AnchorReferenceFramesInput, type AnchorFrameResult } from './anchor-frame.js';
 import { paragraphGapPt } from './paragraph-spacing.js';
+import {
+  translateDrawing,
+  translateLine,
+  translateParagraphLayout,
+  translatePlacement,
+  translatePoint,
+  translateRect,
+  translateTextBox,
+} from './retained-geometry-translation.js';
+export { translateParagraphLayout } from './retained-geometry-translation.js';
 import { paginationFieldDependency } from './pagination-fields.js';
 import {
   measureParagraphIntrinsicWidth,
@@ -72,13 +82,11 @@ export {
 export type { BodyFrameGroup } from './frame.js';
 import type { ParagraphAcquisitionInput } from './text.js';
 import type {
-  ClipPathData,
   DrawingLayout,
   DrawingPaintCommand,
   AcquiredParagraphLayoutInput,
   InlineResourceLayout,
   LineLayout,
-  LayoutNodeId,
   LayoutRect,
   ParagraphLayout,
   ParagraphPlacement,
@@ -2806,247 +2814,16 @@ export function paragraphLayoutFromMeasurement(
   });
 }
 
-interface LayoutTranslation {
-  readonly xPt: number;
-  readonly yPt: number;
-}
-
-function translatePoint(point: PointPt, delta: LayoutTranslation): PointPt {
-  return { ...point, xPt: point.xPt + delta.xPt, yPt: point.yPt + delta.yPt };
-}
-
-function translateRect(rect: LayoutRect, delta: LayoutTranslation): LayoutRect {
-  return { ...rect, xPt: rect.xPt + delta.xPt, yPt: rect.yPt + delta.yPt };
-}
-
-function translateClip(clip: ClipPathData, delta: LayoutTranslation): ClipPathData {
-  return clip.kind === 'rect'
-    ? { ...clip, rect: translateRect(clip.rect, delta) }
-    : { ...clip, points: clip.points.map((point) => translatePoint(point, delta)) };
-}
-
-function translateDrawingCommand(
-  command: DrawingPaintCommand,
-  delta: LayoutTranslation,
-): DrawingPaintCommand {
-  if (command.kind === 'noop') return command;
-  if (command.kind === 'drawingml-shape') return {
-    ...command,
-    plan: {
-      ...command.plan,
-      rect: {
-        ...command.plan.rect,
-        x: command.plan.rect.x + delta.xPt,
-        y: command.plan.rect.y + delta.yPt,
-      },
-    },
-  };
-  return { ...command, rect: translateRect(command.rect, delta) };
-}
-
-function translateDrawing(drawing: DrawingLayout, delta: LayoutTranslation): DrawingLayout {
-  return {
-    ...drawing,
-    flowBounds: translateRect(drawing.flowBounds, delta),
-    inkBounds: translateRect(drawing.inkBounds, delta),
-    ...(drawing.clipBounds
-      ? { clipBounds: translateRect(drawing.clipBounds, delta) }
-      : {}),
-    ...(drawing.transform
-      ? { transform: {
-          ...drawing.transform,
-          e: drawing.transform.e + delta.xPt,
-          f: drawing.transform.f + delta.yPt,
-        } }
-      : {}),
-    ...(drawing.clip ? { clip: translateClip(drawing.clip, delta) } : {}),
-    commands: drawing.commands.map((command) => translateDrawingCommand(command, delta)),
-  };
-}
-
-function translatePlacement(
-  placement: ParagraphPlacement,
-  delta: LayoutTranslation,
-  drawingTranslations?: ReadonlyMap<LayoutNodeId, LayoutTranslation>,
-): ParagraphPlacement {
-  if (placement.kind === 'text') return {
-    ...placement,
-    origin: translatePoint(placement.origin, delta),
-    bounds: translateRect(placement.bounds, delta),
-    decorations: placement.decorations.map((decoration) => ({
-      ...decoration,
-      from: translatePoint(decoration.from, delta),
-      to: translatePoint(decoration.to, delta),
-      ...(decoration.path
-        ? { path: decoration.path.map((point) => translatePoint(point, delta)) }
-        : {}),
-    })),
-    ...(placement.highlightFragments ? { highlightFragments: placement.highlightFragments.map((fragment) => ({
-      ...fragment,
-      rect: translateRect(fragment.rect, delta),
-    })) } : {}),
-    ...(placement.ruby ? { ruby: {
-      ...placement.ruby,
-      paintOps: placement.ruby.paintOps.map((operation) => ({
-        ...operation,
-        origin: translatePoint(operation.origin, delta),
-      })),
-    } } : {}),
-    ...(placement.emphasis ? { emphasis: {
-      ...placement.emphasis,
-      ...(placement.emphasis.glyphs ? { glyphs: placement.emphasis.glyphs.map((glyph) => ({
-        ...glyph,
-        origin: translatePoint(glyph.origin, delta),
-      })) } : {}),
-      ...(placement.emphasis.paths ? { paths: placement.emphasis.paths.map((path) => ({
-        ...path,
-        points: path.points.map((point) => translatePoint(point, delta)),
-      })) } : {}),
-    } } : {}),
-    ...(placement.runBorderFragments ? {
-      runBorderFragments: placement.runBorderFragments.map((border) => ({
-        ...border,
-        from: translatePoint(border.from, delta),
-        to: translatePoint(border.to, delta),
-      })),
-    } : {}),
-  };
-  if (placement.kind === 'anchor-host') return {
-    ...placement,
-    bounds: translateRect(placement.bounds, delta),
-    baselinePt: placement.baselinePt + delta.yPt,
-  };
-  if (placement.kind === 'drawing') return {
-    ...placement,
-    bounds: translateRect(
-      placement.bounds,
-      drawingTranslations?.get(placement.drawingId) ?? delta,
-    ),
-  };
-  if (placement.kind === 'tab' && placement.leaderGlyphs) return {
-    ...placement,
-    ...(placement.bounds ? { bounds: translateRect(placement.bounds, delta) } : {}),
-    leaderGlyphs: placement.leaderGlyphs.map((operation) => ({
-      ...operation,
-      origin: translatePoint(operation.origin, delta),
-    })),
-  };
-  if (placement.bounds) return {
-    ...placement,
-    bounds: translateRect(placement.bounds, delta),
-  };
-  return placement;
-}
-
-function translateLine(
-  line: LineLayout,
-  delta: LayoutTranslation,
-  drawingTranslations?: ReadonlyMap<LayoutNodeId, LayoutTranslation>,
-): LineLayout {
-  return {
-    ...line,
-    bounds: translateRect(line.bounds, delta),
-    baselinePt: line.baselinePt + delta.yPt,
-    placements: line.placements.map((placement) =>
-      translatePlacement(placement, delta, drawingTranslations)),
-  };
-}
-
-/** Translate host-owned retained geometry while preserving axes owned by the
- * page anchor solver. This is the only relocation primitive used after a
- * local frame acquisition, so nested anchors cannot be measured a second time. */
-export function translateParagraphLayout(
-  paragraph: ParagraphLayout,
-  delta: LayoutTranslation,
-): ParagraphLayout {
-  const anchorOwnership = new Map(paragraph.drawings.flatMap((drawing) =>
-    drawing.anchorLayer ? [[drawing.anchorLayer.occurrenceId, drawing.anchorLayer] as const] : []));
-  const textBoxTranslations = new Map<LayoutNodeId, LayoutTranslation>();
-  const drawingTranslations = new Map<LayoutNodeId, LayoutTranslation>();
-  paragraph.drawings.forEach((drawing) => {
-    const drawingDelta = {
-      xPt: drawing.anchorLayer?.horizontalOwnership === 'page' ? 0 : delta.xPt,
-      yPt: drawing.anchorLayer?.verticalOwnership === 'page' ? 0 : delta.yPt,
-    };
-    drawingTranslations.set(drawing.id, drawingDelta);
-    drawing.textBoxIds?.forEach((id) => textBoxTranslations.set(id, drawingDelta));
-  });
-  return {
-    ...paragraph,
-    flowBounds: translateRect(paragraph.flowBounds, delta),
-    inkBounds: translateRect(paragraph.inkBounds, delta),
-    ...(paragraph.clipBounds
-      ? { clipBounds: translateRect(paragraph.clipBounds, delta) }
-      : {}),
-    lines: paragraph.lines.map((line) => translateLine(line, delta, drawingTranslations)),
-    borders: paragraph.borders.map((border) => ({
-      ...border,
-      from: translatePoint(border.from, delta),
-      to: translatePoint(border.to, delta),
-    })),
-    drawings: paragraph.drawings.map((drawing) => {
-      const drawingDelta = {
-        xPt: drawing.anchorLayer?.horizontalOwnership === 'page' ? 0 : delta.xPt,
-        yPt: drawing.anchorLayer?.verticalOwnership === 'page' ? 0 : delta.yPt,
-      };
-      return translateDrawing(drawing, drawingDelta);
-    }),
-    textBoxes: paragraph.textBoxes.map((textBox) => translateTextBox(
-      textBox,
-      textBoxTranslations.get(textBox.id) ?? delta,
-    )),
-    exclusions: paragraph.exclusions.map((exclusion) => {
-      const owner = exclusion.anchorOccurrenceId
-        ? anchorOwnership.get(exclusion.anchorOccurrenceId)
-        : undefined;
-      const exclusionDelta = {
-        xPt: owner?.horizontalOwnership === 'page' ? 0 : delta.xPt,
-        yPt: exclusion.verticalOwnership === 'page' || owner?.verticalOwnership === 'page'
-          ? 0 : delta.yPt,
-      };
-      return {
-        ...exclusion,
-        bounds: translateRect(exclusion.bounds, exclusionDelta),
-        polygon: exclusion.polygon.map((point) => translatePoint(point, exclusionDelta)),
-      };
-    }),
-    ...(paragraph.paragraphMark
-      ? { paragraphMark: {
-          ...paragraph.paragraphMark,
-          bounds: translateRect(paragraph.paragraphMark.bounds, delta),
-        } }
-      : {}),
-  };
-}
-
-function translateTextBox(textBox: TextBoxLayout, delta: LayoutTranslation): TextBoxLayout {
-  const pageRelativeContent = textBox.verticalMode === undefined;
-  return {
-    ...textBox,
-    flowBounds: translateRect(textBox.flowBounds, delta),
-    inkBounds: translateRect(textBox.inkBounds, delta),
-    ...(textBox.clipBounds
-      ? { clipBounds: translateRect(textBox.clipBounds, delta) }
-      : {}),
-    ...(textBox.contentBounds
-      ? { contentBounds: pageRelativeContent
-          ? translateRect(textBox.contentBounds, delta)
-          : textBox.contentBounds }
-      : {}),
-    paragraphs: pageRelativeContent
-      ? textBox.paragraphs.map((paragraph) => translateParagraphLayout(paragraph, delta))
-      : textBox.paragraphs,
-  };
-}
-
 const translatePointY = (point: PointPt, yPt: number): PointPt =>
   translatePoint(point, { xPt: 0, yPt });
 const translateRectY = (rect: LayoutRect, yPt: number): LayoutRect =>
   translateRect(rect, { xPt: 0, yPt });
 const translateDrawingY = (drawing: DrawingLayout, yPt: number): DrawingLayout =>
   translateDrawing(drawing, { xPt: 0, yPt });
-const translatePlacementY = (placement: ParagraphPlacement, yPt: number): ParagraphPlacement =>
-  translatePlacement(placement, { xPt: 0, yPt });
+const translatePlacementY = (
+  placement: import('./types.js').ParagraphPlacement,
+  yPt: number,
+): import('./types.js').ParagraphPlacement => translatePlacement(placement, { xPt: 0, yPt });
 const translateLineY = (line: LineLayout, yPt: number): LineLayout =>
   translateLine(line, { xPt: 0, yPt });
 const translateParagraphY = (paragraph: ParagraphLayout, yPt: number): ParagraphLayout =>

--- a/packages/docx/src/layout/plain-data.test.ts
+++ b/packages/docx/src/layout/plain-data.test.ts
@@ -41,4 +41,17 @@ describe('plain layout data snapshots', () => {
     expect(() => snapshotPlainData(cyclic, 'layout payload'))
       .toThrow(/structured-clone-safe plain data/i);
   });
+
+  it('validates a shared plain-data DAG only once before cloning', () => {
+    let reads = 0;
+    const shared = Object.defineProperty({}, 'value', {
+      enumerable: true,
+      get() { reads += 1; return 7; },
+    });
+
+    const snapshot = snapshotPlainData({ first: shared, second: shared }, 'layout payload');
+
+    expect(snapshot.first).toBe(snapshot.second);
+    expect(reads).toBe(2); // one validation traversal and one structured clone traversal
+  });
 });

--- a/packages/docx/src/layout/plain-data.ts
+++ b/packages/docx/src/layout/plain-data.ts
@@ -3,7 +3,8 @@ import type { DeepReadonly } from './types.js';
 function assertPlainData(
   value: unknown,
   path: string,
-  ancestors = new WeakSet<object>(),
+  visiting = new WeakSet<object>(),
+  completed = new WeakSet<object>(),
 ): void {
   if (
     value === null
@@ -18,21 +19,23 @@ function assertPlainData(
   if (typeof value !== 'object') {
     throw new TypeError(`${path} must be structured-clone-safe plain data`);
   }
-  if (ancestors.has(value)) {
+  if (visiting.has(value)) {
     throw new TypeError(`${path} must be structured-clone-safe plain data`);
   }
+  if (completed.has(value)) return;
   const prototype = Object.getPrototypeOf(value);
   if (!Array.isArray(value) && prototype !== Object.prototype && prototype !== null) {
     throw new TypeError(`${path} must be structured-clone-safe plain data`);
   }
-  ancestors.add(value);
+  visiting.add(value);
   try {
     for (const [key, child] of Object.entries(value)) {
-      assertPlainData(child, `${path}.${key}`, ancestors);
+      assertPlainData(child, `${path}.${key}`, visiting, completed);
     }
   } finally {
-    ancestors.delete(value);
+    visiting.delete(value);
   }
+  completed.add(value);
 }
 
 export function deepFreezePlainData<T>(

--- a/packages/docx/src/layout/retained-geometry-translation.ts
+++ b/packages/docx/src/layout/retained-geometry-translation.ts
@@ -1,0 +1,304 @@
+import type { AnchorFrameResult } from './anchor-frame.js';
+import type {
+  BorderSegment, ClipPathData, DrawingLayout, DrawingPaintCommand, LayoutNodeId,
+  FloatingTablePositionInput, LayoutRect, LineLayout, ParagraphLayout, ParagraphPlacement, PointPt, TableLayout,
+  TextBoxLayout,
+} from './types.js';
+
+export interface LayoutTranslation { readonly xPt: number; readonly yPt: number }
+
+/** Initial tblpPr placement and retained occurrence translation must share this
+ * predicate or their resolved frame and later axis ownership diverge. */
+export function floatingTableAxesFollowHostFlow(
+  positioning: FloatingTablePositionInput,
+): Readonly<{ x: boolean; y: boolean }> {
+  return {
+    x: !positioning.horzSpecified
+      || (positioning.horzAnchor !== 'page' && positioning.horzAnchor !== 'margin'),
+    y: positioning.vertAnchor !== 'page' && positioning.vertAnchor !== 'margin',
+  };
+}
+
+interface ParagraphTranslationContext {
+  readonly memo: WeakMap<ParagraphLayout, { readonly key: string; readonly value: ParagraphLayout }>;
+  readonly drawingMemo: WeakMap<DrawingLayout, { readonly key: string; readonly value: DrawingLayout }>;
+}
+
+export function translatePoint(point: PointPt, delta: LayoutTranslation): PointPt {
+  return { ...point, xPt: point.xPt + delta.xPt, yPt: point.yPt + delta.yPt };
+}
+
+export function translateRect(rect: LayoutRect, delta: LayoutTranslation): LayoutRect {
+  return { ...rect, xPt: rect.xPt + delta.xPt, yPt: rect.yPt + delta.yPt };
+}
+
+export function translateBorder(border: BorderSegment, delta: LayoutTranslation): BorderSegment {
+  return { ...border, from: translatePoint(border.from, delta), to: translatePoint(border.to, delta) };
+}
+
+function translateClip(clip: ClipPathData, delta: LayoutTranslation): ClipPathData {
+  return clip.kind === 'rect'
+    ? { ...clip, rect: translateRect(clip.rect, delta) }
+    : { ...clip, points: clip.points.map((point) => translatePoint(point, delta)) };
+}
+
+function translateDrawingCommand(command: DrawingPaintCommand, delta: LayoutTranslation): DrawingPaintCommand {
+  if (command.kind === 'noop') return command;
+  if (command.kind === 'drawingml-shape') return {
+    ...command,
+    plan: { ...command.plan, rect: {
+      ...command.plan.rect,
+      x: command.plan.rect.x + delta.xPt,
+      y: command.plan.rect.y + delta.yPt,
+    } },
+  };
+  return { ...command, rect: translateRect(command.rect, delta) };
+}
+
+export function translateDrawing(drawing: DrawingLayout, delta: LayoutTranslation): DrawingLayout {
+  return {
+    ...drawing,
+    flowBounds: translateRect(drawing.flowBounds, delta),
+    inkBounds: translateRect(drawing.inkBounds, delta),
+    ...(drawing.clipBounds ? { clipBounds: translateRect(drawing.clipBounds, delta) } : {}),
+    ...(drawing.transform ? { transform: {
+      ...drawing.transform, e: drawing.transform.e + delta.xPt, f: drawing.transform.f + delta.yPt,
+    } } : {}),
+    ...(drawing.clip ? { clip: translateClip(drawing.clip, delta) } : {}),
+    commands: drawing.commands.map((command) => translateDrawingCommand(command, delta)),
+  };
+}
+
+function translateDrawingWithContext(
+  drawing: DrawingLayout,
+  delta: LayoutTranslation,
+  context: ParagraphTranslationContext,
+): DrawingLayout {
+  const key = `${delta.xPt}\u0000${delta.yPt}`;
+  const prior = context.drawingMemo.get(drawing);
+  if (prior) {
+    if (prior.key !== key) throw new Error('incompatible projection ownership');
+    return prior.value;
+  }
+  const value = translateDrawing(drawing, delta);
+  context.drawingMemo.set(drawing, { key, value });
+  return value;
+}
+
+export function translatePlacement(
+  placement: ParagraphPlacement,
+  delta: LayoutTranslation,
+  drawingTranslations?: ReadonlyMap<LayoutNodeId, LayoutTranslation>,
+): ParagraphPlacement {
+  if (placement.kind === 'text') return {
+    ...placement,
+    origin: translatePoint(placement.origin, delta), bounds: translateRect(placement.bounds, delta),
+    decorations: placement.decorations.map((decoration) => ({
+      ...decoration, from: translatePoint(decoration.from, delta), to: translatePoint(decoration.to, delta),
+      ...(decoration.path ? { path: decoration.path.map((point) => translatePoint(point, delta)) } : {}),
+    })),
+    ...(placement.highlightFragments ? { highlightFragments: placement.highlightFragments.map((fragment) => ({
+      ...fragment, rect: translateRect(fragment.rect, delta),
+    })) } : {}),
+    ...(placement.ruby ? { ruby: { ...placement.ruby, paintOps: placement.ruby.paintOps.map((operation) => ({
+      ...operation, origin: translatePoint(operation.origin, delta),
+    })) } } : {}),
+    ...(placement.emphasis ? { emphasis: {
+      ...placement.emphasis,
+      ...(placement.emphasis.glyphs ? { glyphs: placement.emphasis.glyphs.map((glyph) => ({
+        ...glyph, origin: translatePoint(glyph.origin, delta),
+      })) } : {}),
+      ...(placement.emphasis.paths ? { paths: placement.emphasis.paths.map((path) => ({
+        ...path, points: path.points.map((point) => translatePoint(point, delta)),
+      })) } : {}),
+    } } : {}),
+    ...(placement.runBorderFragments ? { runBorderFragments: placement.runBorderFragments.map((border) =>
+      translateBorder(border, delta)) } : {}),
+  };
+  if (placement.kind === 'anchor-host') return {
+    ...placement, bounds: translateRect(placement.bounds, delta), baselinePt: placement.baselinePt + delta.yPt,
+  };
+  if (placement.kind === 'drawing') return {
+    ...placement, bounds: translateRect(placement.bounds, drawingTranslations?.get(placement.drawingId) ?? delta),
+  };
+  if (placement.kind === 'tab' && placement.leaderGlyphs) return {
+    ...placement,
+    ...(placement.bounds ? { bounds: translateRect(placement.bounds, delta) } : {}),
+    leaderGlyphs: placement.leaderGlyphs.map((operation) => ({
+      ...operation, origin: translatePoint(operation.origin, delta),
+    })),
+  };
+  return placement.bounds ? { ...placement, bounds: translateRect(placement.bounds, delta) } : placement;
+}
+
+export function translateLine(
+  line: LineLayout,
+  delta: LayoutTranslation,
+  drawingTranslations?: ReadonlyMap<LayoutNodeId, LayoutTranslation>,
+): LineLayout {
+  return {
+    ...line, bounds: translateRect(line.bounds, delta), baselinePt: line.baselinePt + delta.yPt,
+    placements: line.placements.map((placement) => translatePlacement(placement, delta, drawingTranslations)),
+  };
+}
+
+function axisIsPageOwned(frame: AnchorFrameResult, axis: 'horizontal' | 'vertical'): boolean {
+  const diagnostic = frame.axes[axis];
+  return diagnostic.status === 'resolved'
+    && ['page', 'margin', 'leftMargin', 'rightMargin', 'topMargin', 'bottomMargin'].includes(diagnostic.referenceFrame);
+}
+
+function translateAnchorFrame(frame: AnchorFrameResult, delta: LayoutTranslation): AnchorFrameResult {
+  const xPt = axisIsPageOwned(frame, 'horizontal') ? 0 : delta.xPt;
+  const yPt = axisIsPageOwned(frame, 'vertical') ? 0 : delta.yPt;
+  const frameDelta = { xPt, yPt };
+  const axes = {
+    horizontal: frame.axes.horizontal.status === 'resolved' ? {
+      ...frame.axes.horizontal,
+      baseStartPt: frame.axes.horizontal.baseStartPt + xPt,
+      baseEndPt: frame.axes.horizontal.baseEndPt + xPt,
+      resolvedOriginPt: frame.axes.horizontal.resolvedOriginPt + xPt,
+    } : frame.axes.horizontal,
+    vertical: frame.axes.vertical.status === 'resolved' ? {
+      ...frame.axes.vertical,
+      baseStartPt: frame.axes.vertical.baseStartPt + yPt,
+      baseEndPt: frame.axes.vertical.baseEndPt + yPt,
+      resolvedOriginPt: frame.axes.vertical.resolvedOriginPt + yPt,
+    } : frame.axes.vertical,
+  };
+  if (frame.status === 'unsupported') return { ...frame, axes };
+  return {
+    ...frame, axes,
+    geometry: {
+      ...frame.geometry,
+      objectFrame: translateRect(frame.geometry.objectFrame, frameDelta),
+      inkBounds: translateRect(frame.geometry.inkBounds, frameDelta),
+      wrapBounds: frame.geometry.wrapBounds ? translateRect(frame.geometry.wrapBounds, frameDelta) : null,
+      wrap: { ...frame.geometry.wrap, polygon: frame.geometry.wrap.polygon ? {
+        ...frame.geometry.wrap.polygon,
+        points: frame.geometry.wrap.polygon.points.map((point) => translatePoint(point, frameDelta)),
+      } : null },
+    },
+  };
+}
+
+/** Translate retained paragraph geometry without invoking acquisition services. */
+export function translateParagraphLayout(paragraph: ParagraphLayout, delta: LayoutTranslation): ParagraphLayout {
+  return translateParagraphWithContext(paragraph, delta, {
+    memo: new WeakMap(), drawingMemo: new WeakMap(),
+  });
+}
+
+function translateParagraphWithContext(
+  paragraph: ParagraphLayout,
+  delta: LayoutTranslation,
+  context: ParagraphTranslationContext,
+): ParagraphLayout {
+  const key = `${delta.xPt}\u0000${delta.yPt}`;
+  const prior = context.memo.get(paragraph);
+  if (prior) {
+    if (prior.key !== key) throw new Error('incompatible projection ownership');
+    return prior.value;
+  }
+  const anchorOwnership = new Map(paragraph.drawings.flatMap((drawing) =>
+    drawing.anchorLayer ? [[drawing.anchorLayer.occurrenceId, drawing.anchorLayer] as const] : []));
+  const textBoxTranslations = new Map<LayoutNodeId, LayoutTranslation>();
+  const drawingTranslations = new Map<LayoutNodeId, LayoutTranslation>();
+  for (const drawing of paragraph.drawings) {
+    const drawingDelta = {
+      xPt: drawing.anchorLayer?.horizontalOwnership === 'page' ? 0 : delta.xPt,
+      yPt: drawing.anchorLayer?.verticalOwnership === 'page' ? 0 : delta.yPt,
+    };
+    drawingTranslations.set(drawing.id, drawingDelta);
+    drawing.textBoxIds?.forEach((id) => textBoxTranslations.set(id, drawingDelta));
+  }
+  const translated: ParagraphLayout = {
+    ...paragraph,
+    flowBounds: translateRect(paragraph.flowBounds, delta), inkBounds: translateRect(paragraph.inkBounds, delta),
+    ...(paragraph.clipBounds ? { clipBounds: translateRect(paragraph.clipBounds, delta) } : {}),
+    lines: paragraph.lines.map((line) => translateLine(line, delta, drawingTranslations)),
+    borders: paragraph.borders.map((border) => translateBorder(border, delta)),
+    drawings: paragraph.drawings.map((drawing) => translateDrawingWithContext(
+      drawing, drawingTranslations.get(drawing.id) ?? delta, context,
+    )),
+    textBoxes: paragraph.textBoxes.map((textBox) =>
+      translateTextBoxWithContext(textBox, textBoxTranslations.get(textBox.id) ?? delta, context)),
+    exclusions: paragraph.exclusions.map((exclusion) => {
+      const owner = exclusion.anchorOccurrenceId ? anchorOwnership.get(exclusion.anchorOccurrenceId) : undefined;
+      const exclusionDelta = {
+        xPt: owner?.horizontalOwnership === 'page' ? 0 : delta.xPt,
+        yPt: exclusion.verticalOwnership === 'page' || owner?.verticalOwnership === 'page' ? 0 : delta.yPt,
+      };
+      return {
+        ...exclusion, bounds: translateRect(exclusion.bounds, exclusionDelta),
+        polygon: exclusion.polygon.map((point) => translatePoint(point, exclusionDelta)),
+      };
+    }),
+    ...(paragraph.anchorFrames ? { anchorFrames: paragraph.anchorFrames.map((frame) =>
+      translateAnchorFrame(frame, delta)) } : {}),
+    ...(paragraph.paragraphMark ? { paragraphMark: {
+      ...paragraph.paragraphMark, bounds: translateRect(paragraph.paragraphMark.bounds, delta),
+    } } : {}),
+    ...(paragraph.lineNumbers ? { lineNumbers: paragraph.lineNumbers.map((lineNumber) => ({
+      ...lineNumber, bounds: translateRect(lineNumber.bounds, delta),
+      paintOps: lineNumber.paintOps.map((operation) => ({
+        ...operation, origin: translatePoint(operation.origin, delta),
+      })),
+    })) } : {}),
+  };
+  context.memo.set(paragraph, { key, value: translated });
+  return translated;
+}
+
+export function translateTextBox(textBox: TextBoxLayout, delta: LayoutTranslation): TextBoxLayout {
+  return translateTextBoxWithContext(textBox, delta, {
+    memo: new WeakMap(), drawingMemo: new WeakMap(),
+  });
+}
+
+function translateTextBoxWithContext(
+  textBox: TextBoxLayout,
+  delta: LayoutTranslation,
+  context: ParagraphTranslationContext,
+): TextBoxLayout {
+  const pageRelativeContent = textBox.verticalMode === undefined;
+  return {
+    ...textBox,
+    flowBounds: translateRect(textBox.flowBounds, delta), inkBounds: translateRect(textBox.inkBounds, delta),
+    ...(textBox.clipBounds ? { clipBounds: translateRect(textBox.clipBounds, delta) } : {}),
+    ...(textBox.contentBounds ? { contentBounds: pageRelativeContent
+      ? translateRect(textBox.contentBounds, delta) : textBox.contentBounds } : {}),
+    paragraphs: pageRelativeContent
+      ? textBox.paragraphs.map((paragraph) => translateParagraphWithContext(paragraph, delta, context))
+      : textBox.paragraphs,
+  };
+}
+
+export function translateCompleteParagraphLayout(
+  paragraph: ParagraphLayout,
+  delta: LayoutTranslation,
+): ParagraphLayout {
+  return translateParagraphLayout(paragraph, delta);
+}
+
+export function translateTableLayout(table: TableLayout, delta: LayoutTranslation): TableLayout {
+  return {
+    ...table,
+    flowBounds: translateRect(table.flowBounds, delta), inkBounds: translateRect(table.inkBounds, delta),
+    ...(table.clipBounds ? { clipBounds: translateRect(table.clipBounds, delta) } : {}),
+    borders: table.borders.map((border) => translateBorder(border, delta)),
+    rows: table.rows.map((row) => ({
+      ...row,
+      flowBounds: translateRect(row.flowBounds, delta), inkBounds: translateRect(row.inkBounds, delta),
+      ...(row.clipBounds ? { clipBounds: translateRect(row.clipBounds, delta) } : {}),
+      cells: row.cells.map((cell) => ({
+        ...cell,
+        flowBounds: translateRect(cell.flowBounds, delta), inkBounds: translateRect(cell.inkBounds, delta),
+        ...(cell.clipBounds ? { clipBounds: translateRect(cell.clipBounds, delta) } : {}),
+        contentBounds: translateRect(cell.contentBounds, delta),
+        // Cell paint adds contentBounds/offsetPt; retained descendants are cell-local.
+        blocks: cell.blocks,
+      })),
+    })),
+  };
+}

--- a/packages/docx/src/layout/types.ts
+++ b/packages/docx/src/layout/types.ts
@@ -154,6 +154,8 @@ export interface DrawingLayout extends LayoutNodeBase {
   readonly commands: readonly DrawingPaintCommand[];
   readonly anchorLayer?: Readonly<{
     occurrenceId: string;
+    /** Stable identity from acquisition before occurrence-local re-keying. */
+    acquisitionOccurrenceId?: string;
     behindDoc: boolean;
     relativeHeight: number;
     sourceOrder: number;

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -347,6 +347,38 @@ function assertCapabilityBoundaries(root) {
   }
 }
 
+function assertOccurrenceProjectionRuntimeDependencies(root) {
+  const occurrence = resolve(root, LAYOUT_SOURCE, 'occurrence-projection.ts');
+  const translation = resolve(root, LAYOUT_SOURCE, 'retained-geometry-translation.ts');
+  const plainData = resolve(root, LAYOUT_SOURCE, 'plain-data.ts');
+  const guarded = [occurrence, translation, plainData];
+  for (const path of guarded) {
+    if (!existsSync(path)) {
+      fail('OCCURRENCE_PROJECTION_RUNTIME_DEPENDENCY', `missing ${posixPath(relative(root, path))}`);
+    }
+  }
+  const allowedTargets = new Map([
+    [occurrence, new Set([translation, plainData])],
+    [translation, new Set()],
+    [plainData, new Set()],
+  ]);
+  for (const current of guarded) {
+    for (const edge of moduleEdges(current)) {
+      if (edge.typeOnly) continue;
+      const detail = `${posixPath(relative(root, current))} -> ${edge.specifier}`;
+      if (!edge.literal || edge.kind === 'dynamic-import' || edge.kind === 'require'
+        || edge.bare || edge.specifier.includes('?') || edge.specifier.includes('#')
+        || !edge.specifier.startsWith('.')) {
+        fail('OCCURRENCE_PROJECTION_RUNTIME_DEPENDENCY', detail);
+      }
+      const dependency = resolveLocalImport(current, edge.specifier);
+      if (!dependency || !allowedTargets.get(current)?.has(dependency)) {
+        fail('OCCURRENCE_PROJECTION_RUNTIME_DEPENDENCY', detail);
+      }
+    }
+  }
+}
+
 /**
  * Body paint consumes retained placements. Letting this adapter call a layout
  * entry point would silently reintroduce a second layout pass whose result can
@@ -2656,6 +2688,7 @@ export function checkDocxLayoutBoundaries(options) {
   assertNoProductionTestSupportImports(root);
   assertPaintBoundaries(root);
   assertCapabilityBoundaries(root);
+  assertOccurrenceProjectionRuntimeDependencies(root);
   assertBodyPaintConsumesRetainedLayout(root);
   assertLayoutParserModelBoundaries(root);
 

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -30,8 +30,17 @@ function runChecker(root, ...args) {
   return command(root, process.execPath, [checker, '--root', root, ...args]);
 }
 
+function initializeFixture(prefix) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  write(root, 'packages/docx/src/layout/plain-data.ts', 'export function snapshotPlainData(value) { return value; }\n');
+  write(root, 'packages/docx/src/layout/occurrence-projection.ts', "import { snapshotPlainData } from './plain-data.js';\nexport const project = snapshotPlainData;\n");
+  write(root, 'packages/docx/src/layout/retained-geometry-translation.ts', "import type { PointPt } from './types.js';\nexport const translate = (point: PointPt) => point;\n");
+  write(root, 'packages/docx/src/layout/types.ts', 'export interface PointPt { xPt: number; yPt: number }\n');
+  return root;
+}
+
 function initializeRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-'));
+  const root = initializeFixture('docx-layout-boundary-');
   write(root, 'packages/docx/src/renderer.ts', 'function buildMeasureState(ctx: unknown, fonts: unknown) { return [ctx, fonts]; }\nexport function computePages(ctx: unknown, resolvedLocalFonts: unknown = {}) { const measure = buildMeasureState(ctx, resolvedLocalFonts); return [measure]; }\nexport function computeTableLayout() { return []; }\n');
   write(root, 'packages/docx/src/line-layout.ts', 'export function layoutLines() { return []; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -42,6 +51,76 @@ function initializeRepository() {
   git(root, 'commit', '-m', 'base');
   git(root, 'switch', '-c', 'a1');
   return root;
+}
+
+function initializeOccurrenceProjectionRepository(importSource = "import { snapshotPlainData } from './plain-data.js';\nexport const project = snapshotPlainData;\n") {
+  const root = initializeRepository();
+  establishA1Baseline(root);
+  write(root, 'packages/docx/src/layout/occurrence-projection.ts', importSource);
+  return root;
+}
+
+test('occurrence projection runtime graph allows only its entries and plain-data', () => {
+  const root = initializeOccurrenceProjectionRepository();
+  const result = runChecker(root, '--base-ref', 'main');
+  assert.equal(result.status, 0, result.output);
+});
+
+test('occurrence projection runtime graph rejects translation and plain-data dependencies', () => {
+  const translationRoot = initializeOccurrenceProjectionRepository();
+  write(translationRoot, 'packages/docx/src/layout/retained-geometry-translation.ts',
+    "import { measure } from '../paragraph-measure.js';\nexport const translate = measure;\n");
+  assert.match(runChecker(translationRoot, '--base-ref', 'main').output,
+    /OCCURRENCE_PROJECTION_RUNTIME_DEPENDENCY/);
+
+  const plainRoot = initializeOccurrenceProjectionRepository();
+  write(plainRoot, 'packages/docx/src/layout/plain-data.ts',
+    "import { parser } from '../parser-model.js';\nexport const snapshotPlainData = parser;\n");
+  assert.match(runChecker(plainRoot, '--base-ref', 'main').output,
+    /OCCURRENCE_PROJECTION_RUNTIME_DEPENDENCY/);
+});
+
+test('occurrence projection runtime graph rejects reverse edges', () => {
+  const reverseRoot = initializeOccurrenceProjectionRepository();
+  write(reverseRoot, 'packages/docx/src/layout/retained-geometry-translation.ts',
+    "import { project } from './occurrence-projection.js';\nexport const translate = project;\n");
+  assert.match(runChecker(reverseRoot, '--base-ref', 'main').output,
+    /OCCURRENCE_PROJECTION_RUNTIME_DEPENDENCY/);
+
+});
+
+for (const missing of ['occurrence-projection.ts', 'retained-geometry-translation.ts', 'plain-data.ts']) {
+  test(`occurrence projection runtime graph rejects missing ${missing}`, () => {
+    const root = initializeOccurrenceProjectionRepository();
+    rmSync(join(root, 'packages/docx/src/layout', missing));
+    assert.match(runChecker(root, '--base-ref', 'main').output,
+      /OCCURRENCE_PROJECTION_RUNTIME_DEPENDENCY/);
+  });
+}
+
+test('occurrence projection runtime graph rejects a missing seam', () => {
+  const root = initializeOccurrenceProjectionRepository();
+  for (const missing of ['occurrence-projection.ts', 'retained-geometry-translation.ts', 'plain-data.ts']) {
+    rmSync(join(root, 'packages/docx/src/layout', missing));
+  }
+  assert.match(runChecker(root, '--base-ref', 'main').output,
+    /OCCURRENCE_PROJECTION_RUNTIME_DEPENDENCY/);
+});
+
+for (const [name, source] of [
+  ['external local', "import { measure } from '../paragraph-measure.js';\nexport const project = measure;\n"],
+  ['decorated', "import { snapshotPlainData } from './plain-data.js?raw';\nexport const project = snapshotPlainData;\n"],
+  ['dynamic literal', "export const project = import('./plain-data.js');\n"],
+  ['dynamic nonliteral', "const path = './plain-data.js';\nexport const project = import(path);\n"],
+  ['bare parser', "import { parser } from '../parser-model.js';\nexport const project = parser;\n"],
+  ['bare package', "import value from 'measurement-service';\nexport const project = value;\n"],
+]) {
+  test(`occurrence projection runtime graph rejects ${name} dependencies`, () => {
+    const root = initializeOccurrenceProjectionRepository(source);
+    const result = runChecker(root, '--base-ref', 'main');
+    assert.notEqual(result.status, 0);
+    assert.match(result.output, /OCCURRENCE_PROJECTION_RUNTIME_DEPENDENCY/);
+  });
 }
 
 const computePagesTableStampBaseline = `
@@ -133,7 +212,7 @@ const computePagesEnvelopeMigration = computePagesEnvelopeBaseline
   .replaceAll('attachRetainedTableEnvelope', 'attachTableFragment');
 
 function initializeComputePagesUprightRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-upright-finalize-'));
+  const root = initializeFixture('docx-layout-boundary-upright-finalize-');
   write(root, 'packages/docx/src/renderer.ts', computePagesUprightBaseline);
   write(root, 'packages/docx/src/line-layout.ts', 'export function layoutLines() { return []; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -148,7 +227,7 @@ function initializeComputePagesUprightRepository() {
 }
 
 function initializeComputePagesEnvelopeRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-envelope-rename-'));
+  const root = initializeFixture('docx-layout-boundary-envelope-rename-');
   write(root, 'packages/docx/src/renderer.ts', computePagesEnvelopeBaseline);
   write(root, 'packages/docx/src/line-layout.ts', 'export function layoutLines() { return []; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -199,7 +278,7 @@ export function computeTableLayout() { return []; }
 `;
 
 function initializeComputePagesFittingOuterRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-fitting-outer-finalize-'));
+  const root = initializeFixture('docx-layout-boundary-fitting-outer-finalize-');
   write(root, 'packages/docx/src/renderer.ts', computePagesFittingOuterBaseline);
   write(root, 'packages/docx/src/line-layout.ts', 'export function layoutLines() { return []; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -262,7 +341,7 @@ function priorFittingOuterProbeSource(current) {
 }
 
 function initializeComposedFittingOuterProbeRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-composed-fitting-probe-'));
+  const root = initializeFixture('docx-layout-boundary-composed-fitting-probe-');
   const productionRoot = resolve(import.meta.dirname, '..');
   const current = readFileSync(join(productionRoot, 'packages/docx/src/renderer.ts'), 'utf8');
   write(root, 'packages/docx/src/renderer.ts', priorFittingOuterProbeSource(current));
@@ -432,7 +511,7 @@ function priorOccurrenceOwnerSource(current) {
 }
 
 function initializeOccurrenceOwnerRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-occurrence-owner-'));
+  const root = initializeFixture('docx-layout-boundary-occurrence-owner-');
   const productionRoot = resolve(import.meta.dirname, '..');
   const current = readFileSync(join(productionRoot, 'packages/docx/src/renderer.ts'), 'utf8');
   write(root, 'packages/docx/src/renderer.ts', priorOccurrenceOwnerSource(current));
@@ -449,7 +528,7 @@ function initializeOccurrenceOwnerRepository() {
 }
 
 function initializeSplitFloatLivePageRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-split-float-live-page-'));
+  const root = initializeFixture('docx-layout-boundary-split-float-live-page-');
   const productionRoot = resolve(import.meta.dirname, '..');
   const current = readFileSync(join(productionRoot, 'packages/docx/src/renderer.ts'), 'utf8');
   const livePageCallback = '            () => pages.length - 1,\n';
@@ -486,7 +565,7 @@ function priorEffectiveFlowSource(current) {
 }
 
 function initializeEffectiveFlowRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-effective-flow-'));
+  const root = initializeFixture('docx-layout-boundary-effective-flow-');
   const productionRoot = resolve(import.meta.dirname, '..');
   const current = readFileSync(join(productionRoot, 'packages/docx/src/renderer.ts'), 'utf8');
   write(root, 'packages/docx/src/renderer.ts', priorEffectiveFlowSource(current));
@@ -533,7 +612,7 @@ function priorSplitParentCommitSource(current) {
 }
 
 function initializeSplitParentCommitRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-split-parent-commit-'));
+  const root = initializeFixture('docx-layout-boundary-split-parent-commit-');
   const productionRoot = resolve(import.meta.dirname, '..');
   const current = readFileSync(join(productionRoot, 'packages/docx/src/renderer.ts'), 'utf8');
   write(root, 'packages/docx/src/renderer.ts', priorSplitParentCommitSource(current));
@@ -550,7 +629,7 @@ function initializeSplitParentCommitRepository() {
 }
 
 function initializeComputePagesTableStampRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-compute-pages-table-stamp-'));
+  const root = initializeFixture('docx-layout-boundary-compute-pages-table-stamp-');
   write(root, 'packages/docx/src/renderer.ts', computePagesTableStampBaseline);
   write(root, 'packages/docx/src/line-layout.ts', 'export function layoutLines() { return []; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -621,7 +700,7 @@ export function computeTableLayout(table: any, contentWPx: number, state: any) {
 ${computeTableLayoutCommonTail.slice(1)}`;
 
 function initializeComputeTableLayoutRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-compute-table-layout-'));
+  const root = initializeFixture('docx-layout-boundary-compute-table-layout-');
   write(root, 'packages/docx/src/renderer.ts', computeTableLayoutStampBaseline);
   write(root, 'packages/docx/src/line-layout.ts', 'export function layoutLines() { return []; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -738,7 +817,7 @@ export function computeTableLayout() { return []; }
 `;
 
 function initializeComputePagesAcquisitionRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-compute-pages-'));
+  const root = initializeFixture('docx-layout-boundary-compute-pages-');
   write(root, 'packages/docx/src/renderer.ts', computePagesAcquisitionBaseline);
   write(root, 'packages/docx/src/line-layout.ts', 'export function layoutLines() { return []; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -776,7 +855,7 @@ const tablePaintGateMigration = tablePaintGateBaseline
   .replace('    !fragmentPaintEnabled ||\n', '');
 
 function initializeTablePaintGateRepository(pruneDeletedFlag = true) {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-table-gate-'));
+  const root = initializeFixture('docx-layout-boundary-table-gate-');
   write(root, 'packages/docx/src/renderer.ts', tablePaintGateBaseline);
   write(root, 'packages/docx/src/line-layout.ts', 'export function layoutLines() { return []; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -808,7 +887,7 @@ function initializeTablePaintGateRepository(pruneDeletedFlag = true) {
 }
 
 function initializeLayoutParserBoundaryRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-parser-boundary-'));
+  const root = initializeFixture('docx-layout-parser-boundary-');
   write(root, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(root, 'packages/docx/src/parser-model.ts', 'export function normalizeInternalDocumentModel(document: unknown) { return { document, mathOccurrences: [] }; }\nexport const parserFacts = true;\nexport interface ParserFacts { value: string; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -822,7 +901,7 @@ const exactParserGatewaySource =
   + '}\n';
 
 function initializeShapeRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-shape-'));
+  const root = initializeFixture('docx-layout-boundary-shape-');
   write(root, 'packages/docx/src/renderer.ts', 'function buildFont(bold: boolean, italic: boolean, size: number, family: string | null, classes: Record<string, string>) { return String([bold, italic, size, family, classes]); }\nexport function renderShapeText(s: { bold: boolean; italic: boolean; size: number; family: string | null; fontRoute?: unknown }, classes: Record<string, string>) { return buildFont(s.bold, s.italic, s.size, s.family, classes); }\n');
   write(root, 'packages/docx/src/line-layout.ts', 'export function layoutLines() { return []; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -837,7 +916,7 @@ function initializeShapeRepository() {
 }
 
 function initializeMetricShapeRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-shape-metric-'));
+  const root = initializeFixture('docx-layout-boundary-shape-metric-');
   write(root, 'packages/docx/src/renderer.ts', 'function buildFont(bold: boolean, italic: boolean, size: number, family: string | null, classes: Record<string, string>, route?: unknown) { return String([bold, italic, size, family, classes, route]); }\nexport function renderShapeText(s: { bold: boolean; italic: boolean; size: number; family: string | null; fontRoute?: unknown; eaFloorRoute?: unknown }, classes: Record<string, string>) { const shapeLineMetrics = (family: string | null) => { return buildFont(s.bold, s.italic, s.size, family, classes); }; return shapeLineMetrics(s.family); }\n');
   write(root, 'packages/docx/src/line-layout.ts', 'export function layoutLines() { return []; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -852,7 +931,7 @@ function initializeMetricShapeRepository() {
 }
 
 function initializeNumberingShapeRepository() {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-shape-numbering-'));
+  const root = initializeFixture('docx-layout-boundary-shape-numbering-');
   write(root, 'packages/docx/src/renderer.ts', 'export function renderShapeText(block: any, ctx: any, scale: number, effState: any, eaVertUpright: boolean, markerX: number, baseline: number) { const markerText = markerDisplayText(block.numbering); const markerW = ctx.measureText(markerText).width; if (eaVertUpright) { drawVerticalRun(ctx, markerText, markerX, baseline, block.fontSizePt * scale, 0); } else { ctx.fillText(markerText, markerX, baseline); } return markerW; }\n');
   write(root, 'packages/docx/src/line-layout.ts', 'export function layoutLines() { return []; }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
@@ -901,7 +980,7 @@ test('allows a migrated legacy declaration to be deleted from source and baselin
 });
 
 test('rejects a transitive paint edge to a measurement module', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-edge-'));
+  const root = initializeFixture('docx-layout-boundary-edge-');
   write(root, 'packages/docx/src/renderer.ts', 'export const adapter = true;\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', "import { helper } from './helper.js';\nexport { helper };\n");
   write(root, 'packages/docx/src/paint/helper.ts', "import { layoutLines } from '../line-layout.js';\nexport const helper = layoutLines;\n");
@@ -1128,7 +1207,7 @@ test('rejects non-literal dynamic and CommonJS edges in the parser gateway', () 
 });
 
 test('rejects any paint runtime dependency outside the paint owner directory', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-arbitrary-edge-'));
+  const root = initializeFixture('docx-layout-boundary-arbitrary-edge-');
   write(root, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', "import { helper } from '../text-wrap.js';\nexport { helper };\n");
   write(root, 'packages/docx/src/text-wrap.ts', 'export const helper = true;\n');
@@ -1141,7 +1220,7 @@ test('rejects any paint runtime dependency outside the paint owner directory', (
 });
 
 test('allows only the layout contract as a type-only paint dependency', () => {
-  const allowed = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-type-edge-'));
+  const allowed = initializeFixture('docx-layout-boundary-type-edge-');
   write(allowed, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(allowed, 'packages/docx/src/layout/types.ts', 'export interface Layout { pages: number; }\n');
   write(allowed, 'packages/docx/src/paint/canvas-page.ts', "import type { Layout } from '../layout/types.js';\nexport type Page = Layout;\n");
@@ -1155,7 +1234,7 @@ test('allows only the layout contract as a type-only paint dependency', () => {
 });
 
 test('allows only named shared atomic painters from core', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-shared-paint-'));
+  const root = initializeFixture('docx-layout-boundary-shared-paint-');
   write(root, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', "import { renderChart } from '@silurus/ooxml-core';\nexport { renderChart };\n");
   assert.equal(runChecker(root, '--final').status, 0);
@@ -1213,7 +1292,7 @@ test('allows only named shared atomic painters from core', () => {
 });
 
 test('rejects forbidden core APIs reached through a paint helper', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-shared-paint-transitive-'));
+  const root = initializeFixture('docx-layout-boundary-shared-paint-transitive-');
   write(root, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', "import { paint } from './helper.js';\nvoid paint;\n");
   write(root, 'packages/docx/src/paint/helper.ts', "import { measureTextWidth } from '@silurus/ooxml-core';\nexport const paint = measureTextWidth;\n");
@@ -1226,7 +1305,7 @@ test('rejects forbidden core APIs reached through a paint helper', () => {
 });
 
 test('keeps layout-only border treatment outside the paint dependency graph', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-border-treatment-'));
+  const root = initializeFixture('docx-layout-boundary-border-treatment-');
   write(root, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(root, 'packages/docx/src/layout/types.ts', 'export interface Layout { pages: number; }\n');
   write(root, 'packages/docx/src/layout/border-treatment.ts', "import { docxBorderDashArray } from '@silurus/ooxml-core';\nexport const treatment = docxBorderDashArray('dotDash', 1);\n");
@@ -1243,7 +1322,7 @@ test('rejects paint dependencies on layout resource implementations even when ty
     "import { createPaintResourceRegistry } from '../layout/paint-resources.js';\nexport const registry = createPaintResourceRegistry([]);\n",
     "import type { PaintResourceRegistry } from '../layout/paint-resources.js';\nexport type Registry = PaintResourceRegistry;\n",
   ]) {
-    const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-resource-owner-'));
+    const root = initializeFixture('docx-layout-boundary-resource-owner-');
     write(root, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
     write(root, 'packages/docx/src/layout/paint-resources.ts', 'export interface PaintResourceRegistry {}\nexport function createPaintResourceRegistry() {}\n');
     write(root, 'packages/docx/src/paint/canvas-page.ts', source);
@@ -1256,7 +1335,7 @@ test('rejects paint dependencies on layout resource implementations even when ty
 });
 
 test('audits dependencies of the retained page graph allowed in paint', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-page-graph-edge-'));
+  const root = initializeFixture('docx-layout-boundary-page-graph-edge-');
   write(root, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', "import { orderedPagePaintNodes } from '../layout/page-graph.js';\nexport { orderedPagePaintNodes };\n");
   write(root, 'packages/docx/src/layout/page-graph.ts', "import { measureTextWidth } from '../measurement.js';\nexport const orderedPagePaintNodes = measureTextWidth;\n");
@@ -1270,7 +1349,7 @@ test('audits dependencies of the retained page graph allowed in paint', () => {
 });
 
 test('rejects non-literal dynamic paint imports', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-dynamic-edge-'));
+  const root = initializeFixture('docx-layout-boundary-dynamic-edge-');
   write(root, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export const load = (name: string) => import(`../${name}.js`);\n');
 
@@ -1281,14 +1360,14 @@ test('rejects non-literal dynamic paint imports', () => {
 });
 
 test('rejects computed measurement access in paint and display inputs in layout TSX', () => {
-  const paintRoot = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-computed-'));
+  const paintRoot = initializeFixture('docx-layout-boundary-computed-');
   write(paintRoot, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(paintRoot, 'packages/docx/src/paint/canvas-page.ts', "export const width = (ctx: CanvasRenderingContext2D) => ctx['measureText']('x').width;\n");
   const paintResult = runChecker(paintRoot, '--final');
   assert.notEqual(paintResult.status, 0);
   assert.match(paintResult.output, /PAINT_CAPABILITY/);
 
-  const layoutRoot = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-layout-display-'));
+  const layoutRoot = initializeFixture('docx-layout-boundary-layout-display-');
   write(layoutRoot, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(layoutRoot, 'packages/docx/src/layout/page.tsx', 'export const Page = ({ dpr }: { dpr: number }) => dpr;\n');
   const layoutResult = runChecker(layoutRoot, '--final');
@@ -1315,7 +1394,7 @@ test('rejects layout acquisition from the retained body paint adapter', () => {
     'renderParagraph()',
     'services.resolveFrameBox()',
   ]) {
-    const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-body-paint-'));
+    const root = initializeFixture('docx-layout-boundary-body-paint-');
     write(
       root,
       'packages/docx/src/renderer.ts',
@@ -1385,7 +1464,7 @@ test('rejects aliased, computed, and unresolved calls from retained body paint',
   ];
 
   for (const renderer of renderers) {
-    const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-body-paint-alias-'));
+    const root = initializeFixture('docx-layout-boundary-body-paint-alias-');
     write(root, 'packages/docx/src/renderer.ts', renderer);
     write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
 
@@ -1548,7 +1627,7 @@ test('rejects late mutations of canonical body fragment sidecars', () => {
 });
 
 test('rejects transitive layout acquisition from a local body paragraph paint helper', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-body-paint-transitive-'));
+  const root = initializeFixture('docx-layout-boundary-body-paint-transitive-');
   write(
     root,
     'packages/docx/src/renderer.ts',
@@ -1573,7 +1652,7 @@ test('rejects transitive layout acquisition from a local body paragraph paint he
 });
 
 test('rejects layout acquisition hidden inside an inline retained-paint callback', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-body-paint-callback-'));
+  const root = initializeFixture('docx-layout-boundary-body-paint-callback-');
   write(
     root,
     'packages/docx/src/renderer.ts',
@@ -1597,7 +1676,7 @@ test('rejects layout acquisition hidden inside an inline retained-paint callback
 });
 
 test('follows the else branch of a negated paragraph dispatch', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-body-paint-negated-'));
+  const root = initializeFixture('docx-layout-boundary-body-paint-negated-');
   write(
     root,
     'packages/docx/src/renderer.ts',
@@ -1620,7 +1699,7 @@ test('follows the else branch of a negated paragraph dispatch', () => {
 });
 
 test('fails closed when the body paragraph dispatch cannot be audited', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-body-paint-opaque-'));
+  const root = initializeFixture('docx-layout-boundary-body-paint-opaque-');
   write(root, 'packages/docx/src/renderer.ts', 'function renderBodyElements() { dispatchBody(); }\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paint() {}\n');
 
@@ -1667,7 +1746,7 @@ test('allows the exact frozen production fragment map and retained paragraph pai
 });
 
 test('rejects a CommonJS require edge that bypasses static ESM imports', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-require-'));
+  const root = initializeFixture('docx-layout-boundary-require-');
   write(root, 'packages/docx/src/renderer.ts', 'export const adapter = true;\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', "const helper = require('./helper.js');\nexport { helper };\n");
   write(root, 'packages/docx/src/paint/helper.ts', "const measured = require('../line-layout.js');\nexport { measured };\n");
@@ -2445,7 +2524,7 @@ test('rejects any non-exact A2 parameter syntax and pass-through expression', ()
 });
 
 test('final mode enforces the renderer adapter export and import allowlists', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-final-adapter-'));
+  const root = initializeFixture('docx-layout-boundary-final-adapter-');
   write(root, 'packages/docx/src/layout/document.ts', 'export function layoutDocument() {}\n');
   write(root, 'packages/docx/src/paint/canvas-page.ts', 'export function paintLayoutPage() {}\n');
   write(root, 'packages/docx/src/renderer.ts', "import { layoutDocument } from './layout/document.js';\nimport { paintLayoutPage } from './paint/canvas-page.js';\nexport function paginateDocument() { return layoutDocument(); }\nexport function renderDocumentToCanvas() { return paintLayoutPage(); }\n");
@@ -2459,7 +2538,7 @@ test('final mode enforces the renderer adapter export and import allowlists', ()
 });
 
 test('final mode rejects layout logic hidden inside an allowed renderer adapter', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-inline-adapter-'));
+  const root = initializeFixture('docx-layout-boundary-inline-adapter-');
   write(root, 'packages/docx/src/renderer.ts', `
 export function paginateDocument(items: unknown[]) {
   const pages = [];
@@ -2476,19 +2555,19 @@ export function renderDocumentToCanvas() {}
 });
 
 test('final mode rejects renamed fallback and style-cascade capabilities', () => {
-  const diagnostic = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-diagnostic-fallback-'));
+  const diagnostic = initializeFixture('docx-layout-boundary-diagnostic-fallback-');
   write(diagnostic, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(diagnostic, 'packages/docx/src/layout/page.ts', "export const diagnosticFallback = { code: 'UNSUPPORTED_FEATURE' };\n");
   assert.equal(runChecker(diagnostic, '--final').status, 0);
 
-  const fallback = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-old-engine-'));
+  const fallback = initializeFixture('docx-layout-boundary-old-engine-');
   write(fallback, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(fallback, 'packages/docx/src/layout/page.ts', 'export const useOldEngine = true;\n');
   const fallbackResult = runChecker(fallback, '--final');
   assert.notEqual(fallbackResult.status, 0);
   assert.match(fallbackResult.output, /FINAL_LEGACY_BOUNDARY/);
 
-  const style = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-fold-style-'));
+  const style = initializeFixture('docx-layout-boundary-fold-style-');
   write(style, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');
   write(style, 'packages/docx/src/layout/page.ts', 'export function foldRunFormatting(base: object, direct: object) { return { ...base, ...direct }; }\n');
   const styleResult = runChecker(style, '--final');
@@ -2497,7 +2576,7 @@ test('final mode rejects renamed fallback and style-cascade capabilities', () =>
 });
 
 test('final mode rejects star exports from renderer', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-star-export-'));
+  const root = initializeFixture('docx-layout-boundary-star-export-');
   write(root, 'packages/docx/src/layout/page.ts', 'export function accidentalAlgorithm() {}\n');
   write(root, 'packages/docx/src/renderer.ts', "export * from './layout/page.js';\nexport function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n");
 
@@ -2508,7 +2587,7 @@ test('final mode rejects star exports from renderer', () => {
 });
 
 test('excludes test-support modules from production inventory but rejects production imports', () => {
-  const root = mkdtempSync(join(tmpdir(), 'docx-layout-boundary-test-support-'));
+  const root = initializeFixture('docx-layout-boundary-test-support-');
   write(root, 'packages/docx/src/retained.test-support.ts', 'export function acquireForTest() { return 1; }\n');
   write(root, 'packages/docx/src/retained.test.ts', "import { acquireForTest } from './retained.test-support.js';\nvoid acquireForTest();\n");
   write(root, 'packages/docx/src/renderer.ts', 'export function paginateDocument() {}\nexport function renderDocumentToCanvas() {}\n');


### PR DESCRIPTION
## Summary

- add deterministic projection of retained paragraph and table layout graphs into occurrence-local identities and flow domains
- move retained geometry translation into a shared pure module, preserving page/margin-owned axes and valid DAG aliases
- add semantic ownership checks for anchors and floating-table placements without rejecting valid fragment/source aliases
- make the projection output structured-clone-safe, deeply frozen, and guarded by a fail-closed runtime dependency check

## Specification basis

- ECMA-376 Part 1 §17.4.49: repeated table header occurrences
- ECMA-376 Part 1 §17.4.57: floating-table positioning and anchor ownership
- ECMA-376 Part 1 §17.16.5.42 and §17.16.5.44: PAGE and NUMPAGES context retention
- DrawingML §20.4.2.3: anchored drawing ownership

Deterministic ID namespaces, nested flow-domain spelling, semantic ownership rejection, structured-clone snapshotting, and deep freezing are documented as engine policies rather than OOXML rules.

## Verification

- `pnpm test` — 5,078 passed, 26 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:test`
- `pnpm build`
- `node scripts/check-docx-public-api.mjs`
- `pnpm test:docx-boundaries` — 95 passed
- independent specification/correctness review: approved
- independent architecture/code-quality review: approved
- final Fable critical review: approved

Part of #1037 (A6 occurrence projection). The top-level A6 item remains open for the remaining cutover steps.