### PR TITLE
fix(pptx): ignore terminal paragraph spaces

### DIFF
--- a/packages/pptx/src/paragraph-trailing-whitespace.test.ts
+++ b/packages/pptx/src/paragraph-trailing-whitespace.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { TextRunData } from '@silurus/ooxml-core';
+import { layoutParagraph } from './renderer.js';
+import type { Paragraph } from './types.js';
+
+function mockCtx(): CanvasRenderingContext2D {
+  return {
+    measureText: (text: string) => ({ width: text.length * 10 }),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function textRun(text: string, bold: boolean | null = null): TextRunData {
+  return {
+    type: 'text',
+    text,
+    bold,
+    italic: null,
+    underline: false,
+    strikethrough: false,
+    fontSize: 20,
+    color: '000000',
+    fontFamily: 'Arial',
+  };
+}
+
+function paragraph(runs: TextRunData[]): Paragraph {
+  return {
+    alignment: 'l',
+    marL: 0,
+    marR: 0,
+    indent: 0,
+    spaceBefore: null,
+    spaceAfter: null,
+    spaceLine: null,
+    lvl: 0,
+    bullet: { type: 'none' },
+    defFontSize: null,
+    defColor: null,
+    defBold: null,
+    defItalic: null,
+    defFontFamily: null,
+    tabStops: [],
+    eaLnBrk: true,
+    runs,
+  } as Paragraph;
+}
+
+function lineText(line: { segments: { text: string }[] }): string {
+  return line.segments.map((segment) => segment.text).join('');
+}
+
+describe('PowerPoint paragraph-terminal whitespace', () => {
+  it('does not create an empty continuation line at the wrap boundary', () => {
+    const lines = layoutParagraph(
+      mockCtx(),
+      paragraph([textRun('aaaa bbbb ')]),
+      90,
+      20,
+      '#000000',
+      1,
+      0,
+    );
+
+    expect(lines).toHaveLength(1);
+    expect(lineText(lines[0])).toBe('aaaa bbbb');
+  });
+
+  it('trims only the terminal suffix across formatting runs', () => {
+    const lines = layoutParagraph(
+      mockCtx(),
+      paragraph([textRun('aaaa '), textRun('bbbb '), textRun('  ', true)]),
+      90,
+      20,
+      '#000000',
+      1,
+      0,
+    );
+
+    expect(lines).toHaveLength(1);
+    expect(lineText(lines[0])).toBe('aaaa bbbb');
+  });
+});

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -715,6 +715,21 @@ export function layoutParagraph(
   firstLineIndentPx: number = 0,
 ): LayoutLine[] {
   const lines: LayoutLine[] = [];
+  // PowerPoint does not give paragraph-terminal whitespace any advance. In
+  // particular, a trailing space that lands exactly beyond the wrap boundary
+  // must not create a visually empty continuation line. Trim the terminal
+  // suffix across formatting-run boundaries without touching interior spaces
+  // or explicit line-break runs.
+  const terminalText = new Map<TextRun, string>();
+  let scanningTerminalWhitespace = true;
+  for (let i = para.runs.length - 1; i >= 0 && scanningTerminalWhitespace; i--) {
+    const run = para.runs[i];
+    if (run.type === 'break') continue;
+    if (run.type === 'math') break;
+    const trimmed = run.text.trimEnd();
+    if (trimmed !== run.text) terminalText.set(run, trimmed);
+    if (trimmed.length > 0 || run.fieldType != null) scanningTerminalWhitespace = false;
+  }
   // The first line's wrap budget is narrower by a POSITIVE first-line indent
   // (it occupies indentPx of the line); continuation lines use the full width.
   // `lines.length === 0` ⇒ still filling the first line (newLine() pushes to it).
@@ -1004,7 +1019,7 @@ export function layoutParagraph(
     // ~80% size is the long-established Office fallback when the font lacks
     // smcp; we just upper-case for now and rely on the configured size.
     const caps = run.caps;
-    let baseText = run.text;
+    let baseText = terminalText.get(run) ?? run.text;
     if (caps === 'all' || caps === 'small') baseText = baseText.toUpperCase();
 
     // Resolve field values (e.g. slidenum → actual slide number)


### PR DESCRIPTION
## Summary

- ignore paragraph-terminal whitespace when computing PPTX line wrapping
- trim the terminal suffix across formatting-run boundaries
- preserve interior whitespace, explicit line breaks, fields, and math content
- add focused regressions for terminal spaces at an exact wrap boundary

## Root cause

When visible text exactly filled a line, a trailing space could exceed the remaining width and create an empty continuation line. PowerPoint does not assign layout advance to paragraph-terminal whitespace, so every later paragraph was displaced by one line.

## Verification

- focused wrapping tests — 3 files, 13 tests
- `pnpm typecheck`
- `git diff --check`
- local-only comparison against a PowerPoint-exported PDF; the affected slide improved from 98.106% to 99.175% with metric-compatible fonts enabled

Private fixtures and reference output are intentionally not included in this PR.
