### PR TITLE
fix(pptx): inherit chart theme defaults

### DIFF
--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -834,8 +834,7 @@ pub trait ColorResolver {
     /// (no leading `#`) lets the renderer draw the correct default palette
     /// without needing theme access.
     ///
-    /// Defaults to `None` so a resolver whose renderer already owns a default
-    /// palette (pptx) leaves the series color unset and lets that palette apply.
+    /// Defaults to `None` for callers that do not carry a theme palette.
     fn resolve_series_accent(&self, _idx: usize) -> Option<String> {
         None
     }
@@ -4054,9 +4053,20 @@ pub fn parse_chart_part_with_references(
     let val_axis_major_tick_mark = read_major_tick_mark(val_ax);
     let cat_axis_major_tick_mark = read_major_tick_mark(cat_ax);
 
-    // Axis tick-label font size from `<c:txPr>` (in OOXML hundredths of a point).
-    let cat_axis_font_size_hpt = cat_ax.and_then(extract_axis_tick_label_size);
-    let val_axis_font_size_hpt = val_ax.and_then(extract_axis_tick_label_size);
+    // Axis-local text properties override the chart-wide `<c:chartSpace><c:txPr>`
+    // defaults. Microsoft documents the latter as the OfficeArt text properties
+    // for the entire chart, so an axis without its own `<c:txPr>` must inherit
+    // these values rather than fall back to renderer constants.
+    let chart_text_font_size_hpt = extract_axis_tick_label_size(root);
+    let chart_text_font_color = extract_axis_tick_label_color(root, color_resolver);
+    let chart_text_font_bold = extract_axis_tick_label_bold(root);
+    let chart_text_font_face = extract_axis_tick_label_face(root);
+    let cat_axis_font_size_hpt = cat_ax
+        .and_then(extract_axis_tick_label_size)
+        .or(chart_text_font_size_hpt);
+    let val_axis_font_size_hpt = val_ax
+        .and_then(extract_axis_tick_label_size)
+        .or(chart_text_font_size_hpt);
 
     // Data-label font size — first `<c:dLbls><c:txPr>` defRPr/rPr@sz we find.
     let data_label_font_size_hpt = extract_data_label_font_size(root);
@@ -4078,8 +4088,12 @@ pub fn parse_chart_part_with_references(
     // tick labels and `<c:spPr><a:ln>` styles the axis rule. Shared helpers so
     // the gray "2025年3月期" category labels and the light-gray category-axis
     // line in sample-2 slide-16's horizontal bar chart resolve the same way.
-    let cat_axis_font_color = cat_ax.and_then(|n| extract_axis_tick_label_color(n, color_resolver));
-    let val_axis_font_color = val_ax.and_then(|n| extract_axis_tick_label_color(n, color_resolver));
+    let cat_axis_font_color = cat_ax
+        .and_then(|n| extract_axis_tick_label_color(n, color_resolver))
+        .or_else(|| chart_text_font_color.clone());
+    let val_axis_font_color = val_ax
+        .and_then(|n| extract_axis_tick_label_color(n, color_resolver))
+        .or_else(|| chart_text_font_color.clone());
     let (cat_axis_line_color, cat_axis_line_width_emu, cat_axis_line_hidden) = cat_ax
         .map(|n| extract_axis_line_style(n, color_resolver))
         .unwrap_or((None, None, false));
@@ -4109,8 +4123,9 @@ pub fn parse_chart_part_with_references(
             title: t,
             hidden: axis_is_deleted(ax),
             format_code: extract_axis_format_code(ax),
-            font_color: extract_axis_tick_label_color(ax, color_resolver),
-            font_size_hpt: extract_axis_tick_label_size(ax),
+            font_color: extract_axis_tick_label_color(ax, color_resolver)
+                .or_else(|| chart_text_font_color.clone()),
+            font_size_hpt: extract_axis_tick_label_size(ax).or(chart_text_font_size_hpt),
             line_color,
             line_width_emu,
             line_hidden,
@@ -4261,8 +4276,12 @@ pub fn parse_chart_part_with_references(
     // ooxml-common helpers so the two parsers stay in lockstep. The chart-title
     // bold helper expects the `<c:title>`'s parent, so pass `title_node_opt`'s
     // parent (the element that holds it as a direct child).
-    let cat_axis_font_bold = cat_ax.and_then(extract_axis_tick_label_bold);
-    let val_axis_font_bold = val_ax.and_then(extract_axis_tick_label_bold);
+    let cat_axis_font_bold = cat_ax
+        .and_then(extract_axis_tick_label_bold)
+        .or(chart_text_font_bold);
+    let val_axis_font_bold = val_ax
+        .and_then(extract_axis_tick_label_bold)
+        .or(chart_text_font_bold);
     let title_font_bold = title_node_opt
         .and_then(|t| t.parent())
         .and_then(extract_chart_title_bold);
@@ -4289,8 +4308,12 @@ pub fn parse_chart_part_with_references(
     // (`<c:dLbls><c:txPr>…<a:latin>`) and legend text props, all via the shared
     // ooxml-common extractors so pptx/xlsx stay in lockstep. Absent faces stay
     // None; the renderer falls back to the theme body/heading font.
-    let cat_axis_font_face = cat_ax.and_then(extract_axis_tick_label_face);
-    let val_axis_font_face = val_ax.and_then(extract_axis_tick_label_face);
+    let cat_axis_font_face = cat_ax
+        .and_then(extract_axis_tick_label_face)
+        .or_else(|| chart_text_font_face.clone());
+    let val_axis_font_face = val_ax
+        .and_then(extract_axis_tick_label_face)
+        .or_else(|| chart_text_font_face.clone());
     let data_label_font_face = extract_data_label_face(root);
     let (legend_font_face, legend_font_size_hpt, legend_font_bold) =
         extract_legend_text_props(root);

--- a/packages/pptx/parser/src/chart.rs
+++ b/packages/pptx/parser/src/chart.rs
@@ -33,6 +33,10 @@ impl ooxml_common::chart::ColorResolver for PptxColorResolver<'_> {
     fn theme_minor_font_latin(&self) -> Option<String> {
         self.theme.get("+mn-lt").cloned()
     }
+
+    fn resolve_series_accent(&self, idx: usize) -> Option<String> {
+        self.theme.get(&format!("accent{}", idx % 6 + 1)).cloned()
+    }
 }
 
 /// Parse a legacy OOXML chart (`c:` namespace) — barChart / lineChart etc.
@@ -96,4 +100,61 @@ pub(crate) fn parse_chartex(
         flip_v: false,
         chart,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const C_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+    const A_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+    #[test]
+    fn legacy_chart_uses_theme_accents_and_chart_wide_text_defaults() {
+        let xml = format!(
+            r#"<c:chartSpace xmlns:c="{C_NS}" xmlns:a="{A_NS}">
+              <c:chart>
+                <c:plotArea>
+                  <c:barChart>
+                    <c:barDir val="col"/>
+                    <c:grouping val="clustered"/>
+                    <c:ser>
+                      <c:idx val="0"/><c:order val="0"/>
+                      <c:tx><c:v>2025</c:v></c:tx>
+                      <c:cat><c:strLit><c:ptCount val="1"/><c:pt idx="0"><c:v>T1</c:v></c:pt></c:strLit></c:cat>
+                      <c:val><c:numLit><c:ptCount val="1"/><c:pt idx="0"><c:v>12.5</c:v></c:pt></c:numLit></c:val>
+                    </c:ser>
+                    <c:ser>
+                      <c:idx val="1"/><c:order val="1"/>
+                      <c:tx><c:v>2026</c:v></c:tx>
+                      <c:cat><c:strLit><c:ptCount val="1"/><c:pt idx="0"><c:v>T1</c:v></c:pt></c:strLit></c:cat>
+                      <c:val><c:numLit><c:ptCount val="1"/><c:pt idx="0"><c:v>15</c:v></c:pt></c:numLit></c:val>
+                    </c:ser>
+                    <c:axId val="1"/><c:axId val="2"/>
+                  </c:barChart>
+                  <c:catAx>
+                    <c:axId val="1"/><c:axPos val="b"/><c:crossAx val="2"/>
+                    <c:txPr><a:bodyPr/><a:p><a:pPr><a:defRPr sz="900"/></a:pPr></a:p></c:txPr>
+                  </c:catAx>
+                  <c:valAx><c:axId val="2"/><c:axPos val="l"/><c:crossAx val="1"/></c:valAx>
+                </c:plotArea>
+              </c:chart>
+              <c:txPr>
+                <a:bodyPr/><a:lstStyle/>
+                <a:p><a:pPr><a:defRPr sz="1800"/></a:pPr></a:p>
+              </c:txPr>
+            </c:chartSpace>"#
+        );
+        let theme = HashMap::from([
+            ("accent1".to_string(), "4F81BD".to_string()),
+            ("accent2".to_string(), "C0504D".to_string()),
+        ]);
+
+        let element = parse_legacy_chart(&xml, &theme).expect("chart should parse");
+
+        assert_eq!(element.chart.series[0].color.as_deref(), Some("4F81BD"));
+        assert_eq!(element.chart.series[1].color.as_deref(), Some("C0504D"));
+        assert_eq!(element.chart.cat_axis_font_size_hpt, Some(900));
+        assert_eq!(element.chart.val_axis_font_size_hpt, Some(1800));
+    }
 }


### PR DESCRIPTION
## Summary
- resolve unstyled legacy chart series from presentation theme accent colors
- inherit chartSpace text defaults for axis tick labels while preserving axis-local overrides
- add a parser regression covering both theme series colors and chart-wide text size fallback

## Rationale
DrawingML uses theme accent slots for default chart series colors. The chartSpace text properties define formatting for the entire chart, so an axis without local text properties inherits those defaults.

## Verification
- cargo test -p ooxml-common
- cargo test -p pptx-parser
- cargo clippy -p pptx-parser -- -D warnings
- vitest packages/pptx/src: 625 tests
- git diff --check

Fixes #1187