### PR TITLE
fix(xlsx): localize short dates and mirror RTL layout

### DIFF
--- a/packages/xlsx/src/number-format.test.ts
+++ b/packages/xlsx/src/number-format.test.ts
@@ -15,6 +15,25 @@ function styles(formatCode: string): Styles {
   };
 }
 
+function builtinStyles(numFmtId: number): Styles {
+  return {
+    fonts: [],
+    fills: [],
+    borders: [],
+    cellXfs: [{
+      fontId: 0,
+      fillId: 0,
+      borderId: 0,
+      numFmtId,
+      alignH: null,
+      alignV: null,
+      wrapText: false,
+    }],
+    numFmts: [],
+    dxfs: [],
+  };
+}
+
 function numCell(n: number): Cell {
   return { row: 1, col: 1, value: { type: 'number', number: n }, styleIndex: 0 };
 }
@@ -151,6 +170,24 @@ describe('date formats (Excel serial; 45292 = 2024-01-01)', () => {
     expect(fmt(45292, 'd')).toBe('1');
     expect(fmt(45292, 'dd')).toBe('01');
   });
+
+  it('localizes built-in short-date format 14 to the application UI language', () => {
+    vi.stubGlobal('navigator', { language: 'ja-JP' });
+    try {
+      expect(formatCellValue(numCell(45306), builtinStyles(14))).toBe('2024/1/15');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('keeps built-in short-date format 14 in month/day/year order for en-US', () => {
+    vi.stubGlobal('navigator', { language: 'en-US' });
+    try {
+      expect(formatCellValue(numCell(45306), builtinStyles(14))).toBe('1/15/2024');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
 describe('date formats — 1900 Lotus leap-year-bug compat (§18.17.4.1)', () => {
@@ -245,6 +282,17 @@ describe('volatile TODAY()/NOW() exemption from date1904 (§18.17.4.1)', () => {
   it('TODAY() in a 1904 workbook renders the correct 1900-system today (not 1462 days off)', () => {
     const rendered = formatCellValue(volatileCell('TODAY()'), styles('yyyy-mm-dd'), null, true);
     expect(rendered).toBe(frozenTodayString());
+  });
+
+  it('renders TODAY() through localized built-in short-date format 14', () => {
+    vi.stubGlobal('navigator', { language: 'ja-JP' });
+    try {
+      const [year, month, day] = frozenTodayString().split('-').map(Number);
+      const rendered = formatCellValue(volatileCell('TODAY()'), builtinStyles(14));
+      expect(rendered).toBe(`${year}/${month}/${day}`);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('tolerates a leading = and whitespace in the recomputed formula', () => {

--- a/packages/xlsx/src/number-format.test.ts
+++ b/packages/xlsx/src/number-format.test.ts
@@ -188,6 +188,24 @@ describe('date formats (Excel serial; 45292 = 2024-01-01)', () => {
       vi.unstubAllGlobals();
     }
   });
+
+  it('reuses the localized short-date formatter for cells in the same UI locale', () => {
+    vi.stubGlobal('navigator', { language: 'ko-KR' });
+    const NativeDateTimeFormat = Intl.DateTimeFormat;
+    const formatter = vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(
+      function dateTimeFormat(locales, options) {
+        return new NativeDateTimeFormat(locales, options);
+      },
+    );
+    try {
+      formatCellValue(numCell(45306), builtinStyles(14));
+      formatCellValue(numCell(45307), builtinStyles(14));
+      expect(formatter).toHaveBeenCalledTimes(1);
+    } finally {
+      formatter.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
 describe('date formats — 1900 Lotus leap-year-bug compat (§18.17.4.1)', () => {

--- a/packages/xlsx/src/number-format.ts
+++ b/packages/xlsx/src/number-format.ts
@@ -2,6 +2,23 @@ import { excelSerialToUtcDate, roundDecimalHalfUp } from '@silurus/ooxml-core';
 import type { Cell, CellValue, Styles } from './types.js';
 import { todaySerial, nowSerial } from './formula.js';
 
+const localizedShortDateFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function localizedShortDateFormatter(locale: string | undefined): Intl.DateTimeFormat {
+  const cacheKey = locale ?? '';
+  const cached = localizedShortDateFormatters.get(cacheKey);
+  if (cached) return cached;
+
+  const formatter = new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+  localizedShortDateFormatters.set(cacheKey, formatter);
+  return formatter;
+}
+
 
 function cellValueText(value: CellValue): string {
   switch (value.type) {
@@ -508,12 +525,7 @@ function applyFormat(num: number, numFmtId: number, formatCode: string | null, d
     const locale = typeof navigator === 'undefined' ? undefined : navigator.language;
     const date = excelSerialToUtcDate(num, date1904);
     return {
-      text: new Intl.DateTimeFormat(locale, {
-        year: 'numeric',
-        month: 'numeric',
-        day: 'numeric',
-        timeZone: 'UTC',
-      }).format(date),
+      text: localizedShortDateFormatter(locale).format(date),
     };
   }
   // Built-in date/time numFmtIds (ECMA-376 §18.8.30 table)

--- a/packages/xlsx/src/number-format.ts
+++ b/packages/xlsx/src/number-format.ts
@@ -151,14 +151,12 @@ function recomputeVolatile(formula: string | undefined): number | null {
 // Date / time formatting  (ECMA-376 §18.8.30)
 // ────────────────────────────────────────────────────────────────
 
-// Built-in numFmtId → format code. IDs 14-22 are the ECMA-376 US-English
-// built-ins; IDs 27-31 and 50-58 are East-Asian (Japanese) locale built-ins
-// that Office ships pre-assigned when the file was authored in ja-JP. The
-// spec lists the codes under §18.8.30 Table "Built-in formats" (the
-// locale-dependent block is given without format strings but the de-facto
-// codes match the ones that Office writes back when opening and re-saving).
+// Built-in numFmtId → format code. ID 14 is handled separately because
+// ECMA-376 §18.8.30 permits built-in formats to be interpreted differently
+// according to the implementing application's UI language. IDs 15-22 use the
+// generic table's patterns here; IDs 27-31 and 50-58 are East-Asian (Japanese)
+// locale built-ins that Office ships pre-assigned when authored in ja-JP.
 const BUILTIN_DATE_FMT: Record<number, string> = {
-  14: 'm/d/yyyy',
   15: 'd-mmm-yy',
   16: 'd-mmm',
   17: 'mmm-yy',
@@ -502,6 +500,22 @@ function formatGeneralNumber(num: number): string {
 }
 
 function applyFormat(num: number, numFmtId: number, formatCode: string | null, date1904 = false): FormattedCell {
+  // Built-in 14 is Excel's locale-sensitive short-date format rather than a
+  // file-authored pattern. Use the host application's UI locale, while keeping
+  // UTC fields so the Excel serial cannot cross a calendar-day boundary in a
+  // non-UTC timezone.
+  if (numFmtId === 14 && !formatCode) {
+    const locale = typeof navigator === 'undefined' ? undefined : navigator.language;
+    const date = excelSerialToUtcDate(num, date1904);
+    return {
+      text: new Intl.DateTimeFormat(locale, {
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric',
+        timeZone: 'UTC',
+      }).format(date),
+    };
+  }
   // Built-in date/time numFmtIds (ECMA-376 §18.8.30 table)
   const builtinFmt = BUILTIN_DATE_FMT[numFmtId];
   if (builtinFmt) return { text: formatExcelDateCode(num, builtinFmt, date1904) };

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2506,7 +2506,6 @@ function renderQuadrant(
       // centering uses the combined width. Walk right collecting empty
       // centerContinuous neighbours so we know how wide to center over.
       let centerContinuousW = cellW;
-      let centerContinuousX = cx;
       let centerContinuousLastCi = ci;
       if (alignH === 'centerContinuous' && !mergeInfo) {
         for (let oci = ci + 1; oci < numCols; oci++) {
@@ -2521,11 +2520,16 @@ function renderQuadrant(
           centerContinuousLastCi = oci;
         }
       }
+      const centerContinuousX = rc.rtl
+        ? cx - (centerContinuousW - cellW)
+        : cx;
 
-      // Text overflow into adjacent empty cells (ECMA-376 §18.3.1.4 "spans"
-      // — Excel behavior when `wrapText=false`). Left-aligned text flows
-      // rightward, right-aligned flows leftward, and centered splits evenly.
-      // We only extend the clip rect; the text itself is still drawn once.
+      // Text overflow into adjacent empty cells is observed Excel display
+      // behavior when `wrapText=false`; OOXML persists the cell's alignment
+      // and wrapping state but does not specify this paint-time spill rule.
+      // Left-aligned text flows rightward, right-aligned flows leftward, and
+      // centered text splits evenly. We only extend the clip rect; the text
+      // itself is still drawn once.
       // Stops at merge-cell boundaries, non-empty cells, and iconSet-left
       // overrun (since an icon sits inside this cell's left padding).
       let drawX = alignH === 'centerContinuous' ? centerContinuousX : cx;
@@ -2554,18 +2558,23 @@ function renderQuadrant(
           } else {
             extendRight = overflow;
           }
+          // Resolve the logical range to its physical outside neighbours once.
+          // In an RTL sheet (§18.3.1.87), increasing column indices move left,
+          // so the range's physical right edge is `ci` and its physical left
+          // edge is `centerContinuousLastCi`.
+          const physicalRightStep = rc.rtl ? -1 : 1;
+          const physicalRightStartOci = rc.rtl
+            ? ci - 1
+            : centerContinuousLastCi + 1;
+          const physicalLeftStep = rc.rtl ? 1 : -1;
+          const physicalLeftStartOci = rc.rtl
+            ? centerContinuousLastCi + 1
+            : ci - 1;
           if (extendRight > 0) {
             let budget = extendRight;
-            // Column indices increase to the physical right in LTR sheets but
-            // to the physical left in RTL sheets (§18.3.1.87). Overflow is
-            // based on the physical alignment direction, so mirror the walk as
-            // well as the cell geometry. centerContinuous retains its existing
-            // logical-range walk here; its range is authored across columns.
-            const step = rc.rtl && !isCenterCont ? -1 : 1;
-            const startOci = isCenterCont ? centerContinuousLastCi + 1 : ci + step;
-            for (let oci = startOci;
+            for (let oci = physicalRightStartOci;
               oci >= 0 && oci < numCols && budget > 0;
-              oci += step) {
+              oci += physicalRightStep) {
               const adjKey = `${rowIndex}:${colIndices[oci]}`;
               if (mergeSkipSet.has(adjKey) || mergeAnchorMap.has(adjKey)) break;
               const adjCell = cellMap.get(adjKey);
@@ -2576,10 +2585,9 @@ function renderQuadrant(
           }
           if (extendLeft > 0) {
             let budget = extendLeft;
-            const step = rc.rtl ? 1 : -1;
-            for (let oci = ci + step;
+            for (let oci = physicalLeftStartOci;
               oci >= 0 && oci < numCols && budget > 0;
-              oci += step) {
+              oci += physicalLeftStep) {
               const adjKey = `${rowIndex}:${colIndices[oci]}`;
               if (mergeSkipSet.has(adjKey) || mergeAnchorMap.has(adjKey)) break;
               const adjCell = cellMap.get(adjKey);

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -2556,8 +2556,16 @@ function renderQuadrant(
           }
           if (extendRight > 0) {
             let budget = extendRight;
-            const startOci = isCenterCont ? centerContinuousLastCi + 1 : ci + 1;
-            for (let oci = startOci; oci < numCols && budget > 0; oci++) {
+            // Column indices increase to the physical right in LTR sheets but
+            // to the physical left in RTL sheets (§18.3.1.87). Overflow is
+            // based on the physical alignment direction, so mirror the walk as
+            // well as the cell geometry. centerContinuous retains its existing
+            // logical-range walk here; its range is authored across columns.
+            const step = rc.rtl && !isCenterCont ? -1 : 1;
+            const startOci = isCenterCont ? centerContinuousLastCi + 1 : ci + step;
+            for (let oci = startOci;
+              oci >= 0 && oci < numCols && budget > 0;
+              oci += step) {
               const adjKey = `${rowIndex}:${colIndices[oci]}`;
               if (mergeSkipSet.has(adjKey) || mergeAnchorMap.has(adjKey)) break;
               const adjCell = cellMap.get(adjKey);
@@ -2568,7 +2576,10 @@ function renderQuadrant(
           }
           if (extendLeft > 0) {
             let budget = extendLeft;
-            for (let oci = ci - 1; oci >= 0 && budget > 0; oci--) {
+            const step = rc.rtl ? 1 : -1;
+            for (let oci = ci + step;
+              oci >= 0 && oci < numCols && budget > 0;
+              oci += step) {
               const adjKey = `${rowIndex}:${colIndices[oci]}`;
               if (mergeSkipSet.has(adjKey) || mergeAnchorMap.has(adjKey)) break;
               const adjCell = cellMap.get(adjKey);

--- a/packages/xlsx/src/rtl-cell-text-overflow.test.ts
+++ b/packages/xlsx/src/rtl-cell-text-overflow.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { colWidthToPx, getMdwForWorksheet, renderViewport } from './renderer.js';
+import { colWidthToPx, getMdwForWorksheet, HEADER_W, renderViewport } from './renderer.js';
 import type { Styles, Worksheet } from './types.js';
 
 const TEXT = 'ورقة ثانية بالعربية';
+const CENTER_TEXT = TEXT.repeat(2);
 
 const STYLES: Styles = {
   fonts: [{
@@ -22,8 +23,19 @@ const STYLES: Styles = {
     borderId: 0,
     numFmtId: 0,
     alignH: 'right',
+    alignV: null,
+    wrapText: false,
     readingOrder: 2,
-  } as Styles['cellXfs'][number]],
+  }, {
+    fontId: 0,
+    fillId: 0,
+    borderId: 0,
+    numFmtId: 0,
+    alignH: 'centerContinuous',
+    alignV: null,
+    wrapText: false,
+    readingOrder: 2,
+  }],
   numFmts: [],
   dxfs: [],
 };
@@ -64,7 +76,7 @@ function recordingContext(): {
   let lastRect = { x: 0, width: 0 };
   const textClips: Array<{ text: string; x: number; width: number }> = [];
   const state: Record<string, unknown> = {
-    canvas: { width: 240, height: 100 },
+    canvas: { width: 400, height: 100 },
     fillStyle: '#000000',
     strokeStyle: '#000000',
     lineWidth: 1,
@@ -108,5 +120,37 @@ describe('RTL cell text overflow', () => {
     const cellWidth = colWidthToPx(sheet.colWidths[1], getMdwForWorksheet(sheet));
     expect(textDraw).toBeDefined();
     expect(textDraw?.width).toBe(cellWidth * 2);
+  });
+
+  it('centers across the physical RTL range and overflows beyond its left edge', () => {
+    const recording = recordingContext();
+    const sheet = worksheet();
+    sheet.colWidths[3] = 8.43;
+    sheet.rows[0].cells = [{
+      row: 1,
+      col: 1,
+      styleIndex: 1,
+      value: { type: 'text', text: CENTER_TEXT },
+    }, {
+      row: 1,
+      col: 2,
+      styleIndex: 1,
+      value: { type: 'empty' },
+    }];
+
+    renderViewport(
+      recording.ctx,
+      sheet,
+      STYLES,
+      { row: 1, col: 1, rows: 1, cols: 3 },
+    );
+
+    const textDraw = recording.textClips.find((call) => call.text === CENTER_TEXT);
+    const cellWidth = colWidthToPx(sheet.colWidths[1], getMdwForWorksheet(sheet));
+    expect(textDraw).toEqual({
+      text: CENTER_TEXT,
+      x: 400 - HEADER_W - cellWidth * 3,
+      width: cellWidth * 3,
+    });
   });
 });

--- a/packages/xlsx/src/rtl-cell-text-overflow.test.ts
+++ b/packages/xlsx/src/rtl-cell-text-overflow.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { colWidthToPx, getMdwForWorksheet, renderViewport } from './renderer.js';
+import type { Styles, Worksheet } from './types.js';
+
+const TEXT = 'ورقة ثانية بالعربية';
+
+const STYLES: Styles = {
+  fonts: [{
+    bold: false,
+    italic: false,
+    underline: false,
+    strike: false,
+    size: 14,
+    color: null,
+    name: 'Amiri',
+  }],
+  fills: [],
+  borders: [],
+  cellXfs: [{
+    fontId: 0,
+    fillId: 0,
+    borderId: 0,
+    numFmtId: 0,
+    alignH: 'right',
+    readingOrder: 2,
+  } as Styles['cellXfs'][number]],
+  numFmts: [],
+  dxfs: [],
+};
+
+function worksheet(): Worksheet {
+  return {
+    name: 'ورقة٢',
+    rows: [{
+      index: 1,
+      height: null,
+      cells: [{
+        row: 1,
+        col: 1,
+        styleIndex: 0,
+        value: { type: 'text', text: TEXT },
+      }],
+    }],
+    colWidths: { 1: 8.43, 2: 8.43 },
+    rowHeights: {},
+    defaultColWidth: 8.43,
+    defaultRowHeight: 15,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    images: [],
+    charts: [],
+    defaultFontFamily: 'Calibri',
+    defaultFontSize: 11,
+    rightToLeft: true,
+  } as Worksheet;
+}
+
+function recordingContext(): {
+  ctx: CanvasRenderingContext2D;
+  textClips: Array<{ text: string; x: number; width: number }>;
+} {
+  let lastRect = { x: 0, width: 0 };
+  const textClips: Array<{ text: string; x: number; width: number }> = [];
+  const state: Record<string, unknown> = {
+    canvas: { width: 240, height: 100 },
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    lineWidth: 1,
+    font: '14px Amiri',
+    textAlign: 'left',
+    textBaseline: 'alphabetic',
+    direction: 'ltr',
+    globalAlpha: 1,
+    letterSpacing: '0px',
+    measureText: (text: string) => ({ width: [...text].length * 10 }),
+    rect: (x: number, _y: number, width: number) => { lastRect = { x, width }; },
+    fillText: (text: string) => { textClips.push({ text, ...lastRect }); },
+    createLinearGradient: () => ({ addColorStop: () => {} }),
+  };
+  const noOp = () => {};
+  const ctx = new Proxy(state, {
+    get(target, property) {
+      return property in target ? target[property as string] : noOp;
+    },
+    set(target, property, value) {
+      target[property as string] = value;
+      return true;
+    },
+  });
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, textClips };
+}
+
+describe('RTL cell text overflow', () => {
+  it('extends right-aligned A1 text physically left into the empty B1 cell', () => {
+    const recording = recordingContext();
+    const sheet = worksheet();
+
+    renderViewport(
+      recording.ctx,
+      sheet,
+      STYLES,
+      { row: 1, col: 1, rows: 1, cols: 2 },
+    );
+
+    const textDraw = recording.textClips.find((call) => call.text === TEXT);
+    const cellWidth = colWidthToPx(sheet.colWidths[1], getMdwForWorksheet(sheet));
+    expect(textDraw).toBeDefined();
+    expect(textDraw?.width).toBe(cellWidth * 2);
+  });
+});

--- a/packages/xlsx/src/viewer-zoom-contract.test.ts
+++ b/packages/xlsx/src/viewer-zoom-contract.test.ts
@@ -54,6 +54,17 @@ interface Priv {
   canvasArea: { clientWidth: number; clientHeight: number; getBoundingClientRect(): DOMRect };
   scrollHost: FakeScrollHost;
   navPrev: { parentElement: { style: { width: string } } | null };
+  tabBar: { style: { flexDirection: string } };
+  tabStrip: {
+    style: { marginLeft: string; marginRight: string };
+    scrollLeft: number;
+    clientWidth: number;
+    scrollWidth: number;
+  };
+  tabList: { style: { flexDirection: string; minWidth: string; width: string } };
+  tabs: Array<{ offsetLeft: number; offsetWidth: number }>;
+  updateFooterDirection(): void;
+  scrollTabs(direction: -1 | 1): void;
   _pendingZoomAnchor: { x: number; y: number } | null;
 }
 
@@ -148,6 +159,51 @@ describe('XlsxViewer IX9 zoom contract', () => {
     expect(priv.navPrev.parentElement?.style.width).toBe(`${HEADER_W}px`);
     v.setScale(0.5);
     expect(priv.navPrev.parentElement?.style.width).toBe(`${HEADER_W}px`);
+  });
+
+  it('mirrors footer control order for an RTL worksheet', () => {
+    installDom();
+    const rtlSheet = { ...makeSheet(), rightToLeft: true };
+    const { priv } = mount(rtlSheet);
+
+    priv.updateFooterDirection();
+
+    expect(priv.tabBar.style.flexDirection).toBe('row-reverse');
+    expect(priv.tabStrip.style.marginLeft).toBe('0');
+    expect(priv.tabStrip.style.marginRight).toBe('1px');
+    expect(priv.tabList.style.flexDirection).toBe('row-reverse');
+    expect(priv.tabList.style.minWidth).toBe('100%');
+    expect(priv.tabList.style.width).toBe('max-content');
+
+    priv.currentWorksheet = makeSheet();
+    priv.updateFooterDirection();
+
+    expect(priv.tabBar.style.flexDirection).toBe('row');
+    expect(priv.tabStrip.style.marginLeft).toBe('1px');
+    expect(priv.tabStrip.style.marginRight).toBe('0');
+    expect(priv.tabList.style.flexDirection).toBe('row');
+  });
+
+  it('scrolls to the nearest clipped tab by geometry regardless of visual order', () => {
+    installDom();
+    const { priv } = mount(makeSheet());
+    priv.tabStrip.clientWidth = 100;
+    priv.tabStrip.scrollWidth = 200;
+    // Visual RTL order: the first logical tab has the greatest offset.
+    priv.tabs = [
+      { offsetLeft: 150, offsetWidth: 50 },
+      { offsetLeft: 100, offsetWidth: 50 },
+      { offsetLeft: 50, offsetWidth: 50 },
+      { offsetLeft: 0, offsetWidth: 50 },
+    ];
+
+    priv.tabStrip.scrollLeft = 0;
+    priv.scrollTabs(1);
+    expect(priv.tabStrip.scrollLeft).toBe(50);
+
+    priv.tabStrip.scrollLeft = 100;
+    priv.scrollTabs(-1);
+    expect(priv.tabStrip.scrollLeft).toBe(50);
   });
 
   it('zoomIn / zoomOut walk the shared ladder', () => {

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -390,6 +390,9 @@ class XlsxViewerEngine implements ZoomableViewer {
    *  container-mounted workbook viewer; sheet mounts create no footer DOM. */
   private tabBar!: HTMLDivElement;
   private tabStrip!: HTMLDivElement;
+  /** Direction-aware flex row inside the LTR scroll host. Keeping direction on
+   *  this inner row avoids browser-specific negative scrollLeft semantics. */
+  private tabList!: HTMLDivElement;
   private navPrev!: HTMLButtonElement;
   private navNext!: HTMLButtonElement;
   private tabs: HTMLButtonElement[] = [];
@@ -620,14 +623,23 @@ class XlsxViewerEngine implements ZoomableViewer {
       // The scrollable strip that actually holds the sheet tabs. position:relative
       // so each tab's offsetLeft is measured against the strip's scroll content.
       this.tabStrip = document.createElement('div');
-      // margin-left (not padding) keeps the leading gap OUTSIDE the scroll content
-      // so each tab's offsetLeft / scrollLeft math is unaffected and scrolling
-      // still returns to exactly 0.
+      // Keep the scroll host itself LTR so scrollLeft is consistently 0..max in
+      // every browser. The inner tabList owns visual LTR/RTL ordering.
       this.tabStrip.style.cssText =
-        `position:relative;display:flex;align-items:flex-end;flex:1;min-width:0;height:100%;` +
-        `margin-left:${TAB_GAP}px;overflow-x:auto;overflow-y:hidden;gap:${TAB_GAP}px;scrollbar-width:none;`;
+        `position:relative;display:block;flex:1;min-width:0;height:100%;` +
+        `margin-left:${TAB_GAP}px;overflow-x:auto;overflow-y:hidden;scrollbar-width:none;`;
       this.tabStrip.classList.add('xlsx-tab-strip');
       this.tabStrip.addEventListener('scroll', () => this.updateNavButtons());
+
+      // width:max-content preserves overflow scrolling; min-width:100% makes a
+      // short RTL tab row fill the strip so row-reverse can right-align it.
+      this.tabList = document.createElement('div');
+      this.tabList.style.cssText =
+        `display:flex;align-items:flex-end;height:100%;` +
+        `gap:${TAB_GAP}px;box-sizing:border-box;`;
+      this.tabList.style.width = 'max-content';
+      this.tabList.style.minWidth = '100%';
+      this.tabStrip.appendChild(this.tabList);
 
       this.tabBar.appendChild(navGroup);
       this.tabBar.appendChild(this.tabStrip);
@@ -828,6 +840,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
     this.currentSheet = index;
     this.currentWorksheet = worksheet;
+    this.updateFooterDirection();
     this.viewportTop = 0;
     this.selectionController.reset();
     this.hideCommentPopup();
@@ -1319,6 +1332,18 @@ class XlsxViewerEngine implements ZoomableViewer {
   /** True when the current sheet's grid is laid out right-to-left. */
   private get isRtl(): boolean {
     return this.currentWorksheet?.rightToLeft === true;
+  }
+
+  /** Mirror the workbook footer around the sheet-tab strip for an RTL sheet.
+   *  The DOM order remains navigation → tabs → zoom, which is also the
+   *  logical reading order; `row-reverse` places that sequence right-to-left.
+   *  Move the strip's leading gap with it so the spacing stays symmetric. */
+  private updateFooterDirection(): void {
+    if (this._mountKind !== 'composite') return;
+    this.tabBar.style.flexDirection = this.isRtl ? 'row-reverse' : 'row';
+    this.tabStrip.style.marginLeft = this.isRtl ? '0' : `${TAB_GAP}px`;
+    this.tabStrip.style.marginRight = this.isRtl ? `${TAB_GAP}px` : '0';
+    this.tabList.style.flexDirection = this.isRtl ? 'row-reverse' : 'row';
   }
 
   /** Maximum horizontal logical viewport offset (≥ 0). */
@@ -2801,7 +2826,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
   private buildTabs(): void {
     if (this._mountKind === 'sheet') return;
-    this.tabStrip.innerHTML = '';
+    this.tabList.innerHTML = '';
     this.tabs = [];
     this.tabColors = this.workbook.tabColors;
     this.workbook.sheetNames.forEach((name, i) => {
@@ -2810,7 +2835,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       btn.title = name;
       btn.style.cssText = this.tabCss(i, false);
       btn.addEventListener('click', () => this.showSheet(i));
-      this.tabStrip.appendChild(btn);
+      this.tabList.appendChild(btn);
       this.tabs.push(btn);
     });
     this.updateNavButtons();
@@ -2847,28 +2872,27 @@ class XlsxViewerEngine implements ZoomableViewer {
     const viewRight = viewLeft + strip.clientWidth;
     let target: number | null = null;
     if (dir === 1) {
-      // First tab clipped on the right; align its right edge to the viewport.
+      // Nearest tab clipped on the physical right; align its right edge.
+      let nearestRight = Number.POSITIVE_INFINITY;
       for (const tab of this.tabs) {
         const right = tab.offsetLeft + tab.offsetWidth;
-        if (right > viewRight + 1) {
-          target = right - strip.clientWidth;
-          break;
-        }
+        if (right > viewRight + 1) nearestRight = Math.min(nearestRight, right);
       }
+      if (Number.isFinite(nearestRight)) target = nearestRight - strip.clientWidth;
     } else {
-      // Last tab clipped on the left; align its left edge to the viewport.
-      for (let i = this.tabs.length - 1; i >= 0; i--) {
-        const left = this.tabs[i].offsetLeft;
-        if (left < viewLeft - 1) {
-          target = left;
-          break;
-        }
+      // Nearest tab clipped on the physical left; align its left edge. Search
+      // by geometry, not DOM order, because RTL reverses the visual tab row.
+      let nearestLeft = Number.NEGATIVE_INFINITY;
+      for (const tab of this.tabs) {
+        const left = tab.offsetLeft;
+        if (left < viewLeft - 1) nearestLeft = Math.max(nearestLeft, left);
       }
+      if (Number.isFinite(nearestLeft)) target = nearestLeft;
     }
     if (target !== null) {
       // Instant (not smooth) so the disabled state is consistent the moment the
       // click resolves — keeps the interaction deterministic to drive/test.
-      strip.scrollLeft = Math.max(0, target);
+      strip.scrollLeft = Math.max(0, Math.min(target, strip.scrollWidth - strip.clientWidth));
     }
     this.updateNavButtons();
   }
@@ -2906,6 +2930,7 @@ class XlsxViewerEngine implements ZoomableViewer {
         strip.scrollLeft += tabRect.right - stripRect.right;
       }
     }
+    this.updateNavButtons();
   }
 
   private tabStyle(active: boolean, tabColor?: string | null): string {

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -2976,7 +2976,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     return css;
   }
 
-  /** Excel-style zoom control pinned to the right end of the tab bar:
+  /** Excel-style zoom control pinned to the footer's logical end:
    *  `−  [────slider────]  +  100%`. Live-updates the cell scale on input. */
   private buildZoomControl(): HTMLDivElement {
     const zoomMin = this.opts.zoomMin ?? 0.1;


### PR DESCRIPTION
## Summary
- localize built-in short-date format ID 14 from the browser UI locale while preserving UTC serial conversion
- let right-aligned text on RTL worksheets overflow physically left into adjacent empty cells
- mirror RTL workbook footer groups so tab navigation is rightmost, sheet tabs are right-aligned in reverse visual order, and zoom is leftmost

## Specification basis
- ECMA-376 Part 1 section 18.8.30: implied built-in formats may vary with the implementing application's UI language
- ECMA-376 Part 1 section 18.3.1.87: worksheet right-to-left display order

## Verification
- 697 XLSX unit tests
- repository typecheck
- XLSX production build
- previous-renderer private-corpus VRT: all unaffected documents/items pixel-identical; the sole changed canvas region is the corrected RTL text overflow
- interactive Storybook verification for localized date output, RTL text overflow, tab order/alignment, and footer group ordering