### PR TITLE
fix(docx): preserve DrawingML layout fidelity

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "word",
     "excel",
     "powerpoint",
+    "office-viewer",
+    "office",
     "viewer",
     "canvas",
     "wasm",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -137,6 +137,8 @@ export { hexToRgba, relativeLuma, autoContrastColor, resolveFill, applyStroke } 
 export { buildShapePath, drawStar, drawPolygon, ooxmlArcTo } from './shape/preset';
 export {
   paintDrawingMLShape,
+  clipDrawingMLShape,
+  withDrawingMLShapeTransform,
   type DrawingMLShapeFill,
   type DrawingMLShapeGeometry,
   type DrawingMLShapePaintPlan,
@@ -252,6 +254,7 @@ export {
   renderPresetShape,
   hasPreset,
   buildPresetGeometryPath,
+  buildPresetGeometryFillPath,
   getConnectorAnchors,
 } from './shape/preset-geometry';
 export { type PresetPath } from './shape/preset-geometry/path-executor';

--- a/packages/core/src/shape/drawingml-shape.test.ts
+++ b/packages/core/src/shape/drawingml-shape.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  clipDrawingMLShape,
   paintDrawingMLShape,
   type DrawingMLShapePaintPlan,
 } from './drawingml-shape.js';
@@ -29,6 +30,7 @@ function recordingContext() {
     bezierCurveTo(...args: unknown[]) { operations.push({ name: 'bezierCurveTo', args }); },
     ellipse(...args: unknown[]) { operations.push({ name: 'ellipse', args }); },
     closePath() { operations.push({ name: 'closePath', args: [] }); },
+    clip(...args: unknown[]) { operations.push({ name: 'clip', args }); },
     fill(...args: unknown[]) { operations.push({ name: 'fill', args }); },
     stroke() { operations.push({ name: 'stroke', args: [] }); },
     setLineDash(...args: unknown[]) { operations.push({ name: 'setLineDash', args }); },
@@ -150,5 +152,30 @@ describe('shared DrawingML shape painter', () => {
 
     expect(() => paintDrawingMLShape(ctx, plan, 1)).not.toThrow();
     expect(plan.geometry.kind === 'preset' && plan.geometry.adjustments).toHaveLength(12);
+  });
+
+  it('clips overlapping custom subpaths with the normal nonzero rule', () => {
+    const { ctx, operations } = recordingContext();
+    clipDrawingMLShape(ctx, {
+      rect: { x: 0, y: 0, w: 100, h: 100 },
+      geometry: { kind: 'custom', subpaths: [[
+        { cmd: 'moveTo', x: 0, y: 0 },
+        { cmd: 'lineTo', x: 1, y: 0 },
+        { cmd: 'lineTo', x: 1, y: 1 },
+        { cmd: 'close' },
+      ], [
+        { cmd: 'moveTo', x: .25, y: .25 },
+        { cmd: 'lineTo', x: .75, y: .25 },
+        { cmd: 'lineTo', x: .75, y: .75 },
+        { cmd: 'close' },
+      ]] },
+      fill: null,
+      stroke: null,
+      transform: { rotationDeg: 0, flipH: false, flipV: false },
+    });
+
+    expect(operations.filter(({ name }) => name === 'clip')).toEqual([
+      { name: 'clip', args: [] },
+    ]);
   });
 });

--- a/packages/core/src/shape/drawingml-shape.ts
+++ b/packages/core/src/shape/drawingml-shape.ts
@@ -4,7 +4,12 @@ import { buildCustomPath } from './custGeom';
 import { getCustGeomEndpoints } from './custgeom-endpoints';
 import { applyStroke, resolveFill } from './paint';
 import { buildShapePath } from './preset';
-import { getConnectorAnchors, hasPreset, renderPresetShape } from './preset-geometry';
+import {
+  buildPresetGeometryFillPath,
+  getConnectorAnchors,
+  hasPreset,
+  renderPresetShape,
+} from './preset-geometry';
 
 type DeepReadonly<T> =
   T extends (...args: never[]) => unknown ? T
@@ -35,6 +40,56 @@ export interface DrawingMLShapePaintPlan {
     flipH: boolean;
     flipV: boolean;
   }>;
