### PR TITLE
test(docx): add synthetic conformance corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,14 +136,10 @@ jobs:
       - name: Build WASM
         run: pnpm build:wasm
 
-      # Redistributable synthetic DOCX bytes exercise the real WASM parser and
-      # retained layout without the gitignored private-sample corpus.
-      - name: DOCX synthetic conformance (deterministic services)
-        run: pnpm vitest run packages/docx/src/conformance/layout.test.ts
-
       # Unit tests. Most cover pure-logic modules, but the packages/node canvas
       # probes dynamically import the WASM parsers (built above) and skia-canvas,
-      # so they run AFTER Build WASM. OOXML_REQUIRE_SKIA=1 turns a missing binding
+      # so they run AFTER Build WASM. This also includes the redistributable DOCX
+      # synthetic conformance corpus. OOXML_REQUIRE_SKIA=1 turns a missing binding
       # from a silent skip into a hard failure, guaranteeing the probes execute.
       - name: Unit tests
         run: pnpm test
@@ -261,4 +257,4 @@ jobs:
       # each engine. Native-shaped text coordinates are intentionally not
       # compared between engines.
       - name: DOCX synthetic conformance (all browser engines)
-        run: pnpm --filter @silurus/ooxml-docx exec playwright test --config playwright.config.ts conformance.spec.ts
+        run: pnpm --filter @silurus/ooxml-docx conformance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,11 @@ jobs:
       - name: Build WASM
         run: pnpm build:wasm
 
+      # Redistributable synthetic DOCX bytes exercise the real WASM parser and
+      # retained layout without the gitignored private-sample corpus.
+      - name: DOCX synthetic conformance (deterministic services)
+        run: pnpm vitest run packages/docx/src/conformance/layout.test.ts
+
       # Unit tests. Most cover pure-logic modules, but the packages/node canvas
       # probes dynamically import the WASM parsers (built above) and skia-canvas,
       # so they run AFTER Build WASM. OOXML_REQUIRE_SKIA=1 turns a missing binding
@@ -250,3 +255,10 @@ jobs:
       # Google Chrome the smoke job already relies on.
       - name: Worker-equivalence tests
         run: pnpm vrt:worker
+
+      # Public synthetic fixtures cover semantic retained geometry in every
+      # browser engine and compare the shipped main/worker modes exactly within
+      # each engine. Native-shaped text coordinates are intentionally not
+      # compared between engines.
+      - name: DOCX synthetic conformance (all browser engines)
+        run: pnpm --filter @silurus/ooxml-docx exec playwright test --config playwright.config.ts conformance.spec.ts

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@types/node": "^25.6.0",
     "@types/pngjs": "^6.0.5",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.59.1",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -38,8 +38,9 @@
     "preview": "vite preview",
     "wasm": "cd parser && wasm-pack build --target web --out-dir ../src/wasm && node ../../../scripts/append-wasm-reinit.mjs ../src/wasm/docx_parser.js",
     "typecheck": "tsc --noEmit",
-    "vrt": "playwright test --config playwright.config.ts",
-    "vrt:worker": "playwright test --config playwright.config.ts worker-equivalence"
+    "vrt": "playwright test --config playwright.config.ts --project=chrome",
+    "vrt:worker": "playwright test --config playwright.config.ts worker-equivalence",
+    "conformance": "playwright test --config playwright.config.ts conformance.spec.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/packages/docx/playwright.config.ts
+++ b/packages/docx/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests/visual',
@@ -21,11 +21,29 @@ export default defineConfig({
         viewport: { width: 1280, height: 960 },
       },
     },
+    {
+      name: 'firefox',
+      testMatch: '**/conformance.spec.ts',
+      use: {
+        ...devices['Desktop Firefox'],
+        deviceScaleFactor: 1,
+        viewport: { width: 1280, height: 960 },
+      },
+    },
+    {
+      name: 'webkit',
+      testMatch: '**/conformance.spec.ts',
+      use: {
+        ...devices['Desktop Safari'],
+        deviceScaleFactor: 1,
+        viewport: { width: 1280, height: 960 },
+      },
+    },
   ],
   // Start the Vite dev server separately before running tests:
