### PR TITLE
refactor(drawingml): share custom geometry parsing

### DIFF
--- a/packages/core/src/shape/custGeom.test.ts
+++ b/packages/core/src/shape/custGeom.test.ts
@@ -124,10 +124,35 @@ describe('getCustomGeometryBounds', () => {
     });
   });
 
+  it('includes a quadratic control point outside the nominal shape rect', () => {
+    expect(getCustomGeometryBounds([[
+      { cmd: 'moveTo', x: 0, y: 0 },
+      { cmd: 'quadBezTo', x1: 0.5, y1: -1, x: 1, y: 0 },
+    ]], 10, 20, 100, 50)).toEqual({ x: 10, y: -30, w: 100, h: 50 });
+  });
+
   it('conservatively includes the complete ellipse used by arcTo', () => {
     expect(getCustomGeometryBounds([[
       { cmd: 'moveTo', x: 1, y: 0.5 },
       { cmd: 'arcTo', wr: 0.75, hr: 0.5, stAng: 0, swAng: 90 },
     ]], 10, 20, 100, 200)).toEqual({ x: -40, y: 20, w: 150, h: 200 });
+  });
+});
+
+describe('buildCustomPath — quadBezTo', () => {
+  it('maps the control point and endpoint into the shape rectangle', () => {
+    const calls: unknown[][] = [];
+    const ctx = new Proxy({} as CanvasRenderingContext2D, {
+      get(_target, property) {
+        return (...args: unknown[]) => calls.push([property, ...args]);
+      },
+    });
+
+    buildCustomPath(ctx, [[
+      { cmd: 'moveTo', x: 0, y: 0 },
+      { cmd: 'quadBezTo', x1: 0.5, y1: 0.25, x: 1, y: 1 },
+    ]], 10, 20, 100, 200);
+
+    expect(calls).toContainEqual(['quadraticCurveTo', 60, 70, 110, 220]);
   });
 });

