### PR TITLE
refactor(docx): remove dead acquisition bridge state

### DIFF
--- a/packages/docx/src/float-line-start-one-inch.test.ts
+++ b/packages/docx/src/float-line-start-one-inch.test.ts
@@ -67,7 +67,7 @@ function leftBand(floatRightPx: number, floatBottomPx: number): FloatRect {
     imageX: 0, imageY: 0, imageW: floatRightPx, imageH: floatBottomPx,
     xLeft: 0, xRight: floatRightPx, yTop: 0, yBottom: floatBottomPx,
     side: 'bothSides', distLeft: 0, distRight: 0, distTop: 0, distBottom: 0,
-    paraId: 1, drawn: false,
+    paraId: 1,
   } as FloatRect;
 }
 

--- a/packages/docx/src/float-table-geometry.test.ts
+++ b/packages/docx/src/float-table-geometry.test.ts
@@ -290,7 +290,6 @@ describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
     expect(f.mode).toBe('square');
     expect(f.side).toBe('right');
     expect(f.imageKey).toBe(''); // non-image float (table painted directly)
-    expect(f.drawn).toBe(true);
     expect(f.xLeft).toBe(0 - 5); // box.x − leftFromText
     expect(f.xRight).toBe(0 + 150 + 9); // box.x + tableW + rightFromText
     expect(f.yTop).toBe(b.y - 3);
@@ -314,7 +313,7 @@ describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
         kind: 'table', tableOverlap: 'overlap', mode: 'square',
         imageKey: '', imageX: 0, imageY: 300, imageW: 200, imageH: 60,
         xLeft: 0, xRight: 200, yTop: 300, yBottom: 360, side: 'bothSides',
-        distLeft: 0, distRight: 0, distTop: 0, distBottom: 0, paraId: 0, drawn: true,
+        distLeft: 0, distRight: 0, distTop: 0, distBottom: 0, paraId: 0,
       }],
     });
     // A new floating table at page-left x=0 overlapping the blocker; never ⇒ avoid.
@@ -351,7 +350,6 @@ describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
       distTop: 4,
       distBottom: 8,
       paraId: 1,
-      drawn: true,
     };
     const st = makeState({ floatParaSeq: 1, floats: [blocker] });
     const tp = tblp({
@@ -383,7 +381,7 @@ describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
       imageX: 20, imageY: 30, imageW: 60, imageH: 20,
       xLeft: 20, xRight: 80, yTop: 30, yBottom: 50, side: 'bothSides',
       distLeft: 0, distRight: 0, distTop: 0, distBottom: 0,
-      paraId: 7, drawn: true,
+      paraId: 7,
     };
     const st = makeState({ floatParaSeq: 8, floats: [child] });
     const tp = tblp({
@@ -422,7 +420,7 @@ describe('floating table float registration (§17.4.57 / §17.4.56)', () => {
         mode: 'square' as const,
         imageKey: '', imageX: 0, imageY: 300, imageW: 200, imageH: 60,
       xLeft: 0, xRight: 200, yTop: 300, yBottom: 360, side: 'bothSides',
-      distLeft: 0, distRight: 0, distTop: 0, distBottom: 0, paraId: 0, drawn: true,
+      distLeft: 0, distRight: 0, distTop: 0, distBottom: 0, paraId: 0,
       };
       return kind === 'table'
         ? { ...core, kind: 'table', tableOverlap: 'overlap' }

--- a/packages/docx/src/float-table-geometry.ts
+++ b/packages/docx/src/float-table-geometry.ts
@@ -189,7 +189,6 @@ export function registerTableFloat(
     mode: 'square',
     side,
     imageKey: '', // non-image float: retained table paint owns it.
-    drawn: true, // deferred resource paint must skip this retained table.
     paraId,
     avoidOverlap: !preResolved,
   });

--- a/packages/docx/src/frame-geometry.test.ts
+++ b/packages/docx/src/frame-geometry.test.ts
@@ -130,7 +130,6 @@ describe('legacy float transport facts', () => {
       mode: 'square',
       side: 'bothSides',
       imageKey: '',
-      drawn: true,
       paraId: 0,
       avoidOverlap: true,
     })).toThrow('Floating-table transport omitted tblOverlap');
@@ -157,7 +156,6 @@ describe('legacy float transport facts', () => {
         distTop: 0,
         distBottom: 0,
         paraId: 1,
-        drawn: true,
       }],
     });
 
