### PR TITLE
fix(chart): honor text and outer-axis margins

### DIFF
--- a/packages/core/src/chart/layout.ts
+++ b/packages/core/src/chart/layout.ts
@@ -290,6 +290,63 @@ export function catAxisLabelBandH(catAxFontPx: number): number {
   return catAxFontPx * CAT_AXIS_LABEL_BAND_FONT_FRAC;
 }
 
+/** Office's default distance from an axis rule to one line of tick-label text,
+ * expressed relative to the resolved label font. These are paint metrics, not
+ * chart-size percentages, so the authored point size remains stable at zoom. */
+export function categoryTickLabelGapPx(fontPx: number): number {
+  return fontPx * (5 / 6);
+}
+
+export function valueTickLabelGapPx(fontPx: number): number {
+  return fontPx;
+}
+
+/** Excel/PowerPoint keep 1.5 pt of clear chart space outside the tick-label
+ * ink when resolving an authored outer plot rectangle. This is distinct from
+ * the rule-to-label gap. The value is consistent across the horizontal and
+ * vertical axes in the Office vector exports used to verify outer layouts. */
+export const AXIS_OUTER_TEXT_MARGIN_PT = 1.5;
+
+/** Measured conversion from a `layoutTarget="outer"` plot-area rectangle to
+ * its inner data rectangle (ECMA-376 §21.2.2.89). The outer rectangle includes
+ * tick marks, tick labels, axis titles, and Office's outer text clearance.
+ * Keeping this one-line label geometry shared prevents the
+ * bar, line, and area families from assigning different inner plot rectangles
+ * to the same authored layout. */
+export function chartManualOuterAxisInsets(metrics: Readonly<{
+  valAxisHidden: boolean;
+  catAxisHidden: boolean;
+  valLabelWidth: number;
+  valLabelFontPx: number;
+  catLabelFontPx: number;
+  valLabelGapPx?: number;
+  catLabelGapPx?: number;
+  outerTextMarginPx?: number;
+  valTitleBandW: number;
+  catTitleBandH: number;
+  secondaryBandW?: number;
+}>): ChartPad {
+  const outerMargin = metrics.outerTextMarginPx ?? 0;
+  return {
+    t: metrics.valAxisHidden ? 0 : metrics.valLabelFontPx / 2 + outerMargin,
+    r: (metrics.secondaryBandW ?? 0) > 0
+      ? (metrics.secondaryBandW ?? 0) + outerMargin
+      : 0,
+    b: metrics.catAxisHidden
+      ? 0
+      : metrics.catLabelFontPx
+        + (metrics.catLabelGapPx ?? categoryTickLabelGapPx(metrics.catLabelFontPx))
+        + metrics.catTitleBandH
+        + outerMargin,
+    l: metrics.valAxisHidden
+      ? 0
+      : metrics.valLabelWidth
+        + (metrics.valLabelGapPx ?? valueTickLabelGapPx(metrics.valLabelFontPx))
+        + metrics.valTitleBandW
+        + outerMargin,
+  };
+}
+
 // ─── Frame parameters + computeChartFrame ────────────────────────────────────
 
 /** A resolved `{t,r,b,l}` plot pad (canvas px). The caller builds this from the

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -182,6 +182,49 @@ describe('chart-space background', () => {
 });
 
 describe('chart drawing user-shape text boxes', () => {
+  it('applies DrawingML default text insets inside chart user shapes', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      categories: ['A'],
+      series: [series({ values: [1] })],
+      chartTextBoxes: [{
+        x: 0,
+        y: 0,
+        w: 1,
+        h: 0.2,
+        paragraphs: [{ runs: [{ text: 'Title', fontSizeHpt: 1000 }] }],
+      }],
+    }), RECT, 1);
+
+    const title = rec.texts.find(text => text.text === 'Title');
+    expect(title?.x).toBeCloseTo(7.2, 6);
+    expect(title?.y).toBeCloseTo(3.6 + 9, 6);
+  });
+
+  it('honors explicit asymmetric DrawingML text insets and the content-box alignment', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      categories: ['A'],
+      series: [series({ values: [1] })],
+      chartTextBoxes: [{
+        x: 0.1,
+        y: 0.1,
+        w: 0.5,
+        h: 0.2,
+        lIns: 12700,
+        tIns: 25400,
+        rIns: 38100,
+        bIns: 50800,
+        paragraphs: [{ align: 'r', runs: [{ text: 'Right', fontSizeHpt: 1000 }] }],
+      }],
+    }), RECT, 1);
+
+    const text = rec.texts.find(item => item.text === 'Right');
+    const contentRight = RECT.w * 0.6 - 3;
+    expect((text?.x ?? 0) + (text?.width ?? 0)).toBeCloseTo(contentRight, 6);
+    expect(text?.y).toBeCloseTo(RECT.h * 0.1 + 2 + 9, 6);
+  });
+
   it('draws relative paragraphs with authored run formatting above the chart', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({
@@ -1064,7 +1107,7 @@ describe('CH4 — stackedAreaPct normalizes like the line/bar percentStacked con
     // CT_LayoutTarget defaults to `outer`: its left edge includes the value
     // labels, while the inner data rectangle begins after their measured width
     // and authored-font gap. The label must not be pushed outside chart space.
-    expect(tickLeft).toBeCloseTo(outerX, 5);
+    expect(tickLeft).toBeCloseTo(outerX + 1.5, 5);
     const plotBg = rec.rects.find(rect => rect.fs === '#ABCDEF');
     expect(plotBg?.x).toBeGreaterThan(outerX);
   });
@@ -1165,7 +1208,7 @@ describe('ECMA-376 §21.2.2.89 — omitted layoutTarget defaults to outer', () =
     const topTick = rec.texts.find(text => text.text === '$1,400');
     expect(topTick).toBeDefined();
     const tickLeft = (topTick?.x ?? 0) - (topTick?.width ?? 0);
-    expect(tickLeft).toBeCloseTo(7, 5);
+    expect(tickLeft).toBeCloseTo(8.5, 5);
     expect(rec.rects.find(rect => rect.fs === '#ABCDEF')?.x).toBeGreaterThan(7);
   });
 
@@ -1186,6 +1229,26 @@ describe('ECMA-376 §21.2.2.89 — omitted layoutTarget defaults to outer', () =
     expect(plot?.x).toBeCloseTo(7, 5);
     expect(plot?.h).toBeLessThan(0.68 * 420);
     expect(rec.texts.find(text => text.text === 'A')?.y).toBeGreaterThan((plot?.y ?? 0) + (plot?.h ?? 0));
+  });
+
+  it('uses the same measured axis-label insets for line and area geometry', () => {
+    const plots = (chartType: 'line' | 'area') => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['2016', '2017'],
+        series: [series({ values: [20, 40] })],
+        valMax: 40,
+        valAxisMajorUnit: 10,
+        valAxisFontSizeHpt: 1000,
+        catAxisFontSizeHpt: 1000,
+        plotAreaBg: 'ABCDEF',
+        plotAreaManualLayout: outer,
+      }), { x: 0, y: 0, w: 700, h: 420 }, 1);
+      return rec.rects.find(rect => rect.fs === '#ABCDEF');
+    };
+
+    expect(plots('line')).toEqual(plots('area'));
   });
 });
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -6,14 +6,18 @@
 import type { ChartDataLabelOverride, ChartModel, ChartRect, ChartSeries, ChartSeriesDataLabels, ChartTextBox, SecondaryValueAxis } from '../types/chart';
 import type { Fill } from '../types/common';
 import {
+  AXIS_OUTER_TEXT_MARGIN_PT,
   computeChartFrame,
   cartesianTitleBand,
   catAxisLabelBandH,
   chartLegendReserve,
   chartLegendBands,
   chartAxisTitleBands,
+  chartManualOuterAxisInsets,
+  categoryTickLabelGapPx,
   axisTitleMargin,
   resolveManualLayoutRect,
+  valueTickLabelGapPx,
   type ChartLegendReserve,
 } from './layout.js';
 import { niceStep, valueAxisScale, axisFraction, logAxisScale, fitTrendline } from './axis-scale.js';
@@ -21,7 +25,12 @@ import { axisLineWidthPx, resolveAxisLine, resolveGridline, isCrossBetween } fro
 import { formatChartVal, formatChartValWithCode, formatCategoryLabel } from './chart-number-format.js';
 import { elideToWidth } from './text-elide.js';
 import { hexToRgba, resolveFill } from '../shape/paint.js';
-import { EMU_PER_PT, PT_TO_PX } from '../units.js';
+import {
+  DEFAULT_TEXT_INSET_LR_EMU,
+  DEFAULT_TEXT_INSET_TB_EMU,
+  EMU_PER_PT,
+  PT_TO_PX,
+} from '../units.js';
 
 // ─── Palette + helpers ──────────────────────────────────────────────────────
 
@@ -896,18 +905,6 @@ function axisLabelPx(sizeHpt: number | null | undefined, h: number, ptToPx: numb
   return Math.max(8, h * 0.045);
 }
 
-/** Office's default clearances between an axis rule and its tick-label text.
- * PDF vector output consistently places a 12pt category label 10pt below the
- * rule and a value label's right edge 12pt left of the rule. Keep the spacing
- * proportional to the authored font so zoom and non-default sizes scale. */
-function categoryTickLabelGapPx(fontPx: number): number {
-  return fontPx * (5 / 6);
-}
-
-function valueTickLabelGapPx(fontPx: number): number {
-  return fontPx;
-}
-
 /** Wrap text against the active canvas font without discarding characters.
  * Words are kept intact when possible; a single over-wide token is split at
  * measured character boundaries. Used by chart families whose category-label
@@ -1455,6 +1452,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const prevFont = ctx.font;
   // Primary value-axis label band (column charts only; horizontal bars keep a
   // wider left band for the category labels).
+  let valLabelTextW = 0;
   let valLabelBandW = 0;
   if (!isH && !chart.valAxisHidden) {
     // Measure with the same face the value-axis ticks draw with (below), so the
@@ -1467,7 +1465,8 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       const label = formatPrimaryValueAxisTick(chart, val, pct);
       wmax = Math.max(wmax, ctx.measureText(label).width);
     }
-    valLabelBandW = wmax + 16; // ~12px tick+gap to the axis + ~4px to the title
+    valLabelTextW = wmax;
+    valLabelBandW = valLabelTextW + 16; // ~12px tick+gap to the axis + ~4px to the title
   }
   let horizontalCategoryLabelBandW = 0;
   if (
@@ -1530,12 +1529,23 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
         b: chart.valAxisHidden ? 0 : measuredValTickFontPx + catTitleH,
         l: chart.catAxisHidden ? 0 : horizontalCategoryLabelBandW + valTitleW,
       }
-    : {
-        t: chart.valAxisHidden ? 0 : measuredValTickFontPx / 2,
-        r: secLabelBandW + secTitleBandW,
-        b: chart.catAxisHidden ? 0 : catAxisLabelBandH(catAxFontPx) + catTitleH,
-        l: chart.valAxisHidden ? 0 : valLabelBandW + valTitleW,
-      };
+    : chartManualOuterAxisInsets({
+        valAxisHidden: chart.valAxisHidden,
+        catAxisHidden: chart.catAxisHidden,
+        valLabelWidth: valLabelTextW,
+        valLabelFontPx: measuredValTickFontPx,
+        catLabelFontPx: catAxFontPx,
+        valLabelGapPx: chart.valAxisFontSizeHpt != null
+          ? valueTickLabelGapPx(measuredValTickFontPx)
+          : 12,
+        catLabelGapPx: chart.catAxisFontSizeHpt != null
+          ? categoryTickLabelGapPx(catAxFontPx)
+          : 3,
+        outerTextMarginPx: AXIS_OUTER_TEXT_MARGIN_PT * ptToPx,
+        valTitleBandW: valTitleW,
+        catTitleBandH: catTitleH,
+        secondaryBandW: secLabelBandW + secTitleBandW,
+      });
 
   drawChartTitleForLayout(ctx, chart, x, y, w, h, y + titleTopPad, titleFontPx);
 
@@ -2284,10 +2294,6 @@ function renderLineChart(
     }
     ctx.font = previousFont;
   }
-  const primaryLabelGap = chart.valAxisFontSizeHpt != null
-    ? valueTickLabelGapPx(valAxFontPx)
-    : 6;
-
   // Pad based on actual label metrics rather than magic percents so an explicit
   // <c:txPr sz="1000"> (10pt) correctly compresses the plot area.
   const pad = {
@@ -2297,12 +2303,23 @@ function renderLineChart(
     l: valAxFontPx * 2.2 + 10 + valTitleW + legLeftW,
   };
 
-  const manualOuterInsets = {
-    t: chart.valAxisHidden ? 0 : valAxFontPx / 2,
-    r: secLabelBandW + secTitleBandW,
-    b: chart.catAxisHidden ? 0 : catAxisLabelBandH(catAxFontPx) + catTitleH,
-    l: chart.valAxisHidden ? 0 : primaryLabelWidth + primaryLabelGap + valTitleW,
-  };
+  const manualOuterInsets = chartManualOuterAxisInsets({
+    valAxisHidden: chart.valAxisHidden,
+    catAxisHidden: chart.catAxisHidden,
+    valLabelWidth: primaryLabelWidth,
+    valLabelFontPx: valAxFontPx,
+    catLabelFontPx: catAxFontPx,
+    valLabelGapPx: chart.valAxisFontSizeHpt != null
+      ? valueTickLabelGapPx(valAxFontPx)
+      : 6,
+    catLabelGapPx: chart.catAxisFontSizeHpt != null
+      ? categoryTickLabelGapPx(catAxFontPx)
+      : 5,
+    outerTextMarginPx: AXIS_OUTER_TEXT_MARGIN_PT * ptToPx,
+    valTitleBandW: valTitleW,
+    catTitleBandH: catTitleH,
+    secondaryBandW: secLabelBandW + secTitleBandW,
+  });
 
   drawChartTitleForLayout(ctx, chart, x, y, w, h, y + titleTopPad, titleFontPx);
 
@@ -2953,17 +2970,23 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     }
     ctx.font = prevFont;
   }
-  const primaryLabelGap = chart.valAxisFontSizeHpt != null
-    ? valueTickLabelGapPx(manualValTickFontPx)
-    : 6;
-  const manualOuterInsets = {
-    t: chart.valAxisHidden ? 0 : manualValTickFontPx / 2,
-    r: secLabelBandW + secTitleBandW,
-    b: chart.catAxisHidden
-      ? 0
-      : catAxFontPx + (chart.catAxisFontSizeHpt != null ? categoryTickLabelGapPx(catAxFontPx) : 3) + catTitleH,
-    l: chart.valAxisHidden ? 0 : primaryLabelWidth + primaryLabelGap + valTitleW,
-  };
+  const manualOuterInsets = chartManualOuterAxisInsets({
+    valAxisHidden: chart.valAxisHidden,
+    catAxisHidden: chart.catAxisHidden,
+    valLabelWidth: primaryLabelWidth,
+    valLabelFontPx: manualValTickFontPx,
+    catLabelFontPx: catAxFontPx,
+    valLabelGapPx: chart.valAxisFontSizeHpt != null
+      ? valueTickLabelGapPx(manualValTickFontPx)
+      : 6,
+    catLabelGapPx: chart.catAxisFontSizeHpt != null
+      ? categoryTickLabelGapPx(catAxFontPx)
+      : 3,
+    outerTextMarginPx: AXIS_OUTER_TEXT_MARGIN_PT * ptToPx,
+    valTitleBandW: valTitleW,
+    catTitleBandH: catTitleH,
+    secondaryBandW: secLabelBandW + secTitleBandW,
+  });
 
   const pad = {
     t: padT,
@@ -6822,6 +6845,13 @@ function drawChartTextBoxes(
     const bw = box.w * rect.w;
     const bh = box.h * rect.h;
     if (!(bw > 0 && bh > 0)) continue;
+    const contentX = bx + ((box.lIns ?? DEFAULT_TEXT_INSET_LR_EMU) / EMU_PER_PT) * ptToPx;
+    const contentY0 = by + ((box.tIns ?? DEFAULT_TEXT_INSET_TB_EMU) / EMU_PER_PT) * ptToPx;
+    const contentRight = bx + bw - ((box.rIns ?? DEFAULT_TEXT_INSET_LR_EMU) / EMU_PER_PT) * ptToPx;
+    const contentBottom = by + bh - ((box.bIns ?? DEFAULT_TEXT_INSET_TB_EMU) / EMU_PER_PT) * ptToPx;
+    const contentW = contentRight - contentX;
+    const contentH = contentBottom - contentY0;
+    if (!(contentW > 0 && contentH > 0)) continue;
 
     type MeasuredTextRun = {
       run: ChartTextBox['paragraphs'][number]['runs'][number];
@@ -6860,7 +6890,7 @@ function drawChartTextBoxes(
         return { run, text: run.text, fontPx, font, width: ctx.measureText(run.text).width };
       });
       const paragraphWidth = measuredRuns.reduce((sum, run) => sum + run.width, 0);
-      if (box.wrap === 'none' || paragraphWidth <= bw) {
+      if (box.wrap === 'none' || paragraphWidth <= contentW) {
         return [makeLine(paragraph, measuredRuns)];
       }
 
@@ -6880,7 +6910,7 @@ function drawChartTextBoxes(
           const whitespace = /^\s+$/.test(token);
           ctx.font = measured.font;
           const tokenWidth = ctx.measureText(token).width;
-          if (current.length && currentWidth + tokenWidth > bw) {
+          if (current.length && currentWidth + tokenWidth > contentW) {
             flush();
           }
           // A wrapped line does not begin with the inter-word whitespace that
@@ -6895,10 +6925,10 @@ function drawChartTextBoxes(
     });
     const textHeight = lines.reduce((sum, line) => sum + line.height, 0);
     const contentY = box.verticalAnchor === 'b'
-      ? by + bh - textHeight
+      ? contentBottom - textHeight
       : box.verticalAnchor === 'ctr'
-        ? by + (bh - textHeight) / 2
-        : by;
+        ? contentY0 + (contentH - textHeight) / 2
+        : contentY0;
 
     ctx.save();
     ctx.beginPath();
@@ -6910,10 +6940,10 @@ function drawChartTextBoxes(
     for (const metric of lines) {
       const align = metric.paragraph.align;
       let runX = align === 'ctr'
-        ? bx + (bw - metric.width) / 2
+        ? contentX + (contentW - metric.width) / 2
         : align === 'r'
-          ? bx + bw - metric.width
-          : bx;
+          ? contentRight - metric.width
+          : contentX;
       for (const measured of metric.runs) {
         ctx.font = measured.font;
         ctx.fillStyle = measured.run.color ? `#${measured.run.color}` : '#000000';

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -817,6 +817,12 @@ export interface ChartTextBox {
   verticalAnchor?: 't' | 'ctr' | 'b' | 'just' | 'dist' | string | null;
   /** DrawingML `<a:bodyPr wrap>`; absent uses the application-default square wrap. */
   wrap?: 'none' | 'square' | string | null;
