### PR TITLE
fix(vscode): capture webview pinch zoom

### DIFF
--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -23,6 +23,7 @@ import { DocxScrollViewer } from '@silurus/ooxml-docx';
 import { PptxScrollViewer } from '@silurus/ooxml-pptx';
 import { svgExtents, type ZoomableViewer } from '@silurus/ooxml-core';
 import { loadAtNaturalScale } from './naturalScale';
+import { captureUnhandledWheelZoom } from './wheelZoomFallback';
 // Side-effect import: bundles the self-contained MathJax + STIX Two Math engine
 // into the webview and sets globalThis.__ooxmlStix2. The library renders OMML
 // equations only when handed a `math` engine; its built-in engine loads lazily
@@ -88,6 +89,19 @@ zoomOutButton.addEventListener('click', () => {
 zoomInButton.addEventListener('click', () => {
   void runZoom('zoomIn');
 });
+
+// Chromium normally sends a trackpad pinch as Ctrl+wheel to the viewer-owned
+// scroll host. VS Code's webview can target the frame instead, so capture it at
+// the window and fall back only when the viewer's own handler did not run.
+window.addEventListener(
+  'wheel',
+  (event) => {
+    captureUnhandledWheelZoom(event, activeViewer, undefined, (err) => {
+      showError(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  },
+  { capture: true, passive: false },
+);
 
 // Notify extension host that the webview script is ready to receive messages.
 vscodeApi.postMessage({ type: 'webview-ready' });

--- a/packages/vscode-extension/src/webview/wheelZoomFallback.test.ts
+++ b/packages/vscode-extension/src/webview/wheelZoomFallback.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ZoomableViewer } from '@silurus/ooxml-core';
+import { captureUnhandledWheelZoom, type WheelZoomEvent } from './wheelZoomFallback.js';
+
+function fakeViewer(initialScale = 1): ZoomableViewer {
+  let scale = initialScale;
+  return {
+    getScale: () => scale,
+    setScale: (next) => {
+      scale = next;
+    },
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    fitWidth: vi.fn(),
+    fitPage: vi.fn(),
+  };
+}
+
+function fakeEvent(overrides: Partial<WheelZoomEvent> = {}): WheelZoomEvent {
+  return {
+    ctrlKey: true,
+    metaKey: false,
+    deltaY: -10,
+    preventDefault: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('VS Code webview wheel-zoom fallback', () => {
+  it('zooms when the viewer-owned handler did not receive the pinch event', () => {
+    const viewer = fakeViewer();
+    const event = fakeEvent();
+    let deferred: (() => void) | undefined;
+
+    expect(
+      captureUnhandledWheelZoom(event, viewer, (callback) => {
+        deferred = callback;
+      }),
+    ).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(viewer.getScale()).toBe(1);
+
+    deferred?.();
+    expect(viewer.getScale()).toBeGreaterThan(1);
+  });
+
+  it('does not zoom twice when the scroll viewer already handled the event', () => {
+    const viewer = fakeViewer();
+    const event = fakeEvent();
+    let deferred: (() => void) | undefined;
+
+    captureUnhandledWheelZoom(event, viewer, (callback) => {
+      deferred = callback;
+    });
+    viewer.setScale(1.1);
+    deferred?.();
+
+    expect(viewer.getScale()).toBe(1.1);
+  });
+
+  it('leaves an unmodified wheel event to native scrolling', () => {
+    const viewer = fakeViewer();
+    const event = fakeEvent({ ctrlKey: false });
+
+    expect(captureUnhandledWheelZoom(event, viewer)).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(viewer.getScale()).toBe(1);
+  });
+
+  it('accepts Command-modified wheel gestures', () => {
+    const viewer = fakeViewer();
+    let deferred: (() => void) | undefined;
+
+    expect(
+      captureUnhandledWheelZoom(
+        fakeEvent({ ctrlKey: false, metaKey: true }),
+        viewer,
+        (callback) => {
+          deferred = callback;
+        },
+      ),
+    ).toBe(true);
+
+    deferred?.();
+    expect(viewer.getScale()).toBeGreaterThan(1);
+  });
+
+  it('reports a synchronous viewer failure', () => {
+    const error = new Error('viewer destroyed');
+    const viewer = fakeViewer();
+    viewer.setScale = () => {
+      throw error;
+    };
+    const onError = vi.fn();
+    let deferred: (() => void) | undefined;
+
+    captureUnhandledWheelZoom(
+      fakeEvent(),
+      viewer,
+      (callback) => {
+        deferred = callback;
+      },
+      onError,
+    );
+    deferred?.();
+
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/vscode-extension/src/webview/wheelZoomFallback.ts
+++ b/packages/vscode-extension/src/webview/wheelZoomFallback.ts
@@ -1,0 +1,37 @@
+import { zoomStepScale, type ZoomableViewer } from '@silurus/ooxml-core';
+
+export interface WheelZoomEvent {
+  ctrlKey: boolean;
+  metaKey: boolean;
+  deltaY: number;
+  preventDefault(): void;
+}
+
+/**
+ * Capture a Chromium trackpad pinch before the VS Code webview can consume it.
+ *
+ * The scroll viewers normally handle the same Ctrl/Command+wheel event on their
+ * private scroll host. We defer the fallback by one microtask and only act when
+ * that handler did not change the scale, avoiding a double zoom while still
+ * covering events targeted at the webview frame rather than the scroll host.
+ */
+export function captureUnhandledWheelZoom(
+  event: WheelZoomEvent,
+  viewer: ZoomableViewer | null,
+  defer: (callback: () => void) => void = queueMicrotask,
+  onError?: (error: unknown) => void,
+): boolean {
+  if (!viewer || !(event.ctrlKey || event.metaKey) || event.deltaY === 0) return false;
+
+  const initialScale = viewer.getScale();
+  event.preventDefault();
+  defer(() => {
+    if (viewer.getScale() !== initialScale) return;
+    try {
+      Promise.resolve(viewer.setScale(zoomStepScale(initialScale, event.deltaY))).catch(onError);
+    } catch (error) {
+      onError?.(error);
+    }
+  });
+  return true;
+}


### PR DESCRIPTION
## What changed

- capture Ctrl/Command wheel gestures at the VS Code webview frame
- fall back to the active viewer only when its own scroll-host handler did not change scale
- route synchronous and asynchronous zoom failures through the existing error status
- add focused coverage for fallback zoom, double-zoom prevention, Command gestures, and failure reporting

## Why

VS Code can target a trackpad pinch at the webview frame instead of the ScrollViewer-owned scroll host. In that case the normal viewer handler never receives the gesture even though toolbar zoom remains functional.

## Validation

- focused webview zoom tests (6 tests)
- VS Code extension TypeScript check
- VS Code extension production bundle
- git diff --check
- independent GPT-5.6 Sol review: approved