+}
+
+/** Execute paint in the authored DrawingML shape transform. Resource-backed
+ * fills use this same frame as ordinary solid/gradient shape paint. */
+export function withDrawingMLShapeTransform(
+  ctx: CanvasRenderingContext2D,
+  plan: DrawingMLShapePaintPlan,
+  paint: () => void,
+): void {
+  const { x, y, w, h } = plan.rect;
+  const { rotationDeg, flipH, flipV } = plan.transform;
+  ctx.save();
+  try {
+    if (rotationDeg !== 0 || flipH || flipV) {
+      ctx.translate(x + w / 2, y + h / 2);
+      if (rotationDeg !== 0) ctx.rotate(rotationDeg * Math.PI / 180);
+      ctx.scale(flipH ? -1 : 1, flipV ? -1 : 1);
+      ctx.translate(-(x + w / 2), -(y + h / 2));
+    }
+    paint();
+  } finally {
+    ctx.restore();
+  }
+}
+
+/** Clip the current canvas state to the exact DrawingML shape silhouette.
+ * The caller owns save/restore and should enter the shape transform first. */
+export function clipDrawingMLShape(
+  ctx: CanvasRenderingContext2D,
+  plan: DrawingMLShapePaintPlan,
+): void {
+  const { x, y, w, h } = plan.rect;
+  ctx.beginPath();
+  if (plan.geometry.kind === 'preset') {
+    const adjustments = [...plan.geometry.adjustments];
+    if (!buildPresetGeometryFillPath(
+      ctx, plan.geometry.name, x, y, w, h, adjustments,
+    )) {
+      buildShapePath(
+        ctx, plan.geometry.name, x, y, w, h,
+        adjustments[0], adjustments[1], adjustments[2], adjustments[3],
+      );
+    }
+  } else {
+    buildCustomPath(ctx, plan.geometry.subpaths as PathCmd[][], x, y, w, h);
+  }
+  // Use Canvas's nonzero rule, matching normal DrawingML shape fill and PPTX
+  // picture clipping. `evenodd` would turn overlapping silhouette subpaths into
+  // XOR holes that do not exist in the authored geometry.
+  ctx.clip();
 }
 
 const CONNECTOR_GEOMETRIES = new Set([
@@ -164,15 +219,7 @@ export function paintDrawingMLShape(
   unitToDevice: number,
 ): void {
   const { x, y, w, h } = plan.rect;
-  const { rotationDeg, flipH, flipV } = plan.transform;
-  ctx.save();
-  try {
-    if (rotationDeg !== 0 || flipH || flipV) {
-      ctx.translate(x + w / 2, y + h / 2);
-      if (rotationDeg !== 0) ctx.rotate(rotationDeg * Math.PI / 180);
-      ctx.scale(flipH ? -1 : 1, flipV ? -1 : 1);
-      ctx.translate(-(x + w / 2), -(y + h / 2));
-    }
+  withDrawingMLShapeTransform(ctx, plan, () => {
     // Shared fill resolution is observational; retained plans keep gradient
     // stops readonly so layout snapshots cannot be mutated by a painter.
     const fillStyle = resolveFill(plan.fill as Fill | null, ctx, x, y, w, h);
@@ -228,7 +275,5 @@ export function paintDrawingMLShape(
       if (applyAndStroke) applyAndStroke();
       paintCustomEnds(ctx, plan, unitToDevice);
     }
-  } finally {
-    ctx.restore();
-  }
+  });
 }

--- a/packages/core/src/shape/preset-geometry/index.ts
+++ b/packages/core/src/shape/preset-geometry/index.ts
@@ -110,6 +110,33 @@ export function buildPresetGeometryPath(
   return true;
 }
 
+/** Append only the fill-bearing paths of a preset geometry.
+ *
+ * CT_Path2D paths whose `fill` is `none` are decorative stroke overlays, not
+ * part of the object's painted silhouette. Picture and image-fill clipping must
+ * therefore exclude them; otherwise an open accent/leader path is implicitly
+ * closed by Canvas and cuts a false region into the image. Fill modifiers such
+ * as `lighten` and `darken` remain included because those paths do carry fill.
+ */
+export function buildPresetGeometryFillPath(
+  ctx: CanvasRenderingContext2D,
+  geom: string,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  adj: (number | null | undefined)[] = [],
+): boolean {
+  const def = PRESETS[geom.toLowerCase()];
+  if (!def) return false;
+  const evaluator = evaluatorForDef(def, w, h, adj);
+  for (const path of def.paths) {
+    if (path.fill === 'none') continue;
+    applyPresetPath(ctx, path, evaluator, x, y, w, h);
+  }
+  return true;
+}
+
 // A wedge callout's tail only protrudes when its tip is OUTSIDE the body. When
 // the author drags the tip into the body (e.g. to hide the tail), PowerPoint
 // renders just the base shape — no inward dent. The literal ECMA-376 preset

--- a/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
+++ b/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
@@ -3,6 +3,7 @@ import {
   renderPresetShape,
   hasPreset,
   buildPresetGeometryPath,
+  buildPresetGeometryFillPath,
   getConnectorAnchors,
 } from './index';
 
@@ -168,6 +169,20 @@ describe('renderPresetShape (core preset-geometry engine)', () => {
       const ok = buildPresetGeometryPath(ctx, 'totallyMadeUpShape', 0, 0, 10, 10);
       expect(ok).toBe(false);
       expect(points.length).toBe(0);
+    });
+
+    it('excludes fill=none decorative paths from a multi-path clip silhouette', () => {
+      const complete = makeRecorder();
+      const silhouette = makeRecorder();
+      expect(buildPresetGeometryPath(
+        complete.ctx, 'verticalScroll', 0, 0, 200, 100,
+      )).toBe(true);
+      expect(buildPresetGeometryFillPath(
+        silhouette.ctx, 'verticalScroll', 0, 0, 200, 100,
+      )).toBe(true);
+
+      expect(silhouette.points.length).toBeGreaterThan(0);
+      expect(silhouette.points.length).toBeLessThan(complete.points.length);
     });
   });
 

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -81,9 +81,10 @@ export interface TileInfo {
   flip: string;
   /**
    * Anchor corner the tile grid registers against:
-   * `tl|t|tr|l|ctr|r|bl|b|br` (`algn`). Default `'tl'`.
+   * `tl|t|tr|l|ctr|r|bl|b|br` (`algn`). The schema has no default; a host may
+   * apply a compatibility fallback when omitted.
    */
-  algn: string;
+  algn?: string;
 }
 
 /**

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -775,6 +775,12 @@ export declare interface FieldRun {
     highlight?: string | null;
     emphasisMark?: EmphasisMark;
 }
+declare interface FillRect {
+    l?: number;
+    t?: number;
+    r?: number;
+    b?: number;
+}
 export declare interface FindMatch<Loc = unknown> {
     matchIndex: number;
     text: string;
@@ -1271,8 +1277,24 @@ declare type ShapeFill = {
     stops: GradientStop[];
     angle: number;
     gradType: string;
+} | {
+    fillType: 'image';
+    imagePath: string;
+    mimeType: string;
+    svgImagePath?: string;
+    srcRect?: {
+        l: number;
+        t: number;
+        r: number;
+        b: number;
+    };
+    fillRect?: FillRect;
+    tile?: TileInfo;
+    alpha?: number;
+    duotone?: Duotone;
 };
 export declare interface ShapeRun {
+    inline?: boolean;
     widthPt: number;
     heightPt: number;
     anchorXPt: number;
@@ -1392,6 +1414,14 @@ export declare interface TextPath {
     fontFamily?: string | null;
     bold?: boolean;
     italic?: boolean;
+}
+declare interface TileInfo {
+    tx: number;
+    ty: number;
+    sx: number;
+    sy: number;
+    flip: string;
+    algn?: string;
 }
 export declare type WireRenderPageOptions = Omit<RenderPageOptions, 'onTextRun'>;
 declare interface ZoomableViewer {

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -4,6 +4,7 @@ use ooxml_common::blip::{
 };
 use ooxml_common::depth::{parse_guarded, DepthGuard};
 use ooxml_common::drawing::{parse_xsd_bool, DrawingGroupSpec, DrawingGroupTransform, DrawingRect};
+use ooxml_common::fill::{parse_fill_rect, parse_tile};
 use ooxml_common::ns::{attr_ns, is_w_ns, is_wp_ns, math, relationships, wordprocessingml};
 use ooxml_common::package_session::{PackageEntryStream, PackageOperation, PackageSessionHandle};
 use ooxml_common::resource::ResourceUsage;
@@ -6739,6 +6740,56 @@ fn parse_inline_drawing_impl(
                 }
             }
         }
+        // ECMA-376 §20.4.2.8: wp:inline contains an arbitrary DrawingML
+        // graphic, not only a picture. Word emits WPS text panels as a direct
+        // `<wps:wsp>` payload (for example section-label rectangles). Parse it
+        // through the same shape grammar as an anchored WPS object, but keep it
+        // in paragraph flow: no anchor-acquisition wire, wrap metadata, or page
+        // positioning. Inline placement is resolved later from the paragraph
+        // pen, so anchor-relative flags remain false just like an inline image.
+        let direct_wps_payload = container
+            .descendants()
+            .find(|n| n.tag_name().name() == "graphicData")
+            .filter(|graphic_data| {
+                graphic_data
+                    .attribute("uri")
+                    .is_some_and(|uri| uri.contains("wordprocessingShape"))
+            })
+            .and_then(|graphic_data| {
+                graphic_data
+                    .children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "wsp")
+            });
+        if let (Some(wsp), Some((width_pt, height_pt))) =
+            (direct_wps_payload, drawing_extent_points(container))
+        {
+            if let Some(mut shape) = parse_wsp_shape(
+                style_map,
+                num_map,
+                wsp,
+                theme,
+                media_map,
+                chart_map,
+                rel_map,
+                depth,
+                0.0,
+                false,
+                0.0,
+                false,
+                &AnchorMeta::default(),
+                None,
+                None,
+                0,
+            ) {
+                // §20.4.2.7: wp:extent is the final outer size of the inline
+                // object. The WPS a:xfrm remains the shape's internal geometry;
+                // it must not dictate paragraph advance or final paint bounds.
+                shape.width_pt = width_pt;
+                shape.height_pt = height_pt;
+                shape.inline = true;
+                return vec![DocRun::Shape(Box::new(shape))];
+            }
+        }
         // Resolve the picture's blip + `<wp:extent>` natural size. The Microsoft
         // 2016 SVG extension is handled inside `resolve_inline_blip` →
         // `resolve_blip_urls` (prefer the vector original, keep the raster as a
@@ -8567,7 +8618,7 @@ fn parse_wsp_shape(
         .children()
         .find(|n| n.is_element() && n.tag_name().name() == "style");
 
-    let fill = match parse_shape_fill(sp_pr, theme) {
+    let fill = match parse_shape_fill(sp_pr, theme, media_map) {
         FillSpec::Explicit(f) => Some(f),
         FillSpec::NoFill => None,
         FillSpec::Absent => style_node
@@ -8686,6 +8737,7 @@ fn parse_wsp_shape(
     );
 
     let mut shape = ShapeRun {
+        inline: false,
         width_pt,
         height_pt,
         anchor_x_pt,
@@ -9934,6 +9986,7 @@ fn parse_vml_pict(
         .unwrap_or_default();
 
     Some(ShapeRun {
+        inline: false,
         width_pt,
         height_pt,
         anchor_x_pt,
@@ -10651,7 +10704,11 @@ enum FillSpec {
 /// Parse a shape's direct fill (solidFill / gradFill / noFill), reporting which
 /// of the three states applies so the caller can decide whether to fall back to
 /// the style's fillRef.
-fn parse_shape_fill(sp_pr: roxmltree::Node, theme: &ThemeColors) -> FillSpec {
+fn parse_shape_fill(
+    sp_pr: roxmltree::Node,
+    theme: &ThemeColors,
+    media_map: &HashMap<String, String>,
+) -> FillSpec {
     for child in sp_pr.children().filter(|n| n.is_element()) {
         match child.tag_name().name() {
             "solidFill" => {
@@ -10668,6 +10725,45 @@ fn parse_shape_fill(sp_pr: roxmltree::Node, theme: &ThemeColors) -> FillSpec {
                     Some(f) => FillSpec::Explicit(f),
                     None => FillSpec::NoFill,
                 };
+            }
+            "blipFill" => {
+                // §20.1.8.14: a direct picture fill is an authored fill even
+                // when its relationship cannot be resolved. Never fall back to
+                // wps:style/fillRef, which would replace the picture with an
+                // unrelated theme paint.
+                let Some(blip) = child
+                    .children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "blip")
+                else {
+                    return FillSpec::NoFill;
+                };
+                let Some((image_path, mime_type, svg_image_path)) =
+                    resolve_blip_urls(blip, media_map)
+                else {
+                    return FillSpec::NoFill;
+                };
+                let tile = child
+                    .children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "tile")
+                    .map(parse_tile);
+                let fill_rect = if tile.is_none() {
+                    child
+                        .children()
+                        .find(|n| n.is_element() && n.tag_name().name() == "stretch")
+                        .and_then(parse_fill_rect)
+                } else {
+                    None
+                };
+                return FillSpec::Explicit(ShapeFill::Image {
+                    image_path,
+                    mime_type,
+                    svg_image_path,
+                    src_rect: parse_src_rect(child),
+                    fill_rect,
+                    tile,
+                    alpha: parse_blip_alpha(child),
+                    duotone: parse_blip_duotone_docx(child, theme),
+                });
             }
             "noFill" => return FillSpec::NoFill,
             _ => {}
@@ -15438,6 +15534,14 @@ mod cs_toggle_tests {
         assert!(!run.underline);
         assert_eq!(run.underline_style, None);
         assert_eq!(run.underline_color, None);
+
+        // §17.3.2.40: the element may carry color while omitting @val; @val
+        // then inherits and must not manufacture a single underline.
+        let color_only =
+            run_of(r#"<w:p><w:r><w:rPr><w:u w:color="FF0000"/></w:rPr><w:t>x</w:t></w:r></w:p>"#);
+        assert!(!color_only.underline);
+        assert_eq!(color_only.underline_style, None);
+        assert_eq!(color_only.underline_color, None);
     }
 
     #[test]
@@ -18793,120 +18897,6 @@ mod anchor_image_relative_from_tests {
             }
             other => panic!("expected DocRun::Chart, got {other:?}"),
         }
-    }
-
-    /// CH14 end-to-end — `private/sample-24.docx` has 6 `<w:drawing>` chart
-    /// references total (`word/charts/chart1.xml`..`chart6.xml`, rId5..rId11
-    /// each used exactly once in `document.xml`). Two of the six parts —
-    /// `chart4.xml` (box-and-whisker) and `chart6.xml` (sunburst) — are
-    /// actually `<cx:chartSpace>` chartEx parts wrapped in
-    /// `<mc:AlternateContent><mc:Choice Requires="cx">` (with an `mc:Fallback`
-    /// rendered-image for older Word versions); the other four
-    /// (`chart1`/`chart2`/`chart3`/`chart5`) are legacy `<c:chartSpace>`
-    /// bar/line/radar/stock charts. Before this fix the uri gate in
-    /// `parse_inline_drawing` only matched the legacy DrawingML chart uri, so
-    /// chart4/chart6 fell through to the (blip-less) picture path and
-    /// produced nothing — this confirms the full zip → document.xml →
-    /// AlternateContent/Choice → inline drawing → chart_map pipeline now
-    /// surfaces both as `DocRun::Chart`, and that all 6 chart drawings still
-    /// produce exactly one `DocRun::Chart` each (no regression, no
-    /// duplication from the `mc:Fallback` branch). `stockChart` (chart5) is
-    /// not implemented by `parse_chart_part` and reports as "unknown" —  a
-    /// pre-existing legacy-chart gap, unrelated to and out of scope for this
-    /// chartex wiring task. Skips gracefully when the private,
-    /// non-redistributable fixture is not present (e.g. CI).
-    #[test]
-    fn sample24_chartex_charts_parse_as_chart_runs() {
-        const LOCAL_SAMPLE_24: &str = "../public/private/sample-24.docx";
-        let Ok(data) = std::fs::read(LOCAL_SAMPLE_24) else {
-            eprintln!(
-                "skipping sample24_chartex_charts_parse_as_chart_runs: local sample not found"
-            );
-            return;
-        };
-        let doc = parse_from_bytes(&data).expect("sample-24.docx must parse");
-
-        fn collect_from_paragraph(p: &DocParagraph, out: &mut Vec<String>) {
-            for run in &p.runs {
-                if let DocRun::Chart(c) = run {
-                    out.push(c.chart.chart_type.clone());
-                }
-            }
-        }
-        fn collect_from_table(t: &DocTable, out: &mut Vec<String>) {
-            for row in &t.rows {
-                for cell in &row.cells {
-                    for el in &cell.content {
-                        match el {
-                            CellElement::Paragraph(p) => collect_from_paragraph(p, out),
-                            CellElement::Table(t) => collect_from_table(t, out),
-                        }
-                    }
-                }
-            }
-        }
-        let mut chart_types = Vec::new();
-        for el in &doc.body {
-            match el {
-                BodyElement::Paragraph(p) => collect_from_paragraph(p, &mut chart_types),
-                BodyElement::Table(t) => collect_from_table(t, &mut chart_types),
-                _ => {}
-            }
-        }
-
-        assert_eq!(
-            chart_types.iter().filter(|t| *t == "boxWhisker").count(),
-            1,
-            "expected exactly one boxWhisker chartex chart, got {chart_types:?}"
-        );
-        assert_eq!(
-            chart_types.iter().filter(|t| *t == "sunburst").count(),
-            1,
-            "expected exactly one sunburst chartex chart, got {chart_types:?}"
-        );
-        // 6 chart drawings total: chart1(bar)/chart2(line)/chart3(radar)/
-        // chart5(stock, unimplemented → "unknown") legacy + chart4(boxWhisker)/
-        // chart6(sunburst) chartex. No duplication from mc:Fallback.
-        assert_eq!(
-            chart_types.len(),
-            6,
-            "expected 6 total chart runs (4 legacy + 2 chartex), got {chart_types:?}"
-        );
-
-        // The two chartex Fallback PNGs (image1.png/image2.png) must NOT surface
-        // as image runs: MCE (ECMA-376 Part 3 §9.3) selects the understood `cx`
-        // Choice, so the Fallback is dropped — no double-emit. (Guards #747.)
-        fn count_images_para(p: &DocParagraph, n: &mut usize) {
-            for run in &p.runs {
-                if let DocRun::Image(_) = run {
-                    *n += 1;
-                }
-            }
-        }
-        fn count_images_table(t: &DocTable, n: &mut usize) {
-            for row in &t.rows {
-                for cell in &row.cells {
-                    for el in &cell.content {
-                        match el {
-                            CellElement::Paragraph(p) => count_images_para(p, n),
-                            CellElement::Table(t) => count_images_table(t, n),
-                        }
-                    }
-                }
-            }
-        }
-        let mut image_count = 0usize;
-        for el in &doc.body {
-            match el {
-                BodyElement::Paragraph(p) => count_images_para(p, &mut image_count),
-                BodyElement::Table(t) => count_images_table(t, &mut image_count),
-                _ => {}
-            }
-        }
-        assert_eq!(
-            image_count, 0,
-            "chartex mc:Fallback PNGs must not surface as image runs (got {image_count})"
-        );
     }
 
     /// Parse a `<w:p>` whose namespaces + chart_map are supplied by the caller,
@@ -22353,6 +22343,171 @@ mod shape_preset_geometry_tests {
 
         assert_eq!(shape.stroke.as_deref(), Some("4472C4"));
         assert!((shape.stroke_width - 2.0).abs() < 1e-6);
+    }
+}
+
+// ECMA-376 §20.4.2.8 permits any DrawingML graphic payload inside wp:inline;
+// WPS text boxes are therefore inline layout objects, not picture-only data.
+// Their direct fill is independently governed by §20.1.8.14 blipFill.
+#[cfg(test)]
+mod inline_wps_shape_tests {
+    use super::*;
+
+    fn inline_shape_runs(sp_pr_fill: &str, media_map: &HashMap<String, String>) -> Vec<DocRun> {
+        let xml = format!(
+            r#"<w:drawing
+                 xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                 xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                 xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                 xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+                 <wp:inline>
+                   <wp:extent cx="2540000" cy="635000"/>
+                   <wp:docPr id="1" name="Inline text box"/>
+                   <a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+                     <wps:wsp>
+                       <wps:spPr>
+                         <a:xfrm><a:off x="0" y="0"/><a:ext cx="1270000" cy="317500"/></a:xfrm>
+                         <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+                         {sp_pr_fill}
+                       </wps:spPr>
+                       <wps:txbx><w:txbxContent><w:p><w:r><w:t>Typical Application</w:t></w:r></w:p></w:txbxContent></wps:txbx>
+                       <wps:bodyPr anchor="ctr"><a:noAutofit/></wps:bodyPr>
+                     </wps:wsp>
+                   </a:graphicData></a:graphic>
+                 </wp:inline>
+               </w:drawing>"#,
+        );
+        let doc = roxmltree::Document::parse(&xml).expect("inline WPS fixture");
+        parse_inline_drawing_impl(
+            &StyleMap::default(),
+            &mut NumberingMap::default(),
+            doc.root_element(),
+            media_map,
+            &HashMap::new(),
+            &HashMap::new(),
+            &ThemeColors::default(),
+            DepthGuard::root(),
+        )
+    }
+
+    #[test]
+    fn wp_inline_wps_text_box_is_retained_as_an_inline_shape() {
+        let runs = inline_shape_runs(
+            r#"<a:solidFill><a:srgbClr val="009989"/></a:solidFill>"#,
+            &HashMap::new(),
+        );
+        let [DocRun::Shape(shape)] = runs.as_slice() else {
+            panic!("expected one inline WPS ShapeRun, got {runs:?}");
+        };
+
+        assert_eq!(shape.width_pt, 200.0);
+        assert_eq!(shape.height_pt, 50.0);
+        assert!(
+            shape.inline,
+            "wp:inline WPS must participate in paragraph flow"
+        );
+        assert!(!shape.anchor_x_from_margin);
+        assert!(!shape.anchor_y_from_para);
+        assert_eq!(
+            shape.fill.as_ref().and_then(|fill| match fill {
+                ShapeFill::Solid { color } => Some(color.as_str()),
+                _ => None,
+            }),
+            Some("009989")
+        );
+        assert_eq!(shape.text_blocks[0].text, "Typical Application");
+        assert!(
+            shape.anchor_acquisition.is_none(),
+            "wp:inline must not acquire floating-anchor semantics"
+        );
+    }
+
+    #[test]
+    fn wps_blip_fill_is_preserved_and_blocks_theme_fill_fallback() {
+        let media = HashMap::from([(
+            "rIdOverlay".to_string(),
+            "word/media/overlay.png".to_string(),
+        )]);
+        let runs = inline_shape_runs(
+            r#"<a:blipFill>
+                 <a:blip r:embed="rIdOverlay"><a:alphaModFix amt="75000"/></a:blip>
+                 <a:srcRect l="12500" b="25000"/>
+                 <a:stretch><a:fillRect l="10000" r="-7574"/></a:stretch>
+               </a:blipFill>"#,
+            &media,
+        );
+        let [DocRun::Shape(shape)] = runs.as_slice() else {
+            panic!("expected one image-filled WPS ShapeRun, got {runs:?}");
+        };
+        let json = serde_json::to_value(shape.fill.as_ref().expect("direct image fill"))
+            .expect("image fill serializes");
+        assert_eq!(json["fillType"], "image");
+        assert_eq!(json["imagePath"], "word/media/overlay.png");
+        assert_eq!(json["mimeType"], "image/png");
+        assert_eq!(json["srcRect"]["l"], 0.125);
+        assert_eq!(json["srcRect"]["b"], 0.25);
+        assert_eq!(json["fillRect"]["l"], 0.1);
+        assert_eq!(json["fillRect"]["r"], -0.07574);
+        assert_eq!(json["alpha"], 0.75);
+    }
+
+    #[test]
+    fn wps_tiled_blip_fill_retains_authored_tile_without_stretch() {
+        let media = HashMap::from([(
+            "rIdOverlay".to_string(),
+            "word/media/overlay.png".to_string(),
+        )]);
+        let runs = inline_shape_runs(
+            r#"<a:blipFill>
+                 <a:blip r:embed="rIdOverlay"/>
+                 <a:tile tx="12700" ty="-25400" sx="50000" sy="75000" flip="xy" algn="ctr"/>
+               </a:blipFill>"#,
+            &media,
+        );
+        let [DocRun::Shape(shape)] = runs.as_slice() else {
+            panic!("expected one tiled WPS ShapeRun, got {runs:?}");
+        };
+        let json = serde_json::to_value(shape.fill.as_ref().expect("direct tiled fill"))
+            .expect("tiled fill serializes");
+        assert!(json.get("fillRect").is_none());
+        assert_eq!(json["tile"]["tx"], 12_700);
+        assert_eq!(json["tile"]["ty"], -25_400);
+        assert_eq!(json["tile"]["sx"], 0.5);
+        assert_eq!(json["tile"]["sy"], 0.75);
+        assert_eq!(json["tile"]["flip"], "xy");
+        assert_eq!(json["tile"]["algn"], "ctr");
+    }
+
+    #[test]
+    fn wp_inline_group_is_not_misread_as_its_first_nested_wps_shape() {
+        let xml = r#"<w:drawing
+          xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+          xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+          xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"
+          xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+          <wp:inline><wp:extent cx="2540000" cy="635000"/>
+            <a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup">
+              <wpg:wgp><wps:wsp><wps:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1270000" cy="317500"/></a:xfrm><a:prstGeom prst="rect"/></wps:spPr></wps:wsp></wpg:wgp>
+            </a:graphicData></a:graphic>
+          </wp:inline>
+        </w:drawing>"#;
+        let doc = roxmltree::Document::parse(xml).expect("inline WPG fixture");
+        let runs = parse_inline_drawing_impl(
+            &StyleMap::default(),
+            &mut NumberingMap::default(),
+            doc.root_element(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &ThemeColors::default(),
+            DepthGuard::root(),
+        );
+        assert!(
+            !runs.iter().any(|run| matches!(run, DocRun::Shape(_))),
+            "an inline WPG group must not collapse to its first nested WPS shape"
+        );
     }
 }
 

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -8619,7 +8619,7 @@ fn parse_wsp_shape(
         .find(|n| n.is_element() && n.tag_name().name() == "style");
 
     let fill = match parse_shape_fill(sp_pr, theme, media_map) {
-        FillSpec::Explicit(f) => Some(f),
+        FillSpec::Explicit(f) => Some(*f),
         FillSpec::NoFill => None,
         FillSpec::Absent => style_node
             .and_then(|st| {
@@ -10694,7 +10694,7 @@ fn parse_object_ole_image(
 /// the theme gradient referenced by fillRef, which is wrong.
 enum FillSpec {
     /// A direct solidFill/gradFill was present and resolved.
-    Explicit(ShapeFill),
+    Explicit(Box<ShapeFill>),
     /// An explicit `<a:noFill/>` — the shape is intentionally unfilled.
     NoFill,
     /// No direct fill element at all — defer to wps:style/fillRef.
@@ -10713,7 +10713,7 @@ fn parse_shape_fill(
         match child.tag_name().name() {
             "solidFill" => {
                 return match resolve_color_element(child, theme) {
-                    Some(c) => FillSpec::Explicit(ShapeFill::Solid { color: c }),
+                    Some(c) => FillSpec::Explicit(Box::new(ShapeFill::Solid { color: c })),
                     // A solidFill whose color failed to resolve is still an
                     // explicit, direct fill declaration — do not fall back to
                     // the style reference.
@@ -10722,7 +10722,7 @@ fn parse_shape_fill(
             }
             "gradFill" => {
                 return match parse_grad_fill(child, theme) {
-                    Some(f) => FillSpec::Explicit(f),
+                    Some(f) => FillSpec::Explicit(Box::new(f)),
                     None => FillSpec::NoFill,
                 };
             }
@@ -10745,7 +10745,8 @@ fn parse_shape_fill(
                 let tile = child
                     .children()
                     .find(|n| n.is_element() && n.tag_name().name() == "tile")
-                    .map(parse_tile);
+                    .map(parse_tile)
+                    .map(Box::new);
                 let fill_rect = if tile.is_none() {
                     child
                         .children()
@@ -10754,7 +10755,7 @@ fn parse_shape_fill(
                 } else {
                     None
                 };
-                return FillSpec::Explicit(ShapeFill::Image {
+                return FillSpec::Explicit(Box::new(ShapeFill::Image {
                     image_path,
                     mime_type,
                     svg_image_path,
@@ -10763,7 +10764,7 @@ fn parse_shape_fill(
                     tile,
                     alpha: parse_blip_alpha(child),
                     duotone: parse_blip_duotone_docx(child, theme),
-                });
+                }));
             }
             "noFill" => return FillSpec::NoFill,
             _ => {}

--- a/packages/docx/parser/src/styles.rs
+++ b/packages/docx/parser/src/styles.rs
@@ -1862,13 +1862,18 @@ pub fn parse_run_fmt(rpr: roxmltree::Node) -> RunFmt {
     // (skipping "single"/"none", which need no hint). `w:u@color` (§17.18.99 note)
     // is an underline-only colour override (hex 6 or the literal "auto").
     if let Some(u) = child_w(rpr, "u") {
-        let val = attr_w(u, "val").unwrap_or_else(|| "single".to_string());
-        fmt.underline = Some(val != "none");
-        fmt.underline_style = if val == "none" || val == "single" {
-            None
-        } else {
-            Some(val)
-        };
+        // §17.3.2.40: an omitted @val inherits the setting from the previous
+        // style-hierarchy level; the element's color/theme attributes can still
+        // override an inherited underline. Do not invent `single` merely from
+        // element presence.
+        if let Some(val) = attr_w(u, "val") {
+            fmt.underline = Some(val != "none");
+            fmt.underline_style = if val == "none" || val == "single" {
+                None
+            } else {
+                Some(val)
+            };
+        }
         if let Some(color) = attr_w(u, "color") {
             // Lowercase like the sibling `color` field below: the renderer's
             // `underlineColor !== 'auto'` check (§17.3.2.40's `color="auto"`
@@ -2803,6 +2808,20 @@ mod tests {
         // sibling w:color@val field above.
         let fmt = run_fmt_from(r#"<w:u w:val="single" w:color="FF0000"/>"#);
         assert_eq!(fmt.underline_color.as_deref(), Some("ff0000"));
+    }
+
+    #[test]
+    fn underline_without_val_inherits_instead_of_enabling_single() {
+        let direct = run_fmt_from(r#"<w:u w:color="FF0000"/>"#);
+        assert_eq!(direct.underline, None);
+        assert_eq!(direct.underline_style, None);
+        assert_eq!(direct.underline_color.as_deref(), Some("ff0000"));
+
+        let mut inherited = run_fmt_from(r#"<w:u w:val="double"/>"#);
+        apply_run(&mut inherited, &direct);
+        assert_eq!(inherited.underline, Some(true));
+        assert_eq!(inherited.underline_style.as_deref(), Some("double"));
+        assert_eq!(inherited.underline_color.as_deref(), Some("ff0000"));
     }
 
     #[test]

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1,3 +1,4 @@
+use ooxml_common::fill::{FillRect, TileInfo};
 use serde::Serialize;
 use std::collections::BTreeMap;
 
@@ -1454,6 +1455,10 @@ pub(crate) struct AnchorAcquisitionWire {
 #[derive(Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ShapeRun {
+    /// True when this WPS shape is hosted by `wp:inline` and therefore
+    /// participates in paragraph line flow like a glyph-sized drawing object.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub inline: bool,
     /// pt
     pub width_pt: f64,
     /// pt
@@ -1720,6 +1725,29 @@ pub enum ShapeFill {
         angle: f64,
         /// "linear" | "radial"
         grad_type: String,
+    },
+    /// ECMA-376 §20.1.8.14 `a:blipFill` applied to a DrawingML shape.
+    /// The embedded package path is retained for the renderer's ordinary lazy
+    /// image-resource pipeline; stretch and tile are mutually exclusive.
+    #[serde(rename_all = "camelCase")]
+    Image {
+        image_path: String,
+        mime_type: String,
+        /// Microsoft 2016 SVG extension carried beside the raster fallback.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        svg_image_path: Option<String>,
+        /// ECMA-376 §20.1.8.55 source-image crop. This is independent of the
+        /// destination inset represented by `fill_rect`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        src_rect: Option<SrcRect>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        fill_rect: Option<FillRect>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tile: Option<TileInfo>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        alpha: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        duotone: Option<Duotone>,
     },
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1743,7 +1743,7 @@ pub enum ShapeFill {
         #[serde(skip_serializing_if = "Option::is_none")]
         fill_rect: Option<FillRect>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        tile: Option<TileInfo>,
+        tile: Option<Box<TileInfo>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         alpha: Option<f64>,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/docx/src/layout/body-pagination-compatibility.ts
+++ b/packages/docx/src/layout/body-pagination-compatibility.ts
@@ -97,8 +97,11 @@ export const WORD_VERTICAL_RL_FINAL_LINE_BASELINE_ADMISSION = defineCompatibilit
 export const WORD_LOWERED_DROP_CAP_ANCHOR_LEADING = defineCompatibilityRule({
   id: 'word-lowered-drop-cap-anchor-leading',
   evidence: {
-    kind: 'regression-test',
-    reference: 'packages/docx/src/frame-keep-with-anchor.test.ts#keeps anchor text below a lowered drop cap without extending its authored line count',
+    kind: 'office-observation',
+    syntheticFixtureId: 'lowered-drop-cap-anchor-leading',
+    application: 'Microsoft Word',
+    version: '16.111.1',
+    platform: 'macOS 26.5.2',
   },
   description: 'Word keeps the following anchor text below a baseline-lowered drop-cap glyph while preserving the drop cap exclusion height authored by framePr lines. ECMA-376 specifies those two inputs independently but does not prescribe this interaction.',
 });
@@ -109,6 +112,13 @@ export function wordLoweredDropCapAnchorLeadingPt(
   maximumBaselineLoweringPt: number,
 ): number {
   return Math.max(0, maximumBaselineLoweringPt);
+}
+
+/** Whether a framed paragraph's baseline shift contributes to its line box.
+ * Only the observed lowered-drop-cap interaction suppresses that contribution;
+ * an ordinary `w:framePr` remains governed by §17.3.2.24 metrics. */
+export function wordFramePositionExtendsLineBox(dropCap: string): boolean {
+  return dropCap === 'none';
 }
 
 /** Compatibility projection governed by {@link WORD_TRAILING_SPACE_AFTER_FIT_ADMISSION}. */
