### PR TITLE
fix(chart): bound automatic value-axis planning

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -18,24 +18,12 @@ stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 88.8,277.7
-lineTo 540,277.7
-stroke ss=#e0e0e0 lw=0.5 dash=
-beginPath
 moveTo 88.8,241.95
 lineTo 540,241.95
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 88.8,206.2
-lineTo 540,206.2
-stroke ss=#e0e0e0 lw=0.5 dash=
-beginPath
 moveTo 88.8,170.45
 lineTo 540,170.45
-stroke ss=#e0e0e0 lw=0.5 dash=
-beginPath
-moveTo 88.8,134.7
-lineTo 540,134.7
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
 moveTo 88.8,98.95
@@ -43,18 +31,18 @@ lineTo 540,98.95
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
 moveTo 107.6,313.45
-lineTo 107.6,259.825
-lineTo 145.2,224.075
-lineTo 182.8,241.95
-lineTo 220.4,206.2
-lineTo 258,188.325
-lineTo 295.6,224.075
-lineTo 333.2,170.45
-lineTo 370.8,206.2
-lineTo 408.4,152.575
-lineTo 446,188.325
-lineTo 483.6,134.7
-lineTo 521.2,170.45
+lineTo 107.6,270.55
+lineTo 145.2,241.95
+lineTo 182.8,256.25
+lineTo 220.4,227.65
+lineTo 258,213.35
+lineTo 295.6,241.95
+lineTo 333.2,199.05
+lineTo 370.8,227.65
+lineTo 408.4,184.75
+lineTo 446,213.35
+lineTo 483.6,170.45
+lineTo 521.2,199.05
 lineTo 521.2,313.45
 closePath
 set fillStyle=#4472C4
@@ -79,30 +67,12 @@ fillText "0" 82.8,313.45 fs=#555 font=10.725px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,277.7
-lineTo 88.8,277.7
-stroke ss=#aaa lw=1 dash=
-set strokeStyle=#4472C4
-set lineWidth=1.5
-fillText "2" 82.8,277.7 fs=#555 font=10.725px sans-serif al=right bl=middle
-set strokeStyle=#aaa
-set lineWidth=1
-beginPath
 moveTo 84.8,241.95
 lineTo 88.8,241.95
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=1.5
-fillText "4" 82.8,241.95 fs=#555 font=10.725px sans-serif al=right bl=middle
-set strokeStyle=#aaa
-set lineWidth=1
-beginPath
-moveTo 84.8,206.2
-lineTo 88.8,206.2
-stroke ss=#aaa lw=1 dash=
-set strokeStyle=#4472C4
-set lineWidth=1.5
-fillText "6" 82.8,206.2 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "5" 82.8,241.95 fs=#555 font=10.725px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -111,16 +81,7 @@ lineTo 88.8,170.45
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=1.5
-fillText "8" 82.8,170.45 fs=#555 font=10.725px sans-serif al=right bl=middle
-set strokeStyle=#aaa
-set lineWidth=1
-beginPath
-moveTo 84.8,134.7
-lineTo 88.8,134.7
-stroke ss=#aaa lw=1 dash=
-set strokeStyle=#4472C4
-set lineWidth=1.5
-fillText "10" 82.8,134.7 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "10" 82.8,170.45 fs=#555 font=10.725px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -129,7 +90,7 @@ lineTo 88.8,98.95
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=1.5
-fillText "12" 82.8,98.95 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "15" 82.8,98.95 fs=#555 font=10.725px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -321,27 +282,42 @@ stroke ss=#888 lw=1 dash=
 restore
 set textAlign=center
 set textBaseline=top
-fillText "1" 88.8,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "0" 88.8,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 88.8,339.45
 lineTo 88.8,335.45
 stroke ss=#888 lw=1 dash=
-fillText "1.5" 221.6,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "0.5" 164.6857,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 221.6,339.45
-lineTo 221.6,335.45
+moveTo 164.6857,339.45
+lineTo 164.6857,335.45
 stroke ss=#888 lw=1 dash=
-fillText "2" 354.4,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "1" 240.5714,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 354.4,339.45
-lineTo 354.4,335.45
+moveTo 240.5714,339.45
+lineTo 240.5714,335.45
 stroke ss=#888 lw=1 dash=
-fillText "2.5" 487.2,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "1.5" 316.4571,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
-moveTo 487.2,339.45
-lineTo 487.2,335.45
+moveTo 316.4571,339.45
+lineTo 316.4571,335.45
 stroke ss=#888 lw=1 dash=
-fillText "3" 620,339.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "2" 392.3429,339.45 fs=#555 font=11px sans-serif al=center bl=top
+beginPath
+moveTo 392.3429,339.45
+lineTo 392.3429,335.45
+stroke ss=#888 lw=1 dash=
+fillText "2.5" 468.2286,339.45 fs=#555 font=11px sans-serif al=center bl=top
+beginPath
+moveTo 468.2286,339.45
+lineTo 468.2286,335.45
+stroke ss=#888 lw=1 dash=
+fillText "3" 544.1143,339.45 fs=#555 font=11px sans-serif al=center bl=top
+beginPath
+moveTo 544.1143,339.45
+lineTo 544.1143,335.45
+stroke ss=#888 lw=1 dash=
+fillText "3.5" 620,339.45 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 620,339.45
 lineTo 620,335.45
@@ -349,17 +325,17 @@ stroke ss=#888 lw=1 dash=
 save
 set fillStyle=#4472C4
 beginPath
-arc 88.8,213.31,26.9894,0,6.2832
+arc 240.5714,213.31,26.9894,0,6.2832
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-arc 354.4,91.17,38.1687,0,6.2832
+arc 392.3429,91.17,38.1687,0,6.2832
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-arc 620,152.24,31.9343,0,6.2832
+arc 544.1143,152.24,31.9343,0,6.2832
 fill fs=#4472C4 ga=1
 restore
 restore"
@@ -393,30 +369,15 @@ fillText "0" 55.67,313.45 fs=#555 font=10.725px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 67.67,277.7
-lineTo 552.8,277.7
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "5" 55.67,277.7 fs=#555 font=10.725px sans-serif al=right bl=middle
-beginPath
 moveTo 67.67,241.95
 lineTo 552.8,241.95
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "10" 55.67,241.95 fs=#555 font=10.725px sans-serif al=right bl=middle
 beginPath
-moveTo 67.67,206.2
-lineTo 552.8,206.2
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "15" 55.67,206.2 fs=#555 font=10.725px sans-serif al=right bl=middle
-beginPath
 moveTo 67.67,170.45
 lineTo 552.8,170.45
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "20" 55.67,170.45 fs=#555 font=10.725px sans-serif al=right bl=middle
-beginPath
-moveTo 67.67,134.7
-lineTo 552.8,134.7
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "25" 55.67,134.7 fs=#555 font=10.725px sans-serif al=right bl=middle
 beginPath
 moveTo 67.67,98.95
 lineTo 552.8,98.95
@@ -466,24 +427,12 @@ moveTo 63.67,313.45
 lineTo 67.67,313.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 63.67,277.7
-lineTo 67.67,277.7
-stroke ss=#aaa lw=1 dash=
-beginPath
 moveTo 63.67,241.95
 lineTo 67.67,241.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 63.67,206.2
-lineTo 67.67,206.2
-stroke ss=#aaa lw=1 dash=
-beginPath
 moveTo 63.67,170.45
 lineTo 67.67,170.45
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 63.67,134.7
-lineTo 67.67,134.7
 stroke ss=#aaa lw=1 dash=
 beginPath
 moveTo 63.67,98.95
@@ -555,96 +504,61 @@ fillText "0" 30.775,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 70.9308,98.95
-lineTo 70.9308,335.45
+moveTo 117.7792,98.95
+lineTo 117.7792,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "2" 70.9308,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "5" 117.7792,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 111.0865,98.95
-lineTo 111.0865,335.45
+moveTo 204.7833,98.95
+lineTo 204.7833,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "4" 111.0865,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "10" 204.7833,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 151.2423,98.95
-lineTo 151.2423,335.45
+moveTo 291.7875,98.95
+lineTo 291.7875,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "6" 151.2423,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "15" 291.7875,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 191.3981,98.95
-lineTo 191.3981,335.45
+moveTo 378.7917,98.95
+lineTo 378.7917,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "8" 191.3981,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "20" 378.7917,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 231.5538,98.95
-lineTo 231.5538,335.45
+moveTo 465.7958,98.95
+lineTo 465.7958,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "10" 231.5538,345.45 fs=#555 font=11px sans-serif al=center bl=middle
-beginPath
-moveTo 271.7096,98.95
-lineTo 271.7096,335.45
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "12" 271.7096,345.45 fs=#555 font=11px sans-serif al=center bl=middle
-beginPath
-moveTo 311.8654,98.95
-lineTo 311.8654,335.45
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "14" 311.8654,345.45 fs=#555 font=11px sans-serif al=center bl=middle
-beginPath
-moveTo 352.0212,98.95
-lineTo 352.0212,335.45
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "16" 352.0212,345.45 fs=#555 font=11px sans-serif al=center bl=middle
-beginPath
-moveTo 392.1769,98.95
-lineTo 392.1769,335.45
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "18" 392.1769,345.45 fs=#555 font=11px sans-serif al=center bl=middle
-beginPath
-moveTo 432.3327,98.95
-lineTo 432.3327,335.45
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "20" 432.3327,345.45 fs=#555 font=11px sans-serif al=center bl=middle
-beginPath
-moveTo 472.4885,98.95
-lineTo 472.4885,335.45
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "22" 472.4885,345.45 fs=#555 font=11px sans-serif al=center bl=middle
-beginPath
-moveTo 512.6442,98.95
-lineTo 512.6442,335.45
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "24" 512.6442,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "25" 465.7958,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
 moveTo 552.8,98.95
 lineTo 552.8,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "26" 552.8,345.45 fs=#555 font=11px sans-serif al=center bl=middle
+fillText "30" 552.8,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 set fillStyle=#4472C4
-fillRect 30.775,273.5095,200.7788,22.5238 fs=#4472C4
+fillRect 30.775,273.5095,174.0083,22.5238 fs=#4472C4
 set font=bold 11px sans-serif
 set fillStyle=#333
 set textAlign=left
-fillText "10" 233.5538,284.7714 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "10" 206.7833,284.7714 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 30.775,296.0333,160.6231,22.5238 fs=#ED7D31
+fillRect 30.775,296.0333,139.2067,22.5238 fs=#ED7D31
 set fillStyle=#333
-fillText "8" 193.3981,307.2952 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "8" 171.9817,307.2952 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#4472C4
-fillRect 30.775,194.6762,481.8692,22.5238 fs=#4472C4
+fillRect 30.775,194.6762,417.62,22.5238 fs=#4472C4
 set fillStyle=#333
-fillText "24" 514.6442,205.9381 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "24" 450.395,205.9381 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 30.775,217.2,301.1683,22.5238 fs=#ED7D31
+fillRect 30.775,217.2,261.0125,22.5238 fs=#ED7D31
 set fillStyle=#333
-fillText "15" 333.9433,228.4619 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "15" 293.7875,228.4619 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#4472C4
-fillRect 30.775,115.8429,341.324,22.5238 fs=#4472C4
+fillRect 30.775,115.8429,295.8142,22.5238 fs=#4472C4
 set fillStyle=#333
-fillText "17" 374.099,127.1048 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "17" 328.5892,127.1048 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 30.775,138.3667,441.7135,22.5238 fs=#ED7D31
+fillRect 30.775,138.3667,382.8183,22.5238 fs=#ED7D31
 set fillStyle=#333
-fillText "22" 474.4885,149.6286 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "22" 415.5933,149.6286 fs=#333 font=bold 11px sans-serif al=left bl=middle
 set fillStyle=#555
 set font=11px sans-serif
 set textAlign=right
@@ -662,52 +576,24 @@ moveTo 30.775,339.45
 lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 70.9308,339.45
-lineTo 70.9308,335.45
+moveTo 117.7792,339.45
+lineTo 117.7792,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 111.0865,339.45
-lineTo 111.0865,335.45
+moveTo 204.7833,339.45
+lineTo 204.7833,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 151.2423,339.45
-lineTo 151.2423,335.45
+moveTo 291.7875,339.45
+lineTo 291.7875,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 191.3981,339.45
-lineTo 191.3981,335.45
+moveTo 378.7917,339.45
+lineTo 378.7917,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 231.5538,339.45
-lineTo 231.5538,335.45
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 271.7096,339.45
-lineTo 271.7096,335.45
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 311.8654,339.45
-lineTo 311.8654,335.45
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 352.0212,339.45
-lineTo 352.0212,335.45
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 392.1769,339.45
-lineTo 392.1769,335.45
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 432.3327,339.45
-lineTo 432.3327,335.45
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 472.4885,339.45
-lineTo 472.4885,335.45
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 512.6442,339.45
-lineTo 512.6442,335.45
+moveTo 465.7958,339.45
+lineTo 465.7958,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
 moveTo 552.8,339.45
@@ -789,49 +675,24 @@ fillText "0" 35.8,335.45 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 47.8,305.8875
-lineTo 495.6,305.8875
+moveTo 47.8,256.6167
+lineTo 495.6,256.6167
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "20" 35.8,305.8875 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "50" 35.8,256.6167 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 47.8,276.325
-lineTo 495.6,276.325
+moveTo 47.8,177.7833
+lineTo 495.6,177.7833
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "40" 35.8,276.325 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 47.8,246.7625
-lineTo 495.6,246.7625
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "60" 35.8,246.7625 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 47.8,217.2
-lineTo 495.6,217.2
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "80" 35.8,217.2 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 47.8,187.6375
-lineTo 495.6,187.6375
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "100" 35.8,187.6375 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 47.8,158.075
-lineTo 495.6,158.075
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "120" 35.8,158.075 fs=#555 font=11px sans-serif al=right bl=middle
-beginPath
-moveTo 47.8,128.5125
-lineTo 495.6,128.5125
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "140" 35.8,128.5125 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "100" 35.8,177.7833 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
 moveTo 47.8,98.95
 lineTo 495.6,98.95
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "160" 35.8,98.95 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "150" 35.8,98.95 fs=#555 font=11px sans-serif al=right bl=middle
 set fillStyle=#4472C4
-fillRect 92.58,187.6375,59.7067,147.8125 fs=#4472C4
-fillRect 241.8467,128.5125,59.7067,206.9375 fs=#4472C4
-fillRect 391.1133,158.075,59.7067,177.375 fs=#4472C4
+fillRect 92.58,177.7833,59.7067,157.6667 fs=#4472C4
+fillRect 241.8467,114.7167,59.7067,220.7333 fs=#4472C4
+fillRect 391.1133,146.25,59.7067,189.2 fs=#4472C4
 set fillStyle=#555
 set textAlign=center
 set textBaseline=top
@@ -867,32 +728,12 @@ moveTo 43.8,335.45
 lineTo 47.8,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 43.8,305.8875
-lineTo 47.8,305.8875
+moveTo 43.8,256.6167
+lineTo 47.8,256.6167
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 43.8,276.325
-lineTo 47.8,276.325
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 43.8,246.7625
-lineTo 47.8,246.7625
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 43.8,217.2
-lineTo 47.8,217.2
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 43.8,187.6375
-lineTo 47.8,187.6375
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 43.8,158.075
-lineTo 47.8,158.075
-stroke ss=#aaa lw=1 dash=
-beginPath
-moveTo 43.8,128.5125
-lineTo 47.8,128.5125
+moveTo 43.8,177.7833
+lineTo 47.8,177.7833
 stroke ss=#aaa lw=1 dash=
 beginPath
 moveTo 43.8,98.95
@@ -1059,19 +900,6 @@ fillText "0" 78.44,313.45 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 84.44,277.7
-lineTo 540,277.7
-stroke ss=#e0e0e0 lw=0.5 dash=
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 80.44,277.7
-lineTo 84.44,277.7
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-fillText "2" 78.44,277.7 fs=#555 font=16.2px sans-serif al=right bl=middle
-beginPath
 moveTo 84.44,241.95
 lineTo 540,241.95
 stroke ss=#e0e0e0 lw=0.5 dash=
@@ -1083,20 +911,7 @@ lineTo 84.44,241.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "4" 78.44,241.95 fs=#555 font=16.2px sans-serif al=right bl=middle
-beginPath
-moveTo 84.44,206.2
-lineTo 540,206.2
-stroke ss=#e0e0e0 lw=0.5 dash=
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 80.44,206.2
-lineTo 84.44,206.2
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-fillText "6" 78.44,206.2 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "5" 78.44,241.95 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
 moveTo 84.44,170.45
 lineTo 540,170.45
@@ -1109,20 +924,7 @@ lineTo 84.44,170.45
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "8" 78.44,170.45 fs=#555 font=16.2px sans-serif al=right bl=middle
-beginPath
-moveTo 84.44,134.7
-lineTo 540,134.7
-stroke ss=#e0e0e0 lw=0.5 dash=
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 80.44,134.7
-lineTo 84.44,134.7
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-fillText "10" 78.44,134.7 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "10" 78.44,170.45 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
 moveTo 84.44,98.95
 lineTo 540,98.95
@@ -1135,7 +937,7 @@ lineTo 84.44,98.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "12" 78.44,98.95 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "15" 78.44,98.95 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -1150,228 +952,228 @@ set strokeStyle=#4472C4
 set lineWidth=2.3625
 setLineDash
 beginPath
