### PR TITLE
fix(text): honor explicit DrawingML line spacing

### DIFF
--- a/packages/pptx/src/percentage-line-spacing.test.ts
+++ b/packages/pptx/src/percentage-line-spacing.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import { renderTextBody } from './renderer.js';
+import type { Bullet, Paragraph, TextBody } from './types';
+import type { TextRun } from '@silurus/ooxml-core';
+
+/**
+ * DrawingML percentage line spacing is authored explicitly by `a:lnSpc >
+ * a:spcPct` (ECMA-376 §21.1.2.2.5 / §21.1.2.2.11). It is based on the
+ * largest text size on the line. A document-font design-height floor used for
+ * implicit single spacing must therefore not override an explicit percentage.
+ *
+ * The regression was visible with Meiryo UI: its 1.596-em design-height floor
+ * expanded an authored 100% line pitch, while PowerPoint kept the same pitch as
+ * another face at the same point size.
+ */
+
+const SCALE = 1 / 12700; // 1 pt => 1 px
+
+function recordingCtx(): {
+  ctx: CanvasRenderingContext2D;
+  texts: Array<{ text: string; y: number }>;
+} {
+  const texts: Array<{ text: string; y: number }> = [];
+  let fillStyle = '';
+  let font = '';
+  let direction: CanvasDirection = 'ltr';
+  const ctx = {
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string) { fillStyle = v; },
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get direction() { return direction; },
+    set direction(v: CanvasDirection) { direction = v; },
+    measureText: (text: string) => ({
+      width: [...text].length * 10,
+      actualBoundingBoxAscent: 8,
+      actualBoundingBoxDescent: 2,
+      fontBoundingBoxAscent: 16,
+      fontBoundingBoxDescent: 4,
+    }),
+    fillText: (text: string, _x: number, y: number) => texts.push({ text, y }),
+    fillRect: () => {},
+    drawImage: () => {},
+    save: () => {},
+    restore: () => {},
+    translate: () => {},
+    rotate: () => {},
+    scale: () => {},
+    beginPath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    stroke: () => {},
+    clip: () => {},
+    rect: () => {},
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, texts };
+}
+
+function textRun(text: string, fontFamily: string): TextRun {
+  return {
+    type: 'text',
+    text,
+    bold: null,
+    italic: null,
+    underline: false,
+    strikethrough: false,
+    fontSize: 20,
+    color: '000000',
+    fontFamily,
+    fontFamilyEa: fontFamily,
+  };
+}
+
+function textBody(
+  fontFamily: string,
+  spaceLine: Paragraph['spaceLine'],
+  bullet: Bullet = { type: 'none' },
+): TextBody {
+  const paragraph = (text: string): Paragraph => ({
+    alignment: 'l',
+    marL: bullet.type === 'none' ? 0 : 342900,
+    marR: 0,
+    indent: bullet.type === 'none' ? 0 : -190500,
+    spaceBefore: 0,
+    spaceAfter: 0,
+    spaceLine,
+    lvl: 0,
+    bullet,
+    defFontSize: null,
+    defColor: null,
+    defBold: null,
+    defItalic: null,
+    defFontFamily: null,
+    tabStops: [],
+    eaLnBrk: true,
+    runs: [textRun(text, fontFamily)],
+  } as Paragraph);
+  return {
+    verticalAnchor: 't',
+    paragraphs: [paragraph('第一段落'), paragraph('第二段落')],
+    defaultFontSize: 20,
+    defaultBold: null,
+    defaultItalic: null,
+    lIns: 0,
+    rIns: 0,
+    tIns: 0,
+    bIns: 0,
+    wrap: 'square',
+    vert: 'horz',
+    autoFit: 'none',
+  } as TextBody;
+}
+
+function baselinePitch(
+  fontFamily: string,
+  spaceLine: Paragraph['spaceLine'],
+  bullet: Bullet = { type: 'none' },
+): number {
+  const { ctx, texts } = recordingCtx();
+  renderTextBody(ctx, textBody(fontFamily, spaceLine, bullet), 0, 0, 400, 300, SCALE);
+  const ys = [...new Set(texts.filter(({ text }) => text !== '•').map(({ y }) => y))]
+    .sort((a, b) => a - b);
+  expect(ys).toHaveLength(2);
+  return ys[1] - ys[0];
+}
+
+describe('pptx DrawingML percentage line spacing', () => {
+  const pct100: Paragraph['spaceLine'] = { type: 'pct', val: 100000 };
+  const bullet: Bullet = {
+    type: 'char',
+    char: '•',
+    color: null,
+    sizePct: null,
+    fontFamily: null,
+  };
+
+  it.each(['Meiryo UI', 'Sakkal Majalla'])(
+    'does not let the %s design-height floor override an explicit 100%',
+    (fontFamily) => {
+      expect(baselinePitch(fontFamily, pct100))
+        .toBeCloseTo(baselinePitch('Arial', pct100), 5);
+    },
+  );
+
+  it('applies the same explicit-percentage rule to bulleted paragraphs', () => {
+    expect(baselinePitch('Meiryo UI', pct100, bullet))
+      .toBeCloseTo(baselinePitch('Arial', pct100, bullet), 5);
+  });
+
+  it('keeps the Meiryo design-height floor for implicit single spacing', () => {
+    expect(baselinePitch('Meiryo UI', null))
+      .toBeGreaterThan(baselinePitch('Arial', null));
+  });
+
+  it('keeps absolute point line spacing independent of the font design height', () => {
+    const pts18: Paragraph['spaceLine'] = { type: 'pts', val: 18 };
+    expect(baselinePitch('Meiryo UI', pts18)).toBeCloseTo(18, 5);
+    expect(baselinePitch('Meiryo UI', pts18))
+      .toBeCloseTo(baselinePitch('Arial', pts18), 5);
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -3207,14 +3207,13 @@ export function renderTextBody(
       // defaults like `defRPr sz="30000"` (300pt prompt-text marker) would
       // inflate lineHeight and push real 24pt runs far below the anchor.
       let maxSizePx = 0;
-      // Design single-line-height FLOOR (ECMA-376 §17.3.1.33, shared with docx
-      // via core's `intendedSingleLinePx`). PowerPoint sizes single spacing as a
-      // flat 1.2×em; for a SUBSTITUTED face whose Windows design line height is
-      // taller than that (Meiryo 1.596×em, Sakkal Majalla 1.3965×em) the flat
-      // ratio understates Word/PowerPoint's line box and lines overlap. This is
-      // a FLOOR, not a replacement: `intendedSingleLinePx` returns 0 for every
-      // non-tabled family, so `max(1.2×em, 0)` leaves all other fonts (all Latin,
-      // installed CJK, etc.) exactly on PowerPoint's 1.2×em convention.
+      // Design single-line-height FLOOR for IMPLICIT single spacing, shared
+      // with docx via core's `intendedSingleLinePx`. For a substituted face
+      // whose Windows design line height is taller than the 1.2×em fallback
+      // (Meiryo 1.596×em, Sakkal Majalla 1.3965×em), the floor keeps omitted
+      // `<a:lnSpc>` from collapsing. It must not override an explicitly
+      // authored `<a:spcPct>`; §21.1.2.2.5 / §21.1.2.2.11 define percentage
+      // spacing from the line's largest text size.
       let designSingle = 0;
       for (const seg of line.segments) {
         // For an equation, the line must be at least as tall as its own font
@@ -3246,22 +3245,21 @@ export function renderTextBody(
         maxSizePx = bulletImage.sizePx;
       }
 
-      // Single-line base with the design-line-height floor applied (see the
-      // `designSingle` loop above). `singleLine` replaces the bare `maxSizePx *
-      // 1.2` everywhere the base is a MULTIPLE of the single line (the pct and
-      // no-spaceLine cases); the exact-pt `spcPts` case is an absolute height
-      // and is deliberately NOT floored.
-      const singleLine = Math.max(maxSizePx * 1.2, designSingle);
+      // PowerPoint's existing natural-line approximation for authored
+      // percentage spacing. The document-font design floor applies only when
+      // line spacing is omitted; an explicit percentage is already the
+      // author's vertical-spacing decision, and `spcPts` remains absolute.
+      const naturalSingle = maxSizePx * 1.2;
+      const implicitSingle = Math.max(naturalSingle, designSingle);
       let lineHeight: number;
       if (para.spaceLine) {
         if (para.spaceLine.type === 'pct') {
-          // spcPct 100% = single line spacing = natural font leading ≈ 1.2× em
-          lineHeight = singleLine * (para.spaceLine.val / 100000);
+          lineHeight = naturalSingle * (para.spaceLine.val / 100000);
         } else {
           lineHeight = para.spaceLine.val * PT_TO_EMU * scale;
         }
       } else {
-        lineHeight = singleLine;
+        lineHeight = implicitSingle;
       }
       // normAutofit lnSpcReduction (ECMA-376 §21.1.2.1.3): PowerPoint reduces
       // each paragraph's line spacing by this fraction alongside the font

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3978,10 +3978,11 @@ export function drawShapeText(
     let lineHeight = 0;
     let lineAscent = 0;
     let hasMath = false;
-    // ECMA-376 §21.1.2.2.5 <a:lnSpc> + §21.1.2.1.3 normAutofit lnSpcReduction,
-    // applied to a natural (design-floored) single-line height. Mirrors the pptx
-    // renderer. `h` is the natural single line, so it is the correct pct base;
-    // pts is an absolute per-line height (cs-scaled, like the cell/run px sizes).
+    // ECMA-376 §21.1.2.2.5 <a:lnSpc> + §21.1.2.1.3 normAutofit lnSpcReduction.
+    // An explicitly authored spcPct uses the natural 1.2×em line base; the
+    // document-font design floor is reserved for omitted line spacing. spcPts
+    // remains an absolute per-line height (cs-scaled, like the cell/run px sizes).
+    const hasExplicitPct = p.spaceLine?.type === 'pct';
     const applyLineSpacing = (h: number): number => {
       let out = h;
       if (p.spaceLine) {
@@ -4017,7 +4018,10 @@ export function drawShapeText(
           intendedSingleLinePx(lastTextFace, fallbackPx),
           intendedSingleLinePx(lastTextFaceEa, fallbackPx),
         );
-        lineHeight = Math.max(fallbackPx * 1.2, designFloor);
+        const naturalSingle = fallbackPx * 1.2;
+        lineHeight = hasExplicitPct
+          ? naturalSingle
+          : Math.max(naturalSingle, designFloor);
         // An empty line carries no segment, so this ascent is never consumed by
         // the draw pass (no text/math to place on the baseline); it is set only
         // to keep the Line shape consistent. Measure it the same way as text
@@ -4082,15 +4086,18 @@ export function drawShapeText(
       lastTextFaceEa = run.fontFaceEa;
       const { font, px: pxSize } = textFont(run);
       const color = run.color ?? '#000000';
-      // Floor the natural single line (Excel's flat 1.2×em) by the AUTHORED
-      // font's design line box (OS/2 win metrics, ECMA-376 §21.1.2.1.1) via
-      // core's intendedSingleLinePx — same floor docx/pptx apply. It returns 0
-      // for every untabled face (Calibri etc. stay on 1.2×em); a substituted
-      // Meiryo (1.596×em) / Sakkal Majalla must measure to its taller design
-      // line. Floor by the tallest of the LATIN and EAST-ASIAN faces (the common
-      // Japanese encoding sets Meiryo only on `<a:ea>` while leaving `<a:latin>`
-      // default, §21.1.2.3.1). `<a:cs>` is parsed (see fontFaceCs) but
-      // deliberately NOT in this line-box floor: per the font-slot rules
+      // When line spacing is omitted, floor the natural single line (Excel's
+      // flat 1.2×em) by the AUTHORED font's design line box (OS/2 win metrics,
+      // ECMA-376 §21.1.2.1.1) via core's intendedSingleLinePx — same floor
+      // docx/pptx apply. An explicit spcPct bypasses this floor per
+      // §21.1.2.2.5 / §21.1.2.2.11. intendedSingleLinePx returns 0 for every
+      // untabled face (Calibri etc. stay on 1.2×em); a substituted Meiryo
+      // (1.596×em) / Sakkal Majalla must measure to its taller design line when
+      // spacing is omitted. Floor by the tallest of the LATIN and EAST-ASIAN
+      // faces (the common Japanese encoding sets Meiryo only on `<a:ea>` while
+      // leaving `<a:latin>` default, §21.1.2.3.1). `<a:cs>` is parsed
+      // (see fontFaceCs) but deliberately NOT in this line-box floor: per the
+      // font-slot rules
       // (§21.1.2.3.1 / §17.3.2.26) the complex-script face renders ONLY
       // complex-script glyphs (Arabic/Hebrew/Thai), so an unconditional
       // line-box floor by cs would over-grow a run whose glyphs are Latin/CJK
@@ -4103,7 +4110,10 @@ export function drawShapeText(
         intendedSingleLinePx(run.fontFace, pxSize),
         intendedSingleLinePx(run.fontFaceEa, pxSize),
       );
-      const singleLinePx = Math.max(pxSize * 1.2, designFloor);
+      const naturalSingle = pxSize * 1.2;
+      const singleLinePx = hasExplicitPct
+        ? naturalSingle
+        : Math.max(naturalSingle, designFloor);
       lineHeight = Math.max(lineHeight, singleLinePx);
       lineAscent = Math.max(lineAscent, measuredAscent(font, pxSize));
       ctx.font = font;

--- a/packages/xlsx/src/shape-text-line-spacing.test.ts
+++ b/packages/xlsx/src/shape-text-line-spacing.test.ts
@@ -98,6 +98,18 @@ describe('shape-text line spacing (§21.1.2.2.5 <a:lnSpc>) + normAutofit lnSpcRe
     expect(spaced).toBeCloseTo(gap([para('A'), para('B')]) * 2, 5);
   });
 
+  it.each(['Meiryo UI', 'Sakkal Majalla'])(
+    'does not let the %s design-height floor override an explicit spcPct',
+    (fontFace) => {
+      const pct100 = { type: 'pct', val: 100000 } as const;
+      const explicit = gap([
+        para('A', pct100, fontFace),
+        para('B', pct100, fontFace),
+      ]);
+      expect(explicit).toBeCloseTo(naturalSingle, 5);
+    },
+  );
+
   it('spcPts 40 makes each line an absolute 40 pt (cs-scaled) height', () => {
     const spaced = gap([para('A', { type: 'pts', val: 40 }), para('B', { type: 'pts', val: 40 })]);
     expect(spaced).toBeCloseTo(40 * PT_TO_PX * cs, 5);
@@ -130,11 +142,11 @@ describe('shape-text line spacing (§21.1.2.2.5 <a:lnSpc>) + normAutofit lnSpcRe
   });
 });
 
-// Commit-1 companion: the natural single line is FLOORED by the authored font's
-// design line (intendedSingleLinePx) before line spacing is applied. A tabled
-// face (Meiryo, 1.5962×em) must measure to its taller design box; an untabled
-// face (Calibri) stays on the flat 1.2×em. The mock canvas is metric-agnostic,
-// so this exercises the pure design-metric floor keyed on the authored name.
+// For OMITTED line spacing, the natural single line is FLOORED by the authored
+// font's design line (intendedSingleLinePx). A tabled face (Meiryo, 1.5962×em)
+// must measure to its taller design box; an untabled face (Calibri) stays on
+// the flat 1.2×em. Explicit spcPct is covered above and deliberately bypasses
+// this implicit-spacing floor.
 describe('shape-text single-line height floor by font design metric (§21.1.2.1.1)', () => {
   const em = 20 * PT_TO_PX;
 


### PR DESCRIPTION
## Summary

- keep the document-font design-height floor for omitted DrawingML line spacing
- honor explicitly authored `a:spcPct` values without reapplying that floor
- apply the same rule to PPTX text and XLSX DrawingML shape text
- add regressions for Meiryo UI and Sakkal Majalla, including bulleted paragraphs, implicit spacing, and absolute point spacing

## Rationale

ECMA-376 Part 1 §§21.1.2.2.5 and 21.1.2.2.11 define percentage line spacing relative to the largest text size on the line. The existing design-height compatibility floor is still needed when line spacing is omitted, but applying it before an explicit percentage expands authored 100% spacing for tall-metric fonts.

A local PowerPoint/PDF comparison confirmed that bypassing the floor only for explicit percentage spacing aligns the affected paragraph pitch while preserving omitted-spacing behavior.

## Verification

- `./node_modules/.bin/vitest run packages/pptx/src packages/xlsx/src` (137 files, 1081 tests)
- focused PPTX/XLSX line-spacing regressions (18 tests)
- `tsc --build packages/pptx packages/xlsx --pretty false`
- `git diff --check`
- local Storybook comparison against a PowerPoint-exported PDF