### PR TITLE
fix(chart): stabilize box and whisker layout

### DIFF
--- a/packages/core/src/chart/box-whisker.test.ts
+++ b/packages/core/src/chart/box-whisker.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BOX_WHISKER_SLOT_GUTTER_FRACTION,
+  boxWhiskerGeometry,
+  boxWhiskerPointCount,
+  computeBoxWhiskerStats,
+} from './box-whisker.js';
+
+describe('computeBoxWhiskerStats', () => {
+  it('uses exclusive and inclusive median-of-halves quartiles for odd samples', () => {
+    expect(computeBoxWhiskerStats([1, 2, 3, 4, 5], 'exclusive')).toMatchObject({
+      q1: 1.5, median: 3, q3: 4.5,
+    });
+    expect(computeBoxWhiskerStats([1, 2, 3, 4, 5], 'inclusive')).toMatchObject({
+      q1: 2, median: 3, q3: 4,
+    });
+  });
+
+  it('uses the same halves for even samples', () => {
+    const expected = { q1: 2, median: 3.5, q3: 5 };
+    expect(computeBoxWhiskerStats([1, 2, 3, 4, 5, 6], 'exclusive')).toMatchObject(expected);
+    expect(computeBoxWhiskerStats([1, 2, 3, 4, 5, 6], 'inclusive')).toMatchObject(expected);
+  });
+
+  it('drops missing/non-finite observations and preserves finite repeats', () => {
+    const stats = computeBoxWhiskerStats(
+      [null, 5, Number.NaN, 5, Infinity, 5, -Infinity, undefined, 5],
+      'exclusive',
+    );
+    expect(stats).toMatchObject({
+      q1: 5, median: 5, q3: 5,
+      lowerFence: 5, upperFence: 5,
+      whiskerLo: 5, whiskerHi: 5, mean: 5,
+      outliers: [], inner: [5, 5, 5, 5],
+    });
+  });
+
+  it('keeps equality inside strict fences and rejects a value just above', () => {
+    const atFence = computeBoxWhiskerStats([0, 1, 2, 3, 4, 5, 6, 7, 12], 'inclusive');
+    const aboveFence = computeBoxWhiskerStats([0, 1, 2, 3, 4, 5, 6, 7, 12.0001], 'inclusive');
+    expect(atFence).toMatchObject({ upperFence: 12, whiskerHi: 12, outliers: [] });
+    expect(aboveFence).toMatchObject({ upperFence: 12, whiskerHi: 7, outliers: [12.0001] });
+  });
+
+  it('returns no statistics for an empty retained sample', () => {
+    expect(computeBoxWhiskerStats([null, NaN, Infinity], 'inclusive')).toBeNull();
+  });
+
+  it('keeps derived statistics finite for extreme finite observations', () => {
+    const stats = computeBoxWhiskerStats(
+      [-Number.MAX_VALUE, -Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE],
+      'exclusive',
+    );
+    expect(stats).not.toBeNull();
+    expect(Object.values(stats as object).flat().filter(value => typeof value === 'number')
+      .every(Number.isFinite)).toBe(true);
+  });
+});
+
+describe('boxWhiskerGeometry', () => {
+  it('uses stable equal series slots and a fixed 6% local gutter', () => {
+    const first = boxWhiskerGeometry(20, 400, 1, 2, 0, 0, 33);
+    const second = boxWhiskerGeometry(20, 400, 1, 2, 0, 1, 33);
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(first?.boxWidth).toBeCloseTo(second?.boxWidth ?? 0, 10);
+    const seriesSlotWidth = (400 / 2 / 1.33) / 2;
+    expect(first?.boxWidth).toBeCloseTo(seriesSlotWidth * (1 - BOX_WHISKER_SLOT_GUTTER_FRACTION), 10);
+    expect((second?.centerX ?? 0) - (first?.centerX ?? 0)).toBeCloseTo(seriesSlotWidth, 10);
+    expect((second?.boxX ?? 0) - ((first?.boxX ?? 0) + (first?.boxWidth ?? 0)))
+      .toBeCloseTo(seriesSlotWidth * BOX_WHISKER_SLOT_GUTTER_FRACTION, 10);
+  });
+
+  it('keeps a series position independent of whether peer series are populated', () => {
+    const firstCategory = boxWhiskerGeometry(0, 600, 2, 3, 0, 2, 33);
+    const secondCategory = boxWhiskerGeometry(0, 600, 2, 3, 1, 2, 33);
+    expect((secondCategory?.centerX ?? 0) - (firstCategory?.centerX ?? 0)).toBeCloseTo(200, 10);
+  });
+
+  it('rejects invalid geometry inputs and bounds aggregate point counting', () => {
+    expect(boxWhiskerGeometry(0, 100, 0, 1, 0, 0, 33)).toBeNull();
+    expect(boxWhiskerPointCount([[[1, 2]], [[3]]], 10)).toBe(3);
+    expect(boxWhiskerPointCount([[[...new Array(6)]], [[...new Array(5)]]], 10)).toBe(11);
+  });
+});

