### PR TITLE
fix(chart): place automatic trendline labels

### DIFF
--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -4446,6 +4446,148 @@ describe('CH6-follow — series trendlines (commit 3)', () => {
     expect(hidden.segs).toEqual(without.segs);
   });
 
+  it('places equation and R² at the same bounded automatic anchor for either slope sign', () => {
+    const renderLabels = (values: number[]) => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, lineWithTrend({
+        values,
+        trendLines: [{ trendlineType: 'linear', dispEq: true, dispRSqr: true }],
+      }), RECT, 1);
+      return rec.texts.filter(text => text.text.startsWith('y = ') || text.text.startsWith('R² = '));
+    };
+    const positive = renderLabels([1, 3, 5, 7]);
+    const negative = renderLabels([7, 5, 3, 1]);
+    expect(positive[0].x + (positive[0].width ?? 0)).toBe(
+      negative[0].x + (negative[0].width ?? 0),
+    );
+    expect(positive.map(text => text.y)).toEqual(negative.map(text => text.y));
+    expect(positive.map(text => text.text)).toEqual(['y = 2x + 1', 'R² = 1']);
+    expect(positive).toHaveLength(2);
+    for (const text of positive) {
+      expect(text.x).toBeGreaterThanOrEqual(RECT.x);
+      expect(text.x + (text.width ?? 0)).toBeLessThanOrEqual(RECT.x + RECT.w);
+      expect(text.y).toBeGreaterThanOrEqual(RECT.y);
+      expect(text.y).toBeLessThanOrEqual(RECT.y + RECT.h);
+    }
+  });
+
+  it('honors trendline-label manual layout and text properties independently of line paint', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, lineWithTrend({
+      trendLines: [{
+        trendlineType: 'linear',
+        lineHidden: true,
+        dispEq: true,
+        labelText: 'Authored fit',
+        labelFontSizeHpt: 1800,
+        labelFontBold: true,
+        labelFontColor: '123456',
+        labelFontFace: 'Georgia',
+        labelTextAlign: 'ctr',
+        labelManualLayout: {
+          xMode: 'edge', yMode: 'edge', wMode: 'factor', hMode: 'factor',
+          x: 0.1, y: 0.2, w: 0.25, h: 0.1,
+        },
+      }],
+    }), RECT, 1);
+    const label = rec.texts.find(text => text.text === 'Authored fit');
+    expect(label).toMatchObject({
+      x: RECT.x + RECT.w * 0.225,
+      y: RECT.y + RECT.h * 0.2,
+      align: 'center',
+      baseline: 'top',
+      fillStyle: '#123456',
+    });
+    expect(label?.font).toContain('bold 18px');
+    expect(label?.font).toContain('Georgia');
+  });
+
+  it('uses shared data-label bold and color when trendline text properties are omitted', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, {
+      ...lineWithTrend({
+        trendLines: [{ trendlineType: 'linear', labelText: 'First\nSecond' }],
+      }),
+      dataLabelFontBold: true,
+      dataLabelFontColor: 'FF0000',
+    }, RECT, 1);
+    const labels = rec.texts.filter(text => text.text === 'First' || text.text === 'Second');
+    expect(labels.map(label => label.text)).toEqual(['First', 'Second']);
+    expect(labels.every(label => label.font?.includes('bold'))).toBe(true);
+    expect(labels.every(label => label.fillStyle === '#FF0000')).toBe(true);
+  });
+
+  it.each([
+    { flags: { dispEq: true }, expected: ['y = 2x + 1'] },
+    { flags: { dispRSqr: true }, expected: ['R² = 1'] },
+  ])('renders $expected without coupling text calculation to placement', ({ flags, expected }) => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, lineWithTrend({
+      trendLines: [{ trendlineType: 'linear', ...flags }],
+    }), RECT, 1);
+    expect(rec.texts.map(text => text.text).filter(text => text.startsWith('y =') || text.startsWith('R²')))
+      .toEqual(expected);
+  });
+
+  it('uses the same top-right edge for near-flat and steep linear fits', () => {
+    const rightEdge = (values: number[]): number => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, lineWithTrend({
+        values,
+        trendLines: [{ trendlineType: 'linear', dispEq: true }],
+      }), RECT, 1);
+      const label = rec.texts.find(text => text.text.startsWith('y = '));
+      return (label?.x ?? 0) + (label?.width ?? 0);
+    };
+    expect(rightEdge([1, 1.01, 1.02, 1.03])).toBe(rightEdge([1, 51, 101, 151]));
+  });
+
+  it('does not send overflowed regression coordinates or labels to Canvas', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, {
+      ...lineWithTrend({
+        values: [Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE],
+        trendLines: [{ trendlineType: 'linear', dispEq: true, dispRSqr: true }],
+      }),
+      valMin: 0,
+      valMax: 10,
+    }, RECT, 1);
+    expect(rec.texts.map(text => text.text).join(' ')).not.toMatch(/NaN|Infinity/);
+    expect(rec.texts.some(text => text.text.startsWith('y = ') || text.text.startsWith('R² = ')))
+      .toBe(false);
+  });
+
+  it('rejects non-finite trendline geometry after finite forward extension', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, lineWithTrend({
+      trendLines: [{
+        trendlineType: 'linear',
+        forward: Number.MAX_VALUE,
+        dispEq: true,
+      }],
+    }), RECT, 1);
+    expect(rec.texts.map(text => text.text).join(' ')).not.toMatch(/NaN|Infinity/);
+    expect(rec.texts.some(text => text.text.startsWith('y = '))).toBe(false);
+  });
+
+  it('renders a scatter trendline label through the shared plot-aware path', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'scatter',
+      categories: [],
+      series: [series({
+        categories: ['0', '1', '2', '3'],
+        values: [1, 3, 5, 7],
+        trendLines: [{ trendlineType: 'linear', dispEq: true }],
+      })],
+      catAxisMin: 0,
+      catAxisMax: 3,
+      valMin: 0,
+      valMax: 8,
+    }), RECT, 1);
+    expect(rec.texts.some(text => text.text === 'y = 2x + 1')).toBe(true);
+  });
+
   it('applies the authored major-gridline dash without leaking it to other strokes', () => {
     const rec = dashSegRecordingCtx();
     renderChart(rec.ctx, baseModel({

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -3,7 +3,7 @@
 // scatter, waterfall). Ported from the xlsx implementation with pptx
 // extensions (valMin-aware axis, plotAreaBg, dataPointColors, waterfall).
 
-import type { ChartDataLabelOverride, ChartModel, ChartRect, ChartSeries, ChartSeriesDataLabels, ChartTextBox, SecondaryValueAxis } from '../types/chart';
+import type { ChartDataLabelOverride, ChartModel, ChartRect, ChartSeries, ChartSeriesDataLabels, ChartTextBox, ChartTrendline, SecondaryValueAxis } from '../types/chart';
 import type { Fill } from '../types/common';
 import {
   AXIS_OUTER_TEXT_MARGIN_PT,
@@ -21,7 +21,7 @@ import {
   valueTickLabelGapPx,
   type ChartLegendReserve,
 } from './layout.js';
-import { niceStep, valueAxisScale, axisFraction, logAxisScale, fitTrendline } from './axis-scale.js';
+import { niceStep, valueAxisScale, axisFraction, logAxisScale, fitTrendline, linearTrendlineStats } from './axis-scale.js';
 import { axisLineWidthPx, resolveAxisLine, resolveGridline, isCrossBetween } from './axis-style.js';
 import { formatChartVal, formatChartValWithCode, formatCategoryLabel } from './chart-number-format.js';
 import { elideToWidth } from './text-elide.js';
@@ -36,6 +36,7 @@ import {
   computeBoxWhiskerStats,
 } from './box-whisker.js';
 import { planParetoLayout } from './pareto-layout.js';
+import { placeTrendlineLabel } from './trendline-label.js';
 import { hexToRgba, resolveFill } from '../shape/paint.js';
 import {
   DEFAULT_TEXT_INSET_LR_EMU,
@@ -1037,6 +1038,90 @@ function planValueAxis(
   };
 }
 
+interface TrendlineLabelContext {
+  chart: ChartModel;
+  chartRect: ChartRect;
+  plotRect: ChartRect;
+  clipLineToPlot?: boolean;
+}
+
+function compactTrendlineNumber(value: number): string {
+  return formatChartVal(Number(value.toPrecision(6)));
+}
+
+function generatedTrendlineLabel(
+  tl: ChartTrendline,
+  stats: ReturnType<typeof linearTrendlineStats>,
+): string[] {
+  if (tl.labelText) return tl.labelText.split(/\r?\n/);
+  if (!stats) return [];
+  const lines: string[] = [];
+  if (tl.dispEq) {
+    const sign = stats.intercept < 0 ? '−' : '+';
+    lines.push(
+      `y = ${compactTrendlineNumber(stats.slope)}x ${sign} ${compactTrendlineNumber(Math.abs(stats.intercept))}`,
+    );
+  }
+  if (tl.dispRSqr) lines.push(`R² = ${compactTrendlineNumber(stats.rSquared)}`);
+  return lines;
+}
+
+function drawTrendlineLabel(
+  ctx: CanvasRenderingContext2D,
+  tl: ChartTrendline,
+  stats: ReturnType<typeof linearTrendlineStats>,
+  ptToPx: number,
+  labelContext?: TrendlineLabelContext,
+): void {
+  if (!labelContext) return;
+  const lines = generatedTrendlineLabel(tl, stats);
+  if (lines.length === 0) return;
+  const { chart, chartRect, plotRect } = labelContext;
+  const fontPx = tl.labelFontSizeHpt != null
+    ? (tl.labelFontSizeHpt / 100) * ptToPx
+    : chart.dataLabelFontSizeHpt != null
+      ? (chart.dataLabelFontSizeHpt / 100) * ptToPx
+      : 10 * ptToPx;
+  const face = chartFontFamily(chart, tl.labelFontFace ?? chart.dataLabelFontFace, 'minor');
+  const bold = tl.labelFontBold ?? chart.dataLabelFontBold ?? false;
+  ctx.font = `${bold ? 'bold ' : ''}${fontPx}px ${face}`;
+  const lineHeight = fontPx * 1.2;
+  const naturalWidth = Math.max(...lines.map(line => ctx.measureText(line).width));
+  const placement = placeTrendlineLabel(
+    chartRect,
+    plotRect,
+    naturalWidth,
+    lines.length * lineHeight,
+    fontPx,
+    tl.labelManualLayout,
+  );
+  if (!placement) return;
+
+  ctx.save();
+  if (placement.automatic) {
+    ctx.beginPath();
+    ctx.rect(plotRect.x, plotRect.y, plotRect.w, plotRect.h);
+    ctx.clip();
+  }
+  const alignment = tl.labelTextAlign;
+  ctx.textAlign = alignment === 'r' ? 'right' : alignment === 'ctr' ? 'center' : 'left';
+  ctx.textBaseline = 'top';
+  const color = tl.labelFontColor ?? chart.dataLabelFontColor;
+  ctx.fillStyle = color ? `#${color}` : '#595959';
+  const textX = ctx.textAlign === 'right'
+    ? placement.x + placement.w
+    : ctx.textAlign === 'center'
+      ? placement.x + placement.w / 2
+      : placement.x;
+  const completeLines = placement.automatic
+    ? lines.length
+    : Math.min(lines.length, Math.floor(placement.h / lineHeight));
+  for (let index = 0; index < completeLines; index++) {
+    ctx.fillText(elideToWidth(ctx, lines[index], placement.w), textX, placement.y + index * lineHeight);
+  }
+  ctx.restore();
+}
+
 /** Draw a series' `<c:trendline>` regression lines (ECMA-376 §21.2.2.211).
  *  Each trendline is fitted over the series' non-null `(categoryIndex, value)`
  *  points via {@link fitTrendline} and stroked through the chart's
@@ -1053,6 +1138,7 @@ function drawSeriesTrendlines(
   toY: (v: number) => number,
   ptToPx: number,
   xValues?: readonly (number | null)[],
+  labelContext?: TrendlineLabelContext,
 ): void {
   const tls = s.trendLines;
   if (!tls || tls.length === 0) return;
@@ -1061,16 +1147,29 @@ function drawSeriesTrendlines(
   for (let i = 0; i < s.values.length; i++) {
     const v = s.values[i];
     const x = xValues ? xValues[i] : i;
-    if (v != null && x != null) { xs.push(x); ys.push(v); }
+    if (v != null && x != null && Number.isFinite(v) && Number.isFinite(x)) {
+      xs.push(x);
+      ys.push(v);
+    }
   }
   if (xs.length < 2) return;
   const prevDash = ctx.getLineDash ? ctx.getLineDash() : [];
   for (const tl of tls) {
-    if (tl.lineHidden) continue;
     const fit = fitTrendline(xs, ys, tl.trendlineType, {
       period: tl.period, intercept: tl.intercept,
     });
     if (fit.xs.length < 2) continue;
+    if (![...fit.xs, ...fit.ys].every(Number.isFinite)) continue;
+    const candidateStats = tl.trendlineType === 'linear'
+      ? linearTrendlineStats(xs, ys, tl.intercept)
+      : null;
+    const stats = candidateStats && [
+      candidateStats.slope,
+      candidateStats.intercept,
+      candidateStats.rSquared,
+    ].every(Number.isFinite)
+      ? candidateStats
+      : null;
     // For a linear fit, forward/backward extend the two endpoints along the
     // fitted slope (in category-index units).
     let fxs = fit.xs; let fys = fit.ys;
@@ -1081,20 +1180,37 @@ function drawSeriesTrendlines(
       fxs = [x0, x1];
       fys = [fit.ys[0] - m * bwd, fit.ys[1] + m * fwd];
     }
-    ctx.strokeStyle = tl.lineColor ? `#${tl.lineColor}` : seriesColor;
-    ctx.lineWidth = tl.lineWidthEmu ? axisLineWidthPx(tl.lineWidthEmu, ptToPx) : 1.5;
-    // DrawingML line presets are authored paint; omission means solid.
-    ctx.setLineDash(dashPatternForPreset(tl.lineDash ?? undefined));
-    ctx.beginPath();
-    for (let i = 0; i < fxs.length; i++) {
-      const px = toX(fxs[i]); const py = toY(fys[i]);
-      if (i === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
+    if (![...fxs, ...fys].every(Number.isFinite)) continue;
+    if (!tl.lineHidden) {
+      if (labelContext?.clipLineToPlot) {
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(
+          labelContext.plotRect.x,
+          labelContext.plotRect.y,
+          labelContext.plotRect.w,
+          labelContext.plotRect.h,
+        );
+        ctx.clip();
+      }
+      ctx.strokeStyle = tl.lineColor ? `#${tl.lineColor}` : seriesColor;
+      ctx.lineWidth = tl.lineWidthEmu ? axisLineWidthPx(tl.lineWidthEmu, ptToPx) : 1.5;
+      // DrawingML line presets are authored paint; omission means solid.
+      ctx.setLineDash(dashPatternForPreset(tl.lineDash ?? undefined));
+      ctx.beginPath();
+      const mapped = fxs.map((x, index) => ({ x: toX(x), y: toY(fys[index]) }));
+      if (!mapped.every(point => Number.isFinite(point.x) && Number.isFinite(point.y))) {
+        if (labelContext?.clipLineToPlot) ctx.restore();
+        continue;
+      }
+      for (let i = 0; i < mapped.length; i++) {
+        const { x: px, y: py } = mapped[i];
+        if (i === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
+      }
+      ctx.stroke();
+      if (labelContext?.clipLineToPlot) ctx.restore();
     }
-    ctx.stroke();
-
-    // `<c:dispEq>` / `<c:dispRSqr>` control a trendline-label object whose
-    // omitted layout is application-defined. Do not invent an anchor here;
-    // authored label layout is tracked separately from rendering the line.
+    drawTrendlineLabel(ctx, tl, stats, ptToPx, labelContext);
   }
   ctx.setLineDash(prevDash);
 }
@@ -2416,7 +2532,12 @@ function renderBarChart(
         }
       }
       // Trendlines (`<c:trendline>`, §21.2.2.211) for the combo line series.
-      drawSeriesTrendlines(ctx, s, color, (i) => px0 + categorySlotIndex(i) * catGap + catGap / 2, yOf, ptToPx);
+      drawSeriesTrendlines(
+        ctx, s, color,
+        (i) => px0 + categorySlotIndex(i) * catGap + catGap / 2,
+        yOf, ptToPx, undefined,
+        { chart, chartRect: r, plotRect: { x: px0, y: py0, w: pw, h: ph } },
+      );
     }
   }
 
@@ -2460,6 +2581,9 @@ function renderBarChart(
         false,
         scatterToX,
         scatterToY,
+        r,
+        px0,
+        py0,
         pw,
         ph,
         ptToPx,
@@ -2935,7 +3059,10 @@ function renderLineChart(
     // Trendlines (`<c:trendline>`, §21.2.2.211) over this series' points —
     // drawn on top of the line/markers, dashed, in the series color unless the
     // trendline declares its own `<a:ln>`.
-    drawSeriesTrendlines(ctx, s, color, toX, yOf, ptToPx);
+    drawSeriesTrendlines(
+      ctx, s, color, toX, yOf, ptToPx, undefined,
+      { chart, chartRect: r, plotRect: { x: px0, y: py0, w: pw, h: ph } },
+    );
   }
 
   if (!chart.catAxisHidden) {
@@ -3693,7 +3820,10 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       ctx, s, cats, n, toX, yOf, plottedOf, ph, ptToPx, chart.date1904 ?? false, false,
       chartFontFamily(chart, chart.dataLabelFontFace, 'minor'), chart.dataLabelPosition ?? 'r',
     );
-    drawSeriesTrendlines(ctx, s, stroke, toX, yOf, ptToPx);
+    drawSeriesTrendlines(
+      ctx, s, stroke, toX, yOf, ptToPx, undefined,
+      { chart, chartRect: r, plotRect: { x: px0, y: py0, w: pw, h: ph } },
+    );
   }
 
   // Value-axis tick marks + labels. The gridlines themselves were already laid
@@ -4817,6 +4947,9 @@ function drawScatterSeriesLayer(
   useIndexX: boolean,
   toX: (value: number) => number,
   toY: (value: number) => number,
+  chartRect: ChartRect,
+  px0: number,
+  py0: number,
   pw: number,
   ph: number,
   ptToPx: number,
@@ -4933,7 +5066,10 @@ function drawScatterSeriesLayer(
 
   for (const { series: s, fallbackColor, cats } of layers) {
     const trendlineX = s.values.map((_, index) => scatterXValue(cats, index, useIndexX));
-    drawSeriesTrendlines(ctx, s, fallbackColor, toX, toY, ptToPx, trendlineX);
+    drawSeriesTrendlines(
+      ctx, s, fallbackColor, toX, toY, ptToPx, trendlineX,
+      { chart, chartRect, plotRect: { x: px0, y: py0, w: pw, h: ph } },
+    );
   }
 }
 
@@ -5347,12 +5483,15 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
 
     if (s.trendLines && s.trendLines.length > 0) {
       const trendlineX = s.values.map((_, index) => scatterXValue(cats, index, useIndexX));
-      ctx.save();
-      ctx.beginPath();
-      ctx.rect(px0, py0, pw, ph);
-      ctx.clip();
-      drawSeriesTrendlines(ctx, s, fallbackColor, toX, toY, ptToPx, trendlineX);
-      ctx.restore();
+      drawSeriesTrendlines(
+        ctx, s, fallbackColor, toX, toY, ptToPx, trendlineX,
+        {
+          chart,
+          chartRect: r,
+          plotRect: { x: px0, y: py0, w: pw, h: ph },
+          clipLineToPlot: true,
+        },
+      );
     }
   }
 

--- a/packages/core/src/chart/trendline-label.test.ts
+++ b/packages/core/src/chart/trendline-label.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { placeTrendlineLabel } from './trendline-label.js';
+
+const CHART = { x: 0, y: 0, w: 400, h: 300 };
+const PLOT = { x: 50, y: 40, w: 300, h: 200 };
+
+describe('automatic trendline label placement', () => {
+  it('uses one measured top-right inset independent of slope or chart family', () => {
+    expect(placeTrendlineLabel(CHART, PLOT, 90, 30, 10)).toEqual({
+      x: 255, y: 45, w: 90, h: 30, automatic: true,
+    });
+  });
+
+  it('bounds an over-wide and over-tall block to the plot', () => {
+    expect(placeTrendlineLabel(CHART, PLOT, 900, 900, 12)).toEqual({
+      x: 56, y: 40, w: 288, h: 200, automatic: true,
+    });
+  });
+
+  it('keeps a positive clipped block when the plot is shorter than one line', () => {
+    expect(placeTrendlineLabel(CHART, { x: 20, y: 30, w: 100, h: 5 }, 60, 24, 10))
+      .toEqual({ x: 55, y: 30, w: 60, h: 5, automatic: true });
+  });
+
+  it('lets a valid authored manual layout bypass the automatic anchor', () => {
+    expect(placeTrendlineLabel(CHART, PLOT, 90, 30, 10, {
+      xMode: 'edge', yMode: 'edge', wMode: 'factor', hMode: 'factor',
+      x: 0.1, y: 0.2, w: 0.25, h: 0.1,
+    })).toEqual({ x: 40, y: 60, w: 100, h: 30, automatic: false });
+  });
+
+  it.each([
+    { x: 10, y: 20, w: 600, h: 120 },
+    { x: 10, y: 20, w: 120, h: 600 },
+    { x: 10, y: 20, w: 240, h: 240 },
+  ])('uses the same top-right rule for $w by $h plots', plot => {
+    const placed = placeTrendlineLabel(CHART, plot, 80, 24, 10);
+    expect(placed?.automatic).toBe(true);
+    expect((placed?.x ?? 0) + (placed?.w ?? 0)).toBe(plot.x + plot.w - 5);
+    expect(placed?.y).toBe(plot.y + 5);
+  });
+});

--- a/packages/core/src/chart/trendline-label.ts
+++ b/packages/core/src/chart/trendline-label.ts
@@ -1,0 +1,42 @@
+import type { ChartManualLayout } from '../types/chart';
+import { resolveManualLayoutRect, type ManualLayoutRect } from './layout.js';
+
+export interface TrendlineLabelPlacement {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  automatic: boolean;
+}
+
+/**
+ * Resolve one measured trendline-label block.
+ *
+ * Automatic labels use one shared top-right plot anchor. A valid authored
+ * manual layout is resolved against chart space and bypasses that anchor.
+ */
+export function placeTrendlineLabel(
+  chartRect: ManualLayoutRect,
+  plotRect: ManualLayoutRect,
+  measuredWidth: number,
+  measuredHeight: number,
+  fontPx: number,
+  manual?: ChartManualLayout | null,
+): TrendlineLabelPlacement | null {
+  if (![measuredWidth, measuredHeight, fontPx].every(Number.isFinite) ||
+      measuredWidth <= 0 || measuredHeight <= 0 || plotRect.w <= 0 || plotRect.h <= 0) return null;
+  const inset = Math.max(4, fontPx * 0.5);
+  const w = Math.min(measuredWidth, Math.max(0, plotRect.w - inset * 2));
+  const h = Math.min(measuredHeight, plotRect.h);
+  const automatic = {
+    x: Math.max(plotRect.x, plotRect.x + plotRect.w - inset - w),
+    y: Math.min(plotRect.y + plotRect.h - h, plotRect.y + inset),
+    w,
+    h,
+  };
+  if (manual) {
+    const resolved = resolveManualLayoutRect(manual, chartRect, automatic);
+    if (resolved) return { ...resolved, automatic: false };
+  }
+  return { ...automatic, automatic: true };
+}

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -188,10 +188,21 @@ export interface ChartTrendline {
   backward?: number | null;
   /** `<c:intercept val>` — forced y-intercept (linear/exp). null = free fit. */
   intercept?: number | null;
-  /** `<c:dispRSqr val="1">` — show the R² value (label; not yet rendered). */
+  /** `<c:dispRSqr val="1">` — show the R² value. */
   dispRSqr?: boolean | null;
-  /** `<c:dispEq val="1">` — show the fit equation (label; not yet rendered). */
+  /** `<c:dispEq val="1">` — show the fit equation. */
   dispEq?: boolean | null;
+  /** `<c:trendlineLbl><c:layout><c:manualLayout>` authored label placement. */
+  labelManualLayout?: ChartManualLayout | null;
+  /** Explicit `<c:trendlineLbl><c:tx>` text, when present. */
+  labelText?: string | null;
+  /** Trendline-label `<c:txPr>` run properties. */
+  labelFontSizeHpt?: number | null;
+  labelFontBold?: boolean | null;
+  labelFontColor?: string | null;
+  labelFontFace?: string | null;
+  /** First authored paragraph alignment from `<c:trendlineLbl><c:txPr>`. */
+  labelTextAlign?: string | null;
   /** `<c:spPr><a:ln><a:solidFill>` trendline color (hex without '#'). null =
    *  inherit the series color. */
   lineColor?: string | null;

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -404,6 +404,13 @@ export interface ChartTrendline {
     intercept?: number | null;
     dispRSqr?: boolean | null;
     dispEq?: boolean | null;
+    labelManualLayout?: ChartManualLayout | null;
+    labelText?: string | null;
+    labelFontSizeHpt?: number | null;
+    labelFontBold?: boolean | null;
+    labelFontColor?: string | null;
+    labelFontFace?: string | null;
+    labelTextAlign?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -689,6 +689,20 @@ pub struct ChartTrendline {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disp_eq: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label_manual_layout: Option<ChartManualLayout>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label_text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label_font_size_hpt: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label_font_bold: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label_font_color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label_font_face: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label_text_align: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_width_emu: Option<u32>,
@@ -2170,14 +2184,23 @@ fn bool_child(parent: Node, name: &str) -> Option<bool> {
 /// `<c:ser><c:trendline>` (ECMA-376 §21.2.2.211, `CT_Trendline`) — every
 /// trendline declared on `ser_node` (0..N). Each carries a required
 /// `<c:trendlineType>` plus optional order/period/forward/backward/intercept,
-/// the `<c:dispRSqr>` / `<c:dispEq>` label flags, and an `<c:spPr><a:ln>` line
-/// style (color resolved via `resolver`, width in EMU). Returns `None` when the
-/// series declares no trendline (byte-stable); otherwise the parsed vec. Shared
-/// so pptx and xlsx honor trendlines identically.
+/// the `<c:dispRSqr>` / `<c:dispEq>` label flags, optional
+/// `<c:trendlineLbl>` layout/text properties, and an `<c:spPr><a:ln>` line style
+/// (color resolved via `resolver`, width in EMU). Returns `None` when the series
+/// declares no trendline (byte-stable); otherwise the parsed vec. Shared so pptx
+/// and xlsx honor trendlines identically.
 pub fn extract_series_trendlines(
     ser_node: Node,
     resolver: &dyn ColorResolver,
 ) -> Option<Vec<ChartTrendline>> {
+    fn first_named_descendant<'a, 'input>(
+        container: Node<'a, 'input>,
+        name: &str,
+    ) -> Option<Node<'a, 'input>> {
+        container
+            .descendants()
+            .find(|node| node.is_element() && node.tag_name().name() == name)
+    }
     let mut out = Vec::new();
     for tl in ser_node
         .children()
@@ -2212,6 +2235,67 @@ pub fn extract_series_trendlines(
                 (color, width, dash, hidden)
             }
         };
+        let label = child(tl, "trendlineLbl");
+        let label_txpr = label.and_then(|node| child(node, "txPr"));
+        let label_tx = label.and_then(|node| child(node, "tx"));
+        let label_rich = label_tx.and_then(|tx| child(tx, "rich"));
+        let rich_run_prop = label_rich.and_then(|rich| first_named_descendant(rich, "rPr"));
+        let rich_default_prop = label_rich.and_then(|rich| first_named_descendant(rich, "defRPr"));
+        let txpr_run_prop = label_txpr.and_then(|txpr| first_named_descendant(txpr, "rPr"));
+        let txpr_default_prop = label_txpr.and_then(|txpr| first_named_descendant(txpr, "defRPr"));
+        let run_props = [
+            rich_run_prop,
+            rich_default_prop,
+            txpr_run_prop,
+            txpr_default_prop,
+        ];
+        let label_text = label_tx
+            .and_then(|tx| {
+                child(tx, "rich")
+                    .map(|rich| flatten_rich_text(rich, None))
+                    .or_else(|| {
+                        child(tx, "strRef")
+                            .and_then(|reference| child(reference, "strCache"))
+                            .map(|cache| {
+                                cache
+                                    .children()
+                                    .filter(|node| {
+                                        node.is_element() && node.tag_name().name() == "pt"
+                                    })
+                                    .filter_map(|point| child(point, "v"))
+                                    .filter_map(|value| value.text())
+                                    .collect::<Vec<_>>()
+                                    .join("\n")
+                            })
+                    })
+            })
+            .filter(|text| !text.is_empty());
+        let label_manual_layout = label
+            .and_then(|node| child(node, "layout"))
+            .and_then(extract_manual_layout);
+        let label_font_size_hpt = run_props
+            .iter()
+            .flatten()
+            .find_map(|node| attr(node, "sz").and_then(|value| value.parse::<i32>().ok()));
+        let label_font_bold = run_props
+            .iter()
+            .flatten()
+            .find_map(|node| chart_text_bool_attr(*node, "b"));
+        let label_font_color = run_props.iter().flatten().find_map(|node| {
+            child(*node, "solidFill").and_then(|fill| resolver.resolve_solid_fill(fill))
+        });
+        let label_font_face = run_props
+            .iter()
+            .flatten()
+            .find_map(|node| first_latin_typeface(*node));
+        let label_text_align = label_rich
+            .and_then(|rich| first_named_descendant(rich, "pPr"))
+            .and_then(|node| attr(&node, "algn"))
+            .or_else(|| {
+                label_txpr
+                    .and_then(|txpr| first_named_descendant(txpr, "pPr"))
+                    .and_then(|node| attr(&node, "algn"))
+            });
         out.push(ChartTrendline {
             trendline_type: trendline_type.to_string(),
             order: u32_val("order"),
@@ -2221,6 +2305,13 @@ pub fn extract_series_trendlines(
             intercept: f64_val("intercept"),
             disp_r_sqr: bool_child(tl, "dispRSqr"),
             disp_eq: bool_child(tl, "dispEq"),
+            label_manual_layout,
+            label_text,
+            label_font_size_hpt,
+            label_font_bold,
+            label_font_color,
+            label_font_face,
+            label_text_align,
             line_color,
             line_width_emu,
             line_dash,
@@ -8151,27 +8242,51 @@ mod tests {
                    <c:trendlineType val="linear"/>
                    <c:dispEq val="1"/>
                    <c:dispRSqr val="1"/>
+                   <c:trendlineLbl>
+                     <c:layout><c:manualLayout><c:xMode val="edge"/><c:yMode val="edge"/><c:x val="0.1"/><c:y val="0.2"/></c:manualLayout></c:layout>
+                     <c:tx><c:rich><a:bodyPr/><a:p><a:pPr algn="r"><a:defRPr sz="1800" b="1"><a:solidFill><a:srgbClr val="123456"/></a:solidFill><a:latin typeface="Georgia"/></a:defRPr></a:pPr><a:r><a:rPr sz="2000" b="0"><a:solidFill><a:srgbClr val="654321"/></a:solidFill></a:rPr><a:t>Authored</a:t></a:r></a:p><a:p><a:r><a:t>fit</a:t></a:r></a:p></c:rich></c:tx>
+                     <c:txPr><a:bodyPr/><a:p><a:pPr algn="ctr"><a:defRPr sz="1800" b="1"><a:solidFill><a:srgbClr val="123456"/></a:solidFill><a:latin typeface="Georgia"/></a:defRPr></a:pPr></a:p></c:txPr>
+                   </c:trendlineLbl>
                  </c:trendline>
                  <c:trendline>
                    <c:spPr><a:ln><a:noFill/></a:ln></c:spPr>
                    <c:trendlineType val="movingAvg"/>
                    <c:period val="3"/>
                  </c:trendline>
+                 <c:trendline>
+                   <c:trendlineType val="linear"/>
+                   <c:trendlineLbl><c:tx><c:strRef><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Cached fit</c:v></c:pt></c:strCache></c:strRef></c:tx></c:trendlineLbl>
+                 </c:trendline>
                </c:ser>"#
         );
         let got = extract_series_trendlines(root_of(&xml).root_element(), &StubResolver).unwrap();
-        assert_eq!(got.len(), 2);
+        assert_eq!(got.len(), 3);
         assert_eq!(got[0].trendline_type, "linear");
         assert_eq!(got[0].line_color.as_deref(), Some("FF0000"));
         assert_eq!(got[0].line_width_emu, Some(19050));
         assert_eq!(got[0].line_dash.as_deref(), Some("dash"));
         assert_eq!(got[0].disp_eq, Some(true));
         assert_eq!(got[0].disp_r_sqr, Some(true));
+        assert_eq!(got[0].label_text.as_deref(), Some("Authored\nfit"));
+        assert_eq!(got[0].label_font_size_hpt, Some(2000));
+        assert_eq!(got[0].label_font_bold, Some(false));
+        assert_eq!(got[0].label_font_color.as_deref(), Some("654321"));
+        assert_eq!(got[0].label_font_face.as_deref(), Some("Georgia"));
+        assert_eq!(got[0].label_text_align.as_deref(), Some("r"));
+        let manual = got[0]
+            .label_manual_layout
+            .as_ref()
+            .expect("trendline label manual layout");
+        assert_eq!(manual.x_mode, "edge");
+        assert_eq!(manual.y_mode, "edge");
+        assert_eq!(manual.x, 0.1);
+        assert_eq!(manual.y, 0.2);
         assert_eq!(got[1].trendline_type, "movingAvg");
         assert_eq!(got[1].period, Some(3));
         assert_eq!(got[1].line_color, None);
         assert_eq!(got[0].line_hidden, None);
         assert_eq!(got[1].line_hidden, Some(true));
+        assert_eq!(got[2].label_text.as_deref(), Some("Cached fit"));
     }
 
     // ========================================================================

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -392,6 +392,13 @@ export interface ChartTrendline {
     intercept?: number | null;
     dispRSqr?: boolean | null;
     dispEq?: boolean | null;
+    labelManualLayout?: ChartManualLayout | null;
+    labelText?: string | null;
+    labelFontSizeHpt?: number | null;
+    labelFontBold?: boolean | null;
+    labelFontColor?: string | null;
+    labelFontFace?: string | null;
+    labelTextAlign?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -492,6 +492,13 @@ export interface ChartTrendline {
     intercept?: number | null;
     dispRSqr?: boolean | null;
     dispEq?: boolean | null;
+    labelManualLayout?: ChartManualLayout | null;
+    labelText?: string | null;
+    labelFontSizeHpt?: number | null;
+    labelFontBold?: boolean | null;
+    labelFontColor?: string | null;
+    labelFontFace?: string | null;
+    labelTextAlign?: string | null;
     lineColor?: string | null;
     lineWidthEmu?: number | null;
     lineDash?: string | null;


### PR DESCRIPTION
## Summary
- preserve authored trendline label text, manual layout, and rich-text properties through the parser and model
- generate equation and R-squared text from finite linear-regression statistics
- place automatic labels consistently at the plot edge and clip them to the plot rectangle
- keep label visibility independent from the trendline stroke while preserving authored formatting precedence

## Verification
- 340 focused core chart tests
- focused ooxml-common parser test
- TypeScript 7 project build and three-package API baselines
- full private self-regression VRT against the merge-base: DOCX 47/47, PPTX 15/15, XLSX 19/19 documents exact
- repeated independent adversarial review

Closes #1235