### PR TITLE
refactor(docx): make coordinate ownership explicit

### DIFF
--- a/docs/docx-layout-engine-series-a-plan.md
+++ b/docs/docx-layout-engine-series-a-plan.md
@@ -852,17 +852,24 @@ floating test.
 export interface PageFlowState {
   readonly pageIndex: number;
   readonly columnIndex: number;
+  readonly pageHasContent: boolean;
   readonly cursorBlockPt: number;
   readonly pageContentStartBlockPt: number;
   readonly regionStartBlockPt: number;
-  readonly sectionOccurrenceId: string;
-  readonly section: SectionLayoutContext;
+  readonly deepestColumnBlockPt: number;
+  readonly section: PageFlowSectionContext;
 }
 export type PageFlowEvent =
-  | Readonly<{ type: 'place'; node: PaintNode }>
+  | Readonly<{ type: 'place'; node: PaintNode; blockStartPt: number; blockEndPt: number }>
   | Readonly<{ type: 'next-column' }>
-  | Readonly<{ type: 'next-page'; reason: 'overflow' | 'explicit-break' | 'section-break' | 'parity' }>
-  | Readonly<{ type: 'begin-section'; section: SectionLayoutContext }>;
+  | Readonly<{
+      type: 'next-page';
+      reason: 'overflow' | 'explicit-break' | 'page-break-before' | 'section-break' | 'parity';
+      pageIndex: number;
+      sectionOccurrenceId: string;
+      parityBlank: boolean;
+    }>
+  | Readonly<{ type: 'begin-section'; section: PageFlowSectionContext }>;
 export function paginateBody(input: BodyLayoutInput, services: LayoutServices, options: LayoutOptions): DocumentLayout;
 ```
 
@@ -896,13 +903,17 @@ are recovered from element stamps rather than `LayoutPage`.
 
 - [ ] **Step 3: Implement explicit transitions and page ownership**
 
+PR4 supplies the explicit logical/physical coordinate and retained ownership
+contracts without connecting a production caller. PR5 performs the producer,
+paint, main-thread, and worker cutover.
+
 Normalize consecutive same-effective-style-ID in-flow tables into one logical
 table before page transitions, without merging across paragraphs or effective
 floating tables. Make each transition return a new `PageFlowState` over the
 logical block axis. A physical `LayoutPage` owns its page box and page-start
-header/footer geometry, while clone-safe page-local section regions own their
-section occurrence, columns, block origin, direction, page numbering, and flow
-domains; nodes reference the owning region/domain. This permits multiple
+header/footer geometry and resolved page number, while clone-safe page-local
+section regions own their section occurrence, columns, block origin, direction,
+page-numbering policy, and flow domains; nodes reference the owning region/domain. This permits multiple
 continuous sections on one physical page and avoids treating one singular
 `LayoutPage.section` as ownership for the whole page. Replace `computePages` closure state
 with `paginateBody`. The render worker retains `Map<string, DocumentLayout>` keyed

--- a/packages/docx/src/layout/compatibility.test.ts
+++ b/packages/docx/src/layout/compatibility.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { defineCompatibilityRule } from './compatibility.js';
+import {
+  defineCompatibilityRule,
+  WORD_SECTION_BTLR_TBRL_PAGE_FRAME,
+} from './compatibility.js';
 
 describe('defineCompatibilityRule', () => {
   it('retains explicit Microsoft evidence as immutable data', () => {
@@ -26,5 +29,23 @@ describe('defineCompatibilityRule', () => {
       },
       description: 'Unreproducible observation',
     })).toThrow(/syntheticFixtureId/);
+  });
+
+  it('records the approved Word section btLr page-frame difference', () => {
+    expect(WORD_SECTION_BTLR_TBRL_PAGE_FRAME).toEqual({
+      id: 'word-section-btlr-tbrl-page-frame',
+      evidence: {
+        kind: 'office-observation',
+        syntheticFixtureId: 'issue-988-batch-3-section-btlr',
+        application: 'Microsoft Word',
+        version: 'not recorded',
+        platform: 'not recorded',
+      },
+      description: expect.stringMatching(
+        /Issue #988 comment 4950296007.*normative.*lr.*page frame.*glyph orientation.*paint-owned/i,
+      ),
+    });
+    expect(Object.isFrozen(WORD_SECTION_BTLR_TBRL_PAGE_FRAME)).toBe(true);
+    expect(Object.isFrozen(WORD_SECTION_BTLR_TBRL_PAGE_FRAME.evidence)).toBe(true);
   });
 });

--- a/packages/docx/src/layout/compatibility.ts
+++ b/packages/docx/src/layout/compatibility.ts
@@ -18,3 +18,15 @@ export function defineCompatibilityRule(rule: CompatibilityRule): DeepReadonly<C
   Object.freeze(rule.evidence);
   return Object.freeze(rule);
 }
+
+export const WORD_SECTION_BTLR_TBRL_PAGE_FRAME = defineCompatibilityRule({
+  id: 'word-section-btlr-tbrl-page-frame',
+  evidence: {
+    kind: 'office-observation',
+    syntheticFixtureId: 'issue-988-batch-3-section-btlr',
+    application: 'Microsoft Word',
+    version: 'not recorded',
+    platform: 'not recorded',
+  },
+  description: 'Issue #988 comment 4950296007 records that, unlike the normative ECMA-376 Part 4 §14.11.7 equivalence to lr, Word uses the tbRl page frame for section-level btLr; this rule covers only the page frame, while glyph orientation is paint-owned.',
+});

--- a/packages/docx/src/layout/coordinate-space.test.ts
+++ b/packages/docx/src/layout/coordinate-space.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSectionRegionCoordinateSpace,
+  logicalPageExtent,
+  logicalToPhysicalMatrix,
+  physicalToLogicalMatrix,
+  uprightPhysicalExtent,
+  writingModeFromTextDirection,
+  transformPoint,
+  transformRect,
+} from './coordinate-space.js';
+import type { LayoutRect, PointPt, WritingMode } from './types.js';
+
+const page = { widthPt: 612, heightPt: 792 };
+const point: PointPt = { xPt: 80, yPt: 120 };
+const rect: LayoutRect = { xPt: 80, yPt: 120, widthPt: 140, heightPt: 60 };
+
+describe('coordinate-space', () => {
+  it.each<readonly [WritingMode, PointPt, LayoutRect]>([
+    ['horizontal-tb', { xPt: 80, yPt: 120 }, rect],
+    ['vertical-rl', { xPt: 492, yPt: 80 }, { xPt: 432, yPt: 80, widthPt: 60, heightPt: 140 }],
+    ['vertical-lr', { xPt: 120, yPt: 80 }, { xPt: 120, yPt: 80, widthPt: 60, heightPt: 140 }],
+  ])('maps %s logical points and rectangles to upright physical space', (mode, expectedPoint, expectedRect) => {
+    const matrix = logicalToPhysicalMatrix(mode, page);
+
+    expect(transformPoint(matrix, point)).toEqual(expectedPoint);
+    expect(transformRect(matrix, rect)).toEqual(expectedRect);
+  });
+
+  it.each<WritingMode>(['horizontal-tb', 'vertical-rl', 'vertical-lr'])
+    ('uses an exact closed-form inverse for %s points and rectangles', (mode) => {
+      const forward = logicalToPhysicalMatrix(mode, page);
+      const inverse = physicalToLogicalMatrix(mode, page);
+
+      expect(transformPoint(inverse, transformPoint(forward, point))).toEqual(point);
+      expect(transformRect(inverse, transformRect(forward, rect))).toEqual(rect);
+      expect(createSectionRegionCoordinateSpace(mode, page)).toEqual({
+        writingMode: mode,
+        logicalToPhysical: forward,
+        physicalToLogical: inverse,
+      });
+    });
+
+  it('derives vertical-rl translation from each physical page width', () => {
+    expect(logicalToPhysicalMatrix('vertical-rl', { widthPt: 500, heightPt: 700 }).e).toBe(500);
+    expect(logicalToPhysicalMatrix('vertical-rl', { widthPt: 840, heightPt: 600 }).e).toBe(840);
+  });
+
+  it.each([
+    ['tb', 'horizontal-tb'],
+    ['tbV', 'horizontal-tb'],
+    ['lrTb', 'horizontal-tb'],
+    ['lrTbV', 'horizontal-tb'],
+    ['rl', 'vertical-rl'],
+    ['rlV', 'vertical-rl'],
+    ['tbRl', 'vertical-rl'],
+    ['tbRlV', 'vertical-rl'],
+    ['lr', 'vertical-lr'],
+    ['lrV', 'vertical-lr'],
+    ['tbLrV', 'vertical-lr'],
+    ['btLr', 'vertical-rl'],
+  ] as const)('maps Transitional text direction %s to %s', (token, expected) => {
+    expect(writingModeFromTextDirection(token)).toBe(expected);
+  });
+
+  it.each(['', 'unknown'])('rejects unsupported text direction %j', (token) => {
+    expect(() => writingModeFromTextDirection(token)).toThrow(RangeError);
+  });
+
+  it('derives logical and upright extents without conflating vertical axes', () => {
+    expect(logicalPageExtent(page, 'horizontal-tb')).toEqual(page);
+    expect(logicalPageExtent(page, 'vertical-rl')).toEqual({ widthPt: 792, heightPt: 612 });
+    expect(logicalPageExtent(page, 'vertical-lr')).toEqual({ widthPt: 792, heightPt: 612 });
+    expect(uprightPhysicalExtent({ widthPt: 792, heightPt: 612 }, 'vertical-rl'))
+      .toEqual(page);
+    expect(uprightPhysicalExtent(page, 'horizontal-tb')).toEqual(page);
+  });
+
+  it.each([
+    { widthPt: 0, heightPt: 792 },
+    { widthPt: -1, heightPt: 792 },
+    { widthPt: Number.NaN, heightPt: 792 },
+    { widthPt: 612, heightPt: Number.POSITIVE_INFINITY },
+  ])('rejects invalid physical page extent $widthPt x $heightPt', (invalidPage) => {
+    expect(() => logicalToPhysicalMatrix('horizontal-tb', invalidPage)).toThrow(RangeError);
+    expect(() => physicalToLogicalMatrix('vertical-rl', invalidPage)).toThrow(RangeError);
+  });
+
+  it('rejects non-finite points and invalid rectangles', () => {
+    const identity = logicalToPhysicalMatrix('horizontal-tb', page);
+
+    expect(() => transformPoint(identity, { xPt: Number.NaN, yPt: 0 })).toThrow(RangeError);
+    expect(() => transformRect(identity, { ...rect, widthPt: -1 })).toThrow(RangeError);
+    expect(() => transformRect(identity, { ...rect, heightPt: Number.POSITIVE_INFINITY }))
+      .toThrow(RangeError);
+  });
+
+  it.each(['a', 'b', 'c', 'd', 'e', 'f'] as const)
+    ('rejects a non-finite %s matrix coefficient', (coefficient) => {
+      const matrix = {
+        a: 1, b: 0, c: 0, d: 1, e: 0, f: 0,
+        [coefficient]: Number.NaN,
+      };
+
+      expect(() => transformPoint(matrix, point)).toThrow(RangeError);
+      expect(() => transformRect(matrix, rect)).toThrow(RangeError);
+    });
+});

--- a/packages/docx/src/layout/coordinate-space.ts
+++ b/packages/docx/src/layout/coordinate-space.ts
@@ -1,0 +1,178 @@
+import type {
+  LayoutRect,
+  Matrix2DData,
+  PointPt,
+  SectionRegionCoordinateSpace,
+  WritingMode,
+} from './types.js';
+
+export type PhysicalPageExtent = Readonly<{
+  widthPt: number;
+  heightPt: number;
+}>;
+
+export function writingModeFromTextDirection(textDirection: string): WritingMode {
+  switch (textDirection) {
+    case 'tb':
+    case 'tbV':
+    case 'lrTb':
+    case 'lrTbV':
+      return 'horizontal-tb';
+    case 'rl':
+    case 'rlV':
+    case 'tbRl':
+    case 'tbRlV':
+      return 'vertical-rl';
+    case 'btLr':
+      // Compatibility rule `word-section-btlr-tbrl-page-frame`; glyph orientation is paint-owned.
+      return 'vertical-rl';
+    case 'lr':
+    case 'lrV':
+    case 'tbLrV':
+      return 'vertical-lr';
+    default:
+      throw new RangeError(`Unsupported Transitional text direction ${JSON.stringify(textDirection)}`);
+  }
+}
+
+function requirePage(page: PhysicalPageExtent): void {
+  if (!Number.isFinite(page.widthPt) || !Number.isFinite(page.heightPt)
+    || page.widthPt <= 0 || page.heightPt <= 0) {
+    throw new RangeError('Physical page extents must be positive and finite');
+  }
+}
+
+function requirePoint(point: PointPt): void {
+  if (!Number.isFinite(point.xPt) || !Number.isFinite(point.yPt)) {
+    throw new RangeError('Point coordinates must be finite');
+  }
+}
+
+function requireMatrix(matrix: Matrix2DData): void {
+  if (![matrix.a, matrix.b, matrix.c, matrix.d, matrix.e, matrix.f].every(Number.isFinite)) {
+    throw new RangeError('Matrix coefficients must be finite');
+  }
+}
+
+function requireRect(rect: LayoutRect): void {
+  requirePoint(rect);
+  if (!Number.isFinite(rect.widthPt) || !Number.isFinite(rect.heightPt)
+    || rect.widthPt < 0 || rect.heightPt < 0) {
+    throw new RangeError('Rectangle extents must be finite and non-negative');
+  }
+}
+
+export function logicalPageExtent(
+  physicalPage: PhysicalPageExtent,
+  writingMode: WritingMode,
+): PhysicalPageExtent {
+  requirePage(physicalPage);
+  switch (writingMode) {
+    case 'horizontal-tb':
+      return { widthPt: physicalPage.widthPt, heightPt: physicalPage.heightPt };
+    case 'vertical-rl':
+    case 'vertical-lr':
+      return { widthPt: physicalPage.heightPt, heightPt: physicalPage.widthPt };
+    default:
+      throw new RangeError(`Unsupported writing mode ${String(writingMode)}`);
+  }
+}
+
+export function uprightPhysicalExtent(
+  logicalSectionExtent: PhysicalPageExtent,
+  writingMode: WritingMode,
+): PhysicalPageExtent {
+  requirePage(logicalSectionExtent);
+  switch (writingMode) {
+    case 'horizontal-tb':
+      return {
+        widthPt: logicalSectionExtent.widthPt,
+        heightPt: logicalSectionExtent.heightPt,
+      };
+    case 'vertical-rl':
+    case 'vertical-lr':
+      return {
+        widthPt: logicalSectionExtent.heightPt,
+        heightPt: logicalSectionExtent.widthPt,
+      };
+    default:
+      throw new RangeError(`Unsupported writing mode ${String(writingMode)}`);
+  }
+}
+
+export function logicalToPhysicalMatrix(
+  writingMode: WritingMode,
+  page: PhysicalPageExtent,
+): Matrix2DData {
+  requirePage(page);
+  switch (writingMode) {
+    case 'horizontal-tb':
+      return { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
+    case 'vertical-rl':
+      return { a: 0, b: 1, c: -1, d: 0, e: page.widthPt, f: 0 };
+    case 'vertical-lr':
+      return { a: 0, b: 1, c: 1, d: 0, e: 0, f: 0 };
+    default:
+      throw new RangeError(`Unsupported writing mode ${String(writingMode)}`);
+  }
+}
+
+export function physicalToLogicalMatrix(
+  writingMode: WritingMode,
+  page: PhysicalPageExtent,
+): Matrix2DData {
+  requirePage(page);
+  switch (writingMode) {
+    case 'horizontal-tb':
+      return { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
+    case 'vertical-rl':
+      return { a: 0, b: -1, c: 1, d: 0, e: 0, f: page.widthPt };
+    case 'vertical-lr':
+      return { a: 0, b: 1, c: 1, d: 0, e: 0, f: 0 };
+    default:
+      throw new RangeError(`Unsupported writing mode ${String(writingMode)}`);
+  }
+}
+
+export function transformPoint(matrix: Matrix2DData, point: PointPt): PointPt {
+  requireMatrix(matrix);
+  requirePoint(point);
+  return {
+    xPt: matrix.a * point.xPt + matrix.c * point.yPt + matrix.e,
+    yPt: matrix.b * point.xPt + matrix.d * point.yPt + matrix.f,
+  };
+}
+
+export function transformRect(matrix: Matrix2DData, rect: LayoutRect): LayoutRect {
+  requireRect(rect);
+  const corners = [
+    transformPoint(matrix, rect),
+    transformPoint(matrix, { xPt: rect.xPt + rect.widthPt, yPt: rect.yPt }),
+    transformPoint(matrix, { xPt: rect.xPt, yPt: rect.yPt + rect.heightPt }),
+    transformPoint(matrix, {
+      xPt: rect.xPt + rect.widthPt,
+      yPt: rect.yPt + rect.heightPt,
+    }),
+  ];
+  const xs = corners.map(({ xPt }) => xPt);
+  const ys = corners.map(({ yPt }) => yPt);
+  const xPt = Math.min(...xs);
+  const yPt = Math.min(...ys);
+  return {
+    xPt,
+    yPt,
+    widthPt: Math.max(...xs) - xPt,
+    heightPt: Math.max(...ys) - yPt,
+  };
+}
+
+export function createSectionRegionCoordinateSpace(
+  writingMode: WritingMode,
+  page: PhysicalPageExtent,
+): SectionRegionCoordinateSpace {
+  return {
+    writingMode,
+    logicalToPhysical: logicalToPhysicalMatrix(writingMode, page),
+    physicalToLogical: physicalToLogicalMatrix(writingMode, page),
+  };
+}

--- a/packages/docx/src/layout/drawing-command-invariants.test.ts
+++ b/packages/docx/src/layout/drawing-command-invariants.test.ts
@@ -24,7 +24,8 @@ function layoutWith(command: DrawingLayout['commands'][number]): DocumentLayout 
       },
       flowDomains: [{
         id: 'body', kind: 'body',
-        bounds: { xPt: 72, yPt: 72, widthPt: 468, heightPt: 648 },
+        logicalBounds: { xPt: 72, yPt: 72, widthPt: 468, heightPt: 648 },
+        physicalBounds: { xPt: 72, yPt: 72, widthPt: 468, heightPt: 648 },
       }],
       section: {} as DocumentLayout['pages'][number]['section'],
       layers: {

--- a/packages/docx/src/layout/error-page.ts
+++ b/packages/docx/src/layout/error-page.ts
@@ -185,7 +185,9 @@ export function layoutParseErrorPage(
         contentTopPt: padPt,
         contentBottomPt: size.heightPt - padPt,
       },
-      flowDomains: [{ id: 'parse-error', kind: 'body', bounds: frame }],
+      flowDomains: [{
+        id: 'parse-error', kind: 'body', logicalBounds: frame, physicalBounds: frame,
+      }],
       section,
       layers: {
         paintOrder: [{ layer: 'body', nodeId: node.id }],

--- a/packages/docx/src/layout/flow-container-types.test.ts
+++ b/packages/docx/src/layout/flow-container-types.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { layoutFlowBlocks } from './flow.js';
+import type {
+  BlockLayoutAlgorithms,
+  FlowContainer,
+  FlowDomain,
+  LayoutServices,
+} from './types.js';
+
+describe('flow ownership types', () => {
+  it('keeps acquisition bounds separate from retained dual-space domains', () => {
+    expectTypeOf<FlowContainer>().toHaveProperty('bounds');
+    expectTypeOf<FlowDomain>().toHaveProperty('logicalBounds');
+    expectTypeOf<FlowDomain>().toHaveProperty('physicalBounds');
+    // @ts-expect-error retained page domains intentionally have no ambiguous bounds alias
+    const ambiguous = ({} as FlowDomain).bounds;
+    expect(ambiguous).toBeUndefined();
+  });
+
+  it('continues to acquire flow in container-local logical bounds', () => {
+    const algorithms: BlockLayoutAlgorithms = {
+      layoutParagraph(input, placement) {
+        const bounds = { xPt: 10, yPt: 20, widthPt: 40, heightPt: 10 };
+        return {
+          layout: {
+            kind: 'paragraph', id: 'paragraph', source: input.source,
+            flowDomainId: placement.container.id, flowBounds: bounds, inkBounds: bounds,
+            advancePt: 10, ordinaryFlow: true, spacing: { beforePt: 0, afterPt: 0 },
+            contextualSpacing: false, lines: [], borders: [], resources: [], drawings: [],
+            textBoxes: [], events: [], exclusions: [],
+          },
+          nextCursor: { xPt: 10, yPt: 30 },
+        };
+      },
+      layoutTable() { throw new Error('not used'); },
+    };
+    const services = {} as LayoutServices;
+
+    const result = layoutFlowBlocks({
+      source: { story: 'body', storyInstance: 'body', path: [0] },
+      container: {
+        id: 'column-local', kind: 'body',
+        bounds: { xPt: 10, yPt: 20, widthPt: 100, heightPt: 200 },
+      },
+      cursor: { xPt: 10, yPt: 20 },
+      blocks: [{ kind: 'paragraph', source: { story: 'body', storyInstance: 'body', path: [1] } }],
+    }, services, algorithms);
+
+    expect(result.flowBounds).toEqual({ xPt: 10, yPt: 20, widthPt: 40, heightPt: 10 });
+  });
+});

--- a/packages/docx/src/layout/invariants.test.ts
+++ b/packages/docx/src/layout/invariants.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { layoutFlowBlocks } from './flow.js';
 import { assertDocumentLayout, layoutFingerprint } from './invariants.js';
+import { LayoutInvariantError } from './diagnostics.js';
 import type {
   BlockLayoutAlgorithms,
   DocumentLayout,
@@ -64,8 +65,130 @@ function drawing(
 const bodyDomain: FlowDomain = {
   id: 'body',
   kind: 'body',
-  bounds: rect(72, 72, 468, 648),
+  logicalBounds: rect(72, 72, 468, 648),
+  physicalBounds: rect(72, 72, 468, 648),
 };
+
+const horizontalSection: SectionLayoutContext = {
+  geometry: {
+    pageWidth: 612, pageHeight: 792,
+    marginTop: 72, marginRight: 72, marginBottom: 72, marginLeft: 72,
+    headerDistance: 36, footerDistance: 36,
+  },
+  columns: [{ xPt: 72, wPt: 468 }],
+  grid: { kind: 'none', linePitchPt: null, charSpacePt: null },
+  textDirection: 'lrTb',
+  verticalAlignment: 'top',
+};
+
+const verticalSection: SectionLayoutContext = {
+  ...horizontalSection,
+  geometry: { ...horizontalSection.geometry, pageWidth: 792, pageHeight: 612 },
+  columns: [{ xPt: 72, wPt: 648 }],
+  textDirection: 'tbRl',
+};
+
+function regionLayout(): DocumentLayout {
+  const base = documentWith([]);
+  return {
+    ...base,
+    pages: [{
+      ...base.pages[0]!,
+      section: horizontalSection,
+      sectionOccurrenceId: 'section:body',
+      flowDomains: [{
+        id: 'body', kind: 'body',
+        logicalBounds: rect(72, 72, 468, 648),
+        physicalBounds: rect(72, 72, 468, 648),
+      }],
+      sectionRegions: [{
+        id: 'region:body', sectionOccurrenceId: 'section:body',
+        coordinateSpace: {
+          writingMode: 'horizontal-tb',
+          logicalToPhysical: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+          physicalToLogical: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+        },
+        blockStartPt: 72, blockEndPt: 720,
+        flowDomainIds: ['body'], section: horizontalSection,
+      }],
+    }],
+  };
+}
+
+function twoRegionLayout(
+  secondSectionOccurrenceId: string,
+  secondWritingMode: 'horizontal-tb' | 'vertical-rl' = 'horizontal-tb',
+): DocumentLayout {
+  const base = regionLayout();
+  const firstDomain = {
+    ...base.pages[0]!.flowDomains[0]!,
+    logicalBounds: rect(72, 72, 468, 228),
+    physicalBounds: rect(72, 72, 468, 228),
+  };
+  const secondIsVertical = secondWritingMode === 'vertical-rl';
+  const secondSection = secondIsVertical ? verticalSection : horizontalSection;
+  const secondDomain: FlowDomain = secondIsVertical
+    ? {
+        id: 'body:second', kind: 'body',
+        logicalBounds: rect(72, 300, 648, 240),
+        physicalBounds: rect(72, 72, 240, 648),
+      }
+    : {
+        id: 'body:second', kind: 'body',
+        logicalBounds: rect(72, 300, 468, 420),
+        physicalBounds: rect(72, 300, 468, 420),
+      };
+  return {
+    ...base,
+    pages: [{
+      ...base.pages[0]!,
+      flowDomains: [firstDomain, secondDomain],
+      sectionRegions: [
+        {
+          ...base.pages[0]!.sectionRegions![0]!,
+          blockEndPt: 300,
+          flowDomainIds: [firstDomain.id],
+        },
+        {
+          id: 'region:second',
+          sectionOccurrenceId: secondSectionOccurrenceId,
+          coordinateSpace: secondIsVertical
+            ? {
+                writingMode: 'vertical-rl',
+                logicalToPhysical: { a: 0, b: 1, c: -1, d: 0, e: 612, f: 0 },
+                physicalToLogical: { a: 0, b: -1, c: 1, d: 0, e: 0, f: 612 },
+              }
+            : {
+                writingMode: 'horizontal-tb',
+                logicalToPhysical: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+                physicalToLogical: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+              },
+          blockStartPt: 300,
+          blockEndPt: secondIsVertical ? 540 : 720,
+          flowDomainIds: [secondDomain.id],
+          section: secondSection,
+        },
+      ],
+    }],
+  };
+}
+
+function expectInvariantCode(
+  code: LayoutInvariantError['code'],
+  run: () => void,
+): void {
+  try {
+    run();
+    throw new Error(`expected ${code}`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(LayoutInvariantError);
+    expect((error as LayoutInvariantError).code).toBe(code);
+  }
+}
+
+function expectInvalidGeometry(run: () => void): void {
+  expectInvariantCode('INVALID_GEOMETRY', run);
+}
 
 function serviceStubs(): LayoutServices {
   return {
@@ -164,7 +287,10 @@ describe('assertDocumentLayout', () => {
         ...base.pages[0]!,
         flowDomains: [
           bodyDomain,
-          { id: 'footer:default', kind: 'footer', bounds: rect(72, 730, 468, 40) },
+          {
+            id: 'footer:default', kind: 'footer',
+            logicalBounds: rect(72, 730, 468, 40), physicalBounds: rect(72, 730, 468, 40),
+          },
         ],
         layers: {
           ...base.pages[0]!.layers,
@@ -191,8 +317,14 @@ describe('assertDocumentLayout', () => {
       pages: [{
         ...base.pages[0]!,
         flowDomains: [
-          { id: 'cell:1', kind: 'tableCell', bounds: rect(90, 90, 100, 40) },
-          { id: 'cell:2', kind: 'tableCell', bounds: rect(90, 90, 100, 40) },
+          {
+            id: 'cell:1', kind: 'tableCell',
+            logicalBounds: rect(90, 90, 100, 40), physicalBounds: rect(90, 90, 100, 40),
+          },
+          {
+            id: 'cell:2', kind: 'tableCell',
+            logicalBounds: rect(90, 90, 100, 40), physicalBounds: rect(90, 90, 100, 40),
+          },
         ],
       }],
     };
@@ -289,22 +421,359 @@ describe('assertDocumentLayout', () => {
 
   it('requires every body flow domain to belong to exactly one page-local section region', () => {
     const base = documentWith([drawing('n1', rect(72, 100, 200, 30))]);
+    const noColumnSection = { ...horizontalSection, columns: [] };
     const layout = {
       ...base,
       pages: [{
         ...base.pages[0]!,
+        section: noColumnSection,
         sectionRegions: [{
           id: 'section-region:0',
           sectionOccurrenceId: 'section:0',
+          coordinateSpace: {
+            writingMode: 'horizontal-tb',
+            logicalToPhysical: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+            physicalToLogical: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+          },
           blockStartPt: 72,
           blockEndPt: 720,
           flowDomainIds: [],
-          section: base.pages[0]!.section,
+          section: noColumnSection,
         }],
       }],
     } as DocumentLayout;
 
     expect(() => assertDocumentLayout(layout)).toThrow(/section region ownership/);
+  });
+
+  it('accepts logical vertical flow even when its upright physical rectangle has exchanged axes', () => {
+    const node = drawing('vertical', rect(72, 100, 648, 40), { flowDomainId: 'vertical-body' });
+    const base = documentWith([node]);
+    const strictVerticalSection = { ...verticalSection, textDirection: 'rlV' };
+    const layout: DocumentLayout = {
+      ...base,
+      pages: [{
+        ...base.pages[0]!,
+        section: strictVerticalSection,
+        sectionOccurrenceId: 'section:vertical',
+        flowDomains: [{
+          id: 'vertical-body', kind: 'body',
+          logicalBounds: rect(72, 72, 648, 468),
+          physicalBounds: rect(72, 72, 468, 648),
+        }],
+        sectionRegions: [{
+          id: 'region:vertical', sectionOccurrenceId: 'section:vertical',
+          coordinateSpace: {
+            writingMode: 'vertical-rl',
+            logicalToPhysical: { a: 0, b: 1, c: -1, d: 0, e: 612, f: 0 },
+            physicalToLogical: { a: 0, b: -1, c: 1, d: 0, e: 0, f: 612 },
+          },
+          blockStartPt: 72, blockEndPt: 540,
+          flowDomainIds: ['vertical-body'], section: strictVerticalSection,
+        }],
+      }],
+    };
+
+    expect(() => assertDocumentLayout(layout)).not.toThrow();
+  });
+
+  it('rejects genuine logical vertical block overflow regardless of physical page containment', () => {
+    const node = drawing('vertical-overflow', rect(72, 530, 100, 20), {
+      flowDomainId: 'vertical-body',
+    });
+    const base = documentWith([node]);
+    const layout: DocumentLayout = {
+      ...base,
+      pages: [{
+        ...base.pages[0]!, section: verticalSection, sectionOccurrenceId: 'section:vertical',
+        flowDomains: [{
+          id: 'vertical-body', kind: 'body',
+          logicalBounds: rect(72, 72, 648, 468), physicalBounds: rect(72, 72, 468, 648),
+        }],
+        sectionRegions: [{
+          id: 'region:vertical', sectionOccurrenceId: 'section:vertical',
+          coordinateSpace: {
+            writingMode: 'vertical-rl',
+            logicalToPhysical: { a: 0, b: 1, c: -1, d: 0, e: 612, f: 0 },
+            physicalToLogical: { a: 0, b: -1, c: 1, d: 0, e: 0, f: 612 },
+          },
+          blockStartPt: 72, blockEndPt: 540,
+          flowDomainIds: ['vertical-body'], section: verticalSection,
+        }],
+      }],
+    };
+
+    expect(() => assertDocumentLayout(layout))
+      .toThrow(/BOTTOM_MARGIN_INVASION|FLOW_DOMAIN_INVASION/);
+  });
+
+  it('rejects a retained physical domain that is not derived from its region transform', () => {
+    const base = documentWith([]);
+    const layout: DocumentLayout = {
+      ...base,
+      pages: [{
+        ...base.pages[0]!, section: verticalSection, sectionOccurrenceId: 'section:vertical',
+        flowDomains: [{
+          id: 'vertical-body', kind: 'body',
+          logicalBounds: rect(72, 72, 648, 468), physicalBounds: rect(0, 0, 1, 1),
+        }],
+        sectionRegions: [{
+          id: 'region:vertical', sectionOccurrenceId: 'section:vertical',
+          coordinateSpace: {
+            writingMode: 'vertical-rl',
+            logicalToPhysical: { a: 0, b: 1, c: -1, d: 0, e: 612, f: 0 },
+            physicalToLogical: { a: 0, b: -1, c: 1, d: 0, e: 0, f: 612 },
+          },
+          blockStartPt: 72, blockEndPt: 540,
+          flowDomainIds: ['vertical-body'], section: verticalSection,
+        }],
+      }],
+    };
+
+    expect(() => assertDocumentLayout(layout)).toThrow(/INVALID_GEOMETRY/);
+  });
+
+  it('requires equal dual-space bounds on transitional pages without regions', () => {
+    const base = documentWith([]);
+    const unequal: DocumentLayout = {
+      ...base,
+      pages: [{
+        ...base.pages[0]!,
+        flowDomains: [{
+          ...bodyDomain,
+          physicalBounds: rect(0, 0, 468, 648),
+        }],
+      }],
+    };
+
+    expect(() => assertDocumentLayout(unequal)).toThrow(/INVALID_GEOMETRY/);
+    expect(() => assertDocumentLayout(base)).not.toThrow();
+  });
+
+  it('requires page-start ownership and the exact supported retained transform', () => {
+    const base = documentWith([]);
+    const region = {
+      id: 'region:body', sectionOccurrenceId: 'section:first',
+      coordinateSpace: {
+        writingMode: 'horizontal-tb' as const,
+        logicalToPhysical: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+        physicalToLogical: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+      },
+      blockStartPt: 72, blockEndPt: 720,
+      flowDomainIds: ['body'], section: horizontalSection,
+    };
+    const page = {
+      ...base.pages[0]!, section: horizontalSection,
+      sectionOccurrenceId: 'section:first', sectionRegions: [region],
+    };
+
+    expect(() => assertDocumentLayout({ ...base, pages: [page] })).not.toThrow();
+    expect(() => assertDocumentLayout({
+      ...base, pages: [{ ...page, sectionOccurrenceId: 'section:other' }],
+    })).toThrow(/page-start section occurrence/);
+    expect(() => assertDocumentLayout({
+      ...base,
+      pages: [{
+        ...page,
+        sectionRegions: [{
+          ...region,
+          coordinateSpace: {
+            ...region.coordinateSpace,
+            logicalToPhysical: { ...region.coordinateSpace.logicalToPhysical, e: 1 },
+          },
+        }],
+      }],
+    })).toThrow(/invalid coordinate transform/);
+  });
+
+  it('rejects clone data whose region direction or columns contradict its section', () => {
+    const valid = regionLayout();
+    expect(() => assertDocumentLayout(valid)).not.toThrow();
+    expectInvalidGeometry(() => assertDocumentLayout({
+      ...valid,
+      pages: [{
+        ...valid.pages[0]!,
+        sectionRegions: [{
+          ...valid.pages[0]!.sectionRegions![0]!,
+          coordinateSpace: {
+            ...valid.pages[0]!.sectionRegions![0]!.coordinateSpace,
+            writingMode: 'vertical-rl',
+          },
+        }],
+      }],
+    }));
+    expectInvalidGeometry(() => assertDocumentLayout({
+      ...valid,
+      pages: [{
+        ...valid.pages[0]!,
+        sectionRegions: [{
+          ...valid.pages[0]!.sectionRegions![0]!,
+          section: { ...horizontalSection, columns: [{ xPt: 73, wPt: 468 }] },
+        }],
+      }],
+    }));
+  });
+
+  it('rejects duplicate section occurrence identities in cloned page regions', () => {
+    expectInvariantCode(
+      'INVALID_REFERENCE',
+      () => assertDocumentLayout(twoRegionLayout('section:body')),
+    );
+  });
+
+  it('rejects cloned page regions that mix logical coordinate systems', () => {
+    expectInvalidGeometry(() => assertDocumentLayout(
+      twoRegionLayout('section:second', 'vertical-rl'),
+    ));
+  });
+
+  it('rejects page-start section facts that contradict the first region clone', () => {
+    const valid = regionLayout();
+    const mismatches: SectionLayoutContext[] = [
+      { ...horizontalSection, geometry: { ...horizontalSection.geometry, marginLeft: 73 } },
+      { ...horizontalSection, columns: [{ xPt: 73, wPt: 468 }] },
+      { ...horizontalSection, textDirection: 'lrTbV' },
+      { ...horizontalSection, grid: { ...horizontalSection.grid, kind: 'lines' } },
+      { ...horizontalSection, verticalAlignment: 'center' },
+      {
+        ...horizontalSection,
+        lineNumbering: { start: 1, countBy: 1, restart: 'newPage' },
+      },
+    ];
+    for (const section of mismatches) {
+      expectInvalidGeometry(() => assertDocumentLayout({
+        ...valid, pages: [{ ...valid.pages[0]!, section }],
+      }));
+    }
+  });
+
+  it('rejects invalid region intervals and owned logical domain geometry', () => {
+    const valid = regionLayout();
+    const region = valid.pages[0]!.sectionRegions![0]!;
+    const domain = valid.pages[0]!.flowDomains[0]!;
+    const invalidRegions = [
+      { ...region, blockStartPt: -1 },
+      { ...region, blockEndPt: 793 },
+      { ...region, blockEndPt: region.blockStartPt },
+    ];
+    for (const invalidRegion of invalidRegions) {
+      expectInvalidGeometry(() => assertDocumentLayout({
+        ...valid,
+        pages: [{ ...valid.pages[0]!, sectionRegions: [invalidRegion] }],
+      }));
+    }
+
+    const invalidDomains = [
+      { ...domain, logicalBounds: rect(72, 71, 468, 649) },
+      { ...domain, logicalBounds: rect(72, 72, 0, 648) },
+      { ...domain, logicalBounds: rect(72, 72, 468, 0) },
+      { ...domain, logicalBounds: rect(71, 72, 469, 648) },
+      { ...domain, physicalBounds: rect(600, 72, 20, 648) },
+    ];
+    for (const invalidDomain of invalidDomains) {
+      expectInvalidGeometry(() => assertDocumentLayout({
+        ...valid,
+        pages: [{ ...valid.pages[0]!, flowDomains: [invalidDomain] }],
+      }));
+    }
+  });
+
+  it('rejects overlapping and out-of-page inline domains', () => {
+    const valid = regionLayout();
+    const region = valid.pages[0]!.sectionRegions![0]!;
+    const domains: FlowDomain[] = [
+      {
+        id: 'body:first', kind: 'body',
+        logicalBounds: rect(72, 72, 250, 648), physicalBounds: rect(72, 72, 250, 648),
+      },
+      {
+        id: 'body:second', kind: 'body',
+        logicalBounds: rect(300, 72, 240, 648), physicalBounds: rect(300, 72, 240, 648),
+      },
+    ];
+    const section = { ...horizontalSection, columns: [{ xPt: 72, wPt: 250 }, { xPt: 300, wPt: 240 }] };
+    expectInvalidGeometry(() => assertDocumentLayout({
+      ...valid,
+      pages: [{
+        ...valid.pages[0]!, section,
+        flowDomains: domains,
+        sectionRegions: [{ ...region, section, flowDomainIds: domains.map(({ id }) => id) }],
+      }],
+    }));
+
+    const outsideSection = {
+      ...horizontalSection,
+      columns: [{ xPt: 500, wPt: 200 }],
+    };
+    const outsideDomain: FlowDomain = {
+      id: 'body:outside', kind: 'body',
+      logicalBounds: rect(500, 72, 200, 648),
+      physicalBounds: rect(500, 72, 200, 648),
+    };
+    expectInvalidGeometry(() => assertDocumentLayout({
+      ...valid,
+      pages: [{
+        ...valid.pages[0]!, section: outsideSection,
+        flowDomains: [outsideDomain],
+        sectionRegions: [{
+          ...region, section: outsideSection, flowDomainIds: [outsideDomain.id],
+        }],
+      }],
+    }));
+  });
+
+  it('rejects exact derived physical bounds that leave the retained physical page box', () => {
+    const valid = regionLayout();
+    const page = valid.pages[0]!;
+    const region = page.sectionRegions![0]!;
+    const section = {
+      ...horizontalSection,
+      columns: [{ xPt: 0, wPt: 468 }],
+    };
+    const domain: FlowDomain = {
+      id: 'body:physical-overflow', kind: 'body',
+      logicalBounds: rect(0, 72, 468, 648),
+      physicalBounds: rect(0, 72, 468, 648),
+    };
+    expectInvalidGeometry(() => assertDocumentLayout({
+      ...valid,
+      pages: [{
+        ...page,
+        geometry: { ...page.geometry, xPt: 10 },
+        section,
+        flowDomains: [domain],
+        sectionRegions: [{ ...region, section, flowDomainIds: [domain.id] }],
+      }],
+    }));
+  });
+
+  it('normalizes malformed coordinate clones and invalid page extents to INVALID_GEOMETRY', () => {
+    const valid = regionLayout();
+    const region = valid.pages[0]!.sectionRegions![0]!;
+    const malformedCoordinateSpaces: unknown[] = [
+      undefined,
+      {},
+      { writingMode: 'diagonal', logicalToPhysical: {}, physicalToLogical: {} },
+      { writingMode: 'horizontal-tb', logicalToPhysical: undefined, physicalToLogical: {} },
+    ];
+    for (const coordinateSpace of malformedCoordinateSpaces) {
+      expectInvalidGeometry(() => assertDocumentLayout({
+        ...valid,
+        pages: [{
+          ...valid.pages[0]!,
+          sectionRegions: [{ ...region, coordinateSpace }],
+        }],
+      } as DocumentLayout));
+    }
+    for (const [widthPt, heightPt] of [[0, 792], [-1, 792], [612, 0]]) {
+      expectInvalidGeometry(() => assertDocumentLayout({
+        ...valid,
+        pages: [{
+          ...valid.pages[0]!,
+          geometry: { ...valid.pages[0]!.geometry, widthPt, heightPt },
+        }],
+      }));
+    }
   });
 });
 

--- a/packages/docx/src/layout/invariants.ts
+++ b/packages/docx/src/layout/invariants.ts
@@ -1,5 +1,16 @@
 import { LayoutInvariantError } from './diagnostics.js';
+import {
+  createSectionRegionCoordinateSpace,
+  logicalPageExtent,
+  transformRect,
+  uprightPhysicalExtent,
+  writingModeFromTextDirection,
+} from './coordinate-space.js';
 import { orderedPagePaintNodes, pageLayerNodes, PageGraphError } from './page-graph.js';
+import {
+  derivePageBookmarkStarts,
+  sectionLayoutContextsEqual,
+} from './page-factory.js';
 import type {
   DeepReadonly,
   DocumentLayout,
@@ -8,8 +19,11 @@ import type {
   FlowDomain,
   LayoutRect,
   LayoutPage,
+  PageSectionRegion,
   PaintNode,
   PointPt,
+  SectionRegionCoordinateSpace,
+  WritingMode,
 } from './types.js';
 
 function assertPlainData(value: unknown, path: string, ancestors = new WeakSet<object>()): void {
@@ -78,7 +92,14 @@ function requireFinite(value: number, path: string): void {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 function requirePoint(point: PointPt, path: string): void {
+  if (!isRecord(point)) {
+    throw new LayoutInvariantError('INVALID_GEOMETRY', `${path} is not a point`);
+  }
   requireFinite(point.xPt, `${path}.xPt`);
   requireFinite(point.yPt, `${path}.yPt`);
 }
@@ -90,6 +111,33 @@ function requireRect(rect: LayoutRect, path: string): void {
   if (rect.widthPt < 0 || rect.heightPt < 0) {
     throw new LayoutInvariantError('INVALID_GEOMETRY', `${path} has a negative extent`);
   }
+}
+
+function requireMatrix(matrix: unknown, path: string): asserts matrix is SectionRegionCoordinateSpace['logicalToPhysical'] {
+  if (!isRecord(matrix)) {
+    throw new LayoutInvariantError('INVALID_GEOMETRY', `${path} is not a matrix`);
+  }
+  for (const coefficient of ['a', 'b', 'c', 'd', 'e', 'f'] as const) {
+    requireFinite(matrix[coefficient] as number, `${path}.${coefficient}`);
+  }
+}
+
+function requireWritingMode(value: unknown, path: string): asserts value is WritingMode {
+  if (value !== 'horizontal-tb' && value !== 'vertical-rl' && value !== 'vertical-lr') {
+    throw new LayoutInvariantError('INVALID_GEOMETRY', `${path} is unsupported`);
+  }
+}
+
+function requireCoordinateSpace(
+  value: unknown,
+  path: string,
+): asserts value is SectionRegionCoordinateSpace {
+  if (!isRecord(value)) {
+    throw new LayoutInvariantError('INVALID_GEOMETRY', `${path} is not a coordinate space`);
+  }
+  requireWritingMode(value.writingMode, `${path}.writingMode`);
+  requireMatrix(value.logicalToPhysical, `${path}.logicalToPhysical`);
+  requireMatrix(value.physicalToLogical, `${path}.physicalToLogical`);
 }
 
 function requireDrawingMLShapePlan(
@@ -147,6 +195,21 @@ function contains(outer: LayoutRect, inner: LayoutRect): boolean {
     && inner.yPt >= outer.yPt
     && inner.xPt + inner.widthPt <= outer.xPt + outer.widthPt
     && inner.yPt + inner.heightPt <= outer.yPt + outer.heightPt;
+}
+
+function equalRect(left: LayoutRect, right: LayoutRect): boolean {
+  return left.xPt === right.xPt
+    && left.yPt === right.yPt
+    && left.widthPt === right.widthPt
+    && left.heightPt === right.heightPt;
+}
+
+function equalMatrix(
+  left: PageSectionRegion['coordinateSpace']['logicalToPhysical'],
+  right: PageSectionRegion['coordinateSpace']['logicalToPhysical'],
+): boolean {
+  return left.a === right.a && left.b === right.b && left.c === right.c
+    && left.d === right.d && left.e === right.e && left.f === right.f;
 }
 
 function retainUniqueNodeId(
@@ -240,7 +303,7 @@ function requireDrawingGeometry(node: DrawingLayout, path: string): void {
   });
 }
 
-export function assertDocumentLayout(layout: DocumentLayout): void {
+function assertDocumentLayoutUnchecked(layout: DocumentLayout): void {
   assertPlainData(layout, 'layout');
   const documentRetainedNodeIds = new Set<string>();
   layout.pages.forEach((page, pageIndex) => {
@@ -254,7 +317,9 @@ export function assertDocumentLayout(layout: DocumentLayout): void {
     requireFinite(page.geometry.contentTopPt, `pages[${pageIndex}].geometry.contentTopPt`);
     requireFinite(page.geometry.contentBottomPt, `pages[${pageIndex}].geometry.contentBottomPt`);
     if (
-      page.geometry.contentTopPt < 0
+      page.geometry.widthPt <= 0
+      || page.geometry.heightPt <= 0
+      || page.geometry.contentTopPt < 0
       || page.geometry.contentTopPt > page.geometry.contentBottomPt
       || page.geometry.contentBottomPt > page.geometry.heightPt
     ) {
@@ -266,7 +331,14 @@ export function assertDocumentLayout(layout: DocumentLayout): void {
 
     const domains = new Map<string, FlowDomain>();
     page.flowDomains.forEach((domain, domainIndex) => {
-      requireRect(domain.bounds, `pages[${pageIndex}].flowDomains[${domainIndex}].bounds`);
+      requireRect(
+        domain.logicalBounds,
+        `pages[${pageIndex}].flowDomains[${domainIndex}].logicalBounds`,
+      );
+      requireRect(
+        domain.physicalBounds,
+        `pages[${pageIndex}].flowDomains[${domainIndex}].physicalBounds`,
+      );
       if (domains.has(domain.id)) {
         throw new LayoutInvariantError('INVALID_REFERENCE', `duplicate flow domain ${domain.id}`);
       }
@@ -298,9 +370,13 @@ export function assertDocumentLayout(layout: DocumentLayout): void {
       sectionOccurrenceIds.add(page.sectionOccurrenceId);
     }
 
+    const regionByDomain = new Map<string, PageSectionRegion>();
     if (page.sectionRegions) {
       const regionIds = new Set<string>();
+      const occurrenceIds = new Set<string>();
       const bodyOwnership = new Map<string, number>();
+      let priorBlockEndPt = 0;
+      let pageWritingMode: WritingMode | undefined;
       page.sectionRegions.forEach((region, regionIndex) => {
         const path = `pages[${pageIndex}].sectionRegions[${regionIndex}]`;
         if (region.id.length === 0 || regionIds.has(region.id)) {
@@ -313,17 +389,119 @@ export function assertDocumentLayout(layout: DocumentLayout): void {
             `${path} has an empty section occurrence id`,
           );
         }
+        if (occurrenceIds.has(region.sectionOccurrenceId)) {
+          throw new LayoutInvariantError(
+            'INVALID_REFERENCE',
+            `${path} has a duplicate section occurrence id`,
+          );
+        }
+        occurrenceIds.add(region.sectionOccurrenceId);
         sectionOccurrenceIds.add(region.sectionOccurrenceId);
+        requireCoordinateSpace(region.coordinateSpace, `${path}.coordinateSpace`);
+        const writingMode = region.coordinateSpace.writingMode;
+        if (pageWritingMode !== undefined && pageWritingMode !== writingMode) {
+          throw new LayoutInvariantError(
+            'INVALID_GEOMETRY',
+            `${path} mixes coordinate systems on one physical page`,
+          );
+        }
+        pageWritingMode = writingMode;
+        let sectionWritingMode: WritingMode;
+        try {
+          sectionWritingMode = writingModeFromTextDirection(region.section.textDirection);
+        } catch (error) {
+          throw new LayoutInvariantError(
+            'INVALID_GEOMETRY',
+            `${path}.section.textDirection is unsupported: ${(error as Error).message}`,
+          );
+        }
+        if (writingMode !== sectionWritingMode) {
+          throw new LayoutInvariantError(
+            'INVALID_GEOMETRY',
+            `${path} writing mode contradicts its section text direction`,
+          );
+        }
+        const logicalExtent = logicalPageExtent(page.geometry, writingMode);
+        const physicalExtent = uprightPhysicalExtent({
+          widthPt: region.section.geometry.pageWidth,
+          heightPt: region.section.geometry.pageHeight,
+        }, writingMode);
+        if (physicalExtent.widthPt !== page.geometry.widthPt
+          || physicalExtent.heightPt !== page.geometry.heightPt) {
+          throw new LayoutInvariantError(
+            'INVALID_GEOMETRY',
+            `${path} section geometry does not match the upright physical page`,
+          );
+        }
         requireFinite(region.blockStartPt, `${path}.blockStartPt`);
         requireFinite(region.blockEndPt, `${path}.blockEndPt`);
-        if (region.blockEndPt < region.blockStartPt) {
-          throw new LayoutInvariantError('INVALID_GEOMETRY', `${path} has a negative block extent`);
+        if (region.blockStartPt < 0
+          || region.blockStartPt < priorBlockEndPt
+          || region.blockEndPt <= region.blockStartPt
+          || region.blockEndPt > logicalExtent.heightPt) {
+          throw new LayoutInvariantError('INVALID_GEOMETRY', `${path} has an invalid block interval`);
         }
-        region.flowDomainIds.forEach((domainId) => {
-          if (!domains.has(domainId)) {
+        priorBlockEndPt = region.blockEndPt;
+        const expectedCoordinateSpace = createSectionRegionCoordinateSpace(
+          region.coordinateSpace.writingMode,
+          page.geometry,
+        );
+        if (!equalMatrix(
+          region.coordinateSpace.logicalToPhysical,
+          expectedCoordinateSpace.logicalToPhysical,
+        ) || !equalMatrix(
+          region.coordinateSpace.physicalToLogical,
+          expectedCoordinateSpace.physicalToLogical,
+        )) {
+          throw new LayoutInvariantError('INVALID_GEOMETRY', `${path} has an invalid coordinate transform`);
+        }
+        if (region.flowDomainIds.length !== region.section.columns.length) {
+          throw new LayoutInvariantError('INVALID_GEOMETRY', `${path} columns contradict its section`);
+        }
+        let priorInlineEndPt = 0;
+        region.flowDomainIds.forEach((domainId, columnIndex) => {
+          const domain = domains.get(domainId);
+          if (!domain) {
             throw new LayoutInvariantError('INVALID_REFERENCE', `${path} references missing flow domain ${domainId}`);
           }
+          if (domain.kind !== 'body') {
+            throw new LayoutInvariantError('INVALID_REFERENCE', `${path} owns non-body flow domain ${domainId}`);
+          }
           bodyOwnership.set(domainId, (bodyOwnership.get(domainId) ?? 0) + 1);
+          regionByDomain.set(domainId, region);
+          const bounds = domain.logicalBounds;
+          const sectionColumn = region.section.columns[columnIndex];
+          if (bounds.widthPt <= 0 || bounds.heightPt <= 0
+            || bounds.yPt !== region.blockStartPt
+            || bounds.yPt + bounds.heightPt !== region.blockEndPt
+            || bounds.xPt < 0
+            || bounds.xPt < priorInlineEndPt
+            || bounds.xPt + bounds.widthPt > logicalExtent.widthPt
+            || sectionColumn === undefined
+            || bounds.xPt !== sectionColumn.xPt
+            || bounds.widthPt !== sectionColumn.wPt) {
+            throw new LayoutInvariantError(
+              'INVALID_GEOMETRY',
+              `${domainId} is not the section column's positive logical region`,
+            );
+          }
+          priorInlineEndPt = bounds.xPt + bounds.widthPt;
+          const expectedPhysicalBounds = transformRect(
+            region.coordinateSpace.logicalToPhysical,
+            domain.logicalBounds,
+          );
+          if (!equalRect(expectedPhysicalBounds, domain.physicalBounds)) {
+            throw new LayoutInvariantError(
+              'INVALID_GEOMETRY',
+              `${domainId} physical bounds do not match its section region transform`,
+            );
+          }
+          if (!contains(page.geometry, domain.physicalBounds)) {
+            throw new LayoutInvariantError(
+              'INVALID_GEOMETRY',
+              `${domainId} physical bounds leave the upright physical page`,
+            );
+          }
         });
       });
       page.flowDomains.filter((domain) => domain.kind === 'body').forEach((domain) => {
@@ -334,6 +512,30 @@ export function assertDocumentLayout(layout: DocumentLayout): void {
           );
         }
       });
