### PR TITLE
fix(docx): restore nested table and drop cap layout

### DIFF
--- a/packages/core/src/worker/wasm-guard.test.ts
+++ b/packages/core/src/worker/wasm-guard.test.ts
@@ -148,7 +148,7 @@ describe('WasmParserHost', () => {
     await host.ensureReady();
     expect(init).toHaveBeenCalledTimes(1); // still just the first load
     expect(reinit).toHaveBeenCalledTimes(1); // the fresh instance came from reinit
-    expect(reinit).toHaveBeenCalledWith('wasm://x');
+    expect(reinit).toHaveBeenCalledWith({ module_or_path: 'wasm://x' });
     expect(host.poisoned).toBe(false);
     // ...and the next parse succeeds on clean linear memory.
     const good = host.run(() => {
@@ -213,8 +213,8 @@ describe('WasmParserHost', () => {
     ).toThrow(WasmTrapError);
     await host.ensureReady();
     // First load through `init`, recovery through `reinit`, both with the same url.
-    expect(init).toHaveBeenNthCalledWith(1, 'wasm://original');
-    expect(reinit).toHaveBeenNthCalledWith(1, 'wasm://original');
+    expect(init).toHaveBeenNthCalledWith(1, { module_or_path: 'wasm://original' });
+    expect(reinit).toHaveBeenNthCalledWith(1, { module_or_path: 'wasm://original' });
   });
 
   it('falls back to init when no reinit hook is supplied (unit hosts only)', async () => {

--- a/packages/core/src/worker/wasm-guard.ts
+++ b/packages/core/src/worker/wasm-guard.ts
@@ -118,15 +118,24 @@ export function isWasmTrap(err: unknown): boolean {
 }
 
 /**
- * The input a wasm-bindgen `init(input)` accepts: a URL string / `URL` to fetch,
+ * The module input a wasm-bindgen `init({ module_or_path })` accepts: a URL
+ * string / `URL` to fetch,
  * or the already-decoded module bytes (a `data:` URL that `init` cannot fetch is
  * decoded to an `ArrayBuffer`/`BufferSource` by the worker first). Kept wide to
  * match the generated glue's `InitInput` without depending on its exact type.
  */
 export type WasmInitInput = string | URL | ArrayBuffer | ArrayBufferView | Response;
 
-/** How a {@link WasmParserHost} initialises its WASM module. Mirrors the
- *  wasm-bindgen `init(input)` free function each parser package exports. */
+/** Current wasm-bindgen async initialization options. Passing the module input
+ * directly remains supported by generated glue for compatibility, but emits a
+ * deprecation warning in browsers. */
+interface WasmInitOptions {
+  readonly module_or_path: WasmInitInput | Promise<WasmInitInput>;
+}
+
+/** How a {@link WasmParserHost} initialises its WASM module. This intentionally
+ * keeps the established callback type; the host adapts its invocation to
+ * wasm-bindgen's current object form internally. */
 export type WasmInit = (input: WasmInitInput) => Promise<unknown>;
 
 /**
@@ -144,6 +153,18 @@ export type WasmInit = (input: WasmInitInput) => Promise<unknown>;
  * {@link WasmParserHost.ensureReady}.
  */
 export type WasmReinit = (input: WasmInitInput) => Promise<unknown>;
+
+function invokeWasmInitializer(
+  initializer: WasmInit | WasmReinit,
+  input: WasmInitInput,
+): Promise<unknown> {
+  // Generated wasm-bindgen functions accept both forms, but the positional
+  // form is deprecated and logs once per new worker. Keep that glue detail at
+  // this boundary instead of leaking it into each DOCX/XLSX/PPTX worker.
+  return (initializer as unknown as (options: WasmInitOptions) => Promise<unknown>)({
+    module_or_path: input,
+  });
+}
 
 /** Optional per-host hooks. */
 export interface WasmParserHostOptions<TArchive> {
@@ -213,11 +234,12 @@ export class WasmParserHost<TArchive = unknown> {
   }
 
   /** Record the WASM URL/input and kick off the first `init`. Called once, on
-   *  the worker's `init` message — same moment the old code did `init(url)`. */
+   *  the worker's `init` message. The object form is required by current
+   *  wasm-bindgen glue; its legacy positional form logs a browser warning. */
   setWasmUrl(input: WasmInitInput): void {
     this._wasmInput = input;
     this._poisoned = false;
-    this._initPromise = this._init(input);
+    this._initPromise = invokeWasmInitializer(this._init, input);
   }
 
   /** The archive handle for the current instance, or null when none is open
@@ -277,7 +299,7 @@ export class WasmParserHost<TArchive = unknown> {
       // Only flip `_poisoned` off once the rebuild settles successfully, so a
       // failed rebuild stays poisoned and is retried on the following request
       // rather than handing back a dead module.
-      const p = rebuild(this._wasmInput);
+      const p = invokeWasmInitializer(rebuild, this._wasmInput);
       this._initPromise = p;
       await p;
       this._poisoned = false;

--- a/packages/docx/src/DocxViewer.stories.ts
+++ b/packages/docx/src/DocxViewer.stories.ts
@@ -164,7 +164,7 @@ export const DebugJson: Story = {
     // idempotent and cached, so the second await resolves instantly. This
     // closes the race where picking a file before init resolved would silently
     // return and leave the placeholder visible.
-    const wasmReady = init(wasmUrl);
+    const wasmReady = init({ module_or_path: wasmUrl });
 
     fileInput.addEventListener('change', async () => {
       const file = fileInput.files?.[0];

--- a/packages/docx/src/frame-keep-with-anchor.test.ts
+++ b/packages/docx/src/frame-keep-with-anchor.test.ts
@@ -96,10 +96,11 @@ function para(opts: { text?: string; fontSize?: number } = {}): BodyElement {
 /** A frame paragraph (`w:framePr`) carrying a single text run. */
 function framePara(
   fp: FramePr,
-  opts: { text?: string; fontSize?: number; footnoteId?: string } = {},
+  opts: { text?: string; fontSize?: number; footnoteId?: string; position?: number } = {},
 ): BodyElement {
   const fontSize = opts.fontSize ?? 20;
   const run = textRun(opts.text ?? 'F', fontSize);
+  if (run.type === 'text' && opts.position !== undefined) run.position = opts.position;
   if (run.type === 'text' && opts.footnoteId !== undefined) {
     run.noteRef = { kind: 'footnote', id: opts.footnoteId };
     run.vertAlign = 'super';
@@ -365,5 +366,34 @@ describe('canonical body layout — text-frame keep-with-anchor (§17.3.1.11)', 
     // The drop cap registers a wrap float on page 1 (following text wraps around
     // it), confirming the register path still runs when no relocation happens.
     expect(pages[0].length).toBe(2);
+  });
+
+  it('keeps anchor text below a lowered drop cap without extending its authored line count', () => {
+    const body = [
+      framePara(
+        frame({ dropCap: 'drop', lines: 2, wrap: 'around' }),
+        { text: 'D', fontSize: 40, position: -5 },
+      ),
+      para({ text: 'あ'.repeat(32), fontSize: 20 }),
+    ];
+    const nodes = bodyLayout(body, section({ pageHeight: 220 }), makeCtx()).pages[0]!.layers.body;
+    const dropCap = nodes.find((node) => node.kind === 'paragraph' && !node.ordinaryFlow);
+    const anchor = nodes.find((node) => node.kind === 'paragraph' && node.ordinaryFlow);
+    expect(dropCap?.kind).toBe('paragraph');
+    expect(anchor?.kind).toBe('paragraph');
+    if (dropCap?.kind !== 'paragraph' || anchor?.kind !== 'paragraph') {
+      throw new Error('Expected retained drop-cap and anchor paragraphs');
+    }
+
+    // `position=-5pt` lowers the retained glyph baseline by 5pt. Word keeps the
+    // frame's §17.3.1.11 two-line height, but starts its anchor band 5pt lower so
+    // the first line after those two lines cannot collide with the glyph.
+    const glyph = dropCap.lines[0]!.placements.find((placement) => placement.kind === 'text');
+    expect(glyph?.kind).toBe('text');
+    if (glyph?.kind !== 'text') throw new Error('Expected drop-cap text placement');
+    expect(Math.max(...glyph.paintOps.map((operation) => operation.offset.yPt)))
+      .toBeCloseTo(5, 6);
+    expect(anchor.lines[0]!.bounds.yPt - dropCap.flowBounds.yPt).toBeCloseTo(5, 6);
+    expect(dropCap.flowBounds.heightPt).toBeCloseTo(40, 6);
   });
 });

--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -3987,6 +3987,29 @@ export interface RetainedFrameGroupAcquisition {
   }>[];
 }
 
+/** Downward glyph paint outside a retained frame member's nominal baseline.
+ * Frame admission and anchor flow consume this immutable retained geometry;
+ * neither stage reconstructs run-position semantics from parser fields. */
+export function retainedFrameDownwardPaintOverflowPt(
+  acquisition: RetainedFrameGroupAcquisition,
+): number {
+  let maximumPt = 0;
+  for (const member of acquisition.members) {
+    for (const line of member.fragment.lines) {
+      for (const placement of line.placements) {
+        if (placement.kind !== 'text') continue;
+        for (const operation of placement.paintOps) {
+          maximumPt = Math.max(
+            maximumPt,
+            placement.origin.yPt + operation.offset.yPt - line.baselinePt,
+          );
+        }
+      }
+    }
+  }
+  return maximumPt;
+}
+
 export interface RetainedFrameGroupOptions {
   readonly contexts: readonly ParagraphLayoutContext[];
   readonly inputs: readonly ParagraphAcquisitionInput[];

--- a/packages/docx/src/layout/production-body-layout.ts
+++ b/packages/docx/src/layout/production-body-layout.ts
@@ -26,7 +26,7 @@ import { isAllRotatedVerticalTextDirection, isVerticalSection, isVerticalTextDir
 import { gridForParagraphContext, paragraphMeasurementEnvironment } from './measurement-environment.js';
 import { BODY_STORY_CONTEXT, bodyAnchorReferenceFrames, retainedTableRecord, resolveBodyParagraphLayoutContext, resolveStateParagraphLayoutContext, withTableCellStory } from './acquisition-state.js';
 import { applyNumberingBodyOffset, resolveNumberingMarkerGeometry } from './numbering-marker.js';
-import { resolveTableColumnWidths } from './table-columns.js';
+import { measureTableIntrinsicWidths, resolveTableColumnWidths } from './table-columns.js';
 import { measureParagraphIntrinsicWidths, measureTableCellIntrinsicWidths } from './intrinsic-width.js';
 // ── Line-layout engine (segmentation + line-breaking + measurement) ──────────
 // Body acquisition drives the pure root line-layout kernel through this
@@ -40,7 +40,7 @@ import { layoutTable as layoutRetainedTableInput } from './table.js';
 import { startTableFragmentCursor, takeTableFragment, type PageDependentTableBlockRequest } from './table-pagination.js';
 import { paragraphGapAdjustment } from './paragraph-spacing.js';
 import { bottomBorderExtentPt, resolveParagraphBorderEdges } from './paragraph-border-adjacency.js';
-import { acquireParagraphResult, acquireRetainedFrameGroup, bodyFrameGroupFor, bodyParagraphBorderEdgesFor, projectPhysicalAnchorResult, type BodyFrameGroup } from './paragraph.js';
+import { acquireParagraphResult, acquireRetainedFrameGroup, bodyFrameGroupFor, bodyParagraphBorderEdgesFor, projectPhysicalAnchorResult, retainedFrameDownwardPaintOverflowPt, type BodyFrameGroup } from './paragraph.js';
 import type { CompleteTextBoxStoryAcquirer } from './paragraph.js';
 import type { AnchorFloatRegistrationState, BodyAcquisitionState, BodyMeasurementContext, RetainedTableRecord } from './acquisition-context.js';
 import { ownedParagraphAnchorCollisions, inheritedParagraphAuthorityForReacquisition, TRANSIENT_TABLE_FINAL_FRAME_EXCLUSION_PREFIX } from './paragraph-wrap-registry.js';
@@ -936,6 +936,10 @@ function buildConcreteBodyLayoutKernel(
             if (!acquiredGroup) throw new Error('Body frame acquisition omitted its retained group');
             const member = acquiredGroup.members.find((candidate) => candidate.paragraph === paragraph);
             if (!member) throw new Error('Body frame acquisition omitted its retained member');
+            const dropCapAnchorLeadingPt = paragraph === frameGroup.members.at(-1)
+              && frameGroup.framePr.dropCap !== 'none'
+              ? retainedFrameDownwardPaintOverflowPt(acquiredGroup)
+              : 0;
             const absoluteVertical = paragraph.framePr.vAnchor === 'page'
               || paragraph.framePr.vAnchor === 'margin';
             const frameOccurrenceId = box.exclusionId
@@ -960,7 +964,12 @@ function buildConcreteBodyLayoutKernel(
             });
             return Object.freeze({
               layout: member.fragment,
-              blockExtentPt: 0,
+              // §17.3.1.11 fixes a drop cap's exclusion to N anchor lines, while
+              // §17.3.2.24 can lower its glyph without changing that line box.
+              // Advance only the anchor band's leading edge by the retained
+              // downward paint offset; extending the exclusion would wrap N+1
+              // lines and moving the frame would change its authored anchor.
+              blockExtentPt: dropCapAnchorLeadingPt,
               lineEndBoundaries: Object.freeze([]),
               placement: Object.freeze({
                 coordinateSpace: 'logical-body' as const,
@@ -2182,11 +2191,6 @@ function resolveColumnWidths(
   state: BodyMeasurementContext,
 ): number[] {
   const format = state.acquisitionInputs.tableFormatInput(table);
-  const marginsByCell = new WeakMap<object, Readonly<{ left: number; right: number }>>();
-  table.rows.forEach((row, rowIndex) => row.cells.forEach((cell, cellIndex) => {
-    const acquired = format.rows[rowIndex]?.cells[cellIndex]?.marginsPt;
-    marginsByCell.set(cell, acquired ?? effCellMargins(cell, table));
-  }));
   const baseIndentPt = Number.isFinite(table.tblInd) ? (table.tblInd ?? 0) : 0;
   const rowIndentPts = format.rows.map((row) => {
     const exception = row.exception;
@@ -2243,12 +2247,20 @@ function resolveColumnWidths(
   const maximumTableWidthPt = isLeadingMarginPageStoryTable
     ? Math.max(contentWPt, pageFitCeilingPt)
     : contentWPt;
-  return [...resolveTableColumnWidths(state.acquisitionInputs.tableColumnLayoutInput(
-    table,
-    contentWPt,
-    (cell) => {
-      const margins = marginsByCell.get(cell as object) ?? effCellMargins(cell, table);
-      return measureTableCellIntrinsicWidths(cell, margins, {
+
+  const intrinsicWidthsForTable = (
+    owner: TableLayoutSource,
+    ownerFormat = state.acquisitionInputs.tableFormatInput(owner),
+  ): ((cell: DeepReadonly<DocTableCell>) => ReturnType<typeof measureTableCellIntrinsicWidths>) => {
+    const ownerMargins = new WeakMap<object, Readonly<{ left: number; right: number }>>();
+    owner.rows.forEach((row, rowIndex) => row.cells.forEach((cell, cellIndex) => {
+      const acquired = ownerFormat.rows[rowIndex]?.cells[cellIndex]?.marginsPt;
+      ownerMargins.set(cell, acquired ?? effCellMargins(cell, owner));
+    }));
+    return (cell) => measureTableCellIntrinsicWidths(
+      cell,
+      ownerMargins.get(cell as object) ?? effCellMargins(cell, owner),
+      {
         paragraph: (paragraph) => {
           const baseContext = resolveParagraphLayoutContext(
             state.layoutSettings,
@@ -2289,13 +2301,21 @@ function resolveColumnWidths(
             numbering,
           );
         },
-        nestedTable: (nested) => {
-          const widthPt = resolveColumnWidths(nested, contentWPt, state)
-            .reduce((sum, width) => sum + width, 0);
-          return { minWidthPt: widthPt, maxWidthPt: widthPt };
-        },
-      });
-    },
+        nestedTable: (nested) => measureTableIntrinsicWidths(
+          state.acquisitionInputs.tableColumnLayoutInput(
+            nested,
+            contentWPt,
+            intrinsicWidthsForTable(nested),
+            contentWPt,
+          ),
+        ),
+      },
+    );
+  };
+  return [...resolveTableColumnWidths(state.acquisitionInputs.tableColumnLayoutInput(
+    table,
+    contentWPt,
+    intrinsicWidthsForTable(table, format),
     state.acquisitionInputs.tableParticipatesInOrdinaryFlow(table)
       ? maximumTableWidthPt
       : Math.max(contentWPt, state.pageWidth),

--- a/packages/docx/src/layout/table-columns.ts
+++ b/packages/docx/src/layout/table-columns.ts
@@ -333,6 +333,54 @@ function growSpan(widths: number[], start: number, span: number, amountPt: numbe
   }
 }
 
+export interface TableIntrinsicWidths {
+  readonly minWidthPt: number;
+  readonly maxWidthPt: number;
+}
+
+/**
+ * Measure only the content interval contributed by a table when it is nested
+ * inside another cell. ECMA-376 §17.18.87 establishes these content bounds
+ * before the containing grid is fitted. tblW/tcW remain preferred-width
+ * constraints; feeding a nested table's fitted occurrence width back as its
+ * parent's content minimum would create a circular width constraint.
+ *
+ * Fixed-layout tables do not acquire cell-content constraints (§17.18.87).
+ * They remain one fixed-width atom using their already-projected preferred
+ * width; only AutoFit tables expose recursively measured content min/max.
+ */
+export function measureTableIntrinsicWidths(
+  input: TableColumnLayoutInput,
+): TableIntrinsicWidths {
+  const columnCount = requiredColumnCount(input);
+  if (input.layout === 'fixed') {
+    const widthsPt = fixedWidths(input, columnCount);
+    const widthPt = widthsPt.reduce((sum, width) => sum + width, 0);
+    return Object.freeze({ minWidthPt: widthPt, maxWidthPt: widthPt });
+  }
+  const minimums = new Array<number>(columnCount).fill(0);
+  const maximums = new Array<number>(columnCount).fill(0);
+  const cells = input.rows.flatMap((row) => row.cells)
+    .sort((left, right) => left.columnSpan - right.columnSpan);
+  const enforce = (widths: number[], cell: TableColumnCellConstraint, requiredPt: number): void => {
+    const start = Math.max(0, cell.columnStart);
+    const span = Math.max(1, Math.min(cell.columnSpan, widths.length - start));
+    if (span <= 0) return;
+    const deficitPt = finiteNonNegative(requiredPt) - spanSum(widths, start, span);
+    if (deficitPt > EPSILON_PT) growSpan(widths, start, span, deficitPt);
+  };
+  for (const cell of cells) {
+    enforce(minimums, cell, cell.minContentWidthPt);
+    enforce(maximums, cell, Math.max(cell.minContentWidthPt, cell.maxContentWidthPt));
+  }
+  const minWidthPt = minimums.reduce((sum, width) => sum + width, 0);
+  const maxWidthPt = Math.max(
+    minWidthPt,
+    maximums.reduce((sum, width) => sum + width, 0),
+  );
+  return Object.freeze({ minWidthPt, maxWidthPt });
+}
+
 function enforceContentConstraint(
   widths: number[],
   minimums: readonly number[],

--- a/packages/docx/src/layout/table-pagination.ts
+++ b/packages/docx/src/layout/table-pagination.ts
@@ -190,6 +190,39 @@ function paginationRowHeight(source: RetainedTableAcquisition, rowIndex: number)
   return Math.max(0, row.heightPt, row.contentHeightPt);
 }
 
+function nestedTableFragmentContext(
+  source: RetainedTableAcquisition,
+  parentCell: TableCellLayoutInput,
+  context: TableFragmentContext,
+  availableHeightPt: number,
+): TableFragmentContext {
+  const retainedCell = source.layout.rows
+    .flatMap((row) => row.cells)
+    .find((cell) => cell.id === parentCell.id);
+  if (!retainedCell) {
+    throw new LayoutInvariantError(
+      'INVALID_REFERENCE',
+      `nested table fragment lost parent cell geometry: ${parentCell.id}`,
+    );
+  }
+  const bounds = Object.freeze({
+    xPt: 0,
+    yPt: 0,
+    widthPt: retainedCell.contentBounds.widthPt,
+    heightPt: Math.max(0, availableHeightPt),
+  });
+  return Object.freeze({
+    ...context,
+    availableHeightPt: bounds.heightPt,
+    placement: Object.freeze({
+      ...context.placement,
+      container: Object.freeze({ ...context.placement.container, bounds }),
+      cursor: Object.freeze({ xPt: 0, yPt: 0 }),
+      availableBounds: bounds,
+    }),
+  });
+}
+
 function paginationRowHeightForOccurrence(
   source: RetainedTableAcquisition,
   row: TableRowLayoutInput,
@@ -300,17 +333,16 @@ function remainingRowAtCursor(
           if (blockOffset === 0 && cellCursor.nestedCursor && block.layout.kind === 'table') {
             const nested = source.nestedById[block.layout.id];
             if (nested) {
-              const remaining = takeTableFragment(nested, cellCursor.nestedCursor, {
-                ...context,
-                availableHeightPt: context.freshPageHeightPt,
-                placement: {
-                  ...context.placement,
-                  availableBounds: {
-                    ...context.placement.availableBounds,
-                    heightPt: context.freshPageHeightPt,
-                  },
-                },
-              });
+              const remaining = takeTableFragment(
+                nested,
+                cellCursor.nestedCursor,
+                nestedTableFragmentContext(
+                  source,
+                  cell,
+                  context,
+                  context.freshPageHeightPt,
+                ),
+              );
               const requiredAnchor = requiredAnchorByCell.get(cell.id);
               if (remaining.nextCursor && requiredAnchor !== undefined
                 && block.sourceBlockIndex < requiredAnchor) {
@@ -729,14 +761,11 @@ function selectCell(
         0,
         availableContentHeightPt - measureTableCellBlockFlowHeightPt(blocks),
       );
-      const nestedResult = takeTableFragment(nested, nestedCursor ?? startTableFragmentCursor(), {
-        ...context,
-        availableHeightPt: remainingPt,
-        placement: {
-          ...context.placement,
-          availableBounds: { ...context.placement.availableBounds, heightPt: remainingPt },
-        },
-      });
+      const nestedResult = takeTableFragment(
+        nested,
+        nestedCursor ?? startTableFragmentCursor(),
+        nestedTableFragmentContext(source, cell, context, remainingPt),
+      );
       if (!nestedResult.fragment) break;
       blocks.push({ layout: nestedResult.fragment, sourceBlockIndex: sourceBlock.sourceBlockIndex });
       range.push({

--- a/packages/docx/src/table-a4-acceptance.test.ts
+++ b/packages/docx/src/table-a4-acceptance.test.ts
@@ -188,12 +188,60 @@ function table(
   } as unknown as DocTable;
 }
 
-function document(body: BodyElement[]): DocxDocumentModel {
+function percentageNestedTable(nestedRowCount = 1): DocTable {
+  const nested = {
+    type: 'table', colWidths: [40, 40],
+    rows: Array.from({ length: nestedRowCount }, (_unused, index) => row([
+      textCell(index === 0 ? 'one' : `left${index}`),
+      textCell(index === 0 ? 'two' : `right${index}`),
+    ])), borders: noBorders,
+    cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+    jc: 'center', layout: 'autofit',
+    __tableLayout: {
+      effectiveStyleId: null,
+      grid: {
+        authored: true,
+        columns: [{ width: '800' }, { width: '800' }],
+        requiredColumnCount: 2,
+      },
+      preferredWidth: { kind: 'pct', value: '4000' },
+      layout: { kind: 'autofit' }, cellSpacing: null, cellMargins: null,
+    },
+  } as unknown as DocTable;
+  return {
+    type: 'table', colWidths: [100, 100],
+    rows: [row([
+      {
+        content: [nested as CellElement], colSpan: 1, vMerge: null,
+        borders: noBorders, background: null, vAlign: 'top', widthPt: null,
+      } as unknown as DocTableCell,
+      textCell('side'),
+    ])],
+    borders: noBorders,
+    cellMarginTop: 0, cellMarginRight: 0, cellMarginBottom: 0, cellMarginLeft: 0,
+    jc: 'center', layout: 'autofit',
+    __tableLayout: {
+      effectiveStyleId: null,
+      grid: {
+        authored: true,
+        columns: [{ width: '2000' }, { width: '2000' }],
+        requiredColumnCount: 2,
+      },
+      preferredWidth: { kind: 'pct', value: '3500' },
+      layout: { kind: 'autofit' }, cellSpacing: null, cellMargins: null,
+    },
+  } as unknown as DocTable;
+}
+
+function document(
+  body: BodyElement[],
+  sectionOverrides: Partial<SectionProps> = {},
+): DocxDocumentModel {
   const section = {
     pageWidth: 240, pageHeight: 400,
     marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
     headerDistance: 4, footerDistance: 4, titlePage: false, evenAndOddHeaders: false,
-    sectionStart: 'nextPage', columns: null,
+    sectionStart: 'nextPage', columns: null, ...sectionOverrides,
   } as SectionProps;
   return {
     section, body,
@@ -250,6 +298,68 @@ function retainedTable(model: DocxDocumentModel): Readonly<{
 }
 
 describe('A4 retained table acceptance', () => {
+  it('resolves a nested percentage table only after its parent cell width is final', () => {
+    // ECMA-376 §17.18.87 measures cell-content minima before fitting the parent
+    // grid. A nested table's fitted preferred width is not content, so feeding
+    // that occurrence width back into the parent would form a circular
+    // constraint and incorrectly widen the first outer column.
+    const acquired = retainedTable(document([
+      percentageNestedTable() as BodyElement,
+    ])).layout;
+
+    expect(acquired.columnWidthsPt).toEqual([77, 77]);
+    const nestedBlock = acquired.rows[0]?.cells[0]?.blocks[0]?.layout;
+    expect(nestedBlock?.kind).toBe('table');
+    if (nestedBlock?.kind !== 'table') throw new Error('Expected nested retained table');
+    expect(nestedBlock.columnWidthsPt.reduce((sum, widthPt) => sum + widthPt, 0))
+      .toBeCloseTo(61.6, 6);
+    expect(nestedBlock.flowBounds.xPt).toBeCloseTo(7.7, 6);
+  });
+
+  it('does not promote a saved nested percentage occurrence to parent content minimum', () => {
+    const outer = percentageNestedTable(2);
+    outer.colWidths = [174.4, 160.75];
+    outer.rows[0]!.cells[0]!.widthPt = 239.4;
+    outer.rows[0]!.cells[1]!.widthPt = 239.4;
+    const nested = outer.rows[0]!.cells[0]!.content[0];
+    if (nested?.type !== 'table') throw new Error('Expected nested source table');
+    nested.colWidths = [67.15, 63.35];
+    nested.rows[0]!.cells[0]!.widthPt = 83.9;
+    nested.rows[0]!.cells[1]!.widthPt = 81.45;
+    nested.rows[0]!.cells[0]!.vMerge = true;
+    nested.rows[1]!.cells[0]!.widthPt = 83.9;
+    nested.rows[1]!.cells[1]!.widthPt = 81.45;
+    nested.rows[1]!.cells[0]!.vMerge = false;
+
+    const acquired = retainedTable(document(
+      [outer as BodyElement],
+      { pageWidth: 612, marginLeft: 72, marginRight: 72 },
+    )).layout;
+
+    expect(acquired.columnWidthsPt[0]).toBeCloseTo(163.8, 6);
+    expect(acquired.columnWidthsPt[1]).toBeCloseTo(163.8, 6);
+  });
+
+  it('keeps page-sliced nested tables in their parent-cell coordinate space', () => {
+    const model = document(
+      [percentageNestedTable(4) as BodyElement],
+      { pageHeight: 50 },
+    );
+    const result = layoutDocument(model, createLayoutServices(model, {
+      measureContext: measuringContext(),
+    }));
+    const nestedFragments = result.pages.flatMap((page) => page.layers.body)
+      .filter((node): node is TableLayout => node.kind === 'table')
+      .flatMap((outer) => outer.rows.flatMap((outerRow) => outerRow.cells[0]?.blocks ?? []))
+      .map((block) => block.layout)
+      .filter((block): block is TableLayout => block.kind === 'table');
+
+    expect(nestedFragments.length).toBeGreaterThan(1);
+    nestedFragments.forEach((nested) => {
+      expect(nested.flowBounds.xPt).toBeCloseTo(7.7, 6);
+    });
+  });
+
   it.each([
     ['fixed', 'autofit'],
     ['autofit', 'fixed'],

--- a/packages/node/src/wasm-reinit-recovery.test.ts
+++ b/packages/node/src/wasm-reinit-recovery.test.ts
@@ -98,16 +98,16 @@ describe.each(FORMATS)('RB6 real-glue recovery: $name parser', ({ glue, wasmRel 
     // Track how the live instance moves by reading the module's exported memory
     // through the glue each time.
     const host = new WasmParserHost<unknown>(
-      (input) => mod.default(input as unknown as { module_or_path: WebAssembly.Module }),
+      (options) => mod.default(options as unknown as { module_or_path: WebAssembly.Module }),
       {
-        reinit: (input) => mod.reinit(input as unknown as { module_or_path: WebAssembly.Module }),
+        reinit: (options) => mod.reinit(options as unknown as { module_or_path: WebAssembly.Module }),
       },
     );
     // Ensure a known baseline: force a fresh instance before this test so the
     // singleton isn't whatever a sibling test left cached, then let the host load.
     const baseline = await mod.reinit({ module_or_path: compiled });
     const sentinel = stampSentinel(baseline.memory);
-    host.setWasmUrl({ module_or_path: compiled } as unknown as string);
+    host.setWasmUrl(compiled as unknown as string);
     await host.ensureReady(); // host's `init` returns the cached (stamped) instance
 
     // Sanity: the host is running on the SAME stamped instance right now (init is

--- a/packages/pptx/src/PptxViewer.stories.ts
+++ b/packages/pptx/src/PptxViewer.stories.ts
@@ -160,7 +160,7 @@ export const DebugJson: Story = {
     // idempotent and cached, so the second await resolves instantly. This
     // closes the race where picking a file before init resolved would silently
     // return without ever updating the pre.
-    const wasmReady = init(wasmUrl);
+    const wasmReady = init({ module_or_path: wasmUrl });
 
     fileInput.addEventListener('change', async () => {
       const file = fileInput.files?.[0];

--- a/packages/xlsx/src/XlsxViewer.stories.ts
+++ b/packages/xlsx/src/XlsxViewer.stories.ts
@@ -113,7 +113,7 @@ export const DebugJson: Story = {
     // idempotent and cached, so the second await resolves instantly. This
     // closes the race where picking a file before init resolved would silently
     // return and leave the placeholder visible.
-    const wasmReady = init(wasmUrl);
+    const wasmReady = init({ module_or_path: wasmUrl });
 
     fileInput.addEventListener('change', async () => {
       const file = fileInput.files?.[0];


### PR DESCRIPTION
## Summary

- measure nested AutoFit tables from intrinsic cell content before fitting the parent grid
- keep page-sliced nested table fragments in parent-cell coordinates
- account for downward run-position paint overflow when advancing drop-cap anchor flow
- use the current wasm-bindgen object initialization form across DOCX, XLSX, and PPTX workers and Storybook examples

## Specification basis

The DOCX layout changes follow ECMA-376 sections 17.18.87, 17.3.1.11, and 17.3.2.24. Preferred table widths remain constraints rather than content minima, and drop-cap line exclusion remains authored while retained paint overflow advances the following anchor band.

## Verification

- pnpm test: 6281 passed, 27 skipped
- pnpm typecheck
- DOCX final architecture boundary checks: 88 passed
- DOCX compatibility evidence checks: 17 passed
- DOCX public API checks: 25 passed
- DOCX package build checks: 2 passed
- focused WASM host and real-glue recovery tests: 33 passed
- local-only visual comparison of representative nested-table and drop-cap documents
- Storybook browser console verification: wasm initialization deprecation warning absent

## Compatibility

Viewer APIs are unchanged. The shared WASM host retains its established callback types and adapts generated glue invocation internally.