### PR TITLE
fix(pptx): render face-on shape bevels

### DIFF
--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2515,8 +2515,13 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
   const paintShapeBody = (
     target: CanvasRenderingContext2D,
     silhouette?: string,
+    bounds: { x: number; y: number; w: number; h: number } = { x, y, w, h },
   ): void => {
-    const tFill = silhouette ?? fillStyle;
+    const { x: bx, y: by, w: bw, h: bh } = bounds;
+    const tFill = silhouette ??
+      (target === ctx && bx === x && by === y && bw === w && bh === h
+        ? fillStyle
+        : resolveShapeFill(el.fill, target, bx, by, bw, bh));
     const tStroke = silhouette
       ? null
       : el.stroke
@@ -2529,7 +2534,7 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
 
     if (usePresetEngine && !silhouette) {
       renderPresetShape(
-        target, geom, x, y, w, h,
+        target, geom, bx, by, bw, bh,
         [el.adj, el.adj2, el.adj3, el.adj4, el.adj5, el.adj6, el.adj7, el.adj8],
         tFill, tStroke, tClearShadow,
         // A retractable leader (callout / straight / bent connector) is
@@ -2543,14 +2548,14 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
 
     target.beginPath();
     if (el.custGeom && el.custGeom.length > 0) {
-      buildCustomPath(target, el.custGeom, x, y, w, h);
+      buildCustomPath(target, el.custGeom, bx, by, bw, bh);
     } else if (usePresetEngine) {
       // Silhouette of a preset shape: build a single filled outline. Preset
       // path 0 is the body outline (secondary paths are highlights), so the
       // legacy buildShapePath gives a faithful silhouette of the body.
-      buildShapePath(target, geom, x, y, w, h, el.adj, el.adj2, el.adj3, el.adj4);
+      buildShapePath(target, geom, bx, by, bw, bh, el.adj, el.adj2, el.adj3, el.adj4);
     } else {
-      buildShapePath(target, geom, x, y, w, h, el.adj, el.adj2, el.adj3, el.adj4);
+      buildShapePath(target, geom, bx, by, bw, bh, el.adj, el.adj2, el.adj3, el.adj4);
     }
     // Normal arc bodies render through the preset engine above; this legacy
     // path is only reached for an arc as a custGeom/effect silhouette built by
@@ -2586,6 +2591,40 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
   const devScale = det > 0 ? Math.sqrt(det) : 1;
   const effBBox = { x: x * devScale, y: y * devScale, w: w * devScale, h: h * devScale };
   const effScale = scale * devScale; // EMU → device px
+  // A face-on camera does not need a homography, but sp3d bevels still alter
+  // the front surface. Pictures already take this flat offscreen path; shapes
+  // must do the same instead of treating an identity camera as "no 3-D".
+  const flatBevels = !spScene3d
+    ? buildBevelInputs(
+        el.sp3d as Sp3dLike | undefined,
+        el.scene3d?.lightRig as LightRigLike | undefined,
+        el.sp3d?.prstMaterial,
+        scale,
+        devScale,
+      )
+    : [];
+  const flatBevelEdgePadCss = (el.stroke ? (el.stroke.width * scale) / 2 : 0) + 2;
+  const paintVisibleShapeBody = (target: CanvasRenderingContext2D): void => {
+    if (flatBevels.length > 0) {
+      const ok = paintBeveledFlat(
+        target,
+        x,
+        y,
+        w,
+        h,
+        flatBevels,
+        (octx, ox, oy, ow, oh) =>
+          paintShapeBody(octx, undefined, { x: ox, y: oy, w: ow, h: oh }),
+        undefined,
+        flatBevelEdgePadCss,
+      );
+      if (ok) {
+        clearShadow(target);
+        return;
+      }
+    }
+    paintShapeBody(target);
+  };
   const applyLiveTransform = (c: CanvasRenderingContext2D) => {
     c.setTransform(liveTransform);
   };
@@ -2598,7 +2637,7 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     ctx.save();
     ctx.setTransform(new DOMMatrix());
     applyReflection(
-      ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintShapeBody(c as CanvasRenderingContext2D); },
+      ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintVisibleShapeBody(c as CanvasRenderingContext2D); },
       effBBox, el.reflection, effScale, deviceW, deviceH,
     );
     ctx.restore();
@@ -2613,14 +2652,14 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     ctx.save();
     ctx.setTransform(new DOMMatrix());
     applySoftEdge(
-      ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintShapeBody(c as CanvasRenderingContext2D); },
+      ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintVisibleShapeBody(c as CanvasRenderingContext2D); },
       effBBox, el.softEdge, effScale, deviceW, deviceH,
       // Mask is the flat filled silhouette (no stroke) — see applySoftEdge.
       (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintShapeBody(c as CanvasRenderingContext2D, '#000'); },
     );
     ctx.restore();
   } else {
-    paintShapeBody(ctx);
+    paintVisibleShapeBody(ctx);
   }
 
   // innerShdw casts inward, ON TOP of the fill. §20.1.8.40. Composite after the

