### PR TITLE
fix(viewers): harden lifecycle and XLSX alignment

### DIFF
--- a/packages/core/src/internal/canvas-viewer-mechanics.test.ts
+++ b/packages/core/src/internal/canvas-viewer-mechanics.test.ts
@@ -4,6 +4,29 @@ import { CanvasViewerErrorRouter, StaticCanvasRenderDispatcher } from './canvas-
 afterEach(() => vi.restoreAllMocks());
 
 describe('StaticCanvasRenderDispatcher', () => {
+  it('acquires the bitmap context once and avoids redundant backing-store resets', () => {
+    const bitmapContext = { transferFromImageBitmap: vi.fn() };
+    let width = 10;
+    let height = 20;
+    const setWidth = vi.fn((value: number) => { width = value; });
+    const setHeight = vi.fn((value: number) => { height = value; });
+    const canvas = {
+      get width() { return width; },
+      set width(value: number) { setWidth(value); },
+      get height() { return height; },
+      set height(value: number) { setHeight(value); },
+      style: {},
+      getContext: vi.fn(() => bitmapContext),
+    } as unknown as HTMLCanvasElement;
+    const dispatcher = new StaticCanvasRenderDispatcher(canvas, true);
+    const bitmap = { width: 10, height: 20, close: vi.fn() } as unknown as ImageBitmap;
+
+    expect(dispatcher.commitBitmap(dispatcher.begin(), bitmap)).toBe(true);
+    expect(canvas.getContext).toHaveBeenCalledOnce();
+    expect(setWidth).not.toHaveBeenCalled();
+    expect(setHeight).not.toHaveBeenCalled();
+  });
+
   it('closes a stale worker bitmap instead of committing it', () => {
     const transferFromImageBitmap = vi.fn();
     const canvas = {

--- a/packages/core/src/internal/canvas-viewer-mechanics.ts
+++ b/packages/core/src/internal/canvas-viewer-mechanics.ts
@@ -107,13 +107,13 @@ export interface BitmapCommitSize {
 export class StaticCanvasRenderDispatcher {
   private generation = 0;
   private destroyed = false;
-  private bitmapContext: ImageBitmapRenderingContext | null | undefined;
+  private readonly bitmapContext: ImageBitmapRenderingContext | null;
 
   constructor(
     private readonly canvas: HTMLCanvasElement,
-    private readonly bitmapMode: boolean,
+    bitmapMode: boolean,
   ) {
-    this.bitmapContext = undefined;
+    this.bitmapContext = bitmapMode ? canvas.getContext('bitmaprenderer') : null;
   }
 
   begin(): number {
@@ -134,15 +134,12 @@ export class StaticCanvasRenderDispatcher {
       bitmap.close();
       return false;
     }
-    if (this.bitmapContext === undefined) {
-      this.bitmapContext = this.bitmapMode ? this.canvas.getContext('bitmaprenderer') : null;
-    }
     if (!this.bitmapContext) {
       bitmap.close();
       throw new Error('bitmaprenderer context not available');
     }
-    this.canvas.width = bitmap.width;
-    this.canvas.height = bitmap.height;
+    if (this.canvas.width !== bitmap.width) this.canvas.width = bitmap.width;
+    if (this.canvas.height !== bitmap.height) this.canvas.height = bitmap.height;
     if (size.cssWidth !== undefined) this.canvas.style.width = `${size.cssWidth}px`;
     if (size.cssHeight !== undefined) this.canvas.style.height = `${size.cssHeight}px`;
     try {

--- a/packages/node/src/pptx-slide-session.test.ts
+++ b/packages/node/src/pptx-slide-session.test.ts
@@ -74,6 +74,29 @@ describe('Node bounded PPTX presentation session', () => {
     }
   });
 
+  it('keeps raw-part extraction independent while a slide cursor awaits acknowledgement', async () => {
+    const prototype = archivePrototype();
+    const originalPullSlide = prototype.pull_slide;
+    let extractedBytes = 0;
+    const pullSlide = vi.spyOn(prototype, 'pull_slide').mockImplementation(function (
+      this: ArchivePrototype,
+      ...args: Parameters<ArchivePrototype['pull_slide']>
+    ) {
+      const payload = originalPullSlide.apply(this, args);
+      extractedBytes = this.extract_image('ppt/media/image1.jpeg').byteLength;
+      return payload;
+    });
+    try {
+      const session = await openPptxPresentation(bytes);
+      const iterator = session.slides();
+      await expect(iterator.next()).resolves.toMatchObject({ done: false });
+      expect(extractedBytes).toBeGreaterThan(0);
+      await iterator.return();
+    } finally {
+      pullSlide.mockRestore();
+    }
+  });
+
   it('invalidates sibling sessions after a trap and recovers on one fresh generation', async () => {
     const extract = vi.spyOn(archivePrototype(), 'extract_image')
       .mockImplementationOnce(() => { throw new RangeError('synthetic trap'); });
@@ -245,6 +268,12 @@ describe('Node bounded PPTX presentation session', () => {
 type ArchivePrototype = {
   free(): void;
   extract_image(path: string): Uint8Array;
+  pull_slide(
+    slideIndex: number,
+    operationId: number,
+    generation: number,
+    byteCredit: number,
+  ): Uint8Array;
 };
 
 function archivePrototype(): ArchivePrototype {

--- a/packages/ooxml-common/src/package_session.rs
+++ b/packages/ooxml-common/src/package_session.rs
@@ -760,6 +760,40 @@ impl PackageSessionHandle {
         })
     }
 
+    /// Run one self-contained package read in its own accounting operation.
+    ///
+    /// Format cursors may retain a different operation across an acknowledged
+    /// unit boundary. This helper deliberately does not borrow that cursor's
+    /// operation: the package session owns both lifecycles and applies the same
+    /// shared governor to them. Success commits only this operation; failure
+    /// cancels only this operation while preserving a package-wide resource
+    /// failure as the primary error.
+    pub fn run_operation<T>(
+        &self,
+        name: impl Into<String>,
+        run: impl FnOnce(&PackageOperation) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let mut operation = self.begin_operation(name)?;
+        let result = run(&operation);
+        if let Err(resource_error) = self.assert_healthy() {
+            let _ = operation.cancel();
+            return Err(resource_error);
+        }
+        match result {
+            Ok(value) => match operation.finish() {
+                Ok(()) => Ok(value),
+                Err(error) => {
+                    let _ = operation.cancel();
+                    Err(error)
+                }
+            },
+            Err(error) => {
+                let _ = operation.cancel();
+                Err(error)
+            }
+        }
+    }
+
     /// Verify that the package is still open and has not encountered a
     /// package-wide resource failure.
     pub fn assert_healthy(&self) -> Result<(), String> {

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -916,9 +916,9 @@ impl PptxArchive {
     pub fn extract_media(&mut self, path: &str) -> Result<Vec<u8>, JsValue> {
         let zip = self
             .archive
-            .as_mut()
+            .as_ref()
             .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
-        zip.run_operation("extract-media", |zip| read_zip_bytes(zip, path))
+        zip.read_part_in_independent_operation("extract-media", path)
             .map_err(|e| JsValue::from_str(&e))
     }
 
@@ -929,9 +929,9 @@ impl PptxArchive {
     pub fn extract_image(&mut self, path: &str) -> Result<Vec<u8>, JsValue> {
         let zip = self
             .archive
-            .as_mut()
+            .as_ref()
             .map_err(|e| JsValue::from_str(&format!("pptx-parser error: {e}")))?;
-        zip.run_operation("extract-image", |zip| read_zip_bytes(zip, path))
+        zip.read_part_in_independent_operation("extract-image", path)
             .map_err(|e| JsValue::from_str(&e))
     }
 
@@ -1067,6 +1067,19 @@ impl PptxZip {
 
     fn usage(&self) -> ResourceUsage {
         self.session.usage()
+    }
+
+    /// Raw package parts are independent of the retained slide cursor. Give
+    /// each read its own package operation so rendering slide N may overlap the
+    /// acknowledged pull lifecycle for slide N+1 without sharing ownership or
+    /// accounting state.
+    fn read_part_in_independent_operation(
+        &self,
+        operation_name: &str,
+        path: &str,
+    ) -> Result<Vec<u8>, String> {
+        self.session
+            .run_operation(operation_name, |operation| operation.read_bytes(path))
     }
 
     fn index_for_name(&self, path: &str) -> Option<()> {

--- a/packages/xlsx/src/internal/grid-geometry.test.ts
+++ b/packages/xlsx/src/internal/grid-geometry.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import type { Worksheet } from '../types.js';
+import { colWidthToPx, getMdwForWorksheet, rowHeightToPx } from '../renderer.js';
+import { GridGeometry } from './grid-geometry.js';
+
+function worksheet(): Worksheet {
+  return {
+    name: 'Geometry',
+    rows: [],
+    colWidths: { 1: 12, 2: 20, 4: 30, 16_384: 5 },
+    rowHeights: { 1: 25, 2: 40, 5: 60, 1_048_576: 12 },
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [],
+    freezeRows: 2,
+    freezeCols: 2,
+    conditionalFormats: [],
+    images: [],
+    charts: [],
+  } as Worksheet;
+}
+
+describe('GridGeometry', () => {
+  it('computes far-cell rectangles from cumulative axes while preserving per-cell scale rounding', () => {
+    const ws = worksheet();
+    const geometry = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws));
+    const scale = 1.25;
+    const scrollX = 231.5;
+    const scrollY = 417.25;
+    const rect = geometry.cellRect(1_048_576, 16_384, {
+      scale,
+      scrollX,
+      scrollY,
+      headerWidth: 48,
+      headerHeight: 24,
+    });
+
+    const sp = (value: number) => Math.round(value * scale);
+    const defaultCol = sp(colWidthToPx(ws.defaultColWidth, getMdwForWorksheet(ws)));
+    const defaultRow = sp(rowHeightToPx(ws.defaultRowHeight));
+    const scaledCol = (index: number) => sp(colWidthToPx(ws.colWidths[index] ?? ws.defaultColWidth, getMdwForWorksheet(ws)));
+    const scaledRow = (index: number) => sp(rowHeightToPx(ws.rowHeights[index] ?? ws.defaultRowHeight));
+    const sparseColDelta = [1, 2, 4]
+      .reduce((sum, index) => sum + scaledCol(index) - defaultCol, 0);
+    const sparseRowDelta = [1, 2, 5]
+      .reduce((sum, index) => sum + scaledRow(index) - defaultRow, 0);
+    const frozenW = scaledCol(1) + scaledCol(2);
+    const frozenH = scaledRow(1) + scaledRow(2);
+    const logicalColStart = geometry.col.indexAt(scrollX + geometry.col.offsetOf(3));
+    const logicalRowStart = geometry.row.indexAt(scrollY + geometry.row.offsetOf(3));
+    const expectedX = sp(48) + frozenW - logicalColStart.partial * scale
+      + (16_384 - 1) * defaultCol + sparseColDelta
+      - ((logicalColStart.index - 1) * defaultCol
+        + [1, 2, 4].filter((index) => index < logicalColStart.index)
+          .reduce((sum, index) => sum + scaledCol(index) - defaultCol, 0));
+    const expectedY = sp(24) + frozenH - logicalRowStart.partial * scale
+      + (1_048_576 - 1) * defaultRow + sparseRowDelta
+      - ((logicalRowStart.index - 1) * defaultRow
+        + [1, 2, 5].filter((index) => index < logicalRowStart.index)
+          .reduce((sum, index) => sum + scaledRow(index) - defaultRow, 0));
+
+    expect(rect).toEqual({
+      x: expectedX,
+      y: expectedY,
+      w: scaledCol(16_384),
+      h: scaledRow(1_048_576),
+    });
+  });
+
+  it('rejects coordinates outside the worksheet limits', () => {
+    const geometry = GridGeometry.forWorksheet(worksheet(), 7);
+    const options = {
+      scale: 1,
+      scrollX: 0,
+      scrollY: 0,
+      headerWidth: 48,
+      headerHeight: 24,
+    };
+    expect(geometry.cellRect(0, 1, options)).toBeNull();
+    expect(geometry.cellRect(1_048_577, 1, options)).toBeNull();
+    expect(geometry.cellRect(1, 0, options)).toBeNull();
+    expect(geometry.cellRect(1, 16_385, options)).toBeNull();
+  });
+
+  it('derives hit tests and visible ranges from the same frozen-pane axes', () => {
+    const ws = worksheet();
+    const geometry = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws));
+    const frozen = geometry.logicalFrozenExtent();
+    const scrollX = 51;
+    const scrollY = 37;
+
+    expect(geometry.cellAt(frozen.width + 1, frozen.height + 1, { scrollX, scrollY })).toEqual({
+      row: geometry.row.scrollableIndexAt(1 + scrollY, 3),
+      col: geometry.col.scrollableIndexAt(1 + scrollX, 3),
+    });
+    const visible = geometry.visibleRange({
+      width: 640,
+      height: 480,
+      scale: 1,
+      scrollX,
+      scrollY,
+      headerWidth: 48,
+      headerHeight: 24,
+      buffer: 2,
+    });
+    expect(visible.range.row).toBeGreaterThanOrEqual(3);
+    expect(visible.range.col).toBeGreaterThanOrEqual(3);
+    expect(visible.range.rows).toBeGreaterThan(2);
+    expect(visible.range.cols).toBeGreaterThan(2);
+  });
+
+  it('matches the former visible-band walk across scales and partial scroll offsets', () => {
+    const ws = worksheet();
+    const geometry = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws));
+    const oldCount = (
+      axis: typeof geometry.row,
+      start: number,
+      partial: number,
+      available: number,
+      max: number,
+    ) => {
+      let accumulated = -partial;
+      let index = start;
+      let count = 0;
+      while (accumulated < available + partial && index <= max) {
+        accumulated += axis.sizeOf(index);
+        count++;
+        index++;
+      }
+      return count + 2;
+    };
+
+    for (const scale of [0.75, 1, 1.25]) {
+      for (const [scrollX, scrollY] of [[0, 0], [51, 37], [1234.5, 987.25]]) {
+        const width = 641;
+        const height = 479;
+        const visible = geometry.visibleRange({
+          width,
+          height,
+          scale,
+          scrollX,
+          scrollY,
+          headerWidth: 48,
+          headerHeight: 24,
+          buffer: 2,
+        });
+        const frozen = geometry.logicalFrozenExtent();
+        const availableWidth = width / scale - 48 - frozen.width;
+        const availableHeight = height / scale - 24 - frozen.height;
+        expect(visible.range.cols).toBe(oldCount(
+          geometry.col,
+          visible.range.col,
+          visible.offsetX,
+          availableWidth,
+          16_384,
+        ));
+        expect(visible.range.rows).toBe(oldCount(
+          geometry.row,
+          visible.range.row,
+          visible.offsetY,
+          availableHeight,
+          1_048_576,
+        ));
+      }
+    }
+  });
+
+  it('does not inspect every preceding band when locating a far cell', () => {
+    let rowReads = 0;
+    const ws = worksheet();
+    ws.rowHeights = new Proxy(ws.rowHeights, {
+      get(target, key, receiver) {
+        if (typeof key === 'string' && /^\d+$/.test(key)) rowReads++;
+        return Reflect.get(target, key, receiver);
+      },
+    });
+    const geometry = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws));
+
+    expect(geometry.cellRect(1_048_576, 16_384, {
+      scale: 1.25,
+      scrollX: 0,
+      scrollY: 0,
+      headerWidth: 48,
+      headerHeight: 24,
+    })).not.toBeNull();
+    expect(rowReads).toBeLessThan(100);
+  });
+});

--- a/packages/xlsx/src/internal/grid-geometry.ts
+++ b/packages/xlsx/src/internal/grid-geometry.ts
@@ -1,10 +1,14 @@
-import type { Worksheet } from '../types.js';
+import type { ViewportRange, Worksheet } from '../types.js';
 import { colWidthToPx, rowHeightToPx } from '../renderer.js';
+
+export const MAX_WORKSHEET_ROW = 1_048_576;
+export const MAX_WORKSHEET_COL = 16_384;
 
 /** Sparse cumulative axis geometry. Offsets are logical, unscaled pixels. */
 export class GridAxisGeometry {
   private readonly indices: number[];
   private readonly cumulativeDelta: number[];
+  private readonly customPx: number[];
 
   constructor(
     customs: Record<number, number>,
@@ -17,9 +21,12 @@ export class GridAxisGeometry {
       .filter((value) => value >= 1 && value <= maxIndex)
       .sort((a, b) => a - b);
     this.cumulativeDelta = new Array(this.indices.length);
+    this.customPx = new Array(this.indices.length);
     let accumulated = 0;
     for (let index = 0; index < this.indices.length; index++) {
-      accumulated += toPx(customs[this.indices[index]]) - defaultPx;
+      const px = toPx(customs[this.indices[index]]);
+      this.customPx[index] = px;
+      accumulated += px - defaultPx;
       this.cumulativeDelta[index] = accumulated;
     }
   }
@@ -59,9 +66,66 @@ export class GridAxisGeometry {
     return this.indexAt(absoluteOffset).index;
   }
 
-  private sizeOf(index: number): number {
+  sizeOf(index: number): number {
     return this.offsetOf(index + 1) - this.offsetOf(index);
   }
+
+  /** Same sparse axis after Excel-style per-band scale rounding. */
+  scaled(scale: number): GridAxisGeometry {
+    const customs: Record<number, number> = {};
+    for (let index = 0; index < this.indices.length; index++) {
+      customs[this.indices[index]] = Math.round(this.customPx[index] * scale);
+    }
+    return new GridAxisGeometry(
+      customs,
+      Math.round(this.defaultPx * scale),
+      (value) => value,
+      this.maxIndex,
+    );
+  }
+
+  /** Number of bands required to cover `distance` from the start of `index`. */
+  countToCover(index: number, distance: number): number {
+    if (index > this.maxIndex || distance <= 0) return 0;
+    const target = this.offsetOf(index) + distance;
+    const end = this.offsetOf(this.maxIndex) + this.sizeOf(this.maxIndex);
+    if (target >= end) return this.maxIndex - index + 1;
+    const located = this.indexAt(target);
+    return located.index - index + (located.partial > 0 ? 1 : 0);
+  }
+}
+
+export interface GridCellRectOptions {
+  readonly scale: number;
+  readonly scrollX: number;
+  readonly scrollY: number;
+  readonly headerWidth: number;
+  readonly headerHeight: number;
+}
+
+export interface GridVisibleRangeOptions extends GridCellRectOptions {
+  readonly width: number;
+  readonly height: number;
+  readonly buffer?: number;
+}
+
+export interface GridVisibleGeometry {
+  readonly range: ViewportRange;
+  readonly offsetX: number;
+  readonly offsetY: number;
+  readonly frozenWidth: number;
+  readonly frozenHeight: number;
+}
+
+export interface GridScrollToCellOptions {
+  readonly scale: number;
+  readonly viewportWidth: number;
+  readonly viewportHeight: number;
+  readonly currentX: number;
+  readonly currentY: number;
+  readonly headerWidth: number;
+  readonly headerHeight: number;
+  readonly align: 'nearest' | 'start' | 'center' | 'end';
 }
 
 /** Pure worksheet geometry shared by both XLSX viewer facades. */
@@ -82,19 +146,245 @@ export class GridGeometry {
 
   readonly col: GridAxisGeometry;
   readonly row: GridAxisGeometry;
+  private readonly freezeRows: number;
+  private readonly freezeCols: number;
+  private scaledCache: Readonly<{
+    scale: number;
+    row: GridAxisGeometry;
+    col: GridAxisGeometry;
+  }> | null = null;
 
   private constructor(worksheet: Worksheet, mdw: number) {
+    this.freezeRows = Math.min(MAX_WORKSHEET_ROW, Math.max(0, worksheet.freezeRows ?? 0));
+    this.freezeCols = Math.min(MAX_WORKSHEET_COL, Math.max(0, worksheet.freezeCols ?? 0));
     this.col = new GridAxisGeometry(
       worksheet.colWidths,
       colWidthToPx(worksheet.defaultColWidth, mdw),
       (raw) => colWidthToPx(raw, mdw),
-      16_384,
+      MAX_WORKSHEET_COL,
     );
     this.row = new GridAxisGeometry(
       worksheet.rowHeights,
       rowHeightToPx(worksheet.defaultRowHeight),
       rowHeightToPx,
-      1_048_576,
+      MAX_WORKSHEET_ROW,
     );
+  }
+
+  logicalFrozenExtent(): { width: number; height: number } {
+    return {
+      width: this.col.offsetOf(this.freezeCols + 1),
+      height: this.row.offsetOf(this.freezeRows + 1),
+    };
+  }
+
+  roundedFrozenExtent(scale: number): { width: number; height: number } {
+    const axes = this.scaledAxes(scale);
+    return {
+      width: axes.col.offsetOf(this.freezeCols + 1),
+      height: axes.row.offsetOf(this.freezeRows + 1),
+    };
+  }
+
+  logicalContentExtent(
+    maxRow: number,
+    maxCol: number,
+    headerWidth: number,
+    headerHeight: number,
+  ): { width: number; height: number } {
+    return {
+      width: headerWidth + this.col.offsetOf(Math.min(MAX_WORKSHEET_COL, maxCol) + 1),
+      height: headerHeight + this.row.offsetOf(Math.min(MAX_WORKSHEET_ROW, maxRow) + 1),
+    };
+  }
+
+  roundedContentExtent(
+    maxRow: number,
+    maxCol: number,
+    scale: number,
+    headerWidth: number,
+    headerHeight: number,
+  ): { width: number; height: number } {
+    const axes = this.scaledAxes(scale);
+    return {
+      width: Math.round(headerWidth * scale)
+        + axes.col.offsetOf(Math.min(MAX_WORKSHEET_COL, maxCol) + 1),
+      height: Math.round(headerHeight * scale)
+        + axes.row.offsetOf(Math.min(MAX_WORKSHEET_ROW, maxRow) + 1),
+    };
+  }
+
+  cellAt(
+    innerX: number,
+    innerY: number,
+    viewport: { readonly scrollX: number; readonly scrollY: number },
+  ): { row: number; col: number } | null {
+    if (innerX < 0 || innerY < 0) return null;
+    const row = this.rowAt(innerY, viewport.scrollY);
+    if (row === null) return null;
+    const col = this.colAt(innerX, viewport.scrollX);
+    return col === null ? null : { row, col };
+  }
+
+  rowAt(innerY: number, scrollY: number): number | null {
+    if (innerY < 0) return null;
+    const frozenHeight = this.row.offsetOf(this.freezeRows + 1);
+    return innerY < frozenHeight
+      ? this.indexWithinFrozen(this.row, innerY, this.freezeRows)
+      : this.row.scrollableIndexAt(innerY - frozenHeight + scrollY, this.freezeRows + 1);
+  }
+
+  colAt(innerX: number, scrollX: number): number | null {
+    if (innerX < 0) return null;
+    const frozenWidth = this.col.offsetOf(this.freezeCols + 1);
+    return innerX < frozenWidth
+      ? this.indexWithinFrozen(this.col, innerX, this.freezeCols)
+      : this.col.scrollableIndexAt(innerX - frozenWidth + scrollX, this.freezeCols + 1);
+  }
+
+  cellRect(
+    row: number,
+    col: number,
+    options: GridCellRectOptions,
+  ): { x: number; y: number; w: number; h: number } | null {
+    if (row < 1 || row > MAX_WORKSHEET_ROW || col < 1 || col > MAX_WORKSHEET_COL) return null;
+    const axes = this.scaledAxes(options.scale);
+    const headerX = Math.round(options.headerWidth * options.scale);
+    const headerY = Math.round(options.headerHeight * options.scale);
+    const frozen = this.roundedFrozenExtent(options.scale);
+
+    const x = col <= this.freezeCols
+      ? headerX + axes.col.offsetOf(col)
+      : this.scrollableCellPosition(
+          this.col,
+          axes.col,
+          col,
+          this.freezeCols,
+          options.scrollX,
+          options.scale,
+          headerX + frozen.width,
+        );
+    const y = row <= this.freezeRows
+      ? headerY + axes.row.offsetOf(row)
+      : this.scrollableCellPosition(
+          this.row,
+          axes.row,
+          row,
+          this.freezeRows,
+          options.scrollY,
+          options.scale,
+          headerY + frozen.height,
+        );
+    return { x, y, w: axes.col.sizeOf(col), h: axes.row.sizeOf(row) };
+  }
+
+  visibleRange(options: GridVisibleRangeOptions): GridVisibleGeometry {
+    const frozen = this.logicalFrozenExtent();
+    const colStart = this.col.indexAt(options.scrollX + this.col.offsetOf(this.freezeCols + 1));
+    const rowStart = this.row.indexAt(options.scrollY + this.row.offsetOf(this.freezeRows + 1));
+    const cellWidth = options.width / options.scale - options.headerWidth - frozen.width;
+    const cellHeight = options.height / options.scale - options.headerHeight - frozen.height;
+    const buffer = options.buffer ?? 0;
+    return {
+      range: {
+        row: rowStart.index,
+        col: colStart.index,
+        rows: this.row.countToCover(rowStart.index, cellHeight + rowStart.partial * 2) + buffer,
+        cols: this.col.countToCover(colStart.index, cellWidth + colStart.partial * 2) + buffer,
+      },
+      offsetX: colStart.partial,
+      offsetY: rowStart.partial,
+      frozenWidth: frozen.width,
+      frozenHeight: frozen.height,
+    };
+  }
+
+  scrollOffsetForCell(
+    row: number,
+    col: number,
+    options: GridScrollToCellOptions,
+  ): { x: number; y: number } {
+    const scaledFrozen = this.roundedFrozenExtent(options.scale);
+    const viewTop = Math.round(options.headerHeight * options.scale) + scaledFrozen.height;
+    const viewLeft = Math.round(options.headerWidth * options.scale) + scaledFrozen.width;
+    let y = options.currentY;
+    if (row > this.freezeRows && row <= MAX_WORKSHEET_ROW) {
+      const cellStart = (this.row.offsetOf(row) - this.row.offsetOf(this.freezeRows + 1))
+        * options.scale;
+      const cellSize = this.row.sizeOf(row) * options.scale;
+      y = this.alignedOffset(
+        cellStart,
+        cellSize,
+        options.currentY,
+        viewTop,
+        options.viewportHeight,
+        options.align,
+      );
+    }
+    let x = options.currentX;
+    if (col > this.freezeCols && col <= MAX_WORKSHEET_COL) {
+      const cellStart = (this.col.offsetOf(col) - this.col.offsetOf(this.freezeCols + 1))
+        * options.scale;
+      const cellSize = this.col.sizeOf(col) * options.scale;
+      x = this.alignedOffset(
+        cellStart,
+        cellSize,
+        options.currentX,
+        viewLeft,
+        options.viewportWidth,
+        options.align,
+      );
+    }
+    return { x: Math.max(0, x), y: Math.max(0, y) };
+  }
+
+  private scaledAxes(scale: number): { row: GridAxisGeometry; col: GridAxisGeometry } {
+    if (this.scaledCache?.scale === scale) return this.scaledCache;
+    const scaled = { scale, row: this.row.scaled(scale), col: this.col.scaled(scale) };
+    this.scaledCache = scaled;
+    return scaled;
+  }
+
+  private indexWithinFrozen(
+    axis: GridAxisGeometry,
+    offset: number,
+    frozenCount: number,
+  ): number | null {
+    if (frozenCount === 0) return null;
+    const index = axis.indexAt(offset).index;
+    return index <= frozenCount ? index : null;
+  }
+
+  private scrollableCellPosition(
+    logicalAxis: GridAxisGeometry,
+    scaledAxis: GridAxisGeometry,
+    index: number,
+    frozenCount: number,
+    scroll: number,
+    scale: number,
+    scrollAreaStart: number,
+  ): number {
+    const start = logicalAxis.indexAt(scroll + logicalAxis.offsetOf(frozenCount + 1));
+    return scrollAreaStart - start.partial * scale
+      + scaledAxis.offsetOf(index) - scaledAxis.offsetOf(start.index);
+  }
+
+  private alignedOffset(
+    cellStart: number,
+    cellSize: number,
+    current: number,
+    viewportStart: number,
+    viewportEnd: number,
+    align: GridScrollToCellOptions['align'],
+  ): number {
+    const cellOnScreen = viewportStart + cellStart - current;
+    if (align === 'start') return cellStart;
+    if (align === 'center') return cellStart - (viewportEnd - viewportStart - cellSize) / 2;
+    if (align === 'end') return cellStart - (viewportEnd - viewportStart - cellSize);
+    if (cellOnScreen < viewportStart) return cellStart;
+    if (cellOnScreen + cellSize > viewportEnd) {
+      return cellStart - (viewportEnd - viewportStart - cellSize);
+    }
+    return current;
   }
 }

--- a/packages/xlsx/src/internal/sheet-viewer-runtime.test.ts
+++ b/packages/xlsx/src/internal/sheet-viewer-runtime.test.ts
@@ -31,6 +31,36 @@ describe('XLSX viewer composition roles', () => {
     expect(second.destroy).toHaveBeenCalledOnce();
   });
 
+  it('SheetAcquisition is terminally closed and disposes a candidate that resolves late', async () => {
+    const acquisition = new SheetAcquisition();
+    let resolveLate: ((value: XlsxWorkbook) => void) | undefined;
+    const pending = new Promise<XlsxWorkbook>((resolve) => { resolveLate = resolve; });
+    const replacement = acquisition.replace(() => pending);
+
+    acquisition.destroy();
+    const late = workbook();
+    resolveLate?.(late.value);
+
+    await expect(replacement).rejects.toThrow('SheetAcquisition is closed');
+    expect(late.destroy).toHaveBeenCalledOnce();
+    await expect(acquisition.replace(() => Promise.resolve(workbook().value))).rejects.toThrow(
+      'SheetAcquisition is closed',
+    );
+    expect(() => acquisition.install(workbook().value)).toThrow('SheetAcquisition is closed');
+  });
+
+  it('SheetAcquisition reports terminal close when an in-flight loader rejects late', async () => {
+    const acquisition = new SheetAcquisition();
+    let rejectLate: ((reason: Error) => void) | undefined;
+    const pending = new Promise<XlsxWorkbook>((_resolve, reject) => { rejectLate = reject; });
+    const replacement = acquisition.replace(() => pending);
+
+    acquisition.destroy();
+    rejectLate?.(new Error('late parser failure'));
+
+    await expect(replacement).rejects.toThrow('SheetAcquisition is closed');
+  });
+
   it('ViewportState clamps logical offsets without a native scroll element', () => {
     const viewport = new ViewportState(1);
     viewport.setExtent(1000, 800);

--- a/packages/xlsx/src/internal/sheet-viewer-runtime.ts
+++ b/packages/xlsx/src/internal/sheet-viewer-runtime.ts
@@ -1,22 +1,30 @@
 import type { XlsxWorkbook } from '../workbook.js';
+import { StaticCanvasRenderDispatcher } from '@silurus/ooxml-core/internal/canvas-viewer-mechanics';
 
 /** Generation-safe workbook ownership for one viewer instance. */
 export class SheetAcquisition {
   private generation = 0;
   private currentWorkbook: XlsxWorkbook | null = null;
+  private closed = false;
 
   get current(): XlsxWorkbook | null {
     return this.currentWorkbook;
   }
 
   async replace(load: () => Promise<XlsxWorkbook>): Promise<XlsxWorkbook | null> {
+    this.assertOpen();
     const generation = ++this.generation;
     let candidate: XlsxWorkbook;
     try {
       candidate = await load();
     } catch (error) {
+      if (this.closed) throw this.closedError();
       if (generation !== this.generation) return null;
       throw error;
+    }
+    if (this.closed) {
+      candidate.destroy();
+      throw this.closedError();
     }
     if (generation !== this.generation) {
       candidate.destroy();
@@ -28,15 +36,26 @@ export class SheetAcquisition {
 
   /** Commit an already acquired workbook, closing the previously owned one. */
   install(candidate: XlsxWorkbook): void {
+    this.assertOpen();
     const previous = this.currentWorkbook;
     this.currentWorkbook = candidate;
     previous?.destroy();
   }
 
   destroy(): void {
+    if (this.closed) return;
+    this.closed = true;
     this.generation++;
     this.currentWorkbook?.destroy();
     this.currentWorkbook = null;
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw this.closedError();
+  }
+
+  private closedError(): Error {
+    return new Error('SheetAcquisition is closed');
   }
 }
 
@@ -101,31 +120,33 @@ export class ViewportState {
   }
 }
 
-/** Coalescing and stale-result generation mechanics for one sheet surface. */
+/** XLSX render scheduling around core-owned static bitmap lifecycle mechanics. */
 export class SheetRenderDispatcher {
   private animationFrame: number | null = null;
+  private readonly staticDispatcher: StaticCanvasRenderDispatcher | null;
   private generation = 0;
-  private readonly bitmapContext: ImageBitmapRenderingContext | null;
+  private destroyed = false;
 
   constructor(
-    private readonly canvas?: HTMLCanvasElement,
+    canvas?: HTMLCanvasElement,
     workerBitmapMode = false,
   ) {
-    this.bitmapContext = workerBitmapMode && canvas
-      ? canvas.getContext('bitmaprenderer')
+    this.staticDispatcher = canvas
+      ? new StaticCanvasRenderDispatcher(canvas, workerBitmapMode)
       : null;
   }
 
   begin(): number {
+    if (this.staticDispatcher) return this.staticDispatcher.begin();
     return ++this.generation;
   }
 
   isCurrent(generation: number): boolean {
-    return generation === this.generation;
+    if (this.staticDispatcher) return this.staticDispatcher.isCurrent(generation);
+    return !this.destroyed && generation === this.generation;
   }
 
-  /** Own the full lifecycle of an off-thread frame: stale frames are closed,
-   * current frames resize the backing store and atomically replace the bitmap. */
+  /** Delegate stale disposal and atomic bitmap replacement to the core owner. */
   commitBitmap(
     generation: number,
     bitmap: ImageBitmap,
@@ -136,23 +157,14 @@ export class SheetRenderDispatcher {
       bitmap.close();
       return false;
     }
-    if (!this.canvas || !this.bitmapContext) {
+    if (!this.staticDispatcher) {
       bitmap.close();
       throw new Error('SheetRenderDispatcher is not configured for worker bitmap rendering');
     }
-    if (this.canvas.width !== bitmap.width) this.canvas.width = bitmap.width;
-    if (this.canvas.height !== bitmap.height) this.canvas.height = bitmap.height;
-    const width = `${cssWidth}px`;
-    const height = `${cssHeight}px`;
-    if (this.canvas.style.width !== width) this.canvas.style.width = width;
-    if (this.canvas.style.height !== height) this.canvas.style.height = height;
-    try {
-      this.bitmapContext.transferFromImageBitmap(bitmap);
-    } catch (error) {
-      bitmap.close();
-      throw error;
-    }
-    return true;
+    return this.staticDispatcher.commitBitmap(generation, bitmap, {
+      cssWidth,
+      cssHeight,
+    });
   }
 
   schedule(render: () => void): void {
@@ -168,10 +180,13 @@ export class SheetRenderDispatcher {
   }
 
   destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
     if (this.animationFrame !== null && typeof cancelAnimationFrame === 'function') {
       cancelAnimationFrame(this.animationFrame);
       this.animationFrame = null;
     }
+    this.staticDispatcher?.destroy();
     this.generation++;
   }
 }

--- a/packages/xlsx/src/internal/viewer-composition-boundary.test.ts
+++ b/packages/xlsx/src/internal/viewer-composition-boundary.test.ts
@@ -1,10 +1,36 @@
 import { describe, expect, it } from 'vitest';
 import viewer from '../viewer.ts?raw';
+import geometry from './grid-geometry.ts?raw';
+import runtime from './sheet-viewer-runtime.ts?raw';
+import surface from './sheet-surface.ts?raw';
 
 describe('XLSX viewer composition boundary', () => {
-  it('the composite facade subclasses the engine while the canvas facade owns exactly one engine', () => {
+  it('both public facades reach one shared engine instead of copying sheet behavior', () => {
     expect(viewer).toContain("super(container, opts, { kind: 'composite' })");
     expect(viewer.match(/new XlsxViewerEngine\(/g)).toHaveLength(1);
     expect(viewer).not.toContain("parseSheetLocally");
+  });
+
+  it('the shared engine composes each state/surface role exactly once', () => {
+    for (const role of [
+      'SheetAcquisition',
+      'ViewportState',
+      'SelectionController',
+      'SheetRenderDispatcher',
+      'CanvasSurface',
+      'SheetOverlayHost',
+    ]) {
+      expect(viewer.match(new RegExp(`new ${role}\\(`, 'g')), role).toHaveLength(1);
+    }
+    expect(viewer).toContain('GridGeometry.forWorksheet');
+  });
+
+  it('keeps geometry pure and delegates static bitmap ownership to core', () => {
+    expect(geometry).not.toContain('document.');
+    expect(geometry).not.toContain('HTMLCanvasElement');
+    expect(surface).not.toContain('XlsxWorkbook');
+    expect(runtime).toContain('StaticCanvasRenderDispatcher');
+    expect(runtime).not.toContain('transferFromImageBitmap');
+    expect(runtime).not.toContain("getContext('bitmaprenderer')");
   });
 });

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -1287,6 +1287,22 @@ function decoYForBaseline(baseline: CanvasTextBaseline, textY: number, rSizePx: 
   return { underline: textY + rSizePx + 1, strike: textY + Math.round(rSizePx * 0.5) };
 }
 
+/** Resolve the vertical anchor for content that lays out as exactly one line.
+ *  ECMA-376 Part 1 §18.8.1 makes wrapText a line-wrapping switch, while
+ *  §18.18.88 defines vertical alignment over the cell height. A wrap-enabled
+ *  value that still fits on one line therefore uses the same top/middle/bottom
+ *  anchor as an unwrapped value; only a genuinely multi-line result owns a
+ *  line-box block. */
+function singleLineVerticalAnchor(geom: RichCellGeom): {
+  baseline: CanvasTextBaseline;
+  textY: number;
+} {
+  const { alignV, cy, cellH, paddingY } = geom;
+  if (alignV === 'top') return { baseline: 'top', textY: cy + paddingY };
+  if (alignV === 'center') return { baseline: 'middle', textY: cy + cellH / 2 };
+  return { baseline: 'bottom', textY: cy + cellH - paddingY };
+}
+
 /** The draw font for a run/segment: super/subscript renders at ~65% size
  *  (ECMA-376 §18.4.14 vertAlign / ST_VerticalAlignRun §22.9.2.17); everything
  *  else keeps its declared size. The *base* size still governs line height and
@@ -1371,6 +1387,26 @@ export function drawResolvedRichLine(
  * Used by the non-wrap rich paths; the wrap path drives `drawResolvedRichLine`
  * directly from its laid-out segments.
  */
+function drawRichSegments(
+  ctx: CanvasRenderingContext2D,
+  segs: RichSeg[],
+  geom: RichCellGeom,
+  cs: number,
+  dpr: number,
+  opts: { fontColor?: string | null; readingOrder?: number },
+  textY: number,
+  baseline: CanvasTextBaseline,
+): void {
+  const { alignH, cx, cellW, leftPad, paddingX } = geom;
+  const totalWidth = segs.reduce((a, s) => a + s.width, 0);
+  let startX: number;
+  if (alignH === 'right') startX = cx + cellW - paddingX - totalWidth;
+  else if (alignH === 'center') startX = cx + cellW / 2 - totalWidth / 2;
+  else startX = cx + leftPad;
+  const { needBidi, baseRtl } = resolveCellBidi(opts.readingOrder, segs.map((s) => s.text).join(''));
+  drawResolvedRichLine(ctx, segs, startX, textY, baseline, cs, dpr, { fontColor: opts.fontColor, needBidi, baseRtl });
+}
+
 function drawRichLine(
   ctx: CanvasRenderingContext2D,
   lineRuns: Run[],
@@ -1382,19 +1418,12 @@ function drawRichLine(
   textY: number,
   baseline: CanvasTextBaseline,
 ): void {
-  const { alignH, cx, cellW, leftPad, paddingX } = geom;
   const segs: RichSeg[] = lineRuns.map((r) => {
     const font = applyRunFont(baseFont, r);
     ctx.font = buildFont(vertAlignDrawFont(font), cs);
     return { text: r.text, font, width: ctx.measureText(r.text).width };
   });
-  const totalWidth = segs.reduce((a, s) => a + s.width, 0);
-  let startX: number;
-  if (alignH === 'right') startX = cx + cellW - paddingX - totalWidth;
-  else if (alignH === 'center') startX = cx + cellW / 2 - totalWidth / 2;
-  else startX = cx + leftPad;
-  const { needBidi, baseRtl } = resolveCellBidi(opts.readingOrder, segs.map((s) => s.text).join(''));
-  drawResolvedRichLine(ctx, segs, startX, textY, baseline, cs, dpr, { fontColor: opts.fontColor, needBidi, baseRtl });
+  drawRichSegments(ctx, segs, geom, cs, dpr, opts, textY, baseline);
 }
 
 /**
@@ -1414,12 +1443,7 @@ function drawSingleLineRichText(
   dpr: number,
   opts: { fontColor?: string | null; readingOrder?: number } = {},
 ): void {
-  const { alignV, cy, cellH, paddingY } = geom;
-  let textY: number;
-  let baseline: CanvasTextBaseline;
-  if (alignV === 'top') { baseline = 'top'; textY = cy + paddingY; }
-  else if (alignV === 'center') { baseline = 'middle'; textY = cy + cellH / 2; }
-  else { baseline = 'bottom'; textY = cy + cellH - paddingY; }
+  const { baseline, textY } = singleLineVerticalAnchor(geom);
   drawRichLine(ctx, runs, baseFont, geom, cs, dpr, opts, textY, baseline);
 }
 
@@ -1516,6 +1540,40 @@ export function drawNonWrapRichText(
   }
 }
 
+/** Lay out and draw a plain wrap-enabled cell value. A value that does not
+ *  actually wrap remains a single line and uses the ordinary cell-height
+ *  anchor; only two or more produced lines use the design line-box block. This
+ *  helper is shared by visible cells and off-screen merged anchors so scrolling
+ *  cannot select a different vertical-placement algorithm. */
+export function drawWrappedPlainText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  textX: number,
+  font: CellFont,
+  geom: RichCellGeom,
+  cs: number,
+): void {
+  const { alignV, cy, cellH, leftPad, paddingX, paddingY } = geom;
+  const lines = wrapTextLines(ctx, text, geom.cellW - leftPad - paddingX);
+  if (lines.length === 1) {
+    const { baseline, textY } = singleLineVerticalAnchor(geom);
+    ctx.textBaseline = baseline;
+    ctx.fillText(lines[0], textX, textY);
+    return;
+  }
+
+  const lineH = vMetricPx(font.size, cs, 1.2, font.name ?? undefined);
+  const totalTextH = lines.length * lineH;
+  let startY: number;
+  if (alignV === 'top') startY = cy + paddingY;
+  else if (alignV === 'center') startY = cy + (cellH - totalTextH) / 2;
+  else startY = cy + cellH - totalTextH - paddingY;
+  ctx.textBaseline = 'top';
+  for (let li = 0; li < lines.length; li++) {
+    ctx.fillText(lines[li], textX, startY + li * lineH);
+  }
+}
+
 /**
  * Lay out and draw WRAP-mode rich text (mixed-font runs, §18.8.1 wrapText on).
  * `layoutRichTextLines` soft-wraps at word / CJK boundaries (and hard breaks),
@@ -1544,6 +1602,13 @@ export function drawWrappedRichText(
 ): void {
   const { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY } = geom;
   const rLines = layoutRichTextLines(ctx, runs, baseFont, cs, cellW - leftPad - paddingX);
+  // layoutRichTextLines preserves leading, trailing, and consecutive hard-break
+  // regions, so exactly one produced line also proves there was no hard break.
+  if (rLines.length === 1) {
+    const { baseline, textY } = singleLineVerticalAnchor(geom);
+    drawRichSegments(ctx, rLines[0].segments, geom, cs, dpr, opts, textY, baseline);
+    return;
+  }
   const totalH = rLines.reduce((s, l) => s + vMetricPx(l.maxFontSize, cs, 1.2, l.maxFontFamily ?? undefined), 0);
   let yy: number;
   if (alignV === 'top') yy = cy + paddingY;
@@ -2134,17 +2199,14 @@ function renderQuadrant(
         cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder },
       );
     } else if (xf.wrapText) {
-      const lines = wrapTextLines(ctx, text, cW - leftPad - paddingX);
-      const lineH = vMetricPx(font.size, cs, 1.2, font.name ?? undefined);
-      const totalTextH = lines.length * lineH;
-      let startY: number;
-      if (alignV === 'top') startY = aCy + paddingY;
-      else if (alignV === 'center') startY = aCy + (cH - totalTextH) / 2;
-      else startY = aCy + cH - totalTextH - paddingY;
-      ctx.textBaseline = 'top';
-      for (let li = 0; li < lines.length; li++) {
-        ctx.fillText(lines[li], textX, startY + li * lineH);
-      }
+      drawWrappedPlainText(
+        ctx,
+        text,
+        textX,
+        fontForDraw,
+        { alignH, alignV, cx: aCx, cy: aCy, cellW: cW, cellH: cH, leftPad, paddingX, paddingY },
+        cs,
+      );
     } else if (hasRichText) {
       // Non-wrap rich text — same helper as the in-viewport path so an
       // off-screen-anchored merge renders identical per-run text (single line, or
@@ -2155,10 +2217,10 @@ function renderQuadrant(
         cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder },
       );
     } else {
-      let textY: number;
-      if (alignV === 'top') { ctx.textBaseline = 'top'; textY = aCy + paddingY; }
-      else if (alignV === 'center') { ctx.textBaseline = 'middle'; textY = aCy + cH / 2; }
-      else { ctx.textBaseline = 'bottom'; textY = aCy + cH - paddingY; }
+      const { baseline, textY } = singleLineVerticalAnchor({
+        alignH, alignV, cx: aCx, cy: aCy, cellW: cW, cellH: cH, leftPad, paddingX, paddingY,
+      });
+      ctx.textBaseline = baseline;
       ctx.fillText(text, textX, textY);
     }
     ctx.restore();
@@ -2752,16 +2814,14 @@ function renderQuadrant(
           cs, dpr, { fontColor: cf.fontColor, readingOrder: xf.readingOrder },
         );
       } else if (xf.wrapText) {
-        const lines = wrapTextLines(ctx, text, cellW - leftPad - paddingX);
-        const lineH = vMetricPx(font.size, cs, 1.2, font.name ?? undefined);
-        const totalTextH = lines.length * lineH;
-        let startY: number;
-        if (alignV === 'top') { startY = cy + paddingY; ctx.textBaseline = 'top'; }
-        else if (alignV === 'center') { startY = cy + (cellH - totalTextH) / 2; ctx.textBaseline = 'top'; }
-        else { startY = cy + cellH - totalTextH - paddingY; ctx.textBaseline = 'top'; }
-        for (let li = 0; li < lines.length; li++) {
-          ctx.fillText(lines[li], textX, startY + li * lineH);
-        }
+        drawWrappedPlainText(
+          ctx,
+          text,
+          textX,
+          fontForDraw,
+          { alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY },
+          cs,
+        );
       } else if (hasRichText) {
         // Non-wrap rich text: per-run fonts, honoring hard breaks (Alt+Enter LF;
         // ECMA-376 §18.8.1 — Excel renders breaks even with wrapText off). The
@@ -2845,10 +2905,10 @@ function renderQuadrant(
             ctx.fillText(lines[li], textX, startY + li * lineH + vaYShift);
           }
         } else {
-          let textY: number;
-          if (alignV === 'top') { ctx.textBaseline = 'top'; textY = cy + paddingY; }
-          else if (alignV === 'center') { ctx.textBaseline = 'middle'; textY = cy + cellH / 2; }
-          else { ctx.textBaseline = 'bottom'; textY = cy + cellH - paddingY; }
+          const { baseline, textY } = singleLineVerticalAnchor({
+            alignH, alignV, cx, cy, cellW, cellH, leftPad, paddingX, paddingY,
+          });
+          ctx.textBaseline = baseline;
           ctx.fillText(drawText, textX, textY + vaYShift);
         }
       }

--- a/packages/xlsx/src/viewer-destroy.test.ts
+++ b/packages/xlsx/src/viewer-destroy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { XlsxViewer } from './viewer.js';
+import { XlsxWorkbook } from './workbook.js';
 import { installDom, makeContainer, type FakeDocument, type FakeEl } from './viewer-destroy-test-dom.js';
 
 afterEach(() => {
@@ -91,5 +92,16 @@ describe('XlsxViewer.destroy() — subtree + listeners + style', () => {
     v.destroy();
     expect(() => v.destroy()).not.toThrow();
     expect(container.childNodes.length).toBe(0);
+  });
+
+  it('permanently rejects a new load after destroy without acquiring a workbook', async () => {
+    installDom();
+    const viewer = new XlsxViewer(makeContainer() as unknown as HTMLElement);
+    const load = vi.spyOn(XlsxWorkbook, 'load');
+    viewer.destroy();
+
+    const closed = 'XlsxViewer is destroyed';
+    await expect(viewer.load(new ArrayBuffer(0))).rejects.toThrow(closed);
+    expect(load).not.toHaveBeenCalled();
   });
 });

--- a/packages/xlsx/src/viewer-reload-orphan.test.ts
+++ b/packages/xlsx/src/viewer-reload-orphan.test.ts
@@ -80,4 +80,32 @@ describe('XlsxViewer.load() — no orphaned workbook on re-load (SC20)', () => {
     v.destroy();
     expect(a.destroy).toHaveBeenCalledTimes(1);
   });
+
+  it('maps an in-flight loader rejection after destroy to the terminal viewer error', async () => {
+    const { v } = build();
+    let rejectLoad: ((reason: Error) => void) | undefined;
+    vi.spyOn(XlsxWorkbook, 'load').mockImplementation(() =>
+      new Promise<XlsxWorkbook>((_resolve, reject) => { rejectLoad = reject; }));
+
+    const pending = v.load('pending.xlsx');
+    v.destroy();
+    rejectLoad?.(new Error('late parser failure'));
+
+    await expect(pending).rejects.toThrow('XlsxViewer is destroyed');
+  });
+
+  it('disposes an in-flight workbook that resolves after destroy and reports terminal close', async () => {
+    const { v } = build();
+    const late = fakeWorkbook();
+    let resolveLoad: ((workbook: XlsxWorkbook) => void) | undefined;
+    vi.spyOn(XlsxWorkbook, 'load').mockImplementation(() =>
+      new Promise<XlsxWorkbook>((resolve) => { resolveLoad = resolve; }));
+
+    const pending = v.load('pending.xlsx');
+    v.destroy();
+    resolveLoad?.(late.wb);
+
+    await expect(pending).rejects.toThrow('XlsxViewer is destroyed');
+    expect(late.destroy).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -3,7 +3,7 @@ import type { Hyperlink, ViewportRange, Worksheet, XlsxComment } from './types.j
 import type { FindHighlightColors, HyperlinkTarget, LoadOptions, FindMatch, FindMatchesOptions, OoxmlResourceMetrics, ZoomableViewer } from '@silurus/ooxml-core';
 import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale, anchoredZoomOffset, openExternalHyperlink, nextZoomStep, prevZoomStep, fitScale } from '@silurus/ooxml-core';
 import { CallerCanvasMount } from '@silurus/ooxml-core/internal/canvas-viewer-mechanics';
-import { HEADER_W, HEADER_H, colWidthToPx, rowHeightToPx, pxToColWidth, pxToRowHeight, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
+import { HEADER_W, HEADER_H, pxToColWidth, pxToRowHeight, getMdwForWorksheet, rtlMirrorX } from './renderer.js';
 import { findListValidationAt } from './data-validation.js';
 import { parseA1 } from './a1.js';
 import { XlsxFindController, type FindCell, type XlsxMatchLocation } from './find.js';
@@ -741,6 +741,7 @@ class XlsxViewerEngine implements ZoomableViewer {
    *   RESOLVES, matching every subsequent navigation call.
    */
   async load(source: string | ArrayBuffer): Promise<void> {
+    this.assertOpen();
     // SC20 atomic swap: retain the previous workbook locally and only tear it down
     // AFTER the new one loads successfully. A re-load thus never orphans the old
     // workbook's worker + pinned WASM allocation (the leak this guards), yet a
@@ -768,6 +769,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       this.opts.onReady?.(wb.sheetNames);
       await this.showSheet(this._initialSheet());
     } catch (err) {
+      if (this._destroyed) throw this.destroyedError();
       const e = err instanceof Error ? err : new Error(String(err));
       if (this.opts.onError) {
         this.opts.onError(e);
@@ -1497,6 +1499,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
   /** Returns the cell at canvas-client coordinates, or null if outside the cell grid. */
   getCellAt(clientX: number, clientY: number): CellAddress | null {
+    if (this._destroyed) return null;
     const ws = this.currentWorksheet;
     if (!ws) return null;
     const cs = this.viewport.scale;
@@ -1514,62 +1517,10 @@ class XlsxViewerEngine implements ZoomableViewer {
     const innerX = lx - HEADER_W;
     const innerY = ly - HEADER_H;
 
-    const freezeRows = ws.freezeRows ?? 0;
-    const freezeCols = ws.freezeCols ?? 0;
-
-    // Compute frozen pixel dimensions (unscaled)
-    let frozenH = 0;
-    const frozenRowH: number[] = [];
-    for (let r = 1; r <= freezeRows; r++) {
-      const h = rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
-      frozenRowH.push(h);
-      frozenH += h;
-    }
-    let frozenW = 0;
-    const frozenColW: number[] = [];
-    for (let c = 1; c <= freezeCols; c++) {
-      const w = colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, getMdwForWorksheet(ws));
-      frozenColW.push(w);
-      frozenW += w;
-    }
-
-    // Find row
-    let row: number;
-    if (innerY < frozenH) {
-      row = -1;
-      let acc = 0;
-      for (let r = 0; r < freezeRows; r++) {
-        acc += frozenRowH[r];
-        if (innerY < acc) { row = r + 1; break; }
-      }
-      if (row === -1) return null;
-    } else {
-      const contentY = innerY - frozenH + this.viewportTop / cs;
-      const axes = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws));
-      const r = axes.row.scrollableIndexAt(contentY, freezeRows + 1);
-      if (r === null) return null;
-      row = r;
-    }
-
-    // Find col
-    let col: number;
-    if (innerX < frozenW) {
-      col = -1;
-      let acc = 0;
-      for (let c = 0; c < freezeCols; c++) {
-        acc += frozenColW[c];
-        if (innerX < acc) { col = c + 1; break; }
-      }
-      if (col === -1) return null;
-    } else {
-      const contentX = innerX - frozenW + this.effectiveScrollLeft / cs;
-      const axes = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws));
-      const c = axes.col.scrollableIndexAt(contentX, freezeCols + 1);
-      if (c === null) return null;
-      col = c;
-    }
-
-    return { row, col };
+    return GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws)).cellAt(innerX, innerY, {
+      scrollX: this.effectiveScrollLeft / cs,
+      scrollY: this.viewportTop / cs,
+    });
   }
 
   /** Returns the CSS-pixel rect of a cell within canvasArea, or null if not
@@ -1582,70 +1533,13 @@ class XlsxViewerEngine implements ZoomableViewer {
     const ws = this.currentWorksheet;
     if (!ws) return null;
     const cs = this.viewport.scale;
-    const mdw = getMdwForWorksheet(ws);
-    const sp = (px: number) => Math.round(px * cs);
-    const colW = (c: number) => sp(colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw));
-    const rowH = (r: number) => sp(rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight));
-
-    const freezeRows = ws.freezeRows ?? 0;
-    const freezeCols = ws.freezeCols ?? 0;
-
-    // Compute x. The renderer draws the scrollable area starting at
-    // `scrollAreaX = sp(HEADER_W) + Σ sp(frozenWidth)` and offsets each
-    // cell by `-(offsetX * cs)` where offsetX is the *logical* partial
-    // visibility of the leftmost visible column.
-    let x: number;
-    if (col <= freezeCols) {
-      let acc = sp(HEADER_W);
-      for (let c = 1; c < col; c++) acc += colW(c);
-      x = acc;
-    } else {
-      let frozenW = 0;
-      for (let c = 1; c <= freezeCols; c++) frozenW += colW(c);
-      const scrollAreaX = sp(HEADER_W) + frozenW;
-
-      // Mirror renderCurrentSheet's startCol / offsetX search (binary search).
-      const logicalScrollX = this.effectiveScrollLeft / cs;
-      const colAxis = GridGeometry.forWorksheet(ws, mdw).col;
-      const { index: startCol, partial: offsetX } =
-        colAxis.indexAt(logicalScrollX + colAxis.offsetOf(freezeCols + 1));
-
-      let acc = scrollAreaX - offsetX * cs;
-      if (col >= startCol) {
-        for (let c = startCol; c < col; c++) acc += colW(c);
-      } else {
-        // Cell scrolled off to the left of startCol — subtract instead.
-        for (let c = col; c < startCol; c++) acc -= colW(c);
-      }
-      x = acc;
-    }
-
-    // Compute y, same logic as x.
-    let y: number;
-    if (row <= freezeRows) {
-      let acc = sp(HEADER_H);
-      for (let r = 1; r < row; r++) acc += rowH(r);
-      y = acc;
-    } else {
-      let frozenH = 0;
-      for (let r = 1; r <= freezeRows; r++) frozenH += rowH(r);
-      const scrollAreaY = sp(HEADER_H) + frozenH;
-
-      const logicalScrollY = this.viewportTop / cs;
-      const rowAxis = GridGeometry.forWorksheet(ws, mdw).row;
-      const { index: startRow, partial: offsetY } =
-        rowAxis.indexAt(logicalScrollY + rowAxis.offsetOf(freezeRows + 1));
-
-      let acc = scrollAreaY - offsetY * cs;
-      if (row >= startRow) {
-        for (let r = startRow; r < row; r++) acc += rowH(r);
-      } else {
-        for (let r = row; r < startRow; r++) acc -= rowH(r);
-      }
-      y = acc;
-    }
-
-    return { x, y, w: colW(col), h: rowH(row) };
+    return GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws)).cellRect(row, col, {
+      scale: cs,
+      scrollX: this.effectiveScrollLeft / cs,
+      scrollY: this.viewportTop / cs,
+      headerWidth: HEADER_W,
+      headerHeight: HEADER_H,
+    });
   }
 
   /** Returns the current selection, including mode. */
@@ -1692,53 +1586,20 @@ class XlsxViewerEngine implements ZoomableViewer {
     if (!inRowHeader && !inColHeader) return null;
     if (inRowHeader && inColHeader) return { kind: 'corner' };
 
-    const freezeRows = ws.freezeRows ?? 0;
-    const freezeCols = ws.freezeCols ?? 0;
+    const geometry = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws));
 
     if (inRowHeader) {
       // Determine which row was clicked
       const innerY = ly - HEADER_H;
       if (innerY < 0) return { kind: 'corner' };
-      let frozenH = 0;
-      const frozenRowH: number[] = [];
-      for (let r = 1; r <= freezeRows; r++) {
-        const h = rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
-        frozenRowH.push(h); frozenH += h;
-      }
-      if (innerY < frozenH) {
-        let acc = 0;
-        for (let r = 0; r < freezeRows; r++) {
-          acc += frozenRowH[r];
-          if (innerY < acc) return { kind: 'row', row: r + 1 };
-        }
-        return null;
-      }
-      const contentY = innerY - frozenH + this.viewportTop / cs;
-      const axes = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws));
-      const r = axes.row.scrollableIndexAt(contentY, freezeRows + 1);
+      const r = geometry.rowAt(innerY, this.viewportTop / cs);
       return r === null ? null : { kind: 'row', row: r };
     }
 
     // inColHeader
     const innerX = lx - HEADER_W;
     if (innerX < 0) return { kind: 'corner' };
-    let frozenW = 0;
-    const frozenColW: number[] = [];
-    for (let c = 1; c <= freezeCols; c++) {
-      const w = colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, getMdwForWorksheet(ws));
-      frozenColW.push(w); frozenW += w;
-    }
-    if (innerX < frozenW) {
-      let acc = 0;
-      for (let c = 0; c < freezeCols; c++) {
-        acc += frozenColW[c];
-        if (innerX < acc) return { kind: 'col', col: c + 1 };
-      }
-      return null;
-    }
-    const contentX = innerX - frozenW + this.effectiveScrollLeft / cs;
-    const axes = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws));
-    const c = axes.col.scrollableIndexAt(contentX, freezeCols + 1);
+    const c = geometry.colAt(innerX, this.effectiveScrollLeft / cs);
     return c === null ? null : { kind: 'col', col: c };
   }
 
@@ -1950,10 +1811,9 @@ class XlsxViewerEngine implements ZoomableViewer {
     const headerW = sp(HEADER_W);
     const headerH = sp(HEADER_H);
 
-    let frozenH = 0;
-    if (ws) for (let r = 1; r <= freezeRows; r++) frozenH += sp(rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight));
-    let frozenW = 0;
-    if (ws) for (let c = 1; c <= freezeCols; c++) frozenW += sp(colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, getMdwForWorksheet(ws)));
+    const frozen = ws
+      ? GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws)).roundedFrozenExtent(cs)
+      : { width: 0, height: 0 };
 
     let x: number, y: number, w: number, h: number;
     let selR1 = 1, selC1 = 1;
@@ -2003,8 +1863,8 @@ class XlsxViewerEngine implements ZoomableViewer {
     // Clamp scrollable-region selections at the frozen pane boundary.
     // Frozen cells legitimately live inside the frozen area; scrollable cells
     // that have scrolled behind the frozen area must be clipped there instead.
-    const frozenBoundX = headerW + frozenW;
-    const frozenBoundY = headerH + frozenH;
+    const frozenBoundX = headerW + frozen.width;
+    const frozenBoundY = headerH + frozen.height;
     if (selC1 > freezeCols && x < frozenBoundX) { w -= frozenBoundX - x; x = frozenBoundX; }
     if (selR1 > freezeRows && y < frozenBoundY) { h -= frozenBoundY - y; y = frozenBoundY; }
 
@@ -2126,14 +1986,9 @@ class XlsxViewerEngine implements ZoomableViewer {
     const headerH = sp(HEADER_H);
     const freezeRows = ws.freezeRows ?? 0;
     const freezeCols = ws.freezeCols ?? 0;
-    let frozenW = 0;
-    for (let c = 1; c <= freezeCols; c++)
-      frozenW += sp(colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, getMdwForWorksheet(ws)));
-    let frozenH = 0;
-    for (let r = 1; r <= freezeRows; r++)
-      frozenH += sp(rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight));
-    const frozenBoundX = headerW + frozenW;
-    const frozenBoundY = headerH + frozenH;
+    const frozen = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws)).roundedFrozenExtent(cs);
+    const frozenBoundX = headerW + frozen.width;
+    const frozenBoundY = headerH + frozen.height;
 
     // A match accent: same single-color → border + translucent fill derivation
     // the selection overlay uses. The active match uses a warm accent so it is
@@ -2242,64 +2097,22 @@ class XlsxViewerEngine implements ZoomableViewer {
     const ws = this.currentWorksheet;
     if (!ws) return;
     const cs = this.viewport.scale;
-    const mdw = getMdwForWorksheet(ws);
-    const axes = GridGeometry.forWorksheet(ws, mdw);
-    const freezeRows = ws.freezeRows ?? 0;
-    const freezeCols = ws.freezeCols ?? 0;
-
-    // Vertical: only scroll for a scrollable-region row.
-    if (row > freezeRows) {
-      const headerH = Math.round(HEADER_H * cs);
-      let frozenH = 0;
-      for (let r = 1; r <= freezeRows; r++) frozenH += Math.round(rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight) * cs);
-      const viewTop = headerH + frozenH; // top of the scrollable region (canvasArea px)
-      const viewH = this.canvasArea.clientHeight;
-      // Cell offset from the first scrollable row, in logical px, → scaled px.
-      const cellTopLogical = axes.row.offsetOf(row) - axes.row.offsetOf(freezeRows + 1);
-      const cellHLogical = rowHeightToPx(ws.rowHeights[row] ?? ws.defaultRowHeight);
-      const cellTop = viewTop + (cellTopLogical * cs - this.viewportTop);
-      const cellBot = cellTop + cellHLogical * cs;
-      if (align === 'start') {
-        this.viewportTop = cellTopLogical * cs;
-      } else if (align === 'center') {
-        this.viewportTop = cellTopLogical * cs - (viewH - viewTop - cellHLogical * cs) / 2;
-      } else if (align === 'end') {
-        this.viewportTop = cellTopLogical * cs - (viewH - viewTop - cellHLogical * cs);
-      } else if (cellTop < viewTop) {
-        this.viewportTop = cellTopLogical * cs;
-      } else if (cellBot > viewH) {
-        this.viewportTop = cellTopLogical * cs - (viewH - viewTop - cellHLogical * cs);
-      }
-    }
-
-    // Horizontal: only scroll for a scrollable-region column. Work in the
-    // start-anchored logical space, then re-derive the native scrollLeft (RTL
-    // safe) via the existing anchor path.
-    if (col > freezeCols) {
-      const headerW = Math.round(HEADER_W * cs);
-      let frozenW = 0;
-      for (let c = 1; c <= freezeCols; c++) frozenW += Math.round(colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw) * cs);
-      const viewLeft = headerW + frozenW;
-      const viewW = this.canvasArea.clientWidth;
-      const cellLeftLogical = axes.col.offsetOf(col) - axes.col.offsetOf(freezeCols + 1);
-      const cellWLogical = colWidthToPx(ws.colWidths[col] ?? ws.defaultColWidth, mdw);
-      const cellLeft = viewLeft + (cellLeftLogical * cs - this.effectiveScrollLeft);
-      const cellRight = cellLeft + cellWLogical * cs;
-      let wantEff = this.effectiveScrollLeft;
-      if (align === 'start') {
-        wantEff = cellLeftLogical * cs;
-      } else if (align === 'center') {
-        wantEff = cellLeftLogical * cs - (viewW - viewLeft - cellWLogical * cs) / 2;
-      } else if (align === 'end') {
-        wantEff = cellLeftLogical * cs - (viewW - viewLeft - cellWLogical * cs);
-      } else if (cellLeft < viewLeft) {
-        wantEff = cellLeftLogical * cs;
-      } else if (cellRight > viewW) {
-        wantEff = cellLeftLogical * cs - (viewW - viewLeft - cellWLogical * cs);
-      }
-      wantEff = Math.max(0, wantEff);
-      this.setViewportLeft(wantEff);
-    }
+    const offset = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws)).scrollOffsetForCell(
+      row,
+      col,
+      {
+        scale: cs,
+        viewportWidth: this.canvasArea.clientWidth,
+        viewportHeight: this.canvasArea.clientHeight,
+        currentX: this.effectiveScrollLeft,
+        currentY: this.viewportTop,
+        headerWidth: HEADER_W,
+        headerHeight: HEADER_H,
+        align,
+      },
+    );
+    this.viewportTop = offset.y;
+    this.setViewportLeft(offset.x);
   }
 
   // ─── List data-validation dropdown panel (display-only) ───────────────────
