### PR TITLE
fix(chart): scale bars with hidden value axes

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -733,17 +733,17 @@ set textBaseline=middle
 set font=11px sans-serif
 set fillStyle=#555
 set fillStyle=#4472C4
-fillRect 31.2,292.8367,143.2381,45.6933 fs=#4472C4
+fillRect 31.2,292.8367,120.32,45.6933 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 174.4381,292.8367,114.5905,45.6933 fs=#ED7D31
+fillRect 151.52,292.8367,96.256,45.6933 fs=#ED7D31
 set fillStyle=#4472C4
-fillRect 31.2,178.6033,343.7714,45.6933 fs=#4472C4
+fillRect 31.2,178.6033,288.768,45.6933 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 374.9714,178.6033,214.8571,45.6933 fs=#ED7D31
+fillRect 319.968,178.6033,180.48,45.6933 fs=#ED7D31
 set fillStyle=#4472C4
-fillRect 31.2,64.37,243.5048,45.6933 fs=#4472C4
+fillRect 31.2,64.37,204.544,45.6933 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 274.7048,64.37,315.1238,45.6933 fs=#ED7D31
+fillRect 235.744,64.37,264.704,45.6933 fs=#ED7D31
 restore"
 `;
 

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -190,6 +190,37 @@ describe('CH1 — negative bar/column values extend from the zero line', () => {
     expect(neg.w).toBeCloseTo(pos.w, 4);
   });
 
+  it('a deleted value axis uses the default automatic scale instead of visible-tick density', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBarH',
+      categories: ['A'],
+      series: [
+        series({ name: 'S1', values: [20] }),
+        series({ name: 'S2', values: [77] }),
+      ],
+      valAxisHidden: true,
+      plotAreaManualLayout: {
+        layoutTarget: 'inner',
+        xMode: 'edge',
+        yMode: 'edge',
+        x: 0.1,
+        y: 0.1,
+        w: 0.8,
+        h: 0.8,
+      },
+    }), RECT, 1);
+
+    // With no visible value-axis ticks, Office uses the default five-interval
+    // auto-scale target: data max 97 → major unit 20 → axis max 120. Applying
+    // the wide-axis tick-density rule would instead choose unit 10 / max 110,
+    // making the stacked bar too long relative to separately authored labels.
+    const bars = rec.rects;
+    expect(bars).toHaveLength(2);
+    const totalLength = bars[0].w + bars[1].w;
+    expect(totalLength).toBeCloseTo(RECT.w * 0.8 * (97 / 120), 4);
+  });
+
   it('positive-only data keeps the axis anchored at 0 (pre-fix behavior)', () => {
     // Regression guard: min degenerates to 0 so nothing about a positive-only
     // chart changes. Zero-line bottom edge == plot bottom.

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1201,7 +1201,12 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const pwEst = isH
     ? w - ((chart.catAxisHidden ? w * 0.03 : w * 0.22) + valTitleW + legLeftW) - (legRightW + w * 0.03)
     : 0;
-  const valAxisLenPt = (isH ? pwEst : phEst) / ptToPx;
+  // A deleted value axis has no ticks whose density needs adapting to the
+  // available screen length. Office falls back to its default automatic scale
+  // target in that case. Feeding the plot length into the visible-tick planner
+  // over-refines the major unit and stretches bars relative to slide-authored
+  // overlay labels.
+  const valAxisLenPt = chart.valAxisHidden ? undefined : (isH ? pwEst : phEst) / ptToPx;
 
   // Value-axis extent. Bars extend from the zero line (the category-axis
   // crossing) toward each value, so the axis must span both the positive and


### PR DESCRIPTION
## Summary
- exclude deleted value axes from visible-tick density planning
- use the default automatic scale target when no value-axis ticks are rendered
- add a stacked horizontal-bar regression and update its draw signature

## Rationale
Office automatic major-unit selection is not specified by ECMA-376. Observed PowerPoint behavior uses the default scale target for a deleted value axis; adapting to plot length over-refines the maximum and stretches bars relative to separately authored annotations.

## Verification
- `./node_modules/.bin/vitest run` (6,367 passed)
- `./node_modules/.bin/tsc --build --pretty false`
- `git diff --check`
- local-only browser and PDF comparison