### PR TITLE
fix(pptx): honor DrawingML effect properties

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -310,7 +310,7 @@ export {
   type Scene3dQuad,
   type Vec2,
 } from './shape/scene3d-camera';
-export { drawProjected, expandProjectedQuad } from './shape/scene3d-draw';
+export { drawProjected, expandProjectedQuad, projectQuadPoint } from './shape/scene3d-draw';
 // DrawingML 3D bevel shading (Phase B). ECMA-376 §20.1.5.12 (sp3d) /
 // §20.1.5.3 (bevel) / §20.1.10.9 (ST_BevelPresetType) / §20.1.5.9 (lightRig).
 // `edt1d` / `shadePixel` / `shadeParamsFor` / `fillDirFromKey` are internal

--- a/packages/core/src/shape/effects.test.ts
+++ b/packages/core/src/shape/effects.test.ts
@@ -186,13 +186,14 @@ describe('applyOuterShadow (ECMA-376 §20.1.8.45)', () => {
 
     expect(applyOuterShadow(
       live as never, (() => {}) as never, BBOX, shadow, SCALE, DEVICE_W, DEVICE_H, 90,
+      [75, 75],
     )).toBe(true);
 
     const transforms = live.ops.filter(o =>
       o.op === 'translate' || o.op === 'rotate' || o.op === 'transform');
     expect(transforms[0].args?.[0]).toBeCloseTo(0, 6);
     expect(transforms[0].args?.[1]).toBeCloseTo(1, 6);
-    expect(transforms[1]).toEqual({ op: 'translate', args: [300, 50] });
+    expect(transforms[1]).toEqual({ op: 'translate', args: [75, 75] });
     expect(transforms[2].args?.[0]).toBeCloseTo(Math.PI / 2, 9);
     expect(transforms[3].args).toEqual([
       0.5,
@@ -203,7 +204,7 @@ describe('applyOuterShadow (ECMA-376 §20.1.8.45)', () => {
       0,
     ]);
     expect(transforms[4].args?.[0]).toBeCloseTo(-Math.PI / 2, 9);
-    expect(transforms[5]).toEqual({ op: 'translate', args: [-300, -50] });
+    expect(transforms[5]).toEqual({ op: 'translate', args: [-75, -75] });
   });
 
   it('keeps direction and transform in page space when rotWithShape is false', () => {

--- a/packages/core/src/shape/effects.test.ts
+++ b/packages/core/src/shape/effects.test.ts
@@ -41,6 +41,8 @@ class RecordingCtx {
   restore() { this.ops.push({ op: 'restore' }); }
   translate(x: number, y: number) { this.ops.push({ op: 'translate', args: [x, y] }); }
   scale(x: number, y: number) { this.ops.push({ op: 'scale', args: [x, y] }); }
+  rotate(angle: number) { this.ops.push({ op: 'rotate', args: [angle] }); }
+  transform(...a: number[]) { this.ops.push({ op: 'transform', args: a }); }
   setTransform(...a: number[]) { this.ops.push({ op: 'setTransform', args: a }); }
   fillRect(...a: number[]) { this.ops.push({ op: 'fillRect', args: a }); }
   fill(...a: unknown[]) { this.ops.push({ op: 'fill', args: a }); }
@@ -155,7 +157,8 @@ describe('applyOuterShadow (ECMA-376 §20.1.8.45)', () => {
     expect(live.usedBlurFilters).toEqual(['blur(4px)']);
     const finalBlit = live.ops.filter(o => o.op === 'drawImage');
     expect(finalBlit).toHaveLength(1);
-    expect(finalBlit[0].args?.slice(1)).toEqual([84, 36]);
+    expect(finalBlit[0].args?.slice(1)).toEqual([84, 34]);
+    expect(live.ops.filter(o => o.op === 'translate')[0].args?.[1]).toBeCloseTo(2, 6);
   });
 
   it('uses one auxiliary surface and no filter for a sharp shadow', () => {
@@ -172,6 +175,52 @@ describe('applyOuterShadow (ECMA-376 §20.1.8.45)', () => {
     expect(fake.auxCtxs[0].usedBlurFilters).toEqual([]);
     expect(live.usedBlurFilters).toEqual([]);
     expect(live.ops.filter(o => o.op === 'drawImage')).toHaveLength(1);
+  });
+
+  it('applies alignment, scale, skew and shape-relative rotation before the blit', () => {
+    const live = new RecordingCtx();
+    const shadow: Shadow = {
+      color: '000000', alpha: 0.5, blur: 0, dist: 9525, dir: 0,
+      sx: 0.5, sy: 1.5, kx: 10, ky: -5, algn: 'tr', rotWithShape: true,
+    };
+
+    expect(applyOuterShadow(
+      live as never, (() => {}) as never, BBOX, shadow, SCALE, DEVICE_W, DEVICE_H, 90,
+    )).toBe(true);
+
+    const transforms = live.ops.filter(o =>
+      o.op === 'translate' || o.op === 'rotate' || o.op === 'transform');
+    expect(transforms[0].args?.[0]).toBeCloseTo(0, 6);
+    expect(transforms[0].args?.[1]).toBeCloseTo(1, 6);
+    expect(transforms[1]).toEqual({ op: 'translate', args: [300, 50] });
+    expect(transforms[2].args?.[0]).toBeCloseTo(Math.PI / 2, 9);
+    expect(transforms[3].args).toEqual([
+      0.5,
+      Math.tan(-5 * Math.PI / 180),
+      Math.tan(10 * Math.PI / 180),
+      1.5,
+      0,
+      0,
+    ]);
+    expect(transforms[4].args?.[0]).toBeCloseTo(-Math.PI / 2, 9);
+    expect(transforms[5]).toEqual({ op: 'translate', args: [-300, -50] });
+  });
+
+  it('keeps direction and transform in page space when rotWithShape is false', () => {
+    const live = new RecordingCtx();
+    const shadow: Shadow = {
+      color: '000000', alpha: 0.5, blur: 0, dist: 9525, dir: 0,
+      rotWithShape: false,
+    };
+
+    expect(applyOuterShadow(
+      live as never, (() => {}) as never, BBOX, shadow, SCALE, DEVICE_W, DEVICE_H, 90,
+    )).toBe(true);
+
+    const transforms = live.ops.filter(o =>
+      o.op === 'translate' || o.op === 'rotate' || o.op === 'transform');
+    expect(transforms[0]).toEqual({ op: 'translate', args: [1, 0] });
+    expect(transforms.some(o => o.op === 'rotate')).toBe(false);
   });
 });
 

--- a/packages/core/src/shape/effects.ts
+++ b/packages/core/src/shape/effects.ts
@@ -192,6 +192,7 @@ export function applyOuterShadow(
   deviceW: number,
   deviceH: number,
   shapeRotationDegrees = 0,
+  alignmentAnchor?: readonly [number, number],
 ): boolean {
   const blur = Math.max(0, emuToPx(shadow.blur, scale));
   const dist = emuToPx(shadow.dist, scale);
@@ -229,7 +230,13 @@ export function applyOuterShadow(
   // ECMA-376 defines the order as alignment origin, scale/skew, then offset.
   // The source aux is already in absolute device coordinates; compose the
   // page-space offset separately so it is not itself scaled or skewed.
-  const [anchorX, anchorY] = shadowAlignmentPoint(bbox, shadow.algn ?? 'b');
+  // Placement owns the authored shape frame.  In particular, the corner of a
+  // rotated or perspective-projected shape is not the corresponding corner of
+  // its post-transform AABB.  Callers that know that frame pass the exact
+  // device-space anchor; bbox-based placement remains the compatibility
+  // fallback for headless/custom callers that only have a silhouette box.
+  const [anchorX, anchorY] = alignmentAnchor ??
+    shadowAlignmentPoint(bbox, shadow.algn ?? 'b');
   const sx = shadow.sx ?? 1;
   const sy = shadow.sy ?? 1;
   const kx = Math.tan(((shadow.kx ?? 0) * Math.PI) / 180);

--- a/packages/core/src/shape/effects.ts
+++ b/packages/core/src/shape/effects.ts
@@ -37,6 +37,20 @@ export interface EffectBBox {
   h: number;
 }
 
+function shadowAlignmentPoint(bbox: EffectBBox, algn: Shadow['algn']): [number, number] {
+  const x = algn === 'tl' || algn === 'l' || algn === 'bl'
+    ? bbox.x
+    : algn === 'tr' || algn === 'r' || algn === 'br'
+      ? bbox.x + bbox.w
+      : bbox.x + bbox.w / 2;
+  const y = algn === 'tl' || algn === 't' || algn === 'tr'
+    ? bbox.y
+    : algn === 'l' || algn === 'ctr' || algn === 'r'
+      ? bbox.y + bbox.h / 2
+      : bbox.y + bbox.h;
+  return [x, y];
+}
+
 /**
  * EMU → device px. Mirrors `emuToPx` in the pptx renderer, where `scale` is
  * px-per-EMU (it already folds in the EMU→px conversion), so this is a bare
@@ -177,10 +191,15 @@ export function applyOuterShadow(
   scale: number,
   deviceW: number,
   deviceH: number,
+  shapeRotationDegrees = 0,
 ): boolean {
   const blur = Math.max(0, emuToPx(shadow.blur, scale));
   const dist = emuToPx(shadow.dist, scale);
-  const dirRad = (shadow.dir * Math.PI) / 180;
+  // rotWithShape defaults true (§20.1.8.45). A false value keeps the effect in
+  // page space while the source silhouette itself remains the rotated object.
+  const followRotation = shadow.rotWithShape !== false;
+  const effectRotation = followRotation ? shapeRotationDegrees : 0;
+  const dirRad = ((shadow.dir + effectRotation) * Math.PI) / 180;
   const dx = Math.cos(dirRad) * dist;
   const dy = Math.sin(dirRad) * dist;
   // CSS blur has an unbounded Gaussian tail. Three radii cover the visible
@@ -207,7 +226,21 @@ export function applyOuterShadow(
 
   liveCtx.save();
   if (blur > 0) liveCtx.filter = `blur(${blur}px)`;
-  liveCtx.drawImage(aux as CanvasImageSource, crop.x + dx, crop.y + dy);
+  // ECMA-376 defines the order as alignment origin, scale/skew, then offset.
+  // The source aux is already in absolute device coordinates; compose the
+  // page-space offset separately so it is not itself scaled or skewed.
+  const [anchorX, anchorY] = shadowAlignmentPoint(bbox, shadow.algn ?? 'b');
+  const sx = shadow.sx ?? 1;
+  const sy = shadow.sy ?? 1;
+  const kx = Math.tan(((shadow.kx ?? 0) * Math.PI) / 180);
+  const ky = Math.tan(((shadow.ky ?? 0) * Math.PI) / 180);
+  liveCtx.translate(dx, dy);
+  liveCtx.translate(anchorX, anchorY);
+  if (effectRotation !== 0) liveCtx.rotate((effectRotation * Math.PI) / 180);
+  liveCtx.transform(sx, ky, kx, sy, 0, 0);
+  if (effectRotation !== 0) liveCtx.rotate((-effectRotation * Math.PI) / 180);
+  liveCtx.translate(-anchorX, -anchorY);
+  liveCtx.drawImage(aux as CanvasImageSource, crop.x, crop.y);
   liveCtx.restore();
   return true;
 }

--- a/packages/core/src/shape/scene3d-draw.test.ts
+++ b/packages/core/src/shape/scene3d-draw.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { drawProjected } from './scene3d-draw';
+import { drawProjected, projectQuadPoint } from './scene3d-draw';
 import { computeScene3dQuad, type Vec2 } from './scene3d-camera';
 
 /**
@@ -244,5 +244,21 @@ describe('drawProjected', () => {
       expect(d.sx + d.sw).toBeLessThanOrEqual(200 + 1e-6);
       expect(d.sy + d.sh).toBeLessThanOrEqual(150 + 1e-6);
     }
+  });
+});
+
+describe('projectQuadPoint', () => {
+  it('maps authored edge anchors through the projective face instead of its AABB', () => {
+    const corners: [Vec2, Vec2, Vec2, Vec2] = [
+      { x: 20, y: 10 },
+      { x: 95, y: 30 },
+      { x: 80, y: 100 },
+      { x: 5, y: 75 },
+    ];
+    expect(projectQuadPoint(corners, 1, 0)).toEqual(corners[1]);
+    const center = projectQuadPoint(corners, 0.5, 0.5);
+    expect(center).not.toBeNull();
+    expect(center!.x).toBeGreaterThan(5);
+    expect(center!.x).toBeLessThan(95);
   });
 });

--- a/packages/core/src/shape/scene3d-draw.ts
+++ b/packages/core/src/shape/scene3d-draw.ts
@@ -427,6 +427,23 @@ export function expandProjectedQuad(
   return out as [Vec2, Vec2, Vec2, Vec2];
 }
 
+/**
+ * Map an authored point in the unit shape frame through the same homography as
+ * the projected face.  Effect placement uses this for DrawingML alignment
+ * anchors: deriving a corner or edge midpoint from the projected AABB is wrong
+ * for rotated and perspective-projected faces.
+ */
+export function projectQuadPoint(
+  corners: [Vec2, Vec2, Vec2, Vec2],
+  u: number,
+  v: number,
+): Vec2 | null {
+  const h = unitSquareToQuad(corners[0], corners[1], corners[2], corners[3]);
+  if (!h) return null;
+  const denominator = h[6] * u + h[7] * v + h[8];
+  return denominator > 1e-9 ? applyH(h, u, v) : null;
+}
+
 let fallbackWarned = false;
 /**
  * Warn (once per process) that scene3d warp fell back to the non-supersampled

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -134,6 +134,18 @@ export interface Shadow {
   dist: number;   // EMU
   /** degrees clockwise from East */
   dir: number;
+  /** Horizontal scale (1.0 = unchanged). Outer shadows only. */
+  sx?: number;
+  /** Vertical scale (1.0 = unchanged). Outer shadows only. */
+  sy?: number;
+  /** Horizontal skew in degrees. Outer shadows only. */
+  kx?: number;
+  /** Vertical skew in degrees. Outer shadows only. */
+  ky?: number;
+  /** Alignment origin used before scaling/skewing. Default `b`. */
+  algn?: 'tl' | 't' | 'tr' | 'l' | 'ctr' | 'r' | 'bl' | 'b' | 'br';
+  /** Whether shadow transforms and offset rotate with the shape. Default true. */
+  rotWithShape?: boolean;
 }
 
 /** ECMA-376 §20.1.8.17 (CT_GlowEffect) — coloured halo with blur radius. */

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -1008,6 +1008,12 @@ export interface Shadow {
     blur: number;
     dist: number;
     dir: number;
+    sx?: number;
+    sy?: number;
+    kx?: number;
+    ky?: number;
+    algn?: 'tl' | 't' | 'tr' | 'l' | 'ctr' | 'r' | 'bl' | 'b' | 'br';
+    rotWithShape?: boolean;
 }
 export interface ShapeElement {
     type: 'shape';
@@ -1078,6 +1084,7 @@ export interface Sp3d {
     extrusionH?: number;
     contourW?: number;
     contourClr?: string;
+    extrusionClr?: string;
     prstMaterial: string;
     bevelT?: Bevel3d;
     bevelB?: Bevel3d;

--- a/packages/pptx/parser/src/fill.rs
+++ b/packages/pptx/parser/src/fill.rs
@@ -351,6 +351,15 @@ fn parse_shadow_node_with_resolver<R: ThemeResolver + ?Sized>(
     let blur = attr_i64(&n, "blurRad").unwrap_or(0);
     let dist = attr_i64(&n, "dist").unwrap_or(0);
     let dir = attr_f64(&n, "dir").unwrap_or(0.0) / 60_000.0;
+    // CT_OuterShadowEffect (§20.1.8.45). These attributes do not exist on
+    // CT_InnerShadowEffect, so the shared reader keeps them optional.
+    let sx = attr_f64(&n, "sx").map(|value| value / 100_000.0);
+    let sy = attr_f64(&n, "sy").map(|value| value / 100_000.0);
+    let kx = attr_f64(&n, "kx").map(|value| value / 60_000.0);
+    let ky = attr_f64(&n, "ky").map(|value| value / 60_000.0);
+    let algn = attr(&n, "algn");
+    let rot_with_shape =
+        attr(&n, "rotWithShape").map(|value| value == "1" || value.eq_ignore_ascii_case("true"));
 
     let color_str = ooxml_common::color::parse_color_node(n, resolver, tint_mode)
         .unwrap_or_else(|| "000000".to_owned());
@@ -367,6 +376,12 @@ fn parse_shadow_node_with_resolver<R: ThemeResolver + ?Sized>(
         blur,
         dist,
         dir,
+        sx,
+        sy,
+        kx,
+        ky,
+        algn,
+        rot_with_shape,
     })
 }
 
@@ -537,7 +552,13 @@ pub(crate) fn parse_style_matrix_effects(
             ooxml_common::color::TintMode::PowerPointLinear,
         ),
         scene3d: effect_style.and_then(parse_scene3d),
-        sp3d: effect_style.and_then(parse_sp3d),
+        sp3d: effect_style.and_then(|node| {
+            parse_sp3d_with_resolver(
+                node,
+                &resolver,
+                ooxml_common::color::TintMode::PowerPointLinear,
+            )
+        }),
     }
 }
 
@@ -595,17 +616,33 @@ pub(crate) fn parse_bevel3d(bevel: roxmltree::Node<'_, '_>) -> Bevel3d {
 /// Parse `<a:sp3d>` (`CT_Shape3D`, ECMA-376 §20.1.5.12). Defaults follow the
 /// schema: z=0, extrusionH=0, contourW=0, prstMaterial="warmMatte". Parsed in
 /// full but not rendered in Phase A.
-pub(crate) fn parse_sp3d(sppr: roxmltree::Node<'_, '_>) -> Option<Sp3d> {
+pub(crate) fn parse_sp3d(
+    sppr: roxmltree::Node<'_, '_>,
+    theme: &HashMap<String, String>,
+) -> Option<Sp3d> {
+    parse_sp3d_with_resolver(
+        sppr,
+        &PptxSchemeResolver { theme },
+        ooxml_common::color::TintMode::PowerPointLinear,
+    )
+}
+
+fn parse_sp3d_with_resolver<R: ThemeResolver + ?Sized>(
+    sppr: roxmltree::Node<'_, '_>,
+    resolver: &R,
+    tint_mode: ooxml_common::color::TintMode,
+) -> Option<Sp3d> {
     let n = child(sppr, "sp3d")?;
-    // contourClr is colour-only here; pass an empty theme map because sp3d
-    // contour colours in practice are srgbClr (no theme lookup needed) and this
-    // parser has the theme threaded only into the line/fill paths.
-    let contour_clr = child(n, "contourClr").and_then(|c| parse_color_node(c, &HashMap::new()));
+    let contour_clr = child(n, "contourClr")
+        .and_then(|c| ooxml_common::color::parse_color_node(c, resolver, tint_mode));
+    let extrusion_clr = child(n, "extrusionClr")
+        .and_then(|c| ooxml_common::color::parse_color_node(c, resolver, tint_mode));
     Some(Sp3d {
         z: attr_i64(&n, "z").unwrap_or(0),
         extrusion_h: attr_i64(&n, "extrusionH").unwrap_or(0),
         contour_w: attr_i64(&n, "contourW").unwrap_or(0),
         contour_clr,
+        extrusion_clr,
         prst_material: attr(&n, "prstMaterial").unwrap_or_else(|| "warmMatte".into()),
         bevel_t: child(n, "bevelT").map(parse_bevel3d),
         bevel_b: child(n, "bevelB").map(parse_bevel3d),

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -5006,7 +5006,11 @@ mod tests {
     fn test_pic_effect_lst_resolves_all_effects() {
         let xml = r#"<spPr xmlns="http://schemas.openxmlformats.org/drawingml/2006/main">
             <effectLst>
-                <outerShdw blurRad="50800" dist="38100" dir="2700000"><srgbClr val="000000"><alpha val="40000"/></srgbClr></outerShdw>
+                <outerShdw blurRad="50800" dist="38100" dir="2700000"
+                            sx="50000" sy="150000" kx="1200000" ky="-600000"
+                            algn="tr" rotWithShape="0">
+                    <srgbClr val="000000"><alpha val="40000"/></srgbClr>
+                </outerShdw>
                 <innerShdw blurRad="63500" dist="50800" dir="5400000"><srgbClr val="111111"/></innerShdw>
                 <glow rad="63500"><srgbClr val="FFCC00"/></glow>
                 <softEdge rad="25400"/>
@@ -5022,6 +5026,12 @@ mod tests {
         assert_eq!(shadow.blur, 50_800);
         assert_eq!(shadow.dist, 38_100);
         assert!((shadow.alpha - 0.4).abs() < 0.01);
+        assert_eq!(shadow.sx, Some(0.5));
+        assert_eq!(shadow.sy, Some(1.5));
+        assert_eq!(shadow.kx, Some(20.0));
+        assert_eq!(shadow.ky, Some(-10.0));
+        assert_eq!(shadow.algn.as_deref(), Some("tr"));
+        assert_eq!(shadow.rot_with_shape, Some(false));
 
         let inner = eff.inner_shadow.expect("innerShdw should resolve");
         assert_eq!(inner.blur, 63_500);
@@ -6445,7 +6455,7 @@ mod tests {
         assert_eq!(lr.rig, "threePt");
         assert_eq!(lr.dir, "t");
 
-        let sp3d = parse_sp3d(sppr).expect("sp3d should parse");
+        let sp3d = parse_sp3d(sppr, &HashMap::new()).expect("sp3d should parse");
         assert_eq!(sp3d.contour_w, 6350);
         assert_eq!(sp3d.prst_material, "matte");
         assert_eq!(sp3d.z, 0); // default
@@ -6488,7 +6498,7 @@ mod tests {
         // No <a:rot> → None (renderer uses the preset base orientation).
         assert!(scene.camera.rot.is_none());
 
-        let sp3d = parse_sp3d(sppr).unwrap();
+        let sp3d = parse_sp3d(sppr, &HashMap::new()).unwrap();
         assert_eq!(sp3d.z, 0);
         assert_eq!(sp3d.extrusion_h, 0);
         assert_eq!(sp3d.contour_w, 0);
@@ -6507,7 +6517,7 @@ mod tests {
         let doc = roxmltree::Document::parse(xml).unwrap();
         let sppr = parse_sppr_frag(&doc);
         assert!(parse_scene3d(sppr).is_none());
-        assert!(parse_sp3d(sppr).is_none());
+        assert!(parse_sp3d(sppr, &HashMap::new()).is_none());
     }
 
     // ===== sp3d contour colour (ECMA-376 §20.1.5.12 contourClr) =====
@@ -6519,19 +6529,26 @@ mod tests {
             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
             xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
           <p:spPr>
-            <a:sp3d contourW="6350" prstMaterial="matte">
+            <a:sp3d contourW="6350" extrusionH="12700" prstMaterial="matte">
               <a:bevelT w="101600" h="101600"/>
-              <a:contourClr><a:srgbClr val="969696"/></a:contourClr>
+              <a:contourClr><a:schemeClr val="accent1"/></a:contourClr>
+              <a:extrusionClr><a:schemeClr val="accent2"/></a:extrusionClr>
             </a:sp3d>
           </p:spPr>
         </root>"#;
         let doc = roxmltree::Document::parse(xml).unwrap();
         let sppr = parse_sppr_frag(&doc);
-        let sp3d = parse_sp3d(sppr).expect("sp3d should parse");
+        let theme = HashMap::from([
+            ("accent1".to_owned(), "969696".to_owned()),
+            ("accent2".to_owned(), "4472C4".to_owned()),
+        ]);
+        let sp3d = parse_sp3d(sppr, &theme).expect("sp3d should parse");
         assert_eq!(sp3d.contour_w, 6350);
         assert_eq!(sp3d.contour_clr.as_deref(), Some("969696"));
+        assert_eq!(sp3d.extrusion_clr.as_deref(), Some("4472C4"));
         let json = serde_json::to_string(&sp3d).unwrap();
         assert!(json.contains("\"contourClr\":\"969696\""), "{json}");
+        assert!(json.contains("\"extrusionClr\":\"4472C4\""), "{json}");
     }
 
     #[test]
@@ -6543,7 +6560,7 @@ mod tests {
         </root>"#;
         let doc = roxmltree::Document::parse(xml).unwrap();
         let sppr = parse_sppr_frag(&doc);
-        let sp3d = parse_sp3d(sppr).unwrap();
+        let sp3d = parse_sp3d(sppr, &HashMap::new()).unwrap();
         assert!(sp3d.contour_clr.is_none());
         // Omitted from JSON when absent.
         let json = serde_json::to_string(&sp3d).unwrap();
@@ -7483,6 +7500,61 @@ mod tests {
         assert!(
             pic.svg_image_path.is_none(),
             "svg_image_path must be None without an svgBlip extension"
+        );
+    }
+
+    /// p:pic carries the same CT_ShapeStyle references as p:sp. A picture with
+    /// no local line/effect component must therefore inherit lnRef/effectRef,
+    /// including effect-style 3D colours resolved through phClr.
+    #[test]
+    fn picture_inherits_line_effect_and_3d_from_style_matrix() {
+        let pic_xml = r#"<p:pic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:nvPicPr><p:cNvPr id="5" name="StyledPic"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+  <p:blipFill><a:blip r:embed="rIdPng"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>
+  <p:spPr><a:xfrm><a:off x="100" y="200"/><a:ext cx="300000" cy="300000"/></a:xfrm>
+    <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+  <p:style>
+    <a:lnRef idx="2"><a:schemeClr val="accent2"/></a:lnRef>
+    <a:fillRef idx="0"><a:schemeClr val="accent1"/></a:fillRef>
+    <a:effectRef idx="1"><a:schemeClr val="accent1"/></a:effectRef>
+    <a:fontRef idx="minor"><a:schemeClr val="tx1"/></a:fontRef>
+  </p:style>
+</p:pic>"#;
+        let doc = roxmltree::Document::parse(pic_xml).unwrap();
+        let mut rels = HashMap::new();
+        rels.insert("rIdPng".to_owned(), "../media/image1.png".to_owned());
+        let mut theme = HashMap::from([
+            ("accent1".to_owned(), "112233".to_owned()),
+            ("accent2".to_owned(), "445566".to_owned()),
+            ("+lnRef-2".to_owned(), "19050".to_owned()),
+        ]);
+        theme.insert(
+            "+effectStyle-1".to_owned(),
+            r#"<a:effectStyle>
+              <a:effectLst><a:outerShdw blurRad="12700"><a:schemeClr val="phClr"/></a:outerShdw></a:effectLst>
+              <a:scene3d><a:camera prst="orthographicFront"/></a:scene3d>
+              <a:sp3d extrusionH="25400"><a:extrusionClr><a:schemeClr val="phClr"/></a:extrusionClr></a:sp3d>
+            </a:effectStyle>"#.to_owned(),
+        );
+        let data = build_blip_media_zip(b"png", b"<svg/>");
+        let mut zip = PptxZip::new(Cursor::new(data)).unwrap();
+
+        let pic = parse_picture(doc.root_element(), "ppt/slides", &rels, &theme, &mut zip)
+            .expect("styled picture should parse");
+
+        let stroke = pic.stroke.expect("lnRef should supply a picture border");
+        assert_eq!(stroke.width, 19_050);
+        assert_eq!(stroke.color, "445566");
+        assert_eq!(pic.shadow.expect("effectRef shadow").color, "112233");
+        assert_eq!(
+            pic.scene3d.expect("effectRef scene3d").camera.prst,
+            "orthographicFront"
+        );
+        assert_eq!(
+            pic.sp3d.expect("effectRef sp3d").extrusion_clr.as_deref(),
+            Some("112233")
         );
     }
 

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -7,9 +7,11 @@
 
 use crate::fill::{
     parse_background, parse_blip_alpha, parse_color_node, parse_cust_geom, parse_fill,
-    parse_reflection, parse_stroke, parse_xfrm,
+    parse_reflection, parse_xfrm,
 };
-use crate::shape::extract_decorative_shapes;
+use crate::shape::{
+    extract_decorative_shapes, resolve_picture_shape_properties, PictureShapeProperties,
+};
 use crate::text::{
     empty_level_bullets, extract_level_bullets, extract_level_font_sizes, extract_level_indents,
     extract_lvl1_font_size, has_any_level_bullet, has_any_level_indent, has_any_level_size,
@@ -105,6 +107,12 @@ pub(crate) struct LayoutPlaceholders {
     pub(crate) by_type_stroke: HashMap<String, Stroke>,
     /// Stroke per placeholder idx from layout spPr > ln
     pub(crate) by_idx_stroke: HashMap<u32, Stroke>,
+    /// Complete picture-like shape properties inherited from the matching
+    /// layout placeholder. This accompanies an inherited `blipFill` so every
+    /// PictureElement construction path retains the same effects and 3-D
+    /// components as an ordinary `p:pic`.
+    pub(crate) by_type_picture_properties: HashMap<String, PictureShapeProperties>,
+    pub(crate) by_idx_picture_properties: HashMap<u32, PictureShapeProperties>,
     /// Default line spacing (spcPct val, e.g. 90000 = 90%) per placeholder idx, from layout lstStyle
     pub(crate) by_idx_line_spacing: HashMap<u32, f64>,
     /// Default line spacing (spcPct val) per placeholder type, from layout lstStyle
@@ -545,6 +553,44 @@ impl LayoutPlaceholders {
                 None
             }
         })
+    }
+
+    /// Look up all picture-affecting shape properties from the same placeholder
+    /// slot as an inherited blipFill. Explicit idx matching remains strict per
+    /// §19.7.16, exactly like fill, geometry, stroke and blipFill.
+    pub(crate) fn lookup_picture_properties(
+        &self,
+        ph_type: &str,
+        ph_idx: Option<u32>,
+    ) -> Option<PictureShapeProperties> {
+        if let Some(i) = ph_idx {
+            return self.by_idx_picture_properties.get(&i).cloned().or_else(|| {
+                self.by_idx_stroke
+                    .get(&i)
+                    .cloned()
+                    .map(|stroke| PictureShapeProperties {
+                        stroke: Some(stroke),
+                        ..Default::default()
+                    })
+            });
+        }
+        self.by_type_picture_properties
+            .get(ph_type)
+            .cloned()
+            .or_else(|| {
+                if ph_type == "body" {
+                    self.by_type_picture_properties.get("").cloned()
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                self.lookup_stroke(ph_type, None)
+                    .map(|stroke| PictureShapeProperties {
+                        stroke: Some(stroke),
+                        ..Default::default()
+                    })
+            })
     }
 
     /// Look up inherited default text color for this placeholder (layout then master fallback).
@@ -1391,8 +1437,12 @@ pub(crate) fn parse_layout_placeholders(
         ];
         let has_layout_text_inset = layout_text_insets.iter().any(Option::is_some);
 
-        // Layout spPr > ln stroke (real visible border, not edit-mode indicator when solidFill is present)
-        let layout_stroke: Option<Stroke> = child(sp_pr, "ln").and_then(|n| parse_stroke(n, theme));
+        // A picture placeholder inherits the same CT_ShapeProperties component
+        // cascade as an ordinary picture. Resolve the layout's local/style
+        // tiers once, then retain that bundle alongside its blipFill.
+        let layout_picture_properties =
+            resolve_picture_shape_properties(Some(sp_pr), child(sp, "style"), None, theme);
+        let layout_stroke = layout_picture_properties.stroke.clone();
 
         // Layout spPr fill (solidFill / noFill / gradFill / pattFill). The
         // slide-level placeholder shape inherits this when its own `<p:spPr>` is
@@ -1479,6 +1529,11 @@ pub(crate) fn parse_layout_placeholders(
                 }
                 if let Some(ref s) = layout_stroke {
                     lph.by_idx_stroke.entry(idx).or_insert(s.clone());
+                }
+                if !layout_picture_properties.is_empty() {
+                    lph.by_idx_picture_properties
+                        .entry(idx)
+                        .or_insert_with(|| layout_picture_properties.clone());
                 }
                 if let Some(ls) = layout_line_spacing {
                     lph.by_idx_line_spacing.entry(idx).or_insert(ls);
@@ -1599,6 +1654,11 @@ pub(crate) fn parse_layout_placeholders(
             }
             if let Some(s) = layout_stroke {
                 lph.by_type_stroke.entry(ph_type.clone()).or_insert(s);
+            }
+            if !layout_picture_properties.is_empty() {
+                lph.by_type_picture_properties
+                    .entry(ph_type.clone())
+                    .or_insert(layout_picture_properties);
             }
             if let Some(bf) = layout_blip_fill {
                 lph.by_type_blip_fill.entry(ph_type.clone()).or_insert(bf);
@@ -2067,6 +2127,49 @@ mod placeholder_geometry_tests {
             &mut zip,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn layout_retains_picture_effect_components_for_placeholder_inheritance() {
+        let placeholders = parse_layout_geometry(
+            r#"<p:sp>
+              <p:nvSpPr><p:cNvPr id="2" name="Picture slot"/><p:cNvSpPr/>
+                <p:nvPr><p:ph type="pic" idx="9"/></p:nvPr></p:nvSpPr>
+              <p:spPr>
+                <a:xfrm><a:off x="0" y="0"/><a:ext cx="1000" cy="1000"/></a:xfrm>
+                <a:ln w="33333"><a:solidFill><a:srgbClr val="445566"/></a:solidFill></a:ln>
+                <a:effectLst><a:outerShdw blurRad="500" dist="700" dir="0"><a:srgbClr val="112233"/></a:outerShdw></a:effectLst>
+                <a:scene3d><a:camera prst="perspectiveFront"/><a:lightRig rig="threePt" dir="t"/></a:scene3d>
+                <a:sp3d prstMaterial="plastic"/>
+              </p:spPr>
+            </p:sp>"#,
+        );
+
+        let properties = placeholders
+            .lookup_picture_properties("pic", Some(9))
+            .expect("layout picture properties");
+        assert_eq!(
+            properties.stroke.as_ref().map(|stroke| stroke.width),
+            Some(33_333)
+        );
+        assert_eq!(
+            properties.shadow.as_ref().map(|shadow| shadow.dist),
+            Some(700)
+        );
+        assert_eq!(
+            properties
+                .scene3d
+                .as_ref()
+                .map(|scene| scene.camera.prst.as_str()),
+            Some("perspectiveFront")
+        );
+        assert_eq!(
+            properties
+                .sp3d
+                .as_ref()
+                .map(|surface| surface.prst_material.as_str()),
+            Some("plastic")
+        );
     }
 
     #[test]

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -328,6 +328,102 @@ fn parse_style_stroke(
         })
 }
 
+/// The DrawingML shape-property components that affect a picture's composed
+/// bitmap/border silhouette. `p:pic` and a `p:sp` painted by `a:blipFill` both
+/// use `CT_ShapeProperties`; keeping their component cascade in one resolver
+/// prevents the alternate picture construction paths from silently dropping
+/// style-matrix or placeholder-inherited effects.
+#[derive(Default, Clone, serde::Serialize)]
+pub(crate) struct PictureShapeProperties {
+    pub(crate) stroke: Option<Stroke>,
+    pub(crate) shadow: Option<Shadow>,
+    pub(crate) inner_shadow: Option<Shadow>,
+    pub(crate) glow: Option<Glow>,
+    pub(crate) soft_edge: Option<SoftEdge>,
+    pub(crate) reflection: Option<Reflection>,
+    pub(crate) scene3d: Option<Scene3d>,
+    pub(crate) sp3d: Option<Sp3d>,
+}
+
+impl PictureShapeProperties {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.stroke.is_none()
+            && self.shadow.is_none()
+            && self.inner_shadow.is_none()
+            && self.glow.is_none()
+            && self.soft_edge.is_none()
+            && self.reflection.is_none()
+            && self.scene3d.is_none()
+            && self.sp3d.is_none()
+    }
+}
+
+/// Resolve the component cascade for a picture-like shape.
+///
+/// ECMA-376 Part 1, Annex L.3.2.3 defines the slide/layout placeholder
+/// inheritance tier. CT_ShapeStyle's `lnRef`/`effectRef` supplies the next
+/// tier, and local CT_ShapeProperties components override it. In particular,
+/// MS-OI29500 §20.1.2.2.37(b) specifies that an authored local effect component
+/// replaces the referenced style component rather than merging its children.
+pub(crate) fn resolve_picture_shape_properties(
+    sp_pr: Option<roxmltree::Node<'_, '_>>,
+    style_node: Option<roxmltree::Node<'_, '_>>,
+    inherited: Option<PictureShapeProperties>,
+    theme: &HashMap<String, String>,
+) -> PictureShapeProperties {
+    let inherited = inherited.unwrap_or_default();
+
+    // An explicit lnRef (including idx=0) replaces the placeholder tier.
+    // Without an lnRef, the layout placeholder remains the inherited base.
+    let style_stroke = if style_node.and_then(|style| child(style, "lnRef")).is_some() {
+        parse_style_stroke(style_node, theme)
+    } else {
+        inherited.stroke
+    };
+    let stroke = merge_local_stroke(
+        sp_pr.and_then(|node| child(node, "ln")),
+        style_stroke,
+        theme,
+    );
+
+    let effect_ref = style_node.and_then(|style| child(style, "effectRef"));
+    let style_effects = effect_ref
+        .map(|node| parse_style_matrix_effects(node, theme))
+        .unwrap_or_default();
+    let local_effect_node =
+        sp_pr.and_then(|node| child(node, "effectLst").or_else(|| child(node, "effectDag")));
+    let effects = if local_effect_node.is_some() {
+        parse_effect_lst(local_effect_node, theme)
+    } else if effect_ref.is_some() {
+        style_effects.effects
+    } else {
+        EffectLst {
+            shadow: inherited.shadow,
+            inner_shadow: inherited.inner_shadow,
+            glow: inherited.glow,
+            soft_edge: inherited.soft_edge,
+            reflection: inherited.reflection,
+        }
+    };
+
+    PictureShapeProperties {
+        stroke,
+        shadow: effects.shadow,
+        inner_shadow: effects.inner_shadow,
+        glow: effects.glow,
+        soft_edge: effects.soft_edge,
+        reflection: effects.reflection,
+        scene3d: sp_pr
+            .and_then(parse_scene3d)
+            .or(style_effects.scene3d)
+            .or(inherited.scene3d),
+        sp3d: sp_pr
+            .and_then(|node| parse_sp3d(node, theme))
+            .or(style_effects.sp3d)
+            .or(inherited.sp3d),
+    }
+}
+
 pub(crate) fn parse_shape(
     sp_node: roxmltree::Node<'_, '_>,
     lph: &LayoutPlaceholders,
@@ -850,40 +946,17 @@ pub(crate) fn parse_picture(
     let cust_geom = child(sp_pr, "custGeom")
         .map(|geometry| parse_cust_geom(geometry, t.cx as f64, t.cy as f64));
 
-    // A picture has the same CT_ShapeStyle component references as a shape.
-    // Resolve the theme recipe first; a local spPr component then replaces or
-    // overlays it according to MS-OI29500 §20.1.2.2.37(b).
     let style_node = child(pic_node, "style");
-    let style_effects = style_node
-        .and_then(|style| child(style, "effectRef"))
-        .map(|effect_ref| parse_style_matrix_effects(effect_ref, theme))
-        .unwrap_or_default();
-    let style_scene3d = style_effects.scene3d;
-    let style_sp3d = style_effects.sp3d;
-    let local_effect_node = child(sp_pr, "effectLst").or_else(|| child(sp_pr, "effectDag"));
-
-    // §19.3.1.37: p:pic's spPr is CT_ShapeProperties, so effects apply to the
-    // composed bitmap/border silhouette exactly as they do to shapes.
-    let EffectLst {
+    let PictureShapeProperties {
+        stroke,
         shadow,
         inner_shadow,
         glow,
         soft_edge,
         reflection,
-    } = if local_effect_node.is_some() {
-        parse_effect_lst(local_effect_node, theme)
-    } else {
-        style_effects.effects
-    };
-
-    // §20.1.2.2.24 — a `p:pic`'s spPr may carry an `<a:ln>` border (e.g. the
-    // white frame of PowerPoint's picture styles). `parse_stroke` returns None
-    // for `<a:noFill/>`, so an explicitly border-less picture stays None.
-    let stroke = merge_local_stroke(
-        child(sp_pr, "ln"),
-        parse_style_stroke(style_node, theme),
-        theme,
-    );
+        scene3d,
+        sp3d,
+    } = resolve_picture_shape_properties(Some(sp_pr), style_node, None, theme);
 
     let (prst_geom, prst_adjust) = parse_pic_prst_geom(sp_pr);
     Some(PictureElement {
@@ -917,8 +990,8 @@ pub(crate) fn parse_picture(
         glow,
         soft_edge,
         reflection,
-        scene3d: parse_scene3d(sp_pr).or(style_scene3d),
-        sp3d: parse_sp3d(sp_pr, theme).or(style_sp3d),
+        scene3d,
+        sp3d,
     })
 }
 
@@ -1786,23 +1859,21 @@ pub(crate) fn parse_sp_tree_node(
                                         .map(|geometry| {
                                             parse_cust_geom(geometry, t.cx as f64, t.cy as f64)
                                         });
-                                // §20.1.8.16 effectLst applies to a sp painted as
-                                // a picture (blipFill) just like a regular p:pic.
-                                let EffectLst {
+                                let PictureShapeProperties {
+                                    stroke,
                                     shadow,
                                     inner_shadow,
                                     glow,
                                     soft_edge,
                                     reflection,
-                                } = parse_effect_lst(
-                                    sp_pr_node.and_then(|p| child(p, "effectLst")),
+                                    scene3d,
+                                    sp3d,
+                                } = resolve_picture_shape_properties(
+                                    sp_pr_node,
+                                    child(node, "style"),
+                                    None,
                                     theme,
                                 );
-                                // §20.1.2.2.24 — a blipFill-painted sp can carry
-                                // an `<a:ln>` border just like a real p:pic.
-                                let stroke = sp_pr_node
-                                    .and_then(|p| child(p, "ln"))
-                                    .and_then(|n| parse_stroke(n, theme));
                                 out.push(SlideElement::Picture(PictureElement {
                                     x: t.x,
                                     y: t.y,
@@ -1834,8 +1905,8 @@ pub(crate) fn parse_sp_tree_node(
                                     glow,
                                     soft_edge,
                                     reflection,
-                                    scene3d: sp_pr_node.and_then(parse_scene3d),
-                                    sp3d: sp_pr_node.and_then(|node| parse_sp3d(node, theme)),
+                                    scene3d,
+                                    sp3d,
                                 }));
                                 return;
                             }
@@ -1860,13 +1931,21 @@ pub(crate) fn parse_sp_tree_node(
                         let t = slide_xfrm.or_else(|| lph.lookup(&ph_type, ph_idx).cloned());
                         if let Some(t) = t {
                             if t.cx > 0 && t.cy > 0 {
-                                // §20.1.2.2.24 — honour the slide sp's own `<a:ln>`
-                                // border, falling back to the inherited layout
-                                // placeholder stroke when the slide omits one.
-                                let stroke = match sp_pr_node.and_then(|p| child(p, "ln")) {
-                                    Some(ln) => parse_stroke(ln, theme),
-                                    None => lph.lookup_stroke(&ph_type, ph_idx),
-                                };
+                                let PictureShapeProperties {
+                                    stroke,
+                                    shadow,
+                                    inner_shadow,
+                                    glow,
+                                    soft_edge,
+                                    reflection,
+                                    scene3d,
+                                    sp3d,
+                                } = resolve_picture_shape_properties(
+                                    sp_pr_node,
+                                    child(node, "style"),
+                                    lph.lookup_picture_properties(&ph_type, ph_idx),
+                                    theme,
+                                );
                                 out.push(SlideElement::Picture(PictureElement {
                                     x: t.x,
                                     y: t.y,
@@ -1900,13 +1979,13 @@ pub(crate) fn parse_sp_tree_node(
                                     // render applies it via the shared core cache.
                                     duotone: bf.duotone,
                                     cust_geom: None,
-                                    shadow: None,
-                                    inner_shadow: None,
-                                    glow: None,
-                                    soft_edge: None,
-                                    reflection: None,
-                                    scene3d: None,
-                                    sp3d: None,
+                                    shadow,
+                                    inner_shadow,
+                                    glow,
+                                    soft_edge,
+                                    reflection,
+                                    scene3d,
+                                    sp3d,
                                 }));
                                 return;
                             }
@@ -1925,9 +2004,13 @@ pub(crate) fn parse_sp_tree_node(
                 out.push(SlideElement::Picture(pic));
             } else {
                 // Placeholder pic: no xfrm in spPr — position comes from layout by_idx
-                let ph_idx = node
+                let ph_node = node
                     .descendants()
-                    .find(|n| n.is_element() && n.tag_name().name() == "ph")
+                    .find(|n| n.is_element() && n.tag_name().name() == "ph");
+                let ph_type = ph_node
+                    .and_then(|ph| attr(&ph, "type"))
+                    .unwrap_or_else(|| "body".to_owned());
+                let ph_idx = ph_node
                     .and_then(|ph| attr(&ph, "idx"))
                     .and_then(|s| s.parse::<u32>().ok())
                     .filter(|idx| *idx != u32::MAX);
@@ -1950,14 +2033,21 @@ pub(crate) fn parse_sp_tree_node(
                                     // p:pic's blip — prefer the vector original.
                                     let svg_image_path =
                                         blip.and_then(|b| svg_blip_path(b, slide_dir, rels, zip));
-                                    // §20.1.2.2.24 — placeholder pic border: the
-                                    // p:pic's own `<a:ln>`, else the inherited
-                                    // layout placeholder stroke.
-                                    let stroke =
-                                        match child(node, "spPr").and_then(|p| child(p, "ln")) {
-                                            Some(ln) => parse_stroke(ln, theme),
-                                            None => lph.by_idx_stroke.get(&idx).cloned(),
-                                        };
+                                    let PictureShapeProperties {
+                                        stroke,
+                                        shadow,
+                                        inner_shadow,
+                                        glow,
+                                        soft_edge,
+                                        reflection,
+                                        scene3d,
+                                        sp3d,
+                                    } = resolve_picture_shape_properties(
+                                        child(node, "spPr"),
+                                        child(node, "style"),
+                                        lph.lookup_picture_properties(&ph_type, Some(idx)),
+                                        theme,
+                                    );
                                     out.push(SlideElement::Picture(PictureElement {
                                         x: t.x,
                                         y: t.y,
@@ -1984,13 +2074,13 @@ pub(crate) fn parse_sp_tree_node(
                                             )
                                         }),
                                         cust_geom: None,
-                                        shadow: None,
-                                        inner_shadow: None,
-                                        glow: None,
-                                        soft_edge: None,
-                                        reflection: None,
-                                        scene3d: None,
-                                        sp3d: None,
+                                        shadow,
+                                        inner_shadow,
+                                        glow,
+                                        soft_edge,
+                                        reflection,
+                                        scene3d,
+                                        sp3d,
                                     }));
                                 }
                             }
@@ -2724,6 +2814,232 @@ mod style_ref_tests {
             (body.l_ins, body.t_ins, body.r_ins, body.b_ins),
             (100, 200, 300, 400)
         );
+    }
+}
+
+#[cfg(test)]
+mod picture_property_resolution_tests {
+    use super::*;
+    use crate::master::{InheritedBlipFill, LayoutPlaceholders};
+    use std::io::{Cursor, Write};
+
+    fn tiny_png() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"\x89PNG\r\n\x1a\n");
+        bytes.extend_from_slice(&[0, 0, 0, 13]);
+        bytes.extend_from_slice(b"IHDR");
+        bytes.extend_from_slice(&2u32.to_be_bytes());
+        bytes.extend_from_slice(&2u32.to_be_bytes());
+        bytes.extend_from_slice(&[8, 6, 0, 0, 0]);
+        bytes.extend_from_slice(&[0, 0, 0, 0]);
+        bytes
+    }
+
+    fn image_zip() -> PptxZip {
+        let mut bytes = Vec::new();
+        {
+            let mut writer = zip::ZipWriter::new(Cursor::new(&mut bytes));
+            writer
+                .start_file(
+                    "ppt/media/image1.png",
+                    zip::write::SimpleFileOptions::default(),
+                )
+                .unwrap();
+            writer.write_all(&tiny_png()).unwrap();
+            writer.finish().unwrap();
+        }
+        PptxZip::new(Cursor::new(bytes)).unwrap()
+    }
+
+    fn theme_with_picture_style() -> HashMap<String, String> {
+        HashMap::from([
+            ("+lnRef-1".to_owned(), "22222".to_owned()),
+            (
+                "+effectStyle-1".to_owned(),
+                r#"<a:effectStyle>
+                  <a:effectLst><a:outerShdw blurRad="100" dist="200" dir="0">
+                    <a:srgbClr val="112233"/>
+                  </a:outerShdw></a:effectLst>
+                  <a:scene3d><a:camera prst="isometricLeftUp"/><a:lightRig rig="threePt" dir="t"/></a:scene3d>
+                  <a:sp3d prstMaterial="matte"/>
+                </a:effectStyle>"#
+                    .to_owned(),
+            ),
+        ])
+    }
+
+    fn run_tree_child(
+        xml: &str,
+        placeholders: &LayoutPlaceholders,
+        theme: &HashMap<String, String>,
+        zip: &mut PptxZip,
+    ) -> PictureElement {
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let mut out = Vec::new();
+        let rels = HashMap::from([("rIdImg".to_owned(), "../media/image1.png".to_owned())]);
+        parse_sp_tree_node(
+            doc.root_element(),
+            placeholders,
+            "ppt/slides",
+            &rels,
+            &HashMap::new(),
+            zip,
+            theme,
+            &mut out,
+            false,
+            None,
+            DepthGuard::root(),
+        );
+        let SlideElement::Picture(picture) = out.pop().expect("picture output") else {
+            panic!("expected PictureElement")
+        };
+        picture
+    }
+
+    fn assert_theme_properties(picture: &PictureElement) {
+        assert_eq!(
+            picture.stroke.as_ref().map(|stroke| stroke.width),
+            Some(22_222)
+        );
+        assert_eq!(picture.shadow.as_ref().map(|shadow| shadow.dist), Some(200));
+        assert_eq!(
+            picture
+                .scene3d
+                .as_ref()
+                .map(|scene| scene.camera.prst.as_str()),
+            Some("isometricLeftUp")
+        );
+        assert_eq!(
+            picture
+                .sp3d
+                .as_ref()
+                .map(|surface| surface.prst_material.as_str()),
+            Some("matte")
+        );
+    }
+
+    #[test]
+    fn normal_picture_and_blip_filled_shape_share_style_component_resolution() {
+        let theme = theme_with_picture_style();
+        let mut zip = image_zip();
+        let ordinary = run_tree_child(
+            r#"<p:pic xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <p:nvPicPr><p:cNvPr id="1" name="Picture"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+              <p:blipFill><a:blip r:embed="rIdImg"/></p:blipFill>
+              <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000" cy="1000"/></a:xfrm></p:spPr>
+              <p:style><a:lnRef idx="1"><a:srgbClr val="FFFFFF"/></a:lnRef>
+                <a:effectRef idx="1"><a:srgbClr val="FFFFFF"/></a:effectRef></p:style>
+            </p:pic>"#,
+            &LayoutPlaceholders::default(),
+            &theme,
+            &mut zip,
+        );
+        assert_theme_properties(&ordinary);
+
+        let mut zip = image_zip();
+        let blip_shape = run_tree_child(
+            r#"<p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                           xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                           xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <p:nvSpPr><p:cNvPr id="2" name="Blip shape"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+              <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000" cy="1000"/></a:xfrm>
+                <a:blipFill><a:blip r:embed="rIdImg"/></a:blipFill></p:spPr>
+              <p:style><a:lnRef idx="1"><a:srgbClr val="FFFFFF"/></a:lnRef>
+                <a:effectRef idx="1"><a:srgbClr val="FFFFFF"/></a:effectRef></p:style>
+            </p:sp>"#,
+            &LayoutPlaceholders::default(),
+            &theme,
+            &mut zip,
+        );
+        assert_theme_properties(&blip_shape);
+    }
+
+    #[test]
+    fn inherited_blip_shape_and_transformless_picture_retain_layout_effects() {
+        let property_xml = roxmltree::Document::parse(
+            r#"<p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <p:spPr><a:ln w="33333"><a:solidFill><a:srgbClr val="445566"/></a:solidFill></a:ln>
+                <a:effectLst><a:outerShdw blurRad="500" dist="700" dir="0"><a:srgbClr val="112233"/></a:outerShdw></a:effectLst>
+                <a:scene3d><a:camera prst="perspectiveFront"/><a:lightRig rig="threePt" dir="t"/></a:scene3d>
+                <a:sp3d prstMaterial="plastic"/>
+              </p:spPr>
+            </p:sp>"#,
+        )
+        .unwrap();
+        let properties = resolve_picture_shape_properties(
+            child(property_xml.root_element(), "spPr"),
+            None,
+            None,
+            &HashMap::new(),
+        );
+        let transform = Transform {
+            cx: 1000,
+            cy: 1000,
+            ..Default::default()
+        };
+        let inherited_blip = InheritedBlipFill {
+            image_path: "ppt/media/image1.png".to_owned(),
+            mime_type: "image/png".to_owned(),
+            src_rect: None,
+            alpha: None,
+            duotone: None,
+        };
+        let mut placeholders = LayoutPlaceholders::default();
+        placeholders.by_idx.insert(9, transform);
+        placeholders.by_idx_blip_fill.insert(9, inherited_blip);
+        placeholders.by_idx_picture_properties.insert(9, properties);
+
+        let assert_inherited = |picture: &PictureElement| {
+            assert_eq!(
+                picture.stroke.as_ref().map(|stroke| stroke.width),
+                Some(33_333)
+            );
+            assert_eq!(picture.shadow.as_ref().map(|shadow| shadow.dist), Some(700));
+            assert_eq!(
+                picture
+                    .scene3d
+                    .as_ref()
+                    .map(|scene| scene.camera.prst.as_str()),
+                Some("perspectiveFront")
+            );
+            assert_eq!(
+                picture
+                    .sp3d
+                    .as_ref()
+                    .map(|surface| surface.prst_material.as_str()),
+                Some("plastic")
+            );
+        };
+
+        let mut zip = image_zip();
+        let inherited_shape = run_tree_child(
+            r#"<p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                           xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <p:nvSpPr><p:cNvPr id="3" name="Inherited"/><p:cNvSpPr/><p:nvPr><p:ph type="pic" idx="9"/></p:nvPr></p:nvSpPr>
+              <p:spPr/>
+            </p:sp>"#,
+            &placeholders,
+            &HashMap::new(),
+            &mut zip,
+        );
+        assert_inherited(&inherited_shape);
+
+        let mut zip = image_zip();
+        let placeholder_picture = run_tree_child(
+            r#"<p:pic xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <p:nvPicPr><p:cNvPr id="4" name="Placeholder"/><p:cNvPicPr/><p:nvPr><p:ph type="pic" idx="9"/></p:nvPr></p:nvPicPr>
+              <p:blipFill><a:blip r:embed="rIdImg"/></p:blipFill><p:spPr/>
+            </p:pic>"#,
+            &placeholders,
+            &HashMap::new(),
+            &mut zip,
+        );
+        assert_inherited(&placeholder_picture);
     }
 }
 

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -295,6 +295,39 @@ fn merge_local_stroke(
     }
 }
 
+/// Resolve `p:style/a:lnRef` into the inherited line component. The complete
+/// theme line recipe will move to the shared format-scheme model; until then,
+/// keeping this fallback in one place prevents shapes, connectors and pictures
+/// from disagreeing about the same CT_ShapeStyle component.
+fn parse_style_stroke(
+    style_node: Option<roxmltree::Node<'_, '_>>,
+    theme: &HashMap<String, String>,
+) -> Option<Stroke> {
+    style_node
+        .and_then(|style| child(style, "lnRef"))
+        .and_then(|line_ref| {
+            let idx: u32 = attr(&line_ref, "idx")
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(1);
+            if idx == 0 {
+                return None;
+            }
+            parse_color_node(line_ref, theme).map(|color| Stroke {
+                color,
+                width: theme
+                    .get(&format!("+lnRef-{idx}"))
+                    .and_then(|value| value.parse::<i64>().ok())
+                    .unwrap_or(9525),
+                fill: None,
+                dash_style: None,
+                line_cap: None,
+                head_end: None,
+                tail_end: None,
+                cmpd: None,
+            })
+        })
+}
+
 pub(crate) fn parse_shape(
     sp_node: roxmltree::Node<'_, '_>,
     lph: &LayoutPlaceholders,
@@ -431,29 +464,7 @@ pub(crate) fn parse_shape(
     // lnStyleLst (stored as "+lnRef-N") and color from the ref's own solidFill.
     // Falling back to 9525 under-weights idx>=2 strokes (Office default theme
     // idx=2 is 19050 EMU = 1.5pt, idx=3 is 25400 EMU = 2pt).
-    let style_stroke: Option<Stroke> = style_node.and_then(|s| child(s, "lnRef")).and_then(|lr| {
-        let idx: u32 = attr(&lr, "idx").and_then(|v| v.parse().ok()).unwrap_or(1);
-        if idx == 0 {
-            None
-        } else {
-            parse_color_node(lr, theme).map(|c| {
-                let width = theme
-                    .get(&format!("+lnRef-{}", idx))
-                    .and_then(|s| s.parse::<i64>().ok())
-                    .unwrap_or(9525);
-                Stroke {
-                    color: c,
-                    width,
-                    fill: None,
-                    dash_style: None,
-                    line_cap: None,
-                    head_end: None,
-                    tail_end: None,
-                    cmpd: None,
-                }
-            })
-        }
-    });
+    let style_stroke = parse_style_stroke(style_node, theme);
 
     // fontRef → default text color for this shape.
     // Fall back to layout/master placeholder inherited color (lstStyle > lvl1pPr > defRPr
@@ -654,7 +665,9 @@ pub(crate) fn parse_shape(
         placeholder_idx: ph_idx,
         text_rect: None,
         scene3d: sp_pr.and_then(parse_scene3d).or(style_scene3d),
-        sp3d: sp_pr.and_then(parse_sp3d).or(style_sp3d),
+        sp3d: sp_pr
+            .and_then(|node| parse_sp3d(node, theme))
+            .or(style_sp3d),
     })
 }
 
@@ -837,20 +850,40 @@ pub(crate) fn parse_picture(
     let cust_geom = child(sp_pr, "custGeom")
         .map(|geometry| parse_cust_geom(geometry, t.cx as f64, t.cy as f64));
 
-    // §19.3.1.37: p:pic's spPr is CT_ShapeProperties, so effectLst (§20.1.8.16)
-    // applies to images exactly as it does to shapes.
+    // A picture has the same CT_ShapeStyle component references as a shape.
+    // Resolve the theme recipe first; a local spPr component then replaces or
+    // overlays it according to MS-OI29500 §20.1.2.2.37(b).
+    let style_node = child(pic_node, "style");
+    let style_effects = style_node
+        .and_then(|style| child(style, "effectRef"))
+        .map(|effect_ref| parse_style_matrix_effects(effect_ref, theme))
+        .unwrap_or_default();
+    let style_scene3d = style_effects.scene3d;
+    let style_sp3d = style_effects.sp3d;
+    let local_effect_node = child(sp_pr, "effectLst").or_else(|| child(sp_pr, "effectDag"));
+
+    // §19.3.1.37: p:pic's spPr is CT_ShapeProperties, so effects apply to the
+    // composed bitmap/border silhouette exactly as they do to shapes.
     let EffectLst {
         shadow,
         inner_shadow,
         glow,
         soft_edge,
         reflection,
-    } = parse_effect_lst(child(sp_pr, "effectLst"), theme);
+    } = if local_effect_node.is_some() {
+        parse_effect_lst(local_effect_node, theme)
+    } else {
+        style_effects.effects
+    };
 
     // §20.1.2.2.24 — a `p:pic`'s spPr may carry an `<a:ln>` border (e.g. the
     // white frame of PowerPoint's picture styles). `parse_stroke` returns None
     // for `<a:noFill/>`, so an explicitly border-less picture stays None.
-    let stroke = child(sp_pr, "ln").and_then(|n| parse_stroke(n, theme));
+    let stroke = merge_local_stroke(
+        child(sp_pr, "ln"),
+        parse_style_stroke(style_node, theme),
+        theme,
+    );
 
     let (prst_geom, prst_adjust) = parse_pic_prst_geom(sp_pr);
     Some(PictureElement {
@@ -884,8 +917,8 @@ pub(crate) fn parse_picture(
         glow,
         soft_edge,
         reflection,
-        scene3d: parse_scene3d(sp_pr),
-        sp3d: parse_sp3d(sp_pr),
+        scene3d: parse_scene3d(sp_pr).or(style_scene3d),
+        sp3d: parse_sp3d(sp_pr, theme).or(style_sp3d),
     })
 }
 
@@ -1802,7 +1835,7 @@ pub(crate) fn parse_sp_tree_node(
                                     soft_edge,
                                     reflection,
                                     scene3d: sp_pr_node.and_then(parse_scene3d),
-                                    sp3d: sp_pr_node.and_then(parse_sp3d),
+                                    sp3d: sp_pr_node.and_then(|node| parse_sp3d(node, theme)),
                                 }));
                                 return;
                             }
@@ -2445,29 +2478,7 @@ fn parse_connector(
     // theme fmtScheme lnStyleLst entry N (1-based). We look up the canonical
     // width from the theme map ("+lnRef-N") rather than hardcoding 9525.
     let style_node = child(node, "style");
-    let style_stroke: Option<Stroke> = style_node.and_then(|s| child(s, "lnRef")).and_then(|lr| {
-        let idx: u32 = attr(&lr, "idx").and_then(|v| v.parse().ok()).unwrap_or(1);
-        if idx == 0 {
-            None
-        } else {
-            parse_color_node(lr, theme).map(|c| {
-                let width = theme
-                    .get(&format!("+lnRef-{}", idx))
-                    .and_then(|s| s.parse::<i64>().ok())
-                    .unwrap_or(9525);
-                Stroke {
-                    color: c,
-                    width,
-                    fill: None,
-                    dash_style: None,
-                    line_cap: None,
-                    head_end: None,
-                    tail_end: None,
-                    cmpd: None,
-                }
-            })
-        }
-    });
+    let style_stroke = parse_style_stroke(style_node, theme);
 
     let stroke = merge_local_stroke(child(sp_pr, "ln"), style_stroke, theme);
 
@@ -2570,7 +2581,7 @@ fn parse_connector(
         placeholder_idx: None,
         text_rect: None,
         scene3d: parse_scene3d(sp_pr).or(style_scene3d),
-        sp3d: parse_sp3d(sp_pr).or(style_sp3d),
+        sp3d: parse_sp3d(sp_pr, theme).or(style_sp3d),
     })
 }
 

--- a/packages/pptx/parser/src/shape.rs
+++ b/packages/pptx/parser/src/shape.rs
@@ -406,6 +406,21 @@ pub(crate) fn resolve_picture_shape_properties(
         }
     };
 
+    // An explicit effectRef replaces the inherited CT_EffectStyleItem as a
+    // whole.  Its absence may inherit layout 3-D; its presence with idx=0 or
+    // an item without scene3d/sp3d must clear the older layout components just
+    // as it clears/replaces the raster effects above.
+    let inherited_scene3d = if effect_ref.is_some() {
+        None
+    } else {
+        inherited.scene3d
+    };
+    let inherited_sp3d = if effect_ref.is_some() {
+        None
+    } else {
+        inherited.sp3d
+    };
+
     PictureShapeProperties {
         stroke,
         shadow: effects.shadow,
@@ -416,11 +431,11 @@ pub(crate) fn resolve_picture_shape_properties(
         scene3d: sp_pr
             .and_then(parse_scene3d)
             .or(style_effects.scene3d)
-            .or(inherited.scene3d),
+            .or(inherited_scene3d),
         sp3d: sp_pr
             .and_then(|node| parse_sp3d(node, theme))
             .or(style_effects.sp3d)
-            .or(inherited.sp3d),
+            .or(inherited_sp3d),
     }
 }
 
@@ -3040,6 +3055,39 @@ mod picture_property_resolution_tests {
             &mut zip,
         );
         assert_inherited(&placeholder_picture);
+    }
+
+    #[test]
+    fn explicit_effect_ref_clears_inherited_3d_components() {
+        let inherited_xml = roxmltree::Document::parse(
+            r#"<p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <p:spPr><a:scene3d><a:camera prst="perspectiveFront"/><a:lightRig rig="threePt" dir="t"/></a:scene3d>
+                <a:sp3d prstMaterial="plastic"/></p:spPr>
+            </p:sp>"#,
+        )
+        .unwrap();
+        let inherited = resolve_picture_shape_properties(
+            child(inherited_xml.root_element(), "spPr"),
+            None,
+            None,
+            &HashMap::new(),
+        );
+        let slide_xml = roxmltree::Document::parse(
+            r#"<p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <p:spPr/><p:style><a:effectRef idx="0"/></p:style>
+            </p:sp>"#,
+        )
+        .unwrap();
+        let resolved = resolve_picture_shape_properties(
+            child(slide_xml.root_element(), "spPr"),
+            child(slide_xml.root_element(), "style"),
+            Some(inherited),
+            &HashMap::new(),
+        );
+        assert!(resolved.scene3d.is_none());
+        assert!(resolved.sp3d.is_none());
     }
 }
 

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -324,6 +324,9 @@ pub(crate) struct Sp3d {
     /// the shape's line/fill colour, which the renderer does not approximate).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) contour_clr: Option<String>,
+    /// Extrusion side-wall colour (`<a:extrusionClr>` child).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) extrusion_clr: Option<String>,
     /// Preset surface material (`ST_PresetMaterialType`), default "warmMatte".
     pub(crate) prst_material: String,
     /// Top bevel.
@@ -587,6 +590,24 @@ pub(crate) struct Shadow {
     pub(crate) dist: i64,
     /// direction in degrees, clockwise from East
     pub(crate) dir: f64,
+    /// Horizontal scale (1.0 = unchanged). Outer shadows only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) sx: Option<f64>,
+    /// Vertical scale (1.0 = unchanged). Outer shadows only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) sy: Option<f64>,
+    /// Horizontal skew in degrees. Outer shadows only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) kx: Option<f64>,
+    /// Vertical skew in degrees. Outer shadows only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) ky: Option<f64>,
+    /// Alignment origin for scale/skew.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) algn: Option<String>,
+    /// Whether the shadow transform follows shape rotation. Schema default true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) rot_with_shape: Option<bool>,
 }
 
 /// ECMA-376 §20.1.8.17 (CT_GlowEffect) — coloured halo with blur radius.

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2597,10 +2597,10 @@ export function cacheDevicePaint(
   const w = Math.max(1, Math.ceil(bbox.x + bbox.w) - x + 1);
   const h = Math.max(1, Math.ceil(bbox.y + bbox.h) - y + 1);
   // This cache is an optimization, not a rendering dependency. Do not allocate
-  // a viewport-external or oversized projected surface: replaying the source
+  // a fully viewport-external or oversized projected surface: replaying the source
   // projection is slower but preserves both effect reach and the shared canvas
   // safety limits without risking an OOM/DOMException.
-  if (viewport && (x < 0 || y < 0 || x + w > viewport.w || y + h > viewport.h)) return paint;
+  if (viewport && (x + w <= 0 || y + h <= 0 || x >= viewport.w || y >= viewport.h)) return paint;
   if (clampCanvasSize(w, h).clamped) return paint;
   let canvas: ReturnType<typeof createAuxCanvas> = null;
   try {
@@ -2881,19 +2881,23 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
           h: (ctx.canvas as { height: number }).height || 0,
         },
       );
+      // A declined cache is still a valid projection path: the compositor will
+      // replay rawPaint. Check success only AFTER that first paint so an
+      // off-viewport or oversized cache request cannot demote a 3-D shape to
+      // the flat fallback merely because the optimization was skipped.
+      paintWithRasterEffects(
+        ctx,
+        el,
+        cachedPaint,
+        cachedPaint,
+        projectedGeometry.bbox,
+        projectedGeometry.anchor,
+        scale,
+        scale * devScale,
+        liveTransform,
+        Boolean(el.fill),
+      );
       if (projectionSucceeded) {
-        paintWithRasterEffects(
-          ctx,
-          el,
-          cachedPaint,
-          cachedPaint,
-          projectedGeometry.bbox,
-          projectedGeometry.anchor,
-          scale,
-          scale * devScale,
-          liveTransform,
-          Boolean(el.fill),
-        );
         paintProjectedText(ctx);
         ctx.restore();
         return;

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2985,6 +2985,7 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
       effScale,
       deviceW,
       deviceH,
+      Math.atan2(liveTransform.b, liveTransform.a) * 180 / Math.PI,
     );
     ctx.restore();
     nativeShadowFallback = !painted;
@@ -5152,6 +5153,7 @@ async function renderPicture(
         effScale,
         deviceW,
         deviceH,
+        Math.atan2(liveTransform.b, liveTransform.a) * 180 / Math.PI,
       );
       ctx.restore();
       nativeShadowFallback = !painted;

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -2590,12 +2590,24 @@ export function cacheDevicePaint(
   paint: EffectPaint,
   liveTransform: EffectTransform,
   bbox: { x: number; y: number; w: number; h: number },
+  viewport?: { w: number; h: number },
 ): EffectPaint {
   const x = Math.floor(bbox.x) - 1;
   const y = Math.floor(bbox.y) - 1;
   const w = Math.max(1, Math.ceil(bbox.x + bbox.w) - x + 1);
   const h = Math.max(1, Math.ceil(bbox.y + bbox.h) - y + 1);
-  const canvas = createAuxCanvas(w, h);
+  // This cache is an optimization, not a rendering dependency. Do not allocate
+  // a viewport-external or oversized projected surface: replaying the source
+  // projection is slower but preserves both effect reach and the shared canvas
+  // safety limits without risking an OOM/DOMException.
+  if (viewport && (x < 0 || y < 0 || x + w > viewport.w || y + h > viewport.h)) return paint;
+  if (clampCanvasSize(w, h).clamped) return paint;
+  let canvas: ReturnType<typeof createAuxCanvas> = null;
+  try {
+    canvas = createAuxCanvas(w, h);
+  } catch {
+    return paint;
+  }
   const cache = canvas?.getContext('2d') as CanvasRenderingContext2D | null;
   if (!canvas || !cache) return paint;
   cache.setTransform(
@@ -2802,12 +2814,22 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
       softEdge: undefined,
       reflection: undefined,
     };
+    const localBodyEl: ShapeElement = { ...localEl, textBody: null };
+    const localTextEl: ShapeElement = {
+      ...localEl,
+      fill: null,
+      stroke: null,
+    };
     const edgePadCss =
       (el.stroke ? (el.stroke.width * scale) / 2 : 0) +
       (el.sp3d?.contourW ? el.sp3d.contourW * scale : 0) +
       (extrusion ? Math.hypot(extrusion.offsetX, extrusion.offsetY) / ctxDevScale : 0) +
       2;
-    const paintProjectedBody = (target: CanvasRenderingContext2D): boolean =>
+    const paintProjectedElement = (
+      target: CanvasRenderingContext2D,
+      projectedElement: ShapeElement,
+      padded: boolean,
+    ): boolean =>
       projectScene3dPaint(
         target,
         spScene3d.camera,
@@ -2819,10 +2841,16 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
         // localEl is at the origin (x=y=0) with the element's own EMU size, so
         // the recursive render fills the (0,0,w,h) offscreen at the same scale.
         // No onTextRun → the projected text is not selectable (see the note).
-          renderShape(octx, localEl, scale, themeDefaultColor, slideNumber, rc, undefined);
+          renderShape(octx, projectedElement, scale, themeDefaultColor, slideNumber, rc, undefined);
         },
-        { bevels, extrusion: extrusion ?? undefined, edgePadCss },
+        padded
+          ? { bevels, extrusion: extrusion ?? undefined, edgePadCss }
+          : {},
       );
+    const paintProjectedBody = (target: CanvasRenderingContext2D): boolean =>
+      paintProjectedElement(target, localBodyEl, true);
+    const paintProjectedText = (target: CanvasRenderingContext2D): boolean =>
+      !el.textBody || paintProjectedElement(target, localTextEl, false);
     const hasRasterEffects = Boolean(
       el.shadow || el.innerShadow || el.glow || el.softEdge || el.reflection,
     );
@@ -2844,7 +2872,15 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
       const rawPaint: EffectPaint = (target) => {
         projectionSucceeded = paintProjectedBody(target) || projectionSucceeded;
       };
-      const cachedPaint = cacheDevicePaint(rawPaint, liveTransform, projectedGeometry.bbox);
+      const cachedPaint = cacheDevicePaint(
+        rawPaint,
+        liveTransform,
+        projectedGeometry.bbox,
+        {
+          w: (ctx.canvas as { width: number }).width || 0,
+          h: (ctx.canvas as { height: number }).height || 0,
+        },
+      );
       if (projectionSucceeded) {
         paintWithRasterEffects(
           ctx,
@@ -2856,11 +2892,13 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
           scale,
           scale * devScale,
           liveTransform,
+          Boolean(el.fill),
         );
+        paintProjectedText(ctx);
         ctx.restore();
         return;
       }
-    } else if (paintProjectedBody(ctx)) {
+    } else if (paintProjectedElement(ctx, localEl, true)) {
       ctx.restore();
       return;
     }
@@ -5290,6 +5328,19 @@ async function renderPicture(
     );
     const devScale = det > 0 ? Math.sqrt(det) : 1;
     const paintedPad = strokeHalfCss + contourCss;
+    const clipGeometryBounds = el.custGeom && el.custGeom.length > 0
+      ? getCustomGeometryBounds(el.custGeom, x, y, w, h)
+      : el.prstGeom && hasPreset(el.prstGeom.toLowerCase())
+        ? getPresetGeometryBounds(
+            el.prstGeom.toLowerCase(),
+            x,
+            y,
+            w,
+            h,
+            el.prstAdjust ?? [],
+          )
+        : null;
+    const flatGeometryBounds = clipGeometryBounds ?? { x, y, w, h };
     const projectedGeometry = scene3d
       ? projectedEffectGeometry(
           scene3d.camera,
@@ -5304,10 +5355,10 @@ async function renderPicture(
       : {
           bbox: transformedEffectBounds(
             liveTransform,
-            x - paintedPad,
-            y - paintedPad,
-            w + paintedPad * 2,
-            h + paintedPad * 2,
+            flatGeometryBounds.x - paintedPad,
+            flatGeometryBounds.y - paintedPad,
+            flatGeometryBounds.w + paintedPad * 2,
+            flatGeometryBounds.h + paintedPad * 2,
           ),
           anchor: authoredAlignmentAnchor(
             liveTransform,
@@ -5324,10 +5375,16 @@ async function renderPicture(
     );
     const rawMask: EffectPaint = (target) => paintMask(target, '#000');
     const effectBody = scene3d && hasRasterEffects
-      ? cacheDevicePaint(paintImage, liveTransform, projectedGeometry.bbox)
+      ? cacheDevicePaint(paintImage, liveTransform, projectedGeometry.bbox, {
+          w: (ctx.canvas as { width: number }).width || 0,
+          h: (ctx.canvas as { height: number }).height || 0,
+        })
       : paintImage;
     const effectMask = scene3d && hasRasterEffects
-      ? cacheDevicePaint(rawMask, liveTransform, projectedGeometry.bbox)
+      ? cacheDevicePaint(rawMask, liveTransform, projectedGeometry.bbox, {
+          w: (ctx.canvas as { width: number }).width || 0,
+          h: (ctx.canvas as { height: number }).height || 0,
+        })
       : rawMask;
     paintWithRasterEffects(
       ctx,

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -51,6 +51,7 @@ import {
   isScene3dNonIdentity,
   drawProjected,
   expandProjectedQuad,
+  projectQuadPoint,
   createAuxCanvas,
   applyBevelShading,
   applyExtrusion,
@@ -2518,6 +2519,196 @@ export function transformedEffectBounds(
   return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
 }
 
+type EffectPaint = (target: CanvasRenderingContext2D) => void;
+
+interface RasterEffects {
+  shadow?: ShapeElement['shadow'];
+  innerShadow?: ShapeElement['innerShadow'];
+  glow?: ShapeElement['glow'];
+  softEdge?: ShapeElement['softEdge'];
+  reflection?: ShapeElement['reflection'];
+}
+
+const ALIGNMENT_UV: Record<NonNullable<Shadow['algn']>, readonly [number, number]> = {
+  tl: [0, 0], t: [0.5, 0], tr: [1, 0],
+  l: [0, 0.5], ctr: [0.5, 0.5], r: [1, 0.5],
+  bl: [0, 1], b: [0.5, 1], br: [1, 1],
+};
+
+function transformPoint(transform: EffectTransform, x: number, y: number): [number, number] {
+  return [
+    transform.a * x + transform.c * y + transform.e,
+    transform.b * x + transform.d * y + transform.f,
+  ];
+}
+
+function authoredAlignmentAnchor(
+  transform: EffectTransform,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  algn: Shadow['algn'],
+): [number, number] {
+  const [u, v] = ALIGNMENT_UV[algn ?? 'b'];
+  return transformPoint(transform, x + u * w, y + v * h);
+}
+
+export function projectedEffectGeometry(
+  camera: CameraInput,
+  transform: EffectTransform,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  edgePadCss: number,
+  algn: Shadow['algn'],
+): { bbox: { x: number; y: number; w: number; h: number }; anchor: [number, number] } {
+  const face = computeScene3dQuad(camera, w, h).corners;
+  const painted = edgePadCss > 0
+    ? expandProjectedQuad(face, edgePadCss / w, edgePadCss / h) ?? face
+    : face;
+  const devicePoints = painted.map((point) => transformPoint(transform, x + point.x, y + point.y));
+  const xs = devicePoints.map(([px]) => px);
+  const ys = devicePoints.map(([, py]) => py);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+  const [u, v] = ALIGNMENT_UV[algn ?? 'b'];
+  const projectedAnchor = projectQuadPoint(face, u, v);
+  return {
+    bbox: { x: minX, y: minY, w: maxX - minX, h: maxY - minY },
+    anchor: projectedAnchor
+      ? transformPoint(transform, x + projectedAnchor.x, y + projectedAnchor.y)
+      : authoredAlignmentAnchor(transform, x, y, w, h, algn),
+  };
+}
+
+/** Cache an expensive projected body for this one render call only. */
+export function cacheDevicePaint(
+  paint: EffectPaint,
+  liveTransform: EffectTransform,
+  bbox: { x: number; y: number; w: number; h: number },
+): EffectPaint {
+  const x = Math.floor(bbox.x) - 1;
+  const y = Math.floor(bbox.y) - 1;
+  const w = Math.max(1, Math.ceil(bbox.x + bbox.w) - x + 1);
+  const h = Math.max(1, Math.ceil(bbox.y + bbox.h) - y + 1);
+  const canvas = createAuxCanvas(w, h);
+  const cache = canvas?.getContext('2d') as CanvasRenderingContext2D | null;
+  if (!canvas || !cache) return paint;
+  cache.setTransform(
+    liveTransform.a,
+    liveTransform.b,
+    liveTransform.c,
+    liveTransform.d,
+    liveTransform.e - x,
+    liveTransform.f - y,
+  );
+  paint(cache);
+  const identity = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 } as DOMMatrix;
+  return (target) => {
+    target.save();
+    target.setTransform(identity);
+    target.drawImage(canvas as CanvasImageSource, x, y);
+    target.restore();
+  };
+}
+
+function paintWithRasterEffects(
+  ctx: CanvasRenderingContext2D,
+  effects: RasterEffects,
+  paintBody: EffectPaint,
+  paintMask: EffectPaint,
+  bbox: { x: number; y: number; w: number; h: number },
+  alignmentAnchor: readonly [number, number],
+  scale: number,
+  effectScale: number,
+  liveTransform: EffectTransform,
+  hasInterior = true,
+  paintInnerMask: EffectPaint = paintMask,
+): void {
+  const deviceW = (ctx.canvas as { width: number }).width || 0;
+  const deviceH = (ctx.canvas as { height: number }).height || 0;
+  const haveAux = deviceW > 0 && deviceH > 0;
+  const identity = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 } as DOMMatrix;
+  const applyLiveTransform = (target: CanvasRenderingContext2D) => target.setTransform(liveTransform);
+  const body = (target: CanvasRenderingContext2D) => {
+    applyLiveTransform(target);
+    paintBody(target);
+  };
+  const mask = (target: CanvasRenderingContext2D) => {
+    applyLiveTransform(target);
+    paintMask(target);
+  };
+  const innerMask = (target: CanvasRenderingContext2D) => {
+    applyLiveTransform(target);
+    paintInnerMask(target);
+  };
+  let nativeShadowFallback = false;
+  if (effects.shadow && haveAux) {
+    ctx.save();
+    ctx.setTransform(identity);
+    nativeShadowFallback = !applyOuterShadow(
+      ctx,
+      body as never,
+      bbox,
+      effects.shadow,
+      effectScale,
+      deviceW,
+      deviceH,
+      Math.atan2(liveTransform.b, liveTransform.a) * 180 / Math.PI,
+      alignmentAnchor,
+    );
+    ctx.restore();
+  } else if (effects.shadow) {
+    nativeShadowFallback = true;
+  }
+  if (effects.reflection && haveAux) {
+    ctx.save();
+    ctx.setTransform(identity);
+    applyReflection(ctx, body as never, bbox, effects.reflection, effectScale, deviceW, deviceH);
+    ctx.restore();
+  }
+  if (nativeShadowFallback) applyShadow(ctx, effects.shadow ?? null, scale);
+  else if (effects.glow) applyGlow(ctx, effects.glow, scale);
+
+  if (effects.softEdge && haveAux) {
+    ctx.save();
+    ctx.setTransform(identity);
+    applySoftEdge(
+      ctx,
+      body as never,
+      bbox,
+      effects.softEdge,
+      effectScale,
+      deviceW,
+      deviceH,
+      mask as never,
+    );
+    ctx.restore();
+  } else {
+    paintBody(ctx);
+  }
+  if (nativeShadowFallback || effects.glow) clearShadow(ctx);
+
+  if (effects.innerShadow && hasInterior && haveAux) {
+    ctx.save();
+    ctx.setTransform(identity);
+    applyInnerShadow(
+      ctx,
+      innerMask as never,
+      bbox,
+      effects.innerShadow,
+      effectScale,
+      deviceW,
+      deviceH,
+    );
+    ctx.restore();
+  }
+}
+
 function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: number, themeDefaultColor = '#000000', slideNumber?: number, rc: RenderContext = { themeMajorFont: null, themeMinorFont: null, dpr: 1 }, onTextRun?: TextRunCallback, fetchImage?: FetchImage) {
   const x = emuToPx(el.x, scale);
   const y = emuToPx(el.y, scale);
@@ -2602,34 +2793,74 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
       // The outer projection owns bevel and extrusion. Retaining sp3d here
       // would shade the recursive flat body and then shade it again outside.
       sp3d: undefined,
+      // Raster effects apply to the projected silhouette, not to the flat
+      // source face. Keeping them here clips their reach at the source
+      // offscreen and then warps the already-clipped result.
+      shadow: null,
+      innerShadow: undefined,
+      glow: undefined,
+      softEdge: undefined,
+      reflection: undefined,
     };
-    const ok = projectScene3dPaint(
-      ctx,
-      spScene3d.camera,
-      x,
-      y,
-      w,
-      h,
-      (octx) => {
+    const edgePadCss =
+      (el.stroke ? (el.stroke.width * scale) / 2 : 0) +
+      (el.sp3d?.contourW ? el.sp3d.contourW * scale : 0) +
+      (extrusion ? Math.hypot(extrusion.offsetX, extrusion.offsetY) / ctxDevScale : 0) +
+      2;
+    const paintProjectedBody = (target: CanvasRenderingContext2D): boolean =>
+      projectScene3dPaint(
+        target,
+        spScene3d.camera,
+        x,
+        y,
+        w,
+        h,
+        (octx) => {
         // localEl is at the origin (x=y=0) with the element's own EMU size, so
         // the recursive render fills the (0,0,w,h) offscreen at the same scale.
         // No onTextRun → the projected text is not selectable (see the note).
-        renderShape(octx, localEl, scale, themeDefaultColor, slideNumber, rc, undefined);
-      },
-      {
-        bevels,
-        extrusion: extrusion ?? undefined,
-        // Edge margin so the centre-aligned stroke's outer half and the
-        // extrusion sweep aren't clipped by the box-sized offscreen (see
-        // Project3dOpts.edgePadCss).
-        edgePadCss:
-          (el.stroke ? (el.stroke.width * scale) / 2 : 0) +
-          (el.sp3d?.contourW ? el.sp3d.contourW * scale : 0) +
-          (extrusion ? Math.hypot(extrusion.offsetX, extrusion.offsetY) / ctxDevScale : 0) +
-          2,
-      },
+          renderShape(octx, localEl, scale, themeDefaultColor, slideNumber, rc, undefined);
+        },
+        { bevels, extrusion: extrusion ?? undefined, edgePadCss },
+      );
+    const hasRasterEffects = Boolean(
+      el.shadow || el.innerShadow || el.glow || el.softEdge || el.reflection,
     );
-    if (ok) {
+    if (hasRasterEffects) {
+      const liveTransform = ctx.getTransform();
+      const det = Math.abs(liveTransform.a * liveTransform.d - liveTransform.b * liveTransform.c);
+      const devScale = det > 0 ? Math.sqrt(det) : 1;
+      const projectedGeometry = projectedEffectGeometry(
+        spScene3d.camera,
+        liveTransform,
+        x,
+        y,
+        w,
+        h,
+        edgePadCss,
+        el.shadow?.algn,
+      );
+      let projectionSucceeded = false;
+      const rawPaint: EffectPaint = (target) => {
+        projectionSucceeded = paintProjectedBody(target) || projectionSucceeded;
+      };
+      const cachedPaint = cacheDevicePaint(rawPaint, liveTransform, projectedGeometry.bbox);
+      if (projectionSucceeded) {
+        paintWithRasterEffects(
+          ctx,
+          el,
+          cachedPaint,
+          cachedPaint,
+          projectedGeometry.bbox,
+          projectedGeometry.anchor,
+          scale,
+          scale * devScale,
+          liveTransform,
+        );
+        ctx.restore();
+        return;
+      }
+    } else if (paintProjectedBody(ctx)) {
       ctx.restore();
       return;
     }
@@ -2771,9 +3002,6 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
   };
 
   // ── effectLst edge/blur effects (independent siblings, ECMA-376 §20.1.8.25)
-  // Device-pixel canvas extent for the auxiliary effect canvases.
-  const deviceW = (ctx.canvas as { width: number }).width || 0;
-  const deviceH = (ctx.canvas as { height: number }).height || 0;
   // The effect helpers operate in DEVICE pixels: the aux silhouette is painted
   // through the live transform (which already folds in devicePixelRatio +
   // rotation + flip), and the blit happens at identity. So bbox / radii passed
@@ -2962,86 +3190,26 @@ function renderShape(ctx: CanvasRenderingContext2D, el: ShapeElement, scale: num
     paintShapeBody(target);
     paintLineDecorations(target);
   };
-  const applyLiveTransform = (c: CanvasRenderingContext2D) => {
-    c.setTransform(liveTransform);
-  };
-
-  // outerShdw applies to the composed shape, including its outline. Drawing it
-  // from the fill alone lets a thick outline cover the dense part of the shadow
-  // (common for title bars); drawing fill and stroke with native shadow state
-  // stacks two shadows. Rasterise the complete body once and shadow that union.
-  let nativeShadowFallback = false;
-  if (el.shadow && deviceW > 0 && deviceH > 0) {
-    ctx.save();
-    ctx.setTransform(new DOMMatrix());
-    const painted = applyOuterShadow(
-      ctx,
-      (c) => {
-        applyLiveTransform(c as CanvasRenderingContext2D);
-        paintVisibleShapeBody(c as CanvasRenderingContext2D);
-      },
-      effBBox,
-      el.shadow,
-      effScale,
-      deviceW,
-      deviceH,
-      Math.atan2(liveTransform.b, liveTransform.a) * 180 / Math.PI,
-    );
-    ctx.restore();
-    nativeShadowFallback = !painted;
-  } else if (el.shadow) {
-    nativeShadowFallback = true;
-  }
-  if (nativeShadowFallback) applyShadow(ctx, el.shadow ?? null, scale);
-
-  // Reflection sits BEHIND/below the shape — draw it first so the body paints
-  // on top. §20.1.8.50. The aux silhouette bakes in the live rotation/flip via
-  // setTransform, and the helper's mirror transform operates in device space,
-  // so the live ctx must blit at identity.
-  if (el.reflection && deviceW > 0 && deviceH > 0) {
-    ctx.save();
-    ctx.setTransform(new DOMMatrix());
-    applyReflection(
-      ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintVisibleShapeBody(c as CanvasRenderingContext2D); },
-      effBBox, el.reflection, effScale, deviceW, deviceH,
-    );
-    ctx.restore();
-  }
-
-  // softEdge feathers the whole body, so it REPLACES the direct body paint.
-  // §20.1.8.53. When absent, paint the body normally.
-  if (el.softEdge && deviceW > 0 && deviceH > 0) {
-    // The feathered body is composited in untransformed device space, so reset
-    // the live transform around the blit and re-apply the same transform when
-    // painting the body into the aux canvas.
-    ctx.save();
-    ctx.setTransform(new DOMMatrix());
-    applySoftEdge(
-      ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintVisibleShapeBody(c as CanvasRenderingContext2D); },
-      effBBox, el.softEdge, effScale, deviceW, deviceH,
-      // Reuse the composed body so line-end decorations participate in the
-      // feather mask as well as the colour layer.
-      (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintVisibleShapeBody(c as CanvasRenderingContext2D); },
-    );
-    ctx.restore();
-  } else {
-    paintVisibleShapeBody(ctx);
-  }
-
-  // innerShdw casts inward, ON TOP of the fill. §20.1.8.40. Composite after the
-  // body. The silhouette callback paints a flat opaque mask.
-  // Inner shadow is cast by the filled surface. A no-fill shape has no interior
-  // to shade; synthesizing an opaque mask here invents an effect Office does
-  // not paint (a stroke, if present, remains independently visible).
-  if (el.innerShadow && fillStyle && deviceW > 0 && deviceH > 0) {
-    ctx.save();
-    ctx.setTransform(new DOMMatrix());
-    applyInnerShadow(
-      ctx, (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintShapeBody(c as CanvasRenderingContext2D, '#000'); },
-      effBBox, el.innerShadow, effScale, deviceW, deviceH,
-    );
-    ctx.restore();
-  }
+  paintWithRasterEffects(
+    ctx,
+    el,
+    paintVisibleShapeBody,
+    paintVisibleShapeBody,
+    effBBox,
+    authoredAlignmentAnchor(
+      liveTransform,
+      x,
+      y,
+      w,
+      h,
+      el.shadow?.algn,
+    ),
+    scale,
+    effScale,
+    liveTransform,
+    Boolean(fillStyle),
+    (target) => paintShapeBody(target, '#000'),
+  );
 
   // Render text inside the rotation context so text follows shape rotation
   if (el.textBody) {
@@ -5116,99 +5284,62 @@ async function renderPicture(
 
     // ── effectLst (§19.3.1.37 routes p:pic's spPr through CT_ShapeProperties,
     // so §20.1.8.16 effects apply to images). Same sequence as the p:sp path.
-    const deviceW = (ctx.canvas as { width: number }).width || 0;
-    const deviceH = (ctx.canvas as { height: number }).height || 0;
     const liveTransform = ctx.getTransform();
     const det = Math.abs(
       liveTransform.a * liveTransform.d - liveTransform.b * liveTransform.c,
     );
     const devScale = det > 0 ? Math.sqrt(det) : 1;
     const paintedPad = strokeHalfCss + contourCss;
-    const effBBox = transformedEffectBounds(
-      liveTransform,
-      x - paintedPad,
-      y - paintedPad,
-      w + paintedPad * 2,
-      h + paintedPad * 2,
-    );
+    const projectedGeometry = scene3d
+      ? projectedEffectGeometry(
+          scene3d.camera,
+          liveTransform,
+          x,
+          y,
+          w,
+          h,
+          edgePadCss,
+          el.shadow?.algn,
+        )
+      : {
+          bbox: transformedEffectBounds(
+            liveTransform,
+            x - paintedPad,
+            y - paintedPad,
+            w + paintedPad * 2,
+            h + paintedPad * 2,
+          ),
+          anchor: authoredAlignmentAnchor(
+            liveTransform,
+            x,
+            y,
+            w,
+            h,
+            el.shadow?.algn,
+          ),
+        };
     const effScale = scale * devScale; // EMU → device px
-    const applyLiveTransform = (c: CanvasRenderingContext2D) => c.setTransform(liveTransform);
-    const haveAux = deviceW > 0 && deviceH > 0;
-
-    // Cast one shadow from the composed picture (bitmap + border + contour).
-    // Native canvas shadow state would cast once for each of those paint calls,
-    // producing stacked shadows and using the pre-transform rectangle as crop.
-    let nativeShadowFallback = false;
-    if (el.shadow && haveAux) {
-      ctx.save();
-      ctx.setTransform(new DOMMatrix());
-      const painted = applyOuterShadow(
-        ctx,
-        (c) => {
-          applyLiveTransform(c as CanvasRenderingContext2D);
-          paintImage(c as CanvasRenderingContext2D);
-        },
-        effBBox,
-        el.shadow,
-        effScale,
-        deviceW,
-        deviceH,
-        Math.atan2(liveTransform.b, liveTransform.a) * 180 / Math.PI,
-      );
-      ctx.restore();
-      nativeShadowFallback = !painted;
-    } else if (el.shadow) {
-      nativeShadowFallback = true;
-    }
-
-    // Reflection sits below the picture — paint it first. §20.1.8.50. The aux
-    // paint bakes in the live rotation/flip via setTransform, so the blit runs
-    // at identity.
-    if (el.reflection && haveAux) {
-      ctx.save();
-      ctx.setTransform(new DOMMatrix());
-      applyReflection(
-        ctx,
-        (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintImage(c as CanvasRenderingContext2D); },
-        effBBox, el.reflection, effScale, deviceW, deviceH,
-      );
-      ctx.restore();
-    }
-
-    // Glow remains a native fallback effect. Outer shadow wins when both are
-    // present, matching the shape path's precedence.
-    if (nativeShadowFallback) applyShadow(ctx, el.shadow ?? null, scale);
-    else if (el.glow) applyGlow(ctx, el.glow, scale);
-
-    // softEdge feathers the whole picture, REPLACING the direct body paint
-    // (§20.1.8.53). The shadow/glow set above is carried into the aux paint via
-    // setTransform of the same live context, so it still casts.
-    if (el.softEdge && haveAux) {
-      ctx.save();
-      ctx.setTransform(new DOMMatrix());
-      applySoftEdge(
-        ctx,
-        (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintImage(c as CanvasRenderingContext2D); },
-        effBBox, el.softEdge, effScale, deviceW, deviceH,
-        (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintMask(c as CanvasRenderingContext2D, '#000'); },
-      );
-      ctx.restore();
-    } else {
-      paintImage(ctx);
-    }
-    if (nativeShadowFallback || el.glow) clearShadow(ctx);
-
-    // innerShdw casts inward, on top of the picture (§20.1.8.40).
-    if (el.innerShadow && haveAux) {
-      ctx.save();
-      ctx.setTransform(new DOMMatrix());
-      applyInnerShadow(
-        ctx,
-        (c) => { applyLiveTransform(c as CanvasRenderingContext2D); paintMask(c as CanvasRenderingContext2D, '#000'); },
-        effBBox, el.innerShadow, effScale, deviceW, deviceH,
-      );
-      ctx.restore();
-    }
+    const hasRasterEffects = Boolean(
+      el.shadow || el.innerShadow || el.glow || el.softEdge || el.reflection,
+    );
+    const rawMask: EffectPaint = (target) => paintMask(target, '#000');
+    const effectBody = scene3d && hasRasterEffects
+      ? cacheDevicePaint(paintImage, liveTransform, projectedGeometry.bbox)
+      : paintImage;
+    const effectMask = scene3d && hasRasterEffects
+      ? cacheDevicePaint(rawMask, liveTransform, projectedGeometry.bbox)
+      : rawMask;
+    paintWithRasterEffects(
+      ctx,
+      el,
+      effectBody,
+      effectMask,
+      projectedGeometry.bbox,
+      projectedGeometry.anchor,
+      scale,
+      effScale,
+      liveTransform,
+    );
 
     ctx.restore();
     // bitmap is owned by getCachedBitmapByPath's cache — do not close it here.

--- a/packages/pptx/src/shape-effect-line-decoration.test.ts
+++ b/packages/pptx/src/shape-effect-line-decoration.test.ts
@@ -5,11 +5,12 @@ import type { ShapeElement, Slide } from './types';
 interface RecordedContext {
   fills: number;
   strokes: number;
+  draws: number;
 }
 
 function contextFor(
   canvas: { width: number; height: number },
-  recorded: RecordedContext = { fills: 0, strokes: 0 },
+  recorded: RecordedContext = { fills: 0, strokes: 0, draws: 0 },
 ): CanvasRenderingContext2D {
   const state: Record<string, unknown> = {
     canvas,
@@ -17,6 +18,7 @@ function contextFor(
     measureText: (text: string) => ({ width: text.length * 6 }),
     fill: () => { recorded.fills += 1; },
     stroke: () => { recorded.strokes += 1; },
+    drawImage: () => { recorded.draws += 1; },
   };
   return new Proxy(state, {
     get(target, property, receiver) {
@@ -30,7 +32,7 @@ function contextFor(
 }
 
 class TestOffscreenCanvas {
-  readonly recorded: RecordedContext = { fills: 0, strokes: 0 };
+  readonly recorded: RecordedContext = { fills: 0, strokes: 0, draws: 0 };
   readonly context: CanvasRenderingContext2D;
 
   constructor(public width: number, public height: number) {
@@ -121,5 +123,38 @@ describe('shape raster effects', () => {
     expect(created).toHaveLength(1);
     expect(created[0].recorded.strokes).toBeGreaterThan(0);
     expect(created[0].recorded.fills).toBeGreaterThan(0);
+  });
+
+  it('keeps a partly off-viewport shadowed shape in the 3-D projection path', async () => {
+    vi.stubGlobal('OffscreenCanvas', TestOffscreenCanvas);
+    const canvas = {
+      width: 960,
+      height: 540,
+      style: {} as CSSStyleDeclaration,
+      offsetWidth: 960,
+    } as HTMLCanvasElement;
+    const recorded: RecordedContext = { fills: 0, strokes: 0, draws: 0 };
+    canvas.getContext = (() => contextFor(canvas, recorded)) as unknown as HTMLCanvasElement['getContext'];
+    const shape: ShapeElement = {
+      ...shadowedArrow(),
+      x: -457_200,
+      geometry: 'rect',
+      fill: { fillType: 'solid', color: '4472C4' },
+      stroke: null,
+      scene3d: {
+        camera: { prst: 'isometricLeftUp' },
+        lightRig: { rig: 'threePt', dir: 't' },
+      },
+    };
+    await renderSlide(canvas, {
+      index: 0,
+      slideNumber: 1,
+      background: null,
+      elements: [shape],
+    }, 9_144_000, 6_858_000, { width: 960, dpr: 1 });
+
+    // A flat fallback only fills/strokes paths. drawImage on the live context
+    // proves the camera warp survived the declined viewport-external cache.
+    expect(recorded.draws).toBeGreaterThan(0);
   });
 });

--- a/packages/pptx/src/shape-effect-transform.test.ts
+++ b/packages/pptx/src/shape-effect-transform.test.ts
@@ -63,4 +63,20 @@ describe('shape effect bounds', () => {
     expect(expensiveProjection).toHaveBeenCalledTimes(1);
     expect(replayContext.drawImage).toHaveBeenCalledTimes(2);
   });
+
+  it('declines an oversized projection cache and safely replays the source', () => {
+    const constructor = vi.fn();
+    vi.stubGlobal('OffscreenCanvas', constructor);
+    const projection = vi.fn();
+    const replay = cacheDevicePaint(
+      projection,
+      { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+      { x: 0, y: 0, w: 100_000, h: 100_000 },
+      { w: 960, h: 540 },
+    );
+    replay({} as CanvasRenderingContext2D);
+    replay({} as CanvasRenderingContext2D);
+    expect(constructor).not.toHaveBeenCalled();
+    expect(projection).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/pptx/src/shape-effect-transform.test.ts
+++ b/packages/pptx/src/shape-effect-transform.test.ts
@@ -79,4 +79,28 @@ describe('shape effect bounds', () => {
     expect(constructor).not.toHaveBeenCalled();
     expect(projection).toHaveBeenCalledTimes(2);
   });
+
+  it('still caches a bounded projection that crosses a viewport edge', () => {
+    const cacheContext = { setTransform: vi.fn() };
+    let created = 0;
+    class CrossingCanvas {
+      constructor() { created += 1; }
+      getContext(): typeof cacheContext { return cacheContext; }
+    }
+    vi.stubGlobal('OffscreenCanvas', CrossingCanvas);
+    const projection = vi.fn();
+    const replay = cacheDevicePaint(
+      projection,
+      { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+      { x: -2, y: 20, w: 100, h: 60 },
+      { w: 960, h: 540 },
+    );
+    const target = {
+      save: vi.fn(), restore: vi.fn(), setTransform: vi.fn(), drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D;
+    replay(target);
+    replay(target);
+    expect(created).toBe(1);
+    expect(projection).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/pptx/src/shape-effect-transform.test.ts
+++ b/packages/pptx/src/shape-effect-transform.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { transformedEffectBounds } from './renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cacheDevicePaint, projectedEffectGeometry, transformedEffectBounds } from './renderer';
 
 describe('shape effect bounds', () => {
+  afterEach(() => vi.unstubAllGlobals());
   it('includes the active group transform translation and scale', () => {
     expect(transformedEffectBounds(
       { a: 1.5, b: 0, c: 0, d: 1.5, e: 72, f: 45 },
@@ -20,5 +21,46 @@ describe('shape effect bounds', () => {
       40,
       30,
     )).toEqual({ x: 400, y: 50, w: 60, h: 80 });
+  });
+
+  it('keeps the authored shadow anchor distinct from the projected AABB corner', () => {
+    const geometry = projectedEffectGeometry(
+      { prst: 'orthographicFront' },
+      { a: 0, b: 1, c: -1, d: 0, e: 75, f: -25 },
+      0,
+      0,
+      100,
+      50,
+      0,
+      'tr',
+    );
+    expect(geometry.bbox).toEqual({ x: 25, y: -25, w: 50, h: 100 });
+    expect(geometry.anchor).toEqual([75, 75]);
+    expect(geometry.anchor).not.toEqual([geometry.bbox.x + geometry.bbox.w, geometry.bbox.y]);
+  });
+
+  it('reuses one device-space projection across multiple effect passes', () => {
+    const cacheContext = { setTransform: vi.fn() };
+    class TestOffscreenCanvas {
+      constructor(public width: number, public height: number) {}
+      getContext(): typeof cacheContext { return cacheContext; }
+    }
+    vi.stubGlobal('OffscreenCanvas', TestOffscreenCanvas);
+    const expensiveProjection = vi.fn();
+    const replayContext = {
+      save: vi.fn(),
+      restore: vi.fn(),
+      setTransform: vi.fn(),
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D;
+    const replay = cacheDevicePaint(
+      expensiveProjection,
+      { a: 2, b: 0, c: 0, d: 2, e: 20, f: 30 },
+      { x: 10, y: 15, w: 100, h: 60 },
+    );
+    replay(replayContext);
+    replay(replayContext);
+    expect(expensiveProjection).toHaveBeenCalledTimes(1);
+    expect(replayContext.drawImage).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -425,6 +425,8 @@ export interface Sp3d {
    *  approximation of the 3D contour edge (uniform-width outline, no bevel
    *  shading) when both `contourW` and `contourClr` are present. */
   contourClr?: string;
+  /** Extrusion side-wall colour (`<a:extrusionClr>`) as a resolved hex string. */
+  extrusionClr?: string;
   /** Preset surface material (`ST_PresetMaterialType`), default "warmMatte". */
   prstMaterial: string;
   /** Top bevel. */


### PR DESCRIPTION
## Summary
- honor standard outer-shadow alignment, scale, skew, and rotWithShape behavior
- resolve picture line/effect style references through the same CT_ShapeStyle path as shapes
- preserve theme-resolved contour and extrusion colors from CT_Shape3D

## Specification
- ECMA-376 Part 1 §20.1.8.45 (outerShdw)
- ECMA-376 Part 1 §20.1.5.12 (sp3d)
- ECMA-376 Part 1 §19.3.1.37 and MS-OI29500 §20.1.2.2.37(b) (picture shape style inheritance)

## Verification
- cargo test -p pptx-parser
- cargo clippy -p pptx-parser -- -D warnings
- focused core/PPTX effect and 3D renderer tests
- pnpm typecheck
- pnpm build
- pnpm check:public-api:built
- pnpm check:public-type-exports
- git diff --check