### PR TITLE
fix(examples): keep scroll viewer backgrounds transparent

### DIFF
--- a/examples/frameworks/react/src/useOfficeViewer.tsx
+++ b/examples/frameworks/react/src/useOfficeViewer.tsx
@@ -51,11 +51,10 @@ function createViewer(
     return new XlsxViewer(container, { showZoomSlider: true });
   }
   if (format === 'pptx') {
-    return new PptxScrollViewer(container, { background: '#53606d' });
+    return new PptxScrollViewer(container);
   }
   return new DocxScrollViewer(container, {
     enableTextSelection: true,
-    background: '#53606d',
   });
 }
 

--- a/examples/frameworks/solid/src/createOfficeViewer.ts
+++ b/examples/frameworks/solid/src/createOfficeViewer.ts
@@ -32,11 +32,10 @@ function createViewer(
     return new XlsxViewer(container, { showZoomSlider: true });
   }
   if (format === 'pptx') {
-    return new PptxScrollViewer(container, { background: '#53606d' });
+    return new PptxScrollViewer(container);
   }
   return new DocxScrollViewer(container, {
     enableTextSelection: true,
-    background: '#53606d',
   });
 }
 

--- a/examples/frameworks/svelte/src/createOfficeViewer.ts
+++ b/examples/frameworks/svelte/src/createOfficeViewer.ts
@@ -45,11 +45,10 @@ function createViewer(
     return new XlsxViewer(container, { showZoomSlider: true });
   }
   if (format === 'pptx') {
-    return new PptxScrollViewer(container, { background: '#53606d' });
+    return new PptxScrollViewer(container);
   }
   return new DocxScrollViewer(container, {
     enableTextSelection: true,
-    background: '#53606d',
   });
 }
 

--- a/examples/frameworks/vue/src/useOfficeViewer.ts
+++ b/examples/frameworks/vue/src/useOfficeViewer.ts
@@ -32,11 +32,10 @@ function createViewer(
     return new XlsxViewer(container, { showZoomSlider: true });
   }
   if (format === 'pptx') {
-    return new PptxScrollViewer(container, { background: '#53606d' });
+    return new PptxScrollViewer(container);
   }
   return new DocxScrollViewer(container, {
     enableTextSelection: true,
-    background: '#53606d',
   });
 }
 

--- a/site/src/framework-guides.test.ts
+++ b/site/src/framework-guides.test.ts
@@ -177,4 +177,15 @@ describe('framework integration guides', () => {
     expect(packageJson.stackblitz?.startCommand).toBe(false);
   });
 
+  it.each(['react', 'vue', 'svelte', 'solid'])(
+    'keeps the %s viewer surface transparent and owns the desk background in CSS',
+    (framework) => {
+      const integration = exampleSource(exampleFiles[framework].integration);
+      const css = exampleSource(`${framework}/src/example.css`);
+
+      expect(integration).not.toMatch(/\bbackground\s*:/);
+      expect(css).toMatch(/\.stage\s*\{[\s\S]*?background:\s*#53606d;/);
+    },
+  );
+
 });


### PR DESCRIPTION
## Summary
- remove duplicate desk background options from the React, Vue, Svelte, and Solid ScrollViewer constructors
- keep the visual desk background owned solely by each example's outer stage CSS
- add a contract test covering all four portable framework integrations

## Verification
- `./node_modules/.bin/vitest run site/src/framework-guides.test.ts`
- `pnpm check` in `examples/frameworks`
- `./node_modules/.bin/astro build` in `site`
- `git diff --check`