### PR TITLE
chore: ignore local development artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 /spec
 spec/
 node_modules/
+# Per-worktree pnpm store used by sandboxed/local agent sessions.
+/.pnpm-store/
 .claude/
 dist/
 # WASM build output (regenerate with: npm run wasm)
@@ -39,6 +41,12 @@ packages/pptx/tests/visual/screenshots/
 packages/pptx/tests/visual/diffs/
 packages/pptx/tests/visual/report/
 packages/pptx/tests/visual/baseline/
+# The VRT specs use package-relative output paths. When Playwright is invoked
+# from the repository root, the same generated tree lands here instead.
+/tests/visual/screenshots/
+/tests/visual/diffs/
+/tests/visual/report/
+/tests/visual/baseline/
 # Playwright
 playwright-report/
 test-results/
@@ -62,6 +70,8 @@ package-lock.json
 # (docs/images/ stays tracked — it holds the README / extension screenshots.)
 docs/superpowers/
 docs/dev-notes/
+/.superpowers/
+/tmp/
 # Internal task list (Japanese dev notes); keep local, not for the public repo.
 TODO.md
 


### PR DESCRIPTION
## Summary
- ignore repository-root VRT output created when package specs run from the root working directory
- ignore per-worktree pnpm stores and root-local scratch directories
- keep prospective visual test sources and public references visible to Git

## Root cause
The VRT specs write package-relative paths. When Playwright is launched from the repository root, those generated paths land under the root `tests/visual` tree rather than the package tree covered by existing ignore rules.

## Verification
- `git diff --check`
- positive `git check-ignore --no-index` checks for generated VRT/store/scratch paths
- negative checks for root visual test sources and public reference paths
- independent review: approved after narrowing the VRT rules to generated subdirectories only