### PR TITLE
fix(chart): share ChartEx category gap policy

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -2813,17 +2813,17 @@ moveTo 49.16,357.8
 lineTo 639.2,357.8
 stroke ss=#aaa lw=1 dash=
 set fillStyle=#5B9BD5
-fillRect 93.413,123.7286,59.004,234.0714 fs=#5B9BD5
+fillRect 67.4601,123.7286,110.9098,234.0714 fs=#5B9BD5
 set strokeStyle=#5B9BD5
 setLineDash
-strokeRect 93.413,123.7286,59.004,234.0714 ss=#5B9BD5 lw=1
+strokeRect 67.4601,123.7286,110.9098,234.0714 ss=#5B9BD5 lw=1
 save
 set strokeStyle=#ccc
 setLineDash
 set lineWidth=0.8
 beginPath
-moveTo 152.417,123.7286
-lineTo 240.923,123.7286
+moveTo 178.3699,123.7286
+lineTo 214.9701,123.7286
 stroke ss=#ccc lw=0.8 dash=
 restore
 set fillStyle=#595959
@@ -2831,46 +2831,46 @@ set textAlign=center
 set textBaseline=bottom
 fillText "100" 122.915,120.7286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#5B9BD5
-fillRect 240.923,53.5071,59.004,70.2214 fs=#5B9BD5
+fillRect 214.9701,53.5071,110.9098,70.2214 fs=#5B9BD5
 set strokeStyle=#5B9BD5
 set lineWidth=1
 setLineDash
-strokeRect 240.923,53.5071,59.004,70.2214 ss=#5B9BD5 lw=1
+strokeRect 214.9701,53.5071,110.9098,70.2214 ss=#5B9BD5 lw=1
 save
 set strokeStyle=#ccc
 setLineDash
 set lineWidth=0.8
 beginPath
-moveTo 299.927,53.5071
-lineTo 388.433,53.5071
+moveTo 325.8799,53.5071
+lineTo 362.4801,53.5071
 stroke ss=#ccc lw=0.8 dash=
 restore
 set fillStyle=#595959
 fillText "30" 270.425,50.5071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#ED7D31
-fillRect 388.433,53.5071,59.004,46.8143 fs=#ED7D31
+fillRect 362.4801,53.5071,110.9098,46.8143 fs=#ED7D31
 set strokeStyle=#ED7D31
 set lineWidth=1
 setLineDash
-strokeRect 388.433,53.5071,59.004,46.8143 ss=#ED7D31 lw=1
+strokeRect 362.4801,53.5071,110.9098,46.8143 ss=#ED7D31 lw=1
 save
 set strokeStyle=#ccc
 setLineDash
 set lineWidth=0.8
 beginPath
-moveTo 447.437,100.3214
-lineTo 535.943,100.3214
+moveTo 473.3899,100.3214
+lineTo 509.9901,100.3214
 stroke ss=#ccc lw=0.8 dash=
 restore
 set fillStyle=#595959
 set textBaseline=top
 fillText "-20" 417.935,103.3214 fs=#595959 font=16.2px sans-serif al=center bl=top
 set fillStyle=#A5A5A5
-fillRect 535.943,100.3214,59.004,257.4786 fs=#A5A5A5
+fillRect 509.9901,100.3214,110.9098,257.4786 fs=#A5A5A5
 set strokeStyle=#A5A5A5
 set lineWidth=1
 setLineDash
-strokeRect 535.943,100.3214,59.004,257.4786 ss=#A5A5A5 lw=1
+strokeRect 509.9901,100.3214,110.9098,257.4786 ss=#A5A5A5 lw=1
 set fillStyle=#595959
 set textBaseline=bottom
 fillText "110" 565.445,97.3214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
@@ -2893,17 +2893,17 @@ moveTo 24.8,357.8
 lineTo 639.2,357.8
 stroke ss=#aaa lw=1 dash=
 set fillStyle=#5B9BD5
-fillRect 70.88,123.7286,61.44,234.0714 fs=#5B9BD5
+fillRect 43.8556,123.7286,115.4887,234.0714 fs=#5B9BD5
 set strokeStyle=#5B9BD5
 setLineDash
-strokeRect 70.88,123.7286,61.44,234.0714 ss=#5B9BD5 lw=1
+strokeRect 43.8556,123.7286,115.4887,234.0714 ss=#5B9BD5 lw=1
 save
 set strokeStyle=#ccc
 setLineDash
 set lineWidth=0.8
 beginPath
-moveTo 132.32,123.7286
-lineTo 224.48,123.7286
+moveTo 159.3444,123.7286
+lineTo 197.4556,123.7286
 stroke ss=#ccc lw=0.8 dash=
 restore
 set fillStyle=#595959
@@ -2911,46 +2911,46 @@ set textAlign=center
 set textBaseline=bottom
 fillText "100" 101.6,120.7286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#5B9BD5
-fillRect 224.48,53.5071,61.44,70.2214 fs=#5B9BD5
+fillRect 197.4556,53.5071,115.4887,70.2214 fs=#5B9BD5
 set strokeStyle=#5B9BD5
 set lineWidth=1
 setLineDash
-strokeRect 224.48,53.5071,61.44,70.2214 ss=#5B9BD5 lw=1
+strokeRect 197.4556,53.5071,115.4887,70.2214 ss=#5B9BD5 lw=1
 save
 set strokeStyle=#ccc
 setLineDash
 set lineWidth=0.8
 beginPath
-moveTo 285.92,53.5071
-lineTo 378.08,53.5071
+moveTo 312.9444,53.5071
+lineTo 351.0556,53.5071
 stroke ss=#ccc lw=0.8 dash=
 restore
 set fillStyle=#595959
 fillText "30" 255.2,50.5071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
 set fillStyle=#ED7D31
