### PR TITLE
chore(release): 0.77.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ semantic versioning. While the major version is zero, minor releases may contain
 explicitly documented breaking changes; patch releases remain compatible with
 the corresponding minor release.
 
+## 0.77.1 — 2026-08-11
+
+Patch. Improves shared DrawingML fidelity and PowerPoint rendering without
+changing the 0.77 public API.
+
+- **shared DrawingML geometry and styles:** evaluate custom-geometry guides and
+  quadratic Bézier paths consistently in DOCX, XLSX, and PPTX; preserve theme
+  fill and line recipes, chart color-map overrides, and complete linear/path
+  gradient geometry instead of flattening them during parsing. Theme fragment,
+  relationship, raster-tile, and projected-effect work remains bounded for
+  untrusted documents. (#1209, #1210, #1212, #1213)
+- **PowerPoint themes, charts, and tables:** resolve theme backgrounds, image
+  fills, tint/shade transforms, hidden layout graphics, chart series and axis
+  defaults, table banding, text roles, bullets, borders, gradients, and vertical
+  cell content more like PowerPoint. (#1188–#1202, #1204, #1206, #1212, #1213)
+- **PowerPoint effects and 3-D:** compose shadows, reflections, soft edges,
+  callout leaders, arrowheads, picture effects, bevels, extrusion colors, and
+  projected 3-D silhouettes from the complete painted object. Effect surfaces
+  use conservative bounds and allocation limits, and floor reflections keep a
+  sharp contact edge while blur increases with distance. (#1203, #1205,
+  #1207–#1211, #1214–#1217)
+- **layout correctness and verification:** ignore terminal paragraph whitespace
+  that would create a spurious continuation line, preserve inherited bullet and
+  auto-number formatting, and verify the cross-format renderer changes against
+  the complete private regression corpus using v0.77.0 as the baseline.
+  (#1193, #1198, #1204, #1213)
+
 ## 0.77.0 — 2026-08-10
 
 Breaking minor release. Unifies read-only selection and integration context

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.77.0"
+version = "0.77.1"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pnpm add @silurus/ooxml
 > **Bundle size note**: the package is ESM-only (`.mjs`). npm's *Unpacked
 > Size* sums every entry bundle **and** the standalone MathJax + STIX Two Math
 > asset, so the reported figure is much larger than any single app build. For
-> v0.77.0, the complete npm package is approximately 11.3 MB unpacked (3.8 MB
+> v0.77.1, the complete npm package is approximately 11.3 MB unpacked (3.8 MB
 > as the downloaded tarball), while a format-specific application graph is
 > approximately:
 >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.77.0",
+  "version": "0.77.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.77.0",
+  "version": "0.77.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.77.0",
+  "version": "0.77.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.77.0",
+  "version": "0.77.1",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.77.0"
+version = "0.77.1"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.77.0",
+  "version": "0.77.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.77.0",
+  "version": "0.77.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.77.0",
+  "version": "0.77.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.77.0",
+  "version": "0.77.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.77.0",
+  "version": "0.77.1",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/lib/announcements.ts
+++ b/site/src/lib/announcements.ts
@@ -28,6 +28,62 @@ export interface Announcement {
 
 export const announcements: readonly Announcement[] = [
   {
+    slug: 'v0771-rendering-fidelity',
+    date: '2026-08-11',
+    label: 'Release note',
+    version: 'v0.77.1',
+    title: 'DrawingML and PowerPoint fidelity in v0.77.1',
+    summary: 'v0.77.1 improves shared DrawingML geometry, theme styles and gradients, and fixes PowerPoint effects, charts, tables and text without changing the v0.77 API.',
+    audience: 'Applications that display DOCX, XLSX or PPTX files. No source changes are required when upgrading from v0.77.0.',
+    sections: [
+      {
+        title: 'In short',
+        modules: ['@silurus/ooxml/docx', '@silurus/ooxml/xlsx', '@silurus/ooxml/pptx', '@silurus/ooxml/node', 'office-open-xml-viewer (VS Code extension)'],
+        rationale: 'DrawingML concepts shared by Word, Excel and PowerPoint should be parsed once and retain the information each renderer needs.',
+        kind: 'summary',
+        paragraphs: [
+          'This patch is compatible with v0.77.0. It changes rendering and parser fidelity only; it does not rename or remove public APIs.',
+          'The largest improvements are visible in presentations that rely on theme fills, custom geometry, table and chart defaults, shadows, 3-D effects or reflected text. Shared DrawingML line and gradient fixes also benefit Word and Excel documents that use the same OOXML features.',
+        ],
+        bullets: [
+          'DOCX, XLSX and PPTX now share custom-geometry guide evaluation and complete theme line and gradient models.',
+          'PowerPoint theme backgrounds, image fills, chart defaults, table styles, bullets and terminal whitespace follow their authored or inherited values more closely.',
+          'Shadows and related effects use the complete painted silhouette, including protruding callout leaders, strokes and line ends.',
+          'Text reflections stay sharp where they meet the source and become blurrier with distance while keeping bounded rendering work.',
+        ],
+      },
+      {
+        title: 'Shared DrawingML improvements',
+        modules: ['@silurus/ooxml/docx', '@silurus/ooxml/xlsx', '@silurus/ooxml/pptx', '@silurus/ooxml/node'],
+        rationale: 'Custom geometry, themes, line styles and gradients are DrawingML features used by all three Office formats.',
+        paragraphs: [
+          'The parsers now evaluate custom-geometry formulas and quadratic Bézier paths through one shared implementation, including the standard fallback when a path omits its own coordinate size.',
+          'Theme fill and line recipes retain their colors, dashes, joins, line ends and gradient geometry. Chart color-map overrides and XLSX theme relationships are resolved before rendering instead of being replaced with a flat fallback color.',
+          'Theme XML retention, gradient tiles and projected effect surfaces remain bounded so these fidelity improvements do not remove the existing protections for large or hostile documents.',
+        ],
+      },
+      {
+        title: 'PowerPoint rendering fixes',
+        modules: ['@silurus/ooxml/pptx', '@silurus/ooxml/node', 'office-open-xml-viewer (VS Code extension)'],
+        rationale: 'PowerPoint builds the final appearance by combining inherited theme, layout and local properties before applying effects to the complete painted object.',
+        paragraphs: [
+          'Presentation backgrounds and shape fills now preserve theme images and PowerPoint color transforms. Hidden layout graphics stay hidden, while charts and tables inherit the intended axes, labels, banding, text, borders and fills.',
+          'Outer shadows, reflections, soft edges and 3-D effects are composited after the full fill, stroke, callout and arrowhead silhouette is known. This prevents effects from disappearing, being clipped, or being applied separately to only part of an object.',
+          'Text layout retains authored bullet and auto-number formatting, ignores paragraph-ending whitespace that should not create another line, and renders floor reflections with a legible contact edge and increasing blur farther from the text.',
+        ],
+      },
+      {
+        title: 'Compatibility and verification',
+        modules: ['@silurus/ooxml/docx', '@silurus/ooxml/xlsx', '@silurus/ooxml/pptx'],
+        rationale: 'A patch release must improve rendering without requiring application code changes.',
+        paragraphs: [
+          'The v0.77 public API remains unchanged. Existing Viewer, document, selection and MCP integrations continue to use the same calls and types.',
+          'The renderer changes were checked with parser and TypeScript test suites, public API checks, focused PowerPoint/PDF comparisons, independent adversarial reviews, and the complete private DOCX/XLSX/PPTX visual regression corpus using v0.77.0 as the previous-renderer baseline.',
+        ],
+      },
+    ],
+  },
+  {
     slug: 'v077-migration-guide',
     date: '2026-08-10',
     label: 'Release note',


### PR DESCRIPTION
## Summary

- bump the npm package, internal workspace packages, VS Code extension, site, and MCP server to 0.77.1
- document the shared DrawingML and PowerPoint fidelity fixes merged since v0.77.0
- publish a matching official-site release note with no API migration required
- refresh the README package-size version; regenerated screenshots are byte-identical

## Verification

- `pnpm typecheck`
- `pnpm build`
- public API baselines, viewer symmetry, and published type-export checks
- `cargo check -p ooxml-mcp-server`
- official site production build (19 routes)
- 6,856 general Vitest assertions plus the native Canvas pixel-equality suite in an isolated process
- complete private DOCX/XLSX/PPTX regression corpus against fixed previous-renderer revisions; the final reflection pass-count optimization changed only its intended effect region (maximum channel delta 5), with every DOCX/XLSX capture and all other PPTX captures matching
- npm dry-run package: 3,889,888 bytes compressed, 11,671,716 bytes unpacked
