### PR TITLE
fix(vscode): enable embedded presentation media

### DIFF
--- a/packages/pptx/src/presentation-handle-media-errors.test.ts
+++ b/packages/pptx/src/presentation-handle-media-errors.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPresentationHandle, type PresentOptions } from './presentation-handle';
+import type { MediaElement } from './types';
+
+type Listener = (event: Event) => void;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function mediaElement(kind: 'audio' | 'video' = 'audio'): MediaElement {
+  return {
+    type: 'media',
+    x: 0,
+    y: 0,
+    width: 914_400,
+    height: 914_400,
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+    mediaKind: kind,
+    posterPath: '',
+    posterMimeType: '',
+    mediaPath: kind === 'audio' ? 'ppt/media/clip.mp3' : 'ppt/media/clip.mp4',
+    mimeType: kind === 'audio' ? 'audio/mpeg' : 'video/mp4',
+  };
+}
+
+function makeContext() {
+  const gradient = { addColorStop: vi.fn() };
+  return {
+    setTransform: vi.fn(),
+    drawImage: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    closePath: vi.fn(),
+    createLinearGradient: vi.fn(() => gradient),
+    measureText: vi.fn((text: string) => ({ width: text.length * 6 })),
+    fillText: vi.fn(),
+    font: '',
+    textAlign: 'left',
+    textBaseline: 'alphabetic',
+    fillStyle: '',
+    shadowColor: '',
+    shadowBlur: 0,
+  };
+}
+
+function makeCanvas(ctx = makeContext()) {
+  const listeners = new Map<string, Listener[]>();
+  return {
+    width: 960,
+    height: 540,
+    style: { cursor: '' },
+    getContext: vi.fn(() => ctx),
+    getBoundingClientRect: vi.fn(() => ({ left: 0, top: 0, width: 960, height: 540 })),
+    addEventListener: vi.fn((type: string, listener: Listener) => {
+      const list = listeners.get(type) ?? [];
+      list.push(listener);
+      listeners.set(type, list);
+    }),
+    removeEventListener: vi.fn((type: string, listener: Listener) => {
+      listeners.set(type, (listeners.get(type) ?? []).filter((item) => item !== listener));
+    }),
+    setPointerCapture: vi.fn(),
+    releasePointerCapture: vi.fn(),
+  };
+}
+
+function makeMedia() {
+  const listeners = new Map<string, Listener[]>();
+  const media = {
+    src: '',
+    preload: '',
+    playsInline: false,
+    paused: true,
+    duration: Number.NaN,
+    currentTime: 0,
+    readyState: 0,
+    networkState: 0,
+    error: null as MediaError | null,
+    play: vi.fn(() => Promise.resolve()),
+    pause: vi.fn(),
+    load: vi.fn(),
+    canPlayType: vi.fn(() => 'probably'),
+    removeAttribute: vi.fn(),
+    addEventListener: vi.fn((type: string, listener: Listener) => {
+      const list = listeners.get(type) ?? [];
+      list.push(listener);
+      listeners.set(type, list);
+    }),
+    removeEventListener: vi.fn((type: string, listener: Listener) => {
+      listeners.set(type, (listeners.get(type) ?? []).filter((item) => item !== listener));
+    }),
+    dispatch(type: string) {
+      for (const listener of listeners.get(type) ?? []) listener(new Event(type));
+    },
+  };
+  return media;
+}
+
+function installDom(media = makeMedia()) {
+  const baseContext = makeContext();
+  const baseCanvas = makeCanvas(baseContext);
+  vi.stubGlobal('document', {
+    createElement(tag: string) {
+      return tag === 'canvas' ? baseCanvas : media;
+    },
+  });
+  vi.stubGlobal('URL', {
+    createObjectURL: vi.fn(() => 'blob:media'),
+    revokeObjectURL: vi.fn(),
+  });
+  vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1));
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  return { media, baseCanvas, baseContext };
+}
+
+function options(overrides: Partial<PresentOptions> = {}): PresentOptions {
+  return {
+    width: 960,
+    dpr: 1,
+    slideWidthEmu: 9_144_000,
+    fetchMedia: vi.fn(async () => new Blob(['media'], { type: 'audio/mpeg' })),
+    fetchImage: vi.fn(),
+    drawBase: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('presentation media failure reporting', () => {
+  it('reports fetchMedia failures with the media path instead of silently skipping them', async () => {
+    installDom();
+    const onError = vi.fn();
+    const canvasContext = makeContext();
+    const canvas = makeCanvas(canvasContext);
+
+    await createPresentationHandle(
+      canvas as unknown as HTMLCanvasElement,
+      [mediaElement()],
+      options({
+        fetchMedia: vi.fn(async () => {
+          throw new Error('archive read failed');
+        }),
+        onError,
+      }),
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0].message).toContain('ppt/media/clip.mp3');
+    expect(onError.mock.calls[0][0].message).toContain('archive read failed');
+    expect(canvasContext.fillText).toHaveBeenLastCalledWith(
+      'Media unavailable',
+      expect.any(Number),
+      expect.any(Number),
+    );
+  });
+
+  it('registers readiness/error listeners, explicitly loads media, and reports decode errors', async () => {
+    const { media } = installDom();
+    const onError = vi.fn();
+
+    const handle = await createPresentationHandle(
+      makeCanvas() as unknown as HTMLCanvasElement,
+      [mediaElement('video')],
+      options({
+        fetchMedia: vi.fn(async () => new Blob(['video'], { type: 'video/mp4' })),
+        onError,
+      }),
+    );
+
+    expect(media.addEventListener).toHaveBeenCalledWith('loadedmetadata', expect.any(Function));
+    expect(media.addEventListener).toHaveBeenCalledWith('canplay', expect.any(Function));
+    expect(media.addEventListener).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(media.load).toHaveBeenCalledTimes(1);
+
+    media.error = { code: 4, message: 'unsupported source' } as MediaError;
+    media.dispatch('error');
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const error = onError.mock.calls[0][0] as Error;
+    expect(error.message).toContain('ppt/media/clip.mp4');
+    expect(error.message).toContain('unsupported source');
+    expect(error.message).toContain('readyState=0');
+    expect(error.message).toContain('canPlayType=probably');
+    handle.destroy();
+  });
+
+  it('reports play() promise rejections instead of discarding them', async () => {
+    const { media } = installDom();
+    const onError = vi.fn();
+    media.play.mockRejectedValueOnce(new DOMException('codec unavailable', 'NotSupportedError'));
+
+    const handle = await createPresentationHandle(
+      makeCanvas() as unknown as HTMLCanvasElement,
+      [mediaElement()],
+      options({ onError }),
+    );
+    handle.play();
+    await Promise.resolve();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const error = onError.mock.calls[0][0] as Error;
+    expect(error.message).toContain('play');
+    expect(error.message).toContain('NotSupportedError');
+    expect(error.message).toContain('codec unavailable');
+    handle.destroy();
+  });
+
+  it('does not report a late play rejection after the handle is destroyed', async () => {
+    const { media } = installDom();
+    const onError = vi.fn();
+    const pendingPlay = deferred<void>();
+    media.play.mockReturnValueOnce(pendingPlay.promise);
+
+    const handle = await createPresentationHandle(
+      makeCanvas() as unknown as HTMLCanvasElement,
+      [mediaElement()],
+      options({ onError }),
+    );
+    handle.play();
+    handle.destroy();
+    pendingPlay.reject(new DOMException('interrupted by teardown', 'AbortError'));
+    await Promise.resolve();
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('draws a loading affordance while a large media extraction is pending', async () => {
+    installDom();
+    const pending = deferred<Blob>();
+    const canvasContext = makeContext();
+    const promise = createPresentationHandle(
+      makeCanvas(canvasContext) as unknown as HTMLCanvasElement,
+      [mediaElement('video')],
+      options({ fetchMedia: vi.fn(() => pending.promise) }),
+    );
+    await Promise.resolve();
+
+    expect(canvasContext.fillText).toHaveBeenCalledWith(
+      expect.stringContaining('Loading'),
+      expect.any(Number),
+      expect.any(Number),
+    );
+
+    pending.resolve(new Blob(['video'], { type: 'video/mp4' }));
+    const handle = await promise;
+    handle.destroy();
+  });
+});

--- a/packages/pptx/src/presentation-handle.ts
+++ b/packages/pptx/src/presentation-handle.ts
@@ -15,6 +15,8 @@ interface MediaState {
   posterRect: { x: number; y: number; w: number; h: number };
   media: HTMLVideoElement | HTMLAudioElement;
   objectUrl: string;
+  loadState: 'loading' | 'metadata' | 'ready' | 'error';
+  detachListeners: () => void;
 }
 
 export interface PresentationHandle {
@@ -48,6 +50,8 @@ export interface PresentOptions {
   fetchImage: (imagePath: string, mimeType: string) => Promise<Blob>;
   /** Draw the static slide (poster + play badge) onto the canvas. */
   drawBase: () => Promise<void>;
+  /** Report an embedded-media fetch, decode, or playback failure. */
+  onError?: (error: Error) => void;
 }
 
 /**
@@ -76,12 +80,34 @@ export async function createPresentationHandle(
   baseCtx.drawImage(canvas, 0, 0);
 
   const states: MediaState[] = [];
+  const unavailableRects: Array<{ x: number; y: number; w: number; h: number }> = [];
+  let disposed = false;
+
+  const reportError = (error: Error) => {
+    if (disposed) return;
+    if (opts.onError) opts.onError(error);
+    else console.error('[ooxml] PPTX embedded media failed:', error);
+  };
+
+  // Media extraction can be noticeably slower than the static slide paint
+  // (large embedded videos are common). Keep the already-painted slide visible
+  // and make the pending state explicit while each Blob is read from the PPTX.
+  if (mediaElements.length > 0) {
+    ctx.save();
+    ctx.setTransform(opts.dpr, 0, 0, opts.dpr, 0, 0);
+    for (const el of mediaElements) {
+      drawMediaStatus(ctx, mediaRect(el, slideScale), 'Loading media…');
+    }
+    ctx.restore();
+  }
 
   for (const el of mediaElements) {
     let blob: Blob;
     try {
       blob = await opts.fetchMedia(el.mediaPath);
-    } catch {
+    } catch (cause) {
+      reportError(mediaFetchError(el, cause));
+      unavailableRects.push(mediaRect(el, slideScale));
       continue;
     }
     // getMedia already types the blob in main mode; re-wrapping copies the whole
@@ -100,12 +126,7 @@ export async function createPresentationHandle(
     if (el.mediaKind === 'video') {
       (media as HTMLVideoElement).playsInline = true;
     }
-    const posterRect = {
-      x: emuToPx(el.x, slideScale),
-      y: emuToPx(el.y, slideScale),
-      w: emuToPx(el.width, slideScale),
-      h: emuToPx(el.height, slideScale),
-    };
+    const posterRect = mediaRect(el, slideScale);
     // Audio icons in pptx are often small (40–80 px); a bar that narrow is
     // unusable, so expand the control surface horizontally and push it
     // downward below the icon so the bar sits clearly under the speaker —
@@ -119,11 +140,44 @@ export async function createPresentationHandle(
           h: posterRect.h + 36,
         }
       : posterRect;
-    states.push({ el, rect, posterRect, media, objectUrl: url });
+    const state: MediaState = {
+      el,
+      rect,
+      posterRect,
+      media,
+      objectUrl: url,
+      loadState: 'loading',
+      detachListeners: () => {},
+    };
+    const onLoadedMetadata = () => {
+      if (!disposed) state.loadState = 'metadata';
+    };
+    const onCanPlay = () => {
+      if (!disposed) state.loadState = 'ready';
+    };
+    const onMediaError = () => {
+      if (disposed) return;
+      state.loadState = 'error';
+      reportError(mediaRuntimeError(el, media, 'decode'));
+    };
+    media.addEventListener('loadedmetadata', onLoadedMetadata);
+    media.addEventListener('canplay', onCanPlay);
+    media.addEventListener('error', onMediaError);
+    state.detachListeners = () => {
+      media.removeEventListener('loadedmetadata', onLoadedMetadata);
+      media.removeEventListener('canplay', onCanPlay);
+      media.removeEventListener('error', onMediaError);
+    };
+    states.push(state);
+    try {
+      media.load();
+    } catch (cause) {
+      state.loadState = 'error';
+      reportError(mediaRuntimeError(el, media, 'load', cause));
+    }
   }
 
   let rafId: number | null = null;
-  let disposed = false;
   let hoveredState: MediaState | null = null;
 
   const drawFrame = () => {
@@ -132,8 +186,21 @@ export async function createPresentationHandle(
     const cssH = canvas.height / opts.dpr;
     ctx.drawImage(base, 0, 0, canvas.width, canvas.height, 0, 0, cssW, cssH);
 
+    for (const rect of unavailableRects) {
+      drawMediaStatus(ctx, rect, 'Media unavailable');
+    }
+
     for (const s of states) {
       const media = s.media;
+
+      if (s.loadState === 'loading') {
+        drawMediaStatus(ctx, s.posterRect, 'Loading media…');
+        continue;
+      }
+      if (s.loadState === 'error') {
+        drawMediaStatus(ctx, s.posterRect, 'Media unavailable');
+        continue;
+      }
 
       // Draw the current video frame whenever the element has pixel data —
       // paused or playing. Paused should hold the frame you stopped on, not
@@ -218,6 +285,16 @@ export async function createPresentationHandle(
     state.media.currentTime = duration * fraction;
   };
 
+  const playMedia = (state: MediaState) => {
+    try {
+      void state.media.play().catch((cause: unknown) => {
+        reportError(mediaRuntimeError(state.el, state.media, 'play', cause));
+      });
+    } catch (cause) {
+      reportError(mediaRuntimeError(state.el, state.media, 'play', cause));
+    }
+  };
+
   const onPointerDown = (e: PointerEvent) => {
     const { x: lx, y: ly } = toLocal(e.clientX, e.clientY);
     const hit = hitTest(lx, ly);
@@ -229,7 +306,7 @@ export async function createPresentationHandle(
       canvas.setPointerCapture(e.pointerId);
       e.preventDefault();
     } else {
-      if (hit.state.media.paused) void hit.state.media.play().catch(() => undefined);
+      if (hit.state.media.paused) playMedia(hit.state);
       else hit.state.media.pause();
     }
   };
@@ -261,7 +338,7 @@ export async function createPresentationHandle(
     const { wasPlaying, state } = seeking;
     seeking = null;
     canvas.releasePointerCapture(e.pointerId);
-    if (wasPlaying) void state.media.play().catch(() => undefined);
+    if (wasPlaying) playMedia(state);
   };
 
   // Slides without media: no playback overlay, so skip the RAF loop and
@@ -274,13 +351,18 @@ export async function createPresentationHandle(
     canvas.addEventListener('pointercancel', onPointerUp);
     canvas.style.cursor = 'pointer';
     tick();
+  } else if (unavailableRects.length > 0) {
+    // A slide whose every media fetch failed has no RAF-backed state. Replace
+    // the provisional loading badges once so the canvas does not remain stuck
+    // on "Loading media…" after the failure was already reported.
+    drawFrame();
   }
 
   return {
     play(mediaPath) {
       for (const s of states) {
         if (!mediaPath || s.el.mediaPath === mediaPath) {
-          void s.media.play().catch(() => undefined);
+          playMedia(s);
         }
       }
     },
@@ -300,6 +382,7 @@ export async function createPresentationHandle(
       canvas.removeEventListener('pointercancel', onPointerUp);
       canvas.style.cursor = '';
       for (const s of states) {
+        s.detachListeners();
         s.media.pause();
         s.media.removeAttribute('src');
         s.media.load();
@@ -307,6 +390,83 @@ export async function createPresentationHandle(
       }
     },
   };
+}
+
+function mediaRect(el: MediaElement, slideScale: number) {
+  return {
+    x: emuToPx(el.x, slideScale),
+    y: emuToPx(el.y, slideScale),
+    w: emuToPx(el.width, slideScale),
+    h: emuToPx(el.height, slideScale),
+  };
+}
+
+function drawMediaStatus(
+  ctx: CanvasRenderingContext2D,
+  rect: { x: number; y: number; w: number; h: number },
+  label: string,
+): void {
+  const fontSize = Math.max(10, Math.min(14, rect.h * 0.12));
+  ctx.save();
+  ctx.font = `500 ${fontSize}px system-ui, -apple-system, sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  const padX = 12;
+  const h = fontSize + 12;
+  const w = Math.min(rect.w, Math.max(100, ctx.measureText(label).width + padX * 2));
+  const x = rect.x + (rect.w - w) / 2;
+  const y = rect.y + (rect.h - h) / 2;
+  roundedRect(ctx, x, y, w, h, h / 2);
+  ctx.fillStyle = 'rgba(20, 20, 20, 0.72)';
+  ctx.fill();
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.95)';
+  ctx.fillText(label, rect.x + rect.w / 2, rect.y + rect.h / 2);
+  ctx.restore();
+}
+
+function mediaFetchError(el: MediaElement, cause: unknown): Error {
+  return new Error(
+    `Embedded ${el.mediaKind} fetch failed for "${el.mediaPath}" ` +
+      `(mime=${el.mimeType || 'unknown'}): ${describeCause(cause)}`,
+  );
+}
+
+function mediaRuntimeError(
+  el: MediaElement,
+  media: HTMLMediaElement,
+  stage: 'load' | 'decode' | 'play',
+  cause?: unknown,
+): Error {
+  let support = '';
+  try {
+    support = el.mimeType ? media.canPlayType(el.mimeType) : '';
+  } catch {
+    // Diagnostic only; failure reporting itself must remain reliable.
+  }
+  const nativeError = media.error;
+  const details = [
+    `mime=${el.mimeType || 'unknown'}`,
+    `canPlayType=${support || 'no'}`,
+    `readyState=${media.readyState}`,
+    `networkState=${media.networkState}`,
+  ];
+  if (nativeError) {
+    details.push(
+      `mediaError=${nativeError.code}${nativeError.message ? ` ${nativeError.message}` : ''}`,
+    );
+  }
+  const causeText = cause === undefined ? '' : `: ${describeCause(cause)}`;
+  return new Error(
+    `Embedded ${el.mediaKind} ${stage} failed for "${el.mediaPath}" ` +
+      `(${details.join('; ')})${causeText}`,
+  );
+}
+
+function describeCause(cause: unknown): string {
+  if (cause instanceof Error) {
+    return `${cause.name || 'Error'}${cause.message ? `: ${cause.message}` : ''}`;
+  }
+  return String(cause);
 }
 
 const AUDIO_PILL_H = 28;

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -81,6 +81,11 @@ export interface RenderSlideOptions {
   skipMediaControls?: boolean;
   /** Translucent overlay drawn over the finished slide (hidden-slide dimming). */
   dim?: DimOptions;
+  /**
+   * Called for asynchronous embedded-media fetch, decode, and playback
+   * failures created by {@link PptxPresentation.presentSlide}.
+   */
+  onError?: (error: Error) => void;
 }
 
 /**
@@ -568,6 +573,7 @@ export class PptxPresentation {
       fetchMedia: (path) => this.getMedia(path),
       fetchImage: this._fetchImage,
       drawBase,
+      onError: opts.onError,
     });
   }
 

--- a/packages/pptx/src/scroll-viewer-test-dom.ts
+++ b/packages/pptx/src/scroll-viewer-test-dom.ts
@@ -281,6 +281,7 @@ export interface RenderCall {
 
 export interface PresentationCall extends RenderCall {
   handle: PresentationHandle & { destroy: ReturnType<typeof vi.fn> };
+  reportError?: (error: Error) => void;
 }
 
 /** A fake PptxPresentation covering exactly the surface PptxScrollViewer consumes.
@@ -395,6 +396,7 @@ export class FakePptxEngine {
         width: opts?.width,
         canvas,
         handle,
+        reportError: opts?.onError,
         resolve: () => resolve(handle),
         reject,
       };

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1014,6 +1014,35 @@ describe('PptxScrollViewer — interactive media lifecycle', () => {
     },
   );
 
+  it('routes asynchronous media failures through the viewer onError callback', () => {
+    installDom();
+    const container = makeContainer(200, 400);
+    const engine = new FakePptxEngine(2, SLIDE_W_EMU, SLIDE_H_EMU, 'main', true);
+    const onError = vi.fn();
+    const v = new PptxScrollViewer(container as unknown as HTMLElement, {
+      presentation: engine.asPres(),
+      enableMediaPlayback: true,
+      onError,
+      gap: 10,
+      paddingTop: 0,
+      paddingBottom: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+    });
+    const scrollHost = (container.children[0] as FakeEl).children[0] as FakeEl;
+    scrollHost.clientWidth = 200;
+    scrollHost.clientHeight = 400;
+    v.relayout();
+
+    const call = engine.presentationCalls[0];
+    expect(call.reportError).toEqual(expect.any(Function));
+    call.reportError?.(new Error('media decode failed'));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0].message).toContain('media decode failed');
+    v.destroy();
+  });
+
   it('keeps interactive media bounded when text-selection overscan mounts a large deck', () => {
     installDom();
     const container = makeContainer(200, 400);

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -151,9 +151,10 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
   /** Error callback. When set, `load()` invokes it and resolves (otherwise the
    *  error is rethrown — shared viewer error contract). It ALSO fires for async
    *  per-slot render failures (both main `renderSlide` and worker
-   *  `renderSlideToBitmap` rejections); a failed slide is left blank rather than
-   *  crashing the loop. Without an `onError`, render failures are logged via
-   *  `console.error` so they are never fully silent. */
+   *  `renderSlideToBitmap` rejections) and embedded-media fetch/decode/playback
+   *  failures. A failed slide is left blank rather than crashing the loop.
+   *  Without an `onError`, failures are logged via `console.error` so they are
+   *  never fully silent. */
   onError?: (err: Error) => void;
   /**
    * IX1 (design decision — NOT user-confirmed, integrator may veto). Fires on a
@@ -982,7 +983,14 @@ export class PptxScrollViewer implements ZoomableViewer {
     const onTextRun = wantRuns ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
 
     this._pres
-      .presentSlide(slot.canvas, i, { width: widthPx, dpr, onTextRun })
+      .presentSlide(slot.canvas, i, {
+        width: widthPx,
+        dpr,
+        onTextRun,
+        onError: (error) => {
+          if (generation === slot.presentationGeneration) this._reportRenderError(error);
+        },
+      })
       .then((handle) => {
         if (
           generation !== slot.presentationGeneration ||
@@ -1644,7 +1652,14 @@ export class PptxScrollViewer implements ZoomableViewer {
     const onTextRun = wantRuns ? (r: PptxTextRunInfo) => runs.push(r) : undefined;
 
     this._pres
-      .presentSlide(spare, i, { width: widthPx, dpr, onTextRun })
+      .presentSlide(spare, i, {
+        width: widthPx,
+        dpr,
+        onTextRun,
+        onError: (error) => {
+          if (generation === slot.presentationGeneration) this._reportRenderError(error);
+        },
+      })
       .then((handle) => {
         if (
           generation !== slot.presentationGeneration ||

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -28,7 +28,7 @@ const DEFAULT_HIDDEN_DIM: DimOptions = { color: '#ffffff', opacity: 0.6 };
 export interface PptxViewerOptions extends RenderOptions, LoadOptions {
   /** Called when a slide finishes rendering */
   onSlideChange?: (index: number, total: number) => void;
-  /** Called on parse or render errors */
+  /** Called on parse, render, or embedded-media playback errors. */
   onError?: (err: Error) => void;
   /** IX9 zoom contract ({@link ZoomableViewer}) — the clamp range for
    *  {@link PptxViewer.setScale} / `zoomIn` / `zoomOut` / `fitWidth` / `fitPage`,
@@ -490,6 +490,7 @@ export class PptxViewer implements ZoomableViewer {
           dpr,
           dim,
           onTextRun,
+          onError: (error) => this._reportRenderError(error),
         });
       } else if (isWorker) {
         const bmp = await this.engine.renderSlideToBitmap(this.currentSlide, { width: targetWidth, dpr, dim, onTextRun });

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -18,7 +18,7 @@ A high-fidelity viewer for `.docx`, `.xlsx`, and `.pptx` files — powered by a 
 
 - **DOCX** — Continuous **scroll view** of every page with a transparent text layer (PDF.js-style) — drag to select, copy as plain text.
 - **XLSX** — Spreadsheet viewer with cell / row / column / range selection, tab-separated copy (Ctrl+C / Cmd+C), freeze-pane support, and a multi-sheet tab bar.
-- **PPTX** — Continuous **scroll view** of every slide with a transparent text layer that handles rotated text boxes correctly.
+- **PPTX** — Continuous **scroll view** of every slide with a transparent text layer that handles rotated text boxes correctly, plus interactive playback for embedded audio and video.
 - **Find in preview** — Press **Ctrl+F / Cmd+F** to search the complete document, workbook, or presentation. Matching is case-insensitive; Enter / Shift+Enter moves between results.
 - **High fidelity** — Charts, conditional formatting, theme colors, custom geometry shapes, math equations (OMML, via MathJax + STIX Two Math), and more rendered straight from the OOXML spec.
 - **MCP server (opt-in)** — Lets AI coding agents (Copilot, Claude, etc.) read `.xlsx` / `.docx` / `.pptx` files in your workspace through dedicated tools instead of unzipping XML by hand. See [MCP server for AI agents](#mcp-server-for-ai-agents) below.
@@ -89,7 +89,9 @@ VS Code's own telemetry is independent of this extension and can be controlled v
 - XLSX: formula evaluation is not yet supported (raw cached values are shown).
 - DOCX: image-anchored float wrap, footnotes, and header/footer rendering may differ slightly from Word.
 - PPTX: a small number of obscure preset shapes fall back to a rectangle placeholder.
-- Media playback (audio / video) is not supported in the Webview.
+- PPTX media: VS Code Webviews support MP3 audio and H.264 video, but not AAC
+  audio tracks. An H.264/AAC MP4 therefore plays video without sound; use a
+  separate MP3 audio track when sound is required.
 
 ## Issues & Contributions
 

--- a/packages/vscode-extension/src/pptxMediaPlayback.test.ts
+++ b/packages/vscode-extension/src/pptxMediaPlayback.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const bootstrap = readFileSync(
+  new URL('./webview/bootstrap.ts', import.meta.url),
+  'utf8',
+);
+
+describe('VS Code PPTX media playback wiring', () => {
+  it('enables interactive media on the continuous-scroll viewer', () => {
+    const pptxInitializer = bootstrap.match(
+      /async function initPptx[\s\S]*?new PptxScrollViewer\([\s\S]*?\n  \}\);/,
+    )?.[0];
+
+    expect(pptxInitializer).toBeDefined();
+    expect(pptxInitializer).toContain('enableMediaPlayback: true');
+    expect(pptxInitializer).toContain('mediaOverscan: 1');
+  });
+});

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -220,6 +220,8 @@ async function initPptx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
     math,
     useGoogleFonts,
     enableTextSelection: true,
+    enableMediaPlayback: true,
+    mediaOverscan: 1,
     refitOnResize: true,
     background: 'var(--vscode-editor-background)',
     onScaleChange: updateZoomLabel,

--- a/packages/vscode-extension/src/webviewHtml.test.ts
+++ b/packages/vscode-extension/src/webviewHtml.test.ts
@@ -28,6 +28,7 @@ describe('buildContentSecurityPolicy', () => {
     expect(csp).toContain(`script-src 'nonce-${NONCE}' 'wasm-unsafe-eval'`);
     expect(csp).toContain("style-src 'unsafe-inline'");
     expect(csp).toContain(`font-src ${CSP_SOURCE}`);
+    expect(csp).toContain(`media-src ${CSP_SOURCE} blob:`);
   });
 
   it('whitelists only the two font CDN origins when enabled', () => {
@@ -47,6 +48,7 @@ describe('buildContentSecurityPolicy', () => {
     const connectSrc = csp.match(/connect-src ([^;]*)/)?.[1] ?? '';
     expect(connectSrc).not.toContain('googleapis');
     expect(connectSrc).not.toContain('gstatic');
+    expect(csp).toContain(`media-src ${CSP_SOURCE} blob:`);
   });
 });
 


### PR DESCRIPTION
## What changed

- enable interactive embedded PPTX audio/video in the VS Code scroll viewer
- keep one adjacent slide mounted so media remains usable around the viewport boundary
- explicitly load media elements and track loading/readiness/error state
- surface media fetch, decode, and `play()` failures through the existing viewer `onError` contract
- show lightweight loading and unavailable affordances without replacing the slide poster
- clean up listeners, media sources, and Blob URLs when a slide is recycled or destroyed
- document VS Code Webview codec support and the AAC-audio limitation

## Why

The shared PPTX viewer already had embedded-media controls, but the VS Code Webview never enabled them. Playback failures were also intentionally swallowed, which made a codec error, an archive extraction failure, and an ordinary load failure indistinguishable.

VS Code Webviews support MP3 audio and H.264/VP8 video, but not AAC audio. An H.264/AAC MP4 therefore plays its video track without sound, as documented by the [VS Code Webview guide](https://code.visualstudio.com/api/extension-guides/webview#supported-media-formats).

## Verification

- 81 Vitest files / 537 tests passed
- root TypeScript project build passed
- VS Code extension TypeScript check passed
- VS Code extension esbuild bundle passed
- `git diff --check` passed