-fillRect 378.08,53.5071,61.44,46.8143 fs=#ED7D31
+fillRect 351.0556,53.5071,115.4887,46.8143 fs=#ED7D31
 set strokeStyle=#ED7D31
 set lineWidth=1
 setLineDash
-strokeRect 378.08,53.5071,61.44,46.8143 ss=#ED7D31 lw=1
+strokeRect 351.0556,53.5071,115.4887,46.8143 ss=#ED7D31 lw=1
 save
 set strokeStyle=#ccc
 setLineDash
 set lineWidth=0.8
 beginPath
-moveTo 439.52,100.3214
-lineTo 531.68,100.3214
+moveTo 466.5444,100.3214
+lineTo 504.6556,100.3214
 stroke ss=#ccc lw=0.8 dash=
 restore
 set fillStyle=#595959
 set textBaseline=top
 fillText "-20" 408.8,103.3214 fs=#595959 font=16.2px sans-serif al=center bl=top
 set fillStyle=#A5A5A5
-fillRect 531.68,100.3214,61.44,257.4786 fs=#A5A5A5
+fillRect 504.6556,100.3214,115.4887,257.4786 fs=#A5A5A5
 set strokeStyle=#A5A5A5
 set lineWidth=1
 setLineDash
-strokeRect 531.68,100.3214,61.44,257.4786 ss=#A5A5A5 lw=1
+strokeRect 504.6556,100.3214,115.4887,257.4786 ss=#A5A5A5 lw=1
 set fillStyle=#595959
 set textBaseline=bottom
 fillText "110" 562.4,97.3214 fs=#595959 font=16.2px sans-serif al=center bl=bottom

--- a/packages/core/src/chart/category-spacing.ts
+++ b/packages/core/src/chart/category-spacing.ts
@@ -1,0 +1,18 @@
+/** Which format owns the omitted category-axis gap policy. */
+export type CategoryGapPolicy = 'legacy' | 'chartex';
+
+/**
+ * Resolve the gap between category bodies as a percentage of one body.
+ *
+ * Classic `<c:barChart>` keeps the ECMA-376 default of 150%. ChartEx
+ * `<cx:catScaling gapWidth>` has no schema default, so the supported ordinal
+ * layouts share a small deterministic 33% fallback. An authored value has
+ * already been normalized by the parser and is always authoritative.
+ */
+export function resolveCategoryGapWidthPercent(
+  authoredPercent: number | null | undefined,
+  policy: CategoryGapPolicy,
+): number {
+  if (authoredPercent != null) return authoredPercent;
+  return policy === 'legacy' ? 150 : 33;
+}

--- a/packages/core/src/chart/histogram-binning.test.ts
+++ b/packages/core/src/chart/histogram-binning.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_HISTOGRAM_BINS,
+  MAX_HISTOGRAM_INPUT_POINTS,
+  planHistogramBins,
+} from './histogram-binning.js';
+
+describe('ChartEx histogram bin planning', () => {
+  it('honors authored bin count and the closed interval side', () => {
+    const values = [0, 1, 2, 3, 4];
+    expect(planHistogramBins(values, { binCount: 2, intervalClosed: 'l' })).toMatchObject({
+      kind: 'bins',
+      counts: [2, 3],
+    });
+    expect(planHistogramBins(values, { binCount: 2, intervalClosed: 'r' })).toMatchObject({
+      kind: 'bins',
+      counts: [3, 2],
+    });
+  });
+
+  it('assigns authored underflow and overflow boundaries consistently', () => {
+    const values = [-1, 0, 1, 2, 3, 4, 5];
+    expect(planHistogramBins(values, {
+      binCount: 2,
+      intervalClosed: 'l',
+      underflow: 0,
+      overflow: 4,
+    })).toMatchObject({ kind: 'bins', counts: [1, 2, 2, 2] });
+    expect(planHistogramBins(values, {
+      binCount: 2,
+      intervalClosed: 'r',
+      underflow: 0,
+      overflow: 4,
+    })).toMatchObject({ kind: 'bins', counts: [2, 2, 2, 1] });
+  });
+
+  it('caps the final authored-size label at an explicit overflow boundary', () => {
+    expect(planHistogramBins([0, 3, 4], {
+      binSize: 3,
+      intervalClosed: 'l',
+      overflow: 4,
+    })).toMatchObject({
+      kind: 'bins',
+      categories: ['≥ 0 – < 3', '≥ 3 – < 4', '≥ 4'],
+      counts: [1, 1, 1],
+    });
+  });
+
+  it('coarsens an extreme authored size into a bounded bin plan', () => {
+    const result = planHistogramBins([0, 1_000_000_000_000], { binSize: 0.000_000_000_001 });
+    expect(result.kind).toBe('bins');
+    if (result.kind !== 'bins') return;
+    expect(result.counts).toHaveLength(MAX_HISTOGRAM_BINS);
+    expect(result.counts.reduce((sum, count) => sum + count, 0)).toBe(2);
+  });
+
+  it('keeps finite observations when their derived range overflows binary64', () => {
+    expect(planHistogramBins([-1e308, 1e308], { binCount: 10 })).toMatchObject({
+      kind: 'bins',
+      counts: [2],
+    });
+  });
+
+  it('keeps every observation when a derived bin width would underflow', () => {
+    expect(planHistogramBins([0, Number.MIN_VALUE], { binCount: 2 })).toMatchObject({
+      kind: 'bins',
+      counts: [1, 1],
+    });
+  });
+
+  it('rejects input beyond the parser cache ceiling before scanning it', () => {
+    const oversized = new Array<number | null>(MAX_HISTOGRAM_INPUT_POINTS + 1);
+    expect(planHistogramBins(oversized, {})).toEqual({ kind: 'tooManyInputPoints' });
+  });
+});

