### PR TITLE
refactor(docx): inject body acquisition projections

### DIFF
--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -184,7 +184,6 @@ import {
   bodyAcquisitionInputProjections,
   internalDocumentModel,
   numberingMarkerShapeInput,
-  paragraphAcquisitionInput,
   publicAnchorBridge,
 } from './parser-model.js';
 import {
@@ -222,7 +221,6 @@ import {
   applyNumberingBodyOffset,
   resolveNumberingMarkerGeometry,
 } from './layout/numbering-marker.js';
-import { tableFormatInput } from './parser-model.js';
 import { resolveTableColumnWidths } from './layout/table-columns.js';
 import {
   measureParagraphIntrinsicWidths,
@@ -1688,7 +1686,7 @@ function createConcreteBodyLayoutKernel(
     };
     const context = resolveBodyParagraphLayoutContext(state, paragraph);
     return acquireParagraphResult(
-      paragraphAcquisitionInput(paragraph, source),
+      state.acquisitionInputs.paragraphAcquisitionInput(paragraph, source),
       {
         id: `${source.story}:${source.storyInstance}:${source.path.join('.')}`,
         source,
@@ -2148,7 +2146,7 @@ function createConcreteBodyLayoutKernel(
             const borderEdges = resolveParagraphBorderEdges(previous, paragraph, next);
             const result = acquireRegisteredParagraph(
               candidate,
-              paragraphAcquisitionInput(paragraph, block.source),
+              candidate.acquisitionInputs.paragraphAcquisitionInput(paragraph, block.source),
               {
                 id: `${block.source.story}:${block.source.storyInstance}:${block.source.path.join('.')}`,
                 source: block.source,
@@ -2516,7 +2514,7 @@ function createConcreteBodyLayoutKernel(
           }
           const cursor = request.cursor?.cursor ?? startTableFragmentCursor();
           const pageHeightPt = state.pageH / state.scale;
-          const authoredPositioning = tableFormatInput(table).positioning;
+          const authoredPositioning = state.acquisitionInputs.tableFormatInput(table).positioning;
           if (authoredPositioning) {
             const positioning = request.cursor?.kind === 'table'
               && request.cursor.floatingContinuationFrame === 'fresh-text'
@@ -3191,7 +3189,10 @@ function createConcreteBodyLayoutKernel(
             if (paragraph.type !== 'paragraph') {
               throw new Error('Page-anchor prescan source kind mismatch');
             }
-            const acquired = paragraphAcquisitionInput(paragraph, anchor.paragraphSource);
+            const acquired = state.acquisitionInputs.paragraphAcquisitionInput(
+              paragraph,
+              anchor.paragraphSource,
+            );
             const hostMatches = acquired.runs.filter((run) =>
               run.type === 'anchorHost' && run.anchorOccurrenceId === anchor.occurrenceId);
             const payloads = acquired.runs

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -479,15 +479,22 @@ function assertRendererAcquisitionProjectionBoundary(root) {
       || (ts.isElementAccessExpression(expression)
         && expression.argumentExpression
         && staticString(expression.argumentExpression) === 'acquisitionInputs')
-      || (ts.isIdentifier(expression)
-        && expression.text === 'bodyAcquisitionInputProjections')
     )
   );
-  const enclosingFunctionName = (node) => {
+  const buildMeasureStateOwner = source.statements.find((statement) => (
+    ts.isFunctionDeclaration(statement)
+    && statement.name?.text === 'buildMeasureState'
+  ));
+  const enclosingFunction = (node) => {
     let current = node.parent;
     while (current) {
-      if (ts.isFunctionDeclaration(current)) return current.name?.text ?? null;
-      if (ts.isFunctionExpression(current) || ts.isArrowFunction(current)) return null;
+      if (ts.isFunctionDeclaration(current)
+        || ts.isFunctionExpression(current)
+        || ts.isArrowFunction(current)
+        || ts.isMethodDeclaration(current)
+        || ts.isGetAccessorDeclaration(current)
+        || ts.isSetAccessorDeclaration(current)
+        || ts.isConstructorDeclaration(current)) return current;
       current = current.parent;
     }
     return null;
@@ -496,7 +503,7 @@ function assertRendererAcquisitionProjectionBoundary(root) {
     if (ts.isIdentifier(node)
       && node.text === 'bodyAcquisitionInputProjections'
       && !ts.isImportSpecifier(node.parent)
-      && enclosingFunctionName(node) !== 'buildMeasureState') {
+      && enclosingFunction(node) !== buildMeasureStateOwner) {
       fail(
         'RENDERER_ACQUISITION_PROJECTION_BYPASS',
         `${DOCX_SOURCE}/renderer.ts uses bodyAcquisitionInputProjections outside buildMeasureState`,

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -402,6 +402,128 @@ function assertAcquisitionContextBoundary(root) {
   }
 }
 
+function assertRendererAcquisitionProjectionBoundary(root) {
+  const renderer = resolve(root, DOCX_SOURCE, 'renderer.ts');
+  if (!existsSync(renderer)) return;
+  const parserModel = resolve(root, PARSER_MODEL);
+  const injectedProjectionMembers = new Set([
+    'paragraphAcquisitionInput',
+    'tableFormatInput',
+  ]);
+
+  for (const edge of moduleEdges(renderer)) {
+    if (!edge.literal) continue;
+    const targetsParserModel = resolveLocalImport(renderer, edge.specifier) === parserModel
+      || edge.specifier === './parser-model.js';
+    if (!targetsParserModel) continue;
+    const importsProjectionDirectly = edge.importedNames?.some((name) => (
+      name === '*' || name === 'default' || injectedProjectionMembers.has(name)
+    ));
+    if (edge.kind !== 'import' || importsProjectionDirectly) {
+      fail(
+        'RENDERER_ACQUISITION_PROJECTION_BYPASS',
+        `${DOCX_SOURCE}/renderer.ts ${edge.kind} ${edge.specifier}`,
+      );
+    }
+  }
+
+  const source = sourceFile(renderer);
+  for (const statement of source.statements) {
+    if (!ts.isImportDeclaration(statement)
+      || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const targetsParserModel = resolveLocalImport(renderer, statement.moduleSpecifier.text)
+      === parserModel || statement.moduleSpecifier.text === './parser-model.js';
+    if (!targetsParserModel) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text;
+      if (imported === 'bodyAcquisitionInputProjections'
+        && element.name.text !== 'bodyAcquisitionInputProjections') {
+        fail(
+          'RENDERER_ACQUISITION_PROJECTION_BYPASS',
+          `${DOCX_SOURCE}/renderer.ts aliases bodyAcquisitionInputProjections`,
+        );
+      }
+    }
+  }
+  const staticString = (expression) => {
+    if (ts.isParenthesizedExpression(expression)) return staticString(expression.expression);
+    if (ts.isStringLiteralLike(expression)) return expression.text;
+    if (ts.isBinaryExpression(expression)
+      && expression.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+      const left = staticString(expression.left);
+      const right = staticString(expression.right);
+      return left === null || right === null ? null : left + right;
+    }
+    return null;
+  };
+  const projectionMember = (expression) => {
+    if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+    if (ts.isElementAccessExpression(expression)
+      && expression.argumentExpression) {
+      return staticString(expression.argumentExpression);
+    }
+    return null;
+  };
+  const projectionReceiver = (expression) => (
+    ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)
+      ? expression.expression
+      : null
+  );
+  const isInjectedReceiver = (expression) => (
+    expression !== null
+    && (
+      (ts.isPropertyAccessExpression(expression)
+        && expression.name.text === 'acquisitionInputs')
+      || (ts.isElementAccessExpression(expression)
+        && expression.argumentExpression
+        && staticString(expression.argumentExpression) === 'acquisitionInputs')
+      || (ts.isIdentifier(expression)
+        && expression.text === 'bodyAcquisitionInputProjections')
+    )
+  );
+  const enclosingFunctionName = (node) => {
+    let current = node.parent;
+    while (current) {
+      if (ts.isFunctionDeclaration(current)) return current.name?.text ?? null;
+      if (ts.isFunctionExpression(current) || ts.isArrowFunction(current)) return null;
+      current = current.parent;
+    }
+    return null;
+  };
+  const visit = (node) => {
+    if (ts.isIdentifier(node)
+      && node.text === 'bodyAcquisitionInputProjections'
+      && !ts.isImportSpecifier(node.parent)
+      && enclosingFunctionName(node) !== 'buildMeasureState') {
+      fail(
+        'RENDERER_ACQUISITION_PROJECTION_BYPASS',
+        `${DOCX_SOURCE}/renderer.ts uses bodyAcquisitionInputProjections outside buildMeasureState`,
+      );
+    }
+    if (ts.isCallExpression(node)) {
+      if (ts.isIdentifier(node.expression)
+        && injectedProjectionMembers.has(node.expression.text)) {
+        fail(
+          'RENDERER_ACQUISITION_PROJECTION_BYPASS',
+          `${DOCX_SOURCE}/renderer.ts calls ${node.expression.text} directly`,
+        );
+      }
+      const member = projectionMember(node.expression);
+      if (member && injectedProjectionMembers.has(member)
+        && !isInjectedReceiver(projectionReceiver(node.expression))) {
+        fail(
+          'RENDERER_ACQUISITION_PROJECTION_BYPASS',
+          `${DOCX_SOURCE}/renderer.ts calls ${member} outside acquisitionInputs`,
+        );
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(source, visit);
+}
+
 function assertFloatPlacementAuthority(root) {
   const sourceRoot = resolve(root, DOCX_SOURCE);
   const authority = `${LAYOUT_SOURCE}/floats.ts`;
@@ -3899,6 +4021,7 @@ export function checkDocxLayoutBoundaries(options) {
   const allowTransitionalParagraphAnchorAdapter = baselineExists && !options.final;
   assertNoProductionTestSupportImports(root);
   assertAcquisitionContextBoundary(root);
+  assertRendererAcquisitionProjectionBoundary(root);
   assertFloatPlacementAuthority(root);
   assertNoDeletedPageProducerIdentifiers(root);
   assertPaintBoundaries(root);

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -535,6 +535,18 @@ test('renderer body acquisition cannot bypass its injected parser projections', 
         + canonicalRenderer,
     ],
     [
+      'nested owner impersonation',
+      "import { bodyAcquisitionInputProjections } from './parser-model.js';\n"
+        + canonicalRenderer.replace(
+          'return { doc, ctx, localMetrics };',
+          'function buildMeasureState() {\n'
+            + '    bodyAcquisitionInputProjections.tableFormatInput();\n'
+            + '  }\n'
+            + '  buildMeasureState();\n'
+            + '  return { doc, ctx, localMetrics };',
+        ),
+    ],
+    [
       'computed non-injected projection access',
       canonicalRenderer.replace(
         'return { doc, ctx, localMetrics };',

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -480,6 +480,82 @@ test('layout acquisition ownership cannot be bypassed by removing a required mod
   }
 });
 
+test('renderer body acquisition cannot bypass its injected parser projections', () => {
+  for (const [label, importSource] of [
+    [
+      'direct paragraph projection',
+      "import { paragraphAcquisitionInput } from './parser-model.js';\n",
+    ],
+    [
+      'aliased table projection',
+      "import { tableFormatInput as formatTable } from './parser-model.js';\n",
+    ],
+    [
+      'namespace projection access',
+      "import * as parserModel from './parser-model.js';\n",
+    ],
+    [
+      'CommonJS projection access',
+      "const parserModel = require('./parser-model.js');\n",
+    ],
+    [
+      'dynamic projection access',
+      "const parserModelPromise = import('./parser-model.js');\n",
+    ],
+  ]) {
+    const root = initializeCanonicalFixture(
+      `docx-layout-boundary-renderer-projection-${label.replaceAll(' ', '-')}-`,
+    );
+    write(
+      root,
+      'packages/docx/src/renderer.ts',
+      importSource + canonicalRenderer,
+    );
+    expectDiagnostic(
+      root,
+      'RENDERER_ACQUISITION_PROJECTION_BYPASS',
+      label,
+      '--final',
+    );
+  }
+
+  for (const [label, rendererSource] of [
+    [
+      'global projection record use',
+      "import { bodyAcquisitionInputProjections } from './parser-model.js';\n"
+        + canonicalRenderer.replace(
+          'return { doc, ctx, localMetrics };',
+          'bodyAcquisitionInputProjections.paragraphAcquisitionInput();\n'
+            + '  return { doc, ctx, localMetrics };',
+        ),
+    ],
+    [
+      'aliased projection record',
+      "import { bodyAcquisitionInputProjections as projections } from './parser-model.js';\n"
+        + canonicalRenderer,
+    ],
+    [
+      'computed non-injected projection access',
+      canonicalRenderer.replace(
+        'return { doc, ctx, localMetrics };',
+        "doc['parserFacts']['paragraph' + 'AcquisitionInput']();\n"
+          + '  return { doc, ctx, localMetrics };',
+      ),
+    ],
+  ]) {
+    const root = initializeCanonicalFixture(
+      `docx-layout-boundary-renderer-projection-${label.replaceAll(' ', '-')}-`,
+    );
+    write(root, 'packages/docx/src/renderer.ts', rendererSource);
+    expectDiagnostic(
+      root,
+      'RENDERER_ACQUISITION_PROJECTION_BYPASS',
+      label,
+      '--final',
+    );
+  }
+});
+
 test('coordinate-space and page-factory accept only their explicit dependencies', () => {
   assert.equal(runChecker(initializeCanonicalFixture(), '--final').status, 0);
   for (const [name, path, source] of [


### PR DESCRIPTION
## Summary\n\n- route the four deferred body-kernel paragraph/table parser projections through each acquisition state's immutable capability record\n- remove direct `paragraphAcquisitionInput` and `tableFormatInput` imports from the renderer\n- add an architecture ratchet that rejects direct, aliased, namespace, CommonJS, dynamic, computed, and global-record bypasses\n\nThis is C3d beta-3 of #1037. It closes the parser-projection follow-up recorded during C3d-alpha without moving display-scale/Canvas bridges into the point-space layout layer.\n\n## Design notes\n\n`bodyAcquisitionInputProjections` retains the exact parser-owned function identities, but the concrete body kernel may access them only through `BodyAcquisitionState.acquisitionInputs`. The global record is restricted to `buildMeasureState`, where the immutable capability is attached. No OOXML behavior or public declaration changes.\n\n## Verification\n\n- `pnpm test`: 5,633 passed, 26 skipped\n- `pnpm typecheck`\n- DOCX layout boundary mutations: 94 passed\n- DOCX compatibility mutations: 17 passed; 65 rules verified\n- DOCX public API mutations: 19 passed\n- DOCX package-build ownership\n- `pnpm lint`\n- `pnpm lint:test`: 8 passed\n- `git diff --check`\n\n## Review\n\nGPT-5.6 Sol reviewed the implementation and strengthened the first boundary design to reject global projection-record, alias, computed-member, CommonJS, and dynamic-import bypasses. No unresolved P1/P2 finding remains.