### PR TITLE
fix(pptx): honor inherited DrawingML effects

### DIFF
--- a/packages/core/src/fonts/google-fonts.ts
+++ b/packages/core/src/fonts/google-fonts.ts
@@ -49,6 +49,8 @@ const NOTO_NASKH_ARABIC_URL =
   'https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic:wght@400;700&display=swap';
 const NOTO_SANS_ARABIC_URL =
   'https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@400;700&display=swap';
+const LIBRE_FRANKLIN_URL =
+  'https://fonts.googleapis.com/css2?family=Libre+Franklin:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&display=swap';
 
 export const GOOGLE_FONT_SUBSTITUTES: Record<string, FontPreloadEntry> = {
   // Metric-compatible Office substitutes (same advance widths / vertical
@@ -58,6 +60,12 @@ export const GOOGLE_FONT_SUBSTITUTES: Record<string, FontPreloadEntry> = {
   'calibri light':     { url: 'https://fonts.googleapis.com/css2?family=Carlito:ital,wght@0,400;0,700;1,400;1,700&display=swap', loadFamily: 'Carlito' },
   'cambria':           { url: 'https://fonts.googleapis.com/css2?family=Caladea:ital,wght@0,400;0,700;1,400;1,700&display=swap', loadFamily: 'Caladea' },
   'cambria math':      { url: 'https://fonts.googleapis.com/css2?family=Caladea:ital,wght@0,400;0,700;1,400;1,700&display=swap', loadFamily: 'Caladea' },
+  // Libre Franklin is the open Franklin-family substitute. Office templates
+  // distinguish Book (regular) and Medium in the family name rather than with
+  // rPr@b; exposing both keys preserves that authored face choice on hosts that
+  // do not ship Franklin Gothic (notably macOS/Linux/browser workers).
+  'franklin gothic book':   { url: LIBRE_FRANKLIN_URL, loadFamily: 'Libre Franklin' },
+  'franklin gothic medium': { url: LIBRE_FRANKLIN_URL, loadFamily: 'Libre Franklin' },
   // Popular free Google web fonts frequently used as Office template body /
   // heading faces. Google serves each under the requested family name, so no
   // `loadFamily` redirect is needed.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -280,6 +280,7 @@ export {
   type Polyline,
 } from './shape/text-warp';
 export {
+  applyOuterShadow,
   applyInnerShadow,
   applySoftEdge,
   applyReflection,

--- a/packages/core/src/shape/effects.test.ts
+++ b/packages/core/src/shape/effects.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
+  applyOuterShadow,
   applyInnerShadow,
   applySoftEdge,
   applyReflection,
@@ -119,6 +120,32 @@ describe('createAuxCanvas', () => {
     const ctx = { canvas: Object.create(BrokenCanvas.prototype) } as unknown as CanvasRenderingContext2D;
 
     expect(createAuxCanvasForContext(ctx, 10, 10)).toBeNull();
+  });
+});
+
+describe('applyOuterShadow (ECMA-376 §20.1.8.45)', () => {
+  let fake: { auxCtxs: RecordingCtx[] };
+  beforeEach(() => { fake = installFakeCanvas(); });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('recolours one composed silhouette and blurs/offsets it once', () => {
+    const live = new RecordingCtx();
+    const paint = vi.fn((c: unknown) => {
+      (c as RecordingCtx).ops.push({ op: 'paintShape' });
+    });
+    const shadow: Shadow = {
+      color: '000000', alpha: 0.38, blur: 38_100, dist: 19_050, dir: 90,
+    };
+
+    expect(applyOuterShadow(
+      live as never, paint as never, BBOX, shadow, SCALE, DEVICE_W, DEVICE_H,
+    )).toBe(true);
+
+    expect(paint).toHaveBeenCalledTimes(1);
+    expect(fake.auxCtxs[0].usedCompositeOps).toContain('source-in');
+    expect(fake.auxCtxs[0].ops.some(o => o.op === 'fillRect')).toBe(true);
+    expect(live.usedBlurFilters).toEqual(['blur(4px)']);
+    expect(live.ops.filter(o => o.op === 'drawImage')).toHaveLength(1);
   });
 });
 

--- a/packages/core/src/shape/effects.ts
+++ b/packages/core/src/shape/effects.ts
@@ -8,9 +8,10 @@ import { createAuxCanvas, type AuxCanvas, type AuxContext } from '../canvas/aux-
 export { createAuxCanvas };
 
 /**
- * Canvas 2D rendering of the three DrawingML edge/blur effects that the
+ * Canvas 2D rendering of the four DrawingML edge/blur effects that the
  * Canvas shadow primitive (a single offset+blur slot) cannot express:
  *
+ *   - outerShdw — ECMA-376 §20.1.8.45 (CT_OuterShadowEffect)
  *   - innerShdw  — ECMA-376 §20.1.8.40 (CT_InnerShadowEffect)
  *   - softEdge   — ECMA-376 §20.1.8.53 (CT_SoftEdgesEffect)
  *   - reflection — ECMA-376 §20.1.8.50 (CT_ReflectionEffect)
@@ -153,6 +154,56 @@ function offsetPaintCtx(real: AuxContext, crop: EffectCrop): AuxContext {
       return true;
     },
   }) as unknown as AuxContext;
+}
+
+/**
+ * outerShdw — ECMA-376 §20.1.8.45. Build the shadow from the alpha of the
+ * COMPOSED shape (fill + stroke) rather than putting Canvas's shadow state on
+ * each individual fill/stroke call. The latter is observably wrong for a
+ * stroked shape: clearing after the fill lets the outline cover the shadow's
+ * dense edge, while leaving it enabled makes every path cast another shadow.
+ *
+ * The cropped aux keeps the cost proportional to the affected shape. Its
+ * pixels are recoloured through `source-in`, then the one resulting silhouette
+ * is blurred and offset as a single draw operation behind the live shape.
+ * Returns false when the host cannot allocate an auxiliary surface so callers
+ * may retain a native Canvas-shadow fallback.
+ */
+export function applyOuterShadow(
+  liveCtx: AuxContext,
+  paintShape: PaintShape,
+  bbox: EffectBBox,
+  shadow: Shadow,
+  scale: number,
+  deviceW: number,
+  deviceH: number,
+): boolean {
+  const blur = Math.max(0, emuToPx(shadow.blur, scale));
+  const dist = emuToPx(shadow.dist, scale);
+  const dirRad = (shadow.dir * Math.PI) / 180;
+  const dx = Math.cos(dirRad) * dist;
+  const dy = Math.sin(dirRad) * dist;
+  // CSS blur has an unbounded Gaussian tail. Three radii cover the visible
+  // contribution while the extra offset/safety band prevents crop-edge cuts.
+  const margin = Math.ceil(blur * 3 + Math.max(Math.abs(dx), Math.abs(dy))) + 2;
+  const crop = computeCrop(bbox, margin, deviceW, deviceH);
+  const aux = createAuxCanvas(crop.w, crop.h);
+  if (!aux) return false;
+  const c = get2d(aux);
+  if (!c) return false;
+
+  paintShape(offsetPaintCtx(c, crop));
+  c.save();
+  c.globalCompositeOperation = 'source-in';
+  c.fillStyle = hexToRgba(shadow.color, shadow.alpha);
+  c.fillRect(0, 0, crop.w, crop.h);
+  c.restore();
+
+  liveCtx.save();
+  if (blur > 0) liveCtx.filter = `blur(${blur}px)`;
+  liveCtx.drawImage(aux as CanvasImageSource, crop.x + dx, crop.y + dy);
+  liveCtx.restore();
+  return true;
 }
 
 /**

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -257,7 +257,7 @@ export type Bullet =
   | { type: 'none' }
   | { type: 'inherit' }
   | { type: 'char'; char: string; color: string | null; sizePct: number | null; sizePts?: number; fontFamily: string | null }
-  | { type: 'autoNum'; numType: string; startAt: number | null; color: string | null; sizePct: number | null; sizePts?: number; fontFamily: string | null };
+  | { type: 'autoNum'; numType: string; startAt: number | null; color: string | null; sizePct?: number | null; sizePts?: number; fontFamily?: string | null };
 
 export interface TabStop {
   /** Position in EMU from the LEADING text-inset edge of the text area —
@@ -401,6 +401,12 @@ export interface TextRunData {
    * Absent means no run-level shadow.
    */
   shadow?: Shadow;
