### PR TITLE
fix(release): update Pages artifact upload

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -66,7 +66,7 @@ jobs:
           echo "ooxml.silurus.dev" > site/dist/CNAME
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/dist
 


### PR DESCRIPTION
## Summary

- update the Pages artifact upload action from v4 to v5
- use its Node 24-compatible `upload-artifact` v7 dependency

The v4 action transitively invokes a Node 20 artifact action and now emits a deprecation warning on GitHub-hosted runners.

## Verification

- confirmed `actions/upload-pages-artifact@v5.0.0` updates its internal upload action to v7
- `git diff --check`
