### PR TITLE
fix(xlsx): prevent zoom controls from submitting forms

### DIFF
--- a/packages/xlsx/src/viewer-zoom-contract.test.ts
+++ b/packages/xlsx/src/viewer-zoom-contract.test.ts
@@ -414,6 +414,12 @@ describe('XlsxViewer built-in +/- buttons follow the shared ladder (issue #842)'
     b.v.zoomIn();
     expect(a.v.getScale()).toBe(b.v.getScale());
   });
+
+  it('uses non-submit buttons so a surrounding form is not submitted (issue #1082)', () => {
+    const { minus, plus } = mountWithButtons();
+    expect(minus.type).toBe('button');
+    expect(plus.type).toBe('button');
+  });
 });
 
 /**

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -3059,6 +3059,7 @@ export class XlsxViewer implements ZoomableViewer {
     // Pre-IX9 these stepped ±0.1 linearly.
     const mkBtn = (glyph: string, label: string, step: () => void): HTMLButtonElement => {
       const b = document.createElement('button');
+      b.type = 'button';
       b.textContent = glyph;
       b.setAttribute('aria-label', label);
       b.title = label;


### PR DESCRIPTION
## Summary

- set `type="button"` on the XLSX viewer's built-in zoom-out and zoom-in controls
- add a focused regression test for both controls

## Root cause

HTML `<button>` elements default to submit buttons when nested inside a form. The zoom controls did not declare a button type, so clicking them could submit a surrounding host form.

## Verification

- `vitest run packages/xlsx/src/viewer-zoom-contract.test.ts` (23 tests passed)
- `git diff --check`

Closes #1082