### PR TITLE
refactor(docx): unify float placement callers

### DIFF
--- a/docs/docx-layout-engine-series-c-plan.md
+++ b/docs/docx-layout-engine-series-c-plan.md
@@ -34,6 +34,7 @@
 - Modify: `packages/docx/src/layout/compatibility.test.ts`
 - Modify: `packages/docx/src/layout/convergence.ts`
 - Modify: `packages/docx/src/layout/line-wrap-convergence.ts`
+- Modify: `packages/docx/src/layout/body-paginator.ts`
 - Modify: `packages/docx/src/layout/paragraph.ts`
 - Modify: `packages/docx/src/layout/floating-table-transaction.ts`
 - Modify: `packages/docx/src/layout/table-pagination.ts`
@@ -43,6 +44,8 @@
 - Modify: `packages/docx/src/float-line-start-one-inch.test.ts`
 - Modify: `packages/docx/src/float-table-geometry.test.ts`
 - Modify: `scripts/docx-layout-boundary-baseline.json`
+- Modify: `scripts/check-docx-layout-boundaries.mjs`
+- Modify: `scripts/check-docx-layout-boundaries.test.mjs`
 
 **Interfaces:**
 
@@ -70,9 +73,15 @@ generic geometry contains no observation-derived constant.
 ```ts
 export type FloatAvoidance =
   | { readonly kind: 'drawingml-normative' }
-  | { readonly kind: 'floating-table-never' }
   | { readonly kind: 'word-different-paragraph'; readonly paragraphId: number }
   | { readonly kind: 'none' };
+export type FloatPlacementParticipant =
+  | (FloatParticipantCore & {
+      readonly kind: 'table';
+      readonly tableOverlap: 'never' | 'overlap';
+    })
+  | (FloatParticipantCore & { readonly kind: 'drawingml' })
+  | (FloatParticipantCore & { readonly kind: 'frame' });
 export interface FloatPlacement {
   readonly bounds: LayoutRect;
   readonly exclusionBounds: LayoutRect;
@@ -82,7 +91,7 @@ export interface FloatPlacement {
 export function resolveFloatPlacement(input: ResolveFloatPlacementInput): FloatPlacement;
 ```
 
-- [ ] **C1a Step 1: Add failing policy and real-convergence tests**
+- [x] **C1a Step 1: Add failing policy and real-convergence tests**
 
 Do not duplicate the existing `anchor-frame.test.ts` axis/wrap matrix. Cover
 DrawingML-only normative blockers, table-only §17.4.56 blockers using raw table
@@ -92,7 +101,7 @@ padding. Add exact-state tests for adjacent fixed points, non-adjacent cycles,
 and all-distinct resource-budget exhaustion. Pin the actual paragraph-anchor,
 line-wrap, and floating-table final-frame fixed points.
 
-- [ ] **C1a Step 2: Run tests to verify Red**
+- [x] **C1a Step 2: Run tests to verify Red**
 
 Run:
 
@@ -104,7 +113,7 @@ Expected: displacement policy is duplicated, `repeated-state.ts` is a second
 unbounded convergence mechanism, all-distinct line/anchor states can run
 without a typed limit failure, and table collision includes text-only padding.
 
-- [ ] **C1a Step 3: Implement policy extraction and bounded exact convergence**
+- [x] **C1a Step 3: Implement policy extraction and bounded exact convergence**
 
 Keep axis/wrap resolution in `anchor-frame.ts`. Select normative versus
 compatibility blocker geometry in `floats.ts`, delegate only direction/math to
@@ -119,7 +128,7 @@ different-paragraph displacement are compatibility rules. Normative
 `allowOverlap=false`, `tblOverlap=never`, and `layoutInCell` remain typed
 constraints rather than compatibility records.
 
-- [ ] **C1a Step 4: Verify Green and deterministic failure**
+- [x] **C1a Step 4: Verify Green and deterministic failure**
 
 Run the command from Step 2 plus:
 
@@ -132,25 +141,37 @@ Expected: tests pass; identical input produces identical placement and layout
 fingerprints; a cycle and an all-distinct orbit both fail with
 `NON_CONVERGENCE`; no last candidate is returned.
 
-- [ ] **C1a Step 5: Commit, independently review, fix, and merge**
+- [x] **C1a Step 5: Commit, independently review, fix, and merge**
 
 Commit subject: `refactor(docx): centralize float placement policy`.
 Use the roadmap review gate.
 
-- [ ] **C1b Step 1: Consolidate remaining registry callers and pairwise facts**
+- [x] **C1b Step 1: Consolidate remaining registry callers and pairwise facts**
 
 Add the blocker-side `tblOverlap=never` fact required by §17.4.56's pairwise
-"either table" rule. Route renderer/table/frame adapters through the same typed
-policy, extract block-cursor retry math, and migrate remaining float-related
-page-anchor/selection fixed points to the shared convergence primitive.
+"either table" rule as a required discriminated-union field. Route
+renderer/table/frame adapters through the same typed policy and retain the
+established display/point numerical policies explicitly.
 
-- [ ] **C1b Step 2: Delete duplicated policy and ratchet boundaries**
+Extract ordinary-table retry as block-flow admission against §17.4.57 exclusion
+geometry. It is a finite monotone sweep, not float-to-float placement and not a
+non-monotone convergence problem. Migrate the two concrete remaining fixed
+points — page-owned-anchor destination planning and floating-table parent/child
+final-frame reflow — to the shared exact-state convergence primitive. The old
+"selected-page ownership" wording was stale; selected-page ownership is now
+pure and loop-free.
+
+- [x] **C1b Step 2: Delete duplicated policy and ratchet boundaries**
 
 Delete the scalar overlap adapter and inline blocker filters. Keep the mutable
 registry only as a transport bridge tracked for C3; it must no longer choose
-blocker classes, geometry, direction, tolerance, or retries. Add static/mutation
-checks that observation-derived constants are imported only from
-`compatibility.ts` and displacement math is callable only through `floats.ts`.
+blocker classes, geometry, direction, tolerance, or retries. Isolate the
+existing absolute floating-table page-deferral observation behind a named
+compatibility record. Add static/mutation checks that float-specific
+observation-derived rules are declared in `compatibility.ts`, generic numerical
+policies retain their exact audited owners/values, and the displacement kernel
+cannot be reached through named/namespace/default imports, re-exports, dynamic
+imports, CommonJS, or string-key laundering.
 
 - [ ] **C1b Step 3: Review, broad-verify, and merge**
 

