### PR TITLE
feat(xlsx): add reusable sheet viewer windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ pnpm add @silurus/ooxml
 
 ```typescript
 import { DocxViewer } from '@silurus/ooxml/docx';
-import { XlsxSheetViewer, XlsxViewer } from '@silurus/ooxml/xlsx';
+import { XlsxSheetViewer, XlsxViewer, XlsxWorkbook } from '@silurus/ooxml/xlsx';
 import { PptxViewer } from '@silurus/ooxml/pptx';
 
 // DOCX — caller provides the <canvas>
-const canvas = document.getElementById('docx-canvas') as HTMLCanvasElement;
-const docx = new DocxViewer(canvas);
+const docxCanvas = document.getElementById('docx-canvas') as HTMLCanvasElement;
+const docx = new DocxViewer(docxCanvas);
 await docx.load('/document.docx');
 docx.nextPage();
 
@@ -99,9 +99,26 @@ const sheet = new XlsxSheetViewer(sheetCanvas);
 await sheet.load('/workbook.xlsx');
 await sheet.goToSheet(1);
 
+// Share one parsed workbook across independently scrollable sheet canvases,
+// including canvases created in same-origin popup windows.
+const workbook = await XlsxWorkbook.load('/workbook.xlsx');
+const firstCanvas = document.getElementById('xlsx-first-canvas') as HTMLCanvasElement;
+const secondCanvas = document.getElementById('xlsx-second-canvas') as HTMLCanvasElement;
+const firstSheet = new XlsxSheetViewer(firstCanvas, { workbook });
+const secondSheet = new XlsxSheetViewer(secondCanvas, { workbook });
+await Promise.all([
+  firstSheet.goToSheet(0),
+  secondSheet.goToSheet(1),
+]);
+
+// Each viewer borrows the workbook; the caller closes it after the viewers.
+firstSheet.destroy();
+secondSheet.destroy();
+workbook.destroy();
+
 // PPTX — caller provides the <canvas>
-const canvas = document.getElementById('pptx-canvas') as HTMLCanvasElement;
-const pptx = new PptxViewer(canvas);
+const pptxCanvas = document.getElementById('pptx-canvas') as HTMLCanvasElement;
+const pptx = new PptxViewer(pptxCanvas);
 await pptx.load('/deck.pptx');
 pptx.nextSlide();
 ```
@@ -261,7 +278,8 @@ Pass `enableHyperlinks: false` to disable hyperlink interactivity entirely — n
 hit-testing, no pointer cursor over links, no default navigation, and
 `onHyperlinkClick` is never called; links still render as authored but are inert.
 This applies to every viewer that supports hyperlinks (`DocxViewer`,
-`DocxScrollViewer`, `PptxViewer`, `PptxScrollViewer`, `XlsxViewer`).
+`DocxScrollViewer`, `PptxViewer`, `PptxScrollViewer`, `XlsxViewer`,
+`XlsxSheetViewer`).
 
 **Master–detail / shared engine.** Inject an already-loaded headless engine so a
 paged viewer and a scroll viewer (or several panes) share **one** parse. When you
@@ -270,17 +288,20 @@ inject, `load()` is unsupported (the engine is already loaded), the engine's own
 its lifecycle:
 
 ```typescript
-import { DocxDocument, DocxScrollViewer } from '@silurus/ooxml/docx';
+import { DocxDocument, DocxScrollViewer, DocxViewer } from '@silurus/ooxml/docx';
 
 const doc = await DocxDocument.load('/document.docx'); // parse once
 const scroll = new DocxScrollViewer(container, { document: doc });
-// ...also drive a thumbnail grid, a paged view, etc. from the same `doc`.
+const page = new DocxViewer(canvas, { document: doc });
+await page.goToPage(0);
+// ...also drive a thumbnail grid or more panes from the same `doc`.
+page.destroy();
 scroll.destroy(); // the injected `doc` is NOT destroyed — you own it
 doc.destroy();    // release it yourself when every pane is gone
 ```
 
-`PptxScrollViewer` takes the same shape with `{ presentation: pres }`
-(`await PptxPresentation.load(...)`).
+`PptxViewer` and `PptxScrollViewer` take the same shape with
+`{ presentation: pres }` (`await PptxPresentation.load(...)`).
 
 For presentations, `enableMediaPlayback: true` makes embedded audio and video
 interactive inside the real viewport plus `mediaOverscan` slides. Other mounted
@@ -790,7 +811,7 @@ await viewer.load(file);
   The package counters and raster-image guards are deterministic admission limits, not exact JavaScript/WASM process-memory accounting. XML trees, document models, canvas backing stores, browser decoder overhead, renderer state, and browser-managed SVG/vector parse or decoded storage can still require several times the measured input. SVG has no portable decoded-byte measure or explicit browser release primitive; the library count-bounds its cache and revokes owned object URLs, but cannot charge it as RGBA bytes. The defaults therefore reduce risk but cannot promise that an OOM is impossible on every device. Running parse and render work in `mode: 'worker'` can contain many failures away from the main UI thread, but a Worker is not a separate operating-system process or a strict memory sandbox.
 
   A measured limit crossing is reported as `OoxmlResourceLimitError`. A residual WASM failure that reaches a recognized trap-shaped boundary is reported conservatively as `parser-crashed`, not `parser-oom`: with the current aborting Rust/WASM boundary, panic, allocation failure, explicit `unreachable`, and stack overflow can lose their distinct causes and converge on the same generic runtime error. Inferring OOM from an exception class or message would misclassify some parser defects as large-file failures. Reliable OOM classification would require preserving a structured cause before the trap across every relevant allocation path; it cannot be recovered from the generic trap afterward. The WebAssembly JavaScript embedding also permits implementation-defined stack/OOM failures, including an indistinguishable plain `Error` or process termination, so converting and poisoning every engine-level failure cannot be guaranteed.
-- **No network by default.** The library does not send telemetry or analytics, and does not contact third-party services unless you ask it to. In particular, theme webfonts, Office font metric substitutes (Carlito/Caladea), and the script fallback fonts are **not** loaded from Google Fonts unless you pass `useGoogleFonts: true` to the relevant `Viewer` / `load(...)` options — supported uniformly by `DocxViewer`, `PptxViewer`, and `XlsxViewer`. When enabled, fonts for non-Latin scripts are supplied on demand from Noto families so text does not fall back to tofu: Arabic (Noto Naskh/Sans Arabic), CJK (Noto Sans/Serif KR · SC · TC · JP, picked per document language so shared Han glyphs take the right shapes), Cyrillic (Noto Sans/Serif), Hebrew (Noto Sans/Serif Hebrew, RTL), Thai (Noto Sans Thai) and Devanagari (Noto Sans Devanagari). No font binaries ship in the bundle. Enabling this option causes the end-user's browser to send an HTTP request (IP and User-Agent) to `fonts.googleapis.com`, which may have GDPR implications for your application — consider self-hosting the required fonts via `@font-face` instead.
+- **No network by default.** The library does not send telemetry or analytics, and does not contact third-party services unless you ask it to. In particular, theme webfonts, Office font metric substitutes (Carlito/Caladea), and the script fallback fonts are **not** loaded from Google Fonts unless you pass `useGoogleFonts: true` to the relevant `Viewer` / `load(...)` options — supported uniformly by `DocxViewer`, `PptxViewer`, `XlsxViewer`, and `XlsxSheetViewer`. When enabled, fonts for non-Latin scripts are supplied on demand from Noto families so text does not fall back to tofu: Arabic (Noto Naskh/Sans Arabic), CJK (Noto Sans/Serif KR · SC · TC · JP, picked per document language so shared Han glyphs take the right shapes), Cyrillic (Noto Sans/Serif), Hebrew (Noto Sans/Serif Hebrew, RTL), Thai (Noto Sans Thai) and Devanagari (Noto Sans Devanagari). No font binaries ship in the bundle. Enabling this option causes the end-user's browser to send an HTTP request (IP and User-Agent) to `fonts.googleapis.com`, which may have GDPR implications for your application — consider self-hosting the required fonts via `@font-face` instead.
 - **XML parsing.** Uses `roxmltree`, which does not resolve external entities (XXE-safe by default).
 - **Encrypted OOXML ([MS-OFFCRYPTO] Agile Encryption).** Password-protected `.docx` / `.xlsx` / `.pptx` files are OLE2/CFB containers, not ZIPs. Pass `password` to `load(...)` and the file is decrypted **client-side** via WebCrypto — no bytes and no password leave the browser:
   ```ts

--- a/docs/api-architecture-0.76.ja.md
+++ b/docs/api-architecture-0.76.ja.md
@@ -128,11 +128,21 @@ sheet描画・interactionとcontainer chromeが1つの大きなclassに結合し
 既存の公開名は維持する。`XlsxScrollViewer` aliasは追加しない。Container componentは
 whole sheetの一覧ではなく、sheet tabとscrollable cell gridを持つWorkbook Viewerだからである。
 
+すべてのCanvasマウント型unit viewerは、対応するload済みengine（`document`、
+`presentation`、`workbook`）を受け取れる。Containerマウント型Viewerも同じoptionを持つ。
+6つすべてで、注入されたengineがrender modeとlifecycleを所有する。明示的に競合する
+`mode`は拒否し、`load()`は利用不可、Viewerの破棄では借用engineを破棄しない。
+
 ### XLSX Canvas Viewerのcontract
 
 `XlsxSheetViewer`は、1つのactive worksheet viewportをCanvasへマウントして表示する。
 sheet tab/footer chromeとscrollbarは所有しない。worksheetは有限pageではないため、
 形式固有のviewport移動を追加で公開する。この状態をDOCX/PPTXへ無理に持ち込まない。
+
+mount用DOM、style、DPR参照、document listenerは`canvas.ownerDocument`とその
+`defaultView`を基準に解決する。これにより親画面が1つの`XlsxWorkbook`を保持したまま、
+同一originの別WindowにあるCanvasへ借用Sheet Viewerをマウントでき、packageの再parseは
+発生しない。
 
 実装前に、次のcontractを中心に公開declarationを確定する。
 
@@ -149,6 +159,8 @@ export interface XlsxScrollToCellOptions {
 }
 
 export interface XlsxSheetViewerOptions extends LoadOptions {
+  /** load済みengineを借用する。lifecycleはcallerが所有する。 */
+  readonly workbook?: XlsxWorkbook;
   readonly cellScale?: number;
   readonly resizable?: boolean;
   readonly zoomMin?: number;
@@ -206,6 +218,12 @@ export interface XlsxViewerOptions extends XlsxSheetViewerOptions {
   readonly showZoomSlider?: boolean;
 }
 ```
+
+`workbook`は、DOCX Viewerの`document`、PPTX Viewerの`presentation`と同じ
+option注入contractに従う。`load()`は利用不可、engine自身のrender modeを正とし、Viewerの破棄では
+caller-owned engineを破棄しない。初回描画の完了点が必要なcallerは`goToSheet(index)`をawaitする。
+複数のsheet viewerはparse、archive access、worksheet materialization、immutable content cacheを
+共有しながら、viewport、selection、zoom、resize、outline、render generationを独立して保持する。
 
 Offsetは現在scaleにおけるlogical CSS pixelとする。`x`はBrowserのRTL `scrollLeft`
 規則に依存せず、column A側のlogical startから後続column方向へ増加し、`y`は下方向へ

--- a/docs/api-architecture-0.76.md
+++ b/docs/api-architecture-0.76.md
@@ -145,12 +145,23 @@ The existing public names remain stable. We do not add an `XlsxScrollViewer`
 alias: the container component is a workbook viewer with sheet tabs and a
 scrollable cell grid, not a list of whole sheets.
 
+Every canvas-mounted unit viewer accepts its corresponding already-loaded
+engine (`document`, `presentation`, or `workbook`). Every container-mounted
+viewer accepts the same option. In all six cases the injected engine owns its
+render mode and lifecycle: a conflicting explicit `mode` is rejected, `load()`
+is unavailable, and viewer teardown does not destroy the borrowed engine.
+
 ### XLSX canvas-viewer contract
 
 `XlsxSheetViewer` is a canvas-mounted view of one active worksheet viewport. It
 owns no sheet-tab/footer chrome and creates no scrollbar. Because a worksheet is
 not a finite page, it additionally exposes format-specific viewport movement.
 That extra state is not forced onto DOCX or PPTX.
+
+All mount DOM, styles, DPR reads, and document listeners resolve from
+`canvas.ownerDocument` and its `defaultView`. A parent page can therefore retain
+one `XlsxWorkbook` and mount borrowed sheet viewers into same-origin popup
+canvases without reparsing the package.
 
 The public declaration is frozen before implementation around this contract:
 
