### PR TITLE
test(docx): cover universal half-point measures

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -395,7 +395,7 @@ mod private_typography_wire_tests {
             r#"<w:r><w:ruby>
               <w:rubyPr>
                 <w:rubyAlign w:val="distributeSpace"/><w:hps w:val="12"/>
-                <w:hpsBaseText w:val="24"/><w:hpsRaise w:val="10"/><w:lid w:val="ja-JP"/>
+                <w:hpsBaseText w:val="12pt"/><w:hpsRaise w:val="3.6mm"/><w:lid w:val="ja-JP"/>
               </w:rubyPr>
               <w:rt><w:r><w:rPr><w:rFonts w:ascii="Yu Gothic"/><w:sz w:val="12"/>
                 <w:b/><w:i/><w:color w:val="112233"/><w:lang w:val="ja-JP"/></w:rPr><w:t>かん</w:t></w:r></w:rt>
@@ -407,7 +407,10 @@ mod private_typography_wire_tests {
 
         assert_eq!(ruby["align"]["value"], "distributeSpace");
         assert_eq!(ruby["baseFontSizePt"]["value"], 12.0);
-        assert_eq!(ruby["raisePt"]["value"], 5.0);
+        assert!(
+            (ruby["raisePt"]["value"].as_f64().expect("raise value") - 72.0 * 3.6 / 25.4).abs()
+                < 1e-9
+        );
         assert_eq!(ruby["language"]["value"], "ja-jp");
         assert_eq!(ruby["guideRuns"][0]["text"], "かん");
         assert_eq!(ruby["guideRuns"][0]["fontFamily"], "Yu Gothic");
@@ -415,6 +418,76 @@ mod private_typography_wire_tests {
         assert_eq!(ruby["guideRuns"][0]["bold"], true);
         assert_eq!(ruby["guideRuns"][0]["italic"], true);
         assert_eq!(ruby["guideRuns"][0]["color"], "112233");
+    }
+
+    #[test]
+    fn invalid_hps_measure_lexemes_remain_invalid_in_private_ruby_wire() {
+        let styles = StyleMap::parse("");
+        for invalid in ["-0", "-0pt", "1.5", "1e2", "+12pt"] {
+            let paragraph = parse_p(
+                &format!(
+                    r#"<w:r><w:ruby>
+                      <w:rubyPr>
+                        <w:hps w:val="{invalid}"/>
+                        <w:hpsBaseText w:val="{invalid}"/>
+                        <w:hpsRaise w:val="{invalid}"/>
+                      </w:rubyPr>
+                      <w:rt><w:r><w:t>かん</w:t></w:r></w:rt>
+                      <w:rubyBase><w:r><w:t>漢</w:t></w:r></w:rubyBase>
+                    </w:ruby></w:r>"#
+                ),
+                &styles,
+            );
+            let run = first_run_json(&paragraph, "text");
+            let ruby = &run["__typographyAcquisition"]["ruby"];
+            for metric in ["baseFontSizePt", "raisePt"] {
+                assert_eq!(
+                    ruby[metric]["status"], "invalid",
+                    "{invalid:?} must remain invalid for {metric}"
+                );
+                assert!(ruby[metric]["value"].is_null());
+            }
+            assert_eq!(
+                run["ruby"]["fontSizePt"], 5.0,
+                "{invalid:?} hps must use the established half-font-size fallback"
+            );
+            assert!(
+                run["ruby"].get("hpsRaisePt").is_none(),
+                "{invalid:?} hpsRaise must remain absent from the public projection"
+            );
+        }
+    }
+
+    #[test]
+    fn position_public_fallback_and_private_status_survive_serialization() {
+        let styles = StyleMap::parse("");
+        let invalid = parse_p(
+            r#"<w:r><w:rPr><w:position w:val="1e2"/></w:rPr><w:t>x</w:t></w:r>"#,
+            &styles,
+        );
+        let invalid = first_run_json(&invalid, "text");
+        assert_eq!(invalid["position"], 0.0);
+        assert_eq!(
+            invalid["__typographyAcquisition"]["positionPt"]["status"],
+            "invalid"
+        );
+        assert!(invalid["__typographyAcquisition"]["positionPt"]["value"].is_null());
+
+        let valid = parse_p(
+            r#"<w:r><w:rPr><w:position w:val="-3.6mm"/></w:rPr><w:t>x</w:t></w:r>"#,
+            &styles,
+        );
+        let valid = first_run_json(&valid, "text");
+        let expected = -72.0 * 3.6 / 25.4;
+        assert!((valid["position"].as_f64().expect("public position") - expected).abs() < 1e-9);
+        assert!(
+            (valid["__typographyAcquisition"]["positionPt"]["value"]
+                .as_f64()
+                .expect("private position")
+                - expected)
+                .abs()
+                < 1e-9
+        );
     }
 
     #[test]
@@ -4524,11 +4597,7 @@ fn ruby_typography_wire(
     });
     let half_points = |name: &str| {
         let raw = element_value(name);
-        let value = raw
-            .as_deref()
-            .and_then(|value| value.parse::<f64>().ok())
-            .filter(|value| value.is_finite() && *value >= 0.0)
-            .map(|value| value / 2.0);
+        let value = raw.as_deref().and_then(half_pt_to_pt);
         parsed_typography_value(raw, value)
     };
     let language_raw = element_value("lid");
@@ -5386,14 +5455,12 @@ fn parse_run_inner(
                 let rt_size_pt: f64 = child_w(child, "rubyPr")
                     .and_then(|rp| child_w(rp, "hps"))
                     .and_then(|hps| attr_w(hps, "val"))
-                    .and_then(|v| v.parse::<f64>().ok())
-                    .map(|hp| hp / 2.0) // half-points → points
+                    .and_then(|value| half_pt_to_pt(&value))
                     .unwrap_or_else(|| fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE) / 2.0);
                 let hps_raise_pt = child_w(child, "rubyPr")
                     .and_then(|rp| child_w(rp, "hpsRaise"))
                     .and_then(|hps_raise| attr_w(hps_raise, "val"))
-                    .and_then(|v| v.parse::<f64>().ok())
-                    .map(|hp| hp / 2.0); // half-points → points (§17.3.3.12)
+                    .and_then(|value| half_pt_to_pt(&value));
                 let ruby_typography = ruby_typography_wire(child, &fmt, style_map, theme);
                 let ruby = if !rt_text.is_empty() {
                     Some(RubyAnnotation {
@@ -8474,14 +8541,12 @@ fn extract_simple_paragraph_text(
                     let font_size_pt = child_w(ruby_node, "rubyPr")
                         .and_then(|rp| child_w(rp, "hps"))
                         .and_then(|hps| attr_w(hps, "val"))
-                        .and_then(|v| v.parse::<f64>().ok())
-                        .map(|hp| hp / 2.0)
+                        .and_then(|value| half_pt_to_pt(&value))
                         .unwrap_or_else(|| fmt.font_size.unwrap_or(DEFAULT_FONT_SIZE) / 2.0);
                     let hps_raise_pt = child_w(ruby_node, "rubyPr")
                         .and_then(|rp| child_w(rp, "hpsRaise"))
                         .and_then(|hps_raise| attr_w(hps_raise, "val"))
-                        .and_then(|v| v.parse::<f64>().ok())
-                        .map(|hp| hp / 2.0);
+                        .and_then(|value| half_pt_to_pt(&value));
                     Some(RubyAnnotation {
                         text: rt_text,
                         font_size_pt,
@@ -12521,6 +12586,54 @@ mod tests {
             serde_json::to_value(annotation).unwrap()["hpsRaisePt"],
             serde_json::json!(0.0),
         );
+
+        let universal = r#"<w:r><w:ruby>
+          <w:rubyPr><w:hps w:val="12pt"/><w:hpsRaise w:val="3.6mm"/></w:rubyPr>
+          <w:rt><w:r><w:t>かん</w:t></w:r></w:rt>
+          <w:rubyBase><w:r><w:t>漢</w:t></w:r></w:rubyBase>
+        </w:ruby></w:r>"#;
+        let universal_runs = parse_para(universal, &base, &styles);
+        let annotation = first_text(&universal_runs)
+            .ruby
+            .as_ref()
+            .expect("ruby annotation");
+        assert_eq!(annotation.font_size_pt, 12.0);
+        assert!(
+            (annotation.hps_raise_pt.expect("universal hpsRaise") - 72.0 * 3.6 / 25.4).abs() < 1e-9
+        );
+
+        for invalid in ["-0", "-0pt", "1.5", "1e2", "+12pt"] {
+            let invalid_runs = parse_para(
+                &ruby(&format!(r#"<w:hpsRaise w:val="{invalid}"/>"#)),
+                &base,
+                &styles,
+            );
+            let annotation = first_text(&invalid_runs)
+                .ruby
+                .as_ref()
+                .expect("ruby annotation");
+            assert_eq!(
+                annotation.hps_raise_pt, None,
+                "{invalid:?} must not become a body ruby raise"
+            );
+
+            let invalid_hps = format!(
+                r#"<w:r><w:ruby>
+                  <w:rubyPr><w:hps w:val="{invalid}"/></w:rubyPr>
+                  <w:rt><w:r><w:t>かん</w:t></w:r></w:rt>
+                  <w:rubyBase><w:r><w:t>漢</w:t></w:r></w:rubyBase>
+                </w:ruby></w:r>"#
+            );
+            let invalid_runs = parse_para(&invalid_hps, &base, &styles);
+            let annotation = first_text(&invalid_runs)
+                .ruby
+                .as_ref()
+                .expect("ruby annotation");
+            assert_eq!(
+                annotation.font_size_pt, 5.0,
+                "{invalid:?} must use the body ruby size fallback"
+            );
+        }
     }
 
     // §17.16.5.69 — Word generates each TOC entry as a navigation hyperlink
@@ -25011,6 +25124,45 @@ mod ruby_tab_tests {
                 .is_none(),
             "absent w:hpsRaise must remain distinguishable from zero",
         );
+
+        let universal = parse_shape_para(
+            r#"<w:r><w:ruby>
+              <w:rubyPr><w:hps w:val="12pt"/><w:hpsRaise w:val="3.6mm"/></w:rubyPr>
+              <w:rt><w:r><w:t>かん</w:t></w:r></w:rt>
+              <w:rubyBase><w:r><w:t>漢</w:t></w:r></w:rubyBase>
+            </w:ruby></w:r>"#,
+        )
+        .expect("text-box paragraph yields a ShapeText block");
+        let annotation = universal.runs[0].ruby.as_ref().expect("ruby annotation");
+        assert_eq!(annotation.font_size_pt, 12.0);
+        assert!(
+            (annotation.hps_raise_pt.expect("universal hpsRaise") - 72.0 * 3.6 / 25.4).abs() < 1e-9
+        );
+
+        for invalid in ["-0", "-0pt", "1.5", "1e2", "+12pt"] {
+            let invalid_shape = parse_shape_para(&format!(
+                r#"<w:r><w:ruby>
+                  <w:rubyPr>
+                    <w:hps w:val="{invalid}"/><w:hpsRaise w:val="{invalid}"/>
+                  </w:rubyPr>
+                  <w:rt><w:r><w:t>かん</w:t></w:r></w:rt>
+                  <w:rubyBase><w:r><w:t>漢</w:t></w:r></w:rubyBase>
+                </w:ruby></w:r>"#
+            ))
+            .expect("text-box paragraph yields a ShapeText block");
+            let annotation = invalid_shape.runs[0]
+                .ruby
+                .as_ref()
+                .expect("ruby annotation");
+            assert_eq!(
+                annotation.font_size_pt, 5.0,
+                "{invalid:?} must use the text-box ruby size fallback"
+            );
+            assert_eq!(
+                annotation.hps_raise_pt, None,
+                "{invalid:?} must not become a text-box ruby raise"
+            );
+        }
     }
 
     /// ECMA-376 §17.3.3.25 (`w:ruby`) + §17.3.3.32 (`w:tab`) — a `<w:tab/>` inside

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -1900,28 +1900,25 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
     // carries only szCs (common Word editing residue) must inherit its sz from
     // the style/docDefaults chain, not adopt the complex-script metric —
     // otherwise body text with a leftover szCs renders a size too large.
-    if let Some(sz) = child_w(rpr, "sz") {
-        if let Some(v) = attr_w(sz, "val") {
-            fmt.font_size = Some(half_pt_to_pt(&v));
-        }
-    }
+    fmt.font_size = child_w(rpr, "sz")
+        .and_then(|sz| attr_w(sz, "val"))
+        .and_then(|value| half_pt_to_pt(&value));
 
     // Complex-script font size (ECMA-376 §17.3.2.39 w:szCs, half-points).
     // Recorded independently of the sz/szCs fallback above so RTL runs can use
     // the complex-script metric without disturbing the existing Latin/CJK size.
-    if let Some(sz_cs) = child_w(rpr, "szCs") {
-        if let Some(v) = attr_w(sz_cs, "val") {
-            fmt.font_size_cs = Some(half_pt_to_pt(&v));
-        }
-    }
+    fmt.font_size_cs = child_w(rpr, "szCs")
+        .and_then(|sz_cs| attr_w(sz_cs, "val"))
+        .and_then(|value| half_pt_to_pt(&value));
 
     // Record which of w:sz / w:szCs were set AT THIS LEVEL so the style-chain
     // merge can mirror a directly-applied Latin size into the complex-script
-    // size when no szCs accompanies it (Word's behaviour — §17.3.2.18). Use the
-    // literal child presence (not the sz/szCs fallback above, which conflates
-    // them).
-    fmt.font_size_set_here = child_w(rpr, "sz").is_some();
-    fmt.font_size_cs_set_here = child_w(rpr, "szCs").is_some();
+    // size when no szCs accompanies it (Word's behaviour — §17.3.2.18). Only a
+    // successfully normalized finite, non-negative value is an authored
+    // formatting fact; malformed children remain absent so they cannot
+    // manufacture a 0pt override of inheritance.
+    fmt.font_size_set_here = fmt.font_size.is_some();
+    fmt.font_size_cs_set_here = fmt.font_size_cs.is_some();
 
     // Complex-script bold / italic toggles (ECMA-376 §17.3.2.3 / §17.3.2.17).
     fmt.bold_cs = bool_prop(rpr, "bCs");
@@ -2130,13 +2127,10 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
     // it as a baseline y-offset without changing the font size or line box.
     if let Some(pos) = child_w(rpr, "position") {
         let raw = attr_w(pos, "val");
-        let value = raw
-            .as_deref()
-            .and_then(|value| value.parse::<f64>().ok())
-            .map(|value| value / 2.0);
+        let value = raw.as_deref().and_then(signed_half_pt_to_pt);
         // Keep the stable public projection byte-for-byte compatible while the
         // private value carries invalid status for the replacement layout path.
-        fmt.position = raw.as_deref().map(half_pt_to_pt);
+        fmt.position = raw.as_ref().map(|_| value.unwrap_or(0.0));
         fmt.position_typography = Some(typography_value(raw, value));
     }
 
@@ -2146,7 +2140,7 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
     // hierarchy default is OFF. `w:val="0"` = kern at all sizes. Stored in points.
     if let Some(kern) = child_w(rpr, "kern") {
         if let Some(v) = attr_w(kern, "val") {
-            fmt.kerning = Some(half_pt_to_pt(&v));
+            fmt.kerning = half_pt_to_pt(&v);
         }
     }
 
@@ -2831,6 +2825,96 @@ mod tests {
     }
 
     #[test]
+    fn sz_and_szcs_accept_positive_universal_measures() {
+        // ECMA-376 §17.18.42: ST_HpsMeasure is the union of an unsigned
+        // half-point count and ST_PositiveUniversalMeasure. Unit-bearing values
+        // are absolute, so they must not be divided by two.
+        let fmt = run_fmt_from(r#"<w:sz w:val="3.6mm"/><w:szCs w:val="12pt"/>"#);
+        assert!((fmt.font_size.expect("w:sz parses") - 72.0 * 3.6 / 25.4).abs() < 1e-9);
+        assert_eq!(fmt.font_size_cs, Some(12.0));
+    }
+
+    #[test]
+    fn universal_measure_font_sizes_survive_docdefaults_and_basedon_cascades() {
+        // §17.7.2 applies docDefaults below the paragraph style chain. Exercise
+        // the lexical union through both inheritance sources rather than only
+        // testing the conversion helper.
+        let defaults = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:docDefaults><w:rPrDefault><w:rPr>
+                <w:sz w:val="3.6mm"/><w:szCs w:val="12pt"/>
+              </w:rPr></w:rPrDefault></w:docDefaults>
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal"/>
+            </w:styles>"#,
+            ns = W_NS,
+        );
+        let (_, inherited_defaults) = StyleMap::parse(&defaults).resolve_para(None, None);
+        assert!(
+            (inherited_defaults.font_size.expect("docDefaults w:sz") - 72.0 * 3.6 / 25.4).abs()
+                < 1e-9
+        );
+        assert_eq!(inherited_defaults.font_size_cs, Some(12.0));
+
+        let styles = format!(
+            r#"<w:styles xmlns:w="{ns}">
+              <w:docDefaults><w:rPrDefault><w:rPr>
+                <w:sz w:val="18"/><w:szCs w:val="20"/>
+              </w:rPr></w:rPrDefault></w:docDefaults>
+              <w:style w:type="paragraph" w:default="1" w:styleId="Normal"/>
+              <w:style w:type="paragraph" w:styleId="Base">
+                <w:basedOn w:val="Normal"/>
+                <w:rPr><w:sz w:val="3.6mm"/><w:szCs w:val="12pt"/></w:rPr>
+              </w:style>
+              <w:style w:type="paragraph" w:styleId="Derived">
+                <w:basedOn w:val="Base"/>
+              </w:style>
+            </w:styles>"#,
+            ns = W_NS,
+        );
+        let (_, inherited_style) = StyleMap::parse(&styles).resolve_para(Some("Derived"), None);
+        assert!(
+            (inherited_style.font_size.expect("basedOn w:sz") - 72.0 * 3.6 / 25.4).abs() < 1e-9
+        );
+        assert_eq!(inherited_style.font_size_cs, Some(12.0));
+
+        // A malformed value is not a valid formatting value and must not become
+        // an authored 0pt override that blocks the inherited style.
+        for invalid in [
+            "invalid", "-0", "-0pt", "-2", "-2pt", "1.5", "1e2", "+12", "+12pt",
+        ] {
+            let mut inherited = inherited_style.clone();
+            let direct = run_fmt_from(&format!(
+                r#"<w:sz w:val="{invalid}"/><w:szCs w:val="{invalid}"/>"#
+            ));
+            apply_run(&mut inherited, &direct);
+            assert!(
+                (inherited
+                    .font_size
+                    .expect("style survives invalid direct w:sz")
+                    - 72.0 * 3.6 / 25.4)
+                    .abs()
+                    < 1e-9,
+                "{invalid:?} must not block w:sz inheritance"
+            );
+            assert_eq!(
+                inherited.font_size_cs,
+                Some(12.0),
+                "{invalid:?} must not block w:szCs inheritance"
+            );
+        }
+
+        for valid_zero in ["0", "0pt"] {
+            let mut inherited = inherited_style.clone();
+            let direct = run_fmt_from(&format!(
+                r#"<w:sz w:val="{valid_zero}"/><w:szCs w:val="{valid_zero}"/>"#
+            ));
+            apply_run(&mut inherited, &direct);
+            assert_eq!(inherited.font_size, Some(0.0));
+            assert_eq!(inherited.font_size_cs, Some(0.0));
+        }
+    }
+
+    #[test]
     fn szcs_alone_does_not_set_latin_cjk_font_size() {
         // §17.3.2.39: w:szCs is the complex-script size only. A non-complex run
         // carrying ONLY szCs (Word editing residue) must leave font_size None so
@@ -3252,6 +3336,38 @@ mod tests {
         // Negative = lowered (sample-11 uses -10 half-pt = -5 pt).
         let f = run_fmt_from(r#"<w:position w:val="-10"/>"#);
         assert_eq!(f.position, Some(-5.0));
+        let f = run_fmt_from(r#"<w:position w:val="12pt"/>"#);
+        assert_eq!(f.position, Some(12.0));
+        assert_eq!(
+            f.position_typography.and_then(|value| value.value),
+            Some(12.0),
+            "the private layout input uses the same universal-measure conversion"
+        );
+        let f = run_fmt_from(r#"<w:position w:val="-3.6mm"/>"#);
+        let expected = -72.0 * 3.6 / 25.4;
+        assert!((f.position.expect("signed universal projection") - expected).abs() < 1e-9);
+        assert!(
+            (f.position_typography
+                .and_then(|value| value.value)
+                .expect("signed universal private value")
+                - expected)
+                .abs()
+                < 1e-9
+        );
+        for invalid in ["invalid", "1.5", "1e2", "+12pt"] {
+            let f = run_fmt_from(&format!(r#"<w:position w:val="{invalid}"/>"#));
+            assert_eq!(
+                f.position,
+                Some(0.0),
+                "the stable public projection keeps its legacy invalid-value fallback"
+            );
+            let private = f.position_typography.expect("authored position fact");
+            assert_eq!(
+                private.status,
+                crate::types::TypographyValueStatusWire::Invalid
+            );
+            assert_eq!(private.value, None);
+        }
         let f = run_fmt_from(r#"<w:b/>"#);
         assert_eq!(f.position, None);
     }
@@ -3266,6 +3382,27 @@ mod tests {
         // not absence, so it must be Some(0.0) to keep kerning enabled.
         let f = run_fmt_from(r#"<w:kern w:val="0"/>"#);
         assert_eq!(f.kerning, Some(0.0));
+        let f = run_fmt_from(r#"<w:kern w:val="12pt"/>"#);
+        assert_eq!(f.kerning, Some(12.0));
+        let f = run_fmt_from(r#"<w:kern w:val="0pt"/>"#);
+        assert_eq!(f.kerning, Some(0.0));
+        for invalid in [
+            "invalid", "-0", "-0pt", "-2", "-2pt", "1.5", "1e2", "+12", "+12pt",
+        ] {
+            let f = run_fmt_from(&format!(r#"<w:kern w:val="{invalid}"/>"#));
+            assert_eq!(
+                f.kerning, None,
+                "{invalid:?} must not become an authored kerning threshold"
+            );
+
+            let mut inherited = run_fmt_from(r#"<w:kern w:val="24"/>"#);
+            apply_run(&mut inherited, &f);
+            assert_eq!(
+                inherited.kerning,
+                Some(12.0),
+                "{invalid:?} must not block an inherited kerning threshold"
+            );
+        }
         // Absent ⇒ None (inherit; the hierarchy default is kerning OFF).
         let f = run_fmt_from(r#"<w:b/>"#);
         assert_eq!(f.kerning, None);

--- a/packages/docx/parser/src/xml_util.rs
+++ b/packages/docx/parser/src/xml_util.rs
@@ -76,8 +76,8 @@ pub fn attr_w14(node: Node, name: &str) -> Option<String> {
 /// Suffixed values use the fixed physical-unit conversions from
 /// `ST_UniversalMeasure` (`pt`, `in`, `pc`/`pi`, `mm`, `cm`). The meaning of a
 /// bare number is context-dependent, so callers supply how many of that unit
-/// make one point: VML shape lengths use `1.0`, `ST_TwipsMeasure` uses `20.0`,
-/// and `ST_HpsMeasure` uses `2.0`.
+/// make one point: VML shape lengths use `1.0`, while `ST_TwipsMeasure` uses
+/// `20.0`. HPS measures use their stricter dedicated parsers below.
 pub(crate) fn parse_measure_to_pt(value: &str, unitless_per_pt: f64) -> Option<f64> {
     let value = value.trim();
     let (number, scale) = if let Some(number) = value.strip_suffix("pt") {
@@ -118,10 +118,85 @@ pub fn twips_to_pt(s: &str) -> f64 {
     parse_measure_to_pt(s, 20.0).unwrap_or(0.0)
 }
 
-/// Parse `ST_HpsMeasure` (§17.18.42) to points. A bare number is half-points; a
-/// `ST_PositiveUniversalMeasure` suffix is an absolute size.
-pub fn half_pt_to_pt(s: &str) -> f64 {
-    parse_measure_to_pt(s, 2.0).unwrap_or(0.0)
+/// Parse `ST_HpsMeasure` (§17.18.42) to points.
+///
+/// Its lexical union is deliberately narrower than an `f64`: a bare value is
+/// `ST_UnsignedDecimalNumber` (digits only, in half-points), while a suffixed
+/// value is `ST_PositiveUniversalMeasure` (an unsigned decimal plus a supported
+/// absolute unit). Rejecting signs, fractional/exponent bare numbers, and
+/// negative universal measures keeps malformed direct formatting from blocking
+/// a valid inherited value.
+pub fn half_pt_to_pt(s: &str) -> Option<f64> {
+    let value = s.trim();
+    if !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return value.parse::<u64>().ok().map(|number| number as f64 / 2.0);
+    }
+    universal_measure_to_pt(value, false)
+}
+
+/// Parse `ST_SignedHpsMeasure` (§17.18.81) to points.
+///
+/// The bare member is the XSD `integer` lexical form (optional `+`/`-`, then
+/// digits) in half-points. The unit-bearing member is `ST_UniversalMeasure`,
+/// whose schema pattern allows an optional minus sign, but not a plus sign.
+pub fn signed_half_pt_to_pt(s: &str) -> Option<f64> {
+    let value = s.trim();
+    if is_xsd_integer_lexeme(value) {
+        return parse_finite(value).map(|number| number / 2.0);
+    }
+    universal_measure_to_pt(value, true)
+}
+
+fn is_xsd_integer_lexeme(value: &str) -> bool {
+    let digits = value
+        .strip_prefix('+')
+        .or_else(|| value.strip_prefix('-'))
+        .unwrap_or(value);
+    !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn universal_measure_to_pt(value: &str, signed: bool) -> Option<f64> {
+    let (number, scale) = if let Some(number) = value.strip_suffix("pt") {
+        (number, 1.0)
+    } else if let Some(number) = value.strip_suffix("in") {
+        (number, 72.0)
+    } else if let Some(number) = value
+        .strip_suffix("pc")
+        .or_else(|| value.strip_suffix("pi"))
+    {
+        (number, 12.0)
+    } else if let Some(number) = value.strip_suffix("mm") {
+        (number, 72.0 / 25.4)
+    } else {
+        (value.strip_suffix("cm")?, 72.0 / 2.54)
+    };
+
+    let unsigned_number = if signed {
+        number.strip_prefix('-').unwrap_or(number)
+    } else {
+        number
+    };
+    if unsigned_number.is_empty()
+        || unsigned_number.starts_with('+')
+        || (!signed && number.starts_with('-'))
+    {
+        return None;
+    }
+
+    let mut parts = unsigned_number.split('.');
+    let integer = parts.next().unwrap_or_default();
+    let fraction = parts.next();
+    if integer.is_empty()
+        || !integer.bytes().all(|byte| byte.is_ascii_digit())
+        || fraction.is_some_and(|digits| {
+            digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit())
+        })
+        || parts.next().is_some()
+    {
+        return None;
+    }
+
+    parse_finite(number).map(|number| number * scale)
 }
 
 /// Parse a ST_OnOff-style toggle child element. ECMA-376 §17.3.2.22 allows
@@ -150,19 +225,55 @@ pub fn on_off_attr(node: Node, name: &str) -> Option<bool> {
 
 #[cfg(test)]
 mod measure_tests {
-    use super::{half_pt_to_pt, twips_to_pt};
+    use super::{half_pt_to_pt, signed_half_pt_to_pt, twips_to_pt};
 
     #[test]
     fn half_pt_to_pt_accepts_positive_universal_measures() {
         // ST_HpsMeasure (§17.18.42) = ST_UnsignedDecimalNumber |
         // ST_PositiveUniversalMeasure.
-        assert_eq!(half_pt_to_pt("20"), 10.0, "20 half-points = 10pt");
-        assert_eq!(half_pt_to_pt("12pt"), 12.0, "12pt is absolute, not 6pt");
-        assert_eq!(half_pt_to_pt("1in"), 72.0);
-        assert_eq!(half_pt_to_pt("1pc"), 12.0);
-        assert_eq!(half_pt_to_pt("1pi"), 12.0);
-        assert!((half_pt_to_pt("3.6mm") - 72.0 * 3.6 / 25.4).abs() < 1e-9);
-        assert!((half_pt_to_pt("2.54cm") - 72.0).abs() < 1e-9);
+        assert_eq!(half_pt_to_pt("20"), Some(10.0), "20 half-points = 10pt");
+        assert_eq!(
+            half_pt_to_pt("12pt"),
+            Some(12.0),
+            "12pt is absolute, not 6pt"
+        );
+        assert_eq!(half_pt_to_pt("1in"), Some(72.0));
+        assert_eq!(half_pt_to_pt("1pc"), Some(12.0));
+        assert_eq!(half_pt_to_pt("1pi"), Some(12.0));
+        assert_eq!(half_pt_to_pt("0"), Some(0.0));
+        assert_eq!(half_pt_to_pt("0pt"), Some(0.0));
+        assert!((half_pt_to_pt("3.6mm").unwrap() - 72.0 * 3.6 / 25.4).abs() < 1e-9);
+        assert!((half_pt_to_pt("2.54cm").unwrap() - 72.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn half_pt_to_pt_rejects_values_outside_st_hps_measure_lexical_space() {
+        for invalid in ["-0", "-0pt", "-10", "-10pt", "1.5", "1e2", "+10", "+10pt"] {
+            assert_eq!(
+                half_pt_to_pt(invalid),
+                None,
+                "{invalid:?} is neither ST_UnsignedDecimalNumber nor ST_PositiveUniversalMeasure"
+            );
+        }
+    }
+
+    #[test]
+    fn signed_half_pt_to_pt_matches_st_signed_hps_measure_lexical_space() {
+        assert_eq!(signed_half_pt_to_pt("10"), Some(5.0));
+        assert_eq!(signed_half_pt_to_pt("-10"), Some(-5.0));
+        assert_eq!(signed_half_pt_to_pt("+10"), Some(5.0));
+        assert_eq!(signed_half_pt_to_pt("-0"), Some(-0.0));
+        assert_eq!(signed_half_pt_to_pt("-0pt"), Some(-0.0));
+        assert_eq!(signed_half_pt_to_pt("-12pt"), Some(-12.0));
+        assert!((signed_half_pt_to_pt("-3.6mm").unwrap() + 72.0 * 3.6 / 25.4).abs() < 1e-9);
+
+        for invalid in ["1.5", "1e2", "+12pt", "12PT"] {
+            assert_eq!(
+                signed_half_pt_to_pt(invalid),
+                None,
+                "{invalid:?} is outside ST_SignedHpsMeasure's lexical union"
+            );
+        }
     }
 
     #[test]
@@ -175,9 +286,9 @@ mod measure_tests {
 
     #[test]
     fn measure_parsers_reject_unparseable_and_non_finite_values() {
-        assert_eq!(half_pt_to_pt(""), 0.0);
-        assert_eq!(half_pt_to_pt("auto"), 0.0);
-        assert_eq!(half_pt_to_pt("inf"), 0.0);
+        assert_eq!(half_pt_to_pt(""), None);
+        assert_eq!(half_pt_to_pt("auto"), None);
+        assert_eq!(half_pt_to_pt("inf"), None);
         assert_eq!(twips_to_pt("NaN"), 0.0);
     }
 }

--- a/packages/docx/src/conformance/layout.test.ts
+++ b/packages/docx/src/conformance/layout.test.ts
@@ -219,6 +219,37 @@ function encodedXml(value: string): Uint8Array {
   return new TextEncoder().encode(value);
 }
 
+function fontSizeMeasureDocx(
+  body: string,
+  styles: string,
+): Uint8Array {
+  const seed = CONFORMANCE_CASES[0];
+  if (!seed) throw new Error('conformance corpus is empty');
+  const parts = new Map(generateConformanceParts(seed));
+  parts.set(
+    'word/document.xml',
+    encodedXml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          ${body}
+          <w:sectPr>
+            <w:pgSz w:w="12240" w:h="15840"/>
+            <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"
+              w:header="720" w:footer="720" w:gutter="0"/>
+          </w:sectPr>
+        </w:body>
+      </w:document>`),
+  );
+  parts.set(
+    'word/styles.xml',
+    encodedXml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        ${styles}
+      </w:styles>`),
+  );
+  return storeZip(parts);
+}
+
 function inlineDrawingCase() {
   const testCase = CONFORMANCE_CASES.find(({ axes }) =>
     axes.story === 'body'
@@ -331,6 +362,186 @@ describe('synthetic DOCX conformance matrix', () => {
     for (const bytes of first) {
       expect([...bytes.subarray(0, 4)]).toEqual([0x50, 0x4b, 0x03, 0x04]);
     }
+  });
+});
+
+describe('ST_HpsMeasure font sizes through the WASM parser', () => {
+  const expectedMmSizePt = 72 * 3.6 / 25.4;
+
+  it('preserves unit-bearing w:sz and w:szCs inherited from docDefaults', () => {
+    const model = parse(fontSizeMeasureDocx(
+      '<w:p><w:r><w:t>DOC_DEFAULT_UNITS</w:t></w:r></w:p>',
+      `<w:docDefaults><w:rPrDefault><w:rPr>
+        <w:sz w:val="3.6mm"/><w:szCs w:val="12pt"/>
+      </w:rPr></w:rPrDefault></w:docDefaults>
+      <w:style w:type="paragraph" w:default="1" w:styleId="Normal"/>`,
+    ));
+    const run = textRunOf(
+      targetParagraph(model, 'body', 'DOC_DEFAULT_UNITS'),
+      'DOC_DEFAULT_UNITS',
+    );
+
+    expect(run.fontSize).toBeCloseTo(expectedMmSizePt, 10);
+    expect(run.fontSizeCs).toBe(12);
+  });
+
+  it('preserves unit-bearing sizes through basedOn and ignores invalid direct values', () => {
+    const model = parse(fontSizeMeasureDocx(
+      `<w:p>
+        <w:pPr><w:pStyle w:val="Derived"/></w:pPr>
+        <w:r>
+          <w:rPr><w:sz w:val="invalid"/><w:szCs w:val="invalid"/></w:rPr>
+          <w:t>STYLE_CHAIN_UNITS</w:t>
+        </w:r>
+      </w:p>`,
+      `<w:docDefaults><w:rPrDefault><w:rPr>
+        <w:sz w:val="18"/><w:szCs w:val="20"/>
+      </w:rPr></w:rPrDefault></w:docDefaults>
+      <w:style w:type="paragraph" w:default="1" w:styleId="Normal"/>
+      <w:style w:type="paragraph" w:styleId="Base">
+        <w:basedOn w:val="Normal"/>
+        <w:rPr><w:sz w:val="3.6mm"/><w:szCs w:val="12pt"/></w:rPr>
+      </w:style>
+      <w:style w:type="paragraph" w:styleId="Derived">
+        <w:basedOn w:val="Base"/>
+      </w:style>`,
+    ));
+    const run = textRunOf(
+      targetParagraph(model, 'body', 'STYLE_CHAIN_UNITS'),
+      'STYLE_CHAIN_UNITS',
+    );
+
+    expect(run.fontSize).toBeCloseTo(expectedMmSizePt, 10);
+    expect(run.fontSizeCs).toBe(12);
+  });
+
+  it('rejects non-schema HPS lexemes without blocking inherited sizes or enabling kerning', () => {
+    const invalidValues = [
+      '-0', '-0pt', '-2', '-2pt', '1.5', '1e2', '+12', '+12pt',
+    ];
+    const body = invalidValues.map((value, index) => `<w:p>
+      <w:pPr><w:pStyle w:val="Derived"/></w:pPr>
+      <w:r>
+        <w:rPr>
+          <w:sz w:val="${value}"/><w:szCs w:val="${value}"/>
+          <w:kern w:val="${value}"/>
+        </w:rPr>
+        <w:t>INVALID_HPS_${index}</w:t>
+      </w:r>
+    </w:p>`).join('');
+    const model = parse(fontSizeMeasureDocx(
+      body,
+      `<w:docDefaults><w:rPrDefault><w:rPr>
+        <w:sz w:val="18"/><w:szCs w:val="20"/>
+      </w:rPr></w:rPrDefault></w:docDefaults>
+      <w:style w:type="paragraph" w:default="1" w:styleId="Normal"/>
+      <w:style w:type="paragraph" w:styleId="Base">
+        <w:basedOn w:val="Normal"/>
+        <w:rPr><w:sz w:val="3.6mm"/><w:szCs w:val="12pt"/></w:rPr>
+      </w:style>
+      <w:style w:type="paragraph" w:styleId="Derived">
+        <w:basedOn w:val="Base"/>
+      </w:style>`,
+    ));
+
+    invalidValues.forEach((value, index) => {
+      const target = `INVALID_HPS_${index}`;
+      const run = textRunOf(targetParagraph(model, 'body', target), target);
+      expect(run.fontSize, value).toBeCloseTo(expectedMmSizePt, 10);
+      expect(run.fontSizeCs, value).toBe(12);
+      expect(run.kerning, value).toBeUndefined();
+    });
+  });
+
+  it('keeps authored zero sizes and kerning thresholds', () => {
+    const model = parse(fontSizeMeasureDocx(
+      `<w:p><w:r><w:rPr>
+        <w:sz w:val="0pt"/><w:szCs w:val="0"/><w:kern w:val="0pt"/>
+      </w:rPr><w:t>VALID_ZERO_HPS</w:t></w:r></w:p>`,
+      '<w:style w:type="paragraph" w:default="1" w:styleId="Normal"/>',
+    ));
+    const run = textRunOf(
+      targetParagraph(model, 'body', 'VALID_ZERO_HPS'),
+      'VALID_ZERO_HPS',
+    );
+
+    expect(run.fontSize).toBe(0);
+    expect(run.fontSizeCs).toBe(0);
+    expect(run.kerning).toBe(0);
+  });
+
+  it('keeps position compatibility projection separate from strict private acquisition', () => {
+    const model = parse(fontSizeMeasureDocx(
+      `<w:p>
+        <w:r><w:rPr><w:position w:val="1e2"/></w:rPr><w:t>BAD_POSITION</w:t></w:r>
+        <w:r><w:rPr><w:position w:val="-3.6mm"/></w:rPr><w:t>SIGNED_POSITION</w:t></w:r>
+      </w:p>`,
+      '<w:style w:type="paragraph" w:default="1" w:styleId="Normal"/>',
+    ));
+    const invalid = textRunOf(
+      targetParagraph(model, 'body', 'BAD_POSITION'),
+      'BAD_POSITION',
+    ) as DocxTextRun & {
+      __typographyAcquisition: {
+        positionPt: { status: string; value: number | null };
+      };
+    };
+    expect(invalid.position).toBe(0);
+    expect(invalid.__typographyAcquisition.positionPt).toMatchObject({
+      status: 'invalid',
+      value: null,
+    });
+
+    const valid = textRunOf(
+      targetParagraph(model, 'body', 'SIGNED_POSITION'),
+      'SIGNED_POSITION',
+    ) as DocxTextRun & {
+      __typographyAcquisition: {
+        positionPt: { status: string; value: number | null };
+      };
+    };
+    expect(valid.position).toBeCloseTo(-expectedMmSizePt, 10);
+    expect(valid.__typographyAcquisition.positionPt).toMatchObject({
+      status: 'valid',
+    });
+    expect(valid.__typographyAcquisition.positionPt.value)
+      .toBeCloseTo(-expectedMmSizePt, 10);
+  });
+
+  it('rejects invalid ruby HPS lexemes in the public and private WASM projections', () => {
+    const model = parse(fontSizeMeasureDocx(
+      `<w:p><w:r><w:ruby>
+        <w:rubyPr>
+          <w:hps w:val="1.5"/><w:hpsBaseText w:val="-0pt"/>
+          <w:hpsRaise w:val="1e2"/>
+        </w:rubyPr>
+        <w:rt><w:r><w:t>guide</w:t></w:r></w:rt>
+        <w:rubyBase><w:r><w:t>INVALID_RUBY_HPS</w:t></w:r></w:rubyBase>
+      </w:ruby></w:r></w:p>`,
+      '<w:style w:type="paragraph" w:default="1" w:styleId="Normal"/>',
+    ));
+    const run = textRunOf(
+      targetParagraph(model, 'body', 'INVALID_RUBY_HPS'),
+      'INVALID_RUBY_HPS',
+    ) as DocxTextRun & {
+      __typographyAcquisition: {
+        ruby: {
+          baseFontSizePt: { status: string; value: number | null };
+          raisePt: { status: string; value: number | null };
+        };
+      };
+    };
+
+    expect(run.ruby?.fontSizePt).toBe(5);
+    expect(run.ruby?.hpsRaisePt).toBeUndefined();
+    expect(run.__typographyAcquisition.ruby.baseFontSizePt).toMatchObject({
+      status: 'invalid',
+      value: null,
+    });
+    expect(run.__typographyAcquisition.ruby.raisePt).toMatchObject({
+      status: 'invalid',
+      value: null,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- follow up #1110 with strict, separate lexical parsing for `ST_HpsMeasure` and `ST_SignedHpsMeasure`
- apply unsigned handling to run sizes, kerning, and ruby metrics while retaining signed baseline-position support
- preserve style inheritance/fallback for invalid unsigned values and retain the established public invalid-position fallback
- add parser and ZIP-to-WASM conformance coverage for unit-bearing values, style inheritance, signed values, invalid lexemes, and private acquisition state

## Specification

ECMA-376 Part 1 sections 17.3.2.32, 17.3.2.33, 17.3.2.16, and 17.3.2.24, plus the Part 4 simple types `ST_HpsMeasure` and `ST_SignedHpsMeasure`.

## Verification

- Rust parser: 448 unit + 10 integration tests
- `cargo fmt` and Clippy with warnings denied
- WASM conformance: 56 tests
- full Vitest: 5,848 passed, 26 skipped
- browser conformance: 66 tests across Chromium, Firefox, and WebKit
- layout boundary: 88; compatibility: 17; public API: 23; package build: 2
- TypeScript typechecks and `git diff --check`

Independent GPT-5.6 Sol review and DOCX architecture audit: approved with no blockers.