### PR TITLE
fix(fuzz): keep ZIP extraction target buildable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,16 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # The cargo-fuzz harness is an intentionally independent workspace, so
+      # the root workspace checks above do not format, lint, or compile it.
+      - name: Fuzz target format check
+        run: cargo fmt --manifest-path fuzz/Cargo.toml -- --check
+
+      # Keep every target buildable and its separate lockfile synchronized on
+      # ordinary PRs, before the long scheduled fuzz run discovers API drift.
+      - name: Fuzz target clippy
+        run: cargo clippy --manifest-path fuzz/Cargo.toml --bins --locked -- -D warnings
+
       - name: Test
         run: cargo test --workspace
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -94,6 +94,7 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "ooxml-common",
+ "quick-xml",
  "roxmltree",
  "serde",
  "serde_json",
@@ -215,8 +216,12 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 name = "ooxml-common"
 version = "0.1.0"
 dependencies = [
+ "crc32fast",
+ "flate2",
+ "quick-xml",
  "roxmltree",
  "serde",
+ "serde_json",
  "zip",
 ]
 
@@ -251,6 +256,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -438,6 +452,7 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "ooxml-common",
+ "quick-xml",
  "roxmltree",
  "serde",
  "serde_json",

--- a/fuzz/fuzz_targets/fuzz_zip_handle.rs
+++ b/fuzz/fuzz_targets/fuzz_zip_handle.rs
@@ -1,23 +1,36 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+use ooxml_common::resource::OoxmlFormat;
 
-// Exercises the shared zip-part-open path used by every parser
-// (`ooxml_common::zip::extract_zip_entry`): open a raw byte blob as a zip
-// archive and read one entry by name. This covers the zip-bomb size guard
-// (`scoped_max` / `current_max`) and the central-directory parsing that
-// docx/pptx/xlsx all funnel through, without going through a full document
-// parse. `data` is split into a path string (first line, up to the first
-// newline) and the remaining bytes are the candidate zip archive, so the
-// fuzzer can co-evolve plausible part names (e.g. "word/document.xml")
-// alongside the archive bytes instead of only ever missing by name.
+// Exercises the XLSX free extraction facade's shared validated ZIP reader and
+// resource governor. DOCX, XLSX, and PPTX session paths are covered by their
+// full-parser targets. Raw ZIP inputs (such as the scheduled XLSX seed) use a
+// stable workbook part name and remain intact. Other inputs with a newline use
+// the prefix as a co-evolving part name and the suffix as the candidate archive.
 fuzz_target!(|data: &[u8]| {
-    let split_at = data.iter().position(|&b| b == b'\n').unwrap_or(0);
-    let (path_bytes, rest) = data.split_at(split_at);
-    let zip_bytes = if rest.is_empty() { rest } else { &rest[1..] };
-    let path = String::from_utf8_lossy(path_bytes);
-    let _ = ooxml_common::zip::extract_zip_entry(zip_bytes, &path, None);
-    // Also fuzz the "already declared a tighter cap" path, which is the one
-    // real callers actually hit (max_zip_entry_bytes override from JS).
-    let _ = ooxml_common::zip::extract_zip_entry(zip_bytes, &path, Some(4096));
+    let (path, zip_bytes) = if data.starts_with(b"PK") {
+        ("xl/workbook.xml".into(), data)
+    } else {
+        match data.iter().position(|&byte| byte == b'\n') {
+            Some(split_at) => {
+                let (path_bytes, rest) = data.split_at(split_at);
+                (String::from_utf8_lossy(path_bytes), &rest[1..])
+            }
+            None => ("xl/workbook.xml".into(), data),
+        }
+    };
+
+    // Exercise defaults and each public limit independently. A total limit can
+    // bind before the entry limit for this single-entry operation.
+    for (max_entry_bytes, max_total_bytes) in [(None, None), (Some(4096), None), (None, Some(2048))]
+    {
+        let _ = ooxml_common::zip::extract_zip_entry(
+            zip_bytes,
+            &path,
+            OoxmlFormat::Xlsx,
+            max_entry_bytes,
+            max_total_bytes,
+        );
+    }
 });


### PR DESCRIPTION
## Summary

- update the shared ZIP extraction fuzz target for the resource-governed API
- preserve raw OOXML seed archives and exercise default, per-entry, and aggregate limits
- add format and locked Clippy gates for the independent fuzz workspace in ordinary CI
- synchronize the independent fuzz lockfile

This is a harness/CI correction only. It does not change OOXML parsing semantics or introduce format-specific compatibility behavior. The target follows the existing shared package/resource interface, while the three full-parser targets retain DOCX/XLSX/PPTX coverage.

## Verification

- cargo fmt for the fuzz workspace
- locked cargo clippy and cargo check for all fuzz targets
- cargo test --workspace
- 60-second fuzz_zip_handle campaign with the public XLSX fixture: 109,812 executions, no findings
- two independent architecture reviews, followed by independent remediation re-reviews with no remaining findings