### PR TITLE
fix(viewers): preserve leading padding when zooming

### DIFF
--- a/packages/docx/src/scroll-viewer.test.ts
+++ b/packages/docx/src/scroll-viewer.test.ts
@@ -1706,6 +1706,15 @@ describe('DocxScrollViewer — paddingTop/paddingBottom (desk margin)', () => {
     expect(Math.abs(scrollHost.scrollTop - (24 + 3 * 810))).toBeLessThan(2);
     v.destroy();
   });
+
+  it('keeps the leading desk padding visible when setScale runs at the top', () => {
+    const { v, scrollHost } = setup({ paddingTop: 24, paddingBottom: 24, zoomMin: 0.5, zoomMax: 3 });
+    expect(scrollHost.scrollTop).toBe(0);
+    v.setScale(v.scaleForTest() * 0.75);
+    expect(scrollHost.scrollTop).toBe(0);
+    expect(slotTopFor(scrollHost, 0, PAGE_H * 0.75 + GAP, 24)).toBeDefined();
+    v.destroy();
+  });
 });
 
 describe('DocxScrollViewer — paddingLeft/paddingRight (horizontal desk gutters)', () => {

--- a/packages/docx/src/scroll-viewer.ts
+++ b/packages/docx/src/scroll-viewer.ts
@@ -1154,7 +1154,8 @@ export class DocxScrollViewer implements ZoomableViewer {
     // content under the pointer: content-y = scrollTop + anchorY (anchorY 0 ⇒ the
     // viewport top, the historical behaviour).
     const r0 = this._range();
-    const anchorContentY = this._scrollHost.scrollTop + anchorY;
+    const scrollTop0 = this._scrollHost.scrollTop;
+    const anchorContentY = scrollTop0 + anchorY;
     // Which page does that content-y fall in? `computeVisibleRange` attributes a
     // point in the trailing gap to the page ABOVE it, so clamp the fraction to
     // [0,1] to pin the page rather than drift into the gap.
@@ -1196,7 +1197,14 @@ export class DocxScrollViewer implements ZoomableViewer {
     // must stay at `anchorY`, so newScrollTop = newContentY − anchorY.
     const maxTop = Math.max(0, r1.totalHeight - this._scrollHost.clientHeight);
     const newContentY = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
-    this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, newContentY - anchorY));
+    // The leading desk padding is fixed viewport space: none of it scales. If the
+    // anchor is still inside that padding, keep the native scroll offset instead
+    // of snapping to page 0's offset and hiding the margin after a programmatic
+    // zoom at scrollTop 0.
+    const reanchoredTop = anchorContentY < (r0.offsets[0] ?? 0)
+      ? scrollTop0
+      : newContentY - anchorY;
+    this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, reanchoredTop));
 
     // Re-anchor horizontally for a gesture zoom. `padL` is a FIXED (non-scaling)
     // gutter, so it is subtracted from the ANCHOR only — the scroll offset stays

--- a/packages/pptx/src/scroll-viewer.test.ts
+++ b/packages/pptx/src/scroll-viewer.test.ts
@@ -2302,6 +2302,15 @@ describe('PptxScrollViewer — paddingTop/paddingBottom (desk margin)', () => {
     expect(Math.abs(scrollHost.scrollTop - (24 + 3 * 250))).toBeLessThan(2);
     v.destroy();
   });
