### PR TITLE
fix(chart): normalize Pareto and waterfall semantics

### DIFF
--- a/packages/core/src/chart/pareto-layout.test.ts
+++ b/packages/core/src/chart/pareto-layout.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import type { ChartSeries } from '../types/chart';
+import { planParetoLayout } from './pareto-layout.js';
+
+function series(values: Array<number | null>): ChartSeries {
+  return { name: 'Frequency', color: null, values };
+}
+
+describe('planParetoLayout', () => {
+  it('sorts descending, preserves tie source order, and omits invalid values', () => {
+    const layout = planParetoLayout(
+      series([5, 20, 10, 20, null, 0, -2, 10]),
+      ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'],
+    );
+
+    expect(layout.points.map(point => point.sourceIndex)).toEqual([1, 3, 2, 7, 0, 5]);
+    expect(layout.categories).toEqual(['B', 'D', 'C', 'H', 'A', 'F']);
+    expect(layout.points.at(-1)?.cumulativeFraction).toBe(1);
+  });
+
+  it('retains all-zero values in source order without NaN or Infinity', () => {
+    const layout = planParetoLayout(series([0, 0, 0]), ['A', 'B', 'C']);
+    expect(layout.points.map(point => point.sourceIndex)).toEqual([0, 1, 2]);
+    expect(layout.series.values).toEqual([0, 0, 0]);
+    expect(layout.series.values.every(Number.isFinite)).toBe(true);
+  });
+
+  it('reaches exactly one for decimal data without rounding the running sum', () => {
+    const layout = planParetoLayout(series([0.1, 1000.25, 0.2]), ['A', 'B', 'C']);
+    expect(layout.series.values.at(-1)).toBe(1);
+    expect(layout.series.values[0]).toBeGreaterThan(0.99);
+  });
+
+  it('keeps indexed point and label formatting attached to source identity', () => {
+    const source = series([5, 20, 10]);
+    source.dataPointColors = ['AAAAAA', 'BBBBBB', 'CCCCCC'];
+    source.dataLabelColors = ['111111', '222222', '333333'];
+    source.dataPointOverrides = [{ idx: 1, color: 'ABCDEF' }];
+    source.dataLabelOverrides = [{ idx: 0, text: 'five' }];
+
+    const layout = planParetoLayout(source, ['A', 'B', 'C']);
+    expect(layout.series.dataPointColors).toEqual(['BBBBBB', 'CCCCCC', 'AAAAAA']);
+    expect(layout.series.dataLabelColors).toEqual(['222222', '333333', '111111']);
+    expect(layout.series.dataPointOverrides).toEqual([{ idx: 0, color: 'ABCDEF' }]);
+    expect(layout.series.dataLabelOverrides).toEqual([{ idx: 2, text: 'five' }]);
+    expect(layout.orderedSeries.values).toEqual([20, 10, 5]);
+    expect(layout.orderedSeries.dataPointOverrides).toEqual([{ idx: 0, color: 'ABCDEF' }]);
+    expect(layout.orderedSeries.dataLabelOverrides).toEqual([{ idx: 2, text: 'five' }]);
+  });
+
+  it('omits non-finite values defensively', () => {
+    const layout = planParetoLayout(series([1, Number.NaN, Number.POSITIVE_INFINITY, 2]), []);
+    expect(layout.points.map(point => point.sourceIndex)).toEqual([3, 0]);
+    expect(layout.series.values).toEqual([2 / 3, 1]);
+  });
+
+  it('uses series-local categories when chart-level categories are absent', () => {
+    const source = series([1, 3, 2]);
+    source.categories = ['One', 'Three', 'Two'];
+    const layout = planParetoLayout(source, []);
+    expect(layout.categories).toEqual(['Three', 'Two', 'One']);
+    expect(layout.series.categories).toEqual(['Three', 'Two', 'One']);
+  });
+
+  it('keeps owner-series categories authoritative when chart categories differ', () => {
+    const source = series([1, 3, 2]);
+    source.categories = ['Owner one', 'Owner three', 'Owner two'];
+    const layout = planParetoLayout(source, ['Chart one', 'Chart three', 'Chart two']);
+    expect(layout.categories).toEqual(['Owner three', 'Owner two', 'Owner one']);
+  });
+
+  it('fills sparse parallel arrays with null rather than contract-invalid undefined', () => {
+    const source = series([3, 2, 1]);
+    source.dataPointColors = ['AAAAAA'];
+    source.dataLabelColors = [];
+    source.catFormatCodes = ['0'];
+    const layout = planParetoLayout(source, []);
+    expect(layout.series.dataPointColors).toEqual(['AAAAAA', null, null]);
+    expect(layout.series.dataLabelColors).toEqual([null, null, null]);
+    expect(layout.series.catFormatCodes).toEqual(['0', null, null]);
+  });
+
+  it('keeps proportional fractions finite when finite inputs would overflow a raw sum', () => {
+    const max = Number.MAX_VALUE;
+    const layout = planParetoLayout(series([max, max]), ['A', 'B']);
+    expect(layout.series.values).toEqual([0.5, 1]);
+  });
+});

