### PR TITLE
fix(chart): honor percent axis units and label size

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -2230,72 +2230,67 @@ fillText "0%" 183.2,335.45 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 195.2,307.6909
-lineTo 632.8,307.6909
+moveTo 195.2,304.915
+lineTo 632.8,304.915
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "10%" 183.2,307.6909 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "10%" 183.2,304.915 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 195.2,279.9318
-lineTo 632.8,279.9318
+moveTo 195.2,274.38
+lineTo 632.8,274.38
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "20%" 183.2,279.9318 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "20%" 183.2,274.38 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 195.2,252.1727
-lineTo 632.8,252.1727
+moveTo 195.2,243.845
+lineTo 632.8,243.845
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "30%" 183.2,252.1727 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "30%" 183.2,243.845 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 195.2,224.4136
-lineTo 632.8,224.4136
+moveTo 195.2,213.31
+lineTo 632.8,213.31
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "40%" 183.2,224.4136 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "40%" 183.2,213.31 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 195.2,196.6545
-lineTo 632.8,196.6545
+moveTo 195.2,182.775
+lineTo 632.8,182.775
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "50%" 183.2,196.6545 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "50%" 183.2,182.775 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 195.2,168.8955
-lineTo 632.8,168.8955
+moveTo 195.2,152.24
+lineTo 632.8,152.24
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "60%" 183.2,168.8955 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "60%" 183.2,152.24 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 195.2,141.1364
-lineTo 632.8,141.1364
+moveTo 195.2,121.705
+lineTo 632.8,121.705
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "70%" 183.2,141.1364 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "70%" 183.2,121.705 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 195.2,113.3773
-lineTo 632.8,113.3773
+moveTo 195.2,91.17
+lineTo 632.8,91.17
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "80%" 183.2,113.3773 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "80%" 183.2,91.17 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 195.2,85.6182
-lineTo 632.8,85.6182
+moveTo 195.2,60.635
+lineTo 632.8,60.635
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "90%" 183.2,85.6182 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 195.2,57.8591
-lineTo 632.8,57.8591
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "100%" 183.2,57.8591 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "90%" 183.2,60.635 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
 moveTo 195.2,30.1
 lineTo 632.8,30.1
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "110%" 183.2,30.1 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "100%" 183.2,30.1 fs=#555 font=11px sans-serif al=right bl=middle
 set fillStyle=#4472C4
-fillRect 238.96,181.2328,58.3467,154.2172 fs=#4472C4
+fillRect 238.96,165.8111,58.3467,169.6389 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 238.96,57.8591,58.3467,123.3737 fs=#ED7D31
+fillRect 238.96,30.1,58.3467,135.7111 fs=#ED7D31
 set fillStyle=#4472C4
-fillRect 384.8267,164.6248,58.3467,170.8252 fs=#4472C4
+fillRect 384.8267,147.5423,58.3467,187.9077 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 384.8267,57.8591,58.3467,106.7657 fs=#ED7D31
+fillRect 384.8267,30.1,58.3467,117.4423 fs=#ED7D31
 set fillStyle=#4472C4
-fillRect 530.6933,214.4488,58.3467,121.0012 fs=#4472C4
+fillRect 530.6933,202.3487,58.3467,133.1013 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 530.6933,57.8591,58.3467,156.5897 fs=#ED7D31
+fillRect 530.6933,30.1,58.3467,172.2487 fs=#ED7D31
 set fillStyle=#555
 set textAlign=center
 set textBaseline=top
@@ -2313,44 +2308,40 @@ moveTo 191.2,335.45
 lineTo 195.2,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 191.2,307.6909
-lineTo 195.2,307.6909
+moveTo 191.2,304.915
+lineTo 195.2,304.915
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 191.2,279.9318
-lineTo 195.2,279.9318
+moveTo 191.2,274.38
+lineTo 195.2,274.38
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 191.2,252.1727
-lineTo 195.2,252.1727
+moveTo 191.2,243.845
+lineTo 195.2,243.845
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 191.2,224.4136
-lineTo 195.2,224.4136
+moveTo 191.2,213.31
+lineTo 195.2,213.31
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 191.2,196.6545
-lineTo 195.2,196.6545
+moveTo 191.2,182.775
+lineTo 195.2,182.775
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 191.2,168.8955
-lineTo 195.2,168.8955
+moveTo 191.2,152.24
+lineTo 195.2,152.24
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 191.2,141.1364
-lineTo 195.2,141.1364
+moveTo 191.2,121.705
+lineTo 195.2,121.705
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 191.2,113.3773
-lineTo 195.2,113.3773
+moveTo 191.2,91.17
+lineTo 195.2,91.17
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 191.2,85.6182
-lineTo 195.2,85.6182
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 191.2,57.8591
-lineTo 195.2,57.8591
+moveTo 191.2,60.635
+lineTo 195.2,60.635
 stroke ss=#aaa lw=1 dash=
 beginPath
 moveTo 191.2,30.1

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -13,7 +13,14 @@ import { renderChart } from './renderer.js';
 import { formatChartValWithCode } from './chart-number-format.js';
 
 interface RectCall { x: number; y: number; w: number; h: number; fs: string }