@@ -3316,7 +3129,6 @@ class XlsxViewerEngine implements ZoomableViewer {
    *  {@link updateSpacerSize} at cs=1 (same used-range detection) so the fit
    *  targets exactly the region the spacer/scroll extent covers. */
   private _naturalContentExtent(ws: Worksheet): { width: number; height: number } {
-    const mdw = getMdwForWorksheet(ws);
     let maxRow = Math.max(50, ws.freezeRows ?? 0);
     let maxCol = Math.max(26, ws.freezeCols ?? 0);
     for (const row of ws.rows) {
@@ -3325,24 +3137,16 @@ class XlsxViewerEngine implements ZoomableViewer {
         if (cell.col > maxCol) maxCol = cell.col;
       }
     }
-    let width = HEADER_W;
-    for (let c = 1; c <= maxCol; c++) {
-      width += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw);
-    }
-    let height = HEADER_H;
-    for (let r = 1; r <= maxRow; r++) {
-      height += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
-    }
-    return { width, height };
+    return GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws)).logicalContentExtent(
+      maxRow,
+      maxCol,
+      HEADER_W,
+      HEADER_H,
+    );
   }
 
   private updateSpacerSize(ws: Worksheet): void {
     const cs = this.viewport.scale;
-    const mdw = getMdwForWorksheet(ws);
-    // Match getCellRect / the renderer: round each cell's scaled width
-    // independently so the scrollbar's max scroll lines up with the
-    // canvas's furthest-right / furthest-down drawn cell edge.
-    const sp = (px: number) => Math.round(px * cs);
     const freezeRows = ws.freezeRows ?? 0;
     const freezeCols = ws.freezeCols ?? 0;
 
@@ -3358,15 +3162,16 @@ class XlsxViewerEngine implements ZoomableViewer {
     maxRow += 30;
     maxCol += 10;
 
-    // Spacer = sp(header) + Σ sp(width) for every visible col, same for rows.
-    let totalW = sp(HEADER_W);
-    for (let c = 1; c <= maxCol; c++) {
-      totalW += sp(colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, mdw));
-    }
-    let totalH = sp(HEADER_H);
-    for (let r = 1; r <= maxRow; r++) {
-      totalH += sp(rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight));
-    }
+    // Spacer = rounded header + cumulative per-band-rounded geometry.
+    const extent = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws)).roundedContentExtent(
+      maxRow,
+      maxCol,
+      cs,
+      HEADER_W,
+      HEADER_H,
+    );
+    const totalW = extent.width;
+    const totalH = extent.height;
 
     this.spacer.style.width = `${totalW}px`;
     this.spacer.style.height = `${totalH}px`;
