### PR TITLE
fix(pptx): preserve sharp reflection contact edge

### DIFF
--- a/packages/pptx/src/reflection-blur.test.ts
+++ b/packages/pptx/src/reflection-blur.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { paintDistanceAwareReflectionBlur } from './reflection-blur';
+
+class RecordingContext {
+  readonly ops: Array<{ op: string; args?: number[] | string[] }> = [];
+  filter = 'none';
+
+  save() { this.ops.push({ op: 'save' }); }
+  restore() { this.ops.push({ op: 'restore' }); this.filter = 'none'; }
+  beginPath() { this.ops.push({ op: 'beginPath' }); }
+  rect(...args: number[]) { this.ops.push({ op: 'rect', args }); }
+  clip() { this.ops.push({ op: 'clip' }); }
+  drawImage() { this.ops.push({ op: 'drawImage', args: [this.filter] }); }
+}
+
+describe('paintDistanceAwareReflectionBlur', () => {
+  it('keeps the contact band sharp and increases blur toward the far edge', () => {
+    const target = new RecordingContext();
+
+    paintDistanceAwareReflectionBlur(
+      target as unknown as CanvasRenderingContext2D,
+      {} as HTMLCanvasElement,
+      { x: 10, y: 20, w: 100, h: 40 },
+      2,
+      140,
+    );
+
+    const radii = target.ops
+      .filter(op => op.op === 'drawImage')
+      .map(op => op.args?.[0] as string)
+      .map(filter => filter === 'none' ? 0 : Number(/^blur\((.+)px\)$/.exec(filter)?.[1]));
+    expect(radii.length).toBeGreaterThan(4);
+    expect(radii[0]).toBe(0);
+    expect(radii.at(-1)).toBeCloseTo(2, 10);
+    expect(radii.every((radius, index) => index === 0 || radius >= radii[index - 1])).toBe(true);
+
+    const clips = target.ops.filter(op => op.op === 'rect');
+    expect(clips[0].args?.[1]).toBeGreaterThan(20);
+    expect(clips.at(-1)?.args?.[1]).toBeCloseTo(20, 10);
+  });
+
+  it('uses one sharp pass when no blur is authored', () => {
+    const target = new RecordingContext();
+
+    paintDistanceAwareReflectionBlur(
+      target as unknown as CanvasRenderingContext2D,
+      {} as HTMLCanvasElement,
+      { x: 0, y: 5, w: 20, h: 10 },
+      0,
+      20,
+    );
+
+    expect(target.ops.filter(op => op.op === 'drawImage')).toEqual([
+      { op: 'drawImage', args: ['none'] },
+    ]);
+  });
+});
+

