### PR TITLE
fix(docx): preserve ideographic-space pagination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,16 @@ UPDATE_REFS=1 pnpm vrt:fidelity
 
 Do not automatically update files under `packages/*/tests/visual/references/`.
 
+An exact private self-VRT difference is a detected regression candidate, even
+when every changed document carries the setting being implemented. Enumerate
+every changed page, sheet, or slide and adjudicate each one against an
+Office-produced reference. A manual review counts only when it explicitly
+compares the candidate and previous renderers with that Office output, or when
+the user explicitly adjudicates the difference. Never approve a group of
+differences solely because the affected files share a feature flag or OOXML
+element. If neither an Office reference nor user adjudication is available,
+report that item as unadjudicated rather than calling the VRT successful.
+
 ## Documentation and Public Examples
 
 Public docs and commit messages should be written in English.

--- a/packages/docx/src/balance-single-double-byte-width.test.ts
+++ b/packages/docx/src/balance-single-double-byte-width.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { DEFAULT_KINSOKU_RULES } from '@silurus/ooxml-core';
 import {
   buildSegments,
+  layoutLines,
   segAdvanceWidth,
   type LayoutTextSeg,
   type LineLayoutEnvironment,
@@ -57,6 +59,21 @@ function textRun(text: string): DocRun {
   } as unknown as DocRun;
 }
 
