### PR TITLE
refactor(docx): narrow acquisition capabilities

### DIFF
--- a/packages/docx/src/body-layout-context-integration.test.ts
+++ b/packages/docx/src/body-layout-context-integration.test.ts
@@ -8,6 +8,7 @@ import {
   computeColumns,
   resolveBodyParagraphLayoutContext,
 } from './renderer.js';
+import { bodyAcquisitionInputProjections } from './parser-model.js';
 import type {
   DocParagraph,
   DocxDocumentModel,
@@ -58,7 +59,7 @@ describe('body layout context integration', () => {
     const layoutSettings = resolveDocumentLayoutSettings(document);
     const sectionLayout = resolveSectionLayoutContext(layoutSettings, document.section);
     const context = resolveBodyParagraphLayoutContext(
-      { layoutSettings, sectionLayout },
+      { layoutSettings, sectionLayout, acquisitionInputs: bodyAcquisitionInputProjections },
       paragraph(),
     );
 

--- a/packages/docx/src/column-widths.test.ts
+++ b/packages/docx/src/column-widths.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createLayoutServices, resolveColumnWidths } from './renderer.js';
 import { buildSegments, layoutLines } from './line-layout.js';
+import { bodyAcquisitionInputProjections } from './parser-model.js';
 import { canvasFontString } from '@silurus/ooxml-core';
 import type {
   DocParagraph,
@@ -18,10 +19,11 @@ type ColState = Parameters<typeof resolveColumnWidths>[2];
 // §17.18.87 then applies tblW, wBefore/wAfter and tcW preferences. A saved
 // grid is not evidence that a producer already applied those constraints.
 //
-// Empty cells carry no content, so the min-content floor is 0 and `state` is
-// never dereferenced (mirrors table-row-height.test's EMPTY_STATE).
+// Empty cells carry no content, so the min-content floor is 0. The projection
+// capability remains required because table-format facts are acquired before
+// the empty-content fast path.
 
-const EMPTY_STATE = {} as unknown as ColState;
+const EMPTY_STATE = { acquisitionInputs: bodyAcquisitionInputProjections } as unknown as ColState;
 
 function cell(colSpan: number, widthPct: number | null, widthPt: number | null = null): DocTableCell {
   return {
@@ -180,6 +182,7 @@ describe('resolveColumnWidths — a tblW=auto table sizes to tcW/content, ignori
     const t = autofit([row([textCell])], [200]);
     const state = {
       ctx, fontFamilyClasses: {}, layoutServices: services, pageWidth: 300,
+      acquisitionInputs: bodyAcquisitionInputProjections,
     } as unknown as ColState;
 
     resolveColumnWidths(t, 300, state);
@@ -242,6 +245,7 @@ describe('resolveColumnWidths — a tblW=auto table sizes to tcW/content, ignori
     const state = {
       ctx, fontFamilyClasses: {}, layoutServices: services, pageWidth: 100,
       pageH: 200, scale: 1, pageIndex: 0, totalPages: 1,
+      acquisitionInputs: bodyAcquisitionInputProjections,
     } as unknown as ColState;
 
     // min-content is [20, 10], but the first cell's no-wrap maximum is 50.
@@ -306,6 +310,7 @@ describe('resolveColumnWidths — a tblW=auto table sizes to tcW/content, ignori
     const t = autofit([row([textCell])], [200]);
     const state = {
       ctx, fontFamilyClasses: {}, layoutServices: services, pageWidth: 300,
+      acquisitionInputs: bodyAcquisitionInputProjections,
     } as unknown as ColState;
 
     const segments = buildSegments(paragraph.runs, {
@@ -355,6 +360,7 @@ describe('resolveColumnWidths — a tblW=auto table sizes to tcW/content, ignori
     const t = autofit([row([textCell])], [200]);
     const state = {
       ctx, fontFamilyClasses: {}, layoutServices: services, pageWidth: 300,
+      acquisitionInputs: bodyAcquisitionInputProjections,
     } as unknown as ColState;
 
     expect(resolveColumnWidths(t, 300, state)[0]).toBe(20);
@@ -392,6 +398,7 @@ describe('resolveColumnWidths — a tblW=auto table sizes to tcW/content, ignori
     const t = autofit([row([textCell])], [200]);
     const state = {
       ctx, fontFamilyClasses: {}, layoutServices: services, pageWidth: 300,
+      acquisitionInputs: bodyAcquisitionInputProjections,
     } as unknown as ColState;
 
     expect(resolveColumnWidths(t, 300, state)[0]).toBe(20);

--- a/packages/docx/src/layout-lines-scale-invariance.test.ts
+++ b/packages/docx/src/layout-lines-scale-invariance.test.ts
@@ -196,6 +196,17 @@ describe('layoutLines scale-invariance (Phase 4-1 B2 Stage 1) — LINEAR font, t
     )).toThrow(/vertical glyph measurement capability is required/i);
   });
 
+  it('fails closed when vertical lines are rescaled without the bound capability', () => {
+    const { ctx } = makeLinearCtx();
+    const stamp = layoutVerticalTestLines(
+      ctx,
+      [textSeg('縦書き', 10, { verticalRun: true })],
+    );
+
+    expect(() => rescaleLayoutLines(stamp, 2, ctx, {}, 0))
+      .toThrow(/vertical glyph measurement capability is required/i);
+  });
+
   it('removes horizontal kern compression only for a vertical run', () => {
     const text = '、。「」ー';
     const makeCtx = (): CanvasRenderingContext2D => ({

--- a/packages/docx/src/layout-lines-scale-invariance.test.ts
+++ b/packages/docx/src/layout-lines-scale-invariance.test.ts
@@ -9,6 +9,8 @@ import {
   type LayoutTextSeg,
   type WrapLayoutCtx,
 } from './line-layout.js';
+import { verticalRunInkExtraPx } from './vertical-text.js';
+import type { VerticalGlyphMeasurementService } from './layout/measurement-capabilities.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Phase 4-1 B2 Stage 1 — scale-invariance characterization of `layoutLines`.
@@ -33,6 +35,37 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface MeasureCall { font: string; text: string; }
+
+function layoutVerticalTestLines(
+  ctx: CanvasRenderingContext2D,
+  segments: LayoutSeg[],
+  verticalGlyphMeasurement: VerticalGlyphMeasurementService = Object.freeze({
+    fingerprint: 'vertical:test-context',
+    measureRunInkExtra: (text: string) => verticalRunInkExtraPx(ctx, text),
+  }),
+): LayoutLine[] {
+  return layoutLines(
+    ctx,
+    segments,
+    200,
+    0,
+    1,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    verticalGlyphMeasurement,
+  );
+}
 
 /** A recording 2D-context stub whose glyph advance is EXACTLY `perPx · px · n`
  *  (linear in the font px size). Font-metric ascent/descent are the fixed 0.8/0.2
@@ -151,6 +184,18 @@ function assertScaleLinear(a: LayoutLine[], b: LayoutLine[], s: number, tol = 1e
 const SCALES = [1.5, 2, 3];
 
 describe('layoutLines scale-invariance (Phase 4-1 B2 Stage 1) — LINEAR font, the algorithm is scale-clean', () => {
+  it('fails closed when vertical text has no glyph measurement capability', () => {
+    const { ctx } = makeLinearCtx();
+
+    expect(() => layoutLines(
+      ctx,
+      [textSeg('縦書き', 10, { verticalRun: true })],
+      200,
+      0,
+      1,
+    )).toThrow(/vertical glyph measurement capability is required/i);
+  });
+
   it('removes horizontal kern compression only for a vertical run', () => {
     const text = '、。「」ー';
     const makeCtx = (): CanvasRenderingContext2D => ({
@@ -168,12 +213,9 @@ describe('layoutLines scale-invariance (Phase 4-1 B2 Stage 1) — LINEAR font, t
     }) as unknown as CanvasRenderingContext2D;
 
     const horizontal = layoutLines(makeCtx(), [textSeg(text)], 200, 0, 1);
-    const vertical = layoutLines(
+    const vertical = layoutVerticalTestLines(
       makeCtx(),
       [textSeg(text, 10, { verticalRun: true })],
-      200,
-      0,
-      1,
     );
     expect(horizontal[0].segments[0].measuredWidth).toBe(40);
     expect(vertical[0].segments[0].measuredWidth).toBe(50);
@@ -202,12 +244,9 @@ describe('layoutLines scale-invariance (Phase 4-1 B2 Stage 1) — LINEAR font, t
       },
     } as unknown as CanvasRenderingContext2D;
 
-    const lines = layoutLines(
+    const lines = layoutVerticalTestLines(
       ctx,
       [textSeg(text, 10, { verticalRun: true, kerning: 1 })],
-      200,
-      0,
-      1,
     );
 
     expect(lines[0].segments[0].measuredWidth).toBe(50);
@@ -234,16 +273,18 @@ describe('layoutLines scale-invariance (Phase 4-1 B2 Stage 1) — LINEAR font, t
         } as TextMetrics;
       },
     } as unknown as CanvasRenderingContext2D;
-    const stamp = layoutLines(
+    const verticalGlyphMeasurement = Object.freeze({
+      fingerprint: 'vertical:test-context',
+      measureRunInkExtra: (value: string) => verticalRunInkExtraPx(ctx, value),
+    }) satisfies VerticalGlyphMeasurementService;
+    const stamp = layoutVerticalTestLines(
       ctx,
       [textSeg(text, 10, { verticalRun: true, kerning: 1 })],
-      200,
-      0,
-      1,
+      verticalGlyphMeasurement,
     );
     measuredStates.length = 0;
 
-    rescaleLayoutLines(stamp, 2, ctx, {}, 0);
+    rescaleLayoutLines(stamp, 2, ctx, {}, 0, false, verticalGlyphMeasurement);
 
     expect(new Set(measuredStates)).toEqual(new Set<CanvasFontKerning>(['normal']));
     expect(ctx.fontKerning).toBe('auto');

--- a/packages/docx/src/layout/acquisition-context.ts
+++ b/packages/docx/src/layout/acquisition-context.ts
@@ -9,8 +9,12 @@ import type {
   SectionLayoutContext,
   StoryContext,
 } from '../layout-context.js';
-import type { TextMeasurer } from '../paragraph-measure.js';
 import type { DocParagraph } from '../types.js';
+import type {
+  MeasurementTextContext,
+  VerticalGlyphMeasurementService,
+} from './measurement-capabilities.js';
+import type { BodyAcquisitionInputProjections } from './acquisition-input-projections.js';
 import type { CompleteTextBoxStoryAcquirer } from './paragraph.js';
 import type {
   RetainedTableAcquisition,
@@ -75,8 +79,13 @@ export interface AnchorFloatRegistrationState extends FloatRegistrationState {
  * produced from this cursor; it never reuses or mutates the cursor itself.
  */
 export interface BodyAcquisitionState extends AnchorFloatRegistrationState {
-  /** Canvas is a synchronous text-metric authority only. */
-  ctx: TextMeasurer['context'];
+  /** Synchronous text metrics with no backing-canvas or paint surface. */
+  ctx: MeasurementTextContext;
+  /** Vertical glyph metrics bound to the same concrete measurement context,
+   * without exposing its backing canvas to acquisition consumers. */
+  verticalGlyphMeasurement: VerticalGlyphMeasurementService;
+  /** Required parser-to-layout fact projections. */
+  acquisitionInputs: BodyAcquisitionInputProjections;
   /** Acquisition coordinate scale in pixels per point. */
   scale: number;
   /** Current logical text container, already in acquisition pixels. */
@@ -117,6 +126,8 @@ export interface BodyAcquisitionState extends AnchorFloatRegistrationState {
 export type BodyMeasurementContext = Readonly<Pick<
   BodyAcquisitionState,
   | 'ctx'
+  | 'verticalGlyphMeasurement'
+  | 'acquisitionInputs'
   | 'scale'
   | 'pageH'
   | 'pageWidth'

--- a/packages/docx/src/layout/acquisition-input-projections.ts
+++ b/packages/docx/src/layout/acquisition-input-projections.ts
@@ -1,0 +1,43 @@
+import type {
+  DocParagraph,
+  DocTable,
+  NumberingInfo,
+} from '../types.js';
+import type { ParagraphAcquisitionInput } from './text.js';
+import type {
+  NumberingMarkerShapeInput,
+  SourceRef,
+  TableColumnLayoutInput,
+  TableFormatInput,
+} from './types.js';
+
+/** Parser-owned fact projections needed by otherwise parser-independent body
+ * acquisition. Layout consumes this required capability record instead of
+ * importing parser-model implementation or private wire fields. */
+export interface BodyAcquisitionInputProjections {
+  readonly numberingMarkerShapeInput: (
+    numbering: NumberingInfo,
+    fallbackFontSizePt: number,
+  ) => NumberingMarkerShapeInput;
+  readonly paragraphMarkShapeInput: (
+    paragraph: DocParagraph,
+  ) => NumberingMarkerShapeInput | undefined;
+  readonly tableFormatInput: (
+    table: Readonly<DocTable>,
+  ) => TableFormatInput;
+  readonly tableColumnLayoutInput: (
+    table: Readonly<DocTable>,
+    availableWidthPt: number,
+    intrinsicWidths: (
+      cell: Readonly<DocTable['rows'][number]['cells'][number]>,
+    ) => Readonly<{ minWidthPt: number; maxWidthPt: number }>,
+    maximumWidthPt?: number,
+  ) => TableColumnLayoutInput;
+  readonly tableParticipatesInOrdinaryFlow: (
+    table: Readonly<DocTable>,
+  ) => boolean;
+  readonly paragraphAcquisitionInput: (
+    paragraph: DocParagraph,
+    source: SourceRef,
+  ) => ParagraphAcquisitionInput;
+}

--- a/packages/docx/src/layout/body-layout-kernel.test.ts
+++ b/packages/docx/src/layout/body-layout-kernel.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { LayoutServices } from './types.js';
 import type { BodyLayoutKernel } from './body-layout-kernel.js';
+import type { VerticalGlyphMeasurementService } from './measurement-capabilities.js';
 import {
   attachBodyLayoutKernel,
+  attachVerticalGlyphMeasurementService,
   bodyLayoutKernelOf,
   createFieldAcquisitionServicesView,
+  verticalGlyphMeasurementServiceOf,
 } from './runtime-state.js';
 
 const services = (): LayoutServices => Object.freeze({
@@ -46,5 +49,25 @@ describe('private body layout kernel ownership', () => {
     }))).toThrow(/missing service lineage/i);
     expect(first).not.toHaveProperty('bodyLayoutKernel');
     expect(Object.keys(first)).toEqual(['text', 'images', 'math']);
+  });
+
+  it('keeps vertical measurement on the private document owner and its views', () => {
+    const owned = services();
+    const unowned = services();
+    const vertical = Object.freeze({
+      fingerprint: 'vertical:test',
+      measureRunInkExtra: (_text: string) => 0,
+    }) satisfies VerticalGlyphMeasurementService;
+    const kernel = { openBodyLayoutSession() { throw new Error('unused'); } } as BodyLayoutKernel;
+
+    attachVerticalGlyphMeasurementService(owned, vertical);
+    attachBodyLayoutKernel(owned, kernel);
+    const fieldView = createFieldAcquisitionServicesView(owned, { totalPages: 2 });
+
+    expect(verticalGlyphMeasurementServiceOf(owned)).toBe(vertical);
+    expect(verticalGlyphMeasurementServiceOf(fieldView)).toBe(vertical);
+    expect(() => verticalGlyphMeasurementServiceOf(unowned)).toThrow(/not attached/i);
+    expect(() => attachVerticalGlyphMeasurementService(owned, vertical)).toThrow(/already attached/i);
+    expect(Object.keys(owned)).toEqual(['text', 'images', 'math']);
   });
 });

--- a/packages/docx/src/layout/intrinsic-width.ts
+++ b/packages/docx/src/layout/intrinsic-width.ts
@@ -341,6 +341,7 @@ export function measureParagraphIntrinsicWidths(
     context.stretchLastLine,
     undefined,
     'intrinsic',
+    environment.verticalGlyphMeasurement,
   );
   const oppositeIndentPt = context.baseRtl
     ? context.physicalIndentLeftPt

--- a/packages/docx/src/layout/measurement-capabilities-production.test.ts
+++ b/packages/docx/src/layout/measurement-capabilities-production.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createLayoutServices } from '../renderer.js';
+import { layoutLines, type LayoutSeg } from '../line-layout.js';
 import type { DocxDocumentModel } from '../types.js';
 import { verticalGlyphMeasurementServiceOf } from './runtime-state.js';
 
@@ -11,13 +12,21 @@ const model = {
   footnotes: [],
 } as unknown as DocxDocumentModel;
 
-function measurementContext(canvas: object): CanvasRenderingContext2D {
+interface MeasureCall { readonly font: string; readonly text: string }
+
+function measurementContext(
+  canvas: object,
+  calls: MeasureCall[] = [],
+): CanvasRenderingContext2D {
+  let font = '10px serif';
   return {
     canvas,
-    font: '10px serif',
+    get font() { return font; },
+    set font(value: string) { font = value; },
     letterSpacing: '0px',
     fontKerning: 'auto' as CanvasFontKerning,
     measureText(text: string) {
+      calls.push({ font, text });
       return {
         width: text.length * 5,
         actualBoundingBoxAscent: 8,
@@ -28,6 +37,52 @@ function measurementContext(canvas: object): CanvasRenderingContext2D {
 }
 
 describe('production measurement capability composition', () => {
+  it('binds vertical glyph probing to the context selected by the layout path', () => {
+    const calls: MeasureCall[] = [];
+    const context = measurementContext({}, calls);
+    const services = createLayoutServices(model, { measureContext: context });
+    const segment = {
+      text: '、。',
+      bold: false,
+      italic: false,
+      underline: false,
+      strikethrough: false,
+      fontSize: 23,
+      color: null,
+      fontFamily: 'serif',
+      vertAlign: null,
+      measuredWidth: 0,
+      verticalRun: true,
+    } as LayoutSeg;
+
+    layoutLines(
+      context,
+      [segment],
+      200,
+      0,
+      1,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      verticalGlyphMeasurementServiceOf(services),
+    );
+
+    const runCall = calls.find(({ text }) => text === '、。');
+    const glyphCall = calls.find(({ text }) => text === '、');
+    expect(runCall?.font).toContain('23px');
+    expect(glyphCall?.font).toBe(runCall?.font);
+  });
+
   it('fingerprints DOM vertical probing separately from worker-safe measurement', () => {
     const canvasDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'HTMLCanvasElement');
     const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');

--- a/packages/docx/src/layout/measurement-capabilities-production.test.ts
+++ b/packages/docx/src/layout/measurement-capabilities-production.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { createLayoutServices } from '../renderer.js';
+import type { DocxDocumentModel } from '../types.js';
+import { verticalGlyphMeasurementServiceOf } from './runtime-state.js';
+
+const model = {
+  section: {},
+  body: [],
+  headers: { default: null, first: null, even: null },
+  footers: { default: null, first: null, even: null },
+  footnotes: [],
+} as unknown as DocxDocumentModel;
+
+function measurementContext(canvas: object): CanvasRenderingContext2D {
+  return {
+    canvas,
+    font: '10px serif',
+    letterSpacing: '0px',
+    fontKerning: 'auto' as CanvasFontKerning,
+    measureText(text: string) {
+      return {
+        width: text.length * 5,
+        actualBoundingBoxAscent: 8,
+        actualBoundingBoxDescent: 2,
+      } as TextMetrics;
+    },
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('production measurement capability composition', () => {
+  it('fingerprints DOM vertical probing separately from worker-safe measurement', () => {
+    const canvasDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'HTMLCanvasElement');
+    const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    class TestHtmlCanvasElement {}
+
+    try {
+      Object.defineProperty(globalThis, 'HTMLCanvasElement', {
+        configurable: true,
+        value: TestHtmlCanvasElement,
+      });
+      Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        value: {},
+      });
+
+      const dom = createLayoutServices(model, {
+        measureContext: measurementContext(new TestHtmlCanvasElement()),
+      });
+      const worker = createLayoutServices(model, {
+        measureContext: measurementContext({}),
+      });
+
+      expect(verticalGlyphMeasurementServiceOf(dom).fingerprint)
+        .toBe('vertical-glyph-measurement:dom-vert-probe-v1');
+      expect(verticalGlyphMeasurementServiceOf(worker).fingerprint)
+        .toBe('vertical-glyph-measurement:no-dom-vert-probe-v1');
+      expect(dom.text.fingerprint).not.toBe(worker.text.fingerprint);
+    } finally {
+      if (canvasDescriptor) {
+        Object.defineProperty(globalThis, 'HTMLCanvasElement', canvasDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, 'HTMLCanvasElement');
+      }
+      if (documentDescriptor) {
+        Object.defineProperty(globalThis, 'document', documentDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, 'document');
+      }
+    }
+  });
+});

--- a/packages/docx/src/layout/measurement-capabilities.test.ts
+++ b/packages/docx/src/layout/measurement-capabilities.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  MeasurementTextContext,
+  VerticalGlyphMeasurementService,
+} from './measurement-capabilities.js';
+
+function assertMeasurementSurface(context: MeasurementTextContext): void {
+  context.font = context.font;
+  context.letterSpacing = context.letterSpacing;
+  context.fontKerning = context.fontKerning;
+  context.measureText('measure');
+
+  if (false) {
+    // Acquisition receives text metrics, never a recoverable canvas or painter.
+    // @ts-expect-error paint capability is outside the measurement contract
+    context.canvas;
+    // @ts-expect-error paint capability is outside the measurement contract
+    context.fillText('paint', 0, 0);
+    // @ts-expect-error paint capability is outside the measurement contract
+    context.drawImage({} as CanvasImageSource, 0, 0);
+    // @ts-expect-error mutable graphics state is outside the measurement contract
+    context.save();
+  }
+}
+
+describe('layout measurement capabilities', () => {
+  it('expose metrics and an injected vertical measurement service without paint', () => {
+    const context = {
+      font: '10px serif',
+      letterSpacing: '0px',
+      fontKerning: 'auto' as CanvasFontKerning,
+      measureText: (text: string) => ({ width: text.length * 5 }) as TextMetrics,
+    } satisfies MeasurementTextContext;
+    const vertical = {
+      fingerprint: 'vertical:test',
+      measureRunInkExtra: (_text: string) => 0,
+    } satisfies VerticalGlyphMeasurementService;
+
+    assertMeasurementSurface(context);
+    expect(context.measureText('ab').width).toBe(10);
+    expect(vertical.measureRunInkExtra('ab')).toBe(0);
+  });
+});

--- a/packages/docx/src/layout/measurement-capabilities.ts
+++ b/packages/docx/src/layout/measurement-capabilities.ts
@@ -1,0 +1,20 @@
+/** Canvas capabilities that retained layout may use synchronously.
+ *
+ * Vertical OpenType feature probing is deliberately excluded: it needs the
+ * backing DOM canvas and is injected separately as a document-scoped service.
+ */
+export interface MeasurementTextContext {
+  font: string;
+  letterSpacing: string;
+  fontKerning: CanvasFontKerning;
+  measureText(text: string): TextMetrics;
+}
+
+/** Document-scoped vertical glyph measurement bound to the same concrete
+ * context as {@link MeasurementTextContext}, without exposing its canvas or
+ * paint methods to acquisition. Calls are synchronous because the underlying
+ * OpenType feature probe mutates and restores font state in one stack frame. */
+export interface VerticalGlyphMeasurementService {
+  readonly fingerprint: string;
+  measureRunInkExtra(text: string): number;
+}

--- a/packages/docx/src/layout/runtime-state.ts
+++ b/packages/docx/src/layout/runtime-state.ts
@@ -3,6 +3,7 @@ import type { PaintResourceRegistry } from './types.js';
 import type { NumberFormat } from '@silurus/ooxml-core';
 import type { BodyLayoutKernel } from './body-layout-kernel.js';
 import type { LayoutVariantStore } from './variant-store.js';
+import type { VerticalGlyphMeasurementService } from './measurement-capabilities.js';
 
 export interface DocumentLayoutRuntimeState {
   services: LayoutServices | null;
@@ -57,6 +58,10 @@ type LayoutServicesRuntimeOwner = object;
 
 const layoutServicesRuntimeOwners = new WeakMap<object, LayoutServicesRuntimeOwner>();
 const bodyLayoutKernels = new WeakMap<LayoutServicesRuntimeOwner, BodyLayoutKernel>();
+const verticalGlyphMeasurementServices = new WeakMap<
+  LayoutServicesRuntimeOwner,
+  VerticalGlyphMeasurementService
+>();
 const layoutVariantStores = new WeakMap<LayoutServices, LayoutVariantStore>();
 
 /** Service views may replace one component, but mixing components already owned
@@ -102,6 +107,29 @@ export function attachBodyLayoutKernel(
 export function bodyLayoutKernelOf(services: LayoutServices): BodyLayoutKernel | undefined {
   const owner = layoutServicesRuntimeOwner(services, false);
   return owner ? bodyLayoutKernels.get(owner) : undefined;
+}
+
+/** Attach the synchronous vertical-glyph metric authority to the same private
+ * document owner as the public layout service components. Runtime service views
+ * therefore inherit it without widening the stable LayoutServices contract. */
+export function attachVerticalGlyphMeasurementService(
+  services: LayoutServices,
+  service: VerticalGlyphMeasurementService,
+): void {
+  const owner = layoutServicesRuntimeOwner(services, true)!;
+  if (verticalGlyphMeasurementServices.has(owner)) {
+    throw new Error('Vertical glyph measurement service is already attached');
+  }
+  verticalGlyphMeasurementServices.set(owner, service);
+}
+
+export function verticalGlyphMeasurementServiceOf(
+  services: LayoutServices,
+): VerticalGlyphMeasurementService {
+  const owner = layoutServicesRuntimeOwner(services, false);
+  const service = owner ? verticalGlyphMeasurementServices.get(owner) : undefined;
+  if (!service) throw new Error('Vertical glyph measurement service is not attached');
+  return service;
 }
 
 export function attachLayoutVariantStore(

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -61,8 +61,11 @@ import {
   cloneSegmentsForLinePass,
   convergeLineWrap,
 } from './layout/line-wrap-convergence.js';
-import { verticalRunInkExtraPx } from './vertical-text.js';
 import type { LayoutServices, NumberingMarkerShapeInput } from './layout/types.js';
+import type {
+  MeasurementTextContext,
+  VerticalGlyphMeasurementService,
+} from './layout/measurement-capabilities.js';
 import type {
   ParagraphMathRun,
   ParagraphTextBearingRun,
@@ -274,7 +277,7 @@ export function rubyAscentReservePx(
   hpsRaisePt: number | undefined,
   scale: number,
   segment?: LayoutTextSeg,
-  ctx?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  ctx?: MeasurementTextContext,
   fontFamilyClasses: Record<string, string> = {},
 ): number {
   if (hpsRaisePt != null) return hpsRaisePt * scale;
@@ -560,6 +563,7 @@ export interface LineLayoutEnvironment {
   readonly verticalCJK?: boolean;
   readonly resolvedLocalFonts?: Readonly<Record<string, ResolvedLocalFontMetric>>;
   readonly layoutServices?: LayoutServices;
+  readonly verticalGlyphMeasurement?: VerticalGlyphMeasurementService;
 }
 
 // ── Math (OMML) rendering via MathJax ───────────────────────────────────────
@@ -1300,7 +1304,7 @@ export function paragraphMarkLineMetrics(
   grid: DocGridCtx | undefined,
   paraHasRuby: boolean,
   eastAsian = false,
-  ctx?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  ctx?: MeasurementTextContext,
   fontFamilyClasses: Record<string, string> = {},
   effectiveLineSpacing: LineSpacing | null = para.lineSpacing,
   resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>> = {},
@@ -1410,7 +1414,7 @@ export function paragraphMarkLineHeight(
   grid: DocGridCtx | undefined,
   paraHasRuby: boolean,
   eastAsian = false,
-  ctx?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  ctx?: MeasurementTextContext,
   fontFamilyClasses: Record<string, string> = {},
   effectiveLineSpacing: LineSpacing | null = para.lineSpacing,
   resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>> = {},
@@ -1452,7 +1456,7 @@ export function paragraphMarkBelowBaselinePt(
   grid: DocGridCtx | undefined,
   paraHasRuby: boolean,
   eastAsian: boolean,
-  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | undefined,
+  ctx: MeasurementTextContext | undefined,
   fontFamilyClasses: Record<string, string>,
   effectiveLineSpacing: LineSpacing | null,
   resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>> = {},
@@ -1661,7 +1665,7 @@ function extendThroughTrailingIdeographicSpaces(chars: string[], split: number):
 }
 
 export function fitCJKPrefix(
-  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  ctx: MeasurementTextContext,
   text: string,
   maxWidth: number,
   // ECMA-376 §17.6.5 character-grid delta (px per EA glyph, 0 when inactive).
@@ -1680,6 +1684,7 @@ export function fitCJKPrefix(
   // fits — not one that only fits by the under-reported raw width. 0 for horizontal
   // / non-under-reporting runs, so the split is byte-identical there.
   verticalRun = false,
+  verticalGlyphMeasurement?: VerticalGlyphMeasurementService,
 ): string {
   const chars = [...text]; // spread handles surrogate pairs
   // Trailing IDEOGRAPHIC SPACE (U+3000) line-end allowance: a candidate that
@@ -1699,8 +1704,15 @@ export function fitCJKPrefix(
     while (visibleEnd > 0 && chars[visibleEnd - 1] === '\u3000') visibleEnd--;
     const prefix = chars.slice(0, visibleEnd).join('');
     if (prefix.length === 0) return true;
+    let verticalExtraPx = 0;
+    if (verticalRun) {
+      if (!verticalGlyphMeasurement) {
+        throw new Error('Vertical glyph measurement capability is required for vertical text');
+      }
+      verticalExtraPx = verticalGlyphMeasurement.measureRunInkExtra(prefix);
+    }
     const advance = textAdvanceWidth(
-      ctx.measureText(prefix).width + (verticalRun ? verticalRunInkExtraPx(ctx, prefix) : 0),
+      ctx.measureText(prefix).width + verticalExtraPx,
       prefix,
       gridDeltaPx,
       charScale,
@@ -2798,7 +2810,7 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
 }
 
 export function layoutLines(
-  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  ctx: MeasurementTextContext,
   segs: LayoutSeg[],
   maxWidth: number,
   firstIndent: number,
@@ -2816,9 +2828,10 @@ export function layoutLines(
   stretchLastLine?: boolean,
   startBoundary?: LineBoundary,
   widthPolicy?: 'bounded' | 'intrinsic',
+  verticalGlyphMeasurement?: VerticalGlyphMeasurementService,
 ): LayoutLine[];
 export function layoutLines(
-  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  ctx: MeasurementTextContext,
   segs: LayoutSeg[],
   maxWidth: number,
   firstIndent: number,
@@ -2862,6 +2875,7 @@ export function layoutLines(
   stretchLastLine = false,
   startBoundary?: LineBoundary,
   widthPolicy: 'bounded' | 'intrinsic' = 'bounded',
+  verticalGlyphMeasurement?: VerticalGlyphMeasurementService,
   passContext?: Readonly<{
     probeHeights: readonly number[] | null;
     preparedFloatWrap?: PreparedFloatWrap;
@@ -2896,6 +2910,7 @@ export function layoutLines(
       stretchLastLine,
       startBoundary,
       widthPolicy,
+      verticalGlyphMeasurement,
       { probeHeights, preparedFloatWrap },
     );
     if (!wrapCtx || widthPolicy === 'intrinsic') return runPass(null);
@@ -3318,13 +3333,16 @@ export function layoutLines(
   // select it via measureText / setMeasureFont immediately before).
   const verticalInkExtra = (s: LayoutTextSeg, text: string): number => {
     if (!s.verticalRun) return 0;
+    if (!verticalGlyphMeasurement) {
+      throw new Error('Vertical glyph measurement capability is required for vertical text');
+    }
     // The format-neutral text service may measure on a different adapter and
     // restores its Canvas state. The vertical-feature probe is intentionally
     // paint-context-local, so select the same resolved face explicitly here.
     setMeasureFont(buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses, s.fontRoute));
     const prevKern = setSegKerning(s);
     try {
-      return verticalRunInkExtraPx(ctx, text);
+      return verticalGlyphMeasurement.measureRunInkExtra(text);
     } finally {
       restoreKerning(prevKern);
     }
@@ -3984,7 +4002,7 @@ export function layoutLines(
       const prevKern = setSegKerning(s);
       let rawPrefix = '';
       try {
-        rawPrefix = available > 0 ? fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), charScaleFactor(s), charSpacingDeltaPx(s, scale), s.verticalRun === true) : '';
+        rawPrefix = available > 0 ? fitCJKPrefix(ctx, s.text, available, segmentCharacterGridDeltaPx(s, gridDeltaPx), charScaleFactor(s), charSpacingDeltaPx(s, scale), s.verticalRun === true, verticalGlyphMeasurement) : '';
       } finally {
         restoreKerning(prevKern);
       }
@@ -4208,6 +4226,7 @@ export function layoutLines(
               charScaleFactor(s),
               charSpacingDeltaPx(s, scale),
               s.verticalRun === true,
+              verticalGlyphMeasurement,
             ).length
           : 0;
       } finally {
@@ -4323,10 +4342,11 @@ export function layoutLines(
 export function rescaleLayoutLines(
   lines: LayoutLine[],
   scale: number,
-  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  ctx: MeasurementTextContext,
   fontFamilyClasses: Record<string, string>,
   gridDeltaPx: number,
   canonicalGeometry = false,
+  verticalGlyphMeasurement?: VerticalGlyphMeasurementService,
 ): LayoutLine[] {
   if (scale === 1) return lines;
 
@@ -4408,11 +4428,17 @@ export function rescaleLayoutLines(
 
   const verticalInkExtra = (s: LayoutTextSeg, text: string, fontPx: number): number => {
     if (!s.verticalRun) return 0;
+    if (!verticalGlyphMeasurement) {
+      throw new Error('Vertical glyph measurement capability is required for vertical text');
+    }
     // Vertical feature capability belongs to the paint context, not the
     // format-neutral text service. Select the exact resolved paint face before
     // applying this narrow glyph-cell correction.
     ctx.font = buildFont(s.bold, s.italic, fontPx, s.fontFamily, fontFamilyClasses, s.fontRoute);
-    return withSegKerning(s, () => verticalRunInkExtraPx(ctx, text));
+    return withSegKerning(
+      s,
+      () => verticalGlyphMeasurement.measureRunInkExtra(text),
+    );
   };
 
   // Per-text-segment measurement at the PAINT scale — the SAME model layoutLines

--- a/packages/docx/src/paragraph-measure.ts
+++ b/packages/docx/src/paragraph-measure.ts
@@ -18,6 +18,7 @@ import type { DocParagraph } from './types.js';
 import type { WrapOracle } from './layout/float-wrap-oracle.js';
 import type { NumberingMarkerShapeInput } from './layout/types.js';
 import { wordEmptyMarkMinimumStartWidthPx } from './layout/compatibility.js';
+import type { MeasurementTextContext } from './layout/measurement-capabilities.js';
 
 export type { LineLayoutEnvironment } from './line-layout.js';
 export { createFloatWrapOracle } from './layout/float-wrap-oracle.js';
@@ -29,9 +30,7 @@ export interface ParagraphMeasurementEnvironment extends LineLayoutEnvironment {
 }
 
 export interface TextMeasurer {
-  readonly context:
-    | CanvasRenderingContext2D
-    | OffscreenCanvasRenderingContext2D;
+  readonly context: MeasurementTextContext;
   readonly fontFamilyClasses: Readonly<Record<string, string>>;
 }
 
@@ -240,6 +239,8 @@ export function measureParagraph(
     context.isJustified,
     context.stretchLastLine,
     continuation?.boundary,
+    undefined,
+    environment.verticalGlyphMeasurement,
   );
   if (lines.length === 0) return measureMarkOnly();
 

--- a/packages/docx/src/parser-model-acquisition-projections.test.ts
+++ b/packages/docx/src/parser-model-acquisition-projections.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bodyAcquisitionInputProjections,
+  numberingMarkerShapeInput,
+  paragraphAcquisitionInput,
+  paragraphMarkShapeInput,
+  tableColumnLayoutInput,
+  tableFormatInput,
+  tableParticipatesInOrdinaryFlow,
+} from './parser-model.js';
+
+describe('parser-to-body-acquisition projection capability', () => {
+  it('is one frozen identity-preserving record without compatibility wrappers', () => {
+    expect(Object.isFrozen(bodyAcquisitionInputProjections)).toBe(true);
+    expect(Object.keys(bodyAcquisitionInputProjections).sort()).toEqual([
+      'numberingMarkerShapeInput',
+      'paragraphAcquisitionInput',
+      'paragraphMarkShapeInput',
+      'tableColumnLayoutInput',
+      'tableFormatInput',
+      'tableParticipatesInOrdinaryFlow',
+    ]);
+    expect(bodyAcquisitionInputProjections.numberingMarkerShapeInput)
+      .toBe(numberingMarkerShapeInput);
+    expect(bodyAcquisitionInputProjections.paragraphAcquisitionInput)
+      .toBe(paragraphAcquisitionInput);
+    expect(bodyAcquisitionInputProjections.paragraphMarkShapeInput)
+      .toBe(paragraphMarkShapeInput);
+    expect(bodyAcquisitionInputProjections.tableColumnLayoutInput)
+      .toBe(tableColumnLayoutInput);
+    expect(bodyAcquisitionInputProjections.tableFormatInput).toBe(tableFormatInput);
+    expect(bodyAcquisitionInputProjections.tableParticipatesInOrdinaryFlow)
+      .toBe(tableParticipatesInOrdinaryFlow);
+  });
+});

--- a/packages/docx/src/parser-model.ts
+++ b/packages/docx/src/parser-model.ts
@@ -62,6 +62,7 @@ import type {
   BodyLayoutAcquisitionInput,
   BodyLayoutSequenceEntryFor,
 } from './layout/body-layout-input.js';
+import type { BodyAcquisitionInputProjections } from './layout/acquisition-input-projections.js';
 import { isInklessParagraph } from './layout/paragraph-visibility.js';
 import {
   wordTableCellSpacingValuePt,
@@ -1794,3 +1795,15 @@ export function internalParagraph(paragraph: DocParagraph): InternalDocParagraph
 export function internalDocumentModel(doc: DocxDocumentModel): InternalDocxDocumentModel {
   return doc as InternalDocxDocumentModel;
 }
+
+/** One explicit parser-owned projection record composed by the renderer and
+ * consumed by parser-independent retained acquisition. Function identities are
+ * preserved: this record introduces no compatibility wrappers. */
+export const bodyAcquisitionInputProjections = Object.freeze({
+  numberingMarkerShapeInput,
+  paragraphMarkShapeInput,
+  tableFormatInput,
+  tableColumnLayoutInput,
+  tableParticipatesInOrdinaryFlow,
+  paragraphAcquisitionInput,
+}) satisfies BodyAcquisitionInputProjections;

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -447,7 +447,10 @@ export function createLayoutServices(
         ? 'vertical-glyph-measurement:dom-vert-probe-v1'
         : 'vertical-glyph-measurement:no-dom-vert-probe-v1',
     measureRunInkExtra(text: string): number {
-      return canvasContext === null ? 0 : verticalRunInkExtraPx(canvasContext, text);
+      if (canvasContext === null) {
+        throw new Error('Vertical glyph measurement requires a concrete text context');
+      }
+      return verticalRunInkExtraPx(canvasContext, text);
     },
   });
   const routedFontFamilies = [...new Set([

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -142,11 +142,13 @@ import {
   attachBodyLayoutKernel,
   attachPrivateResourceLookup,
   attachPaintResourceRegistry,
+  attachVerticalGlyphMeasurementService,
   createLayoutServicesRuntimeView,
   fieldAcquisitionContextOf,
   layoutVariantStoreOf,
   paintResourceRegistryOf,
   privateResourceLookupOf,
+  verticalGlyphMeasurementServiceOf,
 } from './layout/runtime-state.js';
 import {
   attachStoryBlockLayoutAlgorithms,
@@ -184,12 +186,11 @@ import {
 import { DOCX_GOOGLE_FONTS, docxFontPreloadNames } from './google-fonts.js';
 import {
   effectiveTablePositioning,
+  bodyAcquisitionInputProjections,
   internalDocumentModel,
   numberingMarkerShapeInput,
   paragraphAcquisitionInput,
-  paragraphMarkShapeInput,
   publicAnchorBridge,
-  tableParticipatesInOrdinaryFlow,
 } from './parser-model.js';
 import {
   normalizeInternalDocumentModel,
@@ -205,7 +206,7 @@ import {
   applyNumberingBodyOffset,
   resolveNumberingMarkerGeometry,
 } from './layout/numbering-marker.js';
-import { tableColumnLayoutInput, tableFormatInput } from './parser-model.js';
+import { tableFormatInput } from './parser-model.js';
 import { resolveTableColumnWidths } from './layout/table-columns.js';
 import {
   measureParagraphIntrinsicWidths,
@@ -293,7 +294,12 @@ import { resolveAnchorFrame } from './layout/anchor-frame.js';
 import {
   drawTateChuYokoRun,
   physicalToLogicalAnchorBox,
+  verticalRunInkExtraPx,
 } from './vertical-text.js';
+import type {
+  MeasurementTextContext,
+  VerticalGlyphMeasurementService,
+} from './layout/measurement-capabilities.js';
 import { textRunsForPage } from './text-run-projection.js';
 
 function kashidaLevelOf(alignment: string | null | undefined): KashidaLevel | null {
@@ -414,11 +420,36 @@ export function createLayoutServices(
       }
     }
   }
-  const ctx = options.measureContext ?? (typeof OffscreenCanvas !== 'undefined'
+  const canvasContext = options.measureContext ?? (typeof OffscreenCanvas !== 'undefined'
     ? new OffscreenCanvas(1, 1).getContext('2d')
     : typeof document !== 'undefined'
       ? document.createElement('canvas').getContext('2d')
       : null);
+  const ctx: MeasurementTextContext | null = canvasContext === null
+    ? null
+    : Object.freeze({
+        get font() { return canvasContext.font; },
+        set font(value: string) { canvasContext.font = value; },
+        get letterSpacing() { return canvasContext.letterSpacing; },
+        set letterSpacing(value: string) { canvasContext.letterSpacing = value; },
+        get fontKerning() { return canvasContext.fontKerning; },
+        set fontKerning(value: CanvasFontKerning) { canvasContext.fontKerning = value; },
+        measureText(text: string) { return canvasContext.measureText(text); },
+      });
+  const hasDomVertProbe = canvasContext !== null
+    && typeof HTMLCanvasElement !== 'undefined'
+    && canvasContext.canvas instanceof HTMLCanvasElement
+    && typeof document !== 'undefined';
+  const verticalGlyphMeasurement: VerticalGlyphMeasurementService = Object.freeze({
+    fingerprint: canvasContext === null
+      ? 'vertical-glyph-measurement:deterministic-v1'
+      : hasDomVertProbe
+        ? 'vertical-glyph-measurement:dom-vert-probe-v1'
+        : 'vertical-glyph-measurement:no-dom-vert-probe-v1',
+    measureRunInkExtra(text: string): number {
+      return canvasContext === null ? 0 : verticalRunInkExtraPx(canvasContext, text);
+    },
+  });
   const routedFontFamilies = [...new Set([
     ...Object.keys(doc.fontFamilyClasses ?? {}),
     ...Object.keys(doc.fontFamilyPitches ?? {}),
@@ -448,21 +479,21 @@ export function createLayoutServices(
       ]),
     ),
     measurer: {
-      fingerprint: ctx ? 'canvas-text-metrics-v1' : 'deterministic-text-metrics-v1',
+      fingerprint: `${canvasContext ? 'canvas-text-metrics-v1' : 'deterministic-text-metrics-v1'}:${verticalGlyphMeasurement.fingerprint}`,
       measure(request: Readonly<GlyphMeasureRequest>) {
-        if (!ctx) return {
+        if (!canvasContext) return {
           advancePt: [...request.text].length * request.fontSizePt * 0.5,
           ascentPt: request.fontSizePt * 0.8,
           descentPt: request.fontSizePt * 0.2,
         };
-        const previousFont = ctx.font;
-        const previousLetterSpacing = ctx.letterSpacing;
-        const previousKerning = ctx.fontKerning;
+        const previousFont = canvasContext.font;
+        const previousLetterSpacing = canvasContext.letterSpacing;
+        const previousKerning = canvasContext.fontKerning;
         try {
-          ctx.font = canvasFontString(request.fontRoute, request.fontSizePt, request.weight, request.style);
-          ctx.letterSpacing = `${request.letterSpacingPt}px`;
-          if (request.kerning != null) ctx.fontKerning = request.kerning ? 'normal' : 'none';
-          const metrics = ctx.measureText(request.text);
+          canvasContext.font = canvasFontString(request.fontRoute, request.fontSizePt, request.weight, request.style);
+          canvasContext.letterSpacing = `${request.letterSpacingPt}px`;
+          if (request.kerning != null) canvasContext.fontKerning = request.kerning ? 'normal' : 'none';
+          const metrics = canvasContext.measureText(request.text);
           const inkBounds = {
             xMinPt: Number.isFinite(metrics.actualBoundingBoxLeft)
               ? -metrics.actualBoundingBoxLeft : 0,
@@ -479,9 +510,9 @@ export function createLayoutServices(
             ...(hasFiniteInkBounds ? { inkBounds } : {}),
           };
         } finally {
-          ctx.font = previousFont;
-          ctx.letterSpacing = previousLetterSpacing;
-          if (request.kerning != null) ctx.fontKerning = previousKerning;
+          canvasContext.font = previousFont;
+          canvasContext.letterSpacing = previousLetterSpacing;
+          if (request.kerning != null) canvasContext.fontKerning = previousKerning;
         }
       },
     },
@@ -532,6 +563,7 @@ export function createLayoutServices(
     availableMathKeys,
   );
   attachPaintResourceRegistry(services, createDocumentPaintResourceRegistry(doc, imageMetadata));
+  attachVerticalGlyphMeasurementService(services, verticalGlyphMeasurement);
   attachBodyLayoutKernel(services, createConcreteBodyLayoutKernel(doc, ctx, localMetrics));
   return services;
 }
@@ -602,7 +634,7 @@ const BODY_STORY_CONTEXT: StoryContext = {
 };
 
 export function resolveBodyParagraphLayoutContext(
-  state: Pick<BodyAcquisitionState, 'layoutSettings' | 'sectionLayout'>
+  state: Pick<BodyAcquisitionState, 'layoutSettings' | 'sectionLayout' | 'acquisitionInputs'>
     & Partial<Pick<BodyAcquisitionState, 'layoutServices' | 'defaultTabPt'>>,
   paragraph: DocParagraph,
 ): ParagraphLayoutContext {
@@ -615,7 +647,10 @@ export function resolveBodyParagraphLayoutContext(
   return applyNumberingBodyOffset(context, {
     numbering: paragraph.numbering,
     ...(paragraph.numbering ? {
-      markerInput: numberingMarkerShapeInput(paragraph.numbering, getDefaultFontSize(paragraph)),
+      markerInput: state.acquisitionInputs.numberingMarkerShapeInput(
+        paragraph.numbering,
+        getDefaultFontSize(paragraph),
+      ),
     } : {}),
     authoredFirstIndentPt: paragraph.indentFirst,
     tabStops: paragraph.tabStops,
@@ -625,7 +660,10 @@ export function resolveBodyParagraphLayoutContext(
 }
 
 function resolveStateParagraphLayoutContext(
-  state: Pick<BodyAcquisitionState, 'layoutSettings' | 'sectionLayout' | 'storyContext'>
+  state: Pick<
+    BodyAcquisitionState,
+    'layoutSettings' | 'sectionLayout' | 'storyContext' | 'acquisitionInputs'
+  >
     & Partial<Pick<BodyAcquisitionState, 'layoutServices' | 'defaultTabPt'>>,
   paragraph: DocParagraph,
 ): ParagraphLayoutContext {
@@ -638,7 +676,10 @@ function resolveStateParagraphLayoutContext(
   return applyNumberingBodyOffset(context, {
     numbering: paragraph.numbering,
     ...(paragraph.numbering ? {
-      markerInput: numberingMarkerShapeInput(paragraph.numbering, getDefaultFontSize(paragraph)),
+      markerInput: state.acquisitionInputs.numberingMarkerShapeInput(
+        paragraph.numbering,
+        getDefaultFontSize(paragraph),
+      ),
     } : {}),
     authoredFirstIndentPt: paragraph.indentFirst,
     tabStops: paragraph.tabStops,
@@ -1550,33 +1591,23 @@ export function layoutDocument(
 }
 
 function buildMeasureState(
-  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  ctx: MeasurementTextContext,
   section: SectionProps,
   fontFamilyClasses: Record<string, string> = {},
   layoutSettings: DocumentLayoutSettings,
   resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>> = {},
-  layoutServices?: LayoutServices,
+  layoutServices: LayoutServices,
   layoutOptions?: LayoutOptions,
 ): BodyAcquisitionState {
   const sectionLayout = resolveSectionLayoutContext(layoutSettings, section);
-  // Story acquisition may omit services. Acquisition itself no longer
-  // has an optional text authority: construct the same A2 service at this stable
-  // state boundary so every downstream buildSegments/layoutLines call records
-  // authoritative grapheme geometry. Production document entry points already
-  // pass their document-scoped service and therefore keep their exact font
-  // inventory/resource session.
-  const effectiveLayoutServices = layoutServices ?? createLayoutServices({
-    section,
-    body: [],
-    headers: EMPTY_HEADERS_FOOTERS,
-    footers: EMPTY_HEADERS_FOOTERS,
-    fontFamilyClasses,
-  }, {
-    measureContext: ctx,
-    localMetrics: resolvedLocalFonts,
-  });
+  // Acquisition always uses the document-scoped service owner supplied by the
+  // private body kernel, so its text and vertical measurement capabilities have
+  // one auditable lineage and fingerprint.
+  const effectiveLayoutServices = layoutServices;
   return {
     ctx,
+    verticalGlyphMeasurement: verticalGlyphMeasurementServiceOf(effectiveLayoutServices),
+    acquisitionInputs: bodyAcquisitionInputProjections,
     scale: 1,
     // Mirror the PAINT pass seed (renderDocumentToCanvas: `contentX =
     // sec.marginLeft × scale`; scale is 1 here). contentX/contentW carry the
@@ -1615,7 +1646,7 @@ function buildMeasureState(
     layoutServices: effectiveLayoutServices,
     retainedTableAcquisition: {
       layoutServices: (state) => state.layoutServices,
-      tableFormat: tableFormatInput,
+      tableFormat: bodyAcquisitionInputProjections.tableFormatInput,
       resolveColumns: resolveColumnWidths,
       createCellState: (state, contentWidthPt, cell) => ({
         ...withTableCellStory(state),
@@ -1657,7 +1688,7 @@ function buildMeasureState(
         const context = resolveStateParagraphLayoutContext(cellState, paragraph);
         const layout = acquireRegisteredParagraph(
           cellState,
-          paragraphAcquisitionInput(paragraph, source),
+          cellState.acquisitionInputs.paragraphAcquisitionInput(paragraph, source),
           {
             id: `${source.story}:${source.storyInstance}:${source.path.join('.')}`,
             source,
@@ -1822,7 +1853,7 @@ function buildMeasureState(
 
 function createConcreteBodyLayoutKernel(
   doc: DocxDocumentModel,
-  measureContext: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null,
+  measureContext: MeasurementTextContext | null,
   resolvedLocalFonts: Readonly<Record<string, ResolvedLocalFontMetric>>,
 ): BodyLayoutKernel {
   const ordinaryAcquisitionInputForAdjacentGroup = (
@@ -3657,6 +3688,7 @@ function paragraphMeasurementEnvironment(
     documentHasEastAsianText: state.docEastAsian,
     resolvedLocalFonts: state.resolvedLocalFonts,
     layoutServices: state.layoutServices,
+    verticalGlyphMeasurement: state.verticalGlyphMeasurement,
   };
 }
 
@@ -3799,13 +3831,13 @@ export function resolveColumnWidths(
   contentWPt: number,
   state: BodyMeasurementContext,
 ): number[] {
-  const format = tableFormatInput(table);
+  const format = state.acquisitionInputs.tableFormatInput(table);
   const marginsByCell = new WeakMap<object, Readonly<{ left: number; right: number }>>();
   table.rows.forEach((row, rowIndex) => row.cells.forEach((cell, cellIndex) => {
     const acquired = format.rows[rowIndex]?.cells[cellIndex]?.marginsPt;
     marginsByCell.set(cell, acquired ?? effCellMargins(cell, table));
   }));
-  return [...resolveTableColumnWidths(tableColumnLayoutInput(
+  return [...resolveTableColumnWidths(state.acquisitionInputs.tableColumnLayoutInput(
     table,
     contentWPt,
     (cell) => {
@@ -3845,7 +3877,10 @@ export function resolveColumnWidths(
                 defaultTabPt: state.defaultTabPt ?? DEFAULT_TAB_PT,
               };
           const markerInput = paragraph.numbering
-            ? numberingMarkerShapeInput(paragraph.numbering, getDefaultFontSize(paragraph))
+            ? state.acquisitionInputs.numberingMarkerShapeInput(
+                paragraph.numbering,
+                getDefaultFontSize(paragraph),
+              )
             : undefined;
           const context = applyNumberingBodyOffset(baseContext, {
             numbering: paragraph.numbering,
@@ -3881,7 +3916,7 @@ export function resolveColumnWidths(
         },
       });
     },
-    tableParticipatesInOrdinaryFlow(table)
+    state.acquisitionInputs.tableParticipatesInOrdinaryFlow(table)
       ? contentWPt
       : Math.max(contentWPt, state.pageWidth),
   ))];
@@ -4007,7 +4042,7 @@ function frameAnchorLineHeightPx(
       p.lineSpacing,
       state.resolvedLocalFonts,
       state.layoutServices?.text,
-      paragraphMarkShapeInput(p),
+      state.acquisitionInputs.paragraphMarkShapeInput(p),
     );
   }
   const fp = frameEl as unknown as DocParagraph;
@@ -4022,7 +4057,7 @@ function frameAnchorLineHeightPx(
     fp.lineSpacing,
     state.resolvedLocalFonts,
     state.layoutServices?.text,
-    paragraphMarkShapeInput(fp),
+    state.acquisitionInputs.paragraphMarkShapeInput(fp),
   );
 }
 
@@ -4051,7 +4086,7 @@ function resolveFrameBox(
       contexts: group.members.map((paragraph) =>
         resolveBodyParagraphLayoutContext(state, paragraph)),
       inputs: group.members.map((paragraph, index) =>
-        paragraphAcquisitionInput(paragraph, {
+        state.acquisitionInputs.paragraphAcquisitionInput(paragraph, {
           story: 'body', storyInstance: 'body', path: [group.sourceIndices[index]!],
         })),
       borderEdges,
@@ -4145,6 +4180,9 @@ function resolveFrameBox(
     paragraphContext.baseRtl,
     paragraphContext.isJustified,
     paragraphContext.stretchLastLine,
+    undefined,
+    undefined,
+    state.verticalGlyphMeasurement,
   );
   const contentW = lines.length === 0 ? 0 : Math.max(...lines.map((line) =>
     line.segments.reduce((sum, segment) => sum + segment.measuredWidth, 0)));
@@ -4817,7 +4855,7 @@ function measureCellParagraphWindow(
           paragraphContext.lineSpacing,
           state.resolvedLocalFonts,
           state.layoutServices?.text,
-          paragraphMarkShapeInput(para),
+          state.acquisitionInputs.paragraphMarkShapeInput(para),
         ),
         totalLines,
       };
@@ -4843,6 +4881,7 @@ function measureCellParagraphWindow(
       state.fontFamilyClasses,
       gridCharDeltaPx(grid, scale),
       canonicalTextScale,
+      state.verticalGlyphMeasurement,
     );
     const uniformLineH = paraHasRuby
       ? snapParaLineToGrid(

--- a/packages/docx/src/table-intrinsic-widths.test.ts
+++ b/packages/docx/src/table-intrinsic-widths.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_KINSOKU_RULES } from '@silurus/ooxml-core';
 import { layoutDocument } from './document-layout.js';
 import { createLayoutServices, resolveColumnWidths } from './renderer.js';
 import { measureParagraphIntrinsicWidths } from './layout/intrinsic-width.js';
+import { bodyAcquisitionInputProjections } from './parser-model.js';
 import type { ParagraphLayoutContext } from './layout-context.js';
 import type { TextLayoutService } from './layout/text.js';
 import type {
@@ -124,6 +125,7 @@ function columnState(
     ctx, fontFamilyClasses: {}, layoutServices: services,
     pageWidth: 200, pageH: 300, scale: 1, pageIndex: 0, totalPages: 1,
     defaultTabPt: 36,
+    acquisitionInputs: bodyAcquisitionInputProjections,
   } as unknown as ColumnState;
 }
 

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -200,6 +200,31 @@ const ACQUISITION_INPUT_PROJECTION_DECLARATIONS = new Set([
   'BodyAcquisitionInputProjections',
 ]);
 
+const EXACT_ACQUISITION_SURFACE_MEMBERS = new Map([
+  [ACQUISITION_INPUT_PROJECTIONS, new Map([
+    ['BodyAcquisitionInputProjections', new Set([
+      'numberingMarkerShapeInput',
+      'paragraphMarkShapeInput',
+      'tableFormatInput',
+      'tableColumnLayoutInput',
+      'tableParticipatesInOrdinaryFlow',
+      'paragraphAcquisitionInput',
+    ])],
+  ])],
+  [MEASUREMENT_CAPABILITIES, new Map([
+    ['MeasurementTextContext', new Set([
+      'font',
+      'letterSpacing',
+      'fontKerning',
+      'measureText',
+    ])],
+    ['VerticalGlyphMeasurementService', new Set([
+      'fingerprint',
+      'measureRunInkExtra',
+    ])],
+  ])],
+]);
+
 const ACQUISITION_CONTEXT_CONSUMERS = [
   `${DOCX_SOURCE}/anchor-geometry.ts`,
   `${DOCX_SOURCE}/float-table-geometry.ts`,
@@ -282,6 +307,39 @@ function assertAcquisitionContextBoundary(root) {
         if (name && ACQUISITION_PAINT_PROPERTIES.has(name)) {
           fail('ACQUISITION_PAINT_CAPABILITY', `${file}#${name}`);
         }
+      }
+    }
+    const exactInterfaces = EXACT_ACQUISITION_SURFACE_MEMBERS.get(file);
+    if (!exactInterfaces) continue;
+    const unexpectedDeclarations = [...declarations]
+      .filter((name) => !requiredDeclarations.has(name));
+    if (unexpectedDeclarations.length > 0) {
+      fail(
+        'ACQUISITION_CONTEXT_SURFACE',
+        `${file} extra declarations ${unexpectedDeclarations.sort().join(',')}`,
+      );
+    }
+    for (const [interfaceName, expectedMembers] of exactInterfaces) {
+      const declaration = source.statements.find((statement) => (
+        ts.isInterfaceDeclaration(statement) && statement.name.text === interfaceName
+      ));
+      if (!declaration || declaration.heritageClauses?.length) {
+        fail('ACQUISITION_CONTEXT_SURFACE', `${file}#${interfaceName} heritage`);
+      }
+      const memberNames = declaration.members.map((member) => (
+        member.name && (ts.isIdentifier(member.name) || ts.isStringLiteralLike(member.name))
+          ? member.name.text
+          : null
+      ));
+      const actualMembers = new Set(memberNames.filter((name) => name !== null));
+      const exact = memberNames.length === expectedMembers.size
+        && actualMembers.size === expectedMembers.size
+        && [...expectedMembers].every((name) => actualMembers.has(name));
+      if (!exact) {
+        fail(
+          'ACQUISITION_CONTEXT_SURFACE',
+          `${file}#${interfaceName} members ${[...actualMembers].sort().join(',')}`,
+        );
       }
     }
   }

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -20,6 +20,8 @@ const PARAGRAPH_ANCHOR_FRAME_ADAPTER = `${DOCX_SOURCE}/paragraph-anchor-frame-ad
 const WORKER_LAYOUT_RETENTION = `${DOCX_SOURCE}/render-worker-layout.ts`;
 const TEXT_RUN_PROJECTION_ADAPTER = `${DOCX_SOURCE}/text-run-projection.ts`;
 const ACQUISITION_CONTEXT = `${LAYOUT_SOURCE}/acquisition-context.ts`;
+const ACQUISITION_INPUT_PROJECTIONS = `${LAYOUT_SOURCE}/acquisition-input-projections.ts`;
+const MEASUREMENT_CAPABILITIES = `${LAYOUT_SOURCE}/measurement-capabilities.ts`;
 const LAYOUT_PARSER_MODEL_GATEWAY = `${LAYOUT_SOURCE}/resources.ts`;
 const LAYOUT_AFFINE = `${LAYOUT_SOURCE}/affine.ts`;
 const LAYOUT_PARSER_MODEL_GATEWAY_IMPORT = '../parser-model.js';
@@ -189,6 +191,15 @@ const ACQUISITION_CONTEXT_DECLARATIONS = new Set([
   'RetainedTableRecord',
 ]);
 
+const MEASUREMENT_CAPABILITY_DECLARATIONS = new Set([
+  'MeasurementTextContext',
+  'VerticalGlyphMeasurementService',
+]);
+
+const ACQUISITION_INPUT_PROJECTION_DECLARATIONS = new Set([
+  'BodyAcquisitionInputProjections',
+]);
+
 const ACQUISITION_CONTEXT_CONSUMERS = [
   `${DOCX_SOURCE}/anchor-geometry.ts`,
   `${DOCX_SOURCE}/float-table-geometry.ts`,
@@ -198,10 +209,15 @@ const ACQUISITION_CONTEXT_CONSUMERS = [
 ];
 
 const ACQUISITION_PAINT_PROPERTIES = new Set([
+  'canvas',
   'defaultColor',
   'dpr',
+  'drawImage',
   'dryRun',
+  'fillText',
   'images',
+  'restore',
+  'save',
   'showTrackChanges',
 ]);
 
@@ -237,30 +253,44 @@ function assertNoProductionTestSupportImports(root) {
 }
 
 function assertAcquisitionContextBoundary(root) {
-  const contextPath = resolve(root, ACQUISITION_CONTEXT);
-  if (!existsSync(contextPath)) {
-    fail('ACQUISITION_CONTEXT_SURFACE', `${ACQUISITION_CONTEXT} missing`);
-  }
-  const source = sourceFile(contextPath);
-  const declarations = new Set(source.statements.flatMap(declarationNames));
-  for (const name of ACQUISITION_CONTEXT_DECLARATIONS) {
-    if (!declarations.has(name)) {
-      fail('ACQUISITION_CONTEXT_SURFACE', `${ACQUISITION_CONTEXT} missing ${name}`);
+  const surfaces = new Map([
+    [ACQUISITION_CONTEXT, ACQUISITION_CONTEXT_DECLARATIONS],
+    [ACQUISITION_INPUT_PROJECTIONS, ACQUISITION_INPUT_PROJECTION_DECLARATIONS],
+    [MEASUREMENT_CAPABILITIES, MEASUREMENT_CAPABILITY_DECLARATIONS],
+  ]);
+  for (const [file, requiredDeclarations] of surfaces) {
+    const path = resolve(root, file);
+    if (!existsSync(path)) {
+      fail('ACQUISITION_CONTEXT_SURFACE', `${file} missing`);
     }
-  }
-  for (const statement of source.statements) {
-    if (!ts.isInterfaceDeclaration(statement)) continue;
-    for (const member of statement.members) {
-      if (!ts.isPropertySignature(member) || !member.name) continue;
-      const name = ts.isIdentifier(member.name) || ts.isStringLiteralLike(member.name)
-        ? member.name.text
-        : null;
-      if (name && ACQUISITION_PAINT_PROPERTIES.has(name)) {
-        fail('ACQUISITION_PAINT_CAPABILITY', `${ACQUISITION_CONTEXT}#${name}`);
+    const source = sourceFile(path);
+    const declarations = new Set(source.statements.flatMap(declarationNames));
+    for (const name of requiredDeclarations) {
+      if (!declarations.has(name)) {
+        fail('ACQUISITION_CONTEXT_SURFACE', `${file} missing ${name}`);
+      }
+    }
+    for (const statement of source.statements) {
+      if (!ts.isInterfaceDeclaration(statement)) continue;
+      for (const member of statement.members) {
+        if ((!ts.isPropertySignature(member) && !ts.isMethodSignature(member)) || !member.name) {
+          continue;
+        }
+        const name = ts.isIdentifier(member.name) || ts.isStringLiteralLike(member.name)
+          ? member.name.text
+          : null;
+        if (name && ACQUISITION_PAINT_PROPERTIES.has(name)) {
+          fail('ACQUISITION_PAINT_CAPABILITY', `${file}#${name}`);
+        }
       }
     }
   }
-  const inspected = [ACQUISITION_CONTEXT, ...ACQUISITION_CONTEXT_CONSUMERS];
+  const inspected = [
+    ACQUISITION_CONTEXT,
+    ACQUISITION_INPUT_PROJECTIONS,
+    MEASUREMENT_CAPABILITIES,
+    ...ACQUISITION_CONTEXT_CONSUMERS,
+  ];
   for (const file of inspected) {
     const path = resolve(root, file);
     if (!existsSync(path)) continue;

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -85,6 +85,11 @@ function initializeCanonicalFixture(prefix = 'docx-layout-boundary-canonical-') 
       + 'export interface FloatRegistrationState {}\n'
       + 'export interface PhysicalAnchorFrame {}\n'
       + 'export interface RetainedTableRecord {}\n');
+  write(root, 'packages/docx/src/layout/acquisition-input-projections.ts',
+    'export interface BodyAcquisitionInputProjections {}\n');
+  write(root, 'packages/docx/src/layout/measurement-capabilities.ts',
+    'export interface MeasurementTextContext { measureText(text: string): unknown }\n'
+      + 'export interface VerticalGlyphMeasurementService { measureRunInkExtra(text: string): number }\n');
   write(root, 'packages/docx/src/layout/affine.ts',
     "import type { PointPt } from './types.js';\n"
       + 'export const composeAffine = (point: PointPt) => point;\n');
@@ -347,6 +352,20 @@ test('layout acquisition contexts reject paint capabilities and renderer back-ed
     paintRoot,
     'ACQUISITION_PAINT_CAPABILITY',
     'images',
+    '--final',
+  );
+
+  const measurementRoot = initializeCanonicalFixture('docx-layout-boundary-measurement-paint-');
+  write(
+    measurementRoot,
+    'packages/docx/src/layout/measurement-capabilities.ts',
+    'export interface MeasurementTextContext { canvas: HTMLCanvasElement }\n'
+      + 'export interface VerticalGlyphMeasurementService { measureRunInkExtra(text: string): number }\n',
+  );
+  expectDiagnostic(
+    measurementRoot,
+    'ACQUISITION_PAINT_CAPABILITY',
+    'canvas',
     '--final',
   );
 

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -86,10 +86,25 @@ function initializeCanonicalFixture(prefix = 'docx-layout-boundary-canonical-') 
       + 'export interface PhysicalAnchorFrame {}\n'
       + 'export interface RetainedTableRecord {}\n');
   write(root, 'packages/docx/src/layout/acquisition-input-projections.ts',
-    'export interface BodyAcquisitionInputProjections {}\n');
+    'export interface BodyAcquisitionInputProjections {\n'
+      + '  numberingMarkerShapeInput(): unknown;\n'
+      + '  paragraphMarkShapeInput(): unknown;\n'
+      + '  tableFormatInput(): unknown;\n'
+      + '  tableColumnLayoutInput(): unknown;\n'
+      + '  tableParticipatesInOrdinaryFlow(): unknown;\n'
+      + '  paragraphAcquisitionInput(): unknown;\n'
+      + '}\n');
   write(root, 'packages/docx/src/layout/measurement-capabilities.ts',
-    'export interface MeasurementTextContext { measureText(text: string): unknown }\n'
-      + 'export interface VerticalGlyphMeasurementService { measureRunInkExtra(text: string): number }\n');
+    'export interface MeasurementTextContext {\n'
+      + '  font: string;\n'
+      + '  letterSpacing: string;\n'
+      + '  fontKerning: unknown;\n'
+      + '  measureText(text: string): unknown;\n'
+      + '}\n'
+      + 'export interface VerticalGlyphMeasurementService {\n'
+      + '  fingerprint: string;\n'
+      + '  measureRunInkExtra(text: string): number;\n'
+      + '}\n');
   write(root, 'packages/docx/src/layout/affine.ts',
     "import type { PointPt } from './types.js';\n"
       + 'export const composeAffine = (point: PointPt) => point;\n');
@@ -368,6 +383,37 @@ test('layout acquisition contexts reject paint capabilities and renderer back-ed
     'canvas',
     '--final',
   );
+
+  for (const [label, source, detail] of [
+    [
+      'unlisted member',
+      'export interface MeasurementTextContext { font: string; letterSpacing: string; fontKerning: unknown; measureText(text: string): unknown; fillRect(): void }\n'
+        + 'export interface VerticalGlyphMeasurementService { fingerprint: string; measureRunInkExtra(text: string): number }\n',
+      'fillRect',
+    ],
+    [
+      'heritage clause',
+      'export interface MeasurementTextContext extends CanvasRenderingContext2D { font: string; letterSpacing: string; fontKerning: unknown; measureText(text: string): unknown }\n'
+        + 'export interface VerticalGlyphMeasurementService { fingerprint: string; measureRunInkExtra(text: string): number }\n',
+      'heritage',
+    ],
+    [
+      'extra declaration',
+      'export interface MeasurementTextContext { font: string; letterSpacing: string; fontKerning: unknown; measureText(text: string): unknown }\n'
+        + 'export interface VerticalGlyphMeasurementService { fingerprint: string; measureRunInkExtra(text: string): number }\n'
+        + 'export interface PaintEscape { fillRect(): void }\n',
+      'PaintEscape',
+    ],
+  ]) {
+    const exactRoot = initializeCanonicalFixture(`docx-layout-boundary-measurement-${label.replace(' ', '-')}-`);
+    write(exactRoot, 'packages/docx/src/layout/measurement-capabilities.ts', source);
+    expectDiagnostic(
+      exactRoot,
+      'ACQUISITION_CONTEXT_SURFACE',
+      detail,
+      '--final',
+    );
+  }
 
   const edgeRoot = initializeCanonicalFixture('docx-layout-boundary-acquisition-edge-');
   write(


### PR DESCRIPTION
## Summary

- replace body acquisition's structural Canvas dependency with a runtime text-measurement facade exposing only font selection, spacing, kerning, and `measureText`
- inject DOM-aware vertical-glyph measurement as a separate private service-owner capability, include it in text fingerprints, and fail closed for unbound vertical layout
- compose one frozen, identity-preserving parser projection record for acquisition facts instead of adding parser-model back-edges or compatibility wrappers
- extend the DOCX architecture ratchet to require these seams and reject paint capabilities, renderer back-edges, missing modules, and declaration expansion

This is the C3d-alpha capability-seam step for #1037. It intentionally prepares the physical acquisition-cluster relocation planned for C3d-beta; it does not move those clusters yet or change OOXML semantics.

## Design notes

The measurement facade delegates to the exact same concrete context used by the vertical-glyph service, so existing metrics and kerning state remain coherent while acquisition receives no backing canvas or painter. DOM vertical probing and worker-safe measurement have distinct fingerprints to prevent incompatible retained layouts from sharing a key.

The parser projection record preserves the identities of the existing normalization functions. It is a required acquisition capability, not a wrapper or sample-specific heuristic.

## Verification

- full repository Vitest: 5,616 passed, 26 skipped
- DOCX Vitest: 2,689 passed
- TypeScript workspace typecheck
- DOCX boundary checker and 93 mutation tests
- public API baseline and 19 mutation tests
- compatibility evidence (65 rules) and 17 mutation tests
- DOCX package-build ownership test
- ast-grep scan and 8 lint-rule tests
- `git diff --check`
