### PR TITLE
fix(site): theme XLSX multi-window demo

### DIFF
--- a/site/src/lib/demos.ts
+++ b/site/src/lib/demos.ts
@@ -112,6 +112,7 @@ export function mountDemoInto(el: HTMLElement, kind: DemoKind, format: Format, u
 interface SheetWindowSession {
   readonly popup: Window;
   readonly viewer: Omit<XlsxSheetViewer, 'load'>;
+  readonly themeObserver: MutationObserver;
 }
 
 // Excel — parse once in the parent and project borrowed sheet viewers into
@@ -190,18 +191,35 @@ function mountSheetWindows(el: HTMLElement, url: string): void {
           popupDocument.title = `${name} · XLSX Sheet Viewer`;
           const popupStyle = popupDocument.createElement('style');
           popupStyle.textContent =
-            'html,body{width:100%;height:100%;margin:0;overflow:hidden;background:#eef2f6;' +
+            ':root{color-scheme:light;--sheet-window-page:#eef2f6;--sheet-window-bar:#172333;' +
+            '--sheet-window-bar-dark:#05090e;--sheet-window-bar-border:#34445a;' +
+            '--sheet-window-bar-meta:#9fe2c4}' +
+            ':root[data-theme="dark"]{color-scheme:dark;--sheet-window-page:#030508;' +
+            '--sheet-window-bar:var(--sheet-window-bar-dark);--sheet-window-bar-border:#18232f;' +
+            '--sheet-window-bar-meta:#72d9a8}' +
+            'html,body{width:100%;height:100%;margin:0;overflow:hidden;background:var(--sheet-window-page);' +
             'font-family:Inter,ui-sans-serif,system-ui,sans-serif}' +
             '.sheet-window{height:100%;display:grid;grid-template-rows:48px minmax(0,1fr)}' +
             '.sheet-window__bar{display:flex;align-items:center;gap:12px;padding:0 16px;' +
-            'background:#172333;color:#fff;border-bottom:1px solid #34445a}' +
+            'background:var(--sheet-window-bar);color:#fff;border-bottom:1px solid var(--sheet-window-bar-border)}' +
             '.sheet-window__bar strong{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}' +
-            '.sheet-window__bar span{margin-left:auto;font:11px ui-monospace,monospace;color:#9fe2c4}' +
+            '.sheet-window__bar span{margin-left:auto;font:11px ui-monospace,monospace;color:var(--sheet-window-bar-meta)}' +
             '.sheet-window__viewport{position:relative;min-height:0;background:#fff}' +
             '.sheet-window__canvas{display:block;width:100%;height:100%;background:#fff}' +
             '.sheet-window__loading{position:absolute;inset:0;display:grid;place-items:center;' +
             'z-index:10;background:#fff;color:#59687a;font-size:13px}';
           popupDocument.head.appendChild(popupStyle);
+
+          const syncPopupTheme = () => {
+            popupDocument.documentElement.dataset.theme =
+              document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+          };
+          syncPopupTheme();
+          const themeObserver = new MutationObserver(syncPopupTheme);
+          themeObserver.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['data-theme'],
+          });
 
           const shell = popupDocument.createElement('main');
           shell.className = 'sheet-window';
@@ -230,13 +248,14 @@ function mountSheetWindows(el: HTMLElement, url: string): void {
               loading.textContent = err(error);
             },
           });
