### PR TITLE
fix(pptx): keep reflection contact edge legible

### DIFF
--- a/packages/pptx/src/reflection-blur.test.ts
+++ b/packages/pptx/src/reflection-blur.test.ts
@@ -37,6 +37,40 @@ describe('paintDistanceAwareReflectionBlur', () => {
     const clips = target.ops.filter(op => op.op === 'rect');
     expect(clips[0].args?.[1]).toBeGreaterThan(20);
     expect(clips.at(-1)?.args?.[1]).toBeCloseTo(20, 10);
+
+    // The band containing the spatial midpoint follows radius = maxBlur × d².
+    const midpointY = 40;
+    const midpointIndex = clips.findIndex(op => {
+      const y = op.args?.[1] as number;
+      const h = op.args?.[3] as number;
+      return y <= midpointY && midpointY <= y + h;
+    });
+    expect(radii[midpointIndex]).toBeCloseTo(0.5, 1);
+
+    // Radius increments stay uniform even though the spatial bands do not.
+    const radiusSteps = radii.slice(1).map((radius, index) => radius - radii[index]);
+    expect(Math.max(...radiusSteps) - Math.min(...radiusSteps)).toBeLessThan(1e-10);
+    expect(clips[0].args?.[3]).toBeGreaterThan(clips.at(-1)?.args?.[3] as number);
+  });
+
+  it('bounds adjacent radius changes when the pass cap is reached', () => {
+    const target = new RecordingContext();
+
+    paintDistanceAwareReflectionBlur(
+      target as unknown as CanvasRenderingContext2D,
+      {} as HTMLCanvasElement,
+      { x: 0, y: 0, w: 100, h: 80 },
+      100,
+      100,
+    );
+
+    const radii = target.ops
+      .filter(op => op.op === 'drawImage')
+      .map(op => op.args?.[0] as string)
+      .map(filter => filter === 'none' ? 0 : Number(/^blur\((.+)px\)$/.exec(filter)?.[1]));
+    expect(radii).toHaveLength(24);
+    const radiusSteps = radii.slice(1).map((radius, index) => radius - radii[index]);
+    expect(Math.max(...radiusSteps)).toBeCloseTo(100 / 23, 10);
   });
 
   it('uses one sharp pass when no blur is authored', () => {
@@ -55,4 +89,3 @@ describe('paintDistanceAwareReflectionBlur', () => {
     ]);
   });
 });
-

--- a/packages/pptx/src/reflection-blur.ts
+++ b/packages/pptx/src/reflection-blur.ts
@@ -38,14 +38,27 @@ function reflectionBlurBands(
   const bottom = bounds.y + bounds.h;
   const bands: ReflectionBlurBand[] = [];
   for (let index = 0; index < count; index++) {
-    const near = index / count;
-    const far = (index + 1) / count;
+    // Quantise the quadratic radius curve by equal radius increments, then
+    // derive non-uniform spatial cells around those samples. Keeping radius
+    // deltas uniform avoids the large far-edge jumps (and visible horizontal
+    // seams) produced by evaluating distance² over uniformly-spaced bands.
+    const sample = Math.sqrt(index / (count - 1));
+    const previous = index === 0
+      ? 0
+      : Math.sqrt((index - 1) / (count - 1));
+    const next = index === count - 1
+      ? 1
+      : Math.sqrt((index + 1) / (count - 1));
+    const near = index === 0 ? 0 : (previous + sample) / 2;
+    const far = index === count - 1 ? 1 : (sample + next) / 2;
     const y = bottom - far * bounds.h;
     bands.push({
       y,
-      h: bottom - near * bounds.h - y,
+      h: (far - near) * bounds.h,
       // The first band touches the source and must remain sharp. The last band
-      // reaches the authored blur radius at the far edge.
+      // reaches the authored blur radius at the far edge. PowerPoint's floor
+      // reflection keeps the near field legible longer than a linear radius
+      // ramp; a quadratic ramp matches that observed depth-of-field falloff.
       radius: maxBlur * index / (count - 1),
     });
   }


### PR DESCRIPTION
## Summary
- preserve a sharper near-contact region for DrawingML text reflections
- quantize the distance-aware blur curve with equal radius increments to avoid new far-edge banding
- keep the existing 24-pass performance bound

## Rationale
ECMA-376 section 20.1.8.50 defines the authored reflection blur radius but does not prescribe Canvas rasterization. PowerPoint floor reflections keep the contact edge legible and increase blur with distance; this change models that observed behavior without sample-specific tuning.

## Verification
- independent adversarial review: APPROVE, no P0-P2 findings
- PPTX Vitest: 97 files / 651 tests passed
- TypeScript 7 project build passed
- git diff --check passed
- local PowerPoint/PDF fidelity comparison completed