### PR TITLE
fix(chart): share bounded data label layout

### DIFF
--- a/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
+++ b/packages/core/src/chart/__snapshots__/renderer-signature.test.ts.snap
@@ -387,30 +387,60 @@ fillText "30" 56.14,98.95 fs=#555 font=10.7px sans-serif al=right bl=middle
 set fillStyle=#4472C4
 fillRect 102.7586,241.6167,46.1581,71.3333 fs=#4472C4
 set font=bold 11px sans-serif
+save
+beginPath
+rect 68.14,98.95,484.66,214
+clip
 set fillStyle=#333
 set textAlign=center
 set textBaseline=bottom
-fillText "10" 125.8376,240.6167 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "10" 125.8376,236.1167 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+restore
 set fillStyle=#ED7D31
 fillRect 148.9167,255.8833,46.1581,57.0667 fs=#ED7D31
+save
+beginPath
+rect 68.14,98.95,484.66,214
+clip
 set fillStyle=#333
-fillText "8" 171.9957,254.8833 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "8" 171.9957,250.3833 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+restore
 set fillStyle=#4472C4
 fillRect 264.3119,141.75,46.1581,171.2 fs=#4472C4
+save
+beginPath
+rect 68.14,98.95,484.66,214
+clip
 set fillStyle=#333
-fillText "24" 287.391,140.75 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "24" 287.391,136.25 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+restore
 set fillStyle=#ED7D31
 fillRect 310.47,205.95,46.1581,107 fs=#ED7D31
+save
+beginPath
+rect 68.14,98.95,484.66,214
+clip
 set fillStyle=#333
-fillText "15" 333.549,204.95 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "15" 333.549,200.45 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+restore
 set fillStyle=#4472C4
 fillRect 425.8652,191.6833,46.1581,121.2667 fs=#4472C4
+save
+beginPath
+rect 68.14,98.95,484.66,214
+clip
 set fillStyle=#333
-fillText "17" 448.9443,190.6833 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "17" 448.9443,186.1833 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+restore
 set fillStyle=#ED7D31
 fillRect 472.0233,156.0167,46.1581,156.9333 fs=#ED7D31
+save
+beginPath
+rect 68.14,98.95,484.66,214
+clip
 set fillStyle=#333
-fillText "22" 495.1024,155.0167 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+fillText "22" 495.1024,150.5167 fs=#333 font=bold 11px sans-serif al=center bl=bottom
+restore
 set fillStyle=#555
 set font=11px sans-serif
 set textBaseline=top
@@ -538,29 +568,59 @@ fillText "30" 552.8,345.45 fs=#555 font=11px sans-serif al=center bl=middle
 set fillStyle=#4472C4
 fillRect 30.775,273.5095,174.0083,22.5238 fs=#4472C4
 set font=bold 11px sans-serif
+save
+beginPath
+rect 30.775,98.95,522.025,236.5
+clip
 set fillStyle=#333
 set textAlign=left
-fillText "10" 206.7833,284.7714 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "10" 210.2833,284.7714 fs=#333 font=bold 11px sans-serif al=left bl=middle
+restore
 set fillStyle=#ED7D31
 fillRect 30.775,296.0333,139.2067,22.5238 fs=#ED7D31
+save
+beginPath
+rect 30.775,98.95,522.025,236.5
+clip
 set fillStyle=#333
-fillText "8" 171.9817,307.2952 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "8" 175.4817,307.2952 fs=#333 font=bold 11px sans-serif al=left bl=middle
+restore
 set fillStyle=#4472C4
 fillRect 30.775,194.6762,417.62,22.5238 fs=#4472C4
+save
+beginPath
+rect 30.775,98.95,522.025,236.5
+clip
 set fillStyle=#333
-fillText "24" 450.395,205.9381 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "24" 453.895,205.9381 fs=#333 font=bold 11px sans-serif al=left bl=middle
+restore
 set fillStyle=#ED7D31
 fillRect 30.775,217.2,261.0125,22.5238 fs=#ED7D31
+save
+beginPath
+rect 30.775,98.95,522.025,236.5
+clip
 set fillStyle=#333
-fillText "15" 293.7875,228.4619 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "15" 297.2875,228.4619 fs=#333 font=bold 11px sans-serif al=left bl=middle
+restore
 set fillStyle=#4472C4
 fillRect 30.775,115.8429,295.8142,22.5238 fs=#4472C4
+save
+beginPath
+rect 30.775,98.95,522.025,236.5
+clip
 set fillStyle=#333
-fillText "17" 328.5892,127.1048 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "17" 332.0892,127.1048 fs=#333 font=bold 11px sans-serif al=left bl=middle
+restore
 set fillStyle=#ED7D31
 fillRect 30.775,138.3667,382.8183,22.5238 fs=#ED7D31
+save
+beginPath
+rect 30.775,98.95,522.025,236.5
+clip
 set fillStyle=#333
-fillText "22" 415.5933,149.6286 fs=#333 font=bold 11px sans-serif al=left bl=middle
+fillText "22" 419.0933,149.6286 fs=#333 font=bold 11px sans-serif al=left bl=middle
+restore
 set fillStyle=#555
 set font=11px sans-serif
 set textAlign=right
@@ -972,97 +1032,157 @@ beginPath
 arc 103.9008,270.15,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
 set textAlign=left
-fillText "3" 117.2458,270.15 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "3" 115.6258,270.15 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 beginPath
 arc 141.8225,241.6167,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "5" 155.1675,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 153.5475,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 beginPath
 arc 179.7442,255.8833,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "4" 193.0892,255.8833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "4" 191.4692,255.8833 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 beginPath
 arc 217.6658,227.35,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "6" 231.0108,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 229.3908,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 beginPath
 arc 255.5875,213.0833,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "7" 268.9325,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 267.3125,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 beginPath
 arc 293.5092,241.6167,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "5" 306.8542,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 305.2342,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 beginPath
 arc 331.4308,198.8167,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "8" 344.7758,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 343.1558,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 beginPath
 arc 369.3525,227.35,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "6" 382.6975,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 381.0775,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 beginPath
 arc 407.2742,184.55,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "9" 420.6192,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 418.9992,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 beginPath
 arc 445.1958,213.0833,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "7" 458.5408,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 456.9208,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 beginPath
 arc 483.1175,170.2833,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "10" 496.4625,170.2833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "10" 494.8425,170.2833 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 beginPath
 arc 521.0392,198.8167,2.625,0,6.2832
 fill fs=#4472C4 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "8" 534.3842,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 530.28,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#4472C4
 set strokeStyle=#ED7D31
@@ -1086,96 +1206,156 @@ beginPath
 arc 103.9008,284.4167,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "2" 117.2458,284.4167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "2" 115.6258,284.4167 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 beginPath
 arc 141.8225,270.15,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "3" 155.1675,270.15 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "3" 153.5475,270.15 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 beginPath
 arc 179.7442,241.6167,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "5" 193.0892,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "5" 191.4692,241.6167 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 beginPath
 arc 217.6658,255.8833,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "4" 231.0108,255.8833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "4" 229.3908,255.8833 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 beginPath
 arc 255.5875,227.35,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "6" 268.9325,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 267.3125,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 beginPath
 arc 293.5092,198.8167,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "8" 306.8542,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 305.2342,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 beginPath
 arc 331.4308,213.0833,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "7" 344.7758,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 343.1558,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 beginPath
 arc 369.3525,184.55,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "9" 382.6975,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 381.0775,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 beginPath
 arc 407.2742,227.35,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "6" 420.6192,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "6" 418.9992,227.35 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 beginPath
 arc 445.1958,198.8167,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "8" 458.5408,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "8" 456.9208,198.8167 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 beginPath
 arc 483.1175,213.0833,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "7" 496.4625,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "7" 494.8425,213.0833 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 beginPath
 arc 521.0392,184.55,2.625,0,6.2832
 fill fs=#ED7D31 ga=1
 save
+save
+beginPath
+rect 84.94,98.95,455.06,214
+clip
 set fillStyle=#333
-fillText "9" 534.3842,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
+fillText "9" 530.28,184.55 fs=#333 font=16.2px sans-serif al=left bl=middle
+restore
 restore
 set fillStyle=#ED7D31
 set fillStyle=#555
@@ -2508,10 +2688,15 @@ moveTo 178.3699,123.7286
 lineTo 214.9701,123.7286
 stroke ss=#ccc lw=0.8 dash=
 restore
+save
+beginPath
+rect 49.16,30.1,590.04,327.7
+clip
 set fillStyle=#595959
 set textAlign=center
 set textBaseline=bottom
-fillText "100" 122.915,120.7286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+fillText "100" 122.915,115.6286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+restore
 set fillStyle=#5B9BD5
 fillRect 214.9701,53.5071,110.9098,70.2214 fs=#5B9BD5
 set strokeStyle=#5B9BD5
@@ -2527,8 +2712,13 @@ moveTo 325.8799,53.5071
 lineTo 362.4801,53.5071
 stroke ss=#ccc lw=0.8 dash=
 restore
+save
+beginPath
+rect 49.16,30.1,590.04,327.7
+clip
 set fillStyle=#595959
-fillText "30" 270.425,50.5071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+fillText "30" 270.425,45.4071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+restore
 set fillStyle=#ED7D31
 fillRect 362.4801,53.5071,110.9098,46.8143 fs=#ED7D31
 set strokeStyle=#ED7D31
@@ -2544,18 +2734,28 @@ moveTo 473.3899,100.3214
 lineTo 509.9901,100.3214
 stroke ss=#ccc lw=0.8 dash=
 restore
+save
+beginPath
+rect 49.16,30.1,590.04,327.7
+clip
 set fillStyle=#595959
 set textBaseline=top
-fillText "-20" 417.935,103.3214 fs=#595959 font=16.2px sans-serif al=center bl=top
+fillText "-20" 417.935,108.4214 fs=#595959 font=16.2px sans-serif al=center bl=top
+restore
 set fillStyle=#A5A5A5
 fillRect 509.9901,100.3214,110.9098,257.4786 fs=#A5A5A5
 set strokeStyle=#A5A5A5
 set lineWidth=1
 setLineDash
 strokeRect 509.9901,100.3214,110.9098,257.4786 ss=#A5A5A5 lw=1
+save
+beginPath
+rect 49.16,30.1,590.04,327.7
+clip
 set fillStyle=#595959
 set textBaseline=bottom
-fillText "110" 565.445,97.3214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+fillText "110" 565.445,92.2214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+restore
 set textBaseline=top
 fillText "Start" 122.915,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q1" 270.425,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
@@ -2588,10 +2788,15 @@ moveTo 159.3444,123.7286
 lineTo 197.4556,123.7286
 stroke ss=#ccc lw=0.8 dash=
 restore
+save
+beginPath
+rect 24.8,30.1,614.4,327.7
+clip
 set fillStyle=#595959
 set textAlign=center
 set textBaseline=bottom
-fillText "100" 101.6,120.7286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+fillText "100" 101.6,115.6286 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+restore
 set fillStyle=#5B9BD5
 fillRect 197.4556,53.5071,115.4887,70.2214 fs=#5B9BD5
 set strokeStyle=#5B9BD5
@@ -2607,8 +2812,13 @@ moveTo 312.9444,53.5071
 lineTo 351.0556,53.5071
 stroke ss=#ccc lw=0.8 dash=
 restore
+save
+beginPath
+rect 24.8,30.1,614.4,327.7
+clip
 set fillStyle=#595959
-fillText "30" 255.2,50.5071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+fillText "30" 255.2,45.4071 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+restore
 set fillStyle=#ED7D31
 fillRect 351.0556,53.5071,115.4887,46.8143 fs=#ED7D31
 set strokeStyle=#ED7D31
@@ -2624,18 +2834,28 @@ moveTo 466.5444,100.3214
 lineTo 504.6556,100.3214
 stroke ss=#ccc lw=0.8 dash=
 restore
+save
+beginPath
+rect 24.8,30.1,614.4,327.7
+clip
 set fillStyle=#595959
 set textBaseline=top
-fillText "-20" 408.8,103.3214 fs=#595959 font=16.2px sans-serif al=center bl=top
+fillText "-20" 408.8,108.4214 fs=#595959 font=16.2px sans-serif al=center bl=top
+restore
 set fillStyle=#A5A5A5
 fillRect 504.6556,100.3214,115.4887,257.4786 fs=#A5A5A5
 set strokeStyle=#A5A5A5
 set lineWidth=1
 setLineDash
 strokeRect 504.6556,100.3214,115.4887,257.4786 ss=#A5A5A5 lw=1
+save
+beginPath
+rect 24.8,30.1,614.4,327.7
+clip
 set fillStyle=#595959
 set textBaseline=bottom
-fillText "110" 562.4,97.3214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+fillText "110" 562.4,92.2214 fs=#595959 font=16.2px sans-serif al=center bl=bottom
+restore
 set textBaseline=top
 fillText "Start" 101.6,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top
 fillText "Q1" 255.2,361.8 fs=#595959 font=16.2px sans-serif al=center bl=top

