### PR TITLE
fix(chart): make hierarchy layouts deterministic

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -5207,6 +5207,70 @@ describe('CH15 — chartEx sunburst', () => {
     expect(sweeps[0] / sweeps[1]).toBeCloseTo(2, 1);
   });
 
+  it('ignores non-positive and non-finite hierarchy weights without changing source order', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel({
+      chartexSunburst: {
+        rows: [
+          { path: ['First', 'Positive'], size: 10 },
+          { path: ['First', 'Negative'], size: -100 },
+          { path: ['First', 'NaN'], size: Number.NaN },
+          { path: ['Second', 'Positive'], size: 10 },
+          { path: ['Second', 'Infinity'], size: Number.POSITIVE_INFINITY },
+          { path: ['Third', 'Zero'], size: 0 },
+        ],
+      },
+    }), RECT, 1);
+
+    const innerOuterR = [...new Set(rec.arcs.map(arc => Math.round(arc.r)))]
+      .sort((a, b) => a - b)[1];
+    const branchArcs = rec.arcs.filter(arc => Math.round(arc.r) === innerOuterR && !arc.ccw);
+    const sweeps = branchArcs.map(arc => arc.a1 - arc.a0);
+    expect(sweeps).toHaveLength(2);
+    expect(sweeps[0]).toBeCloseTo(Math.PI, 5);
+    expect(sweeps[1]).toBeCloseTo(Math.PI, 5);
+    expect(branchArcs[0].a0).toBeCloseTo(-Math.PI / 2, 5);
+    expect(branchArcs[1].a0).toBeCloseTo(branchArcs[0].a1, 5);
+  });
+
+  it('keeps proportional finite angles when positive hierarchy sums exceed Number.MAX_VALUE', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel({
+      chartexSunburst: {
+        rows: [
+          { path: ['First', 'A'], size: Number.MAX_VALUE },
+          { path: ['First', 'B'], size: Number.MAX_VALUE },
+          { path: ['Second', 'C'], size: Number.MAX_VALUE },
+        ],
+      },
+    }), RECT, 1);
+
+    const innerOuterR = [...new Set(rec.arcs.map(arc => Math.round(arc.r)))]
+      .sort((a, b) => a - b)[1];
+    const branchArcs = rec.arcs.filter(arc => Math.round(arc.r) === innerOuterR && !arc.ccw);
+    expect(branchArcs).toHaveLength(2);
+    expect(branchArcs.every(arc => Number.isFinite(arc.a0) && Number.isFinite(arc.a1))).toBe(true);
+    expect(branchArcs[0].a1 - branchArcs[0].a0).toBeCloseTo((Math.PI * 4) / 3, 5);
+    expect(branchArcs[1].a1 - branchArcs[1].a0).toBeCloseTo((Math.PI * 2) / 3, 5);
+  });
+
+  it('paints no sunburst geometry when every hierarchy weight normalizes to zero', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, sunburstModel({
+      chartexSunburst: {
+        rows: [
+          { path: ['Zero'], size: 0 },
+          { path: ['Negative'], size: -1 },
+          { path: ['NaN'], size: Number.NaN },
+          { path: ['Infinity'], size: Number.POSITIVE_INFINITY },
+        ],
+      },
+    }), RECT, 1);
+
+    expect(rec.arcs).toHaveLength(0);
+    expect(rec.fills).toHaveLength(0);
+  });
+
   it('draws an authored top legend outside the rings', () => {
     const rec = ringRecordingCtx();
     renderChart(rec.ctx, sunburstModel({ showLegend: true, legendPos: 't' }), RECT, 1);
@@ -5294,6 +5358,173 @@ describe('CH15 — chartEx treemap', () => {
     expect(rec.texts.filter(text => text.text === 'Repeat').length).toBeGreaterThanOrEqual(6);
   });
 
+  it('normalizes hierarchy weights before allocating proportional parent areas', () => {
+    const rec = recordingCtx();
+    const model = baseModel({
+      chartType: 'treemap',
+      chartexAccents: ['5B9BD5', 'ED7D31', 'A5A5A5'],
+      chartexTreemap: {
+        parentLabelLayout: 'none',
+        rows: [
+          { path: ['A', 'positive'], size: 10 },
+          { path: ['A', 'negative'], size: -100 },
+          { path: ['A', 'invalid'], size: Number.NaN },
+          { path: ['B', 'positive'], size: 10 },
+          { path: ['B', 'infinite'], size: Number.POSITIVE_INFINITY },
+          { path: ['C', 'zero'], size: 0 },
+        ],
+      },
+      series: [series({})],
+    });
+    renderChart(rec.ctx, model, RECT, 1);
+
+    const areaByFill = new Map<string, number>();
+    for (const tile of rec.rects) {
+      areaByFill.set(tile.fs, (areaByFill.get(tile.fs) ?? 0) + tile.w * tile.h);
+    }
+    expect([...areaByFill.keys()]).toEqual(['#5B9BD5', '#ED7D31']);
+    expect(areaByFill.get('#5B9BD5')).toBeCloseTo(areaByFill.get('#ED7D31') ?? 0, 5);
+  });
+
+  it('keeps squarified tiles proportional, contained, non-overlapping, and deterministic', () => {
+    const model = baseModel({
+      chartType: 'treemap',
+      chartexAccents: ['5B9BD5', 'ED7D31', 'A5A5A5'],
+      chartexTreemap: {
+        parentLabelLayout: 'none',
+        rows: [
+          { path: ['Large', '1000'], size: 1000 },
+          { path: ['Small', '1'], size: 1 },
+          { path: ['Zero', '0'], size: 0 },
+        ],
+      },
+      series: [series({})],
+    });
+    const bounds = { x: 0, y: 0, w: 2200, h: 1200 };
+    const first = recordingCtx();
+    const second = recordingCtx();
+    renderChart(first.ctx, model, bounds, 1);
+    renderChart(second.ctx, model, bounds, 1);
+
+    expect(first.rects).toEqual(second.rects);
+    expect(first.rects).toHaveLength(2);
+    const [large, small] = first.rects.sort((a, b) => b.w * b.h - a.w * a.h);
+    expect((large.w * large.h) / (small.w * small.h)).toBeCloseTo(1000, 5);
+
+    const minX = Math.min(...first.rects.map(tile => tile.x));
+    const minY = Math.min(...first.rects.map(tile => tile.y));
+    const maxX = Math.max(...first.rects.map(tile => tile.x + tile.w));
+    const maxY = Math.max(...first.rects.map(tile => tile.y + tile.h));
+    const unionArea = (maxX - minX) * (maxY - minY);
+    const tileArea = first.rects.reduce((sum, tile) => sum + tile.w * tile.h, 0);
+    expect(tileArea).toBeCloseTo(unionArea, 5);
+    for (let i = 0; i < first.rects.length; i++) {
+      const a = first.rects[i];
+      expect(a.x).toBeGreaterThanOrEqual(minX);
+      expect(a.y).toBeGreaterThanOrEqual(minY);
+      expect(a.x + a.w).toBeLessThanOrEqual(maxX);
+      expect(a.y + a.h).toBeLessThanOrEqual(maxY);
+      for (let j = i + 1; j < first.rects.length; j++) {
+        const b = first.rects[j];
+        const overlapW = Math.max(0, Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x));
+        const overlapH = Math.max(0, Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y));
+        expect(overlapW * overlapH).toBeCloseTo(0, 8);
+      }
+    }
+  });
+
+  it('preserves a 10:1 aggregate-weight ratio between top-level parents', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'treemap',
+      chartexAccents: ['5B9BD5', 'ED7D31'],
+      chartexTreemap: {
+        parentLabelLayout: 'none',
+        rows: [
+          { path: ['Ten', 'A'], size: 6 },
+          { path: ['Ten', 'B'], size: 4 },
+          { path: ['One', 'C'], size: 1 },
+        ],
+      },
+      series: [series({})],
+    }), RECT, 1);
+    const area = (color: string): number => rec.rects
+      .filter(tile => tile.fs === color)
+      .reduce((sum, tile) => sum + tile.w * tile.h, 0);
+    expect(area('#5B9BD5') / area('#ED7D31')).toBeCloseTo(10, 5);
+  });
+
+  it('keeps deep aggregate areas finite when positive sums exceed Number.MAX_VALUE', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'treemap',
+      chartexAccents: ['5B9BD5', 'ED7D31'],
+      chartexTreemap: {
+        parentLabelLayout: 'none',
+        rows: [
+          { path: ['First', 'Deep', 'A'], size: Number.MAX_VALUE },
+          { path: ['First', 'Deep', 'B'], size: Number.MAX_VALUE },
+          { path: ['Second', 'C'], size: Number.MAX_VALUE },
+        ],
+      },
+      series: [series({})],
+    }), RECT, 1);
+
+    expect(rec.rects).toHaveLength(3);
+    expect(rec.rects.every(tile => [tile.x, tile.y, tile.w, tile.h].every(Number.isFinite))).toBe(true);
+    const area = (color: string): number => rec.rects
+      .filter(tile => tile.fs === color)
+      .reduce((sum, tile) => sum + tile.w * tile.h, 0);
+    expect(area('#5B9BD5') / area('#ED7D31')).toBeCloseTo(2, 5);
+  });
+
+  it('keeps an overflowing aggregate display label finite', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'treemap',
+      chartexAccents: ['5B9BD5'],
+      chartexTreemap: {
+        parentLabelLayout: 'overlapping',
+        rows: [
+          { path: ['Aggregate', 'A'], size: Number.MAX_VALUE },
+          { path: ['Aggregate', 'B'], size: Number.MAX_VALUE },
+        ],
+      },
+      series: [series({
+        seriesDataLabels: {
+          showVal: true,
+          showCatName: false,
+          showSerName: false,
+          showPercent: false,
+        },
+      })],
+    }), RECT, 1);
+
+    const parentValues = rec.texts
+      .filter(text => text.baseline === 'top')
+      .map(text => Number(text.text));
+    expect(parentValues).toEqual([Number.MAX_VALUE]);
+    expect(parentValues.every(Number.isFinite)).toBe(true);
+  });
+
+  it('keeps equal-weight top-level tiles in first-seen source order', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'treemap',
+      chartexAccents: ['5B9BD5', 'ED7D31', 'A5A5A5'],
+      chartexTreemap: {
+        parentLabelLayout: 'none',
+        rows: [
+          { path: ['First'], size: 1 },
+          { path: ['Second'], size: 1 },
+          { path: ['Third'], size: 1 },
+        ],
+      },
+      series: [series({})],
+    }), RECT, 1);
+
+    expect(rec.rects.map(tile => tile.fs)).toEqual(['#5B9BD5', '#ED7D31', '#A5A5A5']);
+  });
 
   it('does not paint padded parent frames for overlapping parent labels', () => {
     const rec = recordingCtx();
@@ -5354,6 +5585,46 @@ describe('CH15 — chartEx treemap', () => {
         lw: 1.5,
       });
     });
