### PR TITLE
fix(pptx): render composed shape shadows reliably

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -261,6 +261,7 @@ export {
   hasPreset,
   buildPresetGeometryPath,
   buildPresetGeometryFillPath,
+  getPresetGeometryBounds,
   getConnectorAnchors,
 } from './shape/preset-geometry';
 export { type PresetPath } from './shape/preset-geometry/path-executor';

--- a/packages/core/src/shape/effects.test.ts
+++ b/packages/core/src/shape/effects.test.ts
@@ -128,10 +128,12 @@ describe('applyOuterShadow (ECMA-376 §20.1.8.45)', () => {
   beforeEach(() => { fake = installFakeCanvas(); });
   afterEach(() => vi.unstubAllGlobals());
 
-  it('recolours one composed silhouette, blurs locally, then offsets it once', () => {
+  it('resets the crop transform before recolouring, then blurs/offsets once', () => {
     const live = new RecordingCtx();
     const paint = vi.fn((c: unknown) => {
-      (c as RecordingCtx).ops.push({ op: 'paintShape' });
+      const target = c as RecordingCtx;
+      target.setTransform({ a: 2, b: 0, c: 0, d: 2, e: 400, f: 200 } as never);
+      target.ops.push({ op: 'paintShape' });
     });
     const shadow: Shadow = {
       color: '000000', alpha: 0.38, blur: 38_100, dist: 19_050, dir: 90,
@@ -142,12 +144,15 @@ describe('applyOuterShadow (ECMA-376 §20.1.8.45)', () => {
     )).toBe(true);
 
     expect(paint).toHaveBeenCalledTimes(1);
-    expect(fake.auxCtxs).toHaveLength(2);
+    expect(fake.auxCtxs).toHaveLength(1);
     expect(fake.auxCtxs[0].usedCompositeOps).toContain('source-in');
-    expect(fake.auxCtxs[0].ops.some(o => o.op === 'fillRect')).toBe(true);
-    expect(fake.auxCtxs[1].usedBlurFilters).toEqual(['blur(4px)']);
-    expect(fake.auxCtxs[1].ops.filter(o => o.op === 'drawImage')).toHaveLength(1);
-    expect(live.usedBlurFilters).toEqual([]);
+    const recolour = fake.auxCtxs[0].ops.findIndex(o => o.op === 'fillRect');
+    expect(recolour).toBeGreaterThan(0);
+    expect(fake.auxCtxs[0].ops[recolour - 1]).toMatchObject({
+      op: 'setTransform',
+      args: [1, 0, 0, 1, 0, 0],
+    });
+    expect(live.usedBlurFilters).toEqual(['blur(4px)']);
     const finalBlit = live.ops.filter(o => o.op === 'drawImage');
     expect(finalBlit).toHaveLength(1);
     expect(finalBlit[0].args?.slice(1)).toEqual([84, 36]);

--- a/packages/core/src/shape/effects.ts
+++ b/packages/core/src/shape/effects.ts
@@ -194,30 +194,20 @@ export function applyOuterShadow(
 
   paintShape(offsetPaintCtx(c, crop));
   c.save();
+  // The paint callback installs the live absolute-device transform (shifted by
+  // the crop origin). Recolouring is a crop-local full-surface operation, so it
+  // must not inherit that transform. Otherwise the source-in rectangle moves
+  // away from silhouettes positioned farther across/down the slide, producing
+  // position-dependent partial or entirely missing shadows.
+  c.setTransform(1, 0, 0, 1, 0, 0);
   c.globalCompositeOperation = 'source-in';
   c.fillStyle = hexToRgba(shadow.color, shadow.alpha);
   c.fillRect(0, 0, crop.w, crop.h);
   c.restore();
 
-  // Blur in crop-local coordinates before placing the result on the live
-  // canvas. Applying `filter` to the final device-coordinate draw is unreliable
-  // on high-DPI canvases in Chromium: the filter's logical-pixel clip can drop
-  // shadows whose device-space destination lies beyond the CSS canvas width.
-  // Keeping the filtered draw at (0,0) also confines all filter work to the
-  // bounded auxiliary surface. The final device-space blit is unfiltered.
-  let shadowCanvas = aux;
-  if (blur > 0) {
-    const blurred = createAuxCanvas(crop.w, crop.h);
-    if (!blurred) return false;
-    const blurredCtx = get2d(blurred);
-    if (!blurredCtx) return false;
-    blurredCtx.filter = `blur(${blur}px)`;
-    blurredCtx.drawImage(aux as CanvasImageSource, 0, 0);
-    shadowCanvas = blurred;
-  }
-
   liveCtx.save();
-  liveCtx.drawImage(shadowCanvas as CanvasImageSource, crop.x + dx, crop.y + dy);
+  if (blur > 0) liveCtx.filter = `blur(${blur}px)`;
+  liveCtx.drawImage(aux as CanvasImageSource, crop.x + dx, crop.y + dy);
   liveCtx.restore();
   return true;
 }

--- a/packages/core/src/shape/preset-geometry/index.ts
+++ b/packages/core/src/shape/preset-geometry/index.ts
@@ -166,6 +166,98 @@ function effAdj(adj: (number | null | undefined)[], def: PresetDef, i: number): 
   return d ? Number(d[1].replace(/^val\s+/, '')) || 0 : 0;
 }
 
+function effectivePreset(
+  key: string,
+  w: number,
+  h: number,
+  adj: (number | null | undefined)[],
+): { def: PresetDef; adj: (number | null | undefined)[] } | null {
+  let def = PRESETS[key];
+  if (!def) return null;
+
+  // Suppress a wedge-callout tail whose tip sits inside the body (see note above).
+  if (key in WEDGE_CALLOUT_BASE) {
+    const a1 = effAdj(adj, def, 0); // dxPos fraction (×1e5) of width from centre
+    const a2 = effAdj(adj, def, 1); // dyPos fraction (×1e5) of height from centre
+    const xPos = w / 2 + (w * a1) / 100000;
+    const yPos = h / 2 + (h * a2) / 100000;
+    const tipInside = xPos >= 0 && xPos <= w && yPos >= 0 && yPos <= h;
+    if (tipInside) {
+      const baseKey = WEDGE_CALLOUT_BASE[key];
+      if (baseKey === 'roundrect') {
+        def = PRESETS.roundrect;
+        adj = [effAdj(adj, PRESETS[key], 2)]; // adj3 → corner radius
+      } else if (baseKey && PRESETS[baseKey]) {
+        def = PRESETS[baseKey];
+        adj = [];
+      } else {
+        def = RECT_DEF;
+        adj = [];
+      }
+    }
+  }
+
+  return { def, adj };
+}
+
+/**
+ * Conservative painted-path bounds for a preset geometry in canvas space.
+ *
+ * DrawingML adjustments can place vertices outside the shape's `<a:xfrm>`
+ * rectangle (wedge callout tips are the common example). Effect rasters must
+ * include those vertices or their shadow/reflection/soft edge is clipped.
+ * Curve control points and complete ellipse boxes are included deliberately:
+ * they may overestimate a curve's exact extrema, but never crop valid paint.
+ */
+export function getPresetGeometryBounds(
+  geom: string,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  adj: (number | null | undefined)[] = [],
+): { x: number; y: number; w: number; h: number } | null {
+  const selected = effectivePreset(geom.toLowerCase(), w, h, adj);
+  if (!selected) return null;
+
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  const include = (px: number, py: number) => {
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return;
+    minX = Math.min(minX, px);
+    minY = Math.min(minY, py);
+    maxX = Math.max(maxX, px);
+    maxY = Math.max(maxY, py);
+  };
+  const boundsCtx = {
+    moveTo: include,
+    lineTo: include,
+    bezierCurveTo(x1: number, y1: number, x2: number, y2: number, ex: number, ey: number) {
+      include(x1, y1);
+      include(x2, y2);
+      include(ex, ey);
+    },
+    quadraticCurveTo(x1: number, y1: number, ex: number, ey: number) {
+      include(x1, y1);
+      include(ex, ey);
+    },
+    ellipse(cx: number, cy: number, rx: number, ry: number) {
+      include(cx - Math.abs(rx), cy - Math.abs(ry));
+      include(cx + Math.abs(rx), cy + Math.abs(ry));
+    },
+    closePath() {},
+  } as unknown as CanvasRenderingContext2D;
+  const evaluator = evaluatorForDef(selected.def, w, h, selected.adj);
+  for (const path of selected.def.paths) {
+    applyPresetPath(boundsCtx, path, evaluator, x, y, w, h);
+  }
+
+  if (!Number.isFinite(minX)) return { x, y, w, h };
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+}
+
 /**
  * Render a preset shape onto the canvas. Handles all paths (including
  * secondary outline-only / highlight paths) with per-path fill/stroke
@@ -189,30 +281,10 @@ export function renderPresetShape(
   opts?: { skipTrailingStroke?: boolean },
 ): boolean {
   const key = geom.toLowerCase();
-  let def = PRESETS[key];
-  if (!def) return false;
-
-  // Suppress a wedge-callout tail whose tip sits inside the body (see note above).
-  if (key in WEDGE_CALLOUT_BASE) {
-    const a1 = effAdj(adj, def, 0); // dxPos fraction (×1e5) of width from centre
-    const a2 = effAdj(adj, def, 1); // dyPos fraction (×1e5) of height from centre
-    const xPos = w / 2 + (w * a1) / 100000;
-    const yPos = h / 2 + (h * a2) / 100000;
-    const tipInside = xPos >= 0 && xPos <= w && yPos >= 0 && yPos <= h;
-    if (tipInside) {
-      const baseKey = WEDGE_CALLOUT_BASE[key];
-      if (baseKey === 'roundrect') {
-        def = PRESETS.roundrect;
-        adj = [effAdj(adj, PRESETS[key], 2)]; // adj3 → corner radius
-      } else if (baseKey && PRESETS[baseKey]) {
-        def = PRESETS[baseKey];
-        adj = [];
-      } else {
-        def = RECT_DEF;
-        adj = [];
-      }
-    }
-  }
+  const selected = effectivePreset(key, w, h, adj);
+  if (!selected) return false;
+  const { def } = selected;
+  adj = selected.adj;
 
   const evaluator = evaluatorForDef(def, w, h, adj);
 

--- a/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
+++ b/packages/core/src/shape/preset-geometry/preset-geometry.test.ts
@@ -4,6 +4,7 @@ import {
   hasPreset,
   buildPresetGeometryPath,
   buildPresetGeometryFillPath,
+  getPresetGeometryBounds,
   getConnectorAnchors,
 } from './index';
 
@@ -62,6 +63,31 @@ function distinct(points: Array<{ x: number; y: number }>) {
 }
 
 describe('renderPresetShape (core preset-geometry engine)', () => {
+  it('includes a wedge-callout tip outside the transform box in its effect bounds', () => {
+    expect(getPresetGeometryBounds(
+      'wedgeRoundRectCallout',
+      100,
+      200,
+      200,
+      100,
+      [41242, 92245, 16667],
+    )).toEqual({ x: 100, y: 200, w: 200, h: 142.245 });
+
+    const rightFacing = getPresetGeometryBounds(
+      'wedgeRoundRectCallout',
+      100,
+      200,
+      200,
+      100,
+      [-89365, 13468, 16667],
+    );
+    expect(rightFacing).not.toBeNull();
+    expect(rightFacing?.x).toBeCloseTo(21.27);
+    expect(rightFacing?.y).toBe(200);
+    expect(rightFacing?.w).toBeCloseTo(278.73);
+    expect(rightFacing?.h).toBe(100);
+  });
+
   it('knows the common xlsx preset names', () => {
     expect(hasPreset('parallelogram')).toBe(true);
     expect(hasPreset('rtTriangle')).toBe(true);

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -39,6 +39,7 @@ import {
   hasPreset,
   buildPresetGeometryPath,
   buildPresetGeometryFillPath,
+  getPresetGeometryBounds,
   getConnectorAnchors,
   getCustGeomEndpoints,
   drawArrowHead,
@@ -2780,7 +2781,31 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
   const liveTransform = ctx.getTransform();
   const det = Math.abs(liveTransform.a * liveTransform.d - liveTransform.b * liveTransform.c);
   const devScale = det > 0 ? Math.sqrt(det) : 1;
-  const effBBox = transformedEffectBounds(liveTransform, x, y, w, h);
+  // Preset adjustments may place painted vertices outside the nominal xfrm
+  // rectangle (for example, a wedge callout's tail). Crop effects to the
+  // geometry bounds so those protrusions participate in the shadow/reflection
+  // instead of being clipped before compositing.
+  const needsRasterEffectBounds = Boolean(
+    el.shadow || el.reflection || el.softEdge || el.innerShadow,
+  );
+  const adjustedGeometryBounds = usePresetEngine && needsRasterEffectBounds
+    ? getPresetGeometryBounds(
+        geom,
+        x,
+        y,
+        w,
+        h,
+        [el.adj, el.adj2, el.adj3, el.adj4, el.adj5, el.adj6, el.adj7, el.adj8],
+      )
+    : null;
+  const effectBounds = adjustedGeometryBounds ?? { x, y, w, h };
+  const effBBox = transformedEffectBounds(
+    liveTransform,
+    effectBounds.x,
+    effectBounds.y,
+    effectBounds.w,
+    effectBounds.h,
+  );
   const effScale = scale * devScale; // EMU → device px
   // A face-on camera does not need a homography, but sp3d bevels still alter
   // the front surface. Pictures already take this flat offscreen path; shapes


### PR DESCRIPTION
## Summary

- reset the auxiliary shadow mask transform before crop-local recoloring
- derive raster-effect crop bounds from adjusted preset geometry
- preserve shadows for geometry that protrudes beyond its nominal transform rectangle, including callout tails
- keep the additional geometry traversal limited to shapes that use raster effects

## Root cause

The composed outer-shadow mask inherited the shape's absolute device transform during its crop-local recoloring pass. This made shadows position-dependent. After correcting that transform, preset vertices outside the nominal DrawingML transform rectangle could still be clipped by the effect crop.

The fix uses the authoritative preset geometry evaluator to calculate conservative painted-path bounds, so effects cover the same geometry that is rendered.

## Verification

- focused preset geometry and shape-effect tests (37 tests)
- workspace TypeScript typecheck
- public type export check
- Storybook visual inspection
- local-only PowerPoint PDF comparison across the presentation corpus
- git diff check