### PR TITLE
fix(docx): restore East Asian pagination metrics

### DIFF
--- a/packages/docx/src/empty-paragraph-mark-height.test.ts
+++ b/packages/docx/src/empty-paragraph-mark-height.test.ts
@@ -191,14 +191,14 @@ describe('empty paragraph mark line height (§17.3.1.29 / §17.3.1.33)', () => {
     const p = {
       ...para(''),
       defaultFontFamily: 'Century',
-      defaultFontFamilyEastAsia: 'ＭＳ 明朝',
+      defaultFontFamilyEastAsia: 'Test East Asian Serif',
     } as DocParagraph;
     let font = '';
     const ctx = {
       get font() { return font; },
       set font(v: string) { font = v; },
       measureText: () => {
-        const ea = font.includes('ＭＳ 明朝');
+        const ea = font.includes('Test East Asian Serif');
         const total = ea ? 30 : 10;
         return {
           width: 0,
@@ -212,6 +212,117 @@ describe('empty paragraph mark line height (§17.3.1.29 / §17.3.1.33)', () => {
 
     expect(paragraphMarkLineHeight(p, 1, { type: null, linePitchPt: null }, false, false, ctx, {})).toBe(10);
     expect(paragraphMarkLineHeight(p, 1, { type: null, linePitchPt: null }, false, true, ctx, {})).toBe(30);
+  });
+
+  it('uses the MS Mincho Far East single-line height for an empty East Asian mark', () => {
+    const p = {
+      ...para(''),
+      defaultFontSize: 12,
+      defaultFontFamily: 'Century',
+      defaultFontFamilyEastAsia: 'ＭＳ 明朝',
+    } as DocParagraph;
+    const ctx = {
+      font: '',
+      measureText: () => ({
+        width: 12,
+        fontBoundingBoxAscent: 10.3125,
+        fontBoundingBoxDescent: 1.6875,
+        actualBoundingBoxAscent: 10.3125,
+        actualBoundingBoxDescent: 1.6875,
+      } as TextMetrics),
+    } as unknown as CanvasRenderingContext2D;
+
+    expect(paragraphMarkLineHeight(
+      p,
+      1,
+      { type: null, linePitchPt: null },
+      false,
+      false,
+      ctx,
+      {},
+      null,
+      {},
+      undefined,
+      {
+        fontSizePt: 12,
+        fonts: { complexScript: 'Times New Roman' },
+        themeFonts: {
+          ascii: 'ＭＳ 明朝',
+          highAnsi: 'ＭＳ 明朝',
+          eastAsia: 'ＭＳ 明朝',
+        },
+        themeFontPresence: {
+          ascii: true,
+          highAnsi: true,
+          eastAsia: true,
+          complexScript: false,
+        },
+        weight: 400,
+        style: 'normal',
+        complexScript: false,
+        fontHint: 'eastAsia',
+        eastAsiaLanguage: 'ja-jp',
+      },
+    )).toBeCloseTo(15.6, 5);
+  });
+
+  it('keeps the following East-Asian line on page two in the observed MS Mincho fixture', async () => {
+    const observedParagraph = (text: string, shading?: string): DocParagraph => ({
+      ...para(text),
+      runs: text === ''
+        ? []
+        : [{
+            type: 'text',
+            ...textRun(text),
+            fontSize: 12,
+            fontFamily: 'Century',
+            fontFamilyEastAsia: 'ＭＳ 明朝',
+          } as DocParagraph['runs'][number]],
+      defaultFontSize: 12,
+      defaultFontFamily: 'Century',
+      defaultFontFamilyEastAsia: 'ＭＳ 明朝',
+      shading,
+      paragraphMarkFontFacts: {
+        fontSize: 12,
+        fontFamily: 'Century',
+        fontFamilyEastAsia: 'ＭＳ 明朝',
+        fontHint: 'eastAsia',
+        langEastAsia: 'ja-jp',
+      },
+    } as unknown as DocParagraph);
+    const model = docOf([
+      observedParagraph('甲'),
+      observedParagraph('', 'c0ffee'),
+      observedParagraph('乙'),
+    ]);
+    model.section.pageWidth = 200;
+    model.section.pageHeight = 39;
+    model.fontFamilyClasses = {};
+    const measurement = makeResolvedMetricCanvas();
+    const services = createLayoutServices(model, {
+      measureContext: measurement.canvas.getContext('2d') as CanvasRenderingContext2D,
+    });
+
+    // Word records the empty 12pt MS Mincho EA mark as a 15.6pt line. Together
+    // with the two 12pt visible lines this is 39.6pt, so the final line starts
+    // on page two. Treating the mark as the font's raw 12pt design box would
+    // incorrectly fit all three lines into the 39pt first-page band.
+    const layout = layoutDocument(model, services, { currentDateMs: 0 });
+    expect(layout.pages).toHaveLength(2);
+
+    const painted = [] as ReturnType<typeof makeResolvedMetricCanvas>[];
+    for (let pageIndex = 0; pageIndex < layout.pages.length; pageIndex++) {
+      const recording = makeResolvedMetricCanvas();
+      painted.push(recording);
+      await renderDocumentToCanvas(model, recording.canvas, pageIndex, {
+        dpr: 1,
+        width: 200,
+        layoutServices: services,
+      });
+    }
+    expect(painted[0].textCalls.map((call) => call.text)).toContain('甲');
+    expect(painted[0].textCalls.map((call) => call.text)).not.toContain('乙');
+    expect(painted[1].textCalls.map((call) => call.text)).toContain('乙');
   });
 
   it('counts an untabled 20pt East Asian mark as two cells on a 20pt grid', () => {

--- a/packages/docx/src/layout/compatibility.test.ts
+++ b/packages/docx/src/layout/compatibility.test.ts
@@ -44,9 +44,11 @@ import {
   WORD_FIT_TEXT_INTER_CHARACTER_EXPANSION,
   WORD_FULL_WIDTH_CHARACTER_SPACING_SCOPE,
   WORD_GRID_AT_LEAST_TALL_LINE_UNSNAPPED,
+  WORD_JAPANESE_PUNCTUATION_COMPRESSION_CELL,
   WORD_JUSTIFICATION_LEADING_INDENT_EXCLUSION,
   WORD_JUSTIFIED_CANDIDATE_SEPARATOR_FIT,
   WORD_MIXED_ANCHOR_VISIBLE_LINE_METRICS,
+  WORD_MS_MINCHO_EMPTY_EAST_ASIAN_MARK_HEIGHT,
   WORD_NUMBERING_MARKER_OVERFLOW_TAB_ADVANCE,
   WORD_NUMBERING_SUFFIX_COINCIDENT_LIST_TAB,
   WORD_NUMERIC_DECIMAL_TAB_INFERENCE,
@@ -64,6 +66,8 @@ import {
   wordUseFeLayoutInheritedGridHeightPx,
   wordCandidateFitWidthPx,
   wordJustifiedCandidateFitAllowancePx,
+  wordJapanesePunctuationRetainedExtentPt,
+  wordMsMinchoEmptyEastAsianMarkSingleLinePx,
   wordNumberingSuffixAcceptsCoincidentListTab,
   wordRubyUniformLineHeightPx,
   wordVisibleLineMetricPx,
@@ -352,7 +356,7 @@ describe('layout compatibility inventory', () => {
       .not.toMatch(/sample|private|\.docx|\.pdf/i);
   });
 
-  it('registers the public Microsoft punctuation notes without claiming a fixed trim', () => {
+  it('separates normative punctuation eligibility from the observed compression amount', () => {
     expect(WORD_OVERFLOW_PUNCTUATION_LANGUAGE_SETS.evidence).toEqual({
       kind: 'microsoft-note',
       reference: '[MS-OE376] §2.1.56',
@@ -362,7 +366,42 @@ describe('layout compatibility inventory', () => {
       reference: '[MS-OE376] §2.1.562',
     });
     expect(WORD_FULL_WIDTH_CHARACTER_SPACING_SCOPE.description)
-      .toMatch(/eligibility.*not a universal trim amount/i);
+      .toMatch(/only which characters are eligible.*not define.*compression amount/i);
+    expect(WORD_JAPANESE_PUNCTUATION_COMPRESSION_CELL.evidence).toEqual({
+      kind: 'office-observation',
+      syntheticFixtureId: 'japanese-fullwidth-punctuation-compression-cell',
+      application: 'Microsoft Word',
+      version: '16.111.1',
+      platform: 'macOS 26.5.2',
+    });
+    expect(WORD_JAPANESE_PUNCTUATION_COMPRESSION_CELL.description)
+      .not.toMatch(/sample|private|\.docx|\.pdf/i);
+    expect(wordJapanesePunctuationRetainedExtentPt({
+      punctuationAdvancePt: 8,
+      punctuationInkEndPt: 1,
+      ideographicCellAdvancePt: 10,
+    })).toBe(5);
+    expect(wordJapanesePunctuationRetainedExtentPt({
+      punctuationAdvancePt: 8,
+      punctuationInkEndPt: 6,
+      ideographicCellAdvancePt: 10,
+    })).toBe(6);
+  });
+
+  it('scopes the observed MS Mincho height to empty East-Asian marks', () => {
+    expect(WORD_MS_MINCHO_EMPTY_EAST_ASIAN_MARK_HEIGHT.evidence).toEqual({
+      kind: 'office-observation',
+      syntheticFixtureId: 'ms-mincho-empty-east-asian-paragraph-mark',
+      application: 'Microsoft Word',
+      version: '16.111.1',
+      platform: 'macOS 26.5.2',
+    });
+    expect(WORD_MS_MINCHO_EMPTY_EAST_ASIAN_MARK_HEIGHT.description)
+      .not.toMatch(/sample|private|\.docx|\.pdf/i);
+    expect(wordMsMinchoEmptyEastAsianMarkSingleLinePx('MS Mincho', 12, true)).toBeCloseTo(15.6, 5);
+    expect(wordMsMinchoEmptyEastAsianMarkSingleLinePx('ＭＳ 明朝', 12, true)).toBeCloseTo(15.6, 5);
+    expect(wordMsMinchoEmptyEastAsianMarkSingleLinePx('MS Mincho', 12, false)).toBe(0);
+    expect(wordMsMinchoEmptyEastAsianMarkSingleLinePx('MS PMincho', 12, true)).toBe(0);
   });
 
   it('records the anonymized Word observation for vertical final-line admission', () => {

--- a/packages/docx/src/layout/line-compatibility.ts
+++ b/packages/docx/src/layout/line-compatibility.ts
@@ -108,8 +108,50 @@ export const WORD_FULL_WIDTH_CHARACTER_SPACING_SCOPE = defineCompatibilityRule({
     kind: 'microsoft-note',
     reference: '[MS-OE376] §2.1.562',
   },
-  description: 'Interpret ST_CharacterSpacing as applying whitespace compression to full-width punctuation characters. The note establishes eligibility, not a universal trim amount; compression geometry comes only from authoritative selected-glyph ink bounds.',
+  description: 'Interpret ST_CharacterSpacing as applying whitespace compression to full-width punctuation characters. This rule establishes only which characters are eligible; it does not define a universal compression amount.',
 });
+
+export const WORD_JAPANESE_PUNCTUATION_COMPRESSION_CELL = defineCompatibilityRule({
+  id: 'word-japanese-punctuation-compression-cell',
+  evidence: {
+    kind: 'office-observation',
+    syntheticFixtureId: 'japanese-fullwidth-punctuation-compression-cell',
+    application: 'Microsoft Word',
+    version: '16.111.1',
+    platform: 'macOS 26.5.2',
+  },
+  description: 'In the observed Japanese compatibility fixture, compressed full-width punctuation retains at least half of the ideographic cell measured through the selected font route. Tight glyph ink can require a larger retained extent. This is an Office-observed compression amount, not a normative interpretation of ST_CharacterSpacing.',
+});
+
+export const WORD_MS_MINCHO_EMPTY_EAST_ASIAN_MARK_HEIGHT = defineCompatibilityRule({
+  id: 'word-ms-mincho-empty-east-asian-mark-height',
+  evidence: {
+    kind: 'office-observation',
+    syntheticFixtureId: 'ms-mincho-empty-east-asian-paragraph-mark',
+    application: 'Microsoft Word',
+    version: '16.111.1',
+    platform: 'macOS 26.5.2',
+  },
+  description: 'In the observed compatibility fixture, an empty 12-point East-Asian paragraph mark routed to MS Mincho occupies a 15.6-point single-line box. Scope this 1.3-em floor to empty East-Asian paragraph marks; ordinary MS Mincho text lines and Latin marks retain their independently measured metrics.',
+});
+
+/** Compatibility projection governed by
+ * {@link WORD_JAPANESE_PUNCTUATION_COMPRESSION_CELL}. */
+export function wordJapanesePunctuationRetainedExtentPt(input: Readonly<{
+  punctuationAdvancePt: number;
+  punctuationInkEndPt: number;
+  ideographicCellAdvancePt: number;
+}>): number {
+  const advancePt = Math.max(0, input.punctuationAdvancePt);
+  return Math.min(
+    advancePt,
+    Math.max(
+      0,
+      input.punctuationInkEndPt,
+      input.ideographicCellAdvancePt / 2,
+    ),
+  );
+}
 
 const WORD_OVERFLOW_PUNCTUATION = {
   ja: new Set([...',.’”、。」』】），．］｝｡､']),
@@ -290,6 +332,20 @@ export function wordRunVerticalAlignRaisePt(
 }
 
 export const WORD_FAR_EAST_SINGLE_LINE_FACTOR = 1.3;
+
+/** Compatibility projection governed by
+ * {@link WORD_MS_MINCHO_EMPTY_EAST_ASIAN_MARK_HEIGHT}. */
+export function wordMsMinchoEmptyEastAsianMarkSingleLinePx(
+  family: string | null | undefined,
+  emPx: number,
+  eastAsianMark: boolean,
+): number {
+  if (!eastAsianMark || !family) return 0;
+  const normalized = family.trim().toLowerCase();
+  return normalized === 'ms mincho' || normalized === 'ｍｓ 明朝'
+    ? emPx * WORD_FAR_EAST_SINGLE_LINE_FACTOR
+    : 0;
+}
 
 export function wordEastAsianGridLineCells(
   naturalHeightPx: number,

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -91,6 +91,8 @@ import {
   wordCandidateFitWidthPx,
   wordJustifiedCandidateFitAllowancePx,
   wordIsOverflowPunctuation,
+  wordJapanesePunctuationRetainedExtentPt,
+  wordMsMinchoEmptyEastAsianMarkSingleLinePx,
 } from './layout/line-compatibility.js';
 import { wordNeutralAttachesToActiveScript } from './layout/script-compatibility.js';
 
@@ -1426,9 +1428,17 @@ export function paragraphMarkLineMetrics(
   } else {
     ({ asc, desc } = emptyLineNaturalPx(fs, scale));
   }
-  const intendedSingle = resolvedLocalFont?.lineHeightRatio != null
+  const measuredIntendedSingle = resolvedLocalFont?.lineHeightRatio != null
     ? fs * scale * resolvedLocalFont.lineHeightRatio
     : emptyIntendedSingleForScriptPx(para, scale, markUsesEastAsianFace);
+  const intendedSingle = Math.max(
+    measuredIntendedSingle,
+    wordMsMinchoEmptyEastAsianMarkSingleLinePx(
+      authoredFamily,
+      fs * scale,
+      markUsesEastAsianFace,
+    ),
+  );
   const gridCountSingle = eastAsian
     ? eastAsianGridCountSinglePx(intendedSingle, fs * scale)
     : undefined;
@@ -2475,21 +2485,57 @@ export function buildSegments(runs: DocRun[], environment: LineLayoutEnvironment
               measure: true,
               clusterGeometry: false,
             });
-            // `characterSpacingControl` removes the selected full-width
-            // character's blank trailing side. Only authoritative tight ink can
-            // identify that whitespace. Neither ECMA-376 §17.15.1.18 nor
-            // the implementation note defines a universal fixed trim, so a
-            // backend without tight horizontal bounds deterministically applies
-            // no trim.
+            // ECMA-376 §17.15.1.18 defines only compression eligibility. The
+            // registered Word observation retains half of the selected route's
+            // ideographic cell for punctuation; this is not assumed to be half
+            // of a proportional punctuation glyph's own advance. Kana in
+            // `compressPunctuationAndJapaneseKana` has no observed cell floor,
+            // so only its measured trailing sidebearing is removed.
             const removableUnscaledPt = measured?.inkBounds
               && measured.horizontalInkBoundsAreTight === true
-              ? Math.max(
-                  0,
-                  Math.min(
-                    measured.advancePt,
-                    measured.advancePt - measured.inkBounds.xMaxPt,
-                  ),
-                )
+              ? (() => {
+                  const trailingWhitespacePt = Math.max(
+                    0,
+                    Math.min(
+                      measured.advancePt,
+                      measured.advancePt - measured.inkBounds.xMaxPt,
+                    ),
+                  );
+                  if (!COMPRESSIBLE_TRAILING_FULL_WIDTH_PUNCTUATION.has(text)) {
+                    return trailingWhitespacePt;
+                  }
+                  const punctuationRoute = measured.spans[0]?.fontRoute.fingerprint;
+                  const ideographicCell = environment.layoutServices?.text.shape({
+                    ...textShapeRequest,
+                    text: '\u3000',
+                    fontHint: 'eastAsia',
+                    measure: true,
+                    clusterGeometry: false,
+                  });
+                  const cellRoute = ideographicCell?.spans[0]?.fontRoute.fingerprint;
+                  const cellAdvancePt = ideographicCell?.advancePt;
+                  if (
+                    !punctuationRoute
+                    || cellRoute !== punctuationRoute
+                    || cellAdvancePt === undefined
+                    || !Number.isFinite(cellAdvancePt)
+                    || cellAdvancePt <= 0
+                  ) {
+                    return 0;
+                  }
+                  const retainedExtentPt = wordJapanesePunctuationRetainedExtentPt({
+                    punctuationAdvancePt: measured.advancePt,
+                    punctuationInkEndPt: measured.inkBounds.xMaxPt,
+                    ideographicCellAdvancePt: cellAdvancePt,
+                  });
+                  return Math.max(
+                    0,
+                    Math.min(
+                      trailingWhitespacePt,
+                      measured.advancePt - retainedExtentPt,
+                    ),
+                  );
+                })()
               : 0;
             // §17.3.2.43 w:w scales the glyph and both of its sidebearings;
             // trim in the same post-scale coordinate space as segAdvanceWidth.

--- a/packages/docx/src/punctuation-layout.test.ts
+++ b/packages/docx/src/punctuation-layout.test.ts
@@ -106,7 +106,10 @@ const textOf = (line: LayoutLine): string =>
     .map((segment) => segment.text)
     .join('');
 
-function punctuationMetricsServices(): LayoutServices {
+function punctuationMetricsServices(options: Readonly<{
+  punctuationAdvancePt?: number;
+  ideographicCellAdvancePt?: number;
+}> = {}): LayoutServices {
   const text: TextLayoutService = createTextLayoutService({
     fonts: createFontResolver([]),
     measurer: {
@@ -114,9 +117,13 @@ function punctuationMetricsServices(): LayoutServices {
       measure(request) {
         const scalarCount = [...request.text].length;
         const tightTrailingWhitespace = new Set([
-          '。', '．', '！', '？', '：', '；', 'あ', 'ア', 'ー', 'か\u3099',
+          '、', '。', '．', '）', '！', '？', '：', '；', 'あ', 'ア', 'ー', 'か\u3099',
         ]).has(request.text);
-        const advancePt = scalarCount * 10;
+        const advancePt = request.text === '\u3000'
+          ? (options.ideographicCellAdvancePt ?? 10)
+          : tightTrailingWhitespace
+            ? (options.punctuationAdvancePt ?? scalarCount * 10)
+            : scalarCount * 10;
         return {
           advancePt,
           ascentPt: 8,
@@ -125,7 +132,11 @@ function punctuationMetricsServices(): LayoutServices {
             ? {
                 inkBounds: {
                   xMinPt: 1,
-                  xMaxPt: request.text === '．' ? 3 : advancePt - 5,
+                  xMaxPt: request.text === '．'
+                    ? 3
+                    : request.text === '、'
+                      ? 1
+                      : advancePt - 5,
                   ascentPt: 2,
                   descentPt: 0,
                 },
@@ -140,8 +151,8 @@ function punctuationMetricsServices(): LayoutServices {
 }
 
 describe('ECMA-376 East-Asian punctuation fit', () => {
-  it('compresses a full-width trailing period from tight selected-glyph geometry', () => {
-    const segments = buildSegments([textRun('甲乙．')], {
+  it('retains at least a half-width cell around compressed full-width punctuation', () => {
+    const segments = buildSegments([textRun('甲乙．丙')], {
       pageIndex: 0,
       totalPages: 1,
       characterSpacingControl: 'compressPunctuation',
@@ -151,19 +162,59 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
     expect(segments.map((segment) => 'text' in segment ? segment.text : '')).toEqual([
       '甲乙',
       '．',
+      '丙',
     ]);
     const punctuation = segments[1] as LayoutTextSeg;
     expect(punctuation.charSpacing).toBeUndefined();
-    expect(punctuation.punctuationCompressionPt).toBe(-7);
+    expect(punctuation.punctuationCompressionPt).toBe(-5);
 
-    const laidOut = lines(segments, 23, false);
+    const laidOut = lines(segments, 35, false);
     expect(laidOut).toHaveLength(1);
-    expect(textOf(laidOut[0])).toBe('甲乙．');
-    expect((laidOut[0].segments[1] as LayoutTextSeg).measuredWidth).toBe(3);
+    expect(textOf(laidOut[0])).toBe('甲乙．丙');
+    expect((laidOut[0].segments[1] as LayoutTextSeg).measuredWidth).toBe(5);
+  });
+
+  it('does not trim a Japanese comma to its tiny ink bounds', () => {
+    const segments = buildSegments([textRun('甲、乙')], {
+      pageIndex: 0,
+      totalPages: 1,
+      characterSpacingControl: 'compressPunctuation',
+      layoutServices: punctuationMetricsServices(),
+    }) as LayoutTextSeg[];
+
+    expect(segments.map((segment) => segment.text)).toEqual(['甲', '、', '乙']);
+    // The comma ink ends at 1pt in a 10pt cell. Compressing all 9pt of trailing
+    // whitespace makes the following ideograph touch the comma; Word's
+    // punctuation compression retains the half-em punctuation cell.
+    expect(segments[1].punctuationCompressionPt).toBe(-5);
+    expect(lines(segments, 25, false)).toHaveLength(1);
+    expect(lines(segments, 25, false)[0].segments.map((segment) =>
+      'text' in segment ? segment.measuredWidth : undefined,
+    )).toEqual([10, 5, 10]);
+  });
+
+  it('derives the retained half-cell from the selected font route, not punctuation advance', () => {
+    const segments = buildSegments([textRun('甲、乙')], {
+      pageIndex: 0,
+      totalPages: 1,
+      characterSpacingControl: 'compressPunctuation',
+      layoutServices: punctuationMetricsServices({
+        punctuationAdvancePt: 8,
+        ideographicCellAdvancePt: 10,
+      }),
+    }) as LayoutTextSeg[];
+
+    // The proportional punctuation advance is 8pt, while the same route's
+    // ideographic cell is 10pt. Retain 5pt (half the cell), so only 3pt may be
+    // removed despite the comma's 1pt tight ink extent.
+    expect(segments[1].punctuationCompressionPt).toBe(-3);
+    expect(lines(segments, 25, false)[0].segments.map((segment) =>
+      'text' in segment ? segment.measuredWidth : undefined,
+    )).toEqual([10, 5, 10]);
   });
 
   it('does not invent a fixed trim when tight horizontal ink bounds are unavailable', () => {
-    const segments = buildSegments([textRun('甲乙．')], {
+    const segments = buildSegments([textRun('甲乙．丙')], {
       pageIndex: 0,
       totalPages: 1,
       characterSpacingControl: 'compressPunctuation',
@@ -172,12 +223,12 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
     const punctuation = segments[1] as LayoutTextSeg;
     expect(punctuation.text).toBe('．');
     expect(punctuation.punctuationCompressionPt).toBeUndefined();
-    expect(lines(segments, 23, false)).toHaveLength(2);
+    expect(lines(segments, 35, false)).toHaveLength(2);
   });
 
   it('scales punctuation sidebearing trim with the authored glyph width', () => {
     const run = {
-      ...textRun('．'),
+      ...textRun('．甲'),
       charScale: 0.5,
     } as DocParagraph['runs'][number];
     const [punctuation] = buildSegments([run], {
@@ -187,9 +238,9 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
       layoutServices: punctuationMetricsServices(),
     }) as LayoutTextSeg[];
 
-    // Natural 10pt cell and 7pt trailing sidebearing are both scaled to 50%.
-    expect(punctuation.punctuationCompressionPt).toBe(-3.5);
-    expect(lines([punctuation], 1.5, false)).toHaveLength(1);
+    // The retained half-cell and its 5pt trim are both scaled to 50%.
+    expect(punctuation.punctuationCompressionPt).toBe(-2.5);
+    expect(lines([punctuation], 2.5, false)).toHaveLength(1);
   });
 
   it('allows one eligible punctuation character past the line extent by default policy', () => {
@@ -225,19 +276,20 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
   });
 
   it('dispatches exact ST_CharacterSpacing values and compresses kana only in the combined mode', () => {
-    const punctuationOnly = buildSegments([textRun('あアー．')], {
+    const punctuationOnly = buildSegments([textRun('あアー．漢')], {
       pageIndex: 0,
       totalPages: 1,
       characterSpacingControl: 'compressPunctuation',
       layoutServices: punctuationMetricsServices(),
     }) as LayoutTextSeg[];
-    expect(punctuationOnly.map((segment) => segment.text)).toEqual(['あアー', '．']);
+    expect(punctuationOnly.map((segment) => segment.text)).toEqual(['あアー', '．', '漢']);
     expect(punctuationOnly.map((segment) => segment.punctuationCompressionPt)).toEqual([
       undefined,
-      -7,
+      -5,
+      undefined,
     ]);
 
-    const punctuationAndKana = buildSegments([textRun('あアー・漢．')], {
+    const punctuationAndKana = buildSegments([textRun('あアー・漢．乙')], {
       pageIndex: 0,
       totalPages: 1,
       characterSpacingControl: 'compressPunctuationAndJapaneseKana',
@@ -249,13 +301,15 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
       'ー',
       '・漢',
       '．',
+      '乙',
     ]);
     expect(punctuationAndKana.map((segment) => segment.punctuationCompressionPt)).toEqual([
       -5,
       -5,
       -5,
       undefined,
-      -7,
+      -5,
+      undefined,
     ]);
 
     const unknownPrefix = buildSegments([textRun('あ．')], {
@@ -295,7 +349,7 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
   });
 
   it('recognizes unambiguous full-width exclamation, question, colon, and semicolon punctuation', () => {
-    const segments = buildSegments([textRun('！甲？乙：丙；')], {
+    const segments = buildSegments([textRun('！甲？乙：丙；丁')], {
       pageIndex: 0,
       totalPages: 1,
       characterSpacingControl: 'compressPunctuation',
@@ -303,10 +357,10 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
     }) as LayoutTextSeg[];
 
     expect(segments.map((segment) => segment.text)).toEqual([
-      '！', '甲', '？', '乙', '：', '丙', '；',
+      '！', '甲', '？', '乙', '：', '丙', '；', '丁',
     ]);
     expect(segments.map((segment) => segment.punctuationCompressionPt)).toEqual([
-      -5, undefined, -5, undefined, -5, undefined, -5,
+      -5, undefined, -5, undefined, -5, undefined, -5, undefined,
     ]);
   });
 
@@ -327,7 +381,7 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
   });
 
   it('applies the document-wide punctuation compression in vertical CJK columns', () => {
-    const text = `${'甲'.repeat(37)}。`;
+    const text = `${'甲'.repeat(36)}。甲`;
     const compressed = buildSegments([textRun(text)], {
       pageIndex: 0,
       totalPages: 1,
@@ -335,9 +389,11 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
       characterSpacingControl: 'compressPunctuation',
       layoutServices: punctuationMetricsServices(),
     });
-    // 37 full-em cells + the selected period's retained 5pt ink extent = 375pt.
+    // 37 full-em ideographs + the selected period's retained half-em cell = 375pt.
     expect(lines(compressed, 375, false)).toHaveLength(1);
-    const compressedMark = compressed.at(-1) as LayoutTextSeg;
+    const compressedMark = compressed.find((segment) =>
+      'text' in segment && segment.text === '。'
+    ) as LayoutTextSeg;
     expect(compressedMark.text).toBe('。');
     expect(compressedMark.verticalRun).toBe(true);
     expect(compressedMark.punctuationCompressionPt).toBe(-5);
@@ -350,7 +406,7 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
     });
     expect(lines(uncompressed, 375, false)).toHaveLength(2);
 
-    const middleDot = buildSegments([textRun(`${'甲'.repeat(37)}・`)], {
+    const middleDot = buildSegments([textRun(`${'甲'.repeat(36)}・甲`)], {
       pageIndex: 0,
       totalPages: 1,
       verticalCJK: true,


### PR DESCRIPTION
## Summary

- preserve a Word-observed half ideographic cell when compressing full-width punctuation, measured through the selected font route
- scope the observed MS Mincho 1.3-em floor to empty East-Asian paragraph marks only
- add anonymized compatibility fixtures for punctuation spacing and the affected page boundary

This is a regression follow-up to #1037. It does not change the public API or ordinary MS Mincho text-line metrics.

## Verification

- pnpm test (5,792 passed, 25 skipped)
- pnpm typecheck
- DOCX architecture boundaries (88 passed)
- DOCX compatibility evidence (17 passed)
- DOCX public API (23 passed)
- DOCX package build (2 passed)
- browser conformance (66 passed across Chrome, Firefox, and WebKit)
- git diff --check

The locally supplied Office-reference fixtures were also compared visually; they are not part of this commit.