### PR TITLE
fix(xlsx): honor authored chart layout and axis ticks

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -526,6 +526,9 @@ restore"
 
 exports[`renderChart draw-call signature (characterization) > is stable for: clusteredBarH+dataLabels 1`] = `
 "save
+save
+set font=11px sans-serif
+restore
 set font=bold 30.6px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
@@ -536,186 +539,186 @@ set font=11px sans-serif
 set fillStyle=#555
 set strokeStyle=#aaa
 beginPath
-moveTo 152.8,98.95
-lineTo 152.8,335.45
+moveTo 30.775,98.95
+lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
-fillText "0" 152.8,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "0" 30.775,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 178.8923,98.95
-lineTo 178.8923,335.45
+moveTo 66.2538,98.95
+lineTo 66.2538,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "2" 178.8923,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "2" 66.2538,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 204.9846,98.95
-lineTo 204.9846,335.45
+moveTo 101.7327,98.95
+lineTo 101.7327,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "4" 204.9846,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "4" 101.7327,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 231.0769,98.95
-lineTo 231.0769,335.45
+moveTo 137.2115,98.95
+lineTo 137.2115,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "6" 231.0769,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "6" 137.2115,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 257.1692,98.95
-lineTo 257.1692,335.45
+moveTo 172.6904,98.95
+lineTo 172.6904,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "8" 257.1692,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "8" 172.6904,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 283.2615,98.95
-lineTo 283.2615,335.45
+moveTo 208.1692,98.95
+lineTo 208.1692,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "10" 283.2615,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "10" 208.1692,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 309.3538,98.95
-lineTo 309.3538,335.45
+moveTo 243.6481,98.95
+lineTo 243.6481,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "12" 309.3538,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "12" 243.6481,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 335.4462,98.95
-lineTo 335.4462,335.45
+moveTo 279.1269,98.95
+lineTo 279.1269,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "14" 335.4462,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "14" 279.1269,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 361.5385,98.95
-lineTo 361.5385,335.45
+moveTo 314.6058,98.95
+lineTo 314.6058,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "16" 361.5385,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "16" 314.6058,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 387.6308,98.95
-lineTo 387.6308,335.45
+moveTo 350.0846,98.95
+lineTo 350.0846,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "18" 387.6308,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "18" 350.0846,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 413.7231,98.95
-lineTo 413.7231,335.45
+moveTo 385.5635,98.95
+lineTo 385.5635,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "20" 413.7231,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "20" 385.5635,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 439.8154,98.95
-lineTo 439.8154,335.45
+moveTo 421.0423,98.95
+lineTo 421.0423,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "22" 439.8154,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "22" 421.0423,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 465.9077,98.95
-lineTo 465.9077,335.45
+moveTo 456.5212,98.95
+lineTo 456.5212,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "24" 465.9077,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "24" 456.5212,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
 moveTo 492,98.95
 lineTo 492,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "26" 492,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 set fillStyle=#4472C4
-fillRect 152.8,273.5095,130.4615,22.5238 fs=#4472C4
+fillRect 30.775,273.5095,177.3942,22.5238 fs=#4472C4
 set font=bold 11px sans-serif
 set fillStyle=#333
 set textAlign=left
-fillText "10" 285.2615,284.7714 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "10" 210.1692,284.7714 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 152.8,296.0333,104.3692,22.5238 fs=#ED7D31
+fillRect 30.775,296.0333,141.9154,22.5238 fs=#ED7D31
 set fillStyle=#333
-fillText "8" 259.1692,307.2952 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "8" 174.6904,307.2952 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#4472C4
-fillRect 152.8,194.6762,313.1077,22.5238 fs=#4472C4
+fillRect 30.775,194.6762,425.7462,22.5238 fs=#4472C4
 set fillStyle=#333
-fillText "24" 467.9077,205.9381 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "24" 458.5212,205.9381 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 152.8,217.2,195.6923,22.5238 fs=#ED7D31
+fillRect 30.775,217.2,266.0913,22.5238 fs=#ED7D31
 set fillStyle=#333
-fillText "15" 350.4923,228.4619 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "15" 298.8663,228.4619 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#4472C4
-fillRect 152.8,115.8429,221.7846,22.5238 fs=#4472C4
+fillRect 30.775,115.8429,301.5702,22.5238 fs=#4472C4
 set fillStyle=#333
-fillText "17" 376.5846,127.1048 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "17" 334.3452,127.1048 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 152.8,138.3667,287.0154,22.5238 fs=#ED7D31
+fillRect 30.775,138.3667,390.2673,22.5238 fs=#ED7D31
 set fillStyle=#333
-fillText "22" 441.8154,149.6286 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "22" 423.0423,149.6286 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#555
 set font=11px sans-serif
 set textAlign=right
-fillText "Q1" 148.8,296.0333 fs=#555 font=11px sans-serif al=right bl=middle
-fillText "Q2" 148.8,217.2 fs=#555 font=11px sans-serif al=right bl=middle
-fillText "Q3" 148.8,138.3667 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "Q1" 26.775,296.0333 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "Q2" 26.775,217.2 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "Q3" 26.775,138.3667 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 152.8,98.95
-lineTo 152.8,335.45
+moveTo 30.775,98.95
+lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 152.8,339.45
-lineTo 152.8,335.45
+moveTo 30.775,339.45
+lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 178.8923,339.45
-lineTo 178.8923,335.45
+moveTo 66.2538,339.45
+lineTo 66.2538,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 204.9846,339.45
-lineTo 204.9846,335.45
+moveTo 101.7327,339.45
+lineTo 101.7327,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 231.0769,339.45
-lineTo 231.0769,335.45
+moveTo 137.2115,339.45
+lineTo 137.2115,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 257.1692,339.45
-lineTo 257.1692,335.45
+moveTo 172.6904,339.45
+lineTo 172.6904,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 283.2615,339.45
-lineTo 283.2615,335.45
+moveTo 208.1692,339.45
+lineTo 208.1692,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 309.3538,339.45
-lineTo 309.3538,335.45
+moveTo 243.6481,339.45
+lineTo 243.6481,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 335.4462,339.45
-lineTo 335.4462,335.45
+moveTo 279.1269,339.45
+lineTo 279.1269,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 361.5385,339.45
-lineTo 361.5385,335.45
+moveTo 314.6058,339.45
+lineTo 314.6058,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 387.6308,339.45
-lineTo 387.6308,335.45
+moveTo 350.0846,339.45
+lineTo 350.0846,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 413.7231,339.45
-lineTo 413.7231,335.45
+moveTo 385.5635,339.45
+lineTo 385.5635,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 439.8154,339.45
-lineTo 439.8154,335.45
+moveTo 421.0423,339.45
+lineTo 421.0423,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 465.9077,339.45
-lineTo 465.9077,335.45
+moveTo 456.5212,339.45
+lineTo 456.5212,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
 moveTo 492,339.45
 lineTo 492,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 148.8,98.95
-lineTo 152.8,98.95
+moveTo 26.775,98.95
+lineTo 30.775,98.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 148.8,177.7833
-lineTo 152.8,177.7833
+moveTo 26.775,177.7833
+lineTo 30.775,177.7833
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 148.8,256.6167
-lineTo 152.8,256.6167
+moveTo 26.775,256.6167
+lineTo 30.775,256.6167
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 148.8,335.45
-lineTo 152.8,335.45
+moveTo 26.775,335.45
+lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
 set font=12px sans-serif
 set fillStyle=#4472C4

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -396,6 +396,60 @@ describe('bar chart authored layout and fills', () => {
     expect(right).toBeDefined();
     expect(left?.x).toBeLessThan(right?.x ?? 0);
   });
+
+  it('measures the automatic horizontal category-label gutter instead of eliding long labels', () => {
+    const rec = recordingCtx();
+    const category = 'San Francisco County, California';
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBarH',
+      categories: [category],
+      catAxisFontSizeHpt: 1200,
+      catAxisFontFace: 'Lato',
+      series: [series({ values: [1] })],
+    }), RECT, 1);
+
+    expect(rec.texts.some((text) => text.text === category)).toBe(true);
+    expect(rec.texts.some((text) => text.text.endsWith('…'))).toBe(false);
+  });
+
+  it('does not reserve a horizontal category-label gutter when tick labels are hidden', () => {
+    const render = (tickLabelPos: ChartModel['catAxisTickLabelPos']) => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType: 'clusteredBarH',
+        categories: ['A category label long enough to affect the gutter'],
+        catAxisTickLabelPos: tickLabelPos,
+        plotAreaBg: 'ABCDEF',
+        series: [series({ values: [1] })],
+      }), RECT, 1);
+      return rec.rects.find(rect => rect.fs === '#ABCDEF');
+    };
+
+    const visible = render('nextTo');
+    const hidden = render('none');
+    expect(hidden?.x).toBeLessThan(visible?.x ?? 0);
+    expect(hidden?.w).toBeGreaterThan(visible?.w ?? Number.POSITIVE_INFINITY);
+  });
+
+  it('measures an unauthored horizontal category font at the painted slot size', () => {
+    const rect: ChartRect = { x: 0, y: 0, w: 640, h: 720 };
+    const render = (fontSizeHpt: number | null) => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType: 'clusteredBarH',
+        categories: ['A category label whose width is sensitive to the font size'],
+        catAxisFontSizeHpt: fontSizeHpt,
+        plotAreaBg: 'ABCDEF',
+        series: [series({ values: [1] })],
+      }), rect, 1);
+      return rec.rects.find(item => item.fs === '#ABCDEF');
+    };
+
+    const automatic = render(null);
+    const authoredElevenPx = render(1100);
+    expect(automatic?.x).toBeCloseTo(authoredElevenPx?.x ?? 0, 6);
+    expect(automatic?.w).toBeCloseTo(authoredElevenPx?.w ?? 0, 6);
+  });
 });
 
 describe('CH1 — negative bar/column values extend from the zero line', () => {
@@ -1587,6 +1641,35 @@ const SECONDARY_AXIS = {
   majorTickMark: 'out',
   lineHidden: false,
 };
+
+describe('axis noFill tick visibility', () => {
+  it('suppresses value-axis tick lines with a hidden axis rule while retaining labels', () => {
+    const render = (lineHidden: boolean) => {
+      const rec = pathRecordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType: 'line',
+        categories: ['2008', '2009', '2010'],
+        series: [series({ values: [0.18, 0.19, 0.17] })],
+        valAxisLineHidden: lineHidden,
+        valAxisMajorTickMark: 'out',
+        catAxisMajorTickMark: 'none',
+        valAxisFormatCode: '0%',
+      }), RECT, 1);
+      return rec;
+    };
+    const visible = render(false);
+    const hidden = render(true);
+    const valueTicks = (segments: Array<Array<{ x: number; y: number }>>) => segments.filter((segment) =>
+      segment.length === 2
+      && segment[0].y === segment[1].y
+      && Math.abs(segment[1].x - segment[0].x) <= 8,
+    );
+
+    expect(valueTicks(visible.segments).length).toBeGreaterThan(0);
+    expect(valueTicks(hidden.segments)).toHaveLength(0);
+    expect(hidden.texts.some((text) => text.text.endsWith('%'))).toBe(true);
+  });
+});
 
 describe('CH7 — line/area series honor a secondary value axis (§21.2.2.*)', () => {
   // The primary series ASCENDS [10,20,30]; the secondary series DESCENDS

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -595,8 +595,12 @@ function drawAxisTick(
   // left). A secondary value axis sits on the RIGHT, where "outside" points
   // right — pass `opposite` to flip the out/in direction.
   opposite = false,
+  lineHidden = false,
 ): void {
-  if (mode === 'none' || !mode) return;
+  // Axis shape properties style both the rule and its tick marks. An authored
+  // `<a:ln><a:noFill/>` therefore suppresses the ticks too, while labels and
+  // gridlines remain independently visible.
+  if (lineHidden || mode === 'none' || !mode) return;
   // Tick length scales mildly with the axis line weight so a thick
   // ruler-style axis (e.g. Vertex42 Gantt 5 pt) produces ticks that
   // are visible without being huge.
@@ -1117,7 +1121,7 @@ function drawSecondaryValueAxis(
       const sval = secScale.min + si * secScale.step;
       const gy = toYSecondary(sval);
       // Same tick geometry as the left axis, mirrored to the right edge.
-      drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true);
+      drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true, sec.lineHidden);
       ctx.fillText(formatChartValWithCode(sval, sec.formatCode ?? null, date1904), axX + 14, gy);
     }
   }
@@ -1354,11 +1358,39 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     ? (chart.valAxisHidden ? h * 0.02 : catAxisLabelBandH(valAxLabelFontPx)) + catTitleH + legBottomH
     : catAxisLabelBandH(catAxFontPx) + catTitleH + legBottomH;
   const phEst = h - padT - padB;
+  let horizontalCategoryLabelBandW = 0;
+  if (isH && !chart.catAxisHidden && catLabelsVisible(chart)) {
+    // The paint path derives an unauthored tick font from the category slot,
+    // not the overall chart height. Use the same resolver here so tall charts
+    // do not reserve a gutter for a much larger font than they actually draw.
+    const measuredHorizontalCatTickFontPx = chart.catAxisFontSizeHpt != null
+      ? catAxFontPx
+      : Math.max(8, Math.min(11, (phEst / n) * 0.5));
+    ctx.save();
+    ctx.font = `${measuredHorizontalCatTickFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
+    for (const category of cats) {
+      horizontalCategoryLabelBandW = Math.max(
+        horizontalCategoryLabelBandW,
+        ctx.measureText(formatCategoryLabel(category, chart.catAxisFormatCode, chart.date1904)).width,
+      );
+    }
+    ctx.restore();
+    horizontalCategoryLabelBandW += (chart.catAxisFontSizeHpt != null
+      ? valueTickLabelGapPx(measuredHorizontalCatTickFontPx)
+      : 4) + AXIS_OUTER_TEXT_MARGIN_PT * ptToPx;
+  }
+  // Auto layout keeps at least half of the frame available to the data plot;
+  // labels beyond that measured budget are elided at paint time. Authored outer
+  // layouts still use the full measured band in `manualOuterInsets` below.
+  const automaticHorizontalCategoryLabelBandW = Math.min(
+    horizontalCategoryLabelBandW,
+    Math.max(0, w / 2 - valTitleW - legLeftW),
+  );
   // Horizontal bars run the value axis along the (wide) bottom, so its length is