--- a/packages/core/src/chart/pareto-layout.ts
+++ b/packages/core/src/chart/pareto-layout.ts
@@ -1,0 +1,114 @@
+import type {
+  ChartDataLabelOverride,
+  ChartDataPointOverride,
+  ChartSeries,
+} from '../types/chart';
+
+export interface ParetoPoint {
+  sourceIndex: number;
+  category: string;
+  value: number;
+  cumulativeFraction: number;
+}
+
+export interface ParetoLayout {
+  points: ParetoPoint[];
+  /** Source series reordered for the frequency bars. */
+  orderedSeries: ChartSeries;
+  /** Reordered series whose values are the cumulative 0..1 fractions. */
+  series: ChartSeries;
+  categories: string[];
+}
+
+function remapIndexed<T extends { idx: number }>(
+  values: readonly T[] | null | undefined,
+  newIndexBySource: ReadonlyMap<number, number>,
+): T[] | null | undefined {
+  if (values == null) return values;
+  return values.flatMap(value => {
+    const idx = newIndexBySource.get(value.idx);
+    return idx == null ? [] : [{ ...value, idx }];
+  });
+}
+
+function reorderNullable<T>(
+  values: readonly T[] | null | undefined,
+  sourceIndices: readonly number[],
+): Array<T | null> | null | undefined {
+  if (values == null) return values;
+  return sourceIndices.map(index => values[index] ?? null);
+}
+
+/**
+ * Derive a deterministic Pareto order without mutating the authored model.
+ *
+ * Finite non-negative values participate. Ties retain source order, missing or
+ * invalid values are omitted, and a zero-total series produces finite zero
+ * cumulative values. Indexed point/label properties follow their source point
+ * through the reorder.
+ */
+export function planParetoLayout(
+  series: ChartSeries,
+  chartCategories: readonly string[],
+): ParetoLayout {
+  const retained = series.values
+    .map((value, sourceIndex) => ({ value, sourceIndex }))
+    .filter((entry): entry is { value: number; sourceIndex: number } =>
+      entry.value != null && Number.isFinite(entry.value) && entry.value >= 0
+    )
+    .sort((a, b) => b.value - a.value || a.sourceIndex - b.sourceIndex);
+
+  // Normalize before summing so finite values near Number.MAX_VALUE cannot
+  // overflow the denominator to Infinity and collapse early fractions to 0.
+  const scale = retained[0]?.value ?? 0;
+  const normalizedTotal = scale > 0
+    ? retained.reduce((sum, entry) => sum + entry.value / scale, 0)
+    : 0;
+  let running = 0;
+  const points = retained.map((entry): ParetoPoint => {
+    if (scale > 0) running += entry.value / scale;
+    return {
+      sourceIndex: entry.sourceIndex,
+      category: series.categories?.[entry.sourceIndex]
+        ?? chartCategories[entry.sourceIndex]
+        ?? String(entry.sourceIndex + 1),
+      value: entry.value,
+      cumulativeFraction: normalizedTotal > 0
+        ? (running >= normalizedTotal ? 1 : running / normalizedTotal)
+        : 0,
+    };
+  });
+  const sourceIndices = points.map(point => point.sourceIndex);
+  const newIndexBySource = new Map(
+    sourceIndices.map((sourceIndex, newIndex) => [sourceIndex, newIndex]),
+  );
+  const categories = points.map(point => point.category);
+  const reordered = {
+    ...series,
+    categories,
+    catFormatCodes: reorderNullable(series.catFormatCodes, sourceIndices),
+    dataPointColors: reorderNullable(series.dataPointColors, sourceIndices),
+    dataLabelColors: reorderNullable(series.dataLabelColors, sourceIndices),
+    dataPointOverrides: remapIndexed<ChartDataPointOverride>(
+      series.dataPointOverrides,
+      newIndexBySource,
+    ),
+    dataLabelOverrides: remapIndexed<ChartDataLabelOverride>(
+      series.dataLabelOverrides,
+      newIndexBySource,
+    ),
+  };
+
+  return {
+    points,
+    categories,
+    orderedSeries: {
+      ...reordered,
+      values: points.map(point => point.value),
+    },
+    series: {
+      ...reordered,
+      values: points.map(point => point.cumulativeFraction),
+    },
+  };
+}

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -1787,6 +1787,149 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
     )).toBe(true);
   });
 
