### PR TITLE
fix(pptx): honor authored chart and text layout

### DIFF
--- a/packages/core/src/chart/layout.test.ts
+++ b/packages/core/src/chart/layout.test.ts
@@ -215,7 +215,7 @@ describe('computeChartFrame — cartesian', () => {
     });
   });
 
-  it('keeps an inner manual-layout data region within the measured outer gutters', () => {
+  it('uses an inner manual-layout data region verbatim instead of applying auto-layout gutters', () => {
     const chart = model({
       plotAreaManualLayout: {
         layoutTarget: 'inner',
@@ -234,10 +234,15 @@ describe('computeChartFrame — cartesian', () => {
       pad: { t: 20, r: 10, b: 30, l: 40 },
       honorPlotAreaManualLayout: true,
     });
-    expect(frame.plotRect.px0).toBe(X + 40);
-    expect(frame.plotRect.py0).toBe(Y + 20);
-    expect(frame.plotRect.pw).toBeCloseTo(X + 0.81 * W - (X + 40));
-    expect(frame.plotRect.ph).toBeCloseTo(Y + 0.82 * H - (Y + 20));
+    // ECMA-376 §21.2.2.89: layoutTarget="inner" means that the authored
+    // rectangle IS the plot area excluding axes and labels. Auto-layout pads
+    // describe a different layout mode and must not move any of its edges.
+    expect(frame.plotRect).toEqual({
+      px0: X + 0.01 * W,
+      py0: Y + 0.02 * H,
+      pw: 0.8 * W,
+      ph: 0.8 * H,
+    });
   });
 
   it('ignores plotArea manual layout when the flag is off', () => {

--- a/packages/core/src/chart/layout.ts
+++ b/packages/core/src/chart/layout.ts
@@ -387,26 +387,16 @@ export function computeChartFrame(
     if (pml && pml.w != null && pml.h != null) {
       const manualLeft = x + pml.x * w;
       const manualTop = y + pml.y * h;
-      const manualRight = manualLeft + pml.w * w;
-      const manualBottom = manualTop + pml.h * h;
-      if (pml.layoutTarget === 'inner') {
-        // ECMA-376 §21.2.2.89: an "inner" manual layout describes only the
-        // data region, excluding axes and labels. Browser font metrics can
-        // require slightly more gutter than the producer reserved, so keep
-        // that outer content inside the chart frame without moving the
-        // declared plot's right/bottom edges.
-        px0 = Math.max(manualLeft, x + pad.l);
-        py0 = Math.max(manualTop, y + pad.t);
-        const right = Math.min(manualRight, x + w - pad.r);
-        const bottom = Math.min(manualBottom, y + h - pad.b);
-        pw = Math.max(0, right - px0);
-        ph = Math.max(0, bottom - py0);
-      } else {
-        px0 = manualLeft;
-        py0 = manualTop;
-        pw = pml.w * w;
-        ph = pml.h * h;
-      }
+      // ECMA-376 §21.2.2.89: layoutTarget="inner" means the authored
+      // rectangle is the plot area excluding axes and labels; "outer" includes
+      // them. In either case the manual rectangle is authoritative. The
+      // auto-layout pads describe a different layout mode and must not clamp
+      // or move an explicitly authored edge. Clamping an inner rectangle can
+      // shift stacked bars away from separately authored overlay labels.
+      px0 = manualLeft;
+      py0 = manualTop;
+      pw = pml.w * w;
+      ph = pml.h * h;
     } else {
       px0 = x + pad.l;
       py0 = y + pad.t;

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -431,7 +431,7 @@ describe('CH7 â€” percentStacked normalizes signed values against per-category Î
     }
   });
 
-  it('keeps explicit-size value-axis labels inside an inner manual-layout chart frame', () => {
+  it('keeps explicit-size value-axis labels inside a correctly authored inner manual-layout frame', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({
       chartType: 'stackedBarPct',
@@ -444,13 +444,13 @@ describe('CH7 â€” percentStacked normalizes signed values against per-category Î
       valAxisFormatCode: '0%',
       valAxisFontSizeHpt: 1100,
       // ECMA-376 Â§21.2.2.89: an inner target describes the data region,
-      // excluding axes and labels. Those labels must still remain inside the
-      // chart frame when their actual DrawingML font metrics need more room.
+      // excluding axes and labels. The producer therefore reserves the label
+      // gutter in the authored x offset rather than relying on auto-layout.
       plotAreaManualLayout: {
         layoutTarget: 'inner',
         xMode: 'edge',
         yMode: 'edge',
-        x: 0.055,
+        x: 0.184,
         y: 0.046,
         w: 0.728,
         h: 0.784,

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -5007,6 +5007,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
                 ShapeKind::Sp,
                 &mut zip,
             );
@@ -5651,6 +5652,7 @@ mod tests {
                 None, // inherited_italic
                 None, // inherited_caps
                 None, // inherited_anchor
+                None, // inherited_text_insets
                 None, // inherited_alignment
                 None, // inherited_ea_ln_brk
                 None, // inherited_space_before
@@ -5717,6 +5719,7 @@ mod tests {
                 [None; 9],
                 Default::default(),
                 &empty_level_bullets(),
+                None,
                 None,
                 None,
                 None,
@@ -5808,6 +5811,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
                 ShapeKind::Sp,
                 &mut zip,
             );
@@ -5885,6 +5889,7 @@ mod tests {
                 [None; 9],
                 Default::default(),
                 &empty_level_bullets(),
+                None,
                 None,
                 None,
                 None,

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -69,6 +69,12 @@ pub(crate) struct LayoutPlaceholders {
     pub(crate) by_type_caps: HashMap<String, String>,
     /// Vertical anchor ("t"/"ctr"/"b") per placeholder type, from layout/master bodyPr
     pub(crate) by_type_anchor: HashMap<String, String>,
+    /// Per-placeholder layout `bodyPr` text insets (`lIns`, `tIns`, `rIns`,
+    /// `bIns`). Each component stays optional so an omitted layout attribute
+    /// can continue through the theme/spec fallback instead of being replaced
+    /// by a synthetic layout default.
+    pub(crate) by_idx_text_insets: HashMap<u32, [Option<i64>; 4]>,
+    pub(crate) by_type_text_insets: HashMap<String, [Option<i64>; 4]>,
     /// Default paragraph alignment per placeholder type, from layout/master lstStyle
     pub(crate) by_type_alignment: HashMap<String, String>,
     /// Paragraph alignment per placeholder idx — layout placeholder's own algn,
@@ -346,6 +352,25 @@ impl LayoutPlaceholders {
         self.by_type_anchor.get(ph_type).cloned().or_else(|| {
             if ph_type == "body" {
                 self.by_type_anchor.get("").cloned()
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Look up layout placeholder text insets. An explicit idx is strict so a
+    /// body placeholder cannot borrow another body slot's margins.
+    pub(crate) fn lookup_text_insets(
+        &self,
+        ph_type: &str,
+        ph_idx: Option<u32>,
+    ) -> Option<[Option<i64>; 4]> {
+        if let Some(i) = ph_idx {
+            return self.by_idx_text_insets.get(&i).copied();
+        }
+        self.by_type_text_insets.get(ph_type).copied().or_else(|| {
+            if ph_type == "body" {
+                self.by_type_text_insets.get("").copied()
             } else {
                 None
             }
@@ -1242,11 +1267,18 @@ pub(crate) fn parse_layout_placeholders(
             .and_then(|ls| child(ls, "spcPct"))
             .and_then(|s| attr_f64(&s, "val"));
 
-        // Layout bodyPr anchor; fall back to master anchor map
-        let layout_anchor: Option<String> = child(sp, "txBody")
-            .and_then(|tb| child(tb, "bodyPr"))
+        let layout_body_pr = child(sp, "txBody").and_then(|tb| child(tb, "bodyPr"));
+        // Layout bodyPr anchor; fall back to master anchor map.
+        let layout_anchor: Option<String> = layout_body_pr
             .and_then(|bp| attr(&bp, "anchor"))
             .map(|a| a.to_string());
+        let layout_text_insets: [Option<i64>; 4] = [
+            layout_body_pr.and_then(|bp| attr_i64(&bp, "lIns")),
+            layout_body_pr.and_then(|bp| attr_i64(&bp, "tIns")),
+            layout_body_pr.and_then(|bp| attr_i64(&bp, "rIns")),
+            layout_body_pr.and_then(|bp| attr_i64(&bp, "bIns")),
+        ];
+        let has_layout_text_inset = layout_text_insets.iter().any(Option::is_some);
 
         // Layout spPr > ln stroke (real visible border, not edit-mode indicator when solidFill is present)
         let layout_stroke: Option<Stroke> = child(sp_pr, "ln").and_then(|n| parse_stroke(n, theme));
@@ -1332,6 +1364,11 @@ pub(crate) fn parse_layout_placeholders(
                 if let Some(ls) = layout_line_spacing {
                     lph.by_idx_line_spacing.entry(idx).or_insert(ls);
                 }
+                if has_layout_text_inset {
+                    lph.by_idx_text_insets
+                        .entry(idx)
+                        .or_insert(layout_text_insets);
+                }
                 if let Some(ref bf) = layout_blip_fill {
                     lph.by_idx_blip_fill.entry(idx).or_insert(bf.clone());
                 }
@@ -1415,6 +1452,11 @@ pub(crate) fn parse_layout_placeholders(
                 lph.by_type_line_spacing
                     .entry(ph_type.clone())
                     .or_insert(ls);
+            }
+            if has_layout_text_inset {
+                lph.by_type_text_insets
+                    .entry(ph_type.clone())
+                    .or_insert(layout_text_insets);
             }
             // Anchor: layout bodyPr > fall back to master anchor map
             let effective_anchor = layout_anchor
@@ -1848,6 +1890,44 @@ mod placeholder_geometry_tests {
             &mut zip,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn slide_placeholder_inherits_layout_body_properties() {
+        let layout = r#"
+          <p:sp>
+            <p:nvSpPr><p:cNvPr id="2" name="Title"/><p:cNvSpPr/>
+              <p:nvPr><p:ph type="title"/></p:nvPr>
+            </p:nvSpPr>
+            <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="12192000" cy="500000"/></a:xfrm></p:spPr>
+            <p:txBody>
+              <a:bodyPr lIns="216000" tIns="72000" rIns="216000" bIns="72000" anchor="ctr"/>
+              <a:lstStyle/><a:p/>
+            </p:txBody>
+          </p:sp>"#;
+        let placeholders = parse_layout_geometry(layout);
+        let slide = r#"
+          <p:nvSpPr><p:cNvPr id="2" name="Title"/><p:cNvSpPr/>
+            <p:nvPr><p:ph type="title"/></p:nvPr>
+          </p:nvSpPr>
+          <p:spPr/>
+          <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Title</a:t></a:r></a:p></p:txBody>"#;
+
+        let shape = parse_slide_shape(slide, &placeholders);
+        let body = shape.text_body.expect("placeholder text body");
+        assert_eq!(body.l_ins, 216_000);
+        assert_eq!(body.t_ins, 72_000);
+        assert_eq!(body.r_ins, 216_000);
+        assert_eq!(body.b_ins, 72_000);
+        assert_eq!(body.vertical_anchor, "ctr");
+
+        let local_left_override = slide.replace("<a:bodyPr/>", "<a:bodyPr lIns=\"0\"/>");
+        let shape = parse_slide_shape(&local_left_override, &placeholders);
+        let body = shape.text_body.expect("placeholder text body");
+        assert_eq!(body.l_ins, 0);
+        assert_eq!(body.t_ins, 72_000);
+        assert_eq!(body.r_ins, 216_000);
+        assert_eq!(body.b_ins, 72_000);
     }
 
     const LAYOUT_ELLIPSE: &str = r#"

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -403,6 +403,7 @@ pub(crate) fn parse_shape(
         inherited_italic,
         inherited_caps,
         inherited_anchor,
+        inherited_text_insets,
         inherited_alignment,
         inherited_ea_ln_brk,
         inherited_space_before,
@@ -415,6 +416,7 @@ pub(crate) fn parse_shape(
             lph.lookup_italic(&ph_type),
             lph.lookup_caps(&ph_type),
             lph.lookup_anchor(&ph_type),
+            lph.lookup_text_insets(&ph_type, ph_idx),
             lph.lookup_alignment(&ph_type, ph_idx),
             lph.lookup_ea_ln_brk(&ph_type),
             lph.lookup_space_before(&ph_type),
@@ -422,7 +424,9 @@ pub(crate) fn parse_shape(
             lph.lookup_line_spacing(&ph_type, ph_idx),
         )
     } else {
-        (None, None, None, None, None, None, None, None, None, None)
+        (
+            None, None, None, None, None, None, None, None, None, None, None,
+        )
     };
     let inherited_level_font_sizes: LevelFontSizes = if ph_node.is_some() {
         lph.lookup_level_font_sizes(&ph_type, ph_idx)
@@ -471,6 +475,7 @@ pub(crate) fn parse_shape(
             inherited_italic,
             inherited_caps.clone(),
             inherited_anchor,
+            inherited_text_insets,
             inherited_alignment,
             inherited_ea_ln_brk,
             inherited_space_before,
@@ -1406,6 +1411,7 @@ pub(crate) fn parse_table_cell(
             None,
             None,
             anchor,
+            None, // inherited_text_insets
             None, // inherited_alignment
             None, // inherited_ea_ln_brk
             None, // inherited_space_before

--- a/packages/pptx/parser/src/smartart_fallback.rs
+++ b/packages/pptx/parser/src/smartart_fallback.rs
@@ -318,6 +318,7 @@ fn append_point_paragraphs(
         None,
         None,
         None,
+        None,
         ShapeKind::Sp,
         zip,
     );

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -378,6 +378,7 @@ pub(crate) fn parse_text_body(
     inherited_italic: Option<bool>,
     inherited_caps: Option<String>,
     inherited_anchor: Option<String>,
+    inherited_text_insets: Option<[Option<i64>; 4]>,
     inherited_alignment: Option<String>,
     inherited_ea_ln_brk: Option<bool>,
     inherited_space_before: Option<i64>,
@@ -422,16 +423,25 @@ pub(crate) fn parse_text_body(
     // (auto_fit default below); a normAutofit also captures PowerPoint's stored
     // fontScale / lnSpcReduction (ECMA-376 §21.1.2.1.3, 62500 → 0.625).
     let spec = ooxml_common::text::BodyPrDefaults::spec();
+    let inherited_text_insets = inherited_text_insets.unwrap_or([None; 4]);
     let body_pr_defaults = ooxml_common::text::BodyPrDefaults {
         anchor: inherited_anchor
             .or_else(|| theme_default_str("anchor"))
             .unwrap_or(spec.anchor),
         wrap: theme_default_str("wrap").unwrap_or(spec.wrap),
         vert: theme_default_str("vert").unwrap_or(spec.vert),
-        l_ins: theme_default_i64("lIns").unwrap_or(spec.l_ins),
-        t_ins: theme_default_i64("tIns").unwrap_or(spec.t_ins),
-        r_ins: theme_default_i64("rIns").unwrap_or(spec.r_ins),
-        b_ins: theme_default_i64("bIns").unwrap_or(spec.b_ins),
+        l_ins: inherited_text_insets[0]
+            .or_else(|| theme_default_i64("lIns"))
+            .unwrap_or(spec.l_ins),
+        t_ins: inherited_text_insets[1]
+            .or_else(|| theme_default_i64("tIns"))
+            .unwrap_or(spec.t_ins),
+        r_ins: inherited_text_insets[2]
+            .or_else(|| theme_default_i64("rIns"))
+            .unwrap_or(spec.r_ins),
+        b_ins: inherited_text_insets[3]
+            .or_else(|| theme_default_i64("bIns"))
+            .unwrap_or(spec.b_ins),
         auto_fit: theme_auto_fit().unwrap_or(spec.auto_fit),
     };
     let body = match body_pr {

--- a/packages/pptx/src/multi-column-overflow.test.ts
+++ b/packages/pptx/src/multi-column-overflow.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { TextRunData } from '@silurus/ooxml-core';
+import { renderTextBody } from './renderer.js';
+import type { Paragraph, TextBody } from './types';
+
+// Two same-sized numCol="2" round-rect text bodies exercise the boundary: the
+// short one contains a heading + three bullets and fits in column 1 once the
+// final paragraph's trailing spcAft is excluded from the overflow test; the
+// long one genuinely overflows and uses both columns.
+//
+// ECMA-376 §21.1.2.1.1 bodyPr@numCol defines columns as overflow containers:
+// content only advances after the preceding column is filled. A trailing
+// paragraph gap has no following content, so it cannot itself fill the column.
+
+const SCALE = 1 / 9525; // 1280px / 12192000 EMU
+const FONT_PT = 14;
+
+function recordingCtx(): {
+  ctx: CanvasRenderingContext2D;
+  texts: Array<{ text: string; x: number; y: number }>;
+} {
+  const texts: Array<{ text: string; x: number; y: number }> = [];
+  let fillStyle = '';
+  let font = '';
+  let direction: CanvasDirection = 'ltr';
+  const ctx = {
+    get fillStyle() { return fillStyle; },
+    set fillStyle(v: string) { fillStyle = v; },
+    get font() { return font; },
+    set font(v: string) { font = v; },
+    get direction() { return direction; },
+    set direction(v: CanvasDirection) { direction = v; },
+    measureText: (text: string) => ({
+      width: [...text].length * FONT_PT * 1.2,
+      actualBoundingBoxAscent: 14,
+      actualBoundingBoxDescent: 4,
+    }),
+    fillText: (text: string, x: number, y: number) => texts.push({ text, x, y }),
+    fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
+    translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
+    moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, texts };
+}
+
+function run(text: string): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: FONT_PT, color: '000000', fontFamily: 'Arial',
+  };
+}
+
+function paragraph(text: string): Paragraph {
+  return {
+    alignment: 'l', marL: 0, marR: 0, indent: 0,
+    spaceBefore: null, spaceAfter: 300,
+    spaceLine: { type: 'pct', val: 120000 }, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null,
+    defBold: null, defItalic: null, defFontFamily: null, tabStops: [],
+    eaLnBrk: true, runs: [run(text)],
+  } as Paragraph;
+}
+
+function body(texts: string[]): TextBody {
+  return {
+    verticalAnchor: 't', paragraphs: texts.map(paragraph), defaultFontSize: FONT_PT,
+    defaultBold: null, defaultItalic: null,
+    lIns: 108000, rIns: 108000, tIns: 108000, bIns: 108000,
+    wrap: 'square', vert: 'horz', autoFit: 'none', numCol: 2, spcCol: 0,
+  } as TextBody;
+}
+
+describe('pptx DrawingML multi-column overflow', () => {
+  it('keeps four fitting paragraphs in the first column when only trailing spcAft crosses the boundary', () => {
+    const { ctx, texts } = recordingCtx();
+    // The roundRect preset text rectangle is about 142.64px tall after its
+    // corner inset (full shape: 149.24px).
+    renderTextBody(ctx, body(['heading', 'age', 'gender', 'home']), 0, 0, 290, 142.64, SCALE);
+
+    const content = texts.filter(({ text }) => text !== '•');
+    expect(content.map(({ text }) => text)).toEqual(['heading', 'age', 'gender', 'home']);
+    expect(new Set(content.map(({ x }) => x)).size).toBe(1);
+  });
+
+  it('still uses both columns when the content itself exceeds one column', () => {
+    const { ctx, texts } = recordingCtx();
+    renderTextBody(ctx, body(['heading', 'age', 'gender', 'home', '', 'history', 'values', 'details']), 0, 0, 290, 142.64, SCALE);
+
+    const xs = new Set(texts.filter(({ text }) => text).map(({ x }) => x));
+    expect(xs.size).toBe(2);
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -3416,7 +3416,19 @@ export function renderTextBody(
   const colHeightCapacity = Math.max(0, effectiveBh - tPad - bPad);
   // When `bh === 0` (caller relies on auto-height) the capacity is unbounded
   // and content always fits, so a multi-col directive collapses to single col.
-  const fitsInOneCol = bh === 0 || totalHeight <= colHeightCapacity + 0.5;
+  // `spcAft` is spacing AFTER a paragraph. On the final line there is no
+  // following content, so that trailing gap cannot by itself fill the column
+  // and force otherwise-fitting text into the next overflow container
+  // (ECMA-376 §21.1.2.1.1 bodyPr@numCol). Keep it for drawing/anchoring, but
+  // exclude it from the one-column overflow decision. A common boundary case
+  // is a heading plus three short bullets whose final 3pt spcAft alone crosses
+  // a rounded-rectangle text-rect capacity.
+  const lastEntry = allLines[allLines.length - 1];
+  const trailingSpaceAfter = lastEntry
+    ? Math.max(0, lastEntry.linePx - lastEntry.lineHeight)
+    : 0;
+  const occupiedHeight = totalHeight - trailingSpaceAfter;
+  const fitsInOneCol = bh === 0 || occupiedHeight <= colHeightCapacity + 0.5;
   const useMultiCol = numCol > 1 && !fitsInOneCol;
   const linesPerCol = useMultiCol ? Math.ceil(allLines.length / numCol) : allLines.length;
   let colIdx = 0;


### PR DESCRIPTION
## Summary

- honor explicit chart plot-area rectangles without auto-layout clamping
- preserve layout-placeholder text insets on slide placeholders
- keep short multi-column text in the first column when only terminal paragraph spacing crosses the boundary

## Specification

- ECMA-376 Part 1 §21.2.2.89 (layoutTarget)
- ECMA-376 Part 1 §21.1.2.1.1 (bodyPr columns and insets)
- ECMA-376 Part 1 Annex L.3.2.3 (presentation-slide inheritance)

## Verification

- cargo test -p pptx-parser
- focused chart and multi-column Vitest regressions (174 tests)
- full Vitest suite (6,354 passed; 28 skipped)
- TypeScript project build
- local-only comparison against PowerPoint PDF output