### PR TITLE
fix(xlsx): harden drag selection ownership

### DIFF
--- a/packages/vscode-extension/src/package-boundary.test.ts
+++ b/packages/vscode-extension/src/package-boundary.test.ts
@@ -6,13 +6,16 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const extensionRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const vsce = resolve(extensionRoot, 'node_modules/.bin/vsce');
+const require = createRequire(import.meta.url);
+const vscePackage = require.resolve('@vscode/vsce/package.json');
+const vsce = resolve(dirname(vscePackage), 'vsce');
 const fixtures: string[] = [];
 
 afterEach(() => {
@@ -32,10 +35,10 @@ describe('VS Code extension package boundary', () => {
     writeFileSync(resolve(fixture, 'dist/extension.js.map'), '{"version":3}');
     writeFileSync(resolve(fixture, 'dist/webview.js.map'), '{"version":3}');
 
-    const files = execFileSync(vsce, ['ls', '--no-dependencies'], {
+    const files = execFileSync(process.execPath, [vsce, 'ls', '--no-dependencies'], {
       cwd: fixture,
       encoding: 'utf8',
-    }).trim().split('\n');
+    }).trim().split(/\r?\n/);
 
     expect(files).toContain('dist/extension.js');
     expect(files).toContain('dist/webview.js');

--- a/packages/xlsx/src/internal/sheet-viewer-runtime.test.ts
+++ b/packages/xlsx/src/internal/sheet-viewer-runtime.test.ts
@@ -117,6 +117,21 @@ describe('XLSX viewer composition roles', () => {
     expect(selection.active).toBeNull();
   });
 
+  it('SelectionController only ends a drag for its active pointer', () => {
+    const selection = new SelectionController();
+    selection.beginDrag(7);
+    expect(selection.dragging).toBe(true);
+    expect(selection.draggingPointerId).toBe(7);
+
+    selection.endDrag(9);
+    expect(selection.dragging).toBe(true);
+    expect(selection.draggingPointerId).toBe(7);
+
+    selection.endDrag(7);
+    expect(selection.dragging).toBe(false);
+    expect(selection.draggingPointerId).toBeNull();
+  });
+
   it('SelectionController owns range extension and renderer header projection', () => {
     const selection = new SelectionController();
     selection.select({ row: 2, col: 1 }, 'rows');

--- a/packages/xlsx/src/internal/sheet-viewer-runtime.ts
+++ b/packages/xlsx/src/internal/sheet-viewer-runtime.ts
@@ -241,7 +241,7 @@ export class SelectionController {
   private anchorCell: SheetCellAddress | null = null;
   private activeCell: SheetCellAddress | null = null;
   private selectionMode: SheetSelectionMode = 'cells';
-  private dragActive = false;
+  private dragPointerId: number | null = null;
 
   get anchor(): SheetCellAddress | null {
     return this.anchorCell ? { ...this.anchorCell } : null;
@@ -252,7 +252,8 @@ export class SelectionController {
   }
 
   get mode(): SheetSelectionMode { return this.selectionMode; }
-  get dragging(): boolean { return this.dragActive; }
+  get dragging(): boolean { return this.dragPointerId !== null; }
+  get draggingPointerId(): number | null { return this.dragPointerId; }
 
   setAnchor(cell: SheetCellAddress | null): void {
     this.anchorCell = cell ? { ...cell } : null;
@@ -263,13 +264,20 @@ export class SelectionController {
   }
 
   setMode(mode: SheetSelectionMode): void { this.selectionMode = mode; }
-  setDragging(dragging: boolean): void { this.dragActive = dragging; }
+
+  beginDrag(pointerId: number): void {
+    this.dragPointerId = pointerId;
+  }
+
+  endDrag(pointerId?: number): void {
+    if (pointerId === undefined || pointerId === this.dragPointerId) this.dragPointerId = null;
+  }
 
   reset(): void {
     this.anchorCell = null;
     this.activeCell = null;
     this.selectionMode = 'cells';
-    this.dragActive = false;
+    this.dragPointerId = null;
   }
 
   select(cell: SheetCellAddress, mode: SheetSelectionMode = 'cells'): void {

--- a/packages/xlsx/src/sheet-viewer.test.ts
+++ b/packages/xlsx/src/sheet-viewer.test.ts
@@ -137,6 +137,7 @@ describe('XlsxSheetViewer canvas mount', () => {
         setExtent(width: number, height: number): void;
         setViewportSize(width: number, height: number): void;
       };
+      getCellAt(clientX: number, clientY: number): { row: number; col: number } | null;
       scheduleRender(): void;
     } }).engine;
     engine.currentWorksheet = {
@@ -145,8 +146,10 @@ describe('XlsxSheetViewer canvas mount', () => {
     };
     engine.canvasArea.clientWidth = 800;
     engine.canvasArea.clientHeight = 600;
-    engine.scrollHost.clientWidth = 800;
-    engine.scrollHost.clientHeight = 600;
+    // Simulate classic scrollbars that reserve a 20px gutter inside the
+    // canvasArea (unlike overlay scrollbars on macOS).
+    engine.scrollHost.clientWidth = 780;
+    engine.scrollHost.clientHeight = 580;
     engine.scrollHost.scrollWidth = 5_000;
     engine.scrollHost.scrollHeight = 5_000;
     engine.viewport.setExtent(5_000, 5_000);
@@ -172,9 +175,49 @@ describe('XlsxSheetViewer canvas mount', () => {
       ...overrides,
     });
 
+    engine.scrollHost.dispatch('pointerdown', pointer({
+      pointerId: 2,
+      pointerType: 'touch',
+      clientX: 400,
+      clientY: 300,
+    }));
     engine.scrollHost.dispatch('pointerdown', pointer({}));
-    engine.scrollHost.dispatch('pointermove', pointer({ clientX: 790, clientY: 590 }));
+    const primarySelection = viewer.selection;
+    engine.scrollHost.dispatch('pointerup', pointer({
+      pointerId: 2,
+      pointerType: 'touch',
+      clientX: 400,
+      clientY: 300,
+    }));
+    expect(viewer.selection).toEqual(primarySelection);
+
+    engine.scrollHost.dispatch('pointerdown', pointer({
+      pointerId: 2,
+      pointerType: 'touch',
+      clientX: 400,
+      clientY: 300,
+    }));
+    engine.scrollHost.dispatch('pointerup', pointer({
+      pointerId: 2,
+      pointerType: 'touch',
+      clientX: 400,
+      clientY: 300,
+    }));
+    engine.scrollHost.dispatch('pointermove', pointer({
+      pointerId: 2,
+      clientX: 1_600,
+      clientY: 1_200,
+    }));
+    engine.scrollHost.dispatch('pointerup', pointer({ pointerId: 2 }));
+    engine.scrollHost.dispatch('pointercancel', pointer({ pointerId: 2 }));
+    expect(frames).toHaveLength(0);
+    expect(viewer.selection).toEqual(primarySelection);
+
+    engine.scrollHost.dispatch('pointermove', pointer({ clientX: 1_600, clientY: 1_200 }));
+    expect(viewer.selection?.active).toEqual(engine.getCellAt(779, 579));
     const visibleEdgeSelection = viewer.selection;
+    engine.scrollHost.dispatch('pointerup', pointer({ pointerId: 2 }));
+    engine.scrollHost.dispatch('pointercancel', pointer({ pointerId: 2 }));
     for (let frame = 1; frame <= 20; frame += 1) {
       const callback = frames.shift();
       expect(callback).toBeDefined();
@@ -186,7 +229,7 @@ describe('XlsxSheetViewer canvas mount', () => {
     expect(viewer.selection?.active.row).toBeGreaterThan(visibleEdgeSelection?.active.row ?? 0);
     expect(viewer.selection?.active.col).toBeGreaterThan(visibleEdgeSelection?.active.col ?? 0);
 
-    engine.scrollHost.dispatch('pointerup', pointer({ clientX: 790, clientY: 590 }));
+    engine.scrollHost.dispatch('pointerup', pointer({ clientX: 1_600, clientY: 1_200 }));
     viewer.destroy();
   });
 

--- a/packages/xlsx/src/viewer.ts
+++ b/packages/xlsx/src/viewer.ts
@@ -495,8 +495,16 @@ class XlsxViewerEngine implements ZoomableViewer {
     return this.selectionController.dragging;
   }
 
-  private set isSelecting(value: boolean) {
-    this.selectionController.setDragging(value);
+  private get selectionPointerId(): number | null {
+    return this.selectionController.draggingPointerId;
+  }
+
+  /** Claim drag-selection ownership and discard deferred gestures from any
+   * other pointer that began before this drag. */
+  private beginSelectionDrag(pointerId: number): void {
+    if (this.pendingTap?.pointerId !== pointerId) this.pendingTap = null;
+    if (this.pendingClick?.pointerId !== pointerId) this.pendingClick = null;
+    this.selectionController.beginDrag(pointerId);
   }
 
   /** Gesture-only pointer anchor for the NEXT `setScale`, in canvasArea-viewport
@@ -2634,7 +2642,7 @@ class XlsxViewerEngine implements ZoomableViewer {
         this.selectionMode = 'all';
         this.anchorCell = { row: 1, col: 1 };
         this.activeCell = { row: 1, col: 1 };
-        this.isSelecting = false;
+        this.selectionController.endDrag();
       } else if (headerHit.kind === 'row') {
         if (shiftKey && this.anchorCell && this.selectionMode === 'rows') {
           this.selectionController.extend({ row: headerHit.row, col: 1 });
@@ -2643,7 +2651,7 @@ class XlsxViewerEngine implements ZoomableViewer {
           this.anchorCell = { row: headerHit.row, col: 1 };
           this.activeCell = { row: headerHit.row, col: 1 };
           if (allowDrag) {
-            this.isSelecting = true;
+            this.beginSelectionDrag(pointerId);
             this.scrollHost.setPointerCapture(pointerId);
           }
         }
@@ -2655,7 +2663,7 @@ class XlsxViewerEngine implements ZoomableViewer {
           this.anchorCell = { row: 1, col: headerHit.col };
           this.activeCell = { row: 1, col: headerHit.col };
           if (allowDrag) {
-            this.isSelecting = true;
+            this.beginSelectionDrag(pointerId);
             this.scrollHost.setPointerCapture(pointerId);
           }
         }
@@ -2677,7 +2685,7 @@ class XlsxViewerEngine implements ZoomableViewer {
       this.activeCell = cell;
     }
     if (allowDrag) {
-      this.isSelecting = true;
+      this.beginSelectionDrag(pointerId);
       this.scrollHost.setPointerCapture(pointerId);
     }
     this.updateSelectionOverlay();
@@ -2687,9 +2695,24 @@ class XlsxViewerEngine implements ZoomableViewer {
     this.opts.onSelectionChange?.(this.selection);
   }
 
-  /** Extend the active drag selection to the pointer's cell. Auto-scroll ticks
-   * clamp an outside pointer to the visible data edge so each viewport movement
-   * advances the active cell even when no new pointermove event is emitted. */
+  /** Browser-visible input box, excluding classic native scrollbar gutters. */
+  private viewportInputBounds(): { left: number; top: number; width: number; height: number } {
+    const rect = this.canvasArea.getBoundingClientRect();
+    const left = rect.left + this.scrollHost.clientLeft;
+    const top = rect.top + this.scrollHost.clientTop;
+    const availableWidth = Math.max(0, rect.width - this.scrollHost.clientLeft);
+    const availableHeight = Math.max(0, rect.height - this.scrollHost.clientTop);
+    return {
+      left,
+      top,
+      width: Math.min(availableWidth, this.scrollHost.clientWidth || availableWidth),
+      height: Math.min(availableHeight, this.scrollHost.clientHeight || availableHeight),
+    };
+  }
+
+  /** Extend the active drag selection to the pointer's cell. Captured pointers
+   * outside the canvas and auto-scroll ticks clamp to the visible data edge so
+   * selection never jumps ahead of the viewport. */
   private extendDragSelection(
     clientX: number,
     clientY: number,
@@ -2697,15 +2720,20 @@ class XlsxViewerEngine implements ZoomableViewer {
   ): boolean {
     let pointerX = clientX;
     let pointerY = clientY;
-    if (clampToViewport) {
-      const rect = this.canvasArea.getBoundingClientRect();
+    const bounds = this.viewportInputBounds();
+    const outsideViewport = clientX < bounds.left || clientX >= bounds.left + bounds.width ||
+      clientY < bounds.top || clientY >= bounds.top + bounds.height;
+    if (clampToViewport || outsideViewport) {
       const cs = this.viewport.scale;
       const headerW = Math.round(HEADER_W * cs);
       const headerH = Math.round(HEADER_H * cs);
-      const dataLeft = rect.left + (this.isRtl ? 0 : headerW);
-      const dataRight = rect.left + rect.width - (this.isRtl ? headerW : 0);
+      const dataLeft = bounds.left + (this.isRtl ? 0 : headerW);
+      const dataRight = bounds.left + bounds.width - (this.isRtl ? headerW : 0);
       pointerX = Math.min(dataRight - 1, Math.max(dataLeft + 1, pointerX));
-      pointerY = Math.min(rect.top + rect.height - 1, Math.max(rect.top + headerH + 1, pointerY));
+      pointerY = Math.min(
+        bounds.top + bounds.height - 1,
+        Math.max(bounds.top + headerH + 1, pointerY),
+      );
     }
 
     if (this.selectionMode === 'rows') {
@@ -2739,16 +2767,17 @@ class XlsxViewerEngine implements ZoomableViewer {
   private selectionAutoScrollSpeed(): { x: number; y: number } {
     const pointer = this.selectionAutoScrollPointer;
     if (!pointer) return { x: 0, y: 0 };
-    const rect = this.canvasArea.getBoundingClientRect();
+    const bounds = this.viewportInputBounds();
     return selectionAutoScrollVelocity(
-      { x: pointer.clientX - rect.left, y: pointer.clientY - rect.top },
-      { width: rect.width, height: rect.height },
+      { x: pointer.clientX - bounds.left, y: pointer.clientY - bounds.top },
+      { width: bounds.width, height: bounds.height },
       this.isRtl,
       this.selectionMode,
     );
   }
 
   private trackSelectionAutoScroll(e: PointerEvent): void {
+    if (e.pointerId !== this.selectionPointerId) return;
     this.selectionAutoScrollPointer = {
       clientX: e.clientX,
       clientY: e.clientY,
@@ -2769,7 +2798,12 @@ class XlsxViewerEngine implements ZoomableViewer {
   private runSelectionAutoScroll(time: number): void {
     this.selectionAutoScrollFrame = null;
     const pointer = this.selectionAutoScrollPointer;
-    if (!pointer || !this.isSelecting || this._destroyed) {
+    if (
+      !pointer ||
+      pointer.pointerId !== this.selectionPointerId ||
+      !this.isSelecting ||
+      this._destroyed
+    ) {
       this.stopSelectionAutoScroll();
       return;
     }
@@ -2825,6 +2859,7 @@ class XlsxViewerEngine implements ZoomableViewer {
 
     this.surface.on('pointerdown', (e: PointerEvent) => {
       if (e.button !== 0) return;
+      if (this.isSelecting && e.pointerId !== this.selectionPointerId) return;
 
       // Drag-to-resize a column/row from its header border (issue #567). Checked
       // before selection so grabbing the border never moves the cell selection.
@@ -2953,7 +2988,7 @@ class XlsxViewerEngine implements ZoomableViewer {
           hovered && this.hyperlinkAtCell(hovered) ? 'pointer' : '';
       }
 
-      if (!this.isSelecting) return;
+      if (!this.isSelecting || e.pointerId !== this.selectionPointerId) return;
 
       this.trackSelectionAutoScroll(e);
       if (!this.extendDragSelection(e.clientX, e.clientY, false)) return;
@@ -2994,7 +3029,8 @@ class XlsxViewerEngine implements ZoomableViewer {
         }
         this.pendingTap = null;
       }
-      this.stopSelectionAutoScroll();
+      const endsSelectionDrag = e.pointerId === this.selectionPointerId;
+      if (endsSelectionDrag) this.stopSelectionAutoScroll();
       // IX1 — a mouse click (press+release without a drag) on a hyperlinked cell
       // activates it. The release must still land on the same cell the press did.
       if (this.pendingClick && this.pendingClick.pointerId === e.pointerId) {
@@ -3011,7 +3047,7 @@ class XlsxViewerEngine implements ZoomableViewer {
         }
         this.pendingClick = null;
       }
-      this.isSelecting = false;
+      if (endsSelectionDrag) this.selectionController.endDrag(e.pointerId);
     });
 
     this.surface.on('pointercancel', (e: PointerEvent) => {
@@ -3024,8 +3060,10 @@ class XlsxViewerEngine implements ZoomableViewer {
       if (this.pendingClick && this.pendingClick.pointerId === e.pointerId) {
         this.pendingClick = null;
       }
-      this.stopSelectionAutoScroll();
-      this.isSelecting = false;
+      if (e.pointerId === this.selectionPointerId) {
+        this.stopSelectionAutoScroll();
+        this.selectionController.endDrag(e.pointerId);
+      }
     });
 
     // Ctrl/⌘ + mouse wheel (and trackpad pinch, which the browser reports as a


### PR DESCRIPTION
## Summary
- Bind drag selection to its initiating pointer across every pointer event and deferred tap ordering.
- Clamp captured pointers and edge scrolling to the actual scroll-host content box, excluding classic scrollbar gutters.
- Run the VSCE package-boundary regression test through its cross-platform Node CLI entry.

## Adversarial review
An independent adversarial review was repeated after each correction. It found and verified fixes for secondary pointer move/up/cancel takeover, both pointerdown orderings, off-canvas selection jumps, classic scrollbar gutters, and Windows VSCE test portability. Final result: APPROVE with no unresolved findings.

## Verification
- Full unit suite: 6,620 passed; 27 skipped.
- XLSX and VS Code suites: 748 passed.
- Focused ownership, off-canvas, classic-scrollbar, auto-scroll, and VSCE tests: 32 passed.
- TypeScript typecheck and diff check.