### PR TITLE
perf(docx): memoize immutable polygon compilation

### DIFF
--- a/packages/docx/src/layout/float-wrap.ts
+++ b/packages/docx/src/layout/float-wrap.ts
@@ -9,6 +9,7 @@
 // this module receives its square-line minimum as an explicit input.
 
 import {
+  assertValidPolygonCompileInput,
   compilePolygonWrap,
   polygonBandExactIntervalFunctions,
   polygonLineTopEventYPts,
@@ -238,7 +239,111 @@ export interface PreparedFloatWrap {
   readonly floats: readonly PreparedFloatRect[];
 }
 
+export interface FloatWrapPreparationDiagnostics {
+  polygonCompileCount: number;
+  polygonCacheHitCount: number;
+  polygonSnapshotPointCount: number;
+}
+
 const sweepEventCache = new WeakMap<PreparedFloatWrap, Map<number, readonly number[]>>();
+
+interface CompiledPolygonMemo {
+  readonly kind: 'tight' | 'through';
+  readonly xLeftPt: number;
+  readonly xRightPt: number;
+  readonly yTopPt: number;
+  readonly yBottomPt: number;
+  readonly compiled: CompiledPolygonWrap;
+}
+
+/**
+ * Realm-local derived geometry keyed by the authoritative retained point-array
+ * identity. A small variant bound avoids alternating kind/bounds thrash while
+ * keeping memory bounded by live immutable polygons; translated/scaled clones
+ * intentionally compile under their own identities.
+ */
+const MAX_COMPILED_POLYGON_VARIANTS = 4;
+const compiledPolygonMemo = new WeakMap<
+  readonly Readonly<{ xPt: number; yPt: number }>[],
+  readonly CompiledPolygonMemo[]
+>();
+
+function polygonIsDeepFrozen(
+  points: readonly Readonly<{ xPt: number; yPt: number }>[],
+): boolean {
+  return Object.isFrozen(points) && points.every((point) => Object.isFrozen(point));
+}
+
+function memoMatches(
+  memo: CompiledPolygonMemo,
+  kind: 'tight' | 'through',
+  xLeftPt: number,
+  xRightPt: number,
+  yTopPt: number,
+  yBottomPt: number,
+): boolean {
+  return memo.kind === kind
+    && Object.is(memo.xLeftPt, xLeftPt)
+    && Object.is(memo.xRightPt, xRightPt)
+    && Object.is(memo.yTopPt, yTopPt)
+    && Object.is(memo.yBottomPt, yBottomPt);
+}
+
+function compiledPolygonFor(
+  rect: Readonly<FloatRect>,
+  sourcePoints: readonly Readonly<{ xPt: number; yPt: number }>[],
+  diagnostics?: FloatWrapPreparationDiagnostics,
+): CompiledPolygonWrap {
+  const kind = rect.authoredWrap;
+  if (kind !== 'tight' && kind !== 'through') {
+    throw new Error('Polygon compilation requires tight or through wrap');
+  }
+  const compileInput = {
+    kind,
+    imageKey: rect.imageKey,
+    points: rect.wrapPolygon,
+    xLeftPt: rect.xLeft,
+    xRightPt: rect.xRight,
+    yTopPt: rect.yTop,
+    yBottomPt: rect.yBottom,
+  };
+  // Validate the current FloatRect before lookup so a prior valid entry cannot
+  // mask malformed geometry or replace its current imageKey in the error.
+  assertValidPolygonCompileInput(compileInput);
+  const cacheable = polygonIsDeepFrozen(sourcePoints);
+  if (cacheable) {
+    const memo = compiledPolygonMemo.get(sourcePoints)?.find((candidate) => memoMatches(
+      candidate,
+      kind,
+      rect.xLeft,
+      rect.xRight,
+      rect.yTop,
+      rect.yBottom,
+    ));
+    if (memo) {
+      if (diagnostics) diagnostics.polygonCacheHitCount += 1;
+      return memo.compiled;
+    }
+  }
+  if (diagnostics) diagnostics.polygonCompileCount += 1;
+  const compiled = compilePolygonWrap(compileInput);
+  if (cacheable) {
+    const memo = Object.freeze({
+      kind,
+      xLeftPt: rect.xLeft,
+      xRightPt: rect.xRight,
+      yTopPt: rect.yTop,
+      yBottomPt: rect.yBottom,
+      compiled,
+    });
+    compiledPolygonMemo.set(sourcePoints, Object.freeze([
+      memo,
+      ...(compiledPolygonMemo.get(sourcePoints) ?? [])
+        .slice(0, MAX_COMPILED_POLYGON_VARIANTS - 1),
+    ]));
+  }
+  return compiled;
+}
 
 interface ExactAttributedGap {
   readonly l: ExactRational;
@@ -248,24 +353,23 @@ interface ExactAttributedGap {
 }
 
 /** Snapshot and compile geometry once at the line-wrap oracle boundary. */
-export function prepareFloatWrap(floats: readonly FloatRect[]): PreparedFloatWrap {
+export function prepareFloatWrap(
+  floats: readonly FloatRect[],
+  diagnostics?: FloatWrapPreparationDiagnostics,
+): PreparedFloatWrap {
   const prepared = floats.map((float): PreparedFloatRect => {
+    const sourcePoints = float.wrapPolygon;
+    if (diagnostics && sourcePoints) {
+      diagnostics.polygonSnapshotPointCount += sourcePoints.length;
+    }
     const rect = Object.freeze({
       ...float,
-      ...(float.wrapPolygon
-        ? { wrapPolygon: Object.freeze(float.wrapPolygon.map((point) => Object.freeze({ ...point }))) }
+      ...(sourcePoints
+        ? { wrapPolygon: Object.freeze(sourcePoints.map((point) => Object.freeze({ ...point }))) }
         : {}),
     });
     const polygon = rect.authoredWrap === 'tight' || rect.authoredWrap === 'through'
-      ? compilePolygonWrap({
-          kind: rect.authoredWrap,
-          imageKey: rect.imageKey,
-          points: rect.wrapPolygon,
-          xLeftPt: rect.xLeft,
-          xRightPt: rect.xRight,
-          yTopPt: rect.yTop,
-          yBottomPt: rect.yBottom,
-        })
+      ? compiledPolygonFor(rect, sourcePoints ?? [], diagnostics)
       : null;
     return Object.freeze({
       rect,

--- a/packages/docx/src/layout/paragraph-float-authority.test.ts
+++ b/packages/docx/src/layout/paragraph-float-authority.test.ts
@@ -42,17 +42,19 @@ describe('paragraph float authority projection', () => {
   });
 
   it('projects retained wrap semantics without renderer state', () => {
+    const polygon = Object.freeze([
+      Object.freeze({ xPt: 11, yPt: 21 }),
+      Object.freeze({ xPt: 43, yPt: 21 }),
+      Object.freeze({ xPt: 43, yPt: 67 }),
+    ]);
     const input = float({
       anchorOccurrenceId: 'shape:0',
       authoredWrap: 'tight',
-      wrapPolygon: [
-        { xPt: 11, yPt: 21 },
-        { xPt: 43, yPt: 21 },
-        { xPt: 43, yPt: 67 },
-      ],
+      wrapPolygon: polygon,
     });
 
-    expect(paragraphWrapExclusions([input], 'body:0')).toEqual([{
+    const exclusions = paragraphWrapExclusions([input], 'body:0');
+    expect(exclusions).toEqual([{
       id: 'body:0:float:0',
       wrap: 'tight',
       wrapSide: 'left',
@@ -61,5 +63,6 @@ describe('paragraph float authority projection', () => {
       anchorOccurrenceId: 'shape:0',
       verticalOwnership: 'page',
     }]);
+    expect(exclusions[0]!.polygon).toBe(polygon);
   });
 });

--- a/packages/docx/src/layout/polygon-wrap-complexity.test.ts
+++ b/packages/docx/src/layout/polygon-wrap-complexity.test.ts
@@ -66,6 +66,14 @@ function denseStar(vertexCount: number, step: number): FloatRect {
   };
 }
 
+function frozenDenseStar(vertexCount: number, step: number): Readonly<FloatRect> {
+  const star = denseStar(vertexCount, step);
+  return Object.freeze({
+    ...star,
+    wrapPolygon: Object.freeze(star.wrapPolygon!.map((point) => Object.freeze({ ...point }))),
+  });
+}
+
 function edgeXAt(
   edge: CompiledPolygonWrap['edges'][number],
   yPt: number,
@@ -930,6 +938,170 @@ describe('polygon line-window active sweep complexity', () => {
     expect(seen.size).toBe(polygon.contourSpans.length);
     expect(maximumIndexDepth)
       .toBeLessThanOrEqual(Math.ceil(Math.log2(polygon.contourSpans.length + 1)) + 1);
+  });
+
+  it('compiles one immutable dense star once across a linear number of acquisitions', () => {
+    const vertexCount = 31;
+    const acquisitionCount = vertexCount;
+    const star = frozenDenseStar(vertexCount, 15);
+    const compiled: CompiledPolygonWrap[] = [];
+    const totals = {
+      polygonCompileCount: 0,
+      polygonCacheHitCount: 0,
+      polygonSnapshotPointCount: 0,
+    };
+
+    for (let index = 0; index < acquisitionCount; index += 1) {
+      const diagnostics = {
+        polygonCompileCount: 0,
+        polygonCacheHitCount: 0,
+        polygonSnapshotPointCount: 0,
+      };
+      compiled.push(prepareFloatWrap([star], diagnostics).floats[0]!.polygon!);
+      totals.polygonCompileCount += diagnostics.polygonCompileCount;
+      totals.polygonCacheHitCount += diagnostics.polygonCacheHitCount;
+      totals.polygonSnapshotPointCount += diagnostics.polygonSnapshotPointCount;
+    }
+
+    expect(new Set(compiled).size).toBe(1);
+    expect(totals).toEqual({
+      polygonCompileCount: 1,
+      polygonCacheHitCount: acquisitionCount - 1,
+      polygonSnapshotPointCount: acquisitionCount * vertexCount,
+    });
+    expect(compiled[0]!.intersectionCount)
+      .toBeGreaterThanOrEqual(vertexCount * (vertexCount - 3) / 4);
+  });
+
+  it('keys an immutable polygon compilation by exact kind and bounds', () => {
+    const star = frozenDenseStar(15, 7);
+    const first = prepareFloatWrap([star]).floats[0]!.polygon!;
+    const changedKind = prepareFloatWrap([{
+      ...star,
+      authoredWrap: 'through',
+    }]).floats[0]!.polygon!;
+    expect(changedKind).not.toBe(first);
+    expect(prepareFloatWrap([star]).floats[0]!.polygon).toBe(first);
+
+    for (const field of ['xLeft', 'xRight', 'yTop', 'yBottom'] as const) {
+      const changedBounds = prepareFloatWrap([{
+        ...star,
+        [field]: star[field] + 1,
+      }]).floats[0]!.polygon!;
+      expect(changedBounds).not.toBe(first);
+    }
+  });
+
+  it('retains alternating immutable kind variants across repeated acquisitions', () => {
+    const vertexCount = 31;
+    const acquisitionCount = vertexCount;
+    const tight = frozenDenseStar(vertexCount, 15);
+    const through = Object.freeze({ ...tight, authoredWrap: 'through' as const });
+    const diagnostics = {
+      polygonCompileCount: 0,
+      polygonCacheHitCount: 0,
+      polygonSnapshotPointCount: 0,
+    };
+    const tightCompilations: CompiledPolygonWrap[] = [];
+    const throughCompilations: CompiledPolygonWrap[] = [];
+
+    for (let index = 0; index < acquisitionCount; index += 1) {
+      const prepared = prepareFloatWrap([tight, through], diagnostics).floats;
+      tightCompilations.push(prepared[0]!.polygon!);
+      throughCompilations.push(prepared[1]!.polygon!);
+    }
+
+    expect(new Set(tightCompilations).size).toBe(1);
+    expect(new Set(throughCompilations).size).toBe(1);
+    expect(tightCompilations[0]).not.toBe(throughCompilations[0]);
+    expect(diagnostics).toEqual({
+      polygonCompileCount: 2,
+      polygonCacheHitCount: 2 * (acquisitionCount - 1),
+      polygonSnapshotPointCount: 2 * acquisitionCount * vertexCount,
+    });
+  });
+
+  it('does not reuse translated, cloned, or mutable polygon geometry', () => {
+    const star = frozenDenseStar(15, 7);
+    const first = prepareFloatWrap([star]).floats[0]!.polygon!;
+    const clonedPoints = Object.freeze(star.wrapPolygon!.map((point) =>
+      Object.freeze({ ...point })));
+    const cloned = prepareFloatWrap([{
+      ...star,
+      wrapPolygon: clonedPoints,
+    }]).floats[0]!.polygon!;
+    expect(cloned).not.toBe(first);
+    expect(cloned.eventYPts).toEqual(first.eventYPts);
+
+    const translatedPoints = Object.freeze(star.wrapPolygon!.map((point) => Object.freeze({
+      xPt: point.xPt + 10,
+      yPt: point.yPt + 20,
+    })));
+    const translated = prepareFloatWrap([{
+      ...star,
+      wrapPolygon: translatedPoints,
+      xLeft: star.xLeft + 10,
+      xRight: star.xRight + 10,
+      yTop: star.yTop + 20,
+      yBottom: star.yBottom + 20,
+    }]).floats[0]!.polygon!;
+    expect(translated).not.toBe(first);
+    expect(translated.polygonLeftPt).toBeCloseTo(first.polygonLeftPt + 10, 12);
+    expect(translated.polygonTopPt).toBeCloseTo(first.polygonTopPt + 20, 12);
+
+    const scaledPoints = Object.freeze(star.wrapPolygon!.map((point) => Object.freeze({
+      xPt: point.xPt * 2,
+      yPt: point.yPt * 3,
+    })));
+    const scaled = prepareFloatWrap([{
+      ...star,
+      wrapPolygon: scaledPoints,
+      xLeft: star.xLeft * 2,
+      xRight: star.xRight * 2,
+      yTop: star.yTop * 3,
+      yBottom: star.yBottom * 3,
+    }]).floats[0]!.polygon!;
+    expect(scaled).not.toBe(first);
+    expect(scaled.polygonRightPt).toBeCloseTo(first.polygonRightPt * 2, 12);
+    expect(scaled.polygonBottomPt).toBeCloseTo(first.polygonBottomPt * 3, 12);
+
+    const mutable = denseStar(15, 7);
+    const mutablePoints = mutable.wrapPolygon!.map((point) => ({ ...point }));
+    const mutableInput = { ...mutable, wrapPolygon: mutablePoints };
+    const beforeMutation = prepareFloatWrap([mutableInput]).floats[0]!.polygon!;
+    mutablePoints[0]!.xPt += 5;
+    const afterMutation = prepareFloatWrap([mutableInput]).floats[0]!.polygon!;
+    expect(afterMutation).not.toBe(beforeMutation);
+    expect(afterMutation.edges[0]!.from.xPt).toBe(beforeMutation.edges[0]!.from.xPt + 5);
+  });
+
+  it('validates current bounds before consulting an immutable polygon memo', () => {
+    const star = frozenDenseStar(15, 7);
+    prepareFloatWrap([star]);
+
+    expect(() => prepareFloatWrap([{
+      ...star,
+      imageKey: 'reversed-after-valid-cache-entry',
+      xLeft: star.xRight + 1,
+    }])).toThrow('Invalid finite wrap bounds for reversed-after-valid-cache-entry');
+  });
+
+  it('distinguishes signed-zero bounds in the immutable polygon memo', () => {
+    const points = Object.freeze([
+      Object.freeze({ xPt: 0, yPt: 0 }),
+      Object.freeze({ xPt: 10, yPt: 0 }),
+      Object.freeze({ xPt: 0, yPt: 10 }),
+    ]);
+    const base: FloatRect = {
+      kind: 'shape', mode: 'square', authoredWrap: 'through', wrapPolygon: points,
+      imageKey: 'signed-zero-bounds', imageX: 0, imageY: 0, imageW: 10, imageH: 10,
+      xLeft: 0, xRight: 10, yTop: 0, yBottom: 10,
+      side: 'bothSides', distLeft: 0, distRight: 0, distTop: 0, distBottom: 0, paraId: 1,
+    };
+    const positiveZero = prepareFloatWrap([base]).floats[0]!.polygon!;
+    const negativeZero = prepareFloatWrap([{ ...base, xLeft: -0 }]).floats[0]!.polygon!;
+
+    expect(negativeZero).not.toBe(positiveZero);
   });
 
   it('matches a full active sort across exact same-Y and endpoint events', () => {

--- a/packages/docx/src/layout/polygon-wrap.ts
+++ b/packages/docx/src/layout/polygon-wrap.ts
@@ -65,7 +65,7 @@ export interface CompiledPolygonWrap {
   readonly padBottomPt: number;
 }
 
-interface PolygonCompileInput {
+export interface PolygonCompileInput {
   readonly kind: 'tight' | 'through';
   readonly imageKey: string;
   readonly points: readonly PolygonPoint[] | undefined;
@@ -73,6 +73,20 @@ interface PolygonCompileInput {
   readonly xRightPt: number;
   readonly yTopPt: number;
   readonly yBottomPt: number;
+}
+
+export function assertValidPolygonCompileInput(
+  input: PolygonCompileInput,
+): asserts input is PolygonCompileInput & { readonly points: readonly PolygonPoint[] } {
+  if (!input.points || input.points.length < 3
+    || input.points.some((point) =>
+      !Number.isFinite(point.xPt) || !Number.isFinite(point.yPt))) {
+    throw new Error(`Invalid ${input.kind} wrapPolygon for ${input.imageKey}`);
+  }
+  if (![input.xLeftPt, input.xRightPt, input.yTopPt, input.yBottomPt].every(Number.isFinite)
+    || input.xRightPt < input.xLeftPt || input.yBottomPt < input.yTopPt) {
+    throw new Error(`Invalid finite wrap bounds for ${input.imageKey}`);
+  }
 }
 
 export interface PolygonInterval {
@@ -639,15 +653,8 @@ function compileContourSpans(
  * participant-adjacent slots, hence O(K) pair-membership work.
  */
 export function compilePolygonWrap(input: PolygonCompileInput): CompiledPolygonWrap {
+  assertValidPolygonCompileInput(input);
   const points = input.points;
-  if (!points || points.length < 3
-    || points.some((point) => !Number.isFinite(point.xPt) || !Number.isFinite(point.yPt))) {
-    throw new Error(`Invalid ${input.kind} wrapPolygon for ${input.imageKey}`);
-  }
-  if (![input.xLeftPt, input.xRightPt, input.yTopPt, input.yBottomPt].every(Number.isFinite)
-    || input.xRightPt < input.xLeftPt || input.yBottomPt < input.yTopPt) {
-    throw new Error(`Invalid finite wrap bounds for ${input.imageKey}`);
-  }
   const retainedPoints = Object.freeze(points.map((point) => Object.freeze({ ...point })));
   const latticeValues = [
     ...retainedPoints.flatMap((point) => [point.xPt, point.yPt]),


### PR DESCRIPTION
## Summary

Series C3f for #1037 removes repeated dense-polygon compilation across paragraph layout acquisitions.

- memoize compiled `tight` / `through` wrap geometry by the authoritative deeply frozen polygon-array identity;
- key variants by exact wrap kind and binary64 bounds, retaining at most four variants per weak key;
- keep mutable, cloned, translated, and scaled polygon inputs on the defensive compile path;
- validate the current geometry before every lookup so a cached entry cannot hide malformed input or stale diagnostic identity;
- preserve polygon identity through paragraph float-authority projection.

The cache is realm-local and weak. Compiled exact-geometry sidecars are not added to retained layout or structured-clone output.

## Complexity

The exact dense-polygon compiler remains intrinsically O(V²), as established by the preceding sweep refactor. Previously, P paragraph/oracle acquisitions each recompiled the same polygon, producing O(PV²), or O(V³) when P scales with V.

For immutable retained geometry this change performs one O(V²) compilation plus O(PV) validation and defensive snapshot work. With P = V, aggregate work is therefore O(V²). An alternating two-variant regression proves that valid shared-array variants do not overwrite and recompile each other.

## Correctness coverage

- one immutable 31-vertex dense star: 1 compile + 30 cache hits;
- alternating `tight` / `through` variants: 2 compiles + 60 cache hits;
- exact kind and all four bounds participate in the cache key;
- signed-zero bounds remain distinct;
- equal-content clones, translations, scales, and mutable inputs do not reuse stale geometry;
- invalid current bounds still throw with the current image key after a valid entry exists;
- paragraph float authority preserves the deeply frozen polygon identity.

## Verification

- `pnpm typecheck`
- `pnpm test` — 543 files passed, 11 skipped; 5,644 tests passed, 26 skipped
- DOCX-only tests — 288 files / 2,717 tests passed
- focused polygon/authority tests — 28 passed
- `pnpm lint:test` — 8 passed
- `pnpm lint` — passed with only pre-existing warning tripwires
- `pnpm build:packages`
- `pnpm build`
- `pnpm check:public-type-exports`
- `node scripts/check-docx-public-api.mjs`
- `git diff --check`
- independent GPT-5.6 Sol review — APPROVE

Part of #1037.
