### PR TITLE
feat(pptx): expose shape id on text runs

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -136,6 +136,11 @@ export interface RenderContext {
 
 /** Information about a rendered text segment for building a transparent selection overlay. */
 export interface PptxTextRunInfo {
+  /**
+   * Source shape's DrawingML `cNvPr@id`. The identifier is stable and unique
+   * within its slide. Absent for parser-synthesized shapes that have no cNvPr.
+   */
+  shapeId?: string;
   text: string;
   /** X position in CSS px, relative to the shape's top-left corner. */
   inShapeX: number;
@@ -2294,6 +2299,9 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
   const y = emuToPx(el.y, scale);
   const w = emuToPx(el.width, scale);
   const h = emuToPx(el.height, scale);
+  const shapeTextRunCallback: TextRunCallback | undefined = onTextRun && el.id !== undefined
+    ? (run) => onTextRun({ ...run, shapeId: el.id })
+    : onTextRun;
 
   // anchor="b" + h=0: shape grows upward from y; render stroke as bottom border,
   // then let renderTextBody handle positioning.
@@ -2309,7 +2317,7 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     }
     if (el.textBody) {
       const defaultTextColor = shapeDefaultTextColor(el, rc);
-      renderTextBody(ctx, el.textBody, x, y, w, h, scale, defaultTextColor, el.rotation, el.flipH, el.flipV, themeDefaultColor, slideNumber, rc, onTextRun, false, fetchImage);
+      renderTextBody(ctx, el.textBody, x, y, w, h, scale, defaultTextColor, el.rotation, el.flipH, el.flipV, themeDefaultColor, slideNumber, rc, shapeTextRunCallback, false, fetchImage);
     }
     return;
   }
@@ -2714,7 +2722,7 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
       if (tr) { tx = tr.tx; ty = tr.ty; tw = tr.tw; th = tr.th; }
     }
     // Pass el.rotation so the text-layer overlay can CSS-rotate the shape div to match.
-    renderTextBody(ctx, el.textBody, tx, ty, tw, th, scale, defaultTextColor, el.rotation, false, false, themeDefaultColor, slideNumber, rc, onTextRun, false, fetchImage);
+    renderTextBody(ctx, el.textBody, tx, ty, tw, th, scale, defaultTextColor, el.rotation, false, false, themeDefaultColor, slideNumber, rc, shapeTextRunCallback, false, fetchImage);
     ctx.restore();
   }
 

--- a/packages/pptx/src/smartart-fallback-contrast.test.ts
+++ b/packages/pptx/src/smartart-fallback-contrast.test.ts
@@ -4,7 +4,7 @@ import {
   isSmartArtFallbackShape,
   smartArtFallbackTextColor,
 } from './smartart-fallback-contrast';
-import { renderSlide } from './renderer';
+import { renderSlide, type PptxTextRunInfo } from './renderer';
 import type { Fill } from '@silurus/ooxml-core';
 import type { Paragraph, ShapeElement, Slide, TextBody } from './types';
 
@@ -308,6 +308,38 @@ async function renderAndCollect(slide: Slide): Promise<FillTextCall[]> {
   });
   return fillTexts;
 }
+
+async function renderAndCollectTextRuns(slide: Slide): Promise<PptxTextRunInfo[]> {
+  const { ctx } = recordingCtx();
+  const canvas = stubCanvas(ctx);
+  const runs: PptxTextRunInfo[] = [];
+  await renderSlide(canvas, slide, 9_144_000, 6_858_000, {
+    width: 960,
+    dpr: 1,
+    defaultTextColor: '383838',
+  }, (run) => runs.push(run));
+  return runs;
+}
+
+describe('renderSlide text-run shape identity', () => {
+  it('surfaces the source cNvPr id on every run of a file-authored shape', async () => {
+    const runs = await renderAndCollectTextRuns(
+      slideWith(null, [fallbackShape('Editable title', { id: '42', name: 'Title 1' })]),
+    );
+
+    expect(runs).not.toHaveLength(0);
+    expect(runs.every((run) => run.shapeId === '42')).toBe(true);
+  });
+
+  it('leaves identity absent for parser-synthesized SmartArt fallback shapes', async () => {
+    const runs = await renderAndCollectTextRuns(
+      slideWith(null, [fallbackShape('Synthetic item')]),
+    );
+
+    expect(runs).not.toHaveLength(0);
+    expect(runs.every((run) => run.shapeId === undefined)).toBe(true);
+  });
+});
 
 describe('renderSlide SmartArt fallback contrast (issue #805)', () => {
   it('renders null-colour fallback runs white on a dark background', async () => {


### PR DESCRIPTION
## Summary

- expose the source shape's slide-local `cNvPr@id` as optional `PptxTextRunInfo.shapeId`
- propagate the identifier to every text run emitted for a file-authored shape
- keep the field absent for parser-synthesized shapes without `cNvPr`

## Motivation

Consumers of Canvas text-run geometry need a stable source-shape handle for selection and edit integrations. The PPTX parser already retains `cNvPr@id` on `ShapeElement`, but the renderer previously dropped that identity from text-run callbacks.

## Validation

- `vitest run packages/pptx/src/smartart-fallback-contrast.test.ts` (16 tests)
- `vitest run packages/pptx/src` (477 tests)
- `tsc --build --pretty false`
- `pnpm --filter @silurus/ooxml-pptx build:ci`
- `pnpm build`
- `pnpm lint` (passes with existing warnings)
