### PR TITLE
feat(vscode): add find in preview

### DIFF
--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -536,6 +536,8 @@ export declare class DocxScrollViewer implements ZoomableViewer {
     private _prevBase;
     private _lastFitWidth;
     private readonly _pageShadow;
+    private readonly _find;
+    private _findActive;
     constructor(container: HTMLElement, opts?: DocxScrollViewerOptions);
     load(source: string | ArrayBuffer): Promise<void>;
     get pageCount(): number;
@@ -581,6 +583,14 @@ export declare class DocxScrollViewer implements ZoomableViewer {
     scrollToPage(index: number, opts?: {
         behavior?: 'auto' | 'smooth';
     }): void;
+    findText(query: string, opts?: FindMatchesOptions): Promise<FindMatch<DocxMatchLocation>[]>;
+    findNext(): Promise<FindMatch<DocxMatchLocation> | null>;
+    findPrev(): Promise<FindMatch<DocxMatchLocation> | null>;
+    clearFind(): void;
+    private _activateMatch;
+    private _collectPageRuns;
+    private _redrawHighlights;
+    private _redrawSlotHighlights;
     private _onResize;
     get topVisiblePage(): number;
     destroy(): void;

--- a/packages/docx/src/find.test.ts
+++ b/packages/docx/src/find.test.ts
@@ -144,4 +144,63 @@ describe('DocxFindController.invalidate', () => {
     expect(c.pageHighlights(0)).toHaveLength(0);
     expect(c.activePage()).toBeNull();
   });
+
+  it('prevents a pending find from restoring matches after invalidate', async () => {
+    let resolveRuns!: (runs: DocxTextRunInfo[]) => void;
+    const c = new DocxFindController(
+      () => 1,
+      () => new Promise((resolve) => { resolveRuns = resolve; }),
+    );
+    const pending = c.find('a');
+
+    c.invalidate();
+    resolveRuns([run('a')]);
+
+    await expect(pending).resolves.toEqual([]);
+    expect(c.matches()).toEqual([]);
+    expect(c.pageRuns(0)).toBeUndefined();
+    expect(c.next()).toBeNull();
+  });
+
+  it('commits collected page runs atomically only after the complete scan', async () => {
+    let resolveSecond!: (runs: DocxTextRunInfo[]) => void;
+    const c = new DocxFindController(
+      () => 2,
+      (page) => page === 0
+        ? Promise.resolve([run('a')])
+        : new Promise((resolve) => { resolveSecond = resolve; }),
+    );
+    const pending = c.find('a');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(c.pageRuns(0)).toBeUndefined();
+    resolveSecond([run('a')]);
+    await expect(pending).resolves.toHaveLength(2);
+    expect(c.pageRuns(0)).toEqual([run('a')]);
+    expect(c.pageRuns(1)).toEqual([run('a')]);
+  });
+
+  it('does not overwrite newer visible-render geometry when a pending scan completes', async () => {
+    let resolveSecond!: (runs: DocxTextRunInfo[]) => void;
+    const oldVisibleRuns = [{ ...run('a'), x: 1 }];
+    const freshVisibleRuns = [{ ...run('a'), x: 20 }];
+    const c = new DocxFindController(
+      () => 2,
+      (page) => page === 0
+        ? Promise.resolve(oldVisibleRuns)
+        : new Promise((resolve) => { resolveSecond = resolve; }),
+    );
+    c.setPageRuns(0, oldVisibleRuns);
+    const pending = c.find('a');
+    await Promise.resolve();
+
+    // A zoom-settle render publishes fresh geometry while the full-document
+    // scan is still waiting on another page.
+    c.setPageRuns(0, freshVisibleRuns);
+    resolveSecond([run('a')]);
+
+    await expect(pending).resolves.toHaveLength(2);
+    expect(c.pageRuns(0)).toBe(freshVisibleRuns);
+  });
 });

