### PR TITLE
fix(chart): stabilize automatic axis title layout

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -12,38 +12,38 @@ set textBaseline=top
 fillText "Area" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
 set strokeStyle=#aaa
 beginPath
-moveTo 88.8,313.45
-lineTo 540,313.45
+moveTo 88.8,312.95
+lineTo 540,312.95
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 88.8,241.95
-lineTo 540,241.95
+moveTo 88.8,241.6167
+lineTo 540,241.6167
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 88.8,170.45
-lineTo 540,170.45
+moveTo 88.8,170.2833
+lineTo 540,170.2833
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
 moveTo 88.8,98.95
 lineTo 540,98.95
 stroke ss=#e0e0e0 lw=0.5 dash=
 beginPath
-moveTo 107.6,313.45
-lineTo 107.6,270.55
-lineTo 145.2,241.95
-lineTo 182.8,256.25
-lineTo 220.4,227.65
-lineTo 258,213.35
-lineTo 295.6,241.95
-lineTo 333.2,199.05
-lineTo 370.8,227.65
-lineTo 408.4,184.75
-lineTo 446,213.35
-lineTo 483.6,170.45
-lineTo 521.2,199.05
-lineTo 521.2,313.45
+moveTo 107.6,312.95
+lineTo 107.6,270.15
+lineTo 145.2,241.6167
+lineTo 182.8,255.8833
+lineTo 220.4,227.35
+lineTo 258,213.0833
+lineTo 295.6,241.6167
+lineTo 333.2,198.8167
+lineTo 370.8,227.35
+lineTo 408.4,184.55
+lineTo 446,213.0833
+lineTo 483.6,170.2833
+lineTo 521.2,198.8167
+lineTo 521.2,312.95
 closePath
 set fillStyle=#4472C4
 fill fs=#4472C4 ga=1
@@ -51,37 +51,37 @@ set strokeStyle=#4472C4
 set lineWidth=1.5
 setLineDash
 stroke ss=#4472C4 lw=1.5 dash=
-set font=10.725px sans-serif
+set font=10.7px sans-serif
 set textBaseline=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,313.45
-lineTo 88.8,313.45
+moveTo 84.8,312.95
+lineTo 88.8,312.95
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=1.5
 set fillStyle=#555
 set textAlign=right
-fillText "0" 82.8,313.45 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "0" 82.8,312.95 fs=#555 font=10.7px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,241.95
-lineTo 88.8,241.95
+moveTo 84.8,241.6167
+lineTo 88.8,241.6167
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=1.5
-fillText "5" 82.8,241.95 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "5" 82.8,241.6167 fs=#555 font=10.7px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.8,170.45
-lineTo 88.8,170.45
+moveTo 84.8,170.2833
+lineTo 88.8,170.2833
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=1.5
-fillText "10" 82.8,170.45 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "10" 82.8,170.2833 fs=#555 font=10.7px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
@@ -90,92 +90,93 @@ lineTo 88.8,98.95
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=1.5
-fillText "15" 82.8,98.95 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "15" 82.8,98.95 fs=#555 font=10.7px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 88.8,313.45
-lineTo 540,313.45
+moveTo 88.8,312.95
+lineTo 540,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 88.8,317.45
-lineTo 88.8,313.45
+moveTo 88.8,316.95
+lineTo 88.8,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 126.4,317.45
-lineTo 126.4,313.45
+moveTo 126.4,316.95
+lineTo 126.4,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 164,317.45
-lineTo 164,313.45
+moveTo 164,316.95
+lineTo 164,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 201.6,317.45
-lineTo 201.6,313.45
+moveTo 201.6,316.95
+lineTo 201.6,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 239.2,317.45
-lineTo 239.2,313.45
+moveTo 239.2,316.95
+lineTo 239.2,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 276.8,317.45
-lineTo 276.8,313.45
+moveTo 276.8,316.95
+lineTo 276.8,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 314.4,317.45
-lineTo 314.4,313.45
+moveTo 314.4,316.95
+lineTo 314.4,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 352,317.45
-lineTo 352,313.45
+moveTo 352,316.95
+lineTo 352,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 389.6,317.45
-lineTo 389.6,313.45
+moveTo 389.6,316.95
+lineTo 389.6,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 427.2,317.45
-lineTo 427.2,313.45
+moveTo 427.2,316.95
+lineTo 427.2,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 464.8,317.45
-lineTo 464.8,313.45
+moveTo 464.8,316.95
+lineTo 464.8,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 502.4,317.45
-lineTo 502.4,313.45
+moveTo 502.4,316.95
+lineTo 502.4,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 540,317.45
-lineTo 540,313.45
+moveTo 540,316.95
+lineTo 540,312.95
 stroke ss=#aaa lw=1 dash=
 set textAlign=center
 set textBaseline=top
 set font=11px sans-serif
-fillText "Jan" 107.6,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Feb" 145.2,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Mar" 182.8,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Apr" 220.4,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "May" 258,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Jun" 295.6,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Jul" 333.2,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Aug" 370.8,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Sep" 408.4,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Oct" 446,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Nov" 483.6,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Dec" 521.2,316.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Jan" 107.6,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Feb" 145.2,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Mar" 182.8,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Apr" 220.4,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "May" 258,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Jun" 295.6,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Jul" 333.2,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Aug" 370.8,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Sep" 408.4,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Oct" 446,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Nov" 483.6,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Dec" 521.2,315.95 fs=#555 font=11px sans-serif al=center bl=top
 set font=10.5px sans-serif
 set textBaseline=middle
 set fillStyle=#4472C4
-fillRect 576,198.95,10,10.5 fs=#4472C4
+fillRect 576,198.7,10,10.5 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "A" 590,204.2 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "A" 590,203.95 fs=#333 font=10.5px sans-serif al=left bl=middle
 save
-set font=bold 10px sans-serif
+set font=bold 10.5px sans-serif
 set fillStyle=#555
+translate 314.4,366.75
 set textAlign=center
-fillText "Month" 314.4,367 fs=#555 font=bold 10px sans-serif al=center bl=middle
+fillText "Month" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 restore"
 `;
@@ -346,7 +347,7 @@ exports[`renderChart draw-call signature (characterization) > is stable for: clu
 save
 set font=10.5px sans-serif
 restore
-set font=10.725px sans-serif
+set font=10.7px sans-serif
 set font=10.5px sans-serif
 set font=bold 30.6px Calibri, Arial, sans-serif
 set fillStyle=#333
@@ -357,124 +358,125 @@ save
 set font=11px sans-serif
 restore
 set textBaseline=middle
-set font=10.725px sans-serif
+set font=10.7px sans-serif
 set fillStyle=#555
 set strokeStyle=#aaa
 beginPath
-moveTo 67.67,313.45
-lineTo 552.8,313.45
+moveTo 68.14,312.95
+lineTo 552.8,312.95
 stroke ss=#aaa lw=1 dash=
 set textAlign=right
-fillText "0" 55.67,313.45 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "0" 56.14,312.95 fs=#555 font=10.7px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 67.67,241.95
-lineTo 552.8,241.95
+moveTo 68.14,241.6167
+lineTo 552.8,241.6167
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "10" 55.67,241.95 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "10" 56.14,241.6167 fs=#555 font=10.7px sans-serif al=right bl=middle
 beginPath
-moveTo 67.67,170.45
-lineTo 552.8,170.45
+moveTo 68.14,170.2833
+lineTo 552.8,170.2833
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "20" 55.67,170.45 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "20" 56.14,170.2833 fs=#555 font=10.7px sans-serif al=right bl=middle
 beginPath
-moveTo 67.67,98.95
+moveTo 68.14,98.95
 lineTo 552.8,98.95
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "30" 55.67,98.95 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "30" 56.14,98.95 fs=#555 font=10.7px sans-serif al=right bl=middle
 set fillStyle=#4472C4
-fillRect 102.3221,241.95,46.2029,71.5 fs=#4472C4
+fillRect 102.7586,241.6167,46.1581,71.3333 fs=#4472C4
 set font=bold 11px sans-serif
 set fillStyle=#333
 set textAlign=center
 set textBaseline=bottom
-fillText "10" 125.4236,240.95 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "10" 125.8376,240.6167 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 set fillStyle=#ED7D31
-fillRect 148.525,256.25,46.2029,57.2 fs=#ED7D31
+fillRect 148.9167,255.8833,46.1581,57.0667 fs=#ED7D31
 set fillStyle=#333
-fillText "8" 171.6264,255.25 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "8" 171.9957,254.8833 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 set fillStyle=#4472C4
-fillRect 264.0321,141.85,46.2029,171.6 fs=#4472C4
+fillRect 264.3119,141.75,46.1581,171.2 fs=#4472C4
 set fillStyle=#333
-fillText "24" 287.1336,140.85 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "24" 287.391,140.75 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 set fillStyle=#ED7D31
-fillRect 310.235,206.2,46.2029,107.25 fs=#ED7D31
+fillRect 310.47,205.95,46.1581,107 fs=#ED7D31
 set fillStyle=#333
-fillText "15" 333.3364,205.2 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "15" 333.549,204.95 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 set fillStyle=#4472C4
-fillRect 425.7421,191.9,46.2029,121.55 fs=#4472C4
+fillRect 425.8652,191.6833,46.1581,121.2667 fs=#4472C4
 set fillStyle=#333
-fillText "17" 448.8436,190.9 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "17" 448.9443,190.6833 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 set fillStyle=#ED7D31
-fillRect 471.945,156.15,46.2029,157.3 fs=#ED7D31
+fillRect 472.0233,156.0167,46.1581,156.9333 fs=#ED7D31
 set fillStyle=#333
-fillText "22" 495.0464,155.15 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "22" 495.1024,155.0167 fs=#333 font=bold 11px sans-serif al=center bl=bottom
 set fillStyle=#555
 set font=11px sans-serif
 set textBaseline=top
-fillText "Q1" 148.525,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Q2" 310.235,316.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Q3" 471.945,316.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q1" 148.9167,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q2" 310.47,315.95 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q3" 472.0233,315.95 fs=#555 font=11px sans-serif al=center bl=top
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 67.67,313.45
-lineTo 552.8,313.45
+moveTo 68.14,312.95
+lineTo 552.8,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 63.67,313.45
-lineTo 67.67,313.45
+moveTo 64.14,312.95
+lineTo 68.14,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 63.67,241.95
-lineTo 67.67,241.95
+moveTo 64.14,241.6167
+lineTo 68.14,241.6167
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 63.67,170.45
-lineTo 67.67,170.45
+moveTo 64.14,170.2833
+lineTo 68.14,170.2833
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 63.67,98.95
-lineTo 67.67,98.95
+moveTo 64.14,98.95
+lineTo 68.14,98.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 67.67,317.45
-lineTo 67.67,313.45
+moveTo 68.14,316.95
+lineTo 68.14,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 229.38,317.45
-lineTo 229.38,313.45
+moveTo 229.6933,316.95
+lineTo 229.6933,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 391.09,317.45
-lineTo 391.09,313.45
+moveTo 391.2467,316.95
+lineTo 391.2467,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 552.8,317.45
-lineTo 552.8,313.45
+moveTo 552.8,316.95
+lineTo 552.8,312.95
 stroke ss=#aaa lw=1 dash=
 set font=10.5px sans-serif
 set textBaseline=middle
 set fillStyle=#4472C4
-fillRect 576,191.7,10,10.5 fs=#4472C4
+fillRect 576,191.45,10,10.5 fs=#4472C4
 set fillStyle=#333
 set textAlign=left
-fillText "Alpha" 590,196.95 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Alpha" 590,196.7 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
-fillRect 576,206.2,10,10.5 fs=#ED7D31
+fillRect 576,205.95,10,10.5 fs=#ED7D31
 set fillStyle=#333
-fillText "Beta" 590,211.45 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "Beta" 590,211.2 fs=#333 font=10.5px sans-serif al=left bl=middle
 save
-set font=bold 10px sans-serif
+set font=bold 10.5px sans-serif
 set fillStyle=#555
-translate 29.8,206.2
+translate 30.05,205.95
 rotate -1.5708
 set textAlign=center