--- a/packages/core/src/chart/data-label-layout.test.ts
+++ b/packages/core/src/chart/data-label-layout.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { fitDataLabelLines, resolveDataLabelPlacement } from './data-label-layout';
+
+const bounds = { x: 0, y: 0, w: 200, h: 100 };
+
+describe('resolveDataLabelPlacement', () => {
+  it.each([
+    [false, 'inBase', 85], [false, 'inEnd', 15], [false, 'outEnd', 5],
+    [true, 'inBase', 15], [true, 'inEnd', 85], [true, 'outEnd', 95],
+  ] as const)('maps vertical bar sign=%s position=%s deterministically', (negative, position, expectedY) => {
+    const got = resolveDataLabelPlacement(
+      { kind: 'bar', rect: { x: 40, y: 10, w: 40, h: 80 }, orientation: 'vertical', negative, position },
+      bounds, { w: 20, h: 10 }, 10,
+    );
+    expect(got?.x).toBe(60);
+    expect(got?.y).toBe(expectedY);
+  });
+
+  it('maps horizontal positive, negative, and zero-sized bars without non-finite geometry', () => {
+    const positive = resolveDataLabelPlacement(
+      { kind: 'bar', rect: { x: 40, y: 20, w: 80, h: 20 }, orientation: 'horizontal', negative: false, position: 'outEnd' },
+      bounds, { w: 20, h: 10 }, 10,
+    );
+    const negative = resolveDataLabelPlacement(
+      { kind: 'bar', rect: { x: 40, y: 20, w: 80, h: 20 }, orientation: 'horizontal', negative: true, position: 'outEnd' },
+      bounds, { w: 20, h: 10 }, 10,
+    );
+    const zero = resolveDataLabelPlacement(
+      { kind: 'bar', rect: { x: 40, y: 20, w: 0, h: 20 }, orientation: 'horizontal', negative: false },
+      bounds, { w: 20, h: 10 }, 10,
+    );
+    expect(positive?.x).toBe(125);
+    expect(negative?.x).toBe(35);
+    expect(zero?.x).toBe(45);
+  });
+
+  it('keeps line/scatter edge labels inside wide and tall plot bounds', () => {
+    const left = resolveDataLabelPlacement(
+      { kind: 'point', x: 1, y: 50, position: 'l' }, bounds, { w: 40, h: 10 }, 10,
+    );
+    const top = resolveDataLabelPlacement(
+      { kind: 'point', x: 100, y: 1, position: 't' }, bounds, { w: 40, h: 10 }, 10,
+    );
+    expect(left).toMatchObject({ x: 40, y: 50, textAlign: 'right' });
+    expect(top).toMatchObject({ x: 100, y: 10, textBaseline: 'bottom' });
+  });
+
+  it('maps bounded box positions with a half-em inset', () => {
+    const rect = { x: 20, y: 10, w: 100, h: 60 };
+    const topLeft = resolveDataLabelPlacement(
+      { kind: 'box', rect, position: 'inBase' }, bounds, { w: 20, h: 10 }, 10,
+    );
+    const bottomLeft = resolveDataLabelPlacement(
+      { kind: 'box', rect, position: 'inEnd' }, bounds, { w: 20, h: 10 }, 10,
+    );
+    expect(topLeft).toMatchObject({ x: 25, y: 15, textAlign: 'left', textBaseline: 'top' });
+    expect(bottomLeft).toMatchObject({ x: 25, y: 65, textAlign: 'left', textBaseline: 'bottom' });
+  });
+
+  it('applies authored manual layout after the automatic anchor', () => {
+    const got = resolveDataLabelPlacement(
+      { kind: 'point', x: 20, y: 20, position: 'r' }, bounds, { w: 20, h: 10 }, 10,
+      { xMode: 'edge', yMode: 'edge', x: 0.75, y: 0.25, w: 0.1, h: 0.2 },
+    );
+    expect(got).toMatchObject({
+      x: 160, y: 35, maxWidth: 20, maxHeight: 20,
+      rect: { x: 150, y: 25, w: 20, h: 20 },
+    });
+  });
+
+  it('resolves manual fractions against chart space while clipping to plot space', () => {
+    const chartRect = { x: 0, y: 0, w: 400, h: 200 };
+    const plotClip = { x: 100, y: 50, w: 200, h: 100 };
+    const got = resolveDataLabelPlacement(
+      { kind: 'point', x: 120, y: 70, position: 'r' },
+      plotClip,
+      { w: 20, h: 10 },
+      10,
+      { xMode: 'edge', yMode: 'edge', x: 0.5, y: 0.5, w: 0.1, h: 0.1 },
+      chartRect,
+    );
+    expect(got).toMatchObject({
+      x: 220, y: 110, maxWidth: 40, maxHeight: 20,
+      rect: { x: 200, y: 100, w: 40, h: 20 },
+      clip: { x: 200, y: 100, w: 40, h: 20 },
+    });
+  });
+
+  it('preserves a partially clipped manual center and fails closed when fully outside', () => {
+    const chartRect = { x: 0, y: 0, w: 400, h: 200 };
+    const plotClip = { x: 100, y: 50, w: 200, h: 100 };
+    const partial = resolveDataLabelPlacement(
+      { kind: 'point', x: 150, y: 75 }, plotClip, { w: 20, h: 10 }, 10,
+      { xMode: 'edge', yMode: 'edge', x: 0.2, y: 0.25, w: 0.1, h: 0.2 },
+      chartRect,
+    );
+    expect(partial).toMatchObject({
+      x: 100, y: 70,
+      rect: { x: 80, y: 50, w: 40, h: 40 },
+      clip: { x: 100, y: 50, w: 20, h: 40 },
+    });
+    expect(resolveDataLabelPlacement(
+      { kind: 'point', x: 150, y: 75 }, plotClip, { w: 20, h: 10 }, 10,
+      { xMode: 'edge', yMode: 'edge', x: 0, y: 0, w: 0.1, h: 0.1 },
+      chartRect,
+    )).toBeNull();
+  });
+
+  it('omits labels in tiny bounds and rejects non-finite input', () => {
+    expect(resolveDataLabelPlacement(
+      { kind: 'point', x: 1, y: 1 }, { x: 0, y: 0, w: 4, h: 4 }, { w: 10, h: 10 }, 10,
+    )).toBeNull();
+    expect(resolveDataLabelPlacement(
+      { kind: 'point', x: Number.POSITIVE_INFINITY, y: 1 }, bounds, { w: 10, h: 10 }, 10,
+    )).toBeNull();
+  });
+});
+
+describe('fitDataLabelLines', () => {
+  const measure = (text: string): number => text.length * 5;
+
+  it('uses one bounded wrapping/elision policy for wide and tall labels', () => {
+    expect(fitDataLabelLines('alpha beta gamma', 45, 30, 10, measure)).toEqual(['alpha ', 'beta ', 'gamma']);
+    expect(fitDataLabelLines('abcdefghijk', 30, 10, 10, measure)).toEqual(['abcde…']);
+  });
+
+  it('bounds line count and safely omits an unpaintable label', () => {
+    expect(fitDataLabelLines('a\nb\nc\nd\ne', 30, 100, 10, measure)).toHaveLength(4);
+    expect(fitDataLabelLines('value', 30, 5, 10, measure)).toEqual([]);
+  });
+
+  it('preserves authored whitespace while wrapping and eliding', () => {
+    expect(fitDataLabelLines('A  42', 50, 10, 10, measure)).toEqual(['A  42']);
+    expect(fitDataLabelLines('alpha  beta', 35, 20, 10, measure)).toEqual(['alpha  ', 'beta']);
+  });
+
+  it('counts the 4096-character ceiling by Unicode scalar without splitting a surrogate pair', () => {
+    const result = fitDataLabelLines(
+      '😀'.repeat(4097),
+      5000,
+      10,
+      10,
+      text => Array.from(text).length,
+    );
+    expect(result).toHaveLength(1);
+    expect(Array.from(result[0])).toHaveLength(4097);
+    expect(result[0]).toBe(`${'😀'.repeat(4096)}…`);
+  });
+});

--- a/packages/core/src/chart/data-label-layout.ts
+++ b/packages/core/src/chart/data-label-layout.ts
@@ -1,0 +1,321 @@
+import type { ChartManualLayout } from '../types/chart';
+import { resolveManualLayoutRect } from './layout.js';
+
+export interface DataLabelRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export type DataLabelAnchor =
+  | { kind: 'point'; x: number; y: number; position?: string; markerGap?: number }
+  | { kind: 'box'; rect: DataLabelRect; position?: string }
+  | {
+      kind: 'bar';
+      rect: DataLabelRect;
+      orientation: 'vertical' | 'horizontal';
+      negative: boolean;
+      position?: string;
+    };
+
+export interface DataLabelPlacement {
+  x: number;
+  y: number;
+  textAlign: CanvasTextAlign;
+  textBaseline: CanvasTextBaseline;
+  maxWidth: number;
+  maxHeight: number;
+  clip: DataLabelRect;
+  /** Resolved authored/automatic label box before clipping. */
+  rect: DataLabelRect;
+}
+
+const finiteRect = (rect: DataLabelRect): boolean =>
+  [rect.x, rect.y, rect.w, rect.h].every(Number.isFinite) && rect.w > 0 && rect.h > 0;
+
+function intersection(a: DataLabelRect, b: DataLabelRect): DataLabelRect | null {
+  const x = Math.max(a.x, b.x);
+  const y = Math.max(a.y, b.y);
+  const right = Math.min(a.x + a.w, b.x + b.w);
+  const bottom = Math.min(a.y + a.h, b.y + b.h);
+  return right > x && bottom > y ? { x, y, w: right - x, h: bottom - y } : null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Resolve the shared, intentionally simple chart data-label anchor.
+ *
+ * OOXML defines position tokens but not their exact automatic geometry. We use
+ * one half-em inset for every family, keep authored manual layout ahead of the
+ * automatic anchor, and bound the result to the caller's plot/slice rectangle.
+ * An inside-bar label is omitted when the bar cannot contain one text line.
+ */
+export function resolveDataLabelPlacement(
+  anchor: DataLabelAnchor,
+  bounds: DataLabelRect,
+  textSize: { w: number; h: number },
+  fontSizePx: number,
+  manualLayout?: ChartManualLayout,
+  layoutReferenceRect: DataLabelRect = bounds,
+): DataLabelPlacement | null {
+  if (!finiteRect(bounds) || !finiteRect(layoutReferenceRect) ||
+      !Number.isFinite(fontSizePx) || fontSizePx <= 0 ||
+      ![textSize.w, textSize.h].every(Number.isFinite) || textSize.w < 0 || textSize.h <= 0) {
+    return null;
+  }
+
+  const inset = fontSizePx * 0.5;
+  let constraint = bounds;
+  let x: number;
+  let y: number;
+  let clipWithoutReanchoring = false;
+  let textAlign: CanvasTextAlign = 'center';
+  let textBaseline: CanvasTextBaseline = 'middle';
+
+  if (anchor.kind === 'point') {
+    if (![anchor.x, anchor.y, anchor.markerGap ?? 0].every(Number.isFinite)) return null;
+    const gap = inset + Math.max(0, anchor.markerGap ?? 0);
+    x = anchor.x;
+    y = anchor.y;
+    switch (anchor.position ?? 'r') {
+      case 'l': x -= gap + textSize.w / 2; textAlign = 'right'; break;
+      case 't': y -= gap + textSize.h / 2; textBaseline = 'bottom'; break;
+      case 'b': y += gap + textSize.h / 2; textBaseline = 'top'; break;
+      case 'ctr': case 'inEnd': case 'bestFit': break;
+      default: x += gap + textSize.w / 2; textAlign = 'left'; break;
+    }
+  } else if (anchor.kind === 'box') {
+    if (![anchor.rect.x, anchor.rect.y, anchor.rect.w, anchor.rect.h].every(Number.isFinite) ||
+        anchor.rect.w <= 0 || anchor.rect.h <= 0) return null;
+    const box = intersection(anchor.rect, bounds);
+    if (!box) return null;
+    const pos = anchor.position ?? 'ctr';
+    x = box.x + box.w / 2;
+    y = box.y + box.h / 2;
+    if (pos === 'inBase') {
+      constraint = { x: box.x + inset, y: box.y + inset, w: box.w - inset, h: box.h - inset };
+      x = constraint.x + textSize.w / 2;
+      y = constraint.y + textSize.h / 2;
+      textAlign = 'left';
+      textBaseline = 'top';
+    } else if (pos === 'inEnd') {
+      constraint = { x: box.x + inset, y: box.y, w: box.w - inset, h: box.h - inset };
+      x = constraint.x + textSize.w / 2;
+      y = constraint.y + constraint.h - textSize.h / 2;
+      textAlign = 'left';
+      textBaseline = 'bottom';
+    } else if (pos === 'l') {
+      constraint = { x: box.x + inset, y: box.y + inset, w: box.w - inset, h: box.h - inset * 2 };
+      x = constraint.x + textSize.w / 2;
+      textAlign = 'left';
+    } else if (pos === 'r' || pos === 'outEnd') {
+      constraint = { x: box.x, y: box.y + inset, w: box.w - inset, h: box.h - inset * 2 };
+      x = constraint.x + constraint.w - textSize.w / 2;
+      textAlign = 'right';
+    } else if (pos === 't') {
+      constraint = { x: box.x + inset, y: box.y + inset, w: box.w - inset * 2, h: box.h - inset };
+      y = constraint.y + textSize.h / 2;
+      textBaseline = 'top';
+    } else if (pos === 'b') {
+      constraint = { x: box.x + inset, y: box.y, w: box.w - inset * 2, h: box.h - inset };
+      y = constraint.y + constraint.h - textSize.h / 2;
+      textBaseline = 'bottom';
+    } else {
+      constraint = {
+        x: box.x + inset,
+        y: box.y + inset,
+        w: box.w - inset * 2,
+        h: box.h - inset * 2,
+      };
+    }
+  } else {
+    if (![anchor.rect.x, anchor.rect.y, anchor.rect.w, anchor.rect.h].every(Number.isFinite) ||
+        anchor.rect.w < 0 || anchor.rect.h < 0) return null;
+    const pos = anchor.position ?? 'outEnd';
+    const inside = pos === 'inBase' || pos === 'inEnd' || pos === 'ctr';
+    clipWithoutReanchoring = !inside;
+    if (inside) {
+      const bar = intersection(anchor.rect, bounds);
+      if (!bar) return null;
+      constraint = bar;
+    } else if ((anchor.orientation === 'vertical' && anchor.rect.w <= 0) ||
+               (anchor.orientation === 'horizontal' && anchor.rect.h <= 0)) {
+      return null;
+    }
+    const cx = anchor.rect.x + anchor.rect.w / 2;
+    const cy = anchor.rect.y + anchor.rect.h / 2;
+    x = cx;
+    y = cy;
+    if (anchor.orientation === 'vertical') {
+      const end = anchor.negative ? anchor.rect.y + anchor.rect.h : anchor.rect.y;
+      const base = anchor.negative ? anchor.rect.y : anchor.rect.y + anchor.rect.h;
+      if (pos === 'inBase') {
+        y = base + (anchor.negative ? 1 : -1) * (inset + textSize.h / 2);
+        textBaseline = anchor.negative ? 'top' : 'bottom';
+      } else if (pos === 'inEnd') {
+        y = end + (anchor.negative ? -1 : 1) * (inset + textSize.h / 2);
+        textBaseline = anchor.negative ? 'bottom' : 'top';
+      } else if (pos !== 'ctr') {
+        y = end + (anchor.negative ? 1 : -1) * (inset + textSize.h / 2);
+        textBaseline = anchor.negative ? 'top' : 'bottom';
+      }
+    } else {
+      const end = anchor.negative ? anchor.rect.x : anchor.rect.x + anchor.rect.w;
+      const base = anchor.negative ? anchor.rect.x + anchor.rect.w : anchor.rect.x;
+      if (pos === 'inBase') {
+        x = base + (anchor.negative ? -1 : 1) * (inset + textSize.w / 2);
+        textAlign = anchor.negative ? 'right' : 'left';
+      } else if (pos === 'inEnd') {
+        x = end + (anchor.negative ? 1 : -1) * (inset + textSize.w / 2);
+        textAlign = anchor.negative ? 'left' : 'right';
+      } else if (pos !== 'ctr') {
+        x = end + (anchor.negative ? -1 : 1) * (inset + textSize.w / 2);
+        textAlign = anchor.negative ? 'right' : 'left';
+      }
+    }
+  }
+
+  const minLineWidth = Math.max(2, fontSizePx * 0.5);
+  const minLineHeight = Math.max(2, fontSizePx * 0.9);
+  if (constraint.w < minLineWidth || constraint.h < minLineHeight) return null;
+
+  let resolved = {
+    x: x - Math.min(textSize.w, constraint.w) / 2,
+    y: y - Math.min(textSize.h, constraint.h) / 2,
+    w: Math.min(textSize.w, constraint.w),
+    h: Math.min(textSize.h, constraint.h),
+  };
+  if (manualLayout) {
+    const manual = resolveManualLayoutRect(manualLayout, layoutReferenceRect, resolved);
+    if (!manual) return null;
+    resolved = manual;
+    textAlign = 'center';
+    textBaseline = 'middle';
+    const visibleManual = intersection(manual, bounds);
+    if (!visibleManual) return null;
+    constraint = visibleManual;
+    if (constraint.w < minLineWidth || constraint.h < minLineHeight) return null;
+  }
+
+  const fittedW = Math.min(Math.max(minLineWidth, resolved.w), constraint.w);
+  const fittedH = Math.min(Math.max(minLineHeight, resolved.h), constraint.h);
+  const halfW = fittedW / 2;
+  const halfH = fittedH / 2;
+  const centerX = (clipWithoutReanchoring || manualLayout)
+    ? resolved.x + resolved.w / 2
+    : clamp(resolved.x + resolved.w / 2, constraint.x + halfW, constraint.x + constraint.w - halfW);
+  const centerY = (clipWithoutReanchoring || manualLayout)
+    ? resolved.y + resolved.h / 2
+    : clamp(resolved.y + resolved.h / 2, constraint.y + halfH, constraint.y + constraint.h - halfH);
+  if (![centerX, centerY].every(Number.isFinite)) return null;
+  const drawX = textAlign === 'left' ? centerX - halfW : textAlign === 'right' ? centerX + halfW : centerX;
+  const drawY = textBaseline === 'top' ? centerY - halfH : textBaseline === 'bottom' ? centerY + halfH : centerY;
+  return {
+    x: drawX,
+    y: drawY,
+    textAlign,
+    textBaseline,
+    maxWidth: constraint.w,
+    maxHeight: constraint.h,
+    clip: constraint,
+    rect: resolved,
+  };
+}
+
+const MAX_LABEL_CHARS = 4096;
+const MAX_LABEL_LINES = 4;
+
+function elide(
+  text: string,
+  maxWidth: number,
+  measure: (value: string) => number,
+): string {
+  if (measure(text) <= maxWidth) return text;
+  const ellipsis = '…';
+  if (measure(ellipsis) > maxWidth) return '';
+  let lo = 0;
+  const characters = Array.from(text);
+  let hi = characters.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (measure(`${characters.slice(0, mid).join('')}${ellipsis}`) <= maxWidth) lo = mid;
+    else hi = mid - 1;
+  }
+  return `${characters.slice(0, lo).join('')}${ellipsis}`;
+}
+
+export function boundDataLabelText(text: string): { value: string; truncated: boolean } {
+  let value = '';
+  let count = 0;
+  for (const character of text) {
+    if (count >= MAX_LABEL_CHARS) return { value, truncated: true };
+    value += character;
+    count++;
+  }
+  return { value, truncated: false };
+}
+
+/** Shared bounded wrapping/elision for all automatic chart data labels. */
+export function fitDataLabelLines(
+  text: string,
+  maxWidth: number,
+  maxHeight: number,
+  lineHeight: number,
+  measure: (value: string) => number,
+): string[] {
+  if (![maxWidth, maxHeight, lineHeight].every(Number.isFinite) ||
+      maxWidth <= 0 || maxHeight < lineHeight || lineHeight <= 0) return [];
+  const lineLimit = Math.max(1, Math.min(MAX_LABEL_LINES, Math.floor(maxHeight / lineHeight)));
+  const bounded = boundDataLabelText(text);
+  const paragraphs = bounded.value.split(/\r?\n/);
+  const lines: string[] = [];
+  let truncated = bounded.truncated;
+  const splitMeasuredToken = (token: string): string[] => {
+    const chunks: string[] = [];
+    let chunk = '';
+    for (const character of Array.from(token)) {
+      const candidate = `${chunk}${character}`;
+      if (chunk && measure(candidate) > maxWidth) {
+        chunks.push(chunk);
+        chunk = character;
+      } else {
+        chunk = candidate;
+      }
+    }
+    if (chunk) chunks.push(chunk);
+    return chunks.filter(value => measure(value) <= maxWidth);
+  };
+  for (const paragraph of paragraphs) {
+    if (measure(paragraph) <= maxWidth) {
+      lines.push(paragraph);
+      continue;
+    }
+    const words = paragraph.match(/\S+\s*|\s+/g) ?? [];
+    if (words.length <= 1) {
+      lines.push(...splitMeasuredToken(paragraph));
+    } else {
+      let current = '';
+      for (const word of words) {
+        const candidate = `${current}${word}`;
+        if (measure(candidate) <= maxWidth) current = candidate;
+        else {
+          if (current) lines.push(current);
+          const chunks = splitMeasuredToken(word);
+          current = chunks.pop() ?? '';
+          lines.push(...chunks);
+        }
+      }
+      if (current) lines.push(current);
+    }
+  }
+  truncated ||= lines.length > lineLimit;
+  const result = lines.slice(0, lineLimit);
+  if (truncated && result.length > 0 && !result[result.length - 1].endsWith('…')) {
+    result[result.length - 1] = elide(`${result[result.length - 1]}…`, maxWidth, measure);
+  }
+  return result;
+}