--- a/packages/core/src/chart/histogram-binning.ts
+++ b/packages/core/src/chart/histogram-binning.ts
@@ -1,0 +1,147 @@
+import type { ChartexHistogramBinning } from '../types/chart';
+
+/** Matches the shared parser's maximum retained ChartEx cache width. */
+export const MAX_HISTOGRAM_INPUT_POINTS = 1_048_576;
+
+/**
+ * Histogram output is a Canvas primitive plan, not a lossless data cache.
+ * Keep it comfortably below the general 10,000-mark Canvas ceiling so an
+ * authored microscopic bin size cannot expand a compact source into a large
+ * synchronous paint.
+ */
+export const MAX_HISTOGRAM_BINS = 512;
+
+export type HistogramBinPlan =
+  | { kind: 'bins'; categories: string[]; counts: number[] }
+  | { kind: 'tooManyInputPoints' };
+
+function finiteOrNull(value: number | null | undefined): number | null {
+  return value != null && Number.isFinite(value) ? value : null;
+}
+
+function boundaryLabel(value: number): string {
+  if (Object.is(value, -0)) return '0';
+  if (Number.isInteger(value)) return String(value);
+  return String(Number(value.toPrecision(6)));
+}
+
+/**
+ * Aggregate raw ChartEx histogram observations into a bounded bar plan.
+ *
+ * MS-ODRAWXML defines authored bin size/count and interval boundaries but not
+ * automatic bin selection. Omission therefore uses a deterministic sqrt(n)
+ * rule. Authored plans beyond the Canvas bound are coarsened over the same
+ * domain instead of allocating an unbounded counts array.
+ */
+export function planHistogramBins(
+  source: readonly (number | null | undefined)[],
+  options: ChartexHistogramBinning,
+): HistogramBinPlan {
+  if (source.length > MAX_HISTOGRAM_INPUT_POINTS) {
+    return { kind: 'tooManyInputPoints' };
+  }
+
+  const intervalClosed = options.intervalClosed === 'r' ? 'r' : 'l';
+  let underflow = finiteOrNull(options.underflow);
+  let overflow = finiteOrNull(options.overflow);
+  if (underflow != null && overflow != null && underflow >= overflow) {
+    underflow = null;
+    overflow = null;
+  }
+
+  const isUnderflow = (value: number): boolean => underflow != null
+    && (intervalClosed === 'r' ? value <= underflow : value < underflow);
+  const isOverflow = (value: number): boolean => overflow != null
+    && (intervalClosed === 'r' ? value > overflow : value >= overflow);
+
+  let regularMin = Number.POSITIVE_INFINITY;
+  let regularMax = Number.NEGATIVE_INFINITY;
+  let regularCount = 0;
+  let underflowCount = 0;
+  let overflowCount = 0;
+  for (const sourceValue of source) {
+    const value = finiteOrNull(sourceValue);
+    if (value == null) continue;
+    if (isUnderflow(value)) {
+      underflowCount++;
+    } else if (isOverflow(value)) {
+      overflowCount++;
+    } else {
+      regularCount++;
+      regularMin = Math.min(regularMin, value);
+      regularMax = Math.max(regularMax, value);
+    }
+  }
+  if (regularCount + underflowCount + overflowCount === 0) {
+    return { kind: 'bins', categories: [], counts: [] };
+  }
+
+  const categories: string[] = [];
+  const counts: number[] = [];
+  if (underflow != null) {
+    categories.push(`${intervalClosed === 'r' ? '≤' : '<'} ${boundaryLabel(underflow)}`);
+    counts.push(underflowCount);
+  }
+
+  if (regularCount > 0) {
+    const lower = underflow ?? regularMin;
+    const upper = overflow ?? regularMax;
+    const range = upper - lower;
+    if (!Number.isFinite(range)) {
+      categories.push(`${boundaryLabel(lower)} – ${boundaryLabel(upper)}`);
+      counts.push(regularCount);
+    } else {
+      const authoredSize = finiteOrNull(options.binSize);
+      let requestedCount: number;
+      if (authoredSize != null && authoredSize > 0 && range > 0) {
+        requestedCount = Math.max(1, Math.ceil(range / authoredSize));
+      } else if (options.binCount != null && Number.isFinite(options.binCount) && options.binCount > 0) {
+        requestedCount = Math.max(1, Math.floor(options.binCount));
+      } else {
+        requestedCount = Math.max(1, Math.ceil(Math.sqrt(regularCount)));
+      }
+      const binCount = range <= 0 ? 1 : Math.min(MAX_HISTOGRAM_BINS, requestedCount);
+      const usesAuthoredSize = range > 0
+        && authoredSize != null
+        && authoredSize > 0
+        && requestedCount <= MAX_HISTOGRAM_BINS;
+      const width = range === 0 ? 1 : usesAuthoredSize ? authoredSize : range / binCount;
+      const regularCounts = new Array<number>(binCount).fill(0);
+      for (const sourceValue of source) {
+        const value = finiteOrNull(sourceValue);
+        if (value == null) continue;
+        if (isUnderflow(value) || isOverflow(value)) continue;
+        // Normalize by the whole range for automatic/coarsened bins. Dividing
+        // a subnormal range by binCount can underflow `width` to zero even
+        // though both observations are finite (e.g. 0..Number.MIN_VALUE).
+        const position = usesAuthoredSize
+          ? (value - lower) / width
+          : range === 0
+            ? 0
+            : ((value - lower) / range) * binCount;
+        const rawIndex = intervalClosed === 'r' ? Math.ceil(position) - 1 : Math.floor(position);
+        const index = Math.max(0, Math.min(binCount - 1, rawIndex));
+        regularCounts[index]++;
+      }
+      for (let index = 0; index < binCount; index++) {
+        const start = usesAuthoredSize
+          ? lower + width * index
+          : lower + range * (index / binCount);
+        const end = usesAuthoredSize
+          ? start + width
+          : lower + range * ((index + 1) / binCount);
+        const displayEnd = overflow == null ? end : Math.min(end, overflow);
+        const leftRelation = intervalClosed === 'r' && (underflow != null || index > 0) ? '>' : '≥';
+        const rightRelation = intervalClosed === 'l' && (overflow != null || index < binCount - 1) ? '<' : '≤';
+        categories.push(`${leftRelation} ${boundaryLabel(start)} – ${rightRelation} ${boundaryLabel(displayEnd)}`);
+        counts.push(regularCounts[index]);
+      }
+    }
+  }
+
+  if (overflow != null) {
+    categories.push(`${intervalClosed === 'r' ? '>' : '≥'} ${boundaryLabel(overflow)}`);
+    counts.push(overflowCount);
+  }
+  return { kind: 'bins', categories, counts };
+}

