### PR TITLE
fix(pptx): resolve theme-owned image fills

### DIFF
--- a/packages/pptx/parser/src/fill.rs
+++ b/packages/pptx/parser/src/fill.rs
@@ -5,7 +5,7 @@
 //! Shared XML helpers (`child`, `children_vec`, `attr`, `attr_r`, `attr_i64`,
 //! `attr_f64`) stay in `lib.rs` and are imported here.
 
-use crate::theme::PptxSchemeResolver;
+use crate::theme::{theme_relationship_path, PptxSchemeResolver};
 use crate::types::*;
 use crate::{attr, attr_f64, attr_i64, attr_r, child, children_vec, parse_preflighted_pptx_xml};
 use ooxml_common::blip::{mime_from_ext, parse_blip_duotone};
@@ -62,9 +62,8 @@ pub(crate) fn parse_fill(
 }
 
 /// Parse DrawingML fill properties with the caller-selected tint semantics.
-/// Normal presentation backgrounds and theme style-matrix fills use the
-/// literal ECMA-376 retained-input definition. The historical generic path
-/// keeps PowerPointLinear for SmartArt compatibility.
+/// Presentation fills use PowerPoint's linear-light tint interpolation. A few
+/// specialized callers, such as table styles, select their own tint semantics.
 fn parse_fill_tint(
     node: roxmltree::Node<'_, '_>,
     theme: &HashMap<String, String>,
@@ -165,6 +164,16 @@ pub(crate) fn parse_style_matrix_fill(
         theme,
         placeholder_color: placeholder_color.as_deref(),
     };
+    if let Some(blip_fill) = child(doc.root_element(), "blipFill") {
+        let mut resolve_blip = |relationship_id: &str| {
+            theme_relationship_path(theme, relationship_id).map(str::to_owned)
+        };
+        if let Some(fill) =
+            parse_blip_fill_with_color_resolver(blip_fill, &resolver, &mut resolve_blip)
+        {
+            return Some(fill);
+        }
+    }
     parse_fill_with_resolver(doc.root_element(), &resolver, PowerPointLinear)
 }
 
