### PR TITLE
fix(pptx): normalize DrawingML letter spacing

### DIFF
--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1855,7 +1855,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
         }
         const seriesLabels = s.seriesDataLabels;
         if ((chart.showDataLabels || seriesLabels?.showVal === true) && sv !== 0) {
-          // ECMA-376 §21.2.2.30 / §21.1.2.3.10 — data label font size comes from
+          // ECMA-376 §21.2.2.30 / §21.1.2.3.2 — data label font size comes from
           // `<c:dLbls><c:txPr>...<a:defRPr@sz>` (hundredths of a point). When
           // the file specifies one we honor it; otherwise the proportional
           // heuristic keeps small bars readable.

--- a/packages/core/src/text/justify-positions.test.ts
+++ b/packages/core/src/text/justify-positions.test.ts
@@ -77,10 +77,10 @@ describe('justifiedPiecePositions', () => {
   });
 
   it('adds letter-spacing × prefix-codepoint-count to each piece offset', () => {
-    // OOXML rPr @spc (§17.3.2.35 docx, §21.1.2.3.7 pptx) widens every code
-    // point's advance by `letterSpacingPx`, including the final one. A split
-    // piece's dx therefore needs `from · letterSpacingPx` on top of the prefix
-    // measure to land on the same x that `fillText(whole)` would draw it at.
+    // The renderer's Canvas spacing advance comes from OOXML w:spacing
+    // (§17.3.2.35) or DrawingML rPr@spc (§21.1.2.3.9; ST_TextPoint
+    // §20.1.10.74). A split piece's dx needs `from · letterSpacingPx` on top
+    // of the prefix measure to match where `fillText(whole)` would draw it.
     const cps = [...'a.bc'];
     const splitBefore = [1, 2, 3];
     const perGap = 2;
@@ -97,9 +97,9 @@ describe('justifiedPiecePositions', () => {
 
   it('lands the final glyph exactly on the box including letter-spacing', () => {
     // box = measure(whole) + cps.length·ls + nGaps·perGap, and the last piece's
-    // own advance also adds the trailing letter-spacing (rPr @spc is per glyph,
-    // including after the last). So the final piece's drawn end must equal
-    // measure(whole) + cps.length·ls + nGaps·perGap.
+    // own Canvas advance also includes the trailing letter-spacing. So the final
+    // piece's drawn end must equal measure(whole) + cps.length·ls +
+    // nGaps·perGap.
     const cps = [...'a.bc'];
     const splitBefore = [1, 2, 3];
     const perGap = 2;

--- a/packages/core/src/text/justify-positions.test.ts
+++ b/packages/core/src/text/justify-positions.test.ts
@@ -96,9 +96,9 @@ describe('justifiedPiecePositions', () => {
   });
 
   it('lands the final glyph exactly on the box including letter-spacing', () => {
-    // box = measure(whole) + cps.length·ls + nGaps·perGap, and the last piece's
-    // own Canvas advance also includes the trailing letter-spacing. So the final
-    // piece's drawn end must equal measure(whole) + cps.length·ls +
+    // box = measure(whole) + (cps.length-1)·ls + nGaps·perGap. The last piece
+    // contributes spacing only at its internal boundaries, never after its final
+    // glyph. So the final piece's drawn end must equal measure(whole) + (n-1)·ls +
     // nGaps·perGap.
     const cps = [...'a.bc'];
     const splitBefore = [1, 2, 3];
@@ -106,10 +106,11 @@ describe('justifiedPiecePositions', () => {
     const ls = 4;
     const pieces = justifiedPiecePositions(cps, splitBefore, perGap, measure, ls);
     const last = pieces[pieces.length - 1];
-    const box = measure('a.bc') + cps.length * ls + splitBefore.length * perGap;
-    // Drawn end of the last piece: dx + measure(text) + text.length·ls.
-    const lastEnd = last.dx + measure(last.text) + [...last.text].length * ls;
-    expect(lastEnd).toBe(box); // 44 + 10 + 1·4 = 58, box = 36 + 16 + 6 = 58
+    const box = measure('a.bc') + (cps.length - 1) * ls + splitBefore.length * perGap;
+    // Drawn end: dx + measure(text) + max(0, text.length-1)·ls.
+    const lastEnd = last.dx + measure(last.text)
+      + Math.max(0, [...last.text].length - 1) * ls;
+    expect(lastEnd).toBe(box); // 44 + 10 = 54, box = 36 + 12 + 6 = 54
   });
 
   it('counts letter-spacing per CODE POINT, not UTF-16 code unit (surrogate pair)', () => {
@@ -130,10 +131,11 @@ describe('justifiedPiecePositions', () => {
     //   𠮟: measure('あ')=10        + 1·4 + 1·2 = 16
     //   い: measure('あ𠮟')=20      + 2·4 + 2·2 = 32
     expect(pieces.map((p) => p.dx)).toEqual([0, 16, 32]);
-    // Final glyph lands on the code-point box: measure(whole) + cpLen·ls + nGaps·perGap.
+    // Final glyph lands on the code-point box: measure(whole) + (cpLen-1)·ls + gaps.
     const last = pieces[pieces.length - 1];
-    const box = measure('あ𠮟い') + cps.length * ls + splitBefore.length * perGap;
-    const lastEnd = last.dx + measure(last.text) + [...last.text].length * ls;
-    expect(lastEnd).toBe(box); // 32 + 10 + 4 = 46; box = 30 + 12 + 4 = 46
+    const box = measure('あ𠮟い') + (cps.length - 1) * ls + splitBefore.length * perGap;
+    const lastEnd = last.dx + measure(last.text)
+      + Math.max(0, [...last.text].length - 1) * ls;
+    expect(lastEnd).toBe(box); // 32 + 10 = 42; box = 30 + 8 + 4 = 42
   });
 });

--- a/packages/core/src/text/justify-positions.ts
+++ b/packages/core/src/text/justify-positions.ts
@@ -40,8 +40,8 @@ export interface JustifiedPiece {
  * is anchored to the whole-string cumulative advance up to its start — via
  * `measure` on the prefix — plus `perGap` for every gap that precedes it, plus
  * `letterSpacingPx` for every code point that precedes it. This keeps the drawn
- * glyphs aligned with the segment's `measureText(whole) + ls·n`-based box (so
- * the final glyph reaches `measure(whole) + ls·n + splitBefore.length·perGap`
+ * glyphs aligned with the segment's `measureText(whole) + ls·(n-1)` box (so
+ * the final glyph reaches `measure(whole) + ls·(n-1) + splitBefore.length·perGap`
  * and the next segment never overlaps), while honouring the contextual CJK
  * metrics baked into `measure`.
  *
@@ -52,7 +52,7 @@ export interface JustifiedPiece {
  * @param measure         Contextual width of a string — `ctx.measureText(s).width`
  *                        with the segment's font already selected on `ctx`. Must
  *                        NOT include letter-spacing (pass that via `letterSpacingPx`).
- * @param letterSpacingPx Canvas spacing advance per code point, derived from
+ * @param letterSpacingPx spacing at each internal code-point boundary, derived from
  *                        OOXML `rPr@spc` / `w:spacing`. Default 0.
  * @returns One {@link JustifiedPiece} per slice, in draw order.
  */

--- a/packages/core/src/text/justify-positions.ts
+++ b/packages/core/src/text/justify-positions.ts
@@ -52,8 +52,8 @@ export interface JustifiedPiece {
  * @param measure         Contextual width of a string — `ctx.measureText(s).width`
  *                        with the segment's font already selected on `ctx`. Must
  *                        NOT include letter-spacing (pass that via `letterSpacingPx`).
- * @param letterSpacingPx px added after each code point's glyph advance
- *                        (OOXML `rPr @spc` / `w:spacing` semantics). Default 0.
+ * @param letterSpacingPx Canvas spacing advance per code point, derived from
+ *                        OOXML `rPr@spc` / `w:spacing`. Default 0.
  * @returns One {@link JustifiedPiece} per slice, in draw order.
  */
 export function justifiedPiecePositions(

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -366,7 +366,8 @@ export interface TextRunData {
   underline: boolean;
   /**
    * Specific underline style when not the default single line. Values come
-   * from ECMA-376 §21.1.2.3.16 (ST_TextUnderlineType): "dbl", "heavy",
+   * from `rPr@u` (ECMA-376 §21.1.2.3.9; ST_TextUnderlineType
+   * §20.1.10.82): "dbl", "heavy",
    * "dotted", "dottedHeavy", "dash", "dashHeavy", "dashLong",
    * "dashLongHeavy", "dotDash", "dotDashHeavy", "dotDotDash",
    * "dotDotDashHeavy", "wavy", "wavyHeavy", "wavyDbl". Absent means either
@@ -374,7 +375,7 @@ export interface TextRunData {
    */
   underlineStyle?: string;
   /**
-   * Underline-only colour from rPr > uFill (ECMA-376 §21.1.2.3.20). Absent
+   * Underline-only colour from rPr > uFill (ECMA-376 §21.1.2.3.12). Absent
    * means the underline follows the text colour (uFillTx default).
    */
   underlineColor?: string;
@@ -382,7 +383,8 @@ export interface TextRunData {
   strikethrough: boolean;
   /**
    * True only when rPr strike = "dblStrike". Lets the renderer draw two parallel
-   * lines instead of one. ECMA-376 §21.1.2.3.10 (ST_TextStrikeType).
+   * lines instead of one. ECMA-376 §21.1.2.3.9; ST_TextStrikeType
+   * §20.1.10.79.
    */
   strikeDouble?: boolean;
   /** Font size in points */
@@ -390,7 +392,7 @@ export interface TextRunData {
   color: string | null;
   fontFamily: string | null;
   /**
-   * East Asian font family from rPr > a:ea (ECMA-376 §21.1.2.3.7),
+   * East Asian font family from rPr > a:ea (ECMA-376 §21.1.2.3.3),
    * resolved through the theme. Renderer uses this for CJK glyphs when
    * present; absent means CJK falls back to fontFamily.
    */
@@ -405,7 +407,8 @@ export interface TextRunData {
   /** Baseline shift in thousandths of a point. Positive = superscript, negative = subscript. */
   baseline?: number;
   /**
-   * Capitalisation transform — ECMA-376 §21.1.2.3.13 (ST_TextCapsType).
+   * Capitalisation transform from `rPr@cap` — ECMA-376 §21.1.2.3.9;
+   * ST_TextCapsType §20.1.10.64.
    * 'all' renders text in upper case; 'small' uses small caps (rendered as
    * upper case at ~80% size when no smcp font feature is available).
    * 'none' or omitted leaves the text unchanged.
@@ -413,8 +416,9 @@ export interface TextRunData {
   caps?: 'none' | 'small' | 'all';
   /**
    * Inter-character spacing in points. Positive values add space; negative
-   * values tighten. DrawingML stores `rPr@spc` in 100ths of a point, and the
-   * PPTX parser converts that encoded value to points.
+   * values tighten. DrawingML `rPr@spc` accepts unitless hundredths of a point
+   * or an `ST_UniversalMeasure` value (ECMA-376 §21.1.2.3.9; ST_TextPoint
+   * §20.1.10.74); the PPTX parser normalizes either form to points.
    */
   letterSpacing?: number;
   /** Set for OOXML field runs (e.g. "slidenum"). When set, renderer replaces text with field value. */

--- a/packages/ooxml-common/src/units.rs
+++ b/packages/ooxml-common/src/units.rs
@@ -35,10 +35,8 @@ pub fn text_point_to_pt(value: &str) -> Option<f64> {
         (number, 12.0)
     } else if let Some(number) = value.strip_suffix("mm") {
         (number, 72.0 / 25.4)
-    } else if let Some(number) = value.strip_suffix("cm") {
-        (number, 72.0 / 2.54)
     } else {
-        return None;
+        (value.strip_suffix("cm")?, 72.0 / 2.54)
     };
     if !is_universal_measure_number(number) {
         return None;

--- a/packages/ooxml-common/src/units.rs
+++ b/packages/ooxml-common/src/units.rs
@@ -8,3 +8,93 @@
 /// [MS-OI29500] 2.1.639) and by CSS pixels in general: 914400 EMU/inch ÷ 96
 /// px/inch = 9525 EMU/px.
 pub const EMU_PER_PX_96DPI: i64 = 9525;
+
+/// Parse DrawingML `ST_TextPoint` (ECMA-376 §20.1.10.74) into points.
+///
+/// A unitless value is an XSD integer in hundredths of a point. The union also
+/// accepts `ST_UniversalMeasure` (§22.9.2.15): a signed decimal followed by
+/// `mm`, `cm`, `in`, `pt`, `pc`, or `pi` (`pc` and `pi` are both picas).
+pub fn text_point_to_pt(value: &str) -> Option<f64> {
+    let value = value.trim();
+    let digits = value
+        .strip_prefix('+')
+        .or_else(|| value.strip_prefix('-'))
+        .unwrap_or(value);
+    if !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return finite_number(value).map(|number| number / 100.0);
+    }
+
+    let (number, scale) = if let Some(number) = value.strip_suffix("pt") {
+        (number, 1.0)
+    } else if let Some(number) = value.strip_suffix("in") {
+        (number, 72.0)
+    } else if let Some(number) = value
+        .strip_suffix("pc")
+        .or_else(|| value.strip_suffix("pi"))
+    {
+        (number, 12.0)
+    } else if let Some(number) = value.strip_suffix("mm") {
+        (number, 72.0 / 25.4)
+    } else if let Some(number) = value.strip_suffix("cm") {
+        (number, 72.0 / 2.54)
+    } else {
+        return None;
+    };
+    if !is_universal_measure_number(number) {
+        return None;
+    }
+    finite_number(number).map(|number| number * scale)
+}
+
+fn is_universal_measure_number(value: &str) -> bool {
+    let digits = value.strip_prefix('-').unwrap_or(value);
+    if digits.is_empty() || value.starts_with('+') {
+        return false;
+    }
+    let mut parts = digits.split('.');
+    let whole = parts.next().unwrap_or_default();
+    let fraction = parts.next();
+    !whole.is_empty()
+        && whole.bytes().all(|byte| byte.is_ascii_digit())
+        && fraction
+            .is_none_or(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        && parts.next().is_none()
+}
+
+fn finite_number(value: &str) -> Option<f64> {
+    value
+        .parse::<f64>()
+        .ok()
+        .filter(|number| number.is_finite())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::text_point_to_pt;
+
+    #[test]
+    fn text_point_parses_hundredths_and_universal_measures() {
+        for (value, expected) in [
+            ("100", 1.0),
+            ("-50", -0.5),
+            ("0", 0.0),
+            ("1pt", 1.0),
+            ("1in", 72.0),
+            ("1pc", 12.0),
+            ("1pi", 12.0),
+            ("25.4mm", 72.0),
+            ("2.54cm", 72.0),
+            ("-1.5pt", -1.5),
+        ] {
+            let actual = text_point_to_pt(value).expect("valid ST_TextPoint");
+            assert!((actual - expected).abs() < 1e-9, "value={value}");
+        }
+    }
+
+    #[test]
+    fn text_point_rejects_non_schema_lexemes() {
+        for value in ["", "1.5", "+1pt", "1px", "pt", "1e2", "NaN", "inf"] {
+            assert_eq!(text_point_to_pt(value), None, "value={value}");
+        }
+    }
+}

--- a/packages/pptx/parser/src/lib.rs
+++ b/packages/pptx/parser/src/lib.rs
@@ -4083,7 +4083,8 @@ mod tests {
         }
     }
 
-    /// ECMA-376 §21.1.2.3.10 — strike="dblStrike" produces strike_double=true,
+    /// ECMA-376 §21.1.2.3.9; ST_TextStrikeType §20.1.10.79 —
+    /// strike="dblStrike" produces strike_double=true,
     /// while strike="sngStrike" leaves strike_double=false. The plain
     /// `strikethrough` flag is true in both cases.
     #[test]
@@ -4107,7 +4108,8 @@ mod tests {
         assert!(!r_n.strikethrough && !r_n.strike_double);
     }
 
-    /// ECMA-376 §21.1.2.3.13 — cap="all" / "small" are passed through;
+    /// ECMA-376 §21.1.2.3.9; ST_TextCapsType §20.1.10.64 — cap="all" /
+    /// "small" are passed through;
     /// cap="none" or omitted yields None so the field stays absent in JSON.
     #[test]
     fn test_parse_run_caps_attribute() {
@@ -4128,13 +4130,20 @@ mod tests {
         }
     }
 
-    /// ECMA-376 §21.1.2.3.5 — rPr @spc encodes letter spacing in 100ths of a
-    /// point; positive widens, negative tightens. Zero rounds away (None).
+    /// ECMA-376 §21.1.2.3.9; ST_TextPoint §20.1.10.74 — a unitless rPr @spc
+    /// encodes letter spacing in 100ths of a point; positive widens, negative
+    /// tightens. Zero rounds away (None).
     #[test]
     fn test_parse_run_letter_spacing() {
         let theme = HashMap::new();
         let rels = HashMap::new();
-        for (raw, expected) in [("100", Some(1.0)), ("-50", Some(-0.5)), ("0", None)] {
+        for (raw, expected) in [
+            ("100", Some(1.0)),
+            ("-50", Some(-0.5)),
+            ("1pt", Some(1.0)),
+            ("2.54cm", Some(72.0)),
+            ("0", None),
+        ] {
             let xml = format!(
                 r#"<r xmlns="http://schemas.openxmlformats.org/drawingml/2006/main"><rPr spc="{raw}"/><t>x</t></r>"#
             );
@@ -4872,7 +4881,8 @@ mod tests {
         }
     }
 
-    /// ECMA-376 §21.1.2.3.16 — underline_style carries non-default underline
+    /// ECMA-376 §21.1.2.3.9; ST_TextUnderlineType §20.1.10.82 —
+    /// underline_style carries non-default underline
     /// values (dbl, dotted, wavy, …) verbatim. The plain bool stays true for
     /// any non-"none" value; "sng" and absent both leave underline_style None
     /// because the renderer's default is already a single line.
@@ -4900,7 +4910,7 @@ mod tests {
         }
     }
 
-    /// ECMA-376 §21.1.2.3.20 — rPr > uFill > solidFill yields a per-run
+    /// ECMA-376 §21.1.2.3.12 — rPr > uFill > solidFill yields a per-run
     /// underline colour distinct from the text colour. uFillTx (or absent)
     /// leaves underline_color as None so the renderer falls back to text.
     #[test]
@@ -4987,7 +4997,7 @@ mod tests {
         assert!(r.highlight.is_none());
     }
 
-    /// ECMA-376 §21.1.2.3.7 — rPr > ea sets a separate East Asian font.
+    /// ECMA-376 §21.1.2.3.3 — rPr > ea sets a separate East Asian font.
     /// Resolves through the theme map: "+mn-ea" should expand to whatever
     /// the theme registered, while a literal name is preserved.
     #[test]

--- a/packages/pptx/parser/src/master.rs
+++ b/packages/pptx/parser/src/master.rs
@@ -75,7 +75,8 @@ pub(crate) struct LayoutPlaceholders {
     /// Default italic per placeholder type, from layout lstStyle defRPr i attribute
     pub(crate) by_type_italic: HashMap<String, bool>,
     /// Default caps ("all"/"small") per placeholder type, from layout/master
-    /// lstStyle defRPr cap attribute (ECMA-376 §21.1.2.3.13)
+    /// lstStyle defRPr cap attribute (ECMA-376 §21.1.2.3.9;
+    /// ST_TextCapsType §20.1.10.64)
     pub(crate) by_type_caps: HashMap<String, String>,
     /// Default run reflection per placeholder type, inherited from layout or
     /// master `lvl1pPr/defRPr/effectLst`.
@@ -1124,7 +1125,8 @@ pub(crate) fn parse_master_txstyle_run_properties(
 ) -> MasterTxStyleRunProperties {
     let mut bold_map: HashMap<String, bool> = HashMap::new();
     let mut italic_map: HashMap<String, bool> = HashMap::new();
-    // ECMA-376 §21.1.2.3.13 cap="all"/"small" on the master txStyles defRPr —
+    // ECMA-376 §21.1.2.3.9, ST_TextCapsType §20.1.10.64: cap="all"/"small"
+    // on the master txStyles defRPr —
     // e.g. a template titleStyle with cap="all" upper-cases every title.
     let mut caps_map: HashMap<String, String> = HashMap::new();
     let mut reflection_map: HashMap<String, Reflection> = HashMap::new();

--- a/packages/pptx/parser/src/text.rs
+++ b/packages/pptx/parser/src/text.rs
@@ -12,6 +12,7 @@ use crate::{attr, attr_f64, attr_i64, attr_r, child, children_vec, resolve_path,
 use ooxml_common::blip::mime_from_ext;
 use ooxml_common::math::parse_omath_nodes;
 use ooxml_common::text::{parse_lnspc, SpaceLine};
+use ooxml_common::units::text_point_to_pt;
 use std::collections::HashMap;
 
 /// Extract the lvl1pPr defRPr font size from a txBody node.
@@ -645,8 +646,9 @@ pub(crate) fn parse_text_body(
         })
         .collect();
 
-    // ECMA-376 §21.1.2.3.13 cap: a run inherits cap="all"/"small" from the
-    // shape's own lstStyle defRPr, else from the layout/master placeholder
+    // ECMA-376 §21.1.2.3.9, ST_TextCapsType §20.1.10.64: a run inherits
+    // cap="all"/"small" from the shape's own lstStyle defRPr, else from the
+    // layout/master placeholder
     // style (e.g. a template's titleStyle cap="all" upper-cases the title even
     // though the run's text is stored mixed-case). Run-level rPr/paragraph
     // defRPr already won via parse_run; fill the remainder here.
@@ -1272,7 +1274,8 @@ fn parse_run_with_reflection(
         .and_then(|n| attr(&n, "i"))
         .or_else(|| def_rpr.and_then(|n| attr(&n, "i")))
         .map(|v| v == "1" || v == "true");
-    // ECMA-376 §21.1.2.3.16 — underline style enum: none/sng/dbl/heavy/dotted/
+    // ECMA-376 §21.1.2.3.9, ST_TextUnderlineType §20.1.10.82 — underline
+    // style enum: none/sng/dbl/heavy/dotted/
     // dash/dashLong/dotDash/dotDotDash/wavy plus *Heavy variants. Carry the
     // exact value through for the renderer to dispatch on; the bool stays
     // true for any non-"none" value so existing code paths keep working.
@@ -1285,7 +1288,7 @@ fn parse_run_with_reflection(
         .unwrap_or(false);
     let underline_style = underline_attr.filter(|v| v != "none" && v != "sng");
 
-    // ECMA-376 §21.1.2.3.20 — uFill specifies a per-underline colour that
+    // ECMA-376 §21.1.2.3.12 — uFill specifies a per-underline colour that
     // overrides the text colour. uFillTx (or absence) means "follow text".
     let underline_color = r_pr
         .and_then(|n| child(n, "uFill"))
@@ -1303,19 +1306,21 @@ fn parse_run_with_reflection(
         .unwrap_or(false);
     let strike_double = strike_attr.as_deref() == Some("dblStrike");
 
-    // ECMA-376 §21.1.2.3.13 ST_TextCapsType: "none" | "small" | "all". Treat
+    // ECMA-376 §21.1.2.3.9, ST_TextCapsType §20.1.10.64: "none" | "small" |
+    // "all". Treat
     // "none" as not set (no transform) so the field stays absent in JSON.
     let caps = r_pr
         .and_then(|n| attr(&n, "cap"))
         .or_else(|| def_rpr.and_then(|n| attr(&n, "cap")))
         .filter(|v| v == "small" || v == "all");
 
-    // ECMA-376 §21.1.2.3.5 rPr @spc — letter spacing in 100ths of a point.
-    // Negative values are valid (tightening). Non-zero only.
+    // ECMA-376 §21.1.2.3.9, ST_TextPoint §20.1.10.74: unitless `rPr@spc`
+    // values are hundredths of a point; ST_UniversalMeasure suffixes are also
+    // valid. Normalize both forms to points. Negative values tighten.
     let letter_spacing = r_pr
-        .and_then(|n| attr_f64(&n, "spc"))
-        .or_else(|| def_rpr.and_then(|n| attr_f64(&n, "spc")))
-        .map(|v| v / 100.0)
+        .and_then(|n| attr(&n, "spc"))
+        .or_else(|| def_rpr.and_then(|n| attr(&n, "spc")))
+        .and_then(|value| text_point_to_pt(&value))
         .filter(|v| v.abs() > f64::EPSILON);
 
     // sz in hundredths of a point
@@ -1342,7 +1347,7 @@ fn parse_run_with_reflection(
                 .and_then(|n| attr(&n, "typeface"))
         })
         .map(|tf| resolve_theme_typeface(&tf, theme));
-    // ECMA-376 §21.1.2.3.7 — <a:ea typeface="..."/> sets a separate font for
+    // ECMA-376 §21.1.2.3.3 — <a:ea typeface="..."/> sets a separate font for
     // East Asian glyphs (CJK). Defaults to the theme's +mn-ea slot when the
     // run doesn't specify one explicitly.
     let font_family_ea = r_pr

--- a/packages/pptx/parser/src/types.rs
+++ b/packages/pptx/parser/src/types.rs
@@ -1116,12 +1116,12 @@ pub(crate) struct TextRunData {
     /// OOXML rPr @u value when explicit and != "sng" — e.g. "dbl", "dotted",
     /// "dash", "wavy", "heavy", "dotDash", … None means either no underline
     /// or the default single-line style (rPr @u = "sng" or unset truthy).
-    /// ECMA-376 §21.1.2.3.16 (ST_TextUnderlineType).
+    /// ECMA-376 §21.1.2.3.9 (`rPr@u`); ST_TextUnderlineType §20.1.10.82.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) underline_style: Option<String>,
     /// Underline-specific colour from rPr > uFill > solidFill. None means the
     /// underline follows the text colour (uFillTx behaviour, the default).
-    /// ECMA-376 §21.1.2.3.20 (CT_TextUnderlineFillGroupWrapper).
+    /// ECMA-376 §21.1.2.3.12 (CT_TextUnderlineFillGroupWrapper).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) underline_color: Option<String>,
     /// true when strike == "sngStrike" or "dblStrike"
@@ -1134,7 +1134,7 @@ pub(crate) struct TextRunData {
     pub(crate) font_family: Option<String>,
     /// East Asian font family from rPr > ea (resolved through the theme).
     /// Renderer uses this for CJK runs. None = inherit from latin font.
-    /// ECMA-376 §21.1.2.3.7 (CT_TextFont, ea variant).
+    /// ECMA-376 §21.1.2.3.3 (CT_TextFont, ea variant).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) font_family_ea: Option<String>,
     /// Symbol font family from rPr > sym (resolved through the theme).
@@ -1145,12 +1145,14 @@ pub(crate) struct TextRunData {
     /// Baseline shift in thousandths of a point. Positive = superscript, negative = subscript.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) baseline: Option<i32>,
-    /// Capitalisation transform — ECMA-376 §21.1.2.3.13 (ST_TextCapsType).
+    /// Capitalisation from `rPr@cap` — ECMA-376 §21.1.2.3.9;
+    /// ST_TextCapsType §20.1.10.64.
     /// "none" | "small" | "all". None = inherit / no transform.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) caps: Option<String>,
-    /// Letter spacing in points after converting DrawingML `rPr@spc` from
-    /// 100ths of a point. Positive = looser, negative = tighter.
+    /// Letter spacing in points after normalizing DrawingML `rPr@spc` from
+    /// unitless hundredths of a point or `ST_UniversalMeasure` (ECMA-376
+    /// §21.1.2.3.9; ST_TextPoint §20.1.10.74). Positive = looser, negative = tighter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) letter_spacing: Option<f64>,
     /// Set for OOXML field elements (e.g. "slidenum" for slide number fields)

--- a/packages/pptx/src/cjk-spc-justify.test.ts
+++ b/packages/pptx/src/cjk-spc-justify.test.ts
@@ -9,7 +9,7 @@ import type { TextRunData } from '@silurus/ooxml-core';
 //
 // When a run carries @spc letter-spacing AND its text is East-Asian with an
 // opening bracket adjacent to kana/kanji, the LAYOUT measures the segment box
-// CONTEXTUALLY: `segW = measureText(seg.text) + ls·codePointCount`. The browser's
+// CONTEXTUALLY: `segW = measureText(seg.text) + ls·(clusterCount-1)`. The browser's
 // 約物半角 contextual shaping collapses an opening bracket "［" to half-width when
 // it is FOLLOWED by an East-Asian glyph WITHIN the measured string
 // (`measureText("［あ") < measureText("［") + measureText("あ")`).
@@ -165,7 +165,7 @@ describe('pptx @spc CJK — 約物半角 brackets are drawn contiguously, never 
   });
 
   // (2) No-overlap / contextual abutment: the @spc EA segment is one draw at the
-  //     segment left, its reported box width is the CONTEXTUAL measure + len·ls
+  //     segment left, its reported box width is the contextual measure + (len-1)·ls
   //     (bracket collapsed), and the following run abuts that edge — the bracket
   //     tail is never overrun by the per-glyph isolated sum.
   it('keeps measure==draw so a following run abuts the @spc EA box (no overlap)', () => {
@@ -179,9 +179,9 @@ describe('pptx @spc CJK — 約物半角 brackets are drawn contiguously, never 
     const eaCalls = texts.filter((c) => c.text === EA_SPC);
     expect(eaCalls.length, 'EA segment is a single draw').toBe(1);
 
-    // Reported box width = contextual measure (bracket half) + len·ls.
+    // Reported box width = contextual measure + spacing at len-1 boundaries.
     const len = [...EA_SPC].length;
-    const boxW = ctxMeasure(EA_SPC, FONT_PX) + len * LS;
+    const boxW = ctxMeasure(EA_SPC, FONT_PX) + (len - 1) * LS;
     expect(segEA.w).toBeCloseTo(boxW, 6);
 
     // The drawn EA glyphs start at the segment left and span exactly boxW, so the
@@ -213,7 +213,8 @@ describe('pptx @spc CJK — 約物半角 brackets are drawn contiguously, never 
     const trackedCall = texts.find((call) => call.text === text)!;
     const followingCall = texts.find((call) => call.text === 'C')!;
     const trackedRun = runs.find((candidate) => candidate.text === text)!;
-    const expectedWidth = ctxMeasure(text, FONT_PX) + [...text].length * negativeSpacing;
+    const expectedWidth = ctxMeasure(text, FONT_PX)
+      + ([...text].length - 1) * negativeSpacing;
 
     expect(trackedCall.letterSpacing).toBe(`${negativeSpacing}px`);
     expect(trackedRun.w).toBeCloseTo(expectedWidth, 6);

--- a/packages/pptx/src/cjk-spc-justify.test.ts
+++ b/packages/pptx/src/cjk-spc-justify.test.ts
@@ -3,7 +3,8 @@ import { renderTextBody } from './renderer.js';
 import type { TextBody, Paragraph } from './types';
 import type { TextRunData } from '@silurus/ooxml-core';
 
-// ECMA-376 §21.1.2.3.x (rPr @spc, letter-spacing) — 約物半角 bracket overlap, the
+// ECMA-376 §21.1.2.3.9 (rPr @spc; ST_TextPoint §20.1.10.74) — 約物半角
+// bracket overlap, the
 // pptx analog of docx PR #626 (docGrid §17.6.5).
 //
 // When a run carries @spc letter-spacing AND its text is East-Asian with an
@@ -45,11 +46,10 @@ function ctxMeasure(s: string, fontPx: number): number {
   return w;
 }
 
-/** Recording 2D context. `measureText` models 約物半角 contextual collapse and is
- *  agnostic of letterSpacing (the renderer always measures BEFORE it sets
- *  letterSpacing). `fillText` records text + x + y AND the current letterSpacing
- *  at call time, so a test can assert the contiguous-draw fix set
- *  `ctx.letterSpacing = ls`. */
+/** Recording 2D context. `measureText` models 約物半角 contextual collapse plus
+ * native Canvas letterSpacing. `fillText` records text + x + y AND the current
+ * letterSpacing at call time, so a test can assert the contiguous-draw fix set
+ * `ctx.letterSpacing = ls`. */
 function mockCtx(): {
   ctx: CanvasRenderingContext2D;
   texts: { text: string; x: number; y: number; letterSpacing: string }[];
@@ -69,7 +69,7 @@ function mockCtx(): {
     measureText: (s: string) => {
       const p = px();
       return {
-        width: ctxMeasure(s, p),
+        width: ctxMeasure(s, p) + [...s].length * (parseFloat(letterSpacing) || 0),
         actualBoundingBoxAscent: p * 0.8,
         actualBoundingBoxDescent: p * 0.2,
         fontBoundingBoxAscent: p * 0.8,
@@ -144,7 +144,7 @@ function render(
 const EA_SPC = '［あ］いうえお';
 const LS = 4; // px of @spc letter-spacing (points == px at SCALE 1/12700)
 
-describe('pptx @spc CJK — 約物半角 brackets are drawn contiguously, never overlap (§21.1.2.3.x)', () => {
+describe('pptx @spc CJK — 約物半角 brackets are drawn contiguously, never overlap (§21.1.2.3.9)', () => {
   // (1) RED→GREEN core fix: a NON-justified @spc EA segment is painted by EXACTLY
   //     ONE contiguous fillText carrying the whole string, with letterSpacing=ls.
   //     Before the fix: 7 single-code-point fillText calls, letterSpacing '0px'.
@@ -200,6 +200,24 @@ describe('pptx @spc CJK — 約物半角 brackets are drawn contiguously, never 
   it('restores letterSpacing to its initial value after rendering', () => {
     const { finalLetterSpacing } = render(bodyWith('l', [run(EA_SPC, LS)]));
     expect(finalLetterSpacing).toBe('0px');
+  });
+
+  it('applies negative @spc consistently to drawing and the following run position', () => {
+    const text = 'AB';
+    const negativeSpacing = -4;
+    const { texts, runs } = render(bodyWith('l', [
+      run(text, negativeSpacing),
+      run('C', undefined, 'FF0000'),
+    ]));
+
+    const trackedCall = texts.find((call) => call.text === text)!;
+    const followingCall = texts.find((call) => call.text === 'C')!;
+    const trackedRun = runs.find((candidate) => candidate.text === text)!;
+    const expectedWidth = ctxMeasure(text, FONT_PX) + [...text].length * negativeSpacing;
+
+    expect(trackedCall.letterSpacing).toBe(`${negativeSpacing}px`);
+    expect(trackedRun.w).toBeCloseTo(expectedWidth, 6);
+    expect(followingCall.x).toBeCloseTo(trackedCall.x + expectedWidth, 6);
   });
 
   // (4a) No-regression — @spc justify multi-glyph piece: a `dist` line whose CJK

--- a/packages/pptx/src/cjk-wrap.ts
+++ b/packages/pptx/src/cjk-wrap.ts
@@ -29,6 +29,8 @@ export function fitCjkLine(
   startWidth: number,
   maxWidth: number,
   rules: KinsokuRules,
+  letterSpacingPx: number = 0,
+  leadingBoundary: boolean = false,
 ): number {
   if (chars.length === 0) return 0;
   const lineEmpty = startWidth === 0;
@@ -37,14 +39,15 @@ export function fitCjkLine(
   let raw = 0;
   let w = startWidth;
   for (const c of chars) {
-    if (w + c.w > maxWidth) {
+    const boundary = raw > 0 || leadingBoundary ? letterSpacingPx : 0;
+    if (w + boundary + c.w > maxWidth) {
       if (raw > 0) break; // already have content on this line
       if (!lineEmpty) break; // non-empty line, nothing fits → caller breaks
-      w += c.w; // empty line: force the first char so wrapping advances
+      w += boundary + c.w; // empty line: force the first char so wrapping advances
       raw++;
       break;
     }
-    w += c.w;
+    w += boundary + c.w;
     raw++;
   }
 

--- a/packages/pptx/src/firstline-indent-autofit.test.ts
+++ b/packages/pptx/src/firstline-indent-autofit.test.ts
@@ -48,10 +48,11 @@ function mockCtx() {
   return { ctx: ctx as unknown as CanvasRenderingContext2D, texts };
 }
 
-function run(text: string): TextRunData {
+function run(text: string, letterSpacing?: number): TextRunData {
   return {
     type: 'text', text, bold: null, italic: null, underline: false,
     strikethrough: false, fontSize: 20, color: '000000', fontFamily: 'Arial',
+    ...(letterSpacing != null ? { letterSpacing } : {}),
   };
 }
 
@@ -103,6 +104,28 @@ describe('pptx first-line indent: the measurement path ignores indent for a bull
     // 180px > 135.6px ⇒ overflows (so the bullet — not a blanket "never
     // overflows" — is the discriminator).
     expect(measure(makePara({ runs: [run(TEXT18)], indent: INDENT_50, bullet: noBullet }))).toBe(true);
+  });
+});
+
+describe('pptx spAutoFit measurement includes DrawingML rPr@spc (§21.1.2.3.9)', () => {
+  const measure = (textRun: TextRunData) => {
+    const { ctx } = mockCtx();
+    return naturalWidthExceedsBbox(
+      ctx,
+      makeBody(makePara({ runs: [textRun] })),
+      200,
+      7.2,
+      7.2,
+      SCALE,
+      RC,
+    );
+  };
+
+  it('counts positive and negative spacing in the natural line width', () => {
+    expect(measure(run('A'.repeat(16)))).toBe(false);
+    expect(measure(run('A'.repeat(16), 2))).toBe(true);
+    expect(measure(run('A'.repeat(19)))).toBe(true);
+    expect(measure(run('A'.repeat(19), -1))).toBe(false);
   });
 });
 

--- a/packages/pptx/src/justify-bracket-overlap.test.ts
+++ b/packages/pptx/src/justify-bracket-overlap.test.ts
@@ -54,8 +54,8 @@ const OPEN_BRACKET = '［（「『';
  *  opening bracket (約物連続 packing, e.g. "：［", "、［", "）（"). So
  *  `measure("名：［") < measure("名：") + measure("［")` while `measure("［本")
  *  === measure("［") + measure("本")` (a bracket next to a kanji does NOT pack).
- *  The collapse must NOT include letterSpacing — the renderer sets letterSpacing
- *  AFTER all measureText calls, and the canvas adds it between glyphs. */
+ *  The collapse itself does not include letterSpacing; the recording context
+ *  adds the active Canvas tracking separately. */
 function ctxMeasure(s: string, fontPx: number): number {
   const cps = [...s];
   let w = 0;
@@ -68,11 +68,10 @@ function ctxMeasure(s: string, fontPx: number): number {
   return w;
 }
 
-/** Recording 2D context. `measureText` models 約物連続 contextual packing and is
- *  agnostic of letterSpacing (the renderer always measures BEFORE it sets
- *  letterSpacing). `fillText` records text + x + y AND the current letterSpacing
- *  at call time, so a test can assert the contiguous-draw fix set
- *  `ctx.letterSpacing = ls + segPerGap`. */
+/** Recording 2D context. `measureText` models 約物連続 contextual packing plus
+ * native Canvas letterSpacing. `fillText` records text + x + y AND the current
+ * letterSpacing at call time, so a test can assert the contiguous-draw fix set
+ * `ctx.letterSpacing = ls + segPerGap`. */
 function mockCtx(): {
   ctx: CanvasRenderingContext2D;
   texts: { text: string; x: number; y: number; letterSpacing: string }[];
@@ -92,7 +91,7 @@ function mockCtx(): {
     measureText: (s: string) => {
       const p = px();
       return {
-        width: ctxMeasure(s, p),
+        width: ctxMeasure(s, p) + [...s].length * (parseFloat(letterSpacing) || 0),
         actualBoundingBoxAscent: p * 0.8,
         actualBoundingBoxDescent: p * 0.2,
         fontBoundingBoxAscent: p * 0.8,
@@ -287,7 +286,10 @@ describe('pptx justify CJK — 約物連続 brackets are drawn contiguously, nev
     //     drawWithFont letterSpacing path (text.length > 1), ONE contiguous draw at
     //     letterSpacing === `${ls}px` (NOT ls+segPerGap; this is not a justify line).
     const LS = 4;
-    const spc = render(bodyWith('l', [run(EA_JUST, LS)]), BOX_W);
+    // Include the authored tracking in the box budget so this remains a
+    // paint-path control rather than accidentally becoming a wrap test.
+    const spcBoxW = BOX_W + [...EA_JUST].length * LS;
+    const spc = render(bodyWith('l', [run(EA_JUST, LS)]), spcBoxW);
     const spcSeg = spc.texts.filter((c) => c.text === EA_JUST);
     expect(spcSeg.length, '@spc-only line is one contiguous draw').toBe(1);
     expect(spcSeg[0].letterSpacing, '@spc-only line carries ls (not a justify pitch)').toBe(`${LS}px`);

--- a/packages/pptx/src/justify-bracket-overlap.test.ts
+++ b/packages/pptx/src/justify-bracket-overlap.test.ts
@@ -288,7 +288,7 @@ describe('pptx justify CJK — 約物連続 brackets are drawn contiguously, nev
     const LS = 4;
     // Include the authored tracking in the box budget so this remains a
     // paint-path control rather than accidentally becoming a wrap test.
-    const spcBoxW = BOX_W + [...EA_JUST].length * LS;
+    const spcBoxW = BOX_W + ([...EA_JUST].length - 1) * LS;
     const spc = render(bodyWith('l', [run(EA_JUST, LS)]), spcBoxW);
     const spcSeg = spc.texts.filter((c) => c.text === EA_JUST);
     expect(spcSeg.length, '@spc-only line is one contiguous draw').toBe(1);

--- a/packages/pptx/src/justify-line-break.test.ts
+++ b/packages/pptx/src/justify-line-break.test.ts
@@ -25,7 +25,9 @@ function mockCtx() {
     get letterSpacing() { return letterSpacing; }, set letterSpacing(v: string) { letterSpacing = v; },
     // 10px advance per glyph (font size ignored) → predictable line widths.
     measureText: (s: string) => ({
-      width: [...s].length * 10, actualBoundingBoxAscent: 8, actualBoundingBoxDescent: 2,
+      width: [...s].length * (10 + (parseFloat(letterSpacing) || 0)),
+      actualBoundingBoxAscent: 8,
+      actualBoundingBoxDescent: 2,
     }),
     fillText: (t: string, x: number, y: number) => texts.push({ text: t, x, y, letterSpacing }),
     fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -408,6 +408,10 @@ type LayoutSegment = {
   strikeDouble?: boolean;
   /** Extra inter-character spacing in px (already scaled). */
   letterSpacingPx?: number;
+  /** Internal identity of the authored run; keeps rPr@spc within that run. */
+  sourceRunId?: number;
+  /** Spacing boundary before this segment when one authored run changed font. */
+  leadingLetterSpacingPx?: number;
   baseline?: number;
   /** Run-level glyph drop shadow (rPr > effectLst > outerShdw). */
   shadow?: import('@silurus/ooxml-core').Shadow;
@@ -886,8 +890,10 @@ function hasNativeLetterSpacing(ctx: CanvasRenderingContext2D): boolean {
 /** Measure the Canvas advance with the tracking derived from DrawingML
  * `rPr@spc`. Native `measureText()` uses the same shaping clusters as paint,
  * which matters for combining sequences, emoji ZWJ runs, flags, and Indic
- * conjuncts. Older/inert implementations retain the historical code-point
- * approximation used by the manual paint fallback. */
+ * conjuncts. Canvas includes one trailing spacing unit in its reported width;
+ * DrawingML spacing is only between characters in the run, so remove that
+ * terminal unit. Older/inert implementations use the same n-1 code-point
+ * approximation as the manual paint fallback. */
 function measureTextAdvance(
   ctx: CanvasRenderingContext2D,
   text: string,
@@ -899,12 +905,15 @@ function measureTextAdvance(
     try {
       spacingCtx.letterSpacing = `${letterSpacingPx}px`;
       const tracked = ctx.measureText(text).width;
-      if (Number.isFinite(tracked)) return tracked;
+      if (Number.isFinite(tracked)) {
+        return text.length > 0 ? tracked - letterSpacingPx : tracked;
+      }
     } finally {
       try { spacingCtx.letterSpacing = previous; } catch { /* inert implementation */ }
     }
   }
-  return ctx.measureText(text).width + letterSpacingPx * codePointCount(text);
+  const internalBoundaries = Math.max(0, codePointCount(text) - 1);
+  return ctx.measureText(text).width + letterSpacingPx * internalBoundaries;
 }
 
 export function layoutParagraph(
@@ -1040,6 +1049,27 @@ export function layoutParagraph(
     hasWhitespaceOnLine = false;
   };
 
+  /** Width contributed if `text` is appended now. OOXML spacing is present at
+   * a fragment seam only when both fragments came from the same authored run. */
+  const incomingTextAdvance = (
+    text: string,
+    font: string,
+    letterSpacingPx: number,
+    sourceRunId: number,
+  ): number => {
+    ctx.font = font;
+    const own = measureTextAdvance(ctx, text, letterSpacingPx);
+    const last = currentLine.segments.at(-1);
+    if (
+      !last || last.isTab || last.math || last.sourceRunId !== sourceRunId
+    ) return own;
+    if (last.font === font && (last.letterSpacingPx ?? 0) === letterSpacingPx) {
+      return measureTextAdvance(ctx, last.text + text, letterSpacingPx)
+        - measureTextAdvance(ctx, last.text, letterSpacingPx);
+    }
+    return own + letterSpacingPx;
+  };
+
   const push = (
     text: string,
     font: string,
@@ -1061,6 +1091,7 @@ export function layoutParagraph(
       fontFamily?: string;
       /** Resolved hyperlink target (IX1) — passed through to the overlay span. */
       hyperlink?: HyperlinkTarget;
+      sourceRunId?: number;
     },
   ) => {
     if (!text) return;
@@ -1070,7 +1101,7 @@ export function layoutParagraph(
     // tabs, alignment, combining sequences, and emoji clusters stay consistent.
     // The value comes from DrawingML rPr@spc (§21.1.2.3.9; ST_TextPoint
     // §20.1.10.74).
-    const w = measureTextAdvance(ctx, text, lsPx);
+    const sourceRunId = extras?.sourceRunId;
     const strikeDouble = extras?.strikeDouble;
     const underlineStyle = extras?.underlineStyle;
     const underlineColor = extras?.underlineColor;
@@ -1100,17 +1131,37 @@ export function layoutParagraph(
       a.outline === outline &&
       (a.highlight ?? '') === (highlight ?? '') &&
       (a.fontFamily ?? '') === (fontFamily ?? '') &&
-      hyperlinkKey(a.hyperlink) === hyperlinkKey(hyperlink);
+      hyperlinkKey(a.hyperlink) === hyperlinkKey(hyperlink) &&
+      (lsPx === 0 || a.sourceRunId === sourceRunId);
+    const last = currentLine.segments.at(-1);
+    let w = measureTextAdvance(ctx, text, lsPx);
+    if (last && sameMeta(last)) {
+      // Token/CJK/SEA splitting is a layout concern, not an authored run
+      // boundary. Re-measure the merged string so contextual shaping and the
+      // single spacing boundary between the fragments are retained exactly.
+      w = measureTextAdvance(ctx, last.text + text, lsPx)
+        - measureTextAdvance(ctx, last.text, lsPx);
+    } else if (
+      last && !last.isTab && !last.math
+      && sourceRunId != null && last.sourceRunId === sourceRunId
+    ) {
+      // A font/style split inside one authored run still has one character
+      // boundary between its adjacent fragments.
+      w += lsPx;
+    }
     lineW += w;
     // Mirror the paint-side item sequence so a tabbed line's wrap budget resolves
     // identically (issue #1006). One item per push call; consecutive content
     // items simply sum inside resolveTabWidths.
     lineItems.push({ isTab: false, width: w });
-    const last = currentLine.segments.at(-1);
     if (last && sameMeta(last)) {
       last.text += text;
     } else {
-      currentLine.segments.push({ text, font, fontFamily, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, baseline, shadow, reflection, outline, highlight, hyperlink });
+      const leadingLetterSpacingPx = last && !last.isTab && !last.math
+        && sourceRunId != null && last.sourceRunId === sourceRunId
+        ? lsPx
+        : 0;
+      currentLine.segments.push({ text, font, fontFamily, sizePx, color, underline, underlineStyle, underlineColor, strikethrough, strikeDouble, letterSpacingPx: lsPx || undefined, sourceRunId, leadingLetterSpacingPx: leadingLetterSpacingPx || undefined, baseline, shadow, reflection, outline, highlight, hyperlink });
     }
   };
 
@@ -1153,11 +1204,12 @@ export function layoutParagraph(
       outline: seg.outline,
       highlight: seg.highlight,
       fontFamily: seg.fontFamily,
+      sourceRunId: seg.sourceRunId,
     });
     return true;
   };
 
-  for (const run of para.runs) {
+  for (const [sourceRunId, run] of para.runs.entries()) {
     if (run.type === 'break') {
       // The line being closed ends at a MANUAL break (§21.1.2.2.1) — mark it so
       // a `just` paragraph left-aligns it like its last line (§20.1.10.59).
@@ -1271,6 +1323,7 @@ export function layoutParagraph(
       // alone drives classification: a ppaction://… or a scheme-less internal
       // part name is treated as internal. Overlay-only; does not affect glyphs.
       hyperlink: classifyPptxHyperlink(run.hyperlink),
+      sourceRunId,
     };
 
     // Split on whitespace boundaries, keeping the whitespace tokens
@@ -1308,7 +1361,7 @@ export function layoutParagraph(
       }
 
       ctx.font = font;
-      const tokW = measureTextAdvance(ctx, token, lsPx);
+      const tokW = incomingTextAdvance(token, font, lsPx, sourceRunId);
       const isWhitespace = /^\s+$/.test(token);
 
       // ── Symbol-font characters (Wingdings/Webdings/Symbol) ───────────────
@@ -1339,7 +1392,7 @@ export function layoutParagraph(
             }
           }
           ctx.font = chFont;
-          const chW = measureTextAdvance(ctx, drawCh, lsPx);
+          const chW = incomingTextAdvance(drawCh, chFont, lsPx, sourceRunId);
           if (!fitsW(chW) && lineW > 0) newLine();
           push(drawCh, chFont, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         }
@@ -1387,13 +1440,19 @@ export function layoutParagraph(
           // CJK when an East Asian typeface was declared, else the latin family.
           const chFamily = isEa ? (familyEa as string) : family;
           ctx.font = chFont;
-          measured.push({ ch, w: measureTextAdvance(ctx, ch, lsPx), font: chFont, family: chFamily });
+          measured.push({ ch, w: measureTextAdvance(ctx, ch, 0), font: chFont, family: chFamily });
         }
         if (para.eaLnBrk === false) {
           // Keep the East Asian word whole. If the current line already has
           // content and the token would overflow, wrap once before placing it;
           // never break mid-token (an over-wide token simply overflows).
-          const tokenW = measured.reduce((acc, m) => acc + m.w, 0);
+          const previous = currentLine.segments.at(-1);
+          const leadingBoundary = !!previous
+            && !previous.isTab && !previous.math
+            && previous.sourceRunId === sourceRunId;
+          const tokenW = measured.reduce((acc, m) => acc + m.w, 0)
+            + Math.max(0, measured.length - 1) * lsPx
+            + (leadingBoundary && measured.length > 0 ? lsPx : 0);
           if (lineW > 0 && !fitsW(tokenW)) newLine();
           for (const m of measured) {
             push(m.ch, m.font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, { ...segExtras, fontFamily: m.family });
@@ -1407,7 +1466,18 @@ export function layoutParagraph(
           // slack-adjusted pen (right / centre tab). Equivalent to lineW when no
           // tab, so tab-free CJK is byte-identical.
           const cjkPen = Number.isFinite(lineMaxW()) ? lineMaxW() - availW() : lineW;
-          let n = fitCjkLine(rest, cjkPen, lineMaxW(), DEFAULT_KINSOKU_RULES);
+          const previous = currentLine.segments.at(-1);
+          const leadingBoundary = !!previous
+            && !previous.isTab && !previous.math
+            && previous.sourceRunId === sourceRunId;
+          let n = fitCjkLine(
+            rest,
+            cjkPen,
+            lineMaxW(),
+            DEFAULT_KINSOKU_RULES,
+            lsPx,
+            leadingBoundary,
+          );
           if (n === 0) {
             // A non-empty line can't take the run head → break and retry empty.
             // But a line holding ONLY a tab (lineW===0, tab jump consumed the
@@ -1448,12 +1518,18 @@ export function layoutParagraph(
         const isEaCh = (ch: string): boolean => eaDiffers && isCjkBreakChar(ch.codePointAt(0) ?? 0);
         const measureSub = (sub: string): number => {
           let w = 0;
+          const previous = currentLine.segments.at(-1);
+          let hasBoundary = !!previous
+            && !previous.isTab && !previous.math
+            && previous.sourceRunId === sourceRunId;
           let runText = '';
           let runEa: boolean | null = null;
           const flush = (): void => {
             if (runText === '') return;
             ctx.font = runEa ? (fontEa as string) : font;
             w += measureTextAdvance(ctx, runText, lsPx);
+            if (hasBoundary) w += lsPx;
+            hasBoundary = true;
             runText = '';
           };
           for (const ch of sub) {
@@ -1516,7 +1592,7 @@ export function layoutParagraph(
         if (lineW > 0) newLine();
         for (const ch of token) {
           ctx.font = font;
-          const chW = measureTextAdvance(ctx, ch, lsPx);
+          const chW = incomingTextAdvance(ch, font, lsPx, sourceRunId);
           if (!fitsW(chW) && lineW > 0) newLine();
           push(ch, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         }
@@ -4142,7 +4218,9 @@ export function renderTextBody(
         const ls = seg.letterSpacingPx ?? 0;
         return {
           isTab: false,
-          width: seg.text ? measureTextAdvance(ctx, seg.text, ls) : 0,
+          width: seg.text
+            ? (seg.leadingLetterSpacingPx ?? 0) + measureTextAdvance(ctx, seg.text, ls)
+            : 0,
         };
       });
       const stops = (entry.para.tabStops ?? []).map((stop) => ({
@@ -4178,6 +4256,7 @@ export function renderTextBody(
       ctx.font = seg.font;
       const m = ctx.measureText(seg.text || 'M');
       const ls = seg.letterSpacingPx ?? 0;
+      lineWidth += seg.leadingLetterSpacingPx ?? 0;
       lineWidth += seg.text ? measureTextAdvance(ctx, seg.text, ls) : 0;
       if (m.actualBoundingBoxAscent > 0) {
         maxAscent = Math.max(maxAscent, m.actualBoundingBoxAscent);
@@ -4312,12 +4391,29 @@ export function renderTextBody(
     const visual: LineVisualOrder | null = paraNeedsBidi
       ? computeLineVisualOrder(line.segments, baseRtl)
       : null;
+    const visualBoundarySpacing = (previousLi: number, currentLi: number): number => {
+      if (Math.abs(previousLi - currentLi) !== 1) return 0;
+      const before = line.segments[Math.min(previousLi, currentLi)];
+      const after = line.segments[Math.max(previousLi, currentLi)];
+      if (
+        before.isTab || before.math || after.isTab || after.math
+        || before.sourceRunId == null
+        || before.sourceRunId !== after.sourceRunId
+      ) return 0;
+      // `after` owns the logical boundary metadata. Place that advance between
+      // the two segments in VISUAL order, even when bidi reverses them.
+      return after.leadingLetterSpacingPx ?? 0;
+    };
     const segCount = segs.length;
     for (let vi = 0; vi < segCount; vi++) {
       const li = visual ? visual.order[vi] : vi;
       const seg = segs[li];
       const segRtl = visual ? visual.rtl[li] : false;
       if (paraNeedsBidi) ctx.direction = segRtl ? 'rtl' : 'ltr';
+      if (vi > 0) {
+        const previousLi = visual ? visual.order[vi - 1] : vi - 1;
+        penX += visualBoundarySpacing(previousLi, li);
+      }
       if (seg.isTab) {
         penX += seg.tabWidthPx ?? 0;
         continue;
@@ -4399,9 +4495,11 @@ export function renderTextBody(
             // shaping across the split, but its manual advance matches the
             // code-point approximation in measureTextAdvance.
             let x = atX;
-            for (const ch of text) {
+            const cps = [...text];
+            for (let index = 0; index < cps.length; index++) {
+              const ch = cps[index];
               paint(ch, x, segBaseline);
-              x += measureTextAdvance(target, ch, ls);
+              if (index < cps.length - 1) x += target.measureText(ch).width + ls;
             }
           }
         } else {
@@ -4471,9 +4569,10 @@ export function renderTextBody(
             // Old/inert Canvas: use the same code-point pitch approximation as
             // measureTextAdvance so distributed layout and paint stay aligned.
             let x = penX;
-            for (const ch of cps) {
+            for (let index = 0; index < cps.length; index++) {
+              const ch = cps[index];
               paint(ch, x, segBaseline);
-              x += measureTextAdvance(target, ch, pitch);
+              if (index < cps.length - 1) x += target.measureText(ch).width + pitch;
             }
           }
         } else if (pieces) {

--- a/packages/pptx/src/renderer.ts
+++ b/packages/pptx/src/renderer.ts
@@ -823,7 +823,8 @@ export function naturalWidthExceedsBbox(
       const isBold = run.bold ?? para.defBold ?? body.defaultBold ?? false;
       const isItalic = run.italic ?? para.defItalic ?? body.defaultItalic ?? false;
       ctx.font = buildFont(isBold, isItalic, sizePx, family, rc);
-      lineW += ctx.measureText(run.text).width;
+      const letterSpacingPx = (run.letterSpacing ?? 0) * PT_TO_EMU * scale;
+      lineW += measureTextAdvance(ctx, run.text, letterSpacingPx);
       if (lineW > textMaxW) return true;
     }
   }
@@ -839,17 +840,71 @@ function tokenHasCjk(s: string): boolean {
   return false;
 }
 
-/** Number of Unicode code points in `s` (NOT UTF-16 code units). OOXML letter
- *  spacing (rPr @spc) adds advance per GLYPH, and a supplementary-plane CJK
- *  ideograph (e.g. 𠮟 U+20B9F) is one glyph encoded as a surrogate pair. The
- *  per-glyph draw loops (`for (const ch of text)`) and core's
- *  `justifiedPiecePositions` both iterate code points, so the letter-spacing
- *  width math must count code points too — using `text.length` (code units)
- *  would over-count by one per surrogate pair and drift the pen. */
+/** Number of Unicode code points in `s` (NOT UTF-16 code units). Used only by
+ *  text paths that deliberately paint per code point (WordArt / vertical text)
+ *  and by the fallback for Canvas implementations without native
+ *  `letterSpacing`. Native horizontal text uses {@link measureTextAdvance} so
+ *  the browser's shaping-cluster boundaries remain authoritative. */
 function codePointCount(s: string): number {
   let n = 0;
   for (const _ of s) n++;
   return n;
+}
+
+const nativeLetterSpacingSupport = new WeakMap<CanvasRenderingContext2D, boolean>();
+
+/** Detect real Canvas letter-spacing support, rather than accepting an expando
+ * or an inert test-double property. The result is stable for a context and is
+ * shared by measurement and paint so their fallback choice cannot diverge. */
+function hasNativeLetterSpacing(ctx: CanvasRenderingContext2D): boolean {
+  const cached = nativeLetterSpacingSupport.get(ctx);
+  if (cached != null) return cached;
+
+  const spacingCtx = ctx as CanvasRenderingContext2D & { letterSpacing?: string };
+  const previous = spacingCtx.letterSpacing;
+  if (typeof previous !== 'string') {
+    nativeLetterSpacingSupport.set(ctx, false);
+    return false;
+  }
+
+  let supported = false;
+  try {
+    spacingCtx.letterSpacing = '0px';
+    const natural = ctx.measureText('ii').width;
+    spacingCtx.letterSpacing = '1px';
+    const tracked = ctx.measureText('ii').width;
+    supported = Number.isFinite(natural) && Number.isFinite(tracked) && tracked !== natural;
+  } catch {
+    supported = false;
+  } finally {
+    try { spacingCtx.letterSpacing = previous; } catch { /* inert implementation */ }
+  }
+  nativeLetterSpacingSupport.set(ctx, supported);
+  return supported;
+}
+
+/** Measure the Canvas advance with the tracking derived from DrawingML
+ * `rPr@spc`. Native `measureText()` uses the same shaping clusters as paint,
+ * which matters for combining sequences, emoji ZWJ runs, flags, and Indic
+ * conjuncts. Older/inert implementations retain the historical code-point
+ * approximation used by the manual paint fallback. */
+function measureTextAdvance(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  letterSpacingPx: number,
+): number {
+  const spacingCtx = ctx as CanvasRenderingContext2D & { letterSpacing?: string };
+  const previous = spacingCtx.letterSpacing;
+  if (letterSpacingPx !== 0 && hasNativeLetterSpacing(ctx)) {
+    try {
+      spacingCtx.letterSpacing = `${letterSpacingPx}px`;
+      const tracked = ctx.measureText(text).width;
+      if (Number.isFinite(tracked)) return tracked;
+    } finally {
+      try { spacingCtx.letterSpacing = previous; } catch { /* inert implementation */ }
+    }
+  }
+  return ctx.measureText(text).width + letterSpacingPx * codePointCount(text);
 }
 
 export function layoutParagraph(
@@ -1011,12 +1066,11 @@ export function layoutParagraph(
     if (!text) return;
     ctx.font = font;
     const lsPx = extras?.letterSpacingPx ?? 0;
-    const baseW = ctx.measureText(text).width;
-    // Letter spacing adds an extra gap between every character, including
-    // after the last one — matches the "advance width" semantics of OOXML
-    // spc (each glyph's advance grows by spc points). Tab stops measure the
-    // same way so this stays consistent with measureText below.
-    const w = baseW + lsPx * codePointCount(text);
+    // Measure with the same native Canvas tracking state used by paint so wrap,
+    // tabs, alignment, combining sequences, and emoji clusters stay consistent.
+    // The value comes from DrawingML rPr@spc (§21.1.2.3.9; ST_TextPoint
+    // §20.1.10.74).
+    const w = measureTextAdvance(ctx, text, lsPx);
     const strikeDouble = extras?.strikeDouble;
     const underlineStyle = extras?.underlineStyle;
     const underlineColor = extras?.underlineColor;
@@ -1173,7 +1227,8 @@ export function layoutParagraph(
       : font;
     ctx.font = font;
 
-    // ECMA-376 §21.1.2.3.13 — caps transforms the rendered glyphs without
+    // ECMA-376 §21.1.2.3.9; ST_TextCapsType §20.1.10.64 — caps transforms
+    // the rendered glyphs without
     // changing the underlying text. "small" emulated as upper-case glyphs at
     // ~80% size is the long-established Office fallback when the font lacks
     // smcp; we just upper-case for now and rely on the configured size.
@@ -1253,7 +1308,7 @@ export function layoutParagraph(
       }
 
       ctx.font = font;
-      const tokW = ctx.measureText(token).width;
+      const tokW = measureTextAdvance(ctx, token, lsPx);
       const isWhitespace = /^\s+$/.test(token);
 
       // ── Symbol-font characters (Wingdings/Webdings/Symbol) ───────────────
@@ -1284,7 +1339,7 @@ export function layoutParagraph(
             }
           }
           ctx.font = chFont;
-          const chW = ctx.measureText(drawCh).width;
+          const chW = measureTextAdvance(ctx, drawCh, lsPx);
           if (!fitsW(chW) && lineW > 0) newLine();
           push(drawCh, chFont, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         }
@@ -1332,7 +1387,7 @@ export function layoutParagraph(
           // CJK when an East Asian typeface was declared, else the latin family.
           const chFamily = isEa ? (familyEa as string) : family;
           ctx.font = chFont;
-          measured.push({ ch, w: ctx.measureText(ch).width, font: chFont, family: chFamily });
+          measured.push({ ch, w: measureTextAdvance(ctx, ch, lsPx), font: chFont, family: chFamily });
         }
         if (para.eaLnBrk === false) {
           // Keep the East Asian word whole. If the current line already has
@@ -1392,13 +1447,13 @@ export function layoutParagraph(
         const eaDiffers = familyEa != null && fontEa !== font;
         const isEaCh = (ch: string): boolean => eaDiffers && isCjkBreakChar(ch.codePointAt(0) ?? 0);
         const measureSub = (sub: string): number => {
-          let w = lsPx * codePointCount(sub);
+          let w = 0;
           let runText = '';
           let runEa: boolean | null = null;
           const flush = (): void => {
             if (runText === '') return;
             ctx.font = runEa ? (fontEa as string) : font;
-            w += ctx.measureText(runText).width;
+            w += measureTextAdvance(ctx, runText, lsPx);
             runText = '';
           };
           for (const ch of sub) {
@@ -1461,7 +1516,7 @@ export function layoutParagraph(
         if (lineW > 0) newLine();
         for (const ch of token) {
           ctx.font = font;
-          const chW = ctx.measureText(ch).width;
+          const chW = measureTextAdvance(ctx, ch, lsPx);
           if (!fitsW(chW) && lineW > 0) newLine();
           push(ch, font, sizePx, color, segUnderline, run.strikethrough, run.baseline ?? undefined, segExtras);
         }
@@ -4087,9 +4142,7 @@ export function renderTextBody(
         const ls = seg.letterSpacingPx ?? 0;
         return {
           isTab: false,
-          width: seg.text
-            ? ctx.measureText(seg.text).width + ls * codePointCount(seg.text)
-            : 0,
+          width: seg.text ? measureTextAdvance(ctx, seg.text, ls) : 0,
         };
       });
       const stops = (entry.para.tabStops ?? []).map((stop) => ({
@@ -4125,7 +4178,7 @@ export function renderTextBody(
       ctx.font = seg.font;
       const m = ctx.measureText(seg.text || 'M');
       const ls = seg.letterSpacingPx ?? 0;
-      lineWidth += seg.text ? m.width + ls * codePointCount(seg.text) : 0;
+      lineWidth += seg.text ? measureTextAdvance(ctx, seg.text, ls) : 0;
       if (m.actualBoundingBoxAscent > 0) {
         maxAscent = Math.max(maxAscent, m.actualBoundingBoxAscent);
       }
@@ -4305,8 +4358,7 @@ export function renderTextBody(
       // Box advance = glyph measure + letter spacing + justification stretch
       // (internal CJK pitch + trailing `jext`).
       if (seg.highlight && seg.text) {
-        const hlW = ctx.measureText(seg.text).width
-          + (ls > 0 ? ls * codePointCount(seg.text) : 0)
+        const hlW = measureTextAdvance(ctx, seg.text, ls)
           + internalStretch
           + jext;
         paintHighlight(ctx, penX, segBaseline, hlW, seg.sizePx, seg.highlight, seg.color);
@@ -4324,23 +4376,34 @@ export function renderTextBody(
         op: 'fill' | 'stroke',
       ): void => {
         const paint = op === 'fill' ? target.fillText.bind(target) : target.strokeText.bind(target);
-        if (ls > 0 && text.length > 1) {
-          // rPr @spc (§21.1.2.3.x): distribute the per-glyph advance via canvas
-          // letterSpacing and draw the whole CONTEXTUALLY-shaped string in ONE
-          // paint. This keeps the drawn advance == the layout's contextual
-          // measure + n·ls (約物半角 contextual half-width collapse honoured, so a
+        if (ls !== 0 && codePointCount(text) > 1) {
+          // rPr @spc (§21.1.2.3.9; ST_TextPoint §20.1.10.74): apply the
+          // normalized spacing via Canvas letterSpacing and draw the whole
+          // CONTEXTUALLY-shaped string in ONE paint. The layout measures this
+          // same state via measureTextAdvance, so contextual CJK packing and
+          // multi-code-point shaping clusters use the browser's exact advance.
+          // This keeps 約物半角 contextual half-width collapse honoured, so a
           // piece's glyphs stay aligned with its contextual `dx` origin and the
           // next piece/run never overlaps — the pptx analog of docx PR #626), AND
           // preserves Arabic cursive joining for RTL. (The old LTR branch summed
           // ISOLATED measure(ch)+ls, which overran the contextual box at 約物
-          // punctuation.) Chromium's measureText adds letterSpacing after every
-          // glyph incl. the trailing one (= natural + n·ls), matching
-          // codePointCount(seg.text)·ls used by the layout's segW.
-          const lctx = target as CanvasRenderingContext2D & { letterSpacing: string };
+          // punctuation.)
+          const lctx = target as CanvasRenderingContext2D & { letterSpacing?: string };
           const prev = lctx.letterSpacing;
-          try { lctx.letterSpacing = `${ls}px`; } catch { /* older engines */ }
-          paint(text, atX, segBaseline);
-          try { lctx.letterSpacing = prev; } catch { /* ignore */ }
+          if (hasNativeLetterSpacing(target)) {
+            lctx.letterSpacing = `${ls}px`;
+            paint(text, atX, segBaseline);
+            try { lctx.letterSpacing = prev; } catch { /* inert implementation */ }
+          } else {
+            // Pre-letterSpacing Canvas fallback. It cannot preserve contextual
+            // shaping across the split, but its manual advance matches the
+            // code-point approximation in measureTextAdvance.
+            let x = atX;
+            for (const ch of text) {
+              paint(ch, x, segBaseline);
+              x += measureTextAdvance(target, ch, ls);
+            }
+          }
         } else {
           paint(text, atX, segBaseline);
         }
@@ -4350,19 +4413,19 @@ export function renderTextBody(
       // internal CJK gaps. Anchor each piece to the whole-string prefix advance
       // (via core's `justifiedPiecePositions`) to absorb 約物半角 drift — see
       // packages/core/src/text/justify-positions.ts for the invariant proof.
-      const measureCb = (s: string): number => ctx.measureText(s).width;
+      const measureCb = (s: string): number => measureTextAdvance(ctx, s, ls);
       const pieces =
         splitBefore && splitBefore.length > 0
-          ? justifiedPiecePositions([...seg.text], splitBefore, segPerGap, measureCb, ls)
+          ? justifiedPiecePositions([...seg.text], splitBefore, segPerGap, measureCb)
           : null;
 
       // A run is FULLY distributed when justifyLine opened a gap at EVERY internal
       // inter-glyph boundary (splitBefore.length === cps.length - 1) — e.g. a
       // pure-CJK `algn="just"/"dist"` line. Drawing one single-glyph piece per code
       // point (the `pieces` loop) routes through drawWithFont's `else → paint(ch)`:
-      // each piece has text.length === 1, so the `ls > 0 && text.length > 1`
+      // each piece has one code point, so the `ls !== 0 && codePointCount(text) > 1`
       // letterSpacing branch never fires, and every glyph is painted ISOLATED even
-      // when ls > 0. That loses the browser's JIS X 4051 約物連続 packing — a
+      // when ls is non-zero. That loses the browser's JIS X 4051 約物連続 packing — a
       // closing-class punct immediately followed by an opening bracket ("：［",
       // "、［", "）（") packs ~half-em in measureText (a bracket next to a plain
       // kanji/kana does NOT pack). The isolated full-width bracket then overruns its
@@ -4394,15 +4457,25 @@ export function renderTextBody(
           return;
         }
         if (fullyDistributed) {
-          const lctx = target as CanvasRenderingContext2D & { letterSpacing: string };
-          const prev = lctx.letterSpacing;
-          try { lctx.letterSpacing = `${ls + segPerGap}px`; } catch { /* older engines */ }
-          (op === 'fill' ? target.fillText.bind(target) : target.strokeText.bind(target))(
-            seg.text,
-            penX,
-            segBaseline,
-          );
-          try { lctx.letterSpacing = prev; } catch { /* ignore */ }
+          const paint = op === 'fill'
+            ? target.fillText.bind(target)
+            : target.strokeText.bind(target);
+          const pitch = ls + segPerGap;
+          if (hasNativeLetterSpacing(target)) {
+            const lctx = target as CanvasRenderingContext2D & { letterSpacing: string };
+            const prev = lctx.letterSpacing;
+            lctx.letterSpacing = `${pitch}px`;
+            paint(seg.text, penX, segBaseline);
+            try { lctx.letterSpacing = prev; } catch { /* inert implementation */ }
+          } else {
+            // Old/inert Canvas: use the same code-point pitch approximation as
+            // measureTextAdvance so distributed layout and paint stay aligned.
+            let x = penX;
+            for (const ch of cps) {
+              paint(ch, x, segBaseline);
+              x += measureTextAdvance(target, ch, pitch);
+            }
+          }
         } else if (pieces) {
           for (const { text: pieceText, dx } of pieces) {
             drawWithFont(target, pieceText, penX + dx, op);
@@ -4504,8 +4577,7 @@ export function renderTextBody(
       }
 
       ctx.font = seg.font;
-      const baseW = ctx.measureText(seg.text).width;
-      const segW = baseW + (ls > 0 ? ls * codePointCount(seg.text) : 0) + internalStretch;
+      const segW = measureTextAdvance(ctx, seg.text, ls) + internalStretch;
 
       if (onTextRun && seg.text) {
         onTextRun({

--- a/packages/pptx/src/spc-cluster-advance.test.ts
+++ b/packages/pptx/src/spc-cluster-advance.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import type { TextRunData } from '@silurus/ooxml-core';
+import { renderTextBody } from './renderer.js';
+import type { Paragraph, TextBody } from './types';
+
+const SCALE = 1 / 12700; // 1pt rPr@spc becomes 1px.
+const RC = { themeMajorFont: null, themeMinorFont: null, dpr: 1 };
+
+function clusterCount(text: string): number {
+  return [...new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(text)].length;
+}
+
+type LetterSpacingMode = 'native' | 'inert' | 'absent';
+
+function mockCtx(mode: LetterSpacingMode = 'native') {
+  let letterSpacing = '0px';
+  let font = '20px serif';
+  const fills: Array<{ text: string; x: number; letterSpacing: string }> = [];
+  const ctx = {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    measureText: (text: string) => {
+      const clusters = clusterCount(text);
+      const spacing = mode === 'native' ? Number.parseFloat(letterSpacing) || 0 : 0;
+      return {
+        width: clusters * 10 + clusters * spacing,
+        actualBoundingBoxAscent: 8,
+        actualBoundingBoxDescent: 2,
+      } as TextMetrics;
+    },
+    fillText: (text: string, x: number) => fills.push({
+      text,
+      x,
+      letterSpacing: mode === 'absent' ? '<absent>' : letterSpacing,
+    }),
+    strokeText: () => {},
+    fillRect: () => {}, drawImage: () => {}, save: () => {}, restore: () => {},
+    translate: () => {}, rotate: () => {}, scale: () => {}, beginPath: () => {},
+    moveTo: () => {}, lineTo: () => {}, stroke: () => {}, clip: () => {}, rect: () => {},
+    setLineDash: () => {}, closePath: () => {}, arc: () => {},
+    strokeStyle: '#000', lineWidth: 1, lineJoin: 'miter' as CanvasLineJoin,
+  };
+  if (mode !== 'absent') {
+    Object.defineProperty(ctx, 'letterSpacing', {
+      configurable: true,
+      get: () => letterSpacing,
+      set: (value: string) => { letterSpacing = value; },
+    });
+  }
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fills };
+}
+
+function run(text: string, letterSpacing: number, color: string): TextRunData {
+  return {
+    type: 'text', text, bold: null, italic: null, underline: false,
+    strikethrough: false, fontSize: 20, color, fontFamily: 'Arial', letterSpacing,
+  };
+}
+
+function body(runs: TextRunData[], alignment: Paragraph['alignment'] = 'l'): TextBody {
+  const paragraph = {
+    alignment, marL: 0, marR: 0, indent: 0,
+    spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
+    bullet: { type: 'none' }, defFontSize: null, defColor: null,
+    defBold: null, defItalic: null, defFontFamily: null, tabStops: [],
+    eaLnBrk: true, runs,
+  } as Paragraph;
+  return {
+    verticalAnchor: 't', paragraphs: [paragraph], defaultFontSize: 20,
+    defaultBold: null, defaultItalic: null, lIns: 0, rIns: 0, tIns: 0, bIns: 0,
+    wrap: 'none', vert: 'horz', autoFit: 'none',
+  } as TextBody;
+}
+
+describe('pptx rPr@spc uses Canvas shaping-cluster advances', () => {
+  for (const [name, text] of [
+    ['combining sequence', 'e\u0301'],
+    ['emoji ZWJ sequence', '👨‍👩‍👧‍👦'],
+    ['regional-indicator flag', '🇯🇵'],
+  ] as const) {
+    it(`keeps ${name} layout and paint aligned for positive and negative spacing`, () => {
+      for (const spacing of [4, -4]) {
+        const { ctx, fills } = mockCtx();
+        const seen: Array<{ text: string; x: number; w: number }> = [];
+        renderTextBody(
+          ctx,
+          body([run(text, spacing, '000000'), run('X', 0, 'FF0000')]),
+          0, 0, 400, 100, SCALE,
+          null, 0, false, false, '#000000', undefined, RC,
+          (info) => seen.push({ text: info.text, x: info.inShapeX, w: info.w }),
+        );
+
+        const tracked = seen.find((info) => info.text === text)!;
+        const following = seen.find((info) => info.text === 'X')!;
+        const trackedPaint = fills.find((call) => call.text === text)!;
+        const followingPaint = fills.find((call) => call.text === 'X')!;
+        const expectedAdvance = 10 + spacing;
+
+        expect(tracked.w).toBeCloseTo(expectedAdvance, 6);
+        expect(following.x).toBeCloseTo(tracked.x + expectedAdvance, 6);
+        expect(followingPaint.x).toBeCloseTo(trackedPaint.x + expectedAdvance, 6);
+        expect(trackedPaint.letterSpacing).toBe(`${spacing}px`);
+      }
+    });
+  }
+
+  for (const mode of ['inert', 'absent'] as const) {
+    it(`keeps manual layout and paint aligned when Canvas letterSpacing is ${mode}`, () => {
+      const { ctx, fills } = mockCtx(mode);
+      const seen: Array<{ text: string; x: number; w: number }> = [];
+      renderTextBody(
+        ctx,
+        body([run('AB', 4, '000000'), run('X', 0, 'FF0000')]),
+        0, 0, 400, 100, SCALE,
+        null, 0, false, false, '#000000', undefined, RC,
+        (info) => seen.push({ text: info.text, x: info.inShapeX, w: info.w }),
+      );
+
+      const tracked = seen.find((info) => info.text === 'AB')!;
+      const following = seen.find((info) => info.text === 'X')!;
+      const a = fills.find((call) => call.text === 'A')!;
+      const b = fills.find((call) => call.text === 'B')!;
+      const x = fills.find((call) => call.text === 'X')!;
+
+      expect(fills.some((call) => call.text === 'AB')).toBe(false);
+      expect(tracked.w).toBeCloseTo(28, 6);
+      expect(b.x).toBeCloseTo(a.x + 14, 6);
+      expect(following.x).toBeCloseTo(tracked.x + 28, 6);
+      expect(x.x).toBeCloseTo(a.x + 28, 6);
+    });
+
+    it(`manually paints fully-distributed glyph positions when Canvas letterSpacing is ${mode}`, () => {
+      const { ctx, fills } = mockCtx(mode);
+      renderTextBody(
+        ctx,
+        body([run('あいう', 4, '000000')], 'dist'),
+        0, 0, 100, 100, SCALE,
+        null, 0, false, false, '#000000', undefined, RC,
+      );
+
+      const glyphs = fills.filter((call) => ['あ', 'い', 'う'].includes(call.text));
+      expect(fills.some((call) => call.text === 'あいう')).toBe(false);
+      expect(glyphs).toHaveLength(3);
+      expect(glyphs[1].x).toBeGreaterThan(glyphs[0].x + 14);
+      expect(glyphs[2].x - glyphs[1].x).toBeCloseTo(glyphs[1].x - glyphs[0].x, 6);
+    });
+  }
+});

--- a/packages/pptx/src/spc-cluster-advance.test.ts
+++ b/packages/pptx/src/spc-cluster-advance.test.ts
@@ -50,20 +50,30 @@ function mockCtx(mode: LetterSpacingMode = 'native') {
   return { ctx: ctx as unknown as CanvasRenderingContext2D, fills };
 }
 
-function run(text: string, letterSpacing: number, color: string): TextRunData {
+function run(
+  text: string,
+  letterSpacing: number,
+  color: string,
+  fontFamilyEa?: string,
+): TextRunData {
   return {
     type: 'text', text, bold: null, italic: null, underline: false,
     strikethrough: false, fontSize: 20, color, fontFamily: 'Arial', letterSpacing,
+    ...(fontFamilyEa ? { fontFamilyEa } : {}),
   };
 }
 
-function body(runs: TextRunData[], alignment: Paragraph['alignment'] = 'l'): TextBody {
+function body(
+  runs: TextRunData[],
+  alignment: Paragraph['alignment'] = 'l',
+  rtl: boolean = false,
+): TextBody {
   const paragraph = {
     alignment, marL: 0, marR: 0, indent: 0,
     spaceBefore: null, spaceAfter: null, spaceLine: null, lvl: 0,
     bullet: { type: 'none' }, defFontSize: null, defColor: null,
     defBold: null, defItalic: null, defFontFamily: null, tabStops: [],
-    eaLnBrk: true, runs,
+    eaLnBrk: true, rtl, runs,
   } as Paragraph;
   return {
     verticalAnchor: 't', paragraphs: [paragraph], defaultFontSize: 20,
@@ -73,6 +83,99 @@ function body(runs: TextRunData[], alignment: Paragraph['alignment'] = 'l'): Tex
 }
 
 describe('pptx rPr@spc uses Canvas shaping-cluster advances', () => {
+  it('applies positive and negative spacing only at internal cluster boundaries', () => {
+    for (const spacing of [4, -4]) {
+      const { ctx, fills } = mockCtx();
+      const seen: Array<{ text: string; x: number; w: number }> = [];
+      renderTextBody(
+        ctx,
+        body([run('AB', spacing, '000000'), run('X', 0, 'FF0000')]),
+        0, 0, 400, 100, SCALE,
+        null, 0, false, false, '#000000', undefined, RC,
+        (info) => seen.push({ text: info.text, x: info.inShapeX, w: info.w }),
+      );
+
+      const tracked = seen.find((info) => info.text === 'AB')!;
+      const following = seen.find((info) => info.text === 'X')!;
+      const trackedPaint = fills.find((call) => call.text === 'AB')!;
+      const followingPaint = fills.find((call) => call.text === 'X')!;
+      const expectedAdvance = 20 + spacing;
+
+      expect(tracked.w).toBeCloseTo(expectedAdvance, 6);
+      expect(following.x).toBeCloseTo(tracked.x + expectedAdvance, 6);
+      expect(followingPaint.x).toBeCloseTo(trackedPaint.x + expectedAdvance, 6);
+      expect(trackedPaint.letterSpacing).toBe(`${spacing}px`);
+    }
+  });
+
+  it('preserves the spacing seam when one authored run switches to an EA font', () => {
+    for (const spacing of [4, -4]) {
+      for (const alignment of ['l', 'ctr'] as const) {
+        const { ctx, fills } = mockCtx();
+        const seen: Array<{ text: string; x: number; w: number }> = [];
+        renderTextBody(
+          ctx,
+          body([run('Aあ', spacing, '000000', 'Meiryo')], alignment),
+          0, 0, 100, 100, SCALE,
+          null, 0, false, false, '#000000', undefined, RC,
+          (info) => seen.push({ text: info.text, x: info.inShapeX, w: info.w }),
+        );
+
+        const latin = fills.find((call) => call.text === 'A')!;
+        const cjk = fills.find((call) => call.text === 'あ')!;
+        expect(cjk.x).toBeCloseTo(latin.x + 10 + spacing, 6);
+        const first = seen.find((info) => info.text === 'A')!;
+        const second = seen.find((info) => info.text === 'あ')!;
+        expect(second.x + second.w - first.x).toBeCloseTo(20 + spacing, 6);
+      }
+    }
+  });
+
+  it('preserves an EA-font spacing seam after a tab stop', () => {
+    const { ctx, fills } = mockCtx();
+    const tabbed = body([run('\tAあ', 4, '000000', 'Meiryo')]);
+    tabbed.paragraphs[0].tabStops = [{ pos: 30 * 12700, algn: 'l' }];
+    renderTextBody(
+      ctx, tabbed,
+      0, 0, 100, 100, SCALE,
+      null, 0, false, false, '#000000', undefined, RC,
+    );
+    const latin = fills.find((call) => call.text === 'A')!;
+    const cjk = fills.find((call) => call.text === 'あ')!;
+    expect(latin.x).toBeCloseTo(30, 6);
+    expect(cjk.x).toBeCloseTo(latin.x + 14, 6);
+  });
+
+  it('does not insert spacing between distinct authored runs', () => {
+    const { ctx, fills } = mockCtx();
+    renderTextBody(
+      ctx,
+      body([run('A', 4, '000000'), run('あ', 4, 'FF0000', 'Meiryo')]),
+      0, 0, 100, 100, SCALE,
+      null, 0, false, false, '#000000', undefined, RC,
+    );
+    const latin = fills.find((call) => call.text === 'A')!;
+    const cjk = fills.find((call) => call.text === 'あ')!;
+    expect(cjk.x).toBeCloseTo(latin.x + 10, 6);
+  });
+
+  it('keeps an EA-font spacing seam between visually reordered RTL segments', () => {
+    for (const spacing of [4, -4]) {
+      const { ctx, fills } = mockCtx();
+      renderTextBody(
+        ctx,
+        body([run('אבあ', spacing, '000000', 'Meiryo')], 'r', true),
+        0, 0, 100, 100, SCALE,
+        null, 0, false, false, '#000000', undefined, RC,
+      );
+      const cjk = fills.find((call) => call.text === 'あ')!;
+      const hebrew = fills.find((call) => call.text === 'אב')!;
+      // Visual order is [あ, אב]. The spacing belongs at that visual seam,
+      // never before the first glyph at the line edge.
+      expect(hebrew.x).toBeCloseTo(cjk.x + 10 + spacing, 6);
+    }
+  });
+
   for (const [name, text] of [
     ['combining sequence', 'e\u0301'],
     ['emoji ZWJ sequence', '👨‍👩‍👧‍👦'],
@@ -94,7 +197,9 @@ describe('pptx rPr@spc uses Canvas shaping-cluster advances', () => {
         const following = seen.find((info) => info.text === 'X')!;
         const trackedPaint = fills.find((call) => call.text === text)!;
         const followingPaint = fills.find((call) => call.text === 'X')!;
-        const expectedAdvance = 10 + spacing;
+        // Each case is one browser shaping cluster, so DrawingML has no
+        // internal character boundary at which to apply spacing.
+        const expectedAdvance = 10;
 
         expect(tracked.w).toBeCloseTo(expectedAdvance, 6);
         expect(following.x).toBeCloseTo(tracked.x + expectedAdvance, 6);
@@ -123,10 +228,10 @@ describe('pptx rPr@spc uses Canvas shaping-cluster advances', () => {
       const x = fills.find((call) => call.text === 'X')!;
 
       expect(fills.some((call) => call.text === 'AB')).toBe(false);
-      expect(tracked.w).toBeCloseTo(28, 6);
+      expect(tracked.w).toBeCloseTo(24, 6);
       expect(b.x).toBeCloseTo(a.x + 14, 6);
-      expect(following.x).toBeCloseTo(tracked.x + 28, 6);
-      expect(x.x).toBeCloseTo(a.x + 28, 6);
+      expect(following.x).toBeCloseTo(tracked.x + 24, 6);
+      expect(x.x).toBeCloseTo(a.x + 24, 6);
     });
 
     it(`manually paints fully-distributed glyph positions when Canvas letterSpacing is ${mode}`, () => {

--- a/packages/pptx/src/spc-wrap.test.ts
+++ b/packages/pptx/src/spc-wrap.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { TextRunData } from '@silurus/ooxml-core';
+import { layoutParagraph } from './renderer.js';
+import type { Paragraph } from './types';
+
+const SCALE = 1 / 12700; // 1pt rPr@spc becomes 1px in these tests.
+const RC = { themeMajorFont: null, themeMinorFont: null, dpr: 1 };
+
+function mockCtx(): CanvasRenderingContext2D {
+  let font = '20px serif';
+  return {
+    get font() { return font; },
+    set font(value: string) { font = value; },
+    measureText: (text: string) => ({
+      width: [...text].length * 10,
+      actualBoundingBoxAscent: 8,
+      actualBoundingBoxDescent: 2,
+    }) as TextMetrics,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function paragraph(text: string, letterSpacing: number): Paragraph {
+  const run: TextRunData = {
+    type: 'text',
+    text,
+    bold: null,
+    italic: null,
+    underline: false,
+    strikethrough: false,
+    fontSize: 20,
+    color: '000000',
+    fontFamily: 'Arial',
+    letterSpacing,
+  };
+  return {
+    alignment: 'l',
+    marL: 0,
+    marR: 0,
+    indent: 0,
+    spaceBefore: null,
+    spaceAfter: null,
+    spaceLine: null,
+    lvl: 0,
+    bullet: { type: 'none' },
+    defFontSize: null,
+    defColor: null,
+    defBold: null,
+    defItalic: null,
+    defFontFamily: null,
+    tabStops: [],
+    eaLnBrk: true,
+    runs: [run],
+  } as Paragraph;
+}
+
+function lineTexts(text: string, letterSpacing: number, maxWidth: number): string[] {
+  return layoutParagraph(
+    mockCtx(),
+    paragraph(text, letterSpacing),
+    maxWidth,
+    20,
+    '#000000',
+    SCALE,
+    0,
+    false,
+    false,
+    1,
+    undefined,
+    RC,
+  ).map((line) => line.segments.map((segment) => segment.text).join(''));
+}
+
+describe('pptx rPr@spc wrap budgets (§21.1.2.3.9; ST_TextPoint §20.1.10.74)', () => {
+  it('includes positive and negative spacing when fitting Latin tokens', () => {
+    expect(lineTexts('AA BB', 2, 58)).toEqual(['AA ', 'BB']);
+    expect(lineTexts('AA BB', -2, 42)).toEqual(['AA BB']);
+  });
+
+  it('includes positive and negative spacing at CJK break opportunities', () => {
+    expect(lineTexts('あいうえお', 2, 55)).toEqual(['あいうえ', 'お']);
+    expect(lineTexts('あいうえお', -2, 45)).toEqual(['あいうえお']);
+  });
+});

--- a/packages/pptx/src/spc-wrap.test.ts
+++ b/packages/pptx/src/spc-wrap.test.ts
@@ -72,7 +72,8 @@ function lineTexts(text: string, letterSpacing: number, maxWidth: number): strin
 
 describe('pptx rPr@spc wrap budgets (§21.1.2.3.9; ST_TextPoint §20.1.10.74)', () => {
   it('includes positive and negative spacing when fitting Latin tokens', () => {
-    expect(lineTexts('AA BB', 2, 58)).toEqual(['AA ', 'BB']);
+    // 5 glyphs have 4 internal boundaries: 50 + 4·2 = 58px.
+    expect(lineTexts('AA BB', 2, 57)).toEqual(['AA ', 'BB']);
     expect(lineTexts('AA BB', -2, 42)).toEqual(['AA BB']);
   });
 

--- a/packages/pptx/src/tab-stop-spc.test.ts
+++ b/packages/pptx/src/tab-stop-spc.test.ts
@@ -3,7 +3,8 @@ import { renderTextBody } from './renderer.js';
 import type { TextBody, Paragraph } from './types';
 import type { TextRunData, TabStop } from '@silurus/ooxml-core';
 
-// ECMA-376 §21.1.2.3.x (rPr @spc, letter-spacing) — 約物半角 bracket overlap on the
+// ECMA-376 §21.1.2.3.9 (rPr @spc; ST_TextPoint §20.1.10.74) — 約物半角
+// bracket overlap on the
 // TAB-STOP draw path, the pptx analog of PR #627 (drawWithFont) and docx #626
 // (docGrid §17.6.5).
 //
@@ -47,11 +48,10 @@ function ctxMeasure(s: string, fontPx: number): number {
   return w;
 }
 
-/** Recording 2D context. `measureText` models 約物半角 contextual collapse and is
- *  agnostic of letterSpacing (the renderer always measures BEFORE it sets
- *  letterSpacing). `fillText` records text + x + y AND the current letterSpacing
- *  at call time, so a test can assert the contiguous-draw fix set
- *  `ctx.letterSpacing = ls`. */
+/** Recording 2D context. `measureText` models 約物半角 contextual collapse plus
+ * native Canvas letterSpacing. `fillText` records text + x + y AND the current
+ * letterSpacing at call time, so a test can assert the contiguous-draw fix set
+ * `ctx.letterSpacing = ls`. */
 function mockCtx(): {
   ctx: CanvasRenderingContext2D;
   texts: { text: string; x: number; y: number; letterSpacing: string }[];
@@ -71,7 +71,7 @@ function mockCtx(): {
     measureText: (s: string) => {
       const p = px();
       return {
-        width: ctxMeasure(s, p),
+        width: ctxMeasure(s, p) + [...s].length * (parseFloat(letterSpacing) || 0),
         actualBoundingBoxAscent: p * 0.8,
         actualBoundingBoxDescent: p * 0.2,
         fontBoundingBoxAscent: p * 0.8,
@@ -152,7 +152,7 @@ const LS = 4; // px of @spc letter-spacing (points == px at SCALE 1/12700)
 // Tab stop at 400px from the text-area left (> the current pen of 0 at the `\t`).
 const TAB_POS_EMU = 400 * 12700;
 
-describe('pptx @spc tab-stop — 約物半角 brackets are drawn contiguously, never overlap (§21.1.2.3.x)', () => {
+describe('pptx @spc tab-stop — 約物半角 brackets are drawn contiguously, never overlap (§21.1.2.3.9)', () => {
   // (1) RED→GREEN core fix: a tab-stop @spc EA segment is painted by EXACTLY ONE
   //     contiguous fillText carrying the whole string, with letterSpacing=ls.
   //     Before the fix: 7 single-code-point fillText calls, letterSpacing '0px'.

--- a/packages/pptx/src/tab-stop-spc.test.ts
+++ b/packages/pptx/src/tab-stop-spc.test.ts
@@ -11,7 +11,7 @@ import type { TextRunData, TabStop } from '@silurus/ooxml-core';
 // A right-/centre-aligned tab stop (pPr > tabLst, §21.1.2.1.x) places the text
 // after a `\t` at the stop (since #916, as ordinary inline segments after an
 // inline tab segment). Each segment is measured CONTEXTUALLY:
-// `segW = measureText(seg.text) + ls·codePointCount`. The browser's 約物半角
+// `segW = measureText(seg.text) + ls·(clusterCount-1)`. The browser's 約物半角
 // contextual shaping collapses an opening bracket "［" to half-width when it is
 // FOLLOWED by an East-Asian glyph WITHIN the measured string
 // (`measureText("［あ") < measureText("［") + measureText("あ")`).
@@ -173,7 +173,7 @@ describe('pptx @spc tab-stop — 約物半角 brackets are drawn contiguously, n
   });
 
   // (2) No-overlap / contextual abutment: the EA tab segment is one draw, its
-  //     reported box width is the CONTEXTUAL measure + len·ls (bracket collapsed),
+  //     reported box width is the contextual measure + (len-1)·ls (bracket collapsed),
   //     and the FOLLOWING tab segment abuts that edge (no overlap, no gap). The
   //     buggy per-glyph isolated sum would have overrun by FONT_PX/2 (full−half).
   it('keeps measure==draw so the next tab segment abuts the @spc EA box (no overlap)', () => {
@@ -189,9 +189,9 @@ describe('pptx @spc tab-stop — 約物半角 brackets are drawn contiguously, n
     const eaCalls = texts.filter((c) => c.text === EA_SPC);
     expect(eaCalls.length, 'EA tab segment is a single draw').toBe(1);
 
-    // Reported box width = contextual measure (bracket half) + len·ls = tabSegW.
+    // Reported box width = contextual measure + spacing at len-1 boundaries.
     const len = [...EA_SPC].length;
-    const boxW = ctxMeasure(EA_SPC, FONT_PX) + len * LS;
+    const boxW = ctxMeasure(EA_SPC, FONT_PX) + (len - 1) * LS;
     expect(segEA.w).toBeCloseTo(boxW, 6);
 
     // The next tab segment is drawn at the EA segment's box edge → abuts exactly.


### PR DESCRIPTION
## Summary\n\n- follow up on #1221 by correcting the ECMA-376 references for DrawingML run properties and ST_TextPoint\n- parse rPr@spc according to ST_TextPoint: unitless hundredths of a point and unit-bearing universal measures\n- apply spacing only at internal character boundaries, including shaped clusters and fragments split by font/script or bidi visual ordering\n- use Canvas letterSpacing where supported, with layout/paint-consistent fallback for older or inert implementations\n- apply positive and negative tracking consistently to wrapping, autofit, tabs, alignment, highlights, justification, and text-run callbacks\n\n## Specification\n\n- ECMA-376 §21.1.2.3.9 (rPr)\n- ECMA-376 §20.1.10.74 (ST_TextPoint)\n- ECMA-376 §22.9.2.15 (ST_UniversalMeasure)\n\n## Verification\n\n- 674 PPTX/Core TypeScript tests\n- 355 ooxml-common Rust tests\n- 259 pptx-parser Rust tests\n- TypeScript project build\n- cargo fmt --all --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- complete private-corpus self-regression against the exact merge base: DOCX and XLSX fully unchanged; PPTX changes limited to the two reviewed slides affected by authored negative spacing\n- git diff --check\n\nAdversarial review and follow-up reviews identified and verified fixes for shaping-cluster advances, unit-bearing ST_TextPoint values, old/inert Canvas fallback consistency, trailing Canvas spacing, same-run layout fragmentation, and bidi visual ordering. The final review reported no actionable findings or merge blockers.