+  it('renders owner-backed Pareto bars in sorted source identity order with a 0-100% line axis', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'pareto',
+      categories: ['Five', 'Twenty', 'Ten'],
+      series: [
+        series({
+          name: 'Frequency',
+          values: [5, 20, 10],
+          dataPointOverrides: [
+            { idx: 0, color: 'AA0000' },
+            { idx: 1, color: '00AA00' },
+            { idx: 2, color: '0000AA' },
+          ],
+        }),
+        series({ name: 'Cumulative %', values: [], color: '333333' }),
+      ],
+    }), RECT, 1);
+
+    expect(rec.rects.map(rect => rect.fs.toUpperCase())).toEqual([
+      '#00AA00', '#0000AA', '#AA0000',
+    ]);
+    const texts = rec.texts.map(text => text.text);
+    expect(texts).toEqual(expect.arrayContaining(['Twenty', 'Ten', 'Five', '0%', '100%']));
+  });
+
+  it.each(['pareto', 'paretoLine'])('%s rejects oversized input before sorting or paint', chartType => {
+    const rec = recordingCtx();
+    const values = Array.from({ length: 10_001 }, (_, index) => index);
+    renderChart(rec.ctx, baseModel({
+      chartType,
+      categories: [],
+      series: [series({ values })],
+    }), RECT, 1);
+    expect(rec.texts.map(text => text.text)).toContain('(too many data points)');
+    expect(rec.rects).toHaveLength(0);
+  });
+
+  it('honors direct Pareto cumulative-line width/color and noFill', () => {
+    const model = (chartexStyle: ChartSeries['chartexStyle']) => baseModel({
+      chartType: 'pareto',
+      categories: ['A', 'B', 'C'],
+      series: [
+        series({ values: [3, 2, 1] }),
+        series({
+          values: [],
+          seriesType: 'line',
+          useSecondaryAxis: true,
+          showMarker: false,
+          chartexStyle,
+        }),
+      ],
+    });
+
+    const styled = strokedPolylineCtx();
+    renderChart(styled.ctx, model({ lineColors: ['123456'], lineWidthEmu: 25400 }), RECT, 1);
+    expect(styled.strokes.some(stroke =>
+      stroke.ss.toLowerCase() === '#123456'
+      && stroke.lw === 2
+      && stroke.points.some((point, index) =>
+        index > 0
+        && point.x !== stroke.points[index - 1].x
+        && point.y !== stroke.points[index - 1].y
+      )
+    )).toBe(true);
+
+    const hidden = strokedPolylineCtx();
+    renderChart(hidden.ctx, model({ lineHidden: true }), RECT, 1);
+    expect(hidden.strokes.some(stroke =>
+      stroke.points.some((point, index) =>
+        index > 0
+        && point.x !== stroke.points[index - 1].x
+        && point.y !== stroke.points[index - 1].y
+      )
+    )).toBe(false);
+  });
+
+  it('distinguishes linked NoStyle from linked and direct Pareto line noFill', () => {
+    const model = (
+      linked: ChartModel['chartexDataPointLineStyle'],
+      direct?: ChartSeries['chartexStyle'],
+    ) => baseModel({
+      chartType: 'pareto',
+      categories: ['A', 'B', 'C'],
+      chartexDataPointLineStyle: linked,
+      series: [
+        series({ values: [3, 2, 1] }),
+        series({
+          values: [],
+          seriesType: 'line',
+          useSecondaryAxis: true,
+          showMarker: false,
+          chartexStyle: direct,
+        }),
+      ],
+    });
+    const hasCumulativeLine = (rec: ReturnType<typeof strokedPolylineCtx>): boolean =>
+      rec.strokes.some(stroke => stroke.points.some((point, index) =>
+        index > 0
+        && point.x !== stroke.points[index - 1].x
+        && point.y !== stroke.points[index - 1].y
+      ));
+
+    const noStyle = strokedPolylineCtx();
+    renderChart(noStyle.ctx, model({ lineHidden: true, lineNoStyle: true }), RECT, 1);
+    expect(hasCumulativeLine(noStyle)).toBe(true);
+
+    const linkedNoFill = strokedPolylineCtx();
+    renderChart(linkedNoFill.ctx, model({ lineHidden: true }), RECT, 1);
+    expect(hasCumulativeLine(linkedNoFill)).toBe(false);
+
+    const directNoFill = strokedPolylineCtx();
+    renderChart(
+      directNoFill.ctx,
+      model({ lineHidden: true, lineNoStyle: true }, { lineHidden: true }),
+      RECT,
+      1,
+    );
+    expect(hasCumulativeLine(directNoFill)).toBe(false);
+  });
+
+  it('uses the original combo-series index for linked line style fallback', () => {
+    const rec = strokedPolylineCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBar',
+      categories: ['A', 'B', 'C'],
+      chartexDataPointLineStyle: { lineColors: ['111111', '222222'] },
+      series: [
+        series({ values: [3, 2, 1] }),
+        series({ values: [1, 2, 3], seriesType: 'line', showMarker: false }),
+      ],
+    }), RECT, 1);
+
+    expect(rec.strokes.some(stroke =>
+      stroke.ss.toLowerCase() === '#222222'
+      && stroke.points.some((point, index) =>
+        index > 0
+        && point.x !== stroke.points[index - 1].x
+        && point.y !== stroke.points[index - 1].y
+      )
+    )).toBe(true);
+  });
+
   it('waterfall uses locale-neutral English semantic legend labels', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, baseModel({
@@ -1801,6 +1944,64 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
     expect(rec.texts.map(text => text.text)).toEqual(
       expect.arrayContaining(['Increase', 'Decrease', 'Total']),
     );
+  });
+
+  it('waterfall preserves missing slots without painting or labeling non-finite values', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'Invalid', 'Missing', 'Drop', 'End'],
+      series: [series({ values: [2, Number.NaN, null, -1, 1] })],
+      subtotalIndices: [4],
+      showDataLabels: true,
+      catAxisHidden: true,
+      valAxisHidden: true,
+    }), RECT, 1);
+
+    // Three finite bars plus the historical zero-height placeholder for the
+    // missing numeric slot. The present NaN point is the only suppressed bar.
+    expect(rec.rects).toHaveLength(4);
+    expect(rec.texts.map(text => text.text)).toEqual(['2', '-1', '1']);
+  });
+
+  it('waterfall keeps finite geometry when cumulative finite values overflow', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['A', 'B', 'C'],
+      series: [series({ values: [Number.MAX_VALUE, Number.MAX_VALUE, -1] })],
+      catAxisHidden: true,
+      valAxisHidden: true,
+    }), RECT, 1);
+    expect(rec.rects).toHaveLength(0);
+    expect(rec.texts.map(text => text.text)).toContain('(chart values out of range)');
+  });
+
+  it('waterfall preserves an authored category-only label on a missing numeric slot', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['Start', 'Missing', 'End'],
+      series: [series({
+        values: [2, null, 2],
+        seriesDataLabels: {
+          showVal: true,
+          showCatName: false,
+          showSerName: false,
+          showPercent: false,
+        },
+        dataLabelOverrides: [{
+          idx: 1,
+          text: '',
+          showVal: false,
+          showCatName: true,
+        }],
+      })],
+      catAxisHidden: true,
+      valAxisHidden: true,
+    }), RECT, 1);
+    expect(rec.texts.map(text => text.text)).toContain('Missing');
+    expect(rec.texts.map(text => text.text)).not.toContain('0');
   });
 });
 
@@ -3230,6 +3431,46 @@ describe('CH10 — chart text font faces', () => {
 
 interface Seg { x0: number; y0: number; x1: number; y1: number; ss: string; lw: number }
 interface SegRecorded { ctx: CanvasRenderingContext2D; segs: Seg[]; texts: TextCall[] }
+
+function strokedPolylineCtx(): {
+  ctx: CanvasRenderingContext2D;
+  strokes: Array<{ points: Array<{ x: number; y: number }>; ss: string; lw: number }>;
+} {
+  const strokes: Array<{ points: Array<{ x: number; y: number }>; ss: string; lw: number }> = [];
+  let path: Array<{ x: number; y: number }> = [];
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif', fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
+    textAlign: 'start', textBaseline: 'alphabetic', globalAlpha: 1,
+  };
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText': return (text: string) => ({ width: String(text).length * 6 });
+        case 'beginPath': return () => { path = []; };
+        case 'moveTo': return (x: number, y: number) => { path.push({ x, y }); };
+        case 'lineTo': return (x: number, y: number) => { path.push({ x, y }); };
+        case 'stroke': return () => {
+          if (path.length >= 2) {
+            strokes.push({
+              points: path.map(point => ({ ...point })),
+              ss: String(state.strokeStyle),
+              lw: Number(state.lineWidth),
+            });
+          }
+        };
+        case 'createLinearGradient': case 'createRadialGradient':
+          return () => ({ addColorStop() {} });
+        default: return () => undefined;
+      }
+    },
+    set(_target, prop: string, value) { state[prop] = value; return true; },
+  };
+  return {
+    ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D,
+    strokes,
+  };
+}
 
 /** Recording context that captures stroked line SEGMENTS (moveTo→lineTo→stroke)
  *  plus fillText, so gridline presence/orientation can be asserted. */

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -34,6 +34,7 @@ import {
   boxWhiskerPointCount,
   computeBoxWhiskerStats,
 } from './box-whisker.js';