+  });
+
+  it('uses a one-CSS-pixel chart-background separator when no line is authored', () => {
+    const rec = recordingCtx();
+    const model = treemapModel();
+    model.chartBg = '112233';
+    model.chartexTreemap!.parentLabelLayout = 'overlapping';
+    model.chartexDataPointStyle = null;
+    model.series[0].lineColor = null;
+    model.series[0].lineWidthEmu = null;
+    model.series[0].lineHidden = null;
+    renderChart(rec.ctx, model, RECT, 1);
+
+    const tiles = rec.rects.filter(rect => rect.fs !== '#112233');
+    expect(rec.strokeRects).toHaveLength(tiles.length);
+    expect(rec.strokeRects.every(stroke => stroke.ss === '#112233' && stroke.lw === 1)).toBe(true);
+  });
+
+  it('uses the automatic separator when the linked Chart Style line is NoStyle', () => {
+    const rec = recordingCtx();
+    const model = treemapModel();
+    model.chartBg = '112233';
+    model.chartexTreemap!.parentLabelLayout = 'overlapping';
+    model.chartexDataPointStyle = { lineHidden: true, lineNoStyle: true };
+    renderChart(rec.ctx, model, RECT, 1);
+
+    const tiles = rec.rects.filter(rect => rect.fs !== '#112233');
+    expect(rec.strokeRects).toHaveLength(tiles.length);
+    expect(rec.strokeRects.every(stroke => stroke.ss === '#112233' && stroke.lw === 1)).toBe(true);
+  });
+
+  it('keeps a direct series noFill authoritative over the automatic separator', () => {
+    const rec = recordingCtx();
+    const model = treemapModel();
+    model.chartexTreemap!.parentLabelLayout = 'overlapping';
+    model.chartexDataPointStyle = { lineHidden: true, lineNoStyle: true };
+    model.series[0].chartexStyle = { lineHidden: true };
+    renderChart(rec.ctx, model, RECT, 1);
+
+    expect(rec.strokeRects).toHaveLength(0);
   });
 
   it('uses the per-accent ChartEx outline after phClr substitution', () => {
@@ -5461,6 +5732,40 @@ describe('CH15 — chartEx treemap', () => {
     expect(rec.clips).toEqual(expect.arrayContaining([
       expect.objectContaining({ x: tile.x, y: tile.y, w: tile.w, h: tile.h }),
     ]));
+  });
+
+  it('keeps omitted-position leaf labels inside a font-relative 0.5em inset', () => {
+    const rec = recordingCtx();
+    const model = baseModel({
+      chartType: 'treemap',
+      chartexAccents: ['5B9BD5'],
+      chartexTreemap: {
+        parentLabelLayout: 'none',
+        rows: [{ path: ['Group', 'ABCDEFGHIJKL'], size: 1 }],
+      },
+      series: [series({
+        values: [1],
+        seriesDataLabels: {
+          showVal: false,
+          showCatName: true,
+          showSerName: false,
+          showPercent: false,
+          fontSizeHpt: 2000,
+        },
+      })],
+    });
+    renderChart(rec.ctx, model, { x: 0, y: 0, w: 90, h: 90 }, 1);
+
+    const tile = rec.strokeRects[0];
+    const labels = rec.texts.filter(text => text.baseline === 'middle');
+    expect(labels.length).toBeGreaterThan(0);
+    for (const label of labels) {
+      const fontPx = Number.parseFloat(/(\d+(?:\.\d+)?)px/.exec(label.font ?? '')?.[1] ?? '0');
+      expect(label.x - (label.width ?? 0) / 2).toBeGreaterThanOrEqual(tile.x + fontPx * 0.5 - 1e-6);
+      expect(label.x + (label.width ?? 0) / 2).toBeLessThanOrEqual(tile.x + tile.w - fontPx * 0.5 + 1e-6);
+      expect(label.y).toBeGreaterThanOrEqual(tile.y + fontPx * 0.5 - 1e-6);
+      expect(label.y).toBeLessThanOrEqual(tile.y + tile.h - fontPx * 0.5 + 1e-6);
+    }
   });
 
   it('clips boundary-centered tile strokes to the plot rectangle', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -5942,6 +5942,7 @@ function applyChartExSeriesLineStyle(
   count: number,
   fallbackColor: string,
   ptToPx: number,
+  options: { linkedNoStyleFallback?: boolean } = {},
 ): boolean {
   const local = series?.chartexStyle;
   const localHasLine = local?.lineHidden != null
@@ -5957,6 +5958,9 @@ function applyChartExSeriesLineStyle(
     || series?.lineColor != null
     || series?.lineWidthEmu != null;
   if (!hasLegacyLocalLine) {
+    if (style?.lineNoStyle && options.linkedNoStyleFallback) {
+      return applyChartExLineStyle(ctx, chart, null, index, count, fallbackColor, ptToPx);
+    }
     return applyChartExLineStyle(ctx, chart, style, index, count, fallbackColor, ptToPx);
   }
   if (series?.lineHidden) return false;
@@ -7012,12 +7016,16 @@ function renderBoxWhiskerChart(
 
 // ─── chartEx: sunburst (CH15, MS 2014 chartex ext) ───────────────────────────
 
-/** A node in the sunburst ring tree. `value` is the sum of descendant leaf
- *  sizes (or the node's own size when it is a leaf). `a0`/`a1` are its angular
- *  span (radians, canvas convention) once laid out; `depth` is its ring index
- *  (0 = innermost / root). */
+/** A node in the shared hierarchy tree. `layoutWeight` is the overflow-safe
+ *  aggregate used for treemap areas and sunburst angles; `value` is the finite,
+ *  saturating aggregate exposed to data-label formatting. `a0`/`a1` are the
+ *  sunburst span (radians, canvas convention) once laid out; `depth` is its
+ *  ring index (0 = innermost / root). */
 interface SunburstNode {
   label: string;
+  /** Finite, overflow-safe relative weight used only for geometry. */
+  layoutWeight: number;
+  /** Sanitized display value. Sums saturate when JavaScript cannot represent them. */
   value: number;
   depth: number;
   children: SunburstNode[];
@@ -7043,12 +7051,27 @@ function buildSunburstTree(
   preserveTerminalDuplicates = false,
 ): SunburstNode {
   const root: SunburstNode = {
-    label: '', value: 0, depth: -1, children: [], branchIndex: -1, labelIndex: -1, a0: 0, a1: 0,
+    label: '', layoutWeight: 0, value: 0, depth: -1, children: [], branchIndex: -1, labelIndex: -1, a0: 0, a1: 0,
   };
+  const maxRowValue = rows.reduce((max, row) => (
+    Number.isFinite(row.size) && row.size > max ? row.size : max
+  ), 0);
+  const safeSum = (left: number, right: number): number => (
+    left > Number.MAX_VALUE - right ? Number.MAX_VALUE : left + right
+  );
   // Construction-only indexes keep sibling interning O(1) per path segment;
   // the WeakMap dies with this function and does not pollute the paint model.
   const childIndexes = new WeakMap<SunburstNode, Map<string, SunburstNode>>();
   for (const row of rows) {
+    // ChartEx leaves without a finite positive size remain part of the authored
+    // hierarchy/order, but they do not contribute layout weight. Normalizing at
+    // the shared tree boundary keeps treemap parent areas and sunburst parent
+    // spans consistent; filtering only at either painter would leave ancestors
+    // with contaminated aggregate values.
+    const rowValue = Number.isFinite(row.size) && row.size > 0 ? row.size : 0;
+    // Dividing every positive row by the same maximum preserves all layout
+    // ratios while bounding every later ancestor sum by the source row count.
+    const rowWeight = maxRowValue > 0 ? rowValue / maxRowValue : 0;
     let node = root;
     for (let d = 0; d < row.path.length; d++) {
       const label = row.path[d];
@@ -7062,6 +7085,7 @@ function buildSunburstTree(
       if (!child) {
         child = {
           label,
+          layoutWeight: 0,
           value: 0,
           depth: d,
           children: [],
@@ -7074,11 +7098,13 @@ function buildSunburstTree(
         node.children.push(child);
         if (!preserveNode) index.set(label, child);
       }
-      child.value += row.size;
+      child.layoutWeight += rowWeight;
+      child.value = safeSum(child.value, rowValue);
       node = child;
     }
   }
-  root.value = root.children.reduce((s, c) => s + c.value, 0);
+  root.layoutWeight = root.children.reduce((sum, child) => sum + child.layoutWeight, 0);
+  root.value = root.children.reduce((sum, child) => safeSum(sum, child.value), 0);
   let nextLabelIndex = 0;
   const assignLabelIndices = (node: SunburstNode): void => {
     for (const child of node.children) {
@@ -7091,13 +7117,14 @@ function buildSunburstTree(
 }
 
 /** Assign angular spans top-down: each node partitions its `[a0, a1)` range
- *  across its children proportional to their value, in child (source) order. */
+ *  across its children proportional to their layout weight, in child (source)
+ *  order. */
 function layoutSunburstAngles(node: SunburstNode): void {
-  const total = node.children.reduce((s, c) => s + c.value, 0);
+  const total = node.children.reduce((sum, child) => sum + child.layoutWeight, 0);
   if (total <= 0) return;
   let a = node.a0;
   for (const child of node.children) {
-    const sweep = ((node.a1 - node.a0) * child.value) / total;
+    const sweep = ((node.a1 - node.a0) * child.layoutWeight) / total;
     child.a0 = a;
     child.a1 = a + sweep;
     a = child.a1;
@@ -7135,7 +7162,7 @@ function renderSunburstChart(
   if (!sb || sb.rows.length === 0) return;
   const { x, y, w, h } = r;
   const root = buildSunburstTree(sb.rows);
-  if (root.value <= 0 || root.children.length === 0) return;
+  if (root.layoutWeight <= 0 || root.children.length === 0) return;
   const series = chart.series[0];
   const legendPaints = root.children.map((_, index) =>
     chartExDataPointPaint(chart, index, root.children.length, series?.chartexStyle, series?.color)
@@ -7354,11 +7381,15 @@ interface TreemapRect { x: number; y: number; w: number; h: number }
 interface TreemapTile { node: SunburstNode; rect: TreemapRect }
 
 /** Standard squarified-treemap layout. Areas are exactly proportional to node
- * values; descending stable order keeps the aspect ratios useful without any
- * document-specific tuning. */
+ * layout weights; descending stable order keeps the aspect ratios useful
+ * without any document-specific tuning. */
 function layoutTreemapTiles(nodes: SunburstNode[], rect: TreemapRect): TreemapTile[] {
   const positive = nodes
-    .map((node, index) => ({ node, index, value: Math.max(0, node.value) }))
+    .map((node, index) => ({
+      node,
+      index,
+      value: node.layoutWeight,
+    }))
     .filter(entry => entry.value > 0)
     .sort((a, b) => b.value - a.value || a.index - b.index);
   const total = positive.reduce((sum, entry) => sum + entry.value, 0);
@@ -7445,7 +7476,7 @@ function renderTreemapChart(
   // A treemap data point remains a distinct tile even when its terminal label
   // repeats. Only parent path components are grouping keys.
   const root = buildSunburstTree(treemap.rows, true);
-  if (root.value <= 0 || root.children.length === 0) return;
+  if (root.layoutWeight <= 0 || root.children.length === 0) return;
   const series = chart.series[0];
   const legendPaints = root.children.map(node =>
     chartExDataPointPaint(
@@ -7479,6 +7510,12 @@ function renderTreemapChart(
   const labelOverrides = new Map(
     (chart.series[0]?.dataLabelOverrides ?? []).map(override => [override.idx, override]),
   );
+  // With no direct or linked line recipe, use a one-CSS-pixel separator derived
+  // from the chart background. `applyChartExSeriesLineStyle` still resolves
+  // direct series formatting and the linked data-point role before this fallback.
+  const automaticSeparator = chart.chartBg
+    ? (chart.chartBg.startsWith('#') ? chart.chartBg : `#${chart.chartBg}`)
+    : '#ffffff';
 
   const paint = (node: SunburstNode, tile: TreemapRect): void => {
     if (tile.w < 0.5 || tile.h < 0.5) return;
@@ -7569,8 +7606,9 @@ function renderTreemapChart(
       chart.series[0],
       node.branchIndex,
       root.children.length,
-      '#ffffff',
+      automaticSeparator,
       ptToPx,
+      { linkedNoStyleFallback: true },
     );
     if (hasAuthoredOutline) {
       // ChartEx outlines are centered on the tile boundary. An inset stroke
@@ -7589,12 +7627,20 @@ function renderTreemapChart(
     if (tile.w <= fontPx * 1.2 || tile.h <= fontPx * 1.2) return;
     ctx.font = `${leafLabel.fontBold ? 'bold ' : ''}${fontPx}px ${fontFamily}`;
     ctx.fillStyle = leafLabel.fontColor ? `#${leafLabel.fontColor}` : nodeLabelColor;
-    const lines = leafLabel.text
-      .split(/\r?\n/)
-      .flatMap(line => wrapMeasuredText(ctx, line, Math.max(1, tile.w - 8)));
     const lineH = fontPx * 1.1;
     const position = leafLabel.position ?? 'ctr';
-    const maxLines = Math.max(0, Math.floor((tile.h - 6) / lineH));
+    const inset = position === 'inEnd' ? 4 : fontPx * 0.5;
+    const availableWidth = tile.w - inset * 2;
+    const availableHeight = tile.h - inset * 2;
+    if (availableWidth <= 0 || availableHeight <= 0) return;
+    const lines = leafLabel.text
+      .split(/\r?\n/)
+      .flatMap(line => wrapMeasuredText(ctx, line, availableWidth))
+      // `wrapMeasuredText` deliberately emits one over-wide glyph to guarantee
+      // progress. A treemap label must instead omit a line that cannot fit
+      // completely inside the tile's content box.
+      .filter(line => ctx.measureText(line).width <= availableWidth + 1e-6);
+    const maxLines = Math.max(0, Math.floor(availableHeight / lineH));
     ctx.save();
     ctx.beginPath();
     ctx.rect(tile.x, tile.y, tile.w, tile.h);
@@ -7603,9 +7649,9 @@ function renderTreemapChart(
       ctx.textAlign = 'left';
       ctx.textBaseline = 'bottom';
       const visibleLines = lines.slice(Math.max(0, lines.length - maxLines));
-      const lastY = tile.y + tile.h - 4;
+      const lastY = tile.y + tile.h - inset;
       visibleLines.forEach((line, index) => {
-        if (line) ctx.fillText(line, tile.x + 4, lastY - (visibleLines.length - 1 - index) * lineH);
+        if (line) ctx.fillText(line, tile.x + inset, lastY - (visibleLines.length - 1 - index) * lineH);
       });
     } else {
       ctx.textAlign = 'center';


### PR DESCRIPTION
## Summary
- normalize finite positive hierarchy weights before treemap and sunburst aggregation
- keep source-order tie breaking and terminal-row identity deterministic
- resolve automatic separators from authored paint or the chart background
- constrain default leaf labels to their tile content box

## Verification
- focused renderer and signature tests: 304 passed
- TypeScript project build
- adversarial review: approved with no P1/P2 findings
- private self-VRT against full merge-base 0a47bd5666ce976b986310879e895061585d43a1: XLSX 19/19, DOCX 47/47, PPTX 15/15 documents passed exactly

Closes #1230