+  /** DrawingML text-body insets in EMU. Omitted wire values use the
+   * ECMA-376 defaults: lIns/rIns=91440, tIns/bIns=45720. */
+  lIns?: number;
+  tIns?: number;
+  rIns?: number;
+  bIns?: number;
 }
 
 /**

--- a/packages/core/src/units.ts
+++ b/packages/core/src/units.ts
@@ -18,3 +18,9 @@ export const EMU_PER_PX = 9525;
 
 /** CSS px per point at 96 DPI: 96 / 72 = 4 / 3. */
 export const PT_TO_PX = 4 / 3;
+
+/** ECMA-376 §21.1.2.1.1 default DrawingML text-body left/right inset. */
+export const DEFAULT_TEXT_INSET_LR_EMU = 91440;
+
+/** ECMA-376 §21.1.2.1.1 default DrawingML text-body top/bottom inset. */
+export const DEFAULT_TEXT_INSET_TB_EMU = 45720;

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -344,6 +344,10 @@ export interface ChartTextBox {
     paragraphs: ChartTextParagraph[];
     verticalAnchor?: 't' | 'ctr' | 'b' | 'just' | 'dist' | string | null;
     wrap?: 'none' | 'square' | string | null;
+    lIns?: number;
+    tIns?: number;
+    rIns?: number;
+    bIns?: number;
 }
 export interface ChartTextParagraph {
     runs: ChartTextRun[];

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -32,6 +32,8 @@
 use roxmltree::Node;
 use serde::{Deserialize, Serialize};
 
+use crate::text::{parse_body_pr, BodyPrDefaults};
+
 /// Resource ceiling for the expanded Chart Colors total set. Typical Office
 /// parts contain 6 base colors × at most 9 variations; this bound prevents an
 /// adversarial colors×variations product from amplifying a bounded XML tree.
@@ -516,6 +518,15 @@ pub struct ChartTextBox {
     /// disables wrapping in the renderer.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wrap: Option<String>,
+    /// `<a:bodyPr lIns>` — left text inset in EMU. The parser resolves the
+    /// ECMA-376 §21.1.2.1.1 default when the attribute is omitted.
+    pub l_ins: i64,
+    /// `<a:bodyPr tIns>` — top text inset in EMU.
+    pub t_ins: i64,
+    /// `<a:bodyPr rIns>` — right text inset in EMU.
+    pub r_ins: i64,
+    /// `<a:bodyPr bIns>` — bottom text inset in EMU.
+    pub b_ins: i64,
 }
 
 /// Pattern-only chart-series fill descriptor matching TS `PatternFill`.
@@ -1294,6 +1305,16 @@ pub fn parse_chart_user_shapes(root: Node, resolver: &dyn ColorResolver) -> Vec<
             let wrap = body_pr
                 .and_then(|body| body.attribute("wrap"))
                 .map(str::to_string);
+            let body_defaults = BodyPrDefaults::spec();
+            let parsed_body = body_pr.map(|body| parse_body_pr(body, &body_defaults));
+            let (l_ins, t_ins, r_ins, b_ins) = parsed_body
+                .map(|body| (body.l_ins, body.t_ins, body.r_ins, body.b_ins))
+                .unwrap_or((
+                    body_defaults.l_ins,
+                    body_defaults.t_ins,
+                    body_defaults.r_ins,
+                    body_defaults.b_ins,
+                ));
             let paragraphs = text_body
                 .children()
                 .filter(|node| node.is_element() && node.tag_name().name() == "p")
@@ -1327,6 +1348,10 @@ pub fn parse_chart_user_shapes(root: Node, resolver: &dyn ColorResolver) -> Vec<
                 paragraphs,
                 vertical_anchor,
                 wrap,
+                l_ins,
+                t_ins,
+                r_ins,
+                b_ins,
             })
         })
         .collect()
