### PR TITLE
fix(docx): retain full-width colon spacing

### DIFF
--- a/packages/docx/src/charspacing-paint.test.ts
+++ b/packages/docx/src/charspacing-paint.test.ts
@@ -66,7 +66,7 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; fills: FillCall[] }
         // The punctuation fixture exposes a selected-glyph right ink edge at
         // half its full-width cell. Other text fills its complete advance.
         actualBoundingBoxRight:
-          [...s].length === 1 && /[、．しない）]/u.test(s) ? p / 2 : w,
+          [...s].length === 1 && /[、．：しない）]/u.test(s) ? p / 2 : w,
         fontBoundingBoxAscent: p * 0.8,
         fontBoundingBoxDescent: p * 0.2,
         actualBoundingBoxAscent: p * 0.8,
@@ -229,6 +229,23 @@ describe('run charSpacing/charScale reach the painted glyphs on every branch', (
     expect(textFills).toEqual([
       expect.objectContaining({ text: '甲乙・丙丁', letterSpacing: '0px' }),
     ]);
+  });
+
+  it('retains a full-width middle-punctuation cell before a following Latin run', async () => {
+    const { canvas, fills } = makeRecordingCanvas();
+    const model = {
+      ...doc([para([
+        textRun('E-mail：'),
+        textRun('kifu@example.test', { isLink: true }),
+      ])], section()),
+      settings: { characterSpacingControl: 'compressPunctuation' },
+    } as DocxDocumentModel;
+
+    await renderDocumentToCanvas(model, canvas, 0, { dpr: 1, width: 600 });
+
+    const label = drawOf(fills, 'E-mail');
+    const address = drawOf(fills, 'kifu@example.test');
+    expect(address.x - label.x).toBeCloseTo(7 * FONT_PX, 5);
   });
 
   it('horizontal common path: following run starts at the expanded right edge', async () => {

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1726,15 +1726,17 @@ export function hasCJKBreakOpportunity(text: string): boolean {
 
 // ECMA-376 §17.15.1.18 / §17.18.7 distinguishes punctuation-only compression
 // from punctuation-plus-Japanese-kana compression. This is the reviewed
-// supported subset: full-width closing forms plus the unambiguous full-width
-// ! ? : ; forms. Halfwidth U+FF61/U+FF64 are not full-width. U+30FB remains
-// outside the supported subset because the normative character set is not
-// exhaustive. Opening punctuation needs line-start positioning rather than a
-// pen-advance reduction. The implementation-note evidence for the full-width
-// punctuation scope is registered in layout/line-compatibility.ts.
+// supported subset: full-width closing forms plus full-width ! and ?.
+// JLReq classifies middle dot, colon, and semicolon together (cl-05); their
+// whitespace belongs on both sides and must be resolved from the adjacent
+// character classes, so they cannot use this trailing-side-only projection.
+// Halfwidth U+FF61/U+FF64 are not full-width. Opening punctuation likewise
+// needs line-start positioning rather than a pen-advance reduction. The
+// implementation-note evidence for the full-width punctuation scope is
+// registered in layout/line-compatibility.ts.
 const COMPRESSIBLE_TRAILING_FULL_WIDTH_PUNCTUATION = new Set([
   '、', '。', '，', '．', '」', '』', '】', '〗', '）', '］', '｝',
-  '！', '？', '：', '；',
+  '！', '？',
 ]);
 
 /** Full-width Japanese kana characters for

--- a/packages/docx/src/punctuation-layout.test.ts
+++ b/packages/docx/src/punctuation-layout.test.ts
@@ -347,7 +347,7 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
     expect(segments.every((segment) => segment.text !== '\u3099')).toBe(true);
   });
 
-  it('recognizes unambiguous full-width exclamation, question, colon, and semicolon punctuation', () => {
+  it('keeps middle-punctuation spacing pair-aware while compressing full-width dividing punctuation', () => {
     const segments = buildSegments([textRun('！甲？乙：丙；丁')], {
       pageIndex: 0,
       totalPages: 1,
@@ -361,8 +361,6 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
     expect(segments[0].punctuationCompressions).toEqual([
       { end: 1, adjustmentPt: -5 },
       { end: 3, adjustmentPt: -5 },
-      { end: 5, adjustmentPt: -5 },
-      { end: 7, adjustmentPt: -5 },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- keep Japanese middle-punctuation characters out of the trailing-side-only whitespace compression path
- preserve a full-width colon cell before following Latin hyperlink text
- retain the existing compression behavior for dividing punctuation and trailing punctuation classes

## Root cause

`w:characterSpacingControl="compressPunctuation"` was projected as a trailing-side trim for full-width colon and semicolon. Japanese layout classifies middle dot, colon, and semicolon together, with whitespace governed by both adjacent character classes. Applying only a trailing trim collapsed the gap before the following Latin run.

The fix narrows the reviewed trailing-only subset instead of adding a document-specific or hyperlink-specific exception.

## References

- ECMA-376 Part 1 §17.15.1.18 and §17.18.7
- [MS-OE376] §2.1.562
- JLReq cl-05

## Verification

- full Vitest suite: 5,821 passed, 25 skipped
- focused punctuation layout, paint, and intrinsic-width tests: 44 passed
- final DOCX architecture boundary gate: 88 passed
- DOCX compatibility evidence gate: 17 passed
- DOCX public API gate: 23 passed
- DOCX package-build gate: 2 passed
- TypeScript typecheck
- browser comparison against an Office-produced PDF reference
- `git diff --check`