### PR TITLE
fix(release): stabilize publish workflows

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -57,8 +57,16 @@ jobs:
 
       - name: Build library packages (pptx/xlsx/docx/core)
         # The extension imports @silurus/ooxml-{pptx,xlsx,docx} from workspace:*;
-        # each needs its dist/ before esbuild bundles the extension.
-        run: pnpm -r --filter "@silurus/*" build
+        # each needs its dist/ before esbuild bundles the extension. Keep the
+        # root package out of this recursive build: its declaration bundler and
+        # package tsc builds write overlapping generated state.
+        run: >-
+          pnpm
+          --filter @silurus/ooxml-core
+          --filter @silurus/ooxml-pptx
+          --filter @silurus/ooxml-xlsx
+          --filter @silurus/ooxml-docx
+          -r --workspace-concurrency=1 build
 
       - name: Build extension bundle (esbuild --production)
         working-directory: packages/vscode-extension


### PR DESCRIPTION
## Summary

- restrict the VS Code release build to the four library packages required by the extension
- serialize those package builds so declaration generation cannot overlap through the root workspace build
- update the Pages artifact action to its Node 24-compatible release

The previous VS Code wildcard selected the root workspace as well as the package workspaces. Their concurrent declaration builds could race and fail before the Marketplace publish step. The Pages upload action also transitively used the deprecated Node 20 artifact action.

## Verification

- `pnpm --filter @silurus/ooxml-core --filter @silurus/ooxml-pptx --filter @silurus/ooxml-xlsx --filter @silurus/ooxml-docx -r --workspace-concurrency=1 build`
- `git diff --check`
