### PR TITLE
feat(site): add JavaScript viewer SEO foundation

### DIFF
--- a/site/src/components/FrameworkGuide.astro
+++ b/site/src/components/FrameworkGuide.astro
@@ -8,6 +8,7 @@ import {
   getFrameworkGuide,
   type FrameworkId,
 } from '../lib/framework-guides';
+import { canonicalPageUrl } from '../lib/seo';
 
 interface Props {
   framework: FrameworkId;
@@ -22,7 +23,7 @@ const structuredData = JSON.stringify({
   '@type': 'TechArticle',
   headline: guide.title,
   description: guide.description,
-  url: `https://ooxml.silurus.dev${canonicalPath}`,
+  url: canonicalPageUrl(canonicalPath),
   proficiencyLevel: 'Beginner',
   dependencies: `${guide.name}, TypeScript, @silurus/ooxml`,
 });

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -1,12 +1,14 @@
 ---
 import '../styles/global.css';
+import { canonicalPageUrl, siteMetadata } from '../lib/seo';
 const {
-  title = 'Office Open XML Viewer',
-  description = 'Browser-based OOXML viewer (docx / xlsx / pptx) — Rust/WASM parser + Canvas renderer.',
+  title = siteMetadata.title,
+  description = siteMetadata.description,
   canonicalPath,
 } = Astro.props;
 const base = import.meta.env.BASE_URL;
-const canonicalUrl = canonicalPath ? new URL(canonicalPath, 'https://ooxml.silurus.dev').href : undefined;
+const canonicalUrl = canonicalPath ? canonicalPageUrl(canonicalPath) : undefined;
+const socialImageUrl = canonicalPageUrl('/icon.png');
 ---
 <!doctype html>
 <html lang="en">
@@ -22,8 +24,9 @@ const canonicalUrl = canonicalPath ? new URL(canonicalPath, 'https://ooxml.silur
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
+    <meta property="og:site_name" content={siteMetadata.name} />
     {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
-    <meta property="og:image" content={`${base}icon.png`.replace(/([^:])\/\/+/g, '$1/')} />
+    <meta property="og:image" content={socialImageUrl} />
     <meta name="twitter:card" content="summary" />
     <script is:inline>
       (() => {

--- a/site/src/layouts/FormatPage.astro
+++ b/site/src/layouts/FormatPage.astro
@@ -2,24 +2,24 @@
 import Base from './Base.astro';
 import Nav from '../components/Nav.astro';
 import SiteFooter from '../components/SiteFooter.astro';
+import { formatSeo } from '../lib/seo';
 interface Props {
   format: 'pptx' | 'docx' | 'xlsx';
   name: string;   // "PowerPoint"
   ext: string;    // ".pptx"
-  tagline: string;
 }
-const { format, name, ext, tagline } = Astro.props;
-const title = `${name} (${ext}) — @silurus/ooxml`;
+const { format, name, ext } = Astro.props;
+const seo = formatSeo[format];
 const fileNoun = { docx: 'Word document', xlsx: 'Excel workbook', pptx: 'PowerPoint deck' }[format];
 ---
-<Base title={title}>
+<Base title={seo.title} description={seo.description} canonicalPath={`/${format}/`}>
   <Nav active={format} />
 
   <header class="fp-hero" data-format={format}>
     <div class="wrap">
       <a class="fp-back" href="/">← All formats</a>
       <p class="eyebrow">{name}</p>
-      <h1 class="fp-title">{tagline}</h1>
+      <h1 class="fp-title">{seo.heading}</h1>
       <p class="fp-lead">
         The examples below render a sample {fileNoun} (<code>{ext}</code>) in your browser and show
         the corresponding TypeScript.

--- a/site/src/lib/seo.ts
+++ b/site/src/lib/seo.ts
@@ -1,0 +1,40 @@
+export const siteMetadata = {
+  name: '@silurus/ooxml',
+  alternateName: 'OOXML Viewer',
+  origin: 'https://ooxml.silurus.dev',
+  title: 'OOXML Viewer | JavaScript Office File Viewer',
+  description:
+    'Open-source JavaScript and TypeScript Office file viewer library for rendering DOCX, XLSX and PPTX directly in the browser with WebAssembly and Canvas. No upload or server-side conversion.',
+} as const;
+
+export const formatSeo = {
+  docx: {
+    title: 'JavaScript DOCX Viewer Library | @silurus/ooxml',
+    description:
+      'Open-source JavaScript and TypeScript DOCX viewer library for rendering Word documents directly in the browser with WebAssembly and Canvas.',
+    heading: 'Render DOCX files in the browser with JavaScript.',
+  },
+  xlsx: {
+    title: 'JavaScript XLSX Viewer Library | @silurus/ooxml',
+    description:
+      'Open-source JavaScript and TypeScript XLSX viewer library for rendering Excel workbooks directly in the browser with WebAssembly and Canvas.',
+    heading: 'Render XLSX files in the browser with JavaScript.',
+  },
+  pptx: {
+    title: 'JavaScript PPTX Viewer Library | @silurus/ooxml',
+    description:
+      'Open-source JavaScript and TypeScript PPTX viewer library for rendering PowerPoint presentations directly in the browser with WebAssembly and Canvas.',
+    heading: 'Render PPTX files in the browser with JavaScript.',
+  },
+} as const;
+
+const filePathPattern = /\/[^/]+\.[^/]+$/;
+
+export function canonicalPageUrl(path: string): string {
+  const absolutePath = path.startsWith('/') ? path : `/${path}`;
+  const normalizedPath =
+    absolutePath === '/' || absolutePath.endsWith('/') || filePathPattern.test(absolutePath)
+      ? absolutePath
+      : `${absolutePath}/`;
+  return new URL(normalizedPath, siteMetadata.origin).href;
+}

--- a/site/src/pages/announcements/[slug].astro
+++ b/site/src/pages/announcements/[slug].astro
@@ -14,7 +14,11 @@ export function getStaticPaths() {
 
 const { announcement } = Astro.props as { announcement: Announcement };
 ---
-<Base title={`${announcement.title} — @silurus/ooxml`} description={announcement.summary}>
+<Base
+  title={`${announcement.title} — @silurus/ooxml`}
+  description={announcement.summary}
+  canonicalPath={`/announcements/${announcement.slug}/`}
+>
   <Nav active="announcements" />
   <main>
     <header class="article-hero">

--- a/site/src/pages/announcements/index.astro
+++ b/site/src/pages/announcements/index.astro
@@ -7,6 +7,7 @@ import { announcements, formatAnnouncementDate } from '../../lib/announcements';
 <Base
   title="Announcements — @silurus/ooxml"
   description="Release notices, migration guidance and important behavior changes for @silurus/ooxml."
+  canonicalPath="/announcements/"
 >
   <Nav active="announcements" />
   <main>

--- a/site/src/pages/deprecations.astro
+++ b/site/src/pages/deprecations.astro
@@ -42,7 +42,7 @@ const rows = [
 ] as const;
 ---
 
-<Base title="Deprecated APIs — @silurus/ooxml">
+<Base title="Deprecated APIs — @silurus/ooxml" canonicalPath="/deprecations/">
   <Nav />
   <header class="dep-hero">
     <div class="wrap">

--- a/site/src/pages/docx.astro
+++ b/site/src/pages/docx.astro
@@ -4,8 +4,7 @@ import DemoBlock from '../components/DemoBlock.astro';
 import ApiReference from '../components/ApiReference.astro';
 import { docxSnippets } from '../lib/demo-snippets';
 ---
-<FormatPage format="docx" name="DOCX" ext=".docx"
-  tagline="Render .docx documents to Canvas.">
+<FormatPage format="docx" name="DOCX" ext=".docx">
   <DemoBlock
     format="docx" kind="demo" badge="Story · Demo"
     title="Single viewer with navigation"

--- a/site/src/pages/errors.astro
+++ b/site/src/pages/errors.astro
@@ -65,7 +65,7 @@ await viewer.load(await file.arrayBuffer());
 if (!initialLoadFailed) showPreview();`;
 ---
 
-<Base title="Error handling — @silurus/ooxml">
+<Base title="Error handling — @silurus/ooxml" canonicalPath="/errors/">
   <Nav />
 
   <header class="error-hero">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -6,15 +6,28 @@ import LiveShowcase from '../components/LiveShowcase.astro';
 import Pitch from '../components/Pitch.astro';
 import Capabilities from '../components/Capabilities.astro';
 import { latestAnnouncements, formatAnnouncementDate } from '../lib/announcements';
+import { canonicalPageUrl, siteMetadata } from '../lib/seo';
 const base = import.meta.env.BASE_URL;
+const websiteStructuredData = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: siteMetadata.name,
+  alternateName: siteMetadata.alternateName,
+  url: canonicalPageUrl('/'),
+});
 ---
-<Base>
+<Base
+  title={siteMetadata.title}
+  description={siteMetadata.description}
+  canonicalPath="/"
+>
   <Nav />
+  <script type="application/ld+json" set:html={websiteStructuredData}></script>
 
   <header class="hero" id="top">
     <div class="wrap hero-frame">
       <div class="hero-overline">
-        <span>Open-source OOXML rendering</span>
+        <span>Open-source JavaScript Office file viewer</span>
         <span>Rust / WebAssembly / Canvas 2D</span>
       </div>
 
@@ -23,10 +36,10 @@ const base = import.meta.env.BASE_URL;
           <p class="eyebrow">Rust · WebAssembly · Canvas 2D</p>
           <h1>Office documents,<br />rendered in the<br /><em>browser.</em></h1>
           <p class="hero-lead">
-            <code>@silurus/ooxml</code> parses <strong>.docx</strong>, <strong>.xlsx</strong> and
-            <strong>.pptx</strong> with a Rust/WASM engine and renders them to Canvas. Parsing
-            and rendering run in the browser; no server-side document conversion, native
-            application or iframe is required.
+            <code>@silurus/ooxml</code> is an open-source JavaScript Office file viewer library
+            for <strong>.docx</strong>, <strong>.xlsx</strong> and <strong>.pptx</strong>. Its
+            Rust/WASM engine parses and renders each file to Canvas in the browser; no server-side
+            document conversion, native application or iframe is required.
           </p>
           <div class="hero-cta">
             <a class="btn btn-primary" href="https://www.npmjs.com/package/@silurus/ooxml">npm install @silurus/ooxml</a>

--- a/site/src/pages/pptx.astro
+++ b/site/src/pages/pptx.astro
@@ -4,8 +4,7 @@ import DemoBlock from '../components/DemoBlock.astro';
 import ApiReference from '../components/ApiReference.astro';
 import { pptxSnippets } from '../lib/demo-snippets';
 ---
-<FormatPage format="pptx" name="PPTX" ext=".pptx"
-  tagline="Render .pptx decks to Canvas.">
+<FormatPage format="pptx" name="PPTX" ext=".pptx">
   <DemoBlock
     format="pptx" kind="demo" badge="Story · Demo"
     title="Single viewer with navigation"

--- a/site/src/pages/preview/lower.astro
+++ b/site/src/pages/preview/lower.astro
@@ -8,6 +8,7 @@ import '../../styles/global.css';
 <html lang="en">
   <head>
     <meta charset="utf-8" /><title>preview: lower</title>
+    <meta name="robots" content="noindex, nofollow" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
   </head>
   <body>

--- a/site/src/pages/preview/showcase.astro
+++ b/site/src/pages/preview/showcase.astro
@@ -8,6 +8,7 @@ import '../../styles/global.css';
   <head>
     <meta charset="utf-8" />
     <title>preview: showcase</title>
+    <meta name="robots" content="noindex, nofollow" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"

--- a/site/src/pages/robots.txt.ts
+++ b/site/src/pages/robots.txt.ts
@@ -1,0 +1,16 @@
+import { canonicalPageUrl } from '../lib/seo';
+
+export const prerender = true;
+
+export function GET(): Response {
+  const body = [
+    'User-agent: *',
+    'Allow: /',
+    `Sitemap: ${canonicalPageUrl('/sitemap.xml')}`,
+    '',
+  ].join('\n');
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/site/src/pages/sitemap.xml.ts
+++ b/site/src/pages/sitemap.xml.ts
@@ -1,0 +1,38 @@
+import { announcements } from '../lib/announcements';
+import { canonicalPageUrl } from '../lib/seo';
+
+export const prerender = true;
+
+export const sitemapPaths = [
+  '/',
+  '/docx/',
+  '/xlsx/',
+  '/pptx/',
+  '/try/',
+  '/frameworks/',
+  '/frameworks/react/',
+  '/frameworks/vue/',
+  '/frameworks/svelte/',
+  '/frameworks/solid/',
+  '/announcements/',
+  ...announcements.map(({ slug }) => `/announcements/${slug}/`),
+  '/errors/',
+  '/deprecations/',
+] as const;
+
+export function GET(): Response {
+  const entries = sitemapPaths
+    .map((path) => `  <url><loc>${canonicalPageUrl(path)}</loc></url>`)
+    .join('\n');
+  const body = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    entries,
+    '</urlset>',
+    '',
+  ].join('\n');
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'application/xml; charset=utf-8' },
+  });
+}

--- a/site/src/pages/try.astro
+++ b/site/src/pages/try.astro
@@ -3,7 +3,7 @@ import Base from '../layouts/Base.astro';
 import Nav from '../components/Nav.astro';
 import BrandIcon from '../components/BrandIcon.astro';
 ---
-<Base title="Try your own file — @silurus/ooxml">
+<Base title="Try your own file — @silurus/ooxml" canonicalPath="/try/">
   <Nav />
 
   <main class="wrap try-workspace">

--- a/site/src/pages/xlsx.astro
+++ b/site/src/pages/xlsx.astro
@@ -4,8 +4,7 @@ import DemoBlock from '../components/DemoBlock.astro';
 import ApiReference from '../components/ApiReference.astro';
 import { xlsxSheetSnippet } from '../lib/demo-snippets';
 ---
-<FormatPage format="xlsx" name="XLSX" ext=".xlsx"
-  tagline="Render .xlsx workbooks to Canvas.">
+<FormatPage format="xlsx" name="XLSX" ext=".xlsx">
   <DemoBlock
     format="xlsx" kind="sheet" badge="Story · Demo"
     title="The full workbook viewer"

--- a/site/src/seo-foundation.test.ts
+++ b/site/src/seo-foundation.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalPageUrl,
+  formatSeo,
+  siteMetadata,
+} from './lib/seo';
+import { GET as getRobots } from './pages/robots.txt';
+import { GET as getSitemap, sitemapPaths } from './pages/sitemap.xml';
+
+const source = (path: string) => readFileSync(new URL(path, import.meta.url), 'utf8');
+
+describe('public-site SEO foundation', () => {
+  it('keeps the established OOXML Viewer term while adding the JavaScript Office viewer intent', () => {
+    expect(siteMetadata.title).toBe('OOXML Viewer | JavaScript Office File Viewer');
+    expect(siteMetadata.description).toContain('JavaScript and TypeScript Office file viewer library');
+
+    const homepage = source('./pages/index.astro');
+    expect(homepage).toContain('title={siteMetadata.title}');
+    expect(homepage).toContain('canonicalPath="/"');
+    expect(homepage).toContain('JavaScript Office file viewer library');
+    expect(homepage).toContain("'@type': 'WebSite'");
+    expect(source('./layouts/Base.astro')).toContain('property="og:site_name"');
+  });
+
+  it('gives each format page a distinct JavaScript viewer-library search intent', () => {
+    expect(formatSeo).toEqual({
+      docx: {
+        title: 'JavaScript DOCX Viewer Library | @silurus/ooxml',
+        description: expect.stringContaining('DOCX'),
+        heading: 'Render DOCX files in the browser with JavaScript.',
+      },
+      xlsx: {
+        title: 'JavaScript XLSX Viewer Library | @silurus/ooxml',
+        description: expect.stringContaining('XLSX'),
+        heading: 'Render XLSX files in the browser with JavaScript.',
+      },
+      pptx: {
+        title: 'JavaScript PPTX Viewer Library | @silurus/ooxml',
+        description: expect.stringContaining('PPTX'),
+        heading: 'Render PPTX files in the browser with JavaScript.',
+      },
+    });
+  });
+
+  it('normalizes public canonicals to the trailing-slash URLs served by GitHub Pages', () => {
+    expect(canonicalPageUrl('/')).toBe('https://ooxml.silurus.dev/');
+    expect(canonicalPageUrl('/docx')).toBe('https://ooxml.silurus.dev/docx/');
+    expect(canonicalPageUrl('frameworks/react/')).toBe(
+      'https://ooxml.silurus.dev/frameworks/react/',
+    );
+  });
+
+  it.each([
+    ['./pages/try.astro', 'canonicalPath="/try/"'],
+    ['./pages/errors.astro', 'canonicalPath="/errors/"'],
+    ['./pages/deprecations.astro', 'canonicalPath="/deprecations/"'],
+    ['./pages/announcements/index.astro', 'canonicalPath="/announcements/"'],
+    ['./pages/announcements/[slug].astro', 'canonicalPath={`/announcements/${announcement.slug}/`}'],
+    ['./layouts/FormatPage.astro', 'canonicalPath={`/${format}/`}'],
+    ['./components/FrameworkGuide.astro', 'canonicalPath={canonicalPath}'],
+  ])('declares a canonical for %s', (path, canonicalDeclaration) => {
+    expect(source(path)).toContain(canonicalDeclaration);
+  });
+
+  it('publishes only canonical public pages in the sitemap', async () => {
+    const response = getSitemap();
+    const xml = await response.text();
+
+    expect(response.headers.get('content-type')).toContain('application/xml');
+    for (const path of sitemapPaths) {
+      expect(xml).toContain(`<loc>${canonicalPageUrl(path)}</loc>`);
+    }
+    expect(xml).not.toContain('/preview/');
+  });
+
+  it('advertises the sitemap in robots.txt', async () => {
+    const response = getRobots();
+    const robots = await response.text();
+
+    expect(response.headers.get('content-type')).toContain('text/plain');
+    expect(robots).toContain('User-agent: *');
+    expect(robots).toContain('Allow: /');
+    expect(robots).toContain(`Sitemap: ${canonicalPageUrl('/sitemap.xml')}`);
+  });
+
+  it.each(['lower', 'showcase'])('keeps the %s visual preview out of search results', (page) => {
+    expect(source(`./pages/preview/${page}.astro`)).toContain(
+      '<meta name="robots" content="noindex, nofollow" />',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- preserve the established OOXML Viewer homepage term while adding JavaScript Office viewer intent
- give DOCX, XLSX, and PPTX pages distinct JavaScript viewer-library titles, descriptions, and headings
- normalize canonical URLs to the trailing-slash production routes and add canonical metadata to every public page
- generate sitemap.xml and robots.txt, add WebSite structured data and site-name metadata, and keep internal visual previews out of search results
- leave the framework-guide titles unchanged

## Verification
- `./node_modules/.bin/vitest run site/src` (101 tests)
- `./node_modules/.bin/tsc --build --pretty false`
- `./node_modules/.bin/astro build` in `site`
- generated title, canonical, sitemap, robots, and noindex inspection
- `git diff --check`