### PR TITLE
fix(core): join open arrowhead strokes

### DIFF
--- a/packages/core/src/shape/arrow.test.ts
+++ b/packages/core/src/shape/arrow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { lineEndRetract, retractLineEndpoint } from './arrow';
+import { drawArrowHead, lineEndRetract, retractLineEndpoint } from './arrow';
 import type { ArrowEnd, Stroke } from '../types/common';
 
 const stroke: Stroke = { color: '#000000', width: 10 };
@@ -51,5 +51,51 @@ describe('retractLineEndpoint — pull a point toward its neighbour by `amount`'
     const p = retractLineEndpoint({ x: 0, y: 0 }, { x: 3, y: 4 }, 2.5);
     expect(p.x).toBeCloseTo(1.5, 5);
     expect(p.y).toBeCloseTo(2.0, 5);
+  });
+});
+
+describe('drawArrowHead — open arrow geometry', () => {
+  it('strokes one joined path with rounded exposed ends', () => {
+    const operations: Array<{ name: string; args: unknown[] }> = [];
+    let lineCap: CanvasLineCap = 'butt';
+    let lineJoin: CanvasLineJoin = 'miter';
+    const ctx = {
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 1,
+      get lineCap() { return lineCap; },
+      set lineCap(value: CanvasLineCap) {
+        lineCap = value;
+        operations.push({ name: 'lineCap', args: [value] });
+      },
+      get lineJoin() { return lineJoin; },
+      set lineJoin(value: CanvasLineJoin) {
+        lineJoin = value;
+        operations.push({ name: 'lineJoin', args: [value] });
+      },
+      save() { operations.push({ name: 'save', args: [] }); },
+      restore() { operations.push({ name: 'restore', args: [] }); },
+      translate(...args: unknown[]) { operations.push({ name: 'translate', args }); },
+      rotate(...args: unknown[]) { operations.push({ name: 'rotate', args }); },
+      setLineDash(...args: unknown[]) { operations.push({ name: 'setLineDash', args }); },
+      beginPath() { operations.push({ name: 'beginPath', args: [] }); },
+      moveTo(...args: unknown[]) { operations.push({ name: 'moveTo', args }); },
+      lineTo(...args: unknown[]) { operations.push({ name: 'lineTo', args }); },
+      stroke() { operations.push({ name: 'stroke', args: [] }); },
+    } as unknown as CanvasRenderingContext2D;
+
+    drawArrowHead(ctx, 20, 30, 0, end('arrow'), stroke, 1);
+
+    expect(operations).toEqual(expect.arrayContaining([
+      { name: 'lineCap', args: ['round'] },
+      { name: 'lineJoin', args: ['round'] },
+    ]));
+    expect(operations.filter(({ name }) => name === 'moveTo')).toEqual([
+      { name: 'moveTo', args: [-60, -30] },
+    ]);
+    expect(operations.filter(({ name }) => name === 'lineTo')).toEqual([
+      { name: 'lineTo', args: [0, 0] },
+      { name: 'lineTo', args: [-60, 30] },
+    ]);
   });
 });

--- a/packages/core/src/shape/arrow.ts
+++ b/packages/core/src/shape/arrow.ts
@@ -100,9 +100,13 @@ export function drawArrowHead(
       ctx.fill();
       break;
     case 'arrow':
-      ctx.moveTo(0, 0);
-      ctx.lineTo(-len, -halfW);
-      ctx.moveTo(0, 0);
+      // An open DrawingML arrow is one continuous chevron. Separate subpaths
+      // leave two flat caps stacked at the tip, producing a visibly broken,
+      // jagged point. PowerPoint joins the two arms and rounds the exposed ends.
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      ctx.moveTo(-len, -halfW);
+      ctx.lineTo(0, 0);
       ctx.lineTo(-len, halfW);
       ctx.stroke();
       break;


### PR DESCRIPTION
## Summary
- draw open arrowheads as one continuous chevron path
- use round caps and joins so the tip and endpoints match Office rendering
- add focused geometry regression coverage

## Root cause
The renderer emitted the two sides of an open arrowhead as separate subpaths. Their capped endpoints overlapped at the tip, leaving a visibly cut and jagged join instead of a continuous stroked shape.

## Verification
- 
 RUN  v4.1.4 /Users/yokotani/develop/office-open-xml-viewer


 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  19:32:16
   Duration  73ms (transform 18ms, setup 0ms, import 24ms, tests 2ms, environment 0ms)
- Scope: 3 of 9 workspace projects
packages/markdown typecheck$ tsc --noEmit -p tsconfig.typecheck.json
packages/node typecheck$ tsc --noEmit -p tsconfig.typecheck.json
packages/vscode-extension typecheck$ tsc --noEmit
packages/markdown typecheck: Done
packages/vscode-extension typecheck: Done
packages/node typecheck: Done
- local-only PowerPoint/PDF fidelity comparison