--- a/packages/core/src/shape/custGeom.ts
+++ b/packages/core/src/shape/custGeom.ts
@@ -52,6 +52,12 @@ export function getCustomGeometryBounds(
           penY = command.y;
           include(x + penX * w, y + penY * h);
           break;
+        case 'quadBezTo':
+          include(x + command.x1 * w, y + command.y1 * h);
+          penX = command.x;
+          penY = command.y;
+          include(x + penX * w, y + penY * h);
+          break;
         case 'arcTo': {
           const radiusX = Math.abs(command.wr * w);
           const radiusY = Math.abs(command.hr * h);
@@ -113,6 +119,15 @@ export function buildCustomPath(
             x + cmd.x1 * w, y + cmd.y1 * h,
             x + cmd.x2 * w, y + cmd.y2 * h,
             x + cmd.x  * w, y + cmd.y  * h,
+          );
+          penX = cmd.x; penY = cmd.y;
+          break;
+        case 'quadBezTo':
+          ctx.quadraticCurveTo(
+            x + cmd.x1 * w,
+            y + cmd.y1 * h,
+            x + cmd.x * w,
+            y + cmd.y * h,
           );
           penX = cmd.x; penY = cmd.y;
           break;

--- a/packages/core/src/shape/custgeom-endpoints.ts
+++ b/packages/core/src/shape/custgeom-endpoints.ts
@@ -38,7 +38,8 @@ export interface CustGeomEndpoints {
 const EPS = 1e-9;
 
 function isDrawCmd(cmd: PathCmd): boolean {
-  return cmd.cmd === 'lineTo' || cmd.cmd === 'cubicBezTo' || cmd.cmd === 'arcTo';
+  return cmd.cmd === 'lineTo' || cmd.cmd === 'cubicBezTo' ||
+    cmd.cmd === 'quadBezTo' || cmd.cmd === 'arcTo';
 }
 
 function makeEndpoint(x: number, y: number, dx: number, dy: number): CustGeomEndpoint {
@@ -77,6 +78,15 @@ function startForwardTangent(
       }
       return { dx, dy };
     }
+    case 'quadBezTo': {
+      let dx = cmd.x1 - penX;
+      let dy = cmd.y1 - penY;
+      if (Math.abs(dx) < EPS && Math.abs(dy) < EPS) {
+        dx = cmd.x - penX;
+        dy = cmd.y - penY;
+      }
+      return { dx, dy };
+    }
     case 'arcTo': {
       // Ellipse: P(t) = (cx + wr cos t, cy + hr sin t), with the pen at t=stAng
       // (matches buildCustomPath). Tangent dP/dt = (-wr sin t, hr cos t); for
@@ -106,6 +116,7 @@ function advancePen(px: number, py: number, cmd: PathCmd): { x: number; y: numbe
     case 'moveTo':
     case 'lineTo':
     case 'cubicBezTo':
+    case 'quadBezTo':
       return { x: cmd.x, y: cmd.y };
     case 'arcTo': {
       // Same degenerate guard as buildCustomPath (`rw<=0 || rh<=0`, with w,h>0
@@ -150,6 +161,15 @@ function endForwardTangent(
       }
       if (Math.abs(dx) < EPS && Math.abs(dy) < EPS) {
         // Fully degenerate → chord from the previous point to the end.
+        dx = cmd.x - prevX;
+        dy = cmd.y - prevY;
+      }
+      return { dx, dy, x, y };
+    }
+    case 'quadBezTo': {
+      let dx = cmd.x - cmd.x1;
+      let dy = cmd.y - cmd.y1;
+      if (Math.abs(dx) < EPS && Math.abs(dy) < EPS) {
         dx = cmd.x - prevX;
         dy = cmd.y - prevY;
       }

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -8,6 +8,7 @@ export type PathCmd =
   | { cmd: 'moveTo';     x: number; y: number }
   | { cmd: 'lineTo';     x: number; y: number }
   | { cmd: 'cubicBezTo'; x1: number; y1: number; x2: number; y2: number; x: number; y: number }
+  | { cmd: 'quadBezTo';  x1: number; y1: number; x: number; y: number }
   | { cmd: 'arcTo';      wr: number; hr: number; stAng: number; swAng: number }
   | { cmd: 'close' };
 

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -1139,6 +1139,12 @@ export type PathCmd = {
     x: number;
     y: number;
 } | {
+    cmd: 'quadBezTo';
+    x1: number;
+    y1: number;
+    x: number;
+    y: number;
+} | {
     cmd: 'arcTo';
     wr: number;
     hr: number;

--- a/packages/docx/parser/src/parser.rs
+++ b/packages/docx/parser/src/parser.rs
@@ -8862,7 +8862,7 @@ fn parse_wsp_shape(
         .children()
         .find(|n| n.is_element() && n.tag_name().name() == "custGeom");
     let (subpaths, preset_geometry, adj_values) = if let Some(cg) = cust_geom {
-        (parse_custom_geometry(cg), None, Vec::new())
+        (parse_custom_geometry(cg, cx, cy), None, Vec::new())
     } else {
         // Defer prstGeom rendering to core's buildShapePath. Carry the preset
         // name + adjustment values so the renderer can call into the shared
@@ -11352,101 +11352,67 @@ fn parse_grad_fill_phclr(
 
 /// Parse <a:custGeom><a:pathLst><a:path w="W" h="H">...</a:path></a:pathLst>.
 /// Path coords inside each <a:path> are absolute within W×H; normalize to [0,1].
-fn parse_custom_geometry(cust_geom: roxmltree::Node) -> Vec<Vec<PathCmd>> {
-    let Some(path_lst) = cust_geom
-        .children()
-        .find(|n| n.is_element() && n.tag_name().name() == "pathLst")
-    else {
-        return vec![];
-    };
-    let mut subpaths: Vec<Vec<PathCmd>> = Vec::new();
-    for path in path_lst
-        .children()
-        .filter(|n| n.is_element() && n.tag_name().name() == "path")
-    {
-        let pw = path
-            .attribute("w")
-            .and_then(|v| v.parse::<f64>().ok())
-            .unwrap_or(0.0);
-        let ph = path
-            .attribute("h")
-            .and_then(|v| v.parse::<f64>().ok())
-            .unwrap_or(0.0);
-        if pw <= 0.0 || ph <= 0.0 {
-            continue;
-        }
-        let mut cmds: Vec<PathCmd> = Vec::new();
-        for cmd in path.children().filter(|n| n.is_element()) {
-            let name = cmd.tag_name().name();
-            let pts: Vec<(f64, f64)> = cmd
-                .children()
-                .filter(|n| n.is_element() && n.tag_name().name() == "pt")
-                .filter_map(|p| {
-                    let x = p.attribute("x").and_then(|v| v.parse::<f64>().ok())?;
-                    let y = p.attribute("y").and_then(|v| v.parse::<f64>().ok())?;
-                    Some((x / pw, y / ph))
-                })
-                .collect();
-            match name {
-                "moveTo" => {
-                    if let Some(p) = pts.first() {
-                        cmds.push(PathCmd::MoveTo { x: p.0, y: p.1 });
-                    }
-                }
-                "lnTo" => {
-                    if let Some(p) = pts.first() {
-                        cmds.push(PathCmd::LineTo { x: p.0, y: p.1 });
-                    }
-                }
-                "cubicBezTo" => {
-                    if pts.len() >= 3 {
-                        cmds.push(PathCmd::CubicBezTo {
-                            x1: pts[0].0,
-                            y1: pts[0].1,
-                            x2: pts[1].0,
-                            y2: pts[1].1,
-                            x: pts[2].0,
-                            y: pts[2].1,
-                        });
-                    }
-                }
-                "arcTo" => {
-                    let wr = cmd
-                        .attribute("wR")
-                        .and_then(|v| v.parse::<f64>().ok())
-                        .unwrap_or(0.0)
-                        / pw;
-                    let hr = cmd
-                        .attribute("hR")
-                        .and_then(|v| v.parse::<f64>().ok())
-                        .unwrap_or(0.0)
-                        / ph;
-                    let st_ang = cmd
-                        .attribute("stAng")
-                        .and_then(|v| v.parse::<f64>().ok())
-                        .unwrap_or(0.0)
-                        / 60000.0;
-                    let sw_ang = cmd
-                        .attribute("swAng")
-                        .and_then(|v| v.parse::<f64>().ok())
-                        .unwrap_or(0.0)
-                        / 60000.0;
-                    cmds.push(PathCmd::ArcTo {
+fn parse_custom_geometry(
+    cust_geom: roxmltree::Node,
+    shape_width: f64,
+    shape_height: f64,
+) -> Vec<Vec<PathCmd>> {
+    use ooxml_common::custom_geometry::{parse_custom_geometry as parse_shared, PathCommand};
+
+    parse_shared(cust_geom, shape_width, shape_height)
+        .paths
+        .into_iter()
+        .filter_map(|path| {
+            let commands: Vec<PathCmd> = path
+                .commands
+                .into_iter()
+                .map(|command| match command {
+                    PathCommand::MoveTo { x, y } => PathCmd::MoveTo {
+                        x: x / path.width,
+                        y: y / path.height,
+                    },
+                    PathCommand::LineTo { x, y } => PathCmd::LineTo {
+                        x: x / path.width,
+                        y: y / path.height,
+                    },
+                    PathCommand::CubicBezierTo {
+                        x1,
+                        y1,
+                        x2,
+                        y2,
+                        x,
+                        y,
+                    } => PathCmd::CubicBezTo {
+                        x1: x1 / path.width,
+                        y1: y1 / path.height,
+                        x2: x2 / path.width,
+                        y2: y2 / path.height,
+                        x: x / path.width,
+                        y: y / path.height,
+                    },
+                    PathCommand::QuadraticBezierTo { x1, y1, x, y } => PathCmd::QuadBezTo {
+                        x1: x1 / path.width,
+                        y1: y1 / path.height,
+                        x: x / path.width,
+                        y: y / path.height,
+                    },
+                    PathCommand::ArcTo {
                         wr,
                         hr,
                         st_ang,
                         sw_ang,
-                    });
-                }
-                "close" => cmds.push(PathCmd::Close),
-                _ => {}
-            }
-        }
-        if !cmds.is_empty() {
-            subpaths.push(cmds);
-        }
-    }
-    subpaths
+                    } => PathCmd::ArcTo {
+                        wr: wr / path.width,
+                        hr: hr / path.height,
+                        st_ang: st_ang / 60000.0,
+                        sw_ang: sw_ang / 60000.0,
+                    },
+                    PathCommand::Close => PathCmd::Close,
+                })
+                .collect();
+            (!commands.is_empty()).then_some(commands)
+        })
+        .collect()
 }
 
 /// Resolve a color container (e.g. <a:solidFill>, <a:gs>) into a hex string by
@@ -18347,7 +18313,7 @@ mod svg_blip_tests {
   </a:pathLst>
 </a:custGeom>"#;
         let doc = roxmltree::Document::parse(xml).unwrap();
-        let subpaths = parse_custom_geometry(doc.root_element());
+        let subpaths = parse_custom_geometry(doc.root_element(), 100.0, 100.0);
         let json = serde_json::to_string(&subpaths).expect("custGeom should serialize");
 
         // The two camelCase keys the TS renderer reads must be present…
@@ -18385,7 +18351,7 @@ mod svg_blip_tests {
   </a:pathLst>
 </a:custGeom>"#;
         let doc = roxmltree::Document::parse(xml).unwrap();
-        let subpaths = parse_custom_geometry(doc.root_element());
+        let subpaths = parse_custom_geometry(doc.root_element(), 200.0, 100.0);
         let arc = subpaths[0]
             .iter()
             .find(|c| matches!(c, PathCmd::ArcTo { .. }))
@@ -18405,6 +18371,25 @@ mod svg_blip_tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn custom_geometry_resolves_guides_and_quadratic_bezier() {
+        let xml = r#"<a:custGeom xmlns:a="urn:a">
+          <a:gdLst><a:gd name="half" fmla="*/ w 1 2"/></a:gdLst>
+          <a:pathLst><a:path>
+            <a:moveTo><a:pt x="0" y="0"/></a:moveTo>
+            <a:quadBezTo><a:pt x="half" y="b"/><a:pt x="r" y="0"/></a:quadBezTo>
+          </a:path></a:pathLst>
+        </a:custGeom>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let paths = parse_custom_geometry(doc.root_element(), 200.0, 100.0);
+        assert!(matches!(
+            paths[0][1],
+            PathCmd::QuadBezTo { x1, y1, x, y }
+                if (x1 - 0.5).abs() < 1e-9 && (y1 - 1.0).abs() < 1e-9
+                    && (x - 1.0).abs() < 1e-9 && y.abs() < 1e-9
+        ));
     }
 }
 

--- a/packages/docx/parser/src/types.rs
+++ b/packages/docx/parser/src/types.rs
@@ -1804,6 +1804,12 @@ pub enum PathCmd {
         x: f64,
         y: f64,
     },
+    QuadBezTo {
+        x1: f64,
+        y1: f64,
+        x: f64,
+        y: f64,
+    },
     /// Elliptical arc (all angles in degrees).
     ///
     /// The enum-level `#[serde(tag = ..., rename_all = "camelCase")]` renames the

--- a/packages/docx/src/types.ts
+++ b/packages/docx/src/types.ts
@@ -764,6 +764,7 @@ export type PathCmd =
   | { cmd: 'moveTo'; x: number; y: number }
   | { cmd: 'lineTo'; x: number; y: number }
   | { cmd: 'cubicBezTo'; x1: number; y1: number; x2: number; y2: number; x: number; y: number }
+  | { cmd: 'quadBezTo'; x1: number; y1: number; x: number; y: number }
   | { cmd: 'arcTo'; wr: number; hr: number; stAng: number; swAng: number }
   | { cmd: 'close' };
 

--- a/packages/ooxml-common/src/custom_geometry.rs
+++ b/packages/ooxml-common/src/custom_geometry.rs
@@ -1,0 +1,334 @@
+//! Format-agnostic DrawingML custom-geometry grammar.
+//!
+//! ECMA-376 Part 1 §20.1.9 embeds the same `a:custGeom` vocabulary in Word,
+//! Excel, and PowerPoint. This module resolves its ordered guide program and
+//! path commands once; format parsers only adapt the result to their existing
+//! wire models.
+
+use std::collections::HashMap;
+
+const FULL_CIRCLE: f64 = 21_600_000.0;
+const ANGLE_TO_RAD: f64 = std::f64::consts::TAU / FULL_CIRCLE;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CustomGeometry {
+    pub paths: Vec<CustomPath>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CustomPath {
+    /// Effective path coordinate-system width. Omitted/zero `a:path@w` uses
+    /// the containing shape extent as required by the host shape space.
+    pub width: f64,
+    /// Effective path coordinate-system height.
+    pub height: f64,
+    pub commands: Vec<PathCommand>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PathCommand {
+    MoveTo {
+        x: f64,
+        y: f64,
+    },
+    LineTo {
+        x: f64,
+        y: f64,
+    },
+    CubicBezierTo {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        x: f64,
+        y: f64,
+    },
+    QuadraticBezierTo {
+        x1: f64,
+        y1: f64,
+        x: f64,
+        y: f64,
+    },
+    /// Radii are in path coordinates; angles are DrawingML 60000ths of a degree.
+    ArcTo {
+        wr: f64,
+        hr: f64,
+        st_ang: f64,
+        sw_ang: f64,
+    },
+    Close,
+}
+
+fn child<'a, 'input>(
+    node: roxmltree::Node<'a, 'input>,
+    name: &str,
+) -> Option<roxmltree::Node<'a, 'input>> {
+    node.children()
+        .find(|child| child.is_element() && child.tag_name().name() == name)
+}
+
+fn attr_f64(node: roxmltree::Node<'_, '_>, name: &str) -> Option<f64> {
+    let value = node.attribute(name)?.parse::<f64>().ok()?;
+    value.is_finite().then_some(value)
+}
+
+fn resolve(token: &str, env: &HashMap<String, f64>) -> Option<f64> {
+    env.get(token)
+        .copied()
+        .or_else(|| token.parse::<f64>().ok())
+        .filter(|value| value.is_finite())
+}
+
+fn evaluate_formula(formula: &str, env: &HashMap<String, f64>) -> Option<f64> {
+    let mut tokens = formula.split_whitespace();
+    let op = tokens.next()?;
+    let args: Vec<f64> = tokens
+        .map(|token| resolve(token, env))
+        .collect::<Option<_>>()?;
+    let arg = |index: usize| args.get(index).copied();
+    let value = match op {
+        "val" => arg(0)?,
+        "*/" => arg(0)? * arg(1)? / arg(2)?,
+        "+-" => arg(0)? + arg(1)? - arg(2)?,
+        "+/" => (arg(0)? + arg(1)?) / arg(2)?,
+        "?:" => {
+            if arg(0)? > 0.0 {
+                arg(1)?
+            } else {
+                arg(2)?
+            }
+        }
+        "abs" => arg(0)?.abs(),
+        "at2" => arg(1)?.atan2(arg(0)?) / ANGLE_TO_RAD,
+        "cat2" => arg(0)? * arg(2)?.atan2(arg(1)?).cos(),
+        "cos" => arg(0)? * (arg(1)? * ANGLE_TO_RAD).cos(),
+        "max" => arg(0)?.max(arg(1)?),
+        "min" => arg(0)?.min(arg(1)?),
+        "mod" => (arg(0)?.powi(2) + arg(1)?.powi(2) + arg(2)?.powi(2)).sqrt(),
+        "pin" => {
+            let (low, value, high) = (arg(0)?, arg(1)?, arg(2)?);
+            if value < low {
+                low
+            } else if value > high {
+                high
+            } else {
+                value
+            }
+        }
+        "sat2" => arg(0)? * arg(2)?.atan2(arg(1)?).sin(),
+        "sin" => arg(0)? * (arg(1)? * ANGLE_TO_RAD).sin(),
+        "sqrt" => arg(0)?.max(0.0).sqrt(),
+        "tan" => arg(0)? * (arg(1)? * ANGLE_TO_RAD).tan(),
+        _ => return None,
+    };
+    value.is_finite().then_some(value)
+}
+
+fn guide_environment(
+    cust_geom: roxmltree::Node<'_, '_>,
+    shape_width: f64,
+    shape_height: f64,
+) -> HashMap<String, f64> {
+    let first_path = child(cust_geom, "pathLst").and_then(|paths| {
+        paths
+            .children()
+            .find(|node| node.is_element() && node.tag_name().name() == "path")
+    });
+    let width = if shape_width > 0.0 {
+        shape_width
+    } else {
+        first_path
+            .and_then(|path| attr_f64(path, "w"))
+            .unwrap_or(1.0)
+            .max(1.0)
+    };
+    let height = if shape_height > 0.0 {
+        shape_height
+    } else {
+        first_path
+            .and_then(|path| attr_f64(path, "h"))
+            .unwrap_or(1.0)
+            .max(1.0)
+    };
+    let short_side = width.min(height);
+    let long_side = width.max(height);
+    let mut env = HashMap::new();
+
+    macro_rules! builtins {
+        ($($name:expr => $value:expr),* $(,)?) => { $(env.insert($name.to_owned(), $value);)* };
+    }
+    builtins! {
+        "w" => width, "h" => height,
+        "l" => 0.0, "t" => 0.0, "r" => width, "b" => height,
+        "hc" => width / 2.0, "vc" => height / 2.0,
+        "wd2" => width / 2.0, "wd3" => width / 3.0, "wd4" => width / 4.0,
+        "wd5" => width / 5.0, "wd6" => width / 6.0, "wd8" => width / 8.0,
+        "wd10" => width / 10.0, "wd12" => width / 12.0,
+        "wd16" => width / 16.0, "wd32" => width / 32.0,
+        "hd2" => height / 2.0, "hd3" => height / 3.0, "hd4" => height / 4.0,
+        "hd5" => height / 5.0, "hd6" => height / 6.0, "hd8" => height / 8.0,
+        "hd10" => height / 10.0, "hd12" => height / 12.0,
+        "hd16" => height / 16.0, "hd32" => height / 32.0,
+        "ss" => short_side, "ssd2" => short_side / 2.0, "ssd4" => short_side / 4.0,
+        "ssd6" => short_side / 6.0, "ssd8" => short_side / 8.0,
+        "ssd16" => short_side / 16.0, "ssd32" => short_side / 32.0,
+        "ls" => long_side, "lsd2" => long_side / 2.0, "lsd4" => long_side / 4.0,
+        "lsd6" => long_side / 6.0, "lsd8" => long_side / 8.0,
+        "lsd16" => long_side / 16.0, "lsd32" => long_side / 32.0,
+        "cd" => FULL_CIRCLE, "cd2" => FULL_CIRCLE / 2.0,
+        "cd4" => FULL_CIRCLE / 4.0, "cd8" => FULL_CIRCLE / 8.0,
+        "3cd4" => 3.0 * FULL_CIRCLE / 4.0, "3cd8" => 3.0 * FULL_CIRCLE / 8.0,
+        "5cd8" => 5.0 * FULL_CIRCLE / 8.0, "7cd8" => 7.0 * FULL_CIRCLE / 8.0,
+    }
+
+    for list_name in ["avLst", "gdLst"] {
+        let Some(list) = child(cust_geom, list_name) else {
+            continue;
+        };
+        for guide in list
+            .children()
+            .filter(|node| node.is_element() && node.tag_name().name() == "gd")
+        {
+            let (Some(name), Some(formula)) = (guide.attribute("name"), guide.attribute("fmla"))
+            else {
+                continue;
+            };
+            if let Some(value) = evaluate_formula(formula, &env) {
+                env.insert(name.to_owned(), value);
+            }
+        }
+    }
+    env
+}
+
+fn geometry_attr(
+    node: roxmltree::Node<'_, '_>,
+    name: &str,
+    env: &HashMap<String, f64>,
+) -> Option<f64> {
+    resolve(node.attribute(name)?, env)
+}
+
+fn point(node: roxmltree::Node<'_, '_>, env: &HashMap<String, f64>) -> Option<(f64, f64)> {
+    Some((
+        geometry_attr(node, "x", env)?,
+        geometry_attr(node, "y", env)?,
+    ))
+}
+
+fn parse_command(node: roxmltree::Node<'_, '_>, env: &HashMap<String, f64>) -> Option<PathCommand> {
+    let points: Vec<_> = node
+        .children()
+        .filter(|child| child.is_element() && child.tag_name().name() == "pt")
+        .map(|child| point(child, env))
+        .collect::<Option<_>>()?;
+    match node.tag_name().name() {
+        "moveTo" => points.first().map(|&(x, y)| PathCommand::MoveTo { x, y }),
+        "lnTo" => points.first().map(|&(x, y)| PathCommand::LineTo { x, y }),
+        "cubicBezTo" if points.len() >= 3 => Some(PathCommand::CubicBezierTo {
+            x1: points[0].0,
+            y1: points[0].1,
+            x2: points[1].0,
+            y2: points[1].1,
+            x: points[2].0,
+            y: points[2].1,
+        }),
+        "quadBezTo" if points.len() >= 2 => Some(PathCommand::QuadraticBezierTo {
+            x1: points[0].0,
+            y1: points[0].1,
+            x: points[1].0,
+            y: points[1].1,
+        }),
+        "arcTo" => Some(PathCommand::ArcTo {
+            wr: geometry_attr(node, "wR", env).unwrap_or(0.0),
+            hr: geometry_attr(node, "hR", env).unwrap_or(0.0),
+            st_ang: geometry_attr(node, "stAng", env).unwrap_or(0.0),
+            sw_ang: geometry_attr(node, "swAng", env).unwrap_or(0.0),
+        }),
+        "close" => Some(PathCommand::Close),
+        _ => None,
+    }
+}
+
+/// Parse `a:custGeom` according to ECMA-376 Part 1 §20.1.9.
+pub fn parse_custom_geometry(
+    cust_geom: roxmltree::Node<'_, '_>,
+    shape_width: f64,
+    shape_height: f64,
+) -> CustomGeometry {
+    let Some(path_list) = child(cust_geom, "pathLst") else {
+        return CustomGeometry { paths: Vec::new() };
+    };
+    let env = guide_environment(cust_geom, shape_width, shape_height);
+    let paths = path_list
+        .children()
+        .filter(|node| node.is_element() && node.tag_name().name() == "path")
+        .map(|path| {
+            let width = attr_f64(path, "w")
+                .filter(|value| *value > 0.0)
+                .unwrap_or(shape_width.max(1.0));
+            let height = attr_f64(path, "h")
+                .filter(|value| *value > 0.0)
+                .unwrap_or(shape_height.max(1.0));
+            let commands = path
+                .children()
+                .filter(|node| node.is_element())
+                .filter_map(|node| parse_command(node, &env))
+                .collect();
+            CustomPath {
+                width,
+                height,
+                commands,
+            }
+        })
+        .collect();
+    CustomGeometry { paths }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_custom_geometry, PathCommand};
+
+    #[test]
+    fn resolves_ordered_guides_and_quadratic_beziers() {
+        let xml = r#"<a:custGeom xmlns:a="urn:a">
+          <a:gdLst>
+            <a:gd name="quarter" fmla="*/ w 1 4"/>
+            <a:gd name="threeQuarter" fmla="+- w 0 quarter"/>
+          </a:gdLst>
+          <a:pathLst><a:path w="100" h="200">
+            <a:moveTo><a:pt x="quarter" y="0"/></a:moveTo>
+            <a:quadBezTo><a:pt x="hc" y="h"/><a:pt x="threeQuarter" y="0"/></a:quadBezTo>
+          </a:path></a:pathLst>
+        </a:custGeom>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let geometry = parse_custom_geometry(doc.root_element(), 100.0, 200.0);
+        assert_eq!(
+            geometry.paths[0].commands,
+            vec![
+                PathCommand::MoveTo { x: 25.0, y: 0.0 },
+                PathCommand::QuadraticBezierTo {
+                    x1: 50.0,
+                    y1: 200.0,
+                    x: 75.0,
+                    y: 0.0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn omitted_path_size_uses_shape_coordinate_space() {
+        let xml = r#"<custGeom><pathLst><path>
+          <moveTo><pt x="0" y="0"/></moveTo><lnTo><pt x="r" y="b"/></lnTo>
+        </path></pathLst></custGeom>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let geometry = parse_custom_geometry(doc.root_element(), 300.0, 150.0);
+        assert_eq!(geometry.paths[0].width, 300.0);
+        assert_eq!(geometry.paths[0].height, 150.0);
+        assert_eq!(
+            geometry.paths[0].commands[1],
+            PathCommand::LineTo { x: 300.0, y: 150.0 }
+        );
+    }
+}

--- a/packages/ooxml-common/src/lib.rs
+++ b/packages/ooxml-common/src/lib.rs
@@ -11,6 +11,7 @@ pub mod blip;
 pub mod bounded_xml;
 pub mod chart;
 pub mod color;
+pub mod custom_geometry;
 pub mod depth;
 pub mod drawing;
 pub mod fill;

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -651,6 +651,12 @@ export type PathCmd = {
     x: number;
     y: number;
 } | {
+    cmd: 'quadBezTo';
+    x1: number;
+    y1: number;
+    x: number;
+    y: number;
+} | {
     cmd: 'arcTo';
     wr: number;
     hr: number;

--- a/packages/pptx/parser/src/fill.rs
+++ b/packages/pptx/parser/src/fill.rs
@@ -7,7 +7,7 @@
 
 use crate::theme::{theme_relationship_path, PptxSchemeResolver};
 use crate::types::*;
-use crate::{attr, attr_f64, attr_i64, attr_r, child, children_vec, parse_preflighted_pptx_xml};
+use crate::{attr, attr_f64, attr_i64, attr_r, child, parse_preflighted_pptx_xml};
 use ooxml_common::blip::{mime_from_ext, parse_blip_duotone};
 use ooxml_common::color::ThemeResolver;
 use std::collections::HashMap;
@@ -616,247 +616,63 @@ pub(crate) fn parse_sp3d(sppr: roxmltree::Node<'_, '_>) -> Option<Sp3d> {
 //  Custom geometry parsing
 // ===========================
 
-const DRAWINGML_FULL_CIRCLE: f64 = 21_600_000.0;
-const DRAWINGML_ANGLE_TO_RAD: f64 = std::f64::consts::TAU / DRAWINGML_FULL_CIRCLE;
-
-/// Evaluate the ordered guide program carried by `a:custGeom`.
-///
-/// ECMA-376 Part 1 §20.1.9.11 defines 17 prefix operators and requires guides
-/// to be evaluated in document order. Coordinates in `pathLst` may refer to
-/// these names instead of containing numeric literals. Keeping the evaluation
-/// in the parser preserves the compact, normalized `PathCmd` wire model and
-/// avoids repeating formula work on every canvas repaint.
-fn custom_geometry_guides(
-    cust_geom: roxmltree::Node<'_, '_>,
-    shape_w: f64,
-    shape_h: f64,
-) -> HashMap<String, f64> {
-    let first_path = child(cust_geom, "pathLst").and_then(|paths| {
-        paths
-            .children()
-            .find(|node| node.is_element() && node.tag_name().name() == "path")
-    });
-    let w = if shape_w > 0.0 {
-        shape_w
-    } else {
-        first_path
-            .and_then(|path| attr_f64(&path, "w"))
-            .unwrap_or(1.0)
-            .max(1.0)
-    };
-    let h = if shape_h > 0.0 {
-        shape_h
-    } else {
-        first_path
-            .and_then(|path| attr_f64(&path, "h"))
-            .unwrap_or(1.0)
-            .max(1.0)
-    };
-    let ss = w.min(h);
-    let ls = w.max(h);
-    let mut env = HashMap::new();
-
-    macro_rules! builtins {
-        ($($name:expr => $value:expr),* $(,)?) => {
-            $(env.insert($name.to_owned(), $value);)*
-        };
-    }
-    builtins! {
-        "w" => w, "h" => h,
-        "l" => 0.0, "t" => 0.0, "r" => w, "b" => h,
-        "hc" => w / 2.0, "vc" => h / 2.0,
-        "wd2" => w / 2.0, "wd3" => w / 3.0, "wd4" => w / 4.0,
-        "wd5" => w / 5.0, "wd6" => w / 6.0, "wd8" => w / 8.0,
-        "wd10" => w / 10.0, "wd12" => w / 12.0, "wd16" => w / 16.0,
-        "wd32" => w / 32.0,
-        "hd2" => h / 2.0, "hd3" => h / 3.0, "hd4" => h / 4.0,
-        "hd5" => h / 5.0, "hd6" => h / 6.0, "hd8" => h / 8.0,
-        "hd10" => h / 10.0, "hd12" => h / 12.0, "hd16" => h / 16.0,
-        "hd32" => h / 32.0,
-        "ss" => ss, "ssd2" => ss / 2.0, "ssd4" => ss / 4.0,
-        "ssd6" => ss / 6.0, "ssd8" => ss / 8.0, "ssd16" => ss / 16.0,
-        "ssd32" => ss / 32.0,
-        "ls" => ls, "lsd2" => ls / 2.0, "lsd4" => ls / 4.0,
-        "lsd6" => ls / 6.0, "lsd8" => ls / 8.0, "lsd16" => ls / 16.0,
-        "lsd32" => ls / 32.0,
-        "cd" => DRAWINGML_FULL_CIRCLE,
-        "cd2" => DRAWINGML_FULL_CIRCLE / 2.0,
-        "cd4" => DRAWINGML_FULL_CIRCLE / 4.0,
-        "cd8" => DRAWINGML_FULL_CIRCLE / 8.0,
-        "3cd4" => 3.0 * DRAWINGML_FULL_CIRCLE / 4.0,
-        "3cd8" => 3.0 * DRAWINGML_FULL_CIRCLE / 8.0,
-        "5cd8" => 5.0 * DRAWINGML_FULL_CIRCLE / 8.0,
-        "7cd8" => 7.0 * DRAWINGML_FULL_CIRCLE / 8.0,
-    }
-
-    for list_name in ["avLst", "gdLst"] {
-        let Some(list) = child(cust_geom, list_name) else {
-            continue;
-        };
-        for guide in list
-            .children()
-            .filter(|node| node.is_element() && node.tag_name().name() == "gd")
-        {
-            let (Some(name), Some(formula)) = (attr(&guide, "name"), attr(&guide, "fmla")) else {
-                continue;
-            };
-            if let Some(value) = evaluate_geometry_formula(&formula, &env) {
-                env.insert(name, value);
-            }
-        }
-    }
-    env
-}
-
-fn resolve_geometry_value(token: &str, env: &HashMap<String, f64>) -> Option<f64> {
-    env.get(token)
-        .copied()
-        .or_else(|| token.parse::<f64>().ok())
-        .filter(|value| value.is_finite())
-}
-
-fn evaluate_geometry_formula(formula: &str, env: &HashMap<String, f64>) -> Option<f64> {
-    let mut tokens = formula.split_whitespace();
-    let op = tokens.next()?;
-    let args: Vec<f64> = tokens
-        .map(|token| resolve_geometry_value(token, env))
-        .collect::<Option<_>>()?;
-    let arg = |index: usize| args.get(index).copied();
-    let value = match op {
-        "val" => arg(0)?,
-        "*/" => arg(0)? * arg(1)? / arg(2)?,
-        "+-" => arg(0)? + arg(1)? - arg(2)?,
-        "+/" => (arg(0)? + arg(1)?) / arg(2)?,
-        "?:" => {
-            if arg(0)? > 0.0 {
-                arg(1)?
-            } else {
-                arg(2)?
-            }
-        }
-        "abs" => arg(0)?.abs(),
-        "at2" => arg(1)?.atan2(arg(0)?) / DRAWINGML_ANGLE_TO_RAD,
-        "cat2" => arg(0)? * arg(2)?.atan2(arg(1)?).cos(),
-        "cos" => arg(0)? * (arg(1)? * DRAWINGML_ANGLE_TO_RAD).cos(),
-        "max" => arg(0)?.max(arg(1)?),
-        "min" => arg(0)?.min(arg(1)?),
-        "mod" => (arg(0)?.powi(2) + arg(1)?.powi(2) + arg(2)?.powi(2)).sqrt(),
-        "pin" => {
-            let (low, value, high) = (arg(0)?, arg(1)?, arg(2)?);
-            if value < low {
-                low
-            } else if value > high {
-                high
-            } else {
-                value
-            }
-        }
-        "sat2" => arg(0)? * arg(2)?.atan2(arg(1)?).sin(),
-        "sin" => arg(0)? * (arg(1)? * DRAWINGML_ANGLE_TO_RAD).sin(),
-        "sqrt" => arg(0)?.max(0.0).sqrt(),
-        "tan" => arg(0)? * (arg(1)? * DRAWINGML_ANGLE_TO_RAD).tan(),
-        _ => return None,
-    };
-    value.is_finite().then_some(value)
-}
-
-fn geometry_attr(
-    node: &roxmltree::Node<'_, '_>,
-    name: &str,
-    env: &HashMap<String, f64>,
-) -> Option<f64> {
-    let token = attr(node, name)?;
-    resolve_geometry_value(&token, env)
-}
-
-/// Parse a single path command node; coordinates are normalised to [0,1].
-pub(crate) fn parse_path_cmd(
-    cmd_node: roxmltree::Node<'_, '_>,
-    path_w: f64,
-    path_h: f64,
-    env: &HashMap<String, f64>,
-) -> Option<PathCmd> {
-    match cmd_node.tag_name().name() {
-        "moveTo" => {
-            let pt = child(cmd_node, "pt")?;
-            let x = geometry_attr(&pt, "x", env)? / path_w;
-            let y = geometry_attr(&pt, "y", env)? / path_h;
-            Some(PathCmd::MoveTo { x, y })
-        }
-        "lnTo" => {
-            let pt = child(cmd_node, "pt")?;
-            let x = geometry_attr(&pt, "x", env)? / path_w;
-            let y = geometry_attr(&pt, "y", env)? / path_h;
-            Some(PathCmd::LineTo { x, y })
-        }
-        "cubicBezTo" => {
-            let pts: Vec<_> = children_vec(cmd_node, "pt");
-            if pts.len() < 3 {
-                return None;
-            }
-            let x1 = geometry_attr(&pts[0], "x", env)? / path_w;
-            let y1 = geometry_attr(&pts[0], "y", env)? / path_h;
-            let x2 = geometry_attr(&pts[1], "x", env)? / path_w;
-            let y2 = geometry_attr(&pts[1], "y", env)? / path_h;
-            let x = geometry_attr(&pts[2], "x", env)? / path_w;
-            let y = geometry_attr(&pts[2], "y", env)? / path_h;
-            Some(PathCmd::CubicBezTo {
-                x1,
-                y1,
-                x2,
-                y2,
-                x,
-                y,
-            })
-        }
-        "arcTo" => {
-            // wR/hR are radii in path-local units; stAng/swAng in 60000ths of a degree
-            let wr = geometry_attr(&cmd_node, "wR", env).unwrap_or(0.0) / path_w;
-            let hr = geometry_attr(&cmd_node, "hR", env).unwrap_or(0.0) / path_h;
-            let st_ang = geometry_attr(&cmd_node, "stAng", env).unwrap_or(0.0) / 60000.0;
-            let sw_ang = geometry_attr(&cmd_node, "swAng", env).unwrap_or(0.0) / 60000.0;
-            Some(PathCmd::ArcTo {
-                wr,
-                hr,
-                st_ang,
-                sw_ang,
-            })
-        }
-        "close" => Some(PathCmd::Close),
-        _ => None,
-    }
-}
-
 /// Parse custGeom > pathLst into a list of sub-paths (one per <a:path> element).
 pub(crate) fn parse_cust_geom(
     cust_geom: roxmltree::Node<'_, '_>,
     shape_w: f64,
     shape_h: f64,
 ) -> Vec<Vec<PathCmd>> {
-    let path_lst = match child(cust_geom, "pathLst") {
-        Some(n) => n,
-        None => return vec![],
-    };
+    use ooxml_common::custom_geometry::{parse_custom_geometry, PathCommand};
 
-    let env = custom_geometry_guides(cust_geom, shape_w, shape_h);
-    path_lst
-        .children()
-        .filter(|n| n.is_element() && n.tag_name().name() == "path")
-        .map(|path_node| {
-            // CT_Path2D defaults w/h to zero. A zero/omitted coordinate-system
-            // size means the path's guide values are already in shape space;
-            // normalize them by the shape extents. Treating the schema default
-            // as one makes otherwise valid guide-based paths enormous.
-            let path_w = attr_f64(&path_node, "w")
-                .filter(|value| *value > 0.0)
-                .unwrap_or(shape_w.max(1.0));
-            let path_h = attr_f64(&path_node, "h")
-                .filter(|value| *value > 0.0)
-                .unwrap_or(shape_h.max(1.0));
-            path_node
-                .children()
-                .filter(|n| n.is_element())
-                .filter_map(|cmd| parse_path_cmd(cmd, path_w, path_h, &env))
+    parse_custom_geometry(cust_geom, shape_w, shape_h)
+        .paths
+        .into_iter()
+        .map(|path| {
+            path.commands
+                .into_iter()
+                .map(|command| match command {
+                    PathCommand::MoveTo { x, y } => PathCmd::MoveTo {
+                        x: x / path.width,
+                        y: y / path.height,
+                    },
+                    PathCommand::LineTo { x, y } => PathCmd::LineTo {
+                        x: x / path.width,
+                        y: y / path.height,
+                    },
+                    PathCommand::CubicBezierTo {
+                        x1,
+                        y1,
+                        x2,
+                        y2,
+                        x,
+                        y,
+                    } => PathCmd::CubicBezTo {
+                        x1: x1 / path.width,
+                        y1: y1 / path.height,
+                        x2: x2 / path.width,
+                        y2: y2 / path.height,
+                        x: x / path.width,
+                        y: y / path.height,
+                    },
+                    PathCommand::QuadraticBezierTo { x1, y1, x, y } => PathCmd::QuadBezTo {
+                        x1: x1 / path.width,
+                        y1: y1 / path.height,
+                        x: x / path.width,
+                        y: y / path.height,
+                    },
+                    PathCommand::ArcTo {
+                        wr,
+                        hr,
+                        st_ang,
+                        sw_ang,
+                    } => PathCmd::ArcTo {
+                        wr: wr / path.width,
+                        hr: hr / path.height,
+                        st_ang: st_ang / 60000.0,
+                        sw_ang: sw_ang / 60000.0,
+                    },
+                    PathCommand::Close => PathCmd::Close,
+                })
                 .collect()
         })
         .collect()

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -8990,6 +8990,22 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn custom_geometry_preserves_quadratic_bezier() {
+        let xml = r#"<custGeom><pathLst><path w="100" h="200">
+          <moveTo><pt x="0" y="0"/></moveTo>
+          <quadBezTo><pt x="50" y="200"/><pt x="100" y="0"/></quadBezTo>
+        </path></pathLst></custGeom>"#;
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let paths = parse_cust_geom(doc.root_element(), 100.0, 200.0);
+        assert!(matches!(
+            paths[0][1],
+            PathCmd::QuadBezTo { x1, y1, x, y }
+                if (x1 - 0.5).abs() < 1e-9 && (y1 - 1.0).abs() < 1e-9
+                    && (x - 1.0).abs() < 1e-9 && y.abs() < 1e-9
+        ));
+    }
+
     /// A line chart whose horizontal axis is a `<c:dateAx>` (§21.2.2.39) — the
     /// date/time-series category axis. `axis_inner` is spliced into the dateAx.
     fn date_axis_chart_xml(axis_inner: &str) -> String {

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -765,6 +765,13 @@ pub(crate) enum PathCmd {
         x: f64,
         y: f64,
     },
+    /// Quadratic Bézier: one control point plus endpoint (§20.1.9.21).
+    QuadBezTo {
+        x1: f64,
+        y1: f64,
+        x: f64,
+        y: f64,
+    },
     /// Elliptical arc (all angles in degrees)
     ///
     /// The enum-level `#[serde(tag = ..., rename_all = "camelCase")]` renames the

--- a/packages/xlsx/parser/src/drawing.rs
+++ b/packages/xlsx/parser/src/drawing.rs
@@ -433,95 +433,67 @@ pub(crate) fn parse_solid_fill(
     .map(|hex| format!("#{}", hex.to_uppercase()))
 }
 
-/// Parse a single custGeom path element. Each path has its own coordinate
-/// system (`a:path/@w`, `@h`) that the renderer scales to the shape's rect.
-pub(crate) fn parse_custom_path(path_node: &roxmltree::Node) -> PathInfo {
-    let w: f64 = path_node
-        .attribute("w")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0.0);
-    let h: f64 = path_node
-        .attribute("h")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0.0);
-    let mut commands: Vec<PathCmd> = Vec::new();
-    for cmd in path_node.children().filter(|n| n.is_element()) {
-        let name = cmd.tag_name().name();
-        // Collect `<a:pt x=.. y=..>` points in order.
-        let pts: Vec<(f64, f64)> = cmd
-            .children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "pt")
-            .map(|n| {
-                (
-                    n.attribute("x").and_then(|s| s.parse().ok()).unwrap_or(0.0),
-                    n.attribute("y").and_then(|s| s.parse().ok()).unwrap_or(0.0),
-                )
-            })
-            .collect();
-        match name {
-            "moveTo" => {
-                if let Some(p) = pts.first() {
-                    commands.push(PathCmd::MoveTo { x: p.0, y: p.1 });
-                }
+/// Adapt the shared DrawingML `a:custGeom` grammar to XLSX's existing raw
+/// path-coordinate wire model.
+fn parse_custom_paths(
+    cust_geom: roxmltree::Node<'_, '_>,
+    shape_width: f64,
+    shape_height: f64,
+) -> Vec<PathInfo> {
+    use ooxml_common::custom_geometry::{parse_custom_geometry, PathCommand};
+
+    parse_custom_geometry(cust_geom, shape_width, shape_height)
+        .paths
+        .into_iter()
+        .map(|path| {
+            let commands = path
+                .commands
+                .into_iter()
+                .map(|command| match command {
+                    PathCommand::MoveTo { x, y } => PathCmd::MoveTo { x, y },
+                    PathCommand::LineTo { x, y } => PathCmd::LineTo { x, y },
+                    PathCommand::CubicBezierTo {
+                        x1,
+                        y1,
+                        x2,
+                        y2,
+                        x,
+                        y,
+                    } => PathCmd::CubicBezTo {
+                        x1,
+                        y1,
+                        x2,
+                        y2,
+                        x3: x,
+                        y3: y,
+                    },
+                    PathCommand::QuadraticBezierTo { x1, y1, x, y } => PathCmd::QuadBezTo {
+                        x1,
+                        y1,
+                        x2: x,
+                        y2: y,
+                    },
+                    PathCommand::ArcTo {
+                        wr,
+                        hr,
+                        st_ang,
+                        sw_ang,
+                    } => PathCmd::ArcTo {
+                        wr,
+                        hr,
+                        st_ang,
+                        sw_ang,
+                    },
+                    PathCommand::Close => PathCmd::Close,
+                })
+                .collect();
+            PathInfo {
+                w: path.width,
+                h: path.height,
+                commands,
             }
-            "lnTo" => {
-                if let Some(p) = pts.first() {
-                    commands.push(PathCmd::LineTo { x: p.0, y: p.1 });
-                }
-            }
-            "cubicBezTo" => {
-                if pts.len() >= 3 {
-                    commands.push(PathCmd::CubicBezTo {
-                        x1: pts[0].0,
-                        y1: pts[0].1,
-                        x2: pts[1].0,
-                        y2: pts[1].1,
-                        x3: pts[2].0,
-                        y3: pts[2].1,
-                    });
-                }
-            }
-            "quadBezTo" => {
-                if pts.len() >= 2 {
-                    commands.push(PathCmd::QuadBezTo {
-                        x1: pts[0].0,
-                        y1: pts[0].1,
-                        x2: pts[1].0,
-                        y2: pts[1].1,
-                    });
-                }
-            }
-            "close" => commands.push(PathCmd::Close),
-            "arcTo" => {
-                // ECMA-376 §20.1.9.3: `wR`/`hR` in path-coord units;
-                // `stAng`/`swAng` in 60000ths of a degree.
-                let wr: f64 = cmd
-                    .attribute("wR")
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(0.0);
-                let hr: f64 = cmd
-                    .attribute("hR")
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(0.0);
-                let st_ang: f64 = cmd
-                    .attribute("stAng")
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(0.0);
-                let sw_ang: f64 = cmd
-                    .attribute("swAng")
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(0.0);
-                commands.push(PathCmd::ArcTo {
-                    wr,
-                    hr,
-                    st_ang,
-                    sw_ang,
-                });
-            }
-            _ => {}
-        }
-    }
-    PathInfo { w, h, commands }
+        })
+        .collect()
 }
 
 /// Parse `<xdr:txBody>` into a `ShapeText`. Returns `None` if the body
@@ -879,7 +851,11 @@ fn parse_preset_adj(prst_geom: &roxmltree::Node) -> Vec<Option<f64>> {
     out
 }
 
-pub(crate) fn parse_sp_geom(sp_pr: &roxmltree::Node) -> Option<ShapeGeom> {
+pub(crate) fn parse_sp_geom(
+    sp_pr: &roxmltree::Node,
+    shape_width: f64,
+    shape_height: f64,
+) -> Option<ShapeGeom> {
     for c in sp_pr.children().filter(|n| n.is_element()) {
         match c.tag_name().name() {
             "prstGeom" => {
@@ -889,18 +865,7 @@ pub(crate) fn parse_sp_geom(sp_pr: &roxmltree::Node) -> Option<ShapeGeom> {
                 });
             }
             "custGeom" => {
-                let mut paths: Vec<PathInfo> = Vec::new();
-                for pl in c
-                    .children()
-                    .filter(|n| n.is_element() && n.tag_name().name() == "pathLst")
-                {
-                    for p in pl
-                        .children()
-                        .filter(|n| n.is_element() && n.tag_name().name() == "path")
-                    {
-                        paths.push(parse_custom_path(&p));
-                    }
-                }
+                let paths = parse_custom_paths(c, shape_width, shape_height);
                 return Some(ShapeGeom::Custom { paths });
             }
             _ => {}
@@ -1041,7 +1006,7 @@ pub(crate) fn collect_shapes(
             let nw = root_w / root_ext_x;
             let nh = root_h / root_ext_y;
 
-            let geom = parse_sp_geom(&sp_pr);
+            let geom = parse_sp_geom(&sp_pr, xfrm.ext_x, xfrm.ext_y);
             let Some(geom) = geom else {
                 continue;
             };
@@ -3025,7 +2990,7 @@ mod geom_tests {
 
     fn geom_of(sp_pr_xml: &str) -> ShapeGeom {
         let doc = roxmltree::Document::parse(sp_pr_xml).unwrap();
-        parse_sp_geom(&doc.root_element()).expect("sp_pr has geometry")
+        parse_sp_geom(&doc.root_element(), 100.0, 100.0).expect("sp_pr has geometry")
     }
 
     /// A preset with no `<a:avLst>` yields an empty adjust vector — the engine
@@ -3042,6 +3007,30 @@ mod geom_tests {
             }
             other => panic!("expected Preset, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn custom_geometry_resolves_guides_and_preserves_quadratic_bezier() {
+        let geom = geom_of(&format!(
+            r#"<a:spPr {NS}><a:custGeom>
+          <a:gdLst><a:gd name="half" fmla="*/ w 1 2"/></a:gdLst>
+          <a:pathLst><a:path>
+            <a:moveTo><a:pt x="0" y="0"/></a:moveTo>
+            <a:quadBezTo><a:pt x="half" y="b"/><a:pt x="r" y="0"/></a:quadBezTo>
+          </a:path></a:pathLst>
+        </a:custGeom></a:spPr>"#
+        ));
+        let ShapeGeom::Custom { paths } = geom else {
+            panic!("expected custom geometry")
+        };
+        assert_eq!(paths[0].w, 100.0);
+        assert_eq!(paths[0].h, 100.0);
+        assert!(matches!(
+            paths[0].commands[1],
+            PathCmd::QuadBezTo { x1, y1, x2, y2 }
+                if (x1 - 50.0).abs() < 1e-9 && (y1 - 100.0).abs() < 1e-9
+                    && (x2 - 100.0).abs() < 1e-9 && y2.abs() < 1e-9
+        ));
     }
 
     /// `<a:gd name="adj" fmla="val X"/>` is read into the first adjust slot.
@@ -3419,13 +3408,16 @@ mod custom_path_arc_tests {
         // (`if (rx <= 0 || ry <= 0) break;`) short-circuits before the angles
         // are read, so only non-degenerate arcs surface the missing keys.
         let xml = format!(
-            r#"<a:path {NS} w="100" h="100">
+            r#"<a:custGeom {NS}><a:pathLst><a:path w="100" h="100">
                  <a:moveTo><a:pt x="0" y="50"/></a:moveTo>
                  <a:arcTo wR="50" hR="50" stAng="0" swAng="5400000"/>
-               </a:path>"#
+               </a:path></a:pathLst></a:custGeom>"#
         );
         let doc = roxmltree::Document::parse(&xml).unwrap();
-        let path = parse_custom_path(&doc.root_element());
+        let path = parse_custom_paths(doc.root_element(), 100.0, 100.0)
+            .into_iter()
+            .next()
+            .expect("custom geometry contains one path");
 
         // The parser keeps angles as raw 60000ths of a degree (the xlsx
         // convention — the TS renderer divides by 60000). swAng = 5_400_000 =


### PR DESCRIPTION
## Summary
- move the DrawingML custom-geometry guide evaluator and path grammar into ooxml-common
- adapt the common result to the existing DOCX, XLSX, and PPTX wire models
- support quadBezTo in all parsers and the shared Canvas geometry renderer
- use the containing shape extent when a:path omits or zeroes its coordinate-system size

## Rationale
a:custGeom is one ECMA-376 Part 1 section 20.1.9 grammar shared by all three formats. The previous format-local implementations disagreed on guide formulas, quadratic Béziers, and omitted path dimensions. The common layer now owns only the format-agnostic XML grammar; each host retains its existing output and layout model.

## Verification
- focused cross-format Rust parser tests
- clippy with warnings denied
- focused shared Canvas geometry tests
- pnpm typecheck
- package build and public API/export checks
- git diff --check