+
+  it('keeps the leading desk padding visible when setScale runs at the top', () => {
+    const { v, scrollHost } = setup({ paddingTop: 24, paddingBottom: 24, zoomMin: 0.5, zoomMax: 3 });
+    expect(scrollHost.scrollTop).toBe(0);
+    v.setScale(v.scaleForTest() * 0.75);
+    expect(scrollHost.scrollTop).toBe(0);
+    expect(slotTopFor(scrollHost, 0, SLIDE_H * 0.75 + GAP, 24)).toBeDefined();
+    v.destroy();
+  });
 });
 
 describe('PptxScrollViewer — paddingLeft/paddingRight (horizontal desk gutters)', () => {

--- a/packages/pptx/src/scroll-viewer.ts
+++ b/packages/pptx/src/scroll-viewer.ts
@@ -1303,7 +1303,8 @@ export class PptxScrollViewer implements ZoomableViewer {
     // content under the pointer: content-y = scrollTop + anchorY (anchorY 0 ⇒ the
     // viewport top, the historical behaviour).
     const r0 = this._range();
-    const anchorContentY = this._scrollHost.scrollTop + anchorY;
+    const scrollTop0 = this._scrollHost.scrollTop;
+    const anchorContentY = scrollTop0 + anchorY;
     // Which slide does that content-y fall in? `computeVisibleRange` attributes a
     // point in the trailing gap to the slide ABOVE it, so clamp the fraction to
     // [0,1] to pin the slide rather than drift into the gap.
@@ -1345,7 +1346,14 @@ export class PptxScrollViewer implements ZoomableViewer {
     // must stay at `anchorY`, so newScrollTop = newContentY − anchorY.
     const maxTop = Math.max(0, r1.totalHeight - this._scrollHost.clientHeight);
     const newContentY = (r1.offsets[top] ?? 0) + intraFrac * (this._heights[top] || 0);
-    this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, newContentY - anchorY));
+    // The leading desk padding is fixed viewport space: none of it scales. If the
+    // anchor is still inside that padding, keep the native scroll offset instead
+    // of snapping to slide 0's offset and hiding the margin after a programmatic
+    // zoom at scrollTop 0.
+    const reanchoredTop = anchorContentY < (r0.offsets[0] ?? 0)
+      ? scrollTop0
+      : newContentY - anchorY;
+    this._scrollHost.scrollTop = Math.min(maxTop, Math.max(0, reanchoredTop));
 
     // Re-anchor horizontally for a gesture zoom. `padL` is a FIXED (non-scaling)
     // gutter, so it is subtracted from the ANCHOR only — the scroll offset stays

--- a/site/src/home-design.test.ts
+++ b/site/src/home-design.test.ts
@@ -81,8 +81,9 @@ describe('official-site home design', () => {
     expect(live.match(/enableTextSelection:\s*true/g)).toHaveLength(2);
   });
 
-  it('starts paginated samples at the top of the embedded viewport', () => {
-    expect(live.match(/paddingTop:\s*0/g)).toHaveLength(2);
+  it('starts paginated samples at the top without removing their desk margin', () => {
+    expect(live).not.toMatch(/paddingTop:\s*0/);
+    expect(live.match(/gap:\s*26/g)).toHaveLength(2);
   });
 
   it('centres a smaller hero icon and aligns the second-row format links on mobile', () => {

--- a/site/src/lib/live.ts
+++ b/site/src/lib/live.ts
@@ -80,7 +80,6 @@ function mountPaginated(
       maxScale = MAX_SAMPLE_WIDTH / (presentation.slideWidth / EMU_PER_PX);
       viewer = PptxScrollViewer.fromPresentation(host, presentation, {
         gap: 26,
-        paddingTop: 0,
         overscan: presentation.slideCount,
         enableTextSelection: true,
         pageShadow: 'var(--document-shadow)',
@@ -106,7 +105,6 @@ function mountPaginated(
       maxScale = widestPage > 0 ? MAX_SAMPLE_WIDTH / widestPage : Number.POSITIVE_INFINITY;
       viewer = DocxScrollViewer.fromDocument(host, document, {
         gap: 26,
-        paddingTop: 0,
         overscan: document.pageCount,
         enableTextSelection: true,
         pageShadow: 'var(--document-shadow)',


### PR DESCRIPTION
## Summary
- preserve the native vertical scroll offset when a DOCX/PPTX zoom anchor is inside the scale-invariant leading desk padding
- restore the homepage paginated demos' default 26px top margin without reintroducing the initial scroll offset
- add symmetric regression coverage for both scroll viewers and the site configuration

## Root cause
The homepage applies a width cap through an initial programmatic scale change. At scrollTop 0, the scroll viewers treated the leading desk margin as page/slide content and re-anchored to the first item offset, hiding the margin. The previous site workaround set paddingTop to zero, which removed the intended visual spacing.

## Verification
- 240 focused DOCX/PPTX/site tests
- 111 site tests
- TypeScript project build
- production site build
- ast-grep lint (existing warnings only)
- browser DOM measurement: scrollTop 0, first slot top 26px, visible top gap 26px
