### PR TITLE
fix(pptx): honor table text styles and bullet markers

### DIFF
--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -3592,6 +3592,33 @@ mod tests {
         assert!(BulletProps::default().is_inherit());
     }
 
+    /// PowerPoint treats `buChar` as a single marker even when a producer writes
+    /// more than one Unicode scalar into the schema's string-valued attribute.
+    /// Keep the first scalar so malformed SmartArt caches do not paint doubled
+    /// bullets, while supplementary-plane markers remain intact.
+    #[test]
+    fn character_bullet_uses_one_unicode_scalar() {
+        let doc = roxmltree::Document::parse(
+            r#"<a:pPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:buChar char="••"/></a:pPr>"#,
+        )
+        .expect("valid paragraph properties");
+        let theme = HashMap::new();
+        let mut resolve_blip = |_: &str| None;
+        match parse_bullet(Some(doc.root_element()), &theme, &mut resolve_blip) {
+            Bullet::Char { ch, .. } => assert_eq!(ch, "•"),
+            other => panic!("expected Char, got {other:?}"),
+        }
+
+        let emoji_doc = roxmltree::Document::parse(
+            r#"<a:pPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:buChar char="🡆x"/></a:pPr>"#,
+        )
+        .expect("valid supplementary-plane marker");
+        match parse_bullet(Some(emoji_doc.root_element()), &theme, &mut resolve_blip) {
+            Bullet::Char { ch, .. } => assert_eq!(ch, "🡆"),
+            other => panic!("expected Char, got {other:?}"),
+        }
+    }
+
     /// §21.1.2.4.9 — `<a:buSzPct val>` accepts both the Transitional integer
     /// (thousandths of a percent, `"100000"` = 100%, what PowerPoint writes) and
     /// the Strict percentage string (`"111%"`, as in the spec example).

--- a/packages/pptx/parser/src/table_style_presets.rs
+++ b/packages/pptx/parser/src/table_style_presets.rs
@@ -278,6 +278,7 @@ fn medium_style_2(theme: &HashMap<String, String>, accent_idx: Option<u8>) -> Ta
         .or_else(|| dk1(theme))
         .unwrap_or_else(|| "000000".into());
     let lt = lt1(theme).unwrap_or_else(|| "FFFFFF".into());
+    let dk = dk1(theme).unwrap_or_else(|| "000000".into());
     let border = Some(stroke(&lt));
     let whole_color = apply_transforms(&a, &[("tint", 20000)]);
     let band1h_color = apply_transforms(&a, &[("tint", 40000)]);
@@ -293,6 +294,15 @@ fn medium_style_2(theme: &HashMap<String, String>, accent_idx: Option<u8>) -> Ta
         whole_inside_h: border.clone(),
         whole_inside_v: border,
         first_row_border_b: Some(stroke(&lt)),
+        whole_text_color: Some(dk),
+        first_row_text_color: Some(lt.clone()),
+        last_row_text_color: Some(lt.clone()),
+        first_col_text_color: Some(lt.clone()),
+        last_col_text_color: Some(lt),
+        first_row_bold: Some(true),
+        last_row_bold: Some(true),
+        first_col_bold: Some(true),
+        last_col_bold: Some(true),
         ..Default::default()
     }
 }
@@ -861,5 +871,14 @@ mod tests {
         assert_eq!(solid_color(&style.first_row_fill), Some("4F81BD"));
         assert_eq!(solid_color(&style.whole_fill), Some("DCE6F2"));
         assert_eq!(solid_color(&style.band1h_fill), Some("B9CDE5"));
+        assert_eq!(style.first_row_text_color.as_deref(), Some("FFFFFF"));
+        assert_eq!(style.first_row_bold, Some(true));
+        assert_eq!(style.whole_text_color.as_deref(), Some("000000"));
+        assert_eq!(style.last_row_text_color.as_deref(), Some("FFFFFF"));
+        assert_eq!(style.first_col_text_color.as_deref(), Some("FFFFFF"));
+        assert_eq!(style.last_col_text_color.as_deref(), Some("FFFFFF"));
+        assert_eq!(style.last_row_bold, Some(true));
+        assert_eq!(style.first_col_bold, Some(true));
+        assert_eq!(style.last_col_bold, Some(true));
     }
 }

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -1087,7 +1087,14 @@ fn parse_bullet_marker<F: FnMut(&str) -> Option<String>>(
 
     // Character bullet
     if let Some(bu_char) = child(p_pr, "buChar") {
-        let ch = attr(&bu_char, "char").unwrap_or_else(|| "\u{2022}".into()); // •
+        // CT_TextCharBullet's attribute is schema-typed as a string, but Office
+        // paints a single marker glyph. Some flattened SmartArt caches contain
+        // duplicated values such as `••`; retaining the whole string paints a
+        // visibly doubled marker. Select one Unicode scalar (not one UTF-16
+        // code unit) so supplementary-plane symbols remain intact.
+        let ch = attr(&bu_char, "char")
+            .and_then(|value| value.chars().next().map(|ch| ch.to_string()))
+            .unwrap_or_else(|| "\u{2022}".into()); // •
         return Some(BuMarker::Char(ch));
     }
 


### PR DESCRIPTION
## Summary
- apply the built-in table style's text color and bold roles together with its fill roles
- treat a bullet character as one Unicode scalar so malformed cached markers do not render duplicate bullets
- add parser regressions for both behaviors

## Verification
- PPTX parser tests
- cargo clippy for the PPTX parser
- local PowerPoint PDF comparison
- git diff --check