### PR TITLE
fix(docx): contain unsupported optional drawings

### DIFF
--- a/docs/docx-layout-engine-redesign.md
+++ b/docs/docx-layout-engine-redesign.md
@@ -309,6 +309,24 @@ diagnostic. NaN geometry, invalid ownership, non-convergence, or broken layout
 invariants use the existing render error path. Public error callback signatures do
 not change.
 
+Failure containment follows the retained-layout ownership boundary:
+
+- unsupported or malformed optional content is recoverable only when its layout
+  node can be replaced by a deterministic retained no-op without inventing
+  geometry or changing surrounding flow;
+- the retained node owns an immutable diagnostic with a stable source reference,
+  and pagination collects that diagnostic into `DocumentLayout`;
+- valid content before and after the recoverable node continues through the same
+  acquisition, pagination, and paint pipeline;
+- corrupt required package parts, non-finite or negative geometry, invalid
+  ownership, non-convergence, and invariant violations remain fatal;
+- a recoverable failure never invokes a legacy renderer, retries with guessed
+  defaults, or weakens the validation of fatal state.
+
+This classification is made at the narrowest layer that understands whether the
+feature is optional. Catching arbitrary exceptions at the viewer boundary would
+erase that distinction and could paint a structurally invalid layout.
+
 ## Worker Mode
 
 Main-thread and worker rendering call the same layout and paint modules. Worker