-interface TextCall { text: string; x: number; y: number; align: string; baseline: string }
+interface TextCall {
+  text: string;
+  x: number;
+  y: number;
+  align: string;
+  baseline: string;
+  font?: string;
+}
 
 interface Recorded {
   ctx: CanvasRenderingContext2D;
@@ -57,7 +64,14 @@ function recordingCtx(): Recorded {
             rects.push({ x, y, w, h, fs: String(state.fillStyle) });
         case 'fillText':
           return (text: string, x: number, y: number) =>
-            texts.push({ text, x, y, align: String(state.textAlign), baseline: String(state.textBaseline) });
+            texts.push({
+              text,
+              x,
+              y,
+              align: String(state.textAlign),
+              baseline: String(state.textBaseline),
+              font: String(state.font),
+            });
         case 'createLinearGradient':
         case 'createRadialGradient':
           return () => ({ addColorStop() {} });
@@ -341,6 +355,76 @@ describe('CH6 — negative bar data-label placement mirrors the positive convent
 describe('CH7 — percentStacked normalizes signed values against per-category Σ|v| (§21.2.2.76)', () => {
   // Positive contributions stack up/right, negatives down/left; each series is
   // normalized to (v / Σ|v|)·100 so the axis spans −100..100.
+  it.each([
+    'stackedBarPct',
+    'stackedLinePct',
+    'stackedAreaPct',
+  ] as const)('%s scales fractional OOXML axis units to percentage points', chartType => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType,
+      categories: ['A', 'B'],
+      series: [
+        series({ name: 'S1', values: [25, 75] }),
+        series({ name: 'S2', values: [75, 25] }),
+      ],
+      // The chart stores percent-axis values as ratios. The renderer's stacked
+      // geometry uses percentage points internally, so 0.5 must become the
+      // 50-point interval Excel displays as 50%, not a 0.5-point interval.
+      valAxisMajorUnit: 0.5,
+      valAxisFormatCode: '0%',
+    }), RECT, 1);
+
+    const labels = rec.texts
+      .map(t => t.text)
+      .filter(t => /^-?\d+(?:\.\d+)?%$/.test(t));
+    expect(labels).toEqual(['0%', '50%', '100%']);
+  });
+
+  it('column percent-axis labels honor the font size declared in valAx txPr', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBarPct',
+      categories: ['A'],
+      series: [
+        series({ name: 'S1', values: [25] }),
+        series({ name: 'S2', values: [75] }),
+      ],
+      valAxisMajorUnit: 0.5,
+      valAxisFormatCode: '0%',
+      // DrawingML run sizes are hundredths of a point: 1100 = 11 pt.
+      valAxisFontSizeHpt: 1100,
+    }), RECT, 4 / 3);
+
+    const percentLabels = rec.texts.filter(t => /^(?:0|50|100)%$/.test(t.text));
+    expect(percentLabels).toHaveLength(3);
+    for (const label of percentLabels) {
+      const fontPx = Number(/^([\d.]+)px/.exec(label.font ?? '')?.[1]);
+      expect(fontPx).toBeCloseTo(11 * 4 / 3, 5);
+    }
+  });
+
+  it('scales explicit fractional percent-axis bounds before plotting', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBarPct',
+      categories: ['A'],
+      series: [
+        series({ name: 'S1', values: [25] }),
+        series({ name: 'S2', values: [75] }),
+      ],
+      valMin: 0,
+      valMax: 1,
+      valAxisMajorUnit: 0.5,
+      valAxisFormatCode: '0%',
+    }), RECT, 1);
+
+    const labels = rec.texts
+      .map(t => t.text)
+      .filter(t => /^-?\d+(?:\.\d+)?%$/.test(t));
+    expect(labels).toEqual(['0%', '50%', '100%']);
+  });
+
   it('vertical percentStacked: positives stack above zero, negatives below, normalized to Σ|v|', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -686,19 +686,57 @@ interface ValueAxisPlan {
   frac: (v: number) => number;
 }
 
+/** Convert an OOXML percent-axis value (stored as a 0..1 ratio) into the
+ * renderer's percentStacked geometry space (0..100 percentage points). */
+function valueAxisUnitInRendererSpace(
+  value: number | null | undefined,
+  percentStacked: boolean,
+): number | null | undefined {
+  return value == null || !percentStacked ? value : value * 100;
+}
+
+/** Format a primary value-axis tick from the renderer's data space. For a
+ * percentStacked chart the plotted values are percentage points, while the
+ * axis numFmt still expects the OOXML ratio (0.5 → 50%). */
+function formatPrimaryValueAxisTick(
+  chart: ChartModel,
+  value: number,
+  percentStacked: boolean,
+): string {
+  return formatChartValWithCode(
+    percentStacked ? value / 100 : value,
+    percentStacked ? (chart.valAxisFormatCode ?? '0%') : chart.valAxisFormatCode,
+    chart.date1904,
+  );
+}
+
 /** Build a {@link ValueAxisPlan} for the primary value axis. `dataMin`/`dataMax`
  *  are the raw data extents already massaged by the caller (0-anchoring, pct
  *  normalization, explicit valMin/valMax). `axisLenPt` drives the auto major
  *  unit. Reversal is read from the chart's value-axis orientation. */
 function planValueAxis(
-  chart: ChartModel, dataMin: number, dataMax: number, axisLenPt?: number,
+  chart: ChartModel,
+  dataMin: number,
+  dataMax: number,
+  axisLenPt?: number,
+  percentStacked = false,
 ): ValueAxisPlan {
   const reversed = valAxisReversed(chart);
   const logBase = chart.valAxisLogBase;
+  // c:valAx values remain ratios for percentStacked charts, but all plotted
+  // geometry in this renderer is expressed as percentage points. Explicit
+  // bounds/units therefore cross the same ×100 boundary as the series values.
+  // With no explicit bounds, percentStacked uses its exact normalized extent
+  // (0..100 or -100..100) instead of adding ordinary numeric-axis headroom.
+  const explicitMin = valueAxisUnitInRendererSpace(chart.valMin, percentStacked)
+    ?? (percentStacked ? dataMin : chart.valMin);
+  const explicitMax = valueAxisUnitInRendererSpace(chart.valMax, percentStacked)
+    ?? (percentStacked ? dataMax : chart.valMax);
+  const majorUnit = valueAxisUnitInRendererSpace(chart.valAxisMajorUnit, percentStacked);
   if (logBase != null && isFinite(logBase) && logBase >= 2) {
     // Logarithmic axis (ECMA-376 §21.2.2.98): bounds snap to powers of the base,
     // gridlines fall on those decades, values map in log space.
-    const { min, max, lines } = logAxisScale(dataMin, dataMax, logBase, chart.valMin, chart.valMax);
+    const { min, max, lines } = logAxisScale(dataMin, dataMax, logBase, explicitMin, explicitMax);
     return {
       min, max,
       step: lines.length > 1 ? lines[1] - lines[0] : max - min,
@@ -708,7 +746,7 @@ function planValueAxis(
     };
   }
   const { min, max, step } = valueAxisScale(
-    dataMin, dataMax, chart.valMin, chart.valMax, axisLenPt, chart.valAxisMajorUnit,
+    dataMin, dataMax, explicitMin, explicitMax, axisLenPt, majorUnit,
   );
   const range = (max - min) || 1;
   const majorLines: number[] = [];
@@ -718,7 +756,7 @@ function planValueAxis(
   // declares `<c:minorGridlines>` AND a positive `<c:minorUnit>`; the minor lines
   // between the majors are the interior multiples of the minor unit.
   const minorLines: number[] = [];
-  const mu = chart.valAxisMinorUnit;
+  const mu = valueAxisUnitInRendererSpace(chart.valAxisMinorUnit, percentStacked);
   if (chart.valAxisMinorGridlines && mu != null && isFinite(mu) && mu > 0 && mu < step) {
     for (let v = min + mu; v < max - 1e-9; v += mu) {
       // Skip values that coincide with a major line.
@@ -1213,12 +1251,16 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     dataMax = dataMax > 0 ? 100 : 0;
     dataMin = dataMin < 0 ? -100 : 0;
   }
-  if (chart.valMax != null) dataMax = chart.valMax;
-  if (chart.valMin != null) dataMin = chart.valMin;
+  if (chart.valMax != null) {
+    dataMax = pct ? chart.valMax * 100 : chart.valMax;
+  }
+  if (chart.valMin != null) {
+    dataMin = pct ? chart.valMin * 100 : chart.valMin;
+  }
   if (dataMax === 0 && dataMin === 0) dataMax = 1;
   // `planValueAxis` folds in the CH6 major unit / logBase / orientation; with
   // none set it is byte-identical to `valueAxisScale` + a linear map.
-  const plan = planValueAxis(chart, dataMin, dataMax, valAxisLenPt);
+  const plan = planValueAxis(chart, dataMin, dataMax, valAxisLenPt, pct);
   const { min: axMin, max: axMax, step } = plan;
 
   // Secondary value-axis scale (combo charts). INDEPENDENT of the primary: its
@@ -1232,7 +1274,9 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const sStep = secScale ? secScale.step : 1;
 
   const secTickFontPx = Math.max(8, Math.min(11, h / 20));
-  const tickFontPx = Math.max(8, Math.min(11, phEst / 20));
+  const measuredValTickFontPx = chart.valAxisFontSizeHpt != null
+    ? valAxLabelFontPx
+    : Math.max(8, Math.min(11, phEst / 20));
   const prevFont = ctx.font;
   // Primary value-axis label band (column charts only; horizontal bars keep a
   // wider left band for the category labels).
@@ -1240,14 +1284,12 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   if (!isH && !chart.valAxisHidden) {
     // Measure with the same face the value-axis ticks draw with (below), so the
     // reserved gutter width matches the painted labels when a real face is set.
-    ctx.font = `${tickFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
+    ctx.font = `${measuredValTickFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     let wmax = 0;
     const vSteps = Math.round((axMax - axMin) / step);
     for (let si = 0; si <= vSteps; si++) {
       const val = axMin + si * step;
-      const label = pct
-        ? `${Math.round(val)}%`
-        : formatChartValWithCode(val, chart.valAxisFormatCode, chart.date1904);
+      const label = formatPrimaryValueAxisTick(chart, val, pct);
       wmax = Math.max(wmax, ctx.measureText(label).width);
     }
     valLabelBandW = wmax + 16; // ~12px tick+gap to the axis + ~4px to the title
@@ -1339,7 +1381,10 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const grid = valGridStroke(chart, ptToPx);
   const steps = Math.round(axRange / step);
   ctx.textBaseline = 'middle';
-  ctx.font = `${Math.max(8, Math.min(11, ph / 20))}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
+  const drawnValTickFontPx = chart.valAxisFontSizeHpt != null
+    ? valAxLabelFontPx
+    : Math.max(8, Math.min(11, ph / 20));
+  ctx.font = `${drawnValTickFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
   // Honor `<c:valAx><c:txPr>…<a:solidFill>` when present (ECMA-376 §21.2.2.*);
   // otherwise keep the neutral gray default.
   const valLabelColor = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
@@ -1362,9 +1407,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       // The zero line is the emphasized gridline (`si === 0` was that line only
       // while the axis was anchored at 0; with a negative minimum it moves up).
       const isZero = Math.abs(val) < step * 1e-9;
-      const label = pct
-        ? `${Math.round(val)}%`
-        : formatChartValWithCode(val, chart.valAxisFormatCode, chart.date1904);
+      const label = formatPrimaryValueAxisTick(chart, val, pct);
       if (!isH) {
         const gy = valY(val);
         if (drawMajorGrid) strokeValueGridlineH(ctx, px0, pw, gy, isZero, grid);
@@ -1891,9 +1934,9 @@ function renderLineChart(
   // minimum so `logAxisScale` can floor it to a decade. Linear axes keep the
   // historical 0-anchor for positive data (byte-stable).
   const isLogAxis = chart.valAxisLogBase != null && chart.valAxisLogBase >= 2;
-  if (chart.valMin != null) dataMin = chart.valMin;
+  if (chart.valMin != null) dataMin = pct ? chart.valMin * 100 : chart.valMin;
   else if (dataMin > 0 && !isLogAxis) dataMin = 0;
-  if (chart.valMax != null) dataMax = chart.valMax;
+  if (chart.valMax != null) dataMax = pct ? chart.valMax * 100 : chart.valMax;
   else if (dataMax < 0) dataMax = 0;
   if (dataMax === dataMin) dataMax = dataMin + 1;
 
@@ -1901,7 +1944,7 @@ function renderLineChart(
   // auto major unit, same model as the bar/column renderer). `planValueAxis`
   // folds in the CH6 major unit / logBase / orientation; with none set it is
   // byte-identical to the old `valueAxisScale` + linear `toY`.
-  const plan = planValueAxis(chart, dataMin, dataMax, ph / ptToPx);
+  const plan = planValueAxis(chart, dataMin, dataMax, ph / ptToPx, pct);
   if (plan.max - plan.min === 0) return;
 
   const toY = (v: number) => py0 + ph - plan.frac(v) * ph;
@@ -1936,7 +1979,7 @@ function renderLineChart(
       if (drawLabels) {
         ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
         ctx.textAlign = 'right';
-        ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
+        ctx.fillText(formatPrimaryValueAxisTick(chart, v, pct), px0 - 6, gy);
       }
     }
   }
@@ -2483,12 +2526,21 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   // percentStacked always tops out at exactly 100% (each category's Σ|v|
   // normalizes to 100), matching the bar/line percentStacked axis convention.
   if (pct) dataMax = dataMax > 0 ? 100 : 0;
-  if (chart.valMax != null) dataMax = chart.valMax;
+  if (chart.valMax != null) dataMax = pct ? chart.valMax * 100 : chart.valMax;
   if (dataMax === 0) dataMax = 1;
   // Area anchors the value axis at 0; ignore the returned min. Value axis is
   // vertical → length = plot height (axis-length-aware auto major unit). An
   // explicit `<c:valAx><c:majorUnit>` (§21.2.2.103) overrides the auto step.
-  const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax, ph / ptToPx, chart.valAxisMajorUnit);
+  const explicitMax = pct ? dataMax : chart.valMax;
+  const majorUnit = valueAxisUnitInRendererSpace(chart.valAxisMajorUnit, pct);
+  const { max: axMax, step } = valueAxisScale(
+    0,
+    dataMax,
+    undefined,
+    explicitMax,
+    ph / ptToPx,
+    majorUnit,
+  );
 
   // crossBetween="between" (Office's default; ECMA-376 §21.2.2.32 leaves the
   // default application-defined) gives each category a band of width pw/n and
@@ -2529,7 +2581,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     // the minor unit that don't coincide with a major line — same computation as
     // planValueAxis (renderer.ts ~686-696) used by bar/line/stock, with the area
     // axis anchored at min = 0. Fixes #883 (area previously ignored minor lines).
-    const mu = chart.valAxisMinorUnit;
+    const mu = valueAxisUnitInRendererSpace(chart.valAxisMinorUnit, pct);
     if (chart.valAxisMinorGridlines && mu != null && isFinite(mu) && mu > 0 && mu < step) {
       for (let v = mu; v < axMax - 1e-9; v += mu) {
         if (Math.abs(v / step - Math.round(v / step)) > 1e-6) {
@@ -2693,7 +2745,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, valLineColor, valLineW);
       ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
       ctx.textAlign = 'right';
-      ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
+      ctx.fillText(formatPrimaryValueAxisTick(chart, v, pct), px0 - 6, gy);
     }
   }
   // Category-axis baseline + value-axis rule. `<c:*Ax><c:spPr><a:ln><a:noFill>`


### PR DESCRIPTION
## What changed

- convert percent-stacked value-axis bounds and units from OOXML ratios into the renderer's percentage-point space
- format percent-stacked tick labels from ratios so fractional major units render correctly
- honor explicit DrawingML value-axis font sizes for bar and column charts
- add focused correctness coverage and update the affected characterization snapshot

## Root cause

Percent-stacked series are normalized to percentage points internally, but their OOXML axis bounds and units remain fractional ratios. The renderer previously mixed those two spaces. Bar and column value-axis labels also used a capped fallback font size even when the document declared an explicit size.

## Impact

Percent-stacked charts now show the intended percentage ticks and use the document-defined label size, matching Office behavior more closely.

## Verification

- `vitest run packages/core/src` — 91 files, 1,803 passed, 2 skipped
- `vitest run packages/xlsx/src` — 61 files, 563 passed
- `tsc --build --pretty false`
- local visual comparison against an Office workbook

Relevant behavior: ECMA-376 §21.2.2.76 (`grouping`) and §21.2.2.103 (`majorUnit` / `minorUnit`).