@@ -191,6 +200,17 @@ pub(crate) fn parse_blip_fill<F: FnMut(&str) -> Option<String>>(
     theme: &HashMap<String, String>,
     resolve_blip: &mut F,
 ) -> Option<Fill> {
+    parse_blip_fill_with_color_resolver(blip_fill, &PptxSchemeResolver { theme }, resolve_blip)
+}
+
+fn parse_blip_fill_with_color_resolver<
+    R: ThemeResolver + ?Sized,
+    F: FnMut(&str) -> Option<String>,
+>(
+    blip_fill: roxmltree::Node<'_, '_>,
+    color_resolver: &R,
+    resolve_blip: &mut F,
+) -> Option<Fill> {
     let r_id = child(blip_fill, "blip").and_then(|b| attr_r(&b, "embed"))?;
     let image_path = resolve_blip(&r_id)?;
     let mime_type = mime_from_ext(&image_path).to_owned();
@@ -199,7 +219,7 @@ pub(crate) fn parse_blip_fill<F: FnMut(&str) -> Option<String>>(
     // linear tint (same call the `<p:pic>` paths use). `None` ⇒ no effect.
     let duotone = parse_blip_duotone(
         blip_fill,
-        &PptxSchemeResolver { theme },
+        color_resolver,
         ooxml_common::color::TintMode::PowerPointLinear,
     );
     // §20.1.8.58 tile takes precedence when present (stretch/tile are an

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -2164,11 +2164,12 @@ fn bootstrap_presentation(
     // Used for the deck-wide defaults on `Presentation` (default text color,
     // major/minor fonts, hyperlink colors) and as the fallback theme for any
     // master that declares no /theme relationship of its own.
-    let theme_xml = find_rel_target_by_type(&pres_rels_xml, "/theme")
-        .map(|t| resolve_path("ppt", &t))
-        .and_then(|path| read_zip_str(zip, &path).ok())
+    let theme_path = find_rel_target_by_type(&pres_rels_xml, "/theme")
+        .map(|target| resolve_path("ppt", &target));
+    let theme = theme_path
+        .as_deref()
+        .map(|path| parse_theme_part(path, zip))
         .unwrap_or_default();
-    let theme = parse_theme_colors(&theme_xml);
 
     // --- Presentation-level fallback master ---
     // The first slide master referenced by the presentation. Used for slides
@@ -4163,6 +4164,53 @@ mod tests {
                 );
             }
             other => panic!("expected theme gradient, got {other:?}"),
+        }
+    }
+
+    /// A style-matrix blipFill owns its relationship in the theme part. The
+    /// slide/master relationship resolver must not be used for that embedded
+    /// image when a bgRef selects the style.
+    #[test]
+    fn test_parse_background_bg_ref_resolves_theme_owned_image() {
+        let theme_xml = r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" name="T">
+          <a:themeElements><a:clrScheme name="C"/>
+            <a:fontScheme name="F"><a:majorFont/><a:minorFont/></a:fontScheme>
+            <a:fmtScheme name="S"><a:fillStyleLst/><a:lnStyleLst/><a:effectStyleLst/>
+              <a:bgFillStyleLst><a:blipFill><a:blip r:embed="rIdImage"><a:duotone>
+                <a:schemeClr val="phClr"/><a:srgbClr val="FFFFFF"/>
+              </a:duotone></a:blip>
+                <a:tile sx="95000" sy="95000" algn="t"/></a:blipFill></a:bgFillStyleLst>
+            </a:fmtScheme>
+          </a:themeElements>
+        </a:theme>"#;
+        let mut theme = parse_theme_colors(theme_xml);
+        theme.insert(
+            "+themeRel-rIdImage".to_owned(),
+            "ppt/media/theme-background.jpeg".to_owned(),
+        );
+        theme.insert("bg2".to_owned(), "F0C000".to_owned());
+        let background_xml = r#"<p:cSld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:bg><p:bgRef idx="1001"><a:schemeClr val="bg2"/></p:bgRef></p:bg>
+        </p:cSld>"#;
+        let doc = roxmltree::Document::parse(background_xml).unwrap();
+        let mut wrong_part_resolver = |_rid: &str| -> Option<String> { None };
+
+        match parse_background(doc.root_element(), &theme, &mut wrong_part_resolver) {
+            Some(Fill::Image {
+                image_path,
+                tile,
+                duotone,
+                ..
+            }) => {
+                assert_eq!(image_path, "ppt/media/theme-background.jpeg");
+                assert_eq!(tile.expect("tile descriptor").algn.as_deref(), Some("t"));
+                let duotone = duotone.expect("placeholder-aware duotone");
+                assert_eq!(duotone.clr1, "F0C000");
+                assert_eq!(duotone.clr2, "FFFFFF");
+            }
+            other => panic!("expected theme-owned image fill, got {other:?}"),
         }
     }
 

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -16,7 +16,7 @@ use crate::text::{
     merge_level_bullets, merge_level_indents, merge_level_sizes, read_level_bullets,
     read_level_font_sizes, read_level_indents, LevelBullets, LevelFontSizes, LevelIndents,
 };