@@ -3434,16 +3239,6 @@ class XlsxViewerEngine implements ZoomableViewer {
     const freezeRows = ws.freezeRows ?? 0;
     const freezeCols = ws.freezeCols ?? 0;
 
-    // Compute frozen area in logical (unscaled) pixels
-    let frozenW = 0;
-    for (let c = 1; c <= freezeCols; c++) {
-      frozenW += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, getMdwForWorksheet(ws));
-    }
-    let frozenH = 0;
-    for (let r = 1; r <= freezeRows; r++) {
-      frozenH += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight);
-    }
-
     // DOM scrollLeft/scrollTop are in scaled (physical) CSS pixels.
     // Convert to logical pixels for cell-finding by dividing by cs. For RTL
     // sheets effectiveScrollLeft inverts the native scrollLeft so that 0 = col A
@@ -3451,36 +3246,18 @@ class XlsxViewerEngine implements ZoomableViewer {
     const logicalScrollX = this.effectiveScrollLeft / cs;
     const logicalScrollY = this.viewportTop / cs;
 
-    // Find startCol / startRow in logical pixel space (binary search over the
-    // per-sheet cumulative-offset axes instead of an O(n) walk from cell 1).
-    const axes = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws));
-    const { index: startCol, partial: offsetX } =
-      axes.col.indexAt(logicalScrollX + axes.col.offsetOf(freezeCols + 1));
-    const { index: startRow, partial: offsetY } =
-      axes.row.indexAt(logicalScrollY + axes.row.offsetOf(freezeRows + 1));
-
-    // Effective scrollable area in logical pixels (canvas / cs - headers - frozen)
-    const cellW = w / cs - HEADER_W - frozenW;
-    const cellH = h / cs - HEADER_H - frozenH;
-
-    // Compute exact number of visible columns by walking actual widths (+ 2 buffer)
-    let cols = 0;
-    { let xAcc = -offsetX; let c = startCol;
-      while (xAcc < cellW + offsetX && c <= 16384) {
-        xAcc += colWidthToPx(ws.colWidths[c] ?? ws.defaultColWidth, getMdwForWorksheet(ws)); cols++; c++;
-      }
-      cols += 2;
-    }
-    // Compute exact number of visible rows by walking actual heights (+ 2 buffer)
-    let rows = 0;
-    { let yAcc = -offsetY; let r = startRow;
-      while (yAcc < cellH + offsetY && r <= 1048576) {
-        yAcc += rowHeightToPx(ws.rowHeights[r] ?? ws.defaultRowHeight); rows++; r++;
-      }
-      rows += 2;
-    }
-
-    const viewport: ViewportRange = { row: startRow, col: startCol, rows, cols };
+    const visible = GridGeometry.forWorksheet(ws, getMdwForWorksheet(ws)).visibleRange({
+      width: w,
+      height: h,
+      scale: cs,
+      scrollX: logicalScrollX,
+      scrollY: logicalScrollY,
+      headerWidth: HEADER_W,
+      headerHeight: HEADER_H,
+      buffer: 2,
+    });
+    const viewport: ViewportRange = visible.range;
+    const { offsetX, offsetY } = visible;
 
     const { selectedRowRange, selectedColRange } = this.computeHeaderHighlight();
 