--- a/packages/pptx/src/reflection-blur.ts
+++ b/packages/pptx/src/reflection-blur.ts
@@ -1,0 +1,72 @@
+type ReflectionCanvas = HTMLCanvasElement | OffscreenCanvas;
+type ReflectionContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+export interface ReflectionBlurBounds {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+interface ReflectionBlurBand {
+  y: number;
+  h: number;
+  radius: number;
+}
+
+/**
+ * PowerPoint keeps a floor reflection sharp where it meets the source and
+ * progressively increases the authored blur toward the far edge. ECMA-376
+ * §20.1.8.50 defines the authored blur radius but does not prescribe a Canvas
+ * rasterisation algorithm. Treat that value as the far-edge radius and
+ * approximate the observed Office result with narrow monotonic bands. The
+ * source is painted once; only bitmap copies are repeated, keeping glyph
+ * shaping out of the band loop.
+ */
+function reflectionBlurBands(
+  bounds: ReflectionBlurBounds,
+  maxBlur: number,
+): ReflectionBlurBand[] {
+  if (!(maxBlur > 0) || !(bounds.h > 0)) {
+    return [{ y: bounds.y, h: Math.max(0, bounds.h), radius: 0 }];
+  }
+
+  // Around eight samples per blur pixel keeps adjacent filter radii close
+  // enough to avoid visible steps. Bound the number of bitmap passes because a
+  // presentation may contain many reflected runs.
+  const count = Math.max(4, Math.min(24, Math.ceil(maxBlur * 8)));
+  const bottom = bounds.y + bounds.h;
+  const bands: ReflectionBlurBand[] = [];
+  for (let index = 0; index < count; index++) {
+    const near = index / count;
+    const far = (index + 1) / count;
+    const y = bottom - far * bounds.h;
+    bands.push({
+      y,
+      h: bottom - near * bounds.h - y,
+      // The first band touches the source and must remain sharp. The last band
+      // reaches the authored blur radius at the far edge.
+      radius: maxBlur * index / (count - 1),
+    });
+  }
+  return bands;
+}
+
+/** Paint a sharp reflection source with blur that grows away from its bottom edge. */
+export function paintDistanceAwareReflectionBlur(
+  target: ReflectionContext,
+  source: ReflectionCanvas,
+  bounds: ReflectionBlurBounds,
+  maxBlur: number,
+  canvasWidth: number,
+): void {
+  for (const band of reflectionBlurBands(bounds, maxBlur)) {
+    target.save();
+    target.beginPath();
+    target.rect(0, band.y, canvasWidth, band.h);
+    target.clip();
+    target.filter = band.radius > 0 ? `blur(${band.radius}px)` : 'none';
+    target.drawImage(source as CanvasImageSource, 0, 0);
+    target.restore();
+  }
+}

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -101,6 +101,7 @@ import type { WarpEnvelope, WarpGlyphTransform } from '@silurus/ooxml-core';
 import type { CameraInput, Vec2, BevelInput, ExtrusionInput, BevelRegion } from '@silurus/ooxml-core';
 import type { MathNode, MathRenderer } from '@silurus/ooxml-core';
 import type { HyperlinkTarget } from '@silurus/ooxml-core';
+import { paintDistanceAwareReflectionBlur } from './reflection-blur';
 import { classifyPptxHyperlink } from './hyperlink';
 import { drawPlayBadge } from './media-chrome';
 import {
@@ -632,13 +633,12 @@ function applyTextRunReflection(
   const cropBottom = Math.min(deviceH, Math.ceil(bbox.y + bbox.h + margin));
   const cropW = Math.max(1, cropRight - cropX);
   const cropH = Math.max(1, cropBottom - cropY);
-  const aux = createAuxCanvas(cropW, cropH);
-  const auxCtx = aux?.getContext('2d') as CanvasRenderingContext2D | null;
-  if (!aux || !auxCtx) return;
+  const source = createAuxCanvas(cropW, cropH);
+  const sourceCtx = source?.getContext('2d') as CanvasRenderingContext2D | null;
+  if (!source || !sourceCtx) return;
 
-  auxCtx.save();
-  if (blur > 0) auxCtx.filter = `blur(${blur}px)`;
-  auxCtx.setTransform(
+  sourceCtx.save();
+  sourceCtx.setTransform(
     liveTransform.a,
     liveTransform.b,
     liveTransform.c,
@@ -646,11 +646,30 @@ function applyTextRunReflection(
     liveTransform.e - cropX,
     liveTransform.f - cropY,
   );
-  paintText(auxCtx);
-  auxCtx.restore();
+  paintText(sourceCtx);
+  sourceCtx.restore();
 
   const localTop = bbox.y - cropY;
   const localBottom = localTop + bbox.h;
+  let aux = source;
+  let auxCtx = sourceCtx;
+  if (blur > 0) {
+    const progressive = createAuxCanvas(cropW, cropH);
+    const progressiveCtx = progressive?.getContext('2d') as CanvasRenderingContext2D | null;
+    if (progressive && progressiveCtx) {
+      aux = progressive;
+      auxCtx = progressiveCtx;
+    }
+  }
+  if (aux !== source) {
+    paintDistanceAwareReflectionBlur(
+      auxCtx,
+      source,
+      { x: bbox.x - cropX, y: localTop, w: bbox.w, h: bbox.h },
+      blur,
+      cropW,
+    );
+  }
   const stPos = Math.max(0, Math.min(1, reflection.stPos));
   const endPos = Math.max(0, Math.min(1, reflection.endPos));
   // Chromium's OffscreenCanvas clears the destination for a gradient-filled


### PR DESCRIPTION
## Summary
- paint reflected text once into a sharp source surface
- increase blur monotonically from zero at the contact edge to the authored blur radius at the far edge
- keep the existing alpha ramp, position, scaling, and mirror transform unchanged
- bound bitmap passes so glyph shaping is never repeated

## Basis
ECMA-376 Part 1 section 20.1.8.50 defines the reflection blur radius and alpha ramp. The distance-aware rasterization follows observed PowerPoint floor-reflection behavior; the specification does not prescribe a Canvas rasterization algorithm.

## Verification
- PPTX/Core focused Vitest: 98 files, 664 tests
- PPTX TypeScript build
- Chrome visual comparison against the Office PDF reference
- unchanged current-renderer pixels for unaffected slides in the inspected deck
- git diff --check