@@ -167,6 +178,8 @@ export interface XlsxScrollToCellOptions {
 }
 
 export interface XlsxSheetViewerOptions extends LoadOptions {
+  /** Borrow one loaded engine; the caller retains its lifecycle. */
+  readonly workbook?: XlsxWorkbook;
   readonly cellScale?: number;
   readonly resizable?: boolean;
   readonly zoomMin?: number;
@@ -224,6 +237,15 @@ export interface XlsxViewerOptions extends XlsxSheetViewerOptions {
   readonly showZoomSlider?: boolean;
 }
 ```
+
+`workbook` follows the same option-injection contract as `document` on the DOCX
+viewers and `presentation` on the PPTX viewers. `load()` is
+unsupported, the engine's render mode is authoritative, and viewer teardown
+does not destroy the caller-owned engine. Callers await `goToSheet(index)` when
+they need deterministic first-paint completion. Multiple sheet viewers share
+parsing, archive access, worksheet materialization, and immutable content caches
+while retaining independent viewport, selection, zoom, resize, outline, and
+render-generation state.
 
 Offsets are logical CSS pixels at the current scale: `x` increases from the
 logical sheet start (column A, independent of browser RTL `scrollLeft`

--- a/packages/core/src/fonts/font-registry.test.ts
+++ b/packages/core/src/fonts/font-registry.test.ts
@@ -80,6 +80,20 @@ describe('retainFace', () => {
     expect(rb.face).not.toBe(ra.face);
     expect(facesB).toHaveLength(1);
   });
+
+  it('keeps same-signature registrations independent across document sets', () => {
+    const { set: setA, faces: facesA } = makeSet();
+    const { set: setB, faces: facesB } = makeSet();
+    const faceA = retainFace('sig-a', setA, creator(setA, 'A').create).face;
+    const faceB = retainFace('sig-a', setB, creator(setB, 'A').create).face;
+
+    releaseFaces([faceB]);
+    expect(facesB).toHaveLength(0);
+    expect(facesA).toEqual([faceA as unknown as FakeFace]);
+
+    releaseFaces([faceA]);
+    expect(facesA).toHaveLength(0);
+  });
 });
 
 describe('releaseFaces', () => {

--- a/packages/core/src/fonts/font-registry.ts
+++ b/packages/core/src/fonts/font-registry.ts
@@ -2,13 +2,11 @@
  * Refcounted FontFace registry shared by the embedded-font loader
  * ({@link ./embedded.ts}) and the Google-Fonts preloader ({@link ./preload.ts}).
  *
- * `document.fonts` (the FontFaceSet) is a process-global singleton, so opening
- * the same font in two documents — or the same document twice in an SPA — would
- * otherwise add a second, byte- (or url-) identical `FontFace` every time and
- * leak them all (nothing ever removes them). Both loaders share this dedup +
- * refcount so a face is added to the set once, shared by every holder, and
- * removed from the set only when the LAST holder releases it (e.g. from every
- * open document's `destroy()`).
+ * Each DOM/worker realm owns a FontFaceSet. Opening the same font repeatedly in
+ * one set would otherwise add duplicate faces and leak them; same-origin child
+ * windows additionally require their own registrations. Both loaders share
+ * this per-set dedup + refcount so a face is added once to each target set and
+ * removed only when that set's last holder releases it.
  *
  * The registry is deliberately format-agnostic: callers own how they compute a
  * face's signature (embedded fonts hash the de-obfuscated bytes; Google Fonts
@@ -28,10 +26,10 @@ interface FontRegistration {
   refs: number;
 }
 
-/** signature → the single shared registration. Module-global to mirror the
- *  process-global FontFaceSet: two callers computing the same signature in the
- *  same set share one `FontFace`. */
-const registry = new Map<string, FontRegistration>();
+/** Signature → registrations keyed by FontFaceSet. A same-origin popup owns a
+ * distinct set even though it shares the opener's JavaScript module instance,
+ * so the set identity is part of the registration key. */
+const registry = new Map<string, Map<FontFaceSet, FontRegistration>>();
 
 /** Test hook — clears the shared refcount registry (does NOT touch any
  *  FontFaceSet; tests install a fresh fake set per case). */
@@ -69,13 +67,16 @@ export interface RetainResult {
  * return the face. It runs ONLY on the first-holder path.
  */
 export function retainFace(sig: string, set: FontFaceSet, create: () => FontFace): RetainResult {
-  const existing = registry.get(sig);
-  if (existing && existing.set === set) {
+  const registrations = registry.get(sig);
+  const existing = registrations?.get(set);
+  if (existing) {
     existing.refs++;
     return { face: existing.face, isNew: false };
   }
   const face = create();
-  registry.set(sig, { face, set, refs: 1 });
+  const bySet = registrations ?? new Map<FontFaceSet, FontRegistration>();
+  bySet.set(set, { face, set, refs: 1 });
+  registry.set(sig, bySet);
   return { face, isNew: true };
 }
 
@@ -110,18 +111,24 @@ export function releaseFaces(faces: Iterable<FontFace>): void {
     // small (one entry per distinct face), so a linear scan is fine. A face that
     // was already fully released has no entry → this loop finds nothing and the
     // release is a no-op (cross-call idempotency).
-    for (const [sig, reg] of registry) {
-      if (reg.face !== face) continue;
-      reg.refs--;
-      if (reg.refs <= 0) {
-        try {
-          reg.set.delete(face);
-        } catch {
-          /* a set without delete() (older shim / mock): drop the entry anyway */
+    for (const [sig, registrations] of registry) {
+      let matched = false;
+      for (const [set, reg] of registrations) {
+        if (reg.face !== face) continue;
+        matched = true;
+        reg.refs--;
+        if (reg.refs <= 0) {
+          try {
+            reg.set.delete(face);
+          } catch {
+            /* a set without delete() (older shim / mock): drop the entry anyway */
+          }
+          registrations.delete(set);
+          if (registrations.size === 0) registry.delete(sig);
         }
-        registry.delete(sig);
+        break;
       }
-      break;
+      if (matched) break;
     }
   }
 }

--- a/packages/core/src/fonts/preload.test.ts
+++ b/packages/core/src/fonts/preload.test.ts
@@ -118,6 +118,32 @@ describe('preloadGoogleFonts', () => {
     expect(added).toHaveLength(2);
   });
 
+  it('registers faces in an explicitly selected popup FontFaceSet', async () => {
+    const { set: openerSet, added: openerFaces } = installFakes();
+    const popupFaces: FakeFace[] = [];
+    const popupSet = {
+      add: (face: FakeFace) => popupFaces.push(face),
+      delete: (face: FakeFace) => {
+        const index = popupFaces.indexOf(face);
+        if (index >= 0) popupFaces.splice(index, 1);
+        return index >= 0;
+      },
+      ready: Promise.resolve(),
+    } as unknown as FontFaceSet;
+    G.document = { fonts: openerSet };
+
+    const openerHeld = await preloadGoogleFonts(['Calibri'], MAP);
+    const popupHeld = await preloadGoogleFonts(['Calibri'], MAP, popupSet);
+    expect(openerFaces).toHaveLength(2);
+    expect(popupFaces).toHaveLength(2);
+    expect(popupHeld[0]).not.toBe(openerHeld[0]);
+
+    unloadGoogleFonts(popupHeld);
+    expect(popupFaces).toHaveLength(0);
+    expect(openerFaces).toHaveLength(2);
+    unloadGoogleFonts(openerHeld);
+  });
+
   it('no-ops (returns []) without any FontFaceSet', async () => {
     delete G.document;
     delete G.self;

--- a/packages/core/src/fonts/preload.ts
+++ b/packages/core/src/fonts/preload.ts
@@ -63,8 +63,8 @@ export function withFontCeiling<T>(p: Promise<T>): Promise<T | void> {
  *  the same url JOINs the first fetch instead of re-downloading, and the join
  *  cannot resolve before the fetch settles (first-paint determinism). The actual
  *  `FontFace` objects are dedup + refcounted separately per call in the shared
- *  {@link ./font-registry.ts} (so two documents using the same web font share
- *  one FontFace, and it leaves the set only when both release it). The stored
+ *  {@link ./font-registry.ts} (so holders in one FontFaceSet share one face;
+ *  another document set receives its own face). The stored
  *  promise ALWAYS resolves: a failed fetch records the failed families + deletes
  *  the entry (so a later call retries) inside the producing call, so a cache-hit
  *  awaiter never throws. */
@@ -124,8 +124,8 @@ export function activeFontSet(): FontFaceSet | null {
 /** Stable signature for one Google-Fonts `@font-face`, keyed to the CSS url it
  *  came from + its identity (family + all CSS descriptors). `gfonts:` namespaces
  *  it away from embedded-font signatures in the shared registry. Two documents
- *  requesting the same web font compute the SAME signature and so share one
- *  refcounted FontFace; distinct subsets (latin vs latin-ext, different weights)
+ *  requesting the same web font compute the SAME signature and, within one
+ *  FontFaceSet, share one refcounted FontFace; distinct subsets
  *  key distinctly. */
 function googleFaceSignature(url: string, f: ParsedFontFace): string {
   const d = f.descriptors;
@@ -146,8 +146,9 @@ function googleFaceSignature(url: string, f: ParsedFontFace): string {
 export async function preloadGoogleFonts(
   fontNames: Iterable<string | null | undefined>,
   map: Record<string, FontPreloadEntry>,
+  targetFontSet: FontFaceSet | null = activeFontSet(),
 ): Promise<FontFace[]> {
-  const fonts = activeFontSet();
+  const fonts = targetFontSet;
   if (!fonts || typeof FontFace === 'undefined' || typeof fetch === 'undefined') return [];
 
   const seen = new Set<string>();
@@ -186,8 +187,8 @@ export async function preloadGoogleFonts(
 
   // 1) Fetch each stylesheet once per JS context (network dedup via cssFetches)
   //    and PARSE its `@font-face` rules. The rules are shared data; the FontFace
-  //    objects are created + refcounted per call in step 2 so two open documents
-  //    share one face and it leaves the set only when both release it.
+  //    objects are created + refcounted per call in step 2 so holders targeting
+  //    the same set share one face and it leaves only after all release it.
   const parsedGroups = await withFontCeiling(
     Promise.all(
       [...cssUrls].map(async (url): Promise<{ url: string; rules: ParsedFontFace[] }> => {
@@ -274,7 +275,7 @@ export async function preloadGoogleFonts(
  * preloaded (the array returned by {@link preloadGoogleFonts}). Refcounted +
  * dedup-safe via the shared {@link ./font-registry.ts}: each face is removed
  * from its FontFaceSet only when the LAST holder releases it, so a web font used
- * by two open documents survives until both are destroyed. Double-release safe
+ * by two holders in the same document survives until both are destroyed. Double-release safe
  * (a face passed twice, or a re-release after full release, is a no-op) and safe
  * in a context without a FontFaceSet. Twin of `unregisterEmbeddedFonts`; called
  * from each viewer's `destroy()` to fix the SPA leak where every opened document

--- a/packages/core/src/internal/canvas-viewer-mechanics.test.ts
+++ b/packages/core/src/internal/canvas-viewer-mechanics.test.ts
@@ -1,11 +1,28 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   CanvasViewerErrorRouter,
+  resolveCanvasViewerMode,
   StaticCanvasRenderDispatcher,
   TerminalResourceOwner,
 } from './canvas-viewer-mechanics.js';
 
 afterEach(() => vi.restoreAllMocks());
+
+describe('resolveCanvasViewerMode', () => {
+  it('uses the injected engine mode and rejects only an explicit conflict', () => {
+    const engine = { mode: 'worker' as const };
+    expect(resolveCanvasViewerMode('Viewer', undefined, engine)).toBe('worker');
+    expect(resolveCanvasViewerMode('Viewer', 'worker', engine)).toBe('worker');
+    expect(() => resolveCanvasViewerMode('Viewer', 'main', engine)).toThrow(
+      "Viewer: opts.mode='main' conflicts with the injected engine's mode='worker'",
+    );
+  });
+
+  it('defaults a self-loading viewer to main mode', () => {
+    expect(resolveCanvasViewerMode('Viewer', undefined, undefined)).toBe('main');
+    expect(resolveCanvasViewerMode('Viewer', 'worker', undefined)).toBe('worker');
+  });
+});
 
 describe('StaticCanvasRenderDispatcher', () => {
   it('acquires the bitmap context once and avoids redundant backing-store resets', () => {

--- a/packages/core/src/internal/canvas-viewer-mechanics.ts
+++ b/packages/core/src/internal/canvas-viewer-mechanics.ts
@@ -37,7 +37,8 @@ export class CallerCanvasMount {
     this.originalWidth = canvas.width;
     this.originalHeight = canvas.height;
 
-    this.wrapper = document.createElement('div');
+    const ownerDocument = canvas.ownerDocument ?? document;
+    this.wrapper = ownerDocument.createElement('div');
     this.wrapper.style.cssText = options.wrapperCssText;
     if (options.forceDisplayBlock && !canvas.style.display) canvas.style.display = 'block';
     if (this.originalParent) this.originalParent.insertBefore(this.wrapper, canvas);
@@ -83,12 +84,13 @@ export class CanvasOverlayHost {
   readonly highlightLayer: HTMLDivElement;
 
   constructor(wrapper: HTMLElement, enableTextSelection: boolean) {
-    this.textLayer = enableTextSelection ? document.createElement('div') : null;
+    const ownerDocument = wrapper.ownerDocument ?? document;
+    this.textLayer = enableTextSelection ? ownerDocument.createElement('div') : null;
     if (this.textLayer) {
       this.textLayer.style.cssText = TEXT_LAYER_STYLE;
       wrapper.appendChild(this.textLayer);
     }
-    this.highlightLayer = document.createElement('div');
+    this.highlightLayer = ownerDocument.createElement('div');
     this.highlightLayer.style.cssText = HIGHLIGHT_LAYER_STYLE;
     wrapper.appendChild(this.highlightLayer);
   }
@@ -101,6 +103,24 @@ export interface BitmapCommitSize {
 
 export interface DestroyableResource {
   destroy(): void;
+}
+
+export type CanvasViewerRenderMode = 'main' | 'worker';
+
+/** Resolve the mode of a viewer that may borrow an already-loaded engine. */
+export function resolveCanvasViewerMode(
+  viewerName: string,
+  requestedMode: CanvasViewerRenderMode | undefined,
+  engine: Readonly<{ mode: CanvasViewerRenderMode }> | undefined,
+): CanvasViewerRenderMode {
+  if (engine && requestedMode !== undefined && requestedMode !== engine.mode) {
+    throw new Error(
+      `${viewerName}: opts.mode='${requestedMode}' conflicts with the injected engine's ` +
+        `mode='${engine.mode}'. Omit opts.mode when injecting an engine — ` +
+        'the engine owns its render mode.',
+    );
+  }
+  return engine?.mode ?? requestedMode ?? 'main';
 }
 
 /**

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -3,18 +3,18 @@
 // Do not edit by hand.
 
 // --- file: docx.d.ts ---
-export declare interface AnchorHostMetrics {
+export interface AnchorHostMetrics {
     fontSize: number;
     fontFamily?: string | null;
     fontFamilyEastAsia?: string | null;
     bold?: boolean;
     italic?: boolean;
 }
-export declare function autoResize(render: (width: number, height: number) => void | Promise<void>, element: Element, opts?: AutoResizeOptions): () => void;
-export declare interface AutoResizeOptions {
+export function autoResize(render: (width: number, height: number) => void | Promise<void>, element: Element, opts?: AutoResizeOptions): () => void;
+export interface AutoResizeOptions {
     pauseWhenHidden?: boolean;
 }
-export declare type BodyElement = ({
+export type BodyElement = ({
     type: 'paragraph';
 } & DocParagraph) | ({
     type: 'table';
@@ -35,14 +35,14 @@ export declare type BodyElement = ({
     pageNumType?: PageNumType | null;
     textDirection?: string | null;
 };
-export declare interface BorderSpec {
+export interface BorderSpec {
     width: number;
     color: string | null;
     style: string;
 }
-export declare function buildDocxHighlightLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[], matches: DocxHighlightMatch[], cssWidth: number, cssHeight: number, measureForFont: (font: string) => (s: string) => number, colors?: DocxHighlightColors): void;
-export declare function buildDocxTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[], cssWidth: number, cssHeight: number, onHyperlinkClick?: (target: HyperlinkTarget) => void, measureForFont?: (font: string) => (s: string) => number): void;
-export declare interface CellBorders {
+export function buildDocxHighlightLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[], matches: DocxHighlightMatch[], cssWidth: number, cssHeight: number, measureForFont: (font: string) => (s: string) => number, colors?: DocxHighlightColors): void;
+export function buildDocxTextLayer(layer: HTMLDivElement, runs: DocxTextRunInfo[], cssWidth: number, cssHeight: number, onHyperlinkClick?: (target: HyperlinkTarget) => void, measureForFont?: (font: string) => (s: string) => number): void;
+export interface CellBorders {
     top: BorderSpec | null;
     bottom: BorderSpec | null;
     left: BorderSpec | null;
@@ -50,12 +50,12 @@ export declare interface CellBorders {
     insideH: BorderSpec | null;
     insideV: BorderSpec | null;
 }
-export declare type CellElement = ({
+export type CellElement = ({
     type: 'paragraph';
 } & DocParagraph) | ({
     type: 'table';
 } & DocTable);
-declare interface ChartDataLabelOverride {
+interface ChartDataLabelOverride {
     idx: number;
     text: string;
     position?: string;
@@ -69,7 +69,7 @@ declare interface ChartDataLabelOverride {
     showPercent?: boolean;
     deleted?: boolean;
 }
-declare interface ChartDataPointOverride {
+interface ChartDataPointOverride {
     idx: number;
     color?: string;
     markerSymbol?: string;
@@ -78,7 +78,7 @@ declare interface ChartDataPointOverride {
     markerLine?: string;
     explosion?: number;
 }
-declare interface ChartErrBars {
+interface ChartErrBars {
     dir: string;
     barType: string;
     plus: (number | null)[];
@@ -88,7 +88,7 @@ declare interface ChartErrBars {
     lineWidthEmu?: number;
     dash?: string;
 }
-declare interface ChartexBoxSeries {
+interface ChartexBoxSeries {
     name: string;
     color?: string | null;
     valuesByCategory: number[][];
@@ -98,23 +98,23 @@ declare interface ChartexBoxSeries {
     showNonoutliers: boolean;
     quartileMethod: string;
 }
-declare interface ChartexBoxWhisker {
+interface ChartexBoxWhisker {
     categories: string[];
     series: ChartexBoxSeries[];
 }
-declare interface ChartexSunburst {
+interface ChartexSunburst {
     rows: ChartexSunburstRow[];
 }
-declare interface ChartexSunburstRow {
+interface ChartexSunburstRow {
     path: string[];
     size: number;
 }
-declare interface ChartLabelBox {
+interface ChartLabelBox {
     fill?: string;
     borderColor?: string;
     borderWidthEmu?: number;
 }
-declare interface ChartManualLayout {
+interface ChartManualLayout {
     xMode: string;
     yMode: string;
     layoutTarget?: string;
@@ -123,7 +123,7 @@ declare interface ChartManualLayout {
     w?: number;
     h?: number;
 }
-declare interface ChartModel {
+interface ChartModel {
     chartType: ChartType;
     title: string | null;
     categories: string[];
@@ -227,7 +227,7 @@ declare interface ChartModel {
     chartexSunburst?: ChartexSunburst | null;
     chartexAccents?: string[] | null;
 }
-export declare interface ChartRun {
+export interface ChartRun {
     chart: ChartModel;
     widthPt: number;
     heightPt: number;
@@ -248,7 +248,7 @@ export declare interface ChartRun {
     anchorXRelativeFrom?: string | null;
     anchorYRelativeFrom?: string | null;
 }
-declare interface ChartSeries {
+interface ChartSeries {
     name: string;
     color: string | null;
     values: (number | null)[];
@@ -273,7 +273,7 @@ declare interface ChartSeries {
     trendLines?: ChartTrendline[] | null;
     lineHidden?: boolean | null;
 }
-declare interface ChartSeriesDataLabels {
+interface ChartSeriesDataLabels {
     showVal: boolean;
     showCatName: boolean;
     showSerName: boolean;
@@ -288,7 +288,7 @@ declare interface ChartSeriesDataLabels {
     leaderLineColor?: string;
     leaderLineWidthEmu?: number;
 }
-declare interface ChartTrendline {
+interface ChartTrendline {
     trendlineType: string;
     order?: number | null;
     period?: number | null;
@@ -300,30 +300,30 @@ declare interface ChartTrendline {
     lineColor?: string | null;
     lineWidthEmu?: number | null;
 }
-declare type ChartType = 'line' | 'stackedLine' | 'stackedLinePct' | 'clusteredBar' | 'clusteredBarH' | 'stackedBar' | 'stackedBarH' | 'stackedBarPct' | 'stackedBarHPct' | 'area' | 'stackedArea' | 'stackedAreaPct' | 'pie' | 'doughnut' | 'scatter' | 'bubble' | 'radar' | 'waterfall' | 'stock' | 'boxWhisker' | 'sunburst' | string;
-export declare interface ColSpec {
+type ChartType = 'line' | 'stackedLine' | 'stackedLinePct' | 'clusteredBar' | 'clusteredBarH' | 'stackedBar' | 'stackedBarH' | 'stackedBarPct' | 'stackedBarHPct' | 'area' | 'stackedArea' | 'stackedAreaPct' | 'pie' | 'doughnut' | 'scatter' | 'bubble' | 'radar' | 'waterfall' | 'stock' | 'boxWhisker' | 'sunburst' | string;
+export interface ColSpec {
     widthPt: number;
     spacePt: number;
 }
-export declare interface ColumnsSpec {
+export interface ColumnsSpec {
     count: number;
     spacePt: number;
     equalWidth: boolean;
     sep: boolean;
     cols: ColSpec[];
 }
-export declare interface DocComment {
+export interface DocComment {
     id: string;
     author?: string;
     initials?: string;
     date?: string;
     text: string;
 }
-export declare interface DocNote {
+export interface DocNote {
     id: string;
     content: BodyElement[];
 }
-export declare interface DocParagraph {
+export interface DocParagraph {
     paragraphId?: string;
     alignment: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | 'both' | 'distribute' | 'lowKashida' | 'mediumKashida' | 'highKashida' | 'thaiDistribute' | string;
     indentLeft: number;
@@ -354,13 +354,13 @@ export declare interface DocParagraph {
     snapToGrid?: boolean;
     framePr?: FramePr;
 }
-export declare interface DocRevision {
+export interface DocRevision {
     kind: 'insertion' | 'deletion' | string;
     author?: string;
     date?: string;
     text: string;
 }
-export declare type DocRun = ({
+export type DocRun = ({
     type: 'text';
 } & DocxTextRun) | ({
     type: 'anchorHost';
@@ -384,7 +384,7 @@ export declare type DocRun = ({
 } | ({
     type: 'ptab';
 } & PTabRun);
-export declare interface DocSettings {
+export interface DocSettings {
     kinsoku?: boolean;
     noLineBreaksBefore?: string;
     noLineBreaksAfter?: string;
@@ -395,7 +395,7 @@ export declare interface DocSettings {
     balanceSingleByteDoubleByteWidth?: boolean;
     adjustLineHeightInTable?: boolean;
 }
-export declare interface DocTable {
+export interface DocTable {
     colWidths: number[];
     rows: DocTableRow[];
     borders: TableBorders;
@@ -412,7 +412,7 @@ export declare interface DocTable {
     tblpPr?: TblpPr;
     overlap?: string;
 }
-export declare interface DocTableCell {
+export interface DocTableCell {
     content: CellElement[];
     colSpan: number;
     vMerge: boolean | null;
@@ -426,7 +426,7 @@ export declare interface DocTableCell {
     marginLeft?: number | null;
     marginRight?: number | null;
 }
-export declare interface DocTableRow {
+export interface DocTableRow {
     cells: DocTableCell[];
     gridBefore?: number;
     gridAfter?: number;
@@ -435,22 +435,8 @@ export declare interface DocTableRow {
     isHeader: boolean;
     cantSplit?: boolean;
 }
-export declare class DocxDocument {
-    private _document;
-    private _meta;
-    private _pages;
-    private _bookmarkPages;
-    private _mode;
-    private _worker;
-    private _bridge;
-    private readonly _rawParts;
-    private _embeddedFontFaces;
-    private _googleFontFaces;
-    private _localMetricFontFaces;
-    private readonly _fetchImage;
-    private constructor();
+export class DocxDocument {
     static load(source: string | ArrayBuffer, opts?: LoadOptions): Promise<DocxDocument>;
-    private _parse;
     destroy(): void;
     getImage(imagePath: string, mimeType: string): Promise<Blob>;
     getFontBytes(partPath: string): Promise<Uint8Array>;
@@ -462,8 +448,6 @@ export declare class DocxDocument {
     get comments(): DocComment[];
     get footnotes(): DocNote[];
     get endnotes(): DocNote[];
-    private _getPages;
-    private _getBookmarkPages;
     getBookmarkPage(bookmarkName: string): number | undefined;
     pageSize(pageIndex: number): {
         widthPt: number;
@@ -472,8 +456,10 @@ export declare class DocxDocument {
     renderPage(target: HTMLCanvasElement | OffscreenCanvas, pageIndex: number, opts?: RenderPageOptions): Promise<void>;
     renderPageToBitmap(pageIndex: number, opts?: RenderPageToBitmapOptions): Promise<ImageBitmap>;
     collectPageRuns(pageIndex: number, opts?: WireRenderPageOptions): Promise<DocxTextRunInfo[]>;
+    private __privatePresence;
+    private constructor();
 }
-export declare interface DocxDocumentModel {
+export interface DocxDocumentModel {
     section: SectionProps;
     body: BodyElement[];
     headers: HeadersFooters;
@@ -490,94 +476,31 @@ export declare interface DocxDocumentModel {
     settings?: DocSettings;
     parseError?: string;
 }
-export declare type DocxHighlightColors = FindHighlightColors;
-export declare interface DocxHighlightMatch {
+export type DocxHighlightColors = FindHighlightColors;
+export interface DocxHighlightMatch {
     slices: MatchRunSlice[];
     active: boolean;
 }
-export declare interface DocxMatchLocation {
+export interface DocxMatchLocation {
     page: number;
 }
-export declare interface DocxRunBorder {
+export interface DocxRunBorder {
     style: string;
     color?: string | null;
     width: number;
     space: number;
 }
-export declare class DocxScrollViewer implements ZoomableViewer {
-    private _doc;
-    private readonly _injected;
-    private readonly _opts;
-    private readonly _container;
-    private readonly _wrapper;
-    private readonly _scrollHost;
-    private readonly _spacer;
-    private _mode;
-    private _scale;
-    private _scaleEstablished;
-    private _pendingScale;
-    private readonly _slots;
-    private readonly _free;
-    private _heights;
-    private _lastRange;
-    private _lastTopIndex;
-    private _scrollListener;
-    private _destroyed;
-    private _measureCtx;
-    private _loadGen;
-    private readonly _bitmapInFlight;
-    private _renderEpoch;
-    private _settleTimer;
-    private _wheelListener;
-    private _pendingZoomAnchor;
-    private _resizeObserver;
-    private _prevBase;
-    private _lastFitWidth;
-    private readonly _pageShadow;
-    private readonly _find;
-    private _findActive;
+export class DocxScrollViewer implements ZoomableViewer {
     constructor(container: HTMLElement, opts?: DocxScrollViewerOptions);
     load(source: string | ArrayBuffer): Promise<void>;
     get pageCount(): number;
-    private _pageWidthPx;
-    private _pageHeightPx;
-    private _fitWidthPx;
-    private _baseScale;
     relayout(): void;
-    private _recomputeHeights;
-    private _gap;
-    private _overscan;
-    private _pad;
-    private _padH;
-    private _pageIndexAtOffset;
-    private _range;
-    private _syncSpacer;
-    private _syncSpacerWidth;
-    private _onScroll;
-    private _mountVisible;
-    private _applyPageShadow;
-    private _acquireSlot;
-    private _recycleSlot;
-    private _positionSlot;
-    private _dpr;
-    private _renderSlot;
-    private _hyperlinkHandler;
-    private _measureForFont;
-    private _canvasCssPx;
-    private _reportRenderError;
-    private _renderSlotBitmap;
     setScale(scale: number): void;
     getScale(): number;
     zoomIn(): void;
     zoomOut(): void;
     fitWidth(): void;
     fitPage(): void;
-    private _fit;
-    private _previewVisible;
-    private _previewSlot;
-    private _scheduleSettle;
-    private _settleRender;
-    private _settleSlot;
     scrollToPage(index: number, opts?: {
         behavior?: 'auto' | 'smooth';
     }): void;
@@ -585,16 +508,12 @@ export declare class DocxScrollViewer implements ZoomableViewer {
     findNext(): Promise<FindMatch<DocxMatchLocation> | null>;
     findPrev(): Promise<FindMatch<DocxMatchLocation> | null>;
     clearFind(): void;
-    private _activateMatch;
-    private _collectPageRuns;
-    private _redrawHighlights;
-    private _redrawSlotHighlights;
-    private _onResize;
     get topVisiblePage(): number;
     getResourceMetrics(): Promise<OoxmlResourceMetrics>;
     destroy(): void;
+    private __privatePresence;
 }
-export declare interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onTextRun'>, LoadOptions {
+export interface DocxScrollViewerOptions extends Omit<RenderPageOptions, 'onTextRun'>, LoadOptions {
     width?: number;
     gap?: number;
     paddingTop?: number;
@@ -617,7 +536,7 @@ export declare interface DocxScrollViewerOptions extends Omit<RenderPageOptions,
     enableHyperlinks?: boolean;
     onError?: (err: Error) => void;
 }
-export declare interface DocxTextRun {
+export interface DocxTextRun {
     text: string;
     bold: boolean;
     italic: boolean;
@@ -663,7 +582,7 @@ export declare interface DocxTextRun {
     eastAsianCombineBrackets?: string;
     noteRef?: NoteRef;
 }
-export declare interface DocxTextRunInfo {
+export interface DocxTextRunInfo {
     paragraphId?: string;
     text: string;
     x: number;
@@ -677,24 +596,7 @@ export declare interface DocxTextRunInfo {
     hyperlink?: HyperlinkTarget;
     eastAsianVert?: boolean;
 }
-export declare class DocxViewer implements ZoomableViewer {
-    private _doc;
-    private _currentPage;
-    private _scale;
-    private _canvas;
-    private _wrapper;
-    private _originalParent;
-    private _originalNextSibling;
-    private _originalDisplay;
-    private _textLayer;
-    private _highlightLayer;
-    private _find;
-    private _measureCtx;
-    private _opts;
-    private readonly _mode;
-    private _bitmapCtx;
-    private _destroyed;
-    private _loadGen;
+export class DocxViewer implements ZoomableViewer {
     constructor(canvas: HTMLCanvasElement, opts?: DocxViewerOptions);
     load(source: string | ArrayBuffer): Promise<void>;
     get pageCount(): number;
@@ -703,37 +605,22 @@ export declare class DocxViewer implements ZoomableViewer {
     goToPage(index: number): Promise<void>;
     nextPage(): Promise<void>;
     prevPage(): Promise<void>;
-    private _naturalWidthPx;
-    private _renderWidth;
     getScale(): number;
-    private _zoomMin;
-    private _zoomMax;
     setScale(scale: number): Promise<void>;
     zoomIn(): Promise<void>;
     zoomOut(): Promise<void>;
     fitWidth(): Promise<void>;
     fitPage(): Promise<void>;
-    private _fit;
-    private _fitContainer;
     findText(query: string, opts?: FindMatchesOptions): Promise<FindMatch<DocxMatchLocation>[]>;
     findNext(): Promise<FindMatch<DocxMatchLocation> | null>;
     findPrev(): Promise<FindMatch<DocxMatchLocation> | null>;
     clearFind(): void;
-    private _activateMatch;
-    private _redrawHighlights;
     getResourceMetrics(): Promise<OoxmlResourceMetrics>;
     destroy(): void;
-    private _render;
-    private _reportRenderError;
-    private _renderPage;
-    private _buildHighlightLayer;
-    private _canvasCssPx;
-    private _measureForFont;
-    private _collectPageRuns;
-    private _buildTextLayer;
-    private _hyperlinkHandler;
+    private __privatePresence;
 }
-export declare interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
+export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
+    document?: DocxDocument;
     container?: HTMLElement;
     enableTextSelection?: boolean;
     findHighlightColors?: FindHighlightColors;
@@ -745,18 +632,19 @@ export declare interface DocxViewerOptions extends RenderPageOptions, LoadOption
     enableHyperlinks?: boolean;
     onError?: (err: Error) => void;
 }
-declare interface Duotone {
+interface Duotone {
     clr1: string;
     clr2: string;
 }
-export declare interface EmbeddedFontRef {
+export interface EmbeddedFontRef {
     fontName: string;
     style: 'regular' | 'bold' | 'italic' | 'boldItalic';
     partPath: string;
     fontKey: string;
 }
-declare type EmphasisMark = 'dot' | 'comma' | 'circle' | 'underDot';
-export declare interface FieldRun {
+type EmphasisMark = 'dot' | 'comma' | 'circle' | 'underDot';
+type ExtensibleLiteral<Known extends string> = Known | (string & Record<never, never>);
+export interface FieldRun {
     fieldType: string;
     instruction: string;
     fallbackText: string;
@@ -775,25 +663,25 @@ export declare interface FieldRun {
     highlight?: string | null;
     emphasisMark?: EmphasisMark;
 }
-declare interface FillRect {
+interface FillRect {
     l?: number;
     t?: number;
     r?: number;
     b?: number;
 }
-export declare interface FindMatch<Loc = unknown> {
+export interface FindHighlightColors {
+    match?: string;
+    active?: string;
+}
+export interface FindMatch<Loc = unknown> {
     matchIndex: number;
     text: string;
     location: Loc;
 }
-export declare interface FindHighlightColors {
-    match?: string;
-    active?: string;
-}
-export declare interface FindMatchesOptions {
+export interface FindMatchesOptions {
     caseSensitive?: boolean;
 }
-export declare interface FramePr {
+export interface FramePr {
     dropCap: 'none' | 'drop' | 'margin' | string;
     lines: number;
     wrap: 'around' | 'auto' | 'none' | 'notBeside' | 'through' | 'tight' | string;
@@ -809,19 +697,19 @@ export declare interface FramePr {
     xAlign?: 'left' | 'center' | 'right' | 'inside' | 'outside' | string;
     yAlign?: 'inline' | 'top' | 'center' | 'bottom' | 'inside' | 'outside' | string;
 }
-export declare interface GradientStop {
+export interface GradientStop {
     position: number;
     color: string;
 }
-export declare interface HeaderFooter {
+export interface HeaderFooter {
     body: BodyElement[];
 }
-export declare interface HeadersFooters {
+export interface HeadersFooters {
     default: HeaderFooter | null;
     first: HeaderFooter | null;
     even: HeaderFooter | null;
 }
-export declare type HyperlinkTarget = {
+export type HyperlinkTarget = {
     kind: 'external';
     url: string;
 } | {
@@ -829,7 +717,7 @@ export declare type HyperlinkTarget = {
     ref: string;
     slideIndex?: number;
 };
-export declare interface ImageRun {
+export interface ImageRun {
     imagePath: string;
     mimeType: string;
     svgImagePath?: string;
@@ -864,7 +752,8 @@ export declare interface ImageRun {
     anchorXRelativeFrom?: string | null;
     anchorYRelativeFrom?: string | null;
 }
-declare interface LegendManualLayout {
+export function isOoxmlDecodedImageLimitError(error: unknown): error is OoxmlDecodedImageLimitError;
+interface LegendManualLayout {
     xMode: string;
     yMode: string;
     x: number;
@@ -872,27 +761,27 @@ declare interface LegendManualLayout {
     w: number;
     h: number;
 }
-export declare interface LineEnd {
+export interface LineEnd {
     type: string;
     w: string;
     len: string;
 }
-export declare interface LineNumbering {
+export interface LineNumbering {
     countBy: number;
     start: number;
     distance?: number;
     restart: string;
 }
-export declare interface LineSpacing {
+export interface LineSpacing {
     value: number;
     rule: 'auto' | 'exact' | 'atLeast';
     explicit?: boolean;
 }
-export declare interface LoadOptions extends LoadOptions_2 {
+export interface LoadOptions extends LoadOptions__emitterCollision1 {
     math?: MathRenderer;
     mode?: 'main' | 'worker';
 }
-declare interface LoadOptions_2 {
+interface LoadOptions__emitterCollision1 {
     useGoogleFonts?: boolean;
     password?: string;
     wasmUrl?: string | URL;
@@ -903,27 +792,27 @@ declare interface LoadOptions_2 {
     workerTimeoutMs?: number;
     math?: MathRenderer;
 }
-declare interface MatchRunSlice {
+interface MatchRunSlice {
     runIndex: number;
     start: number;
     end: number;
 }
-declare interface MathAccent {
+interface MathAccent {
     kind: 'accent';
     char: string;
     base: MathNode[];
 }
-declare interface MathArray {
+interface MathArray {
     kind: 'array';
     rows: MathNode[][][];
     align: 'eq' | 'center' | 'left';
 }
-declare interface MathBar {
+interface MathBar {
     kind: 'bar';
     pos: 'top' | 'bot';
     base: MathNode[];
 }
-declare interface MathBorderBox {
+interface MathBorderBox {
     kind: 'borderBox';
     hideTop?: boolean;
     hideBot?: boolean;
@@ -935,44 +824,44 @@ declare interface MathBorderBox {
     strikeTlbr?: boolean;
     base: MathNode[];
 }
-declare interface MathBox {
+interface MathBox {
     kind: 'box';
     base: MathNode[];
 }
-declare interface MathDelimiter {
+interface MathDelimiter {
     kind: 'delimiter';
     begChar: string;
     endChar: string;
     items: MathNode[][];
 }
-declare interface MathFraction {
+interface MathFraction {
     kind: 'fraction';
     num: MathNode[];
     den: MathNode[];
     bar?: boolean;
 }
-declare interface MathFunc {
+interface MathFunc {
     kind: 'func';
     name: MathNode[];
     arg: MathNode[];
 }
-declare interface MathGroup {
+interface MathGroup {
     kind: 'group';
     items: MathNode[];
 }
-declare interface MathGroupChr {
+interface MathGroupChr {
     kind: 'groupChr';
     char: string;
     pos: 'top' | 'bot';
     base: MathNode[];
 }
-declare interface MathLimit {
+interface MathLimit {
     kind: 'limit';
     base: MathNode[];
     lower?: MathNode[];
     upper?: MathNode[];
 }
-declare interface MathNary {
+interface MathNary {
     kind: 'nary';
     op: string;
     limLoc?: string;
@@ -980,8 +869,8 @@ declare interface MathNary {
     sup?: MathNode[];
     body: MathNode[];
 }
-declare type MathNode = MathRun | MathFraction | MathScript | MathNary | MathDelimiter | MathRadical | MathLimit | MathArray | MathGroupChr | MathBar | MathAccent | MathFunc | MathGroup | MathPhant | MathSPre | MathBox | MathBorderBox;
-declare interface MathPhant {
+type MathNode = MathRun | MathFraction | MathScript | MathNary | MathDelimiter | MathRadical | MathLimit | MathArray | MathGroupChr | MathBar | MathAccent | MathFunc | MathGroup | MathPhant | MathSPre | MathBox | MathBorderBox;
+interface MathPhant {
     kind: 'phant';
     show: boolean;
     zeroWid?: boolean;
@@ -989,45 +878,45 @@ declare interface MathPhant {
     zeroDesc?: boolean;
     base: MathNode[];
 }
-declare interface MathRadical {
+interface MathRadical {
     kind: 'radical';
     index?: MathNode[];
     radicand: MathNode[];
 }
-declare interface MathRenderer {
+interface MathRenderer {
     loadMathJax(): Promise<void>;
     mathMLToSvg(mathml: string): Promise<MathSvg>;
 }
-declare interface MathRun {
+interface MathRun {
     kind: 'run';
     text: string;
     style: MathStyle;
 }
-declare interface MathScript {
+interface MathScript {
     kind: 'sup' | 'sub' | 'subSup';
     base: MathNode[];
     sup?: MathNode[];
     sub?: MathNode[];
 }
-declare interface MathSPre {
+interface MathSPre {
     kind: 'sPre';
     sub: MathNode[];
     sup: MathNode[];
     base: MathNode[];
 }
-declare type MathStyle = 'roman' | 'italic' | 'bold' | 'boldItalic';
-declare interface MathSvg {
+type MathStyle = 'roman' | 'italic' | 'bold' | 'boldItalic';
+interface MathSvg {
     svg: string;
     widthEm: number;
     ascentEm: number;
     descentEm: number;
 }
-export declare interface NoteRef {
+export interface NoteRef {
     kind: 'footnote' | 'endnote' | string;
     id: string;
 }
-export declare function noteText(note: DocNote): string;
-export declare interface NumberingInfo {
+export function noteText(note: DocNote): string;
+export interface NumberingInfo {
     numId: number;
     level: number;
     format: string;
@@ -1045,41 +934,39 @@ export declare interface NumberingInfo {
     picBulletWidthPt?: number;
     picBulletHeightPt?: number;
 }
-export declare type OoxmlDecodedImageLimitMetric = 'image-pixels' | 'active-decoded-bytes';
-export declare class OoxmlDecodedImageLimitError extends RangeError {
+export class OoxmlDecodedImageLimitError extends RangeError {
     readonly metric: OoxmlDecodedImageLimitMetric;
     readonly limit: number;
     readonly observed: number;
-    readonly code: "ooxml-decoded-image-limit";
+    readonly code: 'ooxml-decoded-image-limit';
     constructor(metric: OoxmlDecodedImageLimitMetric, limit: number, observed: number);
 }
-export declare function isOoxmlDecodedImageLimitError(error: unknown): error is OoxmlDecodedImageLimitError;
-export declare class OoxmlError extends Error {
+export type OoxmlDecodedImageLimitMetric = 'image-pixels' | 'active-decoded-bytes';
+export class OoxmlError extends Error {
     readonly code: OoxmlErrorCode;
     constructor(code: OoxmlErrorCode, message: string);
 }
-export declare type OoxmlErrorCode = 'encrypted' | 'invalid-password' | 'unsupported-encryption' | 'legacy-binary-format' | 'not-ooxml';
-export declare type OoxmlErrorSource = 'container' | 'zip-part' | 'parser' | 'serializer' | 'layout' | 'renderer' | 'worker';
-export declare type OoxmlErrorStage = 'container' | 'decompression' | 'parsing' | 'serialization' | 'layout' | 'rendering' | 'worker';
-declare type ExtensibleLiteral<Known extends string> = Known | (string & Record<never, never>);
-export declare type OoxmlFormat = 'docx' | 'xlsx' | 'pptx';
-export declare type OoxmlResourceLimit = number | null;
-export declare class OoxmlResourceLimitError extends Error {
+export type OoxmlErrorCode = 'encrypted' | 'invalid-password' | 'unsupported-encryption' | 'legacy-binary-format' | 'not-ooxml';
+export type OoxmlErrorSource = 'container' | 'zip-part' | 'parser' | 'serializer' | 'layout' | 'renderer' | 'worker';
+export type OoxmlErrorStage = 'container' | 'decompression' | 'parsing' | 'serialization' | 'layout' | 'rendering' | 'worker';
+export type OoxmlFormat = 'docx' | 'xlsx' | 'pptx';
+export type OoxmlResourceLimit = number | null;
+export class OoxmlResourceLimitError extends Error {
     readonly code: 'ooxml-resource-limit';
     readonly details: OoxmlResourceLimitErrorDetails;
     constructor(message: string, details: OoxmlResourceLimitErrorDetails);
 }
-export declare interface OoxmlResourceLimitErrorDetails {
+export interface OoxmlResourceLimitErrorDetails {
     readonly stage: OoxmlErrorStage;
     readonly violation: OoxmlResourceViolation;
 }
-export declare interface OoxmlResourceLimits {
+export interface OoxmlResourceLimits {
     maxArchiveEntryBytes?: OoxmlResourceLimit;
     maxTotalInflatedBytes?: OoxmlResourceLimit;
     maxArchiveEntries?: OoxmlResourceLimit;
 }
-export declare type OoxmlResourceMetric = ExtensibleLiteral<'declared-inflated-bytes' | 'actual-inflated-bytes' | 'entry-count' | 'central-directory-bytes' | 'distinct-inflated-bytes' | 'bytes' | 'depth' | 'projected-bytes'>;
-export declare interface OoxmlResourceMetrics {
+export type OoxmlResourceMetric = ExtensibleLiteral<'declared-inflated-bytes' | 'actual-inflated-bytes' | 'entry-count' | 'central-directory-bytes' | 'distinct-inflated-bytes' | 'bytes' | 'depth' | 'projected-bytes'>;
+export interface OoxmlResourceMetrics {
     readonly schemaVersion: 1;
     readonly scope: 'load' | 'session';
     readonly format: OoxmlFormat;
@@ -1098,26 +985,25 @@ export declare interface OoxmlResourceMetrics {
         readonly metric?: string;
     }>;
 }
-export declare interface OoxmlResourceMetricsCheckpoint {
+export interface OoxmlResourceMetricsCheckpoint {
     readonly name: string;
     readonly elapsedMs: number;
     readonly usage?: OoxmlResourceUsageSnapshot;
 }
-export declare type OoxmlResourceName = ExtensibleLiteral<'archive' | 'archive-entry' | 'xml-event' | 'xml-context' | 'xml-tree' | 'worksheet-row' | 'worksheet-shell'>;
-export declare interface OoxmlResourcePolicySnapshot {
+export type OoxmlResourceName = ExtensibleLiteral<'archive' | 'archive-entry' | 'xml-event' | 'xml-context' | 'xml-tree' | 'worksheet-row' | 'worksheet-shell'>;
+export interface OoxmlResourcePolicySnapshot {
     readonly maxArchiveEntryBytes: number | null;
     readonly maxTotalInflatedBytes: number | null;
     readonly maxArchiveEntries: number | null;
 }
-export declare interface OoxmlResourceUsageSnapshot {
+export interface OoxmlResourceUsageSnapshot {
     readonly archiveEntryCount: number;
     readonly declaredInflatedBytes: number;
-    /** Largest actual decompressed size observed for one ZIP entry. */
     readonly largestInflatedEntryBytes?: number;
     readonly distinctInflatedBytes: number;
     readonly operationInflatedBytes: number;
 }