--- a/packages/docx/src/float-layout.ts
+++ b/packages/docx/src/float-layout.ts
@@ -18,7 +18,6 @@ export {
 export {
   FLOAT_OVERLAP_EPS,
   FLOAT_PAGE_RIGHT_SLACK,
-  resolveFloatOverlap,
 } from './layout/floats.js';
 
 export {

--- a/packages/docx/src/float-line-start-one-inch.test.ts
+++ b/packages/docx/src/float-line-start-one-inch.test.ts
@@ -74,7 +74,7 @@ function leftBand(floatRightPx: number, floatBottomPx: number): FloatRect {
 function polygonFloat(
   authoredWrap: 'tight' | 'through',
   points: readonly Readonly<{ xPt: number; yPt: number }>[],
-  overrides: Partial<FloatRect> = {},
+  overrides: Partial<Extract<FloatRect, { kind: 'shape' }>> = {},
 ): FloatRect {
   const xs = points.map((point) => point.xPt);
   const ys = points.map((point) => point.yPt);

--- a/packages/docx/src/float-overlap-resolution.test.ts
+++ b/packages/docx/src/float-overlap-resolution.test.ts
@@ -1,73 +1,72 @@
 import { describe, expect, it } from 'vitest';
-import { rectsOverlap, resolveFloatOverlap } from './float-layout.js';
+import {
+  resolveFloatPlacement,
+  type FloatPlacementParticipant,
+} from './layout/floats.js';
 
-type Blocker = Readonly<{
-  kind: 'table';
-  xLeft: number;
-  xRight: number;
-  yTop: number;
-  yBottom: number;
-  paraId: number;
-}>;
+const table = (
+  occurrenceId: string,
+  xPt: number,
+  widthPt: number,
+  paragraphId: number,
+  tableOverlap: 'never' | 'overlap',
+): FloatPlacementParticipant => ({
+  kind: 'table',
+  tableOverlap,
+  occurrenceId,
+  paragraphId,
+  bounds: { xPt, yPt: 0, widthPt, heightPt: 1 },
+  exclusionBounds: { xPt, yPt: 0, widthPt, heightPt: 1 },
+});
 
-describe('resolveFloatOverlap convergence', () => {
+describe('typed float placement convergence', () => {
   it('clears every blocker in a finite registry larger than sixteen entries', () => {
-    const blockers: Blocker[] = Array.from({ length: 17 }, (_, index) => ({
-      kind: 'table',
-      xLeft: index * 1.1,
-      xRight: (index + 1) * 1.1,
-      yTop: 0,
-      yBottom: 1,
-      paraId: index,
-    }));
+    const blockers = Array.from({ length: 17 }, (_, index) =>
+      table(`blocker:${index}`, index * 1.1, 1.1, index, 'overlap'));
 
-    const resolved = resolveFloatOverlap(
-      0, 0, 1, 1,
-      0, 0, 0, 0,
-      100, false, 'table', 100,
+    const resolved = resolveFloatPlacement({
+      moving: table('moving', 0, 1, 100, 'never'),
       blockers,
-    );
+      avoidance: { kind: 'none' },
+      rightBoundaryPt: 100,
+      overlapEpsilonPt: 0.01,
+      rightBoundarySlackPt: 0.5,
+    });
 
-    expect(resolved.x).toBeCloseTo(18.7);
-    expect(blockers.some((blocker) => rectsOverlap(
-      resolved.x,
-      resolved.x + 1,
-      resolved.y,
-      resolved.y + 1,
-      blocker.xLeft,
-      blocker.xRight,
-      blocker.yTop,
-      blocker.yBottom,
-    ))).toBe(false);
+    expect(resolved.bounds.xPt).toBeCloseTo(18.7);
   });
 
-  it('snapshots accessor-backed legacy blockers before deterministic placement', () => {
+  it('snapshots accessor-backed participant geometry before deterministic placement', () => {
     let left = 0;
     let leftReads = 0;
-    let rightReads = 0;
-    const chasingBlocker = {
-      kind: 'table' as const,
-      get xLeft() {
-        leftReads += 1;
-        return left;
+    let widthReads = 0;
+    const blocker = table('blocker', 0, 1.1, 0, 'overlap');
+    const chasingBlocker: FloatPlacementParticipant = {
+      ...blocker,
+      bounds: {
+        get xPt() {
+          leftReads += 1;
+          return left;
+        },
+        yPt: 0,
+        get widthPt() {
+          widthReads += 1;
+          const width = 1.1;
+          left += width;
+          return width;
+        },
+        heightPt: 1,
       },
-      get xRight() {
-        rightReads += 1;
-        const right = left + 1.1;
-        left = right;
-        return right;
-      },
-      yTop: 0,
-      yBottom: 1,
-      paraId: 0,
     };
 
-    expect(resolveFloatOverlap(
-      0, 0, 1, 1,
-      0, 0, 0, 0,
-      100, false, 'table', 100,
-      [chasingBlocker],
-    )).toEqual({ x: 1.1, y: 0 });
-    expect({ leftReads, rightReads }).toEqual({ leftReads: 1, rightReads: 1 });
+    expect(resolveFloatPlacement({
+      moving: table('moving', 0, 1, 100, 'never'),
+      blockers: [chasingBlocker],
+      avoidance: { kind: 'none' },
+      rightBoundaryPt: 100,
+      overlapEpsilonPt: 0.01,
+      rightBoundarySlackPt: 0.5,
+    }).bounds).toMatchObject({ xPt: 1.1, yPt: 0 });
+    expect({ leftReads, widthReads }).toEqual({ leftReads: 1, widthReads: 1 });
   });
 });

--- a/packages/docx/src/float-table-geometry.test.ts
+++ b/packages/docx/src/float-table-geometry.test.ts
@@ -311,7 +311,8 @@ describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
     const st = makeState({
       floatParaSeq: 1,
       floats: [{
-        kind: 'table', mode: 'square', imageKey: '', imageX: 0, imageY: 300, imageW: 200, imageH: 60,
+        kind: 'table', tableOverlap: 'overlap', mode: 'square',
+        imageKey: '', imageX: 0, imageY: 300, imageW: 200, imageH: 60,
         xLeft: 0, xRight: 200, yTop: 300, yBottom: 360, side: 'bothSides',
         distLeft: 0, distRight: 0, distTop: 0, distBottom: 0, paraId: 0, drawn: true,
       }],
@@ -330,9 +331,55 @@ describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
     expect(f.xLeft).toBe(195);
   });
 
+  it('an overlap-permitted table clears a blocker-side tblOverlap=never fact', () => {
+    const blocker: FloatRect = {
+      kind: 'table',
+      tableOverlap: 'never',
+      mode: 'square',
+      imageKey: '',
+      imageX: 0,
+      imageY: 300,
+      imageW: 200,
+      imageH: 60,
+      xLeft: -5,
+      xRight: 207,
+      yTop: 296,
+      yBottom: 368,
+      side: 'bothSides',
+      distLeft: 5,
+      distRight: 7,
+      distTop: 4,
+      distBottom: 8,
+      paraId: 1,
+      drawn: true,
+    };
+    const st = makeState({ floatParaSeq: 1, floats: [blocker] });
+    const tp = tblp({
+      horzAnchor: 'page',
+      tblpX: 0,
+      vertAnchor: 'page',
+      tblpY: 320,
+      leftFromText: 3,
+      rightFromText: 9,
+    });
+    const resolved = computeFloatTableBox(
+      tp,
+      st as never,
+      0,
+      100,
+      20,
+      false,
+      { allowOverlap: true },
+    );
+
+    // Same paragraph ID disables the Word compatibility path. §17.4.56 still
+    // clears the blocker on its raw right edge (200), not its padded edge (207).
+    expect(resolved.x).toBe(200);
+  });
+
   it('appends a pre-resolved parent exactly after its retained child entry', () => {
     const child: FloatRect = {
-      kind: 'table', mode: 'square', imageKey: 'nested-child',
+      kind: 'table', tableOverlap: 'never', mode: 'square', imageKey: 'nested-child',
       imageX: 20, imageY: 30, imageW: 60, imageH: 20,
       xLeft: 20, xRight: 80, yTop: 30, yBottom: 50, side: 'bothSides',
       distLeft: 0, distRight: 0, distTop: 0, distBottom: 0,
@@ -370,11 +417,17 @@ describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
   describe('overlap="never" scopes to other floating tables only (§17.4.56)', () => {
     // A blocker occupying [0,200]×[300,360], anchored in another paragraph,
     // parameterized by kind so we can assert table-vs-non-table behavior.
-    const blocker = (kind: FloatRect['kind']): FloatRect => ({
-      kind, mode: 'square', imageKey: '', imageX: 0, imageY: 300, imageW: 200, imageH: 60,
+    const blocker = (kind: FloatRect['kind']): FloatRect => {
+      const core = {
+        mode: 'square' as const,
+        imageKey: '', imageX: 0, imageY: 300, imageW: 200, imageH: 60,
       xLeft: 0, xRight: 200, yTop: 300, yBottom: 360, side: 'bothSides',
       distLeft: 0, distRight: 0, distTop: 0, distBottom: 0, paraId: 0, drawn: true,
-    });
+      };
+      return kind === 'table'
+        ? { ...core, kind: 'table', tableOverlap: 'overlap' }
+        : { ...core, kind };
+    };
     // A never-overlap floating table seated at page-left x=0, overlapping [0,200].
     const seatNeverTable = (blockers: FloatRect[]): FloatRect => {
       const st = makeState({ floatParaSeq: 1, floats: blockers });
@@ -549,6 +602,7 @@ describe('retained floating table placement (§17.4.57)', () => {
     expect(() => validateFloatingTableRegistryDelta(delta, current)).not.toThrow();
     expect(delta.entries[0]).toMatchObject({
       occurrenceId: placement.occurrenceId,
+      overlap: 'never',
       paragraphId: 7,
       bounds: resolution.placement.bounds,
       exclusionBounds: resolution.placement.exclusionBounds,
@@ -557,6 +611,48 @@ describe('retained floating table placement (§17.4.57)', () => {
       ...current,
       nextParagraphId: 8,
     })).toThrow('base/domain mismatch');
+  });
+
+  it('retains blocker-side tblOverlap=never across point-space transactions', () => {
+    const placement = Object.freeze({
+      ...retainedFloatingPlacement(),
+      overlap: 'overlap' as const,
+      occurrenceId: 'moving-overlap-table',
+    });
+    const blockerBounds = Object.freeze({
+      xPt: 125,
+      yPt: 256,
+      widthPt: 80,
+      heightPt: 40,
+    });
+    const blocker = Object.freeze({
+      kind: 'table' as const,
+      overlap: 'never' as const,
+      occurrenceId: 'blocker-never-table',
+      paragraphId: 7,
+      bounds: blockerBounds,
+      exclusionBounds: Object.freeze({
+        xPt: 120,
+        yPt: 251,
+        widthPt: 90,
+        heightPt: 50,
+      }),
+    });
+
+    const resolution = resolveFloatingTablePlacementInTransaction(
+      placement,
+      retainedReferenceFrames,
+      beginFloatingTablePlacementTransaction([blocker], 7),
+    );
+
+    // Same paragraph ID prevents the Word compatibility rule from masking the
+    // normative blocker-side fact. Placement clears the raw edge at x=205,
+    // not the padded exclusion edge at x=210.
+    expect(resolution.placement.bounds.xPt).toBe(205);
+    expect(resolution.transaction.delta[0]).toMatchObject({
+      overlap: 'overlap',
+      paragraphId: 7,
+    });
   });
 
   it('re-resolves an upright nested float in a fresh physical-page domain', () => {

--- a/packages/docx/src/float-table-geometry.ts
+++ b/packages/docx/src/float-table-geometry.ts
@@ -14,7 +14,14 @@
 
 import type { TblpPr } from './types.js';
 import type { RenderState } from './renderer.js';
-import { resolveFloatOverlap } from './float-layout.js';
+import {
+  FLOAT_OVERLAP_EPS,
+  FLOAT_PAGE_RIGHT_SLACK,
+  floatRectParticipant,
+  floatingTableAvoidance,
+  resolveFloatPlacement,
+  type FloatPlacementParticipant,
+} from './layout/floats.js';
 import { resolvePointSpaceFloatingTableBoxPt } from './layout/floating-table-transaction.js';
 export {
   resolveFloatingTableBoxPt,
@@ -101,22 +108,34 @@ export function computeFloatTableBox(
     },
   }, tableW, tableH, skipVClamp);
   if (!overlapResolution || box.w <= 0 || box.h <= 0) return box;
-  const resolved = resolveFloatOverlap(
-    box.x,
-    box.y,
-    box.w,
-    box.h,
-    tp.leftFromText * sc,
-    tp.rightFromText * sc,
-    tp.topFromText * sc,
-    tp.bottomFromText * sc,
-    state.floatParaSeq,
-    overlapResolution.allowOverlap,
-    'table',
-    state.pageWidth * sc,
-    state.floats,
-  );
-  return { ...box, x: resolved.x, y: resolved.y };
+  const tableOverlap = overlapResolution.allowOverlap ? 'overlap' : 'never';
+  const moving: FloatPlacementParticipant = {
+    occurrenceId: 'display-moving-table',
+    kind: 'table',
+    tableOverlap,
+    paragraphId: state.floatParaSeq,
+    bounds: {
+      xPt: box.x,
+      yPt: box.y,
+      widthPt: box.w,
+      heightPt: box.h,
+    },
+    exclusionBounds: {
+      xPt: box.x - tp.leftFromText * sc,
+      yPt: box.y - tp.topFromText * sc,
+      widthPt: box.w + (tp.leftFromText + tp.rightFromText) * sc,
+      heightPt: box.h + (tp.topFromText + tp.bottomFromText) * sc,
+    },
+  };
+  const resolved = resolveFloatPlacement({
+    moving,
+    blockers: state.floats.map(floatRectParticipant),
+    avoidance: floatingTableAvoidance(tableOverlap, state.floatParaSeq),
+    rightBoundaryPt: state.pageWidth * sc,
+    overlapEpsilonPt: FLOAT_OVERLAP_EPS,
+    rightBoundarySlackPt: FLOAT_PAGE_RIGHT_SLACK,
+  });
+  return { ...box, x: resolved.bounds.xPt, y: resolved.bounds.yPt };
 }
 
 /**
@@ -156,9 +175,10 @@ export function registerTableFloat(
   // fixing the exclusion rect. allowOverlap=false (tblOverlap="never") forces
   // avoidance of OTHER FLOATING TABLES only — §17.4.56 scopes "never" to other
   // floating tables, NOT DrawingML anchors (§20.4.2.3) or text frames. The
-  // kind==='table' tag below makes resolveFloatOverlap limit blockers to tables.
+  // typed table participant makes resolveFloatPlacement limit normative
+  // blockers to tables and retain this fact for tables placed later.
   // allowOverlap=true only avoids OTHER paragraphs' floats (the implementation-
-  // defined scope documented on resolveFloatOverlap).
+  // defined scope named in compatibility.ts).
   pushFloatRect(state, {
     x: box.x,
     y: box.y,
@@ -166,13 +186,13 @@ export function registerTableFloat(
     h: box.h,
     dl, dr, dt, db,
     kind: 'table',
+    tableOverlap: allowOverlap ? 'overlap' : 'never',
     mode: 'square',
     side,
     imageKey: '', // non-image float: the table is painted by renderFloatTable.
     drawn: true, // painted by renderFloatTable; deferred image path must skip it.
     paraId,
     avoidOverlap: !preResolved,
-    allowOverlap,
   });
 }
 

--- a/packages/docx/src/frame-geometry.test.ts
+++ b/packages/docx/src/frame-geometry.test.ts
@@ -135,6 +135,54 @@ describe('legacy float transport facts', () => {
       avoidOverlap: true,
     })).toThrow('Floating-table transport omitted tblOverlap');
   });
+
+  it('keeps a displaced anchor wrap band within the page-right boundary', () => {
+    const st = makeState({
+      pageWidth: 100,
+      floats: [{
+        kind: 'frame',
+        mode: 'square',
+        imageKey: 'blocker',
+        imageX: 0,
+        imageY: 0,
+        imageW: 50,
+        imageH: 50,
+        xLeft: 0,
+        xRight: 50,
+        yTop: 0,
+        yBottom: 50,
+        side: 'bothSides',
+        distLeft: 0,
+        distRight: 0,
+        distTop: 0,
+        distBottom: 0,
+        paraId: 1,
+        drawn: true,
+      }],
+    });
+
+    const placed = pushFloatRect(st as never, {
+      x: 20,
+      y: 10,
+      w: 45,
+      h: 10,
+      dl: 0,
+      dr: 8,
+      dt: 0,
+      db: 0,
+      kind: 'shape',
+      mode: 'square',
+      side: 'bothSides',
+      imageKey: 'moving',
+      drawn: true,
+      paraId: 2,
+      allowOverlap: true,
+      avoidOverlap: true,
+    });
+
+    expect(placed).toMatchObject({ imageX: 20, imageY: 50 });
+    expect(placed.xRight).toBeLessThanOrEqual(100.5);
+  });
 });
 
 describe('frame geometry (§17.3.1.11) — wrap modes', () => {

--- a/packages/docx/src/frame-geometry.test.ts
+++ b/packages/docx/src/frame-geometry.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { computeFrameBox, registerFrameFloat } from './frame-geometry.js';
+import {
+  computeFrameBox,
+  pushFloatRect,
+  registerFrameFloat,
+} from './frame-geometry.js';
 import type { FrameBox } from './frame-geometry.js';
 import type { FramePr } from './types.js';
 import type { FloatRect } from './float-layout.js';
@@ -106,6 +110,30 @@ describe('frame geometry (§17.3.1.11) — drop cap placement', () => {
     expect(f.xRight).toBe(100 + 42 + 8);
     expect(f.yTop).toBe(200);
     expect(f.yBottom).toBe(200 + 42); // h=3×14, vSpace=0
+  });
+});
+
+describe('legacy float transport facts', () => {
+  it('fails closed when a floating-table transport omits tblOverlap', () => {
+    const st = makeState();
+
+    expect(() => pushFloatRect(st as never, {
+      x: 0,
+      y: 0,
+      w: 10,
+      h: 10,
+      dl: 0,
+      dr: 0,
+      dt: 0,
+      db: 0,
+      kind: 'table',
+      mode: 'square',
+      side: 'bothSides',
+      imageKey: '',
+      drawn: true,
+      paraId: 0,
+      avoidOverlap: true,
+    })).toThrow('Floating-table transport omitted tblOverlap');
   });
 });
 

--- a/packages/docx/src/frame-geometry.ts
+++ b/packages/docx/src/frame-geometry.ts
@@ -365,7 +365,7 @@ export function pushFloatRect(state: RenderState, o: PushFloatOpts): FloatRect {
     };
     const moving: FloatPlacementParticipant = o.kind === 'table'
       ? { ...core, kind: 'table', tableOverlap: o.tableOverlap! }
-      : { ...core, kind: 'drawingml' };
+      : { ...core, kind: o.kind === 'frame' ? 'frame' : 'drawingml' };
     const resolved = resolveFloatPlacement({
       moving,
       blockers: state.floats.map(floatRectParticipant),

--- a/packages/docx/src/frame-geometry.ts
+++ b/packages/docx/src/frame-geometry.ts
@@ -15,7 +15,16 @@
 
 import type { FramePr } from './types.js';
 import type { RenderState } from './renderer.js';
-import { type FloatRect, resolveFloatOverlap } from './float-layout.js';
+import type { FloatRect } from './float-layout.js';
+import {
+  FLOAT_OVERLAP_EPS,
+  FLOAT_PAGE_RIGHT_SLACK,
+  drawingMLAvoidance,
+  floatRectParticipant,
+  floatingTableAvoidance,
+  resolveFloatPlacement,
+  type FloatPlacementParticipant,
+} from './layout/floats.js';
 import type { FrameGeometryState } from './layout/types.js';
 
 /** Resolved geometry (canvas px) of a `<w:framePr>` text frame. Exported for
@@ -314,22 +323,17 @@ export interface PushFloatOpts {
   dr: number;
   dt: number;
   db: number;
-  /** What reserved this float — scopes overlap avoidance (§17.4.56). See
-   *  {@link FloatRect.kind}. */
-  kind: FloatRect['kind'];
   mode: 'square' | 'topAndBottom';
   side: string;
   imageKey: string;
   drawn: boolean;
   paraId: number;
-  /** Run §20.4.2.3 / §17.4.56 overlap avoidance before fixing the rect. When
-   *  false (frame floats) the box is used as-is. */
-  avoidOverlap: boolean;
-  /** allowOverlap arg passed to resolveFloatOverlap when avoidOverlap is true
-   *  (true ⇒ only avoid OTHER paragraphs' floats; false ⇒ spec-mandated
-   *  avoidance, scoped by `kind`: a table avoids only other tables, §17.4.56).
-   *  Ignored when avoidOverlap is false. */
+  kind: FloatRect['kind'];
+  /** Required at runtime for table entries; the resulting FloatRect and typed
+   * placement participant make the fact structurally mandatory. */
+  tableOverlap?: 'never' | 'overlap';
   allowOverlap?: boolean;
+  avoidOverlap: boolean;
 }
 
 /**
@@ -342,18 +346,40 @@ export interface PushFloatOpts {
  * re-seating). The returned ref lets the image path flip `drawn` after painting.
  */
 export function pushFloatRect(state: RenderState, o: PushFloatOpts): FloatRect {
+  if (o.kind === 'table' && o.tableOverlap === undefined) {
+    throw new Error('Floating-table transport omitted tblOverlap');
+  }
   let px = o.x;
   let py = o.y;
   if (o.avoidOverlap) {
-    const resolved = resolveFloatOverlap(
-      px, py, o.w, o.h, o.dl, o.dr, o.dt, o.db, o.paraId, o.allowOverlap ?? true,
-      o.kind, state.pageWidth * state.scale, state.floats,
-    );
-    px = resolved.x;
-    py = resolved.y;
+    const core = {
+      occurrenceId: 'display-moving-float',
+      paragraphId: o.paraId,
+      bounds: { xPt: px, yPt: py, widthPt: o.w, heightPt: o.h },
+      exclusionBounds: {
+        xPt: px - o.dl,
+        yPt: py - o.dt,
+        widthPt: o.w + o.dl + o.dr,
+        heightPt: o.h + o.dt + o.db,
+      },
+    };
+    const moving: FloatPlacementParticipant = o.kind === 'table'
+      ? { ...core, kind: 'table', tableOverlap: o.tableOverlap! }
+      : { ...core, kind: 'drawingml' };
+    const resolved = resolveFloatPlacement({
+      moving,
+      blockers: state.floats.map(floatRectParticipant),
+      avoidance: o.kind === 'table'
+        ? floatingTableAvoidance(o.tableOverlap!, o.paraId)
+        : drawingMLAvoidance(o.allowOverlap ?? true, o.paraId),
+      rightBoundaryPt: state.pageWidth * state.scale,
+      overlapEpsilonPt: FLOAT_OVERLAP_EPS,
+      rightBoundarySlackPt: FLOAT_PAGE_RIGHT_SLACK,
+    });
+    px = resolved.bounds.xPt;
+    py = resolved.bounds.yPt;
   }
-  const rect: FloatRect = {
-    kind: o.kind,
+  const core = {
     mode: o.mode,
     imageKey: o.imageKey,
     imageX: px,
@@ -372,6 +398,9 @@ export function pushFloatRect(state: RenderState, o: PushFloatOpts): FloatRect {
     paraId: o.paraId,
     drawn: o.drawn,
   };
+  const rect: FloatRect = o.kind === 'table'
+    ? { ...core, kind: 'table', tableOverlap: o.tableOverlap! }
+    : { ...core, kind: o.kind };
   state.floats.push(rect);
   return rect;
 }

--- a/packages/docx/src/layout/body-paginator.ts
+++ b/packages/docx/src/layout/body-paginator.ts
@@ -104,6 +104,10 @@ import {
   translateStoryLayout,
 } from './stories.js';
 import { LayoutInvariantError } from './diagnostics.js';
+import {
+  ExactConvergenceError,
+  convergeExactState,
+} from './convergence.js';
 
 class FootnoteAdmissionOverflowError extends Error {
   readonly code = 'FOOTNOTE_RESERVE_EXCEEDS_FRESH_PAGE' as const;
@@ -1923,19 +1927,41 @@ function paginateBodyWithAnchorConvergence(
     && entry.block.kind === 'paragraph'
     && (entry.block.pageOwnedAnchorOccurrenceIds?.length ?? 0) > 0
   ));
-  let plan: ReturnType<typeof pageAnchorDestinationPlan> | null = null;
-  const seen = new Set<string>();
-  while (true) {
-    const pass = paginateBodyPass(input, services, options, reserves, plan, balancePlan);
-    const nextPlan = pageAnchorDestinationPlan(pass.layout);
-    if (!hasPageOwnedAnchors) return pass;
-    const nextIdentity = anchorPlanIdentity(nextPlan);
-    if (plan !== null && nextIdentity === anchorPlanIdentity(plan)) return pass;
-    if (seen.has(nextIdentity)) {
-      throw new Error('Page-anchor destination acquisition did not converge');
+  if (!hasPageOwnedAnchors) {
+    return paginateBodyPass(input, services, options, reserves, null, balancePlan);
+  }
+  try {
+    return convergeExactState({
+      step: (previous: Readonly<{
+        pass: ReturnType<typeof paginateBodyPass>;
+        plan: ReturnType<typeof pageAnchorDestinationPlan>;
+      }> | null) => {
+        const pass = paginateBodyPass(
+          input,
+          services,
+          options,
+          reserves,
+          previous?.plan ?? null,
+          balancePlan,
+        );
+        return Object.freeze({
+          pass,
+          plan: pageAnchorDestinationPlan(pass.layout),
+        });
+      },
+      stateOf: (value) => anchorPlanIdentity(value.plan),
+      limit: 16,
+    }).value.pass;
+  } catch (error) {
+    if (error instanceof ExactConvergenceError) {
+      throw new LayoutInvariantError(
+        'NON_CONVERGENCE',
+        error.reason === 'cycle'
+          ? 'Page-anchor destination acquisition repeated an exact-state cycle'
+          : 'Page-anchor destination acquisition reached the operational pass limit 16',
+      );
     }
-    seen.add(nextIdentity);
-    plan = nextPlan;
+    throw error;
   }
 }
 

--- a/packages/docx/src/layout/compatibility.test.ts
+++ b/packages/docx/src/layout/compatibility.test.ts
@@ -3,6 +3,7 @@ import {
   defineCompatibilityRule,
   LINE_START_GAP_EPS_PT,
   WORD_FLOAT_DIFFERENT_PARAGRAPH_DISPLACEMENT,
+  WORD_PAGE_ANCHORED_TABLE_COLLISION_DEFERRAL,
   WORD_MIN_LINE_START_PT,
   WORD_SQUARE_LINE_START_ONE_INCH,
   WORD_SECTION_BTLR_TBRL_PAGE_FRAME,
@@ -110,6 +111,13 @@ describe('float compatibility evidence', () => {
   it('names the established different-paragraph displacement policy', () => {
     expect(WORD_FLOAT_DIFFERENT_PARAGRAPH_DISPLACEMENT).toMatchObject({
       id: 'word-float-different-paragraph-displacement',
+      evidence: { kind: 'regression-test' },
+    });
+  });
+
+  it('names absolute floating-table collision deferral as compatibility behavior', () => {
+    expect(WORD_PAGE_ANCHORED_TABLE_COLLISION_DEFERRAL).toMatchObject({
+      id: 'word-page-anchored-table-collision-deferral',
       evidence: { kind: 'regression-test' },
     });
   });

--- a/packages/docx/src/layout/compatibility.ts
+++ b/packages/docx/src/layout/compatibility.ts
@@ -47,6 +47,15 @@ export const WORD_FLOAT_DIFFERENT_PARAGRAPH_DISPLACEMENT = defineCompatibilityRu
   description: 'Preserve the established Word-compatible policy that an overlap-permitted float is displaced by exclusion geometry from floats anchored in other paragraphs, while same-paragraph floats may overlap.',
 });
 
+export const WORD_PAGE_ANCHORED_TABLE_COLLISION_DEFERRAL = defineCompatibilityRule({
+  id: 'word-page-anchored-table-collision-deferral',
+  evidence: {
+    kind: 'regression-test',
+    reference: 'packages/docx/src/float-table-page-fit.test.ts#(g) DEFERS a page-anchored floating table when its raw band intersects an existing table float',
+  },
+  description: 'Preserve the established Word-compatible pagination behavior that defers an absolute page- or margin-anchored floating table when its authored object band intersects an existing floating-table text-exclusion band on the page.',
+});
+
 /** Word compatibility width from issue #676, in points. ECMA-376
  * §20.4.2.17 defines square wrapping but no minimum side-gap width. */
 export const WORD_MIN_LINE_START_PT = 72;

--- a/packages/docx/src/layout/float-wrap.ts
+++ b/packages/docx/src/layout/float-wrap.ts
@@ -88,11 +88,10 @@ function exactBinary64Midpoint(left: number, right: number): number {
  * xLeft/xRight/yTop/yBottom are its padded acquisition bounds, not a replacement
  * rectangle for polygon line queries.
  */
-export interface FloatRect {
+interface FloatRectCore {
   /** Transitional registry kind projected into the typed displacement policy
    * in floats.ts. `shape` = DrawingML wp:anchor; `table` = floating table;
    * `frame` = <w:framePr> text frame. */
-  kind: 'table' | 'shape' | 'frame';
   mode: 'square' | 'topAndBottom';
   /** Exact retained wrap semantics; `mode` remains the coarse legacy routing key. */
   authoredWrap?: 'square' | 'tight' | 'through' | 'topAndBottom';
@@ -127,6 +126,19 @@ export interface FloatRect {
   /** true once the image itself has been drawn (drawn after its paragraph lays out). */
   drawn: boolean;
 }
+
+export type FloatRect =
+  | (FloatRectCore & {
+      kind: 'table';
+      /** Required §17.4.56 fact retained for tables placed later. */
+      tableOverlap: 'never' | 'overlap';
+    })
+  | (FloatRectCore & {
+      kind: 'shape';
+    })
+  | (FloatRectCore & {
+      kind: 'frame';
+    });
 
 export type WrapSide = 'bothSides' | 'left' | 'right' | 'largest';
 

--- a/packages/docx/src/layout/floating-table-transaction.ts
+++ b/packages/docx/src/layout/floating-table-transaction.ts
@@ -1,6 +1,8 @@
 import {
   FLOAT_OVERLAP_EPS,
   FLOAT_PAGE_RIGHT_SLACK,
+  floatRegistryParticipant,
+  floatingTableAvoidance,
   resolveFloatPlacement,
   type FloatPlacementParticipant,
 } from './floats.js';
@@ -128,16 +130,6 @@ export function resolveFloatingTablePlacement(
   );
 }
 
-function registryParticipant(entry: FloatRegistryEntryPt): FloatPlacementParticipant {
-  return {
-    occurrenceId: entry.occurrenceId,
-    kind: entry.kind === 'shape' ? 'drawingml' : entry.kind,
-    paragraphId: entry.paragraphId,
-    bounds: entry.bounds,
-    exclusionBounds: entry.exclusionBounds,
-  };
-}
-
 export function floatingTableRegistryDelta(
   snapshot: FloatRegistrySnapshotPt,
   entries: readonly FloatRegistryEntryPt[],
@@ -223,6 +215,7 @@ export function resolveFloatingTablePlacementInTransaction(
   const participant: FloatPlacementParticipant = {
     occurrenceId: placement.occurrenceId,
     kind: 'table',
+    tableOverlap: placement.overlap,
     paragraphId: transaction.nextParagraphId,
     bounds: initial.bounds,
     exclusionBounds: initial.exclusionBounds,
@@ -231,13 +224,11 @@ export function resolveFloatingTablePlacementInTransaction(
     moving: participant,
     blockers: registry
       .filter((entry) => entry.kind !== 'shape' || entry.wrap !== undefined)
-      .map(registryParticipant),
-    avoidance: placement.overlap === 'never'
-      ? { kind: 'floating-table-never' }
-      : {
-          kind: 'word-different-paragraph',
-          paragraphId: transaction.nextParagraphId,
-        },
+      .map(floatRegistryParticipant),
+    avoidance: floatingTableAvoidance(
+      placement.overlap,
+      transaction.nextParagraphId,
+    ),
     rightBoundaryPt: endX(frames.page),
     // Preserve the numeric policy used by the former scalar adapter. This is
     // especially important at an authored page edge, where sub-twip rounding
@@ -253,6 +244,7 @@ export function resolveFloatingTablePlacementInTransaction(
   const entry = Object.freeze({
     kind: 'table' as const,
     occurrenceId: placement.occurrenceId,
+    overlap: placement.overlap,
     paragraphId: transaction.nextParagraphId,
     bounds: finalPlacement.bounds,
     exclusionBounds: finalPlacement.exclusionBounds,

--- a/packages/docx/src/layout/floats.test.ts
+++ b/packages/docx/src/layout/floats.test.ts
@@ -78,6 +78,22 @@ describe('float displacement policy', () => {
     expect(result.appliedCompatibilityRuleIds).toEqual([]);
   });
 
+  it('does not attribute pairwise table displacement to the Word compatibility rule', () => {
+    const moving = participant('moving', 'table', 0, 2, 0, 'overlap');
+    const result = resolveFloatPlacement({
+      moving,
+      blockers: [participant('blocker', 'table', 0, 1, 0, 'never')],
+      avoidance: {
+        kind: 'word-different-paragraph',
+        paragraphId: moving.paragraphId,
+      },
+      rightBoundaryPt: 100,
+    });
+
+    expect(result.bounds.xPt).toBe(10);
+    expect(result.appliedCompatibilityRuleIds).toEqual([]);
+  });
+
   it('enforces tblOverlap=never in both source orders on raw bounds', () => {
     const place = (
       movingOverlap: 'never' | 'overlap',
@@ -141,6 +157,67 @@ describe('float displacement policy', () => {
     expect(result.appliedCompatibilityRuleIds).toEqual([
       'word-float-different-paragraph-displacement',
     ]);
+  });
+
+  it('keeps the compatibility exclusion band within the right boundary and slack', () => {
+    const moving: FloatPlacementParticipant = Object.freeze({
+      occurrenceId: 'moving',
+      kind: 'table',
+      tableOverlap: 'overlap',
+      paragraphId: 2,
+      bounds: Object.freeze({
+        xPt: 20,
+        yPt: 10,
+        widthPt: 45,
+        heightPt: 10,
+      }),
+      exclusionBounds: Object.freeze({
+        xPt: 20,
+        yPt: 10,
+        widthPt: 53,
+        heightPt: 10,
+      }),
+    });
+    const blocker: FloatPlacementParticipant = Object.freeze({
+      occurrenceId: 'blocker',
+      kind: 'frame',
+      paragraphId: 1,
+      bounds: Object.freeze({
+        xPt: 0,
+        yPt: 0,
+        widthPt: 50,
+        heightPt: 50,
+      }),
+      exclusionBounds: Object.freeze({
+        xPt: 0,
+        yPt: 0,
+        widthPt: 50,
+        heightPt: 50,
+      }),
+    });
+    const place = (rightBoundaryPt: number) => resolveFloatPlacement({
+      moving,
+      blockers: [blocker],
+      avoidance: {
+        kind: 'word-different-paragraph',
+        paragraphId: moving.paragraphId,
+      },
+      rightBoundaryPt,
+      overlapEpsilonPt: 0.01,
+      rightBoundarySlackPt: 0.5,
+    });
+
+    const constrained = place(100);
+    expect(constrained.bounds).toMatchObject({ xPt: 20, yPt: 50 });
+    expect(constrained.exclusionBounds.xPt + constrained.exclusionBounds.widthPt)
+      .toBeLessThanOrEqual(100.5);
+    expect(constrained.appliedCompatibilityRuleIds).toEqual([
+      'word-float-different-paragraph-displacement',
+    ]);
+
+    expect(place(110).bounds).toMatchObject({ xPt: 50, yPt: 10 });
+    expect(place(102.5).bounds).toMatchObject({ xPt: 50, yPt: 10 });
+    expect(place(102.48).bounds).toMatchObject({ xPt: 20, yPt: 50 });
   });
 
   it('reports a Word compatibility rule only when it changes placement', () => {

--- a/packages/docx/src/layout/floats.test.ts
+++ b/packages/docx/src/layout/floats.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  resolveBlockFlowAdmission,
   resolveFloatPlacement,
+  resolvePageAnchoredTableDeferral,
   type FloatPlacementParticipant,
 } from './floats.js';
 
@@ -10,6 +12,7 @@ const participant = (
   xPt: number,
   paragraphId: number,
   exclusionPaddingPt = 0,
+  tableOverlap: 'never' | 'overlap' = 'overlap',
 ): FloatPlacementParticipant => Object.freeze({
   occurrenceId,
   kind,
@@ -21,7 +24,8 @@ const participant = (
     widthPt: 10 + exclusionPaddingPt * 2,
     heightPt: 10 + exclusionPaddingPt * 2,
   }),
-});
+  ...(kind === 'table' ? { tableOverlap } : {}),
+}) as FloatPlacementParticipant;
 
 describe('float displacement policy', () => {
   it('applies DrawingML allowOverlap=false only against DrawingML object bounds', () => {
@@ -43,17 +47,50 @@ describe('float displacement policy', () => {
   });
 
   it('applies tblOverlap=never to raw floating-table extents, not text padding', () => {
-    const moving = participant('moving', 'table', 0, 2, 3);
-    const blocker = participant('blocker', 'table', 0, 1, 4);
+    const moving = participant('moving', 'table', 0, 2, 3, 'never');
+    const blocker = participant('blocker', 'table', 0, 1, 4, 'overlap');
     const result = resolveFloatPlacement({
       moving,
       blockers: [blocker],
-      avoidance: { kind: 'floating-table-never' },
+      avoidance: { kind: 'none' },
       rightBoundaryPt: 100,
     });
 
     expect(result.bounds.xPt).toBe(10);
     expect(result.exclusionBounds.xPt).toBe(7);
+  });
+
+  it('enforces blocker-side tblOverlap=never even within the same paragraph', () => {
+    const moving = participant('moving', 'table', 0, 2, 3, 'overlap');
+    const blocker = participant('blocker', 'table', 0, 2, 4, 'never');
+    const result = resolveFloatPlacement({
+      moving,
+      blockers: [blocker],
+      avoidance: {
+        kind: 'word-different-paragraph',
+        paragraphId: moving.paragraphId,
+      },
+      rightBoundaryPt: 100,
+    });
+
+    expect(result.bounds.xPt).toBe(10);
+    expect(result.exclusionBounds.xPt).toBe(7);
+    expect(result.appliedCompatibilityRuleIds).toEqual([]);
+  });
+
+  it('enforces tblOverlap=never in both source orders on raw bounds', () => {
+    const place = (
+      movingOverlap: 'never' | 'overlap',
+      blockerOverlap: 'never' | 'overlap',
+    ) => resolveFloatPlacement({
+      moving: participant('moving', 'table', 0, 2, 3, movingOverlap),
+      blockers: [participant('blocker', 'table', 0, 1, 4, blockerOverlap)],
+      avoidance: { kind: 'none' } as const,
+      rightBoundaryPt: 100,
+    });
+
+    expect(place('never', 'overlap').bounds.xPt).toBe(10);
+    expect(place('overlap', 'never').bounds.xPt).toBe(10);
   });
 
   it('uses the supplied page or cell right boundary before moving down', () => {
@@ -150,5 +187,73 @@ describe('float displacement policy', () => {
     expect(result.bounds).toBe(moving.bounds);
     expect(result.exclusionBounds).toBe(moving.exclusionBounds);
     expect(result.displacement).toEqual({ xPt: 0, yPt: 0 });
+  });
+});
+
+describe('block flow admission around floating-table exclusions', () => {
+  const table = (
+    occurrenceId: string,
+    yPt: number,
+    heightPt: number,
+  ): FloatPlacementParticipant => Object.freeze({
+    occurrenceId,
+    kind: 'table',
+    tableOverlap: 'overlap',
+    paragraphId: 0,
+    bounds: Object.freeze({ xPt: 0, yPt, widthPt: 20, heightPt }),
+    exclusionBounds: Object.freeze({ xPt: 0, yPt, widthPt: 20, heightPt }),
+  });
+
+  const admit = (blockers: readonly FloatPlacementParticipant[]) =>
+    resolveBlockFlowAdmission({
+      inlineStartPt: 0,
+      inlineEndPt: 20,
+      blockStartPt: 0,
+      blockExtentPt: 10,
+      blockers,
+      overlapEpsilonPt: 0.01,
+    }).blockStartPt;
+
+  it('follows a finite chain of newly intersecting exclusion bands', () => {
+    expect(admit([
+      table('first', 0, 10),
+      table('second', 12, 18),
+    ])).toBe(30);
+  });
+
+  it('is independent of blocker order and does not jump to an unreachable band', () => {
+    const first = table('first', 0, 10);
+    const second = table('second', 12, 18);
+    const unreachable = table('unreachable', 100, 100);
+
+    expect(admit([first, second, unreachable])).toBe(30);
+    expect(admit([unreachable, second, first])).toBe(30);
+  });
+
+  it('treats an edge overlap within the supplied epsilon as clear', () => {
+    expect(admit([table('touching', -10.005, 10)])).toBe(0);
+  });
+});
+
+describe('page-anchored floating-table compatibility admission', () => {
+  it('defers on the existing table text-exclusion band and reports the rule', () => {
+    const blocker = Object.freeze({
+      ...participant('blocker', 'table', 20, 1, 5, 'overlap'),
+      bounds: Object.freeze({ xPt: 20, yPt: 0, widthPt: 10, heightPt: 10 }),
+      exclusionBounds: Object.freeze({ xPt: 15, yPt: -5, widthPt: 20, heightPt: 20 }),
+    }) as FloatPlacementParticipant;
+    const result = resolvePageAnchoredTableDeferral({
+      // Raw table extents do not overlap; only the blocker exclusion does.
+      bounds: { xPt: 10, yPt: 0, widthPt: 6, heightPt: 10 },
+      blockers: [blocker],
+      overlapEpsilonPt: 0.01,
+    });
+
+    expect(result).toEqual({
+      defer: true,
+      appliedCompatibilityRuleIds: [
+        'word-page-anchored-table-collision-deferral',
+      ],
+    });
   });
 });

--- a/packages/docx/src/layout/floats.ts
+++ b/packages/docx/src/layout/floats.ts
@@ -216,6 +216,7 @@ function compatibilityBlockerInObjectSpace(
 function resolveObjectPosition(
   input: ResolveFloatPlacementInput,
   blockers: readonly AxisAlignedRect[],
+  rightBoundaryPt = input.rightBoundaryPt,
 ): Readonly<{ left: number; top: number }> {
   const movingRect = axisRect(input.moving.bounds);
   if (blockers.length === 0) {
@@ -223,7 +224,7 @@ function resolveObjectPosition(
   }
   return resolveAxisAlignedOverlap(movingRect, blockers, {
     overlapEpsilon: input.overlapEpsilonPt ?? 0,
-    rightBoundary: input.rightBoundaryPt,
+    rightBoundary: rightBoundaryPt,
     rightBoundarySlack: input.rightBoundarySlackPt ?? 0,
   });
 }
@@ -258,11 +259,29 @@ export function resolveFloatPlacement(
           ? []
           : [compatibilityBlockerInObjectSpace(moving, blocker)])
     : [];
-  const normative = resolveObjectPosition(input, normativeBlockers);
-  const resolved = resolveObjectPosition(
+  const movingRightPaddingPt = moving.exclusionBounds.xPt
+    + moving.exclusionBounds.widthPt
+    - moving.bounds.xPt
+    - moving.bounds.widthPt;
+  // Compatibility displacement historically resolved the moving exclusion
+  // rectangle. Its right edge, not only the object edge, must fit within the
+  // caller's boundary and slack after converting the collision into object
+  // space.
+  const rightBoundaryPt = avoidance.kind === 'word-different-paragraph'
+    ? input.rightBoundaryPt - movingRightPaddingPt
+    : input.rightBoundaryPt;
+  const normative = resolveObjectPosition(
     input,
-    [...normativeBlockers, ...compatibilityBlockers],
+    normativeBlockers,
+    rightBoundaryPt,
   );
+  const resolved = compatibilityBlockers.length === 0
+    ? normative
+    : resolveObjectPosition(
+        input,
+        [...normativeBlockers, ...compatibilityBlockers],
+        rightBoundaryPt,
+      );
   const xPt = resolved.left - moving.bounds.xPt;
   const yPt = resolved.top - moving.bounds.yPt;
   const compatibilityChangedPlacement = resolved.left !== normative.left

--- a/packages/docx/src/layout/floats.ts
+++ b/packages/docx/src/layout/floats.ts
@@ -1,11 +1,14 @@
 import {
   WORD_FLOAT_DIFFERENT_PARAGRAPH_DISPLACEMENT,
+  WORD_PAGE_ANCHORED_TABLE_COLLISION_DEFERRAL,
 } from './compatibility.js';
 import {
+  axisAlignedRectsOverlap,
   resolveAxisAlignedOverlap,
   type AxisAlignedRect,
 } from './axis-aligned-overlap.js';
-import type { LayoutRect } from './types.js';
+import type { FloatRegistryEntryPt, LayoutRect } from './types.js';
+import type { FloatRect } from './float-wrap.js';
 
 /** Numerical tolerances retained by callers while C1b removes the temporary
  * scalar registry. Point-space table transactions also used these exact values
@@ -13,24 +16,117 @@ import type { LayoutRect } from './types.js';
 export const FLOAT_OVERLAP_EPS = 0.01;
 export const FLOAT_PAGE_RIGHT_SLACK = 0.5;
 
-export type FloatPlacementKind = 'drawingml' | 'table' | 'frame';
-
 /** Immutable object and text-exclusion geometry in one caller-selected
  * coordinate space. Normative object collisions use `bounds`; Word-compatible
  * text-wrap displacement uses `exclusionBounds`. */
-export interface FloatPlacementParticipant {
+interface FloatPlacementParticipantCore {
   readonly occurrenceId: string;
-  readonly kind: FloatPlacementKind;
   readonly paragraphId: number;
   readonly bounds: LayoutRect;
   readonly exclusionBounds: LayoutRect;
 }
 
+export type FloatPlacementParticipant =
+  | Readonly<FloatPlacementParticipantCore & {
+      readonly kind: 'table';
+      /** ECMA-376 Part 1 §17.4.56. Required so blocker-side `never`
+       * cannot silently become overlap-permitted. */
+      readonly tableOverlap: 'never' | 'overlap';
+    }>
+  | Readonly<FloatPlacementParticipantCore & {
+      readonly kind: 'drawingml';
+    }>
+  | Readonly<FloatPlacementParticipantCore & {
+      readonly kind: 'frame';
+    }>;
+
 export type FloatAvoidance =
   | Readonly<{ kind: 'drawingml-normative' }>
-  | Readonly<{ kind: 'floating-table-never' }>
   | Readonly<{ kind: 'word-different-paragraph'; paragraphId: number }>
   | Readonly<{ kind: 'none' }>;
+
+export function floatingTableAvoidance(
+  tableOverlap: 'never' | 'overlap',
+  paragraphId: number,
+): FloatAvoidance {
+  return tableOverlap === 'overlap'
+    ? Object.freeze({ kind: 'word-different-paragraph', paragraphId })
+    : Object.freeze({ kind: 'none' });
+}
+
+export function drawingMLAvoidance(
+  allowOverlap: boolean,
+  paragraphId: number,
+): FloatAvoidance {
+  return allowOverlap
+    ? Object.freeze({ kind: 'word-different-paragraph', paragraphId })
+    : Object.freeze({ kind: 'drawingml-normative' });
+}
+
+export function floatRegistryParticipant(
+  entry: FloatRegistryEntryPt,
+): FloatPlacementParticipant {
+  const core = {
+    occurrenceId: entry.occurrenceId,
+    paragraphId: entry.paragraphId,
+    bounds: entry.bounds,
+    exclusionBounds: entry.exclusionBounds,
+  };
+  if (entry.kind === 'table') {
+    return {
+      ...core,
+      kind: 'table',
+      tableOverlap: entry.overlap,
+    };
+  }
+  return {
+    ...core,
+    kind: entry.kind === 'shape' ? 'drawingml' : 'frame',
+  };
+}
+
+export function floatRectParticipant(
+  float: FloatRect,
+  index: number,
+): FloatPlacementParticipant {
+  const imageX = float.imageX;
+  const imageY = float.imageY;
+  const imageW = float.imageW;
+  const imageH = float.imageH;
+  const xLeft = float.xLeft;
+  const xRight = float.xRight;
+  const yTop = float.yTop;
+  const yBottom = float.yBottom;
+  const core = {
+    occurrenceId: float.anchorOccurrenceId
+      ?? float.acquisitionOccurrenceId
+      ?? `display-float:${index}`,
+    paragraphId: float.paraId,
+    bounds: {
+      xPt: imageX,
+      yPt: imageY,
+      widthPt: imageW,
+      heightPt: imageH,
+    },
+    exclusionBounds: {
+      xPt: xLeft,
+      yPt: yTop,
+      widthPt: xRight - xLeft,
+      heightPt: yBottom - yTop,
+    },
+  };
+  if (float.kind === 'table') {
+    return {
+      ...core,
+      kind: 'table',
+      tableOverlap: float.tableOverlap,
+    };
+  }
+  return {
+    ...core,
+    kind: float.kind === 'shape' ? 'drawingml' : 'frame',
+  };
+}
 
 export interface FloatPlacement {
   readonly bounds: LayoutRect;
@@ -51,11 +147,15 @@ export interface ResolveFloatPlacementInput {
 }
 
 function axisRect(rect: LayoutRect): AxisAlignedRect {
+  const xPt = rect.xPt;
+  const yPt = rect.yPt;
+  const widthPt = rect.widthPt;
+  const heightPt = rect.heightPt;
   return {
-    left: rect.xPt,
-    right: rect.xPt + rect.widthPt,
-    top: rect.yPt,
-    bottom: rect.yPt + rect.heightPt,
+    left: xPt,
+    right: xPt + widthPt,
+    top: yPt,
+    bottom: yPt + heightPt,
   };
 }
 
@@ -87,6 +187,47 @@ function placement(
   });
 }
 
+function compatibilityBlockerInObjectSpace(
+  moving: FloatPlacementParticipant,
+  blocker: FloatPlacementParticipant,
+): AxisAlignedRect {
+  const movingLeftPadding = moving.bounds.xPt - moving.exclusionBounds.xPt;
+  const movingTopPadding = moving.bounds.yPt - moving.exclusionBounds.yPt;
+  const movingRightPadding = moving.exclusionBounds.xPt
+    + moving.exclusionBounds.widthPt
+    - moving.bounds.xPt
+    - moving.bounds.widthPt;
+  const movingBottomPadding = moving.exclusionBounds.yPt
+    + moving.exclusionBounds.heightPt
+    - moving.bounds.yPt
+    - moving.bounds.heightPt;
+  const blockerExclusion = axisRect(blocker.exclusionBounds);
+  // Rigid-translation identity:
+  // overlap(movingExclusion + d, blockerExclusion)
+  //   === overlap(movingObject + d, this inflated blocker).
+  return {
+    left: blockerExclusion.left - movingRightPadding,
+    right: blockerExclusion.right + movingLeftPadding,
+    top: blockerExclusion.top - movingBottomPadding,
+    bottom: blockerExclusion.bottom + movingTopPadding,
+  };
+}
+
+function resolveObjectPosition(
+  input: ResolveFloatPlacementInput,
+  blockers: readonly AxisAlignedRect[],
+): Readonly<{ left: number; top: number }> {
+  const movingRect = axisRect(input.moving.bounds);
+  if (blockers.length === 0) {
+    return Object.freeze({ left: movingRect.left, top: movingRect.top });
+  }
+  return resolveAxisAlignedOverlap(movingRect, blockers, {
+    overlapEpsilon: input.overlapEpsilonPt ?? 0,
+    rightBoundary: input.rightBoundaryPt,
+    rightBoundarySlack: input.rightBoundarySlackPt ?? 0,
+  });
+}
+
 /**
  * Resolve only float-to-float displacement policy.
  *
@@ -100,130 +241,110 @@ export function resolveFloatPlacement(
   input: ResolveFloatPlacementInput,
 ): FloatPlacement {
   const { moving, avoidance } = input;
-  if (avoidance.kind === 'none') return placement(moving, 0, 0, []);
-
-  const compatibility = avoidance.kind === 'word-different-paragraph';
-  const movingRect = compatibility ? moving.exclusionBounds : moving.bounds;
-  const eligible = input.blockers.filter((blocker) => {
-    if (avoidance.kind === 'drawingml-normative') {
-      return blocker.kind === 'drawingml';
+  const normativeBlockers = input.blockers.flatMap((blocker): AxisAlignedRect[] => {
+    if (moving.kind === 'table'
+      && blocker.kind === 'table'
+      && (moving.tableOverlap === 'never' || blocker.tableOverlap === 'never')) {
+      return [axisRect(blocker.bounds)];
     }
-    if (avoidance.kind === 'floating-table-never') {
-      return blocker.kind === 'table';
+    if (avoidance.kind === 'drawingml-normative' && blocker.kind === 'drawingml') {
+      return [axisRect(blocker.bounds)];
     }
-    return blocker.paragraphId !== avoidance.paragraphId;
+    return [];
   });
-  if (eligible.length === 0) {
-    return placement(moving, 0, 0, []);
-  }
-  const resolved = resolveAxisAlignedOverlap(
-    axisRect(movingRect),
-    eligible.map((blocker) => axisRect(
-      compatibility ? blocker.exclusionBounds : blocker.bounds,
-    )),
-    {
-      overlapEpsilon: input.overlapEpsilonPt ?? 0,
-      rightBoundary: input.rightBoundaryPt,
-      rightBoundarySlack: input.rightBoundarySlackPt ?? 0,
-    },
+  const compatibilityBlockers = avoidance.kind === 'word-different-paragraph'
+    ? input.blockers.flatMap((blocker): AxisAlignedRect[] =>
+        blocker.paragraphId === avoidance.paragraphId
+          ? []
+          : [compatibilityBlockerInObjectSpace(moving, blocker)])
+    : [];
+  const normative = resolveObjectPosition(input, normativeBlockers);
+  const resolved = resolveObjectPosition(
+    input,
+    [...normativeBlockers, ...compatibilityBlockers],
   );
-  const xPt = resolved.left - movingRect.xPt;
-  const yPt = resolved.top - movingRect.yPt;
-  return placement(moving, xPt, yPt, compatibility && (xPt !== 0 || yPt !== 0)
+  const xPt = resolved.left - moving.bounds.xPt;
+  const yPt = resolved.top - moving.bounds.yPt;
+  const compatibilityChangedPlacement = resolved.left !== normative.left
+    || resolved.top !== normative.top;
+  return placement(moving, xPt, yPt, compatibilityChangedPlacement
     ? [WORD_FLOAT_DIFFERENT_PARAGRAPH_DISPLACEMENT.id]
     : []);
 }
 
-interface ScalarFloatParticipant {
-  readonly kind: 'table' | 'shape' | 'frame';
-  readonly xLeft: number;
-  readonly xRight: number;
-  readonly yTop: number;
-  readonly yBottom: number;
-  readonly paraId: number;
-  readonly imageX?: number;
-  readonly imageY?: number;
-  readonly imageW?: number;
-  readonly imageH?: number;
-}
-
-function scalarParticipant(
-  float: ScalarFloatParticipant,
-  index: number,
-): FloatPlacementParticipant {
-  const xLeft = float.xLeft;
-  const xRight = float.xRight;
-  const yTop = float.yTop;
-  const yBottom = float.yBottom;
-  const hasObjectBounds = [
-    float.imageX, float.imageY, float.imageW, float.imageH,
-  ].every((value) => typeof value === 'number' && Number.isFinite(value));
-  const exclusionBounds = {
-    xPt: xLeft,
-    yPt: yTop,
-    widthPt: xRight - xLeft,
-    heightPt: yBottom - yTop,
-  };
-  return {
-    occurrenceId: `legacy-float:${index}`,
-    kind: float.kind === 'shape' ? 'drawingml' : float.kind,
-    paragraphId: float.paraId,
-    bounds: hasObjectBounds ? {
-      xPt: float.imageX!,
-      yPt: float.imageY!,
-      widthPt: float.imageW!,
-      heightPt: float.imageH!,
-    } : exclusionBounds,
-    exclusionBounds,
-  };
+export interface ResolveBlockFlowAdmissionInput {
+  readonly inlineStartPt: number;
+  readonly inlineEndPt: number;
+  readonly blockStartPt: number;
+  readonly blockExtentPt: number;
+  readonly blockers: readonly FloatPlacementParticipant[];
+  readonly overlapEpsilonPt: number;
 }
 
 /**
- * Temporary compatibility signature for root renderer helpers. All blocker
- * scoping and displacement now delegates to `resolveFloatPlacement`; C1b
- * removes this scalar adapter when the display-space registry is retired.
+ * Admit one ordinary-flow block below floating-table text exclusions.
+ *
+ * This is not §17.4.56 float-to-float placement: the moving object is flow
+ * content, so §17.4.57 exclusion bounds apply. Each move adopts the bottom of
+ * an intersecting blocker. The start is monotone and every cleared blocker can
+ * never intersect again, giving a hard bound of `eligible.length` moves.
  */
-export function resolveFloatOverlap(
-  x: number, y: number, w: number, h: number,
-  dl: number, dr: number, dt: number, db: number,
-  paraId: number, allowOverlap: boolean,
-  kind: ScalarFloatParticipant['kind'],
-  pageRight: number,
-  floats: readonly ScalarFloatParticipant[],
-): { x: number; y: number } {
-  const moving: FloatPlacementParticipant = {
-    occurrenceId: 'legacy-moving-float',
-    kind: kind === 'shape' ? 'drawingml' : kind,
-    paragraphId: paraId,
-    bounds: { xPt: x, yPt: y, widthPt: w, heightPt: h },
-    exclusionBounds: {
-      xPt: x - dl,
-      yPt: y - dt,
-      widthPt: w + dl + dr,
-      heightPt: h + dt + db,
-    },
-  };
-  try {
-    const result = resolveFloatPlacement({
-      moving,
-      blockers: floats.map(scalarParticipant),
-      avoidance: allowOverlap
-        ? { kind: 'word-different-paragraph', paragraphId: paraId }
-        : kind === 'table'
-          ? { kind: 'floating-table-never' }
-          : { kind: 'drawingml-normative' },
-      rightBoundaryPt: pageRight,
-      overlapEpsilonPt: FLOAT_OVERLAP_EPS,
-      rightBoundarySlackPt: FLOAT_PAGE_RIGHT_SLACK,
-    });
-    return { x: result.bounds.xPt, y: result.bounds.yPt };
-  } catch (error) {
-    if (
-      error instanceof Error
-      && error.message === 'Axis-aligned overlap resolution did not converge'
-    ) {
-      throw new Error('Float overlap resolution did not converge');
-    }
-    throw error;
+export function resolveBlockFlowAdmission(
+  input: ResolveBlockFlowAdmissionInput,
+): Readonly<{ blockStartPt: number }> {
+  if (input.inlineEndPt < input.inlineStartPt || input.blockExtentPt < 0) {
+    throw new RangeError('Block-flow admission received a negative extent');
   }
+  const eligible = input.blockers.filter((blocker) => {
+    const bounds = blocker.exclusionBounds;
+    return blocker.kind === 'table'
+      && input.inlineEndPt - bounds.xPt > input.overlapEpsilonPt
+      && bounds.xPt + bounds.widthPt - input.inlineStartPt > input.overlapEpsilonPt;
+  });
+  let blockStartPt = input.blockStartPt;
+  for (let moveCount = 0; moveCount <= eligible.length; moveCount += 1) {
+    const intersecting = eligible.filter((blocker) => {
+      const bounds = blocker.exclusionBounds;
+      return blockStartPt + input.blockExtentPt - bounds.yPt > input.overlapEpsilonPt
+        && bounds.yPt + bounds.heightPt - blockStartPt > input.overlapEpsilonPt;
+    });
+    if (intersecting.length === 0) return Object.freeze({ blockStartPt });
+    if (moveCount === eligible.length) {
+      throw new Error('Block-flow float admission did not converge');
+    }
+    blockStartPt = Math.max(...intersecting.map((blocker) =>
+      blocker.exclusionBounds.yPt + blocker.exclusionBounds.heightPt));
+  }
+  throw new Error('Block-flow float admission did not converge');
+}
+
+export interface ResolvePageAnchoredTableDeferralInput {
+  readonly bounds: LayoutRect;
+  readonly blockers: readonly FloatPlacementParticipant[];
+  readonly overlapEpsilonPt: number;
+}
+
+/** Established Word pagination behavior, deliberately separate from normative
+ * §17.4.56 raw table placement. The authored object band is admitted against
+ * already-reserved §17.4.57 floating-table text-exclusion bands. */
+export function resolvePageAnchoredTableDeferral(
+  input: ResolvePageAnchoredTableDeferralInput,
+): Readonly<{
+  defer: boolean;
+  appliedCompatibilityRuleIds: readonly string[];
+}> {
+  const moving = axisRect(input.bounds);
+  const defer = input.blockers.some((blocker) =>
+    blocker.kind === 'table'
+      && axisAlignedRectsOverlap(
+        moving,
+        axisRect(blocker.exclusionBounds),
+        input.overlapEpsilonPt,
+      ));
+  return Object.freeze({
+    defer,
+    appliedCompatibilityRuleIds: defer
+      ? Object.freeze([WORD_PAGE_ANCHORED_TABLE_COLLISION_DEFERRAL.id])
+      : Object.freeze([]),
+  });
 }

--- a/packages/docx/src/layout/paragraph-float-authority.test.ts
+++ b/packages/docx/src/layout/paragraph-float-authority.test.ts
@@ -5,7 +5,9 @@ import {
 } from './paragraph-float-authority.js';
 import type { FloatRect } from './float-wrap.js';
 
-const float = (overrides: Partial<FloatRect> = {}): FloatRect => ({
+const float = (
+  overrides: Partial<Extract<FloatRect, { kind: 'shape' }>> = {},
+): FloatRect => ({
   kind: 'shape',
   mode: 'square',
   imageKey: '',

--- a/packages/docx/src/layout/table-pagination.test.ts
+++ b/packages/docx/src/layout/table-pagination.test.ts
@@ -372,6 +372,7 @@ describe('retained table pagination', () => {
     const occurrenceId = `page-0:${source.input.rows[0]!.cells[0]!.id}:0:${nested.layout.id}`;
     const baseEntry = Object.freeze({
       kind: 'table' as const,
+      overlap: 'never' as const,
       occurrenceId,
       paragraphId: 7,
       bounds: Object.freeze({ xPt: 10, yPt: 10, widthPt: 100, heightPt: 10 }),
@@ -451,6 +452,7 @@ describe('retained table pagination', () => {
       flowDomainId: 'logical-page:0',
       entries: Object.freeze([Object.freeze({
         kind: 'table' as const,
+        overlap: 'never' as const,
         occurrenceId: baseOccurrenceId,
         paragraphId: 7,
         bounds: baseBounds,

--- a/packages/docx/src/layout/types.ts
+++ b/packages/docx/src/layout/types.ts
@@ -670,9 +670,7 @@ export interface FloatingTableReferenceFramesPt {
   readonly text: LayoutRect;
 }
 
-/** Point-space snapshot used while final table-fragment float placement is probed. */
-export interface FloatRegistryEntryPt {
-  readonly kind: 'table' | 'shape' | 'frame';
+interface FloatRegistryEntryCorePt {
   readonly occurrenceId: string;
   readonly paragraphId: number;
   readonly bounds: LayoutRect;
@@ -694,6 +692,21 @@ export interface FloatRegistryEntryPt {
   }>;
   readonly wrapPolygon?: readonly PointPt[];
 }
+
+/** Point-space snapshot used while final table-fragment float placement is
+ * probed. A table entry must retain its §17.4.56 fact because a blocker-side
+ * `never` constrains tables placed later in source order. */
+export type FloatRegistryEntryPt =
+  | Readonly<FloatRegistryEntryCorePt & {
+      readonly kind: 'table';
+      readonly overlap: 'never' | 'overlap';
+    }>
+  | Readonly<FloatRegistryEntryCorePt & {
+      readonly kind: 'shape';
+    }>
+  | Readonly<FloatRegistryEntryCorePt & {
+      readonly kind: 'frame';
+    }>;
 
 export type FloatRegistryCoordinateSpace = Exclude<
   LayoutCoordinateSpace,

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -3475,12 +3475,18 @@ function createConcreteBodyLayoutKernel(
                   fragment: NonNullable<ReturnType<typeof takeTableFragment>['fragment']>;
                   resolved: ReturnType<typeof resolveFloatingTablePlacementInTransaction>;
                   nestedEntries: readonly FloatRegistryEntryPt[];
+                  fingerprint: string;
                 }>;
             let transaction: FloatingParentTransactionPass;
             try {
               transaction = convergeExactState<FloatingParentTransactionPass>({
                 step: (previous) => {
                   if (previous?.kind === 'fresh-flow-region') return previous;
+                  if (previous?.kind === 'candidate'
+                    && previous.resolved.placement.xPt === previous.parentFrame.xPt
+                    && previous.resolved.placement.yPt === previous.parentFrame.yPt) {
+                    return previous;
+                  }
                   const parentFrame = previous?.resolved.placement ?? {
                     xPt: raw.x,
                     yPt: raw.y,
@@ -3565,6 +3571,15 @@ function createConcreteBodyLayoutKernel(
                       floatRegistry.flowDomainId,
                     ),
                   );
+                  const fingerprint = JSON.stringify({
+                    parentFrame: {
+                      xPt: resolved.placement.xPt,
+                      yPt: resolved.placement.yPt,
+                    },
+                    fragment: result.fragment,
+                    nestedEntries,
+                    resolvedBounds: resolved.placement.bounds,
+                  });
                   return Object.freeze({
                     kind: 'candidate' as const,
                     parentFrame: Object.freeze({
@@ -3575,19 +3590,12 @@ function createConcreteBodyLayoutKernel(
                     fragment: result.fragment,
                     resolved,
                     nestedEntries,
+                    fingerprint,
                   });
                 },
                 stateOf: (value) => value.kind === 'fresh-flow-region'
                   ? 'fresh-flow-region'
-                  : JSON.stringify({
-                      parentFrame: {
-                        xPt: value.resolved.placement.xPt,
-                        yPt: value.resolved.placement.yPt,
-                      },
-                      fragment: value.result.fragment,
-                      nestedEntries: value.nestedEntries,
-                      resolvedBounds: value.resolved.placement.bounds,
-                    }),
+                  : value.fingerprint,
                 limit: 16,
               }).value;
             } catch (error) {

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -163,6 +163,16 @@ import {
   resolveFloatingTablePlacementInTransaction,
   validateFloatingTableRegistryDelta,
 } from './layout/floating-table-transaction.js';
+import {
+  floatRegistryParticipant,
+  resolveBlockFlowAdmission,
+  resolvePageAnchoredTableDeferral,
+} from './layout/floats.js';
+import {
+  ExactConvergenceError,
+  convergeExactState,
+} from './layout/convergence.js';
+import { LayoutInvariantError } from './layout/diagnostics.js';
 import type { LayoutOptions } from './layout/options.js';
 import {
   paginatedFlowHasPaginationDependentFields,
@@ -2408,7 +2418,7 @@ function buildMeasureState(
           drawn: true,
           paraId: state.floatParaSeq++,
           avoidOverlap: true,
-          allowOverlap: request.overlap !== 'never',
+          tableOverlap: request.overlap,
         });
         return Object.freeze({
           xPt: registered.imageX / scale - textFrame.xPt,
@@ -2802,7 +2812,7 @@ function createConcreteBodyLayoutKernel(
           contentW: request.acquired.flowBounds.widthPt * scale,
           y: request.acquired.flowBounds.yPt,
           floats: (request.floatingTableExclusions ?? []).map((bounds, index): FloatRect => ({
-            kind: 'table', mode: 'square',
+            kind: 'table', tableOverlap: 'never', mode: 'square',
             imageKey: `${TRANSIENT_TABLE_FINAL_FRAME_EXCLUSION_PREFIX}${index}`,
             imageX: bounds.xPt * scale, imageY: bounds.yPt * scale,
             imageW: bounds.widthPt * scale, imageH: bounds.heightPt * scale,
@@ -3409,13 +3419,16 @@ function createConcreteBodyLayoutKernel(
             );
             const pageAnchoredCollision = request.cursor?.kind !== 'table'
               && (positioning.vertAnchor === 'page' || positioning.vertAnchor === 'margin')
-              && floatRegistry.entries.some((entry) => entry.kind === 'table'
-                && raw.x + raw.w - entry.exclusionBounds.xPt > FLOAT_OVERLAP_EPS
-                && entry.exclusionBounds.xPt + entry.exclusionBounds.widthPt - raw.x
-                  > FLOAT_OVERLAP_EPS
-                && raw.y + raw.h - entry.exclusionBounds.yPt > FLOAT_OVERLAP_EPS
-                && entry.exclusionBounds.yPt + entry.exclusionBounds.heightPt - raw.y
-                  > FLOAT_OVERLAP_EPS);
+              && resolvePageAnchoredTableDeferral({
+                bounds: {
+                  xPt: raw.x,
+                  yPt: raw.y,
+                  widthPt: raw.w,
+                  heightPt: raw.h,
+                },
+                blockers: floatRegistry.entries.map(floatRegistryParticipant),
+                overlapEpsilonPt: FLOAT_OVERLAP_EPS,
+              }).defer;
             if (pageAnchoredCollision) {
               // Word defers an absolute page/margin table whose authored band is
               // already owned by a table on this page; the fresh page preserves
@@ -3450,110 +3463,168 @@ function createConcreteBodyLayoutKernel(
               : positioning.vertAnchor === 'margin'
                 ? frames.margin.heightPt
                 : request.freshPageBlockExtentPt;
-            let parentFrame = Object.freeze({ xPt: raw.x, yPt: raw.y });
-            let result: ReturnType<typeof takeTableFragment>;
-            let resolved: ReturnType<typeof resolveFloatingTablePlacementInTransaction>;
-            let nestedEntries: readonly FloatRegistryEntryPt[];
-            const visitedTransactions = new Set<string>();
-            while (true) {
-              const availableHeightPt = Math.max(0, admissionBlockEndPt - parentFrame.yPt);
-              result = takeTableFragment(retained, cursor, {
-                availableHeightPt,
-                freshPageHeightPt: freshAdmissionHeightPt,
-                placement: {
-                  container: {
-                    id: `${request.location.flowDomainId}:floating-table`, kind: 'body',
-                    bounds: {
-                      xPt: 0, yPt: 0,
-                      widthPt: request.availableInlineExtentPt, heightPt: availableHeightPt,
+            type FloatingParentTransactionPass =
+              | Readonly<{
+                  kind: 'fresh-flow-region';
+                  result: ReturnType<typeof takeTableFragment>;
+                }>
+              | Readonly<{
+                  kind: 'candidate';
+                  parentFrame: Readonly<{ xPt: number; yPt: number }>;
+                  result: ReturnType<typeof takeTableFragment>;
+                  fragment: NonNullable<ReturnType<typeof takeTableFragment>['fragment']>;
+                  resolved: ReturnType<typeof resolveFloatingTablePlacementInTransaction>;
+                  nestedEntries: readonly FloatRegistryEntryPt[];
+                }>;
+            let transaction: FloatingParentTransactionPass;
+            try {
+              transaction = convergeExactState<FloatingParentTransactionPass>({
+                step: (previous) => {
+                  if (previous?.kind === 'fresh-flow-region') return previous;
+                  const parentFrame = previous?.resolved.placement ?? {
+                    xPt: raw.x,
+                    yPt: raw.y,
+                  };
+                  const availableHeightPt = Math.max(
+                    0,
+                    admissionBlockEndPt - parentFrame.yPt,
+                  );
+                  const result = takeTableFragment(retained, cursor, {
+                    availableHeightPt,
+                    freshPageHeightPt: freshAdmissionHeightPt,
+                    placement: {
+                      container: {
+                        id: `${request.location.flowDomainId}:floating-table`,
+                        kind: 'body',
+                        bounds: {
+                          xPt: 0,
+                          yPt: 0,
+                          widthPt: request.availableInlineExtentPt,
+                          heightPt: availableHeightPt,
+                        },
+                      },
+                      cursor: { xPt: 0, yPt: 0 },
+                      availableBounds: {
+                        xPt: 0,
+                        yPt: 0,
+                        widthPt: request.availableInlineExtentPt,
+                        heightPt: availableHeightPt,
+                      },
                     },
-                  },
-                  cursor: { xPt: 0, yPt: 0 },
-                  availableBounds: {
-                    xPt: 0, yPt: 0,
-                    widthPt: request.availableInlineExtentPt, heightPt: availableHeightPt,
-                  },
+                    services,
+                    compatibility: 'word',
+                    oversizedRowPolicy: 'atomic',
+                    page: {
+                      physicalPageIndex: request.location.pageIndex,
+                      displayPageNumber: state.displayPageNumber
+                        ?? request.location.pageIndex + 1,
+                      occurrenceId: `${retained.input.id}:fitting-outer:${request.location.pageIndex}:${cursor.rowIndex}:${cursor.rowFragmentIndex}`,
+                    },
+                    floatingTableFrames: {
+                      page: frames.page,
+                      margin: frames.margin,
+                      column: frames.text,
+                    },
+                    floatingTableRegistry: floatRegistry,
+                    finalPlacementTranslationPt: parentFrame,
+                    reacquirePageDependentBlock: reacquireTableBlock,
+                  });
+                  if (!result.fragment || result.requiresFreshPage) {
+                    return Object.freeze({
+                      kind: 'fresh-flow-region' as const,
+                      result,
+                    });
+                  }
+                  const sourcePlacement: FloatingTablePlacementLayout = Object.freeze({
+                    kind: 'floating-table-placement',
+                    occurrenceId: `${retained.input.id}:root:${request.location.pageIndex}:${cursor.rowIndex}:${cursor.rowFragmentIndex}`,
+                    ownership: 'source',
+                    physicalPageIndex: request.location.pageIndex,
+                    displayPageNumber: state.displayPageNumber
+                      ?? request.location.pageIndex + 1,
+                    hostCellId: request.location.flowDomainId,
+                    sourceBlockIndex: request.input.source.path[0]!,
+                    anchorBlockIndex: request.input.source.path[0]!,
+                    tableId: result.fragment.id,
+                    overlap: table.overlap === 'never' ? 'never' : 'overlap',
+                    positioning,
+                    anchorBounds: frames.text,
+                    child: result.fragment,
+                  });
+                  const nestedEntries = result.floatingTableRegistryDelta?.entries ?? [];
+                  const nestedNextParagraphId =
+                    result.floatingTableRegistryDelta?.nextParagraphId
+                    ?? floatRegistry.nextParagraphId;
+                  const resolved = resolveFloatingTablePlacementInTransaction(
+                    sourcePlacement,
+                    frames,
+                    beginFloatingTablePlacementTransaction(
+                      floatRegistry.entries,
+                      nestedNextParagraphId,
+                      floatRegistry.coordinateSpace,
+                      floatRegistry.flowDomainId,
+                    ),
+                  );
+                  return Object.freeze({
+                    kind: 'candidate' as const,
+                    parentFrame: Object.freeze({
+                      xPt: parentFrame.xPt,
+                      yPt: parentFrame.yPt,
+                    }),
+                    result,
+                    fragment: result.fragment,
+                    resolved,
+                    nestedEntries,
+                  });
                 },
-                services,
-                compatibility: 'word',
-                oversizedRowPolicy: 'atomic',
-                page: {
-                  physicalPageIndex: request.location.pageIndex,
-                  displayPageNumber: state.displayPageNumber ?? request.location.pageIndex + 1,
-                  occurrenceId: `${retained.input.id}:fitting-outer:${request.location.pageIndex}:${cursor.rowIndex}:${cursor.rowFragmentIndex}`,
-                },
-                floatingTableFrames: {
-                  page: frames.page,
-                  margin: frames.margin,
-                  column: frames.text,
-                },
-                floatingTableRegistry: floatRegistry,
-                finalPlacementTranslationPt: parentFrame,
-                reacquirePageDependentBlock: reacquireTableBlock,
-              });
-              if (!result.fragment || result.requiresFreshPage) {
-                return Object.freeze({
-                  layout: retained.layout,
-                  blockExtentPt: 0,
-                  nextCursor: Object.freeze({
-                    kind: 'table' as const,
-                    cursor,
-                    floatingContinuationFrame: 'fresh-text' as const,
-                  }),
-                  requiresFreshFlowRegion: true,
-                });
+                stateOf: (value) => value.kind === 'fresh-flow-region'
+                  ? 'fresh-flow-region'
+                  : JSON.stringify({
+                      parentFrame: {
+                        xPt: value.resolved.placement.xPt,
+                        yPt: value.resolved.placement.yPt,
+                      },
+                      fragment: value.result.fragment,
+                      nestedEntries: value.nestedEntries,
+                      resolvedBounds: value.resolved.placement.bounds,
+                    }),
+                limit: 16,
+              }).value;
+            } catch (error) {
+              if (error instanceof ExactConvergenceError) {
+                throw new LayoutInvariantError(
+                  'NON_CONVERGENCE',
+                  error.reason === 'cycle'
+                    ? 'Floating table parent/child transaction repeated an exact-state cycle'
+                    : 'Floating table parent/child transaction reached the operational pass limit 16',
+                );
               }
-              const sourcePlacement: FloatingTablePlacementLayout = Object.freeze({
-                kind: 'floating-table-placement',
-                occurrenceId: `${retained.input.id}:root:${request.location.pageIndex}:${cursor.rowIndex}:${cursor.rowFragmentIndex}`,
-                ownership: 'source',
-                physicalPageIndex: request.location.pageIndex,
-                displayPageNumber: state.displayPageNumber ?? request.location.pageIndex + 1,
-                hostCellId: request.location.flowDomainId,
-                sourceBlockIndex: request.input.source.path[0]!,
-                anchorBlockIndex: request.input.source.path[0]!,
-                tableId: result.fragment.id,
-                overlap: table.overlap === 'never' ? 'never' : 'overlap',
-                positioning,
-                anchorBounds: frames.text,
-                child: result.fragment,
-              });
-              nestedEntries = result.floatingTableRegistryDelta?.entries ?? [];
-              const nestedNextParagraphId = result.floatingTableRegistryDelta?.nextParagraphId
-                ?? floatRegistry.nextParagraphId;
-              resolved = resolveFloatingTablePlacementInTransaction(
-                sourcePlacement,
-                frames,
-                beginFloatingTablePlacementTransaction(
-                  floatRegistry.entries,
-                  nestedNextParagraphId,
-                  floatRegistry.coordinateSpace,
-                  floatRegistry.flowDomainId,
-                ),
-              );
-              if (resolved.placement.xPt === parentFrame.xPt
-                && resolved.placement.yPt === parentFrame.yPt) break;
-              const fingerprint = JSON.stringify({
-                parentFrame,
-                fragment: result.fragment,
-                nestedEntries,
-                resolvedBounds: resolved.placement.bounds,
-              });
-              if (visitedTransactions.has(fingerprint)) {
-                throw new Error('Floating table parent/child transaction did not converge');
-              }
-              visitedTransactions.add(fingerprint);
-              parentFrame = Object.freeze({
-                xPt: resolved.placement.xPt,
-                yPt: resolved.placement.yPt,
+              throw error;
+            }
+            if (transaction.kind === 'fresh-flow-region') {
+              return Object.freeze({
+                layout: retained.layout,
+                blockExtentPt: 0,
+                nextCursor: Object.freeze({
+                  kind: 'table' as const,
+                  cursor,
+                  floatingContinuationFrame: 'fresh-text' as const,
+                }),
+                requiresFreshFlowRegion: true,
               });
             }
+            const {
+              result,
+              fragment,
+              resolved,
+              nestedEntries,
+            } = transaction;
             const isFloatingContinuation = request.cursor?.kind === 'table'
               && request.cursor.floatingContinuationFrame !== undefined;
             const admittedBlockEndPt = request.location.availableBounds.yPt
               + request.location.availableBounds.heightPt;
             const hostFlowPlacements = [
-              ...result.fragment.resolvedFloatingTables ?? [],
+              ...fragment.resolvedFloatingTables ?? [],
               resolved.placement,
             ].filter((placement) => placement.source.positioning.vertAnchor === 'text');
             if (!isFloatingContinuation && hostFlowPlacements.some((placement) => (
@@ -3561,7 +3632,7 @@ function createConcreteBodyLayoutKernel(
                 > admittedBlockEndPt
             ))) {
               return Object.freeze({
-                layout: result.fragment,
+                layout: fragment,
                 blockExtentPt: 0,
                 nextCursor: Object.freeze({
                   kind: 'table' as const,
@@ -3572,7 +3643,7 @@ function createConcreteBodyLayoutKernel(
               });
             }
             return Object.freeze({
-              layout: result.fragment,
+              layout: fragment,
               blockExtentPt: 0,
               nextCursor: result.nextCursor
                 ? Object.freeze({
@@ -3728,21 +3799,14 @@ function createConcreteBodyLayoutKernel(
             + retained.layout.flowBounds.xPt;
           const tableInlineEndPt = tableInlineStartPt + retained.layout.flowBounds.widthPt;
           const remainingTableExtentPt = result.fragment?.advancePt ?? 0;
-          let retryAtBlockStartPt = request.location.cursorPt.yPt;
-          while (true) {
-            const blockers = floatRegistry.entries.filter((entry) => entry.kind === 'table'
-              && tableInlineEndPt - entry.exclusionBounds.xPt > FLOAT_OVERLAP_EPS
-              && entry.exclusionBounds.xPt + entry.exclusionBounds.widthPt
-                - tableInlineStartPt > FLOAT_OVERLAP_EPS
-              && retryAtBlockStartPt + remainingTableExtentPt
-                - entry.exclusionBounds.yPt > FLOAT_OVERLAP_EPS
-              && entry.exclusionBounds.yPt + entry.exclusionBounds.heightPt
-                - retryAtBlockStartPt > FLOAT_OVERLAP_EPS);
-            if (blockers.length === 0) break;
-            retryAtBlockStartPt = Math.max(...blockers.map((entry) => (
-              entry.exclusionBounds.yPt + entry.exclusionBounds.heightPt
-            )));
-          }
+          const retryAtBlockStartPt = resolveBlockFlowAdmission({
+            inlineStartPt: tableInlineStartPt,
+            inlineEndPt: tableInlineEndPt,
+            blockStartPt: request.location.cursorPt.yPt,
+            blockExtentPt: remainingTableExtentPt,
+            blockers: floatRegistry.entries.map(floatRegistryParticipant),
+            overlapEpsilonPt: FLOAT_OVERLAP_EPS,
+          }).blockStartPt;
           if (retryAtBlockStartPt > request.location.cursorPt.yPt) {
             return Object.freeze({
               layout: retained.layout,
@@ -4175,9 +4239,10 @@ function createConcreteBodyLayoutKernel(
             const bottom = entry.wrapDistances?.bottomPt
               ?? entry.exclusionBounds.yPt + entry.exclusionBounds.heightPt
                 - entry.bounds.yPt - entry.bounds.heightPt;
-            return {
-              kind: entry.kind,
-              mode: entry.wrap === 'topAndBottom' ? 'topAndBottom' : 'square',
+            const core = {
+              mode: (entry.wrap === 'topAndBottom'
+                ? 'topAndBottom'
+                : 'square') as FloatRect['mode'],
               ...(entry.kind === 'shape' ? {
                 anchorOccurrenceId: entry.occurrenceId,
                 acquisitionOccurrenceId: entry.occurrenceId,
@@ -4199,6 +4264,13 @@ function createConcreteBodyLayoutKernel(
               distTop: top * scale, distBottom: bottom * scale,
               paraId: entry.paragraphId, drawn: true,
             };
+            return entry.kind === 'table'
+              ? {
+                  ...core,
+                  kind: 'table',
+                  tableOverlap: entry.overlap,
+                }
+              : { ...core, kind: entry.kind };
           });
           if (delta.floats) {
             state.floats.push(...retainedFloats);
@@ -7210,7 +7282,7 @@ function renderAnchorImages(
     // wrapNone images anchor against the paragraph's pre-spaceBefore top
     // (paragraphTopPx). Shared box resolution with the float path. By design the
     // box-resolution is symmetric but the overlap handling is NOT: wrap floats
-    // (registerAnchorFloats) build an exclusion rect and run resolveFloatOverlap,
+    // (registerAnchorFloats) build an exclusion rect and run the typed placement policy,
     // whereas wrapNone images carry no exclusion rect — they are positioned
     // directly in the paragraph flow (ECMA-376 wrapNone, §20.4.2.x: the object
     // does not displace text and is not displaced by other floats), so dist* is
@@ -7638,8 +7710,7 @@ function renderAnchorShape(shape: ShapeRun, state: RenderState, paragraphTopPx: 
  * `positionV relativeFrom="paragraph"` float is positioned relative to the
  * paragraph that contains the anchor, i.e. its top edge before spaceBefore).
  * Page-level floats pass 0 (resolveAnchorY ignores paraBaseY for them). This is
- * the box origin BEFORE any overlap displacement; resolveFloatOverlap runs on
- * top of it for floats.
+ * the box origin BEFORE the typed float placement policy displaces it.
  *
  * Exported under a `_test` alias for the anchor-image relativeFrom wiring test
  * (the public renderer entry points consume the box internally; pin the
@@ -8006,7 +8077,7 @@ function registerImageFloat(
   // Implementation-defined (HEURISTIC, Word-mimicking, no ECMA-376 basis):
   // displacing the later document-order float, the "other paragraphs only"
   // gate under allowOverlap=true, and the right-then-down re-seat using dist
-  // padding as the float-to-float gap. See resolveFloatOverlap header.
+  // padding as the float-to-float gap. See layout/floats.ts.
   const allowOverlap = img.allowOverlap ?? true;
   const key = imageKey(img.imagePath, img.colorReplaceFrom, img.duotone);
   const rect = pushFloatRect(state, {

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -210,27 +210,99 @@ function assertNoProductionTestSupportImports(root) {
 function assertFloatPlacementAuthority(root) {
   const sourceRoot = resolve(root, DOCX_SOURCE);
   const authority = `${LAYOUT_SOURCE}/floats.ts`;
+  const kernel = `${LAYOUT_SOURCE}/axis-aligned-overlap.ts`;
+  const wrap = `${LAYOUT_SOURCE}/float-wrap.ts`;
+  const compatibility = `${LAYOUT_SOURCE}/compatibility.ts`;
+  const compatibilityFacade = `${DOCX_SOURCE}/float-layout.ts`;
+  const allowedKernelImports = new Map([
+    [authority, [
+      'AxisAlignedRect',
+      'axisAlignedRectsOverlap',
+      'resolveAxisAlignedOverlap',
+    ]],
+    [wrap, ['axisAlignedRectsOverlap']],
+  ]);
+  const floatCompatibilityName = /^(?:WORD_FLOAT_|WORD_PAGE_ANCHORED_TABLE_|WORD_SQUARE_LINE_|WORD_MIN_LINE_START_PT$|LINE_START_GAP_EPS_PT$|wordMinLineStartPx$)/;
   for (const path of listFiles(sourceRoot).filter(isProductionTypeScript)) {
     const source = sourceFile(path);
     const file = posixPath(relative(root, path));
-    for (const statement of source.statements) {
-      if (!ts.isImportDeclaration(statement)
-        || !ts.isStringLiteralLike(statement.moduleSpecifier)
-        || !statement.importClause?.namedBindings
-        || !ts.isNamedImports(statement.importClause.namedBindings)) continue;
-      const importsKernel = statement.importClause.namedBindings.elements.some(
-        (element) => (element.propertyName?.text ?? element.name.text)
-          === 'resolveAxisAlignedOverlap',
-      );
-      if (!importsKernel) continue;
-      const dependency = resolveLocalImport(path, statement.moduleSpecifier.text);
+    for (const edge of moduleEdges(path)) {
+      if (!edge.literal) continue;
+      const dependency = resolveLocalImport(path, edge.specifier);
       const dependencyFile = dependency ? posixPath(relative(root, dependency)) : null;
-      if (file !== authority
-        || dependencyFile !== `${LAYOUT_SOURCE}/axis-aligned-overlap.ts`) {
+      if (dependencyFile === kernel) {
+        const expected = allowedKernelImports.get(file);
+        const actual = [...(edge.importedNames ?? [])].sort();
+        if (edge.kind !== 'import'
+          || edge.bare
+          || edge.aliased
+          || !expected
+          || JSON.stringify(actual) !== JSON.stringify([...expected].sort())) {
+          fail(
+            'FLOAT_PLACEMENT_AUTHORITY',
+            `${file} -> ${dependencyFile} (${edge.kind}:${actual.join(',')})`,
+          );
+        }
+      }
+      if ((edge.importedNames ?? []).some((name) => floatCompatibilityName.test(name))) {
+        if ((dependencyFile !== compatibility && dependencyFile !== compatibilityFacade)
+          || edge.aliased) {
+          fail(
+            'FLOAT_COMPATIBILITY_AUTHORITY',
+            `${file} -> ${dependencyFile ?? edge.specifier}`,
+          );
+        }
+      }
+    }
+    const visit = (node) => {
+      if ((ts.isIdentifier(node) || ts.isStringLiteralLike(node))
+        && node.text === 'resolveAxisAlignedOverlap'
+        && file !== kernel
+        && file !== authority) {
         fail(
           'FLOAT_PLACEMENT_AUTHORITY',
-          `${file} -> ${dependencyFile ?? statement.moduleSpecifier.text}`,
+          `${file} references resolveAxisAlignedOverlap`,
         );
+      }
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(source, visit);
+    for (const statement of source.statements) {
+      if (ts.isVariableStatement(statement)) {
+        const exported = statement.modifiers?.some(
+          (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+        );
+        for (const declaration of statement.declarationList.declarations) {
+          if (!ts.isIdentifier(declaration.name)) continue;
+          const name = declaration.name.text;
+          if (floatCompatibilityName.test(name) && file !== compatibility) {
+            fail('FLOAT_COMPATIBILITY_AUTHORITY', `${file} declares ${name}`);
+          }
+          if (name === 'FLOAT_OVERLAP_EPS' || name === 'FLOAT_PAGE_RIGHT_SLACK') {
+            const expected = name === 'FLOAT_OVERLAP_EPS' ? 0.01 : 0.5;
+            if (file !== authority
+              || !exported
+              || !declaration.initializer
+              || !ts.isNumericLiteral(declaration.initializer)
+              || Number(declaration.initializer.text) !== expected) {
+              fail('FLOAT_NUMERIC_POLICY', `${file} declares ${name}`);
+            }
+          }
+          if (file === authority
+            && exported
+            && declaration.initializer
+            && ts.isIdentifier(declaration.initializer)
+            && declaration.initializer.text === 'resolveAxisAlignedOverlap') {
+            fail('FLOAT_PLACEMENT_AUTHORITY', `${file} re-exports the displacement kernel`);
+          }
+        }
+      }
+      if (ts.isExportDeclaration(statement) && statement.exportClause
+        && ts.isNamedExports(statement.exportClause)
+        && statement.exportClause.elements.some((element) =>
+          (element.propertyName?.text ?? element.name.text) === 'resolveAxisAlignedOverlap'
+          || element.name.text === 'resolveAxisAlignedOverlap')) {
+        fail('FLOAT_PLACEMENT_AUTHORITY', `${file} re-exports the displacement kernel`);
       }
     }
   }

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -903,10 +903,15 @@ test('late mutation of retained body sidecars is rejected before paint dispatch'
 test('only the float placement authority may import the displacement kernel', () => {
   const root = initializeCanonicalFixture('docx-layout-boundary-float-authority-');
   write(root, 'packages/docx/src/layout/axis-aligned-overlap.ts',
-    'export function resolveAxisAlignedOverlap(value) { return value; }\n');
+    'export interface AxisAlignedRect { left; right; top; bottom }\n'
+      + 'export function axisAlignedRectsOverlap() { return false; }\n'
+      + 'export function resolveAxisAlignedOverlap(value) { return value; }\n');
   write(root, 'packages/docx/src/layout/floats.ts',
-    "import { resolveAxisAlignedOverlap } from './axis-aligned-overlap.js';\n"
-      + 'export const place = resolveAxisAlignedOverlap;\n');
+    "import { axisAlignedRectsOverlap, resolveAxisAlignedOverlap, type AxisAlignedRect } from './axis-aligned-overlap.js';\n"
+      + 'export function place(value: AxisAlignedRect) {\n'
+      + '  axisAlignedRectsOverlap();\n'
+      + '  return resolveAxisAlignedOverlap(value);\n'
+      + '}\n');
   assert.equal(runChecker(root, '--final').status, 0);
 
   write(root, 'packages/docx/src/layout/paragraph.ts',
@@ -916,6 +921,61 @@ test('only the float placement authority may import the displacement kernel', ()
     root,
     'FLOAT_PLACEMENT_AUTHORITY',
     'an aliased direct kernel import must not bypass layout/floats.ts',
+    '--final',
+  );
+});
+
+test('float placement authority rejects every module-edge and property-access bypass', () => {
+  const bypasses = new Map([
+    ['namespace',
+      "import * as overlap from './axis-aligned-overlap.js';\nexport const place = overlap.resolveAxisAlignedOverlap;\n"],
+    ['default',
+      "import overlap from './axis-aligned-overlap.js';\nexport const place = overlap;\n"],
+    ['export-star',
+      "export * from './axis-aligned-overlap.js';\n"],
+    ['named-re-export',
+      "export { resolveAxisAlignedOverlap as place } from './axis-aligned-overlap.js';\n"],
+    ['dynamic-import',
+      "export const place = () => import('./axis-aligned-overlap.js');\n"],
+    ['commonjs-require',
+      "export const place = () => require('./axis-aligned-overlap.js');\n"],
+    ['string-key',
+      "const overlap = { resolveAxisAlignedOverlap() {} };\n"
+        + "export const place = overlap['resolveAxisAlignedOverlap'];\n"],
+  ]);
+  for (const [name, source] of bypasses) {
+    const root = initializeCanonicalFixture(`docx-layout-boundary-float-${name}-`);
+    write(root, 'packages/docx/src/layout/axis-aligned-overlap.ts',
+      'export default function overlap(value) { return value; }\n'
+        + 'export function resolveAxisAlignedOverlap(value) { return value; }\n');
+    write(root, 'packages/docx/src/layout/paragraph.ts', source);
+    expectDiagnostic(root, 'FLOAT_PLACEMENT_AUTHORITY', name, '--final');
+  }
+});
+
+test('float compatibility and numeric policies have exact declaration owners', () => {
+  const compatibilityRoot = initializeCanonicalFixture(
+    'docx-layout-boundary-float-compatibility-owner-',
+  );
+  write(compatibilityRoot, 'packages/docx/src/layout/paragraph.ts',
+    "export const WORD_FLOAT_UNTRACKED_HEURISTIC = 'hidden';\n");
+  expectDiagnostic(
+    compatibilityRoot,
+    'FLOAT_COMPATIBILITY_AUTHORITY',
+    'float compatibility declaration outside compatibility.ts',
+    '--final',
+  );
+
+  const numericRoot = initializeCanonicalFixture(
+    'docx-layout-boundary-float-numeric-owner-',
+  );
+  write(numericRoot, 'packages/docx/src/layout/floats.ts',
+    'export const FLOAT_OVERLAP_EPS = 0.02;\n'
+      + 'export const FLOAT_PAGE_RIGHT_SLACK = 0.5;\n');
+  expectDiagnostic(
+    numericRoot,
+    'FLOAT_NUMERIC_POLICY',
+    'float numerical policy value change',
     '--final',
   );
 });


### PR DESCRIPTION
## Summary

Completes Series C1b of #1037.

- replace the transitional scalar float-overlap adapter with typed placement participants
- require floating-table overlap intent at every retained transport boundary
- apply ECMA-376 §17.4.56 `tblOverlap` as an intrinsic pairwise table constraint, regardless of source order
- keep Word-compatible cross-paragraph displacement, ordinary-flow table admission, and page-anchor deferral as separately named policies
- migrate the remaining floating-table parent/child and page-anchor retry loops to exact-state convergence with explicit non-convergence failures
- harden the DOCX layout boundary checker against namespace/default/re-export/dynamic/CommonJS/property-access bypasses

## Verification

- DOCX source suite: 2,609 tests passed
- full repository suite with bounded thread pool: 5,536 tests passed, 26 skipped
- boundary mutation suite: 90 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:test`
- DOCX production/declaration build
- DOCX public API declaration baseline
- `git diff --check`

## Design and review

Claude Fable 5 reviewed the policy split and fixed-point migration before implementation. Its first public-diff review found two blockers (compatibility right-boundary semantics and a redundant stable convergence pass); both were fixed with regression coverage. The second public-diff review approved the updated PR with no remaining blockers.