### PR TITLE
fix(docx): prevent compressed punctuation glyph overlap

### DIFF
--- a/packages/docx/src/layout/line-compatibility.ts
+++ b/packages/docx/src/layout/line-compatibility.ts
@@ -120,7 +120,7 @@ export const WORD_JAPANESE_PUNCTUATION_COMPRESSION_CELL = defineCompatibilityRul
     version: '16.111.1',
     platform: 'macOS 26.5.2',
   },
-  description: 'In the observed Japanese compatibility fixture, compressed full-width punctuation retains at least half of the ideographic cell measured through the selected font route. Tight glyph ink can require a larger retained extent. This is an Office-observed compression amount, not a normative interpretation of ST_CharacterSpacing.',
+  description: 'In the observed Japanese compatibility fixture, compressed full-width punctuation retains at least half of the ideographic cell measured through the selected font route. Tight adjacent glyph ink can require a larger retained extent to prevent collision. This is an Office-observed compression amount, not a normative interpretation of ST_CharacterSpacing.',
 });
 
 export const WORD_MS_MINCHO_EMPTY_EAST_ASIAN_MARK_HEIGHT = defineCompatibilityRule({

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1064,6 +1064,108 @@ export function slicedPunctuationCompressions(
   return sliced && sliced.length > 0 ? Object.freeze(sliced) : undefined;
 }
 
+function tightHorizontalGraphemeInk(
+  segment: LayoutTextSeg,
+  grapheme: string,
+): Readonly<{ advancePt: number; xMinPt: number; xMaxPt: number }> | undefined {
+  if (!segment.textLayoutService || !segment.textShapeRequest || grapheme.length === 0) {
+    return undefined;
+  }
+  const shaped = segment.textLayoutService.shape({
+    ...segment.textShapeRequest,
+    text: grapheme,
+    measure: true,
+    clusterGeometry: false,
+  });
+  if (
+    shaped.horizontalInkBoundsAreTight !== true
+    || !shaped.inkBounds
+    || !Number.isFinite(shaped.advancePt)
+    || !Number.isFinite(shaped.inkBounds.xMinPt)
+    || !Number.isFinite(shaped.inkBounds.xMaxPt)
+  ) {
+    return undefined;
+  }
+  const scale = segment.charScale ?? 1;
+  return {
+    advancePt: shaped.advancePt * scale,
+    xMinPt: shaped.inkBounds.xMinPt * scale,
+    xMaxPt: shaped.inkBounds.xMaxPt * scale,
+  };
+}
+
+/**
+ * Bound document-level punctuation compression by the adjacent glyphs' tight
+ * horizontal ink. The punctuation's own trailing sidebearing is not the whole
+ * collision equation: a following glyph may extend left of its advance origin.
+ * Resolve this after all source runs have been segmented so a formatting seam
+ * cannot reintroduce the overlap.
+ */
+function retainHorizontalPunctuationInkClearance(segs: LayoutSeg[]): void {
+  let pending: Readonly<{
+    segment: LayoutTextSeg;
+    compressionIndex: number;
+    ink: Readonly<{ advancePt: number; xMinPt: number; xMaxPt: number }>;
+  }> | undefined;
+  const adjustedBySegment = new Map<
+    LayoutTextSeg,
+    Array<{ end: number; adjustmentPt: number }>
+  >();
+  for (const candidate of segs) {
+    if (!('text' in candidate) || candidate.verticalRun) {
+      pending = undefined;
+      continue;
+    }
+    const segment = candidate;
+    const compressions = segment.punctuationCompressions ?? [];
+    const compressionIndexByEnd = new Map(
+      compressions.map((compression, index) => [compression.end, index]),
+    );
+    const boundaries = [0, ...graphemeClusterOffsets(segment.text), segment.text.length];
+    for (let index = 0; index < boundaries.length - 1; index += 1) {
+      const start = boundaries[index]!;
+      const end = boundaries[index + 1]!;
+      if (end <= start) continue;
+      const compressionIndex = compressionIndexByEnd.get(end);
+      const currentInk = pending || compressionIndex !== undefined
+        ? tightHorizontalGraphemeInk(segment, segment.text.slice(start, end))
+        : undefined;
+      if (pending && currentInk) {
+        const adjustments = adjustedBySegment.get(pending.segment)
+          ?? pending.segment.punctuationCompressions!.map((compression) => ({
+            ...compression,
+          }));
+        const compression = adjustments[pending.compressionIndex]!;
+        const collisionSafeAdjustmentPt = Math.min(
+          0,
+          pending.ink.xMaxPt
+            - currentInk.xMinPt
+            - pending.ink.advancePt,
+        );
+        const adjustmentPt = Math.max(
+          compression.adjustmentPt,
+          collisionSafeAdjustmentPt,
+        );
+        if (adjustmentPt !== compression.adjustmentPt) {
+          adjustments[pending.compressionIndex] = {
+            end: compression.end,
+            adjustmentPt,
+          };
+          adjustedBySegment.set(pending.segment, adjustments);
+        }
+      }
+      pending = compressionIndex !== undefined && currentInk
+        ? { segment, compressionIndex, ink: currentInk }
+        : undefined;
+    }
+  }
+  for (const [segment, adjusted] of adjustedBySegment) {
+    segment.punctuationCompressions = Object.freeze(
+      adjusted.map((compression) => Object.freeze(compression)),
+    );
+  }
+}
+
 /** ECMA-376 §17.3.2.43 `<w:w>` — the horizontal glyph-width scale fraction of a
  *  segment (0.67 = 67%). 1 when the run declares no `w:w`. Multiplies the
  *  natural `measureText` width; the paint pass reproduces it with `ctx.scale`. */
@@ -3083,6 +3185,8 @@ export function buildSegments(
       seenFitTextRegions.add(seg.fitTextRegionIndex);
     }
   }
+
+  retainHorizontalPunctuationInkClearance(segs);
 
   return segs;
 }

