### PR TITLE
fix(docx): finalize bookmarks from retained page graph

### DIFF
--- a/packages/docx/src/layout/body-paginator.ts
+++ b/packages/docx/src/layout/body-paginator.ts
@@ -32,6 +32,7 @@ import {
   accumulatePageSectionRegion,
   bodyFlowDomainId,
   createParityBlankLayoutPage,
+  finalizePageBookmarkStarts,
   finalizeLayoutPage,
   type PageSectionRegionInput,
 } from './page-factory.js';
@@ -2195,5 +2196,9 @@ export function paginateBody(
           ...withEndnotes.diagnostics,
         ]),
       });
-  return assertAndDeepFreezeDocumentLayout(withParserDiagnostics) as DocumentLayout;
+  const finalized = Object.freeze({
+    ...withParserDiagnostics,
+    pages: Object.freeze(withParserDiagnostics.pages.map(finalizePageBookmarkStarts)),
+  });
+  return assertAndDeepFreezeDocumentLayout(finalized) as DocumentLayout;
 }

--- a/packages/docx/src/layout/canonical-producer-real-model.test.ts
+++ b/packages/docx/src/layout/canonical-producer-real-model.test.ts
@@ -356,6 +356,39 @@ describe('canonical producer with a real document model', () => {
     ]);
   });
 
+  it('derives bookmark page metadata after header stories join the retained graph', () => {
+    const section = {
+      pageWidth: 200, pageHeight: 100,
+      marginTop: 10, marginRight: 10, marginBottom: 10, marginLeft: 10,
+      headerDistance: 5, footerDistance: 5, titlePage: false,
+      evenAndOddHeaders: false, sectionStart: 'nextPage', columns: null,
+    } as SectionProps;
+    const headerDestination = ordinaryParagraph('header destination');
+    headerDestination.bookmarks = ['header-destination'];
+    const model = {
+      section,
+      body: [ordinaryBodyParagraph('body')],
+      headers: {
+        default: { body: [headerDestination as unknown as BodyElement] },
+        first: null,
+        even: null,
+      },
+      footers: { default: null, first: null, even: null },
+      footnotes: [], endnotes: [], fontFamilyClasses: {},
+    } as unknown as DocxDocumentModel;
+    const services = createLayoutServices(model, { measureContext: measureContext() });
+
+    const layout = layoutDocument(model, services, { currentDateMs: 0 });
+
+    expect(layout.pages[0]?.bookmarkStarts).toEqual([
+      expect.objectContaining({
+        name: 'header-destination',
+        sectionOccurrenceId: layout.pages[0]?.sectionOccurrenceId,
+      }),
+    ]);
+    expect([...buildBookmarkPageMap(layout)]).toEqual([['header-destination', 0]]);
+  });
+
   it('composes compatible continuous sections as disjoint regions on one physical page', () => {
     const model = sectionBoundaryModel(ordinaryBodyParagraph('before'), 'continuous');
     const services = createLayoutServices(model, { measureContext: measureContext() });

--- a/packages/docx/src/layout/invariants.ts
+++ b/packages/docx/src/layout/invariants.ts
@@ -9,7 +9,7 @@ import {
 import { columnSeparatorSegments } from './column-separators.js';
 import { orderedPagePaintNodes, pageLayerNodes, PageGraphError } from './page-graph.js';
 import {
-  derivePageBookmarkStarts,
+  deriveRetainedPageBookmarkStarts,
   sectionLayoutContextsEqual,
 } from './page-factory.js';
 import type {
@@ -939,11 +939,7 @@ function assertDocumentLayoutUnchecked(layout: DocumentLayout): void {
           region.sectionOccurrenceId,
         ]),
       );
-      const expectedBookmarkStarts = derivePageBookmarkStarts(
-        orderedPagePaintNodes(page),
-        page.sectionOccurrenceId ?? '',
-        sectionByDomain,
-      );
+      const expectedBookmarkStarts = deriveRetainedPageBookmarkStarts(page, sectionByDomain);
       const bookmarkOwnersAreValid = expectedBookmarkStarts.every((bookmark) =>
         bookmark.sectionOccurrenceId.length > 0
         && sectionOccurrenceIds.has(bookmark.sectionOccurrenceId));

--- a/packages/docx/src/layout/page-factory.ts
+++ b/packages/docx/src/layout/page-factory.ts
@@ -9,7 +9,11 @@ import {
 } from './coordinate-space.js';
 import { columnSeparatorSegments } from './column-separators.js';
 import { materializePageBorderLayout } from './page-border.js';
-import { createPageLayers, type PageLayerNode } from './page-graph.js';
+import {
+  createPageLayers,
+  orderedPagePaintNodes,
+  type PageLayerNode,
+} from './page-graph.js';
 import type { BodyOccurrenceDestination } from './occurrence-projection.js';
 import type {
   DeepReadonly,
@@ -432,6 +436,49 @@ export function derivePageBookmarkStarts(
     });
   }
   return starts;
+}
+
+function bookmarkSectionByDomain(page: LayoutPage): ReadonlyMap<string, string> {
+  const regions = page.sectionRegions ?? [];
+  const regionById = new Map(regions.map((region) => [region.id, region]));
+  const sectionByDomain = new Map<string, string>();
+  for (const region of regions) {
+    for (const domainId of region.flowDomainIds) {
+      sectionByDomain.set(domainId, region.sectionOccurrenceId);
+    }
+  }
+  for (const domain of page.flowDomains) {
+    if (domain.kind !== 'footnote' && domain.kind !== 'endnote') continue;
+    const region = domain.sectionRegionId
+      ? regionById.get(domain.sectionRegionId)
+      : regions[0];
+    if (region) sectionByDomain.set(domain.id, region.sectionOccurrenceId);
+  }
+  return sectionByDomain;
+}
+
+export function deriveRetainedPageBookmarkStarts(
+  page: LayoutPage,
+  sectionByDomain: ReadonlyMap<string, string> = bookmarkSectionByDomain(page),
+): readonly PageBookmarkStart[] {
+  return derivePageBookmarkStarts(
+    orderedPagePaintNodes(page),
+    page.sectionOccurrenceId ?? '',
+    sectionByDomain,
+  );
+}
+
+/** Bookmark navigation metadata is a projection of the complete retained page
+ * graph. Page stories and notes join that graph after initial body pagination,
+ * so the final document boundary derives the projection again from the graph
+ * that paint and navigation will actually retain. ECMA-376 §17.13.6.2 permits
+ * bookmark starts in paragraph content regardless of the owning story. */
+export function finalizePageBookmarkStarts(page: LayoutPage): LayoutPage {
+  if (page.parityBlank) return page;
+  return Object.freeze({
+    ...page,
+    bookmarkStarts: Object.freeze([...deriveRetainedPageBookmarkStarts(page)]),
+  });
 }
 
 export function createLayoutPage(input: LayoutPageFactoryInput): LayoutPage {


### PR DESCRIPTION
## Summary
- derive bookmark navigation metadata after all retained page stories and notes are composed
- share the retained-graph projection between finalization and invariant validation
- cover bookmarks owned by non-body page stories

## Specification
ECMA-376 Part 1 section 17.13.6.2 permits bookmark starts in paragraph content. The final page metadata therefore reflects the complete retained page graph rather than the earlier body-only pagination state.

## Verification
- focused retained-layout and bookmark navigation tests
- DOCX architecture boundary gates
- compatibility evidence checks
- public API checks
- package build checks
- workspace typecheck
- local private-corpus document opens successfully after rebuilding DOCX WASM