-          const session = { popup, viewer };
+          const session = { popup, viewer, themeObserver };
           sessions.set(index, session);
           closeAll.disabled = false;
           open.textContent = 'Rendering…';
           open.disabled = true;
 
           popup.addEventListener('pagehide', () => {
+            themeObserver.disconnect();
             viewer.destroy();
             if (sessions.get(index) === session) sessions.delete(index);
             open.textContent = 'Open in window \u2197\uFE0E';
@@ -269,7 +288,8 @@ function mountSheetWindows(el: HTMLElement, url: string): void {
       closeAll.addEventListener('click', () => {
         const openSessions = [...sessions.values()];
         sessions.clear();
-        openSessions.forEach(({ popup, viewer }) => {
+        openSessions.forEach(({ popup, viewer, themeObserver }) => {
+          themeObserver.disconnect();
           viewer.destroy();
           popup.close();
         });
@@ -283,7 +303,8 @@ function mountSheetWindows(el: HTMLElement, url: string): void {
       st.remove();
       launcher.append(summary, popupError, list);
       window.addEventListener('pagehide', () => {
-        sessions.forEach(({ popup, viewer }) => {
+        sessions.forEach(({ popup, viewer, themeObserver }) => {
+          themeObserver.disconnect();
           viewer.destroy();
           popup.close();
         });

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -430,13 +430,13 @@ h1, h2, h3 { line-height: 1.08; letter-spacing: -0.035em; margin: 0; }
   margin-bottom: 12px;
   border: 1px solid color-mix(in srgb, var(--preview-text) 18%, transparent);
   border-radius: 10px;
-  background: color-mix(in srgb, #fff 94%, var(--accent));
+  background: var(--bg-elev);
   box-shadow: var(--document-shadow);
-  color: #172333;
+  color: var(--text);
 }
 .demo-sheet-window-summary > div { min-width: 0; display: grid; gap: 3px; }
 .demo-sheet-window-summary strong { font-size: 15px; }
-.demo-sheet-window-summary span { font: 11px var(--mono); color: #69778a; }
+.demo-sheet-window-summary span { font: 11px var(--mono); color: var(--text-faint); }
 .demo-sheet-window-actions {
   margin-left: auto;
   display: flex !important;
@@ -447,31 +447,31 @@ h1, h2, h3 { line-height: 1.08; letter-spacing: -0.035em; margin: 0; }
 .demo-sheet-window-badge {
   flex: 0 0 auto;
   padding: 5px 10px;
-  border: 1px solid #9bd8bd;
+  border: 1px solid color-mix(in srgb, var(--xlsx) 55%, var(--border));
   border-radius: 999px;
-  background: #e8f8f0;
-  color: #18794e !important;
+  background: color-mix(in srgb, var(--xlsx) 13%, var(--bg-elev));
+  color: color-mix(in srgb, var(--xlsx) 72%, var(--text)) !important;
   font-weight: 700 !important;
 }
 .demo-sheet-window-actions button {
   padding: 6px 10px;
-  border: 1px solid #b8c5d2;
+  border: 1px solid var(--border-bright);
   border-radius: 6px;
-  background: #fff;
-  color: #172333;
+  background: var(--bg-elev-2);
+  color: var(--text);
   font: 600 11px var(--sans);
   cursor: pointer;
 }
-.demo-sheet-window-actions button:hover:not(:disabled) { border-color: #5d7187; background: #eef3f7; }
+.demo-sheet-window-actions button:hover:not(:disabled) { border-color: var(--accent); background: var(--surface-muted); }
 .demo-sheet-window-actions button:disabled { cursor: default; opacity: 0.45; }
 .demo-sheet-window-list { display: grid; gap: 8px; }
 .demo-sheet-window-error {
   margin: 0 0 12px;
   padding: 9px 12px;
-  border: 1px solid #efb5b5;
+  border: 1px solid color-mix(in srgb, var(--accent-3) 55%, var(--border));
   border-radius: 7px;
-  background: #fff1f1;
-  color: #9d2525;
+  background: color-mix(in srgb, var(--accent-3) 10%, var(--bg-elev));
+  color: var(--accent-3);
   font-size: 12px;
 }
 .demo-sheet-window-row {
@@ -482,24 +482,24 @@ h1, h2, h3 { line-height: 1.08; letter-spacing: -0.035em; margin: 0; }
   padding: 10px 12px;
   border: 1px solid color-mix(in srgb, var(--preview-text) 16%, transparent);
   border-radius: 8px;
-  background: #fff;
-  color: #172333;
+  background: var(--bg-elev);
+  color: var(--text);
 }
 .demo-sheet-window-identity { min-width: 0; display: flex; align-items: center; gap: 12px; }
-.demo-sheet-window-identity span { flex: 0 0 auto; font: 11px var(--mono); color: #8a98a9; }
+.demo-sheet-window-identity span { flex: 0 0 auto; font: 11px var(--mono); color: var(--text-faint); }
 .demo-sheet-window-identity strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; }
 .demo-sheet-window-row button {
   margin-left: auto;
   flex: 0 0 auto;
   padding: 7px 11px;
-  border: 1px solid #b8c5d2;
+  border: 1px solid var(--border-bright);
   border-radius: 6px;
-  background: #f7f9fb;
-  color: #172333;
+  background: var(--bg-elev-2);
+  color: var(--text);
   font: 600 12px var(--sans);
   cursor: pointer;
 }
-.demo-sheet-window-row button:hover { border-color: #5d7187; background: #eef3f7; }
+.demo-sheet-window-row button:hover { border-color: var(--accent); background: var(--surface-muted); }
 
 @media (max-width: 620px) {
   .demo-sheet-window-summary { align-items: flex-start; }

--- a/site/src/xlsx-sheet-overview.test.ts
+++ b/site/src/xlsx-sheet-overview.test.ts
@@ -47,4 +47,16 @@ describe('XLSX multi-window sheet demo', () => {
     expect(demos).toContain('const openSessions = [...sessions.values()]');
     expect(demos.match(/if \(sessions\.get\(index\) !== session\) return;/g)).toHaveLength(2);
   });
+
+  it('uses the site theme for launcher controls and keeps popup themes in sync', () => {
+    expect(styles).toMatch(/\.demo-sheet-window-summary\s*\{[\s\S]*?background: var\(--bg-elev\);[\s\S]*?color: var\(--text\);/);
+    expect(styles).toMatch(/\.demo-sheet-window-row\s*\{[\s\S]*?background: var\(--bg-elev\);[\s\S]*?color: var\(--text\);/);
+    expect(styles).toMatch(/\.demo-sheet-window-row button\s*\{[\s\S]*?background: var\(--bg-elev-2\);[\s\S]*?color: var\(--text\);/);
+    expect(styles).toMatch(/\.demo-sheet-window-identity span\s*\{[^}]*color: var\(--text-faint\);/);
+    expect(styles).not.toContain('background: color-mix(in srgb, #fff 94%, var(--accent));');
+    expect(demos).toContain('--sheet-window-bar-dark:#05090e');
+    expect(demos).toContain("document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light'");
+    expect(demos).toContain("attributeFilter: ['data-theme']");
+    expect(demos).toContain('themeObserver.disconnect()');
+  });
 });


### PR DESCRIPTION
## Summary

- replace the XLSX multi-window launcher's light-only card and control colors with shared site theme tokens
- synchronize same-origin sheet windows with parent theme changes
- use the near-black dark-theme navy for popup headers while preserving the white worksheet canvas

## Verification

- `vitest run site/src` (113 tests)
- `pnpm --filter ./site build`
- local browser check in dark mode
