### PR TITLE
fix(pptx): retain auto-number marker formatting

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -257,7 +257,7 @@ export type Bullet =
   | { type: 'none' }
   | { type: 'inherit' }
   | { type: 'char'; char: string; color: string | null; sizePct: number | null; sizePts?: number; fontFamily: string | null }
-  | { type: 'autoNum'; numType: string; startAt: number | null; color: string | null };
+  | { type: 'autoNum'; numType: string; startAt: number | null; color: string | null; sizePct: number | null; sizePts?: number; fontFamily: string | null };
 
 export interface TabStop {
   /** Position in EMU from the LEADING text-inset edge of the text area —

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -43,6 +43,9 @@ type Bullet__emitterCollision1 = {
     numType: string;
     startAt: number | null;
     color: string | null;
+    sizePct: number | null;
+    sizePts?: number;
+    fontFamily: string | null;
 };
 export interface Camera3d {
     prst: string;

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -4541,6 +4541,8 @@ mod tests {
         assert_eq!(v["numType"], "arabicPeriod");
         // The buClr resolves to the srgbClr literal (uppercase hex, no '#').
         assert_eq!(v["color"], "C00000");
+        assert_eq!(v["sizePct"], 100.0);
+        assert_eq!(v["fontFamily"], "+mj-lt");
     }
 
     /// §21.1.2.4.10 (buClrTx) — with no explicit `<a:buClr>` the auto-number

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -238,9 +238,9 @@ impl BulletProps {
     ///   (§21.1.2.4.10, absolute points); `FollowText`/inherit → both `None`. The
     ///   two size fields are mutually exclusive (one `xsd:choice`);
     /// - font: `Font(f)` → `Some(f)`; `FollowText`/inherit → `None`.
-    ///   Auto-number and picture markers carry no font/size in the `Bullet`
-    ///   contract (the renderer draws numbers in the run font and pictures as a
-    ///   sized bitmap), so those groups only participate in cascade blocking.
+    ///   Auto-number markers retain both font and size because their glyph
+    ///   metrics determine whether multi-digit labels fit the hanging gutter.
+    ///   Picture markers retain size but have no applicable font.
     pub(crate) fn resolve(&self) -> Bullet {
         let color = match &self.color {
             Some(BuColor::Color(c)) => Some(c.clone()),
@@ -274,6 +274,9 @@ impl BulletProps {
                 num_type: num_type.clone(),
                 start_at: *start_at,
                 color,
+                size_pct,
+                size_pts,
+                font_family,
             },
             Some(BuMarker::Blip {
                 image_path,

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -911,6 +911,14 @@ pub(crate) enum Bullet {
         /// (§21.1.2.4.5 — the first run's colour). Always serialized (like the
         /// `Char` variant's `color`) so the TS side sees a stable `color` key.
         color: Option<String>,
+        /// `<a:buSzPct>` as a percentage of the first run's text size.
+        size_pct: Option<f64>,
+        /// `<a:buSzPts>` as an absolute marker size in points.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default)]
+        size_pts: Option<f64>,
+        /// Explicit `<a:buFont typeface>`; None means follow the first run.
+        font_family: Option<String>,
     },
     /// Picture bullet (buBlip) — ECMA-376 §21.1.2.4.2 `<a:buBlip><a:blip
     /// r:embed="rIdN"/></a:buBlip>`. The `r:embed` is resolved to the blip's

--- a/packages/pptx/src/autonum-bullet-color.test.ts
+++ b/packages/pptx/src/autonum-bullet-color.test.ts
@@ -16,7 +16,7 @@ import type { TextRunData } from '@silurus/ooxml-core';
 const FONT_PX = 20;
 const SCALE = 1 / 12700; // emuToPx(emu) = emu·SCALE; 12700 EMU = 1 pt → 1 px
 
-interface Fill { text: string; fillStyle: string }
+interface Fill { text: string; fillStyle: string; font: string }
 
 function mockCtx(): { ctx: CanvasRenderingContext2D; fills: Fill[] } {
   let font = `${FONT_PX}px serif`;
@@ -38,7 +38,7 @@ function mockCtx(): { ctx: CanvasRenderingContext2D; fills: Fill[] } {
         fontBoundingBoxAscent: p * 0.8, fontBoundingBoxDescent: p * 0.2,
       } as TextMetrics;
     },
-    fillText: (t: string) => fills.push({ text: t, fillStyle }),
+    fillText: (t: string) => fills.push({ text: t, fillStyle, font }),
     strokeText: () => {}, fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
     translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
     moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
@@ -92,8 +92,13 @@ function markerFill(fills: Fill[]): Fill | undefined {
   return fills.find((f) => /\d/.test(f.text));
 }
 
-const autoNum = (color: string | null): Bullet =>
-  ({ type: 'autoNum', numType: 'arabicPeriod', startAt: null, color } as unknown as Bullet);
+type AutoNumBullet = Extract<Bullet, { type: 'autoNum' }>;
+
+const autoNum = (color: string | null): AutoNumBullet =>
+  ({
+    type: 'autoNum', numType: 'arabicPeriod', startAt: null, color,
+    sizePct: null, fontFamily: null,
+  });
 
 describe('§21.1.2.4.4 auto-number marker honours an explicit buClr', () => {
   it('uses the explicit buClr colour, not the inherited first-run colour', () => {
@@ -108,5 +113,17 @@ describe('§21.1.2.4.4 auto-number marker honours an explicit buClr', () => {
     const marker = markerFill(render(body(autoNum(null), '0000FF')));
     expect(marker, 'auto-number marker drawn').toBeTruthy();
     expect(marker!.fillStyle).toBe('rgba(0,0,255,1)');
+  });
+
+  it('uses the authored bullet typeface and percentage size', () => {
+    const marker = markerFill(render(body({
+      ...autoNum(null),
+      sizePct: 50,
+      fontFamily: 'Calibri',
+    }, '0000FF')));
+
+    expect(marker, 'auto-number marker drawn').toBeTruthy();
+    expect(marker!.font).toContain('10px');
+    expect(marker!.font).toContain('Calibri');
   });
 });

--- a/packages/pptx/src/empty-bullet.test.ts
+++ b/packages/pptx/src/empty-bullet.test.ts
@@ -36,7 +36,7 @@ const brk = (): TextRun => ({ type: 'break' });
 const math = (): TextRun => ({ type: 'math', nodes: [], display: false });
 
 const autoNum = (numType = 'arabicPeriod', startAt: number | null = null): Bullet =>
-  ({ type: 'autoNum', numType, startAt, color: null });
+  ({ type: 'autoNum', numType, startAt, color: null, sizePct: null, fontFamily: null });
 const charBullet = (char = '•'): Bullet =>
   ({ type: 'char', char, color: null, sizePct: null, fontFamily: null });
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -3124,6 +3124,12 @@ export function renderTextBody(
     const bulletInheritedColor = firstRunColorHex
       ? hexToRgba(firstRunColorHex)
       : paraDefaultColor;
+    const firstRunFontFamily = (() => {
+      for (const r of para.runs) {
+        if (r.type === 'text' && r.fontFamily) return r.fontFamily;
+      }
+      return para.defFontFamily ?? null;
+    })();
 
     let bulletLabel  = '';
     let bulletFont   = buildFont(false, false, bulletBaseSizePx, 'sans-serif', rc);
@@ -3159,7 +3165,19 @@ export function renderTextBody(
       bulletFont  = buildFont(false, false, bSizePx, convertedFamily, rc);
       bulletColor = b.color ? hexToRgba(b.color) : bulletInheritedColor;
     } else if (bullet.type === 'autoNum') {
-      bulletFont  = buildFont(false, false, bulletBaseSizePx, 'sans-serif', rc);
+      const b = bullet;
+      const bSizePx = b.sizePts != null
+        ? b.sizePts * PT_TO_EMU * scale * fontScale
+        : b.sizePct != null
+          ? bulletBaseSizePx * (b.sizePct / 100)
+          : bulletBaseSizePx;
+      bulletFont = buildFont(
+        false,
+        false,
+        bSizePx,
+        normalizeFontFamily(b.fontFamily ?? firstRunFontFamily, rc),
+        rc,
+      );
       // ECMA-376 §21.1.2.4.4 (buClr): an explicit `<a:buClr>` colours the
       // auto-number marker, mirroring the char-bullet branch above. Only when it
       // is absent does the marker fall back to the buClrTx default


### PR DESCRIPTION
## Summary
- retain auto-number bullet font and size properties from DrawingML
- apply those properties when measuring and drawing generated number markers
- extend parser, renderer, and public API regression coverage

## Root cause
Auto-number bullets were parsed as a numbering scheme plus color only. Independent `buFont`, `buSzPct`, and `buSzPts` properties were discarded, so generated markers could use the wrong metrics and crowd the following text.

## Verification
- focused PPTX renderer tests (17 passed)
- PPTX parser tests (235 passed)
- `cargo clippy -p pptx-parser -- -D warnings`
- `pnpm check:public-api:built`
- `pnpm typecheck`
- local-only PowerPoint/PDF fidelity comparison
