### PR TITLE
fix(pptx): preserve shadows and bullet markers

### DIFF
--- a/packages/core/src/shape/effects.test.ts
+++ b/packages/core/src/shape/effects.test.ts
@@ -128,7 +128,7 @@ describe('applyOuterShadow (ECMA-376 §20.1.8.45)', () => {
   beforeEach(() => { fake = installFakeCanvas(); });
   afterEach(() => vi.unstubAllGlobals());
 
-  it('recolours one composed silhouette and blurs/offsets it once', () => {
+  it('recolours one composed silhouette, blurs locally, then offsets it once', () => {
     const live = new RecordingCtx();
     const paint = vi.fn((c: unknown) => {
       (c as RecordingCtx).ops.push({ op: 'paintShape' });
@@ -142,9 +142,30 @@ describe('applyOuterShadow (ECMA-376 §20.1.8.45)', () => {
     )).toBe(true);
 
     expect(paint).toHaveBeenCalledTimes(1);
+    expect(fake.auxCtxs).toHaveLength(2);
     expect(fake.auxCtxs[0].usedCompositeOps).toContain('source-in');
     expect(fake.auxCtxs[0].ops.some(o => o.op === 'fillRect')).toBe(true);
-    expect(live.usedBlurFilters).toEqual(['blur(4px)']);
+    expect(fake.auxCtxs[1].usedBlurFilters).toEqual(['blur(4px)']);
+    expect(fake.auxCtxs[1].ops.filter(o => o.op === 'drawImage')).toHaveLength(1);
+    expect(live.usedBlurFilters).toEqual([]);
+    const finalBlit = live.ops.filter(o => o.op === 'drawImage');
+    expect(finalBlit).toHaveLength(1);
+    expect(finalBlit[0].args?.slice(1)).toEqual([84, 36]);
+  });
+
+  it('uses one auxiliary surface and no filter for a sharp shadow', () => {
+    const live = new RecordingCtx();
+    const shadow: Shadow = {
+      color: '000000', alpha: 0.38, blur: 0, dist: 19_050, dir: 90,
+    };
+
+    expect(applyOuterShadow(
+      live as never, (() => {}) as never, BBOX, shadow, SCALE, DEVICE_W, DEVICE_H,
+    )).toBe(true);
+
+    expect(fake.auxCtxs).toHaveLength(1);
+    expect(fake.auxCtxs[0].usedBlurFilters).toEqual([]);
+    expect(live.usedBlurFilters).toEqual([]);
     expect(live.ops.filter(o => o.op === 'drawImage')).toHaveLength(1);
   });
 });

--- a/packages/core/src/shape/effects.ts
+++ b/packages/core/src/shape/effects.ts
@@ -199,9 +199,25 @@ export function applyOuterShadow(
   c.fillRect(0, 0, crop.w, crop.h);
   c.restore();
 
+  // Blur in crop-local coordinates before placing the result on the live
+  // canvas. Applying `filter` to the final device-coordinate draw is unreliable
+  // on high-DPI canvases in Chromium: the filter's logical-pixel clip can drop
+  // shadows whose device-space destination lies beyond the CSS canvas width.
+  // Keeping the filtered draw at (0,0) also confines all filter work to the
+  // bounded auxiliary surface. The final device-space blit is unfiltered.
+  let shadowCanvas = aux;
+  if (blur > 0) {
+    const blurred = createAuxCanvas(crop.w, crop.h);
+    if (!blurred) return false;
+    const blurredCtx = get2d(blurred);
+    if (!blurredCtx) return false;
+    blurredCtx.filter = `blur(${blur}px)`;
+    blurredCtx.drawImage(aux as CanvasImageSource, 0, 0);
+    shadowCanvas = blurred;
+  }
+
   liveCtx.save();
-  if (blur > 0) liveCtx.filter = `blur(${blur}px)`;
-  liveCtx.drawImage(aux as CanvasImageSource, crop.x + dx, crop.y + dy);
+  liveCtx.drawImage(shadowCanvas as CanvasImageSource, crop.x + dx, crop.y + dy);
   liveCtx.restore();
   return true;
 }

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -3628,10 +3628,11 @@ mod tests {
         assert!(BulletProps::default().is_inherit());
     }
 
-    /// ECMA-376 §21.1.2.4.3 defines buChar@char as xsd:string. Preserve the
-    /// complete authored value, including multi-scalar grapheme clusters.
+    /// PowerPoint paints one marker glyph when a flattened SmartArt cache
+    /// serializes a duplicated string-valued buChar. Preserve other authored
+    /// multi-character values because ECMA-376 types the attribute as a string.
     #[test]
-    fn character_bullet_preserves_the_authored_string() {
+    fn character_bullet_collapses_only_a_duplicated_marker() {
         let doc = roxmltree::Document::parse(
             r#"<a:pPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:buChar char="••"/></a:pPr>"#,
         )
@@ -3639,18 +3640,35 @@ mod tests {
         let theme = HashMap::new();
         let mut resolve_blip = |_: &str| None;
         match parse_bullet(Some(doc.root_element()), &theme, &mut resolve_blip) {
-            Bullet::Char { ch, .. } => assert_eq!(ch, "••"),
+            Bullet::Char { ch, .. } => assert_eq!(ch, "•"),
             other => panic!("expected Char, got {other:?}"),
         }
 
-        let emoji_doc = roxmltree::Document::parse(
+        let multi_char_doc = roxmltree::Document::parse(
             r#"<a:pPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:buChar char="🡆x"/></a:pPr>"#,
         )
-        .expect("valid supplementary-plane marker");
-        match parse_bullet(Some(emoji_doc.root_element()), &theme, &mut resolve_blip) {
+        .expect("valid multi-character marker");
+        match parse_bullet(
+            Some(multi_char_doc.root_element()),
+            &theme,
+            &mut resolve_blip,
+        ) {
             Bullet::Char { ch, .. } => assert_eq!(ch, "🡆x"),
             other => panic!("expected Char, got {other:?}"),
         }
+    }
+
+    /// PowerPoint serializes an unbound placeholder as idx=2^32-1. That value
+    /// is a sentinel rather than a layout slot, so the paragraph still inherits
+    /// its bullet marker from the master bodyStyle.
+    #[test]
+    fn max_placeholder_idx_uses_type_style_fallback() {
+        let slide_sp = r#"<p:sp><p:nvSpPr><p:cNvPr id="5" name="Unbound body"/><p:cNvSpPr/><p:nvPr><p:ph idx="4294967295"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000000" cy="1000000"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:buClr><a:srgbClr val="C00000"/></a:buClr></a:pPr><a:r><a:t>x</a:t></a:r></a:p></p:txBody></p:sp>"#;
+        let data = build_align_pptx(slide_sp, "", &txstyles_body_lvl1(r#"<a:buChar char="•"/>"#));
+        let b = first_para_bullet(&data);
+        assert_eq!(b["type"], "char");
+        assert_eq!(b["char"], "•");
+        assert_eq!(b["color"], "C00000");
     }
 
     /// §21.1.2.4.9 — `<a:buSzPct val>` accepts both the Transitional integer

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -1619,6 +1619,43 @@ pub(crate) fn parse_layout_placeholders(
             }
         }
     }
+
+    // A slide placeholder can be intentionally unbound to a layout slot (for
+    // example PowerPoint's idx=2^32-1 sentinel on a blank layout). In that case
+    // it still inherits the matching master txStyles / placeholder defaults by
+    // type. The loop above only materializes type entries that also occur in
+    // the layout, so fill the absent types from the master after all layout
+    // overlays have won.
+    for (ph_type, value) in master_font_sizes {
+        lph.by_type_font_size
+            .entry(ph_type.clone())
+            .or_insert(*value);
+    }
+    for (ph_type, value) in master_font_families {
+        lph.by_type_font_family
+            .entry(ph_type.clone())
+            .or_insert_with(|| value.clone());
+    }
+    for (ph_type, value) in master_level_font_sizes {
+        lph.by_type_level_sizes
+            .entry(ph_type.clone())
+            .or_insert(*value);
+    }
+    for (ph_type, value) in master_level_indents {
+        lph.by_type_level_indents
+            .entry(ph_type.clone())
+            .or_insert(*value);
+    }
+    for (ph_type, value) in master_level_bullets {
+        lph.by_type_level_bullets
+            .entry(ph_type.clone())
+            .or_insert_with(|| value.clone());
+    }
+    for (ph_type, value) in master_anchors {
+        lph.by_type_anchor
+            .entry(ph_type.clone())
+            .or_insert_with(|| value.clone());
+    }
     lph
 }
 
@@ -1970,6 +2007,7 @@ pub(crate) fn build_master_bundle(
 mod placeholder_geometry_tests {
     use super::*;
     use crate::shape::parse_shape;
+    use crate::text::{BuMarker, BulletProps};
     use std::io::Cursor;
 
     fn empty_zip() -> PptxZip {
@@ -2029,6 +2067,49 @@ mod placeholder_geometry_tests {
             &mut zip,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn blank_layout_keeps_master_body_bullet_fallback() {
+        let xml = r#"<p:sldLayout
+          xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:cSld><p:spTree/></p:cSld>
+        </p:sldLayout>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let mut zip = empty_zip();
+        let mut master_bullets = HashMap::new();
+        let mut body_levels = empty_level_bullets();
+        body_levels[0] = BulletProps {
+            marker: Some(BuMarker::Char("•".into())),
+            ..Default::default()
+        };
+        master_bullets.insert("body".to_owned(), body_levels);
+
+        let placeholders = parse_layout_placeholders(
+            doc.root_element(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &master_bullets,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            "ppt/slideLayouts",
+            &HashMap::new(),
+            &mut zip,
+        );
+
+        match placeholders.lookup_level_bullets("body", None)[0].resolve() {
+            Bullet::Char { ch, .. } => assert_eq!(ch, "•"),
+            other => panic!("expected master body bullet, got {other:?}"),
+        }
     }
 
     #[test]

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -315,7 +315,11 @@ pub(crate) fn parse_shape(
     let ph_idx: Option<u32> = ph_node
         .as_ref()
         .and_then(|n| attr(n, "idx"))
-        .and_then(|v| v.parse().ok());
+        .and_then(|v| v.parse().ok())
+        // PowerPoint uses the unsigned maximum as an unbound-placeholder
+        // sentinel. It is not a real layout slot; treating it as an authored
+        // idx suppresses the normal type/bodyStyle fallback.
+        .filter(|idx| *idx != u32::MAX);
     // Surface the explicit ph @type / @idx (when present) on the ShapeElement
     // JSON. We keep `ph_type` defaulted to "body" for the internal lookup
     // path, but only emit the `placeholder_type` field when a real `<p:ph>`
@@ -1815,7 +1819,9 @@ pub(crate) fn parse_sp_tree_node(
                     .find(|n| n.is_element() && n.tag_name().name() == "ph")
                 {
                     let ph_type = attr(&ph, "type").unwrap_or_else(|| "body".into());
-                    let ph_idx: Option<u32> = attr(&ph, "idx").and_then(|v| v.parse().ok());
+                    let ph_idx: Option<u32> = attr(&ph, "idx")
+                        .and_then(|v| v.parse().ok())
+                        .filter(|idx| *idx != u32::MAX);
                     if let Some(bf) = lph.lookup_blip_fill(&ph_type, ph_idx) {
                         let slide_xfrm = sp_pr_node.and_then(|p| child(p, "xfrm")).map(parse_xfrm);
                         let t = slide_xfrm.or_else(|| lph.lookup(&ph_type, ph_idx).cloned());
@@ -1890,7 +1896,8 @@ pub(crate) fn parse_sp_tree_node(
                     .descendants()
                     .find(|n| n.is_element() && n.tag_name().name() == "ph")
                     .and_then(|ph| attr(&ph, "idx"))
-                    .and_then(|s| s.parse::<u32>().ok());
+                    .and_then(|s| s.parse::<u32>().ok())
+                    .filter(|idx| *idx != u32::MAX);
                 if let Some(idx) = ph_idx {
                     if let Some(t) = lph.by_idx.get(&idx) {
                         let blip_fill = child(node, "blipFill");

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -1104,9 +1104,22 @@ fn parse_bullet_marker<F: FnMut(&str) -> Option<String>>(
 
     // Character bullet
     if let Some(bu_char) = child(p_pr, "buChar") {
-        // CT_TextCharBullet@char is xsd:string (§21.1.2.4.3). Preserve the
-        // authored string, including variation selectors and combining marks.
-        let ch = attr(&bu_char, "char").unwrap_or_else(|| "\u{2022}".into()); // •
+        // CT_TextCharBullet's attribute is schema-typed as a string. Flattened
+        // SmartArt caches can nevertheless repeat one marker (for example
+        // `••`) even though PowerPoint paints it once. Collapse only that
+        // duplicate-marker form; preserve genuinely multi-character values.
+        let ch = attr(&bu_char, "char")
+            .map(|value| {
+                let mut chars = value.chars();
+                let first = chars.next();
+                match first {
+                    Some(marker) if chars.clone().count() > 0 && chars.all(|ch| ch == marker) => {
+                        marker.to_string()
+                    }
+                    _ => value,
+                }
+            })
+            .unwrap_or_else(|| "\u{2022}".into()); // •
         return Some(BuMarker::Char(ch));
     }
 

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2477,6 +2477,44 @@ export function splitScene3dShapeTransform(
   };
 }
 
+interface EffectTransform {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+  e: number;
+  f: number;
+}
+
+/**
+ * Axis-aligned device-pixel bounds of a shape after the current Canvas
+ * transform. DrawingML group transforms are already folded into that matrix;
+ * effect surfaces must therefore be cropped from these transformed bounds,
+ * not from the shape's group-local coordinates.
+ */
+export function transformedEffectBounds(
+  transform: EffectTransform,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): { x: number; y: number; w: number; h: number } {
+  const points = [
+    { x, y },
+    { x: x + w, y },
+    { x, y: y + h },
+    { x: x + w, y: y + h },
+  ].map((point) => ({
+    x: transform.a * point.x + transform.c * point.y + transform.e,
+    y: transform.b * point.x + transform.d * point.y + transform.f,
+  }));
+  const minX = Math.min(...points.map((point) => point.x));
+  const minY = Math.min(...points.map((point) => point.y));
+  const maxX = Math.max(...points.map((point) => point.x));
+  const maxY = Math.max(...points.map((point) => point.y));
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+}
+
 function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: number, themeDefaultColor = '#000000', slideNumber?: number, rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 }, onTextRun?: TextRunCallback, fetchImage?: FetchImage) {
   const x = emuToPx(el.x, scale);
   const y = emuToPx(el.y, scale);
@@ -2742,7 +2780,7 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
   const liveTransform = ctx.getTransform();
   const det = Math.abs(liveTransform.a * liveTransform.d - liveTransform.b * liveTransform.c);
   const devScale = det > 0 ? Math.sqrt(det) : 1;
-  const effBBox = { x: x * devScale, y: y * devScale, w: w * devScale, h: h * devScale };
+  const effBBox = transformedEffectBounds(liveTransform, x, y, w, h);
   const effScale = scale * devScale; // EMU → device px
   // A face-on camera does not need a homography, but sp3d bevels still alter
   // the front surface. Pictures already take this flat offscreen path; shapes

--- a/packages/pptx/src/shape-effect-transform.test.ts
+++ b/packages/pptx/src/shape-effect-transform.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { transformedEffectBounds } from './renderer';
+
+describe('shape effect bounds', () => {
+  it('includes the active group transform translation and scale', () => {
+    expect(transformedEffectBounds(
+      { a: 1.5, b: 0, c: 0, d: 1.5, e: 72, f: 45 },
+      464,
+      120,
+      146,
+      200,
+    )).toEqual({ x: 768, y: 225, w: 219, h: 300 });
+  });
+
+  it('returns the axis-aligned device bounds after rotation', () => {
+    expect(transformedEffectBounds(
+      { a: 0, b: 2, c: -2, d: 0, e: 500, f: 30 },
+      10,
+      20,
+      40,
+      30,
+    )).toEqual({ x: 400, y: 50, w: 60, h: 80 });
+  });
+});


### PR DESCRIPTION
## Summary

- blur outer shadows on a bounded local surface before the final high-DPI canvas blit
- compute effect crops from the active transformed shape bounds
- retain master paragraph defaults for unbound placeholders on blank layouts
- collapse duplicated identical SmartArt bullet markers without truncating valid multi-character values

## Root causes

Filtered device-space draws could be clipped against the CSS-pixel canvas extent in Chromium, which made otherwise valid shadows disappear depending on horizontal position. Separately, an unsigned-maximum placeholder index was treated as a real layout slot, and flattened SmartArt caches could contain repeated copies of one bullet marker.

The changes follow ECMA-376 Part 1 §20.1.8.45 for outer shadows and the PresentationML/DrawingML placeholder and paragraph-property cascades. The repeated-marker normalization is deliberately limited to identical Unicode scalars because buChar is string-valued.

## Verification

- cargo test -p pptx-parser (243 tests)
- focused core effect and PPTX transform tests (14 tests)
- pnpm typecheck
- git diff --check
- local visual comparison for affected shadow, inherited-bullet, and SmartArt-marker cases