@@ -174,7 +172,6 @@ describe('legacy float transport facts', () => {
       mode: 'square',
       side: 'bothSides',
       imageKey: 'moving',
-      drawn: true,
       paraId: 2,
       allowOverlap: true,
       avoidOverlap: true,

--- a/packages/docx/src/frame-geometry.ts
+++ b/packages/docx/src/frame-geometry.ts
@@ -322,7 +322,6 @@ export interface PushFloatOpts {
   mode: 'square' | 'topAndBottom';
   side: string;
   imageKey: string;
-  drawn: boolean;
   paraId: number;
   kind: FloatRect['kind'];
   /** Required at runtime for table entries; the resulting FloatRect and typed
@@ -393,7 +392,6 @@ export function pushFloatRect(state: FloatRegistrationState, o: PushFloatOpts): 
     distTop: o.dt,
     distBottom: o.db,
     paraId: o.paraId,
-    drawn: o.drawn,
   };
   const rect: FloatRect = o.kind === 'table'
     ? { ...core, kind: 'table', tableOverlap: o.tableOverlap! }
@@ -447,7 +445,6 @@ export function registerFrameFloat(box: FrameBox, fp: FramePr, state: FloatRegis
     // (resolveLineFloatWindow then takes the widest free gap around it).
     side: fp.dropCap === 'drop' || fp.dropCap === 'margin' ? 'right' : 'bothSides',
     imageKey: box.exclusionId ?? '',
-    drawn: true, // retained frame paint owns it; deferred resource paint must skip it.
     paraId,
     avoidOverlap: false, // frames opt out of overlap re-seating.
   });

--- a/packages/docx/src/layout-context.test.ts
+++ b/packages/docx/src/layout-context.test.ts
@@ -11,7 +11,6 @@ import {
   resolveParagraphLayoutContext,
   resolveRunLayoutContext,
   resolveSectionLayoutContext,
-  toLegacyDocGridContext,
   type StoryContext,
 } from './layout-context.js';
 
@@ -183,11 +182,6 @@ describe('layout context resolvers', () => {
     ]);
     expect(context.grid).toEqual({
       kind: 'snapToChars',
-      linePitchPt: 20,
-      charSpacePt: 1,
-    });
-    expect(toLegacyDocGridContext(context)).toEqual({
-      type: 'snapToChars',
       linePitchPt: 20,
       charSpacePt: 1,
     });

--- a/packages/docx/src/layout-context.ts
+++ b/packages/docx/src/layout-context.ts
@@ -5,7 +5,6 @@ import {
 import { EAST_ASIAN_RE } from './layout/text.js';
 import {
   resolveDefaultTabPt,
-  type DocGridCtx,
 } from './line-layout.js';
 import { jcIsFullyJustified, jcStretchesLastLine } from './bidi-line.js';
 import { prepareBodyFrameMetadata } from './layout/frame.js';
@@ -240,17 +239,6 @@ export function resolveSectionLayoutContext(
     sectionBidi: false,
     verticalAlignment: section.vAlign ?? 'top',
     lineNumbering: section.lineNumbering ?? undefined,
-  };
-}
-
-/** Temporary bridge for call sites that still consume the legacy grid shape. */
-export function toLegacyDocGridContext(
-  section: SectionLayoutContext,
-): DocGridCtx {
-  return {
-    type: section.grid.kind === 'none' ? null : section.grid.kind,
-    linePitchPt: section.grid.linePitchPt,
-    charSpacePt: section.grid.charSpacePt,
   };
 }
 

--- a/packages/docx/src/layout/anchor-frame.test.ts
+++ b/packages/docx/src/layout/anchor-frame.test.ts
@@ -474,7 +474,7 @@ describe('retained anchor frame geometry', () => {
       xLeft: bounds.xPt, xRight: bounds.xPt + bounds.widthPt,
       yTop: bounds.yPt, yBottom: bounds.yPt + bounds.heightPt,
       side: 'bothSides', distLeft: 0, distRight: 0, distTop: 0, distBottom: 0,
-      paraId: 0, drawn: false,
+      paraId: 0,
     }]);
 
     expect(oracle.lineWindow({

--- a/packages/docx/src/layout/float-wrap.ts
+++ b/packages/docx/src/layout/float-wrap.ts
@@ -123,8 +123,6 @@ interface FloatRectCore {
    *  never displace each other, while different-paragraph floats do. ECMA-376
    *  does not define this scoping; see compatibility.ts and floats.ts. */
   paraId: number;
-  /** true once the image itself has been drawn (drawn after its paragraph lays out). */
-  drawn: boolean;
 }
 
 export type FloatRect =

--- a/packages/docx/src/layout/paragraph-float-authority.test.ts
+++ b/packages/docx/src/layout/paragraph-float-authority.test.ts
@@ -25,7 +25,6 @@ const float = (
   distTop: 4,
   distBottom: 4,
   paraId: 0,
-  drawn: true,
   ...overrides,
 });
 

--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -2819,7 +2819,7 @@ function measurementPlacement(
           yBottom: exclusion.bounds.yPt + exclusion.bounds.heightPt,
           side: exclusion.wrapSide ?? 'bothSides',
           distLeft: 0, distRight: 0, distTop: 0, distBottom: 0,
-          paraId: index, drawn: false,
+          paraId: index,
         })), {
           xLeftPt: pageReference?.xPt ?? options.placement.paragraphXPt,
           xRightPt: pageReference

--- a/packages/docx/src/layout/polygon-wrap-complexity.test.ts
+++ b/packages/docx/src/layout/polygon-wrap-complexity.test.ts
@@ -63,7 +63,6 @@ function denseStar(vertexCount: number, step: number): FloatRect {
     distTop: 0,
     distBottom: 0,
     paraId: 1,
-    drawn: false,
   };
 }
 
@@ -593,7 +592,6 @@ describe('polygon line-window active sweep complexity', () => {
       distTop: 0,
       distBottom: 0,
       paraId: 1,
-      drawn: false,
     }]);
 
     const { window, diagnostics } = computePreparedLineFloatWindowWithDiagnostics(
@@ -638,7 +636,6 @@ describe('polygon line-window active sweep complexity', () => {
       distTop: 0,
       distBottom: 0,
       paraId: 1,
-      drawn: false,
     }]);
 
     const { window } = computePreparedLineFloatWindowWithDiagnostics(
@@ -672,7 +669,6 @@ describe('polygon line-window active sweep complexity', () => {
       distTop: 0,
       distBottom: 0,
       paraId: 1,
-      drawn: false,
     }]);
     const { window: secondWindow } = computePreparedLineFloatWindowWithDiagnostics(
       0, 5, 0.005, 0, 11, secondPrepared, 0, 11,
@@ -707,7 +703,6 @@ describe('polygon line-window active sweep complexity', () => {
       distTop: 0,
       distBottom: 0,
       paraId: 1,
-      drawn: false,
     }]);
 
     const { window } = computePreparedLineFloatWindowWithDiagnostics(
@@ -744,7 +739,6 @@ describe('polygon line-window active sweep complexity', () => {
       distTop: 0,
       distBottom: 0,
       paraId: 1,
-      drawn: false,
     }]);
 
     const { window } = computePreparedLineFloatWindowWithDiagnostics(
@@ -786,7 +780,6 @@ describe('polygon line-window active sweep complexity', () => {
       distTop: 0,
       distBottom: 0,
       paraId: 1,
-      drawn: false,
     }]);
     const { window: rightGap } = computePreparedLineFloatWindowWithDiagnostics(
       2, 0.1, 0.1, 0, 3, rightGapPrepared, 0, 3,
@@ -819,7 +812,6 @@ describe('polygon line-window active sweep complexity', () => {
       distTop: 0,
       distBottom: 0,
       paraId: 1,
-      drawn: false,
     }]);
     const { window: leftGap } = computePreparedLineFloatWindowWithDiagnostics(
       11, 0.1, 0.1, 0, 5, leftGapPrepared, 0, 5,
@@ -855,7 +847,6 @@ describe('polygon line-window active sweep complexity', () => {
       distTop: 0,
       distBottom: 0,
       paraId: 1,
-      drawn: false,
     });
     const prepared = prepareFloatWrap([
       polygonFloat('left-root-boundary', [

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -123,7 +123,7 @@ describe('measureParagraph', () => {
       imageX: xLeft, imageY: 0, imageW: xRight - xLeft, imageH: 20,
       xLeft, xRight, yTop: 0, yBottom: 20,
       side: 'bothSides', distLeft: 0, distRight: 0, distTop: 0, distBottom: 0,
-      paraId: 0, drawn: false,
+      paraId: 0,
     });
     const oracle = createFloatWrapOracle([
       float('A', 40, 60),
@@ -149,7 +149,7 @@ describe('measureParagraph', () => {
       imageKey: 'compiled-through', imageX: 10, imageY: 0, imageW: 80, imageH: 80,
       xLeft: 10, xRight: 90, yTop: 0, yBottom: 80,
       side: 'bothSides', distLeft: 0, distRight: 0, distTop: 0, distBottom: 0,
-      paraId: 0, drawn: false,
+      paraId: 0,
     }]);
     const query = () => oracle.lineWindow({
       topYPt: 30, minimumStartWidthPt: 1, probeHeightPt: 10,
@@ -262,7 +262,7 @@ describe('measureParagraph', () => {
       imageX: 0, imageY: 10, imageW: 80, imageH: 30,
       xLeft: 0, xRight: 80, yTop: 10, yBottom: 40,
       side: 'bothSides', distLeft: 0, distRight: 0, distTop: 0, distBottom: 0,
-      paraId: 1, drawn: false,
+      paraId: 1,
     };
 
     const result = measureParagraph(

--- a/packages/docx/src/renderer.ts
+++ b/packages/docx/src/renderer.ts
@@ -1546,7 +1546,6 @@ function buildMeasureState(
           mode: 'square',
           side: 'bothSides',
           imageKey: '',
-          drawn: true,
           paraId: state.floatParaSeq++,
           avoidOverlap: true,
           tableOverlap: request.overlap,
@@ -1946,7 +1945,7 @@ function createConcreteBodyLayoutKernel(
             yTop: bounds.yPt * scale,
             yBottom: (bounds.yPt + bounds.heightPt) * scale,
             side: 'bothSides', distLeft: 0, distRight: 0, distTop: 0, distBottom: 0,
-            paraId: index, drawn: true,
+            paraId: index,
           })),
           floatParaSeq: request.floatingTableExclusions?.length ?? 0,
           pageAnchorPrescanned: new Set<DocParagraph>(),
@@ -3397,7 +3396,7 @@ function createConcreteBodyLayoutKernel(
               side: entry.wrapSide ?? 'bothSides',
               distLeft: left * scale, distRight: right * scale,
               distTop: top * scale, distBottom: bottom * scale,
-              paraId: entry.paragraphId, drawn: true,
+              paraId: entry.paragraphId,
             };
             return entry.kind === 'table'
               ? {
@@ -4294,7 +4293,6 @@ function registerImageFloat(
     mode,
     side: img.wrapSide ?? 'bothSides',
     imageKey: key,
-    drawn: false,
     paraId,
     avoidOverlap: true,
     allowOverlap,
@@ -4326,7 +4324,6 @@ function registerChartFloat(
     avoidOverlap: true,
     paraId,
     imageKey: '',
-    drawn: false,
   });
 }
 
@@ -4377,9 +4374,6 @@ function registerShapeFloat(
     mode,
     side: shape.wrapSide ?? 'bothSides',
     imageKey: '',
-    // Retained drawing paint owns the shape; mark the exclusion as already
-    // represented so the bitmap resource path skips it.
-    drawn: true,
     paraId,
     avoidOverlap: true,
     allowOverlap: true,

--- a/packages/docx/src/topandbottom-column-scope.test.ts
+++ b/packages/docx/src/topandbottom-column-scope.test.ts
@@ -63,7 +63,6 @@ function topAndBottomBand(r: {
     distTop: 0,
     distBottom: 0,
     paraId: 1,
-    drawn: false,
   } as FloatRect;
 }
 

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -23,6 +23,7 @@ const ACQUISITION_CONTEXT = `${LAYOUT_SOURCE}/acquisition-context.ts`;
 const ACQUISITION_STATE = `${LAYOUT_SOURCE}/acquisition-state.ts`;
 const ACQUISITION_INPUT_PROJECTIONS = `${LAYOUT_SOURCE}/acquisition-input-projections.ts`;
 const ANCHOR_CLASSIFICATION = `${LAYOUT_SOURCE}/anchor-classification.ts`;
+const FLOAT_WRAP = `${LAYOUT_SOURCE}/float-wrap.ts`;
 const MEASUREMENT_ENVIRONMENT = `${LAYOUT_SOURCE}/measurement-environment.ts`;
 const MEASUREMENT_CAPABILITIES = `${LAYOUT_SOURCE}/measurement-capabilities.ts`;
 const SECTION_ORIENTATION = `${LAYOUT_SOURCE}/section-orientation.ts`;
@@ -529,6 +530,35 @@ function assertRendererAcquisitionProjectionBoundary(root) {
     ts.forEachChild(node, visit);
   };
   ts.forEachChild(source, visit);
+}
+
+function assertFloatRectTransportBoundary(root) {
+  const path = resolve(root, FLOAT_WRAP);
+  if (!existsSync(path)) return;
+  const source = sourceFile(path);
+  const visit = (node) => {
+    if ((ts.isIdentifier(node) || ts.isStringLiteralLike(node))
+      && node.text === 'drawn') {
+      const parent = node.parent;
+      const isStaticPropertyName = (
+        (ts.isPropertyAccessExpression(parent) && parent.name === node)
+        || (ts.isElementAccessExpression(parent) && parent.argumentExpression === node)
+        || (ts.isPropertyAssignment(parent) && parent.name === node)
+        || (ts.isShorthandPropertyAssignment(parent) && parent.name === node)
+        || (ts.isPropertyDeclaration(parent) && parent.name === node)
+        || (ts.isPropertySignature(parent) && parent.name === node)
+        || (ts.isMethodDeclaration(parent) && parent.name === node)
+        || (ts.isGetAccessorDeclaration(parent) && parent.name === node)
+        || (ts.isSetAccessorDeclaration(parent) && parent.name === node)
+        || (ts.isBindingElement(parent) && (parent.propertyName ?? parent.name) === node)
+      );
+      if (isStaticPropertyName) {
+        fail('FLOAT_RECT_TRANSITIONAL_STATE', `${FLOAT_WRAP}#drawn`);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
 }
 
 function assertFloatPlacementAuthority(root) {
@@ -4029,6 +4059,7 @@ export function checkDocxLayoutBoundaries(options) {
   assertNoProductionTestSupportImports(root);
   assertAcquisitionContextBoundary(root);
   assertRendererAcquisitionProjectionBoundary(root);
+  assertFloatRectTransportBoundary(root);
   assertFloatPlacementAuthority(root);
   assertNoDeletedPageProducerIdentifiers(root);
   assertPaintBoundaries(root);

--- a/scripts/check-docx-layout-boundaries.test.mjs
+++ b/scripts/check-docx-layout-boundaries.test.mjs
@@ -1492,6 +1492,17 @@ test('every deleted final producer and legacy stamp identifier is rejected exact
   }
 });
 
+test('FloatRect transport cannot regain the deleted drawn state', () => {
+  const root = initializeCanonicalFixture('docx-layout-boundary-float-drawn-state-');
+  write(root, 'packages/docx/src/layout/float-wrap.ts', `
+interface FloatRectCore {
+  drawn: boolean;
+}
+export type FloatRect = FloatRectCore & { kind: 'shape' };
+`);
+  expectDiagnostic(root, 'FLOAT_RECT_TRANSITIONAL_STATE', 'FloatRect.drawn', '--final');
+});
+
 test('legacy stamp property guards do not ban unrelated local variable names', () => {
   const root = initializeCanonicalFixture('docx-layout-boundary-local-column-index-');
   write(root, 'packages/docx/src/layout/local-index.ts',

--- a/scripts/docx-layout-boundary-baseline.json
+++ b/scripts/docx-layout-boundary-baseline.json
@@ -3,9 +3,7 @@
   "legacySymbolCounts": {
     "packages/docx/src/renderer.ts#measureCellContentHeightPx": 2
   },
-  "migrationIdentifierCounts": {
-    "packages/docx/src/layout-context.ts#toLegacyDocGridContext": 1
-  },
+  "migrationIdentifierCounts": {},
   "nonLayoutDeclarationKeys": [
     "packages/docx/src/anchor-geometry.ts#FunctionDeclaration#resolveAnchorX",
     "packages/docx/src/anchor-geometry.ts#FunctionDeclaration#resolveAnchorY",
@@ -132,7 +130,6 @@
     "packages/docx/src/layout-context.ts#FunctionDeclaration#resolveParagraphLayoutContext",
     "packages/docx/src/layout-context.ts#FunctionDeclaration#resolveRunLayoutContext",
     "packages/docx/src/layout-context.ts#FunctionDeclaration#resolveSectionLayoutContext",
-    "packages/docx/src/layout-context.ts#FunctionDeclaration#toLegacyDocGridContext",
     "packages/docx/src/layout-context.ts#InterfaceDeclaration#CharacterGridPolicy",
     "packages/docx/src/layout-context.ts#InterfaceDeclaration#DocumentLayoutSettings",
     "packages/docx/src/layout-context.ts#InterfaceDeclaration#LineGridPolicy",


### PR DESCRIPTION
## Summary

- remove the write-only `FloatRect.drawn` field from the wrap transport, all production producers, and synthetic fixtures
- remove the production-unused `toLegacyDocGridContext` projection and shrink its transitional baseline allowance
- add a float-wrap-scoped architecture mutation that rejects reintroducing `drawn` without banning unrelated drawing-result properties

This is the first C3e cleanup slice of #1037. It deletes behavior-free transition state before the point-space anchor/frame normalization; it does not move the remaining display-scale bridge into `layout/`.

## Proof of dead state

Repository-wide production AST/search inventory found no read of `FloatRect.drawn`; all occurrences were writes, type declarations, or tests that asserted the write itself. `toLegacyDocGridContext` had no production caller and only duplicated the canonical `SectionLayoutContext.grid` values already asserted by its test.

No OOXML behavior or public declaration changes.

## Verification

- `pnpm test`: 5,633 passed, 26 skipped
- `pnpm typecheck`
- DOCX layout boundary mutations: 95 passed
- DOCX compatibility mutations: 17 passed
- DOCX public API mutations: 19 passed
- DOCX package-build ownership: passed
- focused float/frame/table/paragraph tests: 199 passed
- polygon-wrap complexity tests: 20 passed
- `pnpm lint` (pre-existing warnings only)
- `pnpm lint:test`: 8 passed
- `git diff --check`

## Review

GPT-5.6 Sol reviewed the implementation while authoring it. The first ratchet draft banned the generic property name `drawn` across all production code; review rejected that overbroad design and replaced it with a `layout/float-wrap.ts`-scoped transport boundary. A fresh public-diff review follows before the PR leaves draft.