+  /**
+   * Mirrored reflection on this run's glyphs
+   * (`<a:rPr><a:effectLst><a:reflection>`), ECMA-376 §20.1.8.50.
+   * This is independent of a shape-level reflection on `spPr`.
+   */
+  reflection?: Reflection;
   /**
    * Run-level glyph outline (`<a:rPr><a:ln w="..">`), ECMA-376 §20.1.2.2.24
    * (CT_TextOutlineEffect). Renderer strokes each glyph with the given

--- a/packages/docx/src/google-fonts.test.ts
+++ b/packages/docx/src/google-fonts.test.ts
@@ -105,19 +105,26 @@ describe('DOCX_GOOGLE_FONTS — shared registry consolidation (oracle)', () => {
     }
   });
 
-  it('adds only the safe, documented Office-face keys (Calibri Light, Cambria Math)', () => {
+  it('adds only the safe, documented Office-face keys', () => {
     // Consolidating everything into the shared GOOGLE_FONT_SUBSTITUTES pulls the
-    // two pptx-origin Office face names into docx too. Both are real Office
-    // faces (Calibri Light = theme heading default; Cambria Math = OMML font)
-    // that reduce to the SAME metric substitute as their base family already in
-    // the map — so a docx that happens to request either now resolves to
-    // Carlito/Caladea instead of a wider system fallback. Purely additive.
+    // Office face names into docx too. Calibri Light and Cambria Math reduce to
+    // the same metric substitute as their base family; the two Franklin Gothic
+    // faces share Libre Franklin. A docx that happens to request any of them
+    // now avoids a wider system fallback.
     const oldScriptKeys = new Set(Object.keys(DOCX_GOOGLE_FONTS_OLD));
     const added = Object.keys(DOCX_GOOGLE_FONTS).filter(
       (k) => !oldScriptKeys.has(k) && !k.startsWith('noto '),
     );
-    expect(new Set(added)).toEqual(new Set(['calibri light', 'cambria math']));
+    expect(new Set(added)).toEqual(new Set([
+      'calibri light',
+      'cambria math',
+      'franklin gothic book',
+      'franklin gothic medium',
+    ]));
     expect(DOCX_GOOGLE_FONTS['calibri light']).toEqual(DOCX_GOOGLE_FONTS['calibri']);
     expect(DOCX_GOOGLE_FONTS['cambria math']).toEqual(DOCX_GOOGLE_FONTS['cambria']);
+    expect(DOCX_GOOGLE_FONTS['franklin gothic medium']).toMatchObject({
+      loadFamily: 'Libre Franklin',
+    });
   });
 });

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -43,9 +43,9 @@ type Bullet__emitterCollision1 = {
     numType: string;
     startAt: number | null;
     color: string | null;
-    sizePct: number | null;
+    sizePct?: number | null;
     sizePts?: number;
-    fontFamily: string | null;
+    fontFamily?: string | null;
 };
 export interface Camera3d {
     prst: string;
@@ -1193,6 +1193,7 @@ export interface TextRunData {
     hyperlink?: string;
     hyperlinkAction?: string;
     shadow?: Shadow;
+    reflection?: Reflection;
     outline?: TextOutline;
     highlight?: string;
 }

--- a/packages/pptx/parser/src/fill.rs
+++ b/packages/pptx/parser/src/fill.rs
@@ -136,21 +136,16 @@ impl ThemeResolver for StyleMatrixSchemeResolver<'_> {
 pub(crate) fn parse_style_matrix_fill(
     style_ref: roxmltree::Node<'_, '_>,
     theme: &HashMap<String, String>,
-    background: bool,
+    _background: bool,
 ) -> Option<Fill> {
     use ooxml_common::color::TintMode::PowerPointLinear;
 
     let idx = attr(&style_ref, "idx")?.parse::<u32>().ok()?;
-    let key = if background {
-        match idx {
-            0 | 1000 => return Some(Fill::None),
-            1..=999 => format!("+fillStyle-{idx}"),
-            _ => format!("+bgFillStyle-{}", idx - 1000),
-        }
-    } else if idx == 0 {
-        return Some(Fill::None);
-    } else {
-        format!("+fillStyle-{idx}")
+    // ECMA-376 §20.1.4.2.10 and §19.3.1.3 share one index space.
+    let key = match idx {
+        0 | 1000 => return Some(Fill::None),
+        1..=999 => format!("+fillStyle-{idx}"),
+        _ => format!("+bgFillStyle-{}", idx - 1000),
     };
     let fragment = theme.get(&key)?;
 
@@ -452,6 +447,16 @@ pub(crate) struct EffectLst {
     pub(crate) reflection: Option<Reflection>,
 }
 
+/// One entry in theme `effectStyleLst` (ECMA-376 §20.1.4.1.11).
+/// `scene3d` and `sp3d` are peers of the effect property choice and must not be
+/// discarded when a shape resolves `effectRef`.
+#[derive(Default)]
+pub(crate) struct StyleMatrixEffects {
+    pub(crate) effects: EffectLst,
+    pub(crate) scene3d: Option<Scene3d>,
+    pub(crate) sp3d: Option<Sp3d>,
+}
+
 /// Read every `effectLst` child shapes and pictures share. `effect_lst` is the
 /// optional `<a:effectLst>` node; missing nodes yield an all-`None` result.
 pub(crate) fn parse_effect_lst(
@@ -493,41 +498,47 @@ fn parse_effect_lst_with_resolver<R: ThemeResolver + ?Sized>(
 pub(crate) fn parse_style_matrix_effects(
     effect_ref: roxmltree::Node<'_, '_>,
     theme: &HashMap<String, String>,
-) -> EffectLst {
+) -> StyleMatrixEffects {
     let Some(idx) = attr(&effect_ref, "idx").and_then(|value| value.parse::<u32>().ok()) else {
-        return EffectLst::default();
+        return StyleMatrixEffects::default();
     };
     if idx == 0 {
-        return EffectLst::default();
+        return StyleMatrixEffects::default();
     }
     let Some(fragment) = theme.get(&format!("+effectStyle-{idx}")) else {
-        return EffectLst::default();
+        return StyleMatrixEffects::default();
     };
 
     let placeholder_color = parse_color_node_tint(
         effect_ref,
         theme,
-        ooxml_common::color::TintMode::WordLiteral,
+        ooxml_common::color::TintMode::PowerPointLinear,
     );
     let wrapped = format!(
         r#"<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">{fragment}</root>"#
     );
     let Ok(doc) = parse_preflighted_pptx_xml(&wrapped) else {
-        return EffectLst::default();
+        return StyleMatrixEffects::default();
     };
-    let effect_lst = doc
+    let effect_style = doc
         .root_element()
         .descendants()
-        .find(|node| node.is_element() && node.tag_name().name() == "effectLst");
+        .find(|node| node.is_element() && node.tag_name().name() == "effectStyle");
+    let effect_properties =
+        effect_style.and_then(|node| child(node, "effectLst").or_else(|| child(node, "effectDag")));
     let resolver = StyleMatrixSchemeResolver {
         theme,
         placeholder_color: placeholder_color.as_deref(),
     };
-    parse_effect_lst_with_resolver(
-        effect_lst,
-        &resolver,
-        ooxml_common::color::TintMode::WordLiteral,
-    )
+    StyleMatrixEffects {
+        effects: parse_effect_lst_with_resolver(
+            effect_properties,
+            &resolver,
+            ooxml_common::color::TintMode::PowerPointLinear,
+        ),
+        scene3d: effect_style.and_then(parse_scene3d),
+        sp3d: effect_style.and_then(parse_sp3d),
+    }
 }
 
 // ===========================

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -1168,6 +1168,27 @@ pub(crate) fn read_zip_head(
 
 /// Resolved fills and borders extracted from a single <a:tblStyle> definition.
 #[derive(Debug, Clone, Default)]
+struct TableTextStyle {
+    color: Option<String>,
+    bold: Option<bool>,
+    italic: Option<bool>,
+}
+
+impl TableTextStyle {
+    fn overlay(&mut self, role: &Self) {
+        if role.color.is_some() {
+            self.color = role.color.clone();
+        }
+        if role.bold.is_some() {
+            self.bold = role.bold;
+        }
+        if role.italic.is_some() {
+            self.italic = role.italic;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
 struct TableStyleDef {
     whole_fill: Option<Fill>,
     whole_inside_h: Option<Stroke>,
@@ -1183,19 +1204,21 @@ struct TableStyleDef {
     last_row_fill: Option<Fill>,
     first_col_fill: Option<Fill>,
     last_col_fill: Option<Fill>,
-    /// Default text colour per role, from `<a:tcTxStyle>` (schemeClr/srgbClr).
-    /// e.g. wholeTbl → dk1, firstRow header → lt1 (white). Hex, no `#`.
-    whole_text_color: Option<String>,
-    first_row_text_color: Option<String>,
-    last_row_text_color: Option<String>,
-    first_col_text_color: Option<String>,
-    last_col_text_color: Option<String>,
-    /// Default bold per role, from `<a:tcTxStyle b="on">` (ECMA-376 §20.1.4.2.28).
-    /// e.g. a firstRow header is commonly bold.
-    first_row_bold: Option<bool>,
-    last_row_bold: Option<bool>,
-    first_col_bold: Option<bool>,
-    last_col_bold: Option<bool>,
+    /// Conditional table text roles from `<a:tcTxStyle>`. `None` for bold/
+    /// italic means inherit (`def`), while explicit `off` is `Some(false)`.
+    whole_text: TableTextStyle,
+    band1h_text: TableTextStyle,
+    band2h_text: TableTextStyle,
+    band1v_text: TableTextStyle,
+    band2v_text: TableTextStyle,
+    first_row_text: TableTextStyle,
+    last_row_text: TableTextStyle,
+    first_col_text: TableTextStyle,
+    last_col_text: TableTextStyle,
+    nw_cell_text: TableTextStyle,
+    ne_cell_text: TableTextStyle,
+    sw_cell_text: TableTextStyle,
+    se_cell_text: TableTextStyle,
 }
 
 // ===========================
@@ -1459,6 +1482,7 @@ fn parse_slide(
         master_bold,
         master_italic,
         master_caps,
+        master_reflection,
         master_color,
         ..
     } = bundle;
@@ -1497,6 +1521,11 @@ fn parse_slide(
     }
     for (t, c) in master_caps.iter() {
         lph.by_type_caps.entry(t.clone()).or_insert(c.clone());
+    }
+    for (t, reflection) in master_reflection.iter() {
+        lph.by_type_reflection
+            .entry(t.clone())
+            .or_insert_with(|| reflection.clone());
     }
     for (t, c) in master_color.iter() {
         lph.by_type_master_color
@@ -1605,11 +1634,10 @@ fn parse_slide(
 
     // ── Layout non-placeholder shapes (rendered BEFORE slide shapes) ──────
     // These are decorative background elements defined in the slide layout
-    // (e.g. coloured bands, logos) that are not placeholder anchors. A slide's
-    // showMasterSp="0" is PowerPoint's Hide Background Graphics switch and
-    // suppresses inherited artwork from the selected layout as well as the
-    // slide master. The layout's own flag only controls its master inheritance.
-    if slide_show_master_sp {
+    // (e.g. coloured bands, logos) that are not placeholder anchors. ECMA-376
+    // §19.3.1.38 scopes showMasterSp to shapes on the master slide, so the
+    // selected layout's own shapes remain visible.
+    {
         if let Some(lxml) = layout_xml {
             note_layout_master_parse();
             if let Ok(ldoc) = parse_preflighted_pptx_xml(lxml) {
@@ -3600,12 +3628,10 @@ mod tests {
         assert!(BulletProps::default().is_inherit());
     }
 
-    /// PowerPoint treats `buChar` as a single marker even when a producer writes
-    /// more than one Unicode scalar into the schema's string-valued attribute.
-    /// Keep the first scalar so malformed SmartArt caches do not paint doubled
-    /// bullets, while supplementary-plane markers remain intact.
+    /// ECMA-376 §21.1.2.4.3 defines buChar@char as xsd:string. Preserve the
+    /// complete authored value, including multi-scalar grapheme clusters.
     #[test]
-    fn character_bullet_uses_one_unicode_scalar() {
+    fn character_bullet_preserves_the_authored_string() {
         let doc = roxmltree::Document::parse(
             r#"<a:pPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:buChar char="••"/></a:pPr>"#,
         )
@@ -3613,7 +3639,7 @@ mod tests {
         let theme = HashMap::new();
         let mut resolve_blip = |_: &str| None;
         match parse_bullet(Some(doc.root_element()), &theme, &mut resolve_blip) {
-            Bullet::Char { ch, .. } => assert_eq!(ch, "•"),
+            Bullet::Char { ch, .. } => assert_eq!(ch, "••"),
             other => panic!("expected Char, got {other:?}"),
         }
 
@@ -3622,7 +3648,7 @@ mod tests {
         )
         .expect("valid supplementary-plane marker");
         match parse_bullet(Some(emoji_doc.root_element()), &theme, &mut resolve_blip) {
-            Bullet::Char { ch, .. } => assert_eq!(ch, "🡆"),
+            Bullet::Char { ch, .. } => assert_eq!(ch, "🡆x"),
             other => panic!("expected Char, got {other:?}"),
         }
     }
@@ -4292,6 +4318,38 @@ mod tests {
             }
             other => panic!("expected style-matrix gradient, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_shape_fill_ref_uses_the_normative_background_style_index_range() {
+        let theme_xml = r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <a:themeElements><a:clrScheme name="C"/><a:fontScheme name="F"><a:majorFont/><a:minorFont/></a:fontScheme>
+          <a:fmtScheme name="S"><a:fillStyleLst>
+            <a:solidFill><a:srgbClr val="112233"/></a:solidFill>
+          </a:fillStyleLst><a:lnStyleLst/><a:effectStyleLst/><a:bgFillStyleLst>
+            <a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill>
+          </a:bgFillStyleLst></a:fmtScheme></a:themeElements>
+        </a:theme>"#;
+        let theme = parse_theme_colors(theme_xml);
+        let refs = roxmltree::Document::parse(
+            r#"<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <a:fillRef idx="1000"/><a:fillRef idx="1001"/>
+            </root>"#,
+        )
+        .unwrap();
+        let mut refs = refs
+            .root_element()
+            .children()
+            .filter(|node| node.is_element());
+
+        assert!(matches!(
+            parse_style_matrix_fill(refs.next().unwrap(), &theme, false),
+            Some(Fill::None)
+        ));
+        assert!(matches!(
+            parse_style_matrix_fill(refs.next().unwrap(), &theme, false),
+            Some(Fill::Solid { color }) if color == "ABCDEF"
+        ));
     }
 
     /// ECMA-376 §19.3.1.52 / §21.1.2.3.7: a title with no local Latin
@@ -5315,6 +5373,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
                 ShapeKind::Sp,
                 &mut zip,
             );
@@ -5853,7 +5912,7 @@ mod tests {
         let xml = r#"<a:tblStyleLst xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
           <a:tblStyle styleId="{TEST}" styleName="Medium Style 1 - Accent 2">
             <a:wholeTbl>
-              <a:tcTxStyle>
+              <a:tcTxStyle b="def" i="on">
                 <a:fontRef idx="minor"><a:scrgbClr r="0" g="0" b="0"/></a:fontRef>
                 <a:schemeClr val="dk1"/>
               </a:tcTxStyle>
@@ -5865,6 +5924,7 @@ mod tests {
               </a:tcStyle>
             </a:wholeTbl>
             <a:band1H>
+              <a:tcTxStyle b="on"><a:fontRef idx="minor"/><a:schemeClr val="accent2"/></a:tcTxStyle>
               <a:tcStyle>
                 <a:tcBdr/>
                 <a:fill><a:solidFill><a:schemeClr val="accent2"><a:tint val="20000"/></a:schemeClr></a:solidFill></a:fill>
@@ -5880,6 +5940,7 @@ mod tests {
                 <a:fill><a:solidFill><a:schemeClr val="accent2"/></a:solidFill></a:fill>
               </a:tcStyle>
             </a:firstRow>
+            <a:nwCell><a:tcTxStyle b="off"><a:fontRef idx="minor"/><a:schemeClr val="dk1"/></a:tcTxStyle></a:nwCell>
           </a:tblStyle>
         </a:tblStyleLst>"#;
 
@@ -5912,22 +5973,30 @@ mod tests {
 
         // Text colours from tcTxStyle.
         assert_eq!(
-            def.whole_text_color.as_deref(),
+            def.whole_text.color.as_deref(),
             Some("000000"),
             "wholeTbl text colour should be dk1 black"
         );
         assert_eq!(
-            def.first_row_text_color.as_deref(),
+            def.first_row_text.color.as_deref(),
             Some("FFFFFF"),
             "firstRow header text colour should be lt1 white"
         );
 
         // firstRow `<a:tcTxStyle b="on">` → bold header.
         assert_eq!(
-            def.first_row_bold,
+            def.first_row_text.bold,
             Some(true),
             "firstRow header should be bold from tcTxStyle b=on"
         );
+        assert_eq!(
+            def.whole_text.bold, None,
+            "b=def inherits instead of forcing off"
+        );
+        assert_eq!(def.whole_text.italic, Some(true));
+        assert_eq!(def.band1h_text.color.as_deref(), Some("B83903"));
+        assert_eq!(def.band1h_text.bold, Some(true));
+        assert_eq!(def.nw_cell_text.bold, Some(false));
     }
 
     /// ECMA-376 §21.1.2.1.1 — `<a:bodyPr rtlCol="1">` lays out a multi-column
@@ -5961,6 +6030,7 @@ mod tests {
                 None, // inherited_bold
                 None, // inherited_italic
                 None, // inherited_caps
+                None, // inherited_reflection
                 None, // inherited_anchor
                 None, // inherited_text_insets
                 None, // inherited_alignment
@@ -6030,6 +6100,7 @@ mod tests {
                 [None; 9],
                 Default::default(),
                 &empty_level_bullets(),
+                None,
                 None,
                 None,
                 None,
@@ -6124,6 +6195,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
                 ShapeKind::Sp,
                 &mut zip,
             );
@@ -6202,6 +6274,7 @@ mod tests {
                 [None; 9],
                 Default::default(),
                 &empty_level_bullets(),
+                None,
                 None,
                 None,
                 None,
@@ -6889,18 +6962,18 @@ mod tests {
         );
     }
 
-    /// PowerPoint's Hide Background Graphics command writes showMasterSp="0"
-    /// on the slide. It suppresses inherited non-placeholder artwork from both
-    /// the master and the selected layout, while preserving slide-local shapes.
+    /// ECMA-376 §19.3.1.38 scopes showMasterSp to shapes on the master slide.
+    /// Layout-local decorations remain part of the selected layout.
     #[test]
-    fn slide_show_master_sp_false_hides_layout_and_master_decorations() {
+    fn slide_show_master_sp_false_hides_master_but_keeps_layout_decorations() {
         let data = build_master_sp_pptx(None, Some(false), true);
         let pres = parse_presentation_from_bytes(&data).expect("parse");
         let slide = &pres.slides[0];
 
-        assert_eq!(slide.elements.len(), 1);
-        assert_eq!(slide.element_sources.len(), 1);
-        assert_eq!(slide.element_sources[0].origin, SlideElementOrigin::Slide);
+        assert_eq!(slide.elements.len(), 2);
+        assert_eq!(slide.element_sources.len(), 2);
+        assert_eq!(slide.element_sources[0].origin, SlideElementOrigin::Layout);
+        assert_eq!(slide.element_sources[1].origin, SlideElementOrigin::Slide);
     }
 
     /// showMasterSp="1" (explicit true) on the layout keeps master shapes —

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -7,7 +7,7 @@
 
 use crate::fill::{
     parse_background, parse_blip_alpha, parse_color_node, parse_cust_geom, parse_fill,
-    parse_stroke, parse_xfrm,
+    parse_reflection, parse_stroke, parse_xfrm,
 };
 use crate::shape::extract_decorative_shapes;
 use crate::text::{
@@ -72,6 +72,9 @@ pub(crate) struct LayoutPlaceholders {
     /// Default caps ("all"/"small") per placeholder type, from layout/master
     /// lstStyle defRPr cap attribute (ECMA-376 §21.1.2.3.13)
     pub(crate) by_type_caps: HashMap<String, String>,
+    /// Default run reflection per placeholder type, inherited from layout or
+    /// master `lvl1pPr/defRPr/effectLst`.
+    pub(crate) by_type_reflection: HashMap<String, Reflection>,
     /// Vertical anchor ("t"/"ctr"/"b") per placeholder type, from layout/master bodyPr
     pub(crate) by_type_anchor: HashMap<String, String>,
     /// Per-placeholder layout `bodyPr` text insets (`lIns`, `tIns`, `rIns`,
@@ -363,6 +366,16 @@ impl LayoutPlaceholders {
         self.by_type_caps.get(ph_type).cloned().or_else(|| {
             if ph_type == "body" {
                 self.by_type_caps.get("").cloned()
+            } else {
+                None
+            }
+        })
+    }
+
+    pub(crate) fn lookup_reflection(&self, ph_type: &str) -> Option<Reflection> {
+        self.by_type_reflection.get(ph_type).cloned().or_else(|| {
+            if ph_type == "body" {
+                self.by_type_reflection.get("").cloned()
             } else {
                 None
             }
@@ -1050,20 +1063,24 @@ pub(crate) fn parse_master_level_bullets(
 /// Parse default bold/italic from master txStyles (titleStyle / bodyStyle / otherStyle)
 /// > lvl1pPr > defRPr @b and @i. Keyed by ph_type.
 /// > Only populated when the attribute is explicitly present on the master.
-pub(crate) fn parse_master_txstyle_bold_italic(
-    root: roxmltree::Node<'_, '_>,
-) -> (
+type MasterTxStyleRunProperties = (
     HashMap<String, bool>,
     HashMap<String, bool>,
     HashMap<String, String>,
-) {
+    HashMap<String, Reflection>,
+);
+
+pub(crate) fn parse_master_txstyle_run_properties(
+    root: roxmltree::Node<'_, '_>,
+) -> MasterTxStyleRunProperties {
     let mut bold_map: HashMap<String, bool> = HashMap::new();
     let mut italic_map: HashMap<String, bool> = HashMap::new();
     // ECMA-376 §21.1.2.3.13 cap="all"/"small" on the master txStyles defRPr —
     // e.g. a template titleStyle with cap="all" upper-cases every title.
     let mut caps_map: HashMap<String, String> = HashMap::new();
+    let mut reflection_map: HashMap<String, Reflection> = HashMap::new();
     let Some(tx_styles) = child(root, "txStyles") else {
-        return (bold_map, italic_map, caps_map);
+        return (bold_map, italic_map, caps_map, reflection_map);
     };
     let style_ph_map: &[(&str, &[&str])] = MASTER_TXSTYLE_PH_TYPES;
     for (style_name, ph_types) in style_ph_map {
@@ -1079,6 +1096,9 @@ pub(crate) fn parse_master_txstyle_bold_italic(
         let c = def_rpr
             .and_then(|rp| attr(&rp, "cap"))
             .filter(|v| v == "all" || v == "small");
+        let reflection = def_rpr
+            .and_then(|rp| child(rp, "effectLst"))
+            .and_then(parse_reflection);
         if let Some(bv) = b {
             for t in *ph_types {
                 bold_map.entry(t.to_string()).or_insert(bv);
@@ -1094,8 +1114,15 @@ pub(crate) fn parse_master_txstyle_bold_italic(
                 caps_map.entry(t.to_string()).or_insert(cv.clone());
             }
         }
+        if let Some(value) = reflection {
+            for t in *ph_types {
+                reflection_map
+                    .entry(t.to_string())
+                    .or_insert_with(|| value.clone());
+            }
+        }
     }
-    (bold_map, italic_map, caps_map)
+    (bold_map, italic_map, caps_map, reflection_map)
 }
 
 /// Parse default text color from master txStyles (titleStyle/bodyStyle/otherStyle)
@@ -1324,6 +1351,9 @@ pub(crate) fn parse_layout_placeholders(
         let layout_caps = layout_def_rpr
             .and_then(|rp| attr(&rp, "cap"))
             .filter(|v| v == "all" || v == "small");
+        let layout_reflection = layout_def_rpr
+            .and_then(|rp| child(rp, "effectLst"))
+            .and_then(parse_reflection);
         let layout_color: Option<String> = layout_def_rpr
             .and_then(|rp| child(rp, "solidFill"))
             .and_then(|sf| parse_color_node(sf, theme));
@@ -1532,6 +1562,11 @@ pub(crate) fn parse_layout_placeholders(
             }
             if let Some(c) = layout_caps.clone() {
                 lph.by_type_caps.entry(ph_type.clone()).or_insert(c);
+            }
+            if let Some(reflection) = layout_reflection.clone() {
+                lph.by_type_reflection
+                    .entry(ph_type.clone())
+                    .or_insert(reflection);
             }
             if let Some(a) = layout_alignment {
                 lph.by_type_alignment.entry(ph_type.clone()).or_insert(a);
@@ -1754,6 +1789,7 @@ pub(crate) struct ParsedMaster {
     pub(crate) master_bold: HashMap<String, bool>,
     pub(crate) master_italic: HashMap<String, bool>,
     pub(crate) master_caps: HashMap<String, String>,
+    pub(crate) master_reflection: HashMap<String, Reflection>,
     pub(crate) master_color: HashMap<String, String>,
 }
 
@@ -1877,8 +1913,8 @@ pub(crate) fn build_master_bundle(
     let (master_space_before, master_space_after, master_line_spacing) = master_root
         .map(parse_master_txstyle_spacing)
         .unwrap_or_default();
-    let (master_bold, master_italic, master_caps) = master_root
-        .map(parse_master_txstyle_bold_italic)
+    let (master_bold, master_italic, master_caps, master_reflection) = master_root
+        .map(parse_master_txstyle_run_properties)
         .unwrap_or_default();
     let master_color = master_root
         .map(|root| parse_master_txstyle_color(root, &theme))
@@ -1925,6 +1961,7 @@ pub(crate) fn build_master_bundle(
         master_bold,
         master_italic,
         master_caps,
+        master_reflection,
         master_color,
     }
 }
@@ -1992,6 +2029,43 @@ mod placeholder_geometry_tests {
             &mut zip,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn master_title_style_carries_run_reflection_to_title_placeholders() {
+        let xml = r#"
+          <p:sldMaster
+            xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <p:txStyles>
+              <p:titleStyle>
+                <a:lvl1pPr>
+                  <a:defRPr cap="all">
+                    <a:effectLst>
+                      <a:reflection blurRad="12700" stA="48000" endA="300"
+                        endPos="55000" dir="5400000" sy="-90000"
+                        algn="bl" rotWithShape="0"/>
+                    </a:effectLst>
+                  </a:defRPr>
+                </a:lvl1pPr>
+              </p:titleStyle>
+            </p:txStyles>
+          </p:sldMaster>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let (_, _, caps, reflections) = parse_master_txstyle_run_properties(doc.root_element());
+
+        assert_eq!(caps.get("title").map(String::as_str), Some("all"));
+        assert_eq!(caps.get("ctrTitle").map(String::as_str), Some("all"));
+        for ph_type in ["title", "ctrTitle"] {
+            let reflection = reflections
+                .get(ph_type)
+                .unwrap_or_else(|| panic!("missing reflection for {ph_type}"));
+            assert_eq!(reflection.blur, 12_700);
+            assert!((reflection.st_a - 0.48).abs() < 1e-9);
+            assert!((reflection.end_a - 0.003).abs() < 1e-9);
+            assert!((reflection.end_pos - 0.55).abs() < 1e-9);
+            assert!((reflection.sy + 0.9).abs() < 1e-9);
+        }
     }
 
     #[test]

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -18,7 +18,7 @@ use crate::theme::PptxSchemeResolver;
 use crate::types::*;
 use crate::{
     attr, attr_f64, attr_i64, attr_r, child, find_rel_target_by_type, read_zip_head, read_zip_str,
-    resolve_path, table_style_presets, PptxZip, TableStyleDef,
+    resolve_path, table_style_presets, PptxZip, TableStyleDef, TableTextStyle,
 };
 use ooxml_common::blip::{mime_from_ext, parse_blip_duotone, parse_src_rect, svg_blip_rid};
 use ooxml_common::depth::DepthGuard;
@@ -218,21 +218,26 @@ fn merge_local_stroke(
 
     let ln_width = attr_i64(&ln, "w");
     let parsed = parse_stroke(ln, theme);
+    let has_dash = child(ln, "prstDash").is_some();
     let ln_dash = child(ln, "prstDash")
         .and_then(|n| attr(&n, "val"))
         .filter(|v| v != "solid");
+    let has_cap = attr(&ln, "cap").is_some();
     let ln_cap = attr(&ln, "cap").and_then(|cap| match cap.as_str() {
         "rnd" => Some("round".to_owned()),
         "sq" => Some("square".to_owned()),
         "flat" => Some("butt".to_owned()),
         _ => None,
     });
+    let has_head = child(ln, "headEnd").is_some();
     let ln_head = child(ln, "headEnd")
         .map(parse_arrow_end)
         .filter(|a| a.kind != "none");
+    let has_tail = child(ln, "tailEnd").is_some();
     let ln_tail = child(ln, "tailEnd")
         .map(parse_arrow_end)
         .filter(|a| a.kind != "none");
+    let has_cmpd = attr(&ln, "cmpd").is_some();
     let ln_cmpd = attr(&ln, "cmpd").filter(|v| v != "sng");
 
     match (parsed, inherited) {
@@ -240,31 +245,51 @@ fn merge_local_stroke(
             color: authored.color,
             width: ln_width.unwrap_or_else(|| base.as_ref().map(|s| s.width).unwrap_or(9525)),
             fill: authored.fill,
-            dash_style: authored
-                .dash_style
-                .or_else(|| base.as_ref().and_then(|s| s.dash_style.clone())),
-            line_cap: authored
-                .line_cap
-                .or_else(|| base.as_ref().and_then(|s| s.line_cap.clone())),
-            head_end: authored
-                .head_end
-                .or_else(|| base.as_ref().and_then(|s| s.head_end.clone())),
-            tail_end: authored
-                .tail_end
-                .or_else(|| base.as_ref().and_then(|s| s.tail_end.clone())),
-            cmpd: authored
-                .cmpd
-                .or_else(|| base.as_ref().and_then(|s| s.cmpd.clone())),
+            dash_style: if has_dash {
+                ln_dash
+            } else {
+                authored
+                    .dash_style
+                    .or_else(|| base.as_ref().and_then(|s| s.dash_style.clone()))
+            },
+            line_cap: if has_cap {
+                ln_cap
+            } else {
+                authored
+                    .line_cap
+                    .or_else(|| base.as_ref().and_then(|s| s.line_cap.clone()))
+            },
+            head_end: if has_head {
+                ln_head
+            } else {
+                authored
+                    .head_end
+                    .or_else(|| base.as_ref().and_then(|s| s.head_end.clone()))
+            },
+            tail_end: if has_tail {
+                ln_tail
+            } else {
+                authored
+                    .tail_end
+                    .or_else(|| base.as_ref().and_then(|s| s.tail_end.clone()))
+            },
+            cmpd: if has_cmpd {
+                ln_cmpd
+            } else {
+                authored
+                    .cmpd
+                    .or_else(|| base.as_ref().and_then(|s| s.cmpd.clone()))
+            },
         }),
         (None, Some(base)) => Some(Stroke {
             color: base.color,
             width: ln_width.unwrap_or(base.width),
             fill: base.fill,
-            dash_style: ln_dash.or(base.dash_style),
-            line_cap: ln_cap.or(base.line_cap),
-            head_end: ln_head.or(base.head_end),
-            tail_end: ln_tail.or(base.tail_end),
-            cmpd: ln_cmpd.or(base.cmpd),
+            dash_style: if has_dash { ln_dash } else { base.dash_style },
+            line_cap: if has_cap { ln_cap } else { base.line_cap },
+            head_end: if has_head { ln_head } else { base.head_end },
+            tail_end: if has_tail { ln_tail } else { base.tail_end },
+            cmpd: if has_cmpd { ln_cmpd } else { base.cmpd },
         }),
         (None, None) => None,
     }
@@ -477,6 +502,7 @@ pub(crate) fn parse_shape(
         inherited_bold,
         inherited_italic,
         inherited_caps,
+        inherited_reflection,
         inherited_anchor,
         inherited_text_insets,
         inherited_alignment,
@@ -491,6 +517,7 @@ pub(crate) fn parse_shape(
             lph.lookup_bold(&ph_type),
             lph.lookup_italic(&ph_type),
             lph.lookup_caps(&ph_type),
+            lph.lookup_reflection(&ph_type),
             lph.lookup_anchor(&ph_type),
             lph.lookup_text_insets(&ph_type, ph_idx),
             lph.lookup_alignment(&ph_type, ph_idx),
@@ -501,7 +528,7 @@ pub(crate) fn parse_shape(
         )
     } else {
         (
-            None, None, None, None, None, None, None, None, None, None, None, None,
+            None, None, None, None, None, None, None, None, None, None, None, None, None,
         )
     };
     let inherited_level_font_sizes: LevelFontSizes = if ph_node.is_some() {
@@ -551,6 +578,7 @@ pub(crate) fn parse_shape(
             inherited_bold,
             inherited_italic,
             inherited_caps.clone(),
+            inherited_reflection.clone(),
             inherited_anchor,
             inherited_text_insets,
             inherited_alignment,
@@ -569,18 +597,23 @@ pub(crate) fn parse_shape(
         .and_then(|style| child(style, "effectRef"))
         .map(|effect_ref| parse_style_matrix_effects(effect_ref, theme))
         .unwrap_or_default();
+    let style_scene3d = style_effects.scene3d;
+    let style_sp3d = style_effects.sp3d;
+    let local_effect_node =
+        sp_pr.and_then(|p| child(p, "effectLst").or_else(|| child(p, "effectDag")));
     let EffectLst {
         shadow,
         inner_shadow,
         glow,
         soft_edge,
         reflection,
-    } = parse_effect_lst(sp_pr.and_then(|p| child(p, "effectLst")), theme);
-    let shadow = shadow.or(style_effects.shadow);
-    let inner_shadow = inner_shadow.or(style_effects.inner_shadow);
-    let glow = glow.or(style_effects.glow);
-    let soft_edge = soft_edge.or(style_effects.soft_edge);
-    let reflection = reflection.or(style_effects.reflection);
+    } = if local_effect_node.is_some() {
+        // MS-OI29500 §20.1.2.2.37(b): a local effect component replaces the
+        // style component rather than merging missing fields from effectRef.
+        parse_effect_lst(local_effect_node, theme)
+    } else {
+        style_effects.effects
+    };
 
     Some(ShapeElement {
         x: t.x,
@@ -616,8 +649,8 @@ pub(crate) fn parse_shape(
         placeholder_type: placeholder_type_out,
         placeholder_idx: ph_idx,
         text_rect: None,
-        scene3d: sp_pr.and_then(parse_scene3d),
-        sp3d: sp_pr.and_then(parse_sp3d),
+        scene3d: sp_pr.and_then(parse_scene3d).or(style_scene3d),
+        sp3d: sp_pr.and_then(parse_sp3d).or(style_sp3d),
     })
 }
 
@@ -1133,17 +1166,24 @@ pub(crate) fn parse_table_styles_xml(
             (fill, inside_h, inside_v, border_b, outer_h, outer_v)
         };
 
-        // Default text colour for a role: `<a:tcTxStyle>` holds a `<a:fontRef>`
-        // followed by a colour child (schemeClr/srgbClr). parse_color_node scans
-        // direct children and skips fontRef, picking up the colour.
-        let parse_tc_tx_color = |role: roxmltree::Node<'_, '_>| -> Option<String> {
-            child(role, "tcTxStyle").and_then(|t| parse_color_node(t, theme))
+        let parse_on_off_default = |value: Option<String>| -> Option<bool> {
+            match value.as_deref() {
+                Some("on" | "1" | "true") => Some(true),
+                Some("off" | "0" | "false") => Some(false),
+                // ST_OnOffStyleType `def` inherits; it is not explicit off.
+                Some("def") | None => None,
+                _ => None,
+            }
         };
-        // `<a:tcTxStyle b="on">` → bold for this role (e.g. a bold header row).
-        let parse_tc_tx_bold = |role: roxmltree::Node<'_, '_>| -> Option<bool> {
-            child(role, "tcTxStyle")
-                .and_then(|t| attr(&t, "b"))
-                .map(|v| v == "on" || v == "1" || v == "true")
+        let parse_tc_text = |role: roxmltree::Node<'_, '_>| -> TableTextStyle {
+            let Some(text) = child(role, "tcTxStyle") else {
+                return TableTextStyle::default();
+            };
+            TableTextStyle {
+                color: parse_color_node(text, theme),
+                bold: parse_on_off_default(attr(&text, "b")),
+                italic: parse_on_off_default(attr(&text, "i")),
+            }
         };
 
         if let Some(whole) = child(style_node, "wholeTbl") {
@@ -1153,40 +1193,54 @@ pub(crate) fn parse_table_styles_xml(
             def.whole_inside_v = iv;
             def.whole_outer_h = oh;
             def.whole_outer_v = ov;
-            def.whole_text_color = parse_tc_tx_color(whole);
+            def.whole_text = parse_tc_text(whole);
         }
         if let Some(band) = child(style_node, "band1H") {
             let (fill, _, _, _, _, _) = parse_tc_style(band);
             def.band1h_fill = fill;
+            def.band1h_text = parse_tc_text(band);
         }
         if let Some(band) = child(style_node, "band2H") {
             let (fill, _, _, _, _, _) = parse_tc_style(band);
             def.band2h_fill = fill;
+            def.band2h_text = parse_tc_text(band);
+        }
+        if let Some(band) = child(style_node, "band1V") {
+            def.band1v_text = parse_tc_text(band);
+        }
+        if let Some(band) = child(style_node, "band2V") {
+            def.band2v_text = parse_tc_text(band);
         }
         if let Some(first) = child(style_node, "firstRow") {
             let (fill, _, _, border_b, _, _) = parse_tc_style(first);
             def.first_row_fill = fill;
             def.first_row_border_b = border_b;
-            def.first_row_text_color = parse_tc_tx_color(first);
-            def.first_row_bold = parse_tc_tx_bold(first);
+            def.first_row_text = parse_tc_text(first);
         }
         if let Some(last) = child(style_node, "lastRow") {
             let (fill, _, _, _, _, _) = parse_tc_style(last);
             def.last_row_fill = fill;
-            def.last_row_text_color = parse_tc_tx_color(last);
-            def.last_row_bold = parse_tc_tx_bold(last);
+            def.last_row_text = parse_tc_text(last);
         }
         if let Some(first) = child(style_node, "firstCol") {
             let (fill, _, _, _, _, _) = parse_tc_style(first);
             def.first_col_fill = fill;
-            def.first_col_text_color = parse_tc_tx_color(first);
-            def.first_col_bold = parse_tc_tx_bold(first);
+            def.first_col_text = parse_tc_text(first);
         }
         if let Some(last) = child(style_node, "lastCol") {
             let (fill, _, _, _, _, _) = parse_tc_style(last);
             def.last_col_fill = fill;
-            def.last_col_text_color = parse_tc_tx_color(last);
-            def.last_col_bold = parse_tc_tx_bold(last);
+            def.last_col_text = parse_tc_text(last);
+        }
+        for (role_name, target) in [
+            ("nwCell", &mut def.nw_cell_text),
+            ("neCell", &mut def.ne_cell_text),
+            ("swCell", &mut def.sw_cell_text),
+            ("seCell", &mut def.se_cell_text),
+        ] {
+            if let Some(role) = child(style_node, role_name) {
+                *target = parse_tc_text(role);
+            }
         }
 
         map.insert(style_id, def);
@@ -1219,6 +1273,7 @@ pub(crate) fn parse_table(
     // ECMA-376 §21.1.3.13 (a:tblPr@rtl): right-to-left table layout.
     let rtl = flag("rtl");
     let band_row = flag("bandRow");
+    let band_col = flag("bandCol");
     let first_col = flag("firstCol");
     let last_col = flag("lastCol");
 
@@ -1312,49 +1367,59 @@ pub(crate) fn parse_table(
                 // Mirrors the fill cascade ordering. The header (firstRow) typically
                 // overrides wholeTbl (e.g. white-on-accent header). A run's own
                 // explicit colour still wins later, at render time.
-                let mut effective_text = s.whole_text_color.clone();
+                let mut effective_text = s.whole_text.clone();
+                if band_row && !(first_row && ri == 0) {
+                    let band_ri = ri.saturating_sub(if first_row { 1 } else { 0 });
+                    effective_text.overlay(if band_ri % 2 == 0 {
+                        &s.band1h_text
+                    } else {
+                        &s.band2h_text
+                    });
+                }
+                if band_col && !(first_col && ci == 0) {
+                    let band_ci = ci.saturating_sub(if first_col { 1 } else { 0 });
+                    effective_text.overlay(if band_ci % 2 == 0 {
+                        &s.band1v_text
+                    } else {
+                        &s.band2v_text
+                    });
+                }
                 if first_row && ri == 0 {
-                    if let Some(c) = s.first_row_text_color.clone() {
-                        effective_text = Some(c);
-                    }
+                    effective_text.overlay(&s.first_row_text);
                 }
                 if last_row && ri == last_row_idx {
-                    if let Some(c) = s.last_row_text_color.clone() {
-                        effective_text = Some(c);
-                    }
+                    effective_text.overlay(&s.last_row_text);
                 }
                 if first_col && ci == 0 {
-                    if let Some(c) = s.first_col_text_color.clone() {
-                        effective_text = Some(c);
-                    }
+                    effective_text.overlay(&s.first_col_text);
                 }
                 if last_col && ci == last_col_idx {
-                    if let Some(c) = s.last_col_text_color.clone() {
-                        effective_text = Some(c);
-                    }
+                    effective_text.overlay(&s.last_col_text);
+                }
+                if first_row && ri == 0 && first_col && ci == 0 {
+                    effective_text.overlay(&s.nw_cell_text);
+                }
+                if first_row && ri == 0 && last_col && ci == last_col_idx {
+                    effective_text.overlay(&s.ne_cell_text);
+                }
+                if last_row && ri == last_row_idx && first_col && ci == 0 {
+                    effective_text.overlay(&s.sw_cell_text);
+                }
+                if last_row && ri == last_row_idx && last_col && ci == last_col_idx {
+                    effective_text.overlay(&s.se_cell_text);
                 }
                 if cell.text_color.is_none() {
-                    cell.text_color = effective_text;
+                    cell.text_color = effective_text.color.clone();
                 }
 
-                // ── Bold cascade (style `<a:tcTxStyle b="on">`, role-keyed) ──
-                // Applied as the cell text body's default bold; a run's own @b wins.
-                let mut effective_bold: Option<bool> = None;
-                if first_row && ri == 0 {
-                    effective_bold = effective_bold.or(s.first_row_bold);
-                }
-                if last_row && ri == last_row_idx {
-                    effective_bold = effective_bold.or(s.last_row_bold);
-                }
-                if first_col && ci == 0 {
-                    effective_bold = effective_bold.or(s.first_col_bold);
-                }
-                if last_col && ci == last_col_idx {
-                    effective_bold = effective_bold.or(s.last_col_bold);
-                }
-                if let (Some(b), Some(tb)) = (effective_bold, cell.text_body.as_mut()) {
+                if let (Some(b), Some(tb)) = (effective_text.bold, cell.text_body.as_mut()) {
                     if tb.default_bold.is_none() {
                         tb.default_bold = Some(b);
+                    }
+                }
+                if let (Some(i), Some(tb)) = (effective_text.italic, cell.text_body.as_mut()) {
+                    if tb.default_italic.is_none() {
+                        tb.default_italic = Some(i);
                     }
                 }
 
@@ -1484,8 +1549,17 @@ pub(crate) fn parse_table_cell(
     let anchor = tc_pr
         .and_then(|n| attr(&n, "anchor"))
         .map(|a| a.to_string());
+    let text_direction = tc_pr.and_then(|n| attr(&n, "vert"));
+    let text_insets = tc_pr.map(|n| {
+        [
+            attr_i64(&n, "marL"),
+            attr_i64(&n, "marT"),
+            attr_i64(&n, "marR"),
+            attr_i64(&n, "marB"),
+        ]
+    });
     let text_body = child(tc, "txBody").map(|n| {
-        parse_text_body(
+        let mut body = parse_text_body(
             n,
             theme,
             rels,
@@ -1498,8 +1572,9 @@ pub(crate) fn parse_table_cell(
             None,
             None,
             None,
+            None, // inherited_reflection
             anchor,
-            None, // inherited_text_insets
+            text_insets,
             None, // inherited_alignment
             None, // inherited_ea_ln_brk
             None, // inherited_space_before
@@ -1507,7 +1582,13 @@ pub(crate) fn parse_table_cell(
             None, // inherited_line_spacing
             ShapeKind::Sp,
             zip,
-        )
+        );
+        // Table-cell text direction is authored on tcPr rather than txBody's
+        // bodyPr (ECMA-376 §21.1.3.17 CT_TableCellProperties@vert).
+        if let Some(direction) = text_direction.as_deref() {
+            body.vert = direction.to_owned();
+        }
+        body
     });
 
     let fill = tc_pr.and_then(|n| parse_fill(n, theme));
@@ -2387,18 +2468,20 @@ fn parse_connector(
         .and_then(|style| child(style, "effectRef"))
         .map(|effect_ref| parse_style_matrix_effects(effect_ref, theme))
         .unwrap_or_default();
+    let style_scene3d = style_effects.scene3d;
+    let style_sp3d = style_effects.sp3d;
+    let local_effect_node = child(sp_pr, "effectLst").or_else(|| child(sp_pr, "effectDag"));
     let EffectLst {
         shadow,
         inner_shadow,
         glow,
         soft_edge,
         reflection,
-    } = parse_effect_lst(child(sp_pr, "effectLst"), theme);
-    let shadow = shadow.or(style_effects.shadow);
-    let inner_shadow = inner_shadow.or(style_effects.inner_shadow);
-    let glow = glow.or(style_effects.glow);
-    let soft_edge = soft_edge.or(style_effects.soft_edge);
-    let reflection = reflection.or(style_effects.reflection);
+    } = if local_effect_node.is_some() {
+        parse_effect_lst(local_effect_node, theme)
+    } else {
+        style_effects.effects
+    };
 
     let cy = if t.cy == 0 { 1 } else { t.cy };
 
@@ -2479,8 +2562,8 @@ fn parse_connector(
         placeholder_type: None,
         placeholder_idx: None,
         text_rect: None,
-        scene3d: parse_scene3d(sp_pr),
-        sp3d: parse_sp3d(sp_pr),
+        scene3d: parse_scene3d(sp_pr).or(style_scene3d),
+        sp3d: parse_sp3d(sp_pr).or(style_sp3d),
     })
 }
 
@@ -2513,14 +2596,19 @@ mod style_ref_tests {
                   <a:fillStyleLst/>
                   <a:lnStyleLst>
                     <a:ln w="9525"/><a:ln w="25400"/>
-                    <a:ln w="38100"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>
+                  <a:ln w="38100" cmpd="dbl"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill>
+                    <a:prstDash val="dash"/><a:headEnd type="triangle"/>
+                  </a:ln>
                   </a:lnStyleLst>
                   <a:effectStyleLst>
                     <a:effectStyle><a:effectLst>
                       <a:outerShdw blurRad="40000" dist="23000" dir="5400000">
                         <a:schemeClr val="phClr"><a:alpha val="35000"/></a:schemeClr>
                       </a:outerShdw>
-                    </a:effectLst></a:effectStyle>
+                    </a:effectLst>
+                      <a:scene3d><a:camera prst="isometricLeftUp"/><a:lightRig rig="threePt" dir="t"/></a:scene3d>
+                      <a:sp3d prstMaterial="matte"><a:bevelT w="12700" h="6350"/></a:sp3d>
+                    </a:effectStyle>
                   </a:effectStyleLst>
                   <a:bgFillStyleLst/>
                 </a:fmtScheme>
@@ -2535,7 +2623,7 @@ mod style_ref_tests {
                 <a:xfrm><a:off x="0" y="0"/><a:ext cx="100000" cy="100000"/></a:xfrm>
                 <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
                 <a:solidFill><a:schemeClr val="accent1"/></a:solidFill>
-                <a:ln><a:headEnd type="none"/><a:tailEnd type="none"/></a:ln>
+                <a:ln cmpd="sng"><a:prstDash val="solid"/><a:headEnd type="none"/><a:tailEnd type="none"/></a:ln>
                 <a:effectLst/>
               </p:spPr>
               <p:style>
@@ -2563,12 +2651,61 @@ mod style_ref_tests {
         let stroke = shape.stroke.expect("theme line must survive partial a:ln");
         assert_eq!(stroke.color, "FFFFFF");
         assert_eq!(stroke.width, 38100);
-        let shadow = shape
-            .shadow
-            .expect("effectRef must resolve the theme effect");
-        assert_eq!(shadow.color, "4F81BD");
-        assert!((shadow.alpha - 0.35).abs() < 0.01);
-        assert_eq!(shadow.blur, 40000);
+        assert_eq!(stroke.dash_style, None, "explicit solid clears theme dash");
+        assert!(
+            stroke.head_end.is_none(),
+            "explicit none clears theme arrow"
+        );
+        assert_eq!(
+            stroke.cmpd, None,
+            "explicit single clears theme compound line"
+        );
+        assert!(
+            shape.shadow.is_none(),
+            "an authored effectLst replaces the theme effect component"
+        );
+        assert_eq!(
+            shape
+                .scene3d
+                .as_ref()
+                .map(|scene| scene.camera.prst.as_str()),
+            Some("isometricLeftUp"),
+            "effectRef retains the theme scene3d component"
+        );
+        assert_eq!(
+            shape
+                .sp3d
+                .as_ref()
+                .map(|surface| surface.prst_material.as_str()),
+            Some("matte"),
+            "effectRef retains the theme sp3d component"
+        );
+    }
+
+    #[test]
+    fn table_cell_projects_tcpr_vertical_text_and_margins_into_the_text_body() {
+        let doc = roxmltree::Document::parse(
+            r#"<a:tc xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Vertical label</a:t></a:r></a:p></a:txBody>
+              <a:tcPr vert="vert270" anchor="ctr" marL="100" marT="200" marR="300" marB="400"/>
+            </a:tc>"#,
+        )
+        .unwrap();
+        let mut zip = empty_zip();
+        let cell = parse_table_cell(
+            doc.root_element(),
+            &HashMap::new(),
+            &HashMap::new(),
+            "ppt/slides",
+            &mut zip,
+        );
+        let body = cell.text_body.expect("table cell text body");
+        assert_eq!(body.vert, "vert270");
+        assert_eq!(body.vertical_anchor, "ctr");
+        assert_eq!(
+            (body.l_ins, body.t_ins, body.r_ins, body.b_ins),
+            (100, 200, 300, 400)
+        );
     }
 }
 

--- a/packages/pptx/parser/src/smartart_fallback.rs
+++ b/packages/pptx/parser/src/smartart_fallback.rs
@@ -320,6 +320,7 @@ fn append_point_paragraphs(
         None,
         None,
         None,
+        None,
         ShapeKind::Sp,
         zip,
     );
@@ -480,6 +481,7 @@ fn default_run() -> TextRunData {
         hyperlink: None,
         hyperlink_action: None,
         shadow: None,
+        reflection: None,
         outline: None,
         highlight: None,
     }

--- a/packages/pptx/parser/src/table_style_presets.rs
+++ b/packages/pptx/parser/src/table_style_presets.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{Fill, Stroke, TableStyleDef};
+use crate::{Fill, Stroke, TableStyleDef, TableTextStyle};
 use ooxml_common::color::{apply_tint_channels, TintMode};
 
 // ── Color helpers ────────────────────────────────────────────────────────────
@@ -294,15 +294,30 @@ fn medium_style_2(theme: &HashMap<String, String>, accent_idx: Option<u8>) -> Ta
         whole_inside_h: border.clone(),
         whole_inside_v: border,
         first_row_border_b: Some(stroke(&lt)),
-        whole_text_color: Some(dk),
-        first_row_text_color: Some(lt.clone()),
-        last_row_text_color: Some(lt.clone()),
-        first_col_text_color: Some(lt.clone()),
-        last_col_text_color: Some(lt),
-        first_row_bold: Some(true),
-        last_row_bold: Some(true),
-        first_col_bold: Some(true),
-        last_col_bold: Some(true),
+        whole_text: TableTextStyle {
+            color: Some(dk),
+            ..Default::default()
+        },
+        first_row_text: TableTextStyle {
+            color: Some(lt.clone()),
+            bold: Some(true),
+            ..Default::default()
+        },
+        last_row_text: TableTextStyle {
+            color: Some(lt.clone()),
+            bold: Some(true),
+            ..Default::default()
+        },
+        first_col_text: TableTextStyle {
+            color: Some(lt.clone()),
+            bold: Some(true),
+            ..Default::default()
+        },
+        last_col_text: TableTextStyle {
+            color: Some(lt),
+            bold: Some(true),
+            ..Default::default()
+        },
         ..Default::default()
     }
 }
@@ -871,14 +886,14 @@ mod tests {
         assert_eq!(solid_color(&style.first_row_fill), Some("4F81BD"));
         assert_eq!(solid_color(&style.whole_fill), Some("DCE6F2"));
         assert_eq!(solid_color(&style.band1h_fill), Some("B9CDE5"));
-        assert_eq!(style.first_row_text_color.as_deref(), Some("FFFFFF"));
-        assert_eq!(style.first_row_bold, Some(true));
-        assert_eq!(style.whole_text_color.as_deref(), Some("000000"));
-        assert_eq!(style.last_row_text_color.as_deref(), Some("FFFFFF"));
-        assert_eq!(style.first_col_text_color.as_deref(), Some("FFFFFF"));
-        assert_eq!(style.last_col_text_color.as_deref(), Some("FFFFFF"));
-        assert_eq!(style.last_row_bold, Some(true));
-        assert_eq!(style.first_col_bold, Some(true));
-        assert_eq!(style.last_col_bold, Some(true));
+        assert_eq!(style.first_row_text.color.as_deref(), Some("FFFFFF"));
+        assert_eq!(style.first_row_text.bold, Some(true));
+        assert_eq!(style.whole_text.color.as_deref(), Some("000000"));
+        assert_eq!(style.last_row_text.color.as_deref(), Some("FFFFFF"));
+        assert_eq!(style.first_col_text.color.as_deref(), Some("FFFFFF"));
+        assert_eq!(style.last_col_text.color.as_deref(), Some("FFFFFF"));
+        assert_eq!(style.last_row_text.bold, Some(true));
+        assert_eq!(style.first_col_text.bold, Some(true));
+        assert_eq!(style.last_col_text.bold, Some(true));
     }
 }

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -5,7 +5,7 @@
 //! `children_vec`, `attr`, `attr_r`, `attr_i64`, `attr_f64`, `resolve_path`)
 //! stay in `lib.rs`; the colour + theme helpers live in `fill` / `theme`.
 
-use crate::fill::{parse_color_node, parse_shadow};
+use crate::fill::{parse_color_node, parse_reflection, parse_shadow};
 use crate::theme::resolve_theme_typeface;
 use crate::types::*;
 use crate::{attr, attr_f64, attr_i64, attr_r, child, children_vec, resolve_path, PptxZip};
@@ -381,6 +381,7 @@ pub(crate) fn parse_text_body(
     inherited_bold: Option<bool>,
     inherited_italic: Option<bool>,
     inherited_caps: Option<String>,
+    inherited_reflection: Option<Reflection>,
     inherited_anchor: Option<String>,
     inherited_text_insets: Option<[Option<i64>; 4]>,
     inherited_alignment: Option<String>,
@@ -538,6 +539,11 @@ pub(crate) fn parse_text_body(
     // Own lstStyle > lvl1pPr, then fall back to layout/master inherited values
     let own_lvl1_ppr = child(tx_body, "lstStyle").and_then(|ls| child(ls, "lvl1pPr"));
     let own_def_rpr = own_lvl1_ppr.and_then(|lp| child(lp, "defRPr"));
+    let own_effects = own_def_rpr.and_then(|rp| child(rp, "effectLst"));
+    let default_reflection = match own_effects {
+        Some(effect_lst) => parse_reflection(effect_lst),
+        None => inherited_reflection,
+    };
     let default_font_size = own_def_rpr
         .and_then(|rp| attr_f64(&rp, "sz"))
         .map(|v| v / 100.0)
@@ -630,6 +636,7 @@ pub(crate) fn parse_text_body(
                 body_default_space_after,
                 body_default_line_spacing,
                 default_font_family.as_deref(),
+                default_reflection.as_ref(),
                 &effective_level_sizes,
                 &effective_level_indents,
                 &effective_level_bullets,
@@ -776,6 +783,7 @@ pub(crate) fn parse_paragraph(
     body_default_space_after: Option<i64>,
     body_default_line_spacing: Option<f64>,
     body_default_font_family: Option<&str>,
+    body_default_reflection: Option<&Reflection>,
     level_font_sizes: &LevelFontSizes,
     level_indents: &LevelIndents,
     level_bullets: &LevelBullets,
@@ -939,7 +947,9 @@ pub(crate) fn parse_paragraph(
     for node in p_node.children().filter(|n| n.is_element()) {
         match node.tag_name().name() {
             "r" => {
-                if let Some(run) = parse_run(node, def_rpr, theme, rels) {
+                if let Some(run) =
+                    parse_run_with_reflection(node, def_rpr, body_default_reflection, theme, rels)
+                {
                     runs.push(TextRun::Text(run));
                 }
             }
@@ -1004,6 +1014,10 @@ pub(crate) fn parse_paragraph(
                     hyperlink: None,
                     hyperlink_action: None,
                     shadow: None,
+                    reflection: match r_pr.and_then(|n| child(n, "effectLst")) {
+                        Some(effect_lst) => parse_reflection(effect_lst),
+                        None => body_default_reflection.cloned(),
+                    },
                     outline: None,
                     highlight,
                 }));
@@ -1090,14 +1104,9 @@ fn parse_bullet_marker<F: FnMut(&str) -> Option<String>>(
 
     // Character bullet
     if let Some(bu_char) = child(p_pr, "buChar") {
-        // CT_TextCharBullet's attribute is schema-typed as a string, but Office
-        // paints a single marker glyph. Some flattened SmartArt caches contain
-        // duplicated values such as `••`; retaining the whole string paints a
-        // visibly doubled marker. Select one Unicode scalar (not one UTF-16
-        // code unit) so supplementary-plane symbols remain intact.
-        let ch = attr(&bu_char, "char")
-            .and_then(|value| value.chars().next().map(|ch| ch.to_string()))
-            .unwrap_or_else(|| "\u{2022}".into()); // •
+        // CT_TextCharBullet@char is xsd:string (§21.1.2.4.3). Preserve the
+        // authored string, including variation selectors and combining marks.
+        let ch = attr(&bu_char, "char").unwrap_or_else(|| "\u{2022}".into()); // •
         return Some(BuMarker::Char(ch));
     }
 
@@ -1214,9 +1223,26 @@ pub(crate) fn parse_bullet<F: FnMut(&str) -> Option<String>>(
     parse_bullet_props(p_pr, theme, resolve_blip).resolve()
 }
 
+/// Parse a standalone text run without a shape/master-level reflection input.
+///
+/// Most call sites (and the parser's focused tests) only need run-local and
+/// paragraph `defRPr` inheritance. Text-body parsing uses the private extended
+/// form below because placeholder title styles can additionally contribute a
+/// reflection through the master/layout cascade.
+#[cfg(test)]
 pub(crate) fn parse_run(
     r_node: roxmltree::Node<'_, '_>,
     def_rpr: Option<roxmltree::Node<'_, '_>>,
+    theme: &HashMap<String, String>,
+    rels: &HashMap<String, String>,
+) -> Option<TextRunData> {
+    parse_run_with_reflection(r_node, def_rpr, None, theme, rels)
+}
+
+fn parse_run_with_reflection(
+    r_node: roxmltree::Node<'_, '_>,
+    def_rpr: Option<roxmltree::Node<'_, '_>>,
+    inherited_reflection: Option<&Reflection>,
     theme: &HashMap<String, String>,
     rels: &HashMap<String, String>,
 ) -> Option<TextRunData> {
@@ -1355,9 +1381,18 @@ pub(crate) fn parse_run(
     // ECMA-376 §20.1.8.45 — `<a:rPr><a:effectLst><a:outerShdw>` glyph drop
     // shadow. Reuse the shape-level outerShdw reader so parse semantics
     // stay identical (blurRad, dist, dir, color + alphaModFix).
-    let shadow = r_pr
-        .and_then(|n| child(n, "effectLst"))
-        .and_then(|el| parse_shadow(el, theme));
+    let local_effects = r_pr.and_then(|n| child(n, "effectLst"));
+    let inherited_effects = def_rpr.and_then(|n| child(n, "effectLst"));
+    let shadow = match local_effects {
+        Some(el) => parse_shadow(el, theme),
+        None => inherited_effects.and_then(|el| parse_shadow(el, theme)),
+    };
+    let reflection = match local_effects {
+        Some(el) => parse_reflection(el),
+        None => inherited_effects
+            .and_then(parse_reflection)
+            .or_else(|| inherited_reflection.cloned()),
+    };
 
     // ECMA-376 §20.1.2.2.24 (CT_TextOutlineEffect) — `<a:rPr><a:ln w="..">`
     // strokes each glyph outline. `<a:noFill>` inside the ln means "no
@@ -1408,6 +1443,7 @@ pub(crate) fn parse_run(
         hyperlink,
         hyperlink_action,
         shadow,
+        reflection,
         outline,
         highlight,
     })

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -1095,6 +1095,10 @@ pub(crate) struct TextRunData {
     /// shape-level shadow on `spPr`. None = no shadow on the run.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) shadow: Option<Shadow>,
+    /// ECMA-376 §20.1.8.50 (CT_ReflectionEffect) — mirrored reflection of this
+    /// run's glyphs from `<a:rPr><a:effectLst><a:reflection>`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) reflection: Option<Reflection>,
     /// ECMA-376 §20.1.2.2.24 (CT_TextOutlineEffect) — text glyph outline from
     /// `<a:rPr><a:ln w="EMU"><a:solidFill>...`. None = no outline; renderer
     /// just fillText. When set the renderer also strokeText with the given

--- a/packages/pptx/src/font-stack.test.ts
+++ b/packages/pptx/src/font-stack.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { cssFontStack } from './renderer.js';
+import { buildFont, cssFontStack } from './renderer.js';
 
 describe('cssFontStack — Arabic faces keep the Arabic chain (regression)', () => {
   it('leads with the Arabic Noto fallbacks for an Arabic-script face', () => {
@@ -76,5 +76,26 @@ describe('cssFontStack — serif/sans generic classification (core classifier)',
   it('regression: Calibri stays sans, Times New Roman stays serif', () => {
     expect(cssFontStack('Calibri').endsWith('sans-serif')).toBe(true);
     expect(cssFontStack('Times New Roman').endsWith('serif')).toBe(true);
+  });
+});
+
+describe('buildFont — style encoded in a face name', () => {
+  it('preserves a Medium theme face when the browser falls back', () => {
+    const font = buildFont(false, false, 48, 'Franklin Gothic Medium', {
+      themeMajorFont: null,
+      themeMinorFont: null,
+      dpr: 1,
+    });
+    expect(font).toMatch(/^600 48px "Franklin Gothic Medium"/);
+    expect(font).toContain('"Libre Franklin"');
+  });
+
+  it('lets an explicit bold run override a named Medium face', () => {
+    const font = buildFont(true, false, 48, 'Franklin Gothic Medium', {
+      themeMajorFont: null,
+      themeMinorFont: null,
+      dpr: 1,
+    });
+    expect(font).toMatch(/^bold 48px "Franklin Gothic Medium"/);
   });
 });

--- a/packages/pptx/src/google-fonts.test.ts
+++ b/packages/pptx/src/google-fonts.test.ts
@@ -41,7 +41,7 @@ describe('PPTX_GOOGLE_FONTS — shared registry consolidation (oracle)', () => {
     }
   });
 
-  it('adds only the safe, documented key Ubuntu', () => {
+  it('adds the safe, documented Ubuntu and Franklin-family substitutes', () => {
     // pptx already carried the full web-font + Office-substitute set. The shared
     // registry additionally contributes "ubuntu" (a generic Google web font, no
     // format affinity): a slide that requests Ubuntu now measures glyphs with
@@ -50,9 +50,48 @@ describe('PPTX_GOOGLE_FONTS — shared registry consolidation (oracle)', () => {
     const added = Object.keys(PPTX_GOOGLE_FONTS).filter(
       (k) => !oldKeys.has(k) && !k.startsWith('noto '),
     );
-    expect(new Set(added)).toEqual(new Set(['ubuntu']));
+    expect(new Set(added)).toEqual(new Set([
+      'ubuntu',
+      'franklin gothic book',
+      'franklin gothic medium',
+    ]));
     expect(PPTX_GOOGLE_FONTS['ubuntu'].url).toMatch(/family=Ubuntu(?:[:&]|$)/);
     expect(PPTX_GOOGLE_FONTS['ubuntu'].loadFamily).toBeUndefined();
+    expect(PPTX_GOOGLE_FONTS['franklin gothic medium']).toMatchObject({
+      loadFamily: 'Libre Franklin',
+    });
+  });
+
+  it('includes slide-local paragraph and run families, not only the first theme fonts', () => {
+    const slide = {
+      index: 0,
+      slideNumber: 1,
+      background: null,
+      elements: [{
+        type: 'shape',
+        textBody: {
+          paragraphs: [{
+            defFontFamily: 'Franklin Gothic Medium',
+            runs: [{
+              type: 'text',
+              text: 'Title',
+              fontFamily: null,
+              fontFamilyEa: 'Yu Gothic',
+              fontFamilySym: null,
+            }],
+          }],
+        },
+      }],
+    } as unknown as Slide;
+    const accumulator = new PptxFontPreloadAccumulator('Aptos Display', 'Aptos');
+    accumulator.addSlide(slide);
+
+    expect(accumulator.names()).toEqual(expect.arrayContaining([
+      'Aptos Display',
+      'Aptos',
+      'Franklin Gothic Medium',
+      'Yu Gothic',
+    ]));
   });
 });
 

--- a/packages/pptx/src/google-fonts.ts
+++ b/packages/pptx/src/google-fonts.ts
@@ -34,6 +34,19 @@ function* textBodyRuns(body: TextBody | null | undefined): Generator<string> {
   }
 }
 
+/** Yield every explicitly resolved family carried by one rendered text body. */
+function* textBodyFontFamilies(body: TextBody | null | undefined): Generator<string> {
+  for (const paragraph of body?.paragraphs ?? []) {
+    if (paragraph.defFontFamily) yield paragraph.defFontFamily;
+    for (const run of paragraph.runs) {
+      if (run.type !== 'text') continue;
+      if (run.fontFamily) yield run.fontFamily;
+      if (run.fontFamilyEa) yield run.fontFamilyEa;
+      if (run.fontFamilySym) yield run.fontFamilySym;
+    }
+  }
+}
+
 /** Yield every rendered text string in the presentation: shape text, table
  *  cell text and chart labels across all slides. Speaker notes and comments are
  *  not painted on the slide, so they are excluded (the renderer ignores them). */
