### PR TITLE
feat(xlsx): auto-scroll drag selections

### DIFF
--- a/docs/api-architecture-0.76.ja.md
+++ b/docs/api-architecture-0.76.ja.md
@@ -177,8 +177,9 @@ whole sheetの一覧ではなく、sheet tabとscrollable cell gridを持つWork
 ### XLSX Canvas Viewerのcontract
 
 `XlsxSheetViewer`は、1つのactive worksheet viewportをCanvasへマウントして表示する。
-sheet tab/footer chromeとscrollbarは所有しない。worksheetは有限pageではないため、
-形式固有のviewport移動を追加で公開する。この状態をDOCX/PPTXへ無理に持ち込まない。
+sheet tab/footer chromeは所有しない。worksheetのnative scrollbarは既定で有効とし、host側が
+独自のviewport navigationを提供する場合だけ明示的に無効化できる。worksheetは有限pageでは
+ないため、形式固有のviewport移動を追加で公開する。この状態をDOCX/PPTXへ無理に持ち込まない。
 
 `XlsxWorkbook.renderSheet()`は意図的に用意しない。OOXML worksheetは最大1,048,576行、
 16,384列を持ち、Browser Canvasのdimensionとbacking memoryの上限を大幅に超えうる。
@@ -222,6 +223,7 @@ export interface XlsxScrollToCellOptions {
 export interface XlsxSheetViewerOptions extends LoadOptions {
   readonly cellScale?: number;
   readonly resizable?: boolean;
+  readonly showScrollbars?: boolean;
   readonly zoomMin?: number;
   readonly zoomMax?: number;
   readonly onScaleChange?: (scale: number) => void;
@@ -297,8 +299,8 @@ clampし、callbackにはclamp後の値を渡す。
 
 CanvasのCSS boxをviewport width/heightとし、DPRはbacking-store resolutionだけに影響する。
 `relayout()`でCSS boxを再取得する。共有caller-canvas lifecycleでcanvasをwrapし、
-destroy時に元へ戻す。Wheel/trackpadはscrollbarを作らずviewportをpanする。touch-pinchは今回の
-scope外とする。
+destroy時に元へ戻す。Native scrollbarを明示的に隠した場合もWheel/trackpadでviewportを
+panできる。touch-pinchは今回のscope外とする。
 
 `destroy()`はidempotentでinstanceを恒久的にcloseする。Destroy後のasync mutation
 （`load`、navigation、viewport/relayout、hidden-mode変更、find traversal）は

--- a/docs/api-architecture-0.76.md
+++ b/docs/api-architecture-0.76.md
@@ -199,9 +199,11 @@ and navigation remain asynchronous where they were asynchronous before.
 ### XLSX canvas-viewer contract
 
 `XlsxSheetViewer` is a canvas-mounted view of one active worksheet viewport. It
-owns no sheet-tab/footer chrome and creates no scrollbar. Because a worksheet is
-not a finite page, it additionally exposes format-specific viewport movement.
-That extra state is not forced onto DOCX or PPTX.
+owns no sheet-tab/footer chrome. Native worksheet scrollbars are enabled by
+default and can be disabled explicitly when a host supplies its own viewport
+navigation. Because a worksheet is not a finite page, it additionally exposes
+format-specific viewport movement. That extra state is not forced onto DOCX or
+PPTX.
 
 `XlsxWorkbook.renderSheet()` is deliberately absent. An OOXML worksheet can
 contain 1,048,576 rows and 16,384 columns, far beyond browser Canvas dimension
@@ -248,6 +250,7 @@ export interface XlsxScrollToCellOptions {
 export interface XlsxSheetViewerOptions extends LoadOptions {
   readonly cellScale?: number;
   readonly resizable?: boolean;
+  readonly showScrollbars?: boolean;
   readonly zoomMin?: number;
   readonly zoomMax?: number;
   readonly onScaleChange?: (scale: number) => void;
@@ -328,8 +331,8 @@ callback receives the resulting clamped value.
 The canvas CSS box defines viewport width/height; DPR affects only backing-store
 resolution. `relayout()` re-reads that box. The viewer uses the shared
 caller-canvas lifecycle to wrap and restore the canvas. Wheel/trackpad input pans
-the viewport without creating a scrollbar; touch-pinch remains outside this
-release.
+the viewport, including when native scrollbars are explicitly hidden;
+touch-pinch remains outside this release.
 
 `destroy()` is idempotent and permanently closes the instance. After destroy,
 async mutations (`load`, navigation, viewport/relayout, hidden-mode changes,

--- a/docs/migration-0.76.md
+++ b/docs/migration-0.76.md
@@ -152,9 +152,11 @@ There is intentionally no synchronous wrapper around these asynchronous APIs.
 `XlsxSheetViewer` renders one active worksheet viewport into a caller-owned
 `HTMLCanvasElement`. It includes selection, search, zoom, and
 logical viewport APIs, but no sheet tabs, footer controls, zoom chrome, or
-native scrollbar. Use the existing container-mounted `XlsxViewer` when those
-workbook controls are wanted. This is an XLSX-specific Viewer boundary; it does
-not imply that a worksheet is equivalent to a DOCX page or PPTX slide.
+workbook controls. Native worksheet scrollbars are visible by default; set
+`showScrollbars: false` only when the host provides another viewport navigation
+UI. Use the existing container-mounted `XlsxViewer` when sheet tabs and footer
+controls are wanted. This is an XLSX-specific Viewer boundary; it does not imply
+that a worksheet is equivalent to a DOCX page or PPTX slide.
 
 ```ts
 import { XlsxSheetViewer } from '@silurus/ooxml/xlsx';

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -1264,6 +1264,7 @@ export class XlsxSheetViewer implements ZoomableViewer {
 export interface XlsxSheetViewerOptions extends LoadOptions__emitterCollision1 {
     cellScale?: number;
     resizable?: boolean;
+    showScrollbars?: boolean;
     zoomMin?: number;
     zoomMax?: number;
     onScaleChange?: (scale: number) => void;

--- a/packages/xlsx/src/selection-auto-scroll.test.ts
+++ b/packages/xlsx/src/selection-auto-scroll.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { selectionAutoScrollVelocity } from './selection-auto-scroll.js';
+
+describe('selectionAutoScrollVelocity', () => {
+  const viewport = { width: 800, height: 600 };
+
+  it('does not scroll while the pointer stays outside the edge activation bands', () => {
+    expect(selectionAutoScrollVelocity({ x: 400, y: 300 }, viewport, false, 'cells'))
+      .toEqual({ x: 0, y: 0 });
+  });
+
+  it('accelerates toward the nearest horizontal and vertical edges', () => {
+    const near = selectionAutoScrollVelocity({ x: 20, y: 580 }, viewport, false, 'cells');
+    const atEdge = selectionAutoScrollVelocity({ x: 0, y: 600 }, viewport, false, 'cells');
+
+    expect(near.x).toBeLessThan(0);
+    expect(near.y).toBeGreaterThan(0);
+    expect(Math.abs(atEdge.x)).toBeGreaterThan(Math.abs(near.x));
+    expect(Math.abs(atEdge.y)).toBeGreaterThan(Math.abs(near.y));
+  });
+
+  it('clamps speed after the pointer moves outside the viewport', () => {
+    expect(selectionAutoScrollVelocity({ x: -500, y: 900 }, viewport, false, 'cells'))
+      .toEqual(selectionAutoScrollVelocity({ x: 0, y: 600 }, viewport, false, 'cells'));
+  });
+
+  it('reverses the logical horizontal direction for an RTL worksheet', () => {
+    const ltr = selectionAutoScrollVelocity({ x: 780, y: 300 }, viewport, false, 'cells');
+    const rtl = selectionAutoScrollVelocity({ x: 780, y: 300 }, viewport, true, 'cells');
+
+    expect(ltr.x).toBeGreaterThan(0);
+    expect(rtl.x).toBe(-ltr.x);
+    expect(rtl.y).toBe(0);
+  });
+
+  it('limits row and column selections to their meaningful scroll axis', () => {
+    expect(selectionAutoScrollVelocity({ x: 790, y: 590 }, viewport, false, 'rows').x).toBe(0);
+    expect(selectionAutoScrollVelocity({ x: 790, y: 590 }, viewport, false, 'rows').y).toBeGreaterThan(0);
+    expect(selectionAutoScrollVelocity({ x: 790, y: 590 }, viewport, false, 'cols').x).toBeGreaterThan(0);
+    expect(selectionAutoScrollVelocity({ x: 790, y: 590 }, viewport, false, 'cols').y).toBe(0);
+    expect(selectionAutoScrollVelocity({ x: 790, y: 590 }, viewport, false, 'all'))
+      .toEqual({ x: 0, y: 0 });
+  });
+});

--- a/packages/xlsx/src/selection-auto-scroll.ts
+++ b/packages/xlsx/src/selection-auto-scroll.ts
@@ -1,0 +1,48 @@
+type SelectionAutoScrollMode = 'cells' | 'rows' | 'cols' | 'all';
+
+/** Width of the viewport-edge activation band in CSS pixels. */
+export const SELECTION_AUTO_SCROLL_EDGE_PX = 40;
+/** Maximum logical viewport speed while drag-selecting outside an edge. */
+export const SELECTION_AUTO_SCROLL_MAX_PX_PER_SECOND = 900;
+
+export interface SelectionAutoScrollPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface SelectionAutoScrollViewport {
+  readonly width: number;
+  readonly height: number;
+}
+
+function axisVelocity(position: number, extent: number): number {
+  if (extent <= 0) return 0;
+  const edge = Math.min(SELECTION_AUTO_SCROLL_EDGE_PX, extent / 2);
+  if (position < edge) {
+    const strength = Math.min(1, Math.max(0, (edge - position) / edge));
+    return -SELECTION_AUTO_SCROLL_MAX_PX_PER_SECOND * strength;
+  }
+  if (position > extent - edge) {
+    const strength = Math.min(1, Math.max(0, (position - (extent - edge)) / edge));
+    return SELECTION_AUTO_SCROLL_MAX_PX_PER_SECOND * strength;
+  }
+  return 0;
+}
+
+/**
+ * Return a logical-LTR viewport velocity for one drag-selection pointer.
+ * Physical left/right are inverted for an RTL sheet because logical x=0 is
+ * always the column-A edge. Row/column header selections suppress the axis
+ * that cannot extend that selection.
+ */
+export function selectionAutoScrollVelocity(
+  point: SelectionAutoScrollPoint,
+  viewport: SelectionAutoScrollViewport,
+  rtl: boolean,
+  mode: SelectionAutoScrollMode,
+): SelectionAutoScrollPoint {
+  if (mode === 'all') return { x: 0, y: 0 };
+  const physicalX = mode === 'rows' ? 0 : axisVelocity(point.x, viewport.width);
+  const y = mode === 'cols' ? 0 : axisVelocity(point.y, viewport.height);
+  return { x: rtl ? -physicalX : physicalX, y };
+}

--- a/packages/xlsx/src/sheet-viewer.test.ts
+++ b/packages/xlsx/src/sheet-viewer.test.ts
@@ -80,7 +80,7 @@ describe('XlsxSheetViewer canvas mount', () => {
     expect(popupDocument.listenerCount('keydown')).toBe(0);
   });
 
-  it('uses the caller canvas without constructing workbook footer chrome', () => {
+  it('uses the caller canvas with native scrollbars and without workbook footer chrome', () => {
     installDom();
     const parent = makeContainer();
     const canvas = makeEl('canvas');
@@ -96,10 +96,97 @@ describe('XlsxSheetViewer canvas mount', () => {
     const viewportInput = descendants(parent).find(
       (element) => element.getAttribute('data-xlsx-viewport-input') === 'sheet',
     );
+    expect(viewportInput?.style.overflow).toBe('auto');
+    expect(viewportInput?.children).toHaveLength(1);
+    expect(descendants(parent).some((element) => element.style.overflow === 'auto')).toBe(true);
+
+    viewer.destroy();
+  });
+
+  it('can hide native sheet scrollbars without adding workbook footer chrome', () => {
+    installDom();
+    const parent = makeContainer();
+    const canvas = makeEl('canvas');
+    parent.appendChild(canvas);
+
+    const viewer = new XlsxSheetViewer(canvas as unknown as HTMLCanvasElement, {
+      showScrollbars: false,
+    });
+
+    const viewportInput = descendants(parent).find(
+      (element) => element.getAttribute('data-xlsx-viewport-input') === 'sheet',
+    );
     expect(viewportInput?.style.overflow).toBe('clip');
     expect(viewportInput?.children).toHaveLength(0);
-    expect(descendants(parent).some((element) => element.style.overflow === 'auto')).toBe(false);
+    expect(descendants(parent).filter((element) => element.tag === 'button')).toHaveLength(0);
 
+    viewer.destroy();
+  });
+
+  it('continues drag selection beyond the visible viewport while auto-scrolling', () => {
+    const doc = installDom();
+    const parent = makeContainer();
+    const canvas = makeEl('canvas');
+    parent.appendChild(canvas);
+    const viewer = new XlsxSheetViewer(canvas as unknown as HTMLCanvasElement);
+    const engine = (viewer as unknown as { engine: {
+      currentWorksheet: Worksheet;
+      canvasArea: FakeEl;
+      scrollHost: FakeEl;
+      viewport: {
+        setExtent(width: number, height: number): void;
+        setViewportSize(width: number, height: number): void;
+      };
+      scheduleRender(): void;
+    } }).engine;
+    engine.currentWorksheet = {
+      ...worksheet('Long sheet'),
+      defaultColWidth: 8.43,
+    };
+    engine.canvasArea.clientWidth = 800;
+    engine.canvasArea.clientHeight = 600;
+    engine.scrollHost.clientWidth = 800;
+    engine.scrollHost.clientHeight = 600;
+    engine.scrollHost.scrollWidth = 5_000;
+    engine.scrollHost.scrollHeight = 5_000;
+    engine.viewport.setExtent(5_000, 5_000);
+    engine.viewport.setViewportSize(800, 600);
+    engine.scheduleRender = () => undefined;
+
+    const frames: FrameRequestCallback[] = [];
+    Object.assign(doc.defaultView, {
+      requestAnimationFrame: (callback: FrameRequestCallback) => {
+        frames.push(callback);
+        return frames.length;
+      },
+      cancelAnimationFrame: () => undefined,
+    });
+    const pointer = (overrides: Record<string, unknown>) => ({
+      button: 0,
+      pointerId: 1,
+      pointerType: 'mouse',
+      clientX: 100,
+      clientY: 100,
+      shiftKey: false,
+      preventDefault: () => undefined,
+      ...overrides,
+    });
+
+    engine.scrollHost.dispatch('pointerdown', pointer({}));
+    engine.scrollHost.dispatch('pointermove', pointer({ clientX: 790, clientY: 590 }));
+    const visibleEdgeSelection = viewer.selection;
+    for (let frame = 1; frame <= 20; frame += 1) {
+      const callback = frames.shift();
+      expect(callback).toBeDefined();
+      callback?.(frame * 16);
+    }
+
+    expect(viewer.getViewportOffset().x).toBeGreaterThan(0);
+    expect(viewer.getViewportOffset().y).toBeGreaterThan(0);
+    expect(viewer.selection?.active.row).toBeGreaterThan(visibleEdgeSelection?.active.row ?? 0);
+    expect(viewer.selection?.active.col).toBeGreaterThan(visibleEdgeSelection?.active.col ?? 0);
+
+    engine.scrollHost.dispatch('pointerup', pointer({ clientX: 790, clientY: 590 }));
     viewer.destroy();
   });
 

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -52,6 +52,7 @@ import {
 } from './internal/sheet-viewer-runtime.js';
 import { CanvasSurface, SheetOverlayHost } from './internal/sheet-surface.js';
 import { withXlsxRenderCommitGuard } from './render-orchestrator.js';
+import { selectionAutoScrollVelocity } from './selection-auto-scroll.js';
 
 const borrowedWorkbookOption = Symbol('XlsxViewer.borrowedWorkbook');
 
@@ -141,6 +142,12 @@ export interface XlsxSheetViewerOptions extends LoadOptions {
    * loaded file. Default: true.
    */
   resizable?: boolean;
+  /**
+   * Show native horizontal and vertical scrollbars for the worksheet viewport.
+   * Default: true. Wheel/trackpad panning remains available when explicitly
+   * disabled.
+   */
+  showScrollbars?: boolean;
   /** Lower/upper bounds for the zoom slider as scale factors. Default 0.1–4
    *  (10%–400%, matching Excel's zoom range). Also the clamp range for the IX9
    *  {@link ZoomableViewer} zoom contract ({@link XlsxViewer.setScale} etc.). */
@@ -440,6 +447,8 @@ class XlsxViewerEngine implements ZoomableViewer {
   private sheetViews = new Map<number, Worksheet>();
   private opts: XlsxViewerOptions;
   private readonly _mountKind: XlsxViewerMount['kind'];
+  /** Whether this mount delegates viewport movement to a native scroll host. */
+  private readonly _nativeScrollbars: boolean;
   /** 'main' renders on this thread; 'worker' paints worker-produced bitmaps. */
   private readonly _mode: 'main' | 'worker';
   private _borrowed = false;
@@ -527,6 +536,12 @@ class XlsxViewerEngine implements ZoomableViewer {
   private resizeDrag:
     | { kind: 'col' | 'row'; index: number; originScaled: number; mdw: number; pointerId: number }
     | null = null;
+  /** Last captured drag-selection pointer, retained while edge scrolling runs. */
+  private selectionAutoScrollPointer:
+    | { clientX: number; clientY: number; pointerId: number }
+    | null = null;
+  private selectionAutoScrollFrame: number | null = null;
+  private selectionAutoScrollLastTime: number | null = null;
 
   // ─── Comment hover popup (Excel-style note) ───────────────────────────────
   /** DOM overlay element that shows the hovered cell's comment. Lives in
@@ -576,6 +591,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     this.hostWindow = hostWindow;
     this.opts = opts;
     this._mountKind = mount.kind;
+    this._nativeScrollbars = opts.showScrollbars ?? true;
     const borrowedWorkbook = (opts as InternalXlsxViewerOptions)[borrowedWorkbookOption];
     this._borrowed = borrowedWorkbook !== undefined;
     this._mode = mount.kind === 'sheet'
@@ -628,11 +644,11 @@ class XlsxViewerEngine implements ZoomableViewer {
     this.scrollHost.setAttribute('data-xlsx-viewport-input', mount.kind);
     this.scrollHost.style.cssText =
       `position:absolute;inset:0;` +
-      `overflow:${mount.kind === 'composite' ? 'auto' : 'clip'};` +
+      `overflow:${this._nativeScrollbars ? 'auto' : 'clip'};` +
       `z-index:2;background:transparent;`;
     this.spacer = this.hostDocument.createElement('div');
     this.spacer.style.cssText = `position:absolute;top:0;left:0;pointer-events:none;`;
-    if (mount.kind === 'composite') this.scrollHost.appendChild(this.spacer);
+    if (this._nativeScrollbars) this.scrollHost.appendChild(this.spacer);
     this.surface = new CanvasSurface(this.canvas, this.canvasArea, this.scrollHost);
     this.overlayHost = new SheetOverlayHost(this.canvasArea, this.canvas, this.scrollHost, {
       commentMaxWidth: COMMENT_POPUP_MAX_W,
@@ -645,8 +661,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     this.commentPopup = this.overlayHost.comment;
     this.validationPanel = this.overlayHost.validation;
     // Inject the shared viewer stylesheet once per module (idempotent). Both
-    // mounts use it: the composite footer hides its tab-strip scrollbar and the
-    // canvas mount hides native sheet scrollbars while retaining pan input.
+    // mounts use it; the composite footer also hides its tab-strip scrollbar.
     ensureViewerStyleInjected(this.hostDocument);
 
     if (mount.kind === 'composite') {
@@ -716,7 +731,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     this.rowGutter.addEventListener('pointerdown', (e) => this.onGutterPointerDown(e, 'row'));
     this.colGutter.addEventListener('pointerdown', (e) => this.onGutterPointerDown(e, 'col'));
 
-    if (mount.kind === 'composite') this.surface.on('scroll', () => {
+    if (this._nativeScrollbars) this.surface.on('scroll', () => {
       // Any scroll cancels a deferred tap: the press that started it was a
       // scrollbar-thumb drag (overlay scrollbars) or a touch swipe, not a
       // cell click.
@@ -1481,13 +1496,13 @@ class XlsxViewerEngine implements ZoomableViewer {
   }
 
   private syncNativeViewportExtent(): void {
-    if (this._mountKind !== 'composite') return;
+    if (!this._nativeScrollbars) return;
     this.viewport.setViewportSize(this.scrollHost.clientWidth, this.scrollHost.clientHeight);
     this.viewport.ensureExtent(this.scrollHost.scrollWidth, this.scrollHost.scrollHeight);
   }
 
   private get viewportTop(): number {
-    if (this._mountKind === 'composite') {
+    if (this._nativeScrollbars) {
       this.syncNativeViewportExtent();
       this.viewport.adoptNativeOffset(this.viewport.x, this.scrollHost.scrollTop);
     }
@@ -1496,7 +1511,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
   private set viewportTop(value: number) {
     this.viewport.setOffset(this.viewport.x, value);
-    if (this._mountKind === 'composite') this.scrollHost.scrollTop = this.viewport.y;
+    if (this._nativeScrollbars) this.scrollHost.scrollTop = this.viewport.y;
   }
 
   /**
@@ -1515,7 +1530,7 @@ class XlsxViewerEngine implements ZoomableViewer {
    * `scrollLeft` sign conventions.
    */
   private get effectiveScrollLeft(): number {
-    if (this._mountKind === 'composite') {
+    if (this._nativeScrollbars) {
       this.syncNativeViewportExtent();
       const raw = this.scrollHost.scrollLeft;
       this.viewport.adoptNativeOffset(this.isRtl ? this.maxScrollLeft - raw : raw, this.viewport.y);
@@ -1525,7 +1540,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
   private setViewportLeft(value: number): void {
     this.viewport.setOffset(value, this.viewport.y);
-    if (this._mountKind === 'composite') {
+    if (this._nativeScrollbars) {
       this.scrollHost.scrollLeft = this.isRtl
         ? Math.max(0, this.maxScrollLeft - this.viewport.x)
         : this.viewport.x;
@@ -1550,7 +1565,7 @@ class XlsxViewerEngine implements ZoomableViewer {
    *  the right end for RTL (so col A shows first). */
   private resetHorizontalScroll(): void {
     this.viewport.setOffset(0, this.viewport.y);
-    if (this._mountKind === 'composite') {
+    if (this._nativeScrollbars) {
       this.scrollHost.scrollLeft = this.isRtl ? this.maxScrollLeft : 0;
     }
   }
@@ -1560,7 +1575,7 @@ class XlsxViewerEngine implements ZoomableViewer {
    *  for LTR the native scrollLeft *is* start-anchored and the browser
    *  already clamps it sensibly on resize. */
   private reanchorHorizontalScroll(): void {
-    if (this._mountKind === 'sheet') return;
+    if (!this._nativeScrollbars) return;
     if (!this.isRtl || this.scrollHost.clientWidth === 0) return;
     const want = Math.max(0, this.maxScrollLeft - this.viewport.x);
     if (Math.abs(this.scrollHost.scrollLeft - want) > 1) {
@@ -2672,6 +2687,138 @@ class XlsxViewerEngine implements ZoomableViewer {
     this.opts.onSelectionChange?.(this.selection);
   }
 
+  /** Extend the active drag selection to the pointer's cell. Auto-scroll ticks
+   * clamp an outside pointer to the visible data edge so each viewport movement
+   * advances the active cell even when no new pointermove event is emitted. */
+  private extendDragSelection(
+    clientX: number,
+    clientY: number,
+    clampToViewport: boolean,
+  ): boolean {
+    let pointerX = clientX;
+    let pointerY = clientY;
+    if (clampToViewport) {
+      const rect = this.canvasArea.getBoundingClientRect();
+      const cs = this.viewport.scale;
+      const headerW = Math.round(HEADER_W * cs);
+      const headerH = Math.round(HEADER_H * cs);
+      const dataLeft = rect.left + (this.isRtl ? 0 : headerW);
+      const dataRight = rect.left + rect.width - (this.isRtl ? headerW : 0);
+      pointerX = Math.min(dataRight - 1, Math.max(dataLeft + 1, pointerX));
+      pointerY = Math.min(rect.top + rect.height - 1, Math.max(rect.top + headerH + 1, pointerY));
+    }
+
+    if (this.selectionMode === 'rows') {
+      const hit = clampToViewport ? null : this.getHeaderHit(pointerX, pointerY);
+      const row = hit?.kind === 'row'
+        ? hit.row
+        : this.getCellAt(pointerX, pointerY)?.row;
+      if (!row || row === this.activeCell?.row) return false;
+      this.selectionController.extend({ row, col: 1 });
+      return true;
+    }
+
+    if (this.selectionMode === 'cols') {
+      const hit = clampToViewport ? null : this.getHeaderHit(pointerX, pointerY);
+      const col = hit?.kind === 'col'
+        ? hit.col
+        : this.getCellAt(pointerX, pointerY)?.col;
+      if (!col || col === this.activeCell?.col) return false;
+      this.selectionController.extend({ row: 1, col });
+      return true;
+    }
+
+    const cell = this.getCellAt(pointerX, pointerY);
+    if (!cell || (cell.row === this.activeCell?.row && cell.col === this.activeCell?.col)) {
+      return false;
+    }
+    this.selectionController.extend(cell);
+    return true;
+  }
+
+  private selectionAutoScrollSpeed(): { x: number; y: number } {
+    const pointer = this.selectionAutoScrollPointer;
+    if (!pointer) return { x: 0, y: 0 };
+    const rect = this.canvasArea.getBoundingClientRect();
+    return selectionAutoScrollVelocity(
+      { x: pointer.clientX - rect.left, y: pointer.clientY - rect.top },
+      { width: rect.width, height: rect.height },
+      this.isRtl,
+      this.selectionMode,
+    );
+  }
+
+  private trackSelectionAutoScroll(e: PointerEvent): void {
+    this.selectionAutoScrollPointer = {
+      clientX: e.clientX,
+      clientY: e.clientY,
+      pointerId: e.pointerId,
+    };
+    const speed = this.selectionAutoScrollSpeed();
+    if (speed.x === 0 && speed.y === 0) {
+      this.stopSelectionAutoScroll();
+      return;
+    }
+    if (this.selectionAutoScrollFrame !== null) return;
+    this.selectionAutoScrollLastTime = null;
+    this.selectionAutoScrollFrame = this.hostWindow.requestAnimationFrame(
+      (time) => this.runSelectionAutoScroll(time),
+    );
+  }
+
+  private runSelectionAutoScroll(time: number): void {
+    this.selectionAutoScrollFrame = null;
+    const pointer = this.selectionAutoScrollPointer;
+    if (!pointer || !this.isSelecting || this._destroyed) {
+      this.stopSelectionAutoScroll();
+      return;
+    }
+
+    const speed = this.selectionAutoScrollSpeed();
+    if (speed.x === 0 && speed.y === 0) {
+      this.stopSelectionAutoScroll();
+      return;
+    }
+
+    const previousTime = this.selectionAutoScrollLastTime;
+    const elapsedSeconds = previousTime === null
+      ? 1 / 60
+      : Math.min(0.05, Math.max(0, time - previousTime) / 1000);
+    this.selectionAutoScrollLastTime = time;
+
+    const beforeX = this.effectiveScrollLeft;
+    const beforeY = this.viewportTop;
+    this.setViewportLeft(beforeX + speed.x * elapsedSeconds);
+    this.viewportTop = beforeY + speed.y * elapsedSeconds;
+    const moved = this.effectiveScrollLeft !== beforeX || this.viewportTop !== beforeY;
+    const extended = moved && this.extendDragSelection(pointer.clientX, pointer.clientY, true);
+
+    if (moved) {
+      this.updateSelectionOverlay();
+      this.updateFindOverlay();
+      this.scheduleRender();
+      this.emitViewportChange();
+      if (extended) this.opts.onSelectionChange?.(this.selection);
+    }
+
+    if (!moved) {
+      this.stopSelectionAutoScroll();
+      return;
+    }
+    this.selectionAutoScrollFrame = this.hostWindow.requestAnimationFrame(
+      (nextTime) => this.runSelectionAutoScroll(nextTime),
+    );
+  }
+
+  private stopSelectionAutoScroll(): void {
+    if (this.selectionAutoScrollFrame !== null) {
+      this.hostWindow.cancelAnimationFrame(this.selectionAutoScrollFrame);
+      this.selectionAutoScrollFrame = null;
+    }
+    this.selectionAutoScrollPointer = null;
+    this.selectionAutoScrollLastTime = null;
+  }
+
   private setupSelectionEvents(): void {
     // Distance (CSS px) beyond which a touch/pen pointerdown→pointerup is treated as a swipe (scroll), not a tap.
     const TAP_SLOP = 8;
@@ -2728,7 +2875,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       }
       // Overlay scrollbar hit band (~15 CSS px on macOS / Windows 11).
       const OVERLAY_SCROLLBAR_BAND = 16;
-      const inOverlayBand = this._mountKind === 'composite' && (
+      const inOverlayBand = this._nativeScrollbars && (
         (this.scrollHost.scrollWidth > this.scrollHost.clientWidth &&
           this.scrollHost.clientHeight - localY <= OVERLAY_SCROLLBAR_BAND) ||
         (this.scrollHost.scrollHeight > this.scrollHost.clientHeight &&
@@ -2808,21 +2955,8 @@ class XlsxViewerEngine implements ZoomableViewer {
 
       if (!this.isSelecting) return;
 
-      if (this.selectionMode === 'rows') {
-        const hit = this.getHeaderHit(e.clientX, e.clientY);
-        const row = hit?.kind === 'row' ? hit.row : this.getCellAt(e.clientX, e.clientY)?.row;
-        if (!row || row === this.activeCell?.row) return;
-        this.selectionController.extend({ row, col: 1 });
-      } else if (this.selectionMode === 'cols') {
-        const hit = this.getHeaderHit(e.clientX, e.clientY);
-        const col = hit?.kind === 'col' ? hit.col : this.getCellAt(e.clientX, e.clientY)?.col;
-        if (!col || col === this.activeCell?.col) return;
-        this.selectionController.extend({ row: 1, col });
-      } else {
-        const cell = this.getCellAt(e.clientX, e.clientY);
-        if (!cell || (cell.row === this.activeCell?.row && cell.col === this.activeCell?.col)) return;
-        this.selectionController.extend(cell);
-      }
+      this.trackSelectionAutoScroll(e);
+      if (!this.extendDragSelection(e.clientX, e.clientY, false)) return;
 
       this.updateSelectionOverlay();
       // Drag-select fires per pointermove; coalesce the canvas repaint (the
@@ -2860,6 +2994,7 @@ class XlsxViewerEngine implements ZoomableViewer {
         }
         this.pendingTap = null;
       }
+      this.stopSelectionAutoScroll();
       // IX1 — a mouse click (press+release without a drag) on a hyperlinked cell
       // activates it. The release must still land on the same cell the press did.
       if (this.pendingClick && this.pendingClick.pointerId === e.pointerId) {
@@ -2889,6 +3024,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       if (this.pendingClick && this.pendingClick.pointerId === e.pointerId) {
         this.pendingClick = null;
       }
+      this.stopSelectionAutoScroll();
       this.isSelecting = false;
     });
 
@@ -2902,7 +3038,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       'wheel',
       (e: WheelEvent) => {
         if (!(e.ctrlKey || e.metaKey)) {
-          if (this._mountKind === 'sheet') {
+          if (!this._nativeScrollbars) {
             e.preventDefault();
             const unit = e.deltaMode === WheelEvent.DOM_DELTA_LINE
               ? 16
@@ -3551,6 +3687,7 @@ class XlsxViewerEngine implements ZoomableViewer {
     // viewer (checked at the top of _reportRenderError). The acquisition owner
     // invalidates any load still in flight below.
     this._destroyed = true;
+    this.stopSelectionAutoScroll();
     this.sheetRequestGeneration++;
     this.resizeObserver?.disconnect();
     this.renderDispatcher.destroy();

--- a/site/src/lib/api-reference.ts
+++ b/site/src/lib/api-reference.ts
@@ -303,6 +303,7 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
         { name: 'showZoomSlider', type: 'boolean', def: 'true', desc: 'Show the Excel-style zoom slider at the end of the tab bar. Zooming (slider, Ctrl/⌘+wheel, trackpad pinch) is view-only.' },
         { name: 'zoomMin / zoomMax', type: 'number', def: '0.1 / 4', desc: 'Zoom slider bounds as scale factors (10%–400%).' },
         { name: 'resizable', type: 'boolean', def: 'true', desc: 'Allow resizing columns/rows by dragging header borders. View-only — it changes the on-screen view only and never modifies the loaded file. Set false to disable.', emphasis: 'View-only — it changes the on-screen view only and never modifies the loaded file.' },
+        { name: 'showScrollbars', type: 'boolean', def: 'true', desc: 'Show native worksheet scrollbars. Set false only when the host supplies another viewport navigation UI.' },
         { name: 'selectionColor', type: 'string', def: "'#1a73e8'", desc: 'Accent color for the cell-selection rectangle (any CSS color). The fill is the same color at 8% opacity.' },
         FIND_HIGHLIGHT_COLORS,
         { name: 'hiddenSheetMode', type: "'show' | 'skip' | 'dim'", def: "'show'", desc: 'How hidden / very-hidden sheets (`<sheet state>`, §18.2.19) appear in the tab bar. `show` renders a tab like any other; `skip` hides the tab (`display:none`) and makes sequential navigation jump over it; `dim` renders the tab at reduced opacity. Mirrors pptx `hiddenSlideMode`.' },
@@ -353,11 +354,12 @@ export const apiReference: Record<'docx' | 'xlsx' | 'pptx', ApiClass[]> = {
     {
       name: 'XlsxSheetViewer',
       ctor: 'new XlsxSheetViewer(canvas: HTMLCanvasElement, options?: XlsxSheetViewerOptions)',
-      note: 'Canvas-mounted active-sheet viewport. It uses the caller canvas and the same sheet rendering, selection, find and navigation mechanics as XlsxViewer, but creates no sheet-tab/footer chrome or visible scrollbar. DOM chrome, styles and listeners follow canvas.ownerDocument, so a parent page can mount borrowed workbook sheets into same-origin popup canvases.',
+      note: 'Canvas-mounted active-sheet viewport. It uses the caller canvas and the same sheet rendering, selection, find and navigation mechanics as XlsxViewer, but creates no sheet-tab/footer chrome. Native worksheet scrollbars are visible by default. DOM chrome, styles and listeners follow canvas.ownerDocument, so a parent page can mount borrowed workbook sheets into same-origin popup canvases.',
       options: [
         { name: 'cellScale', type: 'number', def: '1', desc: 'Scale factor for cell/header dimensions (0.5 = half size).' },
         { name: 'zoomMin / zoomMax', type: 'number', def: '0.1 / 4', desc: 'Zoom bounds as scale factors (10%–400%).' },
         { name: 'resizable', type: 'boolean', def: 'true', desc: 'Allow resizing columns/rows by dragging header borders. View-only.' },
+        { name: 'showScrollbars', type: 'boolean', def: 'true', desc: 'Show native worksheet scrollbars. Set false only when the host supplies another viewport navigation UI.' },
         { name: 'selectionColor', type: 'string', def: "'#1a73e8'", desc: 'Accent color for the cell-selection rectangle.' },
         FIND_HIGHLIGHT_COLORS,
         { name: 'hiddenSheetMode', type: "'show' | 'skip' | 'dim'", def: "'show'", desc: 'Controls sequential navigation and hidden-sheet visibility without adding tab chrome.' },

--- a/site/src/lib/demos.ts
+++ b/site/src/lib/demos.ts
@@ -177,7 +177,7 @@ function mountSheetWindows(el: HTMLElement, url: string): void {
           const popup = window.open(
             '',
             '_blank',
-            'popup=yes,width=1100,height=720,resizable=yes,scrollbars=no',
+            'popup=yes,width=1100,height=720,resizable=yes',
           );
           if (!popup) {
             popupError.textContent = 'The browser blocked the popup. Allow popups and try again.';

--- a/site/src/pages/xlsx.astro
+++ b/site/src/pages/xlsx.astro
@@ -14,7 +14,7 @@ import { xlsxSheetSnippet, xlsxSheetWindowsSnippet } from '../lib/demo-snippets'
   <DemoBlock
     format="xlsx" kind="sheetWindows" badge="Workbook · Multi-window"
     title="One workbook. Many windows."
-    description="Parse the file once in the parent page, then open any sheet in its own browser window. Every window gets an independent scroll, zoom and selection state while the workbook archive, worksheet cache and render worker remain shared. Open two or more sheets to compare them side by side."
+    description="Parse the file once in the parent page, then open any sheet in its own browser window. Every window gets its own visible scrollbars, zoom and selection state while the workbook archive, worksheet cache and render worker remain shared. Open two or more sheets to compare them side by side."
     code={xlsxSheetWindowsSnippet}
   />
   <ApiReference format="xlsx" />

--- a/site/src/xlsx-sheet-overview.test.ts
+++ b/site/src/xlsx-sheet-overview.test.ts
@@ -21,6 +21,8 @@ describe('XLSX multi-window sheet demo', () => {
     expect(demos).toContain("window.open(");
     expect(demos).toContain('const popupDocument = popup.document');
     expect(demos).toContain('const viewer = XlsxSheetViewer.fromWorkbook(canvas, workbook, {');
+    expect(demos).not.toContain('showScrollbars: false');
+    expect(demos).not.toContain('scrollbars=no');
     expect(demos).toContain('workbook,');
     expect(demos).toContain('viewer.goToSheet(index)');
     expect(demos).toContain('popup.addEventListener(\'pagehide\'');


### PR DESCRIPTION
## Summary
- Show native worksheet scrollbars by default in both workbook and sheet viewers, with an explicit opt-out for custom viewport navigation.
- Extend cell, row, and column drag selections beyond the visible viewport using frame-rate-independent, RTL-aware edge scrolling.
- Update the multi-window XLSX example and public API documentation.

## Verification
- Full unit suite: 6,618 passed; 27 skipped.
- TypeScript typecheck.
- Package and official-site production builds.
- XLSX public API baseline and viewer API symmetry checks.
- Focused pointer-driven auto-scroll and scrollbar behavior tests.