### PR TITLE
docs(pptx): clarify letter spacing units

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -412,8 +412,9 @@ export interface TextRunData {
    */
   caps?: 'none' | 'small' | 'all';
   /**
-   * Inter-character spacing in 100ths of a point — ECMA-376 §21.1.2.3.5
-   * (rPr @spc). Positive values add space, negative values tighten.
+   * Inter-character spacing in points. Positive values add space; negative
+   * values tighten. DrawingML stores `rPr@spc` in 100ths of a point, and the
+   * PPTX parser converts that encoded value to points.
    */
   letterSpacing?: number;
   /** Set for OOXML field runs (e.g. "slidenum"). When set, renderer replaces text with field value. */

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -1149,7 +1149,8 @@ pub(crate) struct TextRunData {
     /// "none" | "small" | "all". None = inherit / no transform.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) caps: Option<String>,
-    /// Letter spacing (rPr @spc). 100ths of a point. Positive = looser, negative = tighter.
+    /// Letter spacing in points after converting DrawingML `rPr@spc` from
+    /// 100ths of a point. Positive = looser, negative = tighter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) letter_spacing: Option<f64>,
     /// Set for OOXML field elements (e.g. "slidenum" for slide number fields)


### PR DESCRIPTION
## Summary

- document `TextRunData.letterSpacing` as points in the public TypeScript model
- clarify that the Rust parser model contains points after converting DrawingML `rPr@spc`

## Why

DrawingML encodes `rPr@spc` in hundredths of a point. The PPTX parser divides the encoded value by 100 before exposing it, and the renderer consumes the resulting value as points. The previous comments described the OOXML encoding unit as the model unit.

## Impact

This is a documentation-only correction. It does not change parsing, serialization, or rendering behavior.

## Verification

- `git diff --check`
