### PR TITLE
fix(docx): retain signed table extent in exact-row clips

### DIFF
--- a/packages/docx/src/layout/compatibility.test.ts
+++ b/packages/docx/src/layout/compatibility.test.ts
@@ -492,6 +492,10 @@ describe('layout compatibility inventory', () => {
       { xPt: 20, yPt: 30, widthPt: 40, heightPt: 50 },
       { xPt: 5, yPt: 10, widthPt: 100, heightPt: 200 },
     )).toEqual({ xPt: 5, yPt: 30, widthPt: 100, heightPt: 50 });
+    expect(wordExactRowVerticalClipBounds(
+      { xPt: -5, yPt: 30, widthPt: 40, heightPt: 50 },
+      { xPt: 5, yPt: 10, widthPt: 100, heightPt: 200 },
+    )).toEqual({ xPt: -5, yPt: 30, widthPt: 110, heightPt: 50 });
     expect(wordClipsOverPageCantSplitRow({
       compatibility: 'word',
       availableHeightPt: 99.99995,

--- a/packages/docx/src/layout/table-compatibility.ts
+++ b/packages/docx/src/layout/table-compatibility.ts
@@ -223,10 +223,19 @@ export function wordExactRowVerticalClipBounds(
   cellFlowBounds: LayoutRect,
   containingFlowBounds: LayoutRect,
 ): LayoutRect {
+  // The exact trHeight constraint is block-axis-only. Keep the containing
+  // flow's inline spill area, but extend it to any signed §17.4.50 tblInd
+  // placement owned by this cell so a table shifted into the leading margin
+  // is not clipped back to the ordinary text band.
+  const xPt = Math.min(cellFlowBounds.xPt, containingFlowBounds.xPt);
+  const rightPt = Math.max(
+    cellFlowBounds.xPt + cellFlowBounds.widthPt,
+    containingFlowBounds.xPt + containingFlowBounds.widthPt,
+  );
   return Object.freeze({
-    xPt: containingFlowBounds.xPt,
+    xPt,
     yPt: cellFlowBounds.yPt,
-    widthPt: containingFlowBounds.widthPt,
+    widthPt: rightPt - xPt,
     heightPt: cellFlowBounds.heightPt,
   });
 }

--- a/packages/docx/src/table-tblind.test.ts
+++ b/packages/docx/src/table-tblind.test.ts
@@ -154,6 +154,28 @@ describe('§17.4.50 tblInd — table indent from the leading margin', () => {
     expectNear(Math.min(...withInd.xs), 10, 'LTR left origin = contentX + tblInd = 20 + (-10)');
   });
 
+  it('keeps exact-height row clipping open across the signed table extent', () => {
+    const recording = makeRecordingCanvas();
+    const doc = tableDoc(160, -10, false);
+    const row = (doc.body[0] as DocTable).rows[0];
+    if (!row) throw new Error('expected table row');
+    row.rowHeight = 20;
+    row.rowHeightRule = 'exact';
+    const services = createLayoutServices(doc, {
+      measureContext: recording.canvas.getContext('2d') as CanvasRenderingContext2D,
+    });
+
+    const retained = layoutDocument(doc, services, { currentDateMs: 0 }).pages[0]?.layers.body[0];
+
+    if (retained?.kind !== 'table') throw new Error('expected retained table geometry');
+    expect(retained.rows[0]?.cells[0]?.clipBounds).toEqual({
+      xPt: 10,
+      yPt: 20,
+      widthPt: 170,
+      heightPt: 20,
+    });
+  });
+
   it('preserves an authored width beyond the text band when the indented table fits the page', () => {
     // §17.18.87 allows AutoFit to override the preferred table width until the
     // table reaches the page width. The 180pt authored grid is wider than the


### PR DESCRIPTION
## Summary
- keep exact-height row clipping constrained on the block axis
- preserve the inline extent of tables placed into the leading margin by signed table indentation
- add focused regression coverage for fixed-height rows with negative leading indentation

## Specification
ECMA-376 Part 1 sections 17.4.50 and 17.4.80 define table leading-edge indentation and exact row height as separate layout concerns. The row-height clip must not normalize a valid signed table placement back to the ordinary text band.

## Verification
- focused table indentation and compatibility tests
- DOCX architecture boundary and compatibility evidence gates
- public API and package build checks
- workspace typecheck
- private self-VRT against the immediately previous renderer: all PPTX and XLSX items pixel-identical; DOCX differs only in the affected fixed-height signed-indent table pages, with a transient unrelated comparison rerun confirming pixel identity
- local Office-reference fidelity inspection