-use crate::theme::{bake_clr_map, parse_theme_colors, resolve_theme_typeface, PptxSchemeResolver};
+use crate::theme::{bake_clr_map, parse_theme_part, resolve_theme_typeface, PptxSchemeResolver};
 use crate::types::*;
 use crate::{
     attr, attr_f64, attr_i64, attr_r, build_smartart_drawings, child, find_rel_target_by_type,
@@ -1820,13 +1820,10 @@ pub(crate) fn build_master_bundle(
     // presentation theme when the master declares no /theme relationship.
     let theme_path: Option<String> =
         find_rel_target_by_type(&master_rels_xml, "/theme").map(|t| resolve_path(&master_dir, &t));
-    let mut theme: HashMap<String, String> = match theme_path
+    let mut theme: HashMap<String, String> = theme_path
         .as_deref()
-        .and_then(|p| read_zip_str(zip, p).ok())
-    {
-        Some(theme_xml) => parse_theme_colors(&theme_xml),
-        None => fallback_theme.clone(),
-    };
+        .map(|path| parse_theme_part(path, zip))
+        .unwrap_or_else(|| fallback_theme.clone());
     // Bake the master's <p:clrMap> logical-name → slot mapping into the theme.
     bake_clr_map(&mut theme, master_xml_opt.as_deref());
 

--- a/packages/pptx/parser/src/theme.rs
+++ b/packages/pptx/parser/src/theme.rs
@@ -5,8 +5,80 @@
 //! (`child`, `attr`) stay in `lib.rs` and are imported here.
 
 use crate::parse_preflighted_pptx_xml;
-use crate::{attr, child};
+use crate::{attr, child, parse_rels, read_zip_str, resolve_path, PptxZip};
+use ooxml_common::rels::relationship_part_path;
 use std::collections::HashMap;
+
+const THEME_REL_PREFIX: &str = "+themeRel-";
+
+pub(crate) fn theme_relationship_path<'a>(
+    theme: &'a HashMap<String, String>,
+    relationship_id: &str,
+) -> Option<&'a str> {
+    theme
+        .get(&format!("{THEME_REL_PREFIX}{relationship_id}"))
+        .map(String::as_str)
+}
+
+/// Parse a theme part together with relationships owned by that theme.
+///
+/// DrawingML style-matrix fills can embed images. Their relationship IDs are
+/// scoped to the theme part, not to the slide, layout, or master that later
+/// references the style. Retain the resolved package paths beside the existing
+/// flat theme map so deferred `fillRef` / `bgRef` resolution uses the correct
+/// OPC source part.
+pub(crate) fn parse_theme_part(theme_path: &str, zip: &mut PptxZip) -> HashMap<String, String> {
+    let theme_xml = read_zip_str(zip, theme_path).unwrap_or_default();
+    let mut theme = parse_theme_colors(&theme_xml);
+    let rels_xml = read_zip_str(zip, &relationship_part_path(theme_path)).unwrap_or_default();
+    let theme_dir = theme_path.rsplit_once('/').map_or("", |(dir, _)| dir);
+
+    for (relationship_id, target) in parse_rels(&rels_xml) {
+        let path = resolve_path(theme_dir, &target);
+        if zip.index_for_name(&path).is_some() {
+            theme.insert(format!("{THEME_REL_PREFIX}{relationship_id}"), path);
+        }
+    }
+    theme
+}
+
+#[cfg(test)]
+mod relationship_tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+    use zip::write::SimpleFileOptions;
+
+    #[test]
+    fn theme_part_relationships_are_resolved_from_the_theme_directory() {
+        let mut bytes = Vec::new();
+        {
+            let mut archive = zip::ZipWriter::new(Cursor::new(&mut bytes));
+            let options = SimpleFileOptions::default();
+            archive.start_file("ppt/theme/theme1.xml", options).unwrap();
+            archive
+                .write_all(
+                    b"<a:theme xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\"/>",
+                )
+                .unwrap();
+            archive
+                .start_file("ppt/theme/_rels/theme1.xml.rels", options)
+                .unwrap();
+            archive.write_all(br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/background.png"/></Relationships>"#).unwrap();
+            archive
+                .start_file("ppt/media/background.png", options)
+                .unwrap();
+            archive.write_all(b"png").unwrap();
+            archive.finish().unwrap();
+        }
+
+        let mut zip = PptxZip::new(Cursor::new(bytes)).expect("open package");
+        let theme = parse_theme_part("ppt/theme/theme1.xml", &mut zip);
+        assert_eq!(
+            theme_relationship_path(&theme, "rId1"),
+            Some("ppt/media/background.png")
+        );
+    }
+}
 
 /// Parse the color scheme from a theme XML file.
 /// Returns a map: scheme slot name (e.g. "dk1", "lt1", "acc1") → hex string.


### PR DESCRIPTION
## Summary
- retain image relationships owned by each PPTX theme part
- resolve style-matrix `blipFill` entries from the theme relationship scope
- substitute the `fillRef` / `bgRef` placeholder color into theme-image duotone endpoints
- add package-path and image-fill regressions

## Root cause
Deferred style-matrix resolution retained the fill XML but not relationships from the theme part that owned it. Image-backed theme fills therefore could not resolve their embedded part and fell back to another fill. The first implementation step also exposed that `phClr` inside the image's duotone effect must use the referencing style color, not a raw palette lookup.

## Verification
- PPTX parser tests (237 passed)
- `cargo clippy -p pptx-parser -- -D warnings`
- `pnpm typecheck`
- local-only PowerPoint/PDF fidelity comparison
