### PR TITLE
fix: terminate XLSX and PPTX workers after rejected loads

### DIFF
--- a/packages/pptx/src/presentation-destroy.test.ts
+++ b/packages/pptx/src/presentation-destroy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { WorkerBridge, preloadGoogleFonts, type WorkerLike, type FontPreloadEntry } from '@silurus/ooxml-core';
 import { PptxPresentation } from './presentation';
 
@@ -28,12 +28,21 @@ interface DestroyProbe {
 
 // ── Fake FontFaceSet so destroy()'s Google-Fonts release is observable ───────
 const G = globalThis as Record<string, unknown>;
-const ORIG_FONTS = { document: G.document, self: G.self, fetch: G.fetch, FontFace: G.FontFace };
+const ORIG_FONTS = {
+  document: G.document,
+  self: G.self,
+  fetch: G.fetch,
+  FontFace: G.FontFace,
+  Worker: G.Worker,
+  location: G.location,
+};
 afterEach(() => {
   G.document = ORIG_FONTS.document;
   G.self = ORIG_FONTS.self;
   G.fetch = ORIG_FONTS.fetch;
   G.FontFace = ORIG_FONTS.FontFace;
+  G.Worker = ORIG_FONTS.Worker;
+  G.location = ORIG_FONTS.location;
 });
 
 const CSS = `@font-face { font-family: 'Carlito'; font-style: normal; font-weight: 400; src: url(https://fonts.gstatic.com/s/carlito/y.woff2) format('woff2'); }`;
@@ -88,6 +97,32 @@ describe('PptxPresentation.destroy() — rejects in-flight worker requests', () 
     const { pres } = makePresentation();
     pres.destroy();
     expect(() => pres.destroy()).not.toThrow();
+  });
+
+  it('destroys a partially initialized presentation when load rejects', async () => {
+    G.Worker = SilentWorker;
+    G.location = { href: 'http://localhost/' };
+    const failure = new Error('injected load failure');
+    const parse = vi
+      .spyOn(
+        PptxPresentation.prototype as unknown as {
+          _parse(
+            buffer: ArrayBuffer,
+            maxZipEntryBytes?: number,
+            useGoogleFonts?: boolean,
+            timeoutMs?: number,
+          ): Promise<void>;
+        },
+        '_parse',
+      )
+      .mockRejectedValueOnce(failure);
+    const destroy = vi.spyOn(PptxPresentation.prototype, 'destroy');
+
+    await expect(PptxPresentation.load(new ArrayBuffer(0))).rejects.toBe(failure);
+    expect(destroy).toHaveBeenCalledTimes(1);
+
+    parse.mockRestore();
+    destroy.mockRestore();
   });
 
   // Wiring guard: destroy() must actually release the Google-Fonts substitutes