-fillText "Units" 0,0 fs=#555 font=bold 10px sans-serif al=center bl=middle
+fillText "Units" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 save
-fillText "Quarter" 310.235,367 fs=#555 font=bold 10px sans-serif al=center bl=middle
+translate 310.47,366.75
+fillText "Quarter" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 restore"
 `;
@@ -668,7 +670,7 @@ set fillStyle=#555
 set strokeStyle=#aaa
 beginPath
 moveTo 47.8,335.45
-lineTo 495.6,335.45
+lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 set textAlign=right
 fillText "0" 35.8,335.45 fs=#555 font=11px sans-serif al=right bl=middle
@@ -676,52 +678,52 @@ set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
 moveTo 47.8,256.6167
-lineTo 495.6,256.6167
+lineTo 503.1,256.6167
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "50" 35.8,256.6167 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
 moveTo 47.8,177.7833
-lineTo 495.6,177.7833
+lineTo 503.1,177.7833
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "100" 35.8,177.7833 fs=#555 font=11px sans-serif al=right bl=middle
 beginPath
 moveTo 47.8,98.95
-lineTo 495.6,98.95
+lineTo 503.1,98.95
 stroke ss=#e0e0e0 lw=0.5 dash=
 fillText "150" 35.8,98.95 fs=#555 font=11px sans-serif al=right bl=middle
 set fillStyle=#4472C4
-fillRect 92.58,177.7833,59.7067,157.6667 fs=#4472C4
-fillRect 241.8467,114.7167,59.7067,220.7333 fs=#4472C4
-fillRect 391.1133,146.25,59.7067,189.2 fs=#4472C4
+fillRect 93.33,177.7833,60.7067,157.6667 fs=#4472C4
+fillRect 245.0967,114.7167,60.7067,220.7333 fs=#4472C4
+fillRect 396.8633,146.25,60.7067,189.2 fs=#4472C4
 set fillStyle=#555
 set textAlign=center
 set textBaseline=top
-fillText "Q1" 122.4333,338.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Q2" 271.7,338.45 fs=#555 font=11px sans-serif al=center bl=top
-fillText "Q3" 420.9667,338.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q1" 123.6833,338.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q2" 275.45,338.45 fs=#555 font=11px sans-serif al=center bl=top
+fillText "Q3" 427.2167,338.45 fs=#555 font=11px sans-serif al=center bl=top
 set strokeStyle=#ED7D31
 set lineWidth=2
 setLineDash
 beginPath
-moveTo 122.4333,193.55
-lineTo 271.7,122.6
-lineTo 420.9667,158.075
+moveTo 123.6833,193.55
+lineTo 275.45,122.6
+lineTo 427.2167,158.075
 stroke ss=#ED7D31 lw=2 dash=
 set fillStyle=#ED7D31
 beginPath
-arc 122.4333,193.55,3,0,6.2832
+arc 123.6833,193.55,3,0,6.2832
 fill fs=#ED7D31 ga=1
 beginPath
-arc 271.7,122.6,3,0,6.2832
+arc 275.45,122.6,3,0,6.2832
 fill fs=#ED7D31 ga=1
 beginPath
-arc 420.9667,158.075,3,0,6.2832
+arc 427.2167,158.075,3,0,6.2832
 fill fs=#ED7D31 ga=1
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
 moveTo 47.8,335.45
-lineTo 495.6,335.45
+lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
 moveTo 43.8,335.45
@@ -744,55 +746,55 @@ moveTo 47.8,339.45
 lineTo 47.8,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 197.0667,339.45
-lineTo 197.0667,335.45
+moveTo 199.5667,339.45
+lineTo 199.5667,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 346.3333,339.45
-lineTo 346.3333,335.45
+moveTo 351.3333,339.45
+lineTo 351.3333,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 495.6,339.45
-lineTo 495.6,335.45
+moveTo 503.1,339.45
+lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 495.6,98.95
-lineTo 495.6,335.45
+moveTo 503.1,98.95
+lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
 set fillStyle=#555
 set textAlign=left
 set textBaseline=middle
 beginPath
-moveTo 499.6,335.45
-lineTo 495.6,335.45
+moveTo 507.1,335.45
+lineTo 503.1,335.45
 stroke ss=#aaa lw=1 dash=
-fillText "0" 509.6,335.45 fs=#555 font=11px sans-serif al=left bl=middle
+fillText "0" 517.1,335.45 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 499.6,276.325
-lineTo 495.6,276.325
+moveTo 507.1,276.325
+lineTo 503.1,276.325
 stroke ss=#aaa lw=1 dash=
-fillText "5" 509.6,276.325 fs=#555 font=11px sans-serif al=left bl=middle
+fillText "5" 517.1,276.325 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 499.6,217.2
-lineTo 495.6,217.2
+moveTo 507.1,217.2
+lineTo 503.1,217.2
 stroke ss=#aaa lw=1 dash=
-fillText "10" 509.6,217.2 fs=#555 font=11px sans-serif al=left bl=middle
+fillText "10" 517.1,217.2 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 499.6,158.075
-lineTo 495.6,158.075
+moveTo 507.1,158.075
+lineTo 503.1,158.075
 stroke ss=#aaa lw=1 dash=
-fillText "15" 509.6,158.075 fs=#555 font=11px sans-serif al=left bl=middle
+fillText "15" 517.1,158.075 fs=#555 font=11px sans-serif al=left bl=middle
 beginPath
-moveTo 499.6,98.95
-lineTo 495.6,98.95
+moveTo 507.1,98.95
+lineTo 503.1,98.95
 stroke ss=#aaa lw=1 dash=
-fillText "20" 509.6,98.95 fs=#555 font=11px sans-serif al=left bl=middle
+fillText "20" 517.1,98.95 fs=#555 font=11px sans-serif al=left bl=middle
 save
-set font=18px sans-serif
+set font=bold 10.5px sans-serif
+translate 540.6,217.2
+rotate 1.5708
 set textAlign=center
-translate 537.6,217.2
-rotate -1.5708
-fillText "Margin %" 0,0 fs=#555 font=18px sans-serif al=center bl=middle
+fillText "Margin %" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 set font=10.5px sans-serif
 set fillStyle=#4472C4
@@ -885,295 +887,295 @@ set font=16.2px sans-serif
 set textBaseline=middle
 set strokeStyle=#aaa
 beginPath
-moveTo 84.44,313.45
-lineTo 540,313.45
+moveTo 84.94,312.95
+lineTo 540,312.95
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#888
 beginPath
-moveTo 80.44,313.45
-lineTo 84.44,313.45
+moveTo 80.94,312.95
+lineTo 84.94,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#aaa
 set fillStyle=#555
 set textAlign=right
-fillText "0" 78.44,313.45 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "0" 78.94,312.95 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 84.44,241.95
-lineTo 540,241.95
+moveTo 84.94,241.6167
+lineTo 540,241.6167
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.44,241.95
-lineTo 84.44,241.95
+moveTo 80.94,241.6167
+lineTo 84.94,241.6167
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "5" 78.44,241.95 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "5" 78.94,241.6167 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 84.44,170.45
-lineTo 540,170.45
+moveTo 84.94,170.2833
+lineTo 540,170.2833
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.44,170.45
-lineTo 84.44,170.45
+moveTo 80.94,170.2833
+lineTo 84.94,170.2833
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "10" 78.44,170.45 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "10" 78.94,170.2833 fs=#555 font=16.2px sans-serif al=right bl=middle
 beginPath
-moveTo 84.44,98.95
+moveTo 84.94,98.95
 lineTo 540,98.95
 stroke ss=#e0e0e0 lw=0.5 dash=
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 80.44,98.95
-lineTo 84.44,98.95
+moveTo 80.94,98.95
+lineTo 84.94,98.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
-fillText "15" 78.44,98.95 fs=#555 font=16.2px sans-serif al=right bl=middle
+fillText "15" 78.94,98.95 fs=#555 font=16.2px sans-serif al=right bl=middle
 set strokeStyle=#aaa
 set lineWidth=1
 beginPath
-moveTo 84.44,313.45
-lineTo 540,313.45
+moveTo 84.94,312.95
+lineTo 540,312.95
 stroke ss=#aaa lw=1 dash=
 beginPath
-moveTo 84.44,98.95
-lineTo 84.44,313.45
+moveTo 84.94,98.95
+lineTo 84.94,312.95
 stroke ss=#aaa lw=1 dash=
 set strokeStyle=#4472C4
 set lineWidth=2.3625
 setLineDash
 beginPath
-moveTo 103.4217,270.55
-lineTo 141.385,241.95
-lineTo 179.3483,256.25
-lineTo 217.3117,227.65
-lineTo 255.275,213.35
-lineTo 293.2383,241.95
-lineTo 331.2017,199.05
-lineTo 369.165,227.65
-lineTo 407.1283,184.75
-lineTo 445.0917,213.35
-lineTo 483.055,170.45
-lineTo 521.0183,199.05
+moveTo 103.9008,270.15
+lineTo 141.8225,241.6167
+lineTo 179.7442,255.8833
+lineTo 217.6658,227.35
+lineTo 255.5875,213.0833
+lineTo 293.5092,241.6167
+lineTo 331.4308,198.8167
+lineTo 369.3525,227.35
+lineTo 407.2742,184.55
+lineTo 445.1958,213.0833
+lineTo 483.1175,170.2833
+lineTo 521.0392,198.8167
 stroke ss=#4472C4 lw=2.3625 dash=
 set fillStyle=#4472C4
 beginPath
-arc 103.4217,270.55,2.625,0,6.2832
+arc 103.9008,270.15,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
 set textAlign=left
-fillText "3" 116.7667,270.55 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "3" 117.2458,270.15 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 141.385,241.95,2.625,0,6.2832
+arc 141.8225,241.6167,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "5" 154.73,241.95 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 155.1675,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 179.3483,256.25,2.625,0,6.2832
+arc 179.7442,255.8833,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "4" 192.6933,256.25 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "4" 193.0892,255.8833 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 217.3117,227.65,2.625,0,6.2832
+arc 217.6658,227.35,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "6" 230.6567,227.65 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 231.0108,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 255.275,213.35,2.625,0,6.2832
+arc 255.5875,213.0833,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "7" 268.62,213.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 268.9325,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 293.2383,241.95,2.625,0,6.2832
+arc 293.5092,241.6167,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "5" 306.5833,241.95 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 306.8542,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 331.2017,199.05,2.625,0,6.2832
+arc 331.4308,198.8167,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "8" 344.5467,199.05 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 344.7758,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 369.165,227.65,2.625,0,6.2832
+arc 369.3525,227.35,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "6" 382.51,227.65 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 382.6975,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 407.1283,184.75,2.625,0,6.2832
+arc 407.2742,184.55,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "9" 420.4733,184.75 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 420.6192,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 445.0917,213.35,2.625,0,6.2832
+arc 445.1958,213.0833,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "7" 458.4367,213.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 458.5408,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 483.055,170.45,2.625,0,6.2832
+arc 483.1175,170.2833,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "10" 496.4,170.45 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "10" 496.4625,170.2833 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 beginPath
-arc 521.0183,199.05,2.625,0,6.2832
+arc 521.0392,198.8167,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
 set fillStyle=#333
-fillText "8" 534.3633,199.05 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 534.3842,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#4472C4
 set strokeStyle=#ED7D31
 setLineDash
 beginPath
-moveTo 103.4217,284.85
-lineTo 141.385,270.55
-lineTo 179.3483,241.95
-lineTo 217.3117,256.25
-lineTo 255.275,227.65
-lineTo 293.2383,199.05
-lineTo 331.2017,213.35
-lineTo 369.165,184.75
-lineTo 407.1283,227.65
-lineTo 445.0917,199.05
-lineTo 483.055,213.35
-lineTo 521.0183,184.75
+moveTo 103.9008,284.4167
+lineTo 141.8225,270.15
+lineTo 179.7442,241.6167
+lineTo 217.6658,255.8833
+lineTo 255.5875,227.35
+lineTo 293.5092,198.8167
+lineTo 331.4308,213.0833
+lineTo 369.3525,184.55
+lineTo 407.2742,227.35
+lineTo 445.1958,198.8167
+lineTo 483.1175,213.0833
+lineTo 521.0392,184.55
 stroke ss=#ED7D31 lw=2.3625 dash=
 set fillStyle=#ED7D31
 beginPath
-arc 103.4217,284.85,2.625,0,6.2832
+arc 103.9008,284.4167,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "2" 116.7667,284.85 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "2" 117.2458,284.4167 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 141.385,270.55,2.625,0,6.2832
+arc 141.8225,270.15,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "3" 154.73,270.55 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "3" 155.1675,270.15 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 179.3483,241.95,2.625,0,6.2832
+arc 179.7442,241.6167,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "5" 192.6933,241.95 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 193.0892,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 217.3117,256.25,2.625,0,6.2832
+arc 217.6658,255.8833,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "4" 230.6567,256.25 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "4" 231.0108,255.8833 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 255.275,227.65,2.625,0,6.2832
+arc 255.5875,227.35,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "6" 268.62,227.65 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 268.9325,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 293.2383,199.05,2.625,0,6.2832
+arc 293.5092,198.8167,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "8" 306.5833,199.05 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 306.8542,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 331.2017,213.35,2.625,0,6.2832
+arc 331.4308,213.0833,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "7" 344.5467,213.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 344.7758,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 369.165,184.75,2.625,0,6.2832
+arc 369.3525,184.55,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "9" 382.51,184.75 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 382.6975,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 407.1283,227.65,2.625,0,6.2832
+arc 407.2742,227.35,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "6" 420.4733,227.65 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 420.6192,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 445.0917,199.05,2.625,0,6.2832
+arc 445.1958,198.8167,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "8" 458.4367,199.05 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 458.5408,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 483.055,213.35,2.625,0,6.2832
+arc 483.1175,213.0833,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "7" 496.4,213.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 496.4625,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 beginPath
-arc 521.0183,184.75,2.625,0,6.2832
+arc 521.0392,184.55,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
 set fillStyle=#333
-fillText "9" 534.3633,184.75 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 534.3842,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
 restore
 set fillStyle=#ED7D31
 set fillStyle=#555
@@ -1182,154 +1184,155 @@ set textBaseline=top
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 103.4217,317.45
-lineTo 103.4217,313.45
+moveTo 103.9008,316.95
+lineTo 103.9008,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 141.385,317.45
-lineTo 141.385,313.45
+moveTo 141.8225,316.95
+lineTo 141.8225,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 179.3483,317.45
-lineTo 179.3483,313.45
+moveTo 179.7442,316.95
+lineTo 179.7442,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 217.3117,317.45
-lineTo 217.3117,313.45
+moveTo 217.6658,316.95
+lineTo 217.6658,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 255.275,317.45
-lineTo 255.275,313.45
+moveTo 255.5875,316.95
+lineTo 255.5875,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 293.2383,317.45
-lineTo 293.2383,313.45
+moveTo 293.5092,316.95
+lineTo 293.5092,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 331.2017,317.45
-lineTo 331.2017,313.45
+moveTo 331.4308,316.95
+lineTo 331.4308,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 369.165,317.45
-lineTo 369.165,313.45
+moveTo 369.3525,316.95
+lineTo 369.3525,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 407.1283,317.45
-lineTo 407.1283,313.45
+moveTo 407.2742,316.95
+lineTo 407.2742,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 445.0917,317.45
-lineTo 445.0917,313.45
+moveTo 445.1958,316.95
+lineTo 445.1958,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 483.055,317.45
-lineTo 483.055,313.45
+moveTo 483.1175,316.95
+lineTo 483.1175,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 521.0183,317.45
-lineTo 521.0183,313.45
+moveTo 521.0392,316.95
+lineTo 521.0392,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#ED7D31
 set lineWidth=2.3625
-fillText "Jan" 103.4217,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
-fillText "Feb" 141.385,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
-fillText "Mar" 179.3483,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
-fillText "Apr" 217.3117,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
-fillText "May" 255.275,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
-fillText "Jun" 293.2383,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
-fillText "Jul" 331.2017,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
-fillText "Aug" 369.165,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
-fillText "Sep" 407.1283,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
-fillText "Oct" 445.0917,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
-fillText "Nov" 483.055,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
-fillText "Dec" 521.0183,318.45 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "Jan" 103.9008,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "Feb" 141.8225,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "Mar" 179.7442,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "Apr" 217.6658,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "May" 255.5875,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "Jun" 293.5092,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "Jul" 331.4308,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "Aug" 369.3525,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "Sep" 407.2742,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "Oct" 445.1958,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "Nov" 483.1175,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
+fillText "Dec" 521.0392,317.95 fs=#555 font=16.2px sans-serif al=center bl=top
 set font=10.5px sans-serif
 set textBaseline=middle
 set fillStyle=#4472C4
 set strokeStyle=#4472C4
 set lineWidth=1.575
 beginPath
-moveTo 576,196.95
-lineTo 592.8,196.95
+moveTo 576,196.7
+lineTo 592.8,196.7
 stroke ss=#4472C4 lw=1.575 dash=
 set lineWidth=2.3625
 save
 beginPath
-arc 584.4,196.95,3.045,0,6.2832
+arc 584.4,196.7,3.045,0,6.2832
 fill fs=#4472C4 ga=1
 restore
 set fillStyle=#333
 set textAlign=left
-fillText "A" 596.8,196.95 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "A" 596.8,196.7 fs=#333 font=10.5px sans-serif al=left bl=middle
 set fillStyle=#ED7D31
 set strokeStyle=#ED7D31
 set lineWidth=1.575
 beginPath
-moveTo 576,211.45
-lineTo 592.8,211.45
+moveTo 576,211.2
+lineTo 592.8,211.2
 stroke ss=#ED7D31 lw=1.575 dash=
 set lineWidth=2.3625
 save
 beginPath
-arc 584.4,211.45,3.045,0,6.2832
+arc 584.4,211.2,3.045,0,6.2832
 fill fs=#ED7D31 ga=1
 restore
 set fillStyle=#333
-fillText "B" 596.8,211.45 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "B" 596.8,211.2 fs=#333 font=10.5px sans-serif al=left bl=middle
 save
-set font=bold 10px sans-serif
+set font=bold 10.5px sans-serif
 set fillStyle=#555
-translate 29.8,206.2
+translate 30.05,205.95
 rotate -1.5708
 set textAlign=center
-fillText "Value" 0,0 fs=#555 font=bold 10px sans-serif al=center bl=middle
+fillText "Value" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 save
-fillText "Month" 312.22,367 fs=#555 font=bold 10px sans-serif al=center bl=middle
+translate 312.47,366.75
+fillText "Month" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 restore"
 `;
