### PR TITLE
chore(release): 0.73.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.73.1 — 2026-07-24
+
+Patch. Prevents compressed full-width punctuation from colliding with the
+following glyph in horizontal DOCX text.
+
+- **docx:** bound document-level full-width punctuation compression by both
+  adjacent glyph ink extents. A following glyph that extends left of its
+  advance origin can no longer overlap a closing parenthesis or other eligible
+  punctuation, including across source-run formatting boundaries. The
+  collision constraint is resolved once during layout with a linear grapheme
+  pass; paint remains measurement-free and vertical text retains its separate
+  geometry path. (§17.15.1.18, §17.18.7; [MS-OE376] §2.1.562; #1094)
+
 ## 0.73.0 — 2026-07-24
 
 Minor. Completes the DOCX migration to one immutable layout-to-paint pipeline,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.73.0"
+version = "0.73.1"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.73.0",
+  "version": "0.73.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.73.0",
+  "version": "0.73.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.73.0",
+  "version": "0.73.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-markdown",
-  "version": "0.73.0",
+  "version": "0.73.1",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.73.0"
+version = "0.73.1"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.73.0",
+  "version": "0.73.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.73.0",
+  "version": "0.73.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.73.0",
+  "version": "0.73.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.73.0",
+  "version": "0.73.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.73.0",
+  "version": "0.73.1",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",


### PR DESCRIPTION
## Summary

Patch release for the horizontal DOCX full-width punctuation collision fix merged in #1094.

- prevent eligible compressed punctuation from colliding with a following glyph that extends left of its advance origin
- preserve the constraint across source-run formatting boundaries
- keep the correction in the layout phase with a linear grapheme pass and no paint-time measurement
- synchronize package, extension, site, and MCP server versions at 0.73.1

## Release documentation

- added the 0.73.1 changelog entry
- reviewed README, public API reference, capabilities, and README screenshots
- no documentation or screenshot changes are required because this patch does not alter the public API or documented UI, and the screenshots were refreshed in 0.73.0 on the same release date

## Verification

- cargo check -p ooxml-mcp-server
- pnpm typecheck
- pnpm build:packages
- pnpm build
- pnpm test — 5,823 passed, 25 skipped
- pnpm test:docx-public-api
- pnpm test:docx-package-build
- node scripts/check-no-inline-wasm.mjs dist
- git diff --check