### PR TITLE
chore(release): 0.73.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to @silurus/ooxml are documented here. The project follows
 semantic versioning; minor releases add spec-compliant features or behavior
 changes that remain compatible with existing API surfaces.
 
+## 0.73.2 — 2026-07-24
+
+Patch. Restores DOCX list-marker, table-pagination, and grouped-drawing geometry
+that regressed during the retained-layout migration.
+
+- **docx:** anchor right-to-left numbering markers to the retained aligned line
+  instead of the page edge, so bullets and item numbers stay attached to their
+  paragraph text.
+- **docx:** admit a merged table when its resolved row tracks fit the remaining
+  page, avoiding continuation pages that contain only overflowed gauge or bar
+  rows.
+- **docx:** reproduce Word's observed non-uniform scaling for directly grouped
+  leaves at exact odd quarter turns while keeping nested groups and the shared
+  DOCX/XLSX/PPTX DrawingML transform on the normative Annex L path. The
+  compatibility rule is deliberately scoped to the evidence available in Word.
+  (ECMA-376 Part 1 Annex L §L.4.7.4; [MS-OE376] §2.1.1360; #1037, #1096)
+
 ## 0.73.1 — 2026-07-24
 
 Patch. Prevents compressed full-width punctuation from colliding with the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.73.1"
+version = "0.73.2"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.73.1",
+  "version": "0.73.2",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.73.1",
+  "version": "0.73.2",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.73.1",
+  "version": "0.73.2",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-markdown",
-  "version": "0.73.1",
+  "version": "0.73.2",
   "description": "Convert .pptx / .docx / .xlsx to GitHub-flavoured markdown using the workspace WASM parsers — browser / Node / CLI",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.73.1"
+version = "0.73.2"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.73.1",
+  "version": "0.73.2",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.73.1",
+  "version": "0.73.2",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity viewer for Office files (.docx / .xlsx / .pptx). Local-only — files never leave your machine. Powered by a Rust/WASM parser and Canvas renderer.",
-  "version": "0.73.1",
+  "version": "0.73.2",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.73.1",
+  "version": "0.73.2",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.73.1",
+  "version": "0.73.2",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",


### PR DESCRIPTION
## Summary

Prepare the 0.73.2 patch release containing the DOCX regression fixes merged in #1096:

- keep RTL list markers attached to their retained paragraph line
- avoid spill-only continuation pages when resolved merged-table row tracks fit
- scope Word-observed exact-quarter-turn group scaling to directly grouped DOCX leaves while preserving normative shared and nested DrawingML behavior

This PR synchronizes all package, site, VS Code extension, and MCP server versions; updates `Cargo.lock`; and adds the 0.73.2 changelog entry. Public APIs, README guidance, capabilities, and screenshots remain unchanged.

## Verification

- `cargo check -p ooxml-mcp-server`
- `pnpm typecheck`
- `pnpm test` (5,825 passed; 25 skipped)
- `pnpm build:packages`
- `pnpm build`
- `pnpm build-storybook`
- lint and DOCX architecture / compatibility / public API / package-build gates
- `pnpm check:no-inline-wasm`
- `pnpm check:public-type-exports`
- `publint`
- `@arethetypeswrong/cli --pack . --profile esm-only`
- install and import smoke test against the packed 0.73.2 tarball
- `git diff --check`

The preceding implementation PR also passed the complete local private all-page visual regression corpus and all GitHub CI checks.