@@ -56,22 +69,38 @@ export function* pptxSlideTextRuns(slide: Slide): Generator<string> {
 /** Incremental PPTX adapter over core's single script-classification source. */
 export class PptxFontPreloadAccumulator {
   private readonly scripts: ScriptPreloadAccumulator;
+  private readonly families: Set<string>;
 
   constructor(
     private readonly majorFont: string | null,
     private readonly minorFont: string | null,
     scripts?: ScriptPreloadAccumulator,
+    families?: Set<string>,
   ) {
     const cjkLang = classifyCjkFont(majorFont) ?? classifyCjkFont(minorFont) ?? null;
     this.scripts = scripts ?? new ScriptPreloadAccumulator(cjkLang);
+    this.families = families ?? new Set();
+    if (majorFont) this.families.add(majorFont);
+    if (minorFont) this.families.add(minorFont);
   }
 
   addSlide(slide: Slide): void {
     this.scripts.addText(pptxSlideTextRuns(slide));
+    for (const el of slide.elements as SlideElement[]) {
+      if (el.type === 'shape') {
+        for (const family of textBodyFontFamilies(el.textBody)) this.families.add(family);
+      } else if (el.type === 'table') {
+        for (const row of el.rows) {
+          for (const cell of row.cells) {
+            for (const family of textBodyFontFamilies(cell.textBody)) this.families.add(family);
+          }
+        }
+      }
+    }
   }
 
   names(): (string | null)[] {
-    return [this.majorFont, this.minorFont, ...this.scripts.names()];
+    return [...this.families, ...this.scripts.names()];
   }
 
   withSlide(slide: Slide): PptxFontPreloadAccumulator {
@@ -79,6 +108,7 @@ export class PptxFontPreloadAccumulator {
       this.majorFont,
       this.minorFont,
       this.scripts.clone(),
+      new Set(this.families),
     );
     candidate.addSlide(slide);
     return candidate;

--- a/packages/pptx/src/paragraph-trailing-whitespace.test.ts
+++ b/packages/pptx/src/paragraph-trailing-whitespace.test.ts
@@ -79,4 +79,21 @@ describe('PowerPoint paragraph-terminal whitespace', () => {
     expect(lines).toHaveLength(1);
     expect(lineText(lines[0])).toBe('aaaa bbbb');
   });
+
+  it.each(['\u00a0', '\u2007', '\u202f'])(
+    'preserves visible non-breaking terminal whitespace %j',
+    (space) => {
+      const lines = layoutParagraph(
+        mockCtx(),
+        paragraph([textRun(`aaaa${space}`)]),
+        200,
+        20,
+        '#000000',
+        1,
+        0,
+      );
+
+      expect(lineText(lines[0])).toBe(`aaaa${space}`);
+    },
+  );
 });

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -31,6 +31,7 @@ import {
   EMU_PER_PT as PT_TO_EMU,
   mathToMathML,
   recolorSvg,
+  applyOuterShadow,
   applyInnerShadow,
   applySoftEdge,
   applyReflection,
@@ -404,6 +405,8 @@ type LayoutSegment = {
   baseline?: number;
   /** Run-level glyph drop shadow (rPr > effectLst > outerShdw). */
   shadow?: import('@silurus/ooxml-core').Shadow;
+  /** Run-level mirrored glyph reflection (rPr > effectLst > reflection). */
+  reflection?: import('@silurus/ooxml-core').Reflection;
   /** Run-level glyph outline (rPr > a:ln). Width in EMU; renderer scales. */
   outline?: import('@silurus/ooxml-core').TextOutline;
   /**
@@ -487,6 +490,8 @@ const OFFICE_FONT_SUBSTITUTE: Record<string, string> = {
   'calibri light': 'Carlito',
   'cambria': 'Caladea',
   'cambria math': 'Caladea',
+  'franklin gothic book': 'Libre Franklin',
+  'franklin gothic medium': 'Libre Franklin',
   // Common Arabic-script faces that hosts rarely ship. Map them to Noto
   // substitutes so RTL slides (e.g. sample-10, which requests Sakkal Majalla /
   // Univers Next Arabic) render with a real web font instead of an oversized
@@ -570,10 +575,134 @@ function hyperlinkKey(t: HyperlinkTarget | undefined): string {
   return t.kind === 'external' ? `e:${t.url}` : `i:${t.ref}`;
 }
 
-function buildFont(bold: boolean, italic: boolean, sizePx: number, family: string, rc: RenderContext): string {
+/**
+ * Preserve a weight encoded in a specific Office face name when that face is
+ * unavailable and the canvas falls through to a generic/substitute family.
+ * PowerPoint themes commonly name faces such as "Franklin Gothic Medium" with
+ * no separate `b` attribute; treating the missing face as weight 400 makes the
+ * fallback visibly lighter than the authored face.
+ */
+function namedFaceWeight(family: string): number | null {
+  const name = family.toLowerCase();
+  if (/\b(thin|hairline)\b/.test(name)) return 100;
+  if (/\b(extra[- ]?light|ultra[- ]?light)\b/.test(name)) return 200;
+  if (/\blight\b/.test(name)) return 300;
+  if (/\b(black|heavy)\b/.test(name)) return 900;
+  if (/\b(extra[- ]?bold|ultra[- ]?bold)\b/.test(name)) return 800;
+  if (/\b(semi[- ]?bold|demi[- ]?bold)\b/.test(name)) return 600;
+  if (/\bbold\b/.test(name)) return 700;
+  // Office face names such as Franklin Gothic Medium refer to a distinct,
+  // visibly heavier cut. Libre Franklin 600 is the closest web substitute;
+  // 500 makes both the glyphs and their authored reflections too thin.
+  if (/\bmedium\b/.test(name)) return 600;
+  return null;
+}
+
+/**
+ * Paint one text segment's DrawingML reflection in a bbox-sized device-pixel
+ * surface. Shape/picture reflections deliberately use the full-canvas core
+ * helper for long-standing VRT stability, but doing that once per text segment
+ * would allocate a slide-sized canvas for every reflected run. Text reflection
+ * is new, so keep its working set proportional to the glyph bounds.
+ *
+ * The callback paints in absolute device coordinates after the crop offset has
+ * been folded into its transform. The final mirror is therefore composited at
+ * identity, exactly like the shape effect pipeline.
+ */
+function applyTextRunReflection(
+  liveCtx: CanvasRenderingContext2D,
+  paintText: (ctx: CanvasRenderingContext2D) => void,
+  bbox: { x: number; y: number; w: number; h: number },
+  reflection: import('@silurus/ooxml-core').Reflection,
+  effectScale: number,
+  liveTransform: DOMMatrix,
+  deviceW: number,
+  deviceH: number,
+): void {
+  const blur = Math.max(0, reflection.blur * effectScale);
+  const margin = Math.ceil(blur * 3) + 2;
+  const cropX = Math.max(0, Math.floor(bbox.x - margin));
+  const cropY = Math.max(0, Math.floor(bbox.y - margin));
+  const cropRight = Math.min(deviceW, Math.ceil(bbox.x + bbox.w + margin));
+  const cropBottom = Math.min(deviceH, Math.ceil(bbox.y + bbox.h + margin));
+  const cropW = Math.max(1, cropRight - cropX);
+  const cropH = Math.max(1, cropBottom - cropY);
+  const aux = createAuxCanvas(cropW, cropH);
+  const auxCtx = aux?.getContext('2d') as CanvasRenderingContext2D | null;
+  if (!aux || !auxCtx) return;
+
+  auxCtx.save();
+  if (blur > 0) auxCtx.filter = `blur(${blur}px)`;
+  auxCtx.setTransform(
+    liveTransform.a,
+    liveTransform.b,
+    liveTransform.c,
+    liveTransform.d,
+    liveTransform.e - cropX,
+    liveTransform.f - cropY,
+  );
+  paintText(auxCtx);
+  auxCtx.restore();
+
+  const localTop = bbox.y - cropY;
+  const localBottom = localTop + bbox.h;
+  const stPos = Math.max(0, Math.min(1, reflection.stPos));
+  const endPos = Math.max(0, Math.min(1, reflection.endPos));
+  // Chromium's OffscreenCanvas clears the destination for a gradient-filled
+  // `destination-in` pass (the equivalent HTMLCanvas path works), making
+  // worker-rendered reflections disappear. This surface contains only freshly
+  // rasterized text, so it is origin-clean: apply the alpha ramp directly to
+  // its pixel alpha. The work is bounded to the cropped glyph box, not the
+  // entire slide.
+  const span = Math.max(1, localBottom - localTop);
+  try {
+    const pixels = auxCtx.getImageData(0, 0, cropW, cropH);
+    for (let row = 0; row < cropH; row++) {
+      const position = Math.max(0, Math.min(1, (localBottom - (row + 0.5)) / span));
+      let alpha: number;
+      if (position <= stPos) alpha = reflection.stA;
+      else if (position >= endPos || endPos <= stPos) alpha = reflection.endA;
+      else {
+        const t = (position - stPos) / (endPos - stPos);
+        alpha = reflection.stA + (reflection.endA - reflection.stA) * t;
+      }
+      const factor = Math.max(0, Math.min(1, alpha));
+      for (let offset = row * cropW * 4 + 3; offset < (row + 1) * cropW * 4; offset += 4) {
+        pixels.data[offset] = Math.round(pixels.data[offset] * factor);
+      }
+    }
+    auxCtx.putImageData(pixels, 0, 0);
+  } catch {
+    // Text surfaces should remain origin-clean. If a host canvas implementation
+    // cannot expose pixels, keep a uniformly faded reflection instead of
+    // dropping the authored effect entirely.
+    auxCtx.save();
+    auxCtx.globalCompositeOperation = 'destination-in';
+    auxCtx.fillStyle = `rgba(0,0,0,${Math.max(0, Math.min(1, reflection.stA))})`;
+    auxCtx.fillRect(0, 0, cropW, cropH);
+    auxCtx.restore();
+  }
+
+  const dist = reflection.dist * effectScale;
+  const dirRad = (reflection.dir * Math.PI) / 180;
+  const bottom = bbox.y + bbox.h;
+  liveCtx.save();
+  liveCtx.setTransform(1, 0, 0, 1, 0, 0);
+  liveCtx.translate(
+    bbox.x + Math.cos(dirRad) * dist,
+    bottom + Math.sin(dirRad) * dist,
+  );
+  liveCtx.scale(reflection.sx, reflection.sy);
+  liveCtx.translate(-bbox.x, -bottom);
+  liveCtx.drawImage(aux as CanvasImageSource, cropX, cropY);
+  liveCtx.restore();
+}
+
+export function buildFont(bold: boolean, italic: boolean, sizePx: number, family: string, rc: RenderContext): string {
   const style  = italic ? 'italic ' : '';
-  const weight = bold   ? 'bold '   : '';
   const normalized = normalizeFontFamily(family, rc);
+  const inferredWeight = namedFaceWeight(normalized);
+  const weight = bold ? 'bold ' : inferredWeight ? `${inferredWeight} ` : '';
   if (CSS_GENERIC_FAMILIES.has(normalized)) {
     return `${style}${weight}${sizePx}px ${normalized}`;
   }
@@ -726,7 +855,9 @@ export function layoutParagraph(
     const run = para.runs[i];
     if (run.type === 'break') continue;
     if (run.type === 'math') break;
-    const trimmed = run.text.trimEnd();
+    // Only ordinary U+0020 spaces participate in the observed PowerPoint
+    // terminal-space compatibility rule. Non-breaking spaces remain visible.
+    const trimmed = run.text.replace(/ +$/u, '');
     if (trimmed !== run.text) terminalText.set(run, trimmed);
     if (trimmed.length > 0 || run.fieldType != null) scanningTerminalWhitespace = false;
   }
@@ -844,6 +975,7 @@ export function layoutParagraph(
       underlineStyle?: string;
       underlineColor?: string;
       shadow?: import('@silurus/ooxml-core').Shadow;
+      reflection?: import('@silurus/ooxml-core').Reflection;
       outline?: import('@silurus/ooxml-core').TextOutline;
       highlight?: string;
       /** Raw normalized family for the design-line-height floor (see LayoutSegment). */
@@ -865,6 +997,7 @@ export function layoutParagraph(
     const underlineStyle = extras?.underlineStyle;
     const underlineColor = extras?.underlineColor;
     const shadow = extras?.shadow;
+    const reflection = extras?.reflection;
     const outline = extras?.outline;
     const highlight = extras?.highlight;
     const fontFamily = extras?.fontFamily;
@@ -885,6 +1018,7 @@ export function layoutParagraph(
       (a.letterSpacingPx ?? 0) === lsPx &&
       a.baseline === baseline &&
       a.shadow === shadow &&
+      a.reflection === reflection &&
       a.outline === outline &&
       (a.highlight ?? '') === (highlight ?? '') &&
       (a.fontFamily ?? '') === (fontFamily ?? '') &&
@@ -898,7 +1032,7 @@ export function layoutParagraph(
     if (last && sameMeta(last)) {
       last.text += text;
     } else {
-      currentLine.segments.push({ text, font, fontFamily, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, outline, highlight, hyperlink });
+      currentLine.segments.push({ text, font, fontFamily, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, reflection, outline, highlight, hyperlink });
     }
   };
 
@@ -937,6 +1071,7 @@ export function layoutParagraph(
       underlineStyle: seg.underlineStyle,
       underlineColor: seg.underlineColor,
       shadow: seg.shadow,
+      reflection: seg.reflection,
       outline: seg.outline,
       highlight: seg.highlight,
       fontFamily: seg.fontFamily,
@@ -1041,6 +1176,7 @@ export function layoutParagraph(
       underlineStyle: run.underlineStyle,
       underlineColor: run.underlineColor ? hexToRgba(run.underlineColor) : undefined,
       shadow: run.shadow,
+      reflection: run.reflection,
       outline: run.outline,
       // Raw latin/primary family for the design-line-height floor. CJK per-char
       // pushes below override this to `familyEa` when they draw with `fontEa`,
@@ -1565,7 +1701,7 @@ function applyShadow(ctx: CanvasRenderingContext2D, shadow: Shadow | null, scale
   const dirRad = (shadow.dir * Math.PI) / 180;
   const dist = emuToPx(shadow.dist, scale);
   ctx.shadowColor = hexToRgba(shadow.color, shadow.alpha);
-  ctx.shadowBlur = emuToPx(shadow.blur, scale);
+  ctx.shadowBlur = 0;
   ctx.shadowOffsetX = Math.cos(dirRad) * dist;
   ctx.shadowOffsetY = Math.sin(dirRad) * dist;
 }
@@ -2422,6 +2558,9 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
       flipH: sceneTransform.localFlipH,
       flipV: sceneTransform.localFlipV,
       scene3d: undefined,
+      // The outer projection owns bevel and extrusion. Retaining sp3d here
+      // would shade the recursive flat body and then shade it again outside.
+      sp3d: undefined,
     };
     const ok = projectScene3dPaint(
       ctx,
@@ -2470,12 +2609,11 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
   const geom = el.geometry.toLowerCase();
   const fillStyle = resolveShapeFill(el.fill, ctx, x, y, w, h);
 
-  // Apply shadow before fill/stroke drawing; ctx.restore() will clear it.
   // The Canvas API exposes a single shadow slot, so when both an outer shadow
   // and a glow are configured we let the outer shadow win (visually dominant)
-  // and fall back to the glow only when no outer shadow is present. This is
-  // a common — and conservative — interpretation of layered effectLst.
-  applyShadow(ctx, el.shadow ?? null, scale);
+  // and fall back to the glow only when no outer shadow is present. The outer
+  // shadow itself is composited from the complete fill+stroke silhouette below;
+  // applying native shadow state here makes each path cast a separate shadow.
   if (!el.shadow) applyGlow(ctx, el.glow ?? null, scale);
 
   const CONNECTOR_GEOMS = new Set([
@@ -2643,6 +2781,33 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
   const applyLiveTransform = (c: CanvasRenderingContext2D) => {
     c.setTransform(liveTransform);
   };
+
+  // outerShdw applies to the composed shape, including its outline. Drawing it
+  // from the fill alone lets a thick outline cover the dense part of the shadow
+  // (common for title bars); drawing fill and stroke with native shadow state
+  // stacks two shadows. Rasterise the complete body once and shadow that union.
+  let nativeShadowFallback = false;
+  if (el.shadow && deviceW > 0 && deviceH > 0) {
+    ctx.save();
+    ctx.setTransform(new DOMMatrix());
+    const painted = applyOuterShadow(
+      ctx,
+      (c) => {
+        applyLiveTransform(c as CanvasRenderingContext2D);
+        paintVisibleShapeBody(c as CanvasRenderingContext2D);
+      },
+      effBBox,
+      el.shadow,
+      effScale,
+      deviceW,
+      deviceH,
+    );
+    ctx.restore();
+    nativeShadowFallback = !painted;
+  } else if (el.shadow) {
+    nativeShadowFallback = true;
+  }
+  if (nativeShadowFallback) applyShadow(ctx, el.shadow ?? null, scale);
 
   // Reflection sits BEHIND/below the shape — draw it first so the body paints
   // on top. §20.1.8.50. The aux silhouette bakes in the live rotation/flip via
@@ -3796,27 +3961,18 @@ export function renderTextBody(
         paintHighlight(ctx, penX, segBaseline, hlW, seg.sizePx, seg.highlight, seg.color);
       }
 
-      // Run-level text shadow (rPr > effectLst > outerShdw). Set on the
-      // context so the fillText below picks it up, then cleared after so
-      // the outline / underline / strikethrough don't get shadowed too.
-      // ECMA-376 §20.1.8.45 dir is degrees clockwise from east; the same
-      // formula used by the shape-level shadow renderer above.
       const segShadow = seg.shadow;
-      if (segShadow) {
-        const dirRad = (segShadow.dir * Math.PI) / 180;
-        const dist = emuToPx(segShadow.dist, scale);
-        ctx.save();
-        ctx.shadowColor = hexToRgba(segShadow.color, segShadow.alpha);
-        ctx.shadowBlur = emuToPx(segShadow.blur, scale);
-        ctx.shadowOffsetX = Math.cos(dirRad) * dist;
-        ctx.shadowOffsetY = Math.sin(dirRad) * dist;
-      }
 
       // Draw `text` at `atX` honouring this segment's letter-spacing / RTL
       // semantics. Lifted into a closure so the fill and stroke (outline) paths
       // share it, and so the split-CJK branch below can call it per piece.
-      const drawWithFont = (text: string, atX: number, op: 'fill' | 'stroke'): void => {
-        const paint = op === 'fill' ? ctx.fillText.bind(ctx) : ctx.strokeText.bind(ctx);
+      const drawWithFont = (
+        target: CanvasRenderingContext2D,
+        text: string,
+        atX: number,
+        op: 'fill' | 'stroke',
+      ): void => {
+        const paint = op === 'fill' ? target.fillText.bind(target) : target.strokeText.bind(target);
         if (ls > 0 && text.length > 1) {
           // rPr @spc (§21.1.2.3.x): distribute the per-glyph advance via canvas
           // letterSpacing and draw the whole CONTEXTUALLY-shaped string in ONE
@@ -3829,7 +3985,7 @@ export function renderTextBody(
           // punctuation.) Chromium's measureText adds letterSpacing after every
           // glyph incl. the trailing one (= natural + n·ls), matching
           // codePointCount(seg.text)·ls used by the layout's segW.
-          const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
+          const lctx = target as CanvasRenderingContext2D & { letterSpacing: string };
           const prev = lctx.letterSpacing;
           try { lctx.letterSpacing = `${ls}px`; } catch { /* older engines */ }
           paint(text, atX, segBaseline);
@@ -3869,7 +4025,7 @@ export function renderTextBody(
       const cps = [...seg.text];
       const fullyDistributed =
         !!splitBefore && splitBefore.length === cps.length - 1 && cps.length > 1;
-      const drawRun = (op: 'fill' | 'stroke'): void => {
+      const drawRun = (target: CanvasRenderingContext2D, op: 'fill' | 'stroke'): void => {
         if (eaVertUpright) {
           // ECMA-376 §20.1.10.83 eaVert: paint each glyph with its UAX#50 vertical
           // orientation (CJK/kana upright, Latin sideways, brackets/comma
@@ -3883,27 +4039,100 @@ export function renderTextBody(
           // Partial `just` distribution (mixed Latin/CJK pieces) is a rare eaVert
           // edge and is not redistributed here.
           const eaPitch = fullyDistributed ? ls + segPerGap : ls;
-          drawEaVertRun(ctx, seg.text, penX, segBaseline, seg.sizePx, eaPitch, op);
+          drawEaVertRun(target, seg.text, penX, segBaseline, seg.sizePx, eaPitch, op);
           return;
         }
         if (fullyDistributed) {
-          const lctx = ctx as CanvasRenderingContext2D & { letterSpacing: string };
+          const lctx = target as CanvasRenderingContext2D & { letterSpacing: string };
           const prev = lctx.letterSpacing;
           try { lctx.letterSpacing = `${ls + segPerGap}px`; } catch { /* older engines */ }
-          (op === 'fill' ? ctx.fillText.bind(ctx) : ctx.strokeText.bind(ctx))(
+          (op === 'fill' ? target.fillText.bind(target) : target.strokeText.bind(target))(
             seg.text,
             penX,
             segBaseline,
           );
           try { lctx.letterSpacing = prev; } catch { /* ignore */ }
         } else if (pieces) {
-          for (const { text: pieceText, dx } of pieces) drawWithFont(pieceText, penX + dx, op);
+          for (const { text: pieceText, dx } of pieces) {
+            drawWithFont(target, pieceText, penX + dx, op);
+          }
         } else {
-          drawWithFont(seg.text, penX, op);
+          drawWithFont(target, seg.text, penX, op);
         }
       };
 
-      drawRun('fill');
+      // A run-level reflection is painted before the glyphs themselves, using
+      // the same device-space effect pipeline as shape reflections. Keeping the
+      // draw closure target-agnostic preserves letter spacing, justification,
+      // vertical glyph orientation, and outlines without rasterizing the whole
+      // text body as one effect image.
+      const segReflection = seg.reflection;
+      if (segReflection && seg.text) {
+        const deviceW = (ctx.canvas as { width: number }).width || 0;
+        const deviceH = (ctx.canvas as { height: number }).height || 0;
+        if (deviceW > 0 && deviceH > 0) {
+          ctx.font = seg.font;
+          const metrics = ctx.measureText(seg.text);
+          const ascent = Number.isFinite(metrics.actualBoundingBoxAscent)
+            ? metrics.actualBoundingBoxAscent
+            : seg.sizePx * 0.8;
+          // Zero is a valid descent for all-uppercase runs. Treating it as
+          // "missing" inserts a synthetic 0.2em blank band below the glyph;
+          // the reflection's strongest stA region then lands on transparency
+          // and the visible strokes are almost fully faded.
+          const descent = Number.isFinite(metrics.actualBoundingBoxDescent)
+            ? metrics.actualBoundingBoxDescent
+            : seg.sizePx * 0.2;
+          const left = Number.isFinite(metrics.actualBoundingBoxLeft)
+            ? metrics.actualBoundingBoxLeft
+            : 0;
+          const right = Number.isFinite(metrics.actualBoundingBoxRight)
+            ? metrics.actualBoundingBoxRight
+            : metrics.width;
+          const liveTransform = ctx.getTransform();
+          const det = Math.abs(
+            liveTransform.a * liveTransform.d - liveTransform.b * liveTransform.c,
+          );
+          const devScale = det > 0 ? Math.sqrt(det) : 1;
+          const bbox = {
+            x: (penX - left) * devScale,
+            y: (segBaseline - ascent) * devScale,
+            w: Math.max(1, left + right) * devScale,
+            h: Math.max(1, ascent + descent) * devScale,
+          };
+          applyTextRunReflection(
+            ctx,
+            (target) => {
+              target.font = seg.font;
+              target.fillStyle = seg.color;
+              drawRun(target, 'fill');
+            },
+            bbox,
+            segReflection,
+            scale * devScale,
+            liveTransform,
+            deviceW,
+            deviceH,
+          );
+          ctx.font = seg.font;
+          ctx.fillStyle = seg.color;
+        }
+      }
+
+      // Run-level text shadow (rPr > effectLst > outerShdw). Apply it only to
+      // the primary glyph paint; the reflection above must not cast a second
+      // shadow of its already-mirrored pixels.
+      if (segShadow) {
+        const dirRad = (segShadow.dir * Math.PI) / 180;
+        const dist = emuToPx(segShadow.dist, scale);
+        ctx.save();
+        ctx.shadowColor = hexToRgba(segShadow.color, segShadow.alpha);
+        ctx.shadowBlur = emuToPx(segShadow.blur, scale);
+        ctx.shadowOffsetX = Math.cos(dirRad) * dist;
+        ctx.shadowOffsetY = Math.sin(dirRad) * dist;
+      }
+
+      drawRun(ctx, 'fill');
 
       if (segShadow) ctx.restore();
 
@@ -3919,7 +4148,7 @@ export function renderTextBody(
         ctx.lineWidth = Math.max(0.5, emuToPx(segOutline.width, scale));
         ctx.strokeStyle = segOutline.color ? `#${segOutline.color}` : seg.color;
         ctx.lineJoin = 'round';
-        drawRun('stroke');
+        drawRun(ctx, 'stroke');
         ctx.restore();
       }
 

--- a/packages/pptx/src/shape-orthographic-bevel.test.ts
+++ b/packages/pptx/src/shape-orthographic-bevel.test.ts
@@ -77,6 +77,17 @@ function orthographicBeveledShape(): ShapeElement {
   };
 }
 
+function projectedBeveledShape(): ShapeElement {
+  const shape = orthographicBeveledShape();
+  return {
+    ...shape,
+    scene3d: {
+      camera: { prst: 'isometricLeftUp' },
+      lightRig: { rig: 'chilly', dir: 't' },
+    },
+  };
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -112,5 +123,34 @@ describe('shape orthographic bevel', () => {
     expect(created).toHaveLength(1);
     expect(drawImages).toHaveLength(1);
     expect(drawImages[0]?.[0]).toBe(created[0]);
+  });
+
+  it('applies a projected bevel once instead of shading the recursive flat body', async () => {
+    const created: TestOffscreenCanvas[] = [];
+    vi.stubGlobal('OffscreenCanvas', class extends TestOffscreenCanvas {
+      constructor(width: number, height: number) {
+        super(width, height);
+        created.push(this);
+      }
+    });
+
+    const canvas = {
+      width: 960,
+      height: 540,
+      style: {} as CSSStyleDeclaration,
+      offsetWidth: 960,
+    } as HTMLCanvasElement;
+    const ctx = contextFor(canvas);
+    canvas.getContext = (() => ctx) as unknown as HTMLCanvasElement['getContext'];
+    const slide: Slide = {
+      index: 0,
+      slideNumber: 1,
+      background: null,
+      elements: [projectedBeveledShape()],
+    };
+
+    await renderSlide(canvas, slide, 9_144_000, 6_858_000, { width: 960, dpr: 1 });
+
+    expect(created).toHaveLength(1);
   });
 });

--- a/packages/xlsx/src/google-fonts.test.ts
+++ b/packages/xlsx/src/google-fonts.test.ts
@@ -35,6 +35,8 @@ const XLSX_GOOGLE_FONTS_OLD: Record<string, FontPreloadEntry> = {
 const EXPECTED_ADDED = new Set([
   'calibri light',
   'cambria math',
+  'franklin gothic book',
+  'franklin gothic medium',
   'nunito sans',
   'nunito',
   'open sans',
@@ -63,5 +65,8 @@ describe('XLSX_GOOGLE_FONTS — shared registry consolidation (oracle)', () => {
     // The two Office face names reduce to their base family's substitute.
     expect(XLSX_GOOGLE_FONTS['calibri light']).toEqual(XLSX_GOOGLE_FONTS['calibri']);
     expect(XLSX_GOOGLE_FONTS['cambria math']).toEqual(XLSX_GOOGLE_FONTS['cambria']);
+    expect(XLSX_GOOGLE_FONTS['franklin gothic medium']).toMatchObject({
+      loadFamily: 'Libre Franklin',
+    });
   });
 });


### PR DESCRIPTION
## Summary

- resolve fill, line, effect, text, and 3-D style components through the theme/master/layout cascade without discarding independent inherited values
- preserve authored table cell/text properties, bullet markers, and terminal text semantics
- render run-level reflections, named Office face weights, and composed fill+stroke outer shadows
- keep effect working buffers bounded to the affected shape where safe

## Specification basis

The affected behavior follows ECMA-376 Part 1 sections 20.1.4.1.18, 20.1.8.45, 20.1.8.50, 20.1.10.83, and 21.1.3.13.

## Verification

- `cargo test -p pptx-parser` (241 tests)
- focused renderer/effect tests (34 tests)
- `pnpm typecheck`
- `pnpm build`
- `pnpm check:public-api:built`
- `pnpm check:public-type-exports`
- local comparison against Office-exported PDF references