### PR TITLE
fix(pptx): lighten built-in table banding tints

### DIFF
--- a/packages/ooxml-common/src/color.rs
+++ b/packages/ooxml-common/src/color.rs
@@ -79,6 +79,29 @@ pub enum TintMode {
     PowerPointLinear,
 }
 
+/// Apply a DrawingML tint to normalized RGB channels without quantizing the
+/// intermediate result. Exposed for generated preset tables, which carry the
+/// same transforms as XML-backed colours but have no `roxmltree::Node`.
+pub fn apply_tint_channels(rgb: (f64, f64, f64), val: f64, tint_mode: TintMode) -> (f64, f64, f64) {
+    let (r, g, b) = rgb;
+    match tint_mode {
+        TintMode::WordLiteral => (
+            val * r + (1.0 - val),
+            val * g + (1.0 - val),
+            val * b + (1.0 - val),
+        ),
+        TintMode::PowerPointLinear => {
+            // PowerPoint retains `val` of the input in LINEAR sRGB. Verified
+            // against PDF exports of SmartArt accent recolors; treating val as
+            // the amount of white reverses common gradient stops.
+            let apply = |channel: f64| {
+                linear_to_srgb((val * srgb_to_linear(channel) + (1.0 - val)).clamp(0.0, 1.0))
+            };
+            (apply(r), apply(g), apply(b))
+        }
+    }
+}
+
 /// Apply OOXML color transforms to `hex` based on the modifier elements
 /// declared as direct children of `node`. Returns 6-char hex when fully
 /// opaque, or 8-char hex (RRGGBBAA) when alpha < 1.
@@ -170,26 +193,7 @@ pub fn apply_color_transforms(hex: &str, node: Node, tint_mode: TintMode) -> Str
             }
             "tint" => {
                 let val = attr_pct(&t, "val", 0.0);
-                match tint_mode {
-                    TintMode::WordLiteral => {
-                        // `result = val·input + (1-val)·white` per literal spec.
-                        rf = val * rf + (1.0 - val);
-                        gf = val * gf + (1.0 - val);
-                        bf = val * bf + (1.0 - val);
-                    }
-                    TintMode::PowerPointLinear => {
-                        // PowerPoint retains `val` of the input in LINEAR sRGB.
-                        // Verified against PDF exports of SmartArt accent
-                        // recolors; treating val as the amount of white reverses
-                        // the gradient stops used by common SmartArt styles.
-                        let lr = srgb_to_linear(rf);
-                        let lg = srgb_to_linear(gf);
-                        let lb = srgb_to_linear(bf);
-                        rf = linear_to_srgb((val * lr + (1.0 - val)).clamp(0.0, 1.0));
-                        gf = linear_to_srgb((val * lg + (1.0 - val)).clamp(0.0, 1.0));
-                        bf = linear_to_srgb((val * lb + (1.0 - val)).clamp(0.0, 1.0));
-                    }
-                }
+                (rf, gf, bf) = apply_tint_channels((rf, gf, bf), val, tint_mode);
             }
             "alpha" => {
                 // ECMA-376 §20.1.2.3.1 — sets absolute alpha.

--- a/packages/pptx/parser/src/table_style_presets.rs
+++ b/packages/pptx/parser/src/table_style_presets.rs
@@ -10,6 +10,7 @@
 use std::collections::HashMap;
 
 use crate::{Fill, Stroke, TableStyleDef};
+use ooxml_common::color::{apply_tint_channels, TintMode};
 
 // ── Color helpers ────────────────────────────────────────────────────────────
 
@@ -66,22 +67,6 @@ fn hls_to_rgb(h: f64, l: f64, s: f64) -> (f64, f64, f64) {
     )
 }
 