-moveTo 103.4217,259.825
-lineTo 141.385,224.075
-lineTo 179.3483,241.95
-lineTo 217.3117,206.2
-lineTo 255.275,188.325
-lineTo 293.2383,224.075
-lineTo 331.2017,170.45
-lineTo 369.165,206.2
-lineTo 407.1283,152.575
-lineTo 445.0917,188.325
-lineTo 483.055,134.7
-lineTo 521.0183,170.45
+moveTo 103.4217,270.55
+lineTo 141.385,241.95
+lineTo 179.3483,256.25
+lineTo 217.3117,227.65
+lineTo 255.275,213.35
+lineTo 293.2383,241.95
+lineTo 331.2017,199.05
+lineTo 369.165,227.65
+lineTo 407.1283,184.75
+lineTo 445.0917,213.35
+lineTo 483.055,170.45
+lineTo 521.0183,199.05
 stroke ss=#4472C4 lw=2.3625 dash=
 set fillStyle=#4472C4
 beginPath
-arc 103.4217,259.825,2.625,0,6.2832
+arc 103.4217,270.55,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
 set textAlign=left
-fillText "3" 116.7667,259.825 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "3" 116.7667,270.55 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 141.385,224.075,2.625,0,6.2832
+arc 141.385,241.95,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "5" 154.73,224.075 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 154.73,241.95 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 179.3483,241.95,2.625,0,6.2832
+arc 179.3483,256.25,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "4" 192.6933,241.95 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "4" 192.6933,256.25 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 217.3117,206.2,2.625,0,6.2832
+arc 217.3117,227.65,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "6" 230.6567,206.2 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 230.6567,227.65 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 255.275,188.325,2.625,0,6.2832
+arc 255.275,213.35,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "7" 268.62,188.325 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 268.62,213.35 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 293.2383,224.075,2.625,0,6.2832
+arc 293.2383,241.95,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "5" 306.5833,224.075 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 306.5833,241.95 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 331.2017,170.45,2.625,0,6.2832
+arc 331.2017,199.05,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "8" 344.5467,170.45 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 344.5467,199.05 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 369.165,206.2,2.625,0,6.2832
+arc 369.165,227.65,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "6" 382.51,206.2 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 382.51,227.65 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 407.1283,152.575,2.625,0,6.2832
+arc 407.1283,184.75,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "9" 420.4733,152.575 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 420.4733,184.75 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 445.0917,188.325,2.625,0,6.2832
+arc 445.0917,213.35,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "7" 458.4367,188.325 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 458.4367,213.35 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 483.055,134.7,2.625,0,6.2832
+arc 483.055,170.45,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "10" 496.4,134.7 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "10" 496.4,170.45 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 521.0183,170.45,2.625,0,6.2832
+arc 521.0183,199.05,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "8" 534.3633,170.45 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 534.3633,199.05 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 set strokeStyle=#ED7D31
 setLineDash
 beginPath
-moveTo 103.4217,277.7
-lineTo 141.385,259.825
-lineTo 179.3483,224.075
-lineTo 217.3117,241.95
-lineTo 255.275,206.2
-lineTo 293.2383,170.45
-lineTo 331.2017,188.325
-lineTo 369.165,152.575
-lineTo 407.1283,206.2
-lineTo 445.0917,170.45
-lineTo 483.055,188.325
-lineTo 521.0183,152.575
+moveTo 103.4217,284.85
+lineTo 141.385,270.55
+lineTo 179.3483,241.95
+lineTo 217.3117,256.25
+lineTo 255.275,227.65
+lineTo 293.2383,199.05
+lineTo 331.2017,213.35
+lineTo 369.165,184.75
+lineTo 407.1283,227.65
+lineTo 445.0917,199.05
+lineTo 483.055,213.35
+lineTo 521.0183,184.75
 stroke ss=#ED7D31 lw=2.3625 dash=
 set fillStyle=#ED7D31
 beginPath
-arc 103.4217,277.7,2.625,0,6.2832
+arc 103.4217,284.85,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "2" 116.7667,277.7 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "2" 116.7667,284.85 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 141.385,259.825,2.625,0,6.2832
+arc 141.385,270.55,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "3" 154.73,259.825 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "3" 154.73,270.55 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 179.3483,224.075,2.625,0,6.2832
+arc 179.3483,241.95,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "5" 192.6933,224.075 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 192.6933,241.95 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 217.3117,241.95,2.625,0,6.2832
+arc 217.3117,256.25,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "4" 230.6567,241.95 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "4" 230.6567,256.25 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 255.275,206.2,2.625,0,6.2832
+arc 255.275,227.65,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "6" 268.62,206.2 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 268.62,227.65 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 293.2383,170.45,2.625,0,6.2832
+arc 293.2383,199.05,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "8" 306.5833,170.45 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 306.5833,199.05 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 331.2017,188.325,2.625,0,6.2832
+arc 331.2017,213.35,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "7" 344.5467,188.325 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 344.5467,213.35 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 369.165,152.575,2.625,0,6.2832
+arc 369.165,184.75,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "9" 382.51,152.575 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 382.51,184.75 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 407.1283,206.2,2.625,0,6.2832
+arc 407.1283,227.65,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "6" 420.4733,206.2 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 420.4733,227.65 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 445.0917,170.45,2.625,0,6.2832
+arc 445.0917,199.05,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "8" 458.4367,170.45 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 458.4367,199.05 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 483.055,188.325,2.625,0,6.2832
+arc 483.055,213.35,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "7" 496.4,188.325 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 496.4,213.35 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 521.0183,152.575,2.625,0,6.2832
+arc 521.0183,184.75,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "9" 534.3633,152.575 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 534.3633,184.75 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 set fillStyle=#555
@@ -1612,14 +1414,6 @@ fillText "Profile" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-seri
 set strokeStyle=#ddd
 set lineWidth=0.5
 beginPath
-moveTo 292,212.69
-lineTo 309.8894,225.6874
-lineTo 303.0562,246.7176
-lineTo 280.9438,246.7176
-lineTo 274.1106,225.6874
-closePath
-stroke ss=#ddd lw=0.5 dash=
-beginPath
 moveTo 292,193.88
 lineTo 327.7787,219.8748
 lineTo 314.1125,261.9352
@@ -1628,27 +1422,11 @@ lineTo 256.2213,219.8748
 closePath
 stroke ss=#ddd lw=0.5 dash=
 beginPath
-moveTo 292,175.07
-lineTo 345.6681,214.0622
-lineTo 325.1687,277.1528
-lineTo 258.8313,277.1528
-lineTo 238.3319,214.0622
-closePath
-stroke ss=#ddd lw=0.5 dash=
-beginPath
 moveTo 292,156.26
 lineTo 363.5575,208.2496
 lineTo 336.225,292.3704
 lineTo 247.775,292.3704
 lineTo 220.4425,208.2496
-closePath
-stroke ss=#ddd lw=0.5 dash=
-beginPath
-moveTo 292,137.45
-lineTo 381.4469,202.437
-lineTo 347.2812,307.588
-lineTo 236.7188,307.588
-lineTo 202.5531,202.437
 closePath
 stroke ss=#ddd lw=0.5 dash=
 beginPath
@@ -1684,11 +1462,8 @@ set font=16.2px sans-serif
 set fillStyle=#555
 set textAlign=right
 set textBaseline=middle
-fillText "1" 289,212.69 fs=#555 font=16.2px sans-serif al=right bl=middle
 fillText "2" 289,193.88 fs=#555 font=16.2px sans-serif al=right bl=middle
-fillText "3" 289,175.07 fs=#555 font=16.2px sans-serif al=right bl=middle
 fillText "4" 289,156.26 fs=#555 font=16.2px sans-serif al=right bl=middle
-fillText "5" 289,137.45 fs=#555 font=16.2px sans-serif al=right bl=middle
 fillText "6" 289,118.64 fs=#555 font=16.2px sans-serif al=right bl=middle
 set font=11px sans-serif
 set fillStyle=#444
@@ -1778,80 +1553,41 @@ stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 115.6,282.8071
-lineTo 540,282.8071
+moveTo 115.6,259.825
+lineTo 540,259.825
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "1" 111.6,282.8071 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "2" 111.6,259.825 fs=#555 font=10.725px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 111.6,282.8071
-lineTo 115.6,282.8071
+moveTo 111.6,259.825
+lineTo 115.6,259.825
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 115.6,252.1643
-lineTo 540,252.1643
+moveTo 115.6,206.2
+lineTo 540,206.2
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "2" 111.6,252.1643 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "4" 111.6,206.2 fs=#555 font=10.725px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 111.6,252.1643
-lineTo 115.6,252.1643
+moveTo 111.6,206.2
+lineTo 115.6,206.2
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 115.6,221.5214
-lineTo 540,221.5214
+moveTo 115.6,152.575
+lineTo 540,152.575
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "3" 111.6,221.5214 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "6" 111.6,152.575 fs=#555 font=10.725px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 111.6,221.5214
-lineTo 115.6,221.5214
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-beginPath
-moveTo 115.6,190.8786
-lineTo 540,190.8786
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "4" 111.6,190.8786 fs=#555 font=10.725px sans-serif al=right bl=middle
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 111.6,190.8786
-lineTo 115.6,190.8786
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-beginPath
-moveTo 115.6,160.2357
-lineTo 540,160.2357
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "5" 111.6,160.2357 fs=#555 font=10.725px sans-serif al=right bl=middle
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 111.6,160.2357
-lineTo 115.6,160.2357
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-beginPath
-moveTo 115.6,129.5929
-lineTo 540,129.5929
-stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "6" 111.6,129.5929 fs=#555 font=10.725px sans-serif al=right bl=middle
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 111.6,129.5929
-lineTo 115.6,129.5929
+moveTo 111.6,152.575
+lineTo 115.6,152.575
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
@@ -1859,7 +1595,7 @@ beginPath
 moveTo 115.6,98.95
 lineTo 540,98.95
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "7" 111.6,98.95 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "8" 111.6,98.95 fs=#555 font=10.725px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -1884,27 +1620,37 @@ stroke ss=#888 lw=1 dash=
 restore
 set textAlign=center
 set textBaseline=top
-fillText "1" 115.6,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+fillText "0" 115.6,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
 beginPath
 moveTo 115.6,317.45
 lineTo 115.6,313.45
 stroke ss=#888 lw=1 dash=
-fillText "2" 221.7,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+fillText "1" 186.3333,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
 beginPath
-moveTo 221.7,317.45
-lineTo 221.7,313.45
+moveTo 186.3333,317.45
+lineTo 186.3333,313.45
+stroke ss=#888 lw=1 dash=
+fillText "2" 257.0667,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+beginPath
+moveTo 257.0667,317.45
+lineTo 257.0667,313.45
 stroke ss=#888 lw=1 dash=
 fillText "3" 327.8,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
 beginPath
 moveTo 327.8,317.45
 lineTo 327.8,313.45
 stroke ss=#888 lw=1 dash=
-fillText "4" 433.9,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+fillText "4" 398.5333,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
 beginPath
-moveTo 433.9,317.45
-lineTo 433.9,313.45
+moveTo 398.5333,317.45
+lineTo 398.5333,313.45
 stroke ss=#888 lw=1 dash=
-fillText "5" 540,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+fillText "5" 469.2667,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+beginPath
+moveTo 469.2667,317.45
+lineTo 469.2667,313.45
+stroke ss=#888 lw=1 dash=
+fillText "6" 540,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
 beginPath
 moveTo 540,317.45
 lineTo 540,313.45
@@ -1913,56 +1659,56 @@ save
 set strokeStyle=#4472C4
 set lineWidth=1.5
 beginPath
-moveTo 115.6,252.1643
-lineTo 221.7,190.8786
-lineTo 327.8,221.5214
-lineTo 433.9,160.2357
-lineTo 540,129.5929
+moveTo 186.3333,259.825
+lineTo 257.0667,206.2
+lineTo 327.8,233.0125
+lineTo 398.5333,179.3875
+lineTo 469.2667,152.575
 stroke ss=#4472C4 lw=1.5 dash=
 restore
 save
 set fillStyle=#4472C4
 beginPath
-moveTo 115.6,249.5393
-lineTo 118.225,252.1643
-lineTo 115.6,254.7893
-lineTo 112.975,252.1643
+moveTo 186.3333,257.2
+lineTo 188.9583,259.825
+lineTo 186.3333,262.45
+lineTo 183.7083,259.825
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 221.7,188.2536
-lineTo 224.325,190.8786
-lineTo 221.7,193.5036
-lineTo 219.075,190.8786
+moveTo 257.0667,203.575
+lineTo 259.6917,206.2
+lineTo 257.0667,208.825
+lineTo 254.4417,206.2
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 327.8,218.8964
-lineTo 330.425,221.5214
-lineTo 327.8,224.1464
-lineTo 325.175,221.5214
+moveTo 327.8,230.3875
+lineTo 330.425,233.0125
+lineTo 327.8,235.6375
+lineTo 325.175,233.0125
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 433.9,157.6107
-lineTo 436.525,160.2357
-lineTo 433.9,162.8607
-lineTo 431.275,160.2357
+moveTo 398.5333,176.7625
+lineTo 401.1583,179.3875
+lineTo 398.5333,182.0125
+lineTo 395.9083,179.3875
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 540,126.9679
-lineTo 542.625,129.5929
-lineTo 540,132.2179
-lineTo 537.375,129.5929
+moveTo 469.2667,149.95
+lineTo 471.8917,152.575
+lineTo 469.2667,155.2
+lineTo 466.6417,152.575
 closePath
 fill fs=#4472C4 ga=1
 restore
@@ -2013,45 +1759,29 @@ stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 88.8,303.5778
-lineTo 620,303.5778
+moveTo 88.8,278.08
+lineTo 620,278.08
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 88.8,271.7056
-lineTo 620,271.7056
+moveTo 88.8,220.71
+lineTo 620,220.71
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 88.8,239.8333
-lineTo 620,239.8333
+moveTo 88.8,163.34
+lineTo 620,163.34
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 88.8,207.9611
-lineTo 620,207.9611
-stroke ss=#e0e0e0 lw=0.5 dash=
-beginPath
-moveTo 88.8,176.0889
-lineTo 620,176.0889
-stroke ss=#e0e0e0 lw=0.5 dash=
-beginPath
-moveTo 88.8,144.2167
-lineTo 620,144.2167
-stroke ss=#e0e0e0 lw=0.5 dash=
-beginPath
-moveTo 88.8,112.3444
-lineTo 620,112.3444
-stroke ss=#e0e0e0 lw=0.5 dash=
-beginPath
-moveTo 88.8,80.4722
-lineTo 620,80.4722
+moveTo 88.8,105.97
+lineTo 620,105.97
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
 moveTo 88.8,48.6
 lineTo 620,48.6
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 177.3333,271.7056
-lineTo 354.4,182.4633
-lineTo 531.4667,227.0844
+moveTo 177.3333,278.08
+lineTo 354.4,197.762
+lineTo 531.4667,237.921
 lineTo 531.4667,335.45
 lineTo 354.4,335.45
 lineTo 177.3333,335.45
@@ -2063,12 +1793,12 @@ set lineWidth=1.5
 setLineDash
 stroke ss=#4472C4 lw=1.5 dash=
 beginPath
-moveTo 177.3333,220.71
-lineTo 354.4,86.8467
-lineTo 531.4667,86.8467
-lineTo 531.4667,227.0844
-lineTo 354.4,182.4633
-lineTo 177.3333,271.7056
+moveTo 177.3333,232.184
+lineTo 354.4,111.707
+lineTo 531.4667,111.707
+lineTo 531.4667,237.921
+lineTo 354.4,197.762
+lineTo 177.3333,278.08
 closePath
 set fillStyle=#ED7D31
 fill fs=#ED7D31 ga=1
