### PR TITLE
fix(pptx): resolve theme fills in linear sRGB

### DIFF
--- a/packages/pptx/parser/src/fill.rs
+++ b/packages/pptx/parser/src/fill.rs
@@ -139,7 +139,7 @@ pub(crate) fn parse_style_matrix_fill(
     theme: &HashMap<String, String>,
     background: bool,
 ) -> Option<Fill> {
-    use ooxml_common::color::TintMode::WordLiteral;
+    use ooxml_common::color::TintMode::PowerPointLinear;
 
     let idx = attr(&style_ref, "idx")?.parse::<u32>().ok()?;
     let key = if background {
@@ -155,7 +155,7 @@ pub(crate) fn parse_style_matrix_fill(
     };
     let fragment = theme.get(&key)?;
 
-    let placeholder_color = parse_color_node_tint(style_ref, theme, WordLiteral);
+    let placeholder_color = parse_color_node_tint(style_ref, theme, PowerPointLinear);
 
     let wrapped = format!(
         r#"<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">{fragment}</root>"#
@@ -165,7 +165,7 @@ pub(crate) fn parse_style_matrix_fill(
         theme,
         placeholder_color: placeholder_color.as_deref(),
     };
-    parse_fill_with_resolver(doc.root_element(), &resolver, WordLiteral)
+    parse_fill_with_resolver(doc.root_element(), &resolver, PowerPointLinear)
 }
 
 /// ECMA-376 §20.1.8.14 `a:blipFill` → `Fill::Image`. The `resolve_blip`
@@ -880,7 +880,11 @@ pub(crate) fn parse_background<F: FnMut(&str) -> Option<String>>(
                 return Some(fill);
             }
         }
-        return parse_fill_tint(bg_pr, theme, ooxml_common::color::TintMode::WordLiteral);
+        return parse_fill_tint(
+            bg_pr,
+            theme,
+            ooxml_common::color::TintMode::PowerPointLinear,
+        );
     }
     // bgRef references a theme background style; its child is a color element
     if let Some(bg_ref) = child(bg, "bgRef") {

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -4160,11 +4160,11 @@ mod tests {
     }
 
     /// ECMA-376 §20.1.2.3.34 defines tint as retained input colour: an 80%
-    /// tint keeps 80% of the source and adds 20% white. Presentation background
-    /// fills follow that literal definition; the SmartArt compatibility mode is
-    /// intentionally not applied to normal p:bgPr fills.
+    /// tint keeps 80% of the source and adds 20% white. PowerPoint performs
+    /// that blend in linear sRGB for ordinary presentation backgrounds as well
+    /// as theme style-matrix fills.
     #[test]
-    fn test_parse_background_uses_literal_tint_semantics() {
+    fn test_parse_background_uses_powerpoint_linear_tint_semantics() {
         let xml = r#"<p:cSld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
           xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
           <p:bg><p:bgPr><a:solidFill><a:schemeClr val="bg2"><a:tint val="80000"/></a:schemeClr></a:solidFill></p:bgPr></p:bg>
@@ -4173,8 +4173,8 @@ mod tests {
         let theme = HashMap::from([("bg2".to_owned(), "7DAFC3".to_owned())]);
         let mut resolve = |_rid: &str| -> Option<String> { None };
         match parse_background(doc.root_element(), &theme, &mut resolve) {
-            Some(Fill::Solid { color }) => assert_eq!(color, "97BFCF"),
-            other => panic!("expected literal-tint solid fill, got {other:?}"),
+            Some(Fill::Solid { color }) => assert_eq!(color, "A3C3D1"),
+            other => panic!("expected linear-tint solid fill, got {other:?}"),
         }
     }
 
@@ -4230,7 +4230,11 @@ mod tests {
         )
         .expect("shape should parse");
         match shape.fill {
-            Some(Fill::Gradient { stops, .. }) => assert_eq!(stops.len(), 2),
+            Some(Fill::Gradient { stops, .. }) => {
+                assert_eq!(stops.len(), 2);
+                assert_eq!(stops[0].color, "C2CDE1");
+                assert_eq!(stops[1].color, "EFF1F7");
+            }
             other => panic!("expected style-matrix gradient, got {other:?}"),
         }
     }


### PR DESCRIPTION
## Summary
- resolve presentation background tints in PowerPoint's linear-sRGB color space
- use the same mode when substituting placeholder colors into theme style-matrix fills
- assert exact resolved background and gradient stop colors

## Root cause
PPTX background and theme style-matrix fills were routed through Word's encoded-channel tint mode. This made inherited presentation gradients too dark and saturated even though other PowerPoint tint paths already used the observed linear-sRGB behavior.

## Verification
- PPTX parser tests (235 passed)
- `cargo clippy -p pptx-parser -- -D warnings`
- `pnpm typecheck`
- local-only PowerPoint/PDF fidelity comparison
