### PR TITLE
fix(docx): align retained vertical glyph and list geometry

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -413,6 +413,7 @@ export {
   measureVerticalVertGlyph,
   verticalVertGlyphReachable,
   withVertFeature,
+  withVertFeatureCanvasScope,
 } from './text/vertical-vert-feature';
 export type { VerticalGlyphCellMetrics } from './text/vertical-vert-feature';
 // Shared Excel serial-date → UTC `Date` conversion (ECMA-376 §18.17.4.1),

--- a/packages/core/src/text/vertical-vert-feature.test.ts
+++ b/packages/core/src/text/vertical-vert-feature.test.ts
@@ -335,6 +335,18 @@ describe('vertical OpenType vert feature', () => {
     ]);
   });
 
+  it('briefly connects a detached element so measurement and paint resolve the same feature', () => {
+    const fixture = fakeHtmlCanvasProbe();
+    const canvas = fixture.ctx.canvas as HTMLCanvasElement;
+    expect(canvas.isConnected).toBe(false);
+
+    withVertFeature(fixture.ctx, () => {
+      expect(canvas.isConnected).toBe(true);
+    });
+
+    expect(canvas.isConnected).toBe(false);
+  });
+
   it('preserves computed features while restoring the exact inline value', () => {
     let font = '16px serif';
     const style = { fontFeatureSettings: '' };

--- a/packages/core/src/text/vertical-vert-feature.ts
+++ b/packages/core/src/text/vertical-vert-feature.ts
@@ -25,8 +25,17 @@ export interface VerticalGlyphCellMetrics {
 }
 
 function canvasElementFor(ctx: Ctx2D): HTMLCanvasElement | null {
-  if (typeof HTMLCanvasElement === 'undefined') return null;
-  return ctx.canvas instanceof HTMLCanvasElement ? ctx.canvas : null;
+  const candidate = ctx.canvas as HTMLCanvasElement;
+  const ownerConstructor = candidate?.ownerDocument?.defaultView?.HTMLCanvasElement;
+  if (
+    typeof ownerConstructor === 'function'
+    && candidate instanceof ownerConstructor
+  ) return candidate;
+  if (
+    typeof HTMLCanvasElement !== 'undefined'
+    && candidate instanceof HTMLCanvasElement
+  ) return candidate;
+  return null;
 }
 
 function replaceFontSize(font: string, replacement: string): string {
@@ -99,16 +108,52 @@ function withConnectedCanvas<T>(
     pointerEvents: 'none',
   });
   connectedParent.appendChild(canvas);
+  let operationThrew = false;
   try {
     return operation();
+  } catch (error) {
+    operationThrew = true;
+    throw error;
   } finally {
-    if (originalParent) {
-      originalParent.insertBefore(canvas, originalNextSibling);
-    } else {
-      canvas.remove();
+    let treeRestoreError: unknown;
+    try {
+      if (originalParent) {
+        const liveAnchor = originalNextSibling?.parentNode === originalParent
+          ? originalNextSibling
+          : null;
+        originalParent.insertBefore(canvas, liveAnchor);
+      } else {
+        canvas.remove();
+      }
+    } catch (error) {
+      treeRestoreError = error;
+      // If the caller changed the original tree beyond repair, do not leave a
+      // hidden caller-owned canvas attached to the acquisition document.
+      try {
+        canvas.remove();
+      } catch {
+        // Presentation restoration below remains mandatory.
+      }
+    } finally {
+      Object.assign(style, previousPresentation);
     }
-    Object.assign(style, previousPresentation);
+    // Preserve the callback's primary failure. A restoration error is surfaced
+    // only when the callback itself completed successfully.
+    if (treeRestoreError !== undefined && !operationThrew) throw treeRestoreError;
   }
+}
+
+/**
+ * Keep an element-backed context connected for one synchronous vertical-glyph
+ * acquisition unit. Inner feature toggles then use their already-connected
+ * fast path, while detached and Offscreen callers retain their ownership.
+ */
+export function withVertFeatureCanvasScope<T>(
+  ctx: Ctx2D,
+  operation: () => T,
+): T {
+  const canvas = canvasElementFor(ctx);
+  return canvas === null ? operation() : withConnectedCanvas(canvas, operation);
 }
 
 function probeState(doc: Document): ProbeState {
@@ -301,9 +346,7 @@ export function withVertFeature<T>(ctx: Ctx2D, draw: () => T): T {
       ctx.font = ctx.font;
     }
   };
-  return canvasElementFor(ctx) === null
-    ? applyFeature()
-    : withConnectedCanvas(canvas, applyFeature);
+  return withVertFeatureCanvasScope(ctx, applyFeature);
 }
 
 /**

--- a/packages/core/src/text/vertical-vert-feature.ts
+++ b/packages/core/src/text/vertical-vert-feature.ts
@@ -63,6 +63,54 @@ function sourceFeatureSettings(target: HTMLCanvasElement): string {
   return target.style.fontFeatureSettings;
 }
 
+/**
+ * Chromium only resolves Canvas OpenType feature metrics while the backing
+ * element participates in a document. Layout normally owns a detached canvas,
+ * whereas paint uses an attached surface, so feature measurement must briefly
+ * acquire the same DOM capability. Restore both the caller's tree position and
+ * inline presentation exactly; the canvas remains caller-owned.
+ */
+function withConnectedCanvas<T>(
+  canvas: HTMLCanvasElement,
+  operation: () => T,
+): T {
+  if (canvas.isConnected) return operation();
+
+  const doc = canvas.ownerDocument
+    ?? (typeof document === 'undefined' ? null : document);
+  const connectedParent = doc?.body ?? doc?.documentElement;
+  if (!connectedParent) return operation();
+
+  const originalParent = canvas.parentNode;
+  const originalNextSibling = canvas.nextSibling;
+  const style = canvas.style;
+  const previousPresentation = {
+    position: style.position,
+    left: style.left,
+    top: style.top,
+    opacity: style.opacity,
+    pointerEvents: style.pointerEvents,
+  };
+  Object.assign(style, {
+    position: 'fixed',
+    left: '-99999px',
+    top: '0',
+    opacity: '0',
+    pointerEvents: 'none',
+  });
+  connectedParent.appendChild(canvas);
+  try {
+    return operation();
+  } finally {
+    if (originalParent) {
+      originalParent.insertBefore(canvas, originalNextSibling);
+    } else {
+      canvas.remove();
+    }
+    Object.assign(style, previousPresentation);
+  }
+}
+
 function probeState(doc: Document): ProbeState {
   const existing = probeStates.get(doc);
   if (existing) return existing;
@@ -239,18 +287,23 @@ export function verticalVertGlyphReachable(ctx: Ctx2D, cp: number): boolean {
 /** Compose `vert` onto the element features, refont, draw, then restore exactly. */
 export function withVertFeature<T>(ctx: Ctx2D, draw: () => T): T {
   const canvas = ctx.canvas as HTMLCanvasElement;
-  const style = canvas?.style;
-  if (!style) return draw();
+  if (!canvas?.style) return draw();
 
-  const previous = style.fontFeatureSettings;
-  style.fontFeatureSettings = composeVertFeature(sourceFeatureSettings(canvas));
-  ctx.font = ctx.font;
-  try {
-    return draw();
-  } finally {
-    style.fontFeatureSettings = previous;
+  const applyFeature = () => {
+    const style = canvas.style;
+    const previous = style.fontFeatureSettings;
+    style.fontFeatureSettings = composeVertFeature(sourceFeatureSettings(canvas));
     ctx.font = ctx.font;
-  }
+    try {
+      return draw();
+    } finally {
+      style.fontFeatureSettings = previous;
+      ctx.font = ctx.font;
+    }
+  };
+  return canvasElementFor(ctx) === null
+    ? applyFeature()
+    : withConnectedCanvas(canvas, applyFeature);
 }
 
 /**

--- a/packages/docx/parser/src/numbering.rs
+++ b/packages/docx/parser/src/numbering.rs
@@ -27,6 +27,10 @@ pub struct LevelDef {
     pub format: String,   // "decimal" | "bullet" | etc.
     pub text: String,     // lvlText val, e.g. "%1." or "•"
     pub indent_left: f64, // pt — w:ind@left ≡ logical START indent (§17.3.1.12)
+    /// Whether `indent_left` came from this level's authored `w:ind@left`.
+    /// False means the value is only the legacy depth fallback used when no
+    /// lower style layer supplies an indent.
+    pub indent_left_authored: bool,
     /// pt — w:ind@right ≡ logical END indent (Part 4 §14.11.2). RTL list levels
     /// carry their indent here (the renderer maps it to the physical left side).
     pub indent_right: Option<f64>,
@@ -34,6 +38,8 @@ pub struct LevelDef {
     /// marker hangs left of the body), `w:firstLine` ⇒ positive (an additional
     /// first-line indent). Mirrors how `styles.rs` stores a direct `w:ind`.
     pub indent_first: f64,
+    /// Whether `indent_first` came from authored `w:hanging` / `w:firstLine`.
+    pub indent_first_authored: bool,
     /// pt — POSITIVE magnitude of the first-line indent (= `indent_first.abs()`).
     /// Distinct from `indent_first` because the renderer uses it as the marker's
     /// tab-advance distance (§17.9.6 + §17.3.1.38, suff=tab), which is unsigned.
@@ -99,8 +105,10 @@ impl Default for LevelDef {
             format: "decimal".to_string(),
             text: "%1.".to_string(),
             indent_left: 36.0,
+            indent_left_authored: false,
             indent_right: None,
             indent_first: -36.0,
+            indent_first_authored: false,
             tab: 36.0,
             suff: "tab".to_string(),
             lvl_jc: "left".to_string(),
@@ -185,6 +193,7 @@ fn parse_level_def(
     // start indent from this source" (an RTL level carries its
     // indent in @right ≡ end instead); the per-level depth default
     // applies only when no w:ind exists at all.
+    let indent_left_authored = ind_node.and_then(|i| attr_w(i, "left")).is_some();
     let indent_left = ind_node
         .and_then(|i| attr_w(i, "left"))
         .map(|v| twips_to_pt(&v))
@@ -202,6 +211,8 @@ fn parse_level_def(
     // same precedence `styles.rs` applies to a direct `w:ind`. Keep the
     // SIGN in `indent_first`; `tab` keeps the positive magnitude for the
     // marker's tab-advance.
+    let indent_first_authored = ind_node
+        .is_some_and(|i| attr_w(i, "hanging").is_some() || attr_w(i, "firstLine").is_some());
     let indent_first = ind_node
         .and_then(|i| {
             attr_w(i, "hanging")
@@ -237,8 +248,10 @@ fn parse_level_def(
         format,
         text,
         indent_left,
+        indent_left_authored,
         indent_right,
         indent_first,
+        indent_first_authored,
         tab,
         suff,
         lvl_jc,

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3452,9 +3452,11 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
     // Resolve base formatting from style (incl. table-style conditional rPr/pPr).
     let (mut base_para, base_run) =
         style_map.resolve_para_cond(explicit_style_id.as_deref(), table_style_id, cond);
-    let style_indent_left = base_para.indent_left;
-    let style_indent_first = base_para.indent_first;
-    let style_indent_right = base_para.indent_right;
+    let paragraph_style = style_map.resolve_paragraph_style_layer(explicit_style_id.as_deref());
+    let style_indent_left = paragraph_style.indent_left;
+    let style_indent_first = paragraph_style.indent_first;
+    let style_indent_right = paragraph_style.indent_right;
+    let direct_numbering = ppr_node.and_then(|ppr| child_w(ppr, "numPr")).is_some();
 
     // Apply direct paragraph formatting overrides.
     //
@@ -3637,24 +3639,47 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
         .as_ref()
         .and_then(|num| num_map.get_level(num.num_id, num.level));
 
-    // Indent precedence (ECMA-376 §17.7.2 style hierarchy + §17.9.22): the
-    // paragraph's own DIRECT `w:ind` overrides its resolved paragraph STYLE,
-    // which overrides the numbering level's `pPr/ind`. The merge is
-    // per-attribute (§17.3.1.12), so an omitted axis falls through independently.
-    // This matters when a paragraph style associates numbering and also authors
-    // a different hanging band: Word retains the style's band rather than
-    // replacing it with the abstract level's defaults.
+    // Indent precedence (ECMA-376 §17.7.2 style hierarchy + §§17.7.8.1,
+    // 17.9.22) depends on where numPr originated. Style-origin numbering is
+    // applied before the paragraph style; direct numPr and its associated level
+    // properties are part of the final direct-formatting layer. Direct w:ind is
+    // always last. Resolve each axis independently.
+    //
+    // The numbering parser retains a legacy depth fallback for levels without
+    // authored w:ind. That non-normative fallback is used only after every real
+    // style layer, so it cannot overwrite document/table/paragraph formatting.
     // When no level resolves, a de-listed paragraph (numId=0) keeps only its direct
     // ind and a plain paragraph keeps its style/direct (base) ind.
     let (indent_left, indent_first) = if let Some(l) = level {
-        (
-            direct_indent_left
-                .or(style_indent_left)
-                .unwrap_or(l.indent_left),
-            direct_indent_first
-                .or(style_indent_first)
-                .unwrap_or(l.indent_first),
-        )
+        let level_left = l.indent_left_authored.then_some(l.indent_left);
+        let level_first = l.indent_first_authored.then_some(l.indent_first);
+        if direct_numbering {
+            (
+                direct_indent_left
+                    .or(level_left)
+                    .or(style_indent_left)
+                    .or(base_para.indent_left)
+                    .unwrap_or(l.indent_left),
+                direct_indent_first
+                    .or(level_first)
+                    .or(style_indent_first)
+                    .or(base_para.indent_first)
+                    .unwrap_or(l.indent_first),
+            )
+        } else {
+            (
+                direct_indent_left
+                    .or(style_indent_left)
+                    .or(level_left)
+                    .or(base_para.indent_left)
+                    .unwrap_or(l.indent_left),
+                direct_indent_first
+                    .or(style_indent_first)
+                    .or(level_first)
+                    .or(base_para.indent_first)
+                    .unwrap_or(l.indent_first),
+            )
+        }
     } else if base_para.num_id == Some(0) {
         // `numId=0` explicitly removes numbering (ECMA-376 §17.3.1.19 / §17.9.18). That
         // drops the NUMBERING LEVEL's indent (handled by `numbering` being None here).
@@ -3686,7 +3711,17 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
     // indent, else the level's end indent (an RTL list carries its indent there,
     // e.g. w:right="720" w:hanging="360"), else the style/de-list (base) value
     // already resolved into `indent_right` above.
-    let numbered_indent_right = level.and_then(|l| style_indent_right.or(l.indent_right));
+    let numbered_indent_right = level.and_then(|l| {
+        if direct_numbering {
+            l.indent_right
+                .or(style_indent_right)
+                .or(base_para.indent_right)
+        } else {
+            style_indent_right
+                .or(l.indent_right)
+                .or(base_para.indent_right)
+        }
+    });
     let indent_right = direct_indent_right
         .or(numbered_indent_right)
         .unwrap_or(indent_right);
@@ -15427,6 +15462,39 @@ mod footnote_tests {
         panic!("no paragraph parsed");
     }
 
+    fn first_para_with_table_style(
+        body_inner: &str,
+        styles_xml: &str,
+        numbering_xml: &str,
+        table_style_id: &str,
+    ) -> crate::types::DocParagraph {
+        let xml = format!(
+            r#"<w:document xmlns:w="{ns}"><w:body>{inner}</w:body></w:document>"#,
+            ns = W_NS,
+            inner = body_inner,
+        );
+        let doc = XmlDoc::parse(&xml).unwrap();
+        let paragraph_node = doc
+            .root_element()
+            .descendants()
+            .find(|node| node.tag_name().name() == "p")
+            .unwrap();
+        let mut style_map = StyleMap::parse(styles_xml);
+        let mut num_map = NumberingMap::parse(numbering_xml, &HashMap::new());
+        style_map.resolve_numbering_level_backlinks(&num_map);
+        parse_paragraph(
+            paragraph_node,
+            &style_map,
+            &mut num_map,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &ThemeColors::default(),
+            Some(table_style_id),
+            &mut FieldState::default(),
+        )
+    }
+
     /// Like `first_para_with`, but returns EVERY body paragraph (in order) so a
     /// numbering SEQUENCE across several paragraphs can be exercised end-to-end
     /// (the running counter lives in `NumberingMap`, so a single-paragraph helper
@@ -15689,6 +15757,100 @@ mod footnote_tests {
             (paragraph.indent_first + 10.2).abs() < 0.01,
             "style hanging=204 twips must survive the level default, got {}",
             paragraph.indent_first
+        );
+    }
+
+    /// ECMA-376 §17.7.2: when `numPr` is direct formatting, the numbering
+    /// definition and its associated paragraph properties are applied in the
+    /// final direct-formatting layer. Its level indent therefore overrides
+    /// paragraph-style, table-style, and document-default indents independently
+    /// for every authored axis (§17.9.22).
+    #[test]
+    fn direct_numbering_level_indents_override_lower_style_layers() {
+        let numbering = format!(
+            r#"<w:numbering xmlns:w="{ns}">
+              <w:abstractNum w:abstractNumId="21">
+                <w:lvl w:ilvl="0">
+                  <w:start w:val="1"/>
+                  <w:numFmt w:val="bullet"/>
+                  <w:lvlText w:val="•"/>
+                  <w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr>
+                </w:lvl>
+              </w:abstractNum>
+              <w:num w:numId="4"><w:abstractNumId w:val="21"/></w:num>
+            </w:numbering>"#,
+            ns = W_NS
+        );
+        let direct_numbering = r#"<w:p><w:pPr>
+          <w:numPr><w:ilvl w:val="0"/><w:numId w:val="4"/></w:numPr>
+          <w:pBdr>
+            <w:top w:val="single" w:sz="4" w:space="1"/>
+            <w:left w:val="single" w:sz="4" w:space="4"/>
+            <w:bottom w:val="single" w:sz="4" w:space="1"/>
+            <w:right w:val="single" w:sz="4" w:space="4"/>
+          </w:pBdr>
+          <w:ind w:leftChars="0"/>
+        </w:pPr><w:r><w:t>x</w:t></w:r></w:p>"#;
+        let assert_level_indent = |paragraph: crate::types::DocParagraph, layer: &str| {
+            assert!(
+                (paragraph.indent_left - 36.0).abs() < 0.01,
+                "direct numbering level left must override {layer}, got {}",
+                paragraph.indent_left,
+            );
+            assert!(
+                (paragraph.indent_first + 18.0).abs() < 0.01,
+                "direct numbering level hanging must override {layer}, got {}",
+                paragraph.indent_first,
+            );
+        };
+
+        let paragraph_style = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal">
+                <w:name w:val="Normal"/>
+                <w:pPr><w:ind w:left="840" w:hanging="204"/></w:pPr>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        let bordered = first_para_with(direct_numbering, &paragraph_style, &numbering);
+        assert!(
+            bordered.borders.is_some(),
+            "the direct paragraph border must survive the numbering cascade",
+        );
+        assert_level_indent(bordered, "paragraph style");
+
+        let document_defaults = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:docDefaults><w:pPrDefault><w:pPr>
+                <w:ind w:left="100" w:hanging="200"/>
+              </w:pPr></w:pPrDefault></w:docDefaults>
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal">
+                <w:name w:val="Normal"/>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        assert_level_indent(
+            first_para_with(direct_numbering, &document_defaults, &numbering),
+            "document defaults",
+        );
+
+        let table_style = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal">
+                <w:name w:val="Normal"/>
+              </w:style>
+              <w:style w:type="table" w:styleId="Box">
+                <w:name w:val="Box"/>
+                <w:pPr><w:ind w:left="100" w:hanging="200"/></w:pPr>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        assert_level_indent(
+            first_para_with_table_style(direct_numbering, &table_style, &numbering, "Box"),
+            "table style",
         );
     }
 

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -3452,6 +3452,9 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
     // Resolve base formatting from style (incl. table-style conditional rPr/pPr).
     let (mut base_para, base_run) =
         style_map.resolve_para_cond(explicit_style_id.as_deref(), table_style_id, cond);
+    let style_indent_left = base_para.indent_left;
+    let style_indent_first = base_para.indent_first;
+    let style_indent_right = base_para.indent_right;
 
     // Apply direct paragraph formatting overrides.
     //
@@ -3634,20 +3637,23 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
         .as_ref()
         .and_then(|num| num_map.get_level(num.num_id, num.level));
 
-    // Indent precedence (ECMA-376 §17.9.22 + §17.7.2): the paragraph's own DIRECT
-    // `w:ind` overrides the numbering level's `pPr/ind` ("paragraph properties
-    // specified on the numbered paragraph itself override the paragraph properties
-    // specified by pPr elements within a numbering lvl element"), which in turn
-    // overrides the paragraph STYLE. The merge is per-attribute (§17.3.1.12), so a
-    // direct `w:left` that omits `w:hanging`/`w:firstLine` keeps the level's
-    // first-line indent — e.g. sample-15's REFERENCES list: level ind left=720
-    // hanging=360, direct `w:ind w:left="360"` ⇒ body at 18 pt, marker at the margin.
+    // Indent precedence (ECMA-376 §17.7.2 style hierarchy + §17.9.22): the
+    // paragraph's own DIRECT `w:ind` overrides its resolved paragraph STYLE,
+    // which overrides the numbering level's `pPr/ind`. The merge is
+    // per-attribute (§17.3.1.12), so an omitted axis falls through independently.
+    // This matters when a paragraph style associates numbering and also authors
+    // a different hanging band: Word retains the style's band rather than
+    // replacing it with the abstract level's defaults.
     // When no level resolves, a de-listed paragraph (numId=0) keeps only its direct
     // ind and a plain paragraph keeps its style/direct (base) ind.
     let (indent_left, indent_first) = if let Some(l) = level {
         (
-            direct_indent_left.unwrap_or(l.indent_left),
-            direct_indent_first.unwrap_or(l.indent_first),
+            direct_indent_left
+                .or(style_indent_left)
+                .unwrap_or(l.indent_left),
+            direct_indent_first
+                .or(style_indent_first)
+                .unwrap_or(l.indent_first),
         )
     } else if base_para.num_id == Some(0) {
         // `numId=0` explicitly removes numbering (ECMA-376 §17.3.1.19 / §17.9.18). That
@@ -3680,8 +3686,9 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
     // indent, else the level's end indent (an RTL list carries its indent there,
     // e.g. w:right="720" w:hanging="360"), else the style/de-list (base) value
     // already resolved into `indent_right` above.
+    let numbered_indent_right = level.and_then(|l| style_indent_right.or(l.indent_right));
     let indent_right = direct_indent_right
-        .or_else(|| level.and_then(|l| l.indent_right))
+        .or(numbered_indent_right)
         .unwrap_or(indent_right);
 
     // Parse runs
@@ -8584,8 +8591,14 @@ fn extract_simple_paragraph_text(
         .and_then(|num| num_map.get_level(num.num_id, num.level));
     let (indent_left, indent_first) = if let Some(l) = level {
         (
-            direct_ind.indent_left.unwrap_or(l.indent_left),
-            direct_ind.indent_first.unwrap_or(l.indent_first),
+            direct_ind
+                .indent_left
+                .or(style_para.indent_left)
+                .unwrap_or(l.indent_left),
+            direct_ind
+                .indent_first
+                .or(style_para.indent_first)
+                .unwrap_or(l.indent_first),
         )
     } else {
         (
@@ -8601,8 +8614,8 @@ fn extract_simple_paragraph_text(
     };
     let indent_right = direct_ind
         .indent_right
-        .or_else(|| level.and_then(|l| l.indent_right))
         .or(style_para.indent_right)
+        .or_else(|| level.and_then(|l| l.indent_right))
         .unwrap_or(0.0);
 
     // ECMA-376 §17.3.1.33 — the txbxContent paragraph's own `<w:spacing>` is
@@ -15627,10 +15640,61 @@ mod footnote_tests {
         );
     }
 
+    /// ECMA-376 §17.7.2 — paragraph-style properties are retained when the
+    /// style also associates a numbering definition. A level's generic `pPr`
+    /// supplies missing axes; it does not replace a style-authored hanging band.
+    #[test]
+    fn numbered_para_style_ind_overrides_numbering_level_per_attribute() {
+        let styles = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+              <w:style w:type="paragraph" w:styleId="BulletStyle">
+                <w:name w:val="Bullet Style"/>
+                <w:basedOn w:val="Normal"/>
+                <w:pPr>
+                  <w:numPr><w:numId w:val="4"/></w:numPr>
+                  <w:ind w:left="408" w:hanging="204"/>
+                </w:pPr>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS
+        );
+        let numbering = format!(
+            r#"<w:numbering xmlns:w="{ns}">
+              <w:abstractNum w:abstractNumId="21">
+                <w:lvl w:ilvl="0">
+                  <w:start w:val="1"/>
+                  <w:numFmt w:val="bullet"/>
+                  <w:lvlText w:val="•"/>
+                  <w:pPr><w:ind w:left="360" w:hanging="360"/></w:pPr>
+                </w:lvl>
+              </w:abstractNum>
+              <w:num w:numId="4"><w:abstractNumId w:val="21"/></w:num>
+            </w:numbering>"#,
+            ns = W_NS
+        );
+
+        let paragraph = first_para_with(
+            r#"<w:p><w:pPr><w:pStyle w:val="BulletStyle"/></w:pPr><w:r><w:t>x</w:t></w:r></w:p>"#,
+            &styles,
+            &numbering,
+        );
+
+        assert!(
+            (paragraph.indent_left - 20.4).abs() < 0.01,
+            "style left=408 twips must survive the level default, got {}",
+            paragraph.indent_left
+        );
+        assert!(
+            (paragraph.indent_first + 10.2).abs() < 0.01,
+            "style hanging=204 twips must survive the level default, got {}",
+            paragraph.indent_first
+        );
+    }
+
     /// ECMA-376 §17.7.2 (property precedence) — a paragraph's own DIRECT `w:ind`
     /// overrides the numbering level's `w:ind`. Direct formatting is more specific
-    /// than the numbering definition, which in turn overrides the paragraph style
-    /// (Control A in `numid_zero_drops_inherited_list_indent`). The merge is
+    /// than the paragraph style and numbering definition. The merge is
     /// per-attribute: a direct `w:left` that omits `w:hanging` keeps the level's
     /// hanging. sample-15's REFERENCES list proves it — numbering level
     /// `ind left=720 hanging=360`, but each item carries a direct `<w:ind w:left="360"/>`;

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -14,10 +14,10 @@ use roxmltree::Document as XmlDoc;
 use std::collections::{BTreeMap, HashMap};
 use zip::ZipArchive;
 
-use crate::numbering::NumberingMap;
+use crate::numbering::{LevelDef, NumberingMap};
 use crate::styles::{
     apply_para, apply_run, merge_cond_layers, merge_tab_stops, merge_table_margin_layer,
-    parse_para_fmt, parse_run_fmt, CondFmt, EdgeBorder, RawTblBorders, RunFmt, StyleMap,
+    parse_para_fmt, parse_run_fmt, CondFmt, EdgeBorder, ParaFmt, RawTblBorders, RunFmt, StyleMap,
 };
 use crate::types::*;
 use crate::xml_util::*;
@@ -3427,6 +3427,68 @@ fn parse_paragraph_cond_at_depth(
     )
 }
 
+/// Resolve the three paragraph-indent axes when a numbering level is active.
+///
+/// ECMA-376 §§17.7.2, 17.7.8.1 and 17.9.22 place style-origin numbering below
+/// the paragraph style, but place directly selected numbering and its associated
+/// level properties in the final direct-formatting layer. A direct `w:ind`
+/// remains highest in both cases. Keeping this cascade shared prevents the body
+/// paragraph and the stable text-box legacy projection from drifting apart.
+fn resolve_numbered_indent_axes(
+    direct: &ParaFmt,
+    paragraph_style: &ParaFmt,
+    lower_layers: &ParaFmt,
+    level: &LevelDef,
+    direct_numbering: bool,
+) -> (f64, f64, f64) {
+    let level_left = level.indent_left_authored.then_some(level.indent_left);
+    let level_first = level.indent_first_authored.then_some(level.indent_first);
+
+    if direct_numbering {
+        (
+            direct
+                .indent_left
+                .or(level_left)
+                .or(paragraph_style.indent_left)
+                .or(lower_layers.indent_left)
+                .unwrap_or(level.indent_left),
+            direct
+                .indent_first
+                .or(level_first)
+                .or(paragraph_style.indent_first)
+                .or(lower_layers.indent_first)
+                .unwrap_or(level.indent_first),
+            direct
+                .indent_right
+                .or(level.indent_right)
+                .or(paragraph_style.indent_right)
+                .or(lower_layers.indent_right)
+                .unwrap_or(0.0),
+        )
+    } else {
+        (
+            direct
+                .indent_left
+                .or(paragraph_style.indent_left)
+                .or(level_left)
+                .or(lower_layers.indent_left)
+                .unwrap_or(level.indent_left),
+            direct
+                .indent_first
+                .or(paragraph_style.indent_first)
+                .or(level_first)
+                .or(lower_layers.indent_first)
+                .unwrap_or(level.indent_first),
+            direct
+                .indent_right
+                .or(paragraph_style.indent_right)
+                .or(level.indent_right)
+                .or(lower_layers.indent_right)
+                .unwrap_or(0.0),
+        )
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn parse_paragraph_cond_at_depth_with_diagnostics(
     node: roxmltree::Node,
@@ -3453,9 +3515,6 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
     let (mut base_para, base_run) =
         style_map.resolve_para_cond(explicit_style_id.as_deref(), table_style_id, cond);
     let paragraph_style = style_map.resolve_paragraph_style_layer(explicit_style_id.as_deref());
-    let style_indent_left = paragraph_style.indent_left;
-    let style_indent_first = paragraph_style.indent_first;
-    let style_indent_right = paragraph_style.indent_right;
     let direct_numbering = ppr_node.and_then(|ppr| child_w(ppr, "numPr")).is_some();
 
     // Apply direct paragraph formatting overrides.
@@ -3478,20 +3537,17 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
     // indent is honored even when numbering is removed (the numId=0 case below); an
     // inherited indent is not. Captured for all three axes (start/end/first-line) so the
     // de-list drop is symmetric for LTR and RTL.
-    let mut direct_indent_left: Option<f64> = None;
-    let mut direct_indent_first: Option<f64> = None;
-    let mut direct_indent_right: Option<f64> = None;
+    let direct_para = ppr_node.map(parse_para_fmt).unwrap_or_default();
+    let direct_indent_left = direct_para.indent_left;
+    let direct_indent_first = direct_para.indent_first;
+    let direct_indent_right = direct_para.indent_right;
     if let Some(ppr) = ppr_node {
-        let direct = parse_para_fmt(ppr);
-        direct_indent_left = direct.indent_left;
-        direct_indent_first = direct.indent_first;
-        direct_indent_right = direct.indent_right;
         // Layer the paragraph's DIRECT pPr over its resolved style. Reuse the
         // canonical style-cascade merge (`apply_para`) so the two paths can never
         // drift: an earlier hand-written copy here omitted para_borders / shading /
         // pageBreakBefore / contextualSpacing / keepNext / keepLines / widowControl,
         // dropping every DIRECT pBdr (sample-14's full-width references rule).
-        apply_para(&mut base_para, &direct);
+        apply_para(&mut base_para, &direct_para);
         if let Some(rpr) = child_w(ppr, "rPr") {
             let direct_run = parse_run_fmt(rpr);
             apply_direct_run(&mut mark_run, &direct_run);
@@ -3507,7 +3563,7 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
     // A de-listed paragraph (numId=0, see the indent_left/first resolution below) drops
     // its inherited END indent too, honoring only a direct one — symmetric with the
     // start side so an RTL list item de-lists consistently.
-    let indent_right = if base_para.num_id == Some(0) {
+    let fallback_indent_right = if base_para.num_id == Some(0) {
         direct_indent_right.unwrap_or(0.0)
     } else {
         base_para.indent_right.unwrap_or(0.0)
@@ -3650,36 +3706,14 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
     // style layer, so it cannot overwrite document/table/paragraph formatting.
     // When no level resolves, a de-listed paragraph (numId=0) keeps only its direct
     // ind and a plain paragraph keeps its style/direct (base) ind.
-    let (indent_left, indent_first) = if let Some(l) = level {
-        let level_left = l.indent_left_authored.then_some(l.indent_left);
-        let level_first = l.indent_first_authored.then_some(l.indent_first);
-        if direct_numbering {
-            (
-                direct_indent_left
-                    .or(level_left)
-                    .or(style_indent_left)
-                    .or(base_para.indent_left)
-                    .unwrap_or(l.indent_left),
-                direct_indent_first
-                    .or(level_first)
-                    .or(style_indent_first)
-                    .or(base_para.indent_first)
-                    .unwrap_or(l.indent_first),
-            )
-        } else {
-            (
-                direct_indent_left
-                    .or(style_indent_left)
-                    .or(level_left)
-                    .or(base_para.indent_left)
-                    .unwrap_or(l.indent_left),
-                direct_indent_first
-                    .or(style_indent_first)
-                    .or(level_first)
-                    .or(base_para.indent_first)
-                    .unwrap_or(l.indent_first),
-            )
-        }
+    let (indent_left, indent_first, indent_right) = if let Some(l) = level {
+        resolve_numbered_indent_axes(
+            &direct_para,
+            &paragraph_style,
+            &base_para,
+            l,
+            direct_numbering,
+        )
     } else if base_para.num_id == Some(0) {
         // `numId=0` explicitly removes numbering (ECMA-376 §17.3.1.19 / §17.9.18). That
         // drops the NUMBERING LEVEL's indent (handled by `numbering` being None here).
@@ -3700,31 +3734,15 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
         (
             direct_indent_left.unwrap_or(0.0),
             direct_indent_first.unwrap_or(0.0),
+            direct_indent_right.unwrap_or(0.0),
         )
     } else {
         (
             base_para.indent_left.unwrap_or(0.0),
             base_para.indent_first.unwrap_or(0.0),
+            fallback_indent_right,
         )
     };
-    // The end-side axis (w:ind@right ≡ end) follows the same ladder: direct end
-    // indent, else the level's end indent (an RTL list carries its indent there,
-    // e.g. w:right="720" w:hanging="360"), else the style/de-list (base) value
-    // already resolved into `indent_right` above.
-    let numbered_indent_right = level.and_then(|l| {
-        if direct_numbering {
-            l.indent_right
-                .or(style_indent_right)
-                .or(base_para.indent_right)
-        } else {
-            style_indent_right
-                .or(l.indent_right)
-                .or(base_para.indent_right)
-        }
-    });
-    let indent_right = direct_indent_right
-        .or(numbered_indent_right)
-        .unwrap_or(indent_right);
 
     // Parse runs
     let mut runs = vec![];
@@ -8272,13 +8290,16 @@ fn extract_simple_paragraph_text(
             .or_else(|| theme.default_east_asia_font_ref())
     };
 
-    let style_id = child_w(p, "pPr")
+    let ppr_node = child_w(p, "pPr");
+    let style_id = ppr_node
         .and_then(|ppr| child_w(ppr, "pStyle"))
         .and_then(|s| attr_w(s, "val"));
     // ECMA-376 §17.7.2 — resolve the paragraph style chain once. The
     // paragraph half feeds layout below; the run half is the docDefaults +
     // paragraph-style rPr baseline for every run in this paragraph.
     let (style_para, base_run) = style_map.resolve_para(style_id.as_deref(), None);
+    let paragraph_style = style_map.resolve_paragraph_style_layer(style_id.as_deref());
+    let direct_numbering = ppr_node.and_then(|ppr| child_w(ppr, "numPr")).is_some();
     let resolve_run_fmt = |rpr_node: Option<roxmltree::Node>| -> RunFmt {
         let mut fmt = base_run.clone();
         if let Some(rpr) = rpr_node {
@@ -8531,7 +8552,7 @@ fn extract_simple_paragraph_text(
     // as the docx BODY renderer does (Word honors a signed hanging first-line
     // list-independently), unlike the pptx/xlsx shape paths which clamp because
     // they have no list marker to hang.
-    let direct_ind = child_w(p, "pPr").map(parse_para_fmt).unwrap_or_default();
+    let direct_ind = ppr_node.map(parse_para_fmt).unwrap_or_default();
     let numbering = direct_ind.num_id.or(style_para.num_id).and_then(|num_id| {
         if num_id == 0 {
             return None;
@@ -8624,16 +8645,13 @@ fn extract_simple_paragraph_text(
     let level = numbering
         .as_ref()
         .and_then(|num| num_map.get_level(num.num_id, num.level));
-    let (indent_left, indent_first) = if let Some(l) = level {
-        (
-            direct_ind
-                .indent_left
-                .or(style_para.indent_left)
-                .unwrap_or(l.indent_left),
-            direct_ind
-                .indent_first
-                .or(style_para.indent_first)
-                .unwrap_or(l.indent_first),
+    let (indent_left, indent_first, indent_right) = if let Some(l) = level {
+        resolve_numbered_indent_axes(
+            &direct_ind,
+            &paragraph_style,
+            &style_para,
+            l,
+            direct_numbering,
         )
     } else {
         (
@@ -8645,13 +8663,12 @@ fn extract_simple_paragraph_text(
                 .indent_first
                 .or(style_para.indent_first)
                 .unwrap_or(0.0),
+            direct_ind
+                .indent_right
+                .or(style_para.indent_right)
+                .unwrap_or(0.0),
         )
     };
-    let indent_right = direct_ind
-        .indent_right
-        .or(style_para.indent_right)
-        .or_else(|| level.and_then(|l| l.indent_right))
-        .unwrap_or(0.0);
 
     // ECMA-376 §17.3.1.33 — the txbxContent paragraph's own `<w:spacing>` is
     // reserved INSIDE the text box (twips → pt). Word offsets the text down by
@@ -20351,6 +20368,148 @@ mod txbx_inline_image_tests {
         assert_eq!(numbering.level, 0);
         assert!((block.indent_left - 36.0).abs() < 1e-6);
         assert!((block.indent_first + 36.0).abs() < 1e-6);
+    }
+
+    /// ECMA-376 §§17.7.2, 17.7.8.1, 17.9.22 — when a text-box paragraph
+    /// directly selects numbering, the authored numbering-level paragraph
+    /// properties belong to the final direct-formatting layer. They therefore
+    /// override paragraph-style indents, just as they do for body paragraphs.
+    #[test]
+    fn extract_simple_paragraph_text_direct_numbering_indents_override_style() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="paragraph" w:styleId="Indented">
+                <w:pPr><w:ind w:left="840" w:right="360" w:firstLine="240"/></w:pPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        let paragraph = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:pPr>
+                <w:pStyle w:val="Indented"/>
+                <w:numPr><w:ilvl w:val="0"/><w:numId w:val="5"/></w:numPr>
+              </w:pPr>
+              <w:r><w:t>Numbered text</w:t></w:r>
+            </w:p>"#,
+        )
+        .unwrap();
+        let numbering = r#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:abstractNum w:abstractNumId="3">
+                <w:lvl w:ilvl="0">
+                  <w:numFmt w:val="bullet"/>
+                  <w:lvlText w:val="•"/>
+                  <w:pPr><w:ind w:left="360" w:right="480" w:hanging="360"/></w:pPr>
+                </w:lvl>
+              </w:abstractNum>
+              <w:num w:numId="5"><w:abstractNumId w:val="3"/></w:num>
+            </w:numbering>"#;
+        let mut num_map = NumberingMap::parse(numbering, &HashMap::new());
+
+        let block = super::extract_simple_paragraph_text(
+            &styles,
+            &mut num_map,
+            paragraph.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .expect("numbered text-box paragraph yields text");
+
+        assert!((block.indent_left - 18.0).abs() < 1e-6);
+        assert!((block.indent_right - 24.0).abs() < 1e-6);
+        assert!((block.indent_first + 18.0).abs() < 1e-6);
+    }
+
+    /// Style-origin numbering is applied before the paragraph style
+    /// (§§17.7.2, 17.7.8.1), so the style's own per-axis indents win.
+    #[test]
+    fn extract_simple_paragraph_text_style_indents_override_style_numbering() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="paragraph" w:styleId="Numbered">
+                <w:pPr>
+                  <w:numPr><w:ilvl w:val="0"/><w:numId w:val="5"/></w:numPr>
+                  <w:ind w:left="840" w:right="360" w:firstLine="240"/>
+                </w:pPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        let paragraph = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:pPr><w:pStyle w:val="Numbered"/></w:pPr>
+              <w:r><w:t>Numbered text</w:t></w:r>
+            </w:p>"#,
+        )
+        .unwrap();
+        let numbering = r#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:abstractNum w:abstractNumId="3">
+                <w:lvl w:ilvl="0">
+                  <w:numFmt w:val="bullet"/>
+                  <w:lvlText w:val="•"/>
+                  <w:pPr><w:ind w:left="360" w:right="480" w:hanging="360"/></w:pPr>
+                </w:lvl>
+              </w:abstractNum>
+              <w:num w:numId="5"><w:abstractNumId w:val="3"/></w:num>
+            </w:numbering>"#;
+        let mut num_map = NumberingMap::parse(numbering, &HashMap::new());
+
+        let block = super::extract_simple_paragraph_text(
+            &styles,
+            &mut num_map,
+            paragraph.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .expect("numbered text-box paragraph yields text");
+
+        assert!((block.indent_left - 42.0).abs() < 1e-6);
+        assert!((block.indent_right - 18.0).abs() < 1e-6);
+        assert!((block.indent_first - 12.0).abs() < 1e-6);
+    }
+
+    /// A level with no authored `w:ind` carries only the parser's legacy depth
+    /// fallback. That fallback must not displace real paragraph-style values,
+    /// even when the paragraph selects the numbering directly.
+    #[test]
+    fn extract_simple_paragraph_text_ignores_unauthored_numbering_indent_fallback() {
+        let styles = StyleMap::parse(
+            r#"<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:style w:type="paragraph" w:styleId="Indented">
+                <w:pPr><w:ind w:left="840" w:firstLine="240"/></w:pPr>
+              </w:style>
+            </w:styles>"#,
+        );
+        let paragraph = roxmltree::Document::parse(
+            r#"<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:pPr>
+                <w:pStyle w:val="Indented"/>
+                <w:numPr><w:ilvl w:val="0"/><w:numId w:val="5"/></w:numPr>
+              </w:pPr>
+              <w:r><w:t>Numbered text</w:t></w:r>
+            </w:p>"#,
+        )
+        .unwrap();
+        let numbering = r#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:abstractNum w:abstractNumId="3">
+                <w:lvl w:ilvl="0">
+                  <w:numFmt w:val="bullet"/>
+                  <w:lvlText w:val="•"/>
+                </w:lvl>
+              </w:abstractNum>
+              <w:num w:numId="5"><w:abstractNumId w:val="3"/></w:num>
+            </w:numbering>"#;
+        let mut num_map = NumberingMap::parse(numbering, &HashMap::new());
+
+        let block = super::extract_simple_paragraph_text(
+            &styles,
+            &mut num_map,
+            paragraph.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .expect("numbered text-box paragraph yields text");
+
+        assert!((block.indent_left - 42.0).abs() < 1e-6);
+        assert!((block.indent_first - 12.0).abs() < 1e-6);
     }
 
     #[test]

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -677,6 +677,23 @@ impl StyleMap {
         self.resolve_para_cond(style_id, table_style_id, None)
     }
 
+    /// Resolve only the named/default paragraph-style chain, without document
+    /// defaults or table-style layers. Callers that combine numbering paragraph
+    /// properties need this provenance because §17.7.2 places style-origin
+    /// numbering below the paragraph style, while direct `numPr` and its
+    /// associated properties are applied in the final direct-formatting layer.
+    pub(crate) fn resolve_paragraph_style_layer(&self, style_id: Option<&str>) -> ParaFmt {
+        let mut paragraph = ParaFmt::default();
+        let mut run = RunFmt::default();
+        let effective_id = style_id
+            .map(str::to_string)
+            .or_else(|| self.default_para_style_id.clone());
+        if let Some(id) = effective_id.as_deref() {
+            self.apply_style_chain(id, &mut paragraph, &mut run);
+        }
+        paragraph
+    }
+
     /// Like [`resolve_para`], but additionally layers a table style's resolved
     /// conditional formatting (`w:tblStylePr`'s `<w:rPr>`/`<w:pPr>`, §17.7.6)
     /// onto the cell's base formatting.

--- a/packages/docx/src/layout-runtime.ts
+++ b/packages/docx/src/layout-runtime.ts
@@ -1,3 +1,4 @@
+import { withVertFeatureCanvasScope } from '@silurus/ooxml-core';
 import type { DocxDocumentModel } from './types.js';
 import type { ResolvedLocalFontMetric } from './layout/text.js';
 import { snapshotLocalMetrics } from './layout/text.js';
@@ -73,45 +74,60 @@ export function createLayoutServices(
         set fontKerning(value: CanvasFontKerning) { canvasContext.fontKerning = value; },
         measureText(text: string) { return canvasContext.measureText(text); },
       });
+  const canvasElement = canvasContext?.canvas as HTMLCanvasElement | undefined;
+  const ownerCanvasConstructor =
+    canvasElement?.ownerDocument?.defaultView?.HTMLCanvasElement;
   const hasDomVerticalProbe = canvasContext !== null
-    && typeof HTMLCanvasElement !== 'undefined'
-    && canvasContext.canvas instanceof HTMLCanvasElement
-    && typeof document !== 'undefined';
+    && (
+      (
+        typeof ownerCanvasConstructor === 'function'
+        && canvasElement instanceof ownerCanvasConstructor
+      )
+      || (
+        typeof HTMLCanvasElement !== 'undefined'
+        && canvasElement instanceof HTMLCanvasElement
+      )
+    );
   const verticalGlyphMeasurement: VerticalGlyphMeasurementService = Object.freeze({
     fingerprint: canvasContext === null
       ? 'vertical-glyph-measurement:deterministic-v1'
       : hasDomVerticalProbe
-        ? 'vertical-glyph-measurement:dom-vert-probe-v1'
+        ? 'vertical-glyph-measurement:dom-vert-probe-v2'
         : 'vertical-glyph-measurement:no-dom-vert-probe-v1',
     measureRunInkExtra(text: string): number {
       if (canvasContext === null) {
         throw new Error('Vertical glyph measurement requires a concrete text context');
       }
-      return verticalRunInkExtraPx(canvasContext, text);
+      return withVertFeatureCanvasScope(
+        canvasContext,
+        () => verticalRunInkExtraPx(canvasContext, text),
+      );
     },
     planRun(input: Parameters<VerticalGlyphMeasurementService['planRun']>[0]) {
       if (canvasContext === null) {
         throw new Error('Vertical glyph planning requires a concrete text context');
       }
-      const previousFont = canvasContext.font;
-      const previousKerning = canvasContext.fontKerning;
-      canvasContext.font = input.font;
-      canvasContext.fontKerning = input.fontKerning;
-      try {
-        return planVerticalRunWithCapability(
-          canvasContext,
-          input.text,
-          input.fontSizePt,
-          input.letterSpacingPt,
-          input.charScale,
-          input.growTrRotateInk,
-          (cp) => verticalVertGlyphReachable(canvasContext, cp),
-          input.writingMode,
-        );
-      } finally {
-        canvasContext.font = previousFont;
-        canvasContext.fontKerning = previousKerning;
-      }
+      return withVertFeatureCanvasScope(canvasContext, () => {
+        const previousFont = canvasContext.font;
+        const previousKerning = canvasContext.fontKerning;
+        canvasContext.font = input.font;
+        canvasContext.fontKerning = input.fontKerning;
+        try {
+          return planVerticalRunWithCapability(
+            canvasContext,
+            input.text,
+            input.fontSizePt,
+            input.letterSpacingPt,
+            input.charScale,
+            input.growTrRotateInk,
+            (cp) => verticalVertGlyphReachable(canvasContext, cp),
+            input.writingMode,
+          );
+        } finally {
+          canvasContext.font = previousFont;
+          canvasContext.fontKerning = previousKerning;
+        }
+      });
     },
   });
   const localMetrics = snapshotLocalMetrics(options.localMetrics);

--- a/packages/docx/src/layout/invariants.test.ts
+++ b/packages/docx/src/layout/invariants.test.ts
@@ -468,6 +468,87 @@ describe('assertDocumentLayout', () => {
     expect(() => assertDocumentLayout(layout)).not.toThrow();
   });
 
+  it('accepts a non-body node ending one floating-point ULP at its authored domain edge', () => {
+    const domainTopPt = 690.4570068359375;
+    const domainHeightPt = 101.8429931640625;
+    const nodeTopPt = 777.2570068359375;
+    const nodeHeightPt = 15.042993164062494;
+    const domain: FlowDomain = {
+      id: 'footer:fractional', kind: 'footer',
+      logicalBounds: rect(85.05, domainTopPt, 425.2, domainHeightPt),
+      physicalBounds: rect(85.05, domainTopPt, 425.2, domainHeightPt),
+    };
+    const footer = {
+      ...drawing('footer-fractional', rect(85.05, nodeTopPt, 425.2, nodeHeightPt), {
+        flowDomainId: domain.id,
+      }),
+      source: { story: 'footer' as const, storyInstance: 'default', path: [0] },
+    };
+    const base = documentWith([]);
+    const withFooter = (heightPt: number): DocumentLayout => ({
+      ...base,
+      pages: [{
+        ...base.pages[0]!,
+        flowDomains: [bodyDomain, domain],
+        layers: buildPageLayers([
+          {
+            layer: 'footer',
+            node: {
+              ...footer,
+              flowBounds: { ...footer.flowBounds, heightPt },
+              inkBounds: { ...footer.inkBounds, heightPt },
+              advancePt: heightPt,
+            },
+            coordinateSpace: 'section-logical',
+          },
+        ]),
+        readingOrder: [footer.id],
+      }],
+    });
+
+    expect(nodeTopPt + nodeHeightPt).toBeGreaterThan(domainTopPt + domainHeightPt);
+    expect(() => assertDocumentLayout(withFooter(nodeHeightPt))).not.toThrow();
+    expect(() => assertDocumentLayout(withFooter(nodeHeightPt + 0.001)))
+      .toThrow(/FLOW_DOMAIN_INVASION/);
+  });
+
+  it('does not report one-ULP arithmetic drift at an ordinary-flow boundary as overlap', () => {
+    const domain: FlowDomain = {
+      id: 'footer:touching', kind: 'footer',
+      logicalBounds: rect(85.05, 690, 425.2, 102),
+      physicalBounds: rect(85.05, 690, 425.2, 102),
+    };
+    const first = {
+      ...drawing('footer-first', rect(
+        85.05, 722.6570068359375, 425.2, 18.200000000000003,
+      ), { flowDomainId: domain.id }),
+      source: { story: 'footer' as const, storyInstance: 'default', path: [0] },
+    };
+    const second = {
+      ...drawing('footer-second', rect(
+        85.05, 740.8570068359375, 425.2, 18.200000000000003,
+      ), { flowDomainId: domain.id }),
+      source: { story: 'footer' as const, storyInstance: 'default', path: [1] },
+    };
+    const base = documentWith([]);
+    const layout: DocumentLayout = {
+      ...base,
+      pages: [{
+        ...base.pages[0]!,
+        flowDomains: [bodyDomain, domain],
+        layers: buildPageLayers([
+          { layer: 'footer', node: first, coordinateSpace: 'section-logical' },
+          { layer: 'footer', node: second, coordinateSpace: 'section-logical' },
+        ]),
+        readingOrder: [first.id, second.id],
+      }],
+    };
+
+    expect(first.flowBounds.yPt + first.flowBounds.heightPt)
+      .toBeGreaterThan(second.flowBounds.yPt);
+    expect(() => assertDocumentLayout(layout)).not.toThrow();
+  });
+
   it('rejects overlap within one domain but permits the same geometry in independent cells', () => {
     const first = drawing('cell-1', rect(100, 100, 80, 20), { flowDomainId: 'cell:1' });
     const second = drawing('cell-2', rect(100, 100, 80, 20), { flowDomainId: 'cell:2' });

--- a/packages/docx/src/layout/invariants.ts
+++ b/packages/docx/src/layout/invariants.ts
@@ -214,23 +214,46 @@ function requireDrawingMLShapePlan(
   }
 }
 
+/** Inclusive geometry comparisons must tolerate the single-ULP drift produced
+ * when the same authored boundary is reconstructed through different retained
+ * subtraction/addition paths. This is floating-point precision, not a layout
+ * tolerance: a geometrically distinct point value remains outside. */
+function atMostWithinFloatingPrecision(left: number, right: number): boolean {
+  if (left <= right) return true;
+  const precision = Number.EPSILON * Math.max(1, Math.abs(left), Math.abs(right));
+  return left - right <= precision;
+}
+
+function strictlyLessBeyondFloatingPrecision(left: number, right: number): boolean {
+  return left < right && !atMostWithinFloatingPrecision(right, left);
+}
+
 function overlaps(a: LayoutRect, b: LayoutRect): boolean {
-  return a.xPt < b.xPt + b.widthPt
-    && b.xPt < a.xPt + a.widthPt
-    && a.yPt < b.yPt + b.heightPt
-    && b.yPt < a.yPt + a.heightPt;
+  return strictlyLessBeyondFloatingPrecision(a.xPt, b.xPt + b.widthPt)
+    && strictlyLessBeyondFloatingPrecision(b.xPt, a.xPt + a.widthPt)
+    && strictlyLessBeyondFloatingPrecision(a.yPt, b.yPt + b.heightPt)
+    && strictlyLessBeyondFloatingPrecision(b.yPt, a.yPt + a.heightPt);
 }
 
 function contains(outer: LayoutRect, inner: LayoutRect): boolean {
-  return inner.xPt >= outer.xPt
-    && inner.yPt >= outer.yPt
-    && inner.xPt + inner.widthPt <= outer.xPt + outer.widthPt
-    && inner.yPt + inner.heightPt <= outer.yPt + outer.heightPt;
+  return atMostWithinFloatingPrecision(outer.xPt, inner.xPt)
+    && atMostWithinFloatingPrecision(outer.yPt, inner.yPt)
+    && atMostWithinFloatingPrecision(
+      inner.xPt + inner.widthPt,
+      outer.xPt + outer.widthPt,
+    )
+    && atMostWithinFloatingPrecision(
+      inner.yPt + inner.heightPt,
+      outer.yPt + outer.heightPt,
+    );
 }
 
 function containsInlineExtent(outer: LayoutRect, inner: LayoutRect): boolean {
-  return inner.xPt >= outer.xPt
-    && inner.xPt + inner.widthPt <= outer.xPt + outer.widthPt;
+  return atMostWithinFloatingPrecision(outer.xPt, inner.xPt)
+    && atMostWithinFloatingPrecision(
+      inner.xPt + inner.widthPt,
+      outer.xPt + outer.widthPt,
+    );
 }
 
 function containsBlockInterval(
@@ -238,13 +261,16 @@ function containsBlockInterval(
   blockEndPt: number,
   inner: LayoutRect,
 ): boolean {
-  return inner.yPt >= blockStartPt
-    && inner.yPt + inner.heightPt <= blockEndPt;
+  return atMostWithinFloatingPrecision(blockStartPt, inner.yPt)
+    && atMostWithinFloatingPrecision(inner.yPt + inner.heightPt, blockEndPt);
 }
 
 function containsBlockExtent(outer: LayoutRect, inner: LayoutRect): boolean {
-  return inner.yPt >= outer.yPt
-    && inner.yPt + inner.heightPt <= outer.yPt + outer.heightPt;
+  return atMostWithinFloatingPrecision(outer.yPt, inner.yPt)
+    && atMostWithinFloatingPrecision(
+      inner.yPt + inner.heightPt,
+      outer.yPt + outer.heightPt,
+    );
 }
 
 function equalRect(left: LayoutRect, right: LayoutRect): boolean {

--- a/packages/docx/src/layout/measurement-capabilities-production.test.ts
+++ b/packages/docx/src/layout/measurement-capabilities-production.test.ts
@@ -106,7 +106,7 @@ describe('production measurement capability composition', () => {
       });
 
       expect(verticalGlyphMeasurementServiceOf(dom).fingerprint)
-        .toBe('vertical-glyph-measurement:dom-vert-probe-v1');
+        .toBe('vertical-glyph-measurement:dom-vert-probe-v2');
       expect(verticalGlyphMeasurementServiceOf(worker).fingerprint)
         .toBe('vertical-glyph-measurement:no-dom-vert-probe-v1');
       expect(dom.text.fingerprint).toBe(worker.text.fingerprint);
@@ -121,6 +121,34 @@ describe('production measurement capability composition', () => {
         Object.defineProperty(globalThis, 'document', documentDescriptor);
       } else {
         Reflect.deleteProperty(globalThis, 'document');
+      }
+    }
+  });
+
+  it('recognizes an element-backed measurement canvas from its owner realm', () => {
+    class ParentHtmlCanvasElement {}
+    class OwnerHtmlCanvasElement {
+      ownerDocument = {
+        defaultView: { HTMLCanvasElement: OwnerHtmlCanvasElement },
+      };
+    }
+    const canvasDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'HTMLCanvasElement');
+    try {
+      Object.defineProperty(globalThis, 'HTMLCanvasElement', {
+        configurable: true,
+        value: ParentHtmlCanvasElement,
+      });
+      const services = createLayoutServices(model, {
+        measureContext: measurementContext(new OwnerHtmlCanvasElement()),
+      });
+
+      expect(verticalGlyphMeasurementServiceOf(services).fingerprint)
+        .toBe('vertical-glyph-measurement:dom-vert-probe-v2');
+    } finally {
+      if (canvasDescriptor) {
+        Object.defineProperty(globalThis, 'HTMLCanvasElement', canvasDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, 'HTMLCanvasElement');
       }
     }
   });
@@ -163,7 +191,7 @@ describe('production measurement capability composition', () => {
       const services = createLayoutServices(model);
 
       expect(verticalGlyphMeasurementServiceOf(services).fingerprint)
-        .toBe('vertical-glyph-measurement:dom-vert-probe-v1');
+        .toBe('vertical-glyph-measurement:dom-vert-probe-v2');
       expect(domContexts).toBe(1);
       expect(offscreenContexts).toBe(0);
     } finally {

--- a/packages/docx/src/layout/paragraph.test.ts
+++ b/packages/docx/src/layout/paragraph.test.ts
@@ -1464,6 +1464,10 @@ describe('paragraphLayoutFromMeasurement retained authorities', () => {
     const segment = {
       text: value, sourceRunIndex: 0, measuredWidth: 50,
       fontSize: 10, fontFamily: 'Test Sans', fontRoute, verticalRun: true,
+      // A negative East Asian pitch narrows each retained cell. Upright/rotate
+      // glyphs are already positioned by those cell origins; only the
+      // contextual sideways pieces still need Canvas letter spacing.
+      fitTextPerGapPx: -6,
       shapedClusters: [...value].map((_character, index) => ({
         range: { start: index, end: index + 1 }, offsetPt: index * 10, advancePt: 10,
       })),
@@ -1513,22 +1517,26 @@ describe('paragraphLayoutFromMeasurement retained authorities', () => {
         expect.objectContaining({
           text: 'A', range: { start: 0, end: 1 }, glyphOrientation: 'sideways',
           offset: { xPt: 0, yPt: 0 }, glyphOffsetPt: { xPt: 0, yPt: 4 },
+          letterSpacingPt: -6,
         }),
         expect.objectContaining({
           text: '︵', range: { start: 1, end: 2 }, glyphOrientation: 'upright',
           offset: { xPt: 15, yPt: 0 }, glyphOffsetPt: { xPt: 0, yPt: -2 },
+          letterSpacingPt: 0,
         }),
         expect.objectContaining({
           text: 'ー', range: { start: 2, end: 3 }, glyphOrientation: 'rotate',
           offset: { xPt: 25, yPt: 0 },
+          letterSpacingPt: 0,
         }),
         expect.objectContaining({
           text: '）', range: { start: 3, end: 4 }, glyphOrientation: 'upright',
-          offset: { xPt: 35, yPt: 0 }, verticalFeature: true,
+          offset: { xPt: 35, yPt: 0 }, verticalFeature: true, letterSpacingPt: 0,
         }),
         expect.objectContaining({
           text: 'B', range: { start: 4, end: 5 }, glyphOrientation: 'sideways',
           offset: { xPt: 40, yPt: 0 }, glyphOffsetPt: { xPt: 0, yPt: 4 },
+          letterSpacingPt: -6,
         }),
       ],
     });

--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -1689,9 +1689,15 @@ function textPlanSegment(
     basePaintOps: basePaintOps.map((operation) => ({
       ...operation,
       // Measurement resolves w:spacing, docGrid character pitch, and w:fitText
-      // into one authoritative per-scalar pitch. Paint retains that same value;
-      // it must never reconstruct pitch from parser source or remeasure glyphs.
-      letterSpacingPt: pitchPt,
+      // into one authoritative per-scalar pitch. A planned vertical upright or
+      // rotate cell already owns that pitch in its retained origin and advance;
+      // applying Canvas letterSpacing again would move a centered single glyph
+      // on the physical cross axis. Contextual sideways text and horizontal
+      // tate-chu-yoko retain Canvas spacing within their multi-glyph operation.
+      letterSpacingPt:
+        segment.verticalRun && operation.glyphOrientation !== 'sideways'
+          ? 0
+          : pitchPt,
       ...(!segment.verticalRun && segment.selectedFaceInkBounds
         ? { inkBounds: segment.selectedFaceInkBounds }
         : {}),

--- a/packages/docx/src/paint/canvas-text.test.ts
+++ b/packages/docx/src/paint/canvas-text.test.ts
@@ -877,7 +877,7 @@ describe('paintParagraphLayout', () => {
     })).toThrow('Retained glyph slices are incomplete (geometry)');
   });
 
-  it('paints retained vertical glyph routing and offsets without remeasurement', () => {
+  it('paints retained vertical glyph routing, pitch, and offsets without remeasurement', () => {
     const layout = node();
     const placement = layout.lines[0]!.placements[0]!;
     if (placement.kind !== 'text') throw new Error('fixture must contain text');
@@ -894,7 +894,7 @@ describe('paintParagraphLayout', () => {
           {
             text: 'A', range: { start: 0, end: 1 }, offset: { xPt: 1, yPt: 2 },
             glyphOffsetPt: { xPt: 3, yPt: 4 }, glyphOrientation: 'sideways',
-            letterSpacingPt: 0, scaleX: .8, direction: 'ltr', kerning: 'auto',
+            letterSpacingPt: -6, scaleX: .8, direction: 'ltr', kerning: 'auto',
             writingMode: 'vertical-rl',
           },
           {
@@ -912,7 +912,7 @@ describe('paintParagraphLayout', () => {
           {
             text: '２９', range: { start: 3, end: 5 }, offset: { xPt: 24, yPt: 0 },
             glyphOrientation: 'upright',
-            letterSpacingPt: 0, scaleX: .8, scaleY: .75, direction: 'ltr', kerning: 'auto',
+            letterSpacingPt: -6, scaleX: .8, scaleY: .75, direction: 'ltr', kerning: 'auto',
             writingMode: 'horizontal-tb',
           },
         ],
@@ -928,7 +928,9 @@ describe('paintParagraphLayout', () => {
       rotate(angle: number) { calls.push(['rotate', angle]); },
       setLineDash() {}, fillRect() {}, strokeRect() {}, beginPath() {},
       moveTo() {}, lineTo() {}, stroke() {},
-      fillText(text: string, x: number, y: number) { calls.push(['fillText', text, x, y]); },
+      fillText(this: { letterSpacing: string }, text: string, x: number, y: number) {
+        calls.push(['fillText', text, x, y, this.letterSpacing]);
+      },
       measureText() { throw new Error('retained vertical paint must not measure'); },
     } as unknown as CanvasRenderingContext2D;
 
@@ -939,13 +941,13 @@ describe('paintParagraphLayout', () => {
     paintParagraphLayout(vertical, { ctx, scale: 1, dpr: 1, resources: noPaintResources });
 
     expect(calls).toEqual([
-      'save', ['translate', 14, 24], ['scale', .8, 1], ['fillText', 'A', 0, 0], 'restore',
+      'save', ['translate', 14, 24], ['scale', .8, 1], ['fillText', 'A', 0, 0, '-7.5px'], 'restore',
       'save', ['translate', 18, 18], ['rotate', -Math.PI / 2], ['scale', 1, .8],
-      ['fillText', '︵', 2, 3], 'restore',
+      ['fillText', '︵', 2, 3, '0px'], 'restore',
       'save', ['translate', 26, 18], ['scale', .8, 1],
-      ['fillText', 'ー', 1, 2], 'restore',
+      ['fillText', 'ー', 1, 2, '0px'], 'restore',
       'save', ['translate', 34, 18], ['rotate', -Math.PI / 2], ['scale', .8, .75],
-      ['fillText', '２９', 0, 0], 'restore',
+      ['fillText', '２９', 0, 0, '-6px'], 'restore',
     ]);
   });
 

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -86,6 +86,9 @@ describe('planVerticalRunWithCapability (retained vertical paint geometry)', () 
       { text: '︶', orientation: 'upright', range: { start: 3, end: 4 }, verticalFeature: false },
       { text: 'B', orientation: 'sideways', range: { start: 4, end: 5 }, verticalFeature: false },
     ]);
+    // Unicode presentation-form fallbacks are ordinary centred Canvas glyphs.
+    // Feature-backed placement adjustments must not leak into this route.
+    expect(cells.map(({ drawOffsetPt }) => drawOffsetPt.xPt)).toEqual([0, 0, 0, 0, 0]);
   });
 
   it('retains original transform characters and projects their vertical origin into the cell', () => {
@@ -106,7 +109,7 @@ describe('planVerticalRunWithCapability (retained vertical paint geometry)', () 
       { text: 'ー', orientation: 'upright', verticalFeature: true },
       { text: '）', orientation: 'upright', verticalFeature: true },
     ]);
-    expect(cells.map(({ drawOffsetPt }) => drawOffsetPt.xPt)).toEqual([-6, 0, -6]);
+    expect(cells.map(({ drawOffsetPt }) => drawOffsetPt.xPt)).toEqual([0, 0, 0]);
   });
 
   it('retains counter-rotated logical block ink after the upright glyph offset', () => {

--- a/packages/docx/src/vertical-text.test.ts
+++ b/packages/docx/src/vertical-text.test.ts
@@ -88,7 +88,7 @@ describe('planVerticalRunWithCapability (retained vertical paint geometry)', () 
     ]);
   });
 
-  it('retains original transform characters and the proved OpenType vert feature route', () => {
+  it('retains original transform characters and projects their vertical origin into the cell', () => {
     const { ctx } = mockCtx({
       vert: {
         '（': { width: 12, asc: 9, desc: 3 },
@@ -106,6 +106,7 @@ describe('planVerticalRunWithCapability (retained vertical paint geometry)', () 
       { text: 'ー', orientation: 'upright', verticalFeature: true },
       { text: '）', orientation: 'upright', verticalFeature: true },
     ]);
+    expect(cells.map(({ drawOffsetPt }) => drawOffsetPt.xPt)).toEqual([-6, 0, -6]);
   });
 
   it('retains counter-rotated logical block ink after the upright glyph offset', () => {

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -276,6 +276,25 @@ function isVerticalVertCandidate(cp: number): boolean {
 }
 
 /**
+ * Canvas exposes an OpenType vertical alternate through the horizontal text
+ * API. Its raw glyph origin remains on the vertical cell edge: for example,
+ * the featured bracket's reported ink centre is one half-advance to the right
+ * of the requested point. Retained upright paint addresses the Word vertical
+ * cell centre, so project that OpenType vertical origin back by the exact
+ * featured half-advance acquired for the same glyph. Corner punctuation keeps
+ * its designed in-cell offset because this moves the origin, not the ink.
+ */
+function verticalPresentationOriginCorrectionPx(
+  cp: number,
+  cellAdvancePx: number,
+): number {
+  return (
+    verticalFormSubstitute(cp) !== null
+    || verticalBracketFormSubstitute(cp) !== null
+  ) ? -cellAdvancePx / 2 : 0;
+}
+
+/**
  * Along-column ink geometry of a vo=Tr rotate-fallback glyph (issue #1014). The
  * glyph is painted by a plain `fillText` in the +90°-rotated page frame, so its
  * HORIZONTAL ink extent maps onto the ALONG-COLUMN axis (the advance axis). Read
@@ -459,9 +478,13 @@ export function planVerticalRunWithCapability(
         && verticalTrUprightFallback(cp);
       const routed = routedVerticalGlyphCell(ctx, ch, cp, vertCapability, growTrRotateInk);
       const advancePt = routed.naturalPx * charScale + letterSpacingPt;
+      const presentationOriginXPt = verticalPresentationOriginCorrectionPx(
+        cp,
+        routed.naturalPx,
+      );
       const range = { start: sourceOffset, end: sourceOffset + ch.length };
       if (routed.vert !== null) {
-        const drawOffsetPt = { xPt: 0, yPt: 0 };
+        const drawOffsetPt = { xPt: presentationOriginXPt, yPt: 0 };
         const blockAxisInkBounds = plannedVerticalBlockAxisInkBounds(
           ctx, ch, 'upright', drawOffsetPt, charScale, writingMode, true,
         );
@@ -485,7 +508,7 @@ export function planVerticalRunWithCapability(
           ? inkCenterAboveMiddlePx(ctx, drawText) / fontPt
           : 0;
         const drawOffsetPt = {
-          xPt: offset.dx * fontPt,
+          xPt: offset.dx * fontPt + presentationOriginXPt,
           yPt: (alongEm + offset.dy) * fontPt,
         };
         const blockAxisInkBounds = plannedVerticalBlockAxisInkBounds(

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -66,9 +66,9 @@ import {
 } from '@silurus/ooxml-core';
 
 // Browser acceptance tests load this source module through Vite's `/src` bridge;
-// re-export the exact production probe so they exercise the same capability gate
-// as drawVerticalRun instead of maintaining a test-local approximation.
-export { verticalVertGlyphReachable } from '@silurus/ooxml-core';
+// re-export the exact production feature operations so they exercise the same
+// capability gate and restoration contract instead of test-local approximations.
+export { verticalVertGlyphReachable, withVertFeature } from '@silurus/ooxml-core';
 
 /** How a code point is painted inside the +90°-rotated vertical page:
  *   - `upright`  — counter-rotated −90° to stand up (vo=U, and vo=Tu).
@@ -276,25 +276,6 @@ function isVerticalVertCandidate(cp: number): boolean {
 }
 
 /**
- * Canvas exposes an OpenType vertical alternate through the horizontal text
- * API. Its raw glyph origin remains on the vertical cell edge: for example,
- * the featured bracket's reported ink centre is one half-advance to the right
- * of the requested point. Retained upright paint addresses the Word vertical
- * cell centre, so project that OpenType vertical origin back by the exact
- * featured half-advance acquired for the same glyph. Corner punctuation keeps
- * its designed in-cell offset because this moves the origin, not the ink.
- */
-function verticalPresentationOriginCorrectionPx(
-  cp: number,
-  cellAdvancePx: number,
-): number {
-  return (
-    verticalFormSubstitute(cp) !== null
-    || verticalBracketFormSubstitute(cp) !== null
-  ) ? -cellAdvancePx / 2 : 0;
-}
-
-/**
  * Along-column ink geometry of a vo=Tr rotate-fallback glyph (issue #1014). The
  * glyph is painted by a plain `fillText` in the +90°-rotated page frame, so its
  * HORIZONTAL ink extent maps onto the ALONG-COLUMN axis (the advance axis). Read
@@ -478,13 +459,9 @@ export function planVerticalRunWithCapability(
         && verticalTrUprightFallback(cp);
       const routed = routedVerticalGlyphCell(ctx, ch, cp, vertCapability, growTrRotateInk);
       const advancePt = routed.naturalPx * charScale + letterSpacingPt;
-      const presentationOriginXPt = verticalPresentationOriginCorrectionPx(
-        cp,
-        routed.naturalPx,
-      );
       const range = { start: sourceOffset, end: sourceOffset + ch.length };
       if (routed.vert !== null) {
-        const drawOffsetPt = { xPt: presentationOriginXPt, yPt: 0 };
+        const drawOffsetPt = { xPt: 0, yPt: 0 };
         const blockAxisInkBounds = plannedVerticalBlockAxisInkBounds(
           ctx, ch, 'upright', drawOffsetPt, charScale, writingMode, true,
         );
@@ -508,7 +485,7 @@ export function planVerticalRunWithCapability(
           ? inkCenterAboveMiddlePx(ctx, drawText) / fontPt
           : 0;
         const drawOffsetPt = {
-          xPt: offset.dx * fontPt + presentationOriginXPt,
+          xPt: offset.dx * fontPt,
           yPt: (alongEm + offset.dy) * fontPt,
         };
         const blockAxisInkBounds = plannedVerticalBlockAxisInkBounds(

--- a/packages/docx/src/vertical-text.ts
+++ b/packages/docx/src/vertical-text.ts
@@ -48,9 +48,9 @@
 // resolved against the physical page then projected into the logical flow
 // (PDF-verified centroid); inline/anchored/float image uprighting; and the
 // vertical text-layer transform. Still approximated / deferred (flagged inline):
-// the `0.12em` upright-centring nudge and the Tu upper-right corner nudge are
-// font-dependent stage-1 heuristics; paragraph-relative vertical anchors are a
-// follow-up. `btLr` shares the +90° page FRAME but bypasses this module's
+// the U+FF0E Tu upper-right corner fallback is a font-dependent heuristic;
+// paragraph-relative vertical anchors are a follow-up. `btLr` shares the +90°
+// page FRAME but bypasses this module's
 // upright/substitute glyph handling entirely (issue #988 re-adjudication: every
 // glyph rides the page rotation — see BodyAcquisitionState.verticalAllRotated).
 

--- a/packages/docx/tests/visual/math-engine.ts
+++ b/packages/docx/tests/visual/math-engine.ts
@@ -1,0 +1,11 @@
+import {
+  loadMathJax,
+  mathMLToSvg,
+} from '../../../core/src/math/engine.js';
+
+/**
+ * Local Word-PDF acceptance must exercise the same opt-in math route as the
+ * Storybook viewer. Leaving the engine out silently drops equations before
+ * pagination and can fabricate both pixel and page-count regressions.
+ */
+export const math = { loadMathJax, mathMLToSvg };

--- a/packages/docx/tests/visual/pdf-acceptance.spec.ts
+++ b/packages/docx/tests/visual/pdf-acceptance.spec.ts
@@ -100,7 +100,11 @@ test.describe('local Word PDF acceptance', () => {
     await page.goto('/tests/visual/fixture.html');
     const rendered = await page.evaluate(async ({ documentPath: path, width }) => {
       const { DocxDocument } = await import('/src/document.ts');
-      const document = await DocxDocument.load(`/${path}`, { useGoogleFonts: false });
+      const { math } = await import('/tests/visual/math-engine.ts');
+      const document = await DocxDocument.load(`/${path}`, {
+        useGoogleFonts: false,
+        math,
+      });
       const pages = [];
       for (let pageIndex = 0; pageIndex < document.pageCount; pageIndex += 1) {
         const canvas = window.document.createElement('canvas');

--- a/packages/docx/tests/visual/vertical-vert-feature.spec.ts
+++ b/packages/docx/tests/visual/vertical-vert-feature.spec.ts
@@ -408,6 +408,130 @@ test('layer A: the document font keeps Word-adjudicated vertical relationships',
   }
 });
 
+test('negative vertical pitch changes cell advance without shifting punctuation across the column', async ({ page }) => {
+  await page.goto('/tests/visual/vertical-vert-feature.html');
+  const result = await page.evaluate(async () => {
+    await document.fonts.ready;
+    const family = ['Yu Mincho', 'Hiragino Mincho ProN']
+      .find((candidate) => document.fonts.check(`48px "${candidate}"`));
+    if (!family) return null;
+
+    const { createLayoutServices } = await import('/src/layout-runtime.ts');
+    const { renderDocumentToCanvas } = await import('/src/renderer.ts');
+    const { selectDocumentLayoutPage } = await import('/src/layout/document-layout-variants.ts');
+    const canvas = document.querySelector('#subject') as HTMLCanvasElement;
+    const glyphs = [...'「」『』（）〔〕［］｛｝〈〉《》【】、。，．：；！？ー〜～…‥・'];
+
+    const makeModel = (text: string, charSpacing: number) => ({
+      section: {
+        pageWidth: 120, pageHeight: 120,
+        marginTop: 12, marginRight: 12, marginBottom: 12, marginLeft: 12,
+        headerDistance: 0, footerDistance: 0,
+        titlePage: false, evenAndOddHeaders: false, textDirection: 'tbRl',
+      },
+      body: [{
+        type: 'paragraph', alignment: 'left',
+        indentLeft: 0, indentRight: 0, indentFirst: 0,
+        spaceBefore: 0, spaceAfter: 0, lineSpacing: null,
+        numbering: null, tabStops: [],
+        runs: [{
+          type: 'text', text,
+          bold: false, italic: false, underline: false, strikethrough: false,
+          fontSize: 48, color: null,
+          fontFamily: family, fontFamilyEastAsia: family,
+          isLink: false, background: null, vertAlign: null, hyperlink: null,
+          charSpacing,
+        }],
+        defaultFontSize: 48, defaultFontFamily: family,
+        widowControl: false,
+      }],
+      headers: { default: null, first: null, even: null },
+      footers: { default: null, first: null, even: null },
+      fontFamilyClasses: {},
+    }) as never;
+
+    const render = async (text: string, charSpacing: number) => {
+      const model = makeModel(text, charSpacing);
+      const services = createLayoutServices(model);
+      await renderDocumentToCanvas(model, canvas, 0, {
+        dpr: 1, width: 120, layoutServices: services, defaultCurrentDateMs: 1,
+      });
+      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+      if (!ctx) throw new Error('2D context unavailable');
+      const rgba = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+      let inkSum = 0;
+      let weightedX = 0;
+      for (let y = 0; y < canvas.height; y += 1) {
+        for (let x = 0; x < canvas.width; x += 1) {
+          const offset = (y * canvas.width + x) * 4;
+          const alpha = rgba[offset + 3];
+          const ink = alpha * (765 - rgba[offset] - rgba[offset + 1] - rgba[offset + 2]) / 765;
+          if (ink === 0) continue;
+          inkSum += ink;
+          weightedX += x * ink;
+        }
+      }
+      if (inkSum === 0) throw new Error(`${text} produced no ink`);
+
+      const selection = selectDocumentLayoutPage(
+        services,
+        { defaultCurrentDateMs: 1 },
+        0,
+      );
+      const pending: unknown[] = [selection.page];
+      const seen = new Set<object>();
+      const retainedOps: { orientation: string; spacing: number }[] = [];
+      while (pending.length > 0) {
+        const value = pending.pop();
+        if (value === null || typeof value !== 'object' || seen.has(value)) continue;
+        seen.add(value);
+        const record = value as Record<string, unknown>;
+        if (
+          typeof record.glyphOrientation === 'string'
+          && typeof record.letterSpacingPt === 'number'
+        ) {
+          retainedOps.push({
+            orientation: record.glyphOrientation,
+            spacing: record.letterSpacingPt,
+          });
+        }
+        pending.push(...Object.values(record));
+      }
+      return { centroidX: weightedX / inkSum, retainedOps };
+    };
+
+    return Promise.all(glyphs.map(async (glyph) => {
+      const normal = await render(glyph, 0);
+      const compressed = await render(glyph, -6);
+      return {
+        glyph,
+        crossAxisDeltaPx: compressed.centroidX - normal.centroidX,
+        compressedOps: compressed.retainedOps,
+      };
+    }));
+  });
+
+  test.skip(result === null, 'a Japanese document font is required');
+  if (result === null) return;
+  for (const glyph of result) {
+    expect(
+      glyph.compressedOps.length,
+      `${glyph.glyph} has a retained vertical paint operation`,
+    ).toBeGreaterThan(0);
+    for (const operation of glyph.compressedOps) {
+      if (operation.orientation === 'sideways') continue;
+      expect(
+        operation.spacing,
+        `${glyph.glyph} retains upright/rotate pitch in cell geometry only`,
+      ).toBe(0);
+    }
+    expect(
+      Math.abs(glyph.crossAxisDeltaPx),
+      `${glyph.glyph} stays on the same vertical column under negative pitch`,
+    ).toBeLessThanOrEqual(1);
+  }
+});
+
 const VERT_REPERTOIRE = 'ー〜～、。「」（）：；！';
 for (const family of ['Yu Mincho', 'Hiragino Mincho ProN']) {
   test(`layer A/B: ${family} reachable glyphs reproduce the font own vert design`, async ({ page }) => {

--- a/packages/docx/tests/visual/vertical-vert-feature.spec.ts
+++ b/packages/docx/tests/visual/vertical-vert-feature.spec.ts
@@ -388,7 +388,10 @@ test('public detached and Offscreen rendering reproduce layout-proven vert glyph
   await page.goto('/tests/visual/vertical-vert-feature.html');
   const result = await page.evaluate(async () => {
     await document.fonts.ready;
-    const { verticalVertGlyphReachable } = await import('/src/vertical-text.ts');
+    const {
+      planVerticalRunWithCapability,
+      verticalVertGlyphReachable,
+    } = await import('/src/vertical-text.ts');
     const { createLayoutServices } = await import('/src/layout-runtime.ts');
     const { renderDocumentToCanvas } = await import('/src/renderer.ts');
     const { selectDocumentLayoutPage } = await import('/src/layout/document-layout-variants.ts');
@@ -409,6 +412,38 @@ test('public detached and Offscreen rendering reproduce layout-proven vert glyph
       }
     }
     if (!selectedFamily) return null;
+
+    const plan = (ctx: CanvasRenderingContext2D) => {
+      ctx.font = `48px "${selectedFamily}"`;
+      return planVerticalRunWithCapability(
+        ctx,
+        '（）',
+        48,
+        0,
+        1,
+        true,
+        (cp) => verticalVertGlyphReachable(ctx, cp),
+      ).map((cell) => ({
+        text: cell.text,
+        originPt: cell.originPt,
+        advancePt: cell.advancePt,
+        drawOffsetXPt: cell.drawOffsetPt.xPt,
+        verticalFeature: cell.verticalFeature,
+      }));
+    };
+    const detachedMeasureCanvas = document.createElement('canvas');
+    const detachedMeasure = detachedMeasureCanvas.getContext('2d');
+    if (!detachedMeasure) throw new Error('detached measure context unavailable');
+    const detachedPlan = plan(detachedMeasure);
+    const detachedMeasureConnectedAfter = detachedMeasureCanvas.isConnected;
+    const attachedMeasureCanvas = document.createElement('canvas');
+    attachedMeasureCanvas.style.position = 'fixed';
+    attachedMeasureCanvas.style.left = '-99999px';
+    document.body.appendChild(attachedMeasureCanvas);
+    const attachedMeasure = attachedMeasureCanvas.getContext('2d');
+    if (!attachedMeasure) throw new Error('attached measure context unavailable');
+    const attachedPlan = plan(attachedMeasure);
+    attachedMeasureCanvas.remove();
 
     const textRun = {
       type: 'text', text: 'ー（）日',
@@ -508,6 +543,9 @@ test('public detached and Offscreen rendering reproduce layout-proven vert glyph
     };
     return {
       family: selectedFamily,
+      detachedPlan,
+      attachedPlan,
+      detachedMeasureConnectedAfter,
       retainedGlyphs,
       detachedConnectedBefore,
       detachedConnectedAfter,
@@ -523,6 +561,8 @@ test('public detached and Offscreen rendering reproduce layout-proven vert glyph
 
   test.skip(result === null, 'a host font with a reachable OpenType vert glyph is required');
   if (result === null) return;
+  expect(result.detachedPlan).toEqual(result.attachedPlan);
+  expect(result.detachedMeasureConnectedAfter).toBe(false);
   expect(result.retainedGlyphs).toEqual({
     'ー': { upright: true, verticalFeature: true },
     '（': { upright: true, verticalFeature: true },

--- a/packages/docx/tests/visual/vertical-vert-feature.spec.ts
+++ b/packages/docx/tests/visual/vertical-vert-feature.spec.ts
@@ -168,7 +168,11 @@ test('layer A: the document font keeps Word-adjudicated vertical relationships',
     await document.fonts.ready;
     if (!document.fonts.check(`${fontPx}px "${family}"`)) return null;
 
-    const { drawVerticalRun } = await import('/src/vertical-text.ts');
+    const {
+      drawVerticalRun,
+      planVerticalRunWithCapability,
+      verticalVertGlyphReachable,
+    } = await import('/src/vertical-text.ts');
     const canvas = document.querySelector('#subject') as HTMLCanvasElement;
     const prepare = (): CanvasRenderingContext2D => {
       canvas.width = 900;
@@ -299,8 +303,47 @@ test('layer A: the document font keeps Word-adjudicated vertical relationships',
     // preserves the full designed ink rather than clipping at either cell edge.
     const [comma, period] = pairedComponents(punctuationCtx, 'punctuation pair');
 
+    const retainedCentroidX = (ch: string) => {
+      const ctx = prepare();
+      const [planned] = planVerticalRunWithCapability(
+        ctx,
+        ch,
+        fontPx,
+        0,
+        1,
+        true,
+        (cp) => verticalVertGlyphReachable(ctx, cp),
+      );
+      if (!planned) throw new Error(`no retained glyph for ${ch}`);
+      ctx.translate(columnX, startY);
+      ctx.rotate(Math.PI / 2);
+      ctx.translate(planned.originPt, 0);
+      ctx.rotate(-Math.PI / 2);
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      withVert(ctx, () => ctx.fillText(
+        planned.text,
+        planned.drawOffsetPt.xPt,
+        planned.drawOffsetPt.yPt,
+      ));
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      return rangeInk(ctx, 0, canvas.height).centroidX;
+    };
+    const retainedAcross = {
+      open: retainedCentroidX('（'),
+      close: retainedCentroidX('）'),
+      comma: retainedCentroidX('、'),
+      period: retainedCentroidX('。'),
+    };
+
     return {
       fontPx,
+      columnX,
+      retainedAcross,
+      punctuationCentroids: {
+        comma: comma.centroidX,
+        period: period.centroidX,
+      },
       gapPx: latin.minY - prolonged.maxY - 1,
       prolongedAspect: (prolonged.maxY - prolonged.minY + 1) / (prolonged.maxX - prolonged.minX + 1),
       bracketBandSeparationPx:
@@ -348,6 +391,21 @@ test('layer A: the document font keeps Word-adjudicated vertical relationships',
     expect(punctuation.rightOfColumn).toBe(true);
     expect(punctuation.positionInCell, 'corner punctuation stays in the leading cell third').toBeLessThan(1 / 3);
   }
+  for (const retained of [result.retainedAcross.open, result.retainedAcross.close]) {
+    expect(
+      Math.abs(retained - result.columnX),
+      'retained vertical parentheses stay on the central column baseline',
+    ).toBeLessThan(result.fontPx * 0.05);
+  }
+  for (const [retained, direct] of [
+    [result.retainedAcross.comma, result.punctuationCentroids.comma],
+    [result.retainedAcross.period, result.punctuationCentroids.period],
+  ]) {
+    expect(
+      Math.abs(retained - direct),
+      'retained corner punctuation preserves the font vertical baseline',
+    ).toBeLessThan(result.fontPx * 0.05);
+  }
 });
 
 const VERT_REPERTOIRE = 'ー〜～、。「」（）：；！';
@@ -393,6 +451,8 @@ test('public detached and Offscreen rendering reproduce layout-proven vert glyph
       verticalVertGlyphReachable,
     } = await import('/src/vertical-text.ts');
     const { createLayoutServices } = await import('/src/layout-runtime.ts');
+    const { verticalGlyphMeasurementServiceOf } =
+      await import('/src/layout/runtime-state.ts');
     const { renderDocumentToCanvas } = await import('/src/renderer.ts');
     const { selectDocumentLayoutPage } = await import('/src/layout/document-layout-variants.ts');
     const subject = document.querySelector('#subject') as HTMLCanvasElement;
@@ -445,6 +505,26 @@ test('public detached and Offscreen rendering reproduce layout-proven vert glyph
     const attachedPlan = plan(attachedMeasure);
     attachedMeasureCanvas.remove();
 
+    // The viewer can be hosted across realms (for example Storybook previews
+    // or an iframe integration). A canvas created by that realm is not an
+    // instanceof the parent window's HTMLCanvasElement, but it must acquire the
+    // same feature-backed plan while remaining caller-owned and detached.
+    const foreignFrame = document.createElement('iframe');
+    document.body.appendChild(foreignFrame);
+    const foreignDocument = foreignFrame.contentDocument;
+    if (!foreignDocument?.body) throw new Error('foreign document unavailable');
+    const foreignDetachedCanvas = foreignDocument.createElement('canvas');
+    const foreignDetachedMeasure = foreignDetachedCanvas.getContext('2d');
+    if (!foreignDetachedMeasure) throw new Error('foreign detached context unavailable');
+    const foreignDetachedPlan = plan(foreignDetachedMeasure);
+    const foreignDetachedConnectedAfter = foreignDetachedCanvas.isConnected;
+    const foreignAttachedCanvas = foreignDocument.createElement('canvas');
+    foreignDocument.body.appendChild(foreignAttachedCanvas);
+    const foreignAttachedMeasure = foreignAttachedCanvas.getContext('2d');
+    if (!foreignAttachedMeasure) throw new Error('foreign attached context unavailable');
+    const foreignAttachedPlan = plan(foreignAttachedMeasure);
+    foreignFrame.remove();
+
     const textRun = {
       type: 'text', text: 'ー（）日',
       bold: false, italic: false, underline: false, strikethrough: false,
@@ -471,6 +551,39 @@ test('public detached and Offscreen rendering reproduce layout-proven vert glyph
       footers: { default: null, first: null, even: null },
       fontFamilyClasses: {},
     } as never;
+
+    const batchCanvas = document.createElement('canvas');
+    const batchContext = batchCanvas.getContext('2d');
+    if (!batchContext) throw new Error('batch measurement context unavailable');
+    batchContext.font = `48px "${selectedFamily}"`;
+    const batchServices = createLayoutServices(model, { measureContext: batchContext });
+    const batchMeasurement = verticalGlyphMeasurementServiceOf(batchServices);
+    const batchInput = {
+      text: '（'.repeat(20),
+      font: batchContext.font,
+      fontKerning: batchContext.fontKerning,
+      fontSizePt: 48,
+      letterSpacingPt: 0,
+      charScale: 1,
+      growTrRotateInk: true,
+      writingMode: 'vertical-rl' as const,
+    };
+    // Warm the shared feature probe before observing the caller-owned canvas.
+    batchMeasurement.planRun(batchInput);
+    let acquisitionMutationNodes = 0;
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        acquisitionMutationNodes += [...record.addedNodes, ...record.removedNodes]
+          .filter((node) => node === batchCanvas).length;
+      }
+    });
+    observer.observe(document.body, { childList: true });
+    batchContext.font = batchInput.font;
+    batchMeasurement.measureRunInkExtra(batchInput.text);
+    batchMeasurement.planRun(batchInput);
+    await Promise.resolve();
+    observer.disconnect();
+
     const services = createLayoutServices(model);
     const defaultCurrentDateMs = 1;
     await renderDocumentToCanvas(model, subject, 0, {
@@ -545,7 +658,12 @@ test('public detached and Offscreen rendering reproduce layout-proven vert glyph
       family: selectedFamily,
       detachedPlan,
       attachedPlan,
+      foreignDetachedPlan,
+      foreignAttachedPlan,
+      foreignDetachedConnectedAfter,
       detachedMeasureConnectedAfter,
+      acquisitionMutationNodes,
+      batchCanvasConnectedAfter: batchCanvas.isConnected,
       retainedGlyphs,
       detachedConnectedBefore,
       detachedConnectedAfter,
@@ -562,7 +680,12 @@ test('public detached and Offscreen rendering reproduce layout-proven vert glyph
   test.skip(result === null, 'a host font with a reachable OpenType vert glyph is required');
   if (result === null) return;
   expect(result.detachedPlan).toEqual(result.attachedPlan);
+  expect(result.foreignDetachedPlan).toEqual(result.foreignAttachedPlan);
+  expect(result.foreignDetachedConnectedAfter).toBe(false);
   expect(result.detachedMeasureConnectedAfter).toBe(false);
+  // One attach/remove scope for run-width acquisition and one for run planning.
+  expect(result.acquisitionMutationNodes).toBe(4);
+  expect(result.batchCanvasConnectedAfter).toBe(false);
   expect(result.retainedGlyphs).toEqual({
     'ー': { upright: true, verticalFeature: true },
     '（': { upright: true, verticalFeature: true },
@@ -625,4 +748,50 @@ test('forced unreachable keeps FE/upright fallbacks and plain-rotates long marks
   expect(result.rotations.every((angle) => angle === -Math.PI / 2)).toBe(true);
   expect(result.scales.some(([, y]) => y === -1)).toBe(false);
   expect(result.transforms).toEqual([]);
+});
+
+test('feature acquisition restores a detached caller canvas after failure', async ({ page }) => {
+  await page.goto('/tests/visual/vertical-vert-feature.html');
+  const result = await page.evaluate(async () => {
+    const { withVertFeature } = await import('/src/vertical-text.ts');
+    const fragment = document.createDocumentFragment();
+    const before = document.createElement('span');
+    const canvas = document.createElement('canvas');
+    const after = document.createElement('span');
+    canvas.style.cssText =
+      'position:relative;left:7px;top:3px;opacity:0.75;pointer-events:auto;font-feature-settings:"kern" 1';
+    fragment.append(before, canvas, after);
+    const originalCssText = canvas.style.cssText;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('2D context unavailable');
+    let message = '';
+    try {
+      withVertFeature(ctx, () => {
+        if (!canvas.isConnected) throw new Error('canvas was not connected');
+        after.remove();
+        throw new Error('expected acquisition failure');
+      });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    return {
+      message,
+      isConnected: canvas.isConnected,
+      parentRestored: canvas.parentNode === fragment,
+      orderRestored: [...fragment.childNodes].map((node) => (
+        node === before ? 'before' : node === canvas ? 'canvas' : 'after'
+      )),
+      cssRestored: canvas.style.cssText === originalCssText,
+      featureRestored: canvas.style.fontFeatureSettings,
+    };
+  });
+
+  expect(result).toEqual({
+    message: 'expected acquisition failure',
+    isConnected: false,
+    parentRestored: true,
+    orderRestored: ['before', 'canvas'],
+    cssRestored: true,
+    featureRestored: '"kern"',
+  });
 });


### PR DESCRIPTION
## Summary

- acquire OpenType `vert` capability under the same connected Canvas conditions used for paint, including detached and cross-realm canvases
- retain font-derived vertical glyph advances, origins, orientation, and offsets in immutable layout operations; paint only projects that geometry
- keep negative vertical pitch in retained upright/rotate cell geometry instead of applying it a second time through Canvas `letterSpacing`; retain Canvas spacing for contextual sideways text and horizontal tate-chu-yoko
- preserve numbering-indent provenance so paragraph-style numbering and direct `numPr` follow their distinct ECMA-376 cascade positions, independently for each indent axis
- tolerate only machine-precision drift at inclusive retained-layout boundaries
- make local Word-PDF acceptance use the same opt-in MathJax engine as Storybook so equation-bearing pagination is measured accurately

## Root cause

Detached Canvas acquisition could not observe Chromium's font-feature-backed vertical metrics, while paint used an attached canvas and therefore selected different glyph behavior. An attempted retained-origin correction then shifted font-designed vertical alternates away from their intended central baseline. After the retained plan was established, upright and rotated one-glyph cells still received the same negative pitch through Canvas `letterSpacing`, shifting centered ink on the physical cross axis even though the cell origin and advance already contained that pitch.

The parser also collapsed document defaults, table styles, paragraph styles, and direct formatting before resolving numbering-level paragraph properties. That lost whether `numPr` came from a paragraph style or direct formatting, although ECMA-376 §§17.7.2, 17.7.8.1, and 17.9.22 place those two sources at different points in the cascade.

## Architecture

The repair keeps the Issue #1037 single pipeline intact. Font capabilities and metrics are acquired during layout, stored as immutable point-space paint operations, and consumed without paint-time measurement or glyph reclassification. Vertical upright/rotate cells own their complete pitch in retained origins and advances; only operations that contain contextual horizontal text keep Canvas spacing. DOM-only vertical pages fail closed from worker rendering because OffscreenCanvas cannot prove the selected font's `vert` behavior.

The parser now retains the minimum provenance needed to apply numbering-level paragraph properties before or after the paragraph-style layer as required. No fixture-specific geometry, paint-time style resolution, or legacy layout fallback was added.

## Verification

- full Vitest suite: 552 files passed / 8 skipped; 5,796 tests passed / 25 skipped
- DOCX parser: 433 unit tests + 10 diagnostics tests passed
- focused paragraph/layout/paint tests: 111 passed
- Chrome real-font vertical conformance: 7 passed, including negative-pitch cross-axis checks for representative brackets, quotation marks, punctuation, question/exclamation marks, long marks, middle dots, and ellipses
- final DOCX layout-boundary gate: passed
- DOCX boundary tests: 88 passed
- compatibility evidence: 17 passed
- public API: 23 passed
- package build checks: 2 passed
- `pnpm typecheck`: passed
- `pnpm build:packages`: passed
- `pnpm build`: passed
- `git diff --check`: passed

Local Word-PDF allocation and visual comparisons were also run without committing or disclosing private fixtures.