--- a/packages/docx/src/layout/body-paginator.ts
+++ b/packages/docx/src/layout/body-paginator.ts
@@ -146,11 +146,17 @@ function nestedStoryDiagnostics(
 ): readonly LayoutDiagnostic[] {
   if (visited.has(node)) return [];
   visited.add(node);
+  const own = node.diagnostics ?? [];
   if (node.kind === 'paragraph') {
-    return node.textBoxes.flatMap((textBox) => nestedStoryDiagnostics(textBox, visited));
+    return [
+      ...own,
+      ...node.drawings.flatMap((drawing) => nestedStoryDiagnostics(drawing, visited)),
+      ...node.textBoxes.flatMap((textBox) => nestedStoryDiagnostics(textBox, visited)),
+    ];
   }
   if (node.kind === 'table') {
     return [
+      ...own,
       ...node.rows.flatMap((row) => row.cells.flatMap((cell) =>
         cell.blocks.flatMap((block) => nestedStoryDiagnostics(block.layout, visited)))),
       ...(node.floatingTables ?? []).flatMap((placement) =>
@@ -161,11 +167,12 @@ function nestedStoryDiagnostics(
   }
   if (node.kind === 'textbox' || node.kind === 'note') {
     return [
+      ...own,
       ...node.story.diagnostics,
       ...node.story.blocks.flatMap((block) => nestedStoryDiagnostics(block, visited)),
     ];
   }
-  return [];
+  return own;
 }
 
 function assertFreshPageFootnoteAdmission(

--- a/packages/docx/src/layout/canonical-producer-real-model.test.ts
+++ b/packages/docx/src/layout/canonical-producer-real-model.test.ts
@@ -88,6 +88,38 @@ function pageOwnedWrappingParagraph(): BodyElement {
   return result as unknown as BodyElement;
 }
 
+function unsupportedTextPathParagraph(): BodyElement {
+  const result = ordinaryParagraph('');
+  result.runs = [{
+    type: 'shape',
+    widthPt: 30,
+    heightPt: 20,
+    anchorXPt: 0,
+    anchorYPt: 0,
+    anchorXFromMargin: false,
+    anchorYFromPara: true,
+    zOrder: 0,
+    subpaths: [],
+    presetGeometry: 'rect',
+    fill: { fillType: 'solid', color: 'D9D9D9' },
+    stroke: null,
+    textPath: {
+      string: 'DRAFT',
+      fontFamily: 'Arial',
+      bold: false,
+      italic: false,
+      textPathOk: true,
+      on: true,
+      fitShape: true,
+      fitPath: true,
+      trim: false,
+      xScale: false,
+      fontSizePt: 12,
+    },
+  }] as unknown as DocParagraph['runs'];
+  return result as unknown as BodyElement;
+}
+
 function sectionBreak(): BodyElement {
   return {
     type: 'sectionBreak', kind: 'continuous', columns: null,
@@ -158,6 +190,46 @@ function fragmentLineAdvancesPt(fragment: Extract<ReturnType<typeof layoutDocume
 }
 
 describe('canonical producer with a real document model', () => {
+  it('keeps valid surrounding body blocks when an optional drawing feature is unsupported', () => {
+    const section = {
+      pageWidth: 200, pageHeight: 100,
+      marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+      headerDistance: 5, footerDistance: 5, titlePage: false,
+      evenAndOddHeaders: false, sectionStart: 'nextPage', columns: null,
+    } as SectionProps;
+    const model = {
+      section,
+      body: [
+        ordinaryBodyParagraph('before'),
+        unsupportedTextPathParagraph(),
+        ordinaryBodyParagraph('after'),
+      ],
+      headers: { default: null, first: null, even: null },
+      footers: { default: null, first: null, even: null },
+      footnotes: [], endnotes: [], fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const services = createLayoutServices(model, { measureContext: measureContext() });
+
+    const layout = layoutDocument(model, services, { currentDateMs: 0 });
+    const paragraphs = layout.pages.flatMap((page) => page.layers.body)
+      .filter((node) => node.kind === 'paragraph');
+    const text = paragraphs.flatMap((paragraph) => paragraph.lines)
+      .flatMap((line) => line.placements)
+      .filter((placement) => placement.kind === 'text')
+      .map((placement) => placement.text);
+    const unsupported = paragraphs.find((paragraph) => paragraph.source.path[0] === 1);
+
+    expect(text).toEqual(expect.arrayContaining(['before', 'after']));
+    expect(unsupported?.drawings[0]?.commands).toEqual([{ kind: 'noop' }]);
+    expect(layout.diagnostics).toContainEqual({
+      code: 'UNSUPPORTED_FEATURE',
+      severity: 'error',
+      source: { story: 'body', storyInstance: 'body', path: [1, 0] },
+      message: 'VML textPath fitPath=true is not rendered',
+    });
+    expect(Object.isFrozen(layout.diagnostics[0])).toBe(true);
+  });
+
   it('lays out document-end notes through the retained story engine', () => {
     const section = {
       pageWidth: 200, pageHeight: 100,

--- a/packages/docx/src/layout/invariants.test.ts
+++ b/packages/docx/src/layout/invariants.test.ts
@@ -1183,6 +1183,24 @@ describe('layoutFingerprint', () => {
     expect(layoutFingerprint(first)).toBe(layoutFingerprint(second));
     expect(layoutFingerprint(first)).not.toBe(layoutFingerprint(changedCode));
   });
+
+  it('excludes retained node diagnostic prose while preserving its identity', () => {
+    const retained = (message: string, code: DocumentLayout['diagnostics'][number]['code']) => ({
+      ...drawing('n1', rect(72, 100, 200, 30)),
+      diagnostics: [{
+        code,
+        severity: 'warning' as const,
+        source: source(1),
+        message,
+      }],
+    });
+    const first = documentWith([retained('first prose', 'UNSUPPORTED_FEATURE')]);
+    const second = documentWith([retained('different prose', 'UNSUPPORTED_FEATURE')]);
+    const changedCode = documentWith([retained('different prose', 'NON_CONVERGENCE')]);
+
+    expect(layoutFingerprint(first)).toBe(layoutFingerprint(second));
+    expect(layoutFingerprint(first)).not.toBe(layoutFingerprint(changedCode));
+  });
 });
 
 describe('layoutFlowBlocks', () => {

--- a/packages/docx/src/layout/invariants.ts
+++ b/packages/docx/src/layout/invariants.ts
@@ -991,6 +991,15 @@ export function assertDocumentLayout(layout: DocumentLayout): void {
   }
 }
 
+function isLayoutDiagnosticRecord(
+  value: Readonly<Record<string, unknown>>,
+): boolean {
+  return typeof value.code === 'string'
+    && LAYOUT_DIAGNOSTIC_CODES.has(value.code as LayoutDiagnosticCode)
+    && (value.severity === 'warning' || value.severity === 'error')
+    && typeof value.message === 'string';
+}
+
 function canonicalize(value: unknown): unknown {
   if (typeof value === 'number') {
     if (!Number.isFinite(value)) throw new LayoutInvariantError('INVALID_GEOMETRY', 'fingerprint input is not finite');
@@ -1000,7 +1009,10 @@ function canonicalize(value: unknown): unknown {
   if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
   if (Array.isArray(value)) return value.map((entry) => canonicalize(entry));
   if (typeof value === 'object') {
-    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+    const record = value as Record<string, unknown>;
+    const diagnostic = isLayoutDiagnosticRecord(record);
+    return Object.fromEntries(Object.entries(record)
+      .filter(([entryKey]) => !(diagnostic && entryKey === 'message'))
       .sort(([left], [right]) => left.localeCompare(right))
       .map(([entryKey, entry]) => [entryKey, canonicalize(entry)]));
   }

--- a/packages/docx/src/layout/occurrence-projection.test.ts
+++ b/packages/docx/src/layout/occurrence-projection.test.ts
@@ -250,6 +250,12 @@ describe('projectBodyOccurrence', () => {
     const drawing = {
       kind: 'drawing' as const, id: 'drawing/a', source: source([0, 0]), flowDomainId: 'body', ordinaryFlow: false,
       flowBounds: rect(3, 4), inkBounds: rect(3, 4), advancePt: 0, commands: [],
+      diagnostics: [{
+        code: 'UNSUPPORTED_FEATURE' as const,
+        severity: 'error' as const,
+        source: source([0, 0]),
+        message: 'Unsupported optional drawing omitted',
+      }],
       anchorLayer: {
         occurrenceId: 'anchor/a', behindDoc: false, relativeHeight: 1, sourceOrder: 0,
         horizontalOwnership: 'host' as const, verticalOwnership: 'host' as const,
@@ -276,6 +282,9 @@ describe('projectBodyOccurrence', () => {
     expect(first.id).toBe('page 2/header/node/paragraph');
     expect(first.drawings[0]!.id).toBe('page 2/header/node/drawing%2Fa');
     expect(first.lines[0]!.placements[0]).toMatchObject({ drawingId: first.drawings[0]!.id });
+    expect(first.drawings[0]!.diagnostics).toEqual(drawing.diagnostics);
+    expect(Object.isFrozen(first.drawings[0]!.diagnostics)).toBe(true);
+    expect(Object.isFrozen(first.drawings[0]!.diagnostics![0])).toBe(true);
     expect(anchor).toMatchObject({
       occurrenceId: 'page 2/header/anchor/anchor%2Fa', acquisitionOccurrenceId: 'anchor/a',
     });

--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -35,7 +35,10 @@ import {
 import { computeKashidaDistribution, type KashidaLevel } from '../kashida-justify.js';
 import { imageResourceKey } from './source-key.js';
 import { stableFingerprint } from './fingerprint.js';
-import { planShapeDrawing } from './shape-drawing-plan.js';
+import {
+  planShapeDrawing,
+  type ShapeDrawingPlanResult,
+} from './shape-drawing-plan.js';
 import {
   normalizeTextBoxInput,
   type CompleteTextBoxBlockInput,
@@ -126,6 +129,7 @@ import type {
   AcquiredParagraphLayoutInput,
   InlineResourceLayout,
   LineLayout,
+  LayoutDiagnostic,
   LayoutRect,
   Matrix2DData,
   ParagraphLayout,
@@ -1011,6 +1015,21 @@ export interface ParagraphAcquisitionOptions {
 
 function runSource(source: SourceRef, runIndex: number): SourceRef {
   return { ...source, path: [...source.path, runIndex] };
+}
+
+function shapePlanDiagnostics(
+  plan: ShapeDrawingPlanResult,
+  source: SourceRef,
+): readonly LayoutDiagnostic[] {
+  if (plan.status === 'planned') return Object.freeze([]);
+  const retainedSource = Object.freeze({
+    ...source,
+    path: Object.freeze([...source.path]),
+  });
+  return Object.freeze(plan.diagnostics.map((diagnostic) => Object.freeze({
+    ...diagnostic,
+    source: retainedSource,
+  })));
 }
 
 function chartResourceKey(source: SourceRef): string {
@@ -2144,11 +2163,13 @@ function drawingForShape(
     shape.vmlTextPathInput,
   );
   const commands = [plan.command];
+  const diagnostics = shapePlanDiagnostics(plan, runSource(options.source, runIndex));
   return {
     kind: 'drawing', id: `${options.id}:drawing:${runIndex}`, source: runSource(options.source, runIndex),
     flowDomainId: options.flowDomainId, flowBounds: rect, inkBounds: rect, advancePt: 0,
     ordinaryFlow: false,
     commands,
+    ...(diagnostics.length === 0 ? {} : { diagnostics }),
     anchorLayer: {
       occurrenceId: `public-shape:${options.id}:${runIndex}`,
       behindDoc: shape.behindDoc === true,
@@ -2571,6 +2592,7 @@ function acquireAnchorOccurrence(
     verticalPageFrame: false,
   } : options.environment;
   const commands: DrawingPaintCommand[] = [];
+  const diagnostics: LayoutDiagnostic[] = [];
   const textBoxes: TextBoxLayout[] = [];
   const textBoxIds: string[] = [];
   const acquiredShapeTextBoxes = new Map<number, TextBoxLayout>();
@@ -2721,12 +2743,14 @@ function acquireAnchorOccurrence(
         flipH: childTransform.flipH,
         flipV: childTransform.flipV,
       } : run;
-      commands.push(planShapeDrawing(
+      const plan = planShapeDrawing(
         plannedRun,
         paintRect,
         options.environment.layoutServices?.text,
         run.vmlTextPathInput,
-      ).command);
+      );
+      commands.push(plan.command);
+      diagnostics.push(...shapePlanDiagnostics(plan, source));
       const textBoxId = `${options.id}:anchor-textbox:${occurrenceId}:${runIndex}`;
       const textBox = acquiredShapeTextBoxes.get(runIndex) ?? acquireShapeTextBoxLayout(run, paintRect, {
         id: textBoxId,
@@ -2759,6 +2783,7 @@ function acquireAnchorOccurrence(
       transform: uprightTransform,
     } : {}),
     commands,
+    ...(diagnostics.length === 0 ? {} : { diagnostics: Object.freeze(diagnostics) }),
     anchorLayer: {
       occurrenceId,
       behindDoc: behavior.behindDoc,

--- a/packages/docx/src/layout/shape-drawing-plan.test.ts
+++ b/packages/docx/src/layout/shape-drawing-plan.test.ts
@@ -228,15 +228,38 @@ describe('ShapeRun drawing command planner', () => {
     expect(result.command).toEqual({ kind: 'noop' });
   });
 
-  it.each(['fitPath', 'xScale'] as const)('rejects unsupported active %s semantics deterministically', (control) => {
+  it.each(['fitPath', 'xScale'] as const)('isolates unsupported active %s semantics as a diagnostic noop', (control) => {
     const text = { shape: () => { throw new Error('unsupported mode must be rejected before shaping'); } } as unknown as TextLayoutService;
-    expect(() => textPathPlan(shape({
+    const result = textPathPlan(shape({
       textPath: {
         string: 'DRAFT', textPathOk: true, on: true, fitShape: false,
         fitPath: false, trim: false, xScale: false, [control]: true,
       } as NonNullable<InternalShapeRun['textPath']>,
-    }), { xPt: 0, yPt: 0, widthPt: 20, heightPt: 20 }, text))
-      .toThrow(`Unsupported VML textPath ${control}=true`);
+    }), { xPt: 0, yPt: 0, widthPt: 20, heightPt: 20 }, text);
+
+    expect(result).toEqual({
+      status: 'unsupported',
+      command: { kind: 'noop' },
+      diagnostics: [{
+        code: 'UNSUPPORTED_FEATURE',
+        severity: 'error',
+        message: `VML textPath ${control}=true is not rendered`,
+      }],
+    });
+  });
+
+  it.each([
+    [Number.NaN, /must contain finite numbers/],
+    [-1, /must be finite and non-negative/],
+  ] as const)('keeps invalid textPath font size %s fatal', (fontSizePt, expected) => {
+    const text = { shape: () => { throw new Error('invalid input must fail before shaping'); } } as unknown as TextLayoutService;
+    expect(() => textPathPlan(shape({
+      textPath: {
+        string: 'DRAFT', textPathOk: true, on: true, fitShape: true,
+        fitPath: false, trim: false, xScale: false, fontSizePt,
+      },
+    } as InternalShapeRun), { xPt: 0, yPt: 0, widthPt: 20, heightPt: 20 }, text))
+      .toThrow(expected);
   });
 
   it('rejects trim when the measurement adapter cannot provide ink bounds', () => {

--- a/packages/docx/src/layout/shape-drawing-plan.test.ts
+++ b/packages/docx/src/layout/shape-drawing-plan.test.ts
@@ -213,7 +213,15 @@ describe('ShapeRun drawing command planner', () => {
       kind: 'watermark-text',
       sourceBounds: { xPt: -2, yPt: -7, widthPt: 5, heightPt: 8 },
     });
-    expect(() => make(false)).toThrow(/degenerate metrics/);
+    expect(make(false)).toEqual({
+      status: 'unsupported',
+      command: { kind: 'noop' },
+      diagnostics: [{
+        code: 'UNSUPPORTED_FEATURE',
+        severity: 'error',
+        message: 'VML textPath produced empty glyph metrics',
+      }],
+    });
   });
 
   it('turns whitespace-only content into a paint no-op without shaping', () => {
@@ -262,7 +270,31 @@ describe('ShapeRun drawing command planner', () => {
       .toThrow(expected);
   });
 
-  it('rejects trim when the measurement adapter cannot provide ink bounds', () => {
+  it('isolates fitShape=false without an authored font size before shaping', () => {
+    const text = {
+      shape: () => { throw new Error('unsupported input must not be shaped'); },
+    } as unknown as TextLayoutService;
+
+    const result = textPathPlan(shape({
+      textPath: {
+        string: 'DRAFT', fontFamily: 'Arial', bold: false, italic: false,
+        textPathOk: true, on: true, fitShape: false, fitPath: false,
+        trim: false, xScale: false,
+      },
+    } as InternalShapeRun), { xPt: 1, yPt: 2, widthPt: 300, heightPt: 120 }, text);
+
+    expect(result).toEqual({
+      status: 'unsupported',
+      command: { kind: 'noop' },
+      diagnostics: [{
+        code: 'UNSUPPORTED_FEATURE',
+        severity: 'error',
+        message: 'VML textPath fitShape=false requires an authored font-size',
+      }],
+    });
+  });
+
+  it('isolates trim when the measurement adapter cannot provide ink bounds', () => {
     const text = {
       shape: () => ({
         advancePt: 20, ascentPt: 8, descentPt: 2,
@@ -275,14 +307,45 @@ describe('ShapeRun drawing command planner', () => {
       }),
     } as unknown as TextLayoutService;
 
-    expect(() => textPathPlan(shape({
+    const result = textPathPlan(shape({
       textPath: {
         string: 'DRAFT', fontFamily: 'Arial', bold: false, italic: false,
         textPathOk: true, on: true, fitShape: true, fitPath: false,
         trim: true, xScale: false, fontSizePt: 12,
       },
-    } as InternalShapeRun), { xPt: 1, yPt: 2, widthPt: 300, heightPt: 120 }, text)).toThrow(
-      'VML textPath trim=true requires glyph ink bounds',
-    );
+    } as InternalShapeRun), { xPt: 1, yPt: 2, widthPt: 300, heightPt: 120 }, text);
+
+    expect(result).toEqual({
+      status: 'unsupported',
+      command: { kind: 'noop' },
+      diagnostics: [{
+        code: 'UNSUPPORTED_FEATURE',
+        severity: 'error',
+        message: 'VML textPath trim=true requires glyph ink bounds',
+      }],
+    });
+  });
+
+  it('keeps non-finite shaped text metrics fatal', () => {
+    const text = {
+      shape: () => ({
+        advancePt: Number.POSITIVE_INFINITY, ascentPt: 8, descentPt: 2,
+        spans: [{
+          text: 'DRAFT', start: 0, end: 5, script: 'ascii', breakBefore: true,
+          advancePt: Number.POSITIVE_INFINITY, ascentPt: 8, descentPt: 2,
+          font: { route: { familyList: 'Arial', scope: 'native', fingerprint: 'arial' }, weight: 400, style: 'normal', diagnostics: [] },
+          fontRoute: { familyList: 'Arial', scope: 'native', fingerprint: 'arial' },
+        }], graphemeBoundaries: [0, 5], diagnostics: [],
+      }),
+    } as unknown as TextLayoutService;
+
+    expect(() => textPathPlan(shape({
+      textPath: {
+        string: 'DRAFT', fontFamily: 'Arial', bold: false, italic: false,
+        textPathOk: true, on: true, fitShape: true, fitPath: false,
+        trim: false, xScale: false, fontSizePt: 12,
+      },
+    } as InternalShapeRun), { xPt: 1, yPt: 2, widthPt: 300, heightPt: 120 }, text))
+      .toThrow('Shape textPath acquisition produced non-finite metrics');
   });
 });

--- a/packages/docx/src/layout/shape-drawing-plan.ts
+++ b/packages/docx/src/layout/shape-drawing-plan.ts
@@ -31,7 +31,7 @@ export type ShapeDrawingPlanResult =
 const SCALE_NEUTRAL_REFERENCE_FONT_SIZE_PT = 1;
 
 function unsupportedTextPathPlan(
-  control: 'fitPath' | 'xScale',
+  message: string,
 ): Extract<ShapeDrawingPlanResult, { status: 'unsupported' }> {
   return Object.freeze({
     status: 'unsupported',
@@ -39,7 +39,7 @@ function unsupportedTextPathPlan(
     diagnostics: Object.freeze([Object.freeze({
       code: 'UNSUPPORTED_FEATURE',
       severity: 'error',
-      message: `VML textPath ${control}=true is not rendered`,
+      message,
     })]),
   });
 }
@@ -84,10 +84,10 @@ export function planShapeDrawing(
   );
   if (textPathEnabled) {
     if (textPath.fitPath === true) {
-      return unsupportedTextPathPlan('fitPath');
+      return unsupportedTextPathPlan('VML textPath fitPath=true is not rendered');
     }
     if (textPath.xScale === true) {
-      return unsupportedTextPathPlan('xScale');
+      return unsupportedTextPathPlan('VML textPath xScale=true is not rendered');
     }
     if (textPath.string.trim().length === 0) {
       return Object.freeze({ status: 'planned', command: Object.freeze({ kind: 'noop' }) });
@@ -99,7 +99,9 @@ export function planShapeDrawing(
       throw new RangeError('VML textPath fontSizePt must be finite and non-negative');
     }
     if (!fitShape && textPath.fontSizePt === undefined) {
-      throw new Error('VML textPath fitShape=false requires an authored font-size');
+      return unsupportedTextPathPlan(
+        'VML textPath fitShape=false requires an authored font-size',
+      );
     }
     if (textPath.fontSizePt === 0) {
       return Object.freeze({ status: 'planned', command: Object.freeze({ kind: 'noop' }) });
@@ -120,7 +122,9 @@ export function planShapeDrawing(
       measure: true,
     });
     if (textPath.trim === true && !shaped.inkBounds) {
-      throw new Error('VML textPath trim=true requires glyph ink bounds');
+      return unsupportedTextPathPlan(
+        'VML textPath trim=true requires glyph ink bounds',
+      );
     }
     // The retained source rectangle must choose one coherent metric domain:
     // trim removes the font's reserved box and uses tight actual ink, while
@@ -139,13 +143,17 @@ export function planShapeDrawing(
     };
     if (
       !Number.isFinite(shaped.advancePt)
-      || !Number.isFinite(sourceBounds.widthPt)
-      || sourceBounds.widthPt <= 0
-      || !Number.isFinite(sourceBounds.heightPt)
+      || Object.values(sourceBounds).some((value) => !Number.isFinite(value))
+      || shaped.spans.some((span) => !Number.isFinite(span.advancePt))
+    ) {
+      throw new Error('Shape textPath acquisition produced non-finite metrics');
+    }
+    if (
+      sourceBounds.widthPt <= 0
       || sourceBounds.heightPt <= 0
       || shaped.spans.length === 0
     ) {
-      throw new Error('Shape textPath acquisition produced degenerate metrics');
+      return unsupportedTextPathPlan('VML textPath produced empty glyph metrics');
     }
     return Object.freeze({
       status: 'planned',

--- a/packages/docx/src/layout/shape-drawing-plan.ts
+++ b/packages/docx/src/layout/shape-drawing-plan.ts
@@ -2,21 +2,47 @@ import type { ArrowEnd, DrawingMLShapePaintPlan, Stroke } from '@silurus/ooxml-c
 import type { ShapeRun } from '../types.js';
 import type {
   DrawingPaintCommand,
+  LayoutDiagnostic,
   LayoutRect,
   VmlTextPathAcquisitionInput,
 } from './types.js';
 import { snapshotPlainData } from './plain-data.js';
 import type { TextLayoutService } from './text.js';
 
-export type ShapeDrawingPlanResult = Readonly<{
-  status: 'planned';
-  command: Extract<DrawingPaintCommand, { kind: 'noop' | 'drawingml-shape' | 'watermark-text' }>;
-}>;
+type ShapeDrawingCommand = Extract<
+  DrawingPaintCommand,
+  { kind: 'noop' | 'drawingml-shape' | 'watermark-text' }
+>;
+
+export type ShapeDrawingPlanResult =
+  | Readonly<{
+      status: 'planned';
+      command: ShapeDrawingCommand;
+    }>
+  | Readonly<{
+      status: 'unsupported';
+      command: Extract<DrawingPaintCommand, { kind: 'noop' }>;
+      diagnostics: readonly Readonly<Omit<LayoutDiagnostic, 'source'>>[];
+    }>;
 
 // When fitshape is active, every shaped dimension is multiplied by the same
 // target/source ratio, so a 1pt internal reference cancels out exactly. This is
 // used only when VML omitted font-size; an authored size is never replaced.
 const SCALE_NEUTRAL_REFERENCE_FONT_SIZE_PT = 1;
+
+function unsupportedTextPathPlan(
+  control: 'fitPath' | 'xScale',
+): Extract<ShapeDrawingPlanResult, { status: 'unsupported' }> {
+  return Object.freeze({
+    status: 'unsupported',
+    command: Object.freeze({ kind: 'noop' }),
+    diagnostics: Object.freeze([Object.freeze({
+      code: 'UNSUPPORTED_FEATURE',
+      severity: 'error',
+      message: `VML textPath ${control}=true is not rendered`,
+    })]),
+  });
+}
 
 function arrowEnd(end: ShapeRun['headEnd']): ArrowEnd | undefined {
   return end ? { type: end.type, w: end.w, len: end.len } : undefined;
@@ -58,10 +84,10 @@ export function planShapeDrawing(
   );
   if (textPathEnabled) {
     if (textPath.fitPath === true) {
-      throw new Error('Unsupported VML textPath fitPath=true');
+      return unsupportedTextPathPlan('fitPath');
     }
     if (textPath.xScale === true) {
-      throw new Error('Unsupported VML textPath xScale=true');
+      return unsupportedTextPathPlan('xScale');
     }
     if (textPath.string.trim().length === 0) {
       return Object.freeze({ status: 'planned', command: Object.freeze({ kind: 'noop' }) });

--- a/packages/docx/src/layout/types.ts
+++ b/packages/docx/src/layout/types.ts
@@ -108,6 +108,8 @@ export interface FlowOwnership {
 interface LayoutNodeBase extends FlowOwnership {
   readonly id: LayoutNodeId;
   readonly source: SourceRef;
+  /** Recoverable acquisition facts owned by this retained node. */
+  readonly diagnostics?: readonly LayoutDiagnostic[];
 }
 
 export type DrawingPaintCommand =


### PR DESCRIPTION
## Summary

- retain unsupported or unmeasurable optional VML text paths as diagnostic no-op drawing nodes
- preserve valid surrounding body content through the canonical layout and paint pipeline
- keep invalid numeric geometry and other structural failures fatal
- exclude retained diagnostic prose from stable layout fingerprints at every node depth
- document the recoverable/fatal failure-containment boundary

## Design

This is the first vertical slice of #1088. It covers active unsupported VML text-path controls, a schema-valid non-fitting text path without an authored font size, unavailable tight ink bounds, and finite empty glyph metrics. Recovery is decided at the narrowest layer that knows the feature is optional. The retained node owns an immutable diagnostic with a stable source reference; pagination collects it into the document layout. There is no legacy renderer fallback, catch-all exception suppression, guessed geometry, or paint-time branching.

The issue remains open for additional independently proven recoverable feature classes and later-stage failure handling.

## Verification

- focused layout, occurrence projection, invariant, and worker parity tests (112 tests)
- full test suite (5,803 passed; 25 skipped)
- root typecheck
- DOCX package build
- final DOCX layout boundary audit
- DOCX boundary test suite
- git diff check

Closes no issue; progresses #1088 and #1037.