--- a/packages/pptx/src/shape-orthographic-bevel.test.ts
+++ b/packages/pptx/src/shape-orthographic-bevel.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderSlide } from './renderer.js';
+import type { ShapeElement, Slide } from './types.js';
+
+function contextFor(canvas: { width: number; height: number }, drawImages?: unknown[][]): CanvasRenderingContext2D {
+  const state: Record<string, unknown> = {
+    canvas,
+    getTransform: () => ({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 }),
+    measureText: (text: string) => ({ width: text.length * 6 }),
+    getImageData: (_x: number, _y: number, width: number, height: number) => ({
+      data: new Uint8ClampedArray(width * height * 4),
+      width,
+      height,
+    }),
+    drawImage: (...args: unknown[]) => drawImages?.push(args),
+  };
+  return new Proxy(state, {
+    get(target, property, receiver) {
+      if (property in target) return Reflect.get(target, property, receiver);
+      return () => undefined;
+    },
+    set(target, property, value, receiver) {
+      return Reflect.set(target, property, value, receiver);
+    },
+  }) as unknown as CanvasRenderingContext2D;
+}
+
+class TestOffscreenCanvas {
+  width: number;
+  height: number;
+  readonly context: CanvasRenderingContext2D;
+
+  constructor(width: number, height: number) {
+    this.width = width;
+    this.height = height;
+    this.context = contextFor(this);
+  }
+
+  getContext(): CanvasRenderingContext2D {
+    return this.context;
+  }
+}
+
+function orthographicBeveledShape(): ShapeElement {
+  return {
+    type: 'shape',
+    x: 914_400,
+    y: 914_400,
+    width: 914_400,
+    height: 914_400,
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+    geometry: 'roundRect',
+    fill: { fillType: 'solid', color: '4472C4' },
+    stroke: null,
+    textBody: null,
+    defaultTextColor: null,
+    custGeom: null,
+    adj: null,
+    adj2: null,
+    adj3: null,
+    adj4: null,
+    adj5: null,
+    adj6: null,
+    adj7: null,
+    adj8: null,
+    shadow: null,
+    scene3d: {
+      camera: { prst: 'orthographicFront' },
+      lightRig: { rig: 'chilly', dir: 't' },
+    },
+    sp3d: {
+      prstMaterial: 'translucentPowder',
+      bevelT: { w: 127_000, h: 25_400, prst: 'softRound' },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('shape orthographic bevel', () => {
+  it('renders an identity-camera bevel through an offscreen shaded face', async () => {
+    const created: TestOffscreenCanvas[] = [];
+    vi.stubGlobal('OffscreenCanvas', class extends TestOffscreenCanvas {
+      constructor(width: number, height: number) {
+        super(width, height);
+        created.push(this);
+      }
+    });
+
+    const drawImages: unknown[][] = [];
+    const canvas = {
+      width: 960,
+      height: 540,
+      style: {} as CSSStyleDeclaration,
+      offsetWidth: 960,
+    } as HTMLCanvasElement;
+    const ctx = contextFor(canvas, drawImages);
+    canvas.getContext = (() => ctx) as unknown as HTMLCanvasElement['getContext'];
+    const slide: Slide = {
+      index: 0,
+      slideNumber: 1,
+      background: null,
+      elements: [orthographicBeveledShape()],
+    };
+
+    await renderSlide(canvas, slide, 9_144_000, 6_858_000, { width: 960, dpr: 1 });
+
+    expect(created).toHaveLength(1);
+    expect(drawImages).toHaveLength(1);
+    expect(drawImages[0]?.[0]).toBe(created[0]);
+  });
+});


### PR DESCRIPTION
## Summary

- render `a:sp3d` bevels on shapes whose `a:scene3d` camera is face-on
- reuse the existing flat offscreen bevel pipeline without adding camera projection
- preserve the beveled body in reflection and soft-edge repaint paths
- add a focused regression test for `orthographicFront` with `bevelT`

## Root cause

Shape rendering entered the 3-D surface pipeline only when the camera changed the projected quad. A face-on camera therefore skipped the shape's bevel even though camera projection and `a:sp3d` surface geometry are independent concepts under ECMA-376 §20.1.5.12.

## Verification

- `./node_modules/.bin/vitest run packages/pptx/src` — 92 files, 628 tests
- `pnpm typecheck`
- `git diff --check`
- local-only comparison against a PowerPoint-exported PDF

Private fixtures and reference output are intentionally not included in this PR.
