### PR TITLE
fix(site): preserve homepage demos across history restores

### DIFF
--- a/site/src/components/LiveShowcase.astro
+++ b/site/src/components/LiveShowcase.astro
@@ -117,10 +117,21 @@ const formats = [
       io.observe(root);
     }
 
-    window.addEventListener('pagehide', () => {
+    window.addEventListener('pagehide', (event) => {
+      // A persisted pagehide means the browser is freezing this page in the
+      // back-forward cache. Keep the viewers and their DOM alive so the cached
+      // page can resume without rerunning this initialization script.
+      if (event.persisted) return;
       for (const entry of cache.values()) entry.controller.destroy();
       cache.clear();
-    }, { once: true });
+    });
+
+    window.addEventListener('pageshow', (event) => {
+      // Layout may have changed while the page was frozen. The active viewer is
+      // retained across BFCache restores; re-fit it without reparsing the file.
+      if (!event.persisted || !loaded) return;
+      cache.get(loaded)?.controller.activate?.();
+    });
   });
 </script>
 

--- a/site/src/home-design.test.ts
+++ b/site/src/home-design.test.ts
@@ -75,6 +75,15 @@ describe('official-site home design', () => {
     expect(showcase).toContain('for (const entry of cache.values()) entry.controller.destroy();');
   });
 
+  it('preserves the live viewers across back-forward cache restores', () => {
+    expect(showcase).toContain("window.addEventListener('pagehide', (event) => {");
+    expect(showcase).toContain('if (event.persisted) return;');
+    expect(showcase).not.toMatch(/pagehide[\s\S]*?\{ once: true \}/);
+    expect(showcase).toContain("window.addEventListener('pageshow', (event) => {");
+    expect(showcase).toContain('if (!event.persisted || !loaded) return;');
+    expect(showcase).toContain('cache.get(loaded)?.controller.activate?.();');
+  });
+
   it('uses selectable scroll viewers for the DOCX and PPTX samples', () => {
     expect(live).toContain('DocxScrollViewer.fromDocument');
     expect(live).toContain('PptxScrollViewer.fromPresentation');


### PR DESCRIPTION
## Summary
- preserve mounted homepage viewers during back-forward cache transitions
- reactivate the selected viewer after a persisted history restore
- cover the lifecycle contract with a focused site regression test

## Verification
- site test suite (112 tests)
- site production build
- TypeScript project build
- Chrome back-navigation with BFCache confirmed persisted and rendered canvases retained