@@ -1533,74 +1536,74 @@ set fillStyle=#333
 set textAlign=center
 set textBaseline=top
 fillText "XY" 332,38.972 fs=#333 font=bold 30.6px Calibri, Arial, sans-serif al=center bl=top
-set font=10.725px sans-serif
+set font=10.7px sans-serif
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 115.6,313.45
-lineTo 540,313.45
+moveTo 116.1,312.95
+lineTo 540,312.95
 stroke ss=#e0e0e0 lw=0.5 dash=
 set fillStyle=#555
 set textAlign=right
 set textBaseline=middle
-fillText "0" 111.6,313.45 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "0" 112.1,312.95 fs=#555 font=10.7px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 111.6,313.45
-lineTo 115.6,313.45
+moveTo 112.1,312.95
+lineTo 116.1,312.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 115.6,259.825
-lineTo 540,259.825
+moveTo 116.1,259.45
+lineTo 540,259.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "2" 111.6,259.825 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "2" 112.1,259.45 fs=#555 font=10.7px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 111.6,259.825
-lineTo 115.6,259.825
+moveTo 112.1,259.45
+lineTo 116.1,259.45
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 115.6,206.2
-lineTo 540,206.2
+moveTo 116.1,205.95
+lineTo 540,205.95
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "4" 111.6,206.2 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "4" 112.1,205.95 fs=#555 font=10.7px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 111.6,206.2
-lineTo 115.6,206.2
+moveTo 112.1,205.95
+lineTo 116.1,205.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 115.6,152.575
-lineTo 540,152.575
+moveTo 116.1,152.45
+lineTo 540,152.45
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "6" 111.6,152.575 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "6" 112.1,152.45 fs=#555 font=10.7px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 111.6,152.575
-lineTo 115.6,152.575
+moveTo 112.1,152.45
+lineTo 116.1,152.45
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
 beginPath
-moveTo 115.6,98.95
+moveTo 116.1,98.95
 lineTo 540,98.95
 stroke ss=#e0e0e0 lw=0.5 dash=
-fillText "8" 111.6,98.95 fs=#555 font=10.725px sans-serif al=right bl=middle
+fillText "8" 112.1,98.95 fs=#555 font=10.7px sans-serif al=right bl=middle
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 111.6,98.95
-lineTo 115.6,98.95
+moveTo 112.1,98.95
+lineTo 116.1,98.95
 stroke ss=#888 lw=1 dash=
 set strokeStyle=#e0e0e0
 set lineWidth=0.5
@@ -1608,107 +1611,107 @@ save
 set strokeStyle=#888
 set lineWidth=1
 beginPath
-moveTo 115.6,313.45
-lineTo 540,313.45
+moveTo 116.1,312.95
+lineTo 540,312.95
 stroke ss=#888 lw=1 dash=
 restore
 save
 beginPath
-moveTo 115.6,98.95
-lineTo 115.6,313.45
+moveTo 116.1,98.95
+lineTo 116.1,312.95
 stroke ss=#888 lw=1 dash=
 restore
 set textAlign=center
 set textBaseline=top
-fillText "0" 115.6,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+fillText "0" 116.1,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
 beginPath
-moveTo 115.6,317.45
-lineTo 115.6,313.45
+moveTo 116.1,316.95
+lineTo 116.1,312.95
 stroke ss=#888 lw=1 dash=
-fillText "1" 186.3333,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+fillText "1" 186.75,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
 beginPath
-moveTo 186.3333,317.45
-lineTo 186.3333,313.45
+moveTo 186.75,316.95
+lineTo 186.75,312.95
 stroke ss=#888 lw=1 dash=
-fillText "2" 257.0667,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+fillText "2" 257.4,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
 beginPath
-moveTo 257.0667,317.45
-lineTo 257.0667,313.45
+moveTo 257.4,316.95
+lineTo 257.4,312.95
 stroke ss=#888 lw=1 dash=
-fillText "3" 327.8,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+fillText "3" 328.05,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
 beginPath
-moveTo 327.8,317.45
-lineTo 327.8,313.45
+moveTo 328.05,316.95
+lineTo 328.05,312.95
 stroke ss=#888 lw=1 dash=
-fillText "4" 398.5333,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+fillText "4" 398.7,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
 beginPath
-moveTo 398.5333,317.45
-lineTo 398.5333,313.45
+moveTo 398.7,316.95
+lineTo 398.7,312.95
 stroke ss=#888 lw=1 dash=
-fillText "5" 469.2667,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+fillText "5" 469.35,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
 beginPath
-moveTo 469.2667,317.45
-lineTo 469.2667,313.45
+moveTo 469.35,316.95
+lineTo 469.35,312.95
 stroke ss=#888 lw=1 dash=
-fillText "6" 540,317.45 fs=#555 font=10.725px sans-serif al=center bl=top
+fillText "6" 540,316.95 fs=#555 font=10.7px sans-serif al=center bl=top
 beginPath
-moveTo 540,317.45
-lineTo 540,313.45
+moveTo 540,316.95
+lineTo 540,312.95
 stroke ss=#888 lw=1 dash=
 save
 set strokeStyle=#4472C4
 set lineWidth=1.5
 beginPath
-moveTo 186.3333,259.825
-lineTo 257.0667,206.2
-lineTo 327.8,233.0125
-lineTo 398.5333,179.3875
-lineTo 469.2667,152.575
+moveTo 186.75,259.45
+lineTo 257.4,205.95
+lineTo 328.05,232.7
+lineTo 398.7,179.2
+lineTo 469.35,152.45
 stroke ss=#4472C4 lw=1.5 dash=
 restore
 save
 set fillStyle=#4472C4
 beginPath
-moveTo 186.3333,257.2
-lineTo 188.9583,259.825
-lineTo 186.3333,262.45
-lineTo 183.7083,259.825
+moveTo 186.75,256.825
+lineTo 189.375,259.45
+lineTo 186.75,262.075
+lineTo 184.125,259.45
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 257.0667,203.575
-lineTo 259.6917,206.2
-lineTo 257.0667,208.825
-lineTo 254.4417,206.2
+moveTo 257.4,203.325
+lineTo 260.025,205.95
+lineTo 257.4,208.575
+lineTo 254.775,205.95
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 327.8,230.3875
-lineTo 330.425,233.0125
-lineTo 327.8,235.6375
-lineTo 325.175,233.0125
+moveTo 328.05,230.075
+lineTo 330.675,232.7
+lineTo 328.05,235.325
+lineTo 325.425,232.7
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 398.5333,176.7625
-lineTo 401.1583,179.3875
-lineTo 398.5333,182.0125
-lineTo 395.9083,179.3875
+moveTo 398.7,176.575
+lineTo 401.325,179.2
+lineTo 398.7,181.825
+lineTo 396.075,179.2
 closePath
 fill fs=#4472C4 ga=1
 restore
 save
 beginPath
-moveTo 469.2667,149.95
-lineTo 471.8917,152.575
-lineTo 469.2667,155.2
-lineTo 466.6417,152.575
+moveTo 469.35,149.825
+lineTo 471.975,152.45
+lineTo 469.35,155.075
+lineTo 466.725,152.45
 closePath
 fill fs=#4472C4 ga=1
 restore
@@ -1716,32 +1719,33 @@ set font=10.5px sans-serif
 set textBaseline=middle
 set lineWidth=1.575
 beginPath
-moveTo 576,204.2
-lineTo 592.8,204.2
+moveTo 576,203.95
+lineTo 592.8,203.95
 stroke ss=#4472C4 lw=1.575 dash=
 set lineWidth=1.5
 save
 beginPath
-moveTo 584.4,201.155
-lineTo 587.445,204.2
-lineTo 584.4,207.245
-lineTo 581.355,204.2
+moveTo 584.4,200.905
+lineTo 587.445,203.95
+lineTo 584.4,206.995
+lineTo 581.355,203.95
 closePath
 fill fs=#4472C4 ga=1
 restore
 set fillStyle=#333
 set textAlign=left
-fillText "S1" 596.8,204.2 fs=#333 font=10.5px sans-serif al=left bl=middle
+fillText "S1" 596.8,203.95 fs=#333 font=10.5px sans-serif al=left bl=middle
 save
-set font=bold 10px sans-serif
+set font=bold 10.5px sans-serif
 set fillStyle=#555
-translate 29.8,206.2
+translate 30.05,205.95
 rotate -1.5708
 set textAlign=center
