### PR TITLE
fix(vscode): exclude stale source maps from VSIX

### DIFF
--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -2,6 +2,7 @@
 .vscode-test/**
 src/**
 node_modules/**
+**/*.map
 *.config.mjs
 tsconfig.json
 esbuild.config.mjs

--- a/packages/vscode-extension/src/package-boundary.test.ts
+++ b/packages/vscode-extension/src/package-boundary.test.ts
@@ -1,0 +1,44 @@
+import { execFileSync } from 'node:child_process';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const extensionRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const vsce = resolve(extensionRoot, 'node_modules/.bin/vsce');
+const fixtures: string[] = [];
+
+afterEach(() => {
+  for (const fixture of fixtures.splice(0)) rmSync(fixture, { recursive: true, force: true });
+});
+
+describe('VS Code extension package boundary', () => {
+  it('never includes development source maps left by a previous build', () => {
+    const fixture = mkdtempSync(resolve(tmpdir(), 'ooxml-vscode-package-'));
+    fixtures.push(fixture);
+    mkdirSync(resolve(fixture, 'dist'));
+    for (const file of ['package.json', 'README.md', 'icon.png', '.vscodeignore']) {
+      copyFileSync(resolve(extensionRoot, file), resolve(fixture, file));
+    }
+    writeFileSync(resolve(fixture, 'dist/extension.js'), 'module.exports = {};');
+    writeFileSync(resolve(fixture, 'dist/webview.js'), '(() => {})();');
+    writeFileSync(resolve(fixture, 'dist/extension.js.map'), '{"version":3}');
+    writeFileSync(resolve(fixture, 'dist/webview.js.map'), '{"version":3}');
+
+    const files = execFileSync(vsce, ['ls', '--no-dependencies'], {
+      cwd: fixture,
+      encoding: 'utf8',
+    }).trim().split('\n');
+
+    expect(files).toContain('dist/extension.js');
+    expect(files).toContain('dist/webview.js');
+    expect(files.filter((file) => file.endsWith('.map'))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Exclude source maps from the VS Code extension package boundary.
- Add a VSCE-backed regression test using a reused dist directory.
- Keep production package contents deterministic between clean CI and local builds.

## Root cause
Production esbuild disables source map generation but does not remove maps from an earlier development build. VSCE included the stale 14.5 MB webview source map, increasing the compressed VSIX from 3.80 MB to 7.63 MB.

The Marketplace 0.76.0 and 0.76.1 packages were built in clean runners and remain approximately 3.8 MB; this fixes dirty or reused workspaces.

## Verification
- Extension test suite: 29 passed.
- Extension TypeScript typecheck.
- Repackaged with a stale map present: 3.80 MB, 7 files, no source maps.