### PR TITLE
fix(site): make framework embeds code-only

### DIFF
--- a/examples/frameworks/react/package.json
+++ b/examples/frameworks/react/package.json
@@ -2,6 +2,9 @@
   "name": "@ooxml-framework-examples/react",
   "private": true,
   "type": "module",
+  "stackblitz": {
+    "startCommand": false
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",

--- a/examples/frameworks/solid/package.json
+++ b/examples/frameworks/solid/package.json
@@ -2,6 +2,9 @@
   "name": "@ooxml-framework-examples/solid",
   "private": true,
   "type": "module",
+  "stackblitz": {
+    "startCommand": false
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",

--- a/examples/frameworks/svelte/package.json
+++ b/examples/frameworks/svelte/package.json
@@ -2,6 +2,9 @@
   "name": "@ooxml-framework-examples/svelte",
   "private": true,
   "type": "module",
+  "stackblitz": {
+    "startCommand": false
+  },
   "scripts": {
     "dev": "vite",
     "build": "svelte-check --tsconfig ./tsconfig.json && vite build",

--- a/examples/frameworks/vue/package.json
+++ b/examples/frameworks/vue/package.json
@@ -2,6 +2,9 @@
   "name": "@ooxml-framework-examples/vue",
   "private": true,
   "type": "module",
+  "stackblitz": {
+    "startCommand": false
+  },
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",

--- a/site/src/brand-icon.test.ts
+++ b/site/src/brand-icon.test.ts
@@ -5,12 +5,17 @@ const read = (path: string) => readFileSync(new URL(path, import.meta.url), 'utf
 const nav = read('./components/Nav.astro');
 const base = read('./layouts/Base.astro');
 const footerSurfaces = [
-  read('./layouts/FormatPage.astro'),
   read('./pages/index.astro'),
   read('./pages/try.astro'),
   read('./pages/deprecations.astro'),
   read('./pages/errors.astro'),
   read('./pages/announcements/index.astro'),
+];
+const sharedFooter = read('./components/SiteFooter.astro');
+const sharedFooterSurfaces = [
+  read('./layouts/FormatPage.astro'),
+  read('./components/FrameworkGuide.astro'),
+  read('./pages/frameworks/index.astro'),
 ];
 
 describe('official-site brand icon', () => {
@@ -19,6 +24,11 @@ describe('official-site brand icon', () => {
     expect(nav).not.toContain('nav-mark');
     for (const source of footerSurfaces) {
       expect(source).toContain('<BrandIcon />');
+      expect(source).not.toContain('nav-mark');
+    }
+    expect(sharedFooter).toContain('<BrandIcon />');
+    for (const source of sharedFooterSurfaces) {
+      expect(source).toContain('<SiteFooter />');
       expect(source).not.toContain('nav-mark');
     }
   });

--- a/site/src/components/FrameworkGuide.astro
+++ b/site/src/components/FrameworkGuide.astro
@@ -53,9 +53,9 @@ const structuredData = JSON.stringify({
     <section class="section live-section">
       <div class="wrap">
         <div class="section-intro">
-          <p class="eyebrow">Live project</p>
-          <h2 class="section-title">Run it on StackBlitz.</h2>
-          <p class="section-lead">Edit the real {guide.name} project and choose a local DOCX, XLSX, or PPTX file in its preview.</p>
+          <p class="eyebrow">Framework example</p>
+          <h2 class="section-title">Read the code. Run it on StackBlitz.</h2>
+          <p class="section-lead">Browse the complete {guide.name} project here, then open the live project to choose a local DOCX, XLSX, or PPTX file.</p>
         </div>
         <FrameworkStackBlitz framework={guide.name} src={guide.stackBlitzEmbedUrl} openUrl={guide.stackBlitzUrl} />
       </div>

--- a/site/src/components/FrameworkGuide.astro
+++ b/site/src/components/FrameworkGuide.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro';
 import Nav from './Nav.astro';
 import FrameworkStackBlitz from './FrameworkStackBlitz.astro';
+import SiteFooter from './SiteFooter.astro';
 import {
   frameworkGuides,
   getFrameworkGuide,
@@ -69,9 +70,7 @@ const structuredData = JSON.stringify({
     </nav>
   </main>
 
-  <footer class="guide-footer">
-    <div class="wrap">@silurus/ooxml · Browser-based DOCX, XLSX, and PPTX rendering</div>
-  </footer>
+  <SiteFooter />
   <script type="application/ld+json" set:html={structuredData}></script>
 </Base>
 
@@ -94,7 +93,6 @@ const structuredData = JSON.stringify({
   .framework-rail { display: flex; align-items: center; gap: 22px; padding-top: 28px; padding-bottom: 28px; border-top: 1px solid var(--border); font: 12px var(--mono); }
   .framework-rail span { margin-right: auto; color: var(--text-faint); text-transform: uppercase; letter-spacing: .08em; }
   .framework-rail a { border-bottom: 1px solid var(--signal); }
-  .guide-footer { padding: 28px 0; background: var(--hero-bg); color: var(--hero-muted); font: 11px var(--mono); }
   @media (max-width: 900px) {
     .guide-copy { grid-column: 1 / 10; }.guide-facts { grid-column: 10 / 13; }
   }

--- a/site/src/components/FrameworkStackBlitz.astro
+++ b/site/src/components/FrameworkStackBlitz.astro
@@ -14,7 +14,7 @@ const { framework, src, openUrl } = Astro.props;
     loading="lazy"
     allow="cross-origin-isolated; clipboard-write"
   ></iframe>
-  <a href={openUrl}>Open full project in StackBlitz ↗</a>
+  <a href={openUrl}>Open live project in StackBlitz ↗</a>
 </div>
 
 <style>

--- a/site/src/components/SiteFooter.astro
+++ b/site/src/components/SiteFooter.astro
@@ -1,0 +1,21 @@
+---
+import BrandIcon from './BrandIcon.astro';
+---
+
+<footer class="footer">
+  <div class="wrap footer-inner">
+    <div class="footer-brand">
+      <BrandIcon />
+      <div>
+        <strong>@silurus/ooxml</strong>
+        <span>Browser-based OOXML viewer · Rust/WASM + Canvas</span>
+      </div>
+    </div>
+    <div class="footer-links">
+      <a href="/">Home</a>
+      <a href="/announcements">Announcements</a>
+      <a href="https://www.npmjs.com/package/@silurus/ooxml">npm</a>
+      <a href="https://github.com/yukiyokotani/office-open-xml-viewer">GitHub</a>
+    </div>
+  </div>
+</footer>

--- a/site/src/framework-guides.test.ts
+++ b/site/src/framework-guides.test.ts
@@ -148,17 +148,24 @@ describe('framework integration guides', () => {
         `stackblitz.com/github/yukiyokotani/office-open-xml-viewer/tree/main/examples/frameworks/${framework.id}`,
       );
       expect(framework.stackBlitzEmbedUrl).toContain('embed=1');
-      expect(framework.stackBlitzEmbedUrl).toContain('startScript=dev');
-      expect(framework.stackBlitzEmbedUrl).not.toContain('startScript=dev%3A');
+      expect(framework.stackBlitzEmbedUrl).toContain('view=editor');
+      expect(framework.stackBlitzEmbedUrl).toContain('showSidebar=1');
+      expect(framework.stackBlitzEmbedUrl).not.toContain('startScript');
+      expect(framework.stackBlitzUrl).toContain('startScript=dev');
+      expect(framework.stackBlitzUrl).not.toContain('startScript=dev%3A');
     }
   });
 
   it.each(['react', 'vue', 'svelte', 'solid'])('keeps the %s StackBlitz project self-contained', (framework) => {
     const mainExtension = framework === 'react' || framework === 'solid' ? 'tsx' : 'ts';
     const main = exampleSource(`${framework}/src/main.${mainExtension}`);
+    const packageJson = JSON.parse(exampleSource(`${framework}/package.json`)) as {
+      stackblitz?: { startCommand?: boolean };
+    };
 
     expect(main).toContain("import './example.css';");
     expect(existsSync(new URL(`examples/frameworks/${framework}/src/example.css`, repositoryRoot))).toBe(true);
+    expect(packageJson.stackblitz?.startCommand).toBe(false);
   });
 
 });

--- a/site/src/framework-guides.test.ts
+++ b/site/src/framework-guides.test.ts
@@ -35,6 +35,15 @@ describe('framework integration guides', () => {
     expect(index).toContain('React, Vue, Svelte, and Solid');
   });
 
+  it('uses the standard site footer on the chooser and framework detail pages', () => {
+    const index = readFileSync(new URL('pages/frameworks/index.astro', siteRoot), 'utf8');
+    const guide = readFileSync(new URL('components/FrameworkGuide.astro', siteRoot), 'utf8');
+
+    expect(index).toContain('<SiteFooter />');
+    expect(guide).toContain('<SiteFooter />');
+    expect(guide).not.toContain('guide-footer');
+  });
+
   it.each(['docx', 'xlsx', 'pptx'])('keeps %s framework guidance on the dedicated pages', (format) => {
     const formatPage = readFileSync(new URL(`pages/${format}.astro`, siteRoot), 'utf8');
 

--- a/site/src/layouts/FormatPage.astro
+++ b/site/src/layouts/FormatPage.astro
@@ -1,7 +1,7 @@
 ---
 import Base from './Base.astro';
 import Nav from '../components/Nav.astro';
-import BrandIcon from '../components/BrandIcon.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 interface Props {
   format: 'pptx' | 'docx' | 'xlsx';
   name: string;   // "PowerPoint"
@@ -31,23 +31,7 @@ const fileNoun = { docx: 'Word document', xlsx: 'Excel workbook', pptx: 'PowerPo
     <slot />
   </main>
 
-  <footer class="footer">
-    <div class="wrap footer-inner">
-      <div class="footer-brand">
-        <BrandIcon />
-        <div>
-          <strong>@silurus/ooxml</strong>
-          <span>Browser-based OOXML viewer · Rust/WASM + Canvas</span>
-        </div>
-      </div>
-      <div class="footer-links">
-        <a href="/">Home</a>
-        <a href="/announcements">Announcements</a>
-        <a href="https://www.npmjs.com/package/@silurus/ooxml">npm</a>
-        <a href="https://github.com/yukiyokotani/office-open-xml-viewer">GitHub</a>
-      </div>
-    </div>
-  </footer>
+  <SiteFooter />
 
   <script>
     import { mountDemoInto, type DemoKind, type Format } from '../lib/demos';

--- a/site/src/lib/framework-guides.ts
+++ b/site/src/lib/framework-guides.ts
@@ -21,10 +21,9 @@ function stackBlitzEmbed(framework: FrameworkId, file: string): string {
   const params = new URLSearchParams({
     embed: '1',
     file,
-    startScript: 'dev',
-    view: 'both',
+    view: 'editor',
+    showSidebar: '1',
     hideNavigation: '1',
-    terminalHeight: '0',
   });
   return `https://stackblitz.com/github/${repository}/tree/main/examples/frameworks/${framework}?${params}`;
 }

--- a/site/src/pages/frameworks/index.astro
+++ b/site/src/pages/frameworks/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../../layouts/Base.astro';
 import Nav from '../../components/Nav.astro';
+import SiteFooter from '../../components/SiteFooter.astro';
 import { frameworkGuides } from '../../lib/framework-guides';
 
 const title = 'Office file viewer examples for React, Vue, Svelte, and Solid';
@@ -27,6 +28,7 @@ const description = 'Choose a TypeScript integration guide for rendering DOCX, X
       ))}
     </section>
   </main>
+  <SiteFooter />
 </Base>
 
 <style>


### PR DESCRIPTION
## Summary
- configure embedded framework examples not to auto-start WebContainers
- show the StackBlitz editor and source tree without an embedded preview
- keep the top-level StackBlitz link executable with the development script
- clarify code-browser versus live-project copy
- use the standard shared footer on the framework chooser, framework guides, and format pages

## Verification
- site framework, brand, and layout tests
- site production build
- React, Vue, Svelte, and Solid example builds
- local Chrome comparison of the framework chooser, a framework guide, and a format page

The behavior follows StackBlitz's documented project configuration: `stackblitz.startCommand: false` disables automatic execution for embedded imports.