### PR TITLE
feat(pptx): add shape click hit testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,39 @@ Notes:
   transferred back as an `ImageBitmap`, so a single render can be marginally
   slower than `mode: 'main'`. Choose it for non-blocking UI, not raw speed.
 
+### PPTX shape click and hit testing
+
+In `mode: 'main'`, `PptxViewer` can report the topmost identified shape under a
+click. The event includes the slide-local DrawingML id and a detached
+`ShapeElement` snapshot without exposing the presentation's private model.
+
+```typescript
+const viewer = new PptxViewer(canvas, {
+  onShapeClick({ slideIndex, shapeId, shape, nativeEvent }) {
+    console.log(slideIndex, shapeId, shape, nativeEvent);
+  },
+});
+```
+
+Headless integrations can call the same model-backed hit test directly. Points
+and tolerance use slide EMU coordinates:
+
+```typescript
+const rect = canvas.getBoundingClientRect();
+const point = {
+  x: ((event.clientX - rect.left) / rect.width) * pres.slideWidth,
+  y: ((event.clientY - rect.top) / rect.height) * pres.slideHeight,
+};
+const hit = pres.hitTestShape(slideIndex, point, {
+  tolerance: (6 / rect.width) * pres.slideWidth,
+});
+```
+
+Hit testing walks shapes in reverse paint order, uses each shape's transformed
+frame, and applies the optional tolerance to straight lines and connectors.
+Shapes without a file-authored id are ignored. Both `onShapeClick` and
+`hitTestShape()` require `mode: 'main'`.
+
 ### Continuous scroll viewers
 
 `DocxScrollViewer` and `PptxScrollViewer` render the whole document as one

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -1,4 +1,9 @@
-export { PptxViewer, type PptxViewerOptions, type HiddenSlideMode } from './viewer';
+export {
+  PptxViewer,
+  type PptxViewerOptions,
+  type PptxShapeClickEvent,
+  type HiddenSlideMode,
+} from './viewer';
 export { PptxScrollViewer, type PptxScrollViewerOptions } from './scroll-viewer';
 export {
   PptxPresentation,
@@ -6,6 +11,11 @@ export {
   type RenderSlideOptions,
   type RenderSlideToBitmapOptions,
 } from './presentation';
+export {
+  type PptxSlidePoint,
+  type PptxShapeHit,
+  type PptxShapeHitTestOptions,
+} from './shape-hit-test';
 export { renderSlide, type RenderOptions, type PptxTextRunInfo, type TextRunCallback } from './renderer';
 export { buildPptxTextLayer } from './text-layer';
 // IX2 find-in-document: the highlight overlay builder + the pptx match-location

--- a/packages/pptx/src/presentation.hit-test-shape.test.ts
+++ b/packages/pptx/src/presentation.hit-test-shape.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { PptxPresentation } from './presentation';
+import type { Presentation, ShapeElement } from './types';
+
+function shape(): ShapeElement {
+  return {
+    type: 'shape',
+    id: '7',
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 50,
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+    geometry: 'rect',
+    fill: null,
+    stroke: null,
+    textBody: null,
+    defaultTextColor: null,
+    custGeom: null,
+    adj: null,
+    adj2: null,
+    adj3: null,
+    adj4: null,
+    adj5: null,
+    adj6: null,
+    adj7: null,
+    adj8: null,
+    shadow: null,
+  };
+}
+
+function makePresentation(mode: 'main' | 'worker' = 'main') {
+  const target = shape();
+  const model: Presentation = {
+    slideWidth: 1000,
+    slideHeight: 750,
+    slides: [{
+      index: 0,
+      slideNumber: 1,
+      background: null,
+      elements: [target],
+    }],
+    defaultTextColor: null,
+    majorFont: null,
+    minorFont: null,
+  };
+  const instance = Object.create(PptxPresentation.prototype) as Record<string, unknown>;
+  instance._mode = mode;
+  instance._presentation = mode === 'main' ? model : null;
+  instance._meta = mode === 'worker'
+    ? { slideCount: 1, slideWidth: 1000, slideHeight: 750 }
+    : null;
+  return {
+    presentation: instance as unknown as PptxPresentation,
+    target,
+  };
+}
+
+describe('PptxPresentation.hitTestShape', () => {
+  it('returns a detached shape from the current main-thread model', () => {
+    const { presentation, target } = makePresentation();
+
+    const hit = presentation.hitTestShape(0, { x: 20, y: 20 });
+
+    expect(hit).toMatchObject({
+      slideIndex: 0,
+      shapeId: '7',
+      point: { x: 20, y: 20 },
+    });
+    expect(hit?.shape).toEqual(target);
+    expect(hit?.shape).not.toBe(target);
+  });
+
+  it('rejects an invalid slide index', () => {
+    const { presentation } = makePresentation();
+    expect(() => presentation.hitTestShape(1, { x: 0, y: 0 })).toThrow(
+      /slide index 1 out of range/i,
+    );
+  });
+
+  it('requires main mode because worker mode does not retain the shape model', () => {
+    const { presentation } = makePresentation('worker');
+    expect(() => presentation.hitTestShape(0, { x: 0, y: 0 })).toThrow(/mode.*main/i);
+  });
+});

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -29,6 +29,12 @@ import type {
 } from './worker-protocol';
 import InlineWorker from './worker.ts?worker&inline';
 import wasmAssetUrl from './wasm/pptx_parser_bg.wasm?url';
+import {
+  hitTestSlideShape,
+  type PptxShapeHit,
+  type PptxShapeHitTestOptions,
+  type PptxSlidePoint,
+} from './shape-hit-test';
 
 /** Options for {@link PptxPresentation.load}. */
 export type LoadOptions = CoreLoadOptions & {
@@ -236,6 +242,28 @@ export class PptxPresentation {
    *  probing (design §11: no silent mis-pathing). */
   get mode(): 'main' | 'worker' {
     return this._mode;
+  }
+
+  /**
+   * Return the topmost file-authored shape at a point in slide EMU coordinates.
+   *
+   * Main mode only: worker mode does not retain the parsed shape model on this
+   * instance. The returned shape is detached from the live presentation model.
+   */
+  hitTestShape(
+    slideIndex: number,
+    point: PptxSlidePoint,
+    opts: PptxShapeHitTestOptions = {},
+  ): PptxShapeHit | null {
+    if (this._mode !== 'main') {
+      throw new Error('PptxPresentation.hitTestShape requires mode: "main"');
+    }
+    if (!this._presentation) throw new Error('Presentation not loaded');
+    const slide = this._presentation.slides[slideIndex];
+    if (!slide) {
+      throw new Error(`Slide index ${slideIndex} out of range (count: ${this.slideCount})`);
+    }
+    return hitTestSlideShape(slideIndex, slide, point, opts);
   }
 
   /**

--- a/packages/pptx/src/scroll-viewer-test-dom.ts
+++ b/packages/pptx/src/scroll-viewer-test-dom.ts
@@ -1,6 +1,11 @@
 import { vi } from 'vitest';
 import type { PptxPresentation, RenderSlideOptions, RenderSlideToBitmapOptions } from './presentation';
 import type { PptxTextRunInfo } from './renderer';
+import type {
+  PptxShapeHit,
+  PptxShapeHitTestOptions,
+  PptxSlidePoint,
+} from './shape-hit-test';
 
 /** A recording fake DOM element. Extends the `FakeEl` pattern from
  *  text-layer.test.ts with the surface PptxScrollViewer touches: scrollTop,
@@ -295,6 +300,12 @@ export class FakePptxEngine {
    *  worker path now ships runs back beside the bitmap, so the stub mirrors that
    *  by replaying `feedTextRuns` to `renderSlideToBitmap`'s `onTextRun` too. */
   feedTextRuns?: PptxTextRunInfo[];
+  shapeHit: PptxShapeHit | null = null;
+  hitTestCalls: Array<{
+    slide: number;
+    point: PptxSlidePoint;
+    opts: PptxShapeHitTestOptions;
+  }> = [];
   constructor(
     private _slideCount: number,
     public readonly slideWidth: number, // EMU, deck-wide (uniform)
@@ -372,6 +383,14 @@ export class FakePptxEngine {
    *  `PptxPresentation.collectSlideRuns`). Returns the fed runs regardless of mode. */
   collectSlideRuns(_slide: number, _width?: number): Promise<PptxTextRunInfo[]> {
     return Promise.resolve([...(this.feedTextRuns ?? [])]);
+  }
+  hitTestShape(
+    slide: number,
+    point: PptxSlidePoint,
+    opts: PptxShapeHitTestOptions = {},
+  ): PptxShapeHit | null {
+    this.hitTestCalls.push({ slide, point, opts });
+    return this.shapeHit ? structuredClone(this.shapeHit) : null;
   }
   /** The per-call `width` (px) recorded for every renderSlide call, in call order.
    *  T3 asserts each mounted slide received its OWN px width. */

--- a/packages/pptx/src/shape-hit-test.test.ts
+++ b/packages/pptx/src/shape-hit-test.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hitTestShapeElement,
+  hitTestSlideShape,
+  type PptxSlidePoint,
+} from './shape-hit-test';
+import type { ShapeElement, Slide } from './types';
+
+function shape(
+  id: string | undefined,
+  overrides: Partial<ShapeElement> = {},
+): ShapeElement {
+  return {
+    type: 'shape',
+    id,
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 50,
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+    geometry: 'rect',
+    fill: null,
+    stroke: null,
+    textBody: null,
+    defaultTextColor: null,
+    custGeom: null,
+    adj: null,
+    adj2: null,
+    adj3: null,
+    adj4: null,
+    adj5: null,
+    adj6: null,
+    adj7: null,
+    adj8: null,
+    shadow: null,
+    ...overrides,
+  };
+}
+
+function slide(elements: Slide['elements']): Slide {
+  return {
+    index: 0,
+    slideNumber: 1,
+    background: null,
+    elements,
+  };
+}
+
+describe('PPTX shape hit testing', () => {
+  it('hits an ordinary shape by its bounding frame', () => {
+    expect(hitTestShapeElement(shape('1'), { x: 50, y: 25 })).toBe(true);
+    expect(hitTestShapeElement(shape('1'), { x: 101, y: 25 })).toBe(false);
+  });
+
+  it('undoes rotation before testing the local frame', () => {
+    const rotated = shape('1', { width: 100, height: 20, rotation: 90 });
+    expect(hitTestShapeElement(rotated, { x: 50, y: 50 })).toBe(true);
+    expect(hitTestShapeElement(rotated, { x: 90, y: 10 })).toBe(false);
+  });
+
+  it('uses a configurable tolerance for line shapes', () => {
+    const line = shape('1', {
+      width: 100,
+      height: 100,
+      geometry: 'line',
+    });
+    expect(hitTestShapeElement(line, { x: 50, y: 54 }, 5)).toBe(true);
+    expect(hitTestShapeElement(line, { x: 50, y: 60 }, 5)).toBe(false);
+  });
+
+  it('returns the topmost identified shape and a detached snapshot', () => {
+    const bottom = shape('bottom');
+    const top = shape('top');
+    const point: PptxSlidePoint = { x: 20, y: 20 };
+
+    const hit = hitTestSlideShape(3, slide([bottom, top]), point);
+
+    expect(hit).toMatchObject({
+      slideIndex: 3,
+      shapeId: 'top',
+      point,
+    });
+    expect(hit?.shape).toEqual(top);
+    expect(hit?.shape).not.toBe(top);
+    expect(hit?.point).not.toBe(point);
+  });
+
+  it('skips parser-synthesized shapes without an id', () => {
+    expect(hitTestSlideShape(0, slide([shape(undefined)]), { x: 20, y: 20 })).toBeNull();
+  });
+
+  it('returns null for non-finite or empty-space points', () => {
+    const target = slide([shape('1')]);
+    expect(hitTestSlideShape(0, target, { x: Number.NaN, y: 20 })).toBeNull();
+    expect(hitTestSlideShape(0, target, { x: 200, y: 200 })).toBeNull();
+  });
+});

--- a/packages/pptx/src/shape-hit-test.ts
+++ b/packages/pptx/src/shape-hit-test.ts
@@ -1,0 +1,124 @@
+import type { ShapeElement, Slide } from './types';
+
+/** A point in the slide's native EMU coordinate space. */
+export interface PptxSlidePoint {
+  x: number;
+  y: number;
+}
+
+/** Options for {@link hitTestSlideShape}. */
+export interface PptxShapeHitTestOptions {
+  /**
+   * Extra hit radius in EMU for line-like shapes. Viewers should convert their
+   * desired CSS-pixel tolerance using `slideWidth / canvasCssWidth`.
+   */
+  tolerance?: number;
+}
+
+/** Detached result of a successful shape hit test. */
+export interface PptxShapeHit {
+  slideIndex: number;
+  shapeId: string;
+  shape: ShapeElement;
+  point: PptxSlidePoint;
+}
+
+const LINE_GEOMETRIES = new Set(['line', 'straightconnector1']);
+
+function inverseTransformPoint(
+  shape: ShapeElement,
+  point: PptxSlidePoint,
+): PptxSlidePoint {
+  const cx = shape.x + shape.width / 2;
+  const cy = shape.y + shape.height / 2;
+  const radians = (-shape.rotation * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const dx = point.x - cx;
+  const dy = point.y - cy;
+  let x = cx + cos * dx - sin * dy;
+  let y = cy + sin * dx + cos * dy;
+
+  // renderShape applies rotation and then flip around the same frame centre.
+  // After undoing rotation, each flip is its own inverse.
+  if (shape.flipH) x = 2 * cx - x;
+  if (shape.flipV) y = 2 * cy - y;
+  return { x, y };
+}
+
+function distanceToSegment(
+  point: PptxSlidePoint,
+  start: PptxSlidePoint,
+  end: PptxSlidePoint,
+): number {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const lengthSquared = dx * dx + dy * dy;
+  if (lengthSquared === 0) return Math.hypot(point.x - start.x, point.y - start.y);
+  const projection = Math.max(
+    0,
+    Math.min(1, ((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSquared),
+  );
+  return Math.hypot(
+    point.x - (start.x + projection * dx),
+    point.y - (start.y + projection * dy),
+  );
+}
+
+/** Bounding-frame hit test for one shape, with line tolerance for connectors. */
+export function hitTestShapeElement(
+  shape: ShapeElement,
+  point: PptxSlidePoint,
+  tolerance = 0,
+): boolean {
+  if (!Number.isFinite(point.x) || !Number.isFinite(point.y)) return false;
+  const safeTolerance = Number.isFinite(tolerance) && tolerance > 0 ? tolerance : 0;
+  const local = inverseTransformPoint(shape, point);
+  const geometry = shape.geometry.toLowerCase();
+
+  if (LINE_GEOMETRIES.has(geometry) || shape.width === 0 || shape.height === 0) {
+    return distanceToSegment(
+      local,
+      { x: shape.x, y: shape.y },
+      { x: shape.x + shape.width, y: shape.y + shape.height },
+    ) <= safeTolerance;
+  }
+
+  const minX = Math.min(shape.x, shape.x + shape.width);
+  const maxX = Math.max(shape.x, shape.x + shape.width);
+  const minY = Math.min(shape.y, shape.y + shape.height);
+  const maxY = Math.max(shape.y, shape.y + shape.height);
+  return (
+    local.x >= minX &&
+    local.x <= maxX &&
+    local.y >= minY &&
+    local.y <= maxY
+  );
+}
+
+/**
+ * Return the topmost file-authored shape at a slide point.
+ *
+ * Slide elements are painted in array order, so the hit test walks them in
+ * reverse. Parser-synthesized shapes without a stable `cNvPr@id` are skipped.
+ */
+export function hitTestSlideShape(
+  slideIndex: number,
+  slide: Slide,
+  point: PptxSlidePoint,
+  opts: PptxShapeHitTestOptions = {},
+): PptxShapeHit | null {
+  const tolerance = opts.tolerance ?? 0;
+  for (let index = slide.elements.length - 1; index >= 0; index -= 1) {
+    const element = slide.elements[index]!;
+    if (element.type !== 'shape' || element.id === undefined) continue;
+    if (!hitTestShapeElement(element, point, tolerance)) continue;
+    return {
+      slideIndex,
+      shapeId: element.id,
+      shape: structuredClone(element),
+      point: { ...point },
+    };
+  }
+  return null;
+}

--- a/packages/pptx/src/viewer-shape-click.test.ts
+++ b/packages/pptx/src/viewer-shape-click.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PptxPresentation } from './presentation';
+import {
+  installDom,
+  makeEl,
+  FakePptxEngine,
+  type FakeEl,
+} from './scroll-viewer-test-dom';
+import { PptxViewer, type PptxShapeClickEvent } from './viewer';
+import type { ShapeElement } from './types';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const SLIDE_WIDTH = 9_144_000;
+const SLIDE_HEIGHT = 6_858_000;
+
+async function mountLoaded(onShapeClick: (event: PptxShapeClickEvent) => void) {
+  installDom();
+  const canvas = makeEl('canvas');
+  canvas.clientWidth = 960;
+  canvas.clientHeight = 720;
+  const engine = new FakePptxEngine(1, SLIDE_WIDTH, SLIDE_HEIGHT);
+  engine.shapeHit = {
+    slideIndex: 0,
+    shapeId: '7',
+    shape: { type: 'shape', id: '7' } as unknown as ShapeElement,
+    point: { x: SLIDE_WIDTH / 2, y: SLIDE_HEIGHT / 2 },
+  };
+  vi.spyOn(PptxPresentation, 'load').mockResolvedValue(engine.asPres());
+  const viewer = new PptxViewer(
+    canvas as unknown as HTMLCanvasElement,
+    { onShapeClick },
+  );
+  await viewer.load('x.pptx');
+  return {
+    viewer,
+    engine,
+    canvas,
+    wrapper: canvas.parentElement as FakeEl,
+  };
+}
+
+describe('PptxViewer shape clicks', () => {
+  it('converts wrapper clicks to slide EMU and emits the topmost shape hit', async () => {
+    const onShapeClick = vi.fn<(event: PptxShapeClickEvent) => void>();
+    const { viewer, engine, wrapper } = await mountLoaded(onShapeClick);
+    const nativeEvent = {
+      clientX: 480,
+      clientY: 360,
+      defaultPrevented: false,
+    };
+
+    wrapper.dispatch('click', nativeEvent);
+
+    expect(engine.hitTestCalls).toEqual([{
+      slide: 0,
+      point: { x: SLIDE_WIDTH / 2, y: SLIDE_HEIGHT / 2 },
+      opts: { tolerance: (6 / 960) * SLIDE_WIDTH },
+    }]);
+    expect(onShapeClick).toHaveBeenCalledWith({
+      ...engine.shapeHit,
+      nativeEvent,
+    });
+    viewer.destroy();
+  });
+
+  it('ignores prevented hyperlink clicks and empty-space hits', async () => {
+    const onShapeClick = vi.fn<(event: PptxShapeClickEvent) => void>();
+    const { viewer, engine, wrapper } = await mountLoaded(onShapeClick);
+
+    wrapper.dispatch('click', {
+      clientX: 100,
+      clientY: 100,
+      defaultPrevented: true,
+    });
+    engine.shapeHit = null;
+    wrapper.dispatch('click', {
+      clientX: 100,
+      clientY: 100,
+      defaultPrevented: false,
+    });
+
+    expect(engine.hitTestCalls).toHaveLength(1);
+    expect(onShapeClick).not.toHaveBeenCalled();
+    viewer.destroy();
+  });
+
+  it('removes its stable click listener on destroy', async () => {
+    const onShapeClick = vi.fn<(event: PptxShapeClickEvent) => void>();
+    const { viewer, engine, wrapper } = await mountLoaded(onShapeClick);
+
+    viewer.destroy();
+    wrapper.dispatch('click', {
+      clientX: 480,
+      clientY: 360,
+      defaultPrevented: false,
+    });
+
+    expect(engine.hitTestCalls).toEqual([]);
+    expect(onShapeClick).not.toHaveBeenCalled();
+  });
+
+  it('rejects shape click wiring in worker mode', () => {
+    installDom();
+    const canvas = makeEl('canvas');
+    expect(() =>
+      new PptxViewer(
+        canvas as unknown as HTMLCanvasElement,
+        {
+          mode: 'worker',
+          onShapeClick: () => {},
+        },
+      ),
+    ).toThrow(/onShapeClick.*mode.*main/i);
+  });
+});

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -4,6 +4,7 @@ import { buildPptxHighlightLayer, type PptxHighlightMatch } from './find-highlig
 import { PptxFindController, type PptxMatchLocation } from './find';
 import { PptxPresentation, type LoadOptions } from './presentation';
 import type { PresentationHandle } from './presentation-handle';
+import type { PptxShapeHit } from './shape-hit-test';
 import { nextVisibleIndex, resolveVisibleIndex, countVisible } from './hidden';
 import type { DimOptions } from './types';
 import {
@@ -21,6 +22,11 @@ import {
 
 /** How {@link PptxViewer} presents hidden slides (`<p:sld show="0">`). */
 export type HiddenSlideMode = 'show' | 'skip' | 'dim';
+
+/** Shape click emitted by {@link PptxViewerOptions.onShapeClick}. */
+export interface PptxShapeClickEvent extends PptxShapeHit {
+  nativeEvent: MouseEvent;
+}
 
 /** Default `'dim'` overlay: 60% white (hidden content shows at 40%). */
 const DEFAULT_HIDDEN_DIM: DimOptions = { color: '#ffffff', opacity: 0.6 };
@@ -83,6 +89,12 @@ export interface PptxViewerOptions extends RenderOptions, LoadOptions {
    * viewer calls this instead and takes NO default action.
    */
   onHyperlinkClick?: (target: HyperlinkTarget) => void;
+  /**
+   * Fires when the topmost identified ShapeElement is clicked. The callback
+   * receives a detached shape snapshot and slide-local `shapeId`. Main mode
+   * only.
+   */
+  onShapeClick?: (event: PptxShapeClickEvent) => void;
   /** IX1 — master switch for hyperlink interactivity. Default `true`. When
    *  `false`, the hyperlink machinery is not wired at all: the overlay's link
    *  spans are non-interactive, so there is no pointer cursor, no title tooltip,
@@ -147,6 +159,10 @@ export class PptxViewer implements ZoomableViewer {
    *  to an `onError` / `console.error` on a dead viewer — parity with the scroll
    *  viewers' `_destroyed` flag. */
   private _destroyed = false;
+  /** Stable listener identity so destroy() can remove it from the wrapper. */
+  private readonly _shapeClickListener = (event: Event): void => {
+    this._onShapeClick(event as MouseEvent);
+  };
   /**
    * Concurrent-load latch (generation token). Every {@link load} increments this
    * and captures the value; after its engine finishes loading it re-checks the
@@ -168,6 +184,9 @@ export class PptxViewer implements ZoomableViewer {
     this.canvas = canvas;
     this._mode = opts.mode ?? 'main';
     this._hiddenMode = opts.hiddenSlideMode ?? 'show';
+    if (opts.onShapeClick && this._mode !== 'main') {
+      throw new Error('PptxViewer.onShapeClick requires mode: "main"');
+    }
 
     const parent = canvas.parentElement;
     // Capture the canvas's DOM position and inline display BEFORE reparenting so
@@ -187,6 +206,12 @@ export class PptxViewer implements ZoomableViewer {
     if (!canvas.style.display) canvas.style.display = 'block';
     if (parent) parent.insertBefore(this.wrapper, canvas);
     this.wrapper.appendChild(canvas);
+    if (opts.onShapeClick) {
+      // Listen on the wrapper rather than only the canvas: selectable text spans
+      // live in an overlay above the canvas and bubble their ordinary clicks
+      // here. Hyperlink spans call preventDefault(), so they are ignored below.
+      this.wrapper.addEventListener('click', this._shapeClickListener);
+    }
 
     // Static worker-mode rendering paints worker-produced bitmaps via a
     // bitmaprenderer context (grabbed once — a canvas holds one context type for
@@ -659,6 +684,36 @@ export class PptxViewer implements ZoomableViewer {
     if (enriched.slideIndex !== undefined) void this.goToSlide(enriched.slideIndex);
   }
 
+  /** Convert a wrapper click to slide EMU and dispatch the topmost shape hit. */
+  private _onShapeClick(event: MouseEvent): void {
+    if (
+      this._destroyed ||
+      event.defaultPrevented ||
+      !this.engine ||
+      !this.opts.onShapeClick
+    ) {
+      return;
+    }
+    const rect = this.canvas.getBoundingClientRect();
+    if (
+      !(rect.width > 0) ||
+      !(rect.height > 0) ||
+      !Number.isFinite(event.clientX) ||
+      !Number.isFinite(event.clientY)
+    ) {
+      return;
+    }
+    const point = {
+      x: ((event.clientX - rect.left) / rect.width) * this.engine.slideWidth,
+      y: ((event.clientY - rect.top) / rect.height) * this.engine.slideHeight,
+    };
+    const hit = this.engine.hitTestShape(this.currentSlide, point, {
+      // Six CSS pixels keeps thin connectors selectable at every zoom level.
+      tolerance: (6 / rect.width) * this.engine.slideWidth,
+    });
+    if (hit) this.opts.onShapeClick({ ...hit, nativeEvent: event });
+  }
+
   /** Populate an internal {@link HyperlinkTarget}'s `slideIndex` from its `ref`
    *  (a `ppaction://hlinkshowjump?jump=…` verb resolved relative to the current
    *  slide, or a `../slides/slideN.xml` part target resolved through the stamped
@@ -698,6 +753,7 @@ export class PptxViewer implements ZoomableViewer {
     // cleaned up rather than installed onto a torn-down viewer.
     this._destroyed = true;
     this._loadGen++;
+    this.wrapper.removeEventListener('click', this._shapeClickListener);
     this.handle?.destroy();
     this.handle = null;
     this.engine?.destroy();

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -72,6 +72,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         ON_SCALE_CHANGE,
         ON_HYPERLINK_CLICK,
         ENABLE_HYPERLINKS,
+        { name: 'onShapeClick', type: '(event: PptxShapeClickEvent) => void', desc: 'Called with the topmost identified shape under a click. Includes the slide-local shapeId, a detached ShapeElement snapshot, slide coordinates, and the native MouseEvent. Requires `mode: "main"`.' },
         { name: 'onSlideChange', type: '(index: number, total: number) => void', desc: 'Called after a slide finishes rendering.' },
         { name: 'onError', type: '(err: Error) => void', desc: 'Called on parse or render errors.' },
       ],
@@ -100,6 +101,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       methods: [
         { sig: 'static load(source, options?): Promise<PptxPresentation>', desc: 'Parse a deck from a URL or ArrayBuffer.' },
         { sig: 'get slideCount(): number', desc: 'Total slides.' },
+        { sig: 'hitTestShape(slideIndex, point, opts?): PptxShapeHit | null', desc: 'Return the topmost identified ShapeElement at a slide-EMU point in `mode: "main"`. The result contains the slide-local shapeId and a detached shape snapshot; opts.tolerance expands straight-line and connector hits.' },
         { sig: 'renderSlide(canvas, index, opts?: { width?, dpr?, onTextRun?, dim? }): Promise<void>', desc: 'Render one slide into the given canvas at the given width. `onTextRun` is called per rendered text segment so a caller can build a transparent selection overlay; `dim` (a DimOptions) paints a translucent wash over the finished slide (hidden-slide dimming). Equations render when a `math` engine was passed to `load`. Unavailable in `mode: "worker"` — use renderSlideToBitmap.' },
         { sig: 'renderSlideToBitmap(index, opts?: { width?, dpr?, dim? }): Promise<ImageBitmap>', desc: 'Render one slide and return it as an ImageBitmap (both modes; in worker mode the render runs off the main thread). `dim` paints a translucent overlay over the slide (hidden-slide dimming). Equations are skipped in `mode: "worker"` (they require `mode: "main"`). The bitmap is caller-owned: pass it to `transferFromImageBitmap` (which consumes it) or call `bitmap.close()`.' },
         { sig: 'presentSlide(canvas, index, opts?: { width?, dpr?, onTextRun? }): Promise<PresentationHandle>', desc: 'Render a slide and attach canvas-native audio/video playback, returning a handle with play() / pause() / destroy(). Works in both modes — in `mode: "worker"` the base slide is rendered off the main thread and the video overlay is composited on the main thread; `onTextRun` is unavailable there (it cannot cross the worker boundary).' },


### PR DESCRIPTION
## Summary

- add main-mode `PptxPresentation.hitTestShape()` model-backed shape hit testing
- add `PptxViewer.onShapeClick` with slide-local shape IDs and detached shape snapshots
- account for rotation, flips, reverse paint order, and configurable straight-line tolerance
- keep hit testing independent of renderer callbacks and pixel output

## API

```ts
const viewer = new PptxViewer(canvas, {
  onShapeClick({ slideIndex, shapeId, shape, point, nativeEvent }) {
    console.log(slideIndex, shapeId, shape, point, nativeEvent);
  },
});
```

Headless canvas integrations can convert client coordinates to slide EMU and
call the same model-backed hit test:

```ts
const hit = presentation.hitTestShape(slideIndex, point, {
  tolerance: lineToleranceInEmu,
});
```

## Behavior

- walks slide elements in reverse paint order and returns the topmost identified `ShapeElement`
- inverse-transforms the point for rotated and flipped shape frames
- uses segment distance plus caller-provided tolerance for straight lines and connectors
- ignores parser-synthesized shapes without a stable DrawingML `cNvPr@id`
- returns a detached shape snapshot instead of exposing the live presentation model
- listens on the viewer wrapper so selectable text-overlay clicks still reach shape hit testing
- ignores prevented hyperlink clicks
- requires `mode: "main"` because worker mode does not retain the parsed model on the viewer thread

## Scope

This PR does not modify the PPTX renderer or introduce shape mutation APIs.

## Validation

- `vitest run packages/pptx/src` (75 files, 490 tests)
- `tsc --build --pretty false`
- PPTX Vite production and declaration builds
- `ast-grep scan` (passes with existing warnings)
- `git diff --check`
