### PR TITLE
fix(docx): preserve authoritative paragraph layout facts

### DIFF
--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -1350,6 +1350,7 @@ export declare interface ShapeText {
     text: string;
     fontSizePt: number;
     color?: string | null;
+    paragraphMarkColor?: string | null;
     fontFamily?: string | null;
     bold?: boolean;
     italic?: boolean;

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -4272,6 +4272,103 @@ fn resolve_numbered_indent_axes(
     }
 }
 
+/// Project one numbering level to the marker model shared by body and text-box
+/// paragraphs. ECMA-376 §17.9.24 keeps the level `rPr` separate from content
+/// runs. Word additionally uses the resolved paragraph-mark run properties as
+/// the marker fallback when a level property is absent; this compatibility
+/// behavior is applied here once so the two WordprocessingML stories cannot
+/// drift in font, color, theme-slot, or picture-bullet handling. The controlled
+/// observation is catalogued as `word-numbering-marker-paragraph-mark-fallback`
+/// in the renderer compatibility inventory.
+fn resolve_numbering_marker(
+    num_map: &mut NumberingMap,
+    num_id: u32,
+    num_level: u32,
+    paragraph_mark_run: &RunFmt,
+    theme: &ThemeColors,
+) -> NumberingInfo {
+    let (
+        format,
+        indent_left,
+        tab,
+        suff,
+        justification,
+        font_family,
+        font_family_east_asia,
+        font_facts,
+        color,
+        color_auto,
+        picture_bullet,
+    ) = num_map
+        .get_level(num_id, num_level)
+        .map(|level| {
+            let mut marker_run = paragraph_mark_run.clone();
+            apply_direct_run(&mut marker_run, &level.rpr);
+            (
+                level.format.clone(),
+                level.indent_left,
+                level.tab,
+                level.suff.clone(),
+                level.lvl_jc.clone(),
+                theme.resolve_font_ref(marker_run.font_family_ascii.clone()),
+                theme.resolve_font_ref(marker_run.font_family_east_asia.clone()),
+                Some(resolved_run_font_facts(&marker_run, theme)),
+                level.rpr.color.clone(),
+                level.rpr.color_auto,
+                level.pic_bullet.clone(),
+            )
+        })
+        .unwrap_or_else(|| {
+            (
+                "decimal".to_string(),
+                36.0,
+                18.0,
+                "tab".to_string(),
+                "left".to_string(),
+                theme.resolve_font_ref(paragraph_mark_run.font_family_ascii.clone()),
+                theme.resolve_font_ref(paragraph_mark_run.font_family_east_asia.clone()),
+                Some(resolved_run_font_facts(paragraph_mark_run, theme)),
+                None,
+                false,
+                None,
+            )
+        });
+    let counter = num_map.advance(num_id, num_level);
+    let text = num_map.resolve_text(num_id, num_level, counter);
+    let (pic_bullet_image_path, pic_bullet_mime_type, pic_bullet_width_pt, pic_bullet_height_pt) =
+        match picture_bullet {
+            // §17.9.20 defines no default size; absence stays absent so layout can
+            // resolve it against the retained marker font geometry.
+            Some(picture) => (
+                Some(picture.image_path),
+                Some(picture.mime_type),
+                picture.width_pt,
+                picture.height_pt,
+            ),
+            None => (None, None, None, None),
+        };
+
+    NumberingInfo {
+        num_id,
+        level: num_level,
+        format,
+        text,
+        indent_left,
+        tab,
+        suff,
+        jc: justification,
+        font_family,
+        font_family_east_asia,
+        font_facts,
+        color,
+        color_auto,
+        pic_bullet_image_path,
+        pic_bullet_mime_type,
+        pic_bullet_width_pt,
+        pic_bullet_height_pt,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn parse_paragraph_cond_at_depth_with_diagnostics(
     node: roxmltree::Node,
@@ -4366,106 +4463,9 @@ fn parse_paragraph_cond_at_depth_with_diagnostics(
     let numbering = if let (Some(num_id), Some(num_level)) = (base_para.num_id, base_para.num_level)
     {
         if num_id != 0 {
-            // Resolve the marker's font axes (ECMA-376 §17.9.6 + §17.3.2.26): take
-            // the level's own run properties (`rPr`) MERGED OVER the paragraph's
-            // resolved run formatting via the SAME `apply_direct_run` body runs
-            // use, then resolve the ascii and eastAsia axes INDEPENDENTLY through
-            // theme refs. A bare `<w:rFonts w:hint="eastAsia"/>` carries no
-            // typeface, so the marker simply inherits the paragraph's ascii (e.g.
-            // Times → the auto-number renders serif) and eastAsia (e.g. MS Gothic).
-            // §17.9.24 — the level rPr's own `<w:color>` also rides along
-            // (`marker_color` + `marker_color_auto`; parse_run_fmt maps an
-            // explicit auto to None + color_auto, §17.3.2.6). Kept UNMERGED
-            // from the run formatting: the paragraph-mark fallback lives in
-            // `paragraph_mark_color` below and the renderer resolves the
-            // precedence (lvl → mark → default ink; explicit auto stops the
-            // fallback at the default ink).
-            let (
-                format,
-                ind_left,
-                tab,
-                suff,
-                lvl_jc,
-                marker_ascii,
-                marker_ea,
-                marker_font_facts,
-                marker_color,
-                marker_color_auto,
-                pic_bullet,
-            ) = num_map
-                .get_level(num_id, num_level)
-                .map(|l| {
-                    let mut marker_fmt = base_run.clone();
-                    apply_direct_run(&mut marker_fmt, &l.rpr);
-                    let marker_font_facts = resolved_run_font_facts(&marker_fmt, theme);
-                    (
-                        l.format.clone(),
-                        l.indent_left,
-                        l.tab,
-                        l.suff.clone(),
-                        l.lvl_jc.clone(),
-                        theme.resolve_font_ref(marker_fmt.font_family_ascii.clone()),
-                        theme.resolve_font_ref(marker_fmt.font_family_east_asia.clone()),
-                        Some(marker_font_facts),
-                        l.rpr.color.clone(),
-                        l.rpr.color_auto,
-                        l.pic_bullet.clone(),
-                    )
-                })
-                .unwrap_or_else(|| {
-                    (
-                        "decimal".to_string(),
-                        36.0,
-                        18.0,
-                        "tab".to_string(),
-                        "left".to_string(),
-                        theme.resolve_font_ref(base_run.font_family_ascii.clone()),
-                        theme.resolve_font_ref(base_run.font_family_east_asia.clone()),
-                        Some(resolved_run_font_facts(&base_run, theme)),
-                        None,
-                        false,
-                        None,
-                    )
-                });
-            let counter = num_map.advance(num_id, num_level);
-            let text = num_map.resolve_text(num_id, num_level, counter);
-            let (
-                pic_bullet_image_path,
-                pic_bullet_mime_type,
-                pic_bullet_width_pt,
-                pic_bullet_height_pt,
-            ) = match pic_bullet {
-                // width_pt / height_pt are already Option<f64> (None when the VML
-                // shape style omits the dimension — §17.9.20 defines no default
-                // size, so the renderer resolves the absence against the marker
-                // font), so they flow through unchanged.
-                Some(pb) => (
-                    Some(pb.image_path),
-                    Some(pb.mime_type),
-                    pb.width_pt,
-                    pb.height_pt,
-                ),
-                None => (None, None, None, None),
-            };
-            Some(Box::new(NumberingInfo {
-                num_id,
-                level: num_level,
-                format,
-                text,
-                indent_left: ind_left,
-                tab,
-                suff,
-                jc: lvl_jc,
-                font_family: marker_ascii,
-                font_family_east_asia: marker_ea,
-                font_facts: marker_font_facts,
-                color: marker_color,
-                color_auto: marker_color_auto,
-                pic_bullet_image_path,
-                pic_bullet_mime_type,
-                pic_bullet_width_pt,
-                pic_bullet_height_pt,
-            }))
+            Some(Box::new(resolve_numbering_marker(
+                num_map, num_id, num_level, &mark_run, theme,
+            )))
         } else {
             None
         }
@@ -9194,6 +9194,10 @@ fn extract_simple_paragraph_text(
     // paragraph half feeds layout below; the run half is the docDefaults +
     // paragraph-style rPr baseline for every run in this paragraph.
     let (style_para, base_run) = style_map.resolve_para(style_id.as_deref(), None);
+    let mut mark_run = base_run.clone();
+    if let Some(rpr) = ppr_node.and_then(|ppr| child_w(ppr, "rPr")) {
+        apply_direct_run(&mut mark_run, &parse_run_fmt(rpr));
+    }
     let paragraph_style = style_map.resolve_paragraph_style_layer(style_id.as_deref());
     let direct_numbering = ppr_node.and_then(|ppr| child_w(ppr, "numPr")).is_some();
     let resolve_run_fmt = |rpr_node: Option<roxmltree::Node>| -> RunFmt {
@@ -9452,89 +9456,9 @@ fn extract_simple_paragraph_text(
             return None;
         }
         let num_level = direct_ind.num_level.or(style_para.num_level).unwrap_or(0);
-        let first_fmt = first_run_fmt.clone().unwrap_or_default();
-        let (
-            format,
-            ind_left,
-            tab,
-            suff,
-            lvl_jc,
-            marker_ascii,
-            marker_ea,
-            marker_font_facts,
-            marker_color,
-            marker_color_auto,
-            pic_bullet,
-        ) = num_map
-            .get_level(num_id, num_level)
-            .map(|l| {
-                let mut marker_fmt = first_fmt.clone();
-                apply_direct_run(&mut marker_fmt, &l.rpr);
-                let marker_font_facts = resolved_run_font_facts(&marker_fmt, theme);
-                (
-                    l.format.clone(),
-                    l.indent_left,
-                    l.tab,
-                    l.suff.clone(),
-                    l.lvl_jc.clone(),
-                    theme.resolve_font_ref(marker_fmt.font_family_ascii.clone()),
-                    theme.resolve_font_ref(marker_fmt.font_family_east_asia.clone()),
-                    Some(marker_font_facts),
-                    l.rpr.color.clone(),
-                    l.rpr.color_auto,
-                    l.pic_bullet.clone(),
-                )
-            })
-            .unwrap_or_else(|| {
-                (
-                    "decimal".to_string(),
-                    36.0,
-                    18.0,
-                    "tab".to_string(),
-                    "left".to_string(),
-                    theme.resolve_font_ref(first_fmt.font_family_ascii.clone()),
-                    theme.resolve_font_ref(first_fmt.font_family_east_asia.clone()),
-                    Some(resolved_run_font_facts(&first_fmt, theme)),
-                    None,
-                    false,
-                    None,
-                )
-            });
-        let counter = num_map.advance(num_id, num_level);
-        let text = num_map.resolve_text(num_id, num_level, counter);
-        let (
-            pic_bullet_image_path,
-            pic_bullet_mime_type,
-            pic_bullet_width_pt,
-            pic_bullet_height_pt,
-        ) = match pic_bullet {
-            Some(pb) => (
-                Some(pb.image_path),
-                Some(pb.mime_type),
-                pb.width_pt,
-                pb.height_pt,
-            ),
-            None => (None, None, None, None),
-        };
-        Some(Box::new(NumberingInfo {
-            num_id,
-            level: num_level,
-            format,
-            text,
-            indent_left: ind_left,
-            tab,
-            suff,
-            jc: lvl_jc,
-            font_family: marker_ascii,
-            font_family_east_asia: marker_ea,
-            font_facts: marker_font_facts,
-            color: marker_color,
-            color_auto: marker_color_auto,
-            pic_bullet_image_path,
-            pic_bullet_mime_type,
-            pic_bullet_width_pt,
-            pic_bullet_height_pt,
-        }))
+        Some(Box::new(resolve_numbering_marker(
+            num_map, num_id, num_level, &mark_run, theme,
+        )))
     });
     let level = numbering
         .as_ref()
@@ -9673,6 +9597,7 @@ fn extract_simple_paragraph_text(
         text,
         font_size_pt,
         color,
+        paragraph_mark_color: mark_run.color.clone(),
         font_family,
         bold,
         italic,
@@ -22681,6 +22606,48 @@ mod numbering_marker_font_tests {
         )
     }
 
+    fn parse_body_numbered_paragraph(paragraph: &str, numbering: &str) -> DocParagraph {
+        let body_xml = format!(r#"<w:document{NS}><w:body>{paragraph}</w:body></w:document>"#);
+        let doc = roxmltree::Document::parse(&body_xml).unwrap();
+        let body = doc
+            .root_element()
+            .descendants()
+            .find(|node| node.tag_name().name() == "body")
+            .unwrap();
+        let style_map = StyleMap::parse(&styles_xml());
+        let mut num_map = NumberingMap::parse(numbering, &HashMap::new());
+        parse_body_elements(
+            body,
+            &style_map,
+            &mut num_map,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .into_iter()
+        .find_map(|element| match element {
+            BodyElement::Paragraph(para) => Some(*para),
+            _ => None,
+        })
+        .expect("numbered body paragraph")
+    }
+
+    fn parse_textbox_numbered_paragraph(paragraph: &str, numbering: &str) -> ShapeText {
+        let doc = roxmltree::Document::parse(paragraph).unwrap();
+        let style_map = StyleMap::parse(&styles_xml());
+        let mut num_map = NumberingMap::parse(numbering, &HashMap::new());
+        extract_simple_paragraph_text(
+            &style_map,
+            &mut num_map,
+            doc.root_element(),
+            &ThemeColors::default(),
+            &HashMap::new(),
+        )
+        .expect("numbered text-box paragraph")
+    }
+
     /// Parse a body whose single paragraph is the numbered Heading1 "原稿の体裁".
     fn heading_para() -> DocParagraph {
         let body_xml = format!(
@@ -22780,6 +22747,92 @@ mod numbering_marker_font_tests {
             facts.font_family_east_asia.as_deref(),
             Some("ＭＳ ゴシック")
         );
+    }
+
+    /// Word compatibility observation: when §17.9.24 leaves a marker font or
+    /// color unspecified, Word uses the §17.3.1.29 paragraph-mark formatting,
+    /// not a content run. Body and text-box stories must project that observation
+    /// identically from the shared marker resolver.
+    #[test]
+    fn numbering_marker_inherits_direct_paragraph_mark_formatting_in_both_stories() {
+        let paragraph = format!(
+            r#"<w:p{NS}><w:pPr>
+              <w:pStyle w:val="見出し1"/>
+              <w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>
+              <w:rPr><w:rFonts w:ascii="ＭＳ Ｐゴシック" w:hAnsi="ＭＳ Ｐゴシック"
+                w:eastAsia="ＭＳ Ｐゴシック"/><w:color w:val="FF0000"/></w:rPr>
+            </w:pPr><w:r><w:rPr><w:rFonts w:ascii="Times New Roman"/>
+              <w:color w:val="00B050"/></w:rPr><w:t>body</w:t></w:r></w:p>"#,
+        );
+        let numbering_part = numbering_xml();
+        let body = parse_body_numbered_paragraph(&paragraph, &numbering_part);
+        let textbox = parse_textbox_numbered_paragraph(&paragraph, &numbering_part);
+        let body_numbering = body.numbering.as_ref().expect("body marker");
+        let textbox_numbering = textbox.numbering.as_ref().expect("text-box marker");
+
+        assert_eq!(
+            body_numbering.font_family.as_deref(),
+            Some("ＭＳ Ｐゴシック")
+        );
+        assert_eq!(
+            body_numbering.font_family_east_asia.as_deref(),
+            Some("ＭＳ Ｐゴシック"),
+        );
+        assert_eq!(body_numbering.font_family, textbox_numbering.font_family);
+        assert_eq!(
+            body_numbering.font_family_east_asia,
+            textbox_numbering.font_family_east_asia,
+        );
+        assert_eq!(body.paragraph_mark_color.as_deref(), Some("ff0000"));
+        assert_eq!(textbox.paragraph_mark_color.as_deref(), Some("ff0000"));
+        assert_eq!(textbox.runs[0].color.as_deref(), Some("00b050"));
+    }
+
+    /// The level's own §17.9.24 properties remain authoritative over the
+    /// Word-observed paragraph-mark fallback, in both WordprocessingML stories.
+    #[test]
+    fn numbering_level_formatting_wins_over_paragraph_mark_in_both_stories() {
+        let paragraph = format!(
+            r#"<w:p{NS}><w:pPr>
+              <w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>
+              <w:rPr><w:rFonts w:ascii="ＭＳ Ｐゴシック" w:hAnsi="ＭＳ Ｐゴシック"/>
+                <w:color w:val="FF0000"/></w:rPr>
+            </w:pPr><w:r><w:t>body</w:t></w:r></w:p>"#,
+        );
+        let numbering_part = format!(
+            r#"<w:numbering{NS}><w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0">
+              <w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1"/>
+              <w:rPr><w:rFonts w:ascii="Arial" w:hAnsi="Arial"/><w:color w:val="0070C0"/></w:rPr>
+            </w:lvl></w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="0"/>
+            </w:num></w:numbering>"#,
+        );
+        let body = parse_body_numbered_paragraph(&paragraph, &numbering_part);
+        let textbox = parse_textbox_numbered_paragraph(&paragraph, &numbering_part);
+        let body_numbering = body.numbering.as_ref().expect("body marker");
+        let textbox_numbering = textbox.numbering.as_ref().expect("text-box marker");
+
+        assert_eq!(body_numbering.font_family.as_deref(), Some("Arial"));
+        assert_eq!(body_numbering.color.as_deref(), Some("0070c0"));
+        assert_eq!(body_numbering.font_family, textbox_numbering.font_family);
+        assert_eq!(body_numbering.color, textbox_numbering.color);
+    }
+
+    #[test]
+    fn textbox_marker_retains_default_mark_ink_separately_from_content_color() {
+        let paragraph = format!(
+            r#"<w:p{NS}><w:pPr>
+              <w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>
+            </w:pPr><w:r><w:rPr><w:color w:val="00B050"/></w:rPr>
+              <w:t>body</w:t></w:r></w:p>"#,
+        );
+        let textbox = parse_textbox_numbered_paragraph(&paragraph, &numbering_xml());
+
+        assert_eq!(textbox.paragraph_mark_color, None);
+        assert_eq!(
+            serde_json::to_value(&textbox).unwrap()["paragraphMarkColor"],
+            serde_json::Value::Null,
+        );
+        assert_eq!(textbox.runs[0].color.as_deref(), Some("00b050"));
     }
 
     #[test]

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -835,10 +835,11 @@ pub struct DocParagraph {
     /// (direct `pPr/rPr` → pStyle chain → docDefaults, the same `mark_run`
     /// resolution that feeds `default_font_size`; hex 6 lowercased; an
     /// explicit `auto` breaks the chain and surfaces as `None`, §17.3.2.6).
-    /// Word formats a numbering marker with the level rPr (§17.9.24) layered
-    /// over the mark's run properties, so a mark-colored list item tints its
-    /// bullet/number even when the level rPr carries no color — the renderer
-    /// reads this as the marker-color fallback after `NumberingInfo::color`.
+    /// Office compatibility observation: when the numbering-level rPr
+    /// (§17.9.24) leaves color unspecified, Word falls back to the paragraph
+    /// mark's run properties. The renderer reads this after
+    /// `NumberingInfo::color`; §17.3.1.29 defines the mark properties but does
+    /// not itself define this cross-element fallback.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub paragraph_mark_color: Option<String>,
     /// ECMA-376 §17.3.1.20 `<w:outlineLvl w:val="N">` (0–8). Resolved through
@@ -1065,17 +1066,18 @@ pub struct NumberingInfo {
     /// lowercased like run colors). Colors the marker glyph only, never the
     /// paragraph's runs. `None` (absent `<w:color>`) lets the renderer fall
     /// back to the paragraph MARK's resolved color
-    /// (`DocParagraph::paragraph_mark_color`, §17.3.1.29 — Word layers the
-    /// level rPr over the mark's run properties), and finally to its default
-    /// ink. An explicit `val="auto"` is `None` + `color_auto` below.
+    /// (`DocParagraph::paragraph_mark_color`) under the isolated Word-observed
+    /// compatibility rule, and finally to its default ink. §17.3.1.29 defines
+    /// the mark properties but not that fallback. An explicit `val="auto"` is
+    /// `None` + `color_auto` below.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     /// ECMA-376 §17.3.2.6 / ST_HexColorAuto (§17.18.39) — true when the level
     /// rPr carries an EXPLICIT `<w:color w:val="auto"/>`. Auto names no
-    /// concrete color but is NOT "unset": layered over the paragraph mark
-    /// (§17.9.24 over §17.3.1.29) it breaks an inherited concrete mark color,
-    /// so the renderer must NOT fall back to `paragraph_mark_color` and draws
-    /// the automatic (default) ink instead.
+    /// concrete color but is NOT "unset": under the Word-observed marker
+    /// fallback it breaks an inherited concrete mark color, so the renderer
+    /// must NOT fall back to `paragraph_mark_color` and draws automatic/default
+    /// ink instead.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub color_auto: bool,
     /// ECMA-376 §17.9.9/§17.9.20 — when the level uses a `<w:lvlPicBulletId>`,
@@ -2391,6 +2393,13 @@ pub struct ShapeText {
     pub font_size_pt: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
+    /// Resolved run color of the paragraph mark. Kept separate from `color`,
+    /// which is the first content run's compatibility projection, so numbering
+    /// markers in text boxes use the same Word-observed fallback as body lists.
+    /// This field intentionally serializes `None` as null: null means resolution
+    /// selected automatic/default ink, while an absent field remains available
+    /// to legacy hand-built `ShapeText` values as "paragraph mark unknown".
+    pub paragraph_mark_color: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub font_family: Option<String>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]

--- a/packages/docx/src/charspacing-paint.test.ts
+++ b/packages/docx/src/charspacing-paint.test.ts
@@ -243,6 +243,29 @@ describe('run charSpacing/charScale reach the painted glyphs on every branch', (
     expect(followingInkLeftPx).toBeGreaterThanOrEqual(closingInkRightPx);
   });
 
+  it('preserves authored run spacing instead of layering punctuation compression over it', async () => {
+    const { canvas, fills } = makeRecordingCanvas();
+    const authoredText = '独自文面の配置を確認します）。';
+    const model = {
+      ...doc([para([
+        textRun(authoredText, { charSpacing: 0.4 }),
+        textRun('次'),
+      ])], section()),
+      settings: {
+        characterSpacingControl: 'compressPunctuation',
+      },
+    } as DocxDocumentModel;
+
+    await renderDocumentToCanvas(model, canvas, 0, { dpr: 1, width: 600 });
+
+    const authored = drawOf(fills, authoredText);
+    const following = drawOf(fills, '次');
+    expect(authored.letterSpacing).toBe('0.4px');
+    expect(fills.some(({ text }) => text === '）')).toBe(false);
+    expect(fills.some(({ text }) => text === '。')).toBe(false);
+    expect(following.x - authored.x).toBeCloseTo([...authoredText].length * (FONT_PX + 0.4), 5);
+  });
+
   it('does not collapse middle-punctuation advance into the following glyph', async () => {
     const { canvas, fills } = makeRecordingCanvas();
     const model = {

--- a/packages/docx/src/layout/body-layout-kernel.ts
+++ b/packages/docx/src/layout/body-layout-kernel.ts
@@ -1,7 +1,9 @@
 import type { SectionLayoutContext } from '../layout-context.js';
-import type { LineBoundary } from '../line-layout.js';
 import type { LayoutOptions } from './options.js';
-import type { ParagraphFragmentCursor } from './paragraph-pagination.js';
+import type {
+  ParagraphFragmentation,
+  ParagraphFragmentCursor,
+} from './paragraph-pagination.js';
 import type { TableFragmentCursor } from './table-pagination.js';
 import type { BodyAdjacentTableGroupInput } from './body-layout-input.js';
 import type {
@@ -83,7 +85,7 @@ export interface BodyTableAcquisitionInput {
 export interface AcquiredParagraphBlock {
   readonly layout: ParagraphLayout;
   readonly blockExtentPt: number;
-  readonly lineEndBoundaries: readonly LineBoundary[];
+  readonly fragmentation: ParagraphFragmentation;
   readonly uniformRubyAdvancePt?: number;
   readonly markBelowBaselinePt?: number;
   readonly flowRegistryDelta?: BodyFlowRegistryDeltaPt;

--- a/packages/docx/src/layout/body-page-numbering-production.test.ts
+++ b/packages/docx/src/layout/body-page-numbering-production.test.ts
@@ -171,7 +171,7 @@ function createServices(input: Readonly<{
         return {
           layout: paragraph(sourceIndex, heightPt),
           blockExtentPt: heightPt,
-          lineEndBoundaries: [],
+          fragmentation: { kind: 'indivisible' },
         };
       },
       measureTable: () => { throw new Error('unused'); },

--- a/packages/docx/src/layout/body-paginator-production.test.ts
+++ b/packages/docx/src/layout/body-paginator-production.test.ts
@@ -158,7 +158,7 @@ describe('canonical body producer', () => {
       openBodyLayoutSession: () => ({
         hasPaginationFields: false,
         measureParagraph: ({ input }) => ({
-          layout: layouts[input.source.path[0]!]!, blockExtentPt: 60, lineEndBoundaries: [],
+          layout: layouts[input.source.path[0]!]!, blockExtentPt: 60, fragmentation: { kind: 'indivisible' },
         }),
         measureTable: () => { throw new Error('unused'); },
         measureStoryExtent: () => 0,
@@ -231,7 +231,7 @@ describe('canonical body producer', () => {
               spacing: { beforePt: 0, afterPt: 10 },
             },
             blockExtentPt: 20,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -282,7 +282,7 @@ describe('canonical body producer', () => {
         measureParagraph: ({ input }) => ({
           layout: paragraphWithEndnotes('body', input.source, 20, ['end-1', 'end-2']),
           blockExtentPt: 20,
-          lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }],
+          fragmentation: { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] },
         }),
         measureTable: () => { throw new Error('unused'); },
         measureStoryExtent: () => 0,
@@ -335,7 +335,7 @@ describe('canonical body producer', () => {
         measureParagraph: ({ input }) => ({
           layout: paragraphWithFootnote('body', input.source, 20, 'end-1', 'endnote'),
           blockExtentPt: 20,
-          lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }],
+          fragmentation: { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] },
         }),
         measureTable: () => { throw new Error('unused'); },
         layoutNotes: () => {
@@ -388,7 +388,7 @@ describe('canonical body producer', () => {
         measureParagraph: ({ input }) => ({
           layout: paragraphWithFootnote('body', input.source, 20, 'end-1', 'endnote'),
           blockExtentPt: 20,
-          lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }],
+          fragmentation: { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] },
         }),
         measureTable: () => { throw new Error('unused'); },
         layoutNotes: () => { throw failure; },
@@ -439,7 +439,7 @@ describe('canonical body producer', () => {
         measureParagraph: ({ input }) => ({
           layout: paragraphWithFootnote('vertical-body', input.source, 20, 'vertical-note'),
           blockExtentPt: 20,
-          lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }],
+          fragmentation: { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] },
         }),
         measureTable: () => { throw new Error('unused'); },
         measureStoryExtent: () => 0,
@@ -498,7 +498,7 @@ describe('canonical body producer', () => {
               inkBounds: { ...layout.inkBounds, widthPt: 80 },
             },
             blockExtentPt: 20,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -603,7 +603,7 @@ describe('canonical body producer', () => {
         measureParagraph: ({ input }) => ({
           layout: paragraph(`p${input.source.path[0]}`, input.source, 20),
           blockExtentPt: 20,
-          lineEndBoundaries: [],
+          fragmentation: { kind: 'indivisible' },
         }),
         measureTable: () => { throw new Error('unused'); },
         measureStoryExtent: () => 0,
@@ -692,7 +692,7 @@ describe('canonical body producer', () => {
               inkBounds: { ...layout.inkBounds, widthPt: 80 },
             },
             blockExtentPt: 20,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -984,7 +984,9 @@ describe('canonical body producer', () => {
           return {
             layout,
             blockExtentPt: 10,
-            lineEndBoundaries: index === 0 ? [{ segIndex: 0, charOffset: 1 }] : [],
+            fragmentation: index === 0
+              ? { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] }
+              : { kind: 'indivisible' },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -1042,7 +1044,7 @@ describe('canonical body producer', () => {
           return {
             layout: paragraphWithFootnote(`note-${index}`, input.source, 10, `fn-${index}`),
             blockExtentPt: 10,
-            lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }],
+            fragmentation: { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -1105,7 +1107,7 @@ describe('canonical body producer', () => {
             return {
               layout: { ...layout, ordinaryFlow: false },
               blockExtentPt: 0,
-              lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }],
+              fragmentation: { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] },
               placement: {
                 coordinateSpace: 'logical-body' as const,
                 xPt: 10,
@@ -1119,7 +1121,7 @@ describe('canonical body producer', () => {
           return {
             layout: paragraph(`p-${index}`, input.source, heightPt),
             blockExtentPt: heightPt,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -1173,7 +1175,7 @@ describe('canonical body producer', () => {
             return {
               layout: { ...layout, ordinaryFlow: false },
               blockExtentPt: 0,
-              lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }],
+              fragmentation: { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] },
               placement: {
                 coordinateSpace: 'logical-body' as const,
                 xPt: 10,
@@ -1186,7 +1188,7 @@ describe('canonical body producer', () => {
           return {
             layout: paragraph('after', input.source, 10),
             blockExtentPt: 10,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -1249,7 +1251,7 @@ describe('canonical body producer', () => {
             return {
               layout: paragraph('prior', input.source, 75),
               blockExtentPt: 75,
-              lineEndBoundaries: [],
+              fragmentation: { kind: 'indivisible' },
             };
           }
           acquiredAt.push({ pageIndex: location.pageIndex, columnIndex: location.columnIndex });
@@ -1258,7 +1260,7 @@ describe('canonical body producer', () => {
           return {
             layout: { ...layout, ordinaryFlow: false },
             blockExtentPt: 0,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
             placement: {
               coordinateSpace: 'logical-body' as const,
               xPt: 10,
@@ -1364,7 +1366,7 @@ describe('canonical body producer', () => {
                 inkBounds: { ...retained.inkBounds, widthPt: 80 },
               },
               blockExtentPt: 80,
-              lineEndBoundaries: [],
+              fragmentation: { kind: 'indivisible' },
             };
           }
           acquiredAt.push({ pageIndex: location.pageIndex, columnIndex: location.columnIndex });
@@ -1377,7 +1379,7 @@ describe('canonical body producer', () => {
               inkBounds: { ...retained.inkBounds, widthPt: 80 },
             },
             blockExtentPt: 0,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
             placement: {
               coordinateSpace: 'logical-body' as const,
               xPt: location.cursorPt.xPt,
@@ -1463,7 +1465,7 @@ describe('canonical body producer', () => {
                 inkBounds: { ...retained.inkBounds, widthPt: 80 },
               },
               blockExtentPt: 60,
-              lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }],
+              fragmentation: { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] },
             };
           }
           acquiredAt.push({ pageIndex: location.pageIndex, columnIndex: location.columnIndex });
@@ -1476,7 +1478,7 @@ describe('canonical body producer', () => {
               inkBounds: { ...retained.inkBounds, widthPt: 80 },
             },
             blockExtentPt: 0,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
             placement: {
               coordinateSpace: 'logical-body' as const,
               xPt: location.cursorPt.xPt,
@@ -1551,7 +1553,7 @@ describe('canonical body producer', () => {
                 inkBounds: { ...retained.inkBounds, widthPt: 80 },
               },
               blockExtentPt: 75,
-              lineEndBoundaries: [],
+              fragmentation: { kind: 'indivisible' },
             };
           }
           acquiredAt.push({ pageIndex: location.pageIndex, columnIndex: location.columnIndex });
@@ -1563,7 +1565,7 @@ describe('canonical body producer', () => {
               inkBounds: { ...retained.inkBounds, widthPt: 80 },
             },
             blockExtentPt: 10,
-            lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }],
+            fragmentation: { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -1641,7 +1643,7 @@ describe('canonical body producer', () => {
               inkBounds: { ...retained.inkBounds, widthPt: 80 },
             },
             blockExtentPt: 75,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
           };
         },
         measureTable: ({ input, location }) => {
@@ -1705,7 +1707,7 @@ describe('canonical body producer', () => {
             return {
               layout: paragraph('prior', input.source, 75),
               blockExtentPt: 75,
-              lineEndBoundaries: [],
+              fragmentation: { kind: 'indivisible' },
             };
           }
           const ownLayout = index === 1
@@ -1714,7 +1716,7 @@ describe('canonical body producer', () => {
           return {
             layout: { ...ownLayout, ordinaryFlow: false },
             blockExtentPt: 0,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
             placement: {
               coordinateSpace: 'logical-body' as const,
               xPt: 10,
@@ -1768,7 +1770,7 @@ describe('canonical body producer', () => {
           return {
             layout: { ...layout, ordinaryFlow: false },
             blockExtentPt: 0,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
             placement: {
               coordinateSpace: 'logical-body' as const,
               xPt: 10,
@@ -1816,7 +1818,7 @@ describe('canonical body producer', () => {
         measureParagraph: ({ input }) => ({
           layout: paragraphWithFootnote('oversized-note', input.source, 10, 'too-tall'),
           blockExtentPt: 10,
-          lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }],
+          fragmentation: { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] },
         }),
         measureTable: () => { throw new Error('unused'); },
         measureStoryExtent: () => 0,
@@ -1898,7 +1900,9 @@ describe('canonical body producer', () => {
           return {
             layout: retained,
             blockExtentPt: retained.advancePt,
-            lineEndBoundaries: index === 2 ? [{ segIndex: 0, charOffset: 1 }] : [],
+            fragmentation: index === 2
+              ? { kind: 'splittable', lineEndBoundaries: [{ segIndex: 0, charOffset: 1 }] }
+              : { kind: 'indivisible' },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -1955,7 +1959,7 @@ describe('canonical body producer', () => {
           return {
             layout: paragraph(`p${index}`, input.source, extent),
             blockExtentPt: extent,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -2010,7 +2014,7 @@ describe('canonical body producer', () => {
             return {
               layout: paragraph('lead', input.source, 30),
               blockExtentPt: 30,
-              lineEndBoundaries: [],
+              fragmentation: { kind: 'indivisible' },
             };
           }
           const layout = paragraphWithFootnote(
@@ -2027,7 +2031,7 @@ describe('canonical body producer', () => {
               inkBounds: { ...layout.inkBounds, widthPt: 80 },
             },
             blockExtentPt: 0,
-            lineEndBoundaries: [],
+            fragmentation: { kind: 'indivisible' },
             placement: {
               coordinateSpace: 'logical-body' as const,
               xPt: 10,
@@ -2125,7 +2129,7 @@ describe('canonical body producer', () => {
         hasPaginationFields: false,
         measureParagraph: ({ input }) => ({
           layout: paragraph(`p${input.source.path[0]}`, input.source, heights[input.source.path[0]!]!),
-          blockExtentPt: heights[input.source.path[0]!]!, lineEndBoundaries: [],
+          blockExtentPt: heights[input.source.path[0]!]!, fragmentation: { kind: 'indivisible' },
         }),
         measureTable: () => { throw new Error('unused'); },
         measureStoryExtent: () => 0,
@@ -2179,7 +2183,7 @@ describe('canonical body producer', () => {
         measureParagraph: ({ input }) => ({
           layout: paragraph('follower', input.source, 10),
           blockExtentPt: 10,
-          lineEndBoundaries: [],
+          fragmentation: { kind: 'indivisible' },
         }),
         measureTable: ({ input }) => ({
           layout: table('upright', input.source, 30), blockExtentPt: 20,
@@ -2373,7 +2377,7 @@ describe('canonical body producer', () => {
         hasPaginationFields: false,
         measureParagraph: ({ input }) => ({
           layout: paragraph(`p${input.source.path[0]}`, input.source, heights[input.source.path[0]!]!),
-          blockExtentPt: heights[input.source.path[0]!]!, lineEndBoundaries: [],
+          blockExtentPt: heights[input.source.path[0]!]!, fragmentation: { kind: 'indivisible' },
         }),
         measureTable: () => { throw new Error('unused'); },
         measureStoryExtent: () => 0,
@@ -2436,7 +2440,7 @@ describe('canonical body producer', () => {
                   paragraphMark: { hidden: false, bounds: { ...layout.inkBounds, widthPt: 0 } },
                 }
               : layout,
-            blockExtentPt: heights[index]!, lineEndBoundaries: [],
+            blockExtentPt: heights[index]!, fragmentation: { kind: 'indivisible' },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -2499,7 +2503,7 @@ describe('canonical body producer', () => {
               flowBounds: { ...layout.flowBounds, widthPt: 80 },
               inkBounds: { ...layout.inkBounds, widthPt: 80 },
             },
-            blockExtentPt: 20, lineEndBoundaries: [],
+            blockExtentPt: 20, fragmentation: { kind: 'indivisible' },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -2584,7 +2588,7 @@ describe('canonical body producer', () => {
                   inkBounds: { ...layout.inkBounds, widthPt: 80 },
                 },
                 blockExtentPt: 1,
-                lineEndBoundaries: [],
+                fragmentation: { kind: 'indivisible' },
               };
             },
             measureTable: () => { throw new Error('unused'); },
@@ -2680,7 +2684,7 @@ describe('canonical body producer', () => {
           events.push(`measure:${input.source.path[0]}`);
           return {
             layout: paragraph(`p${input.source.path[0]}`, input.source, 20),
-            blockExtentPt: 20, lineEndBoundaries: [],
+            blockExtentPt: 20, fragmentation: { kind: 'indivisible' },
           };
         },
         measureTable: () => { throw new Error('unused'); },
@@ -2775,7 +2779,7 @@ describe('canonical body producer', () => {
                   }] : [],
                 },
                 blockExtentPt: 20,
-                lineEndBoundaries: [],
+                fragmentation: { kind: 'indivisible' },
               };
             }
             if (index === 2) {
@@ -2802,10 +2806,10 @@ describe('canonical body producer', () => {
               return {
                 layout: { ...sized, drawings: [drawing] },
                 blockExtentPt: 20,
-                lineEndBoundaries: [],
+                fragmentation: { kind: 'indivisible' },
               };
             }
-            return { layout: sized, blockExtentPt: 20, lineEndBoundaries: [] };
+            return { layout: sized, blockExtentPt: 20, fragmentation: { kind: 'indivisible' } };
           },
           measureTable: () => { throw new Error('unused'); },
           measureStoryExtent: () => 0,

--- a/packages/docx/src/layout/body-paginator.ts
+++ b/packages/docx/src/layout/body-paginator.ts
@@ -1269,7 +1269,7 @@ function paginateBodyPass(
         const selected = selectParagraphFragment(
           acquired.layout,
           cursor,
-          acquired.lineEndBoundaries,
+          acquired.fragmentation,
           location.availableBounds.heightPt + trailingMarkAdmissionAllowancePt,
           freshPageExtent(state),
           state.flow.pageHasContent,

--- a/packages/docx/src/layout/compatibility.test.ts
+++ b/packages/docx/src/layout/compatibility.test.ts
@@ -36,6 +36,7 @@ import {
 } from './anchor-compatibility.js';
 import {
   WORD_AUTO_MULTIPLE_BASELINE_PIN,
+  WORD_AUTHORED_CHARACTER_SPACING_PITCH_PRIORITY,
   WORD_CJK_BOTH_INTER_CHARACTER_EXPANSION,
   WORD_DEGENERATE_LINE_SPACING_SINGLE,
   WORD_DICTIONARY_SEA_ATOMIC_CHUNK,
@@ -51,6 +52,7 @@ import {
   WORD_MIXED_ANCHOR_VISIBLE_LINE_METRICS,
   WORD_MS_MINCHO_EMPTY_EAST_ASIAN_MARK_HEIGHT,
   WORD_NUMBERING_MARKER_OVERFLOW_TAB_ADVANCE,
+  WORD_NUMBERING_MARKER_PARAGRAPH_MARK_FALLBACK,
   WORD_NUMBERING_SUFFIX_COINCIDENT_LIST_TAB,
   WORD_NUMERIC_DECIMAL_TAB_INFERENCE,
   WORD_OVERFLOW_PUNCTUATION_LANGUAGE_SETS,
@@ -68,6 +70,7 @@ import {
   wordUseFeLayoutParagraphMarkGridAdvancePx,
   wordUseFeLayoutInheritedGridHeightPx,
   wordCandidateFitWidthPx,
+  wordDocumentCharacterCompressionApplies,
   wordJustifiedCandidateFitAllowancePx,
   wordJapanesePunctuationRetainedExtentPt,
   wordMsMinchoEmptyEastAsianMarkSingleLinePx,
@@ -304,12 +307,14 @@ describe('layout compatibility inventory', () => {
       WORD_JUSTIFIED_CANDIDATE_SEPARATOR_FIT,
       WORD_OVERFLOW_PUNCTUATION_LANGUAGE_SETS,
       WORD_FULL_WIDTH_CHARACTER_SPACING_SCOPE,
+      WORD_AUTHORED_CHARACTER_SPACING_PITCH_PRIORITY,
       WORD_RUBY_PARAGRAPH_UNIFORM_LINE_ADVANCE,
       WORD_FIT_TEXT_INTER_CHARACTER_EXPANSION,
       WORD_CJK_BOTH_INTER_CHARACTER_EXPANSION,
       WORD_THAI_DISTRIBUTE_CLUSTER_POLICY,
       WORD_NUMERIC_DECIMAL_TAB_INFERENCE,
       WORD_NUMBERING_MARKER_OVERFLOW_TAB_ADVANCE,
+      WORD_NUMBERING_MARKER_PARAGRAPH_MARK_FALLBACK,
       WORD_NUMBERING_SUFFIX_COINCIDENT_LIST_TAB,
       WORD_TAB_STOP_PAGE_EDGE_CLAMP,
       WORD_DICTIONARY_SEA_NATURAL_FIT,
@@ -404,6 +409,28 @@ describe('layout compatibility inventory', () => {
       punctuationInkEndPt: 6,
       ideographicCellAdvancePt: 10,
     })).toBe(6);
+    expect(WORD_AUTHORED_CHARACTER_SPACING_PITCH_PRIORITY.evidence).toEqual({
+      kind: 'office-observation',
+      syntheticFixtureId: 'authored-character-spacing-punctuation-pitch',
+      application: 'Microsoft Word',
+      version: '16.111.1',
+      platform: 'macOS 26.5.2',
+    });
+    expect(WORD_AUTHORED_CHARACTER_SPACING_PITCH_PRIORITY.description)
+      .not.toMatch(/sample|private|\.docx|\.pdf/i);
+    expect(wordDocumentCharacterCompressionApplies(undefined)).toBe(true);
+    expect(wordDocumentCharacterCompressionApplies(0)).toBe(true);
+    expect(wordDocumentCharacterCompressionApplies(0.4)).toBe(false);
+    expect(wordDocumentCharacterCompressionApplies(-0.5)).toBe(true);
+    expect(WORD_NUMBERING_MARKER_PARAGRAPH_MARK_FALLBACK.evidence).toEqual({
+      kind: 'office-observation',
+      syntheticFixtureId: 'numbering-marker-paragraph-mark-formatting',
+      application: 'Microsoft Word',
+      version: '16.111.1',
+      platform: 'macOS 26.5.2',
+    });
+    expect(WORD_NUMBERING_MARKER_PARAGRAPH_MARK_FALLBACK.description)
+      .not.toMatch(/sample|private|\.docx|\.pdf/i);
   });
 
   it('scopes the observed MS Mincho height to empty East-Asian marks', () => {

--- a/packages/docx/src/layout/header-footer-reserve-production.test.ts
+++ b/packages/docx/src/layout/header-footer-reserve-production.test.ts
@@ -151,7 +151,7 @@ function paginate(input: Readonly<{
       return {
         layout: paragraph(paragraphInput.source.path[0]!, heightPt),
         blockExtentPt: heightPt,
-        lineEndBoundaries: [],
+        fragmentation: { kind: 'indivisible' },
       };
     },
     measureTable: () => { throw new Error('unused'); },

--- a/packages/docx/src/layout/line-compatibility.ts
+++ b/packages/docx/src/layout/line-compatibility.ts
@@ -165,6 +165,18 @@ export const WORD_JAPANESE_PUNCTUATION_COMPRESSION_CELL = defineCompatibilityRul
   description: 'In the observed Japanese compatibility fixture, compressed full-width punctuation retains at least half of the ideographic cell measured through the selected font route. Tight adjacent glyph ink can require a larger retained extent to prevent collision. This is an Office-observed compression amount, not a normative interpretation of ST_CharacterSpacing.',
 });
 
+export const WORD_AUTHORED_CHARACTER_SPACING_PITCH_PRIORITY = defineCompatibilityRule({
+  id: 'word-authored-character-spacing-pitch-priority',
+  evidence: {
+    kind: 'office-observation',
+    syntheticFixtureId: 'authored-character-spacing-punctuation-pitch',
+    application: 'Microsoft Word',
+    version: '16.111.1',
+    platform: 'macOS 26.5.2',
+  },
+  description: 'When a run authors a positive w:spacing character pitch, Word preserves that expanded pitch instead of additionally applying the document-level punctuation whitespace compression. Omitted, zero, or overlapping run spacing leaves characterSpacingControl active.',
+});
+
 export const WORD_MS_MINCHO_EMPTY_EAST_ASIAN_MARK_HEIGHT = defineCompatibilityRule({
   id: 'word-ms-mincho-empty-east-asian-mark-height',
   evidence: {
@@ -193,6 +205,14 @@ export function wordJapanesePunctuationRetainedExtentPt(input: Readonly<{
       input.ideographicCellAdvancePt / 2,
     ),
   );
+}
+
+/** Compatibility projection governed by
+ * {@link WORD_AUTHORED_CHARACTER_SPACING_PITCH_PRIORITY}. */
+export function wordDocumentCharacterCompressionApplies(
+  authoredCharacterSpacingPt: number | undefined,
+): boolean {
+  return authoredCharacterSpacingPt === undefined || authoredCharacterSpacingPt <= 0;
 }
 
 const WORD_OVERFLOW_PUNCTUATION = {
@@ -307,6 +327,18 @@ export const WORD_NUMBERING_SUFFIX_COINCIDENT_LIST_TAB = defineCompatibilityRule
     reference: 'packages/docx/src/layout/numbering-marker.test.ts#keeps a suffix tab on the list stop coincident with the marker end',
   },
   description: 'For the tab synthesized by a numbering suffix, accept an authored numeric list tab coincident with the shaped marker end instead of advancing to the next automatic tab stop.',
+});
+
+export const WORD_NUMBERING_MARKER_PARAGRAPH_MARK_FALLBACK = defineCompatibilityRule({
+  id: 'word-numbering-marker-paragraph-mark-fallback',
+  evidence: {
+    kind: 'office-observation',
+    syntheticFixtureId: 'numbering-marker-paragraph-mark-formatting',
+    application: 'Microsoft Word',
+    version: '16.111.1',
+    platform: 'macOS 26.5.2',
+  },
+  description: 'When numbering-level rPr omits a marker formatting axis, Word takes that axis from the effective paragraph-mark rPr rather than a content run. A numbering-level concrete value or explicit auto remains authoritative, and body and text-box stories use the same cascade.',
 });
 
 /** Compatibility projection governed by {@link WORD_NUMBERING_SUFFIX_COINCIDENT_LIST_TAB}. */

--- a/packages/docx/src/layout/paragraph-pagination.test.ts
+++ b/packages/docx/src/layout/paragraph-pagination.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { selectParagraphFragment } from './paragraph-pagination.js';
 import type { LineLayout, ParagraphLayout } from './types.js';
 
+const splittable = (lineEndBoundaries: readonly { segIndex: number; charOffset: number }[]) => ({
+  kind: 'splittable' as const,
+  lineEndBoundaries,
+});
+
 const paragraph = (): ParagraphLayout => ({
   kind: 'paragraph', id: 'p', source: { story: 'body', storyInstance: 'body', path: [0] },
   flowDomainId: 'body', ordinaryFlow: true,
@@ -84,10 +89,45 @@ const verticalEdgeParagraph = (
 });
 
 describe('paragraph page-local reserve selection', () => {
+  it('does not require a source boundary for a single retained marker-only line', () => {
+    const retained = {
+      ...paragraph(),
+      flowBounds: { xPt: 0, yPt: 0, widthPt: 100, heightPt: 10 },
+      inkBounds: { xPt: 0, yPt: 0, widthPt: 100, heightPt: 10 },
+      advancePt: 10,
+      lines: paragraph().lines.slice(0, 1),
+    };
+
+    const selected = selectParagraphFragment(
+      retained,
+      { boundary: null },
+      { kind: 'indivisible' },
+      20,
+      40,
+      true,
+      { keepLines: false, widowControl: false },
+    );
+
+    expect(selected.fragment?.lines).toHaveLength(1);
+    expect(selected.nextCursor).toBeNull();
+  });
+
+  it('fails closed when a splittable retained paragraph lacks a continuation boundary', () => {
+    expect(() => selectParagraphFragment(
+      paragraph(),
+      { boundary: null },
+      splittable([{ segIndex: 0, charOffset: 1 }]),
+      20,
+      40,
+      true,
+      { keepLines: false, widowControl: false },
+    )).toThrow(/align with retained lines/i);
+  });
+
   it('admits a vertical-rl final visible baseline when only the retained line box crosses the block end', () => {
     const selected = selectParagraphFragment(
       verticalEdgeParagraph('vertical-rl', 17.5),
-      { boundary: null }, [{ segIndex: 0, charOffset: 1 }],
+      { boundary: null }, splittable([{ segIndex: 0, charOffset: 1 }]),
       20, 40, true,
       { keepLines: false, widowControl: false, writingMode: 'vertical-rl' },
     );
@@ -108,7 +148,7 @@ describe('paragraph page-local reserve selection', () => {
   ] as const)('relocates a %s', (_label, writingMode, baselinePt, resourceEndPt) => {
     const selected = selectParagraphFragment(
       verticalEdgeParagraph(writingMode, baselinePt, resourceEndPt),
-      { boundary: null }, [{ segIndex: 0, charOffset: 1 }],
+      { boundary: null }, splittable([{ segIndex: 0, charOffset: 1 }]),
       20, 40, true,
       { keepLines: false, widowControl: false, writingMode },
     );
@@ -123,7 +163,7 @@ describe('paragraph page-local reserve selection', () => {
   it('relocates a vertical final line whose selected-face ink crosses the edge', () => {
     const selected = selectParagraphFragment(
       verticalEdgeParagraph('vertical-rl', 17.5, undefined, 0, 3, true),
-      { boundary: null }, [{ segIndex: 0, charOffset: 1 }],
+      { boundary: null }, splittable([{ segIndex: 0, charOffset: 1 }]),
       20, 40, true,
       { keepLines: false, widowControl: false, writingMode: 'vertical-rl' },
     );
@@ -138,7 +178,7 @@ describe('paragraph page-local reserve selection', () => {
   it('fails closed when transformed final-line ink metrics are unavailable', () => {
     const selected = selectParagraphFragment(
       verticalEdgeParagraph('vertical-rl', 17.5, undefined, 0, undefined, true),
-      { boundary: null }, [{ segIndex: 0, charOffset: 1 }],
+      { boundary: null }, splittable([{ segIndex: 0, charOffset: 1 }]),
       20, 40, true,
       { keepLines: false, widowControl: false, writingMode: 'vertical-rl' },
     );
@@ -170,7 +210,7 @@ describe('paragraph page-local reserve selection', () => {
 
     const selected = selectParagraphFragment(
       withStroke,
-      { boundary: null }, [{ segIndex: 0, charOffset: 1 }],
+      { boundary: null }, splittable([{ segIndex: 0, charOffset: 1 }]),
       20, 40, true,
       { keepLines: false, widowControl: false, writingMode: 'vertical-rl' },
     );
@@ -184,7 +224,7 @@ describe('paragraph page-local reserve selection', () => {
 
   it('admits final visible content when only authored spaceAfter crosses the region edge', () => {
     const selected = selectParagraphFragment(
-      twoLineParagraph(10), { boundary: null }, twoLineBoundaries,
+      twoLineParagraph(10), { boundary: null }, splittable(twoLineBoundaries),
       20, 40, true,
       { keepLines: false, widowControl: true, authoredSpaceAfterPt: 10 },
     );
@@ -200,7 +240,7 @@ describe('paragraph page-local reserve selection', () => {
 
   it('relocates when final visible content itself crosses the region edge', () => {
     const selected = selectParagraphFragment(
-      twoLineParagraph(10), { boundary: null }, twoLineBoundaries,
+      twoLineParagraph(10), { boundary: null }, splittable(twoLineBoundaries),
       19, 40, true,
       { keepLines: false, widowControl: true, authoredSpaceAfterPt: 10 },
     );
@@ -214,7 +254,7 @@ describe('paragraph page-local reserve selection', () => {
 
   it('keeps retained trailing border extent in the final-fragment fit decision', () => {
     const selected = selectParagraphFragment(
-      twoLineParagraph(5, 12), { boundary: null }, twoLineBoundaries,
+      twoLineParagraph(5, 12), { boundary: null }, splittable(twoLineBoundaries),
       25, 40, true,
       { keepLines: false, widowControl: true, authoredSpaceAfterPt: 5 },
     );
@@ -228,7 +268,7 @@ describe('paragraph page-local reserve selection', () => {
 
   it('keeps page-local reserve in the final-fragment fit decision', () => {
     const selected = selectParagraphFragment(
-      twoLineParagraph(10), { boundary: null }, twoLineBoundaries,
+      twoLineParagraph(10), { boundary: null }, splittable(twoLineBoundaries),
       20, 40, true,
       { keepLines: false, widowControl: true, authoredSpaceAfterPt: 10 },
       () => 1,
@@ -243,11 +283,11 @@ describe('paragraph page-local reserve selection', () => {
 
   it('re-evaluates widow removal until the fragment satisfies orphan control', () => {
     const selected = selectParagraphFragment(
-      paragraph(), { boundary: null }, [
+      paragraph(), { boundary: null }, splittable([
         { segIndex: 0, charOffset: 1 },
         { segIndex: 0, charOffset: 2 },
         { segIndex: 0, charOffset: 3 },
-      ], 20, 40, true, { keepLines: false, widowControl: true },
+      ]), 20, 40, true, { keepLines: false, widowControl: true },
     );
 
     expect(selected).toMatchObject({
@@ -259,11 +299,11 @@ describe('paragraph page-local reserve selection', () => {
 
   it('admits only the fresh-region extent when an indivisible first line must make progress', () => {
     const selected = selectParagraphFragment(
-      paragraph(), { boundary: null }, [
+      paragraph(), { boundary: null }, splittable([
         { segIndex: 0, charOffset: 1 },
         { segIndex: 0, charOffset: 2 },
         { segIndex: 0, charOffset: 3 },
-      ], 5, 5, false, { keepLines: false, widowControl: false },
+      ]), 5, 5, false, { keepLines: false, widowControl: false },
     );
 
     expect(selected.fragment?.advancePt).toBe(10);
@@ -272,11 +312,11 @@ describe('paragraph page-local reserve selection', () => {
 
   it('selects against the reserve owned by each candidate slice', () => {
     const selected = selectParagraphFragment(
-      paragraph(), { boundary: null }, [
+      paragraph(), { boundary: null }, splittable([
         { segIndex: 0, charOffset: 1 },
         { segIndex: 0, charOffset: 2 },
         { segIndex: 0, charOffset: 3 },
-      ], 25, 40, false, { keepLines: false, widowControl: false },
+      ]), 25, 40, false, { keepLines: false, widowControl: false },
       (fragment) => fragment.lines.length >= 2 ? 10 : 0,
     );
 
@@ -286,11 +326,11 @@ describe('paragraph page-local reserve selection', () => {
 
   it('keeps a note-bearing slice out of a page whose global reserve cannot grow', () => {
     const selected = selectParagraphFragment(
-      paragraph(), { boundary: null }, [
+      paragraph(), { boundary: null }, splittable([
         { segIndex: 0, charOffset: 1 },
         { segIndex: 0, charOffset: 2 },
         { segIndex: 0, charOffset: 3 },
-      ], 40, 40, false, { keepLines: false, widowControl: false },
+      ]), 40, 40, false, { keepLines: false, widowControl: false },
       (fragment) => fragment.lines.length >= 2 ? 10 : 0,
       undefined,
       (reservePt) => reservePt <= 5,
@@ -302,11 +342,11 @@ describe('paragraph page-local reserve selection', () => {
 
   it('carries the uniform ruby advance into the exact next source cursor', () => {
     const selected = selectParagraphFragment(
-      paragraph(), { boundary: null }, [
+      paragraph(), { boundary: null }, splittable([
         { segIndex: 0, charOffset: 1 },
         { segIndex: 0, charOffset: 2 },
         { segIndex: 0, charOffset: 3 },
-      ], 15, 40, false, { keepLines: false, widowControl: false },
+      ]), 15, 40, false, { keepLines: false, widowControl: false },
       undefined,
       30,
     );

--- a/packages/docx/src/layout/paragraph-pagination.ts
+++ b/packages/docx/src/layout/paragraph-pagination.ts
@@ -22,6 +22,14 @@ export interface ParagraphFragmentSelection {
   readonly admittedBlockExtentPt: number;
 }
 
+export type ParagraphFragmentation =
+  | Readonly<{ kind: 'indivisible' }>
+  | Readonly<{
+      kind: 'splittable';
+      /** Source cursor after every retained visual line, including the final line. */
+      lineEndBoundaries: readonly LineBoundary[];
+    }>;
+
 function compareLineBoundaries(left: LineBoundary, right: LineBoundary): number {
   return left.segIndex - right.segIndex || left.charOffset - right.charOffset;
 }
@@ -29,7 +37,7 @@ function compareLineBoundaries(left: LineBoundary, right: LineBoundary): number 
 export function selectParagraphFragment(
   acquired: ParagraphLayout,
   cursor: ParagraphFragmentCursor,
-  lineEndBoundaries: readonly LineBoundary[],
+  fragmentation: ParagraphFragmentation,
   availableBlockExtentPt: number,
   freshFlowRegionBlockExtentPt: number,
   canRelocate: boolean,
@@ -50,8 +58,14 @@ export function selectParagraphFragment(
   if (![availableBlockExtentPt, freshFlowRegionBlockExtentPt].every(
     (value) => Number.isFinite(value) && value >= 0,
   )) throw new RangeError('Paragraph fragment extents must be finite and non-negative');
-  if (lineEndBoundaries.length !== acquired.lines.length) {
-    throw new RangeError('Paragraph source boundaries must align with retained lines');
+  if (
+    fragmentation.kind === 'splittable'
+    && fragmentation.lineEndBoundaries.length !== acquired.lines.length
+  ) {
+    throw new RangeError('Splittable paragraph source boundaries must align with retained lines');
+  }
+  if (fragmentation.kind === 'indivisible' && cursor.boundary !== null) {
+    throw new RangeError('Indivisible paragraph cannot carry a continuation boundary');
   }
   const authoredSpaceAfterPt = policy.authoredSpaceAfterPt ?? 0;
   if (!Number.isFinite(authoredSpaceAfterPt) || authoredSpaceAfterPt < 0) {
@@ -89,6 +103,26 @@ export function selectParagraphFragment(
       availableBlockExtentPt,
     });
   };
+  if (fragmentation.kind === 'indivisible') {
+    const completeReserve = reserveFor(acquired);
+    const completeExtentPt = admissionExtent(acquired, true);
+    if (canRelocate && (
+      completeExtentPt + completeReserve > availableBlockExtentPt
+      || !reserveFits(completeReserve)
+    ) && completeExtentPt + completeReserve <= freshFlowRegionBlockExtentPt) {
+      return {
+        fragment: null, nextCursor: cursor,
+        requiresFreshFlowRegion: true, additionalReservePt: 0, admittedBlockExtentPt: 0,
+      };
+    }
+    return {
+      fragment: acquired,
+      nextCursor: null,
+      requiresFreshFlowRegion: false,
+      additionalReservePt: completeReserve,
+      admittedBlockExtentPt: Math.min(acquired.advancePt, availableBlockExtentPt),
+    };
+  }
   if (total === 0) {
     const reserve = reserveFor(acquired);
     const completeExtentPt = admissionExtent(acquired, true);
@@ -158,7 +192,7 @@ export function selectParagraphFragment(
     end -= 1;
   }
   const fragment = slice(end);
-  const nextBoundary = end < total ? lineEndBoundaries[end - 1]! : null;
+  const nextBoundary = end < total ? fragmentation.lineEndBoundaries[end - 1]! : null;
   if (
     nextBoundary !== null
     && cursor.boundary !== null

--- a/packages/docx/src/layout/paragraph.test.ts
+++ b/packages/docx/src/layout/paragraph.test.ts
@@ -2380,6 +2380,10 @@ describe('planLine visual geometry', () => {
         { range: { start: 0, end: 1 }, offsetPt: 0, advancePt: 5 },
         { range: { start: 1, end: 2 }, offsetPt: 5, advancePt: 5 },
       ],
+      selectedFaceFontBox: { ascentPt: 8, descentPt: 2 },
+      selectedFaceInkBounds: {
+        xMinPt: 0, xMaxPt: 10, ascentPt: 7, descentPt: 2,
+      },
       smallCaps: true, underline: true, underlineStyle: 'double', underlineColor: 'auto',
       strikethrough: true, doubleStrikethrough: false,
       emphasisMark: 'dot', position: 2, vertAlign: null, fontSize: 10,

--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -898,7 +898,14 @@ export function planLine(input: PlanLineInput): LineLayout {
         ...(ownedTrailingSlackPt !== 0 ? { ownedTrailingSlackPt } : {}),
         ...((style.highlight || style.background) ? {
           highlightFragments: [{
-            rect: {
+            rect: style.highlight && retainedGeometry ? {
+              xPt,
+              // ECMA-376 §17.3.2.15 applies highlighting behind the run
+              // contents, not across the paragraph's authored line advance.
+              yPt: line.baselinePt + baselineOffsetPt - retainedGeometry.base.ascentPt,
+              widthPt: widthPt + ownedTrailingSlackPt,
+              heightPt: retainedGeometry.base.ascentPt + retainedGeometry.base.descentPt,
+            } : {
               xPt, yPt: line.topPt,
               widthPt: widthPt + ownedTrailingSlackPt,
               heightPt: line.advancePt,
@@ -1592,7 +1599,7 @@ function retainedGeometryPlan(
   sourceOffset: number,
   color: TextPlacement['color'],
 ): RetainedTextGeometryPlan | undefined {
-  if (!(segment.underline || segment.strikethrough
+  if (!(segment.highlight || segment.underline || segment.strikethrough
     || segment.doubleStrikethrough || segment.emphasisMark)) return undefined;
   const service = segment.textLayoutService;
   const request = segment.textShapeRequest;
@@ -1612,7 +1619,15 @@ function retainedGeometryPlan(
       ...(span.inkBounds ? { inkBounds: span.inkBounds } : {}),
     };
   };
-  const base = shape(segment.text);
+  const fontBox = segment.selectedFaceFontBox;
+  if (!fontBox || !segment.selectedFaceInkBounds) {
+    throw new Error('Retained typography geometry requires authoritative selected-face metrics');
+  }
+  const base: RetainedInkMetric = {
+    ascentPt: fontBox.ascentPt,
+    descentPt: fontBox.descentPt,
+    inkBounds: segment.selectedFaceInkBounds,
+  };
   const textColor = retainedColorString(color);
   const underline = segment.underline ? {
     ...(segment.underlineStyle ? { authoredStyle: segment.underlineStyle } : {}),
@@ -3920,6 +3935,9 @@ function immutableMeasuredLayoutSegment(
       } : {}),
       ...(segment.selectedFaceInkBounds ? {
         selectedFaceInkBounds: Object.freeze({ ...segment.selectedFaceInkBounds }),
+      } : {}),
+      ...(segment.selectedFaceFontBox ? {
+        selectedFaceFontBox: Object.freeze({ ...segment.selectedFaceFontBox }),
       } : {}),
       ...(segment.ruby ? { ruby: Object.freeze({ ...segment.ruby }) } : {}),
       ...(segment.border ? { border: Object.freeze({ ...segment.border }) } : {}),

--- a/packages/docx/src/layout/production-body-layout.ts
+++ b/packages/docx/src/layout/production-body-layout.ts
@@ -970,7 +970,7 @@ function buildConcreteBodyLayoutKernel(
               // The catalogued projection preserves the §17.3.1.11 authored
               // exclusion height; see WORD_LOWERED_DROP_CAP_ANCHOR_LEADING.
               blockExtentPt: dropCapAnchorLeadingPt,
-              lineEndBoundaries: Object.freeze([]),
+              fragmentation: Object.freeze({ kind: 'indivisible' as const }),
               placement: Object.freeze({
                 coordinateSpace: 'logical-body' as const,
                 xPt: member.fragment.flowBounds.xPt,
@@ -1037,7 +1037,12 @@ function buildConcreteBodyLayoutKernel(
           return Object.freeze({
             layout,
             blockExtentPt: layout.advancePt,
-            lineEndBoundaries: Object.freeze(allBoundaries),
+            fragmentation: measured.markOnly
+              ? Object.freeze({ kind: 'indivisible' as const })
+              : Object.freeze({
+                  kind: 'splittable' as const,
+                  lineEndBoundaries: Object.freeze(allBoundaries),
+                }),
             ...(measured.markOnly
               ? { markBelowBaselinePt: measured.lastLineBelowBaselinePt }
               : {}),

--- a/packages/docx/src/layout/textbox-input.ts
+++ b/packages/docx/src/layout/textbox-input.ts
@@ -109,7 +109,9 @@ export function normalizeTextBoxInput(
       bold: block.bold,
       italic: block.italic,
     }];
-    const paragraphMarkColor = block.color ?? runs[0]?.color;
+    const paragraphMarkColor = block.paragraphMarkColor === undefined
+      ? block.color ?? runs[0]?.color
+      : block.paragraphMarkColor ?? undefined;
     const numbering = block.numbering
       ? {
           ...block.numbering,

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -95,6 +95,7 @@ import {
   wordCandidateFitWidthPx,
   wordJustifiedCandidateFitAllowancePx,
   wordIsOverflowPunctuation,
+  wordDocumentCharacterCompressionApplies,
   wordJapanesePunctuationRetainedExtentPt,
   wordMsMinchoEmptyEastAsianMarkSingleLinePx,
   wordUniformRunPositionPaintPt,
@@ -158,6 +159,10 @@ export interface LayoutTextSeg extends LayoutSegSource {
   /** Tight selected-face ink retained by the authoritative shape call that
    * also produced `shapedClusters`. */
   selectedFaceInkBounds?: GlyphInkBounds;
+  /** Selected-face font box retained by that same authoritative shape call.
+   * Decorations and highlighting consume this instead of shaping the placed
+   * run a second time. */
+  selectedFaceFontBox?: Readonly<{ ascentPt: number; descentPt: number }>;
   /** False when this segment starts inside the preceding grapheme cluster. */
   breakBefore?: boolean;
   smallCaps?: boolean;
@@ -2564,6 +2569,13 @@ export function buildSegments(
       r.position,
     );
     const effectiveCharacterSpacing = acquiredTypography?.characterSpacingPt ?? r.charSpacing;
+    // ECMA-376 §17.3.2.35 gives an authored run an explicit character pitch.
+    // Word observation: a positive `w:spacing` owns that expanded pitch and suppresses
+    // document-level §17.15.1.18 punctuation whitespace compression for the
+    // run. Combining both adjustments collapses consecutive Japanese closing
+    // punctuation even though Word preserves the authored spacing.
+    const documentCharacterCompressionApplies =
+      wordDocumentCharacterCompressionApplies(effectiveCharacterSpacing);
     const effectiveCharacterScale = acquiredTypography?.characterScale ?? r.charScale;
     const effectiveKerningThreshold = acquiredTypography?.kerningThresholdPt ?? r.kerning;
     const effectiveSnapToGrid = acquiredTypography?.snapToGrid ?? r.snapToGrid;
@@ -2663,6 +2675,7 @@ export function buildSegments(
       // whitespace. Non-eligible text retains contextual shaping.
       if (
         !compressCharacterWhitespace
+        && documentCharacterCompressionApplies
         && fitTextRegionIndex === undefined
       ) {
         const boundaries = [0, ...graphemeClusterOffsets(text), text.length];
@@ -2713,7 +2726,8 @@ export function buildSegments(
       const shaped = authoritativeSpan
         ? { spans: [authoritativeSpan] }
         : environment.layoutServices?.text.shape(textShapeRequest);
-      const punctuationCompressions = compressCharacterWhitespace
+      const punctuationCompressions =
+        compressCharacterWhitespace && documentCharacterCompressionApplies
         ? (() => {
             const boundaries = [0, ...graphemeClusterOffsets(text), text.length];
             const compressions: Array<{ end: number; adjustmentPt: number }> = [];
@@ -2812,7 +2826,8 @@ export function buildSegments(
               : span.script === 'highAnsi'
                 ? highAnsiFontFamily
                 : base.fontFamily;
-          const compressedSpan = compressCharacterWhitespace
+          const compressedSpan = documentCharacterCompressionApplies
+            && compressCharacterWhitespace
             && [...span.text].some((grapheme) =>
               characterSpacingControlCompresses(
                 grapheme,
@@ -3908,6 +3923,10 @@ export function layoutLines(
       });
       if (clusterGeometry) {
         s.shapedClusters = shaped.clusters;
+        s.selectedFaceFontBox = {
+          ascentPt: shaped.ascentPt,
+          descentPt: shaped.descentPt,
+        };
         s.selectedFaceInkBounds = shaped.inkBounds ?? {
           xMinPt: 0,
           xMaxPt: shaped.advancePt,

--- a/packages/docx/src/numbering-marker-color.test.ts
+++ b/packages/docx/src/numbering-marker-color.test.ts
@@ -234,6 +234,28 @@ describe('text-box marker color (§17.9.24)', () => {
     expect(textboxMarkerFill({ color: '00b050' })).toBe('#00b050');
   });
 
+  it('uses the retained paragraph-mark color instead of the first content color', () => {
+    expect(textboxMarkerFill({
+      paragraphMarkColor: 'ff0000',
+      color: '00b050',
+      runs: [{ text: 'item', fontSizePt: 10, color: '00b050' }],
+    })).toBe('#ff0000');
+  });
+
+  it('uses default ink when parser-owned paragraph-mark resolution serializes null', () => {
+    expect(textboxMarkerFill({
+      paragraphMarkColor: null,
+      color: '00b050',
+      runs: [{ text: 'item', fontSizePt: 10, color: '00b050' }],
+    })).toBe('#000000');
+  });
+
+  it('preserves the legacy first-run color fallback when paragraph-mark facts are absent', () => {
+    expect(textboxMarkerFill({
+      runs: [{ text: 'item', fontSizePt: 10, color: '00b050' }],
+    })).toBe('#00b050');
+  });
+
   it('explicit level auto stops at the default ink, not the block color', () => {
     const fill = textboxMarkerFill({
       color: '00b050',

--- a/packages/docx/src/punctuation-layout.test.ts
+++ b/packages/docx/src/punctuation-layout.test.ts
@@ -173,6 +173,27 @@ function punctuationMetricsServices(options: Readonly<{
 }
 
 describe('ECMA-376 East-Asian punctuation fit', () => {
+  it('does not apply document-level punctuation compression over authored run spacing', () => {
+    const authoredText = '独自文面の配置を確認します）。';
+    const run = {
+      ...textRun(authoredText),
+      charSpacing: 0.4,
+    } as DocParagraph['runs'][number];
+    const segments = buildSegments([run], {
+      pageIndex: 0,
+      totalPages: 1,
+      characterSpacingControl: 'compressPunctuation',
+      layoutServices: punctuationMetricsServices(),
+    }) as LayoutTextSeg[];
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0].punctuationCompressions).toBeUndefined();
+    expect(segments[0].charSpacing).toBe(0.4);
+    const authoredWidthPt = [...authoredText].length * 10.4;
+    expect(lines(segments, authoredWidthPt, false)[0].segments[0].measuredWidth)
+      .toBeCloseTo(authoredWidthPt, 5);
+  });
+
   it('retains at least a half-width cell around compressed full-width punctuation', () => {
     const segments = buildSegments([textRun('甲乙．丙')], {
       pageIndex: 0,

--- a/packages/docx/src/renderer.textbox-image.test.ts
+++ b/packages/docx/src/renderer.textbox-image.test.ts
@@ -402,6 +402,7 @@ describe('textbox rich text — per-run formatting', () => {
     shape.defaultTextColor = 'FFFFFF';
     shape.textBlocks![0].indentLeft = 36;
     shape.textBlocks![0].indentFirst = -36;
+    shape.textBlocks![0].paragraphMarkColor = '000000';
     shape.textBlocks![0].numbering = {
       numId: 5,
       level: 0,

--- a/packages/docx/src/run-inline-formatting.test.ts
+++ b/packages/docx/src/run-inline-formatting.test.ts
@@ -258,7 +258,21 @@ describe('run box (w:bdr §17.3.2.4) + shading (w:shd §17.3.2.32) geometry', ()
   });
 });
 
-describe('highlight fill spans justification slack (§17.3.1.15 highlight + §17.18.44 both)', () => {
+describe('highlight fill spans justification slack (§17.3.2.15 highlight + §17.18.44 both)', () => {
+  it('uses the selected font box instead of the paragraph line advance', async () => {
+    const events = await render(
+      [textRun('Highlighted', { highlight: 'black' })],
+      { lineSpacing: { value: 30, rule: 'exact', explicit: true } },
+    );
+    const fill = events.find(
+      (event): event is Extract<DrawEvent, { kind: 'fillRect' }> =>
+        event.kind === 'fillRect' && event.style.toUpperCase() === '#000000',
+    );
+
+    expect(fill).toBeDefined();
+    expect(fill?.h).toBeCloseTo(16);
+  });
+
   it('tiles the highlight with no gaps across justified inter-word spaces', async () => {
     // A justified ('both') paragraph that wraps to 2+ lines. Line 0 is justified,
     // so its inter-word spaces are expanded by the per-gap slack. Word highlights

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -500,10 +500,9 @@ export interface DocParagraph {
   defaultFontFamilyEastAsia?: string | null;
   /** ECMA-376 §17.3.1.29 — the paragraph mark run's resolved `w:color` (direct
    *  pPr/rPr → pStyle chain → docDefaults; hex 6 without `#`, lowercased; an
-   *  explicit `auto` surfaces as absent, §17.3.2.6). The numbering level rPr
-   *  (§17.9.24) layers over the mark's run properties, so the renderer uses
-   *  this as the marker-color fallback when {@link NumberingInfo.color} is
-   *  absent. */
+   *  explicit `auto` surfaces as absent, §17.3.2.6). Compatibility rule
+   *  `word-numbering-marker-paragraph-mark-fallback` uses this when §17.9.24
+   *  leaves {@link NumberingInfo.color} absent. */
   paragraphMarkColor?: string | null;
   /**
    * ECMA-376 §17.3.1.6 `<w:bidi>` — right-to-left paragraph. `true` = RTL,
@@ -636,7 +635,8 @@ export interface NumberingInfo {
    *  it (the renderer treats absent as "left"). */
   jc?: string;
   /** ECMA-376 §17.3.2.26 ascii axis for the marker glyph, resolved through the
-   *  level's `rPr` (§17.9.6) merged over the paragraph's run formatting. The
+   *  level's `rPr` (§17.9.24) plus compatibility rule
+   *  `word-numbering-marker-paragraph-mark-fallback`. The
    *  renderer draws Latin marker chars (e.g. a decimal "1") with this family, so
    *  a heading whose ascii=Times renders its auto-number in Times (serif) even
    *  when eastAsia=Gothic. Absent ⇒ the renderer falls back to its default. */
@@ -649,9 +649,11 @@ export interface NumberingInfo {
   /** ECMA-376 §17.9.24 — the numbering level rPr's `w:color` (hex 6 without
    *  `#`, lowercased). Colors the marker glyph only, never the paragraph's
    *  runs. Absent ⇒ the renderer falls back to
-   *  {@link DocParagraph.paragraphMarkColor} (§17.3.1.29 — the level rPr layers
-   *  over the paragraph mark's run properties) and finally to its
-   *  default ink. An explicit `w:val="auto"` is absent here + {@link colorAuto}. */
+   *  {@link DocParagraph.paragraphMarkColor} under compatibility rule
+   *  `word-numbering-marker-paragraph-mark-fallback`, then to its default ink.
+   *  §17.3.1.29 defines the
+   *  mark properties but not that fallback. An explicit `w:val="auto"` is
+   *  absent here + {@link colorAuto}. */
   color?: string | null;
   /** ECMA-376 §17.3.2.6 / ST_HexColorAuto (§17.18.39) — true when the level
    *  rPr carries an EXPLICIT `w:color w:val="auto"`. Auto names no concrete
@@ -952,6 +954,13 @@ export interface ShapeText {
   text: string;
   fontSizePt: number;
   color?: string | null;
+  /** Resolved paragraph-mark run color used by compatibility rule
+   *  `word-numbering-marker-paragraph-mark-fallback` when the numbering level
+   *  has no explicit color; kept separate from the first content run's
+   *  compatibility-level {@link ShapeText.color}. `null` means the parser
+   *  resolved automatic/default ink; `undefined` preserves the legacy contract
+   *  for hand-built values that did not provide paragraph-mark facts. */
+  paragraphMarkColor?: string | null;
   fontFamily?: string | null;
   bold?: boolean;
   italic?: boolean;


### PR DESCRIPTION
## Summary
- carry explicit splittable/indivisible paragraph fragmentation metadata through pagination
- resolve numbering marker font and color once from level and paragraph-mark properties for body and text boxes
- retain selected font geometry for run highlights instead of reshaping during paint planning
- honor positive authored character spacing ahead of document-level punctuation compression through an evidence-backed compatibility rule

## Specification and compatibility
- ECMA-376 sections 17.3.2.15, 17.3.2.23, 17.9.24, and 17.15.1.18
- Office-observed inheritance and pitch precedence are isolated in the compatibility inventory rather than treated as normative rules

## Verification
- 6,425 Vitest tests
- 493 Rust tests
- TypeScript typecheck
- DOCX final architecture, compatibility, public API, and package ownership gates
- local-only before/after visual comparison of every page in the private DOCX regression corpus
- two independent critical architecture/spec-first reviews: approved