### PR TITLE
fix(docx): accept universal measures in ST_HpsMeasure and ST_TwipsMeasure

### DIFF
--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -2095,7 +2095,7 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
     // and is used only for equality linking.
     if let Some(fit_text) = child_w(rpr, "fitText") {
         fmt.fit_text = attr_w(fit_text, "val")
-            .and_then(|value| parse_measure_to_pt(&value, 1.0 / 20.0))
+            .and_then(|value| parse_measure_to_pt(&value, 20.0))
             .map(|points| points * 20.0)
             .filter(|value| *value >= 0.0)
             .map(|val| FitTextSpec {

--- a/packages/docx/parser/src/xml_util.rs
+++ b/packages/docx/parser/src/xml_util.rs
@@ -75,9 +75,10 @@ pub fn attr_w14(node: Node, name: &str) -> Option<String> {
 ///
 /// Suffixed values use the fixed physical-unit conversions from
 /// `ST_UniversalMeasure` (`pt`, `in`, `pc`/`pi`, `mm`, `cm`). The meaning of a
-/// bare number is context-dependent, so callers supply its points-per-unit
-/// scale: VML shape lengths use `1.0`, while `ST_TwipsMeasure` uses `1.0 / 20.0`.
-pub(crate) fn parse_measure_to_pt(value: &str, unitless_scale: f64) -> Option<f64> {
+/// bare number is context-dependent, so callers supply how many of that unit
+/// make one point: VML shape lengths use `1.0`, `ST_TwipsMeasure` uses `20.0`,
+/// and `ST_HpsMeasure` uses `2.0`.
+pub(crate) fn parse_measure_to_pt(value: &str, unitless_per_pt: f64) -> Option<f64> {
     let value = value.trim();
     let (number, scale) = if let Some(number) = value.strip_suffix("pt") {
         (number, 1.0)
@@ -93,25 +94,34 @@ pub(crate) fn parse_measure_to_pt(value: &str, unitless_scale: f64) -> Option<f6
     } else if let Some(number) = value.strip_suffix("cm") {
         (number, 72.0 / 2.54)
     } else {
-        (value, unitless_scale)
+        // Divide rather than multiply by a reciprocal: 1701 / 20.0 is 85.05,
+        // 1701 * (1.0 / 20.0) is 85.05000000000001, and section geometry
+        // asserts the exact value.
+        return parse_finite(value).map(|number| number / unitless_per_pt);
     };
 
-    number
+    parse_finite(number).map(|number| number * scale)
+}
+
+/// Parse a decimal, rejecting non-finite values so NaN/inf never reaches layout.
+fn parse_finite(value: &str) -> Option<f64> {
+    value
         .trim()
         .parse::<f64>()
         .ok()
         .filter(|number| number.is_finite())
-        .map(|number| number * scale)
 }
 
-/// Parse twips (1/20 pt) string to f64 pt.
+/// Parse `ST_TwipsMeasure` (§22.9.2.14) to points. A bare number is twips; a
+/// `ST_PositiveUniversalMeasure` suffix is an absolute size.
 pub fn twips_to_pt(s: &str) -> f64 {
-    s.parse::<f64>().unwrap_or(0.0) / 20.0
+    parse_measure_to_pt(s, 20.0).unwrap_or(0.0)
 }
 
-/// Parse half-points string to f64 pt.
+/// Parse `ST_HpsMeasure` (§17.18.42) to points. A bare number is half-points; a
+/// `ST_PositiveUniversalMeasure` suffix is an absolute size.
 pub fn half_pt_to_pt(s: &str) -> f64 {
-    s.parse::<f64>().unwrap_or(0.0) / 2.0
+    parse_measure_to_pt(s, 2.0).unwrap_or(0.0)
 }
 
 /// Parse a ST_OnOff-style toggle child element. ECMA-376 §17.3.2.22 allows
@@ -136,4 +146,38 @@ pub fn bool_prop(node: Node, tag: &str) -> Option<bool> {
 pub fn on_off_attr(node: Node, name: &str) -> Option<bool> {
     let val = attr_w(node, name)?;
     Some(!matches!(val.as_str(), "0" | "false" | "off"))
+}
+
+#[cfg(test)]
+mod measure_tests {
+    use super::{half_pt_to_pt, twips_to_pt};
+
+    #[test]
+    fn half_pt_to_pt_accepts_positive_universal_measures() {
+        // ST_HpsMeasure (§17.18.42) = ST_UnsignedDecimalNumber |
+        // ST_PositiveUniversalMeasure.
+        assert_eq!(half_pt_to_pt("20"), 10.0, "20 half-points = 10pt");
+        assert_eq!(half_pt_to_pt("12pt"), 12.0, "12pt is absolute, not 6pt");
+        assert_eq!(half_pt_to_pt("1in"), 72.0);
+        assert_eq!(half_pt_to_pt("1pc"), 12.0);
+        assert_eq!(half_pt_to_pt("1pi"), 12.0);
+        assert!((half_pt_to_pt("3.6mm") - 72.0 * 3.6 / 25.4).abs() < 1e-9);
+        assert!((half_pt_to_pt("2.54cm") - 72.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn twips_to_pt_accepts_positive_universal_measures() {
+        // ST_TwipsMeasure (§22.9.2.14) is the same union.
+        assert_eq!(twips_to_pt("240"), 12.0, "240 twips = 12pt");
+        assert_eq!(twips_to_pt("12pt"), 12.0);
+        assert_eq!(twips_to_pt("1in"), 72.0);
+    }
+
+    #[test]
+    fn measure_parsers_reject_unparseable_and_non_finite_values() {
+        assert_eq!(half_pt_to_pt(""), 0.0);
+        assert_eq!(half_pt_to_pt("auto"), 0.0);
+        assert_eq!(half_pt_to_pt("inf"), 0.0);
+        assert_eq!(twips_to_pt("NaN"), 0.0);
+    }
 }


### PR DESCRIPTION
## Problem

`ST_HpsMeasure` (ECMA-376 §17.18.42) is a union of `ST_UnsignedDecimalNumber` and `ST_PositiveUniversalMeasure`. `ST_TwipsMeasure` (§22.9.2.14) is defined the same way. So a bare number carries the context-specific unit, but a suffixed value — `3.6mm`, `12pt`, `1in` — is an absolute size, and Word honours it.

`half_pt_to_pt` and `twips_to_pt` parsed the attribute with a bare `f64` parse:

```rust
pub fn half_pt_to_pt(s: &str) -> f64 {
    s.parse::<f64>().unwrap_or(0.0) / 2.0
}
```

`"3.6mm".parse::<f64>()` fails, so the value falls through `unwrap_or(0.0)` to zero.

For `w:sz` this is worse than a dropped attribute. The zero is stored as an *explicitly set* run size, so the style-chain merge never supplies the real value from `styles.xml`, and every affected run lays out at font size 0.

Browsers then diverge on what that renders as:

- engines that honour a `0px` canvas font paint nothing — the page comes up blank
- engines that reject `0px` as invalid substitute a fallback, so glyphs paint at a normal size while runs keep their collapsed advances — words overlap into each other

Documents that write font sizes as universal measures are affected throughout, not in isolated runs.

## Fix

Route both helpers through the existing `parse_measure_to_pt`, which already implements the `ST_UniversalMeasure` unit table (`pt`, `in`, `pc`/`pi`, `mm`, `cm`). No new unit logic is introduced.

One adjustment was needed to keep this exact. The bare-number unit is now expressed as a **divisor** (units per point) rather than a multiplicative reciprocal:

```
1701 / 20.0        = 85.05
1701 * (1.0/20.0)  = 85.05000000000001
```

`parser::column_tests::section_break_carries_page_geometry` asserts the exact value, and the first version of this change broke it. The divisor form reproduces the original arithmetic exactly, and also removes the same reciprocal error from the existing `styles.rs` call site.

The shared helper additionally rejects non-finite input, so `inf` and `NaN` no longer propagate into layout — previously `half_pt_to_pt("inf")` returned `inf`.

## Tests

Added `measure_tests` in `xml_util.rs`, written against the spec rather than a sample:

- suffixed forms resolve to absolute sizes for both helpers (`12pt`, `1in`, `1pc`, `1pi`, `mm`, `cm`)
- bare numbers keep their existing meaning (`20` half-points = 10pt, `240` twips = 12pt)
- unparseable and non-finite values yield 0

All three fail before the change and pass after.

## Verification

```
cargo test --workspace                    1115 passed, 0 failed
cargo fmt --check                         clean
cargo clippy --workspace --all-targets    clean
```

Not run: WASM rebuild and the JS/VRT suites. The change is confined to two parser helpers with unit coverage, but per `AGENTS.md` a maintainer may want `pnpm build:wasm` plus the parser-backed integration tests before merge, and I'm happy to add anything that surfaces.

## Notes

Found while investigating a rendering failure in a downstream integration; reproduced against 0.72.2 and confirmed still present on `main`.

`half_pt_to_pt` and `twips_to_pt` are the two `unwrap_or(0.0)` measure parsers I found. If you'd prefer this split into two PRs — the `ST_HpsMeasure` fix and the `ST_TwipsMeasure` fix separately — happy to do that; they're grouped here because they're the same defect and the divisor change has to land with both.
