### PR TITLE
fix(chart): use a shared 14pt title fallback

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -5,11 +5,11 @@ exports[`renderChart draw-call signature (characterization) > is stable for: are
 save
 set font=10.5px sans-serif
 restore
-set font=bold 30.6px Calibri, Arial, sans-serif
+set font=bold 14.700000000000001px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
-fillText "Area" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
+fillText "Area" 332,29.114 fs=#333 font=bold 14.700000000000001px Calibri, Arial, sans-serif al=center bl=top
 set strokeStyle=#aaa
 beginPath
 moveTo 88.8,312.95
@@ -18,31 +18,43 @@ stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 88.8,241.6167
-lineTo 540,241.6167
+moveTo 88.8,271.3208
+lineTo 540,271.3208
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 88.8,170.2833
-lineTo 540,170.2833
+moveTo 88.8,229.6917
+lineTo 540,229.6917
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 88.8,98.95
-lineTo 540,98.95
+moveTo 88.8,188.0625
+lineTo 540,188.0625
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,146.4333
+lineTo 540,146.4333
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,104.8042
+lineTo 540,104.8042
+stroke ss=#e0e0e0 lw=0.5 dash=
+beginPath
+moveTo 88.8,63.175
+lineTo 540,63.175
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
 moveTo 107.6,312.95
-lineTo 107.6,270.15
-lineTo 145.2,241.6167
-lineTo 182.8,255.8833
-lineTo 220.4,227.35
-lineTo 258,213.0833
-lineTo 295.6,241.6167
-lineTo 333.2,198.8167
-lineTo 370.8,227.35
-lineTo 408.4,184.55
-lineTo 446,213.0833
-lineTo 483.6,170.2833
-lineTo 521.2,198.8167
+lineTo 107.6,250.5063
+lineTo 145.2,208.8771
+lineTo 182.8,229.6917
+lineTo 220.4,188.0625
+lineTo 258,167.2479
+lineTo 295.6,208.8771
+lineTo 333.2,146.4333
+lineTo 370.8,188.0625
+lineTo 408.4,125.6188
+lineTo 446,167.2479
+lineTo 483.6,104.8042
+lineTo 521.2,146.4333
 lineTo 521.2,312.95
 closePath
 set fillStyle=#4472C4
@@ -51,7 +63,7 @@ set strokeStyle=#4472C4
 set lineWidth=1.5
 setLineDash
 stroke ss=#4472C4 lw=1.5 dash=
-set font=10.7px sans-serif
+set font=11px sans-serif
 set textBaseline=middle
 set strokeStyle=#aaa
 set lineWidth=1
@@ -63,34 +75,61 @@ set strokeStyle=#4472C4
 set lineWidth=1.5
 set fillStyle=#555
 set textAlign=right
-fillText "0" 82.8,312.95 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "0" 82.8,312.95 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,241.6167
-lineTo 88.8,241.6167
+moveTo 84.8,271.3208
+lineTo 88.8,271.3208
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=1.5
-fillText "5" 82.8,241.6167 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "2" 82.8,271.3208 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,170.2833
-lineTo 88.8,170.2833
+moveTo 84.8,229.6917
+lineTo 88.8,229.6917
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=1.5
-fillText "10" 82.8,170.2833 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "4" 82.8,229.6917 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,98.95
-lineTo 88.8,98.95
+moveTo 84.8,188.0625
+lineTo 88.8,188.0625
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=1.5
-fillText "15" 82.8,98.95 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "6" 82.8,188.0625 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#aaa
+set lineWidth=1
+beginPath
+moveTo 84.8,146.4333
+lineTo 88.8,146.4333
+stroke ss=#aaa lw=1 dash=
+set strokeStyle=#4472C4
+set lineWidth=1.5
+fillText "8" 82.8,146.4333 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#aaa
+set lineWidth=1
+beginPath
+moveTo 84.8,104.8042
+lineTo 88.8,104.8042
+stroke ss=#aaa lw=1 dash=
+set strokeStyle=#4472C4
+set lineWidth=1.5
+fillText "10" 82.8,104.8042 fs=#555 font=11px sans-serif al=right bl=middle
+set strokeStyle=#aaa
+set lineWidth=1
+beginPath
+moveTo 84.8,63.175
+lineTo 88.8,63.175
+stroke ss=#aaa lw=1 dash=
+set strokeStyle=#4472C4
+set lineWidth=1.5
+fillText "12" 82.8,63.175 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -151,7 +190,6 @@ lineTo 540,312.95
 stroke ss=#aaa lw=1 dash=
 set textAlign=center
 set textBaseline=top
-set font=11px sans-serif
 fillText "Jan" 107.6,315.95 fs=#555 font=11px sans-serif al=center bl=top
 fillText "Feb" 145.2,315.95 fs=#555 font=11px sans-serif al=center bl=top
 fillText "Mar" 182.8,315.95 fs=#555 font=11px sans-serif al=center bl=top
@@ -167,10 +205,10 @@ fillText "Dec" 521.2,315.95 fs=#555 font=11px sans-serif al=center bl=top
 set font=10.5px sans-serif
 set textBaseline=middle
 set fillStyle=#4472C4
-fillRect 576,198.7,10,10.5 fs=#4472C4
+fillRect 576,180.8125,10,10.5 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "A" 590,203.95 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "A" 590,186.0625 fs=#333 font=10.5px sans-serif al=left bl=middle
 save
 set font=bold 10.5px sans-serif
 set fillStyle=#555
@@ -347,139 +385,165 @@ exports[`renderChart draw-call signature (characterization) > is stable for: clu
 save
 set font=10.5px sans-serif
 restore
-set font=10.7px sans-serif
+set font=11px sans-serif
 set font=10.5px sans-serif
-set font=bold 30.6px Calibri, Arial, sans-serif
+set font=bold 14.700000000000001px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
-fillText "Quarterly" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
+fillText "Quarterly" 332,29.114 fs=#333 font=bold 14.700000000000001px Calibri, Arial, sans-serif al=center bl=top
 save
 set font=11px sans-serif
 restore
 set textBaseline=middle
-set font=10.7px sans-serif
 set fillStyle=#555
 set strokeStyle=#aaa
 beginPath
-moveTo 68.14,312.95
+moveTo 68.5,312.95
 lineTo 552.8,312.95
 stroke ss=#aaa lw=1 dash=
 set textAlign=right
-fillText "0" 56.14,312.95 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "0" 56.5,312.95 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 68.14,241.6167
-lineTo 552.8,241.6167
+moveTo 68.5,271.3208
+lineTo 552.8,271.3208
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "10" 56.14,241.6167 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "5" 56.5,271.3208 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 68.14,170.2833
-lineTo 552.8,170.2833
+moveTo 68.5,229.6917
+lineTo 552.8,229.6917
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "20" 56.14,170.2833 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "10" 56.5,229.6917 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 68.14,98.95
-lineTo 552.8,98.95
+moveTo 68.5,188.0625
+lineTo 552.8,188.0625
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "30" 56.14,98.95 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "15" 56.5,188.0625 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 68.5,146.4333
+lineTo 552.8,146.4333
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "20" 56.5,146.4333 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 68.5,104.8042
+lineTo 552.8,104.8042
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "25" 56.5,104.8042 fs=#555 font=11px sans-serif al=right bl=middle
+beginPath
+moveTo 68.5,63.175
+lineTo 552.8,63.175
+stroke ss=#e0e0e0 lw=0.5 dash=
+fillText "30" 56.5,63.175 fs=#555 font=11px sans-serif al=right bl=middle
 set fillStyle=#4472C4
-fillRect 102.7586,241.6167,46.1581,71.3333 fs=#4472C4
+fillRect 103.0929,229.6917,46.1238,83.2583 fs=#4472C4
 set font=bold 11px sans-serif
 save
 beginPath
-rect 68.14,98.95,484.66,214
+rect 68.5,63.175,484.3,249.775
 clip
 set fillStyle=#333
 set textAlign=center
 set textBaseline=bottom
-fillText "10" 125.8376,236.1167 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "10" 126.1548,224.1917 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 restore
 set fillStyle=#ED7D31
-fillRect 148.9167,255.8833,46.1581,57.0667 fs=#ED7D31
+fillRect 149.2167,246.3433,46.1238,66.6067 fs=#ED7D31
 save
 beginPath
-rect 68.14,98.95,484.66,214
+rect 68.5,63.175,484.3,249.775
 clip
 set fillStyle=#333
-fillText "8" 171.9957,250.3833 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "8" 172.2786,240.8433 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 restore
 set fillStyle=#4472C4
-fillRect 264.3119,141.75,46.1581,171.2 fs=#4472C4
+fillRect 264.5262,113.13,46.1238,199.82 fs=#4472C4
 save
 beginPath
-rect 68.14,98.95,484.66,214
+rect 68.5,63.175,484.3,249.775
 clip
 set fillStyle=#333
-fillText "24" 287.391,136.25 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "24" 287.5881,107.63 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 restore
 set fillStyle=#ED7D31
-fillRect 310.47,205.95,46.1581,107 fs=#ED7D31
+fillRect 310.65,188.0625,46.1238,124.8875 fs=#ED7D31
 save
 beginPath
-rect 68.14,98.95,484.66,214
+rect 68.5,63.175,484.3,249.775
 clip
 set fillStyle=#333
-fillText "15" 333.549,200.45 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "15" 333.7119,182.5625 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 restore
 set fillStyle=#4472C4
-fillRect 425.8652,191.6833,46.1581,121.2667 fs=#4472C4
+fillRect 425.9595,171.4108,46.1238,141.5392 fs=#4472C4
 save
 beginPath
-rect 68.14,98.95,484.66,214
+rect 68.5,63.175,484.3,249.775
 clip
 set fillStyle=#333
-fillText "17" 448.9443,186.1833 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "17" 449.0214,165.9108 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 restore
 set fillStyle=#ED7D31
-fillRect 472.0233,156.0167,46.1581,156.9333 fs=#ED7D31
+fillRect 472.0833,129.7817,46.1238,183.1683 fs=#ED7D31
 save
 beginPath
-rect 68.14,98.95,484.66,214
+rect 68.5,63.175,484.3,249.775
 clip
 set fillStyle=#333
-fillText "22" 495.1024,150.5167 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "22" 495.1452,124.2817 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 restore
 set fillStyle=#555
 set font=11px sans-serif
 set textBaseline=top
-fillText "Q1" 148.9167,315.95 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Q2" 310.47,315.95 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Q3" 472.0233,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q1" 149.2167,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q2" 310.65,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q3" 472.0833,315.95 fs=#555 font=11px sans-serif al=center bl=top
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 68.14,312.95
+moveTo 68.5,312.95
 lineTo 552.8,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 64.14,312.95
-lineTo 68.14,312.95
+moveTo 64.5,312.95
+lineTo 68.5,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 64.14,241.6167
-lineTo 68.14,241.6167
+moveTo 64.5,271.3208
+lineTo 68.5,271.3208
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 64.14,170.2833
-lineTo 68.14,170.2833
+moveTo 64.5,229.6917
+lineTo 68.5,229.6917
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 64.14,98.95
-lineTo 68.14,98.95
+moveTo 64.5,188.0625
+lineTo 68.5,188.0625
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 68.14,316.95
-lineTo 68.14,312.95
+moveTo 64.5,146.4333
+lineTo 68.5,146.4333
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 229.6933,316.95
-lineTo 229.6933,312.95
+moveTo 64.5,104.8042
+lineTo 68.5,104.8042
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 391.2467,316.95
-lineTo 391.2467,312.95
+moveTo 64.5,63.175
+lineTo 68.5,63.175
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 68.5,316.95
+lineTo 68.5,312.95
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 229.9333,316.95
+lineTo 229.9333,312.95
+stroke ss=#aaa lw=1 dash=
+beginPath
+moveTo 391.3667,316.95
+lineTo 391.3667,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
 moveTo 552.8,316.95
@@ -488,24 +552,24 @@ stroke ss=#aaa lw=1 dash=
 set font=10.5px sans-serif
 set textBaseline=middle
 set fillStyle=#4472C4
-fillRect 576,191.45,10,10.5 fs=#4472C4
+fillRect 576,173.5625,10,10.5 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "Alpha" 590,196.7 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Alpha" 590,178.8125 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 576,205.95,10,10.5 fs=#ED7D31
+fillRect 576,188.0625,10,10.5 fs=#ED7D31
 set fillStyle=#333
-fillText "Beta" 590,211.2 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Beta" 590,193.3125 fs=#333 font=10.5px sans-serif al=left bl=middle
 save
 set font=bold 10.5px sans-serif
 set fillStyle=#555
-translate 30.05,205.95
+translate 30.05,188.0625
 rotate -1.5708
 set textAlign=center
 fillText "Units" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 save
-translate 310.47,366.75
+translate 310.65,366.75
 fillText "Quarter" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 restore"
@@ -519,118 +583,118 @@ restore
 save
 set font=11px sans-serif
 restore
-set font=bold 30.6px Calibri, Arial, sans-serif
+set font=bold 14.700000000000001px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
-fillText "Horizontal" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
+fillText "Horizontal" 332,29.114 fs=#333 font=bold 14.700000000000001px Calibri, Arial, sans-serif al=center bl=top
 set textBaseline=middle
 set font=11px sans-serif
 set fillStyle=#555
 set strokeStyle=#aaa
 beginPath
-moveTo 30.775,98.95
+moveTo 30.775,63.175
 lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
 fillText "0" 30.775,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 117.7792,98.95
+moveTo 117.7792,63.175
 lineTo 117.7792,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "5" 117.7792,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 204.7833,98.95
+moveTo 204.7833,63.175
 lineTo 204.7833,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "10" 204.7833,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 291.7875,98.95
+moveTo 291.7875,63.175
 lineTo 291.7875,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "15" 291.7875,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 378.7917,98.95
+moveTo 378.7917,63.175
 lineTo 378.7917,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "20" 378.7917,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 465.7958,98.95
+moveTo 465.7958,63.175
 lineTo 465.7958,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "25" 465.7958,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 beginPath
-moveTo 552.8,98.95
+moveTo 552.8,63.175
 lineTo 552.8,335.45
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "30" 552.8,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 set fillStyle=#4472C4
-fillRect 30.775,273.5095,174.0083,22.5238 fs=#4472C4
+fillRect 30.775,264.1399,174.0083,25.931 fs=#4472C4
 set font=bold 11px sans-serif
 save
 beginPath
-rect 30.775,98.95,522.025,236.5
+rect 30.775,63.175,522.025,272.275
 clip
 set fillStyle=#333
 set textAlign=left
-fillText "10" 210.2833,284.7714 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "10" 210.2833,277.1054 fs=#333 font=bold 11px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
-fillRect 30.775,296.0333,139.2067,22.5238 fs=#ED7D31
+fillRect 30.775,290.0708,139.2067,25.931 fs=#ED7D31
 save
 beginPath
-rect 30.775,98.95,522.025,236.5
+rect 30.775,63.175,522.025,272.275
 clip
 set fillStyle=#333
-fillText "8" 175.4817,307.2952 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "8" 175.4817,303.0363 fs=#333 font=bold 11px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
-fillRect 30.775,194.6762,417.62,22.5238 fs=#4472C4
+fillRect 30.775,173.3815,417.62,25.931 fs=#4472C4
 save
 beginPath
-rect 30.775,98.95,522.025,236.5
+rect 30.775,63.175,522.025,272.275
 clip
 set fillStyle=#333
-fillText "24" 453.895,205.9381 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "24" 453.895,186.347 fs=#333 font=bold 11px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
-fillRect 30.775,217.2,261.0125,22.5238 fs=#ED7D31
+fillRect 30.775,199.3125,261.0125,25.931 fs=#ED7D31
 save
 beginPath
-rect 30.775,98.95,522.025,236.5
+rect 30.775,63.175,522.025,272.275
 clip
 set fillStyle=#333
-fillText "15" 297.2875,228.4619 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "15" 297.2875,212.278 fs=#333 font=bold 11px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
-fillRect 30.775,115.8429,295.8142,22.5238 fs=#4472C4
+fillRect 30.775,82.6232,295.8142,25.931 fs=#4472C4
 save
 beginPath
-rect 30.775,98.95,522.025,236.5
+rect 30.775,63.175,522.025,272.275
 clip
 set fillStyle=#333
-fillText "17" 332.0892,127.1048 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "17" 332.0892,95.5887 fs=#333 font=bold 11px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
-fillRect 30.775,138.3667,382.8183,22.5238 fs=#ED7D31
+fillRect 30.775,108.5542,382.8183,25.931 fs=#ED7D31
 save
 beginPath
-rect 30.775,98.95,522.025,236.5
+rect 30.775,63.175,522.025,272.275
 clip
 set fillStyle=#333
-fillText "22" 419.0933,149.6286 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "22" 419.0933,121.5196 fs=#333 font=bold 11px sans-serif al=left bl=middle
 restore
 set fillStyle=#555
 set font=11px sans-serif
 set textAlign=right
-fillText "Q1" 26.775,296.0333 fs=#555 font=11px sans-serif al=right bl=middle
-fillText "Q2" 26.775,217.2 fs=#555 font=11px sans-serif al=right bl=middle
-fillText "Q3" 26.775,138.3667 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "Q1" 26.775,290.0708 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "Q2" 26.775,199.3125 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "Q3" 26.775,108.5542 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 30.775,98.95
+moveTo 30.775,63.175
 lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
@@ -662,16 +726,16 @@ moveTo 552.8,339.45
 lineTo 552.8,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 26.775,98.95
-lineTo 30.775,98.95
+moveTo 26.775,63.175
+lineTo 30.775,63.175
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 26.775,177.7833
-lineTo 30.775,177.7833
+moveTo 26.775,153.9333
+lineTo 30.775,153.9333
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 26.775,256.6167
-lineTo 30.775,256.6167
+moveTo 26.775,244.6917
+lineTo 30.775,244.6917
 stroke ss=#aaa lw=1 dash=
 beginPath
 moveTo 26.775,335.45
@@ -679,14 +743,14 @@ lineTo 30.775,335.45
 stroke ss=#aaa lw=1 dash=
 set font=10.5px sans-serif
 set fillStyle=#4472C4
-fillRect 576,202.7,10,10.5 fs=#4472C4
+fillRect 576,184.8125,10,10.5 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "Alpha" 590,207.95 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Alpha" 590,190.0625 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 576,217.2,10,10.5 fs=#ED7D31
+fillRect 576,199.3125,10,10.5 fs=#ED7D31
 set fillStyle=#333
-fillText "Beta" 590,222.45 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Beta" 590,204.5625 fs=#333 font=10.5px sans-serif al=left bl=middle
 restore"
 `;
 
@@ -717,11 +781,11 @@ set font=10.5px sans-serif
 restore
 set font=11px sans-serif
 set font=10.5px sans-serif
-set font=bold 30.6px Calibri, Arial, sans-serif
+set font=bold 14.700000000000001px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
-fillText "Combo" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
+fillText "Combo" 332,29.114 fs=#333 font=bold 14.700000000000001px Calibri, Arial, sans-serif al=center bl=top
 save
 set font=11px sans-serif
 restore
@@ -737,24 +801,24 @@ fillText "0" 35.8,335.45 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 47.8,256.6167
-lineTo 503.1,256.6167
+moveTo 47.8,244.6917
+lineTo 503.1,244.6917
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "50" 35.8,256.6167 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "50" 35.8,244.6917 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 47.8,177.7833
-lineTo 503.1,177.7833
+moveTo 47.8,153.9333
+lineTo 503.1,153.9333
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "100" 35.8,177.7833 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "100" 35.8,153.9333 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 47.8,98.95
-lineTo 503.1,98.95
+moveTo 47.8,63.175
+lineTo 503.1,63.175
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "150" 35.8,98.95 fs=#555 font=11px sans-serif al=right bl=middle
+fillText "150" 35.8,63.175 fs=#555 font=11px sans-serif al=right bl=middle
 set fillStyle=#4472C4
-fillRect 93.33,177.7833,60.7067,157.6667 fs=#4472C4
-fillRect 245.0967,114.7167,60.7067,220.7333 fs=#4472C4
-fillRect 396.8633,146.25,60.7067,189.2 fs=#4472C4
+fillRect 93.33,153.9333,60.7067,181.5167 fs=#4472C4
+fillRect 245.0967,81.3267,60.7067,254.1233 fs=#4472C4
+fillRect 396.8633,117.63,60.7067,217.82 fs=#4472C4
 set fillStyle=#555
 set textAlign=center
 set textBaseline=top
@@ -765,19 +829,19 @@ set strokeStyle=#ED7D31
 set lineWidth=2
 setLineDash
 beginPath
-moveTo 123.6833,193.55
-lineTo 275.45,122.6
-lineTo 427.2167,158.075
+moveTo 123.6833,172.085
+lineTo 275.45,90.4025
+lineTo 427.2167,131.2438
 stroke ss=#ED7D31 lw=2 dash=
 set fillStyle=#ED7D31
 beginPath
-arc 123.6833,193.55,3,0,6.2832
+arc 123.6833,172.085,3,0,6.2832
 fill fs=#ED7D31 ga=1
 beginPath
-arc 275.45,122.6,3,0,6.2832
+arc 275.45,90.4025,3,0,6.2832
 fill fs=#ED7D31 ga=1
 beginPath
-arc 427.2167,158.075,3,0,6.2832
+arc 427.2167,131.2438,3,0,6.2832
 fill fs=#ED7D31 ga=1
 set strokeStyle=#aaa
 set lineWidth=1
@@ -790,16 +854,16 @@ moveTo 43.8,335.45
 lineTo 47.8,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 43.8,256.6167
-lineTo 47.8,256.6167
+moveTo 43.8,244.6917
+lineTo 47.8,244.6917
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 43.8,177.7833
-lineTo 47.8,177.7833
+moveTo 43.8,153.9333
+lineTo 47.8,153.9333
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 43.8,98.95
-lineTo 47.8,98.95
+moveTo 43.8,63.175
+lineTo 47.8,63.175
 stroke ss=#aaa lw=1 dash=
 beginPath
 moveTo 47.8,339.45
@@ -818,7 +882,7 @@ moveTo 503.1,339.45
 lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 503.1,98.95
+moveTo 503.1,63.175
 lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 set fillStyle=#555
@@ -830,53 +894,53 @@ lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 fillText "0" 517.1,335.45 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 507.1,276.325
-lineTo 503.1,276.325
+moveTo 507.1,267.3813
+lineTo 503.1,267.3813
 stroke ss=#aaa lw=1 dash=
-fillText "5" 517.1,276.325 fs=#555 font=11px sans-serif al=left bl=middle
+fillText "5" 517.1,267.3813 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 507.1,217.2
-lineTo 503.1,217.2
+moveTo 507.1,199.3125
+lineTo 503.1,199.3125
 stroke ss=#aaa lw=1 dash=
-fillText "10" 517.1,217.2 fs=#555 font=11px sans-serif al=left bl=middle
+fillText "10" 517.1,199.3125 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 507.1,158.075
-lineTo 503.1,158.075
+moveTo 507.1,131.2438
+lineTo 503.1,131.2438
 stroke ss=#aaa lw=1 dash=
-fillText "15" 517.1,158.075 fs=#555 font=11px sans-serif al=left bl=middle
+fillText "15" 517.1,131.2438 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 507.1,98.95
-lineTo 503.1,98.95
+moveTo 507.1,63.175
+lineTo 503.1,63.175
 stroke ss=#aaa lw=1 dash=
-fillText "20" 517.1,98.95 fs=#555 font=11px sans-serif al=left bl=middle
+fillText "20" 517.1,63.175 fs=#555 font=11px sans-serif al=left bl=middle
 save
 set font=bold 10.5px sans-serif
-translate 540.6,217.2
+translate 540.6,199.3125
 rotate 1.5708
 set textAlign=center
 fillText "Margin %" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 set font=10.5px sans-serif
 set fillStyle=#4472C4
-fillRect 576,202.7,10,10.5 fs=#4472C4
+fillRect 576,184.8125,10,10.5 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "Rev" 590,207.95 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Rev" 590,190.0625 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
 set strokeStyle=#ED7D31
 set lineWidth=1.575
 beginPath
-moveTo 576,222.45
-lineTo 592.8,222.45
+moveTo 576,204.5625
+lineTo 592.8,204.5625
 stroke ss=#ED7D31 lw=1.575 dash=
 set lineWidth=1
 save
 beginPath
-arc 584.4,222.45,3.045,0,6.2832
+arc 584.4,204.5625,3.045,0,6.2832
 fill fs=#ED7D31 ga=1
 restore
 set fillStyle=#333
-fillText "Margin" 596.8,222.45 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Margin" 596.8,204.5625 fs=#333 font=10.5px sans-serif al=left bl=middle
 restore"
 `;
 
@@ -938,11 +1002,11 @@ exports[`renderChart draw-call signature (characterization) > is stable for: lin
 save
 set font=10.5px sans-serif
 restore
-set font=bold 30.6px Calibri, Arial, sans-serif
+set font=bold 14.700000000000001px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
-fillText "Trend" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
+fillText "Trend" 332,29.114 fs=#333 font=bold 14.700000000000001px Calibri, Arial, sans-serif al=center bl=top
 set font=16.2px sans-serif
 set textBaseline=middle
 set strokeStyle=#aaa
@@ -962,44 +1026,83 @@ fillText "0" 78.94,312.95 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 84.94,241.6167
-lineTo 540,241.6167
+moveTo 84.94,271.3208
+lineTo 540,271.3208
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.94,241.6167
-lineTo 84.94,241.6167
+moveTo 80.94,271.3208
+lineTo 84.94,271.3208
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "5" 78.94,241.6167 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "2" 78.94,271.3208 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 84.94,170.2833
-lineTo 540,170.2833
+moveTo 84.94,229.6917
+lineTo 540,229.6917
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.94,170.2833
-lineTo 84.94,170.2833
+moveTo 80.94,229.6917
+lineTo 84.94,229.6917
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "10" 78.94,170.2833 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "4" 78.94,229.6917 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 84.94,98.95
-lineTo 540,98.95
+moveTo 84.94,188.0625
+lineTo 540,188.0625
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.94,98.95
-lineTo 84.94,98.95
+moveTo 80.94,188.0625
+lineTo 84.94,188.0625
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "15" 78.94,98.95 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "6" 78.94,188.0625 fs=#555 font=16.2px sans-serif al=right bl=middle
+beginPath
+moveTo 84.94,146.4333
+lineTo 540,146.4333
+stroke ss=#e0e0e0 lw=0.5 dash=
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 80.94,146.4333
+lineTo 84.94,146.4333
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+fillText "8" 78.94,146.4333 fs=#555 font=16.2px sans-serif al=right bl=middle
+beginPath
+moveTo 84.94,104.8042
+lineTo 540,104.8042
+stroke ss=#e0e0e0 lw=0.5 dash=
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 80.94,104.8042
+lineTo 84.94,104.8042
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+fillText "10" 78.94,104.8042 fs=#555 font=16.2px sans-serif al=right bl=middle
+beginPath
+moveTo 84.94,63.175
+lineTo 540,63.175
+stroke ss=#e0e0e0 lw=0.5 dash=
+set strokeStyle=#888
+set lineWidth=1
+beginPath
+moveTo 80.94,63.175
+lineTo 84.94,63.175
+stroke ss=#888 lw=1 dash=
+set strokeStyle=#e0e0e0
+set lineWidth=0.5
+fillText "12" 78.94,63.175 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -1007,354 +1110,354 @@ moveTo 84.94,312.95
 lineTo 540,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 84.94,98.95
+moveTo 84.94,63.175
 lineTo 84.94,312.95
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=2.3625
 setLineDash
 beginPath
-moveTo 103.9008,270.15
-lineTo 141.8225,241.6167
-lineTo 179.7442,255.8833
-lineTo 217.6658,227.35
-lineTo 255.5875,213.0833
-lineTo 293.5092,241.6167
-lineTo 331.4308,198.8167
-lineTo 369.3525,227.35
-lineTo 407.2742,184.55
-lineTo 445.1958,213.0833
-lineTo 483.1175,170.2833
-lineTo 521.0392,198.8167
+moveTo 103.9008,250.5063
+lineTo 141.8225,208.8771
+lineTo 179.7442,229.6917
+lineTo 217.6658,188.0625
+lineTo 255.5875,167.2479
+lineTo 293.5092,208.8771
+lineTo 331.4308,146.4333
+lineTo 369.3525,188.0625
+lineTo 407.2742,125.6188
+lineTo 445.1958,167.2479
+lineTo 483.1175,104.8042
+lineTo 521.0392,146.4333
 stroke ss=#4472C4 lw=2.3625 dash=
 set fillStyle=#4472C4
 beginPath
-arc 103.9008,270.15,2.625,0,6.2832
+arc 103.9008,250.5063,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
 set textAlign=left
-fillText "3" 115.6258,270.15 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "3" 115.6258,250.5063 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 beginPath
-arc 141.8225,241.6167,2.625,0,6.2832
+arc 141.8225,208.8771,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "5" 153.5475,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 153.5475,208.8771 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 beginPath
-arc 179.7442,255.8833,2.625,0,6.2832
+arc 179.7442,229.6917,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "4" 191.4692,255.8833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "4" 191.4692,229.6917 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 beginPath
-arc 217.6658,227.35,2.625,0,6.2832
+arc 217.6658,188.0625,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "6" 229.3908,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 229.3908,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 beginPath
-arc 255.5875,213.0833,2.625,0,6.2832
+arc 255.5875,167.2479,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "7" 267.3125,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 267.3125,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 beginPath
-arc 293.5092,241.6167,2.625,0,6.2832
+arc 293.5092,208.8771,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "5" 305.2342,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 305.2342,208.8771 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 beginPath
-arc 331.4308,198.8167,2.625,0,6.2832
+arc 331.4308,146.4333,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "8" 343.1558,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 343.1558,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 beginPath
-arc 369.3525,227.35,2.625,0,6.2832
+arc 369.3525,188.0625,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "6" 381.0775,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 381.0775,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 beginPath
-arc 407.2742,184.55,2.625,0,6.2832
+arc 407.2742,125.6188,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "9" 418.9992,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 418.9992,125.6188 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 beginPath
-arc 445.1958,213.0833,2.625,0,6.2832
+arc 445.1958,167.2479,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "7" 456.9208,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 456.9208,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 beginPath
-arc 483.1175,170.2833,2.625,0,6.2832
+arc 483.1175,104.8042,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "10" 494.8425,170.2833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "10" 494.8425,104.8042 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 beginPath
-arc 521.0392,198.8167,2.625,0,6.2832
+arc 521.0392,146.4333,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "8" 530.28,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 530.28,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#4472C4
 set strokeStyle=#ED7D31
 setLineDash
 beginPath
-moveTo 103.9008,284.4167
-lineTo 141.8225,270.15
-lineTo 179.7442,241.6167
-lineTo 217.6658,255.8833
-lineTo 255.5875,227.35
-lineTo 293.5092,198.8167
-lineTo 331.4308,213.0833
-lineTo 369.3525,184.55
-lineTo 407.2742,227.35
-lineTo 445.1958,198.8167
-lineTo 483.1175,213.0833
-lineTo 521.0392,184.55
+moveTo 103.9008,271.3208
+lineTo 141.8225,250.5063
+lineTo 179.7442,208.8771
+lineTo 217.6658,229.6917
+lineTo 255.5875,188.0625
+lineTo 293.5092,146.4333
+lineTo 331.4308,167.2479
+lineTo 369.3525,125.6188
+lineTo 407.2742,188.0625
+lineTo 445.1958,146.4333
+lineTo 483.1175,167.2479
+lineTo 521.0392,125.6188
 stroke ss=#ED7D31 lw=2.3625 dash=
 set fillStyle=#ED7D31
 beginPath
-arc 103.9008,284.4167,2.625,0,6.2832
+arc 103.9008,271.3208,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "2" 115.6258,284.4167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "2" 115.6258,271.3208 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 141.8225,270.15,2.625,0,6.2832
+arc 141.8225,250.5063,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "3" 153.5475,270.15 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "3" 153.5475,250.5063 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 179.7442,241.6167,2.625,0,6.2832
+arc 179.7442,208.8771,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "5" 191.4692,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 191.4692,208.8771 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 217.6658,255.8833,2.625,0,6.2832
+arc 217.6658,229.6917,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "4" 229.3908,255.8833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "4" 229.3908,229.6917 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 255.5875,227.35,2.625,0,6.2832
+arc 255.5875,188.0625,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "6" 267.3125,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 267.3125,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 293.5092,198.8167,2.625,0,6.2832
+arc 293.5092,146.4333,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "8" 305.2342,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 305.2342,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 331.4308,213.0833,2.625,0,6.2832
+arc 331.4308,167.2479,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "7" 343.1558,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 343.1558,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 369.3525,184.55,2.625,0,6.2832
+arc 369.3525,125.6188,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "9" 381.0775,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 381.0775,125.6188 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 407.2742,227.35,2.625,0,6.2832
+arc 407.2742,188.0625,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "6" 418.9992,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 418.9992,188.0625 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 445.1958,198.8167,2.625,0,6.2832
+arc 445.1958,146.4333,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "8" 456.9208,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 456.9208,146.4333 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 483.1175,213.0833,2.625,0,6.2832
+arc 483.1175,167.2479,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "7" 494.8425,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 494.8425,167.2479 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 521.0392,184.55,2.625,0,6.2832
+arc 521.0392,125.6188,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 save
 beginPath
-rect 84.94,98.95,455.06,214
+rect 84.94,63.175,455.06,249.775
 clip
 set fillStyle=#333
-fillText "9" 530.28,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 530.28,125.6188 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 restore
 set fillStyle=#ED7D31
@@ -1475,37 +1578,37 @@ set fillStyle=#4472C4
 set strokeStyle=#4472C4
 set lineWidth=1.575
 beginPath
-moveTo 576,196.7
-lineTo 592.8,196.7
+moveTo 576,178.8125
+lineTo 592.8,178.8125
 stroke ss=#4472C4 lw=1.575 dash=
 set lineWidth=2.3625
 save
 beginPath
-arc 584.4,196.7,3.045,0,6.2832
+arc 584.4,178.8125,3.045,0,6.2832
 fill fs=#4472C4 ga=1
 restore
 set fillStyle=#333
 set textAlign=left
-fillText "A" 596.8,196.7 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "A" 596.8,178.8125 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
 set strokeStyle=#ED7D31
 set lineWidth=1.575
 beginPath
-moveTo 576,211.2
-lineTo 592.8,211.2
+moveTo 576,193.3125
+lineTo 592.8,193.3125
 stroke ss=#ED7D31 lw=1.575 dash=
 set lineWidth=2.3625
 save
 beginPath
-arc 584.4,211.2,3.045,0,6.2832
+arc 584.4,193.3125,3.045,0,6.2832
 fill fs=#ED7D31 ga=1
 restore
 set fillStyle=#333
-fillText "B" 596.8,211.2 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "B" 596.8,193.3125 fs=#333 font=10.5px sans-serif al=left bl=middle
 save
 set font=bold 10.5px sans-serif
 set fillStyle=#555
-translate 30.05,205.95
+translate 30.05,188.0625
 rotate -1.5708
 set textAlign=center
 fillText "Value" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
@@ -1532,55 +1635,55 @@ exports[`renderChart draw-call signature (characterization) > is stable for: pie
 save
 set font=10.5px sans-serif
 restore
-set font=bold 30.6px Calibri, Arial, sans-serif
+set font=bold 14.700000000000001px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
-fillText "Share" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
+fillText "Share" 332,29.114 fs=#333 font=bold 14.700000000000001px Calibri, Arial, sans-serif al=center bl=top
 beginPath
-moveTo 292,231.5
-arc 292,231.5,124.74,-1.5708,0.3142
+moveTo 292,223.55
+arc 292,223.55,131.418,-1.5708,0.3142
 closePath
 set fillStyle=#4472C4
 fill fs=#4472C4 ga=1
 set strokeStyle=#fff
 stroke ss=#fff lw=1 dash=
-set font=bold 12.474px sans-serif
+set font=bold 13.141800000000002px sans-serif
 set fillStyle=#fff
 set textBaseline=middle
-fillText "30%" 352.5501,187.5078 fs=#fff font=bold 12.474px sans-serif al=center bl=middle
+fillText "30%" 355.7916,177.2027 fs=#fff font=bold 13.141800000000002px sans-serif al=center bl=middle
 beginPath
-moveTo 292,231.5
-arc 292,231.5,124.74,0.3142,3.1416
+moveTo 292,223.55
+arc 292,223.55,131.418,0.3142,3.1416
 closePath
 set fillStyle=#ED7D31
 fill fs=#ED7D31 ga=1
 stroke ss=#fff lw=1 dash=
 set fillStyle=#fff
-fillText "45%" 280.2918,305.4225 fs=#fff font=bold 12.474px sans-serif al=center bl=middle
+fillText "45%" 279.665,301.43 fs=#fff font=bold 13.141800000000002px sans-serif al=center bl=middle
 beginPath
-moveTo 292,231.5
-arc 292,231.5,124.74,3.1416,4.7124
+moveTo 292,223.55
+arc 292,223.55,131.418,3.1416,4.7124
 closePath
 set fillStyle=#A9D18E
 fill fs=#A9D18E ga=1
 stroke ss=#fff lw=1 dash=
 set fillStyle=#fff
-fillText "25%" 239.0773,178.5773 fs=#fff font=bold 12.474px sans-serif al=center bl=middle
+fillText "25%" 236.2441,167.7941 fs=#fff font=bold 13.141800000000002px sans-serif al=center bl=middle
 set font=10.5px sans-serif
 set fillStyle=#4472C4
-fillRect 576,209.75,10,10.5 fs=#4472C4
+fillRect 576,201.8,10,10.5 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "Q1" 590,215 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Q1" 590,207.05 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 576,224.25,10,10.5 fs=#ED7D31
+fillRect 576,216.3,10,10.5 fs=#ED7D31
 set fillStyle=#333
-fillText "Q2" 590,229.5 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Q2" 590,221.55 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#A9D18E
-fillRect 576,238.75,10,10.5 fs=#A9D18E
+fillRect 576,230.8,10,10.5 fs=#A9D18E
 set fillStyle=#333
-fillText "Q3" 590,244 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Q3" 590,236.05 fs=#333 font=10.5px sans-serif al=left bl=middle
 restore"
 `;
 
@@ -1589,81 +1692,81 @@ exports[`renderChart draw-call signature (characterization) > is stable for: rad
 save
 set font=10.5px sans-serif
 restore
-set font=bold 30.6px Calibri, Arial, sans-serif
+set font=bold 14.700000000000001px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
-fillText "Profile" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
+fillText "Profile" 332,29.114 fs=#333 font=bold 14.700000000000001px Calibri, Arial, sans-serif al=center bl=top
 set strokeStyle=#ddd
 set lineWidth=0.5
 beginPath
-moveTo 292,193.88
-lineTo 327.7787,219.8748
-lineTo 314.1125,261.9352
-lineTo 269.8875,261.9352
-lineTo 256.2213,219.8748
+moveTo 292,183.916
+lineTo 329.6942,211.3024
+lineTo 315.2963,255.6146
+lineTo 268.7037,255.6146
+lineTo 254.3058,211.3024
 closePath
 stroke ss=#ddd lw=0.5 dash=
 beginPath
-moveTo 292,156.26
-lineTo 363.5575,208.2496
-lineTo 336.225,292.3704
-lineTo 247.775,292.3704
-lineTo 220.4425,208.2496
+moveTo 292,144.282
+lineTo 367.3883,199.0548
+lineTo 338.5926,287.6792
+lineTo 245.4074,287.6792
+lineTo 216.6117,199.0548
 closePath
 stroke ss=#ddd lw=0.5 dash=
 beginPath
-moveTo 292,118.64
-lineTo 399.3362,196.6243
-lineTo 358.3374,322.8057
-lineTo 225.6626,322.8057
-lineTo 184.6638,196.6243
+moveTo 292,104.648
+lineTo 405.0825,186.8073
+lineTo 361.8888,319.7437
+lineTo 222.1112,319.7437
+lineTo 178.9175,186.8073
 closePath
 stroke ss=#ddd lw=0.5 dash=
 set strokeStyle=#bbb
 beginPath
-moveTo 292,231.5
-lineTo 292,118.64
+moveTo 292,223.55
+lineTo 292,104.648
 stroke ss=#bbb lw=0.5 dash=
 beginPath
-moveTo 292,231.5
-lineTo 399.3362,196.6243
+moveTo 292,223.55
+lineTo 405.0825,186.8073
 stroke ss=#bbb lw=0.5 dash=
 beginPath
-moveTo 292,231.5
-lineTo 358.3374,322.8057
+moveTo 292,223.55
+lineTo 361.8888,319.7437
 stroke ss=#bbb lw=0.5 dash=
 beginPath
-moveTo 292,231.5
-lineTo 225.6626,322.8057
+moveTo 292,223.55
+lineTo 222.1112,319.7437
 stroke ss=#bbb lw=0.5 dash=
 beginPath
-moveTo 292,231.5
-lineTo 184.6638,196.6243
+moveTo 292,223.55
+lineTo 178.9175,186.8073
 stroke ss=#bbb lw=0.5 dash=
 set font=16.2px sans-serif
 set fillStyle=#555
 set textAlign=right
 set textBaseline=middle
-fillText "2" 289,193.88 fs=#555 font=16.2px sans-serif al=right bl=middle
-fillText "4" 289,156.26 fs=#555 font=16.2px sans-serif al=right bl=middle
-fillText "6" 289,118.64 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "2" 289,183.916 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "4" 289,144.282 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "6" 289,104.648 fs=#555 font=16.2px sans-serif al=right bl=middle
 set font=11px sans-serif
 set fillStyle=#444
 set textAlign=center
-fillText "A" 292,106.64 fs=#444 font=11px sans-serif al=center bl=middle
+fillText "A" 292,92.648 fs=#444 font=11px sans-serif al=center bl=middle
 set textAlign=left
-fillText "B" 410.7489,192.9161 fs=#444 font=11px sans-serif al=left bl=middle
-fillText "C" 365.3909,332.5139 fs=#444 font=11px sans-serif al=left bl=middle
+fillText "B" 416.4952,183.0991 fs=#444 font=11px sans-serif al=left bl=middle
+fillText "C" 368.9423,329.4519 fs=#444 font=11px sans-serif al=left bl=middle
 set textAlign=right
-fillText "D" 218.6091,332.5139 fs=#444 font=11px sans-serif al=right bl=middle
-fillText "E" 173.2511,192.9161 fs=#444 font=11px sans-serif al=right bl=middle
+fillText "D" 215.0577,329.4519 fs=#444 font=11px sans-serif al=right bl=middle
+fillText "E" 167.5048,183.0991 fs=#444 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 292,156.26
-lineTo 345.6681,214.0622
-lineTo 347.2812,307.588
-lineTo 269.8875,261.9352
-lineTo 220.4425,208.2496
+moveTo 292,144.282
+lineTo 348.5413,205.1786
+lineTo 350.2407,303.7114
+lineTo 268.7037,255.6146
+lineTo 216.6117,199.0548
 closePath
 set fillStyle=rgba(68,114,196,0.25)
 fill fs=rgba(68,114,196,0.25) ga=1
@@ -1671,11 +1774,11 @@ set strokeStyle=#4472C4
 set lineWidth=2
 stroke ss=#4472C4 lw=2 dash=
 beginPath
-moveTo 292,193.88
-lineTo 381.4469,202.437
-lineTo 325.1687,277.1528
-lineTo 247.775,292.3704
-lineTo 238.3319,214.0622
+moveTo 292,183.916
+lineTo 386.2354,192.9311
+lineTo 326.9444,271.6469
+lineTo 245.4074,287.6792
+lineTo 235.4587,205.1786
 closePath
 set fillStyle=rgba(237,125,49,0.25)
 fill fs=rgba(237,125,49,0.25) ga=1
@@ -1686,23 +1789,23 @@ set fillStyle=#4472C4
 set strokeStyle=#4472C4
 set lineWidth=1.575
 beginPath
-moveTo 576,222.25
-lineTo 592.8,222.25
+moveTo 576,214.3
+lineTo 592.8,214.3
 stroke ss=#4472C4 lw=1.575 dash=
 set lineWidth=2
 set fillStyle=#333
 set textAlign=left
-fillText "X" 596.8,222.25 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "X" 596.8,214.3 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
 set strokeStyle=#ED7D31
 set lineWidth=1.575
 beginPath
-moveTo 576,236.75
-lineTo 592.8,236.75
+moveTo 576,228.8
+lineTo 592.8,228.8
 stroke ss=#ED7D31 lw=1.575 dash=
 set lineWidth=2
 set fillStyle=#333
-fillText "Y" 596.8,236.75 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Y" 596.8,228.8 fs=#333 font=10.5px sans-serif al=left bl=middle
 restore"
 `;
 
@@ -1711,12 +1814,12 @@ exports[`renderChart draw-call signature (characterization) > is stable for: sca
 save
 set font=10.5px sans-serif
 restore
-set font=bold 30.6px Calibri, Arial, sans-serif
+set font=bold 14.700000000000001px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
-fillText "XY" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
-set font=10.7px sans-serif
+fillText "XY" 332,29.114 fs=#333 font=bold 14.700000000000001px Calibri, Arial, sans-serif al=center bl=top
+set font=11px sans-serif
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
@@ -1726,7 +1829,7 @@ stroke ss=#e0e0e0 lw=0.5 dash=
 set fillStyle=#555
 set textAlign=right
 set textBaseline=middle
-fillText "0" 112.1,312.95 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "0" 112.1,312.95 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
@@ -1736,54 +1839,54 @@ stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 116.1,259.45
-lineTo 540,259.45
+moveTo 116.1,250.5063
+lineTo 540,250.5063
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "2" 112.1,259.45 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "2" 112.1,250.5063 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 112.1,259.45
-lineTo 116.1,259.45
+moveTo 112.1,250.5063
+lineTo 116.1,250.5063
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 116.1,205.95
-lineTo 540,205.95
+moveTo 116.1,188.0625
+lineTo 540,188.0625
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "4" 112.1,205.95 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "4" 112.1,188.0625 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 112.1,205.95
-lineTo 116.1,205.95
+moveTo 112.1,188.0625
+lineTo 116.1,188.0625
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 116.1,152.45
-lineTo 540,152.45
+moveTo 116.1,125.6188
+lineTo 540,125.6188
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "6" 112.1,152.45 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "6" 112.1,125.6188 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 112.1,152.45
-lineTo 116.1,152.45
+moveTo 112.1,125.6188
+lineTo 116.1,125.6188
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 116.1,98.95
-lineTo 540,98.95
+moveTo 116.1,63.175
+lineTo 540,63.175
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "8" 112.1,98.95 fs=#555 font=10.7px sans-serif al=right bl=middle
+fillText "8" 112.1,63.175 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 112.1,98.95
-lineTo 116.1,98.95
+moveTo 112.1,63.175
+lineTo 116.1,63.175
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
@@ -1797,43 +1900,43 @@ stroke ss=#888 lw=1 dash=
 restore
 save
 beginPath
-moveTo 116.1,98.95
+moveTo 116.1,63.175
 lineTo 116.1,312.95
 stroke ss=#888 lw=1 dash=
 restore
 set textAlign=center
 set textBaseline=top
-fillText "0" 116.1,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
+fillText "0" 116.1,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 116.1,316.95
 lineTo 116.1,312.95
 stroke ss=#888 lw=1 dash=
-fillText "1" 186.75,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
+fillText "1" 186.75,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 186.75,316.95
 lineTo 186.75,312.95
 stroke ss=#888 lw=1 dash=
-fillText "2" 257.4,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
+fillText "2" 257.4,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 257.4,316.95
 lineTo 257.4,312.95
 stroke ss=#888 lw=1 dash=
-fillText "3" 328.05,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
+fillText "3" 328.05,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 328.05,316.95
 lineTo 328.05,312.95
 stroke ss=#888 lw=1 dash=
-fillText "4" 398.7,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
+fillText "4" 398.7,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 398.7,316.95
 lineTo 398.7,312.95
 stroke ss=#888 lw=1 dash=
-fillText "5" 469.35,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
+fillText "5" 469.35,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 469.35,316.95
 lineTo 469.35,312.95
 stroke ss=#888 lw=1 dash=
-fillText "6" 540,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
+fillText "6" 540,316.95 fs=#555 font=11px sans-serif al=center bl=top
 beginPath
 moveTo 540,316.95
 lineTo 540,312.95
@@ -1842,56 +1945,56 @@ save
 set strokeStyle=#4472C4
 set lineWidth=1.5
 beginPath
-moveTo 186.75,259.45
-lineTo 257.4,205.95
-lineTo 328.05,232.7
-lineTo 398.7,179.2
-lineTo 469.35,152.45
+moveTo 186.75,250.5063
+lineTo 257.4,188.0625
+lineTo 328.05,219.2844
+lineTo 398.7,156.8406
+lineTo 469.35,125.6188
 stroke ss=#4472C4 lw=1.5 dash=
 restore
 save
 set fillStyle=#4472C4
 beginPath
-moveTo 186.75,256.825
-lineTo 189.375,259.45
-lineTo 186.75,262.075
-lineTo 184.125,259.45
+moveTo 186.75,247.8813
+lineTo 189.375,250.5063
+lineTo 186.75,253.1313
+lineTo 184.125,250.5063
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 257.4,203.325
-lineTo 260.025,205.95
-lineTo 257.4,208.575
-lineTo 254.775,205.95
+moveTo 257.4,185.4375
+lineTo 260.025,188.0625
+lineTo 257.4,190.6875
+lineTo 254.775,188.0625
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 328.05,230.075
-lineTo 330.675,232.7
-lineTo 328.05,235.325
-lineTo 325.425,232.7
+moveTo 328.05,216.6594
+lineTo 330.675,219.2844
+lineTo 328.05,221.9094
+lineTo 325.425,219.2844
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 398.7,176.575
-lineTo 401.325,179.2
-lineTo 398.7,181.825
-lineTo 396.075,179.2
+moveTo 398.7,154.2156
+lineTo 401.325,156.8406
+lineTo 398.7,159.4656
+lineTo 396.075,156.8406
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 469.35,149.825
-lineTo 471.975,152.45
-lineTo 469.35,155.075
-lineTo 466.725,152.45
+moveTo 469.35,122.9938
+lineTo 471.975,125.6188
+lineTo 469.35,128.2438
+lineTo 466.725,125.6188
 closePath
 fill fs=#4472C4 ga=1
 restore
@@ -1899,26 +2002,26 @@ set font=10.5px sans-serif
 set textBaseline=middle
 set lineWidth=1.575
 beginPath
-moveTo 576,203.95
-lineTo 592.8,203.95
+moveTo 576,186.0625
+lineTo 592.8,186.0625
 stroke ss=#4472C4 lw=1.575 dash=
 set lineWidth=1.5
 save
 beginPath
-moveTo 584.4,200.905
-lineTo 587.445,203.95
-lineTo 584.4,206.995
-lineTo 581.355,203.95
+moveTo 584.4,183.0175
+lineTo 587.445,186.0625
+lineTo 584.4,189.1075
+lineTo 581.355,186.0625
 closePath
 fill fs=#4472C4 ga=1
 restore
 set fillStyle=#333
 set textAlign=left
-fillText "S1" 596.8,203.95 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "S1" 596.8,186.0625 fs=#333 font=10.5px sans-serif al=left bl=middle
 save
 set font=bold 10.5px sans-serif
 set fillStyle=#555
-translate 30.05,205.95
+translate 30.05,188.0625
 rotate -1.5708
 set textAlign=center
 fillText "Y" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
@@ -2093,113 +2196,111 @@ exports[`renderChart draw-call signature (characterization) > is stable for: sta
 save
 set font=10.5px sans-serif
 restore
-set font=10.9px sans-serif
+set font=11px sans-serif
 set font=10.5px sans-serif
-set font=bold 30.6px Calibri, Arial, sans-serif
+set font=bold 14.700000000000001px Calibri, Arial, sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=top
-fillText "Stacked" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
+fillText "Stacked" 332,29.114 fs=#333 font=bold 14.700000000000001px Calibri, Arial, sans-serif al=center bl=top
 save
 set font=11px sans-serif
 restore
 set textBaseline=middle
-set font=10.9px sans-serif
 set fillStyle=#555
 set strokeStyle=#aaa
 beginPath
-moveTo 41.08,316.95
+moveTo 41.2,316.95
 lineTo 632.8,316.95
 stroke ss=#aaa lw=1 dash=
 set textAlign=right
-fillText "0" 29.08,316.95 fs=#555 font=10.9px sans-serif al=right bl=middle
+fillText "0" 29.2,316.95 fs=#555 font=11px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 41.08,273.35
-lineTo 632.8,273.35
+moveTo 41.2,266.195
+lineTo 632.8,266.195
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "10" 29.08,273.35 fs=#555 font=10.9px sans-serif al=right bl=middle
+fillText "10" 29.2,266.195 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 41.08,229.75
-lineTo 632.8,229.75
+moveTo 41.2,215.44
+lineTo 632.8,215.44
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "20" 29.08,229.75 fs=#555 font=10.9px sans-serif al=right bl=middle
+fillText "20" 29.2,215.44 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 41.08,186.15
-lineTo 632.8,186.15
+moveTo 41.2,164.685
+lineTo 632.8,164.685
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "30" 29.08,186.15 fs=#555 font=10.9px sans-serif al=right bl=middle
+fillText "30" 29.2,164.685 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 41.08,142.55
-lineTo 632.8,142.55
+moveTo 41.2,113.93
+lineTo 632.8,113.93
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "40" 29.08,142.55 fs=#555 font=10.9px sans-serif al=right bl=middle
+fillText "40" 29.2,113.93 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
-moveTo 41.08,98.95
-lineTo 632.8,98.95
+moveTo 41.2,63.175
+lineTo 632.8,63.175
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "50" 29.08,98.95 fs=#555 font=10.9px sans-serif al=right bl=middle
+fillText "50" 29.2,63.175 fs=#555 font=11px sans-serif al=right bl=middle
 set fillStyle=#4472C4
-fillRect 100.252,273.35,78.896,43.6 fs=#4472C4
+fillRect 100.36,266.195,78.88,50.755 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 100.252,238.47,78.896,34.88 fs=#ED7D31
+fillRect 100.36,225.591,78.88,40.604 fs=#ED7D31
 set fillStyle=#4472C4
-fillRect 297.492,212.31,78.896,104.64 fs=#4472C4
+fillRect 297.56,195.138,78.88,121.812 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 297.492,146.91,78.896,65.4 fs=#ED7D31
+fillRect 297.56,119.0055,78.88,76.1325 fs=#ED7D31
 set fillStyle=#4472C4
-fillRect 494.732,242.83,78.896,74.12 fs=#4472C4
+fillRect 494.76,230.6665,78.88,86.2835 fs=#4472C4
 set fillStyle=#ED7D31
-fillRect 494.732,146.91,78.896,95.92 fs=#ED7D31
+fillRect 494.76,119.0055,78.88,111.661 fs=#ED7D31
 set fillStyle=#555
-set font=11px sans-serif
 set textAlign=center
 set textBaseline=top
-fillText "Q1" 139.7,319.95 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Q2" 336.94,319.95 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Q3" 534.18,319.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q1" 139.8,319.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q2" 337,319.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q3" 534.2,319.95 fs=#555 font=11px sans-serif al=center bl=top
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 41.08,316.95
+moveTo 41.2,316.95
 lineTo 632.8,316.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.08,316.95
-lineTo 41.08,316.95
+moveTo 37.2,316.95
+lineTo 41.2,316.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.08,273.35
-lineTo 41.08,273.35
+moveTo 37.2,266.195
+lineTo 41.2,266.195
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.08,229.75
-lineTo 41.08,229.75
+moveTo 37.2,215.44
+lineTo 41.2,215.44
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.08,186.15
-lineTo 41.08,186.15
+moveTo 37.2,164.685
+lineTo 41.2,164.685
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.08,142.55
-lineTo 41.08,142.55
+moveTo 37.2,113.93
+lineTo 41.2,113.93
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 37.08,98.95
-lineTo 41.08,98.95
+moveTo 37.2,63.175
+lineTo 41.2,63.175
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 41.08,320.95
-lineTo 41.08,316.95
+moveTo 41.2,320.95
+lineTo 41.2,316.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 238.32,320.95
-lineTo 238.32,316.95
+moveTo 238.4,320.95
+lineTo 238.4,316.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 435.56,320.95
-lineTo 435.56,316.95
+moveTo 435.6,320.95
+lineTo 435.6,316.95
 stroke ss=#aaa lw=1 dash=
 beginPath
 moveTo 632.8,320.95

--- a/packages/core/src/chart/layout.test.ts
+++ b/packages/core/src/chart/layout.test.ts
@@ -104,9 +104,13 @@ describe('chartTitleFontPx', () => {
   it('honors XML size in hundredths of a point', () => {
     expect(chartTitleFontPx(model({ titleFontSizeHpt: 1600 }), H, PTPX)).toBe((1600 / 100) * PTPX);
   });
-  it('falls back to max(10, h*0.085)', () => {
-    expect(chartTitleFontPx(model({}), H, PTPX)).toBe(Math.max(10, H * 0.085));
-    expect(chartTitleFontPx(model({}), 80, PTPX)).toBe(Math.max(10, 80 * 0.085));
+  it('uses the same 14pt fallback on compact and large frames', () => {
+    expect(chartTitleFontPx(model({}), 80, PTPX)).toBe(14 * PTPX);
+    expect(chartTitleFontPx(model({}), 720, PTPX)).toBe(14 * PTPX);
+  });
+  it('shares the fallback across classic and ChartEx chart families', () => {
+    expect(chartTitleFontPx(model({ chartType: 'line' }), H, PTPX)).toBe(14 * PTPX);
+    expect(chartTitleFontPx(model({ chartType: 'boxWhisker' }), H, PTPX)).toBe(14 * PTPX);
   });
 });
 

--- a/packages/core/src/chart/layout.ts
+++ b/packages/core/src/chart/layout.ts
@@ -131,12 +131,16 @@ export interface ChartFrame {
 
 // ─── Title band ──────────────────────────────────────────────────────────────
 
-/** Chart title font size (px). Verbatim from renderer.ts `chartTitleFontPx`:
- *  honor the XML `<c:title>…@sz` (hundredths of a point, scaled by ptToPx),
- *  else the proportional `max(10, h*0.085)` fallback. */
-export function chartTitleFontPx(chart: ChartModel, h: number, ptToPx: number): number {
+/** Product fallback for a chart title whose authored rich text and linked
+ *  Chart Style both omit a size. OOXML does not define an automatic size. */
+const DEFAULT_CHART_TITLE_SIZE_PT = 14;
+
+/** Chart title font size (px). Honor the parser-resolved size first (authored
+ *  rich text, then linked Chart Style); otherwise use one deterministic 14pt
+ *  fallback across classic and ChartEx chart families. */
+export function chartTitleFontPx(chart: ChartModel, _h: number, ptToPx: number): number {
   if (chart.titleFontSizeHpt) return (chart.titleFontSizeHpt / 100) * ptToPx;
-  return Math.max(10, h * 0.085);
+  return DEFAULT_CHART_TITLE_SIZE_PT * ptToPx;
 }
 
 /** Fraction of the title font size used as the band's TOP pad — the gap from
@@ -152,15 +156,17 @@ export function chartTitleFontPx(chart: ChartModel, h: number, ptToPx: number): 
  *  places the cap-top at ~0.81×font from the band top, matching PowerPoint's
  *  rendered chart titles (measured against the demo sample-1 line chart PDF).
  *
- *  The band's TOTAL height (`bandH`) is unchanged — see {@link chartTitleBand};
- *  only the split between top and bottom pad moves, so the plot rectangle below
- *  the title does not shift by a single pixel. */
+ *  For an already-resolved `fontPx`, the band's TOTAL height (`bandH`) is
+ *  unchanged by this top/bottom-pad redistribution — see
+ *  {@link chartTitleBand}. A different resolved title size may still change the
+ *  band and therefore the plot rectangle below it. */
 export const TITLE_TOP_PAD_FONT_FRAC = 0.62;
 
 /** Resolve the title band from the family's top/bottom pad FRACTIONS (of `h`).
  *  These fractions still set the band's TOTAL height (`bandH = fontPx +
- *  h*topPadFrac + h*bottomPadFrac`), which every family's plot layout depends on
- *  — that value is byte-identical to before, so the plot area never moves.
+ *  h*topPadFrac + h*bottomPadFrac`), which every family's plot layout depends on.
+ *  Given the same resolved `fontPx`, changing only the top/bottom-pad split keeps
+ *  that total byte-identical; resolving a different font size changes `bandH`.
  *
  *  What changed: the title's vertical placement WITHIN the band. `topPad` (the
  *  draw offset) is now a FONT-proportional inset ({@link TITLE_TOP_PAD_FONT_FRAC}
@@ -180,8 +186,8 @@ export function chartTitleBand(
 ): ChartTitleBand {
   if (!chart.title && !chart.titlePresent) return { fontPx: 0, topPad: 0, bottomPad: 0, bandH: 0 };
   const fontPx = chartTitleFontPx(chart, h, ptToPx);
-  // Total band height is preserved verbatim from the family fractions so the
-  // plot rectangle below stays put.
+  // For a given resolved font size, the family fractions preserve the total
+  // band height while only the top/bottom-pad split changes.
   const bandH = fontPx + h * topPadFrac + h * bottomPadFrac;
   // Font-proportional top inset, clamped so the title never overflows the band.
   const topPad = Math.min(Math.max(0, bandH - fontPx), fontPx * TITLE_TOP_PAD_FONT_FRAC);

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -6329,11 +6329,34 @@ describe('CH15 — chartEx box-and-whisker', () => {
     expect(outlineSegments.every(segment => segment.lw === 2)).toBe(true);
   });
 
-  it('sizes the title from titleFontSizeHpt (chartStyle part) rather than an area-proportional guess', () => {
-    // With titleFontSizeHpt=1400 (14pt, Word's default modern chartStyle) at
-    // scale 1 the title renders at 14px — far below the Math.max(10, h*0.085) ≈
-    // 30.6px the fallback would produce for this 360px-tall rect. Capture the
-    // font active at each fillText so we can read the title's px size.
+  it('uses the same 14pt omitted-title fallback for classic and ChartEx charts', () => {
+    const cases: Array<{ title: string; chart: ChartModel }> = [
+      {
+        title: 'classic title',
+        chart: baseModel({
+          chartType: 'line',
+          title: 'classic title',
+          titleFontSizeHpt: null,
+          categories: ['A', 'B'],
+          series: [series({ values: [1, 2] })],
+        }),
+      },
+      {
+        title: 'ChartEx title',
+        chart: boxModel({ title: 'ChartEx title', titleFontSizeHpt: null }),
+      },
+    ];
+
+    for (const { title, chart } of cases) {
+      const rec = ringRecordingCtx();
+      renderChart(rec.ctx, chart, RECT, 1);
+      expect(rec.fontTexts.find(text => text.text === title)?.font).toContain('14px');
+    }
+  });
+
+  it('uses the parser-resolved linked Chart Style title size', () => {
+    // With titleFontSizeHpt=1400 (14pt) at scale 1 the title renders at 14px.
+    // Capture the font active at each fillText so we can read the title's size.
     const drawn: Array<{ text: string; px: number }> = [];
     const state: Record<string, unknown> = {
       font: '10px sans-serif', fillStyle: '#000', strokeStyle: '#000', lineWidth: 1,
@@ -6357,8 +6380,7 @@ describe('CH15 — chartEx box-and-whisker', () => {
     renderChart(ctx, boxModel({ title: 'the box title', titleFontSizeHpt: 1400 }), RECT, 1);
     const titleDraw = drawn.find(d => d.text === 'the box title');
     expect(titleDraw).toBeDefined();
-    // 1400 hpt → 14pt → 14px at scale 1. Assert it honored the size (14, not the
-    // ~30.6px area-proportional fallback).
+    // 1400 hpt → 14pt → 14px at scale 1.
     expect(titleDraw?.px).toBeCloseTo(14, 5);
   });
 });

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -1849,9 +1849,9 @@ function renderBarChart(
     }
     : chart;
 
-  // Honor the XML-specified title font size when present; otherwise fall back
-  // to the proportional heuristic. Reserve the title band based on the actual
-  // drawn height so the plot shrinks to avoid overlap.
+  // Honor the parser-resolved title font size when present; otherwise use the
+  // shared fixed fallback. Reserve the title band from the actual drawn size
+  // so the plot shrinks to avoid overlap.
   // Shared frame bands. Title + category-label bands follow PowerPoint's chart
   // auto-layout (font-proportional, pinned to the demo slide-5 line-chart PDF);
   // see cartesianTitleBand / catAxisLabelBandH in layout.ts. The default 0.22

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -1924,10 +1924,9 @@ pub const CHART_COLOR_STYLE_REL_TYPE_SUFFIX: &str = "relationships/chartColorSty
 /// A chartEx part almost never inlines the title size on its own `<cx:title>`;
 /// instead the size lives in the sibling `styleN.xml` reached via the chart
 /// part's `.../2011/relationships/chartStyle` relationship. Word's default
-/// modern chart style writes `<cs:title><cs:defRPr sz="1400">` (14pt), so
-/// without reading it a chartEx title would fall back to an area-proportional
-/// guess that is visibly too large. `None` when `style_xml` is absent, malformed,
-/// or declares no `<cs:title>` size.
+/// modern chart style writes `<cs:title><cs:defRPr sz="1400">` (14pt). `None`
+/// when `style_xml` is absent, malformed, or declares no `<cs:title>` size; the
+/// renderer then uses its shared deterministic fallback.
 pub fn extract_chartex_style_title_size(style_xml: &str) -> Option<i32> {
     let doc = crate::depth::parse_guarded(style_xml).ok()?;
     let title = doc
@@ -11701,7 +11700,7 @@ mod tests {
     /// A chartEx title with no inline `sz` falls back to the chartStyle part's
     /// `<cs:title>` size; an inline `sz` on the `<cx:title>` rich text wins over
     /// the style part; and with no style part at all the size is `None` (the
-    /// renderer's area-proportional fallback).
+    /// renderer's shared deterministic fallback).
     #[test]
     fn parse_chartex_part_title_size_resolves_from_style_part() {
         let chart_xml = |title_rpr: &str| {


### PR DESCRIPTION
Closes #1237

## Summary

- resolve omitted chart-title size to a fixed 14pt compatibility fallback
- share the same resolved title size across classic and ChartEx chart families
- preserve authored direct formatting and linked Chart Style precedence

## Verification

- focused layout, renderer correctness, and signature tests
- parser precedence test and TypeScript build
- independent adversarial review
- local-only self-regression and Office-reference fidelity review; final user adjudication remains pending for reference-unavailable differences

This is a deliberately small compatibility policy for behavior that is not fully defined by OOXML.