--- a/packages/docx/src/punctuation-layout.test.ts
+++ b/packages/docx/src/punctuation-layout.test.ts
@@ -115,6 +115,7 @@ const textOf = (line: LayoutLine): string =>
 function punctuationMetricsServices(options: Readonly<{
   punctuationAdvancePt?: number;
   ideographicCellAdvancePt?: number;
+  leadingInkStartPt?: number;
 }> = {}): LayoutServices {
   const text: TextLayoutService = createTextLayoutService({
     fonts: createFontResolver([]),
@@ -155,7 +156,15 @@ function punctuationMetricsServices(options: Readonly<{
                 },
                 horizontalInkBoundsAreTight: true,
               }
-            : { inkBounds: { xMinPt: 0, xMaxPt: advancePt, ascentPt: 8, descentPt: 2 } }),
+            : {
+                inkBounds: {
+                  xMinPt: options.leadingInkStartPt ?? 0,
+                  xMaxPt: advancePt,
+                  ascentPt: 8,
+                  descentPt: 2,
+                },
+                horizontalInkBoundsAreTight: true,
+              }),
         };
       },
     },
@@ -201,6 +210,29 @@ describe('ECMA-376 East-Asian punctuation fit', () => {
     expect(lines(segments, 25, false)[0].segments.map((segment) =>
       'text' in segment ? segment.measuredWidth : undefined,
     )).toEqual([25]);
+  });
+
+  it.each([
+    ['inside one run', [textRun('）次')]],
+    ['across a source-run boundary', [textRun('）'), textRun('次')]],
+  ])('keeps compressed closing punctuation clear of following-glyph left overhang %s', (
+    _case,
+    runs,
+  ) => {
+    const segments = buildSegments(runs, {
+      pageIndex: 0,
+      totalPages: 1,
+      characterSpacingControl: 'compressPunctuation',
+      layoutServices: punctuationMetricsServices({ leadingInkStartPt: -2 }),
+    }) as LayoutTextSeg[];
+
+    const closing = segments[0]!;
+    // The closing parenthesis ink ends at 5pt. The next glyph reaches 2pt left
+    // of its origin, so its origin must remain at or beyond 7pt. A 10pt
+    // full-width cell may therefore be compressed by at most 3pt.
+    expect(closing.punctuationCompressions).toEqual([
+      { end: 1, adjustmentPt: -3 },
+    ]);
   });
 
   it('derives the retained half-cell from the selected font route, not punctuation advance', () => {


### PR DESCRIPTION
## Summary

- cap full-width punctuation compression against both adjacent glyph ink bounds
- preserve the same rule across source-run boundaries without adding paint-time measurement
- keep the cluster pass linear and leave vertical text on its separate geometry path
- add synthetic regression coverage for a full-width closing parenthesis followed by a left-overhanging glyph, within one run and across runs

## Specification and compatibility

ECMA-376 Part 1 sections 17.15.1.18 and 17.18.7 define the character sets eligible for whitespace compression. MS-OE376 section 2.1.562 clarifies that Word applies the setting to full-width punctuation. The retained half-cell amount remains in the existing isolated Office compatibility rule; this fix adds the general adjacent-ink non-collision constraint.

## Verification

- focused DOCX layout/paint/worker tests: 169 passed
- full repository suite: 5,823 passed, 25 skipped
- DOCX layout boundary, compatibility evidence, public API, and package-build gates: passed
- root TypeScript typecheck: passed
- Chrome, Firefox, and WebKit synthetic conformance: 66 passed
- git diff --check: passed