### PR TITLE
chore(release): 0.78.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ semantic versioning. While the major version is zero, minor releases may contain
 explicitly documented breaking changes; patch releases remain compatible with
 the corresponding minor release.
 
+## 0.78.1 — 2026-08-12
+
+Patch. Fixes a DOCX pagination regression introduced in v0.78.0 without
+changing the 0.78 public API.
+
+- **Word table pagination:** keep text in narrow table cells on the same pages
+  as Word when full-width spaces participate in East Asian line layout. This
+  prevents the end of a label from moving unexpectedly to the next page.
+- **authored paragraph spacing:** preserve intentional blank space created by
+  consecutive full-width spaces instead of collapsing it during line layout.
+- **compatibility:** no migration or application changes are required when
+  upgrading from v0.78.0. (#1226)
+
 ## 0.78.0 — 2026-08-12
 
 Compatible minor release. Improves chart rendering across Office formats and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ooxml-mcp-server"
-version = "0.78.0"
+version = "0.78.1"
 dependencies = [
  "anyhow",
  "docx-parser",

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pnpm add @silurus/ooxml
 > **Bundle size note**: the package is ESM-only (`.mjs`). npm's *Unpacked
 > Size* sums every entry bundle **and** the standalone MathJax + STIX Two Math
 > asset, so the reported figure is much larger than any single app build. For
-> v0.78.0, the complete npm package is approximately 12.0 MB unpacked (4.0 MB
+> v0.78.1, the complete npm package is approximately 12.0 MB unpacked (4.0 MB
 > as the downloaded tarball), while a format-specific application graph is
 > approximately:
 >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "Browser-based OOXML viewer (docx/xlsx/pptx) — Rust/WASM parser + Canvas renderer",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-core",
   "private": true,
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "Shared rendering primitives and types (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-docx",
   "private": true,
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "DOCX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-markdown",
   "private": true,
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "Internal workspace adapter for DOCX / XLSX / PPTX Markdown projection",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/mcp-server/Cargo.toml
+++ b/packages/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ooxml-mcp-server"
-version = "0.78.0"
+version = "0.78.1"
 edition = "2021"
 description = "MCP server exposing OOXML (xlsx/docx/pptx) parsers as AI-agent tools"
 license = "MIT"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-node",
   "private": true,
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "Node-side parsers for OOXML (docx/xlsx/pptx) using the workspace WASM artifacts — no browser DOM needed",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-pptx",
   "private": true,
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "PPTX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "office-open-xml-viewer",
   "displayName": "Office Viewer — DOCX, XLSX, PPTX",
   "description": "High-fidelity local viewer for Office files (.docx / .xlsx / .pptx), powered by Rust/WASM and Canvas. Optional MCP integration can share requested context with an AI agent.",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "publisher": "silurus",
   "license": "MIT",
   "icon": "icon.png",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@silurus/ooxml-xlsx",
   "private": true,
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "XLSX parser and Canvas renderer (internal workspace package of @silurus/ooxml)",
   "license": "MIT",
   "author": "Yuki Yokotani <silurus.dev@gmail.com>",

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silurus/ooxml-site",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "private": true,
   "type": "module",
   "description": "Showcase / marketing site for @silurus/ooxml",

--- a/site/src/lib/announcements.ts
+++ b/site/src/lib/announcements.ts
@@ -28,6 +28,25 @@ export interface Announcement {
 
 export const announcements: readonly Announcement[] = [
   {
+    slug: 'v0781-docx-pagination-fix',
+    date: '2026-08-12',
+    label: 'Release note',
+    version: 'v0.78.1',
+    title: 'DOCX pagination fix in v0.78.1',
+    summary: 'v0.78.1 fixes a regression that could move text in narrow Word table cells to the wrong page or hide intentional blank spacing.',
+    audience: 'Users who display Word documents with narrow table columns or full-width spacing. No application changes are required when upgrading from v0.78.0.',
+    sections: [
+      {
+        title: 'In short',
+        kind: 'summary',
+        paragraphs: [
+          'This patch restores Word-compatible page breaks for affected table content and preserves intentional blank space created with full-width spaces.',
+          'There are no public API changes and no migration is required.',
+        ],
+      },
+    ],
+  },
+  {
     slug: 'v078-chart-fidelity-and-multi-selection',
     date: '2026-08-12',
     label: 'Release note',


### PR DESCRIPTION
## Summary

- release the DOCX full-width-space pagination regression fix as v0.78.1
- keep all package, extension, site, and MCP versions aligned
- publish concise changelog and official-site release notes

## Compatibility

This is a compatible patch for v0.78.0. It does not change public APIs and requires no migration.

## Verification

- package build
- workspace typecheck
- DOCX public API checks
- official-site static build
- `cargo check -p ooxml-mcp-server`
- complete private DOCX/XLSX/PPTX visual regression run completed for the merged fix in #1226