### PR TITLE
fix(docx): honor balanced single and double byte widths

### DIFF
--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -15654,8 +15654,7 @@ mod math_jc_tests {
             r#"<w:settings xmlns:w="{w}"><w:compat><w:balanceSingleByteDoubleByteWidth/></w:compat></w:settings>"#,
             w = W_NS
         );
-        let enabled = parse_document_settings(&enabled_xml)
-            .expect("enabled balance setting");
+        let enabled = parse_document_settings(&enabled_xml).expect("enabled balance setting");
         assert_eq!(enabled.balance_single_byte_double_byte_width, Some(true));
     }
 

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -15627,7 +15627,8 @@ mod math_jc_tests {
         assert!(parse_document_settings(empty).is_none());
     }
 
-    // ECMA-376 §17.15.1.18 / §17.15.3.1 — East Asian compatibility settings
+    // ECMA-376 Part 1 §17.15.1.18 / §17.15.3.3 and Part 4 §14.8.3.50 — East
+    // Asian compatibility settings
     // must surface to the renderer instead of being discarded at parse time.
     #[test]
     fn settings_east_asian_compat_flags_surface() {
@@ -15648,6 +15649,14 @@ mod math_jc_tests {
         );
         assert_eq!(s.use_fe_layout, Some(true));
         assert_eq!(s.balance_single_byte_double_byte_width, Some(false));
+
+        let enabled_xml = format!(
+            r#"<w:settings xmlns:w="{w}"><w:compat><w:balanceSingleByteDoubleByteWidth/></w:compat></w:settings>"#,
+            w = W_NS
+        );
+        let enabled = parse_document_settings(&enabled_xml)
+            .expect("enabled balance setting");
+        assert_eq!(enabled.balance_single_byte_double_byte_width, Some(true));
     }
 
     #[test]

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -230,11 +230,11 @@ pub struct DocumentSettings {
     /// punctuation compression / spacing control.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub character_spacing_control: Option<String>,
-    /// §17.15.3.1 `w:compat` / `w:useFELayout` — enable Far East layout
-    /// compatibility behavior.
+    /// ECMA-376 Part 4 §14.8.3.50 `w:compat` / `w:useFELayout` — enable Far
+    /// East layout compatibility behavior.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_fe_layout: Option<bool>,
-    /// §17.15.3.1 `w:compat` / `w:balanceSingleByteDoubleByteWidth` — balance
+    /// §17.15.3.3 `w:compat` / `w:balanceSingleByteDoubleByteWidth` — balance
     /// single-byte and double-byte character widths in East Asian layout.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub balance_single_byte_double_byte_width: Option<bool>,

--- a/packages/docx/src/balance-single-double-byte-width.test.ts
+++ b/packages/docx/src/balance-single-double-byte-width.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSegments,
+  segAdvanceWidth,
+  type LayoutTextSeg,
+  type LineLayoutEnvironment,
+} from './line-layout.js';
+import { createLayoutServices } from './layout-runtime.js';
+import type { DocRun, DocxDocumentModel } from './types.js';
+
+function measureContext(): CanvasRenderingContext2D {
+  return {
+    font: '',
+    letterSpacing: '0px',
+    fontKerning: 'auto',
+    measureText(text: string) {
+      const width = [...text].reduce((sum, character) => {
+        if (character === '\u4e00') return sum + 10;
+        if (character === ' ') return sum + 3;
+        return sum + 5;
+      }, 0);
+      return {
+        width,
+        actualBoundingBoxAscent: 8,
+        actualBoundingBoxDescent: 2,
+        fontBoundingBoxAscent: 8,
+        fontBoundingBoxDescent: 2,
+      } as TextMetrics;
+    },
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function model(): DocxDocumentModel {
+  return {
+    section: {},
+    body: [],
+    headers: { default: null, first: null, even: null },
+    footers: { default: null, first: null, even: null },
+  } as unknown as DocxDocumentModel;
+}
+
+function textRun(text: string): DocRun {
+  return {
+    type: 'text',
+    text,
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    fontSize: 10,
+    color: null,
+    fontFamily: 'Test Latin',
+    fontFamilyEastAsia: 'Test East Asia',
+    isLink: false,
+    background: null,
+    vertAlign: null,
+  } as unknown as DocRun;
+}
+
+function environment(enabled: boolean): LineLayoutEnvironment {
+  return {
+    pageIndex: 0,
+    totalPages: 1,
+    balanceSingleByteDoubleByteWidth: enabled,
+    layoutServices: createLayoutServices(model(), { measureContext: measureContext() }),
+  };
+}
+
+function textSegments(runs: readonly DocRun[], enabled = true): LayoutTextSeg[] {
+  return buildSegments(runs, environment(enabled))
+    .filter((segment): segment is LayoutTextSeg => 'text' in segment);
+}
+
+describe('ECMA-376 §17.15.3.3 single-byte/double-byte width balance', () => {
+  it('applies half of linesAndChars charSpace to SBCS and the full delta to DBCS', () => {
+    const [latin, ideographicSpace, eastAsian] = textSegments([
+      textRun('AB'),
+      textRun('\u3000'),
+      textRun('日本'),
+    ]);
+    const grid = { type: 'linesAndChars', linePitchPt: 12, charSpacePt: -2 };
+
+    expect(latin.widthBalanceGridDeltaFactor).toBe(0.5);
+    expect(ideographicSpace.widthBalanceGridDeltaFactor).toBe(0.5);
+    expect(eastAsian.widthBalanceGridDeltaFactor).toBe(1);
+    expect(segAdvanceWidth(latin, 10, grid, 1)).toBe(8);
+    expect(segAdvanceWidth(ideographicSpace, 10, grid, 1)).toBe(9);
+    expect(segAdvanceWidth(eastAsian, 20, grid, 1)).toBe(16);
+  });
+
+  it('keeps the U+3000 half-delta boundary separate from adjacent CJK text', () => {
+    expect(textSegments([textRun('日\u3000本')]).map((segment) => [
+      segment.text,
+      segment.widthBalanceGridDeltaFactor,
+    ])).toEqual([
+      ['日', 1],
+      ['\u3000', 0.5],
+      ['本', 1],
+    ]);
+  });
+
+  it('balances two or more authored U+0020 spaces against half an ideographic cell', () => {
+    const [spaced] = textSegments([textRun('Anchor  ')]);
+
+    expect(spaced.widthBalanceSpaceSequence).toBe(true);
+    expect(spaced.widthBalanceSpaceAdjustmentPt).toBe(2);
+    // Natural 36pt + two × (5pt half-cell - 3pt natural space).
+    expect(segAdvanceWidth(spaced, 36, undefined, 1)).toBe(40);
+  });
+
+  it('keeps one ordinary inter-word space at its natural advance', () => {
+    const [spaced] = textSegments([textRun('Anchor ')]);
+
+    expect(spaced.widthBalanceSpaceSequence).toBeUndefined();
+    expect(segAdvanceWidth(spaced, 33, undefined, 1)).toBe(33);
+  });
+
+  it('does not balance an ordinary singleton before a separate authored pair', () => {
+    const segments = textSegments([textRun('A B  ')]);
+
+    expect(segments.map((segment) => [
+      segment.text,
+      segment.widthBalanceSpaceSequence ?? false,
+    ])).toEqual([
+      ['A ', false],
+      ['B  ', true],
+    ]);
+    expect(segAdvanceWidth(segments[0], 8, undefined, 1)).toBe(8);
+    expect(segAdvanceWidth(segments[1], 11, undefined, 1)).toBe(15);
+  });
+
+  it('recognizes one consecutive space sequence across source-run boundaries', () => {
+    const segments = textSegments([
+      textRun('Anchor '),
+      textRun(' '),
+      textRun('Target'),
+    ]);
+
+    expect(segments.map((segment) => [
+      segment.text,
+      segment.widthBalanceSpaceSequence ?? false,
+    ])).toEqual([
+      ['Anchor ', true],
+      [' ', true],
+      ['Target', false],
+    ]);
+  });
+
+  it('does not change either grid pitch or spaces when the setting is absent', () => {
+    const [spaced] = textSegments([textRun('Anchor  ')], false);
+    const grid = { type: 'linesAndChars', linePitchPt: 12, charSpacePt: -2 };
+
+    expect(spaced.widthBalanceGridDeltaFactor).toBeUndefined();
+    expect(spaced.widthBalanceSpaceSequence).toBeUndefined();
+    expect(segAdvanceWidth(spaced, 36, grid, 1)).toBe(20);
+  });
+
+  it('does not layer the observed space-cell projection over snapToChars allocation', () => {
+    const [spaced] = textSegments([textRun('Anchor  ')]);
+    const grid = {
+      type: 'snapToChars',
+      linePitchPt: 12,
+      charSpacePt: -2,
+      characterPitchPt: 5,
+    };
+
+    expect(spaced.widthBalanceSpaceSequence).toBe(true);
+    expect(segAdvanceWidth(spaced, 36, grid, 1)).toBe(36);
+  });
+
+  it('keeps complex-script text outside the evidence-bounded Word projection', () => {
+    const [complex] = textSegments([{
+      ...textRun('مرحبا  '),
+      cs: true,
+      rtl: true,
+    } as DocRun]);
+    const grid = { type: 'linesAndChars', linePitchPt: 12, charSpacePt: -2 };
+
+    expect(complex.script).toBe('complexScript');
+    expect(complex.widthBalanceGridDeltaFactor).toBeUndefined();
+    expect(complex.widthBalanceSpaceSequence).toBeUndefined();
+    // The preexisting complex-script character-grid route owns the full delta;
+    // the width-balance observation neither halves it nor rewrites its spaces.
+    expect(segAdvanceWidth(complex, 36, grid, 1)).toBe(22);
+
+    const mixed = textSegments([{
+      ...textRun('م\u3000ر'),
+      cs: true,
+      rtl: true,
+    } as DocRun]);
+    expect(mixed.map((segment) => segment.text)).toEqual(['م\u3000ر']);
+  });
+
+  it.each([
+    ['high-ANSI', 'é'],
+    ['unmarked Arabic', 'مرحبا'],
+  ] as const)('keeps non-matrix %s scalars on the preexisting grid route', (_name, text) => {
+    const [enabled] = textSegments([textRun(text)]);
+    const [disabled] = textSegments([textRun(text)], false);
+    const grid = { type: 'linesAndChars', linePitchPt: 12, charSpacePt: -2 };
+
+    expect(enabled.widthBalanceGridDeltaFactor).toBeUndefined();
+    expect(segAdvanceWidth(enabled, 10, grid, 1))
+      .toBe(segAdvanceWidth(disabled, 10, grid, 1));
+  });
+});

--- a/packages/docx/src/charspacing-paint.test.ts
+++ b/packages/docx/src/charspacing-paint.test.ts
@@ -45,6 +45,7 @@ interface FillCall {
 function makeRecordingCanvas(options: Readonly<{
   followingGlyphLeftInsetPx?: number;
   closingPunctuationPairKerningPx?: number;
+  spaceAdvancePx?: number;
 }> = {}): { canvas: HTMLCanvasElement; fills: FillCall[] } {
   let font = `${FONT_PX}px serif`;
   let letterSpacing = '0px';
@@ -63,7 +64,10 @@ function makeRecordingCanvas(options: Readonly<{
     measureText: (s: string) => {
       const p = px();
       const pairCount = s.match(/。）/gu)?.length ?? 0;
-      const w = [...s].length * p
+      const w = [...s].reduce(
+        (sum, character) => sum + (character === ' ' ? options.spaceAdvancePx ?? p : p),
+        0,
+      )
         - pairCount * (options.closingPunctuationPairKerningPx ?? 0);
       return {
         width: w,
@@ -329,6 +333,34 @@ describe('run charSpacing/charScale reach the painted glyphs on every branch', (
     expect(r1.letterSpacing).toBe('3px');
     expect(r2.letterSpacing).toBe('1px');
     expect(r2.x + r2.translateX - (r1.x + r1.translateX)).toBeCloseTo(4 * FONT_PX + 4 * 3, 5);
+  });
+
+  it('paints balanced SBCS grid pitch and advances across balanced authored spaces', async () => {
+    const { canvas, fills } = makeRecordingCanvas({ spaceAdvancePx: 6 });
+    const model = {
+      ...doc([para([
+        textRun('AB  '),
+        textRun('Target'),
+        textRun('日本', { fontFamilyEastAsia: 'NotInMetrics' }),
+      ])], section({
+        docGridType: 'linesAndChars',
+        docGridLinePitch: 24,
+        docGridCharSpace: -4096,
+      })),
+      settings: { balanceSingleByteDoubleByteWidth: true },
+    } as DocxDocumentModel;
+
+    await renderDocumentToCanvas(model, canvas, 0, { dpr: 1, width: 600 });
+
+    const spaced = drawOf(fills, 'AB  ');
+    const target = drawOf(fills, 'Target');
+    const cjk = drawOf(fills, '日本');
+    // Word's §17.15.3.3 projection applies half of the -1pt grid delta to
+    // SBCS and the full delta to DBCS. The two authored spaces each occupy
+    // half of the selected 20pt East-Asian cell: 2×20 + 2×10 - 4×0.5 = 58.
+    expect(spaced.letterSpacing).toBe('-0.5px');
+    expect(target.x + target.translateX - (spaced.x + spaced.translateX)).toBeCloseTo(58, 5);
+    expect(cjk.letterSpacing).toBe('-1px');
   });
 
   it('justify path: charSpacing adds to the distributed pitch at the draw', async () => {

--- a/packages/docx/src/layout/compatibility.test.ts
+++ b/packages/docx/src/layout/compatibility.test.ts
@@ -37,6 +37,8 @@ import {
 import {
   WORD_AUTO_MULTIPLE_BASELINE_PIN,
   WORD_AUTHORED_CHARACTER_SPACING_PITCH_PRIORITY,
+  WORD_BALANCED_CONSECUTIVE_SPACE_CELL,
+  WORD_BALANCED_LINES_AND_CHARS_GRID_DELTA,
   WORD_CJK_BOTH_INTER_CHARACTER_EXPANSION,
   WORD_DEGENERATE_LINE_SPACING_SINGLE,
   WORD_DICTIONARY_SEA_ATOMIC_CHUNK,
@@ -68,6 +70,9 @@ import {
   WORD_THAI_DISTRIBUTE_CLUSTER_POLICY,
   WORD_UNIFORM_RUN_POSITION_LEADING,
   wordAutoMultipleCenterBoxPx,
+  wordBalancedConsecutiveSpaceCellApplies,
+  wordBalancedLinesAndCharsGridDeltaFactor,
+  wordBalancedSpaceCellAdjustmentApplies,
   wordDegenerateLineSpacingIsSingle,
   wordEastAsianGridLineCells,
   wordFarEastSingleLinePx,
@@ -449,6 +454,33 @@ describe('layout compatibility inventory', () => {
     });
     expect(wordSourceRunSpaceContinuesSequence('deadline ', ' ')).toBe(true);
     expect(wordSourceRunSpaceContinuesSequence('deadline', ' ')).toBe(false);
+    expect(WORD_BALANCED_CONSECUTIVE_SPACE_CELL.evidence).toEqual({
+      kind: 'office-observation',
+      syntheticFixtureId: 'single-double-byte-width-space-grid-matrix',
+      application: 'Microsoft Word',
+      version: '16.111.1',
+      platform: 'macOS 26.5.2',
+    });
+    expect(WORD_BALANCED_CONSECUTIVE_SPACE_CELL.description)
+      .not.toMatch(/sample|private|\.docx|\.pdf/i);
+    expect(wordBalancedConsecutiveSpaceCellApplies(1)).toBe(false);
+    expect(wordBalancedConsecutiveSpaceCellApplies(2)).toBe(true);
+    expect(wordBalancedConsecutiveSpaceCellApplies(8)).toBe(true);
+    expect(wordBalancedSpaceCellAdjustmentApplies(undefined)).toBe(true);
+    expect(wordBalancedSpaceCellAdjustmentApplies('linesAndChars')).toBe(true);
+    expect(wordBalancedSpaceCellAdjustmentApplies('snapToChars')).toBe(false);
+    expect(WORD_BALANCED_LINES_AND_CHARS_GRID_DELTA.evidence).toEqual({
+      kind: 'office-observation',
+      syntheticFixtureId: 'single-double-byte-width-grid-observation-matrix',
+      application: 'Microsoft Word',
+      version: '16.111.1',
+      platform: 'macOS 26.5.2',
+    });
+    expect(wordBalancedLinesAndCharsGridDeltaFactor('A', 'ascii')).toBe(0.5);
+    expect(wordBalancedLinesAndCharsGridDeltaFactor(' ', 'ascii')).toBe(0.5);
+    expect(wordBalancedLinesAndCharsGridDeltaFactor('\u3000', 'eastAsia')).toBe(0.5);
+    expect(wordBalancedLinesAndCharsGridDeltaFactor('日', 'eastAsia')).toBe(1);
+    expect(wordBalancedLinesAndCharsGridDeltaFactor('Ａ', 'eastAsia')).toBe(1);
     expect(WORD_TABLE_CELL_IGNORES_GRID_RIGHT_INDENT_ADJUSTMENT.evidence).toEqual({
       kind: 'office-observation',
       syntheticFixtureId: 'table-cell-adjust-right-indent-width-position-matrix',

--- a/packages/docx/src/layout/intrinsic-width.ts
+++ b/packages/docx/src/layout/intrinsic-width.ts
@@ -114,6 +114,9 @@ function compatibleTextKey(segment: LayoutTextSeg): string {
     segment.fitTextTrailingPadPx ?? null,
     segment.fitTextRegionIndex ?? null,
     segment.snapToCharacterGrid !== false,
+    segment.widthBalanceGridDeltaFactor ?? null,
+    segment.widthBalanceSpaceSequence ?? false,
+    segment.widthBalanceSpaceAdjustmentPt ?? null,
     // The snap-to-character-grid allocator consumes contiguous script blocks.
     // A shaping-compatible Latin→East-Asian seam is therefore still a semantic
     // grid boundary and must survive this intrinsic-only merge.

--- a/packages/docx/src/layout/line-compatibility.ts
+++ b/packages/docx/src/layout/line-compatibility.ts
@@ -319,6 +319,66 @@ export const WORD_CONSECUTIVE_SPACE_NATURAL_ADVANCE = defineCompatibilityRule({
   description: 'When visible text follows two or more authored consecutive spaces, Word preserves the sequence at natural advance instead of using it as Knuth-Plass inter-word shrink capacity. The result is invariant across linesAndChars with negative/zero charSpace and a line-only grid; source-run boundaries remain governed separately by the source-space-sequence rule.',
 });
 
+export const WORD_BALANCED_CONSECUTIVE_SPACE_CELL = defineCompatibilityRule({
+  id: 'word-balanced-consecutive-space-cell',
+  evidence: {
+    kind: 'office-observation',
+    syntheticFixtureId: 'single-double-byte-width-space-grid-matrix',
+    application: 'Microsoft Word',
+    version: '16.111.1',
+    platform: 'macOS 26.5.2',
+  },
+  description: 'With ECMA-376 §17.15.3.3 balanceSingleByteDoubleByteWidth enabled, Word retains one ordinary inter-word U+0020 at its proportional natural advance, while a sequence of two or more authored U+0020 spaces advances each space by half of the selected East-Asian ideographic cell. The observed matrix covers one, two, four, and eight spaces; same-run and source-run boundaries; proportional and fixed-pitch faces; linesAndChars with negative/zero charSpace; and a line-only grid.',
+});
+
+/** Compatibility projection governed by
+ * {@link WORD_BALANCED_CONSECUTIVE_SPACE_CELL}. */
+export function wordBalancedConsecutiveSpaceCellApplies(spaceCount: number): boolean {
+  return Number.isInteger(spaceCount) && spaceCount >= 2;
+}
+
+/** Evidence-bounded grid scope governed by
+ * {@link WORD_BALANCED_CONSECUTIVE_SPACE_CELL}. `snapToChars` has a separate
+ * Microsoft-documented block/cell allocator and is outside this observation. */
+export function wordBalancedSpaceCellAdjustmentApplies(
+  gridType: string | null | undefined,
+): boolean {
+  return gridType !== 'snapToChars';
+}
+
+export const WORD_BALANCED_LINES_AND_CHARS_GRID_DELTA = defineCompatibilityRule({
+  id: 'word-balanced-lines-and-chars-grid-delta',
+  evidence: {
+    kind: 'office-observation',
+    syntheticFixtureId: 'single-double-byte-width-grid-observation-matrix',
+    application: 'Microsoft Word',
+    version: '16.111.1',
+    platform: 'macOS 26.5.2',
+  },
+  description: 'With balanceSingleByteDoubleByteWidth enabled on linesAndChars, Word applies half of the authored charSpace delta to ASCII SBCS text and to U+0020/U+3000 space characters, while applying the full delta to CJK ideographs and full-width ASCII forms. The Word-output evidence covers ASCII digits, letters, punctuation, spaces, CJK, full-width ASCII, mixed text, proportional/fixed-pitch faces, negative/zero/positive charSpace, and line-only controls. Non-ASCII high-ANSI and complex-script text are outside the observed matrix and retain the preexisting grid behavior.',
+});
+
+/** Compatibility projection governed by
+ * {@link WORD_BALANCED_LINES_AND_CHARS_GRID_DELTA}. Script-slot acquisition
+ * has already separated ordinary East-Asian and ASCII SBCS text; the explicit
+ * space branch retains Word's observed U+3000 exception without reclassifying
+ * other East-Asian glyphs. Non-ASCII high-ANSI/complex text stays outside the
+ * observed projection. */
+export function wordBalancedLinesAndCharsGridDeltaFactor(
+  text: string,
+  script: 'ascii' | 'highAnsi' | 'eastAsia' | 'complexScript',
+): 0.5 | 1 | undefined {
+  if (script === 'complexScript') return undefined;
+  const spaceOnly = text.length > 0 && [...text].every(
+    (character) => character === ' ' || character === '\u3000',
+  );
+  if (spaceOnly) return 0.5;
+  if (script === 'eastAsia') return 1;
+  return [...text].every((character) => (character.codePointAt(0) ?? 0x80) <= 0x7f)
+    ? 0.5
+    : undefined;
+}
+
 export const WORD_MS_MINCHO_EMPTY_EAST_ASIAN_MARK_HEIGHT = defineCompatibilityRule({
   id: 'word-ms-mincho-empty-east-asian-mark-height',
   evidence: {

--- a/packages/docx/src/layout/measurement-environment.test.ts
+++ b/packages/docx/src/layout/measurement-environment.test.ts
@@ -94,7 +94,10 @@ describe('layout measurement environment', () => {
       docEastAsian: true,
       layoutSettings: {
         characterSpacingControl: 'compressPunctuation',
-        compat: { useFeLayout: true },
+        compat: {
+          useFeLayout: true,
+          balanceSingleByteDoubleByteWidth: true,
+        },
       },
       resolvedLocalFonts: {},
       layoutServices: { text: {}, images: {}, math: {} },
@@ -111,6 +114,7 @@ describe('layout measurement environment', () => {
       pageWritingMode: 'vertical-rl',
       documentHasEastAsianText: true,
       useFeLayout: true,
+      balanceSingleByteDoubleByteWidth: true,
     });
     const segments = segmentEnvironmentOf(state);
     expect(segments).not.toBe(state);
@@ -120,6 +124,7 @@ describe('layout measurement environment', () => {
     expect(segmentEnvironmentOf(upright)).toMatchObject({
       verticalCJK: true,
       characterSpacingControl: 'compressPunctuation',
+      balanceSingleByteDoubleByteWidth: true,
     });
     expect(paragraphMeasurementEnvironment(upright).verticalCJK).toBe(true);
   });

--- a/packages/docx/src/layout/measurement-environment.ts
+++ b/packages/docx/src/layout/measurement-environment.ts
@@ -83,6 +83,8 @@ export function paragraphMeasurementEnvironment(
     verticalPageFrame: state.verticalCJK === true,
     documentHasEastAsianText: state.docEastAsian,
     useFeLayout: state.layoutSettings.compat.useFeLayout,
+    balanceSingleByteDoubleByteWidth:
+      state.layoutSettings.compat.balanceSingleByteDoubleByteWidth,
     characterSpacingControl: state.layoutSettings.characterSpacingControl,
     resolvedLocalFonts: state.resolvedLocalFonts,
     layoutServices: state.layoutServices,
@@ -96,11 +98,14 @@ export function segmentEnvironmentOf(
   state: BodyMeasurementContext,
 ): LineLayoutEnvironment {
   if (!state.verticalAllRotated
-    && state.layoutSettings.characterSpacingControl === undefined) return state;
+    && state.layoutSettings.characterSpacingControl === undefined
+    && !state.layoutSettings.compat.balanceSingleByteDoubleByteWidth) return state;
   return {
     ...state,
     ...(state.verticalAllRotated ? { verticalCJK: false } : {}),
     characterSpacingControl: state.layoutSettings.characterSpacingControl,
+    balanceSingleByteDoubleByteWidth:
+      state.layoutSettings.compat.balanceSingleByteDoubleByteWidth,
   };
 }
 

--- a/packages/docx/src/layout/paragraph-acquisition-cache.test.ts
+++ b/packages/docx/src/layout/paragraph-acquisition-cache.test.ts
@@ -303,6 +303,10 @@ describe('paragraph acquisition cache', () => {
       key({ environment: { ...base.environment, useFeLayout: true } }),
       key({ environment: {
         ...base.environment,
+        balanceSingleByteDoubleByteWidth: true,
+      } }),
+      key({ environment: {
+        ...base.environment,
         resolvedLocalFonts: {
           'test sans': {
             requestedFamily: 'Test Sans',

--- a/packages/docx/src/layout/paragraph.test.ts
+++ b/packages/docx/src/layout/paragraph.test.ts
@@ -954,6 +954,100 @@ describe('paragraphLayoutFromMeasurement retained authorities', () => {
     ]);
   });
 
+  it('retains balanced authored-space width in LTR cluster geometry', () => {
+    const segment = {
+      text: 'AB  ', sourceRunIndex: 0, measuredWidth: 18,
+      fontSize: 10, fontFamily: 'Test Sans', fontRoute,
+      shapedClusters: [
+        { range: { start: 0, end: 1 }, offsetPt: 0, advancePt: 5 },
+        { range: { start: 1, end: 2 }, offsetPt: 5, advancePt: 5 },
+        { range: { start: 2, end: 3 }, offsetPt: 10, advancePt: 3 },
+        { range: { start: 3, end: 4 }, offsetPt: 13, advancePt: 3 },
+      ],
+      snapToCharacterGrid: true,
+      widthBalanceGridDeltaFactor: 0.5,
+      widthBalanceSpaceSequence: true,
+      widthBalanceSpaceAdjustmentPt: 2,
+    } as unknown as LayoutTextSeg;
+    const node = projectMeasuredSegment(paragraph, segment, {
+      ...acquisitionContext,
+      characterGrid: { active: true, kind: 'linesAndChars', pitchPt: 12, deltaPt: -1 },
+    });
+    const placement = node.lines[0]?.placements[0];
+    if (placement?.kind !== 'text') throw new Error('expected retained text placement');
+
+    expect(placement.clusters).toEqual([
+      expect.objectContaining({ offset: { xPt: 0, yPt: 0 }, advancePt: 4.5 }),
+      expect.objectContaining({ offset: { xPt: 4.5, yPt: 0 }, advancePt: 4.5 }),
+      expect.objectContaining({ offset: { xPt: 9, yPt: 0 }, advancePt: 4.5 }),
+      expect.objectContaining({ offset: { xPt: 13.5, yPt: 0 }, advancePt: 4.5 }),
+    ]);
+    const retainedEnd = placement.clusters.at(-1)!;
+    expect(retainedEnd.offset.xPt + retainedEnd.advancePt).toBe(placement.advancePt);
+  });
+
+  it('uses balanced trailing-space clusters for the RTL physical-leading offset', () => {
+    const segment = {
+      text: 'نص  ', sourceRunIndex: 0, measuredWidth: 20,
+      fontSize: 10, fontFamily: 'Test Sans', fontRoute,
+      shapedClusters: [
+        { range: { start: 0, end: 1 }, offsetPt: 0, advancePt: 5 },
+        { range: { start: 1, end: 2 }, offsetPt: 5, advancePt: 5 },
+        { range: { start: 2, end: 3 }, offsetPt: 10, advancePt: 3 },
+        { range: { start: 3, end: 4 }, offsetPt: 13, advancePt: 3 },
+      ],
+      rtl: true,
+      direction: 'rtl',
+      widthBalanceSpaceSequence: true,
+      widthBalanceSpaceAdjustmentPt: 2,
+    } as unknown as LayoutTextSeg;
+    const node = projectMeasuredSegment(paragraph, segment, {
+      ...acquisitionContext,
+      baseRtl: true,
+    });
+    const placement = node.lines[0]?.placements[0];
+    if (placement?.kind !== 'text') throw new Error('expected retained text placement');
+
+    expect(placement.clusters.slice(-2)).toEqual([
+      expect.objectContaining({ offset: { xPt: 10, yPt: 0 }, advancePt: 5 }),
+      expect.objectContaining({ offset: { xPt: 15, yPt: 0 }, advancePt: 5 }),
+    ]);
+    expect(placement.origin.xPt - placement.bounds.xPt).toBe(10);
+    expect(placement.paintOps.map((operation) => operation.range)).toEqual([
+      { start: 0, end: 2 },
+      { start: 2, end: 4 },
+    ]);
+  });
+
+  it.each([
+    ['fitText', { fitTextPerGapPx: 1 }, 13],
+    ['tate-chu-yoko', { tateChuYoko: true }, 10],
+  ] as const)('keeps %s override geometry outside balanced-space adjustment', (
+    _name,
+    override,
+    measuredWidth,
+  ) => {
+    const segment = {
+      text: 'A  ', sourceRunIndex: 0, measuredWidth,
+      fontSize: 10, fontFamily: 'Test Sans', fontRoute,
+      shapedClusters: [
+        { range: { start: 0, end: 1 }, offsetPt: 0, advancePt: 4 },
+        { range: { start: 1, end: 2 }, offsetPt: 4, advancePt: 3 },
+        { range: { start: 2, end: 3 }, offsetPt: 7, advancePt: 3 },
+      ],
+      widthBalanceSpaceSequence: true,
+      widthBalanceSpaceAdjustmentPt: 2,
+      ...override,
+    } as unknown as LayoutTextSeg;
+    const node = projectMeasuredSegment(paragraph, segment);
+    const placement = node.lines[0]?.placements[0];
+    if (placement?.kind !== 'text') throw new Error('expected retained text placement');
+
+    const retainedEnd = placement.clusters.at(-1)!;
+    expect(retainedEnd.offset.xPt + retainedEnd.advancePt).toBe(placement.advancePt);
+    expect(placement.advancePt).toBe(measuredWidth);
+  });
+
   it('materializes one outer anchor while retaining each grouped child frame', () => {
     const occurrenceId = 'anchor:body:body:3:wp-anchor-group';
     const group = {

--- a/packages/docx/src/layout/paragraph.ts
+++ b/packages/docx/src/layout/paragraph.ts
@@ -21,7 +21,11 @@ import type {
   LayoutTextSeg,
   DocGridCtx,
 } from '../line-layout.js';
-import { effectiveCharacterSpacingPt, segLetterSpacingPx } from '../line-layout.js';
+import {
+  effectiveCharacterSpacingPt,
+  segLetterSpacingPx,
+  widthBalanceSpaceAdjustmentForTextPt,
+} from '../line-layout.js';
 import { calcEffectiveFontPx, EAST_ASIAN_RE, shapeRunToDocRun } from './text.js';
 import type { DocParagraph, DocRun, ShapeRun } from '../types.js';
 import {
@@ -1751,6 +1755,10 @@ function textPlanSegment(
           && compression.end <= cluster.range.end)
         .reduce((sum, compression) => sum + compression.adjustmentPt, 0)
       ?? 0;
+    const precedingWidthBalanceAdjustment =
+      widthBalanceSpaceAdjustmentForTextPt(segment, prefix, characterGrid) * scaleX;
+    const clusterWidthBalanceAdjustment =
+      widthBalanceSpaceAdjustmentForTextPt(segment, text, characterGrid) * scaleX;
     return {
       range: {
         start: sourceOffset + cluster.range.start,
@@ -1760,12 +1768,14 @@ function textPlanSegment(
         xPt:
           cluster.offsetPt * scaleX
           + precedingScalars * pitchPt
+          + precedingWidthBalanceAdjustment
           + precedingPunctuationCompression,
         yPt: baselineOffsetPt,
       },
       advancePt:
         cluster.advancePt * scaleX
         + scalarCount * pitchPt
+        + clusterWidthBalanceAdjustment
         + trailingFitPad
         + clusterPunctuationCompression,
     };
@@ -3967,6 +3977,7 @@ export function paragraphAcquisitionCacheKey(
       environment.verticalPageFrame ?? null,
       environment.documentHasEastAsianText,
       environment.useFeLayout ?? null,
+      environment.balanceSingleByteDoubleByteWidth ?? null,
       environment.characterSpacingControl ?? null,
       environment.resolvedLocalFonts
         ? cache.objectIdentity(environment.resolvedLocalFonts)

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -136,7 +136,7 @@ export interface LayoutTextSeg extends LayoutSegSource {
    * grid: half of `charSpace` for SBCS and the observed space classes, full
    * delta for DBCS. Present only when width balancing is enabled. */
   widthBalanceGridDeltaFactor?: 0.5 | 1;
-  /** Word-observed projection for a two-or-more authored U+0020 sequence.
+  /** Registered compatibility projection for a two-or-more authored U+0020 sequence.
    * The flag preserves sequence membership through source/split boundaries;
    * the adjustment replaces each selected route's natural space with half of
    * its East-Asian ideographic cell. */
@@ -2795,7 +2795,7 @@ export function buildSegments(
         && text.includes('\u3000')
         && [...text].some((character) => character !== '\u3000')
       ) {
-        // Word's width-balance grid treats U+3000 as a half-delta space while
+        // The registered width-balance projection treats U+3000 as a half-delta space while
         // other East-Asian glyphs receive the full delta. Split only at that
         // semantic boundary so Canvas can retain one uniform letterSpacing per
         // segment (measure == paint); the space itself has no contextual shape.

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -101,6 +101,9 @@ import {
   wordMsMinchoEmptyEastAsianMarkSingleLinePx,
   wordSnapToCharsEastAsianCellCount,
   wordSourceRunSpaceContinuesSequence,
+  wordBalancedConsecutiveSpaceCellApplies,
+  wordBalancedLinesAndCharsGridDeltaFactor,
+  wordBalancedSpaceCellAdjustmentApplies,
   wordUniformRunPositionPaintPt,
   wordUseFeLayoutParagraphMarkGridAdvancePx,
 } from './layout/line-compatibility.js';
@@ -129,6 +132,16 @@ export interface LayoutTextSeg extends LayoutSegSource {
   snapGridLeadingPadPx?: number;
   snapGridTrailingPadPx?: number;
   snapGridCellPitchPx?: number;
+  /** Registered Word projection of ECMA-376 §17.15.3.3 onto a `linesAndChars`
+   * grid: half of `charSpace` for SBCS and the observed space classes, full
+   * delta for DBCS. Present only when width balancing is enabled. */
+  widthBalanceGridDeltaFactor?: 0.5 | 1;
+  /** Word-observed projection for a two-or-more authored U+0020 sequence.
+   * The flag preserves sequence membership through source/split boundaries;
+   * the adjustment replaces each selected route's natural space with half of
+   * its East-Asian ideographic cell. */
+  widthBalanceSpaceSequence?: true;
+  widthBalanceSpaceAdjustmentPt?: number;
   /** Zero-advance anchor-character placeholder: contributes run metrics to the
    * line box but paints no glyph. */
   metricOnly?: true;
@@ -622,8 +635,10 @@ export interface LineLayoutEnvironment {
   readonly noteNumbers?: ReadonlyMap<string, number>;
   readonly noteReferenceNumber?: number;
   readonly verticalCJK?: boolean;
-  /** §17.15.3.1 w:useFELayout document compatibility switch. */
+  /** ECMA-376 Part 4 §14.8.3.50 w:useFELayout compatibility switch. */
   readonly useFeLayout?: boolean;
+  /** §17.15.3.3 w:balanceSingleByteDoubleByteWidth document compatibility switch. */
+  readonly balanceSingleByteDoubleByteWidth?: boolean;
   readonly resolvedLocalFonts?: Readonly<Record<string, ResolvedLocalFontMetric>>;
   readonly layoutServices?: LayoutServices;
   readonly verticalGlyphMeasurement?: VerticalGlyphMeasurementService;
@@ -1068,6 +1083,9 @@ export function segmentCharacterGridDeltaPx(
   // snapToChars allocates full cells/blocks in layoutLines. It is not a
   // per-glyph letter-spacing delta.
   if (grid?.type === 'snapToChars') return 0;
+  if (grid?.type === 'linesAndChars' && seg.widthBalanceGridDeltaFactor !== undefined) {
+    return gridCharDeltaPx(grid, scale) * seg.widthBalanceGridDeltaFactor;
+  }
   const total = gridSegDeltaPx(seg.text, grid, scale);
   return total === 0 ? 0 : gridCharDeltaPx(grid, scale);
 }
@@ -1096,6 +1114,40 @@ export function punctuationCompressionTotalPt(seg: LayoutTextSeg): number {
     (sum, compression) => sum + compression.adjustmentPt,
     0,
   ) ?? 0;
+}
+
+/** §17.15.3.3 plus the registered Word space-sequence projection. A segment
+ * created by splitTextForLayout contains at most one trailing U+0020 sequence;
+ * slicing keeps the sequence flag, so prefixes/tails count only their retained
+ * authored spaces. */
+export function widthBalanceSpaceAdjustmentTotalPt(
+  seg: LayoutTextSeg,
+  characterGrid?: DocGridCtx,
+): number {
+  return widthBalanceSpaceAdjustmentForTextPt(seg, seg.text, characterGrid);
+}
+
+/** Retained-cluster projection of the same authored-space adjustment used by
+ * {@link widthBalanceSpaceAdjustmentTotalPt}. Keeping this calculation on the
+ * immutable segment fact makes line measurement, cluster hit geometry, RTL
+ * whitespace anchoring, and paint-plan slicing consume one width authority. */
+export function widthBalanceSpaceAdjustmentForTextPt(
+  seg: LayoutTextSeg,
+  text: string,
+  characterGrid?: DocGridCtx,
+): number {
+  // Both properties replace the ordinary inline advance with their own
+  // specification-defined region/cell width. Their interaction with Word's
+  // proportional-space projection is outside the observation matrix, so keep
+  // the preexisting override geometry intact in every retained consumer.
+  if (seg.fitTextPerGapPx !== undefined || seg.tateChuYoko) return 0;
+  if (!wordBalancedSpaceCellAdjustmentApplies(characterGrid?.type)) return 0;
+  if (!seg.widthBalanceSpaceSequence || seg.widthBalanceSpaceAdjustmentPt === undefined) {
+    return 0;
+  }
+  let count = 0;
+  for (const character of text) if (character === ' ') count += 1;
+  return count * seg.widthBalanceSpaceAdjustmentPt;
 }
 
 export function slicedPunctuationCompressions(
@@ -1332,7 +1384,9 @@ export function segAdvanceWidth(
     segmentDelta,
     charScaleFactor(seg),
     charSpacingDeltaPx(seg, scale),
-  ) + punctuationCompressionTotalPt(seg) * scale;
+  )
+    + widthBalanceSpaceAdjustmentTotalPt(seg, grid) * scale * charScaleFactor(seg)
+    + punctuationCompressionTotalPt(seg) * scale;
 }
 
 export type SnapToCharsClass = 'eastAsia' | 'latin' | 'complexScript';
@@ -2735,6 +2789,21 @@ export function buildSegments(
       compressCharacterWhitespace = false,
       mappedSymbolUnicode = false,
     ) => {
+      if (
+        environment.balanceSingleByteDoubleByteWidth
+        && !cs
+        && text.includes('\u3000')
+        && [...text].some((character) => character !== '\u3000')
+      ) {
+        // Word's width-balance grid treats U+3000 as a half-delta space while
+        // other East-Asian glyphs receive the full delta. Split only at that
+        // semantic boundary so Canvas can retain one uniform letterSpacing per
+        // segment (measure == paint); the space itself has no contextual shape.
+        for (const part of text.split(/(\u3000+)/u).filter(Boolean)) {
+          pushSeg(part, cs, fontFamily, undefined, compressCharacterWhitespace, mappedSymbolUnicode);
+        }
+        return;
+      }
       // ECMA-376 §17.15.1.18 / §17.18.7 — dispatch the exact
       // ST_CharacterSpacing value and split each eligible full-width character
       // so its selected face's tight ink bounds can define the removable
@@ -2952,10 +3021,23 @@ export function buildSegments(
         ?? eaFontFamily;
       const useFeEastAsianMetric = environment.useFeLayout
         && (r.fontHint === 'eastAsia' || Boolean(resolvedEaFloorFamily?.trim()));
+      const resolvedScript = resolvedSpan?.script ?? authoritativeSpan?.script
+        ?? (cs ? 'complexScript' : EAST_ASIAN_RE.test(text) ? 'eastAsia' : 'ascii');
+      const widthBalanceGridDeltaFactor = environment.balanceSingleByteDoubleByteWidth
+        ? wordBalancedLinesAndCharsGridDeltaFactor(text, resolvedScript)
+        : undefined;
       segs.push({
         text,
-        script: resolvedSpan?.script ?? authoritativeSpan?.script
-          ?? (cs ? 'complexScript' : EAST_ASIAN_RE.test(text) ? 'eastAsia' : 'ascii'),
+        script: resolvedScript,
+        ...(widthBalanceGridDeltaFactor !== undefined
+          ? {
+              // §17.15.3.3 defines the SBCS:DBCS width ratio as 1:2; the
+              // registered Word matrix defines how that setting projects onto
+              // linesAndChars charSpace. Production shaping has already split
+              // the segment at §17.3.2.26 script-slot boundaries.
+              widthBalanceGridDeltaFactor,
+            }
+          : {}),
         ...(useFeEastAsianMetric
           ? { metricEastAsian: true as const }
           : {}),
@@ -3335,6 +3417,87 @@ export function buildSegments(
     for (let index = emittedStart; index < segs.length; index += 1) {
       segs[index].sourceRunIndex = runIndex;
     }
+  }
+
+  if (environment.balanceSingleByteDoubleByteWidth) {
+    // ECMA-376 §17.15.3.3 normatively requests a 1:2 SBCS/DBCS width balance,
+    // but does not define how a proportional inter-word separator becomes a
+    // fixed-pitch half-width cell. The registered Word observation limits that
+    // projection to two-or-more explicitly authored U+0020 spaces. One normal
+    // separator remains at its natural proportional advance.
+    const metricCache = new Map<string, number>();
+    const adjustmentFor = (segment: LayoutTextSeg): number | undefined => {
+      const service = segment.textLayoutService;
+      const request = segment.textShapeRequest;
+      if (!service || !request) return undefined;
+      const effectiveFontSizePt = calcEffectiveFontPx(segment, 1);
+      const key = [
+        service.fingerprint,
+        segment.fontRoute?.fingerprint ?? 'implicit-latin',
+        segment.eaFloorRoute?.fingerprint ?? 'implicit-east-asia',
+        effectiveFontSizePt,
+        segment.bold ? 700 : 400,
+        segment.italic ? 'italic' : 'normal',
+        segment.kerning ?? 'auto',
+      ].join('|');
+      const cached = metricCache.get(key);
+      if (cached !== undefined) return cached;
+      const naturalSpace = service.shape({
+        ...request,
+        text: ' ',
+        fontSizePt: effectiveFontSizePt,
+        measure: true,
+        clusterGeometry: false,
+      }).advancePt;
+      const ideographicCell = service.shape({
+        ...request,
+        text: '\u4e00',
+        fontSizePt: effectiveFontSizePt,
+        fontHint: 'eastAsia',
+        measure: true,
+        clusterGeometry: false,
+      }).advancePt;
+      if (
+        !Number.isFinite(naturalSpace)
+        || !Number.isFinite(ideographicCell)
+        || naturalSpace < 0
+        || ideographicCell <= 0
+      ) return undefined;
+      const adjustmentPt = ideographicCell / 2 - naturalSpace;
+      metricCache.set(key, adjustmentPt);
+      return adjustmentPt;
+    };
+    let sequence: LayoutTextSeg[] = [];
+    let sequenceCount = 0;
+    const flushSequence = () => {
+      if (wordBalancedConsecutiveSpaceCellApplies(sequenceCount)) {
+        for (const segment of sequence) {
+          segment.widthBalanceSpaceSequence = true;
+          const adjustmentPt = adjustmentFor(segment);
+          if (adjustmentPt !== undefined) {
+            segment.widthBalanceSpaceAdjustmentPt = adjustmentPt;
+          }
+        }
+      }
+      sequence = [];
+      sequenceCount = 0;
+    };
+    for (const candidate of segs) {
+      if (!('text' in candidate) || candidate.script === 'complexScript') {
+        flushSequence();
+        continue;
+      }
+      const trailingSpaces = candidate.text.length - candidate.text.replace(/ +$/u, '').length;
+      const spaceOnly = trailingSpaces > 0 && trailingSpaces === candidate.text.length;
+      if (!spaceOnly) flushSequence();
+      if (trailingSpaces > 0) {
+        sequence.push(candidate);
+        sequenceCount += trailingSpaces;
+      } else {
+        flushSequence();
+      }
+    }
+    flushSequence();
   }
 
   // ── UAX#14 LB13 / ECMA-376 §17.15.1.59 (行頭禁則 — line-start-forbidden) ──────

--- a/packages/docx/src/table-intrinsic-widths.test.ts
+++ b/packages/docx/src/table-intrinsic-widths.test.ts
@@ -196,6 +196,41 @@ describe('table intrinsic content widths', () => {
     )).toEqual({ minWidthPt: 7, maxWidthPt: 12 });
   });
 
+  it('uses the balanced space cells and SBCS grid delta for intrinsic width', () => {
+    const source = paragraph([textRun('AB  ')]);
+    const context = measuringContext((text) => [...text].reduce(
+      (sum, character) => sum + (character === ' ' ? 3 : character === '一' ? 10 : 5),
+      0,
+    ));
+
+    expect(measureParagraphIntrinsicWidths(
+      source,
+      intrinsicContext({
+        characterGrid: {
+          active: true,
+          kind: 'linesAndChars',
+          pitchPt: 3,
+          deltaPt: -2,
+        },
+      }),
+      200,
+      { context, fontFamilyClasses: {} },
+      {
+        pageIndex: 0,
+        totalPages: 1,
+        pageWritingMode: 'horizontal-tb',
+        documentHasEastAsianText: true,
+        balanceSingleByteDoubleByteWidth: true,
+        layoutServices: createLayoutServices(model([]), { measureContext: context }),
+      },
+    )).toEqual({
+      // The breakable trailing-space sequence is excluded from the minimum;
+      // the unbroken maximum retains both balanced half-width cells.
+      minWidthPt: 8,
+      maxWidthPt: 16,
+    });
+  });
+
   it('uses per-grapheme whole-cell allocation for snapToChars intrinsic widths', () => {
     const source = paragraph([textRun('漢字')]);
 

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -106,9 +106,10 @@ export interface DocSettings {
   /** §17.15.1.18 `w:characterSpacingControl@w:val` — East Asian punctuation /
    *  character-spacing control. */
   characterSpacingControl?: string;
-  /** §17.15.3.1 `w:compat/w:useFELayout` — Far East layout compatibility. */
+  /** ECMA-376 Part 4 §14.8.3.50 `w:compat/w:useFELayout` — Far East layout
+   * compatibility. */
   useFeLayout?: boolean;
-  /** §17.15.3.1 `w:compat/w:balanceSingleByteDoubleByteWidth` — balance
+  /** §17.15.3.3 `w:compat/w:balanceSingleByteDoubleByteWidth` — balance
    *  single-byte and double-byte widths for East Asian layout. */
   balanceSingleByteDoubleByteWidth?: boolean;
   /** §17.15.3.1 `w:compat/w:adjustLineHeightInTable` — apply the section


### PR DESCRIPTION
## Summary

- surface the WordprocessingML balanceSingleByteDoubleByteWidth compatibility setting
- implement ECMA-376 Part 1 §17.15.3.3 plus narrowly registered Office observations for ASCII/CJK grid deltas and authored space sequences
- retain one width authority across measurement, wrapping, intrinsic sizing, selection clusters, RTL placement, and paint
- preserve prior behavior for unobserved high-ANSI, complex-script, fitText, tate-chu-yoko, and snapToChars interactions

## Verification

- full unit suite: 638 files and 6,667 tests passed
- DOCX final architecture boundary: 88 passed
- compatibility evidence: 17 passed
- public API: 26 passed
- package build: 2 passed
- typecheck and diff check passed
- browser conformance and worker parity passed
- local-only full private corpus compared against the exact merge-base renderer; changes were limited to documents carrying the affected setting, while XLSX and PPTX remained pixel-identical
- separate Office-PDF fidelity checks improved for the targeted document class

An independent adversarial review approved the final design and found no sample-specific heuristics or remaining actionable issues.