-  //   npx vite --port 5180
+  //   pnpm exec vite --port 5180
   webServer: {
-    command: 'npx vite --port 5180 --strictPort',
+    command: 'pnpm exec vite --port 5180 --strictPort',
     url: 'http://localhost:5180/tests/visual/fixture.html',
     reuseExistingServer: true,
     timeout: 120_000,

--- a/packages/docx/src/conformance/cases.ts
+++ b/packages/docx/src/conformance/cases.ts
@@ -1,0 +1,264 @@
+/**
+ * Redistributable synthetic DOCX coverage matrix.
+ *
+ * The axes below describe OOXML sources, not renderer branches.  A row is valid
+ * only when every selected value can be represented by the same minimal
+ * document.  Coverage therefore means every *feasible* value pair appears at
+ * least once; impossible pairs (for example an inline object with an anchor
+ * reference frame) are deliberately excluded.
+ */
+
+export const CONFORMANCE_AXES = {
+  story: ['body', 'header', 'footer'],
+  container: ['paragraph', 'table', 'nestedTable'],
+  paragraph: ['single', 'wrapped'],
+  object: ['none', 'inline', 'floating'],
+  direction: ['ltr', 'rtl'],
+  spacing: ['auto', 'exact'],
+  styleSource: ['direct', 'paragraphStyle', 'documentDefault'],
+  fontSource: ['direct', 'theme', 'documentDefault'],
+  anchorReference: ['none', 'margin', 'page', 'paragraph'],
+} as const;
+
+export type ConformanceAxisName = keyof typeof CONFORMANCE_AXES;
+
+export type ConformanceAxisValues = {
+  readonly [K in ConformanceAxisName]: (typeof CONFORMANCE_AXES)[K][number];
+};
+
+export interface ConformanceExpectation {
+  readonly pageCount: number;
+  readonly pageWidthPt: number;
+  readonly pageHeightPt: number;
+  readonly targetText: string;
+  readonly targetStory: ConformanceAxisValues['story'];
+  readonly tableDepth: 0 | 1 | 2;
+  readonly drawingCount: 0 | 1;
+}
+
+export interface ConformanceCase {
+  readonly id: string;
+  readonly axes: ConformanceAxisValues;
+  readonly expected: ConformanceExpectation;
+  readonly seed: boolean;
+}
+
+const AXIS_NAMES = Object.keys(CONFORMANCE_AXES) as ConformanceAxisName[];
+
+function isValidAxes(axes: ConformanceAxisValues): boolean {
+  if (axes.object === 'floating') {
+    if (axes.anchorReference === 'none') return false;
+  } else if (axes.anchorReference !== 'none') {
+    return false;
+  }
+
+  // Header/footer fixtures isolate story routing. Tables and drawings remain in
+  // body cases so a failure cannot be masked by header/footer repetition.
+  if (axes.story !== 'body') {
+    return axes.container === 'paragraph' && axes.object === 'none';
+  }
+  return true;
+}
+
+function isCompleteAxes(
+  row: Partial<ConformanceAxisValues>,
+): row is ConformanceAxisValues {
+  return AXIS_NAMES.every((axis) => row[axis] !== undefined);
+}
+
+function cartesianRows(): ConformanceAxisValues[] {
+  let rows: Partial<ConformanceAxisValues>[] = [{}];
+  for (const axis of AXIS_NAMES) {
+    rows = rows.flatMap((row) =>
+      CONFORMANCE_AXES[axis].map<Partial<ConformanceAxisValues>>((value) => ({
+        ...row,
+        [axis]: value,
+      })),
+    );
+  }
+  return rows
+    .filter(isCompleteAxes)
+    .filter(isValidAxes);
+}
+
+function valueKey(axis: ConformanceAxisName, value: string): string {
+  return `${axis}=${value}`;
+}
+
+function pairKey(
+  leftAxis: ConformanceAxisName,
+  leftValue: string,
+  rightAxis: ConformanceAxisName,
+  rightValue: string,
+): string {
+  return `${valueKey(leftAxis, leftValue)}|${valueKey(rightAxis, rightValue)}`;
+}
+
+function pairsOf(row: ConformanceAxisValues): string[] {
+  const pairs: string[] = [];
+  for (let left = 0; left < AXIS_NAMES.length; left += 1) {
+    for (let right = left + 1; right < AXIS_NAMES.length; right += 1) {
+      const leftAxis = AXIS_NAMES[left]!;
+      const rightAxis = AXIS_NAMES[right]!;
+      pairs.push(pairKey(leftAxis, row[leftAxis], rightAxis, row[rightAxis]));
+    }
+  }
+  return pairs;
+}
+
+function rowKey(row: ConformanceAxisValues): string {
+  return AXIS_NAMES.map((axis) => valueKey(axis, row[axis])).join('|');
+}
+
+const SEED_ROWS: readonly ConformanceAxisValues[] = [
+  {
+    story: 'body',
+    container: 'nestedTable',
+    paragraph: 'wrapped',
+    object: 'floating',
+    direction: 'rtl',
+    spacing: 'exact',
+    styleSource: 'paragraphStyle',
+    fontSource: 'theme',
+    anchorReference: 'page',
+  },
+  {
+    story: 'body',
+    container: 'table',
+    paragraph: 'single',
+    object: 'inline',
+    direction: 'ltr',
+    spacing: 'auto',
+    styleSource: 'direct',
+    fontSource: 'direct',
+    anchorReference: 'none',
+  },
+  {
+    story: 'header',
+    container: 'paragraph',
+    paragraph: 'wrapped',
+    object: 'none',
+    direction: 'rtl',
+    spacing: 'exact',
+    styleSource: 'documentDefault',
+    fontSource: 'documentDefault',
+    anchorReference: 'none',
+  },
+  {
+    story: 'footer',
+    container: 'paragraph',
+    paragraph: 'single',
+    object: 'none',
+    direction: 'ltr',
+    spacing: 'auto',
+    styleSource: 'paragraphStyle',
+    fontSource: 'theme',
+    anchorReference: 'none',
+  },
+];
+
+/**
+ * Deterministic greedy covering-array construction.
+ *
+ * Exhaustive candidate enumeration is intentionally acceptable here: the
+ * constrained matrix has fewer than two thousand rows.  At each step the
+ * lexicographically first row covering the most still-uncovered feasible pairs
+ * wins.  Reverse elimination then removes redundant non-seed rows.
+ */
+export function generatePairwiseAxes(): readonly {
+  readonly axes: ConformanceAxisValues;
+  readonly seed: boolean;
+}[] {
+  const candidates = cartesianRows().sort((left, right) =>
+    rowKey(left).localeCompare(rowKey(right)));
+  const required = new Set(candidates.flatMap(pairsOf));
+  const selected: Array<{ axes: ConformanceAxisValues; seed: boolean }> = [];
+  const selectedKeys = new Set<string>();
+
+  const add = (axes: ConformanceAxisValues, seed: boolean): void => {
+    if (!isValidAxes(axes)) throw new Error(`invalid conformance seed: ${rowKey(axes)}`);
+    const key = rowKey(axes);
+    if (selectedKeys.has(key)) return;
+    selected.push({ axes, seed });
+    selectedKeys.add(key);
+    for (const pair of pairsOf(axes)) required.delete(pair);
+  };
+
+  for (const seed of SEED_ROWS) add(seed, true);
+
+  while (required.size > 0) {
+    let best: ConformanceAxisValues | undefined;
+    let bestScore = -1;
+    for (const candidate of candidates) {
+      if (selectedKeys.has(rowKey(candidate))) continue;
+      let score = 0;
+      for (const pair of pairsOf(candidate)) {
+        if (required.has(pair)) score += 1;
+      }
+      if (score > bestScore) {
+        best = candidate;
+        bestScore = score;
+      }
+    }
+    if (!best || bestScore <= 0) {
+      throw new Error(`pairwise generation stalled with ${required.size} pairs`);
+    }
+    add(best, false);
+  }
+
+  // Remove a non-seed row when every pair it owns is still covered elsewhere.
+  for (let index = selected.length - 1; index >= 0; index -= 1) {
+    const row = selected[index]!;
+    if (row.seed) continue;
+    const others = selected.filter((_, otherIndex) => otherIndex !== index);
+    const covered = new Set(others.flatMap(({ axes }) => pairsOf(axes)));
+    if (pairsOf(row.axes).every((pair) => covered.has(pair))) {
+      selected.splice(index, 1);
+    }
+  }
+  return selected;
+}
+
+function slug(axes: ConformanceAxisValues): string {
+  const abbreviation = {
+    story: { body: 'body', header: 'hdr', footer: 'ftr' },
+    container: { paragraph: 'p', table: 'tbl', nestedTable: 'ntbl' },
+    paragraph: { single: 'one', wrapped: 'wrap' },
+    object: { none: 'noobj', inline: 'inl', floating: 'float' },
+    direction: { ltr: 'ltr', rtl: 'rtl' },
+    spacing: { auto: 'auto', exact: 'exact' },
+    styleSource: { direct: 'direct', paragraphStyle: 'pstyle', documentDefault: 'docdef' },
+    fontSource: { direct: 'font', theme: 'theme', documentDefault: 'fontdef' },
+    anchorReference: { none: 'noref', margin: 'margin', page: 'page', paragraph: 'para' },
+  } as const;
+  return AXIS_NAMES.map((axis) => abbreviation[axis][axes[axis] as never]).join('-');
+}
+
+export const CONFORMANCE_CASES: readonly ConformanceCase[] = generatePairwiseAxes()
+  .map(({ axes, seed }) => {
+    const id = slug(axes);
+    return {
+      id,
+      axes,
+      seed,
+      expected: {
+        pageCount: 1,
+        pageWidthPt: 612,
+        pageHeightPt: 792,
+        targetText: `CASE_${id.toUpperCase().replaceAll('-', '_')}`,
+        targetStory: axes.story,
+        tableDepth: axes.container === 'nestedTable' ? 2 : axes.container === 'table' ? 1 : 0,
+        drawingCount: axes.object === 'none' ? 0 : 1,
+      },
+    } satisfies ConformanceCase;
+  });
+
+export function feasiblePairKeys(): ReadonlySet<string> {
+  return new Set(cartesianRows().flatMap(pairsOf));
+}
+
+export function coveredPairKeys(
+  cases: readonly Pick<ConformanceCase, 'axes'>[],
+): ReadonlySet<string> {
+  return new Set(cases.flatMap(({ axes }) => pairsOf(axes)));
+}

--- a/packages/docx/src/conformance/cases.ts
+++ b/packages/docx/src/conformance/cases.ts
@@ -45,6 +45,10 @@ export interface ConformanceCase {
 
 const AXIS_NAMES = Object.keys(CONFORMANCE_AXES) as ConformanceAxisName[];
 
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 function isValidAxes(axes: ConformanceAxisValues): boolean {
   if (axes.object === 'floating') {
     if (axes.anchorReference === 'none') return false;
@@ -170,7 +174,7 @@ export function generatePairwiseAxes(): readonly {
   readonly seed: boolean;
 }[] {
   const candidates = cartesianRows().sort((left, right) =>
-    rowKey(left).localeCompare(rowKey(right)));
+    compareCodeUnits(rowKey(left), rowKey(right)));
   const required = new Set(candidates.flatMap(pairsOf));
   const selected: Array<{ axes: ConformanceAxisValues; seed: boolean }> = [];
   const selectedKeys = new Set<string>();
@@ -219,19 +223,31 @@ export function generatePairwiseAxes(): readonly {
   return selected;
 }
 
+type AxisAbbreviations = {
+  readonly [K in ConformanceAxisName]: Readonly<Record<ConformanceAxisValues[K], string>>;
+};
+
+const AXIS_ABBREVIATIONS: AxisAbbreviations = {
+  story: { body: 'body', header: 'hdr', footer: 'ftr' },
+  container: { paragraph: 'p', table: 'tbl', nestedTable: 'ntbl' },
+  paragraph: { single: 'one', wrapped: 'wrap' },
+  object: { none: 'noobj', inline: 'inl', floating: 'float' },
+  direction: { ltr: 'ltr', rtl: 'rtl' },
+  spacing: { auto: 'auto', exact: 'exact' },
+  styleSource: { direct: 'direct', paragraphStyle: 'pstyle', documentDefault: 'docdef' },
+  fontSource: { direct: 'font', theme: 'theme', documentDefault: 'fontdef' },
+  anchorReference: { none: 'noref', margin: 'margin', page: 'page', paragraph: 'para' },
+};
+
+function axisAbbreviation<K extends ConformanceAxisName>(
+  axis: K,
+  value: ConformanceAxisValues[K],
+): string {
+  return AXIS_ABBREVIATIONS[axis][value];
+}
+
 function slug(axes: ConformanceAxisValues): string {
-  const abbreviation = {
-    story: { body: 'body', header: 'hdr', footer: 'ftr' },
-    container: { paragraph: 'p', table: 'tbl', nestedTable: 'ntbl' },
-    paragraph: { single: 'one', wrapped: 'wrap' },
-    object: { none: 'noobj', inline: 'inl', floating: 'float' },
-    direction: { ltr: 'ltr', rtl: 'rtl' },
-    spacing: { auto: 'auto', exact: 'exact' },
-    styleSource: { direct: 'direct', paragraphStyle: 'pstyle', documentDefault: 'docdef' },
-    fontSource: { direct: 'font', theme: 'theme', documentDefault: 'fontdef' },
-    anchorReference: { none: 'noref', margin: 'margin', page: 'page', paragraph: 'para' },
-  } as const;
-  return AXIS_NAMES.map((axis) => abbreviation[axis][axes[axis] as never]).join('-');
+  return AXIS_NAMES.map((axis) => axisAbbreviation(axis, axes[axis])).join('-');
 }
 
 export const CONFORMANCE_CASES: readonly ConformanceCase[] = generatePairwiseAxes()

--- a/packages/docx/src/conformance/generate.ts
+++ b/packages/docx/src/conformance/generate.ts
@@ -1,0 +1,423 @@
+import type { ConformanceAxisValues, ConformanceCase } from './cases.js';
+
+const encoder = new TextEncoder();
+const FIXED_DOS_TIME = 0;
+const FIXED_DOS_DATE = 0x0021; // 1980-01-01
+
+const CONTENT_TYPES_NS =
+  'http://schemas.openxmlformats.org/package/2006/content-types';
+const PACKAGE_REL_NS =
+  'http://schemas.openxmlformats.org/package/2006/relationships';
+const WORD_NS =
+  'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const OFFICE_REL_NS =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const DRAWING_NS =
+  'http://schemas.openxmlformats.org/drawingml/2006/main';
+const WORD_DRAWING_NS =
+  'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const PICTURE_NS =
+  'http://schemas.openxmlformats.org/drawingml/2006/picture';
+
+const REL_OFFICE_DOCUMENT =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+const REL_STYLES =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
+const REL_THEME =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme';
+const REL_HEADER =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header';
+const REL_FOOTER =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer';
+const REL_IMAGE =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image';
+
+const ONE_PIXEL_PNG = Uint8Array.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41,
+  0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0xf0,
+  0x1f, 0x00, 0x05, 0x00, 0x01, 0xff, 0x89, 0x99,
+  0x3d, 0x1d, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+  0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+]);
+
+function xml(value: string): Uint8Array {
+  return encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${value}`);
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function paragraphProperties(axes: ConformanceAxisValues): string {
+  const style = axes.styleSource === 'paragraphStyle'
+    ? '<w:pStyle w:val="CaseStyle"/>'
+    : '';
+  if (axes.styleSource !== 'direct') return `<w:pPr>${style}</w:pPr>`;
+  return `<w:pPr>${style}${paragraphPropertyValues(axes)}</w:pPr>`;
+}
+
+function paragraphPropertyValues(axes: ConformanceAxisValues): string {
+  const bidi = axes.direction === 'rtl' ? '<w:bidi/>' : '';
+  const spacing = axes.spacing === 'exact'
+    ? '<w:spacing w:after="120" w:line="240" w:lineRule="exact"/>'
+    : '<w:spacing w:after="120" w:line="240" w:lineRule="auto"/>';
+  return `${bidi}${spacing}`;
+}
+
+function runProperties(axes: ConformanceAxisValues): string {
+  if (axes.fontSource === 'documentDefault') return '';
+  const fonts = axes.fontSource === 'theme'
+    ? '<w:rFonts w:asciiTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi"/>'
+    : '<w:rFonts w:ascii="Ahem" w:hAnsi="Ahem"/>';
+  return `<w:rPr>${fonts}<w:sz w:val="20"/></w:rPr>`;
+}
+
+function targetText(testCase: ConformanceCase): string {
+  const base = testCase.expected.targetText;
+  return testCase.axes.paragraph === 'wrapped'
+    ? `${base} ${'PAIRWISE CONFORMANCE '.repeat(18).trim()}`
+    : base;
+}
+
+function drawing(axes: ConformanceAxisValues): string {
+  if (axes.object === 'none') return '';
+  const extent = '<wp:extent cx="457200" cy="274320"/>';
+  const graphic = `<wp:docPr id="1" name="Synthetic conformance object"/>
+    <wp:cNvGraphicFramePr/>
+    <a:graphic xmlns:a="${DRAWING_NS}">
+      <a:graphicData uri="${PICTURE_NS}">
+        <pic:pic xmlns:pic="${PICTURE_NS}">
+          <pic:nvPicPr>
+            <pic:cNvPr id="1" name="pixel.png"/>
+            <pic:cNvPicPr/>
+          </pic:nvPicPr>
+          <pic:blipFill>
+            <a:blip r:embed="rIdImage"/>
+            <a:stretch><a:fillRect/></a:stretch>
+          </pic:blipFill>
+          <pic:spPr>
+            <a:xfrm><a:off x="0" y="0"/><a:ext cx="457200" cy="274320"/></a:xfrm>
+            <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+          </pic:spPr>
+        </pic:pic>
+      </a:graphicData>
+    </a:graphic>`;
+  if (axes.object === 'inline') {
+    return `<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">
+      ${extent}${graphic}
+    </wp:inline></w:drawing></w:r>`;
+  }
+  const reference = axes.anchorReference;
+  if (reference === 'none') throw new Error('floating conformance object requires a reference');
+  // `paragraph` is an ST_RelFromV value, not ST_RelFromH (§20.4.3.2 versus
+  // §20.4.3.3). Keep the horizontal axis schema-valid while the case exercises
+  // the requested vertical reference frame.
+  const horizontalReference = reference === 'paragraph' ? 'column' : reference;
+  return `<w:r><w:drawing><wp:anchor simplePos="0" relativeHeight="251658240"
+      behindDoc="0" locked="0" layoutInCell="1" allowOverlap="0"
+      distT="0" distB="0" distL="0" distR="0">
+    <wp:simplePos x="0" y="0"/>
+    <wp:positionH relativeFrom="${horizontalReference}"><wp:posOffset>914400</wp:posOffset></wp:positionH>
+    <wp:positionV relativeFrom="${reference}"><wp:posOffset>0</wp:posOffset></wp:positionV>
+    ${extent}<wp:effectExtent l="0" t="0" r="0" b="0"/>
+    <wp:wrapSquare wrapText="bothSides"/>
+    ${graphic}
+  </wp:anchor></w:drawing></w:r>`;
+}
+
+function paragraph(testCase: ConformanceCase, text = targetText(testCase)): string {
+  return `<w:p>
+    ${paragraphProperties(testCase.axes)}
+    <w:r>${runProperties(testCase.axes)}<w:t xml:space="preserve">${escapeXml(text)}</w:t></w:r>
+    ${drawing(testCase.axes)}
+  </w:p>`;
+}
+
+function bodyContent(testCase: ConformanceCase): string {
+  if (testCase.axes.story !== 'body') {
+    return '<w:p><w:r><w:t>BODY_WITNESS</w:t></w:r></w:p>';
+  }
+  const target = paragraph(testCase);
+  if (testCase.axes.container === 'paragraph') return target;
+  if (testCase.axes.container === 'table') {
+    return table(target, false);
+  }
+  const inner = table(target, true);
+  return table(`<w:p><w:r><w:t>NESTED_TABLE_PREFIX</w:t></w:r></w:p>${inner}
+    <w:p><w:r><w:t>NESTED_TABLE_SUFFIX</w:t></w:r></w:p>`, false);
+}
+
+function table(cellContent: string, inner: boolean): string {
+  const width = inner ? 3600 : 7200;
+  return `<w:tbl>
+    <w:tblPr>
+      <w:tblW w:w="${width}" w:type="dxa"/>
+      <w:tblLayout w:type="fixed"/>
+      <w:tblBorders>
+        <w:top w:val="single" w:sz="8" w:space="0" w:color="000000"/>
+        <w:left w:val="single" w:sz="8" w:space="0" w:color="000000"/>
+        <w:bottom w:val="single" w:sz="8" w:space="0" w:color="000000"/>
+        <w:right w:val="single" w:sz="8" w:space="0" w:color="000000"/>
+      </w:tblBorders>
+    </w:tblPr>
+    <w:tblGrid><w:gridCol w:w="${width}"/></w:tblGrid>
+    <w:tr><w:tc>
+      <w:tcPr><w:tcW w:w="${width}" w:type="dxa"/></w:tcPr>
+      ${cellContent}
+    </w:tc></w:tr>
+  </w:tbl>`;
+}
+
+function styles(testCase: ConformanceCase): Uint8Array {
+  const axes = testCase.axes;
+  const defaultParagraph = axes.styleSource === 'documentDefault'
+    ? `<w:pPrDefault><w:pPr>${paragraphPropertyValues(axes)}</w:pPr></w:pPrDefault>`
+    : '<w:pPrDefault><w:pPr/></w:pPrDefault>';
+  const defaultRun = axes.fontSource === 'documentDefault'
+    ? '<w:rPrDefault><w:rPr><w:rFonts w:ascii="Ahem" w:hAnsi="Ahem"/><w:sz w:val="20"/></w:rPr></w:rPrDefault>'
+    : '<w:rPrDefault><w:rPr><w:sz w:val="20"/></w:rPr></w:rPrDefault>';
+  const styleParagraph = axes.styleSource === 'paragraphStyle'
+    ? paragraphPropertyValues(axes)
+    : '';
+  return xml(`<w:styles xmlns:w="${WORD_NS}">
+    <w:docDefaults>${defaultRun}${defaultParagraph}</w:docDefaults>
+    <w:style w:type="paragraph" w:default="1" w:styleId="Normal">
+      <w:name w:val="Normal"/>
+    </w:style>
+    <w:style w:type="paragraph" w:styleId="CaseStyle">
+      <w:name w:val="Case Style"/>
+      <w:basedOn w:val="Normal"/>
+      <w:pPr>${styleParagraph}</w:pPr>
+    </w:style>
+  </w:styles>`);
+}
+
+function theme(): Uint8Array {
+  return xml(`<a:theme xmlns:a="${DRAWING_NS}" name="Synthetic Conformance">
+    <a:themeElements>
+      <a:clrScheme name="Synthetic">
+        <a:dk1><a:srgbClr val="000000"/></a:dk1>
+        <a:lt1><a:srgbClr val="FFFFFF"/></a:lt1>
+        <a:dk2><a:srgbClr val="1F1F1F"/></a:dk2>
+        <a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>
+        <a:accent1><a:srgbClr val="4472C4"/></a:accent1>
+        <a:accent2><a:srgbClr val="ED7D31"/></a:accent2>
+        <a:accent3><a:srgbClr val="A5A5A5"/></a:accent3>
+        <a:accent4><a:srgbClr val="FFC000"/></a:accent4>
+        <a:accent5><a:srgbClr val="5B9BD5"/></a:accent5>
+        <a:accent6><a:srgbClr val="70AD47"/></a:accent6>
+        <a:hlink><a:srgbClr val="0563C1"/></a:hlink>
+        <a:folHlink><a:srgbClr val="954F72"/></a:folHlink>
+      </a:clrScheme>
+      <a:fontScheme name="Synthetic">
+        <a:majorFont><a:latin typeface="Ahem"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont>
+        <a:minorFont><a:latin typeface="Ahem"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont>
+      </a:fontScheme>
+      <a:fmtScheme name="Synthetic">
+        <a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:fillStyleLst>
+        <a:lnStyleLst><a:ln w="9525"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln></a:lnStyleLst>
+        <a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle></a:effectStyleLst>
+        <a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:bgFillStyleLst>
+      </a:fmtScheme>
+    </a:themeElements>
+  </a:theme>`);
+}
+
+function contentTypes(testCase: ConformanceCase): Uint8Array {
+  const storyOverride = testCase.axes.story === 'header'
+    ? '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>'
+    : testCase.axes.story === 'footer'
+      ? '<Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>'
+      : '';
+  return xml(`<Types xmlns="${CONTENT_TYPES_NS}">
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Default Extension="png" ContentType="image/png"/>
+    <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+    <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+    <Override PartName="/word/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+    ${storyOverride}
+  </Types>`);
+}
+
+function documentRelationships(testCase: ConformanceCase): Uint8Array {
+  const storyRelationship = testCase.axes.story === 'header'
+    ? `<Relationship Id="rIdHeader" Type="${REL_HEADER}" Target="header1.xml"/>`
+    : testCase.axes.story === 'footer'
+      ? `<Relationship Id="rIdFooter" Type="${REL_FOOTER}" Target="footer1.xml"/>`
+      : '';
+  const imageRelationship = testCase.axes.object === 'none'
+    ? ''
+    : `<Relationship Id="rIdImage" Type="${REL_IMAGE}" Target="media/pixel.png"/>`;
+  return xml(`<Relationships xmlns="${PACKAGE_REL_NS}">
+    <Relationship Id="rIdStyles" Type="${REL_STYLES}" Target="styles.xml"/>
+    <Relationship Id="rIdTheme" Type="${REL_THEME}" Target="theme/theme1.xml"/>
+    ${storyRelationship}${imageRelationship}
+  </Relationships>`);
+}
+
+function documentXml(testCase: ConformanceCase): Uint8Array {
+  const storyReference = testCase.axes.story === 'header'
+    ? '<w:headerReference w:type="default" r:id="rIdHeader"/>'
+    : testCase.axes.story === 'footer'
+      ? '<w:footerReference w:type="default" r:id="rIdFooter"/>'
+      : '';
+  return xml(`<w:document xmlns:w="${WORD_NS}" xmlns:r="${OFFICE_REL_NS}"
+      xmlns:wp="${WORD_DRAWING_NS}" xmlns:a="${DRAWING_NS}" xmlns:pic="${PICTURE_NS}">
+    <w:body>
+      ${bodyContent(testCase)}
+      <w:sectPr>
+        ${storyReference}
+        <w:pgSz w:w="12240" w:h="15840"/>
+        <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"
+          w:header="720" w:footer="720" w:gutter="0"/>
+      </w:sectPr>
+    </w:body>
+  </w:document>`);
+}
+
+function storyXml(testCase: ConformanceCase): Uint8Array {
+  const root = testCase.axes.story === 'header' ? 'hdr' : 'ftr';
+  return xml(`<w:${root} xmlns:w="${WORD_NS}" xmlns:r="${OFFICE_REL_NS}"
+      xmlns:wp="${WORD_DRAWING_NS}" xmlns:a="${DRAWING_NS}" xmlns:pic="${PICTURE_NS}">
+    ${paragraph(testCase)}
+  </w:${root}>`);
+}
+
+export function generateConformanceParts(
+  testCase: ConformanceCase,
+): ReadonlyMap<string, Uint8Array> {
+  const parts = new Map<string, Uint8Array>([
+    ['[Content_Types].xml', contentTypes(testCase)],
+    ['_rels/.rels', xml(`<Relationships xmlns="${PACKAGE_REL_NS}">
+      <Relationship Id="rId1" Type="${REL_OFFICE_DOCUMENT}" Target="word/document.xml"/>
+    </Relationships>`)],
+    ['word/_rels/document.xml.rels', documentRelationships(testCase)],
+    ['word/document.xml', documentXml(testCase)],
+    ['word/styles.xml', styles(testCase)],
+    ['word/theme/theme1.xml', theme()],
+  ]);
+  if (testCase.axes.story !== 'body') {
+    parts.set(`word/${testCase.axes.story}1.xml`, storyXml(testCase));
+  }
+  if (testCase.axes.object !== 'none') {
+    parts.set('word/media/pixel.png', ONE_PIXEL_PNG);
+  }
+  return new Map([...parts].sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function u16(value: number): Uint8Array {
+  return Uint8Array.of(value & 0xff, (value >>> 8) & 0xff);
+}
+
+function u32(value: number): Uint8Array {
+  return Uint8Array.of(
+    value & 0xff,
+    (value >>> 8) & 0xff,
+    (value >>> 16) & 0xff,
+    (value >>> 24) & 0xff,
+  );
+}
+
+function concat(chunks: readonly Uint8Array[]): Uint8Array {
+  const length = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const output = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+/**
+ * Minimal deterministic ZIP writer using stored entries.
+ *
+ * Avoiding DEFLATE makes the byte stream independent of native zlib versions.
+ * Entry order, timestamps, flags, creator version and attributes are all fixed.
+ */
+export function storeZip(parts: ReadonlyMap<string, Uint8Array>): Uint8Array {
+  const localChunks: Uint8Array[] = [];
+  const centralChunks: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const [name, data] of [...parts].sort(([left], [right]) => left.localeCompare(right))) {
+    const encodedName = encoder.encode(name);
+    const checksum = crc32(data);
+    const local = concat([
+      u32(0x04034b50),
+      u16(20),
+      u16(0x0800),
+      u16(0),
+      u16(FIXED_DOS_TIME),
+      u16(FIXED_DOS_DATE),
+      u32(checksum),
+      u32(data.byteLength),
+      u32(data.byteLength),
+      u16(encodedName.byteLength),
+      u16(0),
+      encodedName,
+      data,
+    ]);
+    localChunks.push(local);
+    centralChunks.push(concat([
+      u32(0x02014b50),
+      u16(20),
+      u16(20),
+      u16(0x0800),
+      u16(0),
+      u16(FIXED_DOS_TIME),
+      u16(FIXED_DOS_DATE),
+      u32(checksum),
+      u32(data.byteLength),
+      u32(data.byteLength),
+      u16(encodedName.byteLength),
+      u16(0),
+      u16(0),
+      u16(0),
+      u16(0),
+      u32(0),
+      u32(offset),
+      encodedName,
+    ]));
+    offset += local.byteLength;
+  }
+
+  const central = concat(centralChunks);
+  return concat([
+    ...localChunks,
+    central,
+    u32(0x06054b50),
+    u16(0),
+    u16(0),
+    u16(parts.size),
+    u16(parts.size),
+    u32(central.byteLength),
+    u32(offset),
+    u16(0),
+  ]);
+}
+
+export function generateConformanceDocx(testCase: ConformanceCase): Uint8Array {
+  return storeZip(generateConformanceParts(testCase));
+}

--- a/packages/docx/src/conformance/generate.ts
+++ b/packages/docx/src/conformance/generate.ts
@@ -161,13 +161,13 @@ function table(cellContent: string, inner: boolean): string {
   return `<w:tbl>
     <w:tblPr>
       <w:tblW w:w="${width}" w:type="dxa"/>
-      <w:tblLayout w:type="fixed"/>
       <w:tblBorders>
         <w:top w:val="single" w:sz="8" w:space="0" w:color="000000"/>
         <w:left w:val="single" w:sz="8" w:space="0" w:color="000000"/>
         <w:bottom w:val="single" w:sz="8" w:space="0" w:color="000000"/>
         <w:right w:val="single" w:sz="8" w:space="0" w:color="000000"/>
       </w:tblBorders>
+      <w:tblLayout w:type="fixed"/>
     </w:tblPr>
     <w:tblGrid><w:gridCol w:w="${width}"/></w:tblGrid>
     <w:tr><w:tc>
@@ -312,7 +312,8 @@ export function generateConformanceParts(
   if (testCase.axes.object !== 'none') {
     parts.set('word/media/pixel.png', ONE_PIXEL_PNG);
   }
-  return new Map([...parts].sort(([left], [right]) => left.localeCompare(right)));
+  return new Map([...parts].sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0));
 }
 
 function crc32(bytes: Uint8Array): number {
@@ -361,7 +362,8 @@ export function storeZip(parts: ReadonlyMap<string, Uint8Array>): Uint8Array {
   const centralChunks: Uint8Array[] = [];
   let offset = 0;
 
-  for (const [name, data] of [...parts].sort(([left], [right]) => left.localeCompare(right))) {
+  for (const [name, data] of [...parts].sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0)) {
     const encodedName = encoder.encode(name);
     const checksum = crc32(data);
     const local = concat([

--- a/packages/docx/src/conformance/layout.test.ts
+++ b/packages/docx/src/conformance/layout.test.ts
@@ -1,0 +1,342 @@
+/// <reference types="node" />
+
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { beforeAll, describe, expect, it } from 'vitest';
+import init, { DocxArchive } from '../wasm/docx_parser.js';
+import type {
+  DocParagraph,
+  DocxDocumentModel,
+  DocxTextRun,
+  ImageRun,
+} from '../types.js';
+import { normalizeInternalDocumentModel } from '../parser-model.js';
+import { createLayoutServices, layoutDocument } from '../renderer.js';
+import { assertDocumentLayout, layoutFingerprint } from '../layout/invariants.js';
+import type {
+  DocumentLayout,
+  LayoutRect,
+  LayoutServices,
+  ParagraphLayout,
+  TextPlacement,
+} from '../layout/types.js';
+import {
+  CONFORMANCE_CASES,
+  coveredPairKeys,
+  feasiblePairKeys,
+} from './cases.js';
+import { generateConformanceDocx, generateConformanceParts } from './generate.js';
+
+function measureContext(): CanvasRenderingContext2D {
+  return {
+    font: '',
+    letterSpacing: '0px',
+    fontKerning: 'auto',
+    measureText: (text: string) => ({
+      width: [...text].length * 6,
+      actualBoundingBoxAscent: 8,
+      actualBoundingBoxDescent: 2,
+      fontBoundingBoxAscent: 8,
+      fontBoundingBoxDescent: 2,
+    }),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function parse(bytes: Uint8Array): DocxDocumentModel {
+  const archive = new DocxArchive(bytes);
+  try {
+    const parsed = JSON.parse(
+      new TextDecoder().decode(archive.parse()),
+    ) as DocxDocumentModel;
+    return normalizeInternalDocumentModel(parsed).document;
+  } finally {
+    archive.free();
+  }
+}
+
+function serviceIdentity(services: LayoutServices): readonly string[] {
+  return [
+    services.text.fingerprint,
+    services.images.fingerprint,
+    services.math.fingerprint,
+  ];
+}
+
+function records(root: unknown): Record<string, unknown>[] {
+  const output: Record<string, unknown>[] = [];
+  const visit = (value: unknown): void => {
+    if (value === null || typeof value !== 'object') return;
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    const record = value as Record<string, unknown>;
+    output.push(record);
+    Object.values(record).forEach(visit);
+  };
+  visit(root);
+  return output;
+}
+
+function rootRecords(layout: DocumentLayout): Record<string, unknown>[] {
+  return layout.pages.flatMap((page) =>
+    page.layers.roots.flatMap(({ node }) => records(node)));
+}
+
+function paragraphRangePartitions(layout: DocumentLayout): void {
+  const paragraphs = rootRecords(layout)
+    .filter((record) => record.kind === 'paragraph') as unknown as ParagraphLayout[];
+  expect(paragraphs.length).toBeGreaterThan(0);
+  for (const paragraph of paragraphs) {
+    let previousEnd = paragraph.lines[0]?.range.start ?? 0;
+    for (const line of paragraph.lines) {
+      expect(line.range.start).toBe(previousEnd);
+      expect(line.range.end).toBeGreaterThanOrEqual(line.range.start);
+      let coveredEnd = line.range.start;
+      const sourceOrdered = [...line.placements]
+        .sort((left, right) => left.range.start - right.range.start
+          || left.range.end - right.range.end);
+      for (const placement of sourceOrdered) {
+        expect(placement.range.start).toBeGreaterThanOrEqual(line.range.start);
+        expect(placement.range.end).toBeLessThanOrEqual(line.range.end);
+        // RTL visual order and anchor-host markers may overlap source ranges,
+        // but the union must remain a gap-free partition of the line.
+        expect(placement.range.start).toBeLessThanOrEqual(coveredEnd);
+        coveredEnd = Math.max(coveredEnd, placement.range.end);
+      }
+      expect(coveredEnd).toBe(line.range.end);
+      previousEnd = line.range.end;
+    }
+  }
+}
+
+function targetTextPlacements(layout: DocumentLayout, target: string): TextPlacement[] {
+  const paragraphs = rootRecords(layout)
+    .filter((record) => record.kind === 'paragraph') as unknown as ParagraphLayout[];
+  for (const paragraph of paragraphs) {
+    const placements = paragraph.lines
+      .flatMap(({ placements: linePlacements }) => linePlacements)
+      .filter((placement): placement is TextPlacement => placement.kind === 'text')
+      .sort((left, right) => left.range.start - right.range.start);
+    if (placements.map(({ text }) => text).join('').includes(target)) return placements;
+  }
+  throw new Error(`retained text does not contain ${target}`);
+}
+
+function assertBottomClearance(layout: DocumentLayout): void {
+  for (const page of layout.pages) {
+    const domains = new Map(page.flowDomains.map((domain) => [domain.id, domain]));
+    for (const { node } of page.layers.roots) {
+      if (!node.ordinaryFlow) continue;
+      const domain = domains.get(node.flowDomainId);
+      expect(domain, `missing flow domain ${node.flowDomainId}`).toBeDefined();
+      if (!domain) continue;
+      const bounds = node.flowBounds as LayoutRect;
+      const domainBottom = domain.logicalBounds.yPt + domain.logicalBounds.heightPt;
+      const oversize = bounds.heightPt > domain.logicalBounds.heightPt;
+      expect(
+        bounds.yPt + bounds.heightPt <= domainBottom || oversize,
+        `${node.id} invades the bottom of ${domain.id}`,
+      ).toBe(true);
+    }
+  }
+}
+
+function maxTableDepth(value: unknown, depth = 0): number {
+  if (value === null || typeof value !== 'object') return depth;
+  if (Array.isArray(value)) {
+    return value.reduce((max, entry) => Math.max(max, maxTableDepth(entry, depth)), depth);
+  }
+  const record = value as Record<string, unknown>;
+  const nextDepth = record.type === 'table' ? depth + 1 : depth;
+  return Object.values(record)
+    .reduce<number>(
+      (max, entry) => Math.max(max, maxTableDepth(entry, nextDepth)),
+      nextDepth,
+    );
+}
+
+function parsedDrawingCount(model: DocxDocumentModel): number {
+  return records(model).filter((record) =>
+    record.type === 'image' || record.type === 'shape').length;
+}
+
+function storyValue(
+  model: DocxDocumentModel,
+  story: 'body' | 'header' | 'footer',
+): unknown {
+  return story === 'body'
+    ? model.body
+    : story === 'header'
+      ? model.headers.default
+      : model.footers.default;
+}
+
+function targetParagraph(
+  model: DocxDocumentModel,
+  story: 'body' | 'header' | 'footer',
+  target: string,
+): DocParagraph {
+  const paragraph = records(storyValue(model, story))
+    .find((record) => record.type === 'paragraph'
+      && JSON.stringify(record).includes(target));
+  if (!paragraph) throw new Error(`parsed story does not contain ${target}`);
+  return paragraph as unknown as DocParagraph;
+}
+
+function targetImage(
+  model: DocxDocumentModel,
+  story: 'body' | 'header' | 'footer',
+): ImageRun | undefined {
+  return records(storyValue(model, story))
+    .find((record) => record.type === 'image') as unknown as ImageRun | undefined;
+}
+
+function textRunOf(paragraph: DocParagraph, target: string): DocxTextRun {
+  const run = paragraph.runs.find((candidate) =>
+    candidate.type === 'text' && candidate.text.includes(target));
+  if (!run || run.type !== 'text') throw new Error(`parsed paragraph lacks ${target}`);
+  return run;
+}
+
+function decodedPart(parts: ReadonlyMap<string, Uint8Array>, name: string): string {
+  const bytes = parts.get(name);
+  if (!bytes) throw new Error(`missing generated part ${name}`);
+  return new TextDecoder().decode(bytes);
+}
+
+beforeAll(async () => {
+  const wasm = await readFile(new URL('../wasm/docx_parser_bg.wasm', import.meta.url));
+  await init({ module_or_path: wasm });
+});
+
+describe('synthetic DOCX conformance matrix', () => {
+  it('is deterministic, bounded, and covers every feasible pair', () => {
+    const feasible = [...feasiblePairKeys()].sort();
+    const covered = [...coveredPairKeys(CONFORMANCE_CASES)].sort();
+    expect(covered).toEqual(feasible);
+    expect(CONFORMANCE_CASES.length).toBeGreaterThanOrEqual(12);
+    expect(CONFORMANCE_CASES.length).toBeLessThanOrEqual(40);
+    expect(new Set(CONFORMANCE_CASES.map(({ id }) => id)).size)
+      .toBe(CONFORMANCE_CASES.length);
+  });
+
+  it('emits byte-identical stored ZIP archives on consecutive generations', () => {
+    const first = CONFORMANCE_CASES.map(generateConformanceDocx);
+    const second = CONFORMANCE_CASES.map(generateConformanceDocx);
+    expect(second).toEqual(first);
+    const hashes = (corpus: readonly Uint8Array[]) => corpus.map((bytes) =>
+      createHash('sha256').update(bytes).digest('hex'));
+    expect(hashes(second)).toEqual(hashes(first));
+    for (const bytes of first) {
+      expect([...bytes.subarray(0, 4)]).toEqual([0x50, 0x4b, 0x03, 0x04]);
+    }
+  });
+});
+
+describe.each(CONFORMANCE_CASES)('$id', (testCase) => {
+  it('parses the intended OOXML facts through the real WASM parser', () => {
+    const parts = generateConformanceParts(testCase);
+    expect(parts.has('word/document.xml')).toBe(true);
+    const model = parse(generateConformanceDocx(testCase));
+    const paragraph = targetParagraph(
+      model,
+      testCase.expected.targetStory,
+      testCase.expected.targetText,
+    );
+    const run = textRunOf(paragraph, testCase.expected.targetText);
+    expect(Boolean(paragraph.bidi)).toBe(testCase.axes.direction === 'rtl');
+    expect(paragraph.lineSpacing).toMatchObject({
+      rule: testCase.axes.spacing,
+      value: testCase.axes.spacing === 'exact' ? 12 : 1,
+    });
+    expect(Boolean(paragraph.lineSpacing?.explicit))
+      .toBe(testCase.axes.styleSource !== 'documentDefault');
+    expect(paragraph.styleId ?? null).toBe(
+      testCase.axes.styleSource === 'paragraphStyle' ? 'CaseStyle' : 'Normal',
+    );
+    expect(run.fontFamily).toBe('Ahem');
+    expect(maxTableDepth(model.body)).toBe(testCase.expected.tableDepth);
+    expect(parsedDrawingCount(model)).toBe(testCase.expected.drawingCount);
+
+    const image = targetImage(model, testCase.expected.targetStory);
+    if (testCase.axes.object === 'none') {
+      expect(image).toBeUndefined();
+    } else {
+      expect(image).toMatchObject({
+        widthPt: 36,
+        heightPt: 21.6,
+        anchor: testCase.axes.object === 'floating',
+      });
+      if (image && testCase.axes.object === 'floating') {
+        expect(Boolean(image.anchorXFromMargin))
+          .toBe(testCase.axes.anchorReference !== 'page');
+        expect(Boolean(image.anchorYFromPara))
+          .toBe(testCase.axes.anchorReference === 'paragraph');
+      }
+    }
+
+    // The parser proves the effective result above. These source-location
+    // checks independently prove the generator placed the same value on the
+    // requested OOXML inheritance layer, so the style/font axes cannot become
+    // decorative while still producing an identical model.
+    const storyPartName = testCase.axes.story === 'body'
+      ? 'word/document.xml'
+      : `word/${testCase.axes.story}1.xml`;
+    const storyXml = decodedPart(parts, storyPartName);
+    const stylesXml = decodedPart(parts, 'word/styles.xml');
+    if (testCase.axes.styleSource === 'direct') {
+      expect(storyXml).toContain('<w:spacing ');
+    } else {
+      expect(storyXml).not.toContain('<w:spacing ');
+      expect(stylesXml).toContain('<w:spacing ');
+    }
+    if (testCase.axes.fontSource === 'direct') {
+      expect(storyXml).toContain('w:ascii="Ahem"');
+    } else if (testCase.axes.fontSource === 'theme') {
+      expect(storyXml).toContain('w:asciiTheme="minorHAnsi"');
+    } else {
+      expect(storyXml).not.toContain('<w:rFonts');
+      expect(stylesXml).toContain('w:ascii="Ahem"');
+    }
+  });
+
+  it('retains deterministic, clone-safe geometry with complete source ranges', () => {
+    const model = parse(generateConformanceDocx(testCase));
+    const cloned = structuredClone(model);
+    const firstServices = createLayoutServices(model, {
+      measureContext: measureContext(),
+    });
+    const secondServices = createLayoutServices(cloned, {
+      measureContext: measureContext(),
+    });
+    const first = layoutDocument(model, firstServices, { currentDateMs: 0 });
+    const second = layoutDocument(cloned, secondServices, { currentDateMs: 0 });
+
+    assertDocumentLayout(first);
+    assertDocumentLayout(second);
+    expect(structuredClone(first)).toEqual(first);
+    expect(serviceIdentity(secondServices)).toEqual(serviceIdentity(firstServices));
+    expect(layoutFingerprint(second)).toBe(layoutFingerprint(first));
+    expect(first.pages).toHaveLength(testCase.expected.pageCount);
+    expect(first.pages[0]?.geometry).toMatchObject({
+      widthPt: testCase.expected.pageWidthPt,
+      heightPt: testCase.expected.pageHeightPt,
+    });
+    expect(first.diagnostics.filter(({ severity }) => severity === 'error')).toEqual([]);
+
+    paragraphRangePartitions(first);
+    const target = targetTextPlacements(first, testCase.expected.targetText);
+    expect(target.length).toBeGreaterThan(0);
+    for (const placement of target) {
+      expect(placement.range.end).toBeGreaterThan(placement.range.start);
+      expect([
+        placement.bounds.xPt,
+        placement.bounds.yPt,
+        placement.bounds.widthPt,
+        placement.bounds.heightPt,
+      ].every(Number.isFinite)).toBe(true);
+    }
+    assertBottomClearance(first);
+  });
+});

--- a/packages/docx/src/conformance/layout.test.ts
+++ b/packages/docx/src/conformance/layout.test.ts
@@ -88,6 +88,8 @@ function paragraphRangePartitions(layout: DocumentLayout): void {
     .filter((record) => record.kind === 'paragraph') as unknown as ParagraphLayout[];
   expect(paragraphs.length).toBeGreaterThan(0);
   for (const paragraph of paragraphs) {
+    expect(paragraph.lines.length, `${paragraph.id} has no retained lines`)
+      .toBeGreaterThan(0);
     let previousEnd = paragraph.lines[0]?.range.start ?? 0;
     for (const line of paragraph.lines) {
       expect(line.range.start).toBe(previousEnd);
@@ -215,6 +217,10 @@ describe('synthetic DOCX conformance matrix', () => {
     const feasible = [...feasiblePairKeys()].sort();
     const covered = [...coveredPairKeys(CONFORMANCE_CASES)].sort();
     expect(covered).toEqual(feasible);
+    expect(feasible).toContain('story=header|fontSource=theme');
+    expect(feasible).not.toContain('story=header|container=table');
+    expect(feasible).toContain('object=floating|anchorReference=paragraph');
+    expect(feasible).not.toContain('object=inline|anchorReference=page');
     expect(CONFORMANCE_CASES.length).toBeGreaterThanOrEqual(12);
     expect(CONFORMANCE_CASES.length).toBeLessThanOrEqual(40);
     expect(new Set(CONFORMANCE_CASES.map(({ id }) => id)).size)

--- a/packages/docx/tests/visual/conformance-fixture.html
+++ b/packages/docx/tests/visual/conformance-fixture.html
@@ -55,7 +55,7 @@
             normalizeNumber(to.yPt),
           ]),
         }))
-        .sort((left, right) => left.id.localeCompare(right.id));
+        .sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
       const drawingRecords = retained
         .filter(({ kind, flowBounds, bounds }) =>
           (kind === 'drawing' && (flowBounds ?? bounds)
@@ -69,7 +69,7 @@
       const drawings = [...new Map(
         drawingRecords.map((record) => [record.id, record]),
       ).values()]
-        .sort((left, right) => left.id.localeCompare(right.id));
+        .sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
       return {
         pageBoxes: layout.pages.map(({ geometry }) => ({
           widthPt: normalizeNumber(geometry.widthPt),

--- a/packages/docx/tests/visual/conformance-fixture.html
+++ b/packages/docx/tests/visual/conformance-fixture.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>DOCX synthetic conformance fixture</title>
+</head>
+<body>
+  <script type="module">
+    import { DocxDocument } from '/src/index.ts';
+    import { createLayoutServices, layoutDocument } from '/src/renderer.ts';
+    import {
+      assertDocumentLayout,
+      layoutFingerprint,
+    } from '/src/layout/invariants.ts';
+    import { CONFORMANCE_CASES } from '/src/conformance/cases.ts';
+    import { generateConformanceDocx } from '/src/conformance/generate.ts';
+
+    const finiteRun = (run) =>
+      ['x', 'y', 'w', 'h', 'fontSize'].every((key) => Number.isFinite(run[key]))
+      && run.w >= 0 && run.h >= 0 && run.fontSize >= 0;
+
+    const normalizeNumber = (value) => {
+      const rounded = Number(value.toFixed(6));
+      return Object.is(rounded, -0) ? 0 : rounded;
+    };
+
+    const records = (root) => {
+      const output = [];
+      const visit = (value) => {
+        if (value === null || typeof value !== 'object') return;
+        if (Array.isArray(value)) {
+          value.forEach(visit);
+          return;
+        }
+        output.push(value);
+        Object.values(value).forEach(visit);
+      };
+      visit(root);
+      return output;
+    };
+
+    const authoredGeometry = (layout) => {
+      const retained = layout.pages.flatMap((page) =>
+        page.layers.roots.flatMap(({ node }) => records(node)));
+      const tables = retained
+        .filter(({ kind, columnWidthsPt, borders }) =>
+          kind === 'table' && Array.isArray(columnWidthsPt) && Array.isArray(borders))
+        .map(({ id, columnWidthsPt, borders }) => ({
+          id,
+          columnWidthsPt: columnWidthsPt.map(normalizeNumber),
+          borderEndpoints: borders.map(({ from, to }) => [
+            normalizeNumber(from.xPt),
+            normalizeNumber(from.yPt),
+            normalizeNumber(to.xPt),
+            normalizeNumber(to.yPt),
+          ]),
+        }))
+        .sort((left, right) => left.id.localeCompare(right.id));
+      const drawingRecords = retained
+        .filter(({ kind, flowBounds, bounds }) =>
+          (kind === 'drawing' && (flowBounds ?? bounds)
+            && typeof (flowBounds ?? bounds) === 'object')
+          || (kind === 'resource' && bounds && typeof bounds === 'object'))
+        .map(({ id, drawingId, resourceKey, flowBounds, bounds }) => ({
+          id: id ?? drawingId ?? resourceKey,
+          widthPt: normalizeNumber((flowBounds ?? bounds).widthPt),
+          heightPt: normalizeNumber((flowBounds ?? bounds).heightPt),
+        }));
+      const drawings = [...new Map(
+        drawingRecords.map((record) => [record.id, record]),
+      ).values()]
+        .sort((left, right) => left.id.localeCompare(right.id));
+      return {
+        pageBoxes: layout.pages.map(({ geometry }) => ({
+          widthPt: normalizeNumber(geometry.widthPt),
+          heightPt: normalizeNumber(geometry.heightPt),
+          contentTopPt: normalizeNumber(geometry.contentTopPt),
+          contentBottomPt: normalizeNumber(geometry.contentBottomPt),
+        })),
+        tables,
+        drawings,
+      };
+    };
+
+    window.runConformanceCase = async (index) => {
+      const testCase = CONFORMANCE_CASES[index];
+      if (!testCase) throw new RangeError(`unknown conformance case ${index}`);
+      const bytes = generateConformanceDocx(testCase);
+      const main = await DocxDocument.load(bytes.slice().buffer, {
+        useGoogleFonts: false,
+      });
+      const worker = await DocxDocument.load(bytes.slice().buffer, {
+        mode: 'worker',
+        useGoogleFonts: false,
+      });
+      try {
+        const services = createLayoutServices(main.document);
+        const layout = layoutDocument(main.document, services, { currentDateMs: 0 });
+        assertDocumentLayout(layout);
+        const clonedLayout = structuredClone(layout);
+        if (JSON.stringify(clonedLayout) !== JSON.stringify(layout)) {
+          throw new Error('retained layout changed across structuredClone');
+        }
+
+        const mainRuns = [];
+        const workerRuns = [];
+        for (let pageIndex = 0; pageIndex < main.pageCount; pageIndex += 1) {
+          mainRuns.push(await main.collectPageRuns(pageIndex, { width: 612, dpr: 1 }));
+          workerRuns.push(await worker.collectPageRuns(pageIndex, { width: 612, dpr: 1 }));
+        }
+        const mainSizes = Array.from(
+          { length: main.pageCount },
+          (_, pageIndex) => main.pageSize(pageIndex),
+        );
+        const workerSizes = Array.from(
+          { length: worker.pageCount },
+          (_, pageIndex) => worker.pageSize(pageIndex),
+        );
+        const text = mainRuns.flat().map(({ text: runText }) => runText).join('');
+
+        return {
+          caseId: testCase.id,
+          expected: testCase.expected,
+          pageCount: main.pageCount,
+          mainSizes,
+          workerSizes,
+          runsFinite: mainRuns.flat().every(finiteRun)
+            && workerRuns.flat().every(finiteRun),
+          targetTextPresent: text.includes(testCase.expected.targetText),
+          cloneSafe: true,
+          layoutFingerprint: layoutFingerprint(layout),
+          mainWorkerParity: {
+            pageCount: main.pageCount === worker.pageCount,
+            sizes: JSON.stringify(mainSizes) === JSON.stringify(workerSizes),
+            runs: JSON.stringify(mainRuns) === JSON.stringify(workerRuns),
+          },
+          authoredGeometry: authoredGeometry(layout),
+        };
+      } finally {
+        main.destroy();
+        worker.destroy();
+      }
+    };
+
+    document.body.dataset.status = 'ready';
+    document.body.dataset.caseCount = String(CONFORMANCE_CASES.length);
+  </script>
+</body>
+</html>

--- a/packages/docx/tests/visual/conformance.spec.ts
+++ b/packages/docx/tests/visual/conformance.spec.ts
@@ -36,70 +36,74 @@ interface BrowserConformanceReport {
   };
 }
 
-test('synthetic corpus preserves semantic geometry and real main/worker parity', async ({ page }) => {
-  test.setTimeout(240_000);
-  await page.goto('/tests/visual/conformance-fixture.html');
-  await page.waitForFunction(() => document.body.dataset.status === 'ready');
-  await expect.poll(() => page.evaluate(() =>
-    Number(document.body.dataset.caseCount))).toBe(CONFORMANCE_CASES.length);
+for (let index = 0; index < CONFORMANCE_CASES.length; index += 1) {
+  const testCase = CONFORMANCE_CASES[index]!;
+  test(testCase.id, async ({ page }) => {
+    test.setTimeout(60_000);
+    await page.goto('/tests/visual/conformance-fixture.html');
+    await page.waitForFunction(() => document.body.dataset.status === 'ready');
+    await expect.poll(() => page.evaluate(() =>
+      Number(document.body.dataset.caseCount))).toBe(CONFORMANCE_CASES.length);
 
-  for (let index = 0; index < CONFORMANCE_CASES.length; index += 1) {
-    const testCase = CONFORMANCE_CASES[index]!;
-    await test.step(testCase.id, async () => {
-      const report = await page.evaluate(async (caseIndex) =>
-        (window as unknown as {
-          runConformanceCase: (index: number) => Promise<BrowserConformanceReport>;
-        }).runConformanceCase(caseIndex), index);
+    const report = await page.evaluate(async (caseIndex) =>
+      (window as unknown as {
+        runConformanceCase: (index: number) => Promise<BrowserConformanceReport>;
+      }).runConformanceCase(caseIndex), index);
 
-      expect(report.caseId).toBe(testCase.id);
-      expect(report.expected).toEqual(testCase.expected);
-      expect(report.pageCount).toBe(testCase.expected.pageCount);
-      expect(report.mainSizes).toEqual([{
-        widthPt: testCase.expected.pageWidthPt,
-        heightPt: testCase.expected.pageHeightPt,
-      }]);
-      expect(report.workerSizes).toEqual(report.mainSizes);
-      expect(report.runsFinite).toBe(true);
-      expect(report.targetTextPresent).toBe(true);
-      expect(report.cloneSafe).toBe(true);
-      expect(report.layoutFingerprint.length).toBeGreaterThan(0);
-      expect(report.mainWorkerParity).toEqual({
-        pageCount: true,
-        sizes: true,
-        runs: true,
-      });
-
-      // These values come entirely from authored twips/EMU and page margins.
-      // Native Canvas shaping is deliberately absent from this exact
-      // cross-browser comparison.
-      expect(report.authoredGeometry.pageBoxes).toMatchObject([{
-        widthPt: 612,
-        heightPt: 792,
-      }]);
-      const pageBox = report.authoredGeometry.pageBoxes[0]!;
-      expect(pageBox.contentTopPt).toBeGreaterThanOrEqual(0);
-      expect(pageBox.contentBottomPt).toBeLessThanOrEqual(pageBox.heightPt);
-      expect(pageBox.contentBottomPt).toBeGreaterThan(pageBox.contentTopPt);
-      expect(report.authoredGeometry.tables).toHaveLength(testCase.expected.tableDepth);
-      const tableWidths = report.authoredGeometry.tables
-        .flatMap(({ columnWidthsPt }) => columnWidthsPt)
-        .sort((left, right) => right - left);
-      expect(tableWidths).toEqual(
-        testCase.expected.tableDepth === 2
-          ? [360, 180]
-          : testCase.expected.tableDepth === 1
-            ? [360]
-            : [],
-      );
-      for (const table of report.authoredGeometry.tables) {
-        expect(table.borderEndpoints.flat().every(Number.isFinite)).toBe(true);
-      }
-      expect(report.authoredGeometry.drawings).toHaveLength(
-        testCase.expected.drawingCount,
-      );
-      for (const drawing of report.authoredGeometry.drawings) {
-        expect(drawing).toMatchObject({ widthPt: 36, heightPt: 21.6 });
-      }
+    expect(report.caseId).toBe(testCase.id);
+    expect(report.expected).toEqual(testCase.expected);
+    expect(report.pageCount).toBe(testCase.expected.pageCount);
+    expect(report.mainSizes).toEqual([{
+      widthPt: testCase.expected.pageWidthPt,
+      heightPt: testCase.expected.pageHeightPt,
+    }]);
+    expect(report.workerSizes).toEqual(report.mainSizes);
+    expect(report.runsFinite).toBe(true);
+    expect(report.targetTextPresent).toBe(true);
+    expect(report.cloneSafe).toBe(true);
+    expect(report.layoutFingerprint.length).toBeGreaterThan(0);
+    expect(report.mainWorkerParity).toEqual({
+      pageCount: true,
+      sizes: true,
+      runs: true,
     });
-  }
-});
+
+    // These values come entirely from authored twips/EMU and page margins.
+    // Native Canvas shaping is deliberately absent from this exact
+    // cross-browser comparison.
+    expect(report.authoredGeometry.pageBoxes).toMatchObject([{
+      widthPt: 612,
+      heightPt: 792,
+    }]);
+    const pageBox = report.authoredGeometry.pageBoxes[0]!;
+    expect(pageBox.contentTopPt).toBeGreaterThanOrEqual(0);
+    expect(pageBox.contentBottomPt).toBeLessThanOrEqual(pageBox.heightPt);
+    expect(pageBox.contentBottomPt).toBeGreaterThan(pageBox.contentTopPt);
+    expect(report.authoredGeometry.tables).toHaveLength(testCase.expected.tableDepth);
+    const tableWidths = report.authoredGeometry.tables
+      .flatMap(({ columnWidthsPt }) => columnWidthsPt)
+      .sort((left, right) => right - left);
+    expect(tableWidths).toEqual(
+      testCase.expected.tableDepth === 2
+        ? [360, 180]
+        : testCase.expected.tableDepth === 1
+          ? [360]
+          : [],
+    );
+    for (const table of report.authoredGeometry.tables) {
+      expect(table.borderEndpoints.flat().every(Number.isFinite)).toBe(true);
+      const horizontalSpans = table.borderEndpoints
+        .filter(([, fromY, , toY]) => fromY === toY)
+        .map(([fromX, , toX]) => Math.abs(toX! - fromX!));
+      expect(Math.max(...horizontalSpans)).toBe(
+        table.columnWidthsPt.reduce((sum, width) => sum + width, 0),
+      );
+    }
+    expect(report.authoredGeometry.drawings).toHaveLength(
+      testCase.expected.drawingCount,
+    );
+    for (const drawing of report.authoredGeometry.drawings) {
+      expect(drawing).toMatchObject({ widthPt: 36, heightPt: 21.6 });
+    }
+  });
+}

--- a/packages/docx/tests/visual/conformance.spec.ts
+++ b/packages/docx/tests/visual/conformance.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@playwright/test';
+import { CONFORMANCE_CASES } from '../../src/conformance/cases.js';
+
+interface BrowserConformanceReport {
+  readonly caseId: string;
+  readonly expected: (typeof CONFORMANCE_CASES)[number]['expected'];
+  readonly pageCount: number;
+  readonly mainSizes: readonly { widthPt: number; heightPt: number }[];
+  readonly workerSizes: readonly { widthPt: number; heightPt: number }[];
+  readonly runsFinite: boolean;
+  readonly targetTextPresent: boolean;
+  readonly cloneSafe: boolean;
+  readonly layoutFingerprint: string;
+  readonly mainWorkerParity: {
+    readonly pageCount: boolean;
+    readonly sizes: boolean;
+    readonly runs: boolean;
+  };
+  readonly authoredGeometry: {
+    readonly pageBoxes: readonly {
+      readonly widthPt: number;
+      readonly heightPt: number;
+      readonly contentTopPt: number;
+      readonly contentBottomPt: number;
+    }[];
+    readonly tables: readonly {
+      readonly id: string;
+      readonly columnWidthsPt: readonly number[];
+      readonly borderEndpoints: readonly (readonly number[])[];
+    }[];
+    readonly drawings: readonly {
+      readonly id: string;
+      readonly widthPt: number;
+      readonly heightPt: number;
+    }[];
+  };
+}
+
+test('synthetic corpus preserves semantic geometry and real main/worker parity', async ({ page }) => {
+  test.setTimeout(240_000);
+  await page.goto('/tests/visual/conformance-fixture.html');
+  await page.waitForFunction(() => document.body.dataset.status === 'ready');
+  await expect.poll(() => page.evaluate(() =>
+    Number(document.body.dataset.caseCount))).toBe(CONFORMANCE_CASES.length);
+
+  for (let index = 0; index < CONFORMANCE_CASES.length; index += 1) {
+    const testCase = CONFORMANCE_CASES[index]!;
+    await test.step(testCase.id, async () => {
+      const report = await page.evaluate(async (caseIndex) =>
+        (window as unknown as {
+          runConformanceCase: (index: number) => Promise<BrowserConformanceReport>;
+        }).runConformanceCase(caseIndex), index);
+
+      expect(report.caseId).toBe(testCase.id);
+      expect(report.expected).toEqual(testCase.expected);
+      expect(report.pageCount).toBe(testCase.expected.pageCount);
+      expect(report.mainSizes).toEqual([{
+        widthPt: testCase.expected.pageWidthPt,
+        heightPt: testCase.expected.pageHeightPt,
+      }]);
+      expect(report.workerSizes).toEqual(report.mainSizes);
+      expect(report.runsFinite).toBe(true);
+      expect(report.targetTextPresent).toBe(true);
+      expect(report.cloneSafe).toBe(true);
+      expect(report.layoutFingerprint.length).toBeGreaterThan(0);
+      expect(report.mainWorkerParity).toEqual({
+        pageCount: true,
+        sizes: true,
+        runs: true,
+      });
+
+      // These values come entirely from authored twips/EMU and page margins.
+      // Native Canvas shaping is deliberately absent from this exact
+      // cross-browser comparison.
+      expect(report.authoredGeometry.pageBoxes).toMatchObject([{
+        widthPt: 612,
+        heightPt: 792,
+      }]);
+      const pageBox = report.authoredGeometry.pageBoxes[0]!;
+      expect(pageBox.contentTopPt).toBeGreaterThanOrEqual(0);
+      expect(pageBox.contentBottomPt).toBeLessThanOrEqual(pageBox.heightPt);
+      expect(pageBox.contentBottomPt).toBeGreaterThan(pageBox.contentTopPt);
+      expect(report.authoredGeometry.tables).toHaveLength(testCase.expected.tableDepth);
+      const tableWidths = report.authoredGeometry.tables
+        .flatMap(({ columnWidthsPt }) => columnWidthsPt)
+        .sort((left, right) => right - left);
+      expect(tableWidths).toEqual(
+        testCase.expected.tableDepth === 2
+          ? [360, 180]
+          : testCase.expected.tableDepth === 1
+            ? [360]
+            : [],
+      );
+      for (const table of report.authoredGeometry.tables) {
+        expect(table.borderEndpoints.flat().every(Number.isFinite)).toBe(true);
+      }
+      expect(report.authoredGeometry.drawings).toHaveLength(
+        testCase.expected.drawingCount,
+      );
+      for (const drawing of report.authoredGeometry.drawings) {
+        expect(drawing).toMatchObject({ widthPt: 36, heightPt: 21.6 });
+      }
+    });
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/pngjs':
         specifier: ^6.0.5
         version: 6.0.5


### PR DESCRIPTION
## Summary

- generate a redistributable deterministic DOCX corpus from a constrained pairwise matrix
- exercise the real Rust/WASM parser and retained layout with authored expectations and structural invariants
- verify exact shipped main/worker geometry parity within Chrome, Firefox, and WebKit without comparing native-shaped text coordinates across engines
- run deterministic Node geometry on every CI change and the tri-browser corpus on the existing browser cadence

## Design

The 22 cases cover every schema-valid feasible pair across story, container, paragraph length, object mode, direction, spacing, style source, font source, and anchor reference. Invalid combinations are excluded explicitly, and known high-risk combinations are seeded before deterministic greedy coverage/minimization.

DOCX archives use stored ZIP entries with fixed order, timestamps, IDs, flags, and attributes. The tests compare consecutive bytes and SHA-256 hashes, then parse every archive through the actual WASM parser. Parser assertions cover not only presence but the intended story, nesting depth, inline/floating mode, dimensions, direction, spacing rule/source, paragraph style source, font source, and anchor semantics.

Retained-layout checks use the existing canonical invariant checker, source-range partitions, bottom clearance with the oversize exception, structured-clone safety, and deterministic service/layout identity. Browser checks compare page count, page sizes, and text-run geometry exactly between the public main and worker modes in the same engine. Cross-browser exact assertions are restricted to authored page, fixed table-grid, border-span, and drawing dimensions.

## Independent review

Claude Fable 5 reviewed the design before implementation. The implementation incorporates its key findings:

- non-overlap is scoped by retained flow ownership, not treated as a global OOXML rule
- Node clone/determinism checks are not mislabeled as worker parity
- fixed fingerprint goldens are not used as a circular conformance oracle
- the pairwise matrix covers only feasible schema-valid pairs
- each axis is checked at the generated source and parsed-model boundaries to prevent decorative coverage

Fable then reviewed the public diff twice. The first pass identified one schema-order defect and several hardening opportunities; all were corrected. The final gate reported no remaining P1, P2, or P3 findings and approved the change.

## Verification

- [x] full DOCX Rust parser suite (434 passed)
- [x] full TypeScript Vitest suite (5,598 passed; 26 skipped)
- [x] synthetic conformance Vitest suite (46 passed)
- [x] diagnostics + conformance Vitest suite (51 passed)
- [x] Playwright Chrome / Firefox / WebKit (66 isolated case-engine tests passed)
- [x] root TypeScript build plus Markdown, Node, and VS Code extension typechecks
- [x] DOCX layout boundary tests (90 passed)
- [x] DOCX compatibility-evidence tests (17 passed; 65 rules verified)
- [x] DOCX public API tests (19 passed)
- [x] DOCX package build-ownership test (1 passed)
- [x] ast-grep rule tests (8 passed) and full scan (no new finding)
- [x] `git diff --check`
- [x] independent public-diff Fable review
- [x] GitHub CI: rust, audit, typecheck, and smoke

Refs #1037