-fillText "Y" 0,0 fs=#555 font=bold 10px sans-serif al=center bl=middle
+fillText "Y" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 save
-fillText "X" 327.8,367 fs=#555 font=bold 10px sans-serif al=center bl=middle
+translate 328.05,366.75
+fillText "X" 0,0 fs=#555 font=bold 10.5px sans-serif al=center bl=middle
 restore
 restore"
 `;

--- a/packages/core/src/chart/axis-title-defaults.test.ts
+++ b/packages/core/src/chart/axis-title-defaults.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import type { ChartModel, ChartRect, ChartSeries } from '../types/chart';
+import { renderChart } from './renderer.js';
+
+interface TextCall {
+  text: string;
+  font: string;
+  rotation: number;
+  translateX: number;
+  translateY: number;
+}
+
+function recordingContext(): { ctx: CanvasRenderingContext2D; texts: TextCall[] } {
+  const texts: TextCall[] = [];
+  const state: Record<string, unknown> = {
+    font: '10px sans-serif',
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    rotation: 0,
+    translateX: 0,
+    translateY: 0,
+  };
+  const stack: Array<{ rotation: number; translateX: number; translateY: number }> = [];
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop: string) {
+      if (prop in state && typeof state[prop] !== 'function') return state[prop];
+      switch (prop) {
+        case 'measureText':
+          return (text: string) => ({ width: String(text).length * 7 });
+        case 'fillText':
+          return (text: string) => texts.push({
+            text,
+            font: String(state.font),
+            rotation: Number(state.rotation),
+            translateX: Number(state.translateX),
+            translateY: Number(state.translateY),
+          });
+        case 'save':
+          return () => stack.push({
+            rotation: Number(state.rotation),
+            translateX: Number(state.translateX),
+            translateY: Number(state.translateY),
+          });
+        case 'restore':
+          return () => {
+            const restored = stack.pop();
+            state.rotation = restored?.rotation ?? 0;
+            state.translateX = restored?.translateX ?? 0;
+            state.translateY = restored?.translateY ?? 0;
+          };
+        case 'rotate':
+          return (angle: number) => { state.rotation = Number(state.rotation) + angle; };
+        case 'beginPath': case 'closePath': case 'fill': case 'stroke':
+        case 'moveTo': case 'lineTo': case 'arc': case 'rect': case 'clip':
+        case 'fillRect': case 'strokeRect': case 'clearRect': case 'strokeText':
+          return () => undefined;
+        case 'translate':
+          return (x: number, y: number) => {
+            state.translateX = Number(state.translateX) + x;
+            state.translateY = Number(state.translateY) + y;
+          };
+        case 'scale': case 'setLineDash': case 'setTransform':
+        case 'resetTransform':
+          return () => undefined;
+        default:
+          return undefined;
+      }
+    },
+    set(_target, prop: string, value) {
+      state[prop] = value;
+      return true;
+    },
+  };
+  return {
+    ctx: new Proxy(state, handler) as unknown as CanvasRenderingContext2D,
+    texts,
+  };
+}
+
+function series(overrides: Partial<ChartSeries> = {}): ChartSeries {
+  return { name: 'Series', color: null, values: [1, 2], ...overrides };
+}
+
+function model(overrides: Partial<ChartModel> = {}): ChartModel {
+  return {
+    chartType: 'clusteredBar',
+    title: null,
+    categories: ['A', 'B'],
+    series: [series()],
+    showDataLabels: false,
+    valMin: null,
+    valMax: null,
+    catAxisTitle: null,
+    valAxisTitle: null,
+    catAxisHidden: false,
+    valAxisHidden: false,
+    catAxisLineHidden: false,
+    valAxisLineHidden: false,
+    plotAreaBg: null,
+    chartBg: null,
+    showLegend: false,
+    legendPos: null,
+    catAxisCrossBetween: 'between',
+    valAxisMajorTickMark: 'out',
+    catAxisMajorTickMark: 'out',
+    titleFontSizeHpt: null,
+    titleFontColor: null,
+    titleFontFace: null,
+    catAxisFontSizeHpt: null,
+    valAxisFontSizeHpt: null,
+    dataLabelFontSizeHpt: null,
+    subtotalIndices: [],
+    ...overrides,
+  };
+}
+
+function titleCall(texts: TextCall[], text: string): TextCall {
+  const call = texts.find(candidate => candidate.text === text);
+  expect(call, `missing title ${text}`).toBeDefined();
+  return call as TextCall;
+}
+
+const WIDE: ChartRect = { x: 0, y: 0, w: 800, h: 260 };
+const TALL: ChartRect = { x: 0, y: 0, w: 260, h: 800 };
+
+describe('axis-title compatibility defaults', () => {
+  it('keeps omitted axis-title text at a fixed 10pt for wide and tall charts', () => {
+    for (const rect of [WIDE, TALL]) {
+      const { ctx, texts } = recordingContext();
+      renderChart(ctx, model({ valAxisTitle: 'Value' }), rect, 4 / 3);
+      expect(titleCall(texts, 'Value').font).toContain('13.333333333333332px');
+    }
+  });
+
+  it('uses side-aware defaults for left, right, and horizontal value axes', () => {
+    const primary = recordingContext();
+    renderChart(primary.ctx, model({ valAxisTitle: 'Left' }), WIDE, 1);
+    expect(titleCall(primary.texts, 'Left').rotation).toBeCloseTo(-Math.PI / 2);
+
+    const horizontal = recordingContext();
+    renderChart(horizontal.ctx, model({
+      chartType: 'clusteredBarH',
+      catAxisTitle: 'Categories',
+      valAxisTitle: 'Horizontal value',
+    }), WIDE, 1);
+    expect(titleCall(horizontal.texts, 'Categories').rotation).toBeCloseTo(-Math.PI / 2);
+    expect(titleCall(horizontal.texts, 'Horizontal value').rotation).toBeCloseTo(0);
+
+    const secondary = recordingContext();
+    renderChart(secondary.ctx, model({
+      series: [
+        series(),
+        series({ name: 'Secondary', values: [10, 20], seriesType: 'line', useSecondaryAxis: true }),
+      ],
+      secondaryValAxis: {
+        min: null,
+        max: null,
+        title: 'Right',
+        hidden: false,
+        lineHidden: false,
+        majorTickMark: 'out',
+      },
+    }), WIDE, 1);
+    expect(titleCall(secondary.texts, 'Right').rotation).toBeCloseTo(Math.PI / 2);
+  });
+
+  it('keeps authored size/orientation and theme face authoritative', () => {
+    const { ctx, texts } = recordingContext();
+    renderChart(ctx, model({
+      valAxisTitle: 'Authored',
+      valAxisTitleFontSizeHpt: 1200,
+      valAxisTitleRotation: 1_800_000,
+      valAxisTitleManualLayout: {
+        xMode: 'edge', yMode: 'edge', x: 0.2, y: 0.1,
+      },
+      themeMajorFontLatin: 'Aptos Display',
+      plotAreaManualLayout: {
+        xMode: 'edge', yMode: 'edge', x: 0.2, y: 0.1, w: 0.6, h: 0.7,
+      },
+    }), WIDE, 1);
+    const call = titleCall(texts, 'Authored');
+    expect(call.font).toContain('12px');
+    expect(call.font).toContain('Aptos Display');
+    expect(call.rotation).toBeCloseTo(Math.PI / 6);
+    expect(call.translateX).toBeCloseTo(188);
+    expect(call.translateY).toBeCloseTo(32);
+  });
+
+  it('keeps authored rot and vertical mode independent at paint time', () => {
+    const { ctx, texts } = recordingContext();
+    renderChart(ctx, model({
+      valAxisTitle: 'Combined',
+      valAxisTitleRotation: 1_800_000,
+      valAxisTitleVerticalMode: 'vert270',
+    }), WIDE, 1);
+    expect(titleCall(texts, 'Combined').rotation).toBeCloseTo(-Math.PI / 3);
+  });
+});

--- a/packages/core/src/chart/layout.test.ts
+++ b/packages/core/src/chart/layout.test.ts
@@ -13,11 +13,29 @@ import {
   chartLegendReserve,
   chartLegendBands,
   chartAxisTitleBands,
+  axisTitleFontPx,
+  axisTitleRotationRad,
   chartTitleFontPx,
   resolveManualLayoutRect,
   TITLE_TOP_PAD_FONT_FRAC,
   type FrameParams,
 } from './layout.js';
+
+describe('axis-title authored properties', () => {
+  it('uses the fixed fallback for non-finite and out-of-schema font sizes', () => {
+    for (const size of [Number.NEGATIVE_INFINITY, -100, 0, 99, 400_001, Number.POSITIVE_INFINITY, Number.NaN]) {
+      expect(axisTitleFontPx(size, 4 / 3)).toBeCloseTo(40 / 3);
+    }
+    expect(axisTitleFontPx(100, 4 / 3)).toBeCloseTo(4 / 3);
+    expect(axisTitleFontPx(400_000, 1)).toBe(4000);
+  });
+
+  it('composes rot with explicit rigid and non-rigid vertical modes', () => {
+    expect(axisTitleRotationRad('left', 1_800_000, 'vert270')).toBeCloseTo(-Math.PI / 3);
+    expect(axisTitleRotationRad('left', null, 'eaVert')).toBeCloseTo(Math.PI / 2);
+    expect(axisTitleRotationRad('right', null, 'horz')).toBe(0);
+  });
+});
 
 describe('resolveManualLayoutRect', () => {
   const chart = { x: 10, y: 20, w: 400, h: 200 };
@@ -210,16 +228,16 @@ describe('chartLegendReserve + bands', () => {
 describe('chartAxisTitleBands', () => {
   it('is zero on both sides without titles', () => {
     expect(chartAxisTitleBands(model({}), W, H, PTPX)).toEqual({
-      catFontPx: Math.max(8, Math.min(10, H * 0.045)),
-      valFontPx: Math.max(8, Math.min(10, H * 0.045)),
+      catFontPx: 10 * PTPX,
+      valFontPx: 10 * PTPX,
       catBandH: 0,
       valBandW: 0,
     });
   });
   it('reserves fontPx + margin + 4 on the titled side', () => {
     const b = chartAxisTitleBands(model({ catAxisTitle: 'C', valAxisTitle: 'V' }), W, H, PTPX);
-    const catF = Math.max(8, Math.min(10, H * 0.045));
-    const valF = Math.max(8, Math.min(10, H * 0.045));
+    const catF = 10 * PTPX;
+    const valF = 10 * PTPX;
     expect(b.catBandH).toBe(catF + Math.max(8, H * 0.02) + 4);
     expect(b.valBandW).toBe(valF + Math.max(8, W * 0.02) + 4);
   });

--- a/packages/core/src/chart/layout.ts
+++ b/packages/core/src/chart/layout.ts
@@ -250,14 +250,76 @@ export function chartLegendBands(leg: ChartLegendReserve | null): ChartLegendBan
 
 // ─── Axis-title bands ────────────────────────────────────────────────────────
 
-/** Axis-title font size (px). Verbatim from renderer.ts `axisTitleFontPx`. */
+/** Product fallback for an axis title whose run/style omits `a:rPr@sz`.
+ *  OOXML does not define application auto-layout text metrics; the fixed 10pt
+ *  value is the intentionally small compatibility policy recorded in #1228. */
+export const AXIS_TITLE_FALLBACK_PT = 10;
+
+/** Axis-title font size (px). Authored/style size is authoritative; omission
+ *  is fixed at 10pt and therefore invariant across chart dimensions. */
 export function axisTitleFontPx(
   sizeHpt: number | null | undefined,
-  h: number,
   ptToPx: number,
 ): number {
-  if (sizeHpt) return (sizeHpt / 100) * ptToPx;
-  return Math.max(8, Math.min(10, h * 0.045));
+  // ST_TextFontSize is 100..400000 hundredths of a point. Keep non-conforming
+  // parser output and direct public-model inputs from creating negative or
+  // unbounded layout bands; invalid values use the same product fallback as
+  // omission. `ptToPx` is a host scale and is validated by the host renderer.
+  if (
+    typeof sizeHpt === 'number' &&
+    Number.isFinite(sizeHpt) &&
+    sizeHpt >= 100 &&
+    sizeHpt <= 400_000
+  ) {
+    return (sizeHpt / 100) * ptToPx;
+  }
+  return AXIS_TITLE_FALLBACK_PT * ptToPx;
+}
+
+export type ChartAxisTitleSide = 'left' | 'right' | 'horizontal';
+
+/** Resolve the title's paint rotation. DrawingML `ST_Angle` is expressed in
+ *  60000ths of a degree; any explicit `bodyPr@rot`/`bodyPr@vert` value has
+ *  priority. With no authoring, left reads bottom-to-top, right top-to-bottom,
+ *  and a top/bottom value axis stays horizontal. */
+export function axisTitleRotationRad(
+  side: ChartAxisTitleSide,
+  authoredRotation: number | null | undefined,
+  authoredVerticalMode?: ChartModel['catAxisTitleVerticalMode'],
+): number {
+  let authoredDegrees = 0;
+  let hasAuthoredOrientation = false;
+  if (authoredVerticalMode != null) {
+    hasAuthoredOrientation = true;
+    // Canvas cannot reproduce East-Asian upright-glyph or WordArt stacking in
+    // this single-line chart-title painter. Preserve those modes in the model
+    // and approximate their vertical flow explicitly instead of silently
+    // treating them as horizontal or applying the automatic side fallback.
+    switch (authoredVerticalMode) {
+      case 'horz':
+        break;
+      case 'vert270':
+        authoredDegrees -= 90;
+        break;
+      case 'vert':
+      case 'wordArtVert':
+      case 'eaVert':
+      case 'mongolianVert':
+      case 'wordArtVertRtl':
+        authoredDegrees += 90;
+        break;
+    }
+  }
+  if (authoredRotation != null && Number.isFinite(authoredRotation)) {
+    authoredDegrees += authoredRotation / 60_000;
+    hasAuthoredOrientation = true;
+  }
+  if (hasAuthoredOrientation) {
+    return authoredDegrees * Math.PI / 180;
+  }
+  if (side === 'left') return -Math.PI / 2;
+  if (side === 'right') return Math.PI / 2;
+  return 0;
 }
 
 /** Margin (px) between the chart's outer edge and an axis title. Verbatim from
@@ -275,8 +337,8 @@ export function chartAxisTitleBands(
   h: number,
   ptToPx: number,
 ): ChartAxisTitleBands {
-  const catFontPx = axisTitleFontPx(chart.catAxisTitleFontSizeHpt, h, ptToPx);
-  const valFontPx = axisTitleFontPx(chart.valAxisTitleFontSizeHpt, h, ptToPx);
+  const catFontPx = axisTitleFontPx(chart.catAxisTitleFontSizeHpt, ptToPx);
+  const valFontPx = axisTitleFontPx(chart.valAxisTitleFontSizeHpt, ptToPx);
   return {
     catFontPx,
     valFontPx,

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -2448,7 +2448,7 @@ describe('CH7 — line/area series honor a secondary value axis (§21.2.2.*)', (
     });
   }
 
-  it('paints the right-axis title bottom-to-top with its authored font', () => {
+  it('paints the right-axis title top-to-bottom with its authored font', () => {
     const rec = ringRecordingCtx();
     const model = comboModel('line', true);
     model.secondaryValAxis = {
@@ -2460,7 +2460,7 @@ describe('CH7 — line/area series honor a secondary value axis (§21.2.2.*)', (
     };
     renderChart(rec.ctx, model, RECT, 1);
 
-    expect(rec.rotates).toContain(-Math.PI / 2);
+    expect(rec.rotates).toContain(Math.PI / 2);
     const title = rec.fontTexts.find(text => text.text === 'Rate');
     expect(title?.font).toContain('9px');
     expect(title?.font).toContain('Aptos Narrow');

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -3,7 +3,7 @@
 // scatter, waterfall). Ported from the xlsx implementation with pptx
 // extensions (valMin-aware axis, plotAreaBg, dataPointColors, waterfall).
 
-import type { ChartDataLabelOverride, ChartModel, ChartRect, ChartSeries, ChartSeriesDataLabels, ChartTextBox, ChartTrendline, SecondaryValueAxis } from '../types/chart';
+import type { ChartDataLabelOverride, ChartManualLayout, ChartModel, ChartRect, ChartSeries, ChartSeriesDataLabels, ChartTextBox, ChartTrendline, SecondaryValueAxis } from '../types/chart';
 import type { Fill } from '../types/common';
 import {
   AXIS_OUTER_TEXT_MARGIN_PT,
@@ -14,12 +14,15 @@ import {
   chartLegendBands,
   packLegendRows,
   chartAxisTitleBands,
+  axisTitleFontPx,
+  axisTitleRotationRad,
   chartManualOuterAxisInsets,
   categoryTickLabelGapPx,
   axisTitleMargin,
   resolveManualLayoutRect,
   valueTickLabelGapPx,
   type ChartLegendReserve,
+  type ChartAxisTitleSide,
 } from './layout.js';
 import {
   axisLengthNiceStep,
@@ -165,16 +168,14 @@ export function legendEntryColor(
   return chartColor(entryIndex, series[entryIndex]);
 }
 
-/** Draw an axis title at an explicit anchor in the outer gutter band (outside
- *  the tick labels), at its real font size/bold/color. The cat title is
- *  centered under the X axis; the val title is rotated -90° centered to the
- *  left of the Y axis. `anchorX`/`anchorY` are the band center the caller
- *  reserved via catTitleH/valTitleW, so the title never overlaps tick labels. */
+/** Draw an axis title at an explicit anchor in the outer gutter band. The
+ *  side-based compatibility rotation is resolved in one place, with authored
+ *  DrawingML body orientation remaining authoritative. */
 function drawAxisTitle(
   ctx: CanvasRenderingContext2D,
   text: string,
   anchorX: number, anchorY: number,
-  axis: 'cat' | 'val',
+  side: ChartAxisTitleSide,
   fontSizePx: number,
   bold: boolean,
   color: string,
@@ -184,20 +185,46 @@ function drawAxisTitle(
   maxPx: number,
   // Resolved CSS font-family (element face ?? theme heading ?? sans-serif).
   fontFamily = 'sans-serif',
+  authoredRotation?: number | null,
+  authoredVerticalMode?: ChartModel['catAxisTitleVerticalMode'],
+  manualLayout?: ChartManualLayout | null,
+  chartRect?: ChartRect,
 ): void {
   ctx.save();
   ctx.font = `${bold ? 'bold ' : ''}${fontSizePx}px ${fontFamily}`;
   ctx.fillStyle = color;
-  const label = elideToWidth(ctx, text, maxPx);
-  if (axis === 'cat') {
-    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-    ctx.fillText(label, anchorX, anchorY);
-  } else {
-    ctx.translate(anchorX, anchorY);
-    ctx.rotate(-Math.PI / 2);
-    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-    ctx.fillText(label, 0, 0);
+  // Automatic titles stay bounded to the axis run. An authored title layout
+  // is authoritative and keeps its complete text rather than being elided by
+  // the automatic plot-width estimate.
+  const label = manualLayout ? text : elideToWidth(ctx, text, maxPx);
+  let resolvedAnchorX = anchorX;
+  let resolvedAnchorY = anchorY;
+  if (manualLayout && chartRect) {
+    const textWidth = ctx.measureText(label).width;
+    const automatic = {
+      x: anchorX - textWidth / 2,
+      y: anchorY - fontSizePx / 2,
+      w: textWidth,
+      h: fontSizePx,
+    };
+    // CT_Title manual layout positions the title box, while Office keeps the
+    // box fitted to its text. Match the existing chart-title rule: x/y win,
+    // authored w/h do not stretch or shrink the text box.
+    const resolved = resolveManualLayoutRect(
+      { ...manualLayout, w: undefined, h: undefined },
+      chartRect,
+      automatic,
+    );
+    if (resolved) {
+      resolvedAnchorX = resolved.x + resolved.w / 2;
+      resolvedAnchorY = resolved.y + resolved.h / 2;
+    }
   }
+  ctx.translate(resolvedAnchorX, resolvedAnchorY);
+  const rotation = axisTitleRotationRad(side, authoredRotation, authoredVerticalMode);
+  if (rotation !== 0) ctx.rotate(rotation);
+  ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+  ctx.fillText(label, 0, 0);
   ctx.restore();
 }
 
@@ -211,13 +238,14 @@ function axisTitleColor(hex: string | null | undefined): string {
  *  anchored in the reserved outer gutter bands so they sit OUTSIDE the tick
  *  labels. `catTitlePx`/`valTitlePx` are the title font sizes the caller used
  *  to size `catTitleH`/`valTitleW`; the anchor centers each title within its
- *  band. cat axis = bottom, val axis = left — the orientation each cartesian
- *  renderer already uses (horizontal bar keeps cat-bottom/val-left too).
+ *  band. Column/line/area/scatter use cat-bottom + val-left. Horizontal bars
+ *  use cat-left + val-bottom because their value axis runs horizontally.
  *  Axis titles default to BOLD — ECMA-376 Part 1 (ST_Style, chart-style
  *  defaults) states "Axis titles and chart titles are bold by default, while
- *  all other chart elements are normal" (same clause sets the default size to
- *  10pt). So an unspecified weight renders bold; only an explicit `b="0"`
- *  un-bolds. Consistent with drawChartTitle, which applies the same default. */
+ *  all other chart elements are normal". So an unspecified weight renders
+ *  bold; only an explicit `b="0"` un-bolds. The separate 10pt size fallback
+ *  is the product compatibility policy in #1228, not a normative OOXML size.
+ *  This remains consistent with drawChartTitle's bold resolution. */
 function drawAxisTitles(
   ctx: CanvasRenderingContext2D,
   chart: ChartModel,
@@ -225,25 +253,53 @@ function drawAxisTitles(
   px0: number, py0: number, pw: number, ph: number,
   legLeftW: number, legBottomH: number,
   catTitlePx: number, valTitlePx: number,
+  horizontalValueAxis = false,
 ): void {
-  if (chart.valAxisTitle) {
-    const anchorX = x + legLeftW + axisTitleMargin(w) + valTitlePx / 2;
-    const anchorY = py0 + ph / 2;
-    // The val title is rotated -90°, so it runs along the plot HEIGHT.
+  const drawPrimaryTitle = (
+    text: string,
+    side: ChartAxisTitleSide,
+    fontSizePx: number,
+    bold: boolean,
+    color: string,
+    fontFamily: string,
+    authoredRotation: number | null | undefined,
+    authoredVerticalMode: ChartModel['catAxisTitleVerticalMode'],
+    manualLayout: ChartManualLayout | null | undefined,
+  ): void => {
+    if (side === 'left') {
+      drawAxisTitle(
+        ctx, text,
+        x + legLeftW + axisTitleMargin(w) + fontSizePx / 2,
+        py0 + ph / 2,
+        side, fontSizePx, bold, color, ph, fontFamily, authoredRotation,
+        authoredVerticalMode, manualLayout, { x, y, w, h },
+      );
+      return;
+    }
     drawAxisTitle(
-      ctx, chart.valAxisTitle, anchorX, anchorY, 'val',
+      ctx, text,
+      px0 + pw / 2,
+      y + h - legBottomH - axisTitleMargin(h) - fontSizePx / 2,
+      side, fontSizePx, bold, color, pw, fontFamily, authoredRotation,
+      authoredVerticalMode, manualLayout, { x, y, w, h },
+    );
+  };
+  if (chart.valAxisTitle) {
+    drawPrimaryTitle(
+      chart.valAxisTitle, horizontalValueAxis ? 'horizontal' : 'left',
       valTitlePx, chart.valAxisTitleFontBold ?? true, axisTitleColor(chart.valAxisTitleFontColor),
-      ph, chartFontFamily(chart, chart.valAxisTitleFontFace, 'major'),
+      chartFontFamily(chart, chart.valAxisTitleFontFace, 'major'), chart.valAxisTitleRotation,
+      chart.valAxisTitleVerticalMode,
+      chart.valAxisTitleManualLayout,
     );
   }
   if (chart.catAxisTitle) {
-    const anchorX = px0 + pw / 2;
-    const anchorY = y + h - legBottomH - axisTitleMargin(h) - catTitlePx / 2;
-    // The cat title runs horizontally along the plot WIDTH.
-    drawAxisTitle(
-      ctx, chart.catAxisTitle, anchorX, anchorY, 'cat',
+    drawPrimaryTitle(
+      chart.catAxisTitle, horizontalValueAxis ? 'left' : 'horizontal',
       catTitlePx, chart.catAxisTitleFontBold ?? true, axisTitleColor(chart.catAxisTitleFontColor),
-      pw, chartFontFamily(chart, chart.catAxisTitleFontFace, 'major'),
+      chartFontFamily(chart, chart.catAxisTitleFontFace, 'major'), chart.catAxisTitleRotation,
+      chart.catAxisTitleVerticalMode,
+      chart.catAxisTitleManualLayout,
     );
   }
 }
@@ -1441,8 +1497,9 @@ function computeSecondaryAxis(
  *  tick marks + labels, and rotated title. Its scale is INDEPENDENT of the
  *  primary axis (its own "nice" major unit; NOT aligned to the primary
  *  gridlines) — PowerPoint places these marks independently. Shared by the
- *  line and area families; the bar renderer keeps its own inline copy for now
- *  (its call sequence is byte-identical to this helper). Callers pass:
+ *  line and area families; the bar renderer keeps its rule/tick loop inline,
+ *  while all families share the title painter and its compatibility defaults.
+ *  Callers pass:
  *  - `secScale`   the resolved scale (from {@link computeSecondaryAxis}),
  *  - `toYSecondary` the value→pixel map (`secScale.makeToY(py0, ph)`),
  *  - `secFontPx` / `secLabelBandW` the tick-label font size + reserved gutter
@@ -1455,8 +1512,8 @@ function drawSecondaryValueAxis(
   sec: SecondaryValueAxis,
   secScale: SecondaryAxisScale,
   toYSecondary: (v: number) => number,
+  chartRect: ChartRect,
   px0: number, py0: number, pw: number, ph: number,
-  h: number,
   ptToPx: number,
   secFontPx: number,
   secLabelBandW: number,
@@ -1493,22 +1550,45 @@ function drawSecondaryValueAxis(
     }
   }
   if (sec.title) {
-    const tFontPx = sec.titleFontSizeHpt ? (sec.titleFontSizeHpt / 100) * ptToPx : Math.max(9, h * 0.05);
-    ctx.save();
-    ctx.fillStyle = sec.titleFontColor
-      ? `#${sec.titleFontColor}`
-      : (sec.fontColor ? `#${sec.fontColor}` : '#555');
-    const titleFamily = chartFontFamily(chart, sec.titleFontFace, 'major');
-    ctx.font = `${sec.titleFontBold ? 'bold ' : ''}${tFontPx}px ${titleFamily}`;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    // Excel keeps both value-axis titles in the same bottom-to-top reading
-    // direction. Mirroring the right-axis placement must not mirror its text.
-    ctx.translate(px0 + pw + secLabelBandW + tFontPx * 0.6, py0 + ph / 2);
-    ctx.rotate(-Math.PI / 2);
-    ctx.fillText(sec.title, 0, 0);
-    ctx.restore();
+    drawSecondaryAxisTitle(
+      ctx, chart, sec, chartRect, px0, py0, pw, ph, secLabelBandW, ptToPx,
+    );
   }
