### PR TITLE
fix(docx): retain contextual punctuation advance

### DIFF
--- a/packages/docx/src/charspacing-paint.test.ts
+++ b/packages/docx/src/charspacing-paint.test.ts
@@ -43,7 +43,8 @@ interface FillCall {
 }
 
 function makeRecordingCanvas(options: Readonly<{
-  followingGlyphLeftOverhangPx?: number;
+  followingGlyphLeftInsetPx?: number;
+  closingPunctuationPairKerningPx?: number;
 }> = {}): { canvas: HTMLCanvasElement; fills: FillCall[] } {
   let font = `${FONT_PX}px serif`;
   let letterSpacing = '0px';
@@ -61,11 +62,15 @@ function makeRecordingCanvas(options: Readonly<{
     fontKerning: 'auto',
     measureText: (s: string) => {
       const p = px();
-      const w = [...s].length * p;
+      const pairCount = s.match(/。）/gu)?.length ?? 0;
+      const w = [...s].length * p
+        - pairCount * (options.closingPunctuationPairKerningPx ?? 0);
       return {
         width: w,
         actualBoundingBoxLeft:
-          s === 'に' ? options.followingGlyphLeftOverhangPx ?? 0 : 0,
+          s === '次'
+            ? -(options.followingGlyphLeftInsetPx ?? 0)
+            : 0,
         // The punctuation fixture exposes a selected-glyph right ink edge at
         // half its full-width cell. Other text fills its complete advance.
         actualBoundingBoxRight:
@@ -215,23 +220,26 @@ describe('run charSpacing/charScale reach the painted glyphs on every branch', (
     expect(following.x - first.x).toBeCloseTo(30, 5);
   });
 
-  it('keeps a compressed closing parenthesis clear of the following CJK glyph ink', async () => {
-    const followingGlyphLeftOverhangPx = 4;
-    const { canvas, fills } = makeRecordingCanvas({ followingGlyphLeftOverhangPx });
+  it('does not compress a contextually half-width closing parenthesis to zero advance', async () => {
+    const followingGlyphLeftInsetPx = 3;
+    const { canvas, fills } = makeRecordingCanvas({
+      followingGlyphLeftInsetPx,
+      closingPunctuationPairKerningPx: 10,
+    });
     const model = {
-      ...doc([para([textRun('ます。）に')])], section()),
+      ...doc([para([textRun('本文。）次')])], section()),
       settings: { characterSpacingControl: 'compressPunctuation' },
     } as DocxDocumentModel;
 
     await renderDocumentToCanvas(model, canvas, 0, { dpr: 1, width: 600 });
 
     const closingParenthesis = drawOf(fills, '）');
-    const following = drawOf(fills, 'に');
+    const following = drawOf(fills, '次');
     const closingInkRightPx = closingParenthesis.x + FONT_PX / 2;
-    const followingInkLeftPx = following.x - followingGlyphLeftOverhangPx;
+    const followingInkLeftPx = following.x + followingGlyphLeftInsetPx;
 
-    expect(closingParenthesis.letterSpacing).toBe('-6px');
-    expect(following.x - closingParenthesis.x).toBeCloseTo(14, 5);
+    expect(closingParenthesis.letterSpacing).toBe('0px');
+    expect(following.x - closingParenthesis.x).toBeCloseTo(10, 5);
     expect(followingInkLeftPx).toBeGreaterThanOrEqual(closingInkRightPx);
   });
 

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1094,18 +1094,43 @@ function tightHorizontalGraphemeInk(
   };
 }
 
+function contextualHorizontalGraphemeAdvances(
+  segment: LayoutTextSeg,
+): ReadonlyMap<number, number> | undefined {
+  if (!segment.textLayoutService || !segment.textShapeRequest || segment.text.length === 0) {
+    return undefined;
+  }
+  const shaped = segment.textLayoutService.shape({
+    ...segment.textShapeRequest,
+    text: segment.text,
+    measure: true,
+    clusterGeometry: true,
+  });
+  if (!shaped.clusters?.length) return undefined;
+  const scale = segment.charScale ?? 1;
+  const advances = new Map<number, number>();
+  for (const cluster of shaped.clusters) {
+    if (!Number.isFinite(cluster.advancePt)) return undefined;
+    advances.set(cluster.range.end, cluster.advancePt * scale);
+  }
+  return advances;
+}
+
 /**
  * Bound document-level punctuation compression by the adjacent glyphs' tight
- * horizontal ink. The punctuation's own trailing sidebearing is not the whole
- * collision equation: a following glyph may extend left of its advance origin.
- * Resolve this after all source runs have been segmented so a formatting seam
- * cannot reintroduce the overlap.
+ * horizontal ink and contextual advance. Canvas shaping can already kern a
+ * punctuation pair down to the retained half-cell; subtracting the isolated
+ * glyph's removable sidebearing again would collapse the second mark to zero
+ * advance. A following glyph's left ink edge also participates in the collision
+ * equation. Resolve this after all source runs have been segmented so a
+ * formatting seam cannot reintroduce the overlap.
  */
 function retainHorizontalPunctuationInkClearance(segs: LayoutSeg[]): void {
   let pending: Readonly<{
     segment: LayoutTextSeg;
     compressionIndex: number;
     ink: Readonly<{ advancePt: number; xMinPt: number; xMaxPt: number }>;
+    contextualAdvancePt: number;
   }> | undefined;
   const adjustedBySegment = new Map<
     LayoutTextSeg,
@@ -1121,6 +1146,9 @@ function retainHorizontalPunctuationInkClearance(segs: LayoutSeg[]): void {
     const compressionIndexByEnd = new Map(
       compressions.map((compression, index) => [compression.end, index]),
     );
+    const contextualAdvances = compressions.length > 0
+      ? contextualHorizontalGraphemeAdvances(segment)
+      : undefined;
     const boundaries = [0, ...graphemeClusterOffsets(segment.text), segment.text.length];
     for (let index = 0; index < boundaries.length - 1; index += 1) {
       const start = boundaries[index]!;
@@ -1136,14 +1164,23 @@ function retainHorizontalPunctuationInkClearance(segs: LayoutSeg[]): void {
             ...compression,
           }));
         const compression = adjustments[pending.compressionIndex]!;
+        const retainedExtentPt = Math.max(
+          0,
+          pending.ink.advancePt + compression.adjustmentPt,
+        );
+        const retainedExtentAdjustmentPt = Math.min(
+          0,
+          retainedExtentPt - pending.contextualAdvancePt,
+        );
         const collisionSafeAdjustmentPt = Math.min(
           0,
           pending.ink.xMaxPt
             - currentInk.xMinPt
-            - pending.ink.advancePt,
+            - pending.contextualAdvancePt,
         );
         const adjustmentPt = Math.max(
           compression.adjustmentPt,
+          retainedExtentAdjustmentPt,
           collisionSafeAdjustmentPt,
         );
         if (adjustmentPt !== compression.adjustmentPt) {
@@ -1155,7 +1192,13 @@ function retainHorizontalPunctuationInkClearance(segs: LayoutSeg[]): void {
         }
       }
       pending = compressionIndex !== undefined && currentInk
-        ? { segment, compressionIndex, ink: currentInk }
+        ? {
+            segment,
+            compressionIndex,
+            ink: currentInk,
+            contextualAdvancePt:
+              contextualAdvances?.get(end) ?? currentInk.advancePt,
+          }
         : undefined;
     }
   }


### PR DESCRIPTION
## What changed

- clamp document-level full-width punctuation compression against the contextually shaped cluster advance
- retain adjacent tight-ink clearance when the next glyph begins near the compressed mark
- add an end-to-end regression for a closing punctuation pair that is already kerned to a half cell

## Root cause

The compression path calculated removable whitespace from an isolated punctuation glyph. When Canvas contextual shaping had already kerned a closing punctuation pair to the retained half-cell, applying the isolated-glyph adjustment a second time could collapse the second mark to zero advance and overlap the following CJK glyph.

Eligibility remains governed by ECMA-376 §17.15.1.18 and [MS-OE376] §2.1.562. The retained half-cell amount follows the existing registered Office observation.

## Verification

- focused punctuation and character-spacing tests
- full Vitest suite: 5,839 passed, 25 skipped
- TypeScript workspace typecheck
- DOCX final architecture boundary, compatibility evidence, public API, and package-build gates
- local-only Word/PDF visual comparison using a non-redistributable document

The private document and generated comparison artifacts are not included in this PR.