--- a/packages/docx/src/find.ts
+++ b/packages/docx/src/find.ts
@@ -51,6 +51,10 @@ export class DocxFindController {
   private _matches: DocxResolvedMatch[] = [];
   /** Active-match index into {@link _matches}, or -1 for none. */
   private _active = -1;
+  /** Invalidates in-flight searches on clear, reload, destroy, or a newer find. */
+  private _generation = 0;
+  /** Advances whenever visible rendering publishes newer run geometry. */
+  private _runsRevision = 0;
 
   constructor(
     private readonly _pageCount: () => number,
@@ -59,6 +63,8 @@ export class DocxFindController {
 
   /** Drop all cached runs + matches (call on reload / render-width change). */
   invalidate(): void {
+    this._generation++;
+    this._runsRevision++;
     this._pageRuns.clear();
     this._matches = [];
     this._active = -1;
@@ -73,6 +79,7 @@ export class DocxFindController {
   /** Cache a page's runs captured from the visible render, so find() reuses
    *  them instead of re-rendering that page offscreen. */
   setPageRuns(page: number, runs: DocxTextRunInfo[]): void {
+    this._runsRevision++;
     this._pageRuns.set(page, runs);
   }
 
@@ -110,13 +117,41 @@ export class DocxFindController {
   /** Run a fresh query across every page, resetting the cursor. Returns the
    *  public match list. An empty query clears matches. */
   async find(query: string, opts: FindMatchesOptions = {}): Promise<FindMatch<DocxMatchLocation>[]> {
-    this._matches = [];
-    this._active = -1;
-    if (query.length === 0) return [];
+    const generation = ++this._generation;
+    if (query.length === 0) {
+      this._runsRevision++;
+      this._pageRuns.clear();
+      this._matches = [];
+      this._active = -1;
+      return [];
+    }
 
+    const runsRevision = this._runsRevision;
+    const pageRuns = new Map(this._pageRuns);
     const pages = this._pageCount();
     for (let page = 0; page < pages; page++) {
-      const runs = await this._ensurePageRuns(page);
+      let runs = pageRuns.get(page);
+      if (!runs) {
+        runs = await this._collectPageRuns(page);
+        if (generation !== this._generation) return [];
+        pageRuns.set(page, runs);
+      }
+    }
+    if (generation !== this._generation) return [];
+
+    // A visible zoom-settle render can publish newer geometry while this scan
+    // awaits an offscreen page. Preserve those per-page updates instead of
+    // replacing them with the snapshot captured when find() began.
+    const committedRuns = runsRevision === this._runsRevision
+      ? pageRuns
+      : new Map([...pageRuns, ...this._pageRuns]);
+
+    // Build slices from the exact run lists being committed. Besides keeping
+    // highlight coordinates current, this keeps slice indices coherent if a
+    // fresh render changes run segmentation.
+    const matches: DocxResolvedMatch[] = [];
+    for (let page = 0; page < pages; page++) {
+      const runs = committedRuns.get(page) ?? [];
       const index = buildTextIndex(runs);
       for (const tm of findMatches(index, query, opts)) {
         // The matched text as it appears in the document: read it back from the
@@ -126,9 +161,13 @@ export class DocxFindController {
         const text = tm.slices
           .map((s) => runs[s.runIndex].text.slice(s.start, s.end))
           .join('');
-        this._matches.push({ page, text, slices: tm.slices });
+        matches.push({ page, text, slices: tm.slices });
       }
     }
+    this._runsRevision++;
+    this._pageRuns = committedRuns;
+    this._matches = matches;
+    this._active = -1;
     return this.matches();
   }
 
@@ -151,12 +190,4 @@ export class DocxFindController {
     return { matchIndex: this._active, text: m.text, location: { page: m.page } };
   }
 
-  /** Get (scanning + caching if needed) the runs for a page. */
-  private async _ensurePageRuns(page: number): Promise<DocxTextRunInfo[]> {
-    const cached = this._pageRuns.get(page);
-    if (cached) return cached;
-    const runs = await this._collectPageRuns(page);
-    this._pageRuns.set(page, runs);
-    return runs;
-  }
 }

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1085,6 +1085,204 @@ describe('DocxScrollViewer — text selection (T5)', () => {
   });
 });
 
+describe('DocxScrollViewer — full-document find', () => {
+  const RUN = {
+    text: 'Alpha beta',
+    x: 4,
+    y: 6,
+    w: 60,
+    h: 12,
+    fontSize: 12,
+    font: '12px serif',
+  };
+
+  it('finds case-insensitively beyond the mounted window, navigates, and clears', async () => {
+    installDom();
+    const container = makeContainer(200, 120);
+    const engine = new FakeDocxEngine(
+      4,
+      Array.from({ length: 4 }, () => ({ widthPt: 100, heightPt: 200 })),
+    );
+    engine.feedTextRuns = [RUN];
+    const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+      document: engine.asDoc(),
+      gap: 0,
+      overscan: 0,
+      paddingTop: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+    });
+    const scrollHost = container.children[0].children[0] as FakeEl;
+    scrollHost.clientHeight = 120;
+    v.relayout();
+
+    const matches = await v.findText('ALPHA');
+    expect(matches).toHaveLength(4);
+    expect(matches.map((match) => match.location.page)).toEqual([0, 1, 2, 3]);
+
+    await v.findNext();
+    const second = await v.findNext();
+    expect(second?.location.page).toBe(1);
+    expect(scrollHost.scrollTop).toBeGreaterThan(0);
+
+    const mountedHighlightLayers = scrollHost.children
+      .filter((child) => child.children.some((nested) => nested.tag === 'canvas'))
+      .map((slot) => slot.children.find((child) => child.tag === 'div') as FakeEl);
+    expect(mountedHighlightLayers.some((layer) => layer.children.length > 0)).toBe(true);
+
+    v.clearFind();
+    expect(mountedHighlightLayers.every((layer) => layer.children.length === 0)).toBe(true);
+    v.destroy();
+  });
+
+  it.each(['main', 'worker'] as const)(
+    'refreshes cached find geometry after a zoom settle render in %s mode',
+    async (mode) => {
+    vi.useFakeTimers();
+    try {
+      installDom();
+      const container = makeContainer(200, 120);
+      const engine = new FakeDocxEngine(1, [{ widthPt: 100, heightPt: 200 }], mode);
+      engine.feedTextRuns = [RUN];
+      const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+        document: engine.asDoc(),
+        gap: 0,
+        paddingTop: 0,
+        paddingBottom: 0,
+        paddingLeft: 0,
+        paddingRight: 0,
+      });
+      const scrollHost = container.children[0].children[0] as FakeEl;
+      scrollHost.clientHeight = 120;
+      v.relayout();
+      await v.findText('alpha');
+      await Promise.resolve();
+
+      const slot = scrollHost.children.find(
+        (child) => child.children.some((nested) => nested.tag === 'canvas'),
+      ) as FakeEl;
+      const highlightLayer = slot.children.find((child) => child.tag === 'div') as FakeEl;
+      expect(highlightLayer.children[0].style.left).toBe('2%');
+
+      engine.feedTextRuns = [{ ...RUN, x: 40 }];
+      v.setScale(v.getScale() * 2);
+      vi.advanceTimersByTime(200);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(highlightLayer.children[0].style.left).toBe('10%');
+      v.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+    },
+  );
+
+  it.each(['main', 'worker'] as const)(
+    'keeps zoom-settle geometry when an older pending find completes in %s mode',
+    async (mode) => {
+      vi.useFakeTimers();
+      try {
+        installDom();
+        const container = makeContainer(200, 120);
+        const engine = new FakeDocxEngine(
+          2,
+          Array.from({ length: 2 }, () => ({ widthPt: 100, heightPt: 200 })),
+          mode,
+        );
+        engine.feedTextRuns = [RUN];
+        let resolveSecond!: (runs: NonNullable<typeof engine.feedTextRuns>) => void;
+        engine.collectPageRuns = (page) => page === 1
+          ? new Promise((resolve) => { resolveSecond = resolve; })
+          : Promise.resolve([RUN]);
+        const v = new DocxScrollViewer(container as unknown as HTMLElement, {
+          document: engine.asDoc(),
+          gap: 0,
+          overscan: 0,
+          paddingTop: 0,
+          paddingBottom: 0,
+          paddingLeft: 0,
+          paddingRight: 0,
+        });
+        const scrollHost = container.children[0].children[0] as FakeEl;
+        scrollHost.clientHeight = 120;
+        v.relayout();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const pending = v.findText('alpha');
+        await Promise.resolve();
+        await Promise.resolve();
+
+        engine.feedTextRuns = [{ ...RUN, x: 40 }];
+        v.setScale(v.getScale() * 2);
+        vi.advanceTimersByTime(200);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        resolveSecond([RUN]);
+        await expect(pending).resolves.toHaveLength(2);
+
+        const slot = scrollHost.children.find(
+          (child) => child.children.some((nested) => nested.tag === 'canvas'),
+        ) as FakeEl;
+        const highlightLayer = slot.children.find((child) => child.tag === 'div') as FakeEl;
+        expect(highlightLayer.children[0].style.left).toBe('10%');
+        v.destroy();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(['clear', 'destroy'] as const)(
+    'does not restore a pending find after %s',
+    async (action) => {
+      installDom();
+      const engine = new FakeDocxEngine(1, [{ widthPt: 100, heightPt: 200 }]);
+      let resolveRuns!: (runs: NonNullable<typeof engine.feedTextRuns>) => void;
+      engine.collectPageRuns = () => new Promise((resolve) => { resolveRuns = resolve; });
+      const v = new DocxScrollViewer(makeContainer(200, 120) as unknown as HTMLElement, {
+        document: engine.asDoc(),
+      });
+      const pending = v.findText('alpha');
+
+      if (action === 'clear') v.clearFind();
+      else v.destroy();
+      resolveRuns([RUN]);
+
+      await expect(pending).resolves.toEqual([]);
+      await expect(v.findNext()).resolves.toBeNull();
+      if (action === 'clear') v.destroy();
+    },
+  );
+
+  it('does not restore a pending find after reload', async () => {
+    installDom();
+    const first = new FakeDocxEngine(1, [{ widthPt: 100, heightPt: 200 }]);
+    const second = new FakeDocxEngine(1, [{ widthPt: 100, heightPt: 200 }]);
+    let resolveRuns!: (runs: NonNullable<typeof first.feedTextRuns>) => void;
+    first.collectPageRuns = () => new Promise((resolve) => { resolveRuns = resolve; });
+    vi.spyOn(DocxDocument, 'load')
+      .mockResolvedValueOnce(first.asDoc())
+      .mockResolvedValueOnce(second.asDoc());
+    const container = makeContainer(200, 120);
+    const v = new DocxScrollViewer(container as unknown as HTMLElement);
+    const scrollHost = container.children[0].children[0] as FakeEl;
+    scrollHost.clientHeight = 120;
+    await v.load('first.docx');
+    const pending = v.findText('alpha');
+
+    await v.load('second.docx');
+    resolveRuns([RUN]);
+
+    await expect(pending).resolves.toEqual([]);
+    await expect(v.findNext()).resolves.toBeNull();
+    v.destroy();
+  });
+});
+
 describe('DocxScrollViewer — navigation, resize, empty (T6)', () => {
   const PT_TO_PX = 4 / 3;
   // container fit width 200, page widthPt 100 → base scale = 200/(100*PT_TO_PX)=1.5.

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1,9 +1,11 @@
 import { computeVisibleRange, openExternalHyperlink, PT_TO_PX, zoomStepScale, anchoredZoomOffset, nextZoomStep, prevZoomStep, fitScale, type VisibleRange } from '@silurus/ooxml-core';
-import type { HyperlinkTarget, ZoomableViewer } from '@silurus/ooxml-core';
+import type { FindMatch, FindMatchesOptions, HyperlinkTarget, ZoomableViewer } from '@silurus/ooxml-core';
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
 import type { DocxTextRunInfo } from './renderer';
 import { buildDocxTextLayer } from './text-layer';
+import { DocxFindController, type DocxMatchLocation } from './find';
+import { buildDocxHighlightLayer } from './find-highlight-layer';
 import type { RenderPageOptions } from './types';
 
 /**
@@ -156,6 +158,7 @@ interface PageSlot {
   wrapper: HTMLDivElement;
   canvas: HTMLCanvasElement;
   textLayer: HTMLDivElement | null;
+  highlightLayer: HTMLDivElement;
   /** page index this slot is currently rendering / has rendered, or -1 when free. */
   renderedPage: number;
   /** The `_scale` at which this slot's on-screen canvas bitmap (and text overlay)
@@ -299,6 +302,11 @@ export class DocxScrollViewer implements ZoomableViewer {
    *  `_settleSlot`) so a recycled/re-mounted slot and a settle-swapped spare all
    *  carry it. */
   private readonly _pageShadow: string | false;
+  private readonly _find = new DocxFindController(
+    () => this.pageCount,
+    (page) => this._collectPageRuns(page),
+  );
+  private _findActive = false;
 
   constructor(container: HTMLElement, opts: DocxScrollViewerOptions = {}) {
     // A <canvas> is an HTMLElement too, so the type system cannot stop a caller
@@ -434,6 +442,8 @@ export class DocxScrollViewer implements ZoomableViewer {
       }
       this._doc = doc;
       previous?.destroy();
+      this._find.invalidate();
+      this._findActive = false;
       if (previous) {
         // Re-loading over a prior document: recycle every mounted slot (they hold
         // the OLD document's rendered canvases) and reset the top-index latch so
@@ -716,11 +726,17 @@ export class DocxScrollViewer implements ZoomableViewer {
         'overflow:hidden;pointer-events:none;user-select:text;-webkit-user-select:text;';
       wrapper.appendChild(textLayer);
     }
+    const highlightLayer = document.createElement('div');
+    highlightLayer.style.cssText =
+      'position:absolute;top:0;left:0;width:100%;height:100%;' +
+      'overflow:hidden;pointer-events:none;';
+    wrapper.appendChild(highlightLayer);
     this._scrollHost.appendChild(wrapper);
     const slot: PageSlot = {
       wrapper,
       canvas,
       textLayer,
+      highlightLayer,
       renderedPage: -1,
       renderedScale: -1,
       bitmap: null,
@@ -747,6 +763,9 @@ export class DocxScrollViewer implements ZoomableViewer {
       slot.textLayer.style.transform = '';
       slot.textLayer.style.transformOrigin = '';
     }
+    slot.highlightLayer.innerHTML = '';
+    slot.highlightLayer.style.transform = '';
+    slot.highlightLayer.style.transformOrigin = '';
     slot.renderedPage = -1;
     slot.renderedScale = -1;
     slot.wrapper.remove();
@@ -817,7 +836,8 @@ export class DocxScrollViewer implements ZoomableViewer {
     // Main mode: render straight onto the slot's canvas.
     const runs: DocxTextRunInfo[] = [];
     const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
-    const onTextRun = wantOverlay ? (r: DocxTextRunInfo) => runs.push(r) : undefined;
+    const wantRuns = wantOverlay || this._findActive;
+    const onTextRun = wantRuns ? (r: DocxTextRunInfo) => runs.push(r) : undefined;
     this._doc
       .renderPage(slot.canvas, i, {
         width: widthPx, // this page's own px width → uniform px-per-pt scale (§7)
@@ -846,6 +866,8 @@ export class DocxScrollViewer implements ZoomableViewer {
             (font) => this._measureForFont(font),
           );
         }
+        if (wantRuns) this._refreshFindRuns(i, runs);
+        this._redrawSlotHighlights(i, slot);
       })
       .catch((err: unknown) => {
         this._reportRenderError(err);
@@ -896,7 +918,7 @@ export class DocxScrollViewer implements ZoomableViewer {
       this._measureCtx = c.getContext('2d');
     }
     const ctx = this._measureCtx;
-    if (!ctx) return (s) => s.length;
+    if (!ctx || typeof ctx.measureText !== 'function') return (s) => s.length;
     ctx.font = font;
     return (s) => ctx.measureText(s).width;
   }
@@ -970,6 +992,7 @@ export class DocxScrollViewer implements ZoomableViewer {
     // The runs ride back beside the bitmap (one round-trip), collected only when
     // an overlay is actually wanted.
     const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
+    const wantRuns = wantOverlay || this._findActive;
     const runs: DocxTextRunInfo[] = [];
     try {
       const bmp = await this._doc!.renderPageToBitmap(i, {
@@ -977,7 +1000,7 @@ export class DocxScrollViewer implements ZoomableViewer {
         dpr,
         defaultTextColor: this._opts.defaultTextColor,
         showTrackChanges: this._opts.showTrackChanges,
-        onTextRun: wantOverlay ? (r) => runs.push(r) : undefined,
+        onTextRun: wantRuns ? (r) => runs.push(r) : undefined,
       });
       // Stale if EITHER (a) the epoch moved (a setScale rescaled mid-flight, so
       // this bitmap is at a superseded resolution — this catches the case where
@@ -1027,6 +1050,8 @@ export class DocxScrollViewer implements ZoomableViewer {
           );
         }
       }
+      if (wantRuns) this._refreshFindRuns(i, runs);
+      this._redrawSlotHighlights(i, slot);
       painted = true;
     } catch (err) {
       this._reportRenderError(err);
@@ -1397,7 +1422,8 @@ export class DocxScrollViewer implements ZoomableViewer {
     this._applyPageShadow(spare);
     const runs: DocxTextRunInfo[] = [];
     const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
-    const onTextRun = wantOverlay ? (r: DocxTextRunInfo) => runs.push(r) : undefined;
+    const wantRuns = wantOverlay || this._findActive;
+    const onTextRun = wantRuns ? (r: DocxTextRunInfo) => runs.push(r) : undefined;
     this._doc
       .renderPage(spare, i, {
         width: widthPx,
@@ -1439,6 +1465,8 @@ export class DocxScrollViewer implements ZoomableViewer {
             );
           }
         }
+        if (wantRuns) this._refreshFindRuns(i, runs);
+        this._redrawSlotHighlights(i, slot);
       })
       .catch((err: unknown) => {
         this._reportRenderError(err);
@@ -1488,6 +1516,81 @@ export class DocxScrollViewer implements ZoomableViewer {
       this._scrollHost.scrollTop = top;
     }
     this._mountVisible();
+  }
+
+  /** Search the complete document, including pages outside the virtualized
+   * mounted window. Matching is case-insensitive by default. */
+  async findText(
+    query: string,
+    opts: FindMatchesOptions = {},
+  ): Promise<FindMatch<DocxMatchLocation>[]> {
+    if (!this._doc) return [];
+    this._findActive = query.length > 0;
+    const matches = await this._find.find(query, opts);
+    this._redrawHighlights();
+    return matches;
+  }
+
+  /** Activate and reveal the next match, wrapping at the end. */
+  async findNext(): Promise<FindMatch<DocxMatchLocation> | null> {
+    return this._activateMatch(this._find.next());
+  }
+
+  /** Activate and reveal the previous match, wrapping at the beginning. */
+  async findPrev(): Promise<FindMatch<DocxMatchLocation> | null> {
+    return this._activateMatch(this._find.prev());
+  }
+
+  /** Clear the current query and every mounted highlight. */
+  clearFind(): void {
+    this._findActive = false;
+    this._find.invalidate();
+    this._redrawHighlights();
+  }
+
+  private async _activateMatch(
+    match: FindMatch<DocxMatchLocation> | null,
+  ): Promise<FindMatch<DocxMatchLocation> | null> {
+    if (match) this.scrollToPage(match.location.page);
+    this._redrawHighlights();
+    return match;
+  }
+
+  private async _collectPageRuns(page: number): Promise<DocxTextRunInfo[]> {
+    if (!this._doc) return [];
+    return this._doc.collectPageRuns(page, {
+      width: this._pageWidthPx(page),
+      defaultTextColor: this._opts.defaultTextColor,
+      showTrackChanges: this._opts.showTrackChanges,
+    });
+  }
+
+  private _redrawHighlights(): void {
+    for (const [page, slot] of this._slots) this._redrawSlotHighlights(page, slot);
+  }
+
+  private _refreshFindRuns(page: number, runs: DocxTextRunInfo[]): void {
+    if (this._findActive) this._find.setPageRuns(page, runs);
+  }
+
+  private _redrawSlotHighlights(page: number, slot: PageSlot): void {
+    if (!this._findActive) {
+      slot.highlightLayer.innerHTML = '';
+      return;
+    }
+    const runs = this._find.pageRuns(page);
+    if (!runs) {
+      slot.highlightLayer.innerHTML = '';
+      return;
+    }
+    buildDocxHighlightLayer(
+      slot.highlightLayer,
+      runs,
+      this._find.pageHighlights(page),
+      this._pageWidthPx(page),
+      this._pageHeightPx(page),
+      (font) => this._measureForFont(font),
+    );
   }
 
   /**
@@ -1634,6 +1737,8 @@ export class DocxScrollViewer implements ZoomableViewer {
     // as superseded and its engine is cleaned up rather than installed onto a
     // torn-down viewer.
     this._loadGen++;
+    this._find.invalidate();
+    this._findActive = false;
     if (this._scrollListener) {
       this._scrollHost.removeEventListener('scroll', this._scrollListener);
       this._scrollListener = null;

--- a/packages/pptx/src/find.test.ts
+++ b/packages/pptx/src/find.test.ts
@@ -83,4 +83,63 @@ describe('PptxFindController cursor + highlights', () => {
     expect(c.matches()).toHaveLength(0);
     expect(c.activeSlide()).toBeNull();
   });
+
+  it('prevents a pending find from restoring matches after invalidate', async () => {
+    let resolveRuns!: (runs: PptxTextRunInfo[]) => void;
+    const c = new PptxFindController(
+      () => 1,
+      () => new Promise((resolve) => { resolveRuns = resolve; }),
+    );
+    const pending = c.find('a');
+
+    c.invalidate();
+    resolveRuns([run('a')]);
+
+    await expect(pending).resolves.toEqual([]);
+    expect(c.matches()).toEqual([]);
+    expect(c.slideRuns(0)).toBeUndefined();
+    expect(c.next()).toBeNull();
+  });
+
+  it('commits collected slide runs atomically only after the complete scan', async () => {
+    let resolveSecond!: (runs: PptxTextRunInfo[]) => void;
+    const c = new PptxFindController(
+      () => 2,
+      (slide) => slide === 0
+        ? Promise.resolve([run('a')])
+        : new Promise((resolve) => { resolveSecond = resolve; }),
+    );
+    const pending = c.find('a');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(c.slideRuns(0)).toBeUndefined();
+    resolveSecond([run('a')]);
+    await expect(pending).resolves.toHaveLength(2);
+    expect(c.slideRuns(0)).toEqual([run('a')]);
+    expect(c.slideRuns(1)).toEqual([run('a')]);
+  });
+
+  it('does not overwrite newer visible-render geometry when a pending scan completes', async () => {
+    let resolveSecond!: (runs: PptxTextRunInfo[]) => void;
+    const oldVisibleRuns = [{ ...run('a'), inShapeX: 1 }];
+    const freshVisibleRuns = [{ ...run('a'), inShapeX: 20 }];
+    const c = new PptxFindController(
+      () => 2,
+      (slide) => slide === 0
+        ? Promise.resolve(oldVisibleRuns)
+        : new Promise((resolve) => { resolveSecond = resolve; }),
+    );
+    c.setSlideRuns(0, oldVisibleRuns);
+    const pending = c.find('a');
+    await Promise.resolve();
+
+    // A zoom-settle render publishes fresh geometry while the full-deck scan
+    // is still waiting on another slide.
+    c.setSlideRuns(0, freshVisibleRuns);
+    resolveSecond([run('a')]);
+
+    await expect(pending).resolves.toHaveLength(2);
+    expect(c.slideRuns(0)).toBe(freshVisibleRuns);
+  });
 });

--- a/packages/pptx/src/find.ts
+++ b/packages/pptx/src/find.ts
@@ -37,6 +37,10 @@ export class PptxFindController {
   private _slideRuns = new Map<number, PptxTextRunInfo[]>();
   private _matches: PptxResolvedMatch[] = [];
   private _active = -1;
+  /** Invalidates in-flight searches on clear, reload, destroy, or a newer find. */
+  private _generation = 0;
+  /** Advances whenever visible rendering publishes newer run geometry. */
+  private _runsRevision = 0;
 
   constructor(
     private readonly _slideCount: () => number,
@@ -45,6 +49,8 @@ export class PptxFindController {
 
   /** Drop all cached runs + matches (call on reload). */
   invalidate(): void {
+    this._generation++;
+    this._runsRevision++;
     this._slideRuns.clear();
     this._matches = [];
     this._active = -1;
@@ -58,6 +64,7 @@ export class PptxFindController {
 
   /** Cache a slide's runs captured from the visible render. */
   setSlideRuns(slide: number, runs: PptxTextRunInfo[]): void {
+    this._runsRevision++;
     this._slideRuns.set(slide, runs);
   }
 
@@ -88,21 +95,52 @@ export class PptxFindController {
 
   /** Run a fresh query across every slide, resetting the cursor. */
   async find(query: string, opts: FindMatchesOptions = {}): Promise<FindMatch<PptxMatchLocation>[]> {
-    this._matches = [];
-    this._active = -1;
-    if (query.length === 0) return [];
+    const generation = ++this._generation;
+    if (query.length === 0) {
+      this._runsRevision++;
+      this._slideRuns.clear();
+      this._matches = [];
+      this._active = -1;
+      return [];
+    }
 
+    const runsRevision = this._runsRevision;
+    const slideRuns = new Map(this._slideRuns);
     const slides = this._slideCount();
     for (let slide = 0; slide < slides; slide++) {
-      const runs = await this._ensureSlideRuns(slide);
+      let runs = slideRuns.get(slide);
+      if (!runs) {
+        runs = await this._collectSlideRuns(slide);
+        if (generation !== this._generation) return [];
+        slideRuns.set(slide, runs);
+      }
+    }
+    if (generation !== this._generation) return [];
+
+    // A visible zoom-settle render can publish newer geometry while this scan
+    // awaits an offscreen slide. Preserve those per-slide updates instead of
+    // replacing them with the snapshot captured when find() began.
+    const committedRuns = runsRevision === this._runsRevision
+      ? slideRuns
+      : new Map([...slideRuns, ...this._slideRuns]);
+
+    // Resolve slices against the exact run lists being committed so slice
+    // indices and highlight geometry remain coherent after a fresh render.
+    const matches: PptxResolvedMatch[] = [];
+    for (let slide = 0; slide < slides; slide++) {
+      const runs = committedRuns.get(slide) ?? [];
       const index = buildTextIndex(runs);
       for (const tm of findMatches(index, query, opts)) {
         const text = tm.slices
           .map((s) => runs[s.runIndex].text.slice(s.start, s.end))
           .join('');
-        this._matches.push({ slide, text, slices: tm.slices });
+        matches.push({ slide, text, slices: tm.slices });
       }
     }
+    this._runsRevision++;
+    this._slideRuns = committedRuns;
+    this._matches = matches;
+    this._active = -1;
     return this.matches();
   }
 
@@ -122,11 +160,4 @@ export class PptxFindController {
     return { matchIndex: this._active, text: m.text, location: { slide: m.slide } };
   }
 
-  private async _ensureSlideRuns(slide: number): Promise<PptxTextRunInfo[]> {
-    const cached = this._slideRuns.get(slide);
-    if (cached) return cached;
-    const runs = await this._collectSlideRuns(slide);
-    this._slideRuns.set(slide, runs);
-    return runs;
-  }
 }

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1670,6 +1670,204 @@ describe('PptxScrollViewer — text selection (T5)', () => {
   });
 });
 
+describe('PptxScrollViewer — full-presentation find', () => {
+  const RUN = {
+    text: 'Alpha beta',
+    x: 4,
+    y: 6,
+    w: 60,
+    h: 12,
+    fontSize: 12,
+    font: '12px serif',
+    shapeX: 0,
+    shapeY: 0,
+    shapeW: 100,
+    shapeH: 40,
+    inShapeX: 4,
+    inShapeY: 6,
+    rotation: 0,
+  };
+
+  it('finds case-insensitively beyond the mounted window, navigates, and clears', async () => {
+    installDom();
+    const container = makeContainer(200, 80);
+    const engine = new FakePptxEngine(4, SLIDE_W_EMU, SLIDE_H_EMU);
+    engine.feedTextRuns = [RUN];
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      gap: 0,
+      overscan: 0,
+      paddingTop: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+    });
+    const scrollHost = container.children[0].children[0] as FakeEl;
+    scrollHost.clientHeight = 80;
+    v.relayout();
+
+    const matches = await v.findText('ALPHA');
+    expect(matches).toHaveLength(4);
+    expect(matches.map((match) => match.location.slide)).toEqual([0, 1, 2, 3]);
+
+    await v.findNext();
+    const second = await v.findNext();
+    expect(second?.location.slide).toBe(1);
+    expect(scrollHost.scrollTop).toBeGreaterThan(0);
+
+    const mountedHighlightLayers = scrollHost.children
+      .filter((child) => child.children.some((nested) => nested.tag === 'canvas'))
+      .map((slot) => slot.children.find((child) => child.tag === 'div') as FakeEl);
+    expect(mountedHighlightLayers.some((layer) => layer.children.length > 0)).toBe(true);
+
+    v.clearFind();
+    expect(mountedHighlightLayers.every((layer) => layer.children.length === 0)).toBe(true);
+    v.destroy();
+  });
+
+  it.each(['main', 'worker'] as const)(
+    'refreshes cached find geometry after a zoom settle render in %s mode',
+    async (mode) => {
+    vi.useFakeTimers();
+    try {
+      installDom();
+      const container = makeContainer(200, 80);
+      const engine = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU, mode);
+      engine.feedTextRuns = [RUN];
+      const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+        presentation: engine.asPres(),
+        gap: 0,
+        paddingTop: 0,
+        paddingBottom: 0,
+        paddingLeft: 0,
+        paddingRight: 0,
+      });
+      const scrollHost = container.children[0].children[0] as FakeEl;
+      scrollHost.clientHeight = 80;
+      v.relayout();
+      await v.findText('alpha');
+      await Promise.resolve();
+
+      const slot = scrollHost.children.find(
+        (child) => child.children.some((nested) => nested.tag === 'canvas'),
+      ) as FakeEl;
+      const highlightLayer = slot.children.find((child) => child.tag === 'div') as FakeEl;
+      expect(highlightLayer.children[0].children[0].style.left).toBe('4%');
+
+      engine.feedTextRuns = [{ ...RUN, inShapeX: 40 }];
+      v.setScale(v.getScale() * 2);
+      vi.advanceTimersByTime(200);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(highlightLayer.children[0].children[0].style.left).toBe('40%');
+      v.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+    },
+  );
+
+  it.each(['main', 'worker'] as const)(
+    'keeps zoom-settle geometry when an older pending find completes in %s mode',
+    async (mode) => {
+      vi.useFakeTimers();
+      try {
+        installDom();
+        const container = makeContainer(200, 80);
+        const engine = new FakePptxEngine(2, SLIDE_W_EMU, SLIDE_H_EMU, mode);
+        engine.feedTextRuns = [RUN];
+        let resolveSecond!: (runs: NonNullable<typeof engine.feedTextRuns>) => void;
+        engine.collectSlideRuns = (slide) => slide === 1
+          ? new Promise((resolve) => { resolveSecond = resolve; })
+          : Promise.resolve([RUN]);
+        const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+          presentation: engine.asPres(),
+          gap: 0,
+          overscan: 0,
+          paddingTop: 0,
+          paddingBottom: 0,
+          paddingLeft: 0,
+          paddingRight: 0,
+        });
+        const scrollHost = container.children[0].children[0] as FakeEl;
+        scrollHost.clientHeight = 80;
+        v.relayout();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const pending = v.findText('alpha');
+        await Promise.resolve();
+        await Promise.resolve();
+
+        engine.feedTextRuns = [{ ...RUN, inShapeX: 40 }];
+        v.setScale(v.getScale() * 2);
+        vi.advanceTimersByTime(200);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        resolveSecond([RUN]);
+        await expect(pending).resolves.toHaveLength(2);
+
+        const slot = scrollHost.children.find(
+          (child) => child.children.some((nested) => nested.tag === 'canvas'),
+        ) as FakeEl;
+        const highlightLayer = slot.children.find((child) => child.tag === 'div') as FakeEl;
+        expect(highlightLayer.children[0].children[0].style.left).toBe('40%');
+        v.destroy();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(['clear', 'destroy'] as const)(
+    'does not restore a pending find after %s',
+    async (action) => {
+      installDom();
+      const engine = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU);
+      let resolveRuns!: (runs: NonNullable<typeof engine.feedTextRuns>) => void;
+      engine.collectSlideRuns = () => new Promise((resolve) => { resolveRuns = resolve; });
+      const v = new PptxScrollViewer(makeContainer(200, 80) as unknown as HTMLElement, {
+        presentation: engine.asPres(),
+      });
+      const pending = v.findText('alpha');
+
+      if (action === 'clear') v.clearFind();
+      else v.destroy();
+      resolveRuns([RUN]);
+
+      await expect(pending).resolves.toEqual([]);
+      await expect(v.findNext()).resolves.toBeNull();
+      if (action === 'clear') v.destroy();
+    },
+  );
+
+  it('does not restore a pending find after reload', async () => {
+    installDom();
+    const first = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU);
+    const second = new FakePptxEngine(1, SLIDE_W_EMU, SLIDE_H_EMU);
+    let resolveRuns!: (runs: NonNullable<typeof first.feedTextRuns>) => void;
+    first.collectSlideRuns = () => new Promise((resolve) => { resolveRuns = resolve; });
+    vi.spyOn(PptxPresentation, 'load')
+      .mockResolvedValueOnce(first.asPres())
+      .mockResolvedValueOnce(second.asPres());
+    const container = makeContainer(200, 80);
+    const v = new PptxScrollViewer(container as unknown as HTMLElement);
+    const scrollHost = container.children[0].children[0] as FakeEl;
+    scrollHost.clientHeight = 80;
+    await v.load('first.pptx');
+    const pending = v.findText('alpha');
+
+    await v.load('second.pptx');
+    resolveRuns([RUN]);
+
+    await expect(pending).resolves.toEqual([]);
+    await expect(v.findNext()).resolves.toBeNull();
+    v.destroy();
+  });
+});
+
 describe('PptxScrollViewer — navigation, resize, empty (T6)', () => {
   // container fit width 200, natural slide width 200px → DIMENSIONLESS base scale
   // 200/200 = 1.0. slide height px = (SLIDE_H_EMU / 9525) * 1.0 = 120. gap 10 ⇒

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1,8 +1,10 @@
-import { computeVisibleRange, EMU_PER_PX, zoomStepScale, anchoredZoomOffset, nextZoomStep, prevZoomStep, fitScale, type VisibleRange, type HyperlinkTarget, type ZoomableViewer, openExternalHyperlink } from '@silurus/ooxml-core';
+import { computeVisibleRange, EMU_PER_PX, zoomStepScale, anchoredZoomOffset, nextZoomStep, prevZoomStep, fitScale, type FindMatch, type FindMatchesOptions, type VisibleRange, type HyperlinkTarget, type ZoomableViewer, openExternalHyperlink } from '@silurus/ooxml-core';
 import { PptxPresentation, type LoadOptions, type RenderSlideOptions } from './presentation';
 import type { PresentationHandle } from './presentation-handle';
 import type { PptxTextRunInfo } from './renderer';
 import { buildPptxTextLayer } from './text-layer';
+import { PptxFindController, type PptxMatchLocation } from './find';
+import { buildPptxHighlightLayer } from './find-highlight-layer';
 
 /**
  * Debounce window (ms) after the last `setScale` in a zoom burst before the
@@ -181,6 +183,7 @@ interface SlideSlot {
   wrapper: HTMLDivElement;
   canvas: HTMLCanvasElement;
   textLayer: HTMLDivElement | null;
+  highlightLayer: HTMLDivElement;
   /** slide index this slot is currently rendering / has rendered, or -1 when free. */
   renderedSlide: number;
   /** The `_scale` at which this slot's on-screen canvas bitmap (and text overlay)
@@ -336,6 +339,12 @@ export class PptxScrollViewer implements ZoomableViewer {
    *  `_settleSlot`) so a recycled/re-mounted slot and a settle-swapped spare all
    *  carry it. */
   private readonly _pageShadow: string | false;
+  private readonly _find = new PptxFindController(
+    () => this.slideCount,
+    (slide) => this._collectSlideRuns(slide),
+  );
+  private _findActive = false;
+  private _findMeasureCtx: CanvasRenderingContext2D | null | undefined;
 
   constructor(container: HTMLElement, opts: PptxScrollViewerOptions = {}) {
     // A <canvas> is an HTMLElement too, so the type system cannot stop a caller
@@ -471,6 +480,8 @@ export class PptxScrollViewer implements ZoomableViewer {
       }
       this._pres = pres;
       previous?.destroy();
+      this._find.invalidate();
+      this._findActive = false;
       if (previous) {
         // Re-loading over a prior deck: recycle every mounted slot (they hold the
         // OLD deck's rendered canvases) and reset the top-index latch so the new
@@ -774,11 +785,17 @@ export class PptxScrollViewer implements ZoomableViewer {
         'overflow:hidden;pointer-events:none;user-select:text;-webkit-user-select:text;';
       wrapper.appendChild(textLayer);
     }
+    const highlightLayer = document.createElement('div');
+    highlightLayer.style.cssText =
+      'position:absolute;top:0;left:0;width:100%;height:100%;' +
+      'overflow:hidden;pointer-events:none;';
+    wrapper.appendChild(highlightLayer);
     this._scrollHost.appendChild(wrapper);
     const slot: SlideSlot = {
       wrapper,
       canvas,
       textLayer,
+      highlightLayer,
       renderedSlide: -1,
       renderedScale: -1,
       bitmap: null,
@@ -817,6 +834,9 @@ export class PptxScrollViewer implements ZoomableViewer {
       slot.textLayer.style.transform = '';
       slot.textLayer.style.transformOrigin = '';
     }
+    slot.highlightLayer.innerHTML = '';
+    slot.highlightLayer.style.transform = '';
+    slot.highlightLayer.style.transformOrigin = '';
     slot.renderedSlide = -1;
     slot.renderedScale = -1;
     slot.wrapper.remove();
@@ -894,7 +914,8 @@ export class PptxScrollViewer implements ZoomableViewer {
     // Main mode: render straight onto the slot's canvas.
     const runs: PptxTextRunInfo[] = [];
     const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
-    const onTextRun = wantOverlay ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
+    const wantRuns = wantOverlay || this._findActive;
+    const onTextRun = wantRuns ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
     const canvas = slot.canvas;
     this._pres
       .renderSlide(canvas, i, {
@@ -927,6 +948,8 @@ export class PptxScrollViewer implements ZoomableViewer {
           // current scale (rounded).
           buildPptxTextLayer(slot.textLayer, runs, Math.round(widthPx), Math.round(this._slideHeightPx()), this._hyperlinkHandler());
         }
+        if (wantRuns) this._refreshFindRuns(i, runs);
+        this._redrawSlotHighlights(i, slot);
       })
       .catch((err: unknown) => {
         this._reportRenderError(err);
@@ -955,7 +978,8 @@ export class PptxScrollViewer implements ZoomableViewer {
     slot.presentationHandle = null;
     const runs: PptxTextRunInfo[] = [];
     const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
-    const onTextRun = wantOverlay ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
+    const wantRuns = wantOverlay || this._findActive;
+    const onTextRun = wantRuns ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
 
     this._pres
       .presentSlide(slot.canvas, i, { width: widthPx, dpr, onTextRun })
@@ -981,6 +1005,8 @@ export class PptxScrollViewer implements ZoomableViewer {
             this._hyperlinkHandler(),
           );
         }
+        if (wantRuns) this._refreshFindRuns(i, runs);
+        this._redrawSlotHighlights(i, slot);
       })
       .catch((err: unknown) => {
         if (generation === slot.presentationGeneration) this._reportRenderError(err);
@@ -1092,12 +1118,13 @@ export class PptxScrollViewer implements ZoomableViewer {
     // The runs ride back beside the bitmap (one round-trip), collected only when
     // an overlay is actually wanted.
     const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
+    const wantRuns = wantOverlay || this._findActive;
     const runs: PptxTextRunInfo[] = [];
     try {
       const bmp = await this._pres!.renderSlideToBitmap(i, {
         width: widthPx,
         dpr,
-        onTextRun: wantOverlay ? (r) => runs.push(r) : undefined,
+        onTextRun: wantRuns ? (r) => runs.push(r) : undefined,
       });
       // Stale if EITHER (a) the epoch moved (a setScale rescaled mid-flight, so
       // this bitmap is at a superseded resolution — this catches the case where
@@ -1154,6 +1181,8 @@ export class PptxScrollViewer implements ZoomableViewer {
           );
         }
       }
+      if (wantRuns) this._refreshFindRuns(i, runs);
+      this._redrawSlotHighlights(i, slot);
       painted = true;
     } catch (err) {
       this._reportRenderError(err);
@@ -1543,7 +1572,8 @@ export class PptxScrollViewer implements ZoomableViewer {
     this._applyPageShadow(spare);
     const runs: PptxTextRunInfo[] = [];
     const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
-    const onTextRun = wantOverlay ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
+    const wantRuns = wantOverlay || this._findActive;
+    const onTextRun = wantRuns ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
     this._pres
       .renderSlide(spare, i, {
         width: widthPx,
@@ -1582,6 +1612,8 @@ export class PptxScrollViewer implements ZoomableViewer {
             buildPptxTextLayer(slot.textLayer, runs, Math.round(widthPx), Math.round(this._slideHeightPx()), this._hyperlinkHandler());
           }
         }
+        if (wantRuns) this._refreshFindRuns(i, runs);
+        this._redrawSlotHighlights(i, slot);
       })
       .catch((err: unknown) => {
         this._reportRenderError(err);
@@ -1608,7 +1640,8 @@ export class PptxScrollViewer implements ZoomableViewer {
     this._applyPageShadow(spare);
     const runs: PptxTextRunInfo[] = [];
     const wantOverlay = !!this._opts.enableTextSelection && !!slot.textLayer;
-    const onTextRun = wantOverlay ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
+    const wantRuns = wantOverlay || this._findActive;
+    const onTextRun = wantRuns ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
 
     this._pres
       .presentSlide(spare, i, { width: widthPx, dpr, onTextRun })
@@ -1647,6 +1680,8 @@ export class PptxScrollViewer implements ZoomableViewer {
             );
           }
         }
+        if (wantRuns) this._refreshFindRuns(i, runs);
+        this._redrawSlotHighlights(i, slot);
       })
       .catch((err: unknown) => {
         if (generation === slot.presentationGeneration) this._reportRenderError(err);
@@ -1696,6 +1731,88 @@ export class PptxScrollViewer implements ZoomableViewer {
       this._scrollHost.scrollTop = top;
     }
     this._mountVisible();
+  }
+
+  /** Search the complete presentation, including slides outside the
+   * virtualized mounted window. Matching is case-insensitive by default. */
+  async findText(
+    query: string,
+    opts: FindMatchesOptions = {},
+  ): Promise<FindMatch<PptxMatchLocation>[]> {
+    if (!this._pres) return [];
+    this._findActive = query.length > 0;
+    const matches = await this._find.find(query, opts);
+    this._redrawHighlights();
+    return matches;
+  }
+
+  /** Activate and reveal the next match, wrapping at the end. */
+  async findNext(): Promise<FindMatch<PptxMatchLocation> | null> {
+    return this._activateMatch(this._find.next());
+  }
+
+  /** Activate and reveal the previous match, wrapping at the beginning. */
+  async findPrev(): Promise<FindMatch<PptxMatchLocation> | null> {
+    return this._activateMatch(this._find.prev());
+  }
+
+  /** Clear the current query and every mounted highlight. */
+  clearFind(): void {
+    this._findActive = false;
+    this._find.invalidate();
+    this._redrawHighlights();
+  }
+
+  private async _activateMatch(
+    match: FindMatch<PptxMatchLocation> | null,
+  ): Promise<FindMatch<PptxMatchLocation> | null> {
+    if (match) this.scrollToSlide(match.location.slide);
+    this._redrawHighlights();
+    return match;
+  }
+
+  private async _collectSlideRuns(slide: number): Promise<PptxTextRunInfo[]> {
+    if (!this._pres) return [];
+    return this._pres.collectSlideRuns(slide, this._slideWidthPx());
+  }
+
+  private _redrawHighlights(): void {
+    for (const [slide, slot] of this._slots) this._redrawSlotHighlights(slide, slot);
+  }
+
+  private _refreshFindRuns(slide: number, runs: PptxTextRunInfo[]): void {
+    if (this._findActive) this._find.setSlideRuns(slide, runs);
+  }
+
+  private _redrawSlotHighlights(slide: number, slot: SlideSlot): void {
+    if (!this._findActive) {
+      slot.highlightLayer.innerHTML = '';
+      return;
+    }
+    const runs = this._find.slideRuns(slide);
+    if (!runs) {
+      slot.highlightLayer.innerHTML = '';
+      return;
+    }
+    buildPptxHighlightLayer(
+      slot.highlightLayer,
+      runs,
+      this._find.slideHighlights(slide),
+      this._slideWidthPx(),
+      this._slideHeightPx(),
+      (font) => this._measureForFind(font),
+    );
+  }
+
+  private _measureForFind(font: string): (text: string) => number {
+    if (this._findMeasureCtx === undefined) {
+      const canvas = document.createElement('canvas');
+      this._findMeasureCtx = canvas.getContext('2d');
+    }
+    const ctx = this._findMeasureCtx;
+    if (!ctx || typeof ctx.measureText !== 'function') return (text) => text.length;
+    ctx.font = font;
+    return (text) => ctx.measureText(text).width;
   }
 
   /**
@@ -1895,6 +2012,8 @@ export class PptxScrollViewer implements ZoomableViewer {
     // as superseded and its engine is cleaned up rather than installed onto a
     // torn-down viewer.
     this._loadGen++;
+    this._find.invalidate();
+    this._findActive = false;
     if (this._scrollListener) {
       this._scrollHost.removeEventListener('scroll', this._scrollListener);
       this._scrollListener = null;

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -19,6 +19,7 @@ A high-fidelity viewer for `.docx`, `.xlsx`, and `.pptx` files — powered by a 
 - **DOCX** — Continuous **scroll view** of every page with a transparent text layer (PDF.js-style) — drag to select, copy as plain text.
 - **XLSX** — Spreadsheet viewer with cell / row / column / range selection, tab-separated copy (Ctrl+C / Cmd+C), freeze-pane support, and a multi-sheet tab bar.
 - **PPTX** — Continuous **scroll view** of every slide with a transparent text layer that handles rotated text boxes correctly.
+- **Find in preview** — Press **Ctrl+F / Cmd+F** to search the complete document, workbook, or presentation. Matching is case-insensitive; Enter / Shift+Enter moves between results.
 - **High fidelity** — Charts, conditional formatting, theme colors, custom geometry shapes, math equations (OMML, via MathJax + STIX Two Math), and more rendered straight from the OOXML spec.
 - **MCP server (opt-in)** — Lets AI coding agents (Copilot, Claude, etc.) read `.xlsx` / `.docx` / `.pptx` files in your workspace through dedicated tools instead of unzipping XML by hand. See [MCP server for AI agents](#mcp-server-for-ai-agents) below.
 
@@ -34,6 +35,14 @@ If a different editor opens by default, right-click the file → **Reopen Editor
 
 - **DOCX / PPTX** — Drag across rendered text to select, then **Ctrl+C / Cmd+C** to copy as plain text. The transparent overlay matches the canvas glyph positions, so selection feels native. *(This dual-layer rendering is planned to be unified once the Canvas [`drawElement`](https://github.com/WICG/html-in-canvas) API ships across browsers.)*
 - **XLSX** — Click a cell to select it, drag for a range, click row/column headers for full-row/column selection, click the corner box for sheet-wide selection. **Ctrl+C / Cmd+C** copies as TSV.
+
+### Find
+
+Press **Ctrl+F / Cmd+F** inside any OOXML preview to open the search popup.
+Search is case-insensitive across the complete file, including pages or slides
+outside the currently rendered scroll window. Press **Enter** for the next match,
+**Shift+Enter** for the previous match, and **Escape** or the **×** button to
+close the popup and clear highlights.
 
 ## MCP server for AI agents
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -83,6 +83,11 @@
         "category": "OOXML Viewer"
       },
       {
+        "command": "ooxmlViewer.find",
+        "title": "Find in Preview",
+        "category": "OOXML Viewer"
+      },
+      {
         "command": "ooxmlViewer.installMcpServer",
         "title": "Install / Enable MCP Server",
         "category": "OOXML Viewer"
@@ -91,6 +96,14 @@
         "command": "ooxmlViewer.disableMcpServer",
         "title": "Disable MCP Server",
         "category": "OOXML Viewer"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "ooxmlViewer.find",
+        "key": "ctrl+f",
+        "mac": "cmd+f",
+        "when": "activeCustomEditorId == ooxmlViewer.docxEditor || activeCustomEditorId == ooxmlViewer.xlsxEditor || activeCustomEditorId == ooxmlViewer.pptxEditor"
       }
     ],
     "mcpServerDefinitionProviders": [

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { DocxEditorProvider } from './providers/docxEditor';
 import { XlsxEditorProvider } from './providers/xlsxEditor';
 import { PptxEditorProvider } from './providers/pptxEditor';
-import { refreshAllWebviews } from './providers/baseEditor';
+import { refreshAllWebviews, showFindInActiveWebview } from './providers/baseEditor';
 import { USE_GOOGLE_FONTS_CONFIG_ID } from './config';
 import { activateMcp } from './mcp';
 
@@ -11,6 +11,7 @@ export function activate(context: vscode.ExtensionContext): void {
     DocxEditorProvider.register(context),
     XlsxEditorProvider.register(context),
     PptxEditorProvider.register(context),
+    vscode.commands.registerCommand('ooxmlViewer.find', showFindInActiveWebview),
   );
 
   // The Google Fonts opt-in is baked into the webview CSP, so changing it (or

--- a/packages/vscode-extension/src/findContribution.test.ts
+++ b/packages/vscode-extension/src/findContribution.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+interface Manifest {
+  contributes: {
+    commands: Array<{ command: string }>;
+    keybindings: Array<{ command: string; key: string; mac?: string; when?: string }>;
+  };
+}
+
+const manifest = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as Manifest;
+
+describe('VS Code find contribution', () => {
+  it('routes Ctrl/Cmd+F only while an OOXML custom editor is active', () => {
+    expect(manifest.contributes.commands).toContainEqual(
+      expect.objectContaining({ command: 'ooxmlViewer.find' }),
+    );
+    expect(manifest.contributes.keybindings).toContainEqual({
+      command: 'ooxmlViewer.find',
+      key: 'ctrl+f',
+      mac: 'cmd+f',
+      when:
+        'activeCustomEditorId == ooxmlViewer.docxEditor || activeCustomEditorId == ooxmlViewer.xlsxEditor || activeCustomEditorId == ooxmlViewer.pptxEditor',
+    });
+  });
+});

--- a/packages/vscode-extension/src/providers/baseEditor.ts
+++ b/packages/vscode-extension/src/providers/baseEditor.ts
@@ -30,6 +30,13 @@ export function refreshAllWebviews(): void {
   }
 }
 
+/** Open the in-preview find popup in the active OOXML custom editor. */
+export async function showFindInActiveWebview(): Promise<void> {
+  const active = [...openViews].find((view) => view.panel.active);
+  if (!active) return;
+  await active.panel.webview.postMessage({ type: 'show-find' });
+}
+
 /** Set the webview HTML for a panel using the current effective flag. */
 function renderWebview(view: OpenView): void {
   view.panel.webview.html = getWebviewHtml(

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -24,6 +24,7 @@ import { PptxScrollViewer } from '@silurus/ooxml-pptx';
 import { svgExtents, type ZoomableViewer } from '@silurus/ooxml-core';
 import { loadAtNaturalScale } from './naturalScale';
 import { captureUnhandledWheelZoom } from './wheelZoomFallback';
+import { FindPopupController, type FindableViewer } from './findPopup';
 // Side-effect import: bundles the self-contained MathJax + STIX Two Math engine
 // into the webview and sets globalThis.__ooxmlStix2. The library renders OMML
 // equations only when handed a `math` engine; its built-in engine loads lazily
@@ -66,8 +67,22 @@ function updateZoomLabel(scale: number): void {
   zoomLabel.textContent = `${Math.round(scale * 100)}%`;
 }
 
-function bindZoomViewer(viewer: ZoomableViewer): void {
+const findPopup = new FindPopupController(
+  {
+    root: document.getElementById('find-popup')!,
+    input: document.getElementById('find-input') as HTMLInputElement,
+    status: document.getElementById('find-status')!,
+    previous: document.getElementById('find-previous') as HTMLButtonElement,
+    next: document.getElementById('find-next') as HTMLButtonElement,
+    close: document.getElementById('find-close') as HTMLButtonElement,
+  },
+  window,
+  (err) => showError(`Error: ${err instanceof Error ? err.message : String(err)}`),
+);
+
+function bindZoomViewer(viewer: ZoomableViewer & FindableViewer): void {
   activeViewer = viewer;
+  findPopup.setViewer(viewer);
   zoomOutButton.disabled = false;
   zoomInButton.disabled = false;
   updateZoomLabel(viewer.getScale());
@@ -108,6 +123,10 @@ vscodeApi.postMessage({ type: 'webview-ready' });
 
 window.addEventListener('message', async (event: MessageEvent) => {
   const msg = event.data;
+  if (msg.type === 'show-find') {
+    findPopup.open();
+    return;
+  }
   if (msg.type !== 'ooxml-init') return;
 
   // Opt-in flag forwarded from the extension host (gated by the

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -22,7 +22,7 @@ import { XlsxViewer, type CellRange } from '@silurus/ooxml-xlsx';
 import { DocxScrollViewer } from '@silurus/ooxml-docx';
 import { PptxScrollViewer } from '@silurus/ooxml-pptx';
 import { svgExtents, type ZoomableViewer } from '@silurus/ooxml-core';
-import { loadAtNaturalScale } from './naturalScale';
+import { loadAtContainerFit, loadAtNaturalScale } from './naturalScale';
 import { captureUnhandledWheelZoom } from './wheelZoomFallback';
 import { FindPopupController, type FindableViewer } from './findPopup';
 // Side-effect import: bundles the self-contained MathJax + STIX Two Math engine
@@ -220,7 +220,7 @@ async function initPptx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
     math,
     useGoogleFonts,
     enableTextSelection: true,
-    refitOnResize: false,
+    refitOnResize: true,
     background: 'var(--vscode-editor-background)',
     onScaleChange: updateZoomLabel,
     onError(err) {
@@ -228,7 +228,9 @@ async function initPptx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
       showError(`Error: ${err.message}`);
     },
   });
-  await loadAtNaturalScale(viewer, buffer);
+  // Presentations default to the available editor width. The viewer subtracts
+  // its built-in desk gutters, leaving a small margin without horizontal scroll.
+  await loadAtContainerFit(viewer, buffer);
   if (loadFailed) return;
   bindZoomViewer(viewer);
   hideStatus();

--- a/packages/vscode-extension/src/webview/findPopup.test.ts
+++ b/packages/vscode-extension/src/webview/findPopup.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  FindPopupController,
+  type FindableViewer,
+  type FindPopupElements,
+} from './findPopup.js';
+
+class FakeTarget {
+  private listeners = new Map<string, Array<(event: Event) => void>>();
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    const fn = typeof listener === 'function' ? listener : listener.handleEvent.bind(listener);
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), fn]);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    const current = this.listeners.get(type) ?? [];
+    this.listeners.set(type, current.filter((fn) => fn !== listener));
+  }
+
+  dispatch(type: string, event: Event): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+function button(): HTMLButtonElement & FakeTarget {
+  return Object.assign(new FakeTarget(), { disabled: false }) as HTMLButtonElement & FakeTarget;
+}
+
+function setup() {
+  const keyTarget = new FakeTarget();
+  const input = Object.assign(new FakeTarget(), {
+    value: '',
+    focus: vi.fn(),
+    select: vi.fn(),
+  }) as unknown as HTMLInputElement & FakeTarget;
+  const elements = {
+    root: { hidden: true },
+    input,
+    status: { textContent: '' },
+    previous: button(),
+    next: button(),
+    close: button(),
+  } as unknown as FindPopupElements;
+  const viewer: FindableViewer = {
+    findText: vi.fn(async () => [{ matchIndex: 0 }, { matchIndex: 1 }]),
+    findNext: vi
+      .fn()
+      .mockResolvedValueOnce({ matchIndex: 0 })
+      .mockResolvedValueOnce({ matchIndex: 1 }),
+    findPrev: vi.fn(async () => ({ matchIndex: 0 })),
+    clearFind: vi.fn(),
+  };
+  const controller = new FindPopupController(elements, keyTarget);
+  controller.setViewer(viewer);
+  return { controller, elements, input, keyTarget, viewer };
+}
+
+function key(key: string, init: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  return {
+    key,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    ...init,
+  } as unknown as KeyboardEvent;
+}
+
+async function flushController(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('VS Code find popup', () => {
+  it.each([
+    { ctrlKey: true },
+    { metaKey: true },
+  ])('opens for Ctrl/Cmd+F and focuses the query', (modifier) => {
+    const { elements, input, keyTarget } = setup();
+    const event = key('f', modifier);
+
+    keyTarget.dispatch('keydown', event);
+
+    expect(elements.root.hidden).toBe(false);
+    expect(input.focus).toHaveBeenCalledOnce();
+    expect(input.select).toHaveBeenCalledOnce();
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it('searches case-insensitively and Enter/Shift+Enter navigate', async () => {
+    const { controller, elements, input, keyTarget, viewer } = setup();
+    controller.open();
+    input.value = 'ALPHA';
+
+    await controller.search();
+    expect(viewer.findText).toHaveBeenCalledWith('ALPHA', { caseSensitive: false });
+    expect(elements.status.textContent).toBe('1 of 2');
+
+    keyTarget.dispatch('keydown', key('Enter'));
+    await flushController();
+    expect(viewer.findNext).toHaveBeenCalledTimes(2);
+
+    keyTarget.dispatch('keydown', key('Enter', { shiftKey: true }));
+    await flushController();
+    expect(viewer.findPrev).toHaveBeenCalledOnce();
+  });
+
+  it.each(['previous', 'next', 'close'] as const)(
+    'leaves Enter on the %s button to native button activation',
+    async (buttonName) => {
+      const { controller, elements, input, keyTarget, viewer } = setup();
+      controller.open();
+      input.value = 'ALPHA';
+      await controller.search();
+      const event = key('Enter', { target: elements[buttonName] });
+
+      keyTarget.dispatch('keydown', event);
+      await flushController();
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(event.stopPropagation).not.toHaveBeenCalled();
+      expect(viewer.findNext).toHaveBeenCalledTimes(1);
+      expect(viewer.findPrev).not.toHaveBeenCalled();
+      expect(elements.root.hidden).toBe(false);
+    },
+  );
+
+  it.each(['Escape', 'close'])('closes with %s and clears highlights', (action) => {
+    const { controller, elements, keyTarget, viewer } = setup();
+    controller.open();
+
+    if (action === 'Escape') keyTarget.dispatch('keydown', key('Escape'));
+    else (elements.close as unknown as FakeTarget).dispatch('click', {} as Event);
+
+    expect(elements.root.hidden).toBe(true);
+    expect(viewer.clearFind).toHaveBeenCalled();
+  });
+
+  it('reports an empty result set and disables navigation', async () => {
+    const { controller, elements, input, viewer } = setup();
+    vi.mocked(viewer.findText).mockResolvedValueOnce([]);
+    controller.open();
+    input.value = 'missing';
+
+    await controller.search();
+
+    expect(elements.status.textContent).toBe('No results');
+    expect(elements.previous.disabled).toBe(true);
+    expect(elements.next.disabled).toBe(true);
+  });
+});

--- a/packages/vscode-extension/src/webview/findPopup.ts
+++ b/packages/vscode-extension/src/webview/findPopup.ts
@@ -1,0 +1,195 @@
+export interface FindResult {
+  matchIndex: number;
+}
+
+/** Search surface shared by DOCX, PPTX, and XLSX viewers. */
+export interface FindableViewer {
+  findText(
+    query: string,
+    opts?: { caseSensitive?: boolean },
+  ): Promise<FindResult[]>;
+  findNext(): Promise<FindResult | null>;
+  findPrev(): Promise<FindResult | null>;
+  clearFind(): void;
+}
+
+export interface FindPopupElements {
+  root: HTMLElement;
+  input: HTMLInputElement;
+  status: HTMLElement;
+  previous: HTMLButtonElement;
+  next: HTMLButtonElement;
+  close: HTMLButtonElement;
+}
+
+type KeyTarget = Pick<EventTarget, 'addEventListener' | 'removeEventListener'>;
+
+/**
+ * VS Code webviews do not expose the editor's native find widget to custom
+ * editors. This controller supplies browser-style find semantics over the
+ * viewers' format-aware search APIs.
+ */
+export class FindPopupController {
+  private viewer: FindableViewer | null = null;
+  private request = 0;
+  private total = 0;
+  private chain: Promise<void> = Promise.resolve();
+  private readonly onInput = () => {
+    void this.search();
+  };
+  private readonly onPrevious = () => {
+    void this.navigate(true);
+  };
+  private readonly onNext = () => {
+    void this.navigate(false);
+  };
+  private readonly onClose = () => this.close();
+  private readonly onKeyDown = (event: Event) => {
+    this.handleKeyDown(event as KeyboardEvent);
+  };
+
+  constructor(
+    private readonly elements: FindPopupElements,
+    private readonly keyTarget: KeyTarget,
+    private readonly onError: (error: unknown) => void = () => {},
+  ) {
+    elements.input.addEventListener('input', this.onInput);
+    elements.previous.addEventListener('click', this.onPrevious);
+    elements.next.addEventListener('click', this.onNext);
+    elements.close.addEventListener('click', this.onClose);
+    keyTarget.addEventListener('keydown', this.onKeyDown, true);
+    this.updateStatus();
+  }
+
+  setViewer(viewer: FindableViewer | null): void {
+    if (viewer === this.viewer) return;
+    this.viewer?.clearFind();
+    this.viewer = viewer;
+    this.request++;
+    this.total = 0;
+    this.updateStatus();
+    if (!this.elements.root.hidden && this.elements.input.value.length > 0) {
+      void this.search();
+    }
+  }
+
+  open(): void {
+    const wasHidden = this.elements.root.hidden;
+    this.elements.root.hidden = false;
+    this.elements.input.focus();
+    this.elements.input.select();
+    if (wasHidden && this.elements.input.value.length > 0) void this.search();
+  }
+
+  close(): void {
+    if (this.elements.root.hidden) return;
+    this.elements.root.hidden = true;
+    this.request++;
+    this.total = 0;
+    this.viewer?.clearFind();
+    this.updateStatus();
+  }
+
+  search(): Promise<void> {
+    const request = ++this.request;
+    const viewer = this.viewer;
+    const query = this.elements.input.value;
+    return this.enqueue(async () => {
+      if (request !== this.request) return;
+      if (!viewer || query.length === 0) {
+        viewer?.clearFind();
+        this.total = 0;
+        this.updateStatus();
+        return;
+      }
+
+      // Explicitly request case-insensitive matching for all three formats.
+      const matches = await viewer.findText(query, { caseSensitive: false });
+      if (request !== this.request || viewer !== this.viewer) {
+        if (this.elements.root.hidden && viewer === this.viewer) viewer.clearFind();
+        return;
+      }
+      this.total = matches.length;
+      if (this.total === 0) {
+        this.updateStatus();
+        return;
+      }
+      const active = await viewer.findNext();
+      if (request !== this.request || viewer !== this.viewer) return;
+      this.updateStatus(active?.matchIndex ?? 0);
+    });
+  }
+
+  navigate(previous: boolean): Promise<void> {
+    const request = this.request;
+    const viewer = this.viewer;
+    return this.enqueue(async () => {
+      if (
+        request !== this.request ||
+        !viewer ||
+        viewer !== this.viewer ||
+        this.total === 0
+      ) return;
+      const active = previous ? await viewer.findPrev() : await viewer.findNext();
+      if (request !== this.request || viewer !== this.viewer) return;
+      this.updateStatus(active?.matchIndex ?? -1);
+    });
+  }
+
+  dispose(): void {
+    this.close();
+    this.elements.input.removeEventListener('input', this.onInput);
+    this.elements.previous.removeEventListener('click', this.onPrevious);
+    this.elements.next.removeEventListener('click', this.onNext);
+    this.elements.close.removeEventListener('click', this.onClose);
+    this.keyTarget.removeEventListener('keydown', this.onKeyDown, true);
+    this.viewer = null;
+  }
+
+  private handleKeyDown(event: KeyboardEvent): void {
+    const key = event.key.toLowerCase();
+    if ((event.ctrlKey || event.metaKey) && !event.altKey && key === 'f') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.open();
+      return;
+    }
+    if (this.elements.root.hidden) return;
+    if (key === 'escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.close();
+      return;
+    }
+    if (key === 'enter') {
+      const target = event.target;
+      if (
+        target === this.elements.previous ||
+        target === this.elements.next ||
+        target === this.elements.close
+      ) return;
+      event.preventDefault();
+      event.stopPropagation();
+      void this.navigate(event.shiftKey);
+    }
+  }
+
+  private enqueue(task: () => Promise<void>): Promise<void> {
+    const result = this.chain.then(task);
+    this.chain = result.catch(this.onError);
+    return result;
+  }
+
+  private updateStatus(activeIndex = -1): void {
+    this.elements.previous.disabled = this.total === 0;
+    this.elements.next.disabled = this.total === 0;
+    if (this.elements.input.value.length === 0) {
+      this.elements.status.textContent = '';
+    } else if (this.total === 0) {
+      this.elements.status.textContent = 'No results';
+    } else {
+      const current = Math.min(this.total, Math.max(1, activeIndex + 1));
+      this.elements.status.textContent = `${current} of ${this.total}`;
+    }
+  }
+}

--- a/packages/vscode-extension/src/webview/naturalScale.test.ts
+++ b/packages/vscode-extension/src/webview/naturalScale.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { loadAtNaturalScale } from './naturalScale';
+import { loadAtContainerFit, loadAtNaturalScale } from './naturalScale';
 
 describe('loadAtNaturalScale', () => {
   it('latches absolute 100% before loading instead of fitting to the view width', async () => {
@@ -19,5 +19,20 @@ describe('loadAtNaturalScale', () => {
 
     expect(viewer.setScale).toHaveBeenCalledWith(1);
     expect(calls).toEqual(['scale:1', 'load']);
+  });
+
+  it('leaves the scale unlatched when loading a presentation to fit its container', async () => {
+    const buffer = new ArrayBuffer(4);
+    const viewer = {
+      setScale: vi.fn(),
+      load: vi.fn(async (source: string | ArrayBuffer) => {
+        expect(source).toBe(buffer);
+      }),
+    };
+
+    await loadAtContainerFit(viewer, buffer);
+
+    expect(viewer.setScale).not.toHaveBeenCalled();
+    expect(viewer.load).toHaveBeenCalledOnce();
   });
 });

--- a/packages/vscode-extension/src/webview/naturalScale.ts
+++ b/packages/vscode-extension/src/webview/naturalScale.ts
@@ -24,3 +24,14 @@ export async function loadAtNaturalScale(
   viewer.setScale(NATURAL_DOCUMENT_SCALE);
   await viewer.load(source);
 }
+
+/**
+ * Load without latching an absolute scale. The ScrollViewer therefore uses its
+ * container-derived fit width, including its built-in left/right desk gutters.
+ */
+export async function loadAtContainerFit(
+  viewer: Pick<LoadableScrollViewer, 'load'>,
+  source: string | ArrayBuffer,
+): Promise<void> {
+  await viewer.load(source);
+}

--- a/packages/vscode-extension/src/webviewHtml.test.ts
+++ b/packages/vscode-extension/src/webviewHtml.test.ts
@@ -70,4 +70,24 @@ describe('getWebviewHtml', () => {
       expect(html).toContain('id="zoom-label"');
     },
   );
+
+  it.each(['docx', 'xlsx', 'pptx'] as const)(
+    'includes the shared find popup for %s',
+    (fileType) => {
+      const html = getWebviewHtml(
+        {
+          cspSource: CSP_SOURCE,
+          asWebviewUri: () => 'vscode-webview://extension/dist/webview.js',
+        } as never,
+        {} as never,
+        fileType,
+      );
+
+      expect(html).toContain('id="find-popup"');
+      expect(html).toContain('id="find-input"');
+      expect(html).toContain('aria-label="Previous match"');
+      expect(html).toContain('aria-label="Next match"');
+      expect(html).toContain('id="find-close"');
+    },
+  );
 });

--- a/packages/vscode-extension/src/webviewHtml.ts
+++ b/packages/vscode-extension/src/webviewHtml.ts
@@ -85,6 +85,7 @@ export function getWebviewHtml(
       font-family: var(--vscode-font-family, sans-serif);
     }
     #viewer-root {
+      position: relative;
       width: 100%;
       height: 100%;
       min-height: 0;
@@ -138,6 +139,65 @@ export function getWebviewHtml(
       flex: 1 1 auto;
       overflow: hidden;
     }
+    #find-popup {
+      position: absolute;
+      z-index: 20;
+      top: 43px;
+      right: 12px;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 6px;
+      border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+      border-radius: 4px;
+      background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+      color: var(--vscode-editorWidget-foreground, var(--vscode-foreground));
+      box-shadow: 0 2px 8px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.35));
+    }
+    #find-popup[hidden] {
+      display: none;
+    }
+    #find-input {
+      width: min(240px, 42vw);
+      height: 24px;
+      padding: 2px 6px;
+      border: 1px solid var(--vscode-input-border, transparent);
+      outline: none;
+      background: var(--vscode-input-background);
+      color: var(--vscode-input-foreground);
+      font: 12px/1.4 var(--vscode-font-family, sans-serif);
+    }
+    #find-input:focus {
+      border-color: var(--vscode-focusBorder);
+    }
+    #find-status {
+      min-width: 70px;
+      text-align: center;
+      white-space: nowrap;
+      font-size: 12px;
+      font-variant-numeric: tabular-nums;
+    }
+    #find-popup button {
+      width: 24px;
+      height: 24px;
+      border: 1px solid transparent;
+      border-radius: 3px;
+      color: inherit;
+      background: transparent;
+      font: 14px/1 var(--vscode-font-family, sans-serif);
+      cursor: pointer;
+    }
+    #find-popup button:hover:not(:disabled) {
+      background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.2));
+    }
+    #find-popup button:focus-visible {
+      outline: 1px solid var(--vscode-focusBorder);
+      outline-offset: -1px;
+    }
+    #find-popup button:disabled {
+      cursor: default;
+      opacity: 0.4;
+    }
     #status {
       position: absolute;
       inset: 0;
@@ -171,6 +231,13 @@ export function getWebviewHtml(
       <button id="zoom-out" type="button" aria-label="Zoom out" title="Zoom out" disabled>−</button>
       <span id="zoom-label" aria-live="polite">100%</span>
       <button id="zoom-in" type="button" aria-label="Zoom in" title="Zoom in" disabled>+</button>
+    </div>
+    <div id="find-popup" role="dialog" aria-label="Find" hidden>
+      <input id="find-input" type="text" aria-label="Find" placeholder="Find" autocomplete="off" spellcheck="false" />
+      <span id="find-status" aria-live="polite"></span>
+      <button id="find-previous" type="button" aria-label="Previous match" title="Previous match (Shift+Enter)" disabled>↑</button>
+      <button id="find-next" type="button" aria-label="Next match" title="Next match (Enter)" disabled>↓</button>
+      <button id="find-close" type="button" aria-label="Close find" title="Close (Escape)">×</button>
     </div>
     <div id="viewer-container">
       <div id="status"><div class="spinner"></div></div>

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -141,6 +141,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       methods: [
         { sig: 'load(source: string | ArrayBuffer): Promise<void>', desc: 'Load a deck from a URL or ArrayBuffer and render the first window. Throws when an engine was injected via `presentation`.' },
         { sig: 'scrollToSlide(index: number, opts?: { behavior?: "auto" | "smooth" }): void', desc: 'Scroll so slide index’s top edge sits at the viewport top (index clamped).' },
+        ...findMethods('PptxMatchLocation'),
         { sig: 'setScale(scale: number): void', desc: 'Set the absolute zoom scale at runtime (clamped to zoomMin/zoomMax). Flicker-free. View-only.' },
         { sig: 'relayout(): void', desc: 'Force a re-fit + re-mount of the visible window. Called automatically after load / resize / zoom; use it when the container resizes in a way a ResizeObserver cannot observe (e.g. a late web-font load). Idempotent.' },
         { sig: 'get slideCount(): number', desc: 'Total slides (0 until loaded).' },
@@ -228,6 +229,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       methods: [
         { sig: 'load(source: string | ArrayBuffer): Promise<void>', desc: 'Load a document from a URL or ArrayBuffer and render the first window. Throws when an engine was injected via `document`.' },
         { sig: 'scrollToPage(index: number, opts?: { behavior?: "auto" | "smooth" }): void', desc: 'Scroll so page index’s top edge sits at the viewport top (index clamped).' },
+        ...findMethods('DocxMatchLocation'),
         { sig: 'setScale(scale: number): void', desc: 'Set the absolute zoom scale at runtime (clamped to zoomMin/zoomMax). Flicker-free. View-only.' },
         { sig: 'relayout(): void', desc: 'Force a re-fit + re-mount of the visible window. Called automatically after load / resize / zoom; use it when the container resizes in a way a ResizeObserver cannot observe (e.g. a late web-font load). Idempotent.' },
         { sig: 'get pageCount(): number', desc: 'Total pages (0 until loaded).' },


### PR DESCRIPTION
## Summary

- register Ctrl/Cmd+F for DOCX, XLSX, and PPTX custom editors
- show a VS Code-themed find popup with case-insensitive search, result counts, next/previous navigation, and Escape/close dismissal
- expose full-document search through virtualized DOCX and PPTX ScrollViewers, including offscreen pages/slides
- preserve highlight geometry across zoom and guard pending searches across newer queries, reload, clear, and destroy
- keep native keyboard activation for the popup buttons
- keep DOCX at natural scale while fitting PPTX to the preview width with built-in side gutters and resize refitting

## Verification

- focused Vitest on clean main: 262 tests passed; presentation-fit tests: 20 passed
- full Vitest: 5,884 passed, 25 skipped (implementation review)
- TypeScript typecheck/build
- DOCX public API and architecture gates
- DOCX/PPTX package builds
- production VS Code bundle and local VSIX packaging/install
- Astro build
- `git diff --check`

Independent GPT-5.6 Sol review: approved after async zoom, lifecycle, and keyboard findings were resolved.

This PR remains draft pending local maintainer inspection of the VSIX.