--- a/packages/core/src/chart/renderer-chartex-gap.test.ts
+++ b/packages/core/src/chart/renderer-chartex-gap.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import type { ChartModel, ChartRect, ChartSeries } from '../types/chart';
+import { renderChart } from './renderer.js';
+
+interface RectCall {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+function recordingContext(): { ctx: CanvasRenderingContext2D; rects: RectCall[] } {
+  const rects: RectCall[] = [];
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif',
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    globalAlpha: 1,
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop: string) {
+      if (prop in state) return state[prop];
+      switch (prop) {
+        case 'measureText':
+          return (text: string) => ({ width: String(text).length * 6 });
+        case 'fillRect':
+          return (x: number, y: number, w: number, h: number) => {
+            rects.push({ x, y, w, h });
+          };
+        case 'createLinearGradient':
+        case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        case 'save':
+        case 'restore':
+        case 'beginPath':
+        case 'closePath':
+        case 'fill':
+        case 'stroke':
+        case 'strokeRect':
+        case 'fillText':
+        case 'moveTo':
+        case 'lineTo':
+        case 'arc':
+        case 'bezierCurveTo':
+        case 'quadraticCurveTo':
+        case 'rect':
+        case 'clip':
+        case 'clearRect':
+        case 'strokeText':
+        case 'setLineDash':
+        case 'translate':
+        case 'rotate':
+        case 'scale':
+        case 'setTransform':
+        case 'resetTransform':
+          return () => undefined;
+        default:
+          return undefined;
+      }
+    },
+    set(_target, prop: string, value) {
+      state[prop] = value;
+      return true;
+    },
+  };
+  return {
+    ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D,
+    rects,
+  };
+}
+
+function series(overrides: Partial<ChartSeries> = {}): ChartSeries {
+  return { name: 'Series 1', color: '4472C4', values: [10, 20, 15], ...overrides };
+}
+
+function model(overrides: Partial<ChartModel>): ChartModel {
+  return {
+    chartType: 'waterfall',
+    title: null,
+    categories: ['A', 'B', 'C'],
+    series: [series()],
+    showDataLabels: false,
+    valMin: null,
+    valMax: null,
+    catAxisTitle: null,
+    valAxisTitle: null,
+    catAxisHidden: true,
+    valAxisHidden: true,
+    catAxisLineHidden: true,
+    valAxisLineHidden: true,
+    plotAreaBg: null,
+    chartBg: null,
+    showLegend: false,
+    legendPos: null,
+    catAxisCrossBetween: 'between',
+    valAxisMajorTickMark: 'out',
+    catAxisMajorTickMark: 'out',
+    titleFontSizeHpt: null,
+    titleFontColor: null,
+    titleFontFace: null,
+    catAxisFontSizeHpt: null,
+    valAxisFontSizeHpt: null,
+    dataLabelFontSizeHpt: null,
+    subtotalIndices: [],
+    ...overrides,
+  };
+}
+
+type ChartExGapFamily =
+  | 'waterfall'
+  | 'clusteredColumn'
+  | 'histogram'
+  | 'funnel'
+  | 'boxWhisker';
+
+function familyModel(family: ChartExGapFamily, barGapWidth?: number): ChartModel {
+  const common = { barGapWidth };
+  switch (family) {
+    case 'waterfall':
+      return model({ chartType: family, ...common });
+    case 'clusteredColumn':
+      return model({ chartType: family, ...common });
+    case 'histogram':
+      return model({
+        chartType: family,
+        ...common,
+        categories: [],
+        series: [series({ values: [1, 2, 3, 4, 5, 6] })],
+        chartexHistogramBinning: { binCount: 3, intervalClosed: 'l' },
+      });
+    case 'funnel':
+      return model({ chartType: family, ...common });
+    case 'boxWhisker':
+      return model({
+        chartType: family,
+        ...common,
+        categories: ['A'],
+        series: [series({ values: [] })],
+        chartexBox: {
+          categories: ['A'],
+          series: [{
+            name: 'Series 1',
+            color: '4472C4',
+            valuesByCategory: [[1, 2, 3, 4, 5]],
+            meanMarker: false,
+            meanLine: false,
+            showOutliers: false,
+            showNonoutliers: false,
+            quartileMethod: 'inclusive',
+          }],
+        },
+      });
+  }
+}
+
+function renderRects(chart: ChartModel, bounds: ChartRect): RectCall[] {
+  const recording = recordingContext();
+  renderChart(recording.ctx, chart, bounds, 1);
+  return recording.rects;
+}
+
+const BOUNDS: ChartRect[] = [
+  { x: 0, y: 0, w: 360, h: 360 },
+  { x: 0, y: 0, w: 480, h: 240 },
+  { x: 0, y: 0, w: 240, h: 480 },
+];
+
+describe('ChartEx omitted category gap policy (#1227)', () => {
+  for (const family of [
+    'waterfall',
+    'clusteredColumn',
+    'histogram',
+    'funnel',
+    'boxWhisker',
+  ] as const) {
+    it(`${family}: omitted gap has the same geometry as authored 33% for square, wide, and tall bounds`, () => {
+      for (const bounds of BOUNDS) {
+        expect(renderRects(familyModel(family), bounds)).toEqual(
+          renderRects(familyModel(family, 33), bounds),
+        );
+      }
+    });
+
+    it(`${family}: an authored 80% gap remains authoritative`, () => {
+      const bounds = BOUNDS[0];
+      expect(renderRects(familyModel(family, 80), bounds)).not.toEqual(
+        renderRects(familyModel(family), bounds),
+      );
+    });
+  }
+
+  it('legacy bar/column omission retains the 150% geometry', () => {
+    const bounds = BOUNDS[0];
+    const legacy = (barGapWidth?: number): ChartModel => model({
+      chartType: 'clusteredBar',
+      barGapWidth,
+    });
+    expect(renderRects(legacy(), bounds)).toEqual(renderRects(legacy(150), bounds));
+    expect(renderRects(legacy(), bounds)).not.toEqual(renderRects(legacy(33), bounds));
+  });
+});

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1690,6 +1690,32 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
     },
   );
 