@@ -3584,6 +3361,16 @@ class XlsxViewerEngine implements ZoomableViewer {
     // detaches every listener bound to elements within it (scrollHost pointer/
     // wheel handlers, tab clicks, zoom slider) without per-element cleanup.
     this.wrapper.remove();
+  }
+
+  private assertOpen(): void {
+    if (this._destroyed) throw this.destroyedError();
+  }
+
+  private destroyedError(): Error {
+    return new Error(this._mountKind === 'sheet'
+      ? 'XlsxSheetViewer is destroyed'
+      : 'XlsxViewer is destroyed');
   }
 }
 

--- a/packages/xlsx/src/wrapped-single-line-vertical-align.test.ts
+++ b/packages/xlsx/src/wrapped-single-line-vertical-align.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import {
+  drawWrappedPlainText,
+  drawWrappedRichText,
+  HEADER_H,
+  renderViewport,
+  rowHeightToPx,
+} from './renderer.js';
+import type { CellFont, Run, Styles, Worksheet } from './types.js';
+
+// ECMA-376 Part 1 §18.8.1 defines wrapText only as enabling line wrapping,
+// while §18.18.88 defines center as centering content across the cell height.
+// Consequently, enabling wrapText must not move a value that still lays out as
+// one line onto the multi-line top-baseline path. Plain and rich strings share
+// this invariant, including when the cell spans a merged range.
+
+const FONT: CellFont = {
+  bold: false,
+  italic: false,
+  underline: false,
+  strike: false,
+  size: 10,
+  color: null,
+  name: 'Meiryo UI',
+};
+
+interface FillTextCall {
+  text: string;
+  y: number;
+  baseline: CanvasTextBaseline;
+}
+
+function recordingContext(): { ctx: CanvasRenderingContext2D; calls: FillTextCall[] } {
+  let font = '13px sans-serif';
+  let baseline: CanvasTextBaseline = 'alphabetic';
+  const calls: FillTextCall[] = [];
+  const ctx = {
+    canvas: { width: 600, height: 120 },
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    get textBaseline() { return baseline; },
+    set textBaseline(value: CanvasTextBaseline) { baseline = value; },
+    measureText: (text: string) => ({ width: [...text].length * 10 }) as TextMetrics,
+    fillText(text: string, _x: number, y: number) {
+      calls.push({ text, y, baseline });
+    },
+    save() {},
+    restore() {},
+    beginPath() {},
+    closePath() {},
+    moveTo() {},
+    lineTo() {},
+    rect() {},
+    arc() {},
+    clip() {},
+    fill() {},
+    stroke() {},
+    fillRect() {},
+    strokeRect() {},
+    clearRect() {},
+    translate() {},
+    rotate() {},
+    scale() {},
+    transform() {},
+    setTransform() {},
+    setLineDash() {},
+    createLinearGradient: () => ({ addColorStop() {} }),
+    fillStyle: '#000' as string,
+    strokeStyle: '#000' as string,
+    lineWidth: 1,
+    textAlign: 'left' as CanvasTextAlign,
+    direction: 'ltr' as 'ltr' | 'rtl',
+    globalAlpha: 1,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+}
+
+const GEOM = {
+  alignH: 'left',
+  alignV: 'center',
+  cx: 0,
+  cy: 20,
+  cellW: 300,
+  cellH: 24,
+  leftPad: 3,
+  paddingX: 3,
+  paddingY: 2,
+};
+
+const STYLES: Styles = {
+  fonts: [FONT],
+  fills: [],
+  borders: [],
+  cellXfs: [{
+    fontId: 0,
+    fillId: 0,
+    borderId: 0,
+    numFmtId: 0,
+    alignH: 'left',
+    alignV: 'center',
+    wrapText: true,
+  }],
+  numFmts: [],
+  dxfs: [],
+};
+
+function mergedWorksheet(): Worksheet {
+  return {
+    name: 'One-line merged alignment',
+    rows: [{
+      index: 1,
+      height: 18,
+      cells: [{
+        row: 1,
+        col: 1,
+        styleIndex: 0,
+        value: { type: 'text', text: 'Merged label' },
+      }],
+    }],
+    colWidths: { 1: 18, 2: 18, 3: 18 },
+    rowHeights: { 1: 18 },
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [{ top: 1, bottom: 1, left: 1, right: 2 }],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    images: [],
+    charts: [],
+    defaultFontFamily: 'Meiryo UI',
+    defaultFontSize: 10,
+  } as Worksheet;
+}
+
+describe('wrapped values that remain one line preserve single-line vertical alignment', () => {
+  it('centers a plain string with the middle baseline', () => {
+    const { ctx, calls } = recordingContext();
+
+    drawWrappedPlainText(ctx, 'Single line', 3, FONT, GEOM, 1);
+
+    expect(calls).toEqual([{ text: 'Single line', y: 32, baseline: 'middle' }]);
+  });
+
+  it('centers rich text with the same middle baseline', () => {
+    const { ctx, calls } = recordingContext();
+    const runs: Run[] = [{
+      text: 'Single line',
+      font: { bold: false, italic: false, underline: false, strike: false, size: 10 },
+    }];
+
+    drawWrappedRichText(ctx, runs, FONT, GEOM, 1, 1);
+
+    expect(calls.map((call) => call.text).join('')).toBe('Single line');
+    expect(calls.every((call) => call.baseline === 'middle')).toBe(true);
+    expect(calls.every((call) => call.y === 32)).toBe(true);
+  });
+
+  it('uses the same middle baseline for visible and off-screen merged anchors', () => {
+    const worksheet = mergedWorksheet();
+    const visible = recordingContext();
+    const offscreen = recordingContext();
+
+    // Anchor A1 is visible and is painted by the ordinary cell loop.
+    renderViewport(visible.ctx, worksheet, STYLES, { row: 1, col: 1, rows: 1, cols: 3 });
+    // Starting at column B leaves A1 outside the viewport while its A1:B1 merge
+    // still overlaps it, forcing the off-screen merged-anchor pre-pass.
+    renderViewport(offscreen.ctx, worksheet, STYLES, { row: 1, col: 2, rows: 1, cols: 2 });
+
+    const visibleLabel = visible.calls.filter(({ text }) => text === 'Merged label');
+    const offscreenLabel = offscreen.calls.filter(({ text }) => text === 'Merged label');
+    const rowCenterY = HEADER_H + rowHeightToPx(18) / 2;
+    expect(visibleLabel).toEqual([{ text: 'Merged label', y: rowCenterY, baseline: 'middle' }]);
+    expect(offscreenLabel).toEqual(visibleLabel);
+  });
+});


### PR DESCRIPTION
## Summary\n- center wrap-enabled XLSX values against the full cell when layout produces exactly one line, for plain, rich, and merged-anchor rendering\n- consolidate XLSX grid geometry and static bitmap ownership so composite and sheet viewers share one implementation without merging format-specific layout concepts\n- make XLSX workbook acquisition terminal after destruction and allow PPTX media reads to coexist with retained slide cursors\n\n## Design review\nTwo independent post-architecture reviews covered public API symmetry, lifecycle ownership, duplication, maintainability, extensibility, and hot-path performance. The identified release blockers are addressed in this PR.\n\n## Specification\nThe XLSX alignment behavior follows ECMA-376 Part 1 sections 18.8.1 and 18.18.88: wrapText enables wrapping, while vertical alignment remains relative to the cell height.\n\n## Verification\n- full repository test suite\n- TypeScript project build and package/site build\n- ooxml-common and PPTX Rust tests\n- DOCX layout architecture audit suite\n- renderer-before/after VRT using the pre-change renderer as baseline\n  - every rendered DOCX page and all 100 PPTX slides were pixel-identical\n  - XLSX changes were limited to wrap-enabled values that remained one line; unaffected sheets were pixel-identical\n