--- a/packages/core/src/chart/renderer-correctness.test.ts
+++ b/packages/core/src/chart/renderer-correctness.test.ts
@@ -32,6 +32,7 @@ interface Recorded {
   texts: TextCall[];
   clips: Array<{ x: number; y: number; w: number; h: number }>;
   gradients: Array<{ args: number[]; stops: Array<{ position: number; color: string }> }>;
+  arcs: Array<{ x: number; y: number; r: number }>;
 }
 
 /** Minimal recording 2D context: captures fillRect + fillText, tracks the
@@ -42,6 +43,7 @@ function recordingCtx(): Recorded {
   const texts: TextCall[] = [];
   const clips: Array<{ x: number; y: number; w: number; h: number }> = [];
   const gradients: Recorded['gradients'] = [];
+  const arcs: Recorded['arcs'] = [];
   let pathRect: { x: number; y: number; w: number; h: number } | null = null;
   const state: Record<string, unknown> = {
     font: '10px sans-serif',
@@ -105,8 +107,10 @@ function recordingCtx(): Recorded {
           return (x: number, y: number, w: number, h: number) => { pathRect = { x, y, w, h }; };
         case 'clip':
           return () => { if (pathRect) clips.push(pathRect); };
+        case 'arc':
+          return (x: number, y: number, r: number) => { arcs.push({ x, y, r }); };
         case 'save': case 'restore': case 'closePath':
-        case 'fill': case 'stroke': case 'moveTo': case 'lineTo': case 'arc':
+        case 'fill': case 'stroke': case 'moveTo': case 'lineTo':
         case 'bezierCurveTo': case 'quadraticCurveTo':
         case 'clearRect': case 'strokeText': case 'setLineDash':
         case 'translate': case 'rotate': case 'scale':
@@ -125,6 +129,7 @@ function recordingCtx(): Recorded {
     texts,
     clips,
     gradients,
+    arcs,
   };
 }
 
@@ -1919,6 +1924,65 @@ describe('ChartEx flat layouts dispatch to semantic renderers', () => {
   );
 
   it.each(['waterfall', 'funnel'])(
+    '%s routes authored labels through the shared four-line bounded layout',
+    chartType => {
+      const rec = recordingCtx();
+      const authored = `A  ${'word '.repeat(1200)}`;
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['A'],
+        catAxisHidden: true,
+        valAxisHidden: true,
+        series: [series({
+          values: [10],
+          dataLabelOverrides: [{ idx: 0, text: authored, position: 'ctr', fontColor: '123456' }],
+        })],
+      }), RECT, 1);
+
+      const labels = rec.texts.filter(text => text.fillStyle === '#123456');
+      expect(labels.length).toBeGreaterThan(0);
+      expect(labels.length).toBeLessThanOrEqual(4);
+      expect(labels.map(text => text.text).join('')).toContain('A  ');
+      expect(labels.map(text => text.text)).not.toContain(authored);
+    },
+  );
+
+  it('applies ChartEx funnel manual label layout in chart coordinates', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'funnel',
+      categories: ['A'],
+      catAxisHidden: true,
+      series: [series({
+        values: [10],
+        dataLabelOverrides: [{
+          idx: 0,
+          text: 'manual funnel',
+          fontColor: '123456',
+          manualLayout: { xMode: 'edge', yMode: 'edge', x: 0.5, y: 0.2, w: 0.2, h: 0.1 },
+        }],
+      })],
+    }), RECT, 1);
+
+    expect(rec.texts.find(text => text.text === 'manual funnel')).toMatchObject({ x: 384, y: 90 });
+  });
+
+  it('keeps a point-level waterfall fontBold=false authoritative', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'waterfall',
+      categories: ['A'],
+      dataLabelFontBold: true,
+      series: [series({
+        values: [10],
+        dataLabelOverrides: [{ idx: 0, text: 'not bold', fontBold: false }],
+      })],
+    }), RECT, 1);
+
+    expect(rec.texts.find(text => text.text === 'not bold')?.font).not.toMatch(/^bold /);
+  });
+
+  it.each(['waterfall', 'funnel'])(
     '%s preserves category-only point slots when the string dimension is longer',
     chartType => {
       const rec = recordingCtx();
@@ -2972,6 +3036,109 @@ describe('CH9 — line/area per-point data labels (§21.2.2.45)', () => {
       expect(rec.texts.some(t => t.text === '7')).toBe(true);
     });
   }
+
+  for (const chartType of ['stackedLine', 'stackedArea'] as const) {
+    it(`${chartType}: showVal uses the source value while the anchor stays cumulative`, () => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['A'],
+        series: [
+          series({
+            name: 'Lower', values: [10],
+            seriesDataLabels: {
+              showVal: true, showCatName: false, showSerName: false, showPercent: false,
+              fontColor: 'FF0000', position: 'ctr',
+            },
+          }),
+          series({
+            name: 'Upper', values: [40],
+            seriesDataLabels: {
+              showVal: true, showCatName: false, showSerName: false, showPercent: false,
+              fontColor: '0000FF', position: 'ctr',
+            },
+          }),
+        ],
+      }), RECT, 1);
+      expect(rec.texts.find(text => text.fillStyle === '#FF0000')?.text).toBe('10');
+      const upper = rec.texts.find(text => text.fillStyle === '#0000FF');
+      expect(upper?.text).toBe('40');
+      const cumulativeTick = rec.texts.find(text => text.text === '50');
+      expect(cumulativeTick).toBeDefined();
+      expect(upper?.y).toBeCloseTo(cumulativeTick?.y as number, 6);
+    });
+  }
+
+  for (const chartType of ['stackedLinePct', 'stackedAreaPct'] as const) {
+    it(`${chartType}: showPercent uses the source contribution and authored numFmt`, () => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType,
+        categories: ['A'],
+        series: [
+          series({
+            values: [1],
+            seriesDataLabels: {
+              showVal: false, showCatName: false, showSerName: false, showPercent: true,
+              formatCode: '0.0%', fontColor: 'FF0000', position: 'ctr',
+            },
+          }),
+          series({ values: [2] }),
+        ],
+      }), RECT, 1);
+      expect(rec.texts.find(text => text.fillStyle === '#FF0000')?.text).toBe('33.3%');
+    });
+  }
+
+  it('percent-stacked labels use authored composition, separator, and number format', () => {
+    const rec = recordingCtx();
+    const labels = {
+      showVal: false, showCatName: true, showSerName: false, showPercent: true,
+      separator: '  ', formatCode: '0.0%', position: 'ctr',
+    };
+    renderChart(rec.ctx, baseModel({
+      chartType: 'stackedBarPct', categories: ['A'],
+      series: [
+        series({ name: 'One', values: [1], seriesDataLabels: labels }),
+        series({ name: 'Two', values: [2], seriesDataLabels: labels }),
+      ],
+    }), RECT, 1);
+    expect(rec.texts.some(text => text.text === 'A  33.3%')).toBe(true);
+    expect(rec.texts.some(text => text.text === '33%')).toBe(false);
+  });
+
+  it('per-point text/manual layout/style wins while format, separator, and delete stay indexed', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'line',
+      categories: ['A', 'B'],
+      series: [series({
+        name: 'S',
+        values: [42, 7],
+        seriesDataLabels: {
+          showVal: true, showCatName: true, showSerName: false, showPercent: false,
+          formatCode: '0', separator: ' ', position: 'r',
+        },
+        dataLabelOverrides: [
+          {
+            idx: 0, text: '', showVal: true, showCatName: true,
+            formatCode: '0.0', separator: '|', position: 'l',
+            fontColor: 'FF0000', fontBold: true, fontSizeHpt: 1200,
+            manualLayout: {
+              xMode: 'edge', yMode: 'edge', x: 0.5, y: 0.5, w: 0.1, h: 0.1,
+            },
+          },
+          { idx: 1, text: 'HIDDEN', deleted: true },
+        ],
+      })],
+    }), RECT, 1);
+
+    const label = rec.texts.find(text => text.text === 'A|42.0');
+    expect(label).toMatchObject({ align: 'center', baseline: 'middle', fillStyle: '#FF0000' });
+    expect(label?.font).toContain('bold 12px');
+    expect(rec.texts.some(text => text.text === 'HIDDEN' || text.text === 'B 7')).toBe(false);
+    expect(rec.clips.some(clip => clip.w > 0 && clip.h > 0 && clip.w < RECT.w / 2)).toBe(true);
+  });
 });
 
 describe('CH11 — line/area/scatter data labels honor <c:dLblPos> (§21.2.2.48)', () => {
@@ -3280,7 +3447,7 @@ describe('CH9 — dispBlanksAs="zero" applies to per-point data labels too (§21
 // ─── CH8 — pie / doughnut geometry ───────────────────────────────────────────
 
 interface RingArc { x: number; y: number; r: number; a0: number; a1: number; ccw: boolean }
-interface FontText { text: string; font: string; fill: string }
+interface FontText { text: string; font: string; fill: string; x: number; y: number }
 
 interface RingRecorded {
   ctx: CanvasRenderingContext2D;
@@ -3326,8 +3493,8 @@ function ringRecordingCtx(): RingRecorded {
         case 'fill':
           return () => fills.push(String(state.fillStyle));
         case 'fillText':
-          return (text: string) =>
-            fontTexts.push({ text, font: String(state.font), fill: String(state.fillStyle) });
+          return (text: string, x: number, y: number) =>
+            fontTexts.push({ text, font: String(state.font), fill: String(state.fillStyle), x, y });
         case 'createLinearGradient':
         case 'createRadialGradient':
           return () => ({ addColorStop() {} });
@@ -3557,6 +3724,57 @@ describe('CH8 — pie / doughnut geometry', () => {
     expect(texts).toContain('Alpha');
     expect(texts).toContain('43%');
     expect(texts).not.toContain('Alpha 0.43');
+  });
+
+  it('rich pie percent labels honor authored numFmt and display scale', () => {
+    const model = pieModel({
+      series: [series({
+        name: 'S', categories: ['A', 'B'], values: [1, 2],
+        seriesDataLabels: {
+          showVal: false, showCatName: false, showSerName: false, showPercent: true,
+          formatCode: '0.0%', fontSizeHpt: 1200, position: 'ctr',
+        },
+      })],
+    });
+    const normal = ringRecordingCtx();
+    renderChart(normal.ctx, model, RECT, 1);
+    const scaled = ringRecordingCtx();
+    renderChart(scaled.ctx, model, RECT, 2);
+    expect(normal.fontTexts.some(text => text.text === '33.3%' && text.font.includes('12px')))
+      .toBe(true);
+    expect(scaled.fontTexts.some(text => text.text === '33.3%' && text.font.includes('24px')))
+      .toBe(true);
+  });
+
+  it('inside pie labels respect tiny-slice capacity', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, pieModel({
+      series: [series({
+        name: 'S', categories: ['TINY_LABEL_LONG', 'Large'], values: [1, 999],
+        seriesDataLabels: {
+          showVal: false, showCatName: true, showSerName: false, showPercent: false,
+          position: 'ctr',
+        },
+      })],
+    }), RECT, 1);
+    expect(rec.fontTexts.some(text => text.text === 'TINY_LABEL_LONG')).toBe(false);
+  });
+
+  it('outside pie labels are bounded, elided, and clipped to chart space', () => {
+    const rec = recordingCtx();
+    const long = 'Outside '.repeat(300);
+    renderChart(rec.ctx, pieModel({
+      series: [series({
+        name: 'S', categories: [long, 'B'], values: [1, 1],
+        seriesDataLabels: {
+          showVal: false, showCatName: true, showSerName: false, showPercent: false,
+          position: 'outEnd',
+        },
+      })],
+    }), RECT, 1);
+    expect(rec.texts.some(text => text.text === long)).toBe(false);
+    expect(rec.texts.some(text => text.text.includes('…'))).toBe(true);
+    expect(rec.clips).toContainEqual(RECT);
   });
 });
 
@@ -4976,6 +5194,132 @@ function pieCalloutModel(over: Partial<ChartModel> = {}): ChartModel {
 }
 
 describe('CH14 — pie callout data labels', () => {
+  it('enters rich pie label layout for a per-point label without series defaults', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'pie',
+      categories: ['Only'],
+      series: [series({
+        values: [1],
+        dataLabelOverrides: [{
+          idx: 0,
+          text: 'point only',
+          showVal: false,
+          showCatName: false,
+          showSerName: false,
+          showPercent: false,
+          labelBox: { fill: 'ABCDEF' },
+        }],
+      })],
+    }), RECT, 1);
+
+    expect(rec.texts.map(text => text.text)).toContain('point only');
+    expect(rec.rects.some(rect => rect.fs === '#ABCDEF')).toBe(true);
+  });
+
+  it.each(['ctr', 'inEnd'])(
+    'keeps a point-only callout at its authored %s anchor without boxing siblings',
+    position => {
+      const rec = recordingCtx();
+      renderChart(rec.ctx, baseModel({
+        chartType: 'pie',
+        categories: ['A', 'B'],
+        series: [series({
+          values: [1, 1],
+          seriesDataLabels: {
+            showVal: false,
+            showCatName: true,
+            showSerName: false,
+            showPercent: false,
+            position: 'outEnd',
+          },
+          dataLabelOverrides: [{
+            idx: 0,
+            text: 'A',
+            position,
+            labelBox: { fill: 'ABCDEF' },
+          }],
+        })],
+      }), RECT, 1);
+
+      const boxes = rec.rects.filter(rect => rect.fs === '#ABCDEF');
+      expect(boxes).toHaveLength(1);
+      const box = boxes[0];
+      const center = rec.arcs[0];
+      const outerR = Math.max(...rec.arcs.map(arc => arc.r));
+      const boxDistance = Math.hypot(
+        box.x + box.w / 2 - center.x,
+        box.y + box.h / 2 - center.y,
+      );
+      expect(boxDistance).toBeLessThan(outerR);
+      const sibling = rec.texts.find(text => text.text === 'B');
+      expect(sibling).toBeDefined();
+      expect(Math.hypot(sibling!.x - center.x, sibling!.y - center.y)).toBeGreaterThan(outerR);
+    },
+  );
+
+  it('composes a per-point show flag without series label defaults', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'pie',
+      categories: ['Only'],
+      series: [series({ values: [1], dataLabelOverrides: [{ idx: 0, text: '', showPercent: true }] })],
+    }), RECT, 1);
+    expect(rec.texts.map(text => text.text)).toContain('100%');
+  });
+
+  it('applies a per-point manual pie layout without series label defaults', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'pie',
+      categories: ['Only'],
+      series: [series({
+        values: [1],
+        dataLabelOverrides: [{
+          idx: 0,
+          text: 'manual point',
+          manualLayout: { xMode: 'edge', yMode: 'edge', x: 0.5, y: 0.5, w: 0.2, h: 0.1 },
+        }],
+      })],
+    }), RECT, 1);
+    expect(rec.texts.find(text => text.text === 'manual point')).toMatchObject({ x: 384, y: 198 });
+  });
+
+  it('keeps a per-point delete from falling back to legacy pie percentages', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'pie',
+      showDataLabels: true,
+      categories: ['Only'],
+      series: [series({ values: [1], dataLabelOverrides: [{ idx: 0, text: '', deleted: true }] })],
+    }), RECT, 1);
+    expect(rec.texts.map(text => text.text)).not.toContain('100%');
+  });
+
+  it('anchors an outer-ring doughnut label in that ring rather than the full doughnut band', () => {
+    const rec = ringRecordingCtx();
+    renderChart(rec.ctx, baseModel({
+      chartType: 'doughnut',
+      holeSize: 50,
+      categories: ['A', 'B'],
+      series: [
+        series({
+          name: 'Outer',
+          values: [1, 1],
+          dataLabelOverrides: [{ idx: 0, text: 'outer-ring' }],
+        }),
+        series({ name: 'Inner', values: [1, 1] }),
+      ],
+    }), RECT, 1);
+
+    const radii = [...new Set(rec.arcs.map(arc => arc.r))].sort((a, b) => b - a);
+    const outerLabel = rec.fontTexts.find(text => text.text === 'outer-ring');
+    expect(radii.length).toBeGreaterThanOrEqual(3);
+    expect(outerLabel).toBeDefined();
+    const centerX = rec.arcs[0].x;
+    expect(outerLabel!.x - centerX).toBeCloseTo((radii[0] + radii[1]) / 2, 3);
+  });
+
   it('draws a filled callout box per slice (category name + percent on separate lines)', () => {
     const rec = recordingCtx();
     renderChart(rec.ctx, pieCalloutModel(), RECT, 1);
@@ -5030,6 +5374,28 @@ describe('CH14 — pie callout data labels', () => {
     // leader; assert at least one leader segment exists in that color.
     const leaders = rec.segs.filter(s => s.ss === '#A6A6A6');
     expect(leaders.length).toBeGreaterThan(0);
+  });
+
+  it('applies authored manual width and height to callout paint and text bounds', () => {
+    const rec = recordingCtx();
+    const model = pieCalloutModel();
+    model.series[0].dataLabelOverrides = [{
+      idx: 0,
+      text: 'A long manually sized callout label',
+      manualLayout: {
+        xMode: 'edge', yMode: 'edge', x: 0.25, y: 0.25, w: 0.2, h: 0.1,
+      },
+      labelBox: { fill: 'FFFFFF', borderColor: '4472C4', borderWidthEmu: 12700 },
+    }];
+    renderChart(rec.ctx, model, RECT, 1);
+    expect(rec.rects.some(box =>
+      box.fs === '#FFFFFF'
+      && Math.abs(box.x - 160) < 1e-6
+      && Math.abs(box.y - 90) < 1e-6
+      && Math.abs(box.w - 128) < 1e-6
+      && Math.abs(box.h - 36) < 1e-6
+    )).toBe(true);
+    expect(rec.texts.some(text => text.text.includes('…'))).toBe(true);
   });
 
   it('keeps plain-text labels (no boxes) when the dLbls carries no box shape', () => {
@@ -6119,6 +6485,40 @@ describe('CH15 — chartEx sunburst', () => {
     expect(rec.rotates[0]).toBeCloseTo(Math.PI / 6, 5);
   });
 
+  it('bounds a long authored sunburst label and preserves whitespace', () => {
+    const rec = ringRecordingCtx();
+    const authored = `A  ${'x'.repeat(5000)}`;
+    renderChart(rec.ctx, sunburstModel({
+      series: [series({
+        values: [],
+        dataLabelOverrides: [{ idx: 0, text: authored, fontColor: '123456', position: 'ctr' }],
+      })],
+    }), RECT, 1);
+
+    const labels = rec.fontTexts.filter(text => text.fill === '#123456');
+    expect(labels.length).toBeGreaterThan(0);
+    expect(labels.length).toBeLessThanOrEqual(4);
+    expect(labels.map(text => text.text).join('')).toContain('A  ');
+    expect(labels.map(text => text.text)).not.toContain(authored);
+  });
+
+  it('applies authored sunburst manual layout in chart coordinates', () => {
+    const rec = recordingCtx();
+    renderChart(rec.ctx, sunburstModel({
+      series: [series({
+        values: [],
+        dataLabelOverrides: [{
+          idx: 0,
+          text: 'manual sunburst',
+          fontColor: '123456',
+          manualLayout: { xMode: 'edge', yMode: 'edge', x: 0.5, y: 0.5, w: 0.2, h: 0.1 },
+        }],
+      })],
+    }), RECT, 1);
+
+    expect(rec.texts.find(text => text.text === 'manual sunburst')).toMatchObject({ x: 384, y: 198 });
+  });
+
   it('sweeps each branch proportional to its aggregated size (Branch A twice Branch B)', () => {
     const rec = ringRecordingCtx();
     renderChart(rec.ctx, sunburstModel(), RECT, 1);
@@ -6590,7 +6990,7 @@ describe('CH15 — chartEx treemap', () => {
     expect(rec.strokeRects).toHaveLength(0);
   });
 
-  it('wraps an over-wide inEnd leaf label without replacing it with an ellipsis', () => {
+  it('bounds an over-wide inEnd leaf label to the shared four-line limit', () => {
     const rec = recordingCtx();
     const model = baseModel({
       chartType: 'treemap',
@@ -6617,13 +7017,14 @@ describe('CH15 — chartEx treemap', () => {
     renderChart(rec.ctx, model, { x: 0, y: 0, w: 180, h: 180 }, 1);
 
     const narrow = [...rec.strokeRects].sort((a, b) => a.w - b.w)[0];
-    const narrowText = rec.texts
+    const narrowLabels = rec.texts
       .filter(text => text.baseline === 'bottom' && text.x >= narrow.x && text.x <= narrow.x + narrow.w)
-      .sort((a, b) => a.y - b.y)
+      .sort((a, b) => a.y - b.y);
+    const narrowText = narrowLabels
       .map(text => text.text)
       .join('');
-    expect(narrowText).toBe('A-medium');
-    expect(rec.texts.map(text => text.text)).not.toContain('…');
+    expect(narrowText).toBe('A-m…');
+    expect(narrowLabels).toHaveLength(4);
   });
 
   it('clips centered leaf labels and limits them to the tile height', () => {
@@ -6750,10 +7151,25 @@ describe('CH15 — chartEx treemap', () => {
       dataLabelOverrides: [{ idx: 4, text: 'Custom East\n20', fontColor: '222222' }],
     })];
     renderChart(rec.ctx, model, RECT, 1);
-    const custom = rec.texts.filter(text => text.text === 'Custom East' || text.text === '20');
+    const custom = rec.texts.filter(text =>
+      (text.text === 'Custom East' || text.text === '20') && text.fillStyle === '#222222'
+    );
     expect(custom.map(text => text.text)).toEqual(expect.arrayContaining(['Custom East', '20']));
-    expect(custom.every(text => text.fillStyle === '#222222')).toBe(true);
     expect(rec.texts.map(text => text.text)).not.toContain('East');
+  });
+
+  it('applies authored treemap manual layout in chart coordinates', () => {
+    const rec = recordingCtx();
+    const model = treemapModel();
+    model.series[0].dataLabelOverrides = [{
+      idx: 1,
+      text: 'manual tile',
+      fontColor: '123456',
+      manualLayout: { xMode: 'edge', yMode: 'edge', x: 0.5, y: 0.5, w: 0.2, h: 0.1 },
+    }];
+    renderChart(rec.ctx, model, RECT, 1);
+
+    expect(rec.texts.find(text => text.text === 'manual tile')).toMatchObject({ x: 384, y: 198 });
   });
 
   it('honors dataLabelHidden for treemap parent nodes', () => {

--- a/packages/core/src/chart/renderer.ts
+++ b/packages/core/src/chart/renderer.ts
@@ -48,6 +48,13 @@ import {
 } from './box-whisker.js';
 import { planParetoLayout } from './pareto-layout.js';
 import { placeTrendlineLabel } from './trendline-label.js';
+import {
+  boundDataLabelText,
+  fitDataLabelLines,
+  resolveDataLabelPlacement,
+  type DataLabelAnchor,
+  type DataLabelRect,
+} from './data-label-layout.js';
 import { hexToRgba, resolveFill } from '../shape/paint.js';
 import {
   DEFAULT_TEXT_INSET_LR_EMU,
@@ -1659,6 +1666,54 @@ function chartCategories(chart: ChartModel): string[] {
   return n > 0 ? Array.from({ length: n }, (_, i) => String(i + 1)) : [];
 }
 
+interface EffectiveDataLabelTextOptions {
+  customText?: string | null;
+  showCategory?: boolean;
+  showSeries?: boolean;
+  showValue?: boolean;
+  showPercent?: boolean;
+  category?: string;
+  seriesName?: string;
+  sourceValue?: number;
+  percentRatio?: number;
+  formatCode?: string | null;
+  percentFormatCode?: string | null;
+  date1904?: boolean;
+  separator?: string | null;
+  defaultSeparator?: string;
+}
+
+/** Compose authored data-label content once, independently from its anchor. */
+function effectiveDataLabelText(options: EffectiveDataLabelTextOptions): string {
+  if (options.customText) return options.customText;
+  const parts: string[] = [];
+  if (options.showCategory && options.category) parts.push(options.category);
+  if (options.showSeries && options.seriesName) parts.push(options.seriesName);
+  if (options.showValue && options.sourceValue != null) {
+    parts.push(formatChartValWithCode(
+      options.sourceValue, options.formatCode ?? null, options.date1904,
+    ));
+  }
+  if (options.showPercent && options.percentRatio != null) {
+    parts.push(formatChartValWithCode(
+      options.percentRatio,
+      options.percentFormatCode ?? options.formatCode ?? '0%',
+      options.date1904,
+    ));
+  }
+  return parts.filter(part => part !== '').join(
+    options.separator ?? options.defaultSeparator ?? ' ',
+  );
+}
+
+function dataLabelRectIntersection(a: DataLabelRect, b: DataLabelRect): DataLabelRect | null {
+  const x = Math.max(a.x, b.x);
+  const y = Math.max(a.y, b.y);
+  const right = Math.min(a.x + a.w, b.x + b.w);
+  const bottom = Math.min(a.y + a.h, b.y + b.h);
+  return right > x && bottom > y ? { x, y, w: right - x, h: bottom - y } : null;
+}
+
 /**
  * Draw a bar data label with the ECMA-376 §21.2.2.16 `dLblPos` semantics.
  *
@@ -1677,54 +1732,25 @@ function drawBarDataLabel(
   orient: 'vertical' | 'horizontal',
   position: string | null,
   color: string | null,
+  fontSizePx: number,
+  bounds: DataLabelRect,
+  layoutReferenceRect: DataLabelRect,
+  manualLayout?: ChartDataLabelOverride['manualLayout'],
   negative = false,
 ): void {
-  const pos = (position ?? 'outEnd');
-  const fill = color ? `#${color}` : '#333';
-  ctx.fillStyle = fill;
-  if (orient === 'vertical') {
-    // bx/by = top-left of bar rect, barL = bar height, barW = bar width. For a
-    // positive column the value END is the TOP edge (`by`) and the BASE the
-    // bottom (`by + barL`); for a negative column those swap (the bar hangs
-    // below the zero line, so its end is the bottom).
-    const cx = bx + barW / 2;
-    const endY  = negative ? by + barL : by;         // the far (value) edge
-    const baseY = negative ? by : by + barL;          // the zero-line edge
-    if (pos === 'inBase') {
-      ctx.textAlign = 'center'; ctx.textBaseline = negative ? 'top' : 'bottom';
-      ctx.fillText(text, cx, negative ? baseY + 2 : baseY - 2);
-    } else if (pos === 'inEnd') {
-      ctx.textAlign = 'center'; ctx.textBaseline = negative ? 'bottom' : 'top';
-      ctx.fillText(text, cx, negative ? endY - 2 : endY + 2);
-    } else if (pos === 'ctr') {
-      ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-      ctx.fillText(text, cx, by + barL / 2);
-    } else {
-      // outEnd / default: just beyond the value edge.
-      ctx.textAlign = 'center'; ctx.textBaseline = negative ? 'top' : 'bottom';
-      ctx.fillText(text, cx, negative ? endY + 1 : endY - 1);
-    }
-  } else {
-    // Horizontal: positive bars grow to the RIGHT from bx, negative bars to the
-    // left (so the value END is the LEFT edge `bx` and the BASE the right edge).
-    const cy = by + barW / 2;
-    const endX  = negative ? bx : bx + barL;          // the far (value) edge
-    const baseX = negative ? bx + barL : bx;          // the zero-line edge
-    if (pos === 'inBase') {
-      ctx.textAlign = negative ? 'right' : 'left'; ctx.textBaseline = 'middle';
-      ctx.fillText(text, negative ? baseX - 4 : baseX + 4, cy);
-    } else if (pos === 'inEnd') {
-      ctx.textAlign = negative ? 'left' : 'right'; ctx.textBaseline = 'middle';
-      ctx.fillText(text, negative ? endX + 4 : endX - 4, cy);
-    } else if (pos === 'ctr') {
-      ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-      ctx.fillText(text, bx + barL / 2, cy);
-    } else {
-      // outEnd / default: just past the value edge.
-      ctx.textAlign = negative ? 'right' : 'left'; ctx.textBaseline = 'middle';
-      ctx.fillText(text, negative ? endX - 2 : endX + 2, cy);
-    }
-  }
+  const rect = orient === 'vertical'
+    ? { x: bx, y: by, w: barW, h: barL }
+    : { x: bx, y: by, w: barL, h: barW };
+  drawBoundedDataLabelText(
+    ctx,
+    text,
+    { kind: 'bar', rect, orientation: orient, negative, position: position ?? 'outEnd' },
+    bounds,
+    fontSizePx,
+    color ? `#${color}` : '#333',
+    manualLayout,
+    layoutReferenceRect,
+  );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -2460,9 +2486,15 @@ function renderBarChart(
         }
         const seriesLabels = s.seriesDataLabels;
         const label = resolveChartExLabel(
-          chart, s, ci, s.categories?.[ci] ?? cats[ci] ?? '', sv,
-          { visible: chart.showDataLabels, showVal: chart.showDataLabels, showCatName: false },
+          chart, s, ci, s.categories?.[ci] ?? cats[ci] ?? '', raw,
+          {
+            visible: chart.showDataLabels,
+            showVal: chart.showDataLabels && !pct,
+            showPercent: chart.showDataLabels && pct,
+            showCatName: false,
+          },
           labelOverrides[si],
+          pct ? sv / 100 : undefined,
         );
         if (label) {
           // ECMA-376 §21.2.2.30 / §21.1.2.3.2 — data label font size comes from
@@ -2477,9 +2509,6 @@ function renderBarChart(
           const bold = label.fontBold
             || (seriesLabels?.fontBold == null && authoredLabel?.fontBold == null);
           ctx.font = `${bold ? 'bold ' : ''}${lsz}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
-          const text = pct && authoredLabel?.text == null
-            ? `${Math.round(sv)}%`
-            : label.text;
           // drawBarDataLabel takes (bx, by, barL=length, barW=thickness). For
           // a vertical column bar, "length" is the bar's height and
           // "thickness" is its horizontal width — pass them in that order.
@@ -2488,11 +2517,15 @@ function renderBarChart(
           // inside the helper) use the bar's HEIGHT instead of its width,
           // pushing data labels far to the right of the bar.
           drawBarDataLabel(
-            ctx, text,
+            ctx, label.text,
             bx, by, barH, barW,
             'vertical',
             label.position ?? chart.dataLabelPosition ?? (stacked ? 'ctr' : null),
             s.dataLabelColors?.[ci] ?? label.fontColor ?? s.labelColor ?? chart.dataLabelFontColor ?? null,
+            lsz,
+            { x: px0, y: py0, w: pw, h: ph },
+            { x, y, w, h },
+            authoredLabel?.manualLayout,
             negative,
           );
         }
@@ -2528,9 +2561,15 @@ function renderBarChart(
         }
         const seriesLabels = s.seriesDataLabels;
         const label = resolveChartExLabel(
-          chart, s, ci, s.categories?.[ci] ?? cats[ci] ?? '', sv,
-          { visible: chart.showDataLabels, showVal: chart.showDataLabels, showCatName: false },
+          chart, s, ci, s.categories?.[ci] ?? cats[ci] ?? '', raw,
+          {
+            visible: chart.showDataLabels,
+            showVal: chart.showDataLabels && !pct,
+            showPercent: chart.showDataLabels && pct,
+            showCatName: false,
+          },
           labelOverrides[si],
+          pct ? sv / 100 : undefined,
         );
         if (label) {
           const sizeHpt = label.fontSizeHpt ?? chart.dataLabelFontSizeHpt;
@@ -2541,15 +2580,16 @@ function renderBarChart(
           const bold = label.fontBold
             || (seriesLabels?.fontBold == null && authoredLabel?.fontBold == null);
           ctx.font = `${bold ? 'bold ' : ''}${lsz}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
-          const text = pct && authoredLabel?.text == null
-            ? `${Math.round(sv)}%`
-            : label.text;
           drawBarDataLabel(
-            ctx, text,
+            ctx, label.text,
             bx, by, barL, barW,
             'horizontal',
             label.position ?? chart.dataLabelPosition ?? (stacked ? 'ctr' : null),
             s.dataLabelColors?.[ci] ?? label.fontColor ?? s.labelColor ?? chart.dataLabelFontColor ?? null,
+            lsz,
+            { x: px0, y: py0, w: pw, h: ph },
+            { x, y, w, h },
+            authoredLabel?.manualLayout,
             negative,
           );
         }
@@ -2716,6 +2756,7 @@ function renderBarChart(
         ptToPx,
         false,
         chart.scatterStyle ?? 'marker',
+        { x, y, w, h },
       );
     }
   }
@@ -3138,6 +3179,11 @@ function renderLineChart(
       // the chart-level position, else PowerPoint's line-chart default `'r'`
       // (right of the point).
       chart.dataLabelPosition ?? 'r',
+      { x: px0, y: py0, w: pw, h: ph },
+      { x, y, w, h },
+      pct && pctTotals
+        ? ci => (s.values[ci] ?? 0) / pctTotals[ci]
+        : undefined,
     );
     if (perPointLabels) ctx.fillStyle = color;
     for (let ci = 0; ci < n; ci++) {
@@ -3167,10 +3213,11 @@ function renderLineChart(
         // clears the dot (2px when there is no marker), matching the prior clear
         // distance but now direction-aware.
         drawDataLabelText(
-          ctx, toX(ci), yOf(pv), formatChartVal(pv),
+          ctx, toX(ci), yOf(pv), formatChartVal(s.values[ci] ?? 0),
           chart.dataLabelPosition ?? 'r', dataLabelPx, undefined, false,
           chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
           drawMarkers ? markerR + 1 : 2,
+          { x: px0, y: py0, w: pw, h: ph },
         );
         ctx.fillStyle = color;
       }
@@ -3874,6 +3921,11 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
         // area-chart default `'ctr'` (centered on the point, ECMA-376 default
         // for the areaChart group).
         chart.dataLabelPosition ?? 'ctr',
+        { x: px0, y: py0, w: pw, h: ph },
+        { x, y, w, h },
+        pct && pctTotals
+          ? ci => (s.values[ci] ?? 0) / pctTotals[ci]
+          : undefined,
       );
     }
   }
@@ -3930,6 +3982,8 @@ function renderAreaChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Ch
     drawCategoryDataLabels(
       ctx, s, cats, n, toX, yOf, plottedOf, ph, ptToPx, chart.date1904 ?? false, false,
       chartFontFamily(chart, chart.dataLabelFontFace, 'minor'), chart.dataLabelPosition ?? 'r',
+      { x: px0, y: py0, w: pw, h: ph },
+      { x, y, w, h },
     );
     drawSeriesTrendlines(
       ctx, s, stroke, toX, yOf, ptToPx, undefined,
@@ -4118,9 +4172,16 @@ function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // `<c:dLbls>` definition; the rich labels are drawn in a separate pass after
   // all slices. Keeping the legacy path inline preserves the historical
   // draw-call order for a plain pie/doughnut (byte-stable).
-  const richDef = s.seriesDataLabels;
-  const hasRichLabels = richDef != null &&
-    (richDef.showVal || richDef.showCatName || richDef.showSerName || richDef.showPercent);
+  const richDef: ChartSeriesDataLabels = s.seriesDataLabels ?? {
+    showVal: false,
+    showCatName: false,
+    showSerName: false,
+    showPercent: false,
+  };
+  // A point-level dLbl is independently authored and must not depend on a
+  // series dLbls default existing. Even a delete-only override participates in
+  // rich dispatch so the legacy chart-wide percent path cannot resurrect it.
+  const hasRichLabels = s.seriesDataLabels != null || (s.dataLabelOverrides?.length ?? 0) > 0;
   const legacyLabels = chart.showDataLabels && !hasRichLabels;
   const dLblFont = chartFontFamily(chart, chart.dataLabelFontFace, 'minor');
 
@@ -4176,9 +4237,10 @@ function renderPieChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r: Cha
   // slices. Only runs when a rich definition is present; the plain percent
   // labels above are byte-identical to the pre-CH8 pie.
   if (hasRichLabels) {
+    const outerRingInnerR = isDoughnut ? outerR - ringBand : 0;
     drawPieRichLabels(
       ctx, chart, richDef, s, cats, vals, total,
-      cx2, cy2, outerR, innerR, startAngle, dLblFont, ptToPx,
+      cx2, cy2, outerR, outerRingInnerR, startAngle, dLblFont, ptToPx,
       plotLeft, plotTop, pw, ph,
       x, y, w, h,
     );
@@ -4228,21 +4290,30 @@ function drawPieRichLabels(
   plotX: number, plotY: number, plotW: number, plotH: number,
   chartX: number, chartY: number, chartW: number, chartH: number,
 ): void {
-  // Callout mode: a `<c:spPr>` box shape on the dLbls (Word's boxed pie labels).
-  // Labels de-overlap and clamp inside the PLOT rect (not the full chart rect),
-  // so the topmost box cannot ride up into the title band above the plot.
-  if (def.labelBox) {
-    drawPieCalloutLabels(ctx, chart, def, s, cats, vals, total, cx2, cy2, outerR, startAngle, font, ptToPx, plotX, plotW, plotY, plotH);
-    return;
+  const overrides = s.dataLabelOverrides ?? [];
+  const calloutIndices = new Set<number>();
+  for (let index = 0; index < vals.length; index++) {
+    const override = overrides.find(item => item.idx === index);
+    if (override?.labelBox || def.labelBox) calloutIndices.add(index);
+  }
+  // Boxed labels have their own paint/collision pass, but only those points are
+  // dispatched to it. A per-point spPr must not turn every sibling into a
+  // callout or change the sibling's authored radial position.
+  if (calloutIndices.size > 0) {
+    drawPieCalloutLabels(
+      ctx, chart, def, s, cats, vals, total, cx2, cy2, outerR, innerR, startAngle,
+      font, ptToPx, plotX, plotW, plotY, plotH, chartX, chartY, chartW, chartH,
+      calloutIndices,
+    );
   }
 
-  const overrides = s.dataLabelOverrides ?? [];
   const outsideLabels: PieOutsideLabel[] = [];
   let angle = startAngle;
   for (let i = 0; i < vals.length; i++) {
     const slice = (vals[i] / total) * Math.PI * 2;
     const midAngle = angle + slice / 2;
     angle += slice;
+    if (calloutIndices.has(i)) continue;
     // A per-point `<c:dLbl idx>` (§21.2.2.47) overrides the series-level
     // `<c:dLbls>` (§21.2.2.49) for this one slice. Its show-flags, font color /
     // size / bold, and position each fall back to the series default when the
@@ -4264,34 +4335,69 @@ function drawPieRichLabels(
     // override text) wins outright; otherwise compose from the resolved flags.
     // Positioning is handled below (§21.2.2.48 `dLblPos`). Percent is the
     // slice's share of the total.
-    let text: string;
-    if (ov && ov.text) {
-      text = ov.text;
-    } else {
-      const parts: string[] = [];
-      if (showCatName) parts.push((cats[i] ?? '').toString());
-      if (showSerName) parts.push(s.name);
-      if (showVal) parts.push(formatChartValWithCode(vals[i], def.formatCode ?? s.valFormatCode ?? null, chart.date1904 ?? false));
-      if (showPercent) parts.push(`${Math.round((vals[i] / total) * 100)}%`);
-      text = parts.filter(Boolean).join(def.separator ?? ' ');
-    }
+    const text = effectiveDataLabelText({
+      customText: ov?.text,
+      showCategory: showCatName,
+      showSeries: showSerName,
+      showValue: showVal,
+      showPercent,
+      category: (cats[i] ?? '').toString(),
+      seriesName: s.name,
+      sourceValue: vals[i],
+      percentRatio: vals[i] / total,
+      formatCode: ov?.formatCode ?? def.formatCode ?? s.valFormatCode ?? null,
+      percentFormatCode: ov?.formatCode ?? def.formatCode ?? '0%',
+      date1904: chart.date1904 ?? false,
+      separator: ov?.separator ?? def.separator,
+    });
     if (!text) continue;
     const pos = ov?.position ?? def.position ?? 'bestFit';
     const outside = pos === 'outEnd';
     const sizeHpt = ov?.fontSizeHpt ?? def.fontSizeHpt;
-    const sizePx = sizeHpt ? sizeHpt / 100 : Math.max(8, outerR * 0.1);
+    const sizePx = sizeHpt ? (sizeHpt / 100) * ptToPx : Math.max(8, outerR * 0.1);
     const bold = ov?.fontBold ?? def.fontBold;
     const fontColor = ov?.fontColor ?? def.fontColor;
-    const lines = text.split(/\r?\n/);
+    const automaticLabelR = innerR > 0.01
+      ? (innerR + outerR) / 2
+      : outerR * PIE_CTR_LABEL_RADIUS_FRAC;
+    if (ov?.manualLayout) {
+      ctx.font = `${bold ? 'bold ' : ''}${sizePx}px ${font}`;
+      drawBoundedDataLabelText(
+        ctx,
+        text,
+        {
+          kind: 'point',
+          x: cx2 + Math.cos(midAngle) * automaticLabelR,
+          y: cy2 + Math.sin(midAngle) * automaticLabelR,
+          position: 'ctr',
+        },
+        { x: plotX, y: plotY, w: plotW, h: plotH },
+        sizePx,
+        fontColor ? `#${fontColor}` : '#fff',
+        ov.manualLayout,
+        { x: chartX, y: chartY, w: chartW, h: chartH },
+      );
+      continue;
+    }
     if (outside) {
       ctx.font = `${bold ? 'bold ' : ''}${sizePx}px ${font}`;
-      const textW = lines.reduce((max, line) => Math.max(max, ctx.measureText(line).width), 0);
       const lineHeight = sizePx * 1.15;
-      const textH = sizePx + Math.max(0, lines.length - 1) * lineHeight;
+      const fittedLines = fitDataLabelLines(
+        text,
+        Math.max(0, chartW - sizePx),
+        Math.max(0, chartH - sizePx),
+        lineHeight,
+        value => ctx.measureText(value).width,
+      );
+      if (fittedLines.length === 0) continue;
+      const textW = fittedLines.reduce(
+        (max, line) => Math.max(max, ctx.measureText(line).width), 0,
+      );
+      const textH = sizePx + Math.max(0, fittedLines.length - 1) * lineHeight;
       outsideLabels.push(createPieOutsideLabel(
-        lines, midAngle, cx2, cy2, outerR,
+        fittedLines, midAngle, cx2, cy2, outerR,
         textW, textH, lineHeight, sizePx, bold ?? false,
-        fontColor ? `#${fontColor}` : '#333', ptToPx,
+        fontColor ? `#${fontColor}` : '#333',
       ));
       continue;
     }
@@ -4311,17 +4417,36 @@ function drawPieRichLabels(
     //     sector centroid. The 5% sliver rides marginally further out in
     //     PowerPoint; we do not model that per-slice nudge. This is an empirical
     //     approximation of an undocumented PowerPoint layout, not a spec formula.
-    const labelR = innerR > 0.01
-        ? (innerR + outerR) / 2
-        : outerR * PIE_CTR_LABEL_RADIUS_FRAC;
+    const labelR = automaticLabelR;
     const lx2 = cx2 + Math.cos(midAngle) * labelR;
     const ly2 = cy2 + Math.sin(midAngle) * labelR;
     ctx.font = `${bold ? 'bold ' : ''}${sizePx}px ${font}`;
-    ctx.fillStyle = fontColor ? `#${fontColor}` : '#fff';
-    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-    const lineHeight = sizePx * 1.15;
-    const firstY = ly2 - ((lines.length - 1) * lineHeight) / 2;
-    lines.forEach((line, lineIndex) => ctx.fillText(line, lx2, firstY + lineIndex * lineHeight));
+    const tangentialCapacity = 2 * labelR * Math.sin(Math.min(Math.PI, Math.abs(slice)) / 2)
+      - sizePx;
+    const radialCapacity = innerR > 0.01
+      ? outerR - innerR - sizePx
+      : outerR - sizePx;
+    if (!(tangentialCapacity > 0) || !(radialCapacity > 0)) continue;
+    const sliceBounds = dataLabelRectIntersection(
+      {
+        x: lx2 - tangentialCapacity / 2,
+        y: ly2 - radialCapacity / 2,
+        w: tangentialCapacity,
+        h: radialCapacity,
+      },
+      { x: plotX, y: plotY, w: plotW, h: plotH },
+    );
+    if (!sliceBounds) continue;
+    drawBoundedDataLabelText(
+      ctx,
+      text,
+      { kind: 'point', x: lx2, y: ly2, position: 'ctr' },
+      sliceBounds,
+      sizePx,
+      fontColor ? `#${fontColor}` : '#fff',
+      undefined,
+      { x: chartX, y: chartY, w: chartW, h: chartH },
+    );
   }
 
   drawPieOutsideLabels(
@@ -4397,12 +4522,8 @@ function createPieOutsideLabel(
   fontPx: number,
   bold: boolean,
   fontColor: string,
-  ptToPx: number,
 ): PieOutsideLabel {
-  // One typographic point prevents antialiasing at the tangent from visually
-  // merging the glyph edge with the slice. It is a rendering clearance, not an
-  // Office-layout estimate; the outside invariant itself comes from outEnd.
-  const clearance = ptToPx;
+  const clearance = fontPx * 0.5;
   const distance = outsideLabelRadialDistance(
     midAngle, outerR, boxW / 2, boxH / 2, clearance,
   );
@@ -4461,8 +4582,8 @@ function drawPieOutsideLabels(
   // Re-solve horizontal placement after collision movement. For a fixed label
   // y-range, the nearest vertical distance to the pie centre determines the
   // exact horizontal clearance required for the full rectangle.
-  const target = outerR + ptToPx;
   for (const label of labels) {
+    const target = outerR + label.fontPx * 0.5;
     const halfW = label.boxW / 2;
     const halfH = label.boxH / 2;
     const nearestDy = Math.max(Math.abs(label.cyBox - pieCy) - halfH, 0);
@@ -4481,6 +4602,10 @@ function drawPieOutsideLabels(
     }
   }
 
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(boundsX, boundsY, boundsW, boundsH);
+  ctx.clip();
   const leaderColor = def.leaderLineColor ? `#${def.leaderLineColor}` : '#a6a6a6';
   const leaderPx = def.leaderLineWidthEmu
     ? Math.max(0.5, (def.leaderLineWidthEmu / EMU_PER_PT) * ptToPx)
@@ -4509,12 +4634,14 @@ function drawPieOutsideLabels(
       ctx.fillText(label.lines[i], label.cxBox, firstY + i * label.lineHeight);
     }
   }
+  ctx.restore();
 }
 
 /** One laid-out pie callout label: its wrapped text lines, box rectangle, the
  *  rim anchor point on its slice, and the resolved per-point style. */
 interface PieCalloutLabel {
   lines: string[];
+  lineHeight: number;
   /** Slice mid-angle (canvas radians) — the leader-line target direction. */
   midAngle: number;
   /** Rim anchor point (on the outer arc at `midAngle`). */
@@ -4534,6 +4661,10 @@ interface PieCalloutLabel {
   boxBorderPx: number;
   fontPx: number;
   bold: boolean;
+  /** An authored inside position keeps the box at its slice anchor. */
+  inside: boolean;
+  /** Explicit per-point manual layout is never moved by the auto collision pass. */
+  manualClip?: DataLabelRect;
 }
 
 /** Word-style boxed pie/doughnut callout labels (`bestFit`). Each label is a
@@ -4553,22 +4684,22 @@ function drawPieCalloutLabels(
   vals: number[],
   total: number,
   cx2: number, cy2: number,
-  outerR: number,
+  outerR: number, innerR: number,
   startAngle: number,
   font: string,
   ptToPx: number,
   boundsX: number, boundsW: number, boundsY: number, boundsH: number,
+  chartX: number, chartY: number, chartW: number, chartH: number,
+  indices: ReadonlySet<number>,
 ): void {
   const overrides = s.dataLabelOverrides ?? [];
   const findOverride = (i: number): ChartDataLabelOverride | undefined =>
     overrides.find(o => o.idx === i);
 
   // Base font size: series default (hpt → px) or a radius-relative fallback.
-  const baseFontPx = def.fontSizeHpt ? def.fontSizeHpt / 100 : Math.max(9, outerR * 0.09);
-  // Box padding around the text block (px). Geometry, not a spec constant.
-  const padX = Math.max(4, baseFontPx * 0.45);
-  const padY = Math.max(2, baseFontPx * 0.28);
-  const lineGap = baseFontPx * 0.22;
+  const baseFontPx = def.fontSizeHpt
+    ? (def.fontSizeHpt / 100) * ptToPx
+    : Math.max(9, outerR * 0.09);
 
   const seriesBox = def.labelBox;
 
@@ -4580,6 +4711,7 @@ function drawPieCalloutLabels(
     const midAngle = angle + slice / 2;
     angle += slice;
     if (slice <= 0) continue;
+    if (!indices.has(i)) continue;
 
     const ov = findOverride(i);
     // A genuine `<c:delete val="1"/>` (§21.2.2.43) skips the label; a per-point
@@ -4595,19 +4727,8 @@ function drawPieCalloutLabels(
     const showSerName = ov?.showSerName ?? def.showSerName;
     const showVal     = ov?.showVal ?? def.showVal;
     const showPercent = ov?.showPercent ?? def.showPercent;
-    const lines: string[] = [];
-    if (ov && ov.text) {
-      lines.push(ov.text);
-    } else {
-      if (showCatName) { const c = (cats[i] ?? '').toString(); if (c) lines.push(c); }
-      if (showSerName && s.name) lines.push(s.name);
-      if (showVal) lines.push(formatChartValWithCode(vals[i], def.formatCode ?? s.valFormatCode ?? null, chart.date1904 ?? false));
-      if (showPercent) lines.push(`${Math.round((vals[i] / total) * 100)}%`);
-    }
-    if (lines.length === 0) continue;
-
     // Per-point overrides (font colour/size/bold + box), else series defaults.
-    const fontPx = ov?.fontSizeHpt ? ov.fontSizeHpt / 100 : baseFontPx;
+    const fontPx = ov?.fontSizeHpt ? (ov.fontSizeHpt / 100) * ptToPx : baseFontPx;
     const bold = ov?.fontBold ?? def.fontBold ?? false;
     const fontColor = ov?.fontColor ? `#${ov.fontColor}` : (def.fontColor ? `#${def.fontColor}` : '#000');
     const box = ov?.labelBox ?? seriesBox;
@@ -4616,28 +4737,139 @@ function drawPieCalloutLabels(
     const boxBorderPx = box?.borderWidthEmu
       ? Math.max(0.75, (box.borderWidthEmu / EMU_PER_PT) * ptToPx)
       : 1;
+    const position = ov?.position ?? def.position ?? 'bestFit';
 
-    // Measure the widest line to size the box.
+    const text = effectiveDataLabelText({
+      customText: ov?.text,
+      showCategory: showCatName,
+      showSeries: showSerName,
+      showValue: showVal,
+      showPercent,
+      category: (cats[i] ?? '').toString(),
+      seriesName: s.name,
+      sourceValue: vals[i],
+      percentRatio: vals[i] / total,
+      formatCode: ov?.formatCode ?? def.formatCode ?? s.valFormatCode ?? null,
+      percentFormatCode: ov?.formatCode ?? def.formatCode ?? '0%',
+      date1904: chart.date1904 ?? false,
+      separator: ov?.separator ?? def.separator,
+      defaultSeparator: '\n',
+    });
+    if (!text) continue;
+
+    const padX = Math.max(4, fontPx * 0.45);
+    const padY = Math.max(2, fontPx * 0.28);
+    const lineGap = fontPx * 0.22;
+    const lineH = fontPx + lineGap;
     ctx.font = `${bold ? 'bold ' : ''}${fontPx}px ${font}`;
+    let lines = fitDataLabelLines(
+      text,
+      Math.max(0, boundsW - padX * 2),
+      Math.max(0, boundsH - padY * 2),
+      lineH,
+      value => ctx.measureText(value).width,
+    );
+    if (lines.length === 0) continue;
     let textW = 0;
     for (const ln of lines) textW = Math.max(textW, ctx.measureText(ln).width);
-    const lineH = fontPx + lineGap;
-    const boxW = textW + padX * 2;
-    const boxH = lines.length * lineH - lineGap + padY * 2;
+    let boxW = textW + padX * 2;
+    let boxH = lines.length * lineH - lineGap + padY * 2;
 
     const rimX = cx2 + Math.cos(midAngle) * outerR;
     const rimY = cy2 + Math.sin(midAngle) * outerR;
-    const leftSide = Math.cos(midAngle) < 0;
+    let leftSide = Math.cos(midAngle) < 0;
 
     // Initial box centre: outside the rim along the mid-angle. The gap scales
     // with the box so small slices get pulled further out (Word `bestFit`).
     const outGap = Math.max(boxW, boxH) * 0.55 + outerR * 0.06;
-    const cxBox = rimX + Math.cos(midAngle) * outGap;
-    const cyBox = rimY + Math.sin(midAngle) * outGap;
+    let cxBox = rimX + Math.cos(midAngle) * outGap;
+    let cyBox = rimY + Math.sin(midAngle) * outGap;
+    let manualClip: DataLabelRect | undefined;
+    let inside = false;
+    if (ov?.manualLayout) {
+      const manual = resolveDataLabelPlacement(
+        { kind: 'point', x: cxBox, y: cyBox, position: 'ctr' },
+        { x: boundsX, y: boundsY, w: boundsW, h: boundsH },
+        { w: boxW, h: boxH },
+        fontPx,
+        ov.manualLayout,
+        { x: chartX, y: chartY, w: chartW, h: chartH },
+      );
+      if (!manual) continue;
+      boxW = manual.rect.w;
+      boxH = manual.rect.h;
+      lines = fitDataLabelLines(
+        text,
+        Math.max(0, boxW - padX * 2),
+        Math.max(0, boxH - padY * 2),
+        lineH,
+        value => ctx.measureText(value).width,
+      );
+      if (lines.length === 0) continue;
+      cxBox = manual.rect.x + manual.rect.w / 2;
+      cyBox = manual.rect.y + manual.rect.h / 2;
+      leftSide = cxBox < cx2;
+      manualClip = manual.clip;
+    } else if (position !== 'bestFit' && position !== 'outEnd') {
+      const labelR = innerR > 0.01
+        ? (innerR + outerR) / 2
+        : outerR * PIE_CTR_LABEL_RADIUS_FRAC;
+      const labelX = cx2 + Math.cos(midAngle) * labelR;
+      const labelY = cy2 + Math.sin(midAngle) * labelR;
+      const tangentialCapacity = 2 * labelR
+        * Math.sin(Math.min(Math.PI, Math.abs(slice)) / 2) - fontPx;
+      const radialCapacity = innerR > 0.01
+        ? outerR - innerR - fontPx
+        : outerR - fontPx;
+      const sliceBounds = dataLabelRectIntersection(
+        {
+          x: labelX - tangentialCapacity / 2,
+          y: labelY - radialCapacity / 2,
+          w: tangentialCapacity,
+          h: radialCapacity,
+        },
+        { x: boundsX, y: boundsY, w: boundsW, h: boundsH },
+      );
+      if (!sliceBounds) continue;
+      lines = fitDataLabelLines(
+        text,
+        Math.max(0, sliceBounds.w - padX * 2),
+        Math.max(0, sliceBounds.h - padY * 2),
+        lineH,
+        value => ctx.measureText(value).width,
+      );
+      if (lines.length === 0) continue;
+      textW = lines.reduce((width, line) => Math.max(width, ctx.measureText(line).width), 0);
+      boxW = textW + padX * 2;
+      boxH = lines.length * lineH - lineGap + padY * 2;
+      const anchorPosition = position === 'inBase' || position === 'inEnd'
+        ? 'ctr'
+        : position;
+      const placement = resolveDataLabelPlacement(
+        { kind: 'point', x: labelX, y: labelY, position: anchorPosition },
+        sliceBounds,
+        { w: boxW, h: boxH },
+        fontPx,
+      );
+      if (!placement) continue;
+      cxBox = placement.textAlign === 'left'
+        ? placement.x + boxW / 2
+        : placement.textAlign === 'right'
+          ? placement.x - boxW / 2
+          : placement.x;
+      cyBox = placement.textBaseline === 'top'
+        ? placement.y + boxH / 2
+        : placement.textBaseline === 'bottom'
+          ? placement.y - boxH / 2
+          : placement.y;
+      leftSide = cxBox < cx2;
+      manualClip = placement.clip;
+      inside = true;
+    }
 
     labels.push({
-      lines, midAngle, rimX, rimY, boxW, boxH, cxBox, cyBox,
-      leftSide, fontColor, boxFill, boxBorder, boxBorderPx, fontPx, bold,
+      lines, lineHeight: lineH, midAngle, rimX, rimY, boxW, boxH, cxBox, cyBox,
+      leftSide, fontColor, boxFill, boxBorder, boxBorderPx, fontPx, bold, inside, manualClip,
     });
   }
 
@@ -4708,8 +4940,8 @@ function drawPieCalloutLabels(
     const topUnderflow = topLimit - (col[0].cyBox - col[0].boxH / 2);
     if (topUnderflow > 0) for (const l of col) l.cyBox += topUnderflow;
   };
-  separate(labels.filter(l => !l.leftSide));
-  separate(labels.filter(l => l.leftSide));
+  separate(labels.filter(l => !l.manualClip && !l.leftSide));
+  separate(labels.filter(l => !l.manualClip && l.leftSide));
 
   // Final round-trip clamp (both edges): guarantee no box escapes the plot rect
   // vertically, independent of which separate() branch ran. In the fits case the
@@ -4721,6 +4953,7 @@ function drawPieCalloutLabels(
   // then bottom so a box taller than the band (degenerate) pins to the TOP edge
   // rather than escaping upward.
   for (const l of labels) {
+    if (l.manualClip) continue;
     l.cyBox = Math.max(topLimit + l.boxH / 2, l.cyBox);
     l.cyBox = Math.min(bottomLimit - l.boxH / 2, l.cyBox);
   }
@@ -4729,12 +4962,17 @@ function drawPieCalloutLabels(
   const leftLimit = boundsX + 2;
   const rightLimit = boundsX + boundsW - 2;
   for (const l of labels) {
+    if (l.manualClip) continue;
     const half = l.boxW / 2;
     if (l.cxBox - half < leftLimit) l.cxBox = leftLimit + half;
     if (l.cxBox + half > rightLimit) l.cxBox = rightLimit - half;
   }
 
   // ── Draw leader lines first (under the boxes), then boxes + text ─────────
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(boundsX, boundsY, boundsW, boundsH);
+  ctx.clip();
   const leaderColor = def.leaderLineColor ? `#${def.leaderLineColor}` : '#a6a6a6';
   const leaderPx = def.leaderLineWidthEmu
     ? Math.max(0.5, (def.leaderLineWidthEmu / EMU_PER_PT) * ptToPx)
@@ -4749,7 +4987,7 @@ function drawPieCalloutLabels(
     const dx = edgeX - l.rimX;
     const dy = edgeY - l.rimY;
     const dist = Math.hypot(dx, dy);
-    if (def.showLeaderLines && dist > l.fontPx * 0.9) {
+    if (!l.inside && def.showLeaderLines && dist > l.fontPx * 0.9) {
       ctx.beginPath();
       ctx.moveTo(l.rimX, l.rimY);
       ctx.lineTo(edgeX, edgeY);
@@ -4760,6 +4998,12 @@ function drawPieCalloutLabels(
   }
 
   for (const l of labels) {
+    if (l.manualClip) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(l.manualClip.x, l.manualClip.y, l.manualClip.w, l.manualClip.h);
+      ctx.clip();
+    }
     const bx = l.cxBox - l.boxW / 2;
     const by = l.cyBox - l.boxH / 2;
     // Box fill + border (§21.2.2.197 spPr). Fill may carry an 8-digit RGBA hex
@@ -4775,12 +5019,14 @@ function drawPieCalloutLabels(
     ctx.fillStyle = l.fontColor;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    const lineH = l.fontPx + lineGap;
-    const blockTop = l.cyBox - (l.lines.length * lineH - lineGap) / 2 + l.fontPx / 2;
+    const lineGap = l.lineHeight - l.fontPx;
+    const blockTop = l.cyBox - (l.lines.length * l.lineHeight - lineGap) / 2 + l.fontPx / 2;
     for (let li = 0; li < l.lines.length; li++) {
-      ctx.fillText(l.lines[li], l.cxBox, blockTop + li * lineH);
+      ctx.fillText(l.lines[li], l.cxBox, blockTop + li * l.lineHeight);
     }
+    if (l.manualClip) ctx.restore();
   }
+  ctx.restore();
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -5108,6 +5354,7 @@ function drawScatterSeriesLayer(
   ptToPx: number,
   isBubble: boolean,
   style: string,
+  layoutReferenceRect: DataLabelRect,
 ): void {
   const drawLines = style === 'line' || style === 'lineMarker' || style === 'lineNoMarker';
   const drawSmooth = style === 'smooth' || style === 'smoothMarker' || style === 'smoothNoMarker';
@@ -5214,6 +5461,8 @@ function drawScatterSeriesLayer(
       chart.date1904,
       chartFontFamily(chart, chart.dataLabelFontFace, 'minor'),
       chart.dataLabelPosition ?? 'r',
+      { x: px0, y: py0, w: pw, h: ph },
+      layoutReferenceRect,
     );
   }
 
@@ -5622,6 +5871,8 @@ function renderScatterChart(ctx: CanvasRenderingContext2D, chart: ChartModel, r:
       // §21.2.2.48 `<c:dLblPos>`: chart-level position, else the scatter default
       // `'r'` (right of the marker) — unchanged from the previous hardcoded 'r'.
       chart.dataLabelPosition ?? 'r',
+      { x: px0, y: py0, w: pw, h: ph },
+      { x, y, w, h },
     );
 
     if (s.trendLines && s.trendLines.length > 0) {
@@ -5842,6 +6093,8 @@ function drawSeriesDataLabels(
    *  the series-level block sets one: the chart-level position, else the
    *  per-chart-type default (scatter defaults to `'r'`). */
   defaultPos = 'r',
+  bounds: DataLabelRect = { x: -1e6, y: -1e6, w: 2e6, h: 2e6 },
+  layoutReferenceRect: DataLabelRect = bounds,
 ): void {
   const overrides = s.dataLabelOverrides ?? [];
   if (overrides.length === 0 && !s.seriesDataLabels) return;
@@ -5859,27 +6112,21 @@ function drawSeriesDataLabels(
     const showCatName = ovr?.showCatName ?? seriesDef?.showCatName;
     const showSerName = ovr?.showSerName ?? seriesDef?.showSerName;
     const showVal     = ovr?.showVal ?? seriesDef?.showVal;
-    let text: string;
-    if (ovr?.text) {
-      text = ovr.text;
-    } else if (showVal || showSerName || showCatName) {
-      const parts: string[] = [];
-      if (showCatName && !useIndexX) {
-        parts.push(formatChartValWithCode(
-          xv,
-          s.catFormatCodes?.[i] ?? s.catFormatCode ?? null,
-          date1904,
-        ));
-      }
-      if (showSerName) parts.push(s.name);
-      if (showVal) {
-        parts.push(formatChartValWithCode(yv, seriesDef?.formatCode ?? null, date1904));
-      }
-      text = parts.filter(Boolean).join(' ');
-      if (!text) continue;
-    } else {
-      continue;
-    }
+    const text = effectiveDataLabelText({
+      customText: ovr?.text,
+      showCategory: showCatName && !useIndexX,
+      showSeries: showSerName,
+      showValue: showVal,
+      category: formatChartValWithCode(
+        xv, s.catFormatCodes?.[i] ?? s.catFormatCode ?? null, date1904,
+      ),
+      seriesName: s.name,
+      sourceValue: yv,
+      formatCode: ovr?.formatCode ?? seriesDef?.formatCode ?? null,
+      date1904,
+      separator: ovr?.separator ?? seriesDef?.separator,
+    });
+    if (!text) continue;
     const pos = ovr?.position ?? seriesDef?.position ?? defaultPos;
     const sizeHpt = ovr?.fontSizeHpt ?? seriesDef?.fontSizeHpt;
     const fontSizePx = sizeHpt
@@ -5887,7 +6134,11 @@ function drawSeriesDataLabels(
       : Math.max(9, Math.min(11, ph / 25));
     const color = ovr?.fontColor ?? seriesDef?.fontColor;
     const bold = ovr?.fontBold ?? seriesDef?.fontBold ?? false;
-    drawDataLabelText(ctx, toX(xv), toY(yv), text, pos, fontSizePx, color, bold, fontFamily);
+    drawDataLabelText(
+      ctx, toX(xv), toY(yv), text, pos, fontSizePx, color, bold, fontFamily, 0,
+      bounds, ovr?.manualLayout,
+      layoutReferenceRect,
+    );
   }
 }
 
@@ -5901,45 +6152,76 @@ function drawDataLabelText(
   bold: boolean,
   fontFamily = 'sans-serif',
   /** Extra gap (px) added to the text offset in the label's direction so the
-   *  text clears an anchor glyph (e.g. a line-chart marker). 0 keeps the
-   *  historical `fontSizePx * 0.6` offset (byte-stable for scatter/area). */
+   *  text clears an anchor glyph (e.g. a line-chart marker). The shared base
+   *  inset is one half-em; markerGap is added outside that inset. */
   markerGap = 0,
+  bounds: DataLabelRect = { x: -1e6, y: -1e6, w: 2e6, h: 2e6 },
+  manualLayout?: ChartDataLabelOverride['manualLayout'],
+  layoutReferenceRect: DataLabelRect = bounds,
 ): void {
   ctx.save();
   ctx.font = `${bold ? 'bold ' : ''}${fontSizePx}px ${fontFamily}`;
-  ctx.fillStyle = color ? `#${color}` : '#333';
-  const offset = fontSizePx * 0.6 + markerGap;
-  let tx = cx, ty = cy;
-  switch (position) {
-    case 'l':
-      ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
-      tx = cx - offset; break;
-    case 'r':
-      ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
-      tx = cx + offset; break;
-    case 't':
-      ctx.textAlign = 'center'; ctx.textBaseline = 'bottom';
-      ty = cy - offset; break;
-    case 'b':
-      ctx.textAlign = 'center'; ctx.textBaseline = 'top';
-      ty = cy + offset; break;
-    case 'ctr':
-      ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-      break;
-    default:
-      ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
-      tx = cx + offset; break;
-  }
-  // Multi-line labels: split on newline and stack vertically.
-  const lines = text.split(/\r?\n/);
-  const lineH = fontSizePx * 1.15;
-  const totalH = lineH * lines.length;
-  let lineY = ty;
-  if (ctx.textBaseline === 'middle') lineY = ty - (totalH - lineH) / 2;
-  else if (ctx.textBaseline === 'bottom') lineY = ty - (totalH - lineH);
-  for (const line of lines) {
-    ctx.fillText(line, tx, lineY);
-    lineY += lineH;
+  drawBoundedDataLabelText(
+    ctx,
+    text,
+    { kind: 'point', x: cx, y: cy, position, markerGap },
+    bounds,
+    fontSizePx,
+    color ? `#${color}` : '#333',
+    manualLayout,
+    layoutReferenceRect,
+  );
+  ctx.restore();
+}
+
+/** Measure, fit, clip, and paint one label through the shared pure resolver. */
+function drawBoundedDataLabelText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  anchor: DataLabelAnchor,
+  bounds: DataLabelRect,
+  fontSizePx: number,
+  color: string,
+  manualLayout?: ChartDataLabelOverride['manualLayout'],
+  layoutReferenceRect: DataLabelRect = bounds,
+): void {
+  if (!text || !Number.isFinite(fontSizePx) || fontSizePx <= 0) return;
+  const lineHeight = fontSizePx * 1.15;
+  const sourceLines = boundDataLabelText(text).value.split(/\r?\n/);
+  const measuredW = sourceLines.reduce((max, line) => Math.max(max, ctx.measureText(line).width), 0);
+  const measuredH = Math.max(lineHeight, sourceLines.length * lineHeight);
+  let placement = resolveDataLabelPlacement(
+    anchor, bounds, { w: measuredW, h: measuredH }, fontSizePx, manualLayout,
+    layoutReferenceRect,
+  );
+  if (!placement) return;
+  const measure = (value: string): number => ctx.measureText(value).width;
+  const lines = fitDataLabelLines(
+    text, placement.maxWidth, placement.maxHeight, lineHeight, measure,
+  );
+  if (lines.length === 0) return;
+  const fittedW = lines.reduce((max, line) => Math.max(max, measure(line)), 0);
+  const fittedH = lines.length * lineHeight;
+  placement = resolveDataLabelPlacement(
+    anchor, bounds, { w: fittedW, h: fittedH }, fontSizePx, manualLayout,
+    layoutReferenceRect,
+  );
+  if (!placement) return;
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(placement.clip.x, placement.clip.y, placement.clip.w, placement.clip.h);
+  ctx.clip();
+  ctx.fillStyle = color;
+  ctx.textAlign = placement.textAlign;
+  ctx.textBaseline = placement.textBaseline;
+  const firstY = placement.textBaseline === 'middle'
+    ? placement.y - ((lines.length - 1) * lineHeight) / 2
+    : placement.textBaseline === 'bottom'
+      ? placement.y - ((lines.length - 1) * lineHeight)
+      : placement.y;
+  for (let index = 0; index < lines.length; index++) {
+    ctx.fillText(lines[index], placement.x, firstY + index * lineHeight);
   }
   ctx.restore();
 }
@@ -6091,13 +6373,17 @@ function drawCategoryDataLabels(
    *  per-chart-type default. Line defaults to `'r'` (PowerPoint), area to
    *  `'ctr'`. */
   defaultPos = 't',
+  bounds: DataLabelRect = { x: -1e6, y: -1e6, w: 2e6, h: 2e6 },
+  layoutReferenceRect: DataLabelRect = bounds,
+  percentRatioAt?: (index: number) => number,
 ): boolean {
   const overrides = s.dataLabelOverrides ?? [];
   const seriesDef = s.seriesDataLabels;
   if (overrides.length === 0 && !seriesDef) return false;
   for (let ci = 0; ci < n; ci++) {
     if (s.values[ci] == null && !plotNullAsZero) continue;
-    const pv = plotted(ci);
+    const anchorValue = plotted(ci);
+    const sourceValue = s.values[ci] ?? 0;
     const ovr = overrides.find(o => o.idx === ci);
     // Genuine `<c:delete val="1"/>` (§21.2.2.43) skips; a style/flag-only
     // override is not a delete. Per-point show-flags (§21.2.2.47) win over the
@@ -6106,25 +6392,32 @@ function drawCategoryDataLabels(
     const showCatName = ovr?.showCatName ?? seriesDef?.showCatName;
     const showSerName = ovr?.showSerName ?? seriesDef?.showSerName;
     const showVal     = ovr?.showVal ?? seriesDef?.showVal;
-    let text: string;
-    if (ovr?.text) {
-      text = ovr.text;
-    } else if (showVal || showSerName || showCatName) {
-      const parts: string[] = [];
-      if (showCatName) parts.push(cats[ci] ?? '');
-      if (showSerName) parts.push(s.name);
-      if (showVal) parts.push(formatChartValWithCode(pv, seriesDef?.formatCode ?? null, date1904));
-      text = parts.filter(Boolean).join(' ');
-      if (!text) continue;
-    } else {
-      continue;
-    }
+    const showPercent = ovr?.showPercent ?? seriesDef?.showPercent;
+    const text = effectiveDataLabelText({
+      customText: ovr?.text,
+      showCategory: showCatName,
+      showSeries: showSerName,
+      showValue: showVal,
+      showPercent,
+      category: cats[ci] ?? '',
+      seriesName: s.name,
+      sourceValue,
+      percentRatio: percentRatioAt?.(ci),
+      formatCode: ovr?.formatCode ?? seriesDef?.formatCode ?? null,
+      date1904,
+      separator: ovr?.separator ?? seriesDef?.separator,
+    });
+    if (!text) continue;
     const pos = ovr?.position ?? seriesDef?.position ?? defaultPos;
     const sizeHpt = ovr?.fontSizeHpt ?? seriesDef?.fontSizeHpt;
     const fontSizePx = sizeHpt ? (sizeHpt / 100) * ptToPx : Math.max(9, Math.min(11, ph / 25));
     const color = ovr?.fontColor ?? seriesDef?.fontColor;
     const bold = ovr?.fontBold ?? seriesDef?.fontBold ?? false;
-    drawDataLabelText(ctx, xAt(ci), yAt(pv), text, pos, fontSizePx, color, bold, fontFamily);
+    drawDataLabelText(
+      ctx, xAt(ci), yAt(anchorValue), text, pos, fontSizePx, color, bold, fontFamily, 0,
+      bounds, ovr?.manualLayout,
+      layoutReferenceRect,
+    );
   }
   return true;
 }
@@ -6140,7 +6433,8 @@ interface ResolvedChartExLabel {
   position?: string;
   fontColor?: string;
   fontSizeHpt?: number;
-  fontBold: boolean;
+  fontBold?: boolean;
+  manualLayout?: ChartDataLabelOverride['manualLayout'];
 }
 
 /** Effective CT_Series formatting index. The shared parser preserves authored
@@ -6163,9 +6457,15 @@ function resolveChartExLabel(
   index: number,
   category: string,
   value: number,
-  defaults: { visible: boolean; showVal: boolean; showCatName: boolean; showSerName?: boolean },
+  defaults: {
+    visible: boolean;
+    showVal: boolean;
+    showCatName: boolean;
+    showSerName?: boolean;
+    showPercent?: boolean;
+  },
   overrideLookup?: ReadonlyMap<number, NonNullable<ChartSeries['dataLabelOverrides']>[number]>,
-  suppressValue = false,
+  valueOption?: boolean | number,
 ): ResolvedChartExLabel | null {
   if (!series) return null;
   const definition = series.seriesDataLabels;
@@ -6173,6 +6473,8 @@ function resolveChartExLabel(
     ?? series.dataLabelOverrides?.find(item => item.idx === index);
   if (override?.deleted) return null;
   if (!definition && !override && !defaults.visible) return null;
+  const suppressValue = typeof valueOption === 'boolean' ? valueOption : false;
+  const percentRatio = typeof valueOption === 'number' ? valueOption : undefined;
   const showVal = !suppressValue
     && (override?.showVal ?? definition?.showVal ?? defaults.showVal);
   const showCatName = override?.showCatName ?? definition?.showCatName ?? defaults.showCatName;
@@ -6180,31 +6482,37 @@ function resolveChartExLabel(
     ?? definition?.showSerName
     ?? defaults.showSerName
     ?? false;
-  let text = override?.text ?? '';
-  if (!text) {
-    const parts: string[] = [];
-    if (showCatName && category) parts.push(category);
-    if (showSerName && series.name) parts.push(series.name);
-    if (showVal) {
-      parts.push(formatChartValWithCode(
-        value,
-        override?.formatCode
-          ?? definition?.formatCode
-          ?? chart.dataLabelFormatCode
-          ?? series.valFormatCode
-          ?? null,
-        chart.date1904,
-      ));
-    }
-    text = parts.join(override?.separator ?? definition?.separator ?? ' ');
-  }
+  const showPercent = override?.showPercent
+    ?? definition?.showPercent
+    ?? defaults.showPercent
+    ?? false;
+  const authoredFormatCode = override?.formatCode
+    ?? definition?.formatCode
+    ?? chart.dataLabelFormatCode
+    ?? null;
+  const text = effectiveDataLabelText({
+    customText: override?.text,
+    showCategory: showCatName,
+    showSeries: showSerName,
+    showValue: showVal,
+    showPercent,
+    category,
+    seriesName: series.name,
+    sourceValue: value,
+    percentRatio,
+    formatCode: authoredFormatCode ?? series.valFormatCode ?? null,
+    percentFormatCode: authoredFormatCode ?? '0%',
+    date1904: chart.date1904,
+    separator: override?.separator ?? definition?.separator,
+  });
   if (!text) return null;
   return {
     text,
     position: override?.position ?? definition?.position,
     fontColor: override?.fontColor ?? definition?.fontColor,
     fontSizeHpt: override?.fontSizeHpt ?? definition?.fontSizeHpt,
-    fontBold: override?.fontBold ?? definition?.fontBold ?? false,
+    fontBold: override?.fontBold ?? definition?.fontBold,
+    manualLayout: override?.manualLayout,
   };
 }
 
@@ -6761,7 +7069,7 @@ function renderWaterfallChart(
     );
     if (label) {
       const perPointColor = series?.dataLabelColors?.[i] ?? label.fontColor ?? null;
-      ctx.fillStyle = perPointColor
+      const labelColor = perPointColor
         ? `#${perPointColor}`
         : chart.dataLabelFontColor
           ? `#${chart.dataLabelFontColor}`
@@ -6769,20 +7077,24 @@ function renderWaterfallChart(
       const dataLabelFontPx = label.fontSizeHpt
         ? (label.fontSizeHpt / 100) * ptToPx
         : axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
-      ctx.font = `${label.fontBold || chart.dataLabelFontBold ? 'bold ' : ''}${dataLabelFontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
-      ctx.textAlign = 'center';
-      // Negative bars: label sits below the bar; positive bars and subtotals
-      // place it above the bar unless an authored position requests center.
-      if (label.position === 'ctr') {
-        ctx.textBaseline = 'middle';
-        ctx.fillText(label.text, bx + barW / 2, (yTop + yBot) / 2);
-      } else if (bar.hasValue && rawVal < 0) {
-        ctx.textBaseline = 'top';
-        ctx.fillText(label.text, bx + barW / 2, yBot + 3);
-      } else {
-        ctx.textBaseline = 'bottom';
-        ctx.fillText(label.text, bx + barW / 2, yTop - 3);
-      }
+      const dataLabelBold = label.fontBold ?? chart.dataLabelFontBold ?? false;
+      ctx.font = `${dataLabelBold ? 'bold ' : ''}${dataLabelFontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
+      drawBoundedDataLabelText(
+        ctx,
+        label.text,
+        {
+          kind: 'bar',
+          rect: { x: bx, y: yTop, w: barW, h: bh },
+          orientation: 'vertical',
+          negative: rawVal < 0,
+          position: label.position ?? 'outEnd',
+        },
+        { x: px0, y: py0, w: pw, h: ph },
+        dataLabelFontPx,
+        labelColor,
+        label.manualLayout,
+        { x, y, w, h },
+      );
     }
   });
 
@@ -6908,10 +7220,22 @@ function renderFunnelChart(
         ? (label.fontSizeHpt / 100) * ptToPx
         : axisLabelPx(chart.dataLabelFontSizeHpt, h, ptToPx);
       ctx.font = `${label.fontBold ? 'bold ' : ''}${fontPx}px ${chartFontFamily(chart, chart.dataLabelFontFace, 'minor')}`;
-      ctx.fillStyle = label.fontColor ? `#${label.fontColor}` : '#ffffff';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillText(label.text, bx + barW / 2, by + barH / 2);
+      drawBoundedDataLabelText(
+        ctx,
+        label.text,
+        {
+          kind: 'bar',
+          rect: { x: bx, y: by, w: barW, h: barH },
+          orientation: 'horizontal',
+          negative: false,
+          position: label.position ?? 'ctr',
+        },
+        { x: px0, y: py0, w: pw, h: ph },
+        fontPx,
+        label.fontColor ? `#${label.fontColor}` : '#ffffff',
+        label.manualLayout,
+        { x, y, w, h },
+      );
     }
   }
   if (!chart.catAxisHidden && !chart.catAxisLineHidden) {
@@ -7840,10 +8164,28 @@ function renderSunburstChart(
       // Tangential arc length at the mid radius.
       const arcLen = sweep * midR;
       // Skip labels that plainly cannot fit even one glyph.
-      if (radialRoom < nodeLabelPx * 0.9 && arcLen < nodeLabelPx * 0.9) continue;
+      if (!label.manualLayout &&
+          radialRoom < nodeLabelPx * 0.9 && arcLen < nodeLabelPx * 0.9) continue;
+
+      const labelX = cx + Math.cos(midA) * midR;
+      const labelY = cy + Math.sin(midA) * midR;
+      ctx.font = `${label.fontBold ? 'bold ' : ''}${nodeLabelPx}px ${labelFont}`;
+      if (label.manualLayout) {
+        drawBoundedDataLabelText(
+          ctx,
+          labelText,
+          { kind: 'point', x: labelX, y: labelY, position: label.position ?? 'ctr' },
+          { x: px0, y: py0, w: pw, h: ph },
+          nodeLabelPx,
+          nodeLabelColor,
+          label.manualLayout,
+          { x, y, w, h },
+        );
+        continue;
+      }
 
       ctx.save();
-      ctx.translate(cx + Math.cos(midA) * midR, cy + Math.sin(midA) * midR);
+      ctx.translate(labelX, labelY);
       // Orient the text along the radius and flip on the left half so it stays
       // readable instead of becoming upside-down.
       let rot = midA;
@@ -7851,53 +8193,14 @@ function renderSunburstChart(
       if (deg > 90 || deg < -90) rot += Math.PI;
       ctx.rotate(rot);
       ctx.font = `${label.fontBold ? 'bold ' : ''}${nodeLabelPx}px ${labelFont}`;
-      ctx.fillStyle = nodeLabelColor;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      // The rotated frame's x-axis is radial: width is the ring band and the
-      // available line stack is the wedge's tangential arc length.
-      const words = labelText.split(/\s+/).filter(Boolean);
-      const maxLineW = radialRoom - 2;
-      const lines: string[] = [];
-      let cur = '';
-      for (const word of words) {
-        const trial = cur ? `${cur} ${word}` : word;
-        if (ctx.measureText(trial).width <= maxLineW) {
-          cur = trial;
-          continue;
-        }
-        if (cur) {
-          lines.push(cur);
-          cur = '';
-        }
-        if (ctx.measureText(word).width <= maxLineW) {
-          cur = word;
-          continue;
-        }
-        // Narrow outer rings may require a break inside a long category name.
-        // Retain every character instead of eliding the label.
-        let chunk = '';
-        for (const char of word) {
-          const next = chunk + char;
-          if (chunk && ctx.measureText(next).width > maxLineW) {
-            lines.push(chunk);
-            chunk = char;
-          } else {
-            chunk = next;
-          }
-        }
-        cur = chunk;
-      }
-      if (cur) lines.push(cur);
-      // Cap the number of lines to what the tangential arc holds.
-      const lineH = nodeLabelPx * 1.05;
-      const maxLines = Math.max(1, Math.floor(arcLen / lineH));
-      const shown = lines.slice(0, maxLines).map(l => elideToWidth(ctx, l, maxLineW));
-      const totalH = shown.length * lineH;
-      shown.forEach((line, li) => {
-        if (line === '') return;
-        ctx.fillText(line, 0, -totalH / 2 + lineH / 2 + li * lineH);
-      });
+      drawBoundedDataLabelText(
+        ctx,
+        labelText,
+        { kind: 'point', x: 0, y: 0, position: label.position ?? 'ctr' },
+        { x: -radialRoom / 2, y: -arcLen / 2, w: radialRoom, h: arcLen },
+        nodeLabelPx,
+        nodeLabelColor,
+      );
       ctx.restore();
     }
   }
@@ -8048,6 +8351,8 @@ function renderTreemapChart(
     radialGapFrac: 0.015,
   });
   drawChartTitleForLayout(ctx, chart, r.x, r.y, r.w, r.h, r.y + frame.title.topPad, frame.title.fontPx);
+  const { px0, py0, pw, ph } = frame.plotRect;
+  const plotBounds = { x: px0, y: py0, w: pw, h: ph };
 
   const fontFamily = chartFontFamily(chart, chart.dataLabelFontFace, 'minor');
   const parentMode = treemap.parentLabelLayout ?? 'overlapping';
@@ -8124,13 +8429,24 @@ function renderTreemapChart(
       };
       for (const child of layoutTreemapTiles(node.children, content)) paint(child.node, child.rect);
 
-      if (showParent && tile.w > fontPx * 2 && tile.h > fontPx + 4) {
+      if (showParent && (parentLabel.manualLayout || (tile.w > fontPx * 2 && tile.h > fontPx + 4))) {
         ctx.font = `${nodeLabelBold ? 'bold ' : ''}${fontPx}px ${fontFamily}`;
-        ctx.fillStyle = nodeLabelColor;
-        ctx.textAlign = 'left';
-        ctx.textBaseline = 'top';
-        const shown = elideToWidth(ctx, parentLabel?.text ?? '', tile.w - 8);
-        if (shown) ctx.fillText(shown, tile.x + 4, tile.y + 3);
+        const labelRect = bannerH > 0
+          ? { x: tile.x, y: tile.y, w: tile.w, h: bannerH }
+          : tile;
+        const automaticBounds = labelRect;
+        drawBoundedDataLabelText(
+          ctx,
+          parentLabel.text,
+          parentLabel.manualLayout
+            ? { kind: 'point', x: tile.x + tile.w / 2, y: tile.y + tile.h / 2, position: parentLabel.position ?? 'inBase' }
+            : { kind: 'box', rect: automaticBounds, position: parentLabel.position ?? 'inBase' },
+          parentLabel.manualLayout ? plotBounds : automaticBounds,
+          fontPx,
+          nodeLabelColor,
+          parentLabel.manualLayout,
+          r,
+        );
       }
       return;
     }
@@ -8173,49 +8489,24 @@ function renderTreemapChart(
     const fontPx = leafLabel.fontSizeHpt
       ? (leafLabel.fontSizeHpt / 100) * ptToPx
       : nodeLabelFontPx;
-    if (tile.w <= fontPx * 1.2 || tile.h <= fontPx * 1.2) return;
+    if (!leafLabel.manualLayout && (tile.w <= fontPx * 1.2 || tile.h <= fontPx * 1.2)) return;
     ctx.font = `${leafLabel.fontBold ? 'bold ' : ''}${fontPx}px ${fontFamily}`;
-    ctx.fillStyle = leafLabel.fontColor ? `#${leafLabel.fontColor}` : nodeLabelColor;
-    const lineH = fontPx * 1.1;
-    const position = leafLabel.position ?? 'ctr';
-    const inset = position === 'inEnd' ? 4 : fontPx * 0.5;
-    const availableWidth = tile.w - inset * 2;
-    const availableHeight = tile.h - inset * 2;
-    if (availableWidth <= 0 || availableHeight <= 0) return;
-    const lines = leafLabel.text
-      .split(/\r?\n/)
-      .flatMap(line => wrapMeasuredText(ctx, line, availableWidth))
-      // `wrapMeasuredText` deliberately emits one over-wide glyph to guarantee
-      // progress. A treemap label must instead omit a line that cannot fit
-      // completely inside the tile's content box.
-      .filter(line => ctx.measureText(line).width <= availableWidth + 1e-6);
-    const maxLines = Math.max(0, Math.floor(availableHeight / lineH));
-    ctx.save();
-    ctx.beginPath();
-    ctx.rect(tile.x, tile.y, tile.w, tile.h);
-    ctx.clip();
-    if (position === 'inEnd') {
-      ctx.textAlign = 'left';
-      ctx.textBaseline = 'bottom';
-      const visibleLines = lines.slice(Math.max(0, lines.length - maxLines));
-      const lastY = tile.y + tile.h - inset;
-      visibleLines.forEach((line, index) => {
-        if (line) ctx.fillText(line, tile.x + inset, lastY - (visibleLines.length - 1 - index) * lineH);
-      });
-    } else {
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      const visibleLines = lines.slice(0, maxLines);
-      const firstY = tile.y + tile.h / 2 - ((visibleLines.length - 1) * lineH) / 2;
-      visibleLines.forEach((line, index) => {
-        if (line) ctx.fillText(line, tile.x + tile.w / 2, firstY + index * lineH);
-      });
-    }
-    ctx.restore();
+    const automaticBounds = tile;
+    drawBoundedDataLabelText(
+      ctx,
+      leafLabel.text,
+      leafLabel.manualLayout
+        ? { kind: 'point', x: tile.x + tile.w / 2, y: tile.y + tile.h / 2, position: leafLabel.position ?? 'ctr' }
+        : { kind: 'box', rect: automaticBounds, position: leafLabel.position ?? 'ctr' },
+      leafLabel.manualLayout ? plotBounds : automaticBounds,
+      fontPx,
+      leafLabel.fontColor ? `#${leafLabel.fontColor}` : nodeLabelColor,
+      leafLabel.manualLayout,
+      r,
+    );
   };
 
   ctx.save();
-  const { px0, py0, pw, ph } = frame.plotRect;
   ctx.beginPath();
   ctx.rect(px0, py0, pw, ph);
   ctx.clip();

--- a/packages/core/src/types/chart.ts
+++ b/packages/core/src/types/chart.ts
@@ -260,6 +260,9 @@ export interface ChartDataLabelOverride {
   formatCode?: string;
   /** Per-point component separator; undefined inherits the series default. */
   separator?: string;
+  /** Authored `<c:dLbl><c:layout><c:manualLayout>` geometry. Automatic label
+   *  placement is used when absent; explicit layout takes precedence when set. */
+  manualLayout?: ChartManualLayout;
   /** Per-point callout box (`<c:dLbl><c:spPr>`, ECMA-376 §21.2.2.47/§21.2.2.197):
    *  overrides the series-default box for this one slice. */
   labelBox?: ChartLabelBox;

--- a/packages/docx/api/public-api-baseline.d.ts
+++ b/packages/docx/api/public-api-baseline.d.ts
@@ -64,6 +64,7 @@ export interface ChartDataLabelOverride {
     fontBold?: boolean;
     formatCode?: string;
     separator?: string;
+    manualLayout?: ChartManualLayout;
     labelBox?: ChartLabelBox;
     showVal?: boolean;
     showCatName?: boolean;

--- a/packages/ooxml-common/src/chart.rs
+++ b/packages/ooxml-common/src/chart.rs
@@ -783,6 +783,12 @@ pub struct ChartDataLabelOverride {
     pub format_code: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub separator: Option<String>,
+    /// Per-point `<c:dLbl><c:layout><c:manualLayout>` (§21.2.2.47/§21.2.2.88).
+    /// The application chooses automatic label geometry when this is absent;
+    /// when authored, preserve it so the shared renderer can resolve it against
+    /// the same bounded chart rectangle as the automatic anchor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manual_layout: Option<ChartManualLayout>,
     /// Per-point label callout box style (`<c:dLbl>` §21.2.2.47 `<c:spPr>`
     /// §21.2.2.197): background fill / border, mirroring the series-level
     /// defaults. Present only when the point's `<c:spPr>` overrides the shape
@@ -3666,6 +3672,7 @@ fn parse_chartex_series_labels(
             separator: child(label, "separator")
                 .and_then(|node| node.text())
                 .map(ToOwned::to_owned),
+            manual_layout: None,
             label_box: None,
             show_val: label_visibility.and_then(|node| chart_text_bool_attr(node, "value")),
             show_cat_name: label_visibility
@@ -3695,6 +3702,7 @@ fn parse_chartex_series_labels(
                 font_bold: None,
                 format_code: None,
                 separator: None,
+                manual_layout: None,
                 label_box: None,
                 show_val: None,
                 show_cat_name: None,
@@ -5378,6 +5386,7 @@ pub fn parse_series_data_labels(
             separator: child(dl, "separator")
                 .and_then(|node| node.text())
                 .map(ToOwned::to_owned),
+            manual_layout: child(dl, "layout").and_then(extract_manual_layout),
             label_box,
             show_val: opt_bool_flag("showVal"),
             show_cat_name: opt_bool_flag("showCatName"),
@@ -9681,6 +9690,11 @@ mod tests {
                   <c:idx val="1"/>
                   <c:tx><c:rich><a:p><a:r><a:t>Custom</a:t></a:r></a:p></c:rich></c:tx>
                   <c:dLblPos val="outEnd"/>
+                  <c:layout><c:manualLayout>
+                    <c:xMode val="edge"/><c:yMode val="edge"/>
+                    <c:x val="0.25"/><c:y val="0.4"/>
+                    <c:w val="0.2"/><c:h val="0.1"/>
+                  </c:manualLayout></c:layout>
                 </c:dLbl>
                 <c:showVal val="1"/>
                 <c:showCatName val="0"/>
@@ -9707,6 +9721,20 @@ mod tests {
         assert_eq!(o.idx, 1);
         assert_eq!(o.text, "Custom");
         assert_eq!(o.position.as_deref(), Some("outEnd"));
+        assert_eq!(
+            o.manual_layout,
+            Some(ChartManualLayout {
+                x_mode: "edge".to_string(),
+                y_mode: "edge".to_string(),
+                w_mode: "factor".to_string(),
+                h_mode: "factor".to_string(),
+                layout_target: Some("outer".to_string()),
+                x: 0.25,
+                y: 0.4,
+                w: Some(0.2),
+                h: Some(0.1),
+            })
+        );
     }
 
     #[test]

--- a/packages/pptx/api/public-api-baseline.d.ts
+++ b/packages/pptx/api/public-api-baseline.d.ts
@@ -62,6 +62,7 @@ export interface ChartDataLabelOverride {
     fontBold?: boolean;
     formatCode?: string;
     separator?: string;
+    manualLayout?: ChartManualLayout;
     labelBox?: ChartLabelBox;
     showVal?: boolean;
     showCatName?: boolean;

--- a/packages/xlsx/api/public-api-baseline.d.ts
+++ b/packages/xlsx/api/public-api-baseline.d.ts
@@ -173,6 +173,7 @@ export interface ChartDataLabelOverride {
     fontBold?: boolean;
     formatCode?: string;
     separator?: string;
+    manualLayout?: ChartManualLayout;
     labelBox?: ChartLabelBox;
     showVal?: boolean;
     showCatName?: boolean;


### PR DESCRIPTION
Closes #1231

## Summary

- centralize bounded data-label placement, wrapping, elision, and clipping
- preserve authored text, formatting, position, per-point overrides, and manual layout
- keep source values distinct from stacked geometry anchors
- share the bounded path across bar, line, area, scatter, pie/doughnut, and supported ChartEx families
- constrain callouts and multi-ring labels to their actual available regions

## Verification

- full core chart and `ooxml-common` tests
- focused integration tests after rebasing onto current main
- TypeScript and public API checks
- three rounds of independent adversarial review

The shared policy is deliberately bounded to avoid unbounded text work or canvas spill.