-export declare interface OoxmlResourceViolation {
+export interface OoxmlResourceViolation {
     readonly format: OoxmlFormat;
     readonly operation: string;
     readonly resource: OoxmlResourceName;
@@ -1128,14 +1014,14 @@ export declare interface OoxmlResourceViolation {
     readonly configurable: boolean;
     readonly usage: OoxmlResourceUsageSnapshot;
 }
-export declare function openExternalHyperlink(url: string, allowed?: readonly string[], win?: Pick<Window, 'open'> | undefined): boolean;
-export declare interface PageBorderEdge {
+export function openExternalHyperlink(url: string, allowed?: readonly string[], win?: Pick<Window, 'open'> | undefined): boolean;
+export interface PageBorderEdge {
     style: string;
     color?: string;
     width: number;
     space: number;
 }
-export declare interface PageBorders {
+export interface PageBorders {
     offsetFrom: string;
     display: string;
     zOrder: string;
@@ -1144,24 +1030,24 @@ export declare interface PageBorders {
     left?: PageBorderEdge;
     right?: PageBorderEdge;
 }
-export declare interface PageNumType {
+export interface PageNumType {
     start?: number;
     fmt?: string;
 }
-export declare interface ParaBorderEdge {
+export interface ParaBorderEdge {
     style: string;
     color: string | null;
     width: number;
     space: number;
 }
-export declare interface ParagraphBorders {
+export interface ParagraphBorders {
     top: ParaBorderEdge | null;
     bottom: ParaBorderEdge | null;
     left: ParaBorderEdge | null;
     right: ParaBorderEdge | null;
     between: ParaBorderEdge | null;
 }
-export declare type PathCmd = {
+export type PathCmd = {
     cmd: 'moveTo';
     x: number;
     y: number;
@@ -1186,13 +1072,13 @@ export declare type PathCmd = {
 } | {
     cmd: 'close';
 };
-export declare interface PTabRun {
+export interface PTabRun {
     alignment: 'left' | 'center' | 'right';
     relativeTo: 'margin' | 'indent';
     leader: 'none' | 'dot' | 'hyphen' | 'underscore' | 'middleDot';
     fontSize: number;
 }
-export declare interface RenderPageOptions {
+export interface RenderPageOptions {
     width?: number;
     dpr?: number;
     defaultTextColor?: string;
@@ -1209,20 +1095,20 @@ export declare interface RenderPageOptions {
     showTrackChanges?: boolean;
     currentDate?: Date | number;
 }
-export declare type RenderPageToBitmapOptions = WireRenderPageOptions & {
+export type RenderPageToBitmapOptions = WireRenderPageOptions & {
     onTextRun?: (run: DocxTextRunInfo) => void;
 };
-export declare interface RubyAnnotation {
+export interface RubyAnnotation {
     text: string;
     fontSizePt: number;
     hpsRaisePt?: number;
 }
-export declare interface RunRevision {
+export interface RunRevision {
     kind: 'insertion' | 'deletion' | string;
     author?: string;
     date?: string;
 }
-declare interface SecondaryValueAxis {
+interface SecondaryValueAxis {
     min: number | null;
     max: number | null;
     title: string | null;
@@ -1239,7 +1125,7 @@ declare interface SecondaryValueAxis {
     titleFontBold?: boolean | null;
     titleFontColor?: string | null;
 }
-export declare interface SectionGeom {
+export interface SectionGeom {
     pageWidth: number;
     pageHeight: number;
     marginTop: number;
@@ -1249,7 +1135,7 @@ export declare interface SectionGeom {
     headerDistance: number;
     footerDistance: number;
 }
-export declare interface SectionProps {
+export interface SectionProps {
     pageWidth: number;
     pageHeight: number;
     marginTop: number;
@@ -1271,7 +1157,7 @@ export declare interface SectionProps {
     lineNumbering?: LineNumbering | null;
     vAlign?: string | null;
 }
-declare type ShapeFill = {
+type ShapeFill = {
     fillType: 'solid';
     color: string;
 } | {
@@ -1295,7 +1181,7 @@ declare type ShapeFill = {
     alpha?: number;
     duotone?: Duotone;
 };
-export declare interface ShapeRun {
+export interface ShapeRun {
     inline?: boolean;
     widthPt: number;
     heightPt: number;
@@ -1348,7 +1234,7 @@ export declare interface ShapeRun {
     textPath?: TextPath | null;
     fillOpacity?: number | null;
 }
-export declare interface ShapeText {
+export interface ShapeText {
     text: string;
     fontSizePt: number;
     color?: string | null;
@@ -1376,7 +1262,7 @@ export declare interface ShapeText {
     imageWidthPt?: number;
     imageHeightPt?: number;
 }
-export declare interface ShapeTextRun {
+export interface ShapeTextRun {
     text: string;
     fontSizePt: number;
     color?: string | null;
@@ -1386,7 +1272,7 @@ export declare interface ShapeTextRun {
     italic?: boolean;
     ruby?: RubyAnnotation | null;
 }
-export declare interface TableBorders {
+export interface TableBorders {
     top: BorderSpec | null;
     bottom: BorderSpec | null;
     left: BorderSpec | null;
@@ -1394,12 +1280,12 @@ export declare interface TableBorders {
     insideH: BorderSpec | null;
     insideV: BorderSpec | null;
 }
-export declare interface TabStop {
+export interface TabStop {
     pos: number;
     alignment: 'left' | 'start' | 'center' | 'right' | 'end' | 'decimal' | 'bar' | 'clear' | 'num';
     leader: 'none' | 'dot' | 'hyphen' | 'underscore' | 'heavy' | 'middleDot';
 }
-export declare interface TblpPr {
+export interface TblpPr {
     leftFromText: number;
     rightFromText: number;
     topFromText: number;
@@ -1412,13 +1298,13 @@ export declare interface TblpPr {
     tblpXSpec?: 'left' | 'center' | 'right' | 'inside' | 'outside' | string;
     tblpYSpec?: 'inline' | 'top' | 'center' | 'bottom' | 'inside' | 'outside' | string;
 }
-export declare interface TextPath {
+export interface TextPath {
     string: string;
     fontFamily?: string | null;
     bold?: boolean;
     italic?: boolean;
 }
-declare interface TileInfo {
+interface TileInfo {
     tx: number;
     ty: number;
     sx: number;
@@ -1426,8 +1312,8 @@ declare interface TileInfo {
     flip: string;
     algn?: string;
 }
-export declare type WireRenderPageOptions = Omit<RenderPageOptions, 'onTextRun'>;
-declare interface ZoomableViewer {
+export type WireRenderPageOptions = Omit<RenderPageOptions, 'onTextRun'>;
+interface ZoomableViewer {
     getScale(): number;
     setScale(scale: number): void | Promise<void>;
     zoomIn(): void | Promise<void>;
@@ -1435,4 +1321,3 @@ declare interface ZoomableViewer {
     fitWidth(): void | Promise<void>;
     fitPage(): void | Promise<void>;
 }
-export {};

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1,6 +1,7 @@
 import { computeVisibleRange, openExternalHyperlink, PT_TO_PX, zoomStepScale, anchoredZoomOffset, nextZoomStep, prevZoomStep, fitScale, type VisibleRange } from '@silurus/ooxml-core';
 import type { FindHighlightColors, FindMatch, FindMatchesOptions, HyperlinkTarget, OoxmlResourceMetrics, ZoomableViewer } from '@silurus/ooxml-core';
 import {
+  resolveCanvasViewerMode,
   StaticCanvasRenderDispatcher,
   TerminalResourceOwner,
 } from '@silurus/ooxml-core/internal/canvas-viewer-mechanics';
@@ -316,20 +317,11 @@ export class DocxScrollViewer implements ZoomableViewer {
     this._injected = !!opts.document;
     if (this._injected) {
       const engine = opts.document as DocxDocument;
-      // Injected engine ⇒ its own mode is the fact (design §11). An EXPLICITLY
-      // conflicting opts.mode is a mis-configuration and is rejected here; an
-      // absent opts.mode is fine.
-      if (opts.mode !== undefined && opts.mode !== engine.mode) {
-        throw new Error(
-          `DocxScrollViewer: opts.mode='${opts.mode}' conflicts with the injected engine's mode='${engine.mode}'. ` +
-            'Omit opts.mode when injecting an engine — the engine owns its render mode.',
-        );
-      }
       this._documentOwner = new TerminalResourceOwner('DocxScrollViewer', engine, false);
-      this._mode = engine.mode;
+      this._mode = resolveCanvasViewerMode('DocxScrollViewer', opts.mode, engine);
     } else {
       this._documentOwner = new TerminalResourceOwner('DocxScrollViewer');
-      this._mode = opts.mode ?? 'main';
+      this._mode = resolveCanvasViewerMode('DocxScrollViewer', opts.mode, undefined);
     }
 
     // container → wrapper → scrollHost → spacer  (design §6)

--- a/packages/docx/src/viewer-destroy.test.ts
+++ b/packages/docx/src/viewer-destroy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { DocxViewer } from './viewer.js';
-import { installDom, makeEl, type FakeEl } from './scroll-viewer-test-dom.js';
+import { installDom, makeEl, FakeDocxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -97,5 +97,27 @@ describe('DocxViewer.destroy() — canvas reparent return', () => {
     expect(() => v.destroy()).not.toThrow();
     expect(canvas.parentElement).toBe(parent);
     expect(parent.children).toEqual([before, canvas]);
+  });
+
+  it('borrows an injected document with the same lifecycle contract as the scroll viewer', async () => {
+    const { canvas } = mount();
+    const engine = new FakeDocxEngine(2, [{ widthPt: 612, heightPt: 792 }]);
+    const viewer = new DocxViewer(canvas as unknown as HTMLCanvasElement, {
+      document: engine.asDoc(),
+    });
+    expect(viewer.pageCount).toBe(2);
+    await expect(viewer.load('x.docx')).rejects.toThrow(/injected/i);
+    viewer.destroy();
+    expect(engine.destroyed).toBe(false);
+  });
+
+  it('rejects an injected mode conflict before reparenting the canvas', () => {
+    const { parent, canvas } = mount();
+    const engine = new FakeDocxEngine(1, [{ widthPt: 612, heightPt: 792 }], 'worker');
+    expect(() => new DocxViewer(canvas as unknown as HTMLCanvasElement, {
+      document: engine.asDoc(),
+      mode: 'main',
+    })).toThrow(/opts\.mode='main'.*mode='worker'/);
+    expect(parent.children).toContain(canvas);
   });
 });

--- a/packages/docx/src/viewer.ts
+++ b/packages/docx/src/viewer.ts
@@ -11,12 +11,18 @@ import {
   CallerCanvasMount,
   CanvasOverlayHost,
   CanvasViewerErrorRouter,
+  resolveCanvasViewerMode,
   StaticCanvasRenderDispatcher,
   TerminalResourceOwner,
 } from '@silurus/ooxml-core/internal/canvas-viewer-mechanics';
 import { invalidateDocxRenderTarget } from './paint/canvas-document';
 
 export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
+  /**
+   * Borrow an already-loaded document. Its mode is authoritative, `load()` is
+   * unavailable, and `destroy()` leaves the caller-owned document open.
+   */
+  document?: DocxDocument;
   container?: HTMLElement;
   /**
    * When true, adds a transparent text overlay div over the canvas so the
@@ -69,8 +75,10 @@ export interface DocxViewerOptions extends RenderPageOptions, LoadOptions {
 }
 
 export class DocxViewer implements ZoomableViewer {
-  private readonly _documentOwner = new TerminalResourceOwner<DocxDocument>('DocxViewer');
+  private readonly _documentOwner: TerminalResourceOwner<DocxDocument>;
   private get _doc(): DocxDocument | null { return this._documentOwner.current; }
+  private readonly _injected: boolean;
+  private readonly _hostWindow: Window & typeof globalThis;
   private _currentPage = 0;
   /**
    * IX9 explicit zoom factor (`1` = 100% = the page at its natural pt→px width),
@@ -104,7 +112,18 @@ export class DocxViewer implements ZoomableViewer {
   constructor(canvas: HTMLCanvasElement, opts: DocxViewerOptions = {}) {
     this._canvas = canvas;
     this._opts = opts;
-    this._mode = opts.mode ?? 'main';
+    const injectedDocument = opts.document;
+    this._injected = injectedDocument !== undefined;
+    this._mode = resolveCanvasViewerMode('DocxViewer', opts.mode, injectedDocument);
+    this._documentOwner = new TerminalResourceOwner(
+      'DocxViewer',
+      injectedDocument ?? null,
+      false,
+    );
+    const hostWindow = canvas.ownerDocument?.defaultView ??
+      (typeof window !== 'undefined' ? window : null);
+    if (!hostWindow) throw new Error('DocxViewer requires a canvas with an active Window');
+    this._hostWindow = hostWindow;
 
     this._canvasMount = new CallerCanvasMount(canvas, {
       wrapperCssText: 'position:relative;display:inline-block;vertical-align:top;',
@@ -138,6 +157,12 @@ export class DocxViewer implements ZoomableViewer {
    */
   async load(source: string | ArrayBuffer): Promise<void> {
     if (this._destroyed) throw new Error('DocxViewer is destroyed');
+    if (this._injected) {
+      throw new Error(
+        'DocxViewer.load() is unsupported when an engine is injected via opts.document; ' +
+          'the injected engine is already loaded.',
+      );
+    }
     // SC20 atomic swap: retain the previous engine locally and only tear it down
     // AFTER the new one loads successfully. A re-load thus never orphans the old
     // engine's worker + pinned WASM allocation (the leak this guards), yet a
@@ -584,7 +609,7 @@ export class DocxViewer implements ZoomableViewer {
     if (custom) return custom;
     return (target: HyperlinkTarget): void => {
       if (target.kind === 'external') {
-        openExternalHyperlink(target.url);
+        openExternalHyperlink(target.url, undefined, this._hostWindow);
         return;
       }
       // Internal anchor (IX-nav): map the bookmark name to its destination page

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -354,6 +354,7 @@ export interface ImageFill {
     alpha?: number;
     duotone?: Duotone;
 }
+export function isOoxmlDecodedImageLimitError(error: unknown): error is OoxmlDecodedImageLimitError;
 interface LegendManualLayout {
     xMode: string;
     yMode: string;
@@ -521,15 +522,14 @@ export interface MediaElement {
 export interface NoFill {
     fillType: 'none';
 }
-export type OoxmlDecodedImageLimitMetric = 'image-pixels' | 'active-decoded-bytes';
 export class OoxmlDecodedImageLimitError extends RangeError {
     readonly metric: OoxmlDecodedImageLimitMetric;
     readonly limit: number;
     readonly observed: number;
-    readonly code: "ooxml-decoded-image-limit";
+    readonly code: 'ooxml-decoded-image-limit';
     constructor(metric: OoxmlDecodedImageLimitMetric, limit: number, observed: number);
 }
-export function isOoxmlDecodedImageLimitError(error: unknown): error is OoxmlDecodedImageLimitError;
+export type OoxmlDecodedImageLimitMetric = 'image-pixels' | 'active-decoded-bytes';
 export class OoxmlError extends Error {
     readonly code: OoxmlErrorCode;
     constructor(code: OoxmlErrorCode, message: string);
@@ -587,7 +587,6 @@ export interface OoxmlResourcePolicySnapshot {
 export interface OoxmlResourceUsageSnapshot {
     readonly archiveEntryCount: number;
     readonly declaredInflatedBytes: number;
-    /** Largest actual decompressed size observed for one ZIP entry. */
     readonly largestInflatedEntryBytes?: number;
     readonly distinctInflatedBytes: number;
     readonly operationInflatedBytes: number;
@@ -820,6 +819,7 @@ export class PptxViewer implements ZoomableViewer {
     private __privatePresence;
 }
 export interface PptxViewerOptions extends RenderOptions, LoadOptions {
+    presentation?: PptxPresentation;
     onSlideChange?: (index: number, total: number) => void;
     onError?: (err: Error) => void;
     zoomMin?: number;

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1,5 +1,6 @@
 import { computeVisibleRange, EMU_PER_PX, zoomStepScale, anchoredZoomOffset, nextZoomStep, prevZoomStep, fitScale, type FindHighlightColors, type FindMatch, type FindMatchesOptions, type VisibleRange, type HyperlinkTarget, type OoxmlResourceMetrics, type ZoomableViewer, openExternalHyperlink } from '@silurus/ooxml-core';
 import {
+  resolveCanvasViewerMode,
   StaticCanvasRenderDispatcher,
   TerminalResourceOwner,
 } from '@silurus/ooxml-core/internal/canvas-viewer-mechanics';
@@ -355,20 +356,11 @@ export class PptxScrollViewer implements ZoomableViewer {
     this._injected = !!opts.presentation;
     if (this._injected) {
       const engine = opts.presentation as PptxPresentation;
-      // Injected engine ⇒ its own mode is the fact (design §11). An EXPLICITLY
-      // conflicting opts.mode is a mis-configuration and is rejected here; an
-      // absent opts.mode is fine.
-      if (opts.mode !== undefined && opts.mode !== engine.mode) {
-        throw new Error(
-          `PptxScrollViewer: opts.mode='${opts.mode}' conflicts with the injected engine's mode='${engine.mode}'. ` +
-            'Omit opts.mode when injecting an engine — the engine owns its render mode.',
-        );
-      }
       this._presentationOwner = new TerminalResourceOwner('PptxScrollViewer', engine, false);
-      this._mode = engine.mode;
+      this._mode = resolveCanvasViewerMode('PptxScrollViewer', opts.mode, engine);
     } else {
       this._presentationOwner = new TerminalResourceOwner('PptxScrollViewer');
-      this._mode = opts.mode ?? 'main';
+      this._mode = resolveCanvasViewerMode('PptxScrollViewer', opts.mode, undefined);
     }
 
     // container → wrapper → scrollHost → spacer  (design §6)

--- a/packages/pptx/src/viewer-destroy.test.ts
+++ b/packages/pptx/src/viewer-destroy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { PptxViewer } from './viewer.js';
-import { installDom, makeEl, type FakeEl } from './scroll-viewer-test-dom.js';
+import { installDom, makeEl, FakePptxEngine, type FakeEl } from './scroll-viewer-test-dom.js';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -97,5 +97,27 @@ describe('PptxViewer.destroy() — canvas reparent return', () => {
     expect(() => v.destroy()).not.toThrow();
     expect(canvas.parentElement).toBe(parent);
     expect(parent.children).toEqual([before, canvas]);
+  });
+
+  it('borrows an injected presentation with the same lifecycle contract as the scroll viewer', async () => {
+    const { canvas } = mount();
+    const engine = new FakePptxEngine(2, 9144000, 5143500);
+    const viewer = new PptxViewer(canvas as unknown as HTMLCanvasElement, {
+      presentation: engine.asPres(),
+    });
+    expect(viewer.slideCount).toBe(2);
+    await expect(viewer.load('x.pptx')).rejects.toThrow(/injected/i);
+    viewer.destroy();
+    expect(engine.destroyed).toBe(false);
+  });
+
+  it('rejects an injected mode conflict before reparenting the canvas', () => {
+    const { parent, canvas } = mount();
+    const engine = new FakePptxEngine(1, 9144000, 5143500, 'worker');
+    expect(() => new PptxViewer(canvas as unknown as HTMLCanvasElement, {
+      presentation: engine.asPres(),
+      mode: 'main',
+    })).toThrow(/opts\.mode='main'.*mode='worker'/);
+    expect(parent.children).toContain(canvas);
   });
 });

--- a/packages/pptx/src/viewer.ts
+++ b/packages/pptx/src/viewer.ts
@@ -28,6 +28,7 @@ import {
   CallerCanvasMount,
   CanvasOverlayHost,
   CanvasViewerErrorRouter,
+  resolveCanvasViewerMode,
   StaticCanvasRenderDispatcher,
   TerminalResourceOwner,
 } from '@silurus/ooxml-core/internal/canvas-viewer-mechanics';
@@ -39,6 +40,11 @@ export type HiddenSlideMode = 'show' | 'skip' | 'dim';
 const DEFAULT_HIDDEN_DIM: DimOptions = { color: '#ffffff', opacity: 0.6 };
 
 export interface PptxViewerOptions extends RenderOptions, LoadOptions {
+  /**
+   * Borrow an already-loaded presentation. Its mode is authoritative, `load()`
+   * is unavailable, and `destroy()` leaves the caller-owned presentation open.
+   */
+  presentation?: PptxPresentation;
   /** Called when a slide finishes rendering */
   onSlideChange?: (index: number, total: number) => void;
   /**
@@ -151,8 +157,10 @@ export class PptxViewer implements ZoomableViewer {
   private _find: PptxFindController;
   /** Private 2d context for measuring highlight text (own 1×1 canvas). */
   private _measureCtx: CanvasRenderingContext2D | null = null;
-  private readonly presentationOwner = new TerminalResourceOwner<PptxPresentation>('PptxViewer');
+  private readonly presentationOwner: TerminalResourceOwner<PptxPresentation>;
   private get engine(): PptxPresentation | null { return this.presentationOwner.current; }
+  private readonly injected: boolean;
+  private readonly hostWindow: Window & typeof globalThis;
   private readonly opts: PptxViewerOptions;
   private currentSlide = 0;
   private _hiddenMode: HiddenSlideMode;
@@ -164,7 +172,18 @@ export class PptxViewer implements ZoomableViewer {
   constructor(canvas: HTMLCanvasElement, opts: PptxViewerOptions = {}) {
     this.opts = opts;
     this.canvas = canvas;
-    this._mode = opts.mode ?? 'main';
+    const injectedPresentation = opts.presentation;
+    this.injected = injectedPresentation !== undefined;
+    this._mode = resolveCanvasViewerMode('PptxViewer', opts.mode, injectedPresentation);
+    this.presentationOwner = new TerminalResourceOwner(
+      'PptxViewer',
+      injectedPresentation ?? null,
+      false,
+    );
+    const hostWindow = canvas.ownerDocument?.defaultView ??
+      (typeof window !== 'undefined' ? window : null);
+    if (!hostWindow) throw new Error('PptxViewer requires a canvas with an active Window');
+    this.hostWindow = hostWindow;
     this._hiddenMode = opts.hiddenSlideMode ?? 'show';
 
     this.canvasMount = new CallerCanvasMount(canvas, {
@@ -202,6 +221,12 @@ export class PptxViewer implements ZoomableViewer {
    */
   async load(source: string | ArrayBuffer): Promise<void> {
     if (this.destroyed) throw new Error('PptxViewer is destroyed');
+    if (this.injected) {
+      throw new Error(
+        'PptxViewer.load() is unsupported when an engine is injected via opts.presentation; ' +
+          'the injected engine is already loaded.',
+      );
+    }
     // SC20 atomic swap: retain the previous engine locally and only tear it down
     // AFTER the new one loads successfully. A re-load thus never orphans the old
     // engine's worker + pinned WASM allocation (the leak this guards), yet a
@@ -630,7 +655,7 @@ export class PptxViewer implements ZoomableViewer {
       return;
     }
     if (enriched.kind === 'external') {
-      openExternalHyperlink(enriched.url);
+      openExternalHyperlink(enriched.url, undefined, this.hostWindow);
       return;
     }
     if (enriched.slideIndex !== undefined) void this.goToSlide(enriched.slideIndex);

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -21,6 +21,7 @@ export interface BorderEdge {
     style: string;
     color: string | null;
 }
+type CanvasViewerRenderMode = 'main' | 'worker';
 export interface Cell {
     col: number;
     row: number;
@@ -1260,6 +1261,7 @@ export class XlsxSheetViewer implements ZoomableViewer {
     private __privatePresence;
 }
 export interface XlsxSheetViewerOptions extends LoadOptions__emitterCollision1 {
+    workbook?: XlsxWorkbook;
     cellScale?: number;
     resizable?: boolean;
     zoomMin?: number;
@@ -1292,7 +1294,7 @@ export class XlsxViewer extends XlsxViewerEngine {
     constructor(container: HTMLElement, opts?: XlsxViewerOptions);
 }
 class XlsxViewerEngine implements ZoomableViewer {
-    constructor(container: HTMLElement, opts: (XlsxViewerOptions | XlsxSheetViewerOptions) | undefined, mount: XlsxViewerMount);
+    constructor(container: HTMLElement, opts: XlsxViewerOptions | XlsxSheetViewerOptions | undefined, mount: XlsxViewerMount);
     load(source: string | ArrayBuffer): Promise<void>;
     showSheet(index: number): Promise<void>;
     get sheetIndex(): number;
@@ -1332,6 +1334,7 @@ type XlsxViewerMount = {
 } | {
     readonly kind: 'sheet';
     readonly canvas: HTMLCanvasElement;
+    readonly mode: CanvasViewerRenderMode;
 };
 export interface XlsxViewerOptions extends XlsxSheetViewerOptions {
     showZoomSlider?: boolean;
@@ -1341,6 +1344,7 @@ export interface XlsxViewportOffset {
     readonly y: number;
 }
 export class XlsxWorkbook {
+    get mode(): 'main' | 'worker';
     static load(source: string | ArrayBuffer, opts?: LoadOptions): Promise<XlsxWorkbook>;
     get sheetNames(): string[];
     get sheetCount(): number;

--- a/packages/xlsx/src/internal/sheet-surface.ts
+++ b/packages/xlsx/src/internal/sheet-surface.ts
@@ -1,12 +1,17 @@
 /** DOM event adapter shared by the workbook and canvas-mounted sheet facades. */
 export class CanvasSurface {
   private readonly cleanups: Array<() => void> = [];
+  private readonly ownerDocument: Document;
+  private readonly ownerWindow: Window | null;
 
   constructor(
     readonly canvas: HTMLCanvasElement,
     readonly area: HTMLDivElement,
     readonly input: HTMLDivElement,
-  ) {}
+  ) {
+    this.ownerDocument = input.ownerDocument ?? document;
+    this.ownerWindow = this.ownerDocument.defaultView;
+  }
 
   on<K extends keyof HTMLElementEventMap>(
     type: K,
@@ -23,7 +28,7 @@ export class CanvasSurface {
     return { width: this.input.clientWidth, height: this.input.clientHeight };
   }
 
-  get dpr(): number { return window.devicePixelRatio ?? 1; }
+  get dpr(): number { return this.ownerWindow?.devicePixelRatio ?? 1; }
 
   localPoint(clientX: number, clientY: number): { x: number; y: number } {
     const rect = this.area.getBoundingClientRect();
@@ -31,8 +36,8 @@ export class CanvasSurface {
   }
 
   onDocumentKeydown(listener: (event: KeyboardEvent) => void): () => void {
-    document.addEventListener('keydown', listener);
-    const cleanup = () => document.removeEventListener('keydown', listener);
+    this.ownerDocument.addEventListener('keydown', listener);
+    const cleanup = () => this.ownerDocument.removeEventListener('keydown', listener);
     this.cleanups.push(cleanup);
     return cleanup;
   }
@@ -72,15 +77,16 @@ export class SheetOverlayHost {
     input: HTMLDivElement,
     options: SheetOverlayHostOptions,
   ) {
-    this.selection = document.createElement('div');
+    const ownerDocument = area.ownerDocument ?? document;
+    this.selection = ownerDocument.createElement('div');
     this.selection.style.cssText =
       `position:absolute;top:0;left:0;z-index:1;pointer-events:none;overflow:hidden;width:100%;height:100%;`;
 
-    this.find = document.createElement('div');
+    this.find = ownerDocument.createElement('div');
     this.find.style.cssText =
       `position:absolute;top:0;left:0;z-index:1;pointer-events:none;overflow:hidden;width:100%;height:100%;`;
 
-    this.comment = document.createElement('div');
+    this.comment = ownerDocument.createElement('div');
     this.comment.style.cssText =
       `position:absolute;z-index:3;pointer-events:none;display:none;` +
       `max-width:${options.commentMaxWidth}px;max-height:${options.commentMaxHeight}px;overflow:hidden;` +
@@ -89,7 +95,7 @@ export class SheetOverlayHost {
       `box-shadow:1px 2px 5px rgba(0,0,0,0.25);` +
       `font:12px/1.4 sans-serif;color:#222;white-space:pre-wrap;word-break:break-word;`;
 
-    this.validation = document.createElement('div');
+    this.validation = ownerDocument.createElement('div');
     this.validation.setAttribute('data-xlsx-validation-panel', '');
     this.validation.style.cssText =
       `position:absolute;z-index:4;pointer-events:auto;display:none;` +

--- a/packages/xlsx/src/internal/sheet-viewer-runtime.test.ts
+++ b/packages/xlsx/src/internal/sheet-viewer-runtime.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 import type { XlsxWorkbook } from '../workbook.js';
 import {
   SelectionController,
+  createSheetViewModel,
   SheetAcquisition,
   SheetRenderDispatcher,
   ViewportState,
 } from './sheet-viewer-runtime.js';
+import type { Worksheet } from '../types.js';
 
 function workbook() {
   const destroy = vi.fn();
@@ -47,6 +49,40 @@ describe('XLSX viewer composition roles', () => {
       'SheetAcquisition is closed',
     );
     expect(() => acquisition.install(workbook().value)).toThrow('SheetAcquisition is closed');
+  });
+
+  it('borrows an injected workbook without destroying the caller-owned resource', () => {
+    const acquisition = new SheetAcquisition();
+    const shared = workbook();
+
+    acquisition.install(shared.value, false);
+    acquisition.destroy();
+
+    expect(shared.destroy).not.toHaveBeenCalled();
+  });
+
+  it('copies only viewer-mutable worksheet state', () => {
+    const cell = { row: 1, col: 1 };
+    const source = {
+      rows: [{ index: 1, collapsed: false, cells: [cell] }],
+      rowHeights: { 1: 20 },
+      colWidths: { 1: 8 },
+      colCollapsed: { 1: false },
+    } as unknown as Worksheet;
+
+    const view = createSheetViewModel(source);
+    const viewColCollapsed = view.colCollapsed;
+    if (!viewColCollapsed) throw new Error('Expected colCollapsed projection');
+    view.rows[0].collapsed = true;
+    view.rowHeights[1] = 30;
+    view.colWidths[1] = 12;
+    viewColCollapsed[1] = true;
+
+    expect(source.rows[0].collapsed).toBe(false);
+    expect(source.rowHeights[1]).toBe(20);
+    expect(source.colWidths[1]).toBe(8);
+    expect(source.colCollapsed?.[1]).toBe(false);
+    expect(view.rows[0].cells[0]).toBe(cell);
   });
 
   it('SheetAcquisition reports terminal close when an in-flight loader rejects late', async () => {
@@ -124,6 +160,33 @@ describe('XLSX viewer composition roles', () => {
     await Promise.resolve();
     expect(calls).toEqual(['first', 'latest']);
     dispatcher.destroy();
+  });
+
+  it('schedules and cancels frames in the target canvas realm', () => {
+    let popupFrame: FrameRequestCallback | null = null;
+    const popupScheduler = {
+      requestAnimationFrame: vi.fn((callback: FrameRequestCallback) => {
+        popupFrame = callback;
+        return 41;
+      }),
+      cancelAnimationFrame: vi.fn(),
+    };
+    const render = vi.fn();
+    const dispatcher = new SheetRenderDispatcher(undefined, false, popupScheduler);
+
+    dispatcher.schedule(render);
+    expect(popupScheduler.requestAnimationFrame).toHaveBeenCalledOnce();
+    expect(render).not.toHaveBeenCalled();
+
+    (popupFrame as FrameRequestCallback | null)?.(0);
+    expect(render).toHaveBeenCalledOnce();
+
+    dispatcher.destroy();
+
+    const pending = new SheetRenderDispatcher(undefined, false, popupScheduler);
+    pending.schedule(render);
+    pending.destroy();
+    expect(popupScheduler.cancelAnimationFrame).toHaveBeenCalledWith(41);
   });
 
   it('invalidates an active worker bitmap as soon as a newer viewport is queued', async () => {

--- a/packages/xlsx/src/internal/sheet-viewer-runtime.ts
+++ b/packages/xlsx/src/internal/sheet-viewer-runtime.ts
@@ -1,3 +1,4 @@
+import type { Worksheet } from '../types.js';
 import type { XlsxWorkbook } from '../workbook.js';
 import {
   StaticCanvasRenderDispatcher,
@@ -19,14 +20,28 @@ export class SheetAcquisition {
     return await this.owner.replace(load, beforeCommit);
   }
 
-  /** Commit an already acquired workbook, closing the previously owned one. */
-  install(candidate: XlsxWorkbook): void {
-    this.owner.install(candidate);
+  /** Commit an already acquired workbook, closing the previously owned one.
+   *  Pass `owned: false` when the caller retains workbook lifecycle ownership. */
+  install(candidate: XlsxWorkbook, owned = true): void {
+    this.owner.install(candidate, owned);
   }
 
   destroy(): void {
     this.owner.close();
   }
+}
+
+/** Create the viewer-owned mutable projection of one cached worksheet.
+ * Cell/content graphs remain shared and read-only; only the maps and row flags
+ * changed by view-only resize/outline interactions are copied. */
+export function createSheetViewModel(source: Worksheet): Worksheet {
+  return {
+    ...source,
+    rows: source.rows.map((row) => ({ ...row })),
+    rowHeights: { ...source.rowHeights },
+    colWidths: { ...source.colWidths },
+    colCollapsed: source.colCollapsed ? { ...source.colCollapsed } : undefined,
+  };
 }
 
 /** Logical viewport independent of native browser scrolling. */
@@ -96,13 +111,24 @@ export class SheetRenderDispatcher {
   private activeRender = false;
   private pendingRender: (() => void | Promise<void>) | null = null;
   private readonly staticDispatcher: StaticCanvasRenderDispatcher | null;
+  private readonly frameScheduler: Pick<Window, 'requestAnimationFrame' | 'cancelAnimationFrame'> | null;
   private generation = 0;
   private destroyed = false;
 
   constructor(
     canvas?: HTMLCanvasElement,
     workerBitmapMode = false,
+    frameScheduler?: Partial<Pick<Window, 'requestAnimationFrame' | 'cancelAnimationFrame'>> | null,
   ) {
+    const scheduler = frameScheduler ?? globalThis;
+    this.frameScheduler =
+      typeof scheduler.requestAnimationFrame === 'function' &&
+      typeof scheduler.cancelAnimationFrame === 'function'
+        ? {
+            requestAnimationFrame: (callback) => scheduler.requestAnimationFrame!(callback),
+            cancelAnimationFrame: (handle) => scheduler.cancelAnimationFrame!(handle),
+          }
+        : null;
     this.staticDispatcher = canvas
       ? new StaticCanvasRenderDispatcher(canvas, workerBitmapMode)
       : null;
@@ -157,11 +183,11 @@ export class SheetRenderDispatcher {
   }
 
   private queuePendingRender(): void {
-    if (typeof requestAnimationFrame !== 'function') {
+    if (!this.frameScheduler) {
       this.startPendingRender();
       return;
     }
-    this.animationFrame = requestAnimationFrame(() => {
+    this.animationFrame = this.frameScheduler.requestAnimationFrame(() => {
       this.animationFrame = null;
       this.startPendingRender();
     });
@@ -194,8 +220,8 @@ export class SheetRenderDispatcher {
     if (this.destroyed) return;
     this.destroyed = true;
     this.pendingRender = null;
-    if (this.animationFrame !== null && typeof cancelAnimationFrame === 'function') {
-      cancelAnimationFrame(this.animationFrame);
+    if (this.animationFrame !== null && this.frameScheduler) {
+      this.frameScheduler.cancelAnimationFrame(this.animationFrame);
       this.animationFrame = null;
     }
     this.staticDispatcher?.destroy();

--- a/packages/xlsx/src/render-worker.ts
+++ b/packages/xlsx/src/render-worker.ts
@@ -28,6 +28,7 @@ import {
   type PullSessionResponse,
 } from '@silurus/ooxml-core/worker';
 import { renderWorksheetViewport } from './render-orchestrator.js';
+import { inheritSheetRenderCache } from './renderer.js';
 import { XLSX_GOOGLE_FONTS, xlsxFontPreloadNames } from './google-fonts.js';
 import { resolveSharedStringRows } from './shared-strings.js';
 import {
@@ -36,7 +37,7 @@ import {
   type WorksheetCacheUsage,
 } from './worksheet-resource-limits.js';
 import type { ParsedWorkbook, Worksheet } from './types.js';
-import { applySizeOverrides } from './worker-protocol.js';
+import { WorksheetViewProjectionCache } from './worker-protocol.js';
 import { GridGeometry } from './internal/grid-geometry.js';
 import type { RenderWorkerRequest, RenderWorkerResponse } from './worker-protocol.js';
 import { isWorksheetPullCommand, WorksheetPullWorker } from './worksheet-pull-worker.js';
@@ -60,6 +61,7 @@ let workbook: ParsedWorkbook | null = null;
  *  release — only the sequencing (fonts landed before first paint) matters. */
 let fontsLoaded: Promise<unknown> = Promise.resolve();
 const sheetCache = new Map<number, Worksheet>();
+const viewProjectionCache = new WorksheetViewProjectionCache();
 const sheetCacheUsage = new Map<number, WorksheetCacheUsage>();
 let retainedSheetUsage: WorksheetCacheUsage = {
   rows: 0, cells: 0, ownedUtf8Bytes: 0, jsonBytes: 0,
@@ -132,6 +134,10 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest | PullSessionCommand
     host.setWasmInput(decodeDataUrl(req.wasmUrl) ?? req.wasmUrl);
     return;
   }
+  if (req.type === 'releaseViewProjection') {
+    viewProjectionCache.release(req.projectionId);
+    return;
+  }
   const id = req.id;
   if (req.type === 'openSheetSession') worksheetPull.reserveOpen(req);
   try {
@@ -173,6 +179,7 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest | PullSessionCommand
       // zip path. Symmetric with XlsxWorkbook.destroy() and the docx/pptx render
       // workers (issue #781).
       sheetCache.clear();
+      viewProjectionCache.clear();
       sheetCacheUsage.clear();
       retainedSheetUsage = { rows: 0, cells: 0, ownedUtf8Bytes: 0, jsonBytes: 0 };
       dropDecodedBitmapCache(getImage);
@@ -212,25 +219,28 @@ self.onmessage = async (e: MessageEvent<RenderWorkerRequest | PullSessionCommand
       await fontsLoaded;
       const ws = sheetCache.get(req.sheetIndex);
       if (!ws) throw new Error('Worksheet is not loaded through its pull session');
-      // Converge this worker-local sheet to the main-thread model before
-      // drawing: view-only size mutations (outline collapse/expand, drag
-      // resize #567) happen on the main thread's Worksheet copy and would
-      // otherwise never reach this cache — the gutter/overlays would update
-      // while the grid bitmap stayed stale. The override map is cumulative and
-      // idempotent, so re-applying it every frame (and after a worker-side
-      // re-parse rebuilt the cache from the file) always converges.
+      // Apply view-only size mutations to a render-local projection. Multiple
+      // viewers may share this worker cache while retaining different outline
+      // and resize state, so the cached worksheet itself must stay unchanged.
       const { sizeOverrides, ...renderOpts } = req.opts;
-      applySizeOverrides(ws, sizeOverrides);
+      const projected = viewProjectionCache.resolve(
+        ws,
+        req.sheetIndex,
+        req.viewProjection,
+        sizeOverrides,
+      );
+      const renderWorksheet = projected.worksheet;
+      if (projected.created) inheritSheetRenderCache(ws, renderWorksheet);
       const maximumDigitWidth = req.layoutMetrics?.maximumDigitWidth;
       if (maximumDigitWidth !== undefined) {
         if (!Number.isFinite(maximumDigitWidth) || maximumDigitWidth <= 0) {
           throw new Error('XLSX maximum digit width must be a finite positive number');
         }
-        GridGeometry.forWorksheet(ws, maximumDigitWidth);
+        GridGeometry.forWorksheet(renderWorksheet, maximumDigitWidth);
       }
       const canvas = new OffscreenCanvas(1, 1); // orchestrator resizes it
       await renderWorksheetViewport(
-        { ws, styles: workbook.styles },
+        { ws: renderWorksheet, styles: workbook.styles },
         canvas,
         req.viewport,
         // Supply the in-worker byte loader so embedded images decode straight

--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -3021,6 +3021,13 @@ export function getSheetRenderCache(worksheet: Worksheet): SheetRenderCache {
   return entry;
 }
 
+/** Reuse viewport-independent indexes for a render-local worksheet projection.
+ * The projection may differ only in row/column sizing and outline flags; cells,
+ * merges, formatting, tables, links, comments, and sparklines remain source-owned. */
+export function inheritSheetRenderCache(source: Worksheet, projection: Worksheet): void {
+  sheetRenderCache.set(projection, getSheetRenderCache(source));
+}
+
 export function renderViewport(
   ctx: CanvasRenderingContext2D,
   worksheet: Worksheet,

--- a/packages/xlsx/src/resource-policy-wiring.test.ts
+++ b/packages/xlsx/src/resource-policy-wiring.test.ts
@@ -12,7 +12,9 @@ describe('XlsxWorkbook resource-policy wiring', () => {
     instance.sheetLoads = new Map();
     instance.imageCache = new Map();
     instance.rawParts = new BoundedRawPartCache({ maxEntries: 4, maxBytes: 1024 });
-    instance.googleFontFaces = [];
+    instance.googleFontNames = [];
+    instance.retainedFontSets = new Map();
+    instance.fontsDestroyed = false;
     const bridge = {
       request: vi.fn(async (createRequest: (id: number) => Record<string, unknown>) => {
         const request = createRequest(requests.length + 1);

--- a/packages/xlsx/src/sheet-viewer.test.ts
+++ b/packages/xlsx/src/sheet-viewer.test.ts
@@ -2,7 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { XlsxSheetViewer } from './viewer.js';
 import { XlsxWorkbook } from './workbook.js';
 import type { OoxmlResourceMetrics } from '@silurus/ooxml-core';
-import { installDom, makeContainer, makeEl, type FakeEl } from './viewer-destroy-test-dom.js';
+import type { Worksheet } from './types.js';
+import {
+  installDom,
+  makeContainer,
+  makeDocument,
+  makeEl,
+  type FakeEl,
+} from './viewer-destroy-test-dom.js';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -13,7 +20,66 @@ function descendants(root: FakeEl): FakeEl[] {
   return root.children.flatMap((child) => [child, ...descendants(child)]);
 }
 
+function worksheet(name: string): Worksheet {
+  return {
+    name,
+    rows: [],
+    colWidths: {},
+    rowHeights: {},
+    defaultColWidth: 64,
+    defaultRowHeight: 20,
+    mergeCells: [],
+    freezeRows: 0,
+    freezeCols: 0,
+    conditionalFormats: [],
+    charts: [],
+    images: [],
+    shapeGroups: [],
+  } as unknown as Worksheet;
+}
+
 describe('XlsxSheetViewer canvas mount', () => {
+  it('creates chrome, styles, and document listeners in the canvas owner window', () => {
+    const openerDocument = installDom();
+    const popupDocument = makeDocument(2);
+    const parent = makeContainer(800, 600, popupDocument);
+    const canvas = makeEl('canvas', popupDocument);
+    parent.appendChild(canvas);
+
+    const viewer = new XlsxSheetViewer(canvas as unknown as HTMLCanvasElement);
+    const mounted = descendants(parent);
+
+    expect(mounted.every((element) => element.ownerDocument === popupDocument)).toBe(true);
+    expect(popupDocument.head.querySelector('style[data-xlsx-viewer-styles]')).not.toBeNull();
+    expect(openerDocument.head.querySelector('style[data-xlsx-viewer-styles]')).toBeNull();
+    expect(popupDocument.listenerCount('keydown')).toBe(1);
+    expect(openerDocument.listenerCount('keydown')).toBe(0);
+
+    const popupWrite = vi.fn(() => Promise.resolve());
+    const openerWrite = vi.fn(() => Promise.resolve());
+    Object.assign(popupDocument.defaultView, { navigator: { clipboard: { writeText: popupWrite } } });
+    Object.assign(openerDocument.defaultView, { navigator: { clipboard: { writeText: openerWrite } } });
+    const engine = (viewer as unknown as { engine: {
+      currentWorksheet: Worksheet;
+      selectionController: { select(cell: { row: number; col: number }): void };
+      copySelection(): void;
+    } }).engine;
+    engine.currentWorksheet = {
+      ...worksheet('Popup'),
+      rows: [{
+        index: 1,
+        cells: [{ row: 1, col: 1, value: { type: 'text', text: 'popup' } }],
+      }],
+    } as unknown as Worksheet;
+    engine.selectionController.select({ row: 1, col: 1 });
+    engine.copySelection();
+    expect(popupWrite).toHaveBeenCalledWith('popup');
+    expect(openerWrite).not.toHaveBeenCalled();
+
+    viewer.destroy();
+    expect(popupDocument.listenerCount('keydown')).toBe(0);
+  });
+
   it('uses the caller canvas without constructing workbook footer chrome', () => {
     installDom();
     const parent = makeContainer();
@@ -176,5 +242,97 @@ describe('XlsxSheetViewer canvas mount', () => {
     viewer.destroy();
 
     await expect(viewer.getResourceMetrics()).resolves.toEqual(metrics);
+  });
+
+  it('borrows one loaded workbook, opens the requested sheet, and leaves workbook cleanup to the caller', async () => {
+    installDom();
+    const destroy = vi.fn();
+    const getWorksheet = vi.fn((index: number) => Promise.resolve(worksheet(`Sheet${index + 1}`)));
+    const workbook = {
+      mode: 'main',
+      sheetCount: 2,
+      sheetNames: ['Sheet1', 'Sheet2'],
+      tabColors: {} as Record<number, string>,
+      getWorksheet,
+      isHidden: () => false,
+      destroy,
+    } as unknown as XlsxWorkbook;
+    const parent = makeContainer();
+    const canvas = makeEl('canvas');
+    parent.appendChild(canvas);
+
+    const viewer = new XlsxSheetViewer(canvas as unknown as HTMLCanvasElement, { workbook });
+    await viewer.goToSheet(1);
+
+    expect(viewer.sheetIndex).toBe(1);
+    expect(getWorksheet).toHaveBeenCalledWith(1);
+    expect(getWorksheet).not.toHaveBeenCalledWith(0);
+    await expect(viewer.load(new ArrayBuffer(0))).rejects.toThrow(
+      'XlsxSheetViewer.load() is unsupported when an engine is injected',
+    );
+
+    viewer.destroy();
+    expect(destroy).not.toHaveBeenCalled();
+    expect(parent.children).toEqual([canvas]);
+  });
+
+  it('validates an injected mode conflict before mounting the caller canvas', () => {
+    installDom();
+    const parent = makeContainer();
+    const canvas = makeEl('canvas');
+    parent.appendChild(canvas);
+    const workbook = {
+      mode: 'worker',
+      sheetCount: 1,
+      sheetNames: ['Sheet1'],
+      destroy: vi.fn(),
+    } as unknown as XlsxWorkbook;
+
+    expect(() => new XlsxSheetViewer(canvas as unknown as HTMLCanvasElement, {
+      workbook,
+      mode: 'main',
+    })).toThrow("opts.mode='main' conflicts with the injected engine's mode='worker'");
+    expect(parent.children).toEqual([canvas]);
+  });
+
+  it('keeps mutable view state independent when two viewers borrow the same cached sheet', async () => {
+    installDom();
+    const source = worksheet('Shared');
+    const workbook = {
+      mode: 'main',
+      sheetCount: 1,
+      sheetNames: ['Shared'],
+      tabColors: {} as Record<number, string>,
+      getWorksheet: vi.fn().mockResolvedValue(source),
+      isHidden: () => false,
+      destroy: vi.fn(),
+    } as unknown as XlsxWorkbook;
+    const first = new XlsxSheetViewer(
+      makeEl('canvas') as unknown as HTMLCanvasElement,
+      { workbook },
+    );
+    const second = new XlsxSheetViewer(
+      makeEl('canvas') as unknown as HTMLCanvasElement,
+      { workbook },
+    );
+    await Promise.all([first.goToSheet(0), second.goToSheet(0)]);
+    const firstWorksheet = (first as unknown as {
+      engine: { currentWorksheet: Worksheet };
+    }).engine.currentWorksheet;
+    const secondWorksheet = (second as unknown as {
+      engine: { currentWorksheet: Worksheet };
+    }).engine.currentWorksheet;
+
+    firstWorksheet.rowHeights[1] = 40;
+    firstWorksheet.colWidths[1] = 16;
+
+    expect(firstWorksheet).not.toBe(secondWorksheet);
+    expect(secondWorksheet.rowHeights[1]).toBeUndefined();
+    expect(secondWorksheet.colWidths[1]).toBeUndefined();
+    expect(source.rowHeights[1]).toBeUndefined();
+    expect(source.colWidths[1]).toBeUndefined();
+
+    first.destroy();
+    second.destroy();
   });
 });

--- a/packages/xlsx/src/viewer-destroy-test-dom.ts
+++ b/packages/xlsx/src/viewer-destroy-test-dom.ts
@@ -15,6 +15,7 @@ import { vi } from 'vitest';
  */
 export interface FakeEl {
   tag: string;
+  ownerDocument: FakeDocument | null;
   textContent: string;
   title: string;
   // <input>-only fields the zoom slider sets
@@ -94,10 +95,11 @@ function queryDeep(root: FakeEl, sel: string): FakeEl | null {
   return null;
 }
 
-export function makeEl(tag: string): FakeEl {
+export function makeEl(tag: string, ownerDocument: FakeDocument | null = null): FakeEl {
   const style: Record<string, string> = {};
   const el: FakeEl = {
     tag,
+    ownerDocument,
     textContent: '',
     title: '',
     type: '',
@@ -292,6 +294,14 @@ export function makeEl(tag: string): FakeEl {
 /** A recording `document.head` that supports appendChild + querySelector. */
 export interface FakeDocument {
   head: FakeEl;
+  defaultView: {
+    devicePixelRatio: number;
+    ResizeObserver: new (callback: () => void) => {
+      observe(): void;
+      disconnect(): void;
+      unobserve(): void;
+    };
+  };
   createElement(tag: string): FakeEl;
   addEventListener(type: string, fn: (e: unknown) => void, opts?: unknown): void;
   removeEventListener(type: string, fn: (e: unknown) => void, opts?: unknown): void;
@@ -303,12 +313,19 @@ export interface FakeDocument {
 /** Install a recording document + window + ResizeObserver into globals.
  *  Returns the fake document so a test can query head / dispatch keydown.
  *  Call `vi.unstubAllGlobals()` in afterEach. */
-export function installDom(): FakeDocument {
-  const head = makeEl('head');
+export function makeDocument(devicePixelRatio = 1): FakeDocument {
   const docListeners = new Map<string, Array<(e: unknown) => void>>();
-  const doc: FakeDocument = {
-    head,
-    createElement: (t: string) => makeEl(t),
+  const ResizeObserver = class {
+    constructor(_callback: () => void) {}
+    observe(): void {}
+    disconnect(): void {}
+    unobserve(): void {}
+  };
+  let doc: FakeDocument;
+  doc = {
+    head: null as unknown as FakeEl,
+    defaultView: { devicePixelRatio, ResizeObserver },
+    createElement: (t: string) => makeEl(t, doc),
     addEventListener(type: string, fn: (e: unknown) => void) {
       const arr = docListeners.get(type) ?? [];
       arr.push(fn);
@@ -325,22 +342,25 @@ export function installDom(): FakeDocument {
       return docListeners.get(type)?.length ?? 0;
     },
   };
+  doc.head = makeEl('head', doc);
+  return doc;
+}
+
+export function installDom(): FakeDocument {
+  const doc = makeDocument();
   vi.stubGlobal('document', doc);
-  vi.stubGlobal('window', { devicePixelRatio: 1 });
-  vi.stubGlobal(
-    'ResizeObserver',
-    class {
-      observe(): void {}
-      disconnect(): void {}
-      unobserve(): void {}
-    },
-  );
+  vi.stubGlobal('window', doc.defaultView);
+  vi.stubGlobal('ResizeObserver', doc.defaultView.ResizeObserver);
   return doc;
 }
 
 /** A container FakeEl with nonzero client size so width defaults resolve. */
-export function makeContainer(clientWidth = 800, clientHeight = 600): FakeEl {
-  const c = makeEl('div');
+export function makeContainer(
+  clientWidth = 800,
+  clientHeight = 600,
+  ownerDocument: FakeDocument | null = null,
+): FakeEl {
+  const c = makeEl('div', ownerDocument);
   c.clientWidth = clientWidth;
   c.clientHeight = clientHeight;
   return c;

--- a/packages/xlsx/src/viewer-hyperlink.test.ts
+++ b/packages/xlsx/src/viewer-hyperlink.test.ts
@@ -47,6 +47,7 @@ function makeSheet(hyperlinks: Hyperlink[]): Worksheet {
 }
 
 interface Priv {
+  hostWindow: { open?: typeof window.open };
   currentWorksheet: Worksheet | null;
   scrollHost: {
     scrollTop: number;
@@ -145,9 +146,7 @@ describe('XlsxViewer IX1 default hyperlink handler (no callback)', () => {
     const ws = makeSheet([{ col: 1, row: 1, url: 'https://example.com/', location: null }]);
     const { priv } = mountViewer(ws); // no onHyperlinkClick → default handler
 
-    // openExternalHyperlink resolves `window.open`; installDom stubs a minimal
-    // window without `open`, so provide one for this assertion.
-    vi.stubGlobal('window', { devicePixelRatio: 1, open: openSpy });
+    priv.hostWindow.open = openSpy;
 
     clickAt(priv, CELL_A1_X, CELL_A1_Y);
     expect(openSpy).toHaveBeenCalledTimes(1);
@@ -158,7 +157,7 @@ describe('XlsxViewer IX1 default hyperlink handler (no callback)', () => {
     const openSpy = vi.fn();
     const ws = makeSheet([{ col: 1, row: 1, url: 'javascript:alert(1)', location: null }]);
     const { priv } = mountViewer(ws); // default handler
-    vi.stubGlobal('window', { devicePixelRatio: 1, open: openSpy });
+    priv.hostWindow.open = openSpy;
 
     clickAt(priv, CELL_A1_X, CELL_A1_Y);
     expect(openSpy).not.toHaveBeenCalled();

--- a/packages/xlsx/src/viewer-outline-worker.test.ts
+++ b/packages/xlsx/src/viewer-outline-worker.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { XlsxViewer } from './viewer.js';
 import { installDom, makeContainer, type FakeEl } from './viewer-destroy-test-dom.js';
-import { applySizeOverrides, type WireSizeOverrides } from './worker-protocol.js';
+import {
+  applySizeOverrides,
+  createSizeOverriddenWorksheet,
+  WorksheetViewProjectionCache,
+  type WireSizeOverrides,
+} from './worker-protocol.js';
+import { getSheetRenderCache, inheritSheetRenderCache } from './renderer.js';
 import type { Worksheet } from './types.js';
 import type { OutlineLayout } from './outline.js';
 
@@ -211,6 +217,58 @@ describe('applySizeOverrides wire semantics', () => {
     expect(JSON.stringify(ws.rowHeights)).toBe(snapshot);
     applySizeOverrides(ws, undefined); // absent overrides: no mutation
     expect(JSON.stringify(ws.rowHeights)).toBe(snapshot);
+  });
+
+  it('creates an isolated render projection for each viewer override set', () => {
+    const cached = outlineWorksheet();
+    const first = createSizeOverriddenWorksheet(cached, { rows: { 4: null }, cols: { 2: 12 } });
+    const second = createSizeOverriddenWorksheet(cached, { rows: { 4: 30 }, cols: { 2: 18 } });
+
+    expect(first.rowHeights[4]).toBeUndefined();
+    expect(first.colWidths[2]).toBe(12);
+    expect(second.rowHeights[4]).toBe(30);
+    expect(second.colWidths[2]).toBe(18);
+    expect(cached.rowHeights[4]).toBe(0);
+    expect(cached.colWidths[2]).toBeUndefined();
+  });
+
+  it('reuses viewport-independent render indexes across size projections', () => {
+    const cached = outlineWorksheet();
+    const first = createSizeOverriddenWorksheet(cached, { rows: { 4: null } });
+    const second = createSizeOverriddenWorksheet(cached, { cols: { 2: 18 } });
+
+    inheritSheetRenderCache(cached, first);
+    inheritSheetRenderCache(cached, second);
+
+    expect(getSheetRenderCache(first)).toBe(getSheetRenderCache(cached));
+    expect(getSheetRenderCache(second)).toBe(getSheetRenderCache(cached));
+  });
+
+  it('reuses one worksheet projection across viewport frames until its revision changes', () => {
+    const source = outlineWorksheet();
+    const cache = new WorksheetViewProjectionCache();
+    const first = cache.resolve(source, 0, { id: 7, revision: 1 }, { cols: { 2: 18 } });
+    const nextFrame = cache.resolve(source, 0, { id: 7, revision: 1 }, { cols: { 2: 18 } });
+    expect(first.created).toBe(true);
+    expect(nextFrame.created).toBe(false);
+    expect(nextFrame.worksheet).toBe(first.worksheet);
+
+    const resized = cache.resolve(source, 0, { id: 7, revision: 2 }, { cols: { 2: 21 } });
+    expect(resized.created).toBe(true);
+    expect(resized.worksheet).not.toBe(first.worksheet);
+    expect(resized.worksheet.colWidths[2]).toBe(21);
+
+    cache.release(7);
+    const reopened = cache.resolve(source, 0, { id: 7, revision: 2 }, { cols: { 2: 21 } });
+    expect(reopened.created).toBe(true);
+    expect(reopened.worksheet).not.toBe(resized.worksheet);
+    const lateFrame = cache.resolve(source, 0, { id: 7, revision: 2 }, { cols: { 2: 21 } });
+    expect(lateFrame.worksheet).not.toBe(reopened.worksheet);
+
+    cache.clear();
+    const nextWorkbook = cache.resolve(source, 0, { id: 7, revision: 2 }, { cols: { 2: 21 } });
+    const nextWorkbookFrame = cache.resolve(source, 0, { id: 7, revision: 2 }, { cols: { 2: 21 } });
+    expect(nextWorkbookFrame.worksheet).toBe(nextWorkbook.worksheet);
   });
 });
 

--- a/packages/xlsx/src/viewer-render-coalesce.test.ts
+++ b/packages/xlsx/src/viewer-render-coalesce.test.ts
@@ -14,17 +14,20 @@ afterEach(() => {
  * removes a still-queued callback. Installed into globals so the viewer's
  * `scheduleRender` coalesces against it. Returns the queue controls.
  */
-function installRaf(): { flush: () => void; queued: () => number } {
+function installRaf(target?: Record<string, unknown>): { flush: () => void; queued: () => number } {
   let nextHandle = 1;
   const cbs = new Map<number, FrameRequestCallback>();
-  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+  const requestAnimationFrame = (cb: FrameRequestCallback): number => {
     const h = nextHandle++;
     cbs.set(h, cb);
     return h;
-  });
-  vi.stubGlobal('cancelAnimationFrame', (h: number): void => {
+  };
+  const cancelAnimationFrame = (h: number): void => {
     cbs.delete(h);
-  });
+  };
+  vi.stubGlobal('requestAnimationFrame', requestAnimationFrame);
+  vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrame);
+  if (target) Object.assign(target, { requestAnimationFrame, cancelAnimationFrame });
   return {
     flush() {
       const pending = [...cbs.values()];
@@ -54,8 +57,8 @@ async function settleRenders(): Promise<void> {
  */
 describe('XlsxViewer scroll-render coalescing (C4 commit 1)', () => {
   function build() {
-    installDom();
-    const raf = installRaf();
+    const doc = installDom();
+    const raf = installRaf(doc.defaultView);
     const container = makeContainer();
     const v = new XlsxViewer(container as unknown as HTMLElement);
     // The scrollHost lives inside canvasArea (canvas, overlay, scrollHost…).

--- a/packages/xlsx/src/viewer-sheet-navigation-race.test.ts
+++ b/packages/xlsx/src/viewer-sheet-navigation-race.test.ts
@@ -72,7 +72,8 @@ describe('XlsxViewer sheet acquisition generation', () => {
     await first;
 
     expect(engine.currentSheet).toBe(1);
-    expect(engine.currentWorksheet).toBe(b);
+    expect(engine.currentWorksheet).not.toBe(b);
+    expect(engine.currentWorksheet).toMatchObject(b);
     expect(onSheetChange).toHaveBeenCalledOnce();
     expect(onSheetChange).toHaveBeenCalledWith(1, 2);
     viewer.destroy();

--- a/packages/xlsx/src/viewer-worker-stale-frame.test.ts
+++ b/packages/xlsx/src/viewer-worker-stale-frame.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { XlsxViewer } from './viewer.js';
 import { installDom, makeContainer, type FakeEl } from './viewer-destroy-test-dom.js';
 import type { Worksheet } from './types.js';
-import { extractViewerLayoutMetrics } from './worker-protocol.js';
+import { extractViewerRenderContext } from './worker-protocol.js';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -111,7 +111,7 @@ describe('XlsxViewer worker-mode stale-frame drop (C4 commit 3)', () => {
     const pending = render();
     const call = renderViewportToBitmap.mock.calls[0] as unknown[] | undefined;
     const options = call?.[2];
-    expect(extractViewerLayoutMetrics(options as never).layoutMetrics).toEqual({
+    expect(extractViewerRenderContext(options as never).layoutMetrics).toEqual({
       maximumDigitWidth: 13,
     });
     inflight[0].resolve(fakeBitmap());

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -1,8 +1,16 @@
-import { XlsxWorkbook } from './workbook.js';
+import {
+  XlsxWorkbook,
+  releaseXlsxViewerProjection,
+  retainXlsxViewerFonts,
+} from './workbook.js';
 import type { Hyperlink, ViewportRange, Worksheet, XlsxComment } from './types.js';
 import type { FindHighlightColors, HyperlinkTarget, LoadOptions, FindMatch, FindMatchesOptions, OoxmlResourceMetrics, ZoomableViewer } from '@silurus/ooxml-core';
 import { nextVisibleIndex, resolveVisibleIndex, countVisible, zoomStepScale, anchoredZoomOffset, openExternalHyperlink, nextZoomStep, prevZoomStep, fitScale } from '@silurus/ooxml-core';
-import { CallerCanvasMount } from '@silurus/ooxml-core/internal/canvas-viewer-mechanics';
+import {
+  CallerCanvasMount,
+  resolveCanvasViewerMode,
+  type CanvasViewerRenderMode,
+} from '@silurus/ooxml-core/internal/canvas-viewer-mechanics';
 import {
   HEADER_W,
   HEADER_H,
@@ -19,7 +27,7 @@ import {
   computeValidationPanelPosition,
   type ResolvedList,
 } from './validation-list.js';
-import { withViewerLayoutMetrics, type WireSizeOverrides } from './worker-protocol.js';
+import { withViewerRenderContext, type WireSizeOverrides } from './worker-protocol.js';
 import {
   buildOutlineLayout,
   toggleGroupHidden,
@@ -40,6 +48,7 @@ import {
   SheetRenderDispatcher,
   SelectionController,
   ViewportState,
+  createSheetViewModel,
 } from './internal/sheet-viewer-runtime.js';
 import { CanvasSurface, SheetOverlayHost } from './internal/sheet-surface.js';
 import { withXlsxRenderCommitGuard } from './render-orchestrator.js';
@@ -73,6 +82,7 @@ const TAB_NAV_W = HEADER_W;
 // space so it is offset from the row-header boundary by the same margin that
 // separates tabs from each other.
 const TAB_GAP = 1;
+let nextViewerProjectionId = 1;
 
 /** How {@link XlsxViewer} presents hidden sheets (`<sheet state>`, §18.2.19). */
 export type HiddenSheetMode = 'show' | 'skip' | 'dim';
@@ -103,24 +113,32 @@ const VIEWER_STYLE_CSS =
   `.xlsx-zoom-slider::-moz-range-thumb{width:12px;height:12px;border:none;border-radius:50%;background:#808080;cursor:pointer;}`;
 
 /**
- * Inject the shared viewer stylesheet into `document.head` exactly once for the
- * whole module, keyed by the {@link VIEWER_STYLE_ATTR} marker. Earlier this ran
+ * Inject the shared viewer stylesheet into one owning document exactly once,
+ * keyed by the {@link VIEWER_STYLE_ATTR} marker. Earlier this ran
  * per-instance, so every mount/unmount cycle leaked another `<style>` into the
  * head (unbounded growth). It is deliberately NEVER removed on destroy: the CSS
  * is a class constant that any still-live viewer may depend on, and a single
  * leftover `<style>` after the last teardown is harmless (a fixed, bounded cost,
  * not a per-instance leak).
  */
-function ensureViewerStyleInjected(): void {
-  if (typeof document === 'undefined' || !document.head) return;
-  if (document.head.querySelector(`style[${VIEWER_STYLE_ATTR}]`)) return;
-  const style = document.createElement('style');
+function ensureViewerStyleInjected(ownerDocument: Document): void {
+  if (!ownerDocument.head) return;
+  if (ownerDocument.head.querySelector(`style[${VIEWER_STYLE_ATTR}]`)) return;
+  const style = ownerDocument.createElement('style');
   style.setAttribute(VIEWER_STYLE_ATTR, '');
   style.textContent = VIEWER_STYLE_CSS;
-  document.head.appendChild(style);
+  ownerDocument.head.appendChild(style);
 }
 
 export interface XlsxSheetViewerOptions extends LoadOptions {
+  /**
+   * Borrow an already-loaded workbook, matching `document` / `presentation`
+   * injection on the DOCX/PPTX scroll viewers. The workbook's mode is
+   * authoritative, `load()` is unsupported, and `destroy()` leaves the
+   * caller-owned workbook open. Await `goToSheet()` when first-paint completion
+   * matters.
+   */
+  workbook?: XlsxWorkbook;
   /** Scale factor for cell/header dimensions (default 1). 0.5 = half size. */
   cellScale?: number;
   /**
@@ -327,9 +345,18 @@ export function findHighlightOverlayStyle(
 
 type XlsxViewerMount =
   | { readonly kind: 'composite' }
-  | { readonly kind: 'sheet'; readonly canvas: HTMLCanvasElement };
+  | {
+      readonly kind: 'sheet';
+      readonly canvas: HTMLCanvasElement;
+      /** Resolved before the caller-owned canvas is reparented. */
+      readonly mode: CanvasViewerRenderMode;
+    };
 
 class XlsxViewerEngine implements ZoomableViewer {
+  /** DOM realm of the mount target. Sheet canvases may belong to a same-origin
+   * popup rather than the Window that created the viewer instance. */
+  private readonly hostDocument: Document;
+  private readonly hostWindow: Window & typeof globalThis;
   private readonly acquisition = new SheetAcquisition();
   private readonly viewport: ViewportState;
   private readonly renderDispatcher: SheetRenderDispatcher;
@@ -368,19 +395,21 @@ class XlsxViewerEngine implements ZoomableViewer {
    * Per-sheet cumulative record of every view-only size mutation (outline
    * collapse/expand, drag-to-resize #567), keyed by sheet index. Value = the
    * band's current model size, or `null` when the model has no entry (default
-   * size). Serialized as {@link WireSizeOverrides} with every worker
-   * `renderViewport` so the worker's local sheet cache converges to the
-   * main-thread model — without it the worker keeps drawing the file's
-   * original sizes and the grid bitmap goes stale under the (up-to-date)
-   * gutter and overlays. Entries are updated in place and never removed
-   * (idempotent re-application); the whole store resets when a new workbook
-   * loads. Main mode never reads it (the main renderer draws from the mutated
-   * model directly).
+   * size). Serialized as {@link WireSizeOverrides} with every render so both
+   * modes draw from a render-local projection matching this viewer, while the
+   * workbook cache remains immutable for sibling viewers. Entries are updated
+   * in place and never removed; the whole store resets with a new workbook.
    */
   private sizeOverrideStore = new Map<
     number,
-    { rows: Map<number, number | null>; cols: Map<number, number | null> }
+    {
+      rows: Map<number, number | null>;
+      cols: Map<number, number | null>;
+      revision: number;
+      wire?: WireSizeOverrides;
+    }
   >();
+  private readonly projectionId = nextViewerProjectionId++;
   private canvasArea: HTMLDivElement;
   private scrollHost: HTMLDivElement;
   private spacer: HTMLDivElement;
@@ -404,12 +433,22 @@ class XlsxViewerEngine implements ZoomableViewer {
   /** Atomically commits an asynchronously acquired worksheet with its index.
    * Incremented by every navigation and teardown so late acquisitions are no-ops. */
   private sheetRequestGeneration = 0;
+  private fontBindingGeneration = 0;
+  private fontBinding: Readonly<{ workbook: XlsxWorkbook; release: () => void }> | null = null;
   private _hiddenSheetMode: HiddenSheetMode;
   private currentWorksheet: Worksheet | null = null;
+  /** Viewer-owned projections of workbook-cached worksheets. Only view-mutable
+   * size/outline state is copied; immutable cell/content graphs stay shared. */
+  private sheetViews = new Map<number, Worksheet>();
   private opts: XlsxViewerOptions;
   private readonly _mountKind: XlsxViewerMount['kind'];
   /** 'main' renders on this thread; 'worker' paints worker-produced bitmaps. */
   private readonly _mode: 'main' | 'worker';
+  private _injected = false;
+  /** Workbook for which viewer-local state has been initialized. A borrowed
+   * sheet mount defers this work until the caller's first goToSheet(), so it
+   * never materializes an unrelated first sheet as a constructor side effect. */
+  private preparedWorkbook: XlsxWorkbook | null = null;
   /** Set by {@link destroy} (first line). Guards {@link _reportRenderError} so a
    *  render rejection that lands AFTER teardown is swallowed rather than surfaced
    *  to an `onError` / `console.error` on a dead viewer — parity with the scroll
@@ -532,13 +571,22 @@ class XlsxViewerEngine implements ZoomableViewer {
     opts: XlsxViewerOptions | XlsxSheetViewerOptions = {},
     mount: XlsxViewerMount,
   ) {
+    this.hostDocument =
+      (mount.kind === 'sheet' ? mount.canvas.ownerDocument : container.ownerDocument) ?? document;
+    const hostWindow = this.hostDocument.defaultView;
+    if (!hostWindow) throw new Error('XlsxViewer requires a document with an active Window');
+    this.hostWindow = hostWindow;
     this.opts = opts;
     this._mountKind = mount.kind;
-    this._mode = opts.mode ?? 'main';
+    const injectedWorkbook = opts.workbook;
+    this._injected = injectedWorkbook !== undefined;
+    this._mode = mount.kind === 'sheet'
+      ? mount.mode
+      : resolveCanvasViewerMode('XlsxViewer', opts.mode, injectedWorkbook);
     this._hiddenSheetMode = opts.hiddenSheetMode ?? 'show';
     this.viewport = new ViewportState(opts.cellScale ?? 1);
 
-    this.wrapper = document.createElement('div');
+    this.wrapper = this.hostDocument.createElement('div');
     this.wrapper.style.cssText =
       `position:relative;width:100%;height:100%;` +
       `background:${mount.kind === 'composite' ? '#fff' : 'transparent'};` +
@@ -548,7 +596,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     // (XL4) sit at its top / left edges and {@link canvasArea} is inset by the
     // gutter extents. With no outlining both extents are 0, so canvasArea covers
     // the whole region exactly as before (byte-identical layout).
-    this.gridRegion = document.createElement('div');
+    this.gridRegion = this.hostDocument.createElement('div');
     this.gridRegion.style.cssText = `position:relative;flex:1;min-height:0;overflow:hidden;`;
 
     // Outline gutter canvases. Absolutely positioned inside gridRegion; sized /
@@ -557,30 +605,34 @@ class XlsxViewerEngine implements ZoomableViewer {
     // thread even in worker mode (cheap chrome, independent of the grid bitmap).
     const gutterStyle =
       `position:absolute;top:0;left:0;z-index:3;display:none;background:#f5f5f5;`;
-    this.cornerGutter = document.createElement('canvas');
+    this.cornerGutter = this.hostDocument.createElement('canvas');
     this.cornerGutter.style.cssText = gutterStyle;
     this.cornerGutter.setAttribute('data-xlsx-outline', 'corner');
-    this.colGutter = document.createElement('canvas');
+    this.colGutter = this.hostDocument.createElement('canvas');
     this.colGutter.style.cssText = gutterStyle;
     this.colGutter.setAttribute('data-xlsx-outline', 'col');
-    this.rowGutter = document.createElement('canvas');
+    this.rowGutter = this.hostDocument.createElement('canvas');
     this.rowGutter.style.cssText = gutterStyle;
     this.rowGutter.setAttribute('data-xlsx-outline', 'row');
 
-    this.canvasArea = document.createElement('div');
+    this.canvasArea = this.hostDocument.createElement('div');
     this.canvasArea.style.cssText = `position:absolute;inset:0;overflow:hidden;`;
 
-    this.canvas = mount.kind === 'sheet' ? mount.canvas : document.createElement('canvas');
+    this.canvas = mount.kind === 'sheet' ? mount.canvas : this.hostDocument.createElement('canvas');
     this.canvas.style.cssText = `position:absolute;top:0;left:0;z-index:0;display:block;`;
-    this.renderDispatcher = new SheetRenderDispatcher(this.canvas, this._mode === 'worker');
+    this.renderDispatcher = new SheetRenderDispatcher(
+      this.canvas,
+      this._mode === 'worker',
+      this.hostWindow,
+    );
 
-    this.scrollHost = document.createElement('div');
+    this.scrollHost = this.hostDocument.createElement('div');
     this.scrollHost.setAttribute('data-xlsx-viewport-input', mount.kind);
     this.scrollHost.style.cssText =
       `position:absolute;inset:0;` +
       `overflow:${mount.kind === 'composite' ? 'auto' : 'clip'};` +
       `z-index:2;background:transparent;`;
-    this.spacer = document.createElement('div');
+    this.spacer = this.hostDocument.createElement('div');
     this.spacer.style.cssText = `position:absolute;top:0;left:0;pointer-events:none;`;
     if (mount.kind === 'composite') this.scrollHost.appendChild(this.spacer);
     this.surface = new CanvasSurface(this.canvas, this.canvasArea, this.scrollHost);
@@ -597,10 +649,10 @@ class XlsxViewerEngine implements ZoomableViewer {
     // Inject the shared viewer stylesheet once per module (idempotent). Both
     // mounts use it: the composite footer hides its tab-strip scrollbar and the
     // canvas mount hides native sheet scrollbars while retaining pan input.
-    ensureViewerStyleInjected();
+    ensureViewerStyleInjected(this.hostDocument);
 
     if (mount.kind === 'composite') {
-      this.tabBar = document.createElement('div');
+      this.tabBar = this.hostDocument.createElement('div');
       this.tabBar.style.cssText =
         `display:flex;align-items:flex-end;height:${TAB_BAR_H}px;flex-shrink:0;` +
         `background:#f0f0f0;border-top:1px solid #c8ccd0;`;
@@ -614,7 +666,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
       // Keep the two-button footer control at the row-header width from the 100%
       // view. It is viewer chrome, so workbook zoom must not resize or shift it.
-      const navGroup = document.createElement('div');
+      const navGroup = this.hostDocument.createElement('div');
       navGroup.style.cssText =
         `display:flex;flex-shrink:0;width:${TAB_NAV_W}px;height:100%;`;
       navGroup.appendChild(this.navPrev);
@@ -622,7 +674,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
       // The scrollable strip that actually holds the sheet tabs. position:relative
       // so each tab's offsetLeft is measured against the strip's scroll content.
-      this.tabStrip = document.createElement('div');
+      this.tabStrip = this.hostDocument.createElement('div');
       // Keep the scroll host itself LTR so scrollLeft is consistently 0..max in
       // every browser. The inner tabList owns visual LTR/RTL ordering.
       this.tabStrip.style.cssText =
@@ -633,7 +685,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
       // width:max-content preserves overflow scrolling; min-width:100% makes a
       // short RTL tab row fill the strip so row-reverse can right-align it.
-      this.tabList = document.createElement('div');
+      this.tabList = this.hostDocument.createElement('div');
       this.tabList.style.cssText =
         `display:flex;align-items:flex-end;height:100%;` +
         `gap:${TAB_GAP}px;box-sizing:border-box;`;
@@ -701,7 +753,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     // size change shifts maxScrollLeft, and for RTL sheets the native
     // scrollLeft must be re-derived from the start-anchored position or the
     // view drifts (or, after a hidden mount, stays stranded at the far end).
-    this.resizeObserver = new ResizeObserver(() => {
+    const resizeObserver = new this.hostWindow.ResizeObserver(() => {
       const offset = { x: this.viewport.x, y: this.viewport.y };
       this.viewport.setViewportSize(this.scrollHost.clientWidth, this.scrollHost.clientHeight);
       this.setViewportLeft(offset.x);
@@ -719,7 +771,8 @@ class XlsxViewerEngine implements ZoomableViewer {
       this.updateFindOverlay();
       this.updateNavButtons();
     });
-    this.resizeObserver.observe(this.gridRegion);
+    resizeObserver.observe(this.gridRegion);
+    this.resizeObserver = resizeObserver;
 
     this.setupSelectionEvents();
 
@@ -728,6 +781,14 @@ class XlsxViewerEngine implements ZoomableViewer {
       (sheet) => this.wb?.sheetNames[sheet] ?? '',
       (sheet) => this._collectSheetCells(sheet),
     );
+
+    if (injectedWorkbook) {
+      this.acquisition.install(injectedWorkbook, false);
+      if (this._mountKind === 'composite') {
+        this.activateWorkbook(injectedWorkbook).catch((error) => this._reportRenderError(error));
+      }
+    }
+
   }
 
   /** Every non-empty cell of a sheet with its rendered display text (IX2 find
@@ -762,6 +823,12 @@ class XlsxViewerEngine implements ZoomableViewer {
    */
   async load(source: string | ArrayBuffer): Promise<void> {
     this.assertOpen();
+    if (this._injected) {
+      throw new Error(
+        `${this._mountKind === 'sheet' ? 'XlsxSheetViewer' : 'XlsxViewer'}.load() is unsupported ` +
+          'when an engine is injected via opts.workbook; the injected engine is already loaded.',
+      );
+    }
     // SC20 atomic swap: retain the previous workbook locally and only tear it down
     // AFTER the new one loads successfully. A re-load thus never orphans the old
     // workbook's worker + pinned WASM allocation (the leak this guards), yet a
@@ -787,16 +854,11 @@ class XlsxViewerEngine implements ZoomableViewer {
           this.renderDispatcher.begin();
           this._find.invalidate();
           this.hideValidationPanel();
+          this.releaseHostFonts();
         });
       if (!wb) return;
       if (this._destroyed) throw this.destroyedError();
-      // A new workbook invalidates any prior find state and every accumulated
-      // view-only size override (sheet indices now name different sheets).
-      this._find.invalidate();
-      this.sizeOverrideStore.clear();
-      this.buildTabs();
-      this.opts.onReady?.(wb.sheetNames);
-      await this.showSheet(this._initialSheet());
+      await this.activateWorkbook(wb);
     } catch (err) {
       if (this._destroyed) throw this.destroyedError();
       const e = err instanceof Error ? err : new Error(String(err));
@@ -806,6 +868,56 @@ class XlsxViewerEngine implements ZoomableViewer {
       }
       throw e;
     }
+  }
+
+  /** Bind the current acquisition to its independent viewer state. Parsing,
+   *  worksheet materialization, archive access, and caches remain workbook-owned. */
+  private async activateWorkbook(workbook: XlsxWorkbook, sheetIndex?: number): Promise<void> {
+    if (!this.prepareWorkbook(workbook)) return;
+    await this.showSheet(sheetIndex ?? this._initialSheet());
+  }
+
+  private async ensureHostFonts(workbook: XlsxWorkbook): Promise<boolean> {
+    if (this.fontBinding?.workbook === workbook) return true;
+    const retain = workbook[retainXlsxViewerFonts];
+    // Structural test doubles and pre-feature adapters have no font hook. A
+    // real XlsxWorkbook always does; absence means there is nothing to retain.
+    if (typeof retain !== 'function') return true;
+    const generation = ++this.fontBindingGeneration;
+    const release = await retain.call(workbook, this.hostDocument);
+    if (
+      this._destroyed ||
+      generation !== this.fontBindingGeneration ||
+      this.wb !== workbook
+    ) {
+      release();
+      return false;
+    }
+    this.fontBinding?.release();
+    this.fontBinding = { workbook, release };
+    return true;
+  }
+
+  private releaseHostFonts(): void {
+    this.fontBindingGeneration++;
+    this.fontBinding?.release();
+    this.fontBinding = null;
+  }
+
+  /** Initialize the viewer-local projection state without choosing a sheet.
+   * This split lets a borrowed sheet viewer make goToSheet(index) its first
+   * worksheet materialization, while the composite viewer can still open its
+   * normal initial sheet automatically. */
+  private prepareWorkbook(workbook: XlsxWorkbook): boolean {
+    if (this._destroyed || this.wb !== workbook) return false;
+    if (this.preparedWorkbook === workbook) return true;
+    this._find.invalidate();
+    this.sizeOverrideStore.clear();
+    this.sheetViews.clear();
+    this.buildTabs();
+    this.preparedWorkbook = workbook;
+    this.opts.onReady?.(workbook.sheetNames);
+    return true;
   }
 
   /** The loaded workbook, or throws if {@link load} has not completed. */
@@ -831,7 +943,10 @@ class XlsxViewerEngine implements ZoomableViewer {
     const workbook = this.workbook;
     let worksheet: Worksheet;
     try {
-      worksheet = await workbook.getWorksheet(index);
+      if (!await this.ensureHostFonts(workbook)) return;
+      const source = await workbook.getWorksheet(index);
+      worksheet = this.sheetViews.get(index) ?? createSheetViewModel(source);
+      this.sheetViews.set(index, worksheet);
     } catch (error) {
       if (!this.isCurrentSheetRequest(generation, workbook)) return;
       throw error;
@@ -1261,36 +1376,46 @@ class XlsxViewerEngine implements ZoomableViewer {
         }
       }
     }
-    // Mirror the post-mutation model value into the worker override channel so
-    // a worker-mode grid actually re-lays the band (main mode ignores this).
+    // Mirror the post-mutation model value into the render override channel so
+    // both modes can draw this viewer's projection without mutating the shared
+    // workbook cache.
     this.recordSizeOverride(axis, index);
   }
 
   /** Record band `index`'s CURRENT model size (or `null` = no entry) in the
-   *  per-sheet override store. Called after every view-only size mutation —
-   *  outline hide/show above and drag-to-resize (#567) — so worker renders
-   *  converge to the main model. */
+   *  per-sheet override store. Called after every view-only size mutation so
+   *  both render modes receive this viewer's independent projection. */
   private recordSizeOverride(axis: OutlineAxis, index: number): void {
     const ws = this.currentWorksheet;
     if (!ws) return;
     let entry = this.sizeOverrideStore.get(this.currentSheet);
     if (!entry) {
-      entry = { rows: new Map(), cols: new Map() };
+      entry = { rows: new Map(), cols: new Map(), revision: 0 };
       this.sizeOverrideStore.set(this.currentSheet, entry);
     }
-    if (axis === 'row') entry.rows.set(index, ws.rowHeights[index] ?? null);
-    else entry.cols.set(index, ws.colWidths[index] ?? null);
+    const target = axis === 'row' ? entry.rows : entry.cols;
+    const value = axis === 'row' ? ws.rowHeights[index] ?? null : ws.colWidths[index] ?? null;
+    if (target.get(index) === value && target.has(index)) return;
+    target.set(index, value);
+    entry.revision++;
+    entry.wire = undefined;
   }
 
   /** The current sheet's override store serialized for the wire, or undefined
    *  when nothing has been mutated (keeps the request payload unchanged). */
-  private wireSizeOverrides(): WireSizeOverrides | undefined {
+  private wireSizeOverrides(): Readonly<{
+    overrides: WireSizeOverrides;
+    revision: number;
+  }> | undefined {
     const entry = this.sizeOverrideStore.get(this.currentSheet);
     if (!entry || (entry.rows.size === 0 && entry.cols.size === 0)) return undefined;
-    const o: WireSizeOverrides = {};
-    if (entry.rows.size > 0) o.rows = Object.fromEntries(entry.rows);
-    if (entry.cols.size > 0) o.cols = Object.fromEntries(entry.cols);
-    return o;
+    if (!entry.wire) {
+      const wire: WireSizeOverrides = {};
+      if (entry.rows.size > 0) wire.rows = Object.fromEntries(entry.rows);
+      if (entry.cols.size > 0) wire.cols = Object.fromEntries(entry.cols);
+      entry.wire = wire;
+    }
+    return { overrides: entry.wire, revision: entry.revision };
   }
 
   /** Update the `collapsed` flag on a band's model entry so the outline rebuild
@@ -1462,6 +1587,8 @@ class XlsxViewerEngine implements ZoomableViewer {
    */
   async goToSheet(index: number): Promise<void> {
     if (this.sheetCount === 0) return;
+    const workbook = this.workbook;
+    if (!this.prepareWorkbook(workbook)) return;
     await this.showSheet(Math.max(0, Math.min(index, this.sheetCount - 1)));
   }
 
@@ -1847,7 +1974,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       for (let c = c1; c <= c2; c++) cols.push(cellMap.get(`${r}:${c}`) ?? '');
       lines.push(cols.join('\t'));
     }
-    navigator.clipboard.writeText(lines.join('\n')).catch(() => undefined);
+    this.hostWindow.navigator.clipboard?.writeText(lines.join('\n')).catch(() => undefined);
   }
 
   private updateSelectionOverlay(): void {
@@ -1935,7 +2062,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     const { border, background } = selectionOverlayStyle(
       this.opts.selectionColor ?? DEFAULT_SELECTION_COLOR,
     );
-    const box = document.createElement('div');
+    const box = this.hostDocument.createElement('div');
     box.style.cssText =
       `position:absolute;` +
       `left:${screenLeft}px;top:${y}px;width:${w}px;height:${h}px;` +
@@ -1989,7 +2116,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
     const screenLeft = this.screenX(btnLogicalX, side);
 
-    const btn = document.createElement('div');
+    const btn = this.hostDocument.createElement('div');
     btn.setAttribute('data-xlsx-validation-dropdown', '');
     btn.style.cssText =
       `position:absolute;` +
@@ -2063,7 +2190,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       if (w <= 0 || h <= 0) continue;
       const screenLeft = this.screenX(x, w);
       const { border, background } = hl.active ? active : other;
-      const box = document.createElement('div');
+      const box = this.hostDocument.createElement('div');
       box.style.cssText =
         `position:absolute;` +
         `left:${screenLeft}px;top:${y}px;width:${w}px;height:${h}px;` +
@@ -2238,7 +2365,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     if (resolved.kind === 'formula' || resolved.values.length === 0) {
       // Unresolved operand (named range / complex formula) or an empty range:
       // disclose the formula / a placeholder rather than showing a blank box.
-      const note = document.createElement('div');
+      const note = this.hostDocument.createElement('div');
       note.style.cssText = 'padding:4px 8px;color:#666;font-style:italic;white-space:pre-wrap;word-break:break-word;';
       note.textContent =
         resolved.kind === 'formula'
@@ -2248,7 +2375,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       return;
     }
     for (const value of resolved.values) {
-      const item = document.createElement('div');
+      const item = this.hostDocument.createElement('div');
       item.setAttribute('data-xlsx-validation-item', '');
       item.style.cssText = 'padding:3px 8px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:default;';
       item.textContent = value;
@@ -2302,7 +2429,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       this.hideValidationPanel();
     };
     // Capture phase so we see the click before it mutates selection.
-    document.addEventListener('pointerdown', this.validationOutsideHandler, true);
+    this.hostDocument.addEventListener('pointerdown', this.validationOutsideHandler, true);
   }
 
   /** Hide the panel and detach its outside-click listener. Called on re-click,
@@ -2312,7 +2439,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     this.overlayHost.hideValidation();
     this.validationPanelKey = null;
     if (this.validationOutsideHandler) {
-      document.removeEventListener('pointerdown', this.validationOutsideHandler, true);
+      this.hostDocument.removeEventListener('pointerdown', this.validationOutsideHandler, true);
       this.validationOutsideHandler = null;
     }
   }
@@ -2382,7 +2509,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     // scheme allowlist (a blocked scheme like `javascript:` is a no-op, not a
     // navigation). Internal: best-effort sheet navigation, below.
     if (target.kind === 'external') {
-      openExternalHyperlink(target.url);
+      openExternalHyperlink(target.url, undefined, this.hostWindow);
     } else {
       this.navigateInternalHyperlink(target.ref);
     }
@@ -2448,12 +2575,12 @@ class XlsxViewerEngine implements ZoomableViewer {
     // from comment text.
     this.commentPopup.textContent = '';
     if (comment.author) {
-      const authorEl = document.createElement('div');
+      const authorEl = this.hostDocument.createElement('div');
       authorEl.style.cssText = 'font-weight:bold;margin-bottom:2px;';
       authorEl.textContent = comment.author;
       this.commentPopup.appendChild(authorEl);
     }
-    const bodyEl = document.createElement('div');
+    const bodyEl = this.hostDocument.createElement('div');
     bodyEl.textContent = comment.text;
     this.commentPopup.appendChild(bodyEl);
 
@@ -2830,7 +2957,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     this.tabs = [];
     this.tabColors = this.workbook.tabColors;
     this.workbook.sheetNames.forEach((name, i) => {
-      const btn = document.createElement('button');
+      const btn = this.hostDocument.createElement('button');
       btn.textContent = name;
       btn.title = name;
       btn.style.cssText = this.tabCss(i, false);
@@ -2842,7 +2969,7 @@ class XlsxViewerEngine implements ZoomableViewer {
   }
 
   private makeNavButton(glyph: string, label: string, onClick: () => void): HTMLButtonElement {
-    const btn = document.createElement('button');
+    const btn = this.hostDocument.createElement('button');
     btn.textContent = glyph;
     btn.setAttribute('aria-label', label);
     btn.title = label;
@@ -2983,7 +3110,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     const zoomMax = this.opts.zoomMax ?? 4;
     const cur = this.viewport.scale;
 
-    const wrap = document.createElement('div');
+    const wrap = this.hostDocument.createElement('div');
     wrap.style.cssText =
       `display:flex;align-items:center;flex-shrink:0;gap:2px;` +
       `padding:0 10px;height:100%;color:#555;font-size:12px;user-select:none;`;
@@ -2993,7 +3120,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     // the ZoomableViewer contract land on identical scales (issue #842).
     // Pre-IX9 these stepped ±0.1 linearly.
     const mkBtn = (glyph: string, label: string, step: () => void): HTMLButtonElement => {
-      const b = document.createElement('button');
+      const b = this.hostDocument.createElement('button');
       b.type = 'button';
       b.textContent = glyph;
       b.setAttribute('aria-label', label);
@@ -3009,7 +3136,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     // to 100% so each half is its own linear segment (zoomMin→1 on the left,
     // 1→zoomMax on the right), mirroring Excel's status-bar zoom where 100% sits
     // in the middle even though the range (10%–400%) is asymmetric.
-    const slider = document.createElement('input');
+    const slider = this.hostDocument.createElement('input');
     slider.type = 'range';
     slider.min = '0';
     slider.max = '100';
@@ -3023,7 +3150,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       this.setScale(this.zoomPosToScale(Number(slider.value), zoomMin, zoomMax)),
     );
 
-    const label = document.createElement('span');
+    const label = this.hostDocument.createElement('span');
     label.textContent = `${Math.round(cur * 100)}%`;
     label.style.cssText = `min-width:42px;margin-left:6px;text-align:right;font-variant-numeric:tabular-nums;`;
 
@@ -3343,21 +3470,28 @@ class XlsxViewerEngine implements ZoomableViewer {
       selectedColRange,
     };
 
+    const sizeProjection = this.wireSizeOverrides();
+    const viewerRenderOpts = withViewerRenderContext(
+      sizeProjection ? { ...renderOpts, sizeOverrides: sizeProjection.overrides } : renderOpts,
+      getGridGeometryForWorksheet(ws).maximumDigitWidth,
+      {
+        worksheet: ws,
+        projection: sizeProjection
+          ? { id: this.projectionId, revision: sizeProjection.revision }
+          : undefined,
+      },
+    );
+
     if (this._mode === 'worker') {
       // Render the viewport off the main thread and paint the returned bitmap.
       // The selection overlay (geometry-based, from getCellRect) is unaffected.
       // Attach the cumulative view-only size overrides (outline collapse/
       // expand, drag resize) so the worker re-lays the mutated bands — its
       // local sheet cache never sees main-thread model writes on its own.
-      const sizeOverrides = this.wireSizeOverrides();
-      const workerOpts = withViewerLayoutMetrics(
-        sizeOverrides ? { ...renderOpts, sizeOverrides } : renderOpts,
-        getGridGeometryForWorksheet(ws).maximumDigitWidth,
-      );
       const bmp = await this.workbook.renderViewportToBitmap(
         this.currentSheet,
         viewport,
-        workerOpts,
+        viewerRenderOpts,
       );
       if (!this.renderDispatcher.commitBitmap(seq, bmp, w, h)) return;
     } else {
@@ -3365,7 +3499,7 @@ class XlsxViewerEngine implements ZoomableViewer {
         this.canvas,
         this.currentSheet,
         viewport,
-        withXlsxRenderCommitGuard(renderOpts, () =>
+        withXlsxRenderCommitGuard(viewerRenderOpts, () =>
           !this._destroyed && this.renderDispatcher.isCurrent(seq),
         ),
       );
@@ -3409,7 +3543,7 @@ class XlsxViewerEngine implements ZoomableViewer {
    * explicit removal: removing the subtree makes them unreachable and eligible
    * for GC. Safe to call more than once.
    *
-   * NOTE: the shared `<style>` in `document.head` is intentionally NOT removed —
+   * NOTE: the shared `<style>` in the owning document is intentionally NOT removed —
    * it is a class constant that any still-live viewer may depend on, and one
    * leftover sheet is a bounded, harmless cost (see {@link ensureViewerStyleInjected}).
    */
@@ -3429,6 +3563,11 @@ class XlsxViewerEngine implements ZoomableViewer {
     // findNext()/findPrev() after teardown returns null instead of a match
     // pointing into a dead viewer (same fix as DocxViewer/PptxViewer.destroy).
     this._find.invalidate();
+    this.releaseHostFonts();
+    const releaseProjection = this.wb?.[releaseXlsxViewerProjection];
+    if (typeof releaseProjection === 'function') {
+      releaseProjection.call(this.wb, this.projectionId);
+    }
     this.acquisition.destroy();
     // Remove the whole UI subtree so the container is empty again. This also
     // detaches every listener bound to elements within it (scrollHost pointer/
@@ -3482,6 +3621,7 @@ export class XlsxSheetViewer implements ZoomableViewer {
     readonly canvasElement: HTMLCanvasElement,
     options: XlsxSheetViewerOptions = {},
   ) {
+    const mode = resolveCanvasViewerMode('XlsxSheetViewer', options.mode, options.workbook);
     const rect = canvasElement.getBoundingClientRect();
     this.canvasMount = new CallerCanvasMount(canvasElement, {
       wrapperCssText:
@@ -3499,6 +3639,7 @@ export class XlsxSheetViewer implements ZoomableViewer {
     }, {
       kind: 'sheet',
       canvas: canvasElement,
+      mode,
     });
     this.snapshot = {
       sheetIndex: 0,

--- a/packages/xlsx/src/workbook-destroy.test.ts
+++ b/packages/xlsx/src/workbook-destroy.test.ts
@@ -9,7 +9,7 @@ import {
   type FontPreloadEntry,
   type OffscreenFactory,
 } from '@silurus/ooxml-core';
-import { XlsxWorkbook } from './workbook.js';
+import { XlsxWorkbook, retainXlsxViewerFonts } from './workbook.js';
 
 /**
  * `XlsxWorkbook.destroy()` tears the parser worker down via
@@ -99,7 +99,9 @@ describe('XlsxWorkbook.destroy() — rejects in-flight worker requests', () => {
     instance.sheetCache = new Map();
     instance.sheetLoads = new Map();
     instance.rawParts = new BoundedRawPartCache({ maxEntries: 4, maxBytes: 1024 });
-    instance.googleFontFaces = [];
+    instance.googleFontNames = [];
+    instance.retainedFontSets = new Map();
+    instance.fontsDestroyed = false;
     instance._fetchImage = () => Promise.resolve(new Blob());
     return { wb: instance as unknown as DestroyProbe, bridge, worker };
   }
@@ -180,19 +182,44 @@ describe('XlsxWorkbook.destroy() — rejects in-flight worker requests', () => {
   });
 
   // Wiring guard: destroy() must actually release the Google-Fonts substitutes
-  // the workbook preloaded. The other tests set `googleFontFaces = []`, so they
-  // never exercise the unload branch — a dropped call would go unnoticed.
+  // retained in the workbook's per-document FontFaceSet registry.
   it('destroy() releases the workbook’s Google fonts from the FontFaceSet', async () => {
     const { added } = installFontFaceSet();
     const held = await preloadGoogleFonts(['Calibri'], MAP);
     expect(added).toHaveLength(1);
 
     const { wb } = makeWorkbook();
-    (wb as unknown as { googleFontFaces: FontFace[] }).googleFontFaces = held;
+    const retainedFontSets = (wb as unknown as {
+      retainedFontSets: Map<FontFaceSet, { refs: number; faces: FontFace[]; loading: Promise<FontFace[]> }>;
+    }).retainedFontSets;
+    const fontSet = (G.document as { fonts: FontFaceSet }).fonts;
+    retainedFontSets.set(fontSet, { refs: 1, faces: held, loading: Promise.resolve(held) });
     wb.destroy();
 
     expect(added).toHaveLength(0);
-    expect((wb as unknown as { googleFontFaces: FontFace[] }).googleFontFaces).toHaveLength(0);
+    expect(retainedFontSets.size).toBe(0);
+  });
+
+  it('an in-flight destroy releases once and preserves another workbook holder', async () => {
+    const { added } = installFontFaceSet();
+    let resolveFetch!: (response: { ok: boolean; text(): Promise<string> }) => void;
+    G.fetch = vi.fn(() => new Promise((resolve) => { resolveFetch = resolve; }));
+    const first = makeWorkbook().wb as unknown as XlsxWorkbook;
+    const second = makeWorkbook().wb as unknown as XlsxWorkbook;
+    (first as unknown as { googleFontNames: string[] }).googleFontNames = ['Cambria'];
+    (second as unknown as { googleFontNames: string[] }).googleFontNames = ['Cambria'];
+    const targetDocument = G.document as Document;
+
+    const firstRetain = first[retainXlsxViewerFonts](targetDocument);
+    const secondRetain = second[retainXlsxViewerFonts](targetDocument);
+    first.destroy();
+    resolveFetch({ ok: true, text: async () => CSS });
+    const [releaseFirst] = await Promise.all([firstRetain, secondRetain]);
+    releaseFirst(); // stale viewer completion after workbook teardown: no-op
+
+    expect(added).toHaveLength(1);
+    second.destroy();
+    expect(added).toHaveLength(0);
   });
 });
 
@@ -215,7 +242,9 @@ describe('XlsxWorkbook.destroy() — drops the shared image caches (GPU-leak gua
     instance.sheetCache = new Map();
     instance.sheetLoads = new Map();
     instance.rawParts = new BoundedRawPartCache({ maxEntries: 4, maxBytes: 1024 });
-    instance.googleFontFaces = [];
+    instance.googleFontNames = [];
+    instance.retainedFontSets = new Map();
+    instance.fontsDestroyed = false;
     instance._fetchImage = fetchImage;
     return instance as unknown as DestroyProbe;
   }

--- a/packages/xlsx/src/workbook.ts
+++ b/packages/xlsx/src/workbook.ts
@@ -54,11 +54,27 @@ import type {
   RenderWorkerResponse,
   WireRenderViewportOptions,
 } from './worker-protocol.js';
-import { extractViewerLayoutMetrics } from './worker-protocol.js';
+import {
+  createSizeOverriddenWorksheet,
+  extractViewerRenderContext,
+} from './worker-protocol.js';
 import {
   isXlsxWorksheetPullResponse,
   XlsxWorksheetPullClient,
 } from './worksheet-pull-client.js';
+import { GridGeometry } from './internal/grid-geometry.js';
+import { inheritSheetRenderCache } from './renderer.js';
+
+/** @internal Viewer-only hook for retaining web fonts in the canvas document. */
+export const retainXlsxViewerFonts = Symbol('retain-xlsx-viewer-fonts');
+/** @internal Release worker-side viewer projection cache entries. */
+export const releaseXlsxViewerProjection = Symbol('release-xlsx-viewer-projection');
+
+interface RetainedFontSet {
+  refs: number;
+  faces: FontFace[] | null;
+  readonly loading: Promise<FontFace[]>;
+}
 
 /** Options for {@link XlsxWorkbook.load}. Extends the shared load-options type
  *  from `@silurus/ooxml-core` (`useGoogleFonts`, `resourceLimits`, the
@@ -107,12 +123,11 @@ export class XlsxWorkbook {
    *  `renderViewport` call reuses it — equations in shapes render when present,
    *  and are skipped (engine tree-shaken) when omitted. */
   private math: MathRenderer | undefined;
-  /** Google-Fonts `FontFace` objects this workbook preloaded into `document.fonts`
-   *  (main mode only — in worker mode the worker owns them and terminates with its
-   *  own FontFaceSet). Released in {@link destroy} so they do not leak into the
-   *  shared FontFaceSet for the lifetime of the SPA (deduped + refcounted in core,
-   *  so a web font shared with another open workbook survives until both go). */
-  private googleFontFaces: FontFace[] = [];
+  /** Web-font registrations are per FontFaceSet. Same-origin child windows have
+   * their own set even when they share this workbook instance. */
+  private googleFontNames: string[] = [];
+  private readonly retainedFontSets = new Map<FontFaceSet, RetainedFontSet>();
+  private fontsDestroyed = false;
   private _mode: 'main' | 'worker' = 'main';
   private generation = 0;
   private archiveOperationTail: Promise<void> = Promise.resolve();
@@ -149,6 +164,12 @@ export class XlsxWorkbook {
     // relative override is still resolved against `location.href`.
     const wasmUrl = new URL(wasmUrlOverride ?? wasmAssetUrl, location.href).href;
     this.bridge.post({ type: 'init', wasmUrl } satisfies WorkerRequest);
+  }
+
+  /** The render mode this loaded workbook owns. Injected viewers use this fact
+   *  to select direct-canvas or worker-bitmap rendering without probing. */
+  get mode(): 'main' | 'worker' {
+    return this._mode;
   }
 
   /** Parse an XLSX from a URL or ArrayBuffer. */
@@ -299,11 +320,45 @@ export class XlsxWorkbook {
       // realm even when paint runs in a worker. Register the same fallback
       // faces in both realms before any worksheet geometry snapshot is made so
       // ECMA-376 MDW is identical across paint and interaction.
-      this.googleFontFaces = await preloadGoogleFonts(
-        xlsxFontPreloadNames(this.parsedWorkbook),
-        XLSX_GOOGLE_FONTS,
-      );
+      this.googleFontNames = [...xlsxFontPreloadNames(this.parsedWorkbook)];
+      if (typeof document !== 'undefined' && document.fonts) {
+        await this.retainFontsInSet(document.fonts);
+      }
     }
+  }
+
+  private async retainFontsInSet(fontSet: FontFaceSet): Promise<() => void> {
+    if (this.googleFontNames.length === 0 || this.fontsDestroyed) return () => undefined;
+    let retained = this.retainedFontSets.get(fontSet);
+    if (retained) {
+      retained.refs++;
+    } else {
+      const loading = preloadGoogleFonts(this.googleFontNames, XLSX_GOOGLE_FONTS, fontSet);
+      retained = { refs: 1, faces: null, loading };
+      this.retainedFontSets.set(fontSet, retained);
+      loading.then((faces) => {
+        retained!.faces = faces;
+        if (this.fontsDestroyed) unloadGoogleFonts(faces);
+      });
+    }
+    await retained.loading;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const current = this.retainedFontSets.get(fontSet);
+      if (current !== retained) return;
+      current.refs--;
+      if (current.refs > 0) return;
+      this.retainedFontSets.delete(fontSet);
+      if (current.faces) unloadGoogleFonts(current.faces);
+      else current.loading.then(unloadGoogleFonts);
+    };
+  }
+
+  /** @internal Retain required faces in the document that owns a viewer canvas. */
+  async [retainXlsxViewerFonts](targetDocument: Document): Promise<() => void> {
+    return await this.retainFontsInSet(targetDocument.fonts);
   }
 
   get sheetNames(): string[] {
@@ -648,15 +703,23 @@ export class XlsxWorkbook {
     }
     if (!this.parsedWorkbook) throw new Error('Workbook not loaded');
     const styles = this.parsedWorkbook.styles;
-    return this.withWorksheetArchiveOperation(sheetIndex, (ws) =>
-      renderWorksheetViewport(
+    const extracted = extractViewerRenderContext(opts as WireRenderViewportOptions);
+    const { sizeOverrides, ...renderOpts } = extracted.opts;
+    return this.withWorksheetArchiveOperation(sheetIndex, (source) => {
+      const ws = extracted.worksheet ?? createSizeOverriddenWorksheet(source, sizeOverrides);
+      if (ws !== source) inheritSheetRenderCache(source, ws);
+      if (extracted.layoutMetrics) {
+        GridGeometry.forWorksheet(ws, extracted.layoutMetrics.maximumDigitWidth);
+      }
+      return renderWorksheetViewport(
         { ws, styles, math: this.math },
         target,
         viewport,
         // The stable closure uses the archive operation already reserved by
         // withWorksheetArchiveOperation, avoiding a nested FIFO acquisition.
-        { ...opts, fetchImage: this._fetchImage },
-      ));
+        { ...renderOpts, fetchImage: this._fetchImage },
+      );
+    });
   }
 
   /**
@@ -676,7 +739,7 @@ export class XlsxWorkbook {
     opts: WireRenderViewportOptions & { width: number; height: number },
   ): Promise<ImageBitmap> {
     this.assertResourceHealthy();
-    const extracted = extractViewerLayoutMetrics(opts);
+    const extracted = extractViewerRenderContext(opts);
     const wireOpts = { ...extracted.opts, dpr: opts.dpr ?? defaultDpr() };
     if (this._mode === 'worker') {
       if (!Number.isInteger(sheetIndex) || sheetIndex < 0 || sheetIndex >= this.sheetCount) {
@@ -691,6 +754,7 @@ export class XlsxWorkbook {
             viewport,
             opts: wireOpts,
             layoutMetrics: extracted.layoutMetrics,
+            viewProjection: extracted.projection,
           }) satisfies RenderWorkerRequest,
         ));
       return (res as Extract<RenderWorkerResponse, { type: 'viewportRendered' }>).bitmap;
@@ -698,6 +762,12 @@ export class XlsxWorkbook {
     const off = new OffscreenCanvas(1, 1);
     await this.renderViewport(off, sheetIndex, viewport, wireOpts);
     return off.transferToImageBitmap();
+  }
+
+  /** @internal Drop projections owned by a destroyed viewer. */
+  [releaseXlsxViewerProjection](projectionId: number): void {
+    if (this._mode !== 'worker') return;
+    this.bridge.post({ type: 'releaseViewProjection', projectionId } satisfies RenderWorkerRequest);
   }
 
   private withWorksheetArchiveOperation<T>(
@@ -750,15 +820,14 @@ export class XlsxWorkbook {
     this.parsedWorkbook = null;
     this.sheetCache.clear();
     this.sheetLoads.clear();
-    // Release the Google-Fonts substitutes this workbook preloaded into the
-    // shared FontFaceSet (main mode). Refcounted in core: a web font also used by
-    // another open workbook stays until that one is destroyed too. Without this,
-    // every opened workbook left its Google FontFace objects in `document.fonts`
-    // forever (SPA memory leak).
-    if (this.googleFontFaces.length > 0) {
-      unloadGoogleFonts(this.googleFontFaces);
-      this.googleFontFaces = [];
+    this.fontsDestroyed = true;
+    for (const retained of this.retainedFontSets.values()) {
+      if (retained.faces) unloadGoogleFonts(retained.faces);
+      // An in-flight registration observes fontsDestroyed in its own completion
+      // callback and releases exactly once when the faces become available.
     }
+    this.retainedFontSets.clear();
+    this.googleFontNames = [];
     // Frame-local lookup maps never escape the renderer; drop the owning core
     // caches to release decoded surfaces and SVG references.
     dropDecodedBitmapCache(this._fetchImage);

--- a/packages/xlsx/src/worker-protocol.ts
+++ b/packages/xlsx/src/worker-protocol.ts
@@ -21,9 +21,9 @@ import { GridGeometry } from './internal/grid-geometry.js';
  * Semantics: keys are 1-based band indices; a number is the band's current
  * `rowHeights` / `colWidths` model value, `null` means "no entry — fall back
  * to the sheet default". The main thread accumulates every band the user has
- * touched this session (entries are updated in place, never removed), so
- * re-applying the full map is idempotent and converges the worker's cached
- * sheet to the main model even across worker-side re-parses.
+ * touched this session (entries are updated in place, never removed). Each
+ * render applies the full map to a render-local worksheet projection, leaving
+ * the workbook/worker cache unchanged for other viewers.
  */
 export interface WireSizeOverrides {
   rows?: Record<number, number | null>;
@@ -32,9 +32,7 @@ export interface WireSizeOverrides {
 
 /**
  * Apply {@link WireSizeOverrides} to a worksheet's size maps (mutates `ws`).
- * Runs worker-side on every `renderViewport` before drawing. Touches only the
- * two size maps, so the worker's memoized render cache (cell map, merge sets —
- * keyed by the Worksheet object identity) stays valid.
+ * Shared render paths call this only on a shallow render-local projection.
  */
 export function applySizeOverrides(ws: Worksheet, overrides: WireSizeOverrides | undefined): void {
   if (!overrides) return;
@@ -70,12 +68,86 @@ export function applySizeOverrides(ws: Worksheet, overrides: WireSizeOverrides |
   if (changed) GridGeometry.invalidate(ws);
 }
 
+/** Return a render-local worksheet when view overrides exist. The cached
+ * worksheet remains immutable across independent viewers. */
+export function createSizeOverriddenWorksheet(
+  source: Worksheet,
+  overrides: WireSizeOverrides | undefined,
+): Worksheet {
+  if (!overrides) return source;
+  const view = {
+    ...source,
+    rowHeights: { ...source.rowHeights },
+    colWidths: { ...source.colWidths },
+  };
+  applySizeOverrides(view, overrides);
+  return view;
+}
+
+export interface WireViewProjection {
+  readonly id: number;
+  readonly revision: number;
+}
+
+/** Worker-local cache for one shallow worksheet projection per viewer/sheet.
+ * Repeated viewport paints at an unchanged revision reuse the same maps. */
+export class WorksheetViewProjectionCache {
+  private readonly entries = new Map<
+    string,
+    Readonly<{ revision: number; source: Worksheet; worksheet: Worksheet }>
+  >();
+  /** Viewer teardown can overtake a render already awaiting fonts/archive work.
+   * A tombstone prevents that late render from resurrecting released entries. */
+  private readonly releasedProjectionIds = new Set<number>();
+
+  resolve(
+    source: Worksheet,
+    sheetIndex: number,
+    projection: WireViewProjection | undefined,
+    overrides: WireSizeOverrides | undefined,
+  ): Readonly<{ worksheet: Worksheet; created: boolean }> {
+    if (!projection) {
+      const worksheet = createSizeOverriddenWorksheet(source, overrides);
+      return { worksheet, created: worksheet !== source };
+    }
+    const cacheable = !this.releasedProjectionIds.has(projection.id);
+    const key = `${projection.id}:${sheetIndex}`;
+    const cached = cacheable ? this.entries.get(key) : undefined;
+    if (
+      cached &&
+      cached.revision === projection.revision &&
+      cached.source === source
+    ) {
+      return { worksheet: cached.worksheet, created: false };
+    }
+    const worksheet = createSizeOverriddenWorksheet(source, overrides);
+    if (worksheet !== source && cacheable) {
+      this.entries.set(key, { revision: projection.revision, source, worksheet });
+      return { worksheet, created: true };
+    }
+    this.entries.delete(key);
+    return { worksheet, created: worksheet !== source };
+  }
+
+  release(projectionId: number): void {
+    this.releasedProjectionIds.add(projectionId);
+    const prefix = `${projectionId}:`;
+    for (const key of this.entries.keys()) {
+      if (key.startsWith(prefix)) this.entries.delete(key);
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.releasedProjectionIds.clear();
+  }
+}
+
 /** Serializable subset of RenderViewportOptions: drop the callback, the image
  *  cache, and the `fetchImage` loader (all non-cloneable; the worker owns its
  *  own cache and supplies its own in-worker fetchImage). Extended with the
- *  optional {@link WireSizeOverrides} so view-only size mutations reach the
- *  worker's local sheet copy; absent (the common case) when nothing has been
- *  resized or collapsed, keeping the wire payload unchanged. */
+ *  optional {@link WireSizeOverrides} so view-only size mutations reach a
+ *  render-local sheet projection; absent when nothing changed. */
 export type WireRenderViewportOptions = Omit<
   RenderViewportOptions,
   'onTextRun' | 'loadedImages' | 'fetchImage'
@@ -83,40 +155,60 @@ export type WireRenderViewportOptions = Omit<
   sizeOverrides?: WireSizeOverrides;
 };
 
-const viewerLayoutMetrics = Symbol('xlsx-viewer-layout-metrics');
+const viewerRenderContext = Symbol('xlsx-viewer-render-context');
 
 type ViewerRenderViewportOptions = WireRenderViewportOptions & {
-  [viewerLayoutMetrics]?: Readonly<{ maximumDigitWidth: number }>;
+  [viewerRenderContext]?: Readonly<{
+    maximumDigitWidth: number;
+    worksheet?: Worksheet;
+    projection?: WireViewProjection;
+  }>;
 };
 
-/** @internal Attach the Window-owned layout metric used by the composite
- * viewer. It is a symbol property, so it cannot become a user-facing OOXML
- * rendering knob or accidentally cross structured-clone. Workbook transport
- * extracts it into the internal worker request envelope. */
-export function withViewerLayoutMetrics<T extends WireRenderViewportOptions>(
+/** @internal Attach the viewer-only render context. The symbol keeps the main-
+ * thread worksheet projection out of the public OOXML options and out of
+ * structured clone; workbook transport extracts only serializable fields for
+ * worker rendering. */
+export function withViewerRenderContext<T extends WireRenderViewportOptions>(
   opts: T,
   maximumDigitWidth: number,
+  view?: Readonly<{
+    worksheet: Worksheet;
+    projection?: WireViewProjection;
+  }>,
 ): T {
   if (!Number.isFinite(maximumDigitWidth) || maximumDigitWidth <= 0) {
     throw new Error('XLSX maximum digit width must be a finite positive number');
   }
   return {
     ...opts,
-    [viewerLayoutMetrics]: { maximumDigitWidth },
+    [viewerRenderContext]: {
+      maximumDigitWidth,
+      worksheet: view?.worksheet,
+      projection: view?.projection,
+    },
   } as T & ViewerRenderViewportOptions;
 }
 
-/** @internal Remove the non-cloneable symbol property and return the internal
- * request-envelope metric separately. */
-export function extractViewerLayoutMetrics(opts: WireRenderViewportOptions): {
+/** @internal Split wire options from the viewer-only render context. */
+export function extractViewerRenderContext(opts: WireRenderViewportOptions): {
   readonly opts: WireRenderViewportOptions;
   readonly layoutMetrics?: Readonly<{ maximumDigitWidth: number }>;
+  readonly worksheet?: Worksheet;
+  readonly projection?: WireViewProjection;
 } {
   const internal = opts as ViewerRenderViewportOptions;
-  const layoutMetrics = internal[viewerLayoutMetrics];
+  const layoutMetrics = internal[viewerRenderContext];
   const wire = { ...opts } as ViewerRenderViewportOptions;
-  delete wire[viewerLayoutMetrics];
-  return layoutMetrics ? { opts: wire, layoutMetrics } : { opts: wire };
+  delete wire[viewerRenderContext];
+  return layoutMetrics
+    ? {
+        opts: wire,
+        layoutMetrics: { maximumDigitWidth: layoutMetrics.maximumDigitWidth },
+        worksheet: layoutMetrics.worksheet,
+        projection: layoutMetrics.projection,
+      }
+    : { opts: wire };
 }
 
 // The base `parse` arm from types.ts is intentionally NOT reused: the render
@@ -137,7 +229,11 @@ export type RenderWorkerRequest =
        * render options because it exists only to align viewer interaction and
        * worker paint across font realms. */
       layoutMetrics?: Readonly<{ maximumDigitWidth: number }>;
+      /** Viewer-local projection cache identity. The worker rebuilds its shallow
+       * worksheet projection only when the revision changes. */
+      viewProjection?: WireViewProjection;
     }
+  | { type: 'releaseViewProjection'; projectionId: number }
   // Worker render mode decodes images in-worker via a getImage closure; this arm
   // exists only for protocol parity with worker.ts (so a stray extractImage
   // never hangs). The render worker reads bytes straight from its retained

--- a/site/src/components/DemoBlock.astro
+++ b/site/src/components/DemoBlock.astro
@@ -3,7 +3,7 @@ import { Code } from 'astro:components';
 import { codeThemes } from '../lib/code-theme';
 interface Props {
   format: 'pptx' | 'docx' | 'xlsx';
-  kind: 'demo' | 'scroll' | 'thumbnails' | 'masterdetail' | 'sheet';
+  kind: 'demo' | 'scroll' | 'thumbnails' | 'masterdetail' | 'sheet' | 'sheetWindows';
   badge: string;
   title: string;
   description: string;

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -85,6 +85,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       ctor: 'new PptxViewer(canvas: HTMLCanvasElement, options?: PptxViewerOptions)',
       note: 'Opinionated single-canvas viewer. Hand it a <canvas>; it owns parsing, rendering and the current slide.',
       options: [
+        { name: 'presentation', type: 'PptxPresentation', desc: 'Borrow an already-loaded presentation. Its mode is authoritative; load() is then unsupported and destroy() leaves it open.' },
         { name: 'width', type: 'number', def: '960', desc: 'Canvas CSS width in px; height is derived from the slide aspect ratio.' },
         DPR,
         GFONTS,
@@ -107,7 +108,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         VIEWER_ON_ERROR,
       ],
       methods: [
-        { sig: 'load(source: string | ArrayBuffer): Promise<void>', desc: 'Load from a URL or ArrayBuffer and render the first slide.' },
+        { sig: 'load(source: string | ArrayBuffer): Promise<void>', desc: 'Load from a URL or ArrayBuffer and render the first slide. Unsupported when presentation is injected.' },
         { sig: 'goToSlide(index: number): Promise<void>', desc: 'Render a specific slide (0-indexed, clamped).' },
         { sig: 'nextSlide(): Promise<void>', desc: 'Advance one slide.' },
         { sig: 'prevSlide(): Promise<void>', desc: 'Go back one slide.' },
@@ -196,6 +197,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
       ctor: 'new DocxViewer(canvas: HTMLCanvasElement, options?: DocxViewerOptions)',
       note: 'Single-canvas viewer that paginates the document and tracks the current page.',
       options: [
+        { name: 'document', type: 'DocxDocument', desc: 'Borrow an already-loaded document. Its mode is authoritative; load() is then unsupported and destroy() leaves it open.' },
         { name: 'width', type: 'number', desc: 'Canvas CSS width in px; height is auto-computed from the page aspect ratio.' },
         DPR,
         GFONTS,
@@ -216,7 +218,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         VIEWER_ON_ERROR,
       ],
       methods: [
-        { sig: 'load(source: string | ArrayBuffer): Promise<void>', desc: 'Load from a URL or ArrayBuffer and render the first page.' },
+        { sig: 'load(source: string | ArrayBuffer): Promise<void>', desc: 'Load from a URL or ArrayBuffer and render the first page. Unsupported when document is injected.' },
         { sig: 'goToPage(index: number): Promise<void>', desc: 'Render a specific page (0-indexed, clamped).' },
         { sig: 'nextPage(): Promise<void>', desc: 'Advance one page.' },
         { sig: 'prevPage(): Promise<void>', desc: 'Go back one page.' },
@@ -304,6 +306,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'selectionColor', type: 'string', def: "'#1a73e8'", desc: 'Accent color for the cell-selection rectangle (any CSS color). The fill is the same color at 8% opacity.' },
         FIND_HIGHLIGHT_COLORS,
         { name: 'hiddenSheetMode', type: "'show' | 'skip' | 'dim'", def: "'show'", desc: 'How hidden / very-hidden sheets (`<sheet state>`, §18.2.19) appear in the tab bar. `show` renders a tab like any other; `skip` hides the tab (`display:none`) and makes sequential navigation jump over it; `dim` renders the tab at reduced opacity. Mirrors pptx `hiddenSlideMode`.' },
+        { name: 'workbook', type: 'XlsxWorkbook', desc: 'Borrow an already-loaded workbook, matching DOCX/PPTX engine injection. load() is then unsupported and destroy() leaves the caller-owned workbook open.' },
         GFONTS,
         ZIP,
         RESOURCE_LIMITS,
@@ -321,7 +324,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         VIEWER_ON_ERROR,
       ],
       methods: [
-        { sig: 'load(source: string | ArrayBuffer): Promise<void>', desc: 'Load a workbook from a URL or ArrayBuffer and render the first sheet.' },
+        { sig: 'load(source: string | ArrayBuffer): Promise<void>', desc: 'Load a workbook from a URL or ArrayBuffer and render the first sheet. Throws when a workbook was injected through options.' },
         { sig: 'goToSheet(index: number): Promise<void>', desc: 'Show a specific sheet (0-indexed, clamped).' },
         { sig: 'nextSheet(): Promise<void>', desc: 'Advance one sheet.' },
         { sig: 'prevSheet(): Promise<void>', desc: 'Go back one sheet.' },
@@ -344,13 +347,13 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { sig: 'getCellAt(clientX: number, clientY: number): CellAddress | null', desc: 'Hit-test a viewport coordinate to a cell address.' },
         { sig: 'get canvasElement(): HTMLCanvasElement', desc: 'The underlying canvas the grid is drawn on.' },
         RESOURCE_METRICS_METHOD,
-        { sig: 'destroy(): void', desc: 'Tear down the worker and release resources.' },
+        { sig: 'destroy(): void', desc: 'Tear down the DOM subtree. Destroys a self-loaded workbook; an injected one remains caller-owned.' },
       ],
     },
     {
       name: 'XlsxSheetViewer',
       ctor: 'new XlsxSheetViewer(canvas: HTMLCanvasElement, options?: XlsxSheetViewerOptions)',
-      note: 'Canvas-mounted active-sheet viewport. It uses the caller canvas and the same sheet rendering, selection, find and navigation mechanics as XlsxViewer, but creates no sheet-tab/footer chrome or visible scrollbar.',
+      note: 'Canvas-mounted active-sheet viewport. It uses the caller canvas and the same sheet rendering, selection, find and navigation mechanics as XlsxViewer, but creates no sheet-tab/footer chrome or visible scrollbar. DOM chrome, styles and listeners follow canvas.ownerDocument, so a parent page can mount borrowed workbook sheets into same-origin popup canvases.',
       options: [
         { name: 'cellScale', type: 'number', def: '1', desc: 'Scale factor for cell/header dimensions (0.5 = half size).' },
         { name: 'zoomMin / zoomMax', type: 'number', def: '0.1 / 4', desc: 'Zoom bounds as scale factors (10%–400%).' },
@@ -358,6 +361,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'selectionColor', type: 'string', def: "'#1a73e8'", desc: 'Accent color for the cell-selection rectangle.' },
         FIND_HIGHLIGHT_COLORS,
         { name: 'hiddenSheetMode', type: "'show' | 'skip' | 'dim'", def: "'show'", desc: 'Controls sequential navigation and hidden-sheet visibility without adding tab chrome.' },
+        { name: 'workbook', type: 'XlsxWorkbook', desc: 'Borrow an already-loaded workbook so multiple sheet viewers share one parse and cache while retaining independent view state. Await goToSheet(index) for deterministic first-paint completion. load() is then unsupported.' },
         { name: 'onViewportChange', type: '(offset: XlsxViewportOffset) => void', desc: 'Called with the clamped logical CSS-pixel offset after the active viewport moves. Horizontal x is measured from column A independently of browser RTL scrollLeft conventions.' },
         GFONTS,
         WASM_URL,
@@ -377,7 +381,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         VIEWER_ON_ERROR,
       ],
       methods: [
-        { sig: 'load(source: string | ArrayBuffer): Promise<void>', desc: 'Load a workbook and render its first active sheet viewport.' },
+        { sig: 'load(source: string | ArrayBuffer): Promise<void>', desc: 'Load a viewer-owned workbook and render its first active sheet viewport. Throws when a workbook was injected through options.' },
         { sig: 'goToSheet(index: number): Promise<void>', desc: 'Show a specific sheet (0-indexed, clamped).' },
         { sig: 'nextSheet(): Promise<void>', desc: 'Advance one sheet.' },
         { sig: 'prevSheet(): Promise<void>', desc: 'Go back one sheet.' },
@@ -395,7 +399,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { sig: 'getCellAt(clientX: number, clientY: number): CellAddress | null', desc: 'Hit-test a viewport coordinate to a cell address.' },
         { sig: 'get canvasElement(): HTMLCanvasElement', desc: 'The caller-owned canvas used by the viewer.' },
         RESOURCE_METRICS_METHOD,
-        { sig: 'destroy(): void', desc: 'Permanently close the viewer, release resources, and restore the caller canvas to its original DOM slot and style.' },
+        { sig: 'destroy(): void', desc: 'Permanently close the viewer and restore the caller canvas. A workbook supplied through options remains caller-owned and is not destroyed.' },
       ],
     },
     {
@@ -407,6 +411,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { sig: 'static load(source, options?): Promise<XlsxWorkbook>', desc: 'Parse a workbook from a URL or ArrayBuffer.' },
         { sig: 'get sheetNames(): string[]', desc: 'Names of all sheets.' },
         { sig: 'get sheetCount(): number', desc: 'Total sheets.' },
+        { sig: 'get mode(): "main" | "worker"', desc: 'The render mode owned by this loaded workbook.' },
         { sig: 'getWorksheet(sheetIndex): Promise<Worksheet>', desc: 'Parse and return one worksheet model. Saved pivot-table facts are exposed read-only via `Worksheet.pivotTables`, with skipped malformed parts reported through `Worksheet.pivotDiagnostics`; saved worksheet cells and styles remain authoritative.' },
         { sig: 'renderViewport(canvas, sheetIndex, viewport, opts?: { width?, height?, dpr?, cellScale?, onTextRun? }): Promise<void>', desc: 'Render a row/col window of a sheet into the given canvas. `onTextRun` receives each text cell as `XlsxTextRunInfo` with required `sheetName` and A1 `cellRef` identity. Equations in shapes render when a `math` engine was passed to `load`. Unavailable in `mode: "worker"` — use renderViewportToBitmap.' },
         { sig: 'renderViewportToBitmap(sheetIndex, viewport, opts: { width, height, dpr?, cellScale? }): Promise<ImageBitmap>', desc: 'Render a sheet viewport and return it as an ImageBitmap (both modes; in worker mode the render runs off the main thread). `width` and `height` are required — a worker has no DOM element to measure. Equations in shapes are skipped in `mode: "worker"` (they require `mode: "main"`). The bitmap is caller-owned: pass it to `transferFromImageBitmap` (which consumes it) or call `bitmap.close()`.', emphasis: '`width` and `height` are required — a worker has no DOM element to measure.' },

--- a/site/src/lib/demo-snippets.ts
+++ b/site/src/lib/demo-snippets.ts
@@ -85,6 +85,40 @@ for (let i = 0; i < doc.${c.count}; i++) {
 export const pptxSnippets = build(pptx);
 export const docxSnippets = build(docx);
 
+export const xlsxSheetWindowsSnippet = `import { XlsxSheetViewer, XlsxWorkbook } from '@silurus/ooxml/xlsx';
+
+const workbook = await XlsxWorkbook.load('/sample.xlsx');
+const viewers = new Map<Window, XlsxSheetViewer>();
+
+async function openSheetInWindow(sheetIndex: number): Promise<void> {
+  // Call this function directly from a click handler so popup blockers allow it.
+  const popup = window.open('', '_blank', 'popup,width=1100,height=720,resizable=yes');
+  if (!popup) throw new Error('The browser blocked the popup');
+
+  const canvas = popup.document.createElement('canvas');
+  canvas.style.cssText = 'display:block;width:100%;height:100%';
+  popup.document.body.style.margin = '0';
+  popup.document.body.appendChild(canvas);
+
+  const viewer = new XlsxSheetViewer(canvas, { workbook });
+  viewers.set(popup, viewer);
+  popup.addEventListener('pagehide', () => {
+    viewer.destroy();
+    viewers.delete(popup);
+  }, { once: true });
+
+  await viewer.goToSheet(sheetIndex);
+}
+
+// Example: openSheetInWindow(1) from a sheet button's click handler.
+window.addEventListener('pagehide', () => {
+  viewers.forEach((viewer, popup) => {
+    viewer.destroy();
+    popup.close();
+  });
+  workbook.destroy();
+}, { once: true });`;
+
 export const xlsxSheetSnippet = `import { XlsxViewer } from '@silurus/ooxml/xlsx';
 
 // XlsxViewer owns its canvas, sheet-tab bar and zoom slider — hand it a

--- a/site/src/lib/demos.ts
+++ b/site/src/lib/demos.ts
@@ -4,10 +4,10 @@
 // parse the same file many times at once.
 import { PptxPresentation, PptxViewer } from '@silurus/ooxml-pptx';
 import { DocxDocument, DocxViewer } from '@silurus/ooxml-docx';
-import { XlsxViewer } from '@silurus/ooxml-xlsx';
+import { XlsxSheetViewer, XlsxViewer, XlsxWorkbook } from '@silurus/ooxml-xlsx';
 
 export type Format = 'pptx' | 'docx' | 'xlsx';
-export type DemoKind = 'demo' | 'scroll' | 'thumbnails' | 'masterdetail' | 'sheet';
+export type DemoKind = 'demo' | 'scroll' | 'thumbnails' | 'masterdetail' | 'sheet' | 'sheetWindows';
 
 const DPR = () => Math.min(typeof window !== 'undefined' ? window.devicePixelRatio : 1, 2);
 
@@ -58,13 +58,204 @@ const UNIT = (f: Format) => (f === 'pptx' ? 'Slide' : 'Page');
 // ── public entry ────────────────────────────────────────────────────
 export function mountDemoInto(el: HTMLElement, kind: DemoKind, format: Format, url: string): void {
   el.innerHTML = '';
-  if (format === 'xlsx') return mountSheet(el, url);
+  if (format === 'xlsx') {
+    switch (kind) {
+      case 'sheetWindows': return mountSheetWindows(el, url);
+      default: return mountSheet(el, url);
+    }
+  }
   switch (kind) {
     case 'scroll': return mountScroll(el, format, url);
     case 'thumbnails': return mountThumbnails(el, format, url);
     case 'masterdetail': return mountMasterDetail(el, format, url);
     default: return mountDemo(el, format, url);
   }
+}
+
+interface SheetWindowSession {
+  readonly popup: Window;
+  readonly viewer: XlsxSheetViewer;
+}
+
+// Excel — parse once in the parent and project borrowed sheet viewers into
+// same-origin popup canvases. Each child owns view state; the parent owns the
+// workbook, archive cache, and worker lifecycle.
+function mountSheetWindows(el: HTMLElement, url: string): void {
+  const launcher = document.createElement('div');
+  launcher.className = 'demo-sheet-window-launcher';
+  el.appendChild(launcher);
+  const st = status(launcher, 'Parsing workbook once…');
+
+  XlsxWorkbook.load(url, { useGoogleFonts: true })
+    .then((workbook) => {
+      const sessions = new Map<number, SheetWindowSession>();
+      const summary = document.createElement('div');
+      summary.className = 'demo-sheet-window-summary';
+      const summaryCopy = document.createElement('div');
+      const summaryTitle = document.createElement('strong');
+      summaryTitle.textContent = 'Workbook parsed once';
+      const summaryDetail = document.createElement('span');
+      summaryDetail.textContent = `${workbook.sheetCount} sheets · shared archive, cache and worker`;
+      summaryCopy.append(summaryTitle, summaryDetail);
+      const parseBadge = document.createElement('span');
+      parseBadge.className = 'demo-sheet-window-badge';
+      parseBadge.textContent = '1× parse';
+      const summaryActions = document.createElement('div');
+      summaryActions.className = 'demo-sheet-window-actions';
+      const closeAll = document.createElement('button');
+      closeAll.type = 'button';
+      closeAll.textContent = 'Close all windows';
+      closeAll.disabled = true;
+      summaryActions.append(parseBadge, closeAll);
+      summary.append(summaryCopy, summaryActions);
+
+      const list = document.createElement('div');
+      list.className = 'demo-sheet-window-list';
+      const sheetButtons: HTMLButtonElement[] = [];
+      const popupError = document.createElement('p');
+      popupError.className = 'demo-sheet-window-error';
+      popupError.hidden = true;
+      workbook.sheetNames.forEach((name, index) => {
+        const row = document.createElement('div');
+        row.className = 'demo-sheet-window-row';
+        const identity = document.createElement('div');
+        identity.className = 'demo-sheet-window-identity';
+        const number = document.createElement('span');
+        number.textContent = String(index + 1).padStart(2, '0');
+        const label = document.createElement('strong');
+        label.textContent = name;
+        identity.append(number, label);
+
+        const open = document.createElement('button');
+        open.type = 'button';
+        open.textContent = 'Open in window ↗';
+        sheetButtons.push(open);
+        open.addEventListener('click', () => {
+          const existing = sessions.get(index);
+          if (existing && !existing.popup.closed) {
+            existing.popup.focus();
+            return;
+          }
+
+          const popup = window.open(
+            '',
+            '_blank',
+            'popup=yes,width=1100,height=720,resizable=yes,scrollbars=no',
+          );
+          if (!popup) {
+            popupError.textContent = 'The browser blocked the popup. Allow popups and try again.';
+            popupError.hidden = false;
+            return;
+          }
+          popupError.hidden = true;
+
+          const popupDocument = popup.document;
+          popupDocument.title = `${name} · XLSX Sheet Viewer`;
+          const popupStyle = popupDocument.createElement('style');
+          popupStyle.textContent =
+            'html,body{width:100%;height:100%;margin:0;overflow:hidden;background:#eef2f6;' +
+            'font-family:Inter,ui-sans-serif,system-ui,sans-serif}' +
+            '.sheet-window{height:100%;display:grid;grid-template-rows:48px minmax(0,1fr)}' +
+            '.sheet-window__bar{display:flex;align-items:center;gap:12px;padding:0 16px;' +
+            'background:#172333;color:#fff;border-bottom:1px solid #34445a}' +
+            '.sheet-window__bar strong{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}' +
+            '.sheet-window__bar span{margin-left:auto;font:11px ui-monospace,monospace;color:#9fe2c4}' +
+            '.sheet-window__viewport{position:relative;min-height:0;background:#fff}' +
+            '.sheet-window__canvas{display:block;width:100%;height:100%;background:#fff}' +
+            '.sheet-window__loading{position:absolute;inset:0;display:grid;place-items:center;' +
+            'z-index:10;background:#fff;color:#59687a;font-size:13px}';
+          popupDocument.head.appendChild(popupStyle);
+
+          const shell = popupDocument.createElement('main');
+          shell.className = 'sheet-window';
+          const toolbar = popupDocument.createElement('header');
+          toolbar.className = 'sheet-window__bar';
+          const popupTitle = popupDocument.createElement('strong');
+          popupTitle.textContent = name;
+          const shared = popupDocument.createElement('span');
+          shared.textContent = `Shared workbook · Sheet ${index + 1} / ${workbook.sheetCount}`;
+          toolbar.append(popupTitle, shared);
+          const viewport = popupDocument.createElement('div');
+          viewport.className = 'sheet-window__viewport';
+          const canvas = popupDocument.createElement('canvas');
+          canvas.className = 'sheet-window__canvas';
+          const loading = popupDocument.createElement('div');
+          loading.className = 'sheet-window__loading';
+          loading.textContent = 'Rendering from the shared workbook…';
+          viewport.append(canvas, loading);
+          shell.append(toolbar, viewport);
+          popupDocument.body.replaceChildren(shell);
+
+          const renderState: { error: Error | null } = { error: null };
+          const viewer = new XlsxSheetViewer(canvas, {
+            workbook,
+            onError: (error) => {
+              renderState.error = error;
+              loading.textContent = err(error);
+            },
+          });
+          const session = { popup, viewer };
+          sessions.set(index, session);
+          closeAll.disabled = false;
+          open.textContent = 'Rendering…';
+          open.disabled = true;
+
+          popup.addEventListener('pagehide', () => {
+            viewer.destroy();
+            if (sessions.get(index) === session) sessions.delete(index);
+            open.textContent = 'Open in window ↗';
+            open.disabled = false;
+            closeAll.disabled = sessions.size === 0;
+          }, { once: true });
+
+          viewer.goToSheet(index)
+            .then(() => {
+              if (sessions.get(index) !== session) return;
+              if (renderState.error) open.textContent = 'View error ↗';
+              else {
+                loading.remove();
+                open.textContent = 'Focus window ↗';
+              }
+              open.disabled = false;
+            })
+            .catch((error) => {
+              if (sessions.get(index) !== session) return;
+              loading.textContent = err(error);
+              open.textContent = 'View error ↗';
+              open.disabled = false;
+            });
+        });
+
+        row.append(identity, open);
+        list.appendChild(row);
+      });
+
+      closeAll.addEventListener('click', () => {
+        const openSessions = [...sessions.values()];
+        sessions.clear();
+        openSessions.forEach(({ popup, viewer }) => {
+          viewer.destroy();
+          popup.close();
+        });
+        sheetButtons.forEach((button) => {
+          button.textContent = 'Open in window ↗';
+          button.disabled = false;
+        });
+        closeAll.disabled = true;
+      });
+
+      st.remove();
+      launcher.append(summary, popupError, list);
+      window.addEventListener('pagehide', () => {
+        sessions.forEach(({ popup, viewer }) => {
+          viewer.destroy();
+          popup.close();
+        });
+        sessions.clear();
+        workbook.destroy();
+      }, { once: true });
+    })
+    .catch((error) => { st.textContent = err(error); });
 }
 
 function status(el: HTMLElement, text: string): HTMLDivElement {

--- a/site/src/pages/xlsx.astro
+++ b/site/src/pages/xlsx.astro
@@ -2,7 +2,7 @@
 import FormatPage from '../layouts/FormatPage.astro';
 import DemoBlock from '../components/DemoBlock.astro';
 import ApiReference from '../components/ApiReference.astro';
-import { xlsxSheetSnippet } from '../lib/demo-snippets';
+import { xlsxSheetSnippet, xlsxSheetWindowsSnippet } from '../lib/demo-snippets';
 ---
 <FormatPage format="xlsx" name="XLSX" ext=".xlsx">
   <DemoBlock
@@ -10,6 +10,12 @@ import { xlsxSheetSnippet } from '../lib/demo-snippets';
     title="The full workbook viewer"
     description="Unlike slides and pages, a spreadsheet is one continuous grid — so XlsxViewer owns its own canvas, sheet-tab bar and zoom slider. Switch sheets along the bottom, click-drag to select a range, press Ctrl/Cmd+C to copy it as TSV, zoom with the slider or Ctrl/Cmd+wheel · trackpad pinch (10–400%), and drag a column/row header border to resize it. Resizing and zooming are view-only — they change what you see, never the loaded file."
     code={xlsxSheetSnippet}
+  />
+  <DemoBlock
+    format="xlsx" kind="sheetWindows" badge="Workbook · Multi-window"
+    title="One workbook. Many windows."
+    description="Parse the file once in the parent page, then open any sheet in its own browser window. Every window gets an independent scroll, zoom and selection state while the workbook archive, worksheet cache and render worker remain shared. Open two or more sheets to compare them side by side."
+    code={xlsxSheetWindowsSnippet}
   />
   <ApiReference format="xlsx" />
 </FormatPage>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -417,5 +417,96 @@ h1, h2, h3 { line-height: 1.08; letter-spacing: -0.035em; margin: 0; }
   .demo-detail { min-width: 0; padding: 10px; }
 }
 
+/* xlsx sheet windows — one parent-owned workbook, many popup canvases */
+.demo-sheet-window-launcher {
+  padding: clamp(12px, 2.5vw, 24px);
+  background: radial-gradient(120% 80% at 50% 0%, var(--preview-top), var(--preview-bottom) 70%);
+}
+.demo-sheet-window-summary {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 18px;
+  margin-bottom: 12px;
+  border: 1px solid color-mix(in srgb, var(--preview-text) 18%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, #fff 94%, var(--accent));
+  box-shadow: var(--document-shadow);
+  color: #172333;
+}
+.demo-sheet-window-summary > div { min-width: 0; display: grid; gap: 3px; }
+.demo-sheet-window-summary strong { font-size: 15px; }
+.demo-sheet-window-summary span { font: 11px var(--mono); color: #69778a; }
+.demo-sheet-window-actions {
+  margin-left: auto;
+  display: flex !important;
+  grid-auto-flow: column;
+  align-items: center;
+  gap: 8px !important;
+}
+.demo-sheet-window-badge {
+  flex: 0 0 auto;
+  padding: 5px 10px;
+  border: 1px solid #9bd8bd;
+  border-radius: 999px;
+  background: #e8f8f0;
+  color: #18794e !important;
+  font-weight: 700 !important;
+}
+.demo-sheet-window-actions button {
+  padding: 6px 10px;
+  border: 1px solid #b8c5d2;
+  border-radius: 6px;
+  background: #fff;
+  color: #172333;
+  font: 600 11px var(--sans);
+  cursor: pointer;
+}
+.demo-sheet-window-actions button:hover:not(:disabled) { border-color: #5d7187; background: #eef3f7; }
+.demo-sheet-window-actions button:disabled { cursor: default; opacity: 0.45; }
+.demo-sheet-window-list { display: grid; gap: 8px; }
+.demo-sheet-window-error {
+  margin: 0 0 12px;
+  padding: 9px 12px;
+  border: 1px solid #efb5b5;
+  border-radius: 7px;
+  background: #fff1f1;
+  color: #9d2525;
+  font-size: 12px;
+}
+.demo-sheet-window-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--preview-text) 16%, transparent);
+  border-radius: 8px;
+  background: #fff;
+  color: #172333;
+}
+.demo-sheet-window-identity { min-width: 0; display: flex; align-items: center; gap: 12px; }
+.demo-sheet-window-identity span { flex: 0 0 auto; font: 11px var(--mono); color: #8a98a9; }
+.demo-sheet-window-identity strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; }
+.demo-sheet-window-row button {
+  margin-left: auto;
+  flex: 0 0 auto;
+  padding: 7px 11px;
+  border: 1px solid #b8c5d2;
+  border-radius: 6px;
+  background: #f7f9fb;
+  color: #172333;
+  font: 600 12px var(--sans);
+  cursor: pointer;
+}
+.demo-sheet-window-row button:hover { border-color: #5d7187; background: #eef3f7; }
+
+@media (max-width: 620px) {
+  .demo-sheet-window-summary { align-items: flex-start; }
+  .demo-sheet-window-actions { align-items: flex-end; grid-auto-flow: row; }
+  .demo-sheet-window-row { align-items: flex-start; flex-direction: column; }
+  .demo-sheet-window-row button { width: 100%; margin-left: 0; }
+}
+
 /* xlsx full viewer */
 .demo-xlsx { width: 100%; height: 560px; background: #fff; }

--- a/site/src/xlsx-sheet-overview.test.ts
+++ b/site/src/xlsx-sheet-overview.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const page = readFileSync(new URL('./pages/xlsx.astro', import.meta.url), 'utf8');
+const demos = readFileSync(new URL('./lib/demos.ts', import.meta.url), 'utf8');
+const snippets = readFileSync(new URL('./lib/demo-snippets.ts', import.meta.url), 'utf8');
+const styles = readFileSync(new URL('./styles/global.css', import.meta.url), 'utf8');
+
+describe('XLSX multi-window sheet demo', () => {
+  it('keeps the full workbook viewer first and presents multi-window composition as an extension', () => {
+    expect(page.indexOf('kind="sheet"')).toBeLessThan(page.indexOf('kind="sheetWindows"'));
+    expect(page).toContain('kind="sheetWindows"');
+    expect(page).toContain('One workbook. Many windows.');
+    expect(page).toContain('Parse the file once in the parent page');
+  });
+
+  it('parses once and opens borrowed sheet viewers in same-origin popup canvases', () => {
+    expect(demos).toContain("import { XlsxSheetViewer, XlsxViewer, XlsxWorkbook } from '@silurus/ooxml-xlsx';");
+    expect(demos).toContain("case 'sheetWindows': return mountSheetWindows(el, url);");
+    expect(demos).toContain('XlsxWorkbook.load(url, { useGoogleFonts: true })');
+    expect(demos).toContain("window.open(");
+    expect(demos).toContain('const popupDocument = popup.document');
+    expect(demos).toContain('const viewer = new XlsxSheetViewer(canvas, {');
+    expect(demos).toContain('workbook,');
+    expect(demos).toContain('viewer.goToSheet(index)');
+    expect(demos).toContain('popup.addEventListener(\'pagehide\'');
+  });
+
+  it('shows copyable TypeScript with the same parse-once composition pattern', () => {
+    expect(snippets).toContain('export const xlsxSheetWindowsSnippet');
+    expect(snippets).toContain("import { XlsxSheetViewer, XlsxWorkbook } from '@silurus/ooxml/xlsx';");
+    expect(snippets).toContain("await XlsxWorkbook.load('/sample.xlsx')");
+    expect(snippets).toContain("window.open('', '_blank'");
+    expect(snippets).toContain('new XlsxSheetViewer(canvas, { workbook })');
+    expect(snippets).toContain('await viewer.goToSheet(sheetIndex)');
+    expect(snippets).toContain('viewer.destroy()');
+  });
+
+  it('uses a responsive launcher that explains the single parse', () => {
+    expect(styles).toContain('.demo-sheet-window-launcher {');
+    expect(styles).toContain('.demo-sheet-window-summary {');
+    expect(styles).toContain('.demo-sheet-window-row button {');
+    expect(demos).toContain("parseBadge.textContent = '1× parse'");
+    expect(demos).toContain("closeAll.textContent = 'Close all windows'");
+    expect(demos).toContain('const openSessions = [...sessions.values()]');
+    expect(demos.match(/if \(sessions\.get\(index\) !== session\) return;/g)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

- add a canvas-mounted `XlsxSheetViewer` that borrows a parsed workbook and renders independent sheets, including in same-origin windows
- align injected-engine ownership and mode handling across DOCX, XLSX, and PPTX viewers while centralizing mode conflict validation
- make popup rendering use the target document realm for DOM, scheduling, clipboard, hyperlinks, and fonts
- reuse viewer projections safely across worker frames and guard lifecycle races
- add API documentation and a public multi-window sheet demo

## Verification

- full Vitest suite: 6,598 passed, 27 skipped
- independent focused re-review: 121 tests passed
- TypeScript project build
- Astro production build: 16 pages
- `git diff --check`