### PR TITLE
feat: bound aggregate OOXML archive inflation

### DIFF
--- a/packages/docx/parser/src/lib.rs
+++ b/packages/docx/parser/src/lib.rs
@@ -1,3 +1,4 @@
+use std::io::Cursor;
 use wasm_bindgen::prelude::*;
 
 mod drawing_compatibility;
@@ -17,9 +18,16 @@ mod xml_util;
 /// thread does a single `TextDecoder.decode` + `JSON.parse`, collapsing three
 /// serializations (Rust String → JsString → structured clone) into one decode.
 #[wasm_bindgen]
-pub fn parse_docx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u8>, JsValue> {
+pub fn parse_docx(
+    data: &[u8],
+    max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
+) -> Result<Vec<u8>, JsValue> {
     console_error_panic_hook::set_once();
-    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
+    let _guard =
+        ooxml_common::zip::scoped_limits(max_zip_entry_bytes, max_zip_total_bytes, max_zip_entries);
+    validate_zip_budget(data).map_err(|e| JsValue::from_str(&format!("docx-parser error: {e}")))?;
     let doc = parser::parse_from_bytes(data)
         .map_err(|e| JsValue::from_str(&format!("docx-parser error: {e}")))?;
     serde_json::to_vec(&doc).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
@@ -29,9 +37,16 @@ pub fn parse_docx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u
 /// GitHub-flavoured markdown of headings / paragraphs / tables / footnotes,
 /// discarding positioning, section properties, fonts, and drawing shapes.
 #[wasm_bindgen]
-pub fn docx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
+pub fn docx_to_markdown(
+    data: &[u8],
+    max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
+) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
-    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
+    let _guard =
+        ooxml_common::zip::scoped_limits(max_zip_entry_bytes, max_zip_total_bytes, max_zip_entries);
+    validate_zip_budget(data).map_err(|e| JsValue::from_str(&e))?;
     let doc = parser::parse_from_bytes(data).map_err(|e| JsValue::from_str(&e))?;
     Ok(markdown::render_document(&doc))
 }
@@ -45,9 +60,17 @@ pub fn extract_image(
     data: &[u8],
     path: &str,
     max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
 ) -> Result<Vec<u8>, JsValue> {
-    ooxml_common::zip::extract_zip_entry(data, path, max_zip_entry_bytes)
-        .map_err(|e| JsValue::from_str(&e))
+    ooxml_common::zip::extract_zip_entry_with_limits(
+        data,
+        path,
+        max_zip_entry_bytes,
+        max_zip_total_bytes,
+        max_zip_entries,
+    )
+    .map_err(|e| JsValue::from_str(&e))
 }
 
 /// A stateful handle over an opened docx archive.
@@ -61,7 +84,7 @@ pub fn extract_image(
 /// self-contained (it owns its bytes and holds no borrow into the input), which
 /// is what lets it live in a `#[wasm_bindgen]` struct field.
 ///
-/// The retained `max` mirrors the per-call `scoped_max` guard the free functions
+/// The retained budget mirrors the per-call ZIP guard the free functions
 /// install: every method re-installs it for its own scope so the zip-bomb entry
 /// cap is honored identically whether callers use the handle or the free
 /// functions.
@@ -73,13 +96,13 @@ pub struct DocxArchive {
     /// document (symmetric with a corrupt inner part) rather than the constructor
     /// throwing an opaque error the viewer can't turn into a placeholder page.
     archive: Result<parser::Zip, String>,
-    max: Option<u64>,
+    budget: ooxml_common::zip::ZipBudget,
 }
 
 #[wasm_bindgen]
 impl DocxArchive {
     /// Copy `data` into WASM once and open the ZIP central directory once.
-    /// `max_zip_entry_bytes` is retained and applied on every subsequent method
+    /// ZIP limits are retained and applied on every subsequent method
     /// call (identical semantics to the free functions' `scoped_max` guard).
     ///
     /// `data` is taken by value (`Vec<u8>`): wasm-bindgen copies the JS `Uint8Array`
@@ -89,15 +112,32 @@ impl DocxArchive {
     /// the `Cursor` could own its backing store, transiently doubling WASM
     /// linear memory to ~2x the file size during construction.
     #[wasm_bindgen(constructor)]
-    pub fn new(data: Vec<u8>, max_zip_entry_bytes: Option<u64>) -> Result<DocxArchive, JsValue> {
+    pub fn new(
+        data: Vec<u8>,
+        max_zip_entry_bytes: Option<u64>,
+        max_zip_total_bytes: Option<u64>,
+        max_zip_entries: Option<u64>,
+    ) -> Result<DocxArchive, JsValue> {
         console_error_panic_hook::set_once();
         // RB7 (MAJOR): a truncated / corrupt CONTAINER is deferred, not thrown, so
         // `parse()` can degrade it to a placeholder document instead of the
         // constructor failing with an opaque error.
-        Ok(DocxArchive {
-            archive: parser::open_zip(data),
-            max: max_zip_entry_bytes,
-        })
+        let budget = ooxml_common::zip::ZipBudget::new(
+            max_zip_entry_bytes,
+            max_zip_total_bytes,
+            max_zip_entries,
+        );
+        let _guard = ooxml_common::zip::scoped_budget(&budget);
+        let archive = parser::open_zip(data).and_then(|mut archive| {
+            ooxml_common::zip::validate_archive_limits(&mut archive)?;
+            Ok(archive)
+        });
+        if let Err(error) = &archive {
+            if error.starts_with("ZIP archive exceeds") {
+                return Err(JsValue::from_str(error));
+            }
+        }
+        Ok(DocxArchive { archive, budget })
     }
 
     /// Parse the retained archive and return the model as UTF-8 JSON bytes.
@@ -105,7 +145,7 @@ impl DocxArchive {
     /// same serializer, same error strings. When the CONTAINER failed to open
     /// (RB7 MAJOR) the model is a degraded placeholder tagged with the container.
     pub fn parse(&mut self) -> Result<Vec<u8>, JsValue> {
-        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let _guard = ooxml_common::zip::scoped_budget(&self.budget);
         let doc = match self.archive.as_mut() {
             Ok(zip) => parser::parse(zip)
                 .map_err(|e| JsValue::from_str(&format!("docx-parser error: {e}")))?,
@@ -119,7 +159,7 @@ impl DocxArchive {
     /// through the already-open archive instead of re-opening it. A corrupt
     /// container has no entries, so this surfaces the container-open error.
     pub fn extract_image(&mut self, path: &str) -> Result<Vec<u8>, JsValue> {
-        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let _guard = ooxml_common::zip::scoped_budget(&self.budget);
         let zip = self
             .archive
             .as_mut()
@@ -130,7 +170,7 @@ impl DocxArchive {
     /// GitHub-flavoured markdown projection of the retained archive. Mirrors the
     /// free `docx_to_markdown`. A corrupt container degrades to an empty document.
     pub fn to_markdown(&mut self) -> Result<String, JsValue> {
-        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let _guard = ooxml_common::zip::scoped_budget(&self.budget);
         let doc = match self.archive.as_mut() {
             Ok(zip) => parser::parse(zip).map_err(|e| JsValue::from_str(&e))?,
             Err(e) => parser::degraded_container_document(e.clone()),
@@ -142,6 +182,8 @@ impl DocxArchive {
 /// Native equivalent of `parse_docx` for use from the MCP server.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn parse_docx_native(data: &[u8]) -> Result<String, String> {
+    let _guard = ooxml_common::zip::scoped_limits(None, None, None);
+    validate_zip_budget(data)?;
     parser::parse_from_bytes(data)
         .and_then(|doc| serde_json::to_string(&doc).map_err(|e| e.to_string()))
 }
@@ -154,8 +196,20 @@ pub fn parse_docx_native(data: &[u8]) -> Result<String, String> {
 /// section properties, font metrics, drawing shapes.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn to_markdown_native(data: &[u8]) -> Result<String, String> {
+    let _guard = ooxml_common::zip::scoped_limits(None, None, None);
+    validate_zip_budget(data)?;
     let doc = parser::parse_from_bytes(data)?;
     Ok(markdown::render_document(&doc))
+}
+
+fn validate_zip_budget(data: &[u8]) -> Result<(), String> {
+    // Preserve the established degraded-container path for malformed ZIPs; a
+    // readable central directory is required before a declared-budget violation
+    // can be proven.
+    let Ok(mut archive) = zip::ZipArchive::new(Cursor::new(data)) else {
+        return Ok(());
+    };
+    ooxml_common::zip::validate_archive_limits(&mut archive)
 }
 
 #[cfg(test)]
@@ -173,7 +227,10 @@ mod tests {
             w.write_all(b"X").unwrap();
             w.finish().unwrap();
         }
-        assert_eq!(extract_image(&buf, "word/media/i.png", None).unwrap(), b"X");
+        assert_eq!(
+            extract_image(&buf, "word/media/i.png", None, None, None).unwrap(),
+            b"X"
+        );
     }
 
     /// The docx JSON path never hand-assembles `{"error":"…"}` — a message with a

--- a/packages/docx/src/document.ts
+++ b/packages/docx/src/document.ts
@@ -41,6 +41,10 @@ import { textRunsForSelectedPage } from './text-run-projection.js';
  *  from `@silurus/ooxml-core` (`useGoogleFonts`, `maxZipEntryBytes`) with the
  *  opt-in math engine. */
 export interface LoadOptions extends CoreLoadOptions {
+  /** Maximum decompressed bytes across distinct ZIP entries (default: 512 MiB). */
+  maxZipTotalBytes?: number;
+  /** Maximum ZIP central-directory entries (default: 20,000). */
+  maxZipEntries?: number;
   /**
    * Opt-in OMML equation engine. Import it from the separate `@silurus/ooxml/math`
    * entry and pass it in: `import { math } from '@silurus/ooxml/math'`. When
@@ -169,6 +173,8 @@ export class DocxDocument {
       await doc._parse(
         buffer,
         opts.maxZipEntryBytes,
+        opts.maxZipTotalBytes,
+        opts.maxZipEntries,
         mode === 'worker' ? !!opts.useGoogleFonts : false,
         opts.workerTimeoutMs,
       );
@@ -238,14 +244,16 @@ export class DocxDocument {
   private async _parse(
     buffer: ArrayBuffer,
     maxZipEntryBytes?: number,
+    maxZipTotalBytes?: number,
+    maxZipEntries?: number,
     useGoogleFonts = false,
     timeoutMs?: number,
   ): Promise<void> {
     const res = await this._bridge.request(
       (id) =>
         this._mode === 'worker'
-          ? ({ type: 'parse', id, data: buffer, maxZipEntryBytes, useGoogleFonts, defaultCurrentDateMs: documentLayoutRuntimeOf(this).defaultCurrentDateMs } satisfies RenderWorkerRequest)
-          : ({ type: 'parse', id, data: buffer, maxZipEntryBytes } satisfies WorkerRequest),
+          ? ({ type: 'parse', id, data: buffer, maxZipEntryBytes, maxZipTotalBytes, maxZipEntries, useGoogleFonts, defaultCurrentDateMs: documentLayoutRuntimeOf(this).defaultCurrentDateMs } satisfies RenderWorkerRequest)
+          : ({ type: 'parse', id, data: buffer, maxZipEntryBytes, maxZipTotalBytes, maxZipEntries } satisfies WorkerRequest),
       [buffer],
       { timeoutMs },
     );

--- a/packages/docx/src/render-worker.ts
+++ b/packages/docx/src/render-worker.ts
@@ -97,6 +97,14 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
+      const maxTotal =
+        typeof req.maxZipTotalBytes === 'number' && req.maxZipTotalBytes > 0
+          ? BigInt(req.maxZipTotalBytes)
+          : undefined;
+      const maxEntries =
+        typeof req.maxZipEntries === 'number' && req.maxZipEntries > 0
+          ? BigInt(req.maxZipEntries)
+          : undefined;
       const bytes = new Uint8Array(req.data);
       // Construction + `parse()` run under `host.run` so a trap in EITHER poisons
       // + recycles the instance (and frees the archive). `setArchive` frees any
@@ -106,7 +114,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
       // the model in-worker, so decode + parse it here (one decode, no
       // passthrough).
       const parsedModel = host.run(() => {
-        const archive = new DocxArchive(bytes, max);
+        const archive = new DocxArchive(bytes, max, maxTotal, maxEntries);
         host.setArchive(archive);
         return JSON.parse(new TextDecoder().decode(archive.parse())) as DocxDocumentModel;
       });

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -426,6 +426,8 @@ export class DocxScrollViewer implements ZoomableViewer {
       const doc = await DocxDocument.load(source, {
         useGoogleFonts: this._opts.useGoogleFonts,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
+        maxZipTotalBytes: this._opts.maxZipTotalBytes,
+        maxZipEntries: this._opts.maxZipEntries,
         workerTimeoutMs: this._opts.workerTimeoutMs,
         wasmUrl: this._opts.wasmUrl,
         math: this._opts.math,

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -1499,7 +1499,7 @@ export interface CellBorders {
 
 export type WorkerRequest =
   | { type: 'init'; wasmUrl: string }
-  | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number }
+  | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number; maxZipTotalBytes?: number; maxZipEntries?: number }
   | { type: 'extractImage'; id: number; path: string }
   // Project the retained archive to GitHub-flavoured markdown (`DocxArchive.to_markdown`,
   // the handle already opened at `parse` — no re-copy of the file). Twin of

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -191,6 +191,8 @@ export class DocxViewer implements ZoomableViewer {
       const doc = await DocxDocument.load(source, {
         useGoogleFonts: this._opts.useGoogleFonts,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
+        maxZipTotalBytes: this._opts.maxZipTotalBytes,
+        maxZipEntries: this._opts.maxZipEntries,
         workerTimeoutMs: this._opts.workerTimeoutMs,
         wasmUrl: this._opts.wasmUrl,
         math: this._opts.math,

--- a/packages/docx/src/worker-protocol.ts
+++ b/packages/docx/src/worker-protocol.ts
@@ -31,7 +31,7 @@ export type WireRenderPageOptions = Omit<RenderPageOptions, 'onTextRun'>;
 // `init` arm is copied verbatim from `WorkerRequest`.
 export type RenderWorkerRequest =
   | { type: 'init'; wasmUrl: string }
-  | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number; useGoogleFonts?: boolean; defaultCurrentDateMs: number }
+  | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number; maxZipTotalBytes?: number; maxZipEntries?: number; useGoogleFonts?: boolean; defaultCurrentDateMs: number }
   | { type: 'renderPage'; id: number; pageIndex: number; opts: WireRenderPageOptions }
   // IX6 — collect a page's text-run geometry WITHOUT transferring a bitmap. The
   // find controller scans every page for its runs; a bitmap per page would be

--- a/packages/docx/src/worker.ts
+++ b/packages/docx/src/worker.ts
@@ -41,6 +41,14 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
+      const maxTotal =
+        typeof req.maxZipTotalBytes === 'number' && req.maxZipTotalBytes > 0
+          ? BigInt(req.maxZipTotalBytes)
+          : undefined;
+      const maxEntries =
+        typeof req.maxZipEntries === 'number' && req.maxZipEntries > 0
+          ? BigInt(req.maxZipEntries)
+          : undefined;
       const bytes = new Uint8Array(req.data);
       // Both the construction and `parse()` run under `host.run` so a trap in
       // EITHER poisons + recycles the instance (and frees the archive). Adopting
@@ -52,7 +60,7 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
       // forward it to the main thread as a transferable — no clone, no decode
       // here. The single decode + JSON.parse happens once, on the main thread.
       const json = host.run(() => {
-        const archive = new DocxArchive(bytes, max);
+        const archive = new DocxArchive(bytes, max, maxTotal, maxEntries);
         host.setArchive(archive);
         return archive.parse();
       });

--- a/packages/docx/src/zip-budget-options.test.ts
+++ b/packages/docx/src/zip-budget-options.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DocxDocument } from './document.js';
+import { attachDocumentLayoutRuntime } from './layout/runtime-state.js';
+
+describe('DocxDocument ZIP budget wiring', () => {
+  it('forwards aggregate and entry-count limits to worker parsing', async () => {
+    let request: Record<string, unknown> | undefined;
+    const instance = Object.create(DocxDocument.prototype) as Record<string, unknown>;
+    attachDocumentLayoutRuntime(instance, 0);
+    instance._mode = 'worker';
+    instance._bridge = {
+      request: vi.fn(async (createRequest: (id: number) => Record<string, unknown>) => {
+        request = createRequest(7);
+        return { type: 'parsedMeta', id: 7, meta: {} };
+      }),
+    };
+
+    await (
+      instance as unknown as {
+        _parse(
+          data: ArrayBuffer,
+          maxEntry: number,
+          maxTotal: number,
+          maxEntries: number,
+          useGoogleFonts: boolean,
+          timeout: number,
+        ): Promise<void>;
+      }
+    )._parse(new ArrayBuffer(1), 64, 512, 20_000, false, 30_000);
+
+    expect(request).toMatchObject({
+      type: 'parse',
+      id: 7,
+      maxZipEntryBytes: 64,
+      maxZipTotalBytes: 512,
+      maxZipEntries: 20_000,
+    });
+  });
+});

--- a/packages/ooxml-common/src/zip.rs
+++ b/packages/ooxml-common/src/zip.rs
@@ -331,7 +331,8 @@ pub fn extract_zip_entry_with_limits(
     let mut entry = zip
         .by_name(path)
         .map_err(|e| format!("entry not found: {path}: {e}"))?;
-    read_limited_bytes(&mut entry, path, entry.size(), None)
+    let declared_size = entry.size();
+    read_limited_bytes(&mut entry, path, declared_size, None)
 }
 
 /// Read one entry's bytes from an **already-opened** [`ZipArchive`]. Twin of
@@ -349,7 +350,8 @@ pub fn read_zip_bytes<R: std::io::Read + std::io::Seek>(
     let mut entry = archive
         .by_name(path)
         .map_err(|e| format!("entry not found: {path}: {e}"))?;
-    read_limited_bytes(&mut entry, path, entry.size(), None)
+    let declared_size = entry.size();
+    read_limited_bytes(&mut entry, path, declared_size, None)
 }
 
 /// UTF-8 string counterpart of [`read_zip_bytes`] for XML parts. Same cap
@@ -376,7 +378,8 @@ pub fn read_zip_prefix_bytes<R: std::io::Read + std::io::Seek>(
     let mut entry = archive
         .by_name(path)
         .map_err(|e| format!("entry not found: {path}: {e}"))?;
-    read_limited_bytes(&mut entry, path, entry.size(), Some(max_bytes))
+    let declared_size = entry.size();
+    read_limited_bytes(&mut entry, path, declared_size, Some(max_bytes))
 }
 
 #[cfg(test)]
@@ -720,7 +723,10 @@ mod tests {
             let be = read_zip_bytes(&mut ar, "ppt/media/big.bin").unwrap_err();
             assert!(be.contains("exceeds size limit"), "got: {be}");
             let se = read_zip_string(&mut ar, "ppt/media/big.bin").unwrap_err();
-            assert!(se.contains("exceeds size limit"), "got: {se}");
+            assert!(
+                se.contains("budget already exceeded"),
+                "a proven breach must poison the retained scoped budget, got: {se}"
+            );
         }
         // Cap restored on guard drop → the same entry now reads in full.
         assert_eq!(

--- a/packages/ooxml-common/src/zip.rs
+++ b/packages/ooxml-common/src/zip.rs
@@ -13,12 +13,24 @@
 //! its scope and the cap is restored on drop, so concurrent JS callers never
 //! interfere (WASM is single-threaded; each invocation runs to completion).
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
 
 /// 512 MiB. OOXML legitimately reaches tens of MB (embedded video, 4K
 /// images) but not hundreds, so this cap blocks zip-bomb DoS without
 /// rejecting real files.
 pub const DEFAULT_MAX_ZIP_ENTRY_BYTES: u64 = 512 * 1024 * 1024;
+
+/// 512 MiB across all distinct entries actually inflated from one archive.
+/// This bounds archives made from many individually-valid entries while keeping
+/// ordinary OOXML packages (whose XML and media total far below this) compatible.
+pub const DEFAULT_MAX_ZIP_TOTAL_BYTES: u64 = 512 * 1024 * 1024;
+
+/// A conservative ceiling for central-directory entries. OOXML packages normally
+/// contain hundreds or a few thousand parts; 20,000 leaves ample headroom while
+/// bounding metadata scans and pathological part explosions.
+pub const DEFAULT_MAX_ZIP_ENTRIES: u64 = 20_000;
 
 /// Upper bound on the buffer we pre-reserve from an entry's DECLARED size.
 ///
@@ -47,6 +59,47 @@ fn initial_reserve(declared_size: u64) -> usize {
 
 thread_local! {
     static MAX_ZIP_ENTRY_BYTES: Cell<u64> = const { Cell::new(DEFAULT_MAX_ZIP_ENTRY_BYTES) };
+    static ACTIVE_BUDGET: RefCell<Option<ZipBudget>> = const { RefCell::new(None) };
+}
+
+#[derive(Clone)]
+pub struct ZipBudget(Rc<RefCell<BudgetState>>);
+
+struct BudgetState {
+    max_entry_bytes: u64,
+    max_total_bytes: u64,
+    max_entries: u64,
+    /// The greatest number of bytes observed for each entry. Re-reading an entry
+    /// through a retained archive replaces this value instead of double-counting.
+    entry_bytes: HashMap<String, u64>,
+    actual_total_bytes: u64,
+    /// A retained archive fails closed after a proven limit breach. Without this,
+    /// callers could catch one error and repeatedly inflate more distinct forged
+    /// entries through the same handle.
+    poisoned: bool,
+}
+
+impl ZipBudget {
+    pub fn new(
+        max_zip_entry_bytes: Option<u64>,
+        max_zip_total_bytes: Option<u64>,
+        max_zip_entries: Option<u64>,
+    ) -> Self {
+        Self(Rc::new(RefCell::new(BudgetState {
+            max_entry_bytes: max_zip_entry_bytes
+                .filter(|&n| n > 0)
+                .unwrap_or(DEFAULT_MAX_ZIP_ENTRY_BYTES),
+            max_total_bytes: max_zip_total_bytes
+                .filter(|&n| n > 0)
+                .unwrap_or(DEFAULT_MAX_ZIP_TOTAL_BYTES),
+            max_entries: max_zip_entries
+                .filter(|&n| n > 0)
+                .unwrap_or(DEFAULT_MAX_ZIP_ENTRIES),
+            entry_bytes: HashMap::new(),
+            actual_total_bytes: 0,
+            poisoned: false,
+        })))
+    }
 }
 
 /// RAII guard that restores the previous cap when dropped. Created by
@@ -55,11 +108,13 @@ thread_local! {
 #[must_use = "binding the guard keeps the cap installed for this scope"]
 pub struct Guard {
     previous: u64,
+    previous_budget: Option<ZipBudget>,
 }
 
 impl Drop for Guard {
     fn drop(&mut self) {
         MAX_ZIP_ENTRY_BYTES.with(|c| c.set(self.previous));
+        ACTIVE_BUDGET.with(|budget| *budget.borrow_mut() = self.previous_budget.take());
     }
 }
 
@@ -67,17 +122,184 @@ impl Drop for Guard {
 /// guard. `None`, zero, or any non-positive value falls back to
 /// [`DEFAULT_MAX_ZIP_ENTRY_BYTES`].
 pub fn scoped_max(value: Option<u64>) -> Guard {
-    let resolved = value
-        .filter(|&n| n > 0)
-        .unwrap_or(DEFAULT_MAX_ZIP_ENTRY_BYTES);
+    scoped_limits(value, None, None)
+}
+
+/// Create and install a ZIP budget for one non-retained parse or extraction.
+pub fn scoped_limits(
+    max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
+) -> Guard {
+    let budget = ZipBudget::new(max_zip_entry_bytes, max_zip_total_bytes, max_zip_entries);
+    scoped_budget(&budget)
+}
+
+/// Install a retained archive's budget for the duration of one method call.
+/// The handle owns this budget, so actual bytes remain accounted across calls.
+pub fn scoped_budget(budget: &ZipBudget) -> Guard {
+    let resolved = budget.0.borrow().max_entry_bytes;
     let previous = MAX_ZIP_ENTRY_BYTES.with(|c| c.replace(resolved));
-    Guard { previous }
+    let previous_budget = ACTIVE_BUDGET.with(|active| active.borrow_mut().replace(budget.clone()));
+    Guard {
+        previous,
+        previous_budget,
+    }
 }
 
 /// Current cap in effect on this thread. Parsers consult this from their
 /// `read_zip_*` helpers when validating entry sizes.
 pub fn current_max() -> u64 {
     MAX_ZIP_ENTRY_BYTES.with(Cell::get)
+}
+
+fn current_limits() -> (u64, u64, u64) {
+    ACTIVE_BUDGET.with(|active| {
+        active
+            .borrow()
+            .as_ref()
+            .map(|budget| {
+                let state = budget.0.borrow();
+                (
+                    state.max_entry_bytes,
+                    state.max_total_bytes,
+                    state.max_entries,
+                )
+            })
+            .unwrap_or((
+                DEFAULT_MAX_ZIP_ENTRY_BYTES,
+                DEFAULT_MAX_ZIP_TOTAL_BYTES,
+                DEFAULT_MAX_ZIP_ENTRIES,
+            ))
+    })
+}
+
+fn ensure_budget_is_healthy() -> Result<(), String> {
+    ACTIVE_BUDGET.with(|active| {
+        let Some(budget) = active.borrow().clone() else {
+            return Ok(());
+        };
+        if budget.0.borrow().poisoned {
+            return Err("ZIP archive budget already exceeded".to_string());
+        }
+        Ok(())
+    })
+}
+
+fn poison_budget(message: &'static str) -> String {
+    ACTIVE_BUDGET.with(|active| {
+        if let Some(budget) = active.borrow().clone() {
+            budget.0.borrow_mut().poisoned = true;
+        }
+    });
+    message.to_string()
+}
+
+/// Reject an archive whose central directory already proves it exceeds a limit.
+/// The declared sizes are not trusted as actual bytes, but they are a safe early
+/// rejection signal that avoids inflating or allocating for a known-over-budget
+/// archive. Actual decompressed bytes are checked separately while reading.
+pub fn validate_archive_limits<R: std::io::Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+) -> Result<(), String> {
+    ensure_budget_is_healthy()?;
+    let (_, max_total, max_entries) = current_limits();
+    if (archive.len() as u64) > max_entries {
+        return Err(poison_budget("ZIP archive exceeds entry count limit"));
+    }
+    let mut declared_total = 0u64;
+    for index in 0..archive.len() {
+        let entry = archive
+            .by_index(index)
+            .map_err(|_| "ZIP archive entry metadata error".to_string())?;
+        declared_total = declared_total
+            .checked_add(entry.size())
+            .ok_or_else(|| poison_budget("ZIP archive exceeds total size limit"))?;
+        if declared_total > max_total {
+            return Err(poison_budget("ZIP archive exceeds total size limit"));
+        }
+    }
+    Ok(())
+}
+
+fn observe_actual_bytes(path: &str, observed_for_entry: u64) -> Result<(), String> {
+    ensure_budget_is_healthy()?;
+    ACTIVE_BUDGET.with(|active| {
+        let Some(budget) = active.borrow().clone() else {
+            return Ok(());
+        };
+        let mut state = budget.0.borrow_mut();
+        let old = state.entry_bytes.get(path).copied().unwrap_or(0);
+        if observed_for_entry <= old {
+            return Ok(());
+        }
+        let next_total = state
+            .actual_total_bytes
+            .checked_add(observed_for_entry - old)
+            .ok_or_else(|| {
+                state.poisoned = true;
+                "ZIP archive exceeds total size limit".to_string()
+            })?;
+        if next_total > state.max_total_bytes {
+            state.poisoned = true;
+            return Err("ZIP archive exceeds total size limit".to_string());
+        }
+        state
+            .entry_bytes
+            .insert(path.to_owned(), observed_for_entry);
+        state.actual_total_bytes = next_total;
+        Ok(())
+    })
+}
+
+fn read_limited_bytes(
+    reader: &mut impl std::io::Read,
+    path: &str,
+    declared_size: u64,
+    max_bytes: Option<u64>,
+) -> Result<Vec<u8>, String> {
+    ensure_budget_is_healthy()?;
+    let (max_entry, _, _) = current_limits();
+    if declared_size > max_entry {
+        return Err(poison_budget("ZIP entry exceeds size limit"));
+    }
+    let limit = max_bytes.unwrap_or(max_entry).min(max_entry);
+    let mut buf = Vec::with_capacity(initial_reserve(declared_size.min(limit)));
+    let mut chunk = [0u8; 32 * 1024];
+    let mut read = 0u64;
+    loop {
+        if read == limit {
+            // Prefix probes intentionally stop here. Full reads consume one more
+            // byte so an entry whose actual inflate output exceeds its cap cannot
+            // masquerade as an exact-limit entry behind forged metadata.
+            if max_bytes.is_some() {
+                break;
+            }
+            let count = reader
+                .read(&mut chunk[..1])
+                .map_err(|_| "ZIP entry read error".to_string())?;
+            if count != 0 {
+                return Err(poison_budget("ZIP entry exceeds size limit"));
+            }
+            break;
+        }
+        let remaining = (limit - read).min(chunk.len() as u64) as usize;
+        let count = reader
+            .read(&mut chunk[..remaining])
+            .map_err(|_| "ZIP entry read error".to_string())?;
+        if count == 0 {
+            break;
+        }
+        read = read
+            .checked_add(count as u64)
+            .ok_or_else(|| poison_budget("ZIP entry exceeds size limit"))?;
+        if read > limit {
+            return Err(poison_budget("ZIP entry exceeds size limit"));
+        }
+        observe_actual_bytes(path, read)?;
+        buf.extend_from_slice(&chunk[..count]);
+    }
+    Ok(buf)
 }
 
 /// Read one zip entry's bytes by path. Honors the scoped max-entry guard:
@@ -89,26 +311,27 @@ pub fn extract_zip_entry(
     path: &str,
     max_zip_entry_bytes: Option<u64>,
 ) -> Result<Vec<u8>, String> {
-    use std::io::{Cursor, Read};
-    let _guard = scoped_max(max_zip_entry_bytes);
-    let max = current_max();
+    extract_zip_entry_with_limits(data, path, max_zip_entry_bytes, None, None)
+}
+
+/// Limit-aware counterpart of [`extract_zip_entry`]. Browser entry points use
+/// this to apply entry, aggregate-byte, and central-directory-count limits.
+pub fn extract_zip_entry_with_limits(
+    data: &[u8],
+    path: &str,
+    max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
+) -> Result<Vec<u8>, String> {
+    use std::io::Cursor;
+    let _guard = scoped_limits(max_zip_entry_bytes, max_zip_total_bytes, max_zip_entries);
     let cursor = Cursor::new(data);
     let mut zip = zip::ZipArchive::new(cursor).map_err(|e| format!("zip open error: {e}"))?;
+    validate_archive_limits(&mut zip)?;
     let mut entry = zip
         .by_name(path)
         .map_err(|e| format!("entry not found: {path}: {e}"))?;
-    if entry.size() > max {
-        return Err(format!("ZIP entry exceeds size limit: {path}"));
-    }
-    // Pre-reserve a capped amount, not the (attacker-controlled) declared size —
-    // `read_to_end` grows the buffer for genuinely large parts. See INITIAL_RESERVE_CAP.
-    let mut buf = Vec::with_capacity(initial_reserve(entry.size()));
-    entry
-        .by_ref()
-        .take(max)
-        .read_to_end(&mut buf)
-        .map_err(|e| format!("read error: {e}"))?;
-    Ok(buf)
+    read_limited_bytes(&mut entry, path, entry.size(), None)
 }
 
 /// Read one entry's bytes from an **already-opened** [`ZipArchive`]. Twin of
@@ -122,23 +345,11 @@ pub fn read_zip_bytes<R: std::io::Read + std::io::Seek>(
     archive: &mut zip::ZipArchive<R>,
     path: &str,
 ) -> Result<Vec<u8>, String> {
-    use std::io::Read;
-    let max = current_max();
+    ensure_budget_is_healthy()?;
     let mut entry = archive
         .by_name(path)
         .map_err(|e| format!("entry not found: {path}: {e}"))?;
-    if entry.size() > max {
-        return Err(format!("ZIP entry exceeds size limit: {path}"));
-    }
-    // Pre-reserve a capped amount, not the (attacker-controlled) declared size —
-    // `read_to_end` grows the buffer for genuinely large parts. See INITIAL_RESERVE_CAP.
-    let mut buf = Vec::with_capacity(initial_reserve(entry.size()));
-    entry
-        .by_ref()
-        .take(max)
-        .read_to_end(&mut buf)
-        .map_err(|e| format!("read error: {e}"))?;
-    Ok(buf)
+    read_limited_bytes(&mut entry, path, entry.size(), None)
 }
 
 /// UTF-8 string counterpart of [`read_zip_bytes`] for XML parts. Same cap
@@ -149,26 +360,142 @@ pub fn read_zip_string<R: std::io::Read + std::io::Seek>(
     archive: &mut zip::ZipArchive<R>,
     path: &str,
 ) -> Result<String, String> {
-    use std::io::Read;
-    let max = current_max();
+    let bytes = read_zip_bytes(archive, path)?;
+    String::from_utf8(bytes).map_err(|_| "ZIP entry is not valid UTF-8".to_string())
+}
+
+/// Read a bounded prefix of an entry while accounting actual bytes in the same
+/// retained-archive budget. A later full read of the same entry raises its
+/// observed total to the full size rather than charging the prefix twice.
+pub fn read_zip_prefix_bytes<R: std::io::Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    path: &str,
+    max_bytes: u64,
+) -> Result<Vec<u8>, String> {
+    ensure_budget_is_healthy()?;
     let mut entry = archive
         .by_name(path)
         .map_err(|e| format!("entry not found: {path}: {e}"))?;
-    if entry.size() > max {
-        return Err(format!("ZIP entry exceeds size limit: {path}"));
-    }
-    let mut buf = String::new();
-    entry
-        .by_ref()
-        .take(max)
-        .read_to_string(&mut buf)
-        .map_err(|e| format!("read error: {e}"))?;
-    Ok(buf)
+    read_limited_bytes(&mut entry, path, entry.size(), Some(max_bytes))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn aggregate_budget_rejects_actual_bytes_across_distinct_entries() {
+        use std::io::{Cursor, Write};
+        let mut buf = Vec::new();
+        {
+            let mut w = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = zip::write::SimpleFileOptions::default();
+            w.start_file("one.bin", opts).unwrap();
+            w.write_all(b"1234").unwrap();
+            w.start_file("two.bin", opts).unwrap();
+            w.write_all(b"5678").unwrap();
+            w.finish().unwrap();
+        }
+        let mut archive = zip::ZipArchive::new(Cursor::new(buf)).unwrap();
+        let _guard = scoped_limits(Some(16), Some(6), Some(2));
+        assert_eq!(read_zip_bytes(&mut archive, "one.bin").unwrap(), b"1234");
+        let err = read_zip_bytes(&mut archive, "two.bin").unwrap_err();
+        assert!(err.contains("total size limit"), "got: {err}");
+    }
+
+    #[test]
+    fn retained_budget_does_not_double_charge_an_entry_read_again() {
+        use std::io::{Cursor, Write};
+        let mut buf = Vec::new();
+        {
+            let mut w = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = zip::write::SimpleFileOptions::default();
+            w.start_file("one.bin", opts).unwrap();
+            w.write_all(b"1234").unwrap();
+            w.start_file("two.bin", opts).unwrap();
+            w.write_all(b"5678").unwrap();
+            w.finish().unwrap();
+        }
+        let mut archive = zip::ZipArchive::new(Cursor::new(buf)).unwrap();
+        let budget = ZipBudget::new(Some(16), Some(8), Some(2));
+        {
+            let _guard = scoped_budget(&budget);
+            assert_eq!(read_zip_bytes(&mut archive, "one.bin").unwrap(), b"1234");
+        }
+        {
+            let _guard = scoped_budget(&budget);
+            assert_eq!(read_zip_bytes(&mut archive, "one.bin").unwrap(), b"1234");
+            assert_eq!(read_zip_bytes(&mut archive, "two.bin").unwrap(), b"5678");
+        }
+    }
+
+    #[test]
+    fn retained_budget_stays_rejected_after_aggregate_crossing() {
+        use std::io::{Cursor, Write};
+        let mut buf = Vec::new();
+        {
+            let mut w = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = zip::write::SimpleFileOptions::default();
+            w.start_file("one.bin", opts).unwrap();
+            w.write_all(b"1234").unwrap();
+            w.start_file("two.bin", opts).unwrap();
+            w.write_all(b"5678").unwrap();
+            w.finish().unwrap();
+        }
+        let mut archive = zip::ZipArchive::new(Cursor::new(buf)).unwrap();
+        let budget = ZipBudget::new(Some(16), Some(6), Some(2));
+        {
+            let _guard = scoped_budget(&budget);
+            assert_eq!(read_zip_bytes(&mut archive, "one.bin").unwrap(), b"1234");
+            let err = read_zip_bytes(&mut archive, "two.bin").unwrap_err();
+            assert!(err.contains("total size limit"), "got: {err}");
+        }
+        {
+            let _guard = scoped_budget(&budget);
+            let err = read_zip_bytes(&mut archive, "one.bin").unwrap_err();
+            assert!(err.contains("budget already exceeded"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn retained_budget_stays_rejected_after_actual_entry_overflow() {
+        use std::io::Cursor;
+        // A forged stream can emit more bytes than its claimed uncompressed
+        // size. Exercise the shared reader directly so the test does not rely on
+        // a ZIP implementation accepting malformed central-directory metadata.
+        let budget = ZipBudget::new(Some(4), Some(16), Some(2));
+        {
+            let _guard = scoped_budget(&budget);
+            let mut forged = Cursor::new(b"12345");
+            let err = read_limited_bytes(&mut forged, "forged.bin", 4, None).unwrap_err();
+            assert!(err.contains("entry exceeds size limit"), "got: {err}");
+        }
+        {
+            let _guard = scoped_budget(&budget);
+            let mut harmless = Cursor::new(b"1");
+            let err = read_limited_bytes(&mut harmless, "later.bin", 1, None).unwrap_err();
+            assert!(err.contains("budget already exceeded"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn central_directory_entry_count_is_rejected_before_reads() {
+        use std::io::{Cursor, Write};
+        let mut buf = Vec::new();
+        {
+            let mut w = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = zip::write::SimpleFileOptions::default();
+            w.start_file("one.xml", opts).unwrap();
+            w.write_all(b"1").unwrap();
+            w.start_file("two.xml", opts).unwrap();
+            w.write_all(b"2").unwrap();
+            w.finish().unwrap();
+        }
+        let mut archive = zip::ZipArchive::new(Cursor::new(buf)).unwrap();
+        let _guard = scoped_limits(Some(16), Some(16), Some(1));
+        let err = validate_archive_limits(&mut archive).unwrap_err();
+        assert!(err.contains("entry count limit"), "got: {err}");
+    }
 
     #[test]
     fn extract_zip_entry_reads_by_path() {

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1,7 +1,7 @@
 use ooxml_common::depth::parse_guarded;
 use ooxml_common::ns::is_r_ns;
 use std::collections::HashMap;
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 use wasm_bindgen::prelude::*;
 
 mod table_style_presets;

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1407,6 +1407,7 @@ fn parse_presentation(zip: &mut PptxZip) -> Result<Presentation, Box<dyn std::er
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Read;
     use crate::chart::{parse_chartex, parse_legacy_chart};
     use ooxml_common::math::nodes_to_text;
 

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -63,9 +63,16 @@ fn note_layout_master_parse() {
 /// thread does a single `TextDecoder.decode` + `JSON.parse`, collapsing three
 /// serializations (Rust String → JsString → structured clone) into one decode.
 #[wasm_bindgen]
-pub fn parse_pptx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u8>, JsValue> {
+pub fn parse_pptx(
+    data: &[u8],
+    max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
+) -> Result<Vec<u8>, JsValue> {
     console_error_panic_hook::set_once();
-    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
+    let _guard =
+        ooxml_common::zip::scoped_limits(max_zip_entry_bytes, max_zip_total_bytes, max_zip_entries);
+    validate_zip_budget(data).map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
     let presentation = parse_presentation_from_bytes(data)
         .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
     serde_json::to_vec(&presentation)
@@ -76,9 +83,16 @@ pub fn parse_pptx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u
 /// so the browser / Node WASM path and the native mcp-server path stay in
 /// lock-step. See `to_markdown_native` for the design rationale.
 #[wasm_bindgen]
-pub fn pptx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
+pub fn pptx_to_markdown(
+    data: &[u8],
+    max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
+) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
-    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
+    let _guard =
+        ooxml_common::zip::scoped_limits(max_zip_entry_bytes, max_zip_total_bytes, max_zip_entries);
+    validate_zip_budget(data).map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
     let pres = parse_presentation_from_bytes(data)
         .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
     Ok(render_presentation_md(&pres))
@@ -86,6 +100,8 @@ pub fn pptx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result
 
 /// Native equivalent of `parse_pptx` for use from the MCP server.
 pub fn parse_pptx_native(data: &[u8]) -> Result<String, String> {
+    let _guard = ooxml_common::zip::scoped_limits(None, None, None);
+    validate_zip_budget(data)?;
     let presentation = parse_presentation_from_bytes(data).map_err(|e| e.to_string())?;
     serde_json::to_string(&presentation).map_err(|e| e.to_string())
 }
@@ -97,6 +113,8 @@ pub fn parse_pptx_native(data: &[u8]) -> Result<String, String> {
 /// need to read content efficiently — typical 10-30× token reduction vs. the
 /// raw JSON of `parse_pptx_native`.
 pub fn to_markdown_native(data: &[u8]) -> Result<String, String> {
+    let _guard = ooxml_common::zip::scoped_limits(None, None, None);
+    validate_zip_budget(data)?;
     let pres = parse_presentation_from_bytes(data).map_err(|e| e.to_string())?;
     Ok(render_presentation_md(&pres))
 }
@@ -109,9 +127,17 @@ pub fn extract_media(
     data: &[u8],
     path: &str,
     max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
 ) -> Result<Vec<u8>, JsValue> {
-    ooxml_common::zip::extract_zip_entry(data, path, max_zip_entry_bytes)
-        .map_err(|e| JsValue::from_str(&e))
+    ooxml_common::zip::extract_zip_entry_with_limits(
+        data,
+        path,
+        max_zip_entry_bytes,
+        max_zip_total_bytes,
+        max_zip_entries,
+    )
+    .map_err(|e| JsValue::from_str(&e))
 }
 
 /// Extract raw bytes for a single embedded image entry (e.g.
@@ -123,9 +149,17 @@ pub fn extract_image(
     data: &[u8],
     path: &str,
     max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
 ) -> Result<Vec<u8>, JsValue> {
-    ooxml_common::zip::extract_zip_entry(data, path, max_zip_entry_bytes)
-        .map_err(|e| JsValue::from_str(&e))
+    ooxml_common::zip::extract_zip_entry_with_limits(
+        data,
+        path,
+        max_zip_entry_bytes,
+        max_zip_total_bytes,
+        max_zip_entries,
+    )
+    .map_err(|e| JsValue::from_str(&e))
 }
 
 /// A stateful handle over an opened pptx archive.
@@ -153,7 +187,7 @@ pub struct PptxArchive {
     /// the constructor throwing an opaque error the viewer can't turn into a
     /// placeholder slide.
     archive: Result<PptxZip, String>,
-    max: Option<u64>,
+    budget: ooxml_common::zip::ZipBudget,
 }
 
 #[wasm_bindgen]
@@ -169,15 +203,30 @@ impl PptxArchive {
     /// the `Cursor` could own its backing store, transiently doubling WASM
     /// linear memory to ~2x the file size during construction.
     #[wasm_bindgen(constructor)]
-    pub fn new(data: Vec<u8>, max_zip_entry_bytes: Option<u64>) -> Result<PptxArchive, JsValue> {
+    pub fn new(
+        data: Vec<u8>,
+        max_zip_entry_bytes: Option<u64>,
+        max_zip_total_bytes: Option<u64>,
+        max_zip_entries: Option<u64>,
+    ) -> Result<PptxArchive, JsValue> {
         console_error_panic_hook::set_once();
         // #774 (RB7 MAJOR): a truncated / corrupt CONTAINER is deferred, not
         // thrown, so `parse()` can degrade it to a placeholder presentation
         // instead of the constructor failing with an opaque error.
-        Ok(PptxArchive {
-            archive: open_zip(data),
-            max: max_zip_entry_bytes,
-        })
+        let budget = ooxml_common::zip::ZipBudget::new(
+            max_zip_entry_bytes,
+            max_zip_total_bytes,
+            max_zip_entries,
+        );
+        let _guard = ooxml_common::zip::scoped_budget(&budget);
+        let archive = match open_zip(data) {
+            Ok(archive) => Ok(archive),
+            Err(error) if error.starts_with("ZIP archive exceeds") => {
+                return Err(JsValue::from_str(&error));
+            }
+            Err(error) => Err(error),
+        };
+        Ok(PptxArchive { archive, budget })
     }
 
     /// Parse the retained archive and return the model as UTF-8 JSON bytes.
@@ -185,7 +234,7 @@ impl PptxArchive {
     /// CONTAINER failed to open (#774) the model is a degraded placeholder
     /// presentation tagged with the container.
     pub fn parse(&mut self) -> Result<Vec<u8>, JsValue> {
-        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let _guard = ooxml_common::zip::scoped_budget(&self.budget);
         let presentation = match self.archive.as_mut() {
             Ok(zip) => parse_presentation(zip)
                 .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?,
@@ -200,7 +249,7 @@ impl PptxArchive {
     /// the already-open archive instead of re-opening it. A corrupt container has
     /// no entries, so this surfaces the container-open error.
     pub fn extract_media(&mut self, path: &str) -> Result<Vec<u8>, JsValue> {
-        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let _guard = ooxml_common::zip::scoped_budget(&self.budget);
         let zip = self
             .archive
             .as_mut()
@@ -213,7 +262,7 @@ impl PptxArchive {
     /// `extract_image`. A corrupt container has no entries, so this surfaces the
     /// container-open error.
     pub fn extract_image(&mut self, path: &str) -> Result<Vec<u8>, JsValue> {
-        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let _guard = ooxml_common::zip::scoped_budget(&self.budget);
         let zip = self
             .archive
             .as_mut()
@@ -224,7 +273,7 @@ impl PptxArchive {
     /// GitHub-flavoured markdown projection of the retained archive. Mirrors the
     /// free `pptx_to_markdown`. A corrupt container degrades to an empty deck.
     pub fn to_markdown(&mut self) -> Result<String, JsValue> {
-        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let _guard = ooxml_common::zip::scoped_budget(&self.budget);
         let pres = match self.archive.as_mut() {
             Ok(zip) => parse_presentation(zip)
                 .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?,
@@ -251,16 +300,7 @@ pub(crate) fn read_zip_str(
     zip: &mut PptxZip,
     path: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let max = ooxml_common::zip::current_max();
-    let mut file = zip
-        .by_name(path)
-        .map_err(|_| format!("missing ZIP entry: {path}"))?;
-    if file.size() > max {
-        return Err(format!("ZIP entry exceeds size limit: {path}").into());
-    }
-    let mut buf = String::new();
-    file.by_ref().take(max).read_to_string(&mut buf)?;
-    Ok(buf)
+    ooxml_common::zip::read_zip_string(zip, path).map_err(Into::into)
 }
 
 // ===========================
@@ -883,7 +923,19 @@ fn load_pptx_comments(zip: &mut PptxZip, rels: &HashMap<String, String>) -> Vec<
 /// caller build a `degraded_container_presentation` tagged with the container,
 /// symmetric with how a corrupt slide part is tagged inside [`parse_presentation`].
 pub(crate) fn open_zip(data: Vec<u8>) -> Result<PptxZip, String> {
-    zip::ZipArchive::new(Cursor::new(data)).map_err(|e| format!("(zip container): {e}"))
+    let mut archive =
+        zip::ZipArchive::new(Cursor::new(data)).map_err(|e| format!("(zip container): {e}"))?;
+    ooxml_common::zip::validate_archive_limits(&mut archive)?;
+    Ok(archive)
+}
+
+fn validate_zip_budget(data: &[u8]) -> Result<(), String> {
+    // Keep malformed-container degradation intact; reject only limits proven by
+    // a readable central directory before parsing/inflation starts.
+    let Ok(mut archive) = zip::ZipArchive::new(Cursor::new(data)) else {
+        return Ok(());
+    };
+    ooxml_common::zip::validate_archive_limits(&mut archive)
 }
 
 /// A placeholder [`Presentation`] for a pptx whose ZIP CONTAINER could not be
@@ -1719,7 +1771,10 @@ mod tests {
             w.write_all(b"X").unwrap();
             w.finish().unwrap();
         }
-        assert_eq!(extract_image(&buf, "ppt/media/i.png", None).unwrap(), b"X");
+        assert_eq!(
+            extract_image(&buf, "ppt/media/i.png", None, None, None).unwrap(),
+            b"X"
+        );
     }
 
     /// A `PictureElement` serializes its blip as a zip path + mime, never as an
@@ -5506,7 +5561,7 @@ mod tests {
             "svg_image_path must point at the .svg part",
         );
         // And the resolved path must hold the original SVG bytes.
-        let svg_bytes = extract_image(&data, "ppt/media/image2.svg", None)
+        let svg_bytes = extract_image(&data, "ppt/media/image2.svg", None, None, None)
             .expect("svg part must be readable by its resolved path");
         assert_eq!(
             svg_bytes, SVG,
@@ -5698,7 +5753,7 @@ mod tests {
         assert_eq!(pic.intrinsic_width_px, None, "no PNG intrinsic for SVG");
         assert_eq!(pic.intrinsic_height_px, None);
         // The resolved SVG path must hold the original SVG bytes.
-        let svg_bytes = extract_image(&data, "ppt/media/image2.svg", None)
+        let svg_bytes = extract_image(&data, "ppt/media/image2.svg", None, None, None)
             .expect("svg part must be readable by its resolved path");
         assert_eq!(
             svg_bytes, SVG,

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -32,6 +32,10 @@ import wasmAssetUrl from './wasm/pptx_parser_bg.wasm?url';
 
 /** Options for {@link PptxPresentation.load}. */
 export type LoadOptions = CoreLoadOptions & {
+  /** Maximum decompressed bytes across distinct ZIP entries (default: 512 MiB). */
+  maxZipTotalBytes?: number;
+  /** Maximum ZIP central-directory entries (default: 20,000). */
+  maxZipEntries?: number;
   /**
    * 'main' (default): parse in a worker, render on the main thread (current
    * behaviour). 'worker': parse AND render inside the worker; use
@@ -183,6 +187,8 @@ export class PptxPresentation {
     await pres._parse(
       buffer,
       opts.maxZipEntryBytes,
+      opts.maxZipTotalBytes,
+      opts.maxZipEntries,
       mode === 'worker' ? !!opts.useGoogleFonts : false,
       opts.workerTimeoutMs,
     );
@@ -198,14 +204,16 @@ export class PptxPresentation {
   private async _parse(
     buffer: ArrayBuffer,
     maxZipEntryBytes?: number,
+    maxZipTotalBytes?: number,
+    maxZipEntries?: number,
     useGoogleFonts = false,
     timeoutMs?: number,
   ): Promise<void> {
     const res = await this._bridge.request(
       (id) =>
         this._mode === 'worker'
-          ? ({ kind: 'parse', id, buffer, maxZipEntryBytes, useGoogleFonts } satisfies RenderWorkerRequest)
-          : ({ kind: 'parse', id, buffer, maxZipEntryBytes } satisfies WorkerRequest),
+          ? ({ kind: 'parse', id, buffer, maxZipEntryBytes, maxZipTotalBytes, maxZipEntries, useGoogleFonts } satisfies RenderWorkerRequest)
+          : ({ kind: 'parse', id, buffer, maxZipEntryBytes, maxZipTotalBytes, maxZipEntries } satisfies WorkerRequest),
       [buffer],
       { timeoutMs },
     );

--- a/packages/pptx/src/render-worker.ts
+++ b/packages/pptx/src/render-worker.ts
@@ -114,6 +114,14 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
+      const maxTotal =
+        typeof req.maxZipTotalBytes === 'number' && req.maxZipTotalBytes > 0
+          ? BigInt(req.maxZipTotalBytes)
+          : undefined;
+      const maxEntries =
+        typeof req.maxZipEntries === 'number' && req.maxZipEntries > 0
+          ? BigInt(req.maxZipEntries)
+          : undefined;
       const bytes = new Uint8Array(req.buffer);
       // Construction + `parse()` run under `host.run` so a trap in EITHER poisons
       // + recycles the instance (and frees the archive). `setArchive` frees any
@@ -121,7 +129,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
       // bytes (Result<Vec<u8>, JsValue>). Render mode consumes the model
       // in-worker, so decode + parse here (one decode, no passthrough).
       pres = host.run(() => {
-        const archive = new PptxArchive(bytes, max);
+        const archive = new PptxArchive(bytes, max, maxTotal, maxEntries);
         host.setArchive(archive);
         return JSON.parse(new TextDecoder().decode(archive.parse())) as Presentation;
       });

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -464,6 +464,8 @@ export class PptxScrollViewer implements ZoomableViewer {
       const pres = await PptxPresentation.load(source, {
         useGoogleFonts: this._opts.useGoogleFonts,
         maxZipEntryBytes: this._opts.maxZipEntryBytes,
+        maxZipTotalBytes: this._opts.maxZipTotalBytes,
+        maxZipEntries: this._opts.maxZipEntries,
         workerTimeoutMs: this._opts.workerTimeoutMs,
         wasmUrl: this._opts.wasmUrl,
         math: this._opts.math,

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -607,7 +607,7 @@ export interface PictureElement {
 
 export type WorkerRequest =
   | { kind: 'init'; wasmUrl: string }
-  | { kind: 'parse'; id: number; buffer: ArrayBuffer; maxZipEntryBytes?: number }
+  | { kind: 'parse'; id: number; buffer: ArrayBuffer; maxZipEntryBytes?: number; maxZipTotalBytes?: number; maxZipEntries?: number }
   | { kind: 'extractMedia'; id: number; path: string }
   | { kind: 'extractImage'; id: number; path: string }
   // Project the retained archive to GitHub-flavoured markdown (`PptxArchive.to_markdown`,

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -245,6 +245,8 @@ export class PptxViewer implements ZoomableViewer {
       const engine = await PptxPresentation.load(source, {
         useGoogleFonts: this.opts.useGoogleFonts,
         maxZipEntryBytes: this.opts.maxZipEntryBytes,
+        maxZipTotalBytes: this.opts.maxZipTotalBytes,
+        maxZipEntries: this.opts.maxZipEntries,
         workerTimeoutMs: this.opts.workerTimeoutMs,
         wasmUrl: this.opts.wasmUrl,
         math: this.opts.math,

--- a/packages/pptx/src/worker-protocol.ts
+++ b/packages/pptx/src/worker-protocol.ts
@@ -33,7 +33,7 @@ export type RenderWorkerRequest =
   | { kind: 'extractMedia'; id: number; path: string }
   | { kind: 'extractImage'; id: number; path: string }
   | { kind: 'toMarkdown'; id: number }
-  | { kind: 'parse'; id: number; buffer: ArrayBuffer; maxZipEntryBytes?: number; useGoogleFonts?: boolean }
+  | { kind: 'parse'; id: number; buffer: ArrayBuffer; maxZipEntryBytes?: number; maxZipTotalBytes?: number; maxZipEntries?: number; useGoogleFonts?: boolean }
   | { kind: 'renderSlide'; id: number; slideIndex: number; width: number; dpr: number; skipMediaControls?: boolean; dim?: DimOptions }
   // IX6 — collect a slide's text-run geometry WITHOUT transferring a bitmap. The
   // find controller scans every slide for its runs; a bitmap per slide would be

--- a/packages/pptx/src/worker.ts
+++ b/packages/pptx/src/worker.ts
@@ -48,6 +48,14 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
+      const maxTotal =
+        typeof req.maxZipTotalBytes === 'number' && req.maxZipTotalBytes > 0
+          ? BigInt(req.maxZipTotalBytes)
+          : undefined;
+      const maxEntries =
+        typeof req.maxZipEntries === 'number' && req.maxZipEntries > 0
+          ? BigInt(req.maxZipEntries)
+          : undefined;
       const bytes = new Uint8Array(req.buffer);
       // Both the construction and `parse()` run under `host.run` so a trap in
       // EITHER poisons + recycles the instance (and frees the archive). Adopting
@@ -57,7 +65,7 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
       // buffer, so forward it to the main thread as a transferable — no clone,
       // no decode here. The single decode + JSON.parse happens once, on main.
       const json = host.run(() => {
-        const archive = new PptxArchive(bytes, max);
+        const archive = new PptxArchive(bytes, max, maxTotal, maxEntries);
         host.setArchive(archive);
         return archive.parse();
       });

--- a/packages/pptx/src/zip-budget-options.test.ts
+++ b/packages/pptx/src/zip-budget-options.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PptxPresentation } from './presentation.js';
+
+describe('PptxPresentation ZIP budget wiring', () => {
+  it('forwards aggregate and entry-count limits to worker parsing', async () => {
+    let request: Record<string, unknown> | undefined;
+    const instance = Object.create(PptxPresentation.prototype) as Record<string, unknown>;
+    instance._mode = 'worker';
+    instance._bridge = {
+      request: vi.fn(async (createRequest: (id: number) => Record<string, unknown>) => {
+        request = createRequest(11);
+        return { kind: 'parsedMeta', id: 11, meta: {} };
+      }),
+    };
+
+    await (
+      instance as unknown as {
+        _parse(
+          data: ArrayBuffer,
+          maxEntry: number,
+          maxTotal: number,
+          maxEntries: number,
+          useGoogleFonts: boolean,
+          timeout: number,
+        ): Promise<void>;
+      }
+    )._parse(new ArrayBuffer(1), 64, 512, 20_000, false, 30_000);
+
+    expect(request).toMatchObject({
+      kind: 'parse',
+      id: 11,
+      maxZipEntryBytes: 64,
+      maxZipTotalBytes: 512,
+      maxZipEntries: 20_000,
+    });
+  });
+});

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 use wasm_bindgen::prelude::*;
 
 use ooxml_common::depth::parse_guarded;

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -63,7 +63,19 @@ const CONTAINER_PART: &str = "(zip container)";
 /// by writing the literal `"(zip container)"` directly instead of a
 /// pre-parenthesized constant).
 pub(crate) fn open_zip(data: Vec<u8>) -> Result<XlsxZip, String> {
-    zip::ZipArchive::new(Cursor::new(data)).map_err(|e| format!("{CONTAINER_PART}: {e}"))
+    let mut archive =
+        zip::ZipArchive::new(Cursor::new(data)).map_err(|e| format!("{CONTAINER_PART}: {e}"))?;
+    ooxml_common::zip::validate_archive_limits(&mut archive)?;
+    Ok(archive)
+}
+
+fn validate_zip_budget(data: &[u8]) -> Result<(), String> {
+    // Malformed containers keep the existing degraded-placeholder behavior;
+    // only a readable central directory can prove a budget violation.
+    let Ok(mut archive) = zip::ZipArchive::new(Cursor::new(data)) else {
+        return Ok(());
+    };
+    ooxml_common::zip::validate_archive_limits(&mut archive)
 }
 
 /// A placeholder [`ParsedWorkbook`] for a xlsx whose ZIP CONTAINER could not be
@@ -128,9 +140,16 @@ const INDEXED_COLORS: &[&str] = &[
 /// thread does a single `TextDecoder.decode` + `JSON.parse`, collapsing three
 /// serializations (Rust String → JsString → structured clone) into one decode.
 #[wasm_bindgen]
-pub fn parse_xlsx(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<Vec<u8>, JsValue> {
+pub fn parse_xlsx(
+    data: &[u8],
+    max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
+) -> Result<Vec<u8>, JsValue> {
     console_error_panic_hook::set_once();
-    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
+    let _guard =
+        ooxml_common::zip::scoped_limits(max_zip_entry_bytes, max_zip_total_bytes, max_zip_entries);
+    validate_zip_budget(data).map_err(|e| JsValue::from_str(&e))?;
     let wb = parse_xlsx_inner(data).map_err(|e| JsValue::from_str(&e))?;
     serde_json::to_vec(&wb).map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
 }
@@ -322,9 +341,13 @@ pub fn parse_sheet(
     sheet_index: u32,
     name: &str,
     max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
 ) -> Result<Vec<u8>, JsValue> {
     console_error_panic_hook::set_once();
-    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
+    let _guard =
+        ooxml_common::zip::scoped_limits(max_zip_entry_bytes, max_zip_total_bytes, max_zip_entries);
+    validate_zip_budget(data).map_err(|e| JsValue::from_str(&e))?;
     // #774: mirror `parse_xlsx_inner` — a corrupt CONTAINER degrades the sheet to
     // the container-tagged placeholder so the viewer paints its overlay instead of
     // the constructor / read throwing an opaque error.
@@ -402,14 +425,7 @@ fn read_zip_entry_head(
     name: &str,
     max_bytes: u64,
 ) -> Result<String, String> {
-    let mut file = archive
-        .by_name(name)
-        .map_err(|e| format!("entry '{}' not found: {}", name, e))?;
-    let mut buf = Vec::new();
-    file.by_ref()
-        .take(max_bytes)
-        .read_to_end(&mut buf)
-        .map_err(|e| e.to_string())?;
+    let buf = ooxml_common::zip::read_zip_prefix_bytes(archive, name, max_bytes)?;
     Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
@@ -2460,6 +2476,8 @@ pub(crate) fn resolve_implicit_ordinal(explicit: Option<u32>, prev: &mut u32) ->
 /// Returns workbook overview (sheet names and metadata) as JSON.
 /// Native equivalent of `parse_xlsx` for use from the MCP server.
 pub fn parse_workbook_native(data: &[u8]) -> Result<String, String> {
+    let _guard = ooxml_common::zip::scoped_limits(None, None, None);
+    validate_zip_budget(data)?;
     parse_xlsx_inner(data)
         .and_then(|wb| serde_json::to_string(&wb.workbook).map_err(|e| e.to_string()))
 }
@@ -2469,9 +2487,16 @@ pub fn parse_workbook_native(data: &[u8]) -> Result<String, String> {
 /// continuation cells are rendered as empty; the display value comes from the
 /// WASM-callable markdown projection (mirrors `to_markdown_native`).
 #[wasm_bindgen]
-pub fn xlsx_to_markdown(data: &[u8], max_zip_entry_bytes: Option<u64>) -> Result<String, JsValue> {
+pub fn xlsx_to_markdown(
+    data: &[u8],
+    max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
+) -> Result<String, JsValue> {
     console_error_panic_hook::set_once();
-    let _guard = ooxml_common::zip::scoped_max(max_zip_entry_bytes);
+    let _guard =
+        ooxml_common::zip::scoped_limits(max_zip_entry_bytes, max_zip_total_bytes, max_zip_entries);
+    validate_zip_budget(data).map_err(|e| JsValue::from_str(&e))?;
     to_markdown_impl(data).map_err(|e| JsValue::from_str(&e))
 }
 
@@ -2484,9 +2509,17 @@ pub fn extract_image(
     data: &[u8],
     path: &str,
     max_zip_entry_bytes: Option<u64>,
+    max_zip_total_bytes: Option<u64>,
+    max_zip_entries: Option<u64>,
 ) -> Result<Vec<u8>, JsValue> {
-    ooxml_common::zip::extract_zip_entry(data, path, max_zip_entry_bytes)
-        .map_err(|e| JsValue::from_str(&e))
+    ooxml_common::zip::extract_zip_entry_with_limits(
+        data,
+        path,
+        max_zip_entry_bytes,
+        max_zip_total_bytes,
+        max_zip_entries,
+    )
+    .map_err(|e| JsValue::from_str(&e))
 }
 
 /// A stateful handle over an opened xlsx archive.
@@ -2516,7 +2549,7 @@ pub struct XlsxArchive {
     /// constructor throwing an opaque error the viewer can't turn into a
     /// placeholder tab.
     archive: Result<XlsxZip, String>,
-    max: Option<u64>,
+    budget: ooxml_common::zip::ZipBudget,
     /// Workbook-level parts parsed once and reused across sheet switches. Loaded
     /// lazily on the first `parse` / `parse_sheet` (see [`XlsxArchive::shared`]).
     shared: Option<WorkbookShared>,
@@ -2536,14 +2569,32 @@ impl XlsxArchive {
     /// the `Cursor` could own its backing store, transiently doubling WASM
     /// linear memory to ~2x the file size during construction.
     #[wasm_bindgen(constructor)]
-    pub fn new(data: Vec<u8>, max_zip_entry_bytes: Option<u64>) -> Result<XlsxArchive, JsValue> {
+    pub fn new(
+        data: Vec<u8>,
+        max_zip_entry_bytes: Option<u64>,
+        max_zip_total_bytes: Option<u64>,
+        max_zip_entries: Option<u64>,
+    ) -> Result<XlsxArchive, JsValue> {
         console_error_panic_hook::set_once();
         // #774 (RB7 MAJOR): a truncated / corrupt CONTAINER is deferred, not
         // thrown, so `parse()` / `parse_sheet()` can degrade it to a placeholder
         // instead of the constructor failing with an opaque error.
+        let budget = ooxml_common::zip::ZipBudget::new(
+            max_zip_entry_bytes,
+            max_zip_total_bytes,
+            max_zip_entries,
+        );
+        let _guard = ooxml_common::zip::scoped_budget(&budget);
+        let archive = match open_zip(data) {
+            Ok(archive) => Ok(archive),
+            Err(error) if error.starts_with("ZIP archive exceeds") => {
+                return Err(JsValue::from_str(&error));
+            }
+            Err(error) => Err(error),
+        };
         Ok(XlsxArchive {
-            archive: open_zip(data),
-            max: max_zip_entry_bytes,
+            archive,
+            budget,
             shared: None,
         })
     }
@@ -2569,7 +2620,7 @@ impl XlsxArchive {
     /// CONTAINER failed to open (#774) the model is a degraded placeholder
     /// workbook tagged with the container.
     pub fn parse(&mut self) -> Result<Vec<u8>, JsValue> {
-        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let _guard = ooxml_common::zip::scoped_budget(&self.budget);
         if let Err(e) = &self.archive {
             let wb = degraded_container_workbook(e.clone());
             return serde_json::to_vec(&wb)
@@ -2588,7 +2639,7 @@ impl XlsxArchive {
     /// When the CONTAINER failed to open (#774) the sheet is the container-tagged
     /// placeholder.
     pub fn parse_sheet(&mut self, sheet_index: u32, name: &str) -> Result<Vec<u8>, JsValue> {
-        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let _guard = ooxml_common::zip::scoped_budget(&self.budget);
         if let Err(e) = &self.archive {
             let ws = degraded_container_sheet(e.clone());
             return serde_json::to_vec(&ws).map_err(|e| JsValue::from_str(&e.to_string()));
@@ -2604,7 +2655,7 @@ impl XlsxArchive {
     /// `extract_image`, but reads through the already-open archive. A corrupt
     /// container has no entries, so this surfaces the container-open error.
     pub fn extract_image(&mut self, path: &str) -> Result<Vec<u8>, JsValue> {
-        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let _guard = ooxml_common::zip::scoped_budget(&self.budget);
         let zip = self
             .archive
             .as_mut()
@@ -2615,7 +2666,7 @@ impl XlsxArchive {
     /// GitHub-flavoured markdown projection of the retained archive. Mirrors the
     /// free `xlsx_to_markdown`. A corrupt container degrades to an empty document.
     pub fn to_markdown(&mut self) -> Result<String, JsValue> {
-        let _guard = ooxml_common::zip::scoped_max(self.max);
+        let _guard = ooxml_common::zip::scoped_budget(&self.budget);
         let zip = self
             .archive
             .as_mut()
@@ -2628,6 +2679,8 @@ impl XlsxArchive {
 /// Designed for AI agents that need to read the spreadsheet content
 /// efficiently — drops styling, formatting, charts, sparklines, drawings.
 pub fn to_markdown_native(data: &[u8]) -> Result<String, String> {
+    let _guard = ooxml_common::zip::scoped_limits(None, None, None);
+    validate_zip_budget(data)?;
     to_markdown_impl(data)
 }
 
@@ -2674,6 +2727,8 @@ fn to_markdown_from_archive(archive: &mut XlsxZip) -> Result<String, String> {
 /// the WASM `parse_sheet`, then decodes the JSON bytes to a `String` — so the
 /// native and WASM paths can never drift.
 pub fn parse_sheet_native(data: &[u8], sheet_index: u32, name: &str) -> Result<String, String> {
+    let _guard = ooxml_common::zip::scoped_limits(None, None, None);
+    validate_zip_budget(data)?;
     // #774: mirror the WASM `parse_sheet` — a corrupt CONTAINER degrades to the
     // container-tagged placeholder sheet rather than erroring.
     let mut archive = match open_zip(data.to_vec()) {
@@ -3331,7 +3386,10 @@ mod extract_image_tests {
             w.write_all(b"X").unwrap();
             w.finish().unwrap();
         }
-        assert_eq!(extract_image(&buf, "xl/media/i.png", None).unwrap(), b"X");
+        assert_eq!(
+            extract_image(&buf, "xl/media/i.png", None, None, None).unwrap(),
+            b"X"
+        );
     }
 }
 

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -129,13 +129,21 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest>) => {
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
+      const maxTotal =
+        typeof req.maxZipTotalBytes === 'number' && req.maxZipTotalBytes > 0
+          ? BigInt(req.maxZipTotalBytes)
+          : undefined;
+      const maxEntries =
+        typeof req.maxZipEntries === 'number' && req.maxZipEntries > 0
+          ? BigInt(req.maxZipEntries)
+          : undefined;
       // Construction + `parse()` run under `host.run` so a trap in EITHER poisons
       // + recycles the instance (and frees the archive). `setArchive` frees any
       // prior handle first — the re-parse dispose. `parse()` returns UTF-8 JSON
       // bytes (Result<Vec<u8>, JsValue>); decode + parse the workbook index here
       // (consumed in-worker, then a light copy is sent to the proxy as an object).
       workbook = host.run(() => {
-        const archive = new XlsxArchive(new Uint8Array(req.data), max);
+        const archive = new XlsxArchive(new Uint8Array(req.data), max, maxTotal, maxEntries);
         host.setArchive(archive);
         return JSON.parse(new TextDecoder().decode(archive.parse())) as ParsedWorkbook;
       });

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -1064,7 +1064,7 @@ export interface RenderViewportOptions {
 
 export type WorkerRequest =
   | { type: 'init'; wasmUrl: string }
-  | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number }
+  | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number; maxZipTotalBytes?: number; maxZipEntries?: number }
   /** Parse one sheet lazily. Deliberately carries NO `data`: the worker already
    *  retained the whole-workbook buffer on the preceding `parse`, so re-sending
    *  it here would structured-clone the entire file per sheet switch for no
@@ -1076,6 +1076,8 @@ export type WorkerRequest =
       sheetIndex: number;
       sheetName: string;
       maxZipEntryBytes?: number;
+      maxZipTotalBytes?: number;
+      maxZipEntries?: number;
     }
   /** Pull one embedded image's raw bytes by zip path from the buffer the worker
    *  retained at parse time. Twin of pptx/docx `extractImage`; xlsx uses the

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,6 +1,7 @@
 import { XlsxWorkbook } from './workbook.js';
 import type { Hyperlink, ViewportRange, Worksheet, XlsxComment } from './types.js';
-import type { HyperlinkTarget, LoadOptions, FindMatch, FindMatchesOptions, ZoomableViewer } from '@silurus/ooxml-core';
+import type { HyperlinkTarget, FindMatch, FindMatchesOptions, ZoomableViewer } from '@silurus/ooxml-core';
+import type { LoadOptions } from './workbook.js';
 import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale, anchoredZoomOffset, openExternalHyperlink, nextZoomStep, prevZoomStep, fitScale } from '@silurus/ooxml-core';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, pxToColWidth, pxToRowHeight, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 import { findListValidationAt } from './data-validation.js';
@@ -833,6 +834,8 @@ export class XlsxViewer implements ZoomableViewer {
       const wb = await XlsxWorkbook.load(source, {
         useGoogleFonts: this.opts.useGoogleFonts,
         maxZipEntryBytes: this.opts.maxZipEntryBytes,
+        maxZipTotalBytes: this.opts.maxZipTotalBytes,
+        maxZipEntries: this.opts.maxZipEntries,
         workerTimeoutMs: this.opts.workerTimeoutMs,
         wasmUrl: this.opts.wasmUrl,
         math: this.opts.math,

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -34,6 +34,10 @@ import type {
  *  from `@silurus/ooxml-core` (`useGoogleFonts`, `maxZipEntryBytes`, `math`)
  *  with the worker-rendering mode. */
 export interface LoadOptions extends CoreLoadOptions {
+  /** Maximum decompressed bytes across distinct ZIP entries (default: 512 MiB). */
+  maxZipTotalBytes?: number;
+  /** Maximum ZIP central-directory entries (default: 20,000). */
+  maxZipEntries?: number;
   /**
    * 'main' (default): parse in a worker, render on the main thread (current
    * behaviour). 'worker': parse AND render inside the worker; use
@@ -65,6 +69,8 @@ export class XlsxWorkbook {
     this.getImage(path, mime);
   private rawData: ArrayBuffer | null = null;
   private maxZipEntryBytes: number | undefined;
+  private maxZipTotalBytes: number | undefined;
+  private maxZipEntries: number | undefined;
   /** Opt-in OMML equation engine, injected once at {@link load}. Every
    *  `renderViewport` call reuses it — equations in shapes render when present,
    *  and are skipped (engine tree-shaken) when omitted. */
@@ -131,6 +137,8 @@ export class XlsxWorkbook {
   private async _load(data: ArrayBuffer, opts: LoadOptions = {}): Promise<void> {
     this.rawData = data;
     this.maxZipEntryBytes = opts.maxZipEntryBytes;
+    this.maxZipTotalBytes = opts.maxZipTotalBytes;
+    this.maxZipEntries = opts.maxZipEntries;
     this.math = opts.math;
     if (opts.math && this._mode === 'worker') {
       console.warn(
@@ -148,6 +156,8 @@ export class XlsxWorkbook {
               id,
               data: data.slice(0),
               maxZipEntryBytes: this.maxZipEntryBytes,
+              maxZipTotalBytes: this.maxZipTotalBytes,
+              maxZipEntries: this.maxZipEntries,
               useGoogleFonts: !!opts.useGoogleFonts,
             } satisfies RenderWorkerRequest)
           : ({
@@ -155,6 +165,8 @@ export class XlsxWorkbook {
               id,
               data: data.slice(0),
               maxZipEntryBytes: this.maxZipEntryBytes,
+              maxZipTotalBytes: this.maxZipTotalBytes,
+              maxZipEntries: this.maxZipEntries,
             } satisfies WorkerRequest),
       undefined,
       { timeoutMs: opts.workerTimeoutMs },
@@ -243,6 +255,8 @@ export class XlsxWorkbook {
       sheetIndex,
       sheetName: sheetMeta.name,
       maxZipEntryBytes: this.maxZipEntryBytes,
+      maxZipTotalBytes: this.maxZipTotalBytes,
+      maxZipEntries: this.maxZipEntries,
     }));
     // Parse mode: the worker forwards the sheet as transferred UTF-8 JSON bytes
     // — decode + parse once here. Worker (render) mode: the worker already

--- a/packages/xlsx/src/worker-protocol.ts
+++ b/packages/xlsx/src/worker-protocol.ts
@@ -67,7 +67,7 @@ export type WireRenderViewportOptions = Omit<
 // `init` arm is copied verbatim from `WorkerRequest`.
 export type RenderWorkerRequest =
   | { type: 'init'; wasmUrl: string }
-  | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number; useGoogleFonts?: boolean }
+  | { type: 'parse'; id: number; data: ArrayBuffer; maxZipEntryBytes?: number; maxZipTotalBytes?: number; maxZipEntries?: number; useGoogleFonts?: boolean }
   // `parseSheet` lets worker-mode XlsxWorkbook.getWorksheet (and the
   // resolveValidationList range path that awaits it) work, mirroring how the
   // pptx render worker handles `extractMedia` for getMedia. The render worker
@@ -76,7 +76,7 @@ export type RenderWorkerRequest =
   // main-mode message getWorksheet posts but is ignored (the worker derives the
   // sheet name from its own `workbook`). No `data`: like main-mode `parseSheet`,
   // the buffer retained at `parse` is reused — never re-sent per sheet.
-  | { type: 'parseSheet'; id: number; sheetIndex: number; sheetName?: string; maxZipEntryBytes?: number }
+  | { type: 'parseSheet'; id: number; sheetIndex: number; sheetName?: string; maxZipEntryBytes?: number; maxZipTotalBytes?: number; maxZipEntries?: number }
   | { type: 'renderViewport'; id: number; sheetIndex: number; viewport: ViewportRange; opts: WireRenderViewportOptions }
   // Worker render mode decodes images in-worker via a getImage closure; this arm
   // exists only for protocol parity with worker.ts (so a stray extractImage

--- a/packages/xlsx/src/worker.ts
+++ b/packages/xlsx/src/worker.ts
@@ -43,6 +43,14 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
         typeof req.maxZipEntryBytes === 'number' && req.maxZipEntryBytes > 0
           ? BigInt(req.maxZipEntryBytes)
           : undefined;
+      const maxTotal =
+        typeof req.maxZipTotalBytes === 'number' && req.maxZipTotalBytes > 0
+          ? BigInt(req.maxZipTotalBytes)
+          : undefined;
+      const maxEntries =
+        typeof req.maxZipEntries === 'number' && req.maxZipEntries > 0
+          ? BigInt(req.maxZipEntries)
+          : undefined;
       const bytes = new Uint8Array(req.data);
       // Both the construction and `parse()` run under `host.run` so a trap in
       // EITHER poisons + recycles the instance (and frees the archive). Adopting
@@ -52,7 +60,7 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
       // buffer, so forward it to main as a transferable — no clone, no decode
       // here. The single decode + JSON.parse happens on main.
       const json = host.run(() => {
-        const archive = new XlsxArchive(bytes, max);
+        const archive = new XlsxArchive(bytes, max, maxTotal, maxEntries);
         host.setArchive(archive);
         return archive.parse();
       });

--- a/packages/xlsx/src/zip-budget-options.test.ts
+++ b/packages/xlsx/src/zip-budget-options.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { XlsxWorkbook } from './workbook.js';
+
+describe('XlsxWorkbook ZIP budget wiring', () => {
+  it('forwards the same limits to the initial parse and retained-archive sheet parse', async () => {
+    const requests: Record<string, unknown>[] = [];
+    const instance = Object.create(XlsxWorkbook.prototype) as Record<string, unknown>;
+    instance._mode = 'worker';
+    instance.sheetCache = new Map();
+    instance.imageCache = new Map();
+    instance.imageBlobCache = new Map();
+    instance.googleFontFaces = [];
+    instance.bridge = {
+      request: vi.fn(async (createRequest: (id: number) => Record<string, unknown>) => {
+        const request = createRequest(requests.length + 1);
+        requests.push(request);
+        if (request.type === 'parse') {
+          return {
+            type: 'parsed',
+            id: 1,
+            workbook: {
+              workbook: { sheets: [{ name: 'Sheet1' }] },
+              styles: {},
+              sharedStrings: [],
+            },
+          };
+        }
+        return {
+          type: 'parsedSheet',
+          id: 2,
+          worksheet: {
+            name: 'Sheet1',
+            rows: [],
+            colWidths: {},
+            rowHeights: {},
+            defaultColWidth: 8,
+            defaultRowHeight: 15,
+            mergeCells: [],
+            freezeRows: 0,
+            freezeCols: 0,
+            conditionalFormats: [],
+            images: [],
+            charts: [],
+          },
+        };
+      }),
+    };
+
+    await (
+      instance as unknown as {
+        _load(data: ArrayBuffer, options: Record<string, unknown>): Promise<void>;
+        getWorksheet(index: number): Promise<unknown>;
+      }
+    )._load(new ArrayBuffer(1), {
+      maxZipEntryBytes: 64,
+      maxZipTotalBytes: 512,
+      maxZipEntries: 20_000,
+    });
+    await (
+      instance as unknown as { getWorksheet(index: number): Promise<unknown> }
+    ).getWorksheet(0);
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toMatchObject({
+      type: 'parse',
+      maxZipEntryBytes: 64,
+      maxZipTotalBytes: 512,
+      maxZipEntries: 20_000,
+    });
+    expect(requests[1]).toMatchObject({
+      type: 'parseSheet',
+      maxZipEntryBytes: 64,
+      maxZipTotalBytes: 512,
+      maxZipEntries: 20_000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add a shared fail-closed ZIP budget covering per-entry bytes, aggregate expanded bytes, and archive entry count
- enforce declared archive limits before reads and actual post-inflate bytes while entries are consumed
- retain one budget across DOCX, XLSX, and PPTX parser objects and propagate limits through main/render worker protocols
- preserve poisoning after a proven breach so later reads cannot continue from a partially trusted archive

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm exec vitest run packages/docx/src packages/pptx/src packages/xlsx/src` (431 files, 3,982 tests)
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` (pre-existing warning-only tripwires)

## Notes

The full root Vitest command also exercises unrelated Node pixel-equality tests; two effect-crop assertions failed and the run did not terminate promptly. All DOCX/XLSX/PPTX package suites and the complete Rust workspace are green.

This PR does not change rendering behavior or add a compatibility fallback.
