### PR TITLE
refactor(docx): own layout acquisition contexts

### DIFF
--- a/packages/docx/src/anchor-align.test.ts
+++ b/packages/docx/src/anchor-align.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { resolveAnchorX, resolveAnchorY } from './anchor-geometry.js';
 
 // resolveAnchorY reads only { scale, marginTop, marginBottom, pageH } of
-// RenderState (via yContainer); cast a minimal stand-in like the other geometry
+// BodyAcquisitionState (via yContainer); cast a minimal stand-in like the other geometry
 // tests. scale=1 so px == pt. pageH=800, top/bottom margins=72 ⇒ the "margin"
 // container band is [72, 728], the "page" band is [0, 800].
 interface MinState {

--- a/packages/docx/src/anchor-column.test.ts
+++ b/packages/docx/src/anchor-column.test.ts
@@ -17,7 +17,7 @@ import { resolveAnchorX, xContainer } from './anchor-geometry.js';
 // column, the closest available base — see anchor-geometry.ts).
 //
 // xContainer reads { scale, pageWidth, marginLeft, marginRight, contentX,
-// contentW } of RenderState; a minimal stand-in is cast like the other geometry
+// contentW } of BodyAcquisitionState; a minimal stand-in is cast like the other geometry
 // tests. contentX/contentW are ALREADY scaled (px), unlike marginLeft etc.
 interface MinState {
   scale: number;

--- a/packages/docx/src/anchor-geometry.ts
+++ b/packages/docx/src/anchor-geometry.ts
@@ -2,13 +2,11 @@
 //
 // Pure placement math for `<wp:positionH>` / `<wp:positionV>` (relativeFrom +
 // posOffset / align / pctPos): given the container indicated by `relativeFrom`
-// and the section margins on `RenderState`, it answers "where does this anchor /
+// and the explicit `AnchorGeometryContext`, it answers "where does this anchor /
 // anchor-group child sit?". Extracted from renderer.ts so the resolve logic can
-// be unit-reasoned in isolation (see anchor-align.test.ts). Only `RenderState`
-// is imported as a type (erased at runtime), so there is no import cycle with
-// renderer.ts.
+// be unit-reasoned in isolation (see anchor-align.test.ts).
 
-import type { RenderState } from './renderer.js';
+import type { AnchorGeometryContext } from './layout/acquisition-context.js';
 
 /** Resolve a shape's page X by combining the explicit `anchorXPt` offset with
  *  any `anchorXAlign` (ECMA-376 §20.4.3.1 wp:align). When align is set we
@@ -37,7 +35,7 @@ import type { RenderState } from './renderer.js';
 export function xContainer(
   relativeFrom: string | null | undefined,
   fromMarginHint: boolean,
-  state: RenderState,
+  state: AnchorGeometryContext,
 ): { start: number; end: number } {
   const { scale } = state;
   const pageW = state.pageWidth * scale;
@@ -72,7 +70,7 @@ export function yContainer(
   relativeFrom: string | null | undefined,
   fromParaHint: boolean,
   paragraphTopPx: number,
-  state: RenderState,
+  state: AnchorGeometryContext,
 ): { start: number; end: number } {
   const { scale } = state;
   const mt = state.marginTop * scale;
@@ -102,7 +100,7 @@ export function resolveAnchorX(
   fromMargin: boolean,
   offsetPt: number,
   widthPx: number,
-  state: RenderState,
+  state: AnchorGeometryContext,
   relativeFrom?: string | null,
   pctPos?: number | null,
   alignWidthPt?: number | null,
@@ -135,7 +133,7 @@ export function resolveAnchorY(
   offsetPt: number,
   heightPx: number,
   paragraphTopPx: number,
-  state: RenderState,
+  state: AnchorGeometryContext,
   relativeFrom?: string | null,
   pctPos?: number | null,
   alignHeightPt?: number | null,

--- a/packages/docx/src/anchor-image-relativefrom.test.ts
+++ b/packages/docx/src/anchor-image-relativefrom.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { __test_resolveAnchorBox, type RenderState } from './renderer.js';
+import { __test_resolveAnchorBox } from './renderer.js';
+import type { AnchorFloatRegistrationState } from './layout/acquisition-context.js';
 import type { ImageRun } from './types.js';
 
 // Pin the wiring of `<wp:positionH/V>@relativeFrom` (ECMA-376 §20.4.3.2 /
@@ -10,7 +11,7 @@ import type { ImageRun } from './types.js';
 // top content margin instead of the page top (Y=0, inside the top margin).
 //
 // resolveAnchorBox reads only { scale, marginLeft/Right/Top/Bottom, pageH,
-// pageWidth } from RenderState; cast a minimal stand-in like anchor-align.test.
+// pageWidth } from the anchor capability; cast a minimal stand-in like anchor-align.test.
 const state = {
   scale: 1,
   marginLeft: 96,
@@ -19,7 +20,7 @@ const state = {
   marginBottom: 72,
   pageH: 800,
   pageWidth: 612,
-} as unknown as RenderState;
+} as unknown as AnchorFloatRegistrationState;
 
 const baseImg: ImageRun = {
   imagePath: 'word/media/image1.png',

--- a/packages/docx/src/anchor-vertical-physical.test.ts
+++ b/packages/docx/src/anchor-vertical-physical.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { __test_resolveAnchorBox, type RenderState } from './renderer.js';
+import { __test_resolveAnchorBox } from './renderer.js';
+import type { AnchorFloatRegistrationState } from './layout/acquisition-context.js';
 import { physicalToLogicalAnchorBox } from './vertical-text.js';
 import type { ImageRun } from './types.js';
 
@@ -12,7 +13,7 @@ import type { ImageRun } from './types.js';
 // fixture below contains only the minimal redistributable geometry needed to
 // preserve that behavior.
 
-// A vertical RenderState carries the LOGICAL (swapped) geometry PLUS `verticalPhys`
+// A vertical anchor capability carries the LOGICAL (swapped) geometry PLUS `verticalPhys`
 // (the physical page geometry the anchor path resolves against). Mirror what the
 // measurement-state writer builds for a vertical section. resolveAnchorBox reads only
 // geometry fields, so a minimal cast stand-in suffices (as in
@@ -43,7 +44,7 @@ const verticalState = {
     marginBottom: PHYS_MB,
     cssWidthPx: PHYS_W,
   },
-} as unknown as RenderState;
+} as unknown as AnchorFloatRegistrationState;
 
 const recordedAnchor: ImageRun = {
   imagePath: 'word/media/image1.png',

--- a/packages/docx/src/anchor-vertical-shape-physical.test.ts
+++ b/packages/docx/src/anchor-vertical-shape-physical.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   __test_resolveAnchorBox,
   __test_resolveShapeBox,
-  type RenderState,
 } from './renderer.js';
+import type { AnchorFloatRegistrationState } from './layout/acquisition-context.js';
 import { layoutBodyModel } from './test-support/document-layout.test-support.js';
 import type { BodyElement, DocParagraph, ImageRun, SectionProps, ShapeRun } from './types.js';
 
@@ -31,7 +31,7 @@ const PHYS_W = 612;
 const PHYS_H = 792;
 const MARGIN = 72;
 
-// Vertical RenderState: LOGICAL (swapped) geometry + `verticalPhys`. The
+// Vertical anchor capability: LOGICAL (swapped) geometry + `verticalPhys`. The
 // logical frame of a portrait Letter tbRl page: logical width = physical
 // height, margins rotated one quarter-turn (verticalLayoutSection). contentX
 // is the current column band start in LOGICAL x — its physical image is the
@@ -57,7 +57,7 @@ const verticalState = {
     marginBottom: MARGIN,
     cssWidthPx: PHYS_W,
   },
-} as unknown as RenderState;
+} as unknown as AnchorFloatRegistrationState;
 
 const SHAPE_W = 100.8;
 const SHAPE_H = 86.4;

--- a/packages/docx/src/column-widths.test.ts
+++ b/packages/docx/src/column-widths.test.ts
@@ -11,7 +11,7 @@ import type {
 } from './types.js';
 
 // State type taken from resolveColumnWidths' signature so the test does not
-// depend on RenderState being exported (mirrors table-row-height.test).
+// depend on the acquisition-state type being re-exported (mirrors table-row-height.test).
 type ColState = Parameters<typeof resolveColumnWidths>[2];
 
 // ECMA-376 §17.4.48 (`<w:tblGrid>`) supplies the INITIAL shared grid;

--- a/packages/docx/src/date-time-field.test.ts
+++ b/packages/docx/src/date-time-field.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveFieldText } from './line-layout.js';
-import type { RenderState } from './renderer.js';
+import { resolveFieldText, type LineLayoutEnvironment } from './line-layout.js';
 import type { FieldRun } from './types';
 
 // ECMA-376 §17.16.5.16 DATE / §17.16.5.72 TIME — resolveFieldText formats the
@@ -9,8 +8,8 @@ import type { FieldRun } from './types';
 // token. Reference instant: Tue Jan 3 2006 17:28:34 (matches the spec example).
 const REF_MS = new Date(2006, 0, 3, 17, 28, 34).getTime();
 
-function state(currentDateMs?: number): RenderState {
-  return { currentDateMs, totalPages: 1, pageIndex: 0 } as unknown as RenderState;
+function state(currentDateMs?: number): LineLayoutEnvironment {
+  return { currentDateMs, totalPages: 1, pageIndex: 0 };
 }
 
 function field(fieldType: string, instruction: string, fallbackText = ''): FieldRun {

--- a/packages/docx/src/float-table-geometry.test.ts
+++ b/packages/docx/src/float-table-geometry.test.ts
@@ -82,7 +82,7 @@ function tblp(over: Partial<TblpPr> = {}): TblpPr {
   };
 }
 
-// Cast helpers: the geometry fns read only the MinState subset of RenderState.
+// Cast helpers: the geometry fns read only the MinState subset of BodyAcquisitionState.
 const box = (tp: TblpPr, st: MinState, paraTop: number, w: number, h: number): FloatTableBox =>
   computeFloatTableBox(tp, st as never, paraTop, w, h);
 const registerFloat = (

--- a/packages/docx/src/float-table-geometry.ts
+++ b/packages/docx/src/float-table-geometry.ts
@@ -2,18 +2,16 @@
 // §17.4.56 `<w:tblOverlap>`).
 //
 // Pure placement math: given a `<w:tblpPr>` and the section geometry on
-// `RenderState`, resolve the table box (canvas px), decide which side body text
+// `FloatRegistrationState`, resolve the table box (canvas px), decide which side body text
 // wraps on, and push the wrap-exclusion FloatRect onto `state.floats`. The
 // anchor / alignment semantics line up 1:1 with a `<w:framePr>` text frame, so
 // this module reuses frame-geometry's frameXContainer / frameYContainer /
 // resolveAlignedPosH / resolveAlignedPosV and the shared pushFloatRect builder.
 // Extracted from renderer.ts so the placement logic can be unit-reasoned in
 // isolation (see float-table-geometry.test.ts / measure-column-geometry.test.ts).
-// Only `RenderState` is imported as a type (erased at runtime), so there is no
-// import cycle with renderer.ts.
 
 import type { TblpPr } from './types.js';
-import type { RenderState } from './renderer.js';
+import type { FloatRegistrationState } from './layout/acquisition-context.js';
 import {
   FLOAT_OVERLAP_EPS,
   FLOAT_PAGE_RIGHT_SLACK,
@@ -57,7 +55,7 @@ export interface FloatTableBox {
  */
 export function computeFloatTableBox(
   tp: TblpPr,
-  state: RenderState,
+  state: FloatRegistrationState,
   paraTop: number,
   tableW: number,
   tableH: number,
@@ -158,7 +156,7 @@ export function computeFloatTableBox(
 export function registerTableFloat(
   box: FloatTableBox,
   tp: TblpPr,
-  state: RenderState,
+  state: FloatRegistrationState,
   side: string,
   allowOverlap: boolean,
   /** The box was already resolved against the pre-descendant registry. */
@@ -205,6 +203,6 @@ export function registerTableFloat(
  *
  * Exported for unit tests only — not package API.
  */
-export function floatTableWrapSide(_box: FloatTableBox, _state: RenderState): string {
+export function floatTableWrapSide(_box: FloatTableBox, _state: FloatRegistrationState): string {
   return 'bothSides';
 }

--- a/packages/docx/src/frame-geometry.test.ts
+++ b/packages/docx/src/frame-geometry.test.ts
@@ -69,7 +69,7 @@ function frame(over: Partial<FramePr> = {}): FramePr {
 }
 
 // Cast helper: computeFrameBox/registerFrameFloat read only the MinState subset
-// of RenderState exercised here.
+// of BodyAcquisitionState exercised here.
 const box = (fp: FramePr, st: MinState, paraTop: number, cW: number, cH: number, anchorH: number): FrameBox =>
   computeFrameBox(fp, st as never, paraTop, cW, cH, anchorH);
 const registerFloat = (b: FrameBox, fp: FramePr, st: MinState): void =>

--- a/packages/docx/src/frame-geometry.ts
+++ b/packages/docx/src/frame-geometry.ts
@@ -1,7 +1,7 @@
 // Text-frame / drop-cap placement geometry (ECMA-376 §17.3.1.11 `<w:framePr>`).
 //
 // Pure placement math: given a `<w:framePr>` and the section geometry on
-// `RenderState`, resolve the frame box (canvas px) and the wrap-exclusion
+// `AnchorGeometryContext`, resolve the frame box (canvas px) and the wrap-exclusion
 // FloatRect it pushes onto `state.floats`. Extracted from renderer.ts so the
 // resolve logic can be unit-reasoned in isolation (see frame-geometry.test.ts /
 // measure-column-geometry.test.ts).
@@ -10,11 +10,13 @@
 // (float-table-geometry.ts), which reuses frameXContainer / frameYContainer /
 // resolveAlignedPosH / resolveAlignedPosV (the anchor/alignment semantics line
 // up 1:1 between a text frame and a floating table) and pushFloatRect (the
-// single source of exclusion-rect construction). Only `RenderState` is imported
-// as a type (erased at runtime), so there is no import cycle with renderer.ts.
+// single source of exclusion-rect construction).
 
 import type { FramePr } from './types.js';
-import type { RenderState } from './renderer.js';
+import type {
+  AnchorGeometryContext,
+  FloatRegistrationState,
+} from './layout/acquisition-context.js';
 import type { FloatRect } from './float-layout.js';
 import {
   FLOAT_OVERLAP_EPS,
@@ -25,7 +27,6 @@ import {
   resolveFloatPlacement,
   type FloatPlacementParticipant,
 } from './layout/floats.js';
-import type { FrameGeometryState } from './layout/types.js';
 
 /** Resolved geometry (canvas px) of a `<w:framePr>` text frame. Exported for
  *  unit tests only (the table-driven frame-geometry assertions) — not part of
@@ -59,7 +60,10 @@ export interface FrameBox {
  *   - "page"   → the physical page edges (0..pageWidth).
  * All values in canvas px.
  */
-export function frameXContainer(hAnchor: string, state: FrameGeometryState): { left: number; right: number } {
+export function frameXContainer(
+  hAnchor: string,
+  state: AnchorGeometryContext,
+): { left: number; right: number } {
   const sc = state.scale;
   switch (hAnchor) {
     case 'margin':
@@ -97,7 +101,7 @@ export function frameYContainer(
   vAnchor: string,
   paraTop: number,
   contentH: number,
-  state: FrameGeometryState,
+  state: AnchorGeometryContext,
 ): { start: number; end: number } {
   const sc = state.scale;
   switch (vAnchor) {
@@ -214,7 +218,7 @@ export function clampAbsBoxIntoContainer(
  */
 export function computeFrameBox(
   fp: FramePr,
-  state: FrameGeometryState,
+  state: AnchorGeometryContext,
   paraTop: number,
   contentW: number,
   contentH: number,
@@ -335,9 +339,10 @@ export interface PushFloatOpts {
  * yTop = y − dt, yBottom = y + h + db` exclusion-rect construction shared by
  * registerFrameFloat / registerTableFloat / registerImageFloat /
  * registerShapeFloat (the `dist*` fields carry dl/dr/dt/db verbatim for
- * re-seating). The returned ref lets the image path flip `drawn` after painting.
+ * re-seating). The returned ref exposes the exact registered transport record
+ * to acquisition callers that need its overlap-resolved position.
  */
-export function pushFloatRect(state: RenderState, o: PushFloatOpts): FloatRect {
+export function pushFloatRect(state: FloatRegistrationState, o: PushFloatOpts): FloatRect {
   if (o.kind === 'table' && o.tableOverlap === undefined) {
     throw new Error('Floating-table transport omitted tblOverlap');
   }
@@ -417,7 +422,7 @@ export function pushFloatRect(state: RenderState, o: PushFloatOpts): FloatRect {
  *
  * Exported for unit tests only (frame-geometry table) — not package API.
  */
-export function registerFrameFloat(box: FrameBox, fp: FramePr, state: RenderState): void {
+export function registerFrameFloat(box: FrameBox, fp: FramePr, state: FloatRegistrationState): void {
   if (box.registerExclusion === false) return;
   if (fp.wrap === 'none') return;
   if (box.w <= 0 || box.h <= 0) return;

--- a/packages/docx/src/layout/acquisition-context.ts
+++ b/packages/docx/src/layout/acquisition-context.ts
@@ -1,0 +1,142 @@
+import type {
+  KinsokuRules,
+  NumberFormat,
+  ResolvedLocalFontMetric,
+} from '@silurus/ooxml-core';
+import type { FloatRect } from '../float-layout.js';
+import type {
+  DocumentLayoutSettings,
+  SectionLayoutContext,
+  StoryContext,
+} from '../layout-context.js';
+import type { TextMeasurer } from '../paragraph-measure.js';
+import type { DocParagraph } from '../types.js';
+import type { CompleteTextBoxStoryAcquirer } from './paragraph.js';
+import type {
+  RetainedTableAcquisition,
+  RetainedTableAcquisitionDependencies,
+} from './table-acquisition.js';
+import type { LayoutServices } from './types.js';
+
+/** One acquired body-table occurrence and the point-space placement facts that
+ * bind it to the current retained-layout session. */
+export interface RetainedTableRecord {
+  readonly sourceIndex: number;
+  readonly acquisition: RetainedTableAcquisition;
+  readonly contentWidthPt: number;
+  readonly anchorYPt: number;
+}
+
+/** Physical page facts needed while projecting DrawingML anchors from a
+ * vertical section's upright page into its logical acquisition frame. */
+export interface PhysicalAnchorFrame {
+  readonly pageWidth: number;
+  readonly pageHeight: number;
+  readonly marginLeft: number;
+  readonly marginRight: number;
+  readonly marginTop: number;
+  readonly marginBottom: number;
+  readonly cssWidthPx: number;
+}
+
+/** Read-only page/container geometry consumed by DrawingML anchor placement. */
+export interface AnchorGeometryContext {
+  readonly scale: number;
+  readonly contentX: number;
+  readonly contentW: number;
+  readonly pageH: number;
+  readonly marginLeft: number;
+  readonly marginRight: number;
+  readonly marginTop: number;
+  readonly marginBottom: number;
+  readonly pageWidth: number;
+}
+
+/** Mutable exclusion registry owned by one layout-acquisition flow domain. */
+export interface FloatRegistrationState extends AnchorGeometryContext {
+  floats: FloatRect[];
+  floatParaSeq: number;
+}
+
+/** DrawingML anchor capability: float registration plus vertical-page
+ * projection and page-start pre-scan ownership. */
+export interface AnchorFloatRegistrationState extends FloatRegistrationState {
+  pageAnchorPrescanned?: Set<DocParagraph>;
+  verticalCJK?: boolean;
+  verticalAllRotated?: boolean;
+  verticalPhys?: PhysicalAnchorFrame;
+}
+
+/**
+ * Mutable cursor owned by retained-layout acquisition.
+ *
+ * This state may measure text and register exclusions, but it has no paint
+ * resources or drawing-mode switch. Body paint consumes the retained result
+ * produced from this cursor; it never reuses or mutates the cursor itself.
+ */
+export interface BodyAcquisitionState extends AnchorFloatRegistrationState {
+  /** Canvas is a synchronous text-metric authority only. */
+  ctx: TextMeasurer['context'];
+  /** Acquisition coordinate scale in pixels per point. */
+  scale: number;
+  /** Current logical text container, already in acquisition pixels. */
+  contentX: number;
+  contentW: number;
+  y: number;
+  pageH: number;
+  pageIndex: number;
+  totalPages: number;
+  displayPageNumber?: number;
+  pageNumberFormat?: NumberFormat;
+  marginLeft: number;
+  marginRight: number;
+  marginTop: number;
+  marginBottom: number;
+  pageWidth: number;
+  layoutSettings: DocumentLayoutSettings;
+  sectionLayout: SectionLayoutContext;
+  storyContext: StoryContext;
+  docEastAsian: boolean;
+  fontFamilyClasses: Record<string, string>;
+  resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>>;
+  layoutServices?: LayoutServices;
+  retainedTableAcquisition?:
+    RetainedTableAcquisitionDependencies<BodyAcquisitionState>;
+  acquireCompleteTextBoxStory?: CompleteTextBoxStoryAcquirer;
+  retainedTablesBySourceIndex?: Map<number, RetainedTableRecord>;
+  kinsoku: KinsokuRules;
+  defaultTabPt: number;
+  currentDateMs?: number;
+  noteNumbers?: Map<string, number>;
+  noteReferenceNumber?: number;
+  containerShading?: string | null;
+}
+
+/** Immutable measurement authority passed to text/table measurement helpers.
+ * Cursor movement and float mutation stay on {@link BodyAcquisitionState}. */
+export type BodyMeasurementContext = Readonly<Pick<
+  BodyAcquisitionState,
+  | 'ctx'
+  | 'scale'
+  | 'pageH'
+  | 'pageWidth'
+  | 'pageIndex'
+  | 'totalPages'
+  | 'displayPageNumber'
+  | 'pageNumberFormat'
+  | 'layoutSettings'
+  | 'sectionLayout'
+  | 'storyContext'
+  | 'docEastAsian'
+  | 'fontFamilyClasses'
+  | 'resolvedLocalFonts'
+  | 'layoutServices'
+  | 'kinsoku'
+  | 'defaultTabPt'
+  | 'currentDateMs'
+  | 'noteNumbers'
+  | 'noteReferenceNumber'
+  | 'verticalCJK'
+  | 'verticalAllRotated'
+  | 'containerShading'
+>>;

--- a/packages/docx/src/layout/types.ts
+++ b/packages/docx/src/layout/types.ts
@@ -524,20 +524,6 @@ export interface ParagraphFlowEvent {
   readonly offset: number;
 }
 
-/** Plain frame placement geometry consumed by layout and renderer adapters. */
-export interface FrameGeometryState {
-  readonly scale: number;
-  readonly contentX: number;
-  readonly contentW: number;
-  readonly pageWidth: number;
-  readonly pageH: number;
-  readonly marginLeft: number;
-  readonly marginRight: number;
-  readonly marginTop: number;
-  readonly marginBottom: number;
-  readonly y: number;
-}
-
 export interface ParagraphMarkLayout {
   readonly hidden: boolean;
   readonly bounds: LayoutRect;

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -7,12 +7,11 @@
 // Lifted verbatim out of renderer.ts along the domain phase boundary that the B2
 // text-layout unification established (paragraph #684/#689, table #693, textbox
 // #697): everything here MEASURES (it may touch a Canvas 2D context to call
-// measureText / set ctx.font) but never DRAWS, mutates RenderState, paginates, or
+// measureText / set ctx.font) but never DRAWS, mutates body acquisition state,
+// paginates, or
 // registers floats — those stay in renderer.ts, which imports this module. The
-// split is one-directional at runtime: renderer.ts → line-layout.ts. The only
-// back-reference is the RenderState / DecodedImage TYPE (import type, erased at
-// runtime — same idiom frame-geometry.ts / anchor-geometry.ts use), so there is
-// no import cycle. Which behaviours here are ECMA-376-mandated vs Word-mimicking
+// split is one-directional at runtime: renderer.ts → line-layout.ts. Which
+// behaviours here are ECMA-376-mandated vs Word-mimicking
 // is documented inline (as before the move) — see packages/docx/CLAUDE.md.
 
 import type {
@@ -20,7 +19,6 @@ import type {
   LineSpacing, TabStop, DocxRunBorder, DocSettings, EmphasisMark,
 } from './types';
 import type { CanvasFontRoute, MathNode, KinsokuRules, ChartModel, HyperlinkTarget, NumberFormat, Duotone, ResolvedLocalFontMetric } from '@silurus/ooxml-core';
-import type { RenderState, DecodedImage } from './renderer.js';
 import {
   classifyCjkFont,
   cjkFallbackChain,
@@ -681,7 +679,7 @@ export function serifTail(cjk: ReturnType<typeof classifyCjkFont>): string {
 /**
  * Per-document memo for {@link normalizeFontFamily}. The regex/classifier work
  * inside is a pure function of `(family, fontFamilyClasses)`, and
- * `fontFamilyClasses` is a stable per-document object (RenderState threads
+ * `fontFamilyClasses` is a stable per-document object (body acquisition threads
  * `doc.fontFamilyClasses` — one identity per render). Keying the outer WeakMap on
  * that object identity gives per-doc caching with zero call-site churn (both
  * callers already pass `fontFamilyClasses`) and no leak: the inner
@@ -4583,29 +4581,4 @@ export function rescaleLayoutLines(
       topY: l.topY === undefined ? undefined : l.topY * scale,
     };
   });
-}
-
-/** Synthesize the `RenderState` fields {@link buildSegments} / {@link layoutLines}
- *  need for text-box layout when the caller does not thread the document state
- *  (unit tests acquire retained text-box geometry with minimal services). Only the
- *  fields those two functions actually read for PLAIN TEXT runs are populated —
- *  buildSegments touches `state` solely on `field`/`noteRef` runs (which shape
- *  runs never produce), so an empty note map + spec-default kinsoku / tab
- *  interval is exact here. The production call site passes the real state, so
- *  document-level kinsoku (§17.3.1.16) / defaultTabStop (§17.15.1.25) flow
- *  through unchanged. */
-export function shapeRenderState(
-  ctx: CanvasRenderingContext2D,
-  scale: number,
-  fontFamilyClasses: Record<string, string>,
-  images: Map<string, DecodedImage>,
-): RenderState {
-  return {
-    ctx,
-    scale,
-    fontFamilyClasses,
-    images,
-    kinsoku: DEFAULT_KINSOKU_RULES,
-    defaultTabPt: DEFAULT_TAB_PT,
-  } as unknown as RenderState;
 }

--- a/packages/docx/src/math-fallback-layout.test.ts
+++ b/packages/docx/src/math-fallback-layout.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildSegments, layoutLines, type LayoutMathSeg } from './line-layout.js';
-import type { RenderState } from './renderer.js';
+import {
+  buildSegments,
+  layoutLines,
+  type LayoutMathSeg,
+  type LineLayoutEnvironment,
+} from './line-layout.js';
 import type { DocRun } from './types.js';
 
 function makeLinearCtx(): CanvasRenderingContext2D {
@@ -37,7 +41,7 @@ describe('layoutLines math fallback', () => {
         ],
       },
     ];
-    const segs = buildSegments(runs, {} as RenderState);
+    const segs = buildSegments(runs, {} as LineLayoutEnvironment);
     const lines = layoutLines(makeLinearCtx(), segs, 300, 0, 1);
     const math = lines[0].segments[0] as LayoutMathSeg;
 

--- a/packages/docx/src/numbering-marker-font.test.ts
+++ b/packages/docx/src/numbering-marker-font.test.ts
@@ -4,8 +4,10 @@ import {
   renderDocumentToCanvas,
   type DocxTextRunInfo,
 } from './renderer.js';
-import { acquireAndPaintShapeTextBox } from './retained-shape-textbox.test-support.js';
-import { shapeRenderState } from './line-layout.js';
+import {
+  acquireAndPaintShapeTextBox,
+  shapeAcquisitionState,
+} from './retained-shape-textbox.test-support.js';
 import { testFontSnapshot } from './layout/test-font-snapshot.js';
 import type {
   BodyElement,
@@ -366,7 +368,7 @@ describe('numbering marker + body eastAsia font routing (§17.3.2.26 / §17.9.6)
       localMetrics: testFontSnapshot([{ family: 'Theme ASCII' }, { family: 'Theme EA' }]),
       measureContext: ctx,
     });
-    const state = shapeRenderState(ctx, 1, {}, new Map());
+    const state = shapeAcquisitionState(ctx, 1, {});
     state.layoutServices = services;
 
     acquireAndPaintShapeTextBox(textBoxShape(num), 0, 0, 200, 100, ctx, 1, {}, new Map(), state);
@@ -407,7 +409,7 @@ describe('numbering marker + body eastAsia font routing (§17.3.2.26 / §17.9.6)
       } as FontFace],
       measureContext: ctx,
     });
-    const state = shapeRenderState(ctx, 1, {}, new Map());
+    const state = shapeAcquisitionState(ctx, 1, {});
     state.layoutServices = services;
 
     acquireAndPaintShapeTextBox(textBoxShape(num), 0, 0, 200, 100, ctx, 1, {}, new Map(), state);

--- a/packages/docx/src/page-anchor-prescan.test.ts
+++ b/packages/docx/src/page-anchor-prescan.test.ts
@@ -4,8 +4,8 @@ import {
   __test_preRegisterPageFloats,
   createLayoutServices,
   layoutDocument,
-  type RenderState,
 } from './renderer.js';
+import type { AnchorFloatRegistrationState } from './layout/acquisition-context.js';
 import type { AnchorAcquisitionInput, AnchorEdgesInput } from './layout/anchor-input.js';
 import type { ParagraphLayout } from './layout/types.js';
 import type {
@@ -672,8 +672,8 @@ describe('preRegisterPageFloats — paragraph-local Y is NOT pre-registered', ()
         pageShapeRun({ widthPt: 100, heightPt: 30, anchorYRelativeFrom: 'paragraph', anchorYFromPara: true, wrapMode: 'topAndBottom' }),
       ]),
     ];
-    // Minimal RenderState stub matching what registerImageFloat/registerShapeFloat
-    // touch: scale, marginLeft/Top, pageH, contentX/W, dryRun (no images), floats.
+    // Minimal acquisition-state stub matching what registerImageFloat/registerShapeFloat
+    // touch: scale, marginLeft/Top, pageH, contentX/W, and floats.
     const state = {
       scale: 1,
       marginLeft: 20, marginRight: 20, marginTop: 20, marginBottom: 20,
@@ -681,9 +681,8 @@ describe('preRegisterPageFloats — paragraph-local Y is NOT pre-registered', ()
       contentX: 20, contentW: 160,
       floats: [],
       floatParaSeq: 0,
-      dryRun: true,
       pageAnchorPrescanned: new Set(),
-    } as unknown as RenderState;
+    } as unknown as AnchorFloatRegistrationState;
     __test_preRegisterPageFloats(body, 0, state);
     expect(state.floats.length).toBe(0);
     expect(state.pageAnchorPrescanned?.size ?? 0).toBe(0);
@@ -704,10 +703,8 @@ describe('preRegisterPageFloats — paragraph-local Y is NOT pre-registered', ()
       contentX: 20, contentW: 160,
       floats: [],
       floatParaSeq: 0,
-      images: new Map(),
-      dryRun: true,
       pageAnchorPrescanned: new Set(),
-    } as unknown as RenderState;
+    } as unknown as AnchorFloatRegistrationState;
     __test_preRegisterPageFloats(body, 0, state);
     expect(state.floats.length).toBe(1);
     expect(state.pageAnchorPrescanned?.size).toBe(1);
@@ -727,10 +724,8 @@ describe('preRegisterPageFloats — idempotent on repeated pre-scan', () => {
       contentX: 20, contentW: 160,
       floats: [],
       floatParaSeq: 0,
-      images: new Map(),
-      dryRun: true,
       pageAnchorPrescanned: new Set(),
-    } as unknown as RenderState;
+    } as unknown as AnchorFloatRegistrationState;
     __test_preRegisterPageFloats(body, 0, state);
     const after1 = state.floats.length;
     expect(after1).toBe(1);
@@ -754,10 +749,8 @@ describe('preRegisterPageFloats — idempotent on repeated pre-scan', () => {
       contentX: 20, contentW: 160,
       floats: [],
       floatParaSeq: 0,
-      images: new Map(),
-      dryRun: true,
       pageAnchorPrescanned: new Set(),
-    } as unknown as RenderState;
+    } as unknown as AnchorFloatRegistrationState;
     __test_preRegisterPageFloats(body, 0, state);
     expect(state.floats.length).toBe(1);
     expect(state.pageAnchorPrescanned?.size).toBe(1);

--- a/packages/docx/src/ptab-run-elements.test.ts
+++ b/packages/docx/src/ptab-run-elements.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { renderDocumentToCanvas, type RenderState } from './renderer.js';
-import { splitTextForLayout, layoutLines, buildSegments, type LayoutTextSeg } from './line-layout.js';
+import { renderDocumentToCanvas } from './renderer.js';
+import {
+  splitTextForLayout,
+  layoutLines,
+  buildSegments,
+  type LayoutTextSeg,
+  type LineLayoutEnvironment,
+} from './line-layout.js';
 import type { DocParagraph, DocxDocumentModel, SectionProps, DocRun } from './types.js';
 
 // ECMA-376 §17.3.3 run-content elements that were previously dropped by the
@@ -207,7 +213,7 @@ describe('noBreakHyphen (§17.3.3.18) and softHyphen (§17.3.3.29)', () => {
   // WHOLE LINE and would otherwise be indistinguishable from an incorrect
   // hyphen-triggered split. Assert the token moves to the next line WHOLE.
   it('a merged noBreakHyphen token wraps to the next line whole, never splitting at the hyphen', () => {
-    const segs = buildSegments([textRun('lead 999-99')], {} as RenderState);
+    const segs = buildSegments([textRun('lead 999-99')], {} as LineLayoutEnvironment);
     const { canvas } = makeRecordingCanvas();
     const ctx = canvas.getContext('2d') as unknown as CanvasRenderingContext2D;
     // Line width 100px. "lead " (5 glyphs * 10px = 50px) leaves 50px

--- a/packages/docx/src/renderer.textbox-image.test.ts
+++ b/packages/docx/src/renderer.textbox-image.test.ts
@@ -3,9 +3,9 @@ import { createLayoutServices, preloadImages } from './renderer';
 import {
   acquireAndPaintShapeTextBox,
   acquireShapeTextBoxForTest,
+  type ShapeAcquisitionTestState,
 } from './retained-shape-textbox.test-support.js';
 import type { DocxDocumentModel, ShapeRun, ShapeText, ShapeTextRun } from './types';
-import type { RenderState } from './renderer';
 import { canvasFontString } from '@silurus/ooxml-core';
 
 /**
@@ -283,7 +283,7 @@ describe('textbox rich text — per-run formatting', () => {
       totalPages: 1,
       layoutServices: services,
       resolvedLocalFonts: services.text.localMetrics,
-    } as unknown as RenderState;
+    } satisfies ShapeAcquisitionTestState;
     const shape = richTextbox([{ text: 'route', fontSizePt: 10, fontFamily: 'Roman Face' }]);
 
     fontCalls.length = 0;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -19,15 +19,11 @@ import {
   deferBitmapCloseWhileLeased,
   applyDuotone,
   imageNaturalSize,
-  drawImageCropped,
   metafileRasterSize,
-  renderChart,
 } from '@silurus/ooxml-core';
 import type {
   MathRenderer,
-  KinsokuRules,
   HyperlinkTarget,
-  NumberFormat,
   Duotone,
   ResolvedLocalFontMetric,
 } from '@silurus/ooxml-core';
@@ -69,7 +65,6 @@ import {
   resolveDocumentLayoutSettings,
   resolveParagraphLayoutContext,
   resolveSectionLayoutContext,
-  toLegacyDocGridContext,
   type DocumentLayoutSettings,
   type ParagraphLayoutContext,
   type SectionLayoutContext,
@@ -223,8 +218,7 @@ export { computeColumns };
 // ── Line-layout engine (segmentation + line-breaking + measurement) ──────────
 // Lifted into ./line-layout.ts (verbatim, B2 phase boundary). renderer.ts is the
 // paint/paginate side; it drives the pure kernel below. One-directional import
-// (renderer → line-layout); line-layout imports RenderState/DecodedImage back as
-// a TYPE only (erased), so there is no runtime cycle.
+// (renderer → line-layout), with acquisition state owned under layout/.
 import {
   DEFAULT_TAB_PT,
   buildFont,
@@ -243,6 +237,7 @@ import type {
   DocGridCtx,
   LayoutLine,
   LayoutSeg,
+  LineLayoutEnvironment,
 } from './line-layout.js';
 import {
   measureParagraph,
@@ -251,7 +246,6 @@ import {
 import {
   acquireRetainedTable,
   type RetainedTableAcquisition,
-  type RetainedTableAcquisitionDependencies,
 } from './layout/table-acquisition.js';
 import { combineAdjacentTableLayoutInputs } from './layout/adjacent-table-layout-input.js';
 import { layoutTable as layoutRetainedTableInput } from './layout/table.js';
@@ -270,8 +264,14 @@ import {
   acquireRetainedFrameGroup,
   bodyFrameGroupFor,
   bodyParagraphBorderEdgesFor,
-  type CompleteTextBoxStoryAcquirer,
 } from './layout/paragraph.js';
+import type { CompleteTextBoxStoryAcquirer } from './layout/paragraph.js';
+import type {
+  AnchorFloatRegistrationState,
+  BodyAcquisitionState,
+  BodyMeasurementContext,
+  RetainedTableRecord,
+} from './layout/acquisition-context.js';
 import {
   ownedParagraphAnchorCollisions,
   inheritedParagraphAuthorityForReacquisition,
@@ -292,7 +292,6 @@ import {
 import { resolveAnchorFrame } from './layout/anchor-frame.js';
 import {
   drawTateChuYokoRun,
-  drawUprightBox,
   physicalToLogicalAnchorBox,
 } from './vertical-text.js';
 import { textRunsForPage } from './text-run-projection.js';
@@ -596,206 +595,6 @@ export async function prepareMathRuns(
   return { records, drawables };
 }
 
-interface RetainedTableRecord {
-  readonly sourceIndex: number;
-  readonly acquisition: RetainedTableAcquisition;
-  readonly contentWidthPt: number;
-  readonly anchorYPt: number;
-}
-
-export interface RenderState {
-  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
-  scale: number;    // px per pt
-  /** Device-pixel ratio the canvas was scaled by (`ctx.scale(dpr, dpr)`). Used to
-   *  compute the crisp-line offset (see crispOffset) so thin axis-aligned strokes
-   *  land on a single device row instead of straddling two. */
-  dpr: number;
-  contentX: number; // left of content area (px)
-  contentW: number; // width of content area (px)
-  y: number;        // current Y cursor (px)
-  pageH: number;    // full page height (px)
-  defaultColor: string;
-  /** 0-based page index currently being rendered */
-  pageIndex: number;
-  /** total page count in the document */
-  totalPages: number;
-  /** ECMA-376 §17.6.12 — the DISPLAYED page number for the current page (after
-   *  per-section `w:start` restart). A PAGE field renders this instead of the raw
-   *  `pageIndex + 1`. Absent ⇒ `pageIndex + 1` (single-section fallback). */
-  displayPageNumber?: number;
-  /** ECMA-376 §17.6.12 / §17.18.59 — the ST_NumberFormat governing the current
-   *  page's number (from the page's section `w:fmt`). A PAGE field formats its
-   *  result with this unless it carries its own `\*` switch (§17.16.4.3.1). Absent
-   *  ⇒ decimal. */
-  pageNumberFormat?: NumberFormat;
-  /** preloaded drawable images keyed by `imageKey(imagePath, colorReplaceFrom)`
-   *  (raster ImageBitmap or, for an `asvg:svgBlip` vector original, an
-   *  HTMLImageElement) */
-  images: Map<string, DecodedImage>;
-  /** when true, layout is performed but nothing is drawn (used for header/footer height measurement) */
-  dryRun: boolean;
-  /** section left margin in pt — used to convert margin-relative anchor X to page-absolute */
-  marginLeft: number;
-  /** section right margin in pt — used by anchor positioning to resolve
-   *  `<wp:positionH relativeFrom="margin">` and the `*Margin` family containers. */
-  marginRight: number;
-  /** ECMA-376 §17.6.11: the body's TOP/BOTTOM **inset** from the page edge in pt — the
-   *  margin's MAGNITUDE (|margin|), NOT the signed pgMar value. A negative top/bottom
-   *  margin (ST_SignedTwipsMeasure) measures the body |margin| from the page edge and
-   *  overlaps the header/footer; `bodyMarginInsetPt` derives this at the
-   *  measurement-state writers. Read as the canonical column-region top
-   *  and as the text-margin container for `relativeFrom=
-   *  "topMargin"/"bottomMargin"/"margin"` anchors/frames (anchor-geometry, frame-geometry;
-   *  §17.18.100 — the text-margin location IS the body edge). Do NOT treat as the signed
-   *  margin: the overflow decision keeps the sign separately (header/footerOverflowPt). */
-  marginTop: number;
-  marginBottom: number;
-  /** Section page width in pt. */
-  pageWidth: number;
-  /** Active anchor-image floats that constrain text layout on the current page. */
-  floats: FloatRect[];
-  /** Monotonic counter assigning a unique id to each registerAnchorFloats call,
-   *  i.e. one id per paragraph per page. Used only to scope the implementation-
-   *  defined (HEURISTIC) overlap avoidance to DIFFERENT paragraphs. Reset to 0
-   *  on every page flip so measure and render assign matching paraIds. */
-  floatParaSeq: number;
-  /** ECMA-376 §17.6.5 docGrid (type + pitch), applied to auto line spacing. */
-  docGrid: DocGridCtx;
-  /** Document-wide OOXML layout policy normalized once at renderer entry. */
-  layoutSettings: DocumentLayoutSettings;
-  /** Active section geometry and grid policy normalized for this state. */
-  sectionLayout: SectionLayoutContext;
-  /** Active WordprocessingML story and nested text-container stack. */
-  storyContext: StoryContext;
-  /** True when the document body contains East Asian text. Gates docGrid line-
-   *  cell rounding of empty / anchor-only paragraph marks (see
-   *  paragraphMarkLineHeight), which carry no text to classify themselves. */
-  docEastAsian: boolean;
-  /** ECMA-376 §17.8.3.10 — font→family map from word/fontTable.xml. Used by
-   *  resolveFontFamily as the authoritative source of serif/sans-serif classification. */
-  fontFamilyClasses: Record<string, string>;
-  /** Exact local faces and version-adaptive Word line metrics resolved before
-   * pagination. Keyed by normalized authored family. */
-  resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>>;
-  /** Instance-scoped resource snapshot shared by pagination and paint. */
-  layoutServices?: LayoutServices;
-  /** Renderer authorities injected into the pure recursive table acquisition. */
-  retainedTableAcquisition?: RetainedTableAcquisitionDependencies<RenderState>;
-  /** Session-local bridge from shape geometry to the shared paragraph/table
-   * story algorithms. Kept renderer-private so retained layouts stay plain. */
-  acquireCompleteTextBoxStory?: CompleteTextBoxStoryAcquirer;
-  /** Each body occurrence owns its acquisition and pagination context for this
-   * render session. Parser objects may legally occur more than once. */
-  retainedTablesBySourceIndex?: Map<number, RetainedTableRecord>;
-  /** ECMA-376 §17.15.1.58–.60 — resolved Japanese line-breaking rules
-   *  (kinsoku enabled flag + line-start/line-end forbidden character sets).
-   *  Default is the application's Japanese kinsoku table with kinsoku ON. */
-  kinsoku: KinsokuRules;
-  /** ECMA-376 §17.15.1.25 `w:defaultTabStop` — the interval (points) at which
-   *  automatic tab stops are generated after all custom stops. Threaded from
-   *  `doc.settings.defaultTabStop` like `kinsoku` so the MEASURE pass matches
-   *  the DRAW pass; falls back to {@link DEFAULT_TAB_PT} (720 twips = 36pt) when
-   *  the document omits the element. */
-  defaultTabPt: number;
-  /** ECMA-376 §17.15.1.18 — East Asian punctuation / character-spacing mode. */
-  characterSpacingControl?: string;
-  /** ECMA-376 §17.15.3.1 `w:compat/w:useFELayout`. */
-  useFeLayout?: boolean;
-  /** ECMA-376 §17.15.3.1 `w:compat/w:balanceSingleByteDoubleByteWidth`. */
-  balanceSingleByteDoubleByteWidth?: boolean;
-  /** ECMA-376 §22.1.2.30 `m:mathPr/m:defJc` — document-wide default math
-   *  justification (ST_Jc math). `undefined` ⇒ spec default `centerGroup`.
-   *  Threaded from `doc.settings.mathDefJc` like `kinsoku`; consumed by the
-   *  per-line alignment step for single display-math lines. */
-  mathDefJc?: string;
-  /** When false, runs tagged with a `revision` render without the
-   *  track-changes overlay (no author colour, no underline/strikethrough). */
-  showTrackChanges: boolean;
-  /** ECMA-376 §17.16.5.16 DATE / §17.16.5.72 TIME — the "current" instant (epoch
-   *  ms) a DATE/TIME field formats through its `\@` picture (§17.16.4.1). Injected
-   *  from the render option `currentDate` so field output is deterministic under
-   *  test; absent ⇒ `Date.now()` (real time). */
-  currentDateMs?: number;
-  /** ECMA-376 §17.11 — footnote/endnote reference markers (`noteRef` runs)
-   *  display the note's 1-based sequential number, not the raw `@w:id`. Keyed by
-   *  `"footnote:<id>"` / `"endnote:<id>"`. The in-note `<w:footnoteRef>`
-   *  placeholder (empty id) is substituted with the number provided via
-   *  {@link noteReferenceNumber} while laying out that note's content. */
-  noteNumbers?: Map<string, number>;
-  /** Set while laying out a footnote/endnote's own content, so the leading
-   *  `<w:footnoteRef>` placeholder (which carries no id) renders the note's
-   *  number. Undefined for body text. */
-  noteReferenceNumber?: number;
-  /** ECMA-376 §20.4.3.2/§20.4.3.5: a DrawingML anchor whose `<wp:positionV>`
-   *  uses a page-level `relativeFrom` (page / margin / topMargin / bottomMargin
-   *  / leftMargin / rightMargin / insideMargin / outsideMargin / column) is
-   *  positioned independently of its source-order anchoring paragraph — Word
-   *  lays it out as soon as the page is opened, so paragraphs that come BEFORE
-   *  the anchor's paragraph in source order still wrap around it. To match,
-   *  we pre-scan upcoming body paragraphs at every page-start and register
-   *  these floats up front. This set records which paragraphs have had their
-   *  page-level floats pre-registered on the current page, so
-   *  {@link registerAnchorFloats} skips re-registering them when the main
-   *  flow reaches that paragraph. Reset whenever floats are reset (page flip
-   *  or column relocation that rolls back this paragraph's own floats). */
-  pageAnchorPrescanned?: Set<DocParagraph>;
-  /** ECMA-376 §17.6.20 vertical writing — the FRAME-level vertical flag. When
-   *  true the page is laid out in a SWAPPED logical coordinate space (logical
-   *  width = physical page height) and the canonical section-region matrix rotates
-   *  body paint +90° into physical space. On a tbRl-family
-   *  page (no {@link verticalAllRotated}) the glyph-draw path then counter-
-   *  rotates each upright (CJK) glyph −90° about its own centre so ideographs
-   *  stand upright while Latin/digits stay sideways (correct for vertical
-   *  Japanese); a `btLr` page sets {@link verticalAllRotated} too, which
-   *  SUPPRESSES that counter-rotation (all glyphs ride the region transform).
-   *  Absent / false ⇒ horizontal (lrTb) — the whole layout + paint path is
-   *  byte-identical to the pre-vertical renderer. */
-  verticalCJK?: boolean;
-  /** ECMA-376 §17.6.20 + Part 4 §14.11.7 — set (always together with
-   *  {@link verticalCJK}) on a section-level `btLr` page. Under
-   *  `word-section-btlr-tbrl-page-frame`, `btLr` shares the `tbRl` PAGE FRAME (swapped logical
-   *  layout, +90° page paint, columns right→left) but rotates EVERY glyph with
-   *  the page — CJK is NOT counter-rotated upright, vertical punctuation forms
-   *  (、。（） → U+FE1x/FE3x) are NOT substituted, and 縦中横 (§17.3.2.10) is
-   *  NOT grouped. When set, the glyph-draw sites take the ordinary HORIZONTAL
-   *  branches inside the rotated frame, so the page raster equals the
-   *  horizontal rendering of the swapped frame rotated +90° CW wholesale.
-   *  Frame-level consumers (region transform, text-layer transform, `verticalPhys`
-   *  anchors, upright images/tables — GT-less for btLr, kept at tbRl parity)
-   *  keep reading {@link verticalCJK}. Absent ⇒ upright-vertical (tbRl family)
-   *  or horizontal. */
-  verticalAllRotated?: boolean;
-  /** ECMA-376 §17.6.20 + §20.4.3.x — the PHYSICAL page geometry for a vertical
-   *  (tbRl) page, in the SAME units the rest of RenderState uses (margins/page
-   *  size in pt; `cssWidthPx` in px). Present only when `verticalCJK` is set.
-   *  A DrawingML anchor's `<wp:positionH/V>` is resolved against the PHYSICAL page
-   *  (the drawing layer is placed independently of the text-flow rotation), so the
-   *  anchor path builds a PHYSICAL-geometry proxy RenderState from this and maps
-   *  the resolved physical box into the swapped logical frame via
-   *  {@link physicalToLogicalAnchorBox}. The four margins are the physical
-   *  pgMar values (already the body inset for the top/bottom, matching
-   *  `bodyMarginInsetPt`). `cssWidthPx` = physical page width in px = the page
-   *  transform's `translate(cssWidth, 0)` term. Absent ⇒ horizontal. */
-  verticalPhys?: {
-    pageWidth: number;
-    pageHeight: number;
-    marginLeft: number;
-    marginRight: number;
-    marginTop: number;
-    marginBottom: number;
-    cssWidthPx: number;
-  };
-  /** ECMA-376 §17.3.2.6 — the effective background (hex 6, no `#`) behind the text
-   *  from the ENCLOSING containers, most-specific first: a table cell's `<w:tcPr>
-   *  <w:shd w:fill>` (§17.4.33), overridden by a paragraph's `<w:pPr><w:shd w:fill>`
-   *  (§17.3.1.31). An automatic run color (`<w:color w:val="auto"/>`, no explicit
-   *  color) contrasts against this when the run has no closer background of its own
-   *  (its run-level `<w:shd>`). The layout acquisition state carries the cell
-   *  fill and paragraph override; absent means the page background. Only the
-   *  auto-contrast decision reads it; retained paint owns the shading geometry. */
-  containerShading?: string | null;
-}
-
 const BODY_STORY_CONTEXT: StoryContext = {
   story: 'body',
   containers: [],
@@ -803,8 +602,8 @@ const BODY_STORY_CONTEXT: StoryContext = {
 };
 
 export function resolveBodyParagraphLayoutContext(
-  state: Pick<RenderState, 'layoutSettings' | 'sectionLayout'>
-    & Partial<Pick<RenderState, 'layoutServices' | 'defaultTabPt'>>,
+  state: Pick<BodyAcquisitionState, 'layoutSettings' | 'sectionLayout'>
+    & Partial<Pick<BodyAcquisitionState, 'layoutServices' | 'defaultTabPt'>>,
   paragraph: DocParagraph,
 ): ParagraphLayoutContext {
   const context = resolveParagraphLayoutContext(
@@ -826,8 +625,8 @@ export function resolveBodyParagraphLayoutContext(
 }
 
 function resolveStateParagraphLayoutContext(
-  state: Pick<RenderState, 'layoutSettings' | 'sectionLayout' | 'storyContext'>
-    & Partial<Pick<RenderState, 'layoutServices' | 'defaultTabPt'>>,
+  state: Pick<BodyAcquisitionState, 'layoutSettings' | 'sectionLayout' | 'storyContext'>
+    & Partial<Pick<BodyAcquisitionState, 'layoutServices' | 'defaultTabPt'>>,
   paragraph: DocParagraph,
 ): ParagraphLayoutContext {
   const context = resolveParagraphLayoutContext(
@@ -848,7 +647,7 @@ function resolveStateParagraphLayoutContext(
   });
 }
 
-function withTableCellStory(state: RenderState): RenderState {
+function withTableCellStory(state: BodyAcquisitionState): BodyAcquisitionState {
   return {
     ...state,
     storyContext: enterTableCellStoryContext(
@@ -1417,7 +1216,7 @@ const renderTokens = new WeakMap<HTMLCanvasElement | OffscreenCanvas, number>();
  *                                 lands bottom-right) and vertical punctuation
  *                                 forms are NOT substituted. So `btLr` routes
  *                                 through the same +90° FRAME as `tbRl` while
- *                                 `RenderState.verticalAllRotated` switches the
+ *                                 `BodyAcquisitionState.verticalAllRotated` switches the
  *                                 glyph draw to the horizontal branches. (The per-
  *                                 SECTION mixing that fixture also exercises —
  *                                 a `btLr` non-final section beside a horizontal
@@ -1444,7 +1243,7 @@ function isVerticalTextDirection(td: string | null | undefined): boolean {
 /** True for a VERTICAL direction whose glyphs ALL ride the +90° page rotation
  *  (no CJK upright counter-rotation, no vertical punctuation forms, no 縦中横):
  *  section-level `btLr` under `word-section-btlr-tbrl-page-frame` (see
- *  {@link RenderState.verticalAllRotated}). The tbRl family keeps
+ *  {@link BodyAcquisitionState.verticalAllRotated}). The tbRl family keeps
  *  the upright-CJK glyph path. Only meaningful when
  *  {@link isVerticalTextDirection} is already true. */
 function isAllRotatedVerticalTextDirection(td: string | null | undefined): boolean {
@@ -1758,7 +1557,7 @@ function buildMeasureState(
   resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>> = {},
   layoutServices?: LayoutServices,
   layoutOptions?: LayoutOptions,
-): RenderState {
+): BodyAcquisitionState {
   const sectionLayout = resolveSectionLayoutContext(layoutSettings, section);
   // Story acquisition may omit services. Acquisition itself no longer
   // has an optional text authority: construct the same A2 service at this stable
@@ -1779,7 +1578,6 @@ function buildMeasureState(
   return {
     ctx,
     scale: 1,
-    dpr: 1,
     // Mirror the PAINT pass seed (renderDocumentToCanvas: `contentX =
     // sec.marginLeft × scale`; scale is 1 here). contentX/contentW carry the
     // current text column, and §20.4.3.4 `relativeFrom="column"` anchors
@@ -1792,11 +1590,8 @@ function buildMeasureState(
     contentW: section.pageWidth - section.marginLeft - section.marginRight,
     y: 0,
     pageH: section.pageHeight,
-    defaultColor: '#000000',
     pageIndex: 0,
     totalPages: fieldAcquisitionContextOf(effectiveLayoutServices).totalPages,
-    images: new Map(),
-    dryRun: true,
     marginLeft: section.marginLeft,
     marginRight: section.marginRight,
     // §17.6.11: the measure state's marginTop is the BODY-LEVEL body inset (|margin|).
@@ -1811,7 +1606,6 @@ function buildMeasureState(
     pageWidth: section.pageWidth,
     floats: [],
     floatParaSeq: 0,
-    docGrid: toLegacyDocGridContext(sectionLayout),
     layoutSettings,
     sectionLayout,
     storyContext: BODY_STORY_CONTEXT,
@@ -1987,11 +1781,6 @@ function buildMeasureState(
     currentDateMs: layoutOptions?.currentDateMs,
     kinsoku: layoutSettings.kinsoku,
     defaultTabPt: layoutSettings.defaultTabPt,
-    characterSpacingControl: layoutSettings.characterSpacingControl,
-    useFeLayout: layoutSettings.compat.useFeLayout,
-    balanceSingleByteDoubleByteWidth:
-      layoutSettings.compat.balanceSingleByteDoubleByteWidth,
-    showTrackChanges: false,
     // ECMA-376 §17.6.20 + §20.4.3.x (issue #988 ②, Codex review F1): for a
     // vertical (tbRl) section — `section` is the SWAPPED logical geometry — the
     // measure pass must resolve DrawingML anchors against the same PHYSICAL
@@ -2097,7 +1886,7 @@ function createConcreteBodyLayoutKernel(
    * renderer state into retained paragraph inputs; layout-owned projections
    * below it receive only immutable structural values. */
   const acquireBodyParagraphAtLocation = (
-    state: RenderState,
+    state: BodyAcquisitionState,
     paragraph: DocParagraph,
     source: SourceRef,
     location: BodyAcquisitionLocation,
@@ -2220,10 +2009,9 @@ function createConcreteBodyLayoutKernel(
           pageRegistryFlowDomainId(location.pageIndex),
           'logical-page-points',
         );
-      const applyLocationTo = (target: RenderState, next: BodyAcquisitionLocation) => {
+      const applyLocationTo = (target: BodyAcquisitionState, next: BodyAcquisitionLocation) => {
         const geometry = next.section.geometry;
         target.sectionLayout = next.section as SectionLayoutContext;
-        target.docGrid = toLegacyDocGridContext(next.section as SectionLayoutContext);
         target.pageIndex = next.pageIndex;
         const page = fieldAcquisitionContextOf(services).resolveDestinationPage?.(next.pageIndex);
         target.displayPageNumber = page?.displayPageNumber ?? next.pageIndex + 1;
@@ -2246,7 +2034,7 @@ function createConcreteBodyLayoutKernel(
       const publicParagraphFloatAcquisition = (
         paragraph: DocParagraph,
         source: SourceRef,
-        candidate: RenderState,
+        candidate: BodyAcquisitionState,
         onlyOccurrenceIds?: ReadonlySet<string>,
         paragraphId = floatRegistry.nextParagraphId,
       ): readonly FloatRegistryEntryPt[] => {
@@ -2360,7 +2148,7 @@ function createConcreteBodyLayoutKernel(
           throw new Error('Table paragraph re-acquisition source kind mismatch');
         }
         const scale = state.scale;
-        const candidate: RenderState = {
+        const candidate: BodyAcquisitionState = {
           ...withTableCellStory(state),
           contentX: 0,
           contentW: request.acquired.flowBounds.widthPt * scale,
@@ -2466,10 +2254,9 @@ function createConcreteBodyLayoutKernel(
         const fieldContext = fieldAcquisitionContextOf(services);
         const pageFieldContext = fieldContext.resolveDestinationPage?.(request.pageIndex);
         const storyVertical = isVerticalTextDirection(request.section.textDirection);
-        const candidate: RenderState = {
+        const candidate: BodyAcquisitionState = {
           ...state,
           sectionLayout: request.section as SectionLayoutContext,
-          docGrid: toLegacyDocGridContext(request.section as SectionLayoutContext),
           pageIndex: request.pageIndex,
           totalPages: fieldContext.totalPages,
           displayPageNumber: pageFieldContext?.displayPageNumber ?? request.pageIndex + 1,
@@ -2746,7 +2533,7 @@ function createConcreteBodyLayoutKernel(
               }),
             });
           }
-          const candidate: RenderState = {
+          const candidate: BodyAcquisitionState = {
             ...state,
             floats: [...state.floats],
             pageAnchorPrescanned: new Set(state.pageAnchorPrescanned),
@@ -3499,7 +3286,7 @@ function createConcreteBodyLayoutKernel(
           return Object.freeze(notes);
         },
         measureFollowingBlock(request) {
-          const candidate: RenderState = {
+          const candidate: BodyAcquisitionState = {
             ...state,
             floats: [...state.floats],
             retainedTablesBySourceIndex: new Map(state.retainedTablesBySourceIndex),
@@ -3652,7 +3439,7 @@ function createConcreteBodyLayoutKernel(
                     || publicRun.type === 'shape')
                   && publicRun.wrapMode === 'none'
                 ) return [];
-                const candidate: RenderState = {
+                const candidate: BodyAcquisitionState = {
                   ...state,
                   floats: [...state.floats],
                   pageAnchorPrescanned: new Set(state.pageAnchorPrescanned),
@@ -3852,21 +3639,7 @@ function createConcreteBodyLayoutKernel(
 }
 
 function paragraphMeasurementEnvironment(
-  state: Pick<
-    RenderState,
-    | 'pageIndex'
-    | 'totalPages'
-    | 'displayPageNumber'
-    | 'pageNumberFormat'
-    | 'currentDateMs'
-    | 'noteNumbers'
-    | 'noteReferenceNumber'
-    | 'verticalCJK'
-    | 'verticalAllRotated'
-    | 'docEastAsian'
-    | 'resolvedLocalFonts'
-    | 'layoutServices'
-  >,
+  state: BodyMeasurementContext,
 ): ParagraphMeasurementEnvironment {
   return {
     pageIndex: state.pageIndex,
@@ -3888,18 +3661,18 @@ function paragraphMeasurementEnvironment(
 }
 
 /** The `LineLayoutEnvironment` for building a paragraph's segments straight
- *  from a paint state. Identity (the state itself — byte-identical) for
+ *  from an acquisition measurement context. Identity for
  *  horizontal and upright-vertical (tbRl family) states; an all-rotated
  *  (§17.6.20 btLr, #988 re-adjudication) page builds its segments with
  *  `verticalCJK` CLEARED so no 縦中横 grouping (§17.3.2.10) engages — the btLr
  *  page is the horizontal layout rotated wholesale, so its segments are the
  *  horizontal ones (measure == paint: the paginator's measure state never sets
  *  `verticalCJK` either). */
-function segmentEnvironmentOf(state: RenderState): RenderState {
+function segmentEnvironmentOf(state: BodyMeasurementContext): LineLayoutEnvironment {
   return state.verticalAllRotated ? { ...state, verticalCJK: false } : state;
 }
 
-function retainedTableRecord(state: RenderState, sourceIndex: number): RetainedTableRecord {
+function retainedTableRecord(state: BodyAcquisitionState, sourceIndex: number): RetainedTableRecord {
   const record = state.retainedTablesBySourceIndex?.get(sourceIndex);
   if (!record) throw new Error('Table placement requires retained table acquisition');
   return record;
@@ -3925,18 +3698,20 @@ function snapParaLineToGrid(h: number, grid: DocGridCtx | undefined, scale: numb
  *  a paragraph with `w:snapToGrid` explicitly off ignores the section grid, so
  *  its lines use natural font metrics / the spacing multiplier directly. */
 function gridForParagraphContext(
-  state: Pick<RenderState, 'docGrid'>,
+  state: Pick<BodyMeasurementContext, 'sectionLayout'>,
   context: ParagraphLayoutContext,
 ): DocGridCtx {
   return {
-    type: state.docGrid.type,
+    type: state.sectionLayout.grid.kind === 'none'
+      ? null
+      : state.sectionLayout.grid.kind,
     linePitchPt: context.lineGrid.active ? context.lineGrid.pitchPt : null,
     charSpacePt:
       context.characterGrid.active ? context.characterGrid.deltaPt : null,
   };
 }
 
-function paraGrid(para: DocParagraph, state: RenderState): DocGridCtx {
+function paraGrid(para: DocParagraph, state: BodyMeasurementContext): DocGridCtx {
   return gridForParagraphContext(
     state,
     resolveStateParagraphLayoutContext(state, para),
@@ -3944,7 +3719,7 @@ function paraGrid(para: DocParagraph, state: RenderState): DocGridCtx {
 }
 
 function computeTableRowHeights(
-  state: RenderState,
+  state: BodyAcquisitionState,
   table: DocTable,
   contentWPt: number,
   sourceIndex?: number,
@@ -3957,7 +3732,7 @@ function computeTableRowHeights(
  *  fallback remains for reduced test/story states until measurement moves fully
  *  under layout ownership. */
 function computeTablePtLayout(
-  state: RenderState,
+  state: BodyAcquisitionState,
   table: DocTable,
   contentWPt: number,
   sourceIndex?: number,
@@ -4004,7 +3779,7 @@ function computeTablePtLayout(
 }
 
 function estimateTableHeight(
-  state: RenderState,
+  state: BodyAcquisitionState,
   table: DocTable,
   contentWPt: number,
   sourceIndex?: number,
@@ -4019,7 +3794,11 @@ function estimateTableHeight(
  * authored `tblW`, `tcW`, `wBefore`, and `wAfter` remain active constraints.
  * Exported for the table-layout integration tests.
  */
-export function resolveColumnWidths(table: DocTable, contentWPt: number, state: RenderState): number[] {
+export function resolveColumnWidths(
+  table: DocTable,
+  contentWPt: number,
+  state: BodyMeasurementContext,
+): number[] {
   const format = tableFormatInput(table);
   const marginsByCell = new WeakMap<object, Readonly<{ left: number; right: number }>>();
   table.rows.forEach((row, rowIndex) => row.cells.forEach((cell, cellIndex) => {
@@ -4209,7 +3988,7 @@ export function sumCellContentHeight(
 function frameAnchorLineHeightPx(
   elements: BodyElement[],
   frameEl: BodyElement,
-  state: RenderState,
+  state: BodyMeasurementContext,
 ): number {
   const start = elements.indexOf(frameEl);
   for (let j = start + 1; j < elements.length; j++) {
@@ -4250,12 +4029,12 @@ function frameAnchorLineHeightPx(
 /** Resolve a prepared body frame group and attach its retained member layouts. */
 function resolveFrameBox(
   para: DocParagraph,
-  state: RenderState,
+  state: BodyAcquisitionState,
   anchorLineHpx: number,
   onAcquired?: (acquired: ReturnType<typeof acquireRetainedFrameGroup>) => void,
 ): FrameBox {
   const group = bodyFrameGroupFor(para);
-  if (group && state.dryRun) {
+  if (group) {
     const measurer = { context: state.ctx, fontFamilyClasses: state.fontFamilyClasses };
     const environment = paragraphMeasurementEnvironment(state);
     const borderEdges = group.members.map(bodyParagraphBorderEdgesFor);
@@ -4383,30 +4162,6 @@ function resolveFrameBox(
   return computeFrameBox(fp, state, paraTop, contentW, contentH, anchorLineHpx);
 }
 
-/** Paint a picture with the effective DrawingML rotation/reflection composed
- * by the parser according to Annex L §L.4.7.4–§L.4.7.6. */
-function drawImageRunBitmap(
-  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
-  bmp: DecodedImage,
-  image: Pick<ImageRun, 'srcRect' | 'rotation' | 'flipH' | 'flipV'>,
-  x: number,
-  y: number,
-  w: number,
-  h: number,
-): void {
-  const rotation = image.rotation ?? 0;
-  if (rotation === 0 && !image.flipH && !image.flipV) {
-    drawImageCropped(ctx, bmp, image.srcRect ?? undefined, x, y, w, h);
-    return;
-  }
-  ctx.save();
-  ctx.translate(x + w / 2, y + h / 2);
-  ctx.rotate((rotation * Math.PI) / 180);
-  ctx.scale(image.flipH ? -1 : 1, image.flipV ? -1 : 1);
-  drawImageCropped(ctx, bmp, image.srcRect ?? undefined, -w / 2, -h / 2, w, h);
-  ctx.restore();
-}
-
 /**
  * Resolve an anchored shape's page-space bounding box {x,y,w,h} (px). Retained
  * drawing acquisition and float registration share this geometry so the
@@ -4420,7 +4175,7 @@ function drawImageRunBitmap(
  */
 function resolveShapeBox(
   shape: ShapeRun,
-  state: RenderState,
+  state: AnchorFloatRegistrationState,
   paragraphTopPx: number,
 ): { x: number; y: number; w: number; h: number } {
   // ECMA-376 §17.6.20 + §20.4.3.x (issue #988 batch-3 adjudication ②): on a
@@ -4516,7 +4271,7 @@ function resolveShapeBox(
  */
 export const __test_resolveAnchorBox = (
   img: ImageRun,
-  state: RenderState,
+  state: AnchorFloatRegistrationState,
   paraBaseY: number,
 ): { x: number; y: number; w: number; h: number; dl: number; dr: number; dt: number; db: number } =>
   resolveAnchorBox(img, state, paraBaseY);
@@ -4526,7 +4281,7 @@ export const __test_resolveAnchorBox = (
  *  an anchored SHAPE's positionH/V on a vertical (tbRl) page. */
 export const __test_resolveShapeBox = (
   shape: ShapeRun,
-  state: RenderState,
+  state: AnchorFloatRegistrationState,
   paragraphTopPx: number,
 ): { x: number; y: number; w: number; h: number } =>
   resolveShapeBox(shape, state, paragraphTopPx);
@@ -4541,12 +4296,12 @@ export const __test_verticalLayoutSection = (phys: SectionProps): SectionProps =
 
 /** Exported for the page-anchor pre-scan test (ECMA-376 §20.4.3.2/§20.4.3.5):
  *  drives {@link preRegisterPageFloats} from a unit test against a stub
- *  RenderState so we can pin which paragraphs get pre-registered and that
+ *  AnchorFloatRegistrationState so we can pin which paragraphs get pre-registered and that
  *  duplicate calls are idempotent. */
 export const __test_preRegisterPageFloats = (
   body: readonly BodyElement[],
   startIdx: number,
-  state: RenderState,
+  state: AnchorFloatRegistrationState,
 ): void => preRegisterPageFloats(body, startIdx, state);
 
 /** Exported for the page-anchor pre-scan test — pins the
@@ -4557,7 +4312,7 @@ export const __test_isPageLevelAnchorY = (
   fromPara: boolean,
 ): boolean => isPageLevelAnchorY(rf, fromPara);
 
-/** ECMA-376 §17.6.20 + §20.4.3.x — a RenderState view whose page/margin geometry
+/** ECMA-376 §17.6.20 + §20.4.3.x — an acquisition-state view whose page/margin geometry
  *  is the PHYSICAL (un-rotated) page, used to resolve a DrawingML anchor's
  *  `<wp:positionH/V>` against the physical page for a vertical (tbRl) section
  *  under `word-vertical-section-physical-drawing-layer`. Only
@@ -4565,7 +4320,9 @@ export const __test_isPageLevelAnchorY = (
  *  read are overridden (scale, page size, margins, `pageH`); everything else is
  *  the live logical state. Callers map the resolved physical box back into the
  *  logical layout frame with {@link physicalToLogicalAnchorBox}. */
-function physicalAnchorState(state: RenderState): RenderState {
+function physicalAnchorState(
+  state: AnchorFloatRegistrationState,
+): AnchorFloatRegistrationState {
   const p = state.verticalPhys;
   if (!p) return state;
   return {
@@ -4581,20 +4338,20 @@ function physicalAnchorState(state: RenderState): RenderState {
   };
 }
 
-/** ECMA-376 §17.6.20 + §20.4.3.x (issue #988 ②/④) — a RenderState view whose
+/** ECMA-376 §17.6.20 + §20.4.3.x (issue #988 ②/④) — an acquisition-state view whose
  *  geometry AND text flags are PHYSICAL, for content that stays UPRIGHT inside a
  *  vertical (tbRl) section: anchored shapes and block tables. Under
- *  `word-vertical-section-physical-drawing-layer`, these resolve and paint
- *  against the un-rotated physical page — cell/label text is
+ *  `word-vertical-section-physical-drawing-layer`, these acquire against the
+ *  un-rotated physical page — cell/label text is
  *  horizontal — so on top of {@link physicalAnchorState}'s page/margin un-swap
  *  this view also re-points the content band at the physical margins and clears
  *  the vertical flags (no per-glyph counter-rotation, no +90° text-layer
  *  transform, `resolveShapeBox`/`resolveAnchorBox` take their horizontal path).
  *  `floats` is fresh: the live float set is in LOGICAL flow coordinates and must
- *  not leak into a physical-frame layout (and vice-versa). The front-paint
- *  session is cleared so a nested front float paints in place, inside the
- *  counter-rotated physical frame its geometry was resolved in. */
-function verticalPhysicalContentState(state: RenderState): RenderState {
+ *  not leak into a physical-frame layout (and vice-versa). */
+function verticalPhysicalContentState(
+  state: AnchorFloatRegistrationState,
+): AnchorFloatRegistrationState {
   const p = state.verticalPhys;
   if (!p) return state;
   return {
@@ -4619,7 +4376,7 @@ type AnchorBoxSource = Pick<ImageRun,
 
 function resolveAnchorBox(
   img: AnchorBoxSource,
-  state: RenderState,
+  state: AnchorFloatRegistrationState,
   paraBaseY: number,
 ): { x: number; y: number; w: number; h: number; dl: number; dr: number; dt: number; db: number } {
   const scale = state.scale;
@@ -4646,7 +4403,7 @@ function resolveAnchorBox(
     // `word-vertical-section-physical-drawing-layer`: resolve positionH/V in
     // the physical page frame independently of rotated text flow, resolve the
     // box there, then project it into the swapped logical layout frame. The
-    // float-exclusion band and the drawUprightBox-un-swapped painted image
+    // float-exclusion band and the retained upright painted image
     // therefore share one geometry. A `paragraph`/`line`-relative positionV
     // anchors from the physical top of the anchor paragraph's column. That y is
     // the column band's logical x start (`state.contentX`; physical y =
@@ -4711,10 +4468,14 @@ function isPageLevelWrapFloat(run: ImageRun | ChartRun | ShapeRun): boolean {
  *  Page-level floats (positionV relativeFrom ∈ {page, margin, *Margin, column},
  *  ECMA-376 §20.4.3.2/§20.4.3.5) are skipped when this paragraph was already
  *  pre-registered at the current page's start by {@link preRegisterPageFloats}
- *  — re-registering would double-stamp the FloatRect (and re-draw the image).
+ *  — re-registering would double-stamp the FloatRect.
  *  Paragraph-local floats (`paragraph`/`line`/`character`) keep the per-
  *  paragraph path so their Y stays anchored at this paragraph's top. */
-function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphAnchorY: number): void {
+function registerAnchorFloats(
+  para: DocParagraph,
+  state: AnchorFloatRegistrationState,
+  paragraphAnchorY: number,
+): void {
   // One id per registerAnchorFloats call ⇒ one id per paragraph. Floats sharing
   // a paraId (e.g. two side-by-side photos in one paragraph) never displace each
   // other; floats from different paragraphs do (de-facto overlap avoidance).
@@ -4745,7 +4506,7 @@ function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphA
  *  (ECMA-376 §20.4.3.2/§20.4.3.5 + §20.4.2.16/.17). Each pre-registered
  *  paragraph is recorded in `state.pageAnchorPrescanned` so the main flow's
  *  {@link registerAnchorFloats} skips its page-level runs (avoiding a
- *  duplicate FloatRect / re-drawn image) while still registering its
+ *  duplicate FloatRect) while still registering its
  *  paragraph-local floats normally.
  *
  *  Bounds: the scan stops at the next forced page boundary that the
@@ -4759,7 +4520,7 @@ function registerAnchorFloats(para: DocParagraph, state: RenderState, paragraphA
 function preRegisterPageFloats(
   body: readonly BodyElement[],
   startIdx: number,
-  state: RenderState,
+  state: AnchorFloatRegistrationState,
 ): void {
   if (!state.pageAnchorPrescanned) state.pageAnchorPrescanned = new Set();
   for (let j = startIdx; j < body.length; j++) {
@@ -4811,11 +4572,11 @@ function preRegisterPageFloats(
   }
 }
 
-/** Reserve the float-exclusion rect for one anchored wrap-image and draw the
- *  bitmap immediately (the image is the float). */
+/** Reserve the float-exclusion rect for one anchored wrap-image. Retained paint
+ * owns the bitmap drawing. */
 function registerImageFloat(
   img: ImageRun,
-  state: RenderState,
+  state: AnchorFloatRegistrationState,
   paragraphAnchorY: number,
   paraId: number,
 ): void {
@@ -4839,7 +4600,7 @@ function registerImageFloat(
   // padding as the float-to-float gap. See layout/floats.ts.
   const allowOverlap = img.allowOverlap ?? true;
   const key = imageKey(img.imagePath, img.colorReplaceFrom, img.duotone);
-  const rect = pushFloatRect(state, {
+  pushFloatRect(state, {
     x: box.x,
     y: box.y,
     w, h, dl, dr, dt, db,
@@ -4852,35 +4613,13 @@ function registerImageFloat(
     avoidOverlap: true,
     allowOverlap,
   });
-
-  if (!state.dryRun) {
-    const bmp = state.images.get(key);
-    if (bmp) {
-      // §20.1.8.6 alphaModFix — multiply the picture's opacity.
-      const hasAlpha = img.alpha != null && img.alpha < 1;
-      if (hasAlpha) {
-        state.ctx.save();
-        state.ctx.globalAlpha *= img.alpha as number;
-      }
-      if (state.verticalCJK) {
-        // §17.6.20 (tbRl) — keep the floated image UPRIGHT inside the rotated page.
-        drawUprightBox(state.ctx, rect.imageX, rect.imageY, rect.imageW, rect.imageH, (dx, dy, dw, dh) =>
-          drawImageRunBitmap(state.ctx, bmp, img, dx, dy, dw, dh),
-        );
-      } else {
-        drawImageRunBitmap(state.ctx, bmp, img, rect.imageX, rect.imageY, rect.imageW, rect.imageH);
-      }
-      if (hasAlpha) state.ctx.restore();
-    }
-    rect.drawn = true;
-  }
 }
 
-/** Reserve the float-exclusion rect for one anchored wrap-chart and paint the
- *  chart at the overlap-resolved box (ECMA-376 §20.4.2.3/.16/.17). */
+/** Reserve the float-exclusion rect for one anchored wrap-chart
+ *  (ECMA-376 §20.4.2.3/.16/.17). Retained paint owns chart drawing. */
 function registerChartFloat(
   chart: ChartRun,
-  state: RenderState,
+  state: AnchorFloatRegistrationState,
   paragraphAnchorY: number,
   paraId: number,
 ): void {
@@ -4890,7 +4629,7 @@ function registerChartFloat(
   const { w, h, dl, dr, dt, db } = box;
   if (w <= 0 || h <= 0) return;
 
-  const rect = pushFloatRect(state, {
+  pushFloatRect(state, {
     x: box.x,
     y: box.y,
     w, h, dl, dr, dt, db,
@@ -4903,30 +4642,13 @@ function registerChartFloat(
     imageKey: '',
     drawn: false,
   });
-
-  if (!state.dryRun) {
-    const paint = (x: number, y: number, width: number, height: number): void =>
-      renderChart(
-        state.ctx as CanvasRenderingContext2D,
-        chart.chart,
-        { x, y, w: width, h: height },
-        state.scale,
-      );
-    if (state.verticalCJK) {
-      // ECMA-376 §17.6.20 (tbRl) — a chart is a graphic, so keep it upright.
-      drawUprightBox(state.ctx, rect.imageX, rect.imageY, rect.imageW, rect.imageH, paint);
-    } else {
-      paint(rect.imageX, rect.imageY, rect.imageW, rect.imageH);
-    }
-    rect.drawn = true;
-  }
 }
 
 /** Reserve the float-exclusion rect for one anchored wrap shape. Retained paint
  *  owns the drawing, so this only pushes an already-represented FloatRect. */
 function registerShapeFloat(
   shape: ShapeRun,
-  state: RenderState,
+  state: AnchorFloatRegistrationState,
   paragraphAnchorY: number,
   paraId: number,
 ): void {
@@ -4995,7 +4717,7 @@ function measureCellContentHeightPx(
   table: DocTable,
   cellW: number,
   scale: number,
-  state: RenderState,
+  state: BodyAcquisitionState,
 ): number {
   const cellState = withTableCellStory(state);
   const cm = effCellMargins(cell, table);
@@ -5029,7 +4751,7 @@ function measureCellContentHeightPx(
  *  invariant is that vAlign, row sizing, and retained paint consume the same
  *  acquired line boxes. */
 function measureCellParagraphWindow(
-  state: RenderState,
+  state: BodyMeasurementContext,
   para: DocParagraph,
   maxWidth: number,
   scale: number,
@@ -5173,7 +4895,7 @@ function effCellMargins(
 /** Measure a cell-level element (paragraph or nested table) at the rendering
  *  scale. Returns total occupied height including paragraph spacing. */
 function measureCellElementHeight(
-  state: RenderState,
+  state: BodyAcquisitionState,
   ce: CellElement,
   innerWPx: number,
   scale: number,

--- a/packages/docx/src/retained-shape-textbox.test-support.ts
+++ b/packages/docx/src/retained-shape-textbox.test-support.ts
@@ -1,11 +1,23 @@
 import { DEFAULT_KINSOKU_RULES } from '@silurus/ooxml-core';
-import type { ParagraphLayoutContext } from './layout-context.js';
+import type {
+  DocumentLayoutSettings,
+  ParagraphLayoutContext,
+  SectionLayoutContext,
+} from './layout-context.js';
 import { acquireShapeTextBoxLayout } from './layout/paragraph.js';
 import { paintTextBoxLayout } from './paint/canvas-text.js';
-import { createLayoutServices, type DecodedImage, type RenderState } from './renderer.js';
+import { createLayoutServices, type DecodedImage } from './renderer.js';
+import type { BodyAcquisitionState } from './layout/acquisition-context.js';
 import { textBoxAcquisitionInput } from './parser-model.js';
 import type { TextBoxLayout } from './layout/types.js';
 import type { DocxDocumentModel, ShapeRun } from './types.js';
+
+export type ShapeAcquisitionTestState =
+  Omit<Partial<BodyAcquisitionState>, 'layoutSettings' | 'sectionLayout'>
+  & {
+    layoutSettings?: Pick<DocumentLayoutSettings, 'mathDefJc'>;
+    sectionLayout?: Pick<SectionLayoutContext, 'grid'>;
+  };
 
 function servicesFor(
   ctx: CanvasRenderingContext2D,
@@ -25,6 +37,22 @@ function servicesFor(
   } as DocxDocumentModel, { measureContext: ctx });
 }
 
+/** Minimal acquisition cursor for tests that need to inject document services
+ * into retained text-box acquisition. */
+export function shapeAcquisitionState(
+  ctx: CanvasRenderingContext2D,
+  scale: number,
+  fontFamilyClasses: Record<string, string>,
+): ShapeAcquisitionTestState {
+  return {
+    ctx,
+    scale,
+    fontFamilyClasses,
+    kinsoku: DEFAULT_KINSOKU_RULES,
+    defaultTabPt: 36,
+  };
+}
+
 /** Test-only adapter over the production retained acquisition API. */
 export function acquireShapeTextBoxForTest(
   shape: ShapeRun,
@@ -32,14 +60,14 @@ export function acquireShapeTextBoxForTest(
   ctx: CanvasRenderingContext2D,
   scale: number,
   fontFamilyClasses: Record<string, string> = {},
-  state?: RenderState,
+  state?: ShapeAcquisitionTestState,
 ): TextBoxLayout | undefined {
   const services = state?.layoutServices ?? servicesFor(ctx, fontFamilyClasses);
-  const grid = state?.docGrid;
+  const grid = state?.sectionLayout?.grid;
   const lineGridActive = grid?.linePitchPt != null && grid.linePitchPt > 0
-    && (grid.type === 'lines' || grid.type === 'linesAndChars' || grid.type === 'snapToChars');
+    && (grid.kind === 'lines' || grid.kind === 'linesAndChars' || grid.kind === 'snapToChars');
   const characterGridActive = grid?.charSpacePt != null
-    && (grid.type === 'linesAndChars' || grid.type === 'snapToChars');
+    && (grid.kind === 'linesAndChars' || grid.kind === 'snapToChars');
   const context: ParagraphLayoutContext = {
     lineGrid: { active: lineGridActive, pitchPt: lineGridActive ? grid?.linePitchPt ?? null : null },
     characterGrid: {
@@ -52,7 +80,7 @@ export function acquireShapeTextBoxForTest(
     tabStops: [], hasRuby: false, hasEastAsianText: false,
     kinsoku: state?.kinsoku ?? DEFAULT_KINSOKU_RULES,
     defaultTabPt: state?.defaultTabPt ?? 36,
-    mathDefJc: state?.mathDefJc,
+    mathDefJc: state?.layoutSettings?.mathDefJc,
   };
   const source = { story: 'textbox' as const, storyInstance: 'test-shape', path: [] as number[] };
   return acquireShapeTextBoxLayout(shape, {
@@ -91,7 +119,7 @@ export function acquireAndPaintShapeTextBox(
   scale: number,
   fontFamilyClasses: Record<string, string> = {},
   images: Map<string, DecodedImage> = new Map(),
-  state?: RenderState,
+  state?: ShapeAcquisitionTestState,
 ): void {
   const layout = acquireShapeTextBoxForTest(
     shape, x, y, w, h, ctx, scale, fontFamilyClasses, state,
@@ -140,10 +168,9 @@ export function acquireAndPaintShapeTextBox(
     }
   });
   paintTextBoxLayout(layout, {
-    ctx: viewportContext, scale, dpr: state?.dpr ?? 1,
+    ctx: viewportContext, scale, dpr: 1,
     defaultTextColor: shape.defaultTextColor
-      ? `#${shape.defaultTextColor}` : state?.defaultColor ?? '#000000',
-    showTrackChanges: state?.showTrackChanges,
+      ? `#${shape.defaultTextColor}` : '#000000',
     resources: {
       paint(resourceKey, kind, bounds, paintContext) {
         if (kind !== 'image') return;

--- a/packages/docx/src/textbox-docgrid-line-pitch.test.ts
+++ b/packages/docx/src/textbox-docgrid-line-pitch.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   acquireAndPaintShapeTextBox,
   acquireShapeTextBoxForTest,
+  shapeAcquisitionState,
+  type ShapeAcquisitionTestState,
 } from './retained-shape-textbox.test-support.js';
-import { shapeRenderState } from './line-layout.js';
-import type { RenderState } from './renderer.js';
 import type { ShapeRun, ShapeText } from './types';
 
 // ECMA-376 §17.6.5 `<w:docGrid w:type="lines" w:linePitch>` — a document with a
@@ -88,9 +88,18 @@ function eaTextbox(): ShapeRun {
 function stateWithGrid(
   ctx: CanvasRenderingContext2D,
   grid: { type: string | null; linePitchPt: number | null } | undefined,
-): RenderState {
-  const base = shapeRenderState(ctx, 1, {}, new Map());
-  return { ...base, docGrid: grid } as unknown as RenderState;
+): ShapeAcquisitionTestState {
+  const base = shapeAcquisitionState(ctx, 1, {});
+  return {
+    ...base,
+    sectionLayout: {
+      grid: {
+        kind: grid?.type === 'lines' ? 'lines' : 'none',
+        linePitchPt: grid?.linePitchPt ?? null,
+        charSpacePt: null,
+      },
+    },
+  };
 }
 
 /** Vertical delta between the first two DISTINCT baseline y values = the first

--- a/packages/docx/src/textbox-docgrid-line-pitch.test.ts
+++ b/packages/docx/src/textbox-docgrid-line-pitch.test.ts
@@ -87,14 +87,18 @@ function eaTextbox(): ShapeRun {
 /** State carrying the section docGrid (like the production render threads). */
 function stateWithGrid(
   ctx: CanvasRenderingContext2D,
-  grid: { type: string | null; linePitchPt: number | null } | undefined,
+  grid: {
+    type: 'default' | 'lines' | 'linesAndChars' | 'snapToChars' | null;
+    linePitchPt: number | null;
+  } | undefined,
 ): ShapeAcquisitionTestState {
   const base = shapeAcquisitionState(ctx, 1, {});
+  const kind = grid?.type == null || grid.type === 'default' ? 'none' : grid.type;
   return {
     ...base,
     sectionLayout: {
       grid: {
-        kind: grid?.type === 'lines' ? 'lines' : 'none',
+        kind,
         linePitchPt: grid?.linePitchPt ?? null,
         charSpacePt: null,
       },

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -52,7 +52,7 @@
 // font-dependent stage-1 heuristics; paragraph-relative vertical anchors are a
 // follow-up. `btLr` shares the +90° page FRAME but bypasses this module's
 // upright/substitute glyph handling entirely (issue #988 re-adjudication: every
-// glyph rides the page rotation — see RenderState.verticalAllRotated).
+// glyph rides the page rotation — see BodyAcquisitionState.verticalAllRotated).
 
 import { wordPreservesVerticalTuCorner } from './layout/script-compatibility.js';
 import {

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -238,7 +238,9 @@ function assertNoProductionTestSupportImports(root) {
 
 function assertAcquisitionContextBoundary(root) {
   const contextPath = resolve(root, ACQUISITION_CONTEXT);
-  if (!existsSync(contextPath)) return;
+  if (!existsSync(contextPath)) {
+    fail('ACQUISITION_CONTEXT_SURFACE', `${ACQUISITION_CONTEXT} missing`);
+  }
   const source = sourceFile(contextPath);
   const declarations = new Set(source.statements.flatMap(declarationNames));
   for (const name of ACQUISITION_CONTEXT_DECLARATIONS) {

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -19,6 +19,7 @@ const BODY_LAYOUT_ADAPTER = `${DOCX_SOURCE}/body-layout-input.ts`;
 const PARAGRAPH_ANCHOR_FRAME_ADAPTER = `${DOCX_SOURCE}/paragraph-anchor-frame-adapter.ts`;
 const WORKER_LAYOUT_RETENTION = `${DOCX_SOURCE}/render-worker-layout.ts`;
 const TEXT_RUN_PROJECTION_ADAPTER = `${DOCX_SOURCE}/text-run-projection.ts`;
+const ACQUISITION_CONTEXT = `${LAYOUT_SOURCE}/acquisition-context.ts`;
 const LAYOUT_PARSER_MODEL_GATEWAY = `${LAYOUT_SOURCE}/resources.ts`;
 const LAYOUT_AFFINE = `${LAYOUT_SOURCE}/affine.ts`;
 const LAYOUT_PARSER_MODEL_GATEWAY_IMPORT = '../parser-model.js';
@@ -127,6 +128,7 @@ const LEGACY_SYMBOLS = [
   'buildTableCellBlocks',
   'renderHeaderFooter',
   'measureFootnoteHeight',
+  'RenderState',
   'deferFront',
   'deferFrontDrawing',
   'deferBehindDrawing',
@@ -177,6 +179,32 @@ const LEGACY_RENDERER_IMPORTS = new Set([
   'table-geometry.ts',
 ]);
 
+const ACQUISITION_CONTEXT_DECLARATIONS = new Set([
+  'AnchorFloatRegistrationState',
+  'AnchorGeometryContext',
+  'BodyAcquisitionState',
+  'BodyMeasurementContext',
+  'FloatRegistrationState',
+  'PhysicalAnchorFrame',
+  'RetainedTableRecord',
+]);
+
+const ACQUISITION_CONTEXT_CONSUMERS = [
+  `${DOCX_SOURCE}/anchor-geometry.ts`,
+  `${DOCX_SOURCE}/float-table-geometry.ts`,
+  `${DOCX_SOURCE}/frame-geometry.ts`,
+  `${DOCX_SOURCE}/line-layout.ts`,
+  `${DOCX_SOURCE}/paragraph-measure.ts`,
+];
+
+const ACQUISITION_PAINT_PROPERTIES = new Set([
+  'defaultColor',
+  'dpr',
+  'dryRun',
+  'images',
+  'showTrackChanges',
+]);
+
 function fail(code, detail) {
   throw new Error(`${code}: ${detail}`);
 }
@@ -202,6 +230,45 @@ function assertNoProductionTestSupportImports(root) {
         fail(
           'PRODUCTION_TEST_SUPPORT_IMPORT',
           `${posixPath(relative(root, path))} -> ${posixPath(relative(root, dependency))}`,
+        );
+      }
+    }
+  }
+}
+
+function assertAcquisitionContextBoundary(root) {
+  const contextPath = resolve(root, ACQUISITION_CONTEXT);
+  if (!existsSync(contextPath)) return;
+  const source = sourceFile(contextPath);
+  const declarations = new Set(source.statements.flatMap(declarationNames));
+  for (const name of ACQUISITION_CONTEXT_DECLARATIONS) {
+    if (!declarations.has(name)) {
+      fail('ACQUISITION_CONTEXT_SURFACE', `${ACQUISITION_CONTEXT} missing ${name}`);
+    }
+  }
+  for (const statement of source.statements) {
+    if (!ts.isInterfaceDeclaration(statement)) continue;
+    for (const member of statement.members) {
+      if (!ts.isPropertySignature(member) || !member.name) continue;
+      const name = ts.isIdentifier(member.name) || ts.isStringLiteralLike(member.name)
+        ? member.name.text
+        : null;
+      if (name && ACQUISITION_PAINT_PROPERTIES.has(name)) {
+        fail('ACQUISITION_PAINT_CAPABILITY', `${ACQUISITION_CONTEXT}#${name}`);
+      }
+    }
+  }
+  const inspected = [ACQUISITION_CONTEXT, ...ACQUISITION_CONTEXT_CONSUMERS];
+  for (const file of inspected) {
+    const path = resolve(root, file);
+    if (!existsSync(path)) continue;
+    for (const edge of moduleEdges(path)) {
+      if (!edge.literal || !edge.specifier.startsWith('.')) continue;
+      const dependency = resolveLocalImport(path, edge.specifier);
+      if (dependency && posixPath(relative(root, dependency)) === `${DOCX_SOURCE}/renderer.ts`) {
+        fail(
+          'ACQUISITION_RENDERER_DEPENDENCY',
+          `${file} -> ${DOCX_SOURCE}/renderer.ts`,
         );
       }
     }
@@ -1990,6 +2057,16 @@ function normalizedNodeHash(node, source) {
   return createHash('sha256').update(normalized).digest('hex');
 }
 
+function normalizedMeasureCellContentHeightHash(node, source) {
+  // C3c changes only the cursor's ownership/type name. Keep the legacy body
+  // byte-pinned until C3d physically moves the measurement chain.
+  const normalized = node.getText(source)
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\bBodyAcquisitionState\b/g, 'RenderState');
+  return createHash('sha256').update(normalized).digest('hex');
+}
+
 function normalizedSyntaxHash(node, source) {
   const shape = (current) => {
     const text = ts.isIdentifier(current) || ts.isLiteralExpression(current)
@@ -3338,6 +3415,8 @@ function declarationInventory(root, allowTransitionalAdapter = false) {
               ? normalizedIsFragmentPaintableTableHash(statement, source)
             : name === 'renderShapeText'
               ? normalizedRenderShapeTextHash(statement, source)
+            : name === 'measureCellContentHeightPx'
+              ? normalizedMeasureCellContentHeightHash(statement, source)
             : normalizedNodeHash(statement, source);
         }
       }
@@ -3692,6 +3771,7 @@ export function checkDocxLayoutBoundaries(options) {
   const baselineExists = existsSync(baselinePath);
   const allowTransitionalParagraphAnchorAdapter = baselineExists && !options.final;
   assertNoProductionTestSupportImports(root);
+  assertAcquisitionContextBoundary(root);
   assertFloatPlacementAuthority(root);
   assertNoDeletedPageProducerIdentifiers(root);
   assertPaintBoundaries(root);

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -312,6 +312,57 @@ test('rejects migration flags and silent alternate layout fallbacks', () => {
   }
 });
 
+test('rejects renderer-owned acquisition state from the final architecture', () => {
+  const root = initializeCanonicalFixture('docx-layout-boundary-render-state-');
+  write(
+    root,
+    'packages/docx/src/layout/obsolete-state.ts',
+    'export interface RenderState { readonly dryRun: boolean }\n',
+  );
+  expectDiagnostic(root, 'FINAL_LEGACY_BOUNDARY', 'RenderState', '--final');
+});
+
+test('layout acquisition contexts reject paint capabilities and renderer back-edges', () => {
+  const paintRoot = initializeCanonicalFixture('docx-layout-boundary-acquisition-paint-');
+  write(
+    paintRoot,
+    'packages/docx/src/layout/acquisition-context.ts',
+    'export interface AnchorFloatRegistrationState {}\n'
+      + 'export interface AnchorGeometryContext {}\n'
+      + 'export interface BodyAcquisitionState { images: Map<string, unknown> }\n'
+      + 'export type BodyMeasurementContext = Readonly<BodyAcquisitionState>;\n'
+      + 'export interface FloatRegistrationState {}\n'
+      + 'export interface PhysicalAnchorFrame {}\n'
+      + 'export interface RetainedTableRecord {}\n',
+  );
+  expectDiagnostic(
+    paintRoot,
+    'ACQUISITION_PAINT_CAPABILITY',
+    'images',
+    '--final',
+  );
+
+  const edgeRoot = initializeCanonicalFixture('docx-layout-boundary-acquisition-edge-');
+  write(
+    edgeRoot,
+    'packages/docx/src/layout/acquisition-context.ts',
+    "import type { Hidden } from '../renderer.js';\n"
+      + 'export interface AnchorFloatRegistrationState {}\n'
+      + 'export interface AnchorGeometryContext {}\n'
+      + 'export interface BodyAcquisitionState { hidden?: Hidden }\n'
+      + 'export type BodyMeasurementContext = Readonly<BodyAcquisitionState>;\n'
+      + 'export interface FloatRegistrationState {}\n'
+      + 'export interface PhysicalAnchorFrame {}\n'
+      + 'export interface RetainedTableRecord {}\n',
+  );
+  expectDiagnostic(
+    edgeRoot,
+    'ACQUISITION_RENDERER_DEPENDENCY',
+    'renderer.ts',
+    '--final',
+  );
+});
+
 test('coordinate-space and page-factory accept only their explicit dependencies', () => {
   assert.equal(runChecker(initializeCanonicalFixture(), '--final').status, 0);
   for (const [name, path, source] of [

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -77,6 +77,14 @@ function initializeCanonicalFixture(prefix = 'docx-layout-boundary-canonical-') 
     "import { snapshotPlainData } from './plain-data.js';\nexport const project = snapshotPlainData;\n");
   write(root, 'packages/docx/src/layout/types.ts',
     'export interface PointPt { xPt: number; yPt: number }\n');
+  write(root, 'packages/docx/src/layout/acquisition-context.ts',
+    'export interface AnchorFloatRegistrationState {}\n'
+      + 'export interface AnchorGeometryContext {}\n'
+      + 'export interface BodyAcquisitionState {}\n'
+      + 'export type BodyMeasurementContext = Readonly<BodyAcquisitionState>;\n'
+      + 'export interface FloatRegistrationState {}\n'
+      + 'export interface PhysicalAnchorFrame {}\n'
+      + 'export interface RetainedTableRecord {}\n');
   write(root, 'packages/docx/src/layout/affine.ts',
     "import type { PointPt } from './types.js';\n"
       + 'export const composeAffine = (point: PointPt) => point;\n');
@@ -359,6 +367,17 @@ test('layout acquisition contexts reject paint capabilities and renderer back-ed
     edgeRoot,
     'ACQUISITION_RENDERER_DEPENDENCY',
     'renderer.ts',
+    '--final',
+  );
+});
+
+test('layout acquisition context ownership cannot be bypassed by removing its module', () => {
+  const root = initializeCanonicalFixture('docx-layout-boundary-acquisition-missing-');
+  rmSync(join(root, 'packages/docx/src/layout/acquisition-context.ts'));
+  expectDiagnostic(
+    root,
+    'ACQUISITION_CONTEXT_SURFACE',
+    'missing acquisition context module must fail the ownership ratchet',
     '--final',
   );
 });

--- a/scripts/docx-layout-boundary-baseline.json
+++ b/scripts/docx-layout-boundary-baseline.json
@@ -4,9 +4,7 @@
     "packages/docx/src/renderer.ts#measureCellContentHeightPx": 2
   },
   "migrationIdentifierCounts": {
-    "packages/docx/src/layout-context.ts#toLegacyDocGridContext": 1,
-    "packages/docx/src/renderer.ts#dryRun": 5,
-    "packages/docx/src/renderer.ts#toLegacyDocGridContext": 4
+    "packages/docx/src/layout-context.ts#toLegacyDocGridContext": 1
   },
   "nonLayoutDeclarationKeys": [
     "packages/docx/src/anchor-geometry.ts#FunctionDeclaration#resolveAnchorX",
@@ -197,7 +195,6 @@
     "packages/docx/src/line-layout.ts#FunctionDeclaration#segmentEastAsiaFloorSingleLinePx",
     "packages/docx/src/line-layout.ts#FunctionDeclaration#segmentIntendedSingleLinePx",
     "packages/docx/src/line-layout.ts#FunctionDeclaration#serifTail",
-    "packages/docx/src/line-layout.ts#FunctionDeclaration#shapeRenderState",
     "packages/docx/src/line-layout.ts#FunctionDeclaration#splitByComplexScript",
     "packages/docx/src/line-layout.ts#FunctionDeclaration#splitByEastAsia",
     "packages/docx/src/line-layout.ts#FunctionDeclaration#splitDigitGroups",
@@ -258,7 +255,6 @@
     "packages/docx/src/renderer.ts#FunctionDeclaration#contextualSpacingAdjust",
     "packages/docx/src/renderer.ts#FunctionDeclaration#decodeRaster",
     "packages/docx/src/renderer.ts#FunctionDeclaration#docDefaultFontSizePt",
-    "packages/docx/src/renderer.ts#FunctionDeclaration#drawImageRunBitmap",
     "packages/docx/src/renderer.ts#FunctionDeclaration#effCellMargins",
     "packages/docx/src/renderer.ts#FunctionDeclaration#estimateTableHeight",
     "packages/docx/src/renderer.ts#FunctionDeclaration#frameAnchorLineHeightPx",
@@ -305,7 +301,6 @@
     "packages/docx/src/renderer.ts#InterfaceDeclaration#ImagePair",
     "packages/docx/src/renderer.ts#InterfaceDeclaration#ParaBorderMerge",
     "packages/docx/src/renderer.ts#InterfaceDeclaration#ParaBorderSegment",
-    "packages/docx/src/renderer.ts#InterfaceDeclaration#RenderState",
     "packages/docx/src/renderer.ts#TypeAliasDeclaration#AnchorBoxSource",
     "packages/docx/src/renderer.ts#TypeAliasDeclaration#DecodedImage",
     "packages/docx/src/renderer.ts#TypeAliasDeclaration#DocxFetchImage",


### PR DESCRIPTION
## Summary

- Replace the renderer-owned `RenderState` with layout-owned capability types for immutable measurement, anchor geometry, float registration, anchor registration, and the mutable body-acquisition cursor.
- Remove the `dryRun` drawing-mode switch and the unreachable image/chart paint branches from layout acquisition. Acquisition no longer carries DPR, colors, image resources, or track-change paint policy.
- Derive paragraph grid behavior directly from normalized section and paragraph contexts instead of converting back through the legacy docGrid adapter.
- Ratchet the DOCX boundary checker against renderer state back-edges and paint capabilities on acquisition contexts.

## Architecture

This is Series C3c for #1037. It establishes the layout-owned state/capability boundary while deliberately leaving physical module relocation to C3d, the final thin renderer adapter and transitional-baseline removal to C3e, and polygon compilation memoization to C3f.

The remaining legacy table-measurement function body is byte-pinned; this PR changes its context type only so C3d can move the implementation without mixing that move into this boundary cutover.

The published DOCX declaration surface is unchanged.

## Specification basis

- ECMA-376 §17.6.5 and §17.3.1.32: section document grid and paragraph `snapToGrid` behavior.
- ECMA-376 §20.4.2.3 and §20.4.3.x: DrawingML anchor overlap and relative-position geometry.

## Verification

- 5,612 Vitest tests passed; 26 skipped.
- 2,685 DOCX tests passed across 281 files.
- Standard workspace TypeScript typecheck passed.
- DOCX boundary checker and mutation tests passed.
- DOCX public API mutation tests passed.
- DOCX package-build ownership test passed.
- DOCX compatibility evidence and mutation tests passed.
- ast-grep lint passed with only pre-existing tripwire warnings.
- `git diff --check` passed.

Refs #1037