### PR TITLE
fix(pptx): reset pooled canvas height after zoom

### DIFF
--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -2505,6 +2505,37 @@ describe('PptxScrollViewer — flicker-free zoom (T8)', () => {
     v.destroy();
   });
 
+  it('pool reuse clears a CSS-preview height from a slide recycled during a zoom burst', () => {
+    vi.useFakeTimers();
+    try {
+      const { v, scrollHost } = setup();
+
+      // Base geometry is 200×120. The first zoom keeps slide 3 mounted and
+      // previews it at 240×144; the second zoom shrinks the visible range and
+      // recycles that slot before it can receive the new 400×240 preview.
+      v.setScale(1.2);
+      const recycled = slotAtTop(scrollHost, '462px')!;
+      const canvas = recycled.children.find((k) => k.tag === 'canvas') as FakeEl;
+      expect(canvas.style.height).toBe('144px');
+      v.setScale(2);
+      expect(recycled.parentElement).toBeNull();
+
+      // Scrolling mounts slide 3 again from the pool while the zoom settle is
+      // still pending. The real main-mode renderer synchronously replaces the
+      // CSS width but deliberately leaves height to the canvas aspect ratio, so
+      // the pooled preview height must have been cleared before reuse.
+      scrollHost.scrollTop = 250;
+      scrollHost.dispatch('scroll');
+      const remounted = slotAtTop(scrollHost, '750px')!;
+      expect(remounted).toBe(recycled);
+      expect(remounted.style.height).toBe('240px');
+      expect(canvas.style.height).toBe('');
+      v.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('CSS preview: text layer gets a transform: scale(ratio) matching newScale / renderedScale', async () => {
     const { v, scrollHost, engine } = setup(20, { enableTextSelection: true });
     engine.feedTextRuns = [

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -840,6 +840,12 @@ export class PptxScrollViewer implements ZoomableViewer {
     slot.highlightLayer.innerHTML = '';
     slot.highlightLayer.style.transform = '';
     slot.highlightLayer.style.transformOrigin = '';
+    // `_previewSlot` pins an explicit CSS height while stretching the current
+    // bitmap during a zoom burst. A slot can leave the visible range before the
+    // debounced settle replaces that canvas, so do not carry the old-scale height
+    // into its next slide. Main-mode renderSlide intentionally updates only the
+    // CSS width and lets height follow the backing-store aspect ratio.
+    slot.canvas.style.height = '';
     slot.renderedSlide = -1;
     slot.renderedScale = -1;
     slot.wrapper.remove();


### PR DESCRIPTION
## Summary

- clear the temporary CSS preview height when a `PptxScrollViewer` slide slot returns to the pool
- add a regression test covering a rapid zoom burst followed by slot recycling and remounting

## Root cause

During flicker-free zoom, mounted canvases receive an explicit CSS height for the immediate stretched preview. A slide can leave the visible range before the debounced settle render replaces that canvas. When the pooled slot was later reused, main-mode rendering updated its CSS width but intentionally relied on the backing-store aspect ratio for height, so the stale preview height compressed the slide vertically inside a correctly sized wrapper.

## Verification

- `pnpm test` — 5937 passed, 26 skipped
- `pnpm typecheck`
- `pnpm build:packages:ci`
- `pnpm --filter ./packages/vscode-extension vscode:prepublish`
- `git diff --check`