### PR TITLE
fix(core): export histogram binning model

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export type {
   ChartTrendline,
   ChartType,
   ChartExElementStyle,
+  ChartexHistogramBinning,
   ChartexBoxSeries,
   ChartexBoxWhisker,
   ChartexSunburst,

--- a/packages/docx/src/index.ts
+++ b/packages/docx/src/index.ts
@@ -34,6 +34,7 @@ export type {
   ChartTrendline,
   ChartType,
   ChartExElementStyle,
+  ChartexHistogramBinning,
   ChartexBoxSeries,
   ChartexBoxWhisker,
   ChartexSunburst,

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -42,6 +42,7 @@ export type {
   ChartTrendline,
   ChartType,
   ChartExElementStyle,
+  ChartexHistogramBinning,
   ChartexBoxSeries,
   ChartexBoxWhisker,
   ChartexSunburst,

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -44,6 +44,7 @@ export type {
   ChartTrendline,
   ChartType,
   ChartExElementStyle,
+  ChartexHistogramBinning,
   ChartexBoxSeries,
   ChartexBoxWhisker,
   ChartexSunburst,


### PR DESCRIPTION
## Summary
- export the ChartEx histogram binning type from the public core entry
- keep document model declarations complete for DOCX, PPTX, and XLSX consumers

## Verification
- DOCX, PPTX, and XLSX export-completeness tests
- TypeScript 7 project build

Follow-up to #1227.