### PR TITLE
fix(pptx): compose effects over complete shape paint

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -133,7 +133,11 @@ export {
 } from './fonts/symbol-font';
 export { renderChart } from './chart/renderer';
 export { autoResize, type AutoResizeOptions } from './autoResize';
-export { buildCustomPath } from './shape/custGeom';
+export {
+  buildCustomPath,
+  getCustomGeometryBounds,
+  type CustomGeometryBounds,
+} from './shape/custGeom';
 export {
   getCustGeomEndpoints,
   type CustGeomEndpoint,
@@ -149,7 +153,12 @@ export {
   type DrawingMLShapeGeometry,
   type DrawingMLShapePaintPlan,
 } from './shape/drawingml-shape';
-export { drawArrowHead, lineEndRetract, retractLineEndpoint } from './shape/arrow';
+export {
+  drawArrowHead,
+  lineEndPaintExtent,
+  lineEndRetract,
+  retractLineEndpoint,
+} from './shape/arrow';
 // Shared embedded-SVG decoder (Microsoft asvg:svgBlip extension) — used by all
 // three renderers to prefer the vector original over the raster fallback.
 // Path-keyed for the lazy byte-on-demand pipeline: fetches SVG bytes via a

--- a/packages/core/src/shape/arrow.test.ts
+++ b/packages/core/src/shape/arrow.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { drawArrowHead, lineEndRetract, retractLineEndpoint } from './arrow';
+import {
+  drawArrowHead,
+  lineEndPaintExtent,
+  lineEndRetract,
+  retractLineEndpoint,
+} from './arrow';
 import type { ArrowEnd, Stroke } from '../types/common';
 
 const stroke: Stroke = { color: '#000000', width: 10 };
@@ -27,6 +32,16 @@ describe('lineEndRetract — how far to pull the leader line back from the tip',
     expect(lineEndRetract(end('triangle', 'med', 'sm'), stroke, 1)).toBeCloseTo(40, 5);
     // width 5, scale 2 → lw = 10 → same as above
     expect(lineEndRetract(end('triangle'), { color: '#000', width: 5 }, 2)).toBeCloseTo(60, 5);
+  });
+});
+
+describe('lineEndPaintExtent', () => {
+  it('covers the decoration and its centered outline around the tip', () => {
+    // med length = 60, centered outline adds 5.
+    expect(lineEndPaintExtent(end('triangle'), stroke, 1)).toBe(65);
+    // large width has half-span 40; small length is 40, plus 5 outline.
+    expect(lineEndPaintExtent(end('arrow', 'lg', 'sm'), stroke, 1)).toBe(45);
+    expect(lineEndPaintExtent(end('none'), stroke, 1)).toBe(0);
   });
 });
 

--- a/packages/core/src/shape/arrow.ts
+++ b/packages/core/src/shape/arrow.ts
@@ -40,6 +40,13 @@ export function lineEndRetract(arrowEnd: ArrowEnd, stroke: Stroke, scale: number
   return arrowGeom(arrowEnd, stroke, scale).len;
 }
 