--- a/packages/core/src/chart/box-whisker.ts
+++ b/packages/core/src/chart/box-whisker.ts
@@ -1,0 +1,150 @@
+/** Fixed empty space inside each equal per-series slot. */
+export const BOX_WHISKER_SLOT_GUTTER_FRACTION = 0.06;
+
+export interface BoxWhiskerStats {
+  q1: number;
+  median: number;
+  q3: number;
+  lowerFence: number;
+  upperFence: number;
+  whiskerLo: number;
+  whiskerHi: number;
+  mean: number;
+  outliers: number[];
+  /** Sorted non-outlier observations, including repeated values. */
+  inner: number[];
+}
+
+export interface BoxWhiskerGeometry {
+  boxX: number;
+  boxWidth: number;
+  centerX: number;
+}
+
+function median(sorted: readonly number[]): number {
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[middle];
+  // Halving before addition avoids overflow for two large finite values.
+  return sorted[middle - 1] / 2 + sorted[middle] / 2;
+}
+
+function finiteMean(values: readonly number[]): number {
+  let scale = 0;
+  for (const value of values) scale = Math.max(scale, Math.abs(value));
+  if (scale === 0) return 0;
+  let normalized = 0;
+  for (const value of values) normalized += value / scale;
+  return (normalized / values.length) * scale;
+}
+
+function finiteFence(value: number, spread: number, direction: -1 | 1): number {
+  if (!Number.isFinite(spread)) {
+    return direction < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+  }
+  const result = value + direction * spread;
+  if (Number.isFinite(result)) return result;
+  return direction < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+}
+
+/**
+ * Compute median-of-halves box statistics from finite observations.
+ * Missing/non-finite observations are discarded and repeats are retained.
+ */
+export function computeBoxWhiskerStats(
+  values: readonly (number | null | undefined)[],
+  method: string,
+): BoxWhiskerStats | null {
+  const sorted = values
+    .filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
+    .sort((a, b) => a - b);
+  if (sorted.length === 0) return null;
+
+  const middle = Math.floor(sorted.length / 2);
+  const center = median(sorted);
+  const includeMedian = method === 'inclusive' && sorted.length % 2 === 1;
+  const lower = sorted.slice(0, middle + (includeMedian ? 1 : 0));
+  const upper = sorted.slice(middle + (sorted.length % 2 === 1 && !includeMedian ? 1 : 0));
+  const q1 = median(lower.length > 0 ? lower : sorted);
+  const q3 = median(upper.length > 0 ? upper : sorted);
+  const iqr = q3 - q1;
+  const spread = iqr * 1.5;
+  const lowerFence = finiteFence(q1, spread, -1);
+  const upperFence = finiteFence(q3, spread, 1);
+  const inner: number[] = [];
+  const outliers: number[] = [];
+  for (const value of sorted) {
+    // The fences are strict: equality remains a whisker candidate.
+    if (value < lowerFence || value > upperFence) outliers.push(value);
+    else inner.push(value);
+  }
+
+  return {
+    q1,
+    median: center,
+    q3,
+    lowerFence,
+    upperFence,
+    whiskerLo: inner[0] ?? sorted[0],
+    whiskerHi: inner[inner.length - 1] ?? sorted[sorted.length - 1],
+    mean: finiteMean(sorted),
+    outliers,
+    inner,
+  };
+}
+
+/** Count raw observations with overflow-safe early termination. */
+export function boxWhiskerPointCount(
+  groups: readonly (readonly (readonly unknown[])[])[],
+  limit: number,
+): number {
+  let count = 0;
+  for (const series of groups) {
+    for (const observations of series) {
+      count += observations.length;
+      if (!Number.isSafeInteger(count) || count > limit) return limit + 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Place a series in a stable equal slot inside a ChartEx category group.
+ * Empty peers keep their slots, so the same series never shifts horizontally
+ * between categories. The 6% gutter is local to each series slot.
+ */
+export function boxWhiskerGeometry(
+  plotX: number,
+  plotWidth: number,
+  categoryCount: number,
+  seriesCount: number,
+  categoryIndex: number,
+  seriesIndex: number,
+  gapWidthPercent: number,
+): BoxWhiskerGeometry | null {
+  if (
+    !Number.isFinite(plotX)
+    || !Number.isFinite(plotWidth)
+    || plotWidth <= 0
+    || !Number.isInteger(categoryCount)
+    || categoryCount <= 0
+    || !Number.isInteger(seriesCount)
+    || seriesCount <= 0
+    || !Number.isInteger(categoryIndex)
+    || categoryIndex < 0
+    || categoryIndex >= categoryCount
+    || !Number.isInteger(seriesIndex)
+    || seriesIndex < 0
+    || seriesIndex >= seriesCount
+    || !Number.isFinite(gapWidthPercent)
+    || gapWidthPercent < 0
+  ) return null;
+
+  const categoryInterval = plotWidth / (categoryCount + 1);
+  const groupWidth = categoryInterval / (1 + gapWidthPercent / 100);
+  const seriesSlotWidth = groupWidth / seriesCount;
+  const gutter = seriesSlotWidth * BOX_WHISKER_SLOT_GUTTER_FRACTION;
+  const boxWidth = seriesSlotWidth - gutter;
+  const groupLeft = plotX + categoryInterval * (categoryIndex + 1) - groupWidth / 2;
+  const boxX = groupLeft + seriesIndex * seriesSlotWidth + gutter / 2;
+  return { boxX, boxWidth, centerX: boxX + boxWidth / 2 };
+}

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -4808,11 +4808,11 @@ describe('CH15 — chartEx box-and-whisker', () => {
       valAxisMajorGridlines: true,
       chartexBox: {
         categories: ['A', 'B', 'C'],
-        series: [
-          { name: 'A', color: '5B9BD5', valuesByCategory: [[1, 2, 3], [], []], meanMarker: false, meanLine: false, showOutliers: false, showNonoutliers: false, quartileMethod: 'inclusive' },
-          { name: 'B', color: 'ED7D31', valuesByCategory: [[], [4, 5, 6], []], meanMarker: false, meanLine: false, showOutliers: false, showNonoutliers: false, quartileMethod: 'inclusive' },
-          { name: 'C', color: 'A5A5A5', valuesByCategory: [[], [], [7, 8, 9]], meanMarker: false, meanLine: false, showOutliers: false, showNonoutliers: false, quartileMethod: 'inclusive' },
-        ],
+        series: [{
+          name: 'S', color: '5B9BD5', valuesByCategory: [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+          meanMarker: false, meanLine: false, showOutliers: false, showNonoutliers: false,
+          quartileMethod: 'inclusive',
+        }],
       },
     }), RECT, 1);
 
@@ -4901,7 +4901,7 @@ describe('CH15 — chartEx box-and-whisker', () => {
     expect(lineRole.every(segment => segment.lw === 2)).toBe(true);
   });
 
-  it('partitions one category among its populated box-and-whisker series', () => {
+  it('partitions one category into equal series slots with a fixed gutter', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, boxModel({
       chartexBox: {
@@ -4922,13 +4922,15 @@ describe('CH15 — chartEx box-and-whisker', () => {
     }), RECT, 1);
 
     expect(rec.rects).toHaveLength(2);
-    expect(rec.rects[0].x + rec.rects[0].w).toBeCloseTo(rec.rects[1].x, 5);
     expect(rec.rects[0].w).toBeCloseTo(rec.rects[1].w, 5);
+    const gutter = rec.rects[1].x - (rec.rects[0].x + rec.rects[0].w);
+    const slotWidth = rec.rects[1].x - rec.rects[0].x;
+    expect(gutter / slotWidth).toBeCloseTo(0.06, 5);
   });
 
-  it('uses the full category width when only one series has data in that category', () => {
-    const rec = recordingCtx();
-    renderChart(rec.ctx, boxModel({
+  it('keeps each series in its stable slot when peer categories are empty', () => {
+    const sparse = recordingCtx();
+    const model = boxModel({
       chartexBox: {
         categories: ['A', 'B'],
         series: [
@@ -4944,11 +4946,115 @@ describe('CH15 — chartEx box-and-whisker', () => {
           },
         ],
       },
-    }), RECT, 1);
+    });
+    renderChart(sparse.ctx, model, RECT, 1);
 
-    expect(rec.rects).toHaveLength(2);
-    expect(rec.rects[0].w).toBeCloseTo(rec.rects[1].w, 5);
-    expect(rec.rects[0].w).toBeGreaterThan(50);
+    const full = recordingCtx();
+    const fullModel = structuredClone(model);
+    if (!fullModel.chartexBox) throw new Error('box fixture missing');
+    fullModel.chartexBox.series[0].valuesByCategory[1] = [1, 2, 3, 4];
+    fullModel.chartexBox.series[1].valuesByCategory[0] = [2, 3, 4, 5];
+    renderChart(full.ctx, fullModel, RECT, 1);
+
+    expect(sparse.rects).toHaveLength(2);
+    expect(full.rects).toHaveLength(4);
+    expect(sparse.rects[0].x).toBeCloseTo(full.rects[0].x, 5);
+    expect(sparse.rects[1].x).toBeCloseTo(full.rects[3].x, 5);
+    expect(sparse.rects[0].w).toBeCloseTo(sparse.rects[1].w, 5);
+  });
+
+  it('drops non-finite observations before deriving or painting geometry', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexBox: {
+        categories: ['A'],
+        series: [{
+          name: 'S', color: '5B9BD5', valuesByCategory: [[NaN, -Infinity, 5, 5, Infinity, 5]],
+          meanMarker: true, meanLine: false, showOutliers: true, showNonoutliers: true,
+          quartileMethod: 'inclusive',
+        }],
+      },
+    }), RECT, 1);
+    expect(rec.rects).toHaveLength(1);
+    expect(rec.rects.every(rect => [rect.x, rect.y, rect.w, rect.h].every(Number.isFinite))).toBe(true);
+  });
+
+  it('does not emit non-finite Canvas geometry for extreme finite observations', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexBox: {
+        categories: ['A'],
+        series: [{
+          name: 'S', color: '5B9BD5',
+          valuesByCategory: [[-Number.MAX_VALUE, -Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE]],
+          meanMarker: true, meanLine: false, showOutliers: true, showNonoutliers: true,
+          quartileMethod: 'exclusive',
+        }],
+      },
+    }), RECT, 1);
+    const coordinates = [
+      ...rec.fillRects.flatMap(rect => [rect.x, rect.y, rect.w, rect.h]),
+      ...rec.arcs.flatMap(arc => [arc.x, arc.y, arc.r]),
+      ...rec.segments.flatMap(segment => segment.flatMap(point => [point.x, point.y])),
+      ...rec.texts.flatMap(text => [text.x, text.y]),
+    ];
+    expect(coordinates.length).toBeGreaterThan(0);
+    expect(coordinates.every(Number.isFinite)).toBe(true);
+  });
+
+  it('atomically rejects finite input whose automatic nice-axis headroom overflows', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexBox: {
+        categories: ['A'],
+        series: [{
+          name: 'S', color: '5B9BD5', valuesByCategory: [[-8e307, 0, 8e307]],
+          meanMarker: true, meanLine: true, showOutliers: true, showNonoutliers: true,
+          quartileMethod: 'inclusive',
+        }],
+      },
+    }), RECT, 1);
+    expect(rec.fillRects).toHaveLength(0);
+    expect(rec.arcs).toHaveLength(0);
+    expect(rec.segments).toHaveLength(0);
+    expect(rec.texts.map(text => text.text)).toEqual(['(chart values out of range)']);
+  });
+
+  it('atomically rejects a huge finite authored range with a tiny major unit', () => {
+    const rec = markerRecordingCtx();
+    renderChart(rec.ctx, boxModel({
+      valMin: 0,
+      valMax: 1e308,
+      valAxisMajorUnit: 1,
+      chartexBox: {
+        categories: ['A'],
+        series: [{
+          name: 'S', color: '5B9BD5', valuesByCategory: [[0, 1, 2]],
+          meanMarker: true, meanLine: true, showOutliers: true, showNonoutliers: true,
+          quartileMethod: 'inclusive',
+        }],
+      },
+    }), RECT, 1);
+    expect(rec.fillRects).toHaveLength(0);
+    expect(rec.arcs).toHaveLength(0);
+    expect(rec.segments).toHaveLength(0);
+    expect(rec.texts.map(text => text.text)).toEqual(['(chart values out of range)']);
+  });
+
+  it('refuses an oversized box-and-whisker chart before sorting or painting', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, boxModel({
+      chartexBox: {
+        categories: ['A'],
+        series: [{
+          name: 'S', color: '5B9BD5', valuesByCategory: [new Array(10_001).fill(1)],
+          meanMarker: false, meanLine: false, showOutliers: false, showNonoutliers: false,
+          quartileMethod: 'inclusive',
+        }],
+      },
+    }), RECT, 1);
+    expect(rec.rects).toHaveLength(0);
+    expect(rec.texts.map(text => text.text)).toContain('(too many data points)');
   });
 
   it('uses the box/whisker semantic outline for Chart Style NoStyle only', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -29,6 +29,11 @@ import {
   type CategoryGapPolicy,
 } from './category-spacing.js';
 import { planHistogramBins } from './histogram-binning.js';
+import {
+  boxWhiskerGeometry,
+  boxWhiskerPointCount,
+  computeBoxWhiskerStats,
+} from './box-whisker.js';
 import { hexToRgba, resolveFill } from '../shape/paint.js';
 import {
   DEFAULT_TEXT_INSET_LR_EMU,
@@ -6488,62 +6493,6 @@ function renderParetoLineChart(
 
 // ─── chartEx: box-and-whisker (CH15, MS 2014 chartex ext) ────────────────────
 
-/** Statistics of one box in a box-and-whisker plot. */
-interface BoxStats {
-  q1: number;
-  median: number;
-  q3: number;
-  /** Whisker ends = min/max of the NON-outlier points. */
-  whiskerLo: number;
-  whiskerHi: number;
-  mean: number;
-  outliers: number[];
-  /** Interior (non-outlier) points used by the optional point overlay. */
-  inner: number[];
-}
-
-function boxMedian(sorted: number[]): number {
-  if (sorted.length === 0) return 0;
-  const middle = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0
-    ? (sorted[middle - 1] + sorted[middle]) / 2
-    : sorted[middle];
-}
-
-/**
- * Compute the five-number summary + mean + outliers for one box, using the
- * 1.5·IQR outlier fence (the Tukey rule Office applies; points beyond
- * `Q1 − 1.5·IQR` / `Q3 + 1.5·IQR` are outliers and the whiskers stop at the
- * most extreme non-outlier).
- */
-function computeBoxStats(values: number[], method: string): BoxStats | null {
-  if (values.length === 0) return null;
-  const sorted = [...values].sort((a, b) => a - b);
-  const middle = Math.floor(sorted.length / 2);
-  const median = boxMedian(sorted);
-  // Excel's box-chart "inclusive median" option includes an odd-sized
-  // sample's median in each half; "exclusive median" omits it. For even-sized
-  // samples the two methods share the same lower and upper halves.
-  const includeMedian = method === 'inclusive' && sorted.length % 2 === 1;
-  const lower = sorted.slice(0, middle + (includeMedian ? 1 : 0));
-  const upper = sorted.slice(middle + (sorted.length % 2 === 1 && !includeMedian ? 1 : 0));
-  const q1 = boxMedian(lower.length ? lower : sorted);
-  const q3 = boxMedian(upper.length ? upper : sorted);
-  const iqr = q3 - q1;
-  const loFence = q1 - 1.5 * iqr;
-  const hiFence = q3 + 1.5 * iqr;
-  const inner: number[] = [];
-  const outliers: number[] = [];
-  for (const v of sorted) {
-    if (v < loFence || v > hiFence) outliers.push(v);
-    else inner.push(v);
-  }
-  const whiskerLo = inner.length ? inner[0] : sorted[0];
-  const whiskerHi = inner.length ? inner[inner.length - 1] : sorted[sorted.length - 1];
-  const mean = values.reduce((a, b) => a + b, 0) / values.length;
-  return { q1, median, q3, whiskerLo, whiskerHi, mean, outliers, inner };
-}
-
 /**
  * Render a chartEx box-and-whisker chart (MS 2014 chartex extension — there is
  * no ECMA-376 section; the structure is Microsoft's `<cx:chartSpace>` with a
@@ -6567,6 +6516,36 @@ function renderBoxWhiskerChart(
   const box = chart.chartexBox;
   if (!box || box.categories.length === 0 || box.series.length === 0) return;
   const { x, y, w, h } = r;
+  const pointCount = boxWhiskerPointCount(
+    box.series.map(series => series.valuesByCategory),
+    MAX_CANVAS_CHART_POINTS,
+  );
+  if (rejectOversizedCanvasChart(ctx, r, pointCount)) return;
+
+  const rejectOutOfRange = (): void => {
+    ctx.fillStyle = '#888';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('(chart values out of range)', x + w / 2, y + h / 2);
+  };
+  const usableScale = (scale: { min: number; max: number; step: number }): boolean => {
+    const span = scale.max - scale.min;
+    const intervalCount = span / scale.step;
+    return Number.isFinite(scale.min)
+      && Number.isFinite(scale.max)
+      && Number.isFinite(scale.step)
+      && Number.isFinite(span)
+      && Number.isFinite(intervalCount)
+      && scale.max > scale.min
+      && scale.step > 0
+      // Axis paint is synchronous. Refuse an authored tiny major unit before
+      // entering a loop whose finite bounds could still imply vast work.
+      && intervalCount <= 1000
+      // A finite positive step may still be too small to advance a large
+      // floating-point bound, which would wedge the major-gridline loop.
+      && scale.min + scale.step > scale.min;
+  };
 
   // Resolve the value range before laying out the plot. The tick labels are a
   // real layout input: reserve their measured width instead of a percentage of
@@ -6576,12 +6555,17 @@ function renderBoxWhiskerChart(
   for (const s of box.series) {
     for (const group of s.valuesByCategory) {
       for (const v of group) {
+        if (!Number.isFinite(v)) continue;
         if (v < dataMin) dataMin = v;
         if (v > dataMax) dataMax = v;
       }
     }
   }
   if (!isFinite(dataMin) || !isFinite(dataMax)) return;
+  if (!Number.isFinite(dataMax - dataMin)) {
+    rejectOutOfRange();
+    return;
+  }
 
   const font = chartFontFamily(chart, chart.valAxisFontFace, 'minor');
   const valFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
@@ -6593,6 +6577,10 @@ function renderBoxWhiskerChart(
     h / ptToPx,
     chart.valAxisMajorUnit,
   );
+  if (!usableScale(provisionalScale)) {
+    rejectOutOfRange();
+    return;
+  }
   let valLabelBandW = 0;
   if (!chart.valAxisHidden) {
     const previousFont = ctx.font;
@@ -6636,7 +6624,6 @@ function renderBoxWhiskerChart(
     legendSideReserveFrac: 0.22,
     pad,
   });
-  drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
   const { px0, py0, pw, ph } = frame.plotRect;
 
   const cats = box.categories;
@@ -6647,10 +6634,16 @@ function renderBoxWhiskerChart(
   );
 
   // Excel's automatic value axis uses nice-rounded bounds and steps.
-  const { min: axisMin, max: axisMax, step } = valueAxisScale(
+  const axisScale = valueAxisScale(
     dataMin, dataMax, chart.valMin, chart.valMax, ph / ptToPx, chart.valAxisMajorUnit,
   );
-  const span = axisMax - axisMin || 1;
+  if (!usableScale(axisScale)) {
+    rejectOutOfRange();
+    return;
+  }
+  drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
+  const { min: axisMin, max: axisMax, step } = axisScale;
+  const span = axisMax - axisMin;
   const yOf = (v: number): number => py0 + ph * (1 - (v - axisMin) / span);
 
   const valAxisLine = resolveAxisLine(chart.valAxisLineColor, chart.valAxisLineWidthEmu, ptToPx);
@@ -6713,12 +6706,11 @@ function renderBoxWhiskerChart(
 
   // ChartEx places categorical box/whisker data points at interior category
   // positions, leaving one category interval between each plot edge and the
-  // first/last point. Multiple populated series split the category group so
-  // their boxes remain individually visible. `gapWidth` controls the
-  // group-vs-gap width inside that interval.
+  // first/last point. Every series owns one stable equal slot in each category
+  // group, including categories where a peer has no retained observations.
+  // `gapWidth` controls the group-vs-gap width inside that interval.
   const slotW = pw / (nCat + 1);
   const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, 'chartex');
-  const groupW = slotW / (1 + gapWidthPct / 100);
   const paletteOf = (si: number): string => {
     const fill = box.series[si].color
       ?? chartExDataPointFill(
@@ -6734,25 +6726,12 @@ function renderBoxWhiskerChart(
     box.series[si].color,
   );
   const statsBySeries = box.series.map(series => series.valuesByCategory.map(values => (
-    computeBoxStats(values, series.quartileMethod)
+    computeBoxWhiskerStats(values, series.quartileMethod)
   )));
-  const populatedSeriesByCategory = cats.map((_category, categoryIndex) =>
-    box.series
-      .map((series, seriesIndex) => ({
-        seriesIndex,
-        populated: (series.valuesByCategory[categoryIndex]?.length ?? 0) > 0,
-      }))
-      .filter(entry => entry.populated)
-      .map(entry => entry.seriesIndex)
-  );
   const boxGeometry = (ci: number, si: number): { bx: number; boxW: number; cx: number } => {
-    const categoryCenterX = px0 + slotW * (ci + 1);
-    const slotLeft = categoryCenterX - groupW / 2;
-    const populated = populatedSeriesByCategory[ci];
-    const activeIndex = Math.max(0, populated.indexOf(si));
-    const boxW = groupW / Math.max(1, populated.length);
-    const bx = slotLeft + activeIndex * boxW;
-    return { bx, boxW, cx: bx + boxW / 2 };
+    const geometry = boxWhiskerGeometry(px0, pw, nCat, nSer, ci, si, gapWidthPct);
+    if (!geometry) return { bx: px0, boxW: 0, cx: px0 };
+    return { bx: geometry.boxX, boxW: geometry.boxWidth, cx: geometry.centerX };
   };
 
   // `<cx:visibility meanLine>` connects the category means for one series.

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -4408,6 +4408,9 @@ fn chartex_data_cat_val_points(
         .enumerate()
         .filter_map(|(index, value)| {
             let value = value?;
+            if !value.is_finite() {
+                return None;
+            }
             let category = categories
                 .as_ref()
                 .and_then(|items| items.get(index))
@@ -10664,6 +10667,35 @@ mod tests {
         assert_eq!(s1.values_by_category, vec![vec![5.0], vec![7.0, 9.0]]);
         assert!(!s1.mean_marker && s1.mean_line && !s1.show_outliers && s1.show_nonoutliers);
         assert_eq!(s1.quartile_method, "inclusive");
+    }
+
+    #[test]
+    fn parse_chartex_part_boxwhisker_discards_non_finite_values_and_keeps_repeats() {
+        let xml = format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}" xmlns:a="{A_NS}">
+              <cx:chartData><cx:data id="0">
+                <cx:strDim type="cat"><cx:lvl ptCount="5">
+                  <cx:pt idx="0">Drop</cx:pt><cx:pt idx="1">Keep</cx:pt>
+                  <cx:pt idx="2">Keep</cx:pt><cx:pt idx="3">Drop</cx:pt>
+                  <cx:pt idx="4">Drop</cx:pt>
+                </cx:lvl></cx:strDim>
+                <cx:numDim type="val"><cx:lvl ptCount="5">
+                  <cx:pt idx="0">NaN</cx:pt><cx:pt idx="1">5</cx:pt>
+                  <cx:pt idx="2">5</cx:pt><cx:pt idx="3">inf</cx:pt>
+                  <cx:pt idx="4">-inf</cx:pt>
+                </cx:lvl></cx:numDim>
+              </cx:data></cx:chartData>
+              <cx:chart><cx:plotArea><cx:plotAreaRegion>
+                <cx:series layoutId="boxWhisker"><cx:dataId val="0"/></cx:series>
+              </cx:plotAreaRegion></cx:plotArea></cx:chart>
+            </cx:chartSpace>"#
+        );
+        let document = chart_space_of(&xml);
+        let model = parse_chartex_part(document.root_element(), &FixtureResolver, None)
+            .expect("finite repeated samples remain plottable");
+        let box_data = model.chartex_box.expect("box data");
+        assert_eq!(box_data.categories, vec!["Keep"]);
+        assert_eq!(box_data.series[0].values_by_category, vec![vec![5.0, 5.0]]);
     }
 
     struct FormulaOnlyBoxResolver;


### PR DESCRIPTION
## Summary
- filter non-finite samples while preserving repeated observations
- derive inclusive and exclusive quartiles with strict 1.5 IQR outlier boundaries in a pure planner
- share ChartEx category spacing and reserve stable equal-width series slots with a 6% gutter
- reject excessive points and unsafe axis ranges before painting

## Verification
- 471 core chart tests
- 364 ooxml-common tests plus doctest
- TypeScript 7 project build
- three parser WASM builds
- independent adversarial review

Closes #1232