### PR TITLE
fix(site): refine document preview experience

### DIFF
--- a/site/src/components/LiveShowcase.astro
+++ b/site/src/components/LiveShowcase.astro
@@ -24,7 +24,16 @@ const formats = [
       <span class="panel-file" data-file>sample-1.docx</span>
       <span class="panel-badge">live · WASM</span>
     </div>
-    <div class="panel-body" data-mount></div>
+    <div class="panel-body" data-mount>
+      {formats.map((format, index) => (
+        <div
+          class="panel-pane"
+          data-format-pane={format.id}
+          data-active={index === 0 ? 'true' : 'false'}
+          aria-hidden={index === 0 ? 'false' : 'true'}
+        ></div>
+      ))}
+    </div>
   </div>
 </div>
 
@@ -38,17 +47,51 @@ const formats = [
     const mount = root.querySelector<HTMLElement>('[data-mount]')!;
     const fileLabel = root.querySelector<HTMLElement>('[data-file]')!;
     const tabs = Array.from(root.querySelectorAll<HTMLButtonElement>('[data-tab]'));
-    let current: LiveController | null = null;
+    type CachedViewer = { pane: HTMLDivElement; controller: LiveController };
+    const cache = new Map<string, CachedViewer>();
     let loaded: string | null = null;
+
+    function ensureViewer(id: string): CachedViewer {
+      let entry = cache.get(id);
+      if (!entry) {
+        const pane = mount.querySelector<HTMLDivElement>(`[data-format-pane="${id}"]`);
+        if (!pane) throw new Error(`Missing showcase pane for ${id}`);
+        const url = sample(`sample-1.${id}`);
+        const controller = id === 'pptx'
+          ? mountPptx(pane, url)
+          : id === 'docx'
+            ? mountDocx(pane, url)
+            : mountXlsx(pane, url);
+        entry = { pane, controller };
+        cache.set(id, entry);
+      }
+      return entry;
+    }
 
     function show(id: string): void {
       if (loaded === id) return;
       loaded = id;
       root.dataset.format = id;
-      current?.destroy();
-      if (id === 'pptx') { fileLabel.textContent = 'sample-1.pptx'; current = mountPptx(mount, sample('sample-1.pptx')); }
-      else if (id === 'docx') { fileLabel.textContent = 'sample-1.docx'; current = mountDocx(mount, sample('sample-1.docx')); }
-      else { fileLabel.textContent = 'sample-1.xlsx'; current = mountXlsx(mount, sample('sample-1.xlsx')); }
+      fileLabel.textContent = `sample-1.${id}`;
+      const active = ensureViewer(id);
+      for (const [format, entry] of cache) {
+        const selected = format === id;
+        entry.pane.dataset.active = String(selected);
+        entry.pane.setAttribute('aria-hidden', String(!selected));
+      }
+      active.controller.activate?.();
+    }
+
+    function warmFormats(activeId: string): void {
+      // The showcase has exactly three small, bundled files. Start the two
+      // inactive viewers after the active pane has been scheduled for paint so
+      // even the first tab switch reuses a parsed, rendered viewer.
+      setTimeout(() => {
+        for (const tab of tabs) {
+          const id = tab.dataset.tab;
+          if (id && id !== activeId) ensureViewer(id);
+        }
+      }, 0);
     }
 
     tabs.forEach((tab) => {
@@ -64,14 +107,20 @@ const formats = [
     const nearViewport = () => root.getBoundingClientRect().top < window.innerHeight + 600;
     if (nearViewport()) {
       show(first);
+      warmFormats(first);
     } else {
       const io = new IntersectionObserver((entries) => {
         for (const e of entries) {
-          if (e.isIntersecting) { show(first); io.disconnect(); }
+          if (e.isIntersecting) { show(first); warmFormats(first); io.disconnect(); }
         }
       }, { rootMargin: '600px' });
       io.observe(root);
     }
+
+    window.addEventListener('pagehide', () => {
+      for (const entry of cache.values()) entry.controller.destroy();
+      cache.clear();
+    }, { once: true });
   });
 </script>
 
@@ -106,6 +155,8 @@ const formats = [
     background: var(--border);
   }
   .panel {
+    min-width: 0;
+    max-width: 100%;
     border: 1px solid var(--border);
     border-radius: 14px;
     background: var(--panel);
@@ -130,10 +181,48 @@ const formats = [
     border-radius: 0;
     padding: 3px 10px;
   }
-  .panel-body { padding: 0; }
-  .panel-body :global(.lv-scroll) { border-radius: 0; }
-  .showcase[data-format='xlsx'] .panel-body :global(.lv-xlsx) { border-radius: 0; }
+  .panel-body {
+    position: relative;
+    width: 100%;
+    height: min(74vh, 680px);
+    min-width: 0;
+    max-width: 100%;
+    min-height: 420px;
+    padding: 0;
+    overflow: hidden;
+  }
+  .panel-pane {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    background: radial-gradient(120% 80% at 50% 0%, var(--preview-top), var(--preview-bottom) 70%);
+    overflow: hidden;
+    visibility: hidden;
+    pointer-events: none;
+  }
+  .panel-pane[data-active='true'] { visibility: visible; pointer-events: auto; }
+  .panel-pane :global(.lv-scroll-viewer),
+  .panel-pane :global(.lv-xlsx) { width: 100%; height: 100%; border-radius: 0; }
+  .panel-pane[data-format-pane='docx'] :global(.lv-scroll-viewer),
+  .panel-pane[data-format-pane='pptx'] :global(.lv-scroll-viewer) {
+    max-width: none;
+  }
+  .panel-pane :global(.lv-status) {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    pointer-events: none;
+  }
+  .panel-pane[data-format-pane='docx'] :global(.lv-scroll-viewer canvas),
+  .panel-pane[data-format-pane='pptx'] :global(.lv-scroll-viewer canvas) {
+    border-radius: 4px;
+  }
   @media (max-width: 620px) {
+    .panel-body { height: min(68vh, 520px); min-height: 340px; }
     .panel-file { display: none; }
     .panel-head { gap: 8px; }
     .panel-badge { margin-left: auto; }

--- a/site/src/demo-loading.test.ts
+++ b/site/src/demo-loading.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const demos = readFileSync(new URL('./lib/demos.ts', import.meta.url), 'utf8');
+const styles = readFileSync(new URL('./styles/global.css', import.meta.url), 'utf8');
+
+describe('detail-page demo parsing progress', () => {
+  it('keeps the initial DOCX/PPTX canvas hidden until parsing completes', () => {
+    expect(demos).toContain('canvas.hidden = true;');
+    expect(demos).toContain('canvas.hidden = false;');
+    expect(demos).toContain('viewerWrapper.hidden = true;');
+    expect(demos).toContain('viewerWrapper.hidden = false;');
+    expect(demos).toContain('detailCanvas.hidden = true;');
+    expect(demos).toContain('detailCanvas.hidden = false;');
+    expect(demos).toContain('detailViewerWrapper.hidden = true;');
+    expect(demos).toContain('detailViewerWrapper.hidden = false;');
+  });
+
+  it('shows the same accessible progress-circle pattern as Try Yours', () => {
+    expect(demos).toContain("d.setAttribute('role', 'status');");
+    expect(demos).toContain("circle.className = 'demo-progress-circle';");
+    expect(styles).toContain('.demo-progress-circle {');
+    expect(styles).toContain('@keyframes preview-progress-spin');
+    expect(styles).toContain('.demo-stage > .demo-status { position: absolute; inset: 0; min-height: 0; }');
+  });
+
+  it('constrains the viewer-owned wrapper as well as its canvas on narrow screens', () => {
+    expect(styles).toContain('.demo-stage > div:not(.demo-status) {');
+    expect(styles).toContain('width: min(100%, 760px);');
+    expect(styles).toContain('.demo-detail > div:not(.demo-status) {');
+    expect(styles).toContain('width: min(100%, 960px);');
+    expect(styles).toContain('margin-inline: auto;');
+    expect(styles).toMatch(/max-width:\s*100%;[\s\S]*?min-width:\s*0;/);
+  });
+});

--- a/site/src/home-design.test.ts
+++ b/site/src/home-design.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const showcase = readFileSync(new URL('./components/LiveShowcase.astro', import.meta.url), 'utf8');
+const live = readFileSync(new URL('./lib/live.ts', import.meta.url), 'utf8');
 const capabilities = readFileSync(new URL('./components/Capabilities.astro', import.meta.url), 'utf8');
 const home = readFileSync(new URL('./pages/index.astro', import.meta.url), 'utf8');
 
@@ -57,5 +58,40 @@ describe('official-site home design', () => {
 
   it('lets the live showcase blend into the dark page background', () => {
     expect(home).toContain('.showcase-section { background: var(--showcase-bg); }');
+  });
+
+  it('keeps one lazily-created viewer per format instead of reparsing on every tab switch', () => {
+    expect(showcase).toContain('data-format-pane={format.id}');
+    expect(showcase).toContain('const cache = new Map<string, CachedViewer>();');
+    expect(showcase).toContain('cache.get(id)');
+    expect(showcase).toContain('cache.set(id, entry)');
+    expect(showcase).toContain('function warmFormats(activeId: string): void');
+    expect(showcase).not.toContain('current?.destroy()');
+    expect(showcase).toContain('for (const entry of cache.values()) entry.controller.destroy();');
+  });
+
+  it('uses selectable scroll viewers for the DOCX and PPTX samples', () => {
+    expect(live).toContain('new DocxScrollViewer');
+    expect(live).toContain('new PptxScrollViewer');
+    expect(live.match(/enableTextSelection:\s*true/g)).toHaveLength(2);
+  });
+
+  it('centres a smaller hero icon and aligns the second-row format links on mobile', () => {
+    expect(home).toContain('.hero-art { grid-column: 1 / 13; min-height: 280px; margin-top: 16px; }');
+    expect(home).toContain('.hero-icon { width: min(62%, 260px); }');
+    expect(home).toContain('.format-rail a + a:nth-child(odd) { padding-left: 0; }');
+    expect(home).toContain('.format-rail a:nth-child(even) { padding-left: 18px; }');
+  });
+
+  it('keeps cached mobile previews constrained to the showcase width', () => {
+    expect(showcase).toContain('min-width: 0;');
+    expect(showcase).toMatch(/@media \(max-width: 620px\)[\s\S]*?\.panel-body \{ height: min\(68vh, 520px\); min-height: 340px; \}/);
+  });
+
+  it('caps paginated samples on wide screens while leaving XLSX full width', () => {
+    expect(live).toContain('const MAX_SAMPLE_WIDTH = 880;');
+    expect(live).toContain('MAX_SAMPLE_WIDTH / (presentation.slideWidth / EMU_PER_PX)');
+    expect(live).toContain('document.pageSize(index).widthPt * PT_TO_PX');
+    expect(showcase).toContain('max-width: none;');
   });
 });

--- a/site/src/lib/demos.ts
+++ b/site/src/lib/demos.ts
@@ -70,7 +70,14 @@ export function mountDemoInto(el: HTMLElement, kind: DemoKind, format: Format, u
 function status(el: HTMLElement, text: string): HTMLDivElement {
   const d = document.createElement('div');
   d.className = 'demo-status';
-  d.textContent = text;
+  d.setAttribute('role', 'status');
+  d.setAttribute('aria-live', 'polite');
+  const circle = document.createElement('span');
+  circle.className = 'demo-progress-circle';
+  circle.setAttribute('aria-hidden', 'true');
+  const label = document.createElement('span');
+  label.textContent = text;
+  d.append(circle, label);
   el.appendChild(d);
   return d;
 }
@@ -90,10 +97,14 @@ function mountDemo(el: HTMLElement, format: Format, url: string): void {
   stage.className = 'demo-stage';
   const canvas = document.createElement('canvas');
   canvas.className = 'demo-page';
+  canvas.hidden = true;
   stage.appendChild(canvas);
+  const st = status(stage, 'Parsing document…');
   el.append(bar, stage);
 
   const v = makeViewer(format, canvas, 960);
+  const viewerWrapper = canvas.parentElement as HTMLDivElement;
+  viewerWrapper.hidden = true;
   const sync = () => {
     const n = v.count();
     info.textContent = n ? `${UNIT(format)} ${v.index() + 1} / ${n}` : 'Loading…';
@@ -102,7 +113,15 @@ function mountDemo(el: HTMLElement, format: Format, url: string): void {
   };
   prev.addEventListener('click', () => void v.prev().then(sync));
   next.addEventListener('click', () => void v.next().then(sync));
-  v.load(url).then(sync).catch((e) => { info.textContent = err(e); });
+  v.load(url).then(() => {
+    canvas.hidden = false;
+    viewerWrapper.hidden = false;
+    st.remove();
+    sync();
+  }).catch((e) => {
+    st.textContent = err(e);
+    info.textContent = 'Failed';
+  });
 }
 
 // ScrollView — every page stacked on a backdrop
@@ -127,7 +146,7 @@ function mountThumbnails(el: HTMLElement, format: Format, url: string): void {
   const grid = document.createElement('div');
   grid.className = 'demo-grid';
   el.appendChild(grid);
-  const st = status(el, 'Rendering thumbnails…');
+  const st = status(grid, 'Rendering thumbnails…');
   loadDoc(format, url).then(async (doc) => {
     for (let i = 0; i < doc.count; i++) {
       const cell = document.createElement('div');
@@ -155,14 +174,19 @@ function mountMasterDetail(el: HTMLElement, format: Format, url: string): void {
   detail.className = 'demo-detail';
   const detailCanvas = document.createElement('canvas');
   detailCanvas.className = 'demo-page';
+  detailCanvas.hidden = true;
   detail.appendChild(detailCanvas);
+  const st = status(detail, 'Parsing document…');
   layout.append(rail, detail);
   el.appendChild(layout);
-  const st = status(el, 'Loading…');
 
   const viewer = makeViewer(format, detailCanvas, 960);
+  const detailViewerWrapper = detailCanvas.parentElement as HTMLDivElement;
+  detailViewerWrapper.hidden = true;
   Promise.all([loadDoc(format, url), viewer.load(url)])
     .then(async ([doc]) => {
+      detailCanvas.hidden = false;
+      detailViewerWrapper.hidden = false;
       st.remove();
       const cells: HTMLDivElement[] = [];
       const select = async (i: number) => {

--- a/site/src/lib/live.ts
+++ b/site/src/lib/live.ts
@@ -1,76 +1,141 @@
-// Client-side mounts for the three real viewers, used by the Live Showcase.
-// PPTX/DOCX render every page/slide stacked on a backdrop (Storybook-style),
-// scrolled vertically. XLSX uses its own full viewer. Each mount returns a
-// destroy() so the showcase can swap formats cleanly.
-import { PptxPresentation } from '@silurus/ooxml-pptx';
-import { DocxDocument } from '@silurus/ooxml-docx';
+// Client-side mounts for the three real viewers used by the home-page showcase.
+// Each format is mounted at most once and retained while the page is open, so a
+// tab switch is a DOM visibility change rather than another parse.
+import { EMU_PER_PX, PT_TO_PX } from '@silurus/ooxml-core';
+import { PptxPresentation, PptxScrollViewer } from '@silurus/ooxml-pptx';
+import { DocxDocument, DocxScrollViewer } from '@silurus/ooxml-docx';
 import { XlsxViewer } from '@silurus/ooxml-xlsx';
 
-export type LiveController = { destroy: () => void };
+export type LiveController = {
+  destroy: () => void;
+  /** Re-fit a retained viewer after its hidden pane becomes visible again. */
+  activate?: () => void;
+};
 
-const DPR = () => Math.min(typeof window !== 'undefined' ? window.devicePixelRatio : 1, 2);
-
-function scroller(): HTMLDivElement {
-  const s = document.createElement('div');
-  s.className = 'lv-scroll';
-  return s;
-}
+const MAX_SAMPLE_WIDTH = 880;
 
 function statusLine(text: string): HTMLDivElement {
-  const d = document.createElement('div');
-  d.className = 'lv-status';
-  d.textContent = text;
-  return d;
+  const status = document.createElement('div');
+  status.className = 'lv-status';
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  const circle = document.createElement('span');
+  circle.className = 'lv-progress-circle';
+  circle.setAttribute('aria-hidden', 'true');
+  const label = document.createElement('span');
+  label.textContent = text;
+  status.append(circle, label);
+  return status;
+}
+
+function mountPaginated(
+  root: HTMLElement,
+  kind: 'docx' | 'pptx',
+  url: string,
+): LiveController {
+  root.innerHTML = '';
+  const host = document.createElement('div');
+  host.className = 'lv-scroll-viewer';
+  const status = statusLine('Parsing document…');
+  root.append(host, status);
+
+  let destroyed = false;
+  let viewer: PptxScrollViewer | DocxScrollViewer | null = null;
+  let engine: PptxPresentation | DocxDocument | null = null;
+  let maxScale = Number.POSITIVE_INFINITY;
+  let resizeObserver: ResizeObserver | null = null;
+  let frame: number | null = null;
+
+  const enforceWidthCap = (): void => {
+    if (!viewer || destroyed) return;
+    const current = viewer.getScale();
+    if (current > maxScale) viewer.setScale(maxScale);
+  };
+  const relayout = (): void => {
+    if (!viewer || destroyed) return;
+    viewer.relayout();
+    if (frame !== null) cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => {
+      frame = null;
+      enforceWidthCap();
+    });
+  };
+  const observeWidth = (): void => {
+    if (typeof ResizeObserver === 'undefined') return;
+    resizeObserver = new ResizeObserver(() => relayout());
+    resizeObserver.observe(host);
+  };
+
+  if (kind === 'pptx') {
+    void PptxPresentation.load(url, { useGoogleFonts: true }).then((presentation) => {
+      if (destroyed) {
+        presentation.destroy();
+        return;
+      }
+      engine = presentation;
+      maxScale = MAX_SAMPLE_WIDTH / (presentation.slideWidth / EMU_PER_PX);
+      viewer = new PptxScrollViewer(host, {
+        presentation,
+        gap: 26,
+        overscan: presentation.slideCount,
+        enableTextSelection: true,
+        pageShadow: 'var(--document-shadow)',
+        background: 'transparent',
+      });
+      enforceWidthCap();
+      observeWidth();
+      status.remove();
+    }).catch((error: unknown) => {
+      if (!destroyed) status.textContent = message(error);
+    });
+  } else {
+    void DocxDocument.load(url, { useGoogleFonts: true }).then((document) => {
+      if (destroyed) {
+        document.destroy();
+        return;
+      }
+      engine = document;
+      let widestPage = 0;
+      for (let index = 0; index < document.pageCount; index++) {
+        widestPage = Math.max(widestPage, document.pageSize(index).widthPt * PT_TO_PX);
+      }
+      maxScale = widestPage > 0 ? MAX_SAMPLE_WIDTH / widestPage : Number.POSITIVE_INFINITY;
+      viewer = new DocxScrollViewer(host, {
+        document,
+        gap: 26,
+        overscan: document.pageCount,
+        enableTextSelection: true,
+        pageShadow: 'var(--document-shadow)',
+        background: 'transparent',
+      });
+      enforceWidthCap();
+      observeWidth();
+      status.remove();
+    }).catch((error: unknown) => {
+      if (!destroyed) status.textContent = message(error);
+    });
+  }
+
+  return {
+    activate: () => relayout(),
+    destroy: () => {
+      if (destroyed) return;
+      destroyed = true;
+      resizeObserver?.disconnect();
+      if (frame !== null) cancelAnimationFrame(frame);
+      viewer?.destroy();
+      engine?.destroy();
+      root.replaceChildren();
+    },
+  };
 }
 
 export function mountPptx(root: HTMLElement, url: string): LiveController {
-  root.innerHTML = '';
-  const sc = scroller();
-  const status = statusLine('Parsing…');
-  sc.appendChild(status);
-  root.append(sc);
-  let destroyed = false;
-
-  PptxPresentation.load(url, { useGoogleFonts: true })
-    .then(async (deck) => {
-      if (destroyed) return;
-      status.remove();
-      for (let i = 0; i < deck.slideCount; i++) {
-        if (destroyed) return;
-        const canvas = document.createElement('canvas');
-        canvas.className = 'lv-page';
-        sc.appendChild(canvas);
-        await deck.renderSlide(canvas, i, { width: 1280, dpr: DPR() });
-      }
-    })
-    .catch((e: unknown) => { status.textContent = msg(e); });
-
-  return { destroy: () => { destroyed = true; root.innerHTML = ''; } };
+  return mountPaginated(root, 'pptx', url);
 }
 
 export function mountDocx(root: HTMLElement, url: string): LiveController {
-  root.innerHTML = '';
-  const sc = scroller();
-  const status = statusLine('Parsing…');
-  sc.appendChild(status);
-  root.append(sc);
-  let destroyed = false;
-
-  DocxDocument.load(url, { useGoogleFonts: true })
-    .then(async (doc) => {
-      if (destroyed) return;
-      status.remove();
-      for (let i = 0; i < doc.pageCount; i++) {
-        if (destroyed) return;
-        const canvas = document.createElement('canvas');
-        canvas.className = 'lv-page';
-        sc.appendChild(canvas);
-        await doc.renderPage(canvas, i, { width: 1000, dpr: DPR() });
-      }
-    })
-    .catch((e: unknown) => { status.textContent = msg(e); });
-
-  return { destroy: () => { destroyed = true; root.innerHTML = ''; } };
+  return mountPaginated(root, 'docx', url);
 }
 
 export function mountXlsx(root: HTMLElement, url: string): LiveController {
@@ -82,13 +147,18 @@ export function mountXlsx(root: HTMLElement, url: string): LiveController {
   const viewer = new XlsxViewer(host, {
     useGoogleFonts: true,
     showZoomSlider: true,
-    onError: (err: Error) => { host.setAttribute('data-error', err.message); },
+    onError: (error: Error) => host.setAttribute('data-error', error.message),
   });
-  viewer.load(url).catch(() => { /* surfaced via onError */ });
+  void viewer.load(url).catch(() => { /* surfaced through onError */ });
 
-  return { destroy: () => { root.innerHTML = ''; } };
+  return {
+    destroy: () => {
+      viewer.destroy();
+      root.replaceChildren();
+    },
+  };
 }
 
-function msg(e: unknown): string {
-  return `Failed: ${e instanceof Error ? e.message : String(e)}`;
+function message(error: unknown): string {
+  return `Failed: ${error instanceof Error ? error.message : String(error)}`;
 }

--- a/site/src/lib/try.ts
+++ b/site/src/lib/try.ts
@@ -155,7 +155,7 @@ export async function renderFile(stage: HTMLElement, file: File): Promise<Render
   return { format: 'docx', units: viewer.pageCount, unitLabel: 'page' };
 }
 
-// Hot standby: warm each WASM engine (and the Google Fonts CSS) on an idle tick
+// Hot standby: warm each WASM engine on an idle tick
 // so the user's first real file parses without paying the cold cost of fetching
 // + compiling the parser binaries. Each `renderFile` spawns a fresh inline
 // worker that re-fetches its `*_parser_bg.wasm`; pre-loading the bundled demo of
@@ -174,16 +174,19 @@ export function prewarmEngines(): void {
   const sample = (f: string) => `${base}samples/${f}`.replace(/([^:])\/\/+/g, '$1/');
 
   const run = (): void => {
-    void PptxPresentation.load(sample('sample-1.pptx'), { useGoogleFonts: true })
+    // Fonts are intentionally disabled here. Prewarming should prime only the
+    // parser binaries; downloading fonts used by bundled samples would compete
+    // with (and may be irrelevant to) the user's own file.
+    void PptxPresentation.load(sample('sample-1.pptx'), { useGoogleFonts: false })
       .then((d) => d.destroy())
       .catch(() => {});
-    void DocxDocument.load(sample('sample-1.docx'), { useGoogleFonts: true })
+    void DocxDocument.load(sample('sample-1.docx'), { useGoogleFonts: false })
       .then((d) => d.destroy())
       .catch(() => {});
     // XlsxViewer needs a container; mount into a detached node never added to the
     // DOM, then dispose. The parse + one render warms the xlsx WASM engine.
     const host = document.createElement('div');
-    const v = new XlsxViewer(host, { useGoogleFonts: true });
+    const v = new XlsxViewer(host, { useGoogleFonts: false });
     void v.load(sample('sample-1.xlsx')).then(() => v.destroy()).catch(() => v.destroy());
   };
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -168,8 +168,11 @@ const base = import.meta.env.BASE_URL;
   }
   @media (max-width: 680px) {
     .hero-overline span:first-child { grid-column: 1 / 8; }.hero-overline span:last-child { grid-column: 8 / 13; text-align: right; }
-    .hero-grid { min-height: auto; padding-bottom: 46px; }.hero-copy { grid-column: 1 / 13; }.hero-art { grid-column: 2 / 13; min-height: 390px; margin-top: 20px; }
+    .hero-grid { min-height: auto; padding-bottom: 46px; }.hero-copy { grid-column: 1 / 13; }.hero-art { grid-column: 1 / 13; min-height: 280px; margin-top: 16px; }
+    .hero-icon { width: min(62%, 260px); }
     .hero h1 { font-size: clamp(42px, 12vw, 60px); }.hero-lead, .hero-cta { margin-left: 0; padding-left: 0; }
     .format-rail a { grid-column: span 6; border-bottom: 1px solid var(--hero-line); }.format-rail a:nth-child(2) { border-right: 0; }
+    .format-rail a + a:nth-child(odd) { padding-left: 0; }
+    .format-rail a:nth-child(even) { padding-left: 18px; }
   }
 </style>

--- a/site/src/pages/try.astro
+++ b/site/src/pages/try.astro
@@ -211,7 +211,6 @@ import BrandIcon from '../components/BrandIcon.astro';
     background: radial-gradient(120% 80% at 50% 0%, var(--preview-top), var(--preview-bottom) 70%);
     overflow: hidden;
   }
-  .try-preview[data-format='xlsx'] { border: 0; }
   .try-empty { height: 100%; }
   .try-empty[hidden] { display: none; }
   .try-panel {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -250,6 +250,21 @@ h1, h2, h3 { line-height: 1.08; letter-spacing: -0.035em; margin: 0; }
   color: var(--preview-text);
   padding: 40px 0;
 }
+.lv-progress-circle,
+.demo-progress-circle {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  border: 2px solid color-mix(in srgb, currentColor 28%, transparent);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: preview-progress-spin 0.8s linear infinite;
+}
+@keyframes preview-progress-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .lv-progress-circle,
+  .demo-progress-circle { animation: none; }
+}
 
 /* XLSX viewer manages its own canvas + tab bar; it needs a sized host. */
 .lv-xlsx {
@@ -295,6 +310,7 @@ h1, h2, h3 { line-height: 1.08; letter-spacing: -0.035em; margin: 0; }
   .nav-links a:not(.nav-gh) { display: none; }
   .nav-links { gap: 12px; }
   .theme-label { display: none; }
+  .footer-links { width: 100%; flex-wrap: wrap; gap: 12px 18px; }
 }
 
 /* ── Footer (shared across pages) ────────────────────────────────── */
@@ -332,14 +348,44 @@ h1, h2, h3 { line-height: 1.08; letter-spacing: -0.035em; margin: 0; }
 .demo-btn:hover:not(:disabled) { border-color: var(--accent); }
 .demo-btn:disabled { opacity: 0.35; cursor: default; }
 .demo-info { font-family: var(--mono); font-size: 13px; color: var(--text-dim); }
-.demo-status { font-family: var(--mono); font-size: 13px; color: var(--preview-text); padding: 36px; text-align: center; }
+.demo-status {
+  width: 100%;
+  min-height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--preview-text);
+  padding: 36px;
+  text-align: center;
+}
+.demo-detail .demo-status { min-height: 100%; }
 
 /* single-viewer demo */
 /* Block (not flex) scroll container + text-align centres the viewer's
  * inline-block wrapper, and keeps the top/bottom padding symmetric — a flex
  * scroll container drops the padding-bottom from the scroll area. */
-.demo-stage { padding: 22px; max-height: 560px; overflow: auto; text-align: center; }
+.demo-stage { position: relative; min-height: 344px; padding: 22px; max-height: 560px; overflow: auto; text-align: center; }
+.demo-stage > .demo-status { position: absolute; inset: 0; min-height: 0; }
+.demo-stage > [hidden], .demo-detail > [hidden] { display: none !important; }
 .demo-stage .demo-page { width: 100%; max-width: 760px; height: auto; }
+/* DocxViewer/PptxViewer wrap the caller's canvas in an inline-block so text and
+ * find overlays can share its coordinate space. Constrain that wrapper too: a
+ * 960px render bitmap may stay crisp while its CSS box fits a narrow preview. */
+.demo-stage > div:not(.demo-status) {
+  width: min(100%, 760px);
+  max-width: 100%;
+  min-width: 0;
+  margin-inline: auto;
+}
+.demo-detail > div:not(.demo-status) {
+  width: min(100%, 960px);
+  max-width: 100%;
+  min-width: 0;
+  margin-inline: auto;
+}
 
 /* scroll demo */
 .demo-scroll {
@@ -363,6 +409,13 @@ h1, h2, h3 { line-height: 1.08; letter-spacing: -0.035em; margin: 0; }
 .demo-rail-cell.active { outline-color: var(--accent); }
 .demo-detail { flex: 1 1 auto; overflow: auto; padding: 22px; display: flex; justify-content: center; align-items: flex-start; }
 .demo-detail .demo-page { width: 100%; max-width: 960px; height: auto; }
+
+@media (max-width: 620px) {
+  .demo-stage, .demo-scroll, .demo-grid { padding: 12px; }
+  .demo-md { height: 460px; }
+  .demo-rail { flex-basis: 92px; padding: 8px; gap: 8px; }
+  .demo-detail { min-width: 0; padding: 10px; }
+}
 
 /* xlsx full viewer */
 .demo-xlsx { width: 100%; height: 560px; background: #fff; }

--- a/site/src/try-loading.test.ts
+++ b/site/src/try-loading.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const source = readFileSync(new URL('./pages/try.astro', import.meta.url), 'utf8');
+const renderer = readFileSync(new URL('./lib/try.ts', import.meta.url), 'utf8');
 
 describe('Try Yours parsing progress', () => {
   it('uses concise, functional copy for the file workflow', () => {
@@ -28,5 +29,15 @@ describe('Try Yours parsing progress', () => {
 
   it('hides the progress UI on both the current render success and failure paths', () => {
     expect(source.match(/stageProgress\.hidden = true;/g)).toHaveLength(2);
+  });
+
+  it('keeps the preview frame for XLSX as well as DOCX and PPTX', () => {
+    expect(source).not.toContain(".try-preview[data-format='xlsx'] { border: 0; }");
+  });
+
+  it('prewarms parser engines without downloading fonts for bundled samples', () => {
+    const prewarm = renderer.slice(renderer.indexOf('export function prewarmEngines'));
+    expect(prewarm).not.toContain('useGoogleFonts: true');
+    expect(prewarm.match(/useGoogleFonts:\s*false/g)).toHaveLength(3);
   });
 });


### PR DESCRIPTION
## Summary
- keep the Try Yours preview frame consistent for DOCX, XLSX, and PPTX
- preload and cache the three home-page sample viewers, with selectable DOCX/PPTX text layers
- use the full preview surface as the scroll viewport while responsively capping document content
- avoid unrelated sample-font downloads during Try Yours parser prewarming
- replace premature detail-demo canvases with centered parsing progress
- correct mobile hero, format-link, and preview sizing

## Verification
- site Vitest suite: 62 tests passed
- TypeScript project build passed
- Astro production build passed
- responsive browser checks at 390px and 1440px

This is a site-only change and does not require a package release.