### PR TITLE
fix(vscode): preserve natural document scale

### DIFF
--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -597,6 +597,7 @@ export declare interface DocxScrollViewerOptions extends Omit<RenderPageOptions,
     zoomMin?: number;
     zoomMax?: number;
     enableZoom?: boolean;
+    refitOnResize?: boolean;
     background?: string;
     pageShadow?: string | false;
     document?: DocxDocument;

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1201,6 +1201,23 @@ describe('DocxScrollViewer — navigation, resize, empty (T6)', () => {
     v.destroy();
   });
 
+  it('refitOnResize false preserves the absolute scale when the container width changes', () => {
+    const onScaleChange = vi.fn();
+    const { v, container } = setup(20, { refitOnResize: false, onScaleChange });
+    v.setScale(1);
+    onScaleChange.mockClear();
+    const epochBefore = v.renderEpochForTest();
+
+    container.clientWidth = 400;
+    (container.children[0] as FakeEl).children[0].clientWidth = 400;
+    v.resizeForTest();
+
+    expect(v.scaleForTest()).toBe(1);
+    expect(v.renderEpochForTest()).toBe(epochBefore);
+    expect(onScaleChange).not.toHaveBeenCalled();
+    v.destroy();
+  });
+
   it('ResizeObserver re-fit bumps the render epoch (resize is an epoch event)', () => {
     const { v, container } = setup();
     const before = v.renderEpochForTest();

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -79,6 +79,13 @@ export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onText
   /** Enable `Ctrl`/`Cmd`+wheel zoom. Default true. */
   enableZoom?: boolean;
   /**
+   * Re-fit the document to the container width when the container is resized.
+   * Default true. Set false to preserve the current absolute scale, including
+   * an explicit pre-load `setScale(1)`, independently of the viewport width.
+   * Explicit `fitWidth()` and `fitPage()` calls remain available.
+   */
+  refitOnResize?: boolean;
+  /**
    * CSS `background` shorthand for the scroll surface (the "desk") visible
    * behind and between pages — the gray a PDF reader paints around the sheet.
    * Applied to the viewer-owned scroll host. The pages themselves are always
@@ -116,8 +123,9 @@ export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onText
   /** IX9 — fires whenever the zoom factor actually changes (`1` = 100% = a page
    *  at its natural pt→px size): from {@link DocxScrollViewer.setScale},
    *  `zoomIn`/`zoomOut`, `fitWidth`/`fitPage`, a Ctrl/⌘+wheel gesture, or a
-   *  container-resize re-fit. Named `onScaleChange` to match the single-canvas
-   *  viewers so all five share one notification shape. */
+   *  container-resize re-fit (when `refitOnResize` is enabled). Named
+   *  `onScaleChange` to match the single-canvas viewers so all five share one
+   *  notification shape. */
   onScaleChange?: (scale: number) => void;
   /** IX1 (design decision — NOT user-confirmed, integrator may veto). Called when
    *  a hyperlink run is clicked. When omitted, the default is: external → open in a
@@ -1513,6 +1521,14 @@ export class DocxScrollViewer implements ZoomableViewer {
     // Zero-width recovery: first non-zero layout establishes the base scale.
     if (!this._scaleEstablished) {
       this.relayout();
+      return;
+    }
+    if (this._opts.refitOnResize === false) {
+      // Fixed-scale hosts (for example VS Code previews) must not turn a pane
+      // resize into an implicit zoom. Recompute the visible window and horizontal
+      // centering only; page geometry and rendered bitmaps remain valid.
+      this._lastFitWidth = this._fitWidthPx();
+      this._mountVisible();
       return;
     }
     const newBase = this._baseScale();

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1350,6 +1350,23 @@ describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
     v.destroy();
   });
 
+  it('refitOnResize false preserves the absolute scale when the container width changes', () => {
+    const onScaleChange = vi.fn();
+    const { v, container } = setup(20, { refitOnResize: false, onScaleChange });
+    v.setScale(1);
+    onScaleChange.mockClear();
+    const epochBefore = v.renderEpochForTest();
+
+    container.clientWidth = 400;
+    (container.children[0] as FakeEl).children[0].clientWidth = 400;
+    v.resizeForTest();
+
+    expect(v.scaleForTest()).toBe(1);
+    expect(v.renderEpochForTest()).toBe(epochBefore);
+    expect(onScaleChange).not.toHaveBeenCalled();
+    v.destroy();
+  });
+
   it('ResizeObserver re-fit bumps the render epoch (resize is an epoch event)', () => {
     const { v, container } = setup();
     const before = v.renderEpochForTest();

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -83,6 +83,13 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
   /** Enable `Ctrl`/`Cmd`+wheel zoom. Default true. */
   enableZoom?: boolean;
   /**
+   * Re-fit the presentation to the container width when the container is
+   * resized. Default true. Set false to preserve the current absolute scale,
+   * including an explicit pre-load `setScale(1)`, independently of the viewport
+   * width. Explicit `fitWidth()` and `fitPage()` calls remain available.
+   */
+  refitOnResize?: boolean;
+  /**
    * CSS `background` shorthand for the scroll surface (the "desk") visible
    * behind and between slides — the gray a presentation viewer paints around the
    * slide. Applied to the viewer-owned scroll host. The slides themselves are
@@ -120,8 +127,9 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
   /** IX9 — fires whenever the zoom factor actually changes (`1` = 100% = a slide
    *  at its natural EMU→px size): from {@link PptxScrollViewer.setScale},
    *  `zoomIn`/`zoomOut`, `fitWidth`/`fitPage`, a Ctrl/⌘+wheel gesture, or a
-   *  container-resize re-fit. Named `onScaleChange` to match the single-canvas
-   *  viewers so all five share one notification shape. */
+   *  container-resize re-fit (when `refitOnResize` is enabled). Named
+   *  `onScaleChange` to match the single-canvas viewers so all five share one
+   *  notification shape. */
   onScaleChange?: (scale: number) => void;
   /** Error callback. When set, `load()` invokes it and resolves (otherwise the
    *  error is rethrown — shared viewer error contract). It ALSO fires for async
@@ -1497,6 +1505,14 @@ export class PptxScrollViewer implements ZoomableViewer {
     // Zero-width recovery: first non-zero layout establishes the base scale.
     if (!this._scaleEstablished) {
       this.relayout();
+      return;
+    }
+    if (this._opts.refitOnResize === false) {
+      // Fixed-scale hosts (for example VS Code previews) must not turn a pane
+      // resize into an implicit zoom. Recompute the visible window and horizontal
+      // centering only; slide geometry and rendered bitmaps remain valid.
+      this._lastFitWidth = this._fitWidthPx();
+      this._mountVisible();
       return;
     }
     const newBase = this._baseScale();

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -22,6 +22,7 @@ import { XlsxViewer, type CellRange } from '@silurus/ooxml-xlsx';
 import { DocxScrollViewer } from '@silurus/ooxml-docx';
 import { PptxScrollViewer } from '@silurus/ooxml-pptx';
 import { svgExtents, type ZoomableViewer } from '@silurus/ooxml-core';
+import { loadAtNaturalScale } from './naturalScale';
 // Side-effect import: bundles the self-contained MathJax + STIX Two Math engine
 // into the webview and sets globalThis.__ooxmlStix2. The library renders OMML
 // equations only when handed a `math` engine; its built-in engine loads lazily
@@ -164,6 +165,7 @@ async function initDocx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
     math,
     useGoogleFonts,
     enableTextSelection: true,
+    refitOnResize: false,
     background: 'var(--vscode-editor-background)',
     onScaleChange: updateZoomLabel,
     onError(err) {
@@ -171,7 +173,7 @@ async function initDocx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
       showError(`Error: ${err.message}`);
     },
   });
-  await viewer.load(buffer);
+  await loadAtNaturalScale(viewer, buffer);
   if (loadFailed) return;
   bindZoomViewer(viewer);
   hideStatus();
@@ -185,6 +187,7 @@ async function initPptx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
     math,
     useGoogleFonts,
     enableTextSelection: true,
+    refitOnResize: false,
     background: 'var(--vscode-editor-background)',
     onScaleChange: updateZoomLabel,
     onError(err) {
@@ -192,7 +195,7 @@ async function initPptx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
       showError(`Error: ${err.message}`);
     },
   });
-  await viewer.load(buffer);
+  await loadAtNaturalScale(viewer, buffer);
   if (loadFailed) return;
   bindZoomViewer(viewer);
   hideStatus();

--- a/packages/vscode-extension/src/webview/naturalScale.test.ts
+++ b/packages/vscode-extension/src/webview/naturalScale.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadAtNaturalScale } from './naturalScale';
+
+describe('loadAtNaturalScale', () => {
+  it('latches absolute 100% before loading instead of fitting to the view width', async () => {
+    const calls: string[] = [];
+    const buffer = new ArrayBuffer(4);
+    const viewer = {
+      setScale: vi.fn((scale: number) => {
+        calls.push(`scale:${scale}`);
+      }),
+      load: vi.fn(async (source: string | ArrayBuffer) => {
+        expect(source).toBe(buffer);
+        calls.push('load');
+      }),
+    };
+
+    await loadAtNaturalScale(viewer, buffer);
+
+    expect(viewer.setScale).toHaveBeenCalledWith(1);
+    expect(calls).toEqual(['scale:1', 'load']);
+  });
+});

--- a/packages/vscode-extension/src/webview/naturalScale.ts
+++ b/packages/vscode-extension/src/webview/naturalScale.ts
@@ -1,0 +1,26 @@
+/**
+ * The VS Code preview's default document scale.
+ *
+ * `1` is the viewers' absolute natural scale: authored points/EMUs map to their
+ * normal CSS-pixel size. Unlike fit-width, this keeps equal font sizes visually
+ * equal across portrait and landscape documents and across editor pane widths.
+ */
+export const NATURAL_DOCUMENT_SCALE = 1;
+
+interface LoadableScrollViewer {
+  setScale(scale: number): void;
+  load(source: string | ArrayBuffer): Promise<void>;
+}
+
+/**
+ * Set the absolute scale before loading. DocxScrollViewer and PptxScrollViewer
+ * intentionally latch a pre-load setScale call and apply it after establishing
+ * their internal base geometry, overriding the default container-width fit.
+ */
+export async function loadAtNaturalScale(
+  viewer: LoadableScrollViewer,
+  source: string | ArrayBuffer,
+): Promise<void> {
+  viewer.setScale(NATURAL_DOCUMENT_SCALE);
+  await viewer.load(source);
+}


### PR DESCRIPTION
## What changed

- initialize VS Code DOCX and PPTX previews at the viewers' absolute 100% natural scale
- add `refitOnResize: false` support to both scroll viewers so editor-pane resizing does not implicitly zoom the document
- preserve explicit zoom, fit-width, and fit-page controls
- add focused regression tests for natural-scale loading and fixed-scale resize behavior

## Why

The scroll viewers normally establish and maintain a container-width fit. In a wide VS Code editor pane, that made documents render far larger than their authored size, and changing the pane width changed the apparent font size. The preview should instead use a stable default scale so equivalent text remains visually consistent across portrait and landscape documents.

## Validation

- `vitest run` for DOCX/PPTX scroll-viewer and zoom-contract tests plus the VS Code natural-scale test (218 tests)
- TypeScript project build
- VS Code extension TypeScript check
- VS Code extension production bundle
- `git diff --check`