### PR TITLE
perf(pptx): reduce reflection blur passes

### DIFF
--- a/packages/pptx/src/reflection-blur.test.ts
+++ b/packages/pptx/src/reflection-blur.test.ts
@@ -29,7 +29,7 @@ describe('paintDistanceAwareReflectionBlur', () => {
       .filter(op => op.op === 'drawImage')
       .map(op => op.args?.[0] as string)
       .map(filter => filter === 'none' ? 0 : Number(/^blur\((.+)px\)$/.exec(filter)?.[1]));
-    expect(radii.length).toBeGreaterThan(4);
+    expect(radii).toHaveLength(5);
     expect(radii[0]).toBe(0);
     expect(radii.at(-1)).toBeCloseTo(2, 10);
     expect(radii.every((radius, index) => index === 0 || radius >= radii[index - 1])).toBe(true);
@@ -50,6 +50,7 @@ describe('paintDistanceAwareReflectionBlur', () => {
     // Radius increments stay uniform even though the spatial bands do not.
     const radiusSteps = radii.slice(1).map((radius, index) => radius - radii[index]);
     expect(Math.max(...radiusSteps) - Math.min(...radiusSteps)).toBeLessThan(1e-10);
+    expect(Math.max(...radiusSteps)).toBeLessThanOrEqual(0.5);
     expect(clips[0].args?.[3]).toBeGreaterThan(clips.at(-1)?.args?.[3] as number);
   });
 

--- a/packages/pptx/src/reflection-blur.ts
+++ b/packages/pptx/src/reflection-blur.ts
@@ -14,6 +14,8 @@ interface ReflectionBlurBand {
   radius: number;
 }
 
+const TARGET_RADIUS_STEP_PX = 0.5;
+
 /**
  * PowerPoint keeps a floor reflection sharp where it meets the source and
  * progressively increases the authored blur toward the far edge. ECMA-376
@@ -31,10 +33,14 @@ function reflectionBlurBands(
     return [{ y: bounds.y, h: Math.max(0, bounds.h), radius: 0 }];
   }
 
-  // Around eight samples per blur pixel keeps adjacent filter radii close
-  // enough to avoid visible steps. Bound the number of bitmap passes because a
-  // presentation may contain many reflected runs.
-  const count = Math.max(4, Math.min(24, Math.ceil(maxBlur * 8)));
+  // A half-device-pixel radius step is already below the visible filter change
+  // for text at normal display scales. Finer sampling only repeats full bitmap
+  // copies without improving the edge. Bound the pass count because one slide
+  // may contain many reflected runs.
+  const count = Math.max(
+    4,
+    Math.min(24, Math.ceil(maxBlur / TARGET_RADIUS_STEP_PX) + 1),
+  );
   const bottom = bounds.y + bounds.h;
   const bands: ReflectionBlurBand[] = [];
   for (let index = 0; index < count; index++) {


### PR DESCRIPTION
## Summary
- reduce distance-aware text-reflection bitmap passes from eighth-pixel to half-pixel radius steps
- keep the quadratic near-contact blur curve and the existing 24-pass safety cap
- reduce the representative 2.67 px case from 22 passes to 7

## Verification
- independent adversarial Canvas comparison: APPROVE, no P0-P2 findings
- PPTX Vitest: 97 files / 651 tests passed
- TypeScript 7 project build passed
- local Storybook fidelity check passed
- git diff --check passed