### PR TITLE
fix(chart): honor ChartEx rendering contracts

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -2823,6 +2823,11 @@ moveTo 152.417,123.7286
 lineTo 240.923,123.7286
 stroke ss=#ccc lw=0.8 dash=
 restore
+set fillStyle=#595959
+set textAlign=center
+set textBaseline=bottom
+fillText "100" 122.915,120.7286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+set fillStyle=#5B9BD5
 fillRect 240.923,53.5071,59.004,70.2214 fs=#5B9BD5
 save
 set lineWidth=1
@@ -2833,6 +2838,8 @@ moveTo 299.927,53.5071
 lineTo 388.433,53.5071
 stroke ss=#ccc lw=0.8 dash=
 restore
+set fillStyle=#595959
+fillText "30" 270.425,50.5071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#ED7D31
 fillRect 388.433,53.5071,59.004,46.8143 fs=#ED7D31
 save
@@ -2844,11 +2851,15 @@ moveTo 447.437,100.3214
 lineTo 535.943,100.3214
 stroke ss=#ccc lw=0.8 dash=
 restore
+set fillStyle=#595959
+set textBaseline=top
+fillText "-20" 417.935,103.3214 fs=#595959 font=16.2px sans-serif al=center bl=top
 set fillStyle=#A5A5A5
 fillRect 535.943,100.3214,59.004,257.4786 fs=#A5A5A5
-set textAlign=center
-set textBaseline=top
 set fillStyle=#595959
+set textBaseline=bottom
+fillText "110" 565.445,97.3214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+set textBaseline=top
 fillText "Start" 122.915,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q1" 270.425,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q2" 417.935,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
@@ -2877,6 +2888,11 @@ moveTo 132.32,123.7286
 lineTo 224.48,123.7286
 stroke ss=#ccc lw=0.8 dash=
 restore
+set fillStyle=#595959
+set textAlign=center
+set textBaseline=bottom
+fillText "100" 101.6,120.7286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+set fillStyle=#5B9BD5
 fillRect 224.48,53.5071,61.44,70.2214 fs=#5B9BD5
 save
 set lineWidth=1
@@ -2887,6 +2903,8 @@ moveTo 285.92,53.5071
 lineTo 378.08,53.5071
 stroke ss=#ccc lw=0.8 dash=
 restore
+set fillStyle=#595959
+fillText "30" 255.2,50.5071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#ED7D31
 fillRect 378.08,53.5071,61.44,46.8143 fs=#ED7D31
 save
@@ -2898,11 +2916,15 @@ moveTo 439.52,100.3214
 lineTo 531.68,100.3214
 stroke ss=#ccc lw=0.8 dash=
 restore
+set fillStyle=#595959
+set textBaseline=top
+fillText "-20" 408.8,103.3214 fs=#595959 font=16.2px sans-serif al=center bl=top
 set fillStyle=#A5A5A5
 fillRect 531.68,100.3214,61.44,257.4786 fs=#A5A5A5
-set textAlign=center
-set textBaseline=top
 set fillStyle=#595959
+set textBaseline=bottom
+fillText "110" 562.4,97.3214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+set textBaseline=top
 fillText "Start" 101.6,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q1" 255.2,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q2" 408.8,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top

--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -938,7 +938,7 @@ save
 set font=18px sans-serif
 set textAlign=center
 translate 476.8,217.2
-rotate 1.5708
+rotate -1.5708
 fillText "Margin %" 0,0 fs=#555 font=18px sans-serif al=center bl=middle
 restore
 set font=12px sans-serif
@@ -2823,11 +2823,6 @@ moveTo 152.417,123.7286
 lineTo 240.923,123.7286
 stroke ss=#ccc lw=0.8 dash=
 restore
-set fillStyle=#595959
-set textAlign=center
-set textBaseline=bottom
-fillText "100" 122.915,120.7286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
-set fillStyle=#5B9BD5
 fillRect 240.923,53.5071,59.004,70.2214 fs=#5B9BD5
 save
 set lineWidth=1
@@ -2838,8 +2833,6 @@ moveTo 299.927,53.5071
 lineTo 388.433,53.5071
 stroke ss=#ccc lw=0.8 dash=
 restore
-set fillStyle=#595959
-fillText "30" 270.425,50.5071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#ED7D31
 fillRect 388.433,53.5071,59.004,46.8143 fs=#ED7D31
 save
@@ -2851,15 +2844,11 @@ moveTo 447.437,100.3214
 lineTo 535.943,100.3214
 stroke ss=#ccc lw=0.8 dash=
 restore
-set fillStyle=#595959
-set textBaseline=top
-fillText "-20" 417.935,103.3214 fs=#595959 font=16.2px sans-serif al=center bl=top
 set fillStyle=#A5A5A5
 fillRect 535.943,100.3214,59.004,257.4786 fs=#A5A5A5
-set fillStyle=#595959
-set textBaseline=bottom
-fillText "110" 565.445,97.3214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+set textAlign=center
 set textBaseline=top
+set fillStyle=#595959
 fillText "Start" 122.915,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q1" 270.425,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q2" 417.935,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
@@ -2888,11 +2877,6 @@ moveTo 132.32,123.7286
 lineTo 224.48,123.7286
 stroke ss=#ccc lw=0.8 dash=
 restore
-set fillStyle=#595959
-set textAlign=center
-set textBaseline=bottom
-fillText "100" 101.6,120.7286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
-set fillStyle=#5B9BD5
 fillRect 224.48,53.5071,61.44,70.2214 fs=#5B9BD5
 save
 set lineWidth=1
@@ -2903,8 +2887,6 @@ moveTo 285.92,53.5071
 lineTo 378.08,53.5071
 stroke ss=#ccc lw=0.8 dash=
 restore
-set fillStyle=#595959
-fillText "30" 255.2,50.5071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#ED7D31
 fillRect 378.08,53.5071,61.44,46.8143 fs=#ED7D31
 save
@@ -2916,15 +2898,11 @@ moveTo 439.52,100.3214
 lineTo 531.68,100.3214
 stroke ss=#ccc lw=0.8 dash=
 restore
-set fillStyle=#595959
-set textBaseline=top
-fillText "-20" 408.8,103.3214 fs=#595959 font=16.2px sans-serif al=center bl=top
 set fillStyle=#A5A5A5
 fillRect 531.68,100.3214,61.44,257.4786 fs=#A5A5A5
-set fillStyle=#595959
-set textBaseline=bottom
-fillText "110" 562.4,97.3214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+set textAlign=center
 set textBaseline=top
+set fillStyle=#595959
 fillText "Start" 101.6,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q1" 255.2,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q2" 408.8,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top

--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -2814,6 +2814,9 @@ lineTo 639.2,357.8
 stroke ss=#aaa lw=1 dash=
 set fillStyle=#5B9BD5
 fillRect 93.413,123.7286,59.004,234.0714 fs=#5B9BD5
+set strokeStyle=#5B9BD5
+setLineDash
+strokeRect 93.413,123.7286,59.004,234.0714 ss=#5B9BD5 lw=1
 save
 set strokeStyle=#ccc
 setLineDash
@@ -2829,8 +2832,12 @@ set textBaseline=bottom
 fillText "100" 122.915,120.7286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#5B9BD5
 fillRect 240.923,53.5071,59.004,70.2214 fs=#5B9BD5
-save
+set strokeStyle=#5B9BD5
 set lineWidth=1
+setLineDash
+strokeRect 240.923,53.5071,59.004,70.2214 ss=#5B9BD5 lw=1
+save
+set strokeStyle=#ccc
 setLineDash
 set lineWidth=0.8
 beginPath
@@ -2842,8 +2849,12 @@ set fillStyle=#595959
 fillText "30" 270.425,50.5071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#ED7D31
 fillRect 388.433,53.5071,59.004,46.8143 fs=#ED7D31
-save
+set strokeStyle=#ED7D31
 set lineWidth=1
+setLineDash
+strokeRect 388.433,53.5071,59.004,46.8143 ss=#ED7D31 lw=1
+save
+set strokeStyle=#ccc
 setLineDash
 set lineWidth=0.8
 beginPath
@@ -2856,6 +2867,10 @@ set textBaseline=top
 fillText "-20" 417.935,103.3214 fs=#595959 font=16.2px sans-serif al=center bl=top
 set fillStyle=#A5A5A5
 fillRect 535.943,100.3214,59.004,257.4786 fs=#A5A5A5
+set strokeStyle=#A5A5A5
+set lineWidth=1
+setLineDash
+strokeRect 535.943,100.3214,59.004,257.4786 ss=#A5A5A5 lw=1
 set fillStyle=#595959
 set textBaseline=bottom
 fillText "110" 565.445,97.3214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
@@ -2879,6 +2894,9 @@ lineTo 639.2,357.8
 stroke ss=#aaa lw=1 dash=
 set fillStyle=#5B9BD5
 fillRect 70.88,123.7286,61.44,234.0714 fs=#5B9BD5
+set strokeStyle=#5B9BD5
+setLineDash
+strokeRect 70.88,123.7286,61.44,234.0714 ss=#5B9BD5 lw=1
 save
 set strokeStyle=#ccc
 setLineDash
@@ -2894,8 +2912,12 @@ set textBaseline=bottom
 fillText "100" 101.6,120.7286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#5B9BD5
 fillRect 224.48,53.5071,61.44,70.2214 fs=#5B9BD5
-save
+set strokeStyle=#5B9BD5
 set lineWidth=1
+setLineDash
+strokeRect 224.48,53.5071,61.44,70.2214 ss=#5B9BD5 lw=1
+save
+set strokeStyle=#ccc
 setLineDash
 set lineWidth=0.8
 beginPath
@@ -2907,8 +2929,12 @@ set fillStyle=#595959
 fillText "30" 255.2,50.5071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#ED7D31
 fillRect 378.08,53.5071,61.44,46.8143 fs=#ED7D31
-save
+set strokeStyle=#ED7D31
 set lineWidth=1
+setLineDash
+strokeRect 378.08,53.5071,61.44,46.8143 ss=#ED7D31 lw=1
+save
+set strokeStyle=#ccc
 setLineDash
 set lineWidth=0.8
 beginPath
@@ -2921,6 +2947,10 @@ set textBaseline=top
 fillText "-20" 408.8,103.3214 fs=#595959 font=16.2px sans-serif al=center bl=top
 set fillStyle=#A5A5A5
 fillRect 531.68,100.3214,61.44,257.4786 fs=#A5A5A5
+set strokeStyle=#A5A5A5
+set lineWidth=1
+setLineDash
+strokeRect 531.68,100.3214,61.44,257.4786 ss=#A5A5A5 lw=1
 set fillStyle=#595959
 set textBaseline=bottom
 fillText "110" 562.4,97.3214 fs=#595959 font=16.2px sans-serif al=center bl=bottom

--- a/packages/core/src/chart/axis-scale.test.ts
+++ b/packages/core/src/chart/axis-scale.test.ts
@@ -7,6 +7,7 @@ import {
   axisFraction,
   logAxisScale,
   fitTrendline,
+  linearTrendlineStats,
 } from './axis-scale.js';
 
 describe('niceStep', () => {
@@ -185,6 +186,20 @@ describe('logAxisScale (power-of-base bounds + gridline exponents)', () => {
 });
 
 describe('fitTrendline', () => {
+  it('reports the fitted coefficients and R² used by equation labels', () => {
+    const stats = linearTrendlineStats([0, 1, 2, 3], [1, 3, 5, 7]);
+    expect(stats?.slope).toBeCloseTo(2, 9);
+    expect(stats?.intercept).toBeCloseTo(1, 9);
+    expect(stats?.rSquared).toBeCloseTo(1, 9);
+  });
+
+  it('computes R² from the authored forced-intercept fit', () => {
+    const stats = linearTrendlineStats([0, 1, 2, 3], [1, 2, 2, 5], 0);
+    expect(stats?.slope).toBeCloseTo(1.5, 9);
+    expect(stats?.intercept).toBe(0);
+    expect(stats?.rSquared).toBeLessThan(1);
+  });
+
   it('linear least squares recovers a perfect line', () => {
     // y = 2x + 1 at x = 0,1,2,3
     const t = fitTrendline([0, 1, 2, 3], [1, 3, 5, 7], 'linear');

--- a/packages/core/src/chart/axis-scale.ts
+++ b/packages/core/src/chart/axis-scale.ts
@@ -163,6 +163,49 @@ export function logAxisScale(
  *  when the type is unsupported or there is too little data to fit. */
 export interface TrendlinePoints { xs: number[]; ys: number[] }
 
+/** Least-squares coefficients and coefficient of determination for a linear
+ * trendline. This is kept separate from the sampled line points because
+ * `<c:dispEq>` / `<c:dispRSqr>` expose the fitted values as chart text. */
+export interface LinearTrendlineStats {
+  slope: number;
+  intercept: number;
+  rSquared: number;
+}
+
+export function linearTrendlineStats(
+  xs: readonly number[],
+  ys: readonly number[],
+  forcedIntercept?: number | null,
+): LinearTrendlineStats | null {
+  const n = Math.min(xs.length, ys.length);
+  if (n < 2) return null;
+  let sx = 0, sy = 0, sxx = 0, sxy = 0;
+  for (let i = 0; i < n; i++) {
+    sx += xs[i]; sy += ys[i]; sxx += xs[i] * xs[i]; sxy += xs[i] * ys[i];
+  }
+  let slope: number;
+  let intercept: number;
+  if (forcedIntercept != null && isFinite(forcedIntercept)) {
+    slope = sxx === 0 ? 0 : (sxy - forcedIntercept * sx) / sxx;
+    intercept = forcedIntercept;
+  } else {
+    const denom = n * sxx - sx * sx;
+    slope = denom === 0 ? 0 : (n * sxy - sx * sy) / denom;
+    intercept = (sy - slope * sx) / n;
+  }
+  const mean = sy / n;
+  let residual = 0;
+  let total = 0;
+  for (let i = 0; i < n; i++) {
+    const error = ys[i] - (slope * xs[i] + intercept);
+    residual += error * error;
+    const centered = ys[i] - mean;
+    total += centered * centered;
+  }
+  const rSquared = total === 0 ? (residual === 0 ? 1 : 0) : 1 - residual / total;
+  return { slope, intercept, rSquared };
+}
+
 /** Fit a trendline to `(xs, ys)` data points (nulls already filtered by the
  *  caller). Implements the two most common ECMA-376 `ST_TrendlineType`
  *  (§21.2.3.50) styles:
@@ -179,23 +222,13 @@ export function fitTrendline(
   const n = Math.min(xs.length, ys.length);
   if (n < 2) return { xs: [], ys: [] };
   if (type === 'linear') {
-    // Least squares. With a forced intercept b0, fit only the slope through
-    // the shifted data: m = Σ x(y-b0) / Σ x².
-    const forced = opts?.intercept;
-    let sx = 0, sy = 0, sxx = 0, sxy = 0;
-    for (let i = 0; i < n; i++) { sx += xs[i]; sy += ys[i]; sxx += xs[i] * xs[i]; sxy += xs[i] * ys[i]; }
-    let m: number, b: number;
-    if (forced != null && isFinite(forced)) {
-      const sxx0 = sxx; const sxy0 = sxy - forced * sx;
-      m = sxx0 === 0 ? 0 : sxy0 / sxx0;
-      b = forced;
-    } else {
-      const denom = n * sxx - sx * sx;
-      m = denom === 0 ? 0 : (n * sxy - sx * sy) / denom;
-      b = (sy - m * sx) / n;
-    }
+    const stats = linearTrendlineStats(xs, ys, opts?.intercept);
+    if (!stats) return { xs: [], ys: [] };
     const x0 = xs[0]; const x1 = xs[n - 1];
-    return { xs: [x0, x1], ys: [m * x0 + b, m * x1 + b] };
+    return {
+      xs: [x0, x1],
+      ys: [stats.slope * x0 + stats.intercept, stats.slope * x1 + stats.intercept],
+    };
   }
   if (type === 'movingAvg') {
     const period = Math.max(2, Math.round(opts?.period ?? 2));

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1408,6 +1408,7 @@ describe('CH3 — labels are locale-independent (§18.8.30)', () => {
       series: [series({ name: 'W', values: [1234567, 0] })],
       subtotalIndices: [1],
       dataLabelFormatCode: '0',
+      showDataLabels: true,
     }), RECT, 1);
     // The 1234567 subtotal bar's label must be un-grouped ("1234567"), proving
     // it went through the §18.8.30 engine rather than toLocaleString().
@@ -1426,6 +1427,7 @@ describe('CH3 — labels are locale-independent (§18.8.30)', () => {
         valFormatCode: '_(* #,##0.0_);_(* \\(#,##0.0\\);_(* "-"??_);_(@_)',
       })],
       subtotalIndices: [2],
+      showDataLabels: true,
     }), RECT, 1);
     expect(rec.texts.some(t => t.text.includes('(0.2)'))).toBe(true);
     expect(rec.texts.every(t => !t.text.includes('△'))).toBe(true);
@@ -1466,6 +1468,7 @@ describe('CH3 — labels are locale-independent (§18.8.30)', () => {
       dataLabelFontSizeHpt: 900,
       dataLabelFontBold: false,
       dataLabelFontFace: 'Calibri',
+      showDataLabels: true,
       categories: [
         'EBITDA FY21',
         'Change in Revenues',
@@ -1513,6 +1516,43 @@ describe('CH3 — labels are locale-independent (§18.8.30)', () => {
     const connectors = rec.segs.filter(segment => segment.ss.toLowerCase() === '#0070c0');
     expect(connectors).toHaveLength(2);
     expect(connectors.every(segment => segment.lw === 2)).toBe(true);
+  });
+});
+
+describe('ChartEx flat layouts dispatch to semantic renderers', () => {
+  it.each(['clusteredColumn', 'funnel', 'paretoLine'])(
+    '%s does not fall back to the unsupported-chart label',
+    chartType => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: chartType === 'paretoLine' ? [] : ['1', '2', '3'],
+        series: [series({ name: 'Authored series', values: [3, 2, 1] })],
+        showLegend: true,
+        legendPos: 't',
+      }), RECT, 1);
+
+      expect(rec.texts.map(text => text.text)).not.toContain(`Chart: ${chartType}`);
+      if (chartType !== 'paretoLine') {
+        expect(rec.texts.map(text => text.text)).toContain('Authored series');
+      }
+    },
+  );
+
+  it('waterfall uses locale-neutral English semantic legend labels', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['1', '2', '3'],
+      series: [series({ values: [3, -1, 2] })],
+      subtotalIndices: [2],
+      showLegend: true,
+      legendPos: 't',
+    }), RECT, 1);
+
+    expect(rec.texts.map(text => text.text)).toEqual(
+      expect.arrayContaining(['Increase', 'Decrease', 'Total']),
+    );
   });
 });
 
@@ -1753,6 +1793,24 @@ describe('CH7 — line/area series honor a secondary value axis (§21.2.2.*)', (
       expect(rec.texts.some(t => t.text === 'Rate')).toBe(false);
     });
   }
+
+  it('paints the right-axis title bottom-to-top with its authored font', () => {
+    const rec = ringRecordingCtx();
+    const model = comboModel('line', true);
+    model.secondaryValAxis = {
+      ...(model.secondaryValAxis as NonNullable<ChartModel['secondaryValAxis']>),
+      title: 'Rate',
+      titleFontFace: 'Aptos Narrow',
+      titleFontSizeHpt: 900,
+      titleFontBold: false,
+    };
+    renderChart(rec.ctx, model, RECT, 1);
+
+    expect(rec.rotates).toContain(-Math.PI / 2);
+    const title = rec.fontTexts.find(text => text.text === 'Rate');
+    expect(title?.font).toContain('9px');
+    expect(title?.font).toContain('Aptos Narrow');
+  });
 });
 
 // ─── CH9 — line/area marker detail, error bars, per-point labels, smooth,
@@ -3295,6 +3353,82 @@ describe('#738 — explicit majorUnit honored on every value axis (§21.2.2.103)
   });
 });
 
+describe('authored minor tick marks are painted between major ticks', () => {
+  const shortHorizontal = (segment: Seg): boolean =>
+    Math.abs(segment.y1 - segment.y0) < 0.01
+    && Math.abs(segment.x1 - segment.x0) > 0
+    && Math.abs(segment.x1 - segment.x0) <= 12;
+  const shortVertical = (segment: Seg): boolean =>
+    Math.abs(segment.x1 - segment.x0) < 0.01
+    && Math.abs(segment.y1 - segment.y0) > 0
+    && Math.abs(segment.y1 - segment.y0) <= 12;
+
+  it('draws primary value-axis minor ticks for a line chart', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B', 'C'],
+      series: [series({ values: [10, 50, 90] })],
+      valMin: 0,
+      valMax: 100,
+      valAxisMajorUnit: 20,
+      valAxisMinorUnit: 5,
+      valAxisMajorTickMark: 'none',
+      valAxisMinorTickMark: 'cross',
+    }), RECT, 1);
+
+    expect(rec.segs.filter(segment => shortHorizontal(segment) && segment.x0 < RECT.w / 2).length)
+      .toBeGreaterThanOrEqual(15);
+  });
+
+  it('draws minor ticks on the independent secondary value axis', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B', 'C'],
+      series: [
+        series({ values: [1, 2, 3] }),
+        series({ values: [10, 50, 90], useSecondaryAxis: true }),
+      ],
+      secondaryValAxis: {
+        min: 0,
+        max: 100,
+        title: null,
+        hidden: false,
+        majorTickMark: 'none',
+        minorTickMark: 'cross',
+        lineHidden: false,
+        majorUnit: 20,
+        minorUnit: 5,
+      },
+    }), RECT, 1);
+
+    expect(rec.segs.filter(segment => shortHorizontal(segment) && segment.x0 > RECT.w / 2).length)
+      .toBeGreaterThanOrEqual(15);
+  });
+
+  it('draws both numeric X- and Y-axis minor ticks for scatter', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'scatter',
+      series: [series({ values: [10, 50, 90], categories: ['10', '50', '90'] })],
+      valMin: 0,
+      valMax: 100,
+      valAxisMajorUnit: 20,
+      valAxisMinorUnit: 5,
+      catAxisMajorUnit: 20,
+      catAxisMinorUnit: 5,
+      valAxisMajorTickMark: 'none',
+      catAxisMajorTickMark: 'none',
+      valAxisMinorTickMark: 'cross',
+      catAxisMinorTickMark: 'cross',
+    }), RECT, 1);
+
+    expect(rec.segs.filter(shortHorizontal).length).toBeGreaterThanOrEqual(15);
+    expect(rec.segs.filter(shortVertical).length).toBeGreaterThanOrEqual(15);
+  });
+});
+
 /** Recording context that counts rotate() calls and captures fillText, for the
  *  category-label rotation / tickLblPos tests. */
 function rotateRecordingCtx(): { ctx: CanvasRenderingContext2D; rotates: number[]; texts: string[] } {
@@ -4199,6 +4333,49 @@ describe('CH15 — chartEx box-and-whisker', () => {
     expect(lineRole.every(segment => segment.lw === 2)).toBe(true);
   });
 
+  it('overlays multiple series at one category using the full category width', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexBox: {
+        categories: ['A'],
+        series: [
+          {
+            name: 'S1', color: '5B9BD5', valuesByCategory: [[1, 2, 3, 4]],
+            meanMarker: false, meanLine: false, showOutliers: false, showNonoutliers: false,
+            quartileMethod: 'inclusive',
+          },
+          {
+            name: 'S2', color: 'ED7D31', valuesByCategory: [[2, 3, 4, 5]],
+            meanMarker: false, meanLine: false, showOutliers: false, showNonoutliers: false,
+            quartileMethod: 'inclusive',
+          },
+        ],
+      },
+    }), RECT, 1);
+
+    expect(rec.rects).toHaveLength(2);
+    expect(rec.rects[0].x).toBeCloseTo(rec.rects[1].x, 5);
+    expect(rec.rects[0].w).toBeCloseTo(rec.rects[1].w, 5);
+  });
+
+  it('uses the box/whisker semantic outline for Chart Style NoStyle only', () => {
+    const noStyle = segRecordingCtx();
+    renderChart(noStyle.ctx, boxModel({
+      chartexDataPointStyle: { lineHidden: true, lineNoStyle: true },
+      chartexDataPointLineStyle: { lineHidden: true, lineNoStyle: true },
+      chartexDataPointMarkerStyle: { lineHidden: true, lineNoStyle: true },
+    }), RECT, 1);
+    expect(noStyle.segs.some(segment => segment.ss.toLowerCase() === '#ed7d31')).toBe(true);
+
+    const explicitNoFill = segRecordingCtx();
+    renderChart(explicitNoFill.ctx, boxModel({
+      chartexDataPointStyle: { lineHidden: true },
+      chartexDataPointLineStyle: { lineHidden: true },
+      chartexDataPointMarkerStyle: { lineHidden: true },
+    }), RECT, 1);
+    expect(explicitNoFill.segs.some(segment => segment.ss.toLowerCase() === '#ed7d31')).toBe(false);
+  });
+
   it('lets an explicit series line override a hidden mean-line style', () => {
     const rec = segRecordingCtx();
     renderChart(rec.ctx, boxModel({
@@ -4406,6 +4583,15 @@ describe('CH15 — chartEx sunburst', () => {
     expect(sweeps.length).toBeGreaterThanOrEqual(2);
     expect(sweeps[0] / sweeps[1]).toBeCloseTo(2, 1);
   });
+
+  it('draws an authored top legend outside the rings', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel({ showLegend: true, legendPos: 't' }), RECT, 1);
+    const legendLabels = rec.fontTexts
+      .filter(text => text.fill !== '#ffffff')
+      .map(text => text.text);
+    expect(legendLabels).toEqual(expect.arrayContaining(['Branch A', 'Branch B']));
+  });
 });
 
 // CH15 — chartEx treemap. The parser supplies the same root→leaf rows as
@@ -4443,6 +4629,29 @@ describe('CH15 — chartEx treemap', () => {
     const fills = rec.rects.map(r => r.fs.toUpperCase());
     expect(fills).toContain('#5B9BD5');
     expect(fills).toContain('#ED7D31');
+  });
+
+  it('keeps repeated terminal labels as distinct tiles and legend entries', () => {
+    const rec = recordingCtx();
+    const model = baseModel({
+      chartType: 'treemap',
+      chartexAccents: ['5B9BD5', 'ED7D31', 'A5A5A5'],
+      chartexTreemap: {
+        parentLabelLayout: 'none',
+        rows: [
+          { path: ['Repeat'], size: 3 },
+          { path: ['Repeat'], size: 2 },
+          { path: ['Repeat'], size: 1 },
+        ],
+      },
+      showLegend: true,
+      legendPos: 't',
+    });
+    renderChart(rec.ctx, model, RECT, 1);
+
+    const tiles = rec.rects.filter(rect => rect.w > 20 && rect.h > 20);
+    expect(tiles).toHaveLength(3);
+    expect(rec.texts.filter(text => text.text === 'Repeat').length).toBeGreaterThanOrEqual(6);
   });
 
   it('does not paint padded parent frames for overlapping parent labels', () => {

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1517,9 +1517,160 @@ describe('CH3 — labels are locale-independent (§18.8.30)', () => {
     expect(connectors).toHaveLength(2);
     expect(connectors.every(segment => segment.lw === 2)).toBe(true);
   });
+
+  it('keeps semantic data-point fills when the ChartEx series shape has noFill', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'Drop', 'End'],
+      series: [series({
+        name: 'W',
+        values: [10, -2, 8],
+        chartexStyle: { fillHidden: true, lineColors: ['4472C4'] },
+      })],
+      subtotalIndices: [2],
+      chartexDataPointStyle: { fillColors: ['5B9BD5', 'ED7D31', 'A5A5A5'] },
+    }), RECT, 1);
+
+    expect(rec.rects.map(rect => rect.fs.toUpperCase())).toEqual([
+      '#5B9BD5', '#ED7D31', '#A5A5A5',
+    ]);
+  });
+
+  it('suppresses waterfall connectors when CT_SeriesElementVisibilities says false', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'Change', 'End'],
+      series: [series({ name: 'W', values: [10, -2, 8] })],
+      subtotalIndices: [2],
+      chartexConnectorLines: false,
+      chartexDataPointLineStyle: { lineColors: ['0070C0'], lineWidthEmu: 25400 },
+    }), RECT, 1);
+    expect(rec.segs.filter(segment => segment.ss.toLowerCase() === '#0070c0')).toHaveLength(0);
+  });
+
+  it('draws authored waterfall minor ticks', () => {
+    const count = (minorTick: ChartModel['valAxisMinorTickMark']): number => {
+      const rec = segRecordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType: 'waterfall', categories: ['Start', 'End'],
+        series: [series({ values: [3, 23] })], subtotalIndices: [1],
+        valMin: 3, valMax: 23, valAxisMajorUnit: 10, valAxisMinorUnit: 4,
+        valAxisMajorGridlines: false, valAxisMinorGridlines: false,
+        valAxisMajorTickMark: 'none', valAxisMinorTickMark: minorTick,
+      }), RECT, 1);
+      return rec.segs.filter(segment =>
+        Math.abs(segment.y1 - segment.y0) < 0.01
+        && Math.abs(segment.x1 - segment.x0) > 0
+        && Math.abs(segment.x1 - segment.x0) <= 12
+      ).length;
+    };
+    expect(count('cross') - count('none')).toBe(4);
+  });
 });
 
 describe('ChartEx flat layouts dispatch to semantic renderers', () => {
+  it('resolves clustered-column automatic style colors by series, not category', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredColumn', categories: ['A', 'B', 'C'],
+      showLegend: true,
+      legendPos: 'r',
+      series: [series({
+        name: 'Histogram', values: [3, 2, 1], chartexFormatIdx: 2,
+      })],
+      chartexDataPointStyle: { fillColors: ['1F6A85', 'ED7D31', '70AD47'] },
+    }), RECT, 1);
+
+    expect(rec.rects.map(rect => rect.fs.toUpperCase())).toEqual([
+      '#70AD47', '#70AD47', '#70AD47', '#70AD47',
+    ]);
+  });
+
+  it('keeps non-contiguous ChartEx series format colors aligned with legend swatches', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredColumn', categories: ['A', 'B'],
+      showLegend: true,
+      legendPos: 'r',
+      series: [
+        series({ name: 'First', values: [3, 2], chartexFormatIdx: 0 }),
+        series({ name: 'Third format', values: [1, 4], chartexFormatIdx: 2 }),
+      ],
+      chartexDataPointStyle: { fillColors: ['1F6A85', 'ED7D31', '70AD47'] },
+    }), RECT, 1);
+
+    const colors = rec.rects.map(rect => rect.fs.toUpperCase());
+    expect(colors.filter(color => color === '#1F6A85')).toHaveLength(3);
+    expect(colors.filter(color => color === '#70AD47')).toHaveLength(3);
+    expect(colors).not.toContain('#ED7D31');
+  });
+
+  it('keeps an explicit ChartEx data-point noFill transparent in the legend', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredColumn', categories: ['A', 'B'],
+      showLegend: true,
+      legendPos: 'r',
+      series: [series({ name: 'Transparent', values: [3, 2] })],
+      chartexDataPointStyle: {
+        fillHidden: true,
+        fillNoStyle: false,
+        lineColors: ['1F6A85'],
+      },
+    }), RECT, 1);
+
+    expect(rec.rects).toHaveLength(0);
+    expect(rec.strokeRects).toHaveLength(3);
+  });
+
+  it('applies clustered-column point paint and indexed series labels', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredColumn', categories: ['A', 'B'],
+      series: [
+        series({ name: 'First', values: [1, 2] }),
+        series({
+          name: 'Second', values: [3, 4],
+          dataPointOverrides: [
+            { idx: 0, color: '112233', fillHidden: false, lineColor: '778899', lineWidthEmu: 25400, lineDash: 'dash', lineHidden: false },
+            { idx: 1, fillHidden: true, lineHidden: true },
+          ],
+          dataLabelColors: ['445566', null],
+          seriesDataLabels: {
+            showVal: true, showCatName: false, showSerName: false, showPercent: false,
+            formatCode: '0.0', position: 'outEnd',
+          },
+          dataLabelOverrides: [
+            { idx: 0, text: '', formatCode: '0.00', fontColor: '445566' },
+            { idx: 1, text: '', deleted: true },
+          ],
+        }),
+      ],
+      chartexDataPointStyle: { fillColors: ['5B9BD5'], lineColors: ['FFFFFF'] },
+    }), RECT, 1);
+
+    expect(rec.rects.filter(rect => rect.fs.toUpperCase() === '#112233')).toHaveLength(1);
+    expect(rec.rects).toHaveLength(3);
+    expect(rec.strokeRects.some(rect => rect.ss.toUpperCase() === '#778899')).toBe(true);
+    expect(rec.texts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ text: '3.00', fillStyle: '#445566' }),
+    ]));
+    expect(rec.texts.map(text => text.text)).not.toContain('4.0');
+  });
+
+  it('bounds clustered-column primitives across multiple visible series', () => {
+    const rec = recordingCtx();
+    const values = Array.from({ length: 6_000 }, () => 1);
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredColumn', categories: [],
+      series: [series({ values }), series({ values })],
+    }), RECT, 1);
+    expect(rec.rects).toHaveLength(0);
+    expect(rec.texts.map(text => text.text)).toContain('(too many data points)');
+  });
+
   it.each(['clusteredColumn', 'funnel', 'paretoLine'])(
     '%s does not fall back to the unsupported-chart label',
     chartType => {
@@ -1538,6 +1689,77 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
       }
     },
   );
