### PR TITLE
feat(ui): customize find highlights and show parsing progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ transparent, selectable text layer per page/slide for native copy. It works in
 both `mode: 'main'` and `mode: 'worker'`; worker rendering returns the retained
 text-run geometry beside each bitmap. `findText()`, `findNext()`, `findPrev()`,
 and `clearFind()` search the complete document, including virtualized pages or
-slides outside the mounted window.
+slides outside the mounted window. Set `findHighlightColors: { match, active }`
+on any viewer to override the two overlay backgrounds with CSS colors; use an
+alpha color when the canvas text should remain visible through the highlight.
 
 **Hyperlinks.** For DOCX/PPTX the link hit regions live on the text-selection
 overlay, so hyperlink interaction requires `enableTextSelection: true`; when that

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -529,3 +529,4 @@ export {
 export { sliceHorizontalExtent, overlayPercent } from './search/highlight-rect';
 export { nextActive, prevActive, clampActive } from './search/find-cursor';
 export type { FindMatch } from './search/find-match';
+export type { FindHighlightColors } from './search/find-highlight';

--- a/packages/core/src/search/find-highlight.ts
+++ b/packages/core/src/search/find-highlight.ts
@@ -1,0 +1,13 @@
+/**
+ * CSS colours used by in-document search overlays.
+ *
+ * The values are applied as the overlay backgrounds verbatim. Use an alpha
+ * colour (`rgba(...)`, 8-digit hex, or `color-mix(...)`) when the rendered text
+ * should remain visible through the highlight.
+ */
+export interface FindHighlightColors {
+  /** Background for every match except the active one. */
+  match?: string;
+  /** Background for the match selected by findNext/findPrev. */
+  active?: string;
+}

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -489,10 +489,7 @@ export declare interface DocxDocumentModel {
     settings?: DocSettings;
     parseError?: string;
 }
-export declare interface DocxHighlightColors {
-    match?: string;
-    active?: string;
-}
+export declare type DocxHighlightColors = FindHighlightColors;
 export declare interface DocxHighlightMatch {
     slices: MatchRunSlice[];
     active: boolean;
@@ -604,6 +601,7 @@ export declare interface DocxScrollViewerOptions extends Omit<RenderPageOptions,
     paddingRight?: number;
     overscan?: number;
     enableTextSelection?: boolean;
+    findHighlightColors?: FindHighlightColors;
     zoomMin?: number;
     zoomMax?: number;
     enableZoom?: boolean;
@@ -735,6 +733,7 @@ export declare class DocxViewer implements ZoomableViewer {
 export declare interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
     container?: HTMLElement;
     enableTextSelection?: boolean;
+    findHighlightColors?: FindHighlightColors;
     onPageChange?: (index: number, total: number) => void;
     zoomMin?: number;
     zoomMax?: number;
@@ -777,6 +776,10 @@ export declare interface FindMatch<Loc = unknown> {
     matchIndex: number;
     text: string;
     location: Loc;
+}
+export declare interface FindHighlightColors {
+    match?: string;
+    active?: string;
 }
 export declare interface FindMatchesOptions {
     caseSensitive?: boolean;

--- a/packages/docx/src/find-highlight-layer.ts
+++ b/packages/docx/src/find-highlight-layer.ts
@@ -20,7 +20,12 @@
  * distinct emphasis colour so the user can tell it apart from the other hits,
  * matching a browser find bar's current-vs-other highlighting.
  */
-import { sliceHorizontalExtent, overlayPercent, type MatchRunSlice } from '@silurus/ooxml-core';
+import {
+  sliceHorizontalExtent,
+  overlayPercent,
+  type FindHighlightColors,
+  type MatchRunSlice,
+} from '@silurus/ooxml-core';
 import type { DocxTextRunInfo } from './renderer';
 import { tateChuYokoOverlayScale } from './tate-chu-yoko-overlay';
 
@@ -37,12 +42,8 @@ export interface DocxHighlightMatch {
 export const DEFAULT_FIND_HIGHLIGHT = 'rgba(255, 214, 0, 0.42)';
 export const DEFAULT_FIND_ACTIVE_HIGHLIGHT = 'rgba(255, 140, 0, 0.55)';
 
-export interface DocxHighlightColors {
-  /** Fill for non-active matches. */
-  match?: string;
-  /** Fill for the active match. */
-  active?: string;
-}
+/** Format-specific compatibility alias for the shared colour contract. */
+export type DocxHighlightColors = FindHighlightColors;
 
 /**
  * Populate a highlight overlay layer with one box per matched run-slice.

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -11,7 +11,7 @@ export {
   type DocxHighlightColors,
 } from './find-highlight-layer';
 export type { DocxMatchLocation } from './find';
-export type { FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
+export type { FindHighlightColors, FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 // IX1 — the shared hyperlink target shape surfaced by `DocxViewerOptions.
 // onHyperlinkClick`, `DocxTextRunInfo.hyperlink`, and the 5th arg of

--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1106,6 +1106,10 @@ describe('DocxScrollViewer — full-document find', () => {
     engine.feedTextRuns = [RUN];
     const v = new DocxScrollViewer(container as unknown as HTMLElement, {
       document: engine.asDoc(),
+      findHighlightColors: {
+        match: 'rgba(1, 2, 3, 0.4)',
+        active: 'rgba(4, 5, 6, 0.7)',
+      },
       gap: 0,
       overscan: 0,
       paddingTop: 0,
@@ -1121,6 +1125,15 @@ describe('DocxScrollViewer — full-document find', () => {
     expect(matches).toHaveLength(4);
     expect(matches.map((match) => match.location.page)).toEqual([0, 1, 2, 3]);
 
+    const initiallyMountedHighlightLayers = scrollHost.children
+      .filter((child) => child.children.some((nested) => nested.tag === 'canvas'))
+      .map((slot) => slot.children.find((child) => child.tag === 'div') as FakeEl);
+    expect(
+      initiallyMountedHighlightLayers
+        .flatMap((layer) => layer.children)
+        .find((box) => box.style.background === 'rgba(1, 2, 3, 0.4)'),
+    ).toBeDefined();
+
     await v.findNext();
     const second = await v.findNext();
     expect(second?.location.page).toBe(1);
@@ -1130,6 +1143,11 @@ describe('DocxScrollViewer — full-document find', () => {
       .filter((child) => child.children.some((nested) => nested.tag === 'canvas'))
       .map((slot) => slot.children.find((child) => child.tag === 'div') as FakeEl);
     expect(mountedHighlightLayers.some((layer) => layer.children.length > 0)).toBe(true);
+    expect(
+      mountedHighlightLayers
+        .flatMap((layer) => layer.children)
+        .find((box) => box.style.background === 'rgba(4, 5, 6, 0.7)'),
+    ).toBeDefined();
 
     v.clearFind();
     expect(mountedHighlightLayers.every((layer) => layer.children.length === 0)).toBe(true);

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1,5 +1,5 @@
 import { computeVisibleRange, openExternalHyperlink, PT_TO_PX, zoomStepScale, anchoredZoomOffset, nextZoomStep, prevZoomStep, fitScale, type VisibleRange } from '@silurus/ooxml-core';
-import type { FindMatch, FindMatchesOptions, HyperlinkTarget, ZoomableViewer } from '@silurus/ooxml-core';
+import type { FindHighlightColors, FindMatch, FindMatchesOptions, HyperlinkTarget, ZoomableViewer } from '@silurus/ooxml-core';
 import { DocxDocument } from './document';
 import type { LoadOptions } from './document';
 import type { DocxTextRunInfo } from './renderer';
@@ -74,6 +74,8 @@ export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onText
    *  shipped back beside the page bitmap, so the overlay is populated identically
    *  to main mode (no more empty overlay / one-time warning). */
   enableTextSelection?: boolean;
+  /** CSS backgrounds for ordinary and active in-document search matches. */
+  findHighlightColors?: FindHighlightColors;
   /** Minimum zoom scale (px-per-pt multiplier floor). Default 0.1. */
   zoomMin?: number;
   /** Maximum zoom scale. Default 4. */
@@ -1590,6 +1592,7 @@ export class DocxScrollViewer implements ZoomableViewer {
       this._pageWidthPx(page),
       this._pageHeightPx(page),
       (font) => this._measureForFont(font),
+      this._opts.findHighlightColors,
     );
   }
 

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -6,7 +6,7 @@ import { buildDocxTextLayer } from './text-layer';
 import { buildDocxHighlightLayer, type DocxHighlightMatch } from './find-highlight-layer';
 import { DocxFindController, type DocxMatchLocation } from './find';
 import { openExternalHyperlink, PT_TO_PX, nextZoomStep, prevZoomStep, clampScale, fitScale } from '@silurus/ooxml-core';
-import type { HyperlinkTarget, FindMatch, FindMatchesOptions, ZoomableViewer } from '@silurus/ooxml-core';
+import type { FindHighlightColors, HyperlinkTarget, FindMatch, FindMatchesOptions, ZoomableViewer } from '@silurus/ooxml-core';
 
 export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
   container?: HTMLElement;
@@ -15,6 +15,8 @@ export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
    * browser's native text selection works on document content.
    */
   enableTextSelection?: boolean;
+  /** CSS backgrounds for ordinary and active in-document search matches. */
+  findHighlightColors?: FindHighlightColors;
   /** Called when a page finishes rendering. */
   onPageChange?: (index: number, total: number) => void;
   /** IX9 zoom contract ({@link ZoomableViewer}) — the clamp range for
@@ -554,6 +556,7 @@ export class DocxViewer implements ZoomableViewer {
       width,
       height,
       (font) => this._measureForFont(font),
+      this._opts.findHighlightColors,
     );
   }
 

--- a/packages/pptx/src/find-highlight-layer.ts
+++ b/packages/pptx/src/find-highlight-layer.ts
@@ -14,7 +14,12 @@
  * coordinate frame (`inShapeX`/`inShapeY`), so the shape div's `rotate()` lays
  * them along the glyphs. The active match uses a distinct emphasis colour.
  */
-import { sliceHorizontalExtent, overlayPercent, type MatchRunSlice } from '@silurus/ooxml-core';
+import {
+  sliceHorizontalExtent,
+  overlayPercent,
+  type FindHighlightColors,
+  type MatchRunSlice,
+} from '@silurus/ooxml-core';
 import type { PptxTextRunInfo } from './renderer';
 
 export interface PptxHighlightMatch {
@@ -26,10 +31,8 @@ export interface PptxHighlightMatch {
 export const DEFAULT_FIND_HIGHLIGHT = 'rgba(255, 214, 0, 0.42)';
 export const DEFAULT_FIND_ACTIVE_HIGHLIGHT = 'rgba(255, 140, 0, 0.55)';
 
-export interface PptxHighlightColors {
-  match?: string;
-  active?: string;
-}
+/** Format-specific compatibility alias for the shared colour contract. */
+export type PptxHighlightColors = FindHighlightColors;
 
 /**
  * Populate a highlight overlay layer with a box per matched run-slice, grouped

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -16,7 +16,7 @@ export {
   type PptxHighlightColors,
 } from './find-highlight-layer';
 export type { PptxMatchLocation } from './find';
-export type { FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
+export type { FindHighlightColors, FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
 export type { PresentationHandle } from './presentation-handle';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 // IX1 — the shared hyperlink target shape surfaced by `PptxViewerOptions.

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -1724,6 +1724,10 @@ describe('PptxScrollViewer — full-presentation find', () => {
     engine.feedTextRuns = [RUN];
     const v = new PptxScrollViewer(container as unknown as HTMLElement, {
       presentation: engine.asPres(),
+      findHighlightColors: {
+        match: 'rgba(1, 2, 3, 0.4)',
+        active: 'rgba(4, 5, 6, 0.7)',
+      },
       gap: 0,
       overscan: 0,
       paddingTop: 0,
@@ -1739,6 +1743,16 @@ describe('PptxScrollViewer — full-presentation find', () => {
     expect(matches).toHaveLength(4);
     expect(matches.map((match) => match.location.slide)).toEqual([0, 1, 2, 3]);
 
+    const initiallyMountedHighlightLayers = scrollHost.children
+      .filter((child) => child.children.some((nested) => nested.tag === 'canvas'))
+      .map((slot) => slot.children.find((child) => child.tag === 'div') as FakeEl);
+    expect(
+      initiallyMountedHighlightLayers
+        .flatMap((layer) => layer.children)
+        .flatMap((shape) => shape.children)
+        .find((box) => box.style.background === 'rgba(1, 2, 3, 0.4)'),
+    ).toBeDefined();
+
     await v.findNext();
     const second = await v.findNext();
     expect(second?.location.slide).toBe(1);
@@ -1748,6 +1762,12 @@ describe('PptxScrollViewer — full-presentation find', () => {
       .filter((child) => child.children.some((nested) => nested.tag === 'canvas'))
       .map((slot) => slot.children.find((child) => child.tag === 'div') as FakeEl);
     expect(mountedHighlightLayers.some((layer) => layer.children.length > 0)).toBe(true);
+    expect(
+      mountedHighlightLayers
+        .flatMap((layer) => layer.children)
+        .flatMap((shape) => shape.children)
+        .find((box) => box.style.background === 'rgba(4, 5, 6, 0.7)'),
+    ).toBeDefined();
 
     v.clearFind();
     expect(mountedHighlightLayers.every((layer) => layer.children.length === 0)).toBe(true);

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1,4 +1,4 @@
-import { computeVisibleRange, EMU_PER_PX, zoomStepScale, anchoredZoomOffset, nextZoomStep, prevZoomStep, fitScale, type FindMatch, type FindMatchesOptions, type VisibleRange, type HyperlinkTarget, type ZoomableViewer, openExternalHyperlink } from '@silurus/ooxml-core';
+import { computeVisibleRange, EMU_PER_PX, zoomStepScale, anchoredZoomOffset, nextZoomStep, prevZoomStep, fitScale, type FindHighlightColors, type FindMatch, type FindMatchesOptions, type VisibleRange, type HyperlinkTarget, type ZoomableViewer, openExternalHyperlink } from '@silurus/ooxml-core';
 import { PptxPresentation, type LoadOptions, type RenderSlideOptions } from './presentation';
 import type { PresentationHandle } from './presentation-handle';
 import type { PptxTextRunInfo } from './renderer';
@@ -78,6 +78,8 @@ export interface PptxScrollViewerOptions extends Omit<RenderSlideOptions, 'onTex
    *  shipped back beside the slide bitmap, so the overlay is populated identically
    *  to main mode (no more empty overlay / one-time warning). */
   enableTextSelection?: boolean;
+  /** CSS backgrounds for ordinary and active in-document search matches. */
+  findHighlightColors?: FindHighlightColors;
   /**
    * Enable interactive audio/video playback. When true, mounted slides render
    * through {@link PptxPresentation.presentSlide} only while they are inside the
@@ -1816,6 +1818,7 @@ export class PptxScrollViewer implements ZoomableViewer {
       this._slideWidthPx(),
       this._slideHeightPx(),
       (font) => this._measureForFind(font),
+      this._opts.findHighlightColors,
     );
   }
 

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -8,6 +8,7 @@ import { nextVisibleIndex, resolveVisibleIndex, countVisible } from './hidden';
 import type { DimOptions } from './types';
 import {
   type HyperlinkTarget,
+  type FindHighlightColors,
   type FindMatch,
   type FindMatchesOptions,
   type ZoomableViewer,
@@ -54,6 +55,8 @@ export interface PptxViewerOptions extends RenderOptions, LoadOptions {
    * browser's native text selection works on slide content.
    */
   enableTextSelection?: boolean;
+  /** CSS backgrounds for ordinary and active in-document search matches. */
+  findHighlightColors?: FindHighlightColors;
   /**
    * How hidden slides (`<p:sld show="0">`, §19.3.1.38) are presented:
    * - `'show'` (default): drawn like any other slide.
@@ -521,8 +524,14 @@ export class PptxViewer implements ZoomableViewer {
     const layer = this.highlightLayer;
     if (!layer) return;
     const highlights: PptxHighlightMatch[] = this._find.slideHighlights(this.currentSlide);
-    buildPptxHighlightLayer(layer, runs, highlights, cssWidth, cssHeight, (font) =>
-      this._measureForFont(font),
+    buildPptxHighlightLayer(
+      layer,
+      runs,
+      highlights,
+      cssWidth,
+      cssHeight,
+      (font) => this._measureForFont(font),
+      this.opts.findHighlightColors,
     );
   }
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -44,6 +44,11 @@ outside the currently rendered scroll window. Press **Enter** for the next match
 **Shift+Enter** for the previous match, and **Escape** or the **×** button to
 close the popup and clear highlights.
 
+The ordinary and active match backgrounds are themeable through
+`ooxmlViewer.findMatchBackground` and
+`ooxmlViewer.findActiveMatchBackground`. Override them under
+`workbench.colorCustomizations` in VS Code settings.
+
 ## MCP server for AI agents
 
 Open a workspace that contains a `.xlsx` / `.docx` / `.pptx` file and the extension offers to enable an [MCP server](https://modelcontextprotocol.io/) — a tiny native binary that lets AI coding agents read those files directly. Without it, agents typically resort to running `unzip` + XML parsing in Python; with it, they call typed tools like `xlsx_get_cell_range`, `docx_extract_text`, or `pptx_get_slide_structure`.

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -98,6 +98,28 @@
         "category": "OOXML Viewer"
       }
     ],
+    "colors": [
+      {
+        "id": "ooxmlViewer.findMatchBackground",
+        "description": "Background of ordinary search matches in Office previews.",
+        "defaults": {
+          "dark": "#FFD6006B",
+          "light": "#FFD6006B",
+          "highContrast": "#FFD60099",
+          "highContrastLight": "#C28A0099"
+        }
+      },
+      {
+        "id": "ooxmlViewer.findActiveMatchBackground",
+        "description": "Background of the active search match in Office previews.",
+        "defaults": {
+          "dark": "#FF8C008C",
+          "light": "#FF8C008C",
+          "highContrast": "#FF8C00CC",
+          "highContrastLight": "#B85E00CC"
+        }
+      }
+    ],
     "keybindings": [
       {
         "command": "ooxmlViewer.find",

--- a/packages/vscode-extension/src/findContribution.test.ts
+++ b/packages/vscode-extension/src/findContribution.test.ts
@@ -5,6 +5,7 @@ interface Manifest {
   contributes: {
     commands: Array<{ command: string }>;
     keybindings: Array<{ command: string; key: string; mac?: string; when?: string }>;
+    colors: Array<{ id: string }>;
   };
 }
 
@@ -24,5 +25,14 @@ describe('VS Code find contribution', () => {
       when:
         'activeCustomEditorId == ooxmlViewer.docxEditor || activeCustomEditorId == ooxmlViewer.xlsxEditor || activeCustomEditorId == ooxmlViewer.pptxEditor',
     });
+  });
+
+  it('contributes theme colours for ordinary and active find matches', () => {
+    expect(manifest.contributes.colors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'ooxmlViewer.findMatchBackground' }),
+        expect.objectContaining({ id: 'ooxmlViewer.findActiveMatchBackground' }),
+      ]),
+    );
   });
 });

--- a/packages/vscode-extension/src/webview/bootstrap.ts
+++ b/packages/vscode-extension/src/webview/bootstrap.ts
@@ -51,6 +51,10 @@ const viewerContainer = document.getElementById('viewer-container')!;
 const zoomOutButton = document.getElementById('zoom-out') as HTMLButtonElement;
 const zoomInButton = document.getElementById('zoom-in') as HTMLButtonElement;
 const zoomLabel = document.getElementById('zoom-label')!;
+const findHighlightColors = {
+  match: 'var(--vscode-ooxmlViewer-findMatchBackground, rgba(255, 214, 0, 0.42))',
+  active: 'var(--vscode-ooxmlViewer-findActiveMatchBackground, rgba(255, 140, 0, 0.55))',
+};
 let activeViewer: ZoomableViewer | null = null;
 
 function showError(msg: string): void {
@@ -165,6 +169,7 @@ async function initXlsx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
     math,
     useGoogleFonts,
     showZoomSlider: false,
+    findHighlightColors,
     onScaleChange: updateZoomLabel,
     onError(err) {
       loadFailed = true;
@@ -198,6 +203,7 @@ async function initDocx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
     math,
     useGoogleFonts,
     enableTextSelection: true,
+    findHighlightColors,
     refitOnResize: false,
     background: 'var(--vscode-editor-background)',
     onScaleChange: updateZoomLabel,
@@ -220,6 +226,7 @@ async function initPptx(buffer: ArrayBuffer, useGoogleFonts: boolean): Promise<v
     math,
     useGoogleFonts,
     enableTextSelection: true,
+    findHighlightColors,
     enableMediaPlayback: true,
     mediaOverscan: 1,
     refitOnResize: true,

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -7,7 +7,7 @@ export type { XlsxViewerOptions, HiddenSheetMode, CellAddress, CellRange, Select
 // IX2 find-in-document: the xlsx match-location shape (sheet + A1 cell ref).
 // `FindMatch` / `FindMatchesOptions` come from core (shared across formats).
 export type { XlsxMatchLocation } from './find.js';
-export type { FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
+export type { FindHighlightColors, FindMatch, FindMatchesOptions } from '@silurus/ooxml-core';
 export { autoResize, type AutoResizeOptions } from '@silurus/ooxml-core';
 // IX1 — the shared hyperlink target shape surfaced by `XlsxViewerOptions.
 // onHyperlinkClick`, plus the default "open in a new tab, sanitised" helper.

--- a/packages/xlsx/src/resize-zoom.test.ts
+++ b/packages/xlsx/src/resize-zoom.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { colWidthToPx, rowHeightToPx, pxToColWidth, pxToRowHeight } from './renderer.js';
-import { resizeHitIndex, selectionOverlayStyle, zoomStepScale } from './viewer.js';
+import { findHighlightOverlayStyle, resizeHitIndex, selectionOverlayStyle, zoomStepScale } from './viewer.js';
 
 /**
  * Drag-to-resize (issue #567) stores the user's dragged pixel size back into the
@@ -43,6 +43,14 @@ describe('selectionOverlayStyle', () => {
     expect(selectionOverlayStyle('rgb(0,128,0)').background).toBe(
       'color-mix(in srgb, rgb(0,128,0) 8%, transparent)',
     );
+  });
+});
+
+describe('findHighlightOverlayStyle', () => {
+  it('uses caller-provided match and active background colours verbatim', () => {
+    const colors = { match: 'rgba(1, 2, 3, 0.4)', active: '#ff00ff99' };
+    expect(findHighlightOverlayStyle(false, colors).background).toBe(colors.match);
+    expect(findHighlightOverlayStyle(true, colors).background).toBe(colors.active);
   });
 });
 

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,6 +1,6 @@
 import { XlsxWorkbook } from './workbook.js';
 import type { Hyperlink, ViewportRange, Worksheet, XlsxComment } from './types.js';
-import type { HyperlinkTarget, LoadOptions, FindMatch, FindMatchesOptions, ZoomableViewer } from '@silurus/ooxml-core';
+import type { FindHighlightColors, HyperlinkTarget, LoadOptions, FindMatch, FindMatchesOptions, ZoomableViewer } from '@silurus/ooxml-core';
 import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale, anchoredZoomOffset, openExternalHyperlink, nextZoomStep, prevZoomStep, fitScale } from '@silurus/ooxml-core';
 import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, pxToColWidth, pxToRowHeight, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 import { findListValidationAt } from './data-validation.js';
@@ -168,6 +168,8 @@ export interface XlsxViewerOptions extends LoadOptions {
    * via {@link XlsxViewer.setSelectionColor}.
    */
   selectionColor?: string;
+  /** CSS backgrounds for ordinary and active in-document search matches. */
+  findHighlightColors?: FindHighlightColors;
   /**
    * `'main'` (default): parse in a worker, render on the main thread. `'worker'`:
    * parse AND render entirely inside the worker and paint the returned
@@ -343,6 +345,20 @@ export function selectionOverlayStyle(color: string): { border: string; backgrou
     border: `2px solid ${color}`,
     background: `color-mix(in srgb, ${color} 8%, transparent)`,
   };
+}
+
+const DEFAULT_FIND_HIGHLIGHT = 'color-mix(in srgb, #ffb300 8%, transparent)';
+const DEFAULT_FIND_ACTIVE_HIGHLIGHT = 'color-mix(in srgb, #fb8c00 8%, transparent)';
+
+/** Resolve an XLSX find box without altering a caller-provided CSS background. */
+export function findHighlightOverlayStyle(
+  active: boolean,
+  colors: FindHighlightColors = {},
+): { border: string; background: string } {
+  const accent = active ? '#fb8c00' : '#ffb300';
+  const custom = active ? colors.active : colors.match;
+  const background = custom ?? (active ? DEFAULT_FIND_ACTIVE_HIGHLIGHT : DEFAULT_FIND_HIGHLIGHT);
+  return { border: `2px solid ${custom ?? accent}`, background };
 }
 
 interface SheetAxes { col: AxisMetrics; row: AxisMetrics; }
@@ -2119,8 +2135,8 @@ export class XlsxViewer implements ZoomableViewer {
     // A match accent: same single-color → border + translucent fill derivation
     // the selection overlay uses. The active match uses a warm accent so it is
     // distinguishable from other hits and from the (blue) selection box.
-    const other = selectionOverlayStyle('#ffb300'); // amber for all matches
-    const active = selectionOverlayStyle('#fb8c00'); // stronger orange for active
+    const other = findHighlightOverlayStyle(false, this.opts.findHighlightColors);
+    const active = findHighlightOverlayStyle(true, this.opts.findHighlightColors);
 
     for (const hl of this._find.sheetHighlights(this.currentSheet)) {
       const rect = this.getCellRect(hl.row, hl.col);

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -51,6 +51,13 @@ const findMethods = (loc: string): ApiMethod[] => [
   { sig: 'clearFind(): void', desc: 'Clear all highlights and reset the find state.' },
 ];
 
+const FIND_HIGHLIGHT_COLORS: ApiOption = {
+  name: 'findHighlightColors',
+  type: '{ match?: string; active?: string }',
+  def: 'yellow / orange',
+  desc: 'CSS backgrounds for ordinary and active find matches. Values are applied verbatim; use an alpha color to keep the canvas text visible through the overlay.',
+};
+
 export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
   pptx: [
     {
@@ -62,6 +69,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         DPR,
         GFONTS,
         { name: 'enableTextSelection', type: 'boolean', def: 'false', desc: 'Overlay a transparent text layer so users can select & copy slide text.' },
+        FIND_HIGHLIGHT_COLORS,
         { name: 'enableMediaPlayback', type: 'boolean', def: 'false', desc: 'Make embedded audio/video interactive (the viewer draws its own play chrome).' },
         { name: 'hiddenSlideMode', type: "'show' | 'skip' | 'dim'", def: "'show'", desc: 'How hidden slides (`<p:sld show="0">`, §19.3.1.38) are presented. `show` draws them like any other slide; `skip` makes sequential navigation (nextSlide/prevSlide and the initial load) jump over them while keeping absolute indices unchanged (an explicit goToSlide to a hidden slide is still honored); `dim` draws them under a translucent overlay (the PowerPoint thumbnail look).' },
         { name: 'hiddenSlideDim', type: 'Partial<DimOptions>', def: "{ color: '#ffffff', opacity: 0.6 }", desc: 'Overrides for the `dim` overlay, merged over the default white 60% wash. A partial so it stays in sync if DimOptions gains a field.' },
@@ -126,6 +134,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'zoomMin / zoomMax', type: 'number', def: '0.1 / 4', desc: 'Absolute zoom scale bounds (10%–400%).' },
         { name: 'refitOnResize', type: 'boolean', def: 'true', desc: 'Re-fit to the container width when it resizes. Set false to preserve an absolute scale independently of viewport width; explicit fitWidth() / fitPage() still work.' },
         { name: 'enableTextSelection', type: 'boolean', def: 'false', desc: 'Overlay a transparent, selectable text layer per slide for native copy in both render modes.' },
+        FIND_HIGHLIGHT_COLORS,
         { name: 'enableMediaPlayback', type: 'boolean', def: 'false', desc: 'Make embedded audio/video interactive inside the real viewport plus mediaOverscan. Other mounted slides remain static and selectable without allocating media blobs or RAF loops.' },
         { name: 'mediaOverscan', type: 'number', def: '1', desc: 'Slides beyond the real viewport that may keep interactive media handles. Independent from the general overscan used for mounted canvases/text overlays.' },
         ON_HYPERLINK_CLICK,
@@ -162,6 +171,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         DPR,
         GFONTS,
         { name: 'enableTextSelection', type: 'boolean', def: 'false', desc: 'Overlay a transparent text layer for native selection & copy.' },
+        FIND_HIGHLIGHT_COLORS,
         { name: 'showTrackChanges', type: 'boolean', desc: 'Render tracked insertions/deletions with author colours.' },
         ZIP,
         MATH,
@@ -216,6 +226,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'zoomMin / zoomMax', type: 'number', def: '0.1 / 4', desc: 'Absolute zoom scale bounds (10%–400%).' },
         { name: 'refitOnResize', type: 'boolean', def: 'true', desc: 'Re-fit to the container width when it resizes. Set false to preserve an absolute scale independently of viewport width; explicit fitWidth() / fitPage() still work.' },
         { name: 'enableTextSelection', type: 'boolean', def: 'false', desc: 'Overlay a transparent, selectable text layer per page for native copy in both render modes.' },
+        FIND_HIGHLIGHT_COLORS,
         ON_HYPERLINK_CLICK,
         ENABLE_HYPERLINKS,
         { name: 'showTrackChanges', type: 'boolean', desc: 'Render tracked insertions/deletions with author colours (forwarded to each page render).' },
@@ -252,6 +263,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'zoomMin / zoomMax', type: 'number', def: '0.1 / 4', desc: 'Zoom slider bounds as scale factors (10%–400%).' },
         { name: 'resizable', type: 'boolean', def: 'true', desc: 'Allow resizing columns/rows by dragging header borders. View-only — it changes the on-screen view only and never modifies the loaded file. Set false to disable.' },
         { name: 'selectionColor', type: 'string', def: "'#1a73e8'", desc: 'Accent color for the cell-selection rectangle (any CSS color). The fill is the same color at 8% opacity.' },
+        FIND_HIGHLIGHT_COLORS,
         { name: 'hiddenSheetMode', type: "'show' | 'skip' | 'dim'", def: "'show'", desc: 'How hidden / very-hidden sheets (`<sheet state>`, §18.2.19) appear in the tab bar. `show` renders a tab like any other; `skip` hides the tab (`display:none`) and makes sequential navigation jump over it; `dim` renders the tab at reduced opacity. Mirrors pptx `hiddenSlideMode`.' },
         GFONTS,
         ZIP,

--- a/site/src/pages/try.astro
+++ b/site/src/pages/try.astro
@@ -35,7 +35,13 @@ import Nav from '../components/Nav.astro';
         <span class="panel-badge">live · WASM</span>
         <button class="try-reset" id="reset">Try another →</button>
       </div>
-      <div class="try-stage" id="stage"></div>
+      <div class="try-stage-shell">
+        <div class="try-stage" id="stage"></div>
+        <div class="try-stage-progress" id="stage-progress" role="status" aria-live="polite" hidden>
+          <span class="try-progress-circle" aria-hidden="true"></span>
+          <span>Parsing document…</span>
+        </div>
+      </div>
     </div>
 
     <p class="try-fineprint">
@@ -72,6 +78,7 @@ import Nav from '../components/Nav.astro';
     const status = document.getElementById('status') as HTMLElement;
     const panel = document.getElementById('panel') as HTMLElement;
     const stage = document.getElementById('stage') as HTMLElement;
+    const stageProgress = document.getElementById('stage-progress') as HTMLElement;
     const fileLabel = document.getElementById('panel-file') as HTMLElement;
     const reset = document.getElementById('reset') as HTMLButtonElement;
     let loadGeneration = 0;
@@ -86,6 +93,7 @@ import Nav from '../components/Nav.astro';
       panel.hidden = false;
       panel.classList.add('loading');
       stage.style.visibility = 'hidden';
+      stageProgress.hidden = false;
       try {
         const t0 = performance.now();
         const res = await renderFile(stage, file);
@@ -95,6 +103,7 @@ import Nav from '../components/Nav.astro';
         fileLabel.textContent = file.name;
         panel.classList.remove('loading');
         stage.style.visibility = '';
+        stageProgress.hidden = true;
         status.textContent = `${count}rendered in ${ms} ms`;
         status.hidden = false;
       } catch (e) {
@@ -104,6 +113,7 @@ import Nav from '../components/Nav.astro';
         if (generation !== loadGeneration) return;
         panel.classList.remove('loading');
         stage.style.visibility = '';
+        stageProgress.hidden = true;
         status.classList.add('error');
         status.textContent = e instanceof Error ? e.message : String(e);
         panel.hidden = true;
@@ -192,6 +202,27 @@ import Nav from '../components/Nav.astro';
     font-size: 12.5px; padding: 6px 12px; border-radius: 8px; transition: border-color 0.15s, color 0.15s;
   }
   .try-reset:hover { border-color: var(--accent); color: var(--text); }
+  .try-stage-shell { position: relative; }
+  .try-panel.loading .try-stage-shell {
+    height: min(74vh, 680px);
+    min-height: 360px;
+    background: radial-gradient(120% 80% at 50% 0%, #20242e, #161922 70%);
+  }
+  .try-stage-progress {
+    position: absolute; inset: 0;
+    display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 14px;
+    color: var(--text-dim); font-family: var(--mono); font-size: 13px;
+  }
+  .try-stage-progress[hidden] { display: none; }
+  .try-progress-circle {
+    width: 34px; height: 34px; box-sizing: border-box; border-radius: 50%;
+    border: 3px solid rgba(148, 163, 184, 0.24); border-top-color: var(--accent);
+    animation: try-progress-spin 0.8s linear infinite;
+  }
+  @keyframes try-progress-spin { to { transform: rotate(360deg); } }
+  @media (prefers-reduced-motion: reduce) {
+    .try-progress-circle { animation: none; }
+  }
   .try-stage :global(.lv-scroll-viewer), .try-stage :global(.lv-xlsx) { border-radius: 0; }
   .try-stage :global(.lv-scroll-viewer) {
     width: 100%;

--- a/site/src/try-loading.test.ts
+++ b/site/src/try-loading.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./pages/try.astro', import.meta.url), 'utf8');
+
+describe('Try Yours parsing progress', () => {
+  it('shows an accessible progress circle in the preview while renderFile is pending', () => {
+    expect(source).toContain('id="stage-progress" role="status" aria-live="polite" hidden');
+    expect(source).toContain('class="try-progress-circle" aria-hidden="true"');
+    expect(source).toMatch(/stageProgress\.hidden = false;[\s\S]*await renderFile\(stage, file\)/);
+  });
+
+  it('hides the progress UI on both the current render success and failure paths', () => {
+    expect(source.match(/stageProgress\.hidden = true;/g)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

- expose shared match and active search-highlight colors across DOCX, PPTX, and XLSX viewers
- contribute VS Code theme colors and use them in all Office preview types
- show an accessible progress circle in the Try Yours preview while a file is being read and parsed

## Why

Search consumers need to distinguish ordinary hits from the active hit using host-appropriate colors. The public Try Yours preview also appeared blank during parser startup, so it now keeps the preview region visible and reports progress there.

The existing DOM overlay architecture remains unchanged. This intentionally avoids injecting transient search state into the Canvas layout and paint pipelines.

## Validation

- full Vitest suite: 5,937 passed, 25 skipped
- pnpm typecheck
- VS Code production bundle
- Astro production build
- DOCX final layout-boundary, compatibility-evidence, public-API, and package-build gates
- git diff --check

DOCX architecture audit: APPROVE. No layout, paint, parser, worker, or retained-model behavior changed.