+      if (!page.parityBlank && page.sectionRegions.length > 0
+      ) {
+        const firstRegion = page.sectionRegions[0]!;
+        if (page.sectionOccurrenceId !== firstRegion.sectionOccurrenceId) {
+          throw new LayoutInvariantError(
+            'INVALID_REFERENCE',
+            `pages[${pageIndex}] page-start section occurrence does not match its first region`,
+          );
+        }
+        if (!sectionLayoutContextsEqual(page.section, firstRegion.section)) {
+          throw new LayoutInvariantError(
+            'INVALID_GEOMETRY',
+            `pages[${pageIndex}] page-start section facts do not match its first region`,
+          );
+        }
+      }
+    }
+    for (const domain of page.flowDomains) {
+      if (!regionByDomain.has(domain.id) && !equalRect(domain.logicalBounds, domain.physicalBounds)) {
+        throw new LayoutInvariantError(
+          'INVALID_GEOMETRY',
+          `${domain.id} has unequal logical and physical bounds without a section region`,
+        );
+      }
     }
 
     if (page.pageNumber) {
@@ -380,11 +582,14 @@ export function assertDocumentLayout(layout: DocumentLayout): void {
         throw new LayoutInvariantError('INVALID_REFERENCE', `${node.id} references missing flow domain ${node.flowDomainId}`);
       }
       if (!node.ordinaryFlow) return;
-      if (domain.kind === 'body'
-        && node.flowBounds.yPt + node.flowBounds.heightPt > page.geometry.contentBottomPt) {
-        throw new LayoutInvariantError('BOTTOM_MARGIN_INVASION', `${node.id} crosses contentBottomPt`);
+      if (domain.kind === 'body') {
+        const region = regionByDomain.get(domain.id);
+        const blockEndPt = region?.blockEndPt ?? page.geometry.contentBottomPt;
+        if (node.flowBounds.yPt + node.flowBounds.heightPt > blockEndPt) {
+          throw new LayoutInvariantError('BOTTOM_MARGIN_INVASION', `${node.id} crosses logical block end`);
+        }
       }
-      if (!contains(domain.bounds, node.flowBounds)) {
+      if (!contains(domain.logicalBounds, node.flowBounds)) {
         throw new LayoutInvariantError('FLOW_DOMAIN_INVASION', `${node.id} crosses flow domain ${domain.id}`);
       }
       ordinary.push(node);
@@ -398,26 +603,36 @@ export function assertDocumentLayout(layout: DocumentLayout): void {
       read.add(nodeId);
     });
 
-    const bookmarkNames = new Set<string>();
-    page.bookmarkStarts?.forEach((bookmark) => {
-      if (
-        bookmark.name.length === 0
-        || bookmarkNames.has(bookmark.name)
-        || !retainedNodeIds.has(bookmark.nodeId)
-      ) {
+    if (page.bookmarkStarts !== undefined) {
+      const sectionByDomain = new Map(
+        [...regionByDomain].map(([domainId, region]) => [
+          domainId,
+          region.sectionOccurrenceId,
+        ]),
+      );
+      const expectedBookmarkStarts = derivePageBookmarkStarts(
+        orderedPagePaintNodes(page),
+        page.sectionOccurrenceId ?? '',
+        sectionByDomain,
+      );
+      const bookmarkOwnersAreValid = expectedBookmarkStarts.every((bookmark) =>
+        bookmark.sectionOccurrenceId.length > 0
+        && sectionOccurrenceIds.has(bookmark.sectionOccurrenceId));
+      const bookmarkMetadataMatches = page.bookmarkStarts.length === expectedBookmarkStarts.length
+        && page.bookmarkStarts.every((bookmark, index) => {
+          const expected = expectedBookmarkStarts[index];
+          return expected !== undefined
+            && bookmark.name === expected.name
+            && bookmark.nodeId === expected.nodeId
+            && bookmark.sectionOccurrenceId === expected.sectionOccurrenceId;
+        });
+      if (!bookmarkOwnersAreValid || !bookmarkMetadataMatches) {
         throw new LayoutInvariantError(
           'INVALID_REFERENCE',
-          `invalid bookmark node ${bookmark.nodeId}`,
+          `pages[${pageIndex}] bookmark metadata does not match its retained graph (invalid bookmark node or ownership)`,
         );
       }
-      if (!sectionOccurrenceIds.has(bookmark.sectionOccurrenceId)) {
-        throw new LayoutInvariantError(
-          'INVALID_REFERENCE',
-          `bookmark ${bookmark.name} has an invalid section owner`,
-        );
-      }
-      bookmarkNames.add(bookmark.name);
-    });
+    }
 
     for (let index = 0; index < ordinary.length; index += 1) {
       for (let other = index + 1; other < ordinary.length; other += 1) {
@@ -431,6 +646,18 @@ export function assertDocumentLayout(layout: DocumentLayout): void {
       }
     }
   });
+}
+
+export function assertDocumentLayout(layout: DocumentLayout): void {
+  try {
+    assertDocumentLayoutUnchecked(layout);
+  } catch (error) {
+    if (error instanceof LayoutInvariantError) throw error;
+    if (error instanceof TypeError || error instanceof RangeError) {
+      throw new LayoutInvariantError('INVALID_GEOMETRY', error.message);
+    }
+    throw error;
+  }
 }
 
 function canonicalize(value: unknown): unknown {

--- a/packages/docx/src/layout/occurrence-projection.test.ts
+++ b/packages/docx/src/layout/occurrence-projection.test.ts
@@ -52,7 +52,7 @@ function table(id = 'table'): TableLayout {
 const options = {
   occurrenceId: 'page 2/header',
   destination: {
-    coordinateSpace: 'logical-body-points' as const,
+    coordinateSpace: 'logical-page-points' as const,
     flowDomainId: 'body/page-2', translation: { xPt: 20, yPt: 30 },
   },
 };

--- a/packages/docx/src/layout/occurrence-projection.ts
+++ b/packages/docx/src/layout/occurrence-projection.ts
@@ -16,10 +16,11 @@ import type {
   TableLayout,
   TableRowLayout,
   TextBoxLayout,
+  LayoutCoordinateSpace,
 } from './types.js';
 
 export interface BodyOccurrenceDestination {
-  readonly coordinateSpace: 'logical-body-points';
+  readonly coordinateSpace: Extract<LayoutCoordinateSpace, 'logical-page-points'>;
   readonly flowDomainId: string;
   readonly translation: Readonly<{ xPt: number; yPt: number }>;
 }

--- a/packages/docx/src/layout/page-factory.test.ts
+++ b/packages/docx/src/layout/page-factory.test.ts
@@ -4,6 +4,7 @@ import type { SectionLayoutContext } from '../layout-context.js';
 import {
   accumulatePagePaintNode,
   accumulatePageSectionRegion,
+  bodyOccurrenceDestinationFor,
   bodyFlowDomainId,
   createLayoutPageAccumulator,
   createLayoutPage,
@@ -11,6 +12,7 @@ import {
   finalizeLayoutPage,
 } from './page-factory.js';
 import { assertDocumentLayout } from './invariants.js';
+import { LayoutInvariantError } from './diagnostics.js';
 import type {
   DocumentLayout,
   DrawingLayout,
@@ -53,6 +55,21 @@ function section(
     grid: { kind: 'none', linePitchPt: null, charSpacePt: null },
     textDirection,
     verticalAlignment: 'top',
+  };
+}
+
+function verticalSection(
+  textDirection: string,
+  columns: readonly Readonly<{ xPt: number; wPt: number }>[],
+): SectionLayoutContext {
+  const horizontal = section(textDirection, columns);
+  return {
+    ...horizontal,
+    geometry: {
+      ...horizontal.geometry,
+      pageWidth: 792,
+      pageHeight: 612,
+    },
   };
 }
 
@@ -163,6 +180,312 @@ function bookmarkTable(
 }
 
 describe('createLayoutPage', () => {
+  it('fails closed for invalid page, identity, region, column, and one-page section facts', () => {
+    const first = section('lrTb', [{ xPt: 72, wPt: 220 }]);
+    const base = {
+      pageIndex: 0,
+      physicalPage: { widthPt: 612, heightPt: 792, contentTopPt: 72, contentBottomPt: 720 },
+      sectionOccurrenceId: 'section:first', section: first,
+      sectionRegions: [{
+        id: 'region:first', sectionOccurrenceId: 'section:first', section: first,
+        writingMode: 'horizontal-tb' as const, blockStartPt: 72, blockEndPt: 330,
+        columns: [{ inlineStartPt: 72, inlineExtentPt: 220 }],
+      }],
+      paint: [], readingOrder: [],
+      pageNumber: { displayNumber: 1, format: 'decimal', sectionOccurrenceId: 'section:first' },
+    };
+
+    expect(() => createLayoutPage({ ...base, sectionOccurrenceId: '' })).toThrow(RangeError);
+    expect(() => createLayoutPage({
+      ...base,
+      sectionRegions: [{ ...base.sectionRegions[0]!, id: '' }],
+    })).toThrow(RangeError);
+    expect(() => createLayoutPage({
+      ...base,
+      sectionRegions: [
+        base.sectionRegions[0]!,
+        {
+          ...base.sectionRegions[0]!, id: 'region:second',
+          sectionOccurrenceId: 'section:second', blockStartPt: 300, blockEndPt: 500,
+        },
+      ],
+    })).toThrow(RangeError);
+    expect(() => createLayoutPage({
+      ...base,
+      sectionRegions: [{
+        ...base.sectionRegions[0]!,
+        columns: [
+          { inlineStartPt: 72, inlineExtentPt: 220 },
+          { inlineStartPt: 200, inlineExtentPt: 100 },
+        ],
+      }],
+    })).toThrow(RangeError);
+    expect(() => createLayoutPage({
+      ...base,
+      sectionRegions: [{ ...base.sectionRegions[0]!, blockEndPt: 793 }],
+    })).toThrow(RangeError);
+    expect(() => createLayoutPage({
+      ...base,
+      sectionRegions: [{
+        ...base.sectionRegions[0]!, columns: [{ inlineStartPt: 600, inlineExtentPt: 20 }],
+      }],
+    })).toThrow(RangeError);
+    const differentBox = {
+      ...first,
+      geometry: { ...first.geometry, pageWidth: 500 },
+    };
+    expect(() => createLayoutPage({
+      ...base,
+      sectionRegions: [{ ...base.sectionRegions[0]!, section: differentBox }],
+    })).toThrow(RangeError);
+    expect(() => createLayoutPage({
+      ...base,
+      sectionRegions: [
+        base.sectionRegions[0]!,
+        {
+          ...base.sectionRegions[0]!, id: 'region:second',
+          sectionOccurrenceId: 'section:second', writingMode: 'vertical-rl',
+          blockStartPt: 330, blockEndPt: 500,
+        },
+      ],
+    })).toThrow(RangeError);
+  });
+
+  it.each([
+    ['tbRl', 'vertical-rl'],
+    ['tbRlV', 'vertical-rl'],
+    ['tbLrV', 'vertical-lr'],
+    ['btLr', 'vertical-rl'],
+  ] as const)('accepts normalized %s section geometry for an upright physical page', (
+    textDirection,
+    writingMode,
+  ) => {
+    const normalized = verticalSection(textDirection, [{ xPt: 72, wPt: 648 }]);
+    expect(() => createLayoutPage({
+      pageIndex: 0,
+      physicalPage: {
+        widthPt: 612, heightPt: 792, contentTopPt: 72, contentBottomPt: 720,
+      },
+      sectionOccurrenceId: 'section:vertical',
+      section: normalized,
+      sectionRegions: [{
+        id: 'region:vertical', sectionOccurrenceId: 'section:vertical',
+        section: normalized, writingMode, blockStartPt: 72, blockEndPt: 540,
+        columns: [{ inlineStartPt: 72, inlineExtentPt: 648 }],
+      }],
+      paint: [], readingOrder: [],
+      pageNumber: {
+        displayNumber: 1, format: 'decimal', sectionOccurrenceId: 'section:vertical',
+      },
+    })).not.toThrow();
+  });
+
+  it.each([
+    {
+      textDirection: 'tb',
+      writingMode: 'horizontal-tb' as const,
+      sectionPage: { pageWidth: 612, pageHeight: 792 },
+      column: { xPt: 72, wPt: 468 },
+      blockEndPt: 720,
+      logicalBounds: rect(72, 72, 468, 648),
+      physicalBounds: rect(72, 72, 468, 648),
+    },
+    {
+      textDirection: 'rl',
+      writingMode: 'vertical-rl' as const,
+      sectionPage: { pageWidth: 792, pageHeight: 612 },
+      column: { xPt: 72, wPt: 648 },
+      blockEndPt: 540,
+      logicalBounds: rect(72, 72, 648, 468),
+      physicalBounds: rect(72, 72, 468, 648),
+    },
+    {
+      textDirection: 'lr',
+      writingMode: 'vertical-lr' as const,
+      sectionPage: { pageWidth: 792, pageHeight: 612 },
+      column: { xPt: 72, wPt: 648 },
+      blockEndPt: 540,
+      logicalBounds: rect(72, 72, 648, 468),
+      physicalBounds: rect(72, 72, 468, 648),
+    },
+  ])('builds normalized $writingMode geometry for Strict $textDirection', ({
+    textDirection,
+    writingMode,
+    sectionPage,
+    column,
+    blockEndPt,
+    logicalBounds,
+    physicalBounds,
+  }) => {
+    const baseSection = section(textDirection, [column]);
+    const normalized = {
+      ...baseSection,
+      geometry: { ...baseSection.geometry, ...sectionPage },
+    };
+    const page = createLayoutPage({
+      pageIndex: 0,
+      physicalPage: {
+        widthPt: 612, heightPt: 792, contentTopPt: 72, contentBottomPt: 720,
+      },
+      sectionOccurrenceId: 'section:strict',
+      section: normalized,
+      sectionRegions: [{
+        id: 'region:strict', sectionOccurrenceId: 'section:strict',
+        section: normalized, writingMode, blockStartPt: 72, blockEndPt,
+        columns: [{ inlineStartPt: column.xPt, inlineExtentPt: column.wPt }],
+      }],
+      paint: [], readingOrder: [],
+      pageNumber: { displayNumber: 1, format: 'decimal', sectionOccurrenceId: 'section:strict' },
+    });
+
+    expect(page.sectionRegions?.[0]?.coordinateSpace.writingMode).toBe(writingMode);
+    expect(page.flowDomains[0]?.logicalBounds).toEqual(logicalBounds);
+    expect(page.flowDomains[0]?.physicalBounds).toEqual(physicalBounds);
+  });
+
+  it('keeps lrTb and lrTbV horizontal and rejects unswapped vertical geometry', () => {
+    for (const textDirection of ['lrTb', 'lrTbV']) {
+      const horizontal = section(textDirection, [{ xPt: 72, wPt: 468 }]);
+      expect(() => createLayoutPage({
+        pageIndex: 0,
+        physicalPage: {
+          widthPt: 612, heightPt: 792, contentTopPt: 72, contentBottomPt: 720,
+        },
+        sectionOccurrenceId: 'section:horizontal', section: horizontal,
+        sectionRegions: [{
+          id: 'region:horizontal', sectionOccurrenceId: 'section:horizontal',
+          section: horizontal, writingMode: 'horizontal-tb',
+          blockStartPt: 72, blockEndPt: 720,
+          columns: [{ inlineStartPt: 72, inlineExtentPt: 468 }],
+        }],
+        paint: [], readingOrder: [],
+        pageNumber: {
+          displayNumber: 1, format: 'decimal', sectionOccurrenceId: 'section:horizontal',
+        },
+      })).not.toThrow();
+    }
+
+    const unswapped = section('tbRl', [{ xPt: 72, wPt: 648 }]);
+    expect(() => createLayoutPage({
+      pageIndex: 0,
+      physicalPage: {
+        widthPt: 612, heightPt: 792, contentTopPt: 72, contentBottomPt: 720,
+      },
+      sectionOccurrenceId: 'section:vertical', section: unswapped,
+      sectionRegions: [{
+        id: 'region:vertical', sectionOccurrenceId: 'section:vertical',
+        section: unswapped, writingMode: 'vertical-rl',
+        blockStartPt: 72, blockEndPt: 540,
+        columns: [{ inlineStartPt: 72, inlineExtentPt: 648 }],
+      }],
+      paint: [], readingOrder: [],
+      pageNumber: {
+        displayNumber: 1, format: 'decimal', sectionOccurrenceId: 'section:vertical',
+      },
+    })).toThrow(RangeError);
+  });
+
+  it('rejects direction, writing-mode, and logical-column disagreement', () => {
+    const horizontal = section('lrTb', [{ xPt: 72, wPt: 468 }]);
+    const base = {
+      pageIndex: 0,
+      physicalPage: {
+        widthPt: 612, heightPt: 792, contentTopPt: 72, contentBottomPt: 720,
+      },
+      sectionOccurrenceId: 'section:body', section: horizontal,
+      sectionRegions: [{
+        id: 'region:body', sectionOccurrenceId: 'section:body', section: horizontal,
+        writingMode: 'horizontal-tb' as const, blockStartPt: 72, blockEndPt: 720,
+        columns: [{ inlineStartPt: 72, inlineExtentPt: 468 }],
+      }],
+      paint: [], readingOrder: [],
+      pageNumber: { displayNumber: 1, format: 'decimal', sectionOccurrenceId: 'section:body' },
+    };
+
+    expect(() => createLayoutPage({
+      ...base,
+      sectionRegions: [{ ...base.sectionRegions[0]!, writingMode: 'vertical-rl' }],
+    })).toThrow(RangeError);
+    expect(() => createLayoutPage({
+      ...base,
+      sectionRegions: [{
+        ...base.sectionRegions[0]!,
+        columns: [{ inlineStartPt: 73, inlineExtentPt: 468 }],
+      }],
+    })).toThrow(RangeError);
+    expect(() => createLayoutPage({
+      ...base,
+      sectionRegions: [{ ...base.sectionRegions[0]!, section: { ...horizontal, textDirection: '' } }],
+    })).toThrow(RangeError);
+  });
+
+  it('rejects page-start section facts that contradict the first region', () => {
+    const first = section('lrTb', [{ xPt: 72, wPt: 468 }]);
+    const base = {
+      pageIndex: 0,
+      physicalPage: {
+        widthPt: 612, heightPt: 792, contentTopPt: 72, contentBottomPt: 720,
+      },
+      sectionOccurrenceId: 'section:first', section: first,
+      sectionRegions: [{
+        id: 'region:first', sectionOccurrenceId: 'section:first', section: first,
+        writingMode: 'horizontal-tb' as const, blockStartPt: 72, blockEndPt: 720,
+        columns: [{ inlineStartPt: 72, inlineExtentPt: 468 }],
+      }],
+      paint: [], readingOrder: [],
+      pageNumber: { displayNumber: 1, format: 'decimal', sectionOccurrenceId: 'section:first' },
+    };
+    const mismatches: SectionLayoutContext[] = [
+      { ...first, geometry: { ...first.geometry, marginLeft: 73 } },
+      { ...first, columns: [{ xPt: 73, wPt: 468 }] },
+      { ...first, textDirection: 'lrTbV' },
+      { ...first, grid: { ...first.grid, kind: 'lines' } },
+      { ...first, verticalAlignment: 'center' },
+      { ...first, lineNumbering: { start: 1, countBy: 1, restart: 'newPage' } },
+    ];
+
+    expect(() => createLayoutPage({
+      ...base, sectionOccurrenceId: 'section:other',
+    })).toThrow(RangeError);
+    for (const mismatch of mismatches) {
+      expect(() => createLayoutPage({ ...base, section: mismatch })).toThrow(RangeError);
+    }
+  });
+
+  it('binds one retained occurrence translation in logical page space', () => {
+    const bodySection = section('lrTb', [{ xPt: 72, wPt: 468 }]);
+    const region = {
+      id: 'region:body', sectionOccurrenceId: 'section:body', section: bodySection,
+      writingMode: 'horizontal-tb' as const, blockStartPt: 72, blockEndPt: 720,
+      columns: [{ inlineStartPt: 72, inlineExtentPt: 468 }],
+    };
+
+    expect(bodyOccurrenceDestinationFor(2, region, 0, 180, rect(12, 30, 100, 20)))
+      .toEqual({
+        coordinateSpace: 'logical-page-points',
+        flowDomainId: bodyFlowDomainId(2, 'region:body', 0),
+        translation: { xPt: 60, yPt: 150 },
+      });
+  });
+
+  it('rejects invalid occurrence destination inputs', () => {
+    const bodySection = section('lrTb', [{ xPt: 72, wPt: 468 }]);
+    const region = {
+      id: 'region:body', sectionOccurrenceId: 'section:body', section: bodySection,
+      writingMode: 'horizontal-tb' as const, blockStartPt: 72, blockEndPt: 720,
+      columns: [{ inlineStartPt: 72, inlineExtentPt: 468 }],
+    };
+
+    expect(() => bodyOccurrenceDestinationFor(-1, region, 0, 100, rect(0, 0, 10, 10)))
+      .toThrow(RangeError);
+    expect(() => bodyOccurrenceDestinationFor(0, region, 1, 100, rect(0, 0, 10, 10)))
+      .toThrow(RangeError);
+    expect(() => bodyOccurrenceDestinationFor(0, region, 0, Number.NaN, rect(0, 0, 10, 10)))
+      .toThrow(RangeError);
+    expect(() => bodyOccurrenceDestinationFor(0, region, 0, 100, rect(0, 0, -1, 10)))
+      .toThrow(RangeError);
+  });
+
   it('accumulates page inputs without mutating prior flow state', () => {
     const bodySection = section('lrTb', [{ xPt: 72, wPt: 468 }]);
     const initial = createLayoutPageAccumulator({
@@ -275,11 +598,13 @@ describe('createLayoutPage', () => {
       ],
       [bodyFlowDomainId(0, 'region:second', 0)],
     ]);
-    expect(page.flowDomains.map((domain) => domain.bounds)).toEqual([
+    expect(page.flowDomains.map((domain) => domain.logicalBounds)).toEqual([
       rect(72, 72, 220, 258),
       rect(320, 72, 220, 258),
       rect(72, 330, 468, 390),
     ]);
+    expect(page.flowDomains.map((domain) => domain.physicalBounds))
+      .toEqual(page.flowDomains.map((domain) => domain.logicalBounds));
     expect(page.sectionOccurrenceId).toBe('section:first');
     expect(page.pageNumber).toEqual({
       displayNumber: 1,
@@ -289,7 +614,7 @@ describe('createLayoutPage', () => {
   });
 
   it('retains a logical-to-physical transform for vertical section regions', () => {
-    const vertical = section('tbRl', [{ xPt: 72, wPt: 648 }]);
+    const vertical = verticalSection('tbRl', [{ xPt: 72, wPt: 648 }]);
 
     const page = createLayoutPage({
       pageIndex: 0,
@@ -322,8 +647,10 @@ describe('createLayoutPage', () => {
     expect(page.sectionRegions?.[0]?.coordinateSpace).toEqual({
       writingMode: 'vertical-rl',
       logicalToPhysical: { a: 0, b: 1, c: -1, d: 0, e: 612, f: 0 },
+      physicalToLogical: { a: 0, b: -1, c: 1, d: 0, e: 0, f: 612 },
     });
-    expect(page.flowDomains[0]?.bounds).toEqual(rect(72, 72, 468, 648));
+    expect(page.flowDomains[0]?.logicalBounds).toEqual(rect(72, 72, 648, 468));
+    expect(page.flowDomains[0]?.physicalBounds).toEqual(rect(72, 72, 468, 648));
   });
 
   it('uses caller-resolved effective body edges for positive and negative margin policies', () => {
@@ -352,7 +679,7 @@ describe('createLayoutPage', () => {
   });
 
   it('keeps resolved body edges independent of the vertical-lr coordinate transform', () => {
-    const vertical = section('tbLr', [{ xPt: 40, wPt: 700 }]);
+    const vertical = verticalSection('tbLrV', [{ xPt: 40, wPt: 700 }]);
     const page = createLayoutPage({
       pageIndex: 0,
       physicalPage: {
@@ -372,6 +699,10 @@ describe('createLayoutPage', () => {
     expect(page.geometry).toMatchObject({ contentTopPt: 88, contentBottomPt: 690 });
     expect(page.sectionRegions?.[0]?.coordinateSpace?.logicalToPhysical)
       .toEqual({ a: 0, b: 1, c: 1, d: 0, e: 0, f: 0 });
+    expect(page.sectionRegions?.[0]?.coordinateSpace.physicalToLogical)
+      .toEqual({ a: 0, b: 1, c: 1, d: 0, e: 0, f: 0 });
+    expect(page.flowDomains[0]?.logicalBounds).toEqual(rect(40, 54, 700, 510));
+    expect(page.flowDomains[0]?.physicalBounds).toEqual(rect(54, 40, 510, 700));
   });
 
   it('builds layer order, reading order, and clone-safe bookmark ownership', () => {
@@ -474,6 +805,34 @@ describe('createLayoutPage', () => {
         sectionOccurrenceId: 'section:body',
       },
     ]);
+    expect(() => assertDocumentLayout({ pages: [page], diagnostics: [] })).not.toThrow();
+  });
+
+  it('derives bookmark metadata in retained paint order across layer storage', () => {
+    const bodySection = section('lrTb', [{ xPt: 72, wPt: 468 }]);
+    const domainId = bodyFlowDomainId(0, 'region:body', 0);
+    const front = bookmarkParagraph(
+      'paragraph:front', domainId, 'front-destination', rect(200, 100, 50, 12),
+    );
+    const body = bookmarkParagraph(
+      'paragraph:body', domainId, 'body-destination', rect(72, 100, 50, 12),
+    );
+    const page = createLayoutPage({
+      pageIndex: 0,
+      physicalPage: { widthPt: 612, heightPt: 792, contentTopPt: 72, contentBottomPt: 720 },
+      sectionOccurrenceId: 'section:body', section: bodySection,
+      sectionRegions: [{
+        id: 'region:body', sectionOccurrenceId: 'section:body', section: bodySection,
+        writingMode: 'horizontal-tb', blockStartPt: 72, blockEndPt: 720,
+        columns: [{ inlineStartPt: 72, inlineExtentPt: 468 }],
+      }],
+      paint: [{ layer: 'front', node: front }, { layer: 'body', node: body }],
+      readingOrder: [front, body],
+      pageNumber: { displayNumber: 1, format: 'decimal', sectionOccurrenceId: 'section:body' },
+    });
+
+    expect(page.bookmarkStarts?.map(({ name }) => name))
+      .toEqual(['front-destination', 'body-destination']);
     expect(() => assertDocumentLayout({ pages: [page], diagnostics: [] })).not.toThrow();
   });
 
@@ -582,6 +941,139 @@ describe('createLayoutPage', () => {
     expect(() => assertDocumentLayout(unknownPageNumberOwner)).toThrow(/page number section owner/);
     expect(() => assertDocumentLayout(unknownBookmarkNode)).toThrow(/bookmark node/);
   });
+
+  it('rejects bookmark metadata assigned to the wrong retained section region', () => {
+    const first = section('lrTb', [{ xPt: 72, wPt: 468 }]);
+    const second = section('lrTb', [{ xPt: 72, wPt: 468 }]);
+    const firstDomainId = bodyFlowDomainId(0, 'region:first', 0);
+    const paragraph = bookmarkParagraph(
+      'paragraph:first', firstDomainId, 'destination', rect(72, 100, 50, 12),
+    );
+    const page = createLayoutPage({
+      pageIndex: 0,
+      physicalPage: { widthPt: 612, heightPt: 792, contentTopPt: 72, contentBottomPt: 720 },
+      sectionOccurrenceId: 'section:first', section: first,
+      sectionRegions: [
+        {
+          id: 'region:first', sectionOccurrenceId: 'section:first', section: first,
+          writingMode: 'horizontal-tb', blockStartPt: 72, blockEndPt: 300,
+          columns: [{ inlineStartPt: 72, inlineExtentPt: 468 }],
+        },
+        {
+          id: 'region:second', sectionOccurrenceId: 'section:second', section: second,
+          writingMode: 'horizontal-tb', blockStartPt: 300, blockEndPt: 720,
+          columns: [{ inlineStartPt: 72, inlineExtentPt: 468 }],
+        },
+      ],
+      paint: [{ layer: 'body', node: paragraph }], readingOrder: [paragraph],
+      pageNumber: { displayNumber: 1, format: 'decimal', sectionOccurrenceId: 'section:first' },
+    });
+    const wrongRegion: DocumentLayout = {
+      pages: [{
+        ...page,
+        bookmarkStarts: [{ ...page.bookmarkStarts![0]!, sectionOccurrenceId: 'section:second' }],
+      }],
+      diagnostics: [],
+    };
+
+    expect(() => assertDocumentLayout(wrongRegion)).toThrow(/bookmark metadata/);
+  });
+
+  it('rejects bookmark metadata with no matching retained placement', () => {
+    const bodySection = section('lrTb', [{ xPt: 72, wPt: 468 }]);
+    const domainId = bodyFlowDomainId(0, 'region:body', 0);
+    const paragraph = bookmarkParagraph(
+      'paragraph:body', domainId, 'retained-destination', rect(72, 100, 50, 12),
+    );
+    const page = createLayoutPage({
+      pageIndex: 0,
+      physicalPage: { widthPt: 612, heightPt: 792, contentTopPt: 72, contentBottomPt: 720 },
+      sectionOccurrenceId: 'section:body', section: bodySection,
+      sectionRegions: [{
+        id: 'region:body', sectionOccurrenceId: 'section:body', section: bodySection,
+        writingMode: 'horizontal-tb', blockStartPt: 72, blockEndPt: 720,
+        columns: [{ inlineStartPt: 72, inlineExtentPt: 468 }],
+      }],
+      paint: [{ layer: 'body', node: paragraph }], readingOrder: [paragraph],
+      pageNumber: { displayNumber: 1, format: 'decimal', sectionOccurrenceId: 'section:body' },
+    });
+    const inventedPlacement: DocumentLayout = {
+      pages: [{
+        ...page,
+        bookmarkStarts: [{
+          name: 'invented-destination',
+          nodeId: paragraph.id,
+          sectionOccurrenceId: 'section:body',
+        }],
+      }],
+      diagnostics: [],
+    };
+
+    expect(() => assertDocumentLayout(inventedPlacement)).toThrow(/bookmark metadata/);
+  });
+
+  it('rejects an ownerless derived bookmark while preserving transitional omission and emptiness', () => {
+    const bodySection = section('lrTb', [{ xPt: 72, wPt: 468 }]);
+    const domainId = bodyFlowDomainId(0, 'region:body', 0);
+    const paragraph = bookmarkParagraph(
+      'paragraph:body', domainId, 'destination', rect(72, 100, 50, 12),
+    );
+    const page = createLayoutPage({
+      pageIndex: 0,
+      physicalPage: { widthPt: 612, heightPt: 792, contentTopPt: 72, contentBottomPt: 720 },
+      sectionOccurrenceId: 'section:body', section: bodySection,
+      sectionRegions: [{
+        id: 'region:body', sectionOccurrenceId: 'section:body', section: bodySection,
+        writingMode: 'horizontal-tb', blockStartPt: 72, blockEndPt: 720,
+        columns: [{ inlineStartPt: 72, inlineExtentPt: 468 }],
+      }],
+      paint: [{ layer: 'body', node: paragraph }], readingOrder: [paragraph],
+      pageNumber: { displayNumber: 1, format: 'decimal', sectionOccurrenceId: 'section:body' },
+    });
+    const {
+      sectionOccurrenceId,
+      sectionRegions,
+      pageNumber,
+      bookmarkStarts,
+      ...transitionalPage
+    } = page;
+    void sectionOccurrenceId;
+    void sectionRegions;
+    void pageNumber;
+    void bookmarkStarts;
+
+    const ownerless: DocumentLayout = {
+      pages: [{
+        ...transitionalPage,
+        bookmarkStarts: [{
+          name: 'destination', nodeId: paragraph.id, sectionOccurrenceId: '',
+        }],
+      }],
+      diagnostics: [],
+    };
+    try {
+      assertDocumentLayout(ownerless);
+      throw new Error('expected ownerless bookmark metadata to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(LayoutInvariantError);
+      expect((error as LayoutInvariantError).code).toBe('INVALID_REFERENCE');
+    }
+
+    expect(() => assertDocumentLayout({ pages: [transitionalPage], diagnostics: [] }))
+      .not.toThrow();
+    expect(() => assertDocumentLayout({
+      pages: [{
+        ...transitionalPage,
+        bookmarkStarts: [],
+        layers: {
+          paintOrder: [], background: [], behindText: [], header: [], body: [],
+          notes: [], front: [], footer: [],
+        },
+        readingOrder: [],
+      }],
+      diagnostics: [],
+    })).not.toThrow();
+  });
 });
 
 describe('createParityBlankLayoutPage', () => {
@@ -650,7 +1142,8 @@ describe('createParityBlankLayoutPage', () => {
         flowDomains: [{
           id: 'unexpected',
           kind: 'body',
-          bounds: rect(72, 72, 468, 648),
+          logicalBounds: rect(72, 72, 468, 648),
+          physicalBounds: rect(72, 72, 468, 648),
         }],
       }],
       diagnostics: [],

--- a/packages/docx/src/layout/page-factory.ts
+++ b/packages/docx/src/layout/page-factory.ts
@@ -1,11 +1,19 @@
 import type { SectionLayoutContext } from '../layout-context.js';
+import {
+  createSectionRegionCoordinateSpace,
+  logicalPageExtent,
+  transformRect,
+  uprightPhysicalExtent,
+  writingModeFromTextDirection,
+  type PhysicalPageExtent,
+} from './coordinate-space.js';
 import { PAGE_LAYER_IDS, type PageLayerNode } from './page-graph.js';
+import type { BodyOccurrenceDestination } from './occurrence-projection.js';
 import type {
   DeepReadonly,
   FlowDomain,
   LayoutPage,
   LayoutRect,
-  Matrix2DData,
   PageBookmarkStart,
   PageLayers,
   PageNumberMetadata,
@@ -17,9 +25,7 @@ import type {
   WritingMode,
 } from './types.js';
 
-export interface PhysicalPageInput {
-  readonly widthPt: number;
-  readonly heightPt: number;
+export interface PhysicalPageInput extends PhysicalPageExtent {
   /** Effective main-story edges after §17.6.11 header/footer interaction. */
   readonly contentTopPt: number;
   readonly contentBottomPt: number;
@@ -76,58 +82,6 @@ export function bodyFlowDomainId(
   return `page:${pageIndex}:region:${encodeURIComponent(regionId)}:column:${columnIndex}`;
 }
 
-function logicalToPhysicalMatrix(
-  writingMode: WritingMode,
-  page: PhysicalPageInput,
-): Matrix2DData {
-  switch (writingMode) {
-    case 'vertical-rl':
-      // ECMA-376 §17.6.20: logical inline advances down; logical block advances
-      // right-to-left. Keeping this transform makes physical bounds derivable.
-      return { a: 0, b: 1, c: -1, d: 0, e: page.widthPt, f: 0 };
-    case 'vertical-lr':
-      return { a: 0, b: 1, c: 1, d: 0, e: 0, f: 0 };
-    case 'horizontal-tb':
-      return { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
-  }
-}
-
-function transformPoint(
-  matrix: Matrix2DData,
-  inlinePt: number,
-  blockPt: number,
-): Readonly<{ xPt: number; yPt: number }> {
-  return {
-    xPt: matrix.a * inlinePt + matrix.c * blockPt + matrix.e,
-    yPt: matrix.b * inlinePt + matrix.d * blockPt + matrix.f,
-  };
-}
-
-function physicalBounds(
-  matrix: Matrix2DData,
-  inlineStartPt: number,
-  inlineEndPt: number,
-  blockStartPt: number,
-  blockEndPt: number,
-): LayoutRect {
-  const points = [
-    transformPoint(matrix, inlineStartPt, blockStartPt),
-    transformPoint(matrix, inlineEndPt, blockStartPt),
-    transformPoint(matrix, inlineStartPt, blockEndPt),
-    transformPoint(matrix, inlineEndPt, blockEndPt),
-  ];
-  const x = points.map((point) => point.xPt);
-  const y = points.map((point) => point.yPt);
-  const xPt = Math.min(...x);
-  const yPt = Math.min(...y);
-  return {
-    xPt,
-    yPt,
-    widthPt: Math.max(...x) - xPt,
-    heightPt: Math.max(...y) - yPt,
-  };
-}
-
 function pageGeometry(page: PhysicalPageInput): LayoutPage['geometry'] {
   requireEffectivePageEdges(page);
   return {
@@ -145,9 +99,12 @@ function pageGeometry(page: PhysicalPageInput): LayoutPage['geometry'] {
 
 function requireEffectivePageEdges(page: PhysicalPageInput): void {
   if (
-    !Number.isFinite(page.heightPt)
+    !Number.isFinite(page.widthPt)
+    || !Number.isFinite(page.heightPt)
     || !Number.isFinite(page.contentTopPt)
     || !Number.isFinite(page.contentBottomPt)
+    || page.widthPt <= 0
+    || page.heightPt <= 0
     || page.contentTopPt < 0
     || page.contentTopPt > page.contentBottomPt
     || page.contentBottomPt > page.heightPt
@@ -157,6 +114,76 @@ function requireEffectivePageEdges(page: PhysicalPageInput): void {
     );
   }
   // Equal edges are valid and represent an empty main-story interval.
+}
+
+function requireIdentity(value: string, name: string): void {
+  if (value.length === 0) throw new RangeError(`${name} must not be empty`);
+}
+
+function equalColumns(
+  left: SectionLayoutContext['columns'],
+  right: SectionLayoutContext['columns'],
+): boolean {
+  return left.length === right.length && left.every((column, index) => {
+    const other = right[index];
+    return other !== undefined && column.xPt === other.xPt && column.wPt === other.wPt;
+  });
+}
+
+function equalLineNumbering(
+  left: SectionLayoutContext['lineNumbering'],
+  right: SectionLayoutContext['lineNumbering'],
+): boolean {
+  return left === right || (left !== undefined && right !== undefined
+    && left.start === right.start
+    && left.countBy === right.countBy
+    && left.distance === right.distance
+    && left.restart === right.restart);
+}
+
+export function sectionLayoutContextsEqual(
+  left: DeepReadonly<SectionLayoutContext>,
+  right: DeepReadonly<SectionLayoutContext>,
+): boolean {
+  return left.geometry.pageWidth === right.geometry.pageWidth
+    && left.geometry.pageHeight === right.geometry.pageHeight
+    && left.geometry.marginTop === right.geometry.marginTop
+    && left.geometry.marginRight === right.geometry.marginRight
+    && left.geometry.marginBottom === right.geometry.marginBottom
+    && left.geometry.marginLeft === right.geometry.marginLeft
+    && left.geometry.headerDistance === right.geometry.headerDistance
+    && left.geometry.footerDistance === right.geometry.footerDistance
+    && equalColumns(left.columns, right.columns)
+    && left.textDirection === right.textDirection
+    && left.grid.kind === right.grid.kind
+    && left.grid.linePitchPt === right.grid.linePitchPt
+    && left.grid.charSpacePt === right.grid.charSpacePt
+    && left.verticalAlignment === right.verticalAlignment
+    && equalLineNumbering(left.lineNumbering, right.lineNumbering);
+}
+
+function requireRegionSectionAgreement(input: PageSectionRegionInput): void {
+  const writingMode = writingModeFromTextDirection(input.section.textDirection);
+  if (writingMode !== input.writingMode) {
+    throw new RangeError('Section region writing mode must agree with its section text direction');
+  }
+  if (input.columns.length !== input.section.columns.length
+    || input.columns.some((column, index) => {
+      const sectionColumn = input.section.columns[index];
+      return sectionColumn === undefined
+        || column.inlineStartPt !== sectionColumn.xPt
+        || column.inlineExtentPt !== sectionColumn.wPt;
+    })) {
+    throw new RangeError('Section region columns must equal its normalized section columns');
+  }
+}
+
+function requireRect(rect: LayoutRect, name: string): void {
+  if (!Number.isFinite(rect.xPt) || !Number.isFinite(rect.yPt)
+    || !Number.isFinite(rect.widthPt) || !Number.isFinite(rect.heightPt)
+    || rect.widthPt < 0 || rect.heightPt < 0) {
+    throw new RangeError(`${name} must be a finite rectangle with non-negative extents`);
+  }
 }
 
 function requirePageIndex(pageIndex: number): void {
@@ -177,21 +204,65 @@ function buildRegions(
   const regions: PageSectionRegion[] = [];
   const domains: FlowDomain[] = [];
   const sectionByDomain = new Map<string, string>();
+  const regionIds = new Set<string>();
+  const occurrenceIds = new Set<string>();
+  let priorBlockEndPt = 0;
+  let pageWritingMode: WritingMode | undefined;
 
   for (const input of inputs) {
-    const logicalToPhysical = logicalToPhysicalMatrix(input.writingMode, physicalPage);
+    requireIdentity(input.id, 'Section region id');
+    requireIdentity(input.sectionOccurrenceId, 'Section occurrence id');
+    if (regionIds.has(input.id) || occurrenceIds.has(input.sectionOccurrenceId)) {
+      throw new RangeError('Section region and occurrence identities must be unique');
+    }
+    regionIds.add(input.id);
+    occurrenceIds.add(input.sectionOccurrenceId);
+    if (pageWritingMode !== undefined && pageWritingMode !== input.writingMode) {
+      throw new RangeError('One physical page cannot mix writing modes');
+    }
+    pageWritingMode = input.writingMode;
+    requireRegionSectionAgreement(input);
+    const expectedPhysicalExtent = uprightPhysicalExtent({
+      widthPt: input.section.geometry.pageWidth,
+      heightPt: input.section.geometry.pageHeight,
+    }, input.writingMode);
+    if (expectedPhysicalExtent.widthPt !== physicalPage.widthPt
+      || expectedPhysicalExtent.heightPt !== physicalPage.heightPt) {
+      throw new RangeError('Section regions on one physical page must use the same page box');
+    }
+    const logicalExtent = logicalPageExtent(physicalPage, input.writingMode);
+    const logicalInlineExtent = logicalExtent.widthPt;
+    const logicalBlockExtent = logicalExtent.heightPt;
+    if (!Number.isFinite(input.blockStartPt) || !Number.isFinite(input.blockEndPt)
+      || input.blockStartPt < 0 || input.blockEndPt <= input.blockStartPt
+      || input.blockEndPt > logicalBlockExtent || input.blockStartPt < priorBlockEndPt) {
+      throw new RangeError('Section regions must be ordered, disjoint, and inside the logical page');
+    }
+    priorBlockEndPt = input.blockEndPt;
+    if (input.columns.length === 0) throw new RangeError('Section region must contain a column');
+    let priorInlineEndPt = 0;
+    const coordinateSpace = createSectionRegionCoordinateSpace(input.writingMode, physicalPage);
     const flowDomainIds = input.columns.map((column, columnIndex) => {
+      if (!Number.isFinite(column.inlineStartPt) || !Number.isFinite(column.inlineExtentPt)
+        || column.inlineStartPt < 0 || column.inlineExtentPt <= 0
+        || column.inlineStartPt + column.inlineExtentPt > logicalInlineExtent
+        || column.inlineStartPt < priorInlineEndPt) {
+        throw new RangeError('Columns must be ordered, disjoint, and inside the logical page');
+      }
+      priorInlineEndPt = column.inlineStartPt + column.inlineExtentPt;
       const id = bodyFlowDomainId(pageIndex, input.id, columnIndex);
+      if (sectionByDomain.has(id)) throw new RangeError(`Duplicate flow domain ${id}`);
+      const logicalBounds = {
+        xPt: column.inlineStartPt,
+        yPt: input.blockStartPt,
+        widthPt: column.inlineExtentPt,
+        heightPt: input.blockEndPt - input.blockStartPt,
+      };
       domains.push({
         id,
         kind: 'body',
-        bounds: physicalBounds(
-          logicalToPhysical,
-          column.inlineStartPt,
-          column.inlineStartPt + column.inlineExtentPt,
-          input.blockStartPt,
-          input.blockEndPt,
-        ),
+        logicalBounds,
+        physicalBounds: transformRect(coordinateSpace.logicalToPhysical, logicalBounds),
       });
       sectionByDomain.set(id, input.sectionOccurrenceId);
       return id;
@@ -199,7 +270,7 @@ function buildRegions(
     regions.push({
       id: input.id,
       sectionOccurrenceId: input.sectionOccurrenceId,
-      coordinateSpace: { writingMode: input.writingMode, logicalToPhysical },
+      coordinateSpace,
       blockStartPt: input.blockStartPt,
       blockEndPt: input.blockEndPt,
       flowDomainIds,
@@ -208,6 +279,32 @@ function buildRegions(
   }
 
   return { regions, domains, sectionByDomain };
+}
+
+export function bodyOccurrenceDestinationFor(
+  pageIndex: number,
+  region: PageSectionRegionInput,
+  columnIndex: number,
+  blockStartPt: number,
+  retainedFlowBounds: LayoutRect,
+): BodyOccurrenceDestination {
+  requirePageIndex(pageIndex);
+  requireIdentity(region.id, 'Section region id');
+  if (!Number.isInteger(columnIndex) || columnIndex < 0 || columnIndex >= region.columns.length) {
+    throw new RangeError('Column index must identify a section region column');
+  }
+  if (!Number.isFinite(blockStartPt)) throw new RangeError('Block start must be finite');
+  requireRect(retainedFlowBounds, 'Retained flow bounds');
+  const column = region.columns[columnIndex]!;
+  if (!Number.isFinite(column.inlineStartPt)) throw new RangeError('Column inline start must be finite');
+  return {
+    coordinateSpace: 'logical-page-points',
+    flowDomainId: bodyFlowDomainId(pageIndex, region.id, columnIndex),
+    translation: {
+      xPt: column.inlineStartPt - retainedFlowBounds.xPt,
+      yPt: blockStartPt - retainedFlowBounds.yPt,
+    },
+  };
 }
 
 function buildLayers(entries: readonly PageLayerNode[]): PageLayers {
@@ -262,14 +359,14 @@ function visitTextBoxBookmarks(
   textBox.paragraphs.forEach((paragraph) => visitBookmarkParagraphs(paragraph, visit));
 }
 
-function bookmarkStarts(
-  paint: readonly PageLayerNode[],
+export function derivePageBookmarkStarts(
+  paint: readonly PaintNode[],
   defaultSectionOccurrenceId: string,
   sectionByDomain: ReadonlyMap<string, string>,
 ): readonly PageBookmarkStart[] {
   const starts: PageBookmarkStart[] = [];
   const seen = new Set<string>();
-  for (const { node } of paint) {
+  for (const node of paint) {
     const sectionOccurrenceId = sectionByDomain.get(node.flowDomainId)
       ?? defaultSectionOccurrenceId;
     visitBookmarkParagraphs(node, (paragraph) => {
@@ -293,11 +390,19 @@ function bookmarkStarts(
 
 export function createLayoutPage(input: LayoutPageFactoryInput): LayoutPage {
   requirePageIndex(input.pageIndex);
+  requireIdentity(input.sectionOccurrenceId, 'Page-start section occurrence id');
   const { regions, domains, sectionByDomain } = buildRegions(
     input.pageIndex,
     input.physicalPage,
     input.sectionRegions,
   );
+  const firstRegion = input.sectionRegions[0];
+  if (firstRegion !== undefined && (
+    input.sectionOccurrenceId !== firstRegion.sectionOccurrenceId
+    || !sectionLayoutContextsEqual(input.section, firstRegion.section)
+  )) {
+    throw new RangeError('Page-start section context must equal the first section region');
+  }
   return {
     pageIndex: input.pageIndex,
     geometry: pageGeometry(input.physicalPage),
@@ -305,8 +410,8 @@ export function createLayoutPage(input: LayoutPageFactoryInput): LayoutPage {
     section: input.section,
     sectionOccurrenceId: input.sectionOccurrenceId,
     parityBlank: false,
-    bookmarkStarts: bookmarkStarts(
-      input.paint,
+    bookmarkStarts: derivePageBookmarkStarts(
+      input.paint.map(({ node }) => node),
       input.sectionOccurrenceId,
       sectionByDomain,
     ),
@@ -321,6 +426,7 @@ export function createLayoutPageAccumulator(
   input: LayoutPageAccumulatorInput,
 ): LayoutPageAccumulator {
   requirePageIndex(input.pageIndex);
+  requireIdentity(input.sectionOccurrenceId, 'Page-start section occurrence id');
   requireEffectivePageEdges(input.physicalPage);
   return Object.freeze({
     ...input,
@@ -365,6 +471,7 @@ export function createParityBlankLayoutPage(
   input: ParityBlankLayoutPageInput,
 ): LayoutPage {
   requirePageIndex(input.pageIndex);
+  requireIdentity(input.sectionOccurrenceId, 'Page-start section occurrence id');
   return {
     pageIndex: input.pageIndex,
     geometry: pageGeometry(input.physicalPage),

--- a/packages/docx/src/layout/structured-clone.test.ts
+++ b/packages/docx/src/layout/structured-clone.test.ts
@@ -19,7 +19,8 @@ describe('DocumentLayout data boundary', () => {
         flowDomains: [{
           id: 'body',
           kind: 'body',
-          bounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
+          logicalBounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
+          physicalBounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
         }],
         section: {
           geometry: {

--- a/packages/docx/src/layout/types.ts
+++ b/packages/docx/src/layout/types.ts
@@ -41,6 +41,11 @@ export interface LayoutRect extends PointPt {
   readonly heightPt: number;
 }
 
+export type LayoutCoordinateSpace =
+  | 'column-local-logical'
+  | 'logical-page-points'
+  | 'upright-physical-page-points';
+
 export type FlowDomainKind =
   | 'body'
   | 'header'
@@ -53,7 +58,10 @@ export type FlowDomainKind =
 export interface FlowDomain {
   readonly id: string;
   readonly kind: FlowDomainKind;
-  readonly bounds: LayoutRect;
+  /** logical-page-points; same space as retained node flowBounds/inkBounds. */
+  readonly logicalBounds: LayoutRect;
+  /** upright-physical-page-points. */
+  readonly physicalBounds: LayoutRect;
 }
 
 export interface PageGeometry extends LayoutRect {
@@ -68,6 +76,12 @@ export interface Matrix2DData {
   readonly d: number;
   readonly e: number;
   readonly f: number;
+}
+
+export interface SectionRegionCoordinateSpace {
+  readonly writingMode: WritingMode;
+  readonly logicalToPhysical: Matrix2DData;
+  readonly physicalToLogical: Matrix2DData;
 }
 
 export type ClipPathData =
@@ -632,9 +646,10 @@ export interface FloatRegistryEntryPt {
   readonly exclusionBounds: LayoutRect;
 }
 
-export type FloatRegistryCoordinateSpace =
-  | 'logical-page-points'
-  | 'upright-physical-page-points';
+export type FloatRegistryCoordinateSpace = Exclude<
+  LayoutCoordinateSpace,
+  'column-local-logical'
+>;
 
 export interface FloatRegistrySnapshotPt {
   readonly coordinateSpace: FloatRegistryCoordinateSpace;
@@ -711,10 +726,7 @@ export interface PageSectionRegion {
   readonly sectionOccurrenceId: string;
   /** Logical inline/block coordinates are retained independently of physical
    * x/y so vertical sections do not silently inherit horizontal Y-flow rules. */
-  readonly coordinateSpace?: Readonly<{
-    writingMode: WritingMode;
-    logicalToPhysical: Matrix2DData;
-  }>;
+  readonly coordinateSpace: SectionRegionCoordinateSpace;
   readonly blockStartPt: number;
   readonly blockEndPt: number;
   readonly flowDomainIds: readonly string[];
@@ -1028,7 +1040,12 @@ export interface TableLayoutInput {
 
 export type FlowBlockInput = ParagraphLayoutInput | TableLayoutInput;
 
-export interface FlowContainer extends FlowDomain {}
+export interface FlowContainer {
+  readonly id: string;
+  readonly kind: FlowDomainKind;
+  /** Acquisition-local logical bounds; never retained physical page bounds. */
+  readonly bounds: LayoutRect;
+}
 
 export interface FlowCursor extends PointPt {}
 

--- a/packages/docx/src/paint/canvas-resources.test.ts
+++ b/packages/docx/src/paint/canvas-resources.test.ts
@@ -21,7 +21,9 @@ function resourceLayout(
         contentTopPt: 10, contentBottomPt: 190,
       },
       flowDomains: [{
-        id: 'body', kind: 'body', bounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
+        id: 'body', kind: 'body',
+        logicalBounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
+        physicalBounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
       }],
       section: {} as SectionLayoutContext,
       layers: {

--- a/packages/docx/src/paint/paint-purity.test.ts
+++ b/packages/docx/src/paint/paint-purity.test.ts
@@ -40,7 +40,8 @@ describe('paintLayoutPage', () => {
         flowDomains: [{
           id: 'body',
           kind: 'body',
-          bounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
+          logicalBounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
+          physicalBounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
         }],
         section: {} as SectionLayoutContext,
         layers: {
@@ -96,7 +97,11 @@ describe('paintLayoutPage', () => {
     const page = {
       pageIndex: 0,
       geometry: { xPt: 0, yPt: 0, widthPt: 100, heightPt: 200, contentTopPt: 10, contentBottomPt: 190 },
-      flowDomains: [{ id: 'body', kind: 'body' as const, bounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 } }],
+      flowDomains: [{
+        id: 'body', kind: 'body' as const,
+        logicalBounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
+        physicalBounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
+      }],
       section: {} as SectionLayoutContext,
       layers: {
         paintOrder: [{ layer: 'body' as const, nodeId: 'missing' }],
@@ -158,7 +163,11 @@ describe('paintLayoutPage', () => {
       pages: [{
         pageIndex: 0,
         geometry: { xPt: 0, yPt: 0, widthPt: 100, heightPt: 200, contentTopPt: 10, contentBottomPt: 190 },
-        flowDomains: [{ id: 'body', kind: 'body', bounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 } }],
+        flowDomains: [{
+          id: 'body', kind: 'body',
+          logicalBounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
+          physicalBounds: { xPt: 10, yPt: 10, widthPt: 80, heightPt: 180 },
+        }],
         section: {} as SectionLayoutContext,
         layers: {
           paintOrder: [{ layer: 'body', nodeId: 'table-0' }],

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -379,6 +379,50 @@ function assertOccurrenceProjectionRuntimeDependencies(root) {
   }
 }
 
+function assertCoordinateSpaceRuntimeDependencies(root) {
+  const coordinate = resolve(root, LAYOUT_SOURCE, 'coordinate-space.ts');
+  const pageFactory = resolve(root, LAYOUT_SOURCE, 'page-factory.ts');
+  for (const path of [coordinate, pageFactory]) {
+    if (!existsSync(path)) {
+      fail('COORDINATE_SPACE_RUNTIME_DEPENDENCY', `missing ${posixPath(relative(root, path))}`);
+    }
+  }
+
+  for (const edge of moduleEdges(coordinate)) {
+    const detail = `${posixPath(relative(root, coordinate))} -> ${edge.specifier}`;
+    if (edge.kind !== 'import' || !edge.literal || edge.bare || !edge.typeOnly
+      || edge.specifier !== './types.js') {
+      fail('COORDINATE_SPACE_RUNTIME_DEPENDENCY', detail);
+    }
+  }
+
+  const runtimeTargets = new Set([
+    resolve(root, LAYOUT_SOURCE, 'coordinate-space.ts'),
+    resolve(root, LAYOUT_SOURCE, 'page-graph.ts'),
+  ]);
+  for (const edge of moduleEdges(pageFactory)) {
+    if (edge.typeOnly) {
+      if (edge.specifier.includes('?') || edge.specifier.includes('#')) {
+        fail(
+          'COORDINATE_SPACE_RUNTIME_DEPENDENCY',
+          `${posixPath(relative(root, pageFactory))} -> ${edge.specifier}`,
+        );
+      }
+      continue;
+    }
+    const detail = `${posixPath(relative(root, pageFactory))} -> ${edge.specifier}`;
+    if (edge.kind !== 'import' || !edge.literal || edge.bare
+      || edge.specifier.includes('?') || edge.specifier.includes('#')
+      || !edge.specifier.startsWith('.')) {
+      fail('COORDINATE_SPACE_RUNTIME_DEPENDENCY', detail);
+    }
+    const dependency = resolveLocalImport(pageFactory, edge.specifier);
+    if (!dependency || !runtimeTargets.has(dependency)) {
+      fail('COORDINATE_SPACE_RUNTIME_DEPENDENCY', detail);
+    }
+  }
+}
+
 /**
  * Body paint consumes retained placements. Letting this adapter call a layout
  * entry point would silently reintroduce a second layout pass whose result can
@@ -2688,6 +2732,7 @@ export function checkDocxLayoutBoundaries(options) {
   assertNoProductionTestSupportImports(root);
   assertPaintBoundaries(root);
   assertCapabilityBoundaries(root);
+  assertCoordinateSpaceRuntimeDependencies(root);
   assertOccurrenceProjectionRuntimeDependencies(root);
   assertBodyPaintConsumesRetainedLayout(root);
   assertLayoutParserModelBoundaries(root);

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -36,6 +36,9 @@ function initializeFixture(prefix) {
   write(root, 'packages/docx/src/layout/occurrence-projection.ts', "import { snapshotPlainData } from './plain-data.js';\nexport const project = snapshotPlainData;\n");
   write(root, 'packages/docx/src/layout/retained-geometry-translation.ts', "import type { PointPt } from './types.js';\nexport const translate = (point: PointPt) => point;\n");
   write(root, 'packages/docx/src/layout/types.ts', 'export interface PointPt { xPt: number; yPt: number }\n');
+  write(root, 'packages/docx/src/layout/coordinate-space.ts', "import type { PointPt } from './types.js';\nexport const coordinate = (point: PointPt) => point;\n");
+  write(root, 'packages/docx/src/layout/page-graph.ts', 'export const PAGE_LAYER_IDS = [];\n');
+  write(root, 'packages/docx/src/layout/page-factory.ts', "import { coordinate } from './coordinate-space.js';\nimport { PAGE_LAYER_IDS } from './page-graph.js';\nimport type { BodyOccurrenceDestination } from './occurrence-projection.js';\nexport const pageFactory = [coordinate, PAGE_LAYER_IDS] satisfies unknown;\nexport type Destination = BodyOccurrenceDestination;\n");
   return root;
 }
 
@@ -59,6 +62,55 @@ function initializeOccurrenceProjectionRepository(importSource = "import { snaps
   write(root, 'packages/docx/src/layout/occurrence-projection.ts', importSource);
   return root;
 }
+
+function initializeCoordinateSpaceRepository() {
+  const root = initializeRepository();
+  establishA1Baseline(root);
+  return root;
+}
+
+test('coordinate-space and page-factory runtime seams allow only their explicit dependencies', () => {
+  const root = initializeCoordinateSpaceRepository();
+  const result = runChecker(root, '--base-ref', 'main');
+  assert.equal(result.status, 0, result.output);
+});
+
+for (const missing of ['coordinate-space.ts', 'page-factory.ts']) {
+  test(`coordinate-space boundary rejects missing ${missing}`, () => {
+    const root = initializeCoordinateSpaceRepository();
+    rmSync(join(root, 'packages/docx/src/layout', missing));
+    assert.match(runChecker(root, '--base-ref', 'main').output,
+      /COORDINATE_SPACE_RUNTIME_DEPENDENCY/);
+  });
+}
+
+for (const [name, source] of [
+  ['renderer', "import { value } from '../renderer.js';\nexport const coordinate = value;\n"],
+  ['parser', "import { value } from '../parser-model.js';\nexport const coordinate = value;\n"],
+  ['paint', "import { value } from '../paint/canvas-page.js';\nexport const coordinate = value;\n"],
+  ['worker', "import { value } from '../render-worker.js';\nexport const coordinate = value;\n"],
+  ['shaping', "import { value } from './text.js';\nexport const coordinate = value;\n"],
+  ['DOM Canvas package', "import value from 'canvas';\nexport const coordinate = value;\n"],
+  ['decorated', "import type { PointPt } from './types.js?raw';\nexport const coordinate = (point: PointPt) => point;\n"],
+  ['dynamic literal', "export const coordinate = import('./types.js');\n"],
+  ['dynamic nonliteral', "const path = './types.js';\nexport const coordinate = import(path);\n"],
+]) {
+  test(`coordinate-space boundary rejects ${name} imports`, () => {
+    const root = initializeCoordinateSpaceRepository();
+    write(root, 'packages/docx/src/layout/coordinate-space.ts', source);
+    const result = runChecker(root, '--base-ref', 'main');
+    assert.notEqual(result.status, 0);
+    assert.match(result.output, /COORDINATE_SPACE_RUNTIME_DEPENDENCY/);
+  });
+}
+
+test('page-factory boundary rejects a runtime occurrence-projection edge', () => {
+  const root = initializeCoordinateSpaceRepository();
+  write(root, 'packages/docx/src/layout/page-factory.ts',
+    "import { project } from './occurrence-projection.js';\nexport const pageFactory = project;\n");
+  assert.match(runChecker(root, '--base-ref', 'main').output,
+    /COORDINATE_SPACE_RUNTIME_DEPENDENCY/);
+});
 
 test('occurrence projection runtime graph allows only its entries and plain-data', () => {
   const root = initializeOccurrenceProjectionRepository();


### PR DESCRIPTION
## Summary

- define acquisition-local flow containers, occurrence-owned layout regions, and physical page coordinate ownership
- make page construction and clone validation enforce transforms, section bookmarks, paint order, and writing-mode consistency
- record the existing Microsoft Word section-level btLr behavior as an explicit compatibility rule
- extend architectural boundary checks without changing the public API

This is A6 substep 4 of Issue #1037. It establishes contracts only; the production page-flow caller is cut over in the next substep.

## Specification basis

- ECMA-376 Part 1 section 17.6 section properties
- ECMA-376 Part 4 section 14.11.7 text direction
- Microsoft Word behavior previously adjudicated in Issue #988 for section-level btLr

## Verification

- focused layout tests: 104 passed
- full TypeScript suite: 5,144 passed, 26 skipped
- pnpm typecheck
- pnpm lint
- pnpm lint:test
- DOCX boundary suite: 108 passed
- pnpm build
- DOCX public API baseline check
- pnpm build-storybook
- git diff --check

Closes no issue; advances #1037.