### PR TITLE
fix(docx): preserve signed at-least empty mark spacing

### DIFF
--- a/packages/docx/src/layout/compatibility.test.ts
+++ b/packages/docx/src/layout/compatibility.test.ts
@@ -63,6 +63,7 @@ import {
   wordFarEastSingleLinePx,
   wordFirstJustifiedContentSegment,
   wordGridAtLeastLineHeightPx,
+  wordUseFeLayoutParagraphMarkGridAdvancePx,
   wordUseFeLayoutInheritedGridHeightPx,
   wordCandidateFitWidthPx,
   wordJustifiedCandidateFitAllowancePx,
@@ -565,6 +566,27 @@ describe('layout compatibility inventory', () => {
     expect(wordPageLevelAnchorY(null, false)).toBe(true);
     expect(wordPageLevelAnchorY(undefined, true)).toBe(false);
     expect(wordGridAtLeastLineHeightPx(28, 18, 18)).toBe(28);
+    const markGridAdvance = (
+      lineSpacing: Parameters<typeof wordUseFeLayoutParagraphMarkGridAdvancePx>[0]['lineSpacing'],
+      gridAllocationActive = true,
+      scale = 1,
+    ): number => wordUseFeLayoutParagraphMarkGridAdvancePx({
+      ordinaryAdvancePx: 16,
+      allocatedGridAdvancePx: 30,
+      atLeastZeroAdvancePx: 18,
+      lineSpacing,
+      gridAllocationActive,
+      scale,
+    });
+    expect(markGridAdvance(null)).toBe(30);
+    expect(markGridAdvance({ rule: 'atLeast', value: 18, explicit: true })).toBe(30);
+    expect(markGridAdvance({ rule: 'atLeast', value: 0, explicit: false })).toBe(18);
+    expect(markGridAdvance({ rule: 'atLeast', value: -1, explicit: true })).toBe(1);
+    expect(markGridAdvance({ rule: 'atLeast', value: -18, explicit: true })).toBe(18);
+    expect(markGridAdvance({ rule: 'atLeast', value: -1, explicit: true }, true, 2)).toBe(2);
+    expect(markGridAdvance({ rule: 'atLeast', value: 0, explicit: true })).toBe(18);
+    expect(markGridAdvance({ rule: 'exact', value: 18, explicit: true })).toBe(16);
+    expect(markGridAdvance({ rule: 'atLeast', value: -1, explicit: true }, false)).toBe(16);
     expect(wordDegenerateLineSpacingIsSingle('exact', 0)).toBe(true);
     expect(wordDegenerateLineSpacingIsSingle('atLeast', 0)).toBe(false);
     expect(wordAutoMultipleCenterBoxPx(true, false, 10, 12, 24)).toBe(12);

--- a/packages/docx/src/layout/line-compatibility.ts
+++ b/packages/docx/src/layout/line-compatibility.ts
@@ -1,4 +1,5 @@
 import { defineCompatibilityRule } from './compatibility.js';
+import type { LineSpacing } from '../types.js';
 
 export const WORD_EAST_ASIAN_GRID_LINE_ALLOCATION = defineCompatibilityRule({
   id: 'word-east-asian-grid-line-allocation',
@@ -30,19 +31,40 @@ export const WORD_USE_FE_LAYOUT_EMPTY_MARK_GRID_ALLOCATION = defineCompatibility
     version: '16.111.1',
     platform: 'macOS 26.5.2',
   },
-  description: 'With useFELayout enabled, a content-less paragraph mark participates in Far East whole-cell document-grid allocation even when the document contains no literal East Asian text. Its face-specific Far East design height governs the cell count; exact spacing and snapToGrid=false remain the document-grid overrides named by ECMA-376 §17.6.5.',
+  description: 'With useFELayout enabled, a content-less paragraph mark participates in Far East whole-cell document-grid allocation even when the document contains no literal East Asian text. Its face-specific Far East design height governs the cell count; exact spacing and snapToGrid=false remain the document-grid overrides named by ECMA-376 §17.6.5. Observed Word output gives signed atLeast spacing a discontinuous boundary on an active grid: negative values use their absolute magnitude as the mark advance, zero keeps the ordinary atLeast-zero advance regardless of inheritance source, and positive values retain whole-cell allocation.',
 });
 
-/** Compatibility projection governed by
- * {@link WORD_USE_FE_LAYOUT_EMPTY_MARK_GRID_ALLOCATION}. The caller supplies
- * the ordinary line-spacing result and the mark's whole-cell grid allocation;
- * §17.6.5 makes exact spacing the sole line-spacing override. */
+/** Compatibility projection governed by the useFELayout empty-mark allocation
+ * and {@link WORD_GRID_AT_LEAST_TALL_LINE_UNSNAPPED}. The caller supplies the
+ * ordinary line-spacing result and the mark's whole-cell grid allocation.
+ * Exact spacing is the normative §17.6.5 override. Observed Word output gives
+ * signed atLeast values an empty-mark-specific negative/zero/positive boundary. */
 export function wordUseFeLayoutParagraphMarkGridAdvancePx(
-  ordinaryAdvancePx: number,
-  allocatedGridAdvancePx: number,
-  exactSpacing: boolean,
+  input: Readonly<{
+    ordinaryAdvancePx: number;
+    allocatedGridAdvancePx: number;
+    atLeastZeroAdvancePx: number;
+    lineSpacing: LineSpacing | null;
+    gridAllocationActive: boolean;
+    scale: number;
+  }>,
 ): number {
-  return exactSpacing
+  const {
+    ordinaryAdvancePx,
+    allocatedGridAdvancePx,
+    atLeastZeroAdvancePx,
+    lineSpacing,
+    gridAllocationActive,
+    scale,
+  } = input;
+  if (!gridAllocationActive) return ordinaryAdvancePx;
+  if (lineSpacing?.rule === 'atLeast' && lineSpacing.value < 0) {
+    return Math.abs(lineSpacing.value) * scale;
+  }
+  if (lineSpacing?.rule === 'atLeast' && lineSpacing.value === 0) {
+    return atLeastZeroAdvancePx;
+  }
+  return lineSpacing?.rule === 'exact'
     ? ordinaryAdvancePx
     : Math.max(ordinaryAdvancePx, allocatedGridAdvancePx);
 }

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -1651,7 +1651,8 @@ export function paragraphMarkLineMetrics(
     eastAsian,
     gridCountSingle,
   );
-  const allocatedGridAdvancePx = useFeLayout && eastAsian && isGridLineRule(grid)
+  const gridAllocationActive = useFeLayout && eastAsian && isGridLineRule(grid);
+  const allocatedGridAdvancePx = gridAllocationActive
     ? lineBoxHeight(
         null,
         asc,
@@ -1664,12 +1665,31 @@ export function paragraphMarkLineMetrics(
         gridCountSingle,
       )
     : ordinaryAdvancePx;
+  // Candidate for the observed atLeast=0 compatibility branch. Compute it
+  // independently of the source's inheritance flag so the compatibility owner
+  // can select it without leaking the signed boundary into this producer.
+  const atLeastZeroAdvancePx = gridAllocationActive
+    ? lineBoxHeight(
+        { rule: 'atLeast', value: 0, explicit: true },
+        asc,
+        desc,
+        scale,
+        grid,
+        paraHasRuby,
+        intendedSingle,
+        eastAsian,
+        gridCountSingle,
+      )
+    : ordinaryAdvancePx;
   const advancePx = useFeLayout
-    ? wordUseFeLayoutParagraphMarkGridAdvancePx(
+    ? wordUseFeLayoutParagraphMarkGridAdvancePx({
         ordinaryAdvancePx,
         allocatedGridAdvancePx,
-        effectiveLineSpacing?.rule === 'exact',
-      )
+        atLeastZeroAdvancePx,
+        lineSpacing: effectiveLineSpacing,
+        gridAllocationActive,
+        scale,
+      })
     : ordinaryAdvancePx;
   return { advancePx, ascentPx: asc, descentPx: desc };
 }

--- a/packages/docx/src/paragraph-measure.test.ts
+++ b/packages/docx/src/paragraph-measure.test.ts
@@ -389,7 +389,7 @@ describe('measureParagraph', () => {
     expect(markAdvance(11, 18, 'ＭＳ 明朝')).toBe(18);
   });
 
-  it('keeps useFELayout paragraph marks on the grid unless exact spacing overrides it', () => {
+  it('keeps positive atLeast useFELayout marks on the grid unless exact spacing overrides it', () => {
     const atLeast = { value: 18, rule: 'atLeast' as const, explicit: true };
     const exact = { value: 18, rule: 'exact' as const, explicit: true };
     const measure = (lineSpacing: typeof atLeast | typeof exact): number => measureParagraph(
@@ -413,6 +413,86 @@ describe('measureParagraph', () => {
     // §17.6.5 names exact spacing (not atLeast) as the grid-line override.
     expect(measure(atLeast)).toBe(36);
     expect(measure(exact)).toBe(18);
+  });
+
+  it.each([true, false])(
+    'keeps an atLeast-zero empty mark at its design advance (explicit=%s)',
+    (explicit) => {
+      const atLeastZero = { value: 0, rule: 'atLeast' as const, explicit };
+      const result = measureParagraph(
+        paragraph({
+          defaultFontSize: 10,
+          defaultFontFamily: 'Meiryo',
+          defaultFontFamilyEastAsia: 'Meiryo',
+          lineSpacing: atLeastZero,
+          spaceBefore: 0,
+        }),
+        layoutContext({
+          lineGrid: { active: true, pitchPt: 14.55 },
+          lineSpacing: atLeastZero,
+          spaceBeforePt: 0,
+        }),
+        placement({ startYPt: 0 }),
+        measurer,
+        environment({ useFeLayout: true }),
+      );
+
+      // Word's atLeast-zero compatibility path keeps a line whose design box
+      // exceeds one grid pitch at its raw design advance instead of rounding
+      // it to a second grid cell. Empty paragraph marks follow the same rule.
+      expect(result.contentEndYPt).toBeCloseTo(10 * 3269 / 2048, 12);
+    },
+  );
+
+  it.each([
+    { value: -18, expected: 18 },
+    { value: -0.05, expected: 0.05 },
+    { value: 0.05, expected: 29.1 },
+  ])('keeps the observed signed atLeast empty-mark boundary at $value pt', ({ value, expected }) => {
+    const lineSpacing = { value, rule: 'atLeast' as const, explicit: true };
+    const result = measureParagraph(
+      paragraph({
+        defaultFontSize: 10,
+        defaultFontFamily: 'Meiryo',
+        defaultFontFamilyEastAsia: 'Meiryo',
+        lineSpacing,
+        spaceBefore: 0,
+      }),
+      layoutContext({
+        lineGrid: { active: true, pitchPt: 14.55 },
+        lineSpacing,
+        spaceBeforePt: 0,
+      }),
+      placement({ startYPt: 0 }),
+      measurer,
+      environment({ useFeLayout: true }),
+    );
+
+    expect(result.contentEndYPt).toBeCloseTo(expected, 12);
+  });
+
+  it.each([
+    { name: 'without a document grid', lineGrid: { active: false, pitchPt: null } },
+    // snapToGrid=false is resolved by layout context into an inactive line axis
+    // while retaining the section pitch for diagnostics.
+    { name: 'when snapToGrid disables the line axis', lineGrid: { active: false, pitchPt: 14.55 } },
+  ])('does not project negative atLeast grid compatibility $name', ({ lineGrid }) => {
+    const lineSpacing = { value: -0.05, rule: 'atLeast' as const, explicit: true };
+    const result = measureParagraph(
+      paragraph({
+        defaultFontSize: 10,
+        defaultFontFamily: 'Meiryo',
+        defaultFontFamilyEastAsia: 'Meiryo',
+        lineSpacing,
+        spaceBefore: 0,
+      }),
+      layoutContext({ lineGrid, lineSpacing, spaceBeforePt: 0 }),
+      placement({ startYPt: 0 }),
+      measurer,
+      environment({ useFeLayout: true }),
+    );
+
+    expect(result.contentEndYPt).toBeCloseTo(10 * 3269 / 2048, 12);
   });
 
   it('matches observed Word spacing for an explicit atLeast line on a body grid', () => {

--- a/packages/docx/src/table-cell-docgrid.test.ts
+++ b/packages/docx/src/table-cell-docgrid.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { layoutBodyTableRowAdvances } from './test-support/document-layout.test-support.js';
+import {
+  layoutBodyModel,
+  layoutBodyTableRowAdvances,
+} from './test-support/document-layout.test-support.js';
 import type {
   DocParagraph,
   DocTable,
@@ -209,6 +212,44 @@ describe('table-cell line grid compatibility', () => {
 // 20 pt; the mock font box is a flat 1.0×em, so every height difference below
 // comes from the line-height / script routing alone.
 describe('docGrid line-cell integration through the cell measure path', () => {
+  it('retains atLeast-zero empty-mark row and horizontal-border boundaries', () => {
+    const para = paragraphWithRuns([]);
+    para.defaultFontSize = 10;
+    para.defaultFontFamily = 'Meiryo';
+    para.defaultFontFamilyEastAsia = 'Meiryo';
+    para.lineSpacing = { value: 0, rule: 'atLeast', explicit: true };
+    const source = table();
+    const horizontal = { width: 2, color: '#000000', style: 'single' };
+    source.rows = [rowWith(para)];
+    source.borders = { ...source.borders, top: horizontal, bottom: horizontal };
+    const gridSection = { ...section(), docGridLinePitch: 14.55 };
+
+    const layout = layoutBodyModel(
+      [{ type: 'table', ...source }],
+      gridSection,
+      makeMeasureContext(),
+      {},
+      { adjustLineHeightInTable: true, useFeLayout: true },
+    );
+    const retained = layout.pages[0]?.layers.body[0];
+    if (retained?.kind !== 'table') throw new Error('Canonical layout omitted the table');
+    const retainedRow = retained.rows[0];
+    if (!retainedRow) throw new Error('Canonical table omitted the row');
+    const top = retained.borders.find((border) => border.edge === 'top');
+    const bottom = retained.borders.find((border) => border.edge === 'bottom');
+    if (!top || !bottom) throw new Error('Canonical table omitted horizontal borders');
+
+    const designAdvancePt = 10 * 3269 / 2048;
+    expect(retainedRow.contentHeightPt).toBeCloseTo(designAdvancePt, 12);
+    expect(retainedRow.advancePt).toBeCloseTo(designAdvancePt + 2, 12);
+    expect(retained.advancePt).toBeCloseTo(retainedRow.advancePt, 12);
+    expect(top.from.yPt).toBeCloseTo(retained.flowBounds.yPt, 12);
+    expect(bottom.from.yPt).toBeCloseTo(
+      retained.flowBounds.yPt + retained.advancePt,
+      12,
+    );
+  });
+
   it('matches observed Word spacing for explicit atLeast lines in a table cell', () => {
     const para = paragraphWithRuns([
       {


### PR DESCRIPTION
## Summary
- preserve Microsoft Word signed atLeast behavior for useFELayout empty paragraph marks on an active document grid
- keep the compatibility decision in one DOCX owner and retain canonical row, table, and horizontal-border geometry

## Specification and compatibility
- ECMA-376 Part 1 §17.3.1.33 defines line spacing behavior
- ECMA-376 Part 1 §17.6.5 defines document-grid allocation and exact/snapToGrid overrides
- synthetic Office observations establish the active-grid negative, zero, and positive atLeast boundary without sample-specific tuning

## Verification
- 2,971 DOCX tests
- final DOCX layout boundary check
- 88 DOCX architecture boundary tests
- compatibility evidence and public API gates
- DOCX package-build gate
- workspace typecheck
- independent spec-first and architecture reviews