### PR TITLE
chore(release): 0.77.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ semantic versioning. While the major version is zero, minor releases may contain
 explicitly documented breaking changes; patch releases remain compatible with
 the corresponding minor release.
 
+## 0.77.0 — 2026-08-10
+
+Breaking minor release. Unifies read-only selection and integration context
+across DOCX, XLSX, and PPTX; lets applications identify selected document
+elements and context-menu targets; and connects the active VS Code preview to
+the OOXML MCP server. See the
+[v0.77 migration guide](https://ooxml.silurus.dev/announcements/v077-migration-guide/)
+for every removed or renamed API.
+
+- **Excel-compatible XLSX selection:** replace the lossy range-only
+  compatibility API with `setSelection()`, `selectionState`, and
+  `onSelectionStateChange()`. The canonical state keeps selected areas,
+  ActiveCell, and the Shift-extension anchor separate, supports multiple areas,
+  and preserves row, column, whole-sheet, RTL, clipboard, keyboard, pointer,
+  and programmatic behavior. (#1176)
+- **cross-format selection context:** expose bounded, detached text, cell-range,
+  and chart/picture/shape context through `getSelectionContext()` and the common
+  `onSelectionContextChange` callback. Optional `enableElementSelection` adds
+  read-only object selection with a visible outline in DOCX, XLSX, and PPTX;
+  `onContextMenu` provides the original browser event plus a lazy asynchronous
+  target lookup. The official site includes matching three-format demos and
+  browser-integration guidance. (#1181, #1182)
+- **VS Code and MCP integration:** add an authenticated loopback bridge from the
+  active OOXML preview to one `ooxml_get_active_context` tool, including local
+  document identity and bounded selected content. Consolidate strict-subset
+  DOCX, XLSX, and PPTX tools, validate the bridge payload and lifecycle, and
+  document the Copilot-specific active-context path separately from standalone
+  path-based MCP use. (#1182)
+- **predictable asynchronous errors:** Promise-returning Viewer and headless
+  operations now reject their Promise on failure even when `onError` is set;
+  `onError` remains for later Viewer-managed work that has no Promise to await.
+  Initial scroll-window and presentation-media work follows the same rule.
+  (#1182)
+- **public API cleanup:** remove the legacy XLSX selection names, no-op rendering
+  options, internal worker transport types, and exact aliases that duplicated a
+  canonical type. Narrow borrowed and operation-specific options, export every
+  reachable public type, forward Viewer passwords correctly, and align the Node
+  and Markdown input contracts with their documented binary inputs. Migration
+  tables cover each source change without temporary duplicate APIs. (#1182)
+- **package guidance and regression evidence:** clarify npm unpacked size versus
+  the assets reachable from each format entry, keep the optional MathJax engine
+  separately lazy-loaded, and verify the complete private DOCX/XLSX/PPTX corpus
+  against the previous renderer with pixel-identical output. (#1180, #1182)
+
 ## 0.76.2 — 2026-08-08
 
 Patch. Improves Word-compatible text and table layout, extends spreadsheet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.76.2"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ npm install @silurus/ooxml
 pnpm add @silurus/ooxml
 ```
 
+> Upgrading from v0.76? Review the
+> [v0.77 migration guide](https://ooxml.silurus.dev/announcements/v077-migration-guide/)
+> for the XLSX selection, selection-context, MCP-tool, option/type, and Viewer
+> error-handling changes.
+
 > **Bundler note**: the Rust parsers ship as real `.wasm` asset files next to the
 > JavaScript, referenced with the standard `new URL('…', import.meta.url)` form
 > and fetched (streaming-compiled) at load time. Verified to work with zero
@@ -74,15 +79,15 @@ pnpm add @silurus/ooxml
 > **Bundle size note**: the package is ESM-only (`.mjs`). npm's *Unpacked
 > Size* sums every entry bundle **and** the standalone MathJax + STIX Two Math
 > asset, so the reported figure is much larger than any single app build. For
-> v0.76.2, the complete npm package is approximately 11.2 MB unpacked (3.7 MB
+> v0.77.0, the complete npm package is approximately 11.3 MB unpacked (3.8 MB
 > as the downloaded tarball), while a format-specific application graph is
 > approximately:
 >
 > | Imported entry | Reachable assets | gzip | Includes |
 > |---|---:|---:|---|
-> | `@silurus/ooxml/docx` | 3.9 MB | 1.2 MB | DOCX renderer, parser WASM, and lazy worker |
-> | `@silurus/ooxml/xlsx` | 2.5 MB | 0.81 MB | XLSX renderer, parser WASM, and lazy worker |
-> | `@silurus/ooxml/pptx` | 2.5 MB | 0.77 MB | PPTX renderer, parser WASM, and lazy worker |
+> | `@silurus/ooxml/docx` | 4.0 MB | 1.2 MB | DOCX renderer, parser WASM, and lazy worker |
+> | `@silurus/ooxml/xlsx` | 2.6 MB | 0.82 MB | XLSX renderer, parser WASM, and lazy worker |
+> | `@silurus/ooxml/pptx` | 2.5 MB | 0.78 MB | PPTX renderer, parser WASM, and lazy worker |
 > | `@silurus/ooxml/math` | 3.1 MB | 1.1 MB | Optional MathJax + STIX Two Math engine |
 >
 > These are production-artifact estimates, not initial-load figures: each row

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.76.2",
+  "version": "0.77.0",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.76.2",
+  "version": "0.77.0",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.76.2",
+  "version": "0.77.0",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.76.2",
+  "version": "0.77.0",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.76.2"
+version = "0.77.0"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.76.2",
+  "version": "0.77.0",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.76.2",
+  "version": "0.77.0",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.76.2",
+  "version": "0.77.0",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.76.2",
+  "version": "0.77.0",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.76.2",
+  "version": "0.77.0",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/lib/announcements.ts
+++ b/site/src/lib/announcements.ts
@@ -29,8 +29,8 @@ export interface Announcement {
 export const announcements: readonly Announcement[] = [
   {
     slug: 'v077-migration-guide',
-    date: '2026-08-09',
-    label: 'Upcoming release',
+    date: '2026-08-10',
+    label: 'Release note',
     version: 'v0.77',
     title: 'Migrating to v0.77',
     summary: 'v0.77 updates selection APIs, adds selectable document elements, simplifies OOXML MCP tools, and makes errors from asynchronous Viewer methods easier to handle.',
@@ -227,7 +227,7 @@ try {
   {
     slug: 'v076-migration-guide',
     date: '2026-08-06',
-    label: 'Upcoming release',
+    label: 'Release note',
     version: 'v0.76',
     title: 'Migrating to v0.76',
     summary: 'v0.76 makes shared-engine Viewer construction explicit, adds the canvas-mounted XLSX sheet Viewer, and replaces the synchronous Node parser compatibility APIs with one owned asynchronous pipeline.',
@@ -344,7 +344,7 @@ workbook.destroy();`,
   {
     slug: 'v075-resource-governance',
     date: '2026-08-02',
-    label: 'Upcoming release',
+    label: 'Release note',
     version: 'v0.75',
     title: 'Resource limits, typed failures and metrics for large files',
     summary: 'v0.75 applies default inflated-package limits to every DOCX, XLSX and PPTX load, reports measured limit failures with typed errors, and exposes content-free usage metrics.',


### PR DESCRIPTION
## Release

Prepare v0.77.0, a breaking minor release focused on read-only selection and external-tool integration across DOCX, XLSX, and PPTX.

- align root, workspace, site, VS Code extension, and MCP server versions at 0.77.0
- add the 0.77.0 changelog and link the ordinary-user migration guide from the README
- publish the v0.77 announcement as a release note
- refresh measured npm package and per-format reachable-asset sizes
- regenerate and inspect all three README screenshots (pixel-identical to the checked-in images)

## Release verification

- full private self-VRT against v0.76.2-era main merge base `abebf336`: DOCX 47/47, PPTX 11/11, XLSX 8/8; all rendered RGBA pixels identical
- `pnpm typecheck`
- all workspace package builds, production site build, and root package build
- public API baselines, Viewer symmetry, public type exports, and no-inline-WASM
- `cargo check -p ooxml-mcp-server`; binary reports `ooxml-mcp-server 0.77.0`
- npm dry-run: 3.8 MB tarball / 11.3 MB unpacked
- VSIX package: 3.83 MB
- feature PR #1182 GitHub CI: audit, rust, smoke, and typecheck all pass

## Local-only test note

The macOS full Vitest run passed 6,811/6,813 executed assertions outside one existing Node/Skia exact-pixel file: its inner-shadow and soft-edge crop comparisons differ on this local Skia backend. The same source tree passed the Linux GitHub unit-test job, and the complete browser private-corpus VRT is pixel-identical. This PR changes only versions and release documentation; GitHub CI remains the merge gate.