+/** Conservative radius around a line-end tip occupied by its painted pixels. */
+export function lineEndPaintExtent(arrowEnd: ArrowEnd, stroke: Stroke, scale: number): number {
+  if (arrowEnd.type === 'none') return 0;
+  const { lw, halfW, len } = arrowGeom(arrowEnd, stroke, scale);
+  return Math.max(len, halfW) + lw / 2;
+}
+
 /**
  * Pull `p` toward its neighbour `toward` by `amount` px, clamped so it never
  * passes the neighbour. Used to retract a polyline's terminal vertex before

--- a/packages/core/src/shape/custGeom.test.ts
+++ b/packages/core/src/shape/custGeom.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { PathCmd } from '../types/common';
-import { buildCustomPath } from './custGeom';
+import { buildCustomPath, getCustomGeometryBounds } from './custGeom';
 
 /**
  * Records the canvas calls `buildCustomPath` makes so we can assert on the arc
@@ -98,5 +98,36 @@ describe('buildCustomPath — arcTo', () => {
     // start/end (indices 5,6) are derived from the missing angles → NaN.
     expect(Number.isNaN(ellipseCalls[0][5])).toBe(true);
     expect(Number.isNaN(ellipseCalls[0][6])).toBe(true);
+  });
+});
+
+describe('getCustomGeometryBounds', () => {
+  it('includes vertices and Bézier control points outside the nominal shape rect', () => {
+    const paths: PathCmd[][] = [[
+      { cmd: 'moveTo', x: -0.25, y: 0.5 },
+      {
+        cmd: 'cubicBezTo',
+        x1: 0.2,
+        y1: -0.5,
+        x2: 0.8,
+        y2: 1.5,
+        x: 1.25,
+        y: 0.5,
+      },
+    ]];
+
+    expect(getCustomGeometryBounds(paths, 100, 200, 200, 100)).toEqual({
+      x: 50,
+      y: 150,
+      w: 300,
+      h: 200,
+    });
+  });
+
+  it('conservatively includes the complete ellipse used by arcTo', () => {
+    expect(getCustomGeometryBounds([[
+      { cmd: 'moveTo', x: 1, y: 0.5 },
+      { cmd: 'arcTo', wr: 0.75, hr: 0.5, stAng: 0, swAng: 90 },
+    ]], 10, 20, 100, 200)).toEqual({ x: -40, y: 20, w: 150, h: 200 });
   });
 });

--- a/packages/core/src/shape/custGeom.ts
+++ b/packages/core/src/shape/custGeom.ts
@@ -1,5 +1,84 @@
 import type { PathCmd } from '../types/common';
 
+export interface CustomGeometryBounds {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * Conservative canvas-space bounds of normalized DrawingML custom geometry.
+ *
+ * CT_Path2D coordinates may be negative or exceed the path coordinate system,
+ * so an `<a:xfrm>` rectangle is not a safe effect crop. Control points and the
+ * complete ellipse behind an arc are included deliberately: that can
+ * overestimate exact curve extrema, but never clips valid paint.
+ */
+export function getCustomGeometryBounds(
+  subpaths: readonly (readonly PathCmd[])[],
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): CustomGeometryBounds | null {
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  const include = (px: number, py: number) => {
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return;
+    minX = Math.min(minX, px);
+    minY = Math.min(minY, py);
+    maxX = Math.max(maxX, px);
+    maxY = Math.max(maxY, py);
+  };
+
+  for (const commands of subpaths) {
+    let penX = 0;
+    let penY = 0;
+    for (const command of commands) {
+      switch (command.cmd) {
+        case 'moveTo':
+        case 'lineTo':
+          penX = command.x;
+          penY = command.y;
+          include(x + penX * w, y + penY * h);
+          break;
+        case 'cubicBezTo':
+          include(x + command.x1 * w, y + command.y1 * h);
+          include(x + command.x2 * w, y + command.y2 * h);
+          penX = command.x;
+          penY = command.y;
+          include(x + penX * w, y + penY * h);
+          break;
+        case 'arcTo': {
+          const radiusX = Math.abs(command.wr * w);
+          const radiusY = Math.abs(command.hr * h);
+          if (radiusX <= 0 || radiusY <= 0) break;
+          const start = command.stAng * Math.PI / 180;
+          const sweep = command.swAng * Math.PI / 180;
+          const penAbsX = x + penX * w;
+          const penAbsY = y + penY * h;
+          const centerX = penAbsX - radiusX * Math.cos(start);
+          const centerY = penAbsY - radiusY * Math.sin(start);
+          include(centerX - radiusX, centerY - radiusY);
+          include(centerX + radiusX, centerY + radiusY);
+          const end = start + sweep;
+          penX = (centerX + radiusX * Math.cos(end) - x) / w;
+          penY = (centerY + radiusY * Math.sin(end) - y) / h;
+          break;
+        }
+        case 'close':
+          break;
+      }
+    }
+  }
+
+  if (!Number.isFinite(minX)) return null;
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+}
+
 /**
  * Build a canvas path from normalised custGeom sub-paths.
  * Coordinates in each PathCmd are in [0,1] relative to the shape bounding box;

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -40,9 +40,11 @@ import {
   buildPresetGeometryPath,
   buildPresetGeometryFillPath,
   getPresetGeometryBounds,
+  getCustomGeometryBounds,
   getConnectorAnchors,
   getCustGeomEndpoints,
   drawArrowHead,
+  lineEndPaintExtent,
   lineEndRetract,
   retractLineEndpoint,
   computeScene3dQuad,
@@ -2788,17 +2790,38 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
   const needsRasterEffectBounds = Boolean(
     el.shadow || el.reflection || el.softEdge || el.innerShadow,
   );
-  const adjustedGeometryBounds = usePresetEngine && needsRasterEffectBounds
-    ? getPresetGeometryBounds(
-        geom,
-        x,
-        y,
-        w,
-        h,
-        [el.adj, el.adj2, el.adj3, el.adj4, el.adj5, el.adj6, el.adj7, el.adj8],
-      )
+  const adjustedGeometryBounds = needsRasterEffectBounds
+    ? usePresetEngine
+      ? getPresetGeometryBounds(
+          geom,
+          x,
+          y,
+          w,
+          h,
+          [el.adj, el.adj2, el.adj3, el.adj4, el.adj5, el.adj6, el.adj7, el.adj8],
+        )
+      : el.custGeom && el.custGeom.length > 0
+        ? getCustomGeometryBounds(el.custGeom, x, y, w, h)
+        : null
     : null;
-  const effectBounds = adjustedGeometryBounds ?? { x, y, w, h };
+  const geometryBounds = adjustedGeometryBounds ?? { x, y, w, h };
+  const strokeHalf = el.stroke ? el.stroke.width * scale / 2 : 0;
+  const lineEndExtent = el.stroke
+    ? Math.max(
+        el.stroke.headEnd ? lineEndPaintExtent(el.stroke.headEnd, el.stroke, scale) : 0,
+        el.stroke.tailEnd ? lineEndPaintExtent(el.stroke.tailEnd, el.stroke, scale) : 0,
+      )
+    : 0;
+  const contourExtent = el.sp3d?.contourW ? el.sp3d.contourW * scale : 0;
+  const paintedPad = Math.max(strokeHalf, lineEndExtent, contourExtent);
+  const effectBounds = paintedPad > 0
+    ? {
+        x: geometryBounds.x - paintedPad,
+        y: geometryBounds.y - paintedPad,
+        w: geometryBounds.w + paintedPad * 2,
+        h: geometryBounds.h + paintedPad * 2,
+      }
+    : geometryBounds;
   const effBBox = transformedEffectBounds(
     liveTransform,
     effectBounds.x,
@@ -2820,6 +2843,102 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
       )
     : [];
   const flatBevelEdgePadCss = (el.stroke ? (el.stroke.width * scale) / 2 : 0) + 2;
+  const paintLineDecorations = (target: CanvasRenderingContext2D): void => {
+    if (el.stroke && (CONNECTOR_GEOMS.has(geom) || CALLOUT_GEOMS.has(geom))) {
+      // The preset body deliberately suppresses retractable leader strokes. Paint
+      // the shortened leader and its line ends into the same target as the body
+      // so outer shadows, reflections and soft edges see one composed object.
+      const anchors = getConnectorAnchors(
+        geom,
+        x,
+        y,
+        w,
+        h,
+        [el.adj, el.adj2, el.adj3, el.adj4, el.adj5, el.adj6, el.adj7, el.adj8],
+      );
+      if (!anchors) return;
+      const cmpd = el.stroke.cmpd;
+      const isStraight = geom === 'line' || geom === 'straightconnector1';
+      if (isRetractableLeader(geom) && anchors.vertices.length >= 2 && !(cmpd && isStraight)) {
+        const pts = anchors.vertices.map((v) => ({ x: v.x, y: v.y }));
+        if (el.stroke.tailEnd) {
+          const retract = lineEndRetract(el.stroke.tailEnd, el.stroke, scale);
+          pts[pts.length - 1] = retractLineEndpoint(
+            pts[pts.length - 1],
+            pts[pts.length - 2],
+            retract,
+          );
+        }
+        if (el.stroke.headEnd) {
+          const retract = lineEndRetract(el.stroke.headEnd, el.stroke, scale);
+          pts[0] = retractLineEndpoint(pts[0], pts[1], retract);
+        }
+        applyStroke(target, el.stroke, scale);
+        target.beginPath();
+        target.moveTo(pts[0].x, pts[0].y);
+        for (let i = 1; i < pts.length; i++) target.lineTo(pts[i].x, pts[i].y);
+        target.stroke();
+      }
+      if (cmpd && isStraight) {
+        drawCompoundLine(target, anchors.start, anchors.end, el.stroke, cmpd, scale);
+      }
+      if (el.stroke.tailEnd) {
+        drawArrowHead(
+          target,
+          anchors.end.x,
+          anchors.end.y,
+          anchors.end.angle,
+          el.stroke.tailEnd,
+          el.stroke,
+          scale,
+        );
+      }
+      if (el.stroke.headEnd) {
+        drawArrowHead(
+          target,
+          anchors.start.x,
+          anchors.start.y,
+          anchors.start.angle,
+          el.stroke.headEnd,
+          el.stroke,
+          scale,
+        );
+      }
+      return;
+    }
+
+    if (
+      !el.stroke ||
+      !el.custGeom ||
+      el.custGeom.length === 0 ||
+      ((!el.stroke.headEnd || el.stroke.headEnd.type === 'none') &&
+        (!el.stroke.tailEnd || el.stroke.tailEnd.type === 'none'))
+    ) return;
+
+    const { start, end } = getCustGeomEndpoints(el.custGeom);
+    if (start && el.stroke.headEnd && el.stroke.headEnd.type !== 'none') {
+      drawArrowHead(
+        target,
+        x + start.x * w,
+        y + start.y * h,
+        Math.atan2(start.dy * h, start.dx * w),
+        el.stroke.headEnd,
+        el.stroke,
+        scale,
+      );
+    }
+    if (end && el.stroke.tailEnd && el.stroke.tailEnd.type !== 'none') {
+      drawArrowHead(
+        target,
+        x + end.x * w,
+        y + end.y * h,
+        Math.atan2(end.dy * h, end.dx * w),
+        el.stroke.tailEnd,
+        el.stroke,
+        scale,
+      );
+    }
+  };
   const paintVisibleShapeBody = (target: CanvasRenderingContext2D): void => {
     if (flatBevels.length > 0) {
       const ok = paintBeveledFlat(
@@ -2835,11 +2954,13 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
         flatBevelEdgePadCss,
       );
       if (ok) {
+        paintLineDecorations(target);
         clearShadow(target);
         return;
       }
     }
     paintShapeBody(target);
+    paintLineDecorations(target);
   };
   const applyLiveTransform = (c: CanvasRenderingContext2D) => {
     c.setTransform(liveTransform);
@@ -2897,8 +3018,9 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     applySoftEdge(
       ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintVisibleShapeBody(c as CanvasRenderingContext2D); },
       effBBox, el.softEdge, effScale, deviceW, deviceH,
-      // Mask is the flat filled silhouette (no stroke) — see applySoftEdge.
-      (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintShapeBody(c as CanvasRenderingContext2D, '#000'); },
+      // Reuse the composed body so line-end decorations participate in the
+      // feather mask as well as the colour layer.
+      (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintVisibleShapeBody(c as CanvasRenderingContext2D); },
     );
     ctx.restore();
   } else {
@@ -2918,86 +3040,6 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
       effBBox, el.innerShadow, effScale, deviceW, deviceH,
     );
     ctx.restore();
-  }
-
-  if (el.stroke && (CONNECTOR_GEOMS.has(geom) || CALLOUT_GEOMS.has(geom))) {
-    // Connectors and callouts both decorate a *leader line* whose two ends +
-    // outward tangents are resolved by getConnectorAnchors from the geometry's
-    // last `<path>` (presets.json). For a connector that is the line itself;
-    // for a callout it is the attach→tip leader (callout1 straight, callout2/3
-    // polyline). headEnd sits on the attach end, tailEnd on the tip — exactly
-    // as the `m … l …` order of the preset's leader path dictates.
-    const anchors = getConnectorAnchors(geom, x, y, w, h, [el.adj, el.adj2, el.adj3, el.adj4, el.adj5, el.adj6, el.adj7, el.adj8]);
-    if (anchors) {
-      // ECMA-376 §20.1.8.42 — compound line styles. For straight lines /
-      // connectors we re-stroke the segment with multiple parallel lines
-      // along the perpendicular of the line direction. Curved connectors and
-      // callout leaders fall through to the single-stroke fast path (parallel
-      // curves / polylines are a non-trivial geometric operation).
-      const cmpd = el.stroke.cmpd;
-      const isStraight = geom === 'line' || geom === 'straightconnector1';
-      // Retractable leaders (callout / straight / bent connector): paintShapeBody
-      // suppressed the preset leader stroke, so re-stroke the polyline here with
-      // each decorated end pulled back by the decoration's length, so the line
-      // stops at the arrow base instead of poking through its tip (PowerPoint
-      // behaviour). Filled ends (triangle/stealth/diamond/oval) retract; open
-      // `arrow` / `none` do not (lineEndRetract → 0). A compound straight segment
-      // is drawn by drawCompoundLine below instead, so skip the retract there.
-      if (isRetractableLeader(geom) && anchors.vertices.length >= 2 && !(cmpd && isStraight)) {
-        const pts = anchors.vertices.map((v) => ({ x: v.x, y: v.y }));
-        if (el.stroke.tailEnd) {
-          const r = lineEndRetract(el.stroke.tailEnd, el.stroke, scale);
-          pts[pts.length - 1] = retractLineEndpoint(pts[pts.length - 1], pts[pts.length - 2], r);
-        }
-        if (el.stroke.headEnd) {
-          const r = lineEndRetract(el.stroke.headEnd, el.stroke, scale);
-          pts[0] = retractLineEndpoint(pts[0], pts[1], r);
-        }
-        applyStroke(ctx, el.stroke, scale);
-        ctx.beginPath();
-        ctx.moveTo(pts[0].x, pts[0].y);
-        for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
-        ctx.stroke();
-      }
-      if (cmpd && isStraight) {
-        drawCompoundLine(ctx, anchors.start, anchors.end, el.stroke, cmpd, scale);
-      }
-      if (el.stroke.tailEnd) {
-        drawArrowHead(ctx, anchors.end.x, anchors.end.y, anchors.end.angle, el.stroke.tailEnd, el.stroke, scale);
-      }
-      if (el.stroke.headEnd) {
-        drawArrowHead(ctx, anchors.start.x, anchors.start.y, anchors.start.angle, el.stroke.headEnd, el.stroke, scale);
-      }
-    }
-  } else if (
-    el.stroke &&
-    el.custGeom &&
-    el.custGeom.length > 0 &&
-    ((el.stroke.headEnd && el.stroke.headEnd.type !== 'none') ||
-      (el.stroke.tailEnd && el.stroke.tailEnd.type !== 'none'))
-  ) {
-    // Freeform / curve (custGeom) lines also carry `<a:ln><a:headEnd|tailEnd>`.
-    // The connector/callout branches above only cover preset geometries, so a
-    // custGeom path's arrow heads were dropped. Extract the open path's two
-    // terminal points + outward tangents and decorate them like a connector.
-    // Endpoints on a *closed* sub-path are returned as null (PowerPoint draws no
-    // line-end decoration on a closed contour).
-    const { start, end } = getCustGeomEndpoints(el.custGeom);
-    // The endpoint tangent is expressed in normalised (0..1) space; convert to
-    // device space accounting for anisotropic scaling (w ≠ h) before atan2 so
-    // the arrow head orientation is correct on non-square boxes.
-    if (start && el.stroke.headEnd && el.stroke.headEnd.type !== 'none') {
-      const sx = x + start.x * w;
-      const sy = y + start.y * h;
-      const sAngle = Math.atan2(start.dy * h, start.dx * w);
-      drawArrowHead(ctx, sx, sy, sAngle, el.stroke.headEnd, el.stroke, scale);
-    }
-    if (end && el.stroke.tailEnd && el.stroke.tailEnd.type !== 'none') {
-      const ex = x + end.x * w;
-      const ey = y + end.y * h;
-      const eAngle = Math.atan2(end.dy * h, end.dx * w);
-      drawArrowHead(ctx, ex, ey, eAngle, el.stroke.tailEnd, el.stroke, scale);
-    }
   }
 
   // Render text inside the rotation context so text follows shape rotation
@@ -5080,10 +5122,42 @@ async function renderPicture(
       liveTransform.a * liveTransform.d - liveTransform.b * liveTransform.c,
     );
     const devScale = det > 0 ? Math.sqrt(det) : 1;
-    const effBBox = { x: x * devScale, y: y * devScale, w: w * devScale, h: h * devScale };
+    const paintedPad = strokeHalfCss + contourCss;
+    const effBBox = transformedEffectBounds(
+      liveTransform,
+      x - paintedPad,
+      y - paintedPad,
+      w + paintedPad * 2,
+      h + paintedPad * 2,
+    );
     const effScale = scale * devScale; // EMU → device px
     const applyLiveTransform = (c: CanvasRenderingContext2D) => c.setTransform(liveTransform);
     const haveAux = deviceW > 0 && deviceH > 0;
+
+    // Cast one shadow from the composed picture (bitmap + border + contour).
+    // Native canvas shadow state would cast once for each of those paint calls,
+    // producing stacked shadows and using the pre-transform rectangle as crop.
+    let nativeShadowFallback = false;
+    if (el.shadow && haveAux) {
+      ctx.save();
+      ctx.setTransform(new DOMMatrix());
+      const painted = applyOuterShadow(
+        ctx,
+        (c) => {
+          applyLiveTransform(c as CanvasRenderingContext2D);
+          paintImage(c as CanvasRenderingContext2D);
+        },
+        effBBox,
+        el.shadow,
+        effScale,
+        deviceW,
+        deviceH,
+      );
+      ctx.restore();
+      nativeShadowFallback = !painted;
+    } else if (el.shadow) {
+      nativeShadowFallback = true;
+    }
 
     // Reflection sits below the picture — paint it first. §20.1.8.50. The aux
     // paint bakes in the live rotation/flip via setTransform, so the blit runs
@@ -5099,9 +5173,9 @@ async function renderPicture(
       ctx.restore();
     }
 
-    // outerShdw / glow use the single Canvas shadow slot, cast by the image's
-    // own opaque pixels. Outer shadow wins when both are present (as in p:sp).
-    if (el.shadow) applyShadow(ctx, el.shadow, scale);
+    // Glow remains a native fallback effect. Outer shadow wins when both are
+    // present, matching the shape path's precedence.
+    if (nativeShadowFallback) applyShadow(ctx, el.shadow ?? null, scale);
     else if (el.glow) applyGlow(ctx, el.glow, scale);
 
     // softEdge feathers the whole picture, REPLACING the direct body paint
@@ -5120,7 +5194,7 @@ async function renderPicture(
     } else {
       paintImage(ctx);
     }
-    if (el.shadow || el.glow) clearShadow(ctx);
+    if (nativeShadowFallback || el.glow) clearShadow(ctx);
 
     // innerShdw casts inward, on top of the picture (§20.1.8.40).
     if (el.innerShadow && haveAux) {

--- a/packages/pptx/src/shape-effect-line-decoration.test.ts
+++ b/packages/pptx/src/shape-effect-line-decoration.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderSlide } from './renderer';
+import type { ShapeElement, Slide } from './types';
+
+interface RecordedContext {
+  fills: number;
+  strokes: number;
+}
+
+function contextFor(
+  canvas: { width: number; height: number },
+  recorded: RecordedContext = { fills: 0, strokes: 0 },
+): CanvasRenderingContext2D {
+  const state: Record<string, unknown> = {
+    canvas,
+    getTransform: () => ({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 }),
+    measureText: (text: string) => ({ width: text.length * 6 }),
+    fill: () => { recorded.fills += 1; },
+    stroke: () => { recorded.strokes += 1; },
+  };
+  return new Proxy(state, {
+    get(target, property, receiver) {
+      if (property in target) return Reflect.get(target, property, receiver);
+      return () => undefined;
+    },
+    set(target, property, value, receiver) {
+      return Reflect.set(target, property, value, receiver);
+    },
+  }) as unknown as CanvasRenderingContext2D;
+}
+
+class TestOffscreenCanvas {
+  readonly recorded: RecordedContext = { fills: 0, strokes: 0 };
+  readonly context: CanvasRenderingContext2D;
+
+  constructor(public width: number, public height: number) {
+    this.context = contextFor(this, this.recorded);
+  }
+
+  getContext(): CanvasRenderingContext2D {
+    return this.context;
+  }
+}
+
+function shadowedArrow(): ShapeElement {
+  return {
+    type: 'shape',
+    x: 914_400,
+    y: 914_400,
+    width: 2_743_200,
+    height: 914_400,
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+    geometry: 'line',
+    fill: null,
+    stroke: {
+      color: '4472C4',
+      width: 63_500,
+      tailEnd: { type: 'triangle', w: 'med', len: 'med' },
+    },
+    textBody: null,
+    defaultTextColor: null,
+    custGeom: null,
+    adj: null,
+    adj2: null,
+    adj3: null,
+    adj4: null,
+    adj5: null,
+    adj6: null,
+    adj7: null,
+    adj8: null,
+    shadow: {
+      color: '000000',
+      alpha: 0.5,
+      blur: 63_500,
+      dist: 50_800,
+      dir: 45,
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('shape raster effects', () => {
+  it('includes a connector leader and arrowhead in the outer-shadow silhouette', async () => {
+    const created: TestOffscreenCanvas[] = [];
+    vi.stubGlobal('DOMMatrix', class {
+      a = 1;
+      b = 0;
+      c = 0;
+      d = 1;
+      e = 0;
+      f = 0;
+    });
+    vi.stubGlobal('OffscreenCanvas', class extends TestOffscreenCanvas {
+      constructor(width: number, height: number) {
+        super(width, height);
+        created.push(this);
+      }
+    });
+
+    const canvas = {
+      width: 960,
+      height: 540,
+      style: {} as CSSStyleDeclaration,
+      offsetWidth: 960,
+    } as HTMLCanvasElement;
+    canvas.getContext = (() => contextFor(canvas)) as unknown as HTMLCanvasElement['getContext'];
+    const slide: Slide = {
+      index: 0,
+      slideNumber: 1,
+      background: null,
+      elements: [shadowedArrow()],
+    };
+
+    await renderSlide(canvas, slide, 9_144_000, 6_858_000, { width: 960, dpr: 1 });
+
+    expect(created).toHaveLength(1);
+    expect(created[0].recorded.strokes).toBeGreaterThan(0);
+    expect(created[0].recorded.fills).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- include custom geometry, strokes, contours, leaders, and line ends in raster-effect bounds
- paint connector/callout decorations into the same shadow, reflection, and soft-edge silhouette as the shape body
- compose picture outer shadows once from the bitmap, border, and contour after the active transform

## Rationale
DrawingML raster effects apply to the composed object. Previously, some visible paint was added after effect composition or shadowed once per canvas paint operation, which could clip effects or produce uneven shadows. Conservative bounds calculation is shared in core; PPTX-specific sequencing remains in the PPTX renderer.

## Verification
- focused core/PPTX effect tests (37 tests)
- Scope: 3 of 9 workspace projects
packages/markdown typecheck$ tsc --noEmit -p tsconfig.typecheck.json
packages/node typecheck$ tsc --noEmit -p tsconfig.typecheck.json
packages/vscode-extension typecheck$ tsc --noEmit
packages/markdown typecheck: Done
packages/vscode-extension typecheck: Done
packages/node typecheck: Done
- 