-  // the plot WIDTH. Estimate it from the fixed isH side pads (those don't depend
-  // on the value-label measurement).
+  // the plot WIDTH. Estimate it from the same measured category-label band that
+  // the final frame uses so automatic tick density agrees with painted geometry.
   const pwEst = isH
-    ? w - ((chart.catAxisHidden ? w * 0.03 : w * 0.22) + valTitleW + legLeftW) - (legRightW + w * 0.03)
+    ? w - ((chart.catAxisHidden ? w * 0.03 : automaticHorizontalCategoryLabelBandW) + valTitleW + legLeftW) - (legRightW + w * 0.03)
     : 0;
   // A deleted value axis has no ticks whose density needs adapting to the
   // available screen length. Office falls back to its default automatic scale
@@ -1468,24 +1500,6 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     valLabelTextW = wmax;
     valLabelBandW = valLabelTextW + 16; // ~12px tick+gap to the axis + ~4px to the title
   }
-  let horizontalCategoryLabelBandW = 0;
-  if (
-    isH
-    && !chart.catAxisHidden
-    && chart.plotAreaManualLayout != null
-    && chart.plotAreaManualLayout.layoutTarget !== 'inner'
-  ) {
-    ctx.font = `${catAxFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
-    for (const category of cats) {
-      horizontalCategoryLabelBandW = Math.max(
-        horizontalCategoryLabelBandW,
-        ctx.measureText(formatCategoryLabel(category, chart.catAxisFormatCode, chart.date1904)).width,
-      );
-    }
-    horizontalCategoryLabelBandW += chart.catAxisFontSizeHpt != null
-      ? valueTickLabelGapPx(catAxFontPx)
-      : 4;
-  }
   // Secondary value-axis label band (right edge). Measure with the SAME font
   // and number format the axis is drawn with (`secFontPx` / `sec.formatCode`),
   // otherwise a `%`/thousands format or an explicit font size makes the
@@ -1514,7 +1528,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     // Horizontal bars: keep the wider left band for the category labels
     // (`c:catAx/c:delete val="1"` → no category labels, so tighten).
     l: isH
-      ? (chart.catAxisHidden ? w * 0.03 : w * 0.22) + valTitleW + legLeftW
+      ? (chart.catAxisHidden ? w * 0.03 : automaticHorizontalCategoryLabelBandW) + valTitleW + legLeftW
       : legLeftW + valTitleW + valLabelBandW,
   };
 
@@ -1760,9 +1774,9 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       for (let si = 0; si <= steps; si++) {
         const val = axMin + si * step;
         if (!isH) {
-          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, valY(val), valLineColor, valLineW);
+          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, valY(val), valLineColor, valLineW, false, chart.valAxisLineHidden);
         } else {
-          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'cat', py0 + ph, valX(val), valLineColor, valLineW);
+          drawAxisTick(ctx, chart.valAxisMajorTickMark, 'cat', py0 + ph, valX(val), valLineColor, valLineW, false, chart.valAxisLineHidden);
         }
       }
     }
@@ -1775,9 +1789,9 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       for (let ci = 0; ci <= last; ci++) {
         const frac = onBoundary ? ci / n : (n === 1 ? 0.5 : ci / (n - 1));
         if (!isH) {
-          drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, px0 + frac * pw, catLineColor, catLineW);
+          drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, px0 + frac * pw, catLineColor, catLineW, false, chart.catAxisLineHidden);
         } else {
-          drawAxisTick(ctx, chart.catAxisMajorTickMark, 'val', px0, py0 + frac * ph, catLineColor, catLineW);
+          drawAxisTick(ctx, chart.catAxisMajorTickMark, 'val', px0, py0 + frac * ph, catLineColor, catLineW, false, chart.catAxisLineHidden);
         }
       }
     }
@@ -2109,7 +2123,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
         const sval = sMin + si * sStep;
         const gy = toYSecondary(sval);
         // Same tick geometry as the left axis, mirrored to the right edge.
-        drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true);
+        drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true, sec.lineHidden);
         ctx.fillText(formatChartValWithCode(sval, sec.formatCode ?? null, chart.date1904), axX + 14, gy);
       }
     }
@@ -2378,7 +2392,7 @@ function renderLineChart(
     for (const v of plan.majorLines) {
       const gy = toY(v);
       if (drawMajorGrid) strokeValueGridlineH(ctx, px0, pw, gy, v === 0, grid);
-      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, primaryValTickColor, primaryValTickWidth);
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, primaryValTickColor, primaryValTickWidth, false, chart.valAxisLineHidden);
       if (drawLabels) {
         ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
         ctx.textAlign = 'right';
@@ -2405,9 +2419,8 @@ function renderLineChart(
   }
 
   // Axis lines: bottom (category) + left (value). Both default to visible
-  // unless hidden explicitly. `<c:spPr><a:ln><a:noFill>` (line-only hide)
-  // suppresses the rule while keeping labels and tick marks — sample-1
-  // "Carbon & Growth" uses this on the value axis.
+  // unless hidden explicitly. Office treats `<c:spPr><a:ln><a:noFill>` as
+  // suppressing the rule and tick marks while retaining labels/gridlines.
   if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
     ctx.strokeStyle = primaryCatLine.color; ctx.lineWidth = primaryCatLine.width;
     ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
@@ -2544,7 +2557,7 @@ function renderLineChart(
     // indices to author intervals such as every second year.
     const tickInterval = Math.max(1, Math.floor(chart.catAxisTickMarkSkip ?? 1));
     for (let ci = 0; ci < n; ci += tickInterval) {
-      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, toX(ci), primaryCatTickColor, primaryCatTickWidth);
+      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, toX(ci), primaryCatTickColor, primaryCatTickWidth, false, chart.catAxisLineHidden);
     }
     const showLabels = catLabelsVisible(chart);
     const labelInterval = Math.max(1, Math.floor(chart.catAxisTickLabelSkip ?? 1));
@@ -2702,7 +2715,7 @@ function renderStockChart(
     for (const v of plan.majorLines) {
       const gy = toY(v);
       if (drawMajorGrid) strokeValueGridlineH(ctx, px0, pw, gy, v === 0, grid);
-      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy);
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, undefined, undefined, false, chart.valAxisLineHidden);
       if (drawLabels) {
         ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
         ctx.textAlign = 'right';
@@ -2800,7 +2813,7 @@ function renderStockChart(
     const rotRad = catLabelRotationRad(chart);
     for (let ci = 0; ci < n; ci += labelInterval) {
       const tx = toX(ci);
-      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, tx);
+      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, tx, undefined, undefined, false, chart.catAxisLineHidden);
       if (!showLabels) continue;
       ctx.fillStyle = catLabelColor;
       const label = formatCategoryLabel((cats[ci] ?? '').toString(), chart.catAxisFormatCode, chart.date1904);
@@ -3295,7 +3308,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     const steps = Math.round(axMax / step);
     for (let si = 0; si <= steps; si++) {
       const v = si * step; const gy = toY(v);
-      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, valLineColor, valLineW);
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, valLineColor, valLineW, false, chart.valAxisLineHidden);
       ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
       ctx.textAlign = 'right';
       const gap = chart.valAxisFontSizeHpt != null
@@ -3304,10 +3317,10 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       ctx.fillText(formatPrimaryValueAxisTick(chart, v, pct), px0 - gap, gy);
     }
   }
-  // Category-axis baseline + value-axis rule. `<c:*Ax><c:spPr><a:ln><a:noFill>`
-  // suppresses just the rule (labels/ticks stay) → `*AxisLineHidden`. The value
-  // rule is drawn only when the file gives it a colour, matching the bar/line
-  // renderers (Office's default value axis is line-less, gridlines stand in).
+  // Category-axis baseline + value-axis rule. Office treats
+  // `<c:*Ax><c:spPr><a:ln><a:noFill>` as suppressing the rule and tick marks
+  // while labels/gridlines remain. The value rule is drawn only when the file
+  // gives it a colour, matching the bar/line renderers.
   if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
     ctx.strokeStyle = catLineColor; ctx.lineWidth = catLineW;
     ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
@@ -3322,11 +3335,11 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     const tickSkip = Math.max(1, Math.floor(chart.catAxisTickMarkSkip ?? 1));
     if (between) {
       for (let ci = 0; ci <= n; ci += tickSkip) {
-        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, px0 + (ci / n) * pw, catLineColor, catLineW);
+        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, px0 + (ci / n) * pw, catLineColor, catLineW, false, chart.catAxisLineHidden);
       }
     } else {
       for (let ci = 0; ci < n; ci += tickSkip) {
-        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, toX(ci), catLineColor, catLineW);
+        drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', py0 + ph, toX(ci), catLineColor, catLineW, false, chart.catAxisLineHidden);
       }
     }
   }
@@ -4697,7 +4710,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       // so only the width formula is shared. `axisLineWidthPx`'s 1 px fallback is
       // equivalent to undefined here (drawAxisTick treats both as a hairline).
       const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
-      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', yAxisX, gy, yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx));
+      drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', yAxisX, gy, yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx), false, chart.valAxisLineHidden);
     }
   }
 
@@ -4719,10 +4732,10 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
 
   // X-axis line (the timeline ruler in Gantt-style scatter charts depends
   // on this line's stroke). Tick labels are skipped when the category axis
-  // is hidden via `<c:delete val="1"/>`; the rule itself is also gated on
-  // `<c:catAx><c:spPr><a:ln><a:noFill>` (line-only hide). Color and
-  // weight come from `<c:catAx><c:spPr><a:ln>` when present; default
-  // otherwise.
+  // is hidden via `<c:delete val="1"/>`. Office treats
+  // `<c:catAx><c:spPr><a:ln><a:noFill>` as suppressing the rule and tick
+  // marks. Color and weight come from
+  // `<c:catAx><c:spPr><a:ln>` when present; default otherwise.
   if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
     ctx.save();
     ctx.strokeStyle = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : '#888';
@@ -4768,7 +4781,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
         ctx.fillText(formatChartValWithCode(v, chart.catAxisFormatCode, chart.date1904), gx, labelY);
       }
       const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
-      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx));
+      drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx), false, chart.catAxisLineHidden);
     }
   }
 
@@ -5638,13 +5651,15 @@ function renderWaterfallChart(
         gy,
         valAxisLine.color,
         valAxisLine.width,
+        false,
+        chart.valAxisLineHidden,
       );
     }
   }
 
   // L-frame: vertical (value-axis) rule + horizontal (category-axis) baseline.
-  // Each segment is independently gated on its axis's `<c:delete>` *and*
-  // `<c:spPr><a:ln><a:noFill>` (line-only hide).
+  // Each segment is independently gated on its axis's `<c:delete>` and on
+  // Office's rule/tick suppression for `<c:spPr><a:ln><a:noFill>`.
   const drawValLine = !chart.valAxisHidden && !chart.valAxisLineHidden;
   const drawCatLine = !chart.catAxisHidden && !chart.catAxisLineHidden;
   if (drawValLine) {
@@ -5998,6 +6013,8 @@ function renderBoxWhiskerChart(
         gy,
         valAxisLine.color,
         valAxisLine.width,
+        false,
+        chart.valAxisLineHidden,
       );
     }
     if (!chart.valAxisLineHidden) {

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -378,12 +378,13 @@ export interface ChartModel {
   catAxisHidden: boolean;
   /** `<c:valAx><c:delete val="1"/>`. */
   valAxisHidden: boolean;
-  /** `<c:catAx><c:spPr><a:ln><a:noFill>` — hide just the axis LINE; labels
-   *  and tick marks still render. Distinct from `catAxisHidden` (which
-   *  removes everything via `<c:delete val="1"/>`). */
+  /** `<c:catAx><c:spPr><a:ln><a:noFill>` — Office-compatible suppression of
+   *  the axis rule and tick marks. Labels and gridlines remain independent.
+   *  Distinct from `catAxisHidden` (which removes everything via
+   *  `<c:delete val="1"/>`). */
   catAxisLineHidden: boolean;
-  /** `<c:valAx><c:spPr><a:ln><a:noFill>` — hide just the axis LINE; labels
-   *  and tick marks still render. */
+  /** `<c:valAx><c:spPr><a:ln><a:noFill>` — Office-compatible suppression of
+   *  the axis rule and tick marks; labels and gridlines remain independent. */
   valAxisLineHidden: boolean;
   /** Hex without '#'. From `<c:plotArea><c:spPr><a:solidFill>`. */
   plotAreaBg: string | null;
@@ -913,7 +914,8 @@ export interface SecondaryValueAxis {
   lineColor?: string | null;
   /** `<c:spPr><a:ln w>` axis-line width in EMU. */
   lineWidthEmu?: number | null;
-  /** `<c:spPr><a:ln><a:noFill>` — hide just the axis rule. */
+  /** `<c:spPr><a:ln><a:noFill>` — Office-compatible suppression of the
+   *  secondary axis rule and tick marks; labels and gridlines remain. */
   lineHidden: boolean;
   /** `<c:majorTickMark>` — "cross" (default) | "out" | "in" | "none". */
   majorTickMark: string;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -2249,8 +2249,9 @@ pub fn extract_axis_tick_label_color(
 ///
 ///  - `color`: resolved hex (no `#`) when the line carries a `<a:solidFill>`.
 ///  - `width_emu`: the `<a:ln w>` width in EMU when present.
-///  - `no_fill`: true when the line is explicitly `<a:noFill>` — the axis still
-///    shows its labels/ticks but the rule itself is suppressed.
+///  - `no_fill`: true when the line is explicitly `<a:noFill>`. The shared
+///    model records this separately from axis deletion; Office suppresses the
+///    axis rule and its tick marks while retaining labels and gridlines.
 ///
 /// When the axis has no `<c:spPr><a:ln>` at all the tuple is
 /// `(None, None, false)` and the caller falls back to its default rule.
@@ -7949,6 +7950,18 @@ mod tests {
         assert_eq!(no_fill_model.val_axis_major_gridlines, Some(false));
         assert_eq!(no_fill_model.val_axis_gridline_color, None);
         assert_eq!(no_fill_model.val_axis_gridline_width_emu, None);
+
+        let no_fill_axis_xml = xml.replace(
+            "<c:valAx><c:delete val=\"0\"/><c:majorGridlines/><c:majorTickMark val=\"out\"/></c:valAx>",
+            "<c:valAx><c:delete val=\"0\"/><c:majorGridlines/><c:majorTickMark val=\"out\"/><c:spPr><a:ln><a:noFill/></a:ln></c:spPr></c:valAx>",
+        );
+        let no_fill_axis_doc = chart_space_of(&no_fill_axis_xml);
+        let no_fill_axis_model =
+            parse_chart_part(no_fill_axis_doc.root_element(), &FixtureResolver)
+                .expect("no-fill axis chart parses");
+        assert!(no_fill_axis_model.val_axis_line_hidden);
+        assert_eq!(no_fill_axis_model.val_axis_major_tick_mark, "out");
+        assert!(!no_fill_axis_model.val_axis_hidden);
     }
 
     /// (b) Combo chart: a bar series on the primary value axis plus a line

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -1298,6 +1298,11 @@ export interface Worksheet {
     name: string;
     rows: Row[];
     colWidths: Record<number, number>;
+    colWidthRanges?: Array<{
+        min: number;
+        max: number;
+        width: number;
+    }>;
     rowHeights: Record<number, number>;
     colOutlineLevels?: Record<number, number>;
     colCollapsed?: Record<number, boolean>;

--- a/packages/xlsx/parser/src/lib.rs
+++ b/packages/xlsx/parser/src/lib.rs
@@ -1453,6 +1453,9 @@ fn parse_projected_worksheet(
 
     let mut rows = streamed.rows;
     let mut col_widths: BTreeMap<u32, f64> = BTreeMap::new();
+    // All authored width declarations in XML order. The boolean records
+    // whether the declaration also needs the compact public wire form.
+    let mut authored_col_widths: Vec<(crate::types::ColumnWidthRange, bool)> = Vec::new();
     let mut row_heights = streamed.row_heights;
     // Outline (grouping) metadata — ECMA-376 §18.3.1.13 (col) / §18.3.1.73
     // (row) / §18.3.1.61 (outlinePr). Only non-default entries are recorded so
@@ -1635,6 +1638,10 @@ fn parse_projected_worksheet(
             "col" if is_x_ns(node.tag_name().namespace()) => {
                 let custom = attr_bool(&node, "customWidth").unwrap_or(false);
                 let hidden = attr_bool(&node, "hidden").unwrap_or(false);
+                let authored_width = node
+                    .attribute("width")
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .filter(|value| value.is_finite() && *value >= 0.0);
                 // §18.3.1.13 outline metadata: `outlineLevel` (0-7) and the
                 // summary-column `collapsed` flag. Recorded independently of the
                 // width so a grouped column at the default width is still
@@ -1645,31 +1652,48 @@ fn parse_projected_worksheet(
                     .unwrap_or(0)
                     .min(7);
                 let collapsed = attr_bool(&node, "collapsed").unwrap_or(false);
-                // Record widths for custom-widthed OR hidden columns, and also
-                // for columns that carry outline info (level > 0 or collapsed) —
-                // those must reach the viewer even at the default width.
+                // ECMA-376 §18.3.1.13: `customWidth` records how the width was
+                // established; it does not gate the authored `width` itself.
+                // Also retain outline-only columns so their gutter metadata
+                // reaches the viewer at the default width.
                 let has_outline = outline_level > 0 || collapsed;
-                if !custom && !hidden && !has_outline {
+                if authored_width.is_none() && !custom && !hidden && !has_outline {
                     continue;
                 }
                 let min: u32 = node
                     .attribute("min")
                     .and_then(|s| s.parse().ok())
-                    .unwrap_or(1);
-                let max: u32 = node
+                    .unwrap_or(1)
+                    .clamp(1, 16_384);
+                let full_max: u32 = node
                     .attribute("max")
                     .and_then(|s| s.parse().ok())
-                    .unwrap_or(1);
-                // Cap range to avoid storing 16K entries for max=16384 ranges
-                let max = max.min(min + 255);
+                    .unwrap_or(min)
+                    .clamp(1, 16_384);
+                if full_max < min {
+                    continue;
+                }
                 let width: f64 = if hidden {
                     0.0
                 } else {
-                    node.attribute("width")
-                        .and_then(|s| s.parse::<f64>().ok())
-                        .filter(|value| value.is_finite() && *value >= 0.0)
-                        .unwrap_or(default_col_width)
+                    authored_width.unwrap_or(default_col_width)
                 };
+                let point_max = full_max.min(min.saturating_add(255));
+                let point_map_covers_width = (custom || hidden) && point_max == full_max;
+                if hidden || authored_width.is_some() || custom {
+                    authored_col_widths.push((
+                        crate::types::ColumnWidthRange {
+                            min,
+                            max: full_max,
+                            width,
+                        },
+                        !point_map_covers_width,
+                    ));
+                }
+                // Keep the legacy point map for existing consumers while
+                // bounding its wire size. Grid geometry applies the compact
+                // full range first, then lets these point entries override it.
+                let max = point_max;
                 for c in min..=max {
                     // Only store a width entry when the column actually has a
                     // custom / hidden width; a default-width grouped column keeps
@@ -2060,6 +2084,46 @@ fn parse_projected_worksheet(
         }
     }
 
+    // Resolve the effective width of every sheet column once, from the last
+    // declaration backwards. The successor DSU skips columns already claimed
+    // by a later declaration, bounding work by declarations + 16,384 columns
+    // rather than declarations × range length.
+    let mut resolved_widths: Vec<Option<f64>> = vec![None; 16_385];
+    let mut successor: Vec<usize> = (0..=16_385).collect();
+    fn find_unassigned(successor: &mut [usize], start: usize) -> usize {
+        let mut root = start;
+        while successor[root] != root {
+            root = successor[root];
+        }
+        let mut index = start;
+        while successor[index] != index {
+            let next = successor[index];
+            successor[index] = root;
+            index = next;
+        }
+        root
+    }
+    for (range, _) in authored_col_widths.iter().rev() {
+        let mut index = find_unassigned(&mut successor, range.min as usize);
+        while index <= range.max as usize {
+            resolved_widths[index] = Some(range.width);
+            successor[index] = find_unassigned(&mut successor, index + 1);
+            index = successor[index];
+        }
+    }
+    // Keep the legacy point map for existing consumers, but normalize its
+    // entries to the final XML document-order result. Live edits still mutate
+    // these points and therefore override compact ranges in grid geometry.
+    for (index, width) in &mut col_widths {
+        if let Some(resolved) = resolved_widths[*index as usize] {
+            *width = resolved;
+        }
+    }
+    let col_width_ranges = authored_col_widths
+        .into_iter()
+        .filter_map(|(range, compact)| compact.then_some(range))
+        .collect();
+
     conditional_formats.extend(x14_icon_formats);
 
     if rows_hidden_by_default {
@@ -2082,6 +2146,7 @@ fn parse_projected_worksheet(
         name: name.to_string(),
         rows,
         col_widths,
+        col_width_ranges,
         row_heights,
         col_outline_levels,
         col_collapsed,
@@ -3869,6 +3934,87 @@ mod sheet_view_tests {
         );
         let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
         assert_eq!(ws.col_widths.get(&2).copied(), Some(10.0));
+    }
+
+    /// ECMA-376 §18.3.1.13 defines `customWidth` as metadata indicating that
+    /// the width differs from the default; it is not a condition for applying
+    /// an authored `width`. Excel can omit the flag on style-wide ranges.
+    #[test]
+    fn col_width_without_custom_width_is_preserved_as_a_compact_range() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><cols><col min="2" max="16384" width="10.83203125" style="44"/></cols><sheetData/></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+
+        assert!(
+            ws.col_widths.is_empty(),
+            "wide ranges must not expand into 16K JSON entries"
+        );
+        assert_eq!(
+            ws.col_width_ranges,
+            vec![crate::types::ColumnWidthRange {
+                min: 2,
+                max: 16_384,
+                width: 10.83203125,
+            }],
+        );
+    }
+
+    #[test]
+    fn later_compact_col_width_range_overrides_legacy_point_projection() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><cols>
+                <col min="2" max="2" width="20" customWidth="1"/>
+                <col min="2" max="16384" width="10"/>
+            </cols><sheetData/></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+
+        assert_eq!(ws.col_widths.get(&2).copied(), Some(10.0));
+        assert_eq!(
+            ws.col_width_ranges,
+            vec![crate::types::ColumnWidthRange {
+                min: 2,
+                max: 16_384,
+                width: 10.0,
+            }],
+        );
+    }
+
+    #[test]
+    fn later_legacy_point_col_width_overrides_compact_range() {
+        let xml = format!(
+            r#"<worksheet xmlns="{NS}"><cols>
+                <col min="2" max="16384" width="10"/>
+                <col min="2" max="2" width="20" customWidth="1"/>
+            </cols><sheetData/></worksheet>"#
+        );
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+
+        assert_eq!(ws.col_widths.get(&2).copied(), Some(20.0));
+        assert_eq!(ws.col_width_ranges[0].width, 10.0);
+    }
+
+    #[test]
+    fn many_overlapping_full_col_width_ranges_are_normalized_in_bounded_work() {
+        let mut cols = String::new();
+        for chunk in 0..64 {
+            let min = chunk * 256 + 1;
+            let max = min + 255;
+            cols.push_str(&format!(
+                r#"<col min="{min}" max="{max}" width="11" customWidth="1"/>"#
+            ));
+        }
+        for index in 0..50_000 {
+            let width = 9 + (index % 2);
+            cols.push_str(&format!(r#"<col min="1" max="16384" width="{width}"/>"#));
+        }
+        let xml = format!(r#"<worksheet xmlns="{NS}"><cols>{cols}</cols><sheetData/></worksheet>"#);
+        let (ws, _) = parse_worksheet(&xml, &[], &[], "Sheet1").expect("worksheet parses");
+
+        assert_eq!(ws.col_widths.len(), 16_384);
+        assert!(ws.col_widths.values().all(|width| *width == 10.0));
+        assert_eq!(ws.col_width_ranges.len(), 50_000);
     }
 
     /// ECMA-376 §18.3.1.81 `zeroHeight` hides rows by default, including rows

--- a/packages/xlsx/parser/src/types.rs
+++ b/packages/xlsx/parser/src/types.rs
@@ -71,6 +71,17 @@ pub struct MergeCell {
     pub right: u32,
 }
 
+/// Compact representation of a `<col min max width>` declaration. SpreadsheetML
+/// permits one declaration to cover all 16,384 columns, so expanding the range
+/// into `col_widths` would unnecessarily inflate the parser wire payload.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnWidthRange {
+    pub min: u32,
+    pub max: u32,
+    pub width: f64,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Worksheet {
@@ -80,6 +91,8 @@ pub struct Worksheet {
     /// rows in ascending index order), making the parser output byte-stable for
     /// identical input.
     pub col_widths: BTreeMap<u32, f64>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub col_width_ranges: Vec<ColumnWidthRange>,
     pub row_heights: BTreeMap<u32, f64>,
     /// Per-column outline (grouping) depth, 0-7 (ECMA-376 §18.3.1.13
     /// `<col outlineLevel>`). Only columns whose level is non-zero are recorded,
@@ -212,6 +225,7 @@ impl Worksheet {
             name: name.to_string(),
             rows: Vec::new(),
             col_widths: BTreeMap::new(),
+            col_width_ranges: Vec::new(),
             row_heights: BTreeMap::new(),
             col_outline_levels: BTreeMap::new(),
             col_collapsed: BTreeMap::new(),

--- a/packages/xlsx/src/internal/grid-geometry.test.ts
+++ b/packages/xlsx/src/internal/grid-geometry.test.ts
@@ -97,6 +97,35 @@ describe('GridGeometry', () => {
     expect(GridGeometry.forWorksheet(ws, 8)).toBe(wide);
   });
 
+  it('applies compact authored column-width ranges that omit customWidth', () => {
+    const ws = worksheet();
+    ws.colWidths = { 1: 30.1640625 };
+    ws.colWidthRanges = [{ min: 2, max: 16_384, width: 10.83203125 }];
+    ws.defaultColWidth = 8.43;
+    const geometry = GridGeometry.forWorksheet(ws, 8);
+
+    expect(geometry.col.sizeOf(1)).toBe(241);
+    expect(geometry.col.sizeOf(2)).toBe(87);
+    expect(geometry.col.sizeOf(16_384)).toBe(87);
+    const anchorWidth = geometry.col.offsetOf(10) - geometry.col.offsetOf(1)
+      + (539_749 - 298_449) / 9_525;
+    expect(anchorWidth).toBeCloseTo(962.33, 2);
+  });
+
+  it('resolves many overlapping full-sheet ranges without expanding each declaration', () => {
+    const ws = worksheet();
+    ws.colWidths = {};
+    ws.colWidthRanges = Array.from({ length: 50_000 }, (_, index) => ({
+      min: 1,
+      max: 16_384,
+      width: 9 + (index % 2),
+    }));
+
+    const geometry = GridGeometry.forWorksheet(ws, 8);
+    expect(geometry.col.sizeOf(1)).toBe(colWidthToPx(10, 8));
+    expect(geometry.col.sizeOf(16_384)).toBe(colWidthToPx(10, 8));
+  });
+
   it('skips a leading run of zero-sized rows and columns at offset zero', () => {
     const ws = worksheet();
     ws.rowHeights = { 1: 0, 2: 0 };

--- a/packages/xlsx/src/internal/grid-geometry.ts
+++ b/packages/xlsx/src/internal/grid-geometry.ts
@@ -84,11 +84,60 @@ export class GridGeometry {
     this.maximumDigitWidth = mdw;
     this.freezeRows = Math.min(MAX_WORKSHEET_ROW, Math.max(0, worksheet.freezeRows ?? 0));
     this.freezeCols = Math.min(MAX_WORKSHEET_COL, Math.max(0, worksheet.freezeCols ?? 0));
+    const defaultColPx = colWidthToPx(worksheet.defaultColWidth, mdw);
+    const resolvedColWidths = new Float64Array(MAX_WORKSHEET_COL + 1);
+    resolvedColWidths.fill(Number.NaN);
+    // Resolve declarations from last to first. The disjoint-set successor
+    // skips columns already assigned by a later declaration, so every sheet
+    // column is written at most once even when an adversarial file contains
+    // many overlapping full-width ranges.
+    const successor = new Int32Array(MAX_WORKSHEET_COL + 2);
+    for (let index = 1; index < successor.length; index++) successor[index] = index;
+    const findUnassigned = (start: number): number => {
+      let root = start;
+      while (successor[root] !== root) root = successor[root];
+      let index = start;
+      while (successor[index] !== index) {
+        const next = successor[index];
+        successor[index] = root;
+        index = next;
+      }
+      return root;
+    };
+    const authoredRanges = worksheet.colWidthRanges ?? [];
+    for (let rangeIndex = authoredRanges.length - 1; rangeIndex >= 0; rangeIndex--) {
+      const range = authoredRanges[rangeIndex];
+      const min = Math.max(1, Math.min(MAX_WORKSHEET_COL, Math.trunc(range.min)));
+      const max = Math.max(1, Math.min(MAX_WORKSHEET_COL, Math.trunc(range.max)));
+      if (max < min || !Number.isFinite(range.width) || range.width < 0) continue;
+      let index = findUnassigned(min);
+      while (index <= max) {
+        resolvedColWidths[index] = range.width;
+        successor[index] = findUnassigned(index + 1);
+        index = successor[index];
+      }
+    }
+    // Explicit point widths are also used by live resize overrides, so they
+    // intentionally win over the parsed compact ranges.
+    for (const [rawIndex, width] of Object.entries(worksheet.colWidths)) {
+      const index = Number(rawIndex);
+      if (Number.isInteger(index) && index >= 1 && index <= MAX_WORKSHEET_COL) {
+        resolvedColWidths[index] = width;
+      }
+    }
+    const columnPixels: Array<{ index: number; px: number }> = [];
+    for (let index = 1; index <= MAX_WORKSHEET_COL; index++) {
+      const width = resolvedColWidths[index];
+      if (!Number.isFinite(width) || width < 0) continue;
+      const px = colWidthToPx(width, mdw);
+      if (px !== defaultColPx) columnPixels.push({ index, px });
+    }
     this.col = new GridAxisGeometry(
-      worksheet.colWidths,
-      colWidthToPx(worksheet.defaultColWidth, mdw),
+      {},
+      defaultColPx,
       (raw) => colWidthToPx(raw, mdw),
       MAX_WORKSHEET_COL,
+      columnPixels,
     );
     this.row = new GridAxisGeometry(
       worksheet.rowHeights,

--- a/packages/xlsx/src/types.ts
+++ b/packages/xlsx/src/types.ts
@@ -62,6 +62,10 @@ export interface Worksheet {
   name: string;
   rows: Row[];
   colWidths: Record<number, number>;
+  /** Compact `<col min max width>` declarations in document order. The parser
+   *  normalizes overlapping legacy point entries in `colWidths` to the final
+   *  effective width; later live point edits can therefore override ranges. */
+  colWidthRanges?: Array<{ min: number; max: number; width: number }>;
   rowHeights: Record<number, number>;
   /** Per-column outline (grouping) depth 0-7 (ECMA-376 §18.3.1.13
    *  `<col outlineLevel>`), keyed by 1-based column index. Present only for


### PR DESCRIPTION
## Summary

- preserve authored SpreadsheetML column widths even when customWidth is omitted
- keep compact range resolution ordered and bounded for overlapping declarations
- measure horizontal category-label gutters with the font used for painting
- suppress axis tick marks with an authored no-fill axis rule while retaining labels and gridlines

## Specification and compatibility

- ECMA-376 §18.3.1.13 for column width declarations
- ChartML axis shape and tick elements, with the no-fill behavior matched to observed Excel output

## Verification

- TypeScript typecheck and full Vitest suite
- XLSX parser and shared OOXML Rust suites
- public API baseline and viewer symmetry checks
- adversarial overlapping full-sheet range tests
- fixed-merge-base private DOCX, XLSX, and PPTX visual regression comparison