@@ -262,8 +272,10 @@ function paragraphHasOnlyDrawingAnchors(layout: ParagraphLayout): boolean {
 /** A positive-size inline DrawingML resource that participates in line flow. */
 export function wordPreBreakInlineDrawingResource(layout: ParagraphLayout): boolean {
   return layout.lines.some((line) => line.placements.some((placement) =>
-    placement.kind === 'resource'
-    && (placement.resourceKind === 'image' || placement.resourceKind === 'chart')
+    ((placement.kind === 'resource'
+      && (placement.resourceKind === 'image' || placement.resourceKind === 'chart'))
+      || placement.kind === 'drawing')
+    && placement.advancePt > 0
     && placement.bounds !== undefined
     && placement.bounds.widthPt > 0
     && placement.bounds.heightPt > 0));

--- a/packages/docx/src/layout/compatibility.test.ts
+++ b/packages/docx/src/layout/compatibility.test.ts
@@ -19,6 +19,7 @@ import {
   WORD_TRAILING_SPACE_AFTER_FIT_ADMISSION,
   WORD_VERTICAL_RL_FINAL_LINE_BASELINE_ADMISSION,
   WORD_TERMINAL_COLUMN_BREAK,
+  wordFramePositionExtendsLineBox,
   wordFinalParagraphAdmissionExtentPt,
 } from './body-pagination-compatibility.js';
 import {
@@ -57,6 +58,7 @@ import {
   WORD_RUBY_PARAGRAPH_UNIFORM_LINE_ADVANCE,
   WORD_TAB_STOP_PAGE_EDGE_CLAMP,
   WORD_THAI_DISTRIBUTE_CLUSTER_POLICY,
+  WORD_UNIFORM_RUN_POSITION_LEADING,
   wordAutoMultipleCenterBoxPx,
   wordDegenerateLineSpacingIsSingle,
   wordEastAsianGridLineCells,
@@ -71,6 +73,7 @@ import {
   wordMsMinchoEmptyEastAsianMarkSingleLinePx,
   wordNumberingSuffixAcceptsCoincidentListTab,
   wordRubyUniformLineHeightPx,
+  wordUniformRunPositionPaintPt,
   wordVisibleLineMetricPx,
 } from './line-compatibility.js';
 import {
@@ -236,6 +239,12 @@ describe('defineCompatibilityRule', () => {
       'packages/docx/src/contextual-spacing-body-paint.test.ts#paints the adjudicated six-case gap table',
     ]);
   });
+
+  it('limits positioned-run line-box suppression to observed drop caps', () => {
+    expect(wordFramePositionExtendsLineBox('none')).toBe(true);
+    expect(wordFramePositionExtendsLineBox('drop')).toBe(false);
+    expect(wordFramePositionExtendsLineBox('margin')).toBe(false);
+  });
 });
 
 describe('float compatibility evidence', () => {
@@ -306,6 +315,7 @@ describe('layout compatibility inventory', () => {
       WORD_DICTIONARY_SEA_NATURAL_FIT,
       WORD_DICTIONARY_SEA_ATOMIC_CHUNK,
       WORD_OVERLONG_TOKEN_EMERGENCY_BREAK,
+      WORD_UNIFORM_RUN_POSITION_LEADING,
       WORD_NEUTRAL_SCRIPT_ATTACHMENT,
       WORD_RTL_RUN_AMBIGUOUS_CLASS_OVERRIDE,
       WORD_RTL_COMPLEX_SCRIPT_EUROPEAN_DIGITS_AN,
@@ -342,6 +352,14 @@ describe('layout compatibility inventory', () => {
     expect(new Set(rules.map((rule) => rule.id)).size).toBe(rules.length);
     expect(rules.every(Object.isFrozen)).toBe(true);
     expect(rules.every((rule) => Object.isFrozen(rule.evidence))).toBe(true);
+  });
+
+  it('isolates uniform w:position leading without changing mixed-run displacement', () => {
+    expect(wordUniformRunPositionPaintPt(6, 6)).toBe(3);
+    expect(wordUniformRunPositionPaintPt(-6, -6)).toBe(-3);
+    expect(wordUniformRunPositionPaintPt(6, 0)).toBe(6);
+    expect(WORD_UNIFORM_RUN_POSITION_LEADING.description)
+      .not.toMatch(/sample|private|\.docx|\.pdf/i);
   });
 
   it('records the anonymized Word observation for lower-layer anchor composition', () => {

--- a/packages/docx/src/layout/invariants.ts
+++ b/packages/docx/src/layout/invariants.ts
@@ -173,7 +173,7 @@ function requireCoordinateSpace(
 }
 
 function requireDrawingMLShapePlan(
-  command: Extract<DrawingPaintCommand, { kind: 'drawingml-shape' }>,
+  command: Extract<DrawingPaintCommand, { kind: 'drawingml-shape' | 'drawingml-image-fill' }>,
   path: string,
 ): void {
   const { plan } = command;
@@ -463,6 +463,18 @@ function requireDrawingGeometry(node: DrawingLayout, path: string): void {
     if (command.kind === 'noop') return;
     if (command.kind === 'drawingml-shape') {
       requireDrawingMLShapePlan(command, commandPath);
+      return;
+    }
+    if (command.kind === 'drawingml-image-fill') {
+      requireDrawingMLShapePlan(command, commandPath);
+      if (command.resourceKey.length === 0) {
+        throw new LayoutInvariantError('INVALID_GEOMETRY', `${commandPath}.resourceKey is empty`);
+      }
+      if (command.fillRect) {
+        for (const edge of ['l', 't', 'r', 'b'] as const) {
+          requireFinite(command.fillRect[edge], `${commandPath}.fillRect.${edge}`);
+        }
+      }
       return;
     }
     requireRect(command.rect, `${commandPath}.rect`);

--- a/packages/docx/src/layout/layout-source-store.ts
+++ b/packages/docx/src/layout/layout-source-store.ts
@@ -253,6 +253,9 @@ function validateResourceManifests(
           }
         }
       }
+      if (run.type === 'shape' && run.fill?.fillType === 'image') {
+        addImage(imageResourceKey(runSource, run.fill.imagePath));
+      }
     });
   }
   const metadataKeys = new Set(imageMetadata.map((record) => record.resourceKey));

--- a/packages/docx/src/layout/line-compatibility.ts
+++ b/packages/docx/src/layout/line-compatibility.ts
@@ -99,10 +99,13 @@ export const WORD_DEGENERATE_LINE_SPACING_SINGLE = defineCompatibilityRule({
 export const WORD_AUTO_MULTIPLE_BASELINE_PIN = defineCompatibilityRule({
   id: 'word-auto-multiple-baseline-pin',
   evidence: {
-    kind: 'regression-test',
-    reference: 'packages/docx/src/line-spacing-baseline.test.ts#2.0× keeps the baseline at top + ascent (extra 1.0× leading below, NOT centred)',
+    kind: 'office-observation',
+    syntheticFixtureId: 'auto-multiple-baseline-pin',
+    application: 'Microsoft Word',
+    version: '16.111.1',
+    platform: 'macOS 26.5.2',
   },
-  description: 'Paint an automatic line-spacing multiplier at or above one with its glyph baseline pinned inside the single design line and place multiplier leading below it; this is draw-only and does not replace the centered trailing-mark pagination metric.',
+  description: 'Paint a positive automatic line-spacing multiplier with its glyph baseline pinned inside the single design line, placing extra leading or compressed overflow toward block-end; this is draw-only and does not replace the centered trailing-mark pagination metric.',
 });
 
 export const WORD_MIXED_ANCHOR_VISIBLE_LINE_METRICS = defineCompatibilityRule({
@@ -358,6 +361,29 @@ export const WORD_RUN_VERTICAL_ALIGN_BASELINE_SHIFT = defineCompatibilityRule({
   },
   description: 'Retain the established run-level baseline displacement for vertically aligned text: superscript rises by 0.35 of its authored font size and subscript falls by 0.15, while the separately authored w:position remains additive.',
 });
+
+export const WORD_UNIFORM_RUN_POSITION_LEADING = defineCompatibilityRule({
+  id: 'word-uniform-run-position-leading',
+  evidence: {
+    kind: 'office-observation',
+    syntheticFixtureId: 'uniform-run-position-leading',
+    application: 'Microsoft Word',
+    version: '16.111.1',
+    platform: 'macOS 26.5.2',
+  },
+  description: 'When every metric-bearing item on a line has the same non-zero w:position, Word preserves the enlarged line extent but shares the resulting surplus above and below the glyphs. A line containing a differently-positioned item retains the full relative displacement.',
+});
+
+/** Paint-relative baseline position governed by
+ * {@link WORD_UNIFORM_RUN_POSITION_LEADING}. */
+export function wordUniformRunPositionPaintPt(
+  authoredPositionPt: number,
+  commonLinePositionPt: number,
+): number {
+  return commonLinePositionPt === 0
+    ? authoredPositionPt
+    : authoredPositionPt - commonLinePositionPt / 2;
+}
 
 /** Compatibility projection governed by
  * {@link WORD_RUN_VERTICAL_ALIGN_BASELINE_SHIFT}. */

--- a/packages/docx/src/layout/paragraph.test.ts
+++ b/packages/docx/src/layout/paragraph.test.ts
@@ -749,6 +749,77 @@ describe('layoutParagraph', () => {
 });
 
 describe('paragraphLayoutFromMeasurement retained authorities', () => {
+  it('flows consecutive wp:inline WPS shapes at their paragraph pen positions', () => {
+    const inlineShape = () => ({
+      type: 'shape' as const,
+      inline: true,
+      widthPt: 20,
+      heightPt: 10,
+      anchorXPt: 0,
+      anchorYPt: 0,
+      anchorXFromMargin: false,
+      anchorYFromPara: false,
+      zOrder: 0,
+      subpaths: [],
+      presetGeometry: 'rect',
+      fill: { fillType: 'solid' as const, color: '009989' },
+      stroke: null,
+      textBlocks: [],
+    });
+    const tabRun = {
+      ...(paragraph.runs[0] as Extract<DocParagraph['runs'][number], { type: 'text' }>),
+      text: '\t',
+    };
+    const inlineParagraph = {
+      ...paragraph,
+      runs: [
+        inlineShape(), tabRun,
+        inlineShape(), tabRun,
+        inlineShape(),
+      ],
+    } as unknown as DocParagraph;
+    const context: ParagraphLayoutContext = {
+      ...acquisitionContext,
+      tabStops: [
+        { pos: 30, alignment: 'left', leader: 'none' },
+        { pos: 60, alignment: 'left', leader: 'none' },
+      ],
+    };
+    const placement = {
+      startYPt: 10,
+      paragraphXPt: 10,
+      availableWidthPt: 100,
+      maximumYPt: 500,
+      suppressSpaceBefore: false,
+    };
+    const measurer = { context: measureContext, fontFamilyClasses: {} };
+    const environment = {
+      documentHasEastAsianText: false,
+      pageWritingMode: 'horizontal-tb' as const,
+      pageIndex: 0,
+      totalPages: 1,
+    };
+    const measured = measureParagraph(
+      inlineParagraph as never,
+      context,
+      placement,
+      measurer,
+      environment,
+    );
+    const node = paragraphLayoutFromMeasurement(inlineParagraph as never, {
+      id: 'inline-wps', source, flowDomainId: 'body', ordinaryFlow: true,
+      context, placement, measurer, environment,
+      exclusions: [],
+    } as never, measured);
+
+    const placements = node.lines.flatMap((line) => line.placements)
+      .filter((item) => item.kind === 'drawing');
+    expect(placements.map((item) => item.bounds.xPt)).toEqual([10, 40, 70]);
+    expect(placements.map((item) => item.advancePt)).toEqual([20, 20, 20]);
+    expect(node.drawings.map((drawing) => drawing.flowBounds.xPt)).toEqual([10, 40, 70]);
+    expect(node.drawings.every((drawing) => drawing.anchorLayer === undefined)).toBe(true);
+  });
+
   it('retains selected-face anchor-host metrics instead of font-size ratios', () => {
     const paragraph = {
       alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,

--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -97,6 +97,7 @@ import {
   wordTextBoxVisibleAnchorExtentPt,
 } from './anchor-compatibility.js';
 import { wordRunVerticalAlignRaisePt } from './line-compatibility.js';
+import { wordFramePositionExtendsLineBox } from './body-pagination-compatibility.js';
 import {
   resolveFloatPlacement,
   type FloatPlacementParticipant,
@@ -254,6 +255,16 @@ export interface MeasuredUnavailableResourcePlanSegment {
   readonly drawingId: string;
 }
 
+export interface MeasuredInlineDrawingPlanSegment {
+  readonly kind: 'inline-drawing';
+  readonly range: import('./types.js').TextRange;
+  readonly measuredWidthPt: number;
+  readonly widthPt: number;
+  readonly heightPt: number;
+  readonly topOffsetPt: number;
+  readonly drawingId: string;
+}
+
 export interface MeasuredAnchorHostPlanSegment {
   readonly kind: 'anchor-host';
   readonly measuredWidthPt: 0;
@@ -267,6 +278,7 @@ export type MeasuredLinePlanSegment =
   | MeasuredTabPlanSegment
   | MeasuredResourcePlanSegment
   | MeasuredUnavailableResourcePlanSegment
+  | MeasuredInlineDrawingPlanSegment
   | MeasuredAnchorHostPlanSegment;
 
 export interface MeasuredLinePlanInput {
@@ -795,7 +807,7 @@ export function planLine(input: PlanLineInput): LineLayout {
         },
         advancePt: segment.measuredWidthPt,
       });
-    } else if (segment.kind === 'unavailable-resource') {
+    } else if (segment.kind === 'unavailable-resource' || segment.kind === 'inline-drawing') {
       placements.push({
         kind: 'drawing',
         range: segment.range,
@@ -1144,7 +1156,8 @@ function retainedBaselineOffsetPt(segment: LayoutTextSeg): number {
     segment.vertAlign,
     segment.fontSize,
   );
-  const raisePt = verticalAlignRaisePt + (segment.position ?? 0);
+  const raisePt = verticalAlignRaisePt
+    + (segment.lineRelativePosition ?? segment.position ?? 0);
   return raisePt === 0 ? 0 : -raisePt;
 }
 
@@ -1953,6 +1966,7 @@ function planMeasuredLines(
   paragraphXPt: number,
   availableWidthPt: number,
   source: SourceRef,
+  paragraphId: string,
   context: ParagraphLayoutContext,
   occurrences: LogicalOccurrenceMap,
   numberingPlan?: RetainedNumberingPlan,
@@ -2083,6 +2097,19 @@ function planMeasuredLines(
         if (image.anchor) continue;
         const runIndex = sourceRunIndex(segment);
         const occurrence = runSource(source, runIndex ?? 0);
+        if (image.inlineShape) {
+          segments.push({
+            kind: 'inline-drawing',
+            range: { start: segmentOffset, end: segmentOffset + occurrenceLength },
+            drawingId: `${paragraphId}:drawing:${runIndex ?? 0}`,
+            measuredWidthPt: image.measuredWidth,
+            widthPt: image.widthPt,
+            heightPt: image.heightPt,
+            topOffsetPt: -image.heightPt,
+          });
+          sourceOffset = Math.max(sourceOffset, segmentOffset + occurrenceLength);
+          continue;
+        }
         if (image.unavailableResourceKind) {
           segments.push({
             kind: 'unavailable-resource',
@@ -2353,22 +2380,27 @@ function drawingForShape(
   rect: LayoutRect,
   options: ParagraphAcquisitionOptions,
   runIndex: number,
+  inline = false,
 ): DrawingLayout {
+  const source = runSource(options.source, runIndex);
   const plan = planShapeDrawing(
     shape,
     rect,
     options.environment.layoutServices?.text,
     shape.vmlTextPathInput,
+    shape.fill?.fillType === 'image'
+      ? imageResourceKey(source, shape.fill.imagePath)
+      : undefined,
   );
   const commands = [plan.command];
-  const diagnostics = shapePlanDiagnostics(plan, runSource(options.source, runIndex));
+  const diagnostics = shapePlanDiagnostics(plan, source);
   return {
-    kind: 'drawing', id: `${options.id}:drawing:${runIndex}`, source: runSource(options.source, runIndex),
+    kind: 'drawing', id: `${options.id}:drawing:${runIndex}`, source,
     flowDomainId: options.flowDomainId, flowBounds: rect, inkBounds: rect, advancePt: 0,
     ordinaryFlow: false,
     commands,
     ...(diagnostics.length === 0 ? {} : { diagnostics }),
-    anchorLayer: {
+    ...(!inline ? { anchorLayer: {
       occurrenceId: `public-shape:${options.id}:${runIndex}`,
       behindDoc: shape.behindDoc === true,
       relativeHeight: Number.isFinite(shape.zOrder) ? shape.zOrder : runIndex,
@@ -2379,7 +2411,7 @@ function drawingForShape(
         || shape.anchorYRelativeFrom === 'character'
         || (!shape.anchorYRelativeFrom && shape.anchorYFromPara)
         ? 'host' : 'page',
-    },
+    } } : {}),
   };
 }
 
@@ -2954,6 +2986,9 @@ function acquireAnchorOccurrence(
         paintRect,
         options.environment.layoutServices?.text,
         run.vmlTextPathInput,
+        run.fill?.fillType === 'image'
+          ? imageResourceKey(source, run.fill.imagePath)
+          : undefined,
       );
       commands.push(plan.command);
       diagnostics.push(...shapePlanDiagnostics(plan, source));
@@ -4207,7 +4242,14 @@ export function acquireRetainedFrameGroup(
           context,
           placement,
           measurer: options.measurer,
-          environment: options.environment,
+          // `word-lowered-drop-cap-anchor-leading`: only a drop cap keeps its
+          // authored line count/height fixed while separately retained glyph
+          // lowering expands the following anchor exclusion. Ordinary frames
+          // keep positioned ink in their line boxes.
+          environment: {
+            ...options.environment,
+            positionExtendsLineBox: wordFramePositionExtendsLineBox(group.framePr.dropCap),
+          },
           exclusions: wrapRegistry.exclusions,
           anchorCollisions: wrapRegistry.collisions,
           containerShading: options.containerShading,
@@ -4277,7 +4319,7 @@ export function paragraphLayoutFromMeasurement(
     ? undefined
     : retainedNumberingPlan(paragraph, planningContext, options);
   let lines = planMeasuredLines(
-    measured, paragraph, paragraphXPt, availableWidthPt, options.source, planningContext,
+    measured, paragraph, paragraphXPt, availableWidthPt, options.source, options.id, planningContext,
     occurrences, numberingPlan, options.environment.layoutServices?.text,
     options.environment.verticalGlyphMeasurement,
     options.environment.verticalPageFrame,
@@ -4426,7 +4468,15 @@ export function paragraphLayoutFromMeasurement(
     if (run.type === 'shape' && !run.anchorAcquisitionInput && !options.continuesFromPrevious) {
       // Resolve the point-space box once. Shape panel paint, retained textbox
       // flow, and the line's drawing placement must own identical geometry.
-      const authoredShapeRect = resolvedShapeLayoutRect(run, options);
+      const drawingId = `${options.id}:drawing:${runIndex}`;
+      const inlinePlacement = run.inline === true
+        ? lines.flatMap((line) => line.placements).find((placement) =>
+            placement.kind === 'drawing' && placement.drawingId === drawingId)
+        : undefined;
+      if (run.inline === true && !inlinePlacement) {
+        throw new Error(`Inline shape ${drawingId} has no retained line placement`);
+      }
+      const authoredShapeRect = inlinePlacement?.bounds ?? resolvedShapeLayoutRect(run, options);
       const textBoxId = `${options.id}:textbox:${runIndex}`;
       const textBox = acquireShapeTextBoxLayout(run, authoredShapeRect, {
         id: textBoxId,
@@ -4438,14 +4488,17 @@ export function paragraphLayoutFromMeasurement(
         input: run.textBoxInput,
         acquireCompleteStory: options.acquireCompleteStory,
       });
-      const shapeRect = textBox?.flowBounds ?? authoredShapeRect;
-      let drawing = drawingForShape(run, shapeRect, options, runIndex);
+      // The wp:inline extent is the line-flow contract. A WPS text body may
+      // acquire richer internal geometry, but it must not move or resize the
+      // outer inline object after the line breaker has committed its advance.
+      const shapeRect = run.inline === true ? authoredShapeRect : textBox?.flowBounds ?? authoredShapeRect;
+      let drawing = drawingForShape(run, shapeRect, options, runIndex, run.inline === true);
       if (textBox) {
         textBoxes.push(textBox);
         drawing = { ...drawing, textBoxIds: [textBoxId] };
       }
       drawings.push(drawing);
-      const firstLine = lines[0];
+      const firstLine = run.inline === true ? undefined : lines[0];
       if (firstLine) {
         lines = [{
           ...firstLine,

--- a/packages/docx/src/layout/production-paint-resources.test.ts
+++ b/packages/docx/src/layout/production-paint-resources.test.ts
@@ -68,7 +68,12 @@ function documentModel(): DocxDocumentModel {
     }, {
       type: 'shape', widthPt: 50, heightPt: 30, anchorXPt: 0, anchorYPt: 0,
       anchorXFromMargin: false, anchorYFromPara: false, zOrder: 0, subpaths: [],
-      fill: null, stroke: null, textBlocks: [{
+      fill: {
+        fillType: 'image', imagePath: 'word/media/shape-fill.png', mimeType: 'image/png',
+        svgImagePath: 'word/media/shape-fill.svg',
+        srcRect: { l: .2, t: 0, r: .1, b: .05 },
+        alpha: .6, duotone: { clr1: '112233', clr2: 'DDEEFF' },
+      }, stroke: null, textBlocks: [{
         text: '', fontSizePt: 10, alignment: 'left', imagePath: 'word/media/textbox.png',
         mimeType: 'image/png', imageWidthPt: 9, imageHeightPt: 5,
       }],
@@ -87,6 +92,9 @@ describe('production paint resources', () => {
     const textBoxKey = imageResourceKey({
       story: 'textbox', storyInstance: 'body:body:0.3', path: [0, 0],
     }, 'word/media/textbox.png');
+    const shapeFillKey = imageResourceKey(
+      { ...body, path: [0, 3] }, 'word/media/shape-fill.png',
+    );
     const headerImageKey = imageResourceKey({
       story: 'header', storyInstance: 'default', path: [0, 0],
     }, 'word/media/header.png');
@@ -95,7 +103,7 @@ describe('production paint resources', () => {
     }, 'word/media/bullet.gif');
 
     expect(registry.keys).toEqual([
-      bulletKey, headerBulletKey, headerImageKey, imageKey, textBoxKey, chartKey, mathKey,
+      bulletKey, headerBulletKey, headerImageKey, imageKey, shapeFillKey, textBoxKey, chartKey, mathKey,
     ].sort((left, right) => left.localeCompare(right)));
     expect(registry.resolve(imageKey, 'image')).toMatchObject({
       partPath: 'word/media/image.png', svgImagePath: 'word/media/image.svg',
@@ -105,6 +113,13 @@ describe('production paint resources', () => {
       duotone: { clr1: '000000', clr2: 'FFFFFF' },
     });
     expect(registry.resolve(chartKey, 'chart').model.chartType).toBe('line');
+    expect(registry.resolve(shapeFillKey, 'image')).toMatchObject({
+      partPath: 'word/media/shape-fill.png',
+      intrinsicSize: { widthPt: 50, heightPt: 30 },
+      svgImagePath: 'word/media/shape-fill.svg',
+      srcRect: { l: .2, t: 0, r: .1, b: .05 },
+      alpha: .6, duotone: { clr1: '112233', clr2: 'DDEEFF' },
+    });
     expect(registry.resolve(bulletKey, 'picture-bullet')).toMatchObject({
       partPath: 'word/media/bullet.gif', intrinsicSize: { widthPt: 6, heightPt: 7 },
     });

--- a/packages/docx/src/layout/production-paint-resources.ts
+++ b/packages/docx/src/layout/production-paint-resources.ts
@@ -85,6 +85,22 @@ function collectDescriptorCandidates(
     }
     if (run.type !== 'shape') return;
     const shape = run as ShapeRun & Readonly<{ textBoxContent?: BodyElement[] }>;
+    if (shape.fill?.fillType === 'image') {
+      addImage(
+        'image', source, shape.fill.imagePath, shape.fill.mimeType,
+        shape.widthPt, shape.heightPt,
+        {
+          ...(shape.fill.svgImagePath === undefined ? {} : {
+            svgImagePath: shape.fill.svgImagePath,
+          }),
+          ...(shape.fill.srcRect === undefined ? {} : {
+            srcRect: { ...shape.fill.srcRect },
+          }),
+          ...(shape.fill.alpha === undefined ? {} : { alpha: shape.fill.alpha }),
+          ...(shape.fill.duotone === undefined ? {} : { duotone: shape.fill.duotone }),
+        },
+      );
+    }
     const storyInstance = `${source.story}:${source.storyInstance}:${source.path.join('.')}`;
     if (shape.textBoxContent !== undefined) {
       visitBody(shape.textBoxContent, 'textbox', storyInstance);

--- a/packages/docx/src/layout/retained-geometry-translation.ts
+++ b/packages/docx/src/layout/retained-geometry-translation.ts
@@ -60,7 +60,7 @@ function translateClip(clip: ClipPathData, delta: LayoutTranslation): ClipPathDa
 
 function translateDrawingCommand(command: DrawingPaintCommand, delta: LayoutTranslation): DrawingPaintCommand {
   if (command.kind === 'noop') return command;
-  if (command.kind === 'drawingml-shape') return {
+  if (command.kind === 'drawingml-shape' || command.kind === 'drawingml-image-fill') return {
     ...command,
     plan: { ...command.plan, rect: {
       ...command.plan.rect,

--- a/packages/docx/src/layout/services-integration.test.ts
+++ b/packages/docx/src/layout/services-integration.test.ts
@@ -110,6 +110,20 @@ describe('production layout service integration', () => {
     expect(lines[0].segments.map((segment) => 'text' in segment ? segment.text : '')).toEqual(['a', '\u0301']);
   });
 
+  it('normalizes service-backed w:sym private encoding before measurement and paint', () => {
+    const services = createLayoutServices(model(), { measureContext: measureContext() });
+    const segments = buildSegments([textRun('\uF0B0', {
+      fontFamily: 'Symbol',
+      fontFamilyHighAnsi: 'Symbol',
+      fontFamilyEastAsia: 'Symbol',
+    })], { pageIndex: 0, totalPages: 1, layoutServices: services });
+    const text = segments.filter((segment) => 'text' in segment);
+
+    expect(text).toHaveLength(1);
+    expect(text[0]).toMatchObject({ text: '°' });
+    expect((text[0] as { fontFamily?: string | null }).fontFamily).not.toBe('Symbol');
+  });
+
   it('carries the w:kern threshold through the text service measure adapter', () => {
     let fontKerning: CanvasFontKerning = 'auto';
     const states: CanvasFontKerning[] = [];

--- a/packages/docx/src/layout/shape-drawing-plan.test.ts
+++ b/packages/docx/src/layout/shape-drawing-plan.test.ts
@@ -86,6 +86,49 @@ describe('ShapeRun drawing command planner', () => {
     });
   });
 
+  it('plans a stretched blip fill as a resource clipped by the shape geometry', () => {
+    const result = planShapeDrawing(shape({
+      fill: {
+        fillType: 'image', imagePath: 'word/media/overlay.png', mimeType: 'image/png',
+        fillRect: { l: 0, t: 0, r: -0.07574, b: 0 }, alpha: 0.5,
+      },
+    }), { xPt: 1, yPt: 2, widthPt: 100, heightPt: 40 }, undefined, undefined, 'image:key');
+
+    expect(result).toMatchObject({
+      status: 'planned',
+      command: {
+        kind: 'drawingml-image-fill',
+        resourceKey: 'image:key',
+        fillRect: { l: 0, t: 0, r: -0.07574, b: 0 },
+        plan: {
+          rect: { x: 1, y: 2, w: 100, h: 40 },
+          fill: null,
+          geometry: { kind: 'preset', name: 'rect' },
+        },
+      },
+    });
+    expect(structuredClone(result.command)).toEqual(result.command);
+  });
+
+  it('diagnoses tiled blip fills instead of silently stretching them', () => {
+    const result = planShapeDrawing(shape({
+      fill: {
+        fillType: 'image', imagePath: 'word/media/tile.png', mimeType: 'image/png',
+        tile: { tx: 0, ty: 0, sx: 1, sy: 1, flip: 'none' },
+      },
+    }), { xPt: 0, yPt: 0, widthPt: 100, heightPt: 40 }, undefined, undefined, 'image:tile');
+
+    expect(result).toEqual({
+      status: 'unsupported',
+      command: { kind: 'noop' },
+      diagnostics: [{
+        code: 'UNSUPPORTED_FEATURE',
+        severity: 'error',
+        message: 'Tiled DrawingML shape image fills are not rendered',
+      }],
+    });
+  });
+
   it('retains authored textPath shaping and fitshape geometry as a clone-safe command', () => {
     const requests: Parameters<TextLayoutService['shape']>[0][] = [];
     const text = {

--- a/packages/docx/src/layout/shape-drawing-plan.ts
+++ b/packages/docx/src/layout/shape-drawing-plan.ts
@@ -12,7 +12,7 @@ import type { TextLayoutService } from './text.js';
 
 type ShapeDrawingCommand = Extract<
   DrawingPaintCommand,
-  { kind: 'noop' | 'drawingml-shape' | 'watermark-text' }
+  { kind: 'noop' | 'drawingml-shape' | 'drawingml-image-fill' | 'watermark-text' }
 >;
 
 export type ShapeDrawingPlanResult =
@@ -66,6 +66,7 @@ export function planShapeDrawing(
   bounds: LayoutRect,
   text?: TextLayoutService,
   textPath?: Readonly<VmlTextPathAcquisitionInput>,
+  imageFillResourceKey?: string,
 ): ShapeDrawingPlanResult {
   const parserControlled = textPath !== undefined && (
     textPath.textPathOk !== undefined
@@ -84,6 +85,9 @@ export function planShapeDrawing(
       : true
   );
   if (textPathEnabled) {
+    if (shape.fill?.fillType === 'image') {
+      return unsupportedTextPathPlan('VML textPath with a DrawingML image fill is not rendered');
+    }
     if (textPath.fitPath === true) {
       return unsupportedTextPathPlan('VML textPath fitPath=true is not rendered');
     }
@@ -192,7 +196,7 @@ export function planShapeDrawing(
           kind: 'custom',
           subpaths: shape.subpaths.map((subpath) => subpath.map((command) => ({ ...command }))),
         },
-    fill: shape.fill ? { ...shape.fill, ...(shape.fill.fillType === 'gradient'
+    fill: shape.fill && shape.fill.fillType !== 'image' ? { ...shape.fill, ...(shape.fill.fillType === 'gradient'
       ? { stops: shape.fill.stops.map((stop) => ({ ...stop })) }
       : {}) } : null,
     stroke: shapeStroke(shape),
@@ -202,6 +206,38 @@ export function planShapeDrawing(
       flipV: shape.flipV ?? false,
     },
   };
+  if (shape.fill?.fillType === 'image') {
+    if (shape.fill.tile !== undefined) {
+      return Object.freeze({
+        status: 'unsupported',
+        command: Object.freeze({ kind: 'noop' }),
+        diagnostics: Object.freeze([Object.freeze({
+          code: 'UNSUPPORTED_FEATURE',
+          severity: 'error',
+          message: 'Tiled DrawingML shape image fills are not rendered',
+        })]),
+      });
+    }
+    if (!imageFillResourceKey) {
+      throw new Error('DrawingML shape image fill requires a retained image resource key');
+    }
+    return Object.freeze({
+      status: 'planned',
+      command: snapshotPlainData({
+        kind: 'drawingml-image-fill' as const,
+        plan,
+        resourceKey: imageFillResourceKey,
+        ...(shape.fill.fillRect === undefined ? {} : {
+          fillRect: {
+            l: shape.fill.fillRect.l ?? 0,
+            t: shape.fill.fillRect.t ?? 0,
+            r: shape.fill.fillRect.r ?? 0,
+            b: shape.fill.fillRect.b ?? 0,
+          },
+        }),
+      }, 'DrawingML shape image-fill command'),
+    });
+  }
   return Object.freeze({
     status: 'planned',
     command: snapshotPlainData(

--- a/packages/docx/src/layout/types.ts
+++ b/packages/docx/src/layout/types.ts
@@ -121,6 +121,13 @@ export type DrawingPaintCommand =
       plan: DeepReadonly<DrawingMLShapePaintPlan>;
     }>
   | Readonly<{
+      /** A retained image resource clipped to the authored DrawingML shape. */
+      kind: 'drawingml-image-fill';
+      plan: DeepReadonly<DrawingMLShapePaintPlan>;
+      resourceKey: string;
+      fillRect?: Readonly<{ l: number; t: number; r: number; b: number }>;
+    }>
+  | Readonly<{
       kind: 'fill-rect';
       rect: LayoutRect;
       fill: string;

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -614,8 +614,8 @@ export interface LineLayoutEnvironment {
   readonly verticalGlyphMeasurement?: VerticalGlyphMeasurementService;
   /** ECMA-376 §17.15.1.18 document-wide full-width character compression. */
   readonly characterSpacingControl?: string;
-  /** False only for the Word-compatible fixed-line-count drop-cap frame path,
-   * whose authored frame height remains authoritative even when glyph paint is
+  /** False only when `w:framePr` specifies a drop cap with a fixed `w:lines`;
+   * the authored frame height remains authoritative even when glyph paint is
    * lowered beyond it. Folded into retained text segments during acquisition. */
   readonly positionExtendsLineBox?: boolean;
 }

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -97,6 +97,7 @@ import {
   wordIsOverflowPunctuation,
   wordJapanesePunctuationRetainedExtentPt,
   wordMsMinchoEmptyEastAsianMarkSingleLinePx,
+  wordUniformRunPositionPaintPt,
   wordUseFeLayoutParagraphMarkGridAdvancePx,
 } from './layout/line-compatibility.js';
 import { wordNeutralAttachesToActiveScript } from './layout/script-compatibility.js';
@@ -259,8 +260,17 @@ export interface LayoutTextSeg extends LayoutSegSource {
   fitTextRegionEnd?: boolean;
   /** ECMA-376 §17.3.2.24 `<w:position>` — baseline raise(+)/lower(−) in POINTS,
    *  applied as a y-offset to the glyphs and decorations without changing the
-   *  font size or the line box. Absent ⇒ 0. */
+   *  font size. Absent ⇒ 0. */
   position?: number;
+  /** Line-relative baseline shift in points, resolved when the line is closed.
+   * When every metric-bearing item has the same `position`, half of the common
+   * displacement is retained so its enlarged line box shares the surplus above
+   * and below the glyphs. The authored, style-resolved value remains in
+   * `position` for the retained model. */
+  lineRelativePosition?: number;
+  /** Whether shifted ink contributes to this retained segment's line extent.
+   * False only for the fixed-line-count drop-cap compatibility projection. */
+  positionExtendsLineBox?: boolean;
   /** ECMA-376 §17.3.2.19 `<w:kern>` — font-kerning threshold in POINTS (smallest
    *  kerned size). Sets `ctx.fontKerning` on measure and paint when the run's
    *  font size ≥ the threshold. Absent ⇒ kerning off (`ctx.fontKerning='none'`
@@ -427,6 +437,9 @@ export interface LayoutImageSeg extends LayoutSegSource {
    *  walk keys off `run.type === 'image'` and never sees a chart run). */
   chart?: true;
   chartResourceKey?: string;
+  /** ECMA-376 §20.4.2.8 — this image-shaped line segment reserves the inline
+   * WPS shape's extent; paint is owned by the paragraph's retained drawing. */
+  inlineShape?: true;
   /** Parser-private retained placeholder for a recognized payload whose
    * package part is unavailable. It participates in line/anchor geometry but
    * never enters the paint resource registry. */
@@ -601,6 +614,10 @@ export interface LineLayoutEnvironment {
   readonly verticalGlyphMeasurement?: VerticalGlyphMeasurementService;
   /** ECMA-376 §17.15.1.18 document-wide full-width character compression. */
   readonly characterSpacingControl?: string;
+  /** False only for the Word-compatible fixed-line-count drop-cap frame path,
+   * whose authored frame height remains authoritative even when glyph paint is
+   * lowered beyond it. Folded into retained text segments during acquisition. */
+  readonly positionExtendsLineBox?: boolean;
 }
 
 // ── Math (OMML) rendering via MathJax ───────────────────────────────────────
@@ -2523,6 +2540,33 @@ export function buildSegments(
     sourceFragmentIndex?: number,
   ) => {
     const r: ParagraphTextBearingRun = base;
+    const acquiredTypography = (r as ParagraphTextBearingRun & Readonly<{
+      typographyInput?: import('./layout/typography-input.js').RunTypographyAcquisitionInput;
+    }>).typographyInput;
+    // ECMA-376 §17.16.18 stores a complex field's instruction/result across
+    // several physical runs. The parser rebuilds recomputed PAGE/NUMPAGES as a
+    // single FieldRun, while its complete effective §17.3.2 run properties live
+    // on the immutable typography acquisition sidecar. Consume those effective
+    // facts exactly like an ordinary text run so the field result does not lose
+    // baseline position or the core character-metric axes used by measure/paint.
+    const acquiredValue = <T>(
+      value: import('./layout/typography-input.js').TypographyValueInput<T> | undefined,
+      fallback: T | undefined,
+    ): T | undefined => value?.status === 'valid' && value.value !== null
+      ? value.value
+      : fallback;
+    const effectiveVertAlign = acquiredValue(
+      acquiredTypography?.verticalAlign,
+      vertAlign ?? undefined,
+    ) ?? null;
+    const effectivePosition = acquiredValue(
+      acquiredTypography?.positionPt,
+      r.position,
+    );
+    const effectiveCharacterSpacing = acquiredTypography?.characterSpacingPt ?? r.charSpacing;
+    const effectiveCharacterScale = acquiredTypography?.characterScale ?? r.charScale;
+    const effectiveKerningThreshold = acquiredTypography?.kerningThresholdPt ?? r.kerning;
+    const effectiveSnapToGrid = acquiredTypography?.snapToGrid ?? r.snapToGrid;
     // §17.3.2.33 small caps are sized per character: lowercase LETTERS render two
     // points smaller, uppercase letters and non-alphabetic characters at the full
     // run size. `reduced` (set per case-piece in the loop below) carries that onto
@@ -2611,6 +2655,7 @@ export function buildSegments(
       fontFamily: string | null,
       authoritativeSpan?: TextShapeSpan,
       compressCharacterWhitespace = false,
+      mappedSymbolUnicode = false,
     ) => {
       // ECMA-376 §17.15.1.18 / §17.18.7 — dispatch the exact
       // ST_CharacterSpacing value and split each eligible full-width character
@@ -2629,7 +2674,7 @@ export function buildSegments(
             grapheme,
             environment.characterSpacingControl,
           ))) {
-          pushSeg(text, cs, fontFamily, undefined, true);
+          pushSeg(text, cs, fontFamily, undefined, true, mappedSymbolUnicode);
           return;
         }
       }
@@ -2640,22 +2685,29 @@ export function buildSegments(
       const textShapeRequest: TextShapeRequest = Object.freeze({
         text,
         fontSizePt: cs ? csFontSize : base.fontSize,
-        fonts: r.fontSlots?.direct ?? {
-          ascii: base.fontFamily,
-          highAnsi: highAnsiFontFamily,
-          eastAsia: eaFontFamily,
-          complexScript: csFontFamily,
-        },
-        themeFonts: r.fontSlots?.theme,
-        themeFontPresence: r.fontSlots?.themePresent,
+        // A successfully decoded Symbol/Wingdings code point is Unicode text,
+        // not a request for the legacy font encoding. Clear every authored
+        // slot so the text service resolves a Unicode-capable generic route;
+        // otherwise its §17.3.2.26 slot resolver selects Symbol again and the
+        // mapped character can still be drawn with the wrong cmap.
+        fonts: mappedSymbolUnicode
+          ? { ascii: null, highAnsi: null, eastAsia: null, complexScript: null }
+          : r.fontSlots?.direct ?? {
+              ascii: base.fontFamily,
+              highAnsi: highAnsiFontFamily,
+              eastAsia: eaFontFamily,
+              complexScript: csFontFamily,
+            },
+        themeFonts: mappedSymbolUnicode ? undefined : r.fontSlots?.theme,
+        themeFontPresence: mappedSymbolUnicode ? undefined : r.fontSlots?.themePresent,
         weight,
         style,
         complexScript: cs,
         fontHint: r.fontHint,
         eastAsiaLanguage: r.langEastAsia,
-        kerning: r.kerning == null
+        kerning: effectiveKerningThreshold == null
           ? undefined
-          : (cs ? csFontSize : base.fontSize) >= r.kerning,
+          : (cs ? csFontSize : base.fontSize) >= effectiveKerningThreshold,
         measure: false,
       });
       const shaped = authoritativeSpan
@@ -2735,7 +2787,7 @@ export function buildSegments(
               : 0;
             // §17.3.2.43 w:w scales the glyph and both of its sidebearings;
             // trim in the same post-scale coordinate space as segAdvanceWidth.
-            const removablePt = removableUnscaledPt * (r.charScale ?? 1);
+            const removablePt = removableUnscaledPt * (effectiveCharacterScale ?? 1);
               if (removablePt > 0) {
                 compressions.push({ end, adjustmentPt: -removablePt });
               }
@@ -2832,7 +2884,7 @@ export function buildSegments(
         fontFamily: resolvedSpan?.font.resolvedFamily ?? localFont?.family ?? fontFamily,
         fontRoute: resolvedSpan?.fontRoute,
         resolvedLineHeightRatio: familyLineMetric?.lineHeightRatio,
-        vertAlign,
+        vertAlign: effectiveVertAlign,
         measuredWidth: 0,
         textLayoutService: environment.layoutServices?.text,
         textShapeRequest,
@@ -2861,21 +2913,22 @@ export function buildSegments(
         // IX1 — resolved hyperlink target of the originating run, for the
         // text-layer clickable overlay. Does not affect layout or drawing.
         hyperlink,
-        snapToCharacterGrid: r.snapToGrid !== false,
+        snapToCharacterGrid: effectiveSnapToGrid !== false,
         // WD4 — run character metrics (§17.3.2.35 spacing / §17.3.2.43 w /
         // §17.3.2.24 position / §17.3.2.19 kern). Uniform across the run, so
         // every emitted segment carries the same values; the measure and paint
         // passes apply them identically (measure==paint).
-        charSpacing: r.charSpacing,
+        charSpacing: effectiveCharacterSpacing,
         punctuationCompressions,
         eastAsiaLanguage: r.langEastAsia,
-        charScale: r.charScale,
+        charScale: effectiveCharacterScale,
         fitTextVal: fitTextRegionIndex === undefined ? undefined : r.fitTextVal,
         fitTextId: fitTextRegionIndex === undefined ? undefined : r.fitTextId,
         fitTextRegionIndex,
         fitTextRunIndex: fitTextRegionIndex === undefined ? undefined : fitTextFragmentEntryIndex,
-        position: r.position,
-        kerning: r.kerning,
+        position: effectivePosition,
+        positionExtendsLineBox: environment.positionExtendsLineBox !== false,
+        kerning: effectiveKerningThreshold,
         // ECMA-376 §17.3.2.10 eastAsianLayout — 縦中横 is meaningful ONLY in a
         // vertical (tbRl) page, so fold the vertical gate in HERE at build time
         // (buildSegments receives it through LineLayoutEnvironment). Measure/paint then read a single
@@ -2912,7 +2965,14 @@ export function buildSegments(
       // build time so measure==draw (the seg.text is never transformed later).
       if (isSymbolFontFamily(fontFamily)) {
         for (const part of symbolTextToUnicodeSegments(word, fontFamily)) {
-          pushSeg(part.text, cs, part.mapped ? null : fontFamily);
+          pushSeg(
+            part.text,
+            cs,
+            part.mapped ? null : fontFamily,
+            undefined,
+            false,
+            part.mapped,
+          );
         }
         return;
       }
@@ -2925,6 +2985,15 @@ export function buildSegments(
     // sits next to a gothic eastAsia title) without changing the cs path.
     const emitNonCs = (slice: string) => {
       if (environment.layoutServices?.text) {
+        // `w:sym` is parsed as a one-run private-encoding character carrying
+        // its own Symbol/Wingdings family (§17.3.3.30). Keep normalization in
+        // front of the service-backed script splitter as well as the legacy
+        // path; otherwise a PUA code point such as Symbol F0B0 reaches Canvas
+        // unchanged and renders as tofu.
+        if (isSymbolFontFamily(base.fontFamily)) {
+          emit(slice, 'latin');
+          return;
+        }
         pushSeg(slice, false, base.fontFamily);
         return;
       }
@@ -3056,6 +3125,24 @@ export function buildSegments(
         anchorYFromPara: chartRun.anchorYFromPara ?? false,
         chart: true,
         chartResourceKey: (chartRun as Partial<import('./layout/text.js').ParagraphChartRun>).resourceKey,
+        measuredWidth: 0,
+      });
+    } else if (run.type === 'shape' && run.inline === true) {
+      // `wp:inline` hosts arbitrary DrawingML, including WPS shapes (§20.4.2.8).
+      // Reserve its extent in the same line-breaking path as an inline picture;
+      // paragraph acquisition replaces the sentinel with a retained drawing
+      // placement at the resolved pen position.
+      segs.push({
+        imagePath: '',
+        mimeType: '',
+        widthPt: run.widthPt,
+        heightPt: run.heightPt,
+        anchor: false,
+        anchorXPt: 0,
+        anchorYPt: 0,
+        anchorXFromMargin: false,
+        anchorYFromPara: false,
+        inlineShape: true,
         measuredWidth: 0,
       });
     } else if (run.type === 'unavailableDrawing') {
@@ -3558,6 +3645,45 @@ export function layoutLines(
     nextStart?: LineBoundary,
   ) => {
     applyBidiTabs();
+    // §17.3.2.24 defines `position` relative to surrounding non-positioned
+    // text. A line whose every metric-bearing item shares the same inherited
+    // position has no differently-positioned peer to pin the resulting extra
+    // line height to one side. `word-uniform-run-position-leading` owns Word's
+    // observed placement of that surplus above and below the glyphs. Keep mixed
+    // lines relative to zero so their authored displacement and ink union
+    // remain unchanged. Images/math
+    // provide a zero-position reference; tabs do not contribute vertical
+    // metrics. The fixed drop-cap path intentionally keeps its paint-only
+    // lowering and therefore opts out of this normalization.
+    let commonPositionPt: number | undefined;
+    let hasPositionReference = false;
+    for (const segment of currentLine) {
+      if ('isTab' in segment) continue;
+      const positionPt = 'text' in segment ? (segment.position ?? 0) : 0;
+      if ('text' in segment && segment.positionExtendsLineBox === false) {
+        commonPositionPt = 0;
+        hasPositionReference = true;
+        break;
+      }
+      if (!hasPositionReference) {
+        commonPositionPt = positionPt;
+        hasPositionReference = true;
+      } else if (commonPositionPt !== positionPt) {
+        commonPositionPt = 0;
+        break;
+      }
+    }
+    const linePositionReferencePt = hasPositionReference ? (commonPositionPt ?? 0) : 0;
+    if (linePositionReferencePt !== 0) {
+      for (const segment of currentLine) {
+        if ('text' in segment) {
+          segment.lineRelativePosition = wordUniformRunPositionPaintPt(
+            segment.position ?? 0,
+            linePositionReferencePt,
+          );
+        }
+      }
+    }
     // §17.3.3.1 — the break is one run among the line's runs: its own size
     // participates in the line height but must not override a taller peer.
     const h = forceHeight !== undefined ? Math.max(lineHeight, forceHeight) : (lineHeight || 10);
@@ -4284,7 +4410,18 @@ export function layoutLines(
       (s.metricEastAsian === true || EAST_ASIAN_RE.test(s.text)) && !s.ruby,
     );
     let asc = corrected.ascent;
-    const desc = corrected.descent;
+    let desc = corrected.descent;
+    // ECMA-376 §17.3.2.24 positions the run relative to the surrounding
+    // default baseline. Its shifted ink therefore contributes to the line's
+    // visible block extent: a raised run extends the ascent, while a lowered
+    // run extends the descent. Keeping the shift paint-only made an all-raised
+    // paragraph start above its retained line box, so table borders crossed the
+    // glyphs and row/body pagination under-counted the painted extent.
+    if (s.positionExtendsLineBox !== false) {
+      const positionPx = (s.position ?? 0) * scale;
+      if (positionPx > 0) asc += positionPx;
+      else if (positionPx < 0) desc -= positionPx;
+    }
     // Ruby annotation: reserve exact authored hpsRaise or selected-face
     // base/guide ink before the paragraph-wide docGrid pitch snap.
     if (s.ruby && (!s.textBoxLineFloor || s.textBoxVertical)) {

--- a/packages/docx/src/page-number-field-render.test.ts
+++ b/packages/docx/src/page-number-field-render.test.ts
@@ -36,10 +36,16 @@ function makeCtx(): CanvasRenderingContext2D {
   return ctx as unknown as CanvasRenderingContext2D;
 }
 
-function makeRecordingCanvas(): { canvas: HTMLCanvasElement; texts: string[] } {
+type TextDraw = Readonly<{ text: string; x: number; y: number }>;
+
+function makeRecordingCanvas(): { canvas: HTMLCanvasElement; texts: string[]; draws: TextDraw[] } {
   const texts: string[] = [];
+  const draws: TextDraw[] = [];
   const ctx = makeCtx() as CanvasRenderingContext2D & Record<string, unknown>;
-  ctx.fillText = (text: string) => { texts.push(text); };
+  ctx.fillText = (text: string, x: number, y: number) => {
+    texts.push(text);
+    draws.push({ text, x, y });
+  };
   Object.assign(ctx, {
     setTransform() {}, clearRect() {}, closePath() {}, rect() {}, clip() {},
     translate() {}, rotate() {}, scale() {}, setLineDash() {}, arc() {},
@@ -52,7 +58,7 @@ function makeRecordingCanvas(): { canvas: HTMLCanvasElement; texts: string[] } {
     height: 0,
     getContext: () => ctx,
   } as unknown as HTMLCanvasElement;
-  return { canvas, texts };
+  return { canvas, texts, draws };
 }
 
 // OffscreenCanvas polyfill (paginateWithHeaderFooterReserve builds its measure ctx
@@ -74,6 +80,15 @@ function pageFieldRun(instruction = 'PAGE', fontSize = 20): DocRun {
   const f: FieldRun = {
     fieldType: 'page', instruction, fallbackText: '?',
     bold: false, italic: false, underline: false, strikethrough: false,
+    fontSize, color: null, fontFamily: 'NotInMetrics', background: null, vertAlign: null,
+  } as unknown as FieldRun;
+  return { type: 'field', ...f } as DocRun;
+}
+
+function numPagesFieldRun(fontSize = 10): DocRun {
+  const f: FieldRun = {
+    fieldType: 'numPages', instruction: 'NUMPAGES', fallbackText: '8',
+    bold: true, italic: false, underline: false, strikethrough: false,
     fontSize, color: null, fontFamily: 'NotInMetrics', background: null, vertAlign: null,
   } as unknown as FieldRun;
   return { type: 'field', ...f } as DocRun;
@@ -306,5 +321,61 @@ describe('PAGE field renders the per-section displayed number (footer)', () => {
     // 6 lines, 5 per page ⇒ 2 pages: footers "1" and "2".
     expect(await footerTexts(doc, 0)).toContain('1');
     expect(await footerTexts(doc, 1)).toContain('2');
+  });
+
+  it('keeps recomputed PAGE and NUMPAGES on the authored run-position baseline', async () => {
+    // §17.16.18 complex-field delimiters split one displayed result across
+    // physical runs. The instruction run inherits w:position=6 (3pt) through
+    // the style hierarchy; the recomputed field must retain that effective
+    // §17.3.2.24 position instead of dropping to the unshifted baseline.
+    const positionedTypography = {
+      strike: false, doubleStrike: false, caps: false, smallCaps: false, colorAuto: false,
+      verticalAlign: { status: 'missing', raw: null, value: null },
+      positionPt: { status: 'valid', raw: '6', value: 3 },
+      snapToGrid: null, characterSpacingPt: null, characterScale: null,
+      kerningThresholdPt: null,
+      emphasis: { status: 'missing', raw: null, value: null },
+      languages: { eastAsia: null, bidi: null },
+      eastAsianLayout: {
+        vert: null, vertCompress: null, combine: null,
+        combineBrackets: { status: 'missing', raw: null, value: null },
+      },
+    } as const;
+    const positionedText = (text: string): DocRun => ({
+      ...textRun(text, 10), position: 3,
+    } as DocRun);
+    const positionedField = (field: DocRun): DocRun => ({
+      ...field, __typographyAcquisition: positionedTypography,
+    } as unknown as DocRun);
+    const footer: HeaderFooter = { body: [{
+      type: 'paragraph', alignment: 'left', indentLeft: 0, indentRight: 0, indentFirst: 0,
+      spaceBefore: 0, spaceAfter: 0, lineSpacing: null, numbering: null, tabStops: [],
+      runs: [
+        positionedText('Page '),
+        positionedField(pageFieldRun('PAGE', 10)),
+        positionedText(' of '),
+        positionedField(numPagesFieldRun()),
+      ],
+      defaultFontSize: 10, defaultFontFamily: 'NotInMetrics', widowControl: false,
+    } as unknown as BodyElement] };
+    const section: SectionProps = {
+      ...GEOM(), titlePage: false, evenAndOddHeaders: false,
+    } as unknown as SectionProps;
+    const doc = {
+      section,
+      // 56 × 20pt lines at five lines/page ⇒ 12 pages, so the runtime NUMPAGES
+      // value is two digits even though its cached fallback is one digit.
+      body: Array.from({ length: 56 }, (_, index) => para(`L${index}`)),
+      headers: { default: null, first: null, even: null },
+      footers: { default: footer, first: null, even: null },
+      fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const { canvas, draws } = makeRecordingCanvas();
+
+    await renderDocumentToCanvas(doc, canvas, 0, { dpr: 1 });
+
+    const footerDraws = draws.filter(({ text }) => ['Page ', '1', '12'].includes(text));
+    expect(footerDraws.map(({ text }) => text)).toEqual(['Page ', '1', '12']);
+    expect(new Set(footerDraws.map(({ y }) => y)).size).toBe(1);
   });
 });

--- a/packages/docx/src/paint/canvas-drawing-shape.test.ts
+++ b/packages/docx/src/paint/canvas-drawing-shape.test.ts
@@ -39,6 +39,7 @@ function recordingContext(): { context: CanvasPaintContext; operations: string[]
     moveTo: () => operations.push('moveTo'),
     lineTo: () => operations.push('lineTo'),
     closePath: () => operations.push('closePath'),
+    clip: () => operations.push('clip'),
     rect: () => operations.push('rect'),
     fill: () => operations.push('fill'),
     stroke: () => operations.push('stroke'),
@@ -65,6 +66,44 @@ function recordingContext(): { context: CanvasPaintContext; operations: string[]
 }
 
 describe('retained DrawingML shape painting', () => {
+  it('clips a retained image resource to the DrawingML geometry and applies fillRect overscan', () => {
+    const { context, operations } = recordingContext();
+    const painted: unknown[] = [];
+    const resourceContext: CanvasPaintContext = {
+      ...context,
+      resources: {
+        paint: (resourceKey, kind, bounds) => painted.push(resourceKey, kind, bounds),
+      },
+    };
+    const bounds = { xPt: 10, yPt: 20, widthPt: 100, heightPt: 50 };
+    const drawing: DrawingLayout = {
+      kind: 'drawing', id: 'image-fill',
+      source: { story: 'header', storyInstance: 'default', path: [0] },
+      flowDomainId: 'header', flowBounds: bounds, inkBounds: bounds,
+      advancePt: 0, ordinaryFlow: false,
+      commands: [{
+        kind: 'drawingml-image-fill', resourceKey: 'image:overlay',
+        fillRect: { l: 0.1, t: 0, r: -0.05, b: 0.2 },
+        plan: {
+          rect: { x: 10, y: 20, w: 100, h: 50 },
+          geometry: { kind: 'preset', name: 'rect', adjustments: [] },
+          fill: null, stroke: { color: '000000', width: 1 },
+          transform: { rotationDeg: 0, flipH: false, flipV: false },
+        },
+      }],
+    };
+
+    paintDrawingLayout(drawing, resourceContext);
+
+    expect(painted).toEqual([
+      'image:overlay', 'image',
+      { xPt: 20, yPt: 20, widthPt: 95, heightPt: 40 },
+    ]);
+    expect(operations).toContain('clip');
+    expect(operations).toContain('stroke');
+    expect(operations).not.toContain('fill');
+  });
+
   it('counter-rotates one upright physical frame around a shape and its owned text box', () => {
     const { context, operations } = recordingContext();
     const localBounds = { xPt: -40, yPt: -15, widthPt: 80, heightPt: 30 };

--- a/packages/docx/src/paint/canvas-drawing.ts
+++ b/packages/docx/src/paint/canvas-drawing.ts
@@ -1,6 +1,12 @@
 import type { DrawingLayout } from '../layout/types.js';
 import type { CanvasPaintContext } from './types.js';
-import { canvasFontString, paintDrawingMLShape, resolveFill } from '@silurus/ooxml-core';
+import {
+  canvasFontString,
+  clipDrawingMLShape,
+  paintDrawingMLShape,
+  resolveFill,
+  withDrawingMLShapeTransform,
+} from '@silurus/ooxml-core';
 import { paintRetainedResource } from './canvas-resource.js';
 
 export function paintDrawingLayout(node: DrawingLayout, context: CanvasPaintContext): void {
@@ -9,6 +15,44 @@ export function paintDrawingLayout(node: DrawingLayout, context: CanvasPaintCont
     if (command.kind === 'drawingml-shape') {
       // Page setup already maps retained point coordinates to device pixels. A
       // second scale here would multiply stroke widths and arrowhead geometry.
+      paintDrawingMLShape(
+        context.ctx as CanvasRenderingContext2D,
+        command.plan,
+        1,
+      );
+      continue;
+    }
+    if (command.kind === 'drawingml-image-fill') {
+      if (!context.resources) throw new Error(`Missing retained resource painter for ${command.resourceKey}`);
+      const { x, y, w, h } = command.plan.rect;
+      const fillRect = command.fillRect ?? { l: 0, t: 0, r: 0, b: 0 };
+      const destination = {
+        xPt: x + fillRect.l * w,
+        yPt: y + fillRect.t * h,
+        widthPt: w * (1 - fillRect.l - fillRect.r),
+        heightPt: h * (1 - fillRect.t - fillRect.b),
+      };
+      if (destination.widthPt > 0 && destination.heightPt > 0) {
+        withDrawingMLShapeTransform(
+          context.ctx as CanvasRenderingContext2D,
+          command.plan,
+          () => {
+            clipDrawingMLShape(
+              context.ctx as CanvasRenderingContext2D,
+              command.plan,
+            );
+            paintRetainedResource(
+              command.resourceKey,
+              'image',
+              destination,
+              undefined,
+              context,
+            );
+          },
+        );
+      }
+      // The retained plan has a null base fill; this second pass paints only
+      // the authored outline/arrow decorations in the same transform.
       paintDrawingMLShape(
         context.ctx as CanvasRenderingContext2D,
         command.plan,

--- a/packages/docx/src/run-char-metrics-render.test.ts
+++ b/packages/docx/src/run-char-metrics-render.test.ts
@@ -157,18 +157,43 @@ describe('WD4 run character metrics reach the glyph draw (measure==paint)', () =
   });
 
   it('w:position (§17.3.2.24) shifts the baseline up for a positive (raised) value', async () => {
-    const raised = await render([textRun('X', { position: 6 })]); // +6 pt raised
-    const plain = await render([textRun('X')]);
+    const raised = await render([
+      textRun('N'),
+      textRun('X', { position: 6 }),
+    ]); // +6 pt raised relative to the surrounding normal run
     const yRaised = drawOf(raised.fills, 'X').y;
-    const yPlain = drawOf(plain.fills, 'X').y;
+    const yPlain = drawOf(raised.fills, 'N').y;
     // Raised text sits HIGHER ⇒ smaller y (canvas y grows downward). 6 pt × scale 1.
     expect(yPlain - yRaised).toBeCloseTo(6, 5);
+    // The raised ink participates in the line extent, preventing a cell border
+    // or the following line from crossing the painted glyph.
+    expect(raised.runs[0].h).toBeCloseTo(FONT_PX + 6, 5);
   });
 
   it('w:position lowers the baseline for a negative value (mirrors raised)', async () => {
-    const lowered = await render([textRun('X', { position: -6 })]);
-    const plain = await render([textRun('X')]);
-    expect(drawOf(lowered.fills, 'X').y - drawOf(plain.fills, 'X').y).toBeCloseTo(6, 5);
+    const lowered = await render([
+      textRun('N'),
+      textRun('X', { position: -6 }),
+    ]);
+    expect(drawOf(lowered.fills, 'X').y - drawOf(lowered.fills, 'N').y).toBeCloseTo(6, 5);
+    expect(lowered.runs[0].h).toBeCloseTo(FONT_PX + 6, 5);
+  });
+
+  it('centers uniformly positioned runs within their enlarged line box', async () => {
+    // §17.3.2.24 defines position relative to surrounding non-positioned text.
+    // With no differently-positioned peer on the line, nothing pins the extra
+    // leading to one side, so the surplus is shared above and below the glyphs.
+    const plain = await render([textRun('N')]);
+    const uniformlyRaised = await render([
+      textRun('A', { position: 6 }),
+      textRun('B', { position: 6 }),
+    ]);
+
+    expect(uniformlyRaised.runs[0].h).toBeCloseTo(FONT_PX + 6, 5);
+    expect(drawOf(uniformlyRaised.fills, 'A').y - drawOf(plain.fills, 'N').y)
+      .toBeCloseTo(3, 5);
+    expect(drawOf(uniformlyRaised.fills, 'B').y - drawOf(plain.fills, 'N').y)
+      .toBeCloseTo(3, 5);
   });
 
   it('w:vertAlign raises superscript, lowers subscript, and leaves ordinary baselines unchanged', async () => {
@@ -189,11 +214,13 @@ describe('WD4 run character metrics reach the glyph draw (measure==paint)', () =
   });
 
   it('w:vertAlign baseline shift composes with an authored w:position', async () => {
-    const plainSuper = await render([textRun('S', { vertAlign: 'super' })]);
-    const raisedSuper = await render([textRun('S', { vertAlign: 'super', position: 4 })]);
+    const composed = await render([
+      textRun('S', { vertAlign: 'super' }),
+      textRun('P', { vertAlign: 'super', position: 4 }),
+    ]);
 
     expect(
-      drawOf(plainSuper.fills, 'S').y - drawOf(raisedSuper.fills, 'S').y,
+      drawOf(composed.fills, 'S').y - drawOf(composed.fills, 'P').y,
     ).toBeCloseTo(4, 5);
   });
 

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -4,6 +4,8 @@ import type {
   MathNode,
   ChartModel,
   Duotone,
+  FillRect,
+  TileInfo,
 } from '@silurus/ooxml-core';
 import type {
   NormalizedOoxmlResourcePolicy,
@@ -773,6 +775,9 @@ export interface AnchorHostMetrics {
 }
 
 export interface ShapeRun {
+  /** ECMA-376 §20.4.2.8 — true when the shape is hosted by `<wp:inline>` and
+   * therefore advances the paragraph pen like an inline drawing object. */
+  inline?: boolean;
   widthPt: number;
   heightPt: number;
   /** X offset in pt */
@@ -1024,7 +1029,21 @@ export interface ShapeText {
 
 export type ShapeFill =
   | { fillType: 'solid'; color: string }
-  | { fillType: 'gradient'; stops: GradientStop[]; angle: number; gradType: string };
+  | { fillType: 'gradient'; stops: GradientStop[]; angle: number; gradType: string }
+  | {
+      /** ECMA-376 §20.1.8.14 picture fill on a DrawingML shape. */
+      fillType: 'image';
+      imagePath: string;
+      mimeType: string;
+      /** Microsoft 2016 SVG original retained beside the raster fallback. */
+      svgImagePath?: string;
+      /** ECMA-376 §20.1.8.55 source-image crop. */
+      srcRect?: { l: number; t: number; r: number; b: number };
+      fillRect?: FillRect;
+      tile?: TileInfo;
+      alpha?: number;
+      duotone?: Duotone;
+    };
 
 export interface GradientStop {
   /** 0.0–1.0 */
@@ -1167,7 +1186,8 @@ export interface DocxTextRun {
    *  width, not the gap between glyphs. Absent ⇒ 100%. */
   charScale?: number;
   /** ECMA-376 §17.3.2.24 `<w:position w:val>` — baseline raise (positive) /
-   *  lower (negative) in POINTS, without changing the font size or line box.
+   *  lower (negative) in POINTS, without changing the font size. The shifted
+   *  ink still participates in the surrounding line's visible extent.
    *  Absent ⇒ no shift. */
   position?: number;
   /** ECMA-376 §17.3.2.19 `<w:kern w:val>` — font-kerning threshold in POINTS

--- a/packages/docx/tests/visual/pdf-acceptance.spec.ts
+++ b/packages/docx/tests/visual/pdf-acceptance.spec.ts
@@ -120,10 +120,12 @@ test.describe('local Word PDF acceptance', () => {
 
     const expectedPageCount = manifest.pageCount ?? referencePages.length;
     expect(referencePages, 'Word PDF page count').toHaveLength(expectedPageCount);
-    expect(rendered.pages, 'DOCX rendered page count').toHaveLength(expectedPageCount);
-    expect(rendered.pageCount).toBe(expectedPageCount);
+    // Keep the page-count assertion loud, but compare every page that exists on
+    // both sides first. A pagination regression must still leave useful image
+    // evidence for the shared prefix instead of failing before page 1 is diffed.
+    const comparablePageCount = Math.min(referencePages.length, rendered.pages.length);
 
-    for (let pageIndex = 0; pageIndex < referencePages.length; pageIndex += 1) {
+    for (let pageIndex = 0; pageIndex < comparablePageCount; pageIndex += 1) {
       const pageNumber = pageIndex + 1;
       const expectation = manifest.pages?.[String(pageNumber)];
       const text = normalizedText(rendered.pages[pageIndex]!.text);
@@ -178,5 +180,8 @@ test.describe('local Word PDF acceptance', () => {
       );
       expect(matchPct, `page ${pageNumber} Word-PDF pixel match`).toBeGreaterThanOrEqual(minimum);
     }
+
+    expect(rendered.pages, 'DOCX rendered page count').toHaveLength(expectedPageCount);
+    expect(rendered.pageCount).toBe(expectedPageCount);
   });
 });

--- a/packages/node/src/docx-sea-justified-fit.probe.test.ts
+++ b/packages/node/src/docx-sea-justified-fit.probe.test.ts
@@ -40,7 +40,7 @@ import {
 
 const skia = await loadSkiaForTests();
 type Skia = typeof import('skia-canvas');
-const { Canvas, loadImage } = (skia ?? {}) as Skia;
+const { Canvas, loadImage, FontLibrary } = (skia ?? {}) as Skia;
 
 const factory: NodeCanvasFactory = {
   createCanvas: (w, h) =>
@@ -293,48 +293,58 @@ const privatePair = (name: string): { docx: string; pdf: string } | null => {
   return existsSync(docx) && existsSync(pdf) ? { docx, pdf } : null;
 };
 
+/** The acceptance pin compares face-dependent line counts. sample-29 authors
+ * SCG, while its current Word PDF substitutes Browallia New on a machine where
+ * SCG is absent. Running the pin on another host that also lacks SCG compares
+ * two unrelated substitutions and produces a false renderer regression. */
+const privatePairHasRequiredFont = (name: string): boolean =>
+  name !== 'sample-29' || FontLibrary?.has('SCG') === true;
+
 // Requires `pdfinfo` (poppler, alongside pdftotext) for the trailing-page
 // emptiness check below.
 describe.skipIf(!baseGate || !havePdfinfo)('issue #991 — private fixture line-count pins', () => {
   for (const name of ['sample-29', 'sample-55']) {
     const pair = privatePair(name);
-    it.skipIf(!pair)(`${name}: per-page visible-line counts match the Word PDF`, async () => {
-      const doc = parse(pair!.docx);
-      const restore = [installOffscreenCanvasShim(factory), installImageBitmapShim(factory)];
-      let layout: DocxLayout;
-      let layoutServices: DocxLayoutServices;
-      try {
-        const renderer = rendererMod!;
-        layoutServices = renderer.createLayoutServices(doc);
-        layout = renderer.layoutDocument(doc, layoutServices, { currentDateMs: 0 });
-      }
-      finally { restore.forEach((r) => r()); }
-      let ourTotal = 0;
-      let wordTotal = 0;
-      for (let p = 0; p < layout.pages.length; p++) {
-        const our = await ourPageLines(doc, layoutServices, p, 595);
-        const word = wordPageLines(pair!.pdf, p);
-        ourTotal += our.length;
-        wordTotal += word.length;
-        expect(our.length, `${name} page ${p + 1} visible-line count`).toBe(word.length);
-      }
-      // Word may paginate onto MORE pages than we do (e.g. the Thai corpus
-      // document renders 11 pages under the #989-adjudicated grazing fit while
-      // Word emits a 12th, empty, page). Any PDF page beyond our page count
-      // must then carry NO text — otherwise the per-page loop above silently
-      // skipped real Word content and the equal totals would be a lie.
-      const pdfInfo = execFileSync('pdfinfo', [pair!.pdf], { encoding: 'utf8' });
-      const pdfPages = Number(/^Pages:\s+(\d+)$/m.exec(pdfInfo)?.[1] ?? '0');
-      expect(pdfPages, `${name} pdfinfo page count`).toBeGreaterThan(0);
-      for (let p = layout.pages.length; p < pdfPages; p++) {
-        expect(
-          wordPageLines(pair!.pdf, p).length,
-          `${name} Word PDF page ${p + 1} exceeds our pagination and must be empty`,
-        ).toBe(0);
-      }
-      // eslint-disable-next-line no-console
-      console.log(`[#991 pin] ${name}: ${ourTotal} lines == Word ${wordTotal} (our ${layout.pages.length} pages, PDF ${pdfPages})`);
-      expect(ourTotal).toBe(wordTotal);
-    });
+    it.skipIf(!pair || !privatePairHasRequiredFont(name))(
+      `${name}: per-page visible-line counts match the Word PDF`,
+      async () => {
+        const doc = parse(pair!.docx);
+        const restore = [installOffscreenCanvasShim(factory), installImageBitmapShim(factory)];
+        let layout: DocxLayout;
+        let layoutServices: DocxLayoutServices;
+        try {
+          const renderer = rendererMod!;
+          layoutServices = renderer.createLayoutServices(doc);
+          layout = renderer.layoutDocument(doc, layoutServices, { currentDateMs: 0 });
+        }
+        finally { restore.forEach((r) => r()); }
+        let ourTotal = 0;
+        let wordTotal = 0;
+        for (let p = 0; p < layout.pages.length; p++) {
+          const our = await ourPageLines(doc, layoutServices, p, 595);
+          const word = wordPageLines(pair!.pdf, p);
+          ourTotal += our.length;
+          wordTotal += word.length;
+          expect(our.length, `${name} page ${p + 1} visible-line count`).toBe(word.length);
+        }
+        // Word may paginate onto MORE pages than we do (e.g. the Thai corpus
+        // document renders 11 pages under the #989-adjudicated grazing fit while
+        // Word emits a 12th, empty, page). Any PDF page beyond our page count
+        // must then carry NO text — otherwise the per-page loop above silently
+        // skipped real Word content and the equal totals would be a lie.
+        const pdfInfo = execFileSync('pdfinfo', [pair!.pdf], { encoding: 'utf8' });
+        const pdfPages = Number(/^Pages:\s+(\d+)$/m.exec(pdfInfo)?.[1] ?? '0');
+        expect(pdfPages, `${name} pdfinfo page count`).toBeGreaterThan(0);
+        for (let p = layout.pages.length; p < pdfPages; p++) {
+          expect(
+            wordPageLines(pair!.pdf, p).length,
+            `${name} Word PDF page ${p + 1} exceeds our pagination and must be empty`,
+          ).toBe(0);
+        }
+        // eslint-disable-next-line no-console
+        console.log(`[#991 pin] ${name}: ${ourTotal} lines == Word ${wordTotal} (our ${layout.pages.length} pages, PDF ${pdfPages})`);
+        expect(ourTotal).toBe(wordTotal);
+      },
+    );
   }
 });

--- a/packages/ooxml-common/src/fill.rs
+++ b/packages/ooxml-common/src/fill.rs
@@ -22,6 +22,40 @@
 use crate::color::{parse_color_node, ThemeResolver, TintMode};
 use roxmltree::Node;
 
+/// ECMA-376 §20.1.8.30 `a:fillRect` (CT_RelativeRect) destination insets.
+/// Values are signed fractions; negative values extend beyond the fill box.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FillRect {
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub l: f64,
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub t: f64,
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub r: f64,
+    #[serde(skip_serializing_if = "is_zero", default)]
+    pub b: f64,
+}
+
+/// ECMA-376 §20.1.8.58 `a:tile` placement facts shared by every DrawingML host.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TileInfo {
+    pub tx: i64,
+    pub ty: i64,
+    pub sx: f64,
+    pub sy: f64,
+    pub flip: String,
+    /// Optional CT_TileInfoProperties registration point. The schema declares
+    /// no default; hosts may apply their own compatibility policy when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub algn: Option<String>,
+}
+
+fn is_zero(value: &f64) -> bool {
+    value.abs() < 1e-9
+}
+
 /// One `<a:gs>` gradient stop: a position in `[0, 1]` and its resolved hex
 /// color (6-char opaque, or 8-char RRGGBBAA when an alpha transform applies).
 /// The serde shape (`{"position":..,"color":".."}`) matches the pptx parser's
@@ -77,6 +111,53 @@ fn attr(node: Node<'_, '_>, local: &str) -> Option<String> {
 fn child<'a, 'i>(node: Node<'a, 'i>, local: &str) -> Option<Node<'a, 'i>> {
     node.children()
         .find(|n| n.is_element() && n.tag_name().name() == local)
+}
+
+/// Parse `<a:stretch><a:fillRect>` into signed fractional destination insets.
+/// Missing edges are zero; an all-zero rectangle is equivalent to absence.
+pub fn parse_fill_rect(stretch: Node<'_, '_>) -> Option<FillRect> {
+    let fill_rect = child(stretch, "fillRect")?;
+    let read = |name: &str| {
+        attr(fill_rect, name)
+            .and_then(|value| value.parse::<f64>().ok())
+            .map(|value| value / 100_000.0)
+            .unwrap_or(0.0)
+    };
+    let rect = FillRect {
+        l: read("l"),
+        t: read("t"),
+        r: read("r"),
+        b: read("b"),
+    };
+    if is_zero(&rect.l) && is_zero(&rect.t) && is_zero(&rect.r) && is_zero(&rect.b) {
+        None
+    } else {
+        Some(rect)
+    }
+}
+
+/// Parse `<a:tile>` preserving optional host policy: zero offsets, 100% scale,
+/// and no mirroring are schema defaults, while `algn` has no normative default.
+pub fn parse_tile(tile: Node<'_, '_>) -> TileInfo {
+    let coordinate = |name: &str| {
+        attr(tile, name)
+            .and_then(|value| value.parse::<i64>().ok())
+            .unwrap_or(0)
+    };
+    let scale = |name: &str| {
+        attr(tile, name)
+            .and_then(|value| value.parse::<f64>().ok())
+            .map(|value| value / 100_000.0)
+            .unwrap_or(1.0)
+    };
+    TileInfo {
+        tx: coordinate("tx"),
+        ty: coordinate("ty"),
+        sx: scale("sx"),
+        sy: scale("sy"),
+        flip: attr(tile, "flip").unwrap_or_else(|| "none".to_owned()),
+        algn: attr(tile, "algn"),
+    }
 }
 
 /// Parse a located `<a:gradFill>` node (ECMA-376 §20.1.8.33). Reads the
@@ -176,6 +257,36 @@ mod tests {
 
     fn doc(xml: &str) -> Document<'_> {
         Document::parse(xml).unwrap()
+    }
+
+    #[test]
+    fn blip_placement_parsers_preserve_signed_insets_and_tile_defaults() {
+        let stretch_xml =
+            format!(r#"<a:stretch xmlns:a="{NS}"><a:fillRect l="10000" r="-7574"/></a:stretch>"#,);
+        let stretch = doc(&stretch_xml);
+        assert_eq!(
+            parse_fill_rect(stretch.root_element()),
+            Some(FillRect {
+                l: 0.1,
+                t: 0.0,
+                r: -0.07574,
+                b: 0.0
+            }),
+        );
+
+        let tile_xml = format!(r#"<a:tile xmlns:a="{NS}"/>"#);
+        let tile = doc(&tile_xml);
+        assert_eq!(
+            parse_tile(tile.root_element()),
+            TileInfo {
+                tx: 0,
+                ty: 0,
+                sx: 1.0,
+                sy: 1.0,
+                flip: "none".to_owned(),
+                algn: None,
+            },
+        );
     }
 
     /// gradFill: stops parsed + sorted, linear angle from `<a:lin ang>`.

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -1110,7 +1110,7 @@ export interface TileInfo {
     sx: number;
     sy: number;
     flip: string;
-    algn: string;
+    algn?: string;
 }
 interface ZoomableViewer {
     getScale(): number;

--- a/packages/pptx/parser/src/fill.rs
+++ b/packages/pptx/parser/src/fill.rs
@@ -17,59 +17,7 @@ use std::collections::HashMap;
 /// alpha identically (previously a pptx-local copy). Returns the fraction
 /// `amt/100000` when present and < 1.0; `None` otherwise.
 pub(crate) use ooxml_common::blip::parse_blip_alpha;
-
-/// Parse `<a:stretch><a:fillRect l t r b>` (ECMA-376 §20.1.8.58 / §20.1.8.30).
-/// Edge attributes are ST_Percentage (1000ths of a percent → /100000 gives a
-/// fraction). Negative values are valid (overscan). Returns None when there is
-/// no fillRect or all four edges are zero (= the source fills the whole box).
-pub(crate) fn parse_fill_rect(stretch: roxmltree::Node<'_, '_>) -> Option<FillRect> {
-    let fr = child(stretch, "fillRect")?;
-    let read = |name: &str| -> f64 {
-        attr(&fr, name)
-            .and_then(|v| v.parse::<f64>().ok())
-            .map(|v| v / 100_000.0)
-            .unwrap_or(0.0)
-    };
-    let rect = FillRect {
-        l: read("l"),
-        t: read("t"),
-        r: read("r"),
-        b: read("b"),
-    };
-    if is_zero_f64(&rect.l) && is_zero_f64(&rect.t) && is_zero_f64(&rect.r) && is_zero_f64(&rect.b)
-    {
-        None
-    } else {
-        Some(rect)
-    }
-}
-
-/// Parse `<a:tile tx ty sx sy flip algn>` (ECMA-376 §20.1.8.58 CT_TileInfoProperties).
-///
-/// - `tx` / `ty`: ST_Coordinate offset of the first tile, in EMU. Default 0.
-/// - `sx` / `sy`: ST_Percentage scale of the tile (1000ths of a percent →
-///   `/100000` gives a fraction). Absent → `1.0` (100% = native blip size).
-/// - `flip`: ST_TileFlipMode (none|x|y|xy). Default "none".
-/// - `algn`: ST_RectAlignment (tl|t|tr|l|ctr|r|bl|b|br) — the anchor corner the
-///   tile grid is registered against. The schema gives no default; PowerPoint
-///   treats an absent `algn` as "tl" (the first tile sits at the box origin
-///   plus tx/ty). We carry it verbatim and default to "tl".
-pub(crate) fn parse_tile(tile: roxmltree::Node<'_, '_>) -> TileInfo {
-    let scale = |name: &str| -> f64 {
-        attr(&tile, name)
-            .and_then(|v| v.parse::<f64>().ok())
-            .map(|v| v / 100_000.0)
-            .unwrap_or(1.0)
-    };
-    TileInfo {
-        tx: attr_i64(&tile, "tx").unwrap_or(0),
-        ty: attr_i64(&tile, "ty").unwrap_or(0),
-        sx: scale("sx"),
-        sy: scale("sy"),
-        flip: attr(&tile, "flip").unwrap_or_else(|| "none".to_owned()),
-        algn: attr(&tile, "algn").unwrap_or_else(|| "tl".to_owned()),
-    }
-}
+pub(crate) use ooxml_common::fill::{parse_fill_rect, parse_tile};
 
 // ===========================
 //  Color parsing

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -4033,7 +4033,7 @@ mod tests {
                 let fr = fill_rect.expect("fillRect should be present");
                 assert!((fr.t - (-0.09)).abs() < 1e-9, "t={}", fr.t);
                 assert!((fr.b - (-0.09)).abs() < 1e-9, "b={}", fr.b);
-                assert!(is_zero_f64(&fr.l) && is_zero_f64(&fr.r));
+                assert!(fr.l.abs() < 1e-9 && fr.r.abs() < 1e-9);
                 assert!(tile.is_none(), "stretch fill must not carry tile");
                 assert!((alpha.expect("alpha") - 0.8).abs() < 1e-6);
             }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -4138,14 +4138,14 @@ mod tests {
                 assert!((t.sx - 0.5).abs() < 1e-9, "sx={}", t.sx);
                 assert!((t.sy - 0.75).abs() < 1e-9, "sy={}", t.sy);
                 assert_eq!(t.flip, "xy");
-                assert_eq!(t.algn, "ctr");
+                assert_eq!(t.algn.as_deref(), Some("ctr"));
             }
             other => panic!("expected Fill::Image, got {other:?}"),
         }
     }
 
-    /// §20.1.8.58 defaults: a bare `<a:tile/>` yields tx/ty=0, sx/sy=1.0
-    /// (100% native size), flip="none", algn="tl".
+    /// §20.1.8.58: a bare `<a:tile/>` yields the schema defaults for tx/ty,
+    /// sx/sy and flip, while omitted algn remains absent for the host policy.
     #[test]
     fn test_parse_background_blip_fill_tile_defaults() {
         let xml = r#"<p:cSld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
@@ -4168,7 +4168,7 @@ mod tests {
                 assert!((t.sx - 1.0).abs() < 1e-9);
                 assert!((t.sy - 1.0).abs() < 1e-9);
                 assert_eq!(t.flip, "none");
-                assert_eq!(t.algn, "tl");
+                assert_eq!(t.algn, None);
             }
             other => panic!("expected Fill::Image, got {other:?}"),
         }

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -526,10 +526,6 @@ pub(crate) struct PictureElement {
     pub(crate) sp3d: Option<Sp3d>,
 }
 
-pub(crate) fn is_zero_f64(v: &f64) -> bool {
-    v.abs() < 1e-9
-}
-
 /// ECMA-376 §19.3.1.17/18 a:audioFile / a:videoFile and the
 /// p14:media extension (embed attribute).
 /// Represents a p:pic that acts as an audio/video placeholder.

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -560,25 +560,7 @@ pub(crate) struct MediaElement {
     pub(crate) mime_type: String,
 }
 
-/// ECMA-376 §20.1.8.58 (CT_TileInfoProperties) — tiled blip-fill placement.
-/// Mutually exclusive with `stretch` inside a single `a:blipFill`.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct TileInfo {
-    /// Horizontal offset of the first tile, EMU (`tx`). Default 0.
-    pub(crate) tx: i64,
-    /// Vertical offset of the first tile, EMU (`ty`). Default 0.
-    pub(crate) ty: i64,
-    /// Horizontal tile scale as a fraction (`sx` / 100000). Default 1.0.
-    pub(crate) sx: f64,
-    /// Vertical tile scale as a fraction (`sy` / 100000). Default 1.0.
-    pub(crate) sy: f64,
-    /// Mirror mode: "none" | "x" | "y" | "xy" (`flip`). Default "none".
-    pub(crate) flip: String,
-    /// Anchor corner the tile grid registers against: tl|t|tr|l|ctr|r|bl|b|br
-    /// (`algn`). Default "tl".
-    pub(crate) algn: String,
-}
+pub(crate) use ooxml_common::fill::{FillRect, TileInfo};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -705,23 +687,6 @@ pub(crate) enum Fill {
         #[serde(skip_serializing_if = "Option::is_none")]
         duotone: Option<Duotone>,
     },
-}
-
-/// ECMA-376 §20.1.8.30 `a:fillRect` (CT_RelativeRect) — the destination
-/// rectangle a stretched blip is mapped into, expressed as edge insets relative
-/// to the fill region. Values are fractions (ST_Percentage / 100000); negative
-/// values push the edge outward so the image bleeds past the box (overscan).
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct FillRect {
-    #[serde(skip_serializing_if = "is_zero_f64", default)]
-    pub(crate) l: f64,
-    #[serde(skip_serializing_if = "is_zero_f64", default)]
-    pub(crate) t: f64,
-    #[serde(skip_serializing_if = "is_zero_f64", default)]
-    pub(crate) r: f64,
-    #[serde(skip_serializing_if = "is_zero_f64", default)]
-    pub(crate) b: f64,
 }
 
 /// Arrow end descriptor for headEnd / tailEnd on a line.

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -37,6 +37,7 @@ import {
   renderPresetShape,
   hasPreset,
   buildPresetGeometryPath,
+  buildPresetGeometryFillPath,
   getConnectorAnchors,
   getCustGeomEndpoints,
   drawArrowHead,
@@ -1516,7 +1517,10 @@ function paintTiledBackground(
   if (!pattern) return;
 
   // Phase: register the grid against the alignment anchor, then add tx/ty.
-  const { ax, ay } = tileAnchorOffset(tile.algn, canvasW, canvasH, tileW, tileH);
+  // PowerPoint registers an omitted algn at the top-left. CT_TileInfoProperties
+  // itself declares no schema default, so keep this host observation here rather
+  // than normalizing it in the shared OOXML parser.
+  const { ax, ay } = tileAnchorOffset(tile.algn ?? 'tl', canvasW, canvasH, tileW, tileH);
   const px = ax + emuToPx(tile.tx, scale);
   const py = ay + emuToPx(tile.ty, scale);
   // `setTransform` exists where DOMMatrix is available (browser + skia-canvas).
@@ -4420,7 +4424,7 @@ async function renderPicture(
         // Driven by the shared preset-geometry engine (roundRect, ellipse, and
         // the other 184 presets), with the avLst adjust handles; the engine
         // substitutes each preset's declared default for any omitted guide.
-        const ok = buildPresetGeometryPath(
+        const ok = buildPresetGeometryFillPath(
           target,
           el.prstGeom,
           cx,

--- a/packages/pptx/tests/visual/pdf-acceptance.spec.ts
+++ b/packages/pptx/tests/visual/pdf-acceptance.spec.ts
@@ -1,0 +1,134 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { expect, test } from '@playwright/test';
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+
+interface BrowserRender {
+  readonly slideCount: number;
+  readonly slides: readonly string[];
+}
+
+const enabled = process.env.LOCAL_PDF_ACCEPTANCE === '1';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required for the local PowerPoint-PDF acceptance gate`);
+  return value;
+}
+
+function paddedPng(source: PNG, width: number, height: number): PNG {
+  if (source.width === width && source.height === height) return source;
+  const result = new PNG({ width, height });
+  result.data.fill(255);
+  PNG.bitblt(source, result, 0, 0, Math.min(source.width, width), Math.min(source.height, height), 0, 0);
+  return result;
+}
+
+function pdfSlidePngs(pdfPath: string, outputPrefix: string): readonly string[] {
+  const probe = spawnSync('pdftoppm', ['-v'], { encoding: 'utf8' });
+  if (probe.error || probe.status !== 0) {
+    throw new Error('pdftoppm was not found. Install Poppler with: brew install poppler');
+  }
+  execFileSync('pdftoppm', ['-png', '-r', '72', pdfPath, outputPrefix], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const directory = resolve(outputPrefix, '..');
+  const prefix = basename(outputPrefix);
+  return readdirSync(directory)
+    .filter((name) => name.startsWith(`${prefix}-`) && name.endsWith('.png'))
+    .sort((left, right) => {
+      const slideNumber = (name: string) => Number(/-(\d+)\.png$/u.exec(name)?.[1] ?? 0);
+      return slideNumber(left) - slideNumber(right);
+    })
+    .map((name) => resolve(directory, name));
+}
+
+test.describe('local PowerPoint PDF acceptance', () => {
+  test.skip(!enabled, 'Set LOCAL_PDF_ACCEPTANCE=1 to run the local PDF gate');
+
+  test('matches slide allocation and rendered pixels', async ({ page }, testInfo) => {
+    const pdfPath = resolve(requiredEnvironment('PPTX_POWERPOINT_PDF'));
+    if (!existsSync(pdfPath)) throw new Error(`PPTX_POWERPOINT_PDF does not exist: ${pdfPath}`);
+    const presentationPath = requiredEnvironment('PPTX_POWERPOINT_FILE').replace(/^\/+/, '');
+    const configuredMinimum = Number(process.env.PPTX_POWERPOINT_MIN_MATCH ?? 0);
+    if (!Number.isFinite(configuredMinimum) || configuredMinimum < 0 || configuredMinimum > 100) {
+      throw new Error(`Invalid minimum pixel match percentage: ${configuredMinimum}`);
+    }
+
+    const referencePaths = pdfSlidePngs(pdfPath, testInfo.outputPath('powerpoint-slide'));
+    if (referencePaths.length === 0) throw new Error(`No slides were rendered from ${pdfPath}`);
+    const references = referencePaths.map((path) => PNG.sync.read(readFileSync(path)));
+    const requestedWidth = references[0]!.width;
+
+    const presentationStem = presentationPath.replace(/\.pptx$/u, '');
+    await page.goto(
+      `/tests/visual/fixture.html?pptx=${encodeURIComponent(presentationStem)}&width=${requestedWidth}`,
+    );
+    await page.waitForFunction(() => document.body.dataset.status === 'ready');
+    const rendered = await page.evaluate(async ({ path, width }) => {
+      const { PptxViewer } = await import('/src/index.ts');
+      const canvas = window.document.createElement('canvas');
+      window.document.body.replaceChildren(canvas);
+      const viewer = new PptxViewer(canvas, { width });
+      const response = await fetch(`/${path}`);
+      if (!response.ok) throw new Error(`fetch failed: ${response.status}`);
+      await viewer.load(await response.arrayBuffer());
+      const slides = [];
+      for (let slideIndex = 0; slideIndex < viewer.slideCount; slideIndex += 1) {
+        if (slideIndex > 0) await viewer.goToSlide(slideIndex);
+        slides.push(canvas.toDataURL('image/png'));
+      }
+      const slideCount = viewer.slideCount;
+      viewer.destroy();
+      return { slideCount, slides };
+    }, { path: presentationPath, width: requestedWidth }) as BrowserRender;
+
+    const comparableSlideCount = Math.min(references.length, rendered.slides.length);
+    for (let slideIndex = 0; slideIndex < comparableSlideCount; slideIndex += 1) {
+      const slideNumber = slideIndex + 1;
+      const reference = references[slideIndex]!;
+      const actual = PNG.sync.read(Buffer.from(
+        rendered.slides[slideIndex]!.replace(/^data:image\/png;base64,/u, ''),
+        'base64',
+      ));
+      expect(Math.abs(reference.width - actual.width), `slide ${slideNumber} width rounding difference`)
+        .toBeLessThanOrEqual(1);
+      expect(Math.abs(reference.height - actual.height), `slide ${slideNumber} height rounding difference`)
+        .toBeLessThanOrEqual(1);
+      const width = Math.max(reference.width, actual.width);
+      const height = Math.max(reference.height, actual.height);
+      const referencePadded = paddedPng(reference, width, height);
+      const actualPadded = paddedPng(actual, width, height);
+      const diff = new PNG({ width, height });
+      const differentPixels = pixelmatch(
+        referencePadded.data,
+        actualPadded.data,
+        diff.data,
+        width,
+        height,
+        { threshold: 0.2, includeAA: false },
+      );
+      const matchPct = 100 - differentPixels / (width * height) * 100;
+      for (const [suffix, png] of [
+        ['actual', actualPadded],
+        ['powerpoint', referencePadded],
+        ['diff', diff],
+      ] as const) {
+        const path = testInfo.outputPath(`slide-${slideNumber}-${suffix}.png`);
+        writeFileSync(path, PNG.sync.write(png));
+        await testInfo.attach(`slide-${slideNumber}-${suffix}`, { path, contentType: 'image/png' });
+      }
+      console.log(
+        `slide ${slideNumber}: match=${matchPct.toFixed(3)}% `
+        + `diff=${differentPixels.toLocaleString()}/${(width * height).toLocaleString()} px`,
+      );
+      expect(matchPct, `slide ${slideNumber} PowerPoint-PDF pixel match`)
+        .toBeGreaterThanOrEqual(configuredMinimum);
+    }
+
+    expect(rendered.slides, 'PPTX rendered slide count').toHaveLength(references.length);
+    expect(rendered.slideCount).toBe(references.length);
+  });
+});

--- a/packages/pptx/tests/visual/visual.spec.ts
+++ b/packages/pptx/tests/visual/visual.spec.ts
@@ -11,10 +11,15 @@ import pixelmatch from 'pixelmatch';
 const PPTX_FILES: { name: string; slideCount: number }[] = [
   { name: 'private/sample-1', slideCount: 5 },
   { name: 'private/sample-2', slideCount: 17 },
-  { name: 'private/sample-3', slideCount: 17 },
-  { name: 'private/sample-4', slideCount: 15 },
-  { name: 'private/sample-5', slideCount: 3 },
-  { name: 'private/sample-6', slideCount: 3 },
+  { name: 'private/sample-3', slideCount: 21 },
+  { name: 'private/sample-4', slideCount: 6 },
+  { name: 'private/sample-5', slideCount: 16 },
+  { name: 'private/sample-6', slideCount: 13 },
+  { name: 'private/sample-7', slideCount: 2 },
+  { name: 'private/sample-8', slideCount: 1 },
+  { name: 'private/sample-9', slideCount: 2 },
+  { name: 'private/sample-10', slideCount: 5 },
+  { name: 'private/sample-11', slideCount: 3 },
   { name: 'demo/sample-1', slideCount: 9 },
 ];
 

--- a/scripts/check-docx-layout-boundaries.mjs
+++ b/scripts/check-docx-layout-boundaries.mjs
@@ -89,6 +89,9 @@ const SHARED_PAINT_IMPORTS = new Map([
     ['autoContrastColor', 'value'],
     ['canvasFontString', 'value'],
     ['clampCanvasSize', 'value'],
+    // DrawingML silhouette clipping is shared paint behavior used by
+    // resource-backed shape fills; it does not expose layout acquisition.
+    ['clipDrawingMLShape', 'value'],
     ['crispOffset', 'value'],
     ['defaultDpr', 'value'],
     ['deferBitmapCloseWhileLeased', 'value'],
@@ -117,6 +120,7 @@ const SHARED_PAINT_IMPORTS = new Map([
     ['resolveFill', 'value'],
     ['recolorSvg', 'value'],
     ['renderChart', 'value'],
+    ['withDrawingMLShapeTransform', 'value'],
     ['Duotone', 'type'],
     ['MathRenderer', 'type'],
   ])],


### PR DESCRIPTION
## Summary

- preserve inline WordprocessingShape objects through parser, immutable layout, pagination, and paint
- retain DrawingML image fills with shared DOCX and PPTX fill parsing and consistent nonzero clipping
- preserve signed run positioning and resolved page-field metrics without paint-time inference
- add local PDF acceptance coverage

## Specification

The implementation follows ECMA-376 sections 20.4.2.7-8 for inline DrawingML extent and payload semantics, and section 20.1.8.14 for authored blipFill behavior. Office-only pagination and frame behavior remains isolated in compatibility modules.

## Verification

- DOCX architecture boundary, compatibility evidence, public API, and package build gates
- full workspace typecheck
- focused parser, layout, paint, and line-spacing tests
- local-only visual regression comparison across available private fixtures; intended changes were manually inspected and references were not updated
- independent architecture and specification-first review findings resolved
- git diff --check