+function laidOutTextLines(
+  runs: readonly DocRun[],
+  grid: Parameters<typeof layoutLines>[10],
+  width = 2,
+): string[] {
+  const lines = layoutLines(
+    measureContext(), textSegments(runs), width, 0, 1, [], undefined, {}, 0,
+    DEFAULT_KINSOKU_RULES, grid, 36, width, false,
+  );
+  return lines.map((line) =>
+    line.segments.filter((segment): segment is LayoutTextSeg => 'text' in segment)
+      .map((segment) => segment.text)
+      .join(''));
+}
+
 function environment(enabled: boolean): LineLayoutEnvironment {
   return {
     pageIndex: 0,
@@ -97,6 +114,76 @@ describe('ECMA-376 §17.15.3.3 single-byte/double-byte width balance', () => {
       ['\u3000', 0.5],
       ['本', 1],
     ]);
+  });
+
+  it('preserves ideographic-space hanging on a line-only document grid', () => {
+    const segments = textSegments([textRun('申\u3000請\u3000事\u3000項')]);
+    expect(segments.map((segment) => [segment.text, segment.joinPrev ?? false])).toEqual([
+      ['申', false],
+      ['\u3000', true],
+      ['請', false],
+      ['\u3000', true],
+      ['事', false],
+      ['\u3000', true],
+      ['項', false],
+    ]);
+
+    const lines = layoutLines(
+      measureContext(), segments, 4, 0, 1, [], undefined, {}, 0,
+      DEFAULT_KINSOKU_RULES, { type: 'lines', linePitchPt: 18 }, 36, 4, false,
+    );
+    const lineTexts = lines.map((line) =>
+      line.segments.filter((segment): segment is LayoutTextSeg => 'text' in segment)
+        .map((segment) => segment.text)
+        .join(''));
+    expect(lineTexts.map((text) => [...text][0])).toEqual(['申', '請', '事', '項']);
+    expect(lineTexts.some((text) => [...text].every((character) => character === '\u3000')))
+      .toBe(false);
+  });
+
+  it.each([-2, 2])(
+    'preserves ideographic-space hanging with linesAndChars charSpace %s',
+    (charSpacePt) => {
+      const lines = laidOutTextLines(
+        [textRun('申\u3000請\u3000事\u3000項')],
+        { type: 'linesAndChars', linePitchPt: 18, charSpacePt },
+      );
+      expect(lines.map((text) => [...text][0])).toEqual(['申', '請', '事', '項']);
+      expect(lines.some((text) => [...text].every((character) => character === '\u3000')))
+        .toBe(false);
+    },
+  );
+
+  it('preserves hanging when the run opts out of the character grid', () => {
+    const run = { ...textRun('申\u3000請\u3000事'), snapToGrid: false } as DocRun;
+    const lines = laidOutTextLines(
+      [run],
+      { type: 'linesAndChars', linePitchPt: 18, charSpacePt: -2 },
+    );
+    expect(lines).toEqual(['申\u3000', '請\u3000', '事']);
+  });
+
+  it('does not detach a paragraph-final U+3000 tail from its ruby source run', () => {
+    const run = {
+      ...textRun('見出し\u3000\u3000'),
+      ruby: { text: 'みだし', fontSizePt: 5 },
+    } as DocRun;
+    const segments = textSegments([run]);
+    expect(segments.map((segment) => [segment.text, segment.ruby !== undefined])).toEqual([
+      ['見出し', true],
+      ['\u3000\u3000', false],
+    ]);
+
+    const lines = layoutLines(
+      measureContext(), segments, 20, 0, 1, [], undefined, {}, 0,
+      DEFAULT_KINSOKU_RULES, { type: 'lines', linePitchPt: 18 }, 36, 20, false,
+    );
+    expect(lines.map((line) => line.segments
+      .filter((segment): segment is LayoutTextSeg => 'text' in segment)
+      .map((segment) => segment.text)
+      .join(''))).toEqual(['見出し\u3000\u3000']);
+    expect(segments.some((segment) => segment.paragraphFinalIdeographicSpaceTail === true))
+      .toBe(false);
   });
 
   it('balances two or more authored U+0020 spaces against half an ideographic cell', () => {

--- a/packages/docx/src/ideographic-space-fit.test.ts
+++ b/packages/docx/src/ideographic-space-fit.test.ts
@@ -89,6 +89,76 @@ describe('trailing U+3000 line-end allowance', () => {
     expect(lineTexts(lines)).toEqual(['　申']);
   });
 
+  it('wraps multiple authored trailing U+3000 onto an intentional blank line', () => {
+    // Heading = 15pt and two spaces = 10pt. A multi-space paragraph-final tail
+    // is width-bearing and therefore moves together to the following line.
+    // Treating all trailing spaces as unbounded hanging content erased it.
+    const heading = { ...textSeg('見出し'), sourceRunIndex: 0 };
+    const spaces = {
+      ...textSeg('　　'), sourceRunIndex: 0, joinPrev: true,
+    };
+    expect(lineTexts(lay([heading, spaces], 20)))
+      .toEqual(['見出し', '　　']);
+    expect(lineTexts(lay([textSeg('見出し　　')], 20)))
+      .toEqual(['見出し', '　　']);
+    expect(lineTexts(lay([textSeg('見出し　'), textSeg('　')], 20)))
+      .toEqual(['見出し', '　　']);
+  });
+
+  it('does not split paragraph-final spaces out of atomic OOXML text cells', () => {
+    const fitText = {
+      ...textSeg('見出し　　'),
+      fitTextRegionIndex: 0,
+      fitTextRegionStart: true,
+      fitTextRegionEnd: true,
+      fitTextVal: 300,
+    };
+    const tateChuYoko = {
+      ...textSeg('12　　'),
+      tateChuYoko: true,
+    };
+    const ruby = {
+      ...textSeg('見出し　　'),
+      ruby: { text: 'みだし', fontSizePt: 5 },
+    };
+
+    const fitTextSegments = lay([fitText], 4).flatMap((line) => line.segments)
+      .filter((segment): segment is LayoutTextSeg => 'text' in segment);
+    expect(fitTextSegments).toHaveLength(1);
+    expect(fitTextSegments[0]?.text).toBe('見出し　　');
+    expect(fitTextSegments[0]?.fitTextRegionIndex).toBe(0);
+
+    const tateChuYokoSegments = lay([tateChuYoko], 20).flatMap((line) => line.segments)
+      .filter((segment): segment is LayoutTextSeg => 'text' in segment);
+    expect(tateChuYokoSegments).toHaveLength(1);
+    expect(tateChuYokoSegments[0]?.text).toBe('12　　');
+    expect(tateChuYokoSegments[0]?.tateChuYoko).toBe(true);
+
+    const rubySegments = lay([ruby], 20).flatMap((line) => line.segments)
+      .filter((segment): segment is LayoutTextSeg => 'text' in segment);
+    expect(rubySegments.filter((segment) => segment.ruby !== undefined)).toHaveLength(1);
+    expect(rubySegments.map((segment) => segment.text).join('')).toBe('見出し　　');
+  });
+
+  it('keeps a paragraph-final U+3000 tail width-bounded beyond one full line', () => {
+    expect(lineTexts(lay([textSeg(`見出し${'　'.repeat(8)}`)], 20)))
+      .toEqual(['見出し', '　　　　', '　　　　']);
+  });
+
+  it('does not extend the East-Asian U+3000 allowance to Latin text', () => {
+    const latin = { ...textSeg('A'), sourceRunIndex: 0 };
+    const ideographicSpace = {
+      ...textSeg('　'), sourceRunIndex: 0, joinPrev: true,
+    };
+    expect(lineTexts(lay([latin, ideographicSpace], 6))).toEqual(['A', '　']);
+
+    const mixed = { ...textSeg('漢A'), sourceRunIndex: 1 };
+    const mixedTail = {
+      ...textSeg('　'), sourceRunIndex: 1, joinPrev: true,
+    };
+    expect(lineTexts(lay([mixed, mixedTail], 10))).toEqual(['漢A', '　']);
+  });
+
   it('does not change ASCII trailing-space behavior', () => {
     const lines = lay([textSeg('ab '), textSeg('cd')], 12); // 'ab ' fit-width 10 (trailing collapse), cd next
     const texts = lineTexts(lines);

--- a/packages/docx/src/layout/line-compatibility.ts
+++ b/packages/docx/src/layout/line-compatibility.ts
@@ -358,6 +358,27 @@ export const WORD_BALANCED_LINES_AND_CHARS_GRID_DELTA = defineCompatibilityRule(
   description: 'With balanceSingleByteDoubleByteWidth enabled on linesAndChars, Word applies half of the authored charSpace delta to ASCII SBCS text and to U+0020/U+3000 space characters, while applying the full delta to CJK ideographs and full-width ASCII forms. The Word-output evidence covers ASCII digits, letters, punctuation, spaces, CJK, full-width ASCII, mixed text, proportional/fixed-pitch faces, negative/zero/positive charSpace, and line-only controls. Non-ASCII high-ANSI and complex-script text are outside the observed matrix and retain the preexisting grid behavior.',
 });
 
+export const WORD_IDEOGRAPHIC_SPACE_LINE_END_ALLOWANCE = defineCompatibilityRule({
+  id: 'word-ideographic-space-line-end-allowance',
+  evidence: {
+    kind: 'office-observation',
+    syntheticFixtureId: 'ideographic-space-line-end-count-and-run-boundary-matrix',
+    application: 'Microsoft Word',
+    version: '16.111.1',
+    platform: 'macOS 26.5.2',
+  },
+  description: 'Word keeps a single U+3000 immediately following visible East-Asian text on that line when the visible glyph is force-fitted into a narrow table cell. A paragraph-final sequence of two or more U+3000 characters remains authored width-bearing content and may form blank continuation lines. The observed matrix covers single and trailing multiple spaces, linesAndChars with negative/positive charSpace, line-only grids, and snapToGrid opt-out.',
+});
+
+/** Compatibility projection governed by
+ * {@link WORD_IDEOGRAPHIC_SPACE_LINE_END_ALLOWANCE}. */
+export function wordIdeographicSpaceLineEndAllowanceCount(
+  hasEastAsianVisiblePredecessor: boolean,
+  consecutiveSpaceCount: number,
+): 0 | 1 {
+  return hasEastAsianVisiblePredecessor && consecutiveSpaceCount === 1 ? 1 : 0;
+}
+
 /** Compatibility projection governed by
  * {@link WORD_BALANCED_LINES_AND_CHARS_GRID_DELTA}. Script-slot acquisition
  * has already separated ordinary East-Asian and ASCII SBCS text; the explicit

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -104,6 +104,7 @@ import {
   wordBalancedConsecutiveSpaceCellApplies,
   wordBalancedLinesAndCharsGridDeltaFactor,
   wordBalancedSpaceCellAdjustmentApplies,
+  wordIdeographicSpaceLineEndAllowanceCount,
   wordUniformRunPositionPaintPt,
   wordUseFeLayoutParagraphMarkGridAdvancePx,
 } from './layout/line-compatibility.js';
@@ -142,6 +143,15 @@ export interface LayoutTextSeg extends LayoutSegSource {
    * its East-Asian ideographic cell. */
   widthBalanceSpaceSequence?: true;
   widthBalanceSpaceAdjustmentPt?: number;
+  /** Internal marker assigned once after queue construction: this segment is
+   * part of the paragraph-final U+3000-only suffix. */
+  paragraphFinalIdeographicSpaceTail?: true;
+  /** Number of trailing U+3000 characters owned by this segment. Kept
+   * separately from the suffix-wide count so a source seam cannot move visible
+   * text into the tail when the segment is split for line breaking. */
+  paragraphFinalIdeographicSpaceLocalCount?: number;
+  paragraphFinalIdeographicSpaceCount?: number;
+  paragraphFinalIdeographicSpaceTailStart?: true;
   /** Zero-advance anchor-character placeholder: contributes run metrics to the
    * line box but paints no glyph. */
   metricOnly?: true;
@@ -2074,11 +2084,32 @@ function rebaseSeaBreaks(offsets: readonly number[] | undefined, cut: number): r
  *  where the band is narrower than a single glyph (a one-glyph-wide form
  *  label column). A zero split (whole-run move / kinsoku retraction) is left
  *  untouched. */
-function extendThroughTrailingIdeographicSpaces(chars: string[], split: number): number {
-  if (split <= 0) return split;
+function extendThroughTrailingIdeographicSpaces(
+  chars: string[],
+  split: number,
+  maximum = Number.POSITIVE_INFINITY,
+): number {
+  if (split <= 0 || maximum <= 0) return split;
+  if (Number.isFinite(maximum) && chars[split - 1] === '\u3000') return split;
   let s = split;
-  while (s < chars.length && chars[s] === '\u3000') s++;
+  let remaining = maximum;
+  while (s < chars.length && chars[s] === '\u3000' && remaining > 0) {
+    s++;
+    remaining--;
+  }
   return s;
+}
+
+/** The observed Word allowance is tied to the immediately preceding visible
+ * East-Asian character, not merely to any East-Asian character elsewhere in a
+ * mixed-script segment. */
+function hasEastAsianVisiblePredecessor(text: string): boolean {
+  const characters = [...text];
+  for (let index = characters.length - 1; index >= 0; index -= 1) {
+    if (characters[index] === '\u3000') continue;
+    return EAST_ASIAN_RE.test(characters[index]);
+  }
+  return false;
 }
 
 export function fitCJKPrefix(
@@ -2106,6 +2137,8 @@ export function fitCJKPrefix(
    * same substring measurement used by whole-segment fit so every prefix uses
    * the canonical selected-face and OOXML pitch model. */
   measureAdvance?: (text: string) => number,
+  /** Maximum trailing U+3000 characters excluded from the fit width. */
+  maximumIdeographicSpaceHang = Number.POSITIVE_INFINITY,
 ): string {
   const chars = [...text]; // spread handles surrogate pairs
   const advanceOf = (prefix: string): number => measureAdvance?.(prefix) ?? (() => {
@@ -2125,7 +2158,7 @@ export function fitCJKPrefix(
     );
   })();
   // Trailing IDEOGRAPHIC SPACE (U+3000) line-end allowance: a candidate that
-  // overflows ONLY because it ends in fullwidth spaces still fits — the spaces
+  // overflows ONLY because it ends in fullwidth spaces still fits — those spaces
   // hang past the line end (JLReq line-end ideographic-space handling; Word
   // does the same, which is what keeps a "char + U+3000" form label at one
   // visible glyph per line instead of alternating glyph/space lines). The
@@ -2138,9 +2171,13 @@ export function fitCJKPrefix(
   // binary search remains valid.
   const fitsWithHang = (endExclusive: number): boolean => {
     let visibleEnd = endExclusive;
-    while (visibleEnd > 0 && chars[visibleEnd - 1] === '\u3000') visibleEnd--;
+    let remainingHang = maximumIdeographicSpaceHang;
+    if (remainingHang > 0) {
+      while (visibleEnd > 0 && chars[visibleEnd - 1] === '\u3000') visibleEnd--;
+      const trailingCount = endExclusive - visibleEnd;
+      visibleEnd += Math.max(0, trailingCount - remainingHang);
+    }
     const prefix = chars.slice(0, visibleEnd).join('');
-    if (prefix.length === 0) return true;
     return advanceOf(prefix) <= maxWidth;
   };
   let lo = 0, hi = chars.length;
@@ -3533,13 +3570,19 @@ export function buildSegments(
     cur.joinPrev = true;
   }
 
-  // UAX #14 LB7 keeps a trailing SP with the preceding text. Script/font
-  // shaping may split that SP into a new segment, so recover the relationship
-  // when both segments came from the same authored run. A real source-run
-  // boundary is delegated to wordSourceRunSpaceContinuesSequence below.
+  // Preserve the established Word/JLReq line-end allowance for U+3000 across
+  // internal script/font/width-balance shaping seams. U+3000 is BA in UAX #14,
+  // so the break opportunity is after the space; splitting the space into its
+  // own internal segment must not invent an opportunity before it. A real
+  // U+0020 source-run boundary is delegated to
+  // wordSourceRunSpaceContinuesSequence below.
   for (let i = 1; i < segs.length; i++) {
     const cur = segs[i];
-    if (!('text' in cur) || cur.joinPrev || !cur.text.startsWith(' ')) continue;
+    if (
+      !('text' in cur)
+      || cur.joinPrev
+      || (cur.text[0] !== ' ' && cur.text[0] !== '\u3000')
+    ) continue;
     const prev = segs[i - 1];
     if (!('text' in prev)) continue;
     const trailingSpaceFromSameRun = cur.sourceRunIndex === prev.sourceRunIndex;
@@ -3547,7 +3590,10 @@ export function buildSegments(
       prev.text,
       cur.text,
     );
-    if (!trailingSpaceFromSameRun && !compatibleSourceBoundary) continue;
+    if (
+      !trailingSpaceFromSameRun
+      && !compatibleSourceBoundary
+    ) continue;
     cur.joinPrev = true;
   }
 
@@ -4440,6 +4486,62 @@ export function layoutLines(
     }
   }
 
+  // Mark the paragraph-final U+3000 suffix once. A backwards pass avoids the
+  // O(N²) suffix rescans that would result from queue.every/reduce per segment.
+  let paragraphFinalIdeographicSpaceCount = 0;
+  let paragraphFinalIdeographicSpaceTailStartIndex = -1;
+  const markedParagraphFinalTail: Array<Readonly<{
+    index: number;
+    segment: LayoutTextSeg;
+  }>> = [];
+  for (let index = queue.length - 1; index >= 0; index -= 1) {
+    const candidate = queue[index];
+    if (!candidate || !('text' in candidate) || candidate.text.length === 0) break;
+    // `fitText` (§17.3.2.14) and tate-chu-yoko (§17.3.2.10) are indivisible
+    // layout cells. Ruby owns one base/guide pair. Paragraph-final whitespace
+    // may affect how those cells measure, but must never split or clone them.
+    if (
+      candidate.fitTextRegionIndex !== undefined
+      || candidate.tateChuYoko === true
+      || candidate.ruby !== undefined
+    ) {
+      // buildSegments can split an atomic source run before its U+3000 tail
+      // (ruby is retained only on the first emitted segment). Undo any markers
+      // already assigned to trailing pieces from that same authored run.
+      if (candidate.sourceRunIndex !== undefined) {
+        for (let markedIndex = markedParagraphFinalTail.length - 1; markedIndex >= 0; markedIndex -= 1) {
+          const marked = markedParagraphFinalTail[markedIndex];
+          if (marked.segment.sourceRunIndex !== candidate.sourceRunIndex) continue;
+          marked.segment.paragraphFinalIdeographicSpaceTail = undefined;
+          marked.segment.paragraphFinalIdeographicSpaceLocalCount = undefined;
+          marked.segment.paragraphFinalIdeographicSpaceCount = undefined;
+          marked.segment.paragraphFinalIdeographicSpaceTailStart = undefined;
+          markedParagraphFinalTail.splice(markedIndex, 1);
+        }
+        paragraphFinalIdeographicSpaceTailStartIndex =
+          markedParagraphFinalTail.at(-1)?.index ?? -1;
+      }
+      break;
+    }
+    const trailingSpaces = /^\u3000+$/u.test(candidate.text);
+    const visibleWithTrailingSpaces = /[^\u3000]\u3000+$/u.test(candidate.text);
+    if (!trailingSpaces && !visibleWithTrailingSpaces) break;
+    const localTrailingCount = trailingSpaces
+      ? [...candidate.text].length
+      : [...candidate.text].reverse().findIndex((character) => character !== '\u3000');
+    paragraphFinalIdeographicSpaceCount += localTrailingCount;
+    candidate.paragraphFinalIdeographicSpaceTail = true;
+    candidate.paragraphFinalIdeographicSpaceLocalCount = localTrailingCount;
+    candidate.paragraphFinalIdeographicSpaceCount = paragraphFinalIdeographicSpaceCount;
+    paragraphFinalIdeographicSpaceTailStartIndex = index;
+    markedParagraphFinalTail.push({ index, segment: candidate });
+    if (visibleWithTrailingSpaces) break;
+  }
+  if (paragraphFinalIdeographicSpaceTailStartIndex >= 0) {
+    const start = queue[paragraphFinalIdeographicSpaceTailStartIndex];
+    if (start && 'text' in start) start.paragraphFinalIdeographicSpaceTailStart = true;
+  }
+
   // Resolve §17.3.2.14 from RAW natural advances at this exact layout scale.
   // The resulting per-gap is folded into segAdvanceWidth below, so the line
   // breaker and paint pen use one width authority. Cached w:spacing is ignored.
@@ -4595,6 +4697,157 @@ export function layoutLines(
       candidate,
       strNaturalAdvance(s, text, retainTrailingPunctuationCompression),
     );
+  };
+
+  /** Measure one text segment's canonical advance and vertical contribution.
+   * Every path that commits a complete text segment to a line must use this
+   * authority so font fallback, small-caps, position, ruby and grid metrics do
+   * not diverge at internal segment seams. */
+  const textSegmentBox = (s: LayoutTextSeg): Readonly<{
+    width: number;
+    height: number;
+    ascent: number;
+    descent: number;
+  }> => {
+    const measured = measureText(s, snapToCharsClass(s, characterGrid) === 'eastAsia');
+    const width = segAdvanceWidth(
+      s,
+      measured.width + verticalInkExtra(s, s.text),
+      characterGrid,
+      scale,
+    );
+    s.snapGridNaturalWidthPx = width;
+
+    const fullPx = s.fontSize * scale;
+    let metricMeasurement = measured;
+    let metricEmPx = effectiveFontPx(s);
+    if (s.smallCaps && !s.vertAlign && metricEmPx !== fullPx) {
+      if (s.textLayoutService && s.textShapeRequest) {
+        const shaped = s.textLayoutService.shape({
+          ...s.textShapeRequest,
+          text: s.text || 'X',
+          fontSizePt: fullPx,
+          measure: true,
+          clusterGeometry: false,
+        });
+        metricMeasurement = {
+          width: shaped.advancePt,
+          actualBoundingBoxAscent: shaped.ascentPt,
+          actualBoundingBoxDescent: shaped.descentPt,
+          fontBoundingBoxAscent: shaped.ascentPt,
+          fontBoundingBoxDescent: shaped.descentPt,
+        } as TextMetrics;
+      } else {
+        const previousFont = ctx.font;
+        ctx.font = buildFont(
+          s.bold,
+          s.italic,
+          fullPx,
+          s.fontFamily,
+          fontFamilyClasses,
+          s.fontRoute,
+        );
+        metricMeasurement = ctx.measureText(s.text || 'X');
+        ctx.font = previousFont;
+      }
+      metricEmPx = fullPx;
+    }
+
+    const corrected = correctedLineMetrics(
+      metricMeasurement,
+      s.fontFamily,
+      fullPx,
+      metricEmPx,
+      (s.metricEastAsian === true || EAST_ASIAN_RE.test(s.text)) && !s.ruby,
+    );
+    let ascent = corrected.ascent;
+    let descent = corrected.descent;
+    if (s.positionExtendsLineBox !== false) {
+      const positionPx = (s.position ?? 0) * scale;
+      if (positionPx > 0) ascent += positionPx;
+      else if (positionPx < 0) descent -= positionPx;
+    }
+    if (s.ruby && (!s.textBoxLineFloor || s.textBoxVertical)) {
+      ascent += rubyAscentReservePx(
+        s.ruby.fontSizePt,
+        s.ruby.hpsRaisePt,
+        scale,
+        s,
+        ctx,
+        fontFamilyClasses,
+      );
+    }
+    return { width, height: s.fontSize, ascent, descent };
+  };
+
+  /** Continue the existing U+3000 line-end hanging rule across an internal
+   * width-balance segment seam. The split space keeps its own font/grid advance
+   * for measure == paint. UAX #14 classifies U+3000 as BA, so an internal seam
+   * before it must not become an authored break opportunity. Restrict
+   * consumption to the same authored run; an actual source boundary remains
+   * independently modeled. */
+  const appendQueuedIdeographicSpaceSegment = (
+    source: LayoutTextSeg,
+  ): void => {
+    if (
+      /\s$/u.test(source.text)
+      || source.ruby !== undefined
+      || source.tateChuYoko === true
+      || source.fitTextRegionIndex !== undefined
+    ) return;
+    const follower = queue[0];
+    if (
+      !follower
+      || !('text' in follower)
+      || follower.joinPrev !== true
+      || follower.text.length === 0
+      || [...follower.text].some((character) => character !== '\u3000')
+    ) return;
+    queue.shift();
+    const hangingCount = wordIdeographicSpaceLineEndAllowanceCount(
+      hasEastAsianVisiblePredecessor(source.text),
+      follower.paragraphFinalIdeographicSpaceCount ?? [...follower.text].length,
+    );
+    if (hangingCount === 0) {
+      queue.unshift(follower);
+      return;
+    }
+    const hangingText = follower.text.slice(0, hangingCount);
+    const hangingSegment: LayoutTextSeg = {
+      ...follower,
+      text: hangingText,
+      measuredWidth: 0,
+      punctuationCompressions: slicedPunctuationCompressions(follower, 0, 1),
+    };
+    const followerBox = textSegmentBox(hangingSegment);
+    hangingSegment.measuredWidth = followerBox.width;
+    addToLine(
+      hangingSegment,
+      followerBox.width,
+      followerBox.height,
+      followerBox.ascent,
+      followerBox.descent,
+    );
+    const remainder = follower.text.slice(hangingText.length);
+    if (remainder.length > 0) {
+      queue.unshift({
+        ...follower,
+        text: remainder,
+        measuredWidth: 0,
+        joinPrev: undefined,
+        punctuationCompressions: slicedPunctuationCompressions(
+          follower,
+          hangingText.length,
+          follower.text.length,
+        ),
+        src: follower.src
+          ? {
+              segIndex: follower.src.segIndex,
+              charOffset: follower.src.charOffset + hangingText.length,
+            }
+          : undefined,
+      });
+    }
   };
 
   // Width of a queued segment, for right/center tab look-ahead.
@@ -4928,96 +5181,82 @@ export function layoutLines(
 
     // ── Text segment ─────────────────────────────────────
     const s = seg as LayoutTextSeg;
-    const m = measureText(s, snapToCharsClass(s, characterGrid) === 'eastAsia');
-    // Advance = natural width + character-grid delta (the SINGLE model shared
-    // with the draw paths; 0 unless an active grid AND a pure-EA segment).
-    // #1014 — plus the vo=Tr rotate-fallback ink deficit for a vertical run, so
-    // this MAIN commit path (the segment's stored measuredWidth and the pen advance
-    // to the next segment) matches the ink-sized cell `drawVerticalRun` paints
-    // (measure == paint); 0 for horizontal / non-under-reporting runs.
-    const w = segAdvanceWidth(
-      s,
-      m.width + verticalInkExtra(s, s.text),
-      characterGrid,
-      scale,
-    );
-    s.snapGridNaturalWidthPx = w;
+    const segmentBox = textSegmentBox(s);
+    const w = segmentBox.width;
     const prospectiveWidth = prospectiveSnapAdvance(s, w);
-    // Line-height tracks the un-scaled pt font so super/sub don't shrink the line.
-    const h = s.fontSize;
-    // Prefer font-metric ascent/descent (stable per font+size) so baselines and
-    // line boxes do not jitter based on the specific characters on each line.
-    // When the document font is substituted by one with different vertical
-    // metrics, rescale to the document font's design line box so the line
-    // height (and thus baseline centering, row auto-heights, cell vAlign
-    // §17.4.84, and pagination) match Word — see font-metrics.ts.
-    // Fallback box at the run's full size; correction at the effective size
-    // (smallCaps/vertAlign shrink it). See correctedLineMetrics.
-    // §17.3.2.33: a small-caps run's LINE BOX follows the FULL run size, not the
-    // 2pt-reduced glyph size — so a wrapped continuation line carrying only reduced
-    // (all-lowercase) small caps is not short. Measure the box metrics at the full
-    // size (the advance `w` above still uses the reduced glyphs). Super/subscript
-    // is excluded: it intentionally shrinks its line contribution.
-    const fullPx = s.fontSize * scale;
-    let metricM = m;
-    let metricEmPx = effectiveFontPx(s);
-    if (s.smallCaps && !s.vertAlign && metricEmPx !== fullPx) {
-      if (s.textLayoutService && s.textShapeRequest) {
-        const shaped = s.textLayoutService.shape({
-          ...s.textShapeRequest,
-          text: s.text || 'X',
-          fontSizePt: fullPx,
-          measure: true,
-          clusterGeometry: false,
-        });
-        metricM = {
-          width: shaped.advancePt,
-          actualBoundingBoxAscent: shaped.ascentPt,
-          actualBoundingBoxDescent: shaped.descentPt,
-          fontBoundingBoxAscent: shaped.ascentPt,
-          fontBoundingBoxDescent: shaped.descentPt,
-        } as TextMetrics;
-      } else {
-        const prevFont = ctx.font;
-        ctx.font = buildFont(s.bold, s.italic, fullPx, s.fontFamily, fontFamilyClasses, s.fontRoute);
-        metricM = ctx.measureText(s.text || 'X');
-        ctx.font = prevFont;
+    const h = segmentBox.height;
+    const asc = segmentBox.ascent;
+    const desc = segmentBox.descent;
+    const paragraphFinalIdeographicSpaceTail =
+      s.paragraphFinalIdeographicSpaceTail === true;
+    const paragraphFinalIdeographicSpaceCount =
+      s.paragraphFinalIdeographicSpaceCount ?? 0;
+    const paragraphFinalIdeographicSpaceLocalCount =
+      s.paragraphFinalIdeographicSpaceLocalCount ?? 0;
+    const visibleBeforeParagraphFinalTail = paragraphFinalIdeographicSpaceTail
+      ? s.text.slice(0, Math.max(0, s.text.length - paragraphFinalIdeographicSpaceLocalCount))
+      : s.text;
+    if (
+      paragraphFinalIdeographicSpaceTail
+      && paragraphFinalIdeographicSpaceCount > 1
+      && visibleBeforeParagraphFinalTail.length > 0
+    ) {
+      const visibleSegment: LayoutTextSeg = {
+        ...s,
+        text: visibleBeforeParagraphFinalTail,
+        paragraphFinalIdeographicSpaceTail: undefined,
+        paragraphFinalIdeographicSpaceLocalCount: undefined,
+        paragraphFinalIdeographicSpaceCount: undefined,
+        paragraphFinalIdeographicSpaceTailStart: undefined,
+        measuredWidth: 0,
+        punctuationCompressions: slicedPunctuationCompressions(
+          s,
+          0,
+          visibleBeforeParagraphFinalTail.length,
+        ),
+      };
+      const trailingSegment: LayoutTextSeg = {
+        ...s,
+        text: s.text.slice(visibleBeforeParagraphFinalTail.length),
+        paragraphFinalIdeographicSpaceLocalCount,
+        joinPrev: undefined,
+        paragraphFinalIdeographicSpaceTailStart: true,
+        measuredWidth: 0,
+        punctuationCompressions: slicedPunctuationCompressions(
+          s,
+          visibleBeforeParagraphFinalTail.length,
+          s.text.length,
+        ),
+        src: s.src
+          ? {
+              segIndex: s.src.segIndex,
+              charOffset: s.src.charOffset + visibleBeforeParagraphFinalTail.length,
+            }
+          : undefined,
+      };
+      queue.unshift(trailingSegment);
+      queue.unshift(visibleSegment);
+      continue;
+    }
+    if (
+      paragraphFinalIdeographicSpaceTail
+      && /^\u3000+$/u.test(s.text)
+      && s.paragraphFinalIdeographicSpaceTailStart === true
+    ) {
+      const currentLineHasVisibleText = currentLine.some((candidate) =>
+        'text' in candidate && /[^\u3000]/u.test(candidate.text));
+      if (currentLineHasVisibleText) {
+        let trailingTailWidth = w;
+        for (const candidate of queue) {
+          if (!('text' in candidate) || candidate.paragraphFinalIdeographicSpaceTail !== true) break;
+          trailingTailWidth += segAdvance(candidate);
+        }
+        if (currentWidth + trailingTailWidth > availW()) {
+          flush(undefined, false, s.src);
+          queue.unshift(s);
+          continue;
+        }
       }
-      metricEmPx = fullPx;
-    }
-    // FE design correction for EA segments only; ruby keeps its measured box
-    // (see addToLine's segScriptHint note).
-    const corrected = correctedLineMetrics(
-      metricM,
-      s.fontFamily,
-      fullPx,
-      metricEmPx,
-      (s.metricEastAsian === true || EAST_ASIAN_RE.test(s.text)) && !s.ruby,
-    );
-    let asc = corrected.ascent;
-    let desc = corrected.descent;
-    // ECMA-376 §17.3.2.24 positions the run relative to the surrounding
-    // default baseline. Its shifted ink therefore contributes to the line's
-    // visible block extent: a raised run extends the ascent, while a lowered
-    // run extends the descent. Keeping the shift paint-only made an all-raised
-    // paragraph start above its retained line box, so table borders crossed the
-    // glyphs and row/body pagination under-counted the painted extent.
-    if (s.positionExtendsLineBox !== false) {
-      const positionPx = (s.position ?? 0) * scale;
-      if (positionPx > 0) asc += positionPx;
-      else if (positionPx < 0) desc -= positionPx;
-    }
-    // Ruby annotation: reserve exact authored hpsRaise or selected-face
-    // base/guide ink before the paragraph-wide docGrid pitch snap.
-    if (s.ruby && (!s.textBoxLineFloor || s.textBoxVertical)) {
-      asc = asc + rubyAscentReservePx(
-        s.ruby!.fontSizePt,
-        s.ruby!.hpsRaisePt,
-        scale,
-        s,
-        ctx,
-        fontFamilyClasses,
-      );
     }
 
     // ECMA-376 §17.3.2.14: a fit region is an atomic fixed-width cell. The
@@ -5296,9 +5535,11 @@ export function layoutLines(
       // Fits on current line as-is
       s.measuredWidth = w;
       addToLine(s, w, h, asc, desc, trailingSpaceW);
+      appendQueuedIdeographicSpaceSegment(s);
     } else if (admitsTrailingOverflowPunctuation) {
       s.measuredWidth = w;
       addToLine(s, w, h, asc, desc, trailingSpaceW);
+      appendQueuedIdeographicSpaceSegment(s);
     } else if (hasCJKBreakOpportunity(s.text) && s.seaBreaks === undefined) {
       // CJK overflow: split at the maximum prefix that fits, re-queue the tail.
       // A segment that ALSO contains SEA (a mixed CJK+SEA `<w:cs/>` run) is routed
@@ -5312,6 +5553,12 @@ export function layoutLines(
       setMeasureFont(buildFont(s.bold, s.italic, effectiveFontPx(s), s.fontFamily, fontFamilyClasses, s.fontRoute));
       const prevKern = setSegKerning(s);
       let rawPrefix = '';
+      const maximumIdeographicSpaceHang = paragraphFinalIdeographicSpaceTail
+        ? wordIdeographicSpaceLineEndAllowanceCount(
+            hasEastAsianVisiblePredecessor(s.text),
+            s.paragraphFinalIdeographicSpaceCount ?? 0,
+          )
+        : Number.POSITIVE_INFINITY;
       try {
         rawPrefix = available > 0 ? fitCJKPrefix(
           ctx,
@@ -5323,6 +5570,7 @@ export function layoutLines(
           s.verticalRun === true,
           verticalGlyphMeasurement,
           (prefix) => strAdvance(s, prefix),
+          maximumIdeographicSpaceHang,
         ) : '';
       } finally {
         restoreKerning(prevKern);
@@ -5350,6 +5598,9 @@ export function layoutLines(
       const split = extendThroughTrailingIdeographicSpaces(
         allChars,
         hangingSplit ?? kinsokuAdjustedSplit(allChars, rawSplit, kinsoku, minSplit),
+        paragraphFinalIdeographicSpaceTail && maximumIdeographicSpaceHang === 0
+          ? 0
+          : maximumIdeographicSpaceHang,
       );
       const prefix = allChars.slice(0, split).join('');
       if (prefix.length > 0) {
@@ -5378,6 +5629,8 @@ export function layoutLines(
               charOffset: s.src!.charOffset + prefix.length,
             },
           });
+        } else {
+          appendQueuedIdeographicSpaceSegment(s);
         }
       } else if (currentLine.length > 0) {
         // No prefix of `s` fits. If `s` would lead the next line with a 行頭禁則
@@ -5440,7 +5693,16 @@ export function layoutLines(
         // Empty line and not even one char fits — force-fit one char to guarantee progress
         const forcedChars = [...s.text];
         const forcedSplit = forcedChars.length > 0
-          ? extendThroughTrailingIdeographicSpaces(forcedChars, 1)
+          ? extendThroughTrailingIdeographicSpaces(
+              forcedChars,
+              1,
+              s.paragraphFinalIdeographicSpaceTail === true
+                ? wordIdeographicSpaceLineEndAllowanceCount(
+                    EAST_ASIAN_RE.test(forcedChars[0] ?? ''),
+                    s.paragraphFinalIdeographicSpaceCount ?? 0,
+                  )
+                : Number.POSITIVE_INFINITY,
+            )
           : 0;
         const firstChar = forcedChars.slice(0, forcedSplit).join('');
         if (firstChar) {
@@ -5468,6 +5730,8 @@ export function layoutLines(
                 charOffset: s.src!.charOffset + firstChar.length,
               },
             });
+          } else {
+            appendQueuedIdeographicSpaceSegment(s);
           }
         }
       }

--- a/packages/docx/src/line-layout.ts
+++ b/packages/docx/src/line-layout.ts
@@ -2100,8 +2100,8 @@ function extendThroughTrailingIdeographicSpaces(
   return s;
 }
 
-/** The observed Word allowance is tied to the immediately preceding visible
- * East-Asian character, not merely to any East-Asian character elsewhere in a
+/** Project the registered line-end allowance from the immediately preceding
+ * visible East-Asian character, not from another character elsewhere in a
  * mixed-script segment. */
 function hasEastAsianVisiblePredecessor(text: string): boolean {
   const characters = [...text];

--- a/packages/docx/src/table-row-split-fidelity.test.ts
+++ b/packages/docx/src/table-row-split-fidelity.test.ts
@@ -160,15 +160,19 @@ function row(
   } as unknown as DocTableRow;
 }
 
-function documentWithRow(tableRow: DocTableRow, pageHeight: number): DocxDocumentModel {
+function documentWithRow(
+  tableRow: DocTableRow,
+  pageHeight: number,
+  pageWidth = 160,
+): DocxDocumentModel {
   const table: DocTable = {
-    colWidths: [160], rows: [tableRow], borders: borders(),
+    colWidths: [pageWidth], rows: [tableRow], borders: borders(),
     cellMarginTop: 0, cellMarginBottom: 0, cellMarginLeft: 0, cellMarginRight: 0,
     jc: 'left', layout: 'fixed',
   } as unknown as DocTable;
   return {
     section: {
-      pageWidth: 160, pageHeight,
+      pageWidth, pageHeight,
       marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0,
       headerDistance: 0, footerDistance: 0, titlePage: false, evenAndOddHeaders: false,
     } as SectionProps,
@@ -204,6 +208,33 @@ const splitText =
   '丁'.repeat(16);
 
 describe('table row split fidelity — fragment-owned paint geometry', () => {
+  it('retains width-balanced CJK label lines across table pagination', async () => {
+    const labelRow = row('申　請　事　項　及　び　理　由', 'top');
+    const model = documentWithRow(labelRow, 85, 12);
+    model.settings = { balanceSingleByteDoubleByteWidth: true };
+    model.section.docGridType = 'linesAndChars';
+    model.section.docGridLinePitch = 20;
+    model.section.docGridCharSpace = -4096;
+
+    const layout = layoutDocument(model);
+    const painted = await Promise.all(
+      layout.pages.map((_, pageIndex) => renderPage(layout, pageIndex)),
+    );
+    const visibleByPage = painted.map((page) => page.texts
+      .map((call) => call.text.replaceAll('　', ''))
+      .join(''));
+    expect({
+      pages: layout.pages.length,
+      slices: layout.pages.map((_, i) => firstSliceOnPage(layout, i)),
+      visibleByPage,
+    }).toEqual({
+      pages: 2,
+      slices: [{ start: 0, end: 4 }, { start: 4, end: 8 }],
+      visibleByPage: ['申請事項', '及び理由'],
+    });
+    expect(visibleByPage.join('')).toBe('申請事項及び理由');
+  });
+
   it('paints only the retained continuation [k, n) line window', async () => {
     const model = documentWithRow(row(splitText, 'top'), 60);
     const layout = layoutDocument(model);


### PR DESCRIPTION
## Summary

- preserve Word-compatible U+3000 line-end behavior across internal width-balance segmentation
- keep authored multi-space paragraph tails width-bearing and retain correct table-row continuation geometry
- require every exact private VRT difference to be individually adjudicated against Office output or explicit user review

## Specification and evidence

The width-balancing correction follows ECMA-376 Part 1 §17.15.3.3 without introducing new authored break opportunities. The single-space line-end allowance is isolated as an Office-observed compatibility rule and is limited to an immediately preceding East-Asian character. Atomic fitText, tate-chu-yoko, and ruby ownership are preserved.

## Verification

- DOCX unit suite: 302 files / 3,079 tests passed
- DOCX architecture boundary, compatibility-evidence, public-API, package-build, and final architecture gates passed
- workspace typecheck passed
- private self-VRT against the fixed merge-base: 45/47 DOCX documents pixel-identical; the remaining two documents contain four expected, individually Office-adjudicated pages; XLSX 19/19 and PPTX 15/15 pixel-identical
- independent adversarial review: APPROVE, no unresolved Blocker, High, or Medium findings
- git diff --check passed