### PR TITLE
fix(chart): keep manual-layout axis labels in frame

### DIFF
--- a/packages/core/src/chart/layout.test.ts
+++ b/packages/core/src/chart/layout.test.ts
@@ -215,6 +215,31 @@ describe('computeChartFrame — cartesian', () => {
     });
   });
 
+  it('keeps an inner manual-layout data region within the measured outer gutters', () => {
+    const chart = model({
+      plotAreaManualLayout: {
+        layoutTarget: 'inner',
+        xMode: 'edge',
+        yMode: 'edge',
+        x: 0.01,
+        y: 0.02,
+        w: 0.8,
+        h: 0.8,
+      },
+    });
+    const frame = computeChartFrame(chart, X, Y, W, H, PTPX, {
+      titleTopPadFrac: 0.02,
+      titleBottomPadFrac: 0.025,
+      legendSideReserveFrac: 0.22,
+      pad: { t: 20, r: 10, b: 30, l: 40 },
+      honorPlotAreaManualLayout: true,
+    });
+    expect(frame.plotRect.px0).toBe(X + 40);
+    expect(frame.plotRect.py0).toBe(Y + 20);
+    expect(frame.plotRect.pw).toBeCloseTo(X + 0.81 * W - (X + 40));
+    expect(frame.plotRect.ph).toBeCloseTo(Y + 0.82 * H - (Y + 20));
+  });
+
   it('ignores plotArea manual layout when the flag is off', () => {
     const chart = model({
       plotAreaManualLayout: { xMode: 'edge', yMode: 'edge', x: 0.1, y: 0.2, w: 0.7, h: 0.6 },

--- a/packages/core/src/chart/layout.ts
+++ b/packages/core/src/chart/layout.ts
@@ -385,10 +385,28 @@ export function computeChartFrame(
     }
     const pml = params.honorPlotAreaManualLayout ? chart.plotAreaManualLayout : null;
     if (pml && pml.w != null && pml.h != null) {
-      px0 = x + pml.x * w;
-      py0 = y + pml.y * h;
-      pw = pml.w * w;
-      ph = pml.h * h;
+      const manualLeft = x + pml.x * w;
+      const manualTop = y + pml.y * h;
+      const manualRight = manualLeft + pml.w * w;
+      const manualBottom = manualTop + pml.h * h;
+      if (pml.layoutTarget === 'inner') {
+        // ECMA-376 §21.2.2.89: an "inner" manual layout describes only the
+        // data region, excluding axes and labels. Browser font metrics can
+        // require slightly more gutter than the producer reserved, so keep
+        // that outer content inside the chart frame without moving the
+        // declared plot's right/bottom edges.
+        px0 = Math.max(manualLeft, x + pad.l);
+        py0 = Math.max(manualTop, y + pad.t);
+        const right = Math.min(manualRight, x + w - pad.r);
+        const bottom = Math.min(manualBottom, y + h - pad.b);
+        pw = Math.max(0, right - px0);
+        ph = Math.max(0, bottom - py0);
+      } else {
+        px0 = manualLeft;
+        py0 = manualTop;
+        pw = pml.w * w;
+        ph = pml.h * h;
+      }
     } else {
       px0 = x + pad.l;
       py0 = y + pad.t;

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -20,6 +20,7 @@ interface TextCall {
   align: string;
   baseline: string;
   font?: string;
+  width?: number;
 }
 
 interface Recorded {
@@ -48,17 +49,18 @@ function recordingCtx(): Recorded {
     const m = /(\d+(?:\.\d+)?)px/.exec(font);
     return m ? parseFloat(m[1]) : 10;
   };
+  const textWidth = (text: string): number => {
+    const px = fontPx(String(state.font));
+    let w = 0;
+    for (const ch of String(text)) w += ch.charCodeAt(0) > 0x2e7f ? px : px * 0.6;
+    return w;
+  };
   const handler: ProxyHandler<Record<string, unknown>> = {
     get(_t, prop: string) {
       if (prop in state && typeof state[prop] !== 'function') return state[prop];
       switch (prop) {
         case 'measureText':
-          return (t: string) => {
-            const px = fontPx(String(state.font));
-            let w = 0;
-            for (const ch of String(t)) w += ch.charCodeAt(0) > 0x2e7f ? px : px * 0.6;
-            return { width: w };
-          };
+          return (t: string) => ({ width: textWidth(t) });
         case 'fillRect':
           return (x: number, y: number, w: number, h: number) =>
             rects.push({ x, y, w, h, fs: String(state.fillStyle) });
@@ -71,6 +73,7 @@ function recordingCtx(): Recorded {
               align: String(state.textAlign),
               baseline: String(state.textBaseline),
               font: String(state.font),
+              width: textWidth(text),
             });
         case 'createLinearGradient':
         case 'createRadialGradient':
@@ -402,6 +405,38 @@ describe('CH7 — percentStacked normalizes signed values against per-category �
       const fontPx = Number(/^([\d.]+)px/.exec(label.font ?? '')?.[1]);
       expect(fontPx).toBeCloseTo(11 * 4 / 3, 5);
     }
+  });
+
+  it('keeps explicit-size value-axis labels inside an inner manual-layout chart frame', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBarPct',
+      categories: ['A'],
+      series: [
+        series({ name: 'S1', values: [25] }),
+        series({ name: 'S2', values: [75] }),
+      ],
+      valAxisMajorUnit: 0.5,
+      valAxisFormatCode: '0%',
+      valAxisFontSizeHpt: 1100,
+      // ECMA-376 §21.2.2.89: an inner target describes the data region,
+      // excluding axes and labels. Those labels must still remain inside the
+      // chart frame when their actual DrawingML font metrics need more room.
+      plotAreaManualLayout: {
+        layoutTarget: 'inner',
+        xMode: 'edge',
+        yMode: 'edge',
+        x: 0.055,
+        y: 0.046,
+        w: 0.728,
+        h: 0.784,
+      },
+    }), RECT, 4 / 3);
+
+    const label = rec.texts.find(t => t.text === '100%');
+    expect(label).toBeDefined();
+    expect(label!.align).toBe('right');
+    expect(label!.x - (label!.width ?? 0)).toBeGreaterThanOrEqual(RECT.x + 4);
   });
 
   it('scales explicit fractional percent-axis bounds before plotting', () => {


### PR DESCRIPTION
## What changed

- constrain `layoutTarget="inner"` manual plot regions to the measured chart gutters
- preserve the declared plot region's right and bottom edges when additional left/top room is required
- add layout-level and render-level regression coverage for explicit-size value-axis labels

## Root cause

An inner plot-area manual layout describes only the data region and excludes axes and labels. The renderer applied that region without reconciling it with the measured outer gutters, so browser font metrics could place wider value-axis labels outside the chart frame.

## Impact

Explicitly sized axis labels now remain inside the chart frame while manual plot placement and series geometry remain stable.

## Verification

- `vitest run packages/core/src` — 91 files, 1,805 passed, 2 skipped
- `vitest run packages/xlsx/src` — 61 files, 563 passed
- `tsc --build --pretty false`
- local visual comparison against an Office workbook

Relevant behavior: ECMA-376 §21.2.2.89 (`layoutTarget`).