### PR TITLE
fix(vscode): render equations in scroll viewers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,9 @@
     "url": "https://github.com/yukiyokotani/office-open-xml-viewer/issues"
   },
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./assets/mathjax-stix2.js"
+  ],
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {

--- a/packages/vscode-extension/src/mathEngineBundle.test.ts
+++ b/packages/vscode-extension/src/mathEngineBundle.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { build } from 'esbuild';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe('VS Code webview math engine bundle', () => {
+  it('retains the MathJax STIX2 side-effect entry used by DOCX, XLSX, and PPTX', async () => {
+    const result = await build({
+      stdin: {
+        contents: "import '@silurus/ooxml-core/mathjax-stix2';",
+        resolveDir: HERE,
+        loader: 'js',
+      },
+      bundle: true,
+      write: false,
+      format: 'iife',
+      platform: 'browser',
+      target: 'es2020',
+      logLevel: 'silent',
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.outputFiles[0]?.text).toContain('globalThis.__ooxmlStix2');
+  });
+});

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -3,9 +3,11 @@
  *
  * Runs inside the VSCode Webview iframe. Receives the file bytes via the
  * `ooxml-init` message and instantiates the appropriate viewer:
- *   - docx / pptx: scroll-stacked render of every page / slide with a transparent
- *     text layer for native selection (PDF.js-style).
- *   - xlsx: XlsxViewer (sheet-based, no scroll stack)
+ *   - docx / pptx: their virtualized continuous-scroll viewers.
+ *   - xlsx: its sheet-based scrolling viewer.
+ *
+ * All three satisfy the shared ZoomableViewer contract, which drives the
+ * extension toolbar's zoom-out / zoom-in controls.
  */
 
 declare const __OOXML_FILE_TYPE__: 'docx' | 'xlsx' | 'pptx';
@@ -17,9 +19,9 @@ declare function acquireVsCodeApi(): {
 };
 
 import { XlsxViewer, type CellRange } from '@silurus/ooxml-xlsx';
-import { DocxDocument, buildDocxTextLayer, type DocxTextRunInfo } from '@silurus/ooxml-docx';
-import { PptxPresentation, buildPptxTextLayer, type PptxTextRunInfo } from '@silurus/ooxml-pptx';
-import { svgExtents } from '@silurus/ooxml-core';
+import { DocxScrollViewer } from '@silurus/ooxml-docx';
+import { PptxScrollViewer } from '@silurus/ooxml-pptx';
+import { svgExtents, type ZoomableViewer } from '@silurus/ooxml-core';
 // Side-effect import: bundles the self-contained MathJax + STIX Two Math engine
 // into the webview and sets globalThis.__ooxmlStix2. The library renders OMML
 // equations only when handed a `math` engine; its built-in engine loads lazily
@@ -43,6 +45,10 @@ const fileType = __OOXML_FILE_TYPE__;
 
 const statusEl = document.getElementById('status')!;
 const viewerContainer = document.getElementById('viewer-container')!;
+const zoomOutButton = document.getElementById('zoom-out') as HTMLButtonElement;
+const zoomInButton = document.getElementById('zoom-in') as HTMLButtonElement;
+const zoomLabel = document.getElementById('zoom-label')!;
+let activeViewer: ZoomableViewer | null = null;
 
 function showError(msg: string): void {
   statusEl.dataset.state = 'error';
@@ -53,6 +59,34 @@ function showError(msg: string): void {
 function hideStatus(): void {
   statusEl.style.display = 'none';
 }
+
+function updateZoomLabel(scale: number): void {
+  zoomLabel.textContent = `${Math.round(scale * 100)}%`;
+}
+
+function bindZoomViewer(viewer: ZoomableViewer): void {
+  activeViewer = viewer;
+  zoomOutButton.disabled = false;
+  zoomInButton.disabled = false;
+  updateZoomLabel(viewer.getScale());
+}
+
+async function runZoom(action: 'zoomIn' | 'zoomOut'): Promise<void> {
+  if (!activeViewer) return;
+  try {
+    await activeViewer[action]();
+    updateZoomLabel(activeViewer.getScale());
+  } catch (err) {
+    showError(`Error: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+zoomOutButton.addEventListener('click', () => {
+  void runZoom('zoomOut');
+});
+zoomInButton.addEventListener('click', () => {
+  void runZoom('zoomIn');
+});
 
 // Notify extension host that the webview script is ready to receive messages.
 vscodeApi.postMessage({ type: 'webview-ready' });
@@ -92,14 +126,14 @@ window.addEventListener('message', async (event: MessageEvent) => {
 // ── XLSX ─────────────────────────────────────────────────────────────────────
 
 async function initXlsx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<void> {
-  const container = document.createElement('div');
-  container.style.cssText = 'width:100%;height:100vh;';
-  viewerContainer.appendChild(container);
-
-  const viewer = new XlsxViewer(container, {
+  let loadFailed = false;
+  const viewer = new XlsxViewer(viewerContainer, {
     math,
     useGoogleFonts,
+    showZoomSlider: false,
+    onScaleChange: updateZoomLabel,
     onError(err) {
+      loadFailed = true;
       showError(`Error: ${err.message}`);
     },
     onSelectionChange(sel: CellRange | null) {
@@ -109,6 +143,8 @@ async function initXlsx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
   });
 
   await viewer.load(buffer);
+  if (loadFailed) return;
+  bindZoomViewer(viewer);
   hideStatus();
 
   document.addEventListener('keydown', (e) => {
@@ -120,90 +156,44 @@ async function initXlsx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
   });
 }
 
-// ── DOCX (scroll view) ───────────────────────────────────────────────────────
-//
-// The text-selection overlay is built by the shared, public buildDocxTextLayer
-// (imported above) rather than a local duplicate: this webview's `.page-canvas`
-// is `width:100%` of `.page-wrapper` (itself capped by an inline `max-width`),
-// so it IS responsively scaled by the editor pane's width, exactly the pattern
-// the shared builder now guards (an overlay pinned to literal px would overflow
-// `.page-wrapper` under a narrow pane, pushing scroll onto an ancestor — the same
-// bug fixed for PptxViewer/DocxViewer). buildDocxTextLayer takes the page's
-// intended CSS box (px, numbers) as the `%` denominators and leaves the
-// `.text-layer` container's own `width:100%;height:100%` (set by CSS class)
-// untouched.
+// ── DOCX (virtualized continuous scroll) ─────────────────────────────────────
 
 async function initDocx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<void> {
-  const doc = await DocxDocument.load(buffer, { math, useGoogleFonts });
-
-  const stack = document.createElement('div');
-  stack.className = 'page-stack';
-  viewerContainer.appendChild(stack);
-
-  const widthPx = Math.min(window.innerWidth - 64, 900);
-
-  for (let i = 0; i < doc.pageCount; i++) {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'page-wrapper';
-    wrapper.style.maxWidth = `${widthPx}px`;
-
-    const canvas = document.createElement('canvas');
-    canvas.className = 'page-canvas';
-
-    const textLayer = document.createElement('div');
-    textLayer.className = 'text-layer';
-
-    wrapper.append(canvas, textLayer);
-    stack.appendChild(wrapper);
-
-    const runs: DocxTextRunInfo[] = [];
-    await doc.renderPage(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
-    const cssHeight = parseFloat(canvas.style.height) || canvas.height;
-    buildDocxTextLayer(textLayer, runs, widthPx, cssHeight);
-  }
-
+  let loadFailed = false;
+  const viewer = new DocxScrollViewer(viewerContainer, {
+    math,
+    useGoogleFonts,
+    enableTextSelection: true,
+    background: 'var(--vscode-editor-background)',
+    onScaleChange: updateZoomLabel,
+    onError(err) {
+      loadFailed = true;
+      showError(`Error: ${err.message}`);
+    },
+  });
+  await viewer.load(buffer);
+  if (loadFailed) return;
+  bindZoomViewer(viewer);
   hideStatus();
 }
 
-// ── PPTX (scroll view) ───────────────────────────────────────────────────────
-//
-// Same rationale as the docx section above: the shared, public
-// buildPptxTextLayer (imported above) replaces the former local duplicate,
-// which pinned `.text-layer`'s width/height and every shape frame / span to
-// literal px — the same responsive-overflow bug fixed for PptxViewer, and a
-// live one here too (`.page-canvas` is `width:100%` of `.page-wrapper`, capped
-// by an inline `max-width`, so it IS responsively scaled by the editor pane).
+// ── PPTX (virtualized continuous scroll) ─────────────────────────────────────
 
 async function initPptx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<void> {
-  const pres = await PptxPresentation.load(buffer, { math, useGoogleFonts });
-
-  const stack = document.createElement('div');
-  stack.className = 'page-stack';
-  viewerContainer.appendChild(stack);
-
-  const widthPx = Math.min(window.innerWidth - 64, 960);
-  const cssHeight = pres.slideWidth > 0
-    ? Math.round((pres.slideHeight * widthPx) / pres.slideWidth)
-    : Math.round((widthPx * 9) / 16);
-
-  for (let i = 0; i < pres.slideCount; i++) {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'page-wrapper';
-    wrapper.style.maxWidth = `${widthPx}px`;
-
-    const canvas = document.createElement('canvas');
-    canvas.className = 'page-canvas';
-
-    const textLayer = document.createElement('div');
-    textLayer.className = 'text-layer';
-
-    wrapper.append(canvas, textLayer);
-    stack.appendChild(wrapper);
-
-    const runs: PptxTextRunInfo[] = [];
-    await pres.presentSlide(canvas, i, { width: widthPx, onTextRun: (r) => runs.push(r) });
-    buildPptxTextLayer(textLayer, runs, widthPx, cssHeight);
-  }
-
+  let loadFailed = false;
+  const viewer = new PptxScrollViewer(viewerContainer, {
+    math,
+    useGoogleFonts,
+    enableTextSelection: true,
+    background: 'var(--vscode-editor-background)',
+    onScaleChange: updateZoomLabel,
+    onError(err) {
+      loadFailed = true;
+      showError(`Error: ${err.message}`);
+    },
+  });
+  await viewer.load(buffer);
+  if (loadFailed) return;
+  bindZoomViewer(viewer);
   hideStatus();
 }

--- a/packages/vscode-extension/src/webviewHtml.test.ts
+++ b/packages/vscode-extension/src/webviewHtml.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, it, vi } from 'vitest';
 // `vscode` only exists inside the extension host. `buildContentSecurityPolicy`
 // does not touch it, but importing the module pulls in the top-level
 // `import * as vscode` — stub it so the unit under test loads in plain Node.
-vi.mock('vscode', () => ({}));
+vi.mock('vscode', () => ({
+  Uri: {
+    joinPath: (...parts: unknown[]) => parts,
+  },
+}));
 
-import { buildContentSecurityPolicy } from './webviewHtml';
+import { buildContentSecurityPolicy, getWebviewHtml } from './webviewHtml';
 
 const CSP_SOURCE = 'vscode-webview://abc';
 const NONCE = 'testnonce';
@@ -44,4 +48,26 @@ describe('buildContentSecurityPolicy', () => {
     expect(connectSrc).not.toContain('googleapis');
     expect(connectSrc).not.toContain('gstatic');
   });
+});
+
+describe('getWebviewHtml', () => {
+  it.each(['docx', 'xlsx', 'pptx'] as const)(
+    'includes shared zoom-out and zoom-in controls for %s',
+    (fileType) => {
+      const html = getWebviewHtml(
+        {
+          cspSource: CSP_SOURCE,
+          asWebviewUri: () => 'vscode-webview://extension/dist/webview.js',
+        } as never,
+        {} as never,
+        fileType,
+      );
+
+      expect(html).toContain('id="zoom-out"');
+      expect(html).toContain('aria-label="Zoom out"');
+      expect(html).toContain('id="zoom-in"');
+      expect(html).toContain('aria-label="Zoom in"');
+      expect(html).toContain('id="zoom-label"');
+    },
+  );
 });

--- a/packages/vscode-extension/src/webviewHtml.ts
+++ b/packages/vscode-extension/src/webviewHtml.ts
@@ -79,30 +79,67 @@ export function getWebviewHtml(
     html, body {
       width: 100%;
       height: 100%;
+      overflow: hidden;
       background: var(--vscode-editor-background);
       color: var(--vscode-foreground);
       font-family: var(--vscode-font-family, sans-serif);
     }
-    /* xlsx fills the whole viewport; docx/pptx scroll inside #viewer-root. */
-    body.layout-xlsx { overflow: hidden; }
-    body.layout-stack { overflow: auto; }
     #viewer-root {
       width: 100%;
-      min-height: 100%;
-      display: flex;
-      justify-content: center;
-      align-items: flex-start;
-      padding: 16px;
-    }
-    body.layout-xlsx #viewer-root { padding: 0; height: 100%; }
-    #viewer-container { max-width: 100%; width: 100%; }
-    body.layout-stack #viewer-container {
+      height: 100%;
+      min-height: 0;
       display: flex;
       flex-direction: column;
+    }
+    #viewer-toolbar {
+      height: 35px;
+      flex: 0 0 35px;
+      display: flex;
       align-items: center;
+      justify-content: flex-end;
+      gap: 4px;
+      padding: 0 8px;
+      border-bottom: 1px solid var(--vscode-panel-border, rgba(127, 127, 127, 0.35));
+      background: var(--vscode-editorGroupHeader-tabsBackground, var(--vscode-editor-background));
+      user-select: none;
+    }
+    #viewer-toolbar button {
+      width: 26px;
+      height: 24px;
+      border: 1px solid transparent;
+      border-radius: 3px;
+      color: var(--vscode-foreground);
+      background: transparent;
+      font: 16px/1 var(--vscode-font-family, sans-serif);
+      cursor: pointer;
+    }
+    #viewer-toolbar button:hover:not(:disabled) {
+      background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.2));
+    }
+    #viewer-toolbar button:focus-visible {
+      outline: 1px solid var(--vscode-focusBorder);
+      outline-offset: -1px;
+    }
+    #viewer-toolbar button:disabled {
+      cursor: default;
+      opacity: 0.4;
+    }
+    #zoom-label {
+      min-width: 46px;
+      text-align: center;
+      font-size: 12px;
+      font-variant-numeric: tabular-nums;
+    }
+    #viewer-container {
+      position: relative;
+      width: 100%;
+      min-width: 0;
+      min-height: 0;
+      flex: 1 1 auto;
+      overflow: hidden;
     }
     #status {
-      position: fixed;
+      position: absolute;
       inset: 0;
       display: flex;
       align-items: center;
@@ -126,40 +163,15 @@ export function getWebviewHtml(
       animation: spin 0.9s linear infinite;
     }
     @keyframes spin { to { transform: rotate(360deg); } }
-    /* docx / pptx scroll-stack styling */
-    .page-stack {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 16px;
-      width: 100%;
-    }
-    .page-wrapper {
-      position: relative;
-      width: 100%;
-      margin: 0 auto;
-    }
-    .page-canvas {
-      display: block;
-      width: 100%;
-      background: #fff;
-      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
-    }
-    .text-layer {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-      pointer-events: none;
-      user-select: text;
-      -webkit-user-select: text;
-    }
   </style>
 </head>
-<body class="${fileType === 'xlsx' ? 'layout-xlsx' : 'layout-stack'}">
+<body>
   <div id="viewer-root">
+    <div id="viewer-toolbar" role="toolbar" aria-label="Zoom controls">
+      <button id="zoom-out" type="button" aria-label="Zoom out" title="Zoom out" disabled>−</button>
+      <span id="zoom-label" aria-live="polite">100%</span>
+      <button id="zoom-in" type="button" aria-label="Zoom in" title="Zoom in" disabled>+</button>
+    </div>
     <div id="viewer-container">
       <div id="status"><div class="spinner"></div></div>
     </div>


### PR DESCRIPTION
## Summary

- preserve the bundled MathJax + STIX Two Math side-effect entry so equations render in VS Code previews
- use `DocxScrollViewer` and `PptxScrollViewer` for virtualized continuous document rendering
- add a shared zoom-out / zoom percentage / zoom-in toolbar for DOCX, XLSX, and PPTX
- add regressions for MathJax bundle retention and the shared zoom controls

## Root cause

The VS Code webview imported the self-contained math engine for its side effect, but the core workspace package declared every entry side-effect-free. Esbuild therefore removed the MathJax entry from the webview bundle. The same adapter is supplied to DOCX, XLSX, and PPTX, so equations could be skipped in all three formats.

## User impact

Equations are now retained and rendered in the VS Code extension for all supported OOXML formats. DOCX and PPTX previews use the library's virtualized continuous-scroll viewers, and all formats expose consistent zoom controls.

## Verification

- 222 focused Vitest tests
- TypeScript build and VS Code extension typecheck
- production VS Code webview bundle, including explicit MathJax retention check
- `git diff --check`