### PR TITLE
fix(docx): resolve nil table borders per ECMA-376

### DIFF
--- a/packages/docx/src/cell-border-conflict-render.test.ts
+++ b/packages/docx/src/cell-border-conflict-render.test.ts
@@ -285,9 +285,9 @@ describe('§17.4.66 — adjacent cell border conflict, end-to-end render', () =>
     expect(colors.some((c) => c.includes('ff0000'))).toBe(false); // table thick loses
   });
 
-  it('Word nil suppresses the shared edge even when the other side is visible', async () => {
-    // [MS-OI29500] 2.1.169 differs from the base ECMA rule: nil suppresses the
-    // complete shared edge, whereas none merely loses to the opposing border.
+  it('nil loses to the opposing visible border', async () => {
+    // ECMA-376 §17.4.66: when either conflicting cell border is nil or none,
+    // the opposing border is displayed.
     const strokes = await render(tableOf([
       rowOf([
         cell('a', { right: bs({ style: 'nil' }) }),
@@ -295,10 +295,14 @@ describe('§17.4.66 — adjacent cell border conflict, end-to-end render', () =>
       ]),
     ]));
     const shared = verticalAt(strokes, 60);
-    expect(shared).toHaveLength(0);
+    expect(shared).toEqual([
+      expect.objectContaining({
+        color: expect.stringContaining('112233'),
+      }),
+    ]);
   });
 
-  it('nil on BOTH sides suppresses the shared gridline entirely', async () => {
+  it('does not paint a shared gridline when both sides are nil', async () => {
     const strokes = await render(tableOf([
       rowOf([
         cell('a', { right: bs({ style: 'nil' }) }),
@@ -391,6 +395,63 @@ describe('§17.4.66 — adjacent cell border conflict, end-to-end render', () =>
     expect(right.some((s) => s.color.toLowerCase().includes('222222'))).toBe(true);
   });
 
+  it('resolves each colSpan split segment independently when the spanning edge is nil', async () => {
+    // §17.4.66 applies independently to each segment at a 3-wide spanning
+    // owner → three independent cells boundary. The nil/nil left segment
+    // remains open while the omitted opposing edges on the middle and right
+    // segments admit the table insideH border.
+    const spanning = cell('intro', { bottom: bs({ style: 'nil' }) });
+    spanning.colSpan = 3;
+    const table = tableOf(
+      [
+        rowOf([spanning]),
+        rowOf([
+          cell('merge-start', { top: bs({ style: 'nil' }) }),
+          cell('label'),
+          cell('value'),
+        ]),
+      ],
+      { insideH: bs({ style: 'single', width: 1, color: '123456' }) },
+    );
+    table.layout = 'fixed';
+    table.widthPt = 180;
+    const strokes = await render(table);
+
+    expect(horizontalAt(strokes, 20)).toEqual([
+      expect.objectContaining({
+        x1: 60,
+        x2: 180,
+        color: expect.stringContaining('123456'),
+      }),
+    ]);
+  });
+
+  it('retains each above-cell bottom segment when the row below spans the full grid', async () => {
+    const bottom = bs({ style: 'single', width: 1, color: '123456' });
+    const spanning = cell('spanning');
+    spanning.colSpan = 3;
+    const strokes = await render(tableOf(
+      [
+        rowOf([
+          cell('left', { bottom }),
+          cell('middle', { bottom }),
+          cell('right', { bottom }),
+        ]),
+        rowOf([spanning]),
+      ],
+      { insideH: bs({ style: 'single', width: 1, color: '654321' }) },
+    ));
+
+    const shared = horizontalAt(strokes, 20);
+    expect(shared).toEqual([
+      expect.objectContaining({
+        x1: 0,
+        x2: 180,
+        color: expect.stringContaining('123456'),
+      }),
+    ]);
+  });
+
   it('§17.4.66 (#815): a vMerge cell resolves EACH right sub-segment against its own neighbour', async () => {
     // A tall cell (vMerge restart) spanning both rows faces TWO right neighbours
     // with DIFFERENT left borders. Its shared vertical edge must be split at the
@@ -410,6 +471,44 @@ describe('§17.4.66 — adjacent cell border conflict, end-to-end render', () =>
     const bot = seg.filter((s) => Math.max(s.y1, s.y2) > 30);
     expect(top.some((s) => s.color.toLowerCase().includes('111111'))).toBe(true);
     expect(bot.some((s) => s.color.toLowerCase().includes('222222'))).toBe(true);
+  });
+
+  it('resolves each vMerge split segment independently when the spanning edge is nil', async () => {
+    // §17.4.66 applies independently to each segment of a three-row merged
+    // owner whose nil right edge faces nil, omitted, and explicit opposing
+    // edges. The results are open, table insideV, and the explicit edge.
+    const restart = cell('merged', { right: bs({ style: 'nil' }) });
+    restart.vMerge = true;
+    const continuation1 = cell('', { right: bs({ style: 'nil' }) });
+    continuation1.vMerge = false;
+    const continuation2 = cell('', { right: bs({ style: 'nil' }) });
+    continuation2.vMerge = false;
+    const strokes = await render(tableOf(
+      [
+        rowOf([restart, cell('top', { left: bs({ style: 'nil' }) })]),
+        rowOf([continuation1, cell('middle')]),
+        rowOf([
+          continuation2,
+          cell('bottom', { left: bs({ style: 'single', width: 1, color: 'ff0000' }) }),
+        ]),
+      ],
+      { insideV: bs({ style: 'single', width: 1, color: '0000ff' }) },
+    ));
+
+    const shared = verticalAt(strokes, 60);
+    expect(shared.some((s) => Math.min(s.y1, s.y2) < 10)).toBe(false);
+    expect(shared).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        y1: 20,
+        y2: 40,
+        color: expect.stringContaining('0000ff'),
+      }),
+      expect.objectContaining({
+        y1: 40,
+        y2: 60,
+        color: expect.stringContaining('ff0000'),
+      }),
+    ]));
   });
 
   it('uses the final continuation cell border at the bottom of a vertical merge', async () => {

--- a/packages/docx/src/cell-border-conflict.test.ts
+++ b/packages/docx/src/cell-border-conflict.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { resolveBorderConflict } from './cell-border-conflict.js';
-import type { BorderSpec } from './types';
+import { resolveBorderConflict, resolveCellEdges } from './cell-border-conflict.js';
+import type { BorderSpec, CellBorders, TableBorders } from './types';
 
-// ECMA-376 §17.4.66 with Word deviations from [MS-OI29500] 2.1.169 —
-// adjacent table cell border conflict resolution. When cell spacing is zero,
-// two cells that share an interior gridline both contribute a border for that
-// edge; the DISPLAYED border is chosen by these rules (in order):
-//   0. none loses to the opposing border; nil suppresses the shared edge.
+// ECMA-376 §17.4.66 — adjacent table cell border conflict resolution. When
+// cell spacing is zero, two cells that share an interior gridline both
+// contribute a border for that edge; the DISPLAYED border is chosen by these
+// rules (in order):
+//   0. nil and none lose to the opposing border.
 //   1. a CELL border beats a TABLE border.
 //   2. Word weight = width in eighth-points × Word border number; dotted and
 //      dashed have weight 1 regardless of width.
@@ -24,14 +24,17 @@ const cell = (over: Partial<BorderSpec> = {}) => ({ spec: spec(over), source: 'c
 const tbl = (over: Partial<BorderSpec> = {}) => ({ spec: spec(over), source: 'table' as const });
 
 describe('§17.4.66 resolveBorderConflict', () => {
-  it('Word rule 0: none loses to a real border', () => {
+  it('rule 0: none loses to a real border', () => {
     expect(resolveBorderConflict(cell({ style: 'single' }), cell({ style: 'none' }))!.spec.style).toBe('single');
   });
 
-  it('Word rule 0: nil suppresses the shared edge even against a real border', () => {
-    expect(resolveBorderConflict(cell({ style: 'nil' }), cell({ style: 'single' }))).toBeNull();
-    expect(resolveBorderConflict(cell({ style: 'double' }), cell({ style: 'nil' }))).toBeNull();
+  it('rule 0: nil loses to the opposing visible border', () => {
+    expect(resolveBorderConflict(cell({ style: 'nil' }), cell({ style: 'single' }))!.spec.style).toBe('single');
+    expect(resolveBorderConflict(cell({ style: 'double' }), cell({ style: 'nil' }))!.spec.style).toBe('double');
+    expect(resolveBorderConflict(cell({ style: 'nil' }), tbl({ style: 'single' }))!.source).toBe('table');
     expect(resolveBorderConflict(cell({ style: 'nil' }), cell({ style: 'none' }))).toBeNull();
+    expect(resolveBorderConflict(cell({ style: 'nil' }), null)).toBeNull();
+    expect(resolveBorderConflict(cell({ style: 'none' }), cell({ style: 'none' }))).toBeNull();
   });
 
   it('one side null (absent) ⇒ the other wins', () => {
@@ -112,5 +115,51 @@ describe('§17.4.66 resolveBorderConflict', () => {
     const b = cell({ style: 'single', color: '808080' });
     const r = resolveBorderConflict(a, b);
     expect(r).toBe(a); // same reference — `a` is displayed
+  });
+});
+
+describe('cell border cascade before §17.4.66 conflict resolution', () => {
+  const empty = (): CellBorders => ({
+    top: null,
+    right: null,
+    bottom: null,
+    left: null,
+    insideH: null,
+    insideV: null,
+  });
+
+  it('lets none fall through while nil blocks lower-precedence fallback on its own side', () => {
+    const tableInside = spec({ style: 'single', color: '123456' });
+    const table: TableBorders = { ...empty(), insideH: tableInside };
+    const flags = { topRow: false, bottomRow: false, leftCol: false, rightCol: false };
+
+    const withNone = resolveCellEdges(
+      { ...empty(), bottom: spec({ style: 'none' }) },
+      table,
+      flags,
+      false,
+    );
+    expect(withNone.bottom).toMatchObject({ source: 'table', spec: tableInside });
+
+    const withNil = resolveCellEdges(
+      { ...empty(), bottom: spec({ style: 'nil' }) },
+      table,
+      flags,
+      false,
+    );
+    expect(withNil.bottom).toMatchObject({ source: 'cell', spec: { style: 'nil' } });
+  });
+
+  it('keeps a conditional cell inside border as a cell conflict candidate', () => {
+    const conditionalInside = spec({ style: 'single', color: '123456' });
+    const tableInside = spec({ style: 'double', color: '654321' });
+    const edges = resolveCellEdges(
+      { ...empty(), insideV: conditionalInside },
+      { ...empty(), insideV: tableInside },
+      { topRow: false, bottomRow: false, leftCol: false, rightCol: false },
+      false,
+    );
+
+    expect(edges.right).toMatchObject({ source: 'cell', spec: conditionalInside });
   });
 });

--- a/packages/docx/src/cell-border-conflict.ts
+++ b/packages/docx/src/cell-border-conflict.ts
@@ -1,7 +1,7 @@
 import type { BorderSpec, CellBorders, TableBorders } from './types';
 import {
-  wordNilBorderSuppressesSharedEdge,
   WORD_TABLE_BORDER_STYLE_PRECEDENCE,
+  wordAuthoredBorderParticipates,
   wordTableBorderWeight,
 } from './layout/table-compatibility.js';
 
@@ -15,10 +15,9 @@ import {
  * candidates for each shared edge and retains only the returned winner, so a
  * gridline is painted once with the correct spec (no more "last cell wins").
  *
- * Rules (ECMA-376 §17.4.66 plus the registered table-border compatibility
- * rules):
- *   0. `none` loses to the opposing border;
- *      `word-nil-table-border-suppression` suppresses the shared edge.
+ * Rules (ECMA-376 §17.4.66 plus the registered table-border weight
+ * compatibility rule):
+ *   0. `nil` and `none` lose to the opposing border.
  *   1. A CELL border always beats a TABLE(-level or table-style) border.
  *   2. `word-table-border-weight-precedence` supplies the border-number weight;
  *      dotted and dashed have weight 1 regardless of width.
@@ -67,18 +66,32 @@ export function resolveCellEdges(
     outer: boolean,
     tableOuter: BorderSpec | null,
   ): BorderCandidate | null => {
-    if (own) return { spec: own, source: 'cell' };
-    const inherited = outer ? tableOuter : (cell.insideH ?? table.insideH);
-    return inherited ? { spec: inherited, source: 'table' } : null;
+    if (own && wordAuthoredBorderParticipates(own.style)) {
+      return { spec: own, source: 'cell' };
+    }
+    if (!outer && cell.insideH && wordAuthoredBorderParticipates(cell.insideH.style)) {
+      return { spec: cell.insideH, source: 'cell' };
+    }
+    const inherited = outer ? tableOuter : table.insideH;
+    return inherited && wordAuthoredBorderParticipates(inherited.style)
+      ? { spec: inherited, source: 'table' }
+      : null;
   };
   const vertical = (
     own: BorderSpec | null,
     outer: boolean,
     tableOuter: BorderSpec | null,
   ): BorderCandidate | null => {
-    if (own) return { spec: own, source: 'cell' };
-    const inherited = outer ? tableOuter : (cell.insideV ?? table.insideV);
-    return inherited ? { spec: inherited, source: 'table' } : null;
+    if (own && wordAuthoredBorderParticipates(own.style)) {
+      return { spec: own, source: 'cell' };
+    }
+    if (!outer && cell.insideV && wordAuthoredBorderParticipates(cell.insideV.style)) {
+      return { spec: cell.insideV, source: 'cell' };
+    }
+    const inherited = outer ? tableOuter : table.insideV;
+    return inherited && wordAuthoredBorderParticipates(inherited.style)
+      ? { spec: inherited, source: 'table' }
+      : null;
   };
 
   const top = horizontal(cell.top, edges.topRow, table.top);
@@ -142,11 +155,19 @@ export function resolveBorderConflict(
   a: BorderCandidate | null,
   b: BorderCandidate | null,
 ): BorderCandidate | null {
-  // `word-nil-table-border-suppression`: nil suppresses the shared edge, while
-  // none merely contributes no competing border.
-  if (wordNilBorderSuppressesSharedEdge(a?.spec.style, b?.spec.style)) return null;
-  const av = a && a.spec.style !== 'none' ? a : null;
-  const bv = b && b.spec.style !== 'none' ? b : null;
+  // §17.4.66: nil and none are both non-painting candidates and lose to the
+  // opposing border. They remain distinct during the per-cell cascade: none
+  // admits style/table fallback, whereas authored nil blocks fallback on that
+  // side before the two resolved candidates reach this kernel.
+  const visible = (candidate: BorderCandidate | null): BorderCandidate | null => (
+    candidate
+      && candidate.spec.style !== 'nil'
+      && candidate.spec.style !== 'none'
+      ? candidate
+      : null
+  );
+  const av = visible(a);
+  const bv = visible(b);
   if (!av && !bv) return null;
   if (!av) return bv;
   if (!bv) return av;

--- a/packages/docx/src/layout/adjacent-table-layout-input.test.ts
+++ b/packages/docx/src/layout/adjacent-table-layout-input.test.ts
@@ -371,7 +371,7 @@ describe('adjacent-table logical layout input (transient union grid)', () => {
     });
   });
 
-  it('cascades a row-exception none border through to its source table border, and nil suppresses it', () => {
+  it('cascades a row-exception none border through while nil blocks source-table fallback', () => {
     const base = tableInput(0, [80], edges({ right: border(2, '#ff0000') }));
     const withNone: TableLayoutInput = {
       ...base,
@@ -393,8 +393,8 @@ describe('adjacent-table logical layout input (transient union grid)', () => {
     expect(noneCombined.rows[0]?.sourceTableEdges.right).toMatchObject({ color: '#ff0000', widthPt: 2 });
 
     const nilCombined = combineAdjacentTableLayoutInputs('group:nil', [withNil, tableInput(1, [80])]);
-    // nil is an authored suppression: it is retained (not replaced by the
-    // source table border) so downstream border resolution suppresses the edge.
+    // nil is retained instead of being replaced by the source table border;
+    // downstream conflict resolution can still display an opposing visible edge.
     expect(nilCombined.rows[0]?.sourceTableEdges.right).toMatchObject({
       authoredStyle: 'nil', widthPt: 0,
     });

--- a/packages/docx/src/layout/compatibility.test.ts
+++ b/packages/docx/src/layout/compatibility.test.ts
@@ -111,11 +111,11 @@ import {
   WORD_AUTHORED_AUTO_ROW_HEIGHT_FLOOR,
   WORD_EFFECTIVE_FLOATING_TABLE_POSITIONING,
   WORD_FIRST_ROW_TABLE_EXCEPTION_SCOPE,
-  WORD_NIL_TABLE_BORDER_SUPPRESSION,
   WORD_OMITTED_ROW_HEIGHT_RULE_AT_LEAST,
   WORD_OVER_PAGE_CANT_SPLIT_CLIP,
   WORD_POSITIONED_TABLE_ADJACENCY_EXCLUSION,
   WORD_SPACED_CELL_INSIDE_BORDER_CONFLICT,
+  WORD_TABLE_BORDER_LAYER_CASCADE,
   WORD_TABLE_BORDER_WEIGHT_PRECEDENCE,
   WORD_TABLE_BORDER_STYLE_PRECEDENCE,
   WORD_TABLE_CELL_SPACING_SCOPE_SHADOW,
@@ -131,7 +131,6 @@ import {
   wordDropsTrailingStructuralCellMarker,
   wordExactRowFloorPt,
   wordExactRowVerticalClipBounds,
-  wordNilBorderSuppressesSharedEdge,
   wordSpacedCellInsideBorderOverridesTable,
   wordTableBorderWeight,
   wordTableCellSpacingValuePt,
@@ -280,7 +279,7 @@ describe('layout compatibility inventory', () => {
       WORD_TRAILING_EMPTY_MARK_BASELINE_ADMISSION,
       WORD_BOOK_FOLD_GUTTER_RIGHT_EDGE,
       WORD_EXACT_ROW_HEIGHT_BOTTOM_PADDING,
-      WORD_NIL_TABLE_BORDER_SUPPRESSION,
+      WORD_TABLE_BORDER_LAYER_CASCADE,
       WORD_SPACED_CELL_INSIDE_BORDER_CONFLICT,
       WORD_TABLE_INDENT_ALL_ALIGNMENTS,
       WORD_EXACT_ROW_VERTICAL_CLIP_ONLY,
@@ -597,8 +596,6 @@ describe('layout compatibility inventory', () => {
     expect(wordTableBorderWeight('single', 1.5)).toBe(12);
     expect(wordTableBorderWeight('dotted', 99)).toBe(1);
     expect(wordTableBorderWeight('unknown', 2)).toBe(0);
-    expect(wordNilBorderSuppressesSharedEdge('nil', 'single')).toBe(true);
-    expect(wordNilBorderSuppressesSharedEdge('none', 'single')).toBe(false);
     expect(wordTableRowHeightRule('auto', false)).toBe('atLeast');
     expect(wordTableRowHeightRule('auto', true)).toBe('auto');
     expect(wordAuthoredAutoRowHeightUsesFloor('auto', 0)).toBe(true);

--- a/packages/docx/src/layout/table-border-layer.ts
+++ b/packages/docx/src/layout/table-border-layer.ts
@@ -2,14 +2,14 @@ import type { TableBorderInput } from './types.js';
 import { wordAuthoredBorderParticipates } from './table-compatibility.js';
 
 /** Resolve one authored border layer before shared-edge conflict resolution.
- * `none` is an omitted layer while `nil` is an authored suppression. Keeping
- * that distinction here prevents callers that merge tblPrEx/table inputs from
- * accidentally turning an OOXML suppression into a fallback. */
+ * `none` is an omitted layer while `nil` blocks lower-precedence fallback on
+ * this side. Keeping that distinction here prevents callers that merge
+ * tblPrEx/table inputs from replacing an authored nil with a lower layer. */
 export function firstAuthoredTableBorder(
   ...borders: readonly (TableBorderInput | null)[]
 ): TableBorderInput | null {
   for (const border of borders) {
-    // Compatibility-owned distinction: nil suppresses while none falls through.
+    // Compatibility-owned cascade distinction: nil participates while none falls through.
     if (border && wordAuthoredBorderParticipates(border.authoredStyle)) return border;
   }
   return null;

--- a/packages/docx/src/layout/table-compatibility.ts
+++ b/packages/docx/src/layout/table-compatibility.ts
@@ -10,13 +10,13 @@ export const WORD_EXACT_ROW_HEIGHT_BOTTOM_PADDING = defineCompatibilityRule({
   description: 'Word adds the largest bottom cell margin to an exact trHeight instead of treating that margin as part of the authored height.',
 });
 
-export const WORD_NIL_TABLE_BORDER_SUPPRESSION = defineCompatibilityRule({
-  id: 'word-nil-table-border-suppression',
+export const WORD_TABLE_BORDER_LAYER_CASCADE = defineCompatibilityRule({
+  id: 'word-table-border-layer-cascade',
   evidence: {
     kind: 'microsoft-note',
     reference: '[MS-OI29500] §2.1.169',
   },
-  description: 'Word treats a table border value of none as omission while nil remains authored and suppresses the complete shared edge.',
+  description: 'During per-side border acquisition, none falls through to a lower-precedence layer while nil remains authored and blocks fallback only on that side.',
 });
 
 export const WORD_SPACED_CELL_INSIDE_BORDER_CONFLICT = defineCompatibilityRule({
@@ -174,6 +174,7 @@ export function wordExactRowFloorPt(
 export function wordAuthoredBorderParticipates(
   authoredStyle: string | null | undefined,
 ): boolean {
+  // `word-table-border-layer-cascade` owns this pre-conflict distinction.
   return authoredStyle !== null
     && authoredStyle !== undefined
     && authoredStyle !== 'none';
@@ -259,13 +260,6 @@ export function wordTableBorderWeight(
 ): number {
   if (style === 'dotted' || style === 'dashed') return 1;
   return Math.max(0, widthPt) * 8 * (WORD_BORDER_NUMBER[style] ?? 0);
-}
-
-export function wordNilBorderSuppressesSharedEdge(
-  firstStyle: string | null | undefined,
-  secondStyle: string | null | undefined,
-): boolean {
-  return firstStyle === 'nil' || secondStyle === 'nil';
 }
 
 export function wordTableRowHeightRule(

--- a/packages/docx/src/layout/table.test.ts
+++ b/packages/docx/src/layout/table.test.ts
@@ -656,7 +656,7 @@ describe('retained table layout', () => {
     expect(cell.clipBounds).toEqual({ xPt: 10, yPt: 20, widthPt: 100, heightPt: 20 });
   });
 
-  it('retains no shared segment when a Word nil border suppresses its opponent', async () => {
+  it('retains the opposing shared segment when the other candidate is nil', async () => {
     const nil = { widthPt: 1, color: '#000000', authoredStyle: 'nil' };
     const single = { widthPt: 1, color: '#000000', authoredStyle: 'single' };
     const input = tableInput([{
@@ -672,7 +672,12 @@ describe('retained table layout', () => {
 
     const { layout } = layoutTable(input, placement(), services);
 
-    expect(layout.borders.filter((border) => border.edge === 'between')).toEqual([]);
+    expect(layout.borders.filter((border) => border.edge === 'between')).toEqual([
+      expect.objectContaining({
+        color: '#000000',
+        widthPt: 1,
+      }),
+    ]);
   });
 
   it('treats a cell-level inside border as a cell conflict candidate', async () => {

--- a/packages/docx/src/layout/table.ts
+++ b/packages/docx/src/layout/table.ts
@@ -448,6 +448,18 @@ function ownerGrid(
   return { owners, occupancy };
 }
 
+function terminalMergeCell(
+  input: TableLayoutInput,
+  owner: CellOwner,
+): TableCellLayoutInput {
+  if (owner.lastRowIndex === owner.rowIndex) return owner.input;
+  return input.rows[owner.lastRowIndex]?.cells.find((cell) => (
+    cell.columnStart === owner.input.columnStart
+    && cell.columnSpan === owner.input.columnSpan
+    && cell.verticalMerge === 'continue'
+  )) ?? owner.input;
+}
+
 function resolvedBoundaries(input: TableLayoutInput): Readonly<{
   horizontal: readonly (readonly (HorizontalBoundary | null)[])[];
   vertical: readonly (readonly (ResolvedBoundary | null)[])[];
@@ -456,20 +468,23 @@ function resolvedBoundaries(input: TableLayoutInput): Readonly<{
   const rowCount = input.rows.length;
   const columnCount = input.columnWidthsPt.length;
   const { owners, occupancy } = ownerGrid(input);
-  const edgesOf = (ownerIndex: number) => {
+  const edgesOf = (ownerIndex: number, terminal = false) => {
     const owner = owners[ownerIndex];
-    return owner
-      ? physicalCellEdges(
-          owner.input,
-          input.borders,
-          input.rows[owner.rowIndex]?.exceptionBorders ?? null,
-          owner.rowIndex,
-          owner.lastRowIndex,
-          rowCount,
-          columnCount,
-          input.bidiVisual,
-        )
-      : null;
+    if (!owner) return null;
+    const cell = terminal ? terminalMergeCell(input, owner) : owner.input;
+    const exceptionRowIndex = terminal && cell !== owner.input
+      ? owner.lastRowIndex
+      : owner.rowIndex;
+    return physicalCellEdges(
+      cell,
+      input.borders,
+      input.rows[exceptionRowIndex]?.exceptionBorders ?? null,
+      owner.rowIndex,
+      owner.lastRowIndex,
+      rowCount,
+      columnCount,
+      input.bidiVisual,
+    );
   };
 
   const horizontal = Array.from({ length: rowCount + 1 }, (_unused, boundary) => (
@@ -477,7 +492,6 @@ function resolvedBoundaries(input: TableLayoutInput): Readonly<{
       const aboveIndex = boundary > 0 ? occupancy[boundary - 1]?.[column] ?? -1 : -1;
       const belowIndex = boundary < rowCount ? occupancy[boundary]?.[column] ?? -1 : -1;
       if (aboveIndex >= 0 && aboveIndex === belowIndex) return null;
-      const above = edgesOf(aboveIndex);
       const below = edgesOf(belowIndex);
       const edge: HorizontalBoundary['edge'] = boundary === 0
         ? 'top'
@@ -485,7 +499,7 @@ function resolvedBoundaries(input: TableLayoutInput): Readonly<{
       return {
         above: {
           owner: owners[aboveIndex] ?? null,
-          border: above?.bottom ?? null,
+          border: edgesOf(aboveIndex, true)?.bottom ?? null,
         },
         below: {
           owner: owners[belowIndex] ?? null,


### PR DESCRIPTION
## What changed

- treat `nil` and `none` as non-painting candidates during shared-edge conflict resolution, allowing an opposing visible border to win
- preserve the distinct per-side cascade behavior: `none` falls through while authored `nil` suppresses lower-priority borders on its own side
- resolve colSpan and vertical-merge boundaries per physical segment
- use the terminal continuation cell for a vertically merged region bottom border
- remove the conflicting shared-edge suppression compatibility rule while retaining the evidence-backed cascade rule

## Specification and compatibility

ECMA-376 Part 1 section 17.4.66 requires the opposing border to be displayed when one conflicting cell border is `nil` or `none`. Current Word output across horizontal, vertical, spanned, and vertically merged cases matches that rule. This intentionally does not apply the conflicting shared-edge suppression described by MS-OI29500 section 2.1.169.

## Validation

- focused conflict and table-layout suite: 129 tests
- DOCX full suite: 2,893 tests
- layout boundary gate and 88 boundary tests
- compatibility evidence: 17 tests
- public API gate: 23 tests
- TypeScript project build
- git diff --check
- DOCX architecture audit: approved
- independent GPT-5.6 Sol review: approved