+}
+
+/** Draw a right-side secondary value-axis title. Both the duplicated combo-bar
+ *  path and the shared line/area path use this helper, so the fixed 10pt
+ *  fallback and +90° reading direction cannot drift. */
+function drawSecondaryAxisTitle(
+  ctx: CanvasRenderingContext2D,
+  chart: ChartModel,
+  sec: SecondaryValueAxis,
+  chartRect: ChartRect,
+  px0: number, py0: number, pw: number, ph: number,
+  secLabelBandW: number,
+  ptToPx: number,
+): void {
+  if (!sec.title) return;
+  const fontSizePx = axisTitleFontPx(sec.titleFontSizeHpt, ptToPx);
+  const color = sec.titleFontColor
+    ? `#${sec.titleFontColor}`
+    : (sec.fontColor ? `#${sec.fontColor}` : '#555');
+  drawAxisTitle(
+    ctx,
+    sec.title,
+    px0 + pw + secLabelBandW + fontSizePx * 0.6,
+    py0 + ph / 2,
+    'right',
+    fontSizePx,
+    sec.titleFontBold ?? true,
+    color,
+    ph,
+    chartFontFamily(chart, sec.titleFontFace, 'major'),
+    sec.titleRotation,
+    sec.titleVerticalMode,
+    sec.titleManualLayout,
+    chartRect,
+  );
 }
 
 function drawChartTitle(
@@ -1766,8 +1846,14 @@ function renderBarChart(
   const axBands = chartAxisTitleBands(chart, w, h, ptToPx);
   const catTitlePx = axBands.catFontPx;
   const valTitlePx = axBands.valFontPx;
-  const catTitleH = axBands.catBandH;
-  const valTitleW = axBands.valBandW;
+  // Horizontal bars swap semantic axes: category title belongs in the left
+  // band, while the horizontal value-axis title belongs in the bottom band.
+  const catTitleH = isH
+    ? (chart.valAxisTitle ? valTitlePx + axisTitleMargin(h) + 4 : 0)
+    : axBands.catBandH;
+  const valTitleW = isH
+    ? (chart.catAxisTitle ? catTitlePx + axisTitleMargin(w) + 4 : 0)
+    : axBands.valBandW;
   // Value-axis scales are computed up-front (before `pad`) so the side gutters
   // can be sized to the actual tick-label widths instead of a fixed fraction of
   // the chart width — short numeric labels otherwise leave a big empty gap
@@ -1943,7 +2029,7 @@ function renderBarChart(
   }
   ctx.font = prevFont;
   const secTitleBandW = sec && sec.title
-    ? (sec.titleFontSizeHpt ? (sec.titleFontSizeHpt / 100) * ptToPx : Math.max(9, h * 0.05)) + 8
+    ? axisTitleFontPx(sec.titleFontSizeHpt, ptToPx) + 8
     : 0;
 
   const pad = {
@@ -2670,19 +2756,7 @@ function renderBarChart(
       }
     }
     if (sec.title) {
-      const tFontPx = sec.titleFontSizeHpt ? (sec.titleFontSizeHpt / 100) * ptToPx : Math.max(9, h * 0.05);
-      ctx.save();
-      ctx.fillStyle = sec.titleFontColor
-        ? `#${sec.titleFontColor}`
-        : (sec.fontColor ? `#${sec.fontColor}` : '#555');
-      ctx.font = `${sec.titleFontBold ? 'bold ' : ''}${tFontPx}px ${chartFontFamily(chart, sec.titleFontFace, 'major')}`;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      // Match the primary value-axis reading direction (bottom-to-top).
-      ctx.translate(px0 + pw + secLabelBandW + tFontPx * 0.6, py0 + ph / 2);
-      ctx.rotate(-Math.PI / 2);
-      ctx.fillText(sec.title, 0, 0);
-      ctx.restore();
+      drawSecondaryAxisTitle(ctx, chart, sec, r, px0, py0, pw, ph, secLabelBandW, ptToPx);
     }
   }
 
@@ -2695,7 +2769,10 @@ function renderBarChart(
     ctx, legendChart, leg, x, y, w, h, px0, py0, pw, ph,
     titleH + 2, ptToPx, legendPaints,
   );
-  drawAxisTitles(ctx, chart, x, y, w, h, px0, py0, pw, ph, legLeftW, legBottomH, catTitlePx, valTitlePx);
+  drawAxisTitles(
+    ctx, chart, x, y, w, h, px0, py0, pw, ph,
+    legLeftW, legBottomH, catTitlePx, valTitlePx, isH,
+  );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -2835,7 +2912,7 @@ function renderLineChart(
     ctx.font = prevFont;
   }
   const secTitleBandW = sec && sec.title
-    ? (sec.titleFontSizeHpt ? (sec.titleFontSizeHpt / 100) * ptToPx : Math.max(9, h * 0.05)) + 8
+    ? axisTitleFontPx(sec.titleFontSizeHpt, ptToPx) + 8
     : 0;
 
   const provisionalPlan = planValueAxis(chart, dataMin, dataMax, phEst / ptToPx, pct);
@@ -3143,7 +3220,7 @@ function renderLineChart(
   if (sec && secScale) {
     const primaryLabelColor = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
     drawSecondaryValueAxis(
-      ctx, chart, sec, secScale, toYSecondary, px0, py0, pw, ph, h, ptToPx,
+      ctx, chart, sec, secScale, toYSecondary, r, px0, py0, pw, ph, ptToPx,
       secFontPx, secLabelBandW, primaryLabelColor, chart.date1904,
     );
   }
@@ -3485,7 +3562,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     ctx.font = prevFont;
   }
   const secTitleBandW = sec && sec.title
-    ? (sec.titleFontSizeHpt ? (sec.titleFontSizeHpt / 100) * ptToPx : Math.max(9, h * 0.05)) + 8
+    ? axisTitleFontPx(sec.titleFontSizeHpt, ptToPx) + 8
     : 0;
 
   // Resolve the primary extent before frame placement so an authored
@@ -3946,7 +4023,7 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
   if (sec && secScale) {
     const primaryLabelColor = chart.valAxisFontColor ? `#${chart.valAxisFontColor}` : '#555';
     drawSecondaryValueAxis(
-      ctx, chart, sec, secScale, toYSecondary, px0, py0, pw, ph, h, ptToPx,
+      ctx, chart, sec, secScale, toYSecondary, r, px0, py0, pw, ph, ptToPx,
       secFontPx, secLabelBandW, primaryLabelColor, chart.date1904,
     );
   }

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -514,12 +514,43 @@ export interface ChartModel {
   catAxisTitleFontBold?: boolean | null;
   /** `<c:catAx><c:title>` run-prop color (hex without '#'). null = default. */
   catAxisTitleFontColor?: string | null;
+  /** Authored `<c:catAx><c:title>` DrawingML `bodyPr@rot` in raw `ST_Angle`
+   *  units (60000ths of a degree). Applied independently from `vert`. */
+  catAxisTitleRotation?: number | null;
+  /** Authored DrawingML `bodyPr@vert`. Omission uses the side-based product
+   *  fallback; explicit modes remain distinguishable from horizontal text. */
+  catAxisTitleVerticalMode?:
+    | 'horz'
+    | 'vert'
+    | 'vert270'
+    | 'wordArtVert'
+    | 'eaVert'
+    | 'mongolianVert'
+    | 'wordArtVertRtl'
+    | null;
+  /** `<c:catAx><c:title><c:layout><c:manualLayout>`. */
+  catAxisTitleManualLayout?: ChartManualLayout | null;
   /** `<c:valAx><c:title>` run-prop font size (hpt). null = renderer default. */
   valAxisTitleFontSizeHpt?: number | null;
   /** `<c:valAx><c:title>` run-prop bold flag. null = not bold. */
   valAxisTitleFontBold?: boolean | null;
   /** `<c:valAx><c:title>` run-prop color (hex without '#'). null = default. */
   valAxisTitleFontColor?: string | null;
+  /** Authored `<c:valAx><c:title>` DrawingML `bodyPr@rot` in raw `ST_Angle`
+   *  units (60000ths of a degree). */
+  valAxisTitleRotation?: number | null;
+  /** Authored DrawingML `bodyPr@vert`. */
+  valAxisTitleVerticalMode?:
+    | 'horz'
+    | 'vert'
+    | 'vert270'
+    | 'wordArtVert'
+    | 'eaVert'
+    | 'mongolianVert'
+    | 'wordArtVertRtl'
+    | null;
+  /** `<c:valAx><c:title><c:layout><c:manualLayout>`. */
+  valAxisTitleManualLayout?: ChartManualLayout | null;
   // ── Chart text font faces (CH10) ─────────────────────────────────────────
   // Each is the `<a:latin typeface>` (ECMA-376 §20.1.4.2.24) resolved from the
   // element's `<c:txPr>`. When absent the renderer falls back to the theme
@@ -1027,6 +1058,20 @@ export interface SecondaryValueAxis {
   /** `<c:title>` run-prop color (hex without '#'). */
   titleFontColor?: string | null;
   titleFontFace?: string | null;
+  /** Authored `<c:title>` DrawingML `bodyPr@rot` in raw `ST_Angle` units. */
+  titleRotation?: number | null;
+  /** Authored `<c:title>` DrawingML `bodyPr@vert`. */
+  titleVerticalMode?:
+    | 'horz'
+    | 'vert'
+    | 'vert270'
+    | 'wordArtVert'
+    | 'eaVert'
+    | 'mongolianVert'
+    | 'wordArtVertRtl'
+    | null;
+  /** `<c:title><c:layout><c:manualLayout>` for this auxiliary axis. */
+  titleManualLayout?: ChartManualLayout | null;
 }
 
 /**

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -211,9 +211,15 @@ export interface ChartModel {
     catAxisTitleFontSizeHpt?: number | null;
     catAxisTitleFontBold?: boolean | null;
     catAxisTitleFontColor?: string | null;
+    catAxisTitleRotation?: number | null;
+    catAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
+    catAxisTitleManualLayout?: ChartManualLayout | null;
     valAxisTitleFontSizeHpt?: number | null;
     valAxisTitleFontBold?: boolean | null;
     valAxisTitleFontColor?: string | null;
+    valAxisTitleRotation?: number | null;
+    valAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
+    valAxisTitleManualLayout?: ChartManualLayout | null;
     catAxisFontFace?: string | null;
     valAxisFontFace?: string | null;
     catAxisTitleFontFace?: string | null;
@@ -1338,6 +1344,9 @@ export interface SecondaryValueAxis {
     titleFontBold?: boolean | null;
     titleFontColor?: string | null;
     titleFontFace?: string | null;
+    titleRotation?: number | null;
+    titleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
+    titleManualLayout?: ChartManualLayout | null;
 }
 export interface SectionGeom {
     pageWidth: number;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -233,12 +233,28 @@ pub struct ChartModel {
     pub cat_axis_title_font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cat_axis_title_font_color: Option<String>,
+    /// Authored `<c:catAx><c:title>` `bodyPr@rot` in raw `ST_Angle` units.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_title_rotation: Option<i32>,
+    /// Authored `<c:catAx><c:title>` `bodyPr@vert` mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_title_vertical_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cat_axis_title_manual_layout: Option<ChartManualLayout>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_title_font_size_hpt: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_title_font_bold: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub val_axis_title_font_color: Option<String>,
+    /// Authored `<c:valAx><c:title>` `bodyPr@rot` in raw `ST_Angle` units.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_title_rotation: Option<i32>,
+    /// Authored `<c:valAx><c:title>` `bodyPr@vert` mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_title_vertical_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub val_axis_title_manual_layout: Option<ChartManualLayout>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chart_border_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -934,6 +950,12 @@ pub struct SecondaryValueAxis {
     pub title_font_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_font_face: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title_rotation: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title_vertical_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title_manual_layout: Option<ChartManualLayout>,
 }
 
 /// One box-and-whisker series (chartEx `boxWhisker`, MS 2014 chartex ext).
@@ -1800,6 +1822,48 @@ pub fn extract_chart_title_text(node: Node) -> Option<String> {
     }
 }
 
+fn parse_text_font_size_hpt(value: &str) -> Option<i32> {
+    value
+        .parse::<i32>()
+        .ok()
+        .filter(|size| (100..=400_000).contains(size))
+}
+
+/// Title text-property nodes in DrawingML cascade order. The rich text body is
+/// direct authoring and precedes title-level `txPr`; within each scope an
+/// explicit run property precedes its default run property.
+fn title_text_property_nodes<'a, 'input>(title: Node<'a, 'input>) -> Vec<Node<'a, 'input>> {
+    let rich = child(title, "tx").and_then(|tx| child(tx, "rich"));
+    let tx_pr = child(title, "txPr");
+    let mut nodes = Vec::new();
+    for (scope, wanted) in [
+        (rich, "rPr"),
+        (rich, "defRPr"),
+        (tx_pr, "rPr"),
+        (tx_pr, "defRPr"),
+    ] {
+        if let Some(scope) = scope {
+            nodes.extend(
+                scope
+                    .descendants()
+                    .filter(|node| node.is_element() && node.tag_name().name() == wanted),
+            );
+        }
+    }
+    // Preserve compatibility with simplified producers/tests that place the
+    // DrawingML paragraph directly under `<c:title>` without the CT_Tx wrapper.
+    if nodes.is_empty() {
+        for wanted in ["rPr", "defRPr"] {
+            nodes.extend(
+                title
+                    .descendants()
+                    .filter(|node| node.is_element() && node.tag_name().name() == wanted),
+            );
+        }
+    }
+    nodes
+}
+
 /// First `<a:defRPr@sz>` / `<a:rPr@sz>` (hundredths of a point) inside `node`'s
 /// direct-child `<c:title>`. `None` when absent.
 pub fn extract_chart_title_size(node: Node) -> Option<i32> {
@@ -1954,12 +2018,50 @@ pub fn extract_chart_title_color(node: Node, resolver: &dyn ColorResolver) -> Op
     })
 }
 
-/// Axis title text + run props from a `<c:catAx>` / `<c:valAx>` node. Reuses
-/// the chart-title helpers (which scope to the node's direct-child `<c:title>`);
-/// run props are resolved only when title text is present, so an axis with no
-/// title yields all `None`. Returns `(text, size_hpt, bold, srgb_color)`.
+fn extract_axis_title_size(axis_node: Node) -> Option<i32> {
+    let title = child(axis_node, "title")?;
+    title_text_property_nodes(title)
+        .into_iter()
+        .find_map(|props| props.attribute("sz").and_then(parse_text_font_size_hpt))
+}
+
+fn extract_axis_title_bold(axis_node: Node) -> Option<bool> {
+    let title = child(axis_node, "title")?;
+    title_text_property_nodes(title)
+        .into_iter()
+        .find_map(|props| {
+            props
+                .attribute("b")
+                .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        })
+}
+
+fn extract_axis_title_srgb(axis_node: Node) -> Option<String> {
+    let title = child(axis_node, "title")?;
+    title_text_property_nodes(title)
+        .into_iter()
+        .find_map(|props| {
+            child(props, "solidFill")
+                .and_then(|fill| child(fill, "srgbClr"))
+                .and_then(|color| color.attribute("val"))
+                .map(ToOwned::to_owned)
+        })
+}
+
+fn extract_axis_title_color(axis_node: Node, resolver: &dyn ColorResolver) -> Option<String> {
+    let title = child(axis_node, "title")?;
+    title_text_property_nodes(title)
+        .into_iter()
+        .find_map(|props| {
+            child(props, "solidFill").and_then(|fill| resolver.resolve_solid_fill(fill))
+        })
+}
+
+/// Axis title text + run props from a `<c:catAx>` / `<c:valAx>` node. Rich
+/// `rPr` wins over rich `defRPr`, then title-level `txPr`, independently for
+/// each property. Run props are resolved only when title text is present.
 ///
-/// NOTE: the color here is srgb-only (via [`extract_chart_title_srgb`]). Prefer
+/// NOTE: the color here is srgb-only. Prefer
 /// [`extract_axis_title_with_props_resolved`] when a `ColorResolver` is in hand
 /// so a `<a:schemeClr>` axis-title color resolves too; this srgb-only variant is
 /// kept for callers without a resolver.
@@ -1970,9 +2072,9 @@ pub fn extract_axis_title_with_props(
         None => (None, None, None, None),
         Some(text) => (
             Some(text),
-            extract_chart_title_size(axis_node),
-            extract_chart_title_bold(axis_node),
-            extract_chart_title_srgb(axis_node),
+            extract_axis_title_size(axis_node),
+            extract_axis_title_bold(axis_node),
+            extract_axis_title_srgb(axis_node),
         ),
     }
 }
@@ -1989,11 +2091,75 @@ pub fn extract_axis_title_with_props_resolved(
         None => (None, None, None, None),
         Some(text) => (
             Some(text),
-            extract_chart_title_size(axis_node),
-            extract_chart_title_bold(axis_node),
-            extract_chart_title_color(axis_node, resolver),
+            extract_axis_title_size(axis_node),
+            extract_axis_title_bold(axis_node),
+            extract_axis_title_color(axis_node, resolver),
         ),
     }
+}
+
+fn axis_title_body_properties<'a, 'input>(
+    axis_node: Node<'a, 'input>,
+) -> Option<(Option<Node<'a, 'input>>, Option<Node<'a, 'input>>)> {
+    let title = child(axis_node, "title")?;
+    let rich_body_pr = child(title, "tx")
+        .and_then(|tx| child(tx, "rich"))
+        .and_then(|rich| child(rich, "bodyPr"));
+    let txpr_body_pr = child(title, "txPr").and_then(|txpr| child(txpr, "bodyPr"));
+    Some((rich_body_pr, txpr_body_pr))
+}
+
+/// Authored DrawingML `bodyPr@rot` for an axis title in raw `ST_Angle` units.
+/// Rich-text body properties win over the title-level `txPr` fallback for this
+/// property only. `vert` is retained independently by
+/// [`extract_axis_title_vertical_mode`] because the two attributes describe
+/// different transforms and may legally coexist.
+pub fn extract_axis_title_rotation(axis_node: Node) -> Option<i32> {
+    let (rich_body_pr, txpr_body_pr) = axis_title_body_properties(axis_node)?;
+    rich_body_pr
+        .into_iter()
+        .chain(txpr_body_pr)
+        .find_map(|body_pr| {
+            body_pr
+                .attribute("rot")
+                .and_then(|value| value.parse::<i32>().ok())
+        })
+}
+
+/// Authored DrawingML `bodyPr@vert` for an axis title. Preserve every schema
+/// mode so the renderer can distinguish horizontal, rigid vertical,
+/// East-Asian/Mongolian vertical, and WordArt stacking. The current canvas
+/// painter explicitly approximates non-rigid vertical modes as vertical flow;
+/// retaining the token avoids silently treating them as horizontal.
+pub fn extract_axis_title_vertical_mode(axis_node: Node) -> Option<String> {
+    let (rich_body_pr, txpr_body_pr) = axis_title_body_properties(axis_node)?;
+    rich_body_pr
+        .into_iter()
+        .chain(txpr_body_pr)
+        .find_map(|body_pr| {
+            body_pr.attribute("vert").and_then(|vertical| {
+                matches!(
+                    vertical,
+                    "horz"
+                        | "vert"
+                        | "vert270"
+                        | "wordArtVert"
+                        | "eaVert"
+                        | "mongolianVert"
+                        | "wordArtVertRtl"
+                )
+                .then(|| vertical.to_string())
+            })
+        })
+}
+
+/// `<c|cx:axis><c|cx:title><c|cx:layout><c|cx:manualLayout>` using the same
+/// CT_ManualLayout resolver as chart/plot titles. Namespace-local names keep
+/// classic charts and ChartEx on one parser path.
+pub fn extract_axis_title_manual_layout(axis_node: Node) -> Option<ChartManualLayout> {
+    let title = child(axis_node, "title")?;
+    let layout = child(title, "layout")?;
+    extract_manual_layout(layout)
 }
 
 // ============================================================================
@@ -2014,6 +2180,14 @@ fn first_latin_typeface(container: Node) -> Option<String> {
     })
 }
 
+/// Resolve a title typeface property-by-property: an authored run face wins
+/// over any paragraph/title default regardless of document order.
+fn title_latin_typeface(container: Node) -> Option<String> {
+    title_text_property_nodes(container)
+        .into_iter()
+        .find_map(first_latin_typeface)
+}
+
 /// `<c:catAx|valAx><c:txPr>…<a:latin typeface>` — the axis tick-label font face.
 /// Scoped to the axis's `<c:txPr>` so an axis *title* face (under `<c:title>`)
 /// is not misread as the tick face. `None` when absent (renderer falls back to
@@ -2025,7 +2199,7 @@ pub fn extract_axis_tick_label_face(axis_node: Node) -> Option<String> {
 /// `<c:catAx|valAx><c:title>…<a:latin typeface>` — the axis-title font face.
 /// Scoped to the axis's direct-child `<c:title>`. `None` when absent.
 pub fn extract_axis_title_face(axis_node: Node) -> Option<String> {
-    first_latin_typeface(child(axis_node, "title")?)
+    title_latin_typeface(child(axis_node, "title")?)
 }
 
 /// First `<c:dLbls><c:txPr>…<a:latin typeface>` in the chart — the data-label
@@ -4040,20 +4214,44 @@ pub fn parse_chartex_part_with_references_and_style_parts(
     let val_axis_title = val_axis
         .and_then(|axis| child(axis, "title"))
         .and_then(chartex_text);
-    let cat_axis_title_font_size_hpt = cat_axis.and_then(extract_chart_title_size);
-    let cat_axis_title_font_bold = cat_axis.and_then(extract_chart_title_bold);
-    let cat_axis_title_font_color =
-        cat_axis.and_then(|axis| extract_chart_title_color(axis, resolver));
-    let cat_axis_title_font_face = cat_axis.and_then(extract_axis_title_face);
-    let val_axis_title_font_size_hpt = val_axis.and_then(extract_chart_title_size);
-    let val_axis_title_font_bold = val_axis.and_then(extract_chart_title_bold);
-    let val_axis_title_font_color =
-        val_axis.and_then(|axis| extract_chart_title_color(axis, resolver));
-    let val_axis_title_font_face = val_axis.and_then(extract_axis_title_face);
+    let inline_cat_title_size = cat_axis.and_then(extract_axis_title_size);
+    let inline_cat_title_bold = cat_axis.and_then(extract_axis_title_bold);
+    let inline_cat_title_color = cat_axis.and_then(|axis| extract_axis_title_color(axis, resolver));
+    let inline_cat_title_face = cat_axis.and_then(extract_axis_title_face);
+    let cat_axis_title_rotation = cat_axis.and_then(extract_axis_title_rotation);
+    let cat_axis_title_vertical_mode = cat_axis.and_then(extract_axis_title_vertical_mode);
+    let cat_axis_title_manual_layout = cat_axis.and_then(extract_axis_title_manual_layout);
+    let inline_val_title_size = val_axis.and_then(extract_axis_title_size);
+    let inline_val_title_bold = val_axis.and_then(extract_axis_title_bold);
+    let inline_val_title_color = val_axis.and_then(|axis| extract_axis_title_color(axis, resolver));
+    let inline_val_title_face = val_axis.and_then(extract_axis_title_face);
+    let val_axis_title_rotation = val_axis.and_then(extract_axis_title_rotation);
+    let val_axis_title_vertical_mode = val_axis.and_then(extract_axis_title_vertical_mode);
+    let val_axis_title_manual_layout = val_axis.and_then(extract_axis_title_manual_layout);
+    let (
+        raw_style_axis_title_size,
+        style_axis_title_bold,
+        style_axis_title_color,
+        style_axis_title_face,
+    ) = extract_chartex_style_text_props(style_element("axisTitle"), resolver);
+    let style_axis_title_size =
+        raw_style_axis_title_size.filter(|size| (100..=400_000).contains(size));
     let (style_cat_size, style_cat_bold, style_cat_color, style_cat_face) =
         extract_chartex_style_text_props(style_element("categoryAxis"), resolver);
     let (style_val_size, style_val_bold, style_val_color, style_val_face) =
         extract_chartex_style_text_props(style_element("valueAxis"), resolver);
+    // Axis-local title runs are authored values and win property-by-property;
+    // the associated Chart Style is only the omitted-property fallback.
+    let cat_axis_title_font_size_hpt = inline_cat_title_size.or(style_axis_title_size);
+    let cat_axis_title_font_bold = inline_cat_title_bold.or(style_axis_title_bold);
+    let cat_axis_title_font_color =
+        inline_cat_title_color.or_else(|| style_axis_title_color.clone());
+    let cat_axis_title_font_face = inline_cat_title_face.or_else(|| style_axis_title_face.clone());
+    let val_axis_title_font_size_hpt = inline_val_title_size.or(style_axis_title_size);
+    let val_axis_title_font_bold = inline_val_title_bold.or(style_axis_title_bold);
+    let val_axis_title_font_color =
+        inline_val_title_color.or_else(|| style_axis_title_color.clone());
+    let val_axis_title_font_face = inline_val_title_face.or_else(|| style_axis_title_face.clone());
     // MS-ODRAWXML 2.8.1.1 defines the associated chartStyle part as the
     // default formatting for every chart element. Excel applies the matching
     // categoryAxis/valueAxis entry to ChartEx tick labels; use the axis-local
@@ -4270,16 +4468,23 @@ pub fn parse_chartex_part_with_references_and_style_parts(
         bubble_scale: None,
         bubble_size_represents: None,
         show_negative_bubbles: None,
-        // chartEx (waterfall/treemap/etc.) has its own axis model and is not
-        // wired for axis titles or an explicit chartSpace border yet.
+        // chartEx (waterfall/treemap/etc.) has its own axis model. Axis-title
+        // text and orientation are shared with the classic renderer model;
+        // an explicit chartSpace border remains unwired here.
         cat_axis_title,
         val_axis_title,
         cat_axis_title_font_size_hpt,
         cat_axis_title_font_bold,
         cat_axis_title_font_color,
+        cat_axis_title_rotation,
+        cat_axis_title_vertical_mode,
+        cat_axis_title_manual_layout,
         val_axis_title_font_size_hpt,
         val_axis_title_font_bold,
         val_axis_title_font_color,
+        val_axis_title_rotation,
+        val_axis_title_vertical_mode,
+        val_axis_title_manual_layout,
         title_font_bold: chartex_title_font_bold,
         cat_axis_font_bold,
         val_axis_font_bold,
@@ -6606,6 +6811,9 @@ pub fn parse_chart_part_with_references(
             title_font_bold: title_bold,
             title_font_color: title_color,
             title_font_face: extract_axis_title_face(ax),
+            title_rotation: extract_axis_title_rotation(ax),
+            title_vertical_mode: extract_axis_title_vertical_mode(ax),
+            title_manual_layout: extract_axis_title_manual_layout(ax),
         }
     };
     let secondary_val_axis = secondary_val_ax.map(&parse_auxiliary_value_axis);
@@ -6668,11 +6876,17 @@ pub fn parse_chart_part_with_references(
     let mut cat_axis_title_bold: Option<bool> = None;
     let mut cat_axis_title_color: Option<String> = None;
     let mut cat_axis_title_face: Option<String> = None;
+    let mut cat_axis_title_rotation: Option<i32> = None;
+    let mut cat_axis_title_vertical_mode: Option<String> = None;
+    let mut cat_axis_title_manual_layout: Option<ChartManualLayout> = None;
     let mut val_axis_title: Option<String> = None;
     let mut val_axis_title_size: Option<i32> = None;
     let mut val_axis_title_bold: Option<bool> = None;
     let mut val_axis_title_color: Option<String> = None;
     let mut val_axis_title_face: Option<String> = None;
+    let mut val_axis_title_rotation: Option<i32> = None;
+    let mut val_axis_title_vertical_mode: Option<String> = None;
+    let mut val_axis_title_manual_layout: Option<ChartManualLayout> = None;
     for ax in plot_area
         .children()
         .filter(|n| n.is_element() && matches!(n.tag_name().name(), "catAx" | "dateAx" | "valAx"))
@@ -6697,6 +6911,9 @@ pub fn parse_chart_part_with_references(
                     cat_axis_title_bold = b;
                     cat_axis_title_color = col;
                     cat_axis_title_face = extract_axis_title_face(ax);
+                    cat_axis_title_rotation = extract_axis_title_rotation(ax);
+                    cat_axis_title_vertical_mode = extract_axis_title_vertical_mode(ax);
+                    cat_axis_title_manual_layout = extract_axis_title_manual_layout(ax);
                 }
             }
         } else if val_axis_title.is_none() {
@@ -6707,6 +6924,9 @@ pub fn parse_chart_part_with_references(
                 val_axis_title_bold = b;
                 val_axis_title_color = col;
                 val_axis_title_face = extract_axis_title_face(ax);
+                val_axis_title_rotation = extract_axis_title_rotation(ax);
+                val_axis_title_vertical_mode = extract_axis_title_vertical_mode(ax);
+                val_axis_title_manual_layout = extract_axis_title_manual_layout(ax);
             }
         }
     }
@@ -6958,9 +7178,15 @@ pub fn parse_chart_part_with_references(
         cat_axis_title_font_size_hpt: cat_axis_title_size,
         cat_axis_title_font_bold: cat_axis_title_bold,
         cat_axis_title_font_color: cat_axis_title_color,
+        cat_axis_title_rotation,
+        cat_axis_title_vertical_mode,
+        cat_axis_title_manual_layout,
         val_axis_title_font_size_hpt: val_axis_title_size,
         val_axis_title_font_bold: val_axis_title_bold,
         val_axis_title_font_color: val_axis_title_color,
+        val_axis_title_rotation,
+        val_axis_title_vertical_mode,
+        val_axis_title_manual_layout,
         title_font_bold,
         cat_axis_font_bold,
         val_axis_font_bold,
@@ -7199,9 +7425,15 @@ mod tests {
             cat_axis_title_font_size_hpt: None,
             cat_axis_title_font_bold: None,
             cat_axis_title_font_color: None,
+            cat_axis_title_rotation: None,
+            cat_axis_title_vertical_mode: None,
+            cat_axis_title_manual_layout: None,
             val_axis_title_font_size_hpt: None,
             val_axis_title_font_bold: None,
             val_axis_title_font_color: None,
+            val_axis_title_rotation: None,
+            val_axis_title_vertical_mode: None,
+            val_axis_title_manual_layout: None,
             chart_border_color: None,
             chart_border_width_emu: None,
             cat_axis_crosses: None,
@@ -7909,6 +8141,78 @@ mod tests {
         assert_eq!(size, Some(1000));
         assert_eq!(bold, Some(true));
         assert_eq!(color.as_deref(), Some("FF0000"));
+    }
+
+    #[test]
+    fn axis_title_run_properties_override_defaults_property_by_property() {
+        let xml = r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <c:title><c:tx><c:rich><a:bodyPr/><a:p>
+              <a:pPr><a:defRPr sz="900" b="0"><a:solidFill><a:srgbClr val="111111"/></a:solidFill><a:latin typeface="Default Face"/></a:defRPr></a:pPr>
+              <a:r><a:rPr sz="1200" b="1"><a:solidFill><a:srgbClr val="222222"/></a:solidFill></a:rPr><a:t>Value</a:t></a:r>
+            </a:p></c:rich></c:tx></c:title>
+        </c:valAx>"#;
+        let d = root_of(xml);
+        let axis = d.root_element();
+        let (_, size, bold, color) = extract_axis_title_with_props(axis);
+        assert_eq!(size, Some(1200));
+        assert_eq!(bold, Some(true));
+        assert_eq!(color.as_deref(), Some("222222"));
+        // The run does not author a face, so that property alone cascades to
+        // defRPr while the other run-authored properties still win.
+        assert_eq!(
+            extract_axis_title_face(axis).as_deref(),
+            Some("Default Face")
+        );
+    }
+
+    #[test]
+    fn axis_title_size_rejects_values_outside_st_text_font_size() {
+        for size in ["NaN", "-1", "0", "99", "400001", "2147483647"] {
+            let xml = format!(
+                r#"<c:valAx xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:title><c:tx><c:rich><a:bodyPr/><a:p><a:r><a:rPr sz="{size}"/><a:t>Value</a:t></a:r></a:p></c:rich></c:tx></c:title></c:valAx>"#
+            );
+            let d = root_of(&xml);
+            assert_eq!(extract_axis_title_size(d.root_element()), None);
+        }
+        for size in ["100", "400000"] {
+            let xml = format!(
+                r#"<c:valAx xmlns:c="{C_NS}" xmlns:a="{A_NS}"><c:title><c:tx><c:rich><a:bodyPr/><a:p><a:r><a:rPr sz="{size}"/><a:t>Value</a:t></a:r></a:p></c:rich></c:tx></c:title></c:valAx>"#
+            );
+            let d = root_of(&xml);
+            assert_eq!(
+                extract_axis_title_size(d.root_element()),
+                size.parse::<i32>().ok()
+            );
+        }
+    }
+
+    #[test]
+    fn axis_title_rotation_and_vertical_mode_are_independent() {
+        let xml = r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <c:title>
+              <c:tx><c:rich><a:bodyPr vert="vert270"/><a:p><a:r><a:t>Value</a:t></a:r></a:p></c:rich></c:tx>
+              <c:txPr><a:bodyPr rot="1800000"/><a:p/></c:txPr>
+            </c:title>
+        </c:valAx>"#;
+        let d = root_of(xml);
+        assert_eq!(
+            extract_axis_title_rotation(d.root_element()),
+            Some(1_800_000)
+        );
+        assert_eq!(
+            extract_axis_title_vertical_mode(d.root_element()).as_deref(),
+            Some("vert270")
+        );
+
+        let txpr_only = r#"<c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+            <c:title><c:txPr><a:bodyPr vert="eaVert"/><a:p/></c:txPr></c:title>
+        </c:valAx>"#;
+        let txpr_doc = root_of(txpr_only);
+        assert_eq!(extract_axis_title_rotation(txpr_doc.root_element()), None);
+        assert_eq!(
+            extract_axis_title_vertical_mode(txpr_doc.root_element()).as_deref(),
+            Some("eaVert")
+        );
     }
 
     #[test]
@@ -8629,11 +8933,15 @@ mod tests {
                   <c:catAx>
                     <c:axId val="1"/>
                     <c:axPos val="b"/>
+                    <c:title><c:tx><c:rich><a:bodyPr vert="horz"/><a:p><a:r><a:t>Quarter</a:t></a:r></a:p></c:rich></c:tx></c:title>
                     <c:spPr><a:ln><a:solidFill><a:srgbClr val="808080"/></a:solidFill></a:ln></c:spPr>
                   </c:catAx>
                   <c:valAx>
                     <c:axId val="2"/>
                     <c:axPos val="l"/>
+                    <c:title><c:tx><c:rich><a:bodyPr rot="-1800000"/><a:p><a:r><a:t>Revenue</a:t></a:r></a:p></c:rich></c:tx>
+                      <c:layout><c:manualLayout><c:xMode val="edge"/><c:yMode val="edge"/><c:x val="0.2"/><c:y val="0.1"/></c:manualLayout></c:layout>
+                    </c:title>
                     <c:majorGridlines><c:spPr><a:ln w="3175"><a:solidFill><a:schemeClr val="accent3"/></a:solidFill></a:ln></c:spPr></c:majorGridlines>
                     <c:scaling><c:min val="0"/><c:max val="30"/></c:scaling>
                   </c:valAx>
@@ -8687,6 +8995,14 @@ mod tests {
         assert_eq!(m.chart_border_width_emu, Some(19050));
         assert!(!m.cat_axis_hidden);
         assert!(!m.val_axis_hidden);
+        assert_eq!(m.cat_axis_title_rotation, None);
+        assert_eq!(m.cat_axis_title_vertical_mode.as_deref(), Some("horz"));
+        assert_eq!(m.val_axis_title_rotation, Some(-1_800_000));
+        let val_title_layout = m
+            .val_axis_title_manual_layout
+            .expect("value-axis title manual layout");
+        assert_eq!(val_title_layout.x, 0.2);
+        assert_eq!(val_title_layout.y, 0.1);
     }
 
     /// A chart title may be a string reference cache rather than DrawingML
@@ -8828,7 +9144,9 @@ mod tests {
                   <c:minorTickMark val="cross"/>
                   <c:minorGridlines><c:spPr><a:ln w="12700"><a:solidFill><a:srgbClr val="123456"/></a:solidFill><a:prstDash val="dot"/></a:ln></c:spPr></c:minorGridlines>
                   <c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface="Tick Face"/></a:defRPr></a:pPr></a:p></c:txPr>
-                  <c:title><c:tx><c:rich><a:p><a:r><a:rPr sz="900" b="0"><a:latin typeface="Title Face"/></a:rPr><a:t>Margin</a:t></a:r></a:p></c:rich></c:tx></c:title>
+                  <c:title><c:tx><c:rich><a:bodyPr vert="vert"/><a:p><a:r><a:rPr sz="900" b="0"><a:latin typeface="Title Face"/></a:rPr><a:t>Margin</a:t></a:r></a:p></c:rich></c:tx>
+                    <c:layout><c:manualLayout><c:x val="0.1"/><c:y val="0.2"/></c:manualLayout></c:layout>
+                  </c:title>
                 </c:valAx>
               </c:plotArea></c:chart>
             </c:chartSpace>"#
@@ -8867,6 +9185,12 @@ mod tests {
         assert_eq!(sec.title_font_face.as_deref(), Some("Title Face"));
         assert_eq!(sec.title_font_size_hpt, Some(900));
         assert_eq!(sec.title_font_bold, Some(false));
+        assert_eq!(sec.title_rotation, None);
+        assert_eq!(sec.title_vertical_mode.as_deref(), Some("vert"));
+        assert_eq!(
+            sec.title_manual_layout.as_ref().map(|layout| layout.x),
+            Some(0.1)
+        );
         // #738: an explicit `<c:majorUnit>` on the secondary axis (§21.2.2.103)
         // is threaded into the model (was silently dropped before).
         assert_eq!(sec.major_unit, Some(0.25));
@@ -9868,7 +10192,11 @@ mod tests {
                     </cx:series>
                   </cx:plotAreaRegion>
                   <cx:axis id="0"><cx:catScaling gapWidth="0.8"/></cx:axis>
-                  <cx:axis id="1" hidden="1"><cx:valScaling/></cx:axis>
+                  <cx:axis id="1" hidden="1"><cx:valScaling/>
+                    <cx:title><cx:tx><cx:rich><a:bodyPr rot="-1800000"/><a:p><a:r><a:t>Value</a:t></a:r></a:p></cx:rich></cx:tx>
+                      <cx:layout><cx:manualLayout><cx:xMode val="edge"/><cx:yMode val="edge"/><cx:x val="0.3"/><cx:y val="0.4"/></cx:manualLayout></cx:layout>
+                    </cx:title>
+                  </cx:axis>
                 </cx:plotArea>
               </cx:chart>
             </cx:chartSpace>"#
@@ -9921,11 +10249,65 @@ mod tests {
         // Hidden value axis, visible category axis.
         assert!(!m.cat_axis_hidden);
         assert!(m.val_axis_hidden);
+        assert_eq!(m.val_axis_title.as_deref(), Some("Value"));
+        assert_eq!(m.val_axis_title_rotation, Some(-1_800_000));
+        assert_eq!(
+            m.val_axis_title_manual_layout
+                .as_ref()
+                .map(|layout| layout.x),
+            Some(0.3)
+        );
         assert_eq!(m.chartex_connector_lines, Some(false));
         // Theme fallback faces threaded from the resolver (NIT-2: not a direct
         // `theme.get("+mj-lt")`).
         assert_eq!(m.theme_major_font_latin.as_deref(), Some("Calibri Light"));
         assert_eq!(m.theme_minor_font_latin.as_deref(), Some("Calibri"));
+    }
+
+    #[test]
+    fn parse_chartex_axis_title_runs_override_chart_style_property_by_property() {
+        let xml = format!(
+            r#"<cx:chartSpace xmlns:cx="{CX_NS}" xmlns:a="{A_NS}">
+              <cx:chart><cx:plotArea>
+                <cx:plotAreaRegion><cx:series layoutId="waterfall"/></cx:plotAreaRegion>
+                <cx:axis id="0"><cx:catScaling/><cx:title><cx:tx><cx:rich>
+                  <a:bodyPr/><a:p><a:r><a:t>Category</a:t></a:r></a:p>
+                </cx:rich></cx:tx></cx:title></cx:axis>
+                <cx:axis id="1"><cx:valScaling/><cx:title><cx:tx><cx:rich>
+                  <a:bodyPr/><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="778899"/></a:solidFill></a:defRPr></a:pPr><a:r><a:rPr sz="1200" b="0"><a:latin typeface="Inline Val"/></a:rPr><a:t>Value</a:t></a:r></a:p>
+                </cx:rich></cx:tx></cx:title></cx:axis>
+              </cx:plotArea></cx:chart>
+            </cx:chartSpace>"#
+        );
+        let style = format!(
+            r#"<cs:chartStyle xmlns:cs="{CS_NS}" xmlns:a="{A_NS}">
+              <cs:axisTitle><cs:defRPr sz="1000" b="1"><a:solidFill><a:srgbClr val="445566"/></a:solidFill><a:latin typeface="Style Axis"/></cs:defRPr></cs:axisTitle>
+              <cs:categoryAxis><cs:defRPr sz="700" b="0"><a:latin typeface="Tick Cat"/></cs:defRPr></cs:categoryAxis>
+              <cs:valueAxis><cs:defRPr sz="800" b="0"><a:latin typeface="Tick Val"/></cs:defRPr></cs:valueAxis>
+            </cs:chartStyle>"#
+        );
+        let document = chart_space_of(&xml);
+        let model = parse_chartex_part(document.root_element(), &FixtureResolver, Some(&style))
+            .expect("ChartEx axis titles parse");
+
+        assert_eq!(model.cat_axis_title_font_size_hpt, Some(1000));
+        assert_eq!(model.cat_axis_title_font_bold, Some(true));
+        assert_eq!(model.cat_axis_title_font_color.as_deref(), Some("445566"));
+        assert_eq!(
+            model.cat_axis_title_font_face.as_deref(),
+            Some("Style Axis")
+        );
+        // Inline run and default-run properties win independently over style.
+        assert_eq!(model.val_axis_title_font_size_hpt, Some(1200));
+        assert_eq!(model.val_axis_title_font_bold, Some(false));
+        assert_eq!(model.val_axis_title_font_color.as_deref(), Some("778899"));
+        assert_eq!(
+            model.val_axis_title_font_face.as_deref(),
+            Some("Inline Val")
+        );
+        // Axis tick labels retain their separate category/value style roles.
+        assert_eq!(model.cat_axis_font_size_hpt, Some(700));
+        assert_eq!(model.val_axis_font_size_hpt, Some(800));
     }
 
     #[test]

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -220,9 +220,15 @@ export interface ChartModel {
     catAxisTitleFontSizeHpt?: number | null;
     catAxisTitleFontBold?: boolean | null;
     catAxisTitleFontColor?: string | null;
+    catAxisTitleRotation?: number | null;
+    catAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
+    catAxisTitleManualLayout?: ChartManualLayout | null;
     valAxisTitleFontSizeHpt?: number | null;
     valAxisTitleFontBold?: boolean | null;
     valAxisTitleFontColor?: string | null;
+    valAxisTitleRotation?: number | null;
+    valAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
+    valAxisTitleManualLayout?: ChartManualLayout | null;
     catAxisFontFace?: string | null;
     valAxisFontFace?: string | null;
     catAxisTitleFontFace?: string | null;
@@ -1127,6 +1133,9 @@ export interface SecondaryValueAxis {
     titleFontBold?: boolean | null;
     titleFontColor?: string | null;
     titleFontFace?: string | null;
+    titleRotation?: number | null;
+    titleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
+    titleManualLayout?: ChartManualLayout | null;
 }
 export interface Shadow {
     color: string;

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -320,9 +320,15 @@ export interface ChartModel {
     catAxisTitleFontSizeHpt?: number | null;
     catAxisTitleFontBold?: boolean | null;
     catAxisTitleFontColor?: string | null;
+    catAxisTitleRotation?: number | null;
+    catAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
+    catAxisTitleManualLayout?: ChartManualLayout | null;
     valAxisTitleFontSizeHpt?: number | null;
     valAxisTitleFontBold?: boolean | null;
     valAxisTitleFontColor?: string | null;
+    valAxisTitleRotation?: number | null;
+    valAxisTitleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
+    valAxisTitleManualLayout?: ChartManualLayout | null;
     catAxisFontFace?: string | null;
     valAxisFontFace?: string | null;
     catAxisTitleFontFace?: string | null;
@@ -1090,6 +1096,9 @@ export interface SecondaryValueAxis {
     titleFontBold?: boolean | null;
     titleFontColor?: string | null;
     titleFontFace?: string | null;
+    titleRotation?: number | null;
+    titleVerticalMode?: 'horz' | 'vert' | 'vert270' | 'wordArtVert' | 'eaVert' | 'mongolianVert' | 'wordArtVertRtl' | null;
+    titleManualLayout?: ChartManualLayout | null;
 }
 export interface ShapeAnchor {
     fromCol: number;


### PR DESCRIPTION
Closes #1228

## Summary

- resolve omitted axis-title size through one fixed 10pt fallback
- preserve authored rich-text properties, text orientation, and manual layout
- use the dedicated Chart Style axis-title role with property-level precedence
- share side-aware title placement across classic, ChartEx, primary, secondary, and horizontal axes
- validate public-model font sizes before they affect plot geometry

## Verification

- full core chart and `ooxml-common` tests
- focused integration tests after rebasing onto current main
- TypeScript, Vite, and API symmetry checks
- independent adversarial review
- private self-regression VRT against current main: XLSX 19/19, PPTX 15/15, DOCX 47/47 exact

This implements a compact compatibility policy while keeping authored OOXML properties authoritative.