@@ -6724,7 +6749,7 @@ mod tests {
                   <cdr:nvSpPr><cdr:cNvPr id="1" name="TitleBox"/><cdr:cNvSpPr txBox="1"/></cdr:nvSpPr>
                   <cdr:spPr/>
                   <cdr:txBody>
-                    <a:bodyPr anchor="b" wrap="square"/><a:lstStyle/>
+                    <a:bodyPr anchor="b" wrap="square" lIns="12700" tIns="25400" rIns="38100" bIns="50800"/><a:lstStyle/>
                     <a:p>
                       <a:pPr algn="ctr"><a:defRPr sz="1200"><a:latin typeface="Lato"/></a:defRPr></a:pPr>
                       <a:r><a:rPr sz="2000" b="1"><a:solidFill><a:srgbClr val="1696d2"/></a:solidFill></a:rPr><a:t>Authored </a:t></a:r>
@@ -6745,6 +6770,10 @@ mod tests {
         assert_eq!(boxes[0].h, 0.11);
         assert_eq!(boxes[0].vertical_anchor.as_deref(), Some("b"));
         assert_eq!(boxes[0].wrap.as_deref(), Some("square"));
+        assert_eq!(boxes[0].l_ins, 12700);
+        assert_eq!(boxes[0].t_ins, 25400);
+        assert_eq!(boxes[0].r_ins, 38100);
+        assert_eq!(boxes[0].b_ins, 50800);
         assert_eq!(boxes[0].paragraphs[0].align.as_deref(), Some("ctr"));
         assert_eq!(boxes[0].paragraphs[0].runs[0].text, "Authored ");
         assert_eq!(boxes[0].paragraphs[0].runs[0].font_size_hpt, Some(2000));
@@ -6759,6 +6788,29 @@ mod tests {
             boxes[0].paragraphs[0].runs[1].font_face.as_deref(),
             Some("Lato")
         );
+    }
+
+    #[test]
+    fn parse_chart_user_shapes_applies_drawingml_text_inset_defaults() {
+        let doc = roxmltree::Document::parse(
+            r#"<c:userShapes xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                 xmlns:cdr="http://schemas.openxmlformats.org/drawingml/2006/chartDrawing"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <cdr:relSizeAnchor>
+                <cdr:from><cdr:x>0</cdr:x><cdr:y>0</cdr:y></cdr:from>
+                <cdr:to><cdr:x>1</cdr:x><cdr:y>0.1</cdr:y></cdr:to>
+                <cdr:sp><cdr:txBody><a:bodyPr/><a:p><a:r><a:t>Title</a:t></a:r></a:p></cdr:txBody></cdr:sp>
+              </cdr:relSizeAnchor>
+            </c:userShapes>"#,
+        )
+        .unwrap();
+
+        let boxes = parse_chart_user_shapes(doc.root_element(), &StubResolver);
+        assert_eq!(boxes.len(), 1);
+        assert_eq!(boxes[0].l_ins, crate::text::DEFAULT_INS_LR_EMU);
+        assert_eq!(boxes[0].r_ins, crate::text::DEFAULT_INS_LR_EMU);
+        assert_eq!(boxes[0].t_ins, crate::text::DEFAULT_INS_TB_EMU);
+        assert_eq!(boxes[0].b_ins, crate::text::DEFAULT_INS_TB_EMU);
     }
 
     #[test]

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -332,6 +332,10 @@ export interface ChartTextBox {
     paragraphs: ChartTextParagraph[];
     verticalAnchor?: 't' | 'ctr' | 'b' | 'just' | 'dist' | string | null;
     wrap?: 'none' | 'square' | string | null;
+    lIns?: number;
+    tIns?: number;
+    rIns?: number;
+    bIns?: number;
 }
 export interface ChartTextParagraph {
     runs: ChartTextRun[];

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -432,6 +432,10 @@ export interface ChartTextBox {
     paragraphs: ChartTextParagraph[];
     verticalAnchor?: 't' | 'ctr' | 'b' | 'just' | 'dist' | string | null;
     wrap?: 'none' | 'square' | string | null;
+    lIns?: number;
+    tIns?: number;
+    rIns?: number;
+    bIns?: number;
 }
 export interface ChartTextParagraph {
     runs: ChartTextRun[];

--- a/packages/xlsx/parser/src/chart.rs
+++ b/packages/xlsx/parser/src/chart.rs
@@ -1028,6 +1028,10 @@ mod hidden_tests {
         assert_eq!(boxes[0].paragraphs[0].runs[0].text, "User-shape title");
         assert_eq!(boxes[0].paragraphs[0].runs[0].font_size_hpt, Some(2000));
         assert_eq!(boxes[0].paragraphs[0].runs[0].bold, Some(true));
+        assert_eq!(boxes[0].l_ins, ooxml_common::text::DEFAULT_INS_LR_EMU);
+        assert_eq!(boxes[0].r_ins, ooxml_common::text::DEFAULT_INS_LR_EMU);
+        assert_eq!(boxes[0].t_ins, ooxml_common::text::DEFAULT_INS_TB_EMU);
+        assert_eq!(boxes[0].b_ins, ooxml_common::text::DEFAULT_INS_TB_EMU);
     }
 }
 


### PR DESCRIPTION
## Summary

- retain DrawingML text-body insets for chart drawing text shapes in the shared OOXML model
- lay chart text out inside its authored inset content box
- use one measured conversion from authored outer plot rectangles to inner data rectangles across bar, line, and area charts
- preserve Office's clear space outside axis tick-label ink

## Specification

- ECMA-376 §21.1.2.1.1 (DrawingML text-body properties)
- ECMA-376 §21.2.2.89 (chart layout target)

## Verification

- core chart renderer tests: 368 passed
- shared and host parser tests passed
- TypeScript build and Rust formatting passed
- full local private XLSX visual regression comparison: 105 sheets checked; unchanged content remained pixel-identical, and differences were limited to affected chart text and outer-axis layouts