@@ -2091,75 +1821,39 @@ fillText "0" 82.8,335.45 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,303.5778
-lineTo 88.8,303.5778
+moveTo 84.8,278.08
+lineTo 88.8,278.08
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=1.5
-fillText "5" 82.8,303.5778 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "10" 82.8,278.08 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,271.7056
-lineTo 88.8,271.7056
+moveTo 84.8,220.71
+lineTo 88.8,220.71
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=1.5
-fillText "10" 82.8,271.7056 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "20" 82.8,220.71 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,239.8333
-lineTo 88.8,239.8333
+moveTo 84.8,163.34
+lineTo 88.8,163.34
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=1.5
-fillText "15" 82.8,239.8333 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "30" 82.8,163.34 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,207.9611
-lineTo 88.8,207.9611
+moveTo 84.8,105.97
+lineTo 88.8,105.97
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=1.5
-fillText "20" 82.8,207.9611 fs=#555 font=11px sans-serif al=right bl=middle
-set strokeStyle=#aaa
-set lineWidth=1
-beginPath
-moveTo 84.8,176.0889
-lineTo 88.8,176.0889
-stroke ss=#aaa lw=1 dash=
-set strokeStyle=#ED7D31
-set lineWidth=1.5
-fillText "25" 82.8,176.0889 fs=#555 font=11px sans-serif al=right bl=middle
-set strokeStyle=#aaa
-set lineWidth=1
-beginPath
-moveTo 84.8,144.2167
-lineTo 88.8,144.2167
-stroke ss=#aaa lw=1 dash=
-set strokeStyle=#ED7D31
-set lineWidth=1.5
-fillText "30" 82.8,144.2167 fs=#555 font=11px sans-serif al=right bl=middle
-set strokeStyle=#aaa
-set lineWidth=1
-beginPath
-moveTo 84.8,112.3444
-lineTo 88.8,112.3444
-stroke ss=#aaa lw=1 dash=
-set strokeStyle=#ED7D31
-set lineWidth=1.5
-fillText "35" 82.8,112.3444 fs=#555 font=11px sans-serif al=right bl=middle
-set strokeStyle=#aaa
-set lineWidth=1
-beginPath
-moveTo 84.8,80.4722
-lineTo 88.8,80.4722
-stroke ss=#aaa lw=1 dash=
-set strokeStyle=#ED7D31
-set lineWidth=1.5
-fillText "40" 82.8,80.4722 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "40" 82.8,105.97 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -2168,7 +1862,7 @@ lineTo 88.8,48.6
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=1.5
-fillText "45" 82.8,48.6 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "50" 82.8,48.6 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -2531,109 +2225,57 @@ fillText "0" 51.64,335.45 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 57.64,301.5222
-lineTo 620,301.5222
+moveTo 57.64,274.38
+lineTo 620,274.38
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,301.5222
-lineTo 57.64,301.5222
+moveTo 53.64,274.38
+lineTo 57.64,274.38
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "5" 51.64,301.5222 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "10" 51.64,274.38 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,267.5944
-lineTo 620,267.5944
+moveTo 57.64,213.31
+lineTo 620,213.31
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,267.5944
-lineTo 57.64,267.5944
+moveTo 53.64,213.31
+lineTo 57.64,213.31
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "10" 51.64,267.5944 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "20" 51.64,213.31 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,233.6667
-lineTo 620,233.6667
+moveTo 57.64,152.24
+lineTo 620,152.24
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,233.6667
-lineTo 57.64,233.6667
+moveTo 53.64,152.24
+lineTo 57.64,152.24
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "15" 51.64,233.6667 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "30" 51.64,152.24 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 57.64,199.7389
-lineTo 620,199.7389
+moveTo 57.64,91.17
+lineTo 620,91.17
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 53.64,199.7389
-lineTo 57.64,199.7389
+moveTo 53.64,91.17
+lineTo 57.64,91.17
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "20" 51.64,199.7389 fs=#555 font=16.2px sans-serif al=right bl=middle
-beginPath
-moveTo 57.64,165.8111
-lineTo 620,165.8111
-stroke ss=#e0e0e0 lw=0.5 dash=
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 53.64,165.8111
-lineTo 57.64,165.8111
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-fillText "25" 51.64,165.8111 fs=#555 font=16.2px sans-serif al=right bl=middle
-beginPath
-moveTo 57.64,131.8833
-lineTo 620,131.8833
-stroke ss=#e0e0e0 lw=0.5 dash=
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 53.64,131.8833
-lineTo 57.64,131.8833
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-fillText "30" 51.64,131.8833 fs=#555 font=16.2px sans-serif al=right bl=middle
-beginPath
-moveTo 57.64,97.9556
-lineTo 620,97.9556
-stroke ss=#e0e0e0 lw=0.5 dash=
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 53.64,97.9556
-lineTo 57.64,97.9556
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-fillText "35" 51.64,97.9556 fs=#555 font=16.2px sans-serif al=right bl=middle
-beginPath
-moveTo 57.64,64.0278
-lineTo 620,64.0278
-stroke ss=#e0e0e0 lw=0.5 dash=
-set strokeStyle=#888
-set lineWidth=1
-beginPath
-moveTo 53.64,64.0278
-lineTo 57.64,64.0278
-stroke ss=#888 lw=1 dash=
-set strokeStyle=#e0e0e0
-set lineWidth=0.5
-fillText "40" 51.64,64.0278 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "40" 51.64,91.17 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
 moveTo 57.64,30.1
 lineTo 620,30.1
@@ -2646,7 +2288,7 @@ lineTo 57.64,30.1
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "45" 51.64,30.1 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "50" 51.64,30.1 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -2661,36 +2303,36 @@ set strokeStyle=#4472C4
 set lineWidth=2.3625
 setLineDash
 beginPath
-moveTo 57.64,267.5944
-lineTo 338.82,172.5967
-lineTo 620,220.0956
+moveTo 57.64,274.38
+lineTo 338.82,188.882
+lineTo 620,231.631
 stroke ss=#4472C4 lw=2.3625 dash=
 set fillStyle=#4472C4
 beginPath
-arc 57.64,267.5944,2.625,0,6.2832
+arc 57.64,274.38,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 beginPath
-arc 338.82,172.5967,2.625,0,6.2832
+arc 338.82,188.882,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 beginPath
-arc 620,220.0956,2.625,0,6.2832
+arc 620,231.631,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 set strokeStyle=#ED7D31
 setLineDash
 beginPath
-moveTo 57.64,213.31
-lineTo 338.82,70.8133
-lineTo 620,70.8133
+moveTo 57.64,225.524
+lineTo 338.82,97.277
+lineTo 620,97.277
 stroke ss=#ED7D31 lw=2.3625 dash=
 set fillStyle=#ED7D31
 beginPath
-arc 57.64,213.31,2.625,0,6.2832
+arc 57.64,225.524,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 beginPath
-arc 338.82,70.8133,2.625,0,6.2832
+arc 338.82,97.277,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 beginPath
-arc 620,70.8133,2.625,0,6.2832
+arc 620,97.277,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 set fillStyle=#555
 set textAlign=center

--- a/packages/core/src/chart/axis-scale.test.ts
+++ b/packages/core/src/chart/axis-scale.test.ts
@@ -8,7 +8,31 @@ import {
   logAxisScale,
   fitTrendline,
   linearTrendlineStats,
+  planLinearValueAxis,
+  MAX_AXIS_TICKS,
+  ceilingNiceStep,
 } from './axis-scale.js';