-fn srgb_to_linear(c: f64) -> f64 {
-    if c <= 0.04045 {
-        c / 12.92
-    } else {
-        ((c + 0.055) / 1.055).powf(2.4)
-    }
-}
-
-fn linear_to_srgb(c: f64) -> f64 {
-    if c <= 0.0031308 {
-        12.92 * c
-    } else {
-        1.055 * c.powf(1.0 / 2.4) - 0.055
-    }
-}
-
 /// Apply a sequence of (name, val) color transforms to a hex color.
 /// val uses OOXML units (100_000 = 100%).
 pub(crate) fn apply_transforms(hex: &str, transforms: &[(&str, i64)]) -> String {
@@ -118,12 +103,10 @@ pub(crate) fn apply_transforms(hex: &str, transforms: &[(&str, i64)]) -> String 
                 bf *= v;
             }
             "tint" => {
-                let lr = srgb_to_linear(rf);
-                let lg = srgb_to_linear(gf);
-                let lb = srgb_to_linear(bf);
-                rf = linear_to_srgb((lr + (1.0 - lr) * v).clamp(0.0, 1.0));
-                gf = linear_to_srgb((lg + (1.0 - lg) * v).clamp(0.0, 1.0));
-                bf = linear_to_srgb((lb + (1.0 - lb) * v).clamp(0.0, 1.0));
+                // Built-in PowerPoint table styles use the same literal tint
+                // semantics as XML-backed table styles: val is the retained
+                // input fraction in encoded sRGB, not a white amount.
+                (rf, gf, bf) = apply_tint_channels((rf, gf, bf), v, TintMode::WordLiteral);
             }
             "alpha" => {
                 alpha = v;
@@ -848,4 +831,35 @@ pub fn lookup_builtin_table_style(
         Family::DarkStyle1 => dark_style_1(theme, accent_idx),
         Family::DarkStyle2 => dark_style_2(theme, accent_idx),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn solid_color(fill: &Option<Fill>) -> Option<&str> {
+        match fill {
+            Some(Fill::Solid { color }) => Some(color),
+            _ => None,
+        }
+    }
+
+    /// The built-in Medium Style 2 / Accent 1 table is the default produced by
+    /// python-pptx and many Office generators. ECMA-376 §20.1.2.3.34 tint values
+    /// retain the stated fraction of the source colour; table styles apply the
+    /// literal encoded-sRGB blend used by PowerPoint's preset definitions.
+    #[test]
+    fn medium_style_2_accent_1_uses_literal_table_tints() {
+        let theme = HashMap::from([
+            ("accent1".to_owned(), "4F81BD".to_owned()),
+            ("lt1".to_owned(), "FFFFFF".to_owned()),
+            ("dk1".to_owned(), "000000".to_owned()),
+        ]);
+        let style = lookup_builtin_table_style("{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}", &theme)
+            .expect("known PowerPoint table style");
+
+        assert_eq!(solid_color(&style.first_row_fill), Some("4F81BD"));
+        assert_eq!(solid_color(&style.whole_fill), Some("DCE6F2"));
+        assert_eq!(solid_color(&style.band1h_fill), Some("B9CDE5"));
+    }
 }


### PR DESCRIPTION
## Summary
- Make generated PowerPoint table presets use the same literal tint semantics as XML-backed table styles.
- Reuse the shared DrawingML tint implementation instead of keeping a divergent table-preset formula.
- Add a regression for the standard Medium Style 2 / Accent 1 GUID, including header, whole-table, and band fills.

## Root cause
Built-in table styles do not carry their complete style XML in the package, so the parser generates them from a GUID catalog. That path had a separate tint implementation which treated the tint value as the amount of white in linear sRGB. A 20 percent retained-input tint therefore stayed close to the raw accent color instead of becoming the light pastel fill used by PowerPoint.

## Verification
- ooxml-common and pptx-parser tests: passed
- PPTX parser regression: passed
- Rust clippy with warnings denied: passed
- PPTX Vitest: 625 tests passed
- PPTX package build: passed
- Git whitespace check: passed

## Specification
ECMA-376 Part 1 section 20.1.2.3.34 (tint).

Fixes #1186