### PR TITLE
refactor(xlsx): reuse worksheet column limit

### DIFF
--- a/packages/xlsx/src/renderer.ts
+++ b/packages/xlsx/src/renderer.ts
@@ -22,7 +22,7 @@ import {
   setCoordinateIndexValue,
   type CoordinateIndexIdentity,
 } from './renderer-coordinate-index.js';
-import { GridGeometry } from './internal/grid-geometry.js';
+import { GridGeometry, MAX_WORKSHEET_COL } from './internal/grid-geometry.js';
 import type { GridAxisGeometry } from './internal/grid-axis-geometry.js';
 import { usesNativeOneCellExtent } from './internal/cell-anchor-geometry.js';
 import {
@@ -3222,7 +3222,7 @@ function virtualizedTextOverflowOverscan(
     const visibleEndCell = cellMap.get(`${row}:${visibleEndCol}`);
     if (
       after != null &&
-      after <= 16_384 &&
+      after <= MAX_WORKSHEET_COL &&
       (!visibleEndCell || visibleEndCell.value.type === 'empty') &&
       !mergeBlocksOverflow(worksheet, row, visibleEndCol, after - 1) &&
       reaches(


### PR DESCRIPTION
## Summary

- replace the duplicated Excel maximum-column literal in virtualized cell-text overflow handling
- reuse the shared worksheet geometry constant
- preserve existing behavior

## Verification

- focused XLSX cell-text overflow virtualization tests: 6 passed
- TypeScript project build
- git diff check