+
+const nextUp = (value: number): number => {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setFloat64(0, value, false);
+  let bits = view.getBigUint64(0, false);
+  bits += value >= 0 ? 1n : -1n;
+  view.setBigUint64(0, bits, false);
+  return view.getFloat64(0, false);
+};
+
+describe('ceilingNiceStep', () => {
+  it('advances to the next ladder step immediately above exact 1/2/5 boundaries', () => {
+    expect(ceilingNiceStep(1)).toBe(1);
+    expect(ceilingNiceStep(nextUp(1))).toBe(2);
+    expect(ceilingNiceStep(2)).toBe(2);
+    expect(ceilingNiceStep(nextUp(2))).toBe(5);
+    expect(ceilingNiceStep(5)).toBe(5);
+    expect(ceilingNiceStep(nextUp(5))).toBe(10);
+  });
+});
 
 describe('niceStep', () => {
   it('picks 1/2/5 × 10ⁿ for ~5 gridlines', () => {
@@ -54,18 +78,14 @@ describe('niceAxisMin', () => {
   });
 });
 
-describe('valueAxisScale (one niceStep drives min, max and gridline step)', () => {
+describe('valueAxisScale (shared linear compatibility policy)', () => {
   it('positive data anchored at 0 (bar/area/radar style)', () => {
-    // step = niceStep(41-0) = niceStep(41) = 10; min = 0; max = niceAxisMax(41,10,0) = 50
     expect(valueAxisScale(0, 41)).toEqual({ min: 0, max: 50, step: 10 });
   });
   it('negative data floors the min and widens the max with the niced min', () => {
-    // step = niceStep(100-(-15)) = niceStep(115) = 20;
-    // min = niceAxisMin(-15,20) = -20; max = niceAxisMax(100,20,-20) = ceil((100+6)/20)*20 = 120
-    expect(valueAxisScale(-15, 100)).toEqual({ min: -20, max: 120, step: 20 });
+    expect(valueAxisScale(-15, 100)).toEqual({ min: -50, max: 150, step: 50 });
   });
   it('explicit min/max override the computed bounds (step still from data range)', () => {
-    // step = niceStep(41-0) = 10; explicit min -5, max 60 win
     expect(valueAxisScale(0, 41, -5, 60)).toEqual({ min: -5, max: 60, step: 10 });
   });
   it('a null explicit bound falls back to the auto value', () => {
@@ -73,41 +93,24 @@ describe('valueAxisScale (one niceStep drives min, max and gridline step)', () =
     expect(valueAxisScale(0, 41, -5, null)).toEqual({ min: -5, max: 50, step: 10 });
   });
   it('a longer value axis gets a finer major unit (Excel axis-length model)', () => {
-    // Excel's auto major unit targets ~1 gridline per GRIDLINE_SPACING_PT (42),
-    // so the SAME data range yields more, finer gridlines on a longer axis.
-    // range 44: default target (5) → step 10 (0–50, 5 intervals); a 380pt axis
-    // (target round(380/42)=9) → step 5 (0–50, 10 intervals) — matching the
-    // horizontal-bar value axis (sample-14 slide-9) vs PowerPoint.
-    expect(valueAxisScale(0, 44)).toEqual({ min: 0, max: 50, step: 10 });
-    expect(valueAxisScale(0, 44, undefined, undefined, 380)).toEqual({ min: 0, max: 50, step: 5 });
+    expect(valueAxisScale(0, 40)).toEqual({ min: 0, max: 50, step: 10 });
+    expect(valueAxisScale(0, 40, undefined, undefined, 380)).toEqual({ min: 0, max: 45, step: 5 });
   });
-  it('a short axis keeps a fine step via the target floor of 4', () => {
-    // Regression: the demo/sample-1 line chart pins the value axis to an
-    // explicit 60–72 (ECMA-376 §21.2.2.90 min/max, range 12) on a ~124pt plot.
-    // round(124/42)=3 would niceStep(12,3)→step 5 (60,65,70). PowerPoint draws
-    // step 2 (60,62,…,72); the floor of 4 gives niceStep(12,4)→step 2. Without
-    // the floor this axis silently coarsens by one major unit.
-    expect(valueAxisScale(60, 72, 60, 72, 124.1)).toEqual({ min: 60, max: 72, step: 2 });
+  it('a short axis uses the target floor of four', () => {
+    expect(valueAxisScale(60, 72, 60, 72, 124.1)).toEqual({ min: 60, max: 72, step: 5 });
   });
   it('a medium axis is not over-refined (42pt/gridline density)', () => {
-    // Regression: sample-14 slide-6's area axis is range 48.6 on a ~263pt plot.
-    // At 40pt/gridline round(263/40)=7 → niceStep(48.6,7)→step 5, but PowerPoint
-    // draws step 10 (0,10,…,60). At 42pt/gridline round(263/42)=6 → step 10.
     const { step } = valueAxisScale(0, 48.6, undefined, undefined, 263.2);
     expect(step).toBe(10);
   });
-  it('data 3.5 → max 4 with step 0.5 (fine-grained positive range)', () => {
-    // step = niceStep(3.5) = 0.5; min = 0; max = niceAxisMax(3.5,0.5,0):
-    //   3.5 + 3.5/20 = 3.675 → ceil(3.675/0.5)*0.5 = 4
-    expect(valueAxisScale(0, 3.5)).toEqual({ min: 0, max: 4, step: 0.5 });
+  it('rounds a fine-grained positive range with a ceiling ladder step', () => {
+    expect(valueAxisScale(0, 3.5)).toEqual({ min: 0, max: 4, step: 1 });
   });
-  it('data 0.1129 → max 0.12 with step 0.02 (sub-unit range)', () => {
-    // step = niceStep(0.1129) = 0.02; min = 0;
-    //   0.1129 + 0.1129/20 = 0.118545 → ceil(0.118545/0.02)*0.02 = 0.12
+  it('keeps the 1/2/5 ladder below one', () => {
     const { min, max, step } = valueAxisScale(0, 0.1129);
     expect(min).toBe(0);
-    expect(step).toBeCloseTo(0.02, 12);
-    expect(max).toBeCloseTo(0.12, 12);
+    expect(step).toBeCloseTo(0.05, 12);
+    expect(max).toBeCloseTo(0.15, 12);
   });
 
   it('an explicit majorUnit overrides the auto step (min/max still auto)', () => {
@@ -133,6 +136,119 @@ describe('valueAxisScale (one niceStep drives min, max and gridline step)', () =
     expect(valueAxisScale(0, 41, undefined, undefined, undefined, -5)).toEqual(
       valueAxisScale(0, 41),
     );
+  });
+});
+
+describe('planLinearValueAxis (bounded automatic value-axis policy)', () => {
+  it('keeps automatic major units on the 1/2/5 × 10ⁿ ladder', () => {
+    for (const dataMax of [1.1e-12, 3.7e-6, 8.4, 173, 9.9e11]) {
+      const { majorUnit } = planLinearValueAxis({ dataMin: 0, dataMax });
+      const magnitude = 10 ** Math.floor(Math.log10(majorUnit));
+      expect([1, 2, 5].some(value => Math.abs(majorUnit / magnitude - value) < 1e-12))
+        .toBe(true);
+    }
+  });
+
+  it('switches to a zero minimum only above the positive 1.2 boundary', () => {
+    const boundary = 1.2 * 10;
+    expect(planLinearValueAxis({ dataMin: 10, dataMax: boundary }).min).toBeGreaterThan(0);
+    expect(planLinearValueAxis({ dataMin: 10, dataMax: nextUp(boundary) }).min).toBe(0);
+    expect(planLinearValueAxis({ dataMin: -nextUp(boundary), dataMax: -10 }).max).toBe(0);
+  });
+
+  it('mirrors negative-only data with the same major and minor units', () => {
+    const positive = planLinearValueAxis({ dataMin: 10, dataMax: 12.000_001, needMinor: true });
+    const negative = planLinearValueAxis({ dataMin: -12.000_001, dataMax: -10, needMinor: true });
+    expect(negative.min).toBe(-positive.max);
+    expect(negative.max).toBeCloseTo(-positive.min, 12);
+    expect(negative.majorUnit).toBe(positive.majorUnit);
+    expect(negative.minorUnit).toBe(positive.minorUnit);
+  });
+
+  it('uses symmetric 5% padding for offset and zero-crossing ranges', () => {
+    const offset = planLinearValueAxis({ dataMin: 10, dataMax: 12 });
+    expect(offset.min).toBeLessThanOrEqual(9.9);
+    expect(offset.max).toBeGreaterThanOrEqual(12.1);
+    const crossing = planLinearValueAxis({ dataMin: -4, dataMax: 6 });
+    expect(crossing.min).toBeLessThanOrEqual(-4.5);
+    expect(crossing.max).toBeGreaterThanOrEqual(6.5);
+  });
+
+  it('handles zero and non-zero degenerate ranges without non-finite values', () => {
+    expect(planLinearValueAxis({ dataMin: 0, dataMax: 0, needMinor: true })).toMatchObject({
+      min: 0, max: 1, majorUnit: 0.1, minorUnit: 0.02,
+    });
+    for (const value of [5, -5]) {
+      const plan = planLinearValueAxis({ dataMin: value, dataMax: value, needMinor: true });
+      expect(plan.min).toBeLessThanOrEqual(value);
+      expect(plan.max).toBeGreaterThanOrEqual(value);
+      expect([plan.min, plan.max, plan.majorUnit, plan.minorUnit]
+        .every((item: number | null) => item != null && Number.isFinite(item))).toBe(true);
+    }
+  });
+
+  it('is scale invariant across powers of ten', () => {
+    const base = planLinearValueAxis({ dataMin: 10, dataMax: 11.9, needMinor: true });
+    for (const factor of [1e-9, 1e9]) {
+      const scaled = planLinearValueAxis({
+        dataMin: 10 * factor, dataMax: 11.9 * factor, needMinor: true,
+      });
+      expect(scaled.min / factor).toBeCloseTo(base.min, 9);
+      expect(scaled.max / factor).toBeCloseTo(base.max, 9);
+      expect(scaled.majorUnit / factor).toBeCloseTo(base.majorUnit, 9);
+      expect((scaled.minorUnit as number) / factor).toBeCloseTo(base.minorUnit as number, 9);
+    }
+  });
+
+  it('preserves authored bounds and units, and resolves omitted minor as major/5 on demand', () => {
+    const explicit = planLinearValueAxis({
+      dataMin: 10, dataMax: 12,
+      explicitMin: -7, explicitMax: 77, majorUnit: 7, minorUnit: 3,
+      needMinor: true,
+    });
+    expect(explicit).toMatchObject({ min: -7, max: 77, majorUnit: 7, minorUnit: 3 });
+    expect(planLinearValueAxis({ dataMin: 0, dataMax: 10 }).minorUnit).toBeNull();
+    const automatic = planLinearValueAxis({ dataMin: 0, dataMax: 10, needMinor: true });
+    expect(automatic.minorUnit).toBe(automatic.majorUnit / 5);
+  });
+
+  it('generates minor positions only when requested, independently of their paint consumer', () => {
+    const withoutMinor = planLinearValueAxis({ dataMin: 0, dataMax: 10 });
+    const withMinor = planLinearValueAxis({ dataMin: 0, dataMax: 10, needMinor: true });
+    expect(withoutMinor.minorTicks).toEqual([]);
+    expect(withMinor.minorTicks.length).toBeGreaterThan(0);
+    expect(withMinor.majorTicks.length).toBeGreaterThan(0);
+  });
+
+  it('bounds huge and tiny authored units before allocation', () => {
+    const tinyOffset = planLinearValueAxis({
+      dataMin: 1e12, dataMax: 1e12 + 1e-3, needMinor: true,
+    });
+    expect(tinyOffset.majorTicks.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+    expect(tinyOffset.minorTicks.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+    expect(tinyOffset.majorTicks.every(Number.isFinite)).toBe(true);
+
+    const huge = planLinearValueAxis({ dataMin: -1e308, dataMax: 1e308, needMinor: true });
+    expect([huge.min, huge.max, huge.majorUnit].every(Number.isFinite)).toBe(true);
+    expect(huge.majorTicks.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+    expect(huge.minorTicks.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+
+    const hostile = planLinearValueAxis({
+      dataMin: 0, dataMax: 1, explicitMin: 0, explicitMax: 1,
+      majorUnit: 1e-12, minorUnit: Number.MIN_VALUE, needMinor: true,
+    });
+    expect(hostile.majorTicks).toHaveLength(MAX_AXIS_TICKS);
+    expect(hostile.minorTicks).toEqual([]);
+
+    const coarsened = planLinearValueAxis({
+      dataMin: 0, dataMax: 1, explicitMin: 0, explicitMax: 1e12, needMinor: true,
+    });
+    expect(coarsened.majorUnit).toBeGreaterThan(1);
+    expect(coarsened.majorTicks.length).toBeGreaterThan(0);
+    expect(coarsened.majorTicks.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+    expect(coarsened.minorTicks.length).toBeGreaterThan(0);
+    expect(coarsened.minorTicks.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+    expect(coarsened.minorTicks.at(-1) as number).toBeGreaterThan(9.8e11);
   });
 });
 
@@ -182,6 +298,16 @@ describe('logAxisScale (power-of-base bounds + gridline exponents)', () => {
     const s = logAxisScale(0, 500, 10);
     expect(s.min).toBeGreaterThan(0);
     expect(s.max).toBe(1000);
+  });
+
+  it('preflights extreme base-2 and base-10 exponent ranges', () => {
+    for (const base of [2, 10]) {
+      const scale = logAxisScale(Number.MIN_VALUE, Number.MAX_VALUE, base);
+      expect(scale.min).toBeGreaterThan(0);
+      expect(scale.max).toBeLessThanOrEqual(Number.MAX_VALUE);
+      expect(scale.lines.length).toBeLessThanOrEqual(MAX_AXIS_TICKS);
+      expect(scale.lines.every(Number.isFinite)).toBe(true);
+    }
   });
 });
 

--- a/packages/core/src/chart/axis-scale.ts
+++ b/packages/core/src/chart/axis-scale.ts
@@ -39,40 +39,192 @@ export function niceAxisMin(dataMin: number, step: number): number {
   return Math.abs(ax - dataMin) < step * 1e-9 ? ax - step : ax;
 }
 
-/** Excel-style auto value-axis bounds + major unit. ONE `niceStep` (of the data
- *  range) drives the rounded min, max AND the gridline step, so they can never
- *  desync. Explicit `<c:valAx><c:scaling><c:min/max>` wins. The auto major unit
- *  is Excel-proprietary (not in ECMA-376); niceStep approximates it. */
 /** Target gridline spacing in POINTS. Excel's auto major unit is not a fixed
  *  gridline count — it targets a roughly constant on-screen spacing, so a long
  *  axis (e.g. a horizontal bar chart's wide value axis) gets MORE, finer
- *  gridlines than a short one of the same data range. Empirically ~one major
- *  gridline per this many points reproduces PowerPoint. This is a runtime Excel
- *  behavior (not in ECMA-376); the constant is the one tunable.
- *
- *  Calibrated against every value axis in the demo/sample-1 line chart plus
- *  sample-14 (column / stacked / area / combo dual-axis / horizontal-bar) and
- *  sample-2 (stacked-column / horizontal-bar) decks — 12 axes spanning
- *  124–391 pt. Those axes uniquely pin the density: at ~243 pt one axis needs
- *  6 intervals (range 79 → step 10) while another needs ≤6 (range 48.6 → step
- *  10), so the target at 243 pt must be exactly 6 → ~40.6 pt/gridline; at
- *  ~263 pt an area axis (range 48.6) must stay at 6 (step 10, not 5) → ≥43.9
- *  pt/gridline. 42 sits in the satisfying band [40.5, 44.2] with the widest
- *  margin to the nearest rounding flip (≈7.8 pt). The earlier value 40 rounded
- *  the 263 pt area axis up to 7 gridlines, over-refining it to a step-5 axis
- *  where PowerPoint draws step 10. */
+ *  gridlines than a short one of the same data range. This density is a
+ *  compatibility approximation, because OOXML does not define it. */
 const GRIDLINE_SPACING_PT = 42;
 
-/** Pick the `niceStep` target-gridline count for an axis of `axisLenPt` points.
- *  Falls back to 5 (the legacy fixed target) when the length is unknown. The
- *  floor is 4: PowerPoint keeps at least ~4 intervals on a value axis for
- *  readability, so a short axis (e.g. the demo line chart's 124 pt axis, which
- *  would otherwise round to 3) still gets a fine enough step — range 12 → step
- *  2 (60,62,…,72), matching PowerPoint, rather than the coarse step 5 a target
- *  of 3 produces. */
+/** Pick the target-gridline count for an axis of `axisLenPt` points. Unknown
+ *  lengths use five intervals; the four-interval floor keeps short axes
+ *  readable and the ceiling bounds paint work on unusually long axes. */
 function targetStepsForAxis(axisLenPt?: number): number {
   if (axisLenPt == null || !isFinite(axisLenPt) || axisLenPt <= 0) return 5;
   return Math.min(15, Math.max(4, Math.round(axisLenPt / GRIDLINE_SPACING_PT)));
+}
+
+/** Existing nearest-ladder density used by specialized percent axes. */
+export function axisLengthNiceStep(range: number, axisLenPt?: number): number {
+  return niceStep(range, targetStepsForAxis(axisLenPt));
+}
+
+/** Hard allocation/paint bound for each numeric-axis tick layer. */
+export const MAX_AXIS_TICKS = 512;
+
+export interface LinearValueAxisOptions {
+  dataMin: number;
+  dataMax: number;
+  explicitMin?: number | null;
+  explicitMax?: number | null;
+  axisLenPt?: number;
+  majorUnit?: number | null;
+  minorUnit?: number | null;
+  /** Minor positions are needed by either minor ticks or minor gridlines. */
+  needMinor?: boolean;
+}
+
+export interface LinearValueAxisPlan {
+  min: number;
+  max: number;
+  majorUnit: number;
+  minorUnit: number | null;
+  majorTicks: number[];
+  minorTicks: number[];
+}
+
+/** Smallest 1/2/5 × 10ⁿ step at least as large as `raw`. */
+export function ceilingNiceStep(raw: number): number {
+  if (!(raw > 0) || !isFinite(raw)) return 1;
+  const exponent = Math.floor(Math.log10(raw));
+  const magnitude = Math.pow(10, exponent);
+  if (!(magnitude > 0) || !isFinite(magnitude)) return raw;
+  const normalized = raw / magnitude;
+  const factor = normalized <= 1
+    ? 1
+    : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  return Math.min(Number.MAX_VALUE, factor * magnitude);
+}
+
+function finiteBound(value: number | null | undefined): number | null {
+  return value != null && isFinite(value) ? value : null;
+}
+
+function positiveUnit(value: number | null | undefined): number | null {
+  return value != null && isFinite(value) && value > 0 ? value : null;
+}
+
+function tickCount(min: number, max: number, unit: number): number {
+  if (!isFinite(min) || !isFinite(max) || !(max >= min) || !(unit > 0) || !isFinite(unit)) return 0;
+  const span = max - min;
+  const intervals = isFinite(span) ? span / unit : max / unit - min / unit;
+  if (!isFinite(intervals) || intervals > Number.MAX_SAFE_INTEGER) return Number.POSITIVE_INFINITY;
+  return Math.max(1, Math.floor(intervals + 1e-9) + 1);
+}
+
+/**
+ * Generate axis positions from integer indices. The count is checked before
+ * allocation; explicit hostile units are either truncated (major) or skipped
+ * (minor) instead of creating an unbounded render loop.
+ */
+function indexedTicks(
+  min: number,
+  max: number,
+  unit: number,
+  overflow: 'truncate' | 'skip',
+  excludeMajorUnit?: number,
+): number[] {
+  const expected = tickCount(min, max, unit);
+  if (expected === 0 || (expected > MAX_AXIS_TICKS && overflow === 'skip')) return [];
+  const count = Math.min(expected, MAX_AXIS_TICKS);
+  const values: number[] = [];
+  const span = max - min;
+  const epsilon = Math.max(
+    Math.abs(unit),
+    isFinite(span) ? Math.abs(span) : Math.max(Math.abs(min), Math.abs(max)),
+  ) * 1e-9;
+  let previousValue = Number.NEGATIVE_INFINITY;
+  for (let index = 0; index < count; index++) {
+    const value = min + index * unit;
+    if (!isFinite(value) || value > max + epsilon) break;
+    if (index > 0 && !(value > previousValue)) break;
+    previousValue = value;
+    if (excludeMajorUnit != null) {
+      if (value >= max - epsilon) break;
+      const delta = value - min;
+      const multiple = isFinite(delta)
+        ? delta / excludeMajorUnit
+        : value / excludeMajorUnit - min / excludeMajorUnit;
+      if (isFinite(multiple) && Math.abs(multiple - Math.round(multiple)) <= 1e-8) continue;
+    }
+    values.push(value);
+  }
+  return values;
+}
+
+/**
+ * Shared, bounded compatibility planner for an automatic linear value axis.
+ * OOXML defines authored bounds/units but deliberately leaves omitted values
+ * to the consuming application; this compact policy supplies those defaults.
+ */
+export function planLinearValueAxis(options: LinearValueAxisOptions): LinearValueAxisPlan {
+  let dataMin = isFinite(options.dataMin) ? options.dataMin : 0;
+  let dataMax = isFinite(options.dataMax) ? options.dataMax : 1;
+  if (dataMin > dataMax) [dataMin, dataMax] = [dataMax, dataMin];
+
+  let autoMin: number;
+  let autoMax: number;
+  let autoMajor: number;
+  if (dataMin === 0 && dataMax === 0) {
+    autoMin = 0;
+    autoMax = 1;
+    autoMajor = 0.1;
+  } else {
+    // A non-zero point range expands toward zero before applying the ordinary
+    // symmetric padding policy.
+    if (dataMin === dataMax) {
+      dataMin = Math.min(0, dataMin);
+      dataMax = Math.max(0, dataMax);
+    }
+    const span = dataMax - dataMin;
+    const padding = isFinite(span)
+      ? span * 0.05
+      : dataMax * 0.05 - dataMin * 0.05;
+    let lo = dataMin - padding;
+    let hi = dataMax + padding;
+    // The 1.2 boundary is intentionally strict: equality remains offset.
+    if (dataMin >= 0 && (dataMin === 0 || dataMax > 1.2 * dataMin)) lo = 0;
+    if (dataMax <= 0 && (dataMax === 0
+      || Math.abs(dataMin) > 1.2 * Math.abs(dataMax))) hi = 0;
+    const target = targetStepsForAxis(options.axisLenPt);
+    autoMajor = ceilingNiceStep(hi / target - lo / target);
+    autoMin = Math.floor(lo / autoMajor) * autoMajor;
+    autoMax = Math.ceil(hi / autoMajor) * autoMajor;
+    // Large offsets can erase sub-ULP padding/rounding. Keep a finite range
+    // containing the data without inventing special offset heuristics.
+    if (!isFinite(autoMin) || !isFinite(autoMax) || !(autoMax > autoMin)) {
+      autoMin = Math.min(dataMin, 0);
+      autoMax = Math.max(dataMax, autoMin + autoMajor);
+    }
+  }
+
+  const explicitMin = finiteBound(options.explicitMin);
+  const explicitMax = finiteBound(options.explicitMax);
+  const min = explicitMin ?? autoMin;
+  const max = explicitMax ?? autoMax;
+  const authoredMajor = positiveUnit(options.majorUnit);
+  let majorUnit = authoredMajor ?? autoMajor;
+  // An automatic unit may be coarsened to keep explicit wide bounds safe.
+  if (authoredMajor == null && tickCount(min, max, majorUnit) > MAX_AXIS_TICKS) {
+    majorUnit = ceilingNiceStep(max / (MAX_AXIS_TICKS - 1) - min / (MAX_AXIS_TICKS - 1));
+  }
+  const authoredMinor = positiveUnit(options.minorUnit);
+  // A fully automatic minor plan must cover the entire axis. Since each major
+  // interval contains five minor intervals, coarsen the automatic major unit
+  // up front instead of returning only the first MAX_AXIS_TICKS positions.
+  if (options.needMinor && authoredMajor == null && authoredMinor == null) {
+    const maxMajorIntervals = Math.floor((MAX_AXIS_TICKS - 1) / 5);
+    if (tickCount(min, max, majorUnit / 5) > MAX_AXIS_TICKS) {
+      majorUnit = ceilingNiceStep(max / maxMajorIntervals - min / maxMajorIntervals);
+    }
+  }
+  const minorUnit = options.needMinor ? (authoredMinor ?? majorUnit / 5) : null;
+
+  const majorTicks = indexedTicks(min, max, majorUnit, authoredMajor == null ? 'skip' : 'truncate');
+  const minorTicks = minorUnit == null
+    ? []
+    : indexedTicks(min, max, minorUnit, 'skip', majorUnit);
+  return { min, max, majorUnit, minorUnit, majorTicks, minorTicks };
 }
 
 export function valueAxisScale(
@@ -81,16 +233,10 @@ export function valueAxisScale(
   axisLenPt?: number,
   majorUnit?: number | null,
 ): { min: number; max: number; step: number } {
-  // A file-specified `<c:valAx><c:majorUnit>` (ECMA-376 §21.2.2.103) overrides
-  // the auto "nice" step. Non-positive / non-finite values are ignored (they'd
-  // wedge the gridline loop) so an absent/invalid majorUnit is byte-stable.
-  const autoStep = niceStep(dataMax - dataMin, targetStepsForAxis(axisLenPt));
-  const step = majorUnit != null && isFinite(majorUnit) && majorUnit > 0 ? majorUnit : autoStep;
-  // The auto min/max still round against the AUTO step (Excel derives the bounds
-  // before the user's manual major unit is applied); explicit scaling wins.
-  const min = explicitMin ?? niceAxisMin(dataMin, autoStep);
-  const max = explicitMax ?? niceAxisMax(dataMax, autoStep, min);
-  return { min, max, step };
+  const plan = planLinearValueAxis({
+    dataMin, dataMax, explicitMin, explicitMax, axisLenPt, majorUnit,
+  });
+  return { min: plan.min, max: plan.max, step: plan.majorUnit };
 }
 
 /** Options for {@link axisFraction}: a logarithmic base and/or a reversed
@@ -148,12 +294,29 @@ export function logAxisScale(
   const rawMin = dataMin > 0 ? dataMin : posMax;
   const minExp = Math.floor(logB(rawMin));
   const maxExp = Math.ceil(logB(posMax));
-  const min = explicitMin != null ? explicitMin : Math.pow(b, minExp);
-  const max = explicitMax != null ? explicitMax : Math.pow(b, Math.max(maxExp, minExp + 1));
+  const finitePow = (exponent: number): number => {
+    const value = Math.pow(b, exponent);
+    if (value === 0) return Number.MIN_VALUE;
+    return isFinite(value) ? value : Number.MAX_VALUE;
+  };
+  const min = explicitMin != null ? explicitMin : finitePow(minExp);
+  const max = explicitMax != null ? explicitMax : finitePow(Math.max(maxExp, minExp + 1));
   const lines: number[] = [];
   const startExp = Math.ceil(logB(min) - 1e-9);
   const endExp = Math.floor(logB(max) + 1e-9);
-  for (let e = startExp; e <= endExp; e++) lines.push(Math.pow(b, e));
+  if (!isFinite(startExp) || !isFinite(endExp) || endExp < startExp) return { min, max, lines };
+  const expected = endExp - startExp + 1;
+  const stride = Math.max(1, Math.ceil((expected - 1) / (MAX_AXIS_TICKS - 1)));
+  const count = Math.min(MAX_AXIS_TICKS, Math.floor((expected - 1) / stride) + 1);
+  for (let index = 0; index < count; index++) {
+    const value = finitePow(startExp + index * stride);
+    if (value >= min && value <= max && (lines.length === 0 || value > lines[lines.length - 1])) {
+      lines.push(value);
+    }
+  }
+  const endValue = finitePow(endExp);
+  if (lines.length < MAX_AXIS_TICKS && endValue >= min && endValue <= max
+    && endValue > (lines[lines.length - 1] ?? 0)) lines.push(endValue);
   return { min, max, lines };
 }
 

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -691,13 +691,12 @@ describe('CH1 — negative bar/column values extend from the zero line', () => {
     }), RECT, 1);
 
     // With no visible value-axis ticks, Office uses the default five-interval
-    // auto-scale target: data max 97 → major unit 20 → axis max 120. Applying
-    // the wide-axis tick-density rule would instead choose unit 10 / max 110,
-    // making the stacked bar too long relative to separately authored labels.
+    // auto-scale target: symmetric padding plus the ceiling 1/2/5 ladder gives
+    // data max 97 → major unit 50 → axis max 150.
     const bars = rec.rects;
     expect(bars).toHaveLength(2);
     const totalLength = bars[0].w + bars[1].w;
-    expect(totalLength).toBeCloseTo(RECT.w * 0.8 * (97 / 120), 4);
+    expect(totalLength).toBeCloseTo(RECT.w * 0.8 * (97 / 150), 4);
   });
 
   it('positive-only data keeps the axis anchored at 0 (pre-fix behavior)', () => {
@@ -4013,9 +4012,9 @@ describe('#738 — explicit majorUnit honored on every value axis (§21.2.2.103)
     const coarse = valTickNumbers({
       chartType: 'scatter',
       series: [series({ name: 'S', values: [10, 40, 70, 100] })],
-      valAxisMajorUnit: 50,
+      valAxisMajorUnit: 70,
     });
-    expect(coarse).toContain(50);
+    expect(coarse).toContain(70);
     expect(new Set(coarse).size).toBeLessThan(new Set(auto).size);
   });
 
@@ -4027,11 +4026,11 @@ describe('#738 — explicit majorUnit honored on every value axis (§21.2.2.103)
     const coarse = valTickNumbers({
       chartType: 'radar', categories: ['A', 'B', 'C', 'D'],
       series: [series({ name: 'S', values: [20, 60, 80, 100] })],
-      valAxisMajorUnit: 50,
+      valAxisMajorUnit: 70,
     });
     // Radar skips the center 0-label, so labels are the ring values.
     expect(new Set(coarse).size).toBeLessThan(new Set(auto).size);
-    expect(coarse).toContain(50);
+    expect(coarse).toContain(70);
   });
 
   it('secondary (combo) axis: majorUnit widens its independent step', () => {
@@ -4067,6 +4066,75 @@ describe('#738 — explicit majorUnit honored on every value axis (§21.2.2.103)
   });
 });
 
+describe('automatic linear-axis bounds reach the shared planner', () => {
+  const numericLabels = (values: number[]): number[] => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A', 'B'],
+      series: [series({ values })],
+      valAxisMajorGridlines: false,
+    }), RECT, 1);
+    return rec.texts.map(item => Number(item.text)).filter(Number.isFinite);
+  };
+
+  it('keeps an exact 1.2 positive line range offset and pins just above it to zero', () => {
+    expect(Math.min(...numericLabels([10, 12]))).toBeGreaterThan(0);
+    expect(numericLabels([10, 12.000_001])).toContain(0);
+  });
+
+  it('area geometry uses an authored non-zero minimum', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'area', categories: ['Low', 'High'],
+      series: [series({ values: [50, 100] })],
+      valMin: 50, valMax: 100, valAxisMajorUnit: 50,
+    }), RECT, 1);
+    const y50 = rec.texts.find(item => item.text === '50')?.y;
+    const y100 = rec.texts.find(item => item.text === '100')?.y;
+    expect(y50).toBeDefined();
+    expect(y100).toBeDefined();
+    expect(rec.segs.some(segment =>
+      Math.abs(segment.x1 - segment.x0) > 20
+      && Math.abs(segment.y0 - (y50 as number)) < 1e-6
+      && Math.abs(segment.y1 - (y100 as number)) < 1e-6
+    )).toBe(true);
+  });
+
+  it('area negative-only data uses a negative mirrored extent for ticks and geometry', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'area', categories: ['Low', 'High'],
+      series: [series({ values: [-10, -5] })],
+      valAxisMajorGridlines: false,
+    }), RECT, 1);
+    const numeric = rec.texts.map(item => Number(item.text)).filter(Number.isFinite);
+    expect(Math.min(...numeric)).toBeLessThanOrEqual(-10);
+    expect(Math.max(...numeric)).toBe(0);
+    expect(numeric).not.toContain(1);
+
+    const axisTickYs = rec.texts
+      .filter(item => Number.isFinite(Number(item.text)))
+      .map(item => item.y);
+    expect(rec.segs.some(segment =>
+      Math.abs(segment.x1 - segment.x0) > 20
+      && axisTickYs.some(y => Math.abs(y - segment.y0) < 1e-6)
+      && axisTickYs.some(y => Math.abs(y - segment.y1) < 1e-6)
+    )).toBe(true);
+  });
+
+  it('stacked area extent accumulates positive and negative values separately', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedArea', categories: ['A'],
+      series: [series({ values: [10] }), series({ values: [-8] })],
+      valAxisMajorGridlines: false,
+    }), RECT, 1);
+    const numeric = rec.texts.map(item => Number(item.text)).filter(Number.isFinite);
+    expect(Math.min(...numeric)).toBeLessThanOrEqual(-8);
+    expect(Math.max(...numeric)).toBeGreaterThanOrEqual(10);
+  });
+});
+
 describe('authored minor tick marks are painted between major ticks', () => {
   const shortHorizontal = (segment: Seg): boolean =>
     Math.abs(segment.y1 - segment.y0) < 0.01
@@ -4093,6 +4161,59 @@ describe('authored minor tick marks are painted between major ticks', () => {
 
     expect(rec.segs.filter(segment => shortHorizontal(segment) && segment.x0 < RECT.w / 2).length)
       .toBeGreaterThanOrEqual(15);
+  });
+
+  it('uses automatic major/5 positions for minor ticks without enabling minor gridlines', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A', 'B', 'C'],
+      series: [series({ values: [10, 50, 90] })],
+      valMin: 0, valMax: 100, valAxisMajorUnit: 20,
+      valAxisMajorGridlines: false, valAxisMinorGridlines: false,
+      valAxisMajorTickMark: 'none', valAxisMinorTickMark: 'cross',
+    }), RECT, 1);
+
+    expect(rec.segs.filter(segment => shortHorizontal(segment) && segment.x0 < RECT.w / 2))
+      .toHaveLength(20);
+    expect(rec.segs.filter(segment =>
+      segment.ss === '#e0e0e0' && Math.abs(segment.x1 - segment.x0) > 50
+    ))
+      .toHaveLength(0);
+  });
+
+  it('uses automatic major/5 positions for minor gridlines without enabling minor ticks', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A', 'B', 'C'],
+      series: [series({ values: [10, 50, 90] })],
+      valMin: 0, valMax: 100, valAxisMajorUnit: 20,
+      valAxisMajorGridlines: false,
+      valAxisMinorGridlines: true,
+      valAxisMinorGridlineColor: '123456',
+      valAxisMajorTickMark: 'none', valAxisMinorTickMark: 'none',
+    }), RECT, 1);
+
+    const minorGridYs = rec.segs
+      .filter(segment => segment.ss === '#123456' && Math.abs(segment.x1 - segment.x0) > 50)
+      .map(segment => segment.y0);
+    expect(minorGridYs).toHaveLength(20);
+    expect(rec.segs.filter(segment =>
+      shortHorizontal(segment)
+      && minorGridYs.some(y => Math.abs(y - segment.y0) < 1e-6)
+    )).toHaveLength(0);
+  });
+
+  it('uses automatic minor positions with horizontal value-axis geometry', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'clusteredBarH', categories: ['A', 'B'],
+      series: [series({ values: [20, 80] })],
+      valMin: 0, valMax: 100, valAxisMajorUnit: 20,
+      valAxisMajorGridlines: false,
+      valAxisMajorTickMark: 'none', valAxisMinorTickMark: 'cross',
+    }), RECT, 1);
+
+    expect(rec.segs.filter(shortVertical).length).toBeGreaterThanOrEqual(20);
   });
 
   it('accepts a positive authored minor unit larger than the major unit', () => {
@@ -4226,6 +4347,54 @@ describe('authored minor tick marks are painted between major ticks', () => {
       .toBeGreaterThanOrEqual(15);
   });
 
+  it('uses automatic minor positions on the independent secondary value axis', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line', categories: ['A', 'B', 'C'],
+      series: [
+        series({ values: [1, 2, 3] }),
+        series({ values: [10, 50, 90], useSecondaryAxis: true }),
+      ],
+      secondaryValAxis: {
+        min: 0, max: 100, title: null, hidden: false,
+        majorTickMark: 'none', minorTickMark: 'cross',
+        lineHidden: false, majorUnit: 20,
+      },
+    }), RECT, 1);
+
+    expect(rec.segs.filter(segment => shortHorizontal(segment) && segment.x0 > RECT.w / 2))
+      .toHaveLength(20);
+  });
+
+  it('keeps secondary minor gridlines and ticks independent', () => {
+    const model = (minorGridlines: boolean, minorTickMark: string): ChartModel => baseModel({
+      chartType: 'line', categories: ['A', 'B', 'C'],
+      series: [
+        series({ values: [1, 2, 3] }),
+        series({ values: [10, 50, 90], useSecondaryAxis: true }),
+      ],
+      secondaryValAxis: {
+        min: 0, max: 100, title: null, hidden: false,
+        majorTickMark: 'none', minorTickMark, lineHidden: false,
+        majorUnit: 20, minorGridlines,
+        minorGridlineColor: '123456',
+      },
+    });
+    const gridOnly = segRecordingCtx();
+    renderChart(gridOnly.ctx, model(true, 'none'), RECT, 1);
+    expect(gridOnly.segs.filter(segment =>
+      segment.ss === '#123456' && Math.abs(segment.x1 - segment.x0) > 50
+    )).toHaveLength(20);
+    expect(gridOnly.segs.filter(segment => shortHorizontal(segment) && segment.x0 > RECT.w / 2))
+      .toHaveLength(0);
+
+    const tickOnly = segRecordingCtx();
+    renderChart(tickOnly.ctx, model(false, 'cross'), RECT, 1);
+    expect(tickOnly.segs.filter(segment => segment.ss === '#123456')).toHaveLength(0);
+    expect(tickOnly.segs.filter(segment => shortHorizontal(segment) && segment.x0 > RECT.w / 2))
+      .toHaveLength(20);
+  });
+
   it('draws both numeric X- and Y-axis minor ticks for scatter', () => {
     const rec = segRecordingCtx();
     renderChart(rec.ctx, baseModel({
@@ -4245,6 +4414,41 @@ describe('authored minor tick marks are painted between major ticks', () => {
 
     expect(rec.segs.filter(shortHorizontal).length).toBeGreaterThanOrEqual(15);
     expect(rec.segs.filter(shortVertical).length).toBeGreaterThanOrEqual(15);
+  });
+});
+
+describe('radar value-axis planning', () => {
+  it('honors an explicit minimum and paints minor gridlines without minor ticks', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'radar', radarStyle: 'standard',
+      categories: ['A', 'B', 'C', 'D'],
+      series: [series({ values: [50, 60, 70, 80] })],
+      valMin: 50, valMax: 100, valAxisMajorUnit: 25,
+      valAxisMinorGridlines: true, valAxisMinorGridlineColor: '123456',
+      valAxisMinorTickMark: 'none',
+    }), RECT, 1);
+    expect(rec.texts.some(item => item.text === '50')).toBe(false);
+    expect(rec.texts.some(item => item.text === '75')).toBe(true);
+    expect(rec.segs.filter(segment => segment.ss === '#123456').length).toBeGreaterThan(0);
+  });
+
+  it('paints radar minor ticks without enabling minor gridlines', () => {
+    const rec = segRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'radar', radarStyle: 'standard',
+      categories: ['A', 'B', 'C', 'D'],
+      series: [series({ values: [50, 60, 70, 80] })],
+      valMin: 50, valMax: 100, valAxisMajorUnit: 25,
+      valAxisMinorGridlines: false,
+      valAxisMinorTickMark: 'cross',
+    }), RECT, 1);
+    expect(rec.segs.filter(segment => segment.ss === '#e0e0e0')).toHaveLength(0);
+    expect(rec.segs.filter(segment =>
+      Math.abs(segment.y1 - segment.y0) < 1e-6
+      && Math.abs(segment.x1 - segment.x0) > 0
+      && Math.abs(segment.x1 - segment.x0) <= 12
+    ).length).toBeGreaterThan(0);
   });
 });
 
@@ -6714,9 +6918,9 @@ describe('CH — combo bar+line primary value axis spans BOTH the bars and the p
       ],
     }), RECT, 1);
     const axisMax = Math.max(...numericValLabels(rec));
-    // Bars alone: max category sum 150 → axis top 160 (unchanged by the fix).
-    expect(axisMax).toBe(160);
-    // The line contribution is what lifts the previous case from 160 to 200.
+    // Bars alone: max category sum 150 → symmetric padding and the ceiling
+    // 1/2/5 ladder produce an axis top of 200.
+    expect(axisMax).toBe(200);
   });
 
   it('a negative primary-axis line pulls the axis minimum below the bars', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -21,7 +21,15 @@ import {
   valueTickLabelGapPx,
   type ChartLegendReserve,
 } from './layout.js';
-import { niceStep, valueAxisScale, axisFraction, logAxisScale, fitTrendline, linearTrendlineStats } from './axis-scale.js';
+import {
+  axisLengthNiceStep,
+  valueAxisScale,
+  planLinearValueAxis,
+  axisFraction,
+  logAxisScale,
+  fitTrendline,
+  linearTrendlineStats,
+} from './axis-scale.js';
 import { axisLineWidthPx, resolveAxisLine, resolveGridline, isCrossBetween } from './axis-style.js';
 import { formatChartVal, formatChartValWithCode, formatCategoryLabel } from './chart-number-format.js';
 import { elideToWidth } from './text-elide.js';
@@ -743,53 +751,31 @@ function drawAxisTick(
   ctx.lineWidth = prevW;
 }
 
-/** Visit authored minor-unit positions between adjacent major ticks. OOXML does
- * not define the application's automatic minor unit, so an omitted
- * `<c:minorUnit>` deliberately produces no guessed positions. */
-const MAX_AXIS_TICKS = 10_000;
-
 function minorAxisValues(
   min: number,
   max: number,
   majorStep: number,
   minorUnit: number | null | undefined,
 ): number[] {
-  const step = minorUnit != null && isFinite(minorUnit) && minorUnit > 0
-    ? minorUnit
-    : 0;
-  if (!(step > 0) || !(majorStep > 0)) return [];
-  const epsilon = Math.max(Math.abs(majorStep), Math.abs(step)) * 1e-8;
-  const values: number[] = [];
-  // Axis units advance from the authored/derived scale minimum. Anchoring at
-  // numeric zero shifts every minor division when an explicit non-zero min is
-  // present and can also double-paint a major position.
-  let iterations = 0;
-  for (let value = min + step;
-    value < max - epsilon && iterations < MAX_AXIS_TICKS;
-    iterations += 1) {
-    // IEEE-754 addition can stop progressing for a positive but sub-ULP unit.
-    // Reject that authored scale instead of hanging the renderer. The count
-    // cap also bounds hostile documents whose unit requests millions of marks.
-    if (!(value > min) || !isFinite(value)) break;
-    // A position shared with a major tick is already painted by the major
-    // layer; do not double-stroke it when the two authored units coincide.
-    const majorMultiple = (value - min) / majorStep;
-    if (Math.abs(majorMultiple - Math.round(majorMultiple)) > 1e-8) values.push(value);
-    const next = value + step;
-    if (!(next > value)) break;
-    value = next;
-  }
-  return values;
+  return planLinearValueAxis({
+    dataMin: min,
+    dataMax: max,
+    explicitMin: min,
+    explicitMax: max,
+    majorUnit: majorStep,
+    minorUnit,
+    needMinor: true,
+  }).minorTicks;
 }
 
-function forEachMinorTick(
-  min: number,
-  max: number,
-  majorStep: number,
-  minorUnit: number | null | undefined,
-  visit: (value: number) => void,
-): void {
-  for (const value of minorAxisValues(min, max, majorStep, minorUnit)) visit(value);
+function majorAxisValues(min: number, max: number, majorStep: number): number[] {
+  return planLinearValueAxis({
+    dataMin: min,
+    dataMax: max,
+    explicitMin: min,
+    explicitMax: max,
+    majorUnit: majorStep,
+  }).majorTicks;
 }
 
 /** Stroke one horizontal value-axis gridline spanning the plot width at `gy`.
@@ -869,6 +855,25 @@ function valMinorGridStroke(
     width,
     explicit: chart.valAxisMinorGridlineColor != null,
     dash: dashPatternForPreset(chart.valAxisMinorGridlineDash ?? undefined),
+  };
+}
+
+function secondaryMinorGridStroke(
+  axis: SecondaryValueAxis,
+  ptToPx: number,
+): { color: string; width: number; explicit: boolean; dash: number[] } {
+  const { color, width } = resolveGridline(
+    axis.minorGridlineColor,
+    axis.minorGridlineWidthEmu,
+    ptToPx,
+  );
+  return {
+    color,
+    width,
+    explicit: axis.minorGridlineColor != null
+      || axis.minorGridlineWidthEmu != null
+      || axis.minorGridlineDash != null,
+    dash: dashPatternForPreset(axis.minorGridlineDash ?? undefined),
   };
 }
 
@@ -952,6 +957,7 @@ interface ValueAxisPlan {
   step: number;
   majorLines: number[];
   minorLines: number[];
+  minorTicks: number[];
   /** 0..1 position of `v` from the axis minimum toward the maximum (log-aware,
    *  orientation-aware). Renderers turn this into a pixel with
    *  `plotBottom - frac(v) * plotHeight` (vertical) — the reversal is already
@@ -1015,25 +1021,52 @@ function planValueAxis(
       step: lines.length > 1 ? lines[1] - lines[0] : max - min,
       majorLines: lines,
       minorLines: [],
+      minorTicks: [],
       frac: (v: number) => axisFraction(v, min, max, { logBase, reversed }),
     };
   }
-  const { min, max, step } = valueAxisScale(
-    dataMin, dataMax, explicitMin, explicitMax, axisLenPt, majorUnit,
-  );
-  const range = (max - min) || 1;
-  const majorLines: number[] = [];
-  const steps = Math.round((max - min) / step);
-  for (let si = 0; si <= steps; si++) majorLines.push(min + si * step);
-  // Minor gridlines (ECMA-376 §21.2.2.109/§21.2.2.112): only when the file both
-  // declares `<c:minorGridlines>` AND a positive `<c:minorUnit>`; the minor lines
-  // are the positive-unit positions measured from the scale minimum. The
-  // schema only requires a positive value; it does not require minor < major.
-  const minorLines: number[] = [];
+  if (percentStacked) {
+    const min = explicitMin ?? dataMin;
+    const max = explicitMax ?? dataMax;
+    const step = majorUnit != null && isFinite(majorUnit) && majorUnit > 0
+      ? majorUnit
+      : axisLengthNiceStep(dataMax - dataMin, axisLenPt);
+    const majorLines = majorAxisValues(min, max, step);
+    const needsMinorTicks = chart.valAxisMinorTickMark != null
+      && chart.valAxisMinorTickMark !== 'none';
+    const mu = valueAxisUnitInRendererSpace(chart.valAxisMinorUnit, true);
+    const minorTicks = chart.valAxisMinorGridlines === true || needsMinorTicks
+      ? minorAxisValues(min, max, step, mu)
+      : [];
+    const range = (max - min) || 1;
+    return {
+      min,
+      max,
+      step,
+      majorLines,
+      minorLines: chart.valAxisMinorGridlines ? minorTicks : [],
+      minorTicks,
+      frac: (v: number) => (reversed ? 1 - (v - min) / range : (v - min) / range),
+    };
+  }
+  const needsMinorTicks = chart.valAxisMinorTickMark != null
+    && chart.valAxisMinorTickMark !== 'none';
   const mu = valueAxisUnitInRendererSpace(chart.valAxisMinorUnit, percentStacked);
-  if (chart.valAxisMinorGridlines) minorLines.push(...minorAxisValues(min, max, step, mu));
+  const linear = planLinearValueAxis({
+    dataMin,
+    dataMax,
+    explicitMin,
+    explicitMax,
+    axisLenPt,
+    majorUnit,
+    minorUnit: mu,
+    needMinor: chart.valAxisMinorGridlines === true || needsMinorTicks,
+  });
+  const { min, max, majorUnit: step, majorTicks: majorLines } = linear;
+  const range = (max - min) || 1;
+  const minorLines = chart.valAxisMinorGridlines ? linear.minorTicks : [];
   return {
-    min, max, step, majorLines, minorLines,
+    min, max, step, majorLines, minorLines, minorTicks: linear.minorTicks,
     frac: (v: number) => (reversed ? 1 - (v - min) / range : (v - min) / range),
   };
 }
@@ -1348,15 +1381,16 @@ interface SecondaryAxisScale {
   min: number;
   max: number;
   step: number;
+  majorLines: number[];
+  minorTicks: number[];
   makeToY: (py0: number, ph: number) => (v: number) => number;
 }
 
 /** Compute the INDEPENDENT scale of a secondary value axis from the series that
  *  opt into it (`useSecondaryAxis === true`). Shared by every axis family that
  *  supports a secondary axis (bar-combo line series, and plain line / area
- *  series): the axis has its own "nice" major unit / gridline count, anchored so
- *  its min never sits above 0 (Excel keeps the zero line reachable), with an
- *  explicit `<c:scaling><c:min/max>` (`sec.min`/`sec.max`) overriding. Returns
+ *  series): the axis has its own bounded automatic plan, with an explicit
+ *  `<c:scaling><c:min/max>` (`sec.min`/`sec.max`) overriding. Returns
  *  null when no `SecondaryValueAxis` was parsed OR no series opts into it — the
  *  caller then keeps the single-axis path unchanged.
  *
@@ -1364,9 +1398,7 @@ interface SecondaryAxisScale {
  *  vertical right edge, so its length drives the auto major unit). `getValues`
  *  yields each opted-in series' raw values.
  *
- *  This is a pure refactor of the bar renderer's inline secondary-scale math —
- *  same `valueAxisScale(Math.min(0, dMin), dMax, sec.min, sec.max, len)` call,
- *  same empty-data fallback (dMin→0, dMax→1). */
+ *  Empty secondary data keeps the neutral 0..1 fallback. */
 function computeSecondaryAxis(
   sec: SecondaryValueAxis | null,
   seriesForSecondary: ChartSeries[],
@@ -1382,12 +1414,25 @@ function computeSecondaryAxis(
   const dMax = secVals.length ? Math.max(...secVals) : 1;
   // An explicit `<c:valAx><c:majorUnit>` on the secondary axis (§21.2.2.103)
   // overrides the auto step, mirroring the primary axis. null ⇒ auto.
-  const { min, max, step } = valueAxisScale(Math.min(0, dMin), dMax, sec.min, sec.max, plotHeightPt, sec.majorUnit);
+  const linear = planLinearValueAxis({
+    dataMin: dMin,
+    dataMax: dMax,
+    explicitMin: sec.min,
+    explicitMax: sec.max,
+    axisLenPt: plotHeightPt,
+    majorUnit: sec.majorUnit,
+    minorUnit: sec.minorUnit,
+    needMinor: sec.minorGridlines === true
+      || (sec.minorTickMark != null && sec.minorTickMark !== 'none'),
+  });
+  const { min, max, majorUnit: step } = linear;
   const range = (max - min) || 1;
   return {
     min,
     max,
     step,
+    majorLines: linear.majorTicks,
+    minorTicks: linear.minorTicks,
     makeToY: (py0: number, ph: number) => (v: number): number => py0 + ph - ((v - min) / range) * ph,
   };
 }
@@ -1425,23 +1470,26 @@ function drawSecondaryValueAxis(
     ctx.beginPath(); ctx.moveTo(axX, py0); ctx.lineTo(axX, py0 + ph); ctx.stroke();
   }
   if (!sec.hidden) {
+    if (sec.minorGridlines) {
+      const grid = secondaryMinorGridStroke(sec, ptToPx);
+      for (const value of secScale.minorTicks) {
+        strokeValueGridlineH(ctx, px0, pw, toYSecondary(value), false, grid);
+      }
+    }
     ctx.font = `${secFontPx}px ${chartFontFamily(chart, sec.fontFace, 'minor')}`;
     ctx.fillStyle = sec.fontColor ? `#${sec.fontColor}` : primaryLabelColor;
     ctx.textAlign = 'left';
     ctx.textBaseline = 'middle';
-    const sRange = (secScale.max - secScale.min) || 1;
-    const secSteps = Math.max(1, Math.round(sRange / secScale.step));
-    for (let si = 0; si <= secSteps; si++) {
-      const sval = secScale.min + si * secScale.step;
+    for (const sval of secScale.majorLines) {
       const gy = toYSecondary(sval);
       // Same tick geometry as the left axis, mirrored to the right edge.
       drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true, sec.lineHidden);
       ctx.fillText(formatChartValWithCode(sval, sec.formatCode ?? null, date1904), axX + 14, gy);
     }
     if (sec.minorTickMark && sec.minorTickMark !== 'none') {
-      forEachMinorTick(secScale.min, secScale.max, secScale.step, sec.minorUnit, value => {
+      for (const value of secScale.minorTicks) {
         drawAxisTick(ctx, sec.minorTickMark, 'val', axX, toYSecondary(value), secLineColor, secLineW, true, sec.lineHidden);
-      });
+      }
     }
   }
   if (sec.title) {
@@ -1846,7 +1894,7 @@ function renderBarChart(
   // `planValueAxis` folds in the CH6 major unit / logBase / orientation; with
   // none set it is byte-identical to `valueAxisScale` + a linear map.
   const plan = planValueAxis(chart, dataMin, dataMax, valAxisLenPt, pct);
-  const { min: axMin, max: axMax, step } = plan;
+  const { step } = plan;
 
   // Secondary value-axis scale (combo charts). INDEPENDENT of the primary: its
   // own "nice" major unit / gridline count. Its axis is the vertical right edge,
@@ -1872,9 +1920,7 @@ function renderBarChart(
     // reserved gutter width matches the painted labels when a real face is set.
     ctx.font = `${measuredValTickFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     let wmax = 0;
-    const vSteps = Math.round((axMax - axMin) / step);
-    for (let si = 0; si <= vSteps; si++) {
-      const val = axMin + si * step;
+    for (const val of plan.majorLines) {
       const label = formatPrimaryValueAxisTick(chart, val, pct);
       wmax = Math.max(wmax, ctx.measureText(label).width);
     }
@@ -1890,9 +1936,8 @@ function renderBarChart(
   if (sec && !sec.hidden) {
     ctx.font = `${secFontPx}px ${chartFontFamily(chart, sec.fontFace, 'minor')}`;
     let wmax = 0;
-    const sSteps = Math.round((sMax - sMin) / sStep);
-    for (let si = 0; si <= sSteps; si++) {
-      wmax = Math.max(wmax, ctx.measureText(formatChartValWithCode(sMin + si * sStep, sec.formatCode ?? null, chart.date1904)).width);
+    for (const value of secScale?.majorLines ?? majorAxisValues(sMin, sMax, sStep)) {
+      wmax = Math.max(wmax, ctx.measureText(formatChartValWithCode(value, sec.formatCode ?? null, chart.date1904)).width);
     }
     secLabelBandW = wmax + 18;
   }
@@ -2008,13 +2053,11 @@ function renderBarChart(
   // line-mapping helpers need the now-final plot rect, so they live here. Line
   // series bound to the secondary axis map through `toYSecondary`; everything
   // else uses the primary `axMax`.
-  const sRange = (sMax - sMin) || 1;
   // Primary value → pixel. `axRange`/`axMin` generalize the old `v / axMax`
   // mapping so the zero line sits wherever the axis crosses it (mid-plot when
   // the data straddles zero); positive-only data keeps `axMin === 0`, so the
   // mapping is unchanged. `valX`/`valY` give the on-axis pixel for a value on
   // the value axis (X for horizontal bars, Y for columns).
-  const axRange = (axMax - axMin) || 1;
   const valY = (v: number): number => py0 + ph - plan.frac(v) * ph;
   const valX = (v: number): number => px0 + plan.frac(v) * pw;
   const zeroY = valY(0); // column zero line
@@ -2030,7 +2073,6 @@ function renderBarChart(
   // the faint `#e0e0e0`/0.5 px default). The vertical (horizontal-bar) path
   // strokes gridlines inline, so it reads `grid.color`/`grid.width` directly.
   const grid = valGridStroke(chart, ptToPx);
-  const steps = Math.round(axRange / step);
   ctx.textBaseline = 'middle';
   const drawnValTickFontPx = chart.valAxisFontSizeHpt != null
     ? valAxLabelFontPx
@@ -2163,8 +2205,7 @@ function renderBarChart(
     // column chart the value axis is vertical (left) and the category axis
     // horizontal (bottom); a horizontal bar chart swaps the two.
     if (!chart.valAxisHidden && chart.valAxisMajorTickMark && chart.valAxisMajorTickMark !== 'none') {
-      for (let si = 0; si <= steps; si++) {
-        const val = axMin + si * step;
+      for (const val of plan.majorLines) {
         if (!isH) {
           drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, valY(val), valLineColor, valLineW, false, chart.valAxisLineHidden);
         } else {
@@ -2173,13 +2214,13 @@ function renderBarChart(
       }
     }
     if (!chart.valAxisHidden && chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
-      forEachMinorTick(axMin, axMax, step, chart.valAxisMinorUnit, value => {
+      for (const value of plan.minorTicks) {
         if (!isH) {
           drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, valY(value), valLineColor, valLineW, false, chart.valAxisLineHidden);
         } else {
           drawAxisTick(ctx, chart.valAxisMinorTickMark, 'cat', py0 + ph, valX(value), valLineColor, valLineW, false, chart.valAxisLineHidden);
         }
-      });
+      }
     }
     // Category ticks sit at band BOUNDARIES with crossBetween="between" (the
     // bar/column default) — the dividers between Q1|Q2|Q3|Q4 (n+1 ticks) — and
@@ -2606,22 +2647,26 @@ function renderBarChart(
     const { color: secLineColor, width: secLineW } = resolveAxisLine(sec.lineColor, sec.lineWidthEmu, ptToPx);
     if (!sec.lineHidden) strokeAxis(axX, py0, axX, py0 + ph, secLineColor, secLineW);
     if (!sec.hidden) {
+      if (sec.minorGridlines) {
+        const grid = secondaryMinorGridStroke(sec, ptToPx);
+        for (const value of secScale?.minorTicks ?? []) {
+          strokeValueGridlineH(ctx, px0, pw, toYSecondary(value), false, grid);
+        }
+      }
       ctx.font = `${secFontPx}px ${chartFontFamily(chart, sec.fontFace, 'minor')}`;
       ctx.fillStyle = sec.fontColor ? `#${sec.fontColor}` : valLabelColor;
       ctx.textAlign = 'left';
       ctx.textBaseline = 'middle';
-      const secSteps = Math.max(1, Math.round(sRange / sStep));
-      for (let si = 0; si <= secSteps; si++) {
-        const sval = sMin + si * sStep;
+      for (const sval of secScale?.majorLines ?? majorAxisValues(sMin, sMax, sStep)) {
         const gy = toYSecondary(sval);
         // Same tick geometry as the left axis, mirrored to the right edge.
         drawAxisTick(ctx, sec.majorTickMark, 'val', axX, gy, secLineColor, secLineW, true, sec.lineHidden);
         ctx.fillText(formatChartValWithCode(sval, sec.formatCode ?? null, chart.date1904), axX + 14, gy);
       }
       if (sec.minorTickMark && sec.minorTickMark !== 'none') {
-        forEachMinorTick(sMin, sMax, sStep, sec.minorUnit, value => {
+        for (const value of secScale?.minorTicks ?? minorAxisValues(sMin, sMax, sStep, sec.minorUnit)) {
           drawAxisTick(ctx, sec.minorTickMark, 'val', axX, toYSecondary(value), secLineColor, secLineW, true, sec.lineHidden);
-        });
+        }
       }
     }
     if (sec.title) {
@@ -2736,10 +2781,9 @@ function renderLineChart(
   if (!isFinite(dataMin)) { dataMin = 0; dataMax = 1; }
   const isLogAxis = chart.valAxisLogBase != null && chart.valAxisLogBase >= 2;
   if (chart.valMin != null) dataMin = pct ? chart.valMin * 100 : chart.valMin;
-  else if (dataMin > 0 && !isLogAxis) dataMin = 0;
+  else if (pct && dataMin > 0 && !isLogAxis) dataMin = 0;
   if (chart.valMax != null) dataMax = pct ? chart.valMax * 100 : chart.valMax;
-  else if (dataMax < 0) dataMax = 0;
-  if (dataMax === dataMin) dataMax = dataMin + 1;
+  else if (pct && dataMax < 0) dataMax = 0;
 
   // Shared frame bands. Title + category-label bands follow PowerPoint's chart
   // auto-layout (font-proportional, pinned to the demo slide-5 line-chart PDF);
@@ -2784,9 +2828,8 @@ function renderLineChart(
     const prevFont = ctx.font;
     ctx.font = `${secFontPx}px ${chartFontFamily(chart, sec.fontFace, 'minor')}`;
     let wmax = 0;
-    const sSteps = Math.round((secScale.max - secScale.min) / secScale.step);
-    for (let si = 0; si <= sSteps; si++) {
-      wmax = Math.max(wmax, ctx.measureText(formatChartValWithCode(secScale.min + si * secScale.step, sec.formatCode ?? null, chart.date1904)).width);
+    for (const value of secScale.majorLines) {
+      wmax = Math.max(wmax, ctx.measureText(formatChartValWithCode(value, sec.formatCode ?? null, chart.date1904)).width);
     }
     secLabelBandW = wmax + 18;
     ctx.font = prevFont;
@@ -2910,9 +2953,9 @@ function renderLineChart(
       }
     }
     if (chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
-      forEachMinorTick(plan.min, plan.max, plan.step, chart.valAxisMinorUnit, value => {
+      for (const value of plan.minorTicks) {
         drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, toY(value), primaryValTickColor, primaryValTickWidth, false, chart.valAxisLineHidden);
-      });
+      }
     }
   }
 
@@ -3192,8 +3235,8 @@ function renderStockChart(
   }
 
   // ── Value-axis extent: across every series' plotted values (the hi-lo line
-  // needs both the low and high extremes). Anchored at 0 for positive data
-  // (matching Excel's stock chart) unless the file sets an explicit min. ──
+  // needs both the low and high extremes). Authored bounds are retained and
+  // omitted bounds flow through the shared automatic planner. ──
   let dataMin = Infinity;
   let dataMax = -Infinity;
   for (const s of series) {
@@ -3206,10 +3249,7 @@ function renderStockChart(
   }
   if (!isFinite(dataMin)) { dataMin = 0; dataMax = 1; }
   if (chart.valMin != null) dataMin = chart.valMin;
-  else if (dataMin > 0) dataMin = 0;
   if (chart.valMax != null) dataMax = chart.valMax;
-  else if (dataMax < 0) dataMax = 0;
-  if (dataMax === dataMin) dataMax = dataMin + 1;
 
   const plan = planValueAxis(chart, dataMin, dataMax, ph / ptToPx);
   if (plan.max - plan.min === 0) return;
@@ -3242,12 +3282,12 @@ function renderStockChart(
         ctx.fillText(formatChartValWithCode(v, chart.valAxisFormatCode, chart.date1904), px0 - 6, gy);
       }
     }
-    forEachMinorTick(plan.min, plan.max, plan.step, chart.valAxisMinorUnit, v => {
+    for (const v of plan.minorTicks) {
       drawAxisTick(
         ctx, chart.valAxisMinorTickMark, 'val', px0, toY(v),
         undefined, undefined, false, chart.valAxisLineHidden,
       );
-    });
+    }
   }
 
   // Axis rules (bottom = category, left = value).
@@ -3438,9 +3478,8 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     const prevFont = ctx.font;
     ctx.font = `${secFontPx}px ${chartFontFamily(chart, sec.fontFace, 'minor')}`;
     let wmax = 0;
-    const sSteps = Math.round((secScale.max - secScale.min) / secScale.step);
-    for (let si = 0; si <= sSteps; si++) {
-      wmax = Math.max(wmax, ctx.measureText(formatChartValWithCode(secScale.min + si * secScale.step, sec.formatCode ?? null, chart.date1904)).width);
+    for (const value of secScale.majorLines) {
+      wmax = Math.max(wmax, ctx.measureText(formatChartValWithCode(value, sec.formatCode ?? null, chart.date1904)).width);
     }
     secLabelBandW = wmax + 18;
     ctx.font = prevFont;
@@ -3454,40 +3493,48 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   // the actual formatted tick-label width. The outer rectangle includes axis
   // labels and ticks (ECMA-376 §21.2.2.89); treating its left edge as `px0`
   // pushes the labels outside chart space.
-  const computeAreaDataMax = (): number => {
-    let max = 0;
+  const computeAreaDataExtent = (): { min: number; max: number } => {
+    let min = Infinity;
+    let max = -Infinity;
     for (let ci = 0; ci < n; ci++) {
       if (stacked) {
-        let sum = 0;
+        let positive = 0;
+        let negative = 0;
         for (let areaIndex = 0; areaIndex < areaSeries.length; areaIndex++) {
-          sum += stackedValue(areaIndex, ci);
+          const value = stackedValue(areaIndex, ci);
+          if (value >= 0) positive += value;
+          else negative += value;
         }
-        max = Math.max(max, sum);
+        min = Math.min(min, negative);
+        max = Math.max(max, positive);
       } else {
-        for (const s of chart.series) {
-          if (isSecondarySeries(s)) continue;
-          max = Math.max(max, s.values[ci] ?? 0);
+        for (const { series } of areaSeries) {
+          if (isSecondarySeries(series)) continue;
+          const value = series.values[ci];
+          if (value == null) continue;
+          min = Math.min(min, value);
+          max = Math.max(max, value);
         }
       }
       for (const { series } of lineSeries) {
         if (isSecondarySeries(series)) continue;
-        max = Math.max(max, series.values[ci] ?? 0);
+        const value = series.values[ci];
+        if (value == null) continue;
+        min = Math.min(min, value);
+        max = Math.max(max, value);
       }
     }
-    if (pct) max = max > 0 ? 100 : 0;
-    if (chart.valMax != null) max = pct ? chart.valMax * 100 : chart.valMax;
-    return max === 0 ? 1 : max;
+    if (!isFinite(min) || !isFinite(max)) return { min: 0, max: 1 };
+    if (pct) return { min: min < 0 ? -100 : 0, max: max > 0 ? 100 : 0 };
+    return { min, max };
   };
-  const dataMax = computeAreaDataMax();
-  const explicitMax = pct ? dataMax : chart.valMax;
-  const majorUnit = valueAxisUnitInRendererSpace(chart.valAxisMajorUnit, pct);
-  const provisionalScale = valueAxisScale(
-    0,
-    dataMax,
-    undefined,
-    explicitMax,
+  const areaExtent = computeAreaDataExtent();
+  const provisionalScale = planValueAxis(
+    chart,
+    areaExtent.min,
+    areaExtent.max,
     phEst / ptToPx,
-    majorUnit,
+    pct,
   );
   const manualValTickFontPx = chart.valAxisFontSizeHpt != null
     ? valAxFontPx
@@ -3500,11 +3547,10 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   ) {
     const prevFont = ctx.font;
     ctx.font = `${manualValTickFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
-    const steps = Math.round(provisionalScale.max / provisionalScale.step);
-    for (let si = 0; si <= steps; si++) {
+    for (const value of provisionalScale.majorLines) {
       primaryLabelWidth = Math.max(
         primaryLabelWidth,
-        ctx.measureText(formatPrimaryValueAxisTick(chart, si * provisionalScale.step, pct)).width,
+        ctx.measureText(formatPrimaryValueAxisTick(chart, value, pct)).width,
       );
     }
     ctx.font = prevFont;
@@ -3554,17 +3600,9 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   // Primary extent from the PRIMARY series only (secondary series live on their
   // own axis). When `sec` is null every series is primary, byte-identical to
   // the pre-CH7 path.
-  // Area anchors the value axis at 0; ignore the returned min. Value axis is
-  // vertical → length = plot height (axis-length-aware auto major unit). An
+  // Value axis is vertical → length = plot height (axis-length-aware auto major unit). An
   // explicit `<c:valAx><c:majorUnit>` (§21.2.2.103) overrides the auto step.
-  const { max: axMax, step } = valueAxisScale(
-    0,
-    dataMax,
-    undefined,
-    explicitMax,
-    ph / ptToPx,
-    majorUnit,
-  );
+  const areaPlan = planValueAxis(chart, areaExtent.min, areaExtent.max, ph / ptToPx, pct);
 
   // crossBetween="between" (Office's default; ECMA-376 §21.2.2.32 leaves the
   // default application-defined) gives each category a band of width pw/n and
@@ -3575,7 +3613,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   const toX = between
     ? (i: number) => px0 + ((i + 0.5) / n) * pw
     : (i: number) => px0 + (n === 1 ? pw / 2 : (i / (n - 1)) * pw);
-  const toY = (v: number) => py0 + ph - (v / axMax) * ph;
+  const toY = (v: number) => py0 + ph - areaPlan.frac(v) * ph;
   // Secondary series map through their own scale; `secScale` is null on the
   // common single-axis path so `yMapFor` always returns the primary `toY`.
   const toYSecondary = secScale ? secScale.makeToY(py0, ph) : toY;
@@ -3601,20 +3639,16 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     const grid = valGridStroke(chart, ptToPx);
     const minorGrid = valMinorGridStroke(chart, ptToPx);
     // Minor gridlines (`<c:valAx><c:minorGridlines>`, §21.2.2.129) drawn first,
-    // UNDER the majors and the series, only when the file declares them AND a
-    // positive `<c:minorUnit>`. Positions are generated by the same scale-min
-    // based helper used by the other value-axis renderers.
-    const mu = valueAxisUnitInRendererSpace(chart.valAxisMinorUnit, pct);
+    // UNDER the majors and the series when the file declares them. An omitted
+    // minor unit uses the shared automatic major/5 fallback.
     if (chart.valAxisMinorGridlines) {
-      forEachMinorTick(0, axMax, step, mu, v => {
+      for (const v of areaPlan.minorLines) {
         strokeValueGridlineH(ctx, px0, pw, toY(v), false, minorGrid);
-      });
+      }
     }
     if (drawValMajorGridlines(chart)) {
-      const steps = Math.round(axMax / step);
-      for (let si = 0; si <= steps; si++) {
-        const v = si * step;
-        strokeValueGridlineH(ctx, px0, pw, toY(v), si === 0, grid);
+      for (const v of areaPlan.majorLines) {
+        strokeValueGridlineH(ctx, px0, pw, toY(v), v === 0, grid);
       }
     }
   }
@@ -3835,9 +3869,8 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       : Math.max(8, Math.min(11, ph / 20));
     ctx.font = `${drawnValTickFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     ctx.textBaseline = 'middle';
-    const steps = Math.round(axMax / step);
-    for (let si = 0; si <= steps; si++) {
-      const v = si * step; const gy = toY(v);
+    for (const v of areaPlan.majorLines) {
+      const gy = toY(v);
       drawAxisTick(ctx, chart.valAxisMajorTickMark, 'val', px0, gy, valLineColor, valLineW, false, chart.valAxisLineHidden);
       ctx.fillStyle = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
       ctx.textAlign = 'right';
@@ -3847,10 +3880,9 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
       ctx.fillText(formatPrimaryValueAxisTick(chart, v, pct), px0 - gap, gy);
     }
     if (chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
-      const minorUnit = valueAxisUnitInRendererSpace(chart.valAxisMinorUnit, pct);
-      forEachMinorTick(0, axMax, step, minorUnit, value => {
+      for (const value of areaPlan.minorTicks) {
         drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', px0, toY(value), valLineColor, valLineW, false, chart.valAxisLineHidden);
-      });
+      }
     }
   }
   // Category-axis baseline + value-axis rule. Office treats
@@ -4702,17 +4734,37 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
   const cy2 = frame.center.cy;
   const rd  = Math.min(pw, ph) * 0.38;
 
-  let dataMax = 0;
-  for (const s of chart.series) for (const v of s.values) dataMax = Math.max(dataMax, v ?? 0);
-  if (chart.valMax != null) dataMax = chart.valMax;
+  let dataMin = Infinity;
+  let dataMax = -Infinity;
+  for (const s of chart.series) for (const v of s.values) {
+    if (v == null) continue;
+    dataMin = Math.min(dataMin, v);
+    dataMax = Math.max(dataMax, v);
+  }
+  if (!isFinite(dataMin)) { dataMin = 0; dataMax = 1; }
   if (dataMax === 0) dataMax = 1;
-  // Radar anchors the value axis at 0; ignore the returned min. An explicit
-  // `<c:valAx><c:majorUnit>` (§21.2.2.103) overrides the auto ring step. The
+  const needsMinorTicks = chart.valAxisMinorTickMark != null
+    && chart.valAxisMinorTickMark !== 'none';
+  // An explicit `<c:valAx><c:majorUnit>` (§21.2.2.103) overrides the auto ring step. The
   // axis-length-aware auto density (GRIDLINE_SPACING_PT) is calibrated against
   // Cartesian bar/line/area axes, not the radial spoke, so radar keeps the
   // legacy fixed auto target (axisLenPt undefined) — only the explicit majorUnit
   // path is new (byte-stable auto rings).
-  const { max: axMax, step } = valueAxisScale(0, dataMax, undefined, chart.valMax, undefined, chart.valAxisMajorUnit);
+  const radarAxisPlan = planLinearValueAxis({
+    dataMin,
+    dataMax,
+    explicitMin: chart.valMin,
+    explicitMax: chart.valMax,
+    majorUnit: chart.valAxisMajorUnit,
+    minorUnit: chart.valAxisMinorUnit,
+    needMinor: chart.valAxisMinorGridlines === true || needsMinorTicks,
+  });
+  const { min: axMin, max: axMax } = radarAxisPlan;
+  const radarFrac = (value: number): number => clamp(
+    axisFraction(value, axMin, axMax, { reversed: valAxisReversed(chart) }),
+    0,
+    1,
+  );
 
   const angle0 = -Math.PI / 2;
   const spoke  = (i: number) => angle0 + (i / n) * Math.PI * 2;
@@ -4722,11 +4774,9 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
   // the value (not `ri / rings`) keeps the rings on the major-unit multiples
   // even when `axMax` is not an exact multiple of `step` (e.g. an explicit
   // `<c:majorUnit>` §21.2.2.103 that doesn't divide the auto-rounded max).
-  const rings = Math.round(axMax / step);
-  const ringValue = (ri: number): number => Math.min(ri * step, axMax);
-  ctx.strokeStyle = '#ddd'; ctx.lineWidth = 0.5;
-  for (let ri = 1; ri <= rings; ri++) {
-    const rr = (ringValue(ri) / axMax) * rd;
+  const ringValues = radarAxisPlan.majorTicks.filter(value => radarFrac(value) > 0);
+  const strokeRing = (value: number): void => {
+    const rr = radarFrac(value) * rd;
     ctx.beginPath();
     for (let i = 0; i < n; i++) {
       const a = spoke(i);
@@ -4734,7 +4784,18 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
       if (i === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
     }
     ctx.closePath(); ctx.stroke();
+  };
+  if (chart.valAxisMinorGridlines) {
+    const minorGrid = valMinorGridStroke(chart, ptToPx);
+    ctx.strokeStyle = minorGrid.color;
+    ctx.lineWidth = minorGrid.width;
+    const previousDash = minorGrid.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
+    if (minorGrid.dash.length > 0) ctx.setLineDash(minorGrid.dash);
+    for (const value of radarAxisPlan.minorTicks) strokeRing(value);
+    if (minorGrid.dash.length > 0) ctx.setLineDash(previousDash);
   }
+  ctx.strokeStyle = '#ddd'; ctx.lineWidth = 0.5;
+  for (const ringValue of ringValues) strokeRing(ringValue);
 
   ctx.strokeStyle = '#bbb'; ctx.lineWidth = 0.5;
   for (let i = 0; i < n; i++) {
@@ -4753,10 +4814,25 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
     ctx.fillStyle = '#555';
     ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
-    for (let ri = 1; ri <= rings; ri++) {
-      const v = ringValue(ri);
-      const rr = (v / axMax) * rd;
+    for (const v of ringValues) {
+      const rr = radarFrac(v) * rd;
       ctx.fillText(formatChartVal(v), cx2 - 3, cy2 - rr);
+    }
+    if (needsMinorTicks) {
+      const valAxisLine = resolveAxisLine(chart.valAxisLineColor, chart.valAxisLineWidthEmu, ptToPx);
+      for (const value of radarAxisPlan.minorTicks) {
+        drawAxisTick(
+          ctx,
+          chart.valAxisMinorTickMark,
+          'val',
+          cx2,
+          cy2 - radarFrac(value) * rd,
+          valAxisLine.color,
+          valAxisLine.width,
+          false,
+          chart.valAxisLineHidden,
+        );
+      }
     }
   }
 
@@ -4805,7 +4881,7 @@ function renderRadarChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: C
     for (let i = 0; i < n; i++) {
       const v = s.values[i];
       if (v == null) { pts.push(null); continue; }
-      const frac = v / axMax;
+      const frac = radarFrac(v);
       const a = spoke(i);
       pts.push([cx2 + Math.cos(a) * rd * frac, cy2 + Math.sin(a) * rd * frac]);
     }
@@ -5155,50 +5231,47 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
 
   let xMin = Math.min(...allX); let xMax = Math.max(...allX);
   let yMin = Math.min(...allY); let yMax = Math.max(...allY);
-  if (xMin === xMax) { xMin -= 1; xMax += 1; }
-  if (yMin === yMax) { yMin -= 1; yMax += 1; }
-  // Apply explicit `<c:valAx><c:scaling><c:min/max>` and `<c:catAx>` scaling
-  // when present; otherwise pad up to zero on the value axis (matches Excel
-  // for charts whose data is all positive).
+  // Apply explicit `<c:valAx><c:scaling><c:min/max>` and `<c:catAx>` scaling.
+  // Omitted Y bounds, including point ranges, flow through the shared planner.
   if (chart.valMin != null) yMin = chart.valMin;
-  else if (yMin > 0) yMin = 0;
   if (chart.valMax != null) yMax = chart.valMax;
-  // Auto value (Y) axis: ONE major unit (the "nice" step) drives both the
-  // rounded bounds and the gridlines — identical to bar/line/area. niceAxisMax
-  // adds ~5% headroom above the data max and rounds up to that step, so the top
-  // point sits below the top gridline (data 3.5 → step 0.5, max 4 → 0,.5,…,4;
-  // 0.1129 → step 0.02, max 0.12). The step is taken from the DATA range and
-  // reused for the gridline loop below. The post-anchor yMin (which already had
-  // chart.valMin and the >0→0 anchor applied above) is the data extent; passing
-  // chart.valMin/valMax as the explicit args reproduces the prior `?? niceAxis…`
-  // behavior exactly. Explicit <c:valAx><c:scaling> wins. NB: the auto major
-  // unit is not specified by ECMA-376 (Excel-proprietary); niceStep approximates
-  // it and may differ from Excel by one step on some ranges. An explicit
-  // `<c:valAx><c:majorUnit>` (§21.2.2.103) overrides the auto step. The
-  // axis-length-aware auto density (GRIDLINE_SPACING_PT) is calibrated against
-  // the bar/line/area value axes; scatter/bubble keep the legacy fixed auto
-  // target (axisLenPt undefined) so their auto gridlines stay byte-stable —
-  // only the explicit majorUnit path is new here.
-  const { min: niceYMin, max: niceYMax, step: yAxisStep } =
-    valueAxisScale(yMin, yMax, chart.valMin, chart.valMax, undefined, chart.valAxisMajorUnit);
-  yMin = niceYMin; yMax = niceYMax;
-  if (chart.catAxisMin != null) xMin = chart.catAxisMin;
-  if (chart.catAxisMax != null) xMax = chart.catAxisMax;
-  // Excel snaps auto-derived axis bounds outward to a multiple of the
-  // step so both ends land on round numbers (e.g. dates jump to a date
-  // before the first task and after the last). When the spec set min /
-  // max explicitly we leave them alone.
-  if (chart.catAxisMin == null || chart.catAxisMax == null) {
-    const step = niceStep(xMax - xMin);
-    if (step > 0) {
-      if (chart.catAxisMin == null) xMin = Math.floor(xMin / step) * step;
-      if (chart.catAxisMax == null) xMax = Math.ceil(xMax / step) * step;
-    }
-  }
+  // Scatter/bubble retain their fixed-density target (axis length omitted),
+  // while using the same bounds, authored-unit precedence, and safety policy.
+  const yNeedsMinor = chart.valAxisMinorGridlines === true
+    || (chart.valAxisMinorTickMark != null && chart.valAxisMinorTickMark !== 'none');
+  const yAxisPlan = planLinearValueAxis({
+    dataMin: yMin,
+    dataMax: yMax,
+    explicitMin: chart.valMin,
+    explicitMax: chart.valMax,
+    majorUnit: chart.valAxisMajorUnit,
+    minorUnit: chart.valAxisMinorUnit,
+    needMinor: yNeedsMinor,
+  });
+  yMin = yAxisPlan.min;
+  yMax = yAxisPlan.max;
+  const xNeedsMinor = chart.catAxisMinorGridlines === true
+    || (chart.catAxisMinorTickMark != null && chart.catAxisMinorTickMark !== 'none');
+  const xAxisPlan = planLinearValueAxis({
+    dataMin: xMin,
+    dataMax: xMax,
+    explicitMin: chart.catAxisMin,
+    explicitMax: chart.catAxisMax,
+    axisLenPt: pw / ptToPx,
+    majorUnit: chart.catAxisMajorUnit,
+    minorUnit: chart.catAxisMinorUnit,
+    needMinor: xNeedsMinor,
+  });
+  xMin = xAxisPlan.min;
+  xMax = xAxisPlan.max;
 
   const toX = (v: number) => px0 + ((v - xMin) / (xMax - xMin)) * pw;
   const toY = (v: number) => py0 + ph - ((v - yMin) / (yMax - yMin)) * ph;
-  const xStep = chart.catAxisMajorUnit ?? niceStep(xMax - xMin);
+  const xStep = xAxisPlan.majorUnit;
+  const yMajorTicks = yAxisPlan.majorTicks;
+  const yMinorTicks = yAxisPlan.minorTicks;
+  const xMajorTicks = xAxisPlan.majorTicks;
+  const xMinorTicks = xAxisPlan.minorTicks;
 
   // Each scatter axis is a numeric value axis. Its crossing coordinate comes
   // from the opposite axis's scale (§21.2.2.31 / §21.2.2.32): autoZero uses
@@ -5234,13 +5307,11 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${yTickFontPx}px ${chartFontFamily(chart, chart.valAxisFontFace, 'minor')}`;
     if (chart.valAxisMinorGridlines) {
       const minorGrid = valMinorGridStroke(chart, ptToPx);
-      forEachMinorTick(yMin, yMax, yAxisStep, chart.valAxisMinorUnit, value => {
+      for (const value of yMinorTicks) {
         strokeValueGridlineH(ctx, px0, pw, toY(value), false, minorGrid);
-      });
+      }
     }
-    const ySteps = Math.round((yMax - yMin) / yAxisStep) + 1;
-    for (let si = 0; si < ySteps; si++) {
-      const v = yMin + si * yAxisStep; if (v > yMax + yAxisStep * 0.01) break;
+    for (const v of yMajorTicks) {
       const gy = toY(v);
       ctx.strokeStyle = grid.color; ctx.lineWidth = grid.width;
       if (drawValMajorGridlines(chart)) {
@@ -5271,9 +5342,9 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     }
     if (chart.valAxisMinorTickMark && chart.valAxisMinorTickMark !== 'none') {
       const yAxisLineColor = chart.valAxisLineColor ? `#${chart.valAxisLineColor}` : undefined;
-      forEachMinorTick(yMin, yMax, yAxisStep, chart.valAxisMinorUnit, value => {
+      for (const value of yMinorTicks) {
         drawAxisTick(ctx, chart.valAxisMinorTickMark, 'val', yAxisX, toY(value), yAxisLineColor, axisLineWidthPx(chart.valAxisLineWidthEmu, ptToPx), false, chart.valAxisLineHidden);
-      });
+      }
     }
   }
 
@@ -5282,14 +5353,11 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
   // Its major gridlines therefore run vertically through each numeric X tick.
   if (!chart.catAxisHidden && drawCatMajorGridlines(chart) && xStep > 0) {
     const xGrid = catGridStroke(chart, ptToPx);
-    const xSteps = Math.round((xMax - xMin) / xStep) + 1;
     ctx.strokeStyle = xGrid.color;
     ctx.lineWidth = xGrid.width;
     const previousDash = xGrid.dash.length > 0 && ctx.getLineDash ? ctx.getLineDash() : [];
     if (xGrid.dash.length > 0) ctx.setLineDash(xGrid.dash);
-    for (let si = 0; si < xSteps; si++) {
-      const v = xMin + si * xStep;
-      if (v > xMax + xStep * 0.01) break;
+    for (const v of xMajorTicks) {
       const gx = toX(v);
       ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
     }
@@ -5301,10 +5369,10 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     ctx.strokeStyle = xGrid.color;
     ctx.lineWidth = xGrid.width;
     if (xGrid.dash.length > 0) ctx.setLineDash(xGrid.dash);
-    forEachMinorTick(xMin, xMax, xStep, chart.catAxisMinorUnit, value => {
+    for (const value of xMinorTicks) {
       const gx = toX(value);
       ctx.beginPath(); ctx.moveTo(gx, py0); ctx.lineTo(gx, py0 + ph); ctx.stroke();
-    });
+    }
     if (xGrid.dash.length > 0) ctx.setLineDash(previousDash);
   }
 
@@ -5344,7 +5412,6 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       ? categoryTickLabelGapPx(tickFontPx)
       : 4;
     ctx.font = `${chart.catAxisFontBold ? 'bold ' : ''}${tickFontPx}px ${chartFontFamily(chart, chart.catAxisFontFace, 'minor')}`;
-    const xSteps = Math.round((xMax - xMin) / xStep) + 1;
     ctx.fillStyle = chart.catAxisFontColor ? `#${chart.catAxisFontColor}` : '#555';
     ctx.textAlign = 'center';
     const labelPos = chart.catAxisTickLabelPos ?? 'nextTo';
@@ -5352,8 +5419,7 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       ? py0 + ph + tickGap
       : labelPos === 'high' ? py0 - tickGap : xAxisY + tickGap;
     ctx.textBaseline = labelPos === 'high' ? 'bottom' : 'top';
-    for (let si = 0; si < xSteps; si++) {
-      const v = xMin + si * xStep; if (v > xMax + xStep * 0.01) break;
+    for (const v of xMajorTicks) {
       const gx = toX(v);
       if (labelPos !== 'none') {
         ctx.fillText(formatChartValWithCode(v, chart.catAxisFormatCode, chart.date1904), gx, labelY);
@@ -5363,9 +5429,9 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
     }
     if (chart.catAxisMinorTickMark && chart.catAxisMinorTickMark !== 'none') {
       const xAxisLineColor = chart.catAxisLineColor ? `#${chart.catAxisLineColor}` : undefined;
-      forEachMinorTick(xMin, xMax, xStep, chart.catAxisMinorUnit, value => {
+      for (const value of xMinorTicks) {
         drawAxisTick(ctx, chart.catAxisMinorTickMark, 'cat', xAxisY, toX(value), xAxisLineColor, axisLineWidthPx(chart.catAxisLineWidthEmu, ptToPx), false, chart.catAxisLineHidden);
-      });
+      }
     }
   }
 
@@ -6523,12 +6589,12 @@ function renderWaterfallChart(
         chart.valAxisLineHidden,
       );
     }
-    forEachMinorTick(plan.min, plan.max, plan.step, chart.valAxisMinorUnit, value => {
+    for (const value of plan.minorTicks) {
       drawAxisTick(
         ctx, chart.valAxisMinorTickMark, 'val', px0, yOf(value),
         valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden,
       );
-    });
+    }
   }
 
   // L-frame: vertical (value-axis) rule + horizontal (category-axis) baseline.
@@ -6966,15 +7032,19 @@ function renderBoxWhiskerChart(
 
   const font = chartFontFamily(chart, chart.valAxisFontFace, 'minor');
   const valFontPx = axisLabelPx(chart.valAxisFontSizeHpt, h, ptToPx);
-  const provisionalScale = valueAxisScale(
+  const provisionalScale = planLinearValueAxis({
     dataMin,
     dataMax,
-    chart.valMin,
-    chart.valMax,
-    h / ptToPx,
-    chart.valAxisMajorUnit,
-  );
-  if (!usableScale(provisionalScale)) {
+    explicitMin: chart.valMin,
+    explicitMax: chart.valMax,
+    axisLenPt: h / ptToPx,
+    majorUnit: chart.valAxisMajorUnit,
+  });
+  if (!usableScale({
+    min: provisionalScale.min,
+    max: provisionalScale.max,
+    step: provisionalScale.majorUnit,
+  })) {
     rejectOutOfRange();
     return;
   }
@@ -6983,12 +7053,7 @@ function renderBoxWhiskerChart(
     const previousFont = ctx.font;
     ctx.font = `${chart.valAxisFontBold ? 'bold ' : ''}${valFontPx}px ${font}`;
     let maxLabelW = 0;
-    const tickCount = Math.min(
-      1000,
-      Math.max(0, Math.round((provisionalScale.max - provisionalScale.min) / provisionalScale.step)),
-    );
-    for (let tickIndex = 0; tickIndex <= tickCount; tickIndex++) {
-      const value = provisionalScale.min + tickIndex * provisionalScale.step;
+    for (const value of provisionalScale.majorTicks) {
       const label = formatChartValWithCode(
         value,
         chart.valAxisFormatCode,
@@ -7042,15 +7107,13 @@ function renderBoxWhiskerChart(
   const nCat = cats.length;
 
   // Excel's automatic value axis uses nice-rounded bounds and steps.
-  const axisScale = valueAxisScale(
-    dataMin, dataMax, chart.valMin, chart.valMax, ph / ptToPx, chart.valAxisMajorUnit,
-  );
-  if (!usableScale(axisScale)) {
+  const boxAxisPlan = planValueAxis(chart, dataMin, dataMax, ph / ptToPx);
+  if (!usableScale(boxAxisPlan)) {
     rejectOutOfRange();
     return;
   }
   drawChartTitleForLayout(ctx, chart, x, y, w, h, y + frame.title.topPad, frame.title.fontPx);
-  const { min: axisMin, max: axisMax, step } = axisScale;
+  const { min: axisMin, max: axisMax } = boxAxisPlan;
   const span = axisMax - axisMin;
   const yOf = (v: number): number => py0 + ph * (1 - (v - axisMin) / span);
 
@@ -7065,11 +7128,11 @@ function renderBoxWhiskerChart(
     ctx.textBaseline = 'middle';
     if (chart.valAxisMinorGridlines) {
       const minorGridline = valMinorGridStroke(chart, ptToPx);
-      forEachMinorTick(axisMin, axisMax, step, chart.valAxisMinorUnit, value => {
+      for (const value of boxAxisPlan.minorLines) {
         strokeValueGridlineH(ctx, px0, pw, yOf(value), false, minorGridline);
-      });
+      }
     }
-    for (let v = axisMin; v <= axisMax + 1e-6; v += step) {
+    for (const v of boxAxisPlan.majorLines) {
       const gy = yOf(v);
       if (chart.valAxisMajorGridlines !== false) {
         ctx.strokeStyle = valGridline.color;
@@ -7093,12 +7156,12 @@ function renderBoxWhiskerChart(
         chart.valAxisLineHidden,
       );
     }
-    forEachMinorTick(axisMin, axisMax, step, chart.valAxisMinorUnit, value => {
+    for (const value of boxAxisPlan.minorTicks) {
       drawAxisTick(
         ctx, chart.valAxisMinorTickMark, 'val', px0, yOf(value),
         valAxisLine.color, valAxisLine.width, false, chart.valAxisLineHidden,
       );
-    });
+    }
     if (!chart.valAxisLineHidden) {
       ctx.strokeStyle = valAxisLine.color;
       ctx.lineWidth = valAxisLine.width;

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -755,7 +755,8 @@ export interface ChartModel {
    */
   valAxisMajorUnit?: number | null;
   /** `<c:valAx><c:minorUnit val>` (§21.2.2.112) — explicit minor step. Drives
-   *  minor gridlines/ticks when present. null ⇒ no minor divisions. */
+   *  minor gridlines/ticks when present. When omitted but either feature is
+   *  requested, the renderer uses the automatic major unit divided by five. */
   valAxisMinorUnit?: number | null;
   /** Numeric horizontal-axis major step (scatter/bubble `<c:valAx>`). */
   catAxisMajorUnit?: number | null;
@@ -1004,6 +1005,11 @@ export interface SecondaryValueAxis {
   majorTickMark: string;
   /** `<c:minorTickMark>` — omitted means no minor ticks. */
   minorTickMark?: string | null;
+  /** `<c:minorGridlines>` independently requests plot-area lines. */
+  minorGridlines?: boolean;
+  minorGridlineColor?: string | null;
+  minorGridlineWidthEmu?: number | null;
+  minorGridlineDash?: string | null;
   /**
    * `<c:valAx><c:majorUnit val>` (§21.2.2.103) — explicit distance between
    * major ticks/gridlines on THIS secondary axis, overriding the Excel-style
@@ -1011,7 +1017,8 @@ export interface SecondaryValueAxis {
    * {@link ChartModel.valAxisMajorUnit} on the primary axis.
    */
   majorUnit?: number | null;
-  /** `<c:valAx><c:minorUnit val>` explicit minor-tick step. */
+  /** `<c:valAx><c:minorUnit val>` explicit minor-tick step; omitted minor ticks
+   *  use this axis's automatic major unit divided by five. */
   minorUnit?: number | null;
   /** `<c:title>` run-prop font size (hpt). */
   titleFontSizeHpt?: number | null;

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -1328,6 +1328,10 @@ export interface SecondaryValueAxis {
     lineHidden: boolean;
     majorTickMark: string;
     minorTickMark?: string | null;
+    minorGridlines?: boolean;
+    minorGridlineColor?: string | null;
+    minorGridlineWidthEmu?: number | null;
+    minorGridlineDash?: string | null;
     majorUnit?: number | null;
     minorUnit?: number | null;
     titleFontSizeHpt?: number | null;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -911,6 +911,15 @@ pub struct SecondaryValueAxis {
     /// `<c:valAx><c:minorTickMark val>` (§21.2.2.115). Omitted means none.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub minor_tick_mark: Option<String>,
+    /// `<c:valAx><c:minorGridlines>` presence and authored line paint.
+    #[serde(default)]
+    pub minor_gridlines: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minor_gridline_color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minor_gridline_width_emu: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minor_gridline_dash: Option<String>,
     /// `<c:valAx><c:majorUnit val>` (§21.2.2.103) — explicit major-unit step on
     /// this secondary axis, overriding the auto "nice" step. `None` ⇒ auto.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6570,6 +6579,8 @@ pub fn parse_chart_part_with_references(
         let (t, title_size, title_bold, title_color) =
             extract_axis_title_with_props_resolved(ax, color_resolver);
         let (line_color, line_width_emu, line_hidden) = extract_axis_line_style(ax, color_resolver);
+        let (minor_gridline_color, minor_gridline_width_emu, minor_gridline_dash) =
+            extract_minor_gridline_style(ax, color_resolver);
         SecondaryValueAxis {
             min,
             max,
@@ -6585,6 +6596,10 @@ pub fn parse_chart_part_with_references(
             line_hidden,
             major_tick_mark: extract_axis_tick_mark_or_default(ax, "majorTickMark"),
             minor_tick_mark: extract_axis_tick_mark(ax, "minorTickMark"),
+            minor_gridlines: axis_has_minor_gridlines(ax),
+            minor_gridline_color,
+            minor_gridline_width_emu,
+            minor_gridline_dash,
             major_unit: extract_axis_major_unit(ax),
             minor_unit: extract_axis_minor_unit(ax),
             title_font_size_hpt: title_size,
@@ -8811,6 +8826,7 @@ mod tests {
                   <c:majorUnit val="0.25"/>
                   <c:minorUnit val="0.05"/>
                   <c:minorTickMark val="cross"/>
+                  <c:minorGridlines><c:spPr><a:ln w="12700"><a:solidFill><a:srgbClr val="123456"/></a:solidFill><a:prstDash val="dot"/></a:ln></c:spPr></c:minorGridlines>
                   <c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface="Tick Face"/></a:defRPr></a:pPr></a:p></c:txPr>
                   <c:title><c:tx><c:rich><a:p><a:r><a:rPr sz="900" b="0"><a:latin typeface="Title Face"/></a:rPr><a:t>Margin</a:t></a:r></a:p></c:rich></c:tx></c:title>
                 </c:valAx>
@@ -8843,6 +8859,10 @@ mod tests {
         assert!(!sec.hidden);
         assert_eq!(sec.font_face.as_deref(), Some("Tick Face"));
         assert_eq!(sec.minor_tick_mark.as_deref(), Some("cross"));
+        assert!(sec.minor_gridlines);
+        assert_eq!(sec.minor_gridline_color.as_deref(), Some("123456"));
+        assert_eq!(sec.minor_gridline_width_emu, Some(12700));
+        assert_eq!(sec.minor_gridline_dash.as_deref(), Some("dot"));
         assert_eq!(sec.minor_unit, Some(0.05));
         assert_eq!(sec.title_font_face.as_deref(), Some("Title Face"));
         assert_eq!(sec.title_font_size_hpt, Some(900));

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -1117,6 +1117,10 @@ export interface SecondaryValueAxis {
     lineHidden: boolean;
     majorTickMark: string;
     minorTickMark?: string | null;
+    minorGridlines?: boolean;
+    minorGridlineColor?: string | null;
+    minorGridlineWidthEmu?: number | null;
+    minorGridlineDash?: string | null;
     majorUnit?: number | null;
     minorUnit?: number | null;
     titleFontSizeHpt?: number | null;

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -1080,6 +1080,10 @@ export interface SecondaryValueAxis {
     lineHidden: boolean;
     majorTickMark: string;
     minorTickMark?: string | null;
+    minorGridlines?: boolean;
+    minorGridlineColor?: string | null;
+    minorGridlineWidthEmu?: number | null;
+    minorGridlineDash?: string | null;
     majorUnit?: number | null;
     minorUnit?: number | null;
     titleFontSizeHpt?: number | null;


### PR DESCRIPTION
Closes #1236

## Summary

- centralize bounded automatic linear value-axis planning with a strict 1/2/5 step ladder
- share finite, integer-index tick plans across primary, secondary, horizontal, radar, area, scatter, and supported ChartEx renderers
- preserve authored bounds and units while bounding major, minor, and logarithmic tick generation
- keep minor ticks and minor gridlines independent, including supported secondary axes

## Verification

- focused and full core chart tests
- full `ooxml-common` tests and doctests
- TypeScript build and public API checks
- repeated independent adversarial review
- private self-regression VRT against the pre-change renderer: XLSX 19/19, PPTX 15/15, DOCX 47/47 exact

This implements a deliberately small compatibility policy for behavior that is not fully defined by OOXML.