### PR TITLE
fix(pptx): resolve theme fill style references

### DIFF
--- a/packages/pptx/parser/src/fill.rs
+++ b/packages/pptx/parser/src/fill.rs
@@ -7,8 +7,9 @@
 
 use crate::theme::PptxSchemeResolver;
 use crate::types::*;
-use crate::{attr, attr_f64, attr_i64, attr_r, child, children_vec};
+use crate::{attr, attr_f64, attr_i64, attr_r, child, children_vec, parse_preflighted_pptx_xml};
 use ooxml_common::blip::{mime_from_ext, parse_blip_duotone};
+use ooxml_common::color::ThemeResolver;
 use std::collections::HashMap;
 
 /// Parse `<a:blip><a:alphaModFix amt="..."/></a:blip>` from a blipFill node
@@ -57,12 +58,32 @@ pub(crate) fn parse_fill(
     node: roxmltree::Node<'_, '_>,
     theme: &HashMap<String, String>,
 ) -> Option<Fill> {
+    parse_fill_tint(node, theme, ooxml_common::color::TintMode::PowerPointLinear)
+}
+
+/// Parse DrawingML fill properties with the caller-selected tint semantics.
+/// Normal presentation backgrounds and theme style-matrix fills use the
+/// literal ECMA-376 retained-input definition. The historical generic path
+/// keeps PowerPointLinear for SmartArt compatibility.
+fn parse_fill_tint(
+    node: roxmltree::Node<'_, '_>,
+    theme: &HashMap<String, String>,
+    tint_mode: ooxml_common::color::TintMode,
+) -> Option<Fill> {
+    parse_fill_with_resolver(node, &PptxSchemeResolver { theme }, tint_mode)
+}
+
+fn parse_fill_with_resolver<R: ThemeResolver + ?Sized>(
+    node: roxmltree::Node<'_, '_>,
+    resolver: &R,
+    tint_mode: ooxml_common::color::TintMode,
+) -> Option<Fill> {
     for c in node.children().filter(|n| n.is_element()) {
         match c.tag_name().name() {
             "solidFill" => {
                 // If the color resolves, use it. If not (e.g. phClr with no theme slot),
                 // return None so the caller can fall back to the shape style color.
-                if let Some(color) = parse_color_node(c, theme) {
+                if let Some(color) = ooxml_common::color::parse_color_node(c, resolver, tint_mode) {
                     return Some(Fill::Solid { color });
                 }
                 // Unresolvable → don't default to black; let fallback logic handle it
@@ -73,21 +94,13 @@ pub(crate) fn parse_fill(
                 // Shared parse (ooxml_common::fill); colors resolve with pptx's
                 // PowerPointLinear tint via PptxSchemeResolver.
                 let ooxml_common::fill::PatternFill { fg, bg, preset } =
-                    ooxml_common::fill::parse_patt_fill(
-                        c,
-                        &PptxSchemeResolver { theme },
-                        ooxml_common::color::TintMode::PowerPointLinear,
-                    );
+                    ooxml_common::fill::parse_patt_fill(c, resolver, tint_mode);
                 return Some(Fill::Pattern { fg, bg, preset });
             }
             "gradFill" => {
                 // Shared parse (ooxml_common::fill). Returns None when there are
                 // no resolvable stops, so we keep scanning sibling fill elements.
-                if let Some(g) = ooxml_common::fill::parse_grad_fill(
-                    c,
-                    &PptxSchemeResolver { theme },
-                    ooxml_common::color::TintMode::PowerPointLinear,
-                ) {
+                if let Some(g) = ooxml_common::fill::parse_grad_fill(c, resolver, tint_mode) {
                     return Some(Fill::Gradient {
                         stops: g.stops,
                         angle: g.angle,
@@ -99,6 +112,60 @@ pub(crate) fn parse_fill(
         }
     }
     None
+}
+
+struct StyleMatrixSchemeResolver<'a> {
+    theme: &'a HashMap<String, String>,
+    placeholder_color: Option<&'a str>,
+}
+
+impl ThemeResolver for StyleMatrixSchemeResolver<'_> {
+    fn resolve_scheme_color(&self, name: &str) -> Option<String> {
+        if name == "phClr" {
+            return self.placeholder_color.map(str::to_owned);
+        }
+        PptxSchemeResolver { theme: self.theme }.resolve_scheme_color(name)
+    }
+}
+
+/// Resolve a shape `fillRef` or slide/master `bgRef` through the theme's format
+/// style matrix. `phClr` inside the selected style is substituted with the
+/// reference element's colour before its own transforms are applied.
+///
+/// ECMA-376 Part 1 §19.3.1.3: bgRef 1..999 indexes fillStyleLst, 1001+
+/// indexes bgFillStyleLst (1001 = first); 0 and 1000 mean no background.
+pub(crate) fn parse_style_matrix_fill(
+    style_ref: roxmltree::Node<'_, '_>,
+    theme: &HashMap<String, String>,
+    background: bool,
+) -> Option<Fill> {
+    use ooxml_common::color::TintMode::WordLiteral;
+
+    let idx = attr(&style_ref, "idx")?.parse::<u32>().ok()?;
+    let key = if background {
+        match idx {
+            0 | 1000 => return Some(Fill::None),
+            1..=999 => format!("+fillStyle-{idx}"),
+            _ => format!("+bgFillStyle-{}", idx - 1000),
+        }
+    } else if idx == 0 {
+        return Some(Fill::None);
+    } else {
+        format!("+fillStyle-{idx}")
+    };
+    let fragment = theme.get(&key)?;
+
+    let placeholder_color = parse_color_node_tint(style_ref, theme, WordLiteral);
+
+    let wrapped = format!(
+        r#"<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">{fragment}</root>"#
+    );
+    let doc = parse_preflighted_pptx_xml(&wrapped).ok()?;
+    let resolver = StyleMatrixSchemeResolver {
+        theme,
+        placeholder_color: placeholder_color.as_deref(),
+    };
+    parse_fill_with_resolver(doc.root_element(), &resolver, WordLiteral)
 }
 
 /// ECMA-376 §20.1.8.14 `a:blipFill` → `Fill::Image`. The `resolve_blip`
@@ -554,11 +621,12 @@ pub(crate) fn parse_background<F: FnMut(&str) -> Option<String>>(
                 return Some(fill);
             }
         }
-        return parse_fill(bg_pr, theme);
+        return parse_fill_tint(bg_pr, theme, ooxml_common::color::TintMode::WordLiteral);
     }
     // bgRef references a theme background style; its child is a color element
     if let Some(bg_ref) = child(bg, "bgRef") {
-        return parse_color_node(bg_ref, theme).map(|c| Fill::Solid { color: c });
+        return parse_style_matrix_fill(bg_ref, theme, true)
+            .or_else(|| parse_color_node(bg_ref, theme).map(|c| Fill::Solid { color: c }));
     }
     None
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -2575,6 +2575,7 @@ fn produce_slide_unit_with_journal(
             parse_layout(
                 lx,
                 &bundle.master_font_sizes,
+                &bundle.master_font_families,
                 &bundle.master_level_font_sizes,
                 &bundle.master_level_indents,
                 layout_master_bullets,
@@ -4042,6 +4043,192 @@ mod tests {
         }
     }
 
+    /// ECMA-376 Part 1 §19.3.1.3: bgRef values 1001 and above index the
+    /// theme's bgFillStyleLst (1001 = first entry). The referenced fill keeps
+    /// its gradient geometry while each phClr is substituted with the bgRef
+    /// colour before applying the style's colour transforms.
+    #[test]
+    fn test_parse_background_bg_ref_resolves_theme_style_matrix() {
+        let theme_xml = r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="T">
+          <a:themeElements>
+            <a:clrScheme name="C">
+              <a:dk1><a:srgbClr val="000000"/></a:dk1><a:lt1><a:srgbClr val="FFFFFF"/></a:lt1>
+              <a:dk2><a:srgbClr val="7DAFC3"/></a:dk2><a:lt2><a:srgbClr val="E5E4DF"/></a:lt2>
+              <a:accent1><a:srgbClr val="4472C4"/></a:accent1><a:accent2><a:srgbClr val="ED7D31"/></a:accent2>
+              <a:accent3><a:srgbClr val="A5A5A5"/></a:accent3><a:accent4><a:srgbClr val="FFC000"/></a:accent4>
+              <a:accent5><a:srgbClr val="5B9BD5"/></a:accent5><a:accent6><a:srgbClr val="70AD47"/></a:accent6>
+              <a:hlink><a:srgbClr val="0563C1"/></a:hlink><a:folHlink><a:srgbClr val="954F72"/></a:folHlink>
+            </a:clrScheme>
+            <a:fontScheme name="F"><a:majorFont><a:latin typeface="Arial"/></a:majorFont><a:minorFont><a:latin typeface="Arial"/></a:minorFont></a:fontScheme>
+            <a:fmtScheme name="S">
+              <a:fillStyleLst/>
+              <a:lnStyleLst/><a:effectStyleLst/>
+              <a:bgFillStyleLst>
+                <a:solidFill><a:schemeClr val="phClr"/></a:solidFill>
+                <a:gradFill rotWithShape="1"><a:gsLst>
+                  <a:gs pos="20000"><a:schemeClr val="phClr"><a:tint val="80000"/></a:schemeClr></a:gs>
+                  <a:gs pos="100000"><a:schemeClr val="phClr"><a:lumMod val="80000"/></a:schemeClr></a:gs>
+                </a:gsLst><a:path path="circle"/></a:gradFill>
+              </a:bgFillStyleLst>
+            </a:fmtScheme>
+          </a:themeElements>
+        </a:theme>"#;
+        let mut theme = parse_theme_colors(theme_xml);
+        theme.insert("bg2".to_owned(), "7DAFC3".to_owned());
+        let background_xml = r#"<p:cSld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:bg><p:bgRef idx="1002"><a:schemeClr val="bg2"/></p:bgRef></p:bg>
+        </p:cSld>"#;
+        let doc = roxmltree::Document::parse(background_xml).unwrap();
+        let mut resolve = |_rid: &str| -> Option<String> { None };
+        let fill = parse_background(doc.root_element(), &theme, &mut resolve)
+            .expect("bgRef 1002 should resolve the second bgFillStyleLst entry");
+        match fill {
+            Fill::Gradient {
+                stops, grad_type, ..
+            } => {
+                assert_eq!(grad_type, "radial");
+                assert_eq!(stops.len(), 2);
+                assert_ne!(
+                    stops[0].color, "7DAFC3",
+                    "style transforms must be retained"
+                );
+                assert_ne!(
+                    stops[1].color, "7DAFC3",
+                    "style transforms must be retained"
+                );
+            }
+            other => panic!("expected theme gradient, got {other:?}"),
+        }
+    }
+
+    /// ECMA-376 §20.1.2.3.34 defines tint as retained input colour: an 80%
+    /// tint keeps 80% of the source and adds 20% white. Presentation background
+    /// fills follow that literal definition; the SmartArt compatibility mode is
+    /// intentionally not applied to normal p:bgPr fills.
+    #[test]
+    fn test_parse_background_uses_literal_tint_semantics() {
+        let xml = r#"<p:cSld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:bg><p:bgPr><a:solidFill><a:schemeClr val="bg2"><a:tint val="80000"/></a:schemeClr></a:solidFill></p:bgPr></p:bg>
+        </p:cSld>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let theme = HashMap::from([("bg2".to_owned(), "7DAFC3".to_owned())]);
+        let mut resolve = |_rid: &str| -> Option<String> { None };
+        match parse_background(doc.root_element(), &theme, &mut resolve) {
+            Some(Fill::Solid { color }) => assert_eq!(color, "97BFCF"),
+            other => panic!("expected literal-tint solid fill, got {other:?}"),
+        }
+    }
+
+    /// ECMA-376 §20.1.4.2.10: a shape fillRef selects fillStyleLst by its
+    /// one-based idx and substitutes the reference colour for phClr. The style
+    /// remains a gradient; reducing it to a solid accent loses the authored
+    /// appearance (the failure reported for Apache POI customGeo.pptx).
+    #[test]
+    fn test_shape_fill_ref_resolves_theme_gradient() {
+        let theme_xml = r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="T">
+          <a:themeElements><a:clrScheme name="C">
+            <a:dk1><a:srgbClr val="000000"/></a:dk1><a:lt1><a:srgbClr val="FFFFFF"/></a:lt1>
+            <a:dk2><a:srgbClr val="1F497D"/></a:dk2><a:lt2><a:srgbClr val="EEECE1"/></a:lt2>
+            <a:accent1><a:srgbClr val="4F81BD"/></a:accent1><a:accent2><a:srgbClr val="C0504D"/></a:accent2>
+            <a:accent3><a:srgbClr val="9BBB59"/></a:accent3><a:accent4><a:srgbClr val="8064A2"/></a:accent4>
+            <a:accent5><a:srgbClr val="4BACC6"/></a:accent5><a:accent6><a:srgbClr val="F79646"/></a:accent6>
+            <a:hlink><a:srgbClr val="0000FF"/></a:hlink><a:folHlink><a:srgbClr val="800080"/></a:folHlink>
+          </a:clrScheme><a:fontScheme name="F"><a:majorFont><a:latin typeface="Calibri"/></a:majorFont><a:minorFont><a:latin typeface="Calibri"/></a:minorFont></a:fontScheme>
+          <a:fmtScheme name="S"><a:fillStyleLst>
+            <a:solidFill><a:schemeClr val="phClr"/></a:solidFill>
+            <a:gradFill><a:gsLst>
+              <a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="50000"/></a:schemeClr></a:gs>
+              <a:gs pos="100000"><a:schemeClr val="phClr"><a:tint val="15000"/></a:schemeClr></a:gs>
+            </a:gsLst><a:lin ang="16200000"/></a:gradFill>
+          </a:fillStyleLst><a:lnStyleLst/><a:effectStyleLst/><a:bgFillStyleLst/></a:fmtScheme>
+          </a:themeElements>
+        </a:theme>"#;
+        let theme = parse_theme_colors(theme_xml);
+        let shape_xml = r#"<p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:nvSpPr><p:cNvPr id="2" name="Styled ellipse"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+          <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000000" cy="1000000"/></a:xfrm><a:prstGeom prst="ellipse"><a:avLst/></a:prstGeom></p:spPr>
+          <p:style><a:fillRef idx="2"><a:schemeClr val="accent1"/></a:fillRef></p:style>
+        </p:sp>"#;
+        let doc = roxmltree::Document::parse(shape_xml).unwrap();
+        let fill_ref = doc
+            .descendants()
+            .find(|node| node.is_element() && node.tag_name().name() == "fillRef")
+            .unwrap();
+        assert!(matches!(
+            parse_style_matrix_fill(fill_ref, &theme, false),
+            Some(Fill::Gradient { .. })
+        ));
+        let mut zip = PptxZip::new(Cursor::new(empty_zip_bytes())).unwrap();
+        let shape = parse_shape(
+            doc.root_element(),
+            &LayoutPlaceholders::default(),
+            &theme,
+            &HashMap::new(),
+            "ppt/slides",
+            None,
+            &mut zip,
+        )
+        .expect("shape should parse");
+        match shape.fill {
+            Some(Fill::Gradient { stops, .. }) => assert_eq!(stops.len(), 2),
+            other => panic!("expected style-matrix gradient, got {other:?}"),
+        }
+    }
+
+    /// ECMA-376 §19.3.1.52 / §21.1.2.3.7: a title with no local Latin
+    /// typeface inherits titleStyle's +mj-lt, resolved through the current
+    /// master's major Latin theme font.
+    #[test]
+    fn test_master_title_font_family_inherits_theme_major_latin() {
+        let theme = parse_theme_colors(
+            r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:themeElements>
+              <a:clrScheme name="C"><a:dk1><a:srgbClr val="000000"/></a:dk1><a:lt1><a:srgbClr val="FFFFFF"/></a:lt1><a:dk2><a:srgbClr val="111111"/></a:dk2><a:lt2><a:srgbClr val="EEEEEE"/></a:lt2><a:accent1><a:srgbClr val="111111"/></a:accent1><a:accent2><a:srgbClr val="222222"/></a:accent2><a:accent3><a:srgbClr val="333333"/></a:accent3><a:accent4><a:srgbClr val="444444"/></a:accent4><a:accent5><a:srgbClr val="555555"/></a:accent5><a:accent6><a:srgbClr val="666666"/></a:accent6><a:hlink><a:srgbClr val="0000FF"/></a:hlink><a:folHlink><a:srgbClr val="800080"/></a:folHlink></a:clrScheme>
+              <a:fontScheme name="F"><a:majorFont><a:latin typeface="Arial Black"/></a:majorFont><a:minorFont><a:latin typeface="Arial"/></a:minorFont></a:fontScheme>
+              <a:fmtScheme name="S"><a:fillStyleLst/><a:lnStyleLst/><a:effectStyleLst/><a:bgFillStyleLst/></a:fmtScheme>
+            </a:themeElements></a:theme>"#,
+        );
+        let master_xml = r#"<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:cSld><p:spTree/></p:cSld><p:txStyles><p:titleStyle><a:lvl1pPr><a:defRPr><a:latin typeface="+mj-lt"/></a:defRPr></a:lvl1pPr></p:titleStyle></p:txStyles>
+        </p:sldMaster>"#;
+        let master_doc = roxmltree::Document::parse(master_xml).unwrap();
+        let families = parse_master_font_families(master_doc.root_element(), &theme);
+        assert_eq!(
+            families.get("title").map(String::as_str),
+            Some("Arial Black")
+        );
+        assert_eq!(
+            families.get("ctrTitle").map(String::as_str),
+            Some("Arial Black")
+        );
+
+        let placeholders = LayoutPlaceholders {
+            by_type_font_family: families,
+            ..LayoutPlaceholders::default()
+        };
+        let shape_xml = r#"<p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:nvSpPr><p:cNvPr id="2" name="Title"/><p:cNvSpPr/><p:nvPr><p:ph type="ctrTitle"/></p:nvPr></p:nvSpPr>
+          <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000000" cy="500000"/></a:xfrm></p:spPr>
+          <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr/><a:t>Trade show</a:t></a:r></a:p></p:txBody>
+        </p:sp>"#;
+        let doc = roxmltree::Document::parse(shape_xml).unwrap();
+        let mut zip = PptxZip::new(Cursor::new(empty_zip_bytes())).unwrap();
+        let shape = parse_shape(
+            doc.root_element(),
+            &placeholders,
+            &theme,
+            &HashMap::new(),
+            "ppt/slides",
+            None,
+            &mut zip,
+        )
+        .expect("title should parse");
+        let paragraph = &shape.text_body.expect("text body").paragraphs[0];
+        assert_eq!(paragraph.def_font_family.as_deref(), Some("Arial Black"));
+    }
+
     /// ECMA-376 §20.1.8.23 — a background `<a:blipFill>` whose `<a:blip>` carries
     /// a `<a:duotone>` surfaces the resolved endpoint colours onto
     /// `Fill::Image.duotone` (through the theme), so a picture FILL recolours like
@@ -4996,6 +5183,7 @@ mod tests {
                 &rels,
                 "ppt/slides",
                 None,
+                None,
                 [None; 9],
                 Default::default(), // inherited_level_indents
                 &empty_level_bullets(),
@@ -5080,6 +5268,7 @@ mod tests {
             layout_doc.root_element(),
             &HashMap::new(),
             &HashMap::new(),
+            &HashMap::new(),
             &master_indents,
             &HashMap::new(),
             &HashMap::new(),
@@ -5152,6 +5341,7 @@ mod tests {
             parse_layout(
                 layout,
                 &m_f64,
+                &m_str,
                 &m_lfs,
                 &m_li,
                 &m_lb,
@@ -5646,6 +5836,7 @@ mod tests {
                 &rels,
                 "ppt/slides",
                 None,               // inherited_font_size
+                None,               // inherited_font_family
                 [None; 9],          // inherited_level_font_sizes
                 Default::default(), // inherited_level_indents
                 &empty_level_bullets(),
@@ -5716,6 +5907,7 @@ mod tests {
                 &theme,
                 &rels,
                 "ppt/slides",
+                None,
                 None,
                 [None; 9],
                 Default::default(),
@@ -5799,6 +5991,7 @@ mod tests {
                 &theme,
                 &rels,
                 "ppt/slides",
+                None,
                 None,
                 [None; 9],
                 Default::default(), // inherited_level_indents
@@ -5886,6 +6079,7 @@ mod tests {
                 &theme,
                 &rels,
                 "ppt/slides",
+                None,
                 None,
                 [None; 9],
                 Default::default(),

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -16,7 +16,7 @@ use crate::text::{
     merge_level_bullets, merge_level_indents, merge_level_sizes, read_level_bullets,
     read_level_font_sizes, read_level_indents, LevelBullets, LevelFontSizes, LevelIndents,
 };
-use crate::theme::{bake_clr_map, parse_theme_colors, PptxSchemeResolver};
+use crate::theme::{bake_clr_map, parse_theme_colors, resolve_theme_typeface, PptxSchemeResolver};
 use crate::types::*;
 use crate::{
     attr, attr_f64, attr_i64, attr_r, build_smartart_drawings, child, find_rel_target_by_type,
@@ -41,6 +41,11 @@ pub(crate) struct LayoutPlaceholders {
     pub(crate) by_idx_font_size: HashMap<u32, f64>,
     /// Default font size (pt) per placeholder type, from layout/master lstStyle
     pub(crate) by_type_font_size: HashMap<String, f64>,
+    /// Default Latin typeface per placeholder idx/type, inherited from the
+    /// layout placeholder's lstStyle and then the master txStyles. Theme font
+    /// tokens such as +mj-lt are resolved before storage.
+    pub(crate) by_idx_font_family: HashMap<u32, String>,
+    pub(crate) by_type_font_family: HashMap<String, String>,
     /// Per-list-level default font sizes (pt) per placeholder idx — index 0..=8
     /// maps to lvl1pPr..lvl9pPr (ECMA-376 §21.1.2.4). Lets nested bullets shrink
     /// per level (e.g. body 28pt → lvl2 24pt → lvl3 20pt) instead of all using
@@ -233,6 +238,19 @@ impl LayoutPlaceholders {
         self.by_type_font_size.get(ph_type).copied().or_else(|| {
             if ph_type == "body" {
                 self.by_type_font_size.get("").copied()
+            } else {
+                None
+            }
+        })
+    }
+
+    pub(crate) fn lookup_font_family(&self, ph_type: &str, ph_idx: Option<u32>) -> Option<String> {
+        if let Some(i) = ph_idx {
+            return self.by_idx_font_family.get(&i).cloned();
+        }
+        self.by_type_font_family.get(ph_type).cloned().or_else(|| {
+            if ph_type == "body" {
+                self.by_type_font_family.get("").cloned()
             } else {
                 None
             }
@@ -794,6 +812,60 @@ pub(crate) fn parse_master_font_sizes(root: roxmltree::Node<'_, '_>) -> HashMap<
     map
 }
 
+/// Default Latin typefaces from master placeholder lstStyle/txStyles. The
+/// specific placeholder shape wins over the generic title/body/other style,
+/// matching the font-size cascade above (ECMA-376 §19.3.1.52 and
+/// §21.1.2.3.7). Theme tokens are resolved against this master's theme.
+pub(crate) fn parse_master_font_families(
+    root: roxmltree::Node<'_, '_>,
+    theme: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let read_family = |def_rpr: roxmltree::Node<'_, '_>| {
+        child(def_rpr, "latin")
+            .and_then(|latin| attr(&latin, "typeface"))
+            .map(|face| resolve_theme_typeface(&face, theme))
+    };
+
+    if let Some(sp_tree) = child(root, "cSld").and_then(|n| child(n, "spTree")) {
+        for sp in sp_tree
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "sp")
+        {
+            if let Some(ph) = sp
+                .descendants()
+                .find(|n| n.is_element() && n.tag_name().name() == "ph")
+            {
+                let ph_type = attr(&ph, "type").unwrap_or_default();
+                if let Some(family) = child(sp, "txBody")
+                    .and_then(|tb| child(tb, "lstStyle"))
+                    .and_then(|ls| child(ls, "lvl1pPr"))
+                    .and_then(|lp| child(lp, "defRPr"))
+                    .and_then(read_family)
+                {
+                    map.entry(ph_type).or_insert(family);
+                }
+            }
+        }
+    }
+
+    if let Some(tx_styles) = child(root, "txStyles") {
+        for &(style_name, ph_types) in MASTER_TXSTYLE_PH_TYPES {
+            if let Some(family) = child(tx_styles, style_name)
+                .and_then(|style| child(style, "lvl1pPr"))
+                .and_then(|lp| child(lp, "defRPr"))
+                .and_then(read_family)
+            {
+                for ph_type in ph_types {
+                    map.entry((*ph_type).to_owned())
+                        .or_insert_with(|| family.clone());
+                }
+            }
+        }
+    }
+    map
+}
+
 /// Per-list-level default font sizes from the master, keyed by ph_type. Mirrors
 /// `parse_master_font_sizes` but captures every list level (lvl1pPr..lvl9pPr) so
 /// nested bullets inherit the correct shrinking sizes (ECMA-376 §21.1.2.4),
@@ -1151,6 +1223,7 @@ pub(crate) fn parse_master_transforms(root: roxmltree::Node<'_, '_>) -> HashMap<
 pub(crate) fn parse_layout_placeholders(
     root: roxmltree::Node<'_, '_>,
     master_font_sizes: &HashMap<String, f64>,
+    master_font_families: &HashMap<String, String>,
     master_level_font_sizes: &HashMap<String, LevelFontSizes>,
     master_level_indents: &HashMap<String, LevelIndents>,
     master_level_bullets: &HashMap<String, LevelBullets>,
@@ -1207,6 +1280,10 @@ pub(crate) fn parse_layout_placeholders(
         let layout_font_size = layout_def_rpr
             .and_then(|rp| attr_f64(&rp, "sz"))
             .map(|v| v / 100.0);
+        let layout_font_family = layout_def_rpr
+            .and_then(|rp| child(rp, "latin"))
+            .and_then(|latin| attr(&latin, "typeface"))
+            .map(|face| resolve_theme_typeface(&face, theme));
         // Per-level sizes from the layout placeholder's own lstStyle (all
         // lvlNpPr), used to give nested bullets their shrinking sizes.
         let layout_level_sizes: LevelFontSizes = child(sp, "txBody")
@@ -1331,6 +1408,12 @@ pub(crate) fn parse_layout_placeholders(
                 if let Some(fs) = fs {
                     lph.by_idx_font_size.entry(idx).or_insert(fs);
                 }
+                let family = layout_font_family
+                    .clone()
+                    .or_else(|| master_font_families.get(&ph_type).cloned());
+                if let Some(family) = family {
+                    lph.by_idx_font_family.entry(idx).or_insert(family);
+                }
                 // Per-level: layout lstStyle wins per level, else master.
                 let level_sizes = merge_level_sizes(
                     &layout_level_sizes,
@@ -1396,6 +1479,14 @@ pub(crate) fn parse_layout_placeholders(
                 layout_font_size.or_else(|| master_font_sizes.get(&ph_type).copied());
             if let Some(fs) = effective_fs {
                 lph.by_type_font_size.entry(ph_type.clone()).or_insert(fs);
+            }
+            let effective_family = layout_font_family
+                .clone()
+                .or_else(|| master_font_families.get(&ph_type).cloned());
+            if let Some(family) = effective_family {
+                lph.by_type_font_family
+                    .entry(ph_type.clone())
+                    .or_insert(family);
             }
             let type_level_sizes = merge_level_sizes(
                 &layout_level_sizes,
@@ -1549,6 +1640,7 @@ pub(crate) fn read_show_master_sp(node: roxmltree::Node<'_, '_>) -> bool {
 pub(crate) fn parse_layout(
     layout_xml: &str,
     master_font_sizes: &HashMap<String, f64>,
+    master_font_families: &HashMap<String, String>,
     master_level_font_sizes: &HashMap<String, LevelFontSizes>,
     master_level_indents: &HashMap<String, LevelIndents>,
     master_level_bullets: &HashMap<String, LevelBullets>,
@@ -1576,6 +1668,7 @@ pub(crate) fn parse_layout(
     let placeholders = parse_layout_placeholders(
         root,
         master_font_sizes,
+        master_font_families,
         master_level_font_sizes,
         master_level_indents,
         master_level_bullets,
@@ -1641,6 +1734,7 @@ pub(crate) struct ParsedMaster {
     /// only by the common no-override slides.
     pub(crate) master_decorative: Vec<SlideElement>,
     pub(crate) master_font_sizes: HashMap<String, f64>,
+    pub(crate) master_font_families: HashMap<String, String>,
     pub(crate) master_level_font_sizes: HashMap<String, LevelFontSizes>,
     pub(crate) master_level_indents: HashMap<String, LevelIndents>,
     pub(crate) master_level_bullets: HashMap<String, LevelBullets>,
@@ -1761,6 +1855,9 @@ pub(crate) fn build_master_bundle(
     });
 
     let master_font_sizes = master_root.map(parse_master_font_sizes).unwrap_or_default();
+    let master_font_families = master_root
+        .map(|root| parse_master_font_families(root, &theme))
+        .unwrap_or_default();
     let master_level_font_sizes = master_root
         .map(parse_master_level_font_sizes)
         .unwrap_or_default();
@@ -1811,6 +1908,7 @@ pub(crate) fn build_master_bundle(
         master_bg,
         master_decorative,
         master_font_sizes,
+        master_font_families,
         master_level_font_sizes,
         master_level_indents,
         master_level_bullets,
@@ -1853,6 +1951,7 @@ mod placeholder_geometry_tests {
         parse_layout_placeholders(
             doc.root_element(),
             &HashMap::<String, f64>::new(),
+            &HashMap::<String, String>::new(),
             &HashMap::<String, LevelFontSizes>::new(),
             &HashMap::<String, LevelIndents>::new(),
             &HashMap::<String, LevelBullets>::new(),

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -7,8 +7,8 @@
 use crate::chart::{parse_chartex, parse_legacy_chart};
 use crate::fill::{
     parse_arrow_end, parse_blip_alpha, parse_color_node, parse_cust_geom, parse_effect_lst,
-    parse_fill, parse_scene3d, parse_shadow, parse_sp3d, parse_stroke, parse_table_style_fill,
-    parse_xfrm, EffectLst,
+    parse_fill, parse_scene3d, parse_shadow, parse_sp3d, parse_stroke, parse_style_matrix_fill,
+    parse_table_style_fill, parse_xfrm, EffectLst,
 };
 use crate::master::{InheritedShapeGeometry, LayoutPlaceholders};
 use crate::text::{
@@ -311,13 +311,16 @@ pub(crate) fn parse_shape(
     // --- Shape style (p:style) provides fill/stroke/text-color fallbacks ---
     let style_node = child(sp_node, "style");
 
-    // fillRef idx=0 → explicit no-fill; idx>0 → use referenced color as solid fill
+    // fillRef idx=0 → explicit no-fill; idx>0 → resolve the referenced
+    // theme fill style, substituting this ref's colour for phClr. Retain the
+    // former solid-colour fallback for incomplete/malformed themes.
     let style_fill: Option<Fill> = style_node.and_then(|s| child(s, "fillRef")).and_then(|fr| {
         let idx: u32 = attr(&fr, "idx").and_then(|v| v.parse().ok()).unwrap_or(1);
         if idx == 0 {
             Some(Fill::None)
         } else {
-            parse_color_node(fr, theme).map(|c| Fill::Solid { color: c })
+            parse_style_matrix_fill(fr, theme, false)
+                .or_else(|| parse_color_node(fr, theme).map(|c| Fill::Solid { color: c }))
         }
     });
 
@@ -399,6 +402,7 @@ pub(crate) fn parse_shape(
     // Inherited defaults from layout/master for this placeholder type/idx
     let (
         inherited_font_size,
+        inherited_font_family,
         inherited_bold,
         inherited_italic,
         inherited_caps,
@@ -412,6 +416,7 @@ pub(crate) fn parse_shape(
     ) = if ph_node.is_some() {
         (
             lph.lookup_font_size(&ph_type, ph_idx),
+            lph.lookup_font_family(&ph_type, ph_idx),
             lph.lookup_bold(&ph_type),
             lph.lookup_italic(&ph_type),
             lph.lookup_caps(&ph_type),
@@ -425,7 +430,7 @@ pub(crate) fn parse_shape(
         )
     } else {
         (
-            None, None, None, None, None, None, None, None, None, None, None,
+            None, None, None, None, None, None, None, None, None, None, None, None,
         )
     };
     let inherited_level_font_sizes: LevelFontSizes = if ph_node.is_some() {
@@ -468,6 +473,7 @@ pub(crate) fn parse_shape(
             rels,
             source_dir,
             inherited_font_size,
+            inherited_font_family,
             inherited_level_font_sizes,
             inherited_level_indents,
             &inherited_level_bullets,
@@ -1403,6 +1409,7 @@ pub(crate) fn parse_table_cell(
             theme,
             rels,
             source_dir,
+            None,
             None,
             [None; 9],
             Default::default(), // inherited_level_indents

--- a/packages/pptx/parser/src/smartart_fallback.rs
+++ b/packages/pptx/parser/src/smartart_fallback.rs
@@ -306,6 +306,7 @@ fn append_point_paragraphs(
         &empty_rels,
         "",
         None,
+        None,
         Default::default(),
         Default::default(),
         &empty_level_bullets(),

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -371,6 +371,7 @@ pub(crate) fn parse_text_body(
     rels: &HashMap<String, String>,
     source_dir: &str,
     inherited_font_size: Option<f64>,
+    inherited_font_family: Option<String>,
     inherited_level_font_sizes: LevelFontSizes,
     inherited_level_indents: LevelIndents,
     inherited_level_bullets: &LevelBullets,
@@ -538,6 +539,11 @@ pub(crate) fn parse_text_body(
         .and_then(|rp| attr_f64(&rp, "sz"))
         .map(|v| v / 100.0)
         .or(inherited_font_size);
+    let default_font_family = own_def_rpr
+        .and_then(|rp| child(rp, "latin"))
+        .and_then(|latin| attr(&latin, "typeface"))
+        .map(|face| resolve_theme_typeface(&face, theme))
+        .or(inherited_font_family);
     // Effective per-list-level default sizes: this shape's own lstStyle wins per
     // level, else the layout/master inherited per-level sizes. Paragraphs pick
     // their size by `lvl` so nested bullets shrink (ECMA-376 §21.1.2.4).
@@ -620,6 +626,7 @@ pub(crate) fn parse_text_body(
                 body_default_space_before,
                 body_default_space_after,
                 body_default_line_spacing,
+                default_font_family.as_deref(),
                 &effective_level_sizes,
                 &effective_level_indents,
                 &effective_level_bullets,
@@ -765,6 +772,7 @@ pub(crate) fn parse_paragraph(
     body_default_space_before: Option<i64>,
     body_default_space_after: Option<i64>,
     body_default_line_spacing: Option<f64>,
+    body_default_font_family: Option<&str>,
     level_font_sizes: &LevelFontSizes,
     level_indents: &LevelIndents,
     level_bullets: &LevelBullets,
@@ -921,7 +929,8 @@ pub(crate) fn parse_paragraph(
     let def_font_family = def_rpr
         .and_then(|n| child(n, "latin"))
         .and_then(|n| attr(&n, "typeface"))
-        .map(|tf| resolve_theme_typeface(&tf, theme));
+        .map(|tf| resolve_theme_typeface(&tf, theme))
+        .or_else(|| body_default_font_family.map(str::to_owned));
 
     let mut runs = Vec::new();
     for node in p_node.children().filter(|n| n.is_element()) {

--- a/packages/pptx/parser/src/theme.rs
+++ b/packages/pptx/parser/src/theme.rs
@@ -46,12 +46,12 @@ pub(crate) fn parse_theme_colors(xml: &str) -> HashMap<String, String> {
 
     let root = doc.root_element();
 
-    // Parse fmtScheme > lnStyleLst so lnRef idx="N" can resolve to the theme's
-    // canonical stroke width (9525 is wrong; theme defines 12700 / 19050 / 25400).
-    // Stored under "+lnRef-1", "+lnRef-2", "+lnRef-3". Kept local: only entries
-    // that declare an explicit `w` get a key (a bare `<a:ln/>` is skipped, unlike
-    // the shared helper which fills the CT_LineProperties 9525 default), and the
-    // value is the raw `w` string the consumer re-parses.
+    // Parse fmtScheme so style references can resolve against the theme's format
+    // style matrix (ECMA-376 §20.1.4.1.18). Fill entries stay as small owned XML
+    // fragments because phClr is supplied by each individual fillRef/bgRef and
+    // therefore cannot be resolved while the theme is parsed. Only a referenced
+    // fragment is reparsed later; ordinary explicit fills keep their current fast
+    // path. Line widths keep their existing compact string representation.
     if let Some(fmt_scheme) = root
         .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "fmtScheme")
@@ -64,6 +64,18 @@ pub(crate) fn parse_theme_colors(xml: &str) -> HashMap<String, String> {
             {
                 if let Some(w) = attr(&ln, "w") {
                     map.insert(format!("+lnRef-{}", i + 1), w);
+                }
+            }
+        }
+        for (list_name, key_prefix) in [
+            ("fillStyleLst", "+fillStyle"),
+            ("bgFillStyleLst", "+bgFillStyle"),
+        ] {
+            if let Some(style_list) = child(fmt_scheme, list_name) {
+                for (i, fill) in style_list.children().filter(|n| n.is_element()).enumerate() {
+                    if let Some(fragment) = xml.get(fill.range()) {
+                        map.insert(format!("{key_prefix}-{}", i + 1), fragment.to_owned());
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- resolve slide background `bgRef` values through the theme format style matrix
- resolve shape `fillRef` values while preserving gradients and `phClr` substitution
- inherit master and layout placeholder Latin typefaces for themed titles

The previous parser reduced theme style references to a single resolved color, which discarded the referenced fill geometry and transforms. It also did not carry the master title typeface into slide text when the run omitted a local font.

## Specification

This follows ECMA-376 Part 1 sections 19.3.1.3, 19.3.1.52, 20.1.2.3.34, and 20.1.4.

## Verification

- `cargo test -p pptx-parser` (228 tests)
- `./node_modules/.bin/vitest run packages/pptx/src` (625 tests)
- `pnpm typecheck`
- `pnpm --filter @silurus/ooxml-pptx build`
- `cargo clippy -p pptx-parser -- -D warnings`
- PowerPoint PDF comparison for the public fixtures linked in the issue

Fixes #1185