+
+  it.each(['waterfall', 'funnel'])(
+    '%s renders every numeric data point when the optional category dimension is unavailable',
+    chartType => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: [],
+        series: [series({ values: [3, 2, 1] })],
+      }), RECT, 1);
+
+      expect(rec.rects).toHaveLength(3);
+    },
+  );
+
+  it.each(['waterfall', 'funnel'])(
+    '%s preserves category-only point slots when the string dimension is longer',
+    chartType => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['A', 'B', 'C'],
+        series: [series({ values: [3] })],
+      }), RECT, 1);
+
+      expect(rec.rects).toHaveLength(3);
+      expect(rec.texts.map(text => text.text)).toEqual(
+        expect.arrayContaining(['A', 'B', 'C']),
+      );
+    },
+  );
+
+  it.each(['waterfall', 'funnel', 'clusteredColumn'])(
+    '%s handles a large numeric dimension without variadic-argument overflow',
+    chartType => {
+      const values = Array.from({ length: 150_000 }, (_, index) => (index % 5) + 1);
+      const rec = recordingCtx();
+      expect(() => renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: [],
+        catAxisHidden: true,
+        valAxisHidden: true,
+        series: [series({
+          values,
+          seriesDataLabels: {
+            showVal: false,
+            showCatName: false,
+            showSerName: false,
+            showPercent: false,
+          },
+        })],
+      }), { x: 0, y: 0, w: 320, h: 180 }, 1)).not.toThrow();
+      expect(rec.rects).toHaveLength(0);
+      expect(rec.texts.map(text => text.text)).toContain('(too many data points)');
+    },
+  );
+
+  it('keeps the Pareto category-axis rule while suppressing ordinal labels', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'paretoLine',
+      categories: [],
+      series: [series({ values: [3, 2, 1] })],
+      catAxisLineColor: 'C00000',
+      catAxisMajorTickMark: 'none',
+    }), RECT, 1);
+
+    expect(rec.segs.some(segment =>
+      segment.ss.toLowerCase() === '#c00000' && segment.y0 === segment.y1
+    )).toBe(true);
+  });
 
   it('waterfall uses locale-neutral English semantic legend labels', () => {
     const rec = recordingCtx();
@@ -1836,6 +2058,7 @@ function markerRecordingCtx(): {
   ctx: CanvasRenderingContext2D;
   arcs: ArcCall[];
   fillRects: FillRectCall[];
+  fillCalls: number;
   beziers: number;
   texts: TextCall[];
   segments: Array<Array<{ x: number; y: number }>>;
@@ -1846,6 +2069,7 @@ function markerRecordingCtx(): {
   const segments: Array<Array<{ x: number; y: number }>> = [];
   let current: Array<{ x: number; y: number }> | null = null;
   let beziers = 0;
+  let fillCalls = 0;
   const state: Record<string, unknown> = {
     font: '10px sans-serif',
     fillStyle: '#000',
@@ -1885,6 +2109,8 @@ function markerRecordingCtx(): {
           return (x: number, y: number, rad: number) => { arcs.push({ x, y, r: rad }); push(x, y); };
         case 'fillRect':
           return (x: number, y: number, w: number, h: number) => fillRects.push({ x, y, w, h });
+        case 'fill':
+          return () => { fillCalls += 1; };
         case 'bezierCurveTo':
           return () => { beziers += 1; };
         case 'fillText':
@@ -1903,6 +2129,7 @@ function markerRecordingCtx(): {
     ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D,
     arcs, fillRects, texts, segments,
     get beziers() { return beziers; },
+    get fillCalls() { return fillCalls; },
   } as never;
 }
 
@@ -2629,6 +2856,7 @@ interface RingRecorded {
   fills: string[];
   fontTexts: FontText[];
   rotates: number[];
+  strokes: Array<{ strokeStyle: string; lineWidth: number }>;
 }
 
 /** Recording context that also captures arc() (radius + angles) and, for each
@@ -2640,6 +2868,7 @@ function ringRecordingCtx(): RingRecorded {
   const fills: string[] = [];
   const fontTexts: FontText[] = [];
   const rotates: number[] = [];
+  const strokes: RingRecorded['strokes'] = [];
   const state: Record<string, unknown> = {
     font: '10px sans-serif', fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
     textAlign: 'start', textBaseline: 'alphabetic', globalAlpha: 1,
@@ -2670,8 +2899,13 @@ function ringRecordingCtx(): RingRecorded {
         case 'createLinearGradient':
         case 'createRadialGradient':
           return () => ({ addColorStop() {} });
+        case 'stroke':
+          return () => strokes.push({
+            strokeStyle: String(state.strokeStyle),
+            lineWidth: Number(state.lineWidth),
+          });
         case 'save': case 'restore': case 'beginPath': case 'closePath':
-        case 'stroke': case 'moveTo': case 'lineTo': case 'bezierCurveTo':
+        case 'moveTo': case 'lineTo': case 'bezierCurveTo':
         case 'quadraticCurveTo': case 'rect': case 'fillRect': case 'strokeRect':
         case 'clearRect': case 'strokeText': case 'setLineDash':
         case 'translate': return () => undefined;
@@ -2685,7 +2919,14 @@ function ringRecordingCtx(): RingRecorded {
     },
     set(_t, prop: string, value) { state[prop] = value; return true; },
   };
-  return { ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D, arcs, fills, fontTexts, rotates };
+  return {
+    ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D,
+    arcs,
+    fills,
+    fontTexts,
+    rotates,
+    strokes,
+  };
 }
 
 /** Outer/inner ring radii for a pie/doughnut: the outer radius is the largest
@@ -3381,6 +3622,111 @@ describe('authored minor tick marks are painted between major ticks', () => {
       .toBeGreaterThanOrEqual(15);
   });
 
+  it('accepts a positive authored minor unit larger than the major unit', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B', 'C'],
+      series: [series({ values: [10, 50, 90] })],
+      valMin: 0,
+      valMax: 100,
+      valAxisMajorUnit: 20,
+      valAxisMinorUnit: 30,
+      valAxisMajorTickMark: 'none',
+      valAxisMinorTickMark: 'cross',
+    }), RECT, 1);
+
+    // 30 and 90 are minor positions; 60 coincides with a major tick and is
+    // intentionally not double-painted.
+    expect(rec.segs.filter(segment => shortHorizontal(segment) && segment.x0 < RECT.w / 2))
+      .toHaveLength(2);
+  });
+
+  it('anchors minor gridlines and ticks at a non-zero scale minimum', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B', 'C'],
+      series: [series({ values: [3, 13, 23] })],
+      valMin: 3,
+      valMax: 23,
+      valAxisMajorUnit: 10,
+      valAxisMinorUnit: 4,
+      valAxisMajorGridlines: false,
+      valAxisMinorGridlines: true,
+      valAxisMinorGridlineColor: '123456',
+      valAxisMajorTickMark: 'none',
+      valAxisMinorTickMark: 'cross',
+    }), RECT, 1);
+
+    const minorGridYs = rec.segs
+      .filter(segment => segment.ss === '#123456' && Math.abs(segment.x1 - segment.x0) > 50)
+      .map(segment => segment.y0);
+    expect(minorGridYs).toHaveLength(4);
+    const minorTicks = rec.segs.filter(segment =>
+      shortHorizontal(segment)
+      && minorGridYs.some(y => Math.abs(y - segment.y0) < 1e-6)
+    );
+    expect(minorTicks).toHaveLength(4);
+  });
+
+  it('bounds hostile or non-progressing minor units', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A', 'B'],
+      series: [series({ values: [1, 2] })],
+      valMin: 1, valMax: 2, valAxisMajorUnit: 0.5,
+      valAxisMinorUnit: Number.MIN_VALUE,
+      valAxisMajorGridlines: false, valAxisMinorGridlines: true,
+      valAxisMajorTickMark: 'none', valAxisMinorTickMark: 'cross',
+    }), RECT, 1);
+    expect(rec.segs.length).toBeLessThan(100);
+
+    const bounded = segRecordingCtx();
+    renderChart(bounded.ctx, baseModel({
+      chartType: 'line', categories: ['A', 'B'],
+      series: [series({ values: [0, 1] })],
+      valMin: 0, valMax: 1, valAxisMajorUnit: 0.5,
+      valAxisMinorUnit: 1e-12,
+      valAxisMajorGridlines: false, valAxisMinorGridlines: true,
+      valAxisMajorTickMark: 'none', valAxisMinorTickMark: 'none',
+    }), RECT, 1);
+    expect(bounded.segs.length).toBeLessThanOrEqual(10_100);
+  });
+
+  it('draws a minor gridline when the positive minor unit exceeds the major unit', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A', 'B'],
+      series: [series({ values: [3, 23] })],
+      valMin: 3, valMax: 23,
+      valAxisMajorUnit: 10, valAxisMinorUnit: 12,
+      valAxisMajorGridlines: false,
+      valAxisMinorGridlines: true,
+      valAxisMinorGridlineColor: '123456',
+    }), RECT, 1);
+    expect(rec.segs.filter(segment =>
+      segment.ss === '#123456' && Math.abs(segment.x1 - segment.x0) > 50
+    )).toHaveLength(1);
+  });
+
+  it('preserves an authored major-gridline width without a solidFill color', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A', 'B'],
+      series: [series({ values: [0, 20] })],
+      valMin: 0, valMax: 20, valAxisMajorUnit: 10,
+      valAxisMajorGridlines: true,
+      valAxisGridlineWidthEmu: 25400,
+      valAxisGridlineDash: 'dash',
+    }), RECT, 1);
+    const gridlines = rec.segs.filter(segment =>
+      Math.abs(segment.x1 - segment.x0) > 50 && segment.ss === '#e0e0e0'
+    );
+    expect(gridlines).toHaveLength(3);
+    expect(gridlines.every(segment => segment.lw === 2)).toBe(true);
+  });
+
   it('draws minor ticks on the independent secondary value axis', () => {
     const rec = segRecordingCtx();
     renderChart(rec.ctx, baseModel({
@@ -3609,6 +3955,53 @@ describe('CH6-follow — series trendlines (commit 3)', () => {
     expect(withTrend.segs.some(s => s.dashed)).toBe(false);
   });
 
+  it('honors the trendline DrawingML dash preset', () => {
+    const rec = dashSegRecordingCtx();
+    renderChart(rec.ctx, lineWithTrend({
+      trendLines: [{ trendlineType: 'linear', lineDash: 'dash' }],
+    }), RECT, 1);
+    expect(rec.segs.some(segment => segment.dashed)).toBe(true);
+  });
+
+  it('suppresses a trendline with an authored DrawingML noFill line', () => {
+    const without = dashSegRecordingCtx();
+    renderChart(without.ctx, lineWithTrend({}), RECT, 1);
+    const hidden = dashSegRecordingCtx();
+    renderChart(hidden.ctx, lineWithTrend({
+      trendLines: [{ trendlineType: 'linear', lineHidden: true }],
+    }), RECT, 1);
+    expect(hidden.segs).toEqual(without.segs);
+  });
+
+  it('applies the authored major-gridline dash without leaking it to other strokes', () => {
+    const rec = dashSegRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B', 'C', 'D'],
+      series: [series({ name: 'S', values: [1, 3, 5, 7] })],
+      valAxisGridlineDash: 'dash',
+    }), RECT, 1);
+    expect(rec.segs.some(segment => segment.dashed)).toBe(true);
+    expect(rec.segs.some(segment => !segment.dashed)).toBe(true);
+  });
+
+  it('applies minor-gridline paint independently from the major gridlines', () => {
+    const rec = dashSegRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B', 'C', 'D'],
+      series: [series({ name: 'S', values: [0, 2, 4, 6] })],
+      valMin: 0,
+      valMax: 6,
+      valAxisMajorUnit: 2,
+      valAxisMinorUnit: 1,
+      valAxisMinorGridlines: true,
+      valAxisMinorGridlineDash: 'dot',
+    }), RECT, 1);
+    expect(rec.segs.some(segment => segment.dashed)).toBe(true);
+    expect(rec.segs.some(segment => !segment.dashed)).toBe(true);
+  });
+
   it('a movingAvg trendline without prstDash draws an additional solid line', () => {
     const noTrend = dashSegRecordingCtx();
     renderChart(noTrend.ctx, lineWithTrend({}), RECT, 1);
@@ -3708,6 +4101,23 @@ describe('CH13 — stock chart (high/low/close)', () => {
     // stockHiLowLineColor omitted → renderer default '#595959'.
     renderChart(rec.ctx, stockModel({ stockHiLowLineColor: null }), RECT, 1);
     expect(hiLoLines(rec.segs).length).toBe(3);
+  });
+
+  it('draws authored stock-chart minor ticks', () => {
+    const count = (minorTick: ChartModel['valAxisMinorTickMark']): number => {
+      const rec = segRecordingCtx();
+      renderChart(rec.ctx, stockModel({
+        valMin: 3, valMax: 23, valAxisMajorUnit: 10, valAxisMinorUnit: 4,
+        valAxisMajorGridlines: false, valAxisMinorGridlines: false,
+        valAxisMajorTickMark: 'none', valAxisMinorTickMark: minorTick,
+      }), RECT, 1);
+      return rec.segs.filter(segment =>
+        Math.abs(segment.y1 - segment.y0) < 0.01
+        && Math.abs(segment.x1 - segment.x0) > 0
+        && Math.abs(segment.x1 - segment.x0) <= 12
+      ).length;
+    };
+    expect(count('cross') - count('none')).toBe(4);
   });
 });
 
@@ -4148,6 +4558,138 @@ describe('CH15 — chartEx box-and-whisker', () => {
     expect(rec.arcs.length).toBe(CAT1_ORANGE.length);
   });
 
+  it('fills box-and-whisker sample points when the marker role uses Chart Style NoStyle', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexDataPointMarkerStyle: {
+        fillHidden: true,
+        fillNoStyle: true,
+        lineHidden: true,
+        lineNoStyle: true,
+      },
+      chartexBox: {
+        categories: ['Category 1'],
+        series: [{
+          name: 'S1', color: 'ED7D31', valuesByCategory: [CAT1_ORANGE],
+          meanMarker: false, meanLine: false, showOutliers: true, showNonoutliers: true,
+          quartileMethod: 'exclusive',
+        }],
+      },
+    }), RECT, 1);
+
+    expect(rec.arcs).toHaveLength(CAT1_ORANGE.length);
+    expect(rec.fillCalls).toBe(CAT1_ORANGE.length);
+  });
+
+  it('keeps box-and-whisker sample points transparent for an explicit marker noFill', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexDataPointMarkerStyle: { fillHidden: true, lineHidden: true },
+      chartexBox: {
+        categories: ['Category 1'],
+        series: [{
+          name: 'S1', color: 'ED7D31', valuesByCategory: [CAT1_ORANGE],
+          meanMarker: false, meanLine: false, showOutliers: true, showNonoutliers: true,
+          quartileMethod: 'exclusive',
+        }],
+      },
+    }), RECT, 1);
+
+    expect(rec.arcs).toHaveLength(CAT1_ORANGE.length);
+    expect(rec.fillCalls).toBe(0);
+  });
+
+  it('does not draw box sample points when the Chart Style marker symbol is none', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexMarkerSymbol: 'none',
+      chartexBox: {
+        categories: ['Category 1'],
+        series: [{
+          name: 'S1', color: 'ED7D31', valuesByCategory: [CAT1_ORANGE],
+          meanMarker: false, meanLine: false, showOutliers: true, showNonoutliers: true,
+          quartileMethod: 'exclusive',
+        }],
+      },
+    }), RECT, 1);
+    expect(rec.arcs).toHaveLength(0);
+  });
+
+  it('keeps a series-local noFill line suppressed over Chart Style NoStyle', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexDataPointStyle: { lineHidden: true, lineNoStyle: true },
+      chartexDataPointLineStyle: { lineHidden: true, lineNoStyle: true },
+      chartexDataPointMarkerStyle: { lineHidden: true, lineNoStyle: true },
+      valAxisHidden: true,
+      catAxisHidden: true,
+      chartexBox: {
+        categories: ['Category 1'],
+        series: [{
+          name: 'S1', color: 'ED7D31', valuesByCategory: [CAT1_ORANGE],
+          meanMarker: false, meanLine: false, showOutliers: false, showNonoutliers: false,
+          quartileMethod: 'exclusive', chartexStyle: { lineHidden: true },
+        }],
+      },
+    }), RECT, 1);
+    expect(rec.segs).toHaveLength(0);
+  });
+
+  it('draws authored box-and-whisker minor ticks', () => {
+    const count = (minorTick: ChartModel['valAxisMinorTickMark']): number => {
+      const rec = segRecordingCtx();
+      renderChart(rec.ctx, boxModel({
+        valMin: 3, valMax: 23, valAxisMajorUnit: 10, valAxisMinorUnit: 4,
+        valAxisMajorGridlines: false, valAxisMinorGridlines: false,
+        valAxisMajorTickMark: 'none', valAxisMinorTickMark: minorTick,
+      }), RECT, 1);
+      return rec.segs.filter(segment =>
+        Math.abs(segment.y1 - segment.y0) < 0.01
+        && Math.abs(segment.x1 - segment.x0) > 0
+        && Math.abs(segment.x1 - segment.x0) <= 12
+      ).length;
+    };
+    expect(count('cross') - count('none')).toBe(4);
+  });
+
+  it('uses the Chart Style marker size in points for box sample dots', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexMarkerSizePt: 6,
+      chartexBox: {
+        categories: ['Category 1'],
+        series: [{
+          name: 'S1', color: 'ED7D31', valuesByCategory: [[1, 2, 3]],
+          meanMarker: false, meanLine: false, showOutliers: true, showNonoutliers: true,
+          quartileMethod: 'exclusive',
+        }],
+      },
+    }), RECT, 2);
+
+    expect(rec.arcs).toHaveLength(3);
+    expect(rec.arcs.every(arc => arc.r === 6)).toBe(true);
+  });
+
+  it('uses the authored Chart Style marker symbol for box sample points', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexMarkerSizePt: 6,
+      chartexMarkerSymbol: 'square',
+      chartexBox: {
+        categories: ['Category 1'],
+        series: [{
+          name: 'S1', color: 'ED7D31', valuesByCategory: [[1, 2, 3]],
+          meanMarker: false, meanLine: false, showOutliers: true, showNonoutliers: true,
+          quartileMethod: 'exclusive',
+        }],
+      },
+    }), RECT, 1);
+
+    expect(rec.arcs).toHaveLength(0);
+    // One IQR box plus three square raw-point markers.
+    expect(rec.fillRects.length).toBeGreaterThanOrEqual(4);
+  });
+
   it('uses median-of-halves quartiles for inclusive and exclusive methods', () => {
     const values = [1, 2, 3, 4, 100];
     const exclusive = markerRecordingCtx();
@@ -4333,7 +4875,7 @@ describe('CH15 — chartEx box-and-whisker', () => {
     expect(lineRole.every(segment => segment.lw === 2)).toBe(true);
   });
 
-  it('overlays multiple series at one category using the full category width', () => {
+  it('partitions one category among its populated box-and-whisker series', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, boxModel({
       chartexBox: {
@@ -4354,8 +4896,33 @@ describe('CH15 — chartEx box-and-whisker', () => {
     }), RECT, 1);
 
     expect(rec.rects).toHaveLength(2);
-    expect(rec.rects[0].x).toBeCloseTo(rec.rects[1].x, 5);
+    expect(rec.rects[0].x + rec.rects[0].w).toBeCloseTo(rec.rects[1].x, 5);
     expect(rec.rects[0].w).toBeCloseTo(rec.rects[1].w, 5);
+  });
+
+  it('uses the full category width when only one series has data in that category', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexBox: {
+        categories: ['A', 'B'],
+        series: [
+          {
+            name: 'S1', color: '5B9BD5', valuesByCategory: [[1, 2, 3, 4], []],
+            meanMarker: false, meanLine: false, showOutliers: false, showNonoutliers: false,
+            quartileMethod: 'inclusive',
+          },
+          {
+            name: 'S2', color: 'ED7D31', valuesByCategory: [[], [2, 3, 4, 5]],
+            meanMarker: false, meanLine: false, showOutliers: false, showNonoutliers: false,
+            quartileMethod: 'inclusive',
+          },
+        ],
+      },
+    }), RECT, 1);
+
+    expect(rec.rects).toHaveLength(2);
+    expect(rec.rects[0].w).toBeCloseTo(rec.rects[1].w, 5);
+    expect(rec.rects[0].w).toBeGreaterThan(50);
   });
 
   it('uses the box/whisker semantic outline for Chart Style NoStyle only', () => {
@@ -4553,7 +5120,17 @@ describe('CH15 — chartEx sunburst', () => {
 
   it('draws white segment labels for the branch/stem/leaf names', () => {
     const rec = ringRecordingCtx();
-    renderChart(rec.ctx, sunburstModel(), RECT, 1);
+    renderChart(rec.ctx, sunburstModel({
+      series: [series({
+        values: [],
+        seriesDataLabels: {
+          showVal: false,
+          showCatName: true,
+          showSerName: false,
+          showPercent: false,
+        },
+      })],
+    }), RECT, 1);
     const whiteLabels = rec.fontTexts.filter(t => t.fill === '#ffffff').map(t => t.text);
     // Labels are word-wrapped, so assert on the first word of each name.
     const joined = whiteLabels.join('').replace(/\s/g, '');
@@ -4562,9 +5139,55 @@ describe('CH15 — chartEx sunburst', () => {
     expect(joined).toContain('Leaf');
   });
 
-  it('orients category labels radially instead of tangentially', () => {
+  it('does not invent ring labels when the ChartEx series omits dataLabels', () => {
     const rec = ringRecordingCtx();
     renderChart(rec.ctx, sunburstModel(), RECT, 1);
+    expect(rec.fontTexts.map(text => text.text)).not.toEqual(
+      expect.arrayContaining(['Branch', 'Stem', 'Leaf']),
+    );
+  });
+
+  it('applies the authored ChartEx series outline ahead of the linked Chart Style', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel({
+      chartexDataPointStyle: { lineHidden: true },
+      series: [series({
+        values: [],
+        lineColor: 'FFFFFF',
+        lineWidthEmu: 12700,
+        lineHidden: false,
+      })],
+    }), RECT, 4 / 3);
+
+    expect(rec.strokes.length).toBeGreaterThan(0);
+    expect(rec.strokes.every(stroke =>
+      stroke.strokeStyle === '#FFFFFF' && Math.abs(stroke.lineWidth - 4 / 3) < 1e-6
+    )).toBe(true);
+  });
+
+  it('honors explicit ChartEx series noFill over a visible linked outline', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel({
+      chartexDataPointStyle: { lineColors: ['FFFFFF'], lineWidthEmu: 12700 },
+      series: [series({ values: [], lineHidden: true })],
+    }), RECT, 4 / 3);
+
+    expect(rec.strokes).toHaveLength(0);
+  });
+
+  it('orients category labels radially instead of tangentially', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel({
+      series: [series({
+        values: [],
+        seriesDataLabels: {
+          showVal: false,
+          showCatName: true,
+          showSerName: false,
+          showPercent: false,
+        },
+      })],
+    }), RECT, 1);
     // Branch A owns 2/3 of the circle. Starting at -90°, its midpoint is 30°.
     // Radial text rotates by that midpoint; the former tangential layout used
     // 120° (midpoint + 90°).
@@ -4592,6 +5215,7 @@ describe('CH15 — chartEx sunburst', () => {
       .map(text => text.text);
     expect(legendLabels).toEqual(expect.arrayContaining(['Branch A', 'Branch B']));
   });
+
 });
 
 // CH15 — chartEx treemap. The parser supplies the same root→leaf rows as
@@ -4601,6 +5225,14 @@ describe('CH15 — chartEx treemap', () => {
     return baseModel({
       chartType: 'treemap',
       title: 'regions',
+      series: [series({
+        seriesDataLabels: {
+          showVal: false,
+          showCatName: true,
+          showSerName: false,
+          showPercent: false,
+        },
+      })],
       chartexAccents: ['5B9BD5', 'ED7D31', 'A5A5A5', 'FFC000', '4472C4', '70AD47'],
       chartexTreemap: {
         parentLabelLayout: 'banner',
@@ -4646,6 +5278,14 @@ describe('CH15 — chartEx treemap', () => {
       },
       showLegend: true,
       legendPos: 't',
+      series: [series({
+        seriesDataLabels: {
+          showVal: false,
+          showCatName: true,
+          showSerName: false,
+          showPercent: false,
+        },
+      })],
     });
     renderChart(rec.ctx, model, RECT, 1);
 
@@ -4653,6 +5293,7 @@ describe('CH15 — chartEx treemap', () => {
     expect(tiles).toHaveLength(3);
     expect(rec.texts.filter(text => text.text === 'Repeat').length).toBeGreaterThanOrEqual(6);
   });
+
 
   it('does not paint padded parent frames for overlapping parent labels', () => {
     const rec = recordingCtx();
@@ -4838,7 +5479,7 @@ describe('CH15 — chartEx treemap', () => {
     expect((plotClip as { h: number }).h).toBeCloseTo(maxY - minY, 5);
   });
 
-  it('honors ChartEx label visibility, separator, and inEnd placement', () => {
+  it('honors ChartEx label visibility, separator, and authored inEnd placement', () => {
     const rec = recordingCtx();
     const model = treemapModel();
     model.series = [series({
@@ -4883,6 +5524,15 @@ describe('CH15 — chartEx treemap', () => {
     expect(custom.map(text => text.text)).toEqual(expect.arrayContaining(['Custom East', '20']));
     expect(custom.every(text => text.fillStyle === '#222222')).toBe(true);
     expect(rec.texts.map(text => text.text)).not.toContain('East');
+  });
+
+  it('honors dataLabelHidden for treemap parent nodes', () => {
+    const rec = recordingCtx();
+    const model = treemapModel();
+    model.series[0].dataLabelOverrides = [{ idx: 0, text: '', deleted: true }];
+    renderChart(rec.ctx, model, RECT, 1);
+    expect(rec.texts.map(text => text.text)).not.toContain('Americas');
+    expect(rec.texts.map(text => text.text)).toContain('Asia');
   });
 });
 

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -314,7 +314,9 @@ function drawLegendSwatch(
   color: string,
   x: number, y: number, w: number, h: number,
   marker: LegendMarker | null = null,
-  fillPaint: Fill | null = null,
+  /** undefined = no structured override (use `color`); null = authored
+   * noFill; Fill = authored/resolved swatch paint. */
+  fillPaint: Fill | null | undefined = undefined,
   outlineColor: string | null = null,
   outlineWidthEmu: number | null = null,
   ptToPx = 1,
@@ -346,12 +348,14 @@ function drawLegendSwatch(
       drawMarker(ctx, x + w / 2, y + h / 2, marker.symbol, h * 0.58, marker.fill, marker.line, 1);
     }
   } else {
-    if (fillPaint) {
-      ctx.fillStyle = fillPaint.fillType === 'solid'
-        ? (fillPaint.color.startsWith('#') ? fillPaint.color : `#${fillPaint.color}`)
-        : (resolveFill(fillPaint, ctx, x, y, w, h, shapeRotationDeg) ?? color);
+    if (fillPaint !== null) {
+      if (fillPaint) {
+        ctx.fillStyle = fillPaint.fillType === 'solid'
+          ? (fillPaint.color.startsWith('#') ? fillPaint.color : `#${fillPaint.color}`)
+          : (resolveFill(fillPaint, ctx, x, y, w, h, shapeRotationDeg) ?? color);
+      }
+      ctx.fillRect(x, y, w, h);
     }
-    ctx.fillRect(x, y, w, h);
     if (outlineColor) {
       const outlineWidth = axisLineWidthPx(outlineWidthEmu, ptToPx);
       ctx.save();
@@ -377,7 +381,7 @@ interface LegendEntry {
   color: string;
   marker: LegendMarker | null;
   swatchStyle: LegendSwatchStyle;
-  fillPaint: Fill | null;
+  fillPaint: Fill | null | undefined;
   outlineColor: string | null;
   outlineWidthEmu: number | null;
 }
@@ -405,7 +409,7 @@ function buildLegendEntries(
       color: legendEntryColor(chartType, series, i, varyByPoint),
       marker: null, // pie/doughnut/varyColors keys are always filled swatches.
       swatchStyle: legendSwatchStyle(chartType),
-      fillPaint: fillPaints[i] ?? null,
+      fillPaint: i < fillPaints.length ? fillPaints[i] : undefined,
       outlineColor: null,
       outlineWidthEmu: null,
     }));
@@ -417,7 +421,7 @@ function buildLegendEntries(
     // A combo chart has multiple chart groups under one plotArea. The legend
     // key describes the individual series' group, not the first/primary group.
     swatchStyle: legendSwatchStyle(s.seriesType ?? chartType),
-    fillPaint: fillPaints[i] ?? s.fillPattern ?? null,
+    fillPaint: i < fillPaints.length ? fillPaints[i] : (s.fillPattern ?? undefined),
     outlineColor: s.lineHidden === true ? null : (s.lineColor ?? null),
     outlineWidthEmu: s.lineWidthEmu ?? null,
   }));
@@ -526,13 +530,15 @@ function drawLegend(
 /** Build the resolved legend text style for a chart (CH10). Absent legend
  *  `<c:txPr>` fields fall back to the historical defaults, keeping legends
  *  byte-stable for files that style nothing. */
-function legendTextStyle(chart: ChartModel): LegendTextStyle {
+function legendTextStyle(chart: ChartModel, ptToPx: number): LegendTextStyle {
   const face = resolveThemeFontRef(chart, chart.legendFontFace) ?? chart.themeMinorFontLatin;
   return {
     fontFamily: face ? `"${face}", Calibri, Arial, sans-serif` : 'sans-serif',
     color: chart.legendFontColor ? `#${chart.legendFontColor}` : '#333',
     bold: chart.legendFontBold ?? false,
-    sizePx: chart.legendFontSizeHpt != null ? chart.legendFontSizeHpt / 100 : null,
+    sizePx: chart.legendFontSizeHpt != null
+      ? (chart.legendFontSizeHpt / 100) * ptToPx
+      : null,
   };
 }
 
@@ -554,7 +560,7 @@ function drawLegendForLayout(
   shapeRotationDeg = 0,
 ): void {
   if (!leg) return;
-  const legStyle = legendTextStyle(chart);
+  const legStyle = legendTextStyle(chart, ptToPx);
   // §21.2.2.227 varyColors single-series bar: the legend lists one entry per
   // data point (colored like each bar), so the legend and the plot fill agree.
   const varyByPoint = chartVariesColorsByPoint(chart);
@@ -639,6 +645,42 @@ function drawAxisTick(
 /** Visit authored minor-unit positions between adjacent major ticks. OOXML does
  * not define the application's automatic minor unit, so an omitted
  * `<c:minorUnit>` deliberately produces no guessed positions. */
+const MAX_AXIS_TICKS = 10_000;
+
+function minorAxisValues(
+  min: number,
+  max: number,
+  majorStep: number,
+  minorUnit: number | null | undefined,
+): number[] {
+  const step = minorUnit != null && isFinite(minorUnit) && minorUnit > 0
+    ? minorUnit
+    : 0;
+  if (!(step > 0) || !(majorStep > 0)) return [];
+  const epsilon = Math.max(Math.abs(majorStep), Math.abs(step)) * 1e-8;
+  const values: number[] = [];
+  // Axis units advance from the authored/derived scale minimum. Anchoring at
+  // numeric zero shifts every minor division when an explicit non-zero min is
+  // present and can also double-paint a major position.
+  let iterations = 0;
+  for (let value = min + step;
+    value < max - epsilon && iterations < MAX_AXIS_TICKS;
+    iterations += 1) {
+    // IEEE-754 addition can stop progressing for a positive but sub-ULP unit.
+    // Reject that authored scale instead of hanging the renderer. The count
+    // cap also bounds hostile documents whose unit requests millions of marks.
+    if (!(value > min) || !isFinite(value)) break;
+    // A position shared with a major tick is already painted by the major
+    // layer; do not double-stroke it when the two authored units coincide.
+    const majorMultiple = (value - min) / majorStep;
+    if (Math.abs(majorMultiple - Math.round(majorMultiple)) > 1e-8) values.push(value);
+    const next = value + step;
+    if (!(next > value)) break;
+    value = next;
+  }
+  return values;
+}
+
 function forEachMinorTick(
   min: number,
   max: number,
@@ -646,17 +688,7 @@ function forEachMinorTick(
   minorUnit: number | null | undefined,
   visit: (value: number) => void,
 ): void {
-  const step = minorUnit != null && isFinite(minorUnit) && minorUnit > 0 && minorUnit < majorStep
-    ? minorUnit
-    : 0;
-  if (!(step > 0) || !(majorStep > 0)) return;
-  const epsilon = Math.abs(majorStep) * 1e-8;
-  const firstMajor = Math.ceil((min - epsilon) / majorStep) * majorStep;
-  for (let major = firstMajor; major < max - epsilon; major += majorStep) {
-    for (let value = major + step; value < major + majorStep - epsilon; value += step) {
-      if (value > min + epsilon && value < max - epsilon) visit(value);
-    }
-  }
+  for (const value of minorAxisValues(min, max, majorStep, minorUnit)) visit(value);
 }
 
 /** Stroke one horizontal value-axis gridline spanning the plot width at `gy`.
@@ -680,7 +712,7 @@ function strokeValueGridlineH(
   pw: number,
   gy: number,
   isZero: boolean,
-  grid?: { color: string; width: number; explicit: boolean },
+  grid?: { color: string; width: number; explicit: boolean; dash: number[] },
 ): void {
   if (grid && grid.explicit) {
     ctx.strokeStyle = grid.color;
@@ -689,15 +721,20 @@ function strokeValueGridlineH(
     ctx.strokeStyle = isZero ? '#aaa' : grid?.color ?? '#e0e0e0';
     ctx.lineWidth = isZero ? 1 : grid?.width ?? 0.5;
   }
+  const authoredDash = grid?.dash ?? [];
+  const previousDash = authoredDash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+  if (authoredDash.length > 0) ctx.setLineDash(authoredDash);
   ctx.beginPath();
   ctx.moveTo(px0, gy);
   ctx.lineTo(px0 + pw, gy);
   ctx.stroke();
+  if (authoredDash.length > 0) ctx.setLineDash(previousDash);
 }
 
 /** Resolve the value-axis MAJOR gridline stroke for `chart` at the current
- *  display scale. `explicit` is true when the file pinned a gridline color via
- *  `<c:valAx><c:majorGridlines><c:spPr><a:ln><a:solidFill>` — that flag tells
+ *  display scale. `explicit` is true when the file pinned any line property
+ *  (color, width, or dash) under `<c:valAx><c:majorGridlines><c:spPr><a:ln>`;
+ *  that flag tells
  *  `strokeValueGridlineH` to stroke every gridline in the resolved color
  *  uniformly (no `#aaa` zero-line emphasis), matching PowerPoint. With no
  *  explicit color the resolved `{ color: '#e0e0e0', width: 0.5 }` reproduces the
@@ -705,9 +742,33 @@ function strokeValueGridlineH(
 function valGridStroke(
   chart: ChartModel,
   ptToPx: number,
-): { color: string; width: number; explicit: boolean } {
+): { color: string; width: number; explicit: boolean; dash: number[] } {
   const { color, width } = resolveGridline(chart.valAxisGridlineColor, chart.valAxisGridlineWidthEmu, ptToPx);
-  return { color, width, explicit: chart.valAxisGridlineColor != null };
+  return {
+    color,
+    width,
+    explicit: chart.valAxisGridlineColor != null
+      || chart.valAxisGridlineWidthEmu != null
+      || chart.valAxisGridlineDash != null,
+    dash: dashPatternForPreset(chart.valAxisGridlineDash ?? undefined),
+  };
+}
+
+function valMinorGridStroke(
+  chart: ChartModel,
+  ptToPx: number,
+): { color: string; width: number; explicit: boolean; dash: number[] } {
+  const { color, width } = resolveGridline(
+    chart.valAxisMinorGridlineColor,
+    chart.valAxisMinorGridlineWidthEmu,
+    ptToPx,
+  );
+  return {
+    color,
+    width,
+    explicit: chart.valAxisMinorGridlineColor != null,
+    dash: dashPatternForPreset(chart.valAxisMinorGridlineDash ?? undefined),
+  };
 }
 
 /** Whether to draw CATEGORY-axis MAJOR gridlines (`<c:catAx><c:majorGridlines>`,
@@ -723,8 +784,22 @@ function drawCatMajorGridlines(chart: ChartModel): boolean {
  *  ⇒ the same faint `#e0e0e0`/0.5 px default as the value axis. Category
  *  gridlines have no zero-line emphasis (there is no "zero category"), so a
  *  single resolved stroke suffices. */
-function catGridStroke(chart: ChartModel, ptToPx: number): { color: string; width: number } {
-  return resolveGridline(chart.catAxisGridlineColor, chart.catAxisGridlineWidthEmu, ptToPx);
+function catGridStroke(chart: ChartModel, ptToPx: number): { color: string; width: number; dash: number[] } {
+  return {
+    ...resolveGridline(chart.catAxisGridlineColor, chart.catAxisGridlineWidthEmu, ptToPx),
+    dash: dashPatternForPreset(chart.catAxisGridlineDash ?? undefined),
+  };
+}
+
+function catMinorGridStroke(chart: ChartModel, ptToPx: number): { color: string; width: number; dash: number[] } {
+  return {
+    ...resolveGridline(
+      chart.catAxisMinorGridlineColor,
+      chart.catAxisMinorGridlineWidthEmu,
+      ptToPx,
+    ),
+    dash: dashPatternForPreset(chart.catAxisMinorGridlineDash ?? undefined),
+  };
 }
 
 /** The plot-fraction positions (0..1 across the category extent) of the CATEGORY
@@ -851,15 +926,11 @@ function planValueAxis(
   for (let si = 0; si <= steps; si++) majorLines.push(min + si * step);
   // Minor gridlines (ECMA-376 §21.2.2.109/§21.2.2.112): only when the file both
   // declares `<c:minorGridlines>` AND a positive `<c:minorUnit>`; the minor lines
-  // between the majors are the interior multiples of the minor unit.
+  // are the positive-unit positions measured from the scale minimum. The
+  // schema only requires a positive value; it does not require minor < major.
   const minorLines: number[] = [];
   const mu = valueAxisUnitInRendererSpace(chart.valAxisMinorUnit, percentStacked);
-  if (chart.valAxisMinorGridlines && mu != null && isFinite(mu) && mu > 0 && mu < step) {
-    for (let v = min + mu; v < max - 1e-9; v += mu) {
-      // Skip values that coincide with a major line.
-      if (Math.abs((v - min) / step - Math.round((v - min) / step)) > 1e-6) minorLines.push(v);
-    }
-  }
+  if (chart.valAxisMinorGridlines) minorLines.push(...minorAxisValues(min, max, step, mu));
   return {
     min, max, step, majorLines, minorLines,
     frac: (v: number) => (reversed ? 1 - (v - min) / range : (v - min) / range),
@@ -895,6 +966,7 @@ function drawSeriesTrendlines(
   if (xs.length < 2) return;
   const prevDash = ctx.getLineDash ? ctx.getLineDash() : [];
   for (const tl of tls) {
+    if (tl.lineHidden) continue;
     const fit = fitTrendline(xs, ys, tl.trendlineType, {
       period: tl.period, intercept: tl.intercept,
     });
@@ -911,16 +983,18 @@ function drawSeriesTrendlines(
     }
     ctx.strokeStyle = tl.lineColor ? `#${tl.lineColor}` : seriesColor;
     ctx.lineWidth = tl.lineWidthEmu ? axisLineWidthPx(tl.lineWidthEmu, ptToPx) : 1.5;
-    // `<c:trendline><c:spPr><a:ln>` without an authored dash is a solid line.
-    // Dash presets can be added to ChartTrendline when the parser retains one;
-    // never invent a dashed style for an otherwise solid DrawingML line.
-    ctx.setLineDash([]);
+    // DrawingML line presets are authored paint; omission means solid.
+    ctx.setLineDash(dashPatternForPreset(tl.lineDash ?? undefined));
     ctx.beginPath();
     for (let i = 0; i < fxs.length; i++) {
       const px = toX(fxs[i]); const py = toY(fys[i]);
       if (i === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
     }
     ctx.stroke();
+
+    // `<c:dispEq>` / `<c:dispRSqr>` control a trendline-label object whose
+    // omitted layout is application-defined. Do not invent an anchor here;
+    // authored label layout is tracked separately from rendering the line.
   }
   ctx.setLineDash(prevDash);
 }
@@ -1344,6 +1418,18 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // series (see {@link chartVariesColorsByPoint}), so combo/multi-series bars
   // are byte-identical.
   const varyByPoint = chartVariesColorsByPoint(chart);
+  const pointOverrides = barSeries.map(series =>
+    new Map((series.dataPointOverrides ?? []).map(point => [point.idx, point])),
+  );
+  const labelOverrides = barSeries.map(series =>
+    new Map((series.dataLabelOverrides ?? []).map(label => [label.idx, label])),
+  );
+  const barStyleIndices = barSeries.map((series, index) =>
+    chartExSeriesFormatIndex(series, index)
+  );
+  const isChartExColumn = chart.chartexDataPointStyle != null
+    || chart.chartexColorPalette != null
+    || barSeries.some(series => series.chartexStyle != null);
 
   // Honor the XML-specified title font size when present; otherwise fall back
   // to the proportional heuristic. Reserve the title band based on the actual
@@ -1538,7 +1624,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   const secFontPx = sec?.fontSizeHpt ? (sec.fontSizeHpt / 100) * ptToPx : secTickFontPx;
   let secLabelBandW = 0;
   if (sec && !sec.hidden) {
-    ctx.font = `${secFontPx}px sans-serif`;
+    ctx.font = `${secFontPx}px ${chartFontFamily(chart, sec.fontFace, 'minor')}`;
     let wmax = 0;
     const sSteps = Math.round((sMax - sMin) / sStep);
     for (let si = 0; si <= sSteps; si++) {
@@ -1692,13 +1778,17 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
 
   if (!chart.valAxisHidden) {
     // Minor gridlines (under the majors) when the file declares them.
+    const minorGrid = valMinorGridStroke(chart, ptToPx);
     for (const val of plan.minorLines) {
       if (!isH) {
-        strokeValueGridlineH(ctx, px0, pw, valY(val), false, grid);
+        strokeValueGridlineH(ctx, px0, pw, valY(val), false, minorGrid);
       } else {
         const gx = valX(val);
-        ctx.strokeStyle = grid.color; ctx.lineWidth = grid.width;
+        ctx.strokeStyle = minorGrid.color; ctx.lineWidth = minorGrid.width;
+        const previousDash = minorGrid.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+        if (minorGrid.dash.length > 0) ctx.setLineDash(minorGrid.dash);
         ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
+        if (minorGrid.dash.length > 0) ctx.setLineDash(previousDash);
       }
     }
     const drawMajorGrid = drawValMajorGridlines(chart);
@@ -1725,7 +1815,10 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
           // matching PowerPoint; otherwise keep the `#aaa`/1 px baseline rule.
           ctx.strokeStyle = grid.explicit ? grid.color : isZero ? '#aaa' : grid.color;
           ctx.lineWidth = grid.explicit ? grid.width : isZero ? 1 : grid.width;
+          const previousDash = grid.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+          if (grid.dash.length > 0) ctx.setLineDash(grid.dash);
           ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
+          if (grid.dash.length > 0) ctx.setLineDash(previousDash);
         }
         if (drawLabels) {
           ctx.textAlign = 'center';
@@ -1749,6 +1842,8 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     const cg = catGridStroke(chart, ptToPx);
     ctx.strokeStyle = cg.color;
     ctx.lineWidth = cg.width;
+    const previousDash = cg.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+    if (cg.dash.length > 0) ctx.setLineDash(cg.dash);
     for (const frac of catGridlineFractions(chart, n)) {
       ctx.beginPath();
       if (!isH) {
@@ -1760,6 +1855,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       }
       ctx.stroke();
     }
+    if (cg.dash.length > 0) ctx.setLineDash(previousDash);
   }
 
   // Axis rules. The CATEGORY axis runs along the bars' baseline — bottom
@@ -1885,10 +1981,58 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       // A `<c:dPt>` fill is an explicit point override regardless of the
       // chart-group `varyColors` flag (§21.2.2.52). varyColors only controls
       // the fallback palette for points without an override.
-      const pointOverride = s.dataPointColors?.[ci];
-      const color = pointOverride
-        ? `#${pointOverride}`
+      const pointOverride = pointOverrides[si].get(ci);
+      const pointColor = pointOverride?.color ?? s.dataPointColors?.[ci];
+      const color = pointColor
+        ? `#${pointColor}`
         : varyByPoint ? pieSliceColor(ci, s) : chartColor(si, s);
+      const pointPaint = pointOverride?.fillHidden
+        ? null
+        : pointOverride?.color
+          ? { fillType: 'solid' as const, color: pointOverride.color }
+          : isChartExColumn
+            // MS-ODRAWXML §2.8.4.5: styleClr="auto" uses the relative
+            // index of the styled element. A clustered-column dataPoint style
+            // colors a series, so every point in that series resolves with
+            // the series index; CT_DataPoint direct formatting above remains
+            // point-local and wins.
+            ? chartExDataPointPaint(
+              chart, barStyleIndices[si], barSeries.length, s.chartexStyle, s.color,
+            )
+            : undefined;
+      const applyPointOutline = (): boolean => {
+        const hasPointLine = pointOverride?.lineHidden != null
+          || pointOverride?.lineColor != null
+          || pointOverride?.lineWidthEmu != null
+          || pointOverride?.lineDash != null;
+        if (hasPointLine) {
+          if (pointOverride?.lineHidden) return false;
+          const fallback = chartExStyleColor(
+            chart, chart.chartexDataPointStyle, 'line', barStyleIndices[si], barSeries.length,
+          )
+            ?? s.lineColor
+            ?? color;
+          ctx.strokeStyle = `#${pointOverride?.lineColor ?? fallback.replace(/^#/, '')}`;
+          ctx.lineWidth = pointOverride?.lineWidthEmu != null
+            ? axisLineWidthPx(pointOverride.lineWidthEmu, ptToPx)
+            : s.lineWidthEmu != null
+              ? axisLineWidthPx(s.lineWidthEmu, ptToPx)
+              : 1;
+          ctx.setLineDash(dashPatternForPreset(pointOverride?.lineDash));
+          return true;
+        }
+        if (isChartExColumn) {
+          return applyChartExSeriesLineStyle(
+            ctx, chart, chart.chartexDataPointStyle, s,
+            barStyleIndices[si], barSeries.length, color, ptToPx,
+          );
+        }
+        if (!s.lineColor || s.lineHidden) return false;
+        ctx.strokeStyle = `#${s.lineColor}`;
+        ctx.lineWidth = axisLineWidthPx(s.lineWidthEmu, ptToPx);
+        ctx.setLineDash([]);
+        return true;
+      };
 
       if (!isH) {
         const bx = stacked
@@ -1902,14 +2046,16 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
         const by = clamp(Math.min(y0, y1), py0, py0 + ph);
         const barBottom = clamp(Math.max(y0, y1), py0, py0 + ph);
         const barH = Math.max(0, barBottom - by);
-        ctx.fillStyle = s.fillPattern
-          ? (resolveFill(s.fillPattern, ctx, bx, by, barW, barH) ?? color)
-          : color;
-        ctx.fillRect(bx, by, barW, barH);
-        if (s.lineColor && !s.lineHidden && barW > 0 && barH > 0) {
-          const outlineW = axisLineWidthPx(s.lineWidthEmu, ptToPx);
-          ctx.strokeStyle = `#${s.lineColor}`;
-          ctx.lineWidth = outlineW;
+        if (pointPaint !== null) {
+          ctx.fillStyle = pointPaint
+            ? chartExFillStyle(ctx, pointPaint, bx, by, barW, barH, color)
+            : s.fillPattern
+              ? (resolveFill(s.fillPattern, ctx, bx, by, barW, barH) ?? color)
+              : color;
+          ctx.fillRect(bx, by, barW, barH);
+        }
+        if (barW > 0 && barH > 0 && applyPointOutline()) {
+          const outlineW = ctx.lineWidth;
           ctx.strokeRect(
             bx + outlineW / 2,
             by + outlineW / 2,
@@ -1918,24 +2064,27 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
           );
         }
         const seriesLabels = s.seriesDataLabels;
-        if ((chart.showDataLabels || seriesLabels?.showVal === true) && sv !== 0) {
+        const label = resolveChartExLabel(
+          chart, s, ci, s.categories?.[ci] ?? cats[ci] ?? '', sv,
+          { visible: chart.showDataLabels, showVal: chart.showDataLabels, showCatName: false },
+          labelOverrides[si],
+        );
+        if (label) {
           // ECMA-376 §21.2.2.30 / §21.1.2.3.2 — data label font size comes from
           // `<c:dLbls><c:txPr>...<a:defRPr@sz>` (hundredths of a point). When
           // the file specifies one we honor it; otherwise the proportional
           // heuristic keeps small bars readable.
-          const sizeHpt = seriesLabels?.fontSizeHpt ?? chart.dataLabelFontSizeHpt;
+          const sizeHpt = label.fontSizeHpt ?? chart.dataLabelFontSizeHpt;
           const lsz = sizeHpt
             ? (sizeHpt / 100) * ptToPx
             : Math.max(7, Math.min(11, barW * 0.6));
-          const bold = seriesLabels?.fontBold ?? true;
+          const authoredLabel = labelOverrides[si].get(ci);
+          const bold = label.fontBold
+            || (seriesLabels?.fontBold == null && authoredLabel?.fontBold == null);
           ctx.font = `${bold ? 'bold ' : ''}${lsz}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
-          const text = pct
+          const text = pct && authoredLabel?.text == null
             ? `${Math.round(sv)}%`
-            : formatChartValWithCode(
-                sv,
-                seriesLabels?.formatCode ?? chart.dataLabelFormatCode ?? s.valFormatCode ?? null,
-                chart.date1904,
-              );
+            : label.text;
           // drawBarDataLabel takes (bx, by, barL=length, barW=thickness). For
           // a vertical column bar, "length" is the bar's height and
           // "thickness" is its horizontal width — pass them in that order.
@@ -1947,8 +2096,8 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
             ctx, text,
             bx, by, barH, barW,
             'vertical',
-            seriesLabels?.position ?? chart.dataLabelPosition ?? (stacked ? 'ctr' : null),
-            seriesLabels?.fontColor ?? s.labelColor ?? chart.dataLabelFontColor ?? null,
+            label.position ?? chart.dataLabelPosition ?? (stacked ? 'ctr' : null),
+            s.dataLabelColors?.[ci] ?? label.fontColor ?? s.labelColor ?? chart.dataLabelFontColor ?? null,
             negative,
           );
         }
@@ -1965,14 +2114,16 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
         const bx = clamp(Math.min(x0, x1), px0, px0 + pw);
         const barRight = clamp(Math.max(x0, x1), px0, px0 + pw);
         const barL = Math.max(0, barRight - bx);
-        ctx.fillStyle = s.fillPattern
-          ? (resolveFill(s.fillPattern, ctx, bx, by, barL, barW) ?? color)
-          : color;
-        ctx.fillRect(bx, by, barL, barW);
-        if (s.lineColor && !s.lineHidden && barL > 0 && barW > 0) {
-          const outlineW = axisLineWidthPx(s.lineWidthEmu, ptToPx);
-          ctx.strokeStyle = `#${s.lineColor}`;
-          ctx.lineWidth = outlineW;
+        if (pointPaint !== null) {
+          ctx.fillStyle = pointPaint
+            ? chartExFillStyle(ctx, pointPaint, bx, by, barL, barW, color)
+            : s.fillPattern
+              ? (resolveFill(s.fillPattern, ctx, bx, by, barL, barW) ?? color)
+              : color;
+          ctx.fillRect(bx, by, barL, barW);
+        }
+        if (barL > 0 && barW > 0 && applyPointOutline()) {
+          const outlineW = ctx.lineWidth;
           ctx.strokeRect(
             bx + outlineW / 2,
             by + outlineW / 2,
@@ -1981,26 +2132,29 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
           );
         }
         const seriesLabels = s.seriesDataLabels;
-        if ((chart.showDataLabels || seriesLabels?.showVal === true) && sv !== 0) {
-          const sizeHpt = seriesLabels?.fontSizeHpt ?? chart.dataLabelFontSizeHpt;
+        const label = resolveChartExLabel(
+          chart, s, ci, s.categories?.[ci] ?? cats[ci] ?? '', sv,
+          { visible: chart.showDataLabels, showVal: chart.showDataLabels, showCatName: false },
+          labelOverrides[si],
+        );
+        if (label) {
+          const sizeHpt = label.fontSizeHpt ?? chart.dataLabelFontSizeHpt;
           const lsz = sizeHpt
             ? (sizeHpt / 100) * ptToPx
             : Math.max(7, Math.min(11, barW * 0.6));
-          const bold = seriesLabels?.fontBold ?? true;
+          const authoredLabel = labelOverrides[si].get(ci);
+          const bold = label.fontBold
+            || (seriesLabels?.fontBold == null && authoredLabel?.fontBold == null);
           ctx.font = `${bold ? 'bold ' : ''}${lsz}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
-          const text = pct
+          const text = pct && authoredLabel?.text == null
             ? `${Math.round(sv)}%`
-            : formatChartValWithCode(
-                sv,
-                seriesLabels?.formatCode ?? chart.dataLabelFormatCode ?? s.valFormatCode ?? null,
-                chart.date1904,
-              );
+            : label.text;
           drawBarDataLabel(
             ctx, text,
             bx, by, barL, barW,
             'horizontal',
-            seriesLabels?.position ?? chart.dataLabelPosition ?? (stacked ? 'ctr' : null),
-            seriesLabels?.fontColor ?? s.labelColor ?? chart.dataLabelFontColor ?? null,
+            label.position ?? chart.dataLabelPosition ?? (stacked ? 'ctr' : null),
+            s.dataLabelColors?.[ci] ?? label.fontColor ?? s.labelColor ?? chart.dataLabelFontColor ?? null,
             negative,
           );
         }
@@ -2189,7 +2343,54 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     }
   }
 
-  drawLegendForLayout(ctx, chart, leg, x, y, w, h, px0, py0, pw, ph, titleH + 2, ptToPx);
+  const legendChart = isChartExColumn
+    ? {
+      ...chart,
+      series: barSeries.map((series, index) => {
+        const styleIndex = barStyleIndices[index];
+        const linkedStyle = chart.chartexDataPointStyle;
+        const localStyle = series.chartexStyle;
+        const localHasLine = localStyle?.lineHidden != null
+          || localStyle?.lineColors?.some(Boolean)
+          || localStyle?.lineWidthEmu != null
+          || localStyle?.lineDash != null;
+        const useLocalLine = localHasLine && !(localStyle?.lineHidden && localStyle.lineNoStyle);
+        const useLegacyLine = !useLocalLine && (
+          series.lineHidden != null || series.lineColor != null || series.lineWidthEmu != null
+        );
+        const effectiveLineStyle = useLocalLine
+          ? localStyle
+          : useLegacyLine ? null : linkedStyle;
+        return {
+          ...series,
+          color: series.color
+            ?? chartExDataPointFill(chart, styleIndex, barSeries.length, localStyle),
+          lineHidden: useLocalLine
+            ? localStyle?.lineHidden === true
+            : useLegacyLine
+              ? series.lineHidden
+              : effectiveLineStyle?.lineHidden ?? false,
+          lineColor: useLegacyLine
+            ? series.lineColor
+            : chartExStyleColor(
+              chart, effectiveLineStyle, 'line', styleIndex, barSeries.length,
+            ),
+          lineWidthEmu: useLegacyLine
+            ? series.lineWidthEmu
+            : effectiveLineStyle?.lineWidthEmu ?? null,
+        };
+      }),
+    }
+    : chart;
+  const legendPaints = isChartExColumn
+    ? barSeries.map((series, index) => chartExDataPointPaint(
+      chart, barStyleIndices[index], barSeries.length, series.chartexStyle, series.color,
+    ))
+    : [];
+  drawLegendForLayout(
+    ctx, legendChart, leg, x, y, w, h, px0, py0, pw, ph,
+    titleH + 2, ptToPx, legendPaints,
+  );
   drawAxisTitles(ctx, chart, x, y, w, h, px0, py0, pw, ph, legLeftW, legBottomH, catTitlePx, valTitlePx);
 }
 
@@ -2322,7 +2523,7 @@ function renderLineChart(
   let secLabelBandW = 0;
   if (sec && secScale && !sec.hidden) {
     const prevFont = ctx.font;
-    ctx.font = `${secFontPx}px sans-serif`;
+    ctx.font = `${secFontPx}px ${chartFontFamily(chart, sec.fontFace, 'minor')}`;
     let wmax = 0;
     const sSteps = Math.round((secScale.max - secScale.min) / secScale.step);
     for (let si = 0; si <= sSteps; si++) {
@@ -2429,9 +2630,10 @@ function renderLineChart(
     ctx.textBaseline = 'middle';
     // Resolved gridline stroke (`<c:majorGridlines><c:spPr><a:ln>` or default).
     const grid = valGridStroke(chart, ptToPx);
+    const minorGrid = valMinorGridStroke(chart, ptToPx);
     // Minor gridlines first (under the majors), then major gridlines + ticks +
     // labels. Minor lines are only populated when the file declares them.
-    for (const v of plan.minorLines) strokeValueGridlineH(ctx, px0, pw, toY(v), false, grid);
+    for (const v of plan.minorLines) strokeValueGridlineH(ctx, px0, pw, toY(v), false, minorGrid);
     const drawMajorGrid = drawValMajorGridlines(chart);
     const drawLabels = chart.valAxisTickLabelPos !== 'none';
     for (const v of plan.majorLines) {
@@ -2462,10 +2664,13 @@ function renderLineChart(
     const cg = catGridStroke(chart, ptToPx);
     ctx.strokeStyle = cg.color;
     ctx.lineWidth = cg.width;
+    const previousDash = cg.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+    if (cg.dash.length > 0) ctx.setLineDash(cg.dash);
     for (const frac of catGridlineFractions(chart, n)) {
       const gx = px0 + frac * pw;
       ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
     }
+    if (cg.dash.length > 0) ctx.setLineDash(previousDash);
   }
 
   // Axis lines: bottom (category) + left (value). Both default to visible
@@ -2759,7 +2964,8 @@ function renderStockChart(
     ctx.font = `${valAxFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     ctx.textBaseline = 'middle';
     const grid = valGridStroke(chart, ptToPx);
-    for (const v of plan.minorLines) strokeValueGridlineH(ctx, px0, pw, toY(v), false, grid);
+    const minorGrid = valMinorGridStroke(chart, ptToPx);
+    for (const v of plan.minorLines) strokeValueGridlineH(ctx, px0, pw, toY(v), false, minorGrid);
     const drawMajorGrid = drawValMajorGridlines(chart);
     const drawLabels = chart.valAxisTickLabelPos !== 'none';
     for (const v of plan.majorLines) {
@@ -2772,6 +2978,12 @@ function renderStockChart(
         ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
       }
     }
+    forEachMinorTick(plan.min, plan.max, plan.step, chart.valAxisMinorUnit, v => {
+      drawAxisTick(
+        ctx, chart.valAxisMinorTickMark, 'val', px0, toY(v),
+        undefined, undefined, false, chart.valAxisLineHidden,
+      );
+    });
   }
 
   // Axis rules (bottom = category, left = value).
@@ -2960,7 +3172,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   let secLabelBandW = 0;
   if (sec && secScale && !sec.hidden) {
     const prevFont = ctx.font;
-    ctx.font = `${secFontPx}px sans-serif`;
+    ctx.font = `${secFontPx}px ${chartFontFamily(chart, sec.fontFace, 'minor')}`;
     let wmax = 0;
     const sSteps = Math.round((secScale.max - secScale.min) / secScale.step);
     for (let si = 0; si <= sSteps; si++) {
@@ -3122,19 +3334,16 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   // by default (`drawValMajorGridlines`); `<c:minorGridlines>` only when declared.
   if (!chart.valAxisHidden) {
     const grid = valGridStroke(chart, ptToPx);
+    const minorGrid = valMinorGridStroke(chart, ptToPx);
     // Minor gridlines (`<c:valAx><c:minorGridlines>`, §21.2.2.129) drawn first,
     // UNDER the majors and the series, only when the file declares them AND a
-    // positive `<c:minorUnit>` smaller than the major step. Interior multiples of
-    // the minor unit that don't coincide with a major line — same computation as
-    // planValueAxis (renderer.ts ~686-696) used by bar/line/stock, with the area
-    // axis anchored at min = 0. Fixes #883 (area previously ignored minor lines).
+    // positive `<c:minorUnit>`. Positions are generated by the same scale-min
+    // based helper used by the other value-axis renderers.
     const mu = valueAxisUnitInRendererSpace(chart.valAxisMinorUnit, pct);
-    if (chart.valAxisMinorGridlines && mu != null && isFinite(mu) && mu > 0 && mu < step) {
-      for (let v = mu; v < axMax - 1e-9; v += mu) {
-        if (Math.abs(v / step - Math.round(v / step)) > 1e-6) {
-          strokeValueGridlineH(ctx, px0, pw, toY(v), false, grid);
-        }
-      }
+    if (chart.valAxisMinorGridlines) {
+      forEachMinorTick(0, axMax, step, mu, v => {
+        strokeValueGridlineH(ctx, px0, pw, toY(v), false, minorGrid);
+      });
     }
     if (drawValMajorGridlines(chart)) {
       const steps = Math.round(axMax / step);
@@ -3151,10 +3360,13 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     const cg = catGridStroke(chart, ptToPx);
     ctx.strokeStyle = cg.color;
     ctx.lineWidth = cg.width;
+    const previousDash = cg.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+    if (cg.dash.length > 0) ctx.setLineDash(cg.dash);
     for (const frac of catGridlineFractions(chart, n)) {
       const gx = px0 + frac * pw;
       ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
     }
+    if (cg.dash.length > 0) ctx.setLineDash(previousDash);
   }
 
   // Draw the series area fills ON TOP of the gridlines laid down above.
@@ -4740,13 +4952,22 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       ? valueTickLabelGapPx(yTickFontPx)
       : 4;
     ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${yTickFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
+    if (chart.valAxisMinorGridlines) {
+      const minorGrid = valMinorGridStroke(chart, ptToPx);
+      forEachMinorTick(yMin, yMax, yAxisStep, chart.valAxisMinorUnit, value => {
+        strokeValueGridlineH(ctx, px0, pw, toY(value), false, minorGrid);
+      });
+    }
     const ySteps = Math.round((yMax - yMin) / yAxisStep) + 1;
     for (let si = 0; si < ySteps; si++) {
       const v = yMin + si * yAxisStep; if (v > yMax + yAxisStep * 0.01) break;
       const gy = toY(v);
       ctx.strokeStyle = grid.color; ctx.lineWidth = grid.width;
       if (drawValMajorGridlines(chart)) {
+        const previousDash = grid.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+        if (grid.dash.length > 0) ctx.setLineDash(grid.dash);
         ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+        if (grid.dash.length > 0) ctx.setLineDash(previousDash);
       }
       if (chart.valAxisTickLabelPos !== 'none') {
         ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
@@ -4784,12 +5005,27 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     const xSteps = Math.round((xMax - xMin) / xStep) + 1;
     ctx.strokeStyle = xGrid.color;
     ctx.lineWidth = xGrid.width;
+    const previousDash = xGrid.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+    if (xGrid.dash.length > 0) ctx.setLineDash(xGrid.dash);
     for (let si = 0; si < xSteps; si++) {
       const v = xMin + si * xStep;
       if (v > xMax + xStep * 0.01) break;
       const gx = toX(v);
       ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
     }
+    if (xGrid.dash.length > 0) ctx.setLineDash(previousDash);
+  }
+  if (!chart.catAxisHidden && chart.catAxisMinorGridlines && xStep > 0) {
+    const xGrid = catMinorGridStroke(chart, ptToPx);
+    const previousDash = xGrid.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+    ctx.strokeStyle = xGrid.color;
+    ctx.lineWidth = xGrid.width;
+    if (xGrid.dash.length > 0) ctx.setLineDash(xGrid.dash);
+    forEachMinorTick(xMin, xMax, xStep, chart.catAxisMinorUnit, value => {
+      const gx = toX(value);
+      ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
+    });
+    if (xGrid.dash.length > 0) ctx.setLineDash(previousDash);
   }
 
   // X-axis line (the timeline ruler in Gantt-style scatter charts depends
@@ -5473,6 +5709,77 @@ function drawCategoryDataLabels(
 
 type ChartExStyle = NonNullable<ChartModel['chartexDataPointStyle']>;
 
+interface ResolvedChartExLabel {
+  text: string;
+  position?: string;
+  fontColor?: string;
+  fontSizeHpt?: number;
+  fontBold: boolean;
+}
+
+/** Effective CT_Series formatting index. The shared parser preserves authored
+ * `formatIdx` and resolves omission to the original document-order index so a
+ * hidden series cannot renumber the visible series' linked Chart Style. */
+function chartExSeriesFormatIndex(
+  series: Pick<ChartSeries, 'chartexFormatIdx'> | null | undefined,
+  fallbackIndex: number,
+): number {
+  return series?.chartexFormatIdx ?? fallbackIndex;
+}
+
+/** Resolve CT_DataLabels + indexed CT_DataLabel/dataLabelHidden without
+ * renderer-specific precedence. Defaults describe the semantic label layer of
+ * the chart type (waterfall values remain visible when no dataLabels element
+ * exists); authored visibility always overrides those defaults. */
+function resolveChartExLabel(
+  chart: ChartModel,
+  series: ChartSeries | null | undefined,
+  index: number,
+  category: string,
+  value: number,
+  defaults: { visible: boolean; showVal: boolean; showCatName: boolean; showSerName?: boolean },
+  overrideLookup?: ReadonlyMap<number, NonNullable<ChartSeries['dataLabelOverrides']>[number]>,
+): ResolvedChartExLabel | null {
+  if (!series) return null;
+  const definition = series.seriesDataLabels;
+  const override = overrideLookup?.get(index)
+    ?? series.dataLabelOverrides?.find(item => item.idx === index);
+  if (override?.deleted) return null;
+  if (!definition && !override && !defaults.visible) return null;
+  const showVal = override?.showVal ?? definition?.showVal ?? defaults.showVal;
+  const showCatName = override?.showCatName ?? definition?.showCatName ?? defaults.showCatName;
+  const showSerName = override?.showSerName
+    ?? definition?.showSerName
+    ?? defaults.showSerName
+    ?? false;
+  let text = override?.text ?? '';
+  if (!text) {
+    const parts: string[] = [];
+    if (showCatName && category) parts.push(category);
+    if (showSerName && series.name) parts.push(series.name);
+    if (showVal) {
+      parts.push(formatChartValWithCode(
+        value,
+        override?.formatCode
+          ?? definition?.formatCode
+          ?? chart.dataLabelFormatCode
+          ?? series.valFormatCode
+          ?? null,
+        chart.date1904,
+      ));
+    }
+    text = parts.join(override?.separator ?? definition?.separator ?? ' ');
+  }
+  if (!text) return null;
+  return {
+    text,
+    position: override?.position ?? definition?.position,
+    fontColor: override?.fontColor ?? definition?.fontColor,
+    fontSizeHpt: override?.fontSizeHpt ?? definition?.fontSizeHpt,
+    fontBold: override?.fontBold ?? definition?.fontBold ?? false,
+  };
+}
+
 function chartExStyleColor(
   _chart: ChartModel,
   style: ChartExStyle | null | undefined,
@@ -5511,13 +5818,23 @@ function chartExPaletteColor(
   return colors[within ? 0 : colorIndex % colors.length] ?? null;
 }
 
-function chartExDataPointFill(chart: ChartModel, index: number, count: number): string {
-  return chartExStyleColor(chart, chart.chartexDataPointStyle, 'fill', index, count)
-    ?? (chart.chartexColorPalette
+function chartExSemanticFill(chart: ChartModel, index: number, count: number): string {
+  return (chart.chartexColorPalette
       ? chartExPaletteColor(chart, chart.chartexColorPalette, index, count)
       : null)
     ?? chart.chartexAccents?.[index % (chart.chartexAccents.length || 1)]
     ?? CHARTEX_DEFAULT_PALETTE[index % CHARTEX_DEFAULT_PALETTE.length];
+}
+
+function chartExDataPointFill(
+  chart: ChartModel,
+  index: number,
+  count: number,
+  localStyle?: ChartExStyle | null,
+): string {
+  return chartExStyleColor(chart, localStyle, 'fill', index, count)
+    ?? chartExStyleColor(chart, chart.chartexDataPointStyle, 'fill', index, count)
+    ?? chartExSemanticFill(chart, index, count);
 }
 
 function chartExStyleFillPaint(
@@ -5529,9 +5846,45 @@ function chartExStyleFillPaint(
   return paints[(style?.fillColorIndex ?? index) % paints.length] ?? null;
 }
 
-function chartExDataPointPaint(chart: ChartModel, index: number, count: number): Fill {
-  return chartExStyleFillPaint(chart.chartexDataPointStyle, index)
-    ?? { fillType: 'solid', color: chartExDataPointFill(chart, index, count) };
+/** Resolve one ChartEx style paint layer. `undefined` means this layer supplied
+ * no paint, while `null` records an explicit no-fill for consumers whose own
+ * shape is governed by that layer. */
+function chartExStylePaintDecision(
+  chart: ChartModel,
+  style: ChartExStyle | null | undefined,
+  index: number,
+  count: number,
+): Fill | null | undefined {
+  if (!style) return undefined;
+  if (style.fillHidden) return style.fillNoStyle ? undefined : null;
+  const paint = chartExStyleFillPaint(style, index);
+  if (paint) return paint;
+  const color = chartExStyleColor(chart, style, 'fill', index, count);
+  return color ? { fillType: 'solid', color } : undefined;
+}
+
+function chartExDataPointPaint(
+  chart: ChartModel,
+  index: number,
+  count: number,
+  localStyle?: ChartExStyle | null,
+  legacyColor?: string | null,
+  linkedStyle: ChartExStyle | null | undefined = chart.chartexDataPointStyle,
+): Fill | null {
+  // CT_Series.spPr formats the series shape; ChartEx semantic data points
+  // (waterfall roles, box bodies, hierarchy nodes) still obtain their own
+  // paint from the dataPoint Chart Style. A conventional series-level
+  // `<a:noFill>` therefore does not erase every point. Positive local series
+  // fills remain direct formatting and do override the linked recipe.
+  const local = localStyle?.fillHidden
+    ? undefined
+    : chartExStylePaintDecision(chart, localStyle, index, count);
+  if (local !== undefined) return local;
+  if (localStyle && legacyColor) return { fillType: 'solid', color: legacyColor };
+  const linked = chartExStylePaintDecision(chart, linkedStyle, index, count);
+  if (linked !== undefined) return linked;
+  if (legacyColor) return { fillType: 'solid', color: legacyColor };
+  return { fillType: 'solid', color: chartExSemanticFill(chart, index, count) };
 }
 
 function chartExFillStyle(
@@ -5576,6 +5929,68 @@ function applyChartExLineStyle(
   return true;
 }
 
+/** Apply CT_Series local shape properties before the linked Chart Style.
+ *  [MS-ODRAWXML] 2.24.3.77 makes `<cx:series><cx:spPr>` the series' own
+ *  OfficeArt formatting, so an authored line (including `noFill`) overrides
+ *  the default data-point recipe instead of being merged underneath it. */
+function applyChartExSeriesLineStyle(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  style: ChartExStyle | null | undefined,
+  series: Pick<ChartSeries, 'chartexStyle' | 'lineHidden' | 'lineColor' | 'lineWidthEmu'> | null | undefined,
+  index: number,
+  count: number,
+  fallbackColor: string,
+  ptToPx: number,
+): boolean {
+  const local = series?.chartexStyle;
+  const localHasLine = local?.lineHidden != null
+    || local?.lineColors?.some(Boolean)
+    || local?.lineWidthEmu != null
+    || local?.lineDash != null
+    || local?.lineCap != null
+    || local?.lineJoin != null;
+  if (localHasLine && !(local?.lineHidden && local.lineNoStyle)) {
+    return applyChartExLineStyle(ctx, chart, local, index, count, fallbackColor, ptToPx);
+  }
+  const hasLegacyLocalLine = series?.lineHidden != null
+    || series?.lineColor != null
+    || series?.lineWidthEmu != null;
+  if (!hasLegacyLocalLine) {
+    return applyChartExLineStyle(ctx, chart, style, index, count, fallbackColor, ptToPx);
+  }
+  if (series?.lineHidden) return false;
+  const color = series?.lineColor ?? fallbackColor;
+  ctx.strokeStyle = color.startsWith('#') ? color : `#${color}`;
+  ctx.lineWidth = series?.lineWidthEmu != null
+    ? axisLineWidthPx(series.lineWidthEmu, ptToPx)
+    : 1;
+  ctx.setLineDash([]);
+  ctx.lineCap = 'butt';
+  ctx.lineJoin = 'miter';
+  return true;
+}
+
+// The parser may preserve up to the OOXML cache ceiling, but expanding every
+// point into several synchronous Canvas calls can monopolize the UI thread.
+// Refuse an oversized paint atomically instead of drawing a misleading prefix.
+// This is an availability boundary, not an automatic chart-layout heuristic.
+const MAX_CANVAS_CHART_POINTS = 10_000;
+
+function rejectOversizedCanvasChart(
+  ctx: CanvasRenderingContext2D,
+  rect: ChartRect,
+  pointCount: number,
+): boolean {
+  if (pointCount <= MAX_CANVAS_CHART_POINTS) return false;
+  ctx.fillStyle = '#888';
+  ctx.font = '12px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText('(too many data points)', rect.x + rect.w / 2, rect.y + rect.h / 2);
+  return true;
+}
+
 function renderWaterfallChart(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
@@ -5586,30 +6001,38 @@ function renderWaterfallChart(
   const { x, y, w, h } = r;
   const vals = chart.series[0]?.values ?? [];
   const cats = chart.categories;
-  const n = cats.length;
+  // ChartEx numeric and string dimensions are independent. Preserve the union
+  // of their point indexes: a missing category removes only its label, while a
+  // missing numeric point retains an empty category slot.
+  const n = Math.max(vals.length, cats.length);
   if (n === 0) return;
+  if (rejectOversizedCanvasChart(ctx, r, n)) return;
 
   const subSet = new Set(chart.subtotalIndices);
   let running = 0;
   const bars: Array<{ start: number; end: number; isSub: boolean; isPos: boolean }> = [];
+  let rawMax = Number.NEGATIVE_INFINITY;
+  let rawMin = 0;
   for (let i = 0; i < n; i++) {
     const v = vals[i] ?? 0;
     const isSub = subSet.has(i);
     if (isSub) {
-      bars.push({ start: 0, end: v, isSub: true, isPos: true });
+      const bar = { start: 0, end: v, isSub: true, isPos: true };
+      bars.push(bar);
+      rawMax = Math.max(rawMax, bar.start, bar.end);
+      rawMin = Math.min(rawMin, bar.start, bar.end);
       running = v;
     } else {
       const start = v >= 0 ? running : running + v;
       const end   = v >= 0 ? running + v : running;
-      bars.push({ start, end, isSub: false, isPos: v >= 0 });
+      const bar = { start, end, isSub: false, isPos: v >= 0 };
+      bars.push(bar);
+      rawMax = Math.max(rawMax, bar.start, bar.end);
+      rawMin = Math.min(rawMin, bar.start, bar.end);
       running += v;
     }
   }
 
-  const allEnds = bars.map(b => b.end);
-  const allStarts = bars.map(b => b.start);
-  const rawMax = Math.max(...allEnds, ...allStarts);
-  const rawMin = Math.min(...allStarts, 0);
   if (rawMax <= rawMin) return;
 
   const titleBand = cartesianTitleBand(chart, h, ptToPx);
@@ -5643,15 +6066,18 @@ function renderWaterfallChart(
   );
   const estimatedSlotW = estimatedPlotW / n;
   ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${catFontPx}px ${catFont}`;
-  const wrappedCategories = cats.map(category =>
+  const wrappedCategories = cats.slice(0, n).map(category =>
     wrapMeasuredText(
       ctx,
       formatCategoryLabel(category, chart.catAxisFormatCode, chart.date1904),
       Math.max(1, estimatedSlotW - 8),
     )
   );
-  const maxCategoryLines = Math.max(1, ...wrappedCategories.map(lines => lines.length));
-  const categoryLabelBandH = chart.catAxisHidden
+  let maxCategoryLines = 0;
+  for (const lines of wrappedCategories) {
+    if (lines.some(Boolean)) maxCategoryLines = Math.max(maxCategoryLines, lines.length);
+  }
+  const categoryLabelBandH = chart.catAxisHidden || maxCategoryLines === 0
     ? 0
     : maxCategoryLines * (catFontPx + 2) + 4;
 
@@ -5683,11 +6109,7 @@ function renderWaterfallChart(
     chart.catAxisLineWidthEmu,
     ptToPx,
   );
-  const valGridline = resolveGridline(
-    chart.valAxisGridlineColor,
-    chart.valAxisGridlineWidthEmu,
-    ptToPx,
-  );
+  const valGridline = valGridStroke(chart, ptToPx);
 
   // ECMA-376 / chartEx §axis@hidden: when the value axis is hidden, skip the
   // value-axis gridlines, tick labels and the left segment of the L-frame.
@@ -5698,12 +6120,19 @@ function renderWaterfallChart(
     ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#595959';
     ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
+    const minorGridline = valMinorGridStroke(chart, ptToPx);
+    for (const value of plan.minorLines) {
+      strokeValueGridlineH(ctx, px0, pw, yOf(value), false, minorGridline);
+    }
     for (const value of plan.majorLines) {
       const gy = yOf(value);
       if (drawValMajorGridlines(chart)) {
         ctx.strokeStyle = valGridline.color;
         ctx.lineWidth = valGridline.width;
+        const previousDash = valGridline.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+        if (valGridline.dash.length > 0) ctx.setLineDash(valGridline.dash);
         ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+        if (valGridline.dash.length > 0) ctx.setLineDash(previousDash);
       }
       // Locale-independent §18.8.30 formatting (honoring `<c:valAx><c:numFmt>`),
       // matching the other renderers — `toLocaleString()` grouped by the
@@ -5725,6 +6154,12 @@ function renderWaterfallChart(
         chart.valAxisLineHidden,
       );
     }
+    forEachMinorTick(plan.min, plan.max, plan.step, chart.valAxisMinorUnit, value => {
+      drawAxisTick(
+        ctx, chart.valAxisMinorTickMark, 'val', px0, yOf(value),
+        valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden,
+      );
+    });
   }
 
   // L-frame: vertical (value-axis) rule + horizontal (category-axis) baseline.
@@ -5743,21 +6178,23 @@ function renderWaterfallChart(
     ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
   }
 
-  const colorPos = `#${chart.series[0]?.color ?? chartExDataPointFill(chart, 0, 3)}`;
-  const colorNeg = `#${chartExDataPointFill(chart, 1, 3)}`;
-  const colorSub = `#${chartExDataPointFill(chart, 2, 3)}`;
-  const paintPos: Fill = chart.series[0]?.color
-    ? { fillType: 'solid', color: chart.series[0].color }
-    : chartExDataPointPaint(chart, 0, 3);
-  const paintNeg = chartExDataPointPaint(chart, 1, 3);
-  const paintSub = chartExDataPointPaint(chart, 2, 3);
+  const series = chart.series[0];
+  const localStyle = series?.chartexStyle;
+  const colorPos = `#${series?.color ?? chartExDataPointFill(chart, 0, 3, localStyle)}`;
+  const colorNeg = `#${chartExDataPointFill(chart, 1, 3, localStyle)}`;
+  const colorSub = `#${chartExDataPointFill(chart, 2, 3, localStyle)}`;
+  const paintPos = chartExDataPointPaint(chart, 0, 3, localStyle, series?.color);
+  const paintNeg = chartExDataPointPaint(chart, 1, 3, localStyle);
+  const paintSub = chartExDataPointPaint(chart, 2, 3, localStyle);
 
   // ECMA-376 / chartEx §17.18.34 ST_GapAmount: gapWidth is the gap between
   // adjacent categories expressed as a percentage of the bar width
   // (legacy `<c:gapWidth val>`) or as a fraction (chartEx
   // `<cx:catScaling gapWidth>`, normalised to the same percent form by the
-  // parser). The bar then occupies `catGap / (1 + gapWidth/100)`. Default
-  // 150% per the spec when neither attribute is present.
+  // parser). The bar then occupies `catGap / (1 + gapWidth/100)`. The existing
+  // 150% fallback is retained for byte compatibility when ChartEx requests
+  // automatic spacing; reproducing Office's automatic choice is tracked
+  // separately and is not tuned in this change.
   const gapW = pw / n;
   const gapWidthPct = chart.barGapWidth ?? 150;
   const barW = gapW / (1 + gapWidthPct / 100);
@@ -5768,34 +6205,36 @@ function renderWaterfallChart(
     const yBot = Math.max(yOf(bar.start), yOf(bar.end));
     const bh = Math.max(1, yBot - yTop);
 
-    if (!chart.chartexDataPointStyle?.fillHidden) {
-      const paint = bar.isSub ? paintSub : bar.isPos ? paintPos : paintNeg;
-      const fallback = bar.isSub ? colorSub : bar.isPos ? colorPos : colorNeg;
+    const paint = bar.isSub ? paintSub : bar.isPos ? paintPos : paintNeg;
+    const fallback = bar.isSub ? colorSub : bar.isPos ? colorPos : colorNeg;
+    if (paint) {
       ctx.fillStyle = chartExFillStyle(ctx, paint, bx, yTop, barW, bh, fallback, shapeRotationDeg);
       ctx.fillRect(bx, yTop, barW, bh);
     }
     const accentIndex = bar.isSub ? 2 : bar.isPos ? 0 : 1;
     const lineColor = chartExStyleColor(chart, chart.chartexDataPointStyle, 'line', accentIndex, 3);
-    if (lineColor && applyChartExLineStyle(
+    if (applyChartExSeriesLineStyle(
       ctx,
       chart,
       chart.chartexDataPointStyle,
+      series,
       accentIndex,
       3,
-      lineColor,
+      lineColor ? `#${lineColor}` : fallback,
       ptToPx,
     )) {
       ctx.strokeRect(bx, yTop, barW, bh);
     }
 
-    if (i < n - 1) {
+    if (i < n - 1 && chart.chartexConnectorLines !== false) {
       const nextBx = px0 + gapW * (i + 1) + (gapW - barW) / 2;
       const connY = bar.isPos ? yTop : yBot;
       ctx.save();
-      if (applyChartExLineStyle(
+      if (applyChartExSeriesLineStyle(
         ctx,
         chart,
         chart.chartexDataPointLineStyle,
+        series,
         accentIndex,
         3,
         '#ccc',
@@ -5811,32 +6250,34 @@ function renderWaterfallChart(
     }
 
     const rawVal = vals[i] ?? 0;
-    // Locale-independent §18.8.30 formatting, honoring the authored negative
-    // section as-is. Excel accounting formats commonly render negatives in
-    // parentheses; the renderer must not replace that syntax with a triangle.
-    const labelFormat = chart.dataLabelFormatCode ?? chart.series[0]?.valFormatCode ?? null;
-    const labelText = formatChartValWithCode(rawVal, labelFormat, chart.date1904);
-    // Per-data-point label colour from chartEx `<cx:dataLabel idx>` (parsed
-    // into series.dataLabelColors). Falls back to chart.dataLabelFontColor,
-    // then to neutral grey.
-    const perPointColor = chart.series[0]?.dataLabelColors?.[i] ?? null;
-    const labelColor = perPointColor
-      ? `#${perPointColor}`
-      : chart.dataLabelFontColor
-        ? `#${chart.dataLabelFontColor}`
-        : '#595959';
-    ctx.fillStyle = labelColor;
-    const dataLabelFontPx = axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
-    ctx.font = `${chart.dataLabelFontBold ? 'bold ' : ''}${dataLabelFontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
-    ctx.textAlign = 'center';
-    // Negative bars: label sits below the bar; positive bars and subtotals
-    // place it above the bar.
-    if (rawVal < 0) {
-      ctx.textBaseline = 'top';
-      ctx.fillText(labelText, bx + barW / 2, yBot + 3);
-    } else {
-      ctx.textBaseline = 'bottom';
-      ctx.fillText(labelText, bx + barW / 2, yTop - 3);
+    const label = resolveChartExLabel(
+      chart, series, i, cats[i] ?? '', rawVal,
+      { visible: true, showVal: true, showCatName: false },
+    );
+    if (label) {
+      const perPointColor = series?.dataLabelColors?.[i] ?? label.fontColor ?? null;
+      ctx.fillStyle = perPointColor
+        ? `#${perPointColor}`
+        : chart.dataLabelFontColor
+          ? `#${chart.dataLabelFontColor}`
+          : '#595959';
+      const dataLabelFontPx = label.fontSizeHpt
+        ? (label.fontSizeHpt / 100) * ptToPx
+        : axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
+      ctx.font = `${label.fontBold || chart.dataLabelFontBold ? 'bold ' : ''}${dataLabelFontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
+      ctx.textAlign = 'center';
+      // Negative bars: label sits below the bar; positive bars and subtotals
+      // place it above the bar unless an authored position requests center.
+      if (label.position === 'ctr') {
+        ctx.textBaseline = 'middle';
+        ctx.fillText(label.text, bx + barW / 2, (yTop + yBot) / 2);
+      } else if (rawVal < 0) {
+        ctx.textBaseline = 'top';
+        ctx.fillText(label.text, bx + barW / 2, yBot + 3);
+      } else {
+        ctx.textBaseline = 'bottom';
+        ctx.fillText(label.text, bx + barW / 2, yTop - 3);
+      }
     }
   });
 
@@ -5848,13 +6289,9 @@ function renderWaterfallChart(
   const labelY = py0 + ph + 4;
   for (let i = 0; i < n && !chart.catAxisHidden; i++) {
     const ccx = px0 + gapW * i + gapW / 2;
-    const lines = wrapMeasuredText(
-      ctx,
-      formatCategoryLabel(cats[i], chart.catAxisFormatCode, chart.date1904),
-      Math.max(1, gapW - 8),
-    );
+    const lines = wrappedCategories[i] ?? [];
     lines.forEach((line, lineIndex) =>
-      ctx.fillText(line, ccx, labelY + lineIndex * (catFontPx + 2))
+      line && ctx.fillText(line, ccx, labelY + lineIndex * (catFontPx + 2))
     );
   }
 
@@ -5901,9 +6338,15 @@ function renderFunnelChart(
   shapeRotationDeg: number,
 ): void {
   const values = chart.series[0]?.values ?? [];
-  const n = Math.min(chart.categories.length, values.length);
+  // ChartEx dimensions carry independent indexed points. Preserve category-only
+  // slots as empty bars and numeric-only slots as unlabeled bars.
+  const n = Math.max(values.length, chart.categories.length);
   if (n === 0) return;
-  const max = Math.max(0, ...values.slice(0, n).map(value => value ?? 0));
+  if (rejectOversizedCanvasChart(ctx, r, n)) return;
+  let max = 0;
+  for (let index = 0; index < n; index++) {
+    max = Math.max(max, values[index] ?? 0);
+  }
   if (!(max > 0)) return;
   const { x, y, w, h } = r;
   const titleBand = cartesianTitleBand(chart, h, ptToPx);
@@ -5912,9 +6355,13 @@ function renderFunnelChart(
   const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
   ctx.save();
   ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${catFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
-  const labelW = chart.catAxisHidden
-    ? 0
-    : Math.max(...chart.categories.slice(0, n).map(label => ctx.measureText(label).width), 0) + 10;
+  let labelW = 0;
+  if (!chart.catAxisHidden) {
+    for (let index = 0; index < Math.min(n, chart.categories.length); index++) {
+      labelW = Math.max(labelW, ctx.measureText(chart.categories[index]).width);
+    }
+    if (chart.categories.length > 0) labelW += 10;
+  }
   const pad = {
     t: titleBand.bandH + legTopH + 2,
     r: legRightW + w * 0.02,
@@ -5925,25 +6372,48 @@ function renderFunnelChart(
   drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
   const { px0, py0, pw, ph } = frame.plotRect;
   const rowH = ph / n;
-  const barH = rowH / (1 + (chart.barGapWidth ?? 50) / 100);
-  const color = `#${chart.series[0]?.color ?? chartExDataPointFill(chart, 0, 1)}`;
-  const paint = chart.series[0]?.color
-    ? { fillType: 'solid', color: chart.series[0].color } as Fill
-    : chartExDataPointPaint(chart, 0, 1);
+  // Apply only an authored ChartEx gap. CT_CategoryAxisScaling does not define
+  // an omitted-value default; matching application auto-spacing is #1227.
+  const barH = chart.barGapWidth == null
+    ? rowH
+    : rowH / (1 + chart.barGapWidth / 100);
+  const series = chart.series[0];
+  const color = `#${series?.color ?? chartExDataPointFill(chart, 0, 1, series?.chartexStyle)}`;
+  const paint = chartExDataPointPaint(chart, 0, 1, series?.chartexStyle, series?.color);
   for (let index = 0; index < n; index++) {
     const value = Math.max(0, values[index] ?? 0);
     const barW = pw * value / max;
     const bx = px0 + (pw - barW) / 2;
     const by = py0 + rowH * index + (rowH - barH) / 2;
-    if (!chart.chartexDataPointStyle?.fillHidden) {
+    if (paint) {
       ctx.fillStyle = chartExFillStyle(ctx, paint, bx, by, barW, barH, color, shapeRotationDeg);
       ctx.fillRect(bx, by, barW, barH);
     }
-    if (!chart.catAxisHidden) {
+    if (applyChartExSeriesLineStyle(
+      ctx, chart, chart.chartexDataPointStyle, series, 0, 1, color, ptToPx,
+    )) {
+      ctx.strokeRect(bx, by, barW, barH);
+    }
+    const category = chart.categories[index];
+    if (!chart.catAxisHidden && category != null) {
       ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#595959';
       ctx.textAlign = 'right';
       ctx.textBaseline = 'middle';
-      ctx.fillText(chart.categories[index], px0 - 6, by + barH / 2);
+      ctx.fillText(category, px0 - 6, by + barH / 2);
+    }
+    const label = resolveChartExLabel(
+      chart, series, index, category ?? '', value,
+      { visible: false, showVal: false, showCatName: false },
+    );
+    if (label) {
+      const fontPx = label.fontSizeHpt
+        ? (label.fontSizeHpt / 100) * ptToPx
+        : axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
+      ctx.font = `${label.fontBold ? 'bold ' : ''}${fontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
+      ctx.fillStyle = label.fontColor ? `#${label.fontColor}` : '#ffffff';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(label.text, bx + barW / 2, by + barH / 2);
     }
   }
   if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
@@ -5975,7 +6445,10 @@ function renderParetoLineChart(
     chartType: 'line',
     categories: cumulative.map((_value, index) => String(index + 1)),
     series: [{ ...source, values: cumulative, showMarker: false }],
-    catAxisHidden: true,
+    // Pareto's ordinal category labels are suppressed, but its authored
+    // category-axis rule remains visible. Keep those two concerns separate.
+    catAxisHidden: false,
+    catAxisTickLabelPos: 'none',
     showLegend: false,
     valMin: 0,
   }, r, ptToPx);
@@ -6137,6 +6610,9 @@ function renderBoxWhiskerChart(
   const cats = box.categories;
   const nCat = cats.length;
   const nSer = box.series.length;
+  const boxStyleIndices = box.series.map((series, index) =>
+    chartExSeriesFormatIndex(series, index)
+  );
 
   // Excel's automatic value axis uses nice-rounded bounds and steps.
   const { min: axisMin, max: axisMax, step } = valueAxisScale(
@@ -6146,11 +6622,7 @@ function renderBoxWhiskerChart(
   const yOf = (v: number): number => py0 + ph * (1 - (v - axisMin) / span);
 
   const valAxisLine = resolveAxisLine(chart.valAxisLineColor, chart.valAxisLineWidthEmu, ptToPx);
-  const valGridline = resolveGridline(
-    chart.valAxisGridlineColor,
-    chart.valAxisGridlineWidthEmu,
-    ptToPx,
-  );
+  const valGridline = valGridStroke(chart, ptToPx);
 
   // Value-axis gridlines + labels (unless the value axis is hidden).
   ctx.save();
@@ -6158,12 +6630,21 @@ function renderBoxWhiskerChart(
     ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${valFontPx}px ${font}`;
     ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
+    if (chart.valAxisMinorGridlines) {
+      const minorGridline = valMinorGridStroke(chart, ptToPx);
+      forEachMinorTick(axisMin, axisMax, step, chart.valAxisMinorUnit, value => {
+        strokeValueGridlineH(ctx, px0, pw, yOf(value), false, minorGridline);
+      });
+    }
     for (let v = axisMin; v <= axisMax + 1e-6; v += step) {
       const gy = yOf(v);
       if (chart.valAxisMajorGridlines !== false) {
         ctx.strokeStyle = valGridline.color;
         ctx.lineWidth = valGridline.width;
+        const previousDash = valGridline.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+        if (valGridline.dash.length > 0) ctx.setLineDash(valGridline.dash);
         ctx.beginPath(); ctx.moveTo(px0, gy); ctx.lineTo(px0 + pw, gy); ctx.stroke();
+        if (valGridline.dash.length > 0) ctx.setLineDash(previousDash);
       }
       ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#595959';
       ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 4, gy);
@@ -6179,6 +6660,12 @@ function renderBoxWhiskerChart(
         chart.valAxisLineHidden,
       );
     }
+    forEachMinorTick(axisMin, axisMax, step, chart.valAxisMinorUnit, value => {
+      drawAxisTick(
+        ctx, chart.valAxisMinorTickMark, 'val', px0, yOf(value),
+        valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden,
+      );
+    });
     if (!chart.valAxisLineHidden) {
       ctx.strokeStyle = valAxisLine.color;
       ctx.lineWidth = valAxisLine.width;
@@ -6192,31 +6679,47 @@ function renderBoxWhiskerChart(
     ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
   }
 
-  // Category slots place every series at the same category coordinate. ChartEx
-  // box/whisker series are overlays, not clustered legacy bars; their boxes
-  // therefore share the full authored category width.
   // ChartEx places categorical box/whisker data points at interior category
   // positions, leaving one category interval between each plot edge and the
-  // first/last point. `gapWidth` controls the box-vs-gap width inside that
-  // interval; it does not consume the two outer category intervals.
+  // first/last point. Multiple populated series split the category group so
+  // their boxes remain individually visible. `gapWidth` controls the
+  // group-vs-gap width inside that interval.
   const slotW = pw / (nCat + 1);
   const gapWidthPct = chart.barGapWidth ?? 150;
   const groupW = slotW / (1 + gapWidthPct / 100);
   const paletteOf = (si: number): string => {
-    const fill = box.series[si].color ?? chartExDataPointFill(chart, si, nSer);
+    const fill = box.series[si].color
+      ?? chartExDataPointFill(
+        chart, boxStyleIndices[si], nSer, box.series[si].chartexStyle,
+      );
     return `#${fill}`;
   };
-  const paintOf = (si: number): Fill => box.series[si].color
-    ? { fillType: 'solid', color: box.series[si].color as string }
-    : chartExDataPointPaint(chart, si, nSer);
+  const paintOf = (si: number): Fill | null => chartExDataPointPaint(
+    chart,
+    boxStyleIndices[si],
+    nSer,
+    box.series[si].chartexStyle,
+    box.series[si].color,
+  );
   const statsBySeries = box.series.map(series => series.valuesByCategory.map(values => (
     computeBoxStats(values, series.quartileMethod)
   )));
+  const populatedSeriesByCategory = cats.map((_category, categoryIndex) =>
+    box.series
+      .map((series, seriesIndex) => ({
+        seriesIndex,
+        populated: (series.valuesByCategory[categoryIndex]?.length ?? 0) > 0,
+      }))
+      .filter(entry => entry.populated)
+      .map(entry => entry.seriesIndex)
+  );
   const boxGeometry = (ci: number, si: number): { bx: number; boxW: number; cx: number } => {
     const categoryCenterX = px0 + slotW * (ci + 1);
     const slotLeft = categoryCenterX - groupW / 2;
-    const boxW = groupW;
-    const bx = slotLeft;
+    const populated = populatedSeriesByCategory[ci];
+    const activeIndex = Math.max(0, populated.indexOf(si));
+    const boxW = groupW / Math.max(1, populated.length);
+    const bx = slotLeft + activeIndex * boxW;
     return { bx, boxW, cx: bx + boxW / 2 };
   };
 
@@ -6228,7 +6731,9 @@ function renderBoxWhiskerChart(
     const lineStyle = chart.chartexDataPointLineStyle ?? chart.chartexDataPointStyle;
     const fallback = series.lineColor ? `#${series.lineColor}` : paletteOf(si);
     ctx.save();
-    const styleLineVisible = applyChartExLineStyle(ctx, chart, lineStyle, si, nSer, fallback, ptToPx);
+    const styleLineVisible = applyChartExSeriesLineStyle(
+      ctx, chart, lineStyle, series, boxStyleIndices[si], nSer, fallback, ptToPx,
+    );
     if (styleLineVisible || series.lineColor != null) {
       if (series.lineColor) ctx.strokeStyle = fallback;
       if (series.lineWidthEmu) ctx.lineWidth = axisLineWidthPx(series.lineWidthEmu, ptToPx);
@@ -6263,30 +6768,44 @@ function renderBoxWhiskerChart(
       const pointStyle = chart.chartexDataPointStyle;
       const lineStyle = chart.chartexDataPointLineStyle ?? pointStyle;
       const markerStyle = chart.chartexDataPointMarkerStyle ?? pointStyle;
-      const styleLine = chartExStyleColor(chart, pointStyle, 'line', si, nSer);
+      const styleIndex = boxStyleIndices[si];
+      const styleLine = chartExStyleColor(chart, pointStyle, 'line', styleIndex, nSer);
       const edge = s.lineColor ? `#${s.lineColor}` : styleLine ? `#${styleLine}` : fill;
       const edgeWidth = s.lineWidthEmu
         ? axisLineWidthPx(s.lineWidthEmu, ptToPx)
         : pointStyle?.lineWidthEmu != null
           ? axisLineWidthPx(pointStyle.lineWidthEmu, ptToPx)
           : 1;
-      const lineEdge = chartExStyleColor(chart, lineStyle, 'line', si, nSer);
-      const markerFill = chartExStyleColor(chart, markerStyle, 'fill', si, nSer);
-      const markerFillPaint = chartExStyleFillPaint(markerStyle, si) ?? fillPaint;
-      const markerEdge = chartExStyleColor(chart, markerStyle, 'line', si, nSer);
+      const lineEdge = chartExStyleColor(chart, lineStyle, 'line', styleIndex, nSer);
+      const markerFill = chartExStyleColor(chart, markerStyle, 'fill', styleIndex, nSer);
+      const markerFillPaint = chartExDataPointPaint(
+        chart, styleIndex, nSer, s.chartexStyle, s.color, markerStyle,
+      );
+      const markerEdge = chartExStyleColor(chart, markerStyle, 'line', styleIndex, nSer);
       const applySeriesLine = (style: ChartExStyle | null | undefined, fallback: string): boolean => {
-        const visible = applyChartExLineStyle(ctx, chart, style, si, nSer, fallback, ptToPx);
+        const local = s.chartexStyle;
+        const hasLocalLine = local?.lineHidden != null
+          || local?.lineColors?.some(Boolean)
+          || local?.lineWidthEmu != null
+          || local?.lineDash != null
+          || local?.lineCap != null
+          || local?.lineJoin != null;
+        const visible = applyChartExSeriesLineStyle(
+          ctx, chart, style, s, styleIndex, nSer, fallback, ptToPx,
+        );
         // Chart Style `NoStyle` means that this role supplies no decorative
         // override. Box/whisker's semantic outline still exists. This is
         // distinct from an authored `<a:noFill>`, which remains suppressed.
-        if (!visible && style?.lineNoStyle) {
+        const semanticNoStyleFallback = style?.lineNoStyle === true
+          && !hasLocalLine && s.lineColor == null && s.lineWidthEmu == null;
+        if (!visible && semanticNoStyleFallback) {
           ctx.strokeStyle = fallback;
           ctx.lineWidth = 1;
           ctx.setLineDash([]);
         }
         if (s.lineColor) ctx.strokeStyle = edge;
         if (s.lineWidthEmu) ctx.lineWidth = edgeWidth;
-        return visible || style?.lineNoStyle === true || s.lineColor != null;
+        return visible || semanticNoStyleFallback || s.lineColor != null;
       };
       const yQ1 = yOf(stats.q1);
       const yQ3 = yOf(stats.q3);
@@ -6305,7 +6824,7 @@ function renderBoxWhiskerChart(
       }
 
       // IQR box: solid accent fill + a thin accent×0.8 edge.
-      if (!pointStyle?.fillHidden) {
+      if (fillPaint) {
         ctx.fillStyle = chartExFillStyle(
           ctx,
           fillPaint,
@@ -6336,24 +6855,44 @@ function renderBoxWhiskerChart(
       // Interior sample points. Excel overlays the raw non-outlier values on
       // the box/whiskers when cx:visibility@nonoutliers is enabled.
       if (s.showNonoutliers) {
-        const pR = Math.max(1.25, boxW * 0.045);
-        const markerLineVisible = applySeriesLine(markerStyle, markerEdge ?? edge);
+        const pR = chart.chartexMarkerSizePt != null
+          ? (chart.chartexMarkerSizePt * ptToPx) / 2
+          : Math.max(1.25, boxW * 0.045);
+        const pointSymbol = chart.chartexMarkerSymbol ?? 'circle';
         for (const point of stats.inner) {
+          if (pointSymbol === 'none') continue;
+          const markerLineVisible = applySeriesLine(markerStyle, markerEdge ?? edge);
           const pointY = yOf(point);
-          ctx.fillStyle = chartExFillStyle(
-            ctx,
-            markerFillPaint,
-            cx - pR,
-            pointY - pR,
-            pR * 2,
-            pR * 2,
-            markerFill ? `#${markerFill}` : fill,
-            shapeRotationDeg,
-          );
-          ctx.beginPath();
-          ctx.arc(cx, pointY, pR, 0, Math.PI * 2);
-          if (!markerStyle?.fillHidden) ctx.fill();
-          if (markerLineVisible) ctx.stroke();
+          if (markerFillPaint) {
+            ctx.fillStyle = chartExFillStyle(
+              ctx,
+              markerFillPaint,
+              cx - pR,
+              pointY - pR,
+              pR * 2,
+              pR * 2,
+              markerFill ? `#${markerFill}` : fill,
+              shapeRotationDeg,
+            );
+          }
+          if (pointSymbol === 'circle') {
+            ctx.beginPath();
+            ctx.arc(cx, pointY, pR, 0, Math.PI * 2);
+            if (markerFillPaint) ctx.fill();
+            if (markerLineVisible) ctx.stroke();
+          } else {
+            drawMarker(
+              ctx,
+              cx,
+              pointY,
+              pointSymbol,
+              chart.chartexMarkerSizePt ?? (pR * 2) / ptToPx,
+              markerFillPaint ? (markerFill ? `#${markerFill}` : fill) : 'transparent',
+              markerLineVisible ? (markerEdge ? `#${markerEdge}` : edge) : null,
+              ptToPx,
+              ctx.lineWidth,
+            );
+          }
         }
       }
 
@@ -6371,23 +6910,43 @@ function renderBoxWhiskerChart(
 
       // Outlier dots.
       if (s.showOutliers) {
-        const markerLineVisible = applySeriesLine(markerStyle, markerEdge ?? edge);
-        const oR = Math.max(1.5, boxW * 0.06);
+        const pointSymbol = chart.chartexMarkerSymbol ?? 'circle';
+        const oR = chart.chartexMarkerSizePt != null
+          ? (chart.chartexMarkerSizePt * ptToPx) / 2
+          : Math.max(1.5, boxW * 0.06);
         for (const o of stats.outliers) {
+          if (pointSymbol === 'none') continue;
+          const markerLineVisible = applySeriesLine(markerStyle, markerEdge ?? edge);
           const outlierY = yOf(o);
-          ctx.fillStyle = chartExFillStyle(
-            ctx,
-            markerFillPaint,
-            cx - oR,
-            outlierY - oR,
-            oR * 2,
-            oR * 2,
-            markerFill ? `#${markerFill}` : fill,
-            shapeRotationDeg,
-          );
-          ctx.beginPath(); ctx.arc(cx, outlierY, oR, 0, Math.PI * 2);
-          if (!markerStyle?.fillHidden) ctx.fill();
-          if (markerLineVisible) ctx.stroke();
+          if (markerFillPaint) {
+            ctx.fillStyle = chartExFillStyle(
+              ctx,
+              markerFillPaint,
+              cx - oR,
+              outlierY - oR,
+              oR * 2,
+              oR * 2,
+              markerFill ? `#${markerFill}` : fill,
+              shapeRotationDeg,
+            );
+          }
+          if (pointSymbol === 'circle') {
+            ctx.beginPath(); ctx.arc(cx, outlierY, oR, 0, Math.PI * 2);
+            if (markerFillPaint) ctx.fill();
+            if (markerLineVisible) ctx.stroke();
+          } else {
+            drawMarker(
+              ctx,
+              cx,
+              outlierY,
+              pointSymbol,
+              chart.chartexMarkerSizePt ?? (oR * 2) / ptToPx,
+              markerFillPaint ? (markerFill ? `#${markerFill}` : fill) : 'transparent',
+              markerLineVisible ? (markerEdge ? `#${markerEdge}` : edge) : null,
+              ptToPx,
+              ctx.lineWidth,
+            );
+          }
         }
       }
     }
@@ -6427,7 +6986,9 @@ function renderBoxWhiskerChart(
     series: box.series.map((series, index) => ({
       name: series.name,
       values: [],
-      color: series.color ?? chartExDataPointFill(chart, index, nSer),
+      color: series.color ?? chartExDataPointFill(
+        chart, boxStyleIndices[index], nSer, series.chartexStyle,
+      ),
     })),
   };
   drawLegendForLayout(
@@ -6573,7 +7134,21 @@ function renderSunburstChart(
   const sb = chart.chartexSunburst;
   if (!sb || sb.rows.length === 0) return;
   const { x, y, w, h } = r;
-
+  const root = buildSunburstTree(sb.rows);
+  if (root.value <= 0 || root.children.length === 0) return;
+  const series = chart.series[0];
+  const legendPaints = root.children.map((_, index) =>
+    chartExDataPointPaint(chart, index, root.children.length, series?.chartexStyle, series?.color)
+  );
+  const legendChart: ChartModel = {
+    ...chart,
+    chartType: 'clusteredBar',
+    series: root.children.map((node, index) => ({
+      name: node.label,
+      values: [],
+      color: chartExDataPointFill(chart, index, root.children.length, series?.chartexStyle),
+    })),
+  };
   // Reuse the radial frame so an authored top legend reserves space above the
   // rings instead of being painted over the circle.
   const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
@@ -6588,18 +7163,11 @@ function renderSunburstChart(
   const cy = py0 + ph / 2;
   const outerR = Math.min(pw, ph) * 0.46;
 
-  const root = buildSunburstTree(sb.rows);
-  if (root.value <= 0 || root.children.length === 0) return;
   // Full circle from 12 o'clock (−90°), clockwise (canvas angles grow CW), each
   // parent partitioning its range across its children in source (first-seen)
   // order. This is the natural spec-consistent reading of the `<cx:lvl>` point
-  // order. NB: Excel's own sunburst places the branches AFTER the first in a
-  // different rotational order (for sample-24 the observed clockwise order is
-  // Branch 1, 3, 2 rather than 1, 2, 3) — an undocumented runtime layout choice.
-  // Matching it exactly would require reverse-engineering that ordering, which
-  // the project's spec-first policy forbids without a documented rule, so the
-  // rings/hierarchy/proportions/colors match while the branch *placement* order
-  // is the straightforward source order.
+  // order. The extension does not specify an alternative automatic reordering,
+  // so the renderer does not infer one from labels or values.
   root.a0 = -Math.PI / 2;
   root.a1 = -Math.PI / 2 + Math.PI * 2;
   layoutSunburstAngles(root);
@@ -6612,17 +7180,23 @@ function renderSunburstChart(
   const ringBand = (outerR - innerR) / ringCount;
 
   const branchColor = (bi: number): string => {
-    const hex = chartExDataPointFill(chart, bi, root.children.length);
+    const hex = chartExDataPointFill(chart, bi, root.children.length, series?.chartexStyle);
     return `#${hex}`;
   };
-  const branchPaint = (bi: number): Fill => chartExDataPointPaint(
+  const branchPaint = (bi: number): Fill | null => chartExDataPointPaint(
     chart,
     bi,
     root.children.length,
+    series?.chartexStyle,
+    series?.color,
   );
 
+  const labelDef = series?.seriesDataLabels;
   const labelFont = chartFontFamily(chart, chart.dataLabelFontFace, 'minor');
-  const labelPx = Math.max(7, Math.min(13, outerR * 0.075));
+  const labelPx = labelDef?.fontSizeHpt
+    ? (labelDef.fontSizeHpt / 100) * ptToPx
+    : Math.max(7, Math.min(13, outerR * 0.075));
+  const labelColor = labelDef?.fontColor ? `#${labelDef.fontColor}` : '#ffffff';
 
   // Draw every non-root node as a ring segment, deepest-last so borders read on
   // top. Iterate breadth-first by depth.
@@ -6644,10 +7218,11 @@ function renderSunburstChart(
       ctx.arc(cx, cy, rOuter, node.a0, node.a1);
       ctx.arc(cx, cy, rInner, node.a1, node.a0, true);
       ctx.closePath();
-      if (!chart.chartexDataPointStyle?.fillHidden) {
+      const nodePaint = branchPaint(node.branchIndex);
+      if (nodePaint) {
         ctx.fillStyle = chartExFillStyle(
           ctx,
-          branchPaint(node.branchIndex),
+          nodePaint,
           cx - rOuter,
           cy - rOuter,
           rOuter * 2,
@@ -6657,10 +7232,11 @@ function renderSunburstChart(
         );
         ctx.fill();
       }
-      if (applyChartExLineStyle(
+      if (applyChartExSeriesLineStyle(
         ctx,
         chart,
         chart.chartexDataPointStyle,
+        chart.series[0],
         node.branchIndex,
         root.children.length,
         '#ffffff',
@@ -6668,6 +7244,17 @@ function renderSunburstChart(
       )) {
         ctx.stroke();
       }
+
+      const label = resolveChartExLabel(
+        chart, series, node.labelIndex, node.label, node.value,
+        { visible: false, showVal: false, showCatName: false },
+      );
+      if (!label) continue;
+      const labelText = label.text;
+      const nodeLabelPx = label.fontSizeHpt
+        ? (label.fontSizeHpt / 100) * ptToPx
+        : labelPx;
+      const nodeLabelColor = label.fontColor ? `#${label.fontColor}` : labelColor;
 
       // Excel's sunburst category labels run along the radius (not around the
       // circumference). Center the text at the wedge mid-radius and wrap it to
@@ -6679,7 +7266,7 @@ function renderSunburstChart(
       // Tangential arc length at the mid radius.
       const arcLen = sweep * midR;
       // Skip labels that plainly cannot fit even one glyph.
-      if (radialRoom < labelPx * 0.9 && arcLen < labelPx * 0.9) continue;
+      if (radialRoom < nodeLabelPx * 0.9 && arcLen < nodeLabelPx * 0.9) continue;
 
       ctx.save();
       ctx.translate(cx + Math.cos(midA) * midR, cy + Math.sin(midA) * midR);
@@ -6689,13 +7276,13 @@ function renderSunburstChart(
       const deg = ((rot * 180) / Math.PI) % 360;
       if (deg > 90 || deg < -90) rot += Math.PI;
       ctx.rotate(rot);
-      ctx.font = `${labelPx}px ${labelFont}`;
-      ctx.fillStyle = '#ffffff';
+      ctx.font = `${label.fontBold ? 'bold ' : ''}${nodeLabelPx}px ${labelFont}`;
+      ctx.fillStyle = nodeLabelColor;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
       // The rotated frame's x-axis is radial: width is the ring band and the
       // available line stack is the wedge's tangential arc length.
-      const words = node.label.split(/\s+/).filter(Boolean);
+      const words = labelText.split(/\s+/).filter(Boolean);
       const maxLineW = radialRoom - 2;
       const lines: string[] = [];
       let cur = '';
@@ -6713,9 +7300,8 @@ function renderSunburstChart(
           cur = word;
           continue;
         }
-        // Narrow outer rings legitimately split a long category name inside
-        // the word (Excel's sample renders "Califor" / "nia"). Retain every
-        // character instead of eliding the label.
+        // Narrow outer rings may require a break inside a long category name.
+        // Retain every character instead of eliding the label.
         let chunk = '';
         for (const char of word) {
           const next = chunk + char;
@@ -6730,7 +7316,7 @@ function renderSunburstChart(
       }
       if (cur) lines.push(cur);
       // Cap the number of lines to what the tangential arc holds.
-      const lineH = labelPx * 1.05;
+      const lineH = nodeLabelPx * 1.05;
       const maxLines = Math.max(1, Math.floor(arcLen / lineH));
       const shown = lines.slice(0, maxLines).map(l => elideToWidth(ctx, l, maxLineW));
       const totalH = shown.length * lineH;
@@ -6743,15 +7329,6 @@ function renderSunburstChart(
   }
   ctx.restore();
 
-  const legendChart: ChartModel = {
-    ...chart,
-    chartType: 'clusteredBar',
-    series: root.children.map((node, index) => ({
-      name: node.label,
-      values: [],
-      color: chartExDataPointFill(chart, index, root.children.length),
-    })),
-  };
   drawLegendForLayout(
     ctx,
     legendChart,
@@ -6766,7 +7343,7 @@ function renderSunburstChart(
     ph,
     frame.title.bandH + 2,
     ptToPx,
-    root.children.map((_, index) => branchPaint(index)),
+    legendPaints,
     shapeRotationDeg,
   );
 }
@@ -6865,7 +7442,25 @@ function renderTreemapChart(
 ): void {
   const treemap = chart.chartexTreemap;
   if (!treemap || treemap.rows.length === 0) return;
-
+  // A treemap data point remains a distinct tile even when its terminal label
+  // repeats. Only parent path components are grouping keys.
+  const root = buildSunburstTree(treemap.rows, true);
+  if (root.value <= 0 || root.children.length === 0) return;
+  const series = chart.series[0];
+  const legendPaints = root.children.map(node =>
+    chartExDataPointPaint(
+      chart, node.branchIndex, root.children.length, series?.chartexStyle, series?.color,
+    )
+  );
+  const legendChart: ChartModel = {
+    ...chart,
+    chartType: 'clusteredBar',
+    series: root.children.map((node, index) => ({
+      name: node.label,
+      values: [],
+      color: chartExDataPointFill(chart, index, root.children.length, series?.chartexStyle),
+    })),
+  };
   const frame = computeChartFrame(chart, r.x, r.y, r.w, r.h, ptToPx, {
     titleTopPadFrac: 0.035,
     titleBottomPadFrac: 0.035,
@@ -6873,10 +7468,6 @@ function renderTreemapChart(
     radialGapFrac: 0.015,
   });
   drawChartTitleForLayout(ctx, chart, r.x, r.y, r.w, r.h, r.y + frame.title.topPad, frame.title.fontPx);
-  // A treemap data point remains a distinct tile even when its terminal label
-  // repeats. Only parent path components are grouping keys.
-  const root = buildSunburstTree(treemap.rows, true);
-  if (root.value <= 0 || root.children.length === 0) return;
 
   const fontFamily = chartFontFamily(chart, chart.dataLabelFontFace, 'minor');
   const parentMode = treemap.parentLabelLayout ?? 'overlapping';
@@ -6891,11 +7482,15 @@ function renderTreemapChart(
 
   const paint = (node: SunburstNode, tile: TreemapRect): void => {
     if (tile.w < 0.5 || tile.h < 0.5) return;
-    const base = chartExDataPointFill(chart, node.branchIndex, root.children.length);
+    const base = chartExDataPointFill(
+      chart, node.branchIndex, root.children.length, series?.chartexStyle,
+    );
     // Every descendant of a top-level branch uses that branch's exact accent.
     // Hierarchy depth does not tint or whiten ChartEx treemap data points.
     const color = `#${base}`;
-    const fillPaint = chartExDataPointPaint(chart, node.branchIndex, root.children.length);
+    const fillPaint = chartExDataPointPaint(
+      chart, node.branchIndex, root.children.length, series?.chartexStyle, series?.color,
+    );
     const labelOverride = labelOverrides.get(node.labelIndex);
     const nodeLabelColor = labelOverride?.fontColor ? `#${labelOverride.fontColor}` : labelColor;
     const nodeLabelFontPx = labelOverride?.fontSizeHpt
@@ -6904,11 +7499,14 @@ function renderTreemapChart(
     const nodeLabelBold = labelOverride?.fontBold ?? labelDef?.fontBold ?? false;
 
     if (node.children.length > 0) {
-      // Office vector output across a three-level hierarchy boundary set shows
-      // `overlapping` captions only for top-level branches. Intermediate nodes
-      // still partition their children but do not place another caption at the
-      // same tile origin. `banner` remains separate because it reserves a band.
-      const showParent = parentMode !== 'none'
+      // `overlapping` captions belong to the top-level branch entries exposed
+      // by the legend; intermediate nodes still partition their descendants.
+      // `banner` remains separate because it reserves a band at each parent.
+      const parentLabel = resolveChartExLabel(
+        chart, series, node.labelIndex, node.label, node.value,
+        { visible: parentMode !== 'none', showVal: false, showCatName: true },
+      );
+      const showParent = parentLabel != null
         && (parentMode !== 'overlapping' || node.depth === 0);
       const fontPx = nodeLabelFontPx;
       const bannerH = parentMode === 'banner' && showParent
@@ -6919,7 +7517,7 @@ function renderTreemapChart(
       // create an additional painted parent rectangle; doing so here produced
       // a hairline frame around each branch. Banner mode alone reserves and
       // paints a caption band.
-      if (bannerH > 0 && !chart.chartexDataPointStyle?.fillHidden) {
+      if (bannerH > 0 && fillPaint) {
         ctx.fillStyle = chartExFillStyle(
           ctx,
           fillPaint,
@@ -6945,13 +7543,13 @@ function renderTreemapChart(
         ctx.fillStyle = nodeLabelColor;
         ctx.textAlign = 'left';
         ctx.textBaseline = 'top';
-        const shown = elideToWidth(ctx, labelOverride?.text || node.label, tile.w - 8);
+        const shown = elideToWidth(ctx, parentLabel?.text ?? '', tile.w - 8);
         if (shown) ctx.fillText(shown, tile.x + 4, tile.y + 3);
       }
       return;
     }
 
-    if (!chart.chartexDataPointStyle?.fillHidden) {
+    if (fillPaint) {
       ctx.fillStyle = chartExFillStyle(
         ctx,
         fillPaint,
@@ -6964,43 +7562,38 @@ function renderTreemapChart(
       );
       ctx.fillRect(tile.x, tile.y, tile.w, tile.h);
     }
-    if (applyChartExLineStyle(
+    const hasAuthoredOutline = applyChartExSeriesLineStyle(
       ctx,
       chart,
       chart.chartexDataPointStyle,
+      chart.series[0],
       node.branchIndex,
       root.children.length,
       '#ffffff',
       ptToPx,
-    )) {
+    );
+    if (hasAuthoredOutline) {
       // ChartEx outlines are centered on the tile boundary. An inset stroke
       // creates a second visible outer frame that Excel does not paint.
       ctx.strokeRect(tile.x, tile.y, tile.w, tile.h);
     }
 
-    const fontPx = nodeLabelFontPx;
+    const leafLabel = resolveChartExLabel(
+      chart, series, node.labelIndex, node.label, node.value,
+      { visible: false, showVal: false, showCatName: false },
+    );
+    if (!leafLabel) return;
+    const fontPx = leafLabel.fontSizeHpt
+      ? (leafLabel.fontSizeHpt / 100) * ptToPx
+      : nodeLabelFontPx;
     if (tile.w <= fontPx * 1.2 || tile.h <= fontPx * 1.2) return;
-    ctx.font = `${nodeLabelBold ? 'bold ' : ''}${fontPx}px ${fontFamily}`;
-    ctx.fillStyle = nodeLabelColor;
-    const parts: string[] = [];
-    if (labelOverride?.text) {
-      parts.push(labelOverride.text);
-    } else {
-      if (labelDef?.showCatName ?? true) parts.push(node.label);
-      if (labelDef?.showVal) {
-        parts.push(formatChartValWithCode(
-          node.value,
-          labelDef.formatCode ?? chart.series[0]?.valFormatCode ?? null,
-          chart.date1904,
-        ));
-      }
-    }
-    const lines = parts
-      .join(labelDef?.separator ?? ' ')
+    ctx.font = `${leafLabel.fontBold ? 'bold ' : ''}${fontPx}px ${fontFamily}`;
+    ctx.fillStyle = leafLabel.fontColor ? `#${leafLabel.fontColor}` : nodeLabelColor;
+    const lines = leafLabel.text
       .split(/\r?\n/)
       .flatMap(line => wrapMeasuredText(ctx, line, Math.max(1, tile.w - 8)));
     const lineH = fontPx * 1.1;
-    const position = labelDef?.position ?? 'ctr';
+    const position = leafLabel.position ?? 'ctr';
     const maxLines = Math.max(0, Math.floor((tile.h - 6) / lineH));
     ctx.save();
     ctx.beginPath();
@@ -7036,15 +7629,6 @@ function renderTreemapChart(
   }
   ctx.restore();
 
-  const legendChart: ChartModel = {
-    ...chart,
-    chartType: 'clusteredBar',
-    series: root.children.map((node, index) => ({
-      name: node.label,
-      values: [],
-      color: chartExDataPointFill(chart, index, root.children.length),
-    })),
-  };
   drawLegendForLayout(
     ctx,
     legendChart,
@@ -7059,7 +7643,7 @@ function renderTreemapChart(
     ph,
     frame.title.bandH + 2,
     ptToPx,
-    root.children.map(node => chartExDataPointPaint(chart, node.branchIndex, root.children.length)),
+    legendPaints,
     shapeRotationDeg,
   );
 }
@@ -7270,6 +7854,23 @@ export function renderChart(
       ctx.fillText('(no data)', x + w / 2, y + h / 2);
       drawChartTextBoxes(ctx, chart, rect, ptToPx);
       return;
+    }
+
+    if (chart.chartType === 'clusteredColumn') {
+      let primitiveCount = 0;
+      for (const series of chart.series) {
+        const points = Math.max(
+          chart.categories.length,
+          series.values.length,
+          series.categories?.length ?? 0,
+        );
+        primitiveCount += points;
+        if (!Number.isSafeInteger(primitiveCount) || primitiveCount > MAX_CANVAS_CHART_POINTS) break;
+      }
+      if (rejectOversizedCanvasChart(ctx, rect, primitiveCount)) {
+        drawChartTextBoxes(ctx, chart, rect, ptToPx);
+        return;
+      }
     }
 
     switch (chart.chartType) {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -636,6 +636,29 @@ function drawAxisTick(
   ctx.lineWidth = prevW;
 }
 
+/** Visit authored minor-unit positions between adjacent major ticks. OOXML does
+ * not define the application's automatic minor unit, so an omitted
+ * `<c:minorUnit>` deliberately produces no guessed positions. */
+function forEachMinorTick(
+  min: number,
+  max: number,
+  majorStep: number,
+  minorUnit: number | null | undefined,
+  visit: (value: number) => void,
+): void {
+  const step = minorUnit != null && isFinite(minorUnit) && minorUnit > 0 && minorUnit < majorStep
+    ? minorUnit
+    : 0;
+  if (!(step > 0) || !(majorStep > 0)) return;
+  const epsilon = Math.abs(majorStep) * 1e-8;
+  const firstMajor = Math.ceil((min - epsilon) / majorStep) * majorStep;
+  for (let major = firstMajor; major < max - epsilon; major += majorStep) {
+    for (let value = major + step; value < major + majorStep - epsilon; value += step) {
+      if (value > min + epsilon && value < max - epsilon) visit(value);
+    }
+  }
+}
+
 /** Stroke one horizontal value-axis gridline spanning the plot width at `gy`.
  *  Extracted from the identical stroke the column-bar, line and area renderers
  *  each emitted inline. `isZero` is the caller's "this is the value-0 line"
@@ -1093,6 +1116,7 @@ function computeSecondaryAxis(
  *    none (the primary value-axis label color). */
 function drawSecondaryValueAxis(
   ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
   sec: SecondaryValueAxis,
   secScale: SecondaryAxisScale,
   toYSecondary: (v: number) => number,
@@ -1111,7 +1135,7 @@ function drawSecondaryValueAxis(
     ctx.beginPath(); ctx.moveTo(axX, py0); ctx.lineTo(axX, py0 + ph); ctx.stroke();
   }
   if (!sec.hidden) {
-    ctx.font = `${secFontPx}px sans-serif`;
+    ctx.font = `${secFontPx}px ${chartFontFamily(chart, sec.fontFace, 'minor')}`;
     ctx.fillStyle = sec.fontColor ? `#${sec.fontColor}` : primaryLabelColor;
     ctx.textAlign = 'left';
     ctx.textBaseline = 'middle';
@@ -1124,6 +1148,11 @@ function drawSecondaryValueAxis(
       drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true, sec.lineHidden);
       ctx.fillText(formatChartValWithCode(sval, sec.formatCode ?? null, date1904), axX + 14, gy);
     }
+    if (sec.minorTickMark && sec.minorTickMark !== 'none') {
+      forEachMinorTick(secScale.min, secScale.max, secScale.step, sec.minorUnit, value => {
+        drawAxisTick(ctx, sec.minorTickMark, 'val', axX, toYSecondary(value), secLineColor, secLineW, true, sec.lineHidden);
+      });
+    }
   }
   if (sec.title) {
     const tFontPx = sec.titleFontSizeHpt ? (sec.titleFontSizeHpt / 100) * ptToPx : Math.max(9, h * 0.05);
@@ -1131,12 +1160,14 @@ function drawSecondaryValueAxis(
     ctx.fillStyle = sec.titleFontColor
       ? `#${sec.titleFontColor}`
       : (sec.fontColor ? `#${sec.fontColor}` : '#555');
-    ctx.font = `${sec.titleFontBold ? 'bold ' : ''}${tFontPx}px sans-serif`;
+    const titleFamily = chartFontFamily(chart, sec.titleFontFace, 'major');
+    ctx.font = `${sec.titleFontBold ? 'bold ' : ''}${tFontPx}px ${titleFamily}`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    // Right-axis title reads top-to-bottom (rotate +90), placed past the labels.
+    // Excel keeps both value-axis titles in the same bottom-to-top reading
+    // direction. Mirroring the right-axis placement must not mirror its text.
     ctx.translate(px0 + pw + secLabelBandW + tFontPx * 0.6, py0 + ph / 2);
-    ctx.rotate(Math.PI / 2);
+    ctx.rotate(-Math.PI / 2);
     ctx.fillText(sec.title, 0, 0);
     ctx.restore();
   }
@@ -1780,6 +1811,15 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
         }
       }
     }
+    if (!chart.valAxisHidden && chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
+      forEachMinorTick(axMin, axMax, step, chart.valAxisMinorUnit, value => {
+        if (!isH) {
+          drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, valY(value), valLineColor, valLineW, false, chart.valAxisLineHidden);
+        } else {
+          drawAxisTick(ctx, chart.valAxisMinorTickMark, 'cat', py0 + ph, valX(value), valLineColor, valLineW, false, chart.valAxisLineHidden);
+        }
+      });
+    }
     // Category ticks sit at band BOUNDARIES with crossBetween="between" (the
     // bar/column default) — the dividers between Q1|Q2|Q3|Q4 (n+1 ticks) — and
     // at category centers under "midCat".
@@ -2114,7 +2154,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     const { color: secLineColor, width: secLineW } = resolveAxisLine(sec.lineColor, sec.lineWidthEmu, ptToPx);
     if (!sec.lineHidden) strokeAxis(axX, py0, axX, py0 + ph, secLineColor, secLineW);
     if (!sec.hidden) {
-      ctx.font = `${secFontPx}px sans-serif`;
+      ctx.font = `${secFontPx}px ${chartFontFamily(chart, sec.fontFace, 'minor')}`;
       ctx.fillStyle = sec.fontColor ? `#${sec.fontColor}` : valLabelColor;
       ctx.textAlign = 'left';
       ctx.textBaseline = 'middle';
@@ -2126,6 +2166,11 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
         drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true, sec.lineHidden);
         ctx.fillText(formatChartValWithCode(sval, sec.formatCode ?? null, chart.date1904), axX + 14, gy);
       }
+      if (sec.minorTickMark && sec.minorTickMark !== 'none') {
+        forEachMinorTick(sMin, sMax, sStep, sec.minorUnit, value => {
+          drawAxisTick(ctx, sec.minorTickMark, 'val', axX, toYSecondary(value), secLineColor, secLineW, true, sec.lineHidden);
+        });
+      }
     }
     if (sec.title) {
       const tFontPx = sec.titleFontSizeHpt ? (sec.titleFontSizeHpt / 100) * ptToPx : Math.max(9, h * 0.05);
@@ -2133,12 +2178,12 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
       ctx.fillStyle = sec.titleFontColor
         ? `#${sec.titleFontColor}`
         : (sec.fontColor ? `#${sec.fontColor}` : '#555');
-      ctx.font = `${sec.titleFontBold ? 'bold ' : ''}${tFontPx}px sans-serif`;
+      ctx.font = `${sec.titleFontBold ? 'bold ' : ''}${tFontPx}px ${chartFontFamily(chart, sec.titleFontFace, 'major')}`;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      // Right-axis title reads top-to-bottom (rotate +90), placed past the labels.
+      // Match the primary value-axis reading direction (bottom-to-top).
       ctx.translate(px0 + pw + secLabelBandW + tFontPx * 0.6, py0 + ph / 2);
-      ctx.rotate(Math.PI / 2);
+      ctx.rotate(-Math.PI / 2);
       ctx.fillText(sec.title, 0, 0);
       ctx.restore();
     }
@@ -2402,6 +2447,11 @@ function renderLineChart(
         ctx.fillText(formatPrimaryValueAxisTick(chart, v, pct), px0 - gap, gy);
       }
     }
+    if (chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
+      forEachMinorTick(plan.min, plan.max, plan.step, chart.valAxisMinorUnit, value => {
+        drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, toY(value), primaryValTickColor, primaryValTickWidth, false, chart.valAxisLineHidden);
+      });
+    }
   }
 
   // Category-axis MAJOR gridlines (`<c:catAx><c:majorGridlines>`, §21.2.2.100):
@@ -2582,7 +2632,7 @@ function renderLineChart(
   if (sec && secScale) {
     const primaryLabelColor = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
     drawSecondaryValueAxis(
-      ctx, sec, secScale, toYSecondary, px0, py0, pw, ph, h, ptToPx,
+      ctx, chart, sec, secScale, toYSecondary, px0, py0, pw, ph, h, ptToPx,
       secFontPx, secLabelBandW, primaryLabelColor, chart.date1904,
     );
   }
@@ -3316,6 +3366,12 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
         : 6;
       ctx.fillText(formatPrimaryValueAxisTick(chart, v, pct), px0 - gap, gy);
     }
+    if (chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
+      const minorUnit = valueAxisUnitInRendererSpace(chart.valAxisMinorUnit, pct);
+      forEachMinorTick(0, axMax, step, minorUnit, value => {
+        drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, toY(value), valLineColor, valLineW, false, chart.valAxisLineHidden);
+      });
+    }
   }
   // Category-axis baseline + value-axis rule. Office treats
   // `<c:*Ax><c:spPr><a:ln><a:noFill>` as suppressing the rule and tick marks
@@ -3378,7 +3434,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   if (sec && secScale) {
     const primaryLabelColor = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
     drawSecondaryValueAxis(
-      ctx, sec, secScale, toYSecondary, px0, py0, pw, ph, h, ptToPx,
+      ctx, chart, sec, secScale, toYSecondary, px0, py0, pw, ph, h, ptToPx,
       secFontPx, secLabelBandW, primaryLabelColor, chart.date1904,
     );
   }
@@ -4650,7 +4706,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
 
   const toX = (v: number) => px0 + ((v - xMin) / (xMax - xMin)) * pw;
   const toY = (v: number) => py0 + ph - ((v - yMin) / (yMax - yMin)) * ph;
-  const xStep = niceStep(xMax - xMin);
+  const xStep = chart.catAxisMajorUnit ?? niceStep(xMax - xMin);
 
   // Each scatter axis is a numeric value axis. Its crossing coordinate comes
   // from the opposite axis's scale (§21.2.2.31 / §21.2.2.32): autoZero uses
@@ -4711,6 +4767,12 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       // equivalent to undefined here (drawAxisTick treats both as a hairline).
       const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
       drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', yAxisX, gy, yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx), false, chart.valAxisLineHidden);
+    }
+    if (chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
+      const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
+      forEachMinorTick(yMin, yMax, yAxisStep, chart.valAxisMinorUnit, value => {
+        drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', yAxisX, toY(value), yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx), false, chart.valAxisLineHidden);
+      });
     }
   }
 
@@ -4782,6 +4844,12 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       }
       const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
       drawAxisTick(ctx, chart.catAxisMajorTickMark, 'cat', xAxisY, gx, xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx), false, chart.catAxisLineHidden);
+    }
+    if (chart.catAxisMinorTickMark && chart.catAxisMinorTickMark !== 'none') {
+      const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
+      forEachMinorTick(xMin, xMax, xStep, chart.catAxisMinorUnit, value => {
+        drawAxisTick(ctx, chart.catAxisMinorTickMark, 'cat', xAxisY, toX(value), xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx), false, chart.catAxisLineHidden);
+      });
     }
   }
 
@@ -5587,11 +5655,13 @@ function renderWaterfallChart(
     ? 0
     : maxCategoryLines * (catFontPx + 2) + 4;
 
+  const leg = chartLegendReserve(chart, w, h, 0.22);
+  const { legRightW, legLeftW, legTopH, legBottomH } = chartLegendBands(leg);
   const pad = {
-    t: titleBand.bandH + valFontPx / 2 + 2,
-    r: w * 0.02,
-    b: axBands.catBandH + categoryLabelBandH,
-    l: axBands.valBandW + (chart.valAxisHidden ? w * 0.02 : valLabelBandW),
+    t: titleBand.bandH + legTopH + valFontPx / 2 + 2,
+    r: legRightW + w * 0.02,
+    b: legBottomH + axBands.catBandH + categoryLabelBandH,
+    l: legLeftW + axBands.valBandW + (chart.valAxisHidden ? w * 0.02 : valLabelBandW),
   };
   const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
     titleBand,
@@ -5741,33 +5811,34 @@ function renderWaterfallChart(
     }
 
     const rawVal = vals[i] ?? 0;
-    // Locale-independent §18.8.30 formatting, honoring the authored negative
-    // section as-is. Excel accounting formats commonly render negatives in
-    // parentheses; the renderer must not replace that syntax with a triangle.
-    const labelFormat = chart.dataLabelFormatCode ?? chart.series[0]?.valFormatCode ?? null;
-    const labelText = formatChartValWithCode(rawVal, labelFormat, chart.date1904);
-    // Per-data-point label colour from chartEx `<cx:dataLabel idx>` (parsed
-    // into series.dataLabelColors). Falls back to chart.dataLabelFontColor,
-    // then to neutral grey. PowerPoint paints negative-bar labels in
-    // accent1 (red) for sample-2's waterfall.
-    const perPointColor = chart.series[0]?.dataLabelColors?.[i] ?? null;
-    const labelColor = perPointColor
-      ? `#${perPointColor}`
-      : chart.dataLabelFontColor
-        ? `#${chart.dataLabelFontColor}`
-        : '#595959';
-    ctx.fillStyle = labelColor;
-    const dataLabelFontPx = axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
-    ctx.font = `${chart.dataLabelFontBold ? 'bold ' : ''}${dataLabelFontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
-    ctx.textAlign = 'center';
-    // Negative bars: label sits BELOW the bar (`outEnd` for a negative value
-    // points downward in chartEx). Positive bars and subtotals: label ABOVE.
-    if (rawVal < 0) {
-      ctx.textBaseline = 'top';
-      ctx.fillText(labelText, bx + barW / 2, yBot + 3);
-    } else {
-      ctx.textBaseline = 'bottom';
-      ctx.fillText(labelText, bx + barW / 2, yTop - 3);
+    if (chart.showDataLabels) {
+      // Locale-independent §18.8.30 formatting, honoring the authored negative
+      // section as-is. Excel accounting formats commonly render negatives in
+      // parentheses; the renderer must not replace that syntax with a triangle.
+      const labelFormat = chart.dataLabelFormatCode ?? chart.series[0]?.valFormatCode ?? null;
+      const labelText = formatChartValWithCode(rawVal, labelFormat, chart.date1904);
+      // Per-data-point label colour from chartEx `<cx:dataLabel idx>` (parsed
+      // into series.dataLabelColors). Falls back to chart.dataLabelFontColor,
+      // then to neutral grey.
+      const perPointColor = chart.series[0]?.dataLabelColors?.[i] ?? null;
+      const labelColor = perPointColor
+        ? `#${perPointColor}`
+        : chart.dataLabelFontColor
+          ? `#${chart.dataLabelFontColor}`
+          : '#595959';
+      ctx.fillStyle = labelColor;
+      const dataLabelFontPx = axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
+      ctx.font = `${chart.dataLabelFontBold ? 'bold ' : ''}${dataLabelFontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
+      ctx.textAlign = 'center';
+      // Negative bars: label sits below the bar; positive bars and subtotals
+      // place it above the bar.
+      if (rawVal < 0) {
+        ctx.textBaseline = 'top';
+        ctx.fillText(labelText, bx + barW / 2, yBot + 3);
+      } else {
+        ctx.textBaseline = 'bottom';
+        ctx.fillText(labelText, bx + barW / 2, yTop - 3);
+      }
     }
   });
 
@@ -5777,7 +5848,7 @@ function renderWaterfallChart(
   // Category (transaction) labels below the bars → category-axis face.
   ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${catFontPx}px ${catFont}`;
   const labelY = py0 + ph + 4;
-  for (let i = 0; i < n; i++) {
+  for (let i = 0; i < n && !chart.catAxisHidden; i++) {
     const ccx = px0 + gapW * i + gapW / 2;
     const lines = wrapMeasuredText(
       ctx,
@@ -5800,13 +5871,116 @@ function renderWaterfallChart(
     py0,
     pw,
     ph,
-    0,
-    0,
+    legLeftW,
+    legBottomH,
     axBands.catFontPx,
     axBands.valFontPx,
   );
 
+  const legendChart: ChartModel = {
+    ...chart,
+    chartType: 'clusteredBar',
+    series: [
+      { name: 'Increase', values: [], color: colorPos.slice(1) },
+      { name: 'Decrease', values: [], color: colorNeg.slice(1) },
+      { name: 'Total', values: [], color: colorSub.slice(1) },
+    ],
+  };
+  drawLegendForLayout(
+    ctx, legendChart, leg, x, y, w, h, px0, py0, pw, ph,
+    titleBand.bandH + 2, ptToPx, [paintPos, paintNeg, paintSub], shapeRotationDeg,
+  );
+
   ctx.restore();
+}
+
+/** ChartEx `funnel`: one centered horizontal bar per ordinal category. */
+function renderFunnelChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+  shapeRotationDeg: number,
+): void {
+  const values = chart.series[0]?.values ?? [];
+  const n = Math.min(chart.categories.length, values.length);
+  if (n === 0) return;
+  const max = Math.max(0, ...values.slice(0, n).map(value => value ?? 0));
+  if (!(max > 0)) return;
+  const { x, y, w, h } = r;
+  const titleBand = cartesianTitleBand(chart, h, ptToPx);
+  const leg = chartLegendReserve(chart, w, h, 0.22);
+  const { legRightW, legLeftW, legTopH, legBottomH } = chartLegendBands(leg);
+  const catFontPx = axisLabelPx(chart.catAxisFontSizeHpt, h, ptToPx);
+  ctx.save();
+  ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${catFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
+  const labelW = chart.catAxisHidden
+    ? 0
+    : Math.max(...chart.categories.slice(0, n).map(label => ctx.measureText(label).width), 0) + 10;
+  const pad = {
+    t: titleBand.bandH + legTopH + 2,
+    r: legRightW + w * 0.02,
+    b: legBottomH + h * 0.02,
+    l: legLeftW + labelW + w * 0.02,
+  };
+  const frame = computeChartFrame(chart, x, y, w, h, ptToPx, { titleBand, legendSideReserveFrac: 0.22, pad });
+  drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
+  const { px0, py0, pw, ph } = frame.plotRect;
+  const rowH = ph / n;
+  const barH = rowH / (1 + (chart.barGapWidth ?? 50) / 100);
+  const color = `#${chart.series[0]?.color ?? chartExDataPointFill(chart, 0, 1)}`;
+  const paint = chart.series[0]?.color
+    ? { fillType: 'solid', color: chart.series[0].color } as Fill
+    : chartExDataPointPaint(chart, 0, 1);
+  for (let index = 0; index < n; index++) {
+    const value = Math.max(0, values[index] ?? 0);
+    const barW = pw * value / max;
+    const bx = px0 + (pw - barW) / 2;
+    const by = py0 + rowH * index + (rowH - barH) / 2;
+    if (!chart.chartexDataPointStyle?.fillHidden) {
+      ctx.fillStyle = chartExFillStyle(ctx, paint, bx, by, barW, barH, color, shapeRotationDeg);
+      ctx.fillRect(bx, by, barW, barH);
+    }
+    if (!chart.catAxisHidden) {
+      ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#595959';
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(chart.categories[index], px0 - 6, by + barH / 2);
+    }
+  }
+  if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
+    const line = resolveAxisLine(chart.catAxisLineColor, chart.catAxisLineWidthEmu, ptToPx);
+    ctx.strokeStyle = line.color;
+    ctx.lineWidth = line.width;
+    ctx.beginPath(); ctx.moveTo(px0, py0); ctx.lineTo(px0, py0 + ph); ctx.stroke();
+  }
+  drawLegendForLayout(ctx, chart, leg, x, y, w, h, px0, py0, pw, ph, titleBand.bandH + 2, ptToPx, [paint], shapeRotationDeg);
+  ctx.restore();
+}
+
+/** ChartEx Pareto line: cumulative share of the source values. */
+function renderParetoLineChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+): void {
+  const source = chart.series[0];
+  if (!source) return;
+  const raw = source.values.map(value => Math.max(0, value ?? 0));
+  const total = raw.reduce((sum, value) => sum + value, 0);
+  if (!(total > 0)) return;
+  let sum = 0;
+  const cumulative = raw.map(value => (sum += value) / total);
+  renderLineChart(ctx, {
+    ...chart,
+    chartType: 'line',
+    categories: cumulative.map((_value, index) => String(index + 1)),
+    series: [{ ...source, values: cumulative, showMarker: false }],
+    catAxisHidden: true,
+    showLegend: false,
+    valMin: 0,
+  }, r, ptToPx);
 }
 
 // ─── chartEx: box-and-whisker (CH15, MS 2014 chartex ext) ────────────────────
@@ -5965,18 +6139,8 @@ function renderBoxWhiskerChart(
   const cats = box.categories;
   const nCat = cats.length;
   const nSer = box.series.length;
-  const oneBoxPerSeries = nCat === nSer && cats.every((_category, categoryIndex) => {
-    const populatedSeries = box.series
-      .map((series, seriesIndex) => ({
-        seriesIndex,
-        populated: (series.valuesByCategory[categoryIndex]?.length ?? 0) > 0,
-      }))
-      .filter(entry => entry.populated);
-    return populatedSeries.length === 1 && populatedSeries[0].seriesIndex === categoryIndex;
-  });
 
-  // Excel's auto value axis (nice-rounded min/max/step). For the sample data
-  // (−78..128) this yields −100..150 step 50, matching PowerPoint.
+  // Excel's automatic value axis uses nice-rounded bounds and steps.
   const { min: axisMin, max: axisMax, step } = valueAxisScale(
     dataMin, dataMax, chart.valMin, chart.valMax, ph / ptToPx, chart.valAxisMajorUnit,
   );
@@ -6030,10 +6194,9 @@ function renderBoxWhiskerChart(
     ctx.beginPath(); ctx.moveTo(px0, py0 + ph); ctx.lineTo(px0 + pw, py0 + ph); ctx.stroke();
   }
 
-  // Category slots; each slot holds `nSer` boxes side by side. `<cx:catScaling
-  // gapWidth>` widens the inter-category gap (parser normalizes the fraction to
-  // the legacy percent, default 150%). The boxes fill the slot minus that gap,
-  // split evenly with a thin inter-box gutter.
+  // Category slots place every series at the same category coordinate. ChartEx
+  // box/whisker series are overlays, not clustered legacy bars; their boxes
+  // therefore share the full authored category width.
   // ChartEx places categorical box/whisker data points at interior category
   // positions, leaving one category interval between each plot edge and the
   // first/last point. `gapWidth` controls the box-vs-gap width inside that
@@ -6041,8 +6204,6 @@ function renderBoxWhiskerChart(
   const slotW = pw / (nCat + 1);
   const gapWidthPct = chart.barGapWidth ?? 150;
   const groupW = slotW / (1 + gapWidthPct / 100);
-  const boxGutter = groupW * 0.06;
-  const clusteredBoxW = (groupW - boxGutter * (nSer - 1)) / nSer;
   const paletteOf = (si: number): string => {
     const fill = box.series[si].color ?? chartExDataPointFill(chart, si, nSer);
     return `#${fill}`;
@@ -6056,8 +6217,8 @@ function renderBoxWhiskerChart(
   const boxGeometry = (ci: number, si: number): { bx: number; boxW: number; cx: number } => {
     const categoryCenterX = px0 + slotW * (ci + 1);
     const slotLeft = categoryCenterX - groupW / 2;
-    const boxW = oneBoxPerSeries ? groupW : clusteredBoxW;
-    const bx = oneBoxPerSeries ? slotLeft : slotLeft + si * (boxW + boxGutter);
+    const boxW = groupW;
+    const bx = slotLeft;
     return { bx, boxW, cx: bx + boxW / 2 };
   };
 
@@ -6117,9 +6278,17 @@ function renderBoxWhiskerChart(
       const markerEdge = chartExStyleColor(chart, markerStyle, 'line', si, nSer);
       const applySeriesLine = (style: ChartExStyle | null | undefined, fallback: string): boolean => {
         const visible = applyChartExLineStyle(ctx, chart, style, si, nSer, fallback, ptToPx);
+        // Chart Style `NoStyle` means that this role supplies no decorative
+        // override. Box/whisker's semantic outline still exists. This is
+        // distinct from an authored `<a:noFill>`, which remains suppressed.
+        if (!visible && style?.lineNoStyle) {
+          ctx.strokeStyle = fallback;
+          ctx.lineWidth = 1;
+          ctx.setLineDash([]);
+        }
         if (s.lineColor) ctx.strokeStyle = edge;
         if (s.lineWidthEmu) ctx.lineWidth = edgeWidth;
-        return visible || s.lineColor != null;
+        return visible || style?.lineNoStyle === true || s.lineColor != null;
       };
       const yQ1 = yOf(stats.q1);
       const yQ3 = yOf(stats.q3);
@@ -6310,7 +6479,10 @@ interface SunburstNode {
  * sizes beneath it). Children keep first-seen (source) order so the ring sweep
  * order matches PowerPoint.
  */
-function buildSunburstTree(rows: { path: string[]; size: number }[]): SunburstNode {
+function buildSunburstTree(
+  rows: { path: string[]; size: number }[],
+  preserveTerminalDuplicates = false,
+): SunburstNode {
   const root: SunburstNode = {
     label: '', value: 0, depth: -1, children: [], branchIndex: -1, labelIndex: -1, a0: 0, a1: 0,
   };
@@ -6326,7 +6498,8 @@ function buildSunburstTree(rows: { path: string[]; size: number }[]): SunburstNo
         index = new Map();
         childIndexes.set(node, index);
       }
-      let child = index.get(label);
+      const preserveNode = preserveTerminalDuplicates && d === row.path.length - 1;
+      let child = preserveNode ? undefined : index.get(label);
       if (!child) {
         child = {
           label,
@@ -6340,7 +6513,7 @@ function buildSunburstTree(rows: { path: string[]; size: number }[]): SunburstNo
           a0: 0, a1: 0,
         };
         node.children.push(child);
-        index.set(label, child);
+        if (!preserveNode) index.set(label, child);
       }
       child.value += row.size;
       node = child;
@@ -6403,9 +6576,8 @@ function renderSunburstChart(
   if (!sb || sb.rows.length === 0) return;
   const { x, y, w, h } = r;
 
-  // Radial frame (title band on top, no legend — Office draws sunburst without
-  // one). Reuse the pie frame params so the geometry matches the other radial
-  // charts.
+  // Reuse the radial frame so an authored top legend reserves space above the
+  // rings instead of being painted over the circle.
   const frame = computeChartFrame(chart, x, y, w, h, ptToPx, {
     titleTopPadFrac: 0.035,
     titleBottomPadFrac: 0.035,
@@ -6572,6 +6744,33 @@ function renderSunburstChart(
     }
   }
   ctx.restore();
+
+  const legendChart: ChartModel = {
+    ...chart,
+    chartType: 'clusteredBar',
+    series: root.children.map((node, index) => ({
+      name: node.label,
+      values: [],
+      color: chartExDataPointFill(chart, index, root.children.length),
+    })),
+  };
+  drawLegendForLayout(
+    ctx,
+    legendChart,
+    frame.legend,
+    x,
+    y,
+    w,
+    h,
+    px0,
+    py0,
+    pw,
+    ph,
+    frame.title.bandH + 2,
+    ptToPx,
+    root.children.map((_, index) => branchPaint(index)),
+    shapeRotationDeg,
+  );
 }
 
 // ─── chartEx: treemap (CH15, MS 2014 chartex ext) ───────────────────────────
@@ -6676,7 +6875,9 @@ function renderTreemapChart(
     radialGapFrac: 0.015,
   });
   drawChartTitleForLayout(ctx, chart, r.x, r.y, r.w, r.h, r.y + frame.title.topPad, frame.title.fontPx);
-  const root = buildSunburstTree(treemap.rows);
+  // A treemap data point remains a distinct tile even when its terminal label
+  // repeats. Only parent path components are grouping keys.
+  const root = buildSunburstTree(treemap.rows, true);
   if (root.value <= 0 || root.children.length === 0) return;
 
   const fontFamily = chartFontFamily(chart, chart.dataLabelFontFace, 'minor');
@@ -6836,6 +7037,33 @@ function renderTreemapChart(
     paint(tile.node, tile.rect);
   }
   ctx.restore();
+
+  const legendChart: ChartModel = {
+    ...chart,
+    chartType: 'clusteredBar',
+    series: root.children.map((node, index) => ({
+      name: node.label,
+      values: [],
+      color: chartExDataPointFill(chart, index, root.children.length),
+    })),
+  };
+  drawLegendForLayout(
+    ctx,
+    legendChart,
+    frame.legend,
+    r.x,
+    r.y,
+    r.w,
+    r.h,
+    px0,
+    py0,
+    pw,
+    ph,
+    frame.title.bandH + 2,
+    ptToPx,
+    root.children.map(node => chartExDataPointPaint(chart, node.branchIndex, root.children.length)),
+    shapeRotationDeg,
+  );
 }
 
 /** Render text shapes from the chart's related Chart Drawing part.
@@ -7073,6 +7301,12 @@ export function renderChart(
         renderScatterChart(ctx, chart, rect, ptToPx); break;
       case 'waterfall':
         renderWaterfallChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
+      case 'clusteredColumn':
+        renderBarChart(ctx, { ...chart, chartType: 'clusteredBar' }, rect, ptToPx); break;
+      case 'funnel':
+        renderFunnelChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
+      case 'paretoLine':
+        renderParetoLineChart(ctx, chart, rect, ptToPx); break;
       case 'stock':
         renderStockChart(ctx, chart, rect, ptToPx); break;
       case 'boxWhisker':

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -5811,34 +5811,32 @@ function renderWaterfallChart(
     }
 
     const rawVal = vals[i] ?? 0;
-    if (chart.showDataLabels) {
-      // Locale-independent §18.8.30 formatting, honoring the authored negative
-      // section as-is. Excel accounting formats commonly render negatives in
-      // parentheses; the renderer must not replace that syntax with a triangle.
-      const labelFormat = chart.dataLabelFormatCode ?? chart.series[0]?.valFormatCode ?? null;
-      const labelText = formatChartValWithCode(rawVal, labelFormat, chart.date1904);
-      // Per-data-point label colour from chartEx `<cx:dataLabel idx>` (parsed
-      // into series.dataLabelColors). Falls back to chart.dataLabelFontColor,
-      // then to neutral grey.
-      const perPointColor = chart.series[0]?.dataLabelColors?.[i] ?? null;
-      const labelColor = perPointColor
-        ? `#${perPointColor}`
-        : chart.dataLabelFontColor
-          ? `#${chart.dataLabelFontColor}`
-          : '#595959';
-      ctx.fillStyle = labelColor;
-      const dataLabelFontPx = axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
-      ctx.font = `${chart.dataLabelFontBold ? 'bold ' : ''}${dataLabelFontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
-      ctx.textAlign = 'center';
-      // Negative bars: label sits below the bar; positive bars and subtotals
-      // place it above the bar.
-      if (rawVal < 0) {
-        ctx.textBaseline = 'top';
-        ctx.fillText(labelText, bx + barW / 2, yBot + 3);
-      } else {
-        ctx.textBaseline = 'bottom';
-        ctx.fillText(labelText, bx + barW / 2, yTop - 3);
-      }
+    // Locale-independent §18.8.30 formatting, honoring the authored negative
+    // section as-is. Excel accounting formats commonly render negatives in
+    // parentheses; the renderer must not replace that syntax with a triangle.
+    const labelFormat = chart.dataLabelFormatCode ?? chart.series[0]?.valFormatCode ?? null;
+    const labelText = formatChartValWithCode(rawVal, labelFormat, chart.date1904);
+    // Per-data-point label colour from chartEx `<cx:dataLabel idx>` (parsed
+    // into series.dataLabelColors). Falls back to chart.dataLabelFontColor,
+    // then to neutral grey.
+    const perPointColor = chart.series[0]?.dataLabelColors?.[i] ?? null;
+    const labelColor = perPointColor
+      ? `#${perPointColor}`
+      : chart.dataLabelFontColor
+        ? `#${chart.dataLabelFontColor}`
+        : '#595959';
+    ctx.fillStyle = labelColor;
+    const dataLabelFontPx = axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
+    ctx.font = `${chart.dataLabelFontBold ? 'bold ' : ''}${dataLabelFontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
+    ctx.textAlign = 'center';
+    // Negative bars: label sits below the bar; positive bars and subtotals
+    // place it above the bar.
+    if (rawVal < 0) {
+      ctx.textBaseline = 'top';
+      ctx.fillText(labelText, bx + barW / 2, yBot + 3);
+    } else {
+      ctx.textBaseline = 'bottom';
+      ctx.fillText(labelText, bx + barW / 2, yTop - 3);
     }
   });
 

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -10,6 +10,10 @@ import type { GradientFill, PatternFill, SolidFill } from './common';
 
 export interface ChartSeries {
   name: string;
+  /** Effective ChartEx `CT_Series@formatIdx` used to select linked Chart Style
+   * formatting. When the attribute is omitted the parser stores the series'
+   * original document-order index, before hidden series are removed. */
+  chartexFormatIdx?: number | null;
   /** Hex without '#'. null = fall back to palette. */
   color: string | null;
   /**
@@ -18,6 +22,10 @@ export interface ChartSeries {
    * solid/fallback series colour.
    */
   fillPattern?: PatternFill | null;
+  /** ChartEx `<cx:series><cx:spPr>` local shape paint. Positive fill/line
+   * properties override linked style roles; series noFill remains distinct
+   * from a data-point noFill. */
+  chartexStyle?: ChartExElementStyle | null;
   /** `<c:ser><c:spPr><a:ln><a:solidFill>` series outline/stroke color (hex,
    * no '#'). For bar/column charts this is the border around each bar. */
   lineColor?: string | null;
@@ -189,12 +197,26 @@ export interface ChartTrendline {
   lineColor?: string | null;
   /** `<c:spPr><a:ln w>` trendline width in EMU. */
   lineWidthEmu?: number | null;
+  /** `<c:spPr><a:ln><a:prstDash val>` DrawingML dash preset. */
+  lineDash?: string | null;
+  /** `<c:spPr><a:ln><a:noFill/>` — suppress the trendline stroke. */
+  lineHidden?: boolean | null;
 }
 
 export interface ChartDataPointOverride {
   idx: number;
   /** Resolved fill hex (no `#`). */
   color?: string;
+  /** Direct point `<a:noFill/>`; suppresses series/style fill fallback. */
+  fillHidden?: boolean;
+  /** Direct point outline color (no `#`). */
+  lineColor?: string;
+  /** Direct point outline width in EMU. */
+  lineWidthEmu?: number;
+  /** Direct point DrawingML preset dash. */
+  lineDash?: string;
+  /** Direct point `<a:ln><a:noFill/>`; suppresses outline fallback. */
+  lineHidden?: boolean;
   markerSymbol?: string;
   markerSize?: number;
   markerFill?: string;
@@ -223,6 +245,10 @@ export interface ChartDataLabelOverride {
   fontSizeHpt?: number;
   /** `<a:defRPr b="1">` inside the per-idx rich text. */
   fontBold?: boolean;
+  /** Per-point number format; undefined inherits the series default. */
+  formatCode?: string;
+  /** Per-point component separator; undefined inherits the series default. */
+  separator?: string;
   /** Per-point callout box (`<c:dLbl><c:spPr>`, ECMA-376 §21.2.2.47/§21.2.2.197):
    *  overrides the series-default box for this one slice. */
   labelBox?: ChartLabelBox;
@@ -335,6 +361,8 @@ export interface ChartExElementStyle {
   /** Per-color-style-index fills after `phClr` substitution and transforms. */
   fillColors?: Array<string | null> | null;
   fillHidden?: boolean | null;
+  /** Linked Chart Style uses `NoStyle`, not an authored no-fill paint. */
+  fillNoStyle?: boolean | null;
   /** Per-color-style-index outlines after `phClr` substitution/transforms. */
   lineColors?: Array<string | null> | null;
   lineWidthEmu?: number | null;
@@ -684,6 +712,8 @@ export interface ChartModel {
    * hairline stays visible). null/absent ⇒ the renderer's 0.5 px default.
    */
   valAxisGridlineWidthEmu?: number | null;
+  /** `<c:valAx><c:majorGridlines>...<a:prstDash val>` dash preset. */
+  valAxisGridlineDash?: string | null;
   /**
    * `<c:catAx><c:majorGridlines><c:spPr><a:ln><a:solidFill>` resolved gridline
    * color (hex without `#`). Only meaningful when {@link catAxisMajorGridlines}
@@ -692,9 +722,21 @@ export interface ChartModel {
   catAxisGridlineColor?: string | null;
   /** `<c:catAx><c:majorGridlines><c:spPr><a:ln w>` gridline width in EMU. */
   catAxisGridlineWidthEmu?: number | null;
+  /** `<c:catAx><c:majorGridlines>...<a:prstDash val>` dash preset. */
+  catAxisGridlineDash?: string | null;
   /** `<c:valAx><c:minorGridlines>` presence (§21.2.2.109). Only drawn when a
    *  minor step is resolvable (see {@link valAxisMinorUnit}). */
   valAxisMinorGridlines?: boolean | null;
+  /** Authored value-axis minor-gridline paint. */
+  valAxisMinorGridlineColor?: string | null;
+  valAxisMinorGridlineWidthEmu?: number | null;
+  valAxisMinorGridlineDash?: string | null;
+  /** `<c:catAx|valAx><c:minorGridlines>` on the horizontal/scatter axis. */
+  catAxisMinorGridlines?: boolean | null;
+  /** Authored horizontal-axis minor-gridline paint. */
+  catAxisMinorGridlineColor?: string | null;
+  catAxisMinorGridlineWidthEmu?: number | null;
+  catAxisMinorGridlineDash?: string | null;
   /**
    * `<c:valAx><c:majorUnit val>` (§21.2.2.103) — explicit distance between major
    * gridlines/ticks, overriding the Excel-style auto "nice" step. null/undefined
@@ -797,6 +839,12 @@ export interface ChartModel {
   chartexDataPointLineStyle?: ChartExElementStyle | null;
   /** Effective `<cs:dataPointMarker>` style for raw/outlier/mean markers. */
   chartexDataPointMarkerStyle?: ChartExElementStyle | null;
+  /** Chart Style `dataPointMarkerLayout@size`, in points (2..72). */
+  chartexMarkerSizePt?: number | null;
+  /** Chart Style `dataPointMarkerLayout@symbol`. */
+  chartexMarkerSymbol?: string | null;
+  /** `<cx:series><cx:layoutPr><cx:visibility connectorLines>` for waterfall. */
+  chartexConnectorLines?: boolean | null;
 }
 
 /** A formatted DrawingML run inside a chart-relative text box. */
@@ -841,6 +889,9 @@ export interface ChartTextBox {
 export interface ChartexBoxSeries {
   /** Series display name (`<cx:tx><cx:v>`). */
   name: string;
+  /** Effective ChartEx `CT_Series@formatIdx`; omitted authoring resolves to
+   * the original document-order series index. */
+  chartexFormatIdx?: number | null;
   /** Explicit `<cx:series><cx:spPr>` fill (hex, no '#'). null = resolve the
    *  Chart Style / linked Chart Colors, then fall back to the theme palette. */
   color?: string | null;
@@ -848,6 +899,8 @@ export interface ChartexBoxSeries {
   lineColor?: string | null;
   /** Explicit series outline width from `<a:ln@w>` (EMU). */
   lineWidthEmu?: number | null;
+  /** Lossless ChartEx series-local `<cx:spPr>` paint. */
+  chartexStyle?: ChartExElementStyle | null;
   /** Raw sample values grouped by category (outer = category index parallel to
    *  {@link ChartexBoxWhisker.categories}, inner = the points in that group). */
   valuesByCategory: number[][];

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -339,6 +339,8 @@ export interface ChartExElementStyle {
   lineColors?: Array<string | null> | null;
   lineWidthEmu?: number | null;
   lineHidden?: boolean | null;
+  /** Linked Chart Style uses `NoStyle`, not an authored no-fill outline. */
+  lineNoStyle?: boolean | null;
   lineDash?: string | null;
   lineCap?: string | null;
   lineJoin?: string | null;
@@ -702,6 +704,10 @@ export interface ChartModel {
   /** `<c:valAx><c:minorUnit val>` (§21.2.2.112) — explicit minor step. Drives
    *  minor gridlines/ticks when present. null ⇒ no minor divisions. */
   valAxisMinorUnit?: number | null;
+  /** Numeric horizontal-axis major step (scatter/bubble `<c:valAx>`). */
+  catAxisMajorUnit?: number | null;
+  /** Numeric horizontal-axis minor step (scatter/bubble `<c:valAx>`). */
+  catAxisMinorUnit?: number | null;
   /**
    * `<c:valAx><c:scaling><c:logBase val>` (§21.2.2.98, `ST_LogBase` §21.2.3.25)
    * — logarithmic value-axis base (>= 2). When set, values map to pixels in log
@@ -910,6 +916,8 @@ export interface SecondaryValueAxis {
   fontColor?: string | null;
   /** `<c:txPr>` tick-label font size (hpt). */
   fontSizeHpt?: number | null;
+  /** `<c:txPr>…<a:latin typeface>` tick-label font face. */
+  fontFace?: string | null;
   /** `<c:spPr><a:ln><a:solidFill>` axis-line color (hex without '#'). */
   lineColor?: string | null;
   /** `<c:spPr><a:ln w>` axis-line width in EMU. */
@@ -919,6 +927,8 @@ export interface SecondaryValueAxis {
   lineHidden: boolean;
   /** `<c:majorTickMark>` — "cross" (default) | "out" | "in" | "none". */
   majorTickMark: string;
+  /** `<c:minorTickMark>` — omitted means no minor ticks. */
+  minorTickMark?: string | null;
   /**
    * `<c:valAx><c:majorUnit val>` (§21.2.2.103) — explicit distance between
    * major ticks/gridlines on THIS secondary axis, overriding the Excel-style
@@ -926,12 +936,15 @@ export interface SecondaryValueAxis {
    * {@link ChartModel.valAxisMajorUnit} on the primary axis.
    */
   majorUnit?: number | null;
+  /** `<c:valAx><c:minorUnit val>` explicit minor-tick step. */
+  minorUnit?: number | null;
   /** `<c:title>` run-prop font size (hpt). */
   titleFontSizeHpt?: number | null;
   /** `<c:title>` run-prop bold flag. */
   titleFontBold?: boolean | null;
   /** `<c:title>` run-prop color (hex without '#'). */
   titleFontColor?: string | null;
+  titleFontFace?: string | null;
 }
 
 /**

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -62,6 +62,8 @@ export interface ChartDataLabelOverride {
     fontColor?: string;
     fontSizeHpt?: number;
     fontBold?: boolean;
+    formatCode?: string;
+    separator?: string;
     labelBox?: ChartLabelBox;
     showVal?: boolean;
     showCatName?: boolean;
@@ -72,6 +74,11 @@ export interface ChartDataLabelOverride {
 export interface ChartDataPointOverride {
     idx: number;
     color?: string;
+    fillHidden?: boolean;
+    lineColor?: string;
+    lineWidthEmu?: number;
+    lineDash?: string;
+    lineHidden?: boolean;
     markerSymbol?: string;
     markerSize?: number;
     markerFill?: string;
@@ -90,9 +97,11 @@ export interface ChartErrBars {
 }
 export interface ChartexBoxSeries {
     name: string;
+    chartexFormatIdx?: number | null;
     color?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
+    chartexStyle?: ChartExElementStyle | null;
     valuesByCategory: number[][];
     meanMarker: boolean;
     meanLine: boolean;
@@ -108,9 +117,11 @@ export interface ChartExElementStyle {
     fillPaints?: Array<SolidFill | GradientFill | PatternFill | null> | null;
     fillColors?: Array<string | null> | null;
     fillHidden?: boolean | null;
+    fillNoStyle?: boolean | null;
     lineColors?: Array<string | null> | null;
     lineWidthEmu?: number | null;
     lineHidden?: boolean | null;
+    lineNoStyle?: boolean | null;
     lineDash?: string | null;
     lineCap?: string | null;
     lineJoin?: string | null;
@@ -237,11 +248,22 @@ export interface ChartModel {
     catAxisMajorGridlines?: boolean | null;
     valAxisGridlineColor?: string | null;
     valAxisGridlineWidthEmu?: number | null;
+    valAxisGridlineDash?: string | null;
     catAxisGridlineColor?: string | null;
     catAxisGridlineWidthEmu?: number | null;
+    catAxisGridlineDash?: string | null;
     valAxisMinorGridlines?: boolean | null;
+    valAxisMinorGridlineColor?: string | null;
+    valAxisMinorGridlineWidthEmu?: number | null;
+    valAxisMinorGridlineDash?: string | null;
+    catAxisMinorGridlines?: boolean | null;
+    catAxisMinorGridlineColor?: string | null;
+    catAxisMinorGridlineWidthEmu?: number | null;
+    catAxisMinorGridlineDash?: string | null;
     valAxisMajorUnit?: number | null;
     valAxisMinorUnit?: number | null;
+    catAxisMajorUnit?: number | null;
+    catAxisMinorUnit?: number | null;
     valAxisLogBase?: number | null;
     valAxisOrientation?: 'minMax' | 'maxMin' | string | null;
     catAxisOrientation?: 'minMax' | 'maxMin' | string | null;
@@ -262,6 +284,9 @@ export interface ChartModel {
     chartexDataPointStyle?: ChartExElementStyle | null;
     chartexDataPointLineStyle?: ChartExElementStyle | null;
     chartexDataPointMarkerStyle?: ChartExElementStyle | null;
+    chartexMarkerSizePt?: number | null;
+    chartexMarkerSymbol?: string | null;
+    chartexConnectorLines?: boolean | null;
 }
 export interface ChartRect {
     x: number;
@@ -292,8 +317,10 @@ export interface ChartRun {
 }
 export interface ChartSeries {
     name: string;
+    chartexFormatIdx?: number | null;
     color: string | null;
     fillPattern?: PatternFill | null;
+    chartexStyle?: ChartExElementStyle | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     values: (number | null)[];
@@ -371,6 +398,8 @@ export interface ChartTrendline {
     dispEq?: boolean | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
+    lineDash?: string | null;
+    lineHidden?: boolean | null;
 }
 export type ChartType = 'line' | 'stackedLine' | 'stackedLinePct' | 'clusteredBar' | 'clusteredBarH' | 'stackedBar' | 'stackedBarH' | 'stackedBarPct' | 'stackedBarHPct' | 'area' | 'stackedArea' | 'stackedAreaPct' | 'pie' | 'doughnut' | 'scatter' | 'bubble' | 'radar' | 'waterfall' | 'stock' | 'boxWhisker' | 'sunburst' | 'treemap' | string;
 export type CollectPageRunsOptions = Pick<RenderPageOptions, 'width' | 'currentDate'>;
@@ -1278,14 +1307,18 @@ export interface SecondaryValueAxis {
     formatCode?: string | null;
     fontColor?: string | null;
     fontSizeHpt?: number | null;
+    fontFace?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineHidden: boolean;
     majorTickMark: string;
+    minorTickMark?: string | null;
     majorUnit?: number | null;
+    minorUnit?: number | null;
     titleFontSizeHpt?: number | null;
     titleFontBold?: boolean | null;
     titleFontColor?: string | null;
+    titleFontFace?: string | null;
 }
 export interface SectionGeom {
     pageWidth: number;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -3271,15 +3271,17 @@ fn parse_data_point_shape(point: Node, resolver: &dyn ColorResolver) -> DataPoin
     )
 }
 
+type ChartexSeriesLabels = (
+    Option<Vec<Option<String>>>,
+    Option<Vec<ChartDataLabelOverride>>,
+    Option<ChartSeriesDataLabels>,
+);
+
 fn parse_chartex_series_labels(
     series: Node,
     value_count: usize,
     resolver: &dyn ColorResolver,
-) -> (
-    Option<Vec<Option<String>>>,
-    Option<Vec<ChartDataLabelOverride>>,
-    Option<ChartSeriesDataLabels>,
-) {
+) -> ChartexSeriesLabels {
     let Some(labels) = child(series, "dataLabels") else {
         return (None, None, None);
     };

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -91,6 +91,11 @@ pub struct ChartExElementStyle {
     pub line_width_emu: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_hidden: Option<bool>,
+    /// The linked Chart Style selected the `NoStyle` line recipe rather than
+    /// an authored `<a:noFill>`. Semantic chart marks may supply their default
+    /// outline in this case; an explicit no-fill must remain suppressed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_no_style: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_dash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -383,6 +388,12 @@ pub struct ChartModel {
     /// `<c:valAx><c:minorUnit val>` (§21.2.2.112) — explicit minor gridline step.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_minor_unit: Option<f64>,
+    /// Numeric horizontal-axis units for scatter/bubble, whose X axis is a
+    /// second `<c:valAx>` even though it occupies the category-axis slot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_major_unit: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_minor_unit: Option<f64>,
     /// `<c:valAx><c:scaling><c:logBase val>` (§21.2.2.98) — logarithmic value
     /// axis base (>= 2). `None` = linear (byte-stable).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -814,21 +825,30 @@ pub struct SecondaryValueAxis {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_size_hpt: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub font_face: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_width_emu: Option<u32>,
     pub line_hidden: bool,
     pub major_tick_mark: String,
+    /// `<c:valAx><c:minorTickMark val>` (§21.2.2.115). Omitted means none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minor_tick_mark: Option<String>,
     /// `<c:valAx><c:majorUnit val>` (§21.2.2.103) — explicit major-unit step on
     /// this secondary axis, overriding the auto "nice" step. `None` ⇒ auto.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub major_unit: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minor_unit: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_font_size_hpt: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_font_color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title_font_face: Option<String>,
 }
 
 /// One box-and-whisker series (chartEx `boxWhisker`, MS 2014 chartex ext).
@@ -2568,10 +2588,13 @@ fn parse_chartex_element_style(
     let fill_recipe = fill_ref.and_then(|reference| chart_style_fill_ref_xml(reference, resolver));
     let fill_recipe_xml = fill_recipe.as_ref().and_then(|recipe| recipe.as_ref().ok());
     let fill_recipe_doc = fill_recipe_xml.and_then(|xml| roxmltree::Document::parse(xml).ok());
+    let local_sp_pr = child(style_node, "spPr");
     let line_recipe = line_ref.and_then(|reference| chart_style_line_ref_xml(reference, resolver));
+    let line_no_style = (matches!(line_recipe.as_ref(), Some(Err(())))
+        && local_sp_pr.and_then(|sp_pr| child(sp_pr, "ln")).is_none())
+    .then_some(true);
     let line_recipe_xml = line_recipe.as_ref().and_then(|recipe| recipe.as_ref().ok());
     let line_recipe_doc = line_recipe_xml.and_then(|xml| roxmltree::Document::parse(xml).ok());
-    let local_sp_pr = child(style_node, "spPr");
     let fill_component_count = local_sp_pr
         .and_then(chart_style_paint_component_count)
         .or_else(|| match fill_recipe.as_ref() {
@@ -2714,6 +2737,7 @@ fn parse_chartex_element_style(
         line_colors,
         line_width_emu,
         line_hidden,
+        line_no_style,
         line_dash,
         line_cap: first_line.and_then(|line| line.cap.clone()),
         line_join,
@@ -3209,7 +3233,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         .as_ref()
         .map(|data| data.rows.as_slice())
         .or_else(|| chartex_sunburst.as_ref().map(|data| data.rows.as_slice()));
-    let categories: Vec<String> = hierarchy_rows
+    let mut categories: Vec<String> = hierarchy_rows
         .map(|rows| {
             rows.iter()
                 .map(|row| row.path.last().cloned().unwrap_or_default())
@@ -3233,7 +3257,45 @@ pub fn parse_chartex_part_with_references_and_style_parts(
             }
         })
         .unwrap_or_else(|| vec![None; pt_count]);
+    // ChartEx permits formula-only dimensions. Some producers leave the
+    // category formula dangling while Office still gives the flat cartesian
+    // layouts ordinal categories. Preserve that interoperable behavior only
+    // for layouts whose category axis is visibly ordinal; Pareto deliberately
+    // keeps its unlabeled horizontal axis.
+    if categories.is_empty()
+        && matches!(
+            chart_type.as_str(),
+            "waterfall" | "clusteredColumn" | "funnel"
+        )
+        && raw_values.iter().any(Option::is_some)
+    {
+        categories = (1..=raw_values.len())
+            .map(|index| index.to_string())
+            .collect();
+    }
     let source_number_format = chartex_number_format(root, &["size", "val"], references);
+
+    let series_name = series_node
+        .descendants()
+        .find(|node| node.is_element() && node.tag_name().name() == "txData")
+        .and_then(|tx_data| {
+            child(tx_data, "v")
+                .and_then(|value| value.text())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .or_else(|| {
+                    child(tx_data, "f")
+                        .and_then(|formula| formula.text())
+                        .map(str::trim)
+                        .filter(|formula| !formula.is_empty())
+                        .and_then(|formula| references.resolve_strings(formula))
+                        .and_then(|values| {
+                            values.into_iter().find(|value| !value.trim().is_empty())
+                        })
+                })
+        })
+        .unwrap_or_default();
 
     // `<cx:subtotals><cx:idx val>` identifies only points explicitly marked as
     // totals. The first waterfall point starts at zero geometrically, but it is
@@ -3329,7 +3391,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
     }
 
     let mut series = vec![ChartSeries {
-        name: String::new(),
+        name: series_name,
         values: raw_values,
         color,
         fill_pattern: None,
@@ -3683,6 +3745,8 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         val_axis_minor_gridlines: None,
         val_axis_major_unit,
         val_axis_minor_unit: None,
+        cat_axis_major_unit: None,
+        cat_axis_minor_unit: None,
         val_axis_log_base: None,
         val_axis_orientation: None,
         cat_axis_orientation: None,
@@ -5884,14 +5948,18 @@ pub fn parse_chart_part_with_references(
             font_color: extract_axis_tick_label_color(ax, color_resolver)
                 .or_else(|| chart_text_font_color.clone()),
             font_size_hpt: extract_axis_tick_label_size(ax).or(chart_text_font_size_hpt),
+            font_face: extract_axis_tick_label_face(ax),
             line_color,
             line_width_emu,
             line_hidden,
             major_tick_mark: extract_axis_tick_mark_or_default(ax, "majorTickMark"),
+            minor_tick_mark: extract_axis_tick_mark(ax, "minorTickMark"),
             major_unit: extract_axis_major_unit(ax),
+            minor_unit: extract_axis_minor_unit(ax),
             title_font_size_hpt: title_size,
             title_font_bold: title_bold,
             title_font_color: title_color,
+            title_font_face: extract_axis_title_face(ax),
         }
     };
     let secondary_val_axis = secondary_val_ax.map(&parse_auxiliary_value_axis);
@@ -6091,6 +6159,8 @@ pub fn parse_chart_part_with_references(
     let val_axis_minor_gridlines = val_ax.map(|ax| axis_has_minor_gridlines(ax));
     let val_axis_major_unit = val_ax.and_then(extract_axis_major_unit);
     let val_axis_minor_unit = val_ax.and_then(extract_axis_minor_unit);
+    let cat_axis_major_unit = cat_ax.and_then(extract_axis_major_unit);
+    let cat_axis_minor_unit = cat_ax.and_then(extract_axis_minor_unit);
     let val_axis_log_base = val_ax.and_then(extract_axis_log_base);
     let val_axis_orientation = val_ax.and_then(extract_axis_orientation);
     let cat_axis_orientation = cat_ax.and_then(extract_axis_orientation);
@@ -6276,6 +6346,8 @@ pub fn parse_chart_part_with_references(
         val_axis_minor_gridlines,
         val_axis_major_unit,
         val_axis_minor_unit,
+        cat_axis_major_unit,
+        cat_axis_minor_unit,
         val_axis_log_base,
         val_axis_orientation,
         cat_axis_orientation,
@@ -6498,6 +6570,8 @@ mod tests {
             val_axis_minor_gridlines: None,
             val_axis_major_unit: None,
             val_axis_minor_unit: None,
+            cat_axis_major_unit: None,
+            cat_axis_minor_unit: None,
             val_axis_log_base: None,
             val_axis_orientation: None,
             cat_axis_orientation: None,
@@ -8009,7 +8083,10 @@ mod tests {
                   <c:crosses val="max"/>
                   <c:scaling><c:min val="0"/><c:max val="1"/></c:scaling>
                   <c:majorUnit val="0.25"/>
-                  <c:title><c:tx><c:rich><a:p><a:r><a:t>Margin</a:t></a:r></a:p></c:rich></c:tx></c:title>
+                  <c:minorUnit val="0.05"/>
+                  <c:minorTickMark val="cross"/>
+                  <c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface="Tick Face"/></a:defRPr></a:pPr></a:p></c:txPr>
+                  <c:title><c:tx><c:rich><a:p><a:r><a:rPr sz="900" b="0"><a:latin typeface="Title Face"/></a:rPr><a:t>Margin</a:t></a:r></a:p></c:rich></c:tx></c:title>
                 </c:valAx>
               </c:plotArea></c:chart>
             </c:chartSpace>"#
@@ -8038,6 +8115,12 @@ mod tests {
         assert_eq!(sec.max, Some(1.0));
         assert_eq!(sec.title.as_deref(), Some("Margin"));
         assert!(!sec.hidden);
+        assert_eq!(sec.font_face.as_deref(), Some("Tick Face"));
+        assert_eq!(sec.minor_tick_mark.as_deref(), Some("cross"));
+        assert_eq!(sec.minor_unit, Some(0.05));
+        assert_eq!(sec.title_font_face.as_deref(), Some("Title Face"));
+        assert_eq!(sec.title_font_size_hpt, Some(900));
+        assert_eq!(sec.title_font_bold, Some(false));
         // #738: an explicit `<c:majorUnit>` on the secondary axis (§21.2.2.103)
         // is threaded into the model (was silently dropped before).
         assert_eq!(sec.major_unit, Some(0.25));
@@ -8287,8 +8370,8 @@ mod tests {
                   </c:ser>
                   <c:axId val="1"/><c:axId val="2"/>
                 </c:scatterChart>
-                <c:valAx><c:axId val="1"/><c:crossAx val="2"/></c:valAx>
-                <c:valAx><c:axId val="2"/><c:crossAx val="1"/></c:valAx>
+                <c:valAx><c:axId val="1"/><c:axPos val="b"/><c:majorUnit val="0.5"/><c:minorUnit val="0.1"/><c:crossAx val="2"/></c:valAx>
+                <c:valAx><c:axId val="2"/><c:axPos val="l"/><c:crossAx val="1"/></c:valAx>
               </c:plotArea></c:chart>
             </c:chartSpace>"#
         );
@@ -8296,6 +8379,8 @@ mod tests {
             .expect("scatter chart parses");
         assert_eq!(m.chart_type, "scatter");
         assert_eq!(m.scatter_style.as_deref(), Some("lineMarker"));
+        assert_eq!(m.cat_axis_major_unit, Some(0.5));
+        assert_eq!(m.cat_axis_minor_unit, Some(0.1));
         // Series 0: explicit `<a:noFill/>` line → line_hidden set.
         assert_eq!(
             m.series[0].line_hidden,
@@ -9130,6 +9215,40 @@ mod tests {
     }
 
     #[test]
+    fn parse_chartex_style_distinguishes_no_style_from_explicit_no_fill() {
+        let xml = format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}"><cx:chart><cx:plotArea><cx:plotAreaRegion>
+              <cx:series layoutId="boxWhisker"/>
+            </cx:plotAreaRegion></cx:plotArea></cx:chart></cx:chartSpace>"#
+        );
+        let no_style = format!(
+            r#"<cs:chartStyle xmlns:cs="{CS_NS}" xmlns:a="{A_NS}">
+              <cs:dataPoint><cs:lnRef idx="0"><cs:styleClr val="auto"/></cs:lnRef></cs:dataPoint>
+            </cs:chartStyle>"#
+        );
+        let document = chart_space_of(&xml);
+        let model = parse_chartex_part(document.root_element(), &FixtureResolver, Some(&no_style))
+            .expect("NoStyle line parses");
+        let role = model.chartex_data_point_style.expect("dataPoint role");
+        assert_eq!(role.line_hidden, Some(true));
+        assert_eq!(role.line_no_style, Some(true));
+
+        let explicit_no_fill = no_style.replace(
+            "</cs:dataPoint>",
+            "<cs:spPr><a:ln><a:noFill/></a:ln></cs:spPr></cs:dataPoint>",
+        );
+        let model = parse_chartex_part(
+            document.root_element(),
+            &FixtureResolver,
+            Some(&explicit_no_fill),
+        )
+        .expect("explicit noFill line parses");
+        let role = model.chartex_data_point_style.expect("dataPoint role");
+        assert_eq!(role.line_hidden, Some(true));
+        assert_eq!(role.line_no_style, None);
+    }
+
+    #[test]
     fn parse_chartex_linked_color_style_and_role_specific_paints() {
         let xml = format!(
             r#"<cx:chartSpace xmlns:cx="{CX_NS}" xmlns:a="{A_NS}">
@@ -9651,6 +9770,54 @@ mod tests {
             vec![Some(50.0), Some(30.0), Some(20.0)]
         );
         assert_eq!(model.series[0].val_format_code.as_deref(), Some("#,##0"));
+    }
+
+    struct FormulaOnlyFlatResolver;
+
+    impl ChartReferenceResolver for FormulaOnlyFlatResolver {
+        fn resolve_strings(&mut self, formula: &str) -> Option<Vec<String>> {
+            (formula == "_xlchart.name").then(|| vec!["Authored series".to_string()])
+        }
+
+        fn resolve_numbers(&mut self, formula: &str) -> Option<Vec<Option<f64>>> {
+            (formula == "_xlchart.values").then(|| vec![Some(3.0), Some(2.0), Some(1.0)])
+        }
+    }
+
+    #[test]
+    fn parse_chartex_formula_only_flat_layouts_keep_series_name_and_ordinal_categories() {
+        for layout in ["waterfall", "clusteredColumn", "funnel", "paretoLine"] {
+            let xml = format!(
+                r#"<cx:chartSpace xmlns:cx="{CX_NS}">
+                  <cx:chartData><cx:data id="0">
+                    <cx:strDim type="cat"><cx:f>_xlchart.missing</cx:f></cx:strDim>
+                    <cx:numDim type="val"><cx:f>_xlchart.values</cx:f></cx:numDim>
+                  </cx:data></cx:chartData>
+                  <cx:chart><cx:plotArea><cx:plotAreaRegion>
+                    <cx:series layoutId="{layout}"><cx:tx><cx:txData><cx:f>_xlchart.name</cx:f></cx:txData></cx:tx><cx:dataId val="0"/></cx:series>
+                  </cx:plotAreaRegion></cx:plotArea></cx:chart>
+                </cx:chartSpace>"#
+            );
+            let document = chart_space_of(&xml);
+            let mut references = FormulaOnlyFlatResolver;
+            let model = parse_chartex_part_with_references(
+                document.root_element(),
+                &FixtureResolver,
+                None,
+                &mut references,
+            )
+            .expect("formula-only flat ChartEx parses");
+            assert_eq!(model.series[0].name, "Authored series");
+            assert_eq!(
+                model.series[0].values,
+                vec![Some(3.0), Some(2.0), Some(1.0)]
+            );
+            if layout == "paretoLine" {
+                assert!(model.categories.is_empty());
+            } else {
+                assert_eq!(model.categories, vec!["1", "2", "3"]);
+            }
+        }
     }
 
     /// (c) A `<cx:chartSpace>` with no `<cx:series>` is not a chartEx chart —

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -85,6 +85,11 @@ pub struct ChartExElementStyle {
     pub fill_colors: Option<Vec<Option<String>>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fill_hidden: Option<bool>,
+    /// The linked Chart Style selected the `NoStyle` fill recipe rather than
+    /// an authored `<a:noFill>`. Semantic chart marks may supply their default
+    /// fill in this case; an explicit no-fill must remain transparent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill_no_style: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_colors: Option<Vec<Option<String>>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -370,6 +375,9 @@ pub struct ChartModel {
     /// `None` = the renderer's default hairline (byte-stable).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_gridline_width_emu: Option<u32>,
+    /// `<c:valAx><c:majorGridlines>...<a:prstDash val>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_gridline_dash: Option<String>,
     /// `<c:catAx><c:majorGridlines><c:spPr><a:ln><a:solidFill>` resolved gridline
     /// colour (hex, no `#`). Only meaningful when `cat_axis_major_gridlines` is
     /// on. `None` keeps the faint default.
@@ -378,9 +386,26 @@ pub struct ChartModel {
     /// `<c:catAx><c:majorGridlines><c:spPr><a:ln w>` gridline width in EMU.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cat_axis_gridline_width_emu: Option<u32>,
+    /// `<c:catAx><c:majorGridlines>...<a:prstDash val>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_gridline_dash: Option<String>,
     /// `<c:valAx><c:minorGridlines>` presence (§21.2.2.109).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_minor_gridlines: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_minor_gridline_color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_minor_gridline_width_emu: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_minor_gridline_dash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_minor_gridlines: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_minor_gridline_color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_minor_gridline_width_emu: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_minor_gridline_dash: Option<String>,
     /// `<c:valAx><c:majorUnit val>` (§21.2.2.103) — explicit major gridline
     /// step, overriding the auto "nice" step. `None` = auto (byte-stable).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -474,6 +499,13 @@ pub struct ChartModel {
     pub chartex_data_point_line_style: Option<ChartExElementStyle>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chartex_data_point_marker_style: Option<ChartExElementStyle>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_marker_size_pt: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_marker_symbol: Option<String>,
+    /// `<cx:series><cx:layoutPr><cx:visibility connectorLines>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_connector_lines: Option<bool>,
     /// §21.2.2.227 `<c:varyColors val="1"/>` on a SINGLE-series bar/column
     /// chart: color each data point (bar) from the theme/palette sequence and
     /// list one legend entry per point (like a pie). `Some(true)` only for that
@@ -555,9 +587,16 @@ pub struct ChartPatternFill {
 #[serde(rename_all = "camelCase")]
 pub struct ChartSeries {
     pub name: String,
+    /// Effective ChartEx `CT_Series@formatIdx` ([MS-ODRAWXML] 2.24.3.77).
+    /// When the attribute is omitted this is the original document-order
+    /// series index, before hidden series are removed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_format_idx: Option<u32>,
     pub color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fill_pattern: Option<ChartPatternFill>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_style: Option<ChartExElementStyle>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -649,6 +688,11 @@ pub struct ChartTrendline {
     pub line_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_width_emu: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_dash: Option<String>,
+    /// `<c:spPr><a:ln><a:noFill/>` — the trendline stroke is explicitly absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_hidden: Option<bool>,
 }
 
 /// Mirror of TS `ChartDataPointOverride`.
@@ -658,6 +702,16 @@ pub struct ChartDataPointOverride {
     pub idx: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill_hidden: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_width_emu: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_dash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_hidden: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub marker_symbol: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -691,6 +745,10 @@ pub struct ChartDataLabelOverride {
     pub font_size_hpt: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_bold: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub separator: Option<String>,
     /// Per-point label callout box style (`<c:dLbl>` §21.2.2.47 `<c:spPr>`
     /// §21.2.2.197): background fill / border, mirroring the series-level
     /// defaults. Present only when the point's `<c:spPr>` overrides the shape
@@ -865,6 +923,10 @@ pub struct SecondaryValueAxis {
 pub struct ChartexBoxSeries {
     /// Series display name (`<cx:tx><cx:txData><cx:v>`), e.g. "Series1".
     pub name: String,
+    /// Effective ChartEx `CT_Series@formatIdx`; omitted authoring resolves to
+    /// the original document-order series index.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_format_idx: Option<u32>,
     /// Explicit `<cx:series><cx:spPr>` fill (hex, no `#`). Absent authoring is
     /// kept as `None` so the shared renderer can apply Chart Style / linked
     /// Chart Colors before falling back to theme accents.
@@ -876,6 +938,9 @@ pub struct ChartexBoxSeries {
     /// Explicit series outline width from `<a:ln@w>` (EMU).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_width_emu: Option<u32>,
+    /// Lossless series-local `<cx:spPr>` paint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_style: Option<ChartExElementStyle>,
     /// Raw sample values grouped by category, parallel to
     /// `ChartexBoxWhisker::categories`. Outer index = category, inner = the
     /// sample points that fell in that category (source order preserved).
@@ -2113,12 +2178,16 @@ pub fn extract_series_trendlines(
                 .and_then(|v| v.parse::<f64>().ok())
         };
         // `<c:spPr><a:ln>` line style: solidFill color + width.
-        let (line_color, line_width_emu) = match child(tl, "spPr").and_then(|sp| child(sp, "ln")) {
-            None => (None, None),
+        let (line_color, line_width_emu, line_dash, line_hidden) = match child(tl, "spPr")
+            .and_then(|sp| child(sp, "ln"))
+        {
+            None => (None, None, None, None),
             Some(ln) => {
                 let color = child(ln, "solidFill").and_then(|sf| resolver.resolve_solid_fill(sf));
                 let width = ln.attribute("w").and_then(|v| v.parse::<u32>().ok());
-                (color, width)
+                let dash = child(ln, "prstDash").and_then(|preset| attr(&preset, "val"));
+                let hidden = child(ln, "noFill").is_some().then_some(true);
+                (color, width, dash, hidden)
             }
         };
         out.push(ChartTrendline {
@@ -2132,6 +2201,8 @@ pub fn extract_series_trendlines(
             disp_eq: bool_child(tl, "dispEq"),
             line_color,
             line_width_emu,
+            line_dash,
+            line_hidden,
         });
     }
     if out.is_empty() {
@@ -2589,6 +2660,13 @@ fn parse_chartex_element_style(
     let fill_recipe_xml = fill_recipe.as_ref().and_then(|recipe| recipe.as_ref().ok());
     let fill_recipe_doc = fill_recipe_xml.and_then(|xml| roxmltree::Document::parse(xml).ok());
     let local_sp_pr = child(style_node, "spPr");
+    let local_fill_authored = local_sp_pr.is_some_and(|sp_pr| {
+        ["noFill", "solidFill", "gradFill", "pattFill"]
+            .iter()
+            .any(|name| child(sp_pr, name).is_some())
+    });
+    let fill_no_style =
+        (matches!(fill_recipe.as_ref(), Some(Err(()))) && !local_fill_authored).then_some(true);
     let line_recipe = line_ref.and_then(|reference| chart_style_line_ref_xml(reference, resolver));
     let line_no_style = (matches!(line_recipe.as_ref(), Some(Err(())))
         && local_sp_pr.and_then(|sp_pr| child(sp_pr, "ln")).is_none())
@@ -2734,6 +2812,7 @@ fn parse_chartex_element_style(
         fill_paints,
         fill_colors,
         fill_hidden,
+        fill_no_style,
         line_colors,
         line_width_emu,
         line_hidden,
@@ -2835,22 +2914,42 @@ fn axis_major_gridlines_visible(axis_node: Node) -> bool {
 /// §21.2.2.100, `CT_ChartLines` → DrawingML §20.1.2.2.24). The `<c:spPr>` on the
 /// gridlines element styles the gridline stroke exactly like `<c:spPr>` on an
 /// axis styles the axis rule, so this reuses the same `<a:ln>` resolver. Returns
-/// `(color, width_emu)`: the resolved hex (no `#`) when the line carries a
+/// `(color, width_emu, dash)`: the resolved hex (no `#`) when the line carries a
 /// `<a:solidFill>` (e.g. `accent3`), and the `<a:ln w>` width in EMU when
-/// present. `(None, None)` when the axis omits `<c:majorGridlines>` or the
+/// present, plus the DrawingML preset dash name. All fields are `None` when the
+/// axis omits `<c:majorGridlines>` or the
 /// element carries no `<c:spPr><a:ln>` — the renderer then keeps its faint
 /// default gridline. Visibility is modeled separately by
 /// [`axis_major_gridlines_visible`] so `<a:noFill>` suppresses the stroke rather
 /// than falling through to a default colour.
+fn extract_gridline_style_named(
+    axis_node: Node,
+    resolver: &dyn ColorResolver,
+    element_name: &str,
+) -> (Option<String>, Option<u32>, Option<String>) {
+    let Some(gridlines) = child(axis_node, element_name) else {
+        return (None, None, None);
+    };
+    let (color, width, _no_fill) = extract_sp_pr_ln_style(gridlines, resolver);
+    let dash = child(gridlines, "spPr")
+        .and_then(|shape| child(shape, "ln"))
+        .and_then(|line| child(line, "prstDash"))
+        .and_then(|preset| attr(&preset, "val"));
+    (color, width, dash)
+}
+
 pub fn extract_gridline_style(
     axis_node: Node,
     resolver: &dyn ColorResolver,
-) -> (Option<String>, Option<u32>) {
-    let Some(gridlines) = child(axis_node, "majorGridlines") else {
-        return (None, None);
-    };
-    let (color, width, _no_fill) = extract_sp_pr_ln_style(gridlines, resolver);
-    (color, width)
+) -> (Option<String>, Option<u32>, Option<String>) {
+    extract_gridline_style_named(axis_node, resolver, "majorGridlines")
+}
+
+pub fn extract_minor_gridline_style(
+    axis_node: Node,
+    resolver: &dyn ColorResolver,
+) -> (Option<String>, Option<u32>, Option<String>) {
+    extract_gridline_style_named(axis_node, resolver, "minorGridlines")
 }
 
 /// `<c:catAx|valAx><c:minorGridlines>` presence (ECMA-376 §21.2.2.109). Same
@@ -3105,6 +3204,187 @@ pub fn parse_chartex_part_with_references(
     )
 }
 
+fn parse_chartex_data_point_overrides(
+    series: Node,
+    resolver: &dyn ColorResolver,
+) -> Vec<ChartDataPointOverride> {
+    series
+        .children()
+        .filter(|node| node.is_element() && node.tag_name().name() == "dataPt")
+        .filter_map(|point| {
+            let idx = attr(&point, "idx")?.parse::<u32>().ok()?;
+            let (color, fill_hidden, line_color, line_width_emu, line_dash, line_hidden) =
+                parse_data_point_shape(point, resolver);
+            Some(ChartDataPointOverride {
+                idx,
+                color,
+                fill_hidden,
+                line_color,
+                line_width_emu,
+                line_dash,
+                line_hidden,
+                marker_symbol: None,
+                marker_size: None,
+                marker_fill: None,
+                marker_line: None,
+                explosion: None,
+            })
+        })
+        .collect()
+}
+
+type DataPointShape = (
+    Option<String>,
+    Option<bool>,
+    Option<String>,
+    Option<u32>,
+    Option<String>,
+    Option<bool>,
+);
+
+fn parse_data_point_shape(point: Node, resolver: &dyn ColorResolver) -> DataPointShape {
+    let shape = child(point, "spPr");
+    let color = shape.and_then(|shape| resolver.resolve_shape_fill(shape));
+    let fill_hidden = shape
+        .and_then(|shape| child(shape, "noFill"))
+        .map(|_| true)
+        .or_else(|| color.as_ref().map(|_| false));
+    let (line_color, line_width_emu, line_no_fill) = extract_sp_pr_ln_style(point, resolver);
+    let line_dash = shape
+        .and_then(|shape| child(shape, "ln"))
+        .and_then(|line| child(line, "prstDash"))
+        .and_then(|preset| attr(&preset, "val"));
+    let line_hidden = if line_no_fill {
+        Some(true)
+    } else if line_color.is_some() || line_width_emu.is_some() || line_dash.is_some() {
+        Some(false)
+    } else {
+        None
+    };
+    (
+        color,
+        fill_hidden,
+        line_color,
+        line_width_emu,
+        line_dash,
+        line_hidden,
+    )
+}
+
+fn parse_chartex_series_labels(
+    series: Node,
+    value_count: usize,
+    resolver: &dyn ColorResolver,
+) -> (
+    Option<Vec<Option<String>>>,
+    Option<Vec<ChartDataLabelOverride>>,
+    Option<ChartSeriesDataLabels>,
+) {
+    let Some(labels) = child(series, "dataLabels") else {
+        return (None, None, None);
+    };
+    let visibility = child(labels, "visibility");
+    let bool_value = |name: &str| {
+        visibility
+            .and_then(|node| chart_text_bool_attr(node, name))
+            .unwrap_or(false)
+    };
+    let defaults = ChartSeriesDataLabels {
+        show_val: bool_value("value"),
+        show_cat_name: bool_value("categoryName"),
+        show_ser_name: bool_value("seriesName"),
+        show_percent: false,
+        position: attr(&labels, "pos"),
+        font_color: extract_axis_tick_label_color(labels, resolver),
+        format_code: child(labels, "numFmt").and_then(|node| attr(&node, "formatCode")),
+        separator: child(labels, "separator")
+            .and_then(|node| node.text())
+            .map(ToOwned::to_owned),
+        font_bold: extract_axis_tick_label_bold(labels),
+        font_size_hpt: extract_axis_tick_label_size(labels),
+        label_box: None,
+        show_leader_lines: false,
+        leader_line_color: None,
+        leader_line_width_emu: None,
+    };
+    let mut colors = vec![None; value_count.max(1)];
+    let mut has_color = false;
+    let mut overrides = Vec::new();
+    for label in labels
+        .children()
+        .filter(|node| node.is_element() && node.tag_name().name() == "dataLabel")
+    {
+        let Some(index) = attr(&label, "idx").and_then(|value| value.parse::<usize>().ok()) else {
+            continue;
+        };
+        if index >= colors.len() {
+            colors.resize(index + 1, None);
+        }
+        let tx_pr = child(label, "txPr");
+        let font_color = extract_axis_tick_label_color(label, resolver);
+        if let Some(color) = font_color.clone() {
+            colors[index] = Some(color);
+            has_color = true;
+        }
+        let label_visibility = child(label, "visibility");
+        overrides.push(ChartDataLabelOverride {
+            idx: index as u32,
+            text: tx_pr
+                .map(|node| flatten_rich_text(node, None))
+                .unwrap_or_default(),
+            position: attr(&label, "pos"),
+            font_color,
+            font_size_hpt: extract_axis_tick_label_size(label),
+            font_bold: extract_axis_tick_label_bold(label),
+            format_code: child(label, "numFmt").and_then(|node| attr(&node, "formatCode")),
+            separator: child(label, "separator")
+                .and_then(|node| node.text())
+                .map(ToOwned::to_owned),
+            label_box: None,
+            show_val: label_visibility.and_then(|node| chart_text_bool_attr(node, "value")),
+            show_cat_name: label_visibility
+                .and_then(|node| chart_text_bool_attr(node, "categoryName")),
+            show_ser_name: label_visibility
+                .and_then(|node| chart_text_bool_attr(node, "seriesName")),
+            show_percent: None,
+            deleted: None,
+        });
+    }
+    for hidden in labels
+        .children()
+        .filter(|node| node.is_element() && node.tag_name().name() == "dataLabelHidden")
+    {
+        let Some(idx) = attr(&hidden, "idx").and_then(|value| value.parse::<u32>().ok()) else {
+            continue;
+        };
+        if let Some(existing) = overrides.iter_mut().find(|override_| override_.idx == idx) {
+            existing.deleted = Some(true);
+        } else {
+            overrides.push(ChartDataLabelOverride {
+                idx,
+                text: String::new(),
+                position: None,
+                font_color: None,
+                font_size_hpt: None,
+                font_bold: None,
+                format_code: None,
+                separator: None,
+                label_box: None,
+                show_val: None,
+                show_cat_name: None,
+                show_ser_name: None,
+                show_percent: None,
+                deleted: Some(true),
+            });
+        }
+    }
+    (
+        has_color.then_some(colors),
+        (!overrides.is_empty()).then_some(overrides),
+        Some(defaults),
+    )
+}
+
 pub fn parse_chartex_part_with_references_and_style_parts(
     chartspace_root: Node,
     resolver: &dyn ColorResolver,
@@ -3126,12 +3406,50 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         })
     };
 
-    // Chart type from series layoutId attribute.
-    let series_node = root
+    // CT_PlotAreaRegion may contain several series. `hidden` is an authored
+    // series visibility flag; a hidden leading series must not select the
+    // chart layout or data used by the visible plot.
+    let all_series_nodes: Vec<Node> = root
         .descendants()
-        .find(|n| n.is_element() && n.tag_name().name() == "series")?;
+        .filter(|n| n.is_element() && n.tag_name().name() == "series")
+        .collect();
+    let series_nodes: Vec<Node> = all_series_nodes
+        .iter()
+        .copied()
+        .filter(|node| {
+            !attr(node, "hidden")
+                .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        })
+        .collect();
+    let series_format_index = |series: Node| -> u32 {
+        attr(&series, "formatIdx")
+            .and_then(|value| value.parse::<u32>().ok())
+            .or_else(|| {
+                all_series_nodes
+                    .iter()
+                    .position(|candidate| *candidate == series)
+                    .and_then(|index| u32::try_from(index).ok())
+            })
+            .unwrap_or(0)
+    };
+    let series_node = *series_nodes.first()?;
     let layout_id = attr(&series_node, "layoutId").unwrap_or_default();
     let chart_type = layout_id; // "waterfall", "treemap", etc.
+    let data_by_id: std::collections::HashMap<String, Node> = root
+        .descendants()
+        .filter(|node| node.is_element() && node.tag_name().name() == "data")
+        .filter_map(|data| attr(&data, "id").map(|id| (id, data)))
+        .collect();
+    let data_for_series = |series: Node| -> Option<Node> {
+        let data_id = child(series, "dataId").and_then(|node| attr(&node, "val"));
+        match data_id {
+            Some(id) => data_by_id.get(&id).copied(),
+            // Retain compatibility with early ChartEx producers that placed a
+            // single data block in chartSpace but omitted CT_Series.dataId.
+            None => Some(root),
+        }
+    };
+    let primary_data = data_for_series(series_node)?;
 
     // ── chartEx title (MS 2014 chartex ext) ──────────────────────────────────
     // Office may save either DrawingML rich text or the compact
@@ -3143,13 +3461,19 @@ pub fn parse_chartex_part_with_references_and_style_parts(
     // Precedence: an explicit `sz` on the chartEx part's own `<cx:title>` rich
     // text wins; otherwise fall back to the associated chartStyle part's
     // `<cs:title><cs:defRPr@sz>` (Word's default modern style = 1400 = 14pt).
-    // Without the style part a chartEx title would be sized by the renderer's
-    // area-proportional guess (≈21pt on sample-24), 1.5× too large. Only
+    // Without the style part a chartEx title falls back to the renderer's
+    // automatic size.
+    let (style_title_size, style_title_bold, style_title_color, style_title_face) =
+        extract_chartex_style_text_props(style_element("title"), resolver);
     let chartex_title_font_size_hpt = extract_chartex_title_size(root)
+        .or(style_title_size)
         .or_else(|| style_xml.and_then(extract_chartex_style_title_size));
-    let chartex_title_font_bold = extract_chart_title_bold(chart_node);
-    let chartex_title_font_color = extract_chart_title_color(chart_node, resolver);
-    let chartex_title_font_face = child(chart_node, "title").and_then(first_latin_typeface);
+    let chartex_title_font_bold = extract_chart_title_bold(chart_node).or(style_title_bold);
+    let chartex_title_font_color =
+        extract_chart_title_color(chart_node, resolver).or(style_title_color);
+    let chartex_title_font_face = child(chart_node, "title")
+        .and_then(first_latin_typeface)
+        .or(style_title_face);
 
     // ── chartEx theme accent palette ─────────────────────────────────────────
     // boxWhisker series and sunburst/treemap branches color by index off the theme
@@ -3203,6 +3527,21 @@ pub fn parse_chartex_part_with_references_and_style_parts(
             chartex_color_style_method.as_deref(),
         )
     });
+    let marker_layout = style_element("dataPointMarkerLayout");
+    let chartex_marker_size_pt = marker_layout
+        .and_then(|node| node.attribute("size"))
+        .and_then(|value| value.parse::<u8>().ok())
+        .filter(|value| (2..=72).contains(value));
+    let chartex_marker_symbol = marker_layout
+        .and_then(|node| node.attribute("symbol"))
+        .map(ToOwned::to_owned);
+    // [MS-ODRAWXML] CT_SeriesElementVisibilities: an authored false value
+    // suppresses waterfall connector lines. Keep omission as `None` so the
+    // renderer can preserve the layout's ordinary default without fabricating
+    // an XML value.
+    let chartex_connector_lines = child(series_node, "layoutPr")
+        .and_then(|layout| child(layout, "visibility"))
+        .and_then(|visibility| chart_text_bool_attr(visibility, "connectorLines"));
     // Keep the raw theme palette separate from effective style-role paint.
     let chartex_accents = theme_accents;
 
@@ -3215,14 +3554,14 @@ pub fn parse_chartex_part_with_references_and_style_parts(
 
     // ── chartEx sunburst structured parse ────────────────────────────────────
     let chartex_sunburst = if chart_type == "sunburst" {
-        parse_chartex_sunburst(root, references)
+        parse_chartex_sunburst(primary_data, references)
     } else {
         None
     };
 
     // ── chartEx treemap structured parse ────────────────────────────────────
     let chartex_treemap = if chart_type == "treemap" {
-        parse_chartex_treemap(root, references)
+        parse_chartex_treemap(primary_data, series_node, references)
     } else {
         None
     };
@@ -3233,7 +3572,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         .as_ref()
         .map(|data| data.rows.as_slice())
         .or_else(|| chartex_sunburst.as_ref().map(|data| data.rows.as_slice()));
-    let mut categories: Vec<String> = hierarchy_rows
+    let categories: Vec<String> = hierarchy_rows
         .map(|rows| {
             rows.iter()
                 .map(|row| row.path.last().cloned().unwrap_or_default())
@@ -3241,7 +3580,8 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         })
         .or_else(|| chartex_box.as_ref().map(|data| data.categories.clone()))
         .or_else(|| {
-            chartex_string_levels(root, references).and_then(|levels| levels.into_iter().next())
+            chartex_string_levels(primary_data, references)
+                .and_then(|levels| levels.into_iter().next())
         })
         .unwrap_or_default();
 
@@ -3253,27 +3593,11 @@ pub fn parse_chartex_part_with_references_and_style_parts(
             if chartex_box.is_some() {
                 None
             } else {
-                chartex_number_values(root, &["val"], references)
+                chartex_number_values(primary_data, &["val"], references)
             }
         })
         .unwrap_or_else(|| vec![None; pt_count]);
-    // ChartEx permits formula-only dimensions. Some producers leave the
-    // category formula dangling while Office still gives the flat cartesian
-    // layouts ordinal categories. Preserve that interoperable behavior only
-    // for layouts whose category axis is visibly ordinal; Pareto deliberately
-    // keeps its unlabeled horizontal axis.
-    if categories.is_empty()
-        && matches!(
-            chart_type.as_str(),
-            "waterfall" | "clusteredColumn" | "funnel"
-        )
-        && raw_values.iter().any(Option::is_some)
-    {
-        categories = (1..=raw_values.len())
-            .map(|index| index.to_string())
-            .collect();
-    }
-    let source_number_format = chartex_number_format(root, &["size", "val"], references);
+    let source_number_format = chartex_number_format(primary_data, &["size", "val"], references);
 
     let series_name = series_node
         .descendants()
@@ -3317,7 +3641,9 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         }
     }
 
-    // Series color (first dataPt or series spPr)
+    // Series shape properties are local formatting on CT_Series
+    // ([MS-ODRAWXML] 2.24.3.77). Preserve both fill and outline instead of
+    // letting the linked Chart Style silently replace an authored `spPr`.
     let color = series_node
         .children()
         .find(|n| n.is_element() && n.tag_name().name() == "spPr")
@@ -3326,83 +3652,31 @@ pub fn parse_chartex_part_with_references_and_style_parts(
                 .find(|n| n.is_element() && n.tag_name().name() == "solidFill")
         })
         .and_then(|fill| resolver.resolve_solid_fill(fill));
+    let (line_color, line_width_emu, line_no_fill) = extract_sp_pr_ln_style(series_node, resolver);
+    let chartex_style = child(series_node, "spPr")
+        .map(|_| parse_chartex_element_style(series_node, resolver, None, None));
+    let line_hidden = if line_no_fill {
+        Some(true)
+    } else if line_color.is_some() || line_width_emu.is_some() {
+        Some(false)
+    } else {
+        None
+    };
 
-    // Per-idx data-label colors. ChartEx writes `<cx:dataLabels>` with
-    // `<cx:dataLabel idx="N">` overrides; each carries its own `<cx:txPr>`
-    // whose first `<a:solidFill>` is the label colour for that bar. Sample-2
-    // waterfall uses this to paint negative-bar labels in accent1 (red) while
-    // positive-bar labels stay tx1 (black).
-    let mut data_label_colors_vec: Vec<Option<String>> = vec![None; raw_values.len().max(1)];
-    let mut has_per_label_color = false;
-    let mut data_label_overrides = Vec::new();
-    for dl in series_node
-        .descendants()
-        .filter(|n| n.is_element() && n.tag_name().name() == "dataLabel")
-    {
-        let Some(idx) = attr(&dl, "idx").and_then(|v| v.parse::<usize>().ok()) else {
-            continue;
-        };
-        if idx >= data_label_colors_vec.len() {
-            data_label_colors_vec.resize(idx + 1, None);
-        }
-        // First `<a:solidFill>` inside the per-idx <cx:txPr>.
-        let txpr = dl
-            .children()
-            .find(|n| n.is_element() && n.tag_name().name() == "txPr");
-        let font_color = txpr.and_then(|txpr| {
-            txpr.descendants()
-                .filter(|n| n.is_element() && n.tag_name().name() == "solidFill")
-                .find_map(|fill| resolver.resolve_solid_fill(fill))
-        });
-        if let Some(color) = font_color.clone() {
-            data_label_colors_vec[idx] = Some(color);
-            has_per_label_color = true;
-        }
-        let text = txpr
-            .map(|txpr| flatten_rich_text(txpr, None))
-            .unwrap_or_default();
-        let font_size_hpt = extract_axis_tick_label_size(dl);
-        let font_bold = extract_axis_tick_label_bold(dl);
-        let position = attr(&dl, "pos");
-        if !text.is_empty()
-            || font_color.is_some()
-            || font_size_hpt.is_some()
-            || font_bold.is_some()
-            || position.is_some()
-        {
-            data_label_overrides.push(ChartDataLabelOverride {
-                idx: idx as u32,
-                text,
-                position,
-                font_color,
-                font_size_hpt,
-                font_bold,
-                label_box: None,
-                show_val: None,
-                show_cat_name: None,
-                show_ser_name: None,
-                show_percent: None,
-                deleted: None,
-            });
-        }
-    }
-    if !has_per_label_color {
-        data_label_colors_vec.clear();
-    }
+    let (data_label_colors, data_label_overrides, _) =
+        parse_chartex_series_labels(series_node, raw_values.len(), resolver);
 
     let mut series = vec![ChartSeries {
         name: series_name,
+        chartex_format_idx: Some(series_format_index(series_node)),
         values: raw_values,
         color,
         fill_pattern: None,
-        line_color: None,
-        line_width_emu: None,
+        chartex_style,
+        line_color,
+        line_width_emu,
         data_point_colors: None,
-        data_label_colors: if has_per_label_color {
-            Some(data_label_colors_vec)
-        } else {
-            None
-        },
+        data_label_colors,
         categories: None,
         bubble_sizes: None,
         val_format_code: source_number_format,
@@ -3416,12 +3690,11 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         marker_size: None,
         marker_fill: None,
         marker_line: None,
-        data_point_overrides: None,
-        data_label_overrides: if data_label_overrides.is_empty() {
-            None
-        } else {
-            Some(data_label_overrides)
+        data_point_overrides: {
+            let overrides = parse_chartex_data_point_overrides(series_node, resolver);
+            (!overrides.is_empty()).then_some(overrides)
         },
+        data_label_overrides,
         series_data_labels: None,
         err_bars: None,
         // chartEx (waterfall) has no `<c:smooth>` concept.
@@ -3429,8 +3702,83 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         // chartEx series carry no classic `<c:trendline>`.
         trend_lines: None,
         // chartEx has no scatter connecting line to suppress.
-        line_hidden: None,
+        line_hidden,
     }];
+
+    // A flat clustered-column ChartEx plot may contain several CT_Series, each
+    // selecting its own CT_Data through dataId. Preserve every visible series
+    // rather than silently collapsing the plot to the first one.
+    if chart_type == "clusteredColumn" {
+        for extra_node in series_nodes
+            .iter()
+            .copied()
+            .skip(1)
+            .filter(|node| attr(node, "layoutId").as_deref() == Some(chart_type.as_str()))
+        {
+            let Some(extra_data) = data_for_series(extra_node) else {
+                continue;
+            };
+            let extra_values =
+                chartex_number_values(extra_data, &["val"], references).unwrap_or_default();
+            let extra_categories = chartex_string_levels(extra_data, references)
+                .and_then(|levels| levels.into_iter().next())
+                .unwrap_or_default();
+            let extra_name = extra_node
+                .descendants()
+                .find(|node| node.is_element() && node.tag_name().name() == "txData")
+                .and_then(|tx_data| {
+                    child(tx_data, "v")
+                        .and_then(|value| value.text())
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .map(ToOwned::to_owned)
+                        .or_else(|| {
+                            child(tx_data, "f")
+                                .and_then(|formula| formula.text())
+                                .map(str::trim)
+                                .filter(|formula| !formula.is_empty())
+                                .and_then(|formula| references.resolve_strings(formula))
+                                .and_then(|values| {
+                                    values.into_iter().find(|value| !value.trim().is_empty())
+                                })
+                        })
+                })
+                .unwrap_or_default();
+            let extra_color =
+                child(extra_node, "spPr").and_then(|shape| resolver.resolve_shape_fill(shape));
+            let (extra_line_color, extra_line_width_emu, extra_line_no_fill) =
+                extract_sp_pr_ln_style(extra_node, resolver);
+            let extra_chartex_style = child(extra_node, "spPr")
+                .map(|_| parse_chartex_element_style(extra_node, resolver, None, None));
+            let mut extra = series[0].clone();
+            extra.name = extra_name;
+            extra.chartex_format_idx = Some(series_format_index(extra_node));
+            extra.values = extra_values;
+            extra.categories = (!extra_categories.is_empty()).then_some(extra_categories);
+            extra.val_format_code = chartex_number_format(extra_data, &["val"], references);
+            extra.color = extra_color;
+            extra.chartex_style = extra_chartex_style;
+            extra.line_color = extra_line_color;
+            extra.line_width_emu = extra_line_width_emu;
+            extra.line_hidden = if extra_line_no_fill {
+                Some(true)
+            } else if extra.line_color.is_some() || extra.line_width_emu.is_some() {
+                Some(false)
+            } else {
+                None
+            };
+            extra.data_point_overrides = {
+                let overrides = parse_chartex_data_point_overrides(extra_node, resolver);
+                (!overrides.is_empty()).then_some(overrides)
+            };
+            let (label_colors, label_overrides, label_defaults) =
+                parse_chartex_series_labels(extra_node, extra.values.len(), resolver);
+            extra.data_label_colors = label_colors;
+            extra.data_label_overrides = label_overrides;
+            extra.series_data_labels = label_defaults;
+            series.push(extra);
+        }
+    }
 
     // ChartEx axis visibility — shared helper that pairs each `<cx:axis hidden>`
     // with its `<cx:catScaling>` / `<cx:valScaling>` child to disambiguate cat
@@ -3452,6 +3800,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
     });
     let cat_axis_major_tick_mark = extract_chartex_axis_tick_mark(cat_axis, "majorTickMarks");
     let val_axis_major_tick_mark = extract_chartex_axis_tick_mark(val_axis, "majorTickMarks");
+    let val_axis_minor_tick_mark = extract_chartex_axis_tick_mark(val_axis, "minorTickMarks");
     let val_scaling = val_axis.and_then(|axis| child(axis, "valScaling"));
     let val_min = val_scaling
         .and_then(|scaling| attr(&scaling, "min"))
@@ -3465,6 +3814,10 @@ pub fn parse_chartex_part_with_references_and_style_parts(
     // remain `None`; a positive finite number is an authored override.
     let val_axis_major_unit = val_scaling
         .and_then(|scaling| attr(&scaling, "majorUnit"))
+        .and_then(|value| value.parse::<f64>().ok())
+        .filter(|value| value.is_finite() && *value > 0.0);
+    let val_axis_minor_unit = val_scaling
+        .and_then(|scaling| attr(&scaling, "minorUnit"))
         .and_then(|value| value.parse::<f64>().ok())
         .filter(|value| value.is_finite() && *value > 0.0);
     let cat_axis_title = cat_axis
@@ -3570,13 +3923,34 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         }
     }
     let val_axis_major_gridlines = val_axis.map(axis_major_gridlines_visible);
-    let (mut val_axis_gridline_color, mut val_axis_gridline_width_emu) = val_axis
-        .map(|axis| extract_gridline_style(axis, resolver))
-        .unwrap_or((None, None));
+    let val_axis_minor_gridlines = val_axis.map(axis_has_minor_gridlines);
+    let (
+        val_axis_minor_gridline_color,
+        val_axis_minor_gridline_width_emu,
+        val_axis_minor_gridline_dash,
+    ) = val_axis
+        .map(|axis| extract_minor_gridline_style(axis, resolver))
+        .unwrap_or((None, None, None));
+    let cat_axis_minor_gridlines = cat_axis.map(axis_has_minor_gridlines);
+    let (
+        cat_axis_minor_gridline_color,
+        cat_axis_minor_gridline_width_emu,
+        cat_axis_minor_gridline_dash,
+    ) = cat_axis
+        .map(|axis| extract_minor_gridline_style(axis, resolver))
+        .unwrap_or((None, None, None));
+    let (mut val_axis_gridline_color, mut val_axis_gridline_width_emu, mut val_axis_gridline_dash) =
+        val_axis
+            .map(|axis| extract_gridline_style(axis, resolver))
+            .unwrap_or((None, None, None));
     if val_axis_gridline_color.is_none() && val_axis_gridline_width_emu.is_none() {
         if let Some(style_gridline) = style_element("gridlineMajor") {
             (val_axis_gridline_color, val_axis_gridline_width_emu, _) =
                 extract_sp_pr_ln_style(style_gridline, resolver);
+            val_axis_gridline_dash = child(style_gridline, "spPr")
+                .and_then(|shape| child(shape, "ln"))
+                .and_then(|line| child(line, "prstDash"))
+                .and_then(|preset| attr(&preset, "val"));
         }
     }
     let val_axis_format_code = val_axis
@@ -3715,7 +4089,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         legend_font_bold,
         theme_major_font_latin: resolver.theme_major_font_latin(),
         theme_minor_font_latin: resolver.theme_minor_font_latin(),
-        val_axis_minor_tick_mark: None,
+        val_axis_minor_tick_mark: Some(val_axis_minor_tick_mark),
         cat_axis_minor_tick_mark: None,
         legend_manual_layout: None,
         title_manual_layout: None,
@@ -3740,11 +4114,20 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         cat_axis_major_gridlines: None,
         val_axis_gridline_color,
         val_axis_gridline_width_emu,
+        val_axis_gridline_dash,
         cat_axis_gridline_color: None,
         cat_axis_gridline_width_emu: None,
-        val_axis_minor_gridlines: None,
+        cat_axis_gridline_dash: None,
+        val_axis_minor_gridlines,
+        val_axis_minor_gridline_color,
+        val_axis_minor_gridline_width_emu,
+        val_axis_minor_gridline_dash,
+        cat_axis_minor_gridlines,
+        cat_axis_minor_gridline_color,
+        cat_axis_minor_gridline_width_emu,
+        cat_axis_minor_gridline_dash,
         val_axis_major_unit,
-        val_axis_minor_unit: None,
+        val_axis_minor_unit,
         cat_axis_major_unit: None,
         cat_axis_minor_unit: None,
         val_axis_log_base: None,
@@ -3767,6 +4150,9 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         chartex_data_point_style,
         chartex_data_point_line_style,
         chartex_data_point_marker_style,
+        chartex_marker_size_pt,
+        chartex_marker_symbol,
+        chartex_connector_lines,
     })
 }
 
@@ -3793,9 +4179,17 @@ fn parse_chartex_boxwhisker(
         .collect();
 
     // Series nodes, in document order (one column each).
-    let series_nodes: Vec<Node> = root
+    let all_series_nodes: Vec<Node> = root
         .descendants()
         .filter(|n| n.is_element() && n.tag_name().name() == "series")
+        .collect();
+    let series_nodes: Vec<Node> = all_series_nodes
+        .iter()
+        .copied()
+        .filter(|node| {
+            !attr(node, "hidden")
+                .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        })
         .collect();
     if series_nodes.is_empty() {
         return None;
@@ -3825,11 +4219,21 @@ fn parse_chartex_boxwhisker(
             series
                 .descendants()
                 .find(|node| node.is_element() && node.tag_name().name() == "txData")
-                .and_then(|tx_data| child(tx_data, "v"))
-                .and_then(|value| value.text())
-                .map(str::trim)
-                .filter(|name| !name.is_empty())
-                .map(ToOwned::to_owned)
+                .and_then(|tx_data| {
+                    child(tx_data, "v")
+                        .and_then(|value| value.text())
+                        .map(str::trim)
+                        .filter(|name| !name.is_empty())
+                        .map(ToOwned::to_owned)
+                        .or_else(|| {
+                            child(tx_data, "f")
+                                .and_then(|formula| formula.text())
+                                .and_then(|formula| references.resolve_strings(formula))
+                                .and_then(|values| {
+                                    values.into_iter().find(|value| !value.trim().is_empty())
+                                })
+                        })
+                })
                 .unwrap_or_else(|| format!("Series {}", index + 1))
         })
         .collect();
@@ -3898,9 +4302,19 @@ fn parse_chartex_boxwhisker(
 
             ChartexBoxSeries {
                 name,
+                chartex_format_idx: attr(s, "formatIdx")
+                    .and_then(|value| value.parse::<u32>().ok())
+                    .or_else(|| {
+                        all_series_nodes
+                            .iter()
+                            .position(|candidate| candidate == s)
+                            .and_then(|index| u32::try_from(index).ok())
+                    }),
                 color: child(*s, "spPr").and_then(|shape| resolver.resolve_shape_fill(shape)),
                 line_color: extract_sp_pr_ln_style(*s, resolver).0,
                 line_width_emu: extract_sp_pr_ln_style(*s, resolver).1,
+                chartex_style: child(*s, "spPr")
+                    .map(|_| parse_chartex_element_style(*s, resolver, None, None)),
                 values_by_category,
                 mean_marker: bool_attr("meanMarker", true),
                 mean_line: bool_attr("meanLine", false),
@@ -4131,26 +4545,22 @@ fn parse_chartex_hierarchy_rows(
 }
 
 fn parse_chartex_sunburst(
-    root: Node,
+    data: Node,
     references: &mut dyn ChartReferenceResolver,
 ) -> Option<ChartexSunburst> {
-    parse_chartex_hierarchy_rows(root, references).map(|rows| ChartexSunburst { rows })
+    parse_chartex_hierarchy_rows(data, references).map(|rows| ChartexSunburst { rows })
 }
 
 /// Parse a chartEx treemap. Its category and size dimensions use the same
 /// hierarchy representation as sunburst; `parentLabelLayout` only affects how
 /// parent captions are painted.
 fn parse_chartex_treemap(
-    root: Node,
+    data: Node,
+    series: Node,
     references: &mut dyn ChartReferenceResolver,
 ) -> Option<ChartexTreemap> {
-    let rows = parse_chartex_hierarchy_rows(root, references)?;
-    let parent_label_layout = root.descendants().find(|n| {
-        n.is_element()
-            && n.tag_name().name() == "series"
-            && attr(n, "layoutId").as_deref() == Some("treemap")
-    })?;
-    let parent_label_layout = parent_label_layout
+    let rows = parse_chartex_hierarchy_rows(data, references)?;
+    let parent_label_layout = series
         .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "parentLabelLayout")
         .and_then(|layout| attr(&layout, "val"));
@@ -4235,7 +4645,8 @@ pub fn parse_data_point_overrides(
             .and_then(|n| n.attribute("val"))
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(0);
-        let color = child(dpt, "spPr").and_then(|p| resolver.resolve_shape_fill(p));
+        let (color, fill_hidden, line_color, line_width_emu, line_dash, line_hidden) =
+            parse_data_point_shape(dpt, resolver);
         let mk = child(dpt, "marker");
         let (marker_symbol, marker_size, marker_fill, marker_line) =
             parse_marker_block(mk, resolver);
@@ -4243,6 +4654,11 @@ pub fn parse_data_point_overrides(
         result.push(ChartDataPointOverride {
             idx,
             color,
+            fill_hidden,
+            line_color,
+            line_width_emu,
+            line_dash,
+            line_hidden,
             marker_symbol,
             marker_size,
             marker_fill,
@@ -4535,6 +4951,10 @@ pub fn parse_series_data_labels(
             font_color,
             font_size_hpt,
             font_bold,
+            format_code: child(dl, "numFmt").and_then(|node| attr(&node, "formatCode")),
+            separator: child(dl, "separator")
+                .and_then(|node| node.text())
+                .map(ToOwned::to_owned),
             label_box,
             show_val: opt_bool_flag("showVal"),
             show_cat_name: opt_bool_flag("showCatName"),
@@ -5693,9 +6113,11 @@ pub fn parse_chart_part_with_references(
 
             ChartSeries {
                 name,
+                chartex_format_idx: None,
                 values,
                 color,
                 fill_pattern: parse_series_pattern_fill(*ser, color_resolver),
+                chartex_style: None,
                 line_color,
                 line_width_emu,
                 data_point_colors: if has_dpt_colors {
@@ -6142,12 +6564,14 @@ pub fn parse_chart_part_with_references(
     // `<c:majorGridlines><c:spPr><a:ln>` colour/width — the explicit gridline
     // style (e.g. sample-1 slide 5's `accent3` 0.25 pt value-axis gridlines).
     // `(None, None)` when absent, so the renderer keeps its faint default.
-    let (mut val_axis_gridline_color, mut val_axis_gridline_width_emu) = val_ax
-        .map(|ax| extract_gridline_style(ax, color_resolver))
-        .unwrap_or((None, None));
-    let (mut cat_axis_gridline_color, mut cat_axis_gridline_width_emu) = cat_ax
-        .map(|ax| extract_gridline_style(ax, color_resolver))
-        .unwrap_or((None, None));
+    let (mut val_axis_gridline_color, mut val_axis_gridline_width_emu, val_axis_gridline_dash) =
+        val_ax
+            .map(|ax| extract_gridline_style(ax, color_resolver))
+            .unwrap_or((None, None, None));
+    let (mut cat_axis_gridline_color, mut cat_axis_gridline_width_emu, cat_axis_gridline_dash) =
+        cat_ax
+            .map(|ax| extract_gridline_style(ax, color_resolver))
+            .unwrap_or((None, None, None));
     if uses_implicit_legacy_style && val_axis_major_gridlines == Some(true) {
         val_axis_gridline_color.get_or_insert_with(|| "000000".to_string());
         val_axis_gridline_width_emu.get_or_insert(9_525);
@@ -6157,6 +6581,21 @@ pub fn parse_chart_part_with_references(
         cat_axis_gridline_width_emu.get_or_insert(9_525);
     }
     let val_axis_minor_gridlines = val_ax.map(|ax| axis_has_minor_gridlines(ax));
+    let (
+        val_axis_minor_gridline_color,
+        val_axis_minor_gridline_width_emu,
+        val_axis_minor_gridline_dash,
+    ) = val_ax
+        .map(|axis| extract_minor_gridline_style(axis, color_resolver))
+        .unwrap_or((None, None, None));
+    let cat_axis_minor_gridlines = cat_ax.map(|ax| axis_has_minor_gridlines(ax));
+    let (
+        cat_axis_minor_gridline_color,
+        cat_axis_minor_gridline_width_emu,
+        cat_axis_minor_gridline_dash,
+    ) = cat_ax
+        .map(|axis| extract_minor_gridline_style(axis, color_resolver))
+        .unwrap_or((None, None, None));
     let val_axis_major_unit = val_ax.and_then(extract_axis_major_unit);
     let val_axis_minor_unit = val_ax.and_then(extract_axis_minor_unit);
     let cat_axis_major_unit = cat_ax.and_then(extract_axis_major_unit);
@@ -6341,9 +6780,18 @@ pub fn parse_chart_part_with_references(
         cat_axis_major_gridlines,
         val_axis_gridline_color,
         val_axis_gridline_width_emu,
+        val_axis_gridline_dash,
         cat_axis_gridline_color,
         cat_axis_gridline_width_emu,
+        cat_axis_gridline_dash,
         val_axis_minor_gridlines,
+        val_axis_minor_gridline_color,
+        val_axis_minor_gridline_width_emu,
+        val_axis_minor_gridline_dash,
+        cat_axis_minor_gridlines,
+        cat_axis_minor_gridline_color,
+        cat_axis_minor_gridline_width_emu,
+        cat_axis_minor_gridline_dash,
         val_axis_major_unit,
         val_axis_minor_unit,
         cat_axis_major_unit,
@@ -6369,6 +6817,9 @@ pub fn parse_chart_part_with_references(
         chartex_data_point_style: None,
         chartex_data_point_line_style: None,
         chartex_data_point_marker_style: None,
+        chartex_marker_size_pt: None,
+        chartex_marker_symbol: None,
+        chartex_connector_lines: None,
     })
 }
 
@@ -6450,8 +6901,10 @@ mod tests {
             categories: vec!["A".to_string(), "B".to_string()],
             series: vec![ChartSeries {
                 name: "S1".to_string(),
+                chartex_format_idx: None,
                 color: Some("FF0000".to_string()),
                 fill_pattern: None,
+                chartex_style: None,
                 line_color: None,
                 line_width_emu: None,
                 values: vec![Some(1.0), None, Some(3.0)],
@@ -6565,9 +7018,18 @@ mod tests {
             cat_axis_major_gridlines: None,
             val_axis_gridline_color: None,
             val_axis_gridline_width_emu: None,
+            val_axis_gridline_dash: None,
             cat_axis_gridline_color: None,
             cat_axis_gridline_width_emu: None,
+            cat_axis_gridline_dash: None,
             val_axis_minor_gridlines: None,
+            val_axis_minor_gridline_color: None,
+            val_axis_minor_gridline_width_emu: None,
+            val_axis_minor_gridline_dash: None,
+            cat_axis_minor_gridlines: None,
+            cat_axis_minor_gridline_color: None,
+            cat_axis_minor_gridline_width_emu: None,
+            cat_axis_minor_gridline_dash: None,
             val_axis_major_unit: None,
             val_axis_minor_unit: None,
             cat_axis_major_unit: None,
@@ -6592,6 +7054,9 @@ mod tests {
             chartex_data_point_style: None,
             chartex_data_point_line_style: None,
             chartex_data_point_marker_style: None,
+            chartex_marker_size_pt: None,
+            chartex_marker_symbol: None,
+            chartex_connector_lines: None,
         };
         let v = serde_json::to_value(&m).unwrap();
         let obj = v.as_object().unwrap();
@@ -7004,35 +7469,57 @@ mod tests {
             <c:majorGridlines><c:spPr><a:ln w="3175"><a:solidFill><a:schemeClr val="accent3"/></a:solidFill></a:ln></c:spPr></c:majorGridlines>
         </c:valAx>"#;
         let d = root_of(xml);
-        let (color, width) = extract_gridline_style(d.root_element(), &StubResolver);
+        let (color, width, dash) = extract_gridline_style(d.root_element(), &StubResolver);
         assert_eq!(color.as_deref(), Some("accent3"));
         assert_eq!(width, Some(3175));
+        assert_eq!(dash, None);
     }
 
     #[test]
     fn gridline_style_present_without_sppr() {
         // `<c:majorGridlines/>` with no `<c:spPr>` → gridlines are requested
         // (presence-only) but carry no explicit colour/width; the renderer keeps
-        // its faint default. `(None, None)`.
+        // its faint default. `(None, None, None)`.
         let xml = r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
             <c:majorGridlines/>
         </c:valAx>"#;
         let d = root_of(xml);
         assert_eq!(
             extract_gridline_style(d.root_element(), &StubResolver),
-            (None, None)
+            (None, None, None)
         );
     }
 
     #[test]
     fn gridline_style_absent() {
-        // No `<c:majorGridlines>` at all → `(None, None)`.
+        // No `<c:majorGridlines>` at all → `(None, None, None)`.
         let xml = r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>"#;
         let d = root_of(xml);
         assert_eq!(
             extract_gridline_style(d.root_element(), &StubResolver),
-            (None, None)
+            (None, None, None)
         );
+    }
+
+    #[test]
+    fn gridline_style_preserves_drawingml_dash() {
+        let xml = format!(
+            r#"<c:valAx xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:majorGridlines><c:spPr><a:ln><a:prstDash val="dash"/></a:ln></c:spPr></c:majorGridlines></c:valAx>"#
+        );
+        let (_, _, dash) = extract_gridline_style(root_of(&xml).root_element(), &StubResolver);
+        assert_eq!(dash.as_deref(), Some("dash"));
+    }
+
+    #[test]
+    fn minor_gridline_style_is_independent_from_major_gridlines() {
+        let xml = format!(
+            r#"<c:valAx xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:majorGridlines/><c:minorGridlines><c:spPr><a:ln w="6350"><a:solidFill><a:srgbClr val="112233"/></a:solidFill><a:prstDash val="dot"/></a:ln></c:spPr></c:minorGridlines></c:valAx>"#
+        );
+        let (color, width, dash) =
+            extract_minor_gridline_style(root_of(&xml).root_element(), &StubResolver);
+        assert_eq!(color.as_deref(), Some("112233"));
+        assert_eq!(width, Some(6350));
+        assert_eq!(dash.as_deref(), Some("dot"));
     }
 
     #[test]
@@ -7540,12 +8027,13 @@ mod tests {
         let xml = format!(
             r#"<c:ser xmlns:c="{C_NS}" xmlns:a="{A_NS}">
                  <c:trendline>
-                   <c:spPr><a:ln w="19050"><a:solidFill><a:srgbClr val="ff0000"/></a:solidFill></a:ln></c:spPr>
+                   <c:spPr><a:ln w="19050"><a:solidFill><a:srgbClr val="ff0000"/></a:solidFill><a:prstDash val="dash"/></a:ln></c:spPr>
                    <c:trendlineType val="linear"/>
                    <c:dispEq val="1"/>
                    <c:dispRSqr val="1"/>
                  </c:trendline>
                  <c:trendline>
+                   <c:spPr><a:ln><a:noFill/></a:ln></c:spPr>
                    <c:trendlineType val="movingAvg"/>
                    <c:period val="3"/>
                  </c:trendline>
@@ -7556,11 +8044,14 @@ mod tests {
         assert_eq!(got[0].trendline_type, "linear");
         assert_eq!(got[0].line_color.as_deref(), Some("FF0000"));
         assert_eq!(got[0].line_width_emu, Some(19050));
+        assert_eq!(got[0].line_dash.as_deref(), Some("dash"));
         assert_eq!(got[0].disp_eq, Some(true));
         assert_eq!(got[0].disp_r_sqr, Some(true));
         assert_eq!(got[1].trendline_type, "movingAvg");
         assert_eq!(got[1].period, Some(3));
         assert_eq!(got[1].line_color, None);
+        assert_eq!(got[0].line_hidden, None);
+        assert_eq!(got[1].line_hidden, Some(true));
     }
 
     // ========================================================================
@@ -9102,13 +9593,18 @@ mod tests {
                   <cx:plotAreaRegion>
                     <cx:series layoutId="waterfall">
                       <cx:spPr><a:solidFill><a:srgbClr val="196eca"/></a:solidFill></cx:spPr>
+                      <cx:layoutPr><cx:visibility connectorLines="0"/></cx:layoutPr>
                       <cx:dataLabels pos="outEnd">
                         <cx:dataLabel idx="0">
                           <cx:txPr><a:p><a:pPr><a:defRPr><a:solidFill><a:schemeClr val="tx1"/></a:solidFill></a:defRPr></a:pPr></a:p></cx:txPr>
                         </cx:dataLabel>
                         <cx:dataLabel idx="2">
+                          <cx:visibility categoryName="1" value="0"/>
+                          <cx:numFmt formatCode="0.0"/>
+                          <cx:separator>|</cx:separator>
                           <cx:txPr><a:p><a:pPr><a:defRPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:defRPr></a:pPr></a:p></cx:txPr>
                         </cx:dataLabel>
+                        <cx:dataLabelHidden idx="1"/>
                       </cx:dataLabels>
                       <cx:subtotals>
                         <cx:idx val="0"/>
@@ -9146,6 +9642,23 @@ mod tests {
         assert_eq!(dl[1], None);
         assert_eq!(dl[2].as_deref(), Some("4472C4"));
         assert_eq!(dl[3], None);
+        let overrides = m.series[0]
+            .data_label_overrides
+            .as_ref()
+            .expect("ChartEx point-label overrides present");
+        let hidden = overrides
+            .iter()
+            .find(|override_| override_.idx == 1)
+            .unwrap();
+        assert_eq!(hidden.deleted, Some(true));
+        let visible_parts = overrides
+            .iter()
+            .find(|override_| override_.idx == 2)
+            .unwrap();
+        assert_eq!(visible_parts.show_cat_name, Some(true));
+        assert_eq!(visible_parts.show_val, Some(false));
+        assert_eq!(visible_parts.format_code.as_deref(), Some("0.0"));
+        assert_eq!(visible_parts.separator.as_deref(), Some("|"));
         // Both totals were explicitly authored; duplicates are de-duplicated.
         assert_eq!(m.subtotal_indices, vec![0, 3]);
         // gapWidth fraction 0.8 → legacy percent 80.
@@ -9153,6 +9666,7 @@ mod tests {
         // Hidden value axis, visible category axis.
         assert!(!m.cat_axis_hidden);
         assert!(m.val_axis_hidden);
+        assert_eq!(m.chartex_connector_lines, Some(false));
         // Theme fallback faces threaded from the resolver (NIT-2: not a direct
         // `theme.get("+mj-lt")`).
         assert_eq!(m.theme_major_font_latin.as_deref(), Some("Calibri Light"));
@@ -9223,19 +9737,24 @@ mod tests {
         );
         let no_style = format!(
             r#"<cs:chartStyle xmlns:cs="{CS_NS}" xmlns:a="{A_NS}">
-              <cs:dataPoint><cs:lnRef idx="0"><cs:styleClr val="auto"/></cs:lnRef></cs:dataPoint>
+              <cs:dataPoint>
+                <cs:fillRef idx="0"><cs:styleClr val="auto"/></cs:fillRef>
+                <cs:lnRef idx="0"><cs:styleClr val="auto"/></cs:lnRef>
+              </cs:dataPoint>
             </cs:chartStyle>"#
         );
         let document = chart_space_of(&xml);
         let model = parse_chartex_part(document.root_element(), &FixtureResolver, Some(&no_style))
             .expect("NoStyle line parses");
         let role = model.chartex_data_point_style.expect("dataPoint role");
+        assert_eq!(role.fill_hidden, Some(true));
+        assert_eq!(role.fill_no_style, Some(true));
         assert_eq!(role.line_hidden, Some(true));
         assert_eq!(role.line_no_style, Some(true));
 
         let explicit_no_fill = no_style.replace(
             "</cs:dataPoint>",
-            "<cs:spPr><a:ln><a:noFill/></a:ln></cs:spPr></cs:dataPoint>",
+            "<cs:spPr><a:noFill/><a:ln><a:noFill/></a:ln></cs:spPr></cs:dataPoint>",
         );
         let model = parse_chartex_part(
             document.root_element(),
@@ -9244,6 +9763,8 @@ mod tests {
         )
         .expect("explicit noFill line parses");
         let role = model.chartex_data_point_style.expect("dataPoint role");
+        assert_eq!(role.fill_hidden, Some(true));
+        assert_eq!(role.fill_no_style, None);
         assert_eq!(role.line_hidden, Some(true));
         assert_eq!(role.line_no_style, None);
     }
@@ -9560,7 +10081,7 @@ mod tests {
     #[test]
     fn chartex_cache_dimensions_reject_unbounded_counts_and_sparse_indices() {
         let huge_count = format!(
-            r#"<cx:chartSpace xmlns:cx="{CX_NS}">
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}" xmlns:a="{A_NS}">
               <cx:chartData><cx:data>
                 <cx:strDim type="cat"><cx:lvl ptCount="4294967295"/></cx:strDim>
                 <cx:numDim type="size"><cx:lvl ptCount="4294967295"/></cx:numDim>
@@ -9785,7 +10306,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_chartex_formula_only_flat_layouts_keep_series_name_and_ordinal_categories() {
+    fn parse_chartex_formula_only_flat_layouts_do_not_invent_missing_categories() {
         for layout in ["waterfall", "clusteredColumn", "funnel", "paretoLine"] {
             let xml = format!(
                 r#"<cx:chartSpace xmlns:cx="{CX_NS}">
@@ -9812,12 +10333,93 @@ mod tests {
                 model.series[0].values,
                 vec![Some(3.0), Some(2.0), Some(1.0)]
             );
-            if layout == "paretoLine" {
-                assert!(model.categories.is_empty());
-            } else {
-                assert_eq!(model.categories, vec!["1", "2", "3"]);
-            }
+            assert!(model.categories.is_empty());
         }
+    }
+
+    #[test]
+    fn parse_chartex_flat_series_resolve_data_id_and_skip_hidden_series() {
+        let xml = format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}" xmlns:a="{A_NS}">
+              <cx:chartData>
+                <cx:data id="0">
+                  <cx:strDim type="cat"><cx:lvl ptCount="1"><cx:pt idx="0">Unused</cx:pt></cx:lvl></cx:strDim>
+                  <cx:numDim type="val"><cx:lvl ptCount="1"><cx:pt idx="0">999</cx:pt></cx:lvl></cx:numDim>
+                </cx:data>
+                <cx:data id="1">
+                  <cx:strDim type="cat"><cx:lvl ptCount="2"><cx:pt idx="0">A</cx:pt><cx:pt idx="1">B</cx:pt></cx:lvl></cx:strDim>
+                  <cx:numDim type="val"><cx:lvl ptCount="2"><cx:pt idx="0">1</cx:pt><cx:pt idx="1">2</cx:pt></cx:lvl></cx:numDim>
+                </cx:data>
+                <cx:data id="2">
+                  <cx:strDim type="cat"><cx:lvl ptCount="2"><cx:pt idx="0">A</cx:pt><cx:pt idx="1">B</cx:pt></cx:lvl></cx:strDim>
+                  <cx:numDim type="val"><cx:lvl ptCount="2"><cx:pt idx="0">3</cx:pt><cx:pt idx="1">4</cx:pt></cx:lvl></cx:numDim>
+                </cx:data>
+                <cx:data id="3"><cx:numDim type="val"><cx:lvl ptCount="1"><cx:pt idx="0">5</cx:pt></cx:lvl></cx:numDim></cx:data>
+              </cx:chartData>
+              <cx:chart><cx:plotArea><cx:plotAreaRegion>
+                <cx:series layoutId="waterfall" hidden="1"><cx:dataId val="0"/></cx:series>
+                <cx:series layoutId="clusteredColumn" formatIdx="0"><cx:tx><cx:txData><cx:v>First</cx:v></cx:txData></cx:tx><cx:dataId val="1"/></cx:series>
+                <cx:series layoutId="clusteredColumn"><cx:tx><cx:txData><cx:v>Second</cx:v></cx:txData></cx:tx>
+                  <cx:dataPt idx="0"><cx:spPr><a:solidFill><a:srgbClr val="112233"/></a:solidFill><a:ln w="25400"><a:solidFill><a:srgbClr val="778899"/></a:solidFill><a:prstDash val="dash"/></a:ln></cx:spPr></cx:dataPt>
+                  <cx:dataPt idx="1"><cx:spPr><a:noFill/><a:ln><a:noFill/></a:ln></cx:spPr></cx:dataPt>
+                  <cx:dataLabels pos="outEnd"><cx:visibility value="1"/><cx:numFmt formatCode="0.0"/>
+                    <cx:dataLabel idx="0"><cx:txPr><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="445566"/></a:solidFill></a:defRPr></a:pPr></a:p></cx:txPr></cx:dataLabel>
+                    <cx:dataLabelHidden idx="1"/>
+                  </cx:dataLabels><cx:dataId val="2"/>
+                </cx:series>
+                <cx:series layoutId="paretoLine" ownerIdx="0"><cx:dataId val="3"/></cx:series>
+              </cx:plotAreaRegion></cx:plotArea></cx:chart>
+            </cx:chartSpace>"#
+        );
+        let document = chart_space_of(&xml);
+        let model = parse_chartex_part(document.root_element(), &FixtureResolver, None)
+            .expect("visible ChartEx series parse");
+
+        assert_eq!(model.chart_type, "clusteredColumn");
+        assert_eq!(model.categories, vec!["A", "B"]);
+        assert_eq!(model.series.len(), 2);
+        assert_eq!(model.series[0].name, "First");
+        assert_eq!(model.series[0].chartex_format_idx, Some(0));
+        assert_eq!(model.series[0].values, vec![Some(1.0), Some(2.0)]);
+        assert_eq!(model.series[1].name, "Second");
+        assert_eq!(model.series[1].chartex_format_idx, Some(2));
+        assert_eq!(model.series[1].values, vec![Some(3.0), Some(4.0)]);
+        assert_eq!(
+            model.series[1].categories.as_deref(),
+            Some(&["A".into(), "B".into()][..])
+        );
+        let labels = model.series[1]
+            .series_data_labels
+            .as_ref()
+            .expect("series-local labels");
+        assert!(labels.show_val);
+        assert_eq!(labels.position.as_deref(), Some("outEnd"));
+        assert_eq!(labels.format_code.as_deref(), Some("0.0"));
+        let label_overrides = model.series[1].data_label_overrides.as_ref().unwrap();
+        assert_eq!(
+            label_overrides
+                .iter()
+                .find(|item| item.idx == 1)
+                .unwrap()
+                .deleted,
+            Some(true)
+        );
+        assert_eq!(
+            model.series[1].data_label_colors.as_ref().unwrap()[0].as_deref(),
+            Some("445566")
+        );
+        let point = &model.series[1].data_point_overrides.as_ref().unwrap()[0];
+        assert_eq!(point.idx, 0);
+        assert_eq!(point.color.as_deref(), Some("112233"));
+        assert_eq!(point.fill_hidden, Some(false));
+        assert_eq!(point.line_color.as_deref(), Some("778899"));
+        assert_eq!(point.line_width_emu, Some(25400));
+        assert_eq!(point.line_dash.as_deref(), Some("dash"));
+        assert_eq!(point.line_hidden, Some(false));
+        let hidden_point = &model.series[1].data_point_overrides.as_ref().unwrap()[1];
+        assert_eq!(hidden_point.idx, 1);
+        assert_eq!(hidden_point.fill_hidden, Some(true));
+        assert_eq!(hidden_point.line_hidden, Some(true));
     }
 
     /// (c) A `<cx:chartSpace>` with no `<cx:series>` is not a chartEx chart —
@@ -9941,8 +10543,8 @@ mod tests {
     struct FormulaOnlyBoxResolver;
 
     impl ChartReferenceResolver for FormulaOnlyBoxResolver {
-        fn resolve_strings(&mut self, _formula: &str) -> Option<Vec<String>> {
-            None
+        fn resolve_strings(&mut self, formula: &str) -> Option<Vec<String>> {
+            (formula == "_xlchart.name").then(|| vec!["Adaptation".to_string()])
         }
 
         fn resolve_numbers(&mut self, formula: &str) -> Option<Vec<Option<f64>>> {
@@ -9978,13 +10580,14 @@ mod tests {
                     <cx:dataId val="0"/>
                   </cx:series>
                   <cx:series layoutId="boxWhisker">
-                    <cx:tx><cx:txData><cx:v>Adaptation</cx:v></cx:txData></cx:tx>
+                    <cx:tx><cx:txData><cx:f>_xlchart.name</cx:f></cx:txData></cx:tx>
                     <cx:dataId val="1"/>
                   </cx:series>
                 </cx:plotAreaRegion>
                 <cx:axis id="0" hidden="1"><cx:catScaling/></cx:axis>
                 <cx:axis id="1">
                   <cx:valScaling min="1" max="6" majorUnit="0.25" minorUnit="0.05"/>
+                  <cx:minorTickMarks type="in"/>
                   <cx:title><cx:tx><cx:rich><a:p><a:r>
                     <a:rPr sz="900" b="0"><a:solidFill><a:schemeClr val="tx1"/></a:solidFill><a:latin typeface="Calibri"/></a:rPr>
                     <a:t>A&amp;R readiness score</a:t>
@@ -10000,6 +10603,7 @@ mod tests {
         );
         let style = format!(
             r#"<cs:chartStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" xmlns:a="{A_NS}">
+              <cs:dataPointMarkerLayout symbol="circle" size="5"/>
               <cs:gridlineMajor><cs:spPr><a:ln w="9525"><a:solidFill><a:srgbClr val="D9D9D9"/></a:solidFill></a:ln></cs:spPr></cs:gridlineMajor>
               <cs:dataPoint><cs:spPr><a:ln w="19050"><a:solidFill><a:schemeClr val="lt1"/></a:solidFill></a:ln></cs:spPr></cs:dataPoint>
               <cs:valueAxis>
@@ -10029,6 +10633,8 @@ mod tests {
         assert_eq!(m.chart_border_width_emu, Some(9525));
         assert_eq!((m.val_min, m.val_max), (Some(1.0), Some(6.0)));
         assert_eq!(m.val_axis_major_unit, Some(0.25));
+        assert_eq!(m.val_axis_minor_unit, Some(0.05));
+        assert_eq!(m.val_axis_minor_tick_mark.as_deref(), Some("in"));
         assert_eq!(m.val_axis_title.as_deref(), Some("A&R readiness score"));
         assert_eq!(m.val_axis_title_font_size_hpt, Some(900));
         assert_eq!(m.val_axis_title_font_bold, Some(false));
@@ -10062,6 +10668,8 @@ mod tests {
         // no `<cx:majorTickMarks>` element, Excel draws no tick marks.
         assert_eq!(m.val_axis_major_tick_mark, "none");
         assert_eq!(m.cat_axis_major_tick_mark, "none");
+        assert_eq!(m.chartex_marker_size_pt, Some(5));
+        assert_eq!(m.chartex_marker_symbol.as_deref(), Some("circle"));
         assert!(m.show_legend);
         assert_eq!(m.legend_pos.as_deref(), Some("r"));
         assert_eq!(m.legend_font_size_hpt, Some(900));
@@ -10158,7 +10766,10 @@ mod tests {
               <cx:chart>
                 <cx:title><cx:tx><cx:rich><a:p><a:r><a:t>My sunburst</a:t></a:r></a:p></cx:rich></cx:tx></cx:title>
                 <cx:plotArea><cx:plotAreaRegion>
-                  <cx:series layoutId="sunburst"><cx:dataId val="0"/></cx:series>
+                  <cx:series layoutId="sunburst">
+                    <cx:spPr><a:ln w="12700"><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill></a:ln></cx:spPr>
+                    <cx:dataId val="0"/>
+                  </cx:series>
                 </cx:plotAreaRegion></cx:plotArea>
               </cx:chart>
             </cx:chartSpace>"#
@@ -10168,6 +10779,9 @@ mod tests {
             parse_chartex_part(d.root_element(), &FixtureResolver, None).expect("sunburst parses");
         assert_eq!(m.chart_type, "sunburst");
         assert_eq!(m.title.as_deref(), Some("My sunburst"));
+        assert_eq!(m.series[0].line_color.as_deref(), Some("FFFFFF"));
+        assert_eq!(m.series[0].line_width_emu, Some(12700));
+        assert_eq!(m.series[0].line_hidden, Some(false));
         let sb = m.chartex_sunburst.expect("sunburst data present");
         assert_eq!(sb.rows.len(), 3);
         // Row 0: full Branch→Stem→Leaf chain.
@@ -10179,6 +10793,18 @@ mod tests {
         // Row 2: full chain under a different branch.
         assert_eq!(sb.rows[2].path, vec!["Branch 2", "Stem 2", "Leaf 3"]);
         assert_eq!(sb.rows[2].size, 18.0);
+
+        let no_fill_xml = xml.replace(
+            r#"<a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill>"#,
+            "<a:noFill/>",
+        );
+        let no_fill_document = chart_space_of(&no_fill_xml);
+        let no_fill_model =
+            parse_chartex_part(no_fill_document.root_element(), &FixtureResolver, None)
+                .expect("sunburst with an explicit noFill outline parses");
+        assert_eq!(no_fill_model.series[0].line_color, None);
+        assert_eq!(no_fill_model.series[0].line_width_emu, Some(12700));
+        assert_eq!(no_fill_model.series[0].line_hidden, Some(true));
     }
 
     /// A waterfall chart must not get hierarchy/box structured fields. It does
@@ -10260,7 +10886,7 @@ mod tests {
             )
         };
         let style = format!(
-            r#"<cs:chartStyle xmlns:cs="{CS_NS}"><cs:title><cs:defRPr sz="1400"/></cs:title></cs:chartStyle>"#
+            r#"<cs:chartStyle xmlns:cs="{CS_NS}" xmlns:a="{A_NS}"><cs:title><cs:fontRef idx="major"><a:srgbClr val="445566"/></cs:fontRef><cs:defRPr sz="1400" b="0"/></cs:title></cs:chartStyle>"#
         );
 
         // No inline sz + style part → style part's 1400.
@@ -10268,6 +10894,9 @@ mod tests {
         let d0 = chart_space_of(&x0);
         let m0 = parse_chartex_part(d0.root_element(), &FixtureResolver, Some(&style)).unwrap();
         assert_eq!(m0.title_font_size_hpt, Some(1400));
+        assert_eq!(m0.title_font_bold, Some(false));
+        assert_eq!(m0.title_font_color.as_deref(), Some("445566"));
+        assert_eq!(m0.title_font_face.as_deref(), Some("Calibri Light"));
 
         // Inline sz on the title wins over the style part.
         let x1 = chart_xml(r#"<a:defRPr sz="2000"/>"#);

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -60,6 +60,8 @@ export interface ChartDataLabelOverride {
     fontColor?: string;
     fontSizeHpt?: number;
     fontBold?: boolean;
+    formatCode?: string;
+    separator?: string;
     labelBox?: ChartLabelBox;
     showVal?: boolean;
     showCatName?: boolean;
@@ -70,6 +72,11 @@ export interface ChartDataLabelOverride {
 export interface ChartDataPointOverride {
     idx: number;
     color?: string;
+    fillHidden?: boolean;
+    lineColor?: string;
+    lineWidthEmu?: number;
+    lineDash?: string;
+    lineHidden?: boolean;
     markerSymbol?: string;
     markerSize?: number;
     markerFill?: string;
@@ -99,9 +106,11 @@ export interface ChartErrBars {
 }
 export interface ChartexBoxSeries {
     name: string;
+    chartexFormatIdx?: number | null;
     color?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
+    chartexStyle?: ChartExElementStyle | null;
     valuesByCategory: number[][];
     meanMarker: boolean;
     meanLine: boolean;
@@ -117,9 +126,11 @@ export interface ChartExElementStyle {
     fillPaints?: Array<SolidFill | GradientFill | PatternFill | null> | null;
     fillColors?: Array<string | null> | null;
     fillHidden?: boolean | null;
+    fillNoStyle?: boolean | null;
     lineColors?: Array<string | null> | null;
     lineWidthEmu?: number | null;
     lineHidden?: boolean | null;
+    lineNoStyle?: boolean | null;
     lineDash?: string | null;
     lineCap?: string | null;
     lineJoin?: string | null;
@@ -246,11 +257,22 @@ export interface ChartModel {
     catAxisMajorGridlines?: boolean | null;
     valAxisGridlineColor?: string | null;
     valAxisGridlineWidthEmu?: number | null;
+    valAxisGridlineDash?: string | null;
     catAxisGridlineColor?: string | null;
     catAxisGridlineWidthEmu?: number | null;
+    catAxisGridlineDash?: string | null;
     valAxisMinorGridlines?: boolean | null;
+    valAxisMinorGridlineColor?: string | null;
+    valAxisMinorGridlineWidthEmu?: number | null;
+    valAxisMinorGridlineDash?: string | null;
+    catAxisMinorGridlines?: boolean | null;
+    catAxisMinorGridlineColor?: string | null;
+    catAxisMinorGridlineWidthEmu?: number | null;
+    catAxisMinorGridlineDash?: string | null;
     valAxisMajorUnit?: number | null;
     valAxisMinorUnit?: number | null;
+    catAxisMajorUnit?: number | null;
+    catAxisMinorUnit?: number | null;
     valAxisLogBase?: number | null;
     valAxisOrientation?: 'minMax' | 'maxMin' | string | null;
     catAxisOrientation?: 'minMax' | 'maxMin' | string | null;
@@ -271,6 +293,9 @@ export interface ChartModel {
     chartexDataPointStyle?: ChartExElementStyle | null;
     chartexDataPointLineStyle?: ChartExElementStyle | null;
     chartexDataPointMarkerStyle?: ChartExElementStyle | null;
+    chartexMarkerSizePt?: number | null;
+    chartexMarkerSymbol?: string | null;
+    chartexConnectorLines?: boolean | null;
 }
 export interface ChartRect {
     x: number;
@@ -280,8 +305,10 @@ export interface ChartRect {
 }
 export interface ChartSeries {
     name: string;
+    chartexFormatIdx?: number | null;
     color: string | null;
     fillPattern?: PatternFill | null;
+    chartexStyle?: ChartExElementStyle | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     values: (number | null)[];
@@ -359,6 +386,8 @@ export interface ChartTrendline {
     dispEq?: boolean | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
+    lineDash?: string | null;
+    lineHidden?: boolean | null;
 }
 export type ChartType = 'line' | 'stackedLine' | 'stackedLinePct' | 'clusteredBar' | 'clusteredBarH' | 'stackedBar' | 'stackedBarH' | 'stackedBarPct' | 'stackedBarHPct' | 'area' | 'stackedArea' | 'stackedAreaPct' | 'pie' | 'doughnut' | 'scatter' | 'bubble' | 'radar' | 'waterfall' | 'stock' | 'boxWhisker' | 'sunburst' | 'treemap' | string;
 export interface DimOptions {
@@ -1067,14 +1096,18 @@ export interface SecondaryValueAxis {
     formatCode?: string | null;
     fontColor?: string | null;
     fontSizeHpt?: number | null;
+    fontFace?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineHidden: boolean;
     majorTickMark: string;
+    minorTickMark?: string | null;
     majorUnit?: number | null;
+    minorUnit?: number | null;
     titleFontSizeHpt?: number | null;
     titleFontBold?: boolean | null;
     titleFontColor?: string | null;
+    titleFontFace?: string | null;
 }
 export interface Shadow {
     color: string;

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -171,6 +171,8 @@ export interface ChartDataLabelOverride {
     fontColor?: string;
     fontSizeHpt?: number;
     fontBold?: boolean;
+    formatCode?: string;
+    separator?: string;
     labelBox?: ChartLabelBox;
     showVal?: boolean;
     showCatName?: boolean;
@@ -181,6 +183,11 @@ export interface ChartDataLabelOverride {
 export interface ChartDataPointOverride {
     idx: number;
     color?: string;
+    fillHidden?: boolean;
+    lineColor?: string;
+    lineWidthEmu?: number;
+    lineDash?: string;
+    lineHidden?: boolean;
     markerSymbol?: string;
     markerSize?: number;
     markerFill?: string;
@@ -199,9 +206,11 @@ export interface ChartErrBars {
 }
 export interface ChartexBoxSeries {
     name: string;
+    chartexFormatIdx?: number | null;
     color?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
+    chartexStyle?: ChartExElementStyle | null;
     valuesByCategory: number[][];
     meanMarker: boolean;
     meanLine: boolean;
@@ -217,9 +226,11 @@ export interface ChartExElementStyle {
     fillPaints?: Array<SolidFill | GradientFill | PatternFill | null> | null;
     fillColors?: Array<string | null> | null;
     fillHidden?: boolean | null;
+    fillNoStyle?: boolean | null;
     lineColors?: Array<string | null> | null;
     lineWidthEmu?: number | null;
     lineHidden?: boolean | null;
+    lineNoStyle?: boolean | null;
     lineDash?: string | null;
     lineCap?: string | null;
     lineJoin?: string | null;
@@ -346,11 +357,22 @@ export interface ChartModel {
     catAxisMajorGridlines?: boolean | null;
     valAxisGridlineColor?: string | null;
     valAxisGridlineWidthEmu?: number | null;
+    valAxisGridlineDash?: string | null;
     catAxisGridlineColor?: string | null;
     catAxisGridlineWidthEmu?: number | null;
+    catAxisGridlineDash?: string | null;
     valAxisMinorGridlines?: boolean | null;
+    valAxisMinorGridlineColor?: string | null;
+    valAxisMinorGridlineWidthEmu?: number | null;
+    valAxisMinorGridlineDash?: string | null;
+    catAxisMinorGridlines?: boolean | null;
+    catAxisMinorGridlineColor?: string | null;
+    catAxisMinorGridlineWidthEmu?: number | null;
+    catAxisMinorGridlineDash?: string | null;
     valAxisMajorUnit?: number | null;
     valAxisMinorUnit?: number | null;
+    catAxisMajorUnit?: number | null;
+    catAxisMinorUnit?: number | null;
     valAxisLogBase?: number | null;
     valAxisOrientation?: 'minMax' | 'maxMin' | string | null;
     catAxisOrientation?: 'minMax' | 'maxMin' | string | null;
@@ -371,6 +393,9 @@ export interface ChartModel {
     chartexDataPointStyle?: ChartExElementStyle | null;
     chartexDataPointLineStyle?: ChartExElementStyle | null;
     chartexDataPointMarkerStyle?: ChartExElementStyle | null;
+    chartexMarkerSizePt?: number | null;
+    chartexMarkerSymbol?: string | null;
+    chartexConnectorLines?: boolean | null;
 }
 export interface ChartRect {
     x: number;
@@ -380,8 +405,10 @@ export interface ChartRect {
 }
 export interface ChartSeries {
     name: string;
+    chartexFormatIdx?: number | null;
     color: string | null;
     fillPattern?: PatternFill | null;
+    chartexStyle?: ChartExElementStyle | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     values: (number | null)[];
@@ -459,6 +486,8 @@ export interface ChartTrendline {
     dispEq?: boolean | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
+    lineDash?: string | null;
+    lineHidden?: boolean | null;
 }
 export type ChartType = 'line' | 'stackedLine' | 'stackedLinePct' | 'clusteredBar' | 'clusteredBarH' | 'stackedBar' | 'stackedBarH' | 'stackedBarPct' | 'stackedBarHPct' | 'area' | 'stackedArea' | 'stackedAreaPct' | 'pie' | 'doughnut' | 'scatter' | 'bubble' | 'radar' | 'waterfall' | 'stock' | 'boxWhisker' | 'sunburst' | 'treemap' | string;
 export interface ConditionalFormat {
@@ -1030,14 +1059,18 @@ export interface SecondaryValueAxis {
     formatCode?: string | null;
     fontColor?: string | null;
     fontSizeHpt?: number | null;
+    fontFace?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineHidden: boolean;
     majorTickMark: string;
+    minorTickMark?: string | null;
     majorUnit?: number | null;
+    minorUnit?: number | null;
     titleFontSizeHpt?: number | null;
     titleFontBold?: boolean | null;
     titleFontColor?: string | null;
+    titleFontFace?: string | null;
 }
 export interface ShapeAnchor {
     fromCol: number;


### PR DESCRIPTION
## Summary

- preserve ChartEx series/data relationships, `formatIdx`, direct point/series formatting, labels, and linked Chart Style paint
- render specification-defined advanced ChartEx geometry and authored axis/gridline/tick properties through shared chart paths
- keep fill/line/marker/legend paint precedence consistent, including explicit `noFill`
- bound synchronous Canvas primitives for large untrusted chart datasets

## Specification basis

Implements the relevant MS-ODRAWXML contracts for CT_Series, CT_Data, CT_DataLabels, CT_DataPoint, CT_ValueAxisScaling, and linked Chart Style color/paint semantics. Automatic legend packing and omitted title typography are intentionally excluded and tracked separately in #1229 and #1237.

## Verification

- core chart tests: 424 passed
- ooxml-common chart tests: 144 passed
- TypeScript project build
- public API baselines and viewer API symmetry
- full DOCX/XLSX/PPTX WASM rebuild
- production bundle build
- private-corpus renderer regression comparison and local visual inspection
- adversarial review: approved