+import { planParetoLayout } from './pareto-layout.js';
 import { hexToRgba, resolveFill } from '../shape/paint.js';
 import {
   DEFAULT_TEXT_INSET_LR_EMU,
@@ -1403,7 +1404,10 @@ function renderBarChart(
   chart: ChartModel,
   r: ChartRect,
   ptToPx: number,
-  gapPolicy: CategoryGapPolicy = 'legacy',
+  options: {
+    gapPolicy?: CategoryGapPolicy;
+    semanticLineNoStyleFallback?: boolean;
+  } = {},
 ): void {
   const { x, y, w, h } = r;
   const isH = chart.chartType === 'clusteredBarH' || chart.chartType === 'stackedBarH' || chart.chartType === 'stackedBarHPct';
@@ -1965,7 +1969,10 @@ function renderBarChart(
     : (catRev ? n - 1 - ci : ci);
   const nSeriesEffective = stacked ? 1 : Math.max(1, barSeries.length);
   const overlapPct  = stacked ? 0 : (chart.barOverlap ?? 0);
-  const gapWidthPct = resolveCategoryGapWidthPercent(chart.barGapWidth, gapPolicy);
+  const gapWidthPct = resolveCategoryGapWidthPercent(
+    chart.barGapWidth,
+    options.gapPolicy ?? 'legacy',
+  );
   const denom = 1 + (nSeriesEffective - 1) * (1 - overlapPct / 100) + gapWidthPct / 100;
   const barW  = catGap / denom;
   // Pitch between bars within a cluster (not the gap — the left-edge to
@@ -2236,7 +2243,29 @@ function renderBarChart(
       // Series bound to the secondary axis map through its scale; others use
       // the primary (bar) value axis.
       const yOf = sec && s.useSecondaryAxis === true ? toYSecondary : toYPrimaryLine;
-      ctx.strokeStyle = color; ctx.lineWidth = 2; ctx.setLineDash([]);
+      const hasAuthoredLine = s.chartexStyle != null
+        || s.lineHidden != null
+        || s.lineColor != null
+        || s.lineWidthEmu != null
+        || chart.chartexDataPointLineStyle != null;
+      const paintLine = hasAuthoredLine
+        ? applyChartExSeriesLineStyle(
+          ctx,
+          chart,
+          chart.chartexDataPointLineStyle,
+          s,
+          chartExSeriesFormatIndex(s, chart.series.indexOf(s)),
+          lineSeries.length,
+          color,
+          ptToPx,
+          { linkedNoStyleFallback: options.semanticLineNoStyleFallback },
+        )
+        : true;
+      if (!hasAuthoredLine) {
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 2;
+        ctx.setLineDash([]);
+      }
       ctx.beginPath();
       let started = false;
       for (let ci = 0; ci < n; ci++) {
@@ -2246,7 +2275,7 @@ function renderBarChart(
         const ly = yOf(v);
         if (!started) { ctx.moveTo(lx, ly); started = true; } else ctx.lineTo(lx, ly);
       }
-      ctx.stroke();
+      if (paintLine) ctx.stroke();
       if (s.showMarker !== false) {
         for (let ci = 0; ci < n; ci++) {
           const v = s.values[ci];
@@ -5755,6 +5784,7 @@ function resolveChartExLabel(
   value: number,
   defaults: { visible: boolean; showVal: boolean; showCatName: boolean; showSerName?: boolean },
   overrideLookup?: ReadonlyMap<number, NonNullable<ChartSeries['dataLabelOverrides']>[number]>,
+  suppressValue = false,
 ): ResolvedChartExLabel | null {
   if (!series) return null;
   const definition = series.seriesDataLabels;
@@ -5762,7 +5792,8 @@ function resolveChartExLabel(
     ?? series.dataLabelOverrides?.find(item => item.idx === index);
   if (override?.deleted) return null;
   if (!definition && !override && !defaults.visible) return null;
-  const showVal = override?.showVal ?? definition?.showVal ?? defaults.showVal;
+  const showVal = !suppressValue
+    && (override?.showVal ?? definition?.showVal ?? defaults.showVal);
   const showCatName = override?.showCatName ?? definition?.showCatName ?? defaults.showCatName;
   const showSerName = override?.showSerName
     ?? definition?.showSerName
@@ -5974,6 +6005,9 @@ function applyChartExSeriesLineStyle(
     || series?.lineColor != null
     || series?.lineWidthEmu != null;
   if (!hasLegacyLocalLine) {
+    // NoStyle means the linked role supplies no decorative override. Layouts
+    // with a semantic line may opt back into their automatic fallback; an
+    // explicit linked noFill remains authoritative because lineNoStyle is false.
     if (style?.lineNoStyle && options.linkedNoStyleFallback) {
       return applyChartExLineStyle(ctx, chart, null, index, count, fallbackColor, ptToPx);
     }
@@ -6029,7 +6063,7 @@ function renderHistogramChart(
     chartType: 'clusteredBar',
     categories: plan.categories,
     series: [{ ...source, categories: undefined, values: plan.counts }],
-  }, rect, ptToPx, 'chartex');
+  }, rect, ptToPx, { gapPolicy: 'chartex' });
 }
 
 function renderWaterfallChart(
@@ -6050,28 +6084,66 @@ function renderWaterfallChart(
   if (rejectOversizedCanvasChart(ctx, r, n)) return;
 
   const subSet = new Set(chart.subtotalIndices);
+  let cumulativeOverflow = false;
+  const safeAdd = (left: number, right: number): number => {
+    const sum = left + right;
+    if (Number.isFinite(sum)) return sum;
+    cumulativeOverflow = true;
+    return sum < 0 ? -Number.MAX_VALUE : Number.MAX_VALUE;
+  };
   let running = 0;
-  const bars: Array<{ start: number; end: number; isSub: boolean; isPos: boolean }> = [];
+  const bars: Array<{
+    start: number;
+    end: number;
+    isSub: boolean;
+    isPos: boolean;
+    hasValue: boolean;
+    paintSlot: boolean;
+  }> = [];
   let rawMax = Number.NEGATIVE_INFINITY;
   let rawMin = 0;
   for (let i = 0; i < n; i++) {
-    const v = vals[i] ?? 0;
+    const authoredValue = vals[i];
+    const hasValue = authoredValue != null && Number.isFinite(authoredValue);
+    // A missing dimension point still owns its authored category slot (the
+    // historical zero-height placeholder). A present but non-finite value is
+    // invalid numeric input and must not reach axis or Canvas geometry.
+    const paintSlot = authoredValue == null || hasValue;
+    const v = hasValue ? authoredValue as number : 0;
     const isSub = subSet.has(i);
     if (isSub) {
-      const bar = { start: 0, end: v, isSub: true, isPos: true };
+      const bar = { start: 0, end: v, isSub: true, isPos: true, hasValue, paintSlot };
       bars.push(bar);
-      rawMax = Math.max(rawMax, bar.start, bar.end);
-      rawMin = Math.min(rawMin, bar.start, bar.end);
-      running = v;
+      if (paintSlot) {
+        rawMax = Math.max(rawMax, bar.start, bar.end);
+        rawMin = Math.min(rawMin, bar.start, bar.end);
+      }
+      if (hasValue) {
+        running = v;
+      }
     } else {
-      const start = v >= 0 ? running : running + v;
-      const end   = v >= 0 ? running + v : running;
-      const bar = { start, end, isSub: false, isPos: v >= 0 };
+      const next = safeAdd(running, v);
+      const start = v >= 0 ? running : next;
+      const end   = v >= 0 ? next : running;
+      const bar = { start, end, isSub: false, isPos: v >= 0, hasValue, paintSlot };
       bars.push(bar);
-      rawMax = Math.max(rawMax, bar.start, bar.end);
-      rawMin = Math.min(rawMin, bar.start, bar.end);
-      running += v;
+      if (paintSlot) {
+        rawMax = Math.max(rawMax, bar.start, bar.end);
+        rawMin = Math.min(rawMin, bar.start, bar.end);
+      }
+      if (hasValue) {
+        running = next;
+      }
     }
+  }
+
+  if (cumulativeOverflow) {
+    ctx.fillStyle = '#888';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('(chart values out of range)', x + w / 2, y + h / 2);
+    return;
   }
 
   if (rawMax <= rawMin) return;
@@ -6247,13 +6319,13 @@ function renderWaterfallChart(
 
     const paint = bar.isSub ? paintSub : bar.isPos ? paintPos : paintNeg;
     const fallback = bar.isSub ? colorSub : bar.isPos ? colorPos : colorNeg;
-    if (paint) {
+    if (bar.paintSlot && paint) {
       ctx.fillStyle = chartExFillStyle(ctx, paint, bx, yTop, barW, bh, fallback, shapeRotationDeg);
       ctx.fillRect(bx, yTop, barW, bh);
     }
     const accentIndex = bar.isSub ? 2 : bar.isPos ? 0 : 1;
     const lineColor = chartExStyleColor(chart, chart.chartexDataPointStyle, 'line', accentIndex, 3);
-    if (applyChartExSeriesLineStyle(
+    if (bar.paintSlot && applyChartExSeriesLineStyle(
       ctx,
       chart,
       chart.chartexDataPointStyle,
@@ -6266,7 +6338,8 @@ function renderWaterfallChart(
       ctx.strokeRect(bx, yTop, barW, bh);
     }
 
-    if (i < n - 1 && chart.chartexConnectorLines !== false) {
+    if (bar.paintSlot && bars[i + 1]?.paintSlot
+      && i < n - 1 && chart.chartexConnectorLines !== false) {
       const nextBx = px0 + gapW * (i + 1) + (gapW - barW) / 2;
       const connY = bar.isPos ? yTop : yBot;
       ctx.save();
@@ -6289,10 +6362,12 @@ function renderWaterfallChart(
       ctx.restore();
     }
 
-    const rawVal = vals[i] ?? 0;
+    const rawVal = bar.hasValue ? vals[i] as number : 0;
     const label = resolveChartExLabel(
       chart, series, i, cats[i] ?? '', rawVal,
       { visible: true, showVal: true, showCatName: false },
+      undefined,
+      !bar.hasValue,
     );
     if (label) {
       const perPointColor = series?.dataLabelColors?.[i] ?? label.fontColor ?? null;
@@ -6311,7 +6386,7 @@ function renderWaterfallChart(
       if (label.position === 'ctr') {
         ctx.textBaseline = 'middle';
         ctx.fillText(label.text, bx + barW / 2, (yTop + yBot) / 2);
-      } else if (rawVal < 0) {
+      } else if (bar.hasValue && rawVal < 0) {
         ctx.textBaseline = 'top';
         ctx.fillText(label.text, bx + barW / 2, yBot + 3);
       } else {
@@ -6472,23 +6547,102 @@ function renderParetoLineChart(
 ): void {
   const source = chart.series[0];
   if (!source) return;
-  const raw = source.values.map(value => Math.max(0, value ?? 0));
-  const total = raw.reduce((sum, value) => sum + value, 0);
-  if (!(total > 0)) return;
-  let sum = 0;
-  const cumulative = raw.map(value => (sum += value) / total);
+  const pointCount = Math.max(
+    chart.categories.length,
+    source.categories?.length ?? 0,
+    source.values.length,
+  );
+  if (rejectOversizedCanvasChart(ctx, r, pointCount)) return;
+  const layout = planParetoLayout(source, chart.categories);
+  if (layout.points.length === 0) return;
   renderLineChart(ctx, {
     ...chart,
     chartType: 'line',
-    categories: cumulative.map((_value, index) => String(index + 1)),
-    series: [{ ...source, values: cumulative, showMarker: false }],
+    categories: layout.categories,
+    series: [{ ...layout.series, showMarker: false }],
     // Pareto's ordinal category labels are suppressed, but its authored
     // category-axis rule remains visible. Keep those two concerns separate.
     catAxisHidden: false,
     catAxisTickLabelPos: 'none',
     showLegend: false,
     valMin: 0,
+    valMax: chart.valMax ?? 1,
+    valAxisFormatCode: chart.valAxisFormatCode ?? '0%',
   }, r, ptToPx);
+}
+
+/** Owner-backed ChartEx Pareto: sorted frequency columns plus cumulative line. */
+function renderParetoChart(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  r: ChartRect,
+  ptToPx: number,
+): void {
+  const owner = chart.series[0];
+  if (!owner) return;
+  const pointCount = Math.max(
+    chart.categories.length,
+    owner.categories?.length ?? 0,
+    owner.values.length,
+  );
+  if (rejectOversizedCanvasChart(ctx, r, pointCount)) return;
+  const layout = planParetoLayout(owner, chart.categories);
+  if (layout.points.length === 0) return;
+
+  const authoredLine = chart.series.find(series => series.seriesType === 'line');
+  const lineStyleIndex = authoredLine?.chartexFormatIdx
+    ?? owner.chartexFormatIdx
+    ?? 0;
+  const cumulativeLine: ChartSeries = {
+    ...(authoredLine ?? layout.series),
+    name: authoredLine?.name || 'Cumulative %',
+    values: layout.series.values,
+    categories: layout.categories,
+    color: authoredLine?.color
+      ?? chartExStyleColor(
+        chart, chart.chartexDataPointLineStyle, 'line', lineStyleIndex, 1,
+      )
+      ?? owner.lineColor
+      ?? owner.color,
+    seriesType: 'line',
+    useSecondaryAxis: true,
+    showMarker: false,
+  };
+  const secondaryAxis: SecondaryValueAxis = {
+    min: chart.secondaryValAxis?.min ?? 0,
+    max: chart.secondaryValAxis?.max ?? 1,
+    title: chart.secondaryValAxis?.title ?? null,
+    hidden: chart.secondaryValAxis?.hidden ?? false,
+    formatCode: chart.secondaryValAxis?.formatCode ?? '0%',
+    fontColor: chart.secondaryValAxis?.fontColor ?? null,
+    fontSizeHpt: chart.secondaryValAxis?.fontSizeHpt ?? null,
+    fontFace: chart.secondaryValAxis?.fontFace ?? null,
+    lineColor: chart.secondaryValAxis?.lineColor ?? null,
+    lineWidthEmu: chart.secondaryValAxis?.lineWidthEmu ?? null,
+    lineHidden: chart.secondaryValAxis?.lineHidden ?? false,
+    majorTickMark: chart.secondaryValAxis?.majorTickMark ?? 'out',
+    minorTickMark: chart.secondaryValAxis?.minorTickMark ?? null,
+    majorUnit: chart.secondaryValAxis?.majorUnit ?? null,
+    minorUnit: chart.secondaryValAxis?.minorUnit ?? null,
+    titleFontSizeHpt: chart.secondaryValAxis?.titleFontSizeHpt ?? null,
+    titleFontBold: chart.secondaryValAxis?.titleFontBold ?? null,
+    titleFontColor: chart.secondaryValAxis?.titleFontColor ?? null,
+    titleFontFace: chart.secondaryValAxis?.titleFontFace ?? null,
+  };
+
+  renderBarChart(ctx, {
+    ...chart,
+    chartType: 'clusteredBar',
+    categories: layout.categories,
+    series: [
+      { ...layout.orderedSeries, seriesType: null, useSecondaryAxis: false },
+      cumulativeLine,
+    ],
+    secondaryValAxis: secondaryAxis,
+  }, r, ptToPx, {
+    gapPolicy: 'chartex',
+    semanticLineNoStyleFallback: true,
+  });
 }
 
 // ─── chartEx: box-and-whisker (CH15, MS 2014 chartex ext) ────────────────────
@@ -7959,7 +8113,7 @@ export function renderChart(
           { ...chart, chartType: 'clusteredBar' },
           rect,
           ptToPx,
-          'chartex',
+          { gapPolicy: 'chartex' },
         ); break;
       case 'histogram':
         renderHistogramChart(ctx, chart, rect, ptToPx); break;
@@ -7967,6 +8121,8 @@ export function renderChart(
         renderFunnelChart(ctx, chart, rect, ptToPx, shapeRotationDeg); break;
       case 'paretoLine':
         renderParetoLineChart(ctx, chart, rect, ptToPx); break;
+      case 'pareto':
+        renderParetoChart(ctx, chart, rect, ptToPx); break;
       case 'stock':
         renderStockChart(ctx, chart, rect, ptToPx); break;
       case 'boxWhisker':

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -3484,16 +3484,39 @@ pub fn parse_chartex_part_with_references_and_style_parts(
             })
             .unwrap_or(0)
     };
-    let series_node = *series_nodes.first()?;
+    // A Pareto plot is represented by an ordinary owner series plus an
+    // auxiliary `paretoLine` whose `ownerIdx` names the owner's original
+    // document-order series index (CT_Series@ownerIdx, [MS-ODRAWXML]
+    // 2.24.3.77). This is independent of `formatIdx`; select the linked owner
+    // even when a hidden or auxiliary series appears first.
+    let pareto_pair = series_nodes.iter().copied().find_map(|pareto| {
+        if attr(&pareto, "layoutId").as_deref() != Some("paretoLine") {
+            return None;
+        }
+        let owner_idx = attr(&pareto, "ownerIdx")?.parse::<usize>().ok()?;
+        let owner = *all_series_nodes.get(owner_idx)?;
+        let owner_is_hidden = attr(&owner, "hidden")
+            .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"));
+        (owner != pareto
+            && !owner_is_hidden
+            && attr(&owner, "layoutId").as_deref() != Some("paretoLine"))
+        .then_some((owner, pareto))
+    });
+    let (series_node, pareto_series_node) = pareto_pair
+        .map(|(owner, pareto)| (owner, Some(pareto)))
+        .unwrap_or((*series_nodes.first()?, None));
     let layout_id = attr(&series_node, "layoutId").unwrap_or_default();
     // [MS-ODRAWXML] represents a histogram as a clusteredColumn series with a
     // CT_Binning child; `histogram` is not an ST_SeriesLayout enumeration.
     // Normalize the semantic family here so raw observations cannot reach the
     // ordinary clustered-column renderer.
-    let chartex_histogram_binning = (layout_id == "clusteredColumn")
+    let chartex_histogram_binning = (pareto_series_node.is_none()
+        && layout_id == "clusteredColumn")
         .then(|| parse_chartex_histogram_binning(series_node))
         .flatten();
-    let chart_type = if chartex_histogram_binning.is_some() {
+    let chart_type = if pareto_series_node.is_some() {
+        "pareto".to_string()
+    } else if chartex_histogram_binning.is_some() {
         "histogram".to_string()
     } else {
         layout_id
@@ -3662,27 +3685,29 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         .unwrap_or_else(|| vec![None; pt_count]);
     let source_number_format = chartex_number_format(primary_data, &["size", "val"], references);
 
-    let series_name = series_node
-        .descendants()
-        .find(|node| node.is_element() && node.tag_name().name() == "txData")
-        .and_then(|tx_data| {
-            child(tx_data, "v")
-                .and_then(|value| value.text())
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(ToOwned::to_owned)
-                .or_else(|| {
-                    child(tx_data, "f")
-                        .and_then(|formula| formula.text())
-                        .map(str::trim)
-                        .filter(|formula| !formula.is_empty())
-                        .and_then(|formula| references.resolve_strings(formula))
-                        .and_then(|values| {
-                            values.into_iter().find(|value| !value.trim().is_empty())
-                        })
-                })
-        })
-        .unwrap_or_default();
+    let series_name_for = |node: Node, references: &mut dyn ChartReferenceResolver| {
+        node.descendants()
+            .find(|child_node| child_node.is_element() && child_node.tag_name().name() == "txData")
+            .and_then(|tx_data| {
+                child(tx_data, "v")
+                    .and_then(|value| value.text())
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned)
+                    .or_else(|| {
+                        child(tx_data, "f")
+                            .and_then(|formula| formula.text())
+                            .map(str::trim)
+                            .filter(|formula| !formula.is_empty())
+                            .and_then(|formula| references.resolve_strings(formula))
+                            .and_then(|values| {
+                                values.into_iter().find(|value| !value.trim().is_empty())
+                            })
+                    })
+            })
+            .unwrap_or_default()
+    };
+    let series_name = series_name_for(series_node, references);
 
     // `<cx:subtotals><cx:idx val>` identifies only points explicitly marked as
     // totals. The first waterfall point starts at zero geometrically, but it is
@@ -3768,6 +3793,52 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         line_hidden,
     }];
 
+    // Preserve the authored Pareto line as a style carrier. Its cached values
+    // are retained on the wire for diagnostics, while the core derives stable
+    // cumulative fractions from the owner values so invalid/negative filtering
+    // and source-identity remapping happen exactly once.
+    if let Some(pareto_node) = pareto_series_node {
+        let pareto_data = data_for_series(pareto_node);
+        let pareto_values = pareto_data
+            .and_then(|data| chartex_number_values(data, &["val"], references))
+            .unwrap_or_default();
+        let pareto_color =
+            child(pareto_node, "spPr").and_then(|shape| resolver.resolve_shape_fill(shape));
+        let (pareto_line_color, pareto_line_width_emu, pareto_line_no_fill) =
+            extract_sp_pr_ln_style(pareto_node, resolver);
+        let pareto_chartex_style = child(pareto_node, "spPr")
+            .map(|_| parse_chartex_element_style(pareto_node, resolver, None, None));
+        let mut pareto_series = series[0].clone();
+        pareto_series.name = series_name_for(pareto_node, references);
+        pareto_series.chartex_format_idx = Some(series_format_index(pareto_node));
+        pareto_series.values = pareto_values;
+        pareto_series.categories = None;
+        pareto_series.color = pareto_line_color.clone().or(pareto_color);
+        pareto_series.chartex_style = pareto_chartex_style;
+        pareto_series.line_color = pareto_line_color;
+        pareto_series.line_width_emu = pareto_line_width_emu;
+        pareto_series.line_hidden = if pareto_line_no_fill {
+            Some(true)
+        } else if pareto_series.line_color.is_some() || pareto_series.line_width_emu.is_some() {
+            Some(false)
+        } else {
+            None
+        };
+        pareto_series.series_type = Some("line".to_string());
+        pareto_series.use_secondary_axis = Some(true);
+        pareto_series.show_marker = Some(false);
+        pareto_series.data_point_overrides = {
+            let overrides = parse_chartex_data_point_overrides(pareto_node, resolver);
+            (!overrides.is_empty()).then_some(overrides)
+        };
+        let (label_colors, label_overrides, label_defaults) =
+            parse_chartex_series_labels(pareto_node, pareto_series.values.len(), resolver);
+        pareto_series.data_label_colors = label_colors;
+        pareto_series.data_label_overrides = label_overrides;
+        pareto_series.series_data_labels = label_defaults;
+        series.push(pareto_series);
+    }
+
     // A flat clustered-column ChartEx plot may contain several CT_Series, each
     // selecting its own CT_Data through dataId. Preserve every visible series
     // rather than silently collapsing the plot to the first one.
@@ -3786,27 +3857,7 @@ pub fn parse_chartex_part_with_references_and_style_parts(
             let extra_categories = chartex_string_levels(extra_data, references)
                 .and_then(|levels| levels.into_iter().next())
                 .unwrap_or_default();
-            let extra_name = extra_node
-                .descendants()
-                .find(|node| node.is_element() && node.tag_name().name() == "txData")
-                .and_then(|tx_data| {
-                    child(tx_data, "v")
-                        .and_then(|value| value.text())
-                        .map(str::trim)
-                        .filter(|value| !value.is_empty())
-                        .map(ToOwned::to_owned)
-                        .or_else(|| {
-                            child(tx_data, "f")
-                                .and_then(|formula| formula.text())
-                                .map(str::trim)
-                                .filter(|formula| !formula.is_empty())
-                                .and_then(|formula| references.resolve_strings(formula))
-                                .and_then(|values| {
-                                    values.into_iter().find(|value| !value.trim().is_empty())
-                                })
-                        })
-                })
-                .unwrap_or_default();
+            let extra_name = series_name_for(extra_node, references);
             let extra_color =
                 child(extra_node, "spPr").and_then(|shape| resolver.resolve_shape_fill(shape));
             let (extra_line_color, extra_line_width_emu, extra_line_no_fill) =
@@ -10436,7 +10487,7 @@ mod tests {
                     <cx:dataLabelHidden idx="1"/>
                   </cx:dataLabels><cx:dataId val="2"/>
                 </cx:series>
-                <cx:series layoutId="paretoLine" ownerIdx="0"><cx:dataId val="3"/></cx:series>
+                <cx:series layoutId="paretoLine" ownerIdx="99"><cx:dataId val="3"/></cx:series>
               </cx:plotAreaRegion></cx:plotArea></cx:chart>
             </cx:chartSpace>"#
         );
@@ -10489,6 +10540,88 @@ mod tests {
         assert_eq!(hidden_point.idx, 1);
         assert_eq!(hidden_point.fill_hidden, Some(true));
         assert_eq!(hidden_point.line_hidden, Some(true));
+    }
+
+    #[test]
+    fn parse_chartex_invalid_pareto_owners_remain_bounded() {
+        let ordinary_series = (0..512)
+            .map(|_| r#"<cx:series layoutId="clusteredColumn"><cx:dataId val="0"/></cx:series>"#)
+            .collect::<String>();
+        let invalid_pareto_series = (0..512)
+            .map(|_| {
+                r#"<cx:series layoutId="paretoLine" ownerIdx="999999"><cx:dataId val="0"/></cx:series>"#
+            })
+            .collect::<String>();
+        let xml = format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}">
+              <cx:chartData><cx:data id="0">
+                <cx:strDim type="cat"><cx:lvl ptCount="1"><cx:pt idx="0">A</cx:pt></cx:lvl></cx:strDim>
+                <cx:numDim type="val"><cx:lvl ptCount="1"><cx:pt idx="0">1</cx:pt></cx:lvl></cx:numDim>
+              </cx:data></cx:chartData>
+              <cx:chart><cx:plotArea><cx:plotAreaRegion>
+                {ordinary_series}{invalid_pareto_series}
+              </cx:plotAreaRegion></cx:plotArea></cx:chart>
+            </cx:chartSpace>"#
+        );
+        let document = chart_space_of(&xml);
+        let model = parse_chartex_part(document.root_element(), &FixtureResolver, None)
+            .expect("ordinary series remain selectable");
+
+        assert_eq!(model.chart_type, "clusteredColumn");
+        assert_eq!(model.series.len(), 512);
+    }
+
+    #[test]
+    fn parse_chartex_pareto_line_keeps_its_owner_and_direct_line_style() {
+        let xml = format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}" xmlns:a="{A_NS}">
+              <cx:chartData>
+                <cx:data id="0">
+                  <cx:strDim type="cat"><cx:lvl ptCount="3">
+                    <cx:pt idx="0">Five</cx:pt><cx:pt idx="1">Twenty</cx:pt><cx:pt idx="2">Ten</cx:pt>
+                  </cx:lvl></cx:strDim>
+                  <cx:numDim type="val"><cx:lvl ptCount="3">
+                    <cx:pt idx="0">5</cx:pt><cx:pt idx="1">20</cx:pt><cx:pt idx="2">10</cx:pt>
+                  </cx:lvl></cx:numDim>
+                </cx:data>
+                <cx:data id="1"><cx:numDim type="val"><cx:lvl ptCount="3">
+                  <cx:pt idx="0">0.142857</cx:pt><cx:pt idx="1">0.714286</cx:pt><cx:pt idx="2">1</cx:pt>
+                </cx:lvl></cx:numDim></cx:data>
+              </cx:chartData>
+              <cx:chart><cx:plotArea><cx:plotAreaRegion>
+                <cx:series layoutId="waterfall" hidden="1" formatIdx="1"/>
+                <cx:series layoutId="clusteredColumn" formatIdx="7">
+                  <cx:tx><cx:txData><cx:v>Frequency</cx:v></cx:txData></cx:tx>
+                  <cx:dataPt idx="1"><cx:spPr><a:solidFill><a:srgbClr val="00AA00"/></a:solidFill></cx:spPr></cx:dataPt>
+                  <cx:dataId val="0"/>
+                </cx:series>
+                <cx:series layoutId="paretoLine" ownerIdx="1" formatIdx="8">
+                  <cx:tx><cx:txData><cx:v>Cumulative %</cx:v></cx:txData></cx:tx>
+                  <cx:spPr><a:ln w="25400"><a:solidFill><a:srgbClr val="333333"/></a:solidFill></a:ln></cx:spPr>
+                  <cx:dataId val="1"/>
+                </cx:series>
+              </cx:plotAreaRegion></cx:plotArea></cx:chart>
+            </cx:chartSpace>"#
+        );
+        let document = chart_space_of(&xml);
+        let model = parse_chartex_part(document.root_element(), &FixtureResolver, None)
+            .expect("owner-backed Pareto parse");
+
+        assert_eq!(model.chart_type, "pareto");
+        assert_eq!(model.categories, vec!["Five", "Twenty", "Ten"]);
+        assert_eq!(model.series.len(), 2);
+        assert_eq!(model.series[0].name, "Frequency");
+        assert_eq!(model.series[0].chartex_format_idx, Some(7));
+        assert_eq!(
+            model.series[0].values,
+            vec![Some(5.0), Some(20.0), Some(10.0)]
+        );
+        assert_eq!(model.series[1].name, "Cumulative %");
+        assert_eq!(model.series[1].chartex_format_idx, Some(8));
+        assert_eq!(model.series[1].series_type.as_deref(), Some("line"));
+        assert_eq!(model.series[1].use_secondary_axis, Some(true));
+        assert_eq!(model.series[1].color.as_deref(), Some("333333"));
+        assert_eq!(model.series[1].line_width_emu, Some(25400));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- resolve ChartEx Pareto owner series by bounded document-order index lookup
- sort finite nonnegative frequencies stably while preserving category and point-format identity
- render the cumulative overlay with authored line-style precedence and bounded point counts
- harden waterfall values, labels, connectors, and cumulative arithmetic at non-finite boundaries

## Verification
- 342 focused core chart tests
- 365 ooxml-common tests plus doctest
- TypeScript 7 project build
- full XLSX private self-regression VRT against the merge-base: 19/19 documents exact
- independent adversarial review

Closes #1233