--- a/packages/pptx/src/presentation.ts
+++ b/packages/pptx/src/presentation.ts
@@ -178,26 +178,33 @@ export class PptxPresentation {
       mode === 'worker'
         ? (await import('./render-worker-host')).createRenderWorker()
         : new InlineWorker();
-    const pres = new PptxPresentation(worker, mode, opts.wasmUrl);
-    if (opts.math && mode === 'worker') {
-      console.warn(
-        "[ooxml] the math engine is unavailable in mode: 'worker'; equations will be skipped. Use mode: 'main' for documents with equations.",
+    let pres: PptxPresentation | undefined;
+    try {
+      pres = new PptxPresentation(worker, mode, opts.wasmUrl);
+      if (opts.math && mode === 'worker') {
+        console.warn(
+          "[ooxml] the math engine is unavailable in mode: 'worker'; equations will be skipped. Use mode: 'main' for documents with equations.",
+        );
+      }
+      pres._math = mode === 'worker' ? undefined : opts.math;
+      await pres._parse(
+        buffer,
+        opts.maxZipEntryBytes,
+        mode === 'worker' ? !!opts.useGoogleFonts : false,
+        opts.workerTimeoutMs,
       );
+      if (mode === 'main' && opts.useGoogleFonts && pres._presentation) {
+        pres._googleFontFaces = await preloadGoogleFonts(
+          pptxFontPreloadNames(pres._presentation),
+          PPTX_GOOGLE_FONTS,
+        );
+      }
+      return pres;
+    } catch (error) {
+      if (pres) pres.destroy();
+      else worker.terminate();
+      throw error;
     }
-    pres._math = mode === 'worker' ? undefined : opts.math;
-    await pres._parse(
-      buffer,
-      opts.maxZipEntryBytes,
-      mode === 'worker' ? !!opts.useGoogleFonts : false,
-      opts.workerTimeoutMs,
-    );
-    if (mode === 'main' && opts.useGoogleFonts && pres._presentation) {
-      pres._googleFontFaces = await preloadGoogleFonts(
-        pptxFontPreloadNames(pres._presentation),
-        PPTX_GOOGLE_FONTS,
-      );
-    }
-    return pres;
   }
 
   private async _parse(

--- a/packages/xlsx/src/workbook-destroy.test.ts
+++ b/packages/xlsx/src/workbook-destroy.test.ts
@@ -39,12 +39,21 @@ interface DestroyProbe {
 
 // ── Fake FontFaceSet so destroy()'s Google-Fonts release is observable ───────
 const G = globalThis as Record<string, unknown>;
-const ORIG_FONTS = { document: G.document, self: G.self, fetch: G.fetch, FontFace: G.FontFace };
+const ORIG_FONTS = {
+  document: G.document,
+  self: G.self,
+  fetch: G.fetch,
+  FontFace: G.FontFace,
+  Worker: G.Worker,
+  location: G.location,
+};
 afterEach(() => {
   G.document = ORIG_FONTS.document;
   G.self = ORIG_FONTS.self;
   G.fetch = ORIG_FONTS.fetch;
   G.FontFace = ORIG_FONTS.FontFace;
+  G.Worker = ORIG_FONTS.Worker;
+  G.location = ORIG_FONTS.location;
 });
 
 const CSS = `@font-face { font-family: 'Carlito'; font-style: normal; font-weight: 400; src: url(https://fonts.gstatic.com/s/carlito/y.woff2) format('woff2'); }`;
@@ -100,6 +109,27 @@ describe('XlsxWorkbook.destroy() — rejects in-flight worker requests', () => {
     const { wb } = makeWorkbook();
     wb.destroy();
     expect(() => wb.destroy()).not.toThrow();
+  });
+
+  it('destroys a partially initialized workbook when load rejects', async () => {
+    G.Worker = SilentWorker;
+    G.location = { href: 'http://localhost/' };
+    const failure = new Error('injected load failure');
+    const load = vi
+      .spyOn(
+        XlsxWorkbook.prototype as unknown as {
+          _load(buffer: ArrayBuffer, opts: object): Promise<void>;
+        },
+        '_load',
+      )
+      .mockRejectedValueOnce(failure);
+    const destroy = vi.spyOn(XlsxWorkbook.prototype, 'destroy');
+
+    await expect(XlsxWorkbook.load(new ArrayBuffer(0))).rejects.toBe(failure);
+    expect(destroy).toHaveBeenCalledTimes(1);
+
+    load.mockRestore();
+    destroy.mockRestore();
   });
 
   // Wiring guard: destroy() must actually release the Google-Fonts substitutes

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -119,9 +119,16 @@ export class XlsxWorkbook {
       mode === 'worker'
         ? (await import('./render-worker-host')).createRenderWorker()
         : new InlineWorker();
-    const wb = new XlsxWorkbook(worker, mode, opts.wasmUrl);
-    await wb._load(buffer, opts);
-    return wb;
+    let wb: XlsxWorkbook | undefined;
+    try {
+      wb = new XlsxWorkbook(worker, mode, opts.wasmUrl);
+      await wb._load(buffer, opts);
+      return wb;
+    } catch (error) {
+      if (wb) wb.destroy();
+      else worker.terminate();
+      throw error;
+    }
   }
 
   // `load()` always resolves a URL/string source to an ArrayBuffer (via


### PR DESCRIPTION
## Summary

- clean up partially initialized XLSX and PPTX instances when loading rejects
- terminate the worker directly if construction fails before an instance exists
- add regression coverage for both rejected-load paths

## Why

DOCX already destroys its partially initialized engine when loading fails, but XLSX and PPTX did not. A parse/load rejection could therefore leave the worker and its bridge alive until the page itself was torn down.

This changes only failure cleanup. Successful loads and the public API are unchanged.

## Validation

- PPTX and XLSX package suites: 137 files, 1,083 tests passed
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` (existing warning-only tripwires)