+  it('bins raw histogram observations before routing them to bar geometry', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'histogram',
+      categories: [],
+      catAxisHidden: true,
+      valAxisHidden: true,
+      series: [series({ values: [0, 1, 2, 3, 4] })],
+      chartexHistogramBinning: { binCount: 2, intervalClosed: 'l' },
+    }), RECT, 1);
+
+    expect(rec.rects).toHaveLength(2);
+  });
+
+  it('rejects histogram input beyond the ChartEx cache ceiling', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'histogram',
+      categories: [],
+      series: [series({ values: new Array<number | null>(1_048_577) })],
+    }), RECT, 1);
+
+    expect(rec.rects).toHaveLength(0);
+    expect(rec.texts.map(text => text.text)).toContain('(too many data points)');
+  });
+
   it.each(['waterfall', 'funnel'])(
     '%s renders every numeric data point when the optional category dimension is unavailable',
     chartType => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -24,6 +24,11 @@ import { niceStep, valueAxisScale, axisFraction, logAxisScale, fitTrendline } fr
 import { axisLineWidthPx, resolveAxisLine, resolveGridline, isCrossBetween } from './axis-style.js';
 import { formatChartVal, formatChartValWithCode, formatCategoryLabel } from './chart-number-format.js';
 import { elideToWidth } from './text-elide.js';
+import {
+  resolveCategoryGapWidthPercent,
+  type CategoryGapPolicy,
+} from './category-spacing.js';
+import { planHistogramBins } from './histogram-binning.js';
 import { hexToRgba, resolveFill } from '../shape/paint.js';
 import {
   DEFAULT_TEXT_INSET_LR_EMU,
@@ -1388,7 +1393,13 @@ function drawBarDataLabel(
 // percentStacked. Also handles mixed bar+line series (seriesType per series).
 // ═══════════════════════════════════════════════════════════════════════════
 
-function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: ChartRect, ptToPx: number): void {
+function renderBarChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+  gapPolicy: CategoryGapPolicy = 'legacy',
+): void {
   const { x, y, w, h } = r;
   const isH = chart.chartType === 'clusteredBarH' || chart.chartType === 'stackedBarH' || chart.chartType === 'stackedBarHPct';
   const stacked = chart.chartType.startsWith('stacked');
@@ -1949,7 +1960,7 @@ function renderBarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
     : (catRev ? n - 1 - ci : ci);
   const nSeriesEffective = stacked ? 1 : Math.max(1, barSeries.length);
   const overlapPct  = stacked ? 0 : (chart.barOverlap ?? 0);
-  const gapWidthPct = chart.barGapWidth ?? 150;
+  const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, gapPolicy);
   const denom = 1 + (nSeriesEffective - 1) * (1 - overlapPct / 100) + gapWidthPct / 100;
   const barW  = catGap / denom;
   // Pitch between bars within a cluster (not the gap — the left-edge to
@@ -5995,6 +6006,27 @@ function rejectOversizedCanvasChart(
   return true;
 }
 
+function renderHistogramChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  rect: ChartRect,
+  ptToPx: number,
+): void {
+  const source = chart.series[0];
+  if (!source) return;
+  const plan = planHistogramBins(source.values, chart.chartexHistogramBinning ?? {});
+  if (plan.kind === 'tooManyInputPoints') {
+    rejectOversizedCanvasChart(ctx, rect, MAX_CANVAS_CHART_POINTS + 1);
+    return;
+  }
+  renderBarChart(ctx, {
+    ...chart,
+    chartType: 'clusteredBar',
+    categories: plan.categories,
+    series: [{ ...source, categories: undefined, values: plan.counts }],
+  }, rect, ptToPx, 'chartex');
+}
+
 function renderWaterfallChart(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
@@ -6195,12 +6227,11 @@ function renderWaterfallChart(
   // adjacent categories expressed as a percentage of the bar width
   // (legacy `<c:gapWidth val>`) or as a fraction (chartEx
   // `<cx:catScaling gapWidth>`, normalised to the same percent form by the
-  // parser). The bar then occupies `catGap / (1 + gapWidth/100)`. The existing
-  // 150% fallback is retained for byte compatibility when ChartEx requests
-  // automatic spacing; reproducing Office's automatic choice is tracked
-  // separately and is not tuned in this change.
+  // parser). The bar then occupies `catGap / (1 + gapWidth/100)`. Omitted
+  // ChartEx spacing uses the shared ordinal-layout policy; an authored
+  // value remains authoritative after parser normalization.
   const gapW = pw / n;
-  const gapWidthPct = chart.barGapWidth ?? 150;
+  const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, 'chartex');
   const barW = gapW / (1 + gapWidthPct / 100);
 
   bars.forEach((bar, i) => {
@@ -6376,11 +6407,8 @@ function renderFunnelChart(
   drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
   const { px0, py0, pw, ph } = frame.plotRect;
   const rowH = ph / n;
-  // Apply only an authored ChartEx gap. CT_CategoryAxisScaling does not define
-  // an omitted-value default; matching application auto-spacing is #1227.
-  const barH = chart.barGapWidth == null
-    ? rowH
-    : rowH / (1 + chart.barGapWidth / 100);
+  const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, 'chartex');
+  const barH = rowH / (1 + gapWidthPct / 100);
   const series = chart.series[0];
   const color = `#${series?.color ?? chartExDataPointFill(chart, 0, 1, series?.chartexStyle)}`;
   const paint = chartExDataPointPaint(chart, 0, 1, series?.chartexStyle, series?.color);
@@ -6689,7 +6717,7 @@ function renderBoxWhiskerChart(
   // their boxes remain individually visible. `gapWidth` controls the
   // group-vs-gap width inside that interval.
   const slotW = pw / (nCat + 1);
-  const gapWidthPct = chart.barGapWidth ?? 150;
+  const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, 'chartex');
   const groupW = slotW / (1 + gapWidthPct / 100);
   const paletteOf = (si: number): string => {
     const fill = box.series[si].color
@@ -7947,7 +7975,15 @@ export function renderChart(
       case 'waterfall':
         renderWaterfallChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
       case 'clusteredColumn':
-        renderBarChart(ctx, { ...chart, chartType: 'clusteredBar' }, rect, ptToPx); break;
+        renderBarChart(
+          ctx,
+          { ...chart, chartType: 'clusteredBar' },
+          rect,
+          ptToPx,
+          'chartex',
+        ); break;
+      case 'histogram':
+        renderHistogramChart(ctx, chart, rect, ptToPx); break;
       case 'funnel':
         renderFunnelChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
       case 'paretoLine':

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -821,6 +821,8 @@ export interface ChartModel {
    * for treemap charts; null/absent otherwise.
    */
   chartexTreemap?: ChartexTreemap | null;
+  /** ChartEx histogram controls; raw observations remain in `series[0]`. */
+  chartexHistogramBinning?: ChartexHistogramBinning | null;
   /**
    * Theme accent palette (`accent1..6`, hex without '#') for chartEx charts
    * that color by branch/series index (boxWhisker series and
@@ -946,6 +948,15 @@ export interface ChartexTreemap {
   rows: ChartexSunburstRow[];
   /** `<cx:parentLabelLayout val>`: `banner`, `overlapping`, or `none`. */
   parentLabelLayout?: string | null;
+}
+
+/** ChartEx `CT_Binning` controls retained for histogram aggregation. */
+export interface ChartexHistogramBinning {
+  binSize?: number | null;
+  binCount?: number | null;
+  intervalClosed?: 'l' | 'r' | null;
+  underflow?: number | null;
+  overflow?: number | null;
 }
 
 /**

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -139,6 +139,13 @@ export interface ChartexTreemap {
     rows: ChartexSunburstRow[];
     parentLabelLayout?: string | null;
 }
+export interface ChartexHistogramBinning {
+    binSize?: number | null;
+    binCount?: number | null;
+    intervalClosed?: 'l' | 'r' | null;
+    underflow?: number | null;
+    overflow?: number | null;
+}
 export interface ChartLabelBox {
     fill?: string;
     borderColor?: string;
@@ -278,6 +285,7 @@ export interface ChartModel {
     chartexBox?: ChartexBoxWhisker | null;
     chartexSunburst?: ChartexSunburst | null;
     chartexTreemap?: ChartexTreemap | null;
+    chartexHistogramBinning?: ChartexHistogramBinning | null;
     chartexAccents?: string[] | null;
     chartexColorPalette?: Array<string | null> | null;
     chartexColorStyleMethod?: string | null;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -481,6 +481,10 @@ pub struct ChartModel {
     /// parent-label layout. `None` otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chartex_treemap: Option<ChartexTreemap>,
+    /// ChartEx histogram `CT_Binning` controls. Raw observations remain in
+    /// `series[0].values` so the renderer can derive a bounded frequency plan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chartex_histogram_binning: Option<ChartexHistogramBinning>,
     /// Theme accent palette (`accent1..6` resolved to hex, no `#`) for chartEx
     /// charts that color by branch/series index (boxWhisker series and
     /// sunburst/treemap branches). `None` when the resolver supplies no default palette (pptx);
@@ -1008,6 +1012,24 @@ pub struct ChartexTreemap {
     /// `none`). Absent stays `None`; the renderer uses its neutral default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_label_layout: Option<String>,
+}
+
+/// ChartEx `CT_Binning` controls ([MS-ODRAWXML] 2.24.3.7). Numeric
+/// underflow/overflow bounds are retained; the schema's `auto` token remains
+/// `None`, as does omission.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChartexHistogramBinning {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bin_size: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bin_count: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interval_closed: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub underflow: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overflow: Option<f64>,
 }
 
 /// Mirror of TS `ChartManualLayout`.
@@ -3104,10 +3126,12 @@ fn chartex_text(container: Node) -> Option<String> {
 /// Colour and theme-font resolution route through the shared [`ColorResolver`]
 /// so XLSX, PPTX, and DOCX retain the same chart model contract.
 ///
-/// The chart type is the series `layoutId` string as-is (`"waterfall"`,
-/// `"treemap"`, `"sunburst"`, `"boxWhisker"`, `"funnel"`, `"histogram"`, …);
-/// this function does not gate on which layouts the renderer supports, so
-/// adding a new chartEx layout is a renderer concern, not a parse concern.
+/// The chart type normally preserves the series `layoutId` (`"waterfall"`,
+/// `"treemap"`, `"sunburst"`, `"boxWhisker"`, `"funnel"`, …). The one
+/// semantic normalization is [MS-ODRAWXML] histogram: `clusteredColumn` with
+/// CT_Binning becomes `"histogram"` so raw observations cannot be mistaken for
+/// already aggregated column heights. Other unsupported layouts pass through
+/// for renderer dispatch.
 ///
 /// Returns `None` when the part has no `<cx:series>` (not a chartEx chart).
 pub fn parse_chartex_part(
@@ -3231,6 +3255,32 @@ fn parse_chartex_data_point_overrides(
             })
         })
         .collect()
+}
+
+fn parse_chartex_histogram_binning(series: Node) -> Option<ChartexHistogramBinning> {
+    let binning = child(child(series, "layoutPr")?, "binning")?;
+    let finite_text = |name: &str| {
+        child(binning, name)
+            .and_then(|node| node.text())
+            .and_then(|text| text.trim().parse::<f64>().ok())
+            .filter(|value| value.is_finite())
+    };
+    let finite_attr = |name: &str| {
+        attr(&binning, name)
+            .and_then(|text| text.parse::<f64>().ok())
+            .filter(|value| value.is_finite())
+    };
+    Some(ChartexHistogramBinning {
+        bin_size: finite_text("binSize").filter(|value| *value > 0.0),
+        bin_count: child(binning, "binCount")
+            .and_then(|node| node.text())
+            .and_then(|text| text.trim().parse::<u32>().ok())
+            .filter(|value| *value > 0),
+        interval_closed: attr(&binning, "intervalClosed")
+            .filter(|value| value == "l" || value == "r"),
+        underflow: finite_attr("underflow"),
+        overflow: finite_attr("overflow"),
+    })
 }
 
 type DataPointShape = (
@@ -3436,7 +3486,18 @@ pub fn parse_chartex_part_with_references_and_style_parts(
     };
     let series_node = *series_nodes.first()?;
     let layout_id = attr(&series_node, "layoutId").unwrap_or_default();
-    let chart_type = layout_id; // "waterfall", "treemap", etc.
+    // [MS-ODRAWXML] represents a histogram as a clusteredColumn series with a
+    // CT_Binning child; `histogram` is not an ST_SeriesLayout enumeration.
+    // Normalize the semantic family here so raw observations cannot reach the
+    // ordinary clustered-column renderer.
+    let chartex_histogram_binning = (layout_id == "clusteredColumn")
+        .then(|| parse_chartex_histogram_binning(series_node))
+        .flatten();
+    let chart_type = if chartex_histogram_binning.is_some() {
+        "histogram".to_string()
+    } else {
+        layout_id
+    };
     let data_by_id: std::collections::HashMap<String, Node> = root
         .descendants()
         .filter(|node| node.is_element() && node.tag_name().name() == "data")
@@ -3987,8 +4048,8 @@ pub fn parse_chartex_part_with_references_and_style_parts(
     // `<c:gapWidth>` but stored as a *fraction* (e.g. 0.8 ≡ 80%) instead of
     // an integer percentage. Convert to the legacy percentage form so the
     // shared renderer's `barW = catGap / (1 + gapWidth/100)` formula works
-    // uniformly across chart types. Default 1.5 (= legacy 150%) per PowerPoint
-    // when the attribute is omitted.
+    // uniformly across chart types. Omission stays `None`: ChartEx has no
+    // schema default, so the renderer owns the shared ordinal-layout policy.
     let bar_gap_width = root
         .descendants()
         .find(|n| n.is_element() && n.tag_name().name() == "catScaling")
@@ -4146,6 +4207,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         chartex_box,
         chartex_sunburst,
         chartex_treemap,
+        chartex_histogram_binning,
         chartex_accents,
         chartex_color_palette,
         chartex_color_style_method,
@@ -6813,6 +6875,7 @@ pub fn parse_chart_part_with_references(
         chartex_box: None,
         chartex_sunburst: None,
         chartex_treemap: None,
+        chartex_histogram_binning: None,
         chartex_accents: None,
         chartex_color_palette: None,
         chartex_color_style_method: None,
@@ -7050,6 +7113,7 @@ mod tests {
             chartex_box: None,
             chartex_sunburst: None,
             chartex_treemap: None,
+            chartex_histogram_binning: None,
             chartex_accents: None,
             chartex_color_palette: None,
             chartex_color_style_method: None,
@@ -10422,6 +10486,66 @@ mod tests {
         assert_eq!(hidden_point.idx, 1);
         assert_eq!(hidden_point.fill_hidden, Some(true));
         assert_eq!(hidden_point.line_hidden, Some(true));
+    }
+
+    #[test]
+    fn parse_chartex_histogram_retains_binning_contract() {
+        let xml = format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}">
+              <cx:chartData><cx:data id="0"><cx:numDim type="val"><cx:lvl ptCount="5">
+                <cx:pt idx="0">0</cx:pt><cx:pt idx="1">1</cx:pt><cx:pt idx="2">2</cx:pt>
+                <cx:pt idx="3">3</cx:pt><cx:pt idx="4">4</cx:pt>
+              </cx:lvl></cx:numDim></cx:data></cx:chartData>
+              <cx:chart><cx:plotArea><cx:plotAreaRegion>
+                <cx:series layoutId="clusteredColumn"><cx:dataId val="0"/><cx:layoutPr>
+                  <cx:binning intervalClosed="r" underflow="0" overflow="4"><cx:binCount>2</cx:binCount></cx:binning>
+                </cx:layoutPr></cx:series>
+              </cx:plotAreaRegion></cx:plotArea></cx:chart>
+            </cx:chartSpace>"#
+        );
+        let document = chart_space_of(&xml);
+        let model = parse_chartex_part(document.root_element(), &FixtureResolver, None)
+            .expect("histogram parses");
+        let binning = model
+            .chartex_histogram_binning
+            .expect("histogram binning contract");
+        assert_eq!(model.chart_type, "histogram");
+        assert_eq!(binning.bin_count, Some(2));
+        assert_eq!(binning.bin_size, None);
+        assert_eq!(binning.interval_closed.as_deref(), Some("r"));
+        assert_eq!(binning.underflow, Some(0.0));
+        assert_eq!(binning.overflow, Some(4.0));
+        assert_eq!(
+            model.series[0].values,
+            vec![Some(0.0), Some(1.0), Some(2.0), Some(3.0), Some(4.0)]
+        );
+    }
+
+    #[test]
+    fn parse_chartex_histogram_binning_accepts_size_and_keeps_auto_unset() {
+        let size_xml = r#"<cx:series xmlns:cx="urn:cx"><cx:layoutPr><cx:binning intervalClosed="l" underflow="auto"><cx:binSize>0.5</cx:binSize></cx:binning></cx:layoutPr></cx:series>"#;
+        let size_document = root_of(size_xml);
+        let size =
+            parse_chartex_histogram_binning(size_document.root_element()).expect("bin size parses");
+        assert_eq!(size.bin_size, Some(0.5));
+        assert_eq!(size.bin_count, None);
+        assert_eq!(size.interval_closed.as_deref(), Some("l"));
+        assert_eq!(size.underflow, None);
+
+        let invalid_xml = r#"<cx:series xmlns:cx="urn:cx"><cx:layoutPr><cx:binning intervalClosed="x" overflow="NaN"><cx:binSize>-1</cx:binSize></cx:binning></cx:layoutPr></cx:series>"#;
+        let invalid_document = root_of(invalid_xml);
+        let invalid = parse_chartex_histogram_binning(invalid_document.root_element())
+            .expect("empty automatic contract remains present");
+        assert_eq!(
+            invalid,
+            ChartexHistogramBinning {
+                bin_size: None,
+                bin_count: None,
+                interval_closed: None,
+                underflow: None,
+                overflow: None,
+            }
+        );
     }
 
     /// (c) A `<cx:chartSpace>` with no `<cx:series>` is not a chartEx chart —

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -148,6 +148,13 @@ export interface ChartexTreemap {
     rows: ChartexSunburstRow[];
     parentLabelLayout?: string | null;
 }
+export interface ChartexHistogramBinning {
+    binSize?: number | null;
+    binCount?: number | null;
+    intervalClosed?: 'l' | 'r' | null;
+    underflow?: number | null;
+    overflow?: number | null;
+}
 export interface ChartLabelBox {
     fill?: string;
     borderColor?: string;
@@ -287,6 +294,7 @@ export interface ChartModel {
     chartexBox?: ChartexBoxWhisker | null;
     chartexSunburst?: ChartexSunburst | null;
     chartexTreemap?: ChartexTreemap | null;
+    chartexHistogramBinning?: ChartexHistogramBinning | null;
     chartexAccents?: string[] | null;
     chartexColorPalette?: Array<string | null> | null;
     chartexColorStyleMethod?: string | null;

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -248,6 +248,13 @@ export interface ChartexTreemap {
     rows: ChartexSunburstRow[];
     parentLabelLayout?: string | null;
 }
+export interface ChartexHistogramBinning {
+    binSize?: number | null;
+    binCount?: number | null;
+    intervalClosed?: 'l' | 'r' | null;
+    underflow?: number | null;
+    overflow?: number | null;
+}
 export interface ChartLabelBox {
     fill?: string;
     borderColor?: string;
@@ -387,6 +394,7 @@ export interface ChartModel {
     chartexBox?: ChartexBoxWhisker | null;
     chartexSunburst?: ChartexSunburst | null;
     chartexTreemap?: ChartexTreemap | null;
+    chartexHistogramBinning?: ChartexHistogramBinning | null;
     chartexAccents?: string[] | null;
     chartexColorPalette?: Array<string | null> | null;
     chartexColorStyleMethod?: string | null;


### PR DESCRIPTION
## Summary
- use one authored-first category gap resolver for supported ChartEx ordinal layouts
- retain the legacy 150% default while using a 33% ChartEx omission fallback
- parse valid clustered-column CT_Binning and normalize it to semantic histogram rendering
- aggregate raw histogram observations into a bounded 512-bin Canvas plan

## Verification
- focused chart tests after rebase: 324 passed
- focused ooxml-common histogram parser tests
- TypeScript core project build
- repeated adversarial review: approved with no remaining findings

Closes #1227